### PR TITLE
chore(build): gitignore .repro-clips — no voice recordings in the public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ playwright-report/
 
 # Historical benchmark output — regenerable, untracked
 benchmark-results/
+# ASR bench corpus + repro clips: contains REAL founder voice recordings.
+# NEVER commit audio to this public repo (founder decision 2026-07-05, #1329).
+# Corpus lives local-only; nightly encrypted restic backup covers it.
+.repro-clips/
 test-results/
 .playwright-mcp/
 


### PR DESCRIPTION
Part of #1329.

**What:** adds `.repro-clips/` to `.gitignore` with an explanatory comment.

**Why:** the #1329 ASR benchmark corpus under `.repro-clips/` contains real founder voice recordings. Founder decision 2026-07-05: audio never lands in this public repo — a folder of voice recordings in a privacy-positioned dictation app's repo is both a privacy and an optics problem. The corpus stays local-only (the benchmark harness under `scripts/asr-bench/` is already gitignored / local-lane); durability is covered by the existing nightly encrypted restic backup of ~/Developer, verified today.

**Blast radius:** zero runtime impact; no CI, script, or source file references a tracked `.repro-clips` path (grep in commit body). Currently the directory is untracked (`??`), so this only prevents a future accidental `git add`.

council-skip: zero-blast-radius (single-value config or constant)