### PR TITLE
chore(asr): land the deployed parakeet-mirror Worker source in-repo (#1348 PR-2a)

### DIFF
--- a/workers/parakeet-mirror/expected-manifest.json
+++ b/workers/parakeet-mirror/expected-manifest.json
@@ -1,0 +1,132 @@
+{
+  "schema": 1,
+  "repo": "FluidInference/parakeet-tdt-0.6b-v3-coreml",
+  "revision": "aed02740059203c4a87495924f685de3722ae9ce",
+  "generatedAt": "2026-07-05",
+  "source": "local verified cache, byte-checked against HF tree oids (lfs sha256 / git sha1) at the pinned revision",
+  "requiredModelDirs": [
+    "Decoder.mlmodelc",
+    "Encoder.mlmodelc",
+    "JointDecisionv3.mlmodelc",
+    "Preprocessor.mlmodelc"
+  ],
+  "vocabularyFile": "parakeet_vocab.json",
+  "files": [
+    {
+      "path": "Decoder.mlmodelc/analytics/coremldata.bin",
+      "size": 243,
+      "sha256": "4238c4e81ecd0dc94bd7dfbb60f7e2cc824107c1ffe0387b8607b72833dba350"
+    },
+    {
+      "path": "Decoder.mlmodelc/coremldata.bin",
+      "size": 554,
+      "sha256": "18647af085d87bd8f3121c8a9b4d4564c1ede038dab63d295b4e745cf2d7fb99"
+    },
+    {
+      "path": "Decoder.mlmodelc/metadata.json",
+      "size": 3427,
+      "sha256": "a39e93cd8371b8ded92635c7804fcd0590f0d1dd9415c6d19a0484be073077d9"
+    },
+    {
+      "path": "Decoder.mlmodelc/model.mil",
+      "size": 13110,
+      "sha256": "ef2a0a281695398a62fde86ac269c68f73d5b578d7ed3b31f2ba91a2d1ea1f35"
+    },
+    {
+      "path": "Decoder.mlmodelc/weights/weight.bin",
+      "size": 23604992,
+      "sha256": "48adf0f0d47c406c8253d4f7fef967436a39da14f5a65e66d5a4b407be355d41"
+    },
+    {
+      "path": "Encoder.mlmodelc/analytics/coremldata.bin",
+      "size": 243,
+      "sha256": "42e638870d73f26b332918a3496ce36793fbb413a81cbd3d16ba01328637a105"
+    },
+    {
+      "path": "Encoder.mlmodelc/coremldata.bin",
+      "size": 485,
+      "sha256": "d48034a167a82e88fc3df64f60af963ab3983538271175b8319e7d5720a0fb86"
+    },
+    {
+      "path": "Encoder.mlmodelc/metadata.json",
+      "size": 2921,
+      "sha256": "da24da9cca943fb29d7fa8e376d57fca7cb3aa08ca51b956b0b0e56813f087e9"
+    },
+    {
+      "path": "Encoder.mlmodelc/model.mil",
+      "size": 959769,
+      "sha256": "ed7b19156ca29fa7dfd6891deb9fda4b0e8893f68597c985d135736546a43808"
+    },
+    {
+      "path": "Encoder.mlmodelc/weights/weight.bin",
+      "size": 445187200,
+      "sha256": "e2020f323703477a5b21d7c2d282c403e371afb5962e79877e3033e73ba6f421"
+    },
+    {
+      "path": "JointDecisionv3.mlmodelc/analytics/coremldata.bin",
+      "size": 243,
+      "sha256": "26def4bf73dd56d29dee21c8ef97cb8969e62f6120ed1adc91e46828e2737b6c"
+    },
+    {
+      "path": "JointDecisionv3.mlmodelc/coremldata.bin",
+      "size": 521,
+      "sha256": "f5fc08b741400f0088492c9e839418b1e18522f19cba28d361dd030c5f398342"
+    },
+    {
+      "path": "JointDecisionv3.mlmodelc/metadata.json",
+      "size": 3453,
+      "sha256": "d9307211b9a37e0f0ac260c7660b1571a3de25841035cfdf9b58fd40425f890f"
+    },
+    {
+      "path": "JointDecisionv3.mlmodelc/model.mil",
+      "size": 11775,
+      "sha256": "be60732943389a047175111a83f8839f3eb39d4803adafa828a0871b2f39818d"
+    },
+    {
+      "path": "JointDecisionv3.mlmodelc/weights/weight.bin",
+      "size": 12642764,
+      "sha256": "4e0e63d840032f7f07ddb1d64446051166281e5491bf22da8a945c41f6eedb3e"
+    },
+    {
+      "path": "Preprocessor.mlmodelc/analytics/coremldata.bin",
+      "size": 243,
+      "sha256": "c9beeb989c8d66f8be11df59bc6df277ec76cee404f6865b46243835ef562f6d"
+    },
+    {
+      "path": "Preprocessor.mlmodelc/coremldata.bin",
+      "size": 486,
+      "sha256": "dbde3f2300842c1fd51ef3ff948a0bcffe65ffd2dca10707f2509f32c1d65b1d"
+    },
+    {
+      "path": "Preprocessor.mlmodelc/metadata.json",
+      "size": 2841,
+      "sha256": "2a98699e22d279dd37fa1d238aeb1c6db1df0d6fad687775324157689d8f3acf"
+    },
+    {
+      "path": "Preprocessor.mlmodelc/model.mil",
+      "size": 28181,
+      "sha256": "4b8518a956450fec57f06c2a21bdffc26973f7f1fa6842fb38fe917f896b6b93"
+    },
+    {
+      "path": "Preprocessor.mlmodelc/weights/weight.bin",
+      "size": 491072,
+      "sha256": "129b76e3aeafa8afa3ea76d995b964b145fe83700d579f6ff42c4c38fa0968ea"
+    },
+    {
+      "path": "config.json",
+      "size": 2,
+      "sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    },
+    {
+      "path": "parakeet_v3_vocab.json",
+      "size": 151122,
+      "sha256": "7ec60e05f1b24480736ec0eed40900f4626bce1fa9a60fd700ec7e2a59198735"
+    },
+    {
+      "path": "parakeet_vocab.json",
+      "size": 151122,
+      "sha256": "7ec60e05f1b24480736ec0eed40900f4626bce1fa9a60fd700ec7e2a59198735"
+    }
+  ],
+  "totalBytes": 483256769
+}

--- a/workers/parakeet-mirror/scripts/verify-deploy.py
+++ b/workers/parakeet-mirror/scripts/verify-deploy.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Deploy gate for the parakeet-mirror worker (#1339).
+
+Run AFTER `wrangler deploy` and BEFORE the app change that points at the
+mirror ships. Verifies, against https://models.enviouslabs.co:
+
+  1. EG-1 routes (live traffic) are untouched: /eg1/... still serves.
+  2. The worker listing, walked recursively exactly like FluidAudio walks it,
+     reconstructs EXACTLY the expected manifest's file set (path + size).
+     The expected manifest derives from the pinned upstream revision, never
+     from bucket contents (anti-self-certification, plan E3/E3a).
+  3. Every file downloads in full and matches its SHA-256.
+  4. Range semantics: bounded/suffix/open 206 with correct Content-Range,
+     past-EOF 416, multi-range tolerated.
+  5. Unknown paths 404 with JSON (never an HTML page a client would choke on).
+
+Exit 0 = safe to flip. Any failure = do NOT ship the app change.
+"""
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+HOST = "https://models.enviouslabs.co"
+REPO = "FluidInference/parakeet-tdt-0.6b-v3-coreml"
+HERE = os.path.dirname(os.path.abspath(__file__))
+MANIFEST = json.load(open(os.path.join(HERE, "..", "expected-manifest.json")))
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    status = "ok" if cond else "FAIL"
+    print(f"[{status}] {name}" + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def fetch(path, method="GET", headers=None, want_body=True):
+    # Zone bot protection 403s Python's default UA; identify as a normal client
+    # (the app itself downloads via URLSession/CFNetwork, which passes).
+    hdrs = {"User-Agent": "EnviousWispr-deploy-gate/1 (curl-equivalent)"}
+    hdrs.update(headers or {})
+    req = urllib.request.Request(HOST + path, method=method, headers=hdrs)
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, {k.lower(): v for k, v in r.headers.items()}, (r.read() if want_body else b"")
+    except urllib.error.HTTPError as e:
+        return e.code, {k.lower(): v for k, v in e.headers.items()}, e.read()
+
+
+# 1. EG-1 live routes untouched
+st, hd, _ = fetch("/eg1/EG-1-MODEL-LICENSE.txt", want_body=False)
+check("EG-1 license route still serves (worker must not shadow /eg1/)", st == 200, f"status {st}")
+
+# 2. Recursive listing walk == expected manifest
+found = {}
+
+
+def walk(sub=""):
+    path = f"/api/models/{REPO}/tree/main" + (f"/{sub}" if sub else "")
+    st, hd, body = fetch(path)
+    check(f"listing {sub or '(root)'} 200 JSON", st == 200 and "json" in hd.get("content-type", ""), f"status {st}")
+    items = json.loads(body)
+    for item in items:
+        if item["type"] == "directory":
+            walk(item["path"])
+        else:
+            found[item["path"]] = item["size"]
+
+
+walk()
+expected = {f["path"]: f["size"] for f in MANIFEST["files"]}
+check(
+    "listing walk reconstructs the exact expected file set (path+size)",
+    found == expected,
+    f"extra={sorted(set(found) - set(expected))} missing={sorted(set(expected) - set(found))} "
+    f"size-diff={[p for p in found if p in expected and found[p] != expected[p]]}",
+)
+
+# 3. Full-content SHA-256 for every file
+for f in MANIFEST["files"]:
+    st, hd, body = fetch(f"/{REPO}/resolve/main/{f['path']}")
+    ok = st == 200 and len(body) == f["size"] and hashlib.sha256(body).hexdigest() == f["sha256"]
+    check(f"sha256 {f['path']}", ok, f"status {st} len {len(body)}")
+
+# 4. Range grid against the big encoder weight
+big = next(f for f in MANIFEST["files"] if f["path"].endswith("Encoder.mlmodelc/weights/weight.bin"))
+bp, bs = f"/{REPO}/resolve/main/{big['path']}", big["size"]
+
+st, hd, body = fetch(bp, headers={"Range": "bytes=0-1023"})
+check("bounded range 206", st == 206 and len(body) == 1024 and hd.get("content-range") == f"bytes 0-1023/{bs}")
+st, hd, body = fetch(bp, headers={"Range": "bytes=-512"})
+check("suffix range 206", st == 206 and len(body) == 512 and hd.get("content-range") == f"bytes {bs-512}-{bs-1}/{bs}")
+st, hd, body = fetch(bp, headers={"Range": f"bytes={bs-64}-"})
+check("open-ended range 206", st == 206 and len(body) == 64)
+st, hd, _ = fetch(bp, headers={"Range": f"bytes={bs}-"}, want_body=False)
+check("past-EOF range 416 with bytes */size", st == 416 and hd.get("content-range") == f"bytes */{bs}")
+
+# 5. Unknown path is JSON 404
+st, hd, _ = fetch(f"/{REPO}/resolve/main/NoSuchFile.bin", want_body=False)
+check("unknown file 404 JSON", st == 404 and "json" in hd.get("content-type", ""), f"status {st}")
+st, hd, _ = fetch(f"/api/models/{REPO}/tree/main/NoSuch.mlmodelc", want_body=False)
+check("unknown listing 404 JSON", st == 404 and "json" in hd.get("content-type", ""), f"status {st}")
+
+print()
+if failures:
+    print(f"DEPLOY GATE FAILED ({len(failures)}): {failures}")
+    sys.exit(1)
+total = sum(f["size"] for f in MANIFEST["files"])
+print(f"DEPLOY GATE PASSED — {len(MANIFEST['files'])} files ({total:,} bytes) verified end to end at {HOST}, EG-1 untouched.")

--- a/workers/parakeet-mirror/src/index.js
+++ b/workers/parakeet-mirror/src/index.js
@@ -1,0 +1,180 @@
+// Parakeet model mirror (#1339).
+//
+// Serves the pinned Parakeet v3 set from R2 behind the two URL shapes
+// FluidAudio's ModelRegistry builds from its baseURL:
+//   listing:  GET /api/models/{REPO}/tree/main[/{subPath}]
+//   download: GET /{REPO}/resolve/main/{filePath}
+//
+// The listing is answered from a precomputed static tree derived from the
+// committed expected-manifest.json (generated from the pinned upstream
+// revision, never from bucket contents) — this kills the listing-API hang at
+// its root: no origin round-trip, no rate limit, byte-exact contract.
+// Downloads stream R2 objects with Range/206 support; the 445MB encoder is
+// never buffered in worker memory.
+
+import manifest from "../expected-manifest.json" with { type: "json" };
+
+const REPO = "FluidInference/parakeet-tdt-0.6b-v3-coreml";
+const R2_PREFIX = `parakeet/${REPO}/`;
+const LISTING_BASE = `/api/models/${REPO}/tree/main`;
+const RESOLVE_BASE = `/${REPO}/resolve/main/`;
+
+// path -> {size, sha256} for every expected file (the only downloadable set).
+const FILES = new Map(manifest.files.map((f) => [f.path, f]));
+
+// dirPath ("" = root) -> immediate children in Hugging Face tree-API shape:
+// [{type: "directory"|"file", path: <full path from repo root>, size}].
+// FluidAudio reads exactly type/path/size and recurses into directories.
+const TREE = (() => {
+  const dirs = new Map(); // dirPath -> Map(childName -> entry)
+  const ensureDir = (p) => {
+    if (!dirs.has(p)) dirs.set(p, new Map());
+    return dirs.get(p);
+  };
+  ensureDir("");
+  for (const f of manifest.files) {
+    const parts = f.path.split("/");
+    for (let i = 0; i < parts.length; i++) {
+      const parent = parts.slice(0, i).join("/");
+      const full = parts.slice(0, i + 1).join("/");
+      const children = ensureDir(parent);
+      if (i === parts.length - 1) {
+        children.set(parts[i], { type: "file", path: full, size: f.size });
+      } else {
+        ensureDir(full);
+        if (!children.has(parts[i])) {
+          children.set(parts[i], { type: "directory", path: full, size: 0 });
+        }
+      }
+    }
+  }
+  const out = new Map();
+  for (const [dir, children] of dirs) out.set(dir, [...children.values()]);
+  return out;
+})();
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const notFound = () => json({ error: "Not found" }, 404);
+
+// Parse a single-range "bytes=..." header against a known total size.
+// Returns {offset, length} | "unsatisfiable" | null (absent/ignored → full 200).
+function parseRange(header, size) {
+  if (!header) return null;
+  const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!m) return null; // multi-range or malformed: ignore per RFC, serve 200
+  const [, startStr, endStr] = m;
+  if (startStr === "" && endStr === "") return null;
+  if (startStr === "") {
+    // suffix: last N bytes
+    const n = Number(endStr);
+    if (n === 0) return "unsatisfiable";
+    const length = Math.min(n, size);
+    return { offset: size - length, length };
+  }
+  const start = Number(startStr);
+  if (start >= size) return "unsatisfiable";
+  const end = endStr === "" ? size - 1 : Math.min(Number(endStr), size - 1);
+  if (end < start) return "unsatisfiable";
+  return { offset: start, length: end - start + 1 };
+}
+
+function contentTypeFor(path) {
+  if (path.endsWith(".json")) return "application/json";
+  if (path.endsWith(".txt")) return "text/plain";
+  return "application/octet-stream";
+}
+
+
+// Malformed percent-encoding must map to the JSON 404 contract, not a thrown
+// URIError -> 500 (public route; Codex r2). Returns null on bad escapes.
+function safeDecode(component) {
+  try {
+    return decodeURIComponent(component);
+  } catch {
+    return null;
+  }
+}
+
+async function handleListing(pathname) {
+  let sub = "";
+  if (pathname !== LISTING_BASE) {
+    if (!pathname.startsWith(LISTING_BASE + "/")) return notFound();
+    sub = safeDecode(pathname.slice(LISTING_BASE.length + 1));
+    if (sub === null) return notFound();
+  }
+  const children = TREE.get(sub);
+  if (!children) return notFound();
+  return json(children);
+}
+
+async function handleResolve(request, env, pathname, isHead) {
+  const filePath = safeDecode(pathname.slice(RESOLVE_BASE.length));
+  const meta = filePath === null ? undefined : FILES.get(filePath);
+  if (!meta) return notFound();
+
+  const range = parseRange(request.headers.get("range"), meta.size);
+  if (range === "unsatisfiable") {
+    return new Response(null, {
+      status: 416,
+      headers: {
+        "content-range": `bytes */${meta.size}`,
+        "accept-ranges": "bytes",
+      },
+    });
+  }
+
+  const key = R2_PREFIX + filePath;
+  const headers = new Headers({
+    "accept-ranges": "bytes",
+    "content-type": contentTypeFor(filePath),
+  });
+
+  if (isHead) {
+    const head = await env.MODELS.head(key);
+    if (!head) return notFound();
+    headers.set("etag", head.httpEtag);
+    headers.set("content-length", String(head.size));
+    return new Response(null, { status: 200, headers });
+  }
+
+  const object = await env.MODELS.get(key, range ? { range } : undefined);
+  if (!object) return notFound();
+  headers.set("etag", object.httpEtag);
+
+  if (range) {
+    headers.set("content-length", String(range.length));
+    headers.set(
+      "content-range",
+      `bytes ${range.offset}-${range.offset + range.length - 1}/${meta.size}`
+    );
+    return new Response(object.body, { status: 206, headers });
+  }
+  headers.set("content-length", String(meta.size));
+  return new Response(object.body, { status: 200, headers });
+}
+
+export default {
+  async fetch(request, env) {
+    const isHead = request.method === "HEAD";
+    if (request.method !== "GET" && !isHead) {
+      return new Response("Method not allowed", {
+        status: 405,
+        headers: { allow: "GET, HEAD" },
+      });
+    }
+    const { pathname } = new URL(request.url);
+    if (pathname === LISTING_BASE || pathname.startsWith(LISTING_BASE + "/")) {
+      return handleListing(pathname);
+    }
+    if (pathname.startsWith(RESOLVE_BASE)) {
+      return handleResolve(request, env, pathname, isHead);
+    }
+    // Anything else under our narrowly-scoped routes is unknown.
+    return notFound();
+  },
+};

--- a/workers/parakeet-mirror/test/contract.test.mjs
+++ b/workers/parakeet-mirror/test/contract.test.mjs
@@ -142,6 +142,11 @@ test("HEAD returns headers without body", async () => {
 
 // --- Range grid ---
 const range = (h) => req(`/${REPO}/resolve/main/${BIG}`, { headers: { range: h } });
+// Cloud review #1355: ignored/malformed range headers fall back to a full 200
+// body — assert those on the SMALL file so the stub never materializes the
+// 445MB encoder just to check a status code. Range MATH stays on BIG.
+const rangeSmall = (h) =>
+  req(`/${REPO}/resolve/main/${SMALL}`, { headers: { range: h } });
 
 test("bounded range: 206 with correct content-range and length", async () => {
   const r = await range("bytes=0-1023");
@@ -205,17 +210,17 @@ test("zero-suffix (bytes=-0): 416", async () => {
 });
 
 test("malformed range is ignored: full 200", async () => {
-  const r = await range("bytes=abc");
+  const r = await rangeSmall("bytes=abc");
   assert.equal(r.status, 200);
 });
 
 test("multi-range is ignored: full 200 (RFC-permitted)", async () => {
-  const r = await range("bytes=0-1,5-9");
+  const r = await rangeSmall("bytes=0-1,5-9");
   assert.equal(r.status, 200);
 });
 
 test("empty range value (bytes=-): ignored, full 200", async () => {
-  const r = await range("bytes=-");
+  const r = await rangeSmall("bytes=-");
   assert.equal(r.status, 200);
 });
 

--- a/workers/parakeet-mirror/test/contract.test.mjs
+++ b/workers/parakeet-mirror/test/contract.test.mjs
@@ -1,0 +1,260 @@
+// Contract grid for the parakeet-mirror worker (#1339).
+// Axes: route shape x method x Range semantics (open / bounded / suffix /
+// zero-suffix / inverted / past-EOF / malformed / multi-range) x known/unknown
+// paths x URL encoding. Run: node --test workers/parakeet-mirror/test/
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const manifest = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../expected-manifest.json", import.meta.url)),
+    "utf8"
+  )
+);
+const worker = (await import("../src/index.js")).default;
+
+const REPO = "FluidInference/parakeet-tdt-0.6b-v3-coreml";
+const SMALL = "config.json"; // 2 bytes
+const BIG = "Encoder.mlmodelc/weights/weight.bin";
+const bigSize = manifest.files.find((f) => f.path === BIG).size;
+
+// Map-backed R2 stub: bodies are deterministic patterns, range-aware.
+function makeEnv() {
+  const bytesFor = (key, offset, length) => {
+    const buf = new Uint8Array(length);
+    for (let i = 0; i < length; i++) buf[i] = (offset + i) % 251;
+    return buf;
+  };
+  const sizeOf = (key) => {
+    const rel = key.replace(`parakeet/${REPO}/`, "");
+    const f = manifest.files.find((x) => x.path === rel);
+    return f ? f.size : null;
+  };
+  return {
+    MODELS: {
+      async head(key) {
+        const size = sizeOf(key);
+        return size === null ? null : { size, httpEtag: '"stub"' };
+      },
+      async get(key, opts) {
+        const size = sizeOf(key);
+        if (size === null) return null;
+        const offset = opts?.range?.offset ?? 0;
+        const length = opts?.range?.length ?? size - offset;
+        return { httpEtag: '"stub"', body: bytesFor(key, offset, length) };
+      },
+    },
+  };
+}
+
+const req = (path, init = {}) =>
+  worker.fetch(
+    new Request(`https://models.enviouslabs.co${path}`, init),
+    makeEnv()
+  );
+
+// --- Listing ---
+test("listing root returns HF-shaped immediate children", async () => {
+  const r = await req(`/api/models/${REPO}/tree/main`);
+  assert.equal(r.status, 200);
+  assert.equal(r.headers.get("content-type"), "application/json");
+  const items = await r.json();
+  assert.ok(Array.isArray(items));
+  const dirs = items.filter((i) => i.type === "directory").map((i) => i.path);
+  assert.ok(dirs.includes("Encoder.mlmodelc"));
+  assert.ok(dirs.includes("JointDecisionv3.mlmodelc"));
+  const files = items.filter((i) => i.type === "file").map((i) => i.path);
+  assert.ok(files.includes("parakeet_vocab.json"));
+  assert.ok(files.includes("config.json"));
+  for (const i of items) {
+    assert.ok(["file", "directory"].includes(i.type));
+    assert.equal(typeof i.path, "string");
+    assert.equal(typeof i.size, "number");
+  }
+});
+
+test("listing subdirectory returns full paths from repo root", async () => {
+  const r = await req(`/api/models/${REPO}/tree/main/Encoder.mlmodelc`);
+  const items = await r.json();
+  const weights = items.find((i) => i.path === "Encoder.mlmodelc/weights");
+  assert.equal(weights.type, "directory");
+  const mil = items.find((i) => i.path === "Encoder.mlmodelc/model.mil");
+  assert.equal(mil.type, "file");
+});
+
+test("listing nested subdirectory", async () => {
+  const r = await req(`/api/models/${REPO}/tree/main/Encoder.mlmodelc/weights`);
+  const items = await r.json();
+  assert.equal(items.length, 1);
+  assert.equal(items[0].path, "Encoder.mlmodelc/weights/weight.bin");
+  assert.equal(items[0].size, bigSize);
+});
+
+test("listing unknown path is 404 JSON, never HTML", async () => {
+  const r = await req(`/api/models/${REPO}/tree/main/NoSuch.mlmodelc`);
+  assert.equal(r.status, 404);
+  assert.equal(r.headers.get("content-type"), "application/json");
+});
+
+test("listing for a different repo is 404 (route scope)", async () => {
+  const r = await req(`/api/models/Other/repo/tree/main`);
+  assert.equal(r.status, 404);
+});
+
+// --- Resolve: full downloads ---
+test("resolve known file: 200, exact length, accept-ranges, etag", async () => {
+  const r = await req(`/${REPO}/resolve/main/${SMALL}`);
+  assert.equal(r.status, 200);
+  assert.equal(r.headers.get("content-length"), "2");
+  assert.equal(r.headers.get("accept-ranges"), "bytes");
+  assert.ok(r.headers.get("etag"));
+  assert.equal((await r.arrayBuffer()).byteLength, 2);
+});
+
+test("resolve unknown file: 404", async () => {
+  const r = await req(`/${REPO}/resolve/main/NoSuch.bin`);
+  assert.equal(r.status, 404);
+});
+
+test("resolve file NOT in manifest but maybe in bucket (_meta) is 404 — manifest is the allowlist", async () => {
+  const r = await req(`/${REPO}/resolve/main/_meta/expected-manifest.json`);
+  assert.equal(r.status, 404);
+});
+
+test("URL-encoded path resolves", async () => {
+  const r = await req(
+    `/${REPO}/resolve/main/Encoder.mlmodelc%2Fmodel.mil`.replace(
+      "%2F",
+      "/"
+    ) // sanity: plain form
+  );
+  assert.equal(r.status, 200);
+});
+
+test("HEAD returns headers without body", async () => {
+  const r = await req(`/${REPO}/resolve/main/${SMALL}`, { method: "HEAD" });
+  assert.equal(r.status, 200);
+  assert.equal(r.headers.get("content-length"), "2");
+  assert.equal((await r.arrayBuffer()).byteLength, 0);
+});
+
+// --- Range grid ---
+const range = (h) => req(`/${REPO}/resolve/main/${BIG}`, { headers: { range: h } });
+
+test("bounded range: 206 with correct content-range and length", async () => {
+  const r = await range("bytes=0-1023");
+  assert.equal(r.status, 206);
+  assert.equal(r.headers.get("content-length"), "1024");
+  assert.equal(r.headers.get("content-range"), `bytes 0-1023/${bigSize}`);
+  assert.equal((await r.arrayBuffer()).byteLength, 1024);
+});
+
+test("open-ended range: 206 to EOF", async () => {
+  const start = bigSize - 100;
+  const r = await range(`bytes=${start}-`);
+  assert.equal(r.status, 206);
+  assert.equal(r.headers.get("content-length"), "100");
+  assert.equal(
+    r.headers.get("content-range"),
+    `bytes ${start}-${bigSize - 1}/${bigSize}`
+  );
+});
+
+test("suffix range: last N bytes", async () => {
+  const r = await range("bytes=-500");
+  assert.equal(r.status, 206);
+  assert.equal(r.headers.get("content-length"), "500");
+  assert.equal(
+    r.headers.get("content-range"),
+    `bytes ${bigSize - 500}-${bigSize - 1}/${bigSize}`
+  );
+});
+
+test("suffix longer than file clamps to whole file", async () => {
+  const r = await req(`/${REPO}/resolve/main/${SMALL}`, {
+    headers: { range: "bytes=-999" },
+  });
+  assert.equal(r.status, 206);
+  assert.equal(r.headers.get("content-length"), "2");
+});
+
+test("end beyond EOF clamps to EOF", async () => {
+  const r = await req(`/${REPO}/resolve/main/${SMALL}`, {
+    headers: { range: "bytes=1-99999" },
+  });
+  assert.equal(r.status, 206);
+  assert.equal(r.headers.get("content-range"), `bytes 1-1/2`);
+});
+
+test("start past EOF: 416 with bytes */size", async () => {
+  const r = await range(`bytes=${bigSize}-`);
+  assert.equal(r.status, 416);
+  assert.equal(r.headers.get("content-range"), `bytes */${bigSize}`);
+});
+
+test("inverted range: 416", async () => {
+  const r = await range("bytes=500-100");
+  assert.equal(r.status, 416);
+});
+
+test("zero-suffix (bytes=-0): 416", async () => {
+  const r = await range("bytes=-0");
+  assert.equal(r.status, 416);
+});
+
+test("malformed range is ignored: full 200", async () => {
+  const r = await range("bytes=abc");
+  assert.equal(r.status, 200);
+});
+
+test("multi-range is ignored: full 200 (RFC-permitted)", async () => {
+  const r = await range("bytes=0-1,5-9");
+  assert.equal(r.status, 200);
+});
+
+test("empty range value (bytes=-): ignored, full 200", async () => {
+  const r = await range("bytes=-");
+  assert.equal(r.status, 200);
+});
+
+// --- Methods and route hygiene ---
+test("POST: 405 with Allow", async () => {
+  const r = await req(`/${REPO}/resolve/main/${SMALL}`, { method: "POST" });
+  assert.equal(r.status, 405);
+  assert.equal(r.headers.get("allow"), "GET, HEAD");
+});
+
+test("unrelated path under scope: 404 JSON", async () => {
+  const r = await req(`/${REPO}/resolve/other/${SMALL}`);
+  assert.equal(r.status, 404);
+});
+
+test("malformed percent-encoding on resolve: 404 JSON, never a thrown 500", async () => {
+  const r = await req(`/${REPO}/resolve/main/%E0%A4%A`);
+  assert.equal(r.status, 404);
+  assert.match(r.headers.get("content-type") ?? "", /application\/json/);
+});
+
+test("malformed percent-encoding on listing: 404 JSON, never a thrown 500", async () => {
+  const r = await req(`/api/models/${REPO}/tree/main/%ZZ`);
+  assert.equal(r.status, 404);
+  assert.match(r.headers.get("content-type") ?? "", /application\/json/);
+});
+
+// --- Manifest integrity (the committed manifest itself) ---
+test("manifest carries sha256+size for all 23 files incl. vocab and required dirs", async () => {
+  assert.equal(manifest.files.length, 23);
+  assert.equal(manifest.repo, REPO);
+  assert.ok(manifest.revision.length === 40);
+  const paths = manifest.files.map((f) => f.path);
+  assert.ok(paths.includes("parakeet_vocab.json"));
+  for (const dir of manifest.requiredModelDirs) {
+    assert.ok(paths.some((p) => p.startsWith(dir + "/")), `missing ${dir}`);
+  }
+  for (const f of manifest.files) {
+    assert.match(f.sha256, /^[0-9a-f]{64}$/);
+    assert.ok(f.size > 0);
+  }
+});

--- a/workers/parakeet-mirror/wrangler.toml
+++ b/workers/parakeet-mirror/wrangler.toml
@@ -1,0 +1,32 @@
+# Parakeet model mirror (#1339): serves EnviousWispr's own copy of the pinned
+# Parakeet v3 model set from R2 behind the two exact URL shapes FluidAudio's
+# ModelRegistry builds — listing (/api/models/{repo}/tree/main[/{sub}]) and
+# file download (/{repo}/resolve/main/{file}) — so the app's first-run download
+# never depends on the public host's listing API or anonymous throttle.
+#
+# Routes are scoped NARROWLY to those two path shapes. /eg1/* (the EG-1 polish
+# model, live traffic) stays on the R2 custom-domain binding and never touches
+# this worker. Verify EG-1 pre/post deploy: scripts/verify-deploy.sh.
+#
+# No [triggers] cron here: the account is at its 5-cron free-plan limit (#1092),
+# and this worker needs none — it is a pure request/response mirror.
+
+name = "enviouswispr-parakeet-mirror"
+main = "src/index.js"
+compatibility_date = "2026-07-01"
+
+# Route-coverage note (Codex review 2026-07-05 asked twice): the first
+# pattern is scoped at the REPO level ("<repo>/*"), so it matches EVERYTHING
+# under the repo path — including the ROOT listing "/api/models/<repo>/tree/main"
+# (no trailing slash) that FluidAudio requests first, and every "/tree/main/<sub>"
+# below it. Verified live: the exact root-listing URL returns the Worker's JSON
+# (200, application/json), and scripts/verify-deploy.py starts its recursive
+# listing walk AT that root URL and gates the deploy on it.
+routes = [
+  { pattern = "models.enviouslabs.co/api/models/FluidInference/parakeet-tdt-0.6b-v3-coreml/*", zone_name = "enviouslabs.co" },
+  { pattern = "models.enviouslabs.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/*", zone_name = "enviouslabs.co" },
+]
+
+[[r2_buckets]]
+binding = "MODELS"
+bucket_name = "enviouslabs-models"


### PR DESCRIPTION
## Summary
Lands the already-deployed parakeet-mirror Worker's source in the repo, verbatim from the parked `feat/1339-reliable-model-source` branch. The Worker has served models.enviouslabs.co in production since the #1339 sprint; until now its source lived only on the parked branch.

- `workers/parakeet-mirror/src/index.js` + `wrangler.toml` (routes scoped to the two FluidAudio URL shapes; /eg1/* untouched)
- 26 contract tests (`node --test`) — all pass locally
- `scripts/verify-deploy.py` — run against production today: **DEPLOY GATE PASSED, 23 files (483,256,769 bytes) verified end to end, EG-1 untouched**
- `expected-manifest.json` — the byte-verified 23-file seed the Phase 2 delivery manifest derives from (the PR-2b compare-seed gate reads this file)

## Validation (Worker lane)
- worker-test: 26/26 pass (`node --test test/contract.test.mjs`)
- deploy evidence: existing production deployment; verify-deploy.py PASSED 2026-07-06
- endpoint smoke: root listing 200 JSON; file URL 200 with accept-ranges: bytes; range semantics 206/416 correct

Part of #1348 (Phase 2). Plan: `docs/feature-requests/issue-1348-2026-07-06-modeldelivery-phase2-parakeet.md` (local, Gate 2 approved under the founder's overnight mandate; grounded review PROCEED-AS-PLANNED r4).

No deploy is performed by this PR; it is repo bookkeeping for a live deployment.