### PR TITLE
fix(asr): transfer-aware silence floor for the download wedge guard (#1348 precondition)

### DIFF
--- a/Sources/EnviousWisprCore/LoadProgressWatcher.swift
+++ b/Sources/EnviousWisprCore/LoadProgressWatcher.swift
@@ -39,11 +39,16 @@ import Foundation
 @MainActor
 public final class LoadProgressWatcher {
   /// Minimum silence (seconds) before the watcher can fire, even if the ratio
-  /// gate is met. Matches `AVCaptureSessionSource` first-buffer liveness latch
-  /// (800ms) — the only foreground-user-watching silence threshold in our
-  /// codebase. Treats "user staring at screen waiting for state to advance"
-  /// as the relevant analogue.
-  private let floorSeconds: TimeInterval = 0.8
+  /// gate is met. The 0.8s default matches `AVCaptureSessionSource`'s
+  /// first-buffer liveness latch — the right beat for XPC lifecycle signals.
+  ///
+  /// #1339 made this injectable: for INTERNET TRANSFER watching the 0.8s beat
+  /// is wrong — the 2026-07-05 Live UAT drill showed a cold edge read of the
+  /// 445MB encoder object producing a legitimate multi-second first-byte gap,
+  /// and a ratio threshold derived from the dense small-file ticks before it
+  /// (~2.5s) killed a HEALTHY fresh-install download. Download watchers pass
+  /// `ModelLoadStallPolicy.transferSilenceFloorSeconds` instead.
+  private let floorSeconds: TimeInterval
 
   /// Multiplier applied to the worst observed inter-signal gap to compute
   /// the ratio threshold. 5x is the statistical "definitely abnormal" ratio.
@@ -107,12 +112,14 @@ public final class LoadProgressWatcher {
     },
     requiresObservedGap: Bool = true,
     listingPhase: String? = nil,
-    listingStallDeadlineSeconds: TimeInterval? = nil
+    listingStallDeadlineSeconds: TimeInterval? = nil,
+    silenceFloorSeconds: TimeInterval = 0.8
   ) {
     self.currentTime = currentTime
     self.requiresObservedGap = requiresObservedGap
     self.listingPhase = listingPhase
     self.listingStallDeadlineSeconds = listingStallDeadlineSeconds
+    self.floorSeconds = silenceFloorSeconds
   }
 
   /// Begin a new attempt. Resets all per-attempt state.
@@ -307,6 +314,15 @@ public enum ModelLoadStallPolicy {
   /// post-ship via the `model_download.listing_ms` probe; source-aware
   /// deadlines (our-copy ~8-10s) arrive with the mirror-first source work.
   public static let listingStallDeadlineSeconds: TimeInterval = 120
+
+  /// Minimum mid-stream silence before a download-watching ratio gate may
+  /// fire. Defended by the 2026-07-05 Live UAT drill (#1339): a COLD edge
+  /// read of the 445MB encoder object produced a legitimate multi-second
+  /// first-byte gap, and the 0.8s XPC-beat floor let a ~2.5s ratio threshold
+  /// kill a healthy fresh-install download. 15s comfortably clears observed
+  /// cold-TTFB (~3-5s) while still surfacing a genuinely dead mid-stream
+  /// transfer fast. PROVISIONAL — tuned post-ship from download telemetry.
+  public static let transferSilenceFloorSeconds: TimeInterval = 15
 }
 
 /// Diagnostic snapshot of a `LoadProgressWatcher`'s per-attempt state.

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -123,7 +123,15 @@ package final class SessionlessLoadWedgeGuard {
     self.staleBaselineMtime = ProgressFile.shared.modificationTime()
     self.watcher = LoadProgressWatcher(
       listingPhase: ModelLoadStallPolicy.listingPhase,
-      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds
+      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
+      // #1339 drill regression (2026-07-05): this guard watches an INTERNET
+      // TRANSFER, and the default 0.8s XPC-beat silence floor let the ratio
+      // gate fire during the 445MB encoder object's legitimate cold
+      // first-byte gap (~3-5s), killing a healthy fresh-install download —
+      // and its recovery (generation bump) cancels the whole load. The
+      // transfer floor rides out cold-TTFB while still surfacing a genuinely
+      // dead mid-stream transfer within seconds.
+      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds
     )
   }
 

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -117,7 +117,8 @@ struct KernelFinalizationWiring {
   static let tickDurationSeconds: Double = 0.1
 
   /// Wedge window in ticks: `10 x 100 ms = 1.0 s`. Above `LoadProgressWatcher`'s
-  /// 0.8 s silence floor (`LoadProgressWatcher.swift:41`) with a 200 ms margin —
+  /// default 0.8 s silence floor (`silenceFloorSeconds` init default) with a
+  /// 200 ms margin —
   /// the kernel's cadence detector cannot false-positive a wedge sooner than
   /// today's shipped detector is even allowed to (no arbitrary timeout; both
   /// values are precedent-derived).

--- a/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
+++ b/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
@@ -441,6 +441,64 @@ struct LoadProgressWatcherTests {
     watcher.stop()
   }
 
+  @Test(
+    "#1339 drill regression: a cold big-file first-byte gap does NOT fire with the transfer floor"
+  )
+  func coldFirstByteGapDoesNotFireWithTransferFloor() async {
+    // The 2026-07-05 Live UAT drill shape: dense ticks from listing + small
+    // files (~0.5s cadence), then the 445MB object's COLD first-byte gap of
+    // ~3s. With the 0.8s floor the ratio threshold (0.5s x 5 = 2.5s) killed
+    // the healthy download; the transfer floor (15s) must ride the gap out.
+    let clock = ManualClock()
+    let watcher = LoadProgressWatcher(
+      currentTime: { clock.now },
+      listingPhase: ModelLoadStallPolicy.listingPhase,
+      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
+      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds)
+    watcher.start()
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    for i in 1..<10 {
+      clock.tick(seconds: 0.5)
+      watcher.observeTick(observedMtime: mtime(i), observedPhase: "Downloading model files...")
+    }
+    // Cold first-byte gap: 3s of silence — the ratio gate (2.5s) is met but
+    // the 15s transfer floor holds.
+    clock.tick(seconds: 3)
+    watcher.observeTick(observedMtime: mtime(9), observedPhase: "Downloading model files...")
+    #expect(!watcher.hasFired, "a cold first-byte gap must never kill a healthy download")
+    // Boundary: total silence just below the floor — still no fire.
+    clock.tick(seconds: 11.9)
+    watcher.observeTick(observedMtime: mtime(9), observedPhase: "Downloading model files...")
+    #expect(!watcher.hasFired, "total silence just below the transfer floor must not fire")
+    // A genuinely dead mid-stream transfer still fires once past the floor.
+    clock.tick(seconds: 0.2)
+    watcher.observeTick(observedMtime: mtime(9), observedPhase: "Downloading model files...")
+    #expect(watcher.hasFired, "true mid-stream death past the transfer floor must fire")
+    watcher.stop()
+  }
+
+  @Test("#1339 drill regression: the DEFAULT 0.8s floor still fires on the same gap (opt-in fix)")
+  func defaultFloorStillFiresOnColdGap() async {
+    // Negative pair for the test above: without the injected transfer floor,
+    // the identical signal shape fires at the ratio threshold. Locks the fix
+    // as opt-in — XPC lifecycle watchers keep the 0.8s beat unchanged.
+    let clock = ManualClock()
+    let watcher = LoadProgressWatcher(
+      currentTime: { clock.now },
+      listingPhase: ModelLoadStallPolicy.listingPhase,
+      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds)
+    watcher.start()
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    for i in 1..<10 {
+      clock.tick(seconds: 0.5)
+      watcher.observeTick(observedMtime: mtime(i), observedPhase: "Downloading model files...")
+    }
+    clock.tick(seconds: 3)
+    watcher.observeTick(observedMtime: mtime(9), observedPhase: "Downloading model files...")
+    #expect(watcher.hasFired, "the default floor lets the ratio gate fire on a 3s gap")
+    watcher.stop()
+  }
+
   @Test("#1339: default init (no deadline) preserves the pre-#1339 listing-stall behavior")
   func defaultsPreserveLegacyBehavior() async {
     let clock = ManualClock()


### PR DESCRIPTION
## What

The sessionless load wedge guard (#1345) watches an internet transfer using `LoadProgressWatcher`'s 0.8s silence floor — a threshold tuned for XPC lifecycle beats. The 2026-07-05 Live UAT drill (#1339) proved the failure mode: the 445MB encoder object's legitimate cold first-byte gap (~3-5s) exceeded the ratio threshold derived from the dense small-file ticks before it (~2.5s), so the guard killed a HEALTHY fresh-install download — and its generation-bump recovery cancels the whole load. This is live false-fire risk for every fresh install on main.

Fix: the silence floor becomes an init parameter (default 0.8s — every existing construction unchanged), and the guard passes the new `ModelLoadStallPolicy.transferSilenceFloorSeconds` (15s, PROVISIONAL) so cold-TTFB gaps ride out while a genuinely dead mid-stream transfer still fires in seconds.

Extracted from parked branch `feat/1339-reliable-model-source` per the #1339 MUST-SHIP note / #1348 precondition. Deliberate adaptation: on the parked branch the guard used a 120s floor because per-attempt failover watchers (15s) fired first there; main has no failover layer, so the guard takes the 15s transfer floor directly.

## Scope verification

- All `LoadProgressWatcher` constructions audited: only the sessionless guard watches a transfer. `XPCOperationSignalFile` keeps the default; the kernel's session-path detector consumes 8Hz poll ticks that flow regardless of file movement (no mtime-silence class).
- Stale 0.8s cross-reference comment in the kernel wiring updated.

## Validation

- `scripts/xcode-test.sh`: 2,393 tests green (+2 = the new regression tests).
- Tests: drill-shape regression (cold 3s gap must NOT fire; boundary just below/above the 15s floor) + negative pair (default floor still fires at the ratio threshold — locks the fix as opt-in).
- Local `codex review` vs origin/main: clean round 1 (no actionable bugs).
- Live UAT on the rebuilt dev app: end-to-end recording PASS (pipeline 0.785s), guard armed at launch, no fire.
- Fresh-install cold-download drill deliberately not repeated for this extraction: the identical floor mechanics passed yesterday's live drill on the parked branch, the drill shape is locked deterministically in tests, and re-running requires wiping the founder's production model cache (authorization was scoped to the #1339 emergency).

Part of #1348 (precondition). Updates #1339.