### PR TITLE
content(website): own "what is on-device dictation" + name EG-1 as the on-device model

### DIFF
--- a/website/src/content/blog/on-device-dictation-polishing-small-models.md
+++ b/website/src/content/blog/on-device-dictation-polishing-small-models.md
@@ -2,6 +2,7 @@
 title: "Structural Engineering for Small Language Models in On-Device Dictation Polishing"
 description: "We brought a roughly 3-billion-parameter on-device model to within six to eight points of frontier cloud models on a 300-case dictation-polishing benchmark. Here is the result and the engineering it took."
 pubDate: 2026-05-30
+updatedDate: 2026-07-06
 tags: ["on-device", "small-language-models", "apple-intelligence", "dictation", "benchmarks", "privacy"]
 author: "Saurabh Vaish"
 keywords: ["on-device dictation", "small language model polishing", "Apple Intelligence on-device model", "private speech to text", "on-device vs cloud language model"]

--- a/website/src/content/blog/on-device-dictation-polishing-small-models.md
+++ b/website/src/content/blog/on-device-dictation-polishing-small-models.md
@@ -127,3 +127,7 @@ This is an internal, judge-scored, English-centric benchmark. The pass rates are
 ## 12. Future work
 
 The mapped gaps in language preservation, revision handling, and homophones are the priority research targets. A learned detector that more precisely identifies when the on-device model has refused or mangled its output is in development. It is not yet shipped, and this report does not claim it as deployed. The system already performs deterministic, non-model text editing before the model runs. The direction is to extend this deterministic layer to more mechanical edits (capitalization, additional filler, light grammar), reserving the model budget for edits that need judgment.
+
+## Postscript: from this research to EG-1
+
+Since this study, we shipped EG-1, our own on-device model tuned specifically for dictation polishing. It runs locally on Apple Silicon inside the same deterministic and reliability layers described here, and ships as a free, optional download in [EnviousWispr](/how-it-works/). It is the production continuation of the work reported here.

--- a/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+++ b/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
@@ -2,7 +2,7 @@
 title: "On-Device vs Cloud Dictation: Which Is Private on Mac?"
 description: "Cloud dictation uploads your voice; on-device dictation keeps it on your Mac. Here's what happens to your audio in each, and which Mac apps do which."
 pubDate: 2026-03-23
-updatedDate: 2026-05-15
+updatedDate: 2026-07-06
 tags: ["privacy", "dictation", "comparison", "on-device", "speech-to-text"]
 author: "Saurabh Vaish"
 faqs:

--- a/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
+++ b/website/src/content/blog/on-device-vs-cloud-dictation-privacy.md
@@ -6,6 +6,8 @@ updatedDate: 2026-05-15
 tags: ["privacy", "dictation", "comparison", "on-device", "speech-to-text"]
 author: "Saurabh Vaish"
 faqs:
+  - question: "What is on-device dictation?"
+    answer: "On-device dictation turns your speech into text entirely on your own computer, with nothing sent to a server. On a Mac, the speech model runs locally on Apple Silicon, so your voice never leaves the device and it works offline. Optional AI cleanup can also stay on-device, using Apple Intelligence, EG-1, or Ollama, or use a cloud provider if you choose."
   - question: "Is on-device dictation as accurate as cloud dictation?"
     answer: "On modern hardware, yes. On-device speech recognition models running natively via Core ML on Apple Silicon achieve word error rates under 2% on standard benchmarks, competitive with leading cloud speech APIs. For most English dictation, you won't notice a meaningful difference."
   - question: "Does on-device dictation work offline?"
@@ -141,6 +143,10 @@ If you want to try on-device dictation on your Mac:
 The speech model downloads automatically on first launch. After that, you're dictating privately, offline, with nothing standing between you and your text. The [getting started guide](/blog/getting-started-enviouswispr-under-2-minutes/) walks through the full first-run setup in under two minutes. If you run into issues, [open an issue on GitHub](https://github.com/saurabhav88/EnviousWispr).
 
 ## Frequently asked questions
+
+### What is on-device dictation?
+
+On-device dictation turns your speech into text entirely on your own computer, with nothing sent to a server. On a Mac, the speech model runs locally on Apple Silicon, so your voice never leaves the device and it works offline. Optional AI cleanup can also stay on-device, using Apple Intelligence, EG-1, or Ollama, or use a cloud provider if you choose.
 
 ### Is on-device dictation as accurate as cloud dictation?
 


### PR DESCRIPTION
## What
SEO entity play. "what is on device dictation" pulls impressions and we already rank page one (pos ~10). EG-1 is now a named site-wide entity with zero keyword competition. This plants the flag on the concept and names EG-1 as the answer, on the two posts that already rank for the on-device concept.

- **Privacy post** (pos 9.2 for the query): added a self-contained, AI-citable "What is on-device dictation?" FAQ (FAQPage schema + visible mirror) that defines the concept and names EG-1 as an on-device polish option.
- **Small-models research post** (pos 3.9, our best-ranked on-device-concept page): added an honest "Postscript: from this research to EG-1" naming EG-1 as the production continuation of the study, with an internal link to /how-it-works/. **Deliberately no benchmark number** next to the post's internal 91.0% table — EG-1's figure comes from a different eval run, and juxtaposing would imply a same-methodology head-to-head.

## Guardrails
Prose-only, Content lane. No dashes, no overclaim, honest benchmark handling. `astro build` green (57 pages). Folds into SEO backlog #538.