### PR TITLE
fix(readme): correct washed-out HDR colors in demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Demo
 
-https://github.com/user-attachments/assets/d390b3ba-b2e5-4801-a46c-7d5fa4c789aa
+https://github.com/user-attachments/assets/ff3e9cec-7fd5-4998-8a11-5a12204d0e58
 
 ## What is this?
 


### PR DESCRIPTION
## Summary
- The demo video merged in #1261 was washed out / muted grey. Root cause: the source Cmd+Shift+5 recording is captured in HDR (bt2020/smpte2084 PQ) since the display runs in HDR mode. The original conversion re-encoded straight to SDR H.264 with no HDR->SDR tone-mapping, so PQ values got read through an SDR gamma curve and crushed toward grey.
- Fix: re-transcoded through macOS's native `avconvert` (AVFoundation, same color pipeline used to capture it) targeting an SDR preset, which correctly tone-maps HDR to Rec.709 before the final compression pass. Verified via `ffprobe` (now tagged `bt709`/`bt709`/`bt709` instead of `bt2020`/`smpte2084`) and a visual frame comparison — blues and dark UI tones are visibly richer and match what was seen live while recording.

## Test plan
- [x] `ffprobe` confirms correct SDR color tags on the new file
- [x] Visual frame comparison confirms colors are no longer washed out
- [ ] `build-check` CI green