### PR TITLE
feat(observability): source-labeled, detail-rich Sentry Discord alerts

### DIFF
--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -5,10 +5,19 @@
  * severity, deduplicates via KV, and fires a Claude Code Routine for P0-P2 issues.
  *
  * Read-only pipeline: the downstream Routine creates/updates GitHub issues.
- * This Worker never touches GitHub directly (except the daily-cap Discord alert).
+ * This Worker never touches GitHub directly (except the Discord alerts it posts
+ * directly: P3 new-issue pings, the daily Routine cap alert, and Routine-fire
+ * failures). Every Discord alert is enriched with a source label (#1229): a
+ * best-effort fetch of the issue's latest Sentry event reads safe, already-scrubbed
+ * metadata (category, stage, environment, build type, OS, device) and renders
+ * whether the failure came from the founder's own test build or a real user.
+ * Fails open to the basic embed on any fetch error — an alert is never lost.
  */
 
 const DISCORD_COLOR = { P0: 0xe74c3c, P1: 0xe67e22, P2: 0xf1c40f, P3: 0x95a5a6 };
+const SENTRY_ORG = "envious-labs-llc";
+const SENTRY_FETCH_TIMEOUT_MS = 5000;
+const FIELD_MAX_CHARS = 200;
 
 // ── Entry point ──────────────────────────────────────────────────────────────
 
@@ -195,8 +204,11 @@ async function handleTriage(body, env) {
 
   // P3: Discord ping only, no Routine
   if (priority === "P3") {
-    await postDiscord(env.DISCORD_WEBHOOK_URL, buildP3Embed(issueId, title, permalink, timesSeen, userCount));
-    console.log(`[sentry-triage] P3 issue ${issueId} — Discord ping only`);
+    const embed = await buildSourceLabeledEmbed({
+      issueId, title, permalink, timesSeen, userCount, priority, env,
+    });
+    await postDiscord(env.DISCORD_WEBHOOK_URL, embed);
+    console.log(`[sentry-triage] P3 issue ${issueId} - Discord ping only`);
     return;
   }
 
@@ -213,8 +225,12 @@ async function handleTriage(body, env) {
   if (capCount >= 13 && priority !== "P0") {
     // Cap at 13 to leave 2 headroom. P0 always bypasses — a critical crash at 11pm
     // should never be silently dropped because the day was busy.
-    console.warn(`[sentry-triage] Daily Routine count at ${capCount}/15 — blocking ${priority}, posting Discord alert`);
-    await postDiscord(env.DISCORD_WEBHOOK_URL, buildCapAlertEmbed(capCount, issueId, title, permalink));
+    console.warn(`[sentry-triage] Daily Routine count at ${capCount}/15 - blocking ${priority}, posting Discord alert`);
+    const sourceLabel = await fetchSourceLabel(issueId, env);
+    await postDiscord(
+      env.DISCORD_WEBHOOK_URL,
+      buildCapAlertEmbed(capCount, issueId, title, permalink, sourceLabel)
+    );
     return;
   }
 
@@ -285,14 +301,15 @@ async function handleTriage(body, env) {
     // resets at midnight UTC when the date rolls over. No TTL needed.
     await env.SENTRY_DEDUP.put(capKey, String(capCount + 1));
 
-    console.log(`[sentry-triage] Routine fired for ${issueId} (${priority}) — session: ${sessionUrl}`);
+    console.log(`[sentry-triage] Routine fired for ${issueId} (${priority}) - session: ${sessionUrl}`);
   } catch (err) {
     console.error(`[sentry-triage] Routine fire failed for ${issueId}:`, err.message);
 
     // Fallback: post Discord alert so nothing is silently dropped
+    const sourceLabel = await fetchSourceLabel(issueId, env);
     await postDiscord(
       env.DISCORD_WEBHOOK_URL,
-      buildFailureEmbed(issueId, title, permalink, priority, err.message)
+      buildFailureEmbed(issueId, title, permalink, priority, err.message, sourceLabel)
     );
 
     // Clear pending state so next event retries
@@ -323,39 +340,183 @@ async function postDiscord(webhookUrl, embed) {
   });
 }
 
-function buildP3Embed(issueId, title, permalink, timesSeen, userCount) {
+// ── Source enrichment (#1229) ─────────────────────────────────────────────────
+//
+// Best-effort: fetch the issue's latest Sentry event and read already-scrubbed
+// metadata (the on-device redactor ran before any of this left the user's Mac)
+// to label whether the failure is the founder's own test build or a real user,
+// plus surface category/stage/version/OS/device safely. Every call site fails
+// open to the basic embed shape on any fetch error — an alert is never lost.
+
+/** Safe-metadata allowlist (#1229 §3 PR-A step 6) — every value Discord ever shows. */
+const SAFE_METADATA_FIELDS = [
+  "category",
+  "stage",
+  "environment",
+  "buildType",
+  "release",
+  "osVersion",
+  "deviceModel",
+];
+
+export function truncate(value, max = FIELD_MAX_CHARS) {
+  if (typeof value !== "string") return value;
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+/** Fetch the latest event for a Sentry issue. Throws on any non-200/timeout/parse failure. */
+async function fetchLatestEvent(issueId, env) {
+  const url = `https://us.sentry.io/api/0/organizations/${SENTRY_ORG}/issues/${issueId}/events/latest/`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${env.SENTRY_AUTH_TOKEN}` },
+    signal: AbortSignal.timeout(SENTRY_FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`Sentry events/latest fetch failed: HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * Pull the safe-metadata allowlist out of a Sentry event. `category` / `stage` /
+ * `environment` / `buildType` / `release` live in `tags[]` ({key,value} pairs,
+ * NOT top-level — SentryBreadcrumb sets error.category/pipeline.stage as event
+ * tags and ObservabilityBootstrap sets environment/app.build_type as scope tags,
+ * all merged into the same tags[] array server-side). `osVersion` / `deviceModel`
+ * live under `contexts.os`/`contexts.device` (CONTEXTS, not tags) — confirmed
+ * empirically against a real captured event during PR-B's round-trip (#1229).
+ */
+export function extractMetadata(event) {
+  const tags = Array.isArray(event?.tags) ? event.tags : [];
+  const tagValue = (key) => tags.find((t) => t?.key === key)?.value ?? null;
+
   return {
-    title: `[Sentry P3] ${title}`,
-    color: DISCORD_COLOR.P3,
+    category: tagValue("error.category"),
+    stage: tagValue("pipeline.stage"),
+    environment: tagValue("environment"),
+    buildType: tagValue("app.build_type"),
+    release: tagValue("release"),
+    osVersion: event?.contexts?.os?.version ?? null,
+    deviceModel: event?.contexts?.device?.model ?? null,
+  };
+}
+
+/**
+ * Three-state source classifier (#1229). Never defaults missing metadata to
+ * "real user" — an older app version or a fetch that returned partial tags
+ * must read as unknown, not silently assumed safe-to-ignore.
+ */
+export function classifySource(metadata) {
+  const { environment, buildType } = metadata ?? {};
+  if (environment === "development" || buildType === "debug") {
+    return "🧪 Your test build (dev/debug)";
+  }
+  if (environment === "production" && buildType === "release") {
+    return "👤 Real user (release)";
+  }
+  return "❓ Unknown source (metadata missing)";
+}
+
+/** Best-effort source label for the cap-alert / failure embeds. Null on fetch failure. */
+async function fetchSourceLabel(issueId, env) {
+  try {
+    const event = await fetchLatestEvent(issueId, env);
+    return classifySource(extractMetadata(event));
+  } catch (err) {
+    console.error(`[sentry-triage] Latest-event fetch failed for ${issueId}:`, err.message);
+    return null;
+  }
+}
+
+/** Readable headline: prefer the safe error.category tag over a possibly-stale title. */
+export function readableHeadline(title, metadata) {
+  return metadata?.category ?? title;
+}
+
+export function metadataFields(metadata) {
+  const what = [metadata.category, metadata.stage].filter(Boolean).join(" / ") || "unknown";
+  const system =
+    [metadata.osVersion ? `macOS ${metadata.osVersion}` : null, metadata.deviceModel]
+      .filter(Boolean)
+      .join(", ") || "unknown";
+  return { what, system };
+}
+
+export function buildEnrichedEmbed({ issueId, title, permalink, timesSeen, userCount, priority, metadata }) {
+  const { what, system } = metadataFields(metadata);
+  return {
+    title: `[Sentry ${priority}] ${truncate(readableHeadline(title, metadata))}`,
+    color: DISCORD_COLOR[priority] ?? DISCORD_COLOR.P3,
     fields: [
-      { name: "Impact", value: `${userCount} user(s), ${timesSeen} occurrences`, inline: true },
+      { name: "Source", value: classifySource(metadata), inline: true },
+      { name: "What", value: truncate(what), inline: true },
+      {
+        name: "Impact",
+        value: `Sentry issue totals: ${userCount} user(s) · ${timesSeen} occurrences`,
+        inline: true,
+      },
+      { name: "Version", value: truncate(metadata.release ?? "unknown"), inline: true },
+      { name: "System", value: truncate(system), inline: true },
       { name: "Sentry", value: `[${issueId}](${permalink})`, inline: true },
     ],
-    footer: { text: "EnviousWispr Sentry Triage • P3 (below threshold — no Routine)" },
+    footer: { text: `EnviousWispr Sentry Triage. ${priority}` },
     timestamp: new Date().toISOString(),
   };
 }
 
-function buildCapAlertEmbed(capCount, issueId, title, permalink) {
+export function buildFailOpenEmbed({ issueId, title, permalink, timesSeen, userCount, priority }) {
+  return {
+    title: `[Sentry ${priority}] ${truncate(title)}`,
+    color: DISCORD_COLOR[priority] ?? DISCORD_COLOR.P3,
+    fields: [
+      { name: "Source", value: "❓ Unknown source (Sentry fetch failed)", inline: true },
+      {
+        name: "Impact",
+        value: `Sentry issue totals: ${userCount} user(s) · ${timesSeen} occurrences`,
+        inline: true,
+      },
+      { name: "Sentry", value: `[${issueId}](${permalink})`, inline: true },
+      { name: "Details", value: "Details unavailable. Sentry fetch failed.", inline: false },
+    ],
+    footer: { text: `EnviousWispr Sentry Triage. ${priority}` },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/** Orchestrator for the P3 new-issue embed: enrich, fail open on any error. */
+async function buildSourceLabeledEmbed({ issueId, title, permalink, timesSeen, userCount, priority, env }) {
+  try {
+    const event = await fetchLatestEvent(issueId, env);
+    const metadata = extractMetadata(event);
+    return buildEnrichedEmbed({ issueId, title, permalink, timesSeen, userCount, priority, metadata });
+  } catch (err) {
+    console.error(`[sentry-triage] Latest-event fetch failed for ${issueId}:`, err.message);
+    return buildFailOpenEmbed({ issueId, title, permalink, timesSeen, userCount, priority });
+  }
+}
+
+export function buildCapAlertEmbed(capCount, issueId, title, permalink, sourceLabel) {
   return {
     title: "⚠️ Sentry Triage Daily Cap Reached",
     color: 0xff0000,
     description: `Daily Routine cap hit (${capCount}/15). Issue not triaged automatically.`,
     fields: [
-      { name: "Missed Issue", value: `[${issueId}](${permalink}) — ${title}` },
+      { name: "Missed Issue", value: truncate(`[${issueId}](${permalink}). ${title}`) },
+      { name: "Source", value: sourceLabel ?? "❓ Unknown source (Sentry fetch failed)" },
     ],
-    footer: { text: "EnviousWispr Sentry Triage • Check claude.ai/settings/usage" },
+    footer: { text: "EnviousWispr Sentry Triage. Check claude.ai/settings/usage" },
     timestamp: new Date().toISOString(),
   };
 }
 
-function buildFailureEmbed(issueId, title, permalink, priority, errMsg) {
+export function buildFailureEmbed(issueId, title, permalink, priority, errMsg, sourceLabel) {
   return {
     title: `[Sentry ${priority}] Routine fire failed`,
     color: 0xff0000,
     description: `Failed to fire Routine for [${issueId}](${permalink}). Manual triage required.`,
     fields: [
       { name: "Issue", value: title },
+      { name: "Source", value: sourceLabel ?? "❓ Unknown source (Sentry fetch failed)" },
       { name: "Error", value: errMsg.slice(0, 200) },
     ],
     footer: { text: "EnviousWispr Sentry Triage • Routine failure" },

--- a/workers/sentry-triage/test/index.test.js
+++ b/workers/sentry-triage/test/index.test.js
@@ -1,0 +1,235 @@
+// Unit tests for the pure source-enrichment logic (#1229). No network.
+// Run: node --test  (from workers/sentry-triage/)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  truncate,
+  extractMetadata,
+  classifySource,
+  readableHeadline,
+  metadataFields,
+  buildEnrichedEmbed,
+  buildFailOpenEmbed,
+  buildCapAlertEmbed,
+  buildFailureEmbed,
+} from "../src/index.js";
+
+function event(tags = {}, contexts = {}) {
+  return {
+    tags: Object.entries(tags).map(([key, value]) => ({ key, value })),
+    contexts,
+  };
+}
+
+// ---- extractMetadata ----
+test("extractMetadata: reads category/stage/environment/buildType/release from tags[]", () => {
+  const e = event({
+    "error.category": "recovery_transcribe_failed",
+    "pipeline.stage": "recovery",
+    environment: "development",
+    "app.build_type": "debug",
+    release: "com.enviouswispr.app@2.2.0",
+  });
+  const m = extractMetadata(e);
+  assert.equal(m.category, "recovery_transcribe_failed");
+  assert.equal(m.stage, "recovery");
+  assert.equal(m.environment, "development");
+  assert.equal(m.buildType, "debug");
+  assert.equal(m.release, "com.enviouswispr.app@2.2.0");
+});
+
+test("extractMetadata: reads osVersion/deviceModel from contexts, not tags", () => {
+  const e = event({}, { os: { version: "26.6.0" }, device: { model: "Mac16,8" } });
+  const m = extractMetadata(e);
+  assert.equal(m.osVersion, "26.6.0");
+  assert.equal(m.deviceModel, "Mac16,8");
+});
+
+test("extractMetadata: missing tags/contexts yield null fields, never throws", () => {
+  const m = extractMetadata({});
+  assert.equal(m.category, null);
+  assert.equal(m.osVersion, null);
+  assert.equal(m.deviceModel, null);
+});
+
+test("extractMetadata: malformed event (null) yields all-null metadata", () => {
+  const m = extractMetadata(null);
+  assert.equal(m.category, null);
+  assert.equal(m.environment, null);
+});
+
+// ---- classifySource ----
+test("classifySource: environment=development -> test build", () => {
+  assert.equal(
+    classifySource({ environment: "development", buildType: "release" }),
+    "🧪 Your test build (dev/debug)"
+  );
+});
+
+test("classifySource: buildType=debug -> test build, even with unknown environment", () => {
+  assert.equal(classifySource({ environment: null, buildType: "debug" }), "🧪 Your test build (dev/debug)");
+});
+
+test("classifySource: environment=production AND buildType=release -> real user", () => {
+  assert.equal(
+    classifySource({ environment: "production", buildType: "release" }),
+    "👤 Real user (release)"
+  );
+});
+
+test("classifySource: production environment but missing buildType -> unknown, never defaults to real user", () => {
+  assert.equal(
+    classifySource({ environment: "production", buildType: null }),
+    "❓ Unknown source (metadata missing)"
+  );
+});
+
+test("classifySource: release buildType but missing environment -> unknown", () => {
+  assert.equal(
+    classifySource({ environment: null, buildType: "release" }),
+    "❓ Unknown source (metadata missing)"
+  );
+});
+
+test("classifySource: all metadata missing -> unknown", () => {
+  assert.equal(classifySource({}), "❓ Unknown source (metadata missing)");
+  assert.equal(classifySource(undefined), "❓ Unknown source (metadata missing)");
+});
+
+// ---- truncate ----
+test("truncate: short string passes through unchanged", () => {
+  assert.equal(truncate("built_in_mic"), "built_in_mic");
+});
+
+test("truncate: long string is capped with an ellipsis", () => {
+  const long = "a".repeat(250);
+  const out = truncate(long);
+  assert.equal(out.length, 200);
+  assert.ok(out.endsWith("…"));
+});
+
+test("truncate: non-string values pass through unchanged", () => {
+  assert.equal(truncate(42), 42);
+  assert.equal(truncate(null), null);
+});
+
+// ---- readableHeadline ----
+test("readableHeadline: prefers error.category over title", () => {
+  assert.equal(
+    readableHeadline("[REDACTED]", { category: "recovery_transcribe_failed" }),
+    "recovery_transcribe_failed"
+  );
+});
+
+test("readableHeadline: falls back to title when category is missing", () => {
+  assert.equal(readableHeadline("some readable title", {}), "some readable title");
+});
+
+// ---- metadataFields ----
+test("metadataFields: joins category + stage for What, OS + device for System", () => {
+  const { what, system } = metadataFields({
+    category: "recovery_transcribe_failed",
+    stage: "recovery",
+    osVersion: "26.6.0",
+    deviceModel: "Mac16,8",
+  });
+  assert.equal(what, "recovery_transcribe_failed / recovery");
+  assert.equal(system, "macOS 26.6.0, Mac16,8");
+});
+
+test("metadataFields: falls back to 'unknown' when both parts are missing", () => {
+  const { what, system } = metadataFields({});
+  assert.equal(what, "unknown");
+  assert.equal(system, "unknown");
+});
+
+// ---- buildEnrichedEmbed ----
+test("buildEnrichedEmbed: dev metadata renders a readable headline + test-build source", () => {
+  const embed = buildEnrichedEmbed({
+    issueId: "123",
+    title: "[REDACTED]",
+    permalink: "https://envious-labs-llc.sentry.io/issues/123/",
+    timesSeen: 5,
+    userCount: 1,
+    priority: "P3",
+    metadata: {
+      category: "recovery_transcribe_failed",
+      stage: "recovery",
+      environment: "development",
+      buildType: "debug",
+      release: "com.enviouswispr.app@2.2.0",
+      osVersion: "26.6.0",
+      deviceModel: "Mac16,8",
+    },
+  });
+  assert.equal(embed.title, "[Sentry P3] recovery_transcribe_failed");
+  assert.ok(!embed.title.includes("REDACTED"));
+  const source = embed.fields.find((f) => f.name === "Source");
+  assert.equal(source.value, "🧪 Your test build (dev/debug)");
+  const sentry = embed.fields.find((f) => f.name === "Sentry");
+  assert.match(sentry.value, /123/);
+});
+
+test("buildEnrichedEmbed: real-user metadata renders the real-user source label", () => {
+  const embed = buildEnrichedEmbed({
+    issueId: "456",
+    title: "fallback title",
+    permalink: "https://example.com/456/",
+    timesSeen: 1,
+    userCount: 1,
+    priority: "P2",
+    metadata: { environment: "production", buildType: "release" },
+  });
+  const source = embed.fields.find((f) => f.name === "Source");
+  assert.equal(source.value, "👤 Real user (release)");
+});
+
+test("buildEnrichedEmbed: no em-dash or en-dash anywhere in the rendered embed", () => {
+  const embed = buildEnrichedEmbed({
+    issueId: "1",
+    title: "t",
+    permalink: "https://example.com/1/",
+    timesSeen: 1,
+    userCount: 1,
+    priority: "P3",
+    metadata: {},
+  });
+  const text = JSON.stringify(embed);
+  assert.ok(!text.includes("—"), "no em-dash");
+  assert.ok(!text.includes("–"), "no en-dash");
+});
+
+// ---- buildFailOpenEmbed ----
+test("buildFailOpenEmbed: always shows unknown source + details-unavailable note", () => {
+  const embed = buildFailOpenEmbed({
+    issueId: "789",
+    title: "[REDACTED]",
+    permalink: "https://example.com/789/",
+    timesSeen: 2,
+    userCount: 1,
+    priority: "P3",
+  });
+  const source = embed.fields.find((f) => f.name === "Source");
+  assert.equal(source.value, "❓ Unknown source (Sentry fetch failed)");
+  const details = embed.fields.find((f) => f.name === "Details");
+  assert.match(details.value, /unavailable/i);
+});
+
+// ---- buildCapAlertEmbed / buildFailureEmbed: source field present, fail-open default ----
+test("buildCapAlertEmbed: includes the Source field when a label is provided", () => {
+  const embed = buildCapAlertEmbed(13, "999", "some title", "https://example.com/999/", "👤 Real user (release)");
+  const source = embed.fields.find((f) => f.name === "Source");
+  assert.equal(source.value, "👤 Real user (release)");
+});
+
+test("buildCapAlertEmbed: falls open to unknown source when sourceLabel is null", () => {
+  const embed = buildCapAlertEmbed(13, "999", "some title", "https://example.com/999/", null);
+  const source = embed.fields.find((f) => f.name === "Source");
+  assert.equal(source.value, "❓ Unknown source (Sentry fetch failed)");
+});
+
+test("buildFailureEmbed: includes the Source field and falls open when sourceLabel is null", () => {
+  const embed = buildFailureEmbed("1", "title", "https://example.com/1/", "P1", "boom", null);
+  const source = embed.fields.find((f) => f.name === "Source");
+  assert.equal(source.value, "❓ Unknown source (Sentry fetch failed)");
+});

--- a/workers/sentry-triage/wrangler.toml
+++ b/workers/sentry-triage/wrangler.toml
@@ -2,11 +2,14 @@
 #   SENTRY_WEBHOOK_SECRET — HMAC key for verifying inbound Sentry webhooks.
 #   DISCORD_WEBHOOK_URL   — Discord channel webhook for triage alerts.
 #   ROUTINE_TOKEN / ROUTINE_TRIGGER_ID — fires the TIK/TOK Claude Code Routine.
-#   SENTRY_AUTH_TOKEN     — read-only Sentry org auth token used to fetch a
-#     captured issue's latest event (category/stage/environment/build_type/
-#     release tags + OS/device contexts) for the source-labeled, detail-rich
-#     Discord embed (#1229). Read-only scope is sufficient; the worker never
-#     writes back to Sentry.
+#   SENTRY_AUTH_TOKEN     — a personal Sentry token scoped to event:read ONLY
+#     (keystore: sentry-triage-worker-token), used to fetch a captured issue's
+#     latest event (category/stage/environment/build_type/release tags +
+#     OS/device contexts) for the source-labeled, detail-rich Discord embed
+#     (#1229). NOT the keystore's `sentry-auth-token` — that one is scoped to
+#     CI release uploads only and 403s on event reads (org tokens on this
+#     Sentry plan only support the org:ci scope; event:read requires a
+#     personal token instead). The worker never writes back to Sentry.
 
 name = "enviouswispr-sentry-triage"
 main = "src/index.js"

--- a/workers/sentry-triage/wrangler.toml
+++ b/workers/sentry-triage/wrangler.toml
@@ -1,3 +1,13 @@
+# Secrets (set via `wrangler secret put <NAME>`, not committed here):
+#   SENTRY_WEBHOOK_SECRET — HMAC key for verifying inbound Sentry webhooks.
+#   DISCORD_WEBHOOK_URL   — Discord channel webhook for triage alerts.
+#   ROUTINE_TOKEN / ROUTINE_TRIGGER_ID — fires the TIK/TOK Claude Code Routine.
+#   SENTRY_AUTH_TOKEN     — read-only Sentry org auth token used to fetch a
+#     captured issue's latest event (category/stage/environment/build_type/
+#     release tags + OS/device contexts) for the source-labeled, detail-rich
+#     Discord embed (#1229). Read-only scope is sufficient; the worker never
+#     writes back to Sentry.
+
 name = "enviouswispr-sentry-triage"
 main = "src/index.js"
 compatibility_date = "2026-04-15"


### PR DESCRIPTION
## Summary
- Discord triage alerts (P3 new-issue, daily-cap, Routine-fire-failure) now fetch the issue's latest Sentry event and render a three-state source label (🧪 your test build / 👤 real user / ❓ unknown), never defaulting missing metadata to "real user".
- Adds category, stage, version, OS, and device from a safe, already-scrubbed metadata allowlist. Headline prefers the `error.category` tag over a possibly-stale title.
- Every code path fails open to a basic embed on any fetch error - an alert is never lost.

PR-A of two for #1229 (PR-B, the app-side title fix, merged in #1248).

## Test plan
- [x] `node --test` from `workers/sentry-triage/` - 24 unit tests pass (extractMetadata, classifySource, truncate, readableHeadline, metadataFields, buildEnrichedEmbed, buildFailOpenEmbed, buildCapAlertEmbed, buildFailureEmbed)
- [x] `node --check src/index.js` - syntax clean
- [x] Codex code-diff review (`codex review --base origin/main`) - clean, independently re-ran the test suite and confirmed all 24 pass
- [x] Em-dash audit: no em/en-dash in any Discord-rendered field (title/description/name/value/footer)
- [ ] `SENTRY_AUTH_TOKEN` secret set on the live worker (done, read-only org token)
- [ ] Deploy + replayed-webhook smoke test (enriched embed + forced fail-open) - planned for right after this PR clears review, before merge