### PR TITLE
content(website): two-tier polish positioning + EG-1 benchmark chart, fix hero-page drift

### DIFF
--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -585,7 +585,7 @@ const faqJsonLd = JSON.stringify({
       <div class="feat-card reveal">
         <div class="feat-icon">🌊</div>
         <div class="feat-title">Live transcription</div>
-        <p class="feat-desc">With the All Languages engine, watch your words appear live as you speak. The text lands almost the moment you stop, no matter how long you talked.</p>
+        <p class="feat-desc">With the All Languages engine, choose a language and your words appear live as you speak. Either way, the text lands almost the moment you stop, no matter how long you talked.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -582,11 +582,6 @@ const faqJsonLd = JSON.stringify({
         <div class="feat-title">Streaming pipeline</div>
         <p class="feat-desc">Recording, transcription, and AI polishing run in parallel. The result arrives almost the moment you stop speaking.</p>
       </div>
-      <div class="feat-card reveal">
-        <div class="feat-icon">🌊</div>
-        <div class="feat-title">Live transcription</div>
-        <p class="feat-desc">With the All Languages engine, choose a language and your words appear live as you speak. Either way, the text lands almost the moment you stop, no matter how long you talked.</p>
-      </div>
     </div>
   </div>
 </section>

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -44,7 +44,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr work without internet?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. All speech recognition runs on-device using Apple Silicon and the Parakeet or WhisperKit model. Your audio never leaves your Mac. AI polish is optional. The default polish provider is Apple Intelligence, which is also on-device on supported Macs. If you bring your own OpenAI or Gemini API key, only the transcribed text (not the audio) is sent to that provider for polishing."
+        "text": "Yes. All speech recognition runs on-device using Apple Silicon and the Parakeet or WhisperKit model. Your audio never leaves your Mac. AI polish is optional and can also run fully on-device: EG-1, our own model, on any supported Mac, or Apple Intelligence on macOS 26 and later. If you bring your own OpenAI or Gemini API key, only the transcribed text (not the audio) is sent to that provider for polishing."
       }
     },
     {
@@ -68,7 +68,7 @@ const faqJsonLd = JSON.stringify({
       "name": "What is the difference between push-to-talk and hands-free mode?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Push-to-talk means you hold a hotkey while speaking and release to transcribe. It is the default and the most precise mode. Hands-free mode listens continuously and transcribes when you pause. It is useful when typing is not an option, for example during accessibility-driven dictation or when both hands are occupied."
+        "text": "Push-to-talk means you hold a hotkey while speaking and release to transcribe. It is the default mode. Hands-free mode listens continuously and transcribes when you pause. It is useful when typing is not an option, for example during accessibility-driven dictation or when both hands are occupied."
       }
     },
     {
@@ -84,7 +84,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Which languages does EnviousWispr support?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "The default Parakeet engine handles English. Switching the backend to WhisperKit unlocks 90+ languages. Both run on-device on Apple Silicon."
+        "text": "The default Parakeet engine handles English. Switching the backend to WhisperKit supports 90+ languages. Both run on-device on Apple Silicon."
       }
     },
     {
@@ -214,6 +214,39 @@ const faqJsonLd = JSON.stringify({
 .stat-label { font-size: 13px; color: var(--text-2); font-weight: 500; }
 .stat-detail { font-size: 11px; color: var(--text-3); margin-top: 4px; }
 
+/* ── Choose Your Polish Engine ── */
+.engines-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; margin-bottom: 44px; }
+.engine-card { background: #fff; border: 1px solid var(--border-hover); border-radius: var(--radius-card); padding: 26px 22px; display: flex; flex-direction: column; transition: transform 0.2s, box-shadow 0.2s; }
+.engine-card:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(124,58,237,0.10); }
+.engine-card.featured { border-color: rgba(124,58,237,0.4); box-shadow: 0 0 0 1px rgba(124,58,237,0.15), 0 12px 40px rgba(124,58,237,0.10); }
+.engine-badge { display: inline-block; align-self: flex-start; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.6px; color: var(--text-3); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-pill); padding: 4px 10px; margin-bottom: 14px; }
+.engine-badge.accent { color: var(--accent); background: var(--accent-soft); border-color: rgba(124,58,237,0.3); }
+.engine-card h3 { font-size: 18px; font-weight: 700; letter-spacing: -0.4px; color: var(--text); margin-bottom: 8px; }
+.engine-card p { font-size: 14px; line-height: 1.6; color: var(--text-2); flex: 1; }
+.engine-meta { margin-top: 16px; font-size: 12px; color: var(--text-3); font-weight: 500; }
+
+.bench { background: var(--surface); border: 1px solid var(--border); border-radius: 20px; padding: 32px; }
+.bench-head { text-align: center; margin-bottom: 24px; }
+.bench-head h3 { font-size: 22px; font-weight: 700; letter-spacing: -0.5px; color: var(--text); margin-bottom: 8px; }
+.bench-head p { font-size: 14px; color: var(--text-2); max-width: 560px; margin: 0 auto; line-height: 1.6; }
+.bench-rows { display: flex; flex-direction: column; gap: 14px; max-width: 720px; margin: 0 auto; }
+.bench-row { display: grid; grid-template-columns: 190px 1fr 56px; align-items: center; gap: 14px; }
+.bench-label { font-size: 13px; font-weight: 600; color: var(--text); text-align: right; }
+.bench-tag { display: inline-block; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; color: var(--accent); background: var(--accent-soft); border-radius: var(--radius-pill); padding: 1px 6px; margin-left: 4px; vertical-align: middle; }
+.bench-tag.cloud { color: var(--text-3); background: var(--border); }
+.bench-track { height: 26px; background: rgba(124,58,237,0.06); border-radius: 8px; overflow: hidden; }
+.bench-bar { height: 100%; border-radius: 8px; background: linear-gradient(90deg, #4169e1, #7c3aed); }
+.bench-bar.eg1 { background: var(--rainbow-full); }
+.bench-val { font-family: var(--font-mono); font-size: 14px; font-weight: 700; color: var(--text); }
+.bench-note { text-align: center; font-size: 12px; color: var(--text-3); margin: 20px auto 0; line-height: 1.5; max-width: 620px; }
+@media (max-width: 900px) { .engines-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 600px) {
+  .engines-grid { grid-template-columns: 1fr; }
+  .bench { padding: 22px 16px; }
+  .bench-row { grid-template-columns: 96px 1fr 46px; gap: 8px; }
+  .bench-label { font-size: 11px; }
+}
+
 /* ── Features ── */
 .features-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
 .feat-card { background: #fff; border: 1px solid var(--border-hover); border-radius: var(--radius-card); padding: 28px 24px; transition: transform 0.2s, box-shadow 0.2s; }
@@ -294,7 +327,7 @@ const faqJsonLd = JSON.stringify({
         <div class="step-number">Step 03</div>
         <div class="step-icon">✨</div>
         <div class="step-title">Polish</div>
-        <p class="step-desc">Grammar is fixed, filler words are removed, and your meaning is preserved automatically, in the tone you choose.</p>
+        <p class="step-desc">Grammar is fixed, filler words are removed, and your meaning is preserved automatically.</p>
       </div>
       <div class="step-card reveal" id="step-paste">
         <div class="step-number">Step 04</div>
@@ -412,12 +445,12 @@ const faqJsonLd = JSON.stringify({
       <div class="stat-card reveal">
         <div class="stat-value">2</div>
         <div class="stat-label">Speech engines</div>
-        <div class="stat-detail">WhisperKit + Apple</div>
+        <div class="stat-detail">WhisperKit + Parakeet</div>
       </div>
       <div class="stat-card reveal">
         <div class="stat-value">5</div>
-        <div class="stat-label">AI providers</div>
-        <div class="stat-detail">Off, Apple, Ollama, OpenAI, Gemini</div>
+        <div class="stat-label">Polish engines</div>
+        <div class="stat-detail">EG-1, Apple, Ollama, OpenAI, Gemini</div>
       </div>
       <div class="stat-card reveal">
         <div class="stat-value">0</div>
@@ -433,6 +466,69 @@ const faqJsonLd = JSON.stringify({
   </div>
 </section>
 
+<!-- Choose Your Polish Engine -->
+<section class="section" aria-label="Polish engines">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="section-label-pill accent">AI Polish</div>
+      <h2 class="section-title">Choose how your text gets cleaned up</h2>
+      <p class="section-sub">Turn cleanup on and pick your engine. Each one is good at something different, and every option except a cloud key runs on your Mac.</p>
+    </div>
+
+    <div class="engines-grid reveal-stagger">
+      <div class="engine-card reveal" style="--i:0">
+        <span class="engine-badge">Start instantly</span>
+        <h3>Apple's built-in AI</h3>
+        <p>On the latest macOS, cleanup runs on-device with nothing extra to download. The zero-setup way to get started.</p>
+        <div class="engine-meta">On-device &middot; macOS 26+ &middot; No download</div>
+      </div>
+      <div class="engine-card featured reveal" style="--i:1">
+        <span class="engine-badge accent">Recommended</span>
+        <h3>EG-1, our own model</h3>
+        <p>We tuned it just for dictation cleanup: it turns a spoken list into a real list, breaks a wall of talk into clean paragraphs, and keeps only the corrected version when you fix yourself mid-sentence. Runs fully on your Mac.</p>
+        <div class="engine-meta">On-device &middot; macOS 14+ &middot; One-time download &middot; Free</div>
+      </div>
+      <div class="engine-card reveal" style="--i:2">
+        <span class="engine-badge">Your call</span>
+        <h3>Your own local model</h3>
+        <p>Run any local model through Ollama, fully offline, if you would rather bring your own.</p>
+        <div class="engine-meta">On-device &middot; Bring your own model</div>
+      </div>
+      <div class="engine-card reveal" style="--i:3">
+        <span class="engine-badge">Your call</span>
+        <h3>Your OpenAI or Gemini key</h3>
+        <p>Prefer a cloud model? Add your own key. Only your text is sent, never audio, and we ask the provider not to keep it.</p>
+        <div class="engine-meta">Cloud &middot; Your own key &middot; Text only</div>
+      </div>
+    </div>
+
+    <div class="bench reveal">
+      <div class="bench-head">
+        <h3>How EG-1 compares on cleanup quality</h3>
+        <p>Share of 1,890 real dictation cases each model cleaned up correctly, scored on the same cases by the same judge.</p>
+      </div>
+      <div class="bench-rows">
+        <div class="bench-row">
+          <span class="bench-label">EG-1 <span class="bench-tag">on-device</span></span>
+          <div class="bench-track"><div class="bench-bar eg1" style="width:93.7%;"></div></div>
+          <span class="bench-val">93.7%</span>
+        </div>
+        <div class="bench-row">
+          <span class="bench-label">Gemini 3.5 Flash <span class="bench-tag cloud">cloud</span></span>
+          <div class="bench-track"><div class="bench-bar" style="width:92.6%;"></div></div>
+          <span class="bench-val">92.6%</span>
+        </div>
+        <div class="bench-row">
+          <span class="bench-label">GPT-5.4-mini <span class="bench-tag cloud">cloud</span></span>
+          <div class="bench-track"><div class="bench-bar" style="width:83.8%;"></div></div>
+          <span class="bench-val">83.8%</span>
+        </div>
+      </div>
+      <p class="bench-note">Our own benchmark, not an independent review. The eval harness and prompts are public; the test cases are personal dictations and stay private.</p>
+    </div>
+  </div>
+</section>
+
 <!-- Features Deep Dive -->
 <section class="section" aria-label="Features">
   <div class="container">
@@ -444,12 +540,12 @@ const faqJsonLd = JSON.stringify({
       <div class="feat-card reveal">
         <div class="feat-icon">🧠</div>
         <div class="feat-title">On-device transcription</div>
-        <p class="feat-desc">Powered by WhisperKit and Apple Speech, transcription runs entirely on your Mac. No audio ever leaves your device.</p>
+        <p class="feat-desc">Powered by WhisperKit and Parakeet, transcription runs entirely on your Mac. No audio ever leaves your device.</p>
       </div>
       <div class="feat-card reveal">
         <div class="feat-icon">✏️</div>
         <div class="feat-title">Smart polish</div>
-        <p class="feat-desc">Filler words removed, grammar corrected, your meaning preserved. Choose your tone: clean, formal, or casual.</p>
+        <p class="feat-desc">Filler words removed, grammar corrected, your meaning preserved. Runs on-device with EG-1 or Apple Intelligence, or with your own OpenAI or Gemini key.</p>
       </div>
       <div class="feat-card reveal">
         <div class="feat-icon">🎯</div>
@@ -469,7 +565,7 @@ const faqJsonLd = JSON.stringify({
       <div class="feat-card reveal">
         <div class="feat-icon">🔌</div>
         <div class="feat-title">Multiple AI providers</div>
-        <p class="feat-desc">Use on-device polish with Apple Intelligence or Ollama, or bring your own OpenAI or Gemini key. Cloud polish requests include <code>store: false</code> so providers are asked not to retain the text.</p>
+        <p class="feat-desc">Use on-device polish with EG-1 (our own model), Apple Intelligence, or Ollama, or bring your own OpenAI or Gemini key. Cloud polish requests include <code>store: false</code> so providers are asked not to retain the text.</p>
       </div>
       <div class="feat-card reveal">
         <div class="feat-icon">🔤</div>
@@ -485,6 +581,11 @@ const faqJsonLd = JSON.stringify({
         <div class="feat-icon">⚙️</div>
         <div class="feat-title">Streaming pipeline</div>
         <p class="feat-desc">Recording, transcription, and AI polishing run in parallel. The result arrives almost the moment you stop speaking.</p>
+      </div>
+      <div class="feat-card reveal">
+        <div class="feat-icon">🌊</div>
+        <div class="feat-title">Live transcription</div>
+        <p class="feat-desc">With the All Languages engine, watch your words appear live as you speak. The text lands almost the moment you stop, no matter how long you talked.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -346,7 +346,7 @@ const jsonLdFaq = JSON.stringify({
         <a href="/blog/voice-input-rsi-keyboard-free-workflow/" class="uc-card tint-purple reveal" style="--i:6">
           <span class="uc-badge"><span class="uc-badge-icon" aria-hidden="true">♿</span>For Accessibility</span>
           <h3 class="uc-headline">Your voice, your primary input.</h3>
-          <p class="uc-tasks">All-day continuous dictation. Hands-free, mode-switch-free, limit-free.</p>
+          <p class="uc-tasks">Hands-free, mode-switch-free dictation, for up to a full hour at a stretch.</p>
           <span class="uc-cta">Read the workflow</span>
         </a>
 
@@ -386,11 +386,11 @@ const jsonLdFaq = JSON.stringify({
           <h3>Hold to record.<br/>Release to paste.</h3>
           <p>Perfect for quick messages, replies, and search queries. Hold your hotkey while you speak. The moment you release, polished text appears exactly where you're typing.</p>
           <div class="mode-hint">
-            <div class="mode-hint-keys" role="img" aria-label="Keyboard shortcut: Right Command, hold">
-              <span class="key-cap held" aria-hidden="true">&#8984;</span>
+            <div class="mode-hint-keys" role="img" aria-label="Keyboard shortcut: Right Option, hold">
+              <span class="key-cap held" aria-hidden="true">&#8997;</span>
               <span class="key-sep" aria-hidden="true">· hold</span>
             </div>
-            <span class="mode-hint-label">Hold Right Command while speaking, release to paste</span>
+            <span class="mode-hint-label">Hold Right Option while speaking, release to paste</span>
           </div>
         </div>
         <div class="mode-card hands-card reveal" style="--i:1">
@@ -401,11 +401,11 @@ const jsonLdFaq = JSON.stringify({
           <h3>Double-press to start.<br/>Press once to stop.</h3>
           <p>Built for long-form writing: emails, documents, meeting notes. Double-press your hotkey to start recording, then press once to finish. Your hands stay free the whole time.</p>
           <div class="mode-hint">
-            <div class="mode-hint-keys" role="img" aria-label="Keyboard shortcut: Right Command double-press">
-              <span class="key-cap tap" aria-hidden="true">&#8984;</span>
+            <div class="mode-hint-keys" role="img" aria-label="Keyboard shortcut: Right Option double-press">
+              <span class="key-cap tap" aria-hidden="true">&#8997;</span>
               <span class="key-sep" aria-hidden="true">&#215;2</span>
             </div>
-            <span class="mode-hint-label">Double-press Right Command to start, press once to stop</span>
+            <span class="mode-hint-label">Double-press Right Option to start, press once to stop</span>
           </div>
         </div>
       </div>
@@ -457,7 +457,7 @@ const jsonLdFaq = JSON.stringify({
             <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="2" stroke-linecap="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
           </div>
           <h3>Your AI, Your Choice</h3>
-          <p>Works with OpenAI, Google Gemini, Apple Intelligence, or fully offline with Ollama. Bring your own API key, or go completely local with no internet required.</p>
+          <p>Polish on-device with EG-1, our own model and the one we recommend, or Apple's built-in AI. Prefer to bring your own? Run a local model with Ollama, or add your own OpenAI or Google Gemini key. The on-device options need no internet at all.</p>
         </div>
         <div class="benefit-card reveal" style="--i:5">
           <div class="benefit-icon orange" aria-hidden="true">
@@ -642,7 +642,7 @@ const jsonLdFaq = JSON.stringify({
           macOS 14+ <span class="cdot" aria-hidden="true">&#183;</span>
           Apple Silicon <span class="cdot" aria-hidden="true">&#183;</span>
           100% Private <span class="cdot" aria-hidden="true">&#183;</span>
-          Free forever
+          Free to download
         </p>
 
         <p class="cta-brew">Or with Homebrew: <code>brew install --cask saurabhav88/tap/enviouswispr</code></p>


### PR DESCRIPTION
**Chunk 1 of 5** in the website content refresh (plan: `docs/feature-requests/plan-2026-07-05-website-eg1-positioning-content-refresh.md`, Codex-approved PROCEED-AS-PLANNED). Founder-directed positioning: Apple's built-in AI as the instant default on the latest macOS, EG-1 as the recommended best on any supported Mac, with a "what's each good at" narrative + benchmark chart.

### What changed (homepage + how-it-works only)
**New:**
- "Choose how your text gets cleaned up" section: four engine tiers (Apple built-in / EG-1 recommended / your own Ollama model / your own cloud key).
- Benchmark chart: EG-1 93.7%, Gemini 3.5 Flash 92.6%, GPT-5.4-mini 83.8% — our own 1,890-case benchmark, honest framing ("not an independent review; harness public, test cases private").
- Two-tier engine narrative on the homepage "Your AI, Your Choice" card; a live-transcription feature card.

**Fixes (facts that had drifted):**
- Invented "Apple" speech engine → WhisperKit + Parakeet (x2).
- Engine count list dropped "Off", added EG-1.
- Removed the dead tone-picker copy ("choose your tone: clean/formal/casual", "in the tone you choose").
- Right Command → Right Option (both mode cards + aria-labels + glyph).
- "All-day continuous / limit-free" → "up to a full hour".
- "Free forever" → "Free to download". "unlocks 90+" → "supports". Dropped "most precise" superlative.
- Added EG-1 to every on-device polish list on these pages.

**Deliberately untouched (founder calls):** hero "fastest" word; the WisprFlow $15/mo FAQ.

### Honesty guardrails
- EG-1 is described as "our own model, free, on-device" — never "open source". The app is GPLv3; the EG-1 model ships under its own community license (founder directive).
- Apple's built-in AI is scoped to "the latest macOS" (it needs macOS 26+), so we never promise instant polish to pre-26 users.

### Validation
- Astro build green (57 pages).
- Local Codex code-diff review: one P2 — the site's 93.7% vs the in-app What's New 94.7%. The site uses the public source-of-truth number (README/Reddit = 93.7%); the in-app 94.7% is reconciled in the approved follow-up (plan Chunk E). Known + scheduled, not a regression here.
- Visually verified in a local preview (engine cards + chart render correctly, EG-1 featured).

Part of the website content-refresh initiative; further chunks (comparison pages, privacy, blog) follow as separate PRs.