### PR TITLE
feat(settings): persist the dictation-audio debug archive toggle across rebuilds

### DIFF
--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -178,7 +178,7 @@ final class PipelineSettingsSync {
     case .crashRecoveryEnabled:
       break  // #1063: read by the recovery wiring at capture start, not the live pipeline.
     case .isDictationAudioArchiveEnabled:
-      break  // #1247: read once at kernel construction (WisprBootstrapper); not live-mirrored.
+      break  // #1247: kernel pulls this live via `dictationAudioArchiveOptInProvider` — no push needed here.
     case .appearance:
       break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
     }

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -177,6 +177,8 @@ final class PipelineSettingsSync {
       break  // UI-only or cold flag.
     case .crashRecoveryEnabled:
       break  // #1063: read by the recovery wiring at capture start, not the live pipeline.
+    case .isDictationAudioArchiveEnabled:
+      break  // #1247: read once at kernel construction (WisprBootstrapper); not live-mirrored.
     case .appearance:
       break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
     }

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -82,8 +82,9 @@ enum SettingsProjection {
     case .cancelKeyCode, .cancelModifiers: return .cancelHotkeyShape
     // Not instrumented.
     case .selectedBackend, .onboardingState, .hasCompletedOnboarding,
-      .isDebugModeEnabled, .debugLogLevel, .whisperKitLanguage, .selectedInputDeviceUID,
-      .noiseSuppression, .preferredInputDeviceIDOverride, .useXPCAudioService:
+      .isDebugModeEnabled, .isDictationAudioArchiveEnabled, .debugLogLevel, .whisperKitLanguage,
+      .selectedInputDeviceUID, .noiseSuppression, .preferredInputDeviceIDOverride,
+      .useXPCAudioService:
       return nil
     }
   }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -158,7 +158,8 @@ public final class WisprBootstrapper {
         keychainManager: keychainManager,
         captureTelemetry: captureTelemetry,
         pasteCompletionRegistry: pasteCompletionRegistry,
-        outputClassifierHolder: outputClassifierHolder
+        outputClassifierHolder: outputClassifierHolder,
+        dictationAudioArchiveOptIn: settings.isDictationAudioArchiveEnabled
       ))
 
     // W6: language-flip telemetry wired via a closure so `EnviousWisprASR`
@@ -195,7 +196,8 @@ public final class WisprBootstrapper {
         keychainManager: keychainManager,
         captureTelemetry: captureTelemetry,
         pasteCompletionRegistry: pasteCompletionRegistry,
-        outputClassifierHolder: outputClassifierHolder
+        outputClassifierHolder: outputClassifierHolder,
+        dictationAudioArchiveOptIn: settings.isDictationAudioArchiveEnabled
       ))
 
     // Phase F (#501) — `SetupCoordinator` needs `asrManager` + the WhisperKit

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -159,7 +159,7 @@ public final class WisprBootstrapper {
         captureTelemetry: captureTelemetry,
         pasteCompletionRegistry: pasteCompletionRegistry,
         outputClassifierHolder: outputClassifierHolder,
-        dictationAudioArchiveOptIn: settings.isDictationAudioArchiveEnabled
+        dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled }
       ))
 
     // W6: language-flip telemetry wired via a closure so `EnviousWisprASR`
@@ -197,7 +197,7 @@ public final class WisprBootstrapper {
         captureTelemetry: captureTelemetry,
         pasteCompletionRegistry: pasteCompletionRegistry,
         outputClassifierHolder: outputClassifierHolder,
-        dictationAudioArchiveOptIn: settings.isDictationAudioArchiveEnabled
+        dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled }
       ))
 
     // Phase F (#501) — `SetupCoordinator` needs `asrManager` + the WhisperKit

--- a/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
@@ -113,6 +113,28 @@ struct DiagnosticsSettingsView: View {
             }
           }
         }
+        #if DEBUG
+          // Intentionally NOT gated by `isDebugModeEnabled` above (Codex review,
+          // #1247): the archive opt-in is a sticky, independently-persisted flag,
+          // so if it's already on, the control that turns it off must stay
+          // visible regardless of whether debug mode is currently toggled —
+          // otherwise active mic-audio retention could be invisible. `#if DEBUG`
+          // keeps the row itself out of release, where the archive doesn't exist.
+          BrandedRow(showDivider: false) {
+            VStack(alignment: .leading, spacing: 4) {
+              Toggle(
+                "Save dictation audio for debugging",
+                isOn: $settings.isDictationAudioArchiveEnabled
+              )
+              .toggleStyle(BrandedToggleStyle())
+              Text(
+                "Saves a local copy of each dictation's audio for diagnosing transcription issues. Stored only on this Mac, newest 500 recordings kept. Persists across rebuilds. Takes effect the next time the app starts, not the current session."
+              )
+              .font(.stHelper)
+              .foregroundStyle(.stTextTertiary)
+            }
+          }
+        #endif
       }
 
       // ── Log Files ─────────────────────────────────────────────────────

--- a/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/DiagnosticsSettingsView.swift
@@ -128,7 +128,7 @@ struct DiagnosticsSettingsView: View {
               )
               .toggleStyle(BrandedToggleStyle())
               Text(
-                "Saves a local copy of each dictation's audio for diagnosing transcription issues. Stored only on this Mac, newest 500 recordings kept. Persists across rebuilds. Takes effect the next time the app starts, not the current session."
+                "Saves a local copy of each dictation's audio for diagnosing transcription issues. Stored only on this Mac, newest 500 recordings kept. Persists across rebuilds. Applies starting with your very next dictation."
               )
               .font(.stHelper)
               .foregroundStyle(.stTextTertiary)

--- a/Sources/EnviousWisprPipeline/DictationAudioArchive.swift
+++ b/Sources/EnviousWisprPipeline/DictationAudioArchive.swift
@@ -43,6 +43,15 @@ import Foundation
     /// over byte-count avoids a recursive stat on every prune.
     static let maxRetainedDirectories = 500
 
+    /// The enablement gate's two sources, OR'd: the ad-hoc env var (`envValue`,
+    /// the raw `ProcessInfo` lookup so this stays a pure function) and the
+    /// persisted Settings toggle (#1247), which survives rebuilds. Extracted so
+    /// the OR logic itself has direct unit coverage independent of the
+    /// directory/XCTest seam in `archive(...)`.
+    static func isArchiveOptedIn(envValue: String?, settingsOptIn: Bool) -> Bool {
+      envValue == "1" || settingsOptIn
+    }
+
     /// The terminal outcome label written to `meta.json`. `CaseIterable` so the
     /// coverage freeze test can lock the set — a new terminal label is a
     /// conscious test change, never a silent gap.
@@ -91,13 +100,22 @@ import Foundation
       backend: String,
       now: Date = Date(),
       directory: URL? = nil,
-      maxRetained: Int = DictationAudioArchive.maxRetainedDirectories
+      maxRetained: Int = DictationAudioArchive.maxRetainedDirectories,
+      settingsOptIn: Bool = false
     ) async -> String? {
       guard !raw.isEmpty else { return nil }
-      // Production/contributor builds: off unless explicitly opted in. Tests
-      // pass an explicit `directory:` and bypass both gates.
+      // Production/contributor builds: off unless explicitly opted in (env var,
+      // for ad-hoc dev runs, or the persisted Settings toggle, #1247, which
+      // survives rebuilds). Tests pass an explicit `directory:` and bypass both
+      // gates.
       if directory == nil {
-        guard ProcessInfo.processInfo.environment[optInEnvVar] == "1" else { return nil }
+        guard
+          isArchiveOptedIn(
+            envValue: ProcessInfo.processInfo.environment[optInEnvVar], settingsOptIn: settingsOptIn
+          )
+        else {
+          return nil
+        }
         // Full-suite kernel tests exercise the real terminals; without this the
         // dogfood corpus would be contaminated by synthetic buffers.
         if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -86,6 +86,10 @@ public enum KernelDictationDriverFactory {
     /// nil when no classifier (tests, or before prewarm). Read lazily at polish
     /// time by `LLMPolishStep`.
     package let outputClassifierHolder: OutputClassifierHolder?
+    /// #1247: persisted Settings opt-in for the DEBUG-only dictation-audio
+    /// archive (#1230), read once at app launch. Forwarded into the kernel's
+    /// `dictationAudioArchiveOptIn` init parameter.
+    package let dictationAudioArchiveOptIn: Bool
 
     /// Explicit package init: Swift's synthesized memberwise init is `internal`
     /// and would prevent App callers from constructing this struct. `@MainActor`
@@ -102,7 +106,8 @@ public enum KernelDictationDriverFactory {
       captureTelemetry: CaptureTelemetryState,
       pasteCompletionRegistry: PasteCompletionRegistry,
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
-      outputClassifierHolder: OutputClassifierHolder? = nil
+      outputClassifierHolder: OutputClassifierHolder? = nil,
+      dictationAudioArchiveOptIn: Bool = false
     ) {
       self.audioCapture = audioCapture
       self.asrManager = asrManager
@@ -113,6 +118,7 @@ public enum KernelDictationDriverFactory {
       self.pasteCompletionRegistry = pasteCompletionRegistry
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
+      self.dictationAudioArchiveOptIn = dictationAudioArchiveOptIn
     }
   }
 
@@ -134,6 +140,9 @@ public enum KernelDictationDriverFactory {
     /// App-owned output-safety classifier holder (#832/#913 PR8). See
     /// `ParakeetInputs.outputClassifierHolder`.
     package let outputClassifierHolder: OutputClassifierHolder?
+    /// #1247: persisted Settings opt-in for the DEBUG-only dictation-audio
+    /// archive (#1230). See `ParakeetInputs.dictationAudioArchiveOptIn`.
+    package let dictationAudioArchiveOptIn: Bool
 
     /// Explicit package init — same reasoning as `ParakeetInputs.init`.
     /// `languageDetector` is intentionally non-optional (no default) so the
@@ -153,7 +162,8 @@ public enum KernelDictationDriverFactory {
       captureTelemetry: CaptureTelemetryState,
       pasteCompletionRegistry: PasteCompletionRegistry,
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
-      outputClassifierHolder: OutputClassifierHolder? = nil
+      outputClassifierHolder: OutputClassifierHolder? = nil,
+      dictationAudioArchiveOptIn: Bool = false
     ) {
       self.audioCapture = audioCapture
       self.whisperKitBackend = whisperKitBackend
@@ -165,6 +175,7 @@ public enum KernelDictationDriverFactory {
       self.pasteCompletionRegistry = pasteCompletionRegistry
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
+      self.dictationAudioArchiveOptIn = dictationAudioArchiveOptIn
     }
   }
 
@@ -217,7 +228,8 @@ public enum KernelDictationDriverFactory {
       captureTelemetry: inputs.captureTelemetry,
       pasteCompletionRegistry: inputs.pasteCompletionRegistry,
       captureErrorSink: inputs.captureErrorSink,
-      outputClassifierHolder: inputs.outputClassifierHolder)
+      outputClassifierHolder: inputs.outputClassifierHolder,
+      dictationAudioArchiveOptIn: inputs.dictationAudioArchiveOptIn)
   }
 
   /// Build the driver stack for the WhisperKit engine. PR-5 Rung 5 flips the
@@ -245,7 +257,8 @@ public enum KernelDictationDriverFactory {
       captureTelemetry: inputs.captureTelemetry,
       pasteCompletionRegistry: inputs.pasteCompletionRegistry,
       captureErrorSink: inputs.captureErrorSink,
-      outputClassifierHolder: inputs.outputClassifierHolder)
+      outputClassifierHolder: inputs.outputClassifierHolder,
+      dictationAudioArchiveOptIn: inputs.dictationAudioArchiveOptIn)
   }
 
   /// Engine-agnostic assembler. The two package entry points construct their
@@ -262,7 +275,8 @@ public enum KernelDictationDriverFactory {
     captureTelemetry: CaptureTelemetryState,
     pasteCompletionRegistry: PasteCompletionRegistry,
     captureErrorSink: @escaping HeartPathCaptureErrorSink,
-    outputClassifierHolder: OutputClassifierHolder? = nil
+    outputClassifierHolder: OutputClassifierHolder? = nil,
+    dictationAudioArchiveOptIn: Bool = false
   ) -> KernelDictationDriver {
     // 1. LimbSteps — same instances driver + wiring hold by reference.
     // #832/#913 PR8: the live-dictation LLMPolishStep receives the app-owned
@@ -380,7 +394,8 @@ public enum KernelDictationDriverFactory {
       markASRTimingEnd: {
         outcome.asrEndedAtSeconds = CFAbsoluteTimeGetCurrent()
       },
-      telemetryState: telemetryState
+      telemetryState: telemetryState,
+      dictationAudioArchiveOptIn: dictationAudioArchiveOptIn
     )
     telemetryRelay.kernel = kernel
 

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -86,10 +86,12 @@ public enum KernelDictationDriverFactory {
     /// nil when no classifier (tests, or before prewarm). Read lazily at polish
     /// time by `LLMPolishStep`.
     package let outputClassifierHolder: OutputClassifierHolder?
-    /// #1247: persisted Settings opt-in for the DEBUG-only dictation-audio
-    /// archive (#1230), read once at app launch. Forwarded into the kernel's
-    /// `dictationAudioArchiveOptIn` init parameter.
-    package let dictationAudioArchiveOptIn: Bool
+    /// #1247: live read of the persisted Settings opt-in for the DEBUG-only
+    /// dictation-audio archive (#1230). Forwarded into the kernel's
+    /// `dictationAudioArchiveOptInProvider` init parameter — a closure, not a
+    /// frozen value, so an off-flip stops archiving on the very next
+    /// dictation (cloud review, PR #1250).
+    package let dictationAudioArchiveOptInProvider: @MainActor () -> Bool
 
     /// Explicit package init: Swift's synthesized memberwise init is `internal`
     /// and would prevent App callers from constructing this struct. `@MainActor`
@@ -107,7 +109,7 @@ public enum KernelDictationDriverFactory {
       pasteCompletionRegistry: PasteCompletionRegistry,
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
-      dictationAudioArchiveOptIn: Bool = false
+      dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false }
     ) {
       self.audioCapture = audioCapture
       self.asrManager = asrManager
@@ -118,7 +120,7 @@ public enum KernelDictationDriverFactory {
       self.pasteCompletionRegistry = pasteCompletionRegistry
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
-      self.dictationAudioArchiveOptIn = dictationAudioArchiveOptIn
+      self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
     }
   }
 
@@ -140,9 +142,10 @@ public enum KernelDictationDriverFactory {
     /// App-owned output-safety classifier holder (#832/#913 PR8). See
     /// `ParakeetInputs.outputClassifierHolder`.
     package let outputClassifierHolder: OutputClassifierHolder?
-    /// #1247: persisted Settings opt-in for the DEBUG-only dictation-audio
-    /// archive (#1230). See `ParakeetInputs.dictationAudioArchiveOptIn`.
-    package let dictationAudioArchiveOptIn: Bool
+    /// #1247: live read of the persisted Settings opt-in for the DEBUG-only
+    /// dictation-audio archive (#1230). See
+    /// `ParakeetInputs.dictationAudioArchiveOptInProvider`.
+    package let dictationAudioArchiveOptInProvider: @MainActor () -> Bool
 
     /// Explicit package init — same reasoning as `ParakeetInputs.init`.
     /// `languageDetector` is intentionally non-optional (no default) so the
@@ -163,7 +166,7 @@ public enum KernelDictationDriverFactory {
       pasteCompletionRegistry: PasteCompletionRegistry,
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
-      dictationAudioArchiveOptIn: Bool = false
+      dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false }
     ) {
       self.audioCapture = audioCapture
       self.whisperKitBackend = whisperKitBackend
@@ -175,7 +178,7 @@ public enum KernelDictationDriverFactory {
       self.pasteCompletionRegistry = pasteCompletionRegistry
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
-      self.dictationAudioArchiveOptIn = dictationAudioArchiveOptIn
+      self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
     }
   }
 
@@ -229,7 +232,7 @@ public enum KernelDictationDriverFactory {
       pasteCompletionRegistry: inputs.pasteCompletionRegistry,
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
-      dictationAudioArchiveOptIn: inputs.dictationAudioArchiveOptIn)
+      dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider)
   }
 
   /// Build the driver stack for the WhisperKit engine. PR-5 Rung 5 flips the
@@ -258,7 +261,7 @@ public enum KernelDictationDriverFactory {
       pasteCompletionRegistry: inputs.pasteCompletionRegistry,
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
-      dictationAudioArchiveOptIn: inputs.dictationAudioArchiveOptIn)
+      dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider)
   }
 
   /// Engine-agnostic assembler. The two package entry points construct their
@@ -276,7 +279,7 @@ public enum KernelDictationDriverFactory {
     pasteCompletionRegistry: PasteCompletionRegistry,
     captureErrorSink: @escaping HeartPathCaptureErrorSink,
     outputClassifierHolder: OutputClassifierHolder? = nil,
-    dictationAudioArchiveOptIn: Bool = false
+    dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false }
   ) -> KernelDictationDriver {
     // 1. LimbSteps — same instances driver + wiring hold by reference.
     // #832/#913 PR8: the live-dictation LLMPolishStep receives the app-owned
@@ -395,7 +398,7 @@ public enum KernelDictationDriverFactory {
         outcome.asrEndedAtSeconds = CFAbsoluteTimeGetCurrent()
       },
       telemetryState: telemetryState,
-      dictationAudioArchiveOptIn: dictationAudioArchiveOptIn
+      dictationAudioArchiveOptInProvider: dictationAudioArchiveOptInProvider
     )
     telemetryRelay.kernel = kernel
 

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -200,10 +200,13 @@ final class RecordingSessionKernel {
   private let markASRTimingEnd: @MainActor () -> Void
   private let telemetryState: KernelTelemetryState
 
-  /// #1247: persisted Settings opt-in for the DEBUG-only dictation-audio
-  /// archive (#1230), read once at kernel construction (`WisprBootstrapper`).
+  /// #1247: live read of the persisted Settings opt-in for the DEBUG-only
+  /// dictation-audio archive (#1230). A closure (not a frozen `Bool`) so
+  /// flipping the toggle off stops archiving on the VERY NEXT dictation, not
+  /// only after a relaunch — cloud review (PR #1250) flagged the asymmetric
+  /// risk of an off-flip silently continuing to save mic audio until quit.
   /// ORs with the `EW_KEEP_DICTATION_AUDIO` env var at the archive call site.
-  private let dictationAudioArchiveOptIn: Bool
+  private let dictationAudioArchiveOptInProvider: @MainActor () -> Bool
 
   // MARK: Observable surface
 
@@ -488,7 +491,7 @@ final class RecordingSessionKernel {
     markASRTimingStart: @escaping @MainActor (_ streaming: Bool) -> Void = { _ in },
     markASRTimingEnd: @escaping @MainActor () -> Void = {},
     telemetryState: KernelTelemetryState = KernelTelemetryState(),
-    dictationAudioArchiveOptIn: Bool = false
+    dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false }
   ) {
     self.adapter = adapter
     self.audioCapture = audioCapture
@@ -506,7 +509,7 @@ final class RecordingSessionKernel {
     self.markASRTimingStart = markASRTimingStart
     self.markASRTimingEnd = markASRTimingEnd
     self.telemetryState = telemetryState
-    self.dictationAudioArchiveOptIn = dictationAudioArchiveOptIn
+    self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
   }
 
   // MARK: Driver entry points (PR-1 §A.2 trigger vocabulary)
@@ -1520,7 +1523,7 @@ final class RecordingSessionKernel {
         }
         let archiveClass = archiveClassification
         let archiveBackend = adapter.engineIdentity.backendType.rawValue
-        let archiveSettingsOptIn = dictationAudioArchiveOptIn
+        let archiveSettingsOptIn = dictationAudioArchiveOptInProvider()
         Task.detached(priority: .utility) {
           let path = await DictationAudioArchive.archive(
             transcriptID: archiveID,

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -200,6 +200,11 @@ final class RecordingSessionKernel {
   private let markASRTimingEnd: @MainActor () -> Void
   private let telemetryState: KernelTelemetryState
 
+  /// #1247: persisted Settings opt-in for the DEBUG-only dictation-audio
+  /// archive (#1230), read once at kernel construction (`WisprBootstrapper`).
+  /// ORs with the `EW_KEEP_DICTATION_AUDIO` env var at the archive call site.
+  private let dictationAudioArchiveOptIn: Bool
+
   // MARK: Observable surface
 
   /// The current FSM state. Callers observe; they never mutate it.
@@ -482,7 +487,8 @@ final class RecordingSessionKernel {
     markPipelineTimingStart: @escaping @MainActor () -> Void = {},
     markASRTimingStart: @escaping @MainActor (_ streaming: Bool) -> Void = { _ in },
     markASRTimingEnd: @escaping @MainActor () -> Void = {},
-    telemetryState: KernelTelemetryState = KernelTelemetryState()
+    telemetryState: KernelTelemetryState = KernelTelemetryState(),
+    dictationAudioArchiveOptIn: Bool = false
   ) {
     self.adapter = adapter
     self.audioCapture = audioCapture
@@ -500,6 +506,7 @@ final class RecordingSessionKernel {
     self.markASRTimingStart = markASRTimingStart
     self.markASRTimingEnd = markASRTimingEnd
     self.telemetryState = telemetryState
+    self.dictationAudioArchiveOptIn = dictationAudioArchiveOptIn
   }
 
   // MARK: Driver entry points (PR-1 §A.2 trigger vocabulary)
@@ -1513,6 +1520,7 @@ final class RecordingSessionKernel {
         }
         let archiveClass = archiveClassification
         let archiveBackend = adapter.engineIdentity.backendType.rawValue
+        let archiveSettingsOptIn = dictationAudioArchiveOptIn
         Task.detached(priority: .utility) {
           let path = await DictationAudioArchive.archive(
             transcriptID: archiveID,
@@ -1521,7 +1529,8 @@ final class RecordingSessionKernel {
             fed: archiveFed,
             outcome: archiveOutcome,
             classification: archiveClass,
-            backend: archiveBackend)
+            backend: archiveBackend,
+            settingsOptIn: archiveSettingsOptIn)
           await AppLogger.shared.log(
             path.map { "Dictation audio archived: \($0)" }
               ?? "Dictation audio archive skipped/failed (diagnostic limb, ignored)",

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -58,6 +58,9 @@ enum SettingsDefaultValues {
   static let crashRecoveryEnabled = true
 
   static let isDebugModeEnabled = false
+  // #1247: off by default, matching the privacy-strict rationale above — local
+  // mic-audio retention is opt-in only, never silently on.
+  static let isDictationAudioArchiveEnabled = false
   static let debugLogLevel: DebugLogLevel = .info
   static let useExtendedThinking = false
 

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -32,6 +32,7 @@ public final class SettingsManager {
     case crashRecoveryEnabled
     case contactsSyncOnLaunchEnabled
     case isDebugModeEnabled
+    case isDictationAudioArchiveEnabled
     case debugLogLevel
     case useExtendedThinking
     case whisperKitLanguage
@@ -73,7 +74,7 @@ public final class SettingsManager {
     "pushToTalkKeyCode", "pushToTalkModifiersRaw", "modelUnloadPolicy",
     "restoreClipboardAfterPaste", "wordCorrectionEnabled", "fillerRemovalEnabled",
     "emojiFormatterEnabled", "crashRecoveryEnabled", "contactsSyncOnLaunchEnabled",
-    "isDebugModeEnabled", "debugLogLevel",
+    "isDebugModeEnabled", "isDictationAudioArchiveEnabled", "debugLogLevel",
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
     "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
     "useStreamingASR", "warmEnginePolicy", "appearancePreference",
@@ -333,6 +334,16 @@ public final class SettingsManager {
     }
   }
 
+  /// Sticky, founder-controlled opt-in for the DEBUG-only per-dictation audio
+  /// archive (#1230). Survives rebuilds/relaunches, unlike the env-var opt-in
+  /// (`EW_KEEP_DICTATION_AUDIO`) it ORs with at `DictationAudioArchive.archive()`.
+  public var isDictationAudioArchiveEnabled: Bool {
+    didSet {
+      defaults.set(isDictationAudioArchiveEnabled, forKey: "isDictationAudioArchiveEnabled")
+      onChange?(.isDictationAudioArchiveEnabled)
+    }
+  }
+
   public var debugLogLevel: DebugLogLevel {
     didSet {
       defaults.set(debugLogLevel.rawValue, forKey: "debugLogLevel")
@@ -571,6 +582,9 @@ public final class SettingsManager {
     isDebugModeEnabled =
       defaults.object(forKey: "isDebugModeEnabled") as? Bool
       ?? SettingsDefaultValues.isDebugModeEnabled
+    isDictationAudioArchiveEnabled =
+      defaults.object(forKey: "isDictationAudioArchiveEnabled") as? Bool
+      ?? SettingsDefaultValues.isDictationAudioArchiveEnabled
     debugLogLevel =
       DebugLogLevel(
         rawValue: defaults.string(forKey: "debugLogLevel") ?? ""

--- a/Tests/EnviousWisprTests/Pipeline/DictationAudioArchiveTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationAudioArchiveTests.swift
@@ -159,6 +159,18 @@ import Testing
       #expect(path == nil)
     }
 
+    @Test("settingsOptIn satisfies the enablement gate independent of the env var")
+    func settingsOptInSatisfiesGate() {
+      // #1247: the persisted Settings toggle is a second source for the one
+      // enablement gate `DictationAudioArchive.archive()` checks — proves the
+      // OR condition directly, since `directory:` (used by every other test in
+      // this suite) bypasses the gate entirely and can't observe it.
+      #expect(DictationAudioArchive.isArchiveOptedIn(envValue: nil, settingsOptIn: true))
+      #expect(DictationAudioArchive.isArchiveOptedIn(envValue: "1", settingsOptIn: false))
+      #expect(!DictationAudioArchive.isArchiveOptedIn(envValue: nil, settingsOptIn: false))
+      #expect(!DictationAudioArchive.isArchiveOptedIn(envValue: "0", settingsOptIn: false))
+    }
+
     @Test("prune keeps the newest N directories by modification time")
     func pruneByTime() async throws {
       let dir = try tempDir()


### PR DESCRIPTION
## Summary
- Adds a persisted Settings toggle ("Save dictation audio for debugging") in Diagnostics, off by default, that keeps the DEBUG-only per-dictation audio archive (#1230) on across rebuilds — previously it only turned on via an env var that every rebuild silently dropped.
- The toggle ORs with the existing env var at the archive's one enablement gate; no change to the 500-recording cap, file permissions, or the no-transcript-text boundary.
- Codex review r1 found the toggle was hidden behind an unrelated flag and lacked a `#if DEBUG` guard (so it would've shown, inertly, in release builds) — both fixed; r2 clean.

## Test plan
- [x] `scripts/xcode-test.sh` — 2143 tests, 0 failures (including a new `DictationAudioArchiveTests` case)
- [x] `swift build -c release` — exit 0
- [x] Live UAT: toggle off → no archive; toggle on + relaunch → archive appears; full rebuild (simulating the original bug) + relaunch without touching the toggle → archive still appears (the regression proof)
- [x] Local `codex review` clean (2 rounds)

Refs #1247