### PR TITLE
feat(readme): add webcam bubble to demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Demo
 
-https://github.com/user-attachments/assets/ff3e9cec-7fd5-4998-8a11-5a12204d0e58
+https://github.com/user-attachments/assets/45cd462f-2c21-453d-9000-15a3b457a5ed
 
 ## What is this?
 


### PR DESCRIPTION
## Summary
- Swaps the README demo video for a version that includes the presenter webcam as a bottom-right picture-in-picture bubble, sourced from the raw Screen Studio capture channels (project export requires a paid plan, so this is a manual ffmpeg composite of the raw display + webcam + microphone channels instead).
- Webcam feed cropped 20% off each side (16:9 -> ~1.07:1) per founder request, to reduce background distraction and frame the face more tightly.

## Test plan
- [x] Verified color tags (bt709) and A/V sync locally before upload
- [ ] `build-check` CI green