### PR TITLE
refactor(asr): consolidate WhisperKit model-load state into one machine (#1276 Step 1)

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -25,6 +25,11 @@ private let dictationComputeOptions = ModelComputeOptions(
   textDecoderCompute: .cpuAndGPU
 )
 
+/// WhisperKit conforms to the load-state machine's opaque model marker so the
+/// consolidated `LoadState` can carry the instance without the machine depending
+/// on WhisperKit (keeping `WhisperKitLoadState.swift` pure + WhisperKit-free).
+extension WhisperKit: LoadedASRModel {}
+
 /// WhisperKit ASR backend — broad language support with hardcoded dictation-optimized quality.
 ///
 /// Uses Argmax WhisperKit SPM for Whisper-based speech recognition.
@@ -34,89 +39,34 @@ private let dictationComputeOptions = ModelComputeOptions(
 ///
 /// The model must be downloaded via WhisperKitSetupService before calling prepare().
 public actor WhisperKitBackend: ASRBackend {
-  public private(set) var isReady = false
+  /// Protocol-required readiness, now COMPUTED from the single `loadState`
+  /// authority (#1276 Step 1) — true iff the model is loaded AND its warm-up has
+  /// resolved. Replaces the stored `isReady` bool that previously had to be
+  /// hand-synced at six sites and could disagree with `whisperKit`.
+  public var isReady: Bool { loadState.isReady }
 
   // BRAIN: gotcha id=default-model-turbo-v20240930
   private let modelVariant: String = WhisperKitBackend.defaultModelVariant()
-  private var whisperKit: WhisperKit?
 
-  /// Issue #445: single-flight guard for `prepare()`/`prepareIfCached()`.
-  /// Prevents duplicate `MLModel.load` work when the pipeline watchdog
-  /// cancels its host await and a subsequent press calls `prepare()` again
-  /// before the first one's background load returns. CoreML model loading is
-  /// uncancellable cooperatively, so we cannot stop the in-flight load — but
-  /// we can stop it from doubling. #1275: both `prepare()` and
-  /// `prepareIfCached()` now join this SAME task via `loadIfNeeded(resolveModelPath:)` —
-  /// previously `prepareIfCached()` called `loadFromPath` directly, bypassing
-  /// the guard.
-  private var loadTask: Task<Void, Error>?
+  /// The single load-state authority (#1276 Step 1). Consolidates the nine
+  /// former members (`whisperKit`, `isReady`, `loadTask`, `loadTaskSeq`,
+  /// `activeLoadTaskID`, `loadGeneration`, `warmupTask`, `warmupTaskGeneration`,
+  /// `warmupBudgetExhausted`) into one value; illegal combinations (kit non-nil
+  /// while not ready, budget-spent forgotten, orphan warm-up with no generation)
+  /// are unrepresentable. Mutated only through `WhisperKitLoadStateMachine.transition`.
+  private var loadState: LoadState = .idle
 
-  /// #1275 (Codex arch-consult finding 4): identity guard for `loadTask`
-  /// cleanup, mirroring `ASRManagerProxy`'s `loadTaskSeq`/`activeLoadTaskID`
-  /// (`ASRManagerProxy.swift:55-62,157-164`). `loadIfNeeded`'s cleanup must
-  /// only nil `loadTask` if it still IS the task this call created — without
-  /// this, a superseded load's late completion/throw can clobber a NEWER
-  /// load's task handle (repro: load A starts (task A, gen 0), `unload()`
-  /// fires (gen 1, A cancelled but CoreML load is uncancellable so A keeps
-  /// running), load B starts (sees `loadTask == nil`, creates task B, gen 1),
-  /// A's `WhisperKit(config)` finally resolves late, A's generation check
-  /// correctly throws, but A's catch-block cleanup does `loadTask = nil` —
-  /// clobbering B's still-in-flight handle, letting a 3rd concurrent load C
-  /// start and double real CoreML load cost). Deliberately separate from
-  /// `loadGeneration`: that guards stale READINESS writes after unload/reload;
-  /// this guards stale TASK-HANDLE cleanup — different failure modes.
-  private var loadTaskSeq: UInt64 = 0
-  private var activeLoadTaskID: UInt64 = 0
+  /// Monotonic generation stamp (former `loadGeneration`). Bumped by `unload()`
+  /// BEFORE the teardown transition so a load/warm-up completing after an unload
+  /// is recognizably stale. Lives OUTSIDE `loadState` because it must be
+  /// capturable at load-task creation time — before the enum transitions — which
+  /// is the #1282 fix (capture the generation before the `resolveModelPath`
+  /// await, not after).
+  private var generation: UInt64 = 0
 
-  /// #1275 (Codex r2 P2): monotonic generation stamp, mirroring
-  /// `ASRManagerProxy.loadGeneration` (`ASRManagerProxy.swift:53`). Bumped by
-  /// `unload()` so a `loadFromPath` in-flight at unload time can never write
-  /// `isReady = true` after the fact on a since-cleared `whisperKit`.
-  private var loadGeneration: UInt64 = 0
-
-  /// #1275 item A: outcome of the silent warm-up inference run at load time.
-  private enum WarmupOutcome: Sendable {
-    case completed(ms: Int)
-    case threw(desc: String)
-  }
-
-  /// Handle to the in-flight (or, after a fail-open timeout, orphaned)
-  /// warm-up task. Drained — never blindly awaited — by
-  /// `readyKitAfterWarmupDrain()`, the single gate every shared-instance
-  /// caller (`transcribe`/`observeLID`/`makeIncrementalSession`) must pass
-  /// through before touching `whisperKit`.
-  private var warmupTask: Task<WarmupOutcome, Never>?
-
-  /// The `loadGeneration` value `warmupTask` belongs to. `nil` when no task
-  /// is tracked. Consolidates what was a separate `warmupToken` counter
-  /// (adversarial-review finding, #1275) into the SAME generation stamp
-  /// `unload()` already bumps: a `warmupTask` left behind by a load that has
-  /// since been superseded (by `unload()`, not just by a newer warm-up
-  /// within the same load) is now recognizable as stale by comparing this
-  /// against the CURRENT `loadGeneration` — not just against a later
-  /// warm-up's own token. This closes a race the separate-counter version
-  /// missed: `readyKitAfterWarmupDrain()` would otherwise await a fail-open
-  /// timeout on an ORPHANED warm-up from a load that `unload()` already
-  /// discarded, while a completely independent newer load is still in its
-  /// (multi-second) CoreML load phase — turning what should be an immediate
-  /// "not ready yet" into a 20-second stall on irrelevant background work.
-  private var warmupTaskGeneration: UInt64?
-
-  /// The `loadGeneration` whose warm-up already burned its one 20s fail-open
-  /// budget in `runWarmup()` itself (i.e. the background warm-up timed out).
-  /// `nil` when the current generation's warm-up has not (yet) exhausted its
-  /// budget. Codex code-diff review (medium effort, #1275): without this,
-  /// `readyKitAfterWarmupDrain()` re-awaits the SAME already-timed-out task
-  /// with its own fresh 20s deadline, so the first real caller after a
-  /// wedged warm-up could pay a SECOND 20s stall on top of the first —
-  /// turning an invisible background hiccup into up to 40s of user-facing
-  /// latency, defeating the fail-open design. Once a generation's budget is
-  /// marked exhausted (by `runWarmup`'s own timeout, or by a caller's drain
-  /// timeout), every subsequent caller for that generation skips the await
-  /// entirely and vends the kit immediately — accepting the same
-  /// theoretical concurrent-decode risk the design already documents as
-  /// unproven-but-low-probability, exactly once per generation, never twice.
-  private var warmupBudgetExhausted: UInt64?
+  /// Monotonic id source (former `loadTaskSeq`) distinguishing concurrent load
+  /// tasks so a superseded load's late cleanup can't clobber a newer load.
+  private var loadSeq: UInt64 = 0
 
   /// Duration of the most recent warm-up inference, in milliseconds. `nil`
   /// when no warm-up has completed yet (still loading, threw, or timed out).
@@ -125,11 +75,58 @@ public actor WhisperKitBackend: ASRBackend {
   /// Parakeet (query by presence, never a new event).
   package private(set) var lastWarmupInferenceMs: Int?
 
+  /// Test-only injection of the two operations that need a real `WhisperKit`
+  /// (building the kit from a path; running the silent warm-up inference). `nil`
+  /// in production — the real paths run. Lets the actor's load/warm-up/unload
+  /// ORCHESTRATION (single-flight, generation staleness, fail-open budget,
+  /// two-consumer) be exercised without a real model. `internal` (not `package`)
+  /// so it never leaks past the ASR module; tests reach it via `@testable import`.
+  struct TestSeams {
+    let loadModel: @Sendable (String) async throws -> any LoadedASRModel
+    /// The kit is deliberately NOT passed in — a self-isolated non-Sendable kit
+    /// can't cross into a `@Sendable` closure, and tests drive the outcome, not
+    /// the kit. Production's real warm-up uses the kit directly (see `performWarmup`).
+    let runWarmup: @Sendable () async -> WarmupOutcome
+    /// Fail-open warm-up deadline. Production is 20s; tests shrink it so the
+    /// timeout path is signal-fast, not a real 20s wait.
+    var warmupDeadlineSeconds: Double = 20
+  }
+  private let testSeams: TestSeams?
+
+  /// Fail-open warm-up ceiling (seconds). Bounds an invisible background task,
+  /// never a user-facing wait (founder-approved exception to
+  /// timeout-numbers-need-distribution-evidence, #1275 Gate 2).
+  private var warmupDeadlineSeconds: Double { testSeams?.warmupDeadlineSeconds ?? 20 }
+
   /// Exposes the configured model variant name (e.g. `openai_whisper-large-v3-v20240930_turbo`).
   /// Read-only; used by telemetry to tag per-transcription events with the model in use.
   package var modelVariantName: String { modelVariant }
 
-  package init() {}
+  package init() { self.testSeams = nil }
+
+  /// Test-only initializer that injects fake load/warm-up operations.
+  init(testSeams: TestSeams) { self.testSeams = testSeams }
+
+  /// Snapshot of the current load phase, for tests to assert orchestration
+  /// outcomes without touching private state.
+  var loadPhaseForTesting: LoadPhase { loadState.phase }
+
+  /// Test-only: drive the load single-flight with an INJECTED resolver, so tests
+  /// avoid the real `WhisperKitSetupService` / network resolver `prepare()` uses.
+  /// Pairs with `TestSeams` (which fakes the kit build + warm-up).
+  func loadForTesting(resolveModelPath: @escaping @Sendable () async throws -> String)
+    async throws
+  {
+    try await loadIfNeeded(resolveModelPath: resolveModelPath)
+  }
+
+  /// Test-only: run the vend gate and report the resulting phase (the fake kit
+  /// can't be a real `WhisperKit`, so the returned kit is not observable — the
+  /// phase transition is what tests assert on).
+  func vendForTesting() async -> LoadPhase {
+    _ = await readyKitAfterWarmupDrain()
+    return loadState.phase
+  }
 
   /// Single source of truth for the shipped default model variant.
   package static func defaultModelVariant() -> String {
@@ -137,8 +134,6 @@ public actor WhisperKitBackend: ASRBackend {
   }
 
   public func prepare() async throws {
-    guard !isReady else { return }  // Idempotent — skip if already loaded
-
     let variant = modelVariant
     try await loadIfNeeded {
       // Use cached model path from WhisperKitSetupService (no network call).
@@ -161,7 +156,7 @@ public actor WhisperKitBackend: ASRBackend {
   /// the artifacts are all present. Used by silent/background warmup paths
   /// that must never trigger a network download.
   package func prepareIfCached() async throws -> Bool {
-    guard !isReady else { return true }
+    if loadState.isReady { return true }
     guard let cached = WhisperKitSetupService.getLocalModelPath(variant: modelVariant) else {
       return false  // Model not cached or cache incomplete — skip silently.
     }
@@ -169,41 +164,209 @@ public actor WhisperKitBackend: ASRBackend {
     return true
   }
 
-  /// Issue #445 + #1275: single owner of the `loadTask` single-flight
-  /// lifecycle for BOTH `prepare()` and `prepareIfCached()`. Previously
-  /// `prepareIfCached()` called `loadFromPath` directly, bypassing this
-  /// guard — a latent double-load race (documented at
-  /// `WhisperKitEngineAdapter.swift` near the `prepareIfCached` call site).
-  /// If a prior load is still in flight (e.g. its host await was cancelled
-  /// by the pipeline watchdog but the underlying CoreML load is still
-  /// grinding), join the existing task instead of spawning a parallel load.
+  // MARK: - Load-state orchestration (#1276 Step 1)
+
+  /// Advance the state machine by one event: apply the returned state, run its
+  /// SYNCHRONOUS side-effects (logging, telemetry, task cancellation), and return
+  /// the ORCHESTRATION effects (`beginLoad`/`joinLoad`/`beginWarmup`/`beginDrain`/
+  /// `throwSuperseded`) for the async caller to drive. State is mutated BEFORE any
+  /// logging await, so a reentrant read never sees a stale phase
+  /// ([[actor-reentrancy-await]]).
+  @discardableResult
+  private func emit(_ event: LoadEvent) async -> [Effect] {
+    let (next, effects) = WhisperKitLoadStateMachine.transition(
+      loadState, on: event, generation: generation)
+    loadState = next
+    for effect in effects { await runSideEffect(effect) }
+    return effects
+  }
+
+  /// Executes the synchronous effects (cancel / log / telemetry). Orchestration
+  /// effects are no-ops here — the async caller drives them.
+  private func runSideEffect(_ effect: Effect) async {
+    switch effect {
+    case .cancelLoadTask(let task): task.cancel()
+    case .cancelWarmupTask(let task): task.cancel()
+    case .cancelOrphanWarmupOnUnload(let task): task.cancel()
+    case .recordWarmupMs(let ms):
+      lastWarmupInferenceMs = ms
+      await AppLogger.shared.log(
+        "WhisperKit warm-up: completed(\(ms)ms)", level: .info, category: "WhisperKitBackend")
+    case .logWarmupThrew(let desc):
+      await AppLogger.shared.log(
+        "WhisperKit warm-up: threw(\(desc))", level: .info, category: "WhisperKitBackend")
+    case .logWarmupTimedOut:
+      await AppLogger.shared.log(
+        "WhisperKit warm-up: timed_out (20s fail-open ceiling)",
+        level: .info, category: "WhisperKitBackend")
+    case .logBudgetExhaustedVend:
+      await AppLogger.shared.log(
+        "WhisperKit warm-up: budget already exhausted — vending kit without re-draining",
+        level: .info, category: "WhisperKitBackend")
+    case .logDrainTimedOutVend:
+      await AppLogger.shared.log(
+        "WhisperKit warm-up: drain also timed_out after 20s — vending kit anyway",
+        level: .info, category: "WhisperKitBackend")
+    case .beginLoad, .joinLoad, .beginWarmup, .beginDrain, .throwSuperseded:
+      break  // orchestration — driven by the async caller
+    }
+  }
+
+  /// Single owner of the load single-flight lifecycle for BOTH `prepare()` and
+  /// `prepareIfCached()` (#445 + #1275). Consults the state machine's
+  /// `prepareRequested` decision: already-ready → return; a load in flight → join
+  /// it (never a second CoreML load); idle → start one.
   private func loadIfNeeded(resolveModelPath: @escaping @Sendable () async throws -> String)
     async throws
   {
-    if let existing = loadTask {
-      try await existing.value
-      return
-    }
-
-    let task = Task<Void, Error> {
-      let modelPath = try await resolveModelPath()
-      try await loadFromPath(modelPath)
-    }
-
-    loadTaskSeq &+= 1
-    let myTaskID = loadTaskSeq
-    loadTask = task
-    activeLoadTaskID = myTaskID
-    defer {
-      // Identity guard: only clear the handle if it still belongs to THIS
-      // call. A superseded load's late completion must not clobber a newer
-      // load's in-flight task handle (finding 4 above).
-      if activeLoadTaskID == myTaskID {
-        loadTask = nil
+    let effects = await emit(.prepareRequested)
+    for effect in effects {
+      switch effect {
+      case .joinLoad(let task):
+        try await task.value
+        return
+      case .beginLoad:
+        try await startLoad(resolveModelPath: resolveModelPath)
+        return
+      default:
+        break
       }
     }
+    // No orchestration effect → already ready; nothing to do.
+  }
 
+  /// Creates the load task and records it (idle → loading). Captures the
+  /// generation + id BEFORE the `resolveModelPath` await runs (the #1282 fix):
+  /// the identity carries the pre-await generation, so an `unload()` during
+  /// `resolveModelPath` bumps `generation` and the later `loadSucceeded` guard
+  /// recognizes this load as stale. The single-flight handle cleanup lives in
+  /// `runLoad`'s terminal transitions (loadFailed → idle / loadSucceeded → warming).
+  private func startLoad(resolveModelPath: @escaping @Sendable () async throws -> String)
+    async throws
+  {
+    let capturedGeneration = generation  // #1282: capture BEFORE any await
+    loadSeq &+= 1
+    let identity = LoadIdentity(generation: capturedGeneration, id: loadSeq)
+    let task = Task<Void, Error> {
+      try await self.runLoad(resolveModelPath: resolveModelPath, identity: identity)
+    }
+    await emit(.loadStarted(identity, task: task))  // → .loading
     try await task.value
+  }
+
+  /// The load task body: resolve the path, build the kit, then hand off to the
+  /// warm-up phase. Every terminal feeds an event into the state machine, which
+  /// owns the staleness decision (a completion racing an `unload()` is dropped by
+  /// generation comparison — the actor never re-checks staleness itself).
+  private func runLoad(
+    resolveModelPath: @escaping @Sendable () async throws -> String, identity: LoadIdentity
+  ) async throws {
+    let modelPath: String
+    do {
+      modelPath = try await resolveModelPath()
+    } catch {
+      await emit(.loadFailed(identity))
+      throw error
+    }
+    let kit: any LoadedASRModel
+    do {
+      kit = try await performLoad(modelPath)
+    } catch {
+      await emit(.loadFailed(identity))
+      throw error
+    }
+    for effect in await emit(.loadSucceeded(kit: kit, identity)) {
+      switch effect {
+      case .throwSuperseded:
+        throw ASRLoadSupersededError()
+      case .beginWarmup(let warmKit, let warmGeneration):
+        try await runWarmupPhase(kit: warmKit, generation: warmGeneration)
+      default:
+        break
+      }
+    }
+  }
+
+  /// Runs the silent warm-up inference (loading → warming → ready). One silent
+  /// decode before `isReady` flips, so the first real press never pays the
+  /// first-decode penalty (#1275 item A). Fails open under a 20s deadline: on
+  /// timeout the model is still vendable, the orphan task rides in
+  /// `.ready(staleWarmup:)`, and its budget is marked spent so no caller ever
+  /// pays the 20s twice. The 20s ceiling bounds an invisible background task,
+  /// never a user-facing wait (founder-approved exception to
+  /// timeout-numbers-need-distribution-evidence, #1275 Gate 2).
+  private func runWarmupPhase(kit: any LoadedASRModel, generation warmGeneration: UInt64)
+    async throws
+  {
+    // Invariant #7: clear the previous load's value before this run — only a
+    // clean completion records a fresh one, so a throw/timeout must not leave a
+    // prior load's stale duration attached to telemetry.
+    lastWarmupInferenceMs = nil
+
+    let warmupTask = Task<WarmupOutcome, Never> { await self.performWarmup(kit) }
+    await emit(.warmupStarted(kit: kit, generation: warmGeneration, warmupTask: warmupTask))
+    // If the warm-up was superseded before it could be recorded, `emit` cancelled
+    // the just-created task and the state is not `.warming` — bail as superseded.
+    guard case .warming = loadState else { throw ASRLoadSupersededError() }
+
+    if let outcome = await withDeadline(
+      seconds: warmupDeadlineSeconds, operation: { await warmupTask.value })
+    {
+      await emit(.warmupResolved(outcome, generation: warmGeneration))
+    } else {
+      // Codex code-diff review (#1275): the timeout marks this generation's
+      // budget spent (via `.warmupTimedOut` → `.ready(staleWarmup: budgetSpent)`)
+      // so the vend gate never re-awaits the same stuck task with a fresh 20s.
+      await emit(.warmupTimedOut(generation: warmGeneration))
+    }
+
+    // Codex code-diff r1: if an `unload()` raced this warm-up await, the state
+    // machine already ignored the (stale) resolve/timeout event and moved the
+    // backend to `.idle`. Without this guard `runWarmupPhase` would return
+    // NORMALLY, so `prepare()`/`prepareIfCached()` would report success while the
+    // backend is actually unloaded (`isReady == false`). Mirror the old
+    // post-warm-up generation guard: a load whose generation no longer matches
+    // the live one throws superseded rather than falsely reporting ready.
+    guard warmGeneration == generation else { throw ASRLoadSupersededError() }
+  }
+
+  /// Builds the WhisperKit instance from a model path. Test seam overrides it so
+  /// the load orchestration is exercisable without a real model.
+  private func performLoad(_ modelPath: String) async throws -> any LoadedASRModel {
+    if let seams = testSeams { return try await seams.loadModel(modelPath) }
+    let config = WhisperKitConfig(
+      model: modelVariant,
+      modelFolder: modelPath,
+      computeOptions: dictationComputeOptions,
+      download: false
+    )
+    // Load-duration timing + the hang signal for this in-process WhisperKit load
+    // already exist via `ensureEngineWarm`'s `coldstart.warmup_*` events; what is
+    // missing is a FINE-GRAINED progress callback (upstream `WhisperKit(config)`
+    // exposes no per-step load progress), so an automatic hang WATCHDOG stays
+    // deferred for lack of a defended-timeout distribution — NOT for lack of
+    // timing data. Do NOT wrap this in a wall-clock timeout
+    // (timeout-numbers-need-distribution-evidence).
+    return try await WhisperKit(config)
+  }
+
+  /// Runs one silent warm-up decode (1s of digital silence through the SAME
+  /// production option builder every real transcribe uses). Test seam overrides
+  /// it so the warm-up orchestration is exercisable without a real model.
+  private func performWarmup(_ kit: any LoadedASRModel) async -> WarmupOutcome {
+    if let seams = testSeams { return await seams.runWarmup() }
+    guard let wk = kit as? WhisperKit else {
+      return .threw(desc: "warm-up skipped: model is not a WhisperKit instance")
+    }
+    let silence = [Float](repeating: 0, count: 16_000)  // 1s at 16kHz
+    let opts = makeDecodeOptions(from: .default, sampleCount: silence.count)
+    let start = CFAbsoluteTimeGetCurrent()
+    do {
+      _ = try await wk.transcribe(audioArray: silence, decodeOptions: opts)
+      return .completed(ms: Int((CFAbsoluteTimeGetCurrent() - start) * 1000))
+    } catch {
+      return .threw(desc: error.localizedDescription)
+    }
   }
 
   /// WhisperKit 0.12+ model folder artifacts required for a successful load.
@@ -246,175 +409,44 @@ public actor WhisperKitBackend: ASRBackend {
     return true
   }
 
-  private func loadFromPath(_ modelPath: String) async throws {
-    // #1275 (Codex r2 P2): capture the generation before any await. `unload()`
-    // bumps it, so a load/warm-up whose completion races an unload can never
-    // resurrect `isReady = true` on a since-cleared `whisperKit` — the same
-    // established pattern `ASRManagerProxy.loadGeneration` uses for the
-    // identical class of race (`ASRManagerProxy.swift:53`), reused here
-    // rather than inventing a new mechanism.
-    let gen = loadGeneration
-
-    let config = WhisperKitConfig(
-      model: modelVariant,
-      modelFolder: modelPath,
-      computeOptions: dictationComputeOptions,
-      download: false
-    )
-    // Load-duration timing + the hang signal for this in-process WhisperKit load
-    // already exist: `ensureEngineWarm` emits `coldstart.warmup_started` /
-    // `_completed {duration_ms}` / `_failed` (and `launch.model_preload_completed`)
-    // for the launch / engine-swap paths where the model actually cold-loads, so
-    // a hang shows up as `warmup_started` with no terminal. What is still missing
-    // is a FINE-GRAINED progress callback: upstream `WhisperKit(config)` exposes
-    // no per-step load progress, so an automatic hang WATCHDOG stays deferred for
-    // lack of a defended-timeout distribution — NOT for lack of timing data. Do
-    // not wrap this in a wall-clock timeout (timeout-numbers-need-distribution-evidence).
-    let kit = try await WhisperKit(config)
-    guard gen == loadGeneration else { throw ASRLoadSupersededError() }
-    self.whisperKit = kit
-
-    // #1275 item A: one silent warm-up inference before flipping isReady, so
-    // the first real press never pays the (path-dependent) first-decode
-    // penalty measured 2026-07-02. Fails open — a throw or timeout still
-    // flips isReady, since the model IS loaded and usable; only the
-    // first-press latency win is lost.
-    await runWarmup(kit: kit, generation: gen)
-    guard gen == loadGeneration else { throw ASRLoadSupersededError() }
-    isReady = true
-  }
-
-  /// Runs the silent warm-up inference (1s of digital silence, decoded
-  /// through the SAME production option builder every real transcribe call
-  /// uses) and records its terminal status. Wrapped in a 20s fail-open
-  /// deadline (founder-approved exception to timeout-numbers-into-evidence,
-  /// #1275 Gate 2 — this bounds an invisible background task, never a
-  /// user-facing wait; a too-large value costs nothing in the healthy case,
-  /// a too-small value merely reverts to today's behavior). On timeout the
-  /// task handle is left in `warmupTask` for `readyKitAfterWarmupDrain()` to
-  /// drain later — never re-awaited here, since `withDeadline` abandons it.
-  /// `generation` is the `loadGeneration` this warm-up belongs to (captured
-  /// by the caller, `loadFromPath`, before any await).
-  private func runWarmup(kit: WhisperKit, generation: UInt64) async {
-    // Codex r1 P3: clear the PREVIOUS load's value before this run — only
-    // `.completed` below sets a fresh one, so a throw/timeout on THIS load
-    // must not leave a prior load's stale duration attached to telemetry.
-    lastWarmupInferenceMs = nil
-    // This generation has not spent its fail-open budget yet.
-    if warmupBudgetExhausted == generation { warmupBudgetExhausted = nil }
-
-    let silence = [Float](repeating: 0, count: 16_000)  // 1s at 16kHz
-    let opts = makeDecodeOptions(from: .default, sampleCount: silence.count)
-
-    let task = Task<WarmupOutcome, Never> {
-      let start = CFAbsoluteTimeGetCurrent()
-      do {
-        _ = try await kit.transcribe(audioArray: silence, decodeOptions: opts)
-        return .completed(ms: Int((CFAbsoluteTimeGetCurrent() - start) * 1000))
-      } catch {
-        return .threw(desc: error.localizedDescription)
-      }
-    }
-    warmupTask = task
-    warmupTaskGeneration = generation
-
-    guard let outcome = await withDeadline(seconds: 20, operation: { await task.value }) else {
-      // Codex code-diff review (medium effort, #1275): mark this generation's
-      // budget spent so `readyKitAfterWarmupDrain()` never re-awaits the same
-      // stuck task with a second fresh 20s deadline.
-      warmupBudgetExhausted = generation
-      await AppLogger.shared.log(
-        "WhisperKit warm-up: timed_out (20s fail-open ceiling)",
-        level: .info, category: "WhisperKitBackend"
-      )
-      return
-    }
-
-    // Per actor-reentrancy-await: only clear the handle — and only record the
-    // outcome — if this generation is still the one `warmupTask` is tracking
-    // (no interleaved unload/reload replaced it during this await). Without
-    // this check, an abandoned load's late completion could overwrite a
-    // NEWER load's `lastWarmupInferenceMs` with stale data (the same class
-    // of race Codex r2 P2 found for `isReady`, closed here too).
-    guard warmupTaskGeneration == generation else { return }
-    warmupTask = nil
-    warmupTaskGeneration = nil
-
-    switch outcome {
-    case .completed(let ms):
-      lastWarmupInferenceMs = ms
-      await AppLogger.shared.log(
-        "WhisperKit warm-up: completed(\(ms)ms)",
-        level: .info, category: "WhisperKitBackend"
-      )
-    case .threw(let desc):
-      await AppLogger.shared.log(
-        "WhisperKit warm-up: threw(\(desc))",
-        level: .info, category: "WhisperKitBackend"
-      )
-    }
-  }
-
   /// Single vend gate for the shared `WhisperKit` instance. Every
   /// shared-instance caller (`transcribe`, `observeLID`,
   /// `makeIncrementalSession`) MUST obtain the kit through this helper, never
-  /// by reading `whisperKit` directly, so a request can never race a
+  /// by reading the state's kit directly, so a request can never race a
   /// straggling orphaned warm-up decode from a prior timeout (no proven
   /// concurrent-decode safety on one `WhisperKit` instance).
   ///
-  /// Codex r1 P1: draining the orphan with NO deadline defeated the whole
-  /// point of the 20s fail-open ceiling — a genuinely wedged warm-up would
-  /// then block every subsequent press indefinitely instead of just its own
-  /// decode. The drain reuses the SAME 20s fail-open budget; if it ALSO
-  /// expires, the handle is cleared anyway and the kit is vended regardless
-  /// (accepting the same theoretical concurrent-decode risk the design
-  /// already documents as unproven-but-low-probability, rather than
-  /// re-paying an unbounded wait on every future press).
+  /// The state machine's `vendRequested` decision (invariants #4/#5/#6):
+  /// - clean ready → vend immediately;
+  /// - ready with a budget-already-spent orphan → vend without re-draining
+  ///   (`.logBudgetExhaustedVend`; the orphan handle is dropped by the transition),
+  ///   so a caller never pays the 20s twice;
+  /// - ready with an un-drained orphan, or mid-warming → drain the warm-up under
+  ///   the SAME 20s fail-open budget, then re-read readiness. If the drain also
+  ///   times out we vend anyway (`.logDrainTimedOutVend`), accepting the same
+  ///   theoretical concurrent-decode risk the design documents as
+  ///   unproven-but-low-probability rather than re-paying an unbounded wait.
   ///
-  /// Adversarial-review finding (#1275): only drain a `warmupTask` that
-  /// belongs to the CURRENT `loadGeneration`. A `warmupTask` left behind by
-  /// a load `unload()` has since superseded is irrelevant to a request that
-  /// arrives while a completely independent newer load is still in its
-  /// (multi-second) CoreML load phase — draining it anyway meant such a
-  /// request could pay up to 20 extra seconds waiting on background work for
-  /// a model that no longer exists, instead of immediately falling through
-  /// to `guard isReady` and returning nil.
-  ///
-  /// Codex code-diff review (medium effort, #1275): if THIS generation's
-  /// warm-up already spent its 20s budget inside `runWarmup()` itself
-  /// (`warmupBudgetExhausted == loadGeneration`), do not re-await the same
-  /// stuck task with a second fresh deadline — the real caller vends
-  /// immediately instead of paying up to 40s total (20s in the background
-  /// warm-up + 20s here) for what the fail-open design intended to cost at
-  /// most 20s of invisible background time.
+  /// The generation carried on `.beginDrain`/`.drainResolved` means a drain whose
+  /// warm-up belonged to a since-superseded load is dropped by the transition —
+  /// the actor never re-checks staleness after the await.
   private func readyKitAfterWarmupDrain() async -> WhisperKit? {
-    if let pending = warmupTask, warmupTaskGeneration == loadGeneration {
-      let generation = loadGeneration
-      if warmupBudgetExhausted == generation {
-        warmupTask = nil
-        warmupTaskGeneration = nil
-        await AppLogger.shared.log(
-          "WhisperKit warm-up: budget already exhausted — vending kit without re-draining",
-          level: .info, category: "WhisperKitBackend"
-        )
-        guard isReady else { return nil }
-        return whisperKit
-      }
-      let outcome = await withDeadline(seconds: 20, operation: { await pending.value })
-      if warmupTaskGeneration == generation {
-        warmupTask = nil
-        warmupTaskGeneration = nil
-        if outcome == nil {
-          warmupBudgetExhausted = generation
-          await AppLogger.shared.log(
-            "WhisperKit warm-up: drain also timed_out after 20s — vending kit anyway",
-            level: .info, category: "WhisperKitBackend"
-          )
-        }
+    for effect in await emit(.vendRequested) {
+      if case .beginDrain(let task, let drainGeneration) = effect {
+        let outcome = await withDeadline(
+          seconds: warmupDeadlineSeconds, operation: { await task.value })
+        await emit(.drainResolved(didTimeOut: outcome == nil, generation: drainGeneration))
       }
     }
-    guard isReady else { return nil }
-    return whisperKit
+    return currentReadyKit()
+  }
+
+  /// The vendable `WhisperKit` iff the state is `.ready`, else nil. In production
+  /// the ready kit is always a `WhisperKit`; the downcast fails only under a test
+  /// seam that injected a fake, which never drives the real transcribe path.
+  private func currentReadyKit() -> WhisperKit? {
+    guard case .ready(let kit, _) = loadState else { return nil }
+    return kit as? WhisperKit
   }
 
   public func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws
@@ -440,38 +472,19 @@ public actor WhisperKitBackend: ASRBackend {
   }
 
   public func unload() async {
-    // #1275 (Codex r2 P2): supersede any in-flight loadFromPath BEFORE
-    // clearing state, so its post-await guards see the bumped generation.
-    loadGeneration &+= 1
-    // Adversarial-review finding (#1275): also clear `loadTask` — mirrors
-    // `ASRManagerProxy.unloadModel()`'s `inFlightLoadTask?.cancel(); nil`
-    // (`ASRManagerProxy.swift:226,233-234`). Without this, a `prepare()`
-    // called right after `unload()` would join the now-doomed task via
-    // `loadIfNeeded`'s single-flight join instead of starting a fresh load —
-    // the doomed task's generation check (`loadFromPath`) throws
-    // `ASRLoadSupersededError`, which would then wrongly fail a legitimate
-    // new load request instead of ever starting one. Cancellation is
-    // best-effort (CoreML loading is uncancellable cooperatively); nil-ing
-    // the handle is what actually matters.
-    loadTask?.cancel()
-    loadTask = nil
-
-    // Codex code-diff review (medium effort, #1275): mirror the loadTask
-    // handling immediately above for `warmupTask` — without this, an
-    // in-flight or fail-open-timed-out warm-up keeps running and retaining
-    // its captured `WhisperKit` instance after unload, so the old model can
-    // stay in memory doing CoreML work while the backend is supposed to be
-    // unloaded (or while a new load is starting). Cancellation is
-    // best-effort for the same reason as `loadTask` (CoreML decode is
-    // uncancellable cooperatively); clearing the handles is what stops US
-    // from later draining or reporting on a task tied to a discarded model.
-    warmupTask?.cancel()
-    warmupTask = nil
-    warmupTaskGeneration = nil
-    warmupBudgetExhausted = nil
-
-    whisperKit = nil
-    isReady = false
+    // Supersede any in-flight load/warm-up BEFORE the teardown transition
+    // (#1275 Codex r2 P2): bumping `generation` first means a load/warm-up
+    // completing after this point sees the new generation and its state-machine
+    // guard drops it (never resurrecting a stale `.ready` on a discarded model).
+    generation &+= 1
+    // The `.unloadRequested` transition returns `.idle` and the cancel effects
+    // for whatever tasks the leaving state held (load task, live warm-up, or
+    // orphaned warm-up). Cancellation is best-effort — CoreML load/decode is
+    // uncancellable cooperatively — but dropping the handles (the enum leaving
+    // those cases) is what stops us from later draining or reporting on a task
+    // tied to a discarded model, and stops a post-unload `prepare()` from
+    // joining a doomed load instead of starting a fresh one.
+    await emit(.unloadRequested)
   }
 
   // MARK: - Private

--- a/Sources/EnviousWisprASR/WhisperKitLoadState.swift
+++ b/Sources/EnviousWisprASR/WhisperKitLoadState.swift
@@ -1,0 +1,355 @@
+import Foundation
+
+// MARK: - WhisperKit model-load state machine (functional core, #1276 Step 1)
+//
+// Consolidates the nine hand-rolled load-state members that used to live on
+// `WhisperKitBackend` (`loadTask`, `loadTaskSeq`, `activeLoadTaskID`,
+// `loadGeneration`, `warmupTask`, `warmupTaskGeneration`, `warmupBudgetExhausted`,
+// `whisperKit`, `isReady`) into ONE `LoadState` value plus one monotonic
+// `generation` counter the actor owns. The scattered fields could disagree with
+// each other (kit non-nil while `isReady` false, a budget-spent flag forgotten,
+// a warm-up task orphaned with no matching generation); folding them into a
+// single enum makes those disagreements unrepresentable.
+//
+// `transition(_:on:generation:)` is a PURE function: given the current state, an
+// event, and the live generation, it returns the next state plus a list of
+// side-effects for the actor to execute (create a task, throw, log). The actor
+// (`WhisperKitBackend`) owns the `WhisperKit` instance and performs every effect;
+// this file makes zero calls into WhisperKit and holds zero live state. That
+// split lets the exhaustive (state × event) matrix be tested without ever
+// constructing a `WhisperKit` (see `WhisperKitLoadStateTests`).
+//
+// Buy-vs-build note (#1276, Codex-validated 2026-07-03): the toolkit ships its
+// own `ModelState`/`ModelManager`, but `ModelManager` needs a `ModelLoader` shim
+// (WhisperKit isn't one) and its `unloadModels()` no-ops mid-load, so it does not
+// solve the unload-during-load race this machine's `generation` guard covers.
+// We therefore keep our own (now consolidated) machine. `isReady` is a strict
+// superset of the toolkit's `.loaded` (loaded AND warm-up resolved), so
+// `modelState` cannot be the readiness authority either. Detail:
+// `docs/feature-requests/issue-1276-step1-buy-vs-build-inventory.md`.
+
+/// Terminal status of the silent warm-up inference run once at load time.
+/// Moved here (was a `private enum` on the actor) so tests can assert on it.
+enum WarmupOutcome: Sendable, Equatable {
+  case completed(ms: Int)
+  case threw(desc: String)
+}
+
+/// Identity of a single load attempt. `generation` is the monotonic stamp
+/// `unload()` bumps (staleness); `id` distinguishes concurrent load-task handles
+/// so a superseded load's late cleanup can't clobber a newer load's handle
+/// (the former `loadTaskSeq`/`activeLoadTaskID` pair).
+struct LoadIdentity: Sendable, Equatable {
+  let generation: UInt64
+  let id: UInt64
+}
+
+/// Warm-up sub-state carried by `.warming` (live) and `.ready(staleWarmup:)`
+/// (orphaned after a fail-open timeout). `budgetSpent` rides WITH the warm-up so
+/// the "pay the 20s fail-open budget at most once per generation" guarantee
+/// survives from the live phase into the ready phase (former
+/// `warmupBudgetExhausted`).
+struct WarmupInfo: Sendable, Equatable {
+  let generation: UInt64
+  var budgetSpent: Bool
+}
+
+/// A warm-up task left running after its 20s fail-open budget expired, carried by
+/// `.ready(staleWarmup:)` so the vend gate can drain-or-skip it exactly once.
+struct OrphanWarmup {
+  var info: WarmupInfo
+  let task: Task<WarmupOutcome, Never>
+}
+
+/// Marker for the loaded model instance the state carries. Real path: `WhisperKit`
+/// (conformance below). Tests: a trivial fake. Deliberately NOT `Sendable` and
+/// requirement-free — the instance is only ever touched inside the owning actor's
+/// isolation, and existentiality is purely to let the state machine be tested
+/// without constructing a real `WhisperKit`.
+protocol LoadedASRModel: AnyObject {}
+
+/// The single load-state authority. Each non-idle case carries exactly the
+/// sub-state that phase needs; nothing outside these cases can represent load
+/// state. Not `Equatable` (it carries `Task` handles and an existential kit);
+/// assert on `phase` / `isReady` in tests.
+enum LoadState {
+  /// No kit, no load in flight.
+  case idle
+  /// A CoreML load is in flight. Carries the load `Task` so a concurrent caller
+  /// joins it (single-flight) instead of starting a second load.
+  case loading(LoadIdentity, task: Task<Void, Error>)
+  /// Model loaded; the silent warm-up inference is running. NOT yet vendable
+  /// (`isReady == false`) — matches the old design where `isReady` flips only
+  /// after warm-up resolves. Carries the load task (still awaited by joiners
+  /// until warm-up resolves, preserving "prepare() returns warm") and the
+  /// warm-up task.
+  case warming(
+    kit: any LoadedASRModel,
+    WarmupInfo,
+    loadTask: Task<Void, Error>,
+    warmupTask: Task<WarmupOutcome, Never>)
+  /// Vendable. `staleWarmup == nil` after a clean warm-up; non-nil means
+  /// fail-open-ready — warm-up timed out, its budget is spent, and its task is
+  /// still orphaned for the vend gate to drain-or-skip exactly once.
+  case ready(kit: any LoadedASRModel, staleWarmup: OrphanWarmup?)
+}
+
+/// Equatable projection of `LoadState` for test assertions (drops the live
+/// `Task`/kit references, keeps identity + warm-up info).
+enum LoadPhase: Sendable, Equatable {
+  case idle
+  case loading(LoadIdentity)
+  case warming(WarmupInfo)
+  case ready(staleWarmup: WarmupInfo?)
+}
+
+extension LoadState {
+  var phase: LoadPhase {
+    switch self {
+    case .idle: return .idle
+    case .loading(let id, _): return .loading(id)
+    case .warming(_, let info, _, _): return .warming(info)
+    case .ready(_, let stale): return .ready(staleWarmup: stale?.info)
+    }
+  }
+
+  /// Protocol-required readiness: true iff the model is loaded AND warm-up has
+  /// resolved. Single source of truth — replaces the stored `isReady` bool the
+  /// old code had to hand-sync at six sites.
+  var isReady: Bool {
+    if case .ready = self { return true }
+    return false
+  }
+}
+
+/// Events fed into `transition`. Payload-carrying cases bring the freshly-created
+/// resource (kit, task) so `transition` can slot it into the next state; identity
+/// / generation on the event is compared against the live generation inside
+/// `transition`, so the actor never re-checks staleness after an await
+/// ([[state-gate-over-recheck]]).
+enum LoadEvent {
+  /// A caller wants the model loaded (`prepare()` / `prepareIfCached()`).
+  case prepareRequested
+  /// The actor created the load task for a `.beginLoad` effect; record it.
+  case loadStarted(LoadIdentity, task: Task<Void, Error>)
+  /// The load task finished building the kit.
+  case loadSucceeded(kit: any LoadedASRModel, LoadIdentity)
+  /// The load task threw.
+  case loadFailed(LoadIdentity)
+  /// The actor created the warm-up task for a `.beginWarmup` effect; record it.
+  case warmupStarted(
+    kit: any LoadedASRModel, generation: UInt64, warmupTask: Task<WarmupOutcome, Never>)
+  /// The warm-up inference resolved (completed or threw) within budget.
+  case warmupResolved(WarmupOutcome, generation: UInt64)
+  /// The warm-up inference blew its 20s fail-open budget in `runWarmup`.
+  case warmupTimedOut(generation: UInt64)
+  /// A shared-instance caller wants the kit (`transcribe`/`observeLID`/
+  /// `makeIncrementalSession`).
+  case vendRequested
+  /// The vend gate finished draining an orphan warm-up.
+  case drainResolved(didTimeOut: Bool, generation: UInt64)
+  /// `unload()` — generation already bumped by the actor before this event.
+  case unloadRequested
+}
+
+/// Side-effects `transition` asks the actor to perform. Not `Equatable` (carries
+/// tasks/kit); assert on `EffectTag` in tests.
+enum Effect {
+  /// Create the load task, then feed `.loadStarted`.
+  case beginLoad
+  /// Await this in-flight load task (single-flight join).
+  case joinLoad(Task<Void, Error>)
+  /// Create the warm-up task for this kit+generation, then feed `.warmupStarted`.
+  case beginWarmup(kit: any LoadedASRModel, generation: UInt64)
+  /// This completion lost its race with an `unload()`/newer load — throw
+  /// `ASRLoadSupersededError` from the load task.
+  case throwSuperseded
+  /// Cancel a warm-up task created for a since-superseded load.
+  case cancelWarmupTask(Task<WarmupOutcome, Never>)
+  /// Record the warm-up duration on telemetry + log completion.
+  case recordWarmupMs(Int)
+  /// Log that the warm-up threw (no ms recorded).
+  case logWarmupThrew(String)
+  /// Log that the warm-up timed out (fail-open).
+  case logWarmupTimedOut
+  /// Drain this orphan warm-up task under the shared fail-open budget, then feed
+  /// `.drainResolved`.
+  case beginDrain(Task<WarmupOutcome, Never>, generation: UInt64)
+  /// The orphan's budget was already spent — log and vend without re-draining.
+  case logBudgetExhaustedVend
+  /// The drain also timed out — log and vend anyway (accept documented risk).
+  case logDrainTimedOutVend
+  /// Cancel these tasks on unload (best-effort; CoreML load/decode is
+  /// uncancellable — clearing the handle is what matters).
+  case cancelLoadTask(Task<Void, Error>)
+  case cancelOrphanWarmupOnUnload(Task<WarmupOutcome, Never>)
+}
+
+/// Equatable tag of an `Effect` for test assertions (drops task/kit payloads).
+enum EffectTag: Sendable, Equatable {
+  case beginLoad
+  case joinLoad
+  case beginWarmup(generation: UInt64)
+  case throwSuperseded
+  case cancelWarmupTask
+  case recordWarmupMs(Int)
+  case logWarmupThrew(String)
+  case logWarmupTimedOut
+  case beginDrain(generation: UInt64)
+  case logBudgetExhaustedVend
+  case logDrainTimedOutVend
+  case cancelLoadTask
+  case cancelOrphanWarmupOnUnload
+}
+
+extension Effect {
+  var tag: EffectTag {
+    switch self {
+    case .beginLoad: return .beginLoad
+    case .joinLoad: return .joinLoad
+    case .beginWarmup(_, let g): return .beginWarmup(generation: g)
+    case .throwSuperseded: return .throwSuperseded
+    case .cancelWarmupTask: return .cancelWarmupTask
+    case .recordWarmupMs(let ms): return .recordWarmupMs(ms)
+    case .logWarmupThrew(let d): return .logWarmupThrew(d)
+    case .logWarmupTimedOut: return .logWarmupTimedOut
+    case .beginDrain(_, let g): return .beginDrain(generation: g)
+    case .logBudgetExhaustedVend: return .logBudgetExhaustedVend
+    case .logDrainTimedOutVend: return .logDrainTimedOutVend
+    case .cancelLoadTask: return .cancelLoadTask
+    case .cancelOrphanWarmupOnUnload: return .cancelOrphanWarmupOnUnload
+    }
+  }
+}
+
+/// The pure decision core. Every legal transition + every staleness/budget/
+/// identity guard lives here; illegal (state, event) pairings are explicit
+/// no-ops (state unchanged, no effects). The actor executes the returned effects
+/// and feeds follow-up events; it never re-decides staleness itself.
+///
+/// `generation` is the LIVE generation at call time — the actor bumps it (in
+/// `unload()`) BEFORE feeding `.unloadRequested`, so a completion event carrying
+/// an older generation is recognizably stale here.
+enum WhisperKitLoadStateMachine {
+  static func transition(
+    _ state: LoadState, on event: LoadEvent, generation: UInt64
+  ) -> (LoadState, [Effect]) {
+    switch (state, event) {
+
+    // MARK: prepareRequested — the 3-way single-flight decision (invariant #1)
+    case (.idle, .prepareRequested):
+      return (state, [.beginLoad])
+    case (.loading(_, let task), .prepareRequested):
+      return (state, [.joinLoad(task)])
+    case (.warming(_, _, let loadTask, _), .prepareRequested):
+      // Still loading (warm-up phase) — join the load task, which resolves only
+      // after warm-up, so a joiner's prepare() returns warm (isReady true).
+      return (state, [.joinLoad(loadTask)])
+    case (.ready, .prepareRequested):
+      return (state, [])  // already loaded — idempotent no-op
+
+    // MARK: loadStarted — record the created load task (idle → loading)
+    case (.idle, .loadStarted(let id, let task)):
+      return (.loading(id, task: task), [])
+    case (_, .loadStarted(_, let task)):
+      // A load task was created but the state already moved on (unload/newer
+      // load between the .beginLoad decision and here — only possible if the
+      // actor suspended, which it does not; defensive). Cancel the orphan.
+      return (state, [.cancelLoadTask(task)])
+
+    // MARK: loadSucceeded — kit built; proceed to warm-up or discard if stale
+    case (.loading(let id, _), .loadSucceeded(let kit, let evId)):
+      guard evId == id, id.generation == generation else {
+        return (state, [.throwSuperseded])
+      }
+      return (state, [.beginWarmup(kit: kit, generation: id.generation)])
+    case (_, .loadSucceeded):
+      // Superseded before the kit finished building.
+      return (state, [.throwSuperseded])
+
+    // MARK: loadFailed — back to idle (retryable), only for the current load
+    case (.loading(let id, _), .loadFailed(let evId)):
+      guard evId == id else { return (state, []) }
+      return (.idle, [])
+    case (_, .loadFailed):
+      return (state, [])  // stale failure — ignore
+
+    // MARK: warmupStarted — record warm-up task (loading → warming)
+    case (.loading(let id, let loadTask), .warmupStarted(let kit, let g, let warmupTask)):
+      guard id.generation == g, g == generation else {
+        return (state, [.cancelWarmupTask(warmupTask)])
+      }
+      return (
+        .warming(
+          kit: kit, WarmupInfo(generation: g, budgetSpent: false),
+          loadTask: loadTask, warmupTask: warmupTask), []
+      )
+    case (_, .warmupStarted(_, _, let warmupTask)):
+      return (state, [.cancelWarmupTask(warmupTask)])
+
+    // MARK: warmupResolved — clean finish → ready(nil) (+ telemetry)
+    case (.warming(let kit, let info, _, _), .warmupResolved(let outcome, let g)):
+      guard info.generation == g, g == generation else { return (state, []) }
+      let effect: Effect =
+        switch outcome {
+        case .completed(let ms): .recordWarmupMs(ms)
+        case .threw(let desc): .logWarmupThrew(desc)
+        }
+      return (.ready(kit: kit, staleWarmup: nil), [effect])
+    case (_, .warmupResolved):
+      return (state, [])  // stale — ignore
+
+    // MARK: warmupTimedOut — fail-open ready, carry the orphan (invariant #6)
+    case (.warming(let kit, let info, _, let warmupTask), .warmupTimedOut(let g)):
+      guard info.generation == g, g == generation else { return (state, []) }
+      let orphan = OrphanWarmup(
+        info: WarmupInfo(generation: g, budgetSpent: true), task: warmupTask)
+      return (.ready(kit: kit, staleWarmup: orphan), [.logWarmupTimedOut])
+    case (_, .warmupTimedOut):
+      return (state, [])
+
+    // MARK: vendRequested — the vend gate (invariants #4, #5, #6)
+    case (.ready(_, nil), .vendRequested):
+      return (state, [])  // clean-ready: actor vends the kit directly, no drain
+    case (.ready(let kit, .some(let orphan)), .vendRequested):
+      if orphan.info.budgetSpent {
+        // Budget already spent for this generation — drop the orphan handle
+        // (mirrors the old code nil-ing `warmupTask`) and vend without re-draining.
+        return (.ready(kit: kit, staleWarmup: nil), [.logBudgetExhaustedVend])
+      }
+      return (state, [.beginDrain(orphan.task, generation: orphan.info.generation)])
+    case (.warming(_, let info, _, let warmupTask), .vendRequested):
+      // Concurrent caller arrived mid-warm-up. Drain the live warm-up (bounded);
+      // the READY transition is owned by the load task, so after draining the
+      // actor re-reads readiness.
+      if info.budgetSpent {
+        return (state, [])
+      }
+      return (state, [.beginDrain(warmupTask, generation: info.generation)])
+    case (.idle, .vendRequested), (.loading, .vendRequested):
+      return (state, [])  // not ready — actor returns nil
+
+    // MARK: drainResolved — clear the orphan, mark budget, let actor re-vend
+    case (.ready(let kit, .some(let orphan)), .drainResolved(let didTimeOut, let g)):
+      guard orphan.info.generation == g, g == generation else { return (state, []) }
+      let effects: [Effect] = didTimeOut ? [.logDrainTimedOutVend] : []
+      return (.ready(kit: kit, staleWarmup: nil), effects)
+    case (_, .drainResolved):
+      // Warm-up resolved to ready(nil)/idle via another path during the drain,
+      // or an unload intervened — nothing to clear.
+      return (state, [])
+
+    // MARK: unloadRequested — teardown to idle, cancel whatever tasks we hold
+    case (.idle, .unloadRequested):
+      return (.idle, [])
+    case (.loading(_, let task), .unloadRequested):
+      return (.idle, [.cancelLoadTask(task)])
+    case (.warming(_, _, let loadTask, let warmupTask), .unloadRequested):
+      return (.idle, [.cancelLoadTask(loadTask), .cancelWarmupTask(warmupTask)])
+    case (.ready(_, .some(let orphan)), .unloadRequested):
+      return (.idle, [.cancelOrphanWarmupOnUnload(orphan.task)])
+    case (.ready(_, nil), .unloadRequested):
+      return (.idle, [])
+    }
+  }
+}

--- a/Tests/EnviousWisprASRTests/WhisperKitBackendLoadOrchestrationTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitBackendLoadOrchestrationTests.swift
@@ -1,0 +1,289 @@
+import Testing
+
+@testable import EnviousWisprASR
+
+// Actor-orchestration tests for the #1276 Step 1 load-state machine. These drive
+// the real `WhisperKitBackend` actor through `TestSeams` (fake kit build + fake
+// warm-up) and an injected resolver, so single-flight, generation staleness
+// (the #1282 class), the fail-open warm-up budget, load-failure retry, and the
+// two-consumer paths are exercised WITHOUT a real WhisperKit / model. The pure
+// (state × event) matrix lives in `WhisperKitLoadStateTests`.
+
+private final class FakeModel: LoadedASRModel {}
+
+/// One-shot async gate (signal-based, no sleeps — test-timing discipline).
+private actor AsyncGate {
+  private var isOpen = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+  func open() {
+    isOpen = true
+    for w in waiters { w.resume() }
+    waiters.removeAll()
+  }
+  func wait() async {
+    if isOpen { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+}
+
+/// Records how many times the fake load / warm-up ran.
+private actor CallRecorder {
+  private(set) var loadCount = 0
+  private(set) var warmupCount = 0
+  func recordLoad() { loadCount += 1 }
+  func recordWarmup() { warmupCount += 1 }
+}
+
+@Suite("WhisperKitBackend — load-state orchestration (#1276 Step 1)")
+struct WhisperKitBackendLoadOrchestrationTests {
+
+  // Seam bundle whose load succeeds immediately and warm-up completes fast.
+  private func fastSeams(_ recorder: CallRecorder) -> WhisperKitBackend.TestSeams {
+    WhisperKitBackend.TestSeams(
+      loadModel: { _ in
+        await recorder.recordLoad()
+        return FakeModel()
+      },
+      runWarmup: {
+        await recorder.recordWarmup()
+        return .completed(ms: 1)
+      })
+  }
+
+  // MARK: invariant #1 — single-flight
+
+  @Test("concurrent prepare joins ONE load (single-flight, invariant #1)")
+  func singleFlightJoinsOneLoad() async throws {
+    let recorder = CallRecorder()
+    let loadEntered = AsyncGate()
+    let release = AsyncGate()
+    let seams = WhisperKitBackend.TestSeams(
+      loadModel: { _ in
+        await recorder.recordLoad()
+        await loadEntered.open()
+        await release.wait()
+        return FakeModel()
+      },
+      runWarmup: {
+        await recorder.recordWarmup()
+        return .completed(ms: 1)
+      })
+    let backend = WhisperKitBackend(testSeams: seams)
+
+    // A starts the load and parks inside loadModel.
+    async let a: Void = backend.loadForTesting { "/fake" }
+    await loadEntered.wait()  // A is in loadModel; state is .loading
+
+    // B arrives while A's load is in flight — must JOIN, not start a 2nd load.
+    async let b: Void = backend.loadForTesting { "/fake" }
+
+    await release.open()
+    try await a
+    try await b
+
+    #expect(await recorder.loadCount == 1)
+    #expect(await recorder.warmupCount == 1)
+    #expect(await backend.isReady)
+    #expect(await backend.loadPhaseForTesting == .ready(staleWarmup: nil))
+  }
+
+  // MARK: invariant #3 / #1282 — unload during load supersedes
+
+  @Test("unload during load → superseded, never becomes ready (invariant #3 / #1282)")
+  func unloadDuringLoadSupersedes() async throws {
+    let recorder = CallRecorder()
+    let loadEntered = AsyncGate()
+    let release = AsyncGate()
+    let seams = WhisperKitBackend.TestSeams(
+      loadModel: { _ in
+        await recorder.recordLoad()
+        await loadEntered.open()
+        await release.wait()
+        return FakeModel()
+      },
+      runWarmup: {
+        await recorder.recordWarmup()
+        return .completed(ms: 1)
+      })
+    let backend = WhisperKitBackend(testSeams: seams)
+
+    let loadTask = Task { try await backend.loadForTesting { "/fake" } }
+    await loadEntered.wait()  // load in flight
+
+    await backend.unload()  // bumps generation, → .idle
+    await release.open()  // let the (now-stale) load finish
+
+    // The superseded load throws rather than resurrecting readiness.
+    do {
+      try await loadTask.value
+      Issue.record("expected the superseded load to throw")
+    } catch is ASRLoadSupersededError {
+      // expected
+    } catch {
+      Issue.record("expected ASRLoadSupersededError, got \(error)")
+    }
+    #expect(await backend.isReady == false)
+    #expect(await backend.loadPhaseForTesting == .idle)
+    #expect(await recorder.warmupCount == 0)  // never warmed a discarded model
+  }
+
+  // MARK: invariant #3 (warm-up phase) — unload during warm-up supersedes
+
+  @Test("unload during warm-up → prepare throws superseded, not false success (Codex code-diff r1)")
+  func unloadDuringWarmupSupersedes() async throws {
+    let recorder = CallRecorder()
+    let warmupEntered = AsyncGate()
+    let release = AsyncGate()
+    let seams = WhisperKitBackend.TestSeams(
+      loadModel: { _ in
+        await recorder.recordLoad()
+        return FakeModel()
+      },
+      runWarmup: {
+        await recorder.recordWarmup()
+        await warmupEntered.open()
+        await release.wait()
+        return .completed(ms: 1)
+      })
+    let backend = WhisperKitBackend(testSeams: seams)
+
+    let loadTask = Task { try await backend.loadForTesting { "/fake" } }
+    await warmupEntered.wait()  // state is .warming, parked in the warm-up await
+    await backend.unload()  // bump generation, → .idle
+    await release.open()  // let the (now-stale) warm-up resolve
+
+    // The superseded warm-up must throw — NOT return success while unloaded.
+    do {
+      try await loadTask.value
+      Issue.record("expected the superseded warm-up to throw")
+    } catch is ASRLoadSupersededError {
+      // expected
+    } catch {
+      Issue.record("expected ASRLoadSupersededError, got \(error)")
+    }
+    #expect(await backend.isReady == false)
+    #expect(await backend.loadPhaseForTesting == .idle)
+  }
+
+  // MARK: invariant #6 / #4 — fail-open ready + budget-once
+
+  @Test(
+    "warm-up timeout → fail-open ready; first vend drops the orphan, no second drain (inv #4/#6)")
+  func warmupTimeoutFailOpenAndBudgetOnce() async throws {
+    let recorder = CallRecorder()
+    let warmupHang = AsyncGate()  // never opened until teardown → warm-up "hangs"
+    var seams = WhisperKitBackend.TestSeams(
+      loadModel: { _ in
+        await recorder.recordLoad()
+        return FakeModel()
+      },
+      runWarmup: {
+        await recorder.recordWarmup()
+        await warmupHang.wait()  // exceeds the (tiny) deadline → fail-open timeout
+        return .completed(ms: 1)
+      })
+    seams.warmupDeadlineSeconds = 0.05  // signal-fast timeout, not a real 20s wait
+    let backend = WhisperKitBackend(testSeams: seams)
+
+    try await backend.loadForTesting { "/fake" }
+
+    // Fail-open: ready despite the warm-up not finishing, orphan carried + spent.
+    #expect(await backend.isReady)
+    #expect(
+      await backend.loadPhaseForTesting
+        == .ready(staleWarmup: WarmupInfo(generation: 0, budgetSpent: true)))
+
+    // First vend: budget already spent → drop the orphan, vend without re-draining.
+    let afterVend = await backend.vendForTesting()
+    #expect(afterVend == .ready(staleWarmup: nil))
+
+    // Second vend: clean ready, nothing to drain.
+    let afterSecondVend = await backend.vendForTesting()
+    #expect(afterSecondVend == .ready(staleWarmup: nil))
+
+    await warmupHang.open()  // release the parked warm-up task for clean teardown
+    await backend.unload()
+  }
+
+  // MARK: invariant #2 — unload then prepare starts a fresh load
+
+  @Test("unload then prepare starts a FRESH load, not a doomed join (invariant #2)")
+  func unloadThenPrepareStartsFresh() async throws {
+    let recorder = CallRecorder()
+    let backend = WhisperKitBackend(testSeams: fastSeams(recorder))
+
+    try await backend.loadForTesting { "/fake" }
+    #expect(await backend.isReady)
+    #expect(await recorder.loadCount == 1)
+
+    await backend.unload()
+    #expect(await backend.loadPhaseForTesting == .idle)
+
+    try await backend.loadForTesting { "/fake" }  // fresh load
+    #expect(await backend.isReady)
+    #expect(await recorder.loadCount == 2)
+  }
+
+  // MARK: test 9 — load failure returns to idle and retries
+
+  @Test("load failure → idle, next prepare retries (test 9)")
+  func loadFailureReturnsToIdleAndRetries() async throws {
+    let recorder = CallRecorder()
+    struct FakeLoadError: Error {}
+    let seams = WhisperKitBackend.TestSeams(
+      loadModel: { _ in
+        await recorder.recordLoad()
+        if await recorder.loadCount == 1 { throw FakeLoadError() }
+        return FakeModel()
+      },
+      runWarmup: {
+        await recorder.recordWarmup()
+        return .completed(ms: 1)
+      })
+    let backend = WhisperKitBackend(testSeams: seams)
+
+    await #expect(throws: FakeLoadError.self) {
+      try await backend.loadForTesting { "/fake" }
+    }
+    #expect(await backend.isReady == false)
+    #expect(await backend.loadPhaseForTesting == .idle)  // retryable, not stuck
+
+    try await backend.loadForTesting { "/fake" }  // retry succeeds
+    #expect(await backend.isReady)
+    #expect(await recorder.loadCount == 2)
+  }
+
+  // MARK: test 10b — two consumers then teardown
+
+  @Test("two consumers join one load, then unload lands everyone in idle (test 10b)")
+  func twoConsumersThenUnload() async throws {
+    let recorder = CallRecorder()
+    let loadEntered = AsyncGate()
+    let release = AsyncGate()
+    let seams = WhisperKitBackend.TestSeams(
+      loadModel: { _ in
+        await recorder.recordLoad()
+        await loadEntered.open()
+        await release.wait()
+        return FakeModel()
+      },
+      runWarmup: {
+        await recorder.recordWarmup()
+        return .completed(ms: 1)
+      })
+    let backend = WhisperKitBackend(testSeams: seams)
+
+    async let a: Void = backend.loadForTesting { "/fake" }
+    await loadEntered.wait()
+    async let b: Void = backend.loadForTesting { "/fake" }
+
+    await release.open()
+    try await a
+    try await b
+    #expect(await recorder.loadCount == 1)  // 10a: shared single load
+
+    await backend.unload()  // 10b: teardown
+    #expect(await backend.isReady == false)
+    #expect(await backend.loadPhaseForTesting == .idle)
+  }
+}

--- a/Tests/EnviousWisprASRTests/WhisperKitLoadStateTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitLoadStateTests.swift
@@ -1,0 +1,338 @@
+import Testing
+
+@testable import EnviousWisprASR
+
+// Pure-function tests for the #1276 Step 1 load-state machine. No WhisperKit
+// instance is ever constructed — the state carries an `any LoadedASRModel`, and
+// these tests supply a trivial `FakeModel`, exactly the property that made the
+// functional-core split worth its cost. Covers the exhaustive (state × event)
+// matrix (plan test 8) plus the targeted invariant scenarios (tests 1-4, 6, 7 at
+// the decision-logic level; the actor-orchestration parts — #1282 capture timing,
+// two-consumer — live in the actor test file).
+
+private final class FakeModel: LoadedASRModel {}
+
+private typealias Machine = WhisperKitLoadStateMachine
+
+// Dummy task handles for building states/events. Their bodies never run in these
+// pure tests — only the handle identity matters to the state machine.
+private func dummyLoadTask() -> Task<Void, Error> { Task {} }
+private func dummyWarmupTask() -> Task<WarmupOutcome, Never> { Task { .completed(ms: 0) } }
+
+private func tags(_ effects: [Effect]) -> [EffectTag] { effects.map(\.tag) }
+
+@Suite("WhisperKitLoadState — pure transition matrix (#1276 Step 1)")
+struct WhisperKitLoadStateTests {
+
+  // MARK: prepareRequested — single-flight 3-way decision (invariant #1)
+
+  @Test("prepareRequested from idle → beginLoad")
+  func prepareFromIdle() {
+    let (next, effects) = Machine.transition(.idle, on: .prepareRequested, generation: 0)
+    #expect(next.phase == .idle)
+    #expect(tags(effects) == [.beginLoad])
+  }
+
+  @Test("prepareRequested while loading → joinLoad, no second load")
+  func prepareWhileLoading() {
+    let id = LoadIdentity(generation: 0, id: 1)
+    let state = LoadState.loading(id, task: dummyLoadTask())
+    let (next, effects) = Machine.transition(state, on: .prepareRequested, generation: 0)
+    #expect(next.phase == .loading(id))
+    #expect(tags(effects) == [.joinLoad])
+  }
+
+  @Test("prepareRequested while warming → joinLoad (returns warm)")
+  func prepareWhileWarming() {
+    let info = WarmupInfo(generation: 0, budgetSpent: false)
+    let state = LoadState.warming(
+      kit: FakeModel(), info, loadTask: dummyLoadTask(), warmupTask: dummyWarmupTask())
+    let (next, effects) = Machine.transition(state, on: .prepareRequested, generation: 0)
+    #expect(next.phase == .warming(info))
+    #expect(tags(effects) == [.joinLoad])
+  }
+
+  @Test("prepareRequested while ready → idempotent no-op")
+  func prepareWhileReady() {
+    let state = LoadState.ready(kit: FakeModel(), staleWarmup: nil)
+    let (next, effects) = Machine.transition(state, on: .prepareRequested, generation: 0)
+    #expect(next.isReady)
+    #expect(effects.isEmpty)
+  }
+
+  // MARK: loadStarted — record the created load task
+
+  @Test("loadStarted from idle → loading with that identity")
+  func loadStartedRecords() {
+    let id = LoadIdentity(generation: 3, id: 7)
+    let (next, effects) = Machine.transition(
+      .idle, on: .loadStarted(id, task: dummyLoadTask()), generation: 3)
+    #expect(next.phase == .loading(id))
+    #expect(effects.isEmpty)
+  }
+
+  // MARK: loadSucceeded — proceed to warm-up, or discard when stale (inv #3)
+
+  @Test("loadSucceeded for the current load → beginWarmup")
+  func loadSucceededCurrent() {
+    let id = LoadIdentity(generation: 2, id: 1)
+    let state = LoadState.loading(id, task: dummyLoadTask())
+    let (next, effects) = Machine.transition(
+      state, on: .loadSucceeded(kit: FakeModel(), id), generation: 2)
+    #expect(next.phase == .loading(id))  // stays loading until warmupStarted records the task
+    #expect(tags(effects) == [.beginWarmup(generation: 2)])
+  }
+
+  @Test("loadSucceeded after unload bumped generation → throwSuperseded (invariant #3)")
+  func loadSucceededStaleGeneration() {
+    // Load captured gen 2; unload() bumped live generation to 3 mid-load.
+    let id = LoadIdentity(generation: 2, id: 1)
+    let state = LoadState.loading(id, task: dummyLoadTask())
+    let (next, effects) = Machine.transition(
+      state, on: .loadSucceeded(kit: FakeModel(), id), generation: 3)
+    #expect(next.phase == .loading(id))
+    #expect(tags(effects) == [.throwSuperseded])
+  }
+
+  @Test("loadSucceeded when state already moved on → throwSuperseded")
+  func loadSucceededWrongState() {
+    let (next, effects) = Machine.transition(
+      .idle, on: .loadSucceeded(kit: FakeModel(), LoadIdentity(generation: 1, id: 1)),
+      generation: 1)
+    #expect(next.phase == .idle)
+    #expect(tags(effects) == [.throwSuperseded])
+  }
+
+  // MARK: loadFailed — retryable idle, only for the current load
+
+  @Test("loadFailed for the current load → idle (retryable)")
+  func loadFailedCurrent() {
+    let id = LoadIdentity(generation: 0, id: 1)
+    let state = LoadState.loading(id, task: dummyLoadTask())
+    let (next, effects) = Machine.transition(state, on: .loadFailed(id), generation: 0)
+    #expect(next.phase == .idle)
+    #expect(effects.isEmpty)
+  }
+
+  @Test("loadFailed for a superseded load → ignored")
+  func loadFailedStale() {
+    let current = LoadIdentity(generation: 1, id: 2)
+    let state = LoadState.loading(current, task: dummyLoadTask())
+    let stale = LoadIdentity(generation: 0, id: 1)
+    let (next, effects) = Machine.transition(state, on: .loadFailed(stale), generation: 1)
+    #expect(next.phase == .loading(current))
+    #expect(effects.isEmpty)
+  }
+
+  // MARK: warmupStarted — record warm-up task (loading → warming)
+
+  @Test("warmupStarted for current load → warming")
+  func warmupStartedCurrent() {
+    let id = LoadIdentity(generation: 4, id: 1)
+    let state = LoadState.loading(id, task: dummyLoadTask())
+    let (next, effects) = Machine.transition(
+      state, on: .warmupStarted(kit: FakeModel(), generation: 4, warmupTask: dummyWarmupTask()),
+      generation: 4)
+    #expect(next.phase == .warming(WarmupInfo(generation: 4, budgetSpent: false)))
+    #expect(effects.isEmpty)
+  }
+
+  @Test("warmupStarted after generation bumped → cancel the orphan warm-up task")
+  func warmupStartedStale() {
+    let id = LoadIdentity(generation: 4, id: 1)
+    let state = LoadState.loading(id, task: dummyLoadTask())
+    let (next, effects) = Machine.transition(
+      state, on: .warmupStarted(kit: FakeModel(), generation: 4, warmupTask: dummyWarmupTask()),
+      generation: 5)
+    #expect(next.phase == .loading(id))
+    #expect(tags(effects) == [.cancelWarmupTask])
+  }
+
+  // MARK: warmupResolved — clean finish → ready(nil) + telemetry (inv #7)
+
+  @Test("warmupResolved(completed) → ready(nil) + recordWarmupMs")
+  func warmupCompleted() {
+    let state = warmingState(generation: 1)
+    let (next, effects) = Machine.transition(
+      state, on: .warmupResolved(.completed(ms: 42), generation: 1), generation: 1)
+    #expect(next.phase == .ready(staleWarmup: nil))
+    #expect(next.isReady)
+    #expect(tags(effects) == [.recordWarmupMs(42)])
+  }
+
+  @Test("warmupResolved(threw) → ready(nil) + logWarmupThrew, no ms recorded (inv #7)")
+  func warmupThrew() {
+    let state = warmingState(generation: 1)
+    let (next, effects) = Machine.transition(
+      state, on: .warmupResolved(.threw(desc: "boom"), generation: 1), generation: 1)
+    #expect(next.phase == .ready(staleWarmup: nil))
+    #expect(tags(effects) == [.logWarmupThrew("boom")])
+  }
+
+  @Test("warmupResolved for a superseded generation → ignored (no stale telemetry, inv #7)")
+  func warmupResolvedStale() {
+    let state = warmingState(generation: 1)
+    let (next, effects) = Machine.transition(
+      state, on: .warmupResolved(.completed(ms: 99), generation: 1), generation: 2)
+    #expect(next.phase == .warming(WarmupInfo(generation: 1, budgetSpent: false)))
+    #expect(effects.isEmpty)
+  }
+
+  // MARK: warmupTimedOut — fail-open ready carrying the orphan (invariant #6)
+
+  @Test("warmupTimedOut → ready(orphan, budgetSpent) + logWarmupTimedOut, still vendable")
+  func warmupTimedOut() {
+    let state = warmingState(generation: 1)
+    let (next, effects) = Machine.transition(
+      state, on: .warmupTimedOut(generation: 1), generation: 1)
+    #expect(next.phase == .ready(staleWarmup: WarmupInfo(generation: 1, budgetSpent: true)))
+    #expect(next.isReady)  // fail-open-ready (invariant #6)
+    #expect(tags(effects) == [.logWarmupTimedOut])
+  }
+
+  @Test("warmupTimedOut for a superseded generation → ignored")
+  func warmupTimedOutStale() {
+    let state = warmingState(generation: 1)
+    let (next, effects) = Machine.transition(
+      state, on: .warmupTimedOut(generation: 1), generation: 9)
+    #expect(next.phase == .warming(WarmupInfo(generation: 1, budgetSpent: false)))
+    #expect(effects.isEmpty)
+  }
+
+  // MARK: vendRequested — vend gate (invariants #4, #5, #6)
+
+  @Test("vendRequested on clean ready → no drain (actor vends directly)")
+  func vendCleanReady() {
+    let state = LoadState.ready(kit: FakeModel(), staleWarmup: nil)
+    let (next, effects) = Machine.transition(state, on: .vendRequested, generation: 0)
+    #expect(next.isReady)
+    #expect(effects.isEmpty)
+  }
+
+  @Test("vendRequested on orphan whose budget is already spent → vend without re-draining (inv #4)")
+  func vendOrphanBudgetSpent() {
+    let orphan = OrphanWarmup(
+      info: WarmupInfo(generation: 1, budgetSpent: true), task: dummyWarmupTask())
+    let state = LoadState.ready(kit: FakeModel(), staleWarmup: orphan)
+    let (next, effects) = Machine.transition(state, on: .vendRequested, generation: 1)
+    #expect(tags(effects) == [.logBudgetExhaustedVend])
+    #expect(next.phase == .ready(staleWarmup: nil))  // orphan handle dropped
+    #expect(next.isReady)
+  }
+
+  @Test("vendRequested on orphan with budget left → beginDrain")
+  func vendOrphanDrain() {
+    let orphan = OrphanWarmup(
+      info: WarmupInfo(generation: 1, budgetSpent: false), task: dummyWarmupTask())
+    let state = LoadState.ready(kit: FakeModel(), staleWarmup: orphan)
+    let (next, effects) = Machine.transition(state, on: .vendRequested, generation: 1)
+    #expect(tags(effects) == [.beginDrain(generation: 1)])
+    #expect(next.isReady)
+  }
+
+  @Test("vendRequested mid-warming with budget left → beginDrain the live warm-up")
+  func vendWhileWarming() {
+    let state = warmingState(generation: 2)
+    let (next, effects) = Machine.transition(state, on: .vendRequested, generation: 2)
+    #expect(tags(effects) == [.beginDrain(generation: 2)])
+    #expect(next.phase == .warming(WarmupInfo(generation: 2, budgetSpent: false)))
+  }
+
+  @Test("vendRequested while idle or loading → no-op (actor returns nil)")
+  func vendNotReady() {
+    let (n1, e1) = Machine.transition(.idle, on: .vendRequested, generation: 0)
+    #expect(n1.phase == .idle)
+    #expect(e1.isEmpty)
+    let id = LoadIdentity(generation: 0, id: 1)
+    let (n2, e2) = Machine.transition(
+      .loading(id, task: dummyLoadTask()), on: .vendRequested, generation: 0)
+    #expect(n2.phase == .loading(id))
+    #expect(e2.isEmpty)
+  }
+
+  // MARK: drainResolved — clear orphan, let actor re-vend
+
+  @Test("drainResolved(success) on orphan → ready(nil), no log")
+  func drainResolvedSuccess() {
+    let orphan = OrphanWarmup(
+      info: WarmupInfo(generation: 1, budgetSpent: false), task: dummyWarmupTask())
+    let state = LoadState.ready(kit: FakeModel(), staleWarmup: orphan)
+    let (next, effects) = Machine.transition(
+      state, on: .drainResolved(didTimeOut: false, generation: 1), generation: 1)
+    #expect(next.phase == .ready(staleWarmup: nil))
+    #expect(effects.isEmpty)
+  }
+
+  @Test("drainResolved(timeout) on orphan → ready(nil) + logDrainTimedOutVend")
+  func drainResolvedTimeout() {
+    let orphan = OrphanWarmup(
+      info: WarmupInfo(generation: 1, budgetSpent: false), task: dummyWarmupTask())
+    let state = LoadState.ready(kit: FakeModel(), staleWarmup: orphan)
+    let (next, effects) = Machine.transition(
+      state, on: .drainResolved(didTimeOut: true, generation: 1), generation: 1)
+    #expect(next.phase == .ready(staleWarmup: nil))
+    #expect(tags(effects) == [.logDrainTimedOutVend])
+  }
+
+  @Test("drainResolved for a superseded generation → ignored")
+  func drainResolvedStale() {
+    let orphan = OrphanWarmup(
+      info: WarmupInfo(generation: 1, budgetSpent: false), task: dummyWarmupTask())
+    let state = LoadState.ready(kit: FakeModel(), staleWarmup: orphan)
+    let (next, effects) = Machine.transition(
+      state, on: .drainResolved(didTimeOut: false, generation: 1), generation: 2)
+    #expect(next.phase == .ready(staleWarmup: WarmupInfo(generation: 1, budgetSpent: false)))
+    #expect(effects.isEmpty)
+  }
+
+  // MARK: unloadRequested — teardown, cancel held tasks
+
+  @Test("unloadRequested from idle → idle")
+  func unloadIdle() {
+    let (next, effects) = Machine.transition(.idle, on: .unloadRequested, generation: 1)
+    #expect(next.phase == .idle)
+    #expect(effects.isEmpty)
+  }
+
+  @Test("unloadRequested while loading → idle + cancelLoadTask")
+  func unloadLoading() {
+    let id = LoadIdentity(generation: 0, id: 1)
+    let state = LoadState.loading(id, task: dummyLoadTask())
+    let (next, effects) = Machine.transition(state, on: .unloadRequested, generation: 1)
+    #expect(next.phase == .idle)
+    #expect(tags(effects) == [.cancelLoadTask])
+  }
+
+  @Test("unloadRequested while warming → idle + cancel both tasks")
+  func unloadWarming() {
+    let state = warmingState(generation: 0)
+    let (next, effects) = Machine.transition(state, on: .unloadRequested, generation: 1)
+    #expect(next.phase == .idle)
+    #expect(tags(effects) == [.cancelLoadTask, .cancelWarmupTask])
+  }
+
+  @Test("unloadRequested with a ready orphan → idle + cancel orphan warm-up")
+  func unloadReadyOrphan() {
+    let orphan = OrphanWarmup(
+      info: WarmupInfo(generation: 0, budgetSpent: true), task: dummyWarmupTask())
+    let state = LoadState.ready(kit: FakeModel(), staleWarmup: orphan)
+    let (next, effects) = Machine.transition(state, on: .unloadRequested, generation: 1)
+    #expect(next.phase == .idle)
+    #expect(tags(effects) == [.cancelOrphanWarmupOnUnload])
+  }
+
+  @Test("unloadRequested from clean ready → idle, nothing to cancel")
+  func unloadReadyClean() {
+    let state = LoadState.ready(kit: FakeModel(), staleWarmup: nil)
+    let (next, effects) = Machine.transition(state, on: .unloadRequested, generation: 1)
+    #expect(next.phase == .idle)
+    #expect(effects.isEmpty)
+  }
+
+  // Helper: a `.warming` state at a given generation.
+  private func warmingState(generation: UInt64) -> LoadState {
+    .warming(
+      kit: FakeModel(), WarmupInfo(generation: generation, budgetSpent: false),
+      loadTask: dummyLoadTask(), warmupTask: dummyWarmupTask())
+  }
+}


### PR DESCRIPTION
**Part of #1276** (WhisperKit refactor bible, Step 1 — the foundation PR; Step 2's live-transcription toggle builds on this).

## What

Collapses the nine hand-rolled load-state members on `WhisperKitBackend` (`whisperKit`, `isReady`, `loadTask`, `loadTaskSeq`, `activeLoadTaskID`, `loadGeneration`, `warmupTask`, `warmupTaskGeneration`, `warmupBudgetExhausted`) into ONE `LoadState` enum + one `generation` counter + one `loadSeq` id source. Impossible combinations (kit non-nil while not ready, budget-spent forgotten, orphan warm-up with no generation) are now unrepresentable.

A pure `WhisperKitLoadStateMachine.transition(state, event, generation)` owns every staleness / identity / budget decision; the actor executes the returned effects and never re-checks staleness after an await. `isReady` becomes computed from `loadState` (was a stored bool hand-synced at six sites).

## Why

This is the load/lifecycle surface the #1275 retrospective flagged: a proven pattern ported field-by-field over 8 rounds left three parallel mechanisms that had to be reasoned about together but were never unified. Step 2 adds a streaming session that also loads/uses the shared instance; cleaning the foundation first keeps that surface tractable. Robust-by-construction, not patched.

## Buy-vs-build (Codex-validated 2026-07-03)

Founder asked "are we reinventing the wheel?" We inventoried against the pinned `argmax-oss-swift` v1.0.0 source and had Codex validate it. The toolkit's `ModelManager` needs a `ModelLoader` shim (WhisperKit isn't one) AND its `unloadModels()` no-ops mid-load, so it does NOT solve the unload-during-load race our `generation` guard covers — we keep our own (now consolidated) machine. Its `modelState` can't be the readiness authority either (our readiness is a strict superset of `.loaded`). Detail: `docs/feature-requests/issue-1276-step1-buy-vs-build-inventory.md`.

## The #1282 residual, fixed

The load generation is now captured at task creation, BEFORE the `resolveModelPath` await, so an `unload()` during resolve is recognized as stale (previously captured too late).

## Tests

- **Pure (state × event) matrix** — 30 tests over `transition`, no WhisperKit instance (`WhisperKitLoadStateTests`).
- **Actor orchestration** — 7 tests via injected seams, no real model: single-flight, unload-during-load supersede (#1282 class), unload-during-warm-up supersede (found by Codex code-diff r1), fail-open budget-once, retry-after-failure, two-consumer teardown (`WhisperKitBackendLoadOrchestrationTests`).
- All 7 #1275 invariants preserved and pinned.
- Full Xcode gate: 2331 tests pass. Ceiling/freeze: 173 pass.

## Live UAT (WhisperKit engine)

13 real dictations across auto-detect on/off, an engine swap (WhisperKit ↔ Parakeet), and 3 rapid back-to-back — all clean pipeline traces, zero errors / superseded / not-ready / stuck states. Cold model load on launch fired the new machinery's warm-up (logged) and every dictation after it worked.

## Review

Council (coverage) + 7 Codex grounded rounds to PROCEED-AS-PLANNED on the plan; 2 Codex code-diff rounds to clean (r1 caught a real "false-ready after unload-during-warm-up" bug, now fixed + regression-tested).