### PR TITLE
chore(dev-tooling): point validate-pr.sh Codex stub text at the two named model scripts

### DIFF
--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -288,7 +288,8 @@ case "$DECLARED" in
     else
       cat > "$RUN_DIR/codex-prose.txt" <<EOF
 [STUB — caller must overwrite]
-Run: codex review --base origin/main -c model=gpt-5.5 -c model_reasoning_effort=medium </dev/null > $RUN_DIR/codex-prose.txt
+Run: ~/.claude/bin/codex-5.5 review --base origin/main > $RUN_DIR/codex-prose.txt
+(fallback if usage-capped: ~/.claude/bin/codex-5.3-spark review --base origin/main > $RUN_DIR/codex-prose.txt)
 Then re-run scripts/validate-pr.sh OR call scripts/attest.sh codex-prose "what I observed"
 EOF
       record_step "codex-prose" 1 "Stage 1 stub — caller must run 'codex review' and overwrite codex-prose.txt + attest"
@@ -309,7 +310,7 @@ esac
 
 echo "==> Phase 3.4: Codex code-diff review (caller's responsibility; MUST be clean BEFORE the smoke + Live UAT rebuild above — script not auto-invoking)"
 if [ ! -s "$RUN_DIR/codex-review.txt" ] && [ "$DECLARED" = "Code" ]; then
-  echo "Run: codex review --base origin/main -c model=gpt-5.5 -c model_reasoning_effort=medium </dev/null > $RUN_DIR/codex-review.txt" > "$RUN_DIR/codex-review-todo.txt"
+  echo "Run: ~/.claude/bin/codex-5.5 review --base origin/main > $RUN_DIR/codex-review.txt (fallback if usage-capped: ~/.claude/bin/codex-5.3-spark review --base origin/main > $RUN_DIR/codex-review.txt)" > "$RUN_DIR/codex-review-todo.txt"
   record_step "codex-review" 1 "Stage 1 stub — caller must run codex review and overwrite codex-review.txt"
 fi
 

--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -310,7 +310,10 @@ esac
 
 echo "==> Phase 3.4: Codex code-diff review (caller's responsibility; MUST be clean BEFORE the smoke + Live UAT rebuild above — script not auto-invoking)"
 if [ ! -s "$RUN_DIR/codex-review.txt" ] && [ "$DECLARED" = "Code" ]; then
-  echo "Run: ~/.claude/bin/codex-5.5 review --base origin/main > $RUN_DIR/codex-review.txt (fallback if usage-capped: ~/.claude/bin/codex-5.3-spark review --base origin/main > $RUN_DIR/codex-review.txt)" > "$RUN_DIR/codex-review-todo.txt"
+  cat > "$RUN_DIR/codex-review-todo.txt" <<EOF
+Run: ~/.claude/bin/codex-5.5 review --base origin/main > $RUN_DIR/codex-review.txt
+(fallback if usage-capped: ~/.claude/bin/codex-5.3-spark review --base origin/main > $RUN_DIR/codex-review.txt)
+EOF
   record_step "codex-review" 1 "Stage 1 stub — caller must run codex review and overwrite codex-review.txt"
 fi
 


### PR DESCRIPTION
## Summary
- The Phase 3 validation stub text told the caller to run bare `codex review` with manual `-c model=gpt-5.5 -c model_reasoning_effort=medium` flags — this bypassed the new `~/.claude/bin/codex-5.5` / `codex-5.3-spark` named scripts that are now the sole place model + reasoning effort are pinned (introduced this session to fix a stuck global Codex model default).
- Text-only change to two stub messages; no control flow or new symbols. `--self-test` passes.

## Review notes
- Round 1 `codex-5.5 review` caught a real bug: the fallback line printed to the terminal instead of redirecting to the required run-dir artifact. Fixed.
- Round 2 clean pass raised one P2 (hardcoding a private `~/.claude/bin` path outside the repo). Judgment call: rejected — this is a solo-founder + Claude project on one machine, and the entire Codex/knowledge-base workflow already assumes `~/.claude/` exists; reverting to bare `codex` flags here would reintroduce the exact mutable-default footgun this session's work was built to eliminate.

## Test plan
- [x] `bash -n scripts/validate-pr.sh`
- [x] `scripts/validate-pr.sh --self-test` (2 passed, 0 failed)
- [x] `~/.claude/bin/codex-5.5 review --base origin/main` clean after round-1 fix