### PR TITLE
feat(telemetry): TIK create-path dev gate + synthetic test tag (#1218)

### DIFF
--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -102,6 +102,18 @@ public enum ObservabilityBootstrap {
     // Set stable tags that rarely change — available on every event including fatal crashes
     SentrySDK.configureScope { scope in
       scope.setTag(value: environment == "development" ? "debug" : "release", key: "app.build_type")
+      // Mark deliberate fault-injection launches so the Sentry-triage routine can
+      // exclude crash-tests deterministically (#1218) instead of by a prose note.
+      // Forward-only: absence means "not known-synthetic", never "known-real".
+      // HOST-SCOPE BY DESIGN: the audio/ASR XPC helpers are launchd `serviceName`
+      // services (`AudioCaptureProxy` NSXPCConnection) that do NOT inherit this env
+      // var, and the fault kinds (force_xpc_kill / force_cancel / buffer-drop) are
+      // host-initiated and captured host-side via `onXPCServiceError` — so helper
+      // events are never fault-injection signals to tag. A genuine helper crash stays
+      // untagged and visible (the gate's create-dev-fatal branch), which is correct.
+      if ProcessInfo.processInfo.environment["EW_FAULT_INJECTION"] == "1" {
+        scope.setTag(value: "true", key: "synthetic")
+      }
     }
   }
 

--- a/workers/sentry-triage/routine-prompt-tik-sentry.md
+++ b/workers/sentry-triage/routine-prompt-tik-sentry.md
@@ -104,7 +104,7 @@ Read this once before the detail sections below. The detail sections are the law
     1b. For EACH shortId in `CLOSED_RECENT` not already in 1a's results, a per-shortId Sentry query (regression watch — covers cold issues that won't appear in the top 50).
     Filter 1a by `lastSeen` within 25h. 1b is unconditional (no time filter).
 2. For each Sentry issue, search GitHub by `sentry-issue-id {shortId}`. Route:
-    - No GitHub issue and no cross-reference hit (Step 2.6) → **Path A** create.
+    - No GitHub issue and no cross-reference hit (Step 2.6) → **Path A**, which now runs the **Step 6.5 create-path eligibility gate** before creating (dev-only self-healed → digest, deliberate fault-injection → suppress, real signal / untagged dev fatal / unclassifiable → create).
     - Open GitHub issue → **Path B** update if throttle allows.
     - Closed GitHub issue → **Path C** reopen + regression comment.
     - Ambiguous (multiple distinct GitHub issues for one shortId) → log + skip; never create.
@@ -133,6 +133,7 @@ If the step DOES document a per-step recovery, follow that recovery and continue
 - **MCP auth-expiry policy** (any GitHub MCP returns "authoriz" / "token expired" / "re-authorization"): trigger the hard policy below — STOP all further GitHub interaction (read AND write) and exit cleanly. The auth-expiry policy is BROADER than other per-step recoveries: it terminates the run.
 - **Path A Step 1 Sentry event-fetch failure**: skip that one Sentry issue, continue to the next.
 - **Path A Step 4 git-tag miss**: fall back to HEAD with a noted caveat in the issue body.
+- **Path A Step 6.5 events-list fetch failure** (any page non-200/non-JSON) **or helper non-zero/unparseable output**: these are NOT errors — fail OPEN (`family=create`) and proceed to Step 7 create. An unclassifiable new fingerprint must stay visible; never silent-suppress. (Mirrors the Step 2.6.5 fail-open invariant.)
 - **Path A Step 7 issue-create failure**: log + skip that one Sentry issue, continue to the next.
 - **Path A Step 8 sub-issue link failure** (including the 422 "already exists" case): log and continue. Same rule for Path C step 3 sub-issue link.
 - **Path C step 1 Sentry event-fetch failure**: fall through with `event = null`, do NOT skip the reopen, use the fail-soft regression-comment template (5b). Same rule when `git show {tag}:{filename}` fails or the tag is missing in step 4.
@@ -156,9 +157,22 @@ This protects against duplicate-issue creation when MCP search returns false-emp
 Maintain an in-memory set `WRITTEN_THIS_RUN` keyed by Sentry `shortId`. The check is performed at **branch entry**, not on every individual write within a multi-step branch:
 
 - **Branch entry** (= the moment Step 2 routing decides Path A vs Path B vs Path C for a Sentry shortId): check `WRITTEN_THIS_RUN` for the key. If present, skip the entire branch silently. Do NOT re-execute any of its steps.
-- **Within a branch** (Path A's 8 steps, Path C's 6 steps): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — at the END of the write sequence (Path A: end of step 8 after sub-link; Path B: end of comment write; Path C: end of step 6 after label add).
+- **Within a branch** (Path A's 8 steps, Path C's 6 steps): the branch-entry rule does NOT block subsequent writes in the same branch invocation. Each branch states explicitly when its key is added — at the END of the write sequence (Path A: end of step 8 after sub-link, OR — when the Step 6.5 gate routes to `digest`/`suppress` — at that short-circuit, which adds the key and SKIPS steps 7–8; Path B: end of comment write; Path C: end of step 6 after label add).
 
 This protects against duplicate writes if logic branches re-evaluate the same issue twice in one run, AND against multi-step branches self-blocking after the first write.
+
+## Dev-only digest (end of run)
+
+Maintain an in-memory `DEV_DIGEST` list. The Step 6.5 create-path gate appends one line to it for every fingerprint it routes to `digest-dev-only` (all-dev, handled, self-healed — the #1192–#1215 class that should NOT become a ticket but stays visible at a glance).
+
+At the **END of the run**, if `DEV_DIGEST` is non-empty, log it as ONE block:
+```
+Step 6.5 dev-only digest (not ticketed):
+  {line}
+  {line}
+  ...
+```
+This is the founder's daily canary: dev-only self-healed fingerprints that did not earn a ticket but are worth a glance (e.g. an organic dev bug hiding among rebuild churn would show up as a repeated digest line across runs). If `DEV_DIGEST` is empty, log nothing — no ticket, no noise.
 
 ## Tool usage
 
@@ -478,6 +492,27 @@ Where start = max(1, lineNo-10) and end = lineNo+10. If the tag doesn't exist, u
 For Path A (new issue) and Path B (open issue), `userCount`/`count` are the Sentry issue aggregate. **For Path C reopens (and ambiguous fail-opens), use the eligibility gate's `eligible_user_count` / `eligible_count` (post-close, production, fix-containing partition) in place of `userCount`/`count` — NEVER the lifetime aggregate.** Scoring a reopen off the lifetime aggregate is exactly the #979 false-P0 (11 lifetime users, all pre-fix → P0). When the verdict is `ambiguous` (counts are 0 because nothing is provably eligible), default the reopen to the LOWEST tier consistent with a visible-triage signal (P3) unless the latest event is `level=fatal`.
 
 **6. Hypothesis fail-soft:** Write the Hypothesis section ONLY if you can name a specific function AND a plausible precondition failure from the stack + source you read. If the evidence is insufficient, write `> Hypothesis pending — stack trace insufficient. Investigation needed.` Do NOT fabricate confident-sounding prose on weak evidence.
+
+**6.5. Create-path eligibility gate (run BEFORE Step 7 create).** A brand-new fingerprint is NOT automatically a ticket. Dev-only, self-healed, single-event errors from the founder's dogfood/test machine (the #1192–#1215 class) must NOT become tracked issues. This gate decides **create vs digest vs suppress**, reusing the SAME `is_development` authority as the reopen gate (Step 2.6.5) — it does NOT add a second dev classifier. Step 3's release-string heuristic stays for label/tag derivation only.
+
+**A. Fetch the events LIST** (Step 1 fetched only `/events/latest/` — ONE event; partitioning a multi-event fingerprint needs the list):
+```bash
+curl -sD - -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+  "https://us.sentry.io/api/0/organizations/envious-labs-llc/issues/{id}/events/?full=true&statsPeriod=90d&per_page=100"
+```
+**PAGINATE** exactly as Step 2.6.5 does: follow the `Link:` response header while it contains `rel="next"; results="true"; cursor="<c>"`, refetch with `&cursor=<c>`, accumulate; cap at 10 pages (1000 events) as a runaway guard. **If the cap is hit with `results="true"` still pending, set `events_truncated=true` in the helper input** — a partial list must NEVER yield a `digest`/`suppress` (page 11 could hold a production or fatal event the gate never saw); the helper downgrades any non-`create` verdict to `create` when `events_truncated=true`. Per event extract: `environment`, `app.build_type`, `release`, the `synthetic` tag, AND `level` — all from the `tags[]` array (`{key,value}` pairs, NOT top-level; `level` may also appear top-level on the event — either source is fine). **`synthetic`** is present ONLY on deliberate fault-injection launches (value `"true"`); its absence means "not known-synthetic", never "known-real". **`level` fallback:** pass the issue/latest-event `level` that Step 5 reads as `issue_level`. The helper applies it as a per-event fallback ONLY for a single-event fingerprint (latest == the only event); in a MULTI-event list a missing per-event `level` is unclassifiable and fails open to `create`, so include each event's own `level` whenever the events API returns it. For a single-event fingerprint, latest == the only event. **If ANY page fetch fails (non-200/non-JSON): fail OPEN — skip the gate and proceed to Step 7 create** (an unclassifiable fingerprint must stay visible; never silent-suppress).
+
+**B. Run the deterministic helper** (`--create` routes to `decide_create`; the verdict math is unit-tested in `test_tik_eligibility.py`, NOT prose):
+```bash
+echo '{"events":[{"environment":"<env>","build_type":"<bt>","release":"<rel>","level":"<lvl>","synthetic":"true"}, ...],"issue_level":"<level Step 5 reads>","events_truncated":<bool>}' \
+  | python3 workers/sentry-triage/tik_eligibility.py --create
+```
+Returns `{verdict, family, reason, dev_count, event_count}`. `family` is one of `create` / `digest` / `suppress`. **`events_truncated` is REQUIRED** — set it `true` only when step A hit the page cap with more pages pending, else `false`. The helper treats a MISSING flag as not-proven-complete and **fails open to `create`** (it cannot confirm a `digest`/`suppress` is safe without it), so always pass it explicitly. A non-zero exit or unparseable output → treat as `family=create` (fail open).
+
+**Branch on `family`:**
+- **`create`** (verdicts `create` / `create-dev-fatal`, incl. fail-open) — a real production event, an untagged dev fatal (a real dev crash is canary-worthy), or unclassifiable input. **Proceed to Step 7** create exactly as today.
+- **`digest`** (verdict `digest-dev-only`) — all-dev, handled, self-healed; no customer signal. Do NOT create. Append ONE line to the in-memory `DEV_DIGEST` list: `{shortId} | {crash-site file or culprit/metadata.type, whatever is bound} | {release} | dev-only, self-healed, {event_count} event(s)`. Add `shortId` to `WRITTEN_THIS_RUN`. SKIP Steps 7–8.
+- **`suppress`** (verdict `suppress-synthetic`) — every event tagged `synthetic=true` (deliberate fault-injection crash-test). Do NOT create. Log one line: `Step 6.5 suppress: {shortId} synthetic fault-injection, not ticketed.` Add `shortId` to `WRITTEN_THIS_RUN`. SKIP Steps 7–8.
 
 **7. Create GitHub issue** via `mcp__github__issue_write`. Do NOT add `shortId` to `WRITTEN_THIS_RUN` here — the add happens at end of step 8 so the sub-issue link in step 8 isn't blocked by the global rule.
 

--- a/workers/sentry-triage/test_tik_eligibility.py
+++ b/workers/sentry-triage/test_tik_eligibility.py
@@ -17,7 +17,9 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from tik_eligibility import decide, normalize_version, is_development, main  # noqa: E402
+from tik_eligibility import (  # noqa: E402
+    decide, decide_create, normalize_version, is_development, main,
+)
 
 CLOSED = "2026-06-17T06:00:00Z"
 
@@ -349,6 +351,243 @@ def test_null_user_ids_do_not_underscore_severity():
                   "fix_released_version": "v2.1.5", "fix_merged": True, "latest_release": "v2.1.5"})
     assert out["verdict"] == "reopen-eligible"
     assert out["eligible_user_count"] == 10  # conservative: anon events each count
+
+
+# ---- decide_create: create-path eligibility gate (issue #1218) --------------
+#
+# The create gate answers "should a brand-new fingerprint with no GitHub issue
+# become a ticket". family in {create, suppress, digest}; the routine only branches
+# on `family`. Fails OPEN (create) on anything not provably dev-only-self-healed.
+
+def cev(*, env="development", build="debug",
+        release="com.enviouswispr.app@2.2.0-3-gabc123-dev",
+        level="error", synthetic=None, user="founder", when="2026-06-24T00:00:00Z"):
+    """A DEV event by default (the #1192-#1215 class). Override fields per case."""
+    e = {"release": release, "environment": env, "build_type": build,
+         "user_id": user, "dateCreated": when, "level": level}
+    if synthetic is not None:
+        e["synthetic"] = synthetic
+    return e
+
+
+def pev(*, release="com.enviouswispr.app@2.2.0", level="error", user="u1"):
+    """A PRODUCTION event (release build, production env)."""
+    return {"release": release, "environment": "production", "build_type": "release",
+            "user_id": user, "dateCreated": "2026-06-24T00:00:00Z", "level": level}
+
+
+def dc_full(events, **kw):
+    """decide_create over a PROVABLY COMPLETE event list (events_truncated=False).
+
+    The create gate REQUIRES `events_truncated` -- a MISSING flag fails open to create
+    (Codex #1218 r3), since the flag is the gate's only completeness signal. Branch
+    tests that assert digest/suppress must therefore prove completeness; this wrapper
+    states that once instead of repeating it at every call site."""
+    return decide_create({"events": events, "events_truncated": False, **kw})
+
+
+def test_create_production_event_creates():
+    out = decide_create({"events": [pev()]})
+    assert out["verdict"] == "create"
+    assert out["family"] == "create"
+
+
+def test_create_mixed_prod_and_dev_creates():
+    # One real production event among dev noise still creates (real customer signal).
+    out = decide_create({"events": [cev(), pev(user="real")]})
+    assert out["family"] == "create"
+    assert out["dev_count"] == 1
+    assert out["event_count"] == 2
+
+
+def test_create_all_dev_all_synthetic_suppresses():
+    # Deliberate fault-injection crash-test -> suppress, never a ticket.
+    out = dc_full([cev(synthetic="true", level="fatal"),
+                   cev(synthetic="true", level="fatal")])
+    assert out["verdict"] == "suppress-synthetic"
+    assert out["family"] == "suppress"
+
+
+def test_create_all_dev_untagged_fatal_creates_canary():
+    # An untagged dev crash could be a real new-crash -> create-visible.
+    out = decide_create({"events": [cev(level="fatal")]})
+    assert out["verdict"] == "create-dev-fatal"
+    assert out["family"] == "create"
+
+
+def test_create_all_dev_handled_error_digests():
+    # The target class: dev-only, handled, self-healed -> digest, NOT a ticket.
+    out = dc_full([cev(level="error")])
+    assert out["verdict"] == "digest-dev-only"
+    assert out["family"] == "digest"
+
+
+def test_create_empty_events_fails_open_to_create():
+    out = decide_create({"events": []})
+    assert out["family"] == "create"
+
+
+def test_create_missing_events_fails_open_to_create():
+    # Missing fetch is NOT proof of "nothing real" -> create (visible).
+    out = decide_create({})
+    assert out["family"] == "create"
+
+
+def test_create_all_dev_warning_level_fails_open():
+    # All-dev but not provably all-handled-error (warning) -> fail open to create.
+    out = decide_create({"events": [cev(level="warning")]})
+    assert out["family"] == "create"
+    assert out["verdict"] == "create"
+
+
+def test_create_unknown_level_no_fallback_fails_open():
+    # No per-event level AND no issue_level -> unclassifiable -> fail open.
+    e = cev()
+    del e["level"]
+    out = decide_create({"events": [e]})
+    assert out["family"] == "create"
+
+
+def test_create_synthetic_string_true_is_coerced():
+    # Sentry tag value is the string "true"; it must coerce to a real suppress.
+    out = dc_full([cev(synthetic="true")])
+    assert out["family"] == "suppress"
+
+
+def test_create_synthetic_absent_is_not_suppressed():
+    # Absence of the tag means "unknown", never "known-synthetic" -> not suppressed.
+    out = dc_full([cev(level="error")])  # no synthetic key
+    assert out["family"] == "digest"  # falls to the handled-error class, not suppress
+
+
+def test_create_per_event_level_overrides_issue_level():
+    # event.level=fatal must win over issue_level=error -> create-dev-fatal.
+    out = decide_create({"events": [cev(level="fatal")], "issue_level": "error"})
+    assert out["verdict"] == "create-dev-fatal"
+
+
+def test_create_issue_level_fallback_when_event_level_absent():
+    # SINGLE-event fingerprint (latest == only event) -> the issue_level fallback is
+    # exact -> digest (handled class).
+    e = cev()
+    del e["level"]
+    out = dc_full([e], issue_level="error")
+    assert out["verdict"] == "digest-dev-only"
+
+
+def test_create_multi_event_missing_per_event_level_fails_open():
+    # Codex P2 (#1218 review r4): in a MULTI-event list, a non-synthetic event missing
+    # its OWN `level` is unclassifiable -- the issue/latest-level fallback (valid only
+    # for a single-event fingerprint) must NOT mask it as 'error' and digest the whole
+    # fingerprint; that event could have been a fatal. Fail open to create.
+    e_no_level = cev()
+    del e_no_level["level"]
+    out = dc_full([cev(level="error"), e_no_level], issue_level="error")
+    assert out["family"] == "create"
+
+
+def test_create_untagged_fatal_mixed_with_synthetic_still_creates():
+    # A genuine (untagged) dev fatal alongside a synthetic one is NOT all-synthetic,
+    # so branch 2 fails and the untagged fatal surfaces (create-dev-fatal).
+    out = decide_create({"events": [cev(synthetic="true", level="fatal"),
+                                    cev(level="fatal")]})
+    assert out["verdict"] == "create-dev-fatal"
+
+
+def test_create_partial_synthetic_handled_errors_digest():
+    # Some synthetic, some not, all handled errors -> not all-synthetic, no fatal,
+    # all-error -> digest (no ticket either way; harmless).
+    out = dc_full([cev(synthetic="true"), cev()])
+    assert out["verdict"] == "digest-dev-only"
+
+
+def test_create_synthetic_fatal_plus_untagged_handled_digests():
+    # Codex P2 (#1218 review r1): a TAGGED fault-injection FATAL alongside an UNTAGGED
+    # handled dev error must NOT create. The synthetic fatal is a deliberate crash-test
+    # and is excluded from the dev signal; the only real signal is the handled error
+    # (the digest class). Before the fix this filed a ticket for the crash-test.
+    out = dc_full([cev(synthetic="true", level="fatal"), cev(level="error")])
+    assert out["verdict"] == "digest-dev-only"
+    assert out["family"] == "digest"
+
+
+def test_create_cli_create_flag_dispatches_to_decide_create():
+    # `--create` routes to decide_create; a digest fixture returns family=digest.
+    payload = json.dumps({"events": [cev(level="error")], "events_truncated": False})
+    proc = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent / "tik_eligibility.py"), "--create"],
+        input=payload, capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout)["family"] == "digest"
+
+
+def test_create_cli_without_flag_is_reopen_gate():
+    # No flag -> the existing reopen gate (decide) -> ambiguous on this fail-open input.
+    # Proves the live Step 2.6.5 invocation is byte-for-byte unchanged.
+    payload = json.dumps({"events": [ev("v2.1.4")], "closed_at": CLOSED,
+                          "close_class": "unknown", "fix_released_version": None,
+                          "fix_merged": False, "latest_release": "v2.1.4"})
+    proc = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent / "tik_eligibility.py")],
+        input=payload, capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout)["verdict"] == "ambiguous"
+
+
+def test_create_cli_create_flag_fails_open_on_bad_json():
+    # Malformed stdin under --create must fail OPEN to create (visible), exit 0.
+    proc = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent / "tik_eligibility.py"), "--create"],
+        input="not json", capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout)["family"] == "create"
+
+
+def test_create_8_fingerprint_regression_zero_creates():
+    # The metric (plan 3a): decide_create over the 8 dev-only self-healed fingerprints
+    # filed 2026-06-24 (ENVIOUSWISPR-1B/1C/1D/1E/1F/1G/1J/1K) returns NO create for any.
+    # Each is modeled as its real class: a single dev, handled (level=error),
+    # self-healed event from the founder's dogfood machine.
+    shortids = ["1B", "1C", "1D", "1E", "1F", "1G", "1J", "1K"]
+    for sid in shortids:
+        out = dc_full([cev(level="error", user=f"founder-{sid}")])
+        assert out["family"] in {"digest", "suppress"}, f"{sid} -> {out}"
+        assert out["family"] != "create", f"{sid} wrongly created: {out}"
+
+
+def test_create_missing_events_truncated_fails_open_on_suppress():
+    # Codex P2 (#1218 review r3): events_truncated is REQUIRED. A digest/suppress with
+    # NO events_truncated key cannot prove the list is complete -> fail open to create.
+    # (Same events that digest/suppress WITH events_truncated=False, per dc_full above.)
+    assert decide_create({"events": [cev(level="error")]})["family"] == "create"
+    assert decide_create({"events": [cev(synthetic="true")]})["family"] == "create"
+
+
+def test_create_truncated_downgrades_digest_to_create():
+    # Codex P2 (#1218 review r2): a digest on a TRUNCATED list is unsafe — an unread
+    # page could hold a production/fatal event -> fail open to create.
+    base = {"events": [cev(level="error")]}
+    assert decide_create({**base, "events_truncated": False})["family"] == "digest"
+    assert decide_create({**base, "events_truncated": True})["family"] == "create"
+
+
+def test_create_truncated_downgrades_suppress_to_create():
+    base = {"events": [cev(synthetic="true")]}
+    assert decide_create({**base, "events_truncated": False})["family"] == "suppress"
+    assert decide_create({**base, "events_truncated": True})["family"] == "create"
+
+
+def test_create_truncated_does_not_change_create():
+    # A create verdict is already visible -> truncation is irrelevant (like the reopen
+    # gate's test_truncated_does_not_downgrade_reopen).
+    base = {"events": [cev(level="fatal")]}  # create-dev-fatal
+    assert decide_create({**base, "events_truncated": True})["verdict"] == "create-dev-fatal"
+
+
+def test_create_truncated_string_true_is_coerced():
+    # Shell-built JSON passes "true"/"false" as strings; only a real true downgrades.
+    out = decide_create({"events": [cev(level="error")], "events_truncated": "true"})
+    assert out["family"] == "create"
 
 
 # ---- self-runner (no pytest dependency in the routine sandbox) --------------

--- a/workers/sentry-triage/tik_eligibility.py
+++ b/workers/sentry-triage/tik_eligibility.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-"""TIK reopen/severity eligibility gate (issue #1143).
+"""TIK Sentry-triage eligibility gates (issue #1143 reopen, #1218 create).
 
-Pure decision function for the TIK Sentry-triage routine. Given the post-close
-event set for a closed fingerprint plus the fix-version boundary, decide whether
-a recurrence is a real regression (reopen), pre-fix-tail noise (hold), or
-unprovable (ambiguous -> fail open).
+Two pure decision functions for the TIK Sentry-triage routine, sharing the
+`is_development()` dev-detector and a fail-open philosophy (anything unprovable
+stays VISIBLE, never silently suppressed):
+  - `decide()` (#1143) -- the REOPEN gate. Given the post-close event set for a
+    closed fingerprint plus the fix-version boundary, decide whether a recurrence is
+    a real regression (reopen), pre-fix-tail noise (hold), or unprovable (ambiguous).
+  - `decide_create()` (#1218) -- the CREATE gate. Given the event list for a NEW
+    fingerprint that has no GitHub issue, decide whether it becomes a ticket (create),
+    is deliberate fault-injection noise (suppress), or is a dev-only self-healed error
+    to list in the run digest (digest). See its own docstring for the branch order.
 
 DESIGN INVARIANTS (council 2026-06-21, 2 rounds; Codex grounded review 3 rounds):
   - HOLD requires PROOF. Anything we cannot prove benign fails OPEN (ambiguous ->
@@ -356,13 +362,167 @@ def _out(verdict, reason, eligible_user_count=0, eligible_count=0,
     }
 
 
+# ---- create-path decision (issue #1218) ------------------------------------
+#
+# Path A of the routine (a brand-new Sentry fingerprint with no GitHub issue) had
+# NO environment gate -- it created a ticket for every new fingerprint, so dev-only,
+# self-healed, single-event errors from the founder's dogfood machine became tracked
+# issues (#1192-#1215). `decide_create` is the create-path sibling of `decide()`. It
+# deliberately does NOT reuse `decide()`: that one is reopen-shaped (built around
+# closed_at + post-close partitioning); a create decision has no close boundary and a
+# different question ("should this exist at all"). Both share the `is_development()`
+# dev-detector -- the single authority for "is this dev" -- and the same fail-open
+# philosophy: anything we cannot PROVE is dev-only-and-self-healed becomes a VISIBLE
+# create, never a silent drop.
+
+# Create-path verdict -> action family. The routine Path A branches on `family`.
+#   create  : file the GitHub issue (real production signal, untagged dev fatal, or
+#             fail-open on unclassifiable input).
+#   suppress: do NOT file; deliberate fault-injection noise (every event synthetic).
+#   digest  : do NOT file; list the fingerprint in the run-summary DEV_DIGEST so the
+#             founder still sees it at a glance (the dev-only self-healed class).
+CREATE_VERDICT_FAMILY = {
+    "create": "create",
+    "create-dev-fatal": "create",
+    "suppress-synthetic": "suppress",
+    "digest-dev-only": "digest",
+}
+
+# Create-path verdicts that SUPPRESS a ticket (do not create). On a truncated event
+# list (the fetch hit the page cap with more pages pending) a hidden later page could
+# carry a real production/fatal event, so any of these must fail OPEN (downgrade to
+# create) when `events_truncated` is set -- mirrors the reopen gate's `_HOLD_VERDICTS`.
+_CREATE_SUPPRESSING_VERDICTS = {"suppress-synthetic", "digest-dev-only"}
+
+
+def _effective_level(event: dict, issue_level) -> str | None:
+    """Per-event `level`, falling back to the issue/latest-event level Path A reads.
+
+    Returns the lowercased level string, or None when neither is present/usable. None
+    means 'cannot classify' -> the caller fails OPEN to create, never digests."""
+    for src in (event.get("level"), issue_level):
+        if isinstance(src, str) and src.strip():
+            return src.strip().lower()
+    return None
+
+
+def decide_create(data: dict) -> dict:
+    """Create-path eligibility gate (#1218): should a NEW fingerprint become a ticket?
+
+    Input (JSON): {events: [{environment, build_type, release, level, synthetic,
+    user_id, dateCreated}], issue_level, events_truncated}. `issue_level` is the
+    aggregate/latest-event level Path A severity already reads -- the per-event `level`
+    fallback. Operates over the event LIST (not a scalar) so a multi-event fingerprint
+    partitions correctly. Output: {verdict, family, reason, dev_count, event_count};
+    family in {create, suppress, digest}. Fails OPEN (create) on empty/unclassifiable
+    input AND on a truncated event list (unread pages could hide a real event).
+    """
+    result = _decide_create_inner(data)
+    # A digest/suppress decision is only valid on a PROVABLY COMPLETE event list. The
+    # `events_truncated` flag is REQUIRED on the input and is this gate's ONLY
+    # completeness signal -- unlike the reopen gate, which ALSO has _inputs_incomplete
+    # (closed_at + per-event timestamps) as a second guard. So treat a MISSING flag as
+    # "not proven complete" (default True) and downgrade any suppressing verdict to a
+    # visible create, exactly as an explicit `events_truncated=true` does. A hidden
+    # later page could carry a production or fatal event; fail open, never silent-suppress.
+    if (result["verdict"] in _CREATE_SUPPRESSING_VERDICTS
+            and _as_bool(data.get("events_truncated", True))):
+        return _out_create(
+            "create",
+            f"cannot {result['family']} on a truncated event list "
+            f"(unread pages could hide a production/fatal event); fail open",
+            dev_count=result.get("dev_count", 0),
+            event_count=result.get("event_count", 0))
+    return result
+
+
+def _decide_create_inner(data: dict) -> dict:
+    events = data.get("events") if isinstance(data.get("events"), list) else []
+    issue_level = data.get("issue_level")
+
+    # No events (empty list / missing fetch / unparseable) -> fail OPEN to create.
+    # Never silently drop a potential real issue (mirrors the reopen gate's invariant).
+    if not events:
+        return _out_create("create",
+                           "no events to classify (empty / missing / fetch failure); fail open")
+
+    dev = [e for e in events if is_development(e)]
+
+    # 1. Any production (non-dev) event -> create. Real customer signal; create as today.
+    if len(dev) < len(events):
+        return _out_create("create",
+                           "at least one production event; real signal, create as today",
+                           dev_count=len(dev), event_count=len(events))
+
+    # All events are dev from here. A `synthetic=true` event is a DELIBERATE
+    # fault-injection test -- it never justifies a ticket, so exclude every synthetic
+    # event from the dev signal and classify on the non-synthetic remainder. Excluding
+    # here (not just in the all-synthetic branch) is what stops a tagged synthetic fatal
+    # mixed with an untagged handled error from creating a ticket for a crash test
+    # (Codex #1218 review).
+    nonsynthetic = [e for e in events if not _as_bool(e.get("synthetic"))]
+
+    # 2. Every event synthetic (no real signal left) -> suppress. Deliberate test noise.
+    if not nonsynthetic:
+        return _out_create("suppress-synthetic",
+                           "all events dev and synthetic=true (deliberate fault-injection test)",
+                           dev_count=len(dev), event_count=len(events))
+
+    # The issue/latest-event level fallback is EXACT only for a single-event fingerprint
+    # (latest == the only event). In a multi-event list, copying the latest level onto a
+    # DIFFERENT event whose own level is missing could mask a fatal -> allow the fallback
+    # only when the whole list is one event; otherwise a missing per-event level is
+    # unclassifiable (None) and fails open at branch 5 (Codex #1218 review).
+    allow_level_fallback = len(events) == 1
+    levels = [_effective_level(e, issue_level if allow_level_fallback else None)
+              for e in nonsynthetic]
+
+    # 3. A non-synthetic (untagged) dev fatal -> create (dev canary). An untagged dev
+    #    crash could be a real new-crash; fail toward visible. Synthetic fatals were
+    #    excluded above, so this catches only genuine dev crashes.
+    if any(lvl == "fatal" for lvl in levels):
+        return _out_create("create-dev-fatal",
+                           "untagged dev fatal; a real dev crash is canary-worthy, create",
+                           dev_count=len(dev), event_count=len(events))
+
+    # 4. All non-synthetic dev events are handled errors -> digest. The #1192-#1215
+    #    class: handled, self-healed, no customer signal. No ticket.
+    if all(lvl == "error" for lvl in levels):
+        return _out_create("digest-dev-only",
+                           "all-dev handled error, self-healed, no customer signal; digest not ticket",
+                           dev_count=len(dev), event_count=len(events))
+
+    # 5. The non-synthetic level set is not provably all-handled-error (mixed / warning /
+    #    info / unknown) -> fail OPEN to create. We stay silent ONLY when we can PROVE
+    #    the dev-only-self-healed class; anything else stays visible.
+    return _out_create("create",
+                       "dev events but level set not provably all-handled-error; fail open",
+                       dev_count=len(dev), event_count=len(events))
+
+
+def _out_create(verdict, reason, dev_count=0, event_count=0):
+    return {
+        "verdict": verdict,
+        "family": CREATE_VERDICT_FAMILY[verdict],
+        "reason": reason,
+        "dev_count": dev_count,
+        "event_count": event_count,
+    }
+
+
 def main(argv=None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    create_mode = "--create" in argv  # default (no flag) stays the reopen gate -> decide()
     try:
         raw = sys.stdin.read()
         data = json.loads(raw)
-        result = decide(data)
+        result = decide_create(data) if create_mode else decide(data)
     except Exception as exc:  # noqa: BLE001 -- fail OPEN on any helper error
-        result = _out("ambiguous", f"helper error: {type(exc).__name__}: {exc}")
+        # Fail-open shape differs per gate: reopen -> ambiguous (visible reopen),
+        # create -> create (visible new ticket). Neither can become a silent drop.
+        result = (_out_create("create", f"helper error: {type(exc).__name__}: {exc}")
+                  if create_mode
+                  else _out("ambiguous", f"helper error: {type(exc).__name__}: {exc}"))
     print(json.dumps(result))
     return 0
 


### PR DESCRIPTION
Closes #1218.

## Problem
Path A of the Sentry-triage routine (TIK) — the create path for a brand-new fingerprint with no GitHub issue — had no environment gate. Only the reopen path (Path C / Step 2.6.5, #1143) was dev-aware. So dev-only, self-healed, single-event errors from the founder's dogfood/test machine became tracked GitHub issues (8 filed 2026-06-24: #1192–#1215). Amplified by per-category fingerprinting (#1144).

## Fix (two coordinated parts)
**Part 1 — create-path gate (Worker lane).** New pure `decide_create(data)` in `workers/sentry-triage/tik_eligibility.py`, sibling to `decide()`, reusing the shared `is_development()` dev-detector. It classifies a new fingerprint over the event LIST:
- any production event → **create** (real signal)
- all-dev + all-synthetic → **suppress** (deliberate fault-injection)
- all-dev untagged fatal → **create** (a real dev crash is canary-worthy)
- all-dev handled error → **digest** (the #1192–#1215 class — no ticket, listed in an end-of-run `DEV_DIGEST`)
- anything not provably dev-only-self-healed → **fail open to create**

Wired into the routine prompt as **Step 6.5** (paginated events-list fetch mirroring Step 2.6.5; fail-open on fetch/helper failure; `events_truncated` downgrade). The reopen-path CLI is byte-for-byte unchanged; `--create` routes the new gate.

**Part 2 — synthetic tag (Code lane).** Stamp Sentry events `synthetic=true` when the app launches with `EW_FAULT_INJECTION=1`, so deliberate crash-tests are excluded deterministically instead of by a prose note. +9 lines in `ObservabilityBootstrap.configureScope` (capture-time seam — the SDK refuses to apply the relaunch scope to a replayed fatal). Host-scope by design: the launchd XPC helpers can't see the env var and the fault kinds are host-initiated / host-captured (documented inline).

## Validation
- `test_tik_eligibility.py`: 66/66 green, incl. the 8-fingerprint regression (all → digest/suppress, zero creates) + truncation & multi-event fail-open cases.
- Routine dry-run probes: production fixture → create; dev handled → digest; dev synthetic → suppress.
- `scripts/xcode-test.sh`: **TEST SUCCEEDED** (2117 tests), redaction tripwire green.
- Codex grounded review: 5 rounds → PROCEED-AS-PLANNED. Codex code-diff review (`codex review`): 5 rounds → clean (4 fail-open hardening fixes; the "tag helper events" finding rejected with evidence — helpers can't see `EW_FAULT_INJECTION`).

## Post-merge
- Deploy the updated routine prompt to the live trigger + drift-check re-sync (the cron clones repo `main`, so the helper must land first).
- Empirical Sentry round-trip (founder crash-test) to confirm `synthetic=true` rides on a real event. Safe-degrades: if absent, the routine just creates a ticket the founder closes (pre-existing behavior).

## Blast radius
`workers/sentry-triage/*` (routine + helper + tests) + `ObservabilityBootstrap.swift` (+9 lines). NOT touched: heart path, ASR, audio, paste, polish, UI, the reopen path (`decide()` / Path C), Sentry alert rules. Rollback: single squash revert.