### PR TITLE
fix(build): cache tuist generate's package resolution in CI (#1295)

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -66,12 +66,13 @@ jobs:
           "$HOME/.local/bin/mise" install tuist@4.195.11
           "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
 
-      - name: Generate Xcode project
+      # See pr-check.yml's "Configure DerivedData cache redirect" comment
+      # (issue #1295) — same rationale, mirrored here since this job is the
+      # cache WRITER (main-post-merge.yml must produce the same directory
+      # shape pr-check.yml restores).
+      - name: Configure DerivedData cache redirect
         if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
-          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+        run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ env.DERIVED_DATA_PATH }}"
 
       - name: Compute Xcode build cache key
         id: xcode-cache-key
@@ -86,7 +87,9 @@ jobs:
 
       # main-post-merge.yml is the cache WRITER: restore freshest compatible
       # cache, run the full debug+release build+test matrix, then save a new
-      # cache under the rolling commit-keyed primary key (issue #804).
+      # cache under the rolling commit-keyed primary key (issue #804). The
+      # third path entry is a glob (issue #1295) — see pr-check.yml's restore
+      # step comment for why.
       - name: Restore Xcode build cache
         id: xcode-cache
         if: steps.changes.outputs.needs_build == 'true'
@@ -95,11 +98,23 @@ jobs:
           path: |
             .derivedData/CI/SourcePackages
             .derivedData/CI/Build
+            .derivedData/CI/*/SourcePackages
           key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
             ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-
             ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-
+
+      - name: Generate Xcode project
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
+          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+
+      - name: Log DerivedData package-resolution location
+        if: steps.changes.outputs.needs_build == 'true'
+        run: find "$DERIVED_DATA_PATH" -maxdepth 3 -type d -name SourcePackages -print 2>/dev/null || true
 
       - name: Build (debug, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
@@ -194,6 +209,7 @@ jobs:
           path: |
             .derivedData/CI/SourcePackages
             .derivedData/CI/Build
+            .derivedData/CI/*/SourcePackages
           key: ${{ steps.xcode-cache.outputs.cache-primary-key }}
 
       - name: Post result

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -80,13 +80,16 @@ jobs:
           "$HOME/.local/bin/mise" install tuist@4.195.11
           "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
 
-      - name: Generate Xcode project
+      # tuist generate's internal `xcodebuild -resolvePackageDependencies` call
+      # passes no -derivedDataPath, so it resolves into Xcode's global default
+      # DerivedData location — NOT the .derivedData/CI path this job caches —
+      # paying a full, uncached network resolution every run (issue #1295).
+      # Redirecting the global default here, before generate runs and before
+      # the cache is restored, makes that resolve land somewhere the cache
+      # below actually covers.
+      - name: Configure DerivedData cache redirect
         if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
-          # Generated project / DerivedData must never be committed.
-          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+        run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ env.DERIVED_DATA_PATH }}"
 
       - name: Compute Xcode build cache key
         id: xcode-cache-key
@@ -102,6 +105,12 @@ jobs:
       # Rolling key (github.sha suffix) so the primary key is never an exact hit
       # here. pr-check.yml is restore-only by design — main-post-merge.yml is the
       # sole writer (issue #804). restore-keys fall through to the freshest cache.
+      # The third path entry is a glob (issue #1295): the redirect above makes
+      # tuist generate's implicit resolve write into a per-project hash-named
+      # subfolder under .derivedData/CI (Xcode's normal global-default naming),
+      # a different shape from the flat SourcePackages/Build the explicit
+      # -derivedDataPath build step below writes to. The glob covers both
+      # without the workflow needing to predict the hash name.
       - name: Restore Xcode build cache
         id: xcode-cache
         if: steps.changes.outputs.needs_build == 'true'
@@ -110,6 +119,7 @@ jobs:
           path: |
             .derivedData/CI/SourcePackages
             .derivedData/CI/Build
+            .derivedData/CI/*/SourcePackages
           key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
@@ -120,6 +130,18 @@ jobs:
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           echo "==> Xcode cache (debug lane): matched=${{ steps.xcode-cache.outputs.cache-matched-key }} hit=${{ steps.xcode-cache.outputs.cache-hit }}"
+
+      - name: Generate Xcode project
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
+          # Generated project / DerivedData must never be committed.
+          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+
+      - name: Log DerivedData package-resolution location
+        if: steps.changes.outputs.needs_build == 'true'
+        run: find "$DERIVED_DATA_PATH" -maxdepth 3 -type d -name SourcePackages -print 2>/dev/null || true
 
       - name: Build (debug, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
@@ -230,12 +252,11 @@ jobs:
           "$HOME/.local/bin/mise" install tuist@4.195.11
           "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
 
-      - name: Generate Xcode project
+      # See build-debug's "Configure DerivedData cache redirect" comment
+      # (issue #1295) — same rationale, mirrored for this lane.
+      - name: Configure DerivedData cache redirect
         if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
-          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+        run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ env.DERIVED_DATA_PATH }}"
 
       - name: Compute Xcode build cache key
         id: xcode-cache-key
@@ -256,6 +277,7 @@ jobs:
           path: |
             .derivedData/CI/SourcePackages
             .derivedData/CI/Build
+            .derivedData/CI/*/SourcePackages
           key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
@@ -266,6 +288,17 @@ jobs:
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           echo "==> Xcode cache (release lane): matched=${{ steps.xcode-cache.outputs.cache-matched-key }} hit=${{ steps.xcode-cache.outputs.cache-hit }}"
+
+      - name: Generate Xcode project
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
+          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
+
+      - name: Log DerivedData package-resolution location
+        if: steps.changes.outputs.needs_build == 'true'
+        run: find "$DERIVED_DATA_PATH" -maxdepth 3 -type d -name SourcePackages -print 2>/dev/null || true
 
       - name: Build (release, Xcode)
         if: steps.changes.outputs.needs_build == 'true'

--- a/scripts/ci/configure-tuist-deriveddata-cache.sh
+++ b/scripts/ci/configure-tuist-deriveddata-cache.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/ci/configure-tuist-deriveddata-cache.sh
+# Redirect Xcode's global default DerivedData location so `tuist generate`'s
+# internal `xcodebuild -resolvePackageDependencies` call (which passes no
+# `-derivedDataPath` of its own) lands somewhere `actions/cache` can capture,
+# instead of an ephemeral per-checkout-path hashed folder outside the cache
+# (issue #1295).
+#
+# Usage:
+#   configure-tuist-deriveddata-cache.sh <ABSOLUTE_PATH>   set the redirect,
+#                                                           echo the readback
+#   configure-tuist-deriveddata-cache.sh --self-test        round-trip check
+#                                                           against a throwaway
+#                                                           defaults domain
+#                                                           (never touches the
+#                                                           real Xcode default)
+set -euo pipefail
+
+DOMAIN="com.apple.dt.Xcode"
+KEY="IDECustomDerivedDataLocation"
+
+configure() {
+  local path="$1"
+  if [ -z "$path" ]; then
+    echo "::error::configure-tuist-deriveddata-cache.sh: empty path argument" >&2
+    exit 1
+  fi
+  defaults write "$DOMAIN" "$KEY" "$path"
+  local readback
+  readback="$(defaults read "$DOMAIN" "$KEY" 2>/dev/null || echo "<unreadable>")"
+  echo "==> Redirected global DerivedData location to: $readback"
+}
+
+self_test() {
+  local test_domain="com.enviouswispr.ci.configure-tuist-deriveddata-cache-selftest.$$"
+  local test_path="/tmp/ew-ci-deriveddata-selftest-$$"
+  local fail=0
+
+  defaults write "$test_domain" "$KEY" "$test_path"
+  local readback
+  readback="$(defaults read "$test_domain" "$KEY" 2>/dev/null || echo "")"
+  if [ "$readback" != "$test_path" ]; then
+    echo "FAIL: round-trip mismatch — wrote '$test_path', read back '$readback'"
+    fail=1
+  else
+    echo "PASS: defaults write/read round-trip"
+  fi
+
+  defaults delete "$test_domain" "$KEY" 2>/dev/null || true
+  defaults delete "$test_domain" 2>/dev/null || true
+
+  if [ "$fail" -ne 0 ]; then
+    exit 1
+  fi
+  echo "==> self-test passed (throwaway domain '$test_domain', never touched $DOMAIN)"
+}
+
+case "${1:-}" in
+  --self-test)
+    self_test
+    ;;
+  "")
+    echo "::error::configure-tuist-deriveddata-cache.sh: missing path argument (or --self-test)" >&2
+    exit 1
+    ;;
+  *)
+    configure "$1"
+    ;;
+esac


### PR DESCRIPTION
## Summary

`tuist generate`'s internal `xcodebuild -resolvePackageDependencies` call passes no `-derivedDataPath`, so it always resolved into Xcode's global default DerivedData location — a per-checkout-path hashed folder — instead of the `.derivedData/CI` path the existing cache restore/save steps cover. Every `pr-check.yml` and `main-post-merge.yml` run paid for a full, uncached, real network package resolution (~90-100s per lane, confirmed on live CI logs) regardless of cache state.

Root cause was confirmed empirically (local A/B testing, not just log-reading) before writing the fix — full writeup in the linked issue and the local plan doc. A competing hypothesis (`tuist install`'s own cache) was tested and ruled out.

## Fix

- New tracked script `scripts/ci/configure-tuist-deriveddata-cache.sh` redirects Xcode's global default DerivedData location to `.derivedData/CI` (via the `IDECustomDerivedDataLocation` user default) before `tuist generate` runs, in all three build sites (both `pr-check.yml` lanes + `main-post-merge.yml`).
- Cache restore (and, in `main-post-merge.yml`, save) steps moved to run BEFORE `tuist generate`, and the cached path widened with a glob (`.derivedData/CI/*/SourcePackages`) to cover the newly-redirected nested resolve output alongside the existing flat build output.
- A non-fatal diagnostic step logs the discovered `SourcePackages` path after generate, so a broken redirect is visible in CI logs.
- No change to the cache key formula, job/required-check structure, or `release.yml` (explicitly out of scope this round).

## Validation

This went through the full plan → council (GPT-5.5 + Gemini-3.1 coverage review) → Codex grounded review (2 rounds, PROCEED-AS-PLANNED) → local Codex code-diff review (clean, no actionable findings) sequence.

Validation is inherently staged since `pr-check.yml` is restore-only: this PR's own run proves mechanism correctness (green build, redirect logged, SourcePackages found) but cannot itself prove a warm-restore speedup — no cache has been saved in the new shape yet. The real proof lands after merge: `main-post-merge.yml`'s next run is the first save under the new shape, and the PR after that is the actual warm-restore timing comparison. Will post real before/after numbers to issue #1295 once that data exists.

Closes #1295 (pending real timing confirmation — will reopen/follow-up if the fix doesn't measure out).

## Test plan
- [x] actionlint clean on both workflow files
- [x] New script's `--self-test` passes locally
- [x] Local Codex code-diff review: no actionable findings
- [ ] `build-check` green on this PR (both lanes)
- [ ] Cloud review gate cleared
- [ ] Real timing captured from a subsequent post-merge + PR run cycle