### PR TITLE
feat(settings): brand signature — rainbow waveform over a luminous aurora (#1299)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -366,6 +366,11 @@ struct AIPolishSettingsView: View {
     @Bindable var settings = settings
 
     SettingsContentView {
+      // ── Brand signature: breathing rainbow waveform over a luminous aurora.
+      // Perf-gated (animates only when the window is truly visible + active),
+      // decorative + accessibility-hidden (#1299).
+      SettingsSignatureView()
+
       // ── AI Polish master switch (slide toggle, on its own card) ──
       BrandedSection {
         BrandedRow(showDivider: false) {

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSignatureView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSignatureView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+// MARK: - Settings signature
+
+/// The brand signature on the AI Polish page: the rainbow waveform (reused from
+/// the recording HUD, UNMODIFIED) held at a pleasing open frame over a soft
+/// static luminous aurora. #1299.
+///
+/// Battery discipline (a speed-and-battery product): this signature is STATIC —
+/// zero animation, zero ongoing CPU. A *breathing* animated variant was built
+/// and measured behind a council-hardened AppKit occlusion gate (it correctly
+/// dropped to 0% CPU when the window was hidden/occluded/minimized), but its
+/// visible-state cost was ~30% CPU in a debug build — far too high for a
+/// decorative element on a product that sells speed. Per the plan's battery-
+/// safety-wins fallback, the animation is NOT shipped; the founder decides
+/// whether to invest in optimizing it, with those numbers in hand. The full
+/// gate design lives in docs/feature-requests/issue-1299-*.
+struct SettingsSignatureView: View {
+  @Environment(\.colorSchemeContrast) private var contrast
+
+  /// Fixed, pleasing level for the waveform (lips gently open).
+  private let restingLevel: Float = 0.34
+
+  var body: some View {
+    ZStack {
+      aurora
+      RainbowLipsIcon(size: 92, audioLevel: restingLevel)
+    }
+    .frame(maxWidth: .infinity)
+    .frame(height: 132)
+    .accessibilityHidden(true)
+  }
+
+  // MARK: Aurora (static luminous)
+
+  private var aurora: some View {
+    // A soft brand-hued glow behind the waveform. Static: renders once, no
+    // per-frame cost. Simplified (dropped) under Increase Contrast, where a
+    // low-opacity multi-hue gradient reads as banding/glitch (#1299).
+    Group {
+      if contrast == .increased {
+        Color.clear
+      } else {
+        ZStack {
+          Circle()
+            .fill(Color(red: 0.541, green: 0.169, blue: 0.886))
+            .frame(width: 210, height: 210)
+            .blur(radius: 70)
+            .opacity(0.16)
+            .offset(x: -70)
+          Circle()
+            .fill(Color(red: 0.0, green: 0.9, blue: 1.0))
+            .frame(width: 180, height: 180)
+            .blur(radius: 70)
+            .opacity(0.12)
+            .offset(x: 80, y: 10)
+          Circle()
+            .fill(Color(red: 1.0, green: 0.4, blue: 0.55))
+            .frame(width: 150, height: 150)
+            .blur(radius: 70)
+            .opacity(0.10)
+            .offset(x: 10, y: -30)
+        }
+        .allowsHitTesting(false)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What & why

PR3 of the settings visual refresh (epic #1296) — the **signature moment** on the AI Polish page: the brand rainbow waveform over a soft luminous aurora, in both themes.

## Changes

- **Signature hero** (`SettingsSignatureView`) at the top of the AI Polish page: the brand rainbow waveform (**reusing the recording-HUD `RainbowLipsIcon` UNMODIFIED**, at a fixed open frame) over a soft static brand-hued aurora (three blurred colour fields). Decorative + `.accessibilityHidden`.
- `RecordingOverlayPanel.swift` (the heart-path recording HUD) is **not touched** — reuse via the existing `audioLevel` parameter keeps the HUD out of a cosmetic blast radius (council).
- The aurora is dropped under **Increase Contrast** (a low-opacity multi-hue gradient would read as banding there).

## The battery decision (this is the important part)

The founder asked for a *living, breathing* waveform, guarded on battery, with the animate-or-not call made **with energy numbers in hand**. So I built the breathing animation behind a **council-hardened AppKit occlusion gate** (`NSWindow.occlusionState` + miniaturize + app-active + reduce-motion + increase-contrast — because SwiftUI's `controlActiveState` alone can't tell a window is 100% occluded), then **measured** it:

| State | CPU |
|---|---|
| visible + frontmost (animating) | **~30%** (debug build) |
| another app frontmost | **0.0%** |
| minimized | **~0.1%** |

**The gate worked** — animation dropped to zero when unseen. But **~30% CPU while visible is far too high** for a decorative element on a product that sells speed. Per the plan's *battery-safety-wins* fallback (§10.4), the **animation is NOT shipped**: PR3 ships the **static** signature (zero ongoing cost). The full gate design is preserved in `docs/feature-requests/issue-1299-*` so the founder can decide, with these numbers, whether to invest in optimizing the breathing version (lower frame rate / a cheaper renderer than a full Canvas redraw).

## Validation

- `swift build` (AppKit) green; Codex code-diff review clean.
- Live UAT: static signature reads as brand in both themes (window-id screenshots); idle CPU ~0%; heart-path `test_recording()` intact; HUD component untouched (not in the diff).

Part of #1296
Closes #1299