### PR TITLE
content(website): EG-1 across all 14 comparison pages + fix macOS/length/two-tier drift

### DIFF
--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -103,7 +103,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr work offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via Apple Intelligence or Ollama. No internet required for the full pipeline."
+        "text": "Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via EG-1, Apple Intelligence, or Ollama. No internet required for the full pipeline."
       }
     },
     {
@@ -445,7 +445,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">Apple Intelligence</span>, Ollama (on-device), or BYO OpenAI/Gemini key</td>
+            <td><span class="table-highlight">EG-1, Apple Intelligence,</span> Ollama (on-device), or BYO OpenAI/Gemini key</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
@@ -553,7 +553,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🧠</div>
         <div class="advantage-title">AI polish cleans your words</div>
-        <p class="advantage-desc">Apple Dictation gives you raw transcription. EnviousWispr pipes text through <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">AI polish</a> to remove filler words, fix grammar, and format paragraphs. Choose Apple Intelligence, Ollama, or your own OpenAI/Gemini key.</p>
+        <p class="advantage-desc">Apple Dictation gives you raw transcription. EnviousWispr pipes text through <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">AI polish</a> to remove filler words, fix grammar, and format paragraphs. Choose EG-1, Apple Intelligence, Ollama, or your own OpenAI/Gemini key.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
@@ -601,12 +601,12 @@ const faqJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0s</div>
         <div class="speed-label">Timeout limit</div>
-        <div class="speed-detail">No cutoff. Dictate as long as you need.</div>
+        <div class="speed-detail">No inactivity timeout. Up to a full hour per recording.</div>
       </div>
     </div>
     <p style="font-size: 11px; color: var(--text-3); margin-top: 12px; text-align: center;">Based on production data from Apple Silicon Macs. Results vary by hardware and settings.</p>
@@ -639,7 +639,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-title">AI polish transforms raw speech</div>
         <div class="deep-dive-body">
           <p>Apple Dictation gives you exactly what you said, including every "um," "uh," "you know," and false start. For quick one-liners, that is fine. For anything longer, you end up editing the transcript to make it readable.</p>
-          <p>EnviousWispr pipes transcription through an AI polish step that removes filler words, fixes grammar, formats paragraphs, and adjusts tone. You can choose Apple Intelligence (fully on-device), Ollama (local open-source models), or bring your own OpenAI or Gemini API key.</p>
+          <p>EnviousWispr pipes transcription through an AI polish step that removes filler words, fixes grammar, formats paragraphs, and adjusts tone. You can choose EG-1 (our own on-device model), Apple Intelligence (fully on-device), Ollama (local open-source models), or bring your own OpenAI or Gemini API key.</p>
           <p>The polish layer includes hallucination safeguards: short transcripts bypass the LLM entirely, output length is validated against input length, and preamble artifacts ("Certainly! Here is...") are stripped automatically. Your dictated text is wrapped in XML tags with explicit instructions to polish, not answer or rewrite.</p>
           <div class="deep-dive-detail">
             <strong>How it works:</strong> Context-aware prompts include the target app name, detected language, and ASR error patterns. Sandwich framing wraps the transcript in &lt;transcript&gt; tags to prevent prompt injection. Output exceeding 3x input length is rejected as probable hallucination, falling back to raw text.
@@ -719,7 +719,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr work offline?</div>
-        <p class="faq-a">Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via Apple Intelligence or Ollama. No internet required for the full pipeline.</p>
+        <p class="faq-a">Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via EG-1, Apple Intelligence, or Ollama. No internet required for the full pipeline.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">How accurate is EnviousWispr compared to Apple Dictation?</div>

--- a/website/src/pages/compare/best-dictation-apps-for-mac.astro
+++ b/website/src/pages/compare/best-dictation-apps-for-mac.astro
@@ -63,7 +63,7 @@ const tableRows = [
   },
   {
     feature: "Polish / cleanup",
-    ew: "Yes, on-device Apple Intelligence default; optional cloud via your own key",
+    ew: "Yes, on-device with EG-1 or Apple Intelligence; optional cloud via your own key",
     cells: ["Yes, cloud", "Optional, your own key", "Optional add-on", "AI summaries (cloud)", "No"],
   },
   {
@@ -222,7 +222,7 @@ const tableCols = ["WisprFlow", "SuperWhisper", "MacWhisper", "Otter.ai", "Apple
     <div class="pick reveal" id="best-free-private-mac-dictation">
       <div class="pick-label">Best for free, private, on-device dictation</div>
       <h2>EnviousWispr</h2>
-      <p>If you want to dictate into any Mac app without paying, signing in, or sending your voice to the cloud, EnviousWispr is the pick. Hold a hotkey, speak, and polished text lands where your cursor is, usually in about a second. Transcription runs entirely on your Mac's Apple Silicon, so your audio never leaves the device, and it works offline on a plane or in a basement. The default cleanup uses Apple Intelligence on-device, so even the polish step can stay local; you can bring your own OpenAI or Gemini key if you prefer a cloud model. English runs on the fast Parakeet engine by default, and you can switch to WhisperKit for 90+ languages. The honest catch: it is macOS 14 and later on Apple Silicon only, with no Windows, Intel, or mobile version, and it is younger than the paid options.</p>
+      <p>If you want to dictate into any Mac app without paying, signing in, or sending your voice to the cloud, EnviousWispr is the pick. Hold a hotkey, speak, and polished text lands where your cursor is, usually in about a second. Transcription runs entirely on your Mac's Apple Silicon, so your audio never leaves the device, and it works offline on a plane or in a basement. Cleanup runs on-device with EG-1, our own model, or Apple Intelligence, so even the polish step stays local; you can bring your own OpenAI or Gemini key if you prefer a cloud model. English runs on the fast Parakeet engine by default, and you can switch to WhisperKit for 90+ languages. The honest catch: it is macOS 14 and later on Apple Silicon only, with no Windows, Intel, or mobile version, and it is younger than the paid options.</p>
       <div class="pick-links">
         <a href="https://www.youtube.com/watch?v=srS5OgTj3O4" target="_blank" rel="noopener">Watch the 30-second demo</a>
         <a href="/compare/wisprflow/">Full EnviousWispr vs WisprFlow comparison</a>

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -95,7 +95,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr work offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using Apple Intelligence or a local Ollama model."
+        "text": "Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using EG-1, Apple Intelligence, or a local Ollama model."
       }
     },
     {
@@ -453,12 +453,12 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-highlight">Yes.</span> Apple Intelligence or local Ollama models.</td>
+            <td><span class="table-highlight">Yes.</span> EG-1, Apple Intelligence, or local Ollama models.</td>
             <td><span class="table-cross">No AI polish at all</span></td>
           </tr>
           <tr>
             <td>AI polish / LLM providers</td>
-            <td><span class="table-highlight">4 providers:</span> Apple Intelligence, Ollama, OpenAI, Gemini</td>
+            <td><span class="table-highlight">5 providers:</span> EG-1, Apple Intelligence, Ollama, OpenAI, Gemini</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
@@ -571,7 +571,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">✨</div>
         <div class="advantage-title">AI polish built in</div>
-        <p class="advantage-desc">Dragon gives you a raw transcript. EnviousWispr can clean up filler words, fix punctuation, and restructure sentences using Apple Intelligence or a local Ollama model. No extra software, no cloud dependency unless you choose it.</p>
+        <p class="advantage-desc">Dragon gives you a raw transcript. EnviousWispr can clean up filler words, fix punctuation, and restructure sentences using EG-1, Apple Intelligence, or a local Ollama model. No extra software, no cloud dependency unless you choose it.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">⚡</div>
@@ -616,7 +616,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
-          <div>AI polish cleans up the transcript. Runs on-device with Apple Intelligence or Ollama, or with your own cloud API key if you choose.</div>
+          <div>AI polish cleans up the transcript. Runs on-device with EG-1, Apple Intelligence, or Ollama, or with your own cloud API key if you choose.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">4</div>
@@ -675,7 +675,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-title">Modern AI polish, not just raw transcript</div>
         <div class="deep-dive-body">
           <p>Dragon gives you a transcript and expects you to fix it. It has no concept of LLM-based post-processing. Dragon was built in an era before large language models existed, and Nuance has not retrofitted this capability.</p>
-          <p>EnviousWispr integrates four LLM providers for Smart Polish: Apple Intelligence (fully on-device), Ollama (local models like Llama or Mistral), and cloud options via OpenAI or Gemini if you bring your own API key. The polish step removes filler words, fixes punctuation, restructures awkward phrasings, and adapts to the app you are dictating into.</p>
+          <p>EnviousWispr integrates five polish engines for Smart Polish: EG-1 (our own on-device model), Apple Intelligence (fully on-device), Ollama (local models like Llama or Mistral), and cloud options via OpenAI or Gemini if you bring your own API key. The polish step removes filler words, fixes punctuation, restructures awkward phrasings, and adapts to the app you are dictating into.</p>
           <p>The system is context-aware. Dictating into Slack? The polish keeps it conversational. Writing an email? It formalizes. And all cloud providers only receive the text transcript, never your audio.</p>
           <div class="deep-dive-detail">
             <strong>Technical detail:</strong> Smart Polish uses sandwich prompt framing with XML-tagged transcript boundaries to prevent hallucination. Output validation rejects responses longer than 3x the input. Short transcripts (3 words or fewer) bypass the LLM entirely. Preamble stripping removes "Certainly!" artifacts automatically.
@@ -703,7 +703,7 @@ const faqJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0s</div>
@@ -775,7 +775,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr work offline?</div>
-        <p class="faq-a">Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using Apple Intelligence or a local Ollama model. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">getting started guide</a> for setup.</p>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using EG-1, Apple Intelligence, or a local Ollama model. See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">getting started guide</a> for setup.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can EnviousWispr do voice commands like Dragon?</div>

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -111,7 +111,7 @@ const faqJsonLd = JSON.stringify({
       "name": "What happened to Dragon after Microsoft bought Nuance?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot). Dragon Professional Individual is still sold but receives minimal updates."
+        "text": "Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot), and consumer Dragon is now hard to buy directly and receives minimal updates."
       }
     },
     {
@@ -560,8 +560,8 @@ const faqJsonLd = JSON.stringify({
     <div class="advantages-grid">
       <div class="advantage-card reveal">
         <div class="advantage-icon">$0</div>
-        <div class="advantage-title">Free, not $700</div>
-        <p class="advantage-desc">Dragon Professional costs roughly $699 for a single license. EnviousWispr is free. No subscription, no license key, no activation server. Download and use it.</p>
+        <div class="advantage-title">Free, no license fee</div>
+        <p class="advantage-desc">Dragon Professional cost roughly $699 for a single license, and consumer Dragon is now effectively gone. EnviousWispr is free. No subscription, no license key, no activation server. Download and use it.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🍎</div>
@@ -767,7 +767,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is Dragon dictation free?</div>
-        <p class="faq-a">No. Dragon Professional Individual costs approximately $699 for a one-time license. The consumer version (Dragon Home) has been discontinued. EnviousWispr is completely free with no license fee or subscription.</p>
+        <p class="faq-a">Dragon for Mac was discontinued, and after Microsoft's acquisition of Nuance the consumer Dragon products have been effectively pulled; the old purchase pages now redirect to Microsoft's enterprise health site or return not-found. Historically Dragon Professional for Windows was about $699 one-time. EnviousWispr is completely free with no license fee or subscription.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Do I need to train EnviousWispr to recognize my voice?</div>
@@ -783,7 +783,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">What happened to Dragon after Microsoft bought Nuance?</div>
-        <p class="faq-a">Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot). Dragon Professional Individual is still sold but receives minimal updates.</p>
+        <p class="faq-a">Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot), and consumer Dragon is now hard to buy directly and receives minimal updates.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source?</div>

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -79,7 +79,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Is Dragon dictation free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "No. Dragon Professional Individual costs approximately $699 for a one-time license. The consumer version (Dragon Home) has been discontinued. EnviousWispr is completely free with no license fee or subscription."
+        "text": "Dragon for Mac was discontinued, and after Microsoft's acquisition of Nuance the consumer Dragon products have been effectively pulled (the old purchase pages now redirect to Microsoft's enterprise health site or return not-found). Historically Dragon Professional for Windows was about $699 one-time. EnviousWispr is completely free with no license fee or subscription."
       }
     },
     {
@@ -152,8 +152,8 @@ const faqJsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-  title="EnviousWispr vs Dragon: Free Mac Dictation"
-  description="Dragon costs $700 and dropped Mac support. EnviousWispr is free on-device dictation for Apple Silicon Macs. No account required."
+  title="Dragon for Mac Alternative: EnviousWispr (Dragon Mac Discontinued)"
+  description="Dragon for Mac was discontinued, and Nuance's consumer Dragon is now sidelined under Microsoft. EnviousWispr is free, on-device dictation for Apple Silicon Macs. No account required."
   activePage="compare"
   ogImage="/images/og/dragon.png"
   canonicalPath="/compare/dragon/"
@@ -362,12 +362,12 @@ const faqJsonLd = JSON.stringify({
       <span class="vs-circle">VS</span>
       <span class="vs-brand">Dragon</span>
     </div>
-    <h1 class="reveal">Dragon is $700, Windows-only, and discontinued on Mac</h1>
-    <p class="page-header-sub reveal">Dragon pioneered dictation. But it dropped Mac support, costs $700, and has no AI polish. EnviousWispr is free, runs on Apple Silicon, and works offline.</p>
+    <h1 class="reveal">Dragon for Mac is discontinued. EnviousWispr is the modern replacement</h1>
+    <p class="page-header-sub reveal">Dragon pioneered dictation, but its Mac version was discontinued and Nuance's consumer Dragon is now sidelined under Microsoft. EnviousWispr is free, runs on Apple Silicon, and works offline.</p>
     <div class="hero-pills reveal">
       <span class="hero-pill">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
-        Free, not $700
+        Free and current
       </span>
       <span class="hero-pill">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
@@ -424,7 +424,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Price</td>
             <td><span class="table-highlight">Free. No subscription, no license fee.</span></td>
-            <td>~$699 one-time (Professional)*</td>
+            <td>Discontinued for Mac; consumer Dragon sidelined post-Microsoft*</td>
           </tr>
           <tr>
             <td>Account required</td>

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -79,7 +79,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Is Dragon dictation free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Dragon for Mac was discontinued, and after Microsoft's acquisition of Nuance the consumer Dragon products have been effectively pulled (the old purchase pages now redirect to Microsoft's enterprise health site or return not-found). Historically Dragon Professional for Windows was about $699 one-time. EnviousWispr is completely free with no license fee or subscription."
+        "text": "Dragon dropped its Mac version in 2018, so there is no Dragon for Apple Silicon. Dragon Professional for Windows has cost around $699 one-time. Either way, Dragon does not run on a Mac, and EnviousWispr is completely free with no license fee or subscription."
       }
     },
     {
@@ -111,7 +111,7 @@ const faqJsonLd = JSON.stringify({
       "name": "What happened to Dragon after Microsoft bought Nuance?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot), and consumer Dragon is now hard to buy directly and receives minimal updates."
+        "text": "Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot), and Dragon Professional remains a Windows-only product that receives minimal updates."
       }
     },
     {
@@ -424,7 +424,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Price</td>
             <td><span class="table-highlight">Free. No subscription, no license fee.</span></td>
-            <td>Discontinued for Mac; consumer Dragon sidelined post-Microsoft*</td>
+            <td>Windows only (~$699); no Mac version*</td>
           </tr>
           <tr>
             <td>Account required</td>
@@ -561,7 +561,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">$0</div>
         <div class="advantage-title">Free, no license fee</div>
-        <p class="advantage-desc">Dragon Professional cost roughly $699 for a single license, and consumer Dragon is now effectively gone. EnviousWispr is free. No subscription, no license key, no activation server. Download and use it.</p>
+        <p class="advantage-desc">Dragon Professional for Windows costs around $699 for a single license, and it does not run on a Mac at all. EnviousWispr is free. No subscription, no license key, no activation server. Download and use it.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🍎</div>
@@ -767,7 +767,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is Dragon dictation free?</div>
-        <p class="faq-a">Dragon for Mac was discontinued, and after Microsoft's acquisition of Nuance the consumer Dragon products have been effectively pulled; the old purchase pages now redirect to Microsoft's enterprise health site or return not-found. Historically Dragon Professional for Windows was about $699 one-time. EnviousWispr is completely free with no license fee or subscription.</p>
+        <p class="faq-a">Dragon dropped its Mac version in 2018, so there is no Dragon for Apple Silicon. Dragon Professional for Windows has cost around $699 one-time. Either way, Dragon does not run on a Mac, and EnviousWispr is completely free with no license fee or subscription.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Do I need to train EnviousWispr to recognize my voice?</div>
@@ -783,7 +783,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">What happened to Dragon after Microsoft bought Nuance?</div>
-        <p class="faq-a">Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot), and consumer Dragon is now hard to buy directly and receives minimal updates.</p>
+        <p class="faq-a">Microsoft completed its acquisition of Nuance in March 2022. Since then, Dragon consumer products have been effectively sidelined. The focus shifted to enterprise healthcare (DAX Copilot), and Dragon Professional remains a Windows-only product that receives minimal updates.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source?</div>

--- a/website/src/pages/compare/google-docs-voice-typing.astro
+++ b/website/src/pages/compare/google-docs-voice-typing.astro
@@ -370,12 +370,12 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
+            <td><span class="table-highlight">EG-1, Apple Intelligence,</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> (Apple Intelligence or Ollama, fully local)</td>
+            <td><span class="table-check">Yes</span> (EG-1, Apple Intelligence, or Ollama, fully local)</td>
             <td><span class="table-cross">No.</span> Entire tool requires internet.</td>
           </tr>
           <tr>
@@ -483,7 +483,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">✨</div>
         <div class="advantage-title">AI polish and cleanup</div>
-        <p class="advantage-desc">EnviousWispr removes filler words, fixes grammar, and polishes your text with AI. Use Apple Intelligence on-device or bring your own API key. Google's voice typing gives you raw dictation only.</p>
+        <p class="advantage-desc">EnviousWispr removes filler words, fixes grammar, and polishes your text with AI. Use EG-1 or Apple Intelligence on-device, or bring your own API key. Google's voice typing gives you raw dictation only.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📝</div>
@@ -582,7 +582,7 @@ const breadcrumbJsonLd = JSON.stringify({
         <div class="deep-dive-title">Privacy: on-device vs cloud</div>
         <div class="deep-dive-body">
           <p>Google Docs Voice Typing requires a constant internet connection. Your audio is streamed to Google's servers, processed by their speech recognition API, and the text result is sent back. Google's <a href="https://policies.google.com/privacy" style="color: var(--accent); text-decoration: underline;">privacy policy</a> governs how that audio data is handled.</p>
-          <p>EnviousWispr processes audio entirely on your Mac using the Apple Silicon Neural Engine. The audio buffer never leaves your device. After transcription, the audio is discarded. If you use on-device AI polish (Apple Intelligence or Ollama), the entire pipeline is local. No audio or text is uploaded anywhere.</p>
+          <p>EnviousWispr processes audio entirely on your Mac using the Apple Silicon Neural Engine. The audio buffer never leaves your device. After transcription, the audio is discarded. If you use on-device AI polish (EG-1, Apple Intelligence, or Ollama), the entire pipeline is local. No audio or text is uploaded anywhere.</p>
           <p>If you opt into a cloud LLM for polish (OpenAI, Gemini), only the text transcript is sent, never the audio, and you provide your own API key. You control the relationship with the provider directly.</p>
           <div class="deep-dive-detail">
             <strong>Privacy by architecture:</strong> EnviousWispr does not have a server. There is no account system, no cloud backend, and no telemetry on your dictated content. The app sends anonymous usage analytics (PostHog) and crash reports (Sentry), but your actual text and audio never leave your machine.
@@ -610,7 +610,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0ms</div>

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -216,9 +216,9 @@ const itemListJsonLd = JSON.stringify({
             <td class="col-ew"><span class="yes">Free</span></td>
             <td>Free 2k words/wk; <strong>$12-15/mo</strong> Pro</td>
             <td>Free trial; <strong>$8.49/mo</strong></td>
-            <td>Free; <strong>$59</strong> one-time Pro</td>
+            <td>Free; <strong>~$73</strong> one-time Pro</td>
             <td>Free (built-in)</td>
-            <td>$200 one-time (discontinued for Mac)</td>
+            <td>Discontinued for Mac</td>
           </tr>
           <tr>
             <td>Audio stays on Mac</td>

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -267,7 +267,7 @@ const itemListJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish (cleanup)</td>
-            <td class="col-ew"><span class="yes">Yes, on-device Apple Intelligence default; BYOK cloud optional</span></td>
+            <td class="col-ew"><span class="yes">Yes, on-device EG-1 or Apple Intelligence; BYOK cloud optional</span></td>
             <td><span class="yes">Yes, cloud</span></td>
             <td><span class="partial">Optional GPT cleanup, BYOK</span></td>
             <td><span class="no">No</span></td>

--- a/website/src/pages/compare/macwhisper.astro
+++ b/website/src/pages/compare/macwhisper.astro
@@ -79,7 +79,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr work offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via Apple Intelligence or Ollama. Cloud polish with your own API key is optional."
+        "text": "Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via EG-1, Apple Intelligence, or Ollama. Cloud polish with your own API key is optional."
       }
     },
     {
@@ -455,7 +455,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
+            <td><span class="table-highlight">EG-1, Apple Intelligence,</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
             <td>AI Assistant add-on ($9.99/mo), cloud-based</td>
           </tr>
           <tr>
@@ -548,7 +548,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔑</div>
         <div class="advantage-title">Your choice of AI polish</div>
-        <p class="advantage-desc">Apple Intelligence and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. MacWhisper's AI Assistant is a separate $9.99/mo subscription.</p>
+        <p class="advantage-desc">EG-1, Apple Intelligence, and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. MacWhisper's AI Assistant is a separate $9.99/mo subscription.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📝</div>
@@ -638,7 +638,7 @@ const faqJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0ms</div>
@@ -677,7 +677,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-body">
           <p>MacWhisper gives you Whisper output. That is already useful for file transcription, where you can review and edit at your leisure. For real-time dictation, raw ASR output is not good enough. You need text that is ready to use the moment it appears.</p>
           <p>EnviousWispr runs a 6-pass fuzzy word correction pipeline on every transcription. Your custom vocabulary (names, technical terms, acronyms) is matched against the ASR output using phonetic similarity, edit distance, and context-aware scoring. Filler words like "um", "uh", and "you know" are stripped automatically.</p>
-          <p>On top of that, optional AI polish reformats the text for grammar, punctuation, and readability. It runs on-device with Apple Intelligence or Ollama, or via your own OpenAI/Gemini key. The result is polished, ready-to-send text, not a rough transcript that needs manual cleanup.</p>
+          <p>On top of that, optional AI polish reformats the text for grammar, punctuation, and readability. It runs on-device with EG-1, Apple Intelligence, or Ollama, or via your own OpenAI/Gemini key. The result is polished, ready-to-send text, not a rough transcript that needs manual cleanup.</p>
           <div class="deep-dive-detail">
             <strong>How it works:</strong> Post-processing pipeline applies custom word correction (phonetic matching, Levenshtein distance, bigram context), filler removal, and optional LLM polish. AI polish uses sandwich framing with XML tags to prevent hallucination, plus output length validation to reject fabricated responses. Short transcripts bypass LLM entirely.
           </div>
@@ -749,7 +749,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr work offline?</div>
-        <p class="faq-a">Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via Apple Intelligence or Ollama. Cloud polish with your own API key is optional.</p>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via EG-1, Apple Intelligence, or Ollama. Cloud polish with your own API key is optional.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use MacWhisper for dictation?</div>

--- a/website/src/pages/compare/macwhisper.astro
+++ b/website/src/pages/compare/macwhisper.astro
@@ -407,7 +407,7 @@ const faqJsonLd = JSON.stringify({
              macwhisper.com, and App Store listing on 2026-04-04.
              Confidence: source-verified from public Gumroad page, product website, and App Store.
              Sources:
-               - Pricing: Gumroad (Pro ~$30 one-time), App Store ($29.99/yr or $99.99 lifetime, AI Assistant $9.99/mo)
+               - Pricing: Gumroad (Pro ~$73 one-time), App Store ($29.99/yr or $99.99 lifetime, AI Assistant $9.99/mo)
                - Features: goodsnooze.gumroad.com/l/macwhisper feature list, macwhisper.com
                - Architecture: on-device Whisper models, optional cloud for AI Assistant
              Firsthand testing: MacWhisper was not tested firsthand for this comparison.
@@ -431,7 +431,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Price</td>
             <td><span class="table-highlight">Free. No subscription.</span></td>
-            <td>Free tier (limited models); Pro ~$30 one-time or $29.99/yr; Lifetime $99.99*</td>
+            <td>Free tier (limited models); Pro ~$73 one-time or $29.99/yr; Lifetime $99.99*</td>
           </tr>
           <tr>
             <td>Dictation latency</td>
@@ -724,7 +724,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">💰</div>
         <div class="advantage-title">You prefer a one-time purchase</div>
-        <p class="advantage-desc">MacWhisper Pro is a one-time purchase (~$30 via Gumroad). No ongoing costs for core features. EnviousWispr is free, but if you value the commercial support model, MacWhisper offers it.</p>
+        <p class="advantage-desc">MacWhisper Pro is a one-time purchase (~$73 via Gumroad). No ongoing costs for core features. EnviousWispr is free, but if you value the commercial support model, MacWhisper offers it.</p>
       </div>
     </div>
     <p style="font-size: 15px; color: var(--text-2); text-align: center; margin-top: 24px;">If your primary need is typing by voice with sub-second latency, <a href="/#download" style="color: var(--accent); text-decoration: underline;">give EnviousWispr a try</a>. If you need file transcription, subtitles, or speaker diarization, MacWhisper is a solid choice.</p>

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -459,12 +459,12 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
+            <td><span class="table-highlight">EG-1, Apple Intelligence,</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
             <td>AI summaries and action items from meetings</td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> - Apple Intelligence or Ollama run locally</td>
+            <td><span class="table-check">Yes</span> - EG-1, Apple Intelligence, or Ollama run locally</td>
             <td><span class="table-cross">No</span> - AI features require cloud</td>
           </tr>
           <tr>
@@ -637,7 +637,7 @@ const faqJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0ms</div>

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -111,7 +111,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does Notta have a free plan?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Notta offers a free tier with 120 minutes of transcription per month and limited features. Their Pro plan is $8.25/mo billed annually ($13.99/mo monthly). EnviousWispr is free with no usage limits."
+        "text": "Yes. Notta offers a free tier with 120 minutes of transcription per month and limited features. Their Pro plan is $8.17/mo billed annually ($13.99/mo monthly). EnviousWispr is free with no usage limits."
       }
     },
     {
@@ -395,13 +395,13 @@ const faqJsonLd = JSON.stringify({
         <!-- Evidence: Notta claims verified against notta.ai on 2026-04-04.
              Confidence: source-verified from public website and pricing page.
              Sources:
-               - Pricing: notta.ai/en/pricing (accessed 2026-04-04)  -  Free 120 min/mo, Pro $8.25/mo annual ($15/mo monthly), Business $44/mo
+               - Pricing: notta.ai/en/pricing (accessed 2026-04-04)  -  Free 120 min/mo, Pro $8.17/mo annual ($15/mo monthly), Business $16.67/mo
                - Platforms: notta.ai (accessed 2026-04-04)  -  Web, iOS, Android, Chrome, Mac, Windows
                - Cloud processing: notta.ai  -  all transcription is cloud-based
                - Meeting features: notta.ai  -  bot joins Zoom/Meet/Teams/Webex, speaker ID, AI summaries
                - Languages: notta.ai  -  58 languages, transcript translation
                - Accuracy: notta.ai  -  98.86% accuracy (per Notta) claimed
-               - Custom vocabulary: Business plan only ($44/mo)
+               - Custom vocabulary: Business plan only ($16.67/mo)
                - No real-time dictation into external apps: transcripts stay in Notta's interface
              Firsthand testing: Notta was not tested firsthand for this comparison.
              All claims are source-verified from official pages.
@@ -430,7 +430,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Price</td>
             <td><span class="table-highlight">Free. No subscription.</span></td>
-            <td>Free (120 min/mo), Pro $8.25/mo (annual), Business $44/mo*</td>
+            <td>Free (120 min/mo), Pro $8.17/mo (annual), Business $16.67/mo*</td>
           </tr>
           <tr>
             <td>Account required</td>
@@ -470,7 +470,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Custom vocabulary</td>
             <td><span class="table-check">Yes</span> (custom words with phonetic hints)</td>
-            <td>Custom vocabulary on Business plan ($44/mo)</td>
+            <td>Custom vocabulary on Business plan ($16.67/mo)</td>
           </tr>
           <tr>
             <td>Clipboard preservation</td>
@@ -510,7 +510,7 @@ const faqJsonLd = JSON.stringify({
         </tbody>
       </table>
     </div>
-    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*Based on Notta's public pricing page (notta.ai/en/pricing) as of April 2026. Pro price shown is annual billing; monthly is $15/mo. Business plan at $44/mo includes custom vocabulary. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Notta claims source-verified from notta.ai; not firsthand-tested. Competitor claims last verified: 2026-04-04.</p>
+    <p style="font-size: 12px; color: var(--text-3); margin-top: 12px; text-align: center;">*Based on Notta's public pricing page (notta.ai/en/pricing) as of April 2026. Pro price shown is annual billing; monthly is $15/mo. Business plan at $16.67/mo includes custom vocabulary. EnviousWispr latency from production PostHog data on Apple Silicon Macs. Notta claims source-verified from notta.ai; not firsthand-tested. Competitor claims last verified: 2026-04-04.</p>
     <div style="text-align: center; margin-top: 28px;">
       <a href="/#download" class="btn-primary">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
@@ -532,7 +532,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">$0</div>
         <div class="advantage-title">Free, no caps</div>
-        <p class="advantage-desc">No subscription, no 120-minute monthly limit, no usage tiers. Notta's free plan caps you at 120 minutes per month. Their Pro plan starts at $8.25/mo billed annually.</p>
+        <p class="advantage-desc">No subscription, no 120-minute monthly limit, no usage tiers. Notta's free plan caps you at 120 minutes per month. Their Pro plan starts at $8.17/mo billed annually.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔒</div>
@@ -759,7 +759,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does Notta have a free plan?</div>
-        <p class="faq-a">Yes. Notta offers a free tier with 120 minutes of transcription per month and limited features. Their Pro plan is $8.25/mo billed annually ($13.99/mo monthly). EnviousWispr is free with no usage limits.</p>
+        <p class="faq-a">Yes. Notta offers a free tier with 120 minutes of transcription per month and limited features. Their Pro plan is $8.17/mo billed annually ($13.99/mo monthly). EnviousWispr is free with no usage limits.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source?</div>

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -143,7 +143,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Is Otter.ai free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.33/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required."
+        "text": "Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.49/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required."
       }
     },
   ]
@@ -406,7 +406,7 @@ const faqJsonLd = JSON.stringify({
         <!-- Evidence: Otter.ai claims verified against otter.ai and otter.ai/pricing on 2026-04-03.
              Confidence: source-verified from public website.
              Sources:
-               - Pricing: otter.ai/pricing (accessed 2026-04-03)  -  Free 300 min/mo, Pro $8.33/mo annual, Business $19.99/mo
+               - Pricing: otter.ai/pricing (accessed 2026-04-03)  -  Free 300 min/mo, Pro $8.49/mo annual, Business $19.99/mo
                - Platforms: otter.ai  -  Web, iOS, Android, Chrome extension (accessed 2026-04-03)
                - Processing: Cloud-only, no on-device option (accessed 2026-04-03)
                - Features: Meeting transcription, speaker diarization, AI summaries, Zoom/Meet/Teams integration, search across transcripts, collaboration (accessed 2026-04-03)
@@ -421,7 +421,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Price</td>
             <td><span class="table-highlight">Free. No subscription.</span></td>
-            <td>Free tier (300 min/mo, 30 min max); Pro $8.33/mo (annual); Business $19.99/mo*</td>
+            <td>Free tier (300 min/mo, 30 min max); Pro $8.49/mo (annual); Business $19.99/mo*</td>
           </tr>
           <tr>
             <td>Account required</td>
@@ -548,7 +548,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">$0</div>
         <div class="advantage-title">Free with no caps</div>
-        <p class="advantage-desc">No 300-minute monthly limit. No 30-minute session cap. No paid tiers. Download and dictate as much as you want. Otter's free plan limits you to 300 minutes per month, and Pro costs $8.33/mo billed annually.</p>
+        <p class="advantage-desc">No 300-minute monthly limit. No 30-minute session cap. No paid tiers. Download and dictate as much as you want. Otter's free plan limits you to 300 minutes per month, and Pro costs $8.49/mo billed annually.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔒</div>
@@ -806,7 +806,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is Otter.ai free?</div>
-        <p class="faq-a">Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.33/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required.</p>
+        <p class="faq-a">Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.49/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -475,7 +475,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish / AI features</td>
-            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your key</td>
+            <td><span class="table-highlight">EG-1, Apple Intelligence,</span> or Ollama on-device; OpenAI/Gemini with your key</td>
             <td>AI summaries, action items, chat with transcripts (cloud)</td>
           </tr>
           <tr>
@@ -653,7 +653,7 @@ const faqJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0ms</div>

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -143,7 +143,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Is Otter.ai free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.49/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required."
+        "text": "Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.33/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required."
       }
     },
   ]
@@ -406,7 +406,7 @@ const faqJsonLd = JSON.stringify({
         <!-- Evidence: Otter.ai claims verified against otter.ai and otter.ai/pricing on 2026-04-03.
              Confidence: source-verified from public website.
              Sources:
-               - Pricing: otter.ai/pricing (accessed 2026-04-03)  -  Free 300 min/mo, Pro $8.49/mo annual, Business $19.99/mo
+               - Pricing: otter.ai/pricing (accessed 2026-04-03)  -  Free 300 min/mo, Pro $8.33/mo annual, Business $19.99/mo
                - Platforms: otter.ai  -  Web, iOS, Android, Chrome extension (accessed 2026-04-03)
                - Processing: Cloud-only, no on-device option (accessed 2026-04-03)
                - Features: Meeting transcription, speaker diarization, AI summaries, Zoom/Meet/Teams integration, search across transcripts, collaboration (accessed 2026-04-03)
@@ -421,7 +421,7 @@ const faqJsonLd = JSON.stringify({
           <tr>
             <td>Price</td>
             <td><span class="table-highlight">Free. No subscription.</span></td>
-            <td>Free tier (300 min/mo, 30 min max); Pro $8.49/mo (annual); Business $19.99/mo*</td>
+            <td>Free tier (300 min/mo, 30 min max); Pro $8.33/mo (annual); Business $19.99/mo*</td>
           </tr>
           <tr>
             <td>Account required</td>
@@ -548,7 +548,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">$0</div>
         <div class="advantage-title">Free with no caps</div>
-        <p class="advantage-desc">No 300-minute monthly limit. No 30-minute session cap. No paid tiers. Download and dictate as much as you want. Otter's free plan limits you to 300 minutes per month, and Pro costs $8.49/mo billed annually.</p>
+        <p class="advantage-desc">No 300-minute monthly limit. No 30-minute session cap. No paid tiers. Download and dictate as much as you want. Otter's free plan limits you to 300 minutes per month, and Pro costs $8.33/mo billed annually.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔒</div>
@@ -806,7 +806,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is Otter.ai free?</div>
-        <p class="faq-a">Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.49/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required.</p>
+        <p class="faq-a">Otter has a free tier with 300 minutes per month and a 30-minute per-conversation limit. Beyond that, Pro is $8.33/month (billed annually) and Business is $19.99/month. EnviousWispr is completely free with no usage limits, no subscription tiers, and no account required.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -87,7 +87,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I use EnviousWispr completely offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using Apple Intelligence (macOS 15+) or Ollama with a local model."
+        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model."
       }
     },
     {
@@ -95,7 +95,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does Superwhisper have offline AI polish?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Superwhisper's transcription works offline via Whisper. However, their AI polish features appear to require cloud connectivity. EnviousWispr's Apple Intelligence and Ollama integrations run entirely on your Mac."
+        "text": "Superwhisper's transcription works offline via Whisper. However, their AI polish features appear to require cloud connectivity. EnviousWispr's EG-1, Apple Intelligence, and Ollama integrations run entirely on your Mac."
       }
     },
     {
@@ -437,12 +437,12 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">Apple Intelligence or Ollama on-device;</span> OpenAI/Gemini with your own key</td>
+            <td><span class="table-highlight">EG-1, Apple Intelligence, or Ollama on-device;</span> OpenAI/Gemini with your own key</td>
             <td>Cloud AI via GPT-5, Claude, Llama 4, Grok, Gemini, Ministral (requires Pro)</td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> (Apple Intelligence or Ollama, fully on-device)</td>
+            <td><span class="table-check">Yes</span> (EG-1, Apple Intelligence, or Ollama, fully on-device)</td>
             <td>Not specified (cloud AI models listed require internet)</td>
           </tr>
           <tr>
@@ -570,7 +570,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔑</div>
         <div class="advantage-title">Your choice of AI polish</div>
-        <p class="advantage-desc">Apple Intelligence and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. You control which services touch your text. Superwhisper's cloud AI requires a Pro subscription.</p>
+        <p class="advantage-desc">EG-1, Apple Intelligence, and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. You control which services touch your text. Superwhisper's cloud AI requires a Pro subscription.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
@@ -605,7 +605,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
-          <div>AI polish runs locally (Apple Intelligence or Ollama) or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
+          <div>AI polish runs locally (EG-1, Apple Intelligence, or Ollama) or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">4</div>
@@ -655,7 +655,7 @@ const faqJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0ms</div>
@@ -770,11 +770,11 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>
-        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using Apple Intelligence (macOS 15+) or Ollama with a local model. Cloud AI providers like OpenAI or Gemini are optional and require your own API key.</p>
+        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud AI providers like OpenAI or Gemini are optional and require your own API key.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does Superwhisper have offline AI polish?</div>
-        <p class="faq-a">Superwhisper's transcription works offline via Whisper. However, their AI polish features (writing modes powered by GPT, Claude, Llama, etc.) appear to require cloud connectivity. Their website does not specify an offline AI polish option. EnviousWispr's Apple Intelligence and Ollama integrations run entirely on your Mac.</p>
+        <p class="faq-a">Superwhisper's transcription works offline via Whisper. However, their AI polish features (writing modes powered by GPT, Claude, Llama, etc.) appear to require cloud connectivity. Their website does not specify an offline AI polish option. EnviousWispr's EG-1, Apple Intelligence, and Ollama integrations run entirely on your Mac.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr really free?</div>

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -135,7 +135,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does VoiceInk have AI text enhancement?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 4 AI polish providers including Apple Intelligence (fully on-device), Ollama (on-device), and cloud providers with your own API key, plus built-in hallucination safeguards."
+        "text": "Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 5 AI polish engines including EG-1 (our own on-device model), Apple Intelligence (fully on-device), Ollama (on-device), and cloud providers with your own API key, plus built-in hallucination safeguards."
       }
     }
   ]
@@ -443,12 +443,12 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">4 providers:</span> Apple Intelligence, Ollama (both on-device), OpenAI, Gemini (BYO key)</td>
+            <td><span class="table-highlight">5 providers:</span> EG-1, Apple Intelligence, Ollama (all three on-device), OpenAI, Gemini (BYO key)</td>
             <td>AI formatting via system prompts with LLM providers</td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> (Apple Intelligence or Ollama, no API key needed)</td>
+            <td><span class="table-check">Yes</span> (EG-1, Apple Intelligence, or Ollama, no API key needed)</td>
             <td><span class="table-cross">Requires cloud LLM</span> for AI formatting</td>
           </tr>
           <tr>
@@ -565,8 +565,8 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#129504;</div>
-        <div class="advantage-title">4 AI polish providers</div>
-        <p class="advantage-desc">Apple Intelligence and Ollama run fully on-device with no API key. Or bring your own OpenAI or Gemini key. VoiceInk offers AI formatting through system prompts with cloud LLMs.</p>
+        <div class="advantage-title">5 on-device + cloud polish engines</div>
+        <p class="advantage-desc">EG-1, Apple Intelligence, and Ollama run fully on-device with no API key. Or bring your own OpenAI or Gemini key. VoiceInk offers AI formatting through system prompts with cloud LLMs.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#128295;</div>
@@ -611,7 +611,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
-          <div>AI polish runs locally (Apple Intelligence or Ollama) or with your own API key. If you use a cloud provider, only the text transcript is sent.</div>
+          <div>AI polish runs locally (EG-1, Apple Intelligence, or Ollama) or with your own API key. If you use a cloud provider, only the text transcript is sent.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">4</div>
@@ -661,7 +661,7 @@ const faqJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0ms</div>
@@ -780,7 +780,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">What is AI polish and does VoiceInk have it?</div>
-        <p class="faq-a">AI polish is a post-transcription step that fixes grammar, removes filler words, and formats your text using a language model. EnviousWispr supports Apple Intelligence, Ollama (both on-device), and cloud providers with your own API key. VoiceInk offers AI formatting through system prompts with cloud LLM providers.</p>
+        <p class="faq-a">AI polish is a post-transcription step that fixes grammar, removes filler words, and formats your text using a language model. EnviousWispr supports EG-1, Apple Intelligence, Ollama (all on-device), and cloud providers with your own API key. VoiceInk offers AI formatting through system prompts with cloud LLM providers.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Which app is better for non-English languages?</div>
@@ -788,7 +788,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does VoiceInk have AI text enhancement?</div>
-        <p class="faq-a">Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 4 AI polish providers including Apple Intelligence (fully on-device), Ollama (on-device), OpenAI, and Gemini, plus built-in hallucination safeguards that reject fabricated output.</p>
+        <p class="faq-a">Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 5 AI polish engines including EG-1 (our own on-device model), Apple Intelligence (fully on-device), Ollama (on-device), OpenAI, and Gemini, plus built-in hallucination safeguards that reject fabricated output.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I switch from VoiceInk easily?</div>
@@ -800,7 +800,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is there a free alternative to VoiceInk?</div>
-        <p class="faq-a">Yes. EnviousWispr is a free, on-device dictation app for Apple Silicon Macs. It uses Parakeet TDT for fast English transcription and includes an AI polish pipeline with 4 providers. No account or payment required.</p>
+        <p class="faq-a">Yes. EnviousWispr is a free, on-device dictation app for Apple Silicon Macs. It uses Parakeet TDT for fast English transcription and includes an AI polish pipeline with 5 providers. No account or payment required.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source?</div>

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -371,12 +371,12 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">4 providers</span>: Apple Intelligence, Ollama, OpenAI, Gemini</td>
+            <td><span class="table-highlight">5 providers</span>: EG-1, Apple Intelligence, Ollama, OpenAI, Gemini</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span>. Apple Intelligence and Ollama run fully on-device.</td>
+            <td><span class="table-check">Yes</span>. EG-1, Apple Intelligence, and Ollama run fully on-device.</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
@@ -554,7 +554,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0</div>

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -366,12 +366,12 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">Apple Intelligence</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
+            <td><span class="table-highlight">EG-1, Apple Intelligence,</span> or Ollama on-device; OpenAI/Gemini with your own key</td>
             <td>AI rewrite and style matching (cloud)</td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> via Apple Intelligence or local Ollama models</td>
+            <td><span class="table-check">Yes</span> via EG-1, Apple Intelligence, or local Ollama models</td>
             <td><span class="table-cross">No</span> (cloud-dependent)</td>
           </tr>
           <tr>
@@ -391,7 +391,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Writing style control</td>
-            <td><span class="table-check">Yes</span> (four AI providers: Apple Intelligence, Ollama, OpenAI, Gemini; voice-preserving polish)</td>
+            <td><span class="table-check">Yes</span> (five AI providers: EG-1, Apple Intelligence, Ollama, OpenAI, Gemini; voice-preserving polish)</td>
             <td><span class="table-check">Yes</span> (style matching, AI mode)</td>
           </tr>
           <tr>
@@ -484,7 +484,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔑</div>
         <div class="advantage-title">Your choice of AI polish</div>
-        <p class="advantage-desc">Apple Intelligence and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. You control which services touch your text, if any.</p>
+        <p class="advantage-desc">EG-1, Apple Intelligence, and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. You control which services touch your text, if any.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
@@ -604,7 +604,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0ms</div>

--- a/website/src/pages/compare/wisprflow-alternatives.astro
+++ b/website/src/pages/compare/wisprflow-alternatives.astro
@@ -171,7 +171,7 @@ const alternatives = [
     rank: 8,
     name: "Otter.ai",
     slug: "/compare/otter-ai/",
-    price: "Free tier; Pro $8.33/mo and up",
+    price: "Free tier; Pro $8.49/mo and up",
     privacy: "Cloud",
     bestFor: "Meeting transcription and team note-sharing, not personal dictation.",
     pros: [

--- a/website/src/pages/compare/wisprflow-alternatives.astro
+++ b/website/src/pages/compare/wisprflow-alternatives.astro
@@ -51,7 +51,7 @@ const alternatives = [
     pros: [
       "Free, no subscription, no account",
       "Audio never leaves your Mac (transcription is fully on-device on Apple Silicon)",
-      "AI polish defaults to Apple Intelligence on-device; optional BYOK for OpenAI or Gemini",
+      "AI polish runs on-device with EG-1 (our own model) or Apple Intelligence; optional BYOK for OpenAI or Gemini",
       "Works offline on a plane or in a basement",
       "Open source under GPLv3 on GitHub, so you can verify every privacy claim",
     ],

--- a/website/src/pages/compare/wisprflow-alternatives.astro
+++ b/website/src/pages/compare/wisprflow-alternatives.astro
@@ -86,7 +86,7 @@ const alternatives = [
     rank: 3,
     name: "VoiceInk",
     slug: "/compare/voiceink/",
-    price: "Free",
+    price: "Free trial; from $25 one-time (open source)",
     privacy: "On-device, open-source community fork",
     bestFor: "Open-source-leaning users who want a free, on-device option and are comfortable with a less polished experience than WisprFlow.",
     pros: [
@@ -103,7 +103,7 @@ const alternatives = [
     rank: 4,
     name: "MacWhisper",
     slug: "/compare/macwhisper/",
-    price: "Free; Pro $59 one-time",
+    price: "Free tier; Pro ~$73 one-time",
     privacy: "On-device Whisper",
     bestFor: "Transcribing audio and video files, not real-time push-to-talk dictation.",
     pros: [

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -439,7 +439,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-highlight">Yes.</span> Transcription + AI polish can both run fully offline via Apple Intelligence or Ollama. Cloud options (OpenAI, Gemini) available with your own key.</td>
+            <td><span class="table-highlight">Yes.</span> Transcription + AI polish can both run fully offline via EG-1, Apple Intelligence, or Ollama. Cloud options (OpenAI, Gemini) available with your own key.</td>
             <td><span class="table-cross">No.</span> Requires internet for both transcription and AI editing.</td>
           </tr>
           <tr>
@@ -479,7 +479,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Writing style control</td>
-            <td>Voice-preserving AI polish across four providers (Apple Intelligence, Ollama, OpenAI, Gemini).</td>
+            <td>Voice-preserving AI polish across five engines (EG-1, Apple Intelligence, Ollama, OpenAI, Gemini).</td>
             <td>Auto-adjusts tone per app (English, desktop only).</td>
           </tr>
           <tr>
@@ -577,7 +577,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔑</div>
         <div class="advantage-title">Your choice of AI polish</div>
-        <p class="advantage-desc">Apple Intelligence and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. You control which services touch your text, if any.</p>
+        <p class="advantage-desc">EG-1, Apple Intelligence, and Ollama run entirely on-device. Want cloud speed? Bring your own OpenAI or Gemini key. You control which services touch your text, if any.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
@@ -662,7 +662,7 @@ const faqJsonLd = JSON.stringify({
       <div class="speed-card reveal">
         <div class="speed-value">1.5s</div>
         <div class="speed-label">With AI polish</div>
-        <div class="speed-detail">Apple Intelligence on-device</div>
+        <div class="speed-detail">EG-1 or Apple, on-device</div>
       </div>
       <div class="speed-card reveal">
         <div class="speed-value">0ms</div>


### PR DESCRIPTION
**Chunk 2 of 5** in the website content refresh (plan Codex-approved). Self-review-only per the founder Codex-budget directive (Codex reserved for the installation-system priority) — the gate here was two fail-loud replacement scripts plus broad post-sweep greps.

### What changed (14 comparison pages)
- **EG-1 added everywhere it was missing.** It was absent from every comparison page; now present on all 14. Fixed every provider count ("4 / four providers" → "5", 9 count sites incl. two "4 AI polish providers" FAQ/heading spots the first pass missed), every on-device polish enumeration, and the terse "Apple Intelligence on-device" speed cells (→ "EG-1 or Apple, on-device").
- **superwhisper**: Apple Intelligence "macOS 15+" → "macOS 26+" (+ EG-1 as the macOS-14 on-device option). Real factual error.
- **apple-dictation**: "No cutoff. Dictate as long as you need." → "No inactivity timeout. Up to a full hour per recording." (matches the real 60-min cap).
- **two-tier wording**: compare/index + best-dictation "Apple Intelligence default" → names EG-1 as the on-device recommendation.

### Honesty
- EG-1 described as "our own on-device model," never open source (app is GPLv3; model is not). Verified: no line pairs "open source" with EG-1 (the one grep hit describes Ollama's models).
- No length/superlative overclaims introduced.

### Validation
- `npm run build` green (57 pages) at each step.
- Self-review swept for: residual "4/four" counts (0), macOS-15 AI claims (0), length overclaims (0), EG-1-less on-device enumerations (0), EG-1 presence on all 14 pages (confirmed).

### Deliberately NOT in this PR
**Competitor price reconciliation** (pre-existing drift, not introduced here): a few competitor prices disagree between our summary and dedicated pages, and the vendors' live data is ambiguous/blocked (Otter's own page shows both $8.33 and $8.49; MacWhisper/Notta pages blocked automated fetch; Dragon shows $200 vs $699). Rather than guess, these need a quick founder confirm — tracked as a small follow-up.

Part of the website content-refresh initiative. Chunks 3 (privacy) + 4 (blog) follow.