### PR TITLE
feat(settings): redesign AI Polish tab as a master-detail engine rail (#1286 Phase 2)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -1,0 +1,524 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import SwiftUI
+
+// MARK: - Provider status (single at-a-glance authority)
+//
+// #1286 Phase 2. The rail's detail header shows exactly ONE status light per
+// selected engine. To avoid a sixth ad-hoc status mapping, this file owns the
+// single summary mapping (`ProviderStatusMapping.status`) that reads the SAME
+// coordinator values the existing inline controls read in `AIPolishSettingsView`
+// (EG-1 install/health, Apple availability, cloud key validation, Ollama setup).
+// The inline controls keep their detailed, actionable UI (refresh, download,
+// per-gate diagnostics); this chip is the "can I use this engine right now?"
+// summary. Partial-consolidation, not a takeover (plan §3c).
+
+/// Severity tone for the header status chip. Rendered as a colored dot + text
+/// label — never color-only, for colorblind / low-vision users (plan §3d).
+enum ProviderStatusTone: Equatable {
+  case ready  // green — usable now
+  case needsSetup  // amber — one action away (download / key / start)
+  case unavailable  // neutral — not offered on this Mac / not checked
+  case error  // red — broken, needs attention
+
+  /// The brand semantic color for this tone. Semantic tokens only, never raw
+  /// `.red`/`.green` (SettingsDesignTokens).
+  var color: Color {
+    switch self {
+    case .ready: return .stSuccess
+    case .needsSetup: return .stWarning
+    case .unavailable: return .stTextTertiary
+    case .error: return .stError
+    }
+  }
+}
+
+/// A resolved status summary for one engine: the short label and its tone.
+struct ProviderStatus: Equatable {
+  let label: String
+  let tone: ProviderStatusTone
+}
+
+/// The one place engine → (label, tone) is decided. Pure function of the
+/// coordinator states, so `ProviderStatusMappingTests` can exercise every
+/// engine's state grid without a running app. Switches on the provider FIRST
+/// and reads ONLY that provider's own coordinator state — a cloud key state
+/// never reaches an Apple/EG-1/Ollama branch and vice versa (plan §3, Codex r2:
+/// provider-first, no cross-provider leak).
+enum ProviderStatusMapping {
+  static func status(
+    for provider: LLMProvider,
+    egOneInstall: EGOneModelStore.InstallState,
+    egOneHealth: EGOneHealth,
+    appleStatus: AIAvailabilityStatus?,
+    cloudValidation: LLMModelDiscoveryCoordinator.KeyValidationState,
+    ollamaSetup: OllamaSetupState
+  ) -> ProviderStatus {
+    switch provider {
+    case .egOne:
+      return egOne(install: egOneInstall, health: egOneHealth)
+    case .appleIntelligence:
+      return apple(appleStatus)
+    case .openAI, .gemini:
+      return cloud(cloudValidation)
+    case .ollama:
+      return ollama(ollamaSetup)
+    case .none:
+      return ProviderStatus(label: "Off", tone: .unavailable)
+    }
+  }
+
+  // EG-1: install lifecycle first, health only once installed — mirrors the
+  // inline `egOneStatusContent` switch (installState first, health inside the
+  // `.installed` case). So the chip and the inline row read the same authority.
+  private static func egOne(
+    install: EGOneModelStore.InstallState, health: EGOneHealth
+  ) -> ProviderStatus {
+    switch install {
+    case .notInstalled:
+      return ProviderStatus(label: "Not installed", tone: .needsSetup)
+    case .downloading:
+      return ProviderStatus(label: "Downloading", tone: .needsSetup)
+    case .verifying:
+      return ProviderStatus(label: "Verifying", tone: .needsSetup)
+    case .failed:
+      return ProviderStatus(label: "Needs attention", tone: .error)
+    case .installed:
+      switch health {
+      case .green:
+        return ProviderStatus(label: "Live", tone: .ready)
+      case .yellow:
+        return ProviderStatus(label: "Starting", tone: .needsSetup)
+      case .red:
+        return ProviderStatus(label: "Not working", tone: .error)
+      }
+    }
+  }
+
+  // Apple Intelligence: unavailable/degraded/unknown/not-checked all read as the
+  // neutral "unavailable" tone (plan §3); available → ready.
+  private static func apple(_ status: AIAvailabilityStatus?) -> ProviderStatus {
+    switch status {
+    case .available:
+      return ProviderStatus(label: "Available", tone: .ready)
+    case .degraded:
+      return ProviderStatus(label: "Degraded", tone: .unavailable)
+    case .unavailable:
+      return ProviderStatus(label: "Unavailable", tone: .unavailable)
+    case .unknown:
+      return ProviderStatus(label: "Unknown", tone: .unavailable)
+    case nil:
+      return ProviderStatus(label: "Not checked", tone: .unavailable)
+    }
+  }
+
+  // Cloud (OpenAI / Gemini): keyed entirely off key validation state.
+  private static func cloud(
+    _ state: LLMModelDiscoveryCoordinator.KeyValidationState
+  ) -> ProviderStatus {
+    switch state {
+    case .idle:
+      return ProviderStatus(label: "Key needed", tone: .needsSetup)
+    case .validating:
+      return ProviderStatus(label: "Validating", tone: .needsSetup)
+    case .valid:
+      return ProviderStatus(label: "Key valid", tone: .ready)
+    case .invalid:
+      return ProviderStatus(label: "Key needed", tone: .error)
+    }
+  }
+
+  // Ollama: setup wizard state.
+  private static func ollama(_ state: OllamaSetupState) -> ProviderStatus {
+    switch state {
+    case .detecting:
+      return ProviderStatus(label: "Checking", tone: .needsSetup)
+    case .notInstalled:
+      return ProviderStatus(label: "Not installed", tone: .needsSetup)
+    case .installedNotRunning:
+      return ProviderStatus(label: "Not running", tone: .needsSetup)
+    case .runningNoModels:
+      return ProviderStatus(label: "No model", tone: .needsSetup)
+    case .pullingModel:
+      return ProviderStatus(label: "Downloading", tone: .needsSetup)
+    case .ready:
+      return ProviderStatus(label: "Running", tone: .ready)
+    case .error:
+      return ProviderStatus(label: "Error", tone: .error)
+    }
+  }
+}
+
+// MARK: - Rail catalog
+
+/// One row's presentation data. Order and grouping are the approved Direction-C
+/// handoff: "On this Mac" (EG-1, Apple, Ollama) then "Cloud" (OpenAI, Gemini),
+/// EG-1 pinned first and Recommended.
+struct PolishRailProvider: Identifiable, Equatable {
+  let provider: LLMProvider
+  let name: String
+  let tagline: String
+  let isLocal: Bool
+  let recommended: Bool
+
+  var id: LLMProvider { provider }
+}
+
+enum PolishRailCatalog {
+  static let local: [PolishRailProvider] = [
+    PolishRailProvider(
+      provider: .egOne, name: "EG-1", tagline: "Our tuned model",
+      isLocal: true, recommended: true),
+    PolishRailProvider(
+      provider: .appleIntelligence, name: "Apple Intelligence", tagline: "Built into macOS",
+      isLocal: true, recommended: false),
+    PolishRailProvider(
+      provider: .ollama, name: "Local (Ollama)", tagline: "Any open model",
+      isLocal: true, recommended: false),
+  ]
+  static let cloud: [PolishRailProvider] = [
+    PolishRailProvider(
+      provider: .openAI, name: "OpenAI", tagline: "Your API key",
+      isLocal: false, recommended: false),
+    PolishRailProvider(
+      provider: .gemini, name: "Google Gemini", tagline: "Your API key",
+      isLocal: false, recommended: false),
+  ]
+  static let all: [PolishRailProvider] = local + cloud
+
+  static func entry(for provider: LLMProvider) -> PolishRailProvider? {
+    all.first { $0.provider == provider }
+  }
+}
+
+// MARK: - Layout metrics
+
+/// Fixed measurements for the two-column master-detail. The settings window's
+/// 710pt minimum guarantees both columns fit, so the layout is always
+/// side-by-side and needs no adaptive width measurement.
+enum PolishRailMetrics {
+  /// Fixed rail column width. Sized to fit the longest engine name
+  /// ("Apple Intelligence") beside a 32pt logo tile without truncation.
+  static let railWidth: CGFloat = 232
+  /// Gap between the rail and the detail column.
+  static let columnGap: CGFloat = 16
+}
+
+// MARK: - Logo tile
+
+/// The rounded logo tile. One swap site for all five marks:
+/// - EG-1: the app's own animated brand mark (`RainbowLipsIcon`) drawn STATIC
+///   (audioLevel 0) so there is no fourth copy of the bar coordinates (plan §3c).
+/// - Apple: the `apple.logo` SF Symbol (empirically confirmed available).
+/// - OpenAI / Gemini / Ollama: their brand marks as inline SVG rendered via
+///   `NSImage(data:)`, template-tinted so one foreground color handles
+///   light/dark and selected/unselected (plan §3).
+/// Any mark that fails to build falls back to a lettered monogram so a row is
+/// never blank (the "Apple tile was empty" class from the preview, plan §7/§9).
+struct ProviderLogoTile: View {
+  let provider: LLMProvider
+  let size: CGFloat
+  let isSelected: Bool
+
+  private var cornerRadius: CGFloat { size * 0.28 }
+
+  var body: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .fill(tileBackground)
+      mark
+        .frame(width: size, height: size)
+    }
+    .frame(width: size, height: size)
+    .accessibilityHidden(true)  // decorative; the row's text label is the identifier
+  }
+
+  // EG-1 keeps its colored soundwave on a fixed dark chip so the brand mark
+  // always reads; every other tile follows the selected/unselected treatment.
+  private var tileBackground: Color {
+    if provider == .egOne {
+      return Color(red: 0.075, green: 0.063, blue: 0.098)  // brand ink, matches #131019
+    }
+    return isSelected ? Color.stAccent : Color.stAccentLight
+  }
+
+  private var markTint: Color {
+    isSelected ? Color.white : Color.stTextSecondary
+  }
+
+  @ViewBuilder
+  private var mark: some View {
+    switch provider {
+    case .egOne:
+      // Reuse the existing brand drawing statically (no audio drive). The mark
+      // fills ~78% of the tile with a little inset.
+      RainbowLipsIcon(size: size * 0.82, audioLevel: 0)
+    case .appleIntelligence:
+      appleMark
+    case .openAI:
+      svgMark(ProviderLogoSVG.openAI, inset: 0.62)
+    case .gemini:
+      svgMark(ProviderLogoSVG.gemini, inset: 0.60)
+    case .ollama:
+      svgMark(ProviderLogoSVG.ollama, inset: 0.60)
+    case .none:
+      monogram("--")
+    }
+  }
+
+  @ViewBuilder
+  private var appleMark: some View {
+    if NSImage(systemSymbolName: "apple.logo", accessibilityDescription: nil) != nil {
+      Image(systemName: "apple.logo")
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .frame(width: size * 0.52, height: size * 0.52)
+        .foregroundStyle(markTint)
+    } else {
+      monogram("")  // Apple glyph unavailable on the macOS-14 floor → letter fallback
+    }
+  }
+
+  /// Renders an inline SVG brand mark, template-tinted. `inset` is the fraction
+  /// of the tile the glyph occupies. Falls back to a monogram if the SVG fails
+  /// to rasterize (macOS-14-floor guard — plan §7 fallback).
+  @ViewBuilder
+  private func svgMark(_ svg: String, inset: CGFloat) -> some View {
+    if let image = ProviderLogoSVG.templateImage(svg) {
+      Image(nsImage: image)
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .frame(width: size * inset, height: size * inset)
+        .foregroundStyle(markTint)
+    } else {
+      monogram(ProviderLogoSVG.monogram(for: provider))
+    }
+  }
+
+  private func monogram(_ letters: String) -> some View {
+    Text(letters)
+      .font(.system(size: size * 0.42, weight: .semibold, design: .rounded))
+      .foregroundStyle(markTint)
+  }
+}
+
+/// Brand-mark SVG strings + the `NSImage(data:)` render helper. The three
+/// monochrome marks (OpenAI / Gemini / Ollama) are set `isTemplate = true` so
+/// SwiftUI `.foregroundStyle` tints them. Marks are used nominatively — solely
+/// to identify the provider being configured, monochrome, no endorsement.
+enum ProviderLogoSVG {
+  static func templateImage(_ svg: String) -> NSImage? {
+    guard let data = svg.data(using: .utf8), let image = NSImage(data: data),
+      image.isValid
+    else { return nil }
+    image.isTemplate = true
+    return image
+  }
+
+  static func monogram(for provider: LLMProvider) -> String {
+    switch provider {
+    case .openAI: return "OA"
+    case .gemini: return "G"
+    case .ollama: return "OL"
+    case .egOne: return "EG"
+    case .appleIntelligence: return ""
+    case .none: return "--"
+    }
+  }
+
+  private static func wrap(_ path: String) -> String {
+    "<svg viewBox=\"0 0 24 24\" width=\"24\" height=\"24\" fill=\"currentColor\">"
+      + "<path d=\"\(path)\"/></svg>"
+  }
+
+  static let openAI = wrap(
+    "M9.205 8.658v-2.26c0-.19.072-.333.238-.428l4.543-2.616c.619-.357 1.356-.523 2.117-.523 2.854 0 4.662 2.212 4.662 4.566 0 .167 0 .357-.024.547l-4.71-2.759a.797.797 0 00-.856 0l-5.97 3.473zm10.609 8.8V12.06c0-.333-.143-.57-.429-.737l-5.97-3.473 1.95-1.118a.433.433 0 01.476 0l4.543 2.617c1.309.76 2.189 2.378 2.189 3.948 0 1.808-1.07 3.473-2.76 4.163zM7.802 12.703l-1.95-1.142c-.167-.095-.239-.238-.239-.428V5.899c0-2.545 1.95-4.472 4.591-4.472 1 0 1.927.333 2.712.928L8.23 5.067c-.285.166-.428.404-.428.737v6.898zM12 15.128l-2.795-1.57v-3.33L12 8.658l2.795 1.57v3.33L12 15.128zm1.796 7.23c-1 0-1.927-.332-2.712-.927l4.686-2.712c.285-.166.428-.404.428-.737v-6.898l1.974 1.142c.167.095.238.238.238.428v5.233c0 2.545-1.974 4.472-4.614 4.472zm-5.637-5.303l-4.544-2.617c-1.308-.761-2.188-2.378-2.188-3.948A4.482 4.482 0 014.21 6.327v5.423c0 .333.143.571.428.738l5.947 3.449-1.95 1.118a.432.432 0 01-.476 0zm-.262 3.9c-2.688 0-4.662-2.021-4.662-4.519 0-.19.024-.38.047-.57l4.686 2.71c.286.167.571.167.856 0l5.97-3.448v2.26c0 .19-.07.333-.237.428l-4.543 2.616c-.619.357-1.356.523-2.117.523zm5.899 2.83a5.947 5.947 0 005.827-4.756C22.287 18.339 24 15.84 24 13.296c0-1.665-.713-3.282-1.998-4.448.119-.5.19-.999.19-1.498 0-3.401-2.759-5.947-5.946-5.947-.642 0-1.26.095-1.88.31A5.962 5.962 0 0010.205 0a5.947 5.947 0 00-5.827 4.757C1.713 5.447 0 7.945 0 10.49c0 1.666.713 3.283 1.998 4.448-.119.5-.19 1-.19 1.499 0 3.401 2.759 5.946 5.946 5.946.642 0 1.26-.095 1.88-.309a5.96 5.96 0 004.162 1.713z"
+  )
+
+  static let gemini = wrap(
+    "M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81"
+  )
+
+  static let ollama = wrap(
+    "M16.361 10.26a.894.894 0 0 0-.558.47l-.072.148.001.207c0 .193.004.217.059.353.076.193.152.312.291.448.24.238.51.3.872.205a.86.86 0 0 0 .517-.436.752.752 0 0 0 .08-.498c-.064-.453-.33-.782-.724-.897a1.06 1.06 0 0 0-.466 0zm-9.203.005c-.305.096-.533.32-.65.639a1.187 1.187 0 0 0-.06.52c.057.309.31.59.598.667.362.095.632.033.872-.205.14-.136.215-.255.291-.448.055-.136.059-.16.059-.353l.001-.207-.072-.148a.894.894 0 0 0-.565-.472 1.02 1.02 0 0 0-.474.007Zm4.184 2c-.131.071-.223.25-.195.383.031.143.157.288.353.407.105.063.112.072.117.136.004.038-.01.146-.029.243-.02.094-.036.194-.036.222.002.074.07.195.143.253.064.052.076.054.255.059.164.005.198.001.264-.03.169-.082.212-.234.15-.525-.052-.243-.042-.28.087-.355.137-.08.281-.219.324-.314a.365.365 0 0 0-.175-.48.394.394 0 0 0-.181-.033c-.126 0-.207.03-.355.124l-.085.053-.053-.032c-.219-.13-.259-.145-.391-.143a.396.396 0 0 0-.193.032zm.39-2.195c-.373.036-.475.05-.654.086-.291.06-.68.195-.951.328-.94.46-1.589 1.226-1.787 2.114-.04.176-.045.234-.045.53 0 .294.005.357.043.524.264 1.16 1.332 2.017 2.714 2.173.3.033 1.596.033 1.896 0 1.11-.125 2.064-.727 2.493-1.571.114-.226.169-.372.22-.602.039-.167.044-.23.044-.523 0-.297-.005-.355-.045-.531-.288-1.29-1.539-2.304-3.072-2.497a6.873 6.873 0 0 0-.855-.031zm.645.937a3.283 3.283 0 0 1 1.44.514c.223.148.537.458.671.662.166.251.26.508.303.82.02.143.01.251-.043.482-.08.345-.332.705-.672.957a3.115 3.115 0 0 1-.689.348c-.382.122-.632.144-1.525.138-.582-.006-.686-.01-.853-.042-.57-.107-1.022-.334-1.35-.68-.264-.28-.385-.535-.45-.946-.03-.192.025-.509.137-.776.136-.326.488-.73.836-.963.403-.269.934-.46 1.422-.512.187-.02.586-.02.773-.002zm-5.503-11a1.653 1.653 0 0 0-.683.298C5.617.74 5.173 1.666 4.985 2.819c-.07.436-.119 1.04-.119 1.503 0 .544.064 1.24.155 1.721.02.107.031.202.023.208a8.12 8.12 0 0 1-.187.152 5.324 5.324 0 0 0-.949 1.02 5.49 5.49 0 0 0-.94 2.339 6.625 6.625 0 0 0-.023 1.357c.091.78.325 1.438.727 2.04l.13.195-.037.064c-.269.452-.498 1.105-.605 1.732-.084.496-.095.629-.095 1.294 0 .67.009.803.088 1.266.095.555.288 1.143.503 1.534.071.128.243.393.264.407.007.003-.014.067-.046.141a7.405 7.405 0 0 0-.548 1.873c-.062.417-.071.552-.071.991 0 .56.031.832.148 1.279L3.42 24h1.478l-.05-.091c-.297-.552-.325-1.575-.068-2.597.117-.472.25-.819.498-1.296l.148-.29v-.177c0-.165-.003-.184-.057-.293a.915.915 0 0 0-.194-.25 1.74 1.74 0 0 1-.385-.543c-.424-.92-.506-2.286-.208-3.451.124-.486.329-.918.544-1.154a.787.787 0 0 0 .223-.531c0-.195-.07-.355-.224-.522a3.136 3.136 0 0 1-.817-1.729c-.14-.96.114-2.005.69-2.834.563-.814 1.353-1.336 2.237-1.475.199-.033.57-.028.776.01.226.04.367.028.512-.041.179-.085.268-.19.374-.431.093-.215.165-.333.36-.576.234-.29.46-.489.822-.729.413-.27.884-.467 1.352-.561.17-.035.25-.04.569-.04.319 0 .398.005.569.04a4.07 4.07 0 0 1 1.914.997c.117.109.398.457.488.602.034.057.095.177.132.267.105.241.195.346.374.43.14.068.286.082.503.045.343-.058.607-.053.943.016 1.144.23 2.14 1.173 2.581 2.437.385 1.108.276 2.267-.296 3.153-.097.15-.193.27-.333.419-.301.322-.301.722-.001 1.053.493.539.801 1.866.708 3.036-.062.772-.26 1.463-.533 1.854a2.096 2.096 0 0 1-.224.258.916.916 0 0 0-.194.25c-.054.109-.057.128-.057.293v.178l.148.29c.248.476.38.823.498 1.295.253 1.008.231 2.01-.059 2.581a.845.845 0 0 0-.044.098c0 .006.329.009.732.009h.73l.02-.074.036-.134c.019-.076.057-.3.088-.516.029-.217.029-1.016 0-1.258-.11-.875-.295-1.57-.597-2.226-.032-.074-.053-.138-.046-.141.008-.005.057-.074.108-.152.376-.569.607-1.284.724-2.228.031-.26.031-1.378 0-1.628-.083-.645-.182-1.082-.348-1.525a6.083 6.083 0 0 0-.329-.7l-.038-.064.131-.194c.402-.604.636-1.262.727-2.04a6.625 6.625 0 0 0-.024-1.358 5.512 5.512 0 0 0-.939-2.339 5.325 5.325 0 0 0-.95-1.02 8.097 8.097 0 0 1-.186-.152.692.692 0 0 1 .023-.208c.208-1.087.201-2.443-.017-3.503-.19-.924-.535-1.658-.98-2.082-.354-.338-.716-.482-1.15-.455-.996.059-1.8 1.205-2.116 3.01a6.805 6.805 0 0 0-.097.726c0 .036-.007.066-.015.066a.96.96 0 0 1-.149-.078A4.857 4.857 0 0 0 12 3.03c-.832 0-1.687.243-2.456.698a.958.958 0 0 1-.148.078c-.008 0-.015-.03-.015-.066a6.71 6.71 0 0 0-.097-.725C8.997 1.392 8.337.319 7.46.048a2.096 2.096 0 0 0-.585-.041Zm.293 1.402c.248.197.523.759.682 1.388.03.113.06.244.069.292.007.047.026.152.041.233.067.365.098.76.102 1.24l.002.475-.12.175-.118.178h-.278c-.324 0-.646.041-.954.124l-.238.06c-.033.007-.038-.003-.057-.144a8.438 8.438 0 0 1 .016-2.323c.124-.788.413-1.501.696-1.711.067-.05.079-.049.157.013zm9.825-.012c.17.126.358.46.498.888.28.854.36 2.028.212 3.145-.019.14-.024.151-.057.144l-.238-.06a3.693 3.693 0 0 0-.954-.124h-.278l-.119-.178-.119-.175.002-.474c.004-.669.066-1.19.214-1.772.157-.623.434-1.185.68-1.382.078-.062.09-.063.159-.012z"
+  )
+}
+
+// MARK: - Status chip
+
+/// 7pt dot + short text label. Color from the single mapping; text ALWAYS
+/// present so status never depends on color alone (plan §3d).
+struct ProviderStatusChip: View {
+  let status: ProviderStatus
+
+  var body: some View {
+    HStack(spacing: 5) {
+      Circle()
+        .fill(status.tone.color)
+        .frame(width: 7, height: 7)
+      Text(status.label)
+        .font(.stHelper)
+        .foregroundStyle(status.tone.color)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Status: \(status.label)")
+  }
+}
+
+// MARK: - Rail row
+
+/// One selectable engine row: logo tile + name (+ EG-1 star) + tagline. A native
+/// `Button` so it inherits AX button traits + Space/Enter activation; the
+/// explicit label/value/hint + `.accessibilityAction` guarantee VoiceOver reads
+/// "engine name, group, selected" and can activate it (plan §3d).
+struct ProviderRailRow: View {
+  let entry: PolishRailProvider
+  let isSelected: Bool
+  let onSelect: () -> Void
+
+  var body: some View {
+    Button(action: onSelect) {
+      HStack(spacing: 12) {
+        ProviderLogoTile(provider: entry.provider, size: 32, isSelected: isSelected)
+        VStack(alignment: .leading, spacing: 2) {
+          HStack(spacing: 6) {
+            Text(entry.name)
+              .font(.system(size: 14, weight: isSelected ? .semibold : .medium))
+              .foregroundStyle(isSelected ? Color.stAccent : Color.stTextSecondary)
+              .lineLimit(1)
+            if entry.recommended {
+              Image(systemName: "star.fill")
+                .font(.system(size: 10))
+                .foregroundStyle(Color.stAccent)
+            }
+          }
+          Text(entry.tagline)
+            .font(.system(size: 11.5))
+            .foregroundStyle(Color.stTextTertiary)
+            .lineLimit(1)
+        }
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 11)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+          .fill(isSelected ? Color.stAccentLight : Color.clear)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+          .strokeBorder(isSelected ? Color.stAccent : Color.clear, lineWidth: 1.5)
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityElement(children: .combine)
+    .accessibilityAddTraits(.isButton)
+    .accessibilityLabel("\(entry.name), \(entry.isLocal ? "on this Mac" : "cloud")")
+    .accessibilityValue(
+      isSelected
+        ? "Selected\(entry.recommended ? ", recommended" : "")"
+        : (entry.recommended ? "Recommended" : "")
+    )
+    .accessibilityHint("Selects \(entry.name) for AI polish")
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    .accessibilityAction { onSelect() }
+  }
+}
+
+// MARK: - Rail
+
+/// The grouped vertical rail: "On this Mac" then "Cloud". Writes the selection
+/// through the same `settings.llmProvider` setter the old dropdown used — no new
+/// state home (plan §3b).
+struct ProviderRail: View {
+  @Binding var selection: LLMProvider
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 5) {
+      groupHeader("On this Mac")
+      ForEach(PolishRailCatalog.local) { row(for: $0) }
+      groupHeader("Cloud")
+        .padding(.top, 14)
+      ForEach(PolishRailCatalog.cloud) { row(for: $0) }
+    }
+    .padding(10)
+    .background(
+      RoundedRectangle(cornerRadius: 14, style: .continuous)
+        .fill(Color.stSectionBg)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 14, style: .continuous)
+        .strokeBorder(Color.stDivider, lineWidth: 1)
+    )
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("AI polish engine")
+  }
+
+  private func row(for entry: PolishRailProvider) -> some View {
+    ProviderRailRow(
+      entry: entry,
+      isSelected: selection == entry.provider,
+      onSelect: { selection = entry.provider })
+  }
+
+  private func groupHeader(_ title: String) -> some View {
+    Text(title.uppercased())
+      .font(.system(size: 11, weight: .semibold))
+      .tracking(0.9)
+      .foregroundStyle(Color.stTextTertiary)
+      .padding(.horizontal, 12)
+      .padding(.bottom, 3)
+      .accessibilityHidden(true)
+  }
+}
+
+// MARK: - Detail header
+
+/// The identity header above the selected engine's existing setup content:
+/// 32pt logo, name, EG-1 "Recommended" pill, privacy sub-line, and exactly ONE
+/// status chip (the single `providerStatus` summary). The "Recommended" pill is
+/// a visual badge only — it never changes the selection (plan §3 honesty).
+struct ProviderDetailHeader: View {
+  let entry: PolishRailProvider
+  let status: ProviderStatus
+
+  private var privacyLine: String {
+    entry.isLocal
+      ? "Nothing you dictate leaves this Mac"
+      : "Sends transcribed text only, never audio"
+  }
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 12) {
+      ProviderLogoTile(provider: entry.provider, size: 32, isSelected: true)
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 7) {
+          Text(entry.name)
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(Color.stTextSecondary)
+          if entry.recommended {
+            Text("Recommended")
+              .font(.system(size: 10, weight: .semibold))
+              .foregroundStyle(Color.stAccent)
+              .padding(.horizontal, 7)
+              .padding(.vertical, 2)
+              .background(
+                Capsule().fill(Color.stAccentLight))
+          }
+        }
+        Text("\(entry.tagline) · \(privacyLine)")
+          .font(.stHelper)
+          .foregroundStyle(Color.stTextTertiary)
+          .lineLimit(1)
+          .truncationMode(.tail)
+      }
+      Spacer(minLength: 8)
+      ProviderStatusChip(status: status)
+    }
+    .padding(.vertical, 2)
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -54,6 +54,7 @@ enum ProviderStatusMapping {
     egOneHealth: EGOneHealth,
     appleStatus: AIAvailabilityStatus?,
     cloudValidation: LLMModelDiscoveryCoordinator.KeyValidationState,
+    cloudKeyPresent: Bool = false,
     ollamaSetup: OllamaSetupState
   ) -> ProviderStatus {
     switch provider {
@@ -62,7 +63,7 @@ enum ProviderStatusMapping {
     case .appleIntelligence:
       return apple(appleStatus)
     case .openAI, .gemini:
-      return cloud(cloudValidation)
+      return cloud(cloudValidation, keyPresent: cloudKeyPresent)
     case .ollama:
       return ollama(ollamaSetup)
     case .none:
@@ -114,13 +115,21 @@ enum ProviderStatusMapping {
     }
   }
 
-  // Cloud (OpenAI / Gemini): keyed entirely off key validation state.
+  // Cloud (OpenAI / Gemini): keyed off validation state. `.idle` means we have
+  // not validated this session — which is the normal state when a saved key is
+  // loaded from the Keychain on settings-open (onAppear does not re-validate).
+  // Showing "Key needed" there would falsely alarm a user with a working saved
+  // key, so idle-with-a-key reads as the neutral "Not checked"; only idle with
+  // NO key reads as "Key needed" (cloud review PR #1293, #1286).
   private static func cloud(
-    _ state: LLMModelDiscoveryCoordinator.KeyValidationState
+    _ state: LLMModelDiscoveryCoordinator.KeyValidationState,
+    keyPresent: Bool
   ) -> ProviderStatus {
     switch state {
     case .idle:
-      return ProviderStatus(label: "Key needed", tone: .needsSetup)
+      return keyPresent
+        ? ProviderStatus(label: "Not checked", tone: .unavailable)
+        : ProviderStatus(label: "Key needed", tone: .needsSetup)
     case .validating:
       return ProviderStatus(label: "Validating", tone: .needsSetup)
     case .valid:
@@ -200,8 +209,10 @@ enum PolishRailCatalog {
 /// side-by-side and needs no adaptive width measurement.
 enum PolishRailMetrics {
   /// Fixed rail column width. Sized to fit the longest engine name
-  /// ("Apple Intelligence") beside a 32pt logo tile without truncation.
-  static let railWidth: CGFloat = 232
+  /// ("Apple Intelligence") beside a 32pt logo tile at full size, while leaving
+  /// the detail column as much room as possible at narrow window widths (the
+  /// rail row name also shrinks slightly before it would ever truncate).
+  static let railWidth: CGFloat = 216
   /// Gap between the rail and the detail column.
   static let columnGap: CGFloat = 16
 }
@@ -388,6 +399,7 @@ struct ProviderRailRow: View {
               .font(.system(size: 14, weight: isSelected ? .semibold : .medium))
               .foregroundStyle(isSelected ? Color.stAccent : Color.stTextSecondary)
               .lineLimit(1)
+              .minimumScaleFactor(0.85)
             if entry.recommended {
               Image(systemName: "star.fill")
                 .font(.system(size: 10))

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -172,157 +172,232 @@ struct AIPolishSettingsView: View {
     }
   }
 
-  var body: some View {
+  // MARK: - Provider rail (#1286)
+
+  /// The single at-a-glance status for the selected engine, read from the same
+  /// coordinators the inline controls use (no cross-provider leak). Rendered
+  /// once, in the detail header.
+  private var currentProviderStatus: ProviderStatus {
+    ProviderStatusMapping.status(
+      for: settings.llmProvider,
+      egOneInstall: egOne.installState,
+      egOneHealth: egOne.health,
+      appleStatus: aiAvailability.latestReport?.overallStatus,
+      cloudValidation: llmDiscovery.keyValidationState,
+      ollamaSetup: setup.ollamaSetup.setupState)
+  }
+
+  /// Rail + detail as the two-column master-detail from the approved mockup:
+  /// a fixed-width rail on the left, the selected engine's detail on the right.
+  /// The settings window's 710pt minimum guarantees both columns fit, so this
+  /// is always side-by-side (no `HSplitView`, which clips under width pressure —
+  /// `hsplitview-never-compresses`); the detail column flexes for wider windows.
+  @ViewBuilder
+  private var providerSelectionSurface: some View {
+    let selection = Binding(
+      get: { settings.llmProvider },
+      set: { settings.llmProvider = $0 })
+
+    HStack(alignment: .top, spacing: PolishRailMetrics.columnGap) {
+      ProviderRail(selection: selection)
+        .frame(width: PolishRailMetrics.railWidth, alignment: .leading)
+      providerDetailPane
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  /// The full detail column for the selected engine: identity header, then a
+  /// stack of cards — setup (key / model download / status), the model picker
+  /// (cloud + Ollama), the "Why use ___" explainer (every engine), and the
+  /// advanced toggle (reasoning models). Everything for the engine lives in one
+  /// column; only Ollama's full model catalog stays below the rail (#1286).
+  @ViewBuilder
+  private var providerDetailPane: some View {
     @Bindable var settings = settings
+    VStack(alignment: .leading, spacing: 14) {
+      if let entry = PolishRailCatalog.entry(for: settings.llmProvider) {
+        ProviderDetailHeader(entry: entry, status: currentProviderStatus)
+      }
 
-    SettingsContentView {
-      // ── Section 1: LLM Provider ───────────────────────────────
-      BrandedSection(
-        header: "LLM Provider",
-        content: {
-          BrandedRow(showDivider: settings.llmProvider != .none) {
-            Toggle(
-              isOn: Binding(
-                get: { settings.llmProvider != .none },
-                set: { isOn in
-                  if isOn {
-                    // Restore the last real engine; fall back to the default if
-                    // none was ever remembered (guards against `.none`, #1285).
-                    settings.llmProvider =
-                      settings.lastLLMProvider == .none
-                      ? .appleIntelligence : settings.lastLLMProvider
-                  } else {
-                    settings.llmProvider = .none
-                  }
-                }
-              )
-            ) {
-              Text("AI Polish")
-            }
-          }
+      detailCard {
+        providerSubConfig
+      }
 
-          if settings.llmProvider == .none {
-            BrandedRow(showDivider: false) {
-              Text("Turn on AI polish to automatically fix grammar, punctuation, and formatting.")
-                .font(.stHelper)
-                .foregroundStyle(Color.stTextTertiary)
-                .fixedSize(horizontal: false, vertical: true)
-            }
-          } else {
-            BrandedRow {
-              Picker("LLM Provider", selection: $settings.llmProvider) {
-                Text("EG-1 (Recommended local model)").tag(LLMProvider.egOne)
-                Text("Apple Intelligence").tag(LLMProvider.appleIntelligence)
-                Text("OpenAI").tag(LLMProvider.openAI)
-                Text("Google Gemini").tag(LLMProvider.gemini)
-                Text("Local (Ollama)").tag(LLMProvider.ollama)
-              }
-            }
-          }
-
-          // Nested API key row — only for cloud providers
-          if isCloudProvider {
-            BrandedRow {
-              apiKeyRow
-            }
-          }
-
-          // Ollama wizard
-          if settings.llmProvider == .ollama {
-            BrandedRow {
-              ollamaSetupContent
-            }
-          }
-
-          // Apple Intelligence status
-          if settings.llmProvider == .appleIntelligence {
-            BrandedRow(showDivider: false) {
-              appleIntelligenceStatus
-            }
-          }
-
-          // EG-1 native model (#1271)
-          if settings.llmProvider == .egOne {
-            BrandedRow(showDivider: false) {
-              egOneStatusContent
-            }
-          }
-        },
-        footer: {
-          if isCloudProvider {
-            if settings.llmProvider == .openAI {
-              Link(
-                "Get your free API key at platform.openai.com",
-                destination: URL(string: "https://platform.openai.com/api-keys")!
-              )
-              .font(.stHelper)
-            } else if settings.llmProvider == .gemini {
-              Link(
-                "Get your free API key at aistudio.google.com",
-                destination: URL(string: "https://aistudio.google.com/apikey")!
-              )
-              .font(.stHelper)
-            }
-          }
-        })
-
-      // ── Section 3: Model ──────────────────────────────────────
       if showModelSection {
-        BrandedSection(header: "Model") {
-          BrandedRow(showDivider: false) {
-            HStack {
-              Picker("Model", selection: $settings.llmModel) {
-                if llmDiscovery.discoveredModels.isEmpty
-                  && !llmDiscovery.isDiscoveringModels
-                {
-                  Text(
-                    settings.llmModel.isEmpty
-                      ? (settings.llmProvider == .ollama
-                        ? "No models found"
-                        : "Save API key to discover models")
-                      : settings.llmModel
-                  )
-                  .tag(settings.llmModel)
-                }
-
-                modelPickerSections
-              }
-
-              if settings.llmProvider == .ollama {
-                ollamaWarmupIndicator
-              } else if llmDiscovery.isDiscoveringModels {
-                ProgressView()
-                  .controlSize(.small)
-              } else {
-                Button {
-                  Task {
-                    await llmDiscovery.validateKeyAndDiscoverModels(
-                      provider: settings.llmProvider, settings: settings)
-                  }
-                } label: {
-                  Image(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.borderless)
-                .help("Refresh available models")
-                .accessibilityLabel("Refresh available models")
-              }
-            }
-          }
-        } footer: {
+        detailCard(label: "Model") {
+          modelSelectorRow
           FrozenPerRecordingFootnote()
         }
       }
 
-      // ── Section 3.5: Why use <Provider> (cloud only) ─────────
-      if isCloudProvider {
-        BrandedSection(header: cloudProviderExplainerHeader) {
-          BrandedRow(showDivider: false) {
-            cloudProviderExplainer
+      detailCard(label: providerExplainerHeader) {
+        providerExplainer
+      }
+
+      if isReasoningModel {
+        detailCard(label: "Advanced") {
+          VStack(alignment: .leading, spacing: 4) {
+            Toggle("Deep reasoning", isOn: $settings.useExtendedThinking)
+              .toggleStyle(BrandedToggleStyle())
+            Text("Takes longer but handles complex formatting instructions better.")
+              .font(.stHelper)
+              .foregroundStyle(Color.stTextTertiary)
           }
+          FrozenPerRecordingFootnote()
+        }
+      }
+    }
+  }
+
+  /// A titled card in the detail column: an optional uppercase label above a
+  /// bordered content box, matching the mockup's stacked-card detail.
+  @ViewBuilder
+  private func detailCard(
+    label: String? = nil, @ViewBuilder content: () -> some View
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      if let label, !label.isEmpty {
+        Text(label.uppercased())
+          .font(.system(size: 10, weight: .semibold))
+          .tracking(0.6)
+          .foregroundStyle(Color.stTextTertiary)
+      }
+      VStack(alignment: .leading, spacing: 10) {
+        content()
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(16)
+      .background(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .fill(Color.stSectionBg)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .strokeBorder(Color.stDivider, lineWidth: 1)
+      )
+    }
+  }
+
+  /// The setup content for the selected engine (API key, Ollama wizard, Apple
+  /// status, or EG-1 status). Behavior, setters, and side effects unchanged;
+  /// only the container moved into the detail column (#1286).
+  @ViewBuilder
+  private var providerSubConfig: some View {
+    if isCloudProvider {
+      apiKeyRow
+      if settings.llmProvider == .openAI {
+        Link(
+          "Get your free API key at platform.openai.com",
+          destination: URL(string: "https://platform.openai.com/api-keys")!
+        )
+        .font(.stHelper)
+      } else if settings.llmProvider == .gemini {
+        Link(
+          "Get your free API key at aistudio.google.com",
+          destination: URL(string: "https://aistudio.google.com/apikey")!
+        )
+        .font(.stHelper)
+      }
+    }
+    if settings.llmProvider == .ollama {
+      ollamaSetupContent
+    }
+    if settings.llmProvider == .appleIntelligence {
+      appleIntelligenceStatus
+    }
+    if settings.llmProvider == .egOne {
+      egOneStatusContent
+    }
+  }
+
+  /// The model picker row (cloud + Ollama), lifted into the detail column.
+  @ViewBuilder
+  private var modelSelectorRow: some View {
+    @Bindable var settings = settings
+    HStack {
+      Picker("Model", selection: $settings.llmModel) {
+        if llmDiscovery.discoveredModels.isEmpty
+          && !llmDiscovery.isDiscoveringModels
+        {
+          Text(
+            settings.llmModel.isEmpty
+              ? (settings.llmProvider == .ollama
+                ? "No models found"
+                : "Save API key to discover models")
+              : settings.llmModel
+          )
+          .tag(settings.llmModel)
+        }
+
+        modelPickerSections
+      }
+
+      if settings.llmProvider == .ollama {
+        ollamaWarmupIndicator
+      } else if llmDiscovery.isDiscoveringModels {
+        ProgressView()
+          .controlSize(.small)
+      } else {
+        Button {
+          Task {
+            await llmDiscovery.validateKeyAndDiscoverModels(
+              provider: settings.llmProvider, settings: settings)
+          }
+        } label: {
+          Image(systemName: "arrow.clockwise")
+        }
+        .buttonStyle(.borderless)
+        .help("Refresh available models")
+        .accessibilityLabel("Refresh available models")
+      }
+    }
+  }
+
+  var body: some View {
+    @Bindable var settings = settings
+
+    SettingsContentView {
+      // ── AI Polish master switch (slide toggle, on its own card) ──
+      BrandedSection {
+        BrandedRow(showDivider: false) {
+          Toggle(
+            isOn: Binding(
+              get: { settings.llmProvider != .none },
+              set: { isOn in
+                if isOn {
+                  // Restore the last real engine; fall back to the default if
+                  // none was ever remembered (guards against `.none`, #1285).
+                  settings.llmProvider =
+                    settings.lastLLMProvider == .none
+                    ? .appleIntelligence : settings.lastLLMProvider
+                } else {
+                  settings.llmProvider = .none
+                }
+              }
+            )
+          ) {
+            VStack(alignment: .leading, spacing: 2) {
+              Text("AI Polish")
+                .font(.system(size: 13, weight: .medium))
+              Text("Automatically fix grammar, punctuation, and formatting.")
+                .font(.stHelper)
+                .foregroundStyle(Color.stTextTertiary)
+            }
+          }
+          .toggleStyle(BrandedToggleStyle())
         }
       }
 
-      // Manage Models for Ollama (always expanded)
+      // ── Engine picker: master-detail rail lifted onto the page so
+      // the rail and the detail read as elevated cards, not dark-on-dark
+      // nested boxes (#1286 polish pass). Same `llmProvider` setter.
+      if settings.llmProvider != .none {
+        providerSelectionSurface
+      }
+
+      // Manage Models for Ollama stays a full-width section below the rail —
+      // the one exception to the single-column detail (the catalog is a long
+      // list). Its selected-model setup + explainer live in the detail column.
       if settings.llmProvider == .ollama,
         ollamaShowsManageModels
       {
@@ -330,23 +405,6 @@ struct AIPolishSettingsView: View {
           BrandedRow(showDivider: false) {
             ollamaModelCatalogView
           }
-        }
-      }
-
-      // ── Section 4: Advanced ───────────────────────────────────
-      if isReasoningModel {
-        BrandedSection(header: "Advanced") {
-          BrandedRow(showDivider: false) {
-            VStack(alignment: .leading, spacing: 4) {
-              Toggle("Deep reasoning", isOn: $settings.useExtendedThinking)
-                .toggleStyle(BrandedToggleStyle())
-              Text("Takes longer but handles complex formatting instructions better.")
-                .font(.stHelper)
-                .foregroundStyle(Color.stTextTertiary)
-            }
-          }
-        } footer: {
-          FrozenPerRecordingFootnote()
         }
       }
     }
@@ -591,7 +649,116 @@ struct AIPolishSettingsView: View {
     }
   }
 
-  // MARK: - Cloud Provider Explainer (#617)
+  // MARK: - Provider Explainer ("Why use ___")
+
+  /// The "Why use ___" card label for every engine (#1286). Cloud reuses the
+  /// existing #617 header.
+  private var providerExplainerHeader: String {
+    switch settings.llmProvider {
+    case .openAI, .gemini: return cloudProviderExplainerHeader
+    case .appleIntelligence: return "Why use Apple Intelligence"
+    case .ollama: return "Why use Local (Ollama)"
+    case .egOne: return "Why use EG-1"
+    case .none: return ""
+    }
+  }
+
+  /// The explainer body per engine. Cloud reuses the existing #617 copy; the
+  /// on-device engines get parallel copy so all five match (#1286). No em or
+  /// en dashes in any of these strings.
+  @ViewBuilder
+  private var providerExplainer: some View {
+    switch settings.llmProvider {
+    case .openAI, .gemini:
+      cloudProviderExplainer
+    case .appleIntelligence:
+      appleIntelligenceExplainer
+    case .ollama:
+      ollamaExplainer
+    case .egOne:
+      egOneExplainer
+    case .none:
+      EmptyView()
+    }
+  }
+
+  @ViewBuilder
+  private var egOneExplainer: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text(
+        "EG-1 is the model we trained ourselves, tuned only for cleaning up dictation. It runs entirely on this Mac, so nothing you say leaves your device, and it is free with no API key to manage."
+      )
+      .font(.stHelper)
+      .foregroundStyle(Color.stTextSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+
+      Text(
+        "One model, no choices. There are no sizes to pick and no per-use cost. We maintain EG-1 and keep improving it, so you get consistent cleanup without tuning anything."
+      )
+      .font(.stHelper)
+      .foregroundStyle(Color.stTextSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+
+      Text(
+        "When to use it. EG-1 is the recommended default for most people who want private, free, on-device polish that is tuned for this exact job. If you need a very large general model, the cloud options are there."
+      )
+      .font(.stHelper)
+      .foregroundStyle(Color.stTextSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  @ViewBuilder
+  private var appleIntelligenceExplainer: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text(
+        "Apple Intelligence uses Apple's on-device model, built into macOS. It is free, needs no API key, and nothing you dictate leaves your Mac. It is a solid choice for short, everyday dictation."
+      )
+      .font(.stHelper)
+      .foregroundStyle(Color.stTextSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+
+      Text(
+        "When to use it. Reach for Apple Intelligence when you want zero setup and clean results on short notes. For longer recordings, lists, or code, EG-1 or a cloud model handles structure better."
+      )
+      .font(.stHelper)
+      .foregroundStyle(Color.stTextSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+
+      Text(
+        "Requires macOS 26 or later. On earlier versions this option is unavailable and your text is pasted exactly as transcribed."
+      )
+      .font(.stHelper)
+      .foregroundStyle(Color.stTextSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  @ViewBuilder
+  private var ollamaExplainer: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text(
+        "Local (Ollama) runs open models on your Mac through Ollama, a free tool you install once. Nothing you dictate leaves your device, and there is no API key or per-use cost."
+      )
+      .font(.stHelper)
+      .foregroundStyle(Color.stTextSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+
+      Text(
+        "These are general open models, not tuned for dictation the way EG-1 is. Quality depends on the model you download, and larger models run slower. You pick and manage the models yourself in the list below."
+      )
+      .font(.stHelper)
+      .foregroundStyle(Color.stTextSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+
+      Text(
+        "When to use it. Choose Ollama if you want to run a specific open model on device or to experiment. For the best on-device cleanup with no setup, EG-1 is simpler."
+      )
+      .font(.stHelper)
+      .foregroundStyle(Color.stTextSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+    }
+  }
 
   private var cloudProviderExplainerHeader: String {
     settings.llmProvider == .openAI ? "Why use OpenAI" : "Why use Gemini"
@@ -681,7 +848,7 @@ struct AIPolishSettingsView: View {
         ollamaStepIndicators(current: 1)
 
         Text(
-          "Ollama runs AI models privately on your Mac — no cloud, no API keys, completely free."
+          "Ollama runs AI models privately on your Mac. No cloud, no API keys, completely free."
         )
         .font(.stHelper)
         .foregroundStyle(Color.stTextTertiary)
@@ -823,16 +990,8 @@ struct AIPolishSettingsView: View {
   /// the 8 GB heads-up. Copy rules: no em or en dashes in these strings.
   @ViewBuilder
   private var egOneStatusContent: some View {
-    Text(
-      "EG-1 is our own polish model, tuned specifically for dictation. "
-        + "It matches leading cloud models on our 1,890-case benchmark "
-        + "(94.7% behavior score) while running entirely on this Mac. "
-        + "Nothing you dictate ever leaves your device."
-    )
-    .font(.stHelper)
-    .foregroundStyle(Color.stTextTertiary)
-    .fixedSize(horizontal: false, vertical: true)
-
+    // The pitch (tuned, on-device, benchmark) lives in the "Why use EG-1" card
+    // now (#1286); this card is just the actionable status/download/remove.
     if isLowMemoryMac {
       Label(
         "This Mac has 8 GB of memory. EG-1 may run slower here. "
@@ -974,11 +1133,8 @@ struct AIPolishSettingsView: View {
 
   @ViewBuilder
   private var appleIntelligenceStatus: some View {
-    Text("On-device model — no internet or API key required.")
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextTertiary)
-
-    // Status row
+    // The "no internet or API key" pitch lives in the "Why use Apple
+    // Intelligence" card now (#1286); this card is just the status row.
     HStack {
       Text("Status:")
       Spacer()

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -184,14 +184,23 @@ struct AIPolishSettingsView: View {
       egOneHealth: egOne.health,
       appleStatus: aiAvailability.latestReport?.overallStatus,
       cloudValidation: llmDiscovery.keyValidationState,
+      cloudKeyPresent: settings.llmProvider == .openAI
+        ? !openAIKey.isEmpty
+        : (settings.llmProvider == .gemini ? !geminiKey.isEmpty : false),
       ollamaSetup: setup.ollamaSetup.setupState)
   }
 
   /// Rail + detail as the two-column master-detail from the approved mockup:
   /// a fixed-width rail on the left, the selected engine's detail on the right.
-  /// The settings window's 710pt minimum guarantees both columns fit, so this
-  /// is always side-by-side (no `HSplitView`, which clips under width pressure —
+  /// Always side-by-side (no `HSplitView`, which clips under width pressure —
   /// `hsplitview-never-compresses`); the detail column flexes for wider windows.
+  ///
+  /// At the settings window's 710pt minimum the usable content width is smaller
+  /// than the window (the ~200pt NavigationSplitView sidebar + divider and the
+  /// SettingsContentView horizontal padding come off the top), so the detail
+  /// column is compact but still functional there; it opens up as the window
+  /// widens. The rail is intentionally narrow to hand the detail as much of
+  /// that width as possible (cloud review PR #1293, #1286).
   @ViewBuilder
   private var providerSelectionSurface: some View {
     let selection = Binding(

--- a/Tests/EnviousWisprTests/Settings/ProviderLogoTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderLogoTests.swift
@@ -1,0 +1,40 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+
+/// Issue #1286 Phase 2 — logo smoke test. Guards two contracts:
+///   1. Each inline brand SVG rasterizes to a valid, template-tinted image.
+///   2. A garbage SVG fails to build → nil, so the tile falls back to a
+///      lettered monogram (the "Apple tile was empty" class, plan §7/§9).
+/// The real render-at-tile-size fidelity check is Live UAT; this locks the
+/// build/fallback boundary in CI.
+@Suite("ProviderLogoSVG — inline marks rasterize, garbage falls back")
+struct ProviderLogoTests {
+
+  @Test("Each brand SVG builds a valid template image")
+  func brandMarksBuild() {
+    for svg in [ProviderLogoSVG.openAI, ProviderLogoSVG.gemini, ProviderLogoSVG.ollama] {
+      let image = ProviderLogoSVG.templateImage(svg)
+      #expect(image != nil, "brand SVG should rasterize to a valid image")
+      #expect(image?.isTemplate == true, "monochrome marks must be template-tinted")
+      #expect((image?.size.width ?? 0) > 0)
+    }
+  }
+
+  @Test("Garbage SVG → nil, so the tile can fall back to a monogram")
+  func garbageFallsBack() {
+    #expect(ProviderLogoSVG.templateImage("not an svg at all") == nil)
+    #expect(ProviderLogoSVG.templateImage("") == nil)
+  }
+
+  @Test("Monograms are non-empty for the SVG-backed providers")
+  func monogramsPresent() {
+    #expect(!ProviderLogoSVG.monogram(for: .openAI).isEmpty)
+    #expect(!ProviderLogoSVG.monogram(for: .gemini).isEmpty)
+    #expect(!ProviderLogoSVG.monogram(for: .ollama).isEmpty)
+    #expect(!ProviderLogoSVG.monogram(for: .egOne).isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+@testable import EnviousWisprLLM
+
+/// Issue #1286 Phase 2 — locks the single at-a-glance status authority
+/// `ProviderStatusMapping.status`. Two contracts:
+///   1. Each engine maps its OWN coordinator states to the right (label, tone).
+///   2. Provider-first, no cross-provider leak: a coordinator state that is
+///      "blocking" for one engine must not change another engine's result
+///      (a cloud key state never reaches the EG-1/Apple/Ollama branch, etc.).
+@Suite("ProviderStatusMapping — one status authority, no cross-provider leak")
+struct ProviderStatusMappingTests {
+
+  // Neutral "everything nominal" inputs for the engines NOT under test, so a
+  // per-engine assertion isolates the one coordinator that should matter.
+  private func status(
+    for provider: LLMProvider,
+    egOneInstall: EGOneModelStore.InstallState = .installed(version: "1"),
+    egOneHealth: EGOneHealth = .green,
+    appleStatus: AIAvailabilityStatus? = .available,
+    cloudValidation: LLMModelDiscoveryCoordinator.KeyValidationState = .valid,
+    ollamaSetup: OllamaSetupState = .ready
+  ) -> ProviderStatus {
+    ProviderStatusMapping.status(
+      for: provider,
+      egOneInstall: egOneInstall,
+      egOneHealth: egOneHealth,
+      appleStatus: appleStatus,
+      cloudValidation: cloudValidation,
+      ollamaSetup: ollamaSetup)
+  }
+
+  // MARK: - EG-1 (install lifecycle first, health once installed)
+
+  @Test("EG-1 not installed → Not installed / needs-setup")
+  func egOneNotInstalled() {
+    let s = status(for: .egOne, egOneInstall: .notInstalled)
+    #expect(s.label == "Not installed")
+    #expect(s.tone == .needsSetup)
+  }
+
+  @Test("EG-1 downloading → Downloading / needs-setup")
+  func egOneDownloading() {
+    let s = status(for: .egOne, egOneInstall: .downloading(fractionCompleted: 0.4))
+    #expect(s.label == "Downloading")
+    #expect(s.tone == .needsSetup)
+  }
+
+  @Test("EG-1 verifying → Verifying / needs-setup")
+  func egOneVerifying() {
+    let s = status(for: .egOne, egOneInstall: .verifying)
+    #expect(s.tone == .needsSetup)
+  }
+
+  @Test("EG-1 download failed → error")
+  func egOneFailed() {
+    let s = status(for: .egOne, egOneInstall: .failed(.network))
+    #expect(s.tone == .error)
+  }
+
+  @Test("EG-1 installed + green → Live / ready")
+  func egOneLive() {
+    let s = status(for: .egOne, egOneInstall: .installed(version: "1"), egOneHealth: .green)
+    #expect(s.label == "Live")
+    #expect(s.tone == .ready)
+  }
+
+  @Test("EG-1 installed + yellow → Starting / needs-setup")
+  func egOneStarting() {
+    let s = status(
+      for: .egOne, egOneInstall: .installed(version: "1"),
+      egOneHealth: .yellow(reason: "starting"))
+    #expect(s.tone == .needsSetup)
+  }
+
+  @Test("EG-1 installed + red → Not working / error")
+  func egOneNotWorking() {
+    let s = status(
+      for: .egOne, egOneInstall: .installed(version: "1"),
+      egOneHealth: .red(reason: "crashed_twice"))
+    #expect(s.label == "Not working")
+    #expect(s.tone == .error)
+  }
+
+  // MARK: - Apple Intelligence
+
+  @Test("Apple available → ready")
+  func appleAvailable() {
+    #expect(status(for: .appleIntelligence, appleStatus: .available).tone == .ready)
+  }
+
+  @Test("Apple degraded/unavailable/unknown/nil → unavailable tone")
+  func appleNonReady() {
+    #expect(status(for: .appleIntelligence, appleStatus: .degraded).tone == .unavailable)
+    #expect(status(for: .appleIntelligence, appleStatus: .unavailable).tone == .unavailable)
+    #expect(status(for: .appleIntelligence, appleStatus: .unknown).tone == .unavailable)
+    #expect(status(for: .appleIntelligence, appleStatus: nil).tone == .unavailable)
+  }
+
+  // MARK: - Cloud (OpenAI / Gemini share the mapping)
+
+  @Test("Cloud valid → Key valid / ready")
+  func cloudValid() {
+    for p in [LLMProvider.openAI, .gemini] {
+      let s = status(for: p, cloudValidation: .valid)
+      #expect(s.label == "Key valid")
+      #expect(s.tone == .ready)
+    }
+  }
+
+  @Test("Cloud validating → needs-setup")
+  func cloudValidating() {
+    #expect(status(for: .openAI, cloudValidation: .validating).tone == .needsSetup)
+  }
+
+  @Test("Cloud idle → Key needed / needs-setup")
+  func cloudIdle() {
+    let s = status(for: .gemini, cloudValidation: .idle)
+    #expect(s.label == "Key needed")
+    #expect(s.tone == .needsSetup)
+  }
+
+  @Test("Cloud invalid → Key needed / error")
+  func cloudInvalid() {
+    let s = status(for: .openAI, cloudValidation: .invalid("bad key"))
+    #expect(s.label == "Key needed")
+    #expect(s.tone == .error)
+  }
+
+  // MARK: - Ollama
+
+  @Test("Ollama ready → Running / ready")
+  func ollamaRunning() {
+    let s = status(for: .ollama, ollamaSetup: .ready)
+    #expect(s.label == "Running")
+    #expect(s.tone == .ready)
+  }
+
+  @Test("Ollama not-installed/not-running/no-model/pulling/detecting → needs-setup")
+  func ollamaNeedsSetup() {
+    #expect(status(for: .ollama, ollamaSetup: .detecting).tone == .needsSetup)
+    #expect(status(for: .ollama, ollamaSetup: .notInstalled).tone == .needsSetup)
+    #expect(status(for: .ollama, ollamaSetup: .installedNotRunning).tone == .needsSetup)
+    #expect(status(for: .ollama, ollamaSetup: .runningNoModels).tone == .needsSetup)
+    #expect(
+      status(for: .ollama, ollamaSetup: .pullingModel(progress: 0.2, status: "x")).tone
+        == .needsSetup)
+  }
+
+  @Test("Ollama error → error")
+  func ollamaError() {
+    #expect(status(for: .ollama, ollamaSetup: .error("boom")).tone == .error)
+  }
+
+  // MARK: - No cross-provider leak
+
+  @Test("A blocking cloud key state does NOT change EG-1/Apple/Ollama results")
+  func cloudStateDoesNotLeak() {
+    // Cloud is .invalid (an error state) but the OTHER engines are nominal.
+    #expect(
+      status(for: .egOne, cloudValidation: .invalid("x")).tone == .ready,
+      "EG-1 stays Live regardless of a broken cloud key")
+    #expect(
+      status(for: .appleIntelligence, cloudValidation: .invalid("x")).tone == .ready,
+      "Apple stays Available regardless of a broken cloud key")
+    #expect(
+      status(for: .ollama, cloudValidation: .invalid("x")).tone == .ready,
+      "Ollama stays Running regardless of a broken cloud key")
+  }
+
+  @Test("A blocking EG-1 state does NOT change cloud/Apple/Ollama results")
+  func egOneStateDoesNotLeak() {
+    #expect(
+      status(for: .openAI, egOneInstall: .notInstalled).tone == .ready,
+      "OpenAI stays Key valid regardless of EG-1 not being installed")
+    #expect(
+      status(for: .appleIntelligence, egOneHealth: .red(reason: "x")).tone == .ready,
+      "Apple stays Available regardless of EG-1 health")
+    #expect(
+      status(for: .ollama, egOneInstall: .notInstalled).tone == .ready,
+      "Ollama stays Running regardless of EG-1 not being installed")
+  }
+
+  @Test("Off provider → neutral, never a real engine status")
+  func offProvider() {
+    #expect(status(for: .none).tone == .unavailable)
+  }
+}

--- a/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderStatusMappingTests.swift
@@ -22,6 +22,7 @@ struct ProviderStatusMappingTests {
     egOneHealth: EGOneHealth = .green,
     appleStatus: AIAvailabilityStatus? = .available,
     cloudValidation: LLMModelDiscoveryCoordinator.KeyValidationState = .valid,
+    cloudKeyPresent: Bool = false,
     ollamaSetup: OllamaSetupState = .ready
   ) -> ProviderStatus {
     ProviderStatusMapping.status(
@@ -30,6 +31,7 @@ struct ProviderStatusMappingTests {
       egOneHealth: egOneHealth,
       appleStatus: appleStatus,
       cloudValidation: cloudValidation,
+      cloudKeyPresent: cloudKeyPresent,
       ollamaSetup: ollamaSetup)
   }
 
@@ -116,11 +118,22 @@ struct ProviderStatusMappingTests {
     #expect(status(for: .openAI, cloudValidation: .validating).tone == .needsSetup)
   }
 
-  @Test("Cloud idle → Key needed / needs-setup")
-  func cloudIdle() {
-    let s = status(for: .gemini, cloudValidation: .idle)
+  @Test("Cloud idle with NO key → Key needed / needs-setup")
+  func cloudIdleNoKey() {
+    let s = status(for: .gemini, cloudValidation: .idle, cloudKeyPresent: false)
     #expect(s.label == "Key needed")
     #expect(s.tone == .needsSetup)
+  }
+
+  @Test("Cloud idle WITH a saved key → neutral Not checked, never a false Key needed")
+  func cloudIdleWithSavedKey() {
+    // A saved key loaded on settings-open leaves validation .idle; the chip must
+    // not alarm the user with "Key needed" (cloud review PR #1293).
+    for p in [LLMProvider.openAI, .gemini] {
+      let s = status(for: p, cloudValidation: .idle, cloudKeyPresent: true)
+      #expect(s.label == "Not checked")
+      #expect(s.tone == .unavailable)
+    }
   }
 
   @Test("Cloud invalid → Key needed / error")


### PR DESCRIPTION
## What

Replaces the flat AI Polish provider dropdown with the approved master-detail engine rail and finishes the detail column.

- **Rail** grouped "On this Mac" (EG-1, Apple Intelligence, Local (Ollama)) and "Cloud" (OpenAI, Google Gemini), EG-1 pinned first, starred, Recommended, each with its real inline logo. Selecting a row shows that engine's detail.
- **Detail column** holds everything for the selected engine: identity header with exactly one status light, setup card (key / model download / status), the model picker (cloud + Ollama), and a "Why use ___" explainer for every engine. Ollama's full model catalog stays a full-width section below the rail.
- **New copy**: "Why use" explainers for EG-1, Apple Intelligence, and Ollama to match the existing OpenAI/Gemini ones; removed duplicate intro blurbs; fixed two in-app em-dashes.
- **Polish**: AI Polish master switch is the branded slide toggle with a subtitle; rail and detail render as elevated cards on the page (not dark-on-dark nested boxes); roomier rows, bigger logo tiles, clearer group separation, rail widened so "Apple Intelligence" never truncates.

## Why it's low-risk

Visual only. The rail writes the same `settings.llmProvider` setter the dropdown used; the per-provider setup, model discovery, key handling, routing, `.onChange`/`.onAppear` side effects, and the heart path are all unchanged. Layout is always the two-column master-detail (the 710pt window minimum guarantees both columns fit).

Logos are inline: EG-1 reuses the existing `RainbowLipsIcon` brand mark statically; Apple uses the `apple.logo` SF Symbol; OpenAI/Gemini/Ollama are inline SVG marks via `NSImage(data:)`, template-tinted, with a monogram fallback. One status authority (`ProviderStatusMapping`) reads the same coordinator values the inline controls read, provider-first with no cross-provider leak.

## Validation

- `scripts/xcode-test.sh`: `ProviderStatusMappingTests` (19, incl. no cross-provider leak) + `ProviderLogo` smoke (3) green.
- Live UAT on the dev app: rail selection switches the detail and fires each engine's setup side effects (Gemini shows its key row + live "Validating" light); heart path (record to paste) unaffected; founder visual sign-off on the polished layout.

Part of #1281. Closes #1286.