### PR TITLE
feat(settings): gliding engine selection, springy toggle, hover lift, rainbow accent (#1298)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -387,7 +387,10 @@ struct ProviderStatusChip: View {
 struct ProviderRailRow: View {
   let entry: PolishRailProvider
   let isSelected: Bool
+  let namespace: Namespace.ID
   let onSelect: () -> Void
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hovering = false
 
   var body: some View {
     Button(action: onSelect) {
@@ -416,17 +419,36 @@ struct ProviderRailRow: View {
       .padding(.horizontal, 12)
       .padding(.vertical, 11)
       .frame(maxWidth: .infinity, alignment: .leading)
-      .background(
-        RoundedRectangle(cornerRadius: 10, style: .continuous)
-          .fill(isSelected ? Color.stAccentLight : Color.clear)
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: 10, style: .continuous)
-          .strokeBorder(isSelected ? Color.stAccent : Color.clear, lineWidth: 1.5)
-      )
+      // ONE moving highlight (matchedGeometryEffect) so selection glides between
+      // rows. Only the selected row renders it; SwiftUI interpolates position on
+      // the animated selection change. Solid accent fill + stroke stay the
+      // primary selected signal (high-contrast / differentiate-without-colour);
+      // the brand rainbow is an ADDITIVE tint on the same edge. #1298.
+      .background {
+        if isSelected {
+          RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(Color.stAccentLight)
+            .overlay(
+              RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color.stAccent, lineWidth: 1.5)
+            )
+            .overlay(
+              RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color.obRainbow, lineWidth: 1.5)
+                .opacity(0.5)
+            )
+            .matchedGeometryEffect(id: "railSelection", in: namespace)
+        }
+      }
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
+    // Subtle hover lift. scaleEffect is a render transform applied AFTER layout,
+    // so the row's frame and hover hit-region do not move (no jitter loop); it
+    // only grows (1.006), never shrinks. Gated on reduce-motion. #1298.
+    .scaleEffect(hovering && !reduceMotion ? 1.006 : 1.0)
+    .onHover { hovering = $0 }
+    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
     .accessibilityElement(children: .combine)
     .accessibilityAddTraits(.isButton)
     .accessibilityLabel("\(entry.name), \(entry.isLocal ? "on this Mac" : "cloud")")
@@ -448,6 +470,10 @@ struct ProviderRailRow: View {
 /// state home (plan §3b).
 struct ProviderRail: View {
   @Binding var selection: LLMProvider
+  /// Shared namespace so the single selection highlight glides between rows
+  /// (matchedGeometryEffect) instead of jumping. #1298.
+  @Namespace private var selectionNS
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   var body: some View {
     VStack(alignment: .leading, spacing: 5) {
@@ -474,7 +500,14 @@ struct ProviderRail: View {
     ProviderRailRow(
       entry: entry,
       isSelected: selection == entry.provider,
-      onSelect: { selection = entry.provider })
+      namespace: selectionNS,
+      onSelect: {
+        // State commits immediately; the spring only animates the highlight
+        // glide. Gated on reduce-motion (instant end state).
+        withAnimation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.82)) {
+          selection = entry.provider
+        }
+      })
   }
 
   private func groupHeader(_ title: String) -> some View {

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
@@ -146,14 +146,27 @@ struct BrandedToggleStyle: ToggleStyle {
       HStack {
         configuration.label
         Spacer()
-        toggleTrack(isOn: configuration.isOn)
+        BrandedToggleTrack(isOn: configuration.isOn)
       }
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
+    // The style is a plain Button, so VoiceOver would otherwise announce only
+    // "button" with no state. Surface on/off as an accessibility value + toggle
+    // trait so the switch state is spoken (#1298; validate keyboard + VO in UAT).
+    .accessibilityValue(configuration.isOn ? "On" : "Off")
+    .accessibilityAddTraits(.isToggle)
   }
+}
 
-  private func toggleTrack(isOn: Bool) -> some View {
+/// The 38x22 track + knob, extracted into a `View` so it can read
+/// `accessibilityReduceMotion` and gate the springy knob animation. The toggle
+/// STATE commits immediately (the Button flips `isOn`); this spring is cosmetic.
+private struct BrandedToggleTrack: View {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  let isOn: Bool
+
+  var body: some View {
     ZStack(alignment: isOn ? .trailing : .leading) {
       Capsule()
         .fill(isOn ? Color.stToggleOn : Color.stToggleOff)
@@ -165,7 +178,8 @@ struct BrandedToggleStyle: ToggleStyle {
         .frame(width: 18, height: 18)
         .padding(2)
     }
-    .animation(.easeInOut(duration: 0.15), value: isOn)
+    .animation(
+      reduceMotion ? nil : .spring(response: 0.30, dampingFraction: 0.62), value: isOn)
   }
 }
 


### PR DESCRIPTION
## What & why

PR2 of the settings visual refresh (epic #1296) — the **joy layer** on the components PR1 (#1297) established. The window should feel alive under the cursor without ever costing speed or accessibility.

## Changes

- **Gliding engine selection** (`AIPolishProviderRail`): one highlight now glides between rows via `matchedGeometryEffect` (a soft `spring(0.35, 0.82)`) instead of jumping. The rail is a static `VStack` over stable `Identifiable` rows, so the highlight is well-behaved.
- **Springy toggle** (`BrandedToggleStyle`): the knob animates with a gentle overshoot (`spring(0.30, 0.62)`). Extracted the track into a small `View` so it can read the reduce-motion environment.
- **Hover lift**: a subtle `scaleEffect(1.006)` on the interactive engine rows. Scale is a render transform applied after layout, so the frame and hover hit-region don't move — no jitter loop.
- **Brand-rainbow accent**: an additive `Color.obRainbow` tint (0.5 opacity, 1.5pt) on the selected row's edge — **reusing the existing token**, no new spectrum. The solid `stAccent` fill + stroke remain the *primary* selected signal, so state reads without colour (high-contrast / differentiate-without-colour safe).
- **Accessibility fix** (carried along): `BrandedToggleStyle` is a plain `Button`, so VoiceOver previously heard only "button". It now surfaces `.accessibilityValue("On"/"Off")` + `.isToggle` — a pre-existing gap fixed while touching the style.

## Motion discipline

- Every animation gated on `@Environment(\.accessibilityReduceMotion)` → instant end state (motion *removed*, not shortened). **State always commits immediately**; springs are cosmetic only.
- One `.animation` per container (never per-row in a `ForEach` — a prior heap-corruption trap).
- **No always-running animation** — settings idle CPU stays flat. The living waveform/aurora is PR3 (#1299).

## Scope calls

- Hover lift is scoped to the **interactive** rail rows; static `BrandedSection` cards do **not** lift — hover-lifting a non-clickable card implies a false affordance.
- Rainbow **dividers** deferred (conservative start per plan §10 — evaluate after the selected-edge accent reads in screenshots).
- Sidebar-selection restyle remains native (`.listStyle(.sidebar)`); a custom restyle isn't worth the AppKit fragility.

## Validation

- `swift build` (AppKit) green; Codex code-diff review clean.
- Live UAT (window-id screenshots) both themes: glide, spring, hover, selected-edge rainbow, light-mode parity; reduce-motion static fallback; keyboard + screen-reader; rapid-switch/resize stability; idle-CPU check; heart-path `test_recording()` intact.

Part of #1296
Closes #1298