### PR TITLE
fix(release): sync third-party notices to FluidAudio pin d5fcca4f

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -38,7 +38,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: 46e96f40 (fork saurabhav88/FluidAudio)
+  Version: d5fcca4f (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -31,7 +31,7 @@ CO="${PROJ_ROOT}/.build/checkouts"
 # this list does not cover, so the notices can't silently go stale (Codex #2).
 COMPONENTS=(
   "WhisperKit (argmax-oss-swift)|1.0.0|MIT|argmax-oss-swift/LICENSE|https://github.com/argmaxinc/argmax-oss-swift|argmax-oss-swift"
-  "FluidAudio|46e96f40 (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
+  "FluidAudio|d5fcca4f (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
   "PostHog iOS|3.61.0|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
   "Sentry Cocoa|9.18.0|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
   "Sparkle|2.9.3|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"


### PR DESCRIPTION
## Summary

The v2.2.1 release build failed at the third-party-notices version-drift gate: PR #1246 bumped the FluidAudio fork pin to d5fcca4 but the notices generator still listed 46e96f40. This syncs the generator's component entry and regenerates THIRD-PARTY-NOTICES.txt. License text unchanged (same Apache-2.0 fork); only the displayed revision.

council-skip: zero-blast-radius (single-value config or constant)

## Test plan

- [x] scripts/ci/gen-third-party-notices.sh --check passes locally (10 components verified)
- [x] Codex diff review clean (re-ran the gate itself, no issues)
- [ ] build-check CI passes
- [ ] Re-tag v2.2.1 after merge; release pipeline reruns