### PR TITLE
feat(audio): observe selected-vs-effective mic transport per recording (#1376)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AudioEnvironmentSnapshotter.swift
+++ b/Sources/EnviousWisprAppKit/App/AudioEnvironmentSnapshotter.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CoreAudio
+import EnviousWisprAudio
 import EnviousWisprServices
 import Foundation
 
@@ -137,8 +138,10 @@ struct CoreAudioEnvironmentCollector: AudioEnvironmentCollecting {
       inputBundleIDs: inputBundles,
       outputBundleIDs: outputBundles,
       frontmostAppBundleID: frontmostAppBundleID,
-      inputDeviceTransport: inputDeviceID.flatMap(Self.deviceTransport),
-      outputDeviceTransport: outputDeviceID.flatMap(Self.deviceTransport),
+      inputDeviceTransport: inputDeviceID.flatMap { AudioDeviceEnumerator.transportLabel(for: $0) },
+      outputDeviceTransport: outputDeviceID.flatMap {
+        AudioDeviceEnumerator.transportLabel(for: $0)
+      },
       route: route,
       bluetoothOutputActive: outputDeviceID.map(Self.isBluetoothDevice) ?? false,
       deviceEventAt: deviceEventAt
@@ -183,36 +186,6 @@ struct CoreAudioEnvironmentCollector: AudioEnvironmentCollecting {
     let transport = deviceTransportRaw(deviceID)
     return transport == kAudioDeviceTransportTypeBluetooth
       || transport == kAudioDeviceTransportTypeBluetoothLE
-  }
-
-  private static func deviceTransport(_ deviceID: AudioDeviceID) -> String? {
-    guard let transport = deviceTransportRaw(deviceID) else { return nil }
-    switch transport {
-    case kAudioDeviceTransportTypeBuiltIn:
-      return "built_in"
-    case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
-      return "bluetooth"
-    case kAudioDeviceTransportTypeUSB:
-      return "usb"
-    case kAudioDeviceTransportTypeAggregate:
-      return "aggregate"
-    case kAudioDeviceTransportTypeVirtual:
-      return "virtual"
-    case kAudioDeviceTransportTypeDisplayPort:
-      return "display_port"
-    case kAudioDeviceTransportTypeHDMI:
-      return "hdmi"
-    case kAudioDeviceTransportTypeAirPlay:
-      return "air_play"
-    case kAudioDeviceTransportTypePCI:
-      return "pci"
-    case kAudioDeviceTransportTypeFireWire:
-      return "fire_wire"
-    case kAudioDeviceTransportTypeThunderbolt:
-      return "thunderbolt"
-    default:
-      return "unknown"
-    }
   }
 
   private static func deviceTransportRaw(_ deviceID: AudioDeviceID) -> UInt32? {

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -414,12 +414,21 @@ final class DictationLifecycleCoordinator {
       },
       reportDictationCompleted: { [weak self] t in
         guard let self else { return }
+        let route = driver.lastResolvedRoute
         TelemetryService.shared.reportDictationCompleted(
           transcript: t, inputMode: self.settings.recordingMode.rawValue,
           recordingSeconds: driver.lastRecordingDurationSeconds,
           stopReason: driver.lastStopReason,
           historySaveStatus: driver.lastHistorySaved ? "succeeded" : "failed",  // #1167
-          historySaveErrorClass: driver.lastHistorySaveErrorClass)
+          historySaveErrorClass: driver.lastHistorySaveErrorClass,
+          // #1376: effective-device telemetry — which mic was selected vs used.
+          selectedTransport: route?.selected,
+          effectiveTransport: route?.effective,
+          routeReason: route?.routeReason,
+          routeFallbackReason: route?.routeFallbackReason,
+          inputSelectionMode: route?.inputSelectionMode,
+          outputTransport: route?.outputTransport,
+          routeResolutionSource: route?.routeResolutionSource)
       },
       reportPipelineFailed: { msg in
         TelemetryService.shared.pipelineFailed(

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -12,6 +12,12 @@ public protocol AudioCaptureInterface: AnyObject {
   var capturedSamples: [Float] { get }
   /// Low-cardinality audio route label for Sentry. Set after route resolution.
   var currentAudioRoute: String { get }
+  /// The resolved-route transports observed for the current session (selected
+  /// vs effective transport, route reason, input-selection mode, output
+  /// transport), derived from the resolver decision. `nil` before the first
+  /// route resolution. Telemetry-only observation — nothing branches capture on
+  /// it (#1376).
+  var currentResolvedRoute: ResolvedRouteTransports? { get }
 
   // Callback properties (read-write)
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -143,20 +143,30 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   /// Low-cardinality audio route label derived from the last route decision.
   public var currentAudioRoute: String {
-    guard let decision = lastRouteDecision else { return "unknown" }
-    switch decision.reason {
-    case .noBTAutoInput, .noBTUserSelectedDevice:
-      return "built_in_mic"
-    case .btOutputAutoInput, .btOutputUserSelectedBuiltIn,
-      .btOutputUserSelectedBTMic, .btOutputUserSelectedWired:
-      return "capture_session_bt"
-    case .forcedEngine, .fallbackToEngine:
-      return "audio_engine"
-    case .forcedCaptureSession:
-      return "capture_session"
-    case .failedNoFallback:
-      return "failed"
-    }
+    lastRouteDecision?.reason.coarseAudioRouteLabel ?? "unknown"
+  }
+
+  /// The resolved-route transports for the current session (#1376). FROZEN at
+  /// resolve time (mirrors the proxy) — NOT a computed property, so an in-flight
+  /// input-device setting change (which `PipelineSettingsSync` applies for the
+  /// NEXT recording while the current source keeps its old device) cannot make a
+  /// later failure-terminal telemetry read report the wrong transport. Nil
+  /// before the first resolution. Telemetry-only observation.
+  public private(set) var currentResolvedRoute: ResolvedRouteTransports?
+
+  /// Adopt a fresh route decision: freeze it plus its derived transports (using
+  /// the device selection that produced THIS decision), then fire
+  /// `onRouteResolved` changed-only. The single write path so `lastRouteDecision`
+  /// and `currentResolvedRoute` never disagree.
+  private func adoptRouteDecision(_ decision: CaptureRouteDecision, prior: CaptureRouteDecision?) {
+    lastRouteDecision = decision
+    currentResolvedRoute = ResolvedRouteTransports.derive(
+      decision: decision,
+      preferredInputDeviceIDOverride: preferredInputDeviceIDOverride,
+      selectedInputDeviceUID: selectedInputDeviceUID
+    )
+    guard CaptureRouteDecision.routeResolvedChanged(from: prior, to: decision) else { return }
+    onRouteResolved?(decision, prior.map { $0.sourceType != decision.sourceType } ?? false)
   }
 
   public init() {}
@@ -481,6 +491,8 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // Cancel any in-flight engine stop from a previous teardown.
     engineStopTask?.cancel()
     engineStopTask = nil
+    // Snapshot the prior decision for the changed-only `onRouteResolved` fire.
+    let priorRouteDecision = lastRouteDecision
 
     // If a source is already running (warm engine), check route compatibility
     if let existing = activeSource, existing.isRunning {
@@ -512,7 +524,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
       if configMatch {
         // Route and config unchanged, reuse warm source
-        lastRouteDecision = decision
+        adoptRouteDecision(decision, prior: priorRouteDecision)
         Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source")
         return existing
       }
@@ -527,7 +539,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       preferredInputDeviceUID: preferredInputDeviceIDOverride,
       noiseSuppression: noiseSuppressionEnabled
     )
-    lastRouteDecision = decision
+    adoptRouteDecision(decision, prior: priorRouteDecision)
 
     // Structured telemetry log
     Self.btRouteLog(

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -244,9 +244,11 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   }
 
   public func startEnginePhase() async throws {
-    deriveResolvedRoute()
-
     try await withStartRetry(stage: "start_engine") { operationID in
+      // Derive INSIDE the operation so it re-runs on the retry (a fresh
+      // connection resends start_engine using current device/output state) —
+      // a device/output change between attempts is otherwise lost (#1387).
+      self.deriveResolvedRoute()
       try await self.awaitStartEnginePhaseReply(operationID: operationID)
     }
   }
@@ -478,16 +480,16 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   public func preWarm() async throws {
     let proxyStart = ContinuousClock.now
 
-    // Derive the route so telemetry is populated even when startEnginePhase()
-    // is skipped on the next recording (warm engine reuse).
-    deriveResolvedRoute()
-
     acquireConnection()
     let connMs = Self.ms(ContinuousClock.now - proxyStart)
     // Phase 1: start engine
     let enginePhaseStart = ContinuousClock.now
     do {
       try await withStartRetry(stage: "start_engine_prewarm") { operationID in
+        // Derive INSIDE the operation (re-runs on the retry) so telemetry is
+        // populated even when startEnginePhase() is skipped on the next
+        // recording (warm reuse), and reflects each attempt's state (#1387).
+        self.deriveResolvedRoute()
         try await self.awaitStartEnginePhaseReply(operationID: operationID)
       }
     } catch {

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -177,6 +177,17 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   /// Derived at startEnginePhase time from the same BT detection logic as CaptureRouteResolver.
   public private(set) var currentAudioRoute: String = "unknown"
 
+  /// App-side route resolver run at every capture (re)start so the proxy's
+  /// derived route carries the full reason, not just the coarse BT label
+  /// (#1376). `.automatic` policy — the proxy never uses the debug overrides.
+  private let routeResolver = CaptureRouteResolver()
+  /// The last app-side route decision — backs the changed-only `onRouteResolved`
+  /// fire and the derived `currentResolvedRoute`.
+  private var lastRouteDecision: CaptureRouteDecision?
+  /// The resolved-route transports observed for the current session (#1376).
+  /// Telemetry-only observation — nothing branches capture on it.
+  public private(set) var currentResolvedRoute: ResolvedRouteTransports?
+
   #if DEBUG
     /// V2 fault-injection seam (issue #291). When > 0, the next N captured
     /// buffers are silently dropped before reaching the continuation or
@@ -209,15 +220,31 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
   // MARK: - Core lifecycle
 
+  /// Run the full route resolver app-side and stash the derived route facts so
+  /// `currentAudioRoute` + `currentResolvedRoute` reflect the last actual start
+  /// (#1376). Called from every path that (re)starts capture. Replaces the
+  /// former coarse inline Bluetooth-output check; the coarse label is preserved
+  /// exactly via `CaptureRouteReason.coarseAudioRouteLabel`. Fires
+  /// `onRouteResolved` per the interface's changed-only contract.
+  private func deriveResolvedRoute() {
+    let decision = routeResolver.resolve(
+      preferredInputDeviceUID: preferredInputDeviceIDOverride,
+      noiseSuppression: noiseSuppressionEnabled
+    )
+    let prior = lastRouteDecision
+    lastRouteDecision = decision
+    currentAudioRoute = decision.reason.coarseAudioRouteLabel
+    currentResolvedRoute = ResolvedRouteTransports.derive(
+      decision: decision,
+      preferredInputDeviceIDOverride: preferredInputDeviceIDOverride,
+      selectedInputDeviceUID: selectedInputDeviceUID
+    )
+    guard CaptureRouteDecision.routeResolvedChanged(from: prior, to: decision) else { return }
+    onRouteResolved?(decision, prior.map { $0.sourceType != decision.sourceType } ?? false)
+  }
+
   public func startEnginePhase() async throws {
-    // Derive route label app-side (same BT check as CaptureRouteResolver).
-    if let outID = AudioDeviceEnumerator.defaultOutputDeviceID(),
-      AudioDeviceEnumerator.isBluetoothDevice(outID)
-    {
-      currentAudioRoute = "capture_session_bt"
-    } else {
-      currentAudioRoute = "built_in_mic"
-    }
+    deriveResolvedRoute()
 
     try await withStartRetry(stage: "start_engine") { operationID in
       try await self.awaitStartEnginePhaseReply(operationID: operationID)
@@ -261,6 +288,9 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     try await withStartRetry(
       stage: "begin_capture",
       prefix: {
+        // A retry re-sends start_engine on a fresh line — re-derive so the
+        // route reflects the actual (possibly changed) start (#1376).
+        self.deriveResolvedRoute()
         try await self.withAudioXPCOperationSignal(stage: "start_engine_retry_prefix") {
           operationID in
           try await self.awaitStartEnginePhaseReply(operationID: operationID)
@@ -338,7 +368,14 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: preferredInputDeviceIDOverride.isEmpty
         ? nil : preferredInputDeviceIDOverride,
-      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+      selectedTransport: currentResolvedRoute?.selected,
+      effectiveTransport: currentResolvedRoute?.effective,
+      routeReason: currentResolvedRoute?.routeReason,
+      routeFallbackReason: currentResolvedRoute?.routeFallbackReason,
+      inputSelectionMode: currentResolvedRoute?.inputSelectionMode,
+      outputTransport: currentResolvedRoute?.outputTransport,
+      routeResolutionSource: currentResolvedRoute?.routeResolutionSource
     )
     onCaptureStalled?(ctx)
   }
@@ -441,15 +478,9 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   public func preWarm() async throws {
     let proxyStart = ContinuousClock.now
 
-    // Derive route label so Sentry telemetry is populated even when
-    // startEnginePhase() is skipped on the next recording (warm engine reuse).
-    if let outID = AudioDeviceEnumerator.defaultOutputDeviceID(),
-      AudioDeviceEnumerator.isBluetoothDevice(outID)
-    {
-      currentAudioRoute = "capture_session_bt"
-    } else {
-      currentAudioRoute = "built_in_mic"
-    }
+    // Derive the route so telemetry is populated even when startEnginePhase()
+    // is skipped on the next recording (warm engine reuse).
+    deriveResolvedRoute()
 
     acquireConnection()
     let connMs = Self.ms(ContinuousClock.now - proxyStart)

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -157,9 +157,62 @@ public enum AudioDeviceEnumerator {
     return builtInMicrophoneDeviceID()
   }
 
+  // MARK: - Transport labels (#1376 single authority)
+
+  /// Maps a CoreAudio transport-type constant to the app's low-cardinality
+  /// transport string. Pure — the single authority for these labels, extracted
+  /// from `AudioEnvironmentSnapshotter.deviceTransport` so no second vocabulary
+  /// exists (#1376). Nil-preserving: a nil raw transport (property read failed)
+  /// yields nil so callers that emit only `if let` keep omitting their key.
+  public static func transportLabel(forTransportType raw: UInt32?) -> String? {
+    guard let raw else { return nil }
+    switch raw {
+    case kAudioDeviceTransportTypeBuiltIn:
+      return "built_in"
+    case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
+      return "bluetooth"
+    case kAudioDeviceTransportTypeUSB:
+      return "usb"
+    case kAudioDeviceTransportTypeAggregate:
+      return "aggregate"
+    case kAudioDeviceTransportTypeVirtual:
+      return "virtual"
+    case kAudioDeviceTransportTypeDisplayPort:
+      return "display_port"
+    case kAudioDeviceTransportTypeHDMI:
+      return "hdmi"
+    case kAudioDeviceTransportTypeAirPlay:
+      return "air_play"
+    case kAudioDeviceTransportTypePCI:
+      return "pci"
+    case kAudioDeviceTransportTypeFireWire:
+      return "fire_wire"
+    case kAudioDeviceTransportTypeThunderbolt:
+      return "thunderbolt"
+    default:
+      return "unknown"
+    }
+  }
+
+  /// Transport label for a device ID, or nil if the device transport is
+  /// unreadable (nil-preserving — see `transportLabel(forTransportType:)`).
+  public static func transportLabel(for deviceID: AudioDeviceID) -> String? {
+    transportLabel(forTransportType: transportTypeRaw(for: deviceID))
+  }
+
+  /// Transport label for an input-device UID, or nil if the UID resolves to no
+  /// currently-connected input device.
+  public static func transportLabel(forUID uid: String) -> String? {
+    guard let id = deviceID(forUID: uid) else { return nil }
+    return transportLabel(for: id)
+  }
+
   // MARK: - Private Helpers
 
-  static func transportType(for deviceID: AudioDeviceID) -> UInt32 {
+  /// Raw CoreAudio transport-type constant, or nil if the property read fails.
+  /// The single low-level read behind both `transportType(for:)` and
+  /// `transportLabel(for:)` (#1376).
+  static func transportTypeRaw(for deviceID: AudioDeviceID) -> UInt32? {
     var transport: UInt32 = 0
     var size = UInt32(MemoryLayout<UInt32>.size)
     var addr = AudioObjectPropertyAddress(
@@ -167,8 +220,13 @@ public enum AudioDeviceEnumerator {
       mScope: kAudioObjectPropertyScopeGlobal,
       mElement: kAudioObjectPropertyElementMain
     )
-    AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &transport)
+    let status = AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &transport)
+    guard status == noErr else { return nil }
     return transport
+  }
+
+  static func transportType(for deviceID: AudioDeviceID) -> UInt32 {
+    transportTypeRaw(for: deviceID) ?? 0
   }
 
   private static func inputChannelCount(for deviceID: AudioDeviceID) -> Int {

--- a/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
+++ b/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
@@ -29,6 +29,43 @@ public enum CaptureRouteReason: String, Sendable {
   case failedNoFallback
 }
 
+extension CaptureRouteReason {
+  /// The single authority mapping a route reason to the low-cardinality
+  /// `currentAudioRoute` label used by Sentry audio extras (#1376). Both the
+  /// in-process `AudioCaptureManager` and the app-side `AudioCaptureProxy`
+  /// derive their `currentAudioRoute` from this, so the coarse label is not
+  /// re-implemented per conformer.
+  public var coarseAudioRouteLabel: String {
+    switch self {
+    case .noBTAutoInput, .noBTUserSelectedDevice:
+      return "built_in_mic"
+    case .btOutputAutoInput, .btOutputUserSelectedBuiltIn,
+      .btOutputUserSelectedBTMic, .btOutputUserSelectedWired:
+      return "capture_session_bt"
+    case .forcedEngine, .fallbackToEngine:
+      return "audio_engine"
+    case .forcedCaptureSession:
+      return "capture_session"
+    case .failedNoFallback:
+      return "failed"
+    }
+  }
+}
+
+extension CaptureRouteDecision {
+  /// The changed-only predicate for the `onRouteResolved` producer (#1376):
+  /// fires on the first resolution (`prior == nil`) and thereafter only when
+  /// `reason` or `sourceType` differs from the prior decision. The single
+  /// authority both `AudioCaptureManager` and `AudioCaptureProxy` use so the
+  /// changed-only semantics are defined once.
+  public static func routeResolvedChanged(
+    from prior: CaptureRouteDecision?, to next: CaptureRouteDecision
+  ) -> Bool {
+    guard let prior else { return true }
+    return prior.reason != next.reason || prior.sourceType != next.sourceType
+  }
+}
+
 /// The result of route resolution — tells AudioCaptureManager which source to create and why.
 public struct CaptureRouteDecision: Sendable {
   public let sourceType: CaptureSourceType

--- a/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
+++ b/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
@@ -1,0 +1,113 @@
+import CoreAudio
+
+/// A pure, per-recording OBSERVATION of the resolver's route decision, derived
+/// into the low-cardinality transport facts the telemetry layer emits (#1376,
+/// Bluetooth-capture epic Phase 1). Never a control input — nothing branches
+/// capture on it; both sinks (`dictation.completed` PostHog + `SentryAudioExtras`)
+/// read this one value instead of re-deriving from raw inputs
+/// (`telemetry-observes-resolved-value-deny-by-default`).
+///
+/// `routeResolutionSource` is the constant `"app_derived"` this phase: the value
+/// reflects the app-side resolver DECISION, not a helper-observed hardware
+/// binding. Phase 3 introduces `"helper_reported"` when the truly device-bound
+/// transport crosses the capture-helper seam.
+public struct ResolvedRouteTransports: Sendable, Equatable {
+  /// Transport of the user's picked device, or `"unknown"` on Auto / unmappable.
+  public let selected: String
+  /// Transport the decision binds (built-in for the capture-session path today).
+  public let effective: String
+  /// `CaptureRouteReason.rawValue` — the machine-readable route reason.
+  public let routeReason: String
+  /// Present iff `routeReason` is a fallback rung (`fallbackToEngine` /
+  /// `failedNoFallback`); absent otherwise. The presence IS the signal.
+  public let routeFallbackReason: String?
+  /// `explicit` when the user pinned a device, `auto` when on system-default,
+  /// `unknown` reserved. Separates the trust-breach cohort (explicit BT pick
+  /// forced to built-in) from the endorsed-policy cohort (Auto → built-in).
+  public let inputSelectionMode: String
+  /// Transport of the current default OUTPUT device (`"unknown"` if unreadable).
+  /// The forced-built-in workaround only triggers under Bluetooth output.
+  public let outputTransport: String
+  /// How the value was obtained: `"app_derived"` this phase.
+  public let routeResolutionSource: String
+
+  public init(
+    selected: String,
+    effective: String,
+    routeReason: String,
+    routeFallbackReason: String?,
+    inputSelectionMode: String,
+    outputTransport: String,
+    routeResolutionSource: String
+  ) {
+    self.selected = selected
+    self.effective = effective
+    self.routeReason = routeReason
+    self.routeFallbackReason = routeFallbackReason
+    self.inputSelectionMode = inputSelectionMode
+    self.outputTransport = outputTransport
+    self.routeResolutionSource = routeResolutionSource
+  }
+
+  /// Derive the observed transports from a resolver decision plus the user's
+  /// device selection. Total over the `CaptureSourceType × CaptureRouteReason`
+  /// grid. The transport lookups reflect live CoreAudio device state, which the
+  /// resolver decision was itself computed against a moment earlier.
+  public static func derive(
+    decision: CaptureRouteDecision,
+    preferredInputDeviceIDOverride: String,
+    selectedInputDeviceUID: String
+  ) -> ResolvedRouteTransports {
+    // The user's effective device pick: an explicit override wins, else the
+    // stored selection, else empty (Auto / system default).
+    let selectedUID =
+      preferredInputDeviceIDOverride.isEmpty
+      ? selectedInputDeviceUID : preferredInputDeviceIDOverride
+    let selectionMode = selectedUID.isEmpty ? "auto" : "explicit"
+
+    let selected =
+      selectedUID.isEmpty
+      ? "unknown"
+      : (AudioDeviceEnumerator.transportLabel(forUID: selectedUID) ?? "unknown")
+
+    let effective: String
+    switch decision.sourceType {
+    case .captureSession:
+      // The capture-session path opens the built-in mic only today (bible R4).
+      effective = "built_in"
+    case .audioEngine:
+      // Mirror AVAudioEngineSource's device resolution exactly: the pinned
+      // device if it resolves to a connected device, ELSE the system-default
+      // input (`AVAudioEngineSource.swift:243` — `resolvedDeviceID ??
+      // defaultInputDeviceID()`). A saved-but-disconnected pinned UID therefore
+      // reports the default input transport the engine actually opens, not
+      // "unknown"; `selected` still stays "unknown" (the pick is unavailable).
+      if !selectedUID.isEmpty, let label = AudioDeviceEnumerator.transportLabel(forUID: selectedUID)
+      {
+        effective = label
+      } else if let defaultID = AudioDeviceEnumerator.defaultInputDeviceID() {
+        effective = AudioDeviceEnumerator.transportLabel(for: defaultID) ?? "unknown"
+      } else {
+        effective = "unknown"
+      }
+    }
+
+    let fallbackReason: String? =
+      (decision.reason == .fallbackToEngine || decision.reason == .failedNoFallback)
+      ? decision.reason.rawValue : nil
+
+    let outputTransport =
+      AudioDeviceEnumerator.defaultOutputDeviceID()
+      .flatMap { AudioDeviceEnumerator.transportLabel(for: $0) } ?? "unknown"
+
+    return ResolvedRouteTransports(
+      selected: selected,
+      effective: effective,
+      routeReason: decision.reason.rawValue,
+      routeFallbackReason: fallbackReason,
+      inputSelectionMode: selectionMode,
+      outputTransport: outputTransport,
+      routeResolutionSource: "app_derived"
+    )
+  }
+}

--- a/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
+++ b/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
@@ -58,17 +58,20 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
     preferredInputDeviceIDOverride: String,
     selectedInputDeviceUID: String
   ) -> ResolvedRouteTransports {
-    // The user's effective device pick: an explicit override wins, else the
-    // stored selection, else empty (Auto / system default).
-    let selectedUID =
-      preferredInputDeviceIDOverride.isEmpty
-      ? selectedInputDeviceUID : preferredInputDeviceIDOverride
-    let selectionMode = selectedUID.isEmpty ? "auto" : "explicit"
+    // The user's EXPLICIT pick is the settings mic picker, which binds to
+    // `preferredInputDeviceIDOverride` ("Auto" = empty) — AND the route resolver
+    // builds its decision from ONLY that value. So `selected` + selection mode
+    // derive from `preferredInputDeviceIDOverride` alone, keeping them
+    // consistent with `route_reason` (a bare `selectedInputDeviceUID` under an
+    // empty picker is Auto to the resolver, not an explicit pick — #1387 cloud
+    // review P2). `selectedInputDeviceUID` still feeds `effective` below because
+    // the engine opens it as a fallback.
+    let selectionMode = preferredInputDeviceIDOverride.isEmpty ? "auto" : "explicit"
 
     let selected =
-      selectedUID.isEmpty
+      preferredInputDeviceIDOverride.isEmpty
       ? "unknown"
-      : (AudioDeviceEnumerator.transportLabel(forUID: selectedUID) ?? "unknown")
+      : (AudioDeviceEnumerator.transportLabel(forUID: preferredInputDeviceIDOverride) ?? "unknown")
 
     let effective: String
     switch decision.sourceType {
@@ -76,14 +79,15 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
       // The capture-session path opens the built-in mic only today (bible R4).
       effective = "built_in"
     case .audioEngine:
-      // Mirror AVAudioEngineSource's device resolution exactly: the pinned
-      // device if it resolves to a connected device, ELSE the system-default
-      // input (`AVAudioEngineSource.swift:243` — `resolvedDeviceID ??
-      // defaultInputDeviceID()`). A saved-but-disconnected pinned UID therefore
-      // reports the default input transport the engine actually opens, not
-      // "unknown"; `selected` still stays "unknown" (the pick is unavailable).
-      if !selectedUID.isEmpty, let label = AudioDeviceEnumerator.transportLabel(forUID: selectedUID)
-      {
+      // Mirror AVAudioEngineSource's device resolution exactly: the preferred
+      // override, else the stored selection, else the system-default input
+      // (`AVAudioEngineSource.swift:227-243` — `resolvedDeviceID ??
+      // defaultInputDeviceID()`). A pinned-but-disconnected UID therefore
+      // reports the default input transport the engine actually opens.
+      let engineUID =
+        preferredInputDeviceIDOverride.isEmpty
+        ? selectedInputDeviceUID : preferredInputDeviceIDOverride
+      if !engineUID.isEmpty, let label = AudioDeviceEnumerator.transportLabel(forUID: engineUID) {
         effective = label
       } else if let defaultID = AudioDeviceEnumerator.defaultInputDeviceID() {
         effective = AudioDeviceEnumerator.transportLabel(for: defaultID) ?? "unknown"

--- a/Sources/EnviousWisprCore/CaptureStallContext.swift
+++ b/Sources/EnviousWisprCore/CaptureStallContext.swift
@@ -17,6 +17,16 @@ public struct CaptureStallContext: Sendable {
   public let formatMismatchObserved: Bool
   public let inputDeviceUIDPreferred: String?
   public let inputDeviceUIDSystemDefault: String?
+  // #1376: resolved-route transports, populated where the resolver decision is
+  // available (the XPC proxy stall path). The direct-source stall paths leave
+  // these nil. Low-cardinality transport/reason strings; no PII.
+  public let selectedTransport: String?
+  public let effectiveTransport: String?
+  public let routeReason: String?
+  public let routeFallbackReason: String?
+  public let inputSelectionMode: String?
+  public let outputTransport: String?
+  public let routeResolutionSource: String?
 
   public init(
     sessionID: UInt64,
@@ -28,7 +38,14 @@ public struct CaptureStallContext: Sendable {
     tapInstalled: Bool,
     formatMismatchObserved: Bool,
     inputDeviceUIDPreferred: String?,
-    inputDeviceUIDSystemDefault: String?
+    inputDeviceUIDSystemDefault: String?,
+    selectedTransport: String? = nil,
+    effectiveTransport: String? = nil,
+    routeReason: String? = nil,
+    routeFallbackReason: String? = nil,
+    inputSelectionMode: String? = nil,
+    outputTransport: String? = nil,
+    routeResolutionSource: String? = nil
   ) {
     self.sessionID = sessionID
     self.armedAtUptimeNs = armedAtUptimeNs
@@ -40,6 +57,13 @@ public struct CaptureStallContext: Sendable {
     self.formatMismatchObserved = formatMismatchObserved
     self.inputDeviceUIDPreferred = inputDeviceUIDPreferred
     self.inputDeviceUIDSystemDefault = inputDeviceUIDSystemDefault
+    self.selectedTransport = selectedTransport
+    self.effectiveTransport = effectiveTransport
+    self.routeReason = routeReason
+    self.routeFallbackReason = routeFallbackReason
+    self.inputSelectionMode = inputSelectionMode
+    self.outputTransport = outputTransport
+    self.routeResolutionSource = routeResolutionSource
   }
 }
 

--- a/Sources/EnviousWisprPipeline/AudioCaptureFailureExtras.swift
+++ b/Sources/EnviousWisprPipeline/AudioCaptureFailureExtras.swift
@@ -9,6 +9,7 @@ enum AudioCaptureFailureExtras {
     failureMode: String,
     backend: String? = nil
   ) -> [String: Any] {
+    let resolvedRoute = audioCapture.currentResolvedRoute
     var extras = SentryAudioExtras.buildCaptureExtras(
       route: audioCapture.currentAudioRoute,
       sourceType: audioCapture.captureSourceType,
@@ -17,7 +18,14 @@ enum AudioCaptureFailureExtras {
       inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
         ? nil : audioCapture.preferredInputDeviceIDOverride,
       inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
-      failureMode: failureMode
+      failureMode: failureMode,
+      selectedTransport: resolvedRoute?.selected,
+      effectiveTransport: resolvedRoute?.effective,
+      routeReason: resolvedRoute?.routeReason,
+      routeFallbackReason: resolvedRoute?.routeFallbackReason,
+      inputSelectionMode: resolvedRoute?.inputSelectionMode,
+      outputTransport: resolvedRoute?.outputTransport,
+      routeResolutionSource: resolvedRoute?.routeResolutionSource
     )
 
     if let source = (error as? AudioError)?.diagnosticSource {

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
@@ -14,6 +14,15 @@ struct NoAudioContext: Sendable {
   let captureSourceType: String
   let inputDeviceUIDPreferred: String?
   let inputDeviceUIDSystemDefault: String?
+  // #1376: resolved-route transports so the "app-derived effective=built_in +
+  // empty transcript" join (CO4) is queryable on the no-audio terminal.
+  var selectedTransport: String? = nil
+  var effectiveTransport: String? = nil
+  var routeReason: String? = nil
+  var routeFallbackReason: String? = nil
+  var inputSelectionMode: String? = nil
+  var outputTransport: String? = nil
+  var routeResolutionSource: String? = nil
 }
 
 /// Per-call context for `HeartPathTelemetryEmitter.zombieZeroPeakIfNeeded(...)`.
@@ -30,4 +39,13 @@ struct ZeroPeakContext: Sendable {
   let captureSourceType: String
   let inputDeviceUIDPreferred: String?
   let inputDeviceUIDSystemDefault: String?
+  // #1376: resolved-route transports so a zero-peak (silent) terminal carries
+  // the same route context as the success + no-audio events (CO4).
+  var selectedTransport: String? = nil
+  var effectiveTransport: String? = nil
+  var routeReason: String? = nil
+  var routeFallbackReason: String? = nil
+  var inputSelectionMode: String? = nil
+  var outputTransport: String? = nil
+  var routeResolutionSource: String? = nil
 }

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -103,7 +103,14 @@ final class HeartPathTelemetryEmitter {
       inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
       inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
       failureMode: "stall_window_elapsed",
-      stallContext: ctx
+      stallContext: ctx,
+      selectedTransport: ctx.selectedTransport,
+      effectiveTransport: ctx.effectiveTransport,
+      routeReason: ctx.routeReason,
+      routeFallbackReason: ctx.routeFallbackReason,
+      inputSelectionMode: ctx.inputSelectionMode,
+      outputTransport: ctx.outputTransport,
+      routeResolutionSource: ctx.routeResolutionSource
     )
     captureError(
       HeartPathError.audioCaptureStalled(sessionID: ctx.sessionID, ctx: ctx),
@@ -197,7 +204,14 @@ final class HeartPathTelemetryEmitter {
         isActivelyCapturing: ctx.isActivelyCapturing,
         inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
         inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
-        failureMode: "no_audio_captured"
+        failureMode: "no_audio_captured",
+        selectedTransport: ctx.selectedTransport,
+        effectiveTransport: ctx.effectiveTransport,
+        routeReason: ctx.routeReason,
+        routeFallbackReason: ctx.routeFallbackReason,
+        inputSelectionMode: ctx.inputSelectionMode,
+        outputTransport: ctx.outputTransport,
+        routeResolutionSource: ctx.routeResolutionSource
       )
     )
   }
@@ -240,7 +254,14 @@ final class HeartPathTelemetryEmitter {
         failureMode: "zombie_engine_zero_peak",
         timeSinceLastSuccessfulRecordingMs:
           captureTelemetry.timeSinceLastSuccessfulRecordingMs(),
-        configChangeCountSinceLaunch: captureTelemetry.configurationChangeCount
+        configChangeCountSinceLaunch: captureTelemetry.configurationChangeCount,
+        selectedTransport: ctx.selectedTransport,
+        effectiveTransport: ctx.effectiveTransport,
+        routeReason: ctx.routeReason,
+        routeFallbackReason: ctx.routeFallbackReason,
+        inputSelectionMode: ctx.inputSelectionMode,
+        outputTransport: ctx.outputTransport,
+        routeResolutionSource: ctx.routeResolutionSource
       )
     )
     return true

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -746,6 +746,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// kernel; never persisted. Reason strings only, never user content.
   public var lastStopReason: String? { kernel.lastStopReason }
   public var lastRecordingDurationSeconds: Double? { kernel.lastRecordingDurationSeconds }
+  /// #1376: the resolved-route transports for the most recent recording, for
+  /// the App layer's `dictation.completed` telemetry. LIVE pass-through from the
+  /// kernel; never persisted. Low-cardinality transport/reason strings only.
+  public var lastResolvedRoute: ResolvedRouteTransports? { kernel.lastResolvedRoute }
 
   // MARK: Caller-facing event + overlay surface
 

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -601,6 +601,7 @@ final class KernelLifecycleTelemetrySink {
       let snapshotDurationMs = telemetryState.recordingSnapshot?.durationMs ?? 0
       let computedDurationMs = sampleCount * 1000 / Int(AudioConstants.sampleRate)
       let preferredID = audioCapture.preferredInputDeviceIDOverride
+      let resolvedRoute = audioCapture.currentResolvedRoute
       let ctx = NoAudioContext(
         sessionID: audioCapture.currentCaptureSessionID,
         durationMs: max(snapshotDurationMs, computedDurationMs),
@@ -609,7 +610,14 @@ final class KernelLifecycleTelemetrySink {
         isActivelyCapturing: audioCapture.isActivelyCapturing,
         captureSourceType: audioCapture.captureSourceType,
         inputDeviceUIDPreferred: preferredID.isEmpty ? nil : preferredID,
-        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+        selectedTransport: resolvedRoute?.selected,
+        effectiveTransport: resolvedRoute?.effective,
+        routeReason: resolvedRoute?.routeReason,
+        routeFallbackReason: resolvedRoute?.routeFallbackReason,
+        inputSelectionMode: resolvedRoute?.inputSelectionMode,
+        outputTransport: resolvedRoute?.outputTransport,
+        routeResolutionSource: resolvedRoute?.routeResolutionSource
       )
       if let noAudioCapturedRich {
         noAudioCapturedRich(ctx)

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -355,6 +355,14 @@ final class RecordingSessionKernel {
   /// processing-time `e2eSeconds`. Never persisted to the transcript.
   private(set) var lastRecordingDurationSeconds: Double?
 
+  /// The resolved-route transports snapshotted at the `.recording` transition
+  /// (#1376): the selected vs effective microphone transport, route reason, and
+  /// input-selection mode this recording actually resolved. Read by the App
+  /// layer for `dictation.completed`. Snapshotted (not read live at emit) so a
+  /// mid-flight device change cannot tear the recorded value. Overwritten each
+  /// session; never persisted.
+  private(set) var lastResolvedRoute: ResolvedRouteTransports?
+
   /// `true` once the polish step returned a non-empty processed transcript —
   /// the kernel-era equivalent of the point at which the old pipeline called
   /// `asrManager.noteTranscriptionComplete(policy:)` (just after polish, before
@@ -912,6 +920,10 @@ final class RecordingSessionKernel {
     recordingStartedAtDate = Date()
     lastStopReason = nil  // #1060: clear prior session's stop reason.
     lastRecordingDurationSeconds = nil
+    // #1376: snapshot the resolved route AFTER all start retries (this
+    // transition is downstream of every startEnginePhase/beginCapturePhase
+    // path) so the recorded value reflects the FINAL resolved route.
+    lastResolvedRoute = audioCapture.currentResolvedRoute
     // Stamp visible-recording start for the #4 discard gate (PR-4.5 #4, §5b).
     // Set ONLY after the transition to .recording; pre-roll buffers fed
     // earlier do not count toward minimum-duration.
@@ -2357,6 +2369,7 @@ final class RecordingSessionKernel {
       rawSamples.count >= AudioConstants.minimumTranscriptionSamples
     else { return }
 
+    let resolvedRoute = audioCapture.currentResolvedRoute
     zombieZeroPeakTelemetry(
       ZeroPeakContext(
         sessionID: audioCapture.currentCaptureSessionID,
@@ -2367,7 +2380,14 @@ final class RecordingSessionKernel {
         captureSourceType: audioCapture.captureSourceType,
         inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
           ? nil : audioCapture.preferredInputDeviceIDOverride,
-        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+        selectedTransport: resolvedRoute?.selected,
+        effectiveTransport: resolvedRoute?.effective,
+        routeReason: resolvedRoute?.routeReason,
+        routeFallbackReason: resolvedRoute?.routeFallbackReason,
+        inputSelectionMode: resolvedRoute?.inputSelectionMode,
+        outputTransport: resolvedRoute?.outputTransport,
+        routeResolutionSource: resolvedRoute?.routeResolutionSource
       )
     )
   }

--- a/Sources/EnviousWisprServices/SentryAudioExtras.swift
+++ b/Sources/EnviousWisprServices/SentryAudioExtras.swift
@@ -22,7 +22,14 @@ public enum SentryAudioExtras {
     stallContext: CaptureStallContext? = nil,
     polishModelSwapMs: Int? = nil,
     timeSinceLastSuccessfulRecordingMs: Int? = nil,
-    configChangeCountSinceLaunch: Int? = nil
+    configChangeCountSinceLaunch: Int? = nil,
+    selectedTransport: String? = nil,
+    effectiveTransport: String? = nil,
+    routeReason: String? = nil,
+    routeFallbackReason: String? = nil,
+    inputSelectionMode: String? = nil,
+    outputTransport: String? = nil,
+    routeResolutionSource: String? = nil
   ) -> [String: Any] {
     var extras: [String: Any] = [
       "capture.source_type": sourceType,
@@ -65,6 +72,19 @@ public enum SentryAudioExtras {
     if let count = configChangeCountSinceLaunch {
       extras["capture.config_change_count_since_launch"] = count
     }
+
+    // #1376: effective-device route context on capture-error events. Absent
+    // params → keys omitted (mirrors the optional-extras pattern above). Low-
+    // cardinality transport/reason strings only (`telemetry-privacy-boundary`);
+    // `capture.effective_transport` is the app-derived value, NOT a helper-bound
+    // "actual started" transport (that name is reserved for Phase 3).
+    if let st = selectedTransport { extras["capture.selected_transport"] = st }
+    if let et = effectiveTransport { extras["capture.effective_transport"] = et }
+    if let rr = routeReason { extras["capture.route_reason"] = rr }
+    if let rfr = routeFallbackReason { extras["capture.route_fallback_reason"] = rfr }
+    if let ism = inputSelectionMode { extras["capture.input_selection_mode"] = ism }
+    if let ot = outputTransport { extras["capture.output_transport"] = ot }
+    if let rrs = routeResolutionSource { extras["capture.route_resolution_source"] = rrs }
 
     return extras
   }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -67,17 +67,28 @@ public final class TelemetryService {
   public func reportDictationCompleted(
     transcript t: Transcript, inputMode: String,
     recordingSeconds: Double? = nil, stopReason: String? = nil,
-    historySaveStatus: String? = nil, historySaveErrorClass: String? = nil
+    historySaveStatus: String? = nil, historySaveErrorClass: String? = nil,
+    selectedTransport: String? = nil, effectiveTransport: String? = nil,
+    routeReason: String? = nil, routeFallbackReason: String? = nil,
+    inputSelectionMode: String? = nil, outputTransport: String? = nil,
+    routeResolutionSource: String? = nil
   ) {
     #if DEBUG
+      var hookStringProps: [String: String] = [
+        "input_mode": inputMode,
+        "asr_backend": t.backendType.rawValue,
+      ]
+      // #1376: mirror the emitted route keys' presence-only semantics so the
+      // App → Telemetry threading is unit-testable.
+      if let st = selectedTransport { hookStringProps["selected_transport"] = st }
+      if let et = effectiveTransport { hookStringProps["effective_transport"] = et }
+      if let rr = routeReason { hookStringProps["route_reason"] = rr }
+      if let rfr = routeFallbackReason { hookStringProps["route_fallback_reason"] = rfr }
+      if let ism = inputSelectionMode { hookStringProps["input_selection_mode"] = ism }
+      if let ot = outputTransport { hookStringProps["output_transport"] = ot }
+      if let rrs = routeResolutionSource { hookStringProps["route_resolution_source"] = rrs }
       testEventHook?(
-        CapturedTelemetryEvent(
-          name: "dictation.completed",
-          stringProps: [
-            "input_mode": inputMode,
-            "asr_backend": t.backendType.rawValue,
-          ]
-        ))
+        CapturedTelemetryEvent(name: "dictation.completed", stringProps: hookStringProps))
     #endif
     let m = t.metrics
     dictationCompleted(
@@ -106,7 +117,14 @@ public final class TelemetryService {
       recordingSeconds: recordingSeconds,
       stopReason: stopReason,
       historySaveStatus: historySaveStatus,
-      historySaveErrorClass: historySaveErrorClass
+      historySaveErrorClass: historySaveErrorClass,
+      selectedTransport: selectedTransport,
+      effectiveTransport: effectiveTransport,
+      routeReason: routeReason,
+      routeFallbackReason: routeFallbackReason,
+      inputSelectionMode: inputSelectionMode,
+      outputTransport: outputTransport,
+      routeResolutionSource: routeResolutionSource
     )
     if let e2e = m?.e2eSeconds {
       metricPipelineE2E(
@@ -418,7 +436,11 @@ public final class TelemetryService {
     emojiInInput: Int? = nil, emojiDropped: Int? = nil, emojiRestored: Int? = nil,
     emojiRestoreIncomplete: Bool? = nil, emojiLatencyMs: Double? = nil,
     recordingSeconds: Double? = nil, stopReason: String? = nil,
-    historySaveStatus: String? = nil, historySaveErrorClass: String? = nil
+    historySaveStatus: String? = nil, historySaveErrorClass: String? = nil,
+    selectedTransport: String? = nil, effectiveTransport: String? = nil,
+    routeReason: String? = nil, routeFallbackReason: String? = nil,
+    inputSelectionMode: String? = nil, outputTransport: String? = nil,
+    routeResolutionSource: String? = nil
   ) {
     var props: [String: Any] = [
       "result": result,
@@ -457,6 +479,17 @@ public final class TelemetryService {
     // The top-line success metric is "completed AND history_save_status != failed".
     if let hss = historySaveStatus { props["history_save_status"] = hss }
     if let hec = historySaveErrorClass { props["history_save_error_class"] = hec }
+    // #1376: effective-device telemetry — which mic was selected vs actually
+    // used, plus route reason + selection mode + output transport. Metadata only
+    // (low-cardinality transport/reason strings, `telemetry-privacy-boundary`).
+    // Query by presence; older app builds simply omit these keys.
+    if let st = selectedTransport { props["selected_transport"] = st }
+    if let et = effectiveTransport { props["effective_transport"] = et }
+    if let rr = routeReason { props["route_reason"] = rr }
+    if let rfr = routeFallbackReason { props["route_fallback_reason"] = rfr }
+    if let ism = inputSelectionMode { props["input_selection_mode"] = ism }
+    if let ot = outputTransport { props["output_transport"] = ot }
+    if let rrs = routeResolutionSource { props["route_resolution_source"] = rrs }
     PostHogSDK.shared.capture("dictation.completed", properties: props)
   }
 

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -20,6 +20,7 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   var audioLevel: Float = 0
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
+  var currentResolvedRoute: ResolvedRouteTransports? = nil
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -147,6 +147,7 @@ private final class SettableAudioCapture: AudioCaptureInterface {
   var audioLevel: Float = 0
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
+  var currentResolvedRoute: ResolvedRouteTransports? = nil
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
@@ -198,6 +199,7 @@ private final class ObservableAudioCapture: AudioCaptureInterface {
   var audioLevel: Float = 0
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
+  var currentResolvedRoute: ResolvedRouteTransports? = nil
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?

--- a/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
+++ b/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
@@ -75,11 +75,39 @@ struct ResolvedRouteTransportsGridTests {
     #expect(r.inputSelectionMode == "explicit")
   }
 
-  @Test("selectedInputDeviceUID (no override) still counts as an explicit pick")
-  func selectedUIDCountsExplicit() {
+  @Test("selection mode follows the settings picker; a bare selectedInputDeviceUID stays Auto")
+  func selectionModeFollowsPicker() {
+    // The mic picker binds to preferredInputDeviceIDOverride and the resolver
+    // uses ONLY that, so a bare selectedInputDeviceUID is Auto to the resolver
+    // — mode/selected must agree with route_reason, not claim explicit (#1387).
     let r = ResolvedRouteTransports.derive(
-      decision: makeDecision(.audioEngine, .noBTUserSelectedDevice),
+      decision: makeDecision(.audioEngine, .noBTAutoInput),
       preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "fake-uid")
+    #expect(r.inputSelectionMode == "auto")
+    #expect(r.selected == "unknown")
+  }
+
+  @Test("bare selectedInputDeviceUID under BT output does NOT misreport explicit (cloud review P2)")
+  func bareSelectedUnderBTOutputStaysConsistentWithRouteReason() {
+    // The exact misclassification the cloud reviewer flagged: a stored device
+    // UID in selectedInputDeviceUID with an empty picker must not emit
+    // explicit/bluetooth while route_reason stays Auto. All three agree on Auto.
+    let r = ResolvedRouteTransports.derive(
+      decision: makeDecision(.captureSession, .btOutputAutoInput),
+      preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "fake-bt-uid")
+    #expect(r.inputSelectionMode == "auto")
+    #expect(r.selected == "unknown")
+    #expect(r.routeReason == "btOutputAutoInput")
+    #expect(r.effective == "built_in")
+  }
+
+  @Test("an explicit picker choice reports explicit + its transport (consistent with route_reason)")
+  func explicitPickerReportsExplicit() {
+    // preferredInputDeviceIDOverride set (the picker) → explicit, and the
+    // resolver saw the same value, so route_reason is a user-selected reason.
+    let r = ResolvedRouteTransports.derive(
+      decision: makeDecision(.captureSession, .btOutputUserSelectedBTMic),
+      preferredInputDeviceIDOverride: "fake-bt-uid", selectedInputDeviceUID: "")
     #expect(r.inputSelectionMode == "explicit")
   }
 

--- a/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
+++ b/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1376 — locks `ResolvedRouteTransports.derive` as a total function over the
+// `CaptureSourceType × CaptureRouteReason` grid: reason passthrough, fallback
+// presence-iff-a-fallback-rung, capture-session-path-is-built-in-only, and the
+// selection-mode split. The selected/effective TRANSPORT values depend on live
+// CoreAudio device state (verified at Live UAT), so these tests assert the
+// deterministic structural invariants only.
+@Suite("ResolvedRouteTransports.derive — #1376")
+struct ResolvedRouteTransportsGridTests {
+
+  private func makeDecision(
+    _ source: CaptureSourceType, _ reason: CaptureRouteReason
+  ) -> CaptureRouteDecision {
+    CaptureRouteDecision(
+      sourceType: source, reason: reason, rationale: "test",
+      vpAvailable: false, fallbackAllowed: false)
+  }
+
+  @Test(
+    "derive is total over the sourceType × reason grid",
+    arguments: [CaptureSourceType.audioEngine, .captureSession],
+    [
+      CaptureRouteReason.btOutputAutoInput, .btOutputUserSelectedBTMic,
+      .btOutputUserSelectedBuiltIn, .btOutputUserSelectedWired, .noBTAutoInput,
+      .noBTUserSelectedDevice, .forcedEngine, .forcedCaptureSession,
+      .fallbackToEngine, .failedNoFallback,
+    ])
+  func totalOverGrid(source: CaptureSourceType, reason: CaptureRouteReason) {
+    let r = ResolvedRouteTransports.derive(
+      decision: makeDecision(source, reason),
+      preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "")
+
+    #expect(r.routeReason == reason.rawValue)
+
+    let isFallbackRung = (reason == .fallbackToEngine || reason == .failedNoFallback)
+    #expect((r.routeFallbackReason != nil) == isFallbackRung)
+    if isFallbackRung { #expect(r.routeFallbackReason == reason.rawValue) }
+
+    // The capture-session path opens the built-in mic only today (bible R4).
+    if source == .captureSession { #expect(r.effective == "built_in") }
+
+    // Empty UIDs → Auto; no user-selected transport.
+    #expect(r.inputSelectionMode == "auto")
+    #expect(r.selected == "unknown")
+
+    #expect(r.routeResolutionSource == "app_derived")
+    // Totality: effective is always a non-empty label.
+    #expect(!r.effective.isEmpty)
+  }
+
+  @Test("explicit Bluetooth pick under BT output: mode=explicit, effective forced to built_in")
+  func explicitBTMicForcedToBuiltIn() {
+    // The core invisible divergence: the user explicitly picked a Bluetooth mic,
+    // but the capture-session route forces the built-in mic. The fake UID does
+    // not resolve to a live device, so `selected` is "unknown", yet the SELECTION
+    // MODE is explicit because the user pinned a device.
+    let r = ResolvedRouteTransports.derive(
+      decision: makeDecision(.captureSession, .btOutputUserSelectedBTMic),
+      preferredInputDeviceIDOverride: "fake-bt-uid", selectedInputDeviceUID: "")
+    #expect(r.inputSelectionMode == "explicit")
+    #expect(r.effective == "built_in")
+    #expect(r.routeReason == "btOutputUserSelectedBTMic")
+  }
+
+  @Test("wired pick under BT output also yields effective=built_in (non-intended class)")
+  func wiredUnderBTOutput() {
+    let r = ResolvedRouteTransports.derive(
+      decision: makeDecision(.captureSession, .btOutputUserSelectedWired),
+      preferredInputDeviceIDOverride: "fake-wired-uid", selectedInputDeviceUID: "")
+    #expect(r.effective == "built_in")
+    #expect(r.inputSelectionMode == "explicit")
+  }
+
+  @Test("selectedInputDeviceUID (no override) still counts as an explicit pick")
+  func selectedUIDCountsExplicit() {
+    let r = ResolvedRouteTransports.derive(
+      decision: makeDecision(.audioEngine, .noBTUserSelectedDevice),
+      preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "fake-uid")
+    #expect(r.inputSelectionMode == "explicit")
+  }
+
+  @Test("a disconnected pinned device falls effective back to the default input (engine parity)")
+  func disconnectedPinFallsBackToDefault() {
+    // AVAudioEngineSource resolves a missing pinned UID to nil and captures from
+    // the system-default input (`resolvedDeviceID ?? defaultInputDeviceID()`),
+    // so the effective transport must match Auto, NOT report "unknown".
+    let disconnected = ResolvedRouteTransports.derive(
+      decision: makeDecision(.audioEngine, .noBTUserSelectedDevice),
+      preferredInputDeviceIDOverride: "fake-disconnected-uid", selectedInputDeviceUID: "")
+    let auto = ResolvedRouteTransports.derive(
+      decision: makeDecision(.audioEngine, .noBTAutoInput),
+      preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "")
+    #expect(disconnected.effective == auto.effective)
+    // The user's pick is unavailable, so `selected` stays unknown.
+    #expect(disconnected.selected == "unknown")
+    #expect(disconnected.inputSelectionMode == "explicit")
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/RouteResolvedProducerTests.swift
+++ b/Tests/EnviousWisprTests/Audio/RouteResolvedProducerTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1376 — locks the changed-only semantics of the `onRouteResolved` producer
+// (`CaptureRouteDecision.routeResolvedChanged`), the single authority both
+// `AudioCaptureManager` and `AudioCaptureProxy` fire through: first resolution
+// fires, an identical warm-reuse resolution is a no-op, and a reason or
+// sourceType change re-fires. Pure predicate — no audio hardware, no timing.
+@Suite("onRouteResolved changed-only predicate — #1376")
+struct RouteResolvedProducerTests {
+
+  private func decision(
+    _ source: CaptureSourceType, _ reason: CaptureRouteReason
+  ) -> CaptureRouteDecision {
+    CaptureRouteDecision(
+      sourceType: source, reason: reason, rationale: "t",
+      vpAvailable: false, fallbackAllowed: false)
+  }
+
+  @Test("fires on the first resolution (prior nil)")
+  func firstResolution() {
+    #expect(
+      CaptureRouteDecision.routeResolvedChanged(
+        from: nil, to: decision(.audioEngine, .noBTAutoInput)))
+  }
+
+  @Test("no-op when reason and sourceType are unchanged (identical warm reuse)")
+  func unchangedNoOp() {
+    let d = decision(.audioEngine, .noBTAutoInput)
+    #expect(!CaptureRouteDecision.routeResolvedChanged(from: d, to: d))
+  }
+
+  @Test("re-fires when the reason differs (same sourceType)")
+  func reasonChanged() {
+    let prior = decision(.captureSession, .btOutputAutoInput)
+    let next = decision(.captureSession, .btOutputUserSelectedBTMic)
+    #expect(CaptureRouteDecision.routeResolvedChanged(from: prior, to: next))
+  }
+
+  @Test("re-fires when the sourceType flips")
+  func sourceTypeFlipped() {
+    let prior = decision(.audioEngine, .noBTAutoInput)
+    let next = decision(.captureSession, .btOutputAutoInput)
+    #expect(CaptureRouteDecision.routeResolvedChanged(from: prior, to: next))
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/TransportLabelParityTests.swift
+++ b/Tests/EnviousWisprTests/Audio/TransportLabelParityTests.swift
@@ -1,0 +1,45 @@
+import CoreAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1376 — locks `AudioDeviceEnumerator.transportLabel(forTransportType:)`, the
+// single transport-string authority extracted from
+// `AudioEnvironmentSnapshotter.deviceTransport`. Byte-identical mapping incl the
+// nil case, so the existing `input_device_transport` / `output_device_transport`
+// Sentry values do not drift after the extraction.
+@Suite("TransportLabel parity — #1376")
+struct TransportLabelParityTests {
+
+  @Test("each CoreAudio transport constant maps to its stable label")
+  func mapping() {
+    let cases: [(UInt32, String)] = [
+      (kAudioDeviceTransportTypeBuiltIn, "built_in"),
+      (kAudioDeviceTransportTypeBluetooth, "bluetooth"),
+      (kAudioDeviceTransportTypeBluetoothLE, "bluetooth"),
+      (kAudioDeviceTransportTypeUSB, "usb"),
+      (kAudioDeviceTransportTypeAggregate, "aggregate"),
+      (kAudioDeviceTransportTypeVirtual, "virtual"),
+      (kAudioDeviceTransportTypeDisplayPort, "display_port"),
+      (kAudioDeviceTransportTypeHDMI, "hdmi"),
+      (kAudioDeviceTransportTypeAirPlay, "air_play"),
+      (kAudioDeviceTransportTypePCI, "pci"),
+      (kAudioDeviceTransportTypeFireWire, "fire_wire"),
+      (kAudioDeviceTransportTypeThunderbolt, "thunderbolt"),
+    ]
+    for (raw, expected) in cases {
+      #expect(AudioDeviceEnumerator.transportLabel(forTransportType: raw) == expected)
+    }
+  }
+
+  @Test("nil raw transport preserves nil (load-bearing for optional Sentry keys)")
+  func nilPreserved() {
+    #expect(AudioDeviceEnumerator.transportLabel(forTransportType: nil) == nil)
+  }
+
+  @Test("an unmapped transport constant falls back to unknown, not nil")
+  func unknownFallback() {
+    #expect(AudioDeviceEnumerator.transportLabel(forTransportType: 0xFFFF_FFFF) == "unknown")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -61,6 +61,7 @@ private final class ExtrasAudioCapture: AudioCaptureInterface {
   var audioLevel: Float = 0
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
+  var currentResolvedRoute: ResolvedRouteTransports? = nil
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -441,6 +441,7 @@ internal final class FixtureAudioCapture: AudioCaptureInterface {
   var audioLevel: Float = 0
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "synthetic-fixture"
+  var currentResolvedRoute: ResolvedRouteTransports? = nil
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -303,6 +303,7 @@ private final class NoOpAudioCapture: AudioCaptureInterface {
   var audioLevel: Float = 0
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
+  var currentResolvedRoute: ResolvedRouteTransports? = nil
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -65,6 +65,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
   var audioLevel: Float { 0 }
   var capturedSamples: [Float] { accumulatedSamples }
   var currentAudioRoute: String { "fake" }
+  var currentResolvedRoute: ResolvedRouteTransports? { nil }
   private(set) var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool { isCapturing }
   var captureSourceType: String { "av_audio_engine" }

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -136,6 +136,7 @@ private final class NeverFinishingAudioCapture: AudioCaptureInterface {
   var audioLevel: Float = 0
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "synthetic-fixture"
+  var currentResolvedRoute: ResolvedRouteTransports? = nil
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?

--- a/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
@@ -1,0 +1,68 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+// #1376 — locks that the App layer's effective-device fields thread through
+// `reportDictationCompleted` into the `dictation.completed` props with the
+// emitted keys' presence-only semantics (populated when supplied, omitted when
+// nil). The end-to-end PostHog emission is verified separately at Live UAT.
+//
+// `testEventHook` + `CapturedTelemetryEvent` are DEBUG-only (stripped from
+// release builds), so this suite is DEBUG-gated to compile under both flavors.
+@Suite("dictation.completed route fields — #1376")
+@MainActor
+struct DictationCompletedRouteFieldsTests {
+  #if DEBUG
+
+    private final class Box: @unchecked Sendable {
+      var event: CapturedTelemetryEvent?
+    }
+
+    @Test("route fields thread into dictation.completed props when populated")
+    func routeFieldsThreaded() {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt",
+        selectedTransport: "bluetooth", effectiveTransport: "built_in",
+        routeReason: "btOutputUserSelectedBTMic",
+        inputSelectionMode: "explicit", outputTransport: "bluetooth",
+        routeResolutionSource: "app_derived")
+
+      let props = box.event?.stringProps
+      #expect(props?["selected_transport"] == "bluetooth")
+      #expect(props?["effective_transport"] == "built_in")
+      #expect(props?["route_reason"] == "btOutputUserSelectedBTMic")
+      #expect(props?["input_selection_mode"] == "explicit")
+      #expect(props?["output_transport"] == "bluetooth")
+      #expect(props?["route_resolution_source"] == "app_derived")
+      // Absent fallback reason → key omitted.
+      #expect(props?["route_fallback_reason"] == nil)
+    }
+
+    @Test("Auto dictation omits route fields when nil")
+    func autoOmitsFields() {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt")
+
+      let props = box.event?.stringProps
+      #expect(props?["selected_transport"] == nil)
+      #expect(props?["effective_transport"] == nil)
+      #expect(props?["route_reason"] == nil)
+      // The pre-existing input_mode key is still emitted.
+      #expect(props?["input_mode"] == "ptt")
+    }
+  #endif
+}

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasRouteTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasRouteTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+@testable import EnviousWisprServices
+
+// #1376 — locks the effective-device route keys on the Sentry capture-error
+// extras: present when supplied, omitted when nil (mirroring the existing
+// optional-extras pattern), the honest `capture.effective_transport` name (NOT
+// the Phase-3-reserved `actual_started_transport`, CR1), and only allowed
+// low-cardinality metadata (no dictated content — `telemetry-privacy-boundary`).
+@Suite("SentryAudioExtras route fields — #1376")
+@MainActor
+struct SentryAudioExtrasRouteTests {
+
+  @Test("route params populate the capture.* keys")
+  func routeKeysPresent() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "capture_session_bt", sourceType: "xpc_proxy", sessionID: 1,
+      isActivelyCapturing: true, inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil, failureMode: "no_audio_captured",
+      selectedTransport: "bluetooth", effectiveTransport: "built_in",
+      routeReason: "btOutputUserSelectedBTMic", routeFallbackReason: nil,
+      inputSelectionMode: "explicit", outputTransport: "bluetooth",
+      routeResolutionSource: "app_derived")
+
+    #expect(extras["capture.selected_transport"] as? String == "bluetooth")
+    #expect(extras["capture.effective_transport"] as? String == "built_in")
+    #expect(extras["capture.route_reason"] as? String == "btOutputUserSelectedBTMic")
+    #expect(extras["capture.input_selection_mode"] as? String == "explicit")
+    #expect(extras["capture.output_transport"] as? String == "bluetooth")
+    #expect(extras["capture.route_resolution_source"] as? String == "app_derived")
+
+    // Nil fallback reason → key omitted (presence IS the fallback-rung signal).
+    #expect(extras["capture.route_fallback_reason"] == nil)
+    // CR1: the Phase-3-reserved name must never appear this phase.
+    #expect(extras["capture.actual_started_transport"] == nil)
+  }
+
+  @Test("absent route params omit every capture.* route key")
+  func routeKeysOmitted() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in_mic", sourceType: "av_audio_engine", sessionID: 2,
+      isActivelyCapturing: false, inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil, failureMode: "stalled")
+
+    #expect(extras["capture.selected_transport"] == nil)
+    #expect(extras["capture.effective_transport"] == nil)
+    #expect(extras["capture.route_reason"] == nil)
+    #expect(extras["capture.input_selection_mode"] == nil)
+    #expect(extras["capture.output_transport"] == nil)
+    #expect(extras["capture.route_resolution_source"] == nil)
+    // The pre-existing keys are unaffected.
+    #expect(extras["capture.route"] as? String == "built_in_mic")
+  }
+
+  @Test("a fallback rung's route_fallback_reason is emitted when supplied")
+  func fallbackReasonPresent() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "failed", sourceType: "av_audio_engine", sessionID: 3,
+      isActivelyCapturing: false, inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil, failureMode: "no_audio_captured",
+      routeReason: "failedNoFallback", routeFallbackReason: "failedNoFallback")
+    #expect(extras["capture.route_fallback_reason"] as? String == "failedNoFallback")
+  }
+}


### PR DESCRIPTION
## Phase 1 of the Bluetooth-capture epic (#1374): effective-device telemetry (observe-only)

Records, per recording, **which microphone the user selected vs which one the app actually used**, plus the machine-readable route reason, input-selection mode, and output transport. This makes the invisible "you picked AirPods but we silently recorded built-in" failure measurable in production. **Zero capture-behavior change; both engines; no UI.**

### What ships
- New `ResolvedRouteTransports` value type (`EnviousWisprAudio`) — the single resolved-route observation, derived once from the resolver decision and **frozen at resolve time**; both sinks consume it, neither re-derives.
- `AudioDeviceEnumerator.transportLabel` — the single transport-string authority, extracted from `AudioEnvironmentSnapshotter.deviceTransport` (nil-preserving, parity-locked).
- `onRouteResolved` producer wired (changed-only) via the shared `CaptureRouteDecision.routeResolvedChanged` predicate — un-deads the declared API (bible R2); telemetry stays pull-based (`currentResolvedRoute`).
- Seven fields on `dictation.completed` (success) + `capture.*` keys on the Sentry capture-error / no-audio / zero-peak / proxy-stall terminals — the CO4 "app-derived effective=built_in + empty transcript" join.

### Fields
`selected_transport` / `effective_transport` / `route_reason` / `route_fallback_reason` / `input_selection_mode` / `output_transport` / `route_resolution_source` (= `app_derived` this phase). Low-cardinality metadata only (transport/reason strings) — no device UIDs, no dictated content (`telemetry-privacy-boundary`).

### Validation
- Logic gate green (2444 tests). The lone failure is a pre-existing parallel-suite flake in the crash-recovery keychain path (`RecoverySpoolReplayerTests`) — passes cleanly in isolation, unrelated to this diff (touches zero recovery/keychain files).
- 5 new test suites (21 cases): derive-grid totality, transport-label parity, changed-only predicate, Sentry route keys, `dictation.completed` threading, and engine-fallback parity.
- Local Codex code-diff review: **clean after 3 rounds**. Fixed two snapshot-vs-live accuracy bugs it surfaced — the in-process manager now **freezes** the derived route (like the proxy) so an in-flight device-setting change can't mislabel a later failure-terminal read; and a saved-but-disconnected pinned device now reports the engine's actual default-input fallback (`AVAudioEngineSource:243`) instead of `unknown`.
- Live UAT (built-in mic): heart path intact (transcript lands), route logs cleanly, no crash, both engines.

### Founder morning check (Bluetooth accuracy)
The AirPods / Bose / Clamshell matrix needs real Bluetooth hardware and physical actions, so it is a quick founder-manual verification. Because the change is **observe-only**, the telemetry starts collecting safely regardless; the accuracy check is confirming `effective_transport` matches the mic actually used on a real Bluetooth-output recording (via a PostHog query on the new fields).

### Scope decisions (flagged for review)
- **Failure-point map** delivered via `route_reason` (the existing `CaptureRouteReason` enum) riding all route-carrying events — not a redundant second failure-code enum.
- `onRouteResolved` wired as a producer but telemetry stays **pull-based** (no push consumer this phase; the plan's §14 Q4 open question resolved to pull).

### Blast radius
Diagnostics only. Both engines, both topologies (XPC proxy + in-process). One-line revert; no migration, no persisted state, no flag to unwind.

Part of #1374
Closes #1376