### PR TITLE
fix(llm): unified polish readiness for Ollama — instant surfaced skip, no phantom model

### DIFF
--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -106,6 +106,15 @@ final class PipelineSettingsSync {
     }
   }
 
+  /// #1305: whether a `.llmModel` change should mirror into `ollamaModel` (the
+  /// remembered Ollama preference). "" means "nothing armed" — discovery found
+  /// no installed models — and must never overwrite the remembered preference,
+  /// which powers the Download-suggestion copy in Settings. Non-empty picks
+  /// mirror exactly as before. Pure + static so it is directly unit-testable.
+  static func shouldMirrorLLMModelToOllama(provider: LLMProvider, llmModel: String) -> Bool {
+    provider == .ollama && !llmModel.isEmpty
+  }
+
   /// Handle a settings change by forwarding to the appropriate subsystem.
   func handleSettingChanged(_ key: SettingsManager.SettingKey, settings: SettingsManager) {
     switch key {
@@ -125,7 +134,9 @@ final class PipelineSettingsSync {
       // #1271: EG-1 server follows the provider selection live.
       reconcileEGOneActivation(settings: settings)
     case .llmModel:
-      if settings.llmProvider == .ollama {
+      if Self.shouldMirrorLLMModelToOllama(
+        provider: settings.llmProvider, llmModel: settings.llmModel)
+      {
         settings.ollamaModel = settings.llmModel
       }
       reconcileOllamaEviction(settings: settings)

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -198,8 +198,11 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       language: result.language ?? Self.lockedLanguage(recovered.settings?.languageMode),
       duration: recoveredSeconds,
       backendType: result.backendType,
-      llmProvider: recovered.settings?.llmProvider,
-      llmModel: recovered.settings?.llmModel,
+      // #1305: stamp provider/model ONLY when polish actually produced output —
+      // the live path never stamps on a failed/skipped polish, and the settings
+      // snapshot would otherwise label a raw recovered transcript AI-polished.
+      llmProvider: textOutcome.polishedText != nil ? recovered.settings?.llmProvider : nil,
+      llmModel: textOutcome.polishedText != nil ? recovered.settings?.llmModel : nil,
       recoverySessionID: id,
       isRecovered: true)
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -1292,7 +1292,16 @@ struct AIPolishSettingsView: View {
             }
           } else if entry.isDownloaded {
             Button {
-              setup.ollamaSetup.deleteModel(name: entry.name)
+              // #1305: sequence delete → discovery refresh so the model picker
+              // (and the armed selection, via applyDiscoveredModels) never
+              // keeps showing a model that no longer exists. The Task outlives
+              // a dismissed view harmlessly — discovery targets app-owned
+              // coordinators.
+              Task {
+                await setup.ollamaSetup.deleteModel(name: entry.name)
+                await llmDiscovery.validateKeyAndDiscoverModels(
+                  provider: .ollama, settings: settings)
+              }
             } label: {
               Text("Delete")
                 .foregroundStyle(.stError)

--- a/Sources/EnviousWisprLLM/LLMProtocol.swift
+++ b/Sources/EnviousWisprLLM/LLMProtocol.swift
@@ -189,6 +189,15 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
   /// `LLMRetryPolicy` (the connector already performs the single
   /// connection-refused retry that covers the restart-once window).
   case egOneSkipped(EGOneSkipReason)
+  /// #1305: the Ollama readiness preflight found local polish not usable —
+  /// server down (`.providerUnreachable`) or armed model not installed
+  /// (`.modelUnavailable`). Thrown by the `LLMPolishStep` entry gate BEFORE any
+  /// polisher construction or connector retry loop. Semantics: a SURFACED SKIP,
+  /// the third class between Failure and Bypass — `polishedText` nil, no
+  /// provider stamp, user notice YES (skipped tone, pinned copy in
+  /// `PolishFailureReason.ollamaPreflightSkipMessage`), Sentry capture NO,
+  /// PostHog `llm.polish_skipped` YES. Non-retryable by `LLMRetryPolicy`.
+  case localPolishNotReady(PolishFailureReason)
   /// A cloud/Ollama polish failure carrying its specific classified reason
   /// (#945). The single adapter that threads the rich `PolishFailureReason`
   /// catalog through the existing `throws LLMError` contract: connectors throw
@@ -218,6 +227,11 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
     case .egOneSkipped(let reason):
       // Silent bypass — never an on-screen notice; log/debug reads only.
       return "EG-1 polish skipped (\(reason.rawValue))."
+    case .localPolishNotReady(let reason):
+      // Surfaced skip (#1305) — the on-screen notice is the pinned copy in
+      // `PolishFailureReason.ollamaPreflightSkipMessage`, composed by the
+      // runner. This generic description exists only for logs.
+      return "Local polish not ready (\(reason.telemetryTag))."
     case .classified(let reason):
       // The user-facing, provider-specific notice is composed by the runner via
       // `reason.composedMessage(provider:)`. This generic description exists only
@@ -243,6 +257,8 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
     case (.outputLanguageDrift(let le, let la), .outputLanguageDrift(let re, let ra)):
       return le == re && la == ra
     case (.egOneSkipped(let a), .egOneSkipped(let b)):
+      return a == b
+    case (.localPolishNotReady(let a), .localPolishNotReady(let b)):
       return a == b
     case (.classified(let a), .classified(let b)):
       return a == b

--- a/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
+++ b/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
@@ -26,6 +26,12 @@ enum LLMRetryPolicy {
         // window already happened inside `EGOneConnector`. Retrying here
         // would stack retries and delay the raw-text fallback.
         return false
+      case .localPolishNotReady:
+        // EXPLICIT (#1305): the Ollama preflight found the server down or the
+        // model missing BEFORE any attempt started. Retrying would reintroduce
+        // the doomed-wait the preflight exists to remove; the next dictation
+        // re-probes fresh.
+        return false
       default: return false
       }
     }

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -19,6 +19,21 @@ public struct OllamaEvictOutcome: Sendable {
   }
 }
 
+/// #1305: the instant answer to "is an Ollama polish attempt worth starting?"
+/// Returned by `OllamaConnector.preflightReadiness(model:)`; consumed by the
+/// polish-entry gate in `LLMPolishStep`. Per-attempt truth — callers must NOT
+/// cache it across dictations (the user can quit/start Ollama at any time).
+public enum OllamaReadiness: Sendable, Equatable {
+  /// Server responded and the tags list contains the model — attempt polish.
+  case ready
+  /// Transport error, timeout, non-2xx, or unparseable body — "Ollama is not
+  /// responding" class.
+  case serverDown
+  /// Server responded with a parsed tags list that has no canonical match for
+  /// the model (or the model string is empty — nothing armed).
+  case modelMissing
+}
+
 /// Ollama local LLM connector. Uses Ollama's native /api/chat endpoint
 /// for access to `think`, `keep_alive`, and timing telemetry.
 /// Requires Ollama to be running: https://ollama.com
@@ -171,6 +186,79 @@ public struct OllamaConnector: TranscriptPolisher {
       polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
         .strippingLLMPreamble()
     )
+  }
+
+  // MARK: - Readiness Preflight (#1305)
+
+  /// Dedicated session for the readiness probe: ephemeral, 1.0s request AND
+  /// resource timeouts. Separate from `LLMNetworkSession` so a probe against a
+  /// down server can never occupy or reconfigure the polish session, and so the
+  /// probe's aggressive timeout never leaks into real polish requests.
+  private static let readinessSession: URLSession = {
+    let config = URLSessionConfiguration.ephemeral
+    config.timeoutIntervalForRequest = 1.0
+    config.timeoutIntervalForResource = 1.0
+    return URLSession(configuration: config)
+  }()
+
+  /// One GET /api/tags on this connector's `baseURL` (the same base the polish
+  /// request uses, so probe truth cannot diverge from request truth), answering
+  /// the three-state readiness question. Localhost-only by construction — the
+  /// probe never touches any external host.
+  ///
+  /// Never throws and performs no retries: every transport failure, timeout,
+  /// non-2xx, and unparseable body maps to `.serverDown`. The session timeouts
+  /// bound the request; `withDeadline` is the absolute wall-clock net on top so
+  /// a socket-accept wedge cannot hang the caller past ~1s either.
+  ///
+  /// `executor`/`deadlineSeconds` are test seams (deterministic classification
+  /// + deadline behavior without a live server); production callers use the
+  /// defaults.
+  public func preflightReadiness(
+    model: String,
+    executor: (@Sendable (URLRequest) async throws -> (Data, URLResponse))? = nil,
+    deadlineSeconds: Double = 1.0
+  ) async -> OllamaReadiness {
+    // Empty model string → nothing armed → modelMissing by definition,
+    // without spending a network round trip.
+    guard !model.isEmpty else { return .modelMissing }
+    guard let url = URL(string: "\(baseURL)/api/tags") else { return .serverDown }
+    var mutableRequest = URLRequest(url: url)
+    mutableRequest.httpMethod = "GET"
+    let request = mutableRequest  // immutable copy for the @Sendable closure below
+    let transport = executor ?? { try await Self.readinessSession.data(for: $0) }
+    let outcome = await withDeadline(seconds: deadlineSeconds) { () -> OllamaReadiness in
+      do {
+        let (data, response) = try await transport(request)
+        return Self.classifyReadiness(data: data, response: response, model: model)
+      } catch {
+        return .serverDown
+      }
+    }
+    // Deadline elapsed with no answer — the server is wedged, treat as down.
+    return outcome ?? .serverDown
+  }
+
+  /// Pure response → readiness classifier (#1305). Membership uses
+  /// `OllamaSetupService.canonicalModelName` (equates `llama2` and
+  /// `llama2:latest`), never raw string equality. Unit-testable without
+  /// network mocking, mirroring `classify(statusCode:bodyString:)` below.
+  static func classifyReadiness(
+    data: Data, response: URLResponse, model: String
+  ) -> OllamaReadiness {
+    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+      return .serverDown
+    }
+    guard
+      let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+      let models = json["models"] as? [[String: Any]]
+    else {
+      return .serverDown
+    }
+    let target = OllamaSetupService.canonicalModelName(model)
+    let installed = models.compactMap { $0["name"] as? String }
+      .map(OllamaSetupService.canonicalModelName)
+    return installed.contains(target) ? .ready : .modelMissing
   }
 
   // MARK: - Eviction (#295)

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -501,38 +501,48 @@ public final class OllamaSetupService {
   }
 
   /// Delete a model by name via DELETE /api/delete.
-  public func deleteModel(name: String) {
-    Task {
-      guard let url = URL(string: "\(Self.baseURL)/api/delete") else { return }
-      let body: [String: Any] = ["model": name]
-      var request = URLRequest(url: url)
-      request.httpMethod = "DELETE"
-      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-      request.httpBody = try? JSONSerialization.data(withJSONObject: body)
-      request.timeoutInterval = 30
+  ///
+  /// #1305: `async` (was fire-and-forget inside its own Task) — returns after
+  /// the server delete + `downloadedModels` mutation complete, so the delete
+  /// button can sequence a discovery refresh on completion and the picker never
+  /// disagrees with reality. Still never throws: errors remain swallow-and-log,
+  /// so callers that don't sequence behave exactly as before. `transport` is a
+  /// test seam (mirrors `OllamaConnector.networkExecutor`, #901) so the
+  /// mutation-before-return contract is assertable without a live server.
+  public func deleteModel(
+    name: String,
+    transport: (@Sendable (URLRequest) async throws -> (Data, URLResponse))? = nil
+  ) async {
+    guard let url = URL(string: "\(Self.baseURL)/api/delete") else { return }
+    let body: [String: Any] = ["model": name]
+    var request = URLRequest(url: url)
+    request.httpMethod = "DELETE"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+    request.timeoutInterval = 30
 
-      do {
-        let (_, response) = try await URLSession.shared.data(for: request)
-        if let http = response as? HTTPURLResponse, http.statusCode == 200 {
-          downloadedModels.removeAll(where: { $0.exactName == name })
-          // Reset warm-up if the deleted model was warmed or warming
-          let canonical = Self.canonicalModelName(name)
-          switch warmupState {
-          case .warm(let m, _) where m == canonical,
-            .warming(let m) where m == canonical:
-            resetWarmup()
-          default:
-            break
-          }
-          // If current model was deleted, update setup state
-          if downloadedModels.isEmpty {
-            setupState = .runningNoModels
-            UserDefaults.standard.set(false, forKey: Self.lastKnownStateKey)
-          }
+    let send = transport ?? { try await URLSession.shared.data(for: $0) }
+    do {
+      let (_, response) = try await send(request)
+      if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+        downloadedModels.removeAll(where: { $0.exactName == name })
+        // Reset warm-up if the deleted model was warmed or warming
+        let canonical = Self.canonicalModelName(name)
+        switch warmupState {
+        case .warm(let m, _) where m == canonical,
+          .warming(let m) where m == canonical:
+          resetWarmup()
+        default:
+          break
         }
-      } catch {
-        // Silently ignore delete errors -- user can try again
+        // If current model was deleted, update setup state
+        if downloadedModels.isEmpty {
+          setupState = .runningNoModels
+          UserDefaults.standard.set(false, forKey: Self.lastKnownStateKey)
+        }
       }
+    } catch {
+      // Silently ignore delete errors -- user can try again
     }
   }
 

--- a/Sources/EnviousWisprLLM/PolishFailureReason.swift
+++ b/Sources/EnviousWisprLLM/PolishFailureReason.swift
@@ -163,6 +163,38 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
     "\(leadIn.text) \(message(provider: provider))"
   }
 
+  /// #1305: the pinned surfaced-skip notice for the Ollama readiness PREFLIGHT
+  /// path only (server down / model missing found before any attempt started).
+  /// Nil for every other reason. Deliberately distinct from the mid-flight
+  /// `composedMessage` copy: at preflight time no attempt failed, so the tone
+  /// is the skip lead-in (which `isSkipNotice` and the completion planner
+  /// already recognize), and the "no model is installed" wording never implies
+  /// a visible selection the picker may honestly not show. Mid-flight failures
+  /// on a running server keep today's `composedMessage(provider:)` copy.
+  public var ollamaPreflightSkipMessage: String? {
+    switch self {
+    case .providerUnreachable:
+      return "\(LeadIn.skipped.text) Ollama isn't running. Start it in Settings → AI Polish."
+    case .modelUnavailable:
+      return
+        "\(LeadIn.skipped.text) no model is installed in Ollama. Download one in Settings → AI Polish."
+    default:
+      return nil
+    }
+  }
+
+  /// #1305: the `llm.polish_skipped` reason string for the Ollama preflight
+  /// path. Joins the existing `local_polish_` prefix family (EG-1's
+  /// `EGOneSkipReason`) so one analytics query prefix captures every local
+  /// polish skip mode. Content-free; nil for non-preflight reasons.
+  public var ollamaPreflightSkipTelemetryReason: String? {
+    switch self {
+    case .providerUnreachable: return "local_polish_ollama_server_down"
+    case .modelUnavailable: return "local_polish_ollama_model_missing"
+    default: return nil
+    }
+  }
+
   /// Whether a composed notice string represents a "skipped" (not-really-broken)
   /// outcome rather than a hard failure. Keyed off the single `LeadIn.skipped.text`
   /// constant that `composedMessage` also uses, so it can never drift from the
@@ -201,6 +233,10 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
         return .modelUnavailable
       case .requestFailed(let msg):
         return msg.contains("server error") ? .providerServerError : .badRequest
+      case .localPolishNotReady(let reason):
+        // #1305: the runner handles this case on its dedicated surfaced-skip
+        // arm before reaching here. Defensive unwrap for any other caller.
+        return reason
       case .frameworkUnavailable, .modelNotReady,
         .unsupportedInputLanguage, .outputLanguageDrift, .egOneSkipped:
         // Silent-skip cases the runner never routes here (AFM is excluded;

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -83,6 +83,15 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     EGOneConnector(endpoint: $0)
   }
 
+  /// #1305 test seam (mirrors `makeEGOnePolisher`): the Ollama readiness
+  /// preflight consulted by the `.ollama` entry gate in `process()`.
+  /// Production probes the real connector (one GET /api/tags on the same base
+  /// URL polish would use, ~1s hard ceiling); tests inject a fixed answer so
+  /// the gate is exercised without a live server.
+  var ollamaReadinessProbe: @MainActor (String) async -> OllamaReadiness = { model in
+    await OllamaConnector().preflightReadiness(model: model)
+  }
+
   /// Holds the app-owned output-safety classifier (#832/#913 PR8). Read LAZILY
   /// at polish time (not at build time) so the value set after async prewarm is
   /// picked up by the next polish. Nil for standalone callsites without one.
@@ -235,6 +244,26 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
         "LLM polish requested: provider=\(provider.rawValue), model=\(model)",
         level: .verbose, category: "LLM"
       )
+    }
+
+    // #1305: Ollama readiness preflight — mirror of the `.egOne` gate below,
+    // sitting exactly where "a polish attempt for this provider is about to
+    // start" is knowable and BEFORE any polisher construction or connector
+    // retry loop. Not-ready is a SURFACED SKIP (notice yes, Sentry no —
+    // TextProcessingRunner owns that policy), so the user gets raw text
+    // essentially instantly instead of ~4s of doomed retries (#1305 root
+    // symptom). The probe uses the entry-snapshot `model`, so a mid-polish
+    // settings change cannot tear it; the answer is per-attempt truth, never
+    // cached across dictations.
+    if provider == .ollama {
+      switch await ollamaReadinessProbe(model) {
+      case .ready:
+        break
+      case .serverDown:
+        throw LLMError.localPolishNotReady(.providerUnreachable)
+      case .modelMissing:
+        throw LLMError.localPolishNotReady(.modelUnavailable)
+      }
     }
 
     // #1271: EG-1 resolves its polisher from the live server endpoint, not

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -171,6 +171,22 @@ internal final class TextProcessingRunner {
         // raw deterministically-cleaned text ships, no "AI polish failed".
         // Cloud-provider timeouts still surface (transient network signal).
         let isEGOnePolishTimeout = isTimeout && polishProviderAtStart == .egOne
+        // #1305: the Ollama readiness preflight found local polish not usable
+        // (server down / model missing) BEFORE any attempt started. This is
+        // the third, SURFACED-SKIP class between Failure and Bypass: user
+        // notice YES (pinned skipped-tone copy), Sentry capture NO (an
+        // expected, non-crashing state the user can sit in for hours —
+        // per-dictation error events would flood the tracker without signal),
+        // PostHog `llm.polish_skipped` YES. Mid-flight failures on a running
+        // server (post-preflight races, 5xx) keep the full surfaced-failure
+        // path below. Locked by the adversarial tests in
+        // TextProcessingRunnerCaptureTests.
+        var localPolishSkipReason: PolishFailureReason?
+        if let llmError = error as? LLMError,
+          case .localPolishNotReady(let notReady) = llmError
+        {
+          localPolishSkipReason = notReady
+        }
         let reason: String
         if isAppleIntelligencePolishTimeout {
           reason =
@@ -182,6 +198,8 @@ internal final class TextProcessingRunner {
           reason = "timed out"
         } else if let cw = contextWindowSkip {
           reason = "skipped: too long for on-device AI polish (\(cw.stage.rawValue))"
+        } else if let notReady = localPolishSkipReason {
+          reason = "skipped: Ollama polish not ready (\(notReady.telemetryTag)), using raw text"
         } else {
           reason = "failed: \(error.localizedDescription)"
         }
@@ -227,7 +245,14 @@ internal final class TextProcessingRunner {
         // `CancellationError` is already short-circuited above
         // (`catch is CancellationError`); this covers the URL-loading variant.
         let isCancellationLike = (error as? URLError)?.code == .cancelled
-        if step.errorSurfacePolicy == .surface && !isSilentPolishSkip
+        if step.errorSurfacePolicy == .surface, let skipReason = localPolishSkipReason {
+          // #1305 surfaced skip: set the pinned skipped-tone notice, fire NO
+          // Sentry capture (that is the point of the class). The composed
+          // fallback covers a defensive future reason without pinned copy.
+          polishError =
+            skipReason.ollamaPreflightSkipMessage
+            ?? skipReason.composedMessage(provider: .ollama)
+        } else if step.errorSurfacePolicy == .surface && !isSilentPolishSkip
           && contextWindowSkip == nil && !isAppleIntelligencePolishTimeout
           && !isEGOnePolishTimeout
           && !isCancellationLike
@@ -291,6 +316,13 @@ internal final class TextProcessingRunner {
         } else if let egOneSkipReason {
           TelemetryService.shared.polishSkipped(
             provider: LLMProvider.egOne.rawValue, reason: egOneSkipReason)
+        } else if let skipReason = localPolishSkipReason?.ollamaPreflightSkipTelemetryReason {
+          // #1305: preflight skips ride the same lightweight `local_polish_`
+          // reason family as EG-1 — the observability split between "preflight
+          // said not ready" (here) and "mid-flight failure on a running
+          // server" (the capture path above) falls out of the reason strings.
+          TelemetryService.shared.polishSkipped(
+            provider: LLMProvider.ollama.rawValue, reason: skipReason)
         }
         // #657 (2026-05-05): emit cap-trip telemetry when WordCorrectionStep
         // exceeds its 3s `maxDuration`. The step's result was discarded; raw

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -146,7 +146,15 @@ public final class SettingsManager {
       llmModel = "apple-intelligence"
     case .egOne:
       llmModel = LLMProvider.egOneModelName
-    case .openAI, .gemini, .ollama, .none:
+    case .ollama:
+      // #1305: empty stays empty for Ollama — refilling from `ollamaModel`
+      // here silently re-armed the phantom picker selection at every launch
+      // after discovery had cleared it. Only discovery and an explicit user
+      // pick may arm an Ollama model; fixed literals still get swept.
+      if fixedLiterals.contains(llmModel) {
+        llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
+      }
+    case .openAI, .gemini, .none:
       if fixedLiterals.contains(llmModel) || llmModel.isEmpty {
         llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
       }
@@ -748,7 +756,23 @@ public final class SettingsManager {
     isApplyingSystemWrite = true
     defer { isApplyingSystemWrite = false }
     if models.isEmpty {
-      llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
+      // #1305: for Ollama, empty discovery means NOTHING is installed — arming
+      // the remembered `ollamaModel` name here was the root cause of the
+      // phantom-model bug (a picker selection and dictation model no /api/tags
+      // list contains). "" is the explicit "nothing armed" state the picker
+      // already renders as "No models found". `ollamaModel` (the remembered
+      // preference) DELIBERATELY stays untouched — it powers the
+      // Download-suggestion copy, and although `effectiveLLMModel` keeps
+      // returning it for dictation configs, every polish attempt is guarded by
+      // the readiness preflight in `LLMPolishStep` (the stale name probes as
+      // model-missing and skips instantly); dictation-time truth is owned by
+      // that gate, not by clearing this field. Cloud providers keep the
+      // default-fill (their catalogs are never legitimately empty; an empty
+      // result is a discovery hiccup).
+      llmModel =
+        llmProvider == .ollama
+        ? ""
+        : LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
       return
     }
     if !models.contains(where: { $0.id == llmModel && $0.isAvailable }) {

--- a/Tests/EnviousWisprTests/App/PipelineSettingsSyncMirrorGuardTests.swift
+++ b/Tests/EnviousWisprTests/App/PipelineSettingsSyncMirrorGuardTests.swift
@@ -1,0 +1,35 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1305: the `.llmModel` → `ollamaModel` mirror decision. "" means "nothing
+/// armed" (empty discovery cleared the picker) and must never wipe the
+/// remembered `ollamaModel` preference; non-empty picks mirror as before.
+/// The decision is a pure static on `PipelineSettingsSync` because the full
+/// sync home needs live kernel drivers a unit test cannot construct.
+@MainActor
+@Suite("PipelineSettingsSync llmModel mirror guard (#1305)")
+struct PipelineSettingsSyncMirrorGuardTests {
+
+  @Test("a non-empty ollama pick mirrors")
+  func nonEmptyOllamaPickMirrors() {
+    #expect(
+      PipelineSettingsSync.shouldMirrorLLMModelToOllama(provider: .ollama, llmModel: "mistral"))
+  }
+
+  @Test("an empty llmModel (nothing armed) never mirrors")
+  func emptyNeverMirrors() {
+    #expect(
+      !PipelineSettingsSync.shouldMirrorLLMModelToOllama(provider: .ollama, llmModel: ""))
+  }
+
+  @Test("non-ollama providers never mirror, empty or not")
+  func nonOllamaNeverMirrors() {
+    #expect(
+      !PipelineSettingsSync.shouldMirrorLLMModelToOllama(provider: .openAI, llmModel: "gpt-4o"))
+    #expect(
+      !PipelineSettingsSync.shouldMirrorLLMModelToOllama(provider: .none, llmModel: ""))
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/OllamaReadinessPreflightTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaReadinessPreflightTests.swift
@@ -1,0 +1,213 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #1305: the `OllamaConnector.preflightReadiness` probe — response
+/// classification (pure), transport-failure mapping, the empty-model
+/// short-circuit, the absolute deadline net, and the surfaced-skip catalog
+/// entries (pinned copy + telemetry reasons + retry policy).
+@Suite("Ollama readiness preflight (#1305)")
+struct OllamaReadinessPreflightTests {
+
+  // MARK: - Fixtures
+
+  private func tagsBody(_ names: [String]) -> Data {
+    let payload: [String: Any] = ["models": names.map { ["name": $0] }]
+    return try! JSONSerialization.data(withJSONObject: payload)
+  }
+
+  private func http(_ status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: URL(string: "http://localhost:11434/api/tags")!,
+      statusCode: status, httpVersion: nil, headerFields: nil)!
+  }
+
+  // MARK: - Pure classification
+
+  @Test("2xx with an exact tags match is ready")
+  func exactMatchReady() {
+    let readiness = OllamaConnector.classifyReadiness(
+      data: tagsBody(["llama3.2", "mistral"]), response: http(200), model: "llama3.2")
+    #expect(readiness == .ready)
+  }
+
+  @Test("canonical matching equates llama2 and llama2:latest in BOTH directions")
+  func latestCanonicalization() {
+    // Installed with :latest, armed without.
+    #expect(
+      OllamaConnector.classifyReadiness(
+        data: tagsBody(["llama2:latest"]), response: http(200), model: "llama2") == .ready)
+    // Installed without, armed with :latest.
+    #expect(
+      OllamaConnector.classifyReadiness(
+        data: tagsBody(["llama2"]), response: http(200), model: "llama2:latest") == .ready)
+    // A NON-latest tag is a different model — must not loosely match.
+    #expect(
+      OllamaConnector.classifyReadiness(
+        data: tagsBody(["llama3.2:1b"]), response: http(200), model: "llama3.2") == .modelMissing)
+  }
+
+  @Test("2xx with a parsed list and no match is modelMissing")
+  func noMatchIsModelMissing() {
+    let readiness = OllamaConnector.classifyReadiness(
+      data: tagsBody(["mistral"]), response: http(200), model: "llama3.2")
+    #expect(readiness == .modelMissing)
+  }
+
+  @Test("2xx with an EMPTY installed list is modelMissing")
+  func emptyListIsModelMissing() {
+    let readiness = OllamaConnector.classifyReadiness(
+      data: tagsBody([]), response: http(200), model: "llama3.2")
+    #expect(readiness == .modelMissing)
+  }
+
+  @Test("non-2xx is serverDown, even with a valid-looking body")
+  func non2xxIsServerDown() {
+    let readiness = OllamaConnector.classifyReadiness(
+      data: tagsBody(["llama3.2"]), response: http(500), model: "llama3.2")
+    #expect(readiness == .serverDown)
+  }
+
+  @Test("unparseable JSON is serverDown, not modelMissing")
+  func invalidJSONIsServerDown() {
+    let readiness = OllamaConnector.classifyReadiness(
+      data: Data("not json".utf8), response: http(200), model: "llama3.2")
+    #expect(readiness == .serverDown)
+  }
+
+  @Test("a 2xx body without a models array is serverDown")
+  func missingModelsKeyIsServerDown() {
+    let body = try! JSONSerialization.data(withJSONObject: ["error": "weird"])
+    let readiness = OllamaConnector.classifyReadiness(
+      data: body, response: http(200), model: "llama3.2")
+    #expect(readiness == .serverDown)
+  }
+
+  // MARK: - Probe wrapper
+
+  @Test("empty model is modelMissing WITHOUT any network call")
+  func emptyModelShortCircuits() async {
+    let connector = OllamaConnector()
+    let readiness = await connector.preflightReadiness(
+      model: "",
+      executor: { _ in
+        Issue.record("the empty-model guard must not reach the network")
+        throw URLError(.badURL)
+      })
+    #expect(readiness == .modelMissing)
+  }
+
+  @Test("a transport error (connection refused) maps to serverDown")
+  func transportErrorIsServerDown() async {
+    let connector = OllamaConnector()
+    let readiness = await connector.preflightReadiness(
+      model: "llama3.2",
+      executor: { _ in throw URLError(.cannotConnectToHost) })
+    #expect(readiness == .serverDown)
+  }
+
+  @Test("a request timeout maps to serverDown")
+  func timeoutErrorIsServerDown() async {
+    let connector = OllamaConnector()
+    let readiness = await connector.preflightReadiness(
+      model: "llama3.2",
+      executor: { _ in throw URLError(.timedOut) })
+    #expect(readiness == .serverDown)
+  }
+
+  @Test("the absolute deadline abandons a wedged transport and reports serverDown")
+  func deadlineNetCatchesWedge() async {
+    let connector = OllamaConnector()
+    // The transport hangs far past the (shrunk) deadline: the probe must
+    // answer serverDown at the deadline instead of waiting the transport out.
+    // The test awaits the probe's RETURN — the deadline firing is the signal;
+    // the sleep below is the simulated wedge it must abandon, never awaited.
+    let readiness = await connector.preflightReadiness(
+      model: "llama3.2",
+      executor: { _ in
+        // settle: simulated wedged socket the deadline under test must abandon
+        try await Task.sleep(for: .seconds(30))
+        throw URLError(.timedOut)
+      },
+      deadlineSeconds: 0.05)
+    #expect(readiness == .serverDown)
+  }
+
+  @Test("the probe answers from the transport's data, end to end")
+  func probeEndToEnd() async {
+    let connector = OllamaConnector()
+    let body = tagsBody(["gemma3n:e4b"])
+    let response = http(200)
+    let ready = await connector.preflightReadiness(
+      model: "gemma3n:e4b", executor: { _ in (body, response) })
+    #expect(ready == .ready)
+
+    let missing = await connector.preflightReadiness(
+      model: "llama3.2", executor: { _ in (body, response) })
+    #expect(missing == .modelMissing)
+  }
+
+  // MARK: - Surfaced-skip catalog entries
+
+  @Test("the pinned preflight skip copy is exact and reads as a skip notice")
+  func pinnedCopy() {
+    let serverDown = PolishFailureReason.providerUnreachable.ollamaPreflightSkipMessage
+    #expect(
+      serverDown == "AI cleanup skipped: Ollama isn't running. Start it in Settings → AI Polish.")
+    let modelMissing = PolishFailureReason.modelUnavailable.ollamaPreflightSkipMessage
+    #expect(
+      modelMissing
+        == "AI cleanup skipped: no model is installed in Ollama. Download one in Settings → AI Polish."
+    )
+    // Both must carry the skip lead-in the completion planner keys off.
+    #expect(PolishFailureReason.isSkipNotice(serverDown ?? "") == true)
+    #expect(PolishFailureReason.isSkipNotice(modelMissing ?? "") == true)
+  }
+
+  @Test("non-preflight reasons have NO preflight copy or telemetry reason")
+  func nonPreflightReasonsAreNil() {
+    for reason in PolishFailureReason.allCases
+    where reason != .providerUnreachable && reason != .modelUnavailable {
+      #expect(reason.ollamaPreflightSkipMessage == nil)
+      #expect(reason.ollamaPreflightSkipTelemetryReason == nil)
+    }
+  }
+
+  @Test("preflight telemetry reasons join the local_polish_ family")
+  func telemetryReasons() {
+    #expect(
+      PolishFailureReason.providerUnreachable.ollamaPreflightSkipTelemetryReason
+        == "local_polish_ollama_server_down")
+    #expect(
+      PolishFailureReason.modelUnavailable.ollamaPreflightSkipTelemetryReason
+        == "local_polish_ollama_model_missing")
+  }
+
+  @Test("localPolishNotReady is explicitly non-retryable")
+  func notReadyIsNotRetryable() {
+    #expect(!LLMRetryPolicy.isRetryable(LLMError.localPolishNotReady(.providerUnreachable)))
+    #expect(!LLMRetryPolicy.isRetryable(LLMError.localPolishNotReady(.modelUnavailable)))
+  }
+
+  @Test("localPolishNotReady equality compares the carried reason")
+  func notReadyEquatable() {
+    #expect(
+      LLMError.localPolishNotReady(.providerUnreachable)
+        == LLMError.localPolishNotReady(.providerUnreachable))
+    #expect(
+      LLMError.localPolishNotReady(.providerUnreachable)
+        != LLMError.localPolishNotReady(.modelUnavailable))
+  }
+
+  @Test("PolishFailureReason.from unwraps localPolishNotReady defensively")
+  func fromUnwrapsNotReady() {
+    #expect(
+      PolishFailureReason.from(LLMError.localPolishNotReady(.providerUnreachable))
+        == .providerUnreachable)
+    #expect(
+      PolishFailureReason.from(LLMError.localPolishNotReady(.modelUnavailable))
+        == .modelUnavailable)
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/OllamaSetupServiceDeleteTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaSetupServiceDeleteTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #1305: `deleteModel` is now `async` and its contract is
+/// mutation-before-return — the delete button sequences a discovery refresh on
+/// the await, so all state consequences (list removal, setup-state flip) must
+/// be applied by the time the call returns. The injected transport mirrors the
+/// `OllamaConnector.networkExecutor` seam (#901).
+@MainActor
+@Suite("OllamaSetupService async delete (#1305)")
+struct OllamaSetupServiceDeleteTests {
+
+  private func okTransport() -> @Sendable (URLRequest) async throws -> (Data, URLResponse) {
+    { request in
+      (
+        Data(),
+        HTTPURLResponse(
+          url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+      )
+    }
+  }
+
+  @Test("a 200 delete applies its state mutations BEFORE the await returns")
+  func mutationCompletesBeforeReturn() async {
+    let service = OllamaSetupService()
+
+    await service.deleteModel(name: "llama3.2", transport: okTransport())
+
+    // With no models left, deleteModel flips the setup state synchronously in
+    // its own body. Observing the flip immediately after the await IS the
+    // sequencing contract: a caller can safely refresh discovery next.
+    #expect(service.setupState == .runningNoModels)
+  }
+
+  @Test("a transport failure returns without mutating state (swallow-and-log, no hang)")
+  func transportFailureSwallowed() async {
+    let service = OllamaSetupService()
+
+    await service.deleteModel(
+      name: "llama3.2", transport: { _ in throw URLError(.cannotConnectToHost) })
+
+    #expect(service.setupState == .detecting)  // untouched initial state
+  }
+
+  @Test("a non-200 delete response mutates nothing")
+  func non200Ignored() async {
+    let service = OllamaSetupService()
+
+    await service.deleteModel(
+      name: "llama3.2",
+      transport: { request in
+        (
+          Data(),
+          HTTPURLResponse(
+            url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+        )
+      })
+
+    #expect(service.setupState == .detecting)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
@@ -146,6 +146,9 @@ struct EGOnePipelineRoutingTests {
     let step = LLMPolishStep(keychainManager: KeychainManager())
     step.llmProvider = .ollama
     step.llmModel = "llama3.2"
+    // #1305: report ready so this stays a MID-FLIGHT surfacing test (the
+    // preflight gate would otherwise intercept, and would probe a real socket).
+    step.ollamaReadinessProbe = { _ in .ready }
     struct Down: TranscriptPolisher {
       func polish(
         text: String, instructions: PolishInstructions, config: LLMProviderConfig,

--- a/Tests/EnviousWisprTests/Pipeline/OllamaReadinessGateTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/OllamaReadinessGateTests.swift
@@ -1,0 +1,241 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1305: the Ollama readiness preflight gate in `LLMPolishStep.process()` and
+/// the runner's SURFACED-SKIP handling of its throw. The gate must fire before
+/// any polisher construction (zero connector invocations on a not-ready
+/// answer), and the runner must treat `localPolishNotReady` as the third class
+/// between Failure and Bypass: user notice YES (pinned skipped-tone copy),
+/// Sentry capture NO, `llm.polish_skipped` YES. These sit alongside the
+/// silent-set locks in `TextProcessingRunnerTests` and the surfaced-failure
+/// locks in `TextProcessingRunnerCaptureTests` so no arm can silently regress.
+@MainActor
+@Suite("Ollama readiness gate (#1305)")
+struct OllamaReadinessGateTests {
+
+  /// Clears the polish step's <=3-word short-circuit so the gate is reached.
+  private static let longTranscript =
+    "quick email to the ethics committee chair subject revised protocol requesting review"
+
+  /// Polisher that records invocations; the gate contract is that it is never
+  /// constructed (factory never called), let alone invoked, on a not-ready probe.
+  private struct CannedPolisher: TranscriptPolisher {
+    func polish(
+      text: String,
+      instructions: PolishInstructions,
+      config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      LLMResult(polishedText: "Quick email to the ethics committee chair about it.")
+    }
+  }
+
+  private func makeStep(
+    probe: @escaping @MainActor (String) async -> OllamaReadiness
+  ) -> (step: LLMPolishStep, factoryCalls: () -> Int) {
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .ollama
+    step.llmModel = "llama3.2"
+    step.ollamaReadinessProbe = probe
+    let counter = Counter()
+    step.makePolisher = { _, _, _ in
+      counter.value += 1
+      return CannedPolisher()
+    }
+    return (step, { counter.value })
+  }
+
+  @MainActor
+  private final class Counter {
+    var value = 0
+  }
+
+  private func context(_ text: String = longTranscript) -> TextProcessingContext {
+    TextProcessingContext(text: text, language: "en")
+  }
+
+  // MARK: - Gate behavior (step level)
+
+  @Test("serverDown throws localPolishNotReady(.providerUnreachable) with ZERO connector work")
+  func serverDownThrowsBeforeAnyPolisher() async {
+    var probeCalls = 0
+    let (step, factoryCalls) = makeStep(probe: { _ in
+      probeCalls += 1
+      return .serverDown
+    })
+
+    await #expect(throws: LLMError.localPolishNotReady(.providerUnreachable)) {
+      _ = try await step.process(context())
+    }
+    #expect(probeCalls == 1)
+    // The whole point of the preflight: no polisher, no request, no retry loop.
+    #expect(factoryCalls() == 0)
+  }
+
+  @Test("modelMissing throws localPolishNotReady(.modelUnavailable) with ZERO connector work")
+  func modelMissingThrowsBeforeAnyPolisher() async {
+    let (step, factoryCalls) = makeStep(probe: { _ in .modelMissing })
+
+    await #expect(throws: LLMError.localPolishNotReady(.modelUnavailable)) {
+      _ = try await step.process(context())
+    }
+    #expect(factoryCalls() == 0)
+  }
+
+  @Test("ready proceeds to the polisher exactly as before")
+  func readyProceedsToPolisher() async throws {
+    let (step, factoryCalls) = makeStep(probe: { _ in .ready })
+
+    let result = try await step.process(context())
+
+    #expect(factoryCalls() == 1)
+    #expect(result.polishedText != nil)
+    #expect(result.llmProvider == "ollama")
+  }
+
+  @Test("the probe receives the entry-snapshot model")
+  func probeReceivesSnapshotModel() async throws {
+    var probedModel: String?
+    let (step, _) = makeStep(probe: { model in
+      probedModel = model
+      return .ready
+    })
+    step.llmModel = "gemma3n:e4b"
+
+    _ = try await step.process(context())
+
+    #expect(probedModel == "gemma3n:e4b")
+  }
+
+  @Test("non-Ollama providers never consult the probe")
+  func nonOllamaProvidersSkipProbe() async throws {
+    var probeCalls = 0
+    let (step, _) = makeStep(probe: { _ in
+      probeCalls += 1
+      return .serverDown
+    })
+    step.llmProvider = .openAI
+    step.llmModel = "gpt-4o-mini"
+
+    _ = try? await step.process(context())
+
+    #expect(probeCalls == 0)
+  }
+
+  @Test("the too-short bypass short-circuits before the probe runs")
+  func tooShortBypassPrecedesProbe() async throws {
+    var probeCalls = 0
+    let (step, factoryCalls) = makeStep(probe: { _ in
+      probeCalls += 1
+      return .serverDown
+    })
+
+    let result = try await step.process(context("just two words"))
+
+    #expect(probeCalls == 0)
+    #expect(factoryCalls() == 0)
+    #expect(result.polishedText == nil)
+  }
+
+  // MARK: - Runner surfaced-skip contract (notice YES, Sentry NO, telemetry YES)
+
+  /// Records every runner Sentry capture (same shape as
+  /// `TextProcessingRunnerCaptureTests.CaptureSpy`).
+  @MainActor
+  private final class CaptureSpy {
+    private(set) var count = 0
+    func sink(
+      _ error: any Error, _ category: SentryBreadcrumb.ErrorCategory,
+      _ stage: String, _ extra: [String: Any]?, _ tags: [String: String],
+      _ fingerprintDetail: String?
+    ) {
+      count += 1
+    }
+  }
+
+  private func runThroughRunner(
+    probe: @escaping @MainActor (String) async -> OllamaReadiness,
+    spy: CaptureSpy
+  ) async throws -> TextProcessingRunResult {
+    let (step, _) = makeStep(probe: probe)
+    let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
+    let runner = TextProcessingRunner(captureError: spy.sink, timeoutExecutor: executor.run)
+    return try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+  }
+
+  @Test("server down -> pinned skipped-tone notice, raw text, NO Sentry capture")
+  func serverDownSurfacedSkip() async throws {
+    let spy = CaptureSpy()
+
+    let result = try await runThroughRunner(probe: { _ in .serverDown }, spy: spy)
+
+    #expect(
+      result.polishError
+        == "AI cleanup skipped: Ollama isn't running. Start it in Settings → AI Polish.")
+    // The completion planner must read this as a skip, not a hard failure —
+    // the "Polish failed" overlay is keyed off this exact predicate.
+    #expect(PolishFailureReason.isSkipNotice(result.polishError ?? "") == true)
+    #expect(result.context.polishedText == nil)
+    #expect(result.context.llmProvider == nil)
+    #expect(result.context.text == Self.longTranscript)
+    // Adversarial lock: an expected not-ready state fires NO Sentry error.
+    #expect(spy.count == 0)
+  }
+
+  @Test("model missing -> pinned skipped-tone notice, raw text, NO Sentry capture")
+  func modelMissingSurfacedSkip() async throws {
+    let spy = CaptureSpy()
+
+    let result = try await runThroughRunner(probe: { _ in .modelMissing }, spy: spy)
+
+    #expect(
+      result.polishError
+        == "AI cleanup skipped: no model is installed in Ollama. Download one in Settings → AI Polish."
+    )
+    #expect(PolishFailureReason.isSkipNotice(result.polishError ?? "") == true)
+    #expect(result.context.polishedText == nil)
+    #expect(spy.count == 0)
+  }
+
+  // testEventHook is DEBUG-only (CI also compiles tests in release); the skip
+  // telemetry assertions are DEBUG-gated like DualModePolishTelemetryTests.
+  #if DEBUG
+    @Test("server down emits llm.polish_skipped with local_polish_ollama_server_down")
+    func serverDownEmitsSkipTelemetry() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+      let spy = CaptureSpy()
+
+      _ = try await runThroughRunner(probe: { _ in .serverDown }, spy: spy)
+
+      let event = try await waiter.waitForEvent(named: "llm.polish_skipped")
+      #expect(event.stringProps["provider"] == "ollama")
+      #expect(event.stringProps["skip_reason"] == "local_polish_ollama_server_down")
+    }
+
+    @Test("model missing emits llm.polish_skipped with local_polish_ollama_model_missing")
+    func modelMissingEmitsSkipTelemetry() async throws {
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+      let spy = CaptureSpy()
+
+      _ = try await runThroughRunner(probe: { _ in .modelMissing }, spy: spy)
+
+      let event = try await waiter.waitForEvent(named: "llm.polish_skipped")
+      #expect(event.stringProps["provider"] == "ollama")
+      #expect(event.stringProps["skip_reason"] == "local_polish_ollama_model_missing")
+    }
+  #endif
+}

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
@@ -70,6 +70,10 @@ struct TextProcessingRunnerCaptureTests {
     step.llmProvider = provider
     step.llmModel = model
     step.makePolisher = { _, _, _ in ThrowingPolisher(makeError: makeError) }
+    // #1305: the .ollama entry gate consults a readiness probe before the
+    // polisher. These are MID-FLIGHT-path tests (failure on a running server),
+    // so the probe reports ready — and never touches a real network.
+    step.ollamaReadinessProbe = { _ in .ready }
     return step
   }
 

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -217,4 +217,23 @@ struct RecoverySpoolReplayerTests {
     #expect(h.asr.transcribeCallCount == 0, "no transcribe runs after Discard during load")
     #expect(h.transcriptCoordinator.transcripts.isEmpty)
   }
+
+  @Test("a recovered transcript with NO polish output carries no provider/model stamp (#1305)")
+  func nilPolishCarriesNoProviderStamp() async throws {
+    // The snapshot's llmProvider/llmModel describe what was CONFIGURED at
+    // record time, not what ran. This spool's snapshot disables polish
+    // (provider "none"), so `polishedText` is nil — the saved transcript must
+    // not be labeled with any provider, matching the live path's
+    // no-stamp-on-skip contract. Pre-#1305 the replayer stamped the snapshot
+    // values unconditionally.
+    let h = Self.makeHarness()
+    let id = "stamp-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.3, 0.2])
+    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    #expect(outcome == .recovered)
+    let saved = try #require(h.transcriptCoordinator.transcripts.first)
+    #expect(saved.polishedText == nil)
+    #expect(saved.llmProvider == nil)
+    #expect(saved.llmModel == nil)
+  }
 }

--- a/Tests/EnviousWisprTests/Services/SettingsManagerOllamaTruthTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsManagerOllamaTruthTests.swift
@@ -1,0 +1,133 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1305: settings truth for the Ollama model fields. The picker's `llmModel`
+/// may never be armed to a model the installed list does not contain — empty
+/// discovery clears it (was: refilled the remembered phantom, the #1305 root
+/// cause), launch-time canonicalization leaves "" alone, and the remembered
+/// `ollamaModel` preference survives both (it powers the Download-suggestion
+/// copy).
+@MainActor
+@Suite("SettingsManager Ollama model truth (#1305)")
+struct SettingsManagerOllamaTruthTests {
+
+  private func freshSettings(seed: ((UserDefaults) -> Void)? = nil) -> SettingsManager {
+    let suite = UserDefaults(suiteName: "SM-1305-\(UUID().uuidString)")!
+    seed?(suite)
+    return SettingsManager(defaults: suite)
+  }
+
+  private func model(_ id: String, available: Bool = true) -> LLMModelInfo {
+    LLMModelInfo(id: id, displayName: id, provider: .ollama, isAvailable: available)
+  }
+
+  // MARK: - Empty discovery (the root-cause fix)
+
+  @Test("ollama empty discovery clears llmModel and preserves ollamaModel")
+  func emptyDiscoveryClears() {
+    let settings = freshSettings()
+    settings.llmProvider = .ollama
+    settings.llmModel = "llama2:latest"  // the Baltimore phantom
+    settings.ollamaModel = "llama2:latest"
+
+    settings.applyDiscoveredModels([], for: .ollama)
+
+    #expect(settings.llmModel == "")
+    // The remembered preference stays — it drives the Download-button copy.
+    #expect(settings.ollamaModel == "llama2:latest")
+  }
+
+  @Test("cloud empty discovery keeps the provider default (unchanged behavior)")
+  func cloudEmptyDiscoveryKeepsDefault() {
+    let settings = freshSettings()
+    settings.llmProvider = .openAI
+
+    settings.applyDiscoveredModels([], for: .openAI)
+
+    #expect(settings.llmModel == LLMProvider.defaultModel(for: .openAI))
+    #expect(!settings.llmModel.isEmpty)
+  }
+
+  @Test("stale empty discovery for a switched-away provider is dropped")
+  func staleEmptyDiscoveryDropped() {
+    let settings = freshSettings()
+    settings.llmProvider = .openAI
+    let before = settings.llmModel
+
+    settings.applyDiscoveredModels([], for: .ollama)
+
+    #expect(settings.llmModel == before)
+  }
+
+  // MARK: - Armed-model-deleted, others remain (characterization of :754-758)
+
+  @Test("armed model missing from discovery auto-selects the first available and mirrors it")
+  func armedMissingAutoSelectsFirst() {
+    let settings = freshSettings()
+    settings.llmProvider = .ollama
+    settings.llmModel = "deleted-model"
+    settings.ollamaModel = "deleted-model"
+
+    settings.applyDiscoveredModels([model("mistral"), model("phi3")], for: .ollama)
+
+    #expect(settings.llmModel == "mistral")
+    #expect(settings.ollamaModel == "mistral")
+  }
+
+  @Test("an armed model present in discovery is left alone")
+  func armedPresentUntouched() {
+    let settings = freshSettings()
+    settings.llmProvider = .ollama
+    settings.llmModel = "phi3"
+    settings.ollamaModel = "phi3"
+
+    settings.applyDiscoveredModels([model("mistral"), model("phi3")], for: .ollama)
+
+    #expect(settings.llmModel == "phi3")
+    #expect(settings.ollamaModel == "phi3")
+  }
+
+  // MARK: - Launch-time canonicalization
+
+  @Test("a persisted empty llmModel stays empty at launch under ollama")
+  func persistedEmptyStaysEmpty() {
+    let settings = freshSettings { suite in
+      suite.set("ollama", forKey: "llmProvider")
+      suite.set("", forKey: "llmModel")
+      suite.set("llama3.2", forKey: "ollamaModel")
+    }
+
+    // Pre-#1305, init's canonicalize pass refilled "" from ollamaModel,
+    // silently re-arming the phantom the last discovery pass had cleared.
+    #expect(settings.llmProvider == .ollama)
+    #expect(settings.llmModel == "")
+    #expect(settings.ollamaModel == "llama3.2")
+  }
+
+  @Test("a persisted fixed literal is still swept at launch under ollama")
+  func fixedLiteralStillSwept() {
+    let settings = freshSettings { suite in
+      suite.set("ollama", forKey: "llmProvider")
+      suite.set("apple-intelligence", forKey: "llmModel")
+      suite.set("llama3.2", forKey: "ollamaModel")
+    }
+
+    // The fixed-literal sweep (#1271 r7) must survive the empty-stays-empty
+    // change: an AFM literal leaking into the ollama slot is still repaired
+    // from the remembered preference.
+    #expect(settings.llmModel == "llama3.2")
+  }
+
+  @Test("cloud providers still refill an empty llmModel at launch (unchanged)")
+  func cloudEmptyRefilledAtLaunch() {
+    let settings = freshSettings { suite in
+      suite.set("openAI", forKey: "llmProvider")
+      suite.set("", forKey: "llmModel")
+    }
+
+    #expect(settings.llmModel == LLMProvider.defaultModel(for: .openAI))
+  }
+}


### PR DESCRIPTION
Closes #1305

## What

When Local (Ollama) polish is selected but not usable — server not running, or the armed model not installed — the app previously spent ~4s in doomed retries behind a "Polishing…" overlay, silently armed a remembered model that isn't installed (the root cause), and kept showing deleted models in the picker. This PR brings Ollama to readiness parity with the other four providers:

1. **Readiness preflight** (`LLMPolishStep` `.ollama` entry gate, mirroring the `.egOne` block): one GET `/api/tags` on the connector's own base URL, canonical-name matching, dedicated 1s-timeout ephemeral session inside a `withDeadline` net. Not ready throws the new `LLMError.localPolishNotReady` — a **surfaced skip** (third class between Failure and Bypass): pinned "AI cleanup skipped:" notice, NO Sentry capture, `llm.polish_skipped` reasons `local_polish_ollama_server_down` / `local_polish_ollama_model_missing`.
2. **Settings truth**: empty Ollama discovery clears `llmModel` to `""` (was: re-armed the phantom); launch canonicalization leaves empty empty; the `PipelineSettingsSync` mirror is guarded so `""` never wipes the remembered `ollamaModel` (which powers the Download-suggestion copy). Keeping `ollamaModel` is deliberate: dictation-time truth is owned by the preflight gate (rationale inline at the `applyDiscoveredModels` site).
3. **Delete refresh**: `deleteModel` is `async` (mutation-before-return) and the delete button sequences a discovery refresh — the picker auto-selects a remaining model or clears to "No models found", never a phantom.
4. **Ride-along**: recovery replay stamps `llmProvider`/`llmModel` only when polish produced output.

Plan: `docs/feature-requests/issue-1305-2026-07-04-unified-polish-readiness.md` (grounded review PROCEED-AS-PLANNED r4; Gate 2 approved 2026-07-04).

## Validation

- `scripts/xcode-test.sh` green (all suites incl. 5 new: readiness gate, probe classification, settings truth, mirror guard, async delete; + recovery stamping; adversarial notice-yes/Sentry-no locks).
- Local `codex review` clean (r2; r1's single finding — keep vs clear `ollamaModel` — validated against every consumer and dispositioned as the plan-pinned two-layer design, rationale now inline).
- Live UAT on the dev build (verdicts from `app.log` + shared-suite plist + `/api/tags`):
  - Server down: skip decided in 5.8ms, pipeline TOTAL **0.886s** (was 4.3-4.8s); picker keeps selection.
  - Model missing (the real Baltimore state, founder's own phantom): skip in 7.1ms, TOTAL 0.944s.
  - Delete armed model (2 installed): picker auto-selects the remaining model, both fields mirrored.
  - Delete last model: picker clears to "No models found", remembered preference preserved (Download button intact); dictation skips in 7.2ms, TOTAL 0.472s.
  - Regression: polish works via installed model; bare-name vs `:latest` canonical matching exercised live.
- Phase 3: `.validation/runs/2026-07-04T17-15-39Z-6a09193` PASS (Code lane).