### PR TITLE
fix(build): sync FluidAudio hash in third-party notices (unblock v2.3.1)

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -38,7 +38,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: d5fcca4f (fork saurabhav88/FluidAudio)
+  Version: e7948e1a (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -31,7 +31,7 @@ CO="${PROJ_ROOT}/.build/checkouts"
 # this list does not cover, so the notices can't silently go stale (Codex #2).
 COMPONENTS=(
   "WhisperKit (argmax-oss-swift)|1.0.0|MIT|argmax-oss-swift/LICENSE|https://github.com/argmaxinc/argmax-oss-swift|argmax-oss-swift"
-  "FluidAudio|d5fcca4f (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
+  "FluidAudio|e7948e1a (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
   "PostHog iOS|3.62.4|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
   "Sentry Cocoa|9.19.0|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
   "Sparkle|2.9.3|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"


### PR DESCRIPTION
## Summary

The v2.3.1 release build failed at the DMG packaging guard `gen-third-party-notices.sh --check` (`build-release-dmg.sh:380`): the notices generator listed FluidAudio fork hash `d5fcca4f` while `Package.resolved` pins `e7948e1a` (drifted when the fork was refreshed in #1336). Release-only guard → sat latent on main.

Fix: sync the generator's FluidAudio token to `e7948e1a` + regenerate `THIRD-PARTY-NOTICES.txt`. Diff is exactly the one version token (license texts byte-identical). The release gate `--check` now passes locally (11 components verified).

## Review
- Codex grounded review: **APPROVE-FIX-AS-PROPOSED**; cross-checked every dependency in the generator against `Package.resolved` — FluidAudio was the ONLY drift, so no third-failure lurking (`docs/audits/2026-07-06-v231-release-fix-grounded-review.txt`).
- v2.3.0 and v2.3.1 failures confirmed unrelated (v2.3.0 = appcast limb transient; v2.3.1 = this notices heart guard).

## Test plan
- [x] `scripts/ci/gen-third-party-notices.sh --check` → exit 0 ("third-party notices verified (11 components)")
- [ ] build-check CI passes
- [ ] Re-tag v2.3.1 after merge → release pipeline re-runs the full build + --check in CI

Unblocks v2.3.1. Part of #1348.