### PR TITLE
feat(settings): 14pt medium reading copy + primary text colour, roomier spacing (#1297)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -565,9 +565,7 @@ struct AIPolishSettingsView: View {
       Text(
         "\(isOpenAI ? "OpenAI" : "Gemini") polish sends only transcribed text, never audio. EnviousWispr also sends store: false so the provider is asked not to retain the request or response."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextTertiary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
     }
   }
 
@@ -697,23 +695,17 @@ struct AIPolishSettingsView: View {
       Text(
         "EG-1 is the model we trained ourselves, tuned only for cleaning up dictation. It runs entirely on this Mac, so nothing you say leaves your device, and it is free with no API key to manage."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextSecondary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
 
       Text(
         "One model, no choices. There are no sizes to pick and no per-use cost. We maintain EG-1 and keep improving it, so you get consistent cleanup without tuning anything."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextSecondary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
 
       Text(
         "When to use it. EG-1 is the recommended default for most people who want private, free, on-device polish that is tuned for this exact job. If you need a very large general model, the cloud options are there."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextSecondary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
     }
   }
 
@@ -723,23 +715,17 @@ struct AIPolishSettingsView: View {
       Text(
         "Apple Intelligence uses Apple's on-device model, built into macOS. It is free, needs no API key, and nothing you dictate leaves your Mac. It is a solid choice for short, everyday dictation."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextSecondary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
 
       Text(
         "When to use it. Reach for Apple Intelligence when you want zero setup and clean results on short notes. For longer recordings, lists, or code, EG-1 or a cloud model handles structure better."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextSecondary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
 
       Text(
         "Requires macOS 26 or later. On earlier versions this option is unavailable and your text is pasted exactly as transcribed."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextSecondary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
     }
   }
 
@@ -749,23 +735,17 @@ struct AIPolishSettingsView: View {
       Text(
         "Local (Ollama) runs open models on your Mac through Ollama, a free tool you install once. Nothing you dictate leaves your device, and there is no API key or per-use cost."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextSecondary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
 
       Text(
         "These are general open models, not tuned for dictation the way EG-1 is. Quality depends on the model you download, and larger models run slower. You pick and manage the models yourself in the list below."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextSecondary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
 
       Text(
         "When to use it. Choose Ollama if you want to run a specific open model on device or to experiment. For the best on-device cleanup with no setup, EG-1 is simpler."
       )
-      .font(.stHelper)
-      .foregroundStyle(Color.stTextSecondary)
-      .fixedSize(horizontal: false, vertical: true)
+      .settingsReadingCopy()
     }
   }
 
@@ -780,23 +760,17 @@ struct AIPolishSettingsView: View {
         Text(
           "Apple Intelligence cleans up short dictation well. OpenAI is a step up for longer recordings, lists, and code. You bring your own API key, you only pay OpenAI for what you use, and most cleanup runs land in well under a second. Cloud polish sends the transcript to OpenAI under your API account."
         )
-        .font(.stHelper)
-        .foregroundStyle(Color.stTextSecondary)
-        .fixedSize(horizontal: false, vertical: true)
+        .settingsReadingCopy()
 
         Text(
           "Picking the right model. OpenAI sells several sizes inside each generation. For dictation cleanup, look for Mini in the name. Those are tuned for fast, light tasks and run roughly 3 to 10 times cheaper than the flagships. Nano is even smaller and faster. The unsuffixed flagships (GPT-5, GPT-4.1) and anything labeled Pro are overkill for this job."
         )
-        .font(.stHelper)
-        .foregroundStyle(Color.stTextSecondary)
-        .fixedSize(horizontal: false, vertical: true)
+        .settingsReadingCopy()
 
         Text(
           "Locked models? Those aren't blocked by EnviousWispr. Your OpenAI API key doesn't currently have access to them. OpenAI gates some models behind spend tier or organization verification."
         )
-        .font(.stHelper)
-        .foregroundStyle(Color.stTextSecondary)
-        .fixedSize(horizontal: false, vertical: true)
+        .settingsReadingCopy()
 
         Link(
           "How OpenAI model availability works by usage tier",
@@ -812,23 +786,17 @@ struct AIPolishSettingsView: View {
         Text(
           "Apple Intelligence cleans up short dictation well. Gemini is a step up for longer recordings, lists, and code. You bring your own API key, the free tier is generous for personal use, and most cleanup runs land in well under a second. Cloud polish sends the transcript to Google under your Gemini API account."
         )
-        .font(.stHelper)
-        .foregroundStyle(Color.stTextSecondary)
-        .fixedSize(horizontal: false, vertical: true)
+        .settingsReadingCopy()
 
         Text(
           "Picking the right model. Gemini sells two sizes inside each generation. For dictation cleanup, look for Flash in the name. Those are tuned for fast, light tasks. Pro models are overkill: slightly smarter on hard reasoning, slower and pricier on a job that doesn't need it."
         )
-        .font(.stHelper)
-        .foregroundStyle(Color.stTextSecondary)
-        .fixedSize(horizontal: false, vertical: true)
+        .settingsReadingCopy()
 
         Text(
           "Locked models? Those aren't blocked by EnviousWispr. Your Gemini API key doesn't currently have access to them. Some Gemini models are gated by region, billing tier, or preview status."
         )
-        .font(.stHelper)
-        .foregroundStyle(Color.stTextSecondary)
-        .fixedSize(horizontal: false, vertical: true)
+        .settingsReadingCopy()
 
         Link(
           "Gemini API rate limits by tier",

--- a/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
@@ -23,8 +23,7 @@ struct AppearanceSettingsView: View {
               selection: $settings.appearancePreference
             )
             Text("System follows your Mac and switches automatically. Light and Dark pin a look.")
-              .font(.stHelper)
-              .foregroundStyle(.stTextTertiary)
+              .settingsReadingCopy()
           }
         }
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
@@ -29,14 +29,12 @@ struct AudioSettingsView: View {
             Text(
               "Built-in microphone selected automatically. Bluetooth headphones cannot record and play audio simultaneously — using the built-in mic avoids degrading your audio playback."
             )
-            .font(.stHelper)
-            .foregroundStyle(.stTextTertiary)
+            .settingsReadingCopy()
           } else {
             Text(
               "Select which microphone to use for recording. \"Auto\" prefers the built-in mic when Bluetooth audio output is active."
             )
-            .font(.stHelper)
-            .foregroundStyle(.stTextTertiary)
+            .settingsReadingCopy()
           }
         }
       } footer: {
@@ -58,8 +56,7 @@ struct AudioSettingsView: View {
             Text(
               "Keeps the microphone engine active after dictation so the next recording starts instantly and captures your first words."
             )
-            .font(.stHelper)
-            .foregroundStyle(.stTextTertiary)
+            .settingsReadingCopy()
             if settings.warmEnginePolicy == .always {
               Text(
                 "Always keeps the microphone engine active. The macOS microphone indicator may remain visible and power usage may increase."

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
@@ -1,5 +1,21 @@
 import SwiftUI
 
+// MARK: - Reading-copy modifier
+
+extension View {
+  /// The single authority for "reading paragraph" styling in Settings: body
+  /// font (14 medium) + primary text colour + vertical wrapping. Multi-sentence
+  /// explainers and section descriptions opt in via `.settingsReadingCopy()`.
+  /// Labels, hints, captions, pagination, and status text stay on the microcopy
+  /// tokens (`stHelper` + secondary/tertiary) and must NOT adopt this.
+  func settingsReadingCopy() -> some View {
+    self
+      .font(.stBody)
+      .foregroundStyle(.stTextPrimary)
+      .fixedSize(horizontal: false, vertical: true)
+  }
+}
+
 // MARK: - Settings Content Container
 
 /// Replaces `Form { }.formStyle(.grouped)` with a branded ScrollView layout.

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsDesignTokens.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsDesignTokens.swift
@@ -38,6 +38,12 @@ extension Color {
     lightRGB: (0.910, 0.886, 0.961, 1), darkRGB: (0.102, 0.086, 0.137, 1))  // #e8e2f5 / #1a1623
 
   // Text
+  //
+  // Primary is the reading-copy colour: near-black in light, near-white in dark.
+  // The dark value is capped below pure white (~92%) to limit halation on the
+  // night-comfort surfaces while staying markedly crisper than the secondary grey.
+  static let stTextPrimary = stDynamic(
+    lightRGB: (0.059, 0.039, 0.102, 1), darkRGB: (0.925, 0.914, 0.957, 1))  // #0f0a1a / #ece9f4
   static let stTextSecondary = stDynamic(
     lightRGB: (0.290, 0.239, 0.376, 1), darkRGB: (0.667, 0.635, 0.749, 1))  // #4a3d60 / #aaa2bf
   static let stTextTertiary = stDynamic(
@@ -73,6 +79,7 @@ extension Color {
 // MARK: - ShapeStyle Shorthands (enables `.stAccent` in `.foregroundStyle()`)
 
 extension ShapeStyle where Self == Color {
+  static var stTextPrimary: Color { Color.stTextPrimary }
   static var stTextSecondary: Color { Color.stTextSecondary }
   static var stTextTertiary: Color { Color.stTextTertiary }
   static var stAccent: Color { Color.stAccent }
@@ -86,15 +93,18 @@ extension ShapeStyle where Self == Color {
 extension Font {
   static let stSectionHeader = Font.system(size: 11.5, weight: .bold)
   static let stHelper = Font.system(size: 11.5)
+  /// Reading-copy body: multi-sentence explainers and section descriptions.
+  /// Medium weight reads crisper on the dark night-comfort surfaces (halation).
+  static let stBody = Font.system(size: 14, weight: .medium)
 }
 
 // MARK: - Settings Layout Constants
 
 enum SettingsLayout {
-  static let sectionRadius: CGFloat = 12
+  static let sectionRadius: CGFloat = 14
   static let rowPaddingH: CGFloat = 14
-  static let rowPaddingV: CGFloat = 10
-  static let sectionSpacing: CGFloat = 16
+  static let rowPaddingV: CGFloat = 12
+  static let sectionSpacing: CGFloat = 18
   static let contentTop: CGFloat = 20
   static let contentH: CGFloat = 24
   static let contentBottom: CGFloat = 32

--- a/Sources/EnviousWisprAppKit/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ShortcutsSettingsView.swift
@@ -38,8 +38,7 @@ struct ShortcutsSettingsView: View {
                 ? "Hold the hotkey to record, release to stop."
                 : "Press the hotkey to start recording, press again to stop."
             )
-            .font(.stHelper)
-            .foregroundStyle(.stTextTertiary)
+            .settingsReadingCopy()
             if settings.isPushToTalk {
               Text("Double-press to go hands-free. Triple-press to cancel.")
                 .font(.stHelper)
@@ -58,8 +57,7 @@ struct ShortcutsSettingsView: View {
         }
         BrandedRow(showDivider: false) {
           Text("Press this to discard the current recording and return to idle.")
-            .font(.stHelper)
-            .foregroundStyle(.stTextTertiary)
+            .settingsReadingCopy()
         }
       }
     }

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -49,8 +49,7 @@ struct SpeechEngineSettingsView: View {
               ? "Powered by Parakeet — fast English transcription with built-in punctuation."
               : "Powered by WhisperKit — broader language support with optimized quality defaults."
           )
-          .font(.stHelper)
-          .foregroundStyle(.stTextTertiary)
+          .settingsReadingCopy()
         }
         if let notice = engineSwitchDeferredNotice {
           BrandedRow(showDivider: false) {
@@ -230,8 +229,7 @@ struct SpeechEngineSettingsView: View {
             Text(
               "The ASR model will be unloaded from RAM after the selected idle period. The next recording will reload it (~2-5 s)."
             )
-            .font(.stHelper)
-            .foregroundStyle(.stTextTertiary)
+            .settingsReadingCopy()
           }
         }
         if settings.modelUnloadPolicy == .immediately {
@@ -305,9 +303,7 @@ struct SpeechEngineSettingsView: View {
         Text(
           "WhisperKit requires a ~1.5 GB model download. It runs fully on your Mac — no internet needed after setup."
         )
-        .font(.stHelper)
-        .foregroundStyle(.stTextTertiary)
-        .fixedSize(horizontal: false, vertical: true)
+        .settingsReadingCopy()
 
         HStack {
           Button("Download WhisperKit Model") {

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -30,8 +30,7 @@ struct YourWordsView: View {
               Text(
                 "Custom terms, vocabulary packs, and learning sources EnviousWispr uses to recognize what you say."
               )
-              .font(.stHelper)
-              .foregroundStyle(.stTextSecondary)
+              .settingsReadingCopy()
             }
             Spacer()
             Button {


### PR DESCRIPTION
## What & why

PR1 of the settings visual refresh (epic #1296). Settings reading paragraphs shipped at ~11.5pt in a dimmed grey — caption size and a de-emphasis colour — for text users are meant to *read*. Founder feedback (2026-07-03): text feels too small and the dark-mode grey is "hard on the eyes." This lays the foundation.

## Changes

- **New tokens** (`SettingsDesignTokens.swift`): `stBody` (14pt medium) and `stTextPrimary` (near-black `#0f0a1a` light / near-white `#ece9f4` dark, capped below pure white to limit halation on the night-comfort surfaces), plus the `stTextPrimary` `ShapeStyle` shorthand. Both use the existing `stDynamic` resolver, so light mode is correct by construction.
- **One reusable modifier** (`SettingsComponents.swift`): `settingsReadingCopy()` = body font + primary colour + vertical wrap. The single authority for reading-paragraph styling; paragraphs opt in.
- **26 standalone reading-paragraph sites** migrated to `.settingsReadingCopy()`: the AI Polish provider explainers + privacy note, standalone section descriptions on Microphone / Transcription / Shortcuts / Appearance, and the Your Words page description.
- **Left as microcopy** (per the plan's taxonomy §3C): one-line hints directly under a toggle/slider label (they must stay subordinate to their control label), semantic-coloured warning/error text, labels, status, pagination, and `lineLimit(1)` taglines.
- **Roomier spacing**: `sectionRadius` 12→14, `rowPaddingV` 10→12, `sectionSpacing` 16→18.

## Scope call (screenshot-verified)

A first pass also promoted the one-line subtitles that sit directly under toggle labels. Both-theme screenshot review showed those subtitles out-weighting their short toggle labels (e.g. "Restore clipboard after paste" dwarfed by its description; the Your Words *Learning* section shouting while the *Vocabulary Packs* blurbs right below whispered). Those were reverted to microcopy — the reverted sites are now byte-identical to `main`. Standalone section descriptions and segmented-picker descriptions read cleanly at 14pt and were kept.

## Not in scope

- Sidebar-selection restyle deferred to PR2 (native `.listStyle(.sidebar)` selection; PR2 is the "gliding selection" work).
- No motion, glows, rainbow accents (PR2 #1298 / PR3 #1299).
- No heart-path or behaviour change; no copy rewrites.

## Validation

- `swift build` (AppKit) green; Codex code-diff review clean.
- Live UAT: both-theme real screenshots across AI Polish, Transcription, Microphone, Clipboard, Shortcuts, Your Words, Appearance. Light mode confirmed correct (not just dark). Heart-path `test_recording()` intact.

Part of #1296
Closes #1297