### PR TITLE
fix(build): doorway lint obeys URL fragment semantics (strip fragment before query)

### DIFF
--- a/scripts/ci/check-download-link-utms.sh
+++ b/scripts/ci/check-download-link-utms.sh
@@ -92,13 +92,16 @@ validate_readme_doorway_link() {
   # host, query, and fragment, then require the path to be exactly "download" — so a
   # typo like /download-old, /downloads, or /download/extra is rejected even when the
   # query is perfectly tagged. (URL identity = path x query; both axes are validated.)
-  local after_scheme="${url#*://}"
+  # Browser fragment semantics: the fragment starts at the FIRST '#'; everything after
+  # it (including a '?') never reaches the server. Strip it up front so a fragment can
+  # neither smuggle tags past the lint nor glue itself onto the last param value (#1251).
+  local without_fragment="${url%%#*}"
+  local after_scheme="${without_fragment#*://}"
   local path_and_query="${after_scheme#*/}"
   local path="${path_and_query%%\?*}"
-  path="${path%%#*}"
 
   local query=""
-  case "$url" in *\?*) query="${url#*\?}" ;; esac
+  case "$without_fragment" in *\?*) query="${without_fragment#*\?}" ;; esac
 
   local source="" usrc="" umed="" ucamp=""
   local have_source=0 have_usrc=0 have_umed=0 have_ucamp=0
@@ -203,6 +206,7 @@ self_test() {
     "$D?source=github_readme&utm_source=github&utm_medium=referral&utm_campaign=$C"         # canonical
     "$D?utm_source=github&utm_medium=referral&utm_campaign=$C&source=github_readme"          # order-independent (source last)
     "$D?source=GitHub_Readme&utm_source=github&utm_medium=referral&utm_campaign=$C"          # case (resolver lowercases source)
+    "$D?source=github_readme&utm_source=github&utm_medium=referral&utm_campaign=$C#install"   # fragment AFTER query: browser still sends all tags
   )
   # BAD: must be rejected. Each row is one cell of the failure space.
   local bad=(
@@ -217,6 +221,8 @@ self_test() {
     "$D?source=github_readme&utm_source=reddit&utm_medium=referral&utm_campaign=$C"          # wrong utm_source value
     "$D?source=github_readme&utm_source=github&utm_medium=cpc&utm_campaign=$C"               # wrong utm_medium value
     "$D?source=github_readme&utm_source=github&utm_medium=referral&utm_campaign=wrong"       # wrong utm_campaign value
+    "$D#x?source=github_readme&utm_source=github&utm_medium=referral&utm_campaign=$C"       # fragment BEFORE query: browser sends NO params (#1251)
+    "$D#source=github_readme&utm_source=github&utm_medium=referral&utm_campaign=$C"          # fragment-only, no real query
     "$D"                                                                                     # bare, no query
     "https://enviouswispr.com/download-old?source=github_readme&utm_source=github&utm_medium=referral&utm_campaign=$C"   # path typo (suffix)
     "https://enviouswispr.com/downloads?source=github_readme&utm_source=github&utm_medium=referral&utm_campaign=$C"      # path typo (plural)


### PR DESCRIPTION
Closes #1251.

## What

The README doorway-link linter extracted the query with a bare first-`?` split, ignoring that a browser treats everything from the FIRST `#` as fragment. Two wrong verdicts:

1. **False-accept (the filed bug):** `/download#x?source=...&utm_...` passed CI, but a browser sends NO query params — the resolver buckets the click by referrer, silently corrupting the attribution this guard exists to protect.
2. **Latent false-reject (found walking the grid):** `/download?source=...&utm_campaign=X#install` is browser-correct, but the linter glued `#install` onto the last param value and failed the link.

Fix: hoist `without_fragment="${url%%#*}"` and derive path + query from it (one parsing change fixes both directions; the dead second fragment-strip is deleted). Three new self-test rows pin the fragment axis.

## Evidence

- **Red-first:** pre-fix, `--self-test` rejected the fragment-after-query good row, and a direct probe confirmed the fragment-before-query URL was accepted. Post-fix: self-test green (21-row doorway matrix), ShellCheck clean, real-repo lint exit 0.
- **Design-time audits (council-prompted, executed not deferred):** the README URL extraction preserves fragments (capture stops only at `)`, `"`, whitespace), so bad links actually reach the validator; blog matchers are substring-presence checks, immune to fragment placement.
- **Adversarial enumeration (per the #1241 postmortem rule, run LOCALLY before push):** Codex enumerated the fragment × query × path × encoding space — no new bypasses. Pre-existing, out-of-scope, fail-closed quirks documented: angle-bracket autolinks and trailing-punctuation URLs false-REJECT (loud CI failure, not silent corruption); `http://` canonicality; percent-encoding/backslash normalization remain header-documented accepted scope.
- Codex grounded review: PROCEED-AS-PLANNED round 1. Local `codex review`: clean round 1.
- Phase 3 run dir `.validation/runs/2026-07-02T06-26-01Z-315a9f7` (Docs/dev-tooling lane): PASS.

## Blast radius

One CI lint script (self-test included). No website, worker, workflow, or Swift changes. Rollback = single-commit revert.