### PR TITLE
feat(telemetry): tail-clip diagnostics — classify capture-clip vs ASR-drop per dictation (#1232)

### DIFF
--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -98,8 +98,18 @@ public actor ParakeetBackend: ASRBackend {
       language: "en",
       duration: fluidResult.duration,
       processingTime: elapsed,
-      backendType: .parakeet
+      backendType: .parakeet,
+      tokenTimingSummary: Self.tokenTimingSummary(from: fluidResult.tokenTimings)
     )
+  }
+
+  /// Numbers-only summary of FluidAudio token timings for tail-clip diagnostics (#1232).
+  /// We keep only the count and the end time (ms) of the last token — never token text.
+  /// Used to compute how far the decoded text reached vs the captured audio.
+  private static func tokenTimingSummary(from timings: [TokenTiming]?) -> ASRTokenTimingSummary? {
+    guard let timings else { return nil }
+    let lastEndMs = timings.map(\.endTime).max().map { Int(($0 * 1000).rounded()) }
+    return ASRTokenTimingSummary(tokenCount: timings.count, lastTokenEndMs: lastEndMs)
   }
 
   // MARK: - Streaming ASR

--- a/Sources/EnviousWisprCore/ASRResult.swift
+++ b/Sources/EnviousWisprCore/ASRResult.swift
@@ -13,6 +13,23 @@ public enum ASRBackendType: String, Codable, Sendable {
   }
 }
 
+/// Numbers-only summary of an ASR pass's token timings.
+///
+/// Tail-clip diagnostics (#1232): the engine returns per-token start/end times
+/// but the app dropped them. We thread only the count and the end time of the
+/// last token (in ms) so we can compute how far the decoded text reached
+/// relative to the captured audio. NO token text — release-safe.
+public struct ASRTokenTimingSummary: Sendable, Codable {
+  public let tokenCount: Int
+  /// End time of the final recognized token, in milliseconds. Nil if no tokens.
+  public let lastTokenEndMs: Int?
+
+  public init(tokenCount: Int, lastTokenEndMs: Int?) {
+    self.tokenCount = tokenCount
+    self.lastTokenEndMs = lastTokenEndMs
+  }
+}
+
 /// Result from an ASR transcription pass.
 public struct ASRResult: Sendable, Codable {
   public let text: String
@@ -20,16 +37,20 @@ public struct ASRResult: Sendable, Codable {
   public let duration: TimeInterval
   public let processingTime: TimeInterval
   public let backendType: ASRBackendType
+  /// Numbers-only token-timing summary, when the backend exposes it (Parakeet).
+  /// Optional + defaulted so existing callers and old Codable payloads still decode.
+  public let tokenTimingSummary: ASRTokenTimingSummary?
 
   public init(
     text: String, language: String?, duration: TimeInterval, processingTime: TimeInterval,
-    backendType: ASRBackendType
+    backendType: ASRBackendType, tokenTimingSummary: ASRTokenTimingSummary? = nil
   ) {
     self.text = text
     self.language = language
     self.duration = duration
     self.processingTime = processingTime
     self.backendType = backendType
+    self.tokenTimingSummary = tokenTimingSummary
   }
 }
 

--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -59,6 +59,19 @@ public struct ExecutionMetrics: Codable, Sendable {
   public var recoveredTailMs: Int?
   public var tailVoicedFraction: Double?
   public var tailRefusedReason: String?
+  /// #1232 tail-clip telemetry: release-safe classifier + lead signals carried
+  /// onto `asr.completed`. Numbers/booleans only — no audio or text. All optional
+  /// (additive Codable, back-compatible with pre-#1232 transcripts on disk).
+  /// `tailClipClassification` = clean / suspected_capture_clip /
+  /// suspected_asr_drop / unknown.
+  public var tailClipClassification: String?
+  public var captureTrailingSilenceMs: Int?
+  public var captureTail200Rms: Double?
+  public var captureTail200Peak: Double?
+  public var asrInputDurationMs: Int?
+  public var asrLastTokenEndMs: Int?
+  public var asrLastTokenGapMs: Int?
+  public var asrChunked: Bool?
   /// Deterministic post-polish emoji-restore telemetry (#761). Populated only for
   /// Apple on-device (AFM) polish; nil for cloud providers, no-polish dictations,
   /// and pre-#761 transcripts on disk (additive optional Codable, back-compatible).
@@ -99,6 +112,14 @@ public struct ExecutionMetrics: Codable, Sendable {
     recoveredTailMs: Int? = nil,
     tailVoicedFraction: Double? = nil,
     tailRefusedReason: String? = nil,
+    tailClipClassification: String? = nil,
+    captureTrailingSilenceMs: Int? = nil,
+    captureTail200Rms: Double? = nil,
+    captureTail200Peak: Double? = nil,
+    asrInputDurationMs: Int? = nil,
+    asrLastTokenEndMs: Int? = nil,
+    asrLastTokenGapMs: Int? = nil,
+    asrChunked: Bool? = nil,
     emojiInInput: Int? = nil,
     emojiDropped: Int? = nil,
     emojiRestored: Int? = nil,
@@ -131,6 +152,14 @@ public struct ExecutionMetrics: Codable, Sendable {
     self.recoveredTailMs = recoveredTailMs
     self.tailVoicedFraction = tailVoicedFraction
     self.tailRefusedReason = tailRefusedReason
+    self.tailClipClassification = tailClipClassification
+    self.captureTrailingSilenceMs = captureTrailingSilenceMs
+    self.captureTail200Rms = captureTail200Rms
+    self.captureTail200Peak = captureTail200Peak
+    self.asrInputDurationMs = asrInputDurationMs
+    self.asrLastTokenEndMs = asrLastTokenEndMs
+    self.asrLastTokenGapMs = asrLastTokenGapMs
+    self.asrChunked = asrChunked
     self.emojiInInput = emojiInInput
     self.emojiDropped = emojiDropped
     self.emojiRestored = emojiRestored

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -417,6 +417,16 @@ struct KernelFinalizationWiring {
       recoveredTailMs: telemetryState.asrCompletedTelemetry?.recoveredTailMs,
       tailVoicedFraction: telemetryState.asrCompletedTelemetry?.tailVoicedFraction,
       tailRefusedReason: telemetryState.asrCompletedTelemetry?.tailRefusedReason,
+      // #1232 tail-clip telemetry — kernel-computed classifier + lead signals,
+      // read from the shared telemetry state. Carried onto `asr.completed`.
+      tailClipClassification: telemetryState.asrCompletedTelemetry?.tailClipClassification,
+      captureTrailingSilenceMs: telemetryState.asrCompletedTelemetry?.captureTrailingSilenceMs,
+      captureTail200Rms: telemetryState.asrCompletedTelemetry?.captureTail200Rms,
+      captureTail200Peak: telemetryState.asrCompletedTelemetry?.captureTail200Peak,
+      asrInputDurationMs: telemetryState.asrCompletedTelemetry?.asrInputDurationMs,
+      asrLastTokenEndMs: telemetryState.asrCompletedTelemetry?.asrLastTokenEndMs,
+      asrLastTokenGapMs: telemetryState.asrCompletedTelemetry?.asrLastTokenGapMs,
+      asrChunked: telemetryState.asrCompletedTelemetry?.asrChunked,
       // #761 deterministic emoji-restore facts (counts only). Populated only on
       // an AFM run; nil for cloud / Ollama / no-polish and pre-#761 records.
       emojiInInput: outcome.emojiRan ? outcome.emojiInInput : nil,

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -391,6 +391,18 @@ final class KernelLifecycleTelemetrySink {
     if let refusedReason = telemetryState.asrCompletedTelemetry?.tailRefusedReason {
       payload["tail_refused_reason"] = refusedReason
     }
+    // #1232 tail-clip telemetry (omit-on-nil, numbers/booleans only — no audio
+    // or text). Lets cross-session triage tell capture-clip from ASR-drop.
+    if let t = telemetryState.asrCompletedTelemetry {
+      if let cls = t.tailClipClassification { payload["tail_clip_class"] = cls }
+      if let v = t.captureTrailingSilenceMs { payload["capture_trailing_silence_ms"] = v }
+      if let v = t.captureTail200Rms { payload["capture_tail_200_rms"] = v }
+      if let v = t.captureTail200Peak { payload["capture_tail_200_peak"] = v }
+      if let v = t.asrInputDurationMs { payload["asr_input_duration_ms"] = v }
+      if let v = t.asrLastTokenEndMs { payload["asr_last_token_end_ms"] = v }
+      if let v = t.asrLastTokenGapMs { payload["asr_last_token_gap_ms"] = v }
+      if let v = t.asrChunked { payload["asr_chunked"] = v }
+    }
     return payload
   }
 

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -78,6 +78,18 @@ struct KernelASRCompletedTelemetry {
   var recoveredTailMs: Int? = nil
   var tailVoicedFraction: Double? = nil
   var tailRefusedReason: String? = nil
+  // #1232 tail-clip telemetry: release-safe classifier + lead signals. All
+  // numbers/booleans, no audio or text. `tailClipClassification` is one of
+  // clean / suspected_capture_clip / suspected_asr_drop / unknown. nil → sink
+  // omits the key (e.g. non-transcript outcomes).
+  var tailClipClassification: String? = nil
+  var captureTrailingSilenceMs: Int? = nil
+  var captureTail200Rms: Double? = nil
+  var captureTail200Peak: Double? = nil
+  var asrInputDurationMs: Int? = nil
+  var asrLastTokenEndMs: Int? = nil
+  var asrLastTokenGapMs: Int? = nil
+  var asrChunked: Bool? = nil
 }
 
 struct KernelASRAdapterDiagnostics {

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1313,6 +1313,27 @@ final class RecordingSessionKernel {
       // `WhisperKitPipeline.swift:1161-1168` `asr_s` semantic. Sentry/app.log
       // ASR-completed payload reads this field; PostHog latency telemetry
       // is already adapter-emitted and unaffected.
+      // #1232 tail-clip diagnostics. Pure compute from signals already in hand;
+      // never alters delivery. `asrSamples` is the authoritative decoded buffer
+      // (the token timings come from decoding IT) in two cases: an eligible
+      // Parakeet batch session, OR a streaming session whose finalize fell back
+      // to the batch rescue — the rescue decodes the conditioned `asrSamples`, so
+      // its tokens map onto that timeline (Codex P2). Streaming that returned
+      // text from the live feed, and WhisperKit (decodes its own raw buffer), are
+      // NOT authoritative. In every authoritative case padding would inflate the
+      // gap, so require unpadded (Codex r4).
+      let cameFromBatchRescue =
+        adapter.capabilities.decodesConditionedBatchSamples
+        && (adapter as? ASREngineTelemetryProviding)?
+          .lastASRDiagnostics?.batchRescueAttempted == true
+      let decodedInputAuthoritative =
+        (tailEligible || cameFromBatchRescue) && !conditioned.samplesPaddedToMinimum
+      let decodedInputCount = decodedInputAuthoritative ? asrSamples.count : nil
+      let tailClip = TailClipDiagnostics.compute(
+        rawSamples: captureResult.samples,
+        vadSegments: vadSegments,
+        decodedInputSampleCount: decodedInputCount,
+        lastTokenEndMs: result.tokenTimingSummary?.lastTokenEndMs)
       telemetryState.asrCompletedTelemetry = KernelASRCompletedTelemetry(
         durationSeconds: result.processingTime,
         charCount: result.text.trimmingCharacters(in: .whitespacesAndNewlines).count,
@@ -1330,8 +1351,27 @@ final class RecordingSessionKernel {
         usedTailPreservation: usedTailPreservation,
         recoveredTailMs: recoveredTailMs,
         tailVoicedFraction: tailVoicedFractionForTelemetry,
-        tailRefusedReason: tailRefusedReason
+        tailRefusedReason: tailRefusedReason,
+        tailClipClassification: tailClip.classification.rawValue,
+        captureTrailingSilenceMs: tailClip.trailingSilenceMs,
+        captureTail200Rms: Double(tailClip.tail200RMS),
+        captureTail200Peak: Double(tailClip.tail200Peak),
+        asrInputDurationMs: tailClip.asrInputDurationMs,
+        asrLastTokenEndMs: tailClip.asrLastTokenEndMs,
+        asrLastTokenGapMs: tailClip.asrLastTokenGapMs,
+        asrChunked: tailClip.asrChunked
       )
+      // #1232 debug-log line: the per-dictation tail-clip verdict + lead signals,
+      // greppable in app.log next to the conditioner line for live triage.
+      log(
+        "tailclip class=\(tailClip.classification.rawValue) "
+          + "trailingSilenceMs=\(tailClip.trailingSilenceMs.map(String.init) ?? "n/a") "
+          + "tail200Peak=\(String(format: "%.4f", tailClip.tail200Peak)) "
+          + "tail200Rms=\(String(format: "%.4f", tailClip.tail200RMS)) "
+          + "asrInputMs=\(tailClip.asrInputDurationMs.map(String.init) ?? "n/a") "
+          + "lastTokenEndMs=\(tailClip.asrLastTokenEndMs.map(String.init) ?? "n/a") "
+          + "tokenGapMs=\(tailClip.asrLastTokenGapMs.map(String.init) ?? "n/a") "
+          + "chunked=\(tailClip.asrChunked.map(String.init) ?? "n/a")")
       await runFinalizing(sid, asrText: result.text)
     case .empty(let hadSpeechEvidence):
       mergeAdapterDiagnosticsIntoASREmpty()

--- a/Sources/EnviousWisprPipeline/TailClipDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/TailClipDiagnostics.swift
@@ -1,0 +1,143 @@
+import EnviousWisprCore
+import Foundation
+
+/// Numbers-only end-of-dictation tail-clip diagnostics (#1232).
+///
+/// Classifies a finished dictation as clean / suspected capture-clip /
+/// suspected ASR-drop from signals already in hand at ASR completion, so the
+/// recurring lost-last-words problem can be triaged from logs/telemetry WITHOUT
+/// saving audio. Pure + `nonisolated` so the classifier boundary cases unit-test
+/// without spinning up a kernel. Release-safe: only counts, durations, and
+/// energy — never audio samples or transcript text.
+///
+/// Three host-side signals (the cross-process capture-append counter, "#4", is a
+/// separate follow-up — see docs/feature-requests/plan-2026-06-28-tailclip-measurement4-append-stats.md):
+/// `trailingSilenceMs` is a GATE only (it is ~0 by design whenever speech is
+/// still open at stop, because VAD finalize closes the open segment at the raw
+/// end). The lead discriminators are tail energy (was the buffer still loud at
+/// the very end?) and the ASR last-token gap (did decoded text reach the audio end?).
+struct TailClipDiagnostics: Sendable, Equatable {
+  enum Classification: String, Sendable {
+    case clean
+    case suspectedCaptureClip = "suspected_capture_clip"
+    case suspectedASRDrop = "suspected_asr_drop"
+    case unknown
+  }
+
+  let trailingSilenceMs: Int?
+  let tail200RMS: Float
+  let tail200Peak: Float
+  let tail400RMS: Float
+  let tail400Peak: Float
+  /// Nil unless the decoded ASR input is authoritative (Parakeet batch, unpadded).
+  /// For WhisperKit (decodes its own raw/padded buffer), streaming (live feed),
+  /// and padded-to-minimum short utterances, `asrSamples` is NOT what the engine
+  /// decoded / includes synthetic silence, so these would be wrong — omit.
+  let asrInputDurationMs: Int?
+  let asrLastTokenEndMs: Int?
+  let asrLastTokenGapMs: Int?
+  let asrChunked: Bool?
+  let classification: Classification
+
+  /// 16 samples per millisecond at the 16 kHz ASR sample rate.
+  static let samplesPerMs = 16
+  /// FluidAudio routes audio above this through its multi-window ChunkProcessor
+  /// (`ASRConstants.maxModelSamples`, 240k = 15s). Mirrors that constant.
+  static let chunkThresholdSamples = 240_000
+
+  // MARK: - Classification thresholds (CALIBRATION CANDIDATES — see issue #1232)
+  // Tune from the first 200-500 dogfood dictations.
+  static let gateSilenceMs = 40
+  static let cleanSilenceMs = 150
+  static let tokenGapClipMaxMs = 300
+  static let tokenGapDropMinMs = 500
+
+  /// - Parameter decodedInputSampleCount: the sample count the engine ACTUALLY
+  ///   decoded, or nil when that is not the unpadded conditioned batch buffer
+  ///   (WhisperKit, streaming, padded short utterance) — ASR-input fields omitted.
+  static func compute(
+    rawSamples: [Float],
+    vadSegments: [SpeechSegment],
+    decodedInputSampleCount: Int?,
+    lastTokenEndMs: Int?
+  ) -> TailClipDiagnostics {
+    let rawCount = rawSamples.count
+
+    let trailingSilenceMs: Int?
+    if let lastEnd = vadSegments.map(\.endSample).max() {
+      trailingSilenceMs = max(0, (rawCount - lastEnd) / samplesPerMs)
+    } else {
+      trailingSilenceMs = nil
+    }
+
+    let (rms200, peak200) = energy(of: rawSamples.suffix(200 * samplesPerMs))
+    let tail400 = Array(rawSamples.suffix(400 * samplesPerMs))
+    let (rms400, peak400) = energy(of: tail400[...])
+    // Dead-air verdict over the 400ms tail via the SHARED #964 helper, so it
+    // checks peak, whole-slice RMS, AND the loudest-40ms-window RMS. A faint
+    // last word concentrated in one window stays below the whole-slice RMS/peak
+    // floors but lifts a local window — the scalar-only check would have hidden
+    // that clip as `.clean` (Codex P2). Delegating keeps this from drifting from
+    // the no-speech gate.
+    let tailIsDeadAir = RecordingSessionKernel.rawAudioIsDeadAir(tail400, peak: peak400)
+
+    let asrInputDurationMs = decodedInputSampleCount.map { $0 / samplesPerMs }
+    let gapMs: Int? =
+      asrInputDurationMs.flatMap { dur in lastTokenEndMs.map { Swift.max(0, dur - $0) } }
+    let chunked = decodedInputSampleCount.map { $0 > chunkThresholdSamples }
+
+    let classification = classify(
+      trailingSilenceMs: trailingSilenceMs,
+      tailIsDeadAir: tailIsDeadAir,
+      lastTokenGapMs: gapMs)
+
+    return TailClipDiagnostics(
+      trailingSilenceMs: trailingSilenceMs,
+      tail200RMS: rms200, tail200Peak: peak200,
+      tail400RMS: rms400, tail400Peak: peak400,
+      asrInputDurationMs: asrInputDurationMs,
+      asrLastTokenEndMs: lastTokenEndMs,
+      asrLastTokenGapMs: gapMs,
+      asrChunked: chunked,
+      classification: classification)
+  }
+
+  /// Pure classifier. `tailIsDeadAir` is the shared #964 dead-air verdict over
+  /// the tail slice (computed in `compute`), so this never drifts from the
+  /// no-speech gate.
+  static func classify(
+    trailingSilenceMs: Int?,
+    tailIsDeadAir: Bool,
+    lastTokenGapMs: Int?
+  ) -> Classification {
+    // Clean: a clear trailing-silence cushion means the user finished and paused.
+    if let ts = trailingSilenceMs, ts >= cleanSilenceMs { return .clean }
+    // Clean: a dead-air tail (no recoverable energy in the last 400ms) — nothing was cut.
+    if tailIsDeadAir { return .clean }
+
+    // Past here the tail is energetic. The gate requires the buffer to actually
+    // end on speech (little/no trailing silence); without a VAD segment we
+    // cannot establish the gate, so we cannot accuse the capture/decode.
+    guard let ts = trailingSilenceMs, ts <= gateSilenceMs else { return .unknown }
+
+    // Discriminate by how far the decoded text reached vs the audio end.
+    if let gap = lastTokenGapMs {
+      if gap <= tokenGapClipMaxMs { return .suspectedCaptureClip }
+      if gap >= tokenGapDropMinMs { return .suspectedASRDrop }
+    }
+    return .unknown
+  }
+
+  /// RMS + peak of a sample slice. Empty slice → zeros.
+  static func energy(of slice: ArraySlice<Float>) -> (rms: Float, peak: Float) {
+    guard !slice.isEmpty else { return (0, 0) }
+    var sumSquares: Float = 0
+    var peak: Float = 0
+    for s in slice {
+      sumSquares += s * s
+      peak = Swift.max(peak, Swift.abs(s))
+    }
+    let rms = (sumSquares / Float(slice.count)).squareRoot()
+    return (rms, peak)
+  }
+}

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -119,7 +119,12 @@ public final class TelemetryService {
         latencySeconds: asrLat, charCount: t.text.count,
         tailDroppedMs: m?.tailDroppedMs, tailHadEnergy: m?.tailHadEnergy,
         usedTailPreservation: m?.usedTailPreservation, recoveredTailMs: m?.recoveredTailMs,
-        tailVoicedFraction: m?.tailVoicedFraction, tailRefusedReason: m?.tailRefusedReason)
+        tailVoicedFraction: m?.tailVoicedFraction, tailRefusedReason: m?.tailRefusedReason,
+        tailClipClass: m?.tailClipClassification,
+        captureTrailingSilenceMs: m?.captureTrailingSilenceMs,
+        captureTail200Rms: m?.captureTail200Rms, captureTail200Peak: m?.captureTail200Peak,
+        asrInputDurationMs: m?.asrInputDurationMs, asrLastTokenEndMs: m?.asrLastTokenEndMs,
+        asrLastTokenGapMs: m?.asrLastTokenGapMs, asrChunked: m?.asrChunked)
     }
     if let llmLat = m?.llmLatencySeconds, llmLat > 0, t.llmProvider != nil {
       llmPolishCompleted(
@@ -683,7 +688,14 @@ public final class TelemetryService {
     // `tailPreservedMs` = ms appended back; `tailVoicedFraction` = sustained-voice
     // ratio; `tailRefusedReason` = why an eligible tail was refused. Metadata only.
     usedTailPreservation: Bool? = nil, recoveredTailMs: Int? = nil,
-    tailVoicedFraction: Double? = nil, tailRefusedReason: String? = nil
+    tailVoicedFraction: Double? = nil, tailRefusedReason: String? = nil,
+    // #1232 tail-clip telemetry (omit-on-nil; numbers/booleans only — no audio
+    // or text). `tailClipClass` = clean / suspected_capture_clip /
+    // suspected_asr_drop / unknown; the rest are the classifier's lead signals.
+    tailClipClass: String? = nil, captureTrailingSilenceMs: Int? = nil,
+    captureTail200Rms: Double? = nil, captureTail200Peak: Double? = nil,
+    asrInputDurationMs: Int? = nil, asrLastTokenEndMs: Int? = nil,
+    asrLastTokenGapMs: Int? = nil, asrChunked: Bool? = nil
   ) {
     var properties: [String: Any] = [
       "backend": backend,
@@ -699,6 +711,16 @@ public final class TelemetryService {
     if let recoveredTailMs { properties["tail_preserved_ms"] = recoveredTailMs }
     if let tailVoicedFraction { properties["tail_voiced_fraction"] = tailVoicedFraction }
     if let tailRefusedReason { properties["tail_refused_reason"] = tailRefusedReason }
+    if let tailClipClass { properties["tail_clip_class"] = tailClipClass }
+    if let captureTrailingSilenceMs {
+      properties["capture_trailing_silence_ms"] = captureTrailingSilenceMs
+    }
+    if let captureTail200Rms { properties["capture_tail_200_rms"] = captureTail200Rms }
+    if let captureTail200Peak { properties["capture_tail_200_peak"] = captureTail200Peak }
+    if let asrInputDurationMs { properties["asr_input_duration_ms"] = asrInputDurationMs }
+    if let asrLastTokenEndMs { properties["asr_last_token_end_ms"] = asrLastTokenEndMs }
+    if let asrLastTokenGapMs { properties["asr_last_token_gap_ms"] = asrLastTokenGapMs }
+    if let asrChunked { properties["asr_chunked"] = asrChunked }
     PostHogSDK.shared.capture("asr.completed", properties: properties)
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/TailClipDiagnosticsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TailClipDiagnosticsTests.swift
@@ -1,0 +1,160 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+@Suite("Tail-clip diagnostics (#1232) — classifier + compute boundaries")
+struct TailClipDiagnosticsTests {
+
+  // MARK: - clean
+
+  @Test("Clean: trailing silence >= 150ms wins regardless of tail energy")
+  func cleanBySilence() {
+    #expect(
+      TailClipDiagnostics.classify(
+        trailingSilenceMs: 150, tailIsDeadAir: false, lastTokenGapMs: 0) == .clean)
+  }
+
+  @Test("Clean: dead-air tail even with zero trailing silence")
+  func cleanByDeadAir() {
+    #expect(
+      TailClipDiagnostics.classify(
+        trailingSilenceMs: 0, tailIsDeadAir: true, lastTokenGapMs: 0) == .clean)
+  }
+
+  // MARK: - suspected capture clip
+
+  @Test("Capture clip: gate satisfied + token gap at the <=300 boundary")
+  func clipByTokenGapBoundary() {
+    #expect(
+      TailClipDiagnostics.classify(
+        trailingSilenceMs: 0, tailIsDeadAir: false, lastTokenGapMs: 300)
+        == .suspectedCaptureClip)
+  }
+
+  @Test("Capture clip: gate satisfied at 40ms boundary + small token gap")
+  func clipAtGateBoundary() {
+    #expect(
+      TailClipDiagnostics.classify(
+        trailingSilenceMs: 40, tailIsDeadAir: false, lastTokenGapMs: 100)
+        == .suspectedCaptureClip)
+  }
+
+  // MARK: - suspected ASR drop
+
+  @Test("ASR drop: gate satisfied, token gap at the >=500 boundary")
+  func dropByTokenGapBoundary() {
+    #expect(
+      TailClipDiagnostics.classify(
+        trailingSilenceMs: 0, tailIsDeadAir: false, lastTokenGapMs: 500)
+        == .suspectedASRDrop)
+  }
+
+  // MARK: - unknown
+
+  @Test("Unknown: gate satisfied but token gap in the ambiguous (300,500) band")
+  func unknownAmbiguousGap() {
+    #expect(
+      TailClipDiagnostics.classify(
+        trailingSilenceMs: 0, tailIsDeadAir: false, lastTokenGapMs: 400) == .unknown)
+  }
+
+  @Test(
+    "Unknown: energetic tail but no VAD segment (nil trailing silence) cannot establish the gate")
+  func unknownNoGate() {
+    #expect(
+      TailClipDiagnostics.classify(
+        trailingSilenceMs: nil, tailIsDeadAir: false, lastTokenGapMs: 100)
+        == .unknown)
+  }
+
+  @Test("Unknown: gate satisfied, energetic tail, but no token gap available")
+  func unknownNoGap() {
+    #expect(
+      TailClipDiagnostics.classify(
+        trailingSilenceMs: 0, tailIsDeadAir: false, lastTokenGapMs: nil) == .unknown)
+  }
+
+  @Test("Gate boundary: trailing silence just over the gate (41ms) with small gap is unknown")
+  func gateJustAbove() {
+    #expect(
+      TailClipDiagnostics.classify(
+        trailingSilenceMs: 41, tailIsDeadAir: false, lastTokenGapMs: 100)
+        == .unknown)
+  }
+
+  // MARK: - compute()
+
+  @Test("compute: trailing silence = (rawCount - lastVadEnd) / 16, and energetic tail")
+  func computeTrailingSilence() {
+    var raw = [Float](repeating: 0.03, count: 16000)  // 1000ms
+    raw[15999] = 0.2
+    let segs = [SpeechSegment(startSample: 0, endSample: 15040)]  // 960 samples tail = 60ms
+    let d = TailClipDiagnostics.compute(
+      rawSamples: raw, vadSegments: segs, decodedInputSampleCount: 16000, lastTokenEndMs: nil)
+    #expect(d.trailingSilenceMs == 60)
+    #expect(d.tail200Peak > RecordingSessionKernel.DeadAirFloor.peak)
+  }
+
+  @Test("compute: token gap = inputDuration - lastTokenEnd; chunked threshold")
+  func computeTokenGapAndChunk() {
+    let raw = [Float](repeating: 0.0, count: 100)
+    let d = TailClipDiagnostics.compute(
+      rawSamples: raw, vadSegments: [], decodedInputSampleCount: 320_000, lastTokenEndMs: 19000)
+    #expect(d.asrInputDurationMs == 20000)
+    #expect(d.asrLastTokenGapMs == 1000)
+    #expect(d.asrChunked == true)
+    #expect(d.trailingSilenceMs == nil)
+  }
+
+  @Test("compute: negative raw token gap is clamped to zero")
+  func computeGapClamped() {
+    let raw = [Float](repeating: 0.0, count: 100)
+    let d = TailClipDiagnostics.compute(
+      rawSamples: raw, vadSegments: [], decodedInputSampleCount: 16000, lastTokenEndMs: 1100)
+    #expect(d.asrLastTokenGapMs == 0)
+  }
+
+  @Test(
+    "compute: non-authoritative decoded input (WhisperKit/streaming/padded) omits ASR-input fields")
+  func computeOmitsAsrFieldsWhenNotAuthoritative() {
+    let raw = [Float](repeating: 0.0, count: 100)
+    let d = TailClipDiagnostics.compute(
+      rawSamples: raw, vadSegments: [], decodedInputSampleCount: nil, lastTokenEndMs: 5000)
+    #expect(d.asrInputDurationMs == nil)
+    #expect(d.asrChunked == nil)
+    #expect(d.asrLastTokenGapMs == nil)
+  }
+
+  // Codex P2 regression: a faint last word concentrated in ONE 40ms window has
+  // peak and whole-400ms-slice RMS below the dead-air floors, but its local
+  // window RMS clears `windowRms` — so the shared #964 helper reports NOT
+  // dead-air and the clip is no longer hidden as `.clean`. With the gate
+  // satisfied and a small token gap, it classifies as a suspected capture clip.
+  @Test("compute: faint last word in one window is NOT dead-air (window-RMS catch)")
+  func computeFaintTailWindowRmsCatch() {
+    // 400ms tail = 6400 samples, silent except the final 640-sample (40ms)
+    // window at 0.003: window RMS 0.003 >= 0.002 floor; whole-slice RMS
+    // ~0.00095 < 0.00125; peak 0.003 < 0.006 → only the window check trips.
+    var raw = [Float](repeating: 0.0, count: 6400)
+    for i in 5760..<6400 { raw[i] = 0.003 }
+    let segs = [SpeechSegment(startSample: 0, endSample: 6400)]  // trailing silence 0 → gate satisfied
+    let d = TailClipDiagnostics.compute(
+      rawSamples: raw, vadSegments: segs, decodedInputSampleCount: 6400, lastTokenEndMs: 300)
+    #expect(d.trailingSilenceMs == 0)
+    // The scalar-only check (peak + whole-400ms RMS) would have called this
+    // dead air — both clear the floor — yet the loudest-window RMS does not.
+    #expect(d.tail400Peak < RecordingSessionKernel.DeadAirFloor.peak)
+    #expect(d.tail400RMS < RecordingSessionKernel.DeadAirFloor.rms)
+    #expect(d.asrLastTokenGapMs == 100)
+    #expect(d.classification == .suspectedCaptureClip)
+  }
+
+  @Test("energy: empty slice returns zeros")
+  func energyEmpty() {
+    let (rms, peak) = TailClipDiagnostics.energy(of: [Float]().suffix(0))
+    #expect(rms == 0)
+    #expect(peak == 0)
+  }
+}


### PR DESCRIPTION
## What

Step 1 of the end-of-dictation clipping investigation (#1099): release-safe, zero-latency, host-side-only telemetry that labels **every** dictation `clean` / `suspected_capture_clip` / `suspected_asr_drop` / `unknown` from signals already in hand at ASR completion. No audio retained, no XPC change, nothing on the heart path.

Lets us triage the recurring lost-last-words problem from logs/telemetry **without** saving recordings, and answers the chunking question raised in #1099 (the last-token gap detects a transcriber-side drop).

## Three host-side measurements

1. **Trailing silence** at the buffer end (a GATE only — ~0 by design when speech is still open at stop) + **tail 200/400ms RMS/peak energy** → was the recording still loud at the very end (mic cut) vs faded to quiet (clean)?
2. **ASR last-token-end gap** — FluidAudio token timings (previously dropped at `ParakeetBackend`) threaded through `ASRResult`; compares where the last decoded word landed vs where the audio ended → did the transcriber drop the tail?
3. Authoritative **only** for unpadded Parakeet-batch decode (incl. streaming sessions rescued by batch); omitted for WhisperKit / live-streaming / padded-short utterances (would report a wrong timeline).

Emitted at `app.log`, the Sentry ASR breadcrumb, the PostHog `asr.completed` event, and `ExecutionMetrics`.

## Scope note

The 4th signal (cross-process capture-append counters) was pulled out — it fought the heart-path-sacred constraint over 5 Codex rounds and belongs in an atomic stop-payload redesign. Deferred to **#1233** with a written plan; the three host-side signals already distinguish mic-cut vs transcriber-drop.

## Validation

- Codex diff review: 2 rounds, clean (round 1 found + fixed faint-tail dead-air shortcut and streaming-batch-rescue authoritativeness).
- Logic-test gate: **2,133 tests pass** (`scripts/xcode-test.sh`); 15 classifier boundary tests incl. a window-RMS regression test.
- Live UAT (Parakeet batch): `tailclip class=… asrInputMs=5129 lastTokenEndMs=4640 tokenGapMs=489` — token timings confirmed populating end-to-end; ASR 90ms, no latency regression.

Thresholds are calibration candidates (tune from the first 200-500 dogfood dictations).

Closes #1232