### PR TITLE
chore(build): reap orphaned dev llama-server helpers in build-dev-app.sh

### DIFF
--- a/scripts/build-dev-app.sh
+++ b/scripts/build-dev-app.sh
@@ -57,6 +57,26 @@ if [ -n "$(dev_pids)" ]; then
   exit 1
 fi
 
+# Reap dev llama-server helpers (EG-1 polish engines). Every dev app instance
+# was just quit, so any dev-bundle llama-server still alive here is an orphan
+# by construction — including servers whose worktree bundle was deleted after
+# a merge (the app's own crash sweep is exact-binary-path scoped, so no future
+# launch can ever reap those; 10 accumulated over one week of parallel
+# worktree sessions, each pinning the model in RAM — 2026-07-04). Scope by the
+# dev bundle path ("EnviousWispr Local.app/..."): prod runs from
+# /Applications/EnviousWispr.app and never matches. pgrep -f matches anywhere
+# in the command line, so verify argv[0] IS the helper binary before killing —
+# a sibling build's codesign invocation merely MENTIONING the path must
+# survive (same trap as the in-app sweep, #1271 seam review).
+dev_llama_pids() { pgrep -f "EnviousWispr Local.app/Contents/Resources/llama-server" 2>/dev/null || true; }
+for pid in $(dev_llama_pids); do
+  case "$(ps -o comm= -p "$pid" 2>/dev/null || true)" in
+    *"EnviousWispr Local.app/Contents/Resources/llama-server")
+      kill -TERM "$pid" 2>/dev/null || true
+      echo "    reaped orphaned dev llama-server (pid $pid)" ;;
+  esac
+done
+
 # ─── Step 3: Generate the Xcode project (gitignored, never committed) ─────────
 echo "==> Step 3: Generating Xcode project (Tuist)..."
 mise x tuist@4.195.11 -- tuist generate --no-open


### PR DESCRIPTION
## What

Dev-tooling only (nothing users receive). Adds an orphan sweep to Step 2 of the dev build script: after quitting every dev app instance, kill any dev-bundle `llama-server` (EG-1 polish engine) still alive — at that point each one is an orphan by construction.

## Why

The in-app crash sweep is exact-binary-path scoped — correct for users (the app always lives at one path) but blind to our dev flow: each worktree's bundle has a unique path, and deleting a merged worktree strands its helper forever. 10 orphans had accumulated over a week of parallel worktree sessions, each pinning the EG-1 model in RAM.

## Safety

- Scoped to the dev bundle path (`EnviousWispr Local.app/...`); prod runs from /Applications and never matches.
- argv[0] is verified to BE the helper binary before killing, so a command line merely mentioning the path (a sibling build's codesign) is never hit — same anchoring discipline as the in-app sweep (#1271 seam review).

## Validation

- `bash -n` clean; positive case proven against the live helper (correct identity match).
- Full script run end-to-end: reaped the stale helper at Step 2, relaunched app spawned exactly one fresh helper.
- Local Codex review: clean, no findings (independently verified the process-identity semantics).