### PR TITLE
feat(settings): AI Polish on/off toggle with remembered engine (#1285)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -180,23 +180,43 @@ struct AIPolishSettingsView: View {
       BrandedSection(
         header: "LLM Provider",
         content: {
-          BrandedRow {
-            Picker("LLM Provider", selection: $settings.llmProvider) {
-              Text("Off").tag(LLMProvider.none)
-              Text("EG-1 (Recommended local model)").tag(LLMProvider.egOne)
-              Text("Apple Intelligence").tag(LLMProvider.appleIntelligence)
-              Text("OpenAI").tag(LLMProvider.openAI)
-              Text("Google Gemini").tag(LLMProvider.gemini)
-              Text("Local (Ollama)").tag(LLMProvider.ollama)
+          BrandedRow(showDivider: settings.llmProvider != .none) {
+            Toggle(
+              isOn: Binding(
+                get: { settings.llmProvider != .none },
+                set: { isOn in
+                  if isOn {
+                    // Restore the last real engine; fall back to the default if
+                    // none was ever remembered (guards against `.none`, #1285).
+                    settings.llmProvider =
+                      settings.lastLLMProvider == .none
+                      ? .appleIntelligence : settings.lastLLMProvider
+                  } else {
+                    settings.llmProvider = .none
+                  }
+                }
+              )
+            ) {
+              Text("AI Polish")
             }
           }
 
           if settings.llmProvider == .none {
-            BrandedRow {
+            BrandedRow(showDivider: false) {
               Text("Turn on AI polish to automatically fix grammar, punctuation, and formatting.")
                 .font(.stHelper)
                 .foregroundStyle(Color.stTextTertiary)
                 .fixedSize(horizontal: false, vertical: true)
+            }
+          } else {
+            BrandedRow {
+              Picker("LLM Provider", selection: $settings.llmProvider) {
+                Text("EG-1 (Recommended local model)").tag(LLMProvider.egOne)
+                Text("Apple Intelligence").tag(LLMProvider.appleIntelligence)
+                Text("OpenAI").tag(LLMProvider.openAI)
+                Text("Google Gemini").tag(LLMProvider.gemini)
+                Text("Local (Ollama)").tag(LLMProvider.ollama)
+              }
             }
           }
 

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -21,6 +21,10 @@ enum SettingsDefaultValues {
   // which made the real default ambiguous. Apple Intelligence is on-device; on
   // machines without it the polish limb degrades to raw text (heart path safe).
   static let llmProvider: LLMProvider = .appleIntelligence
+  // The engine restored when the AI Polish on/off toggle is turned back on and
+  // no engine was ever remembered (#1285). Mirrors the default engine so a
+  // fresh install that toggles off then on lands on Apple Intelligence.
+  static let lastLLMProvider: LLMProvider = llmProvider
   static let ollamaModel = "llama3.2"
 
   static let autoCopyToClipboard = true

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -67,7 +67,7 @@ public final class SettingsManager {
   /// (the #923 migration's source of truth). Excludes `useXPCAudioService`
   /// (per-build XPC debug knob) and `noiseSuppression` (removed/forced-off).
   public nonisolated static let unifiedDefaultsKeys: [String] = [
-    "selectedBackend", "recordingMode", "llmProvider", "llmModel", "ollamaModel",
+    "selectedBackend", "recordingMode", "llmProvider", "lastLLMProvider", "llmModel", "ollamaModel",
     "autoCopyToClipboard", "hotkeyEnabled", "vadAutoStop", "vadSilenceTimeout",
     "vadSensitivity", "vadEnergyGate", "onboardingState", "hasCompletedOnboarding",
     "cancelKeyCode", "cancelModifiersRaw", "toggleKeyCode", "toggleModifiersRaw",
@@ -108,7 +108,27 @@ public final class SettingsManager {
       // vs OpenAI both read `user`). Only async background discovery
       // (`applyDiscoveredModels`) is `system`.
       canonicalizeLLMModelForProvider()
+      // Remember the last real engine so the top on/off toggle can restore it
+      // when polish is turned back on (#1285). `.none` is the "off" state, not
+      // an engine, so it is never remembered. Maintained here (and seeded in
+      // init) so SettingsManager is the single owner of the remembered engine.
+      if llmProvider != .none {
+        lastLLMProvider = llmProvider
+      }
       onChange?(.llmProvider)
+    }
+  }
+
+  /// The last non-off polish engine the user selected. Backs the AI Polish
+  /// on/off toggle (#1285): turning polish off sets `llmProvider = .none`;
+  /// turning it back on restores this. Plain stored property with a persisting
+  /// `didSet` (NOT an observed setting with an `onChange` case) — nothing in the
+  /// pipeline reconciles on it, it is pure UI memory. Seeded in `init` with an
+  /// explicit write-through because Swift does not fire `didSet` for init
+  /// assignments.
+  public var lastLLMProvider: LLMProvider {
+    didSet {
+      defaults.set(lastLLMProvider.rawValue, forKey: "lastLLMProvider")
     }
   }
 
@@ -514,9 +534,21 @@ public final class SettingsManager {
     recordingMode =
       RecordingMode(rawValue: defaults.string(forKey: "recordingMode") ?? "")
       ?? SettingsDefaultValues.recordingMode
-    llmProvider =
+    let resolvedProvider =
       LLMProvider(rawValue: defaults.string(forKey: "llmProvider") ?? "")
       ?? SettingsDefaultValues.llmProvider
+    llmProvider = resolvedProvider
+    // Seed the remembered engine. If the key is already stored, honor it.
+    // Otherwise seed from the resolved provider (existing users keep their
+    // engine as the restore target) or the default when that is off. Write
+    // through explicitly: `didSet` does not fire on init assignment, so
+    // without this an upgrading user who toggles off then quits before ever
+    // switching engines would lose their remembered engine (#1285).
+    let seededLastProvider =
+      LLMProvider(rawValue: defaults.string(forKey: "lastLLMProvider") ?? "")
+      ?? (resolvedProvider != .none ? resolvedProvider : SettingsDefaultValues.lastLLMProvider)
+    lastLLMProvider = seededLastProvider
+    defaults.set(seededLastProvider.rawValue, forKey: "lastLLMProvider")
     llmModel = defaults.string(forKey: "llmModel") ?? LLMProvider.defaultModel(for: .openAI)
     ollamaModel = defaults.string(forKey: "ollamaModel") ?? SettingsDefaultValues.ollamaModel
     autoCopyToClipboard =

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -127,6 +127,30 @@ struct SettingsDefaultsRoutingTests {
     }
   #endif
 
+  // MARK: - lastLLMProvider (#1285 AI Polish on/off toggle memory)
+
+  @Test("lastLLMProvider persists to the injected store and is in the unified key set")
+  func lastLLMProviderPersists() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    settings.llmProvider = .openAI
+    #expect(suite.string(forKey: "lastLLMProvider") == LLMProvider.openAI.rawValue)
+    // Reload from the same store → the remembered engine survives.
+    #expect(SettingsManager(defaults: suite).lastLLMProvider == .openAI)
+    #expect(SettingsManager.unifiedDefaultsKeys.contains("lastLLMProvider"))
+  }
+
+  @Test("fresh install seeds lastLLMProvider to the default engine and writes it through")
+  func lastLLMProviderFreshSeed() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    #expect(settings.lastLLMProvider == SettingsDefaultValues.lastLLMProvider)
+    // Write-through: init must persist the seed even though didSet does not fire
+    // on init assignment (the upgrade-toggle-off-then-quit data-loss guard).
+    #expect(
+      suite.string(forKey: "lastLLMProvider") == SettingsDefaultValues.lastLLMProvider.rawValue)
+  }
+
   // MARK: - Migration (effective-state, dev-store sentinel)
 
   @Test("dev migration copies explicit values, clears stale shared, sets dev sentinel")

--- a/Tests/EnviousWisprTests/Services/SettingsManagerLastProviderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsManagerLastProviderTests.swift
@@ -1,0 +1,107 @@
+import AppKit
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1285 — the AI Polish on/off toggle remembers the last real engine so turning
+/// polish back on restores it. `lastLLMProvider` is the memory: seeded in init,
+/// maintained in the `llmProvider` didSet, never set to `.none`. Every test uses
+/// an ephemeral suite so nothing touches the real store.
+@MainActor
+@Suite("SettingsManager lastLLMProvider (#1285)")
+struct SettingsManagerLastProviderTests {
+  init() { _ = NSApplication.shared }  // @MainActor AppKit-touching SUT (swift-patterns)
+
+  private static func freshSuite() -> UserDefaults {
+    let name = "ew.lastProviderTest." + UUID().uuidString
+    let d = UserDefaults(suiteName: name)!
+    d.removePersistentDomain(forName: name)
+    return d
+  }
+
+  // MARK: - Seeding
+
+  @Test("upgrade: an existing engine with no remembered value seeds from that engine")
+  func seedsFromExistingProvider() {
+    let suite = Self.freshSuite()
+    suite.set(LLMProvider.openAI.rawValue, forKey: "llmProvider")
+    // No "lastLLMProvider" key present — the pre-#1285 upgrade case.
+    let settings = SettingsManager(defaults: suite)
+    #expect(settings.lastLLMProvider == .openAI)
+  }
+
+  @Test("an already-remembered engine is honored over the current engine")
+  func honorsStoredValue() {
+    let suite = Self.freshSuite()
+    suite.set(LLMProvider.ollama.rawValue, forKey: "llmProvider")
+    suite.set(LLMProvider.gemini.rawValue, forKey: "lastLLMProvider")
+    let settings = SettingsManager(defaults: suite)
+    #expect(settings.lastLLMProvider == .gemini)
+  }
+
+  @Test("polish already off with no memory seeds the default engine, never .none")
+  func seedsDefaultWhenOff() {
+    let suite = Self.freshSuite()
+    suite.set(LLMProvider.none.rawValue, forKey: "llmProvider")
+    let settings = SettingsManager(defaults: suite)
+    #expect(settings.lastLLMProvider == SettingsDefaultValues.lastLLMProvider)
+    #expect(settings.lastLLMProvider != .none)
+  }
+
+  @Test("an unparseable stored memory falls back to the current engine")
+  func unparseableFallsBack() {
+    let suite = Self.freshSuite()
+    suite.set(LLMProvider.gemini.rawValue, forKey: "llmProvider")
+    suite.set("not-a-provider", forKey: "lastLLMProvider")
+    let settings = SettingsManager(defaults: suite)
+    #expect(settings.lastLLMProvider == .gemini)
+  }
+
+  // MARK: - Maintenance (didSet)
+
+  @Test("switching to a real engine updates the memory")
+  func realEngineUpdatesMemory() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    settings.llmProvider = .gemini
+    #expect(settings.lastLLMProvider == .gemini)
+    settings.llmProvider = .ollama
+    #expect(settings.lastLLMProvider == .ollama)
+  }
+
+  @Test("turning polish off does NOT overwrite the remembered engine")
+  func offDoesNotOverwriteMemory() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    settings.llmProvider = .openAI
+    settings.llmProvider = .none
+    #expect(settings.lastLLMProvider == .openAI)
+  }
+
+  // MARK: - Toggle restore round trip (the view's on/off contract)
+
+  @Test("off then on restores the previously selected engine")
+  func offThenOnRestores() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    settings.llmProvider = .ollama
+    // Toggle off.
+    settings.llmProvider = .none
+    #expect(settings.llmProvider == .none)
+    // Toggle on → the view restores lastLLMProvider (guarding .none → default).
+    settings.llmProvider =
+      settings.lastLLMProvider == .none ? .appleIntelligence : settings.lastLLMProvider
+    #expect(settings.llmProvider == .ollama)
+  }
+
+  @Test("memory survives a reload after being turned off")
+  func memorySurvivesReloadWhileOff() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    settings.llmProvider = .openAI
+    settings.llmProvider = .none  // user turns polish off, then quits
+    // Relaunch: provider is off, but the remembered engine persists.
+    let reloaded = SettingsManager(defaults: suite)
+    #expect(reloaded.llmProvider == .none)
+    #expect(reloaded.lastLLMProvider == .openAI)
+  }
+}


### PR DESCRIPTION
## What

Phase 1 of the AI Polish tab redesign (#1281). Behavioral only — no layout or logos yet.

Replaces the provider dropdown's "Off" row with a **top on/off toggle**:
- **Off** → provider set to none (frees the local model via the existing reconcile seam).
- **On** → restores the last real engine you used.

The picker loses its "Off" row and is hidden while polish is off (a helper line shows instead).

## How

Adds a persisted `lastLLMProvider` on `SettingsManager` as the single owner of the remembered engine:
- Seeded in `init` with an explicit write-through (Swift doesn't fire `didSet` on init assignment — without this an upgrading user who toggles off then quits would lose their engine).
- Maintained in the `llmProvider` didSet; never set to `.none`.
- Registered in `unifiedDefaultsKeys` for the #923 cross-build migration.

The view only reads it. No new `SettingKey` case / `onChange` — nothing in the pipeline reconciles on this value, it's pure UI memory.

## Tests

- New `SettingsManagerLastProviderTests` (8 cases): upgrade seed, honor-stored, off-seeds-default-not-none, unparseable fallback, didSet maintenance, off-doesn't-overwrite, off→on restore round trip, memory-survives-reload.
- Extended `SettingsDefaultsRoutingTests`: persistence + unified-key membership + fresh-install write-through.
- `scripts/xcode-test.sh` green.

## Validation

- Local Codex code-diff review: clean, no findings.
- Live UAT on the dev build: toggle flips; off hides the engine list and shows the helper; on restores EG-1; local model shut down on off and came back on on; a real end-to-end dictation ran clean through EG-1 polish and paste (1.3s).

Part of #1285