### PR TITLE
feat(telemetry): recalibrate tail-clip diagnostics — ASR-tail-drop detector, drop inverted capture-clip label (#1236)

### DIFF
--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -59,11 +59,12 @@ public struct ExecutionMetrics: Codable, Sendable {
   public var recoveredTailMs: Int?
   public var tailVoicedFraction: Double?
   public var tailRefusedReason: String?
-  /// #1232 tail-clip telemetry: release-safe classifier + lead signals carried
-  /// onto `asr.completed`. Numbers/booleans only — no audio or text. All optional
-  /// (additive Codable, back-compatible with pre-#1232 transcripts on disk).
-  /// `tailClipClassification` = clean / suspected_capture_clip /
-  /// suspected_asr_drop / unknown.
+  /// #1232 tail-clip telemetry (recalibrated #1236): release-safe classifier + lead
+  /// signals carried onto `asr.completed`. Numbers/booleans only — no audio or text.
+  /// All optional (additive Codable, back-compatible with pre-#1232 transcripts on
+  /// disk). `tailClipClassification` = asr_complete / suspected_asr_drop / unknown.
+  /// `asrLastTokenGapMs` = untranscribed tail on the decoded timeline (headline
+  /// ASR-drop metric).
   public var tailClipClassification: String?
   public var captureTrailingSilenceMs: Int?
   public var captureTail200Rms: Double?

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -78,10 +78,11 @@ struct KernelASRCompletedTelemetry {
   var recoveredTailMs: Int? = nil
   var tailVoicedFraction: Double? = nil
   var tailRefusedReason: String? = nil
-  // #1232 tail-clip telemetry: release-safe classifier + lead signals. All
-  // numbers/booleans, no audio or text. `tailClipClassification` is one of
-  // clean / suspected_capture_clip / suspected_asr_drop / unknown. nil → sink
-  // omits the key (e.g. non-transcript outcomes).
+  // #1232 tail-clip telemetry (recalibrated #1236): release-safe classifier + lead
+  // signals. All numbers/booleans, no audio or text. `tailClipClassification` is one
+  // of asr_complete / suspected_asr_drop / unknown. `asrLastTokenGapMs` is the
+  // headline drop metric (untranscribed tail on the decoded timeline). nil → sink
+  // omits the key.
   var tailClipClassification: String? = nil
   var captureTrailingSilenceMs: Int? = nil
   var captureTail200Rms: Double? = nil

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1326,8 +1326,20 @@ final class RecordingSessionKernel {
         adapter.capabilities.decodesConditionedBatchSamples
         && (adapter as? ASREngineTelemetryProviding)?
           .lastASRDiagnostics?.batchRescueAttempted == true
+      // The token gap is trustworthy ONLY when the decoded buffer was the VAD-trimmed
+      // SPEECH buffer. Every raw-fed path (too-aggressive raw fallback, soft-onset raw
+      // preservation, padding, or a SampleFilter no-op on empty/sub-threshold segments)
+      // leaves raw trailing silence/noise, so the gap would mislabel a normal dictation
+      // as a drop (cloud + local Codex P2, #1238). Pass nil there so the classifier
+      // sees no gap and returns .unknown.
+      let decodedTailVadConfirmed = TailClipDiagnostics.decodedTailIsVadConfirmed(
+        usedRawFallbackAfterVAD: conditioned.usedRawFallbackAfterVAD,
+        usedRawSoftOnsetPreservation: conditioned.usedRawSoftOnsetPreservation,
+        samplesPaddedToMinimum: conditioned.samplesPaddedToMinimum,
+        filteredSampleCount: conditioned.filteredSampleCount,
+        rawSampleCount: captureResult.samples.count)
       let decodedInputAuthoritative =
-        (tailEligible || cameFromBatchRescue) && !conditioned.samplesPaddedToMinimum
+        (tailEligible || cameFromBatchRescue) && decodedTailVadConfirmed
       let decodedInputCount = decodedInputAuthoritative ? asrSamples.count : nil
       let tailClip = TailClipDiagnostics.compute(
         rawSamples: captureResult.samples,

--- a/Sources/EnviousWisprPipeline/TailClipDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/TailClipDiagnostics.swift
@@ -1,26 +1,47 @@
 import EnviousWisprCore
 import Foundation
 
-/// Numbers-only end-of-dictation tail-clip diagnostics (#1232).
+/// Numbers-only end-of-dictation tail-clip diagnostics (#1232, recalibrated #1236).
 ///
-/// Classifies a finished dictation as clean / suspected capture-clip /
-/// suspected ASR-drop from signals already in hand at ASR completion, so the
-/// recurring lost-last-words problem can be triaged from logs/telemetry WITHOUT
-/// saving audio. Pure + `nonisolated` so the classifier boundary cases unit-test
-/// without spinning up a kernel. Release-safe: only counts, durations, and
-/// energy — never audio samples or transcript text.
+/// Labels a finished dictation `asr_complete` / `suspected_asr_drop` / `unknown`
+/// from signals already in hand at ASR completion, so the recurring lost-last-words
+/// problem can be triaged from logs/telemetry WITHOUT saving audio. Pure +
+/// `nonisolated` so the boundary cases unit-test without a kernel. Release-safe:
+/// only counts, durations, and energy — never audio samples or transcript text.
 ///
-/// Three host-side signals (the cross-process capture-append counter, "#4", is a
-/// separate follow-up — see docs/feature-requests/plan-2026-06-28-tailclip-measurement4-append-stats.md):
-/// `trailingSilenceMs` is a GATE only (it is ~0 by design whenever speech is
-/// still open at stop, because VAD finalize closes the open segment at the raw
-/// end). The lead discriminators are tail energy (was the buffer still loud at
-/// the very end?) and the ASR last-token gap (did decoded text reach the audio end?).
+/// HONEST SCOPE (validated empirically 2026-06-28 + GPT/Gemini council + Codex):
+/// these host-side signals detect ONLY an **ASR/chunking tail drop** — audio that
+/// WAS captured and fed to the decoder but never emitted as tokens (the live #1099
+/// repro: a 30s chunked dictation, last token at 27.76s of 30.58s of input). A true
+/// **capture-layer clip** (the mic delivered-but-not-appended race) is INVISIBLE
+/// here: truncated audio makes the decoder reach the truncated end with a tiny gap,
+/// indistinguishable from a clean stop. Detecting that needs the deferred
+/// delivered-vs-appended counters (#1233). So `asr_complete` means "the decoder
+/// transcribed through the end of the audio it was given" — it does NOT certify the
+/// capture layer.
+///
+/// The earlier `suspected_capture_clip` label was REMOVED (#1236): a small token gap
+/// means the decoder reached the end = healthy, so flagging it as a capture clip was
+/// inverted and fired on ~100% of normal dictations. `trailingSilenceMs` is a raw
+/// covariate only — it is ~0 by construction whenever speech is open at stop (VAD
+/// finalize closes the open segment at the raw end), so it never gates.
+///
+/// Lead discriminator: the ASR token gap (`asrInputDurationMs - lastTokenEndMs`). The
+/// decoded input is the VAD-FILTERED buffer (trailing silence already trimmed before
+/// decode), so the gap is already "untranscribed SPEAKING at the tail" — do NOT
+/// subtract `trailingSilenceMs`, which lives on the raw-capture timeline and would
+/// cancel a real drop (Codex P2, #1236). Tail energy is the covariate: a large gap
+/// with a DEAD-AIR tail is natural trailing silence (complete), not a drop.
 struct TailClipDiagnostics: Sendable, Equatable {
   enum Classification: String, Sendable {
-    case clean
-    case suspectedCaptureClip = "suspected_capture_clip"
+    /// The decoder transcribed through the end of the captured audio. Does NOT
+    /// certify the capture layer (a mic-cut clip looks identical — see #1233).
+    case asrComplete = "asr_complete"
+    /// Energetic speech remained after the last transcribed word — the decoder
+    /// dropped the tail (the #1099 ASR/chunking drop).
     case suspectedASRDrop = "suspected_asr_drop"
+    /// Not enough authoritative signal to judge (non-Parakeet-batch decode, or the
+    /// gray band between the thresholds).
     case unknown
   }
 
@@ -35,6 +56,8 @@ struct TailClipDiagnostics: Sendable, Equatable {
   /// decoded / includes synthetic silence, so these would be wrong — omit.
   let asrInputDurationMs: Int?
   let asrLastTokenEndMs: Int?
+  /// The ASR token gap on the decoded (VAD-filtered) timeline = untranscribed
+  /// speaking at the tail. The headline ASR-drop metric. Nil when not authoritative.
   let asrLastTokenGapMs: Int?
   let asrChunked: Bool?
   let classification: Classification
@@ -45,12 +68,14 @@ struct TailClipDiagnostics: Sendable, Equatable {
   /// (`ASRConstants.maxModelSamples`, 240k = 15s). Mirrors that constant.
   static let chunkThresholdSamples = 240_000
 
-  // MARK: - Classification thresholds (CALIBRATION CANDIDATES — see issue #1232)
-  // Tune from the first 200-500 dogfood dictations.
-  static let gateSilenceMs = 40
-  static let cleanSilenceMs = 150
-  static let tokenGapClipMaxMs = 300
-  static let tokenGapDropMinMs = 500
+  // MARK: - Classification thresholds (CALIBRATION CANDIDATES — see #1236)
+  // Empirical 2026-06-28: clean dictations sat at untranscribed-tail 0-185ms; the
+  // one real drop at 2825ms; a marginal synthetic at 556ms. Tune from the first
+  // 200-500 dogfood dictations once the recalibrated signal accumulates.
+  /// At/under this much untranscribed speaking tail, the decoder reached the end.
+  static let asrCompleteMaxMs = 250
+  /// At/over this much energetic untranscribed tail, the decoder dropped it.
+  static let asrDropMinMs = 500
 
   /// - Parameter decodedInputSampleCount: the sample count the engine ACTUALLY
   ///   decoded, or nil when that is not the unpadded conditioned batch buffer
@@ -73,23 +98,23 @@ struct TailClipDiagnostics: Sendable, Equatable {
     let (rms200, peak200) = energy(of: rawSamples.suffix(200 * samplesPerMs))
     let tail400 = Array(rawSamples.suffix(400 * samplesPerMs))
     let (rms400, peak400) = energy(of: tail400[...])
-    // Dead-air verdict over the 400ms tail via the SHARED #964 helper, so it
-    // checks peak, whole-slice RMS, AND the loudest-40ms-window RMS. A faint
-    // last word concentrated in one window stays below the whole-slice RMS/peak
-    // floors but lifts a local window — the scalar-only check would have hidden
-    // that clip as `.clean` (Codex P2). Delegating keeps this from drifting from
-    // the no-speech gate.
+    // Dead-air verdict over the 400ms tail via the SHARED #964 helper (peak,
+    // whole-slice RMS, AND loudest-40ms-window RMS) — the covariate that separates
+    // a genuine ASR drop (energetic tail) from a user trailing off into silence
+    // (dead-air tail), without drifting from the no-speech gate.
     let tailIsDeadAir = RecordingSessionKernel.rawAudioIsDeadAir(tail400, peak: peak400)
 
     let asrInputDurationMs = decodedInputSampleCount.map { $0 / samplesPerMs }
+    // The gap is measured on the decoded (VAD-filtered) timeline; do NOT subtract
+    // raw trailingSilenceMs — the filtered buffer already excludes it, and mixing
+    // timelines would cancel a real drop (Codex P2, #1236).
     let gapMs: Int? =
       asrInputDurationMs.flatMap { dur in lastTokenEndMs.map { Swift.max(0, dur - $0) } }
     let chunked = decodedInputSampleCount.map { $0 > chunkThresholdSamples }
 
     let classification = classify(
-      trailingSilenceMs: trailingSilenceMs,
-      tailIsDeadAir: tailIsDeadAir,
-      lastTokenGapMs: gapMs)
+      lastTokenGapMs: gapMs,
+      tailIsDeadAir: tailIsDeadAir)
 
     return TailClipDiagnostics(
       trailingSilenceMs: trailingSilenceMs,
@@ -102,30 +127,22 @@ struct TailClipDiagnostics: Sendable, Equatable {
       classification: classification)
   }
 
-  /// Pure classifier. `tailIsDeadAir` is the shared #964 dead-air verdict over
-  /// the tail slice (computed in `compute`), so this never drifts from the
-  /// no-speech gate.
+  /// Pure classifier. `lastTokenGapMs` is the untranscribed speaking tail on the
+  /// decoded timeline; `tailIsDeadAir` is the shared #964 dead-air verdict.
   static func classify(
-    trailingSilenceMs: Int?,
-    tailIsDeadAir: Bool,
-    lastTokenGapMs: Int?
+    lastTokenGapMs: Int?,
+    tailIsDeadAir: Bool
   ) -> Classification {
-    // Clean: a clear trailing-silence cushion means the user finished and paused.
-    if let ts = trailingSilenceMs, ts >= cleanSilenceMs { return .clean }
-    // Clean: a dead-air tail (no recoverable energy in the last 400ms) — nothing was cut.
-    if tailIsDeadAir { return .clean }
-
-    // Past here the tail is energetic. The gate requires the buffer to actually
-    // end on speech (little/no trailing silence); without a VAD segment we
-    // cannot establish the gate, so we cannot accuse the capture/decode.
-    guard let ts = trailingSilenceMs, ts <= gateSilenceMs else { return .unknown }
-
-    // Discriminate by how far the decoded text reached vs the audio end.
-    if let gap = lastTokenGapMs {
-      if gap <= tokenGapClipMaxMs { return .suspectedCaptureClip }
-      if gap >= tokenGapDropMinMs { return .suspectedASRDrop }
-    }
-    return .unknown
+    // No authoritative token timing (WhisperKit / streaming / padded) — cannot
+    // judge the ASR tail.
+    guard let gap = lastTokenGapMs else { return .unknown }
+    // A dead-air tail means the audio ended in silence: the decoder stopping at
+    // the last spoken word is correct, nothing was dropped, regardless of the gap.
+    if tailIsDeadAir { return .asrComplete }
+    // Energetic tail: the gap is real untranscribed speaking.
+    if gap >= asrDropMinMs { return .suspectedASRDrop }
+    if gap <= asrCompleteMaxMs { return .asrComplete }
+    return .unknown  // gray band between the thresholds
   }
 
   /// RMS + peak of a sample slice. Empty slice → zeros.

--- a/Sources/EnviousWisprPipeline/TailClipDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/TailClipDiagnostics.swift
@@ -128,13 +128,15 @@ struct TailClipDiagnostics: Sendable, Equatable {
   }
 
   /// Pure classifier. `lastTokenGapMs` is the untranscribed speaking tail on the
-  /// decoded timeline; `tailIsDeadAir` is the shared #964 dead-air verdict.
+  /// decoded timeline (nil unless the gap is authoritative — see
+  /// `decodedTailIsVadConfirmed`, enforced kernel-side); `tailIsDeadAir` is the
+  /// shared #964 dead-air verdict.
   static func classify(
     lastTokenGapMs: Int?,
     tailIsDeadAir: Bool
   ) -> Classification {
-    // No authoritative token timing (WhisperKit / streaming / padded) — cannot
-    // judge the ASR tail.
+    // No authoritative token timing (WhisperKit / streaming / padded / raw-fed) —
+    // cannot judge the ASR tail.
     guard let gap = lastTokenGapMs else { return .unknown }
     // A dead-air tail means the audio ended in silence: the decoder stopping at
     // the last spoken word is correct, nothing was dropped, regardless of the gap.
@@ -143,6 +145,35 @@ struct TailClipDiagnostics: Sendable, Equatable {
     if gap >= asrDropMinMs { return .suspectedASRDrop }
     if gap <= asrCompleteMaxMs { return .asrComplete }
     return .unknown  // gray band between the thresholds
+  }
+
+  /// The token gap is a trustworthy "untranscribed speech" signal ONLY when the
+  /// decoded input was the VAD-TRIMMED speech buffer. Every raw-fed conditioning
+  /// path leaves raw trailing silence/noise after the last word, so the gap would
+  /// be measured against unconfirmed audio and could mislabel a normal dictation as
+  /// `suspected_asr_drop` (cloud + local Codex P2, #1238): the too-aggressive raw
+  /// fallback, #843 soft-onset raw preservation, short-utterance padding, and the
+  /// `SampleFilter` no-op for empty/sub-threshold segments (where
+  /// `filteredSampleCount == rawSampleCount`). The kernel passes a nil
+  /// `decodedInputSampleCount` to `compute` whenever this returns false, so the
+  /// classifier sees no gap and returns `.unknown`.
+  ///
+  /// Conservative by design: a fully-voiced edge-to-edge dictation also has
+  /// `filteredSampleCount == rawSampleCount` (nothing to trim) and is treated as
+  /// not-confirmed → `.unknown`. That errs toward losing signal, never toward a
+  /// false `suspected_asr_drop`; such dictations are rare (most have some trimmed
+  /// lead/trail/inter-word silence).
+  static func decodedTailIsVadConfirmed(
+    usedRawFallbackAfterVAD: Bool,
+    usedRawSoftOnsetPreservation: Bool,
+    samplesPaddedToMinimum: Bool,
+    filteredSampleCount: Int,
+    rawSampleCount: Int
+  ) -> Bool {
+    !usedRawFallbackAfterVAD
+      && !usedRawSoftOnsetPreservation
+      && !samplesPaddedToMinimum
+      && filteredSampleCount < rawSampleCount
   }
 
   /// RMS + peak of a sample slice. Empty slice → zeros.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -689,9 +689,10 @@ public final class TelemetryService {
     // ratio; `tailRefusedReason` = why an eligible tail was refused. Metadata only.
     usedTailPreservation: Bool? = nil, recoveredTailMs: Int? = nil,
     tailVoicedFraction: Double? = nil, tailRefusedReason: String? = nil,
-    // #1232 tail-clip telemetry (omit-on-nil; numbers/booleans only — no audio
-    // or text). `tailClipClass` = clean / suspected_capture_clip /
-    // suspected_asr_drop / unknown; the rest are the classifier's lead signals.
+    // #1232 tail-clip telemetry (recalibrated #1236; omit-on-nil; numbers/booleans
+    // only — no audio or text). `tailClipClass` = asr_complete / suspected_asr_drop
+    // / unknown; `asrLastTokenGapMs` = untranscribed-tail drop metric; the rest are
+    // the classifier's lead signals.
     tailClipClass: String? = nil, captureTrailingSilenceMs: Int? = nil,
     captureTail200Rms: Double? = nil, captureTail200Peak: Double? = nil,
     asrInputDurationMs: Int? = nil, asrLastTokenEndMs: Int? = nil,

--- a/Tests/EnviousWisprTests/Pipeline/TailClipDiagnosticsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TailClipDiagnosticsTests.swift
@@ -4,108 +4,90 @@ import Testing
 
 @testable import EnviousWisprPipeline
 
-@Suite("Tail-clip diagnostics (#1232) — classifier + compute boundaries")
+@Suite("Tail-clip diagnostics (#1232/#1236) — recalibrated classifier + compute boundaries")
 struct TailClipDiagnosticsTests {
 
-  // MARK: - clean
+  // MARK: - classify(): asr_complete
 
-  @Test("Clean: trailing silence >= 150ms wins regardless of tail energy")
-  func cleanBySilence() {
+  @Test("asr_complete: token gap at the <=250 boundary, energetic")
+  func completeAtBoundary() {
     #expect(
-      TailClipDiagnostics.classify(
-        trailingSilenceMs: 150, tailIsDeadAir: false, lastTokenGapMs: 0) == .clean)
+      TailClipDiagnostics.classify(lastTokenGapMs: 250, tailIsDeadAir: false) == .asrComplete)
   }
 
-  @Test("Clean: dead-air tail even with zero trailing silence")
-  func cleanByDeadAir() {
+  @Test("asr_complete: a dead-air tail is complete even with a huge gap (user trailed off)")
+  func completeByDeadAirDespiteGap() {
     #expect(
-      TailClipDiagnostics.classify(
-        trailingSilenceMs: 0, tailIsDeadAir: true, lastTokenGapMs: 0) == .clean)
+      TailClipDiagnostics.classify(lastTokenGapMs: 5000, tailIsDeadAir: true) == .asrComplete)
   }
 
-  // MARK: - suspected capture clip
+  // MARK: - classify(): suspected_asr_drop
 
-  @Test("Capture clip: gate satisfied + token gap at the <=300 boundary")
-  func clipByTokenGapBoundary() {
+  @Test("asr_drop: token gap at the >=500 boundary, energetic")
+  func dropAtBoundary() {
     #expect(
-      TailClipDiagnostics.classify(
-        trailingSilenceMs: 0, tailIsDeadAir: false, lastTokenGapMs: 300)
-        == .suspectedCaptureClip)
+      TailClipDiagnostics.classify(lastTokenGapMs: 500, tailIsDeadAir: false) == .suspectedASRDrop)
   }
 
-  @Test("Capture clip: gate satisfied at 40ms boundary + small token gap")
-  func clipAtGateBoundary() {
+  @Test("asr_drop: real-clip magnitude (2825ms energetic tail) is a drop")
+  func dropRealClipMagnitude() {
     #expect(
-      TailClipDiagnostics.classify(
-        trailingSilenceMs: 40, tailIsDeadAir: false, lastTokenGapMs: 100)
-        == .suspectedCaptureClip)
+      TailClipDiagnostics.classify(lastTokenGapMs: 2825, tailIsDeadAir: false) == .suspectedASRDrop)
   }
 
-  // MARK: - suspected ASR drop
+  // MARK: - classify(): unknown
 
-  @Test("ASR drop: gate satisfied, token gap at the >=500 boundary")
-  func dropByTokenGapBoundary() {
+  @Test("unknown: energetic tail in the gray band (250,500)")
+  func unknownGrayBand() {
     #expect(
-      TailClipDiagnostics.classify(
-        trailingSilenceMs: 0, tailIsDeadAir: false, lastTokenGapMs: 500)
-        == .suspectedASRDrop)
+      TailClipDiagnostics.classify(lastTokenGapMs: 400, tailIsDeadAir: false) == .unknown)
   }
 
-  // MARK: - unknown
-
-  @Test("Unknown: gate satisfied but token gap in the ambiguous (300,500) band")
-  func unknownAmbiguousGap() {
-    #expect(
-      TailClipDiagnostics.classify(
-        trailingSilenceMs: 0, tailIsDeadAir: false, lastTokenGapMs: 400) == .unknown)
-  }
-
-  @Test(
-    "Unknown: energetic tail but no VAD segment (nil trailing silence) cannot establish the gate")
-  func unknownNoGate() {
-    #expect(
-      TailClipDiagnostics.classify(
-        trailingSilenceMs: nil, tailIsDeadAir: false, lastTokenGapMs: 100)
-        == .unknown)
-  }
-
-  @Test("Unknown: gate satisfied, energetic tail, but no token gap available")
-  func unknownNoGap() {
-    #expect(
-      TailClipDiagnostics.classify(
-        trailingSilenceMs: 0, tailIsDeadAir: false, lastTokenGapMs: nil) == .unknown)
-  }
-
-  @Test("Gate boundary: trailing silence just over the gate (41ms) with small gap is unknown")
-  func gateJustAbove() {
-    #expect(
-      TailClipDiagnostics.classify(
-        trailingSilenceMs: 41, tailIsDeadAir: false, lastTokenGapMs: 100)
-        == .unknown)
+  @Test("unknown: no authoritative token timing (nil) cannot be judged")
+  func unknownNilGap() {
+    #expect(TailClipDiagnostics.classify(lastTokenGapMs: nil, tailIsDeadAir: false) == .unknown)
+    // nil dominates even if the tail looks dead-air — we still have no gap to judge.
+    #expect(TailClipDiagnostics.classify(lastTokenGapMs: nil, tailIsDeadAir: true) == .unknown)
   }
 
   // MARK: - compute()
 
-  @Test("compute: trailing silence = (rawCount - lastVadEnd) / 16, and energetic tail")
-  func computeTrailingSilence() {
-    var raw = [Float](repeating: 0.03, count: 16000)  // 1000ms
-    raw[15999] = 0.2
-    let segs = [SpeechSegment(startSample: 0, endSample: 15040)]  // 960 samples tail = 60ms
+  @Test("compute: real drop — energetic tail, no trailing silence, large gap → suspected_asr_drop")
+  func computeRealDrop() {
+    let raw = [Float](repeating: 0.03, count: 16000)  // energetic to the end
+    let segs = [SpeechSegment(startSample: 0, endSample: 16000)]  // trailing silence 0
     let d = TailClipDiagnostics.compute(
-      rawSamples: raw, vadSegments: segs, decodedInputSampleCount: 16000, lastTokenEndMs: nil)
-    #expect(d.trailingSilenceMs == 60)
-    #expect(d.tail200Peak > RecordingSessionKernel.DeadAirFloor.peak)
+      rawSamples: raw, vadSegments: segs, decodedInputSampleCount: 16000, lastTokenEndMs: 100)
+    #expect(d.trailingSilenceMs == 0)
+    #expect(d.asrLastTokenGapMs == 900)
+    #expect(d.classification == .suspectedASRDrop)
   }
 
-  @Test("compute: token gap = inputDuration - lastTokenEnd; chunked threshold")
-  func computeTokenGapAndChunk() {
-    let raw = [Float](repeating: 0.0, count: 100)
+  @Test("compute: gap is NOT silence-corrected — raw trailing silence does not cancel a drop")
+  func computeNoSilenceSubtraction() {
+    // Energetic throughout; VAD ends at 8000 of 16000 → raw trailingSilence 500ms.
+    // asrInput 1000ms, last token 300ms → gap 700ms. The gap lives on the decoded
+    // (filtered) timeline, so raw trailing silence must NOT be subtracted (Codex P2):
+    // it stays 700ms → suspected_asr_drop, not hidden as complete.
+    let raw = [Float](repeating: 0.03, count: 16000)
+    let segs = [SpeechSegment(startSample: 0, endSample: 8000)]
+    let d = TailClipDiagnostics.compute(
+      rawSamples: raw, vadSegments: segs, decodedInputSampleCount: 16000, lastTokenEndMs: 300)
+    #expect(d.trailingSilenceMs == 500)
+    #expect(d.asrLastTokenGapMs == 700)
+    #expect(d.classification == .suspectedASRDrop)
+  }
+
+  @Test("compute: dead-air tail is complete even with a large gap; chunked flag set")
+  func computeDeadAirLargeGapChunked() {
+    let raw = [Float](repeating: 0.0, count: 6400)  // silent tail → dead air
     let d = TailClipDiagnostics.compute(
       rawSamples: raw, vadSegments: [], decodedInputSampleCount: 320_000, lastTokenEndMs: 19000)
     #expect(d.asrInputDurationMs == 20000)
     #expect(d.asrLastTokenGapMs == 1000)
     #expect(d.asrChunked == true)
-    #expect(d.trailingSilenceMs == nil)
+    #expect(d.trailingSilenceMs == nil)  // no VAD segment
+    #expect(d.classification == .asrComplete)  // dead-air overrides the large gap
   }
 
   @Test("compute: negative raw token gap is clamped to zero")
@@ -125,30 +107,26 @@ struct TailClipDiagnosticsTests {
     #expect(d.asrInputDurationMs == nil)
     #expect(d.asrChunked == nil)
     #expect(d.asrLastTokenGapMs == nil)
+    #expect(d.classification == .unknown)
   }
 
-  // Codex P2 regression: a faint last word concentrated in ONE 40ms window has
-  // peak and whole-400ms-slice RMS below the dead-air floors, but its local
-  // window RMS clears `windowRms` — so the shared #964 helper reports NOT
-  // dead-air and the clip is no longer hidden as `.clean`. With the gate
-  // satisfied and a small token gap, it classifies as a suspected capture clip.
-  @Test("compute: faint last word in one window is NOT dead-air (window-RMS catch)")
+  // Window-RMS catch (#964 helper) still matters under the new model: a faint last
+  // word concentrated in one 40ms window stays below the whole-slice peak/RMS floors
+  // but lifts a local window, so the tail is NOT dead-air. With a large gap that
+  // routes to suspected_asr_drop; were it mistaken for dead-air it would be wrongly
+  // called asr_complete.
+  @Test("compute: faint last word in one window is NOT dead-air → energetic drop path")
   func computeFaintTailWindowRmsCatch() {
-    // 400ms tail = 6400 samples, silent except the final 640-sample (40ms)
-    // window at 0.003: window RMS 0.003 >= 0.002 floor; whole-slice RMS
-    // ~0.00095 < 0.00125; peak 0.003 < 0.006 → only the window check trips.
-    var raw = [Float](repeating: 0.0, count: 6400)
-    for i in 5760..<6400 { raw[i] = 0.003 }
-    let segs = [SpeechSegment(startSample: 0, endSample: 6400)]  // trailing silence 0 → gate satisfied
+    var raw = [Float](repeating: 0.0, count: 16000)
+    for i in 15360..<16000 { raw[i] = 0.003 }  // faint 40ms window at the very end
+    let segs = [SpeechSegment(startSample: 0, endSample: 16000)]  // trailing silence 0
     let d = TailClipDiagnostics.compute(
-      rawSamples: raw, vadSegments: segs, decodedInputSampleCount: 6400, lastTokenEndMs: 300)
-    #expect(d.trailingSilenceMs == 0)
-    // The scalar-only check (peak + whole-400ms RMS) would have called this
-    // dead air — both clear the floor — yet the loudest-window RMS does not.
+      rawSamples: raw, vadSegments: segs, decodedInputSampleCount: 16000, lastTokenEndMs: 300)
+    // The scalar-only check (peak + whole-400ms RMS) would have called this dead air.
     #expect(d.tail400Peak < RecordingSessionKernel.DeadAirFloor.peak)
     #expect(d.tail400RMS < RecordingSessionKernel.DeadAirFloor.rms)
-    #expect(d.asrLastTokenGapMs == 100)
-    #expect(d.classification == .suspectedCaptureClip)
+    #expect(d.asrLastTokenGapMs == 700)
+    #expect(d.classification == .suspectedASRDrop)
   }
 
   @Test("energy: empty slice returns zeros")

--- a/Tests/EnviousWisprTests/Pipeline/TailClipDiagnosticsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TailClipDiagnosticsTests.swift
@@ -43,14 +43,49 @@ struct TailClipDiagnosticsTests {
       TailClipDiagnostics.classify(lastTokenGapMs: 400, tailIsDeadAir: false) == .unknown)
   }
 
-  @Test("unknown: no authoritative token timing (nil) cannot be judged")
+  @Test("unknown: no authoritative token gap (nil — non-batch, raw-fed, padded) cannot be judged")
   func unknownNilGap() {
     #expect(TailClipDiagnostics.classify(lastTokenGapMs: nil, tailIsDeadAir: false) == .unknown)
     // nil dominates even if the tail looks dead-air — we still have no gap to judge.
     #expect(TailClipDiagnostics.classify(lastTokenGapMs: nil, tailIsDeadAir: true) == .unknown)
   }
 
-  // MARK: - compute()
+  // MARK: - decodedTailIsVadConfirmed(): the kernel gate that nils the gap on raw-fed input
+
+  @Test("vad-confirmed: genuine VAD trim (no raw-feeding flags, filtered < raw) → true")
+  func vadConfirmedGenuineTrim() {
+    #expect(
+      TailClipDiagnostics.decodedTailIsVadConfirmed(
+        usedRawFallbackAfterVAD: false, usedRawSoftOnsetPreservation: false,
+        samplesPaddedToMinimum: false, filteredSampleCount: 12000, rawSampleCount: 16000) == true)
+  }
+
+  @Test("vad-confirmed: each raw-feeding path → false (fallback / soft-onset / padded / no-op)")
+  func vadConfirmedRawFedPathsFalse() {
+    // Too-aggressive raw fallback.
+    #expect(
+      TailClipDiagnostics.decodedTailIsVadConfirmed(
+        usedRawFallbackAfterVAD: true, usedRawSoftOnsetPreservation: false,
+        samplesPaddedToMinimum: false, filteredSampleCount: 12000, rawSampleCount: 16000) == false)
+    // #843 soft-onset raw preservation.
+    #expect(
+      TailClipDiagnostics.decodedTailIsVadConfirmed(
+        usedRawFallbackAfterVAD: false, usedRawSoftOnsetPreservation: true,
+        samplesPaddedToMinimum: false, filteredSampleCount: 12000, rawSampleCount: 16000) == false)
+    // Short-utterance padding (tail is silence).
+    #expect(
+      TailClipDiagnostics.decodedTailIsVadConfirmed(
+        usedRawFallbackAfterVAD: false, usedRawSoftOnsetPreservation: false,
+        samplesPaddedToMinimum: true, filteredSampleCount: 12000, rawSampleCount: 16000) == false)
+    // SampleFilter no-op / fully-voiced: filtered == raw (conservatively not confirmed).
+    #expect(
+      TailClipDiagnostics.decodedTailIsVadConfirmed(
+        usedRawFallbackAfterVAD: false, usedRawSoftOnsetPreservation: false,
+        samplesPaddedToMinimum: false, filteredSampleCount: 16000, rawSampleCount: 16000) == false)
+  }
+
+  // MARK: - compute() (decodedInputSampleCount non-nil simulates the kernel having
+  // decided the gap is authoritative + VAD-confirmed)
 
   @Test("compute: real drop — energetic tail, no trailing silence, large gap → suspected_asr_drop")
   func computeRealDrop() {
@@ -65,10 +100,8 @@ struct TailClipDiagnosticsTests {
 
   @Test("compute: gap is NOT silence-corrected — raw trailing silence does not cancel a drop")
   func computeNoSilenceSubtraction() {
-    // Energetic throughout; VAD ends at 8000 of 16000 → raw trailingSilence 500ms.
-    // asrInput 1000ms, last token 300ms → gap 700ms. The gap lives on the decoded
-    // (filtered) timeline, so raw trailing silence must NOT be subtracted (Codex P2):
-    // it stays 700ms → suspected_asr_drop, not hidden as complete.
+    // asrInput 1000ms, last token 300ms → gap 700ms on the decoded (filtered)
+    // timeline; raw trailingSilence (500ms) must NOT be subtracted (Codex P2).
     let raw = [Float](repeating: 0.03, count: 16000)
     let segs = [SpeechSegment(startSample: 0, endSample: 8000)]
     let d = TailClipDiagnostics.compute(
@@ -86,7 +119,6 @@ struct TailClipDiagnosticsTests {
     #expect(d.asrInputDurationMs == 20000)
     #expect(d.asrLastTokenGapMs == 1000)
     #expect(d.asrChunked == true)
-    #expect(d.trailingSilenceMs == nil)  // no VAD segment
     #expect(d.classification == .asrComplete)  // dead-air overrides the large gap
   }
 
@@ -98,8 +130,7 @@ struct TailClipDiagnosticsTests {
     #expect(d.asrLastTokenGapMs == 0)
   }
 
-  @Test(
-    "compute: non-authoritative decoded input (WhisperKit/streaming/padded) omits ASR-input fields")
+  @Test("compute: nil decodedInputSampleCount (non-batch / raw-fed / padded) omits ASR fields")
   func computeOmitsAsrFieldsWhenNotAuthoritative() {
     let raw = [Float](repeating: 0.0, count: 100)
     let d = TailClipDiagnostics.compute(
@@ -110,19 +141,16 @@ struct TailClipDiagnosticsTests {
     #expect(d.classification == .unknown)
   }
 
-  // Window-RMS catch (#964 helper) still matters under the new model: a faint last
-  // word concentrated in one 40ms window stays below the whole-slice peak/RMS floors
-  // but lifts a local window, so the tail is NOT dead-air. With a large gap that
-  // routes to suspected_asr_drop; were it mistaken for dead-air it would be wrongly
-  // called asr_complete.
+  // Window-RMS catch (#964 helper) still matters: a faint last word concentrated in
+  // one 40ms window stays below the whole-slice peak/RMS floors but lifts a local
+  // window, so the tail is NOT dead-air → large gap routes to suspected_asr_drop.
   @Test("compute: faint last word in one window is NOT dead-air → energetic drop path")
   func computeFaintTailWindowRmsCatch() {
     var raw = [Float](repeating: 0.0, count: 16000)
     for i in 15360..<16000 { raw[i] = 0.003 }  // faint 40ms window at the very end
-    let segs = [SpeechSegment(startSample: 0, endSample: 16000)]  // trailing silence 0
+    let segs = [SpeechSegment(startSample: 0, endSample: 16000)]
     let d = TailClipDiagnostics.compute(
       rawSamples: raw, vadSegments: segs, decodedInputSampleCount: 16000, lastTokenEndMs: 300)
-    // The scalar-only check (peak + whole-400ms RMS) would have called this dead air.
     #expect(d.tail400Peak < RecordingSessionKernel.DeadAirFloor.peak)
     #expect(d.tail400RMS < RecordingSessionKernel.DeadAirFloor.rms)
     #expect(d.asrLastTokenGapMs == 700)


### PR DESCRIPTION
## What

Recalibrates the tail-clip telemetry shipped in #1232 (#1236). Post-merge validation (16 real dictations + 1 live clip + synthetic batch, verdicts from `app.log` RAW ASR) plus a 3-way review (GPT/Gemini council → Codex grounded) showed the classifier was miscalibrated; all three independently chose "drop the misleading parts, keep what works, recalibrate."

## The problem

- `suspected_capture_clip` fired on **16/16 complete real dictations** (~0% precision). A *small* token gap means the decoder reached the end of the audio = healthy, so flagging small-gap + energetic-tail as a capture clip was inverted.
- `trailingSilenceMs` is **~0 by construction** in push-to-talk (VAD finalize closes the open segment at the raw buffer end), so its `>=150 => clean` gate never fired.
- The token gap **did** work: it caught the one real live clip (a 30s chunked dictation, `gap=2825ms`) as `suspected_asr_drop`.

## The change (metadata-only, heart-path-safe, no audio/text retained)

- Classification is now **`asr_complete` / `suspected_asr_drop` / `unknown`**. Removed the inverted `suspected_capture_clip`; renamed `clean` → `asr_complete` (honest: these signals attest the **ASR stage** reached the end, NOT the capture layer — a true mic-cut clip is invisible here and needs the deferred counters, #1233).
- The headline metric is the **ASR token gap on the decoded (VAD-filtered) timeline** = untranscribed speaking tail. Codex P2 fix: do **not** subtract raw `trailingSilenceMs` (a different timeline; the filtered buffer already excludes it, and subtracting would cancel a real drop).
- **Tail energy is the covariate:** a dead-air tail is `asr_complete` even with a large gap (user trailed off); an energetic tail with a large gap is the drop.
- Thresholds (calibration candidates): `<=250ms` complete, `>=500ms` drop, gray band `unknown`.

## Validation

- Codex diff review: 2 rounds (round 1 caught the timeline-mixing P2; round 2 clean).
- Logic gate: full Xcode suite green (2,133 tests); 13 classifier boundary tests incl. a real-drop and a no-silence-subtraction regression.
- Live UAT (recal dev build, verdicts from `app.log`): a normal complete dictation now logs `asr_complete` (gap 25ms, pipeline 1.478s, ASR 93ms — no latency regression), where the old build logged `suspected_capture_clip`.

The live clip was an **ASR/chunking tail drop** (audio captured, tail not decoded), not a capture race — root-cause hunt is #1237; the capture-counter signal #1233 is reprioritized below it.

Closes #1236