### PR TITLE
feat(llm): DEBUG-only AFM adapter live-test seam + Diagnostics toggle

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
@@ -22,6 +22,18 @@ struct DiagnosticsSettingsView: View {
   /// environment (see `AppEnvironmentKeys.swift`).
   private var asrManager: any ASRManagerInterface { asrManagerEnv! }
 
+  #if DEBUG
+    /// DEV-ONLY (AFM adapter PoC): surfaces whether EW_AFM_ADAPTER_PATH is set so
+    /// the founder can see the adapter toggle only takes effect when the dev app
+    /// was launched with the env var pointing at a `.fmadapter`.
+    private var adapterPathHint: String {
+      if let path = ProcessInfo.processInfo.environment["EW_AFM_ADAPTER_PATH"], !path.isEmpty {
+        return "Adapter: \((path as NSString).lastPathComponent)."
+      }
+      return "EW_AFM_ADAPTER_PATH not set — toggle has no effect until you relaunch with it set."
+    }
+  #endif
+
   var body: some View {
     @Bindable var settings = settings
     #if DEBUG
@@ -40,6 +52,22 @@ struct DiagnosticsSettingsView: View {
               .foregroundStyle(.stTextTertiary)
           }
         }
+        #if DEBUG
+          // DEV-ONLY (AFM adapter PoC): flip on-device Apple Intelligence polish
+          // between the tuned local .fmadapter and the stock model, live, to triage
+          // "is this the stock model or our adapter?". Debug builds only.
+          BrandedRow {
+            VStack(alignment: .leading, spacing: 4) {
+              Toggle("Use tuned on-device adapter (PoC)", isOn: $settings.devAdapterPolishEnabled)
+                .toggleStyle(BrandedToggleStyle())
+              Text(
+                "Debug builds only. ON routes Apple Intelligence polish through the local .fmadapter at EW_AFM_ADAPTER_PATH; OFF uses the stock model. Flips live on the next dictation. \(adapterPathHint)"
+              )
+              .font(.stHelper)
+              .foregroundStyle(.stTextTertiary)
+            }
+          }
+        #endif
         if settings.isDebugModeEnabled {
           BrandedRow {
             Picker("Log Level", selection: $settings.debugLogLevel) {

--- a/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
@@ -681,6 +681,13 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       }
     }
 
+    #if DEBUG
+      /// DEV-ONLY (AFM adapter PoC): log adapter load/skip on the LLM channel.
+      private static func logAdapter(_ msg: String) {
+        Task { await AppLogger.shared.log("AFM " + msg, level: .info, category: "LLM") }
+      }
+    #endif
+
     @available(macOS 26.0, *)
     private func makeSession(
       instructions: PolishInstructions,
@@ -689,7 +696,45 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       // Permissive content-transformation guardrails — peer-ecosystem default
       // for text-transform apps. Prevents AFM from refusing to polish benign
       // dictation that happens to mention sensitive topics.
-      let model = SystemLanguageModel(guardrails: .permissiveContentTransformations)
+      let model: SystemLanguageModel
+      #if DEBUG
+        // DEV-ONLY live test seam (AFM adapter PoC): when the per-build toggle is
+        // ON and EW_AFM_ADAPTER_PATH points at a local .fmadapter, polish through
+        // the tuned adapter so the founder can A/B it against stock Apple polish.
+        // A missing/corrupt path throws → logged "FAILED to load" → stock model.
+        // Read fresh per dictation so the Diagnostics toggle flips live, no relaunch.
+        // Compiled out of release entirely.
+        let adapterOn =
+          UserDefaults.standard.object(forKey: "devAdapterPolishEnabled") as? Bool ?? true
+        if adapterOn,
+          let adapterPath = ProcessInfo.processInfo.environment["EW_AFM_ADAPTER_PATH"],
+          !adapterPath.isEmpty
+        {
+          do {
+            let adapter = try SystemLanguageModel.Adapter(
+              fileURL: URL(fileURLWithPath: adapterPath))
+            // NOTE: we intentionally do NOT call the async `adapter.compile()`.
+            // makeSession is synchronous (and shared with the release stock path),
+            // and the Gate-1 PoC proved this exact load→adapter-model→generate path
+            // works on-device for ew_run5_v38.fmadapter with no explicit compile()
+            // (compile front-loads on-device prep; absent it, prep is lazy on first
+            // use). If a future adapter genuinely requires it, generation simply
+            // degrades to the raw-text limb and the "adapter active" UAT check fails
+            // loudly — acceptable for a DEBUG-only triage seam.
+            model = SystemLanguageModel(
+              adapter: adapter, guardrails: .permissiveContentTransformations)
+            Self.logAdapter("DEV adapter active: \((adapterPath as NSString).lastPathComponent)")
+          } catch {
+            Self.logAdapter(
+              "DEV adapter FAILED to load (\(adapterPath)): \(error) — using stock model")
+            model = SystemLanguageModel(guardrails: .permissiveContentTransformations)
+          }
+        } else {
+          model = SystemLanguageModel(guardrails: .permissiveContentTransformations)
+        }
+      #else
+        model = SystemLanguageModel(guardrails: .permissiveContentTransformations)
+      #endif
 
       // Availability is verified at the entry of `polish(...)`, but re-check
       // here to stay safe if `makeSession` is ever reached from another

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -406,6 +406,22 @@ public final class SettingsManager {
     }
   }
 
+  #if DEBUG
+    /// DEV-ONLY per-build knob (AFM adapter PoC): when ON and EW_AFM_ADAPTER_PATH
+    /// is set, on-device Apple Intelligence polish runs through the local
+    /// `.fmadapter`. Lets the founder A/B adapter↔stock live on dev builds.
+    /// PER-BUILD EXCEPTION (#923), exactly like `useXPCAudioService`: persisted to
+    /// `UserDefaults.standard` (the build's own store), excluded from
+    /// `unifiedDefaultsKeys` + the #923 migration, NOT in the `SettingKey` enum
+    /// (no onChange/telemetry — the connector reads it fresh per dictation).
+    /// Compiled out of release entirely.
+    public var devAdapterPolishEnabled: Bool {
+      didSet {
+        UserDefaults.standard.set(devAdapterPolishEnabled, forKey: "devAdapterPolishEnabled")
+      }
+    }
+  #endif
+
   // MARK: - What's New
 
   public var lastSeenWhatsNewVersion: String {
@@ -612,6 +628,13 @@ public final class SettingsManager {
     // (the build's own store), never the shared `defaults`. Matches the bootstrap
     // read at WisprBootstrapper and stays out of unifiedDefaultsKeys.
     useXPCAudioService = UserDefaults.standard.object(forKey: "useXPCAudioService") as? Bool ?? true
+    #if DEBUG
+      // PER-BUILD EXCEPTION (#923), like useXPCAudioService: AFM adapter PoC dev
+      // knob, read from the build's own store, default ON. Stays out of
+      // unifiedDefaultsKeys + the migration. Compiled out of release.
+      devAdapterPolishEnabled =
+        UserDefaults.standard.object(forKey: "devAdapterPolishEnabled") as? Bool ?? true
+    #endif
 
     // Migration (issue #614, 2026-05-04): the Formal/Standard/Friendly preset axis and the
     // hidden custom-prompt path were removed. Drop their orphaned UserDefaults keys so the

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -109,6 +109,24 @@ struct SettingsDefaultsRoutingTests {
     UserDefaults.standard.removeObject(forKey: "useXPCAudioService")  // cleanup
   }
 
+  #if DEBUG
+    // AFM adapter PoC dev knob — same per-build contract as useXPCAudioService:
+    // writes to .standard (not the injected store) and stays out of the unified
+    // key set. DEBUG-gated because the property only exists in DEBUG builds.
+    @Test("devAdapterPolishEnabled writes to .standard and stays out of unified defaults")
+    func devAdapterStaysPerBuild() {
+      let suite = Self.freshSuite()
+      let settings = SettingsManager(defaults: suite)
+      settings.devAdapterPolishEnabled = false
+      // The per-build knob must NOT land in the injected (shared) suite.
+      #expect(suite.object(forKey: "devAdapterPolishEnabled") == nil)
+      #expect(UserDefaults.standard.object(forKey: "devAdapterPolishEnabled") as? Bool == false)
+      // And it must never join the unified key set.
+      #expect(Set(SettingsManager.unifiedDefaultsKeys).contains("devAdapterPolishEnabled") == false)
+      UserDefaults.standard.removeObject(forKey: "devAdapterPolishEnabled")  // cleanup
+    }
+  #endif
+
   // MARK: - Migration (effective-state, dev-store sentinel)
 
   @Test("dev migration copies explicit values, clears stale shared, sets dev sentinel")


### PR DESCRIPTION
## Why
Lets the founder dictate against a locally trained LoRA \`.fmadapter\` inside the real app and A/B it against stock Apple on-device polish, to triage "is this the stock model or our adapter?". Pure dev triage tooling — **all `#if DEBUG`, release binary unchanged.**

## What
- **AppleIntelligenceConnector.makeSession**: when the per-build toggle is ON and \`EW_AFM_ADAPTER_PATH\` points at a \`.fmadapter\`, build the on-device model with the adapter; missing/corrupt path throws → logged "FAILED to load" → falls back to stock model (heart/limbs). Read fresh per dictation so the toggle flips live, no relaunch.
- **SettingsManager.devAdapterPolishEnabled**: per-build knob (\`UserDefaults.standard\`, default ON), mirroring \`useXPCAudioService\`; NOT in the \`SettingKey\` enum / \`unifiedDefaultsKeys\` / #923 migration / telemetry.
- **DiagnosticsSettingsView**: DEBUG toggle row in Debug Mode + \`EW_AFM_ADAPTER_PATH\` hint.
- **SettingsDefaultsRoutingTests**: DEBUG routing test mirroring the \`useXPCAudioService\` per-build contract.

## Scope / not in scope
- Release builds: every changed code path is \`#if DEBUG\`; the \`#else\` branch is the unchanged original \`SystemLanguageModel(guardrails:)\` line, so release behavior is byte-identical.
- No new authority — \`SettingsManager.devAdapterPolishEnabled\` owns the value; connector reads, Diagnostics writes. Mirrors the existing \`useXPCAudioService\` per-build-knob precedent.

## Validation
- Plan: \`docs/feature-requests/plan-2026-06-24-afm-adapter-live-test-seam.md\`; grounded review r6 → PROCEED-AS-PLANNED.
- Logic tests: full suite green (2,118 tests).
- Codex code-diff review: clean (round 1, no actionable findings).
- **Live UAT**: rebuilt DEBUG dev app, launched with \`EW_AFM_ADAPTER_PATH=…/ew_run5_v38.fmadapter\`, dictated → log confirms \`AFM DEV adapter active: ew_run5_v38.fmadapter\` immediately before Apple Intelligence polish; pipeline 1.87s, content check PASS. Adapter genuinely loaded, not stock fallback.