### PR TITLE
fix(asr): make noteStopRequested async so the stop-moment snapshot actually runs (#1309 flake)

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
@@ -1,6 +1,5 @@
 import EnviousWisprCore
 import Foundation
-
 @preconcurrency import WhisperKit
 
 /// Opaque handle to a WhisperKit-backed incremental transcription session.
@@ -35,12 +34,15 @@ package protocol WhisperKitIncrementalSession: Sendable {
 
   /// #1309: the user's stop arrived — snapshot any telemetry that must
   /// reflect the STOP moment (the adapter drains feed tasks before calling
-  /// `finalize`, so state can change in between). Default no-op.
+  /// `finalize`, so state can change in between).
+  ///
+  /// Deliberately NO extension default: a defaulted async no-op plus a
+  /// synchronous conformer implementation lets a concrete-typed `await`
+  /// call resolve to the no-op instead of the conformer's method (Swift
+  /// prefers the async overload in async contexts), silently dropping the
+  /// snapshot — the #1309 flaky-test root cause. Conformers with nothing to
+  /// snapshot implement an explicit `async` no-op.
   func noteStopRequested() async
-}
-
-extension WhisperKitIncrementalSession {
-  package func noteStopRequested() async {}
 }
 
 // MARK: - Shared incremental-decode types (#1315: moved here when the

--- a/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
@@ -491,7 +491,11 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
     return (sumSquares / Float(samples.count)).squareRoot()
   }
 
-  package func noteStopRequested() {
+  // Keep `async`, exactly matching the protocol requirement — a synchronous
+  // signature here combined with any defaulted async overload silently skips
+  // the snapshot on concrete-typed calls (#1309 flaky-test root cause; see
+  // the requirement's doc in WhisperKitIncrementalSession.swift).
+  package func noteStopRequested() async {
     guard !stopSnapshotTaken else { return }
     stopSnapshotTaken = true
     stoppedMidDecode = loopDecodeInFlight

--- a/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
+++ b/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
@@ -131,7 +131,6 @@ actor StubWhisperKitBackend: WhisperKitBackendDriving {
     return observeLIDResult
   }
 
-
   func makeStreamingSession(options: TranscriptionOptions) async
     -> (any WhisperKitIncrementalSession)?
   {
@@ -187,6 +186,10 @@ actor StubIncrementalSession: WhisperKitIncrementalSession {
   ) async {
     startCount += 1
   }
+
+  // Explicit no-op — the protocol deliberately has no default (see
+  // `WhisperKitIncrementalSession.noteStopRequested` doc).
+  func noteStopRequested() async {}
 
   func finalize(
     finalSamples: [Float],


### PR DESCRIPTION
## Root cause (empirically proven)

Main's post-merge check went red twice on `stopSnapshotTakenAtStopMoment` (the #1309 telemetry test, ~1% flake). The happens-before chain in the test read airtight; an actor-side event trace found the real mechanism:

- The actor implemented the `async` protocol requirement `noteStopRequested()` with a **synchronous** method, while the protocol extension shipped a defaulted **async** no-op.
- A concrete-typed `await session.noteStopRequested()` (the test's shape) resolves to the extension's async no-op, NOT the actor's method — the snapshot never ran in ANY test run (trace: no snapshot entry, `stopSnapshotTaken=false` at finalize, in both passing and failing runs).
- The test therefore only ever exercised finalize's fallback capture, which races `release()` against finalize entry. Loop wins ~1% of the time → flag already cleared → telemetry false → red.
- **Production is unaffected**: the adapter calls through the existential (`any WhisperKitIncrementalSession`), which witness-dispatches to the real method (verified empirically in-repo with a trace on both dispatch shapes). Shipped telemetry was never wrong.

## Fix

1. Actor method signature exact-matches the requirement (`async`) — removes the overload split.
2. The extension default no-op is **deleted** — a defaulted async no-op next to a sync conformer implementation is the whole trap class; conformers now implement an explicit no-op (`StubIncrementalSession`).
3. No test changes needed: with the real method running, the snapshot is taken deterministically and the fallback race is never consulted.

## Validation

- Repro before fix: 1/100 and 1/300 hammer runs failed with probes confirming the decode WAS in flight at stop.
- After fix: **0/300** hammer runs; suite deterministic.
- `scripts/xcode-test.sh` green (2,336 tests).
- Local Codex code-diff review: clean, no actionable findings.
- Live UAT on the touched path (WhisperKit + streaming): clean 58-char transcript, pipeline 1.805s total, streaming flush + telemetry lines present in app.log. Founder's Parakeet setting restored (quit-write-relaunch, verified).

Updates #1309.