### PR TITLE
feat(pipeline): effective-path streaming telemetry on asr.completed (#1276 PR-3)

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
@@ -29,4 +29,13 @@ package protocol WhisperKitIncrementalSession: Sendable {
   /// Cancel the incremental loop without producing a result. Used on PTT
   /// cancel and on stop-recording-too-short paths.
   func cancel() async
+
+  /// #1309: the user's stop arrived — snapshot any telemetry that must
+  /// reflect the STOP moment (the adapter drains feed tasks before calling
+  /// `finalize`, so state can change in between). Default no-op.
+  func noteStopRequested() async
+}
+
+extension WhisperKitIncrementalSession {
+  package func noteStopRequested() async {}
 }

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift
@@ -15,6 +15,9 @@ package struct IncrementalResult: Sendable {
   package let mode: String
   package let strategy: String
   package let tailDecodeMs: Int
+  /// #1309: a loop decode was still in flight when finalize/stop arrived
+  /// (streaming session only; the worker never sets it). Telemetry metadata.
+  package var stopWhileDecodeInFlight: Bool = false
 }
 
 /// Narrow seam over WhisperKit's transcribe entry point, mirroring

--- a/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
@@ -167,9 +167,13 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
   /// finalize (after awaiting the loop's exit) to stamp the #1309
   /// `stop_while_decode_in_flight` telemetry field.
   private var loopDecodeInFlight = false
-  /// Snapshot of `loopDecodeInFlight` at finalize entry (#1309 telemetry),
-  /// stamped onto every result this finalize produces.
+  /// Snapshot of `loopDecodeInFlight` at the STOP moment (#1309 telemetry),
+  /// stamped onto every result this finalize produces. Captured by
+  /// `noteStopRequested()` (called by the adapter BEFORE its feed drain — a
+  /// decode can finish during the drain, which would undercount the exact
+  /// case the field measures); finalize entry is the fallback capture point.
   private var stoppedMidDecode = false
+  private var stopSnapshotTaken = false
 
   private var running = false
   /// Set exactly once at the first terminal (`finalize`/`cancel`) so a late loop
@@ -278,6 +282,7 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     totalDecodeTimeMs = 0
     retainedUnconfirmedSegments = []
     stoppedMidDecode = false
+    stopSnapshotTaken = false
     loopDecodeInFlight = false
     previousHypothesisWords = []
     bufferStartSec = 0
@@ -305,8 +310,10 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     speechSegments: [SpeechSegment]
   ) async -> IncrementalResult {
     // #1309 telemetry: was a loop decode still in flight when stop arrived?
-    // Snapshot BEFORE awaiting the loop's exit (which clears the flag).
-    stoppedMidDecode = loopDecodeInFlight
+    // Prefer the `noteStopRequested()` snapshot (taken before the adapter's
+    // feed drain); fall back to finalize-entry state, BEFORE awaiting the
+    // loop's exit (which clears the flag).
+    if !stopSnapshotTaken { stoppedMidDecode = loopDecodeInFlight }
     running = false
     finished = true
     let loop = loopTask
@@ -482,6 +489,12 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     guard !samples.isEmpty else { return 0 }
     let sumSquares = samples.reduce(Float(0)) { $0 + $1 * $1 }
     return (sumSquares / Float(samples.count)).squareRoot()
+  }
+
+  package func noteStopRequested() {
+    guard !stopSnapshotTaken else { return }
+    stopSnapshotTaken = true
+    stoppedMidDecode = loopDecodeInFlight
   }
 
   package func cancel() async {

--- a/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
@@ -121,7 +121,10 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
   /// exceeds this, confirm the oldest unconfirmed segment(s) so the per-cycle
   /// decode window stays under one 30s WhisperKit window even if confirmation
   /// stalls. 25s leaves headroom under the 30s window.
-  private let maxUnconfirmedWindowSec: Float = 25.0
+  /// Single source for the hard window bound — telemetry echoes it (#1309).
+  package static let defaultMaxUnconfirmedWindowSec: Float = 25.0
+  private let maxUnconfirmedWindowSec: Float =
+    WhisperKitStreamingSession.defaultMaxUnconfirmedWindowSec
 
   /// Minimum uncovered-tail duration (seconds) below which the flush skips the
   /// tail decode and accepts the confirmed prefix — a sub-100ms tail is too short
@@ -159,6 +162,14 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
   /// arm S1's "release-only" material (rulebook §5.0). The segment-lag
   /// finalize ignores it. Empty until the first decode.
   private var retainedUnconfirmedSegments: [BenchmarkSegment] = []
+
+  /// True while a loop decode is inside `whisperKit.transcribe` — read by
+  /// finalize (after awaiting the loop's exit) to stamp the #1309
+  /// `stop_while_decode_in_flight` telemetry field.
+  private var loopDecodeInFlight = false
+  /// Snapshot of `loopDecodeInFlight` at finalize entry (#1309 telemetry),
+  /// stamped onto every result this finalize produces.
+  private var stoppedMidDecode = false
 
   private var running = false
   /// Set exactly once at the first terminal (`finalize`/`cancel`) so a late loop
@@ -266,6 +277,8 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     decodeCount = 0
     totalDecodeTimeMs = 0
     retainedUnconfirmedSegments = []
+    stoppedMidDecode = false
+    loopDecodeInFlight = false
     previousHypothesisWords = []
     bufferStartSec = 0
     committedWordsInBuffer = []
@@ -291,6 +304,9 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     finalSamples: [Float],
     speechSegments: [SpeechSegment]
   ) async -> IncrementalResult {
+    // #1309 telemetry: was a loop decode still in flight when stop arrived?
+    // Snapshot BEFORE awaiting the loop's exit (which clears the flag).
+    stoppedMidDecode = loopDecodeInFlight
     running = false
     finished = true
     let loop = loopTask
@@ -458,7 +474,8 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
       samplesCovered: 0, decodeCount: decodeCount,
       totalDecodeTimeMs: totalDecodeTimeMs,
       accepted: false, mode: "streaming",
-      strategy: strategy, tailDecodeMs: tailMs)
+      strategy: strategy, tailDecodeMs: tailMs,
+      stopWhileDecodeInFlight: stoppedMidDecode)
   }
 
   private func rms(_ samples: [Float]) -> Float {
@@ -568,7 +585,9 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
       }
       let decodeStart = CFAbsoluteTimeGetCurrent()
       do {
+        loopDecodeInFlight = true
         let results = try await whisperKit.transcribe(audioArray: samples, decodeOptions: opts)
+        loopDecodeInFlight = false
         // Re-check terminal state AFTER the decode await before mutating confirmed
         // state — a finalize/cancel during the decode must win.
         guard running, !finished, !Task.isCancelled else { break }
@@ -585,6 +604,7 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
         let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - decodeStart) * 1000)
         totalDecodeTimeMs += elapsedMs
       } catch {
+        loopDecodeInFlight = false
         if !Task.isCancelled {
           await AppLogger.shared.log(
             "WhisperKit streaming decode failed: \(error.localizedDescription)",
@@ -861,6 +881,7 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
       samplesCovered: samplesCovered, decodeCount: decodeCount,
       totalDecodeTimeMs: totalDecodeTimeMs,
       accepted: !trimmed.isEmpty, mode: "streaming",
-      strategy: "streaming", tailDecodeMs: tailDecodeMs)
+      strategy: "streaming", tailDecodeMs: tailDecodeMs,
+      stopWhileDecodeInFlight: stoppedMidDecode)
   }
 }

--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -85,6 +85,21 @@ public struct ExecutionMetrics: Codable, Sendable {
   public var emojiRestored: Int?
   public var emojiRestoreIncomplete: Bool?
   public var emojiLatencyMs: Double?
+  /// #1309 effective-path streaming telemetry (WhisperKit only; nil for
+  /// Parakeet and pre-#1309 transcripts on disk — additive optional Codable,
+  /// back-compatible). `streamingMode` above is the REQUESTED mode (kernel
+  /// capability gate); these describe what actually ran. Metadata only.
+  /// `streamingDegradeReason` = none / disabled / auto_language /
+  /// model_not_ready / flush_empty / flush_throw. `streamingFinalPath` =
+  /// streaming_flush / clean_batch / fallback_batch / failed.
+  public var streamingEffective: Bool?
+  public var streamingDegradeReason: String?
+  public var streamingFinalPath: String?
+  public var streamingDecodeCount: Int?
+  public var streamingCoveredSec: Double?
+  public var tailDecodeSec: Double?
+  public var maxUnconfirmedWindowSec: Double?
+  public var stopWhileDecodeInFlight: Bool?
 
   public init(
     asrLatencySeconds: Double? = nil,
@@ -125,7 +140,15 @@ public struct ExecutionMetrics: Codable, Sendable {
     emojiDropped: Int? = nil,
     emojiRestored: Int? = nil,
     emojiRestoreIncomplete: Bool? = nil,
-    emojiLatencyMs: Double? = nil
+    emojiLatencyMs: Double? = nil,
+    streamingEffective: Bool? = nil,
+    streamingDegradeReason: String? = nil,
+    streamingFinalPath: String? = nil,
+    streamingDecodeCount: Int? = nil,
+    streamingCoveredSec: Double? = nil,
+    tailDecodeSec: Double? = nil,
+    maxUnconfirmedWindowSec: Double? = nil,
+    stopWhileDecodeInFlight: Bool? = nil
   ) {
     self.asrLatencySeconds = asrLatencySeconds
     self.llmLatencySeconds = llmLatencySeconds
@@ -166,6 +189,14 @@ public struct ExecutionMetrics: Codable, Sendable {
     self.emojiRestored = emojiRestored
     self.emojiRestoreIncomplete = emojiRestoreIncomplete
     self.emojiLatencyMs = emojiLatencyMs
+    self.streamingEffective = streamingEffective
+    self.streamingDegradeReason = streamingDegradeReason
+    self.streamingFinalPath = streamingFinalPath
+    self.streamingDecodeCount = streamingDecodeCount
+    self.streamingCoveredSec = streamingCoveredSec
+    self.tailDecodeSec = tailDecodeSec
+    self.maxUnconfirmedWindowSec = maxUnconfirmedWindowSec
+    self.stopWhileDecodeInFlight = stopWhileDecodeInFlight
   }
 }
 

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -434,7 +434,18 @@ struct KernelFinalizationWiring {
       emojiDropped: outcome.emojiRan ? outcome.emojiDropped : nil,
       emojiRestored: outcome.emojiRan ? outcome.emojiRestored : nil,
       emojiRestoreIncomplete: outcome.emojiRan ? outcome.emojiRestoreIncomplete : nil,
-      emojiLatencyMs: outcome.emojiRan ? outcome.emojiLatencyMs : nil
+      emojiLatencyMs: outcome.emojiRan ? outcome.emojiLatencyMs : nil,
+      // #1309 effective-path streaming telemetry — kernel-assembled from the
+      // adapter's diagnostics (WhisperKit only; nil omitted). `streamingMode`
+      // above stays the REQUESTED mode.
+      streamingEffective: telemetryState.asrCompletedTelemetry?.streamingEffective,
+      streamingDegradeReason: telemetryState.asrCompletedTelemetry?.streamingDegradeReason,
+      streamingFinalPath: telemetryState.asrCompletedTelemetry?.streamingFinalPath,
+      streamingDecodeCount: telemetryState.asrCompletedTelemetry?.streamingDecodeCount,
+      streamingCoveredSec: telemetryState.asrCompletedTelemetry?.streamingCoveredSec,
+      tailDecodeSec: telemetryState.asrCompletedTelemetry?.tailDecodeSec,
+      maxUnconfirmedWindowSec: telemetryState.asrCompletedTelemetry?.maxUnconfirmedWindowSec,
+      stopWhileDecodeInFlight: telemetryState.asrCompletedTelemetry?.stopWhileDecodeInFlight
     )
     outcome.transcript = transcript
   }

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -369,6 +369,15 @@ final class KernelLifecycleTelemetrySink {
     if let incremental = telemetryState.asrCompletedTelemetry?.incrementalAccepted {
       payload["incremental"] = incremental
     }
+    // #1309 effective-path streaming facts (WhisperKit only; nil omitted).
+    if let t = telemetryState.asrCompletedTelemetry {
+      if let v = t.streamingRequested { payload["streaming_requested"] = v }
+      if let v = t.streamingEffective { payload["streaming_effective"] = v }
+      if let v = t.streamingDegradeReason { payload["streaming_degrade_reason"] = v }
+      if let v = t.streamingFinalPath { payload["final_path"] = v }
+      if let v = t.streamingDecodeCount { payload["streaming_decode_count"] = v }
+      if let v = t.stopWhileDecodeInFlight { payload["stop_while_decode_in_flight"] = v }
+    }
     // #950 tail-trim diagnostic (eligible Parakeet batch only; nil omitted).
     // `tail_dropped_ms` always present when set (incl. 0); `tail_had_energy` only
     // when a tail was dropped. Metadata only — no audio/content.

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -376,6 +376,9 @@ final class KernelLifecycleTelemetrySink {
       if let v = t.streamingDegradeReason { payload["streaming_degrade_reason"] = v }
       if let v = t.streamingFinalPath { payload["final_path"] = v }
       if let v = t.streamingDecodeCount { payload["streaming_decode_count"] = v }
+      if let v = t.streamingCoveredSec { payload["streaming_covered_sec"] = v }
+      if let v = t.tailDecodeSec { payload["tail_decode_sec"] = v }
+      if let v = t.maxUnconfirmedWindowSec { payload["max_unconfirmed_window_sec"] = v }
       if let v = t.stopWhileDecodeInFlight { payload["stop_while_decode_in_flight"] = v }
     }
     // #950 tail-trim diagnostic (eligible Parakeet batch only; nil omitted).

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -91,9 +91,33 @@ struct KernelASRCompletedTelemetry {
   var asrLastTokenEndMs: Int? = nil
   var asrLastTokenGapMs: Int? = nil
   var asrChunked: Bool? = nil
+  // #1309 effective-path streaming telemetry (WhisperKit only; nil omitted).
+  // `mode` above is the REQUESTED mode (kernel capability gate);
+  // `streamingRequested` restates it as an explicit boolean so the event can
+  // filter requested-vs-effective without string parsing. All metadata.
+  var streamingRequested: Bool? = nil
+  var streamingEffective: Bool? = nil
+  var streamingDegradeReason: String? = nil
+  var streamingFinalPath: String? = nil
+  var streamingDecodeCount: Int? = nil
+  var streamingCoveredSec: Double? = nil
+  var tailDecodeSec: Double? = nil
+  var maxUnconfirmedWindowSec: Double? = nil
+  var stopWhileDecodeInFlight: Bool? = nil
 }
 
 struct KernelASRAdapterDiagnostics {
+  // #1309 effective-path telemetry (WhisperKit adapter; nil for Parakeet).
+  // `streamingEffective`: did a streaming flush deliver the transcript.
+  // `streamingDegradeReason`: none / disabled / auto_language /
+  // model_not_ready / flush_empty / flush_throw.
+  // `streamingFinalPath`: streaming_flush / clean_batch / fallback_batch / failed.
+  var streamingEffective: Bool? = nil
+  var streamingDegradeReason: String? = nil
+  var streamingFinalPath: String? = nil
+  var stopWhileDecodeInFlight: Bool? = nil
+  var streamingMaxUnconfirmedWindowSec: Double? = nil
+
   var streamingResultChars: Int? = nil
   var streamingFinalizeFailed: Bool? = nil
   var streamingFinalizeErrorType: String? = nil

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1400,7 +1400,7 @@ final class RecordingSessionKernel {
         // #1309 effective-path streaming telemetry. Requested comes from the
         // kernel's own capability gate; effective/degrade/path from the
         // adapter's diagnostics. WhisperKit-only (nil for Parakeet → omitted).
-        streamingRequested: adapterDiag != nil ? isStreamingSession : nil,
+        streamingRequested: adapterDiag?.streamingEffective != nil ? isStreamingSession : nil,
         streamingEffective: adapterDiag?.streamingEffective,
         streamingDegradeReason: adapterDiag?.streamingDegradeReason,
         streamingFinalPath: adapterDiag?.streamingFinalPath,

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1371,6 +1371,7 @@ final class RecordingSessionKernel {
         vadSegments: vadSegments,
         decodedInputSampleCount: decodedInputCount,
         lastTokenEndMs: result.tokenTimingSummary?.lastTokenEndMs)
+      let adapterDiag = (adapter as? ASREngineTelemetryProviding)?.lastASRDiagnostics
       telemetryState.asrCompletedTelemetry = KernelASRCompletedTelemetry(
         durationSeconds: result.processingTime,
         charCount: result.text.trimmingCharacters(in: .whitespacesAndNewlines).count,
@@ -1379,8 +1380,7 @@ final class RecordingSessionKernel {
         // PR-5 Rung 5 Pass 2 r2 #B1: carry the incremental-vs-batch outcome into
         // the ASR-completed Sentry breadcrumb (parity with OLD
         // `WhisperKitPipeline.swift:1049-1052`). nil for Parakeet.
-        incrementalAccepted: (adapter as? ASREngineTelemetryProviding)?
-          .lastASRDiagnostics?.incrementalAccepted,
+        incrementalAccepted: adapterDiag?.incrementalAccepted,
         // #950 tail-trim diagnostic (eligible Parakeet batch only; nil omitted).
         droppedTailMs: tailDroppedMs,
         tailHadEnergy: tailHadEnergy,
@@ -1396,7 +1396,21 @@ final class RecordingSessionKernel {
         asrInputDurationMs: tailClip.asrInputDurationMs,
         asrLastTokenEndMs: tailClip.asrLastTokenEndMs,
         asrLastTokenGapMs: tailClip.asrLastTokenGapMs,
-        asrChunked: tailClip.asrChunked
+        asrChunked: tailClip.asrChunked,
+        // #1309 effective-path streaming telemetry. Requested comes from the
+        // kernel's own capability gate; effective/degrade/path from the
+        // adapter's diagnostics. WhisperKit-only (nil for Parakeet → omitted).
+        streamingRequested: adapterDiag != nil ? isStreamingSession : nil,
+        streamingEffective: adapterDiag?.streamingEffective,
+        streamingDegradeReason: adapterDiag?.streamingDegradeReason,
+        streamingFinalPath: adapterDiag?.streamingFinalPath,
+        streamingDecodeCount: adapterDiag?.incrementalDecodeCount,
+        streamingCoveredSec: adapterDiag?.incrementalSamplesCovered.map {
+          Double($0) / AudioConstants.sampleRate
+        },
+        tailDecodeSec: adapterDiag?.incrementalTailDecodeMs.map { Double($0) / 1000.0 },
+        maxUnconfirmedWindowSec: adapterDiag?.streamingMaxUnconfirmedWindowSec,
+        stopWhileDecodeInFlight: adapterDiag?.stopWhileDecodeInFlight
       )
       // #1232 debug-log line: the per-dictation tail-clip verdict + lead signals,
       // greppable in app.log next to the conditioner line for live triage.

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -164,9 +164,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// flush_throw. Surfaced through `KernelASRAdapterDiagnostics`.
   private var sessionStreamingRequested = false
   private var sessionStreamingDegradeReason = "none"
-  /// #1309: preserved from a degraded streaming flush so the batch fallback's
-  /// diagnostics still carry the stop-mid-decode signal.
-  private var sessionStopWhileDecodeInFlight: Bool?
+  /// #1309: the WHOLE degraded streaming-flush result, preserved so the batch
+  /// fallback's diagnostics still carry every streaming counter (decode count,
+  /// coverage, tail-decode time, stop-mid-decode) — the telemetry matters most
+  /// exactly for degraded sessions (Codex r2: field-by-field preservation kept
+  /// losing the next field; preserve the source record once).
+  private var sessionDegradedFlushResult: IncrementalResult?
 
   /// The adapter-owned LOSSLESS audio the streaming session reads — the single
   /// coordinate the whole streaming path lives in (§3.2). Fed by `acceptAudio`
@@ -378,7 +381,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     // at begin; flush_empty / flush_throw at finalize).
     sessionStreamingRequested = streaming
     sessionStreamingDegradeReason = streaming ? "none" : "disabled"
-    sessionStopWhileDecodeInFlight = nil
+    sessionDegradedFlushResult = nil
     lastLanguageDetection = nil
     retainedPCM.removeAll(keepingCapacity: true)
     observedSpeechSegments.removeAll()
@@ -767,7 +770,15 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     diagnostics.streamingFinalPath =
       ["flush_empty", "flush_throw"].contains(sessionStreamingDegradeReason)
       ? "fallback_batch" : "clean_batch"
-    diagnostics.stopWhileDecodeInFlight = sessionStopWhileDecodeInFlight
+    if let flush = sessionDegradedFlushResult {
+      // A streaming session ran before this fallback: carry its counters.
+      diagnostics.incrementalDecodeCount = flush.decodeCount
+      diagnostics.incrementalSamplesCovered = flush.samplesCovered
+      diagnostics.incrementalTailDecodeMs = flush.tailDecodeMs
+      diagnostics.stopWhileDecodeInFlight = flush.stopWhileDecodeInFlight
+      diagnostics.streamingMaxUnconfirmedWindowSec =
+        Double(WhisperKitStreamingSession.defaultMaxUnconfirmedWindowSec)
+    }
     // PR-5 Rung 4.5 (#827): LID perf-signpost transport for kernel-side
     // `t_release` and wiring-side `t_clipboard_write` emits. Populated here
     // so every terminal write of `lastASRDiagnostics` carries them. Uses the
@@ -1089,12 +1100,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     let trimmed = (result.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     guard result.accepted, !trimmed.isEmpty else {
       // Streaming produced nothing usable — fall through to the batch fallback.
-      // #1309: record WHY streaming degraded — and preserve the stop-mid-decode
-      // signal — for the batch fallback's diagnostics (Codex r1 P2: dropping it
-      // here loses the field exactly when a mid-decode stop broke the flush).
+      // #1309: record WHY streaming degraded and preserve the whole flush
+      // result — the batch fallback's diagnostics re-stamp every streaming
+      // counter from it (Codex r1/r2).
       sessionStreamingDegradeReason =
         result.strategy == "streaming_flush_failed" ? "flush_throw" : "flush_empty"
-      sessionStopWhileDecodeInFlight = result.stopWhileDecodeInFlight
+      sessionDegradedFlushResult = result
       Task { [strategy = result.strategy] in
         await AppLogger.shared.log(
           "WhisperKit streaming flush empty (strategy=\(strategy)) — falling back to batch",

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1082,6 +1082,9 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     session: SessionID, sessionIDForLog: UInt64
   ) async -> ASREngineOutcome? {
     guard streamingActive, let live = streamingSession else { return nil }
+    // #1309: snapshot stop-moment telemetry BEFORE the feed drain — a decode
+    // can finish during the drain and undercount stop_while_decode_in_flight.
+    await live.noteStopRequested()
     await drainStreamingFeeds()
     let flushStart = CFAbsoluteTimeGetCurrent()
     // The session ignores both params (single-coordinate design §3.2): it flushes

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -164,6 +164,9 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// flush_throw. Surfaced through `KernelASRAdapterDiagnostics`.
   private var sessionStreamingRequested = false
   private var sessionStreamingDegradeReason = "none"
+  /// #1309: preserved from a degraded streaming flush so the batch fallback's
+  /// diagnostics still carry the stop-mid-decode signal.
+  private var sessionStopWhileDecodeInFlight: Bool?
 
   /// The adapter-owned LOSSLESS audio the streaming session reads — the single
   /// coordinate the whole streaming path lives in (§3.2). Fed by `acceptAudio`
@@ -375,6 +378,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     // at begin; flush_empty / flush_throw at finalize).
     sessionStreamingRequested = streaming
     sessionStreamingDegradeReason = streaming ? "none" : "disabled"
+    sessionStopWhileDecodeInFlight = nil
     lastLanguageDetection = nil
     retainedPCM.removeAll(keepingCapacity: true)
     observedSpeechSegments.removeAll()
@@ -763,6 +767,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     diagnostics.streamingFinalPath =
       ["flush_empty", "flush_throw"].contains(sessionStreamingDegradeReason)
       ? "fallback_batch" : "clean_batch"
+    diagnostics.stopWhileDecodeInFlight = sessionStopWhileDecodeInFlight
     // PR-5 Rung 4.5 (#827): LID perf-signpost transport for kernel-side
     // `t_release` and wiring-side `t_clipboard_write` emits. Populated here
     // so every terminal write of `lastASRDiagnostics` carries them. Uses the
@@ -1084,9 +1089,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     let trimmed = (result.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     guard result.accepted, !trimmed.isEmpty else {
       // Streaming produced nothing usable — fall through to the batch fallback.
-      // #1309: record WHY streaming degraded for the fallback's diagnostics.
+      // #1309: record WHY streaming degraded — and preserve the stop-mid-decode
+      // signal — for the batch fallback's diagnostics (Codex r1 P2: dropping it
+      // here loses the field exactly when a mid-decode stop broke the flush).
       sessionStreamingDegradeReason =
         result.strategy == "streaming_flush_failed" ? "flush_throw" : "flush_empty"
+      sessionStopWhileDecodeInFlight = result.stopWhileDecodeInFlight
       Task { [strategy = result.strategy] in
         await AppLogger.shared.log(
           "WhisperKit streaming flush empty (strategy=\(strategy)) — falling back to batch",

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -157,6 +157,14 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// `true` between a successful streaming-session start and finalize/cancel.
   private var streamingActive = false
 
+  /// #1309 effective-path telemetry, per session. `sessionStreamingRequested`
+  /// mirrors the kernel's capability-gate decision as handed to `beginSession`;
+  /// the degrade reason narrows as the session progresses:
+  /// none / disabled / auto_language / model_not_ready / flush_empty /
+  /// flush_throw. Surfaced through `KernelASRAdapterDiagnostics`.
+  private var sessionStreamingRequested = false
+  private var sessionStreamingDegradeReason = "none"
+
   /// The adapter-owned LOSSLESS audio the streaming session reads — the single
   /// coordinate the whole streaming path lives in (§3.2). Fed by `acceptAudio`
   /// via retained `streamingFeedTasks` (Parakeet's drain pattern ported
@@ -362,6 +370,11 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     lastResult = nil
     lastASRDiagnostics = nil
     lastFailureError = nil
+    // #1309 effective-path telemetry: reset per session. The degrade reason
+    // is refined as the session progresses (auto_language / model_not_ready
+    // at begin; flush_empty / flush_throw at finalize).
+    sessionStreamingRequested = streaming
+    sessionStreamingDegradeReason = streaming ? "none" : "disabled"
     lastLanguageDetection = nil
     retainedPCM.removeAll(keepingCapacity: true)
     observedSpeechSegments.removeAll()
@@ -407,6 +420,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     if streaming, options.language != nil {
       await startStreamingSession(id, options: options)
     } else {
+      if streaming { sessionStreamingDegradeReason = "auto_language" }
       let reason = streaming ? "auto language, batch (Ship 2)" : "toggle off"
       let languageForLog = options.language ?? "auto"
       Task {
@@ -425,6 +439,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// then runs the clean batch fallback (fail-open, heart stays alive).
   private func startStreamingSession(_ id: SessionID, options: TranscriptionOptions) async {
     guard let session = await backend.makeStreamingSession(options: options) else {
+      sessionStreamingDegradeReason = "model_not_ready"
       Task {
         await AppLogger.shared.log(
           "WhisperKit recording started (batch mode, streaming requested but model not loaded)",
@@ -738,6 +753,16 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     // terminal outcome.
     var diagnostics = KernelASRAdapterDiagnostics()
     diagnostics.rawSampleCount = rawSamples.count
+    // #1309 effective-path telemetry: this is the batch finalize, so streaming
+    // did not deliver the transcript. `fallback_batch` when a streaming
+    // session ran and degraded at flush; `clean_batch` when streaming never
+    // ran (toggle off / auto language / model not ready). The .failed exit
+    // below overrides `finalPath` to "failed".
+    diagnostics.streamingEffective = false
+    diagnostics.streamingDegradeReason = sessionStreamingDegradeReason
+    diagnostics.streamingFinalPath =
+      ["flush_empty", "flush_throw"].contains(sessionStreamingDegradeReason)
+      ? "fallback_batch" : "clean_batch"
     // PR-5 Rung 4.5 (#827): LID perf-signpost transport for kernel-side
     // `t_release` and wiring-side `t_clipboard_write` emits. Populated here
     // so every terminal write of `lastASRDiagnostics` carries them. Uses the
@@ -777,6 +802,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
       return .cancelled
     case .failed(let error):
       lastFailureError = error
+      diagnostics.streamingFinalPath = "failed"  // #1309
       lastASRDiagnostics = diagnostics
       isTerminal = true
       clearSessionBuffers()
@@ -1058,6 +1084,9 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     let trimmed = (result.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     guard result.accepted, !trimmed.isEmpty else {
       // Streaming produced nothing usable — fall through to the batch fallback.
+      // #1309: record WHY streaming degraded for the fallback's diagnostics.
+      sessionStreamingDegradeReason =
+        result.strategy == "streaming_flush_failed" ? "flush_throw" : "flush_empty"
       Task { [strategy = result.strategy] in
         await AppLogger.shared.log(
           "WhisperKit streaming flush empty (strategy=\(strategy)) — falling back to batch",
@@ -1084,6 +1113,17 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     var diagnostics = KernelASRAdapterDiagnostics()
     diagnostics.rawSampleCount = result.samplesCovered
     diagnostics.lidCaptureSessionID = sessionIDForLog
+    // #1309 effective-path telemetry: streaming ran and its flush IS the
+    // transcript.
+    diagnostics.streamingEffective = true
+    diagnostics.streamingDegradeReason = "none"
+    diagnostics.streamingFinalPath = "streaming_flush"
+    diagnostics.incrementalDecodeCount = result.decodeCount
+    diagnostics.incrementalSamplesCovered = result.samplesCovered
+    diagnostics.incrementalTailDecodeMs = result.tailDecodeMs
+    diagnostics.stopWhileDecodeInFlight = result.stopWhileDecodeInFlight
+    diagnostics.streamingMaxUnconfirmedWindowSec =
+      Double(WhisperKitStreamingSession.defaultMaxUnconfirmedWindowSec)
     lastASRDiagnostics = diagnostics
     isTerminal = true
     clearSessionBuffers()

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -446,7 +446,11 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   /// then runs the clean batch fallback (fail-open, heart stays alive).
   private func startStreamingSession(_ id: SessionID, options: TranscriptionOptions) async {
     guard let session = await backend.makeStreamingSession(options: options) else {
-      sessionStreamingDegradeReason = "model_not_ready"
+      // Stale guard (cloud r2): a cancel + beginSession(B) during the vend
+      // await must not overwrite B's per-session telemetry state.
+      if sessionID == id, !isCancelled {
+        sessionStreamingDegradeReason = "model_not_ready"
+      }
       Task {
         await AppLogger.shared.log(
           "WhisperKit recording started (batch mode, streaming requested but model not loaded)",
@@ -772,8 +776,10 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
       ? "fallback_batch" : "clean_batch"
     if let flush = sessionDegradedFlushResult {
       // A streaming session ran before this fallback: carry its counters.
+      // `samplesCovered` is 0 by construction on a forced fallback — omit it
+      // rather than report zero coverage as fact (cloud r2).
       diagnostics.incrementalDecodeCount = flush.decodeCount
-      diagnostics.incrementalSamplesCovered = flush.samplesCovered
+      diagnostics.incrementalSamplesCovered = flush.samplesCovered > 0 ? flush.samplesCovered : nil
       diagnostics.incrementalTailDecodeMs = flush.tailDecodeMs
       diagnostics.stopWhileDecodeInFlight = flush.stopWhileDecodeInFlight
       diagnostics.streamingMaxUnconfirmedWindowSec =

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -124,7 +124,18 @@ public final class TelemetryService {
         captureTrailingSilenceMs: m?.captureTrailingSilenceMs,
         captureTail200Rms: m?.captureTail200Rms, captureTail200Peak: m?.captureTail200Peak,
         asrInputDurationMs: m?.asrInputDurationMs, asrLastTokenEndMs: m?.asrLastTokenEndMs,
-        asrLastTokenGapMs: m?.asrLastTokenGapMs, asrChunked: m?.asrChunked)
+        asrLastTokenGapMs: m?.asrLastTokenGapMs, asrChunked: m?.asrChunked,
+        // #1309: requested restated from the metrics' streamingMode only when
+        // the effective-path facts are present (WhisperKit; Parakeet omits all).
+        streamingRequested: m?.streamingEffective != nil ? m?.streamingMode : nil,
+        streamingEffective: m?.streamingEffective,
+        streamingDegradeReason: m?.streamingDegradeReason,
+        streamingFinalPath: m?.streamingFinalPath,
+        streamingDecodeCount: m?.streamingDecodeCount,
+        streamingCoveredSec: m?.streamingCoveredSec,
+        tailDecodeSec: m?.tailDecodeSec,
+        maxUnconfirmedWindowSec: m?.maxUnconfirmedWindowSec,
+        stopWhileDecodeInFlight: m?.stopWhileDecodeInFlight)
     }
     if let llmLat = m?.llmLatencySeconds, llmLat > 0, t.llmProvider != nil {
       llmPolishCompleted(
@@ -722,7 +733,19 @@ public final class TelemetryService {
     tailClipClass: String? = nil, captureTrailingSilenceMs: Int? = nil,
     captureTail200Rms: Double? = nil, captureTail200Peak: Double? = nil,
     asrInputDurationMs: Int? = nil, asrLastTokenEndMs: Int? = nil,
-    asrLastTokenGapMs: Int? = nil, asrChunked: Bool? = nil
+    asrLastTokenGapMs: Int? = nil, asrChunked: Bool? = nil,
+    // #1309 effective-path streaming telemetry (WhisperKit only; omit-on-nil;
+    // metadata only — no audio/content). `streamingRequested` = the kernel's
+    // capability-gate decision; `streamingEffective` = a streaming flush
+    // delivered the transcript; `streamingDegradeReason` = none / disabled /
+    // auto_language / model_not_ready / flush_empty / flush_throw;
+    // `streamingFinalPath` = streaming_flush / clean_batch / fallback_batch /
+    // failed.
+    streamingRequested: Bool? = nil, streamingEffective: Bool? = nil,
+    streamingDegradeReason: String? = nil, streamingFinalPath: String? = nil,
+    streamingDecodeCount: Int? = nil, streamingCoveredSec: Double? = nil,
+    tailDecodeSec: Double? = nil, maxUnconfirmedWindowSec: Double? = nil,
+    stopWhileDecodeInFlight: Bool? = nil
   ) {
     var properties: [String: Any] = [
       "backend": backend,
@@ -748,6 +771,21 @@ public final class TelemetryService {
     if let asrLastTokenEndMs { properties["asr_last_token_end_ms"] = asrLastTokenEndMs }
     if let asrLastTokenGapMs { properties["asr_last_token_gap_ms"] = asrLastTokenGapMs }
     if let asrChunked { properties["asr_chunked"] = asrChunked }
+    if let streamingRequested { properties["streaming_requested"] = streamingRequested }
+    if let streamingEffective { properties["streaming_effective"] = streamingEffective }
+    if let streamingDegradeReason {
+      properties["streaming_degrade_reason"] = streamingDegradeReason
+    }
+    if let streamingFinalPath { properties["final_path"] = streamingFinalPath }
+    if let streamingDecodeCount { properties["streaming_decode_count"] = streamingDecodeCount }
+    if let streamingCoveredSec { properties["streaming_covered_sec"] = streamingCoveredSec }
+    if let tailDecodeSec { properties["tail_decode_sec"] = tailDecodeSec }
+    if let maxUnconfirmedWindowSec {
+      properties["max_unconfirmed_window_sec"] = maxUnconfirmedWindowSec
+    }
+    if let stopWhileDecodeInFlight {
+      properties["stop_while_decode_in_flight"] = stopWhileDecodeInFlight
+    }
     PostHogSDK.shared.capture("asr.completed", properties: properties)
   }
 

--- a/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
+++ b/Tests/EnviousWisprASRTests/WhisperKitStreamingSessionTests.swift
@@ -671,6 +671,25 @@ import Testing
     #expect(r.strategy == "streaming_buffer_empty_fallback")
   }
 
+  @Test("stop_while_decode_in_flight reflects the STOP moment, not finalize entry (Codex r3)")
+  func stopSnapshotTakenAtStopMoment() async throws {
+    // Stop arrives while a decode is blocked in flight (noteStopRequested);
+    // the decode then finishes BEFORE finalize runs (the adapter's feed-drain
+    // window). The result must still report stop_while_decode_in_flight=true.
+    let loop = result("the meeting", [seg(0, 2, "the meeting")])
+    let dec = GateDecoder(loopResult: [loop], flushResult: [loop])
+    let s = WhisperKitStreamingSession(
+      whisperKit: dec, decodingOptions: DecodingOptions(),
+      requiredSegmentsForConfirmation: 2, cadence: .milliseconds(1))
+    let pcm = [Float](repeating: 0.4, count: 96_000)
+    await s.start(audioSamplesProvider: fixedProvider(pcm))
+    while !(await dec.loopEntered) { await Task.yield() }  // decode blocked in flight
+    await s.noteStopRequested()  // the user's stop — decode still running
+    await dec.release()  // decode finishes during the "drain window"
+    let r = await s.finalize(finalSamples: [], speechSegments: [])
+    #expect(r.stopWhileDecodeInFlight == true, "stop-moment snapshot wins over finalize-entry state")
+  }
+
   // MARK: Bounded conditioning prompt (UFAL prompt() 200-char suffix)
 
   @Test("promptSuffix returns short text whole and bounds long text at a word boundary")

--- a/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
+++ b/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
@@ -253,7 +253,7 @@ extension IncrementalResult {
     )
   }
 
-  static func rejected() -> IncrementalResult {
+  static func rejected(stopWhileDecodeInFlight: Bool = false) -> IncrementalResult {
     IncrementalResult(
       text: nil,
       samplesCovered: 0,
@@ -262,7 +262,8 @@ extension IncrementalResult {
       accepted: false,
       mode: "stub-mode",
       strategy: "stub-strategy",
-      tailDecodeMs: 0
+      tailDecodeMs: 0,
+      stopWhileDecodeInFlight: stopWhileDecodeInFlight
     )
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -618,6 +618,14 @@ import Testing
     #expect(adapter.lastLanguageDetection?.lang == "en")
     #expect(adapter.lastLanguageDetection?.tier == .locked)
     #expect(adapter.lastLanguageDetection?.abstained == false)
+    // #1309 effective-path telemetry: streaming delivered the transcript.
+    let diag = adapter.lastASRDiagnostics
+    #expect(diag?.streamingEffective == true)
+    #expect(diag?.streamingDegradeReason == "none")
+    #expect(diag?.streamingFinalPath == "streaming_flush")
+    #expect(diag?.incrementalDecodeCount == 1)
+    #expect(diag?.stopWhileDecodeInFlight == false)
+    #expect(diag?.streamingMaxUnconfirmedWindowSec == 25.0)
   }
 
   @Test("streaming ON + auto language: degrades to clean batch, no streaming session")
@@ -644,6 +652,12 @@ import Testing
     #expect(result.text == "auto-batch")
     let txCount = await backend.transcribeCount
     #expect(txCount == 1, "auto + streaming ON runs clean batch")
+    // #1309: requested-but-degraded — the auto-language case (the issue's
+    // named test scenario: requested=true, effective=false, reason=auto_language).
+    let diag = adapter.lastASRDiagnostics
+    #expect(diag?.streamingEffective == false)
+    #expect(diag?.streamingDegradeReason == "auto_language")
+    #expect(diag?.streamingFinalPath == "clean_batch")
   }
 
   @Test("streaming ON + locked but model not ready (nil vend): fail-open to clean batch")
@@ -668,6 +682,11 @@ import Testing
     #expect(result.text == "fallback-batch", "nil streaming vend → clean batch fallback")
     let txCount = await backend.transcribeCount
     #expect(txCount == 1)
+    // #1309: model-not-ready degrade.
+    let diag = adapter.lastASRDiagnostics
+    #expect(diag?.streamingEffective == false)
+    #expect(diag?.streamingDegradeReason == "model_not_ready")
+    #expect(diag?.streamingFinalPath == "clean_batch")
   }
 
   @Test("streaming ON + locked but flush returns empty: fail-open to clean batch")
@@ -695,6 +714,11 @@ import Testing
     #expect(mss == 1, "streaming session was started")
     let txCount = await backend.transcribeCount
     #expect(txCount == 1, "batch fallback ran after empty flush")
+    // #1309: flush produced nothing → fallback_batch with flush_empty.
+    let diag = adapter.lastASRDiagnostics
+    #expect(diag?.streamingEffective == false)
+    #expect(diag?.streamingDegradeReason == "flush_empty")
+    #expect(diag?.streamingFinalPath == "fallback_batch")
   }
 
   @Test("streaming OFF + locked: no streaming session, clean batch")
@@ -720,6 +744,11 @@ import Testing
       return
     }
     #expect(result.text == "off-batch")
+    // #1309: not requested → disabled / clean_batch.
+    let diag = adapter.lastASRDiagnostics
+    #expect(diag?.streamingEffective == false)
+    #expect(diag?.streamingDegradeReason == "disabled")
+    #expect(diag?.streamingFinalPath == "clean_batch")
   }
 
   // MARK: Finalize — coordinate space (council F1 / OQ-1)

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -723,6 +723,10 @@ import Testing
     #expect(diag?.streamingDegradeReason == "flush_empty")
     #expect(diag?.streamingFinalPath == "fallback_batch")
     #expect(diag?.stopWhileDecodeInFlight == true)
+    // Codex r2: the flush's counters survive the fallback too.
+    #expect(diag?.incrementalDecodeCount == 0)
+    #expect(diag?.incrementalTailDecodeMs == 0)
+    #expect(diag?.streamingMaxUnconfirmedWindowSec == 25.0)
   }
 
   @Test("streaming OFF + locked: no streaming session, clean batch")

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -692,7 +692,8 @@ import Testing
   @Test("streaming ON + locked but flush returns empty: fail-open to clean batch")
   func streamingEmptyFlushFailsOpen() async throws {
     let backend = StubWhisperKitBackend()
-    let stubSession = StubIncrementalSession(result: .rejected())
+    let stubSession = StubIncrementalSession(
+      result: .rejected(stopWhileDecodeInFlight: true))
     await backend.setStreamingSessionFactory({ stubSession })
     await backend.setTranscribeResult(
       ASRResult(
@@ -714,11 +715,14 @@ import Testing
     #expect(mss == 1, "streaming session was started")
     let txCount = await backend.transcribeCount
     #expect(txCount == 1, "batch fallback ran after empty flush")
-    // #1309: flush produced nothing → fallback_batch with flush_empty.
+    // #1309: flush produced nothing → fallback_batch with flush_empty, and the
+    // stop-mid-decode signal survives into the fallback's diagnostics
+    // (Codex r1 P2 — it matters most exactly when the flush broke).
     let diag = adapter.lastASRDiagnostics
     #expect(diag?.streamingEffective == false)
     #expect(diag?.streamingDegradeReason == "flush_empty")
     #expect(diag?.streamingFinalPath == "fallback_batch")
+    #expect(diag?.stopWhileDecodeInFlight == true)
   }
 
   @Test("streaming OFF + locked: no streaming session, clean batch")


### PR DESCRIPTION
Part of #1276 (Step 2, Ship 1). Closes #1309. Depends on PR-2 (#1313, merged).

## What ships
Measures requested-vs-effective streaming and why it degraded, so the auto-detect slice excluded from streaming can be sized on real data (Ship 2 prioritization). WhisperKit only; all fields absent for Parakeet; metadata only; omit-on-nil.

**New `asr.completed` properties** (mirrored into the lifecycle breadcrumb): `streaming_requested` (kernel capability-gate decision), `streaming_effective`, `streaming_degrade_reason` (none | disabled | auto_language | model_not_ready | flush_empty | flush_throw), `final_path` (streaming_flush | clean_batch | fallback_batch | failed), `streaming_decode_count`, `streaming_covered_sec`, `tail_decode_sec`, `max_unconfirmed_window_sec` (config echo), `stop_while_decode_in_flight`.

**Plumbing** per the adopted plan's named hops: adapter stamps effective-path facts into its diagnostics on every terminal path (a degraded flush preserves its WHOLE result so the batch fallback re-stamps every counter); kernel assembles requested (its own gate) + effective (diagnostics); wiring maps into ExecutionMetrics (additive optional Codable); TelemetryService carries the new optional params. The streaming session snapshots decode-in-flight at the STOP moment (adapter notifies pre-drain) so the field cannot undercount its own scenario.

## Validation
- Codex local review: 4 rounds → clean (r1: Parakeet leak + fallback signal drop; r2: fallback counters; r3: stop-moment snapshot — each fixed with a pinning test).
- `scripts/xcode-test.sh`: 2355 tests green, including the issue's named degrade case (requested=true, effective=false, reason=auto_language) across all five streaming routing-matrix tests.
- Live smoke on the dev build: streaming dictation PASS, flush telemetry line present.