### PR TITLE
test(ci): disposable benchmark for #1295 warm-cache validation

### DIFF
--- a/Sources/EnviousWisprAppKit/App/LastRecordingResult.swift
+++ b/Sources/EnviousWisprAppKit/App/LastRecordingResult.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Observation
 
+// no-op: forces a real Swift build for #1295 CI-cache warm-restore benchmark
+
 /// PR7 of epic #763. Owns post-recording polish/error state — the single
 /// observable fact "did the last polish fail, and with what message" — for
 /// views to render an error banner after a recording completes.


### PR DESCRIPTION
Disposable, will-not-merge PR to capture real Generate Xcode project step timing against the cache saved by the post-merge run for PR #1300. Closing without merging once timing is captured.