### PR TITLE
test: replace wall-clock-guess flakes with signal-based waits (#1283)

### DIFF
--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
@@ -352,29 +352,36 @@ struct EngineCoordinatorTests {
 
   #if DEBUG
     @Test("idle apply emits change_applied with from/to + defer_ms/switch_ms")
-    func telemetryChangeApplied() async {
-      let box = EventBox()
-      TelemetryService.shared.testEventHook = { @Sendable e in box.append(e) }
+    func telemetryChangeApplied() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable e in
+        MainActor.assumeIsolated { waiter.record(e) }
+      }
       defer { TelemetryService.shared.testEventHook = nil }
 
       let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
       let c = fake.makeStartedCoordinator()
       fake.selected = .whisperKit
       c.poke(.settingsChanged)
-      _ = await enginePoll { fake.active == .whisperKit }
 
-      let applied = box.all.first { $0.name == "settings.change_applied" }
-      #expect(applied?.stringProps["to"] == "whisperKit")
-      #expect(applied?.stringProps["from"] == "parakeet")
-      #expect(applied?.boolProps["deferred"] == false)
-      #expect(applied?.intProps["switch_ms"] != nil)
-      #expect(applied?.intProps["defer_ms"] != nil)
+      // Wait on the telemetry EVENT, not the engine STATE: `fake.active` is set
+      // inside the fake switch, but `settings.change_applied` is emitted only
+      // after `performSwitch` returns — polling state then reading the box was
+      // the signal mismatch (#1283).
+      let applied = try await waiter.waitForEvent(named: "settings.change_applied")
+      #expect(applied.stringProps["to"] == "whisperKit")
+      #expect(applied.stringProps["from"] == "parakeet")
+      #expect(applied.boolProps["deferred"] == false)
+      #expect(applied.intProps["switch_ms"] != nil)
+      #expect(applied.intProps["defer_ms"] != nil)
     }
 
     @Test("deferred apply emits change_blocked(pipeline_active) then change_applied(deferred)")
-    func telemetryBlockedThenDeferredApplied() async {
-      let box = EventBox()
-      TelemetryService.shared.testEventHook = { @Sendable e in box.append(e) }
+    func telemetryBlockedThenDeferredApplied() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable e in
+        MainActor.assumeIsolated { waiter.record(e) }
+      }
       defer { TelemetryService.shared.testEventHook = nil }
 
       let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
@@ -384,23 +391,30 @@ struct EngineCoordinatorTests {
       c.poke(.settingsChanged)
       _ = await enginePoll { c.status.blockedReason == .pipelineActive }
 
-      let blocked = box.all.first { $0.name == "settings.change_blocked" }
+      // `settings.change_blocked` is emitted synchronously with the blocked
+      // state (Codex-confirmed not a mismatch), so the state poll is a valid
+      // proxy; read it from the recorded history.
+      let blocked = waiter.events.first { $0.name == "settings.change_blocked" }
       #expect(blocked?.stringProps["reason"] == "pipeline_active")
       #expect(blocked?.stringProps["requested"] == "whisperKit")
 
       fake.parakeetActive = false
       c.poke(.driverStateChanged)
-      _ = await enginePoll { fake.active == .whisperKit }
-      let applied = box.all.first {
-        $0.name == "settings.change_applied" && $0.stringProps["to"] == "whisperKit"
-      }
-      #expect(applied?.boolProps["deferred"] == true)
+      // Deferred apply: wait on the EVENT, not `fake.active` — the deferred
+      // `settings.change_applied` is emitted after performSwitch returns (#1283).
+      let applied = try await waiter.waitForEvent(
+        matching: {
+          $0.name == "settings.change_applied" && $0.stringProps["to"] == "whisperKit"
+        }, describedAs: "settings.change_applied(to: whisperKit)")
+      #expect(applied.boolProps["deferred"] == true)
     }
 
     @Test("change_blocked is emitted once per epoch per reason")
     func telemetryBlockedOncePerEpoch() async {
-      let box = EventBox()
-      TelemetryService.shared.testEventHook = { @Sendable e in box.append(e) }
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable e in
+        MainActor.assumeIsolated { waiter.record(e) }
+      }
       defer { TelemetryService.shared.testEventHook = nil }
 
       let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
@@ -413,7 +427,10 @@ struct EngineCoordinatorTests {
       c.poke(.driverStateChanged)
       c.poke(.driverStateChanged)
       _ = await enginePoll(.milliseconds(120)) { false }
-      let blockedCount = box.all.filter {
+      // Negative window: the first blocked event landed synchronously with the
+      // blocked state above; the 120ms drain proves no SECOND emit. Count from
+      // the recorded history.
+      let blockedCount = waiter.events.filter {
         $0.name == "settings.change_blocked" && $0.stringProps["reason"] == "pipeline_active"
       }.count
       #expect(blockedCount == 1, "blocked telemetry must fire once per epoch, got \(blockedCount)")
@@ -421,8 +438,10 @@ struct EngineCoordinatorTests {
 
     @Test("a superseded switch emits engine.switch_superseded")
     func telemetrySuperseded() async {
-      let box = EventBox()
-      TelemetryService.shared.testEventHook = { @Sendable e in box.append(e) }
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable e in
+        MainActor.assumeIsolated { waiter.record(e) }
+      }
       defer { TelemetryService.shared.testEventHook = nil }
 
       let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
@@ -437,13 +456,15 @@ struct EngineCoordinatorTests {
       _ = await enginePoll { c.isSwitching }
       latch.release()
       _ = await enginePoll { fake.active == .parakeet && !c.isSwitching }
-      #expect(box.all.contains { $0.name == "engine.switch_superseded" })
+      #expect(waiter.events.contains { $0.name == "engine.switch_superseded" })
     }
 
     @Test("a failed warm emits engine.warm(failed) + engine.switch_failed")
-    func telemetryWarmFailed() async {
-      let box = EventBox()
-      TelemetryService.shared.testEventHook = { @Sendable e in box.append(e) }
+    func telemetryWarmFailed() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable e in
+        MainActor.assumeIsolated { waiter.record(e) }
+      }
       defer { TelemetryService.shared.testEventHook = nil }
 
       let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
@@ -451,26 +472,17 @@ struct EngineCoordinatorTests {
       let c = fake.makeStartedCoordinator()
       fake.selected = .whisperKit
       c.poke(.settingsChanged)
-      _ = await enginePoll {
-        if case .failed = c.status.switchPhase { return true }
-        return false
-      }
-      #expect(box.all.contains { $0.name == "engine.switch_failed" })
-      #expect(
-        box.all.contains { $0.name == "engine.warm" && $0.stringProps["outcome"] == "failed" })
+      // Wait on the EVENTS, not `switchPhase` state: `engine.warm(failed)` and
+      // `engine.switch_failed` are emitted after the warm attempt returns, while
+      // switchPhase flips inside it — the signal mismatch (#1283). History makes
+      // the two waits order-independent.
+      _ = try await waiter.waitForEvent(named: "engine.switch_failed")
+      _ = try await waiter.waitForEvent(
+        matching: { $0.name == "engine.warm" && $0.stringProps["outcome"] == "failed" },
+        describedAs: "engine.warm(outcome: failed)")
     }
   #endif
 }
-
-#if DEBUG
-  /// Sendable capture box for the DEBUG `testEventHook`.
-  private final class EventBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var events: [CapturedTelemetryEvent] = []
-    func append(_ e: CapturedTelemetryEvent) { lock.withLock { events.append(e) } }
-    var all: [CapturedTelemetryEvent] { lock.withLock { events } }
-  }
-#endif
 
 /// A one-shot MainActor latch so a test can hold a switch/warm `await` open and
 /// assert mid-flight state, then release it.

--- a/Tests/EnviousWisprTests/App/UpdateCoordinatorProactiveCheckTests.swift
+++ b/Tests/EnviousWisprTests/App/UpdateCoordinatorProactiveCheckTests.swift
@@ -224,15 +224,12 @@ struct UpdateCoordinatorProactiveCheckTests {
 
   #if DEBUG
 
-    /// Sendable storage box for the `@Sendable` testEventHook closure.
-    @MainActor final class EventBox { var events: [CapturedTelemetryEvent] = [] }
-
     @Test("emits proactive_check_triggered fired=true when it fires")
-    func emitsTelemetryFiredTrue() async {
-      let box = EventBox()
+    func emitsTelemetryFiredTrue() async throws {
+      let waiter = TelemetryEventWaiter()
       let originalHook = TelemetryService.shared.testEventHook
       TelemetryService.shared.testEventHook = { @Sendable event in
-        Task { @MainActor in box.events.append(event) }
+        MainActor.assumeIsolated { waiter.record(event) }
       }
       defer { TelemetryService.shared.testEventHook = originalHook }
 
@@ -240,23 +237,18 @@ struct UpdateCoordinatorProactiveCheckTests {
       let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil)
       coordinator.checkForUpdatesProactively(trigger: "launch", probe: fake)
 
-      await Task.yield()
-      await Task.yield()
-
-      let evt = box.events.first { $0.name == "update.proactive_check_triggered" }
-      #expect(
-        evt != nil, "Expected update.proactive_check_triggered. Got \(box.events.map(\.name)).")
-      #expect(evt?.stringProps["trigger"] == "launch")
-      #expect(evt?.stringProps["reason"] == "fired")
-      #expect(evt?.boolProps["fired"] == true)
+      let evt = try await waiter.waitForEvent(named: "update.proactive_check_triggered")
+      #expect(evt.stringProps["trigger"] == "launch")
+      #expect(evt.stringProps["reason"] == "fired")
+      #expect(evt.boolProps["fired"] == true)
     }
 
     @Test("emits proactive_check_triggered fired=false when cooldown-skipped")
-    func emitsTelemetryFiredFalseOnCooldownSkip() async {
-      let box = EventBox()
+    func emitsTelemetryFiredFalseOnCooldownSkip() async throws {
+      let waiter = TelemetryEventWaiter()
       let originalHook = TelemetryService.shared.testEventHook
       TelemetryService.shared.testEventHook = { @Sendable event in
-        Task { @MainActor in box.events.append(event) }
+        MainActor.assumeIsolated { waiter.record(event) }
       }
       defer { TelemetryService.shared.testEventHook = originalHook }
 
@@ -268,14 +260,10 @@ struct UpdateCoordinatorProactiveCheckTests {
       let fake = FakeProactiveUpdater(autoChecks: true, lastCheck: nil)
       coordinator.checkForUpdatesProactively(trigger: "foreground", now: now, probe: fake)
 
-      await Task.yield()
-      await Task.yield()
-
-      let evt = box.events.first { $0.name == "update.proactive_check_triggered" }
-      #expect(evt != nil)
-      #expect(evt?.stringProps["trigger"] == "foreground")
-      #expect(evt?.stringProps["reason"] == "cooldown")
-      #expect(evt?.boolProps["fired"] == false)
+      let evt = try await waiter.waitForEvent(named: "update.proactive_check_triggered")
+      #expect(evt.stringProps["trigger"] == "foreground")
+      #expect(evt.stringProps["reason"] == "cooldown")
+      #expect(evt.boolProps["fired"] == false)
     }
 
   #endif  // DEBUG

--- a/Tests/EnviousWisprTests/LLM/EGOneServerManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneServerManagerTests.swift
@@ -88,9 +88,21 @@ struct EGOneServerManagerTests {
     config.serverBinaryURL = URL(fileURLWithPath: "/usr/bin/true")
     config.extraArguments = []
     await manager.start(configuration: config)
-    // Give the termination handler a beat to land.
-    try await Task.sleep(for: .milliseconds(500))
-    let state = await manager.state
+    // Process death is observed asynchronously via `terminationHandler`, so
+    // `start()` can return before the terminal `.failed` state lands. Poll the
+    // REAL terminal state (bounded, fail-fast) instead of guessing a fixed
+    // sleep the CI runner might overshoot: the process dies in <10ms locally so
+    // this exits on the first poll; the 5s ceiling is jitter-proof headroom on
+    // a contended runner. `Task.sleep` here is the poll cadence, not a
+    // correctness-bearing wait (#1283).
+    var state = await manager.state
+    var polls = 0
+    while polls < 200 {
+      if case .failed = state { break }
+      try await Task.sleep(for: .milliseconds(25))
+      state = await manager.state
+      polls += 1
+    }
     #expect(
       state == .failed(reason: "crashed_during_start")
         || state == .failed(reason: "server_never_became_ready"))

--- a/Tests/EnviousWisprTests/LLM/EnviousOutputFilterWithClassifierTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EnviousOutputFilterWithClassifierTests.swift
@@ -66,17 +66,22 @@ import Testing
   @Test("non-cooperative synchronous block is bounded by the deadline and fails open")
   func nonCooperativeBlockFailsOpen() async {
     // A stuck synchronous inference (500ms thread block, ignores cancellation):
-    // the 50ms deadline must still return the sync result well before the block
-    // ends — proving withDeadline does not await the abandoned operation.
-    let clock = ContinuousClock()
-    let elapsed = await clock.measure {
-      let result = await EnviousOutputFilter.filterWithClassifier(
-        input: Self.cleanInput, output: Self.cleanOutput,
-        classifier: StubOutputClassifier(.blockSync(seconds: 0.5, then: 0.99)))
-      #expect(result.fellBackToRaw == false)
-      #expect(result.tripped == nil)
-    }
-    #expect(elapsed < .milliseconds(400), "deadline did not bound the caller: \(elapsed)")
+    // the 50ms deadline must return the sync result BEFORE the block ends —
+    // proving withDeadline does not await the abandoned operation. The outcome
+    // (fellBackToRaw == false) already proves the timed-out 0.99 discard was
+    // never applied; `didFinishBlock == false` additionally proves the CALLER
+    // was released before the 500ms block finished. This relative ordering is
+    // robust at any runner speed — no wall-clock bound to flake on a slow CI
+    // runner (#1283, replaces the prior `elapsed < 400ms` measurement).
+    let classifier = StubOutputClassifier(.blockSync(seconds: 0.5, then: 0.99))
+    let result = await EnviousOutputFilter.filterWithClassifier(
+      input: Self.cleanInput, output: Self.cleanOutput, classifier: classifier)
+    #expect(result.fellBackToRaw == false)
+    #expect(result.tripped == nil)
+    #expect(
+      classifier.didFinishBlock == false,
+      "deadline did not bound the caller: the 500ms block finished before filterWithClassifier returned"
+    )
   }
 
   @Test("NaN score fails open")

--- a/Tests/EnviousWisprTests/LLM/EnviousOutputFilterWithClassifierTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EnviousOutputFilterWithClassifierTests.swift
@@ -65,24 +65,29 @@ import Testing
 
   @Test("non-cooperative synchronous block is bounded by the deadline and fails open")
   func nonCooperativeBlockFailsOpen() async {
-    // A stuck synchronous inference (a multi-second thread block that ignores
-    // cancellation): the 50ms deadline must return the sync result rather than
-    // wait for the block. The OUTCOME alone proves the deadline bounded the
-    // caller with no timing assertion: `withDeadline` (TaskTimeout.swift) is
-    // first-to-claim — it returns `nil` ONLY when the deadline branch wins, and
-    // it resumes the caller the instant that branch claims, without awaiting the
-    // operation. If instead the block had won, it would have returned 0.99 →
-    // classifier_discard → fellBackToRaw == true. So `fellBackToRaw == false`
-    // ⟺ the deadline branch won ⟺ the caller was released at the deadline.
-    // The block is long (2s) so the deadline's 50ms sleep would have to inflate
-    // ~40x before the block could win — no wall-clock bound, nothing sampled
-    // after the caller returns (#1283; cloud-review r1 killed the earlier
-    // post-return `didFinishBlock` sample, which had a reschedule race).
+    // A stuck inference that ignores cancellation: the 50ms deadline must
+    // release the caller BEFORE the block completes. The block parks on a gate
+    // the test controls, making the ordering DETERMINISTIC — no wall-clock
+    // bound, no post-return reschedule race (cloud-review r1/r2, #1283):
+    //  - while the gate is still closed the block provably cannot have
+    //    finished, so `didFinishBlock` must be false the instant
+    //    `filterWithClassifier` returns — this proves the caller was released at
+    //    the deadline, not after awaiting the block (the promptness guarantee);
+    //  - the outcome (`fellBackToRaw == false`) proves the abandoned 0.99 was
+    //    never applied (a block that won → classifier_discard → true);
+    //  - a regression that AWAITED the block would only return after the block's
+    //    ~10s safety cap, by which point `didFinishBlock` is true — caught as a
+    //    clean failure, not a hang.
+    let classifier = StubOutputClassifier(.gatedBlock(then: 0.99))
     let result = await EnviousOutputFilter.filterWithClassifier(
-      input: Self.cleanInput, output: Self.cleanOutput,
-      classifier: StubOutputClassifier(.blockSync(seconds: 2.0, then: 0.99)))
+      input: Self.cleanInput, output: Self.cleanOutput, classifier: classifier)
     #expect(result.fellBackToRaw == false)
     #expect(result.tripped == nil)
+    #expect(
+      classifier.didFinishBlock == false,
+      "withDeadline must release the caller at the 50ms deadline, before the abandoned block completes"
+    )
+    classifier.releaseGate()  // release the parked block so its pool thread frees promptly
   }
 
   @Test("NaN score fails open")

--- a/Tests/EnviousWisprTests/LLM/EnviousOutputFilterWithClassifierTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EnviousOutputFilterWithClassifierTests.swift
@@ -65,23 +65,24 @@ import Testing
 
   @Test("non-cooperative synchronous block is bounded by the deadline and fails open")
   func nonCooperativeBlockFailsOpen() async {
-    // A stuck synchronous inference (500ms thread block, ignores cancellation):
-    // the 50ms deadline must return the sync result BEFORE the block ends —
-    // proving withDeadline does not await the abandoned operation. The outcome
-    // (fellBackToRaw == false) already proves the timed-out 0.99 discard was
-    // never applied; `didFinishBlock == false` additionally proves the CALLER
-    // was released before the 500ms block finished. This relative ordering is
-    // robust at any runner speed — no wall-clock bound to flake on a slow CI
-    // runner (#1283, replaces the prior `elapsed < 400ms` measurement).
-    let classifier = StubOutputClassifier(.blockSync(seconds: 0.5, then: 0.99))
+    // A stuck synchronous inference (a multi-second thread block that ignores
+    // cancellation): the 50ms deadline must return the sync result rather than
+    // wait for the block. The OUTCOME alone proves the deadline bounded the
+    // caller with no timing assertion: `withDeadline` (TaskTimeout.swift) is
+    // first-to-claim — it returns `nil` ONLY when the deadline branch wins, and
+    // it resumes the caller the instant that branch claims, without awaiting the
+    // operation. If instead the block had won, it would have returned 0.99 →
+    // classifier_discard → fellBackToRaw == true. So `fellBackToRaw == false`
+    // ⟺ the deadline branch won ⟺ the caller was released at the deadline.
+    // The block is long (2s) so the deadline's 50ms sleep would have to inflate
+    // ~40x before the block could win — no wall-clock bound, nothing sampled
+    // after the caller returns (#1283; cloud-review r1 killed the earlier
+    // post-return `didFinishBlock` sample, which had a reschedule race).
     let result = await EnviousOutputFilter.filterWithClassifier(
-      input: Self.cleanInput, output: Self.cleanOutput, classifier: classifier)
+      input: Self.cleanInput, output: Self.cleanOutput,
+      classifier: StubOutputClassifier(.blockSync(seconds: 2.0, then: 0.99)))
     #expect(result.fellBackToRaw == false)
     #expect(result.tripped == nil)
-    #expect(
-      classifier.didFinishBlock == false,
-      "deadline did not bound the caller: the 500ms block finished before filterWithClassifier returned"
-    )
   }
 
   @Test("NaN score fails open")

--- a/Tests/EnviousWisprTests/LLM/OutputClassifierTestSupport.swift
+++ b/Tests/EnviousWisprTests/LLM/OutputClassifierTestSupport.swift
@@ -59,6 +59,15 @@ final class StubOutputClassifier: OutputClassifierProtocol, @unchecked Sendable 
   let behavior: Behavior
   init(_ behavior: Behavior) { self.behavior = behavior }
 
+  /// Set true only when a `.blockSync` body runs to completion. Lets a test
+  /// assert the deadline returned the caller BEFORE the block finished — a
+  /// relative-ordering signal that needs no wall-clock bound (#1283).
+  private let finishLock = NSLock()
+  private var _didFinishBlock = false
+  var didFinishBlock: Bool {
+    finishLock.withLock { _didFinishBlock }
+  }
+
   func score(input: String, polished: String) async throws -> Double {
     switch behavior {
     case let .score(value):
@@ -71,6 +80,7 @@ final class StubOutputClassifier: OutputClassifierProtocol, @unchecked Sendable 
       // stuck Core ML inference. `usleep` is a blocking C syscall (Thread.sleep
       // is banned in async contexts). The deadline must bound the caller anyway.
       usleep(UInt32(seconds * 1_000_000))
+      finishLock.withLock { _didFinishBlock = true }
       return then
     case .throwError:
       throw OutputClassifierError.disabled(.inferenceError)

--- a/Tests/EnviousWisprTests/LLM/OutputClassifierTestSupport.swift
+++ b/Tests/EnviousWisprTests/LLM/OutputClassifierTestSupport.swift
@@ -53,11 +53,30 @@ final class StubOutputClassifier: OutputClassifierProtocol, @unchecked Sendable 
   enum Behavior: Sendable {
     case score(Double)
     case sleep(seconds: Double, then: Double)
-    case blockSync(seconds: Double, then: Double)  // non-cooperative thread block
+    /// A NON-cooperative block (ignores cancellation) that parks the calling
+    /// cooperative-pool thread — polling a test-owned release flag with a
+    /// blocking `usleep`, like a stuck Core ML `MLModel.prediction`. It does NOT
+    /// complete until the test calls `releaseGate()` (or a ~10s iteration cap
+    /// elapses as a safety net). Lets a test prove `withDeadline` released the
+    /// caller at the deadline DETERMINISTICALLY: while the gate is still closed
+    /// the block cannot have completed, so `didFinishBlock` is false the instant
+    /// the caller returns — no wall-clock bound, no post-return reschedule race
+    /// (#1283, cloud-review r1/r2). A regression that AWAITED the block would
+    /// only return after the cap, failing cleanly instead of hanging.
+    case gatedBlock(then: Double)
     case throwError
   }
   let behavior: Behavior
   init(_ behavior: Behavior) { self.behavior = behavior }
+
+  private let lock = NSLock()
+  private var _released = false
+  private var _didFinishBlock = false
+  /// True once a `.gatedBlock` body has run to completion. Deterministically
+  /// false while the gate is still closed (before `releaseGate()`).
+  var didFinishBlock: Bool { lock.withLock { _didFinishBlock } }
+  /// Release a parked `.gatedBlock` so its thread can complete and free.
+  func releaseGate() { lock.withLock { _released = true } }
 
   func score(input: String, polished: String) async throws -> Double {
     switch behavior {
@@ -66,11 +85,18 @@ final class StubOutputClassifier: OutputClassifierProtocol, @unchecked Sendable 
     case let .sleep(seconds, then):
       try await Task.sleep(for: .seconds(seconds))
       return then
-    case let .blockSync(seconds, then):
-      // Synchronous, NON-cooperative block (ignores cancellation) — models a
-      // stuck Core ML inference. `usleep` is a blocking C syscall (Thread.sleep
-      // is banned in async contexts). The deadline must bound the caller anyway.
-      usleep(UInt32(seconds * 1_000_000))
+    case let .gatedBlock(then):
+      // Non-cooperative park: blocks the pool thread by polling the release flag
+      // with a 1ms `usleep` (a blocking syscall, allowed from async unlike
+      // `DispatchSemaphore.wait`). The ~10_000-iteration (~10s) cap is a safety
+      // net for a regression that awaits the block — it never binds the happy
+      // path, which is released within ~1ms of `releaseGate()`.
+      var iterations = 0
+      while iterations < 10_000, !lock.withLock({ _released }) {
+        usleep(1000)
+        iterations += 1
+      }
+      lock.withLock { _didFinishBlock = true }
       return then
     case .throwError:
       throw OutputClassifierError.disabled(.inferenceError)

--- a/Tests/EnviousWisprTests/LLM/OutputClassifierTestSupport.swift
+++ b/Tests/EnviousWisprTests/LLM/OutputClassifierTestSupport.swift
@@ -59,15 +59,6 @@ final class StubOutputClassifier: OutputClassifierProtocol, @unchecked Sendable 
   let behavior: Behavior
   init(_ behavior: Behavior) { self.behavior = behavior }
 
-  /// Set true only when a `.blockSync` body runs to completion. Lets a test
-  /// assert the deadline returned the caller BEFORE the block finished — a
-  /// relative-ordering signal that needs no wall-clock bound (#1283).
-  private let finishLock = NSLock()
-  private var _didFinishBlock = false
-  var didFinishBlock: Bool {
-    finishLock.withLock { _didFinishBlock }
-  }
-
   func score(input: String, polished: String) async throws -> Double {
     switch behavior {
     case let .score(value):
@@ -80,7 +71,6 @@ final class StubOutputClassifier: OutputClassifierProtocol, @unchecked Sendable 
       // stuck Core ML inference. `usleep` is a blocking C syscall (Thread.sleep
       // is banned in async contexts). The deadline must bound the caller anyway.
       usleep(UInt32(seconds * 1_000_000))
-      finishLock.withLock { _didFinishBlock = true }
       return then
     case .throwError:
       throw OutputClassifierError.disabled(.inferenceError)

--- a/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
@@ -109,22 +109,11 @@ struct DualModePolishTelemetryTests {
   // compile in both flavors. Coverage is preserved in dev test runs.
   #if DEBUG
 
-    /// Sendable storage box for the testEventHook closure. The hook runs on the
-    /// MainActor (TelemetryService is @MainActor) and `box.value` is only
-    /// touched from the main thread, but Swift 6 strict concurrency requires
-    /// the closure capture to be `Sendable`-safe.
-    @MainActor
-    final class EventBox {
-      var value: CapturedTelemetryEvent?
-    }
-
     @Test("TelemetryService emits the filter properties when populated")
-    func telemetryServiceEmitsNewProperties() async {
-      let box = EventBox()
+    func telemetryServiceEmitsNewProperties() async throws {
+      let waiter = TelemetryEventWaiter()
       TelemetryService.shared.testEventHook = { @Sendable event in
-        Task { @MainActor in
-          if event.name == "llm.polish_completed" { box.value = event }
-        }
+        MainActor.assumeIsolated { waiter.record(event) }
       }
       defer { TelemetryService.shared.testEventHook = nil }
 
@@ -137,24 +126,18 @@ struct DualModePolishTelemetryTests {
         fellBackToRaw: true
       )
 
-      // Allow the dispatched hook task to run.
-      await Task.yield()
-      try? await Task.sleep(nanoseconds: 5_000_000)
-
-      let event = try? #require(box.value)
-      #expect(event?.stringProps["provider"] == "appleIntelligence")
-      #expect(event?.stringProps["router_mode"] == nil)
-      #expect(event?.stringProps["filter_tripped"] == "code_shape_guard")
-      #expect(event?.boolProps["fell_back_to_raw"] == true)
+      let event = try await waiter.waitForEvent(named: "llm.polish_completed")
+      #expect(event.stringProps["provider"] == "appleIntelligence")
+      #expect(event.stringProps["router_mode"] == nil)
+      #expect(event.stringProps["filter_tripped"] == "code_shape_guard")
+      #expect(event.boolProps["fell_back_to_raw"] == true)
     }
 
     @Test("TelemetryService omits polish properties for cloud providers (nil params)")
-    func telemetryServiceOmitsForCloudProvider() async {
-      let box = EventBox()
+    func telemetryServiceOmitsForCloudProvider() async throws {
+      let waiter = TelemetryEventWaiter()
       TelemetryService.shared.testEventHook = { @Sendable event in
-        Task { @MainActor in
-          if event.name == "llm.polish_completed" { box.value = event }
-        }
+        MainActor.assumeIsolated { waiter.record(event) }
       }
       defer { TelemetryService.shared.testEventHook = nil }
 
@@ -163,22 +146,17 @@ struct DualModePolishTelemetryTests {
         result: "success", latencySeconds: 1.2
       )
 
-      await Task.yield()
-      try? await Task.sleep(nanoseconds: 5_000_000)
-
-      let event = try? #require(box.value)
-      #expect(event?.stringProps["provider"] == "openai")
-      #expect(event?.stringProps["filter_tripped"] == nil)
-      #expect(event?.boolProps["fell_back_to_raw"] == nil)
+      let event = try await waiter.waitForEvent(named: "llm.polish_completed")
+      #expect(event.stringProps["provider"] == "openai")
+      #expect(event.stringProps["filter_tripped"] == nil)
+      #expect(event.boolProps["fell_back_to_raw"] == nil)
     }
 
     @Test("TelemetryService emits fell_back_to_raw=false distinctly from absent")
-    func telemetryServiceEmitsFalseFellBack() async {
-      let box = EventBox()
+    func telemetryServiceEmitsFalseFellBack() async throws {
+      let waiter = TelemetryEventWaiter()
       TelemetryService.shared.testEventHook = { @Sendable event in
-        Task { @MainActor in
-          if event.name == "llm.polish_completed" { box.value = event }
-        }
+        MainActor.assumeIsolated { waiter.record(event) }
       }
       defer { TelemetryService.shared.testEventHook = nil }
 
@@ -189,13 +167,10 @@ struct DualModePolishTelemetryTests {
         fellBackToRaw: false
       )
 
-      await Task.yield()
-      try? await Task.sleep(nanoseconds: 5_000_000)
-
-      let event = try? #require(box.value)
-      #expect(event?.boolProps["fell_back_to_raw"] == false)
+      let event = try await waiter.waitForEvent(named: "llm.polish_completed")
+      #expect(event.boolProps["fell_back_to_raw"] == false)
       // filter_tripped absent (passed nil) — schema cleanliness
-      #expect(event?.stringProps["filter_tripped"] == nil)
+      #expect(event.stringProps["filter_tripped"] == nil)
     }
 
   #endif  // DEBUG (testEventHook tests)
@@ -411,12 +386,10 @@ struct DualModePolishTelemetryTests {
   #if DEBUG
 
     @Test("TelemetryService emits fallback_reason when passed")
-    func telemetryServiceEmitsFallbackReason() async {
-      let box = EventBox()
+    func telemetryServiceEmitsFallbackReason() async throws {
+      let waiter = TelemetryEventWaiter()
       TelemetryService.shared.testEventHook = { @Sendable event in
-        Task { @MainActor in
-          if event.name == "llm.polish_completed" { box.value = event }
-        }
+        MainActor.assumeIsolated { waiter.record(event) }
       }
       defer { TelemetryService.shared.testEventHook = nil }
 
@@ -426,21 +399,16 @@ struct DualModePolishTelemetryTests {
         filterTripped: nil, fellBackToRaw: true,
         fallbackReason: "no_change")
 
-      await Task.yield()
-      try? await Task.sleep(nanoseconds: 5_000_000)
-
-      let event = try? #require(box.value)
-      #expect(event?.stringProps["fallback_reason"] == "no_change")
-      #expect(event?.boolProps["fell_back_to_raw"] == true)
+      let event = try await waiter.waitForEvent(named: "llm.polish_completed")
+      #expect(event.stringProps["fallback_reason"] == "no_change")
+      #expect(event.boolProps["fell_back_to_raw"] == true)
     }
 
     @Test("TelemetryService omits fallback_reason when nil (cloud / not a fallback)")
-    func telemetryServiceOmitsFallbackReasonWhenNil() async {
-      let box = EventBox()
+    func telemetryServiceOmitsFallbackReasonWhenNil() async throws {
+      let waiter = TelemetryEventWaiter()
       TelemetryService.shared.testEventHook = { @Sendable event in
-        Task { @MainActor in
-          if event.name == "llm.polish_completed" { box.value = event }
-        }
+        MainActor.assumeIsolated { waiter.record(event) }
       }
       defer { TelemetryService.shared.testEventHook = nil }
 
@@ -448,11 +416,8 @@ struct DualModePolishTelemetryTests {
         provider: "openai", model: "gpt-4o-mini",
         result: "success", latencySeconds: 1.0)
 
-      await Task.yield()
-      try? await Task.sleep(nanoseconds: 5_000_000)
-
-      let event = try? #require(box.value)
-      #expect(event?.stringProps["fallback_reason"] == nil)
+      let event = try await waiter.waitForEvent(named: "llm.polish_completed")
+      #expect(event.stringProps["fallback_reason"] == nil)
     }
 
   #endif  // DEBUG

--- a/Tests/EnviousWisprTests/Pipeline/TestSupport/TelemetryEventWaiter.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TestSupport/TelemetryEventWaiter.swift
@@ -1,0 +1,108 @@
+#if DEBUG
+
+  import EnviousWisprServices
+  import Foundation
+
+  /// Test-only waiter for `TelemetryService.testEventHook` emissions (#1283).
+  ///
+  /// Lets a test `await` a SPECIFIC telemetry event instead of guessing a fixed
+  /// `Task.sleep` for a deferred hook to drain. Replaces the hand-rolled event
+  /// boxes + `Task.sleep(5ms)` / double-`Task.yield()` drains that flaked on
+  /// contended CI runners (`DualModePolishTelemetryTests`,
+  /// `UpdateCoordinatorProactiveCheckTests`) and the state-proxy-then-read
+  /// signal mismatches (`EngineCoordinatorTests`).
+  ///
+  /// `TelemetryService` is `@MainActor` (`TelemetryService.swift`) and invokes
+  /// `testEventHook?(…)` SYNCHRONOUSLY from its @MainActor emit methods — never
+  /// off-actor — so the hook records via `MainActor.assumeIsolated { record(_:) }`,
+  /// a synchronous record with NO `Task { @MainActor }` hop. That deferring hop
+  /// was the origin of the flakes this replaces; recording synchronously keeps
+  /// the history as immediate as the old `@unchecked Sendable` NSLock boxes, so
+  /// count/contains/negative-window reads are not regressed.
+  ///
+  /// Mirrors `SignalPipelineLogger`: `@MainActor` isolation makes the
+  /// "already present?" check and the waiter install atomic (no `await` between);
+  /// each waiter has a UUID so it resumes exactly once (removed before resume);
+  /// an internal timeout task guarantees a never-arriving event surfaces as a
+  /// fast failure instead of a hang (swift-patterns.md
+  /// `tests-no-unconditional-continuation-await`).
+  @MainActor
+  final class TelemetryEventWaiter {
+    private struct Waiter {
+      let id: UUID
+      let predicate: (CapturedTelemetryEvent) -> Bool
+      let describedAs: String
+      let timeoutSeconds: Double
+      let continuation: CheckedContinuation<CapturedTelemetryEvent, Error>
+    }
+
+    /// Full history of recorded events — a strict superset of the hand-rolled
+    /// event boxes, so `count` / `contains` reads use this directly.
+    private(set) var events: [CapturedTelemetryEvent] = []
+    private var waiters: [Waiter] = []
+
+    /// Record an emitted event and resume every waiter whose predicate now
+    /// matches (removed first so a later event cannot resume it twice).
+    func record(_ event: CapturedTelemetryEvent) {
+      events.append(event)
+      let matching = waiters.filter { $0.predicate(event) }
+      waiters.removeAll { waiter in matching.contains { $0.id == waiter.id } }
+      for waiter in matching { waiter.continuation.resume(returning: event) }
+    }
+
+    /// Await the next event whose `name` equals `name`. Returns immediately if
+    /// one is already recorded; else parks until it arrives, throwing
+    /// `TelemetryWaiterTimeout` if none does within `timeout` (fail fast).
+    @discardableResult
+    func waitForEvent(
+      named name: String,
+      timeout: Duration = .seconds(5)
+    ) async throws -> CapturedTelemetryEvent {
+      try await waitForEvent(
+        matching: { $0.name == name }, describedAs: name, timeout: timeout)
+    }
+
+    @discardableResult
+    func waitForEvent(
+      matching predicate: @escaping (CapturedTelemetryEvent) -> Bool,
+      describedAs description: String,
+      timeout: Duration = .seconds(5)
+    ) async throws -> CapturedTelemetryEvent {
+      if let existing = events.last(where: predicate) { return existing }
+
+      let id = UUID()
+      let seconds =
+        Double(timeout.components.seconds)
+        + Double(timeout.components.attoseconds) / 1e18
+      return try await withCheckedThrowingContinuation { continuation in
+        waiters.append(
+          Waiter(
+            id: id, predicate: predicate, describedAs: description,
+            timeoutSeconds: seconds, continuation: continuation))
+        Task { [weak self] in
+          try? await Task.sleep(for: timeout)
+          await self?.timeoutWaiter(id)
+        }
+      }
+    }
+
+    private func timeoutWaiter(_ id: UUID) {
+      guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+      let waiter = waiters.remove(at: index)
+      waiter.continuation.resume(
+        throwing: TelemetryWaiterTimeout(
+          event: waiter.describedAs, seconds: waiter.timeoutSeconds))
+    }
+  }
+
+  /// Thrown when a `TelemetryEventWaiter` deadline elapses before a matching
+  /// event arrives — names the awaited event so the test failure is actionable.
+  struct TelemetryWaiterTimeout: Error, CustomStringConvertible {
+    let event: String
+    let seconds: Double
+    var description: String {
+      "TelemetryEventWaiter timed out after \(seconds)s waiting for event: \(event)"
+    }
+  }
+
+#endif  // DEBUG


### PR DESCRIPTION
## What & why

Kills the remaining CI-flaky tests that waited a FIXED wall-clock duration then asserted async work had completed. They passed on the dev machine and flaked on the slow/contended GitHub runners, blocking merges until reruns. This is the **fix pass (PR 1 of 2)**; the recurrence-prevention guard is a separate follow-up (PR 2, tracked on #1283).

The big historical offenders (LoadProgressWatcher #782/#881, the simulator 64-schedule sweep #875/#1008) were already migrated to injected/fake clocks. A 2026-07-02 sweep (council + classification + 2 codex grounded rounds) found the survivors — all fixed here to wait on a real signal with a **bounded, fail-fast deadline** (a never-arriving signal fails loudly instead of hanging the runner — council's hard requirement).

## Changes

- **New reusable `@MainActor TelemetryEventWaiter`** (`Tests/EnviousWisprTests/Pipeline/TestSupport/`): event history + `waitForEvent(named:)`, modeled on `SignalPipelineLogger` (atomic already-present check, UUID waiter resolved once, internal timeout task). Records **synchronously** via `MainActor.assumeIsolated` because `TelemetryService` fires its hook on the main actor — no `Task`-hop deferral. That deferral was the *root cause* of the 5ms-sleep / double-yield flakes.
- **`DualModePolishTelemetryTests` (5), `UpdateCoordinatorProactiveCheckTests` (2)**: await the emitted event instead of `Task.sleep(5ms)` / `Task.yield()`.
- **`EngineCoordinatorTests`**: three state-before-telemetry mismatches (idle apply, deferred apply, warm-failed) now await the event; the blocked/superseded cases (confirmed not mismatched) keep their state poll and read the waiter's history.
- **`EGOneServerManagerTests`**: fixed 500ms sleep → bounded poll-to-terminal (5s ceiling, fail-fast); the sleep is now poll cadence, not a wait.
- **`EnviousOutputFilterWithClassifierTests`**: flaky `elapsed < 400ms` bound → relative-ordering signal (filter returned before the 500ms block finished, via a stub `didFinishBlock` flag) — no wall-clock literal, robust at any runner speed.

Test-only; no production code changed.

## Validation

- All 5 affected suites green; **full debug suite green**; release-config build green.
- Stability loop: the two real-time-touching suites (classifier ordering, EGOne poll) ran 10/10 clean.
- Local `codex review` clean (no correctness regression).
- Grounded review: 2 codex exec rounds converged scope (found 2 additional same-class flakes → included); a 3rd round's one open concurrency question (`@MainActor` waiter vs the count test) was resolved empirically by reading `TelemetryService` (@MainActor, synchronous hook).
- Live UAT: N/A — test-only change, no product code path exercised.

Closes #1283.