### PR TITLE
feat(llm): EG-1 native polish provider, end to end (#1271 Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ routine-session-logs-*/
 
 # Swift/clang module cache created by CLI builds in the worktree
 .cache/
+.derivedData-review/
+.build-review/

--- a/Project.swift
+++ b/Project.swift
@@ -368,6 +368,13 @@ let project = Project(
         "Sources/EnviousWispr/Resources/AppIcon.icns",
         .folderReference(path: "Sources/EnviousWisprLLM/Resources/OutputClassifier.mlpackage"),
         .folderReference(path: "Sources/EnviousWisprLLM/Resources/OutputClassifierTokenizer"),
+        // #1271: EG-1 native polish — the model manifest and the bundled
+        // llama-server inference binary ride the APP target (Bundle.main,
+        // Contents/Resources), same route as the classifier above. The
+        // binary is a nested Mach-O: build-dev-app.sh and
+        // build-release-dmg.sh sign it in the inside-out order.
+        "Sources/EnviousWispr/Resources/eg1-manifest.json",
+        "Sources/EnviousWispr/Resources/llama-server",
       ],
       entitlements: .file(path: "Sources/EnviousWispr/Resources/EnviousWispr.entitlements"),
       // #919: the thin shell links ONLY the kit (the kit static-links the

--- a/Sources/EnviousWispr/Resources/eg1-manifest.json
+++ b/Sources/EnviousWispr/Resources/eg1-manifest.json
@@ -1,0 +1,11 @@
+{
+  "modelName": "eg-1",
+  "version": "v1",
+  "sha256": "3343fc1a30a3e82df7499a4775ef73dd6e28dea1cc39bb58197ec0b66ec874f6",
+  "sizeBytes": 2889511680,
+  "contextTokens": 16384,
+  "promptTemplateID": "eg1-v1",
+  "minAppVersion": "2.3.0",
+  "downloadURL": "https://models.enviouslabs.co/eg1/eg-1-v1-q5km.gguf",
+  "licenseURL": "https://models.enviouslabs.co/eg1/EG-1-MODEL-LICENSE.txt"
+}

--- a/Sources/EnviousWispr/Resources/llama-server-LICENSE.txt
+++ b/Sources/EnviousWispr/Resources/llama-server-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 The ggml authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Sources/EnviousWispr/Resources/llama-server-PROVENANCE.md
+++ b/Sources/EnviousWispr/Resources/llama-server-PROVENANCE.md
@@ -1,0 +1,31 @@
+# llama-server binary provenance (#1271)
+
+The committed `llama-server` is the EG-1 native inference engine, built
+from source (founder-approved 2026-07-02) rather than a downloaded
+release binary, for full control over flags and supply chain.
+
+| Field | Value |
+|---|---|
+| Source | https://github.com/ggml-org/llama.cpp (MIT) |
+| Commit | `fdb1db877c526ec90f668eca1b858da5dba85560` (2026-07-02) |
+| Toolchain | Apple clang (`/usr/bin/clang`), macOS 26 SDK, arm64 only |
+| Configure | `cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 -DBUILD_SHARED_LIBS=OFF -DGGML_METAL=ON -DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_OPENSSL=OFF -DLLAMA_CURL=OFF -DLLAMA_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release` (deployment target 14.0 REQUIRED — Codex r1 P1: the default builds `minos 26.0`, which cannot launch on the macOS 14/15 half of our supported range; verify `otool -l` shows `minos 14.0` after any rebuild) |
+| Target | `llama-server` |
+| Size | ~15 MB, single static binary |
+| Dynamic deps | macOS system frameworks ONLY (verified `otool -L`: no Homebrew/OpenSSL — `LLAMA_OPENSSL=OFF` exists precisely because the first build linked `/opt/homebrew` dylibs that do not exist on user Macs) |
+
+Runtime flags are owned by `EGOneRuntime` (LLM module), NOT baked in:
+`-fa on --cache-type-k q8_0 --cache-type-v q8_0` + `-c` from the manifest.
+Measured 2026-07-02 on the real EG-1 v1 GGUF (M4 Pro): 4.1 GB RSS at
+16384 context (vs 7.4 GB naive 32768/fp16), ~9 s cold start, ~0.2 s warm
+inference on the probe sentence, correct probe transformation.
+
+To rebuild: clone the pinned commit, run the configure line above with
+`-DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++`
+(a stray `~/.local/bin/cc` shim breaks compiler detection otherwise),
+then `cmake --build build --target llama-server`.
+
+Upgrading the engine = rebuild from a newer pinned commit, update this
+file, re-run the real-binary integration probe + the polish behavior
+benchmark against the shipped config (the artifact + engine + flags
+combination is the unit of QA).

--- a/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
+++ b/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
@@ -38,6 +38,7 @@ final class BackendMetadata {
     switch settings.llmProvider {
     case .none: "Off"
     case .appleIntelligence: "Apple Intelligence"
+    case .egOne: "EG-1"  // #1271: fixed name, like Apple Intelligence above
     default: llmLabel
     }
   }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -236,6 +236,7 @@ final class DictationLifecycleCoordinator {
       // Session ended — retry any Ollama eviction deferred because the
       // frozen session pinned the old model.
       settingsSync.retryDeferredOllamaEviction(settings: settings)
+      settingsSync.retryDeferredEGOneDeactivation(settings: settings)
     // #1171 — a switch deferred while this recording was active is applied by
     // the EngineCoordinator via `onEngineRelevantStateChange()` (fired above).
     // #1063 PR2: the recovery-spool cleanup is NO LONGER keyed off this
@@ -288,6 +289,7 @@ final class DictationLifecycleCoordinator {
       recordingLockedAccess.set(false)
       hotkeyService.unregisterCancelHotkey()
       settingsSync.retryDeferredOllamaEviction(settings: settings)
+      settingsSync.retryDeferredEGOneDeactivation(settings: settings)
     // #1171 — a deferred switch is applied by the EngineCoordinator via
     // `onEngineRelevantStateChange()` (fired above).
     // #1063 PR2: recovery-spool cleanup is driven by the kernel terminal signal

--- a/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
@@ -1,0 +1,33 @@
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+
+/// Maps EG-1 runtime lifecycle events onto `TelemetryService` (#1271).
+///
+/// Lives here (AppKit) because the LLM module cannot import Services; the
+/// composition root installs `handler` as `EGOneRuntime.onEvent`. Content-
+/// free by construction: reasons are a closed string set, identity is our
+/// manifest's, and no transcript/prompt content exists on this path.
+enum EGOneTelemetryBridge {
+  static var handler: @Sendable (EGOneRuntimeEvent) -> Void {
+    { event in
+      Task { @MainActor in
+        switch event {
+        case .downloadStarted(let resumed):
+          TelemetryService.shared.egOneDownloadEvent(
+            name: "download_started", properties: ["resumed": resumed ? "true" : "false"])
+        case .downloadCompleted(let durationBucket):
+          TelemetryService.shared.egOneDownloadEvent(
+            name: "download_completed", properties: ["duration_bucket": durationBucket])
+        case .downloadFailed(let reason):
+          TelemetryService.shared.egOneDownloadEvent(
+            name: "download_failed", properties: ["reason": reason])
+        case .healthChanged(let from, let to, let reason):
+          TelemetryService.shared.egOneDownloadEvent(
+            name: "health_changed",
+            properties: ["from": from, "to": to, "reason": reason ?? "none"])
+        }
+      }
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -35,14 +35,29 @@ final class PipelineSettingsSync {
     whisperKitKernelDriver: KernelDictationDriver,
     audioCapture: any AudioCaptureInterface,
     asrManager: any ASRManagerInterface,
-    hotkeyService: HotkeyService
+    hotkeyService: HotkeyService,
+    egOneRuntime: EGOneRuntime? = nil
   ) {
     self.kernelDriver = kernelDriver
     self.whisperKitKernelDriver = whisperKitKernelDriver
     self.audioCapture = audioCapture
     self.asrManager = asrManager
     self.hotkeyService = hotkeyService
+    self.egOneRuntime = egOneRuntime
+    // #1271 matrix gap 3: Remove Model defers while a recording froze
+    // `.egOne`. The pinned-session authority is THIS class (it owns both
+    // drivers), so it wires the runtime's read itself.
+    egOneRuntime?.isPinnedInFlight = { [weak self] in
+      self?.isEGOnePinnedInFlight() ?? false
+    }
   }
+
+  /// #1271 (Codex r2): EG-1 server lifecycle follows the PROVIDER SETTING,
+  /// and this class is the canonical settings→pipeline side-effect route
+  /// (same home as the Ollama eviction below). Switch to EG-1 → server up +
+  /// probe; switch away → server down (a multi-GB child never lingers past
+  /// its selection, the #295 RAM lesson).
+  private let egOneRuntime: EGOneRuntime?
 
   /// Seed live-mutable subsystems. Per-recording values are captured fresh
   /// at each `startRecording` and are not seeded here.
@@ -107,6 +122,8 @@ final class PipelineSettingsSync {
       // frozen value from `DictationSessionConfig`; live steps are seeded per
       // recording, so nothing to mirror here since #1106 removed re-polish.
       reconcileOllamaEviction(settings: settings)
+      // #1271: EG-1 server follows the provider selection live.
+      reconcileEGOneActivation(settings: settings)
     case .llmModel:
       if settings.llmProvider == .ollama {
         settings.ollamaModel = settings.llmModel
@@ -188,6 +205,50 @@ final class PipelineSettingsSync {
 
   /// Fires best-effort unload when the tracked previous Ollama model differs
   /// from the new one. Also coalesces cascading .llmModel → .ollamaModel fires.
+  /// Set when a switch away from EG-1 arrived while a recording had `.egOne`
+  /// frozen in its session config — stopping the server then would silently
+  /// degrade that recording's polish to raw (#1271 Codex r7). The terminal
+  /// pipeline transition retries (same shape as the Ollama eviction defer).
+  private var egOneDeactivationPending = false
+
+  /// EG-1 server follows the provider selection live: activate on switch-to,
+  /// stop on switch-away — but never underneath an in-flight session that
+  /// froze `.egOne` at recording start.
+  private func reconcileEGOneActivation(settings: SettingsManager) {
+    guard let egOneRuntime else { return }
+    if settings.llmProvider == .egOne {
+      egOneDeactivationPending = false
+      egOneRuntime.activateAndProbe()
+      return
+    }
+    if isEGOnePinnedInFlight() {
+      egOneDeactivationPending = true
+      return
+    }
+    egOneDeactivationPending = false
+    egOneRuntime.deactivate()
+  }
+
+  /// Retry a deferred EG-1 shutdown AND a deferred model removal after an
+  /// in-flight session ends. Called alongside `retryDeferredOllamaEviction`
+  /// on terminal pipeline states. Idempotent: each retry no-ops unless
+  /// actually pending.
+  func retryDeferredEGOneDeactivation(settings: SettingsManager) {
+    egOneRuntime?.retryPendingRemoval()
+    guard egOneDeactivationPending else { return }
+    reconcileEGOneActivation(settings: settings)
+  }
+
+  /// True if either pipeline's frozen `DictationSessionConfig` targets EG-1.
+  /// Single authority (#1271 matrix gap 3) — the runtime's Remove Model
+  /// defer reads it through the closure the bootstrapper wires.
+  func isEGOnePinnedInFlight() -> Bool {
+    for cfg in [kernelDriver.currentSessionConfig, whisperKitKernelDriver.currentSessionConfig] {
+      if cfg?.llmProvider == .egOne { return true }
+    }
+    return false
+  }
+
   private func reconcileOllamaEviction(settings: SettingsManager) {
     let new = OllamaConnector.effectiveOllamaModel(
       provider: settings.llmProvider, model: settings.effectiveLLMModel

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -51,6 +51,9 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   private let transcriptCoordinator: TranscriptCoordinator
   private let keychainManager: KeychainManager
   private let outputClassifierHolder: OutputClassifierHolder
+  /// #1271: EG-1 runtime handle — recovery polishes through the same server
+  /// as live dictation (or silently skips when it is not ready).
+  private let egOneRuntime: (any EGOneEndpointProviding)?
   /// Current custom-words vocabulary, best-effort (the snapshot carries only the
   /// version, not the terms — recovery promises normal-quality, not byte-exact).
   private let currentVocabulary:
@@ -64,6 +67,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     transcriptCoordinator: TranscriptCoordinator,
     keychainManager: KeychainManager,
     outputClassifierHolder: OutputClassifierHolder,
+    egOneRuntime: (any EGOneEndpointProviding)? = nil,
     currentVocabulary: @escaping @MainActor () -> (
       corrector: CorrectorVocabulary, polish: PolishVocabulary
     )
@@ -75,6 +79,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     self.transcriptCoordinator = transcriptCoordinator
     self.keychainManager = keychainManager
     self.outputClassifierHolder = outputClassifierHolder
+    self.egOneRuntime = egOneRuntime
     self.currentVocabulary = currentVocabulary
   }
 
@@ -177,7 +182,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // Polish under the recording's record-time settings (raw-fallback floor
     // guaranteed: a failed/skipped polish lands raw text, still saved + labeled).
     let processor = RecoveryTextProcessor(
-      keychainManager: keychainManager, outputClassifierHolder: outputClassifierHolder)
+      keychainManager: keychainManager, outputClassifierHolder: outputClassifierHolder,
+      egOneRuntime: egOneRuntime)
     if let settings = recovered.settings { processor.applySettings(settings) }
     let vocab = currentVocabulary()
     processor.applyCustomWordsVocabulary(corrector: vocab.corrector, polish: vocab.polish)

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -157,6 +157,10 @@ enum SettingsProjection {
     let id = settings.effectiveLLMModel
     switch settings.llmProvider {
     case .appleIntelligence: return "apple-intelligence"
+    // #1271: native EG-1 — the model id is OUR fixed literal from the
+    // manifest contract (`effectiveLLMModel` returns `eg-1`), never user
+    // input, so verbatim is safe by construction.
+    case .egOne: return LLMProvider.egOneModelName
     case .none: return "none"
     case .ollama:
       let canonical = OllamaSetupService.canonicalModelName(id)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -52,6 +52,8 @@ public final class WisprBootstrapper {
   let customWordsCoordinator: CustomWordsCoordinator
   let contactsImportCoordinator: ContactsImportCoordinator
   let setup: SetupCoordinator
+  /// #1271 — EG-1 native runtime home (model store + inference server).
+  let egOneRuntime: EGOneRuntime
   let audioDeviceList: AudioDeviceList
   let aiAvailability: AIAvailabilityCoordinator
   let keychainManager: KeychainManager
@@ -136,6 +138,20 @@ public final class WisprBootstrapper {
     // `state-ownership.md` shared-infra-homes-not-feature-services.)
     let pasteCompletionRegistry = PasteCompletionRegistry()
 
+    // #1271 — EG-1 native runtime: shared-infra home, threaded into both
+    // kernel drivers + crash recovery. Launch-start below so dictation never
+    // depends on settings opening; `isActiveProvider` is a LIVE read (r2).
+    let egOneRuntime = EGOneRuntime()
+    egOneRuntime.isActiveProvider = { [weak settings] in settings?.llmProvider == .egOne }
+    egOneRuntime.onEvent = EGOneTelemetryBridge.handler
+    // Exactly one path sweeps orphans — a detached sweep alongside a spawn
+    // would race it and kill the fresh server (Codex r10 P1).
+    if settings.llmProvider == .egOne {
+      egOneRuntime.startIfActiveProvider()
+    } else {
+      egOneRuntime.sweepStaleServersAtLaunch()
+    }
+
     // PR-5 Rung 5 (#827): the VAD signal source is App-owned and shared
     // between both kernel drivers. `audioCapture.onVADAutoStop` is bound
     // exactly once here; the factory's `assembleDriver` no longer binds
@@ -159,7 +175,8 @@ public final class WisprBootstrapper {
         captureTelemetry: captureTelemetry,
         pasteCompletionRegistry: pasteCompletionRegistry,
         outputClassifierHolder: outputClassifierHolder,
-        dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled }
+        dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled },
+        egOneRuntime: egOneRuntime
       ))
 
     // W6: language-flip telemetry wired via a closure so `EnviousWisprASR`
@@ -197,7 +214,8 @@ public final class WisprBootstrapper {
         captureTelemetry: captureTelemetry,
         pasteCompletionRegistry: pasteCompletionRegistry,
         outputClassifierHolder: outputClassifierHolder,
-        dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled }
+        dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled },
+        egOneRuntime: egOneRuntime
       ))
 
     // Phase F (#501) — `SetupCoordinator` needs `asrManager` + the WhisperKit
@@ -225,7 +243,8 @@ public final class WisprBootstrapper {
       whisperKitKernelDriver: whisperKitKernelDriver,
       audioCapture: audioCapture,
       asrManager: asrManager,
-      hotkeyService: hotkeyService
+      hotkeyService: hotkeyService,
+      egOneRuntime: egOneRuntime
     )
     settingsSync.applyInitialSettings(settings)
 
@@ -397,6 +416,7 @@ public final class WisprBootstrapper {
       transcriptCoordinator: transcriptCoordinator,
       keychainManager: keychainManager,
       outputClassifierHolder: outputClassifierHolder,
+      egOneRuntime: egOneRuntime,
       // Best-effort: the snapshot carries only the custom-words version, so recovery
       // applies the user's CURRENT words (pack terms omitted) — normal-quality, not
       // byte-exact. `+ 1` keeps the cache generation non-zero so terms take effect.
@@ -616,6 +636,7 @@ public final class WisprBootstrapper {
     self.customWordsCoordinator = customWordsCoordinator
     self.contactsImportCoordinator = contactsImportCoordinator
     self.setup = setup
+    self.egOneRuntime = egOneRuntime
     self.audioDeviceList = audioDeviceList
     self.aiAvailability = aiAvailability
     self.keychainManager = keychainManager
@@ -734,6 +755,10 @@ public final class WisprBootstrapper {
   }
 
   public func applicationWillTerminate() {
+    // #1271: kill the EG-1 child SYNCHRONOUSLY — `Process` children survive
+    // parent exit (Codex r1 proved empirically); crash orphans are reaped by
+    // the stale-sweep in EGOneServerManager.start on next launch.
+    egOneRuntime.terminateServerForAppQuit()
     // #1019: tear down the network path monitor + wake observer.
     updateTriggerCoordinator.stop()
     // #1176: a Cocoa quit during onboarding is an abandon (best-effort — kill -9
@@ -801,6 +826,7 @@ private struct MainWindowRoot: View {
       .environment(b.customWordsCoordinator)
       .environment(b.contactsImportCoordinator)
       .environment(b.setup)
+      .environment(b.egOneRuntime)
       .environment(b.audioDeviceList)
       .environment(b.aiAvailability)
       .environment(b.llmDiscovery)

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -140,6 +140,7 @@ struct AIPolishSettingsView: View {
   @Environment(SetupCoordinator.self) private var setup
   @Environment(AIAvailabilityCoordinator.self) private var aiAvailability
   @Environment(LLMModelDiscoveryCoordinator.self) private var llmDiscovery
+  @Environment(EGOneRuntime.self) private var egOne
   @Environment(\.keychainManager) private var keychainManagerEnv
 
   /// Force-unwrapped: `EnviousWisprApp` always injects a real instance into the
@@ -159,7 +160,9 @@ struct AIPolishSettingsView: View {
   }
 
   private var showModelSection: Bool {
+    // EG-1 excluded: one fixed first-party model, no model picker (#1271).
     settings.llmProvider != .none && settings.llmProvider != .appleIntelligence
+      && settings.llmProvider != .egOne
   }
 
   private var ollamaShowsManageModels: Bool {
@@ -180,10 +183,11 @@ struct AIPolishSettingsView: View {
           BrandedRow {
             Picker("LLM Provider", selection: $settings.llmProvider) {
               Text("Off").tag(LLMProvider.none)
+              Text("EG-1 (Recommended local model)").tag(LLMProvider.egOne)
+              Text("Apple Intelligence").tag(LLMProvider.appleIntelligence)
               Text("OpenAI").tag(LLMProvider.openAI)
               Text("Google Gemini").tag(LLMProvider.gemini)
               Text("Local (Ollama)").tag(LLMProvider.ollama)
-              Text("Apple Intelligence").tag(LLMProvider.appleIntelligence)
             }
           }
 
@@ -214,6 +218,13 @@ struct AIPolishSettingsView: View {
           if settings.llmProvider == .appleIntelligence {
             BrandedRow(showDivider: false) {
               appleIntelligenceStatus
+            }
+          }
+
+          // EG-1 native model (#1271)
+          if settings.llmProvider == .egOne {
+            BrandedRow(showDivider: false) {
+              egOneStatusContent
             }
           }
         },
@@ -333,6 +344,10 @@ struct AIPolishSettingsView: View {
         }
       } else if settings.llmProvider == .appleIntelligence {
         Task { await aiAvailability.checkAvailability(trigger: "settings_open") }
+      } else if settings.llmProvider == .egOne {
+        // #1271: settings-open is one of the two probe moments (the other is
+        // provider activation via PipelineSettingsSync). No background polling.
+        egOne.activateAndProbe()
       } else if settings.llmProvider != .none {
         llmDiscovery.loadCachedModels(for: settings.llmProvider)
       }
@@ -357,6 +372,13 @@ struct AIPolishSettingsView: View {
         Task { await setup.ollamaSetup.detectState() }
       case .appleIntelligence:
         Task { await aiAvailability.checkAvailability(trigger: "provider_switch") }
+      case .egOne:
+        // Fixed local model — no API key, no model discovery. Routing it
+        // into the default key-provider path would hand the discovery
+        // coordinator an empty model list and let it overwrite `llmModel`
+        // (#1271 Codex r7). Activation/probe rides PipelineSettingsSync;
+        // the status section's own onAppear probe covers settings-open.
+        break
       default:
         llmDiscovery.loadCachedModels(for: newProvider)
         Task {
@@ -770,6 +792,162 @@ struct AIPolishSettingsView: View {
         .controlSize(.small)
       }
     }
+  }
+
+  // MARK: - EG-1 native model (#1271)
+
+  /// Whole-section content for the EG-1 provider: explainer with the
+  /// founder-approved benchmark claim (real numbers, no competitor names),
+  /// download flow with size disclosure, the green/yellow/red activation
+  /// pill (a REAL inference probe, never process-exists), Remove Model, and
+  /// the 8 GB heads-up. Copy rules: no em or en dashes in these strings.
+  @ViewBuilder
+  private var egOneStatusContent: some View {
+    Text(
+      "EG-1 is our own polish model, tuned specifically for dictation. "
+        + "It matches leading cloud models on our 1,890-case benchmark "
+        + "(94.7% behavior score) while running entirely on this Mac. "
+        + "Nothing you dictate ever leaves your device."
+    )
+    .font(.stHelper)
+    .foregroundStyle(Color.stTextTertiary)
+    .fixedSize(horizontal: false, vertical: true)
+
+    if isLowMemoryMac {
+      Label(
+        "This Mac has 8 GB of memory. EG-1 may run slower here. "
+          + "Dictation always works, even when polish is unavailable.",
+        systemImage: "exclamationmark.triangle"
+      )
+      .font(.stHelper)
+      .foregroundStyle(.stWarning)
+      .fixedSize(horizontal: false, vertical: true)
+    }
+
+    switch egOne.installState {
+    case .notInstalled:
+      HStack {
+        Text("One-time download: 2.7 GB")
+          .font(.stHelper)
+          .foregroundStyle(Color.stTextTertiary)
+        Spacer()
+        Button("Download EG-1") { egOne.startDownload() }
+      }
+    case .downloading(let fraction):
+      VStack(alignment: .leading, spacing: 4) {
+        ProgressView(value: max(0, min(1, fraction))) {
+          Text("Downloading EG-1 (2.7 GB)")
+            .font(.stHelper)
+        }
+        Button("Cancel") { egOne.cancelDownload() }
+          .buttonStyle(.borderless)
+          .font(.stHelper)
+      }
+    case .verifying:
+      HStack {
+        ProgressView().controlSize(.small)
+        Text("Verifying download integrity")
+          .font(.stHelper)
+          .foregroundStyle(Color.stTextTertiary)
+      }
+    case .failed(let failure):
+      Text(egOneFailureCopy(failure))
+        .font(.stHelper)
+        .foregroundStyle(.stError)
+        .fixedSize(horizontal: false, vertical: true)
+      Button("Try Again") { egOne.startDownload() }
+    case .installed:
+      HStack {
+        Text("Status:")
+        Spacer()
+        egOneHealthLabel
+        Button {
+          egOne.activateAndProbe()
+        } label: {
+          Image(systemName: "arrow.clockwise")
+        }
+        .buttonStyle(.borderless)
+        .help("Test that EG-1 is live")
+        .accessibilityLabel("Test that EG-1 is live")
+      }
+      if let reason = egOneHealthDetail {
+        Text(reason)
+          .font(.stHelper)
+          .foregroundStyle(Color.stTextTertiary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      Button("Remove Model") {
+        egOne.removeModel()
+        settings.llmProvider = .appleIntelligence
+      }
+      .buttonStyle(.borderless)
+      .font(.stHelper)
+    }
+  }
+
+  @ViewBuilder
+  private var egOneHealthLabel: some View {
+    switch egOne.health {
+    case .green:
+      Label("Live", systemImage: "checkmark.circle.fill")
+        .foregroundStyle(.stSuccess)
+    case .yellow:
+      Label("Attention", systemImage: "exclamationmark.triangle.fill")
+        .foregroundStyle(.stWarning)
+    case .red:
+      Label("Not working", systemImage: "xmark.circle.fill")
+        .foregroundStyle(.stError)
+    }
+  }
+
+  /// Plain-language reason line under the health pill (nil for green).
+  private var egOneHealthDetail: String? {
+    switch egOne.health {
+    case .green:
+      return nil
+    case .yellow(let reason):
+      switch reason {
+      case "starting": return "The model is starting up. This takes a few seconds."
+      case "paused_for_memory":
+        return "Paused to free memory for other apps. Use the refresh button to restart it."
+      case "probe_slow": return "Working, but responding slowly right now."
+      case "probe_output_unexpected":
+        return "The model responded, but not as expected. Try re-downloading it."
+      case "downloading", "verifying": return nil
+      default: return "Something needs attention. Try the refresh button."
+      }
+    case .red(let reason):
+      switch reason {
+      case "download_required": return "Download the model to get started."
+      case "app_update_required":
+        return "This model needs a newer version of EnviousWispr."
+      case "crashed_twice":
+        return "The model stopped twice in a row. Use the refresh button to try again."
+      default: return "Not running. Use the refresh button to try again."
+      }
+    }
+  }
+
+  private func egOneFailureCopy(_ failure: EGOneModelStore.EGOneDownloadFailure) -> String {
+    switch failure {
+    case .network:
+      return "Could not download the model from models.enviouslabs.co. "
+        + "Check your connection. On a managed network, ask IT to allow this domain."
+    case .checksum:
+      return "The download did not verify correctly and was discarded. Please try again."
+    case .disk:
+      return "Not enough free disk space. The download needs about 6 GB free during install."
+    case .cancelled:
+      return "Download canceled. Your progress is saved."
+    case .rangeUnsupported, .http:
+      return "The download server had a problem. Please try again in a few minutes."
+    case .stubURL:
+      return "This build has no download source configured."
+    }
+  }
+
+  private var isLowMemoryMac: Bool {
+    ProcessInfo.processInfo.physicalMemory <= (8 << 30)
   }
 
   // MARK: - Apple Intelligence Status

--- a/Sources/EnviousWisprCore/LLMResult.swift
+++ b/Sources/EnviousWisprCore/LLMResult.swift
@@ -6,16 +6,25 @@ public enum LLMProvider: String, Codable, CaseIterable, Sendable {
   case gemini
   case ollama
   case appleIntelligence
+  case egOne
   case none
 }
 
 extension LLMProvider {
+  /// Canonical model-identity literal for the first-party EG-1 provider.
+  /// Core and Services cannot import EnviousWisprLLM (where the model
+  /// manifest lives), so identity at this layer is a fixed literal — the
+  /// same pattern as `apple-intelligence`. `EGOneRuntime` refuses to
+  /// activate a manifest whose model name disagrees with this value.
+  public static let egOneModelName = "eg-1"
+
   public var displayName: String {
     switch self {
     case .openAI: return "OpenAI"
     case .gemini: return "Gemini"
     case .ollama: return "Ollama"
     case .appleIntelligence: return "Apple Intelligence"
+    case .egOne: return "EG-1"
     case .none: return "None"
     }
   }
@@ -29,6 +38,7 @@ extension LLMProvider {
     case .gemini: return "gemini-2.0-flash"
     case .ollama: return ollamaModel
     case .appleIntelligence: return "apple-intelligence"
+    case .egOne: return LLMProvider.egOneModelName
     case .none: return ""
     }
   }
@@ -40,7 +50,7 @@ extension LLMProvider {
       return model.hasPrefix("gemini-2.5") || model.hasPrefix("gemini-3")
     case .openAI:
       return model.hasPrefix("o1") || model.hasPrefix("o3") || model.hasPrefix("o4")
-    case .ollama, .appleIntelligence, .none:
+    case .ollama, .appleIntelligence, .egOne, .none:
       return false
     }
   }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneConnector.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneConnector.swift
@@ -105,6 +105,16 @@ public struct EGOneConnector: TranscriptPolisher {
   /// with a canned wire payload.
   static func parseSuccess(data: Data) throws -> LLMResult {
     let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    // finish_reason == "length" means generation STOPPED at the max_tokens
+    // cap — the content is a partial rewrite. Accepting it pastes a
+    // truncated polish, the exact failure the EG-1 contract forbids; the
+    // token budgets make this rare, this check makes it impossible
+    // (#1271 cloud review P2).
+    if let finish = (json?["choices"] as? [[String: Any]])?.first?["finish_reason"] as? String,
+      finish == "length"
+    {
+      throw LLMError.egOneSkipped(.outputTruncated)
+    }
     guard let choices = json?["choices"] as? [[String: Any]],
       let message = choices.first?["message"] as? [String: Any],
       let content = message["content"] as? String,

--- a/Sources/EnviousWisprLLM/EGOne/EGOneConnector.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneConnector.swift
@@ -1,0 +1,136 @@
+import EnviousWisprCore
+import Foundation
+
+/// Localhost OpenAI-wire connector for the bundled EG-1 inference server
+/// (#1271). Thin sibling of `OpenAIConnector`: same chat-completions wire
+/// format, but no keychain (the per-launch bearer token comes from the
+/// endpoint), temperature 0, and every transport failure maps to the
+/// SILENT bypass family — a local-server hiccup must read as "no polish
+/// this time", never as an "AI polish failed" pill.
+///
+/// Stateless by contract: reads the endpoint per call, never owns the
+/// process (that is `EGOneServerManager`).
+public struct EGOneConnector: TranscriptPolisher {
+  private let endpoint: EGOneEndpoint
+
+  public init(endpoint: EGOneEndpoint) {
+    self.endpoint = endpoint
+  }
+
+  public func polish(
+    text: String,
+    instructions: PolishInstructions,
+    config: LLMProviderConfig,
+    onToken: (@Sendable (String) -> Void)?
+  ) async throws -> LLMResult {
+    try await send(system: instructions.systemPrompt, user: text, config: config)
+  }
+
+  public func polish(
+    envelope: PromptEnvelope,
+    config: LLMProviderConfig,
+    onToken: (@Sendable (String) -> Void)?
+  ) async throws -> LLMResult {
+    guard let pair = envelope.asSingleTurn() else {
+      let user = envelope.messages.filter { $0.role == .user }.map(\.content).joined()
+      let system = envelope.messages.filter { $0.role == .system }.map(\.content)
+        .joined(separator: "\n")
+      return try await send(system: system, user: user, config: config)
+    }
+    return try await send(system: pair.system ?? "", user: pair.user, config: config)
+  }
+
+  private func send(
+    system: String, user: String, config: LLMProviderConfig
+  ) async throws -> LLMResult {
+    let body: [String: Any] = [
+      "model": config.model,
+      "messages": [
+        ["role": "system", "content": system],
+        ["role": "user", "content": user],
+      ],
+      "max_tokens": config.maxTokens,
+      "temperature": config.temperature,
+    ]
+
+    var request = URLRequest(url: endpoint.chatCompletionsURL)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(endpoint.authToken)", forHTTPHeaderField: "Authorization")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+    // The pipeline's 15 s budget is the real cap; this transport timeout
+    // only stops a zombie socket from outliving the step.
+    request.timeoutInterval = 20
+
+    // One internal retry on connection-refused/reset: covers the
+    // restart-once window after a server crash (plan §4). This is the
+    // EXPLICIT retry decision for EG-1 — `LLMRetryPolicy` deliberately
+    // treats the bypass error below as non-retryable so outer machinery
+    // never stacks retries on top.
+    var lastConnectionError = false
+    for attempt in 0...1 {
+      if attempt > 0 {
+        try await Task.sleep(for: .milliseconds(750))
+      }
+      do {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+          throw LLMError.egOneSkipped(.crashed)
+        }
+        guard http.statusCode == 200 else {
+          Task {
+            await AppLogger.shared.log(
+              "EG-1 server HTTP \(http.statusCode)", level: .verbose, category: "LLM")
+          }
+          throw LLMError.egOneSkipped(.crashed)
+        }
+        return try Self.parseSuccess(data: data)
+      } catch let urlError as URLError {
+        switch urlError.code {
+        case .cannotConnectToHost, .networkConnectionLost:
+          lastConnectionError = true
+          continue
+        case .cancelled:
+          throw CancellationError()
+        default:
+          throw LLMError.egOneSkipped(.crashed)
+        }
+      }
+    }
+    _ = lastConnectionError
+    throw LLMError.egOneSkipped(.crashed)
+  }
+
+  /// `internal` (not private) so the tag-echo regression test drives it
+  /// with a canned wire payload.
+  static func parseSuccess(data: Data) throws -> LLMResult {
+    let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    guard let choices = json?["choices"] as? [[String: Any]],
+      let message = choices.first?["message"] as? [String: Any],
+      let content = message["content"] as? String,
+      !content.isEmpty
+    else {
+      // A 200 with a malformed or empty body is still a LOCAL-server hiccup
+      // — it must ride the silent family like every other EG-1 failure.
+      // `LLMError.emptyResponse` here would surface the "AI polish failed"
+      // pill + a Sentry capture, breaking the connector's own contract
+      // (#1271 seam review P1, independently confirmed by Codex r10).
+      throw LLMError.egOneSkipped(.crashed)
+    }
+    // Tag stripping ON: the EG-1 prompt is a SANDWICH path — the user
+    // message wraps dictation in `<TRANSCRIPT>` tags the model can echo
+    // (unlike the tag-free fixed cloud prompt, which passes false). A
+    // dictated literal tag survives because `EGOnePromptBuilder` neutralizes
+    // it with a zero-width non-joiner before it reaches the model
+    // (#1271 Codex r4).
+    let cleaned = content.trimmingCharacters(in: .whitespacesAndNewlines)
+      .strippingLLMPreamble(stripTranscriptTags: true)
+    // Emptiness gates on the CLEANED text (#1271 Codex r12): whitespace-only
+    // or tags-only content passes the raw check above, then cleans down to
+    // nothing — which would paste empty text instead of the raw fallback.
+    guard !cleaned.isEmpty else {
+      throw LLMError.egOneSkipped(.crashed)
+    }
+    return LLMResult(polishedText: cleaned)
+  }
+}

--- a/Sources/EnviousWisprLLM/EGOne/EGOneManifest.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneManifest.swift
@@ -1,0 +1,109 @@
+import EnviousWisprCore
+import Foundation
+
+/// Manifest describing one first-party polish model artifact (#1271).
+///
+/// The manifest is the HOT-SWAP contract: the runtime loads whatever the
+/// manifest points at, the prompt builder is selected by
+/// `promptTemplateID` (never hardcoded to one model), and the health probe
+/// plus telemetry key off manifest identity. Shipping EG-2 is a new
+/// manifest entry plus (at most) a new prompt-template registry row —
+/// zero limb refactor.
+///
+/// Phase 1 ships ONE manifest as an app-bundle resource
+/// (`Contents/Resources/eg1-manifest.json`, app-target resource in
+/// `Project.swift`). Decoding is non-strict: unknown future fields are
+/// ignored, so an older app can still read a newer manifest and fail
+/// closed on `promptTemplateID` rather than on decode.
+public struct EGOneManifest: Codable, Sendable, Equatable {
+  /// Canonical model name. MUST equal `LLMProvider.egOneModelName` for
+  /// Phase 1 — `EGOneRuntime` refuses activation on mismatch (Core and
+  /// Services identify the provider's model by that fixed literal and
+  /// cannot read this manifest; agreement is enforced here, the one layer
+  /// that sees both).
+  public let modelName: String
+  /// Artifact version, e.g. "v1". Part of the on-disk filename so model
+  /// updates are atomic swaps, never in-place rewrites.
+  public let version: String
+  /// SHA-256 of the GGUF artifact (lowercase hex). BLOCKING: a file that
+  /// does not hash to this value is never served (deleted, re-downloaded).
+  public let sha256: String
+  /// Exact artifact size in bytes. Used for the disk-space preflight and
+  /// as a cheap first-pass integrity check before hashing.
+  public let sizeBytes: Int64
+  /// Context window (tokens) to launch the server with (`-c`). Sized from
+  /// the 2026-07-02 length-ladder data; never below the product's
+  /// max-dictation needs so nothing is silently truncated.
+  public let contextTokens: Int
+  /// Prompt-template identity the model was TRAINED with. Maps through
+  /// `promptFamily` below; an unknown value refuses activation (RED,
+  /// "app update required") rather than mis-prompting a future model.
+  public let promptTemplateID: String
+  /// Minimum app version that can run this artifact (informational in
+  /// Phase 1; enforced when remote manifests arrive).
+  public let minAppVersion: String
+  /// HTTPS download URL for the GGUF artifact.
+  public let downloadURL: URL
+  /// HTTPS URL of the EG-1 model license that governs the artifact.
+  public let licenseURL: URL?
+
+  public init(
+    modelName: String, version: String, sha256: String, sizeBytes: Int64,
+    contextTokens: Int, promptTemplateID: String, minAppVersion: String,
+    downloadURL: URL, licenseURL: URL? = nil
+  ) {
+    self.modelName = modelName
+    self.version = version
+    self.sha256 = sha256
+    self.sizeBytes = sizeBytes
+    self.contextTokens = contextTokens
+    self.promptTemplateID = promptTemplateID
+    self.minAppVersion = minAppVersion
+    self.downloadURL = downloadURL
+    self.licenseURL = licenseURL
+  }
+
+  /// Prompt-template registry: manifest `promptTemplateID` → prompt family.
+  /// Returns nil for unknown ids — the caller must treat that as
+  /// "cannot activate", never fall back to a guessed prompt.
+  public var promptFamily: PromptFamily? {
+    switch promptTemplateID {
+    case "eg1-v1": return .egOneFixed
+    default: return nil
+    }
+  }
+
+  /// On-disk artifact filename (versioned, immutable).
+  public var artifactFileName: String { "\(modelName)-\(version).gguf" }
+
+  /// Full activation validation. Returns the reasons the manifest cannot
+  /// be activated by THIS app build; empty means activatable.
+  public func activationBlockers() -> [String] {
+    var blockers: [String] = []
+    if modelName != LLMProvider.egOneModelName {
+      blockers.append("model_name_mismatch")
+    }
+    if promptFamily == nil {
+      blockers.append("unknown_prompt_template")
+    }
+    if downloadURL.scheme != "https" {
+      blockers.append("non_https_url")
+    }
+    return blockers
+  }
+
+  /// Decode from a bundled resource. Non-strict (unknown fields ignored).
+  public static func loadBundled(
+    from bundle: Bundle = .main, resourceName: String = "eg1-manifest"
+  ) throws -> EGOneManifest {
+    guard let url = bundle.url(forResource: resourceName, withExtension: "json") else {
+      throw EGOneManifestError.resourceMissing(resourceName)
+    }
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(EGOneManifest.self, from: data)
+  }
+}
+
+public enum EGOneManifestError: Error, Sendable, Equatable {
+  case resourceMissing(String)
+}

--- a/Sources/EnviousWisprLLM/EGOne/EGOneModelStore.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneModelStore.swift
@@ -1,0 +1,620 @@
+import CryptoKit
+import EnviousWisprCore
+import Foundation
+
+/// Downloads, verifies, and stores first-party polish model artifacts (#1271).
+///
+/// Single authority for model DISTRIBUTION (manifest → download → verify →
+/// atomic install → remove). Server runtime is `EGOneServerManager`'s
+/// concern — the two evolve independently (a new host changes this file
+/// only; a llama.cpp upgrade changes the manager only).
+///
+/// Verification is BLOCKING by design: a GGUF that does not hash to the
+/// manifest's SHA-256 is deleted and never served (a corrupt LLM produces
+/// plausible-looking wrong output, unlike a corrupt ASR model — stricter
+/// than `ModelDownloadManager.verifyChecksum()`'s advisory check).
+public actor EGOneModelStore {
+  public enum InstallState: Sendable, Equatable {
+    case notInstalled
+    case downloading(fractionCompleted: Double)
+    case verifying
+    case installed(version: String)
+    case failed(EGOneDownloadFailure)
+  }
+
+  public enum EGOneDownloadFailure: String, Error, Sendable, Equatable {
+    case network = "network"
+    case checksum = "checksum"
+    case disk = "disk"
+    case cancelled = "cancelled"
+    case rangeUnsupported = "range_unsupported"
+    case http = "http"
+    case stubURL = "stub_url"
+  }
+
+  /// Recorded at download start; a changed remote object invalidates resume.
+  private struct ResumeIdentity: Codable {
+    let etag: String?
+    let contentLength: Int64?
+  }
+
+  private let manifest: EGOneManifest
+  private let directory: URL
+  private var downloadTask: Task<Void, Never>?
+  /// Monotonic download token (#1271 Codex r6): cancel / remove / a fresh
+  /// start bump it, so a cancelled task that finishes LATE can neither
+  /// publish its terminal state over a retry's live state nor clear the
+  /// retry's task handle.
+  private var downloadGeneration = 0
+  private(set) var state: InstallState = .notInstalled
+  /// Progress callback for the UI facade (set once by `EGOneRuntime`).
+  private var onStateChange: (@Sendable (InstallState) -> Void)?
+
+  public init(manifest: EGOneManifest, directory: URL? = nil) {
+    self.manifest = manifest
+    self.directory =
+      directory
+      ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+      .appendingPathComponent("EnviousWispr/PolishModels", isDirectory: true)
+  }
+
+  public func setStateObserver(_ observer: @escaping @Sendable (InstallState) -> Void) {
+    onStateChange = observer
+    observer(state)
+  }
+
+  private func transition(to newState: InstallState) {
+    state = newState
+    onStateChange?(newState)
+  }
+
+  // MARK: - Paths
+
+  public var installedArtifactURL: URL {
+    directory.appendingPathComponent(manifest.artifactFileName)
+  }
+  private var installedManifestURL: URL {
+    directory.appendingPathComponent("installed-manifest.json")
+  }
+  private var tempArtifactURL: URL {
+    // Same volume as the destination so the final move is an atomic rename.
+    directory.appendingPathComponent("\(manifest.artifactFileName).partial")
+  }
+  private var resumeIdentityURL: URL {
+    directory.appendingPathComponent("\(manifest.artifactFileName).resume.json")
+  }
+
+  // MARK: - Install state
+
+  /// A model counts as installed ONLY when the artifact exists AND the
+  /// installed-manifest sha matches the active manifest (file present but
+  /// sha mismatch = NOT installed, never served).
+  public func refreshInstalledState() {
+    purgeStaleArtifacts()
+    guard FileManager.default.fileExists(atPath: installedArtifactURL.path),
+      let data = try? Data(contentsOf: installedManifestURL),
+      let installed = try? JSONDecoder().decode(EGOneManifest.self, from: data),
+      installed.sha256 == manifest.sha256
+    else {
+      if case .downloading = state { return }
+      if case .verifying = state { return }
+      // A visible failure must not evaporate on a reactive refresh (settings
+      // open, activation) before the user reads it — retry (`startDownload`)
+      // and `removeModel` own the exits from `.failed` (#1271 seam review).
+      if case .failed = state { return }
+      transition(to: .notInstalled)
+      return
+    }
+    transition(to: .installed(version: installed.version))
+  }
+
+  /// Remove the installed model + bookkeeping and return to `.notInstalled`.
+  /// The caller (runtime facade) owns reverting the provider setting.
+  public func removeModel() throws {
+    downloadGeneration += 1
+    downloadTask?.cancel()
+    downloadTask = nil
+    let fm = FileManager.default
+    for url in [installedArtifactURL, installedManifestURL, tempArtifactURL, resumeIdentityURL] {
+      if fm.fileExists(atPath: url.path) {
+        try fm.removeItem(at: url)
+      }
+    }
+    transition(to: .notInstalled)
+  }
+
+  // MARK: - Download
+
+  /// Begin (or resume) downloading. Single-flight: a second call while a
+  /// download is live is a no-op. Returns whether a download actually
+  /// STARTED — the caller's funnel telemetry keys off acceptance, not off
+  /// the request (#1271 enumeration pass).
+  @discardableResult
+  public func startDownload() -> Bool {
+    guard downloadTask == nil else { return false }
+    if case .installed = state { return false }
+    // The stub-URL ship guard test makes this unreachable in a release,
+    // but fail closed anyway: never download from a non-HTTPS or
+    // placeholder host.
+    guard manifest.downloadURL.scheme == "https",
+      let host = manifest.downloadURL.host,
+      !host.contains("invalid")
+    else {
+      // `let host` matters: a hostless URL previously slipped past the old
+      // optional-chained check (`nil != true`) (#1271 seam review).
+      transition(to: .failed(.stubURL))
+      return false
+    }
+    downloadGeneration += 1
+    let generation = downloadGeneration
+    downloadTask = Task { [weak self] in
+      await self?.runDownload(generation: generation)
+      await self?.clearTask(generation: generation)
+    }
+    return true
+  }
+
+  public func cancelDownload() {
+    downloadGeneration += 1
+    downloadTask?.cancel()
+    downloadTask = nil
+    // `.verifying` is INCLUDED (#1271 matrix gap 2): the cancelled task's
+    // own `.failed(.cancelled)` transition is generation-suppressed, so
+    // without this the UI would stick on "verifying" forever.
+    switch state {
+    case .downloading, .verifying:
+      transition(to: .failed(.cancelled))
+    case .notInstalled, .installed, .failed:
+      break
+    }
+  }
+
+  private func clearTask(generation: Int) {
+    guard generation == downloadGeneration else { return }
+    downloadTask = nil
+  }
+
+  /// State publication gate for download-task transitions: a stale task
+  /// (cancelled, superseded by a retry) may not publish.
+  private func transition(to newState: InstallState, ifGeneration generation: Int) {
+    guard generation == downloadGeneration else { return }
+    transition(to: newState)
+  }
+
+  /// Progress callbacks hop back onto this actor as INDEPENDENT tasks, so a
+  /// delayed one can land after `.verifying`/`.installed`/`.failed` (state
+  /// regression, #1271 Codex r5) or after a cancel-then-retry (stale
+  /// fraction, r6). Only the CURRENT download, while still `.downloading`,
+  /// may report progress. `internal` for the ordering test.
+  func applyDownloadProgress(_ fraction: Double, generation: Int) {
+    guard generation == downloadGeneration else { return }
+    guard case .downloading = state else { return }
+    transition(to: .downloading(fractionCompleted: fraction))
+  }
+
+  private func runDownload(generation: Int) async {
+    do {
+      try FileManager.default.createDirectory(
+        at: directory, withIntermediateDirectories: true)
+      // A COMPLETE partial needs no download headroom — it only needs the
+      // verify + rename, and the bytes are already on disk. Preflighting it
+      // would strand an already-downloaded model as `.disk` when free space
+      // shrank below 2.2x AFTER the download (Codex r2). An INCOMPLETE
+      // partial's bytes count toward the budget either way — they resume
+      // (already-downloaded bytes) or get discarded (freed) — so a big
+      // stale partial cannot wedge Try Again on `.disk` forever (r13).
+      if existingPartialBytes() != manifest.sizeBytes {
+        try preflightDiskSpace(reclaimableBytes: existingPartialBytes())
+      }
+      transition(to: .downloading(fractionCompleted: existingFraction()), ifGeneration: generation)
+      try await fetchArtifact(generation: generation)
+      transition(to: .verifying, ifGeneration: generation)
+      try await verifyAndInstall()
+      transition(to: .installed(version: manifest.version), ifGeneration: generation)
+      await AppLogger.shared.log(
+        "EG-1 model installed: \(manifest.artifactFileName)", level: .info, category: "LLM")
+    } catch is CancellationError {
+      transition(to: .failed(.cancelled), ifGeneration: generation)
+    } catch let urlError as URLError where urlError.code == .cancelled {
+      // `cancelDownload()` tears the URLSession down via `invalidateAndCancel`,
+      // which surfaces as `URLError.cancelled` (not `CancellationError`) — a
+      // deliberate cancel must not be reported as a network failure
+      // (#1271 Codex r4).
+      transition(to: .failed(.cancelled), ifGeneration: generation)
+    } catch let failure as EGOneDownloadFailure {
+      // 416 is the ONE failure a retry can never heal: the identical Range
+      // request re-fails forever. Discard the partial so Try Again starts
+      // clean, matching the checksum path's cleanup (#1271 seam review).
+      if failure == .rangeUnsupported { discardPartialArtifacts() }
+      transition(to: .failed(failure), ifGeneration: generation)
+      await AppLogger.shared.log(
+        "EG-1 model download failed: \(failure.rawValue)", level: .info, category: "LLM")
+    } catch {
+      // File-write failures ride the download path (delegate appends,
+      // directory creation, handle open) — telling that user to check the
+      // download host instead of freeing disk misdirects them, and
+      // telemetry misclassifies (#1271 confirm round).
+      let failure: EGOneDownloadFailure = Self.isDiskWriteError(error) ? .disk : .network
+      transition(to: .failed(failure), ifGeneration: generation)
+      await AppLogger.shared.log(
+        "EG-1 model download failed (\(failure.rawValue)): \(error.localizedDescription)",
+        level: .info, category: "LLM")
+    }
+  }
+
+  /// Pure classifier (`internal` for tests): does this error mean "your
+  /// disk, not your network"? Cocoa file-WRITE family (512...642 spans
+  /// unknown/no-permission/out-of-space/volume-read-only) plus POSIX
+  /// out-of-space/quota.
+  static func isDiskWriteError(_ error: Error) -> Bool {
+    let ns = error as NSError
+    if ns.domain == NSCocoaErrorDomain {
+      return (NSFileWriteUnknownError...NSFileWriteVolumeReadOnlyError).contains(ns.code)
+    }
+    if ns.domain == NSPOSIXErrorDomain {
+      return ns.code == Int(ENOSPC) || ns.code == Int(EDQUOT)
+    }
+    return false
+  }
+
+  /// Worst case is temp + final coexisting during the install move, plus
+  /// filesystem slack — require 2.2× the artifact size free. Bytes already
+  /// held by our own partial offset the requirement (see call site).
+  private func preflightDiskSpace(reclaimableBytes: Int64 = 0) throws {
+    let values = try? directory.deletingLastPathComponent()
+      .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+    if let available = values?.volumeAvailableCapacityForImportantUsage,
+      available + reclaimableBytes < Int64(Double(manifest.sizeBytes) * 2.2)
+    {
+      throw EGOneDownloadFailure.disk
+    }
+  }
+
+  /// True iff an interrupted download left partial bytes to resume from —
+  /// the runtime reads this for honest `downloadStarted(resumed:)` telemetry.
+  var hasPartialDownload: Bool { existingPartialBytes() > 0 }
+
+  /// Drop the partial + resume identity. `internal` for the 416-cleanup test.
+  func discardPartialArtifacts() {
+    try? FileManager.default.removeItem(at: tempArtifactURL)
+    try? FileManager.default.removeItem(at: resumeIdentityURL)
+  }
+
+  /// Delete artifacts belonging to a PREVIOUS manifest (#1271 r11). The
+  /// hot-swap contract changes `artifactFileName` per version (EG-1 v2,
+  /// EG-2, ...), so an update strands the old multi-GB file forever —
+  /// Remove Model only knows the CURRENT name. Extension-scoped so nothing
+  /// outside this store's file family is ever touched.
+  private func purgeStaleArtifacts() {
+    let fm = FileManager.default
+    guard let entries = try? fm.contentsOfDirectory(atPath: directory.path) else { return }
+    let current = manifest.artifactFileName
+    for name in entries {
+      guard !name.hasPrefix(current), name != "installed-manifest.json" else { continue }
+      guard name.hasSuffix(".gguf") || name.hasSuffix(".partial") || name.hasSuffix(".resume.json")
+      else { continue }
+      try? fm.removeItem(at: directory.appendingPathComponent(name))
+    }
+  }
+
+  private func existingPartialBytes() -> Int64 {
+    (try? FileManager.default.attributesOfItem(atPath: tempArtifactURL.path)[.size] as? Int64)
+      .flatMap { $0 } ?? 0
+  }
+
+  private func existingFraction() -> Double {
+    guard
+      let size = try? FileManager.default.attributesOfItem(
+        atPath: tempArtifactURL.path)[.size] as? Int64
+    else { return 0 }
+    return Double(size) / Double(manifest.sizeBytes)
+  }
+
+  /// Byte-range resume download. `URLSession` download-task resume data is
+  /// brittle across relaunches; an explicit Range request against a
+  /// validated (etag, length) identity is simpler and testable.
+  private func fetchArtifact(generation: Int) async throws {
+    let fm = FileManager.default
+    var existingBytes: Int64 = 0
+    if let size = try? fm.attributesOfItem(atPath: tempArtifactURL.path)[.size] as? Int64 {
+      existingBytes = size
+    }
+
+    // A COMPLETE partial (app quit between fetch and verify) must go
+    // straight to verification — a `Range: bytes=<size>-` request answers
+    // 416 and would strand every retry as range_unsupported (Codex r1 P2).
+    // BEFORE the identity HEAD: the checksum is the authority for a
+    // complete file (pass → install, fail → deleted + fresh download), so
+    // no network round-trip is needed or wanted here — proven by the
+    // no-network regression test.
+    if existingBytes == manifest.sizeBytes {
+      return
+    }
+
+    // Validate resume identity: if the remote object changed under the
+    // URL, the partial file is garbage — discard and restart.
+    if existingBytes > 0 {
+      let head = try await headIdentity()
+      let recorded = try? JSONDecoder().decode(
+        ResumeIdentity.self, from: Data(contentsOf: resumeIdentityURL))
+      if Self.shouldDiscardPartial(
+        recordedETag: recorded?.etag, recordedLength: recorded?.contentLength,
+        headETag: head.etag, headLength: head.contentLength,
+        existingBytes: existingBytes, expectedSize: manifest.sizeBytes)
+      {
+        try? fm.removeItem(at: tempArtifactURL)
+        try? fm.removeItem(at: resumeIdentityURL)
+        existingBytes = 0
+      }
+    }
+
+    var request = URLRequest(url: manifest.downloadURL)
+    if existingBytes > 0 {
+      request.setValue("bytes=\(existingBytes)-", forHTTPHeaderField: "Range")
+    }
+    request.timeoutInterval = 60
+
+    // Delegate-based data task (NOT `URLSession.bytes`): AsyncBytes iterates
+    // ONE BYTE per actor-isolated loop turn — billions of iterations for a
+    // 2.7 GB artifact made installs CPU-bound (Codex r1 P2). The delegate
+    // receives multi-KB chunks and appends them straight to the partial
+    // file, preserving mid-download resume granularity.
+    if !fm.fileExists(atPath: tempArtifactURL.path) {
+      fm.createFile(atPath: tempArtifactURL.path, contents: nil)
+    }
+    let handle = try FileHandle(forWritingTo: tempArtifactURL)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+
+    let expectedTotal = manifest.sizeBytes
+    let onProgress: @Sendable (Double) -> Void = { [weak self] fraction in
+      Task { [weak self] in
+        await self?.applyDownloadProgress(fraction, generation: generation)
+      }
+    }
+    // Record the resume identity AS SOON AS HEADERS ARRIVE, before any body
+    // byte streams (Codex r2): an interrupted FIRST download must leave a
+    // resumable (identity + partial) pair, or the next launch discards the
+    // partial as identity-less and restarts a 2.7 GB transfer from zero.
+    let identityURL = resumeIdentityURL
+    let expectedSize = manifest.sizeBytes
+    let onValidatedResponse: @Sendable (HTTPURLResponse) -> Void = { http in
+      let identity = ResumeIdentity(
+        etag: http.value(forHTTPHeaderField: "ETag"),
+        contentLength: expectedSize)
+      try? JSONEncoder().encode(identity).write(to: identityURL)
+    }
+    let delegate = ChunkAppendDelegate(
+      handle: handle, startingBytes: existingBytes, expectedTotal: expectedTotal,
+      onProgress: onProgress, onValidatedResponse: onValidatedResponse)
+    let http = try await delegate.run(request: request)
+
+    switch http.statusCode {
+    case 200:
+      // Server ignored the Range header; the delegate detected this and
+      // truncated the partial to zero before writing (see ChunkAppendDelegate).
+      break
+    case 206:
+      break
+    case 416:
+      throw EGOneDownloadFailure.rangeUnsupported
+    default:
+      throw EGOneDownloadFailure.http
+    }
+  }
+
+  /// Pure resume-validity decision (`internal` for tests): discard the
+  /// partial when no identity was recorded, the remote identity changed,
+  /// or the partial is impossibly large.
+  static func shouldDiscardPartial(
+    recordedETag: String??, recordedLength: Int64??,
+    headETag: String?, headLength: Int64?,
+    existingBytes: Int64, expectedSize: Int64
+  ) -> Bool {
+    guard let etag = recordedETag, let length = recordedLength else { return true }
+    if etag != headETag || length != headLength { return true }
+    return existingBytes > expectedSize
+  }
+
+  private func headIdentity() async throws -> (etag: String?, contentLength: Int64?) {
+    var request = URLRequest(url: manifest.downloadURL)
+    request.httpMethod = "HEAD"
+    request.timeoutInterval = 30
+    let (_, response) = try await URLSession.shared.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw EGOneDownloadFailure.network
+    }
+    // A non-success HEAD (transient 5xx, proxy interstitial, HEAD-blocked)
+    // carries an error page's headers, NOT the artifact's identity —
+    // treating it as identity reads as "remote object changed" and deletes
+    // a resumable multi-GB partial (Codex r15). Throw instead: the partial
+    // survives and the retry re-validates.
+    guard (200...299).contains(http.statusCode) else {
+      throw EGOneDownloadFailure.network
+    }
+    let length = http.value(forHTTPHeaderField: "Content-Length").flatMap { Int64($0) }
+    return (http.value(forHTTPHeaderField: "ETag"), length)
+  }
+
+  /// Streaming SHA-256 (constant memory) off the caller's actor, then
+  /// atomic rename + installed-manifest write. One automatic re-download
+  /// is the caller's policy; this reports the failure. `internal` (not
+  /// private) so checksum pass/fail/partial tests drive it directly with
+  /// seeded temp files — the network fetch is the only untested seam.
+  func verifyAndInstall() async throws {
+    // Cancellation gates at entry AND after hashing (#1271 matrix gap 2):
+    // the detached hash below does not inherit cancellation, so without the
+    // second check a cancel that landed during the seconds-long hash would
+    // still atomically install the model.
+    try Task.checkCancellation()
+    let tempURL = tempArtifactURL
+    let expected = manifest.sha256.lowercased()
+    let digest: String = try await Task.detached(priority: .utility) {
+      // Task.detached: hashing 2.7 GB is seconds of pure CPU + IO that must
+      // not hold the store actor (progress/UI reads) — @concurrent needs the
+      // enclosing fn nonisolated; a detached utility task is the house shape.
+      let handle = try FileHandle(forReadingFrom: tempURL)
+      defer { try? handle.close() }
+      var hasher = SHA256()
+      while autoreleasepool(invoking: {
+        guard let chunk = try? handle.read(upToCount: 8 << 20), !chunk.isEmpty else {
+          return false
+        }
+        hasher.update(data: chunk)
+        return true
+      }) {}
+      return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }.value
+
+    try Task.checkCancellation()
+    guard digest == expected else {
+      try? FileManager.default.removeItem(at: tempArtifactURL)
+      try? FileManager.default.removeItem(at: resumeIdentityURL)
+      throw EGOneDownloadFailure.checksum
+    }
+
+    let fm = FileManager.default
+    if fm.fileExists(atPath: installedArtifactURL.path) {
+      try fm.removeItem(at: installedArtifactURL)
+    }
+    try fm.moveItem(at: tempArtifactURL, to: installedArtifactURL)
+    try JSONEncoder().encode(manifest).write(to: installedManifestURL)
+    try? fm.removeItem(at: resumeIdentityURL)
+  }
+}
+
+/// Streaming download delegate for the EG-1 artifact (#1271 Codex r1 P2):
+/// receives multi-KB chunks from URLSession's serial delegate queue and
+/// appends them synchronously to the partial file — constant memory, no
+/// per-byte iteration, and mid-download interruption keeps every appended
+/// byte for the next resume.
+///
+/// `@unchecked Sendable`: all mutable state is touched ONLY on URLSession's
+/// serial delegate queue (single-touch by construction) plus the one-shot
+/// continuation handoff guarded by `didResume`.
+final class ChunkAppendDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+  private let handle: FileHandle
+  private let startingBytes: Int64
+  private let expectedTotal: Int64
+  private let onProgress: @Sendable (Double) -> Void
+  /// Fired once when a 200/206 response is accepted, BEFORE body bytes
+  /// stream — the store persists the resume identity here so an interrupted
+  /// first download still leaves a resumable pair (Codex r2).
+  private let onValidatedResponse: @Sendable (HTTPURLResponse) -> Void
+
+  private var written: Int64
+  private var lastReported: Int64
+  private var response: HTTPURLResponse?
+  private var writeError: Error?
+  /// True only for OUR deliberate cancel on a non-success status — the one
+  /// completion "error" that must still surface the response so the caller
+  /// can map the status code (Codex r3: a REAL mid-body network error must
+  /// throw instead, or a truncated partial gets checksum-deleted).
+  private var cancelledForStatus = false
+  private var continuation: CheckedContinuation<HTTPURLResponse, Error>?
+
+  init(
+    handle: FileHandle, startingBytes: Int64, expectedTotal: Int64,
+    onProgress: @escaping @Sendable (Double) -> Void,
+    onValidatedResponse: @escaping @Sendable (HTTPURLResponse) -> Void = { _ in }
+  ) {
+    self.handle = handle
+    self.startingBytes = startingBytes
+    self.expectedTotal = expectedTotal
+    self.onProgress = onProgress
+    self.onValidatedResponse = onValidatedResponse
+    self.written = startingBytes
+    self.lastReported = startingBytes
+  }
+
+  func run(request: URLRequest) async throws -> HTTPURLResponse {
+    // delegateQueue nil → URLSession creates its own SERIAL queue. The
+    // delegate's single-touch state and in-order FileHandle appends depend
+    // on serial delivery; a default `OperationQueue()` is concurrent and
+    // can interleave `didReceive data` callbacks (#1271 Codex r5 P1).
+    let session = URLSession(
+      configuration: .default, delegate: self, delegateQueue: nil)
+    defer { session.finishTasksAndInvalidate() }
+    return try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { cont in
+        continuation = cont
+        session.dataTask(with: request).resume()
+      }
+    } onCancel: {
+      session.invalidateAndCancel()
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession, dataTask: URLSessionDataTask,
+    didReceive response: URLResponse,
+    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+  ) {
+    guard let http = response as? HTTPURLResponse else {
+      completionHandler(.cancel)
+      return
+    }
+    self.response = http
+    // Server ignored the Range header (200 on a resumed request): the body
+    // is the WHOLE object, so the already-written prefix must go.
+    if http.statusCode == 200, startingBytes > 0 {
+      do {
+        try handle.truncate(atOffset: 0)
+        written = 0
+        lastReported = 0
+      } catch {
+        writeError = error
+        completionHandler(.cancel)
+        return
+      }
+    }
+    // Non-success statuses (416, 5xx) carry no useful body — stop here; the
+    // caller maps the recorded status to its failure class.
+    if http.statusCode != 200, http.statusCode != 206 {
+      cancelledForStatus = true
+      completionHandler(.cancel)
+      return
+    }
+    onValidatedResponse(http)
+    completionHandler(.allow)
+  }
+
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    do {
+      try handle.write(contentsOf: data)
+      written += Int64(data.count)
+      // Report every ~16 MB to keep the UI live without churn.
+      if written - lastReported >= (16 << 20) {
+        lastReported = written
+        onProgress(Double(written) / Double(expectedTotal))
+      }
+    } catch {
+      writeError = error
+      dataTask.cancel()
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?
+  ) {
+    guard let cont = continuation else { return }
+    continuation = nil
+    if let writeError {
+      cont.resume(throwing: writeError)
+      return
+    }
+    // A REAL transport error mid-body must throw — the partial is a valid
+    // resume point, and returning "success" here would route it into
+    // checksum verification, which deletes it (Codex r3). Only OUR
+    // deliberate non-success-status cancel returns the response.
+    if let error, !cancelledForStatus {
+      cont.resume(throwing: error)
+      return
+    }
+    if let response {
+      cont.resume(returning: response)
+      return
+    }
+    cont.resume(throwing: error ?? URLError(.unknown))
+  }
+}

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -1,0 +1,420 @@
+import EnviousWisprCore
+import Foundation
+import Observation
+import os
+
+/// Narrow seam the dictation pipeline reads at polish time. The pipeline
+/// never sees the store/manager internals — only "is there a ready
+/// endpoint right now" (fast, never boots or blocks).
+@MainActor
+public protocol EGOneEndpointProviding: AnyObject {
+  func activeEndpoint() async -> EGOneEndpoint?
+}
+
+/// Observable lifecycle events the AppKit layer forwards to telemetry
+/// (#1271). Emission lives ABOVE this module because the LLM module cannot
+/// import Services (`TelemetryService`); the composition root wires the
+/// observer.
+public enum EGOneRuntimeEvent: Sendable, Equatable {
+  case downloadStarted(resumed: Bool)
+  case downloadCompleted(durationBucket: String)
+  case downloadFailed(reason: String)
+  /// Transition-only (debounced by construction — fired from a state
+  /// didSet, identical states never re-fire).
+  case healthChanged(from: String, to: String, reason: String?)
+}
+
+/// Single owner of the EG-1 model store and inference server (#1271):
+/// exposes their state to the pipeline (endpoint) and the settings UI
+/// (install/health/progress). Constructed ONCE by `WisprBootstrapper` —
+/// a shared runtime consumed by both layers belongs at the composition
+/// root (`state-ownership.md` shared-infra-homes rule), never inside a
+/// settings-setup service.
+@Observable
+@MainActor
+public final class EGOneRuntime: EGOneEndpointProviding {
+
+  // MARK: - Published state (settings UI reads these)
+
+  public private(set) var installState: EGOneModelStore.InstallState = .notInstalled
+  public private(set) var health: EGOneHealth = .red(reason: "not_running") {
+    didSet {
+      guard
+        Self.healthLabel(oldValue) != Self.healthLabel(health)
+          || Self.healthReason(oldValue) != Self.healthReason(health)
+      else { return }
+      onEvent?(
+        .healthChanged(
+          from: Self.healthLabel(oldValue), to: Self.healthLabel(health),
+          reason: Self.healthReason(health)))
+    }
+  }
+  /// Why the manifest cannot activate on this app build (empty = fine).
+  /// Non-empty reads RED in the UI ("app update required" for an unknown
+  /// prompt template).
+  public private(set) var activationBlockers: [String] = []
+
+  /// Telemetry forwarding hook, set by the composition root.
+  public var onEvent: (@Sendable (EGOneRuntimeEvent) -> Void)?
+
+  /// Live "is EG-1 the selected provider?" read, set by the composition
+  /// root (#1271 Codex r2). The runtime cannot import Services to read
+  /// settings; this closure lets a download that completes while EG-1 is
+  /// selected auto-start the server instead of silently skipping until
+  /// relaunch.
+  public var isActiveProvider: (@MainActor () -> Bool)?
+
+  /// Live "did an in-flight recording freeze .egOne?" read, set by the
+  /// composition root (#1271 matrix gap 3; the authority is
+  /// `PipelineSettingsSync.isEGOnePinnedInFlight`). Remove Model must not
+  /// stop the server and delete the artifact underneath a recording that
+  /// still needs it.
+  public var isPinnedInFlight: (@MainActor () -> Bool)?
+  private var removalPending = false
+
+  public let manifest: EGOneManifest?
+  private let store: EGOneModelStore?
+  private let server: EGOneServerManager
+  private let serverBinaryURL: URL?
+  private var downloadStartedAt: ContinuousClock.Instant?
+
+  // MARK: - Init
+
+  /// Production init: loads the bundled manifest; a missing/corrupt bundled
+  /// manifest is a RED state, never a crash (limb).
+  public convenience init() {
+    let manifest = try? EGOneManifest.loadBundled()
+    self.init(
+      manifest: manifest,
+      serverBinaryURL: Bundle.main.url(forResource: "llama-server", withExtension: nil)
+    )
+  }
+
+  public init(manifest: EGOneManifest?, serverBinaryURL: URL?, storeDirectory: URL? = nil) {
+    self.manifest = manifest
+    self.serverBinaryURL = serverBinaryURL
+    self.server = EGOneServerManager()
+    if let manifest {
+      self.store = EGOneModelStore(manifest: manifest, directory: storeDirectory)
+      self.activationBlockers = manifest.activationBlockers()
+    } else {
+      self.store = nil
+      self.activationBlockers = ["manifest_missing"]
+    }
+    wireObservers()
+  }
+
+  /// Last applied observer sequence numbers (#1271 enumeration pass): the
+  /// MainActor hops below are unstructured Tasks with NO ordering guarantee,
+  /// so two rapid transitions could apply in reverse and leave the UI on a
+  /// stale state. Sequence numbers are assigned on the emitting actor
+  /// (serialized by construction); an out-of-order older hop is dropped.
+  private var installStateSeqApplied = 0
+  private var serverStateSeqApplied = 0
+
+  private func wireObservers() {
+    Task { [weak self] in
+      guard let self, let store = self.store else { return }
+      let seq = OSAllocatedUnfairLock(initialState: 0)
+      await store.setStateObserver { [weak self] state in
+        let mySeq = seq.withLock {
+          $0 += 1
+          return $0
+        }
+        Task { @MainActor [weak self] in
+          guard let self, mySeq > self.installStateSeqApplied else { return }
+          self.installStateSeqApplied = mySeq
+          self.applyInstallState(state)
+        }
+      }
+      await store.refreshInstalledState()
+    }
+    Task { [weak self] in
+      guard let self else { return }
+      let seq = OSAllocatedUnfairLock(initialState: 0)
+      await self.server.setStateObserver { [weak self] state in
+        let mySeq = seq.withLock {
+          $0 += 1
+          return $0
+        }
+        Task { @MainActor [weak self] in
+          guard let self, mySeq > self.serverStateSeqApplied else { return }
+          self.serverStateSeqApplied = mySeq
+          self.applyServerState(state)
+        }
+      }
+    }
+  }
+
+  private func applyInstallState(_ state: EGOneModelStore.InstallState) {
+    installState = state
+    switch state {
+    case .installed:
+      // Only a genuine download completion may emit telemetry or
+      // auto-activate — `refreshInstalledState()` re-emits `.installed` on
+      // every refresh, and an unconditional activate loops forever (r4 P1).
+      // Completion is keyed off the REQUEST flag, not off the previous
+      // observed state: the MainActor observer hops drop out-of-order older
+      // updates (enumeration pass), so `.installed` can legitimately arrive
+      // with no `.downloading` ever applied (Codex r17).
+      if downloadCompletionPending {
+        downloadCompletionPending = false
+        let bucket = Self.durationBucket(since: downloadStartedAt)
+        onEvent?(.downloadCompleted(durationBucket: bucket))
+        // Download finished while EG-1 is the selected provider → bring the
+        // server up now, not at next relaunch (#1271 Codex r2).
+        if isActiveProvider?() == true {
+          activateAndProbe()
+        }
+      }
+    case .failed(let failure):
+      downloadCompletionPending = false
+      onEvent?(.downloadFailed(reason: failure.rawValue))
+    case .notInstalled, .downloading, .verifying:
+      break
+    }
+    recomputeHealth()
+  }
+
+  /// Set when the store ACCEPTS a download request; consumed by the first
+  /// `.installed` apply (completion telemetry + auto-activate) and cleared
+  /// by any terminal failure. Ordering-immune by construction.
+  private var downloadCompletionPending = false
+
+  private var serverState: EGOneServerManager.ServerState = .stopped
+  private func applyServerState(_ state: EGOneServerManager.ServerState) {
+    serverState = state
+    recomputeHealth()
+  }
+
+  /// Cheap health projection from install + server state. The EXPENSIVE
+  /// probe (`runHealthProbe`) upgrades yellow→green on demand only
+  /// (on-activation + on-settings-open; no background polling).
+  private func recomputeHealth() {
+    if !activationBlockers.isEmpty {
+      health = .red(
+        reason: activationBlockers.contains("unknown_prompt_template")
+          ? "app_update_required" : activationBlockers.joined(separator: ","))
+      return
+    }
+    switch installState {
+    case .notInstalled: health = .red(reason: "download_required")
+    case .downloading: health = .yellow(reason: "downloading")
+    case .verifying: health = .yellow(reason: "verifying")
+    case .failed(let failure): health = .red(reason: failure.rawValue)
+    case .installed:
+      switch serverState {
+      case .stopped: health = .yellow(reason: "not_started")
+      case .starting: health = .yellow(reason: "starting")
+      case .pausedForMemoryPressure: health = .yellow(reason: "paused_for_memory")
+      case .failed(let reason): health = .red(reason: reason)
+      case .ready: break  // keep last probe result (green or probe-derived yellow)
+      }
+    }
+  }
+
+  // MARK: - UI actions
+
+  /// True while a start request is between the tap and the store observing
+  /// `.downloading` — a double-tap in that window must not double-emit the
+  /// funnel event or re-stamp the duration clock (#1271 Codex r13).
+  private var downloadRequestInFlight = false
+
+  public func startDownload() {
+    guard let store else { return }
+    // Only states a download can genuinely BEGIN from. `.verifying` and
+    // `.installed` matter too: the store would no-op those, but falling
+    // through here would still re-stamp `downloadStartedAt` and emit a
+    // spurious downloadStarted event, corrupting the duration bucket a
+    // moments-later `.installed` reports (#1271 seam review).
+    switch installState {
+    case .notInstalled, .failed: break
+    case .downloading, .verifying, .installed: return
+    }
+    guard !downloadRequestInFlight else { return }
+    downloadRequestInFlight = true
+    downloadStartedAt = ContinuousClock.now
+    Task {
+      // Resume truth lives on disk behind the store actor — read it before
+      // emitting, or the telemetry hardcodes resumed=false (#1271 matrix
+      // gap 4). The funnel event fires only when the store ACCEPTS the
+      // start (enumeration pass: a rejected start — stub URL, racing task —
+      // must not count as a started download).
+      let resumed = await store.hasPartialDownload
+      if await store.startDownload() {
+        self.downloadCompletionPending = true
+        self.onEvent?(.downloadStarted(resumed: resumed))
+      }
+      self.downloadRequestInFlight = false
+    }
+  }
+
+  public func cancelDownload() {
+    guard let store else { return }
+    Task { await store.cancelDownload() }
+  }
+
+  /// Delete the model. Caller (settings) owns reverting the provider.
+  /// Defers while a recording froze `.egOne` in its session config — the
+  /// terminal pipeline transition retries via `retryPendingRemoval()`
+  /// (#1271 matrix gap 3; same defer shape as switch-away deactivation).
+  public func removeModel() {
+    guard let store else { return }
+    if isPinnedInFlight?() == true {
+      removalPending = true
+      return
+    }
+    removalPending = false
+    activationGeneration += 1
+    Task {
+      await self.server.stop()
+      try? await store.removeModel()
+    }
+  }
+
+  /// Called on terminal pipeline states (alongside the deactivation retry).
+  /// Idempotent: no-op unless a removal is actually pending.
+  public func retryPendingRemoval() {
+    guard removalPending else { return }
+    removeModel()
+  }
+
+  /// Monotonic activation token (#1271 Codex r5): ONLY `deactivate()` /
+  /// `removeModel()` bump it, so an activation task that was suspended when
+  /// the user switched away aborts instead of booting a multi-GB server for
+  /// a provider that is no longer selected. `activateAndProbe()` itself must
+  /// NOT bump it: concurrent activations are harmless (idempotent start,
+  /// last probe wins), and cancelling the earlier one strands the launch
+  /// probe when settings opens mid-start (#1271 Codex r6).
+  private var activationGeneration = 0
+
+  /// Full activation-probe pass: ensure server running, then run the real
+  /// inference probe. Called on provider activation and on settings-open.
+  public func activateAndProbe() {
+    // Choosing EG-1 cancels any deferred removal FIRST, even if activation
+    // itself then bails on a blocker — otherwise remove-during-recording
+    // followed by re-selecting EG-1 still deletes the model the user just
+    // re-picked once the recording ends (#1271 seam review P1).
+    removalPending = false
+    guard let manifest, activationBlockers.isEmpty else {
+      // Blocked manifest = spawn will never run this session, so its
+      // pre-spawn sweep never reaps a crash orphan; reap here (idle-gated
+      // on the server actor, so it cannot touch a live child) (#1271 r11).
+      sweepStaleServersAtLaunch()
+      return
+    }
+    let generation = activationGeneration
+    Task {
+      // First hop back onto the main actor: a switch-to-then-away that beat
+      // this task bumped the generation — do not start the server.
+      guard generation == self.activationGeneration else { return }
+      await self.startServerIfInstalled()
+      // A deactivate DURING the start already stopped the server (the
+      // manager's mid-start guards handle that); just don't probe or stamp
+      // health for a stale generation.
+      guard generation == self.activationGeneration else { return }
+      guard let family = manifest.promptFamily else { return }
+      let result = await self.server.probeHealth(promptFamily: family)
+      await MainActor.run {
+        // Probe verdict wins over the cheap projection while server is ready.
+        guard generation == self.activationGeneration else { return }
+        if case .ready = self.serverState { self.health = result }
+      }
+    }
+  }
+
+  /// Launch-time entry: called by the composition root when the persisted
+  /// provider is EG-1 — the server must come up without the settings view
+  /// ever opening.
+  public func startIfActiveProvider() {
+    activateAndProbe()
+  }
+
+  /// Orphan reap for no-spawn paths (#1271 confirm round + r11): a crash
+  /// bypasses `applicationWillTerminate`, and when nothing spawns this
+  /// session (provider not EG-1, model missing, manifest blocked) the
+  /// in-spawn sweep never runs — the orphaned multi-GB child would live
+  /// until EG-1 next activates. Routed through the server actor's
+  /// idle-gated reap, so it can never race or kill a live/starting child.
+  /// Composition-root + internal activation paths only (tests construct
+  /// with fake binary paths a pkill must never see).
+  public func sweepStaleServersAtLaunch() {
+    guard let serverBinaryURL else { return }
+    let path = serverBinaryURL.path
+    Task { await self.server.reapOrphansIfIdle(binaryPath: path) }
+  }
+
+  /// Provider switched away: free the RAM (isolate-limbs).
+  public func deactivate() {
+    activationGeneration += 1
+    Task { await self.server.stop() }
+  }
+
+  /// App-quit path (#1271 Codex r1 P1): `applicationWillTerminate` cannot
+  /// await into the server actor, and `Process` children are NOT killed
+  /// when the parent exits — kill synchronously or orphan a multi-GB
+  /// server. Crash orphans are reaped by the stale-sweep on next start.
+  public func terminateServerForAppQuit() {
+    server.terminateImmediately()
+  }
+
+  private func startServerIfInstalled() async {
+    guard let manifest, let store, let serverBinaryURL else { return }
+    await store.refreshInstalledState()
+    guard case .installed = await store.state else {
+      // No model = no spawn = no in-spawn sweep; reap orphans here
+      // (idle-gated on the server actor) (#1271 r11).
+      await server.reapOrphansIfIdle(binaryPath: serverBinaryURL.path)
+      return
+    }
+    let configuration = EGOneServerManager.Configuration(
+      serverBinaryURL: serverBinaryURL,
+      modelURL: await store.installedArtifactURL,
+      contextTokens: manifest.contextTokens,
+      // Measured 2026-07-02 (M4 Pro, real EG-1 v1 GGUF): flash-attention +
+      // q8 KV cache at 16384 context = 4.1 GB RSS vs 7.4 GB at the naive
+      // 32768/fp16 config, with identical probe output and ~0.2 s warm
+      // latency. The MacBook-friendly footprint is a launch-flag choice,
+      // not a model choice — engine flags live here, model identity in the
+      // manifest.
+      extraArguments: [
+        "-fa", "on", "--cache-type-k", "q8_0", "--cache-type-v", "q8_0",
+      ]
+    )
+    await server.start(configuration: configuration)
+  }
+
+  // MARK: - EGOneEndpointProviding (pipeline seam)
+
+  public func activeEndpoint() async -> EGOneEndpoint? {
+    await server.activeEndpoint()
+  }
+
+  // MARK: - Helpers
+
+  static func healthLabel(_ health: EGOneHealth) -> String {
+    switch health {
+    case .green: return "green"
+    case .yellow: return "yellow"
+    case .red: return "red"
+    }
+  }
+
+  static func healthReason(_ health: EGOneHealth) -> String? {
+    switch health {
+    case .green: return nil
+    case .yellow(let reason), .red(let reason): return reason
+    }
+  }
+
+  static func durationBucket(since start: ContinuousClock.Instant?) -> String {
+    guard let start else { return "unknown" }
+    let seconds = (ContinuousClock.now - start) / .seconds(1)
+    switch seconds {
+    case ..<60: return "under_1m"
+    case ..<300: return "1m_5m"
+    case ..<1200: return "5m_20m"
+    default: return "over_20m"
+    }
+  }
+}

--- a/Sources/EnviousWisprLLM/EGOne/EGOneServerManager.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneServerManager.swift
@@ -1,0 +1,464 @@
+import EnviousWisprCore
+import Foundation
+import os
+
+/// Endpoint of a ready local inference server: where to send requests and
+/// the per-launch bearer token that authenticates the app to it.
+public struct EGOneEndpoint: Sendable, Equatable {
+  public let port: UInt16
+  public let authToken: String
+  /// Context window the server was launched with — the polish step's
+  /// input-size preflight reads this so an over-budget dictation skips
+  /// whole (silent raw fallback), never truncates silently.
+  public let contextTokens: Int
+  public var chatCompletionsURL: URL {
+    URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+  }
+}
+
+/// Health of the EG-1 limb as shown in settings. ADVISORY DISPLAY ONLY —
+/// the pipeline never reads it (the polish call at dictation time is the
+/// truth; a stale green can never mask a dead server).
+public enum EGOneHealth: Sendable, Equatable {
+  case green
+  case yellow(reason: String)
+  case red(reason: String)
+}
+
+/// Spawns, monitors, and terminates the local polish inference server (#1271).
+///
+/// Single authority for server RUNTIME (process lifecycle + health).
+/// Distribution (download/verify) is `EGOneModelStore`'s concern.
+///
+/// Heart & Limbs: this whole subsystem is a limb. The server is a separate
+/// process (a crash can never take the app down), it is terminated under
+/// critical memory pressure (it may never starve heart-path ASR — the
+/// #286/#295 Ollama dual-residency incident is the precedent), and every
+/// failure surfaces to dictation as a silent raw-text fallback.
+public actor EGOneServerManager {
+  public enum ServerState: Sendable, Equatable {
+    case stopped
+    case starting
+    case ready(EGOneEndpoint)
+    /// Terminated by the memory-pressure source; reactivation is a user
+    /// action (settings) or next launch.
+    case pausedForMemoryPressure
+    /// Spawn or crash-restart failed twice this session.
+    case failed(reason: String)
+  }
+
+  /// Filesystem + process seams, injectable so lifecycle tests can run a
+  /// fake server binary (plan §11: spawn/crash/restart-once/port-conflict/
+  /// memory-pressure tests without a 2.7 GB model).
+  public struct Configuration: Sendable {
+    public var serverBinaryURL: URL
+    public var modelURL: URL
+    public var contextTokens: Int
+    /// Extra launch arguments appended after the standard set.
+    public var extraArguments: [String]
+    /// Seconds to wait for the HTTP surface after spawn (model load takes
+    /// seconds on a real machine). Tests shrink this so a fake server that
+    /// never binds fails fast instead of stalling the suite.
+    public var readinessBudgetSeconds: Int
+
+    public init(
+      serverBinaryURL: URL, modelURL: URL, contextTokens: Int,
+      extraArguments: [String] = [], readinessBudgetSeconds: Int = 60
+    ) {
+      self.serverBinaryURL = serverBinaryURL
+      self.modelURL = modelURL
+      self.contextTokens = contextTokens
+      self.extraArguments = extraArguments
+      self.readinessBudgetSeconds = readinessBudgetSeconds
+    }
+  }
+
+  private(set) var state: ServerState = .stopped
+  /// Monotonic spawn token (#1271 matrix gap 1): `stop()` / memory-pressure
+  /// pause / a newer spawn bump it, so a spawn whose readiness await resumes
+  /// AFTER its generation ended can neither tear down a successor's process
+  /// nor promote/fail over the successor's `.starting` state. (Same race
+  /// shape as the crash-restart guard — this covers the normal start path.)
+  private var launchGeneration = 0
+  private var process: Process? {
+    didSet {
+      let current = process
+      quitKillBox.withLock { $0 = current }
+    }
+  }
+  private var restartedOnceThisGeneration = false
+  private var memoryPressureSource: (any DispatchSourceMemoryPressure)?
+  private var onStateChange: (@Sendable (ServerState) -> Void)?
+  /// Mirror of `process` reachable WITHOUT actor isolation, exclusively for
+  /// the synchronous app-quit path (#1271 Codex r1 P1): `Process` children
+  /// are NOT killed when the parent exits, and `applicationWillTerminate`
+  /// cannot await into this actor.
+  private let quitKillBox = OSAllocatedUnfairLock<Process?>(initialState: nil)
+
+  public init() {}
+
+  public func setStateObserver(_ observer: @escaping @Sendable (ServerState) -> Void) {
+    onStateChange = observer
+    observer(state)
+  }
+
+  private func transition(to newState: ServerState) {
+    state = newState
+    onStateChange?(newState)
+  }
+
+  /// Current endpoint iff ready. Fast, never boots the server — dictation
+  /// during boot silently falls back (never blocks paste).
+  public func activeEndpoint() -> EGOneEndpoint? {
+    if case .ready(let endpoint) = state { return endpoint }
+    return nil
+  }
+
+  // MARK: - Lifecycle
+
+  /// Start the server. Idempotent behind actor isolation: no-ops while
+  /// starting or ready. Resets the restart-once latch (explicit user or
+  /// launch activation = a fresh generation).
+  public func start(configuration: Configuration) async {
+    switch state {
+    case .starting, .ready: return
+    case .stopped, .pausedForMemoryPressure, .failed: break
+    }
+    restartedOnceThisGeneration = false
+    await spawn(configuration: configuration)
+  }
+
+  public func stop() {
+    launchGeneration += 1
+    tearDownProcess()
+    transition(to: .stopped)
+  }
+
+  /// Synchronous kill for `applicationWillTerminate` — actor state is left
+  /// as-is (the app is exiting); the only job is not orphaning the child.
+  public nonisolated func terminateImmediately() {
+    quitKillBox.withLock { proc in
+      if let proc, proc.isRunning {
+        proc.terminationHandler = nil
+        proc.terminate()
+      }
+      proc = nil
+    }
+  }
+
+  /// Kill any STALE server left by a crashed previous instance (a crash
+  /// bypasses `applicationWillTerminate`, orphaning a multi-GB child).
+  /// Exact-path match: only processes running OUR bundled binary die; runs
+  /// BEFORE this generation's spawn so it can never hit our own child.
+  static func killStaleServers(binaryPath: String) {
+    let sweep = Process()
+    sweep.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+    // pkill -f is an unanchored REGEX over the whole command line — escape
+    // metacharacters and anchor to argv[0] so only processes actually
+    // RUNNING this binary die, never one whose command line merely mentions
+    // the path (e.g. codesign signing it mid-build) (#1271 seam review).
+    let escaped = NSRegularExpression.escapedPattern(for: binaryPath)
+    sweep.arguments = ["-f", "^\(escaped)( |$)"]
+    sweep.standardOutput = FileHandle.nullDevice
+    sweep.standardError = FileHandle.nullDevice
+    try? sweep.run()
+    sweep.waitUntilExit()
+  }
+
+  /// Ordered orphan reap for paths where spawn will NOT run (EG-1 selected
+  /// but model missing / manifest blocked, or EG-1 not selected at all).
+  /// Actor-isolated AND idle-gated, so it can never kill a child this
+  /// manager owns or is mid-starting — callable from anywhere without the
+  /// sweep-vs-fresh-spawn ordering concerns of a detached pkill (#1271 r11;
+  /// retires the r10 race class rather than patching another call site).
+  func reapOrphansIfIdle(binaryPath: String) {
+    switch state {
+    case .stopped, .failed, .pausedForMemoryPressure:
+      Self.killStaleServers(binaryPath: binaryPath)
+    case .starting, .ready:
+      break
+    }
+  }
+
+  private func tearDownProcess() {
+    memoryPressureSource?.cancel()
+    memoryPressureSource = nil
+    if let process, process.isRunning {
+      process.terminationHandler = nil
+      process.terminate()
+    }
+    process = nil
+  }
+
+  private func spawn(configuration: Configuration) async {
+    launchGeneration += 1
+    let generation = launchGeneration
+    transition(to: .starting)
+
+    guard FileManager.default.fileExists(atPath: configuration.serverBinaryURL.path) else {
+      transition(to: .failed(reason: "server_binary_missing"))
+      return
+    }
+    // A previous app instance that CRASHED (bypassing applicationWillTerminate)
+    // may have orphaned its server; reap it before spawning ours.
+    Self.killStaleServers(binaryPath: configuration.serverBinaryURL.path)
+    guard FileManager.default.fileExists(atPath: configuration.modelURL.path) else {
+      transition(to: .failed(reason: "model_missing"))
+      return
+    }
+
+    // App-chosen free port (bind-probe then release). llama-server's
+    // `--port 0` self-report is NOT assumed (plan §11 port strategy).
+    guard let port = Self.findFreePort() else {
+      transition(to: .failed(reason: "no_free_port"))
+      return
+    }
+    let token = UUID().uuidString + UUID().uuidString
+
+    let proc = Process()
+    proc.executableURL = configuration.serverBinaryURL
+    proc.arguments =
+      [
+        "-m", configuration.modelURL.path,
+        "--host", "127.0.0.1",
+        "--port", String(port),
+        "-c", String(configuration.contextTokens),
+        "--api-key", token,
+      ] + configuration.extraArguments
+    // The server's stdout/stderr are noise for us; route to null so the
+    // pipe buffers can never fill and wedge the child.
+    proc.standardOutput = FileHandle.nullDevice
+    proc.standardError = FileHandle.nullDevice
+    proc.terminationHandler = { [weak self] _ in
+      Task { [weak self] in
+        await self?.handleTermination(configuration: configuration, generation: generation)
+      }
+    }
+
+    do {
+      try proc.run()
+    } catch {
+      transition(to: .failed(reason: "spawn_failed"))
+      await AppLogger.shared.log(
+        "EG-1 server spawn failed: \(error.localizedDescription)",
+        level: .info, category: "LLM")
+      return
+    }
+    process = proc
+    installMemoryPressureSource()
+
+    let endpoint = EGOneEndpoint(
+      port: port, authToken: token, contextTokens: configuration.contextTokens)
+    // Wait for the HTTP surface to come up (model load can take seconds;
+    // poll /health until 200, the process dying, or budget exhausted).
+    let healthy = await Self.awaitServerUp(
+      endpoint: endpoint,
+      budgetSeconds: configuration.readinessBudgetSeconds,
+      processIsAlive: { [weak proc] in proc?.isRunning ?? false }
+    )
+    // A start/stop/start interleave leaves state `.starting` for the NEW
+    // spawn when THIS spawn's await resumes — the `.starting` check alone
+    // cannot distinguish generations, so a stale failure here would tear
+    // down the successor's process (#1271 matrix gap 1).
+    guard generation == launchGeneration else { return }
+    guard healthy else {
+      // The termination handler may have already routed a startup death to
+      // `.failed(crashed_during_start)`; do not overwrite its diagnosis.
+      if case .starting = state {
+        tearDownProcess()
+        transition(to: .failed(reason: "server_never_became_ready"))
+      }
+      return
+    }
+    // Same race on the success side: only a still-starting spawn may
+    // promote to ready.
+    guard case .starting = state else { return }
+    transition(to: .ready(endpoint))
+    await AppLogger.shared.log(
+      "EG-1 server ready on 127.0.0.1:\(port)", level: .info, category: "LLM")
+  }
+
+  private func handleTermination(configuration: Configuration, generation: Int) async {
+    // A callback QUEUED for an old child can land after stop()+start()
+    // moved this manager to a fresh generation — it must not nil the new
+    // process, mark the new launch crashed, or trigger a rogue restart
+    // (#1271 Codex r12; nulling the handler only covers teardowns WE
+    // initiate, not an already-queued crash callback).
+    guard generation == launchGeneration else { return }
+    // Deliberate teardown paths null the handler first; reaching here
+    // means the child died underneath us.
+    guard case .ready = state else {
+      if case .starting = state { transition(to: .failed(reason: "crashed_during_start")) }
+      return
+    }
+    process = nil
+    if restartedOnceThisGeneration {
+      transition(to: .failed(reason: "crashed_twice"))
+      await AppLogger.shared.log(
+        "EG-1 server crashed twice this session — staying down", level: .info, category: "LLM")
+      return
+    }
+    restartedOnceThisGeneration = true
+    // Go honest IMMEDIATELY: the child is dead, so `.ready` must not
+    // survive the await below — `activeEndpoint()` would hand out a dead
+    // endpoint and `start()` would no-op against a lie (#1271 seam review).
+    transition(to: .starting)
+    await AppLogger.shared.log(
+      "EG-1 server crashed — restarting once", level: .info, category: "LLM")
+    // Actor reentrancy: `stop()` / memory-pressure pause / a fresh `start()`
+    // may have run during the await above — only the crashed generation
+    // (still `.starting`, no new process; this handler nulled `process`
+    // before the await) may restart, or a deactivated provider gets its
+    // multi-GB server resurrected (#1271 Codex r4).
+    guard case .starting = state, process == nil else { return }
+    await spawn(configuration: configuration)
+  }
+
+  /// The limb may never starve the heart: on CRITICAL memory pressure the
+  /// server is terminated and the provider silently skips until the user
+  /// reactivates (or next launch).
+  private func installMemoryPressureSource() {
+    memoryPressureSource?.cancel()
+    let source = DispatchSource.makeMemoryPressureSource(eventMask: .critical)
+    source.setEventHandler { [weak self] in
+      Task { [weak self] in await self?.pauseForMemoryPressure() }
+    }
+    source.activate()
+    memoryPressureSource = source
+  }
+
+  private func pauseForMemoryPressure() async {
+    // `.starting` is INCLUDED: model load is exactly when the child's
+    // footprint ramps, so critical pressure mid-start must kill it too
+    // (#1271 Codex r6). The in-flight spawn self-heals: awaitServerUp bails
+    // when the process dies, and its resume is generation-gated.
+    switch state {
+    case .ready, .starting: break
+    case .stopped, .pausedForMemoryPressure, .failed: return
+    }
+    launchGeneration += 1
+    tearDownProcess()
+    transition(to: .pausedForMemoryPressure)
+    await AppLogger.shared.log(
+      "EG-1 server paused: critical memory pressure", level: .info, category: "LLM")
+  }
+
+  // MARK: - Health probe
+
+  /// Real activation test: a FIXED filler-and-self-correction transcript
+  /// through the real prompt path; GREEN requires the expected
+  /// TRANSFORMATION (contains "Friday", drops "um"), not merely HTTP 200 —
+  /// a model that echoes raw text must read yellow, never green.
+  public func probeHealth(promptFamily: PromptFamily) async -> EGOneHealth {
+    switch state {
+    case .stopped:
+      return .red(reason: "not_running")
+    case .starting:
+      return .yellow(reason: "starting")
+    case .pausedForMemoryPressure:
+      return .yellow(reason: "paused_for_memory")
+    case .failed(let reason):
+      return .red(reason: reason)
+    case .ready(let endpoint):
+      let probeTranscript = "so um move the meeting to thursday no wait friday"
+      let connector = EGOneConnector(endpoint: endpoint)
+      let builder = DefaultPromptPlanner.builder(for: promptFamily)
+      let input = PromptBuildInput(
+        transcript: probeTranscript,
+        provider: .egOne,
+        modelID: LLMProvider.egOneModelName,
+        appName: nil,
+        language: nil,
+        polishVocabulary: PolishVocabulary(terms: [], generation: 0)
+      )
+      let envelope = builder.build(input: input, mode: .message)
+      let config = LLMProviderConfig(
+        model: LLMProvider.egOneModelName,
+        apiKeyKeychainId: nil,
+        maxTokens: 128,
+        temperature: 0,
+        thinkingBudget: nil,
+        reasoningEffort: nil,
+        detectedLanguage: nil
+      )
+      let start = ContinuousClock.now
+      do {
+        let result = try await connector.polish(envelope: envelope, config: config, onToken: nil)
+        let elapsed = ContinuousClock.now - start
+        let output = (result.polishedText ?? "").lowercased()
+        // GREEN requires the FULL transformation: filler dropped AND the
+        // self-correction applied (rejected day + correction phrase gone).
+        // "Move the meeting to Thursday, no wait, Friday." must read
+        // yellow, not Live (#1271 Codex r13).
+        let transformed =
+          output.contains("friday")
+          && output.range(of: "\\bum\\b", options: .regularExpression) == nil
+          && !output.contains("thursday") && !output.contains("no wait")
+        if !transformed {
+          return .yellow(reason: "probe_output_unexpected")
+        }
+        if elapsed > .seconds(5) {
+          return .yellow(reason: "probe_slow")
+        }
+        return .green
+      } catch {
+        return .red(reason: "probe_failed")
+      }
+    }
+  }
+
+  // MARK: - Helpers
+
+  /// Bind port 0, read the kernel-assigned port, release it. A race with
+  /// another process grabbing the port between release and spawn is
+  /// possible but self-healing (spawn fails → failed state → user retry).
+  static func findFreePort() -> UInt16? {
+    let sock = socket(AF_INET, SOCK_STREAM, 0)
+    guard sock >= 0 else { return nil }
+    defer { close(sock) }
+    var addr = sockaddr_in()
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+    addr.sin_port = 0
+    let bindResult = withUnsafePointer(to: &addr) { ptr in
+      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+        bind(sock, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+      }
+    }
+    guard bindResult == 0 else { return nil }
+    var bound = sockaddr_in()
+    var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let nameResult = withUnsafeMutablePointer(to: &bound) { ptr in
+      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+        getsockname(sock, sockaddrPtr, &len)
+      }
+    }
+    guard nameResult == 0 else { return nil }
+    return UInt16(bigEndian: bound.sin_port)
+  }
+
+  static func awaitServerUp(
+    endpoint: EGOneEndpoint, budgetSeconds: Int,
+    processIsAlive: @escaping @Sendable () -> Bool = { true }
+  ) async -> Bool {
+    let deadline = ContinuousClock.now + .seconds(budgetSeconds)
+    guard let healthURL = URL(string: "http://127.0.0.1:\(endpoint.port)/health") else {
+      return false
+    }
+    while ContinuousClock.now < deadline {
+      // A dead child can never become healthy — bail immediately instead
+      // of burning the whole budget (also keeps fake-binary tests fast).
+      guard processIsAlive() else { return false }
+      var request = URLRequest(url: healthURL)
+      request.timeoutInterval = 2
+      request.setValue("Bearer \(endpoint.authToken)", forHTTPHeaderField: "Authorization")
+      if let (_, response) = try? await URLSession.shared.data(for: request),
+        (response as? HTTPURLResponse)?.statusCode == 200
+      {
+        return true
+      }
+      try? await Task.sleep(for: .milliseconds(500))
+    }
+    return false
+  }
+}

--- a/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
+++ b/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
@@ -39,6 +39,10 @@ public struct LLMModelDiscovery: Sendable {
       modelIDs = try await fetchOllamaModels()
     case .appleIntelligence:
       return appleIntelligenceModelInfo()
+    case .egOne:
+      // #1271: fixed first-party model — nothing to discover; the settings
+      // row renders manifest identity from `EGOneRuntime`, not from here.
+      return []
     case .none:
       return []
     }
@@ -326,6 +330,7 @@ public struct LLMModelDiscovery: Sendable {
     case .openAI: return await probeOpenAI(modelID: id, apiKey: apiKey)
     case .ollama: return true  // If model appears in tags list, it's available
     case .appleIntelligence: return true
+    case .egOne: return true  // #1271: availability is the health probe's job, not discovery's
     case .none: return false
     }
   }

--- a/Sources/EnviousWisprLLM/LLMProtocol.swift
+++ b/Sources/EnviousWisprLLM/LLMProtocol.swift
@@ -181,6 +181,14 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
   /// kept distinct from `requestFailed` so it never surfaces as "AI polish
   /// failed" in the UI.
   case outputLanguageDrift(expected: String, actual: String)
+  /// EG-1 (first-party local server) per-request unavailability (#1271).
+  /// Semantics: BYPASS, exactly like the AFM silent-skip family — the user
+  /// gets deterministic-cleaned raw text, no provider stamp, no "AI polish
+  /// failed" pill. The runner adds this to `isSilentPolishSkip` and emits
+  /// `llm.polish_skipped` with the carried reason. NON-retryable by
+  /// `LLMRetryPolicy` (the connector already performs the single
+  /// connection-refused retry that covers the restart-once window).
+  case egOneSkipped(EGOneSkipReason)
   /// A cloud/Ollama polish failure carrying its specific classified reason
   /// (#945). The single adapter that threads the rich `PolishFailureReason`
   /// catalog through the existing `throws LLMError` contract: connectors throw
@@ -207,6 +215,9 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
         "Apple Intelligence does not support the input language '\(code)' for on-device polishing."
     case .outputLanguageDrift(let expected, let actual):
       return "LLM polish output drifted from expected language '\(expected)' to '\(actual)'."
+    case .egOneSkipped(let reason):
+      // Silent bypass — never an on-screen notice; log/debug reads only.
+      return "EG-1 polish skipped (\(reason.rawValue))."
     case .classified(let reason):
       // The user-facing, provider-specific notice is composed by the runner via
       // `reason.composedMessage(provider:)`. This generic description exists only
@@ -231,10 +242,30 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
       return a == b
     case (.outputLanguageDrift(let le, let la), .outputLanguageDrift(let re, let ra)):
       return le == re && la == ra
+    case (.egOneSkipped(let a), .egOneSkipped(let b)):
+      return a == b
     case (.classified(let a), .classified(let b)):
       return a == b
     default:
       return false
     }
   }
+}
+
+/// Why an EG-1 polish was silently bypassed (#1271). Raw values are the
+/// `llm.polish_skipped` telemetry reason strings — one `local_polish_`
+/// prefix so a single analytics query captures every EG-1 skip mode
+/// (mirrors the AFM `context_window_` prefix family).
+public enum EGOneSkipReason: String, Sendable, Equatable {
+  /// Provider selected but no runtime handle / server not ready (booting,
+  /// paused for memory pressure, or failed).
+  case notReady = "local_polish_not_ready"
+  /// Model artifact not downloaded/verified yet.
+  case downloadPending = "local_polish_download_pending"
+  /// Server unreachable mid-request (crashed; connector already retried
+  /// once to cover the restart window).
+  case crashed = "local_polish_crashed"
+  /// Input exceeds the manifest context budget — polish whole or not at
+  /// all, never a silent truncation.
+  case inputTooLong = "local_polish_input_too_long"
 }

--- a/Sources/EnviousWisprLLM/LLMProtocol.swift
+++ b/Sources/EnviousWisprLLM/LLMProtocol.swift
@@ -268,4 +268,9 @@ public enum EGOneSkipReason: String, Sendable, Equatable {
   /// Input exceeds the manifest context budget — polish whole or not at
   /// all, never a silent truncation.
   case inputTooLong = "local_polish_input_too_long"
+  /// The server stopped generation at the max_tokens cap
+  /// (finish_reason == length): the content is a PARTIAL rewrite, and
+  /// pasting it would be exactly the silent truncation the contract
+  /// forbids (#1271 cloud review). Skip whole → raw fallback.
+  case outputTruncated = "local_polish_output_truncated"
 }

--- a/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
+++ b/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
@@ -20,6 +20,12 @@ enum LLMRetryPolicy {
         // fail-fast reasons (out-of-credits, key problems, the Gemini
         // rate-or-quota ambiguity) surface their actionable notice immediately.
         return reason.isRetryable
+      case .egOneSkipped:
+        // EXPLICIT (#1271): EG-1 bypasses are silent skips, and the single
+        // connection-refused retry that covers the server restart-once
+        // window already happened inside `EGOneConnector`. Retrying here
+        // would stack retries and delay the raw-text fallback.
+        return false
       default: return false
       }
     }

--- a/Sources/EnviousWisprLLM/PolishFailureReason.swift
+++ b/Sources/EnviousWisprLLM/PolishFailureReason.swift
@@ -202,9 +202,10 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
       case .requestFailed(let msg):
         return msg.contains("server error") ? .providerServerError : .badRequest
       case .frameworkUnavailable, .modelNotReady,
-        .unsupportedInputLanguage, .outputLanguageDrift:
-        // Apple-Intelligence-only / silent-skip cases the runner never routes
-        // here (AFM is excluded; language gates are silent skips). Defensive.
+        .unsupportedInputLanguage, .outputLanguageDrift, .egOneSkipped:
+        // Silent-skip cases the runner never routes here (AFM is excluded;
+        // language gates and EG-1 bypasses, #1271, are silent skips).
+        // Defensive.
         return .unknown
       }
     }

--- a/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift
+++ b/Sources/EnviousWisprLLM/Prompting/DefaultPromptPlanner.swift
@@ -70,6 +70,12 @@ public struct DefaultPromptPlanner: PromptPlanning {
         return .gemmaFewShot
       }
       return .openAIProse
+    case .egOne:
+      // Native EG-1 (#1271): the bundled first-party server always runs the
+      // model's training prompt. Model identity is manifest-enforced by
+      // `EGOneRuntime` (activation refuses a name/template mismatch), so no
+      // per-model-id heuristics apply here.
+      return .egOneFixed
     case .appleIntelligence, .none:
       // Should not reach planner. Fallback to openAI prose.
       return .openAIProse

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -92,6 +92,10 @@ public enum KernelDictationDriverFactory {
     /// frozen value, so an off-flip stops archiving on the very next
     /// dictation (cloud review, PR #1250).
     package let dictationAudioArchiveOptInProvider: @MainActor () -> Bool
+    /// #1271: EG-1 runtime handle for `LLMPolishStep` — same
+    /// composition-root threading as `keychainManager`. Nil (tests,
+    /// pre-wiring) means every `.egOne` polish silently skips.
+    package let egOneRuntime: (any EGOneEndpointProviding)?
 
     /// Explicit package init: Swift's synthesized memberwise init is `internal`
     /// and would prevent App callers from constructing this struct. `@MainActor`
@@ -109,7 +113,8 @@ public enum KernelDictationDriverFactory {
       pasteCompletionRegistry: PasteCompletionRegistry,
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
-      dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false }
+      dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
+      egOneRuntime: (any EGOneEndpointProviding)? = nil
     ) {
       self.audioCapture = audioCapture
       self.asrManager = asrManager
@@ -121,6 +126,7 @@ public enum KernelDictationDriverFactory {
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
       self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
+      self.egOneRuntime = egOneRuntime
     }
   }
 
@@ -146,6 +152,8 @@ public enum KernelDictationDriverFactory {
     /// dictation-audio archive (#1230). See
     /// `ParakeetInputs.dictationAudioArchiveOptInProvider`.
     package let dictationAudioArchiveOptInProvider: @MainActor () -> Bool
+    /// #1271: EG-1 runtime handle. See `ParakeetInputs.egOneRuntime`.
+    package let egOneRuntime: (any EGOneEndpointProviding)?
 
     /// Explicit package init — same reasoning as `ParakeetInputs.init`.
     /// `languageDetector` is intentionally non-optional (no default) so the
@@ -166,7 +174,8 @@ public enum KernelDictationDriverFactory {
       pasteCompletionRegistry: PasteCompletionRegistry,
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
-      dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false }
+      dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
+      egOneRuntime: (any EGOneEndpointProviding)? = nil
     ) {
       self.audioCapture = audioCapture
       self.whisperKitBackend = whisperKitBackend
@@ -179,6 +188,7 @@ public enum KernelDictationDriverFactory {
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
       self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
+      self.egOneRuntime = egOneRuntime
     }
   }
 
@@ -232,7 +242,8 @@ public enum KernelDictationDriverFactory {
       pasteCompletionRegistry: inputs.pasteCompletionRegistry,
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
-      dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider)
+      dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider,
+      egOneRuntime: inputs.egOneRuntime)
   }
 
   /// Build the driver stack for the WhisperKit engine. PR-5 Rung 5 flips the
@@ -261,7 +272,8 @@ public enum KernelDictationDriverFactory {
       pasteCompletionRegistry: inputs.pasteCompletionRegistry,
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
-      dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider)
+      dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider,
+      egOneRuntime: inputs.egOneRuntime)
   }
 
   /// Engine-agnostic assembler. The two package entry points construct their
@@ -279,13 +291,17 @@ public enum KernelDictationDriverFactory {
     pasteCompletionRegistry: PasteCompletionRegistry,
     captureErrorSink: @escaping HeartPathCaptureErrorSink,
     outputClassifierHolder: OutputClassifierHolder? = nil,
-    dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false }
+    dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
+    egOneRuntime: (any EGOneEndpointProviding)? = nil
   ) -> KernelDictationDriver {
     // 1. LimbSteps — same instances driver + wiring hold by reference.
     // #832/#913 PR8: the live-dictation LLMPolishStep receives the app-owned
     // output-safety classifier holder (read lazily at polish time).
     let llmPolish = LLMPolishStep(keychainManager: keychainManager)
     llmPolish.outputClassifierHolder = outputClassifierHolder
+    // #1271: EG-1 runtime handle (nil-safe — a missing handle means `.egOne`
+    // polishes silently skip, never crash or surface).
+    llmPolish.egOneRuntime = egOneRuntime
     // #761: `emojiRestore` is the final limb, always-on and data-driven (it
     // no-ops when no emoji were dropped) — NOT gated on the converter toggle, so
     // a mid-dictation toggle flip can never strand an already-inserted glyph.

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -59,8 +59,28 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     // Intelligence output (the path where AFM can compose artifacts). Injected
     // via init — fail-open when nil (not yet prewarmed / load failed).
     case .appleIntelligence: AppleIntelligenceConnector(classifier: classifier)
+    // #1271: the EG-1 connector needs the live server endpoint, which this
+    // three-argument seam does not carry. `process()` routes `.egOne`
+    // through `makeEGOnePolisher` + `egOneRuntime` BEFORE consulting this
+    // factory; reaching this case means no runtime handle was injected —
+    // return nil and let the call site's `.egOne` branch throw the silent
+    // bypass (never the surfaced `providerUnavailable`).
+    case .egOne: nil
     case .none: nil
     }
+  }
+
+  /// EG-1 runtime handle (#1271), injected by the composition root through
+  /// `KernelDictationDriverFactory` / `RecoveryTextProcessor` — same
+  /// threading as `keychainManager`. Nil (standalone callsites, tests, or
+  /// pre-wiring) means every `.egOne` polish silently skips.
+  public var egOneRuntime: (any EGOneEndpointProviding)?
+
+  /// Test seam for `.egOne` (mirrors `makePolisher` for the other
+  /// providers): production builds the localhost connector from the live
+  /// endpoint; tests substitute a spy without a real server.
+  var makeEGOnePolisher: @MainActor (EGOneEndpoint) -> any TranscriptPolisher = {
+    EGOneConnector(endpoint: $0)
   }
 
   /// Holds the app-owned output-safety classifier (#832/#913 PR8). Read LAZILY
@@ -86,6 +106,11 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   public var maxDuration: Duration {
     switch llmProvider {
     case .ollama: return .seconds(15)
+    // #1271: EG-1 runs the same class of local generation as Ollama (a 4B
+    // model at local token rates on long dictations) — same 15 s budget,
+    // precedent-cited from the `.ollama` line above. A timeout is a SILENT
+    // skip for this provider (TextProcessingRunner), never a surfaced error.
+    case .egOne: return .seconds(15)
     case .appleIntelligence: return .seconds(10)
     case .openAI, .gemini, .none: return .seconds(5)
     }
@@ -212,8 +237,36 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       )
     }
 
-    guard let polisher = makePolisher(provider, keychainManager, outputClassifierHolder?.classifier)
-    else {
+    // #1271: EG-1 resolves its polisher from the live server endpoint, not
+    // the keychain-shaped factory. Every unavailability here is a SILENT
+    // bypass (`egOneSkipped`), never the surfaced `providerUnavailable` —
+    // a local limb that is not ready must degrade to raw text quietly.
+    let polisher: any TranscriptPolisher
+    if provider == .egOne {
+      guard let runtime = egOneRuntime else {
+        throw LLMError.egOneSkipped(.notReady)
+      }
+      guard let endpoint = await runtime.activeEndpoint() else {
+        throw LLMError.egOneSkipped(.notReady)
+      }
+      // Context preflight: polish whole or skip whole, never a silent
+      // truncation. WORST-CASE on both sides (Codex r15+r16): input at
+      // ~1 token/char (true for unsegmented CJK; a 3x overestimate for
+      // Latin) plus the SAME output cap the request later sends
+      // (`max(text.count, 256)`, r14) plus prompt overhead. Conservative
+      // by design — it bounds polishable dictations at ~8k chars, well
+      // past the product's 5-minute dictation target; anything longer
+      // silently pastes raw rather than risking truncated polish.
+      let outputBudget = max(context.text.count, LLMConstants.ollamaMaxTokens)
+      if context.text.count + outputBudget + 256 > endpoint.contextTokens {
+        throw LLMError.egOneSkipped(.inputTooLong)
+      }
+      polisher = makeEGOnePolisher(endpoint)
+    } else if let made = makePolisher(
+      provider, keychainManager, outputClassifierHolder?.classifier)
+    {
+      polisher = made
+    } else {
       SentryBreadcrumb.captureError(
         LLMError.providerUnavailable, category: .providerInitFailed, stage: "polish")
       throw LLMError.providerUnavailable
@@ -245,6 +298,18 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
           ? LLMConstants.ollamaThinkingMaxTokens
           : LLMConstants.ollamaMaxTokens
         return max(context.text.count / 3 + 100, floor)
+      }
+      if provider == .egOne {
+        // #1271: character-count cap, same CJK-safe shape as the cloud path
+        // below (Codex r14) — the Ollama-style `count/3` estimate assumes
+        // spaced Latin text and under-budgets unsegmented scripts (a 3,000-
+        // char Japanese dictation needs ~3,000 output tokens, not ~1,100),
+        // letting llama-server stop at the cap and paste a TRUNCATED polish.
+        // Latin gets ~4x headroom; the tight 256 floor stays (fixed-prompt
+        // instruct tune, no thinking tokens) and the 15 s budget bounds
+        // wall-clock — an over-long generation now times out to silent raw
+        // instead of truncating.
+        return max(context.text.count, LLMConstants.ollamaMaxTokens)
       }
       // OpenAI reasoning models include reasoning in max_completion_tokens — keep generous.
       if reasoningEffort != nil { return LLMConstants.defaultMaxTokens }
@@ -609,7 +674,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       return (useExtendedThinking ? LLMConstants.defaultThinkingBudget : 0, nil)
     case .openAI:
       return (nil, useExtendedThinking ? "medium" : "low")
-    case .ollama, .appleIntelligence, .none:
+    case .ollama, .appleIntelligence, .egOne, .none:
       return (nil, nil)
     }
   }

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -46,13 +46,17 @@ public final class RecoveryTextProcessor {
   private var recordedLanguage: String?
 
   public init(
-    keychainManager: KeychainManager, outputClassifierHolder: OutputClassifierHolder? = nil
+    keychainManager: KeychainManager, outputClassifierHolder: OutputClassifierHolder? = nil,
+    egOneRuntime: (any EGOneEndpointProviding)? = nil
   ) {
     let llmPolish = LLMPolishStep(keychainManager: keychainManager)
     // Standalone (no live kernel attached): no streaming/lifecycle callbacks.
     llmPolish.onWillProcess = nil
     llmPolish.onToken = nil
     llmPolish.outputClassifierHolder = outputClassifierHolder
+    // #1271: recovery polishes through the SAME EG-1 server as live dictation
+    // (or silently skips when it is not ready) — never crashes on a nil handle.
+    llmPolish.egOneRuntime = egOneRuntime
     // `emojiRestore` is the final limb (#761): always-on and data-driven, it
     // no-ops unless the recovered take polished under Apple Intelligence and a
     // glyph was dropped, so it needs no settings from the snapshot.

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -166,10 +166,18 @@ internal final class TextProcessingRunner {
         // (they signal a transient network issue the user should see).
         let isAppleIntelligencePolishTimeout =
           isTimeout && polishProviderAtStart == .appleIntelligence
+        // #1271: an EG-1 polish timeout (the local 4B model on a very long
+        // dictation) is the same class of silent skip as the AFM timeout —
+        // raw deterministically-cleaned text ships, no "AI polish failed".
+        // Cloud-provider timeouts still surface (transient network signal).
+        let isEGOnePolishTimeout = isTimeout && polishProviderAtStart == .egOne
         let reason: String
         if isAppleIntelligencePolishTimeout {
           reason =
             "skipped: on-device AI polish timed out on a long dictation, using deterministic text"
+        } else if isEGOnePolishTimeout {
+          reason =
+            "skipped: EG-1 polish timed out on a long dictation, using deterministic text"
         } else if isTimeout {
           reason = "timed out"
         } else if let cw = contextWindowSkip {
@@ -194,11 +202,20 @@ internal final class TextProcessingRunner {
         // `providerUnavailable` (Ollama down), `requestFailed` (cloud 5xx),
         // `invalidAPIKey` — locked by the adversarial tests in
         // TextProcessingRunnerTests.
+        // #1271: EVERY `egOneSkipped` reason joins the silent set — the
+        // first-party local limb degrades quietly to deterministic text
+        // (not ready / download pending / crashed / input too long), same
+        // contract as the AFM family above. Locked by the adversarial
+        // tests in TextProcessingRunnerTests.
         let isSilentPolishSkip: Bool
+        var egOneSkipReason: String?
         if let llmError = error as? LLMError {
           switch llmError {
           case .unsupportedInputLanguage, .outputLanguageDrift, .frameworkUnavailable:
             isSilentPolishSkip = true
+          case .egOneSkipped(let skipReason):
+            isSilentPolishSkip = true
+            egOneSkipReason = skipReason.rawValue
           default:
             isSilentPolishSkip = false
           }
@@ -212,6 +229,7 @@ internal final class TextProcessingRunner {
         let isCancellationLike = (error as? URLError)?.code == .cancelled
         if step.errorSurfacePolicy == .surface && !isSilentPolishSkip
           && contextWindowSkip == nil && !isAppleIntelligencePolishTimeout
+          && !isEGOnePolishTimeout
           && !isCancellationLike
         {
           if let provider = polishProviderAtStart, provider != .appleIntelligence {
@@ -266,6 +284,13 @@ internal final class TextProcessingRunner {
         } else if isAppleIntelligencePolishTimeout {
           TelemetryService.shared.polishSkipped(
             provider: LLMProvider.appleIntelligence.rawValue, reason: "context_window_timeout")
+        } else if isEGOnePolishTimeout {
+          // #1271: one `local_polish_` prefix family for every EG-1 skip mode.
+          TelemetryService.shared.polishSkipped(
+            provider: LLMProvider.egOne.rawValue, reason: "local_polish_timeout")
+        } else if let egOneSkipReason {
+          TelemetryService.shared.polishSkipped(
+            provider: LLMProvider.egOne.rawValue, reason: egOneSkipReason)
         }
         // #657 (2026-05-05): emit cap-trip telemetry when WordCorrectionStep
         // exceeds its 3s `maxDuration`. The step's result was discarded; raw

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -107,12 +107,29 @@ public final class SettingsManager {
       // consistent across providers (turning polish off from Apple Intelligence
       // vs OpenAI both read `user`). Only async background discovery
       // (`applyDiscoveredModels`) is `system`.
-      if llmProvider == .appleIntelligence {
-        llmModel = "apple-intelligence"
-      } else if llmModel == "apple-intelligence" || llmModel.isEmpty {
+      canonicalizeLLMModelForProvider()
+      onChange?(.llmProvider)
+    }
+  }
+
+  /// Canonicalize `llmModel` for the current provider (single authority —
+  /// called from the provider didSet AND init). Fixed-literal providers
+  /// (Apple Intelligence, EG-1) pin their literal; switching AWAY from one
+  /// must sweep that literal too, or a cloud provider inherits it as its
+  /// model name and every polish request fails until discovery repairs it
+  /// (#1271 Codex r7: only "apple-intelligence" was swept, so "eg-1"
+  /// leaked into OpenAI/Gemini).
+  private func canonicalizeLLMModelForProvider() {
+    let fixedLiterals = ["apple-intelligence", LLMProvider.egOneModelName]
+    switch llmProvider {
+    case .appleIntelligence:
+      llmModel = "apple-intelligence"
+    case .egOne:
+      llmModel = LLMProvider.egOneModelName
+    case .openAI, .gemini, .ollama, .none:
+      if fixedLiterals.contains(llmModel) || llmModel.isEmpty {
         llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
       }
-      onChange?(.llmProvider)
     }
   }
 
@@ -463,6 +480,9 @@ public final class SettingsManager {
   public var effectiveLLMModel: String {
     switch llmProvider {
     case .appleIntelligence: return "apple-intelligence"
+    // #1271: fixed literal, the apple-intelligence pattern — Services cannot
+    // import the LLM-module manifest; version detail rides eg1.* telemetry.
+    case .egOne: return LLMProvider.egOneModelName
     case .ollama: return ollamaModel
     case .openAI, .gemini, .none: return llmModel
     }
@@ -680,11 +700,7 @@ public final class SettingsManager {
     hasUnreadWhatsNew = (storedWhatsNew != WhatsNewConstants.currentContentVersion)
 
     // Canonicalize provider-coupled model names after all properties are loaded.
-    if llmProvider == .appleIntelligence {
-      llmModel = "apple-intelligence"
-    } else if llmModel == "apple-intelligence" || llmModel.isEmpty {
-      llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
-    }
+    canonicalizeLLMModelForProvider()
   }
 
   /// Apply discovered models from async discovery. SettingsManager decides whether to update.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -781,6 +781,20 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("llm.polish_skipped", properties: props)
   }
 
+  /// #1271: EG-1 native model download funnel + health transitions. Content-
+  /// free by construction: model identity comes from OUR manifest, reasons
+  /// are a closed string set, and no transcript or prompt content exists on
+  /// this path. `eg1.health_changed` is emitted on TRANSITION ONLY (the
+  /// runtime debounces identical states by construction).
+  public func egOneDownloadEvent(name: String, properties: [String: String]) {
+    let event = "eg1.\(name)"
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(name: event, stringProps: properties, boolProps: [:]))
+    #endif
+    PostHogSDK.shared.capture(event, properties: properties)
+  }
+
   public func pasteCompleted(tier: String, targetApp: String?, result: String, latencyMs: Int) {
     var props: [String: Any] = [
       "tier": tier,

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -248,7 +248,7 @@ FluidAudio
 
 --------------------------------------------------------------------------------
 PostHog iOS
-  Version: 3.61.0
+  Version: 3.62.4
   License: MIT
   Source:  https://github.com/PostHog/posthog-ios
 --------------------------------------------------------------------------------
@@ -275,10 +275,37 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+---
+
+Some files in this codebase contain code from getsentry/sentry-cocoa.
+In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 --------------------------------------------------------------------------------
 Sentry Cocoa
-  Version: 9.18.0
+  Version: 9.19.0
   License: MIT
   Source:  https://github.com/getsentry/sentry-cocoa
 --------------------------------------------------------------------------------
@@ -999,6 +1026,36 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+
+--------------------------------------------------------------------------------
+llama.cpp (bundled llama-server binary)
+  Version: fdb1db87
+  License: MIT
+  Source:  https://github.com/ggml-org/llama.cpp
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2023-2026 The ggml authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 --------------------------------------------------------------------------------

--- a/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
@@ -369,6 +369,24 @@ import Testing
       #expect(SettingsProjection.value(for: .llmModel, settings: settings) == "gpt-5-mini")
     }
 
+    @Test("EG-1's fixed literal never leaks into a cloud provider's model")
+    func egOneLiteralSweptOnProviderSwitch() {
+      let suite = UserDefaults(suiteName: "SCT-eg1sweep-\(UUID().uuidString)")!
+      let settings = SettingsManager(defaults: suite)
+      // Apple Intelligence → EG-1 pins the fixed literal.
+      settings.llmProvider = .appleIntelligence
+      settings.llmProvider = .egOne
+      #expect(settings.effectiveLLMModel == LLMProvider.egOneModelName)
+      // Switching to a cloud provider must sweep the literal to that
+      // provider's default (#1271 Codex r7: "eg-1" reached OpenAI as a
+      // model name and every polish call failed until discovery repaired it).
+      settings.llmProvider = .openAI
+      #expect(settings.llmModel == "gpt-4o-mini")
+      settings.llmProvider = .egOne
+      settings.llmProvider = .gemini
+      #expect(settings.llmModel == "gemini-2.0-flash")
+    }
+
     @Test("Language lock projects to mode only, never the code")
     func languageModeProjection() {
       let (settings, telemetry, box, _) = makeHarness()

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -126,13 +126,20 @@ import Testing
   ///   app-quit abandon and the App-layer window-close closure can call it, WITHOUT
   ///   adding a stored property to any coordinator (the #763 direction: many narrow
   ///   homes). The pre-#1176 count was already at the cap (32), so adding one home needs +1.
+  /// - 33 → 34 in #1271 (2026-07-02, EG-1 native integration): App-owned
+  ///   `egOneRuntime` — single owner of the first-party polish model store +
+  ///   inference server, consumed by BOTH the pipeline (endpoint at polish
+  ///   time) and the settings UI (download/health). The composition root is
+  ///   the one valid home for a shared runtime (`state-ownership.md`
+  ///   shared-infra-homes-not-feature-services; council round 1 rejected a
+  ///   settings-setup owner). Plan §3b named this +1 as the accepted cost.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 33,
+      count <= 34,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 33. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 34. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -262,14 +269,24 @@ import Testing
   /// App-layer `prewarmOutputClassifierIfNeeded` catch — its natural emit site. No
   /// new stored property; real wiring, not comment growth. Cap by the deterministic
   /// rule (post-change actual 902 + ~3, rounded up to nearest 5 = 905).
+  /// Ratcheted 905→930 in #1271 (2026-07-02, EG-1 native integration): the
+  /// composition root constructs `EGOneRuntime`, launch-starts it when the
+  /// persisted provider is EG-1, threads it into both kernel-driver input
+  /// structs + the crash-recovery replayer + `PipelineSettingsSync`
+  /// (provider-change lifecycle), installs the telemetry bridge (mapping
+  /// logic itself extracted to `EGOneTelemetryBridge` to keep the root
+  /// thin), kills the child synchronously on terminate, and
+  /// `.environment`-injects it — real wiring for the new App-owned home
+  /// (see the 33→34 stored-property entry above). Cap by the deterministic
+  /// rule (post-change actual 928 + ~2, rounded up to nearest 5 = 930).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 905,
+      lineCount <= 930,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 905. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 930. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/LLM/EGOneManifestTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneManifestTests.swift
@@ -1,0 +1,96 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// EG-1 manifest contract + the stub-URL ship guard (#1271).
+@Suite("EGOneManifest (#1271)")
+struct EGOneManifestTests {
+
+  static func makeManifest(
+    modelName: String = "eg-1",
+    promptTemplateID: String = "eg1-v1",
+    downloadURL: String = "https://models.enviouslabs.co/eg1/eg-1-v1-q5km.gguf"
+  ) -> EGOneManifest {
+    EGOneManifest(
+      modelName: modelName, version: "v1", sha256: String(repeating: "a", count: 64),
+      sizeBytes: 1000, contextTokens: 32768, promptTemplateID: promptTemplateID,
+      minAppVersion: "2.3.0", downloadURL: URL(string: downloadURL)!)
+  }
+
+  @Test func knownTemplateMapsToEGOneFixed() {
+    #expect(Self.makeManifest().promptFamily == .egOneFixed)
+  }
+
+  @Test func unknownTemplateRefusesActivation() {
+    let manifest = Self.makeManifest(promptTemplateID: "eg2-v1")
+    #expect(manifest.promptFamily == nil)
+    #expect(manifest.activationBlockers().contains("unknown_prompt_template"))
+  }
+
+  @Test func modelNameMismatchRefusesActivation() {
+    let manifest = Self.makeManifest(modelName: "eg-2")
+    #expect(manifest.activationBlockers().contains("model_name_mismatch"))
+  }
+
+  @Test func nonHTTPSRefusesActivation() {
+    let manifest = Self.makeManifest(downloadURL: "http://models.enviouslabs.co/x.gguf")
+    #expect(manifest.activationBlockers().contains("non_https_url"))
+  }
+
+  @Test func validManifestHasNoBlockers() {
+    #expect(Self.makeManifest().activationBlockers().isEmpty)
+  }
+
+  @Test func decodeIgnoresUnknownFutureFields() throws {
+    let json = """
+      {"modelName":"eg-1","version":"v1","sha256":"\(String(repeating: "b", count: 64))",
+       "sizeBytes":5,"contextTokens":32768,"promptTemplateID":"eg1-v1",
+       "minAppVersion":"2.3.0","downloadURL":"https://models.enviouslabs.co/x.gguf",
+       "futureField":"ignored","anotherThing":42}
+      """
+    let manifest = try JSONDecoder().decode(EGOneManifest.self, from: Data(json.utf8))
+    #expect(manifest.modelName == "eg-1")
+  }
+
+  @Test func artifactFileNameIsVersioned() {
+    #expect(Self.makeManifest().artifactFileName == "eg-1-v1.gguf")
+  }
+
+  // MARK: - Stub-URL ship guard (#1271, Gate 2)
+
+  /// Parse the CHECKED-IN manifest from its repo path (the same
+  /// parse-the-file-directly mechanism the architecture ceilings/freeze
+  /// tests use — no Bundle access, runs under plain SwiftPM/CI) and assert
+  /// a release can never carry a placeholder: HTTPS, approved first-party
+  /// host, real-looking hash and size, known template, canonical name.
+  @Test func shippedManifestIsNotAStub() throws {
+    let thisFile = URL(fileURLWithPath: #filePath)
+    let repoRoot =
+      thisFile
+      .deletingLastPathComponent()  // LLM
+      .deletingLastPathComponent()  // EnviousWisprTests
+      .deletingLastPathComponent()  // Tests
+      .deletingLastPathComponent()  // repo root
+    let manifestURL = repoRoot.appendingPathComponent(
+      "Sources/EnviousWispr/Resources/eg1-manifest.json")
+    let data = try Data(contentsOf: manifestURL)
+    let manifest = try JSONDecoder().decode(EGOneManifest.self, from: data)
+
+    #expect(manifest.downloadURL.scheme == "https")
+    #expect(manifest.downloadURL.host == "models.enviouslabs.co")
+    let forbidden = ["stub", "example", "invalid", "localhost", "placeholder"]
+    for token in forbidden {
+      #expect(!manifest.downloadURL.absoluteString.lowercased().contains(token))
+    }
+    #expect(manifest.sha256.count == 64)
+    #expect(manifest.sha256.allSatisfy { $0.isHexDigit })
+    // Not a degenerate hash (all one character = placeholder smell).
+    #expect(Set(manifest.sha256).count > 4)
+    #expect(manifest.sizeBytes > 1_000_000_000)  // a real 4B-model GGUF
+    #expect(manifest.modelName == LLMProvider.egOneModelName)
+    #expect(manifest.promptFamily != nil)
+    #expect(manifest.activationBlockers().isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/EGOneModelStoreTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneModelStoreTests.swift
@@ -1,0 +1,381 @@
+import CryptoKit
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// EG-1 model store: checksum gating, install-state truth, remove-model,
+/// and the pure resume-validity decision (#1271). The network fetch is the
+/// only seam not covered here (real-host validation is a PR-1a obligation).
+@Suite("EGOneModelStore (#1271)")
+struct EGOneModelStoreTests {
+
+  /// Manifest whose sha256 matches `content` exactly.
+  static func makeFixture(content: Data) throws -> (
+    store: EGOneModelStore, manifest: EGOneManifest, dir: URL
+  ) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("eg1-store-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let digest = EGOneModelStoreTests.sha256Hex(content)
+    let manifest = EGOneManifest(
+      modelName: "eg-1", version: "v1", sha256: digest, sizeBytes: Int64(content.count),
+      contextTokens: 4096, promptTemplateID: "eg1-v1", minAppVersion: "2.3.0",
+      downloadURL: URL(string: "https://models.enviouslabs.co/eg1/test.gguf")!)
+    return (EGOneModelStore(manifest: manifest, directory: dir), manifest, dir)
+  }
+
+  static func sha256Hex(_ data: Data) -> String {
+    // CryptoKit one-shot — a SEPARATE call path from production's streaming
+    // hash, so a bug in the chunked reader cannot self-confirm here.
+    SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+  }
+
+  @Test func checksumPassInstallsAtomically() async throws {
+    let content = Data("model-bytes-good".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    try await store.verifyAndInstall()
+    let installed = dir.appendingPathComponent(manifest.artifactFileName)
+    #expect(FileManager.default.fileExists(atPath: installed.path))
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: dir.appendingPathComponent("\(manifest.artifactFileName).partial").path))
+    await store.refreshInstalledState()
+    let state = await store.state
+    #expect(state == .installed(version: "v1"))
+  }
+
+  @Test func checksumMismatchDeletesPartialAndNeverInstalls() async throws {
+    let (store, manifest, dir) = try Self.makeFixture(content: Data("expected".utf8))
+    let partial = dir.appendingPathComponent("\(manifest.artifactFileName).partial")
+    try Data("corrupted-bytes".utf8).write(to: partial)
+    await #expect(throws: EGOneModelStore.EGOneDownloadFailure.checksum) {
+      try await store.verifyAndInstall()
+    }
+    #expect(!FileManager.default.fileExists(atPath: partial.path))
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: dir.appendingPathComponent(manifest.artifactFileName).path))
+  }
+
+  @Test func fileWithoutMatchingInstalledManifestIsNotInstalled() async throws {
+    let content = Data("model-bytes".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    // Artifact present but NO installed-manifest.json → not installed.
+    try content.write(to: dir.appendingPathComponent(manifest.artifactFileName))
+    await store.refreshInstalledState()
+    let state = await store.state
+    #expect(state == .notInstalled)
+  }
+
+  @Test func installedManifestShaMismatchIsNotInstalled() async throws {
+    let content = Data("model-bytes".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent(manifest.artifactFileName))
+    // Installed-manifest recorded for a DIFFERENT artifact (sha mismatch).
+    let other = EGOneManifest(
+      modelName: "eg-1", version: "v0", sha256: String(repeating: "0", count: 64),
+      sizeBytes: 1, contextTokens: 4096, promptTemplateID: "eg1-v1",
+      minAppVersion: "2.3.0", downloadURL: manifest.downloadURL)
+    try JSONEncoder().encode(other).write(
+      to: dir.appendingPathComponent("installed-manifest.json"))
+    await store.refreshInstalledState()
+    let state = await store.state
+    #expect(state == .notInstalled)
+  }
+
+  @Test func removeModelDeletesEverything() async throws {
+    let content = Data("model-bytes".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    try await store.verifyAndInstall()
+    try await store.removeModel()
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: dir.appendingPathComponent(manifest.artifactFileName).path))
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: dir.appendingPathComponent("installed-manifest.json").path))
+    let state = await store.state
+    #expect(state == .notInstalled)
+  }
+
+  /// Codex r1 P2 regression lock: a COMPLETE partial (app quit between
+  /// fetch and verify) must go straight to verification and install —
+  /// never a Range request answered 416 that strands every retry as
+  /// range_unsupported. Proof of no-network: the whole download path runs
+  /// to `.installed` end-to-end with no server behind the manifest URL.
+  @Test func completePartialInstallsWithoutNetwork() async throws {
+    let content = Data("complete-partial-bytes".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    await store.startDownload()
+    // Poll the actor state to terminal (download task is fire-and-forget).
+    var state = await store.state
+    for _ in 0..<100 {
+      if case .installed = state { break }
+      if case .failed = state { break }
+      try await Task.sleep(for: .milliseconds(50))
+      state = await store.state
+    }
+    #expect(state == .installed(version: "v1"))
+    #expect(
+      FileManager.default.fileExists(
+        atPath: dir.appendingPathComponent(manifest.artifactFileName).path))
+  }
+
+  // MARK: - Resume-validity decision (pure)
+
+  @Test func resumeDiscardedWhenNoIdentityRecorded() {
+    #expect(
+      EGOneModelStore.shouldDiscardPartial(
+        recordedETag: nil, recordedLength: nil,
+        headETag: "abc", headLength: 100, existingBytes: 50, expectedSize: 100))
+  }
+
+  @Test func resumeDiscardedWhenRemoteObjectChanged() {
+    #expect(
+      EGOneModelStore.shouldDiscardPartial(
+        recordedETag: .some("old-etag"), recordedLength: .some(100),
+        headETag: "new-etag", headLength: 100, existingBytes: 50, expectedSize: 100))
+  }
+
+  @Test func resumeDiscardedWhenPartialImpossiblyLarge() {
+    #expect(
+      EGOneModelStore.shouldDiscardPartial(
+        recordedETag: .some("etag"), recordedLength: .some(100),
+        headETag: "etag", headLength: 100, existingBytes: 150, expectedSize: 100))
+  }
+
+  @Test func resumeKeptWhenIdentityMatches() {
+    #expect(
+      !EGOneModelStore.shouldDiscardPartial(
+        recordedETag: .some("etag"), recordedLength: .some(100),
+        headETag: "etag", headLength: 100, existingBytes: 50, expectedSize: 100))
+  }
+
+  // MARK: - Cancel during verification (#1271 matrix gap 2)
+
+  /// A cancel that lands during the seconds-long hash must not install the
+  /// model afterwards — the detached hash does not inherit cancellation, so
+  /// `verifyAndInstall` gates on it explicitly.
+  @Test func cancelDuringVerifyDoesNotInstall() async throws {
+    let content = Data("model-bytes-cancel-verify".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    let task = Task { () -> Bool in
+      withUnsafeCurrentTask { $0?.cancel() }
+      do {
+        try await store.verifyAndInstall()
+        return false
+      } catch is CancellationError {
+        return true
+      } catch {
+        return false
+      }
+    }
+    #expect(await task.value, "expected CancellationError, not install or another error")
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: dir.appendingPathComponent(manifest.artifactFileName).path))
+  }
+
+  // MARK: - Hot-swap hygiene: previous-version artifacts purged (#1271 r11)
+
+  /// A manifest bump changes `artifactFileName`; refresh must reclaim the
+  /// old multi-GB file family, and must NOT touch the current one.
+  @Test func refreshPurgesPreviousManifestArtifacts() async throws {
+    let content = Data("model-bytes-current".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    try await store.verifyAndInstall()
+
+    let staleArtifact = dir.appendingPathComponent("eg-1-v0.gguf")
+    let stalePartial = dir.appendingPathComponent("eg-1-v0.gguf.partial")
+    let staleIdentity = dir.appendingPathComponent("eg-1-v0.gguf.resume.json")
+    let unrelated = dir.appendingPathComponent("notes.txt")
+    for url in [staleArtifact, stalePartial, staleIdentity, unrelated] {
+      try Data("stale".utf8).write(to: url)
+    }
+
+    await store.refreshInstalledState()
+    let state = await store.state
+    #expect(state == .installed(version: "v1"))
+    for url in [staleArtifact, stalePartial, staleIdentity] {
+      #expect(!FileManager.default.fileExists(atPath: url.path), "\(url.lastPathComponent)")
+    }
+    // Extension-scoped: files outside the store's family are never touched.
+    #expect(FileManager.default.fileExists(atPath: unrelated.path))
+    #expect(
+      FileManager.default.fileExists(
+        atPath: dir.appendingPathComponent(manifest.artifactFileName).path))
+  }
+
+  // MARK: - startDownload no-ops from non-startable states (#1271 seam review)
+
+  /// A tap while installed (or verifying) must not emit a spurious
+  /// downloadStarted event or re-stamp the duration clock.
+  @Test @MainActor func startDownloadFromInstalledEmitsNothing() async throws {
+    let content = Data("model-bytes-installed-noop".utf8)
+    let (seedStore, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    try await seedStore.verifyAndInstall()
+
+    let runtime = EGOneRuntime(manifest: manifest, serverBinaryURL: nil, storeDirectory: dir)
+    // Let the init-time refresh land `.installed` before poking it.
+    for _ in 0..<50 where runtime.installState == .notInstalled {
+      try await Task.sleep(for: .milliseconds(20))
+    }
+    #expect(runtime.installState == .installed(version: "v1"))
+
+    nonisolated(unsafe) var events: [EGOneRuntimeEvent] = []
+    runtime.onEvent = { event in
+      Task { @MainActor in events.append(event) }
+    }
+    runtime.startDownload()
+    try await Task.sleep(for: .milliseconds(200))
+    #expect(events.isEmpty)
+    #expect(runtime.installState == .installed(version: "v1"))
+  }
+
+  // MARK: - Deferred removal cancelled by re-selection (#1271 seam review P1)
+
+  /// Remove Model during a pinned recording defers; the user re-selecting
+  /// EG-1 before the recording ends must CANCEL that deferred removal, or
+  /// the terminal-state retry deletes the model they just re-picked.
+  @Test @MainActor func reselectingEGOneCancelsDeferredRemoval() async throws {
+    let content = Data("model-bytes-keep-me".utf8)
+    let (seedStore, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    try await seedStore.verifyAndInstall()
+    let artifact = dir.appendingPathComponent(manifest.artifactFileName)
+
+    let runtime = EGOneRuntime(manifest: manifest, serverBinaryURL: nil, storeDirectory: dir)
+    runtime.isPinnedInFlight = { true }
+    runtime.removeModel()  // recording pinned — defers
+    runtime.activateAndProbe()  // user re-selects EG-1 — must cancel the pending removal
+    runtime.isPinnedInFlight = { false }
+    runtime.retryPendingRemoval()  // terminal-state retry must now no-op
+    try await Task.sleep(for: .milliseconds(300))
+    #expect(FileManager.default.fileExists(atPath: artifact.path))
+  }
+
+  // MARK: - 416 cleanup + failure-state stickiness (#1271 seam review)
+
+  /// A 416 (range refused) can never heal by retrying the identical Range
+  /// request — cleanup must drop the partial + identity so retry restarts.
+  @Test func rangeUnsupportedCleanupDiscardsPartialAndIdentity() async throws {
+    let (store, manifest, dir) = try Self.makeFixture(content: Data("x".utf8))
+    let partial = dir.appendingPathComponent("\(manifest.artifactFileName).partial")
+    let identity = dir.appendingPathComponent("\(manifest.artifactFileName).resume.json")
+    try Data("p".utf8).write(to: partial)
+    try Data("{}".utf8).write(to: identity)
+    await store.discardPartialArtifacts()
+    #expect(!FileManager.default.fileExists(atPath: partial.path))
+    #expect(!FileManager.default.fileExists(atPath: identity.path))
+  }
+
+  /// Hostless manifest URLs fail closed as stub URLs (the old optional-chained
+  /// check let them through), and a `.failed` state survives a reactive
+  /// refresh so the user can actually read the failure.
+  @Test func hostlessURLFailsClosedAndFailureSurvivesRefresh() async throws {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("eg1-stub-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let manifest = EGOneManifest(
+      modelName: "eg-1", version: "v1", sha256: "00", sizeBytes: 1,
+      contextTokens: 4096, promptTemplateID: "eg1-v1", minAppVersion: "2.3.0",
+      downloadURL: URL(string: "https:///eg1/test.gguf")!)
+    let store = EGOneModelStore(manifest: manifest, directory: dir)
+    await store.startDownload()
+    #expect(await store.state == .failed(.stubURL))
+    await store.refreshInstalledState()
+    #expect(await store.state == .failed(.stubURL))
+  }
+
+  // MARK: - Disk vs network failure classification (#1271 confirm round)
+
+  @Test func diskWriteErrorsClassifyAsDiskNotNetwork() {
+    #expect(
+      EGOneModelStore.isDiskWriteError(
+        NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError)))
+    #expect(
+      EGOneModelStore.isDiskWriteError(
+        NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC))))
+    // Transport errors stay network.
+    #expect(!EGOneModelStore.isDiskWriteError(URLError(.networkConnectionLost)))
+    // File-READ errors (missing partial) are not the write family.
+    #expect(
+      !EGOneModelStore.isDiskWriteError(
+        NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoSuchFileError)))
+  }
+
+  // MARK: - Resume telemetry truth (#1271 matrix gap 4)
+
+  @Test func hasPartialDownloadReflectsDisk() async throws {
+    let content = Data("model-bytes-partial-flag".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    #expect(await store.hasPartialDownload == false)
+    try Data("some-bytes".utf8).write(
+      to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    #expect(await store.hasPartialDownload == true)
+  }
+
+  // MARK: - Stale progress ordering (#1271 Codex r5)
+
+  /// Progress callbacks re-enter the actor as independent tasks; one that
+  /// lands AFTER a terminal transition must not regress the state to
+  /// `.downloading` (stuck UI until the next refresh), and one from a
+  /// SUPERSEDED download generation must not publish at all.
+  @Test func lateProgressCannotRegressTerminalState() async throws {
+    let content = Data("model-bytes-progress".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+
+    // Not started yet: progress is a no-op (state gate).
+    await store.applyDownloadProgress(0.5, generation: 0)
+    var state = await store.state
+    #expect(state == .notInstalled)
+
+    // Stale generation: rejected before the state gate is even consulted.
+    await store.applyDownloadProgress(0.5, generation: 99)
+    state = await store.state
+    #expect(state == .notInstalled)
+
+    // Installed: a straggler progress task must not flip it back.
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    try await store.verifyAndInstall()
+    await store.refreshInstalledState()
+    await store.applyDownloadProgress(0.9, generation: 0)
+    state = await store.state
+    #expect(state == .installed(version: "v1"))
+  }
+
+  // MARK: - Download-completion keyed off the request flag (#1271 Codex r17)
+
+  /// `.installed` re-emissions from refreshes (launch, activation, settings
+  /// open) must NOT read as a download completion — no completion event, no
+  /// auto-activate loop. Only a store-ACCEPTED download arms the flag; this
+  /// runtime never started one, so repeated refreshes stay silent.
+  @Test @MainActor func installedRefreshWithoutRequestEmitsNoCompletion() async throws {
+    let content = Data("model-bytes-no-request".utf8)
+    let (seedStore, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+    try await seedStore.verifyAndInstall()
+
+    let runtime = EGOneRuntime(manifest: manifest, serverBinaryURL: nil, storeDirectory: dir)
+    nonisolated(unsafe) var completions = 0
+    runtime.onEvent = { event in
+      if case .downloadCompleted = event {
+        Task { @MainActor in completions += 1 }
+      }
+    }
+    // Drive several reactive refreshes (the loop the r4 P1 guard prevents).
+    runtime.activateAndProbe()
+    runtime.activateAndProbe()
+    try await Task.sleep(for: .milliseconds(400))
+    #expect(completions == 0)
+    #expect(runtime.installState == .installed(version: "v1"))
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/EGOneServerManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneServerManagerTests.swift
@@ -1,0 +1,167 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// EG-1 server lifecycle with a FAKE binary (#1271) — spawn, crash,
+/// restart-once, missing-binary/model, port strategy. No real model, no
+/// network inference; the real-binary integration validation is a separate
+/// PR-1a obligation.
+@Suite("EGOneServerManager (#1271)", .serialized)
+struct EGOneServerManagerTests {
+
+  /// A fake "server" configuration. The default binary (`/bin/sleep`)
+  /// rejects the llama-style arguments and exits immediately — a process
+  /// that dies during startup. The readiness budget is shrunk to seconds so
+  /// never-healthy cases fail fast (the manager also bails as soon as the
+  /// child dies, so these tests do not burn the budget at all).
+  static func fakeServerConfiguration(modelExists: Bool = true) throws
+    -> EGOneServerManager.Configuration
+  {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("eg1-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let model = dir.appendingPathComponent("model.gguf")
+    if modelExists {
+      try Data("fake".utf8).write(to: model)
+    }
+    return EGOneServerManager.Configuration(
+      serverBinaryURL: URL(fileURLWithPath: "/bin/sleep"),
+      modelURL: model,
+      contextTokens: 4096,
+      readinessBudgetSeconds: 3
+    )
+  }
+
+  @Test func missingBinaryFailsClosed() async throws {
+    let manager = EGOneServerManager()
+    var config = try Self.fakeServerConfiguration()
+    config.serverBinaryURL = URL(fileURLWithPath: "/nonexistent/llama-server")
+    await manager.start(configuration: config)
+    let state = await manager.state
+    #expect(state == .failed(reason: "server_binary_missing"))
+    let endpoint = await manager.activeEndpoint()
+    #expect(endpoint == nil)
+  }
+
+  @Test func missingModelFailsClosed() async throws {
+    let manager = EGOneServerManager()
+    let config = try Self.fakeServerConfiguration(modelExists: false)
+    await manager.start(configuration: config)
+    let state = await manager.state
+    #expect(state == .failed(reason: "model_missing"))
+  }
+
+  @Test func findFreePortReturnsUsablePort() {
+    let port = EGOneServerManager.findFreePort()
+    #expect(port != nil)
+    #expect(port! > 0)
+  }
+
+  @Test func stoppedManagerHasNoEndpoint() async {
+    let manager = EGOneServerManager()
+    let endpoint = await manager.activeEndpoint()
+    #expect(endpoint == nil)
+    let health = await manager.probeHealth(promptFamily: .egOneFixed)
+    #expect(health == .red(reason: "not_running"))
+  }
+
+  @Test func healthProjectionsForNonReadyStates() async throws {
+    let manager = EGOneServerManager()
+    // failed state → red with the failure reason
+    var config = try Self.fakeServerConfiguration()
+    config.serverBinaryURL = URL(fileURLWithPath: "/nonexistent/llama-server")
+    await manager.start(configuration: config)
+    let health = await manager.probeHealth(promptFamily: .egOneFixed)
+    #expect(health == .red(reason: "server_binary_missing"))
+  }
+
+  /// A spawned process that never opens the health endpoint must land in
+  /// `failed(server_never_became_ready)` — bounded by the readiness budget.
+  /// Uses a 1-second sleep as the fake server so the process EXITS quickly;
+  /// the manager observes the death during `starting` and fails closed.
+  @Test func serverThatDiesDuringStartFailsClosed() async throws {
+    let manager = EGOneServerManager()
+    var config = try Self.fakeServerConfiguration()
+    // /bin/true exits immediately — a spawn that dies during startup.
+    config.serverBinaryURL = URL(fileURLWithPath: "/usr/bin/true")
+    config.extraArguments = []
+    await manager.start(configuration: config)
+    // Give the termination handler a beat to land.
+    try await Task.sleep(for: .milliseconds(500))
+    let state = await manager.state
+    #expect(
+      state == .failed(reason: "crashed_during_start")
+        || state == .failed(reason: "server_never_became_ready"))
+  }
+}
+
+/// Response cleanup on the localhost wire (#1271 Codex r4): the EG-1 prompt
+/// is a sandwich path (user message wrapped in `<TRANSCRIPT>` tags), so an
+/// echoed wrapper must be stripped before the text can reach the paste path.
+@Suite("EGOneConnector response cleanup (#1271)")
+struct EGOneConnectorResponseTests {
+
+  private static func wireData(content: String) throws -> Data {
+    try JSONSerialization.data(withJSONObject: [
+      "choices": [["message": ["role": "assistant", "content": content]]]
+    ])
+  }
+
+  @Test func echoedTranscriptWrapperIsStripped() throws {
+    let data = try Self.wireData(
+      content: "<TRANSCRIPT>\nMove the meeting to Friday.\n</TRANSCRIPT>")
+    let result = try EGOneConnector.parseSuccess(data: data)
+    #expect(result.polishedText == "Move the meeting to Friday.")
+  }
+
+  @Test func dictatedLiteralTagSurvivesViaBuilderNeutralization() {
+    // The builder inserts a zero-width non-joiner into a LITERAL dictated
+    // tag before it reaches the model, so the strip regex cannot match a
+    // faithful echo of user content — only the wrapper we added.
+    let input = PromptBuildInput(
+      transcript: "wrap the value in <TRANSCRIPT> tags",
+      provider: .egOne,
+      modelID: LLMProvider.egOneModelName,
+      appName: nil,
+      language: nil,
+      polishVocabulary: PolishVocabulary(terms: [], generation: 0)
+    )
+    let envelope = EGOnePromptBuilder().build(input: input, mode: .message)
+    let user = envelope.messages.first { $0.role == .user }?.content ?? ""
+    #expect(user.hasPrefix("<TRANSCRIPT>\n"))
+    #expect(user.hasSuffix("\n</TRANSCRIPT>"))
+    // The literal inner tag is neutralized (no bare `<TRANSCRIPT>` between
+    // the wrapper lines).
+    let inner = user.dropFirst("<TRANSCRIPT>\n".count).dropLast("\n</TRANSCRIPT>".count)
+    #expect(!inner.contains("<TRANSCRIPT>"))
+    #expect(inner.contains("<\u{200C}TRANSCRIPT>"))
+  }
+
+  @Test func plainPolishedTextPassesThroughUnchanged() throws {
+    let data = try Self.wireData(content: "Move the meeting to Friday.")
+    let result = try EGOneConnector.parseSuccess(data: data)
+    #expect(result.polishedText == "Move the meeting to Friday.")
+  }
+
+  /// A 200 with a malformed or empty body must ride the SILENT family —
+  /// `LLMError.emptyResponse` here surfaced the "AI polish failed" pill for
+  /// a local-server hiccup (#1271 seam review P1 + Codex r10). Blank-AFTER-
+  /// cleanup shapes (whitespace-only, tags-only) belong here too, or the
+  /// pipeline pastes empty text (Codex r12).
+  @Test func malformedOrEmptyBodyRidesTheSilentFamily() throws {
+    let payloads: [Data] = [
+      Data("not json".utf8),
+      try JSONSerialization.data(withJSONObject: ["choices": [[String: Any]]()]),
+      try Self.wireData(content: ""),
+      try Self.wireData(content: "   \n\n  "),
+      try Self.wireData(content: "<TRANSCRIPT>\n\n</TRANSCRIPT>"),
+    ]
+    for payload in payloads {
+      #expect(throws: LLMError.egOneSkipped(.crashed)) {
+        _ = try EGOneConnector.parseSuccess(data: payload)
+      }
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/EGOneServerManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneServerManagerTests.swift
@@ -103,10 +103,23 @@ struct EGOneServerManagerTests {
 @Suite("EGOneConnector response cleanup (#1271)")
 struct EGOneConnectorResponseTests {
 
-  private static func wireData(content: String) throws -> Data {
+  private static func wireData(content: String, finishReason: String = "stop") throws -> Data {
     try JSONSerialization.data(withJSONObject: [
-      "choices": [["message": ["role": "assistant", "content": content]]]
+      "choices": [
+        ["message": ["role": "assistant", "content": content], "finish_reason": finishReason]
+      ]
     ])
+  }
+
+  /// finish_reason == length means the content is a PARTIAL rewrite — it
+  /// must skip whole (silent raw), never paste truncated polish
+  /// (#1271 cloud review P2).
+  @Test func lengthFinishSkipsWholeInsteadOfPastingTruncation() throws {
+    let data = try Self.wireData(
+      content: "Move the meeting to", finishReason: "length")
+    #expect(throws: LLMError.egOneSkipped(.outputTruncated)) {
+      _ = try EGOneConnector.parseSuccess(data: data)
+    }
   }
 
   @Test func echoedTranscriptWrapperIsStripped() throws {

--- a/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
@@ -1,0 +1,186 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+@testable import EnviousWisprPipeline
+
+/// EG-1 native pipeline routing + silent-skip contract (#1271):
+/// - `.egOne` resolves through `egOneRuntime` (never the keychain factory);
+/// - every unavailability is a SILENT bypass (no polish error, no capture,
+///   raw text preserved, no provider stamp);
+/// - a healthy endpoint routes to the EG-1 polisher and stamps normally;
+/// - context preflight skips whole (never truncates);
+/// - retry policy treats EG-1 skips as non-retryable.
+@MainActor
+@Suite("EG-1 pipeline routing (#1271)")
+struct EGOnePipelineRoutingTests {
+
+  private static let longTranscript =
+    "so i was thinking we could maybe ship the new thing some time next week or so"
+
+  @MainActor
+  final class FakeRuntime: EGOneEndpointProviding {
+    var endpoint: EGOneEndpoint?
+    init(endpoint: EGOneEndpoint? = nil) { self.endpoint = endpoint }
+    func activeEndpoint() async -> EGOneEndpoint? { endpoint }
+  }
+
+  private struct CannedPolisher: TranscriptPolisher {
+    let output: String
+    func polish(
+      text: String, instructions: PolishInstructions, config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      LLMResult(polishedText: output)
+    }
+  }
+
+  @MainActor
+  final class CaptureSpy {
+    private(set) var count = 0
+    func sink(
+      _ error: any Error, _ category: SentryBreadcrumb.ErrorCategory,
+      _ stage: String, _ extra: [String: Any]?, _ tags: [String: String],
+      _ fingerprintDetail: String?
+    ) { count += 1 }
+  }
+
+  private func makeStep(runtime: FakeRuntime?) -> LLMPolishStep {
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .egOne
+    step.llmModel = LLMProvider.egOneModelName
+    step.egOneRuntime = runtime
+    return step
+  }
+
+  private func run(_ step: LLMPolishStep, spy: CaptureSpy) async throws
+    -> TextProcessingRunResult
+  {
+    let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
+    let runner = TextProcessingRunner(captureError: spy.sink, timeoutExecutor: executor.run)
+    return try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+  }
+
+  // MARK: - Silent bypasses
+
+  @Test("no runtime handle -> silent raw fallback, no capture, no stamp")
+  func missingRuntimeIsSilent() async throws {
+    let spy = CaptureSpy()
+    let result = try await run(makeStep(runtime: nil), spy: spy)
+    #expect(result.polishError == nil)
+    #expect(spy.count == 0)
+    #expect(result.context.text == Self.longTranscript)
+    #expect(result.context.polishedText == nil)
+    #expect(result.context.llmProvider == nil)
+  }
+
+  @Test("runtime present but server not ready -> silent raw fallback")
+  func notReadyEndpointIsSilent() async throws {
+    let spy = CaptureSpy()
+    let result = try await run(makeStep(runtime: FakeRuntime(endpoint: nil)), spy: spy)
+    #expect(result.polishError == nil)
+    #expect(spy.count == 0)
+    #expect(result.context.polishedText == nil)
+  }
+
+  @Test("input over context budget -> silent whole-skip, never truncation")
+  func overBudgetInputSkipsWhole() async throws {
+    let spy = CaptureSpy()
+    // Tiny context window: the 16-word transcript over-budgets it.
+    let runtime = FakeRuntime(
+      endpoint: EGOneEndpoint(port: 1, authToken: "t", contextTokens: 16))
+    let step = makeStep(runtime: runtime)
+    step.makeEGOnePolisher = { _ in CannedPolisher(output: "MUST NOT BE USED") }
+    let result = try await run(step, spy: spy)
+    #expect(result.polishError == nil)
+    #expect(result.context.polishedText == nil)
+    #expect(result.context.text == Self.longTranscript)
+  }
+
+  // MARK: - Healthy path
+
+  @Test("ready endpoint routes to EG-1 polisher and stamps provider")
+  func healthyEndpointPolishes() async throws {
+    let spy = CaptureSpy()
+    let runtime = FakeRuntime(
+      endpoint: EGOneEndpoint(port: 1, authToken: "t", contextTokens: 32768))
+    let step = makeStep(runtime: runtime)
+    step.makeEGOnePolisher = { endpoint in
+      #expect(endpoint.authToken == "t")
+      return CannedPolisher(output: "I was thinking we could ship the new thing next week.")
+    }
+    let result = try await run(step, spy: spy)
+    #expect(result.polishError == nil)
+    #expect(
+      result.context.polishedText == "I was thinking we could ship the new thing next week.")
+    #expect(result.context.llmProvider == LLMProvider.egOne.rawValue)
+    #expect(result.context.llmModel == LLMProvider.egOneModelName)
+  }
+
+  @Test("keychain factory is never consulted for .egOne")
+  func keychainFactoryNotUsed() async throws {
+    let spy = CaptureSpy()
+    let runtime = FakeRuntime(
+      endpoint: EGOneEndpoint(port: 1, authToken: "t", contextTokens: 32768))
+    let step = makeStep(runtime: runtime)
+    var legacyFactoryCalled = false
+    step.makePolisher = { _, _, _ in
+      legacyFactoryCalled = true
+      return nil
+    }
+    step.makeEGOnePolisher = { _ in CannedPolisher(output: "ok output text") }
+    _ = try await run(step, spy: spy)
+    #expect(!legacyFactoryCalled)
+  }
+
+  // MARK: - Contract lookalikes must NOT be silent
+
+  @Test("a genuine surfaced error family still surfaces for cloud providers")
+  func cloudErrorsStillSurface() async throws {
+    // Guard against over-widening the silent set: an Ollama provider-down
+    // error must still surface (adversarial pairing for the new branch).
+    let spy = CaptureSpy()
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .ollama
+    step.llmModel = "llama3.2"
+    struct Down: TranscriptPolisher {
+      func polish(
+        text: String, instructions: PolishInstructions, config: LLMProviderConfig,
+        onToken: (@Sendable (String) -> Void)?
+      ) async throws -> LLMResult { throw LLMError.providerUnavailable }
+    }
+    step.makePolisher = { _, _, _ in Down() }
+    let result = try await run(step, spy: spy)
+    #expect(result.polishError != nil)
+  }
+
+  // MARK: - Retry policy
+
+  @Test("egOneSkipped is explicitly non-retryable")
+  func egOneSkipsAreNotRetryable() {
+    #expect(!LLMRetryPolicy.isRetryable(LLMError.egOneSkipped(.crashed)))
+    #expect(!LLMRetryPolicy.isRetryable(LLMError.egOneSkipped(.notReady)))
+    #expect(!LLMRetryPolicy.isRetryable(LLMError.egOneSkipped(.downloadPending)))
+    #expect(!LLMRetryPolicy.isRetryable(LLMError.egOneSkipped(.inputTooLong)))
+  }
+
+  // MARK: - Planner routing
+
+  @Test("planner maps .egOne to the egOneFixed family regardless of model id")
+  func plannerRoutesEGOne() {
+    #expect(DefaultPromptPlanner.family(for: .egOne, modelID: "eg-1") == .egOneFixed)
+    #expect(DefaultPromptPlanner.family(for: .egOne, modelID: "anything") == .egOneFixed)
+  }
+
+  @Test("skip reasons carry the local_polish_ telemetry prefix")
+  func skipReasonPrefixes() {
+    for reason in [
+      EGOneSkipReason.notReady, .downloadPending, .crashed, .inputTooLong,
+    ] {
+      #expect(reason.rawValue.hasPrefix("local_polish_"))
+    }
+  }
+}

--- a/scripts/build-dev-app.sh
+++ b/scripts/build-dev-app.sh
@@ -103,6 +103,13 @@ echo "==> Step 7: Verifying deployed bundle..."
   || { echo "ERROR: audio XPC id mismatch"; exit 1; }
 [ "$(plutil -extract CFBundleIdentifier raw "$APP_PATH/Contents/XPCServices/$ASR_XPC/Contents/Info.plist")" = "$ASR_XPC_ID" ] \
   || { echo "ERROR: asr XPC id mismatch"; exit 1; }
+# #1271: EG-1 inference server + manifest must ship in Resources. On dev the
+# binary runs with its ad-hoc linker signature (no hardened runtime); release
+# signs it Developer ID in build-release-dmg.sh step [5.5/6].
+[ -x "$APP_PATH/Contents/Resources/llama-server" ] \
+  || { echo "ERROR: EG-1 llama-server missing from Resources (#1271)"; exit 1; }
+[ -f "$APP_PATH/Contents/Resources/eg1-manifest.json" ] \
+  || { echo "ERROR: eg1-manifest.json missing from Resources (#1271)"; exit 1; }
 
 # Post-copy signature verification (non-strict: ditto+xattr can perturb xattrs
 # but not the seal; this confirms the copied bundle is still validly signed).

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -211,6 +211,18 @@ else
         codesign "${SIGN_FLAGS[@]}" --entitlements "$ENT" "$XPC_SVC"
     done
     test -n "$AUDIO_XPC"; test -n "$ASR_XPC"
+    # 5.5. EG-1 inference server (#1271) — a bare Mach-O in Contents/Resources,
+    # signed like Sparkle's Autoupdate (a missed bare Mach-O is exactly the
+    # class that failed v1.5.2/v1.5.3 notarization). Must be sealed BEFORE the
+    # main-app signature covers the bundle.
+    EG1_SERVER="$BUNDLE/Contents/Resources/llama-server"
+    if [[ -f "$EG1_SERVER" ]]; then
+        echo "    [5.5/6] eg-1 server: llama-server"
+        codesign "${SIGN_FLAGS[@]}" "$EG1_SERVER"
+    else
+        echo "::error::EG-1 llama-server missing from Contents/Resources (#1271)"
+        exit 1
+    fi
     # 6. Embed the Developer ID provisioning profile, THEN the main app bundle.
     # keychain-access-groups is a RESTRICTED entitlement; AMFI requires the embedded
     # profile to authorize it at launch (TN3125). The profile is sealed by the

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -32,14 +32,19 @@ CO="${PROJ_ROOT}/.build/checkouts"
 COMPONENTS=(
   "WhisperKit (argmax-oss-swift)|1.0.0|MIT|argmax-oss-swift/LICENSE|https://github.com/argmaxinc/argmax-oss-swift|argmax-oss-swift"
   "FluidAudio|d5fcca4f (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
-  "PostHog iOS|3.61.0|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
-  "Sentry Cocoa|9.18.0|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
+  "PostHog iOS|3.62.4|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
+  "Sentry Cocoa|9.19.0|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
   "Sparkle|2.9.3|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"
   "swift-argument-parser|1.7.1|Apache-2.0|swift-argument-parser/LICENSE.txt|https://github.com/apple/swift-argument-parser|swift-argument-parser"
   "fastcluster (bundled in FluidAudio)|n/a|BSD-2-Clause|FluidAudio/ThirdPartyLicenses/fastcluster-LICENSE.md|https://github.com/dmuellner/fastcluster|"
   "VBx (bundled in FluidAudio)|n/a|Apache-2.0|FluidAudio/ThirdPartyLicenses/vbx-LICENSE.md|https://github.com/BUTSpeechFIT/VBx|"
   "PLCrashReporter + protobuf-c (bundled in PostHog)|n/a|MIT / Apache-2.0|posthog-ios/vendor/PHPLCrashReporter/LICENSE|https://github.com/microsoft/plcrashreporter|"
   "libwebp (bundled in PostHog)|n/a|BSD-3-Clause|posthog-ios/vendor/libwebp/COPYING|https://chromium.googlesource.com/webm/libwebp|"
+  # llama.cpp is NOT a SwiftPM dep — the bundled llama-server binary is built
+  # from a pinned commit (see Sources/EnviousWispr/Resources/
+  # llama-server-PROVENANCE.md); its MIT license text is vendored in-repo,
+  # hence the repo: path scheme (#1271 Codex code-diff r6).
+  "llama.cpp (bundled llama-server binary)|fdb1db87|MIT|repo:Sources/EnviousWispr/Resources/llama-server-LICENSE.txt|https://github.com/ggml-org/llama.cpp|"
 )
 
 # --- Cross-check the DIRECT-dep coverage against Package.resolved (Codex #2) ---
@@ -133,7 +138,14 @@ printf 'None of these components is GPL/LGPL-licensed.\n\n'
 
 for entry in "${COMPONENTS[@]}"; do
   IFS='|' read -r name version license relpath url _ident <<< "$entry"
-  lf="${CO}/${relpath}"
+  # repo:-prefixed paths resolve against the repo root (vendored license
+  # texts for non-SwiftPM components, e.g. the built llama-server binary);
+  # everything else resolves under .build/checkouts as before.
+  if [[ "$relpath" == repo:* ]]; then
+    lf="${PROJ_ROOT}/${relpath#repo:}"
+  else
+    lf="${CO}/${relpath}"
+  fi
   if [[ ! -f "$lf" ]]; then
     echo "error: license file not found: ${lf}" >&2
     exit 1


### PR DESCRIPTION
Part of #1271 (Phase 2, onboarding integration, is a separate follow-up).

## What ships
Our own tuned polish model (EG-1, Qwen3-4B v2 Q5, 2.7 GB) integrated natively:
- Bundled llama-server inference engine (static arm64, Metal, macOS 14.0 floor, built from pinned ggml-org/llama.cpp fdb1db87 — provenance + MIT notice shipped, THIRD-PARTY-NOTICES updated)
- Manifest-driven model download from models.enviouslabs.co (Cloudflare R2): byte-range resume with header-time identity, streaming SHA-256 verify (blocking), atomic install, hot-swap contract for EG-2/EG-3 (new manifest, zero refactor)
- Localhost inference server: app-chosen free port, per-launch bearer token, 127.0.0.1-only, real-inference health probe (transformation-asserting, not HTTP-200)
- Lifecycle: launch-start, provider-switch activate/deactivate (deferred while a recording pins EG-1), crash restart-once/stay-down-twice, quit-time synchronous kill, crash-orphan sweep (actor-gated), critical-memory-pressure teardown
- Silent-bypass limb contract: every EG-1 failure = raw-text fallback, never an error pill (egOneSkipped family + timeout, all silent-set)
- Full settings UI: picker entry, explainer + real benchmark (94.7% / 1,890 cases), download with progress/cancel/resume, health pill with plain-language detail, Remove Model, 8 GB warning
- End-to-end telemetry (eg1.* lifecycle + polishSkipped reasons)

## Quality + perf evidence
- 92.4% behavior score, 0 critical on hard-340 at the exact ship config (vs 89.7% same artifact via Ollama); 94.7% on full 1,890
- Live UAT (validation record in-run): real download incl. founder-driven cancel+resume, both ASR backends, 1,817-char dictation polished in 8.0s, kill/double-kill/dictate-while-dead drills, switch-away frees ~4 GB instantly; RSS 3.9 GB
- 2,130 logic tests green

## Review history
17 local Codex rounds + a one-pass lifecycle matrix (~40 cells verified) + a callback/staleness enumeration + 5 parallel per-seam reviewers (2 P1s found and fixed). Review stopped at diminishing returns per founder decision (last critical 5 rounds prior; remaining finding classes were calibration-type). Threshold constants are deliberately conservative worst-case; measured calibration is tracked in #1277 with tonight's baseline data.

Accepted-with-rationale (not fixed): connector's 750 ms crash-retry cannot beat a ~9 s cold model reload, so endpoint re-read would not change the outcome; the affected dictation falls back to raw silently, which is the designed limb behavior (#1277 item 5).