### PR TITLE
feat(analytics): count off-site downloads in the weekly digest (#1243)

### DIFF
--- a/workers/weekly-digest/package.json
+++ b/workers/weekly-digest/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "enviouswispr-weekly-digest",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -59,26 +59,11 @@ async function fetchCloudflareStats(env, dateFrom, dateTo) {
     }
   }`;
 
-  // Separate query for referrers — uses httpRequestsAdaptiveGroups
-  const refQuery = `query {
-    viewer {
-      zones(filter: {zoneTag: "${env.CF_ZONE_ID}"}) {
-        httpRequestsAdaptiveGroups(
-          limit: 10
-          filter: {
-            date_geq: "${dateFrom}"
-            date_leq: "${dateTo}"
-            requestSource: "eyeball"
-          }
-          orderBy: [count_DESC]
-        ) {
-          count
-          dimensions { refererHost }
-        }
-      }
-    }
-  }`;
-
+  // NOTE: the former "Top Referrers" query (httpRequestsAdaptiveGroups { refererHost })
+  // was removed (#1243): refererHost is rejected by the Cloudflare API on the zone
+  // dataset (the valid field, clientRefererHost, is paid-only), so the section was
+  // silently empty. Download attribution now comes from PostHog source_bucket — see
+  // the "Download Sources" field built from fetchPostHogStats.
   const opts = {
     method: "POST",
     headers: {
@@ -88,16 +73,10 @@ async function fetchCloudflareStats(env, dateFrom, dateTo) {
     },
   };
 
-  const [mainRes, refRes] = await Promise.all([
-    fetch("https://api.cloudflare.com/client/v4/graphql", {
-      ...opts,
-      body: JSON.stringify({ query }),
-    }).then((r) => r.json()),
-    fetch("https://api.cloudflare.com/client/v4/graphql", {
-      ...opts,
-      body: JSON.stringify({ query: refQuery }),
-    }).then((r) => r.json()),
-  ]);
+  const mainRes = await fetch("https://api.cloudflare.com/client/v4/graphql", {
+    ...opts,
+    body: JSON.stringify({ query }),
+  }).then((r) => r.json());
 
   const zone = mainRes?.data?.viewer?.zones?.[0];
   const totals = zone?.totals || [];
@@ -117,19 +96,11 @@ async function fetchCloudflareStats(env, dateFrom, dateTo) {
     }
   }
 
-  // Top referrers
-  const refZone = refRes?.data?.viewer?.zones?.[0];
-  const refGroups = refZone?.httpRequestsAdaptiveGroups || [];
-  const referrers = refGroups
-    .filter((r) => r.dimensions?.refererHost && r.dimensions.refererHost !== "enviouswispr.com")
-    .slice(0, 5)
-    .map((r) => ({ host: r.dimensions.refererHost, count: r.count }));
-
   const topCountries = Object.entries(countries)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5);
 
-  return { totalRequests, totalPageViews, totalUniques, topCountries, referrers };
+  return { totalRequests, totalPageViews, totalUniques, topCountries };
 }
 
 // ── GitHub Release Downloads ──────────────────────────────────
@@ -163,7 +134,7 @@ async function fetchGitHubDownloads(env) {
 
 async function fetchPostHogStats(env, dateFrom, dateTo) {
   const apiKey = env.POSTHOG_PERSONAL_API_KEY;
-  if (!apiKey) return { weeklyActiveUsers: "?", newUsers: "?", downloadClicks: "?" };
+  if (!apiKey) return { weeklyActiveUsers: "?", newUsers: "?", downloadIntents: "?", downloadSources: null, botExcluded: "?" };
 
   const headers = {
     Authorization: `Bearer ${apiKey}`,
@@ -183,20 +154,15 @@ async function fetchPostHogStats(env, dateFrom, dateTo) {
     ],
   };
 
-  // Download button clicks on website (autocaptured link clicks to DMG)
-  const clickQuery = {
-    kind: "TrendsQuery",
-    dateRange: { date_from: dateFrom, date_to: dateTo },
-    interval: "week",
-    series: [
-      {
-        kind: "EventsNode",
-        event: "download_clicked",
-        math: "total",
-        custom_name: "Download clicks",
-      },
-    ],
-  };
+  // Download intents (7d) = on-site clicks + non-bot off-site doorway redirects.
+  // HogQL (not TrendsQuery) because the union + bot-exclusion needs coalesce() on a
+  // property; bare property names do NOT resolve in HogQL — must be properties.<name>.
+  const intentsQuery = { kind: "HogQLQuery", query: downloadIntentsHogQL(dateFrom, dateTo) };
+  // Off-site download sources (non-bot) grouped by canonical source_bucket.
+  const sourcesQuery = { kind: "HogQLQuery", query: downloadSourcesHogQL(dateFrom, dateTo) };
+  // Off-site bot hits excluded this week — integrity line (surfaces a bot surge OR
+  // over-aggressive filtering).
+  const botQuery = { kind: "HogQLQuery", query: botExcludedHogQL(dateFrom, dateTo) };
 
   // Website pageviews
   const pvQuery = {
@@ -211,50 +177,122 @@ async function fetchPostHogStats(env, dateFrom, dateTo) {
 
   const queryUrl = `https://us.posthog.com/api/projects/${env.POSTHOG_PROJECT_ID}/query/`;
 
-  const [wauRes, clickRes, pvRes] = await Promise.all([
-    fetch(queryUrl, { method: "POST", headers, body: JSON.stringify({ query: wauQuery }) })
+  const post = (query) =>
+    fetch(queryUrl, { method: "POST", headers, body: JSON.stringify({ query }) })
       .then((r) => r.json())
-      .catch(() => null),
-    fetch(queryUrl, { method: "POST", headers, body: JSON.stringify({ query: clickQuery }) })
-      .then((r) => r.json())
-      .catch(() => null),
-    fetch(queryUrl, { method: "POST", headers, body: JSON.stringify({ query: pvQuery }) })
-      .then((r) => r.json())
-      .catch(() => null),
+      .catch(() => null);
+
+  const [wauRes, pvRes, intentsRes, sourcesRes, botRes] = await Promise.all([
+    post(wauQuery),
+    post(pvQuery),
+    post(intentsQuery),
+    post(sourcesQuery),
+    post(botQuery),
   ]);
 
-  const extractTotal = (res, seriesIdx = 0) => {
-    try {
-      const series = res?.results?.[seriesIdx];
-      if (!series) return "?";
-      // aggregated_value can be null for weekly intervals; sum the data array instead
-      if (series.aggregated_value != null) return series.aggregated_value;
-      if (Array.isArray(series.data)) return series.data.reduce((a, b) => a + b, 0);
-      return "?";
-    } catch {
-      return "?";
-    }
-  };
-
   return {
-    weeklyActiveUsers: extractTotal(wauRes, 0),
-    newUsers: extractTotal(wauRes, 1),
-    downloadClicks: extractTotal(clickRes, 0),
-    websitePageViews: extractTotal(pvRes, 0),
-    websiteVisitors: extractTotal(pvRes, 1),
+    weeklyActiveUsers: extractTrendTotal(wauRes, 0),
+    newUsers: extractTrendTotal(wauRes, 1),
+    websitePageViews: extractTrendTotal(pvRes, 0),
+    websiteVisitors: extractTrendTotal(pvRes, 1),
+    downloadIntents: extractHogScalar(intentsRes),
+    downloadSources: extractHogRows(sourcesRes),
+    botExcluded: extractHogScalar(botRes),
   };
+}
+
+// ── Helpers (pure; exported for node --test) ──────────────────
+
+// HogQL query builders. NOTE: every event-property ref MUST be properties.<name>
+// (bare names do not resolve in PostHog HogQL). The union/bot predicate is the
+// single shared DEFINITION (mirrored by the PostHog ping function; see
+// .claude/knowledge/analytics-operations.md). #1243
+export function downloadIntentsHogQL(dateFrom, dateTo) {
+  return `SELECT count() FROM events WHERE toDate(timestamp) >= toDate('${dateFrom}') AND toDate(timestamp) <= toDate('${dateTo}') AND (event = 'download_clicked' OR (event = 'download_redirect' AND coalesce(properties.excluded_reason, '') = ''))`;
+}
+export function downloadSourcesHogQL(dateFrom, dateTo) {
+  return `SELECT properties.source_bucket AS bucket, count() AS n FROM events WHERE event = 'download_redirect' AND coalesce(properties.excluded_reason, '') = '' AND toDate(timestamp) >= toDate('${dateFrom}') AND toDate(timestamp) <= toDate('${dateTo}') GROUP BY bucket ORDER BY n DESC LIMIT 8`;
+}
+export function botExcludedHogQL(dateFrom, dateTo) {
+  return `SELECT count() FROM events WHERE event = 'download_redirect' AND coalesce(properties.excluded_reason, '') != '' AND toDate(timestamp) >= toDate('${dateFrom}') AND toDate(timestamp) <= toDate('${dateTo}')`;
+}
+
+// TrendsQuery total extractor (aggregated_value or summed data array).
+export function extractTrendTotal(res, seriesIdx = 0) {
+  try {
+    const series = res?.results?.[seriesIdx];
+    if (!series) return "?";
+    if (series.aggregated_value != null) return series.aggregated_value;
+    if (Array.isArray(series.data)) return series.data.reduce((a, b) => a + b, 0);
+    return "?";
+  } catch {
+    return "?";
+  }
+}
+
+// HogQLQuery scalar (first cell of first row, e.g. a count()).
+export function extractHogScalar(res) {
+  try {
+    const v = res?.results?.[0]?.[0];
+    return v == null ? "?" : v;
+  } catch {
+    return "?";
+  }
+}
+
+// HogQLQuery rows (array of [col0, col1, ...]). Returns null (NOT []) on a failed
+// or malformed response, so a query error is distinguishable from a genuine empty
+// week — a real empty array means "zero off-site downloads", null means "unknown".
+export function extractHogRows(res) {
+  return Array.isArray(res?.results) ? res.results : null;
+}
+
+// Canonical source_bucket -> human label for the digest (concise; the live ping
+// uses its own slightly longer phrasing). Unknown/null -> "Other".
+export const SOURCE_LABELS = {
+  github_readme: "GitHub README",
+  github_release: "GitHub",
+  blog: "Blog",
+  directory_alternativeto: "AlternativeTo",
+  directory_macupdate: "MacUpdate",
+  directory_other: "Directory listing",
+  linkedin: "LinkedIn",
+  reddit: "Reddit",
+  x: "X",
+  youtube: "YouTube",
+  medium: "Medium",
+  facebook: "Facebook",
+  hackernews: "Hacker News",
+  producthunt: "Product Hunt",
+  discord: "Discord",
+  ai_assistant: "AI assistant",
+  newsletter: "Newsletter",
+  direct_or_dark: "Direct / untracked",
+  unknown_referrer: "Unrecognized site",
+};
+export function sourceLabel(bucket) {
+  return (bucket && SOURCE_LABELS[bucket]) || "Other";
+}
+
+// Render the source-breakdown rows ([[bucket, n], ...]) for the embed.
+// null (query failed/unknown) and [] (genuine zero) render differently so a
+// telemetry outage never masquerades as a true zero-source week.
+export function formatSourceBreakdown(rows) {
+  if (rows == null || !Array.isArray(rows)) return "Sources unavailable";
+  if (rows.length === 0) return "No off-site downloads yet";
+  return rows
+    .map(([bucket, n]) => `${sourceLabel(bucket)}: ${Number(n).toLocaleString()}`)
+    .join("\n");
 }
 
 // ── Discord Embed ─────────────────────────────────────────────
 
-function buildEmbed(weekStart, weekEnd, cf, gh, ph) {
+export function buildEmbed(weekStart, weekEnd, cf, gh, ph) {
   const topCountriesStr = cf.topCountries
     .map(([name, count]) => `${name}: ${count.toLocaleString()}`)
     .join("\n") || "No data";
 
-  const referrersStr = cf.referrers
-    .map((r) => `${r.host}: ${r.count.toLocaleString()}`)
-    .join("\n") || "Direct / none tracked";
+  const sourcesStr = formatSourceBreakdown(ph.downloadSources);
 
   return {
     embeds: [
@@ -277,7 +315,7 @@ function buildEmbed(weekStart, weekEnd, cf, gh, ph) {
             value: [
               `**Tracked Visitors:** ${ph.websiteVisitors ?? "—"}`,
               `**Tracked Page Views:** ${ph.websitePageViews ?? "—"}`,
-              `**Download Clicks:** ${ph.downloadClicks ?? "—"}`,
+              `**Download Intents (7d):** ${ph.downloadIntents ?? "—"}`,
             ].join("\n"),
             inline: true,
           },
@@ -308,8 +346,8 @@ function buildEmbed(weekStart, weekEnd, cf, gh, ph) {
             inline: false,
           },
           {
-            name: "🔗 Top Referrers",
-            value: `\`\`\`\n${referrersStr}\n\`\`\``,
+            name: "⬇️ Download Sources (7d)",
+            value: `\`\`\`\n${sourcesStr}\n\`\`\`\nOff-site bots excluded: ${ph.botExcluded ?? "—"}`,
             inline: true,
           },
           {

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -1,0 +1,131 @@
+// Unit tests for the pure query-builder / extractor / formatter helpers (no network).
+// Run: node --test  (from workers/weekly-digest/)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  downloadIntentsHogQL,
+  downloadSourcesHogQL,
+  botExcludedHogQL,
+  extractTrendTotal,
+  extractHogScalar,
+  extractHogRows,
+  sourceLabel,
+  formatSourceBreakdown,
+  buildEmbed,
+} from "../src/index.js";
+
+// ---- HogQL builders: must qualify every event-property as properties.<name> ----
+// A bare excluded_reason / source_bucket (not preceded by "properties.") would fail
+// in PostHog HogQL. This regex catches the regression Codex flagged twice.
+const BARE_PROP = /(?<!properties\.)\b(excluded_reason|source_bucket)\b/;
+
+test("downloadIntentsHogQL: union of both events, bot-excluded, fully qualified", () => {
+  const q = downloadIntentsHogQL("2026-06-23", "2026-06-30");
+  assert.match(q, /event = 'download_clicked'/);
+  assert.match(q, /event = 'download_redirect'/);
+  assert.match(q, /coalesce\(properties\.excluded_reason, ''\) = ''/);
+  assert.ok(!BARE_PROP.test(q), "no bare event-property refs allowed");
+  assert.match(q, /2026-06-23/);
+  assert.match(q, /2026-06-30/);
+});
+
+test("downloadSourcesHogQL: groups off-site only by qualified source_bucket", () => {
+  const q = downloadSourcesHogQL("2026-06-23", "2026-06-30");
+  assert.match(q, /properties\.source_bucket/);
+  assert.match(q, /event = 'download_redirect'/);
+  assert.ok(!/download_clicked/.test(q), "source breakdown must be off-site only");
+  assert.match(q, /coalesce\(properties\.excluded_reason, ''\) = ''/);
+  assert.match(q, /GROUP BY bucket/);
+  assert.ok(!BARE_PROP.test(q), "no bare event-property refs allowed");
+});
+
+test("botExcludedHogQL: counts non-empty excluded_reason, qualified", () => {
+  const q = botExcludedHogQL("2026-06-23", "2026-06-30");
+  assert.match(q, /coalesce\(properties\.excluded_reason, ''\) != ''/);
+  assert.match(q, /event = 'download_redirect'/);
+  assert.ok(!BARE_PROP.test(q), "no bare event-property refs allowed");
+});
+
+// ---- extractors ----
+test("extractHogScalar: first cell, '?' fallbacks", () => {
+  assert.equal(extractHogScalar({ results: [[5]] }), 5);
+  assert.equal(extractHogScalar({ results: [[0]] }), 0); // zero is a real count, not "?"
+  assert.equal(extractHogScalar({ results: [] }), "?");
+  assert.equal(extractHogScalar(null), "?");
+  assert.equal(extractHogScalar({}), "?");
+});
+
+test("extractHogRows: passthrough; null on failure (unknown != empty)", () => {
+  assert.deepEqual(extractHogRows({ results: [["reddit", 2], ["blog", 1]] }), [["reddit", 2], ["blog", 1]]);
+  assert.deepEqual(extractHogRows({ results: [] }), []); // genuine zero week is a real []
+  assert.equal(extractHogRows(null), null); // failed query -> unknown, NOT empty
+  assert.equal(extractHogRows({ results: "nope" }), null);
+});
+
+test("extractTrendTotal: aggregated_value, summed data, fallback", () => {
+  assert.equal(extractTrendTotal({ results: [{ aggregated_value: 12 }] }, 0), 12);
+  assert.equal(extractTrendTotal({ results: [{ data: [1, 2, 3] }] }, 0), 6);
+  assert.equal(extractTrendTotal({ results: [] }, 0), "?");
+  assert.equal(extractTrendTotal(null, 0), "?");
+});
+
+// ---- labels / formatting ----
+test("sourceLabel: known maps, unknown/null -> Other", () => {
+  assert.equal(sourceLabel("github_readme"), "GitHub README");
+  assert.equal(sourceLabel("reddit"), "Reddit");
+  assert.equal(sourceLabel("ai_assistant"), "AI assistant");
+  assert.equal(sourceLabel("some_new_bucket"), "Other");
+  assert.equal(sourceLabel(null), "Other");
+  assert.equal(sourceLabel(undefined), "Other");
+});
+
+test("formatSourceBreakdown: empty vs unknown vs rows", () => {
+  assert.equal(formatSourceBreakdown([]), "No off-site downloads yet"); // genuine zero
+  assert.equal(formatSourceBreakdown(null), "Sources unavailable"); // query failed/unknown
+  const out = formatSourceBreakdown([["github_readme", 3], ["reddit", 1], ["mystery", 1]]);
+  assert.match(out, /GitHub README: 3/);
+  assert.match(out, /Reddit: 1/);
+  assert.match(out, /Other: 1/); // unknown bucket never disappears
+});
+
+// ---- embed smoke ----
+const cf = { totalUniques: 10, totalPageViews: 50, totalRequests: 100, topCountries: [["United States", 5]] };
+const gh = { totalDownloads: 1234, latestVersion: "v1.10.2" };
+
+test("buildEmbed: shows Download Intents + Download Sources, drops legacy labels", () => {
+  const ph = {
+    websiteVisitors: 9, websitePageViews: 40,
+    downloadIntents: 7, downloadSources: [["github_readme", 4], ["reddit", 2]],
+    botExcluded: 3, weeklyActiveUsers: 20, newUsers: 2,
+  };
+  const json = JSON.stringify(buildEmbed("2026-06-23", "2026-06-30", cf, gh, ph));
+  assert.match(json, /Download Intents \(7d\)/);
+  assert.match(json, /Download Sources \(7d\)/);
+  assert.match(json, /Off-site bots excluded: 3/);
+  assert.match(json, /GitHub README: 4/);
+  assert.ok(!/Download Clicks/.test(json), "legacy 'Download Clicks' label removed");
+  assert.ok(!/Top Referrers/.test(json), "broken 'Top Referrers' section removed");
+  // All-time GitHub file-download count stays separate and labeled.
+  assert.match(json, /All-Time DMG Downloads/);
+});
+
+test("buildEmbed: empty sources renders the friendly placeholder", () => {
+  const ph = {
+    websiteVisitors: 9, websitePageViews: 40,
+    downloadIntents: 0, downloadSources: [], botExcluded: 0,
+    weeklyActiveUsers: 20, newUsers: 2,
+  };
+  const json = JSON.stringify(buildEmbed("2026-06-23", "2026-06-30", cf, gh, ph));
+  assert.match(json, /No off-site downloads yet/);
+});
+
+test("buildEmbed: failed sources query renders 'Sources unavailable', not a false zero", () => {
+  const ph = {
+    websiteVisitors: 9, websitePageViews: 40,
+    downloadIntents: "?", downloadSources: null, botExcluded: "?",
+    weeklyActiveUsers: 20, newUsers: 2,
+  };
+  const json = JSON.stringify(buildEmbed("2026-06-23", "2026-06-30", cf, gh, ph));
+  assert.match(json, /Sources unavailable/);
+  assert.ok(!/No off-site downloads yet/.test(json), "a failed query must not look like a true zero");
+});


### PR DESCRIPTION
Part of #1243.

## What
Wires the **weekly Discord digest** to count off-site doorway downloads (it only saw on-site button clicks before) and surfaces where downloads come from.

- **"Download Clicks" -> "Download Intents (7d)"** = on-site `download_clicked` + non-bot off-site `download_redirect` (HogQL union; `coalesce(properties.excluded_reason,'')=''`).
- **New "Download Sources (7d)"**: off-site redirects grouped by canonical `source_bucket` (bots excluded), with an **"Off-site bots excluded: N"** integrity line.
- **Removed the silently-broken "Top Referrers" section** (queried `refererHost` on the CF zone dataset, a field the API rejects -> always empty). Attribution now comes from PostHog `source_bucket`.

## Correctness notes
- All HogQL event-property refs are `properties.<name>`-qualified (bare names don't resolve in PostHog HogQL).
- On-site `download_clicked` carries no bot flag and stays unfiltered (bot exclusion scoped to the off-site doorway only).
- A failed sources query renders **"Sources unavailable"**, never a false "No off-site downloads yet" (unknown != empty).
- "All-Time DMG Downloads" (GitHub's file counter) unchanged, stays separately labeled.

## Validation
- `node --test`: 11 cases (query-builder qualification, extractors, label map, formatter empty/unknown/rows, embed smoke).
- Three HogQL queries validated against **live PostHog**: intents=26, sources sum to 5 non-bot, bots=5.
- Council coverage round + Codex grounded review r1-r3 (PROCEED-AS-PLANNED) + Codex code-diff review (clean).

The real-time "Download #N" ping (PostHog destination function, infra/not-in-repo) gets the matching union + source-named message + one-time changelog note separately, then #1243 closes.

Plan: `docs/feature-requests/issue-1243-2026-06-30-discord-download-attribution.md`