### PR TITLE
fix(llm): drain cancelled EG-1 download before a retry reuses the partial

### DIFF
--- a/Sources/EnviousWisprLLM/EGOne/EGOneModelStore.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneModelStore.swift
@@ -46,6 +46,14 @@ public actor EGOneModelStore {
   /// publish its terminal state over a retry's live state nor clear the
   /// retry's task handle.
   private var downloadGeneration = 0
+  /// The most recently cancelled/superseded download task, possibly still
+  /// draining its URLSession delegate queue (#1287): its `ChunkAppendDelegate`
+  /// may deliver late `didReceive` appends to the shared `.partial` until
+  /// `didCompleteWithError` fires. The next `startDownload` awaits this task's
+  /// completion before touching the partial — task completion IS the drain
+  /// signal (the delegate's continuation resumes only on terminal completion,
+  /// and `fetchArtifact`'s defer then closes the handle).
+  private var drainingTask: Task<Void, Never>?
   private(set) var state: InstallState = .notInstalled
   /// Progress callback for the UI facade (set once by `EGOneRuntime`).
   private var onStateChange: (@Sendable (InstallState) -> Void)?
@@ -113,6 +121,9 @@ public actor EGOneModelStore {
   public func removeModel() throws {
     downloadGeneration += 1
     downloadTask?.cancel()
+    // Guarded stash (#1287): a nil downloadTask (double-cancel, self-cleared
+    // task) must not clobber a predecessor that is still draining.
+    if let live = downloadTask { drainingTask = live }
     downloadTask = nil
     let fm = FileManager.default
     for url in [installedArtifactURL, installedManifestURL, tempArtifactURL, resumeIdentityURL] {
@@ -147,7 +158,27 @@ public actor EGOneModelStore {
     }
     downloadGeneration += 1
     let generation = downloadGeneration
+    let drain = drainingTask
+    drainingTask = nil
+    // Publish BEFORE the drain wait (#1287): the user gets an instant
+    // progress card with a live Cancel button. Without this, a slow or
+    // wedged drain leaves the failed card up while single-flight silently
+    // rejects every further Try Again tap — a dead button.
+    transition(to: .downloading(fractionCompleted: existingFraction()), ifGeneration: generation)
     downloadTask = Task { [weak self] in
+      if let drain {
+        await AppLogger.shared.log(
+          "EG-1 retry waiting for cancelled download to drain", level: .debug, category: "LLM")
+        let waitStart = ContinuousClock.now
+        // Drain barrier (#1287): the predecessor's task finishes only after
+        // its delegate delivered terminal completion (no further didReceive
+        // possible) and its partial-file handle closed. Signal-based; no
+        // timer — Cancel stays live during the wait via the publish above.
+        await drain.value
+        await AppLogger.shared.log(
+          "EG-1 drain wait finished in \(ContinuousClock.now - waitStart)",
+          level: .debug, category: "LLM")
+      }
       await self?.runDownload(generation: generation)
       await self?.clearTask(generation: generation)
     }
@@ -157,6 +188,8 @@ public actor EGOneModelStore {
   public func cancelDownload() {
     downloadGeneration += 1
     downloadTask?.cancel()
+    // Guarded stash (#1287): see removeModel.
+    if let live = downloadTask { drainingTask = live }
     downloadTask = nil
     // `.verifying` is INCLUDED (#1271 matrix gap 2): the cancelled task's
     // own `.failed(.cancelled)` transition is generation-suppressed, so
@@ -173,6 +206,11 @@ public actor EGOneModelStore {
     guard generation == downloadGeneration else { return }
     downloadTask = nil
   }
+
+  /// Test seams for the drain gate (#1287). `internal`, house pattern
+  /// alongside `verifyAndInstall` / `applyDownloadProgress`.
+  func seedDrainingTaskForTest(_ task: Task<Void, Never>) { drainingTask = task }
+  var hasPendingDrainForTest: Bool { drainingTask != nil }
 
   /// State publication gate for download-task transitions: a stale task
   /// (cancelled, superseded by a retry) may not publish.
@@ -193,6 +231,11 @@ public actor EGOneModelStore {
   }
 
   private func runDownload(generation: Int) async {
+    // Post-drain staleness stop (#1287): a retry cancelled, superseded, or
+    // removed while it awaited the predecessor's drain must not touch disk —
+    // without this it would recreate the directory/partial and open a
+    // network fetch whose state is then silently generation-suppressed.
+    guard generation == downloadGeneration else { return }
     do {
       try FileManager.default.createDirectory(
         at: directory, withIntermediateDirectories: true)

--- a/Tests/EnviousWisprTests/LLM/EGOneModelStoreTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneModelStoreTests.swift
@@ -352,6 +352,163 @@ struct EGOneModelStoreTests {
     #expect(state == .installed(version: "v1"))
   }
 
+  // MARK: - Cancel→retry drain gate (#1287 / #1279)
+
+  /// Poll the actor state to a terminal value (house pattern:
+  /// `completePartialInstallsWithoutNetwork`).
+  private func awaitTerminalState(
+    _ store: EGOneModelStore, sourceLocation: SourceLocation = #_sourceLocation
+  ) async throws -> EGOneModelStore.InstallState {
+    var state = await store.state
+    for _ in 0..<100 {
+      if case .installed = state { return state }
+      if case .failed = state { return state }
+      try await Task.sleep(for: .milliseconds(50))  // settle: poll actor state to terminal
+      state = await store.state
+    }
+    return state
+  }
+
+  /// Thread-safe state-sequence recorder for observer-ordering assertions.
+  /// `@unchecked Sendable`: all mutation behind the NSLock.
+  final class StateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _states: [EGOneModelStore.InstallState] = []
+    func add(_ s: EGOneModelStore.InstallState) {
+      lock.lock()
+      _states.append(s)
+      lock.unlock()
+    }
+    var states: [EGOneModelStore.InstallState] {
+      lock.lock()
+      defer { lock.unlock() }
+      return _states
+    }
+    var downloadingCount: Int {
+      states.reduce(0) { count, s in
+        if case .downloading = s { return count + 1 }
+        return count
+      }
+    }
+  }
+
+  /// The invariant is EXCLUSION while a cancelled predecessor drains: the
+  /// accepted retry publishes `.downloading` once at acceptance (instant
+  /// Cancel, no dead Try Again button) and its download body must not run —
+  /// observable as the ABSENCE of the body's own `.downloading` re-publish,
+  /// which is cheap synchronous actor work and lands within a few yields
+  /// whenever the body (incorrectly) starts. Negative-control validated:
+  /// removing the drain await flips `downloadingCount` to 2 inside the
+  /// yield window.
+  @Test func retryWaitsForPriorDrainBeforeTouchingPartial() async throws {
+    let content = Data("model-bytes-drain-gate".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    let partial = dir.appendingPathComponent("\(manifest.artifactFileName).partial")
+    try content.write(to: partial)
+
+    let recorder = StateRecorder()
+    await store.setStateObserver { recorder.add($0) }  // fires once with .notInstalled
+    // Pre-warm the shared logger: the download body's first suspension is a
+    // log call, and first-time logger init would otherwise stretch the
+    // un-gated body's latency past the absence window below, masking a
+    // missing gate (found via negative control).
+    await AppLogger.shared.log("drain-gate test warm-up", level: .debug, category: "LLM")
+
+    // Held predecessor: finishes only when the stream is finished.
+    let (releases, releaseCont) = AsyncStream.makeStream(of: Void.self)
+    let drain = Task { for await _ in releases {} }
+    await store.seedDrainingTaskForTest(drain)
+
+    let accepted = await store.startDownload()
+    #expect(accepted == true)
+    // Pre-drain publish: instant progress state (complete partial → 1.0).
+    #expect(await store.state == .downloading(fractionCompleted: 1.0))
+    #expect(recorder.downloadingCount == 1)
+
+    // Absence window in which an un-gated body would re-publish
+    // `.downloading` and begin mutating disk (~ms with the logger warm).
+    for _ in 0..<200 { await Task.yield() }
+    try await Task.sleep(for: .milliseconds(150))  // settle: absence-of-effect window for the gated body
+    #expect(
+      recorder.downloadingCount == 1,
+      "download body must not run while the drain is held (no re-publish)")
+    #expect(
+      try Data(contentsOf: partial) == content, "partial bytes must be untouched while drain held")
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: dir.appendingPathComponent(manifest.artifactFileName).path),
+      "no install may happen behind a held drain")
+
+    releaseCont.finish()
+    let terminal = try await awaitTerminalState(store)
+    #expect(terminal == .installed(version: "v1"))
+    #expect(recorder.downloadingCount >= 2, "released body re-publishes and completes")
+  }
+
+  /// Cancel must stash the live task as the drain (single-flight reopens
+  /// only through the gate), and a double-cancel must NOT clobber the stash
+  /// with nil — cancel → cancel → Try Again would otherwise reopen the race.
+  @Test func cancelStashesLiveTaskAsDrainAndDoubleCancelKeepsIt() async throws {
+    let content = Data("model-bytes-stash".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    try content.write(to: dir.appendingPathComponent("\(manifest.artifactFileName).partial"))
+
+    let (releases, releaseCont) = AsyncStream.makeStream(of: Void.self)
+    let drain = Task { for await _ in releases {} }
+    await store.seedDrainingTaskForTest(drain)
+
+    // T1 is accepted and blocks awaiting the held drain — a live download task.
+    #expect(await store.startDownload() == true)
+    await store.cancelDownload()
+    #expect(await store.hasPendingDrainForTest == true, "cancel stashes the live task")
+    #expect(await store.state == .failed(.cancelled))
+
+    await store.cancelDownload()  // double-cancel
+    #expect(await store.hasPendingDrainForTest == true, "nil task must not clobber the stash")
+
+    // Retry is accepted and chains behind the whole drain lineage.
+    #expect(await store.startDownload() == true)
+    #expect(await store.hasPendingDrainForTest == false, "retry consumed the drain slot")
+    releaseCont.finish()
+    let terminal = try await awaitTerminalState(store)
+    #expect(terminal == .installed(version: "v1"))
+  }
+
+  /// A retry that was cancelled AND whose files were removed while it
+  /// awaited the drain must never touch disk afterwards: no recreated
+  /// `.partial`, no `.resume.json`, state stays `.notInstalled`.
+  @Test func staleRetryNeverTouchesDiskAfterGenerationBump() async throws {
+    let content = Data("model-bytes-stale-retry".utf8)
+    let (store, manifest, dir) = try Self.makeFixture(content: content)
+    let partial = dir.appendingPathComponent("\(manifest.artifactFileName).partial")
+    let identity = dir.appendingPathComponent("\(manifest.artifactFileName).resume.json")
+    try content.write(to: partial)
+
+    let (releases, releaseCont) = AsyncStream.makeStream(of: Void.self)
+    let drain = Task { for await _ in releases {} }
+    await store.seedDrainingTaskForTest(drain)
+    await AppLogger.shared.log("stale-retry test warm-up", level: .debug, category: "LLM")
+
+    #expect(await store.startDownload() == true)  // T1 awaits the held drain
+    try await store.removeModel()  // bumps generation, deletes files
+    #expect(await store.state == .notInstalled)
+
+    releaseCont.finish()  // T1 unblocks — its staleness stop must return
+    // Absence window: an un-guarded stale body's first disk mutation
+    // (partial re-creation in fetchArtifact) is synchronous actor work right
+    // after the drain resumes, so this settle discriminates. Negative-control
+    // validated: removing the staleness stop recreates the partial here.
+    for _ in 0..<200 { await Task.yield() }
+    try await Task.sleep(for: .milliseconds(100))  // settle: absence-of-effect window for the stale retry
+    #expect(
+      !FileManager.default.fileExists(atPath: partial.path),
+      "stale retry must not recreate the partial")
+    #expect(
+      !FileManager.default.fileExists(atPath: identity.path),
+      "stale retry must not write resume identity")
+    #expect(await store.state == .notInstalled)
+  }
+
   // MARK: - Download-completion keyed off the request flag (#1271 Codex r17)
 
   /// `.installed` re-emissions from refreshes (launch, activation, settings


### PR DESCRIPTION
## What

Cancel then immediate Try Again on the EG-1 model download could let the cancelled URLSession's serial delegate queue append late chunks into the same `.partial` file the retry had already reopened — interleaved bytes, checksum failure, and the cleanup deleted ~2.7 GB of saved progress. First-run download is the front door for the EG-1 launch; cancel/retry on flaky Wi-Fi is exactly the surge crowd's behavior.

## Fix (all inside `EGOneModelStore`'s existing task lifecycle)

- `cancelDownload()` / `removeModel()` stash the live task as `drainingTask` (guarded: a nil task never clobbers a pending drain on double-cancel)
- `startDownload()` publishes `.downloading(existingFraction)` at acceptance (instant progress card + live Cancel; no dead Try Again button while draining) and the new task awaits `drain.value` before running — task completion IS the drain signal (delegate continuation resumes only on terminal completion, then the handle closes)
- `runDownload()` gains a post-drain staleness stop so a retry cancelled/superseded/removed during the wait never touches disk
- Debug AppLogger lines around the drain wait (field-diagnosable). No timer escape by design (`timeout-numbers-need-distribution-evidence`): with the pre-drain publish, a wedged drain presents as a stalled download with a live Cancel.

## Review trail

Plan council (GPT + Gemini) → Codex grounded review ×3 → PROCEED-AS-PLANNED (`docs/audits/2026-07-04-1287-grounded-review-r{1,2,3}.txt`). Local `codex review` on the diff: clean, no findings.

## Validation

- 3 new tests, each proven by negative control (protection removed → test fails); full suite 2,339 green via `scripts/xcode-test.sh`
- Live UAT on the dev build against the production host: removed the installed model, real 2.7 GB download, same-second Cancel→Try Again at 15% and at 40% — both resumed (440 MB and 1.17 GB preserved), drain-wait log lines present, SHA-256 verified install at exact size, EG-1 server healthy, dictation polished end-to-end in 0.82 s

Closes #1287
Closes #1279