### PR TITLE
docs(release): mark self-hosted runner fully decommissioned (#1087)

### DIFF
--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -66,27 +66,35 @@ tail -f ~/Library/Logs/actions.runner.saurabhav88-EnviousWispr.enviouswispr-rele
 
 ## Recovery: Re-register Runner
 
-If the runner token expires or the runner needs re-registration:
+`~/actions-runner/` was deleted as part of the 2026-07-02 decommission, so
+re-establishing the runner is a fresh install, not a token refresh against an
+existing directory:
 
 ```bash
-cd ~/actions-runner
+# Download + extract a fresh runner package (get the current version/URL from
+# https://github.com/actions/runner/releases)
+mkdir ~/actions-runner && cd ~/actions-runner
+curl -o actions-runner-osx-arm64-VERSION.tar.gz -L https://github.com/actions/runner/releases/download/vVERSION/actions-runner-osx-arm64-VERSION.tar.gz
+tar xzf actions-runner-osx-arm64-VERSION.tar.gz
 
-# Get new token
+# Get a registration token
 TOKEN=$(gh api repos/saurabhav88/EnviousWispr/actions/runners/registration-token --method POST --jq '.token')
 
-# Remove old config
-./config.sh remove --token "$TOKEN"
-
-# Re-register
+# Register
 ./config.sh --url https://github.com/saurabhav88/EnviousWispr \
   --token "$TOKEN" \
   --name enviouswispr-release \
   --labels self-hosted,macOS,apple-silicon,enviouswispr-release \
   --unattended --replace
 
-# Restart service
+# Install + start service
 ./svc.sh install && ./svc.sh start
 ```
+
+Re-adding the `self-hosted, enviouswispr-release` labels to any workflow after
+registering is a separate, deliberate step — see `NEVER re-add its labels to a
+workflow` in `.claude/knowledge/distribution.md` FACT:
+self-hosted-release-runner-decommissioned before doing so.
 
 ## Updating the Runner
 

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -91,10 +91,11 @@ TOKEN=$(gh api repos/saurabhav88/EnviousWispr/actions/runners/registration-token
 ./svc.sh install && ./svc.sh start
 ```
 
-Re-adding the `self-hosted, enviouswispr-release` labels to any workflow after
-registering is a separate, deliberate step — see `NEVER re-add its labels to a
-workflow` in `.claude/knowledge/distribution.md` FACT:
-self-hosted-release-runner-decommissioned before doing so.
+Registering the runner does NOT put it back in the release pipeline by itself.
+`release.yml` currently has zero `self-hosted` references (all jobs run on
+GitHub-hosted `macos-26`); re-adding the `self-hosted, enviouswispr-release`
+labels to any workflow `runs-on:` line is a separate, deliberate decision —
+don't do it as a side effect of re-registering.
 
 ## Updating the Runner
 

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -92,8 +92,10 @@ TOKEN=$(gh api repos/saurabhav88/EnviousWispr/actions/runners/registration-token
 ```
 
 Registering the runner does NOT put it back in the release pipeline by itself.
-`release.yml` currently has zero `self-hosted` references (all jobs run on
-GitHub-hosted `macos-26`); re-adding the `self-hosted, enviouswispr-release`
+`release.yml` currently has zero `self-hosted` references — `build-release-artifacts`
+and `publish-github-release` run on hosted `macos-26`, the other four jobs
+(`preflight`, `publish-appcast`, `upload-sentry-dsyms`, `release-summary`) run on
+`ubuntu-latest`; re-adding the `self-hosted, enviouswispr-release`
 labels to any workflow `runs-on:` line is a separate, deliberate decision —
 don't do it as a side effect of re-registering.
 

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -1,13 +1,15 @@
 # Self-Hosted GitHub Actions Runner
 
-> **DECOMMISSIONED (#1087, 2026-06-20).** The release pipeline (`release.yml`) was
-> migrated to GitHub-hosted `macos-26` runners with ephemeral-keychain signing —
-> all 6 jobs now `runs-on: macos-26`, so no machine at rest holds the signing cert.
-> The "Why" below is obsolete: hosted `macos-26` carries the macOS 26 SDK and
-> already runs our build + FoundationModels probe. The runner is unregistered only
-> AFTER the first real hosted release succeeds; until then it stays registered as a
-> one-revert fallback. The setup/recovery instructions below are retained for the
-> record (re-registration recipe if a self-hosted lane is ever needed again).
+> **FULLY DECOMMISSIONED (#1087, 2026-07-02).** The release pipeline (`release.yml`)
+> migrated to GitHub-hosted runners (PR #1113, 2026-06-20) with ephemeral-keychain
+> signing — no machine at rest holds the signing cert. Two real releases shipped
+> clean end-to-end on hosted (v2.2.0 2026-06-24, v2.2.1 2026-07-01). The runner
+> (`enviouswispr-release`) has now been fully removed: unregistered from GitHub
+> (`gh api --method DELETE .../actions/runners/22`) and the local install at
+> `~/actions-runner/` deleted. Everything below — Current Setup, Workflow Split,
+> Managing the Runner, Recovery — is HISTORICAL, describing a runner that no longer
+> exists. Retained only as the re-registration recipe if a self-hosted lane is ever
+> needed again.
 
 ## Why (obsolete — see banner)
 
@@ -25,13 +27,13 @@ free, fast, and fully controlled.
 - **Service plist:** `~/Library/LaunchAgents/actions.runner.saurabhav88-EnviousWispr.enviouswispr-release.plist`
 - **Logs:** `~/Library/Logs/actions.runner.saurabhav88-EnviousWispr.enviouswispr-release/`
 
-## Workflow Split
+## Workflow Split (historical — as of decommission)
 
 | Workflow | Runner | Purpose |
 |----------|--------|---------|
 | `pr-check.yml` → `build-debug` / `build-release` | `macos-26` (hosted) | Xcode/Tuist build lanes — debug build + XPC hygiene + debug tests ‖ release build + FoundationModels compile probe |
 | `pr-check.yml` → `build-check` | `ubuntu-latest` (hosted) | Required-gate aggregator over both build lanes (`needs: [build-debug, build-release]`) |
-| `release.yml` → `build-release-artifacts` | `self-hosted, enviouswispr-release` | Full release: Xcode/Tuist archive + inside-out sign (embeds the Developer ID provisioning profile) + notarize + DMG |
+| `release.yml` → `build-release-artifacts` | `macos-26` (hosted, since #1113) | Full release: Xcode/Tuist archive + inside-out sign (embeds the Developer ID provisioning profile) + notarize + DMG. Formerly `self-hosted, enviouswispr-release`; that runner no longer exists. |
 
 ## Release Toolchain (Xcode engine, #913)
 
@@ -43,7 +45,7 @@ Release builds run on the Xcode build engine via Tuist (not SwiftPM). The runner
 
 The build/sign/DMG mechanics live in `scripts/build-release-dmg.sh` (the release workflow calls it), so a local release proof runs identical code to CI. GitHub Action `run:` steps are non-interactive, so the script resolves `mise` by absolute path (the interactive `mise` shell function is absent in CI shells).
 
-## Managing the Runner
+## Managing the Runner (historical — commands assume a runner exists again; see Recovery below)
 
 ```bash
 # Check status


### PR DESCRIPTION
## Summary
- Final cleanup step of #1087 (release pipeline moved to GitHub-hosted `macos-26` in PR #1113, 2026-06-20). The self-hosted runner was unregistered from GitHub and its local install deleted on 2026-07-02, after two clean hosted releases (v2.2.0, v2.2.1).
- This PR updates the one tracked doc that described the runner as still existing (`docs/self-hosted-runner.md`): banner, workflow-split table row, and management-commands heading now reflect that it's gone, kept only as a historical re-registration recipe.
- Companion knowledge-base updates (`.claude/knowledge/distribution.md`, `.claude/knowledge/ci-security-architecture.md`, `session-log.md`) are gitignored Local-lane files, already updated directly, not part of this PR.

Content-only change, no code/workflow touched.

## Test plan
- [x] Content-only diff (docs/ classification regex excludes it from a forced Swift build)
- [x] `build-check` green (required check)