### PR TITLE
fix(pipeline): stop keep-magnitude corrupting scale ordinals; rejoin hyphenated ordinal modifiers

### DIFF
--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -519,7 +519,10 @@ public struct InverseTextNormalizer: Sendable {
     }
     // hyphenated compound modifier: converting "twenty-step" leaves "20 -step" (the cardinal pass
     // re-emits " 20 " with pad spaces). Re-tighten "digit space-hyphen word" -> "digit-word".
-    t = reSub(#"(\d)\s+-(\w)"#, t, caseInsensitive: false) { m in "\(m.g(1) ?? "")-\(m.g(2) ?? "")"
+    // The compound-ordinal pass emits the same pad-space artifact ending in our own lowercase
+    // suffix ("twenty-third-century" -> "23rd -century" #1202), so accept an optional st/nd/rd/th.
+    t = reSub(#"(\d(?:st|nd|rd|th)?)\s+-(\w)"#, t, caseInsensitive: false) {
+      m in "\(m.g(1) ?? "")-\(m.g(2) ?? "")"
     }
     t = reSub(#"[ \t]+"#, t, caseInsensitive: false) { _ in " " }  // collapse spaces (keep newlines)
     return t.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -830,7 +833,11 @@ public struct InverseTextNormalizer: Sendable {
     // ONLY comma-grouped numbers: everything WE render >=1000 carries commas, so a bare digit
     // run (8000000, an ID/phone/account/serial) is passthrough input and must NOT collapse.
     // (?!\.\d) so '$5,000,000.00' is not split into '$5 million.00'.
-    return reSub(#"(?<cur>\$)?(?<n>\d{1,3}(?:,\d{3})+)\b(?!\.\d)"#, t, caseInsensitive: false) {
+    // (?!,\d) so a backtracked PARTIAL comma group never rewrites: a complete comma-grouped
+    // number is never followed by ",digit" (greedy match would have consumed it), so this only
+    // fires where \b failed on the full figure — ordinal suffixes ('1,000,000,000th' #1201),
+    // decimals past the (?!\.\d) block ('$5,000,000,000.00'), plurals ('1,000,000,000s').
+    return reSub(#"(?<cur>\$)?(?<n>\d{1,3}(?:,\d{3})+)\b(?!\.\d)(?!,\d)"#, t, caseInsensitive: false) {
       m in
       let cur = m.g("cur") ?? ""
       guard let n = Int((m.g("n") ?? "").replacingOccurrences(of: ",", with: "")) else {

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
@@ -209,4 +209,43 @@ struct InverseTextNormalizerParityTests {
   func apNumberPolicy(input: String, expected: String) {
     #expect(InverseTextNormalizer().normalize(input) == expected)
   }
+
+  // Codex-finding regressions from PR #1191's review. Fix 1: keep-magnitude must never rewrite
+  // a PARTIAL comma group (a complete comma-grouped number is never followed by ",digit", so the
+  // (?!,\d) guard only blocks backtracked prefixes). Fix 2: the pad-space rejoin must accept our
+  // own ordinal-suffix emissions ("23rd"), not only bare digits ("20").
+  @Test(
+    "Codex-finding regressions hold (#1201/#1202)",
+    .bug("https://github.com/saurabhav88/EnviousWispr/issues/1201", "scale ordinals >= billion"),
+    .bug("https://github.com/saurabhav88/EnviousWispr/issues/1202", "hyphenated ordinal rejoin"),
+    arguments: [
+      // #1201: billion-scale ordinal survives keep-magnitude intact (was "1 million,000th")
+      ("one billionth", "1,000,000,000th"),
+      // leading coefficient on a billion-scale ordinal (was "2 million,000th")
+      ("two billionth", "2,000,000,000th"),
+      // same defect class through the currency-decimal guard: the (?!\.\d) block on the full
+      // match let keep-magnitude backtrack onto the "5,000,000" prefix (was "$5 million,000.00")
+      ("$5,000,000,000.00", "$5,000,000,000.00"),
+      // keep-magnitude positives must keep converting (guard is partial-groups only)
+      ("we raised eighty million dollars", "we raised $80 million"),
+      ("the deal was worth three billion dollars", "the deal was worth $3 billion"),
+      // millionth was accidentally safe before the fix and must stay safe after it
+      ("one millionth", "1,000,000th"),
+      // fraction guard unaffected: "of" keeps the spelled form
+      ("a billionth of a second", "a billionth of a second"),
+      // plural / multiplier suffixes ride the same partial-group class: preserve unchanged
+      // (old code corrupted both to "1 million,000s" / "1 million,000x")
+      ("the count is in the 1,000,000,000s now", "the count is in the 1,000,000,000s now"),
+      ("roughly 1,000,000,000x faster", "roughly 1,000,000,000x faster"),
+      // #1202: hyphenated compound-ordinal modifier rejoins (was "23rd -century art")
+      ("twenty-third-century art", "23rd-century art"),
+      ("her twenty-first-birthday party", "her 21st-birthday party"),
+      // digit-cardinal rejoin (pre-existing behavior) must keep working
+      ("a twenty-step process", "a 20-step process"),
+      // hyphen followed by a space is prose punctuation, never rejoined
+      ("she came 3rd - not bad", "she came 3rd - not bad"),
+    ])
+  func codexFindingRegressions(input: String, expected: String) {
+    #expect(InverseTextNormalizer().normalize(input) == expected)
+  }
 }


### PR DESCRIPTION
Closes #1201, closes #1202.

## What

Two Codex-traced regex defects in the inverse text normalizer (both findings from PR #1191's review, founder-reproduced live 2026-07-02):

1. **#1201 — keep-magnitude corrupted scale ordinals.** `keepMagnitude`'s pattern could not anchor a word boundary before an ordinal suffix, so it backtracked onto a partial comma group and rewrote the prefix: "one billionth" → "1 million,000th". Same class through the currency-decimal guard: "$5,000,000,000.00" → "$5 million,000.00", and plural/multiplier suffixes ("1,000,000,000s"/"x"). Fix: append `(?!,\d)` — a complete comma-grouped number is never followed by ",digit", so the guard only kills backtracked partial matches, with zero effect on legitimate conversions.
2. **#1202 — hyphenated ordinal modifiers left malformed.** The final pad-space rejoin only accepted a bare digit before the space, so "twenty-third-century art" emerged as "23rd -century art". Fix: accept our own lowercase ordinal-suffix emissions: `(\d(?:st|nd|rd|th)?)\s+-(\w)`.

The gitignored Python oracle (`hand_rolled.py`) was mirrored identically, preserving the #145 Oracle ↔ Swift parity contract.

## Evidence

- **Failing-first tests:** new 13-case regression `@Test` (with `.bug` traits) ran red pre-fix with exactly the 5 bug-shaped failures, green post-fix. Guard cases pin legit conversions ("$80 million", "1,000,000th", "20-step", "3rd - not bad" untouched).
- **Zero collateral:** full old-vs-new oracle diff over every baked fixture row: rows=5945, diffs=0, drift=0. Byte-for-byte parity + holdout suites green.
- **Full suite:** `scripts/xcode-test.sh` green (2,151 tests).
- **Codex:** grounded review r1/r2 PROCEED-WITH-REVISIONS (all revisions applied), r3 PROCEED-AS-PLANNED; local `codex review --base origin/main` clean round 1.
- **Live UAT** (run dir `.validation/runs/2026-07-02T05-39-54Z-dc84b3b`, check-validation PASS): heart path PASS on 3 recordings; #1201 proven at final output via app.log (ITN OUT "He came 1,000,000,000th in line…", LLM Polish no-change, polish char-count matches ITN OUT). #1202's hyphenated-spelled shape could not be elicited live: Parakeet pre-normalizes to digits and WhisperKit has no local model on this machine (unrelated to this change; backend restored + re-verified). The #1202 transform is pinned at the unit/parity layer.

## Blast radius

`EnviousWisprPostProcessing` only (one source file + its test file). No pipeline orchestration, ASR, audio, LLM, fixture, or UI changes. Rollback = single-commit revert.