### PR TITLE
fix(asr): recover end-of-dictation tail clip (empty-chunk recovery) (#1237)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b300ed4830594d97095663a3db7624c6f3c7c0af1b15744ed2bdecbc0137a39c",
+  "originHash" : "07b6c551e18ce8ac363e2cfd735bba86ed30ff48900880a3536a80595842f3bc",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/saurabhav88/FluidAudio.git",
       "state" : {
-        "branch" : "46e96f4",
-        "revision" : "46e96f40bff968db80e53c45f084b6f9380c41c0"
+        "branch" : "d5fcca4",
+        "revision" : "d5fcca4f7d72f8e22e988ee08a7caa0a914a0b4e"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", from: "1.0.0"),
-    .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "46e96f4"),
+    .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "d5fcca4"),
     .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
     .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),


### PR DESCRIPTION
## What

Fixes the long-standing end-of-dictation tail clip (#1237, the real root cause behind #1099). On long dictations, the on-device speech engine splits audio into ~15-second windows; when a window's speech is bracketed by silence in a content-dependent way, the Parakeet TDT decoder emits **zero tokens for the entire window** ("EMPTY CHUNK") despite real speech — silently dropping the end of the dictation after a mid-sentence pause.

This PR is a **one-line dependency pin bump** repointing FluidAudio to the fork commit that recovers those windows: when a window decodes empty but its encoder produced substantial frames, it splits the window at internal silence into speech islands, re-decodes each once with fresh decoder state, offsets timestamps onto the existing window basis, and merges through the existing chunk merge. Fail-open to today's exact behavior on any failure; island count capped; each island decoded once (no loop).

## Where the substantive change lives

Engine fix + tests are in the fork `saurabhav88/FluidAudio` @ `d5fcca4` (`ChunkProcessor.recoverEmptyChunk` + `SilenceIslandDetector`), which went through **4 rounds of Codex code-diff review to clean** (fixed: cancellation propagation, interior-chunk finalization, fail-open semantics) plus 13 new unit tests + 83 existing chunk/merge tests green, swift-format clean.

## Validation

- **Offline, deterministic** (`fluidaudiocli` built from the same pinned commit the app's XPC service runs): both real founder tail-clippers recover their dropped tails (`13F80652`: "...figure it out" → "...Without understanding. The systems."; `A8171A1F`: "...that you might" → "...That you should be using today."); **14/16 long clips byte-identical** (recovery only runs inside the empty-window branch).
- **In-app Live UAT** (dev build pinned to `d5fcca4`): heart path completes clean; a normal >15s multi-window dictation keeps its final word end-to-end (no tail regression). The sample-exact empty-chunk bug can't be reproduced through a speaker→mic round-trip, so the deterministic recovery proof is the offline decode on identical engine code.
- **EW logic tests:** 2142 green.

## Notes

- Behavioral delta only: the engine returns a more-complete transcript for the same audio. No EW API/contract change; rollback = revert the pin.
- Partial recovery is intentional and empirically grounded: if one island re-blanks, the others are kept (recovers strictly more real speech than abandoning the window; A8171A1F is the proof). Never worse than today.
- No EW-side regression test added (deviation from the plan): the fix logic + unit tests live in the fork, the repro fixtures are private founder dictations, and the model isn't in CI — a gated in-suite test would skip everywhere but locally. Coverage is stronger via fork tests + offline proof + Live UAT.

Closes #1237. Part of #1099.