### PR TITLE
fix(build): quit ALL dev instances before relaunch (one-dev-instance policy)

### DIFF
--- a/scripts/build-dev-app.sh
+++ b/scripts/build-dev-app.sh
@@ -38,23 +38,22 @@ if ! security find-identity -v -p codesigning | grep -q "$DEV_CERT_NAME"; then
   exit 1
 fi
 
-# ─── Step 2: Stop ONLY this worktree's running dev app (path-scoped) ──────────
-# Scope strictly to PIDs whose executable path is inside THIS worktree's bundle.
-# The `.dev` bundle id is shared by every worktree's dev build AND prod shares
-# the `EnviousWispr` executable name — so a bundle-id quit or `pkill -x
-# EnviousWispr` would also kill a sibling worktree's app or the founder's live
-# session (pkill-scope-to-own-worktree rule). Never quit by bundle id, never
-# kill by bare process name.
-echo "==> Step 2: Stopping this worktree's dev app (path-scoped)..."
-DEV_EXE="$APP_PATH/Contents/MacOS/EnviousWispr"
-this_worktree_pids() { pgrep -f "$DEV_EXE" 2>/dev/null || true; }
+# ─── Step 2: Stop ALL running dev EnviousWispr instances (any worktree) ───────
+# Only ONE dev EW runs at a time (founder decision 2026-07-01): quit every
+# running dev instance — main checkout or any worktree — before launching the
+# new build. Scope by the dev bundle's
+# executable path ("EnviousWispr Local.app/..."): prod never lives in a bundle
+# by that name, so it is untouched. Never quit by bundle id (shared `.dev` id)
+# and never kill by bare process name (`pkill -x EnviousWispr` would hit prod).
+echo "==> Step 2: Stopping all running dev EnviousWispr instances..."
+dev_pids() { pgrep -f "EnviousWispr Local.app/Contents/MacOS/EnviousWispr" 2>/dev/null || true; }
 
-for pid in $(this_worktree_pids); do kill -TERM "$pid" 2>/dev/null || true; done
-for _ in $(seq 1 50); do [ -z "$(this_worktree_pids)" ] && break; sleep 0.1; done
-for pid in $(this_worktree_pids); do kill -9 "$pid" 2>/dev/null || true; done
+for pid in $(dev_pids); do kill -TERM "$pid" 2>/dev/null || true; done
+for _ in $(seq 1 50); do [ -z "$(dev_pids)" ] && break; sleep 0.1; done
+for pid in $(dev_pids); do kill -9 "$pid" 2>/dev/null || true; done
 sleep 0.3
-if [ -n "$(this_worktree_pids)" ]; then
-  echo "ERROR: this worktree's dev EnviousWispr still running after scoped TERM/KILL"
+if [ -n "$(dev_pids)" ]; then
+  echo "ERROR: a dev EnviousWispr instance is still running after TERM/KILL"
   exit 1
 fi
 

--- a/scripts/lid-perf-bench.sh
+++ b/scripts/lid-perf-bench.sh
@@ -92,18 +92,14 @@ enable_app_file_logging() {
     exit 2
   fi
 
-  osascript <<OSA 2>/dev/null || true
-if application id "$APP_BUNDLE_ID" is running then
-  tell application id "$APP_BUNDLE_ID" to quit
-end if
-OSA
-
-  for _ in $(seq 1 30); do
-    if ! pgrep -f "EnviousWispr Local.app/Contents/MacOS/EnviousWispr" >/dev/null 2>&1; then
-      break
-    fi
-    sleep 0.1
-  done
+  # Quit ALL running dev instances by executable path (same policy as
+  # build-dev-app.sh Step 2): only one dev EW runs at a time, and a bundle-id
+  # quit is unreliable when several worktrees share the .dev id.
+  dev_pids() { pgrep -f "EnviousWispr Local.app/Contents/MacOS/EnviousWispr" 2>/dev/null || true; }
+  for pid in $(dev_pids); do kill -TERM "$pid" 2>/dev/null || true; done
+  for _ in $(seq 1 50); do [ -z "$(dev_pids)" ] && break; sleep 0.1; done
+  for pid in $(dev_pids); do kill -9 "$pid" 2>/dev/null || true; done
+  sleep 0.3
 
   open "$DEV_APP_PATH"
   sleep 3

--- a/scripts/lid-perf-bench.sh
+++ b/scripts/lid-perf-bench.sh
@@ -92,13 +92,26 @@ enable_app_file_logging() {
     exit 2
   fi
 
-  # Quit ALL running dev instances by executable path (same policy as
-  # build-dev-app.sh Step 2): only one dev EW runs at a time, and a bundle-id
-  # quit is unreliable when several worktrees share the .dev id.
+  # Quit ALL running dev instances: Cocoa quit first (only Cocoa terminate runs
+  # applicationWillTerminate, letting the audio/ASR helpers exit cleanly —
+  # Tests/RuntimeUAT/SCENARIOS.md; a raw kill here could leave helpers alive and
+  # contaminate the signpost capture), then a path-scoped TERM/wait/KILL sweep
+  # to enforce the one-dev-instance policy (the bundle-id quit alone is
+  # unreliable when several worktrees share the .dev id).
+  osascript <<OSA 2>/dev/null || true
+if application id "$APP_BUNDLE_ID" is running then
+  tell application id "$APP_BUNDLE_ID" to quit
+end if
+OSA
   dev_pids() { pgrep -f "EnviousWispr Local.app/Contents/MacOS/EnviousWispr" 2>/dev/null || true; }
+  helper_pids() { pgrep -f "EnviousWispr Local.app/Contents/XPCServices/" 2>/dev/null || true; }
+  for _ in $(seq 1 50); do [ -z "$(dev_pids)" ] && break; sleep 0.1; done
   for pid in $(dev_pids); do kill -TERM "$pid" 2>/dev/null || true; done
   for _ in $(seq 1 50); do [ -z "$(dev_pids)" ] && break; sleep 0.1; done
   for pid in $(dev_pids); do kill -9 "$pid" 2>/dev/null || true; done
+  # Reap any orphaned audio/ASR helpers so they can't pollute the benchmark.
+  for _ in $(seq 1 30); do [ -z "$(helper_pids)" ] && break; sleep 0.1; done
+  for pid in $(helper_pids); do kill -TERM "$pid" 2>/dev/null || true; done
   sleep 0.3
 
   open "$DEV_APP_PATH"


### PR DESCRIPTION
## Problem
Rebuilding the dev app from a worktree left the previously running dev instance (main checkout or another worktree) alive: the quit in `build-dev-app.sh` Step 2 was deliberately scoped to the current worktree's bundle path, so 2-3 dev apps stacked up (founder-reported 2026-07-01).

## Change
- `scripts/build-dev-app.sh` Step 2: quit ALL running dev instances via `pgrep -f "EnviousWispr Local.app/Contents/MacOS/EnviousWispr"` (TERM → wait → KILL) before launching. Only one dev EW runs at a time (standing founder policy). Prod is untouched: nothing else runs from a bundle named "EnviousWispr Local.app", and bare-name / bundle-id kills remain forbidden. Step 8 launch-verify stays scoped to this worktree's path (#1095 guard).
- `scripts/lid-perf-bench.sh`: the unreliable bundle-id osascript quit replaced with the same all-dev TERM/wait/KILL pattern.
- Local (untracked) `.claude/` rules, skills, and knowledge updated to the new policy: pkill-scope-to-own-worktree rewritten, rebuild-from-main-after-merge made standing (no ask), rebuild skills, wispr-eyes agent, uat-testing, gotchas, conventions.

## Review
Self-audit clean; local Codex review iterated to explicit PROCEED-AS-PLANNED (round 3) after folding 5 findings (bench script, rebuild-debug skill, 3 knowledge docs, wispr-eyes, uat-testing).

## Validation
- `bash -n` passes on both scripts.
- pgrep pattern tested live: matched the single running dev instance (worktree build), matches nothing else on the machine.