### PR TITLE
content(blog): correct Auto-detect language copy to opening audio, not whole recording (#1328)

### DIFF
--- a/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
+++ b/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
@@ -15,7 +15,7 @@ faqs:
   - question: "Does live transcription send my audio to the cloud?"
     answer: "No. Live transcription runs entirely on your Mac, the same as regular transcription. The audio never leaves your device in either mode. The only difference is when the work happens: while you speak instead of after you stop."
   - question: "Why does live transcription turn off when Auto-detect language is on?"
-    answer: "Live transcription has to commit to one language within the first second or two of your recording, which is not enough audio to detect a language reliably. With Auto-detect on, EnviousWispr waits and decides the language from your whole recording instead, which is far more accurate. Pick a specific language in Settings to stream live."
+    answer: "Live transcription has to commit to one language within the first second or two of your recording, which is not enough audio to detect a language reliably. With Auto-detect on, EnviousWispr waits until you stop and decides the language from more of your opening audio instead, which is far more accurate. Pick a specific language in Settings to stream live."
   - question: "Does live transcription work with the Fast engine too?"
     answer: "Yes. The Fast engine has transcribed live for a while. What is new is that the All Languages engine, the one that covers 99 languages and the toughest audio, now does it too."
   - question: "Is live transcription less accurate?"
@@ -46,7 +46,7 @@ There is one setting that turns this off on purpose: Auto-detect language.
 
 Live transcription has to commit to a language on its very first pass, a second or two into your recording. That is almost no audio to judge from. If it guessed wrong there, every confirmed word after that would be in the wrong language, and confirmed words cannot be taken back.
 
-So with Auto-detect on, EnviousWispr does the careful thing instead: it waits until you finish, listens to the whole recording, and decides the language with all the evidence in hand. You get the traditional end-of-recording wait, and in exchange you get the right language essentially every time. The app notes this right under the toggle, so it is never a mystery.
+So with Auto-detect on, EnviousWispr does the careful thing instead: it waits until you finish, then judges the language from your opening audio, seconds of it, rather than the split second live mode would have to decide from. You get the traditional end-of-recording wait, and in exchange you get the right language essentially every time. The app notes this right under the toggle, so it is never a mystery.
 
 If you dictate in one language, the fix is simple: pick it. Settings, Transcription, Language. Locked to a specific language, the All Languages engine streams live.
 


### PR DESCRIPTION
## What
Fixes the one load-bearing inaccuracy Codex flagged in the live-transcription blog post (#1328): it told readers Auto-detect "decides the language from your whole recording."

## Why it was wrong
Language identification samples only the **opening windows** — the first few seconds, capped at ~12s (`LanguageTypes.swift` `windows = [(0,3),(1,4),(2,6)]`, `fullWindowMaxSec = 12`) — then transcribes the whole recording in one batch pass. So the *transcription* waits for the end (true), but the *language decision* uses the opening audio, not the whole recording.

## Change
Two lines reworded to "more of your opening audio," keeping the post's argument intact (Auto-detect trades the instant live finish for a reliable language call). No mechanism claim beyond what the code does.

- FAQ answer (line 18)
- Body paragraph (line 49)

## Validation
- `astro build` green (57 pages).
- Content lane; blog-only prose change.

Closes #1328