### PR TITLE
feat(telemetry): in-host quiet-limb failure visibility (Telemetry Bible Phase 8a, #1177)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -83,7 +83,10 @@ public final class WisprBootstrapper {
     // pinned Dark never flashes white. `.system` clears the override (follow OS).
     AppearanceController.apply(settings.appearancePreference)
     let permissions = PermissionsService()
-    let keychainManager = KeychainManager()
+    // #1177 (Telemetry Bible Phase 8): inject the live LLM-module telemetry sink at the
+    // composition root. This is the ONLY KeychainManager that gets `.live`; it carries
+    // the sink for the legacy-key-cleanup (Q3.3) + cloud-prewarm (A6) quiet limbs.
+    let keychainManager = KeychainManager(telemetrySink: .live)
     let recordingOverlay = RecordingOverlayPanel()
     let audioDeviceList = AudioDeviceList()
     let captureTelemetry = CaptureTelemetryState()
@@ -673,9 +676,20 @@ public final class WisprBootstrapper {
           level: .info, category: "LLM")
       } catch {
         let reason = (error as? OutputClassifierError)?.reason.rawValue ?? "load_failed"
+        let elapsedMs = Int(
+          Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
         await AppLogger.shared.log(
           "[OutputClassifier] preWarm failed reason=\(reason) — fail open to raw/sync-filtered polish",
           level: .info, category: "LLM")
+        // #1177 (Telemetry Bible Phase 8): the polish path silently lost its safety
+        // net. Population event for the aggregate fail-open rate + a handled error
+        // (this retries on every provider switch, so a genuinely broken model becomes
+        // a recurring issue grouped per-reason). @MainActor static → direct emit.
+        TelemetryService.shared.limbFailureObserved(
+          limb: "output_safety", operation: "classifier_prewarm", result: "fell_open",
+          errorCategory: reason, durationMs: elapsedMs)
+        SentryBreadcrumb.captureError(
+          error, category: .outputClassifierLoadFailed, stage: "llm", fingerprintDetail: reason)
       }
     }
   }

--- a/Sources/EnviousWisprCore/LLMTelemetrySink.swift
+++ b/Sources/EnviousWisprCore/LLMTelemetrySink.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// #1177 (Telemetry Bible Phase 8): the telemetry seam for quiet-limb failures that
+/// occur INSIDE the `EnviousWisprLLM` module (cloud pre-warm, legacy-key cleanup).
+///
+/// The LLM module depends only on Core + ArgmaxOSS — not on Services / PostHog /
+/// Sentry. Rather than pull that weight upward (a new `LLM -> Services` edge), the
+/// module takes this injected sink — the established `HotkeyTelemetrySink` pattern.
+/// The TYPE lives in Core (Foundation-only, NO Services types — Codex grounded review
+/// r2); the `.live` factory that maps these callbacks onto `TelemetryService` +
+/// `SentryBreadcrumb` lives in Services and is injected by the App composition root.
+/// Defaults to `.noop`, so every other construction site (the two connector
+/// default-args, the ~43 test sites) stays silent.
+///
+/// Closures are `@Sendable` and fire-and-forget: the `.live` implementation hops to
+/// the `@MainActor` `TelemetryService` internally, so callers in any isolation — the
+/// `Task.detached` pre-warm, the synchronous Keychain cleanup — just call them
+/// without awaiting and never block the heart path.
+public struct LLMTelemetrySink: Sendable {
+  /// A quiet-limb failure was observed → the `limb.failure_observed` population event.
+  /// Metadata only (never transcript / content / key material).
+  public let limbFailure:
+    @Sendable (
+      _ limb: String, _ operation: String, _ result: String,
+      _ errorCategory: String, _ durationMs: Int?
+    ) -> Void
+
+  /// The legacy plaintext API-key file could not be deleted after migration to the
+  /// Keychain → a security-relevant Sentry handled error. The `.live` factory maps
+  /// this to the `legacyKeyCleanupFailed` category; the payload carries only the
+  /// account name and the bridged error signature, never the key material.
+  public let legacyKeyCleanupFailed: @Sendable (_ error: any Error, _ account: String) -> Void
+
+  public init(
+    limbFailure: @escaping @Sendable (String, String, String, String, Int?) -> Void,
+    legacyKeyCleanupFailed: @escaping @Sendable (any Error, String) -> Void
+  ) {
+    self.limbFailure = limbFailure
+    self.legacyKeyCleanupFailed = legacyKeyCleanupFailed
+  }
+
+  /// No-op sink — the default at every construction site except the App composition
+  /// root (which injects `.live`). Keeps tests and keyless paths silent.
+  public static let noop = LLMTelemetrySink(
+    limbFailure: { _, _, _, _, _ in },
+    legacyKeyCleanupFailed: { _, _ in })
+}

--- a/Sources/EnviousWisprLLM/KeychainManager.swift
+++ b/Sources/EnviousWisprLLM/KeychainManager.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 import OSLog
 import Security
@@ -19,20 +20,30 @@ public struct KeychainManager: Sendable {
   private let backend: KeyStorageBackend
   private let legacyStore: any LegacyKeyFileStorage
   private let keychainStore: any KeychainItemStorage
+  /// #1177 (Telemetry Bible Phase 8): the LLM module's quiet-limb telemetry sink. The
+  /// LLM module has no telemetry dependency, so the App composition root injects the
+  /// `.live` sink here (this is the LLM module's already-ubiquitous dependency) and it
+  /// is reached by Q3.3 (legacy-key cleanup, below) AND A6 (`LLMNetworkSession.preWarmModel`
+  /// reads it off the `keychainManager` it already receives). `internal` — module-visible
+  /// to `LLMNetworkSession`, injected via the public `init` param. Defaults to `.noop`,
+  /// so the ~43 test sites + the connector default-args stay silent.
+  let telemetrySink: LLMTelemetrySink
 
-  public init() {
+  public init(telemetrySink: LLMTelemetrySink = .noop) {
     let legacyStore = FileLegacyKeyStore()
     if Self.usesLegacyFilesForDefaultRuntime {
       self.init(
         backend: .legacyFiles,
         legacyStore: legacyStore,
-        keychainStore: SecurityKeychainItemStore()
+        keychainStore: SecurityKeychainItemStore(),
+        telemetrySink: telemetrySink
       )
     } else {
       self.init(
         backend: .keychain(service: Self.productionService),
         legacyStore: legacyStore,
-        keychainStore: SecurityKeychainItemStore()
+        keychainStore: SecurityKeychainItemStore(),
+        telemetrySink: telemetrySink
       )
     }
   }
@@ -40,11 +51,13 @@ public struct KeychainManager: Sendable {
   init(
     backend: KeyStorageBackend,
     legacyStore: any LegacyKeyFileStorage = FileLegacyKeyStore(),
-    keychainStore: any KeychainItemStorage = SecurityKeychainItemStore()
+    keychainStore: any KeychainItemStorage = SecurityKeychainItemStore(),
+    telemetrySink: LLMTelemetrySink = .noop
   ) {
     self.backend = backend
     self.legacyStore = legacyStore
     self.keychainStore = keychainStore
+    self.telemetrySink = telemetrySink
   }
 
   public func store(key: String, value: String) throws {
@@ -140,6 +153,11 @@ public struct KeychainManager: Sendable {
       Self.logger.error(
         "Legacy plaintext API key file remained on disk after Keychain migration; user-visible polish is unaffected but the security goal is not met. Will retry on next retrieve. account=\(key, privacy: .public) error=\(String(describing: error), privacy: .public)"
       )
+      // #1177 (Telemetry Bible Phase 8): a security goal silently failed — the plaintext
+      // key still sits on disk. The sink's `.live` emits a population event + a
+      // fingerprinted Sentry handled error (per-account); fire-and-forget, never the key
+      // material (only the account name). `.noop` everywhere except the App root.
+      telemetrySink.legacyKeyCleanupFailed(error, key)
     }
   }
 

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -65,11 +65,20 @@ public final class LLMNetworkSession: Sendable {
       do {
         let (_, response) = try await session.data(for: request)
         let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
-        let status = (response as? HTTPURLResponse)?.statusCode.description ?? "n/a"
+        let statusCode = (response as? HTTPURLResponse)?.statusCode
+        let status = statusCode?.description ?? "n/a"
         await AppLogger.shared.log(
           "preWarm completed provider=\(provider.rawValue) model=\(model) duration_ms=\(ms) status=\(status)",
           level: .info, category: "LLM"
         )
+        // Cloud review (PR #1211): a non-2xx response does NOT throw (URLSession
+        // returns it), so it would otherwise log "completed" and never report the
+        // failure — mirror the A5 evict 2xx/non-2xx split. A missing status code
+        // (n/a) is NOT treated as a failure (that path already lacks a real signal).
+        if let code = statusCode, !(200...299).contains(code) {
+          sink.limbFailure(
+            "llm_prewarm", "prewarm", "failed", "\(provider.rawValue)_http_\(code)", ms)
+        }
       } catch {
         let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
         await AppLogger.shared.log(

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -56,7 +56,11 @@ public final class LLMNetworkSession: Sendable {
       )
     else { return }
 
-    Task.detached { [session] in
+    // #1177 (Telemetry Bible Phase 8): A6 reads the LLM module's telemetry sink off
+    // the `keychainManager` it already receives (carried there because the LLM module
+    // has no telemetry dependency — KeychainManager is the App-injected seam). The
+    // sink is `Sendable`, so it crosses into the detached task cleanly.
+    Task.detached { [session, sink = keychainManager.telemetrySink] in
       let start = CFAbsoluteTimeGetCurrent()
       do {
         let (_, response) = try await session.data(for: request)
@@ -72,6 +76,13 @@ public final class LLMNetworkSession: Sendable {
           "preWarm failed provider=\(provider.rawValue) model=\(model) duration_ms=\(ms) error=\(String(describing: error))",
           level: .info, category: "LLM"
         )
+        // Best-effort cloud warm-up failed → first real polish pays a cold start.
+        // Population only (the polish call's own telemetry covers persistent issues);
+        // the sink hops to the @MainActor TelemetryService. Low-cardinality category:
+        // provider + URLError code, never any content.
+        let category =
+          "\(provider.rawValue)_\((error as? URLError)?.code.rawValue.description ?? "error")"
+        sink.limbFailure("llm_prewarm", "prewarm", "failed", category, ms)
       }
     }
   }

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -1,6 +1,24 @@
 import EnviousWisprCore
 import Foundation
 
+/// #1177 (Telemetry Bible Phase 8): the result of an Ollama model eviction. Returned
+/// by `evictModel` (which never throws) so the Pipeline caller can observe a quiet
+/// eviction failure. Content-free metadata only.
+public struct OllamaEvictOutcome: Sendable {
+  /// `"unloaded"` (2xx), `"failed"` (non-2xx or transport error), or `"skipped"`
+  /// (empty model / bad URL — nothing to evict).
+  public let result: String
+  public let durationMs: Int
+  /// `"http_<status>"`, a `URLError` code, or `"invalid_url_or_empty"`.
+  public let reason: String
+
+  public init(result: String, durationMs: Int, reason: String) {
+    self.result = result
+    self.durationMs = durationMs
+    self.reason = reason
+  }
+}
+
 /// Ollama local LLM connector. Uses Ollama's native /api/chat endpoint
 /// for access to `think`, `keep_alive`, and timing telemetry.
 /// Requires Ollama to be running: https://ollama.com
@@ -164,12 +182,21 @@ public struct OllamaConnector: TranscriptPolisher {
   /// VRAM for its full window, which on constrained machines has disrupted
   /// CoreAudio BT audio (root cause for #286).
   ///
-  /// Fire-and-forget: returns void, swallows all errors, short timeout.
-  /// Uses `/api/generate` per Ollama docs — `keep_alive: 0` on `/api/chat`
-  /// is not a documented unload pattern.
-  public func evictModel(_ modelName: String) async {
+  /// Fire-and-forget from the heart-path view: swallows all errors, short timeout,
+  /// never throws. Uses `/api/generate` per Ollama docs — `keep_alive: 0` on
+  /// `/api/chat` is not a documented unload pattern.
+  ///
+  /// #1177 (Telemetry Bible Phase 8): returns an `OllamaEvictOutcome` so the Pipeline
+  /// caller (which has telemetry access; this LLM module does not) can observe a quiet
+  /// eviction FAILURE — a model that won't unload starves VRAM and has disrupted
+  /// CoreAudio BT audio (#286). `@discardableResult` (Codex r1): the previous callers
+  /// + tests treat it as fire-and-forget.
+  @discardableResult
+  public func evictModel(_ modelName: String) async -> OllamaEvictOutcome {
     let endpointURL = "\(baseURL)/api/generate"
-    guard !modelName.isEmpty, let url = URL(string: endpointURL) else { return }
+    guard !modelName.isEmpty, let url = URL(string: endpointURL) else {
+      return OllamaEvictOutcome(result: "skipped", durationMs: 0, reason: "invalid_url_or_empty")
+    }
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
@@ -184,18 +211,20 @@ public struct OllamaConnector: TranscriptPolisher {
       let (_, response) = try await networkExecutor(request)
       let status = (response as? HTTPURLResponse)?.statusCode ?? 0
       let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
-      let result = (200...299).contains(status) ? "unloaded" : "error"
+      let result = (200...299).contains(status) ? "unloaded" : "failed"
       await AppLogger.shared.log(
         "Ollama evict: model=\(modelName) result=\(result) http=\(status) duration_ms=\(elapsedMs)",
         level: .info, category: "LLM"
       )
+      return OllamaEvictOutcome(result: result, durationMs: elapsedMs, reason: "http_\(status)")
     } catch {
       let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
       let reason = (error as? URLError)?.code.rawValue.description ?? "error"
       await AppLogger.shared.log(
-        "Ollama evict: model=\(modelName) result=error reason=\(reason) duration_ms=\(elapsedMs)",
+        "Ollama evict: model=\(modelName) result=failed reason=\(reason) duration_ms=\(elapsedMs)",
         level: .info, category: "LLM"
       )
+      return OllamaEvictOutcome(result: "failed", durationMs: elapsedMs, reason: reason)
     }
   }
 

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -103,7 +103,16 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// `modelName` is empty. Swallows all errors; only logs.
   public func evictPreviousOllamaModel(_ modelName: String) async {
     guard !modelName.isEmpty else { return }
-    await OllamaConnector().evictModel(modelName)
+    let outcome = await OllamaConnector().evictModel(modelName)
+    // #1177 (Telemetry Bible Phase 8): observe a quiet eviction FAILURE — a model that
+    // won't unload lingers in VRAM and has disrupted CoreAudio BT audio (#286). The
+    // eviction itself stays fire-and-forget; this only reports the outcome. @MainActor
+    // step → direct emit. Fire only on failure (success/skip are non-events).
+    if outcome.result == "failed" {
+      TelemetryService.shared.limbFailureObserved(
+        limb: "ollama", operation: "evict", result: "failed",
+        errorCategory: outcome.reason, durationMs: outcome.durationMs)
+    }
   }
 
   /// Warm the configured LLM provider for the upcoming session — parity

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -452,7 +452,26 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
         level: .info, category: "Pipeline"
       )
     }
-    return await finalizeBatchRescue(batchSamples: batchSamples, diagnostics: diagnostics)
+    // Codex r1: store the rescue outcome locally so the emit can read whether the
+    // batch rescue recovered a transcript before returning it.
+    let outcome = await finalizeBatchRescue(batchSamples: batchSamples, diagnostics: diagnostics)
+    // #1177 (Telemetry Bible Phase 8): observe the quiet streaming-finalize failure.
+    // The heart was fine (batch rescue gave text, or raw fell through), but until now
+    // we never knew streaming broke. Fire ONLY on the genuine-failure branch — a
+    // CancellationError returned `.cancelled` and an empty-but-successful streaming
+    // result returned earlier without setting the flag. `@MainActor` adapter → direct
+    // emit, no hop. Metadata only (the error's type name, never any transcript).
+    if diagnostics.streamingFinalizeFailed == true {
+      let recovered: Bool = {
+        if case .transcript = outcome { return true } else { return false }
+      }()
+      TelemetryService.shared.limbFailureObserved(
+        limb: "asr_streaming", operation: "finalize",
+        result: recovered ? "rescued" : "failed",
+        errorCategory: diagnostics.streamingFinalizeErrorType ?? "unknown",
+        durationMs: nil)
+    }
+    return outcome
   }
 
   private func finalizeBatchRescue(

--- a/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
+++ b/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
@@ -1,0 +1,43 @@
+import EnviousWisprCore
+import Foundation
+
+/// #1177 (Telemetry Bible Phase 8): the production wiring for the LLM-module quiet-limb
+/// sink. The TYPE lives in Core (Foundation-only); THIS `.live` factory lives in
+/// Services because it references `TelemetryService` + `SentryBreadcrumb` (Codex
+/// grounded review r2: the Core type must not name Services types). The App composition
+/// root injects `.live`; every other site uses `.noop`.
+extension LLMTelemetrySink {
+  /// Maps the Core-owned callbacks onto the real telemetry homes. Both are
+  /// `@MainActor` (`TelemetryService` / `SentryBreadcrumb`), and the sink's callers run
+  /// off the main actor (A6's `Task.detached`, the off-MainActor Keychain cleanup), so
+  /// each closure hops to the main run loop via `DispatchQueue.main.async`
+  /// (NOT `Task { @MainActor }`, which may run on the current cycle — gotchas-audio
+  /// `dispatch-main-for-runloop-deferral`) and runs the emit there. Fire-and-forget:
+  /// telemetry lost to an immediate quit is acceptable; a limb never blocks the heart.
+  public static let live = LLMTelemetrySink(
+    limbFailure: { limb, operation, result, errorCategory, durationMs in
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          TelemetryService.shared.limbFailureObserved(
+            limb: limb, operation: operation, result: result,
+            errorCategory: errorCategory, durationMs: durationMs)
+        }
+      }
+    },
+    legacyKeyCleanupFailed: { error, account in
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          // Population event (aggregate cleanup-failure rate) + the security-relevant
+          // handled error (per-incident detail). Account name only, never key material.
+          TelemetryService.shared.limbFailureObserved(
+            limb: "keychain", operation: "legacy_cleanup", result: "failed",
+            errorCategory: "delete_failed", durationMs: nil)
+          SentryBreadcrumb.captureError(
+            error, category: .legacyKeyCleanupFailed, stage: "keychain",
+            extra: ["account": account],
+            // Split distinct accounts into their own issue (low cardinality: 2 keys).
+            fingerprintDetail: account)
+        }
+      }
+    })
+}

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -347,6 +347,18 @@ public enum SentryBreadcrumb {
     /// actionable; carries `mechanism` / `hotkey_kind` / `os_status` / `key_shape`
     /// (metadata only — never the key codes).
     case hotkeyRegistrationFailed = "hotkey_registration_failed"
+    /// #1177 (Telemetry Bible Phase 8): the on-device output-safety classifier
+    /// failed to load at prewarm. Polish keeps working WITHOUT the extra safety net
+    /// (fails open) — persistent because it retries on every provider switch, so a
+    /// genuinely broken model surfaces as a recurring handled error. `fingerprintDetail`
+    /// is the load-failure reason, so distinct reasons get distinct issues.
+    case outputClassifierLoadFailed = "output_classifier_load_failed"
+    /// #1177 (Telemetry Bible Phase 8): a legacy plaintext API-key file could not be
+    /// deleted after migration to the Keychain. The user's polish is unaffected (the
+    /// Keychain value works), but the security goal — no plaintext key on disk — is
+    /// silently unmet until the next retrieve retries. Security-relevant + persistent,
+    /// so it earns a handled error (never the key material — only the account name).
+    case legacyKeyCleanupFailed = "legacy_key_cleanup_failed"
   }
 }
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -358,6 +358,39 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("hotkey.pressed", properties: props)
   }
 
+  /// #1177 (Telemetry Bible Phase 8): a limb failed quietly — the user still got
+  /// raw text or a small glitch, but until now we had zero signal. ONE event for
+  /// every quiet-limb site (ASR streaming finalize, output-safety classifier
+  /// prewarm, Ollama eviction, cloud pre-warm, legacy-key cleanup). Metadata only —
+  /// never transcript/content/key material. `durationMs` is mirrored to `$value`
+  /// for PostHog aggregation (Phase 6/7 precedent).
+  public func limbFailureObserved(
+    limb: String, operation: String, result: String,
+    errorCategory: String, durationMs: Int?
+  ) {
+    var props: [String: Any] = [
+      "limb": limb, "operation": operation, "result": result,
+      "error_category": errorCategory,
+    ]
+    if let durationMs {
+      props["duration_ms"] = durationMs
+      props["$value"] = durationMs
+    }
+    #if DEBUG
+      var intProps: [String: Int] = [:]
+      if let durationMs { intProps["duration_ms"] = durationMs }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "limb.failure_observed",
+          stringProps: [
+            "limb": limb, "operation": operation, "result": result,
+            "error_category": errorCategory,
+          ],
+          intProps: intProps))
+    #endif
+    PostHogSDK.shared.capture("limb.failure_observed", properties: props)
+  }
+
   public func dictationCompleted(
     result: String, inputMode: String, asrBackend: String,
     llmProvider: String?, fillerRemoval: Bool,

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -255,14 +255,21 @@ import Testing
   /// and emits the app-quit abandon in `applicationWillTerminate` before the
   /// Phase-1 flush. Cap set by the deterministic rule (post-change actual 876 + 10,
   /// rounded up to nearest 5 = 890).
+  /// Ratcheted 890→905 in #1177 (2026-06-24, Telemetry Bible Phase 8a): the
+  /// composition root injects the `.live` LLM-module telemetry sink into
+  /// `KeychainManager` (Q3.3 + A6 seam) AND emits the Q3.1 output-safety classifier
+  /// prewarm-failure telemetry (population event + Sentry handled error) from the
+  /// App-layer `prewarmOutputClassifierIfNeeded` catch — its natural emit site. No
+  /// new stored property; real wiring, not comment growth. Cap by the deterministic
+  /// rule (post-change actual 902 + ~3, rounded up to nearest 5 = 905).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 890,
+      lineCount <= 905,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 890. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 905. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
@@ -1,8 +1,22 @@
+import EnviousWisprCore
 import Foundation
 import Security
 import Testing
 
 @testable import EnviousWisprLLM
+
+/// #1177 (Telemetry Bible Phase 8): captures the legacy-key-cleanup-failed callback.
+private final class CleanupSinkSpy: @unchecked Sendable {
+  private let lock = NSLock()
+  private var _accounts: [String] = []
+  var accounts: [String] { lock.withLock { _accounts } }
+  func makeSink() -> LLMTelemetrySink {
+    LLMTelemetrySink(
+      limbFailure: { _, _, _, _, _ in },
+      legacyKeyCleanupFailed: { _, account in self.lock.withLock { self._accounts.append(account) }
+      })
+  }
+}
 
 @Suite("KeychainManager", .serialized)
 struct KeychainManagerTests {
@@ -552,6 +566,25 @@ struct KeychainManagerTests {
       try manager.delete(key: "business-workspace-admin-sa.json")
     }
     #expect(FileManager.default.fileExists(atPath: unrelated.path))
+  }
+
+  @Test("legacy-key cleanup failure during retrieve-migration fires the telemetry sink")
+  func legacyCleanupFailureFiresSink() throws {
+    // #1177 (Telemetry Bible Phase 8, Q3.3): retrieve migrates the legacy value into the
+    // Keychain then best-effort deletes the plaintext file; when that delete throws, the
+    // path stays fail-soft (still returns the value) but now reports a security-relevant
+    // handled error so a lingering plaintext key is no longer silent.
+    let spy = CleanupSinkSpy()
+    let manager = KeychainManager(
+      backend: .keychain(service: testService),
+      legacyStore: FailingDeleteLegacyStore(),  // retrieve → "legacy", delete → throws
+      keychainStore: InMemoryKeychainStore(),
+      telemetrySink: spy.makeSink())
+
+    let value = try manager.retrieve(key: KeychainManager.openAIKeyID)
+
+    #expect(value == "legacy")  // fail-soft: the user's key still works
+    #expect(spy.accounts == [KeychainManager.openAIKeyID])  // the cleanup failure was observed
   }
 
   private var testService: String { "com.enviouswispr.tests.api-keys" }

--- a/Tests/EnviousWisprTests/LLM/Phase8LimbTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/LLM/Phase8LimbTelemetryTests.swift
@@ -1,0 +1,123 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+#if DEBUG
+
+  /// Helper spy for the LLM-module telemetry seam.
+  private final class SinkSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _limbs: [String] = []
+    private var _cleanups: [String] = []
+    var limbs: [String] { lock.withLock { _limbs } }
+    var cleanups: [String] { lock.withLock { _cleanups } }
+    func makeSink() -> LLMTelemetrySink {
+      LLMTelemetrySink(
+        limbFailure: { limb, _, _, _, _ in self.lock.withLock { self._limbs.append(limb) } },
+        legacyKeyCleanupFailed: { _, account in
+          self.lock.withLock { self._cleanups.append(account) }
+        })
+    }
+  }
+
+  /// #1177 (Telemetry Bible Phase 8): the shared `limb.failure_observed` event, the
+  /// LLM-module telemetry seam (`LLMTelemetrySink`), and the Ollama eviction outcome.
+  /// Synchronous set-hook → act → read → restore (serialized for the process-global hook).
+  @MainActor
+  @Suite("Phase 8 limb telemetry", .serialized)
+  struct Phase8LimbTelemetryTests {
+
+    final class Box: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
+      func named(_ n: String) -> [CapturedTelemetryEvent] {
+        lock.withLock { stored.filter { $0.name == n } }
+      }
+    }
+
+    private func capture(_ body: () -> Void) -> Box {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable e in box.add(e) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      body()
+      return box
+    }
+
+    @Test("limb.failure_observed carries the metadata payload + numeric duration")
+    func limbFailurePayload() {
+      let box = capture {
+        TelemetryService.shared.limbFailureObserved(
+          limb: "ollama", operation: "evict", result: "failed",
+          errorCategory: "http_500", durationMs: 42)
+      }
+      let e = box.named("limb.failure_observed")
+      #expect(e.count == 1)
+      #expect(e.first?.stringProps["limb"] == "ollama")
+      #expect(e.first?.stringProps["operation"] == "evict")
+      #expect(e.first?.stringProps["result"] == "failed")
+      #expect(e.first?.stringProps["error_category"] == "http_500")
+      #expect(e.first?.intProps["duration_ms"] == 42)
+    }
+
+    @Test("LLMTelemetrySink.noop fires nothing")
+    func noopSinkSilent() {
+      let box = capture {
+        LLMTelemetrySink.noop.limbFailure("x", "y", "failed", "z", 1)
+        LLMTelemetrySink.noop.legacyKeyCleanupFailed(URLError(.timedOut), "acct")
+      }
+      #expect(box.named("limb.failure_observed").isEmpty)
+    }
+
+    @Test("a spy LLMTelemetrySink captures both callbacks")
+    func spySinkCaptures() {
+      let spy = SinkSpy()
+      let sink = spy.makeSink()
+      sink.limbFailure("llm_prewarm", "prewarm", "failed", "openAI_-1001", 10)
+      sink.legacyKeyCleanupFailed(URLError(.timedOut), "openai-api-key")
+      #expect(spy.limbs == ["llm_prewarm"])
+      #expect(spy.cleanups == ["openai-api-key"])
+    }
+
+    @Test("evictModel reports failed on a transport error")
+    func evictFailedOnError() async {
+      let connector = OllamaConnector(networkExecutor: { _ in throw URLError(.timedOut) })
+      #expect(await connector.evictModel("gemma3").result == "failed")
+    }
+
+    @Test("evictModel reports unloaded on a 2xx response")
+    func evictUnloadedOn2xx() async {
+      let connector = OllamaConnector(networkExecutor: { _ in
+        (
+          Data(),
+          HTTPURLResponse(
+            url: URL(string: "http://localhost:11434/api/generate")!, statusCode: 200,
+            httpVersion: nil, headerFields: nil)!
+        )
+      })
+      #expect(await connector.evictModel("gemma3").result == "unloaded")
+    }
+
+    @Test("evictModel reports failed on a non-2xx response")
+    func evictFailedOnNon2xx() async {
+      let connector = OllamaConnector(networkExecutor: { _ in
+        (
+          Data(),
+          HTTPURLResponse(
+            url: URL(string: "http://localhost:11434/api/generate")!, statusCode: 500,
+            httpVersion: nil, headerFields: nil)!
+        )
+      })
+      #expect(await connector.evictModel("gemma3").result == "failed")
+    }
+
+    @Test("evictModel skips an empty model name")
+    func evictSkipsEmpty() async {
+      #expect(await OllamaConnector().evictModel("").result == "skipped")
+    }
+  }
+
+#endif


### PR DESCRIPTION
## Telemetry Bible Phase 8a (#1177): in-host quiet-limb failures

Part of #1177 (the cross-process VAD-prepare gap A4 ships next as 8b — different process, in-service Sentry, no PostHog).

Five places where a limb fails QUIETLY today now emit content-free observation at their EXISTING catch/return points. No behavior change — every limb still fails-open to raw text exactly as before (`instrumentation-stays-observation-only`).

### What it captures
One shared PostHog event `limb.failure_observed` {limb, operation, result, error_category, duration_ms (+$value)} for all five, plus Sentry handled errors for the security/persistent ones (fingerprinted per-reason/per-account):

- **A8** (`ParakeetEngineAdapter`): streaming-finalize failure that the batch rescue masks — `result=rescued|failed` (the rescue outcome is stored locally first, Codex r1).
- **Q3.1** (`WisprBootstrapper`): output-safety classifier prewarm fail-open → population + handled error (it retries on every provider switch, so a broken model recurs).
- **A5** (`OllamaConnector`→`LLMPolishStep`): `evictModel` now returns a `@discardableResult OllamaEvictOutcome`; the Pipeline caller emits on a failed eviction (a stuck model starves VRAM → BT-audio risk #286).
- **A6** (`LLMNetworkSession`): cloud pre-warm failure → population event.
- **Q3.3** (`KeychainManager`): legacy plaintext-key cleanup failure → population + a security-relevant handled error (the security goal silently went unmet).

### Architecture
The LLM module (`OllamaConnector`/`LLMNetworkSession`/`KeychainManager`) has no telemetry dependency, so it takes an injected `LLMTelemetrySink` — type in Core (Foundation-only, no Services types — Codex r2), `.live` factory in Services (maps to `TelemetryService` + `SentryBreadcrumb`), `.noop` default, injected ONCE at the App composition root. The sink is carried by `KeychainManager` (the LLM module's App-injected dependency, already threaded to both Q3.3 and A6's `preWarmModel`). Closures are `@Sendable` fire-and-forget; `.live` hops to the `@MainActor` telemetry homes, so callers in any isolation (A6's `Task.detached`, the off-MainActor Keychain cleanup) never block the heart path. A8/Q3.1 emit directly (their `@MainActor` homes already import Services). `WisprBootstrapper` line ceiling 890→905 (Bible note; real composition-root wiring, no new stored property).

### Validation
- Local Codex code-diff review clean. Council coverage was unavailable (gcloud business auth expired overnight, founder asleep — could not interactively re-auth); the Codex grounded review on the plan returned PROCEED-WITH-REVISIONS and all 5 mechanical revisions were applied.
- 2095 logic tests green via `scripts/xcode-test.sh` (the line-ceiling bump is the only test-value change). New Phase 8 tests: `limb.failure_observed` payload incl. numeric duration; `LLMTelemetrySink` `.noop` silent + spy captures; `evictModel` unloaded/failed/skipped; KeychainManager retrieve-migration cleanup-failure fires the sink (fail-soft, still returns the value).
- Live UAT on the dev build: launches clean (the Q3.1 classifier prewarm + `.live` injection run at launch without crash), and a full dictation completes end-to-end through the modified ASR-finalize and polish paths — `Pipeline timing TOTAL: 1.673s`, transcription exact, no telemetry errors in app.log.