### PR TITLE
chore(ci): retire content-engine/ references (Phase 3g)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,7 +193,6 @@ scripts/eval/corpus/alias-holdout-private.jsonl
 scripts/freeze-suite/compare-output.json
 scripts/freeze-suite/variance-log.jsonl
 docs/
-content-engine/
 Brand Assets/
 .beads/
 workers/weekly-digest/.wrangler/

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -17,8 +17,8 @@
 #
 # Classify contract (lifted VERBATIM from the pre-#1151 inline step):
 #   - a change to pr-check.yml / main-post-merge.yml self-forces a full build
-#   - any path outside (website/ docs/ .github/ content-engine/ .claude/
-#     CLAUDE.md) forces a full build
+#   - any path outside (website/ docs/ .github/ .claude/ CLAUDE.md) forces a
+#     full build
 #   - otherwise content-only -> skip
 #   Empty input -> true: the here-string feeds grep one blank line, which is
 #   NOT excluded, so the verbatim classifier over-builds. Preserved as-is; an
@@ -34,7 +34,7 @@ classify() {
   if grep -qE '^\.github/workflows/(pr-check|main-post-merge)\.yml$' <<<"$changed"; then
     printf 'needs_build=true\n' >>"$GITHUB_OUTPUT"
     echo "==> CI build workflow changed — full Xcode build required"
-  elif grep -qvE '^(website/|docs/|\.github/|content-engine/|\.claude/|CLAUDE\.md)' <<<"$changed"; then
+  elif grep -qvE '^(website/|docs/|\.github/|\.claude/|CLAUDE\.md)' <<<"$changed"; then
     printf 'needs_build=true\n' >>"$GITHUB_OUTPUT"
     echo "==> Swift source changes detected — full Xcode build required"
   else

--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -81,7 +81,7 @@ detect_lane_from_diff() {
   if echo "$changed_files" | grep -qE '^(Sources/|Tests/|Package\.swift|Package\.resolved|Project\.swift|Tuist\.swift|Workspace\.swift|Tuist/)'; then
     lanes="$lanes Code"
   fi
-  if echo "$changed_files" | grep -qE '^(website/|assets/|content-engine/)'; then
+  if echo "$changed_files" | grep -qE '^(website/|assets/)'; then
     lanes="$lanes Content"
   fi
   if echo "$changed_files" | grep -qE '^\.github/workflows/|dependabot'; then


### PR DESCRIPTION
## What

Removes the now-inert `content-engine/` references from the CI classifier, the PR
lane detector, and `.gitignore`. The `content-engine/` workspace has been **deleted**:
its marketing method moved into the cross-product EnviousMarketing engine in Phase 2,
and its two lasting record types (directory listings + follow-up outreach touches)
were migrated into the EnviousMarketing database in Phase 3g. Nothing references the
folder anymore, so these three pointers are dead.

## Why it's safe

- **No behavior change.** Every edit removes a path token for a directory that can no
  longer exist, so no real change set can match it.
- **Classifier self-test PASS** (`scripts/ci/classify-changes.sh --self-test`) — it
  exercises the exact regex edited.
- Local `codex review` clean; `bash -n` clean on both scripts.
- Historical mentions under `docs/` and `.validation/` (audit/plan prose committed
  before those paths were gitignored) are immutable records and intentionally left.

## Lane / process

Code lane (CI scripts are tracked). `council-skip: zero-blast-radius (CI dead-ref
removal; the classifier's own self-test validates the edited regex)`. 4 lines, 3 files.