### PR TITLE
fix(asr): onboarding stall guard — first-run download can never hang forever (#1339 PR-1)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -111,7 +111,7 @@ public final class ASRManager: ASRManagerInterface {
       // #959: capture the load generation; refuse to mark loaded if superseded.
       let gen = self.loadGeneration
       self.downloadProgress = 0
-      self.downloadPhase = "Preparing download..."
+      self.downloadPhase = ModelLoadStallPolicy.listingPhase
       self.downloadDetail = ""
 
       // For Parakeet, use the progress-reporting variant so in-process path also reports progress.

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -66,7 +66,23 @@ public protocol ASRManagerInterface: AnyObject {
   /// path guidance (closure beats `any Protocol` existential dispatch).
   var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)? { get set }
 
+  /// #1339: whether this manager's `loadModel()` progress lands in the shared
+  /// progress file (`ProgressFile.shared`). Only the XPC proxy does — the
+  /// in-process `ASRManager` reports through its own callback and never
+  /// touches the file. The sessionless warm-up wedge guard polls that file,
+  /// so it must arm ONLY over a file-backed load; arming over an in-process
+  /// load would read permanent silence and cancel a healthy long first-run
+  /// download at the deadline (Codex PR-1 r1 P2). Defaults to `false` — a
+  /// manager must opt IN to file-backed stall detection.
+  var feedsSharedProgressFile: Bool { get }
+
   // Crash notification — fires when XPC ASR service dies during an active session.
   // Wired by the former root state to route to the active pipeline (same pattern as AudioCaptureProxy.onEngineInterrupted).
   var onServiceInterrupted: (() -> Void)? { get set }
+}
+
+extension ASRManagerInterface {
+  /// #1339 safe default: managers do NOT feed the shared progress file unless
+  /// they explicitly opt in (`ASRManagerProxy` does).
+  public var feedsSharedProgressFile: Bool { false }
 }

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -113,7 +113,7 @@ public final class ASRManagerProxy: ASRManagerInterface {
       let gen = self.loadGeneration
       // Reset progress state before starting.
       self.downloadProgress = 0
-      self.downloadPhase = "Preparing download..."
+      self.downloadPhase = ModelLoadStallPolicy.listingPhase
       self.downloadDetail = ""
 
       self.connectionPreflight(self)
@@ -186,6 +186,11 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// existing private state — adds no behavior and no new stored property.
   // periphery:ignore - test seam
   internal var progressPollTimerForTesting: Timer? { progressPollTimer }
+
+  /// #1339: the proxy's load progress IS the shared progress file (the XPC
+  /// service writes it; the 8Hz poll above reads it) — the sessionless wedge
+  /// guard may arm over this manager's loads.
+  public var feedsSharedProgressFile: Bool { true }
 
   internal func startProgressPolling() {
     stopProgressPolling()

--- a/Sources/EnviousWisprASR/ModelDownloadManager.swift
+++ b/Sources/EnviousWisprASR/ModelDownloadManager.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Verifies the SHA-256 checksum of the downloaded Parakeet encoder model.
 ///
 /// Heart bootstrap helper. `ParakeetBackend` downloads the model via FluidAudio
-/// directly (using `StallTracker` for stall detection) and calls
+/// directly and calls
 /// `verifyChecksum()` afterward as defense-in-depth. A mismatch logs a warning
 /// but never blocks — a corrupted model is surfaced, not fatally gated.
 enum ModelDownloadManager {
@@ -49,44 +49,5 @@ enum ModelDownloadManager {
         )
       }
     }
-  }
-}
-
-// MARK: - Stall Tracker
-
-/// Thread-safe stall detector. Uses NSLock — zero actor overhead on the download thread.
-/// Called from FluidAudio's URLSession delegate thread; must not block or create Tasks.
-final class StallTracker: @unchecked Sendable {
-  private let timeout: TimeInterval
-  private let lock = NSLock()
-  private var lastProgressTime: CFAbsoluteTime
-  private var lastFraction: Double = 0
-  private var _isStalled = false
-
-  init(timeout: TimeInterval) {
-    self.timeout = timeout
-    self.lastProgressTime = CFAbsoluteTimeGetCurrent()
-  }
-
-  /// Record a progress update. Called from the download delegate thread — must be fast.
-  func recordProgress(fraction: Double) {
-    lock.lock()
-    if fraction > lastFraction + 0.001 {
-      lastProgressTime = CFAbsoluteTimeGetCurrent()
-      lastFraction = fraction
-    }
-    // Check for stall inline — no separate monitor task needed
-    let elapsed = CFAbsoluteTimeGetCurrent() - lastProgressTime
-    if elapsed >= timeout && lastFraction < 0.5 && lastFraction > 0 {
-      _isStalled = true
-    }
-    lock.unlock()
-  }
-
-  /// Whether a stall has been detected.
-  var isStalled: Bool {
-    lock.lock()
-    defer { lock.unlock() }
-    return _isStalled
   }
 }

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -23,6 +23,12 @@ public actor ParakeetBackend: ASRBackend {
 
   public var supportsStreaming: Bool { true }
 
+  /// Total download size shown in the progress detail (#1339). The pinned
+  /// Parakeet v3 set (4 model dirs + vocab + loose json/txt) measures
+  /// 483,256,769 bytes — byte-verified against the pinned upstream revision
+  /// in `workers/parakeet-mirror/expected-manifest.json`.
+  static let totalDownloadMB = 483
+
   public init() {}
 
   public func prepare() async throws {
@@ -38,31 +44,32 @@ public actor ParakeetBackend: ASRBackend {
   /// - `downloadRepo()` only fires on the first `loadModels()` call — subsequent calls find
   ///   files cached and skip. We map directly from FluidAudio's fraction.
   ///
-  /// Stall detection and checksum verification are handled by StallTracker (lock-based,
-  /// zero overhead on the download thread) and ModelDownloadManager.verifyChecksum().
+  /// Stall detection is host-side (#1339): the kernel's session detector and
+  /// the sessionless warm-up guard watch the shared progress file this
+  /// callback feeds. Checksum spot-check stays in ModelDownloadManager.verifyChecksum().
   public func prepare(progressCallback: ProgressCallback?) async throws {
-    let stallTracker = StallTracker(timeout: 20)
-
     let handler: DownloadUtils.ProgressHandler? = progressCallback.map {
       callback -> DownloadUtils.ProgressHandler in
       { progress in
-        // Update stall tracker — lock-based, zero overhead on download thread
-        stallTracker.recordProgress(fraction: progress.fractionCompleted)
-
         let phase: String
         let detail: String
 
         switch progress.phase {
         case .listing:
-          phase = "Preparing download..."
+          // Single authority for this token: the host-side stall guard keys
+          // its listing-stall gate on it (ModelLoadStallPolicy, #1339).
+          phase = ModelLoadStallPolicy.listingPhase
           detail = ""
         case .downloading:
           phase = "Downloading model files..."
-          // Raw download is ~23MB (CoreML source files). The 460MB on disk
-          // is from CoreML compilation which happens in the .compiling phase.
+          // #1339: honest byte counter. The real payload is ~483MB of
+          // already-compiled Core ML artifacts (445MB encoder weights); the
+          // old "23 MB" label was the decoder file alone. Fraction [0, 0.5]
+          // is FluidAudio's byte-weighted download half.
           let downloadPct = min(progress.fractionCompleted * 2.0, 1.0)
-          let downloadedMB = Int(downloadPct * 23)
-          detail = "\(downloadedMB) MB of 23 MB (\(Int(downloadPct * 100))%)"
+          let downloadedMB = Int(downloadPct * Double(Self.totalDownloadMB))
+          detail =
+            "\(downloadedMB) MB of \(Self.totalDownloadMB) MB (\(Int(downloadPct * 100))%)"
         case .compiling(let modelName):
           phase = "Installing model..."
           detail = modelName

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -73,6 +73,13 @@ final class OnboardingV2ViewModel {
   var downloadDetail: String = ""
   private var progressPollTimer: Timer?
 
+  /// #1339 minimal liveness (G8): when the listing phase started, so the
+  /// subtitle can escalate honestly ("Preparing speech model…" → after a short
+  /// delay "Still working: checking download source…") instead of freezing on
+  /// one static string for the whole stall window. Set when the poll first
+  /// observes the listing phase; cleared when the phase moves on.
+  var listingPhaseSince: Date?
+
   /// Quirky installation message, cycled during the compilation phase.
   var installQuip: String = ""
   private var quipTimer: Timer?
@@ -203,6 +210,10 @@ final class OnboardingV2ViewModel {
     installQuip = ""
     stopQuipTimer()
     checklistStatuses = [.pending, .pending, .pending]
+    // #1339: fresh attempt, fresh escalation clock — a stale listing-phase
+    // timestamp from the failed attempt must not flash "Still working" at
+    // second zero of the retry.
+    listingPhaseSince = nil
     retryCount += 1
   }
 
@@ -220,6 +231,14 @@ final class OnboardingV2ViewModel {
         self.downloadProgress = state.fraction
         self.downloadPhase = state.phase
         self.downloadDetail = state.detail
+
+        // #1339 (G8): track how long the listing phase has been showing so
+        // the subtitle can escalate instead of freezing on one string.
+        if state.phase == ModelLoadStallPolicy.listingPhase {
+          if self.listingPhaseSince == nil { self.listingPhaseSince = Date() }
+        } else {
+          self.listingPhaseSince = nil
+        }
 
         // Start quip timer when compilation begins (fraction >= 0.5)
         if state.fraction >= 0.5 && self.quipTimer == nil {
@@ -283,6 +302,14 @@ final class OnboardingV2ViewModel {
 
   /// Maps raw error descriptions to user-friendly messages.
   private static func friendlyError(_ error: any Error) -> String {
+    // #1339: the sessionless stall guard classifies a detected listing stall
+    // as a WedgeError — surface the stall-specific message, not a raw
+    // transport string. (The download did not fail outright; the source hung.)
+    if error is ModelLoadWatchdog.WedgeError {
+      return
+        "Setup is taking longer than expected. Check your internet connection or VPN, then try again."
+    }
+
     let desc = error.localizedDescription.lowercased()
 
     if desc.contains("timed out") || desc.contains("timeout") {
@@ -675,7 +702,7 @@ private struct ChecklistPhaseView: View {
   }
 
   /// Returns live status text for the model setup row.
-  /// During download: "Downloading... X MB of 23 MB"
+  /// During download: "Downloading model files... X MB of 483 MB"
   /// During compilation: cycles through quirky installation quips
   private func downloadSubtitle(for index: Int, fallback: String) -> String {
     guard index == 0, viewModel.checklistStatuses[0].isInProgress else { return fallback }
@@ -688,6 +715,16 @@ private struct ChecklistPhaseView: View {
     let phase = viewModel.downloadPhase
     let detail = viewModel.downloadDetail
     if phase.isEmpty { return fallback }
+
+    // #1339 (G8): honest staged copy for the listing window. The raw phase
+    // token is a status string, not user copy; and a long listing wait must
+    // visibly escalate so the screen never reads as frozen.
+    if phase == ModelLoadStallPolicy.listingPhase {
+      if let since = viewModel.listingPhaseSince, Date().timeIntervalSince(since) > 10 {
+        return "Still working: checking download source…"
+      }
+      return "Preparing speech model…"
+    }
     return detail.isEmpty ? phase : "\(phase) \(detail)"
   }
 }

--- a/Sources/EnviousWisprCore/LoadProgressWatcher.swift
+++ b/Sources/EnviousWisprCore/LoadProgressWatcher.swift
@@ -80,14 +80,39 @@ public final class LoadProgressWatcher {
   /// `@MainActor`.
   private let currentTime: @MainActor () -> TimeInterval
 
+  /// Issue #1339: phase-aware listing-stall gate. The one wedge shape the
+  /// ratio gate deliberately cannot catch is the first-run listing stall —
+  /// exactly one signal ("Preparing download..." at fraction 0), then silence
+  /// while the remote host's repo-listing call hangs. `requiresObservedGap`
+  /// correctly refuses to fire the 800ms floor on a single signal, so that
+  /// stall previously hung forever (the #445-deferred hole).
+  ///
+  /// When BOTH `listingPhase` and `listingStallDeadlineSeconds` are injected,
+  /// two additional defended firings unlock:
+  ///   - single-signal: last observed phase == `listingPhase` and silence
+  ///     since that signal exceeds the deadline;
+  ///   - pre-first-signal: no signal ever observed and time since `start()`
+  ///     exceeds the deadline (service never wrote progress at all).
+  /// The deadline is a PROVISIONAL dial (production-tuned via the
+  /// `model_download.listing_ms` probe, plan §3a): healthy listing→first-byte
+  /// is seconds; the abandonment floor observed in production is 7 minutes.
+  /// Byte-transfer/compile phases (signalCount >= 2) stay governed by the
+  /// existing ratio gate, unchanged.
+  private let listingPhase: String?
+  private let listingStallDeadlineSeconds: TimeInterval?
+
   public init(
     currentTime: @escaping @MainActor () -> TimeInterval = {
       ProcessInfo.processInfo.systemUptime
     },
-    requiresObservedGap: Bool = true
+    requiresObservedGap: Bool = true,
+    listingPhase: String? = nil,
+    listingStallDeadlineSeconds: TimeInterval? = nil
   ) {
     self.currentTime = currentTime
     self.requiresObservedGap = requiresObservedGap
+    self.listingPhase = listingPhase
+    self.listingStallDeadlineSeconds = listingStallDeadlineSeconds
   }
 
   /// Begin a new attempt. Resets all per-attempt state.
@@ -145,7 +170,29 @@ public final class LoadProgressWatcher {
 
     // No new signal this tick — evaluate silence against gates.
     guard lastSignalAt != nil else {
-      // Pre-first-signal: do not fire. Coverage hole acknowledged in plan §2.2.
+      // Pre-first-signal. With the #1339 listing deadline injected, a load
+      // whose service never writes a single progress signal (dead service,
+      // pre-listing crash) fires after the defended deadline instead of
+      // hanging forever. Without the deadline, the original #445 deferral
+      // stands: do not fire.
+      if let deadline = listingStallDeadlineSeconds,
+        now - attemptStartedAt > deadline
+      {
+        fire()
+      }
+      return
+    }
+
+    // #1339 single-signal listing-stall gate: exactly one signal observed,
+    // and it was the listing phase — the remote repo-listing call is hanging.
+    // Fires on the defended deadline; healthy loads leave listing in seconds.
+    if signalCount == 1,
+      let deadline = listingStallDeadlineSeconds,
+      let listing = listingPhase,
+      lastObservedPhase == listing,
+      now - (lastSignalAt ?? attemptStartedAt) > deadline
+    {
+      fire()
       return
     }
     // Codex finding (2026-05-07): require at least one observed inter-signal
@@ -161,11 +208,7 @@ public final class LoadProgressWatcher {
       guard !requiresObservedGap else { return }
       let silence = now - (lastSignalAt ?? attemptStartedAt)
       if silence > floorSeconds {
-        fired = true
-        if let cont = continuation {
-          continuation = nil
-          cont.resume()
-        }
+        fire()
       }
       return
     }
@@ -173,11 +216,17 @@ public final class LoadProgressWatcher {
     let ratioThreshold = maxGapSeconds * abnormalRatio
     let threshold = max(floorSeconds, ratioThreshold)
     if silence > threshold {
-      fired = true
-      if let cont = continuation {
-        continuation = nil
-        cont.resume()
-      }
+      fire()
+    }
+  }
+
+  /// Single fire path: latches `fired` and resumes any pending `wedged()`
+  /// consumer. All observeTick gates funnel here.
+  private func fire() {
+    fired = true
+    if let cont = continuation {
+      continuation = nil
+      cont.resume()
     }
   }
 
@@ -237,6 +286,27 @@ public final class LoadProgressWatcher {
       totalAttemptDurationMs: Int((now - attemptStartedAt) * 1000)
     )
   }
+}
+
+/// Shared model-download stall policy (#1339). Single authority for the
+/// listing-phase token and the listing-stall deadline so the service-side
+/// phase writer (`ParakeetBackend`), the host-side progress seam
+/// (`ASRManagerProxy`), and the sessionless wedge guard
+/// (`KernelDictationDriver`) can never drift apart on the literal or the dial.
+public enum ModelLoadStallPolicy {
+  /// The exact phase string the XPC service writes to the shared progress
+  /// file while the remote host's repo-file-listing call is in flight. The
+  /// wedge guard keys its single-signal stall gate on this token.
+  public static let listingPhase = "Preparing download..."
+
+  /// PROVISIONAL listing-stall deadline (plan §3a, issue #1339): fires only
+  /// on ABSENCE of progress in the listing window (one signal then silence,
+  /// or no signal at all) — never on a progressing transfer. Defended by
+  /// production distribution: healthy listing→first-byte is seconds; the
+  /// abandonment floor observed in production is 7 minutes (420s). Tuned
+  /// post-ship via the `model_download.listing_ms` probe; source-aware
+  /// deadlines (our-copy ~8-10s) arrive with the mirror-first source work.
+  public static let listingStallDeadlineSeconds: TimeInterval = 120
 }
 
 /// Diagnostic snapshot of a `LoadProgressWatcher`'s per-attempt state.

--- a/Sources/EnviousWisprCore/ProgressFile.swift
+++ b/Sources/EnviousWisprCore/ProgressFile.swift
@@ -15,7 +15,21 @@ public final class ProgressFile: Sendable {
 
   /// Well-known path both processes can find.
   /// Uses /tmp/ which is accessible to both the app and its XPC services.
-  private let filePath: String = "/tmp/com.enviouswispr.download-progress"
+  ///
+  /// #1339: DEBUG builds (the dev bundle + its DEBUG-compiled XPC services)
+  /// use a separate path so a dev app and the production app running side by
+  /// side never cross-read each other's download progress. Before this split,
+  /// one app's download made the other's progress UI show phantom movement —
+  /// and worse, would have fed the sessionless wedge guard false "progress"
+  /// signals that mask a genuinely stalled load. Same-variant processes
+  /// (app + its own XPC service) always agree on the path because they are
+  /// compiled together. Two same-variant instances cannot run concurrently
+  /// (LaunchServices for release; one-dev-instance policy for dev).
+  #if DEBUG
+    private let filePath: String = "/tmp/com.enviouswispr.download-progress.dev"
+  #else
+    private let filePath: String = "/tmp/com.enviouswispr.download-progress"
+  #endif
 
   private init() {}
 

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -240,6 +240,14 @@ package protocol ASREngineAdapter: AnyObject {
   /// `ParakeetEngineAdapter` via the XPC `loadProgressTickReporter`) override.
   var lastObservedPhase: String { get }
 
+  /// #1339: whether the sessionless warm-up wedge guard may arm over this
+  /// adapter's loads. True ONLY when the underlying load's progress lands in
+  /// the shared progress file the guard polls. Defaults to `false` (see the
+  /// protocol extension) — an adapter must opt in, because arming without a
+  /// live signal source turns the listing deadline into a false-positive
+  /// cancel of healthy long loads (Codex PR-1 r1 P2).
+  var warmupStallGuardEligible: Bool { get }
+
   // MARK: Session lifecycle
 
   /// Begin a recording session under `id`. `streaming` carries the kernel's
@@ -394,4 +402,11 @@ extension ASREngineAdapter {
   public func observeSpeechSegments(
     _ segments: [SpeechSegment], rawCaptureSamples: [Float]
   ) {}
+}
+
+extension ASREngineAdapter {
+  /// #1339 safe default: not eligible. `ParakeetEngineAdapter` opts in when
+  /// its manager feeds the shared progress file; signal-free adapters
+  /// (WhisperKit) and in-process managers stay uncovered.
+  public var warmupStallGuardEligible: Bool { false }
 }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -81,6 +81,110 @@ struct LimbSteps {
   let emojiRestore: EmojiRestoreStep
 }
 
+/// Issue #1339: sessionless model-load wedge guard for `ensureEngineWarm`.
+///
+/// The record-press path runs the kernel's session-scoped wedge detection
+/// inside `RecordingSessionKernel.warmUp(sid)`. The sessionless warm-up
+/// entries (onboarding / launch / engineSwap / coldPress prewarm) previously
+/// had NO consumer at all — a first-run listing stall hung "Preparing
+/// download..." forever with no Retry and no telemetry (the r/macapps P0).
+///
+/// One guard is armed per sessionless warm-up attempt (single-flighted by the
+/// driver's `sessionlessWedgeGuard` slot). It feeds a `LoadProgressWatcher`
+/// from an 8Hz poll of the shared progress file — the same signal source the
+/// host proxy polls. Reading the file here (instead of consuming
+/// `adapter.loadProgress`) avoids contending for that single-consumer
+/// AsyncStream, which a mid-attempt record-press session may claim for the
+/// kernel's own detector.
+///
+/// On a wedge it emits the existing `.modelLoadWedged` captured event +
+/// PostHog `wedge_detected` (same payload fields as the session path), then
+/// drives the existing heavy recovery (`adapter.recoverFromWedge()` →
+/// `cancelInFlightLoad` → XPC invalidation), which unblocks the parked load
+/// with a throw that `ensureEngineWarm` classifies via `didFire`.
+///
+/// Stale-file trap (mirrors the host proxy's 2026-05-07 Codex finding): the
+/// guard arms BEFORE `loadModel()` clears the progress file, so early reads
+/// may see a PREVIOUS load's file. The mtime observed at arm time is a
+/// baseline, not a signal — the watcher sees `nil` until the mtime changes.
+@MainActor
+package final class SessionlessLoadWedgeGuard {
+  private let watcher: LoadProgressWatcher
+  private let adapter: any ASREngineAdapter
+  private let reasonToken: String
+  private var pollTask: Task<Void, Never>?
+  private var fireTask: Task<Void, Never>?
+  private let staleBaselineMtime: Date?
+  private(set) var didFire = false
+
+  init(adapter: any ASREngineAdapter, reasonToken: String) {
+    self.adapter = adapter
+    self.reasonToken = reasonToken
+    self.staleBaselineMtime = ProgressFile.shared.modificationTime()
+    self.watcher = LoadProgressWatcher(
+      listingPhase: ModelLoadStallPolicy.listingPhase,
+      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds
+    )
+  }
+
+  func arm() {
+    watcher.start()
+    pollTask = Task { @MainActor [weak self] in
+      while let self, !Task.isCancelled {
+        let raw = ProgressFile.shared.modificationTime()
+        let mtime = (raw == self.staleBaselineMtime) ? nil : raw
+        let phase = ProgressFile.shared.read()?.phase ?? ""
+        self.watcher.observeTick(observedMtime: mtime, observedPhase: phase)
+        try? await Task.sleep(nanoseconds: 125_000_000)
+      }
+    }
+    fireTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      await self.watcher.wedged()
+      guard self.watcher.hasFired, !Task.isCancelled else { return }
+      // Same-tick completion race: a load that just finished is healthy —
+      // never tear down a ready engine (mirrors the kernel loop's check).
+      guard self.adapter.readiness != .ready else { return }
+      self.didFire = true
+      let snap = self.watcher.snapshot
+      let backend = self.adapter.engineIdentity.rawValue
+      SentryBreadcrumb.captureError(
+        ModelLoadWatchdog.WedgeError(),
+        category: .modelLoadWedged,
+        stage: "asr",
+        extra: [
+          "backend": backend,
+          "silence_ms": snap.silenceMs,
+          "observed_max_gap_ms": snap.maxGapMs,
+          "observed_phase": snap.lastObservedPhase,
+          "signal_count_total": snap.signalCountTotal,
+          "first_signal_latency_ms": snap.firstSignalLatencyMs ?? -1,
+          "total_attempt_duration_ms": snap.totalAttemptDurationMs,
+          "warmup_reason": reasonToken,
+          "sessionless": true,
+        ])
+      TelemetryService.shared.modelLoadWedged(
+        backend: backend,
+        stage: "sessionless_warmup",
+        silenceMs: snap.silenceMs,
+        observedMaxGapMs: snap.maxGapMs,
+        observedPhase: snap.lastObservedPhase,
+        signalCountTotal: snap.signalCountTotal,
+        firstSignalLatencyMs: snap.firstSignalLatencyMs,
+        totalAttemptDurationMs: snap.totalAttemptDurationMs)
+      await self.adapter.recoverFromWedge()
+    }
+  }
+
+  func disarm() {
+    watcher.stop()
+    pollTask?.cancel()
+    pollTask = nil
+    fireTask?.cancel()
+    fireTask = nil
+  }
+}
+
 /// Wraps `RecordingSessionKernel` as the App layer's recording driver.
 @MainActor
 @Observable
@@ -196,6 +300,13 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   @ObservationIgnored
   public var onApproachingMaxDuration: ((TimeInterval) -> Void)?
 
+  /// #1339 — the single active sessionless load-wedge guard, or nil when no
+  /// sessionless warm-up attempt is in flight. The driver-level single-flight
+  /// slot: exactly one guard per underlying load attempt, asserted by the
+  /// topology test. Package-visible for that test only.
+  @ObservationIgnored
+  package private(set) var sessionlessWedgeGuard: SessionlessLoadWedgeGuard?
+
   /// Heart-path error sink for the driver's own direct `.asrInterrupted`
   /// captureError emit. Defaulted to the production global so the only behavior
   /// change is testability — the factory threads the same injected sink it
@@ -270,6 +381,33 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     let start = ContinuousClock.now
     TelemetryService.shared.coldStartWarmupStarted(
       engine: engine, reason: reason.telemetryToken, warmupInFlight: warmupInFlight)
+    // #1339: arm the sessionless load-wedge guard — exactly one per attempt.
+    // Gated to file-backed signal sources (`warmupStallGuardEligible`:
+    // Parakeet-over-XPC yes; WhisperKit and the in-process debug manager are
+    // signal-free for the guard's poll and stay uncovered — Codex r1 P2) and
+    // to the driver-level single-flight slot (a concurrent second warm-up
+    // joins the same underlying load; the first caller's guard covers it).
+    // The record-press session path never enters here — the kernel runs its
+    // own detector.
+    var wedgeGuard: SessionlessLoadWedgeGuard?
+    if adapter.warmupStallGuardEligible, sessionlessWedgeGuard == nil {
+      let armed = SessionlessLoadWedgeGuard(
+        adapter: adapter, reasonToken: reason.telemetryToken)
+      sessionlessWedgeGuard = armed
+      wedgeGuard = armed
+      armed.arm()
+    }
+    // Joined callers (armed slot taken) must still CLASSIFY a wedge fire:
+    // capture the live guard — theirs or the armer's — before awaiting, so
+    // the catch below reads `didFire` from the guard that actually covered
+    // this load (Codex r1 P2 #2). The reference outlives the armer's disarm.
+    let observedGuard = wedgeGuard ?? sessionlessWedgeGuard
+    defer {
+      if let wedgeGuard {
+        wedgeGuard.disarm()
+        sessionlessWedgeGuard = nil
+      }
+    }
     do {
       try await adapter.warmUp()
       residentModelLostWhileIdle = false  // #959: load succeeded — drop stale marker.
@@ -284,14 +422,20 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       }
       return .ready
     } catch {
+      // #1339: a guard fire tears down the parked load via XPC invalidation,
+      // so the throw seen here is a transport/supersession error — classify it
+      // as the wedge it actually is so onboarding shows the stall-specific
+      // copy + Retry instead of a raw transport string.
+      let classified: any Error =
+        (observedGuard?.didFire == true) ? ModelLoadWatchdog.WedgeError() : error
       TelemetryService.shared.coldStartWarmupFailed(
         engine: engine, reason: reason.telemetryToken,
-        error: String(describing: error))
+        error: String(describing: classified))
       if reason == .launch {
         TelemetryService.shared.launchModelPreloadCompleted(
           backend: engine, result: "failed", durationMs: Self.elapsedMs(since: start))
       }
-      return .failed(error)
+      return .failed(classified)
     }
   }
 

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -149,7 +149,6 @@ package final class SessionlessLoadWedgeGuard {
       // Same-tick completion race: a load that just finished is healthy —
       // never tear down a ready engine (mirrors the kernel loop's check).
       guard self.adapter.readiness != .ready else { return }
-      self.didFire = true
       let snap = self.watcher.snapshot
       let backend = self.adapter.engineIdentity.rawValue
       // Live-UAT + field-diagnosis evidence line (verdicts read app.log).
@@ -158,6 +157,20 @@ package final class SessionlessLoadWedgeGuard {
           + "phase=\(snap.lastObservedPhase) silence_ms=\(snap.silenceMs) "
           + "signals=\(snap.signalCountTotal) total_ms=\(snap.totalAttemptDurationMs)",
         level: .info, category: "ASR")
+      // Deadline-edge race (cloud review, PR #1345): the log await above is a
+      // suspension point — the load can complete and `disarm()` cancel this
+      // task while it is parked. Cancellation does not stop a running task,
+      // so re-check both signals here. Everything from this guard to
+      // `recoverFromWedge()` is synchronous on MainActor, so a ready engine
+      // can no longer be torn down and no wedge telemetry is emitted for a
+      // load that actually finished.
+      guard !Task.isCancelled, self.adapter.readiness != .ready else {
+        await AppLogger.shared.log(
+          "[WedgeGuard] fire aborted — load completed during fire reason=\(self.reasonToken)",
+          level: .info, category: "ASR")
+        return
+      }
+      self.didFire = true
       SentryBreadcrumb.captureError(
         ModelLoadWatchdog.WedgeError(),
         category: .modelLoadWedged,

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -129,6 +129,10 @@ package final class SessionlessLoadWedgeGuard {
 
   func arm() {
     watcher.start()
+    Task { @MainActor [reasonToken] in
+      await AppLogger.shared.log(
+        "[WedgeGuard] armed reason=\(reasonToken)", level: .debug, category: "ASR")
+    }
     pollTask = Task { @MainActor [weak self] in
       while let self, !Task.isCancelled {
         let raw = ProgressFile.shared.modificationTime()
@@ -148,6 +152,12 @@ package final class SessionlessLoadWedgeGuard {
       self.didFire = true
       let snap = self.watcher.snapshot
       let backend = self.adapter.engineIdentity.rawValue
+      // Live-UAT + field-diagnosis evidence line (verdicts read app.log).
+      await AppLogger.shared.log(
+        "[WedgeGuard] sessionless wedge fired reason=\(self.reasonToken) backend=\(backend) "
+          + "phase=\(snap.lastObservedPhase) silence_ms=\(snap.silenceMs) "
+          + "signals=\(snap.signalCountTotal) total_ms=\(snap.totalAttemptDurationMs)",
+        level: .info, category: "ASR")
       SentryBreadcrumb.captureError(
         ModelLoadWatchdog.WedgeError(),
         category: .modelLoadWedged,

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -165,6 +165,12 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// kernel runs signal-based warm-up wedge detection.
   var loadProgress: AsyncStream<ASRLoadProgressTick>? { loadStream }
 
+  /// #1339: eligible only when the manager's load progress lands in the
+  /// shared progress file the wedge guard polls (XPC proxy yes; in-process
+  /// ASRManager no — its progress never touches the file, so the guard would
+  /// read permanent silence and cancel a healthy long download).
+  var warmupStallGuardEligible: Bool { asrManager.feedsSharedProgressFile }
+
   private func emitLoadTick() {
     loadMarker += 1
     loadContinuation.yield(ASRLoadProgressTick(marker: loadMarker))

--- a/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
+++ b/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
@@ -331,4 +331,127 @@ struct LoadProgressWatcherTests {
     #expect(watcher.hasFired, "silence past sticky-maxGap ratio must fire")
     watcher.stop()
   }
+
+  // MARK: - #1339 phase-aware listing-stall gate
+
+  /// Watcher configured like the sessionless warm-up guard: listing phase
+  /// token + a deterministic deadline the ManualClock can cross.
+  private func listingAwareWatcher(_ clock: ManualClock, deadline: TimeInterval = 120)
+    -> LoadProgressWatcher
+  {
+    LoadProgressWatcher(
+      currentTime: { clock.now },
+      listingPhase: ModelLoadStallPolicy.listingPhase,
+      listingStallDeadlineSeconds: deadline)
+  }
+
+  @Test("#1339: single listing signal then silence past the deadline FIRES")
+  func listingStallFiresAtDeadline() async {
+    let clock = ManualClock()
+    let watcher = listingAwareWatcher(clock)
+    watcher.start()
+    // The P0 shape: exactly one "Preparing download..." signal, then silence.
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    clock.tick(seconds: 119.9)
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    #expect(!watcher.hasFired, "just below the listing deadline must not fire")
+    clock.tick(seconds: 0.2)
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    #expect(watcher.hasFired, "listing silence past the deadline is the P0 stall — must fire")
+    let snap = watcher.snapshot
+    #expect(snap.signalCountTotal == 1)
+    #expect(snap.lastObservedPhase == ModelLoadStallPolicy.listingPhase)
+    watcher.stop()
+  }
+
+  @Test("#1339: single NON-listing signal then long silence does NOT fire (adversarial class)")
+  func nonListingSingleSignalStaysCovered() async {
+    let clock = ManualClock()
+    let watcher = listingAwareWatcher(clock)
+    watcher.start()
+    // Same silence shape, different phase — the deadline is scoped to the
+    // listing window only; other single-signal quiets keep the #445 deferral.
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: "Installing model...")
+    clock.tick(seconds: 500)
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: "Installing model...")
+    #expect(
+      !watcher.hasFired,
+      "the listing deadline must not become a generic single-signal timeout")
+    watcher.stop()
+  }
+
+  @Test("#1339: NO signal at all fires past the deadline (dead service)")
+  func preFirstSignalFiresWithDeadline() async {
+    let clock = ManualClock()
+    let watcher = listingAwareWatcher(clock)
+    watcher.start()
+    for _ in 0..<10 {
+      clock.tick(seconds: 13)  // evaluations at 13s..130s, crossing the 120s deadline
+      watcher.observeTick(observedMtime: nil, observedPhase: "")
+    }
+    #expect(
+      watcher.hasFired,
+      "a service that never writes a single progress signal must fire the deadline")
+    let snap = watcher.snapshot
+    #expect(snap.signalCountTotal == 0)
+    watcher.stop()
+  }
+
+  @Test("#1339: progressing download runs past the deadline WITHOUT firing")
+  func progressingTransferNeverDeadlined() async {
+    let clock = ManualClock()
+    let watcher = listingAwareWatcher(clock)
+    watcher.start()
+    // Listing completes quickly, then bytes flow: signals every 2s for 200s
+    // (well past the 120s deadline). A progressing transfer must never be
+    // wall-clock-killed (plan E1) — only the ratio gate governs it.
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    clock.tick(seconds: 2)
+    for i in 1..<100 {
+      watcher.observeTick(observedMtime: mtime(i), observedPhase: "Downloading model files...")
+      clock.tick(seconds: 2)
+    }
+    #expect(
+      !watcher.hasFired,
+      "a slow but progressing transfer must never hit a wall-clock deadline")
+    #expect(watcher.snapshot.totalAttemptDurationMs >= 200_000)
+    watcher.stop()
+  }
+
+  @Test("#1339: listing that resolves before the deadline hands off to the ratio gate")
+  func listingHandsOffToRatioGate() async {
+    let clock = ManualClock()
+    let watcher = listingAwareWatcher(clock)
+    watcher.start()
+    // Healthy listing: 5s to first byte (below deadline), then download
+    // signals. Once 2+ signals exist, the ratio gate owns detection — a
+    // silence past 5x the worst gap fires, exactly as before #1339.
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    clock.tick(seconds: 5)
+    watcher.observeTick(observedMtime: mtime(1), observedPhase: "Downloading model files...")
+    #expect(!watcher.hasFired, "healthy listing handoff must not fire")
+    // maxGap = 5s → ratio threshold 25s. 24.9s of silence: no fire.
+    clock.tick(seconds: 24.9)
+    watcher.observeTick(observedMtime: mtime(1), observedPhase: "Downloading model files...")
+    #expect(!watcher.hasFired)
+    // Past the ratio threshold: fire (mid-download wedge).
+    clock.tick(seconds: 0.2)
+    watcher.observeTick(observedMtime: mtime(1), observedPhase: "Downloading model files...")
+    #expect(watcher.hasFired, "mid-download wedge past the ratio gate must still fire")
+    watcher.stop()
+  }
+
+  @Test("#1339: default init (no deadline) preserves the pre-#1339 listing-stall behavior")
+  func defaultsPreserveLegacyBehavior() async {
+    let clock = ManualClock()
+    let watcher = LoadProgressWatcher(currentTime: { clock.now })
+    watcher.start()
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    clock.tick(seconds: 10_000)
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    #expect(
+      !watcher.hasFired,
+      "without an injected deadline the watcher keeps the deliberate #445 deferral")
+    watcher.stop()
+  }
 }

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -469,6 +469,60 @@ import Testing
     #expect(h.adapter.readiness != .ready)
   }
 
+  // MARK: #1339 — sessionless wedge-guard topology
+
+  @Test("#1339: sessionless warm-up arms EXACTLY ONE wedge guard, single slot, disarmed on exit")
+  func sessionlessWedgeGuardSingleSlot() async {
+    let h = makeDriver(behavior: .slowLoad(ticksToReady: 3))
+    #expect(h.driver.sessionlessWedgeGuard == nil, "no guard before any warm-up")
+    // First sessionless warm-up parks inside the fake's logical-clock sleep.
+    let first = Task { @MainActor in _ = await h.driver.ensureEngineWarm(reason: .onboarding) }
+    await drainUntil { h.adapter.warmUpCallCount == 1 }
+    #expect(h.driver.sessionlessWedgeGuard != nil, "guard armed for the in-flight warm-up")
+    let armed = h.driver.sessionlessWedgeGuard
+    // A concurrent second sessionless warm-up (the onboarding-vs-launch /
+    // prewarm race window) must NOT arm a second guard — the slot is single.
+    let second = Task { @MainActor in _ = await h.driver.ensureEngineWarm(reason: .launch) }
+    await drainUntil { h.adapter.warmUpCallCount == 2 }
+    #expect(
+      h.driver.sessionlessWedgeGuard === armed,
+      "the race window must not stack a second wedge consumer on one load")
+    h.clock.advance(by: 3)
+    _ = await first.value
+    _ = await second.value
+    #expect(h.driver.sessionlessWedgeGuard == nil, "guard disarmed after the attempt resolves")
+    #expect(h.adapter.readiness == .ready)
+  }
+
+  @Test("#1339: signal-free adapter (loadProgress == nil) never arms the guard")
+  func signalFreeAdapterNeverArmsGuard() async {
+    let h = makeDriver(behavior: .slowLoad(ticksToReady: 2), loadProgressAbsent: true)
+    let warm = Task { @MainActor in _ = await h.driver.ensureEngineWarm(reason: .onboarding) }
+    await drainUntil { h.adapter.warmUpCallCount == 1 }
+    #expect(
+      h.driver.sessionlessWedgeGuard == nil,
+      "a signal-free engine (WhisperKit) must stay uncovered — no watcher, no deadline")
+    h.clock.advance(by: 2)
+    _ = await warm.value
+    #expect(h.driver.sessionlessWedgeGuard == nil)
+  }
+
+  @Test("#1339: guard re-arms cleanly on a retry after a failed attempt")
+  func guardReArmsOnRetry() async {
+    let h = makeDriver(behavior: .wedgeOnLoad)
+    await h.adapter.cancel()  // makes warmUp throw immediately (no park)
+    let outcome = await h.driver.ensureEngineWarm(reason: .onboarding)
+    guard case .failed = outcome else {
+      Issue.record("expected .failed, got \(outcome)")
+      return
+    }
+    #expect(h.driver.sessionlessWedgeGuard == nil, "guard released after the failed attempt")
+    // Retry: the slot must be free to arm again (Retry re-drives the load).
+    let retry = Task { @MainActor in _ = await h.driver.ensureEngineWarm(reason: .onboarding) }
+    _ = await retry.value
+    #expect(h.driver.sessionlessWedgeGuard == nil, "and released again after the retry resolves")
+  }
+
   // MARK: Helpers
 
   private struct Harness {
@@ -476,10 +530,16 @@ import Testing
     let kernel: RecordingSessionKernel
     let outcome: KernelFinalizationOutcome
     let adapter: FakeEngine
+    let clock: FakeClock
   }
 
-  private func makeDriver(behavior: FakeEngineBehavior = .batchSuccess(text: "x")) -> Harness {
-    let adapter = FakeEngine(behavior: behavior, clock: FakeClock())
+  private func makeDriver(
+    behavior: FakeEngineBehavior = .batchSuccess(text: "x"),
+    loadProgressAbsent: Bool = false
+  ) -> Harness {
+    let clock = FakeClock()
+    let adapter = FakeEngine(
+      behavior: behavior, clock: clock, loadProgressAbsent: loadProgressAbsent)
     let kernel = RecordingSessionKernel(
       adapter: adapter,
       audioCapture: FakeAudioCapture(),
@@ -507,7 +567,7 @@ import Testing
       kernel: kernel, observer: observer, outcome: outcome,
       context: KernelSessionContext(), steps: steps, adapter: adapter)
     driver.start()
-    return Harness(driver: driver, kernel: kernel, outcome: outcome, adapter: adapter)
+    return Harness(driver: driver, kernel: kernel, outcome: outcome, adapter: adapter, clock: clock)
   }
 
   private func drainUntil(_ condition: @MainActor () -> Bool) async {

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -211,6 +211,12 @@ final class FakeEngine: ASREngineAdapter {
     loadProgressAbsent ? nil : loadStream
   }
 
+  /// #1339: the simulator opts in whenever it exposes a load stream so the
+  /// driver topology tests can exercise guard arm/disarm without a real
+  /// progress file (the guard never FIRES in tests — firing is watcher-level
+  /// tested with a ManualClock).
+  var warmupStallGuardEligible: Bool { !loadProgressAbsent }
+
   /// `nil` when the engine exposes no finalize-progress stream.
   var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? {
     finalizeProgressAbsent ? nil : finalizeStream


### PR DESCRIPTION
## What

The r/macapps P0, part 1 of 2: the sessionless warm-up entries (onboarding / launch / engine swap / cold-press prewarm) had NO stall detector, so a Hugging Face listing stall froze "Preparing download..." forever — no Retry, no telemetry. Production data: 4 of ~13 recent onboarders quit at 7-91 minutes of zero progress.

- **SessionlessLoadWedgeGuard** (driver-level, single-flighted slot): one `LoadProgressWatcher` per sessionless warm-up attempt, fed by an 8Hz poll of the shared progress file. On fire: existing `.modelLoadWedged` Sentry event + PostHog `wedge_detected` (session-path payload parity) → existing `recoverFromWedge` teardown → `ensureEngineWarm` classifies the throw as a `WedgeError`.
- **Phase-aware listing gate in `LoadProgressWatcher`** (closes the #445-deferred hole with a defended deadline): single listing signal + silence past the PROVISIONAL 120s deadline fires; zero signals (dead service) fires at the same deadline; byte/compile phases stay on the existing ratio gate; **a progressing transfer is never wall-clock-killed**.
- **`ModelLoadStallPolicy` (Core):** single authority for the listing phase token + deadline dial.
- **Eligibility gating:** the guard arms only over file-backed loads (`warmupStallGuardEligible` — XPC proxy opts in; WhisperKit and the in-process debug manager stay uncovered so a silent-by-design source can't false-fire the deadline).
- **Dev/prod progress-file split:** DEBUG builds use their own `/tmp` path so a dev app and prod app running side by side can no longer cross-read each other's download progress (pre-existing UI bug; would have poisoned the guard's signal).
- **Onboarding UX floor:** stall-specific copy ("Setup is taking longer than expected...") + working Retry; staged liveness subtitle escalation; honest byte counter (483 MB real payload, manifest-verified — the old "23 MB" was the decoder file alone).
- **Deleted dead `StallTracker`** (created, never read).

## Validation

- Full suite green: 2,391 tests (incl. new ManualClock watcher grid: fires-at-deadline / non-listing-stall-stays-uncovered / dead-service-fires / progressing-transfer-never-deadlined / ratio handoff / legacy defaults; driver topology: exactly one guard per warm-up incl. the concurrent race window, signal-free never armed, re-arm on Retry).
- Local codex review: 3 rounds (r1 two P2s fixed — in-process false-arm, joiner misclassification; r2 clean; r3 clean incl. the progress-file split).
- **Live UAT (drill):** dev ASR service frozen 350ms after spawn during a launch warm-up → guard armed at launch, fired at exactly 120.000s with zero signals, full diagnostic payload in app.log, XPC teardown observed, next warm-up re-armed cleanly. Heart path after recovery: PASS, pipeline 0.938s. Note: the FIRST decode immediately after the drill's kill-during-load returned empty (`asrEmpty`) and recovered on the next press — pre-existing cold-respawn shape, not introduced here (this diff does not touch decode).

Provisional dials per plan §3a (founder-approved ship-and-tune): listing 120s; the `listing_ms` probe + source-aware deadlines land in PR-2 (mirror-first source).

Part of #1339 (PR-1 of 2).