### PR TITLE
fix(audio): rebuild XPC connection lifecycle on generation-stamped single-funnel ownership

### DIFF
--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -23,8 +23,8 @@
   ///   Every command must carry the matching token in its first line.
   ///   Token file is deleted on `stop()`.
   /// - Fixed command set (no arbitrary RPC, no method invocation, no shell escape):
-  ///   `force_proxy_buffer_drop(N)`, `force_cancel`, `force_xpc_kill`,
-  ///   `force_audio_xpc_kill`, `query_state`.
+  ///   `force_proxy_buffer_drop(N)`, `force_audio_wedge_start(N)`,
+  ///   `force_cancel`, `force_xpc_kill`, `force_audio_xpc_kill`, `query_state`.
   /// - Each command dispatches to `@MainActor` via `Task { @MainActor in ... }`
   ///   so command handling matches the actor isolation of the seams it drives.
   ///
@@ -231,25 +231,34 @@
         return "OK parakeet=\(p) whisperkit=\(w) backend=\(activeBackend())"
 
       default:
-        // force_proxy_buffer_drop(N) is the only parameterized command.
-        // Drops the next N buffers inside `AudioCaptureProxy.audioBufferCaptured`
-        // before they reach the app continuation. Tests the PROXY-side stall
-        // watchdog (XPC-channel buffer drop), NOT real OS-level audio
-        // interruption recovery in `AVAudioEngineSource.handleEngineConfigurationChange()`
-        // or `AVCaptureSessionSource` interruption handlers — those run in the
+        // force_proxy_buffer_drop(N) — drops the next N buffers inside
+        // `AudioCaptureProxy.audioBufferCaptured` before they reach the app
+        // continuation. Tests the PROXY-side stall watchdog (XPC-channel buffer
+        // drop), NOT real OS-level audio interruption recovery in
+        // `AVAudioEngineSource.handleEngineConfigurationChange()` or
+        // `AVCaptureSessionSource` interruption handlers — those run in the
         // service process and are not reachable from this host-process endpoint.
         // For real audio-stack interruption testing see `docs/LANE_B_AUDIO_TESTS.md`.
-        if let n = parseForceProxyBufferDrop(cmd) {
+        if let n = parseIntCommand(cmd, prefix: "force_proxy_buffer_drop(") {
           guard let audioProxy else { return "ERR no_dependency" }
           audioProxy.forceStallRemainingBuffers = n
+          return "OK"
+        }
+        // force_audio_wedge_start(N) — #1194: treats the next N audio START
+        // operations as wedged inside `withAudioXPCOperationSignal` (no
+        // transport error, no invalidation — the watchdog-only wedge shape).
+        // Drives Live UAT scenario "forced start wedge with recovery".
+        if let n = parseIntCommand(cmd, prefix: "force_audio_wedge_start(") {
+          guard let audioProxy else { return "ERR no_dependency" }
+          audioProxy.forceWedgeNextStartOps = n
           return "OK"
         }
         return "ERR unknown_command"
       }
     }
 
-    private func parseForceProxyBufferDrop(_ cmd: String) -> Int? {
-      let prefix = "force_proxy_buffer_drop("
+    /// Parse `<prefix>N)` into N for the parameterized commands.
+    private func parseIntCommand(_ cmd: String, prefix: String) -> Int? {
       guard cmd.hasPrefix(prefix), cmd.hasSuffix(")") else { return nil }
       let inner = cmd.dropFirst(prefix.count).dropLast()
       return Int(inner)

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/AudioEventRouter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/AudioEventRouter.swift
@@ -108,6 +108,17 @@ final class AudioEventRouter {
       )
     }
 
+    // #1194: forward resolved start-op retries to PostHog. Diagnostic-only —
+    // the proxy already wrote the app.log line; this is the fleet-level signal.
+    audioCapture.onAudioStartRetryResolved = { ctx in
+      TelemetryService.shared.audioStartRetryResolved(
+        stage: ctx.stage,
+        trigger: ctx.trigger,
+        outcome: ctx.outcome,
+        recoveryMs: ctx.recoveryMs
+      )
+    }
+
     // Kernel-owned path: leave a preinstalled single-slot owner intact.
     // If unclaimed, install the legacy App-router fallback.
     if audioCapture.onVADAutoStop == nil {

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -54,6 +54,13 @@ public protocol AudioCaptureInterface: AnyObject {
   /// into "no_audio_captured".
   var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)? { get set }
 
+  /// Fires once per resolved start-op retry in the XPC proxy (#1194): a
+  /// pre-capture start operation hit a dead-line signature, the proxy
+  /// reacquired the connection and resent exactly once, and the retry either
+  /// recovered or exhausted. Diagnostic-only — consumers must not branch
+  /// control flow on it. Direct sources have no XPC layer and leave nil.
+  var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)? { get set }
+
   /// Fires on the first route resolution and on every subsequent resolution
   /// where sourceType or reason differs from the prior call. No-op on
   /// warm-reuse resolutions that produce the same decision.

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -59,6 +59,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// Only the XPC proxy invokes this; direct-mode manager leaves nil.
   public var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
 
+  /// Only the XPC proxy invokes this (#1194); direct-mode manager leaves nil.
+  public var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
+
   /// Fired by `resolveSource()` — initial resolution + changed-only afterwards.
   public var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
 

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -8,10 +8,27 @@ import Foundation
 /// embedded `EnviousWisprAudioService`. Real audio capture runs in the service process;
 /// the proxy handles connection lifecycle, buffer reconstruction, and state management.
 ///
-/// **Connection lifecycle (Step 1.5 design rules):**
-/// - `interruptionHandler`: if capturing → user-visible failure (reset state, fire onEngineInterrupted).
-///   If idle → transient (set needsReinit only). Always keep the same connection.
-/// - `invalidationHandler`: terminal — nil connection, recreate on next use.
+/// **Connection lifecycle (#1194 single-funnel ownership):**
+/// - The connection and its monotonically increasing generation live in a
+///   `ConnectionSlot` whose private members make `install` / `retire` the only
+///   mutation paths — compiler-enforced (private members + let-bound reference
+///   type, so nothing outside the slot can touch the fields or swap the slot).
+/// - Every fresh connection gets generation-stamped handlers and an
+///   unconditional config replay (`replayConfig()`). There is no reinit flag —
+///   no path can forget to set one.
+/// - Every death signal (invalidation, interruption, watchdog wedge, per-call
+///   transport error) funnels into `reportLineDeath(generation:cause:wasCapturing:)`.
+///   Retirement is generation-guarded, so a stale event about a retired
+///   predecessor is provably inert — including handler Tasks already queued
+///   when the slot moved on.
+/// - Pre-capture start ops (`start_engine` / `begin_capture` /
+///   `start_engine_prewarm`) retry exactly once on a fresh connection via
+///   `withStartRetry`, replaying the failed stage's service-side prefix
+///   (`begin_capture` re-runs `start_engine` — a fresh connection reaches a
+///   brand-new service world). `stopCapture` never retries (non-idempotent).
+/// - The `engineInterrupted(cause:)` service relay is an ENGINE event with no
+///   connection identity on the wire; it stays outside the funnel and keeps
+///   the connection (see its doc).
 @MainActor
 @Observable
 public final class AudioCaptureProxy: AudioCaptureInterface {
@@ -38,6 +55,10 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   public var onXPCServiceError: ((XPCErrorContext) -> Void)?
   public var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
   public var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+
+  /// #1194: fires once per resolved start-op retry (recovered or exhausted).
+  /// Diagnostic-only — consumers must not branch control flow on it.
+  public var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
 
   /// Monotonic capture-session counter — returns `activeCaptureGeneration` so
   /// the id stays stable across the `stopCapture` bump (which flips
@@ -69,10 +90,48 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     }
   }
 
-  // MARK: - XPC connection state
+  // MARK: - XPC connection state (#1194 single-funnel ownership)
 
-  private var connection: NSXPCConnection?
-  private var needsReinit = false
+  /// Sole owner of the XPC connection + its generation. Mutation is possible
+  /// ONLY through `install` / `retire` — compiler-enforced: the members are
+  /// `private` to the nested type (invisible to the outer class), and the
+  /// proxy holds it as a `let`-bound reference type, so the slot can neither
+  /// be reached around nor swapped wholesale. The TYPE is internal (not
+  /// private) solely so unit tests can exercise install/retire semantics
+  /// in isolation via `@testable import`.
+  @MainActor
+  final class ConnectionSlot {
+    private(set) var generation: UInt64 = 0
+    private var connection: NSXPCConnection?
+
+    var current: (connection: NSXPCConnection, generation: UInt64)? {
+      connection.map { ($0, generation) }
+    }
+
+    /// Retire generation `gen`. No-op (returns false) unless `gen` is current —
+    /// this is the stale-event guard. Neutralizes handlers before invalidating
+    /// as best-effort hygiene; correctness does NOT depend on it (an
+    /// already-queued handler Task is stopped by ITS generation check).
+    func retire(_ gen: UInt64) -> Bool {
+      guard gen == generation, let conn = connection else { return false }
+      conn.invalidationHandler = nil
+      conn.interruptionHandler = nil
+      conn.invalidate()
+      connection = nil
+      return true
+    }
+
+    /// Install a fresh connection, retiring any current one. Returns the new
+    /// generation for handler stamping.
+    func install(_ conn: NSXPCConnection) -> UInt64 {
+      _ = retire(generation)
+      generation &+= 1
+      connection = conn
+      return generation
+    }
+  }
+
+  private let slot = ConnectionSlot()
 
   /// AsyncStream continuation for buffer delivery from service → pipeline.
   private var bufferContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
@@ -132,6 +191,18 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     ///
     /// See `Tests/RuntimeUAT/SCENARIOS.md` for negative-control documentation.
     package var forceStallRemainingBuffers: Int = 0
+
+    /// #1194 fault-injection seam: when > 0, the next N START operations
+    /// (`start_engine` / `begin_capture` / `start_engine_prewarm`, including
+    /// their retry/prefix stages) are treated as wedged by
+    /// `withAudioXPCOperationSignal` before dispatch — no transport error, no
+    /// invalidation: exactly the watchdog-only wedge shape. Decrements per
+    /// forced wedge until 0. Never touches `stop_capture`.
+    ///
+    /// `package` access: driven end-to-end via `DebugFaultEndpoint`
+    /// (`force_audio_wedge_start(N)`) → `Tests/RuntimeUAT/faultInjection.py`.
+    /// Inert in release builds — this property does not exist outside DEBUG.
+    package var forceWedgeNextStartOps: Int = 0
   #endif
 
   public init() {}
@@ -148,9 +219,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       currentAudioRoute = "built_in_mic"
     }
 
-    ensureConnection()
-    resendConfigIfNeeded()
-    try await withAudioXPCOperationSignal(stage: "start_engine") { operationID in
+    try await withStartRetry(stage: "start_engine") { operationID in
       try await self.awaitStartEnginePhaseReply(operationID: operationID)
     }
   }
@@ -175,8 +244,6 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   public func beginCapturePhase(recoveryPayload: Data?) async throws
     -> AsyncStream<AVAudioPCMBuffer>
   {
-    ensureConnection()
-
     // Finish any stale continuation from a previous session.
     bufferContinuation?.finish()
     bufferContinuation = nil
@@ -188,7 +255,18 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       self.bufferContinuation = continuation
     }
 
-    try await withAudioXPCOperationSignal(stage: "begin_capture") { operationID in
+    // Retry prefix: a fresh connection reaches a brand-new service world with
+    // no engine, so a `begin_capture` resend must re-run `start_engine` first
+    // (device UIDs ride the message; config was replayed at acquisition).
+    try await withStartRetry(
+      stage: "begin_capture",
+      prefix: {
+        try await self.withAudioXPCOperationSignal(stage: "start_engine_retry_prefix") {
+          operationID in
+          try await self.awaitStartEnginePhaseReply(operationID: operationID)
+        }
+      }
+    ) { operationID in
       try await self.awaitBeginCaptureReply(
         operationID: operationID, recoveryPayload: recoveryPayload)
     }
@@ -326,16 +404,24 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     try await withCheckedThrowingContinuation {
       (cont: CheckedContinuation<CaptureResult, any Error>) in
       let guard_ = OneShotContinuation(cont)
-      serviceProxy { proxy in
-        proxy.stopCapture(operationID: operationID) { sampleData, vadData in
-          let samples = Self.dataToFloats(sampleData)
-          let segments = Self.decodeVADSegments(vadData)
-          guard_.resume(returning: CaptureResult(samples: samples, vadSegments: segments))
-        }
-      } onProxyError: { [weak self] in
-        self?.reportXPCReplyFailure(stage: "stop_capture", sessionID: endingSession)
-        guard_.resume(returning: CaptureResult(samples: []))
-      }
+      // capturingTeardownOnCallError: false — stopCapture owns its own state
+      // teardown (below the await) and deliberately does NOT fire
+      // onEngineInterrupted on a stop failure; a call-error here is
+      // retire-only and onXPCReplyFailed is the sole caller-visible signal.
+      serviceProxy(
+        { proxy in
+          proxy.stopCapture(operationID: operationID) { sampleData, vadData in
+            let samples = Self.dataToFloats(sampleData)
+            let segments = Self.decodeVADSegments(vadData)
+            guard_.resume(returning: CaptureResult(samples: samples, vadSegments: segments))
+          }
+        },
+        onProxyError: { [weak self] in
+          self?.reportXPCReplyFailure(stage: "stop_capture", sessionID: endingSession)
+          guard_.resume(returning: CaptureResult(samples: []))
+        },
+        capturingTeardownOnCallError: false
+      )
     }
   }
 
@@ -345,8 +431,10 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
   public func buildEngine(noiseSuppression: Bool) {
     noiseSuppressionEnabled = noiseSuppression
-    ensureConnection()
-    resendConfigIfNeeded()
+    // If acquisition created a fresh line, replayConfig already sent the new
+    // value (the property is set above, before acquisition). The explicit send
+    // below covers the reused-line case; buildEngine is idempotent service-side.
+    acquireConnection()
     serviceProxy { proxy in proxy.buildEngine(noiseSuppression: noiseSuppression) }
   }
 
@@ -363,13 +451,12 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       currentAudioRoute = "built_in_mic"
     }
 
-    ensureConnection()
-    resendConfigIfNeeded()
+    acquireConnection()
     let connMs = Self.ms(ContinuousClock.now - proxyStart)
     // Phase 1: start engine
     let enginePhaseStart = ContinuousClock.now
     do {
-      try await withAudioXPCOperationSignal(stage: "start_engine_prewarm") { operationID in
+      try await withStartRetry(stage: "start_engine_prewarm") { operationID in
         try await self.awaitStartEnginePhaseReply(operationID: operationID)
       }
     } catch {
@@ -427,6 +514,29 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     parentCancellationBehavior: WatcherParentCancellationBehavior = .returnCancellation,
     _ work: @MainActor @escaping (String) async throws -> T
   ) async throws -> T {
+    // Record the generation this operation dispatches on, so a wedge retires
+    // exactly the line it observed — never a fresh replacement (§3.3).
+    let dispatchedGen = slot.current?.generation
+
+    #if DEBUG
+      // #1194 fault-injection: watchdog-only wedge shape for UAT scenario 5.
+      if forceWedgeNextStartOps > 0, Self.isStartStage(stage) {
+        forceWedgeNextStartOps -= 1
+        let remaining = forceWedgeNextStartOps
+        Task {
+          await AppLogger.shared.log(
+            "[AudioCaptureProxy] forced wedge (DEBUG) stage=\(stage) remaining=\(remaining)",
+            level: .info, category: "XPC"
+          )
+        }
+        if let dispatchedGen {
+          reportLineDeath(generation: dispatchedGen, cause: .wedged, wasCapturing: false)
+        }
+        throw XPCOperationSignalWedgeError(
+          service: "Audio", stage: stage, observedPhase: "forced_wedge")
+      }
+    #endif
+
     let operationID = UUID().uuidString
     let signal = XPCOperationSignalWatcher(file: .audio, operationID: operationID)
     signal.start()
@@ -450,7 +560,19 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       throw error
     case .wedged:
       operationTask.cancel()
-      handleAudioXPCOperationWedge(stage: stage, operationID: operationID, snapshot: snapshot)
+      Task {
+        await AppLogger.shared.log(
+          "[AudioCaptureProxy] signal watchdog fired stage=\(stage) operationID=\(operationID) phase=\(snapshot.lastObservedPhase) silenceMs=\(snapshot.silenceMs)",
+          level: .info, category: "XPC"
+        )
+      }
+      // The wedge is a first-class line-death event in the same funnel as the
+      // handlers (§3.3). Retire-only (`wasCapturing: false`): the thrown error
+      // below is the caller-visible signal, and the only wedge-able stage with
+      // an active capture (`stop_capture`) owns its own state teardown.
+      if let dispatchedGen {
+        reportLineDeath(generation: dispatchedGen, cause: .wedged, wasCapturing: false)
+      }
       throw XPCOperationSignalWedgeError(
         service: "Audio",
         stage: stage,
@@ -459,91 +581,189 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     }
   }
 
-  private func handleAudioXPCOperationWedge(
+  #if DEBUG
+    /// Stages eligible for the `forceWedgeNextStartOps` fault seam — the three
+    /// pre-capture start ops plus their retry/prefix stages. Never `stop_capture`.
+    nonisolated private static func isStartStage(_ stage: String) -> Bool {
+      stage.hasPrefix("start_engine") || stage.hasPrefix("begin_capture")
+    }
+  #endif
+
+  // MARK: - Start-op retry (#1194)
+
+  /// Runs one idempotent pre-capture start op with a bounded single retry.
+  ///
+  /// The three start ops are retry-safe: `isCapturing` is false throughout
+  /// (flipped only after `beginCapturePhase`'s XPC call succeeds), so no audio
+  /// exists to lose or duplicate. The retry always lands on a NEW connection,
+  /// which reaches a brand-new service-side world (fresh `AudioServiceHandler`
+  /// + fresh `AudioCaptureManager` per accepted connection) — duplicate
+  /// delivery to a surviving world is structurally impossible.
+  ///
+  /// Bounded-once semantics: exactly one reacquire-and-resend per public call,
+  /// shared across both error shapes (wedge / unreachable) and including the
+  /// `prefix` — a prefix failure counts as exhaustion, never a nested retry.
+  /// Exhaustion propagates the retry's error unchanged (same types as today).
+  /// Internal (not private) so unit tests can drive it with injected operations.
+  func withStartRetry<T: Sendable>(
     stage: String,
-    operationID: String,
-    snapshot: WatcherSnapshot
+    prefix: (@MainActor () async throws -> Void)? = nil,
+    _ operation: @MainActor @escaping (String) async throws -> T
+  ) async throws -> T {
+    let firstGen = acquireConnection()
+    do {
+      return try await withAudioXPCOperationSignal(stage: stage, operation)
+    } catch let firstError where isLineDeathSignature(firstError) {
+      let retryStarted = ContinuousClock.now
+      // Converge, don't stack: the wedge branch / per-call error path already
+      // reported this generation's death, making this a guarded no-op there;
+      // it is the primary reporter only when the failure surfaced without a
+      // death report (e.g. dispatch on an already-empty slot). If a sibling
+      // already retired firstGen and acquired a fresh line, acquireConnection
+      // below reuses it instead of stacking a second connection.
+      reportLineDeath(
+        generation: firstGen, cause: Self.lineDeathCause(of: firstError), wasCapturing: false)
+      acquireConnection()
+      do {
+        try await prefix?()
+        let value = try await withAudioXPCOperationSignal(stage: "\(stage)_retry", operation)
+        emitRetryResolved(
+          stage: stage, trigger: firstError, outcome: "recovered", since: retryStarted)
+        return value
+      } catch {
+        emitRetryResolved(
+          stage: stage, trigger: firstError, outcome: "exhausted", since: retryStarted)
+        throw error
+      }
+    }
+  }
+
+  /// The two dead-line signatures that trigger the single start retry. Device
+  /// errors and service-reply NSErrors never match — they propagate unretried.
+  private func isLineDeathSignature(_ error: any Error) -> Bool {
+    if error is XPCOperationSignalWedgeError { return true }
+    if case XPCTransportError.serviceUnreachable = error { return true }
+    return false
+  }
+
+  nonisolated private static func lineDeathCause(of error: any Error) -> LineDeathCause {
+    error is XPCOperationSignalWedgeError ? .wedged : .callError
+  }
+
+  private func emitRetryResolved(
+    stage: String, trigger: any Error, outcome: String, since: ContinuousClock.Instant
   ) {
+    let ctx = AudioStartRetryContext(
+      stage: stage,
+      trigger: trigger is XPCOperationSignalWedgeError ? "wedged" : "service_unreachable",
+      outcome: outcome,
+      recoveryMs: Self.ms(ContinuousClock.now - since)
+    )
     Task {
       await AppLogger.shared.log(
-        "[AudioCaptureProxy] signal watchdog fired stage=\(stage) operationID=\(operationID) phase=\(snapshot.lastObservedPhase) silenceMs=\(snapshot.silenceMs)",
+        "[AudioCaptureProxy] start retry resolved stage=\(ctx.stage) trigger=\(ctx.trigger) outcome=\(ctx.outcome) recoveryMs=\(ctx.recoveryMs)",
         level: .info, category: "XPC"
       )
     }
-    connection?.invalidate()
-    connection = nil
-    needsReinit = true
+    onAudioStartRetryResolved?(ctx)
   }
 
-  // MARK: - Config re-send after crash
+  // MARK: - XPC connection management (#1194)
 
-  /// Replays configuration to the service after a crash/relaunch.
-  /// Clears needsReinit after the XPC call is dispatched. Note: buildEngine is fire-and-forget
-  /// (no reply handler), so we cannot detect if the service actually processed the config.
-  /// If the service crashes during replay, the next interruptionHandler will re-set needsReinit.
-  /// This is acceptable because buildEngine is idempotent — replay on next attempt is safe.
-  private func resendConfigIfNeeded() {
-    guard needsReinit else { return }
-    serviceProxy { [self] proxy in
-      proxy.buildEngine(noiseSuppression: noiseSuppressionEnabled)
-      // Replay VAD config so service rebuilds its SilenceDetector after crash.
-      if let vad = vadConfig {
-        proxy.configureVAD(
-          autoStop: vad.autoStop, silenceTimeout: vad.silenceTimeout,
-          sensitivity: vad.sensitivity, energyGate: vad.energyGate)
-      }
-      // Replay warm engine policy so service uses correct idle timeout.
-      proxy.setWarmEnginePolicy(warmEnginePolicy.rawValue)
-      needsReinit = false
-    }
-  }
-
-  // MARK: - XPC connection management
-
-  private func ensureConnection() {
-    guard connection == nil else { return }
+  /// The single acquisition funnel. Fully synchronous — no suspension between
+  /// create, stamp, install handlers, and config replay — so it is atomic on
+  /// the MainActor and cannot race itself. Reuses a live line when one exists.
+  /// Internal (not private) so unit tests can observe generation movement.
+  @discardableResult
+  func acquireConnection() -> UInt64 {
+    if let live = slot.current { return live.generation }
 
     let conn = NSXPCConnection(serviceName: XPCServiceName.audioService)
     conn.remoteObjectInterface = NSXPCInterface(with: AudioServiceProtocol.self)
     conn.exportedInterface = NSXPCInterface(with: AudioServiceClientProtocol.self)
     conn.exportedObject = self
 
-    // DESIGN RULE: Interruption while isCapturing == true is a user-visible capture failure.
-    // Interruption while idle is transient — just set needsReinit.
-    //
-    // IMPORTANT(Step 3+): Step 1.5 proved kill -9 fires interruptionHandler for embedded
-    // XPC services. During active capture, this IS the crash signal. The connection stays
-    // valid — the next XPC call auto-relaunches the service via launchd.
-    // CRITICAL: interruptionHandler and invalidationHandler run on XPC dispatch queues,
-    // NOT MainActor. Closures defined inside @MainActor methods inherit that isolation in
-    // Swift 6, causing dispatch_assert_queue_fail when XPC calls them. Extract to
-    // nonisolated static to break the isolation inheritance.
-    conn.interruptionHandler = Self.makeInterruptionHandler(proxy: self)
-    conn.invalidationHandler = Self.makeInvalidationHandler(proxy: self)
+    let gen = slot.install(conn)
+
+    // CRITICAL: interruptionHandler and invalidationHandler run on XPC dispatch
+    // queues, NOT MainActor. Closures defined inside @MainActor methods inherit
+    // that isolation in Swift 6, causing dispatch_assert_queue_fail when XPC
+    // calls them. Extract to nonisolated static to break the inheritance. Each
+    // handler is stamped with THIS connection's generation.
+    conn.interruptionHandler = Self.makeInterruptionHandler(proxy: self, generation: gen)
+    conn.invalidationHandler = Self.makeInvalidationHandler(proxy: self, generation: gen)
 
     conn.resume()
-    connection = conn
 
-    // Verify service is alive — this ping triggers launchd to spawn the service.
-    serviceProxy { proxy in proxy.ping { _ in } }
+    // Unconditional config replay on every fresh line — there is no reinit
+    // flag to forget. The sends also trigger launchd to spawn the service.
+    replayConfig()
+    return gen
+  }
+
+  /// Replays stored configuration to a freshly acquired connection. All three
+  /// items are fire-and-forget; per-item ordering against the start ops is
+  /// proven in the plan (§3.2): VAD is applied synchronously on delivery
+  /// service-side (the one start-critical item), the other two are not
+  /// consumed in the start window. buildEngine is idempotent service-side.
+  private func replayConfig() {
+    serviceProxy { [self] proxy in
+      proxy.buildEngine(noiseSuppression: noiseSuppressionEnabled)
+      if let vad = vadConfig {
+        proxy.configureVAD(
+          autoStop: vad.autoStop, silenceTimeout: vad.silenceTimeout,
+          sensitivity: vad.sensitivity, energyGate: vad.energyGate)
+      }
+      proxy.setWarmEnginePolicy(warmEnginePolicy.rawValue)
+    }
   }
 
   /// Gets the remote proxy with error handling.
-  /// `onProxyError` is called if the proxy can't be obtained (connection nil or cast fails)
-  /// AND if the XPC framework delivers a per-call error (service crashed mid-call).
-  /// This is critical: when the service dies after a call is dispatched but before it replies,
-  /// the XPC error handler fires but the reply handler does NOT. Without routing the error
-  /// to `onProxyError`, any pending continuation hangs forever.
+  /// `onProxyError` is called if the proxy can't be obtained (no live line or
+  /// cast fails) AND if the XPC framework delivers a per-call error (service
+  /// crashed mid-call). This is critical: when the service dies after a call is
+  /// dispatched but before it replies, the XPC error handler fires but the
+  /// reply handler does NOT. Without routing the error to `onProxyError`, any
+  /// pending continuation hangs forever.
+  ///
+  /// #1194: every per-call transport error also reports line death for the
+  /// generation the call dispatched on (the v1 hole where this path mutated
+  /// nothing, leaving a half-dead connection for the next use, is closed
+  /// structurally). The report precedes `onProxyError` so a retrying caller
+  /// always finds the slot already retired.
+  ///
+  /// `wasCapturing` is read LIVE at error time (Codex code-diff r1 [P2]):
+  /// because `retire` stale-guards the connection-level handlers, the per-call
+  /// error is often the ONLY observer of a mid-capture service death (e.g. a
+  /// streaming `getSamplesSnapshot` or a live `setWarmEnginePolicy` send in
+  /// flight when the helper dies) — hard-coding `false` here would skip the
+  /// capturing teardown forever and wedge the recording. The one caller that
+  /// owns its own teardown (`stopCapture`) suppresses this via
+  /// `capturingTeardownOnCallError: false`, preserving its no-double-fire
+  /// contract (`onXPCReplyFailed` stays the sole caller-visible stop signal).
   private func serviceProxy(
     _ work: (any AudioServiceProtocol) -> Void,
-    onProxyError: (() -> Void)? = nil
+    onProxyError: (() -> Void)? = nil,
+    capturingTeardownOnCallError: Bool = true
   ) {
-    guard let conn = connection else {
+    guard let live = slot.current else {
       onProxyError?()
       return
     }
-    let proxy = conn.remoteObjectProxyWithErrorHandler(
-      Self.makeXPCErrorHandler(onProxyError: onProxyError))
+    let dispatchedGen = live.generation
+    let proxy = live.connection.remoteObjectProxyWithErrorHandler(
+      Self.makeXPCErrorHandler { [weak self] in
+        guard let self else {
+          onProxyError?()
+          return
+        }
+        self.reportLineDeath(
+          generation: dispatchedGen,
+          cause: .callError,
+          wasCapturing: capturingTeardownOnCallError && self.isCapturing
+        )
+        onProxyError?()
+      })
     guard let service = proxy as? AudioServiceProtocol else {
       onProxyError?()
       return
@@ -579,120 +799,182 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
   /// Build the XPC interruptionHandler in a nonisolated context.
   /// Same isolation-escape pattern as makeXPCErrorHandler.
-  nonisolated private static func makeInterruptionHandler(proxy: AudioCaptureProxy) -> @Sendable ()
-    -> Void
-  {
+  ///
+  /// #1194: stamped with the generation of the connection it is installed on.
+  /// After the MainActor hop it reports line death for ITS generation only —
+  /// a stale hop about a retired predecessor fails `reportLineDeath`'s retire
+  /// guard and is provably inert, even when the hop's Task was already queued
+  /// before the slot moved on. Internal (not private) so unit tests can invoke
+  /// the constructed handler directly.
+  nonisolated static func makeInterruptionHandler(
+    proxy: AudioCaptureProxy, generation: UInt64
+  ) -> @Sendable () -> Void {
     return { [weak proxy] in
-
       Task { @MainActor [weak proxy] in
         guard let proxy else { return }
-        let wasCapturing = proxy.isCapturing
         await AppLogger.shared.log(
-          "[AudioCaptureProxy] XPC interruptionHandler fired — wasCapturing=\(wasCapturing)",
+          "[AudioCaptureProxy] XPC interruptionHandler fired gen=\(generation) wasCapturing=\(proxy.isCapturing)",
           level: .info, category: "XPC"
         )
-        if wasCapturing {
-          // Cancel pending stall watchdog before the session ends.
-          proxy.stallWorkItem?.cancel()
-          proxy.stallWorkItem = nil
-          let endingSession = proxy.activeCaptureGeneration
-          // #455: compute duration BEFORE flipping isCapturing / resetting
-          // captureStartUptimeNs so the breadcrumb has a real number.
-          let firedAt = DispatchTime.now().uptimeNanoseconds
-          let durationNs: UInt64? =
-            proxy.captureStartUptimeNs > 0 && firedAt >= proxy.captureStartUptimeNs
-            ? (firedAt - proxy.captureStartUptimeNs) : nil
-          proxy.isCapturing = false
-          proxy.captureStartUptimeNs = 0  // #455
-          proxy.audioLevel = 0
-          proxy.captureGeneration &+= 1
-          proxy.bufferContinuation?.finish()
-          proxy.bufferContinuation = nil
-          // XPC connection break — `onXPCServiceError` (below) is the sole owner
-          // of this capture, so tag `.xpcConnectionLost` (A3 suppresses it).
-          proxy.onEngineInterrupted?(.xpcConnectionLost)
-          // Fire telemetry callback — idle interruptions stay silent (§3.4 row 2).
-          proxy.onXPCServiceError?(
-            XPCErrorContext(
-              kind: .interruptCapturing,
-              sessionID: endingSession,
-              recordingDurationNs: durationNs
-            )
-          )
-        }
-        proxy.needsReinit = true
+        proxy.reportLineDeath(
+          generation: generation, cause: .interrupted, wasCapturing: proxy.isCapturing)
       }
     }
   }
 
-  /// Build the XPC invalidationHandler in a nonisolated context.
-  nonisolated private static func makeInvalidationHandler(proxy: AudioCaptureProxy) -> @Sendable ()
-    -> Void
-  {
+  /// Build the XPC invalidationHandler in a nonisolated context. Same
+  /// generation-stamping contract as `makeInterruptionHandler` — the v1 race
+  /// where a stale invalidation hop clobbered a freshly created replacement
+  /// (the handler nil'd `connection` with no identity check) dies here.
+  nonisolated static func makeInvalidationHandler(
+    proxy: AudioCaptureProxy, generation: UInt64
+  ) -> @Sendable () -> Void {
     return { [weak proxy] in
-
       Task { @MainActor [weak proxy] in
         guard let proxy else { return }
+        await AppLogger.shared.log(
+          "[AudioCaptureProxy] XPC invalidationHandler fired gen=\(generation) wasCapturing=\(proxy.isCapturing)",
+          level: .info, category: "XPC"
+        )
+        proxy.reportLineDeath(
+          generation: generation, cause: .invalidated, wasCapturing: proxy.isCapturing)
+      }
+    }
+  }
 
-        proxy.connection = nil
-        let wasCapturing = proxy.isCapturing
-        let endingSession = proxy.activeCaptureGeneration
-        // #455: compute duration BEFORE flipping isCapturing / resetting
-        // captureStartUptimeNs so the breadcrumb has a real number. Idle
-        // invalidations have no active session and so no duration to report.
-        let firedAt = DispatchTime.now().uptimeNanoseconds
-        let durationNs: UInt64? =
-          wasCapturing && proxy.captureStartUptimeNs > 0
-            && firedAt >= proxy.captureStartUptimeNs
-          ? (firedAt - proxy.captureStartUptimeNs) : nil
-        if wasCapturing {
-          proxy.stallWorkItem?.cancel()
-          proxy.stallWorkItem = nil
-          proxy.isCapturing = false
-          proxy.captureStartUptimeNs = 0  // #455
-          proxy.audioLevel = 0
-          proxy.captureGeneration &+= 1
-          proxy.bufferContinuation?.finish()
-          proxy.bufferContinuation = nil
-          // XPC connection break — `onXPCServiceError` (below) is the sole owner
-          // of this capture, so tag `.xpcConnectionLost` (A3 suppresses it).
-          proxy.onEngineInterrupted?(.xpcConnectionLost)
-        }
-        proxy.needsReinit = true
-        // Invalidation is always a telemetry signal — connection is gone.
-        proxy.onXPCServiceError?(
+  // MARK: - Line death (#1194)
+
+  /// What killed the line. Determines which caller-visible signals fire on
+  /// retirement (`reportLineDeath`) — the existing Sentry taxonomy
+  /// (interruptCapturing / invalidateCapturing / invalidateIdle) is preserved
+  /// per cause.
+  enum LineDeathCause: String, Sendable {
+    case invalidated, interrupted, wedged, callError
+  }
+
+  /// The single generation-guarded consumer for every line-death signal:
+  /// connection invalidation, connection interruption, watchdog wedge, and
+  /// per-call transport error all land here (§3.3). The four uncoordinated
+  /// mutation paths this replaces are gone.
+  ///
+  /// Idempotent per generation: retiring an already-retired (or never-current)
+  /// generation is a logged no-op, so double reports and stale handler hops
+  /// are structurally harmless.
+  ///
+  /// `wasCapturing` is caller-supplied, not read from state: the wedge
+  /// reporters and the stop path hard-code `false` (retire-only —
+  /// `stopCapture` owns its own teardown and today deliberately does NOT fire
+  /// `onEngineInterrupted` on a stop failure; that contract is preserved),
+  /// while handlers and non-stop per-call errors pass the live `isCapturing`
+  /// so a mid-capture death always runs the teardown exactly once.
+  /// Internal (not private) so unit tests can characterize the transition.
+  func reportLineDeath(generation: UInt64, cause: LineDeathCause, wasCapturing: Bool) {
+    guard slot.retire(generation) else {
+      // Stale event about a retired predecessor — provably inert. Log-only
+      // by design: app.log is the diagnosis surface for discards.
+      let currentGen = slot.generation
+      Task {
+        await AppLogger.shared.log(
+          "[AudioCaptureProxy] stale line-death discarded gen=\(generation) cause=\(cause.rawValue) currentGen=\(currentGen)",
+          level: .info, category: "XPC"
+        )
+      }
+      return
+    }
+    Task {
+      await AppLogger.shared.log(
+        "[AudioCaptureProxy] line death gen=\(generation) cause=\(cause.rawValue) wasCapturing=\(wasCapturing)",
+        level: .info, category: "XPC"
+      )
+    }
+
+    let endingSession = activeCaptureGeneration
+    // #455: compute duration BEFORE flipping isCapturing / resetting
+    // captureStartUptimeNs so the breadcrumb has a real number. Idle deaths
+    // have no active session and so no duration to report.
+    let firedAt = DispatchTime.now().uptimeNanoseconds
+    let durationNs: UInt64? =
+      wasCapturing && captureStartUptimeNs > 0 && firedAt >= captureStartUptimeNs
+      ? (firedAt - captureStartUptimeNs) : nil
+
+    if wasCapturing {
+      // Capturing-teardown side effects, byte-identical to the former
+      // interruption/invalidation handlers.
+      stallWorkItem?.cancel()
+      stallWorkItem = nil
+      isCapturing = false
+      captureStartUptimeNs = 0  // #455
+      audioLevel = 0
+      captureGeneration &+= 1
+      bufferContinuation?.finish()
+      bufferContinuation = nil
+      // XPC connection break — `onXPCServiceError` (below) is the sole owner
+      // of this capture, so tag `.xpcConnectionLost` (A3 suppresses it).
+      onEngineInterrupted?(.xpcConnectionLost)
+    }
+
+    switch cause {
+    case .invalidated:
+      // Invalidation is always a telemetry signal — the connection is gone.
+      onXPCServiceError?(
+        XPCErrorContext(
+          kind: wasCapturing ? .invalidateCapturing : .invalidateIdle,
+          sessionID: wasCapturing ? endingSession : nil,
+          recordingDurationNs: durationNs
+        )
+      )
+    case .interrupted, .callError:
+      // Idle events stay silent end-to-end (today's contract). A CAPTURING
+      // call error is the transport-loss-during-capture shape whose Sentry
+      // signal previously arrived via the interruption handler — that handler
+      // is now stale-guarded once this retire runs, so the signal is re-homed
+      // here under the same `interruptCapturing` kind (Codex code-diff r1 [P2]).
+      if wasCapturing {
+        onXPCServiceError?(
           XPCErrorContext(
-            kind: wasCapturing ? .invalidateCapturing : .invalidateIdle,
-            sessionID: wasCapturing ? endingSession : nil,
+            kind: .interruptCapturing,
+            sessionID: endingSession,
             recordingDurationNs: durationNs
           )
         )
       }
+    case .wedged:
+      // Retire-only: the thrown error is the caller-visible signal. No
+      // wedge-able stage runs while capturing — the only one that could
+      // (`stop_capture`) hard-codes `wasCapturing: false` because stopCapture
+      // owns its own teardown.
+      break
     }
   }
 
   // MARK: - V2 fault-injection (DEBUG only, issue #291)
 
   #if DEBUG
-    /// Invalidates the active XPC connection synchronously. Fires the existing
-    /// `invalidationHandler` path, which sets `connection = nil`, flips
+    /// Terminates the active XPC line synchronously through the #1194 funnel:
+    /// reports an `.invalidated` line death for the current generation, which
+    /// retires the slot (invalidating the connection), flips
     /// `isCapturing = false`, finishes the buffer continuation, and emits the
-    /// `onXPCServiceError(.invalidateCapturing)` telemetry callback.
+    /// `onXPCServiceError(.invalidateCapturing / .invalidateIdle)` telemetry
+    /// callback — the same observable effect as the pre-#1194
+    /// `connection?.invalidate()`, now deterministic AND synchronous (no
+    /// async handler hop).
     ///
     /// Drives Lane A scenario A4 ("audio XPC service kill") via the DEBUG
     /// localhost endpoint. Equivalent in effect to a real audio service crash
-    /// mid-stream — but deterministic and synchronous.
+    /// mid-stream.
     ///
     /// `package` access: callable from `DebugFaultEndpoint` in the app target.
     /// Inert in release builds.
     package func forceConnectionTerminationNow() {
-      connection?.invalidate()
+      guard let live = slot.current else { return }
+      reportLineDeath(
+        generation: live.generation, cause: .invalidated, wasCapturing: isCapturing)
     }
   #endif
 
   // MARK: - VAD Interface (Step 5)
 
-  /// Stored VAD config — forwarded to service, replayed after crash via resendConfigIfNeeded().
+  /// Stored VAD config — forwarded to service, replayed on every fresh connection via replayConfig().
   private var vadConfig:
     (autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool)?
 
@@ -849,10 +1131,20 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
   }
 
   /// Service's audio engine was interrupted (device disconnect, emergency
-  /// teardown, max-duration cap). Matches interruptionHandler contract: only
-  /// fires onEngineInterrupted during active capture. Idle interruptions are
-  /// transient — just set needsReinit. `cause` is the relayed
+  /// teardown, max-duration cap). Only fires onEngineInterrupted during
+  /// active capture; idle relays are no-ops. `cause` is the relayed
   /// `EngineInterruptionCause` raw value (issue #1174 A3).
+  ///
+  /// #1194: deliberately OUTSIDE the line-death funnel. This is an ENGINE
+  /// event, not a LINE event — it arrives over the exported-object channel
+  /// with no connection identity on the wire, so it cannot be
+  /// generation-guarded, and retiring the current line on it would let a
+  /// stale relay from a dying predecessor world kill a healthy fresh line.
+  /// The relaying service world is by definition ALIVE with its config intact
+  /// (a crashed process fires the connection-level interruptionHandler
+  /// instead, which IS in the funnel), so the connection is kept and nothing
+  /// needs replaying — the next `start_engine` re-prepares the engine with
+  /// device UIDs riding its own arguments.
   nonisolated public func engineInterrupted(cause: String) {
     Task { @MainActor [weak self] in
       guard let self else { return }
@@ -873,7 +1165,9 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
         // direct mode (issue #1174 A3).
         self.onEngineInterrupted?(EngineInterruptionCause.hostCause(forRelayedRawValue: cause))
       }
-      self.needsReinit = true
+      // #1194: the former `needsReinit = true` here is deleted with nothing
+      // replacing it — any FRESH line gets an unconditional config replay at
+      // acquisition, and the relaying (alive) world keeps its config.
     }
   }
 

--- a/Sources/EnviousWisprCore/CaptureStallContext.swift
+++ b/Sources/EnviousWisprCore/CaptureStallContext.swift
@@ -109,6 +109,28 @@ public struct XPCReplyFailureContext: Sendable {
   }
 }
 
+/// Context for one resolved start-op retry inside `AudioCaptureProxy` (#1194).
+/// Reported via `onAudioStartRetryResolved` after the bounded
+/// reacquire-and-resend resolves either way. Diagnostic-only: consumers must
+/// not branch control flow on it. No PII — four low-cardinality fields.
+public struct AudioStartRetryContext: Sendable {
+  /// The failed public stage: `start_engine` | `begin_capture` | `start_engine_prewarm`.
+  public let stage: String
+  /// What killed the first attempt: `wedged` | `service_unreachable`.
+  public let trigger: String
+  /// `recovered` (silent same-press save) | `exhausted` (today's failure UX).
+  public let outcome: String
+  /// Line-death detection → retry resolution latency in milliseconds.
+  public let recoveryMs: Int
+
+  public init(stage: String, trigger: String, outcome: String, recoveryMs: Int) {
+    self.stage = stage
+    self.trigger = trigger
+    self.outcome = outcome
+    self.recoveryMs = recoveryMs
+  }
+}
+
 /// Classifies XPC interruption / invalidation events for the `onXPCServiceError`
 /// callback on `AudioCaptureInterface`. Exhaustive: any new XPC channel
 /// requires adding a case, which the compiler enforces at every consumer

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -622,6 +622,24 @@ public final class TelemetryService {
       ])
   }
 
+  /// #1194 — one event per resolved audio start-op retry: a record press hit a
+  /// dead XPC line (idle-reap race), the proxy reacquired the connection and
+  /// resent once. `outcome=recovered` is a silent same-press save;
+  /// `outcome=exhausted` means the press failed with today's UX after the
+  /// bounded retry. Privacy: four low-cardinality strings/ints only.
+  public func audioStartRetryResolved(
+    stage: String, trigger: String, outcome: String, recoveryMs: Int
+  ) {
+    PostHogSDK.shared.capture(
+      "coldstart.audio_line_retry",
+      properties: [
+        "stage": stage,
+        "trigger": trigger,
+        "outcome": outcome,
+        "recovery_ms": recoveryMs,
+      ])
+  }
+
   // MARK: - Crash-recovery (#1063 PR2)
   //
   // Privacy: state/counts/buckets only — never transcript text, audio, or

--- a/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
@@ -33,6 +33,7 @@ struct AudioEventRouterTests {
 
     #expect(audio.onEngineInterrupted == nil)
     #expect(audio.onXPCServiceError == nil)
+    #expect(audio.onAudioStartRetryResolved == nil)
     // `makeParakeetDriver` runs `KernelDictationDriverFactory.make` which
     // claims `onVADAutoStop` via `CaptureVADSignalSource.bind`. To exercise
     // the App router's unclaimed-fallback path explicitly, clear the slot
@@ -50,6 +51,7 @@ struct AudioEventRouterTests {
 
     #expect(audio.onEngineInterrupted != nil)
     #expect(audio.onXPCServiceError != nil)
+    #expect(audio.onAudioStartRetryResolved != nil)
     #expect(audio.onVADAutoStop != nil)
     withExtendedLifetime(router) {}
   }

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -27,6 +27,7 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?
   var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
   var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool = false

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -154,6 +154,7 @@ private final class SettableAudioCapture: AudioCaptureInterface {
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?
   var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
   var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool = false
@@ -204,6 +205,7 @@ private final class ObservableAudioCapture: AudioCaptureInterface {
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?
   var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
   var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool = false

--- a/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AudioEventRouterCeilingsTests.swift
@@ -8,6 +8,13 @@ import Testing
 /// collaborator), sub-binned into collaborator / closure-injected slots so the
 /// test fails with a specific message. Caps lower-is-free, raise via the
 /// Bible §30 changelog.
+///
+/// Bible §30 entry (#1194, 2026-07-02): line ceiling 125 → 137. The router
+/// gained one wiring block (`onAudioStartRetryResolved` →
+/// `TelemetryService.audioStartRetryResolved`), consistent with its existing
+/// role as the audio-callback → telemetry wiring home (state-ownership row 9).
+/// No new collaborator slot, no new closure-injected dependency, no new
+/// import — only the line count moved.
 @Suite struct AudioEventRouterCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWisprAppKit/App/DictationRuntime/AudioEventRouter.swift"
@@ -55,9 +62,9 @@ import Testing
       contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      count <= 125,
+      count <= 137,
       """
-      AudioEventRouter line count exceeded: \(count) > 125. \
+      AudioEventRouter line count exceeded: \(count) > 137. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureProxyLineOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureProxyLineOwnershipTests.swift
@@ -134,21 +134,26 @@ struct AudioCaptureProxyLineOwnershipTests {
       for waiter in parked { waiter.resume() }
     }
 
-    /// Signal-based wait: resumes on the next recorded signal, nil-timeout
-    /// backstop so a regression fails fast instead of hanging the runner.
+    /// Signal-based wait: resumes on the next recorded signal, with a timeout
+    /// backstop that RESUMES the parked continuation directly (cloud Codex
+    /// P2 on PR #1274: cancelling a task suspended in `withCheckedContinuation`
+    /// does not resume it — the old shape would hang the runner on a genuine
+    /// handler regression instead of failing fast). Same parked-waiter shape
+    /// as `DriverStateWaiter` in AudioEventRouterTests.
     func waitForNextSignal(timeout: Duration = .seconds(3)) async -> Bool {
       let before = signals.count
-      let waitTask = Task { @MainActor in
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-          if signals.count > before { cont.resume() } else { waiters.append(cont) }
+      await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+        waiters.append(cont)
+        Task { @MainActor [weak self] in
+          try? await Task.sleep(for: timeout)
+          guard let self else { return }
+          // Timeout backstop: drain any still-parked waiters. A signal that
+          // arrived first already drained the list, making this a no-op.
+          let parked = self.waiters
+          self.waiters = []
+          for waiter in parked { waiter.resume() }
         }
       }
-      let timeoutTask = Task { @MainActor in
-        try? await Task.sleep(for: timeout)
-        waitTask.cancel()
-      }
-      await waitTask.value
-      timeoutTask.cancel()
       return signals.count > before
     }
   }

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureProxyLineOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureProxyLineOwnershipTests.swift
@@ -1,0 +1,512 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1194 — locks the single-funnel connection ownership rewrite:
+// `ConnectionSlot` (install/retire are the only mutation paths),
+// `reportLineDeath` (one generation-guarded consumer for every death signal),
+// and `withStartRetry` (bounded single reacquire-and-resend for the three
+// idempotent pre-capture start ops).
+//
+// Determinism note: tests that acquire a REAL connection (to a service name
+// that does not exist in the test runner) keep their act+assert sequence
+// synchronous on the MainActor — environment-driven handler fires need a
+// MainActor hop, which cannot interleave until the test suspends. Tests that
+// do suspend assert only suspension-safe facts (operation counts, thrown
+// error types, telemetry callbacks fired by the retry path itself).
+@MainActor
+@Suite("AudioCaptureProxy line ownership (#1194)")
+struct AudioCaptureProxyLineOwnershipTests {
+
+  // MARK: - ConnectionSlot
+
+  private static func makeConnection() -> NSXPCConnection {
+    // Never resumed — slot tests exercise bookkeeping only.
+    NSXPCConnection(serviceName: "com.enviouswispr.test.nonexistent")
+  }
+
+  @Test("retire of a never-installed generation is a no-op")
+  func retireOnFreshSlotIsNoOp() {
+    let slot = AudioCaptureProxy.ConnectionSlot()
+    #expect(slot.retire(0) == false)
+    #expect(slot.generation == 0)
+    #expect(slot.current == nil)
+  }
+
+  @Test("install bumps the generation and exposes the connection")
+  func installBumpsGeneration() {
+    let slot = AudioCaptureProxy.ConnectionSlot()
+    let conn = Self.makeConnection()
+    let gen = slot.install(conn)
+    #expect(gen == 1)
+    #expect(slot.generation == 1)
+    #expect(slot.current?.generation == 1)
+    #expect(slot.current?.connection === conn)
+  }
+
+  @Test("retire acts exactly once for the current generation")
+  func retireCurrentActsOnce() {
+    let slot = AudioCaptureProxy.ConnectionSlot()
+    let gen = slot.install(Self.makeConnection())
+    #expect(slot.retire(gen) == true)
+    #expect(slot.current == nil)
+    // Second retire of the same generation: connection is gone — no-op.
+    #expect(slot.retire(gen) == false)
+    // Generation does not move on retire; only install bumps it.
+    #expect(slot.generation == gen)
+  }
+
+  @Test("retire of a stale (superseded) generation is a no-op")
+  func retireStaleIsNoOp() {
+    let slot = AudioCaptureProxy.ConnectionSlot()
+    let gen1 = slot.install(Self.makeConnection())
+    let conn2 = Self.makeConnection()
+    let gen2 = slot.install(conn2)
+    #expect(gen2 == gen1 + 1)
+    #expect(slot.retire(gen1) == false)
+    // The fresh line is untouched by the stale retire.
+    #expect(slot.current?.generation == gen2)
+    #expect(slot.current?.connection === conn2)
+  }
+
+  @Test("install retires the predecessor and neutralizes its handlers")
+  func installRetiresPredecessor() {
+    let slot = AudioCaptureProxy.ConnectionSlot()
+    let conn1 = Self.makeConnection()
+    conn1.invalidationHandler = {}
+    conn1.interruptionHandler = {}
+    _ = slot.install(conn1)
+    let gen2 = slot.install(Self.makeConnection())
+    #expect(slot.current?.generation == gen2)
+    // Best-effort hygiene: the retired predecessor's handlers were cleared
+    // before invalidation, so it cannot echo events about itself.
+    #expect(conn1.invalidationHandler == nil)
+    #expect(conn1.interruptionHandler == nil)
+  }
+
+  // MARK: - reportLineDeath (callback recorder)
+
+  /// Records every caller-visible signal the proxy fires, in order.
+  @MainActor
+  private final class SignalRecorder {
+    enum Signal: Equatable {
+      case engineInterrupted(EngineInterruptionCause)
+      case xpcServiceError(XPCErrorKind, sessionID: UInt64?)
+      case xpcReplyFailed(stage: String)
+      case retryResolved(stage: String, trigger: String, outcome: String)
+    }
+    private(set) var signals: [Signal] = []
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Signals minus test-environment noise. Tests that SUSPEND (awaited
+    /// retry flows) acquire REAL connections to a service name that does not
+    /// exist in the test runner; the system invalidates those lines
+    /// asynchronously and their (legitimately current) handlers report an
+    /// idle invalidation. That `.invalidateIdle` fire is correct product
+    /// behavior but nondeterministic in timing here, so suspending tests
+    /// assert on this filtered view. Synchronous tests assert on `signals`
+    /// unfiltered.
+    var signalsExceptIdleInvalidation: [Signal] {
+      signals.filter { $0 != .xpcServiceError(.invalidateIdle, sessionID: nil) }
+    }
+
+    func install(on proxy: AudioCaptureProxy) {
+      proxy.onEngineInterrupted = { [weak self] cause in
+        self?.record(.engineInterrupted(cause))
+      }
+      proxy.onXPCServiceError = { [weak self] ctx in
+        self?.record(.xpcServiceError(ctx.kind, sessionID: ctx.sessionID))
+      }
+      proxy.onXPCReplyFailed = { [weak self] ctx in
+        self?.record(.xpcReplyFailed(stage: ctx.replyStage))
+      }
+      proxy.onAudioStartRetryResolved = { [weak self] ctx in
+        self?.record(.retryResolved(stage: ctx.stage, trigger: ctx.trigger, outcome: ctx.outcome))
+      }
+    }
+
+    private func record(_ signal: Signal) {
+      signals.append(signal)
+      let parked = waiters
+      waiters = []
+      for waiter in parked { waiter.resume() }
+    }
+
+    /// Signal-based wait: resumes on the next recorded signal, nil-timeout
+    /// backstop so a regression fails fast instead of hanging the runner.
+    func waitForNextSignal(timeout: Duration = .seconds(3)) async -> Bool {
+      let before = signals.count
+      let waitTask = Task { @MainActor in
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+          if signals.count > before { cont.resume() } else { waiters.append(cont) }
+        }
+      }
+      let timeoutTask = Task { @MainActor in
+        try? await Task.sleep(for: timeout)
+        waitTask.cancel()
+      }
+      await waitTask.value
+      timeoutTask.cancel()
+      return signals.count > before
+    }
+  }
+
+  @Test("capturing line death fires the full teardown signal set in order")
+  func capturingDeathCharacterization() {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    let gen = proxy.acquireConnection()
+    // Synchronous act + assert — no suspension, so no environment-driven
+    // handler hop can interleave.
+    proxy.reportLineDeath(generation: gen, cause: .invalidated, wasCapturing: true)
+
+    #expect(
+      recorder.signals == [
+        .engineInterrupted(.xpcConnectionLost),
+        .xpcServiceError(.invalidateCapturing, sessionID: 0),
+      ])
+    // Slot was retired: the next acquisition mints a NEW generation.
+    #expect(proxy.acquireConnection() == gen + 1)
+  }
+
+  @Test("idle invalidation fires invalidateIdle with no session")
+  func idleInvalidationCharacterization() {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    let gen = proxy.acquireConnection()
+    proxy.reportLineDeath(generation: gen, cause: .invalidated, wasCapturing: false)
+
+    #expect(recorder.signals == [.xpcServiceError(.invalidateIdle, sessionID: nil)])
+  }
+
+  @Test("idle interruption is silent end-to-end (today's contract)")
+  func idleInterruptionIsSilent() {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    let gen = proxy.acquireConnection()
+    proxy.reportLineDeath(generation: gen, cause: .interrupted, wasCapturing: false)
+
+    #expect(recorder.signals.isEmpty)
+    // But the line WAS retired — next acquisition is a new generation.
+    #expect(proxy.acquireConnection() == gen + 1)
+  }
+
+  @Test("idle wedge and per-call error deaths are retire-only (no lifecycle callbacks)")
+  func wedgeAndCallErrorAreRetireOnly() {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    let gen1 = proxy.acquireConnection()
+    proxy.reportLineDeath(generation: gen1, cause: .wedged, wasCapturing: false)
+    #expect(recorder.signals.isEmpty)
+    let gen2 = proxy.acquireConnection()
+    #expect(gen2 == gen1 + 1)
+
+    proxy.reportLineDeath(generation: gen2, cause: .callError, wasCapturing: false)
+    #expect(recorder.signals.isEmpty)
+    #expect(proxy.acquireConnection() == gen2 + 1)
+  }
+
+  @Test("CAPTURING per-call error runs the full teardown under interruptCapturing (Codex r1 P2)")
+  func capturingCallErrorRunsTeardown() {
+    // Mid-capture service death is often observed FIRST by a per-call error
+    // (streaming getter / live config send in flight); once that retires the
+    // generation, the connection-level handlers are stale-guarded — so this
+    // path must own the capturing teardown or the recording wedges forever.
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    let gen = proxy.acquireConnection()
+    proxy.reportLineDeath(generation: gen, cause: .callError, wasCapturing: true)
+
+    #expect(
+      recorder.signals == [
+        .engineInterrupted(.xpcConnectionLost),
+        .xpcServiceError(.interruptCapturing, sessionID: 0),
+      ])
+    #expect(proxy.acquireConnection() == gen + 1)
+  }
+
+  @Test("stale death report about a retired generation is provably inert")
+  func staleDeathReportIsInert() {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    let gen1 = proxy.acquireConnection()
+    proxy.reportLineDeath(generation: gen1, cause: .interrupted, wasCapturing: false)
+    let gen2 = proxy.acquireConnection()
+
+    // A late event about the dead predecessor — the v1 r7/r8 race shape.
+    proxy.reportLineDeath(generation: gen1, cause: .invalidated, wasCapturing: true)
+
+    #expect(recorder.signals.isEmpty)
+    // The fresh line survives: acquiring again reuses gen2.
+    #expect(proxy.acquireConnection() == gen2)
+  }
+
+  @Test("post-interruption acquisition yields a fresh generation (contract-change lock)")
+  func postInterruptionAcquiresFresh() {
+    let proxy = AudioCaptureProxy()
+    let gen1 = proxy.acquireConnection()
+    // Old contract kept the connection on interruption; #1194 retires it.
+    proxy.reportLineDeath(generation: gen1, cause: .interrupted, wasCapturing: false)
+    let gen2 = proxy.acquireConnection()
+    #expect(gen2 == gen1 + 1)
+    // Reuse-if-live: acquiring again does NOT mint another generation.
+    #expect(proxy.acquireConnection() == gen2)
+  }
+
+  // MARK: - Generation-stamped handlers
+
+  @Test("a handler stamped with the current generation retires it after the hop")
+  func currentGenerationHandlerRetires() async {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    let gen = proxy.acquireConnection()
+    let handler = AudioCaptureProxy.makeInvalidationHandler(proxy: proxy, generation: gen)
+    handler()  // XPC would call this on its own queue; the hop lands on MainActor.
+
+    let signaled = await recorder.waitForNextSignal()
+    #expect(signaled, "handler hop never reported line death")
+    #expect(recorder.signals == [.xpcServiceError(.invalidateIdle, sessionID: nil)])
+    #expect(proxy.acquireConnection() == gen + 1)
+  }
+
+  @Test("a stale handler hop cannot clobber a fresh replacement line")
+  func staleHandlerHopIsInert() async {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    let gen1 = proxy.acquireConnection()
+    // Build the handler for gen1, then move the slot on (retire + reacquire)
+    // BEFORE invoking it — the already-queued-hop shape of the v1 r8 hole.
+    let staleHandler = AudioCaptureProxy.makeInvalidationHandler(proxy: proxy, generation: gen1)
+    proxy.reportLineDeath(generation: gen1, cause: .interrupted, wasCapturing: false)
+    let gen2 = proxy.acquireConnection()
+
+    staleHandler()
+    // Positive signal to bound the wait: fire a CURRENT-generation handler
+    // after the stale one. NSXPC delivers our Task hops in submission order
+    // on the MainActor, so when the current handler's signal arrives, the
+    // stale hop has already run (and must have been discarded).
+    let currentHandler = AudioCaptureProxy.makeInvalidationHandler(proxy: proxy, generation: gen2)
+    currentHandler()
+
+    let signaled = await recorder.waitForNextSignal()
+    #expect(signaled, "current-generation handler never reported")
+    // Exactly ONE signal: the current handler's. The stale hop was inert.
+    #expect(recorder.signals == [.xpcServiceError(.invalidateIdle, sessionID: nil)])
+    #expect(proxy.acquireConnection() == gen2 + 1)
+  }
+
+  // MARK: - withStartRetry
+
+  @Test("first-try success: no retry, no telemetry event")
+  func startRetrySuccessFirstTry() async throws {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    var opCount = 0
+    let value = try await proxy.withStartRetry(stage: "start_engine") { _ in
+      opCount += 1
+      return 42
+    }
+
+    #expect(value == 42)
+    #expect(opCount == 1)
+    #expect(recorder.signalsExceptIdleInvalidation.isEmpty)
+  }
+
+  @Test("forced wedge then clean retry: recovered, exactly one resend, prefix ran")
+  func forcedWedgeRecovers() async throws {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+    proxy.forceWedgeNextStartOps = 1
+
+    var opCount = 0
+    var prefixCount = 0
+    let value = try await proxy.withStartRetry(
+      stage: "begin_capture",
+      prefix: { prefixCount += 1 }
+    ) { _ in
+      opCount += 1
+      return "ok"
+    }
+
+    #expect(value == "ok")
+    // The forced wedge throws BEFORE dispatch, so the operation ran only on
+    // the retry — after the prefix.
+    #expect(opCount == 1)
+    #expect(prefixCount == 1)
+    #expect(
+      recorder.signalsExceptIdleInvalidation == [
+        .retryResolved(stage: "begin_capture", trigger: "wedged", outcome: "recovered")
+      ])
+  }
+
+  @Test("wedge on both attempts: exhausted, same error type, budget not doubled")
+  func doubleWedgeExhausts() async {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+    proxy.forceWedgeNextStartOps = 2
+
+    var opCount = 0
+    do {
+      _ = try await proxy.withStartRetry(stage: "start_engine") { _ -> Int in
+        opCount += 1
+        return 0
+      }
+      Issue.record("expected exhaustion to throw")
+    } catch {
+      #expect(error is XPCOperationSignalWedgeError)
+    }
+
+    #expect(opCount == 0, "both attempts wedged before dispatch")
+    #expect(
+      proxy.forceWedgeNextStartOps == 0, "exactly two forced wedges consumed — one retry, not more")
+    #expect(
+      recorder.signalsExceptIdleInvalidation == [
+        .retryResolved(stage: "start_engine", trigger: "wedged", outcome: "exhausted")
+      ])
+  }
+
+  @Test("unreachable first, clean retry: recovered with service_unreachable trigger")
+  func unreachableThenRecovers() async throws {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    var opCount = 0
+    let value = try await proxy.withStartRetry(stage: "start_engine") { _ -> Int in
+      opCount += 1
+      if opCount == 1 { throw XPCTransportError.serviceUnreachable }
+      return 7
+    }
+
+    #expect(value == 7)
+    #expect(opCount == 2)
+    #expect(
+      recorder.signalsExceptIdleInvalidation == [
+        .retryResolved(stage: "start_engine", trigger: "service_unreachable", outcome: "recovered")
+      ])
+  }
+
+  @Test("wedge then unreachable: single shared budget, retry's error propagates")
+  func wedgeThenUnreachableExhausts() async {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+    proxy.forceWedgeNextStartOps = 1
+
+    var opCount = 0
+    do {
+      _ = try await proxy.withStartRetry(stage: "start_engine") { _ -> Int in
+        opCount += 1
+        throw XPCTransportError.serviceUnreachable
+      }
+      Issue.record("expected exhaustion to throw")
+    } catch {
+      // The RETRY's error propagates — one of today's two exact types.
+      guard case XPCTransportError.serviceUnreachable = error else {
+        Issue.record("unexpected error type: \(error)")
+        return
+      }
+    }
+
+    #expect(opCount == 1, "retry ran once; the wedge-then-error shape must not double the budget")
+    #expect(
+      recorder.signalsExceptIdleInvalidation == [
+        .retryResolved(stage: "start_engine", trigger: "wedged", outcome: "exhausted")
+      ])
+  }
+
+  @Test("prefix failure counts as exhaustion — no nested retry")
+  func prefixFailureExhausts() async {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+    proxy.forceWedgeNextStartOps = 1
+
+    var opCount = 0
+    var prefixCount = 0
+    do {
+      _ = try await proxy.withStartRetry(
+        stage: "begin_capture",
+        prefix: {
+          prefixCount += 1
+          throw XPCTransportError.serviceUnreachable
+        }
+      ) { _ -> Int in
+        opCount += 1
+        return 0
+      }
+      Issue.record("expected exhaustion to throw")
+    } catch {
+      guard case XPCTransportError.serviceUnreachable = error else {
+        Issue.record("unexpected error type: \(error)")
+        return
+      }
+    }
+
+    #expect(prefixCount == 1)
+    #expect(opCount == 0, "operation never dispatched after the prefix failed")
+    #expect(
+      recorder.signalsExceptIdleInvalidation == [
+        .retryResolved(stage: "begin_capture", trigger: "wedged", outcome: "exhausted")
+      ])
+  }
+
+  @Test("device-shaped errors propagate unretried")
+  func deviceErrorsDoNotRetry() async {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    struct DeviceError: Error {}
+    var opCount = 0
+    do {
+      _ = try await proxy.withStartRetry(stage: "start_engine") { _ -> Int in
+        opCount += 1
+        throw DeviceError()
+      }
+      Issue.record("expected the device error to throw")
+    } catch {
+      #expect(error is DeviceError)
+    }
+
+    #expect(opCount == 1, "no retry for non-line-death signatures")
+    #expect(recorder.signalsExceptIdleInvalidation.isEmpty)
+  }
+
+  // MARK: - stopCapture retire-only contract
+
+  @Test("stopCapture with no line: empty result, onXPCReplyFailed once, no lifecycle callbacks")
+  func stopCaptureNoLineRetireOnly() async {
+    let proxy = AudioCaptureProxy()
+    let recorder = SignalRecorder()
+    recorder.install(on: proxy)
+
+    let result = await proxy.stopCapture()
+
+    #expect(result.samples.isEmpty)
+    #expect(recorder.signals == [.xpcReplyFailed(stage: "stop_capture")])
+    #expect(proxy.isCapturing == false)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -68,6 +68,7 @@ private final class ExtrasAudioCapture: AudioCaptureInterface {
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?
   var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
   var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool = false

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -448,6 +448,7 @@ internal final class FixtureAudioCapture: AudioCaptureInterface {
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?
   var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
   var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool = false

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -310,6 +310,7 @@ private final class NoOpAudioCapture: AudioCaptureInterface {
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?
   var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
   var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool = false

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -79,6 +79,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?
   var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
 
   // MARK: AudioCaptureInterface — configuration (inert storage)

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -143,6 +143,7 @@ private final class NeverFinishingAudioCapture: AudioCaptureInterface {
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?
   var onXPCReplyFailed: ((XPCReplyFailureContext) -> Void)?
+  var onAudioStartRetryResolved: ((AudioStartRetryContext) -> Void)?
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
   var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool = false

--- a/Tests/RuntimeUAT/SCENARIOS.md
+++ b/Tests/RuntimeUAT/SCENARIOS.md
@@ -33,6 +33,7 @@ run_scenario("A5_proxy_buffer_drop_watchdog")
 | Real OS-level audio interruption (BT codec switch, Zoom mic-grab, AVAudioEngineConfigurationChange) | See `docs/LANE_B_AUDIO_TESTS.md` (HITL only — not synthetic-viable, see `docs/audits/2026-05-02-v2-synthetic-viability-codex.txt`) | hardware/HITL |
 | Pipeline stuck after ASR service crash | A3_asr_xpc_kill | xpc |
 | Pipeline stuck after audio service crash | A4_audio_xpc_kill | xpc |
+| Record press silently fails on a dead/reaped audio line (first-press cold-start race, #1194) | A10_audio_start_wedge_retry | xpc |
 | Cancel mid-record leaks task / state | A2_force_cancel | timing |
 | Rapid stop/start corrupts state | A1_rapid_stop_start | timing |
 | Live setting toggle doesn't apply mid-record | A6_settings_storm | settings |
@@ -122,6 +123,13 @@ During an active recording, attempt to flip `selectedBackend` via the Speech Eng
 
 **Negative control:** remove `if parakeetActive || whisperKitActive { break }` in `PipelineSettingsSync.handleSettingChanged(.selectedBackend, …)`. Active recording aborts on backend toggle.
 
+### A10_audio_start_wedge_retry (Lane A — xpc, #1194)
+Backends: both. Budget: 20s. Mechanism: xpc.
+
+Arm `force_audio_wedge_start(1)` while idle, then press record. The next START operation (`start_engine` / `begin_capture` / `start_engine_prewarm`) throws the watchdog wedge error before dispatch — no transport error, no invalidation: the one dead-line shape where ONLY the operation watchdog notices. The #1194 bounded retry must retire the wedged line, reacquire a fresh connection (with config replay + prefix), and resend once — the press succeeds silently. Verdict from app.log: `forced wedge (DEBUG)`, `line death ... cause=wedged`, `start retry resolved ... outcome=recovered`.
+
+**Negative control:** arm `force_audio_wedge_start(2)` — the retry wedges too, exhausting the single-retry budget; the press fails with today's error UX and app.log shows `outcome=exhausted`. (Equivalently: remove the `withStartRetry` catch in `AudioCaptureProxy`.)
+
 ### B1_bluetooth_route_flip (Lane B — bt-route, founder-required)
 Backends: both. Budget: 15s. Mechanism: bt-route.
 
@@ -151,6 +159,7 @@ Fixed command set (no arbitrary RPC):
 | Command | Effect |
 |---|---|
 | `force_proxy_buffer_drop(N)` | Drop next N buffers inside `AudioCaptureProxy.audioBufferCaptured` (host-side proxy queue). Tests proxy watchdog only — does NOT exercise real audio-stack interruption recovery. |
+| `force_audio_wedge_start(N)` | Treat the next N audio START operations as wedged inside `AudioCaptureProxy.withAudioXPCOperationSignal` (#1194) — no transport error, no invalidation. Never affects `stop_capture`. |
 | `force_cancel` | Invoke `forceCancelNow()` on the active backend's pipeline |
 | `force_xpc_kill` | Invalidate `ASRManagerProxy` connection mid-stream |
 | `force_audio_xpc_kill` | Invalidate `AudioCaptureProxy` connection mid-stream |

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -191,6 +191,24 @@ def force_proxy_buffer_drop(n: int) -> str:
     return send(f"force_proxy_buffer_drop({n})")
 
 
+def force_audio_wedge_start(n: int) -> str:
+    """Treat the next N audio START operations as wedged (#1194).
+
+    Sets AudioCaptureProxy.forceWedgeNextStartOps via the DEBUG endpoint: the
+    next N start ops (start_engine / begin_capture / start_engine_prewarm,
+    including retry stages) throw the watchdog wedge error BEFORE dispatch —
+    no transport error, no invalidation. This is the watchdog-only wedge
+    shape: with n=1 the press's first attempt wedges and the bounded retry
+    recovers on a fresh connection; with n=2 the retry wedges too and the
+    press fails with outcome=exhausted. Never affects stop_capture.
+
+    Verdicts come from app.log ("forced wedge (DEBUG)", "line death",
+    "start retry resolved ... outcome=recovered|exhausted"), per
+    uat-verdicts-from-app-log.
+    """
+    return send(f"force_audio_wedge_start({n})")
+
+
 # ──────────────────────────── helpers ────────────────────────────
 
 
@@ -1118,6 +1136,63 @@ def A9_backend_switch_mid_record(**_) -> dict:
         "pipeline_state_after_settle": pipeline_state_after_settle,
         "switch_was_blocked": switch_was_blocked,
         "post_backend_userdefaults": _read_setting("selectedBackend"),
+    }
+
+
+
+APP_LOG_PATH = Path("~/Library/Logs/EnviousWispr/app.log").expanduser()
+
+
+@scenario(
+    ScenarioMeta(
+        name="A10_audio_start_wedge_retry",
+        lane="A",
+        family="xpc",
+        backends=["both"],
+        runtime_budget_seconds=20.0,
+        founder_required=False,
+        negative_control="Arm force_audio_wedge_start(2) instead of 1 (exhausts the single retry) — the press fails with outcome=exhausted instead of recovering",
+        description="Arm force_audio_wedge_start(1) while idle, then press record: the first start op wedges (watchdog-only shape — no transport error, no invalidation) and the bounded #1194 retry recovers on a fresh connection within the same press",
+    )
+)
+def A10_audio_start_wedge_retry(**_) -> dict:
+    """User behavior: the user presses record at the exact moment the audio
+    XPC line has silently died (idle-reap race, #1194) in the one shape that
+    produces NO error callback and NO invalidation — only the operation
+    watchdog notices. The press must still succeed: the proxy retires the
+    wedged line, reacquires, replays the prefix, and resends once.
+
+    Verdict source is app.log (`uat-verdicts-from-app-log`): the scenario
+    asserts the forced-wedge marker, the line-death transition, and
+    `start retry resolved ... outcome=recovered` all appeared during the
+    press, alongside the pipeline reaching a terminal state.
+    """
+    log_offset = APP_LOG_PATH.stat().st_size if APP_LOG_PATH.exists() else 0
+    reply = force_audio_wedge_start(1)
+    if not _start_recording_locked():
+        return {
+            "terminal": False,
+            "reason": "could not enter recording (retry did not save the press?)",
+            "state": query_state(),
+            "reply": reply,
+        }
+    with _TTSAudio():
+        time.sleep(1.5)
+    stopped = _stop_recording_locked()
+    terminated = assert_terminated(timeout_s=8.0)
+
+    tail = ""
+    if APP_LOG_PATH.exists():
+        with open(APP_LOG_PATH, "r", errors="replace") as f:
+            f.seek(log_offset)
+            tail = f.read()
+    return {
+        "reply": reply,
+        "stopped": stopped,
+        **terminated,
+        "forced_wedge_logged": "forced wedge (DEBUG)" in tail,
+        "line_death_logged": "line death" in tail and "cause=wedged" in tail,
+        "retry_recovered": "start retry resolved" in tail and "outcome=recovered" in tail,
     }
 
 


### PR DESCRIPTION
Closes #1194

## What

Structural rebuild of the audio XPC connection lifecycle. Four confirmed incidents (2 production, 2 dev, releases 2.1.0–2.2.1 — most recently a brand-new user's first-ever dictation) shared one root cause: `AudioCaptureProxy` held ONE long-lived `NSXPCConnection` mutated by four uncoordinated async paths, so a record press racing the idle-reap teardown silently failed. A v1 one-shot-retry patch burned 8 grounded-review rounds, each finding a new race in the same root; the founder directed a lifecycle fix instead (2026-07-02).

Approved plan: `docs/feature-requests/issue-1194-2026-07-02-audio-xpc-coldstart-retry.md` (local lane; council coverage review + 4 grounded-review rounds to PROCEED-AS-PLANNED).

## Design

- **`ConnectionSlot`** — connection + monotonically increasing generation live in a `let`-bound nested reference type whose private members make `install`/`retire` the only mutation paths (compiler-enforced funnel).
- **`reportLineDeath(generation:cause:wasCapturing:)`** — the single generation-guarded consumer for every death signal (invalidation, interruption, watchdog wedge, per-call transport error). Stale events about retired generations are provably inert, including handler Tasks already queued when the slot moved on.
- **`needsReinit` deleted** — every fresh connection unconditionally replays config during synchronous (MainActor-atomic) acquisition. Per-item replay-ordering proof in the plan §3.2.
- **`withStartRetry`** — the three idempotent pre-capture start ops retry exactly once on a fresh connection, replaying the failed stage's service-side prefix (`begin_capture` re-runs `start_engine`; a fresh connection reaches a brand-new service world). `stopCapture` never retries; its call-errors are retire-only (`onXPCReplyFailed` stays the sole stop signal — unit-locked).
- **Per-call error teardown policy (Codex code-diff r1 [P2])** — non-stop per-call errors pass live `isCapturing`, so a mid-capture death observed first by an in-flight call runs the capturing teardown exactly once (re-homed under `interruptCapturing`).
- **`engineInterrupted(cause:)` relay stays outside the funnel** — engine event, no connection identity on the wire; its dead `needsReinit` write deleted.
- **Telemetry** — `onAudioStartRetryResolved` → `AudioEventRouter` → PostHog `coldstart.audio_line_retry` (stage / trigger / outcome / recovery_ms).
- **UAT plumbing** — `forceWedgeNextStartOps` DEBUG seam + `force_audio_wedge_start(N)` endpoint command + `faultInjection.py` helper + registered scenario `A10_audio_start_wedge_retry` (SCENARIOS.md rows added).

Behavior notes: acquisition ping dropped (replay sends are the launchd spawn trigger; `ping` stays on the wire protocol — service side untouched); a wedge no longer echoes a spurious `invalidateIdle` Sentry event through the invalidation handler (retire neutralizes handlers; the retry telemetry event is the new signal). `AudioEventRouter` line ceiling 125 → 137 (Bible §30 entry in its ceilings test: one wiring block, no new collaborator/closure/import). ASR-line twin tracked as #1273, sequenced after this ships.

## Validation

Run dir: `.validation/runs/2026-07-02T17-35-01Z-04e6d36` — `check-validation.sh --strict` PASS (Code lane).

- **Logic tests:** full suite green via `scripts/xcode-test.sh` (2,191 tests), incl. a new 22-test lifecycle suite (slot semantics, stale-event inertness, capturing-teardown characterization incl. the r1 P2 lock, retry budget across both error shapes, prefix replay, stop-failure retire-only lock, device errors unretried) + ceilings/surface/freeze sweep green.
- **Codex code-diff:** r1 → one P2 (confirmed real, fixed + unit-locked + plan revised); r2 → clean ("no actionable correctness issues").
- **Live UAT (scenarios per plan §11.1, verdicts from app.log):**
  1. Real helper `kill -9` + immediate press → line retired via funnel, fresh acquire, transcript landed. PASS
  2. Forced invalidation racing the start window (6 attempts) → all presses succeeded; 2 hit the true mid-start race and recovered via the bounded retry (81ms / 123ms); late in-flight errors discarded as stale every time (the v1 race, provably inert). PASS
  3. Fault-free regression → zero retry/wedge/death events. PASS
  4. Mid-capture kill → prompt capturing teardown + kernel terminal `audioInterrupted` in ~1s, next press clean. PASS
  5. Watchdog-only wedge (deterministic seam, n=1) → `outcome=recovered` in 86ms, press silently saved. PASS
  6. Exhaustion (n=2) → both attempts wedged, `outcome=exhausted` after exactly one retry, today's exact error type propagated, next press clean. Real-SIGSTOP variant documented: suspended helper never emits a first progress signal (pre-first-signal watchdog non-goal, pre-existing); press exits promptly via PTT-release cancellation (correctly not retried); no stuck state. PASS
  7. Double-tap around a dead line → generation arithmetic proves exactly ONE line minted (gen 13 death → one session → gen 14 death); no connection stacking. PASS
  8. Latency A/B, N=10 PTT medians (main → branch): press-to-recording 35 → 32.5ms; ASR 85 → 80ms; paste 89 → 85ms; polish 507 → 553ms (cloud LLM variance; untouched path — baseline arm's own polish spread was 369–1177ms). No healthy-path regression. PASS
  9. Bluetooth route: SKIPPED with structural rationale (no BT device connected; all BT hardening service-side and untouched; retry gated to the two dead-line signatures, never device errors) — `skip-note.txt` in run dir.