### PR TITLE
content(blog): You Can Now Dictate for a Full Hour (scheduled 2026-07-01)

### DIFF
--- a/website/src/content/blog/you-can-now-dictate-for-a-full-hour.md
+++ b/website/src/content/blog/you-can-now-dictate-for-a-full-hour.md
@@ -1,0 +1,41 @@
+---
+title: "You Can Now Dictate for a Full Hour"
+description: "EnviousWispr used to cap a single dictation at about ten minutes. I raised it to a full hour, on-device, with a warning before it stops and nothing lost when it does."
+pubDate: 2026-07-01
+tags: ["dictation", "macos", "long-form", "privacy", "productivity"]
+draft: false
+author: "Saurabh Vaish"
+keywords:
+  - "long dictation mac"
+  - "dictate for an hour"
+  - "continuous voice to text macos"
+  - "long form dictation mac"
+  - "on device dictation"
+faqs:
+  - question: "How long can a single dictation be in EnviousWispr?"
+    answer: "Up to 60 minutes. One session can run for a full hour before it wraps up. You get a warning as you approach the cap, and it transcribes everything you said before it stops."
+  - question: "What happens when I reach the one-hour limit?"
+    answer: "It stops cleanly and transcribes what you spoke, so you do not lose the last part of the session. A small warning appears before you get there, so it never catches you off guard."
+  - question: "Does the whole recording stay on my Mac?"
+    answer: "Yes. The entire recording is transcribed on your device, with no upload, no server, and no account. That is true whether the dictation is ten seconds or a full hour."
+---
+
+For a while, the longest you could dictate in EnviousWispr in one go was about ten minutes. I picked that number early on without thinking about it much. It was fine for what I used dictation for at the time: messages, commit notes, quick emails.
+
+Then I started using it for the longer stuff, and ten minutes stopped being enough.
+
+I would sit down to talk through a problem out loud, or [get a first draft out](/blog/dictate-first-drafts-sound-like-you/) while it was still in my head, and somewhere in the middle the recording would just end. I would lose my train of thought going back to check what happened. It turns out that when dictation is good enough to think in, ten minutes goes by fast.
+
+So I raised it to a full hour.
+
+A single dictation can now run for sixty minutes before it wraps up. That covers the sessions I actually wanted it for: a long voice memo, a meeting's worth of notes while they are still fresh, or [talking through a long script](/blog/dictating-episode-scripts-without-losing-flow/) without stopping to restart. I am not watching a timer anymore, and I do not think you should have to either.
+
+A couple of things I cared about while doing it.
+
+It warns you before it stops. A long cap is useless if it surprises you, so as you get close to the hour a small warning shows up. And when it does reach the end, it stops cleanly and transcribes everything you said. You do not lose the last few minutes because the timer ran out. What you spoke is what you get. If holding a key for that long is awkward, double-press to lock it hands-free and just talk.
+
+The hour does not change where the audio goes, which is still nowhere. The whole recording is transcribed on your Mac. No upload, no server, no account. That mattered to me at ten minutes and it matters more at sixty: an hour of you thinking out loud is exactly the kind of thing that should never leave your machine.
+
+Short notes still work the way they always did. Hold the hotkey, speak, release, paste. The hour is just there for the days you have more to say.
+
+Talk naturally. Paste perfectly.


### PR DESCRIPTION
New founder-voice blog post on the dictation recording cap going from ~10 minutes to a full hour (on-device, warns before stopping, transcribes everything).

**Scheduling:** future-dated `pubDate: 2026-07-01`, so the existing `deploy-blog.yml` daily cron publishes it on its date (it stays hidden today via `isPublishedPost`). This is the live validation of the EnviousMarketing blog scheduler (5d-blog).

**SEO/GEO:** FAQ schema (3 Q&A) + 2 internal links to related posts.

**Tracking:** EnviousMarketing asset `AST-EW-20260630-VT8J` / placement `PLC-EW-20260630-A1M0`.

Content-only change (no Swift).