### PR TITLE
chore(release): bump version to 2.3.1

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -26,6 +26,18 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.3.1
+
+    Entry(
+      id: "reliable-first-run-download",
+      icon: "arrow.down.circle",
+      title: "First-run setup downloads are far more reliable",
+      description:
+        "Setting up EnviousWispr downloads a speech model, and on some networks that download could stall and leave you stuck before you ever got to dictate. We rebuilt how the app fetches it: the download now resumes on its own if your connection drops, falls back to a backup source when needed, and can no longer hang forever. If setup gets interrupted, reopening the app picks up right where it left off instead of starting over.",
+      category: .fasterAndMoreReliable,
+      version: "2.3.1"
+    ),
+
     // MARK: - v2.3.0
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.3.0"
+  public static let currentContentVersion = "2.3.1"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"


### PR DESCRIPTION
## Summary

Version bump to v2.3.1 — a download-reliability patch. Ships the owned Parakeet model-delivery engine (#1362) + the first-run stall guard (#1345) + the transfer-aware silence floor (#1350), all already merged to main but unreleased since v2.3.0. Users on v2.3.0 are hitting the #1339 "first-run download hangs forever" failure; this release gets them the fix.

What's New entry added (also the public release note): first-run setup downloads now resume on drop, fail over to a backup source, and can never hang forever; interrupted setup resumes instead of restarting.

## Test plan

- [x] scripts/build-dev-app.sh — built locally (bundle confirms 2.3.1)
- [x] Logic tests green from the root checkout (the /tmp release-worktree false-fails 5 path-scanning freeze/contract tests due to the /private/tmp symlink; verified EngineIdentityFreezeTests + OutputClassifierContractTests PASS from the normal path)
- [ ] build-check CI passes on this PR
- [ ] Tag v2.3.1 after merge triggers release pipeline