### PR TITLE
feat(telemetry): update download/verify stage split + version staleness (Telemetry Bible Phase 9, #1178)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
@@ -310,6 +310,43 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
     }
   }
 
+  // MARK: - Update stage split (#1178 Phase 9, B2)
+
+  /// Download/verify(extract) stage breadcrumbs. These 4 `SPUUpdaterDelegate` hooks are
+  /// optional (Sparkle calls them via `respondsToSelector`), so adding them is purely
+  /// additive — no control-flow change. `item.versionString` is the CFBundleVersion
+  /// compare key (Codex r2: NOT `displayVersionString`, which is UI text). Observation
+  /// only; never blocks Sparkle.
+  func updater(
+    _ updater: SPUUpdater, willDownloadUpdate item: SUAppcastItem, with request: NSMutableURLRequest
+  ) {
+    TelemetryService.shared.updateDownloadStarted(
+      version: item.versionString, isCritical: item.isCriticalUpdate)
+  }
+  func updater(_ updater: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {
+    TelemetryService.shared.updateDownloadCompleted(
+      version: item.versionString, isCritical: item.isCriticalUpdate)
+  }
+  func updater(_ updater: SPUUpdater, willExtractUpdate item: SUAppcastItem) {
+    TelemetryService.shared.updateVerifyStarted(
+      version: item.versionString, isCritical: item.isCriticalUpdate)
+  }
+  func updater(_ updater: SPUUpdater, didExtractUpdate item: SUAppcastItem) {
+    TelemetryService.shared.updateVerifyCompleted(
+      version: item.versionString, isCritical: item.isCriticalUpdate)
+  }
+
+  /// Resolve the version-staleness bucket from plain fields (Codex r4: unit-testable
+  /// without constructing `SUAppcastItem`/`SPUUpdater`, whose inits are unavailable).
+  /// The latest is the pending `.available` version, else the latest item Sparkle
+  /// attached to a no-update error; neither known → `on_latest` by policy (Codex r1).
+  static func resolveStalenessBucket(
+    current: String, availableVersion: String?, latestFromErrorVersion: String?
+  ) -> String {
+    guard let latest = availableVersion ?? latestFromErrorVersion else { return "on_latest" }
+    return VersionStaleness.bucket(current: current, latest: latest)
+  }
+
   /// Issue #343: terminal "the cycle ended" hook. Fires diagnostic event,
   /// resolves service state, clears install-source.
   func updater(
@@ -340,6 +377,17 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
     let noUpdateReason = Self.noUpdateReason(from: error as NSError?)
     let checkKind = Self.checkKindString(updateCheck)
     let currentAppVersion = bundleVersionProvider()
+    // #1178 (Phase 9, B3): how stale is this user? The latest version is whatever
+    // Sparkle just resolved live — the pending `.available` update, else the latest
+    // item Sparkle attaches to a no-update error (`SPULatestAppcastItemFoundKey`).
+    // `pendingVersion == nil` is NOT proof of on-latest (Codex r1), so we check the
+    // error too; nil-both → on_latest by policy. No cache, no cross-session persistence.
+    let latestFromError =
+      ((error as NSError?)?.userInfo[SPULatestAppcastItemFoundKey] as? SUAppcastItem)?
+      .versionString
+    let stalenessBucket = Self.resolveStalenessBucket(
+      current: currentAppVersion, availableVersion: pendingVersion,
+      latestFromErrorVersion: latestFromError)
     TelemetryService.shared.updateSparkleCycleFinished(
       version: version,
       isCritical: isCritical,
@@ -347,7 +395,8 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
       errorCode: errorCode,
       noUpdateReason: noUpdateReason,
       checkKind: checkKind,
-      currentAppVersion: currentAppVersion
+      currentAppVersion: currentAppVersion,
+      versionStalenessBucket: stalenessBucket
     )
     // Issue #846: filter Sparkle's three benign terminal outcomes from
     // update.install_failed. Sparkle itself excludes them from its own logging

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1307,7 +1307,8 @@ public final class TelemetryService {
     errorCode: String?,
     noUpdateReason: String?,
     checkKind: String,
-    currentAppVersion: String
+    currentAppVersion: String,
+    versionStalenessBucket: String  // #1178 (Phase 9, B3): on_latest/patch/minor/major_behind.
   ) {
     #if DEBUG
       var hookStringProps: [String: String] = [
@@ -1315,6 +1316,7 @@ public final class TelemetryService {
         "source": source,
         "check_kind": checkKind,
         "current_app_version": currentAppVersion,
+        "version_staleness_bucket": versionStalenessBucket,
       ]
       if let errorCode { hookStringProps["error_code"] = errorCode }
       if let noUpdateReason { hookStringProps["no_update_reason"] = noUpdateReason }
@@ -1331,10 +1333,39 @@ public final class TelemetryService {
       "source": source,
       "check_kind": checkKind,
       "current_app_version": currentAppVersion,
+      "version_staleness_bucket": versionStalenessBucket,
     ]
     if let errorCode { props["error_code"] = errorCode }
     if let noUpdateReason { props["no_update_reason"] = noUpdateReason }
     PostHogSDK.shared.capture("update.sparkle_cycle_finished", properties: props)
+  }
+
+  // MARK: - Update stage split (#1178 Phase 9, B2)
+
+  /// The download/verify(extract) stage breadcrumbs — finer than the cycle result, so we
+  /// can see WHERE an update stalls (download_started without download_completed = stuck
+  /// at download). Plain-field params (Codex r4) so the Sparkle delegate stays a thin
+  /// extractor and these are unit-testable via `testEventHook`. Metadata only.
+  public func updateDownloadStarted(version: String, isCritical: Bool) {
+    emitUpdateStage("update.download_started", version: version, isCritical: isCritical)
+  }
+  public func updateDownloadCompleted(version: String, isCritical: Bool) {
+    emitUpdateStage("update.download_completed", version: version, isCritical: isCritical)
+  }
+  public func updateVerifyStarted(version: String, isCritical: Bool) {
+    emitUpdateStage("update.verify_started", version: version, isCritical: isCritical)
+  }
+  public func updateVerifyCompleted(version: String, isCritical: Bool) {
+    emitUpdateStage("update.verify_completed", version: version, isCritical: isCritical)
+  }
+
+  private func emitUpdateStage(_ name: String, version: String, isCritical: Bool) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: name, stringProps: ["version": version], boolProps: ["is_critical": isCritical]))
+    #endif
+    PostHogSDK.shared.capture(name, properties: ["version": version, "is_critical": isCritical])
   }
 
   public func updateInstallCompleted(version: String, isCritical: Bool, source: String) {

--- a/Sources/EnviousWisprServices/VersionStaleness.swift
+++ b/Sources/EnviousWisprServices/VersionStaleness.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// #1178 (Telemetry Bible Phase 9, B3): buckets how far a user's installed version is
+/// behind the latest available release, for the `version_staleness_bucket` property on
+/// `update.sparkle_cycle_finished`.
+///
+/// An EXACT "releases behind" count is NOT derivable — the appcast lists only the latest
+/// item, not the intermediate versions — so this projects the delta to a low-cardinality,
+/// semver-meaningful bucket. It OWNS the parse/compare (Codex grounded review r3: do not
+/// spawn a second comparator unrelated to `UpdateAvailabilityService.compareVersions`;
+/// this is the pure, self-contained version, mirroring that comparator's split-by-dot int
+/// parse — non-integer components count as 0). Pure + content-free.
+public enum VersionStaleness {
+  /// `on_latest` when `current >= latest` (including a dev/beta build AHEAD of the feed —
+  /// never reports "behind" for an ahead build). Otherwise the highest-order component
+  /// that differs: `major_behind` / `minor_behind` / `patch_behind`.
+  public static func bucket(current: String, latest: String) -> String {
+    let c = parse(current)
+    let l = parse(latest)
+    if compare(c, l) >= 0 { return "on_latest" }
+    if l.major > c.major { return "major_behind" }
+    if l.minor > c.minor { return "minor_behind" }
+    return "patch_behind"
+  }
+
+  /// Split-by-dot integer parse (production tags are `^\d+\.\d+\.\d+$` per release.yml).
+  /// Malformed / pre-release / non-integer components parse to 0 (e.g. `"2.1.4-beta"` →
+  /// `(2, 1, 0)`, `"abc"` → `(0, 0, 0)` → buckets as the worst case, `major_behind`).
+  private static func parse(_ v: String) -> (major: Int, minor: Int, patch: Int) {
+    let parts = v.split(separator: ".").map { Int($0) ?? 0 }
+    return (
+      parts.count > 0 ? parts[0] : 0,
+      parts.count > 1 ? parts[1] : 0,
+      parts.count > 2 ? parts[2] : 0
+    )
+  }
+
+  private static func compare(
+    _ a: (major: Int, minor: Int, patch: Int), _ b: (major: Int, minor: Int, patch: Int)
+  ) -> Int {
+    if a.major != b.major { return a.major < b.major ? -1 : 1 }
+    if a.minor != b.minor { return a.minor < b.minor ? -1 : 1 }
+    if a.patch != b.patch { return a.patch < b.patch ? -1 : 1 }
+    return 0
+  }
+}

--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -181,7 +181,8 @@ struct SparkleUpdateControllerTests {
         errorCode: nil,
         noUpdateReason: nil,
         checkKind: "background",
-        currentAppVersion: "v-host"
+        currentAppVersion: "v-host",
+        versionStalenessBucket: "on_latest"
       )
       TelemetryService.shared.updateInstallCompleted(
         version: "v1", isCritical: false, source: "menu")
@@ -390,7 +391,8 @@ struct SparkleUpdateControllerTests {
         errorCode: "SUSparkleErrorDomain.1001",
         noUpdateReason: "on_latest_version",
         checkKind: "background",
-        currentAppVersion: "v2.0.4"
+        currentAppVersion: "v2.0.4",
+        versionStalenessBucket: "on_latest"
       )
 
       await Task.yield()
@@ -420,7 +422,8 @@ struct SparkleUpdateControllerTests {
         errorCode: nil,
         noUpdateReason: nil,
         checkKind: "user_initiated",
-        currentAppVersion: "v2.0.4"
+        currentAppVersion: "v2.0.4",
+        versionStalenessBucket: "on_latest"
       )
 
       await Task.yield()
@@ -470,6 +473,75 @@ struct SparkleUpdateControllerTests {
       #expect(evt?.stringProps["check_kind"] == "user_initiated")
       #expect(evt?.stringProps["current_app_version"] == "v2.0.4")
       #expect(evt?.stringProps["no_update_reason"] == "on_latest_version")
+    }
+
+    // MARK: - #1178 Phase 9 (B2 stage split + B3 staleness)
+
+    @Test("resolveStalenessBucket prefers .available, falls back to the error item, else on_latest")
+    func resolveStalenessBucketSources() {
+      // .available wins
+      #expect(
+        SparkleUpdateController.resolveStalenessBucket(
+          current: "2.0.0", availableVersion: "2.1.0", latestFromErrorVersion: "9.9.9")
+          == "minor_behind")
+      // no .available → fall back to the latest item Sparkle attached to a no-update error
+      #expect(
+        SparkleUpdateController.resolveStalenessBucket(
+          current: "1.0.0", availableVersion: nil, latestFromErrorVersion: "2.0.0")
+          == "major_behind")
+      // neither known → on_latest by policy (the common clean no-update cycle)
+      #expect(
+        SparkleUpdateController.resolveStalenessBucket(
+          current: "2.1.4", availableVersion: nil, latestFromErrorVersion: nil) == "on_latest")
+    }
+
+    @Test("the 4 download/verify stage events fire with version + is_critical")
+    func stageEventsFire() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      TelemetryService.shared.updateDownloadStarted(version: "2.1.4", isCritical: true)
+      TelemetryService.shared.updateDownloadCompleted(version: "2.1.4", isCritical: true)
+      TelemetryService.shared.updateVerifyStarted(version: "2.1.4", isCritical: false)
+      TelemetryService.shared.updateVerifyCompleted(version: "2.1.4", isCritical: false)
+
+      await Task.yield()
+      await Task.yield()
+
+      let names = Set(box.events.map { $0.name })
+      #expect(
+        names.isSuperset(of: [
+          "update.download_started", "update.download_completed",
+          "update.verify_started", "update.verify_completed",
+        ]))
+      let dl = box.events.first { $0.name == "update.download_started" }
+      #expect(dl?.stringProps["version"] == "2.1.4")
+      #expect(dl?.boolProps["is_critical"] == true)
+    }
+
+    @Test("the cycle event carries version_staleness_bucket")
+    func cycleCarriesStalenessBucket() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      TelemetryService.shared.updateSparkleCycleFinished(
+        version: "2.1.4", isCritical: false, source: "background", errorCode: nil,
+        noUpdateReason: nil, checkKind: "background", currentAppVersion: "2.0.0",
+        versionStalenessBucket: "minor_behind")
+
+      await Task.yield()
+      await Task.yield()
+
+      let evt = box.events.first { $0.name == "update.sparkle_cycle_finished" }
+      #expect(evt?.stringProps["version_staleness_bucket"] == "minor_behind")
     }
 
   #endif  // DEBUG

--- a/Tests/EnviousWisprTests/Services/VersionStalenessTests.swift
+++ b/Tests/EnviousWisprTests/Services/VersionStalenessTests.swift
@@ -1,0 +1,65 @@
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1178 (Telemetry Bible Phase 9, B3): the version-staleness bucket. Boundary cases
+/// per the Codex grounded review (equal, ahead, each delta order, malformed, pre-release,
+/// differing component counts, numeric compare).
+@Suite("VersionStaleness bucket")
+struct VersionStalenessTests {
+
+  @Test("equal versions report on_latest")
+  func equalIsOnLatest() {
+    #expect(VersionStaleness.bucket(current: "2.1.4", latest: "2.1.4") == "on_latest")
+  }
+
+  @Test("a build AHEAD of the feed reports on_latest, never behind")
+  func aheadIsOnLatest() {
+    // dev/beta ahead of the public feed — must never report "behind"
+    #expect(VersionStaleness.bucket(current: "2.2.0", latest: "2.1.4") == "on_latest")
+    #expect(VersionStaleness.bucket(current: "3.0.0", latest: "2.9.9") == "on_latest")
+  }
+
+  @Test("a patch behind reports patch_behind")
+  func patchBehind() {
+    #expect(VersionStaleness.bucket(current: "2.1.3", latest: "2.1.4") == "patch_behind")
+    #expect(VersionStaleness.bucket(current: "2.1.0", latest: "2.1.9") == "patch_behind")
+  }
+
+  @Test("a minor behind reports minor_behind")
+  func minorBehind() {
+    #expect(VersionStaleness.bucket(current: "2.0.9", latest: "2.1.0") == "minor_behind")
+    #expect(VersionStaleness.bucket(current: "2.0.0", latest: "2.4.1") == "minor_behind")
+  }
+
+  @Test("a major behind reports major_behind")
+  func majorBehind() {
+    #expect(VersionStaleness.bucket(current: "1.9.9", latest: "2.0.0") == "major_behind")
+    #expect(VersionStaleness.bucket(current: "1.0.0", latest: "3.2.1") == "major_behind")
+  }
+
+  @Test("numeric (not lexical) component compare: 2.4.10 is newer than 2.4.9")
+  func numericComponentCompare() {
+    #expect(VersionStaleness.bucket(current: "2.4.9", latest: "2.4.10") == "patch_behind")
+    #expect(VersionStaleness.bucket(current: "2.4.10", latest: "2.4.9") == "on_latest")
+  }
+
+  @Test("differing component counts: 2.1 vs 2.1.4")
+  func differingComponentCounts() {
+    // 2.1 parses as (2,1,0) → one patch behind 2.1.4
+    #expect(VersionStaleness.bucket(current: "2.1", latest: "2.1.4") == "patch_behind")
+    #expect(VersionStaleness.bucket(current: "2.1.4", latest: "2.1") == "on_latest")
+  }
+
+  @Test("malformed / non-semver current parses to zeros (worst case, major_behind)")
+  func malformedCurrent() {
+    #expect(VersionStaleness.bucket(current: "abc", latest: "2.1.4") == "major_behind")
+    #expect(VersionStaleness.bucket(current: "", latest: "2.1.4") == "major_behind")
+  }
+
+  @Test("pre-release suffix on a component parses that component to zero")
+  func preReleaseSuffix() {
+    // "2.1.4-beta" → (2,1,0) (the "4-beta" component is non-integer → 0) → vs 2.1.4 = patch_behind.
+    #expect(VersionStaleness.bucket(current: "2.1.4-beta", latest: "2.1.4") == "patch_behind")
+  }
+}


### PR DESCRIPTION
## Telemetry Bible Phase 9 (#1178): update download/verify stage split + version staleness

Closes #1178. The small remainder of the update-telemetry surface (already rich: install_started/completed/failed/cancelled, sparkle_cycle_finished). Observation-only — every new method is a pure emit at the start/end of an existing Sparkle delegate callback, no control-flow change, never blocks the install flow.

### B2 — download/verify stage split
4 optional `SPUUpdaterDelegate` hooks (`willDownloadUpdate`/`didDownloadUpdate`/`willExtractUpdate`/`didExtractUpdate`) → `update.download_started`/`_completed` + `update.verify_started`/`_completed` {version, is_critical}. Sparkle calls these via `respondsToSelector`, so adding them is purely additive. So we can see WHERE an update stalls (a `download_started` with no `download_completed` = stuck at download). Uses `item.versionString` (the CFBundleVersion compare key), not `displayVersionString` (UI text) — Codex r2.

### B3 — version staleness
`version_staleness_bucket` {`on_latest` / `patch_behind` / `minor_behind` / `major_behind`} folded into `update.sparkle_cycle_finished` (which already carries `current_app_version`). The latest version is resolved LIVE — the pending `.available` version, else the latest item Sparkle attaches to a no-update error (`SPULatestAppcastItemFoundKey`), else `on_latest` by policy (Codex r1: `pendingVersion == nil` is NOT proof of on-latest). **No cache, no cross-session persistence** (`instrumentation-stays-observation-only`). An exact "releases behind" count isn't derivable (the appcast lists only the latest item), hence a low-cardinality bucket.

`VersionStaleness` (Services, pure) owns the parse/compare/bucket — the same split-by-dot int parse as `UpdateAvailabilityService.compareVersions`, no second unrelated comparator (Codex r3). `resolveStalenessBucket` (App, plain fields) is the testable seam since `SPUUpdater`/`SUAppcastItem` inits are unavailable (Codex r4).

### Validation
- Council unavailable (gcloud business auth expired overnight). Codex grounded review → PROCEED-WITH-REVISIONS, all 4 revisions applied; local Codex code-diff review clean.
- Full debug logic suite green incl. new tests: `VersionStaleness` boundaries (equal, ahead→on_latest, each delta order, malformed/non-semver→major_behind, pre-release, `2.1` vs `2.1.4`, numeric `2.4.10 > 2.4.9`); the 4 stage events via `testEventHook`; `resolveStalenessBucket` sources; the cycle carrying the bucket. `--release` lane also run locally (the new `testEventHook` tests are `#if DEBUG`-gated; `VersionStaleness` tests aren't, and run in both lanes).
- **No Live UAT possible** — dev builds blank `SUFeedURL`, so the update flow can't run in dev; the issue routes validation to the Sparkle `testEventHook` harness.

With this, the Telemetry Bible's event-creating phases (4-9) are all merged. Phase 10 (alerts, #1179) is deferred by its own design until these ship in a release and accumulate real data for threshold calibration.