### PR TITLE
fix(asr): WhisperKit first-decode penalty, 30s-boundary text loss, seam duplication

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -40,13 +40,42 @@ public actor WhisperKitBackend: ASRBackend {
   private let modelVariant: String = WhisperKitBackend.defaultModelVariant()
   private var whisperKit: WhisperKit?
 
-  /// Issue #445: single-flight guard for `prepare()`. Prevents duplicate
-  /// `MLModel.load` work when the pipeline watchdog cancels its host await
-  /// and a subsequent press calls `prepare()` again before the first one's
-  /// background load returns. CoreML model loading is uncancellable
-  /// cooperatively, so we cannot stop the in-flight load — but we can stop
-  /// it from doubling.
+  /// Issue #445: single-flight guard for `prepare()`/`prepareIfCached()`.
+  /// Prevents duplicate `MLModel.load` work when the pipeline watchdog
+  /// cancels its host await and a subsequent press calls `prepare()` again
+  /// before the first one's background load returns. CoreML model loading is
+  /// uncancellable cooperatively, so we cannot stop the in-flight load — but
+  /// we can stop it from doubling. #1275: both `prepare()` and
+  /// `prepareIfCached()` now join this SAME task via `loadIfNeeded(resolveModelPath:)` —
+  /// previously `prepareIfCached()` called `loadFromPath` directly, bypassing
+  /// the guard.
   private var loadTask: Task<Void, Error>?
+
+  /// #1275 item A: outcome of the silent warm-up inference run at load time.
+  private enum WarmupOutcome: Sendable {
+    case completed(ms: Int)
+    case threw(desc: String)
+  }
+
+  /// Handle to the in-flight (or, after a fail-open timeout, orphaned)
+  /// warm-up task. Drained — never blindly awaited — by
+  /// `readyKitAfterWarmupDrain()`, the single gate every shared-instance
+  /// caller (`transcribe`/`observeLID`/`makeIncrementalSession`) must pass
+  /// through before touching `whisperKit`.
+  private var warmupTask: Task<WarmupOutcome, Never>?
+
+  /// Monotonic token minted per load. Lets the drain helper distinguish "the
+  /// warm-up I'm draining is still the current one" from "a newer load
+  /// started while I was awaiting" (actor-reentrancy-await) so it never
+  /// clears a handle that was replaced mid-await.
+  private var warmupToken: UInt64 = 0
+
+  /// Duration of the most recent warm-up inference, in milliseconds. `nil`
+  /// when no warm-up has completed yet (still loading, threw, or timed out).
+  /// Read by telemetry as an optional property on the existing
+  /// `coldstart.warmup_completed` event — absent for pre-#1275 rows and for
+  /// Parakeet (query by presence, never a new event).
+  package private(set) var lastWarmupInferenceMs: Int?
 
   /// Exposes the configured model variant name (e.g. `openai_whisper-large-v3-v20240930_turbo`).
   /// Read-only; used by telemetry to tag per-transcription events with the model in use.
@@ -62,38 +91,18 @@ public actor WhisperKitBackend: ASRBackend {
   public func prepare() async throws {
     guard !isReady else { return }  // Idempotent — skip if already loaded
 
-    // Issue #445: single-flight. If a prior prepare() call is still loading
-    // (e.g. its host await was cancelled by the pipeline watchdog but the
-    // underlying CoreML load is still grinding), await the existing task
-    // instead of spawning a parallel load.
-    if let existing = loadTask {
-      try await existing.value
-      return
-    }
-
-    let task = Task<Void, Error> {
+    let variant = modelVariant
+    try await loadIfNeeded {
       // Use cached model path from WhisperKitSetupService (no network call).
       // Falls back to WhisperKit.download() if path not found (handles edge cases
       // like user-initiated record when cache was cleared).
-      let modelPath: String
-      if let cached = WhisperKitSetupService.getLocalModelPath(variant: modelVariant) {
-        modelPath = cached
-      } else {
-        // TODO(#827): watchdog needs WhisperKit download progress wired into
-        // this fallback path if product keeps allowing first-record downloads.
-        let folder = try await WhisperKit.download(variant: modelVariant, progressCallback: nil)
-        modelPath = folder.path
+      if let cached = WhisperKitSetupService.getLocalModelPath(variant: variant) {
+        return cached
       }
-
-      try await loadFromPath(modelPath)
-    }
-    loadTask = task
-    do {
-      try await task.value
-      loadTask = nil
-    } catch {
-      loadTask = nil
-      throw error
+      // TODO(#827): watchdog needs WhisperKit download progress wired into
+      // this fallback path if product keeps allowing first-record downloads.
+      let folder = try await WhisperKit.download(variant: variant, progressCallback: nil)
+      return folder.path
     }
   }
 
@@ -108,8 +117,38 @@ public actor WhisperKitBackend: ASRBackend {
     guard let cached = WhisperKitSetupService.getLocalModelPath(variant: modelVariant) else {
       return false  // Model not cached or cache incomplete — skip silently.
     }
-    try await loadFromPath(cached)
+    try await loadIfNeeded { cached }
     return true
+  }
+
+  /// Issue #445 + #1275: single owner of the `loadTask` single-flight
+  /// lifecycle for BOTH `prepare()` and `prepareIfCached()`. Previously
+  /// `prepareIfCached()` called `loadFromPath` directly, bypassing this
+  /// guard — a latent double-load race (documented at
+  /// `WhisperKitEngineAdapter.swift` near the `prepareIfCached` call site).
+  /// If a prior load is still in flight (e.g. its host await was cancelled
+  /// by the pipeline watchdog but the underlying CoreML load is still
+  /// grinding), join the existing task instead of spawning a parallel load.
+  private func loadIfNeeded(resolveModelPath: @escaping @Sendable () async throws -> String)
+    async throws
+  {
+    if let existing = loadTask {
+      try await existing.value
+      return
+    }
+
+    let task = Task<Void, Error> {
+      let modelPath = try await resolveModelPath()
+      try await loadFromPath(modelPath)
+    }
+    loadTask = task
+    do {
+      try await task.value
+      loadTask = nil
+    } catch {
+      loadTask = nil
+      throw error
+    }
   }
 
   /// WhisperKit 0.12+ model folder artifacts required for a successful load.
@@ -170,13 +209,90 @@ public actor WhisperKitBackend: ASRBackend {
     // not wrap this in a wall-clock timeout (timeout-numbers-need-distribution-evidence).
     let kit = try await WhisperKit(config)
     self.whisperKit = kit
+
+    // #1275 item A: one silent warm-up inference before flipping isReady, so
+    // the first real press never pays the (path-dependent) first-decode
+    // penalty measured 2026-07-02. Fails open — a throw or timeout still
+    // flips isReady, since the model IS loaded and usable; only the
+    // first-press latency win is lost.
+    await runWarmup(kit: kit)
     isReady = true
+  }
+
+  /// Runs the silent warm-up inference (1s of digital silence, decoded
+  /// through the SAME production option builder every real transcribe call
+  /// uses) and records its terminal status. Wrapped in a 20s fail-open
+  /// deadline (founder-approved exception to timeout-numbers-into-evidence,
+  /// #1275 Gate 2 — this bounds an invisible background task, never a
+  /// user-facing wait; a too-large value costs nothing in the healthy case,
+  /// a too-small value merely reverts to today's behavior). On timeout the
+  /// task handle is left in `warmupTask` for `readyKitAfterWarmupDrain()` to
+  /// drain later — never re-awaited here, since `withDeadline` abandons it.
+  private func runWarmup(kit: WhisperKit) async {
+    warmupToken &+= 1
+    let token = warmupToken
+
+    let silence = [Float](repeating: 0, count: 16_000)  // 1s at 16kHz
+    let opts = makeDecodeOptions(from: .default, sampleCount: silence.count)
+
+    let task = Task<WarmupOutcome, Never> {
+      let start = CFAbsoluteTimeGetCurrent()
+      do {
+        _ = try await kit.transcribe(audioArray: silence, decodeOptions: opts)
+        return .completed(ms: Int((CFAbsoluteTimeGetCurrent() - start) * 1000))
+      } catch {
+        return .threw(desc: error.localizedDescription)
+      }
+    }
+    warmupTask = task
+
+    guard let outcome = await withDeadline(seconds: 20, operation: { await task.value }) else {
+      await AppLogger.shared.log(
+        "WhisperKit warm-up: timed_out (20s fail-open ceiling)",
+        level: .info, category: "WhisperKitBackend"
+      )
+      return
+    }
+
+    // Per actor-reentrancy-await: only clear the handle if no newer warm-up
+    // (from an interleaved unload/reload during this await) replaced it.
+    if warmupToken == token { warmupTask = nil }
+
+    switch outcome {
+    case .completed(let ms):
+      lastWarmupInferenceMs = ms
+      await AppLogger.shared.log(
+        "WhisperKit warm-up: completed(\(ms)ms)",
+        level: .info, category: "WhisperKitBackend"
+      )
+    case .threw(let desc):
+      await AppLogger.shared.log(
+        "WhisperKit warm-up: threw(\(desc))",
+        level: .info, category: "WhisperKitBackend"
+      )
+    }
+  }
+
+  /// Single vend gate for the shared `WhisperKit` instance. Every
+  /// shared-instance caller (`transcribe`, `observeLID`,
+  /// `makeIncrementalSession`) MUST obtain the kit through this helper, never
+  /// by reading `whisperKit` directly, so a request can never race a
+  /// straggling orphaned warm-up decode from a prior timeout (no proven
+  /// concurrent-decode safety on one `WhisperKit` instance).
+  private func readyKitAfterWarmupDrain() async -> WhisperKit? {
+    if let pending = warmupTask {
+      let token = warmupToken
+      _ = await pending.value
+      if warmupToken == token { warmupTask = nil }
+    }
+    guard isReady else { return nil }
+    return whisperKit
   }
 
   public func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws
     -> ASRResult
   {
-    guard isReady, let kit = whisperKit else { throw ASRError.notReady }
+    guard let kit = await readyKitAfterWarmupDrain() else { throw ASRError.notReady }
 
     let paddedSamples = Self.padAudioWithSilence(audioSamples)
     let decodeOptions = makeDecodeOptions(from: options, sampleCount: paddedSamples.count)
@@ -212,7 +328,7 @@ public actor WhisperKitBackend: ASRBackend {
   package func makeIncrementalSession(options: TranscriptionOptions)
     async -> (any WhisperKitIncrementalSession)?
   {
-    guard let kit = whisperKit else { return nil }
+    guard let kit = await readyKitAfterWarmupDrain() else { return nil }
     let opts = makeDecodeOptions(from: options, sampleCount: 0)
     return WhisperKitIncrementalWorker(whisperKit: kit, decodingOptions: opts)
   }
@@ -230,7 +346,7 @@ public actor WhisperKitBackend: ASRBackend {
     samples: [Float],
     maxWindows: Int
   ) async -> LIDObservationBatch {
-    guard let kit = whisperKit else { return .unavailable }
+    guard let kit = await readyKitAfterWarmupDrain() else { return .unavailable }
 
     let sampleRate = LanguageDetectorThresholds.sampleRate
     let totalSamples = samples.count

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -51,6 +51,23 @@ public actor WhisperKitBackend: ASRBackend {
   /// the guard.
   private var loadTask: Task<Void, Error>?
 
+  /// #1275 (Codex arch-consult finding 4): identity guard for `loadTask`
+  /// cleanup, mirroring `ASRManagerProxy`'s `loadTaskSeq`/`activeLoadTaskID`
+  /// (`ASRManagerProxy.swift:55-62,157-164`). `loadIfNeeded`'s cleanup must
+  /// only nil `loadTask` if it still IS the task this call created — without
+  /// this, a superseded load's late completion/throw can clobber a NEWER
+  /// load's task handle (repro: load A starts (task A, gen 0), `unload()`
+  /// fires (gen 1, A cancelled but CoreML load is uncancellable so A keeps
+  /// running), load B starts (sees `loadTask == nil`, creates task B, gen 1),
+  /// A's `WhisperKit(config)` finally resolves late, A's generation check
+  /// correctly throws, but A's catch-block cleanup does `loadTask = nil` —
+  /// clobbering B's still-in-flight handle, letting a 3rd concurrent load C
+  /// start and double real CoreML load cost). Deliberately separate from
+  /// `loadGeneration`: that guards stale READINESS writes after unload/reload;
+  /// this guards stale TASK-HANDLE cleanup — different failure modes.
+  private var loadTaskSeq: UInt64 = 0
+  private var activeLoadTaskID: UInt64 = 0
+
   /// #1275 (Codex r2 P2): monotonic generation stamp, mirroring
   /// `ASRManagerProxy.loadGeneration` (`ASRManagerProxy.swift:53`). Bumped by
   /// `unload()` so a `loadFromPath` in-flight at unload time can never write
@@ -156,14 +173,21 @@ public actor WhisperKitBackend: ASRBackend {
       let modelPath = try await resolveModelPath()
       try await loadFromPath(modelPath)
     }
+
+    loadTaskSeq &+= 1
+    let myTaskID = loadTaskSeq
     loadTask = task
-    do {
-      try await task.value
-      loadTask = nil
-    } catch {
-      loadTask = nil
-      throw error
+    activeLoadTaskID = myTaskID
+    defer {
+      // Identity guard: only clear the handle if it still belongs to THIS
+      // call. A superseded load's late completion must not clobber a newer
+      // load's in-flight task handle (finding 4 above).
+      if activeLoadTaskID == myTaskID {
+        loadTask = nil
+      }
     }
+
+    try await task.value
   }
 
   /// WhisperKit 0.12+ model folder artifacts required for a successful load.

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -70,11 +70,20 @@ public actor WhisperKitBackend: ASRBackend {
   /// through before touching `whisperKit`.
   private var warmupTask: Task<WarmupOutcome, Never>?
 
-  /// Monotonic token minted per load. Lets the drain helper distinguish "the
-  /// warm-up I'm draining is still the current one" from "a newer load
-  /// started while I was awaiting" (actor-reentrancy-await) so it never
-  /// clears a handle that was replaced mid-await.
-  private var warmupToken: UInt64 = 0
+  /// The `loadGeneration` value `warmupTask` belongs to. `nil` when no task
+  /// is tracked. Consolidates what was a separate `warmupToken` counter
+  /// (adversarial-review finding, #1275) into the SAME generation stamp
+  /// `unload()` already bumps: a `warmupTask` left behind by a load that has
+  /// since been superseded (by `unload()`, not just by a newer warm-up
+  /// within the same load) is now recognizable as stale by comparing this
+  /// against the CURRENT `loadGeneration` — not just against a later
+  /// warm-up's own token. This closes a race the separate-counter version
+  /// missed: `readyKitAfterWarmupDrain()` would otherwise await a fail-open
+  /// timeout on an ORPHANED warm-up from a load that `unload()` already
+  /// discarded, while a completely independent newer load is still in its
+  /// (multi-second) CoreML load phase — turning what should be an immediate
+  /// "not ready yet" into a 20-second stall on irrelevant background work.
+  private var warmupTaskGeneration: UInt64?
 
   /// Duration of the most recent warm-up inference, in milliseconds. `nil`
   /// when no warm-up has completed yet (still loading, threw, or timed out).
@@ -230,7 +239,7 @@ public actor WhisperKitBackend: ASRBackend {
     // penalty measured 2026-07-02. Fails open — a throw or timeout still
     // flips isReady, since the model IS loaded and usable; only the
     // first-press latency win is lost.
-    await runWarmup(kit: kit)
+    await runWarmup(kit: kit, generation: gen)
     guard gen == loadGeneration else { throw ASRLoadSupersededError() }
     isReady = true
   }
@@ -244,9 +253,9 @@ public actor WhisperKitBackend: ASRBackend {
   /// a too-small value merely reverts to today's behavior). On timeout the
   /// task handle is left in `warmupTask` for `readyKitAfterWarmupDrain()` to
   /// drain later — never re-awaited here, since `withDeadline` abandons it.
-  private func runWarmup(kit: WhisperKit) async {
-    warmupToken &+= 1
-    let token = warmupToken
+  /// `generation` is the `loadGeneration` this warm-up belongs to (captured
+  /// by the caller, `loadFromPath`, before any await).
+  private func runWarmup(kit: WhisperKit, generation: UInt64) async {
     // Codex r1 P3: clear the PREVIOUS load's value before this run — only
     // `.completed` below sets a fresh one, so a throw/timeout on THIS load
     // must not leave a prior load's stale duration attached to telemetry.
@@ -265,6 +274,7 @@ public actor WhisperKitBackend: ASRBackend {
       }
     }
     warmupTask = task
+    warmupTaskGeneration = generation
 
     guard let outcome = await withDeadline(seconds: 20, operation: { await task.value }) else {
       await AppLogger.shared.log(
@@ -275,13 +285,14 @@ public actor WhisperKitBackend: ASRBackend {
     }
 
     // Per actor-reentrancy-await: only clear the handle — and only record the
-    // outcome — if no newer warm-up (from an interleaved unload/reload during
-    // this await) replaced it. Without this token check, an abandoned load's
-    // late completion could overwrite a NEWER load's `lastWarmupInferenceMs`
-    // with stale data (the same class of race Codex r2 P2 found for
-    // `isReady`, closed here too rather than leaving a sibling gap).
-    guard warmupToken == token else { return }
+    // outcome — if this generation is still the one `warmupTask` is tracking
+    // (no interleaved unload/reload replaced it during this await). Without
+    // this check, an abandoned load's late completion could overwrite a
+    // NEWER load's `lastWarmupInferenceMs` with stale data (the same class
+    // of race Codex r2 P2 found for `isReady`, closed here too).
+    guard warmupTaskGeneration == generation else { return }
     warmupTask = nil
+    warmupTaskGeneration = nil
 
     switch outcome {
     case .completed(let ms):
@@ -313,12 +324,22 @@ public actor WhisperKitBackend: ASRBackend {
   /// (accepting the same theoretical concurrent-decode risk the design
   /// already documents as unproven-but-low-probability, rather than
   /// re-paying an unbounded wait on every future press).
+  ///
+  /// Adversarial-review finding (#1275): only drain a `warmupTask` that
+  /// belongs to the CURRENT `loadGeneration`. A `warmupTask` left behind by
+  /// a load `unload()` has since superseded is irrelevant to a request that
+  /// arrives while a completely independent newer load is still in its
+  /// (multi-second) CoreML load phase — draining it anyway meant such a
+  /// request could pay up to 20 extra seconds waiting on background work for
+  /// a model that no longer exists, instead of immediately falling through
+  /// to `guard isReady` and returning nil.
   private func readyKitAfterWarmupDrain() async -> WhisperKit? {
-    if let pending = warmupTask {
-      let token = warmupToken
+    if let pending = warmupTask, warmupTaskGeneration == loadGeneration {
+      let generation = loadGeneration
       let outcome = await withDeadline(seconds: 20, operation: { await pending.value })
-      if warmupToken == token {
+      if warmupTaskGeneration == generation {
         warmupTask = nil
+        warmupTaskGeneration = nil
         if outcome == nil {
           await AppLogger.shared.log(
             "WhisperKit warm-up: drain also timed_out after 20s — vending kit anyway",
@@ -357,6 +378,18 @@ public actor WhisperKitBackend: ASRBackend {
     // #1275 (Codex r2 P2): supersede any in-flight loadFromPath BEFORE
     // clearing state, so its post-await guards see the bumped generation.
     loadGeneration &+= 1
+    // Adversarial-review finding (#1275): also clear `loadTask` — mirrors
+    // `ASRManagerProxy.unloadModel()`'s `inFlightLoadTask?.cancel(); nil`
+    // (`ASRManagerProxy.swift:226,233-234`). Without this, a `prepare()`
+    // called right after `unload()` would join the now-doomed task via
+    // `loadIfNeeded`'s single-flight join instead of starting a fresh load —
+    // the doomed task's generation check (`loadFromPath`) throws
+    // `ASRLoadSupersededError`, which would then wrongly fail a legitimate
+    // new load request instead of ever starting one. Cancellation is
+    // best-effort (CoreML loading is uncancellable cooperatively); nil-ing
+    // the handle is what actually matters.
+    loadTask?.cancel()
+    loadTask = nil
     whisperKit = nil
     isReady = false
   }

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -102,6 +102,22 @@ public actor WhisperKitBackend: ASRBackend {
   /// "not ready yet" into a 20-second stall on irrelevant background work.
   private var warmupTaskGeneration: UInt64?
 
+  /// The `loadGeneration` whose warm-up already burned its one 20s fail-open
+  /// budget in `runWarmup()` itself (i.e. the background warm-up timed out).
+  /// `nil` when the current generation's warm-up has not (yet) exhausted its
+  /// budget. Codex code-diff review (medium effort, #1275): without this,
+  /// `readyKitAfterWarmupDrain()` re-awaits the SAME already-timed-out task
+  /// with its own fresh 20s deadline, so the first real caller after a
+  /// wedged warm-up could pay a SECOND 20s stall on top of the first —
+  /// turning an invisible background hiccup into up to 40s of user-facing
+  /// latency, defeating the fail-open design. Once a generation's budget is
+  /// marked exhausted (by `runWarmup`'s own timeout, or by a caller's drain
+  /// timeout), every subsequent caller for that generation skips the await
+  /// entirely and vends the kit immediately — accepting the same
+  /// theoretical concurrent-decode risk the design already documents as
+  /// unproven-but-low-probability, exactly once per generation, never twice.
+  private var warmupBudgetExhausted: UInt64?
+
   /// Duration of the most recent warm-up inference, in milliseconds. `nil`
   /// when no warm-up has completed yet (still loading, threw, or timed out).
   /// Read by telemetry as an optional property on the existing
@@ -284,6 +300,8 @@ public actor WhisperKitBackend: ASRBackend {
     // `.completed` below sets a fresh one, so a throw/timeout on THIS load
     // must not leave a prior load's stale duration attached to telemetry.
     lastWarmupInferenceMs = nil
+    // This generation has not spent its fail-open budget yet.
+    if warmupBudgetExhausted == generation { warmupBudgetExhausted = nil }
 
     let silence = [Float](repeating: 0, count: 16_000)  // 1s at 16kHz
     let opts = makeDecodeOptions(from: .default, sampleCount: silence.count)
@@ -301,6 +319,10 @@ public actor WhisperKitBackend: ASRBackend {
     warmupTaskGeneration = generation
 
     guard let outcome = await withDeadline(seconds: 20, operation: { await task.value }) else {
+      // Codex code-diff review (medium effort, #1275): mark this generation's
+      // budget spent so `readyKitAfterWarmupDrain()` never re-awaits the same
+      // stuck task with a second fresh 20s deadline.
+      warmupBudgetExhausted = generation
       await AppLogger.shared.log(
         "WhisperKit warm-up: timed_out (20s fail-open ceiling)",
         level: .info, category: "WhisperKitBackend"
@@ -357,14 +379,33 @@ public actor WhisperKitBackend: ASRBackend {
   /// request could pay up to 20 extra seconds waiting on background work for
   /// a model that no longer exists, instead of immediately falling through
   /// to `guard isReady` and returning nil.
+  ///
+  /// Codex code-diff review (medium effort, #1275): if THIS generation's
+  /// warm-up already spent its 20s budget inside `runWarmup()` itself
+  /// (`warmupBudgetExhausted == loadGeneration`), do not re-await the same
+  /// stuck task with a second fresh deadline — the real caller vends
+  /// immediately instead of paying up to 40s total (20s in the background
+  /// warm-up + 20s here) for what the fail-open design intended to cost at
+  /// most 20s of invisible background time.
   private func readyKitAfterWarmupDrain() async -> WhisperKit? {
     if let pending = warmupTask, warmupTaskGeneration == loadGeneration {
       let generation = loadGeneration
+      if warmupBudgetExhausted == generation {
+        warmupTask = nil
+        warmupTaskGeneration = nil
+        await AppLogger.shared.log(
+          "WhisperKit warm-up: budget already exhausted — vending kit without re-draining",
+          level: .info, category: "WhisperKitBackend"
+        )
+        guard isReady else { return nil }
+        return whisperKit
+      }
       let outcome = await withDeadline(seconds: 20, operation: { await pending.value })
       if warmupTaskGeneration == generation {
         warmupTask = nil
         warmupTaskGeneration = nil
         if outcome == nil {
+          warmupBudgetExhausted = generation
           await AppLogger.shared.log(
             "WhisperKit warm-up: drain also timed_out after 20s — vending kit anyway",
             level: .info, category: "WhisperKitBackend"

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -455,6 +455,21 @@ public actor WhisperKitBackend: ASRBackend {
     // the handle is what actually matters.
     loadTask?.cancel()
     loadTask = nil
+
+    // Codex code-diff review (medium effort, #1275): mirror the loadTask
+    // handling immediately above for `warmupTask` — without this, an
+    // in-flight or fail-open-timed-out warm-up keeps running and retaining
+    // its captured `WhisperKit` instance after unload, so the old model can
+    // stay in memory doing CoreML work while the backend is supposed to be
+    // unloaded (or while a new load is starting). Cancellation is
+    // best-effort for the same reason as `loadTask` (CoreML decode is
+    // uncancellable cooperatively); clearing the handles is what stops US
+    // from later draining or reporting on a task tied to a discarded model.
+    warmupTask?.cancel()
+    warmupTask = nil
+    warmupTaskGeneration = nil
+    warmupBudgetExhausted = nil
+
     whisperKit = nil
     isReady = false
   }

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -51,6 +51,12 @@ public actor WhisperKitBackend: ASRBackend {
   /// the guard.
   private var loadTask: Task<Void, Error>?
 
+  /// #1275 (Codex r2 P2): monotonic generation stamp, mirroring
+  /// `ASRManagerProxy.loadGeneration` (`ASRManagerProxy.swift:53`). Bumped by
+  /// `unload()` so a `loadFromPath` in-flight at unload time can never write
+  /// `isReady = true` after the fact on a since-cleared `whisperKit`.
+  private var loadGeneration: UInt64 = 0
+
   /// #1275 item A: outcome of the silent warm-up inference run at load time.
   private enum WarmupOutcome: Sendable {
     case completed(ms: Int)
@@ -192,6 +198,14 @@ public actor WhisperKitBackend: ASRBackend {
   }
 
   private func loadFromPath(_ modelPath: String) async throws {
+    // #1275 (Codex r2 P2): capture the generation before any await. `unload()`
+    // bumps it, so a load/warm-up whose completion races an unload can never
+    // resurrect `isReady = true` on a since-cleared `whisperKit` — the same
+    // established pattern `ASRManagerProxy.loadGeneration` uses for the
+    // identical class of race (`ASRManagerProxy.swift:53`), reused here
+    // rather than inventing a new mechanism.
+    let gen = loadGeneration
+
     let config = WhisperKitConfig(
       model: modelVariant,
       modelFolder: modelPath,
@@ -208,6 +222,7 @@ public actor WhisperKitBackend: ASRBackend {
     // lack of a defended-timeout distribution — NOT for lack of timing data. Do
     // not wrap this in a wall-clock timeout (timeout-numbers-need-distribution-evidence).
     let kit = try await WhisperKit(config)
+    guard gen == loadGeneration else { throw ASRLoadSupersededError() }
     self.whisperKit = kit
 
     // #1275 item A: one silent warm-up inference before flipping isReady, so
@@ -216,6 +231,7 @@ public actor WhisperKitBackend: ASRBackend {
     // flips isReady, since the model IS loaded and usable; only the
     // first-press latency win is lost.
     await runWarmup(kit: kit)
+    guard gen == loadGeneration else { throw ASRLoadSupersededError() }
     isReady = true
   }
 
@@ -258,9 +274,14 @@ public actor WhisperKitBackend: ASRBackend {
       return
     }
 
-    // Per actor-reentrancy-await: only clear the handle if no newer warm-up
-    // (from an interleaved unload/reload during this await) replaced it.
-    if warmupToken == token { warmupTask = nil }
+    // Per actor-reentrancy-await: only clear the handle — and only record the
+    // outcome — if no newer warm-up (from an interleaved unload/reload during
+    // this await) replaced it. Without this token check, an abandoned load's
+    // late completion could overwrite a NEWER load's `lastWarmupInferenceMs`
+    // with stale data (the same class of race Codex r2 P2 found for
+    // `isReady`, closed here too rather than leaving a sibling gap).
+    guard warmupToken == token else { return }
+    warmupTask = nil
 
     switch outcome {
     case .completed(let ms):
@@ -333,6 +354,9 @@ public actor WhisperKitBackend: ASRBackend {
   }
 
   public func unload() async {
+    // #1275 (Codex r2 P2): supersede any in-flight loadFromPath BEFORE
+    // clearing state, so its post-await guards see the bumped generation.
+    loadGeneration &+= 1
     whisperKit = nil
     isReady = false
   }

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -231,6 +231,10 @@ public actor WhisperKitBackend: ASRBackend {
   private func runWarmup(kit: WhisperKit) async {
     warmupToken &+= 1
     let token = warmupToken
+    // Codex r1 P3: clear the PREVIOUS load's value before this run — only
+    // `.completed` below sets a fresh one, so a throw/timeout on THIS load
+    // must not leave a prior load's stale duration attached to telemetry.
+    lastWarmupInferenceMs = nil
 
     let silence = [Float](repeating: 0, count: 16_000)  // 1s at 16kHz
     let opts = makeDecodeOptions(from: .default, sampleCount: silence.count)
@@ -279,11 +283,28 @@ public actor WhisperKitBackend: ASRBackend {
   /// by reading `whisperKit` directly, so a request can never race a
   /// straggling orphaned warm-up decode from a prior timeout (no proven
   /// concurrent-decode safety on one `WhisperKit` instance).
+  ///
+  /// Codex r1 P1: draining the orphan with NO deadline defeated the whole
+  /// point of the 20s fail-open ceiling — a genuinely wedged warm-up would
+  /// then block every subsequent press indefinitely instead of just its own
+  /// decode. The drain reuses the SAME 20s fail-open budget; if it ALSO
+  /// expires, the handle is cleared anyway and the kit is vended regardless
+  /// (accepting the same theoretical concurrent-decode risk the design
+  /// already documents as unproven-but-low-probability, rather than
+  /// re-paying an unbounded wait on every future press).
   private func readyKitAfterWarmupDrain() async -> WhisperKit? {
     if let pending = warmupTask {
       let token = warmupToken
-      _ = await pending.value
-      if warmupToken == token { warmupTask = nil }
+      let outcome = await withDeadline(seconds: 20, operation: { await pending.value })
+      if warmupToken == token {
+        warmupTask = nil
+        if outcome == nil {
+          await AppLogger.shared.log(
+            "WhisperKit warm-up: drain also timed_out after 20s — vending kit anyway",
+            level: .info, category: "WhisperKitBackend"
+          )
+        }
+      }
     }
     guard isReady else { return nil }
     return whisperKit

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -119,18 +119,27 @@ package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
   /// text alone, so this can wrongly trim one copy. The trimmer anchors
   /// strictly on the seam (candidate suffix vs tail prefix), never a global
   /// dedup, to keep this risk local to the boundary.
+  ///
+  /// `minOverlap` (Codex r1 P2): a 1-3 character coincidental match (e.g.
+  /// candidate "I am" / tail "amazing today" sharing "am") is far more
+  /// likely to be an unrelated word boundary than genuine acoustic overlap
+  /// — trimming on it corrupts normal continuations ("I am azing today").
+  /// 6 characters comfortably covers the shortest confirmed real overlap
+  /// case ("gerie " — 6 chars, from the founder's `lingerie`/`gerie` repro)
+  /// while excluding short coincidences.
   package static func joinWithOverlapTrim(_ candidate: String, _ tail: String) -> String {
     guard !tail.isEmpty else { return candidate }
     guard !candidate.isEmpty else { return tail }
 
     let maxWindow = 80
+    let minOverlap = 6
     let candidateWindow = Array(candidate.suffix(maxWindow)).map { Character($0.lowercased()) }
     let tailWindow = Array(tail.prefix(maxWindow)).map { Character($0.lowercased()) }
 
     var overlapLength = 0
     let maxK = min(candidateWindow.count, tailWindow.count)
-    if maxK > 0 {
-      for k in stride(from: maxK, through: 1, by: -1) {
+    if maxK >= minOverlap {
+      for k in stride(from: maxK, through: minOverlap, by: -1) {
         if candidateWindow.suffix(k).elementsEqual(tailWindow.prefix(k)) {
           overlapLength = k
           break

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -127,6 +127,28 @@ package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
   /// 6 characters comfortably covers the shortest confirmed real overlap
   /// case ("gerie " — 6 chars, from the founder's `lingerie`/`gerie` repro)
   /// while excluding short coincidences.
+  ///
+  /// KNOWN REGRESSION, not fixed by this trimmer, shipped intentionally as
+  /// documented residual risk (#1275, Live UAT 2026-07-02): this only
+  /// catches a duplicate anchored at the LITERAL seam — candidate's exact
+  /// suffix matching tail's exact prefix. It does NOT catch a duplicate
+  /// where the tail's decode window re-transcribes a phrase from EARLIER in
+  /// candidate (not candidate's trailing edge). Live-repro: dictating "Can
+  /// you double check the numbers in the spreadsheet before I send it to
+  /// the client" produced candidate "...the numbers in the spreadsheet?"
+  /// and tail "e numbers in the spreadsheet before..." — the duplicated
+  /// phrase "the numbers in the spreadsheet" sits mid-candidate, not at its
+  /// suffix, so no seam match exists for this function to find; the raw
+  /// ASR text ships with the phrase duplicated (LLM Polish sometimes, not
+  /// always, cleans it up downstream — do not rely on that). Root cause is
+  /// structural: this function's suffix/prefix seam-matching approach
+  /// cannot express "the tail re-covers audio already transcribed earlier
+  /// in candidate, not just at the boundary." Fixing this properly means
+  /// replacing the whole re-transcribe-and-textually-stitch design with
+  /// WhisperKit's official streaming mechanism (confirmed-vs-hypothesis
+  /// text via LocalAgreement, `AudioStreamTranscriber`), which never emits
+  /// two independent text spans that need post-hoc joining in the first
+  /// place — see #1276 (filed as this bug's structural fix, not a patch).
   package static func joinWithOverlapTrim(_ candidate: String, _ tail: String) -> String {
     guard !tail.isEmpty else { return candidate }
     guard !candidate.isEmpty else { return tail }

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -17,6 +17,35 @@ package struct IncrementalResult: Sendable {
   package let tailDecodeMs: Int
 }
 
+/// Narrow seam over WhisperKit's transcribe entry point, mirroring
+/// `WhisperKitBackendDriving`. Lets `WhisperKitIncrementalWorker` be
+/// characterization-tested with a fake decoder instead of a loaded model.
+package protocol WhisperKitTranscribing: Sendable {
+  func transcribe(audioArray: [Float], decodeOptions: DecodingOptions?) async throws
+    -> [TranscriptionResult]
+}
+
+// Retroactive @unchecked Sendable: WhisperKit (upstream, @preconcurrency-imported)
+// has mutable stored properties so it cannot auto-synthesize Sendable, but every
+// caller of the shared instance in this package already goes through actor
+// isolation (WhisperKitBackend) or the drain gate (`readyKitAfterWarmupDrain`)
+// that serializes access — the same safety argument the rest of this file
+// already relies on when passing `WhisperKit` across actor boundaries under
+// `@preconcurrency import WhisperKit`.
+extension WhisperKit: @retroactive @unchecked Sendable {}
+
+extension WhisperKit: WhisperKitTranscribing {
+  // Explicit wrapper: WhisperKit's real `transcribe(audioArray:decodeOptions:callback:segmentCallback:)`
+  // has two additional defaulted parameters, which structural witness matching
+  // does not bridge automatically. Forward to it explicitly.
+  package func transcribe(audioArray: [Float], decodeOptions: DecodingOptions?) async throws
+    -> [TranscriptionResult]
+  {
+    try await self.transcribe(
+      audioArray: audioArray, decodeOptions: decodeOptions, callback: nil, segmentCallback: nil)
+  }
+}
+
 /// Periodically transcribes the growing audio buffer during recording.
 /// Purely an internal latency optimization — no UI, no streaming model.
 ///
@@ -25,9 +54,9 @@ package struct IncrementalResult: Sendable {
 /// - Long recordings (>30s): use clipTimestamps to only decode new audio (efficient)
 /// - On finalize: async tail decode covers speech after the last worker result
 package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
-  private let whisperKit: WhisperKit
+  private let whisperKit: any WhisperKitTranscribing
   private let baseDecodingOptions: DecodingOptions
-  private let cadence: Duration = .seconds(3)
+  private let cadence: Duration
   private let longRecordingThreshold: Int = 16000 * 30
 
   private var accumulatedText: String = ""
@@ -40,9 +69,83 @@ package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
   private var running = false
   private var loopTask: Task<Void, Never>?
 
-  package init(whisperKit: WhisperKit, decodingOptions: DecodingOptions) {
+  /// `cadence` defaults to the shipped 3s cycle; tests inject a near-zero
+  /// value so the run loop's boundary behavior can be characterized without
+  /// waiting on real wall-clock time (#1275).
+  package init(
+    whisperKit: any WhisperKitTranscribing, decodingOptions: DecodingOptions,
+    cadence: Duration = .seconds(3)
+  ) {
     self.whisperKit = whisperKit
     self.baseDecodingOptions = decodingOptions
+    self.cadence = cadence
+  }
+
+  /// Selects the finalize candidate text. Long-mode prefers `accumulatedText`
+  /// (the clipped incremental accumulation) but falls back to `lastFullResult`
+  /// when the recording only crossed the 30s boundary between the worker's
+  /// last short-mode decode and finalize — `lastFullResult` still covers
+  /// exactly `lastResultSampleCount` samples and the tail decode covers the
+  /// remainder, so it is a valid candidate, not a discard signal (#1275).
+  package static func selectCandidateText(
+    isLong: Bool,
+    accumulatedText: String,
+    lastFullResult: String?
+  ) -> String? {
+    guard isLong else { return lastFullResult }
+    let trimmed = accumulatedText.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? lastFullResult : accumulatedText
+  }
+
+  /// Joins the worker's candidate text with the tail decode's text, trimming
+  /// a duplicated overlap at the seam when the tail's start literally
+  /// repeats the end of the candidate — the deliberate 1.0s audio overlap
+  /// (`overlapStartSeconds` above) re-decodes the same speech, and WhisperKit
+  /// can emit a partial-token continuation split across both decodes (e.g.
+  /// candidate ends "...lingerie outside?", tail starts "gerie outside?").
+  ///
+  /// Case-insensitive longest-common-affix between the last `maxWindow`
+  /// characters of `candidate` and the first `maxWindow` characters of
+  /// `tail`, bounded to a span plausibly produced by the ~1s audio overlap.
+  /// Punctuation and whitespace are compared literally (not stripped) — a
+  /// diverging trailing punctuation mark only prevents a match, it never
+  /// causes an incorrect trim. Trims ONLY from `tail`'s prefix; `candidate`
+  /// is never modified, and no text is removed without a positive seam
+  /// match (no match → today's naive `candidate + " " + tail` join).
+  ///
+  /// Known residual risk (accepted, #1275 §7): a genuine word repeated by
+  /// the speaker exactly at the seam (e.g. "...standing outside outside in
+  /// the rain") is indistinguishable from acoustic-overlap duplication from
+  /// text alone, so this can wrongly trim one copy. The trimmer anchors
+  /// strictly on the seam (candidate suffix vs tail prefix), never a global
+  /// dedup, to keep this risk local to the boundary.
+  package static func joinWithOverlapTrim(_ candidate: String, _ tail: String) -> String {
+    guard !tail.isEmpty else { return candidate }
+    guard !candidate.isEmpty else { return tail }
+
+    let maxWindow = 80
+    let candidateWindow = Array(candidate.suffix(maxWindow)).map { Character($0.lowercased()) }
+    let tailWindow = Array(tail.prefix(maxWindow)).map { Character($0.lowercased()) }
+
+    var overlapLength = 0
+    let maxK = min(candidateWindow.count, tailWindow.count)
+    if maxK > 0 {
+      for k in stride(from: maxK, through: 1, by: -1) {
+        if candidateWindow.suffix(k).elementsEqual(tailWindow.prefix(k)) {
+          overlapLength = k
+          break
+        }
+      }
+    }
+
+    guard overlapLength > 0 else {
+      return candidate + " " + tail
+    }
+
+    let trimStart = tail.index(tail.startIndex, offsetBy: overlapLength)
+    let trimmedTail = String(tail[trimStart...]).trimmingCharacters(in: .whitespaces)
+    guard !trimmedTail.isEmpty else { return candidate }
+    return candidate + " " + trimmedTail
   }
 
   package func start(
@@ -82,7 +185,9 @@ package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
       )
     }
 
-    let candidateText = isLong ? accumulatedText : lastFullResult
+    let candidateText = Self.selectCandidateText(
+      isLong: isLong, accumulatedText: accumulatedText, lastFullResult: lastFullResult
+    )
     let hasText =
       candidateText != nil
       && !candidateText!.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -151,17 +256,27 @@ package actor WhisperKitIncrementalWorker: WhisperKitIncrementalSession {
 
       let tailMs = Int((CFAbsoluteTimeGetCurrent() - tailStart) * 1000)
 
+      // Implied 30s-window count spanned by this decode's clip range. WhisperKit
+      // always encodes a fixed 30s window per pass — a value >1 here means the
+      // clip range exceeds one window (stale worker, large uncovered tail).
+      // Measurement only (#1275 item C): never silently clamp the clip start,
+      // since that would drop uncovered audio unless the worker text already
+      // represents it.
+      let clipSpanSeconds = Float(paddedSamples.count) / 16000.0 - overlapStartSeconds
+      let impliedWindowCount = max(1, Int(ceil(Double(clipSpanSeconds) / 30.0)))
+
       await AppLogger.shared.log(
         "TAIL_DIAG: workerText=[\(candidateText?.suffix(60) ?? "nil")] "
           + "tailText=[\(tailText.suffix(60))] "
           + "overlapStart=\(String(format: "%.1f", overlapStartSeconds))s "
           + "uncoveredDuration=\(String(format: "%.1f", tailDurationSeconds))s "
-          + "tailDecodeMs=\(tailMs)",
+          + "tailDecodeMs=\(tailMs) "
+          + "impliedWindows=\(impliedWindowCount)",
         level: .info, category: "WhisperKitWorker"
       )
 
       if !tailText.isEmpty {
-        let finalText = candidateText! + " " + tailText
+        let finalText = Self.joinWithOverlapTrim(candidateText!, tailText)
         return IncrementalResult(
           text: finalText, samplesCovered: finalSamples.count,
           decodeCount: decodeCount, totalDecodeTimeMs: totalDecodeTimeMs,

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -212,6 +212,12 @@ package protocol ASREngineAdapter: AnyObject {
   /// Current warm-up / load readiness.
   var readiness: ASREngineReadiness { get }
 
+  /// #1275: duration of the most recent silent warm-up inference, in
+  /// milliseconds. `nil` for adapters without this concept (default, e.g.
+  /// Parakeet) or before the first load's warm-up completes. Read only for
+  /// an optional telemetry property — no consumer branches on it.
+  var lastWarmupInferenceMs: Int? { get }
+
   // MARK: Warm-up
 
   /// Idempotent, sessionless warm-up — drives `readiness` toward `.ready`.
@@ -377,6 +383,9 @@ extension ASREngineAdapter {
   /// generic warmup label. Concrete adapters override when they observe
   /// real phase strings.
   public var lastObservedPhase: String { "warmup" }
+
+  /// Default: no warm-up-inference concept (Parakeet). WhisperKit overrides.
+  public var lastWarmupInferenceMs: Int? { nil }
 
   // PR-5 Rung 2A: no-op defaults for the three optional hooks. Adapters
   // with meaningful semantics override; the others inherit these.

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -235,10 +235,15 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// model load via `adapter.warmUp()` — idempotent and single-flighted by the
   /// backend (`WhisperKitBackend.loadTask` / `ASRManager.inFlightLoadTask`), so a
   /// press landing during a launch/onboarding warm-up JOINS the in-flight load
-  /// rather than starting a second compile. "Loaded" already means "first press
-  /// instant" (measured 2026-06-01: no first-inference penalty), so this drives
-  /// the normal load only — no `prewarm` (it would load twice) and no
-  /// dummy-transcribe.
+  /// rather than starting a second compile. This drives the normal load only
+  /// — no `prewarm` (it would load twice). #1275: the earlier "loaded already
+  /// means first press instant, no dummy-transcribe" claim here (measured
+  /// 2026-06-01) turned out to be path-dependent — a warm-cache relaunch
+  /// showed a real first-decode penalty, contradicting that cold-load
+  /// measurement. WhisperKit's backend now runs its own silent warm-up
+  /// inference inside `loadFromPath` before flipping `isReady`, so "loaded"
+  /// now genuinely means "first press instant" regardless of load path; see
+  /// `whisperkit-research.md` for the full finding.
   ///
   /// Never throws into callers (a warm-up failure must not crash the heart-path
   /// press); it returns an `EngineWarmupOutcome` instead. Most callers discard
@@ -270,7 +275,8 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       residentModelLostWhileIdle = false  // #959: load succeeded — drop stale marker.
       let ms = Self.elapsedMs(since: start)
       TelemetryService.shared.coldStartWarmupCompleted(
-        engine: engine, reason: reason.telemetryToken, durationMs: ms)
+        engine: engine, reason: reason.telemetryToken, durationMs: ms,
+        inferenceWarmupMs: adapter.lastWarmupInferenceMs)
       if reason == .launch {
         TelemetryService.shared.launchModelPreloadCompleted(
           backend: engine, result: warmupInFlight ? "joined_in_flight" : "success",

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -82,6 +82,11 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// any subsequent `@MainActor` reader without an intervening `await`.
   private var cachedReadiness: ASREngineReadiness = .notReady
 
+  /// #1275: synchronously-readable cache of the backend's most recent
+  /// warm-up inference duration, refreshed alongside `cachedReadiness`
+  /// wherever `warmUp()` observes the backend reaching `.ready`.
+  private var cachedWarmupInferenceMs: Int?
+
   // MARK: Engine state
 
   /// Issue #445: held `prepare()` task so `cancel()` can cancel its host
@@ -215,6 +220,9 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
 
   var readiness: ASREngineReadiness { cachedReadiness }
 
+  /// #1275: read-only pass-through of the cached warm-up duration.
+  var lastWarmupInferenceMs: Int? { cachedWarmupInferenceMs }
+
   // MARK: ASREngineAdapter — warm-up
 
   /// Idempotent, sessionless warm-up. Held `prepareTask` so `cancel()` can
@@ -225,6 +233,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   func warmUp() async throws {
     if await backend.isReady {
       cachedReadiness = .ready
+      cachedWarmupInferenceMs = await backend.lastWarmupInferenceMs
       return
     }
     cachedReadiness = .warming
@@ -240,6 +249,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
       // reports a false success on an unready engine.
       let ready = await captured.isReady
       cachedReadiness = ready ? .ready : .notReady
+      cachedWarmupInferenceMs = ready ? await captured.lastWarmupInferenceMs : nil
       guard ready else { throw ASRLoadSupersededError() }
     } catch {
       prepareTask = nil
@@ -251,13 +261,14 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// Cache-only warm-up — intentionally a near no-op for WhisperKit.
   ///
   /// Earlier drafts dispatched `prepareIfCached()` here on a detached `Task`
-  /// to silently load a cached model during the kernel's `preWarm` hop. But
-  /// `WhisperKitBackend.prepareIfCached()` does NOT participate in
-  /// `prepare()`'s `loadTask` single-flight guard at
-  /// `WhisperKitBackend.swift:61-97` — so a detached `prepareIfCached` racing
-  /// the kernel's spawned `warmUp()` (which calls `prepare()`) can launch
-  /// two concurrent CoreML loads, doubling cold-start work and memory
-  /// pressure (Codex code-diff r5).
+  /// to silently load a cached model during the kernel's `preWarm` hop, but a
+  /// detached `prepareIfCached` racing the kernel's spawned `warmUp()`
+  /// (which calls `prepare()`) risked two concurrent CoreML loads. #1275
+  /// routed `prepareIfCached()` through the SAME `loadTask` single-flight
+  /// owner `prepare()` uses (`WhisperKitBackend.swift`'s `loadIfNeeded`), so
+  /// that specific race is now closed at the backend layer regardless of
+  /// caller. This adapter still does not dispatch a detached
+  /// `prepareIfCached` here, since it remains unnecessary:
   ///
   /// In the kernel-driven flow, the kernel's spawned `warmUp()` path
   /// already calls `prepare()`, which internally checks
@@ -266,10 +277,13 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// the cached-load optimization is preserved by `prepare()`'s own cache
   /// branch, and the single-flight guard prevents duplicate loads.
   ///
-  /// Side effect: keep `cachedReadiness` refreshed against the backend's
-  /// current state so a recently-unloaded model is reported as `.notReady`.
+  /// Side effect: keep `cachedReadiness`/`cachedWarmupInferenceMs` refreshed
+  /// against the backend's current state so a recently-unloaded model is
+  /// reported as `.notReady`.
   func warmUpFromCache() async throws {
-    cachedReadiness = await backend.isReady ? .ready : .notReady
+    let ready = await backend.isReady
+    cachedReadiness = ready ? .ready : .notReady
+    cachedWarmupInferenceMs = ready ? await backend.lastWarmupInferenceMs : nil
   }
 
   /// WhisperKit / CoreML exposes no model-load progress signal. The kernel
@@ -1161,6 +1175,10 @@ extension WhisperKitEngineAdapter {
 package protocol WhisperKitBackendDriving: Actor {
   var isReady: Bool { get }
   var modelVariantName: String { get }
+  /// #1275 item A: duration of the most recent silent warm-up inference, in
+  /// milliseconds. `nil` until the first load's warm-up reaches a terminal
+  /// state (completed/threw/timed-out — only `.completed` sets it).
+  var lastWarmupInferenceMs: Int? { get }
   func prepare() async throws
   // periphery:ignore - protocol requirement (witnessed by WhisperKitBackend)
   func prepareIfCached() async throws -> Bool

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -550,15 +550,23 @@ public final class TelemetryService {
   }
 
   /// Cold-boot warm-up reached `.ready`. `durationMs` is `ready_at − warmup_started_at`.
-  public func coldStartWarmupCompleted(engine: String, reason: String, durationMs: Int) {
-    PostHogSDK.shared.capture(
-      "coldstart.warmup_completed",
-      properties: [
-        "engine": engine,
-        "reason": reason,
-        "duration_ms": durationMs,
-        "$value": Double(durationMs) / 1000.0,
-      ])
+  /// #1275: `inferenceWarmupMs` is an optional property carrying the WhisperKit
+  /// silent warm-up inference's own duration (nested inside `durationMs`, not
+  /// additive) — absent/nil for Parakeet and for pre-#1275 rows. Query by
+  /// presence; no consumer branches on magnitude.
+  public func coldStartWarmupCompleted(
+    engine: String, reason: String, durationMs: Int, inferenceWarmupMs: Int? = nil
+  ) {
+    var properties: [String: Any] = [
+      "engine": engine,
+      "reason": reason,
+      "duration_ms": durationMs,
+      "$value": Double(durationMs) / 1000.0,
+    ]
+    if let inferenceWarmupMs {
+      properties["inference_warmup_ms"] = inferenceWarmupMs
+    }
+    PostHogSDK.shared.capture("coldstart.warmup_completed", properties: properties)
   }
 
   /// Cold-boot warm-up failed — the engine stays not-ready and the next press

--- a/Tests/EnviousWisprASRTests/WhisperKitWorkerFinalizeSelectionTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitWorkerFinalizeSelectionTests.swift
@@ -221,6 +221,14 @@ struct JoinWithOverlapTrimTests {
     #expect(result == "hello there, how are you completely unrelated continuation text")
   }
 
+  @Test(
+    "short coincidental match below minOverlap does not trim (Codex r1 P2 repro: 'I am' / 'amazing today')"
+  )
+  func test_shortCoincidentalMatch_belowMinOverlap_noTrim() {
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim("I am", "amazing today")
+    #expect(result == "I am amazing today")
+  }
+
   @Test("empty tail returns candidate unchanged")
   func test_emptyTail_returnsCandidate() {
     let result = WhisperKitIncrementalWorker.joinWithOverlapTrim("candidate text", "")

--- a/Tests/EnviousWisprASRTests/WhisperKitWorkerFinalizeSelectionTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitWorkerFinalizeSelectionTests.swift
@@ -168,12 +168,22 @@ struct WorkerFinalizeBoundaryTests {
       [makeResult(text: "the beginning of the sentence")],
       [makeResult(text: "the rest of the sentence")],  // tail decode result
     ])
+    // Adversarial-review finding (#1275): the original 20ms cadence / 30ms
+    // sleep gave only ~1.5x margin (10ms) for the first decode to land
+    // before cancel() — a real CI-flakiness risk under scheduler contention,
+    // since typical OS scheduler jitter is a roughly fixed few-ms magnitude
+    // rather than a percentage of the interval. The sleep must land strictly
+    // between one cadence tick (≥1 decode fires) and two (the fake's second
+    // scripted entry, meant for the LATER tail-decode call, is never
+    // consumed by a second cadence decode) — 40ms cadence / 60ms sleep keeps
+    // the same 50% margin ratio but doubles the absolute buffer on each side
+    // (20ms vs 10ms), meaningfully more robust to scheduler jitter.
     let worker = WhisperKitIncrementalWorker(
-      whisperKit: fake, decodingOptions: DecodingOptions(), cadence: .milliseconds(20))
+      whisperKit: fake, decodingOptions: DecodingOptions(), cadence: .milliseconds(40))
 
     let samples = [Float](repeating: 0, count: shortModeSampleCount)
     await worker.start(audioSamplesProvider: { (samples: samples, count: samples.count) })
-    try await Task.sleep(for: .milliseconds(30))
+    try await Task.sleep(for: .milliseconds(60))
     await worker.cancel()  // stop after exactly one short-mode decode
 
     // Large uncovered tail with actual signal (not silence) so the RMS gate

--- a/Tests/EnviousWisprASRTests/WhisperKitWorkerFinalizeSelectionTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitWorkerFinalizeSelectionTests.swift
@@ -63,6 +63,19 @@ struct SelectCandidateTextTests {
 private actor FakeWhisperKitTranscribing: WhisperKitTranscribing {
   private var scriptedResults: [[TranscriptionResult]]
   private(set) var callCount = 0
+  // CI flakiness fix (#1275): resolved from within `transcribe()` itself, so a
+  // caller can await "the Nth decode call has actually happened" instead of a
+  // fixed wall-clock sleep. A prior version of this fake had no such signal,
+  // forcing tests to guess a sleep duration (20ms/40ms cadence, 30ms/60ms
+  // sleep) that a real CI runner's scheduler jitter could still miss —
+  // exactly the failure mode `timeout-numbers-need-distribution-evidence`
+  // warns about. Resolving inside the SAME actor as the call, before
+  // returning, plus Swift's actor-reentrancy guarantee that the worker actor
+  // runs its post-transcribe state update (`decodeCount += 1`, etc.)
+  // synchronously with no intervening `await` before its next suspension
+  // point, makes a subsequent `worker.cancel()` call race-free: it is
+  // guaranteed to observe that update rather than a stale pre-decode state.
+  private var waiters: [(threshold: Int, continuation: CheckedContinuation<Void, Never>)] = []
 
   init(scriptedResults: [[TranscriptionResult]]) {
     self.scriptedResults = scriptedResults
@@ -73,8 +86,22 @@ private actor FakeWhisperKitTranscribing: WhisperKitTranscribing {
   {
     let index = callCount
     callCount += 1
+    let reached = callCount
+    waiters.removeAll { waiter in
+      guard reached >= waiter.threshold else { return false }
+      waiter.continuation.resume()
+      return true
+    }
     guard index < scriptedResults.count else { return [] }
     return scriptedResults[index]
+  }
+
+  /// Suspends until `transcribe()` has been called at least `n` times.
+  func waitForCallCount(_ n: Int) async {
+    if callCount >= n { return }
+    await withCheckedContinuation { continuation in
+      waiters.append((threshold: n, continuation: continuation))
+    }
   }
 }
 
@@ -106,7 +133,9 @@ struct WorkerFinalizeBoundaryTests {
 
     let samples = [Float](repeating: 0, count: shortModeSampleCount)
     await worker.start(audioSamplesProvider: { (samples: samples, count: samples.count) })
-    try await Task.sleep(for: .milliseconds(150))  // let >=2 short-mode decodes fire
+    // CI flakiness fix (#1275): deterministic signal instead of a fixed
+    // sleep — wait for the second scripted decode to actually happen.
+    await fake.waitForCallCount(2)
 
     // finalSamples crosses the 30s boundary; the tail beyond shortModeSampleCount
     // is silence (all zeros), so the RMS gate skips the tail decode — this
@@ -130,7 +159,8 @@ struct WorkerFinalizeBoundaryTests {
 
     let samples = [Float](repeating: 0, count: 300_000)
     await worker.start(audioSamplesProvider: { (samples: samples, count: samples.count) })
-    try await Task.sleep(for: .milliseconds(60))
+    // CI flakiness fix (#1275): deterministic signal instead of a fixed sleep.
+    await fake.waitForCallCount(1)
 
     // isLong = count > threshold (strict), so exactly the threshold is short-mode.
     let finalSamples = [Float](repeating: 0, count: Self.longRecordingThreshold)
@@ -149,7 +179,8 @@ struct WorkerFinalizeBoundaryTests {
 
     let samples = [Float](repeating: 0, count: 300_000)
     await worker.start(audioSamplesProvider: { (samples: samples, count: samples.count) })
-    try await Task.sleep(for: .milliseconds(60))
+    // CI flakiness fix (#1275): deterministic signal instead of a fixed sleep.
+    await fake.waitForCallCount(1)
 
     let finalSamples = [Float](repeating: 0, count: Self.longRecordingThreshold + 1)
     let result = await worker.finalize(finalSamples: finalSamples, speechSegments: [])
@@ -168,22 +199,21 @@ struct WorkerFinalizeBoundaryTests {
       [makeResult(text: "the beginning of the sentence")],
       [makeResult(text: "the rest of the sentence")],  // tail decode result
     ])
-    // Adversarial-review finding (#1275): the original 20ms cadence / 30ms
-    // sleep gave only ~1.5x margin (10ms) for the first decode to land
-    // before cancel() — a real CI-flakiness risk under scheduler contention,
-    // since typical OS scheduler jitter is a roughly fixed few-ms magnitude
-    // rather than a percentage of the interval. The sleep must land strictly
-    // between one cadence tick (≥1 decode fires) and two (the fake's second
-    // scripted entry, meant for the LATER tail-decode call, is never
-    // consumed by a second cadence decode) — 40ms cadence / 60ms sleep keeps
-    // the same 50% margin ratio but doubles the absolute buffer on each side
-    // (20ms vs 10ms), meaningfully more robust to scheduler jitter.
+    // CI flakiness fix (#1275): a fixed wall-clock sleep (previously 30ms,
+    // then 60ms after a widen-and-hope pass) still failed on a real CI
+    // runner under scheduler contention — "did decode #1 actually complete
+    // yet" cannot be answered by guessing a duration long enough. Replaced
+    // with a signal from the fake itself (`waitForCallCount`): wait for the
+    // first `transcribe()` call to actually happen, then cancel immediately.
+    // A generous cadence (500ms) means even a slow-to-resume test task has
+    // enormous margin before the loop's own next sleep could complete and
+    // fire a second decode — the risk this test guards against.
     let worker = WhisperKitIncrementalWorker(
-      whisperKit: fake, decodingOptions: DecodingOptions(), cadence: .milliseconds(40))
+      whisperKit: fake, decodingOptions: DecodingOptions(), cadence: .milliseconds(500))
 
     let samples = [Float](repeating: 0, count: shortModeSampleCount)
     await worker.start(audioSamplesProvider: { (samples: samples, count: samples.count) })
-    try await Task.sleep(for: .milliseconds(60))
+    await fake.waitForCallCount(1)  // deterministic: the first decode has happened
     await worker.cancel()  // stop after exactly one short-mode decode
 
     // Large uncovered tail with actual signal (not silence) so the RMS gate

--- a/Tests/EnviousWisprASRTests/WhisperKitWorkerFinalizeSelectionTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitWorkerFinalizeSelectionTests.swift
@@ -1,0 +1,290 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+@preconcurrency import WhisperKit
+
+@testable import EnviousWisprASR
+
+/// #1275 item B: the 30s-boundary candidate-selection fix. A recording that
+/// crosses the boundary between the worker's last short-mode decode and
+/// finalize must use the worker's `lastFullResult`, not discard it because
+/// `accumulatedText` (the long-mode accumulation) is empty.
+@Suite("WhisperKitIncrementalWorker.selectCandidateText")
+struct SelectCandidateTextTests {
+
+  @Test("short-mode: always returns lastFullResult regardless of accumulatedText")
+  func test_shortMode_returnsLastFullResult() {
+    let result = WhisperKitIncrementalWorker.selectCandidateText(
+      isLong: false, accumulatedText: "", lastFullResult: "hello world")
+    #expect(result == "hello world")
+  }
+
+  @Test("long-mode: non-empty accumulatedText wins (existing long-path behavior preserved)")
+  func test_longMode_nonEmptyAccumulated_wins() {
+    let result = WhisperKitIncrementalWorker.selectCandidateText(
+      isLong: true, accumulatedText: "clipped accumulation", lastFullResult: "stale full result")
+    #expect(result == "clipped accumulation")
+  }
+
+  @Test(
+    "long-mode boundary case (#1275 B fix): empty accumulatedText falls back to lastFullResult instead of discarding"
+  )
+  func test_longMode_emptyAccumulated_fallsBackToLastFullResult() {
+    let result = WhisperKitIncrementalWorker.selectCandidateText(
+      isLong: true, accumulatedText: "", lastFullResult: "seven short-mode decodes worth of text")
+    #expect(result == "seven short-mode decodes worth of text")
+  }
+
+  @Test("long-mode boundary case: whitespace-only accumulatedText also falls back")
+  func test_longMode_whitespaceOnlyAccumulated_fallsBackToLastFullResult() {
+    let result = WhisperKitIncrementalWorker.selectCandidateText(
+      isLong: true, accumulatedText: "   \n  ", lastFullResult: "the real text")
+    #expect(result == "the real text")
+  }
+
+  @Test("long-mode: both empty returns nil (preserves no_worker fallback)")
+  func test_longMode_bothEmpty_returnsNil() {
+    let result = WhisperKitIncrementalWorker.selectCandidateText(
+      isLong: true, accumulatedText: "", lastFullResult: nil)
+    #expect(result == nil)
+  }
+
+  @Test("short-mode: nil lastFullResult returns nil (preserves no_worker fallback)")
+  func test_shortMode_nilLastFullResult_returnsNil() {
+    let result = WhisperKitIncrementalWorker.selectCandidateText(
+      isLong: false, accumulatedText: "irrelevant in short mode", lastFullResult: nil)
+    #expect(result == nil)
+  }
+}
+
+/// Scripted fake decoder — returns each entry in order, one per `transcribe`
+/// call, so a test can assert exactly what the worker's run loop and tail
+/// decode saw.
+private actor FakeWhisperKitTranscribing: WhisperKitTranscribing {
+  private var scriptedResults: [[TranscriptionResult]]
+  private(set) var callCount = 0
+
+  init(scriptedResults: [[TranscriptionResult]]) {
+    self.scriptedResults = scriptedResults
+  }
+
+  func transcribe(audioArray: [Float], decodeOptions: DecodingOptions?) async throws
+    -> [TranscriptionResult]
+  {
+    let index = callCount
+    callCount += 1
+    guard index < scriptedResults.count else { return [] }
+    return scriptedResults[index]
+  }
+}
+
+private func makeResult(text: String) -> TranscriptionResult {
+  TranscriptionResult(text: text, segments: [], language: "en", timings: TranscriptionTimings())
+}
+
+/// Worker-level finalize characterization via a real (fast-cadence) run loop
+/// + scripted fake decoder — proves the fix end-to-end, not just the pure
+/// selection function, for the exact boundary session shape from the
+/// founder's 2026-07-02 log: several short-mode cadence decodes, then a final
+/// sample count that crosses the 480,000-sample (30s) threshold.
+@Suite("WhisperKitIncrementalWorker.finalize boundary characterization")
+struct WorkerFinalizeBoundaryTests {
+
+  private static let longRecordingThreshold = 16_000 * 30  // 480,000 samples
+
+  @Test(
+    "boundary session: short-mode decodes then final count crosses 480,000 uses worker text (not no_worker) (#1275 B)"
+  )
+  func test_boundarySession_usesWorkerText() async throws {
+    let shortModeSampleCount = 400_000  // under threshold — short mode
+    let fake = FakeWhisperKitTranscribing(scriptedResults: [
+      [makeResult(text: "why are you wearing")],
+      [makeResult(text: "why are you wearing lingerie outside")],
+    ])
+    let worker = WhisperKitIncrementalWorker(
+      whisperKit: fake, decodingOptions: DecodingOptions(), cadence: .milliseconds(20))
+
+    let samples = [Float](repeating: 0, count: shortModeSampleCount)
+    await worker.start(audioSamplesProvider: { (samples: samples, count: samples.count) })
+    try await Task.sleep(for: .milliseconds(150))  // let >=2 short-mode decodes fire
+
+    // finalSamples crosses the 30s boundary; the tail beyond shortModeSampleCount
+    // is silence (all zeros), so the RMS gate skips the tail decode — this
+    // isolates the assertion to candidate selection, not the tail path.
+    let finalSamples = [Float](repeating: 0, count: Self.longRecordingThreshold + 20_000)
+    let result = await worker.finalize(finalSamples: finalSamples, speechSegments: [])
+
+    #expect(result.decodeCount > 0)
+    #expect(result.strategy != "no_worker")
+    #expect(result.accepted == true)
+    #expect(result.text != nil)
+  }
+
+  @Test("off-by-one: final count exactly at threshold (480,000) stays short-mode")
+  func test_finalCount_exactlyAtThreshold_staysShortMode() async throws {
+    let fake = FakeWhisperKitTranscribing(scriptedResults: [
+      [makeResult(text: "short mode decode")]
+    ])
+    let worker = WhisperKitIncrementalWorker(
+      whisperKit: fake, decodingOptions: DecodingOptions(), cadence: .milliseconds(20))
+
+    let samples = [Float](repeating: 0, count: 300_000)
+    await worker.start(audioSamplesProvider: { (samples: samples, count: samples.count) })
+    try await Task.sleep(for: .milliseconds(60))
+
+    // isLong = count > threshold (strict), so exactly the threshold is short-mode.
+    let finalSamples = [Float](repeating: 0, count: Self.longRecordingThreshold)
+    let result = await worker.finalize(finalSamples: finalSamples, speechSegments: [])
+
+    #expect(result.mode.hasPrefix("full"))  // short-mode base, not "clipped"
+  }
+
+  @Test("off-by-one: final count one sample past threshold (480,001) is long-mode")
+  func test_finalCount_onePastThreshold_isLongMode() async throws {
+    let fake = FakeWhisperKitTranscribing(scriptedResults: [
+      [makeResult(text: "short mode decode")]
+    ])
+    let worker = WhisperKitIncrementalWorker(
+      whisperKit: fake, decodingOptions: DecodingOptions(), cadence: .milliseconds(20))
+
+    let samples = [Float](repeating: 0, count: 300_000)
+    await worker.start(audioSamplesProvider: { (samples: samples, count: samples.count) })
+    try await Task.sleep(for: .milliseconds(60))
+
+    let finalSamples = [Float](repeating: 0, count: Self.longRecordingThreshold + 1)
+    let result = await worker.finalize(finalSamples: finalSamples, speechSegments: [])
+
+    #expect(result.mode.hasPrefix("clipped"))  // long-mode base
+    // #1275 B fix: even though long-mode, the empty accumulatedText (worker
+    // never took the isLongRecording branch) must fall back to the worker's
+    // short-mode text, not discard it as no_worker.
+    #expect(result.strategy != "no_worker")
+  }
+
+  @Test("stale worker with large uncovered tail (real speech) routes through tail decode")
+  func test_staleWorker_largeUncoveredTail_routesThroughTailDecode() async throws {
+    let shortModeSampleCount = 100_000
+    let fake = FakeWhisperKitTranscribing(scriptedResults: [
+      [makeResult(text: "the beginning of the sentence")],
+      [makeResult(text: "the rest of the sentence")],  // tail decode result
+    ])
+    let worker = WhisperKitIncrementalWorker(
+      whisperKit: fake, decodingOptions: DecodingOptions(), cadence: .milliseconds(20))
+
+    let samples = [Float](repeating: 0, count: shortModeSampleCount)
+    await worker.start(audioSamplesProvider: { (samples: samples, count: samples.count) })
+    try await Task.sleep(for: .milliseconds(30))
+    await worker.cancel()  // stop after exactly one short-mode decode
+
+    // Large uncovered tail with actual signal (not silence) so the RMS gate
+    // triggers the tail decode.
+    var finalSamples = [Float](repeating: 0, count: shortModeSampleCount)
+    finalSamples.append(contentsOf: (0..<200_000).map { Float(sin(Double($0) * 0.1)) * 0.5 })
+    let result = await worker.finalize(finalSamples: finalSamples, speechSegments: [])
+
+    #expect(result.strategy == "worker+tail")
+    #expect(result.text?.contains("the rest of the sentence") == true)
+  }
+}
+
+/// #1275 item D: the worker/tail seam-overlap trim. Reproduced 2026-07-02 via
+/// controlled TTS (`why are you wearing lingerie outside?` / tail starting
+/// `gerie outside?`) and via the founder's own log capture.
+@Suite("WhisperKitIncrementalWorker.joinWithOverlapTrim")
+struct JoinWithOverlapTrimTests {
+
+  @Test("exact overlap: tail repeats the candidate's full tail phrase")
+  func test_exactOverlap() {
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim(
+      "the meeting starts at nine", "at nine we should be ready")
+    #expect(result == "the meeting starts at nine we should be ready")
+  }
+
+  @Test("partial-token overlap: tail starts mid-word, matching source case (#1275 founder repro)")
+  func test_partialTokenOverlap() {
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim(
+      "why are you wearing lingerie outside?", "gerie outside? She's like, doing dishes.")
+    #expect(result == "why are you wearing lingerie outside? She's like, doing dishes.")
+  }
+
+  @Test("partial-token overlap is case-insensitive")
+  func test_partialTokenOverlap_caseInsensitive() {
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim(
+      "why are you wearing LINGERIE outside?", "gerie Outside? She's like, doing dishes.")
+    #expect(result == "why are you wearing LINGERIE outside? She's like, doing dishes.")
+  }
+
+  @Test("no overlap: naive join preserved")
+  func test_noOverlap_naiveJoin() {
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim(
+      "hello there, how are you", "completely unrelated continuation text")
+    #expect(result == "hello there, how are you completely unrelated continuation text")
+  }
+
+  @Test("empty tail returns candidate unchanged")
+  func test_emptyTail_returnsCandidate() {
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim("candidate text", "")
+    #expect(result == "candidate text")
+  }
+
+  @Test("empty candidate returns tail unchanged")
+  func test_emptyCandidate_returnsTail() {
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim("", "tail text")
+    #expect(result == "tail text")
+  }
+
+  @Test("diverging trailing punctuation prevents a match (no wrong trim)")
+  func test_divergingPunctuation_noMatch() {
+    // Candidate ends "No." (period); tail starts "No," (comma) — literal
+    // mismatch at the boundary, so the trimmer must not guess a match.
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim(
+      "I said no.", "No, I really mean it.")
+    #expect(result == "I said no. No, I really mean it.")
+  }
+
+  @Test(
+    "legitimate repeated word at the seam is trimmed (accepted residual risk, #1275 §7 — documents current behavior, not a target to preserve)"
+  )
+  func test_legitimateRepetitionAtSeam_isTrimmed() {
+    // The speaker genuinely said "outside outside" — text alone cannot
+    // distinguish this from acoustic-overlap duplication, so one copy is
+    // lost. This is the accepted trade-off documented in the plan's §7
+    // failure-mode table; the test exists so a future change to this
+    // behavior is a deliberate decision, not a silent regression.
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim(
+      "he was standing outside", "outside in the pouring rain")
+    #expect(result == "he was standing outside in the pouring rain")
+  }
+
+  @Test("bounded window: overlap beyond ~80 characters is not matched")
+  func test_overlapBeyondWindow_notMatched() {
+    let longRepeatedSuffix = String(repeating: "word ", count: 30)  // 150 chars
+    let candidate = "prefix text " + longRepeatedSuffix
+    let tail = longRepeatedSuffix + "continuation"
+    let result = WhisperKitIncrementalWorker.joinWithOverlapTrim(candidate, tail)
+    // The true overlap (150 chars) exceeds the 80-char window, so only a
+    // partial match within the window is found (or none) — assert the
+    // function terminates and never drops the tail's continuation.
+    #expect(result.contains("continuation"))
+  }
+
+  @Test(
+    "no-op sweep over unrelated sentence pairs: no unwanted trims across a small representative corpus"
+  )
+  func test_noOpSweep_unrelatedPairs() {
+    // Lighter-weight stand-in for "run over a large fixed text corpus" —
+    // representative sentence-boundary pairs with no genuine audio-overlap
+    // duplication. None should trim any text from the tail.
+    let pairs: [(String, String)] = [
+      ("The quarterly report needs two more charts.", "It should be ready by Friday."),
+      ("She picked up the phone and said hello.", "Then she waited for a response."),
+      ("The weather today is sunny and warm.", "Tomorrow looks like rain."),
+      ("He finished the presentation early.", "The client seemed impressed."),
+      ("We should schedule a follow-up meeting.", "Next Tuesday works for everyone."),
+    ]
+    for (candidate, tail) in pairs {
+      let result = WhisperKitIncrementalWorker.joinWithOverlapTrim(candidate, tail)
+      #expect(result == candidate + " " + tail)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
+++ b/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
@@ -24,6 +24,9 @@ actor StubWhisperKitBackend: WhisperKitBackendDriving {
   /// from this value on every transition.
   var isReady = false
   var modelVariantName: String = "stub-whisperkit-large-v3"
+  /// #1275: stub for the warm-up-inference duration read. Defaults nil
+  /// (matches a fresh backend before any load's warm-up completes).
+  var lastWarmupInferenceMs: Int?
   var prepareThrows: (any Error)?
   var prepareIfCachedThrows: (any Error)?
   var prepareIfCachedResult: Bool = true


### PR DESCRIPTION
## Summary

- Fixes the WhisperKit first-decode latency penalty (item A): a silent warm-up inference runs after model load, gated by a fail-open safety mechanism, so the user's real first press never pays the one-time GPU warm-up cost.
- Fixes the 30-second-boundary bug that discarded already-transcribed text and forced a slow full re-decode (item B).
- Adds tail-decode diagnostics (item C).
- Bounds the seam-duplication trim with a minimum-match floor (item D) — **known residual gap documented below, not blocking this ship.**

Item A's warm-up/load-state mechanism went through multiple rounds of Codex review (code-diff + architecture consult) and adversarial subagent review before landing clean; full history in issue #1275.

## Known regression (accepted, tracked)

Live UAT found a real, non-rare duplication the seam trimmer can't catch: a duplicate phrase mid-sentence (not at the literal boundary) ships raw. Repro and full writeup: issue #1275 closeout comment. Structural fix tracked separately in #1276 (WhisperKit official streaming migration) — not something to patch further in this PR.

## Test plan

- [x] Full test suite green (2212 tests)
- [x] Live UAT: 11-case batch covering short/medium/long dictations, a recording crossing the 30s boundary (55s), seam-repeat stress cases, and numbers/dates — verified item A (fast first-press) and item B (no text loss crossing 30s) hold; item D's known gap reproduced and documented
- [x] Local Codex review (medium effort) iterated to clean across multiple rounds
- [ ] Cloud review gate (evaluate before arming auto-merge)

Closes #1275