### PR TITLE
feat(telemetry): onboarding drop-off visibility (Telemetry Bible Phase 7, #1176)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -77,7 +77,10 @@ final class AppLifecycleCoordinator {
     liveRecordingState: LiveRecordingState,
     menuBarController: MenuBarController,
     appWindowCoordinator: AppWindowCoordinator,
-    hotkeyService: HotkeyService
+    hotkeyService: HotkeyService,
+    // #1176: captured in the onboarding-dismiss closure below (NOT stored — keeps
+    // this coordinator's stored-property ceiling clean).
+    onboardingProgress: OnboardingProgress
   ) {
     self.settings = settings
     self.permissions = permissions
@@ -99,8 +102,15 @@ final class AppLifecycleCoordinator {
     // Icon-refresh seam: the window coordinator's two onboarding-dismiss
     // callsites route through this closure. Was wired in `AppDelegate.attach`
     // before PR-B.4.
-    appWindowCoordinator.onOnboardingDismissed = { [weak menuBarController] in
+    appWindowCoordinator.onOnboardingDismissed = {
+      [weak menuBarController, onboardingProgress, permissions] in
       menuBarController?.updateIcon()
+      // #1176: the window closed before completion → record the abandon (deduped
+      // by the box's terminal guard, so a clean finish or a prior quit suppresses it).
+      onboardingProgress.emitAbandonIfInFlight(
+        reason: "window_closed",
+        micStatus: permissions.microphoneStatusString,
+        accessibilityStatus: permissions.accessibilityGranted ? "granted" : "denied")
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -110,7 +110,10 @@ final class AppLifecycleCoordinator {
       onboardingProgress.emitAbandonIfInFlight(
         reason: "window_closed",
         micStatus: permissions.microphoneStatusString,
-        accessibilityStatus: permissions.accessibilityGranted ? "granted" : "denied")
+        // Live read (not the cached `accessibilityGranted`): a grant made in System
+        // Settings just before this close may not have hit the poll yet (cloud Codex
+        // review r3). Pure no-prompt read, no side effects.
+        accessibilityStatus: permissions.accessibilityGrantedLive ? "granted" : "denied")
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
+++ b/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
@@ -21,16 +21,24 @@ final class OnboardingProgress {
   private var source: String = "first_run"
   private var terminalEmitted: Bool = false
 
-  /// Called whenever onboarding is presented incomplete. Resets the session so a
-  /// Diagnostics restart is fresh — no stale timestamp, no stale terminal flag
-  /// (re-entry safe). `source` is supplied by the caller from
-  /// `SettingsManager.onboardingEverCompleted` (the durable flag in the SHARED
-  /// settings store — Codex code-diff r4: the box must not read the wrong defaults
-  /// domain, and the durable completion flag belongs in the settings home).
+  /// Called whenever onboarding is presented. Starts a FRESH session only when no
+  /// session is in flight — i.e. on a first-run open or a genuine restart (every
+  /// terminal, clean-finish or abandon, sets `terminalEmitted`, so the guard lets
+  /// the next open reset). A refocus of an already-open window (the status-menu
+  /// "Continue Setup…" item re-enters this on the single reused SwiftUI window)
+  /// finds a live session and is a no-op — it must NOT rewind the clock or reset
+  /// screen/step back to "welcome", which would under-count elapsed and mislabel a
+  /// subsequent abandon (cloud Codex review PR #1210). `source` is supplied by the
+  /// caller from `SettingsManager.onboardingEverCompleted` (the durable flag in the
+  /// SHARED settings store — Codex code-diff r4: the box must not read the wrong
+  /// defaults domain, and the durable completion flag belongs in the settings home).
   func begin(source: String) {
+    guard sessionStartedAt == nil || terminalEmitted else { return }
     self.source = source
     sessionStartedAt = Date()
     terminalEmitted = false
+    screen = "welcome"
+    step = "welcome"
   }
 
   /// Mirror the current screen/step as the user advances (read at terminal).

--- a/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
+++ b/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
@@ -26,19 +26,23 @@ final class OnboardingProgress {
   /// terminal, clean-finish or abandon, sets `terminalEmitted`, so the guard lets
   /// the next open reset). A refocus of an already-open window (the status-menu
   /// "Continue Setup…" item re-enters this on the single reused SwiftUI window)
-  /// finds a live session and is a no-op — it must NOT rewind the clock or reset
-  /// screen/step back to "welcome", which would under-count elapsed and mislabel a
-  /// subsequent abandon (cloud Codex review PR #1210). `source` is supplied by the
-  /// caller from `SettingsManager.onboardingEverCompleted` (the durable flag in the
-  /// SHARED settings store — Codex code-diff r4: the box must not read the wrong
-  /// defaults domain, and the durable completion flag belongs in the settings home).
+  /// finds a live session and is a no-op — it must NOT rewind the clock (cloud
+  /// Codex review PR #1210).
+  ///
+  /// Deliberately does NOT touch `screen`/`step`: the view owns the position and
+  /// pushes it via `update(...)`. Resetting to "welcome" here mislabels the
+  /// reused-window reopen-after-abandon case — that window keeps its `viewModel`
+  /// and skips `.onAppear`, so no re-sync corrects an assumed "welcome" back to the
+  /// real screen; carrying the last observed position is the honest value (cloud
+  /// Codex review r2). `source` is supplied by the caller from
+  /// `SettingsManager.onboardingEverCompleted` (the durable flag in the SHARED
+  /// settings store — Codex code-diff r4: the box must not read the wrong defaults
+  /// domain, and the durable completion flag belongs in the settings home).
   func begin(source: String) {
     guard sessionStartedAt == nil || terminalEmitted else { return }
     self.source = source
     sessionStartedAt = Date()
     terminalEmitted = false
-    screen = "welcome"
-    step = "welcome"
   }
 
   /// Mirror the current screen/step as the user advances (read at terminal).

--- a/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
+++ b/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
@@ -21,6 +21,14 @@ final class OnboardingProgress {
   private var source: String = "first_run"
   private var terminalEmitted: Bool = false
 
+  /// The current session's start (nil when no session is in flight). The view uses
+  /// this as a FLOOR for per-step durations: a reused-window reopen keeps a stale
+  /// `stepStartedAt`, so a step completed just after reopen would otherwise report a
+  /// duration inflated by the time the window was closed. Flooring at the session
+  /// start clamps any step duration to time-spent-in-THIS-session — the box's
+  /// session is the single authority for session-scoped timing (cloud Codex r4).
+  var sessionStart: Date? { sessionStartedAt }
+
   /// Called whenever onboarding is presented. Starts a FRESH session only when no
   /// session is in flight — i.e. on a first-run open or a genuine restart (every
   /// terminal, clean-finish or abandon, sets `terminalEmitted`, so the guard lets

--- a/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
+++ b/Sources/EnviousWisprAppKit/App/OnboardingProgress.swift
@@ -1,0 +1,63 @@
+import EnviousWisprServices
+import Foundation
+
+/// Telemetry Bible Phase 7 (#1176): the in-flight onboarding session + its single
+/// terminal emit.
+///
+/// Written by `OnboardingV2View` as the user advances; its terminal methods are
+/// called by the App-layer terminal paths — window-close via the existing
+/// `onOnboardingDismissed` closure, app-quit via the bootstrapper's terminate
+/// forwarding. Owning the guarded emit HERE means no coordinator gains a stored
+/// property (those have exact-allowlist ceiling tests) and callers are one-liners.
+///
+/// Plain `@MainActor final class` (NOT `@Observable`) — nothing renders off it; it
+/// is written by the view and read once at terminal, so reactive observation would
+/// be pure overhead.
+@MainActor
+final class OnboardingProgress {
+  private var sessionStartedAt: Date?
+  private(set) var screen: String = "welcome"
+  private(set) var step: String = "welcome"
+  private var source: String = "first_run"
+  private var terminalEmitted: Bool = false
+
+  /// Called whenever onboarding is presented incomplete. Resets the session so a
+  /// Diagnostics restart is fresh — no stale timestamp, no stale terminal flag
+  /// (re-entry safe). `source` is supplied by the caller from
+  /// `SettingsManager.onboardingEverCompleted` (the durable flag in the SHARED
+  /// settings store — Codex code-diff r4: the box must not read the wrong defaults
+  /// domain, and the durable completion flag belongs in the settings home).
+  func begin(source: String) {
+    self.source = source
+    sessionStartedAt = Date()
+    terminalEmitted = false
+  }
+
+  /// Mirror the current screen/step as the user advances (read at terminal).
+  func update(screen: String, step: String) {
+    self.screen = screen
+    self.step = step
+  }
+
+  /// Called on a clean finish BEFORE the window closes, so the unguarded
+  /// window-close path sees `terminalEmitted` and no-ops (the completed/abandoned
+  /// race fix). The durable everCompleted flag is owned by `SettingsManager`
+  /// (set when `onboardingState` flips to `.completed`).
+  func markCompleted() {
+    terminalEmitted = true
+  }
+
+  /// The single guarded abandon emit — both the window-close closure and the
+  /// app-quit terminate path call this. Emits at most once per session; a clean
+  /// finish (`markCompleted`) or a prior abandon suppresses it. Posture is passed
+  /// in by the caller so this box does not depend on `PermissionsService`.
+  func emitAbandonIfInFlight(reason: String, micStatus: String, accessibilityStatus: String) {
+    guard let started = sessionStartedAt, !terminalEmitted else { return }
+    terminalEmitted = true
+    TelemetryService.shared.onboardingAbandoned(
+      screen: screen, step: step,
+      elapsedSeconds: Date().timeIntervalSince(started),
+      micStatus: micStatus, accessibilityStatus: accessibilityStatus,
+      abandonReason: reason, source: source)
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -46,6 +46,8 @@ public final class WisprBootstrapper {
   // scenes' environment by the view factories.
   let settings: SettingsManager
   let permissions: PermissionsService
+  /// #1176: in-flight onboarding session, read at app-quit to emit abandon.
+  let onboardingProgress = OnboardingProgress()
   let asrManager: any ASRManagerInterface
   let customWordsCoordinator: CustomWordsCoordinator
   let contactsImportCoordinator: ContactsImportCoordinator
@@ -580,7 +582,8 @@ public final class WisprBootstrapper {
       liveRecordingState: liveRecordingState,
       menuBarController: menuBarController,
       appWindowCoordinator: appWindowCoordinator,
-      hotkeyService: hotkeyService
+      hotkeyService: hotkeyService,
+      onboardingProgress: onboardingProgress
     )
 
     self.navigationCoordinator = navigationCoordinator
@@ -717,6 +720,13 @@ public final class WisprBootstrapper {
   public func applicationWillTerminate() {
     // #1019: tear down the network path monitor + wake observer.
     updateTriggerCoordinator.stop()
+    // #1176: a Cocoa quit during onboarding is an abandon (best-effort — kill -9
+    // bypasses this). Capture BEFORE the Phase-1 flush in runWillTerminate so it is
+    // durable. Deduped by the box's terminal guard (a clean finish or a prior
+    // window-close abandon suppresses it).
+    onboardingProgress.emitAbandonIfInFlight(
+      reason: "app_quit", micStatus: permissions.microphoneStatusString,
+      accessibilityStatus: permissions.accessibilityGranted ? "granted" : "denied")
     appLifecycleCoordinator.runWillTerminate()
   }
 
@@ -785,6 +795,7 @@ private struct MainWindowRoot: View {
           settings: b.settings,
           appWindowCoordinator: b.appWindowCoordinator,
           menuBarController: b.menuBarController,
+          onboardingProgress: b.onboardingProgress,
           isOnboardingPresented: $isOnboardingPresented
         )
       )
@@ -796,9 +807,10 @@ private struct OnboardingWindowRoot: View {
   let b: WisprBootstrapper
 
   var body: some View {
-    OnboardingV2View(onComplete: {
-      b.appWindowCoordinator.closeOnboardingWindow()
-    })
+    OnboardingV2View(
+      onComplete: { b.appWindowCoordinator.closeOnboardingWindow() },
+      onboardingProgress: b.onboardingProgress
+    )
     .environment(b.navigationCoordinator)
     .environment(b.languageSuggestionPresenter)
     .environment(b.dictationRuntime)
@@ -827,6 +839,9 @@ private struct ActionWirer: View {
   let appWindowCoordinator: AppWindowCoordinator
   /// PR-B.3 of #763: onboarding-dismissal icon refresh targets the menu home.
   let menuBarController: MenuBarController
+  /// #1176: begin a fresh onboarding session on every window open (first-run AND
+  /// Diagnostics restart both funnel through `openOnboardingAction`).
+  let onboardingProgress: OnboardingProgress
   @Binding var isOnboardingPresented: Bool
   @Environment(\.openWindow) private var openWindow
   @Environment(\.dismissWindow) private var dismissWindow
@@ -838,7 +853,14 @@ private struct ActionWirer: View {
         appWindowCoordinator.openMainWindowAction = { [openWindow] in
           openWindow(id: "main")
         }
-        appWindowCoordinator.openOnboardingAction = { [openWindow] in
+        appWindowCoordinator.openOnboardingAction = { [openWindow, onboardingProgress, settings] in
+          // #1176: every onboarding presentation (first-run, Diagnostics restart,
+          // queued replay) funnels through here — begin a fresh session (reset the
+          // dedup flag + clock, re-entry safe; reliable even when the reused window
+          // skips onAppear). `source` reads the durable everCompleted flag from the
+          // shared settings store, so a restart after completion is labeled correctly.
+          let source = settings.onboardingEverCompleted ? "diagnostics_restart" : "first_run"
+          onboardingProgress.begin(source: source)
           openWindow(id: "onboarding")
         }
         appWindowCoordinator.dismissOnboardingAction = { [dismissWindow] in

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -726,7 +726,8 @@ public final class WisprBootstrapper {
     // window-close abandon suppresses it).
     onboardingProgress.emitAbandonIfInFlight(
       reason: "app_quit", micStatus: permissions.microphoneStatusString,
-      accessibilityStatus: permissions.accessibilityGranted ? "granted" : "denied")
+      // Live read so a just-before-quit grant isn't logged denied (cloud Codex r3).
+      accessibilityStatus: permissions.accessibilityGrantedLive ? "granted" : "denied")
     appLifecycleCoordinator.runWillTerminate()
   }
 

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -854,11 +854,11 @@ private struct ActionWirer: View {
           openWindow(id: "main")
         }
         appWindowCoordinator.openOnboardingAction = { [openWindow, onboardingProgress, settings] in
-          // #1176: every onboarding presentation (first-run, Diagnostics restart,
-          // queued replay) funnels through here — begin a fresh session (reset the
-          // dedup flag + clock, re-entry safe; reliable even when the reused window
-          // skips onAppear). `source` reads the durable everCompleted flag from the
-          // shared settings store, so a restart after completion is labeled correctly.
+          // #1176: every onboarding presentation funnels through here. `begin` starts
+          // a fresh session only when none is in flight, so a refocus of the open
+          // window (status-menu "Continue Setup…") never rewinds it — see the guard
+          // in `OnboardingProgress.begin`. `source` reads the durable everCompleted
+          // flag from the shared settings store.
           let source = settings.onboardingEverCompleted ? "diagnostics_restart" : "first_run"
           onboardingProgress.begin(source: source)
           openWindow(id: "onboarding")

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -110,6 +110,10 @@ final class OnboardingV2ViewModel {
     warmUp: @MainActor () async -> EngineWarmupOutcome, settings: SettingsManager
   ) async {
     settings.onboardingState = .settingUp
+    // #1176 (Codex code-diff #2): start the model_download clock here, before the
+    // disk preflight, so a disk-space block reports model-step time, not the
+    // welcome-screen dwell that preceded Get Started.
+    stepStartedAt = Date()
 
     // Disk space preflight — fail early with a friendly message instead of failing at 80%.
     if let attrs = try? FileManager.default.attributesOfFileSystem(
@@ -121,6 +125,7 @@ final class OnboardingV2ViewModel {
       downloadError =
         "Not enough disk space (\(freeMB) MB free). EnviousWispr needs about 1 GB to download and install the speech model."
       checklistStatuses[0] = .error(downloadError!)
+      blockStep("model_download", reason: "insufficient_disk_space")
       return
     }
 
@@ -143,6 +148,7 @@ final class OnboardingV2ViewModel {
       downloadError = friendly
       rawErrorDetails = "\(error)"
       checklistStatuses[0] = .error(friendly)
+      blockStep("model_download", reason: "model_warmup_failed")
       return
     }
 
@@ -150,7 +156,7 @@ final class OnboardingV2ViewModel {
     checklistStatuses[0] = .completed
     installQuip = ""
     stopQuipTimer()
-    TelemetryService.shared.onboardingStepCompleted(step: "model_download", result: "completed")
+    completeStep("model_download", result: "completed")
 
     do {
       checklistStatuses[1] = .inProgress
@@ -162,12 +168,12 @@ final class OnboardingV2ViewModel {
       // Onboarded users get Apple Intelligence via the canonical default; this
       // step stays a visual checklist beat + telemetry only.
       checklistStatuses[1] = .completed
-      TelemetryService.shared.onboardingStepCompleted(step: "ai_config", result: "completed")
+      completeStep("ai_config", result: "completed")
 
       checklistStatuses[2] = .inProgress
       try await Task.sleep(nanoseconds: 1_500_000_000)
       checklistStatuses[2] = .completed
-      TelemetryService.shared.onboardingStepCompleted(step: "hotkey_config", result: "completed")
+      completeStep("hotkey_config", result: "completed")
 
       try await Task.sleep(nanoseconds: 400_000_000)
       settings.onboardingState = .needsPermissions
@@ -287,8 +293,12 @@ final class OnboardingV2ViewModel {
   }
 
   func requestMicPermission(permissions: PermissionsService) async {
-    _ = await permissions.requestMicrophoneAccess()
+    let granted = await permissions.requestMicrophoneAccess()
     micGranted = permissions.hasMicrophonePermission
+    // #1176 (E1): a denied mic prompt is a concrete onboarding block.
+    if !granted {
+      blockStep("mic_permission", reason: "denied", permission: "microphone")
+    }
   }
 
   func openAccessibilitySettings(permissions: PermissionsService) {
@@ -309,6 +319,29 @@ final class OnboardingV2ViewModel {
     TelemetryService.shared.onboardingCompleted(
       asrBackend: settings.selectedBackend.rawValue, recordingMode: settings.recordingMode.rawValue)
   }
+
+  // MARK: - Step telemetry (Telemetry Bible Phase 7, #1176)
+
+  /// Start of the current step. `duration_seconds` on each step event = time since
+  /// the previous step event (reset on completion). Approximate for the artificial
+  /// visual-beat steps; meaningful for model_download warmup + permission on-screen time.
+  var stepStartedAt = Date()
+
+  /// Emit `onboarding.step_completed` with `duration_seconds`, then reset the clock
+  /// for the next step (E2).
+  func completeStep(_ step: String, result: String) {
+    TelemetryService.shared.onboardingStepCompleted(
+      step: step, result: result, durationSeconds: Date().timeIntervalSince(stepStartedAt))
+    stepStartedAt = Date()
+  }
+
+  /// Emit `onboarding.step_blocked` with `duration_seconds` (E1). Does NOT reset the
+  /// clock (the step is stuck, not advanced).
+  func blockStep(_ step: String, reason: String, permission: String? = nil) {
+    TelemetryService.shared.onboardingStepBlocked(
+      step: step, reason: reason, permission: permission,
+      durationSeconds: Date().timeIntervalSince(stepStartedAt))
+  }
 }
 
 // MARK: - Main View
@@ -326,6 +359,9 @@ struct OnboardingV2View: View {
   // replacing the prior direct `asrManager.loadModel()`.
   @Environment(DictationRuntime.self) private var dictationRuntime
   var onComplete: () -> Void
+  /// #1176: in-flight onboarding session + its single terminal abandon emit,
+  /// bootstrapper-owned and shared with the App-layer window-close / app-quit paths.
+  var onboardingProgress: OnboardingProgress
 
   @State private var viewModel = OnboardingV2ViewModel()
 
@@ -341,6 +377,9 @@ struct OnboardingV2View: View {
       case .ready:
         ReadyScreenV2(onComplete: {
           viewModel.finishOnboarding(settings: settings)
+          // #1176 (race fix): mark terminal BEFORE the window closes, so the
+          // unguarded window-close path sees it and does not also fire abandon.
+          onboardingProgress.markCompleted()
           onComplete()
         })
         .transition(Self.screenTransition)
@@ -351,6 +390,11 @@ struct OnboardingV2View: View {
     .frame(width: 460)
     .background(Color.obCardBg)
     .onAppear(perform: recoverFromPersistedState)
+    // #1176: mirror screen/stage into the session box for the abandon emitter.
+    // (The session `begin()` reset fires from `openOnboardingAction`, App-layer,
+    // so re-entry works even when the reused window skips a fresh onAppear.)
+    .onChange(of: viewModel.currentScreen) { syncProgressBox() }
+    .onChange(of: viewModel.setupPhase) { syncProgressBox() }
     // setupPhase is intentionally excluded from the id: changing phase at the end of
     // startSetup must NOT cancel the running task. currentScreen + retryCount are
     // sufficient triggers — retryCount bumps on retry, currentScreen bumps on navigation.
@@ -387,6 +431,29 @@ struct OnboardingV2View: View {
     case .completed:
       viewModel.currentScreen = .ready
     }
+    // #1176: `begin()` (the session reset) fires from `openOnboardingAction` so it
+    // is reliable even when a reused window skips a fresh onAppear; here we only
+    // mirror the resolved screen/step into the box.
+    syncProgressBox()
+  }
+
+  /// #1176: mirror the current screen + stage into the session box so the abandon
+  /// emitter (window-close / app-quit) reports WHERE the user was.
+  private func syncProgressBox() {
+    let screen: String
+    let step: String
+    switch viewModel.currentScreen {
+    case .welcome:
+      screen = "welcome"
+      step = "welcome"
+    case .settingUp:
+      screen = "setting_up"
+      step = viewModel.setupPhase == .permissions ? "permissions" : "model_setup"
+    case .ready:
+      screen = "ready"
+      step = "ready"
+    }
+    onboardingProgress.update(screen: screen, step: step)
   }
 }
 
@@ -858,8 +925,7 @@ private struct PermissionsPhaseView: View {
       if axNow && !viewModel.hasAppliedAxGrant {
         viewModel.hasAppliedAxGrant = true
         settings.autoCopyToClipboard = true
-        TelemetryService.shared.onboardingStepCompleted(
-          step: "accessibility_permission", result: "granted")
+        viewModel.completeStep("accessibility_permission", result: "granted")
       }
 
       // #735 revocation fix: mirror LIVE Accessibility state BOTH directions so a
@@ -872,7 +938,7 @@ private struct PermissionsPhaseView: View {
       // ways could flip a true flag false from stale cache.
       if permissions.hasMicrophonePermission && !viewModel.micGranted {
         viewModel.micGranted = true
-        TelemetryService.shared.onboardingStepCompleted(step: "mic_permission", result: "granted")
+        viewModel.completeStep("mic_permission", result: "granted")
       }
       // #735: showSkipLink no longer used (Skip-for-now backdoor removed); `elapsed` retained
       // so future telemetry can re-attach a "time-on-permissions-screen" event if needed.

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -40,6 +40,20 @@ final class OnboardingV2ViewModel {
   var setupPhase: SetupPhase = .checklist
   var checklistStatuses: [ChecklistItemStatus] = [.pending, .pending, .pending]
 
+  /// The checklist beat the user is currently on, derived from the observable
+  /// statuses (cloud Codex r4) so the abandon event reports the real sub-step
+  /// instead of a coarse "model_setup". The active beat is the first not-yet-
+  /// completed item; all-completed means the user is on the last beat, about to
+  /// advance to permissions.
+  static let checklistStepNames = ["model_download", "ai_config", "hotkey_config"]
+  var activeChecklistStep: String {
+    for (i, status) in checklistStatuses.enumerated() {
+      if case .completed = status { continue }
+      return Self.checklistStepNames[min(i, Self.checklistStepNames.count - 1)]
+    }
+    return Self.checklistStepNames.last!
+  }
+
   var micGranted = false
   var accessibilityGranted = false
   /// #735: one-time guard so the grant telemetry + autoCopy default fire once per
@@ -327,11 +341,27 @@ final class OnboardingV2ViewModel {
   /// visual-beat steps; meaningful for model_download warmup + permission on-screen time.
   var stepStartedAt = Date()
 
+  /// Floor for `stepStartedAt`, supplied by the view from `OnboardingProgress.sessionStart`
+  /// (cloud Codex r4). The permissions-phase `completeStep`s (accessibility/mic grant)
+  /// fire OUTSIDE `startSetup`, which is the only place that refreshes `stepStartedAt`;
+  /// on a reused-window reopen onto the permissions screen, `stepStartedAt` is stale, so
+  /// a grant would report a duration inflated by the time the window was closed. Flooring
+  /// the step start at the current session's start clamps every duration to time-in-this-
+  /// session. nil before the view wires it (then no clamp — the forward path is unaffected
+  /// because `stepStartedAt` is always >= the session start on the forward path).
+  var sessionStartFloor: (@MainActor () -> Date?)?
+
+  /// `stepStartedAt`, never earlier than the current session start.
+  private func clampedStepStart() -> Date {
+    if let floor = sessionStartFloor?(), floor > stepStartedAt { return floor }
+    return stepStartedAt
+  }
+
   /// Emit `onboarding.step_completed` with `duration_seconds`, then reset the clock
   /// for the next step (E2).
   func completeStep(_ step: String, result: String) {
     TelemetryService.shared.onboardingStepCompleted(
-      step: step, result: result, durationSeconds: Date().timeIntervalSince(stepStartedAt))
+      step: step, result: result, durationSeconds: Date().timeIntervalSince(clampedStepStart()))
     stepStartedAt = Date()
   }
 
@@ -340,7 +370,7 @@ final class OnboardingV2ViewModel {
   func blockStep(_ step: String, reason: String, permission: String? = nil) {
     TelemetryService.shared.onboardingStepBlocked(
       step: step, reason: reason, permission: permission,
-      durationSeconds: Date().timeIntervalSince(stepStartedAt))
+      durationSeconds: Date().timeIntervalSince(clampedStepStart()))
   }
 }
 
@@ -395,6 +425,10 @@ struct OnboardingV2View: View {
     // so re-entry works even when the reused window skips a fresh onAppear.)
     .onChange(of: viewModel.currentScreen) { syncProgressBox() }
     .onChange(of: viewModel.setupPhase) { syncProgressBox() }
+    // #1176 (cloud Codex r4): the checklist beats (model_download/ai_config/
+    // hotkey_config) advance via `checklistStatuses` while `setupPhase` stays
+    // `.checklist`, so re-sync on each beat so the abandon reports the real sub-step.
+    .onChange(of: viewModel.checklistStatuses) { syncProgressBox() }
     // setupPhase is intentionally excluded from the id: changing phase at the end of
     // startSetup must NOT cancel the running task. currentScreen + retryCount are
     // sufficient triggers — retryCount bumps on retry, currentScreen bumps on navigation.
@@ -431,6 +465,10 @@ struct OnboardingV2View: View {
     case .completed:
       viewModel.currentScreen = .ready
     }
+    // #1176 (cloud Codex r4): wire the per-step duration floor to the box's session
+    // start. Set-once is reliable even if a later reused-window reopen skips this
+    // onAppear — the closure captures the stable box reference.
+    viewModel.sessionStartFloor = { [onboardingProgress] in onboardingProgress.sessionStart }
     // #1176: `begin()` (the session reset) fires from `openOnboardingAction` so it
     // is reliable even when a reused window skips a fresh onAppear; here we only
     // mirror the resolved screen/step into the box.
@@ -448,7 +486,9 @@ struct OnboardingV2View: View {
       step = "welcome"
     case .settingUp:
       screen = "setting_up"
-      step = viewModel.setupPhase == .permissions ? "permissions" : "model_setup"
+      // #1176 (cloud Codex r4): report the real checklist beat, not a coarse
+      // "model_setup" that collapses model_download / ai_config / hotkey_config.
+      step = viewModel.setupPhase == .permissions ? "permissions" : viewModel.activeChecklistStep
     case .ready:
       screen = "ready"
       step = "ready"

--- a/Sources/EnviousWisprServices/PermissionsService.swift
+++ b/Sources/EnviousWisprServices/PermissionsService.swift
@@ -82,6 +82,16 @@ public final class PermissionsService {
     return trusted
   }
 
+  /// Live Accessibility read for a telemetry SEAM that must observe the RESOLVED
+  /// value, not the lagging `accessibilityGranted` cache (Telemetry Bible Phase 7,
+  /// cloud Codex review r3). A pure `AXIsProcessTrusted()` read (no prompt) with NO
+  /// side effects — unlike `refreshAccessibilityStatus()`, it does not mutate the
+  /// cache, re-arm the warning, or emit a `permission.status` flip event. Use it at
+  /// emit points (e.g. the onboarding-abandon posture) where the cache may still be
+  /// false in the ~2 s window after a grant but before the next poll/launch/pre-record
+  /// refresh. Injectable via the same `accessibilityReader` the init/refresh use.
+  public var accessibilityGrantedLive: Bool { accessibilityReader() }
+
   /// Re-check Accessibility permission using `AXIsProcessTrusted()` (no prompt).
   /// Detects revocation transitions (granted → revoked) and re-arms the warning.
   public func refreshAccessibilityStatus() {

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -176,8 +176,23 @@ public final class SettingsManager {
       defaults.set(onboardingState.rawValue, forKey: "onboardingState")
       // Keep legacy key in sync so any existing observers see the right value.
       defaults.set(onboardingState == .completed, forKey: "hasCompletedOnboarding")
+      // #1176: a durable "ever completed" flag (NEVER reset, unlike the legacy key
+      // which a Diagnostics restart flips false). Lets onboarding telemetry label
+      // `source` as first_run vs diagnostics_restart in the SHARED settings store.
+      if onboardingState == .completed {
+        defaults.set(true, forKey: Self.onboardingEverCompletedKey)
+      }
       onChange?(.onboardingState)
     }
+  }
+
+  static let onboardingEverCompletedKey = "ew.onboarding.everCompleted"
+
+  /// #1176: true once the user has EVER finished onboarding (durable; survives a
+  /// Diagnostics restart). Read by the onboarding-abandon `source` label. Backfilled
+  /// from the legacy completion key in `init` for users who completed before this key.
+  public var onboardingEverCompleted: Bool {
+    defaults.bool(forKey: Self.onboardingEverCompletedKey)
   }
 
   /// Backward-compat computed property — true when onboarding is fully complete.
@@ -438,6 +453,14 @@ public final class SettingsManager {
   public init(defaults: UserDefaults? = nil) {
     let defaults = defaults ?? SettingsDefaults.store
     self.defaults = defaults
+    // #1176: backfill the durable everCompleted flag for users who completed
+    // onboarding before it existed — runs at launch, BEFORE any Diagnostics restart
+    // resets the legacy key, so their first restart still reads diagnostics_restart.
+    if !defaults.bool(forKey: Self.onboardingEverCompletedKey),
+      defaults.bool(forKey: "hasCompletedOnboarding")
+    {
+      defaults.set(true, forKey: Self.onboardingEverCompletedKey)
+    }
     selectedBackend =
       ASRBackendType(rawValue: defaults.string(forKey: "selectedBackend") ?? "")
       ?? SettingsDefaultValues.selectedBackend

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -176,6 +176,13 @@ public final class TelemetryService {
       props["duration_seconds"] = String(format: "%.3f", d)
       props["$value"] = d
     }
+    #if DEBUG
+      // #1176: mirror so the E2 `duration_seconds` plumbing is unit-verifiable.
+      var stringProps = ["step": step, "result": result]
+      if let d = durationSeconds { stringProps["duration_seconds"] = String(format: "%.3f", d) }
+      testEventHook?(
+        CapturedTelemetryEvent(name: "onboarding.step_completed", stringProps: stringProps))
+    #endif
     PostHogSDK.shared.capture("onboarding.step_completed", properties: props)
   }
 
@@ -186,6 +193,61 @@ public final class TelemetryService {
         "asr_backend": asrBackend,
         "recording_mode": recordingMode,
       ])
+  }
+
+  /// Telemetry Bible Phase 7 (#1176): a first-run user was blocked on a setup
+  /// step (model-warmup failure or mic-permission denial). `permission` is absent
+  /// for non-permission steps. `durationSeconds` = time on this step before the
+  /// block. Lets us see WHICH step / permission stalls onboarding.
+  public func onboardingStepBlocked(
+    step: String, reason: String, permission: String? = nil, durationSeconds: Double? = nil
+  ) {
+    var props: [String: Any] = ["step": step, "reason": reason]
+    if let permission { props["permission"] = permission }
+    if let d = durationSeconds {
+      props["duration_seconds"] = String(format: "%.3f", d)
+      props["$value"] = d  // raw numeric for PostHog aggregation (matches step_completed)
+    }
+    #if DEBUG
+      var stringProps = ["step": step, "reason": reason]
+      if let permission { stringProps["permission"] = permission }
+      if let d = durationSeconds { stringProps["duration_seconds"] = String(format: "%.3f", d) }
+      testEventHook?(
+        CapturedTelemetryEvent(name: "onboarding.step_blocked", stringProps: stringProps))
+    #endif
+    PostHogSDK.shared.capture("onboarding.step_blocked", properties: props)
+  }
+
+  /// Telemetry Bible Phase 7 (#1176): a first-run user left setup incomplete via
+  /// window-close (`abandonReason=window_closed`) or app-quit (`app_quit`). Fired
+  /// exactly once per presentation (deduped by `OnboardingProgress.terminalEmitted`).
+  /// `elapsedSeconds` = total since the session began (distinct from a step's
+  /// `duration_seconds`). Carries the permission posture so an AX-blocked drop is
+  /// visible. `app_quit` is best-effort (a `kill -9` bypasses `applicationWillTerminate`).
+  public func onboardingAbandoned(
+    screen: String, step: String, elapsedSeconds: Double?,
+    micStatus: String, accessibilityStatus: String, abandonReason: String, source: String
+  ) {
+    var props: [String: Any] = [
+      "screen": screen, "step": step, "mic_status": micStatus,
+      "accessibility_status": accessibilityStatus, "abandon_reason": abandonReason,
+      "source": source,
+    ]
+    if let e = elapsedSeconds {
+      props["elapsed_seconds"] = String(format: "%.3f", e)
+      props["$value"] = e  // raw numeric for PostHog aggregation (matches step_completed)
+    }
+    #if DEBUG
+      var stringProps = [
+        "screen": screen, "step": step, "mic_status": micStatus,
+        "accessibility_status": accessibilityStatus, "abandon_reason": abandonReason,
+        "source": source,
+      ]
+      if let e = elapsedSeconds { stringProps["elapsed_seconds"] = String(format: "%.3f", e) }
+      testEventHook?(
+        CapturedTelemetryEvent(name: "onboarding.abandoned", stringProps: stringProps))
+    #endif
+    PostHogSDK.shared.capture("onboarding.abandoned", properties: props)
   }
 
   // MARK: - Audio System Events (issue #574)

--- a/Tests/EnviousWisprTests/App/OnboardingTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingTelemetryTests.swift
@@ -134,6 +134,28 @@ import Testing
       }
     }
 
+    @Test("reopen after abandon reports the last observed position, not welcome")
+    func reopenAfterAbandonKeepsLastPosition() {
+      withHook { events in
+        let box = makeBox()
+        box.begin(source: "first_run")
+        box.update(screen: "setting_up", step: "permissions")
+        box.emitAbandonIfInFlight(
+          reason: "window_closed", micStatus: "denied", accessibilityStatus: "denied")
+        // Reopen the single-instance window: terminalEmitted was set, so begin starts
+        // a fresh session — but the reused SwiftUI window keeps its viewModel and skips
+        // onAppear, so syncProgressBox never re-fires. begin must NOT have reset the
+        // position to "welcome"; the honest value is the last observed screen/step.
+        box.begin(source: "first_run")
+        box.emitAbandonIfInFlight(
+          reason: "app_quit", micStatus: "denied", accessibilityStatus: "denied")
+        let a = events.named("onboarding.abandoned")
+        #expect(a.count == 2)
+        #expect(a.last?.stringProps["screen"] == "setting_up")
+        #expect(a.last?.stringProps["step"] == "permissions")
+      }
+    }
+
     @Test("the caller-supplied source is carried into the abandon event")
     func sourceCarriesThrough() {
       withHook { events in

--- a/Tests/EnviousWisprTests/App/OnboardingTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingTelemetryTests.swift
@@ -212,6 +212,55 @@ import Testing
         #expect(c.first?.stringProps["duration_seconds"] == "2.000")
       }
     }
+
+    @Test("activeChecklistStep reports the real beat from the observable statuses")
+    func activeChecklistStepDerivation() {
+      // #1176 cloud Codex r4: the abandon must report the real checklist beat, not a
+      // coarse "model_setup" — derived from the @Published checklistStatuses.
+      let vm = OnboardingV2ViewModel()
+      #expect(vm.activeChecklistStep == "model_download")  // all pending
+      vm.checklistStatuses = [.completed, .inProgress, .pending]
+      #expect(vm.activeChecklistStep == "ai_config")
+      vm.checklistStatuses = [.completed, .completed, .inProgress]
+      #expect(vm.activeChecklistStep == "hotkey_config")
+      vm.checklistStatuses = [.completed, .completed, .completed]
+      #expect(vm.activeChecklistStep == "hotkey_config")  // all done → last beat
+    }
+
+    @Test("step_completed duration is floored at the session start (reused-window staleness)")
+    func stepDurationClampedToSession() {
+      // #1176 cloud Codex r4: the permissions completeStep fires outside startSetup, so a
+      // reused-window reopen leaves stepStartedAt stale; flooring at the session start
+      // clamps the duration to time-in-this-session instead of inflating by the closed time.
+      withHook { events in
+        let vm = OnboardingV2ViewModel()
+        vm.stepStartedAt = Date(timeIntervalSinceNow: -3600)  // stale: 1h ago (window was closed)
+        let sessionStart = Date(timeIntervalSinceNow: -2)  // this session began ~2s ago
+        vm.sessionStartFloor = { sessionStart }
+        vm.completeStep("accessibility_permission", result: "granted")
+        let dur =
+          Double(
+            events.named("onboarding.step_completed").first?
+              .stringProps["duration_seconds"] ?? "0") ?? 0
+        #expect(dur < 60)  // clamped to the session, not the stale ~3600
+      }
+    }
+
+    @Test("step_completed uses the live step clock on the forward path (floor does not over-clamp)")
+    func stepDurationForwardPathUnclamped() {
+      withHook { events in
+        let vm = OnboardingV2ViewModel()
+        // Forward path: the step started AFTER the session began → use the step clock.
+        vm.sessionStartFloor = { Date(timeIntervalSinceNow: -100) }  // session began long ago
+        vm.stepStartedAt = Date(timeIntervalSinceNow: -3)  // this step started 3s ago
+        vm.completeStep("model_download", result: "completed")
+        let dur =
+          Double(
+            events.named("onboarding.step_completed").first?
+              .stringProps["duration_seconds"] ?? "0") ?? 0
+        #expect(dur >= 2 && dur < 20)  // ~3s (the step clock), NOT 100s (the floor)
+      }
+    }
   }
 
 #endif

--- a/Tests/EnviousWisprTests/App/OnboardingTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingTelemetryTests.swift
@@ -1,0 +1,175 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+#if DEBUG
+
+  /// #1176 (Telemetry Bible Phase 7) — onboarding drop-off telemetry.
+  ///
+  /// Covers the `OnboardingProgress` session box (single-terminal dedup, re-entry
+  /// reset, source derivation) and the two new `TelemetryService` event payloads.
+  /// Synchronous bodies install + assert the process-global `testEventHook` with no
+  /// await between, so they are immune to the cross-test global-delegate flake class.
+  @MainActor
+  @Suite("Onboarding telemetry", .serialized)
+  struct OnboardingTelemetryTests {
+
+    final class Events: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
+      var all: [CapturedTelemetryEvent] { lock.withLock { stored } }
+      func named(_ n: String) -> [CapturedTelemetryEvent] { all.filter { $0.name == n } }
+    }
+
+    private func withHook(_ body: (Events) -> Void) {
+      let events = Events()
+      TelemetryService.shared.testEventHook = { @Sendable e in events.add(e) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      body(events)
+    }
+
+    private func makeBox() -> OnboardingProgress { OnboardingProgress() }
+
+    /// A SettingsManager backed by a fresh ephemeral suite (never touches the real
+    /// shared store).
+    private func makeSettings() -> SettingsManager {
+      SettingsManager(defaults: UserDefaults(suiteName: "ewtest.\(UUID().uuidString)")!)
+    }
+
+    @Test("abandon fires once with screen/step/reason/source payload")
+    func abandonPayload() {
+      withHook { events in
+        let box = makeBox()
+        box.begin(source: "first_run")
+        box.update(screen: "setting_up", step: "permissions")
+        box.emitAbandonIfInFlight(
+          reason: "window_closed", micStatus: "denied", accessibilityStatus: "denied")
+        let a = events.named("onboarding.abandoned")
+        #expect(a.count == 1)
+        #expect(a.first?.stringProps["abandon_reason"] == "window_closed")
+        #expect(a.first?.stringProps["screen"] == "setting_up")
+        #expect(a.first?.stringProps["step"] == "permissions")
+        #expect(a.first?.stringProps["source"] == "first_run")
+        #expect(a.first?.stringProps["accessibility_status"] == "denied")
+      }
+    }
+
+    @Test("second terminal is deduped — window-close then app-quit emits once")
+    func terminalDedup() {
+      withHook { events in
+        let box = makeBox()
+        box.begin(source: "first_run")
+        box.emitAbandonIfInFlight(
+          reason: "window_closed", micStatus: "authorized", accessibilityStatus: "granted")
+        box.emitAbandonIfInFlight(
+          reason: "app_quit", micStatus: "authorized", accessibilityStatus: "granted")
+        #expect(events.named("onboarding.abandoned").count == 1)
+        #expect(
+          events.named("onboarding.abandoned").first?.stringProps["abandon_reason"]
+            == "window_closed")
+      }
+    }
+
+    @Test("markCompleted suppresses a later abandon (the complete/abandon race fix)")
+    func completeSuppressesAbandon() {
+      withHook { events in
+        let box = makeBox()
+        box.begin(source: "first_run")
+        box.markCompleted()
+        box.emitAbandonIfInFlight(
+          reason: "window_closed", micStatus: "authorized", accessibilityStatus: "granted")
+        #expect(events.named("onboarding.abandoned").isEmpty)
+      }
+    }
+
+    @Test("not-in-flight (no begin) emits nothing")
+    func notInFlightNoEmit() {
+      withHook { events in
+        let box = makeBox()
+        box.emitAbandonIfInFlight(
+          reason: "app_quit", micStatus: "authorized", accessibilityStatus: "granted")
+        #expect(events.named("onboarding.abandoned").isEmpty)
+      }
+    }
+
+    @Test("re-entry: a 2nd begin resets the terminal flag so a new abandon fires")
+    func reEntryResetsTerminal() {
+      withHook { events in
+        let box = makeBox()
+        box.begin(source: "first_run")
+        box.emitAbandonIfInFlight(
+          reason: "window_closed", micStatus: "denied", accessibilityStatus: "denied")
+        box.begin(source: "first_run")  // fresh session — resets terminalEmitted
+        box.emitAbandonIfInFlight(
+          reason: "app_quit", micStatus: "denied", accessibilityStatus: "denied")
+        let a = events.named("onboarding.abandoned")
+        #expect(a.count == 2)
+        // Never completed → both sessions are first_run (the source comes from the
+        // durable everCompleted flag, NOT the in-session count — Codex code-diff #1).
+        #expect(a.allSatisfy { $0.stringProps["source"] == "first_run" })
+        #expect(a.last?.stringProps["abandon_reason"] == "app_quit")
+      }
+    }
+
+    @Test("the caller-supplied source is carried into the abandon event")
+    func sourceCarriesThrough() {
+      withHook { events in
+        let box = makeBox()
+        box.begin(source: "diagnostics_restart")
+        box.emitAbandonIfInFlight(
+          reason: "window_closed", micStatus: "authorized", accessibilityStatus: "granted")
+        #expect(
+          events.named("onboarding.abandoned").first?.stringProps["source"] == "diagnostics_restart"
+        )
+      }
+    }
+
+    @Test("SettingsManager.onboardingEverCompleted is set on completion and never reset")
+    func everCompletedSetOnCompletionAndDurable() {
+      let s = makeSettings()
+      #expect(s.onboardingEverCompleted == false)
+      s.onboardingState = .completed
+      #expect(s.onboardingEverCompleted == true)
+      // A Diagnostics restart resets onboardingState (and the legacy key) but NOT
+      // the durable flag — so a restart is still labeled diagnostics_restart.
+      s.onboardingState = .notStarted
+      #expect(s.onboardingEverCompleted == true)
+    }
+
+    @Test("SettingsManager backfills everCompleted from the legacy key at init")
+    func everCompletedBackfillsFromLegacyKey() {
+      let d = UserDefaults(suiteName: "ewtest.\(UUID().uuidString)")!
+      d.set(true, forKey: "hasCompletedOnboarding")  // completed before the new key existed
+      let s = SettingsManager(defaults: d)  // init backfills
+      #expect(s.onboardingEverCompleted == true)
+    }
+
+    @Test("step_blocked payload")
+    func stepBlockedPayload() {
+      withHook { events in
+        TelemetryService.shared.onboardingStepBlocked(
+          step: "mic_permission", reason: "denied", permission: "microphone", durationSeconds: 1.5)
+        let b = events.named("onboarding.step_blocked")
+        #expect(b.count == 1)
+        #expect(b.first?.stringProps["step"] == "mic_permission")
+        #expect(b.first?.stringProps["reason"] == "denied")
+        #expect(b.first?.stringProps["permission"] == "microphone")
+      }
+    }
+
+    @Test("step_completed now carries duration_seconds")
+    func stepCompletedDuration() {
+      withHook { events in
+        TelemetryService.shared.onboardingStepCompleted(
+          step: "model_download", result: "completed", durationSeconds: 2.0)
+        let c = events.named("onboarding.step_completed")
+        #expect(c.count == 1)
+        #expect(c.first?.stringProps["duration_seconds"] == "2.000")
+      }
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/App/OnboardingTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingTelemetryTests.swift
@@ -114,6 +114,26 @@ import Testing
       }
     }
 
+    @Test("refocus: a 2nd begin while in-flight does NOT rewind the session")
+    func refocusPreservesInFlightSession() {
+      withHook { events in
+        let box = makeBox()
+        box.begin(source: "first_run")
+        box.update(screen: "setting_up", step: "permissions")
+        // The status-menu "Continue Setup…" re-enters openOnboardingAction on the
+        // already-open window — begin must no-op, NOT reset screen/step to welcome.
+        box.begin(source: "diagnostics_restart")
+        box.emitAbandonIfInFlight(
+          reason: "window_closed", micStatus: "denied", accessibilityStatus: "denied")
+        let a = events.named("onboarding.abandoned")
+        #expect(a.count == 1)
+        // Preserved the real position + the original source, not the refocus values.
+        #expect(a.first?.stringProps["screen"] == "setting_up")
+        #expect(a.first?.stringProps["step"] == "permissions")
+        #expect(a.first?.stringProps["source"] == "first_run")
+      }
+    }
+
     @Test("the caller-supplied source is carried into the abandon event")
     func sourceCarriesThrough() {
       withHook { events in

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -119,13 +119,20 @@ import Testing
   ///   A narrow new App-owned home (the #763 direction: many narrow homes), held
   ///   app-lifetime so it never deallocs and stops emitting. The pre-#1173 count
   ///   was already at the cap (31), so adding one home needs +1.
+  /// - 32 → 33 in #1176 (2026-06-24, Telemetry Bible Phase 7): App-owned
+  ///   `onboardingProgress` — the in-flight onboarding session box that owns the
+  ///   single-terminal abandon dedup (complete / window-close / app-quit) and the
+  ///   re-entry reset. Bootstrapper-owned so `applicationWillTerminate` can emit the
+  ///   app-quit abandon and the App-layer window-close closure can call it, WITHOUT
+  ///   adding a stored property to any coordinator (the #763 direction: many narrow
+  ///   homes). The pre-#1176 count was already at the cap (32), so adding one home needs +1.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 32,
+      count <= 33,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 32. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 33. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -241,14 +248,21 @@ import Testing
   /// narrow new App-owned home (+1 stored property, ≤ 31) keeping the funnel the
   /// single observation seam. Cap set by the deterministic rule (post-change
   /// actual 857 + 10, rounded up to nearest 5 = 870).
+  /// Ratcheted 870→890 in #1176 (2026-06-24, Telemetry Bible Phase 7): the
+  /// composition root constructs the `OnboardingProgress` session box (+1 stored
+  /// property), threads it into `AppLifecycleCoordinator` (captured in the
+  /// onboarding-dismiss closure for the window-close abandon) and `OnboardingV2View`,
+  /// and emits the app-quit abandon in `applicationWillTerminate` before the
+  /// Phase-1 flush. Cap set by the deterministic rule (post-change actual 876 + 10,
+  /// rounded up to nearest 5 = 890).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 870,
+      lineCount <= 890,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 870. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 890. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Services/PermissionsServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/PermissionsServiceTests.swift
@@ -83,6 +83,28 @@ import Testing
 
       #expect(box.events.isEmpty)
     }
+
+    @MainActor
+    @Test(
+      "accessibilityGrantedLive reflects a fresh grant the cache hasn't seen, with no side effect")
+    func liveReadDivergesFromStaleCacheWithoutSideEffect() {
+      // #1176 cloud Codex review r3: the onboarding-abandon posture must observe the
+      // RESOLVED accessibility value, not the lagging cache.
+      var live = false
+      let svc = PermissionsService(accessibilityReader: { live })
+      #expect(svc.accessibilityGranted == false)  // cached at init
+
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "permission.status" { box.add(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      live = true  // user grants in System Settings, before any poll refresh
+      #expect(svc.accessibilityGrantedLive == true)  // live read sees it
+      #expect(svc.accessibilityGranted == false)  // pure read did NOT mutate the cache
+      #expect(box.events.isEmpty)  // and did NOT emit a flip event
+    }
   }
 
 #endif


### PR DESCRIPTION
## Telemetry Bible Phase 7 (#1176): onboarding drop-off telemetry

Closes #1176. Part of epic #1168.

We could not see WHERE first-run users drop or WHICH step/permission blocks them. Now:

- **E2** every `onboarding.step_completed` carries `duration_seconds` (per-step timing; `$value` raw number for PostHog aggregation).
- **E1 `onboarding.step_blocked`** on model-warmup failure, disk-space, and mic denial (`step`, `reason`, `permission`, `duration_seconds`).
- **E1 `onboarding.abandoned`** fired from BOTH the window-close callback AND the app-quit terminate seam, carrying `abandon_reason` (`window_closed`/`app_quit`), permission posture, and `source` (`first_run`/`diagnostics_restart`). Window-close alone missed the Cmd+Q-out-of-a-stuck-screen population (the most frustrated users); `app_quit` is best-effort (`kill -9` bypasses `applicationWillTerminate`).

### Design
- A plain `@MainActor OnboardingProgress` box bridges the view's live state to the App-layer terminal handlers and owns the **single-terminal dedup** (a clean finish, or a prior abandon, suppresses any later one — across the complete / window-close / app-quit terminals) plus the **re-entry reset** (`begin()` fires from `openOnboardingAction`, so a Diagnostics restart is a fresh session even when the reused window skips `onAppear`). No coordinator gains a stored property (the box owns the guarded emit; coordinators capture it in closures).
- `source` reads `SettingsManager.onboardingEverCompleted` — a durable flag in the SHARED settings store, set on first completion, never reset (unlike the legacy `hasCompletedOnboarding` which a restart flips false), and backfilled at launch for pre-existing completers. Owning it in `SettingsManager` keeps the box out of the wrong defaults domain.
- The `WisprBootstrapper` line ceiling ratchets 870→890 and the stored-property ceiling 32→33 (both with Bible notes) for the new App-owned home — the documented #763 "many narrow homes" pattern.
- Telemetry only; never blocks/awaits setup.

### Validation
- Council (GPT-5.5 + Gemini) caught the app-quit blind spot + the session/terminal-dedup semantics. Codex grounded review 2 rounds → PROCEED-AS-PLANNED (complete-before-close race, ceiling-safe placement, mic-`Bool` capture). Codex code-diff 5 rounds → clean (source mislabel × 3 edges, numeric `$value`, wrong-defaults-domain — all real data-quality catches, all fixed).
- 2089 logic tests green incl. 10 new `OnboardingTelemetryTests` (dedup, re-entry reset, source carry-through, `SettingsManager.onboardingEverCompleted` set-on-completion + legacy backfill, payloads).
- Live UAT: dev app launches clean with all the new wiring; triggered onboarding renders the Setup window (the `openOnboardingAction`→`begin` path), a Cocoa-quit with onboarding in flight exits cleanly (the `app_quit` abandon path), the `everCompleted` backfill resolves at launch, founder state restored.