### PR TITLE
fix(asr): refresh FluidAudio fork onto upstream v0.15.4 with full EW carry (#1329 PR-2)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "edce5468ec44bca99eeb89a52750c8622bfe5b447913c7d8c06ee30b38883c9c",
+  "originHash" : "1e64e701c44afeabab312276102681de62de30bab71cbbfc9f54ba886bce8155",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -15,8 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/saurabhav88/FluidAudio.git",
       "state" : {
-        "branch" : "d5fcca4",
-        "revision" : "d5fcca4f7d72f8e22e988ee08a7caa0a914a0b4e"
+        "revision" : "e7948e1ac3e4eb0254201d19bb8496a4398c8476"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", from: "1.0.0"),
-    .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "d5fcca4"),
+    .package(url: "https://github.com/saurabhav88/FluidAudio.git", revision: "e7948e1ac3e4eb0254201d19bb8496a4398c8476"),
     .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
     .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -78,7 +78,8 @@ public actor ParakeetBackend: ASRBackend {
     ModelDownloadManager.verifyChecksum()
 
     let manager = AsrManager(config: .default)
-    try await manager.initialize(models: loadedModels)
+    // v0.15.4 API: initialize(models:) became loadModels(_:).
+    try await manager.loadModels(loadedModels)
     self.fluidAsrManager = manager
 
     isReady = true
@@ -90,7 +91,12 @@ public actor ParakeetBackend: ASRBackend {
     guard isReady, let manager = fluidAsrManager else { throw ASRError.notReady }
 
     let startTime = CFAbsoluteTimeGetCurrent()
-    let fluidResult = try await manager.transcribe(audioSamples, source: .microphone)
+    // v0.15.4 API: the caller owns decoder state (fresh per one-shot batch decode;
+    // upstream's ChunkProcessor also makes fresh state per chunk internally) and the
+    // `source:` parameter is gone. Language hint intentionally NOT passed in PR-2
+    // (parity with the d5fcca4 behavior); G7 language propagation ships in PR-4.
+    var decoderState = TdtDecoderState.make(decoderLayers: await manager.decoderLayerCount)
+    let fluidResult = try await manager.transcribe(audioSamples, decoderState: &decoderState)
     let elapsed = CFAbsoluteTimeGetCurrent() - startTime
 
     return ASRResult(
@@ -126,7 +132,9 @@ public actor ParakeetBackend: ASRBackend {
 
     let config = SlidingWindowAsrConfig.streaming
     let manager = SlidingWindowAsrManager(config: config)
-    try await manager.start(models: models, source: .microphone)
+    // v0.15.4 API: start(models:source:) split into loadModels(_:) + startStreaming(source:).
+    try await manager.loadModels(models)
+    try await manager.startStreaming(source: .microphone)
     self.streamingManager = manager
     self.streamingStartTime = CFAbsoluteTimeGetCurrent()
   }


### PR DESCRIPTION
Part of #1329 (PR-2 of the 4-step plan; plan + Gate 2 approval on the issue).

## What

Bumps the pinned FluidAudio fork d5fcca4 → e7948e1a (`refresh/v0.15.4` = upstream v0.15.4 + 4 reviewed fork commits: CTC/rescorer constants carry, #1237 empty-chunk recovery re-port, fresh-decoder-state streaming + chunk-text assembly carry, CLI build fix). App-side change is 3 hunks in ParakeetBackend — v0.15.4 API drift only, parity by design (language hint deliberately not passed; G7 ships in PR-4).

## Evidence (full tables: docs/audits/2026-07-05-1329-pr1-baseline.md, PR-2 section — local-lane)

- **Batch (G6 fence): PASS with speed wins.** Artifact counts equal in every category; worst-clip WER improved (#1099 tail incident 20%→12% — the carried recovery fires; verified on the incident clip); finalize 1871→1009ms at 5min, 490→261ms at 90-120s (upstream parallel worker pool).
- **Streaming: no-worse fence PASS.** Quality equal-or-better every bucket vs baseline; protected categories all green (single-word "test", leading-silence 0.5/2.0s, soft onset, pause-resume, intentional repeats). clip1/clip3 seam artifacts reproduce IDENTICALLY to baseline — deliberate parity; their fix is PR-3/PR-4 per plan.
- **PR-2 founder checkpoint answer: upstream did NOT heal streaming** (as-is it loses 12-28% of words at length — 327 seam deletions on a 5.2-min exact-truth clip). PR-3 bake-off is required.
- Known non-issue: a 2.1-2.4s finalize appears ONLY on the corpus clip that repeats its own text 2x (dedup-cost canary, documented in the manifest); the non-repeating 398s real-voice composite finalizes in 80-92ms.
- Carried-value note: `defaultMinCombinedConfidence` is currently inert in v0.15.4's `evaluateCTCMatch` path (upstream #634 rework) — carried for config parity, documented in the fork review.

## Reviews

- Fork diff (fork repo, branch `refresh/v0.15.4`): 3 grounded rounds → **PROCEED-AS-PLANNED** (r1 all-PASS + 1 procedural item closed with a 10-point semantic comparison vs the old reviewed patch; r2 + r3 explicit passes). Fork suite 1830/0.
- App diff: local `codex-5.3-spark review` clean ("focused API migration, no functional regression").
- Cloud reviewer note: chatgpt-codex-connector is usage-capped until ~2026-07-06 22:00; the local spark rounds above are the compensating control per founder directive (2026-07-05).

## Validation

- `scripts/xcode-test.sh`: 2236 + 146 tests, 0 failures.
- Live UAT (debug dev build, both modes, log-verified per uat-verdicts-from-app-log): streaming — full raw transcript incl. tail words + known parity duplicate; batch — clip1 clean, tail present; single-word "test" captured in both modes; founder settings restored after.
- Bench: 23 clips × 2 modes × 3 runs, real-time paced, both fence runs archived under benchmark-results (run IDs in the audit doc).

Updates #1329.