### PR TITLE
feat(telemetry): hotkey registration + raw-press visibility (Telemetry Bible Phase 6, #1175)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -209,7 +209,9 @@ public final class WisprBootstrapper {
     // PR10 of #763 — shared `HotkeyService`. One owner so the single instance
     // threads into `HotkeyController`, `PipelineSettingsSync`,
     // `DictationLifecycleCoordinator`, and `AppDelegate` termination.
-    let hotkeyService = HotkeyService()
+    // #1175: the live telemetry sink is constructor-injected so it is in place
+    // before `start()` runs any registration (heart-path + bootstrap ordering).
+    let hotkeyService = HotkeyService(telemetry: .live)
 
     let settingsSync = PipelineSettingsSync(
       kernelDriver: kernelDriver,

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -100,7 +100,46 @@ public final class HotkeyService {
 
   public private(set) var isSuspended = false
 
-  public init() {}
+  // MARK: - Telemetry (Telemetry Bible Phase 6, #1175)
+
+  /// Injected hotkey/input-silence telemetry. Default `.noop` keeps legacy/test
+  /// construction inert; the app wires `.live`. HotkeyService reports its own
+  /// input facts through this seam — it never reads pipeline state.
+  private let telemetry: HotkeyTelemetrySink
+
+  /// The action HotkeyService took with an accepted keydown — derived entirely
+  /// from its own state, no pipeline read. `cancel` covers both the Escape
+  /// cancel hotkey and a PTT triple-press cancel (told apart by `trigger`).
+  private enum PressAction: String {
+    case start, toggle, cancel, lock, stop
+    case ignoredProcessing = "ignored_processing"
+    case ignoredCooldown = "ignored_cooldown"
+  }
+
+  /// Which hotkey delivered the press.
+  private enum PressTrigger: String {
+    case ptt = "ptt_hotkey"
+    case toggle = "toggle_hotkey"
+    case cancel = "cancel_hotkey"
+  }
+
+  public init(telemetry: HotkeyTelemetrySink = .noop) {
+    self.telemetry = telemetry
+  }
+
+  /// Emit `hotkey.pressed` for an accepted keydown. Synchronous + cheap (computes
+  /// two strings, invokes the injected closure); the `.live` sink defers the
+  /// actual PostHog write off the input turn (heart path). The args ARE the
+  /// snapshot — no shared-state re-read.
+  private func emitHotkeyPressed(_ action: PressAction, trigger: PressTrigger) {
+    let inputMode = recordingMode.rawValue
+    // key_shape reflects the TRIGGERING hotkey: the cancel hotkey (Escape, a chord
+    // by default) vs the toggle/PTT hotkey (modifier-only by default). The PTT
+    // hands-free actions all ride the toggle key. (Codex code-diff #1.)
+    let keyCode = trigger == .cancel ? cancelKeyCode : toggleKeyCode
+    let keyShape = ModifierKeyCodes.isModifierOnly(keyCode) ? "modifier_only" : "chord"
+    telemetry.pressed(trigger.rawValue, inputMode, keyShape, action.rawValue)
+  }
 
   public func start() {
     guard !isEnabled else { return }
@@ -195,6 +234,8 @@ public final class HotkeyService {
           level: .info, category: "HotkeyService"
         )
       }
+      // #1175 (C3): a press that never commits is exactly an under-fire case.
+      emitHotkeyPressed(.ignoredProcessing, trigger: .ptt)
       isModifierHeld = false
       return
     }
@@ -210,6 +251,9 @@ public final class HotkeyService {
       debounceTask = nil
       recordingTask?.cancel()
       recordingTask = Task { await onStartRecording?() }
+      // #1175 (C3): emit AFTER the recording Task is created; the `.live` sink
+      // defers the actual write off this turn so it never delays the callback.
+      emitHotkeyPressed(.start, trigger: .ptt)
     } else if let startTime = recordingStartTime,
       Date().timeIntervalSince(startTime) <= Double(TimingConstants.handsFreeDebounceDelayMs)
         / 1000.0
@@ -227,6 +271,9 @@ public final class HotkeyService {
         isModifierHeld = false
         recordingTask?.cancel()
         recordingTask = Task { await onCancelRecording?() }
+        // #1175 (Codex code-diff #2): hands-free triple-press cancel is an
+        // accepted keydown too — distinguished from the Escape cancel by trigger.
+        emitHotkeyPressed(.cancel, trigger: .ptt)
       } else {
         // Double press → lock into hands-free
         Task {
@@ -243,6 +290,7 @@ public final class HotkeyService {
         // continue running. Cancelling it aborts preWarm/toggleRecording,
         // leaving the UI locked but no actual recording happening.
         Task { await onLocked?() }
+        emitHotkeyPressed(.lock, trigger: .ptt)
       }
     } else if isRecordingLocked {
       // Lock cooldown: ignore presses within 500ms of locking.
@@ -257,6 +305,9 @@ public final class HotkeyService {
             level: .info, category: "HotkeyService"
           )
         }
+        // #1175 (Codex code-diff #2): a cooldown finger-bounce is an accepted
+        // keydown that produces no recording action.
+        emitHotkeyPressed(.ignoredCooldown, trigger: .ptt)
         isModifierHeld = false
         return
       }
@@ -271,6 +322,8 @@ public final class HotkeyService {
       isModifierHeld = false
       recordingTask?.cancel()
       recordingTask = Task { await onStopRecording?() }
+      // #1175 (Codex code-diff #2): single press while locked stops the session.
+      emitHotkeyPressed(.stop, trigger: .ptt)
     }
   }
 
@@ -352,27 +405,41 @@ public final class HotkeyService {
     // Only install if the hotkey is modifier-only
     guard ModifierKeyCodes.isModifierOnly(toggleKeyCode) else { return }
 
-    globalModifierMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) {
-      [weak self] event in
-      // Global monitor callbacks may arrive off the main thread.
-      // Extract event data here (NSEvent is not Sendable).
-      let keyCode = event.keyCode
-      let flags = event.modifierFlags
-      DispatchQueue.main.async {
-        guard let self else { return }
-        MainActor.assumeIsolated {
-          self.handleFlagsChangedValues(keyCode: keyCode, flags: flags)
+    globalModifierMonitor = recordMonitorInstall(
+      NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) {
+        [weak self] event in
+        // Global monitor callbacks may arrive off the main thread.
+        // Extract event data here (NSEvent is not Sendable).
+        let keyCode = event.keyCode
+        let flags = event.modifierFlags
+        DispatchQueue.main.async {
+          guard let self else { return }
+          MainActor.assumeIsolated {
+            self.handleFlagsChangedValues(keyCode: keyCode, flags: flags)
+          }
         }
-      }
-    }
+      }, scope: "global")
 
-    localModifierMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) {
-      [weak self] event in
-      MainActor.assumeIsolated {
-        self?.handleFlagsChanged(event)
-      }
-      return event  // pass the event through
+    localModifierMonitor = recordMonitorInstall(
+      NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) {
+        [weak self] event in
+        MainActor.assumeIsolated {
+          self?.handleFlagsChanged(event)
+        }
+        return event  // pass the event through
+      }, scope: "local")
+  }
+
+  /// #1175 (C2): the single chokepoint for an `NSEvent` modifier-monitor install.
+  /// A `nil` return means a modifier-only hotkey is silently dead → report it.
+  /// Returns the monitor unchanged so the call site assigns it as before.
+  /// `internal` (not `private`) so the nil path is unit-testable without
+  /// abstracting the whole `NSEvent` stack.
+  func recordMonitorInstall(_ monitor: Any?, scope: String) -> Any? {
+    if monitor == nil {
+      telemetry.registrationFailed("nsevent_\(scope)", "toggle", nil, "modifier_only")
     }
+    return monitor
   }
 
   private func removeModifierMonitors() {
@@ -425,7 +492,16 @@ public final class HotkeyService {
       0,
       &ref
     )
-    return status == noErr ? ref : nil
+    guard status == noErr else {
+      // #1175: the noErr-but-silent trap means success can't confirm delivery, so
+      // we only report FAILURE. This is the single Carbon chokepoint — both the
+      // toggle and cancel registrations route through here.
+      let kind = id == HotkeyID.cancel.rawValue ? "cancel" : "toggle"
+      let keyShape = ModifierKeyCodes.isModifierOnly(keyCode) ? "modifier_only" : "chord"
+      telemetry.registrationFailed("carbon", kind, status, keyShape)
+      return nil
+    }
+    return ref
   }
 
   // MARK: - Event Dispatch
@@ -443,6 +519,7 @@ public final class HotkeyService {
       if recordingMode == .toggle {
         guard !isRelease else { return }
         Task { await onToggleRecording?() }
+        emitHotkeyPressed(.toggle, trigger: .toggle)
       } else {
         // Push-to-talk mode with hands-free support
         handleRecordAction(isPress: !isRelease)
@@ -452,6 +529,7 @@ public final class HotkeyService {
       guard !isRelease else { return }
       performCleanup()
       Task { await onCancelRecording?() }
+      emitHotkeyPressed(.cancel, trigger: .cancel)
 
     default:
       break
@@ -492,6 +570,7 @@ public final class HotkeyService {
         )
       }
       Task { await onToggleRecording?() }
+      emitHotkeyPressed(.toggle, trigger: .toggle)
     } else {
       // Push-to-talk mode with hands-free support
       handleRecordAction(isPress: isPress)

--- a/Sources/EnviousWisprServices/HotkeyTelemetrySink.swift
+++ b/Sources/EnviousWisprServices/HotkeyTelemetrySink.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Telemetry Bible Phase 6 (#1175): the injection seam for hotkey/input-silence
+/// telemetry. `HotkeyService` reports input facts through these two closures; the
+/// `.live` sink composes the emit channels, the `.noop` default keeps non-app
+/// construction (tests, legacy) inert.
+///
+/// Why a seam (not direct `TelemetryService.shared` calls): input-path unit tests
+/// inject a synchronous spy and never touch a process-global hook, and the
+/// PostHog/Sentry composition lives in one place (`.live`) so `TelemetryService`
+/// stays PostHog-pure and `SentryBreadcrumb` stays Sentry-pure.
+///
+/// Heart path: in `.live` the `pressed` write is DEFERRED off the input turn via
+/// `DispatchQueue.main.async` so a per-press PostHog sync-write never delays the
+/// recording callback. `registrationFailed` is synchronous — it fires off the
+/// latency-critical press path and we want the rare failure durable.
+public struct HotkeyTelemetrySink: Sendable {
+  /// A hotkey registration failed. `osStatus` is the Carbon `OSStatus` (nil for
+  /// the `NSEvent` monitor path). All args are metadata — never key codes.
+  public var registrationFailed:
+    @MainActor (_ mechanism: String, _ hotkeyKind: String, _ osStatus: Int32?, _ keyShape: String)
+      ->
+      Void
+  /// A raw accepted hotkey keydown routed to a recording action.
+  public var pressed:
+    @MainActor (
+      _ triggerSource: String, _ inputMode: String, _ keyShape: String, _ pressAction: String
+    ) -> Void
+
+  public init(
+    registrationFailed: @escaping @MainActor (String, String, Int32?, String) -> Void,
+    pressed: @escaping @MainActor (String, String, String, String) -> Void
+  ) {
+    self.registrationFailed = registrationFailed
+    self.pressed = pressed
+  }
+
+  /// Inert sink — the default for tests and any non-app construction.
+  public static let noop = HotkeyTelemetrySink(
+    registrationFailed: { _, _, _, _ in }, pressed: { _, _, _, _ in })
+
+  /// Production sink. Registration failure → PostHog breakdown + Sentry handled
+  /// error (synchronous, durable). Press → PostHog, deferred to the next run loop
+  /// so the input-press turn does zero telemetry I/O before the recording callback.
+  public static let live = HotkeyTelemetrySink(
+    registrationFailed: { mechanism, hotkeyKind, osStatus, keyShape in
+      TelemetryService.shared.hotkeyRegistration(
+        mechanism: mechanism, hotkeyKind: hotkeyKind, osStatus: osStatus, keyShape: keyShape)
+      var extra: [String: Any] = [
+        "mechanism": mechanism, "hotkey_kind": hotkeyKind, "key_shape": keyShape,
+      ]
+      if let osStatus { extra["os_status"] = Int(osStatus) }
+      SentryBreadcrumb.captureError(
+        HotkeyRegistrationError(mechanism: mechanism, hotkeyKind: hotkeyKind, osStatus: osStatus),
+        category: .hotkeyRegistrationFailed, stage: "input", extra: extra,
+        // Cloud-review P3: a struct Error bridges to one stable NSError code, so
+        // `structuredDescriptor` would group every registration failure into one
+        // Sentry bin. Split by (mechanism, kind) — low cardinality — so a Carbon
+        // toggle conflict and a dead NSEvent monitor are distinct issues.
+        fingerprintDetail: "\(mechanism)/\(hotkeyKind)")
+    },
+    pressed: { triggerSource, inputMode, keyShape, pressAction in
+      // `DispatchQueue.main.async` (NOT `Task { @MainActor }`, which may run on the
+      // current cycle — gotchas-audio `dispatch-main-for-runloop-deferral`) defers
+      // the PostHog enqueue-write to the next run loop so the input-press turn does
+      // ZERO telemetry I/O before the recording callback. Telemetry lost to an
+      // immediate quit is acceptable — heart path is sacred, this is a limb.
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          TelemetryService.shared.hotkeyPressed(
+            triggerSource: triggerSource, inputMode: inputMode,
+            keyShape: keyShape, pressAction: pressAction)
+        }
+      }
+    })
+}
+
+/// The error captured to Sentry when a hotkey registration fails. Carries only
+/// metadata (mechanism / kind / OSStatus) — never the key codes.
+public struct HotkeyRegistrationError: Error, CustomStringConvertible {
+  public let mechanism: String
+  public let hotkeyKind: String
+  public let osStatus: Int32?
+
+  public init(mechanism: String, hotkeyKind: String, osStatus: Int32?) {
+    self.mechanism = mechanism
+    self.hotkeyKind = hotkeyKind
+    self.osStatus = osStatus
+  }
+
+  public var description: String {
+    let status = osStatus.map { String($0) } ?? "nil"
+    return
+      "hotkey registration failed: mechanism=\(mechanism) kind=\(hotkeyKind) os_status=\(status)"
+  }
+}

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -341,6 +341,12 @@ public enum SentryBreadcrumb {
     /// — every dropped glyph is re-inserted — so this fires only on a regression.
     /// The user still got the polished text plus whatever was restored.
     case emojiRestoreIncomplete = "emoji_restore_incomplete"
+    /// #1175 (Telemetry Bible Phase 6): a hotkey registration failed — Carbon
+    /// `RegisterEventHotKey` returned non-`noErr`, or an `NSEvent` modifier
+    /// monitor installed `nil`. The affected hotkey will not fire. Rare and
+    /// actionable; carries `mechanism` / `hotkey_kind` / `os_status` / `key_shape`
+    /// (metadata only — never the key codes).
+    case hotkeyRegistrationFailed = "hotkey_registration_failed"
   }
 }
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -245,6 +245,57 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("dictation.invoked", properties: props)
   }
 
+  // MARK: - Hotkey / input (Telemetry Bible Phase 6, #1175)
+
+  /// A hotkey registration FAILED (Carbon `RegisterEventHotKey` returned
+  /// non-`noErr`, or an `NSEvent` modifier monitor installed `nil`). Emitted only
+  /// on failure — the actionable signal is the Sentry handled error composed in
+  /// `HotkeyTelemetrySink.live`; this is the PostHog breakdown by mechanism /
+  /// kind / key shape. `osStatus` present only for the Carbon path. Metadata
+  /// only — never the key codes.
+  public func hotkeyRegistration(
+    mechanism: String, hotkeyKind: String, osStatus: Int32?, keyShape: String
+  ) {
+    var props: [String: Any] = [
+      "mechanism": mechanism, "hotkey_kind": hotkeyKind, "key_shape": keyShape,
+    ]
+    if let osStatus { props["os_status"] = Int(osStatus) }
+    #if DEBUG
+      var intProps: [String: Int] = [:]
+      if let osStatus { intProps["os_status"] = Int(osStatus) }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "hotkey.registration",
+          stringProps: [
+            "mechanism": mechanism, "hotkey_kind": hotkeyKind, "key_shape": keyShape,
+          ],
+          intProps: intProps))
+    #endif
+    PostHogSDK.shared.capture("hotkey.registration", properties: props)
+  }
+
+  /// A raw accepted hotkey keydown was routed to a recording action — the C3
+  /// denominator for `dictation.invoked` (which fires post-commit and under-fires
+  /// raw presses). Metadata only (low-cardinality enums; never the key codes).
+  public func hotkeyPressed(
+    triggerSource: String, inputMode: String, keyShape: String, pressAction: String
+  ) {
+    let props: [String: Any] = [
+      "trigger_source": triggerSource, "input_mode": inputMode,
+      "key_shape": keyShape, "press_action": pressAction,
+    ]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "hotkey.pressed",
+          stringProps: [
+            "trigger_source": triggerSource, "input_mode": inputMode,
+            "key_shape": keyShape, "press_action": pressAction,
+          ]))
+    #endif
+    PostHogSDK.shared.capture("hotkey.pressed", properties: props)
+  }
+
   public func dictationCompleted(
     result: String, inputMode: String, asrBackend: String,
     llmProvider: String?, fillerRemoval: Bool,

--- a/Tests/EnviousWisprTests/Services/HotkeyTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyTelemetryTests.swift
@@ -1,0 +1,204 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1175 (Telemetry Bible Phase 6) — hotkey/input-silence telemetry.
+///
+/// Drives `HotkeyService` through its public `handleCarbonHotkey` entry with a
+/// SYNCHRONOUS spy `HotkeyTelemetrySink` (no process-global hook, no async) and
+/// asserts the emitted `press_action` / `trigger_source` / `key_shape` and the
+/// registration-failure path. `press_action` is derived entirely from
+/// HotkeyService's own state — no pipeline read — so every value is reachable
+/// here. The modifier-only `handleFlagsChangedValues` toggle site shares the same
+/// helper and is covered by Live UAT (the shipped default).
+@MainActor
+@Suite struct HotkeyTelemetryTests {
+
+  /// Synchronous spy — records every sink call on the main actor. `@MainActor`
+  /// per swift-patterns `mainactor-fntype-implicitly-sendable`.
+  @MainActor final class Spy {
+    struct Press: Equatable {
+      let triggerSource: String
+      let inputMode: String
+      let keyShape: String
+      let pressAction: String
+    }
+    struct Registration: Equatable {
+      let mechanism: String
+      let hotkeyKind: String
+      let osStatus: Int32?
+      let keyShape: String
+    }
+    var presses: [Press] = []
+    var registrations: [Registration] = []
+
+    var sink: HotkeyTelemetrySink {
+      HotkeyTelemetrySink(
+        registrationFailed: { [weak self] mechanism, kind, status, shape in
+          self?.registrations.append(
+            Registration(mechanism: mechanism, hotkeyKind: kind, osStatus: status, keyShape: shape))
+        },
+        pressed: { [weak self] ts, im, ks, pa in
+          self?.presses.append(
+            Press(triggerSource: ts, inputMode: im, keyShape: ks, pressAction: pa))
+        })
+    }
+  }
+
+  // `HotkeyID` raw values are private to `HotkeyService`; mirror them here.
+  private let toggleID: UInt32 = 1
+  private let cancelID: UInt32 = 3
+
+  private func makeService(
+    _ spy: Spy, mode: RecordingMode, modifierOnly: Bool = false
+  ) -> HotkeyService {
+    let service = HotkeyService(telemetry: spy.sink)
+    service.recordingMode = mode
+    // keyCode 0 ('A') is a chord key; right Option (61) is modifier-only.
+    service.toggleKeyCode = modifierOnly ? ModifierKeyCodes.rightOption : 0
+    return service
+  }
+
+  @Test("PTT start press emits hotkey.pressed press_action=start")
+  func pttStartEmits() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .pushToTalk)
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)
+    #expect(
+      spy.presses == [
+        .init(
+          triggerSource: "ptt_hotkey", inputMode: "pushToTalk", keyShape: "chord",
+          pressAction: "start")
+      ])
+  }
+
+  @Test("toggle tap emits press_action=toggle, trigger=toggle_hotkey")
+  func toggleEmits() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .toggle)
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)
+    #expect(
+      spy.presses == [
+        .init(
+          triggerSource: "toggle_hotkey", inputMode: "toggle", keyShape: "chord",
+          pressAction: "toggle")
+      ])
+  }
+
+  @Test("cancel press emits press_action=cancel, trigger=cancel_hotkey")
+  func cancelEmits() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .pushToTalk)
+    service.handleCarbonHotkey(id: cancelID, isRelease: false)
+    #expect(
+      spy.presses == [
+        .init(
+          triggerSource: "cancel_hotkey", inputMode: "pushToTalk", keyShape: "chord",
+          pressAction: "cancel")
+      ])
+  }
+
+  @Test("press blocked by processing emits press_action=ignored_processing")
+  func processingBlockedEmits() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .pushToTalk)
+    service.onIsProcessing = { true }
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)
+    #expect(spy.presses.count == 1)
+    #expect(spy.presses.first?.pressAction == "ignored_processing")
+  }
+
+  @Test("key_shape reflects a modifier-only toggle key")
+  func keyShapeModifierOnly() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .toggle, modifierOnly: true)
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)
+    #expect(spy.presses.first?.keyShape == "modifier_only")
+  }
+
+  @Test("cancel key_shape comes from the cancel key, not the toggle key (Codex #1)")
+  func cancelKeyShapeFromCancelKey() {
+    // Toggle is modifier-only (right Option); cancel is the default Escape (a
+    // chord). A cancel press must report key_shape from the CANCEL key.
+    let spy = Spy()
+    let service = makeService(spy, mode: .pushToTalk, modifierOnly: true)
+    // cancelKeyCode keeps its default (53 = Escape, a chord key).
+    service.handleCarbonHotkey(id: cancelID, isRelease: false)
+    #expect(spy.presses.first?.pressAction == "cancel")
+    #expect(spy.presses.first?.keyShape == "chord")
+  }
+
+  @Test("hands-free double-press emits start then lock (Codex #2)")
+  func doublePressLockEmits() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .pushToTalk)
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)  // down 1 → start
+    service.handleCarbonHotkey(id: toggleID, isRelease: true)  // up 1
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)  // down 2 (<500ms) → lock
+    #expect(spy.presses.map(\.pressAction) == ["start", "lock"])
+    #expect(spy.presses.allSatisfy { $0.triggerSource == "ptt_hotkey" })
+  }
+
+  @Test("hands-free triple-press emits start, lock, cancel (Codex #2)")
+  func triplePressCancelEmits() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .pushToTalk)
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)  // down 1 → start
+    service.handleCarbonHotkey(id: toggleID, isRelease: true)  // up 1
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)  // down 2 → lock
+    service.handleCarbonHotkey(id: toggleID, isRelease: true)  // up 2 (suppressed)
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)  // down 3 → triple cancel
+    #expect(spy.presses.map(\.pressAction) == ["start", "lock", "cancel"])
+    // The triple-press cancel is a PTT keydown, told apart from Escape by trigger.
+    #expect(spy.presses.last?.triggerSource == "ptt_hotkey")
+  }
+
+  @Test("duplicate held press (no intervening release) emits only once")
+  func dedupHeldEmitsOnce() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .pushToTalk)
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)  // held re-fire, ignored
+    #expect(spy.presses.count == 1)
+    #expect(spy.presses.first?.pressAction == "start")
+  }
+
+  @Test("monitor nil-install reports a registration failure")
+  func monitorNilReportsFailure() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .toggle, modifierOnly: true)
+    _ = service.recordMonitorInstall(nil, scope: "global")
+    #expect(
+      spy.registrations == [
+        .init(
+          mechanism: "nsevent_global", hotkeyKind: "toggle", osStatus: nil,
+          keyShape: "modifier_only")
+      ])
+  }
+
+  @Test("non-nil monitor install reports nothing and returns the token")
+  func monitorOkReportsNothing() {
+    let spy = Spy()
+    let service = makeService(spy, mode: .toggle, modifierOnly: true)
+    let token = NSObject()
+    let returned = service.recordMonitorInstall(token, scope: "local")
+    #expect(spy.registrations.isEmpty)
+    #expect((returned as? NSObject) === token)
+  }
+
+  @Test("default .noop sink stays inert — press still processed, nothing emitted")
+  func defaultNoopIsInert() {
+    // Codex r3: the default `HotkeyService()` (no telemetry param) must stay inert
+    // so the existing `HotkeyService()` construction sites are behaviorally
+    // unchanged. The press still flows through the state machine (isModifierHeld
+    // flips) but the no-op closures swallow every emit.
+    let service = HotkeyService()  // `.noop` default
+    service.recordingMode = .pushToTalk
+    service.toggleKeyCode = 0
+    service.handleCarbonHotkey(id: toggleID, isRelease: false)
+    _ = service.recordMonitorInstall(nil, scope: "global")
+    #expect(service.isModifierHeld)  // press was processed normally
+  }
+}


### PR DESCRIPTION
## Telemetry Bible Phase 6 (#1175): hotkey / input-silence telemetry

Closes #1175. Part of epic #1168.

Three input-path blind spots in `HotkeyService`, now visible:

- **C1** Carbon `RegisterEventHotKey`'s `OSStatus` was discarded; a failed registration now reports (`hotkey.registration` PostHog breakdown + a new Sentry `.hotkeyRegistrationFailed` handled error, the actionable signal). Success never emits (noErr can't confirm delivery).
- **C2** NSEvent modifier monitors weren't nil-checked; a silently dead modifier-only hotkey now reports.
- **C3** `dictation.invoked` fires post-commit and under-fires raw keypresses; a new `hotkey.pressed` event at the accepted keydown is the denominator, and doubly the real silent-delivery signal (registration-success-but-zero-presses-despite-usage = silent failure, query-side).

### Design
- Telemetry injected as a no-op-defaulted `HotkeyTelemetrySink` (isolated unit tests, no process-global hook). `TelemetryService` stays PostHog-pure; the Sentry leg composes in the `.live` sink.
- `hotkey.pressed` carries `trigger_source` / `input_mode` / `key_shape` / `press_action`, the last derived entirely from `HotkeyService`'s own state (no pipeline coupling, no toggle-race). Full taxonomy: `start` / `lock` / `stop` / `cancel` / `toggle` / `ignored_processing` / `ignored_cooldown`, so hands-free usage is no longer invisible.
- Heart path: the `.live` press write is deferred off the input turn via `DispatchQueue.main.async` (per `gotchas-audio` dispatch-main-for-runloop-deferral, not `Task { @MainActor }`) so it never delays the recording callback. Registration emit stays synchronous (off the press path, durable).
- Privacy: metadata only. We emit `key_shape` (`modifier_only`/`chord`), never the key codes.

### Validation
- Council (GPT-5.5 + Gemini) coverage + Codex grounded review (2 rounds, PROCEED-AS-PLANNED) + Codex code-diff review (2 rounds, clean; caught a cancel-key_shape bug and a hands-free undercount, both fixed).
- 2079 logic tests green incl. 12 new `HotkeyTelemetryTests`.
- Live UAT (input-heart, PTT modifier-only default): real right-Option keypress drove the full PTT path, recorded "Let me jot this down before the meeting starts.", pasted; Pipeline TOTAL 1.624s, no crash, no added record latency. The deferred `.live` write ran without an `assumeIsolated` crash (runtime-confirms the deferral mechanism).