### PR TITLE
chore(release): bump version to 2.2.1

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -26,6 +26,27 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.2.1
+
+    Entry(
+      id: "tail-clip-recovery",
+      icon: "waveform.badge.checkmark",
+      title: "Long dictations keep every last word",
+      description:
+        "Fixed a long-standing bug where the end of a longer dictation could go missing if you paused mid-sentence near the finish. The speech engine now catches and recovers those moments, so your closing words always land.",
+      category: .fasterAndMoreReliable,
+      version: "2.2.1"
+    ),
+    Entry(
+      id: "cloud-polish-facelift",
+      icon: "cloud.bolt",
+      title: "Cloud AI polish got a facelift",
+      description:
+        "If you bring your own OpenAI or Gemini key, polish just got a major upgrade. We rewrote the prompt from the ground up and benchmarked it across 1,890 real dictation cases: pass rates jumped from about 70% to about 92%. You'll notice the difference most in paragraph breaks when you change topics, spoken lists becoming real lists, cleaner handling of mid-sentence self-corrections, grammar fixes, and emoji staying exactly where you put them.",
+      category: .smarterAIPolish,
+      version: "2.2.1"
+    ),
+
     // MARK: - v2.2.0
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.2.0"
+  public static let currentContentVersion = "2.2.1"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary

Version bump to v2.2.1 with What's New entries for the two user-visible changes shipped since v2.2.0:

- Tail-clip fix: long dictations no longer lose their final words after a mid-sentence pause (#1246 / #1237)
- Cloud polish rebuilt on the single fixed v6 prompt for OpenAI + Gemini, benchmarked 69.6% -> 91.6% green on the 1,890-case corpus (#1257 / #1255)

What's New copy founder-approved 2026-07-01; release notes render verified via scripts/ci/render-release-notes.py.

## Test plan

- [x] scripts/build-dev-app.sh — built and launched locally from the release worktree
- [x] What's New visual check (wispr-eyes): v2.2.1 section on top, both entries render with icons, no truncation
- [ ] build-check CI passes on this PR
- [ ] Tag v2.2.1 after merge triggers release pipeline