### PR TITLE
fix(build): 302-redirect model downloads to the edge-cached R2 path (#1405)

### DIFF
--- a/workers/parakeet-mirror/scripts/verify-deploy.py
+++ b/workers/parakeet-mirror/scripts/verify-deploy.py
@@ -1,20 +1,25 @@
 #!/usr/bin/env python3
-"""Deploy gate for the parakeet-mirror worker (#1339).
+"""Deploy gate for the parakeet-mirror worker (#1339, #1405).
 
 Run AFTER `wrangler deploy` and BEFORE the app change that points at the
 mirror ships. Verifies, against https://models.enviouslabs.co:
 
-  1. EG-1 routes (live traffic) are untouched: /eg1/... still serves.
-  2. The worker listing, walked recursively exactly like FluidAudio walks it,
+  1. EG-1 routes (live traffic) are untouched: /eg1/... still serves DIRECTLY
+     (200, no redirect) — the worker must not shadow /eg1/.
+  2. The download bridge (#1405): a known resolve URL returns a 302 to the
+     native cache-enabled R2 path (/parakeet/{REPO}/{file}); an unknown resolve
+     URL returns THIS worker's JSON 404 (never a redirect, never R2's HTML 404).
+  3. The worker listing, walked recursively exactly like FluidAudio walks it,
      reconstructs EXACTLY the expected manifest's file set (path + size).
      The expected manifest derives from the pinned upstream revision, never
      from bucket contents (anti-self-certification, plan E3/E3a).
-  3. Every file downloads in full and matches its SHA-256.
-  4. Range semantics: bounded/suffix/open 206 with correct Content-Range,
-     past-EOF 416, multi-range tolerated.
-  5. Unknown paths 404 with JSON (never an HTML page a client would choke on).
+  4. Every file, fetched the way a client walks it (resolve -> 302 -> R2),
+     downloads in full and matches its SHA-256, landing on the /parakeet/ path.
+  5. Range semantics through the redirect: bounded/suffix/open 206 with correct
+     Content-Range, past-EOF 416. HEAD through the redirect: 200 + length + etag.
 
 Exit 0 = safe to flip. Any failure = do NOT ship the app change.
+(Cache MISS->HIT + object-size guardrail assertions are Phase 3, #1405.)
 """
 import hashlib
 import json
@@ -25,10 +30,23 @@ import urllib.request
 
 HOST = "https://models.enviouslabs.co"
 REPO = "FluidInference/parakeet-tdt-0.6b-v3-coreml"
+NATIVE_PREFIX = f"/parakeet/{REPO}/"  # cache-enabled R2 custom-domain path
 HERE = os.path.dirname(os.path.abspath(__file__))
 MANIFEST = json.load(open(os.path.join(HERE, "..", "expected-manifest.json")))
 
+# Zone bot protection 403s Python's default UA; identify as a normal client
+# (the app itself downloads via URLSession/CFNetwork, which passes).
+UA = {"User-Agent": "EnviousWispr-deploy-gate/1 (curl-equivalent)"}
+
 failures = []
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None  # decline: the 3xx surfaces as HTTPError, we assert on it
+
+
+_no_redirect = urllib.request.build_opener(_NoRedirect)
 
 
 def check(name, cond, detail=""):
@@ -39,29 +57,53 @@ def check(name, cond, detail=""):
 
 
 def fetch(path, method="GET", headers=None, want_body=True):
-    # Zone bot protection 403s Python's default UA; identify as a normal client
-    # (the app itself downloads via URLSession/CFNetwork, which passes).
-    hdrs = {"User-Agent": "EnviousWispr-deploy-gate/1 (curl-equivalent)"}
+    """Follow redirects (client simulation). Returns (status, headers, body, final_url)."""
+    hdrs = dict(UA)
     hdrs.update(headers or {})
     req = urllib.request.Request(HOST + path, method=method, headers=hdrs)
     try:
         with urllib.request.urlopen(req) as r:
-            return r.status, {k.lower(): v for k, v in r.headers.items()}, (r.read() if want_body else b"")
+            body = r.read() if want_body else b""
+            return r.status, {k.lower(): v for k, v in r.headers.items()}, body, r.geturl()
     except urllib.error.HTTPError as e:
-        return e.code, {k.lower(): v for k, v in e.headers.items()}, e.read()
+        return e.code, {k.lower(): v for k, v in e.headers.items()}, e.read(), e.url
 
 
-# 1. EG-1 live routes untouched
-st, hd, _ = fetch("/eg1/EG-1-MODEL-LICENSE.txt", want_body=False)
-check("EG-1 license route still serves (worker must not shadow /eg1/)", st == 200, f"status {st}")
+def fetch_no_redirect(path, method="GET", headers=None):
+    """Do NOT follow redirects. Returns (status, headers). Used to assert the 302 itself."""
+    hdrs = dict(UA)
+    hdrs.update(headers or {})
+    req = urllib.request.Request(HOST + path, method=method, headers=hdrs)
+    try:
+        with _no_redirect.open(req) as r:
+            return r.status, {k.lower(): v for k, v in r.headers.items()}
+    except urllib.error.HTTPError as e:
+        return e.code, {k.lower(): v for k, v in e.headers.items()}
 
-# 2. Recursive listing walk == expected manifest
+
+# 1. EG-1 live routes untouched — served DIRECTLY (200), not shadowed/redirected.
+st, hd = fetch_no_redirect("/eg1/EG-1-MODEL-LICENSE.txt", method="HEAD")
+check("EG-1 license route serves directly, no worker shadow", st == 200, f"status {st}")
+
+# 2. Download bridge (#1405): known -> 302 to native path; unknown -> JSON 404.
+sample = MANIFEST["files"][0]["path"]
+st, hd = fetch_no_redirect(f"/{REPO}/resolve/main/{sample}")
+loc = hd.get("location", "")
+check(
+    "known resolve -> 302 to native /parakeet/ path",
+    st == 302 and loc == f"{HOST}{NATIVE_PREFIX}{sample}",
+    f"status {st} location {loc!r}",
+)
+st, hd = fetch_no_redirect(f"/{REPO}/resolve/main/NoSuchFile.bin")
+check("unknown resolve -> JSON 404, NOT a redirect", st == 404 and "json" in hd.get("content-type", ""), f"status {st}")
+
+# 3. Recursive listing walk == expected manifest
 found = {}
 
 
 def walk(sub=""):
     path = f"/api/models/{REPO}/tree/main" + (f"/{sub}" if sub else "")
-    st, hd, body = fetch(path)
+    st, hd, body, _ = fetch(path)
     check(f"listing {sub or '(root)'} 200 JSON", st == 200 and "json" in hd.get("content-type", ""), f"status {st}")
     items = json.loads(body)
     for item in items:
@@ -80,29 +122,37 @@ check(
     f"size-diff={[p for p in found if p in expected and found[p] != expected[p]]}",
 )
 
-# 3. Full-content SHA-256 for every file
+# 4. Full-content SHA-256 for every file, walked resolve -> 302 -> R2 like a client.
+first = True
 for f in MANIFEST["files"]:
-    st, hd, body = fetch(f"/{REPO}/resolve/main/{f['path']}")
+    st, hd, body, final = fetch(f"/{REPO}/resolve/main/{f['path']}")
     ok = st == 200 and len(body) == f["size"] and hashlib.sha256(body).hexdigest() == f["sha256"]
     check(f"sha256 {f['path']}", ok, f"status {st} len {len(body)}")
+    if first:
+        # Prove the bytes actually came THROUGH the redirect to the cached path,
+        # not from a worker regression that started serving bytes again.
+        check("download lands on the native /parakeet/ path after 302", NATIVE_PREFIX in final, f"final {final}")
+        first = False
 
-# 4. Range grid against the big encoder weight
+# 5. Range grid + HEAD through the redirect, against the big encoder weight.
 big = next(f for f in MANIFEST["files"] if f["path"].endswith("Encoder.mlmodelc/weights/weight.bin"))
 bp, bs = f"/{REPO}/resolve/main/{big['path']}", big["size"]
 
-st, hd, body = fetch(bp, headers={"Range": "bytes=0-1023"})
-check("bounded range 206", st == 206 and len(body) == 1024 and hd.get("content-range") == f"bytes 0-1023/{bs}")
-st, hd, body = fetch(bp, headers={"Range": "bytes=-512"})
+st, hd, body, final = fetch(bp, headers={"Range": "bytes=0-1023"})
+check("bounded range 206 (via 302)", st == 206 and len(body) == 1024 and hd.get("content-range") == f"bytes 0-1023/{bs}", f"status {st} final {final}")
+st, hd, body, _ = fetch(bp, headers={"Range": "bytes=-512"})
 check("suffix range 206", st == 206 and len(body) == 512 and hd.get("content-range") == f"bytes {bs-512}-{bs-1}/{bs}")
-st, hd, body = fetch(bp, headers={"Range": f"bytes={bs-64}-"})
+st, hd, body, _ = fetch(bp, headers={"Range": f"bytes={bs-64}-"})
 check("open-ended range 206", st == 206 and len(body) == 64)
-st, hd, _ = fetch(bp, headers={"Range": f"bytes={bs}-"}, want_body=False)
+st, hd, _, _ = fetch(bp, headers={"Range": f"bytes={bs}-"}, want_body=False)
 check("past-EOF range 416 with bytes */size", st == 416 and hd.get("content-range") == f"bytes */{bs}")
 
-# 5. Unknown path is JSON 404
-st, hd, _ = fetch(f"/{REPO}/resolve/main/NoSuchFile.bin", want_body=False)
-check("unknown file 404 JSON", st == 404 and "json" in hd.get("content-type", ""), f"status {st}")
-st, hd, _ = fetch(f"/api/models/{REPO}/tree/main/NoSuch.mlmodelc", want_body=False)
+# HEAD through the redirect (the resume-identity path): 200 + length + etag.
+st, hd, _, _ = fetch(bp, method="HEAD", want_body=False)
+check("HEAD via 302 -> 200 with content-length + etag", st == 200 and hd.get("content-length") == str(bs) and bool(hd.get("etag")), f"status {st}")
+
+# 6. Unknown listing path is JSON 404 (the resolve 404 is checked in section 2).
+st, hd, _, _ = fetch(f"/api/models/{REPO}/tree/main/NoSuch.mlmodelc", want_body=False)
 check("unknown listing 404 JSON", st == 404 and "json" in hd.get("content-type", ""), f"status {st}")
 
 print()
@@ -110,4 +160,4 @@ if failures:
     print(f"DEPLOY GATE FAILED ({len(failures)}): {failures}")
     sys.exit(1)
 total = sum(f["size"] for f in MANIFEST["files"])
-print(f"DEPLOY GATE PASSED — {len(MANIFEST['files'])} files ({total:,} bytes) verified end to end at {HOST}, EG-1 untouched.")
+print(f"DEPLOY GATE PASSED — {len(MANIFEST['files'])} files ({total:,} bytes) verified end to end (resolve -> 302 -> cached R2) at {HOST}, EG-1 untouched.")

--- a/workers/parakeet-mirror/src/index.js
+++ b/workers/parakeet-mirror/src/index.js
@@ -1,4 +1,4 @@
-// Parakeet model mirror (#1339).
+// Parakeet model mirror (#1339, #1405).
 //
 // Serves the pinned Parakeet v3 set from R2 behind the two URL shapes
 // FluidAudio's ModelRegistry builds from its baseURL:
@@ -9,8 +9,17 @@
 // committed expected-manifest.json (generated from the pinned upstream
 // revision, never from bucket contents) — this kills the listing-API hang at
 // its root: no origin round-trip, no rate limit, byte-exact contract.
-// Downloads stream R2 objects with Range/206 support; the 445MB encoder is
-// never buffered in worker memory.
+//
+// Downloads are 302-redirected to the object's native R2 custom-domain path
+// (/parakeet/{REPO}/{filePath}), which is edge-cached (#1405 Cache Rule) and
+// serves 200/206/416/HEAD/ETag natively — so a far-from-origin user is served
+// from a regional edge, not transatlantic R2, and the 445MB encoder never
+// streams through this worker's memory or its 100k/day request budget. The
+// worker stays the allowlist authority: an unknown path returns THIS worker's
+// JSON 404, never R2's default HTML 404 (which the app's captive-portal guard
+// would treat as an intercepted network). §14.1 verified the app's URLSession
+// follows the 302 preserving Range + resume identity + the SHA-256 admission
+// gate (2026-07-07), and v2.3.1 clients follow it with no app update.
 
 import manifest from "../expected-manifest.json" with { type: "json" };
 
@@ -18,6 +27,11 @@ const REPO = "FluidInference/parakeet-tdt-0.6b-v3-coreml";
 const R2_PREFIX = `parakeet/${REPO}/`;
 const LISTING_BASE = `/api/models/${REPO}/tree/main`;
 const RESOLVE_BASE = `/${REPO}/resolve/main/`;
+// Downloads redirect to the object's native path on the same custom domain.
+// This path is NOT covered by this worker's routes (which are scoped to
+// LISTING_BASE and RESOLVE_BASE), so it falls through to the R2 custom-domain
+// binding — no loop back through the worker.
+const REDIRECT_ORIGIN = "https://models.enviouslabs.co";
 
 // path -> {size, sha256} for every expected file (the only downloadable set).
 const FILES = new Map(manifest.files.map((f) => [f.path, f]));
@@ -61,35 +75,6 @@ const json = (body, status = 200) =>
 
 const notFound = () => json({ error: "Not found" }, 404);
 
-// Parse a single-range "bytes=..." header against a known total size.
-// Returns {offset, length} | "unsatisfiable" | null (absent/ignored → full 200).
-function parseRange(header, size) {
-  if (!header) return null;
-  const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
-  if (!m) return null; // multi-range or malformed: ignore per RFC, serve 200
-  const [, startStr, endStr] = m;
-  if (startStr === "" && endStr === "") return null;
-  if (startStr === "") {
-    // suffix: last N bytes
-    const n = Number(endStr);
-    if (n === 0) return "unsatisfiable";
-    const length = Math.min(n, size);
-    return { offset: size - length, length };
-  }
-  const start = Number(startStr);
-  if (start >= size) return "unsatisfiable";
-  const end = endStr === "" ? size - 1 : Math.min(Number(endStr), size - 1);
-  if (end < start) return "unsatisfiable";
-  return { offset: start, length: end - start + 1 };
-}
-
-function contentTypeFor(path) {
-  if (path.endsWith(".json")) return "application/json";
-  if (path.endsWith(".txt")) return "text/plain";
-  return "application/octet-stream";
-}
-
-
 // Malformed percent-encoding must map to the JSON 404 contract, not a thrown
 // URIError -> 500 (public route; Codex r2). Returns null on bad escapes.
 function safeDecode(component) {
@@ -112,56 +97,26 @@ async function handleListing(pathname) {
   return json(children);
 }
 
-async function handleResolve(request, env, pathname, isHead) {
-  const filePath = safeDecode(pathname.slice(RESOLVE_BASE.length));
-  const meta = filePath === null ? undefined : FILES.get(filePath);
-  if (!meta) return notFound();
+function handleResolve(pathname) {
+  // Allowlist authority: the committed manifest is the ONLY downloadable set.
+  // Validate against the DECODED path; an unknown or malformed path gets this
+  // worker's JSON 404 and never reaches R2 (whose miss is an HTML 404).
+  const rawSuffix = pathname.slice(RESOLVE_BASE.length);
+  const filePath = safeDecode(rawSuffix);
+  if (filePath === null || !FILES.get(filePath)) return notFound();
 
-  const range = parseRange(request.headers.get("range"), meta.size);
-  if (range === "unsatisfiable") {
-    return new Response(null, {
-      status: 416,
-      headers: {
-        "content-range": `bytes */${meta.size}`,
-        "accept-ranges": "bytes",
-      },
-    });
-  }
-
-  const key = R2_PREFIX + filePath;
-  const headers = new Headers({
-    "accept-ranges": "bytes",
-    "content-type": contentTypeFor(filePath),
-  });
-
-  if (isHead) {
-    const head = await env.MODELS.head(key);
-    if (!head) return notFound();
-    headers.set("etag", head.httpEtag);
-    headers.set("content-length", String(head.size));
-    return new Response(null, { status: 200, headers });
-  }
-
-  const object = await env.MODELS.get(key, range ? { range } : undefined);
-  if (!object) return notFound();
-  headers.set("etag", object.httpEtag);
-
-  if (range) {
-    headers.set("content-length", String(range.length));
-    headers.set(
-      "content-range",
-      `bytes ${range.offset}-${range.offset + range.length - 1}/${meta.size}`
-    );
-    return new Response(object.body, { status: 206, headers });
-  }
-  headers.set("content-length", String(meta.size));
-  return new Response(object.body, { status: 200, headers });
+  // Known file: 302 to the cache-enabled native R2 path. Forward the request's
+  // raw (still percent-encoded) suffix unchanged so Cloudflare's own decode
+  // resolves the exact R2 key — no re-encode asymmetry. GET and HEAD both
+  // redirect; a 302 preserves the method and the Range header (§14.1), and R2
+  // returns the object's stable ETag on both so resume identity is unbroken.
+  const location = `${REDIRECT_ORIGIN}/${R2_PREFIX}${rawSuffix}`;
+  return new Response(null, { status: 302, headers: { location } });
 }
 
 export default {
-  async fetch(request, env) {
-    const isHead = request.method === "HEAD";
-    if (request.method !== "GET" && !isHead) {
+  async fetch(request) {
+    if (request.method !== "GET" && request.method !== "HEAD") {
       return new Response("Method not allowed", {
         status: 405,
         headers: { allow: "GET, HEAD" },
@@ -172,7 +127,7 @@ export default {
       return handleListing(pathname);
     }
     if (pathname.startsWith(RESOLVE_BASE)) {
-      return handleResolve(request, env, pathname, isHead);
+      return handleResolve(pathname);
     }
     // Anything else under our narrowly-scoped routes is unknown.
     return notFound();

--- a/workers/parakeet-mirror/test/contract.test.mjs
+++ b/workers/parakeet-mirror/test/contract.test.mjs
@@ -1,7 +1,11 @@
-// Contract grid for the parakeet-mirror worker (#1339).
-// Axes: route shape x method x Range semantics (open / bounded / suffix /
-// zero-suffix / inverted / past-EOF / malformed / multi-range) x known/unknown
-// paths x URL encoding. Run: node --test workers/parakeet-mirror/test/
+// Contract grid for the parakeet-mirror worker (#1339, #1405).
+// The worker owns listing + the download ALLOWLIST; it 302-redirects known
+// files to the cache-enabled native R2 path and no longer serves bytes itself.
+// So this suite locks: listing shape, the 302 target for known files, the
+// JSON-404 allowlist (never R2's HTML 404), method/encoding hygiene, and
+// manifest integrity. The BYTE + Range grid now lives against live R2 in
+// scripts/verify-deploy.py (R2 owns 200/206/416/HEAD/ETag natively).
+// Run: node --test workers/parakeet-mirror/test/
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -17,45 +21,18 @@ const worker = (await import("../src/index.js")).default;
 
 const REPO = "FluidInference/parakeet-tdt-0.6b-v3-coreml";
 const SMALL = "config.json"; // 2 bytes
-const BIG = "Encoder.mlmodelc/weights/weight.bin";
-const bigSize = manifest.files.find((f) => f.path === BIG).size;
+const SUB = "Encoder.mlmodelc/model.mil"; // a nested known file
 
-// Map-backed R2 stub: bodies are deterministic patterns, range-aware.
-function makeEnv() {
-  const bytesFor = (key, offset, length) => {
-    const buf = new Uint8Array(length);
-    for (let i = 0; i < length; i++) buf[i] = (offset + i) % 251;
-    return buf;
-  };
-  const sizeOf = (key) => {
-    const rel = key.replace(`parakeet/${REPO}/`, "");
-    const f = manifest.files.find((x) => x.path === rel);
-    return f ? f.size : null;
-  };
-  return {
-    MODELS: {
-      async head(key) {
-        const size = sizeOf(key);
-        return size === null ? null : { size, httpEtag: '"stub"' };
-      },
-      async get(key, opts) {
-        const size = sizeOf(key);
-        if (size === null) return null;
-        const offset = opts?.range?.offset ?? 0;
-        const length = opts?.range?.length ?? size - offset;
-        return { httpEtag: '"stub"', body: bytesFor(key, offset, length) };
-      },
-    },
-  };
-}
+// Expected 302 target for a given raw (as-sent) resolve suffix: the object's
+// native R2 custom-domain path on the same host, raw suffix forwarded verbatim.
+const loc = (rawSuffix) =>
+  `https://models.enviouslabs.co/parakeet/${REPO}/${rawSuffix}`;
 
+// The worker no longer reads env (bytes left the worker); pass none.
 const req = (path, init = {}) =>
-  worker.fetch(
-    new Request(`https://models.enviouslabs.co${path}`, init),
-    makeEnv()
-  );
+  worker.fetch(new Request(`https://models.enviouslabs.co${path}`, init));
 
-// --- Listing ---
+// --- Listing (unchanged: precomputed static tree) ---
 test("listing root returns HF-shaped immediate children", async () => {
   const r = await req(`/api/models/${REPO}/tree/main`);
   assert.equal(r.status, 200);
@@ -89,7 +66,6 @@ test("listing nested subdirectory", async () => {
   const items = await r.json();
   assert.equal(items.length, 1);
   assert.equal(items[0].path, "Encoder.mlmodelc/weights/weight.bin");
-  assert.equal(items[0].size, bigSize);
 });
 
 test("listing unknown path is 404 JSON, never HTML", async () => {
@@ -103,19 +79,47 @@ test("listing for a different repo is 404 (route scope)", async () => {
   assert.equal(r.status, 404);
 });
 
-// --- Resolve: full downloads ---
-test("resolve known file: 200, exact length, accept-ranges, etag", async () => {
+// --- Resolve: known files 302 to the cached native R2 path ---
+test("resolve known file: 302 to the native R2 path, no body", async () => {
   const r = await req(`/${REPO}/resolve/main/${SMALL}`);
-  assert.equal(r.status, 200);
-  assert.equal(r.headers.get("content-length"), "2");
-  assert.equal(r.headers.get("accept-ranges"), "bytes");
-  assert.ok(r.headers.get("etag"));
-  assert.equal((await r.arrayBuffer()).byteLength, 2);
+  assert.equal(r.status, 302);
+  assert.equal(r.headers.get("location"), loc(SMALL));
+  assert.equal((await r.arrayBuffer()).byteLength, 0);
 });
 
-test("resolve unknown file: 404", async () => {
+test("resolve nested known file: 302 preserves the full sub-path", async () => {
+  const r = await req(`/${REPO}/resolve/main/${SUB}`);
+  assert.equal(r.status, 302);
+  assert.equal(r.headers.get("location"), loc(SUB));
+});
+
+test("HEAD known file: also 302 (client follows HEAD->HEAD, resume identity intact)", async () => {
+  const r = await req(`/${REPO}/resolve/main/${SMALL}`, { method: "HEAD" });
+  assert.equal(r.status, 302);
+  assert.equal(r.headers.get("location"), loc(SMALL));
+});
+
+test("Range on a known file: still a plain 302 (R2 owns Range, worker never parses it)", async () => {
+  const r = await req(`/${REPO}/resolve/main/${SMALL}`, {
+    headers: { range: "bytes=0-0" },
+  });
+  assert.equal(r.status, 302);
+  assert.equal(r.headers.get("location"), loc(SMALL));
+});
+
+test("302 forwards the raw (percent-encoded) suffix verbatim so CF's own decode resolves the key", async () => {
+  // config%2Ejson decodes to config.json (a known file); the worker validates
+  // the DECODED path but forwards the RAW suffix, and CF applies the same decode.
+  const r = await req(`/${REPO}/resolve/main/config%2Ejson`);
+  assert.equal(r.status, 302);
+  assert.equal(r.headers.get("location"), loc("config%2Ejson"));
+});
+
+// --- Resolve allowlist: unknown/malformed never redirect, never reach R2 ---
+test("resolve unknown file: 404 JSON (never a 302 to R2's HTML 404)", async () => {
   const r = await req(`/${REPO}/resolve/main/NoSuch.bin`);
   assert.equal(r.status, 404);
+  assert.match(r.headers.get("content-type") ?? "", /application\/json/);
 });
 
 test("resolve file NOT in manifest but maybe in bucket (_meta) is 404 — manifest is the allowlist", async () => {
@@ -123,116 +127,8 @@ test("resolve file NOT in manifest but maybe in bucket (_meta) is 404 — manife
   assert.equal(r.status, 404);
 });
 
-test("URL-encoded path resolves", async () => {
-  const r = await req(
-    `/${REPO}/resolve/main/Encoder.mlmodelc%2Fmodel.mil`.replace(
-      "%2F",
-      "/"
-    ) // sanity: plain form
-  );
-  assert.equal(r.status, 200);
-});
-
-test("HEAD returns headers without body", async () => {
-  const r = await req(`/${REPO}/resolve/main/${SMALL}`, { method: "HEAD" });
-  assert.equal(r.status, 200);
-  assert.equal(r.headers.get("content-length"), "2");
-  assert.equal((await r.arrayBuffer()).byteLength, 0);
-});
-
-// --- Range grid ---
-const range = (h) => req(`/${REPO}/resolve/main/${BIG}`, { headers: { range: h } });
-// Cloud review #1355: ignored/malformed range headers fall back to a full 200
-// body — assert those on the SMALL file so the stub never materializes the
-// 445MB encoder just to check a status code. Range MATH stays on BIG.
-const rangeSmall = (h) =>
-  req(`/${REPO}/resolve/main/${SMALL}`, { headers: { range: h } });
-
-test("bounded range: 206 with correct content-range and length", async () => {
-  const r = await range("bytes=0-1023");
-  assert.equal(r.status, 206);
-  assert.equal(r.headers.get("content-length"), "1024");
-  assert.equal(r.headers.get("content-range"), `bytes 0-1023/${bigSize}`);
-  assert.equal((await r.arrayBuffer()).byteLength, 1024);
-});
-
-test("open-ended range: 206 to EOF", async () => {
-  const start = bigSize - 100;
-  const r = await range(`bytes=${start}-`);
-  assert.equal(r.status, 206);
-  assert.equal(r.headers.get("content-length"), "100");
-  assert.equal(
-    r.headers.get("content-range"),
-    `bytes ${start}-${bigSize - 1}/${bigSize}`
-  );
-});
-
-test("suffix range: last N bytes", async () => {
-  const r = await range("bytes=-500");
-  assert.equal(r.status, 206);
-  assert.equal(r.headers.get("content-length"), "500");
-  assert.equal(
-    r.headers.get("content-range"),
-    `bytes ${bigSize - 500}-${bigSize - 1}/${bigSize}`
-  );
-});
-
-test("suffix longer than file clamps to whole file", async () => {
-  const r = await req(`/${REPO}/resolve/main/${SMALL}`, {
-    headers: { range: "bytes=-999" },
-  });
-  assert.equal(r.status, 206);
-  assert.equal(r.headers.get("content-length"), "2");
-});
-
-test("end beyond EOF clamps to EOF", async () => {
-  const r = await req(`/${REPO}/resolve/main/${SMALL}`, {
-    headers: { range: "bytes=1-99999" },
-  });
-  assert.equal(r.status, 206);
-  assert.equal(r.headers.get("content-range"), `bytes 1-1/2`);
-});
-
-test("start past EOF: 416 with bytes */size", async () => {
-  const r = await range(`bytes=${bigSize}-`);
-  assert.equal(r.status, 416);
-  assert.equal(r.headers.get("content-range"), `bytes */${bigSize}`);
-});
-
-test("inverted range: 416", async () => {
-  const r = await range("bytes=500-100");
-  assert.equal(r.status, 416);
-});
-
-test("zero-suffix (bytes=-0): 416", async () => {
-  const r = await range("bytes=-0");
-  assert.equal(r.status, 416);
-});
-
-test("malformed range is ignored: full 200", async () => {
-  const r = await rangeSmall("bytes=abc");
-  assert.equal(r.status, 200);
-});
-
-test("multi-range is ignored: full 200 (RFC-permitted)", async () => {
-  const r = await rangeSmall("bytes=0-1,5-9");
-  assert.equal(r.status, 200);
-});
-
-test("empty range value (bytes=-): ignored, full 200", async () => {
-  const r = await rangeSmall("bytes=-");
-  assert.equal(r.status, 200);
-});
-
-// --- Methods and route hygiene ---
-test("POST: 405 with Allow", async () => {
-  const r = await req(`/${REPO}/resolve/main/${SMALL}`, { method: "POST" });
-  assert.equal(r.status, 405);
-  assert.equal(r.headers.get("allow"), "GET, HEAD");
-});
-
-test("unrelated path under scope: 404 JSON", async () => {
-  const r = await req(`/${REPO}/resolve/other/${SMALL}`);
+test("path-traversal attempt is 404 (not in allowlist, never redirected)", async () => {
+  const r = await req(`/${REPO}/resolve/main/../../etc/passwd`);
   assert.equal(r.status, 404);
 });
 
@@ -246,6 +142,18 @@ test("malformed percent-encoding on listing: 404 JSON, never a thrown 500", asyn
   const r = await req(`/api/models/${REPO}/tree/main/%ZZ`);
   assert.equal(r.status, 404);
   assert.match(r.headers.get("content-type") ?? "", /application\/json/);
+});
+
+// --- Methods and route hygiene ---
+test("POST: 405 with Allow", async () => {
+  const r = await req(`/${REPO}/resolve/main/${SMALL}`, { method: "POST" });
+  assert.equal(r.status, 405);
+  assert.equal(r.headers.get("allow"), "GET, HEAD");
+});
+
+test("unrelated path under scope: 404 JSON", async () => {
+  const r = await req(`/${REPO}/resolve/other/${SMALL}`);
+  assert.equal(r.status, 404);
 });
 
 // --- Manifest integrity (the committed manifest itself) ---

--- a/workers/parakeet-mirror/wrangler.toml
+++ b/workers/parakeet-mirror/wrangler.toml
@@ -1,12 +1,15 @@
-# Parakeet model mirror (#1339): serves EnviousWispr's own copy of the pinned
-# Parakeet v3 model set from R2 behind the two exact URL shapes FluidAudio's
+# Parakeet model mirror (#1339, #1405): serves EnviousWispr's own copy of the
+# pinned Parakeet v3 set behind the two exact URL shapes FluidAudio's
 # ModelRegistry builds — listing (/api/models/{repo}/tree/main[/{sub}]) and
 # file download (/{repo}/resolve/main/{file}) — so the app's first-run download
 # never depends on the public host's listing API or anonymous throttle.
 #
-# Routes are scoped NARROWLY to those two path shapes. /eg1/* (the EG-1 polish
-# model, live traffic) stays on the R2 custom-domain binding and never touches
-# this worker. Verify EG-1 pre/post deploy: scripts/verify-deploy.sh.
+# Listing is answered from a precomputed static tree; downloads are 302-
+# redirected to the object's native R2 custom-domain path (/parakeet/...),
+# which is edge-cached (#1405) and serves bytes + Range natively — so this
+# worker holds NO R2 binding (the byte path left the worker entirely). /eg1/*
+# (the EG-1 polish model, live traffic) also serves from the R2 custom domain
+# and never touches this worker. Verify EG-1 pre/post deploy: scripts/verify-deploy.py.
 #
 # No [triggers] cron here: the account is at its 5-cron free-plan limit (#1092),
 # and this worker needs none — it is a pure request/response mirror.
@@ -27,6 +30,7 @@ routes = [
   { pattern = "models.enviouslabs.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/*", zone_name = "enviouslabs.co" },
 ]
 
-[[r2_buckets]]
-binding = "MODELS"
-bucket_name = "enviouslabs-models"
+# No [[r2_buckets]] binding: downloads 302-redirect to the R2 custom-domain
+# path (/parakeet/...) which serves bytes natively + edge-cached (#1405); the
+# worker no longer streams from R2, so it needs no bucket binding. A revert of
+# this change restores both the byte-serving code and this binding together.


### PR DESCRIPTION
## Why (P0)

First-run model downloads stall/fail for users far from our single US-region origin. Telemetry since v2.3.1 shows a ~100-install Germany surge with 53 stall signals and 2 hard failures (both German, both source-timeout on BOTH the mirror and the HF backup). Root cause: the mirror worker streamed every model byte from single-region R2 via `env.MODELS.get()` with **no edge caching** (verified: no `cf-cache-status`, no `Cache-Control`). It's a distance + no-caching problem, not volume. A real user report (stuck on `JointDecisionv3.mlmodelc` even after reinstall) matches the signature.

## What (Phase 1 of #1405 — server-side, reaches installed v2.3.1 users with NO app update)

`models.enviouslabs.co` is already an R2 custom domain; the object keys live under `/parakeet/…`, a path the worker's routes do **not** shadow, so it's served directly by the cache-capable R2 custom domain. So instead of a new domain, we **reuse the existing one**:

- **Worker** now keeps the listing API + stays the **allowlist authority** (unknown path → its own JSON 404, never R2's default **HTML** 404 that the app's captive-portal guard would treat as an intercepted network) and **302-redirects** known GET/HEAD to `…/parakeet/{REPO}/{file}`. The byte-serving path, Range parsing, and the R2 binding **leave the worker entirely** (complete removal, not a shim — a revert restores both together).
- **Cloudflare config** (applied separately via API, documented below — additive, reversible, free-tier): a Cache Rule + immutable `Cache-Control` (Response Header Transform Rule) + Smart Tiered Cache, all scoped by `http.host eq "models.enviouslabs.co" and starts_with(path, "/parakeet/")` so `/eg1/` and the worker paths are untouched.

R2 owns Range/HEAD/etag natively (verified against the live 445MB encoder: bounded/suffix/open → correct 206; past-EOF/inverted → `416 bytes */size`; HEAD → 200 + length + stable multipart etag). Multi-range now yields R2's `206 multipart/byteranges` instead of the worker's old full-200 — **accepted**: our client only ever sends single ranges.

## Why the 302 is safe for installed clients (§14.1, verified empirically 2026-07-07)

The app's download delegate (`ChunkAppendDelegate`) has **no** `willPerformHTTPRedirection` override — confirmed at the `v2.3.1` tag — so URLSession auto-follows the 302. A probe mirroring its exact session setup proved: GET+Range follows the 302, the delegate sees the **final 206** (not the 302), the `Range` header survives even **cross-origin** (URLSession does not strip it like `Authorization`), and HEAD survives as HEAD via `data(for:)`. R2 returns the same stable etag on HEAD and GET, so resume identity is unbroken across the deploy. Bytes are byte-identical (`no-transform`), so the SHA-256 admission gate is unaffected.

## Tests

- `contract.test.mjs` reworked to lock the 302 target + JSON-404 allowlist + encoding/traversal hygiene (18 pass locally). The byte/Range grid moves to the live deploy gate (R2 owns it).
- `verify-deploy.py` now asserts the worker's 302 + correct native target, then **follows through** to the cached path for SHA (all 23 files), the Range grid, and HEAD, and confirms `/eg1/` still serves directly. Run after `wrangler deploy`, before merge.
- Local Codex code-diff review: clean (round 1).

## Cloudflare config applied (documented for the record)

Scoped to `http.host eq "models.enviouslabs.co" and starts_with(http.request.uri.path, "/parakeet/")`:
1. Cache Rule (`http_request_cache_settings`): cache eligible, edge TTL override 1y (revision-pinned/immutable paths), browser TTL respect-origin.
2. Response Header Transform (`http_response_headers_transform`): `Cache-Control: public, max-age=31536000, immutable, no-transform`.
3. Smart Tiered Cache: on (zone-level, free) — collapses EU edge misses into one upper-tier fill.

## Blast radius & rollback

- **Touched:** the mirror worker + the scoped Cloudflare cache config.
- **NOT touched:** the SHA admission gate, `/eg1/` delivery, WhisperKit path, the heart pipeline beyond first-run fetch, the HF backup source.
- **Rollback:** revert this PR (restores byte-serving + the R2 binding) and delete the two rules + flip Smart Tiered Cache off — instant, no app impact.

Part of #1405.