### PR TITLE
fix(observability): readable Sentry titles for private/nested errors + dev/prod issue separation

### DIFF
--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -8,11 +8,18 @@ import Sentry
 /// Limb: missing keys log a warning and skip initialization — never crashes the app.
 public enum ObservabilityBootstrap {
 
-  /// Detect environment from bundle ID: dev builds use `.dev` suffix.
-  private static var environment: String {
+  /// Bundle-id-derived environment ("development" | "production"), computed once at
+  /// first access — independent of whether Sentry/PostHog init has run yet. Public so
+  /// `SentryBreadcrumb.handledErrorFingerprint` can split dev/prod into separate Sentry
+  /// issues (#1229). A nil `bundleIdentifier` deterministically falls to "production",
+  /// never an "unknown" state.
+  public static let currentEnvironment: String = {
     let bundleID = Bundle.main.bundleIdentifier ?? ""
     return bundleID.hasSuffix(".dev") ? "development" : "production"
-  }
+  }()
+
+  /// Detect environment from bundle ID: dev builds use `.dev` suffix.
+  private static var environment: String { currentEnvironment }
 
   /// App version from bundle (e.g. "1.6.2" for release, "v1.6.1-14-g...-dev" for dev)
   private static var appVersion: String {

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -200,24 +200,44 @@ public enum SentryBreadcrumb {
   /// user content — so dictation text can never reach the message surface, even if
   /// a future error type interpolated a transcript into its `localizedDescription`.
   /// See #1095. `internal` (not `private`) so the redaction tripwire can pin it.
+  ///
+  /// A `private` or file-scope-`private` Swift error type's bridged `NSError.domain`
+  /// demangles to `…(unknown context at $<runtime-ptr>).TypeName` — long enough to trip
+  /// the on-device redactor's `>100`-char heuristic (wiping the whole message to
+  /// `[REDACTED]`), and the per-launch pointer fragments Sentry grouping. When the
+  /// domain carries that artifact, fall back to the plain simple type name instead
+  /// (#1229).
   nonisolated static func structuredDescriptor(_ error: any Error) -> String {
     let ns = error as NSError
+    if ns.domain.contains("(unknown context at ") {
+      return "\(type(of: error))#\(ns.code)"
+    }
     return "\(ns.domain)#\(ns.code)"
   }
 
   /// Stable Sentry grouping key for a handled error: namespace + category + the
-  /// underlying error signature (`domain#code`). The namespace avoids colliding
-  /// with native-crash groups; the category is the defect class; the signature
-  /// splits distinct root causes that share a broad category so they do not
-  /// silently merge into one issue (#1144). The optional `detail` adds a further
+  /// underlying error signature (`domain#code`) + environment. The namespace avoids
+  /// colliding with native-crash groups; the category is the defect class; the
+  /// signature splits distinct root causes that share a broad category so they do
+  /// not silently merge into one issue (#1144). The optional `detail` adds a further
   /// split for error types whose root cause lives in an associated value the
-  /// bridged `domain#code` cannot distinguish (#945 — `LLMError.classified`).
+  /// bridged `domain#code` cannot distinguish (#945 — `LLMError.classified`). The
+  /// trailing `environment` keeps dev-machine and real-user failures as separate,
+  /// individually-alerting Sentry issues now that `structuredDescriptor` no longer
+  /// carries a per-launch pointer to do that incidentally (#1229) — without it,
+  /// stabilizing the descriptor would merge dev and prod into one issue, and the
+  /// Sentry-triage worker only alerts on "issue created", so a real-user occurrence
+  /// landing on an already-dev-created issue would never alert.
   /// `nonisolated` + pure so the non-`@MainActor` test suite calls it directly.
+  /// `environment` defaults to the real bundle-derived value but is injectable so a
+  /// single test process can assert both the dev and prod branches.
   nonisolated static func handledErrorFingerprint(
-    for category: ErrorCategory, error: any Error, detail: String? = nil
+    for category: ErrorCategory, error: any Error, detail: String? = nil,
+    environment: String = ObservabilityBootstrap.currentEnvironment
   ) -> [String] {
     var fingerprint = ["handled_error", category.rawValue, structuredDescriptor(error)]
     if let detail { fingerprint.append(detail) }
+    fingerprint.append(environment)
     return fingerprint
   }
 

--- a/Tests/EnviousWisprTests/Services/SentryEventSanitizerTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryEventSanitizerTests.swift
@@ -29,6 +29,28 @@ import Testing
 /// by guarantee 4 (producers never put transcript text in a field) and would
 /// only need the full key-allowlist rebuild if a regulator-grade claim were
 /// required. So the sentinel below is transcript-SHAPED for denylist surfaces.
+
+/// File-scope `private` fixture reproducing the shape of `EmojiRestoreAnomaly`
+/// (`EmojiRestoreStep.swift`) — a file-scope `private` Swift error type. Its
+/// bridged `NSError.domain` carries the same `(unknown context at $ptr)`
+/// artifact as a nested `private` type (#1229; empirically verified via
+/// `swiftc` — the descriptor fix is type-shape-agnostic).
+private enum FileScopeFixtureError: Error {
+  case boom
+}
+
+/// Wrapper exposing a `private`-nested fixture reproducing the shape of
+/// `RecoveryReplayError` / `RecoveryArmError` / `NilCollaboratorError` (all
+/// `private` nested inside their owning type). The real types are `private`
+/// in other modules and unreachable from this test file (#1229) — this
+/// fixture exercises the identical `(unknown context at $ptr)` branch.
+private struct NestedFixtureWrapper {
+  private enum NestedFixtureError: Error {
+    case boom
+  }
+  static func makeError() -> Error { NestedFixtureError.boom }
+}
+
 @Suite("Sentry/PostHog redaction tripwire (#1095)")
 struct SentryEventSanitizerTests {
 
@@ -76,6 +98,47 @@ struct SentryEventSanitizerTests {
     let descriptor = SentryBreadcrumb.structuredDescriptor(err)
     #expect(descriptor == "MyDomain#7")
     #expect(descriptor.contains(shortPhrase) == false)
+  }
+
+  // MARK: - Layer A: (unknown context) normalization (#1229)
+
+  /// A `private`/nested Swift error type's bridged `NSError.domain` demangles to
+  /// `…(unknown context at $<ptr>).TypeName` — long enough (>100 chars) to trip
+  /// the `>100`-char denylist rule below and wipe the whole message to
+  /// `[REDACTED]`, with a per-launch pointer that also fragments grouping. The
+  /// descriptor must normalize this to the plain simple type name instead.
+  @Test("file-scope private error descriptor normalizes (unknown context) to the simple type name")
+  func fileScopePrivateErrorDescriptorNormalizes() {
+    let descriptor = SentryBreadcrumb.structuredDescriptor(FileScopeFixtureError.boom)
+    #expect(descriptor == "FileScopeFixtureError#0")
+    #expect(descriptor.contains("(unknown context") == false)
+    #expect(descriptor.contains("$") == false)
+    #expect(descriptor.count < 100)
+
+    let event = Event(level: .error)
+    event.message = SentryMessage(
+      formatted:
+        "\(SentryBreadcrumb.ErrorCategory.recoveryTranscribeFailed.rawValue): \(descriptor)"
+    )
+    let sanitized = ObservabilityBootstrap.sanitizeSentryEvent(event)
+    #expect(sanitized.message?.formatted == "recovery_transcribe_failed: FileScopeFixtureError#0")
+  }
+
+  @Test("nested private error descriptor normalizes (unknown context) to the simple type name")
+  func nestedPrivateErrorDescriptorNormalizes() {
+    let descriptor = SentryBreadcrumb.structuredDescriptor(NestedFixtureWrapper.makeError())
+    #expect(descriptor == "NestedFixtureError#0")
+    #expect(descriptor.contains("(unknown context") == false)
+    #expect(descriptor.contains("$") == false)
+    #expect(descriptor.count < 100)
+
+    let event = Event(level: .error)
+    event.message = SentryMessage(
+      formatted:
+        "\(SentryBreadcrumb.ErrorCategory.recoveryTranscribeFailed.rawValue): \(descriptor)"
+    )
+    let sanitized = ObservabilityBootstrap.sanitizeSentryEvent(event)
+    #expect(sanitized.message?.formatted == "recovery_transcribe_failed: NestedFixtureError#0")
   }
 
   // MARK: - Layer D: denylist scrubs transcript-length content from every surface

--- a/Tests/EnviousWisprTests/Services/SentryFingerprintTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryFingerprintTests.swift
@@ -6,28 +6,38 @@ import Testing
 @testable import EnviousWisprServices
 
 /// #1144 — Sentry grouping fingerprints. Handled errors group by
-/// `[namespace, category, domain#code]` so distinct defects that share a broad
-/// category get their own stable, release-independent issue instead of merging
-/// under one stacktrace bin (the `ENVIOUSWISPR-8` pollution behind the #440
-/// false-reopen churn). The helpers are pure + `nonisolated`, so this suite is
-/// not `@MainActor` and calls them directly — no spy/delegate, no actor hop.
+/// `[namespace, category, domain#code, environment]` so distinct defects that share
+/// a broad category get their own stable, release-independent issue instead of
+/// merging under one stacktrace bin (the `ENVIOUSWISPR-8` pollution behind the #440
+/// false-reopen churn), AND so dev-machine and real-user occurrences of the same
+/// defect stay separate, individually-alerting issues (#1229). The helpers are pure
+/// + `nonisolated`, so this suite is not `@MainActor` and calls them directly — no
+/// spy/delegate, no actor hop. Tests below pass `environment:` explicitly so
+/// assertions stay deterministic regardless of the test bundle's own identifier.
 @Suite("Sentry grouping fingerprints (#1144)")
 struct SentryFingerprintTests {
 
+  /// Fixed env value for tests that aren't specifically about env separation —
+  /// keeps the rest of the fingerprint assertions independent of the test bundle ID.
+  private static let testEnv = "production"
+
   // MARK: - handled-error fingerprint
 
-  @Test("handled-error fingerprint is namespace + category + domain#code")
+  @Test("handled-error fingerprint is namespace + category + domain#code + environment")
   func handledErrorShape() {
     let err = NSError(domain: "EnviousWispr", code: -3)
-    let fp = SentryBreadcrumb.handledErrorFingerprint(for: .xpcServiceError, error: err)
-    #expect(fp == ["handled_error", "xpc_service_error", "EnviousWispr#-3"])
+    let fp = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: err, environment: Self.testEnv)
+    #expect(fp == ["handled_error", "xpc_service_error", "EnviousWispr#-3", Self.testEnv])
   }
 
   @Test("distinct categories produce distinct fingerprints")
   func distinctCategoriesSplit() {
     let err = NSError(domain: "EnviousWispr", code: -3)
-    let paste = SentryBreadcrumb.handledErrorFingerprint(for: .pasteFailed, error: err)
-    let audio = SentryBreadcrumb.handledErrorFingerprint(for: .audioCaptureFailed, error: err)
+    let paste = SentryBreadcrumb.handledErrorFingerprint(
+      for: .pasteFailed, error: err, environment: Self.testEnv)
+    let audio = SentryBreadcrumb.handledErrorFingerprint(
+      for: .audioCaptureFailed, error: err, environment: Self.testEnv)
     #expect(paste != audio)
   }
 
@@ -38,18 +48,22 @@ struct SentryFingerprintTests {
   func sameCategoryDifferentErrorSplits() {
     let asrCrash = NSError(domain: "EnviousWispr", code: -3)
     let replyFail = NSError(domain: "HeartPathError", code: 6)
-    let fpA = SentryBreadcrumb.handledErrorFingerprint(for: .xpcServiceError, error: asrCrash)
-    let fpB = SentryBreadcrumb.handledErrorFingerprint(for: .xpcServiceError, error: replyFail)
+    let fpA = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: asrCrash, environment: Self.testEnv)
+    let fpB = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: replyFail, environment: Self.testEnv)
     #expect(fpA != fpB)
-    #expect(fpA == ["handled_error", "xpc_service_error", "EnviousWispr#-3"])
-    #expect(fpB == ["handled_error", "xpc_service_error", "HeartPathError#6"])
+    #expect(fpA == ["handled_error", "xpc_service_error", "EnviousWispr#-3", Self.testEnv])
+    #expect(fpB == ["handled_error", "xpc_service_error", "HeartPathError#6", Self.testEnv])
   }
 
   @Test("same category and same error is stable across calls")
   func stableForSameInputs() {
     let err = NSError(domain: "EnviousWispr", code: -10)
-    let first = SentryBreadcrumb.handledErrorFingerprint(for: .modelLoadFailed, error: err)
-    let second = SentryBreadcrumb.handledErrorFingerprint(for: .modelLoadFailed, error: err)
+    let first = SentryBreadcrumb.handledErrorFingerprint(
+      for: .modelLoadFailed, error: err, environment: Self.testEnv)
+    let second = SentryBreadcrumb.handledErrorFingerprint(
+      for: .modelLoadFailed, error: err, environment: Self.testEnv)
     #expect(first == second)
   }
 
@@ -59,21 +73,56 @@ struct SentryFingerprintTests {
     let err = NSError(
       domain: "AVFoundationErrorDomain", code: -11800,
       userInfo: [NSLocalizedDescriptionKey: secret])
-    let fp = SentryBreadcrumb.handledErrorFingerprint(for: .audioCaptureFailed, error: err)
-    #expect(fp == ["handled_error", "audio_capture_failed", "AVFoundationErrorDomain#-11800"])
+    let fp = SentryBreadcrumb.handledErrorFingerprint(
+      for: .audioCaptureFailed, error: err, environment: Self.testEnv)
+    #expect(
+      fp == [
+        "handled_error", "audio_capture_failed", "AVFoundationErrorDomain#-11800", Self.testEnv,
+      ]
+    )
     #expect(fp.contains { $0.contains(secret) } == false)
+  }
+
+  // MARK: - environment separation (#1229)
+
+  /// The property PR-B exists to guarantee: stabilizing `structuredDescriptor`
+  /// (killing the per-launch pointer) must not merge dev and prod into one issue —
+  /// that would suppress the first real-user alert, since the triage worker only
+  /// fires on "issue created".
+  @Test("dev and prod fingerprints for the same error differ only in the trailing environment")
+  func devAndProdSplit() {
+    let err = NSError(domain: "EnviousWispr", code: -3)
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: err, environment: "development")
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: err, environment: "production")
+    #expect(dev != prod)
+    #expect(dev.dropLast() == prod.dropLast())
+    #expect(dev.last == "development")
+    #expect(prod.last == "production")
+  }
+
+  @Test("same environment across two calls is byte-identical")
+  func sameEnvironmentIsStable() {
+    let err = NSError(domain: "EnviousWispr", code: -3)
+    let first = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: err, environment: "development")
+    let second = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: err, environment: "development")
+    #expect(first == second)
   }
 
   // MARK: - detail discriminator (#945)
 
-  @Test("optional detail appends a fourth fingerprint component")
+  @Test("optional detail appends an extra fingerprint component before the trailing environment")
   func detailAppends() {
     let err = NSError(domain: "EnviousWisprLLM.LLMError", code: 10)
     let fp = SentryBreadcrumb.handledErrorFingerprint(
-      for: .polishProviderFailed, error: err, detail: "out_of_credits")
+      for: .polishProviderFailed, error: err, detail: "out_of_credits", environment: Self.testEnv)
     #expect(
       fp == [
         "handled_error", "polish_provider_failed", "EnviousWisprLLM.LLMError#10", "out_of_credits",
+        Self.testEnv,
       ]
     )
   }
@@ -85,20 +134,21 @@ struct SentryFingerprintTests {
   func detailSplitsSharedCode() {
     let err = NSError(domain: "EnviousWisprLLM.LLMError", code: 10)
     let credits = SentryBreadcrumb.handledErrorFingerprint(
-      for: .polishProviderFailed, error: err, detail: "out_of_credits")
+      for: .polishProviderFailed, error: err, detail: "out_of_credits", environment: Self.testEnv)
     let rate = SentryBreadcrumb.handledErrorFingerprint(
-      for: .polishProviderFailed, error: err, detail: "rate_limited")
+      for: .polishProviderFailed, error: err, detail: "rate_limited", environment: Self.testEnv)
     #expect(credits != rate)
   }
 
-  @Test("nil detail leaves the legacy three-component fingerprint unchanged")
+  @Test("nil detail leaves the base fingerprint unchanged")
   func nilDetailIsBackwardCompatible() {
     let err = NSError(domain: "EnviousWispr", code: -3)
     let withNil = SentryBreadcrumb.handledErrorFingerprint(
-      for: .xpcServiceError, error: err, detail: nil)
-    let legacy = SentryBreadcrumb.handledErrorFingerprint(for: .xpcServiceError, error: err)
+      for: .xpcServiceError, error: err, detail: nil, environment: Self.testEnv)
+    let legacy = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: err, environment: Self.testEnv)
     #expect(withNil == legacy)
-    #expect(withNil == ["handled_error", "xpc_service_error", "EnviousWispr#-3"])
+    #expect(withNil == ["handled_error", "xpc_service_error", "EnviousWispr#-3", Self.testEnv])
   }
 
   // MARK: - AI-failure fingerprint


### PR DESCRIPTION
## Summary
- Private/nested Swift error types (RecoveryReplayError, RecoveryArmError, NilCollaboratorError, EmojiRestoreAnomaly) bridge to an NSError.domain containing a per-launch "(unknown context at $ptr)" artifact, over 100 chars, which trips the on-device redactor and wipes the Sentry title to [REDACTED]. `structuredDescriptor` now falls back to the plain type name when that artifact is present.
- Stabilizing the descriptor removes the per-launch pointer that today (accidentally) keeps dev-machine and real-user occurrences in separate Sentry issues. `handledErrorFingerprint` now appends the environment explicitly so both keep alerting independently instead of merging.

## Test plan
- [x] `scripts/xcode-test.sh --filter "EnviousWisprTests/SentryFingerprintTests"` - 14 tests pass
- [x] `scripts/xcode-test.sh --filter "EnviousWisprTests/SentryEventSanitizerTests"` - 11 tests pass (including the two new unknown-context normalization tests; the two pre-existing redaction tripwires stay byte-identical)
- [x] `scripts/xcode-test.sh --filter "EnviousWisprTests/HelperObservabilityConfigTests"` - 9 tests pass, confirmed unaffected (separate fingerprint mechanism)
- [x] `swift test --filter "Sentry"` - 40 tests pass
- [x] `swift build -c release` - clean
- [x] Codex code-diff review (`codex review --base origin/main`) - clean, no blocking issues
- [x] Real Sentry round-trip: fabricated a genuine orphan recovery spool (existing attempt marker) and relaunched the dev app to exercise the real `RecoveryReplayError.abandonedAfterAttempt` path end to end. Resulting issue (ENVIOUSWISPR-20) title reads `recovery_abandoned_after_attempt: RecoveryReplayError#1` — not `[REDACTED]`. Confirmed `environment=development`, `app.build_type=debug` tags, and `contexts.os.version`/`contexts.device.model` are present and correctly located (de-risks PR-A's planned field reads).
- [ ] Live UAT: N — pure descriptor/fingerprint logic; this PR does not touch the record/ASR/paste heart path.

Issue #1229 (PR-B of two; PR-A is the Discord alert enrichment worker, follows separately).