### PR TITLE
content(website): CTR-recovery meta titles + descriptions on 8 page-1 assets

### DIFF
--- a/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+++ b/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
@@ -1,6 +1,6 @@
 ---
 title: "On-Device vs Cloud Dictation: Which Is Private on Mac?"
-description: "Cloud dictation uploads your voice; on-device keeps it on your Mac. See exactly what happens to your audio in each, and which Mac apps do which."
+description: "Cloud dictation uploads your voice; on-device dictation keeps it on your Mac. Here's what happens to your audio in each, and which Mac apps do which."
 pubDate: 2026-03-23
 updatedDate: 2026-05-15
 tags: ["privacy", "dictation", "comparison", "on-device", "speech-to-text"]

--- a/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+++ b/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
@@ -1,6 +1,6 @@
 ---
-title: "On-Device vs Cloud Dictation: Which Is Actually Private on Mac?"
-description: "Cloud dictation uploads your voice. On-device dictation keeps it on your Mac. We break down exactly what happens to your audio in both, the privacy trade-offs, and which Mac dictation apps fall in which camp."
+title: "On-Device vs Cloud Dictation: Which Is Private on Mac?"
+description: "Cloud dictation uploads your voice; on-device keeps it on your Mac. See exactly what happens to your audio in each, and which Mac apps do which."
 pubDate: 2026-03-23
 updatedDate: 2026-05-15
 tags: ["privacy", "dictation", "comparison", "on-device", "speech-to-text"]

--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -152,8 +152,8 @@ const faqJsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-  title="EnviousWispr vs Apple Dictation: Mac Voice-to-Text"
-  description="Compare EnviousWispr vs Apple Dictation on speed, AI polish, and custom words. Both free, both on-device. See why a dedicated app goes further."
+  title="Apple Dictation vs EnviousWispr: Custom Words on Mac"
+  description="Apple Dictation is built in and free. EnviousWispr adds custom words, longer dictation, and optional AI polish while your voice stays on your Mac."
   activePage="compare"
   ogImage="/images/og/apple-dictation.png"
   canonicalPath="/compare/apple-dictation/"

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -153,7 +153,7 @@ const faqJsonLd = JSON.stringify({
 
 <BaseLayout
   title="EnviousWispr vs Notta: Dictation vs Meeting Notes"
-  description="Compare EnviousWispr vs Notta. Free on-device Mac dictation vs cloud meeting transcription. Different tools for different jobs."
+  description="Notta records and transcribes meetings in the cloud. EnviousWispr is free, on-device Mac dictation for writing anywhere. Different jobs, compared."
   activePage="compare"
   ogImage="/images/og/notta.png"
   ogType="article"

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -144,8 +144,8 @@ const faqJsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-  title="EnviousWispr vs Superwhisper: Free Mac Dictation"
-  description="Compare EnviousWispr vs Superwhisper on price, speech engines, offline support, and speed. Free on-device dictation for Apple Silicon Macs. No subscription."
+  title="Superwhisper vs EnviousWispr: Free Mac Dictation"
+  description="Compare Superwhisper and EnviousWispr on price, privacy, offline use, and paste flow. EnviousWispr is free, GPLv3, and needs no subscription."
   activePage="compare"
   ogImage="/images/og/superwhisper.png"
   canonicalPath="/compare/superwhisper/"

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -144,8 +144,8 @@ const faqJsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-  title="EnviousWispr vs VoiceInk: Free Mac Dictation Compared"
-  description="Compare EnviousWispr vs VoiceInk on price, speed, speech engines, and AI polish. Both are on-device Mac dictation apps. EnviousWispr is free."
+  title="VoiceInk vs EnviousWispr: Free, Open-Source Dictation"
+  description="VoiceInk is on-device and open source with a paid app after a free trial. EnviousWispr is completely free, GPLv3, and needs no account. Compared."
   activePage="compare"
   ogImage="/images/og/voiceink.png"
   ogType="article"

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -74,8 +74,8 @@ const breadcrumbJsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-  title="EnviousWispr vs whisper.cpp: App vs Developer CLI"
-  description="Compare EnviousWispr and whisper.cpp. Both on-device. EnviousWispr adds GUI, hotkeys, AI polish, and clipboard integration. No terminal needed."
+  title="whisper.cpp vs EnviousWispr: Free Mac App, No Terminal"
+  description="whisper.cpp is a command-line tool. EnviousWispr is a free GPLv3 Mac app for on-device dictation: global hotkey, AI polish, paste anywhere. No terminal."
   activePage="compare"
   ogImage="/images/og/whisper-cpp.png"
   ogType="article"

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -75,8 +75,8 @@ const breadcrumbJsonLd = JSON.stringify({
 ---
 
 <BaseLayout
-  title="EnviousWispr vs Willow Voice: Free On-Device Mac Dictation"
-  description="Compare EnviousWispr vs Willow Voice: price, privacy, offline, speed. Free on-device dictation for Apple Silicon. No subscription."
+  title="Willow Voice vs EnviousWispr: Free On-Device Dictation"
+  description="Looking at Willow Voice? EnviousWispr is free, on-device Mac dictation for Apple Silicon: your voice stays on your Mac, no subscription, no account."
   activePage="compare"
   ogImage="/images/og/willow-voice.png"
   ogType="article"

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -153,7 +153,7 @@ const faqJsonLd = JSON.stringify({
 
 <BaseLayout
   title="EnviousWispr vs WisprFlow: Free Private Mac Dictation"
-  description="Compare EnviousWispr vs WisprFlow on price, privacy, offline support, and speed. Free on-device dictation for Apple Silicon Macs. No account required."
+  description="If you like WisprFlow but prefer no subscription or account, compare EnviousWispr: free Mac dictation, on-device audio, hotkey to paste."
   activePage="compare"
   canonicalPath="/compare/wisprflow/"
   ogImage="/images/og/wisprflow.png"


### PR DESCRIPTION
## What
Eight pages rank on Google page one (position 8-11) but earn almost no clicks. Rewrote each **meta title** (50-60 chars) and **meta description** (145-155) to lead with the differentiator matching each page's real search intent, pulled from Search Console (last 28 days). **Meta tags only** — no on-page H1 or structured-data changes.

Targets: 7 comparison pages (whisper-cpp 1533 imp, voiceink 1087, willow-voice, superwhisper, apple-dictation, notta, wisprflow) + the on-device-vs-cloud privacy blog (1143 imp). Competitor-name-first on the 5 clear competitor-brand pages; safe framing kept on WisprFlow + Notta.

## Third-party review (council)
GPT-5.5 + Gemini-3.1 roleplayed real searchers and stress-tested the drafts (session `ctr-title-rewrites-2026-07-06`). Adopted fixes:
- **whisper.cpp:** removed a false claim that we "wrap the same transcription" — EnviousWispr uses WhisperKit + Parakeet, not whisper.cpp.
- **WisprFlow:** "no cloud" → "on-device audio" (optional cloud polish sends chosen text out; kept generous framing).
- **Apple Dictation:** "still on-device" → "while your voice stays on your Mac" (polish may be cloud).
- **VoiceInk:** named the real difference (paid app after trial vs free GPLv3) since VoiceInk is also on-device + open source.

## Guardrails
No banned hype words, no em/en dashes, generous competitor framing, privacy-precise claims. Applied via fail-loud exact-match script (1 occurrence each + length + banned-word + dash guards). `astro build` green (57 pages).

## Measurement
Testable experiment: re-check per-page CTR + position in ~4 weeks; roll back any title that degrades ranking. Folds into SEO backlog #538.

Part of the SEO click-recovery work.