### PR TITLE
feat(telemetry): VAD-prepare failure visibility in the audio service (Telemetry Bible Phase 8b, A4, #1177)

### DIFF
--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -1,6 +1,7 @@
 @preconcurrency import AVFoundation
 import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprObservabilityCore
 import Foundation
 
 /// XPC service handler — composes an AudioCaptureManager and bridges its lifecycle
@@ -364,6 +365,15 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
       do {
         try await detector.prepare()
       } catch {
+        // #1177 (Telemetry Bible Phase 8b, A4): the VAD model failed to load, so
+        // silence auto-stop is silently disabled for this recording (the user must
+        // stop manually). Previously a bare `return` with not even a log. Report it
+        // as an in-process handled error (this runs in the audio XPC service, which
+        // has its own Sentry but cannot reach the host's PostHog / SentryBreadcrumb).
+        // Content-free (error type name only); fail-open continues — the heart path
+        // (capture) is unaffected, only the auto-stop limb is lost.
+        HelperObservability.captureHandledError(
+          category: "vad#prepare_failed", detail: String(reflecting: type(of: error)))
         return
       }
 

--- a/Sources/EnviousWisprObservabilityCore/HelperObservability.swift
+++ b/Sources/EnviousWisprObservabilityCore/HelperObservability.swift
@@ -141,4 +141,39 @@ public enum HelperObservability {
       scope.setTag(value: config.bundleId, key: "xpc.service_bundle_id")
     }
   }
+
+  /// #1177 (Telemetry Bible Phase 8b): capture a HANDLED error from a helper process.
+  /// The host's `SentryBreadcrumb.captureError` lives in `EnviousWisprServices`, which
+  /// the XPC helpers do NOT import — so a helper-process limb failure (the audio
+  /// service's VAD `prepare()`, today a silent bare `return`) reports through this
+  /// in-process Sentry path instead, under the same `process.role=audio_xpc` scope as
+  /// helper crashes. There is no PostHog in a helper process, so this is Sentry-only.
+  ///
+  /// Content-free: `category` is a stable `"<domain>#<detail>"` descriptor and `detail`
+  /// is an error-type name — never user content. The event still passes through the
+  /// started SDK's `beforeSend` sanitizer (`SentryEventSanitizer`) like every other
+  /// event. A LIMB: if the SDK never started (missing/empty DSN, the common dev case),
+  /// `SentrySDK.capture` is a no-op, so this never throws and never blocks the heart
+  /// path (audio capture). `fingerprint` groups all occurrences of one category into a
+  /// single issue (rare + grouped → no alert fatigue), kept apart from native crashes
+  /// by the `helper_handled_error` namespace.
+  public static func captureHandledError(category: String, detail: String = "") {
+    SentrySDK.capture(event: makeHandledErrorEvent(category: category, detail: detail))
+  }
+
+  /// The PURE event builder for `captureHandledError` — the asserted surface the unit
+  /// tests check WITHOUT a live SDK (mirrors the `makeConfig` / `apply` testability
+  /// pattern). `.error` level for parity with the host's `SentryBreadcrumb.captureError`;
+  /// fingerprint groups one category into one issue; `detail` is attached as extra only
+  /// when present. Never carries user content — callers pass error-type names / stable
+  /// descriptors, and the started SDK's `beforeSend` sanitizer is the final backstop.
+  public static func makeHandledErrorEvent(category: String, detail: String = "") -> Event {
+    let event = Event(level: .error)
+    event.message = SentryMessage(formatted: category)
+    event.fingerprint = ["helper_handled_error", category]
+    if !detail.isEmpty {
+      event.extra = ["detail": detail]
+    }
+    return event
+  }
 }

--- a/Tests/EnviousWisprTests/Services/HelperObservabilityConfigTests.swift
+++ b/Tests/EnviousWisprTests/Services/HelperObservabilityConfigTests.swift
@@ -133,4 +133,26 @@ struct HelperObservabilityConfigTests {
     var startCalled = false
     var scopeCalled = false
   }
+
+  // MARK: - captureHandledError (#1177 Phase 8b)
+
+  @Test("handled-error event groups by category and carries only the content-free detail")
+  func handledErrorEventShape() {
+    let event = HelperObservability.makeHandledErrorEvent(
+      category: "vad#prepare_failed", detail: "FluidAudio.VadError")
+    #expect(event.message?.formatted == "vad#prepare_failed")
+    #expect(event.fingerprint == ["helper_handled_error", "vad#prepare_failed"])
+    #expect((event.extra?["detail"] as? String) == "FluidAudio.VadError")
+    // The audio service feeds an error TYPE name, never a transcript — assert the
+    // transcript sentinel can never appear via this path.
+    let serialized = "\(String(describing: event.message)) \(String(describing: event.extra))"
+    #expect(!serialized.contains(Self.marker))
+  }
+
+  @Test("handled-error event omits empty detail")
+  func handledErrorEventOmitsEmptyDetail() {
+    let event = HelperObservability.makeHandledErrorEvent(category: "vad#prepare_failed")
+    #expect(event.extra?["detail"] == nil)
+    #expect(event.fingerprint == ["helper_handled_error", "vad#prepare_failed"])
+  }
 }


### PR DESCRIPTION
## Telemetry Bible Phase 8b (#1177): VAD-prepare failure in the audio service (A4)

Closes #1177 (the final quiet-limb gap; 8a shipped the five in-host limbs in PR #1211).

When the silence detector's model fails to load (`AudioServiceHandler.startVADMonitoring`), silence auto-stop is silently disabled for that recording — the user has to stop manually — and it was a bare `return` with not even a log. This is the only cross-process gap: audio capture runs in a separate XPC service.

### Why a separate path from 8a
The audio service has its OWN in-process Sentry (`HelperObservability.start`, for native crashes) but cannot reach the host's PostHog or `SentryBreadcrumb` — those live in `EnviousWisprServices`, which the helpers don't import. So A4 reports through a new `HelperObservability.captureHandledError`: an in-process Sentry handled error under the same `process.role=audio_xpc` scope, Sentry-only (no PostHog in a helper). It's content-free (the error type name only), passes through the started SDK's `beforeSend` sanitizer like every other event, and is a LIMB — if the SDK never started (no DSN, the common dev case) `SentrySDK.capture` no-ops, so it never throws and never blocks audio capture. The fingerprint groups all VAD-prepare failures into one issue (rare + grouped → no alert fatigue). Fail-open is unchanged: the catch still returns.

This is the design Codex grounded review confirmed for the #1177 plan (a local helper beats a new host XPC callback; the existing engine-interruption XPC path is a different signal).

### Validation
- Local Codex code-diff review clean. Design pre-confirmed by the #1177 plan's Codex grounded review.
- Full logic suite green (`scripts/xcode-test.sh`, 2097 tests). New tests on the pure SDK-free event builder: groups by category, attaches only the content-free detail, omits empty detail, and proves the transcript sentinel can never appear via this path.
- Live UAT on the dev build (compounded — includes Phases 7 + 8a): the audio XPC service starts and a full dictation with VAD auto-stop completes cleanly, confirming the VAD success path is intact after the catch edit (the failure path is unit-tested; forcing a real VAD-model load failure is not reliably reproducible).

With this, #1177 is complete: every quiet-limb failure in the program's scope (A4, A5, A6, A8, Q3.1, Q3.3) is now observable.