### PR TITLE
feat(audio): capture-backend bake-off control plane + candidates A/C (#1377)

### DIFF
--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -130,6 +130,17 @@ final class AVAudioEngineSource: AudioInputSource {
   /// User override for input device. Empty string means "Auto" (smart selection enabled).
   var preferredInputDeviceIDOverride: String = ""
 
+  #if DEBUG
+    /// Bench-only bypass of the BT-output force-nil (#1377 candidate C). When
+    /// true, `startCapture`'s device resolution does NOT skip `setInputDevice`
+    /// under BT output, so the engine targets the user-selected (Bluetooth)
+    /// device instead of the crash-dodge nil. Set ONLY under a
+    /// `CaptureSourcePolicy` force-case by the bake-off; the `.automatic` route
+    /// leaves it false, so the shipped crash-dodge is unchanged. Compiled out
+    /// of release entirely.
+    var benchBypassBTOutputForceNil = false
+  #endif
+
   /// The CoreAudio device ID currently in use.
   private(set) var currentInputDeviceID: AudioDeviceID?
 
@@ -215,8 +226,17 @@ final class AVAudioEngineSource: AudioInputSource {
       btOutputActive = false
     }
 
+    // #1377 candidate C: the bake-off can bypass the BT-output force-nil to
+    // target a Bluetooth mic under BT output. In release (or on `.automatic`)
+    // the crash-dodge always stands — `benchBypassBTOutputForceNil` is
+    // DEBUG-only and never set by the automatic route.
+    var forceNilUnderBTOutput = btOutputActive
+    #if DEBUG
+      if benchBypassBTOutputForceNil { forceNilUnderBTOutput = false }
+    #endif
+
     let resolvedDeviceID: AudioDeviceID?
-    if btOutputActive {
+    if forceNilUnderBTOutput {
       // BT output active — skip device switch.
       // Forcing built-in mic via setInputDevice crashes the XPC service.
       // Root cause: CoreAudio creates corrupted CADefaultDeviceAggregate.
@@ -241,6 +261,20 @@ final class AVAudioEngineSource: AudioInputSource {
     }
     try setInputDevice(resolvedDeviceID)
     currentInputDeviceID = resolvedDeviceID ?? AudioDeviceEnumerator.defaultInputDeviceID()
+    #if DEBUG
+      // Capture-side actual-bound-device evidence (#1377 §3.5): the bench reads
+      // THIS to prove which device the engine really bound (not app-derived
+      // telemetry). `boundTransport` characterizes the device (bluetooth vs
+      // built_in); `benchBypass` records whether the BT-output dodge was skipped.
+      let boundTransport =
+        currentInputDeviceID.flatMap { AudioDeviceEnumerator.transportLabel(for: $0) } ?? "unknown"
+      let requestedUID =
+        preferredInputDeviceIDOverride.isEmpty
+        ? selectedInputDeviceUID : preferredInputDeviceIDOverride
+      AudioCaptureManager.btRouteLog(
+        "CAPTURE_EVIDENCE backend=av_audio_engine boundDeviceID=\(currentInputDeviceID.map(String.init) ?? "nil") boundTransport=\(boundTransport) requestedUID=\(requestedUID.isEmpty ? "auto" : requestedUID) benchBypass=\(benchBypassBTOutputForceNil)"
+      )
+    #endif
     onLifecycleSignal?("engine_input_device_completed")
     let deviceMs = ms(ContinuousClock.now - deviceStart)
 

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -261,20 +261,6 @@ final class AVAudioEngineSource: AudioInputSource {
     }
     try setInputDevice(resolvedDeviceID)
     currentInputDeviceID = resolvedDeviceID ?? AudioDeviceEnumerator.defaultInputDeviceID()
-    #if DEBUG
-      // Capture-side actual-bound-device evidence (#1377 §3.5): the bench reads
-      // THIS to prove which device the engine really bound (not app-derived
-      // telemetry). `boundTransport` characterizes the device (bluetooth vs
-      // built_in); `benchBypass` records whether the BT-output dodge was skipped.
-      let boundTransport =
-        currentInputDeviceID.flatMap { AudioDeviceEnumerator.transportLabel(for: $0) } ?? "unknown"
-      let requestedUID =
-        preferredInputDeviceIDOverride.isEmpty
-        ? selectedInputDeviceUID : preferredInputDeviceIDOverride
-      AudioCaptureManager.btRouteLog(
-        "CAPTURE_EVIDENCE backend=av_audio_engine boundDeviceID=\(currentInputDeviceID.map(String.init) ?? "nil") boundTransport=\(boundTransport) requestedUID=\(requestedUID.isEmpty ? "auto" : requestedUID) benchBypass=\(benchBypassBTOutputForceNil)"
-      )
-    #endif
     onLifecycleSignal?("engine_input_device_completed")
     let deviceMs = ms(ContinuousClock.now - deviceStart)
 
@@ -383,8 +369,33 @@ final class AVAudioEngineSource: AudioInputSource {
     armCaptureStallWatchdog()
 
     isCapturing = true
+    #if DEBUG
+      logBenchCaptureEvidence()
+    #endif
     return stream
   }
+
+  #if DEBUG
+    /// Capture-side actual-bound-device evidence (#1377 §3.5). Emitted at every
+    /// capture START (not just cold `prepare()`), so a warm-reuse bench trial —
+    /// where `prepare()` early-returns on the already-running engine — still logs
+    /// a fresh source row the harness can read. `boundUID` is the EXACT bound
+    /// device (so candidate C proves the requested device bound, not merely a
+    /// non-built-in transport); `boundTransport` characterizes it (bluetooth vs
+    /// built_in); `benchBypass` records whether the BT-output dodge was skipped.
+    private func logBenchCaptureEvidence() {
+      let boundTransport =
+        currentInputDeviceID.flatMap { AudioDeviceEnumerator.transportLabel(for: $0) } ?? "unknown"
+      let boundUID =
+        currentInputDeviceID.flatMap { AudioDeviceEnumerator.inputDeviceUID(for: $0) } ?? "unknown"
+      let requestedUID =
+        preferredInputDeviceIDOverride.isEmpty
+        ? selectedInputDeviceUID : preferredInputDeviceIDOverride
+      AudioCaptureManager.btRouteLog(
+        "CAPTURE_EVIDENCE backend=av_audio_engine boundUID=\(boundUID) boundDeviceID=\(currentInputDeviceID.map(String.init) ?? "nil") boundTransport=\(boundTransport) requestedUID=\(requestedUID.isEmpty ? "auto" : requestedUID) benchBypass=\(benchBypassBTOutputForceNil)"
+      )
+    }
+  #endif
 
   /// Schedule a one-shot stall watchdog for the current `captureGeneration`.
   /// Cancels any prior pending item so stale sessions cannot fire.

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -144,6 +144,15 @@ final class AVAudioEngineSource: AudioInputSource {
   /// The CoreAudio device ID currently in use.
   private(set) var currentInputDeviceID: AudioDeviceID?
 
+  #if DEBUG
+    /// Whether the most recent `setInputDevice` actually bound the requested
+    /// device — `AudioUnitSetProperty` returned noErr. A failed set does NOT
+    /// throw, so this is the #1377 bench's proof the REQUESTED device bound
+    /// rather than being silently ignored. True on the default/no-op path (no
+    /// explicit device to bind). Read only by `logBenchCaptureEvidence()`.
+    private var lastInputDeviceBindOK = true
+  #endif
+
   // MARK: - Private state
 
   private var engine = AVAudioEngine()
@@ -384,6 +393,16 @@ final class AVAudioEngineSource: AudioInputSource {
     /// non-built-in transport); `boundTransport` characterizes it (bluetooth vs
     /// built_in); `benchBypass` records whether the BT-output dodge was skipped.
     private func logBenchCaptureEvidence() {
+      // `bindOK` is the proof the REQUESTED device actually bound: setInputDevice
+      // does NOT throw when `AudioUnitSetProperty` fails (it logs + fires
+      // `onDeviceError` and returns), and line 263 sets `currentInputDeviceID` to
+      // the requested device regardless — so `boundUID` alone would falsely
+      // report a HAL-rejected Bluetooth device as bound. `bindOK=false` lets the
+      // harness FAIL that trial. Reading back `kAudioOutputUnitProperty_CurrentDevice`
+      // was rejected: on the default path AVAudioEngine wraps input in a private
+      // `CADefaultDeviceAggregate`, so a read-back reports an aggregate UID that
+      // no requested-device check could match. `bindOK` sidesteps that. (Cloud
+      // review P2.)
       let boundTransport =
         currentInputDeviceID.flatMap { AudioDeviceEnumerator.transportLabel(for: $0) } ?? "unknown"
       let boundUID =
@@ -392,7 +411,7 @@ final class AVAudioEngineSource: AudioInputSource {
         preferredInputDeviceIDOverride.isEmpty
         ? selectedInputDeviceUID : preferredInputDeviceIDOverride
       AudioCaptureManager.btRouteLog(
-        "CAPTURE_EVIDENCE backend=av_audio_engine boundUID=\(boundUID) boundDeviceID=\(currentInputDeviceID.map(String.init) ?? "nil") boundTransport=\(boundTransport) requestedUID=\(requestedUID.isEmpty ? "auto" : requestedUID) benchBypass=\(benchBypassBTOutputForceNil)"
+        "CAPTURE_EVIDENCE backend=av_audio_engine boundUID=\(boundUID) boundDeviceID=\(currentInputDeviceID.map(String.init) ?? "nil") boundTransport=\(boundTransport) bindOK=\(lastInputDeviceBindOK) requestedUID=\(requestedUID.isEmpty ? "auto" : requestedUID) benchBypass=\(benchBypassBTOutputForceNil)"
       )
     }
   #endif
@@ -586,10 +605,23 @@ final class AVAudioEngineSource: AudioInputSource {
   // MARK: - Private: Input Device
 
   private func setInputDevice(_ deviceID: AudioDeviceID?) throws {
+    #if DEBUG
+      // Reset per attempt: the default/no-op path (no explicit device) counts as
+      // OK; only a failed AudioUnitSetProperty flips this to false. (#1377 §3.5)
+      lastInputDeviceBindOK = true
+    #endif
     guard let deviceID, deviceID != 0 else { return }
 
+    // Past this point a SPECIFIC device was requested. If the input audio unit is
+    // unavailable we never reach AudioUnitSetProperty, so the requested device is
+    // NOT bound — the bench must not read that as success.
     let audioUnit = engine.inputNode.audioUnit
-    guard let au = audioUnit else { return }
+    guard let au = audioUnit else {
+      #if DEBUG
+        lastInputDeviceBindOK = false
+      #endif
+      return
+    }
 
     var devID = deviceID
     let status = AudioUnitSetProperty(
@@ -601,6 +633,9 @@ final class AVAudioEngineSource: AudioInputSource {
       UInt32(MemoryLayout<AudioDeviceID>.size)
     )
     if status != noErr {
+      #if DEBUG
+        lastInputDeviceBindOK = false
+      #endif
       Task {
         await AppLogger.shared.log(
           "Failed to set input device \(deviceID): OSStatus \(status)",

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -116,6 +116,13 @@ final class AVCaptureSessionSource: AudioInputSource {
   private(set) var isCapturing = false
   var isRunning: Bool { session?.isRunning ?? false }
 
+  /// Target capture device UID. Nil = built-in microphone — today's behavior,
+  /// byte-identical. Non-nil pins capture to that device (#1377 candidate A),
+  /// including a Bluetooth mic. Only ever set to a real UID under a
+  /// `CaptureSourcePolicy` force-case; the `.automatic` route leaves it nil,
+  /// so the shipped path is unchanged.
+  var targetDeviceUID: String?
+
   // MARK: - Private state
 
   private var session: AVCaptureSession?
@@ -151,11 +158,13 @@ final class AVCaptureSessionSource: AudioInputSource {
       return
     }
 
-    // Find the built-in microphone by transport type — NOT AVCaptureDevice.default(for: .audio)
-    // which follows the system default and may return a BT device.
+    // Resolve the capture device: the pinned `targetDeviceUID` when set
+    // (#1377 candidate A), otherwise the built-in mic by transport type — NOT
+    // AVCaptureDevice.default(for: .audio), which follows the system default
+    // and may return a BT device.
     onLifecycleSignal?("capture_session_find_mic_entered")
-    let builtInMic = findBuiltInMicrophone()
-    guard let mic = builtInMic else {
+    let resolvedMic = resolveCaptureDevice()
+    guard let mic = resolvedMic else {
       throw AudioError.noBuiltInMicrophoneFound
     }
     onLifecycleSignal?("capture_session_find_mic_completed")
@@ -222,6 +231,18 @@ final class AVCaptureSessionSource: AudioInputSource {
 
     AudioCaptureManager.btRouteLog(
       "AVCaptureSessionSource: prepared with \(mic.localizedName) (uid=\(mic.uniqueID))")
+    #if DEBUG
+      // Capture-side actual-bound-device evidence (#1377 §3.5). The bench reads
+      // THIS (not app-derived `effective_transport`, not the `"xpc_proxy"` masked
+      // `captureSourceType`) to prove which device really bound. `boundUID` is
+      // the unforgeable truth; `requestedUID` shows what was asked for.
+      // `boundDevice` is LAST because a localized device name may contain spaces —
+      // the parser takes it as the line tail so no following token is corrupted.
+      // DEBUG-only, consistent with the engine source's evidence line.
+      AudioCaptureManager.btRouteLog(
+        "CAPTURE_EVIDENCE backend=av_capture_session boundUID=\(mic.uniqueID) requestedUID=\(targetDeviceUID ?? "built_in") boundDevice=\(mic.localizedName)"
+      )
+    #endif
   }
 
   private func awaitStartRunning(
@@ -445,6 +466,33 @@ final class AVCaptureSessionSource: AudioInputSource {
   }
 
   // MARK: - Private: Device Discovery
+
+  /// Resolve the capture device: the pinned `targetDeviceUID` when set
+  /// (#1377 candidate A), otherwise the built-in mic (today's default).
+  /// Falls back to built-in (with a log line) if a pinned UID is not found,
+  /// so the harness sees the real bound device in `CAPTURE_EVIDENCE` rather
+  /// than a hard capture failure that hides which device was requested.
+  private func resolveCaptureDevice() -> AVCaptureDevice? {
+    if let uid = targetDeviceUID, !uid.isEmpty {
+      if let device = findDevice(uid: uid) { return device }
+      AudioCaptureManager.btRouteLog(
+        "AVCaptureSessionSource: target device uid=\(uid) not found — falling back to built-in")
+    }
+    return findBuiltInMicrophone()
+  }
+
+  /// Find an AVCaptureDevice by its CoreAudio unique ID. `AVCaptureDevice.uniqueID`
+  /// shares the CoreAudio UID namespace (see `findBuiltInMicrophone`, which cross-
+  /// references it via `AudioDeviceEnumerator.deviceID(forUID:)`), so a settings-
+  /// stored input-device UID matches directly.
+  private func findDevice(uid: String) -> AVCaptureDevice? {
+    let discovery = AVCaptureDevice.DiscoverySession(
+      deviceTypes: [.microphone],
+      mediaType: .audio,
+      position: .unspecified
+    )
+    return discovery.devices.first { $0.uniqueID == uid }
+  }
 
   /// Find the built-in microphone via CoreAudio transport type.
   /// Does NOT use AVCaptureDevice.default(for: .audio) which follows system default

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -131,6 +131,15 @@ final class AVCaptureSessionSource: AudioInputSource {
   private var interruptionObservers: [NSObjectProtocol] = []
   private var forwarder: PreRollForwarder?
 
+  #if DEBUG
+    /// The device actually bound at cold `prepare()`, retained so the per-capture
+    /// bench evidence (#1377 §3.5) can re-emit it on a warm-reuse trial where
+    /// `prepare()` early-returns. The session keeps this exact input across warm
+    /// reuse, so the retained identity stays truthful.
+    private var boundMicUID: String?
+    private var boundMicName: String?
+  #endif
+
   /// Dedicated serial queue for AVCaptureSession start/stop operations.
   /// Apple recommends session lifecycle on a serial queue to avoid race conditions.
   /// IMPORTANT: This is separate from callbackQueue to avoid ordering bugs — lifecycle
@@ -232,16 +241,11 @@ final class AVCaptureSessionSource: AudioInputSource {
     AudioCaptureManager.btRouteLog(
       "AVCaptureSessionSource: prepared with \(mic.localizedName) (uid=\(mic.uniqueID))")
     #if DEBUG
-      // Capture-side actual-bound-device evidence (#1377 §3.5). The bench reads
-      // THIS (not app-derived `effective_transport`, not the `"xpc_proxy"` masked
-      // `captureSourceType`) to prove which device really bound. `boundUID` is
-      // the unforgeable truth; `requestedUID` shows what was asked for.
-      // `boundDevice` is LAST because a localized device name may contain spaces —
-      // the parser takes it as the line tail so no following token is corrupted.
-      // DEBUG-only, consistent with the engine source's evidence line.
-      AudioCaptureManager.btRouteLog(
-        "CAPTURE_EVIDENCE backend=av_capture_session boundUID=\(mic.uniqueID) requestedUID=\(targetDeviceUID ?? "built_in") boundDevice=\(mic.localizedName)"
-      )
+      // Retain the bound device so the per-capture evidence can re-emit it on a
+      // warm-reuse trial (#1377 §3.5). Emission itself happens in startCapture(),
+      // which runs on every capture; prepare() early-returns on warm reuse.
+      boundMicUID = mic.uniqueID
+      boundMicName = mic.localizedName
     #endif
   }
 
@@ -302,8 +306,26 @@ final class AVCaptureSessionSource: AudioInputSource {
     armCaptureStallWatchdog()
 
     isCapturing = true
+    #if DEBUG
+      logBenchCaptureEvidence()
+    #endif
     return stream
   }
+
+  #if DEBUG
+    /// Capture-side actual-bound-device evidence (#1377 §3.5). Emitted at every
+    /// capture START (not just cold `prepare()`), so a warm-reuse bench trial —
+    /// where `prepare()` early-returns on the already-running session — still logs
+    /// a fresh source row the harness can read. `boundUID` is the unforgeable
+    /// bound-device truth; `requestedUID` shows what was asked for. `boundDevice`
+    /// is LAST because a localized device name may contain spaces — the parser
+    /// takes it as the line tail so no following token is corrupted.
+    private func logBenchCaptureEvidence() {
+      AudioCaptureManager.btRouteLog(
+        "CAPTURE_EVIDENCE backend=av_capture_session boundUID=\(boundMicUID ?? "unknown") requestedUID=\(targetDeviceUID ?? "built_in") boundDevice=\(boundMicName ?? "unknown")"
+      )
+    }
+  #endif
 
   /// Issue #285 — arm one-shot stall watchdog for the current capture session.
   private func armCaptureStallWatchdog() {

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -267,6 +267,16 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     let stream = try await source.startCapture()
     onLifecycleSignal?("manager_start_capture_completed")
     isCapturing = true
+    #if DEBUG
+      // Bake-off manager-side evidence companion (#1377 §3.5): pairs the app's
+      // REQUEST (backend + requested device + active policy) with each source's
+      // own `CAPTURE_EVIDENCE` (actual bound device). In-process only, so
+      // `captureSourceType` is the real backend, never the `"xpc_proxy"` mask.
+      let requestedUID = effectiveInputDeviceUID()
+      Self.btRouteLog(
+        "CAPTURE_EVIDENCE [manager] backend=\(source.captureSourceType) requestedUID=\(requestedUID.isEmpty ? "auto" : requestedUID) policy=\(routeResolver.policy) generation=\(source.captureGeneration)"
+      )
+    #endif
     // Mirror source identity so pipeline-layer Sentry extras still resolve
     // after stopCapture tears `activeSource` down synchronously.
     cachedCaptureGeneration = source.captureGeneration
@@ -491,6 +501,13 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // Cancel any in-flight engine stop from a previous teardown.
     engineStopTask?.cancel()
     engineStopTask = nil
+    #if DEBUG
+      // Bake-off control plane (#1377 slice 2a): a runtime override pins a
+      // candidate engine for the bench, refreshed every resolve so the harness
+      // can switch candidates between recordings. Nil → `.automatic` — the only
+      // path release ever takes, since there is no release setter for `policy`.
+      routeResolver.policy = CaptureRouteResolver.debugPolicyOverride() ?? .automatic
+    #endif
     // Snapshot the prior decision for the changed-only `onRouteResolved` fire.
     let priorRouteDecision = lastRouteDecision
 
@@ -522,7 +539,13 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         configMatch = deviceMatch && vpMatch
       }
 
-      if configMatch {
+      // Under a bench force-policy (#1377), never reuse a warm source: each
+      // trial reconfigures target device / BT-output bypass, so always rebuild
+      // to a freshly-configured candidate. `routeResolver.policy` is only ever
+      // non-`.automatic` in DEBUG (no release setter exists), so release/the
+      // shipped `.automatic` path keeps warm reuse exactly as today.
+      let benchForced = routeResolver.policy != .automatic
+      if configMatch && !benchForced {
         // Route and config unchanged, reuse warm source
         adoptRouteDecision(decision, prior: priorRouteDecision)
         Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source")
@@ -560,18 +583,47 @@ public final class AudioCaptureManager: AudioCaptureInterface {
           "Noise suppression unavailable on AVCaptureSession path — VP requires AVAudioEngine to own input"
         )
       }
-      source = AVCaptureSessionSource()
+      let captureSource = AVCaptureSessionSource()
+      #if DEBUG
+        // Candidate A (#1377): under a force-case, pin the capture session to the
+        // user-selected device (e.g. Bluetooth). `.automatic` never emits
+        // `.forcedCaptureSession`, so the shipped path leaves the target nil
+        // (built-in) — byte-identical to today.
+        if decision.reason == .forcedCaptureSession {
+          captureSource.targetDeviceUID = effectiveInputDeviceUID()
+        }
+      #endif
+      source = captureSource
     case .audioEngine:
       let engineSource = AVAudioEngineSource()
       engineSource.noiseSuppressionEnabled = noiseSuppressionEnabled
       engineSource.selectedInputDeviceUID = selectedInputDeviceUID
       engineSource.preferredInputDeviceIDOverride = preferredInputDeviceIDOverride
+      #if DEBUG
+        // Candidate C (#1377): under a force-case, bypass the BT-output force-nil
+        // so the engine targets the selected BT device. `.automatic` never emits
+        // `.forcedEngine`, so the shipped crash-dodge is unchanged.
+        if decision.reason == .forcedEngine {
+          engineSource.benchBypassBTOutputForceNil = true
+        }
+      #endif
       source = engineSource
     }
 
     activeSource = source
     return source
   }
+
+  #if DEBUG
+    /// Effective input-device UID: the explicit override takes priority, else the
+    /// selected device — the same order the warm-reuse device comparison and the
+    /// engine source's own resolution use. Used to pin a bench candidate's target
+    /// device (#1377). DEBUG-only: only the bake-off force-cases read it.
+    private func effectiveInputDeviceUID() -> String {
+      preferredInputDeviceIDOverride.isEmpty
+        ? selectedInputDeviceUID : preferredInputDeviceIDOverride
+    }
+  #endif
 
   // MARK: - BT Route Logging (Step 6 instrumentation)
 

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -538,15 +538,31 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         let vpMatch = engineSource.noiseSuppressionEnabled == noiseSuppressionEnabled
         configMatch = deviceMatch && vpMatch
       }
+      #if DEBUG
+        // A warm AVCaptureSessionSource from a forced-capture-session trial keeps
+        // its pinned `targetDeviceUID`. When the override is cleared and we
+        // return to `.automatic`, reuse must NOT keep that stale target, or
+        // `.automatic` would capture the forced device instead of built-in.
+        // Compare the target the same way the engine path compares its device.
+        // Release never sets a target (the switch-arm that assigns it is
+        // DEBUG-only), so this is a no-op there. (Cloud review P2.)
+        if configMatch, let captureSource = existing as? AVCaptureSessionSource {
+          let wantsTarget =
+            decision.reason == .forcedCaptureSession ? effectiveInputDeviceUID() : ""
+          let normalize: (String?) -> String = { ($0?.isEmpty ?? true) ? "" : $0! }
+          configMatch = normalize(captureSource.targetDeviceUID) == normalize(wantsTarget)
+        }
+      #endif
 
-      // Under a bench force-policy (#1377), never reuse a warm source: each
-      // trial reconfigures target device / BT-output bypass, so always rebuild
-      // to a freshly-configured candidate. `routeResolver.policy` is only ever
-      // non-`.automatic` in DEBUG (no release setter exists), so release/the
-      // shipped `.automatic` path keeps warm reuse exactly as today.
-      let benchForced = routeResolver.policy != .automatic
-      if configMatch && !benchForced {
-        // Route and config unchanged, reuse warm source
+      if configMatch {
+        // Route and config unchanged, reuse warm source. This applies to the
+        // bench too (#1377): a candidate must be measured with the SAME warm-
+        // engine behavior a real user gets — keeping the source warm across
+        // recordings holds the Bluetooth SCO link open, so the codec switch
+        // fires once at idle teardown (correct, like WisprFlow), NOT on every
+        // record. Config changes that DO warrant a rebuild (candidate switch →
+        // different sourceType; device change; a stale forced capture-session
+        // target) are already caught by the `configMatch` checks above.
         adoptRouteDecision(decision, prior: priorRouteDecision)
         Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source")
         return existing

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -95,6 +95,18 @@ public enum AudioDeviceEnumerator {
     return stringProperty(for: id, selector: kAudioDevicePropertyDeviceUID)
   }
 
+  #if DEBUG
+    /// The persistent UID of a specific device ID. Used ONLY by the #1377
+    /// bake-off capture-evidence line (candidate C / engine path), which knows
+    /// the bound device by its numeric CoreAudio ID and needs the UID to prove
+    /// EXACT device binding — not just a non-built-in transport. Mirrors
+    /// `defaultInputDeviceUID()` but for an arbitrary device ID. DEBUG-only:
+    /// the only caller is the engine source's bench evidence.
+    static func inputDeviceUID(for deviceID: AudioDeviceID) -> String? {
+      stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceUID)
+    }
+  #endif
+
   // MARK: - Bluetooth & Smart Device Selection
 
   /// Returns true if the given device uses Bluetooth transport (Classic or LE).

--- a/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
+++ b/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
@@ -1,4 +1,5 @@
 import CoreAudio
+import Foundation  // UserDefaults (DEBUG bench override); explicit, not transitive via CoreAudio
 
 /// Policy for selecting the audio capture source.
 /// `.automatic` decides based on output route + input intent.
@@ -197,3 +198,31 @@ struct CaptureRouteResolver {
     )
   }
 }
+
+#if DEBUG
+  extension CaptureRouteResolver {
+    /// DEBUG-only bench control plane (#1377 slice 2a — capture-backend bake-off).
+    ///
+    /// The single runtime injection path that lets the bake-off harness pin a
+    /// candidate capture engine WITHOUT touching the `.automatic` route. Reads a
+    /// `defaults` string the harness writes and maps it to an existing force
+    /// policy; returns nil when unset (the normal case), so a build with no
+    /// override behaves exactly as today.
+    ///
+    /// Suite: `UserDefaults.standard`, which on the DEBUG dev build resolves to
+    /// `com.enviouswispr.app.dev` — the SAME per-build store as
+    /// `useXPCAudioService` (`SettingsManager.swift:455`). The harness sets it via
+    /// `defaults write com.enviouswispr.app.dev captureSourcePolicyOverride forceCaptureSession`.
+    /// Compiled out of release entirely; `.automatic` is the only path users reach.
+    static let debugPolicyOverrideKey = "captureSourcePolicyOverride"
+
+    static func debugPolicyOverride(defaults: UserDefaults = .standard) -> CaptureSourcePolicy? {
+      guard let raw = defaults.string(forKey: debugPolicyOverrideKey) else { return nil }
+      switch raw {
+      case "forceEngine": return .forceEngine
+      case "forceCaptureSession": return .forceCaptureSession
+      default: return nil
+      }
+    }
+  }
+#endif

--- a/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1377 slice 2a — freezes the `AudioInputSource` contract every capture engine
+// must satisfy, so a new candidate conformer (slices 2b/2c: HAL, VoiceProcessingIO)
+// cannot silently ship a heart-path regression. Protocol CONFORMANCE is already
+// compiler-enforced; this locks the hardware-free behavioral invariants a stored
+// property can't express:
+//   - a fresh conformer has NOT started a session (`captureGeneration == 0`),
+//   - it is not capturing,
+//   - it exposes a NON-EMPTY, UNIQUE `captureSourceType` tag (catches a
+//     copy-paste that reuses a sibling's backend tag),
+//   - the watchdog callback is wired (settable) — the signal whose absence turns
+//     a zombie zero-buffer capture silent.
+//
+// The RUNTIME wiring the freeze cannot reach without hardware (that
+// `captureGeneration` actually increments in `startCapture`, that the watchdog
+// truly fires and cancels on `stop()`/`deactivateCapture()`) is exercised by the
+// bake-off Live UAT (`Tests/RuntimeUAT/`) per the plan §11 — named honestly, not
+// faked with a mocked engine.
+@MainActor
+@Suite("AudioInputSource conformance freeze — #1377")
+struct AudioInputSourceConformanceFreezeTests {
+
+  /// Every shipped/candidate conformer. Slices 2b/2c append their new sources
+  /// here; the parametric tests then cover them automatically.
+  enum ConformerKind: String, CaseIterable, Sendable {
+    case audioEngine
+    case captureSession
+  }
+
+  private func make(_ kind: ConformerKind) -> any AudioInputSource {
+    switch kind {
+    case .audioEngine: return AVAudioEngineSource()
+    case .captureSession: return AVCaptureSessionSource()
+    }
+  }
+
+  /// The backend tag each conformer must expose. Frozen here so a tag rename or
+  /// collision is caught at test time, not in production Sentry extras.
+  private func expectedTag(_ kind: ConformerKind) -> String {
+    switch kind {
+    case .audioEngine: return "av_audio_engine"
+    case .captureSession: return "av_capture_session"
+    }
+  }
+
+  @Test("fresh conformer has started no session", arguments: ConformerKind.allCases)
+  func freshConformerHasNoSession(_ kind: ConformerKind) {
+    let source = make(kind)
+    #expect(source.captureGeneration == 0)
+    #expect(source.isCapturing == false)
+  }
+
+  @Test("conformer exposes its frozen backend tag", arguments: ConformerKind.allCases)
+  func conformerExposesFrozenTag(_ kind: ConformerKind) {
+    let source = make(kind)
+    #expect(source.captureSourceType == expectedTag(kind))
+    #expect(!source.captureSourceType.isEmpty)
+  }
+
+  @Test("stall watchdog callback is settable (heart-path liveness signal)")
+  func stallWatchdogWired() {
+    for kind in ConformerKind.allCases {
+      let source = make(kind)
+      // Assigning proves the property is a real, wired seam — the freeze guards
+      // against a conformer that drops the watchdog and goes silently zombie.
+      source.onCaptureStalled = { _ in }
+      #expect(source.onCaptureStalled != nil)
+    }
+  }
+
+  @Test("every conformer's backend tag is unique")
+  func backendTagsAreUnique() {
+    let tags = ConformerKind.allCases.map { make($0).captureSourceType }
+    #expect(Set(tags).count == tags.count)
+  }
+}
+
+// #1377 slice 2a — locks candidate A's additive device-target contract: the
+// default is nil (built-in, byte-identical to today's `.automatic` path), and a
+// pinned UID is reflected. WHICH device actually binds is hardware-dependent and
+// proven by the bake-off Live UAT, not here.
+@MainActor
+@Suite("AVCaptureSessionSource device target — #1377")
+struct AVCaptureSessionSourceDeviceTargetTests {
+
+  @Test("default target is nil (automatic path leaves it built-in)")
+  func defaultTargetIsNil() {
+    let source = AVCaptureSessionSource()
+    #expect(source.targetDeviceUID == nil)
+  }
+
+  @Test("a pinned target UID is reflected")
+  func pinnedTargetReflected() {
+    let source = AVCaptureSessionSource()
+    source.targetDeviceUID = "BC-87-FA-9C-7E-71:input"
+    #expect(source.targetDeviceUID == "BC-87-FA-9C-7E-71:input")
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/CaptureBakeoffControlPlaneTests.swift
+++ b/Tests/EnviousWisprTests/Audio/CaptureBakeoffControlPlaneTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1377 slice 2a — locks the capture-backend bake-off control plane: the DEBUG
+// runtime policy override, the force-policy → sourceType mapping, the dormancy
+// invariant (the `.automatic` route never emits a non-shipping backend), and the
+// additive device-target default (nil = built-in, byte-identical to today).
+//
+// Behavioral capture correctness (which device actually binds, non-silent audio,
+// WER) is hardware-and-driver dependent and lives in the bake-off Live UAT
+// (`Tests/RuntimeUAT/`) per the plan's §3a earliest-failure point — no unit test
+// can substitute. These suites lock the pure routing/config logic that CAN be
+// asserted without hardware.
+
+#if DEBUG
+  @MainActor
+  @Suite("Capture bake-off DEBUG policy override — #1377")
+  struct CaptureBakeoffPolicyOverrideTests {
+
+    private func makeDefaults() -> UserDefaults {
+      // Unique in-memory-ish suite per test so we never touch the real store.
+      let suite = "test.captureBakeoff.\(UUID().uuidString)"
+      let defaults = UserDefaults(suiteName: suite)!
+      defaults.removePersistentDomain(forName: suite)
+      return defaults
+    }
+
+    @Test("unset key → nil (build behaves as .automatic)")
+    func unsetIsNil() {
+      let defaults = makeDefaults()
+      #expect(CaptureRouteResolver.debugPolicyOverride(defaults: defaults) == nil)
+    }
+
+    @Test("forceEngine string → .forceEngine")
+    func forceEngineMaps() {
+      let defaults = makeDefaults()
+      defaults.set("forceEngine", forKey: CaptureRouteResolver.debugPolicyOverrideKey)
+      #expect(CaptureRouteResolver.debugPolicyOverride(defaults: defaults) == .forceEngine)
+    }
+
+    @Test("forceCaptureSession string → .forceCaptureSession")
+    func forceCaptureSessionMaps() {
+      let defaults = makeDefaults()
+      defaults.set("forceCaptureSession", forKey: CaptureRouteResolver.debugPolicyOverrideKey)
+      #expect(
+        CaptureRouteResolver.debugPolicyOverride(defaults: defaults) == .forceCaptureSession)
+    }
+
+    @Test("unknown string → nil (never silently forces a candidate)")
+    func garbageIsNil() {
+      let defaults = makeDefaults()
+      defaults.set("forceMysteryEngine", forKey: CaptureRouteResolver.debugPolicyOverrideKey)
+      #expect(CaptureRouteResolver.debugPolicyOverride(defaults: defaults) == nil)
+    }
+  }
+#endif
+
+@MainActor
+@Suite("Capture route resolver — force mapping + dormancy — #1377")
+struct CaptureRouteResolverForceMappingTests {
+
+  @Test("forceEngine policy → .audioEngine / .forcedEngine (no hardware)")
+  func forceEngineDecision() {
+    var resolver = CaptureRouteResolver()
+    resolver.policy = .forceEngine
+    let d = resolver.resolve(preferredInputDeviceUID: "", noiseSuppression: false)
+    #expect(d.sourceType == .audioEngine)
+    #expect(d.reason == .forcedEngine)
+  }
+
+  @Test("forceCaptureSession policy → .captureSession / .forcedCaptureSession (no hardware)")
+  func forceCaptureSessionDecision() {
+    var resolver = CaptureRouteResolver()
+    resolver.policy = .forceCaptureSession
+    let d = resolver.resolve(preferredInputDeviceUID: "", noiseSuppression: false)
+    #expect(d.sourceType == .captureSession)
+    #expect(d.reason == .forcedCaptureSession)
+  }
+
+  // Dormancy lock: whatever the test machine's audio hardware, the `.automatic`
+  // route only ever yields a SHIPPING capture backend. When slices 2b/2c add
+  // `.halDeviceInput` / `.voiceProcessingIO`, this assertion stays the two
+  // shipping cases, so it guards that the automatic route never emits a dormant
+  // candidate (the §4 invariant) — hardware-independent because it asserts
+  // membership, not a specific device-derived result.
+  @Test("automatic route only ever emits a shipping backend (dormancy)")
+  func automaticNeverEmitsDormantCase() {
+    var resolver = CaptureRouteResolver()  // .automatic by default
+    for pref in ["", "some-device-uid"] {
+      let d = resolver.resolve(preferredInputDeviceUID: pref, noiseSuppression: false)
+      #expect(d.sourceType == .audioEngine || d.sourceType == .captureSession)
+    }
+  }
+}

--- a/Tests/RuntimeUAT/capture_bakeoff.py
+++ b/Tests/RuntimeUAT/capture_bakeoff.py
@@ -191,9 +191,13 @@ def _device_bound_as_requested(source_ev, requested_uid, fell_back):
     A transcript alone is not enough — a run that fell back to the built-in mic
     still transcribes fine, so the bench must reject it (cloud review P2). Uses
     the unforgeable CAPTURE_EVIDENCE:
-      - candidate A logs an explicit `boundUID` → must equal `requested_uid`.
-      - candidate C logs `boundTransport` (device-id path, no UID) → for a
-        specific requested device the transport must not be `built_in`.
+      - both candidates log an explicit `boundUID` (the exact bound device) →
+        must equal `requested_uid`. This proves the REQUESTED device bound, not
+        merely a non-built-in one (a USB/virtual mic would pass a transport-only
+        check).
+      - `boundTransport` is a fallback only when a UID could not be resolved
+        (`boundUID` absent) → for a specific requested device the transport must
+        not be `built_in`.
     When no specific device was requested (`auto`/`built_in`), built-in is the
     correct outcome and the check passes.
     """

--- a/Tests/RuntimeUAT/capture_bakeoff.py
+++ b/Tests/RuntimeUAT/capture_bakeoff.py
@@ -242,6 +242,7 @@ def run_trial(candidate, device_label, sentence=DEFAULT_SENTENCE, expect=None):
     recording and reads the verdict from the logs.
     """
     expected_backend = CANDIDATES[candidate]["backend"]
+    expected_policy = CANDIDATES[candidate]["policy"]
     since = _bt_route_line_count()
 
     transcript_pass = wispr_eyes.test_recording(sentence=sentence, expect=expect)
@@ -254,17 +255,31 @@ def run_trial(candidate, device_label, sentence=DEFAULT_SENTENCE, expect=None):
     bound_device = (source_ev or {}).get("boundDevice") or (source_ev or {}).get("boundUID")
     bound_transport = (source_ev or {}).get("boundTransport", "")
     requested_uid = (source_ev or manager_ev or {}).get("requestedUID", "")
+    bound_policy = (manager_ev or {}).get("policy", "")
 
     backend_ok = bound_backend == expected_backend
+    # The FORCED policy must actually be active. Without this, a trial run while
+    # the app is on `.automatic` (dev defaults not applied / not relaunched) can
+    # still pass: under Bluetooth output the automatic route ALSO yields
+    # `av_capture_session`, so candidate A's backend check would match and credit
+    # A for behavior the automatic route produced, not the forced candidate
+    # (cloud review P2). Requires the manager companion row (in-process only).
+    policy_ok = bound_policy == expected_policy
     evidence_found = source_ev is not None
     fell_back = _fell_back_since(since)
     device_ok = _device_bound_as_requested(source_ev, requested_uid, fell_back)
     # Gate: correct non-silent transcript AND the expected backend actually bound
-    # AND the requested DEVICE actually bound (no built-in fallback / wrong mic).
-    # A transcript captured by the built-in after a fallback is a FAIL, not a pass
-    # (cloud review P2) — the whole point is proving a candidate grabs the target.
+    # AND the FORCED policy was active AND the requested DEVICE actually bound (no
+    # built-in fallback / wrong mic). A transcript captured by the built-in after
+    # a fallback, or under the automatic route, is a FAIL, not a pass (cloud
+    # review P2) — the whole point is proving a candidate grabs the target.
     gate_pass = (
-        bool(transcript_pass) and backend_ok and evidence_found and device_ok and not fell_back
+        bool(transcript_pass)
+        and backend_ok
+        and policy_ok
+        and evidence_found
+        and device_ok
+        and not fell_back
     )
 
     row = {
@@ -276,6 +291,9 @@ def run_trial(candidate, device_label, sentence=DEFAULT_SENTENCE, expect=None):
         "expected_backend": expected_backend,
         "bound_backend": bound_backend,
         "backend_ok": backend_ok,
+        "expected_policy": expected_policy,
+        "bound_policy": bound_policy,
+        "policy_ok": policy_ok,
         "bound_device": bound_device,
         "bound_transport": bound_transport,
         "requested_uid": requested_uid,
@@ -297,6 +315,11 @@ def _print_row(row):
     print(f"  transcript_pass = {row['transcript_pass']}")
     print(f"  backend         = {row['bound_backend']} (expected {row['expected_backend']}, "
           f"ok={row['backend_ok']})")
+    print(f"  policy          = {row['bound_policy']} (expected {row['expected_policy']}, "
+          f"ok={row['policy_ok']})")
+    if not row["policy_ok"]:
+        print("  WARN: forced policy NOT active — measuring the automatic route, not the "
+              "candidate (set dev defaults + relaunch)")
     print(f"  bound device    = {row['bound_device']}  transport={row['bound_transport']}")
     print(f"  requested uid   = {row['requested_uid']}")
     print(f"  device bound OK  = {row['device_ok']}   fell_back_to_builtin = {row['fell_back']}")

--- a/Tests/RuntimeUAT/capture_bakeoff.py
+++ b/Tests/RuntimeUAT/capture_bakeoff.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""capture_bakeoff.py — #1377 Phase 2 capture-backend bake-off driver.
+
+Drives each candidate capture engine (force-selected via the DEBUG policy key)
+through a real recording on the running dev app, then scores it from the app's
+OWN logs: the empirical transcript (`app.log` CORRECTION_DEBUG, via
+wispr_eyes.test_recording) PLUS the capture-side actual-bound-device evidence
+(`bt-route.log` CAPTURE_EVIDENCE). It never reads the clipboard — the founder
+deletes the app's clipboard pastings, so the log is the only trustworthy verdict
+source (tools-and-apps.md RULE: uat-verdicts-from-app-log).
+
+Reuses `wispr_eyes.test_recording()` / `tts()` — no reinvented recording or TTS
+loop (validation-discipline.md RULE: use-existing-uat-harness-first).
+
+WHY log evidence, not app-derived telemetry: `effective_transport` /
+`captureSourceType` are app intent (and the XPC proxy masks the backend as
+`"xpc_proxy"`). The unforgeable proof a candidate captured the INTENDED device is
+(a) a correct, non-silent transcript of a known sentence spoken into that device,
+and (b) the source's own CAPTURE_EVIDENCE line naming the device that actually
+bound. The bench runs IN-PROCESS (`useXPCAudioService=false`) so the backend tag
+and bound-device log are real, not proxy-masked (plan §3.5).
+
+COLD-STATE protocol (the Phase 0 lesson — one candidate must not warm the device
+for the next): between candidates, quit the dev app, set the candidate's policy,
+relaunch, and confirm the speaker is actually producing audio into the INTENDED
+device. This module is the driver; the human runs the matrix trial-by-trial and
+switches the input device in Settings (the device selection lives in the shared
+`com.enviouswispr.app` store — the founder's real settings — so the harness never
+pokes it; it only sets the per-build dev knobs).
+
+Slice 2a covers candidates A (AVCaptureSession, device-targeted) and C
+(AVAudioEngine, device-override). Slices 2b/2c add D (AUHAL) and E
+(VoiceProcessingIO) by extending CANDIDATES once their force-policies exist.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import time
+
+import wispr_eyes
+
+# --- Constants ---------------------------------------------------------------
+
+# Per-build dev store (DEBUG dev bundle id). `useXPCAudioService` and the bench
+# policy key both read UserDefaults.standard, which for the dev build resolves
+# here — the SAME suite (SettingsManager.swift:455). NOT the shared
+# `com.enviouswispr.app` store where user prefs (incl. the input device) live.
+DEV_DEFAULTS_DOMAIN = "com.enviouswispr.app.dev"
+POLICY_KEY = "captureSourcePolicyOverride"
+XPC_KEY = "useXPCAudioService"
+
+BT_ROUTE_LOG = os.path.expanduser("~/Library/Logs/EnviousWispr/bt-route.log")
+EVIDENCE_MARKER = "CAPTURE_EVIDENCE"
+
+# Checkout root derived from THIS script's location (…/<checkout>/Tests/RuntimeUAT/
+# capture_bakeoff.py → <checkout>), so the scorecard lands in the checkout being
+# validated — never a hardcoded sibling worktree (Codex r1).
+_CHECKOUT_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+DEFAULT_SCORECARD = os.path.join(_CHECKOUT_ROOT, ".validation", "capture-bakeoff-scorecard.json")
+
+# candidate -> force policy + expected backend tag. Extend for D/E in 2b/2c.
+CANDIDATES = {
+    "A": {
+        "policy": "forceCaptureSession",
+        "backend": "av_capture_session",
+        "desc": "AVCaptureSession, device-targeted",
+    },
+    "C": {
+        "policy": "forceEngine",
+        "backend": "av_audio_engine",
+        "desc": "AVAudioEngine, device-override",
+    },
+}
+
+DEFAULT_SENTENCE = "Let's grab coffee before the standup and review the pull request together."
+
+
+# --- Bench configuration (per-build dev knobs only) --------------------------
+
+
+def configure_candidate(candidate):
+    """Write the per-build dev knobs to force-select a candidate IN-PROCESS.
+
+    Both keys are cold — read at launch only — so the caller MUST relaunch the
+    dev app after this returns. Does not touch the shared user-settings store.
+    """
+    c = CANDIDATES[candidate]
+    subprocess.run(
+        ["defaults", "write", DEV_DEFAULTS_DOMAIN, XPC_KEY, "-bool", "false"], check=True
+    )
+    subprocess.run(
+        ["defaults", "write", DEV_DEFAULTS_DOMAIN, POLICY_KEY, c["policy"]], check=True
+    )
+    print(f"[bakeoff] candidate {candidate} ({c['desc']}) → policy={c['policy']}, in-process ON.")
+    print("[bakeoff] RELAUNCH the dev app now (cold flags), then select the target device in "
+          "Settings and confirm you will speak into it.")
+
+
+def clear_bench():
+    """Remove the bench dev knobs, restoring the normal (XPC + .automatic) path.
+
+    Deleting the keys makes the app read its defaults: XPC on, policy .automatic.
+    Relaunch afterward to return to the shipped path.
+    """
+    for key in (POLICY_KEY, XPC_KEY):
+        subprocess.run(
+            ["defaults", "delete", DEV_DEFAULTS_DOMAIN, key],
+            check=False,  # a missing key is fine
+        )
+    print("[bakeoff] bench knobs cleared. Relaunch for the normal XPC/.automatic path.")
+
+
+# --- Capture-side evidence (bt-route.log CAPTURE_EVIDENCE) --------------------
+
+
+def _bt_route_line_count():
+    """Number of lines currently in bt-route.log (snapshot boundary)."""
+    try:
+        with open(BT_ROUTE_LOG, "r", errors="replace") as f:
+            return sum(1 for _ in f)
+    except FileNotFoundError:
+        return 0
+
+
+def _read_bt_route_lines(since_line=0):
+    try:
+        with open(BT_ROUTE_LOG, "r", errors="replace") as f:
+            return f.readlines()[since_line:]
+    except FileNotFoundError:
+        return []
+
+
+def _parse_evidence(line):
+    """Parse a CAPTURE_EVIDENCE line's `key=value` tokens into a dict.
+
+    Source lines (per backend) carry backend/boundUID/boundDeviceID/
+    boundTransport/requestedUID/benchBypass; the manager companion carries
+    backend/requestedUID/policy/generation. Tokens are whitespace-delimited
+    EXCEPT `boundDevice`, whose value is a localized device name that may contain
+    spaces — the Swift side emits it LAST, so we take everything from
+    `boundDevice=` to end-of-line as its value and tokenize only the prefix."""
+    idx = line.find(EVIDENCE_MARKER)
+    if idx < 0:
+        return None
+    payload = line[idx + len(EVIDENCE_MARKER):].strip()
+    fields = {}
+    # `[manager]` tag (if present) then key=value tokens.
+    if payload.startswith("[manager]"):
+        fields["_kind"] = "manager"
+        payload = payload[len("[manager]"):].strip()
+    else:
+        fields["_kind"] = "source"
+    # Split off the space-containing tail field first.
+    dev_idx = payload.find("boundDevice=")
+    if dev_idx >= 0:
+        fields["boundDevice"] = payload[dev_idx + len("boundDevice="):].strip()
+        payload = payload[:dev_idx].strip()
+    for token in payload.split():
+        if "=" in token:
+            k, v = token.split("=", 1)
+            fields[k] = v
+    return fields
+
+
+def read_new_evidence(since_line):
+    """All CAPTURE_EVIDENCE records appended after `since_line`."""
+    records = []
+    for line in _read_bt_route_lines(since_line):
+        rec = _parse_evidence(line)
+        if rec:
+            records.append(rec)
+    return records
+
+
+# --- Trial + scorecard -------------------------------------------------------
+
+
+def run_trial(candidate, device_label, sentence=DEFAULT_SENTENCE, expect=None):
+    """Run one (candidate x device) trial on the ALREADY-CONFIGURED, RELAUNCHED
+    dev app and return a scorecard row.
+
+    Preconditions (human, cold-state): configure_candidate() run, app relaunched,
+    the intended device selected in Settings, quiet room, speaker will actually
+    talk. This function does not switch devices or relaunch — it drives the
+    recording and reads the verdict from the logs.
+    """
+    expected_backend = CANDIDATES[candidate]["backend"]
+    since = _bt_route_line_count()
+
+    transcript_pass = wispr_eyes.test_recording(sentence=sentence, expect=expect)
+
+    evidence = read_new_evidence(since)
+    source_ev = next((e for e in evidence if e.get("_kind") == "source"), None)
+    manager_ev = next((e for e in evidence if e.get("_kind") == "manager"), None)
+
+    bound_backend = (source_ev or manager_ev or {}).get("backend", "")
+    bound_device = (source_ev or {}).get("boundDevice") or (source_ev or {}).get("boundUID")
+    bound_transport = (source_ev or {}).get("boundTransport", "")
+    requested_uid = (source_ev or manager_ev or {}).get("requestedUID", "")
+
+    backend_ok = bound_backend == expected_backend
+    evidence_found = source_ev is not None
+    # Gate: correct non-silent transcript AND the expected backend actually bound.
+    # (Device-match is scored by a human against `bound_device`/`bound_transport`
+    # vs the intended device — auto-matching UIDs across the shared/dev stores is
+    # deliberately out of scope; the log is the truth for review.)
+    gate_pass = bool(transcript_pass) and backend_ok and evidence_found
+
+    row = {
+        "candidate": candidate,
+        "candidate_desc": CANDIDATES[candidate]["desc"],
+        "device_label": device_label,
+        "sentence": sentence,
+        "transcript_pass": bool(transcript_pass),
+        "expected_backend": expected_backend,
+        "bound_backend": bound_backend,
+        "backend_ok": backend_ok,
+        "bound_device": bound_device,
+        "bound_transport": bound_transport,
+        "requested_uid": requested_uid,
+        "evidence_found": evidence_found,
+        "gate_pass": gate_pass,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    _print_row(row)
+    return row
+
+
+def _print_row(row):
+    verdict = "PASS" if row["gate_pass"] else "FAIL"
+    print("\n" + "=" * 64)
+    print(f"[bakeoff] candidate {row['candidate']} ({row['candidate_desc']}) "
+          f"× {row['device_label']}: {verdict}")
+    print(f"  transcript_pass = {row['transcript_pass']}")
+    print(f"  backend         = {row['bound_backend']} (expected {row['expected_backend']}, "
+          f"ok={row['backend_ok']})")
+    print(f"  bound device    = {row['bound_device']}  transport={row['bound_transport']}")
+    print(f"  requested uid   = {row['requested_uid']}")
+    print(f"  evidence found  = {row['evidence_found']}")
+    if not row["evidence_found"]:
+        print("  WARN: no CAPTURE_EVIDENCE — is this a DEBUG dev build with in-process capture?")
+    print("=" * 64)
+
+
+def write_scorecard(rows, path):
+    """Append rows to a scorecard JSON (list). Merges with any existing file so a
+    matrix run across multiple invocations accumulates."""
+    existing = []
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                existing = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            existing = []
+    existing.extend(rows)
+    parent = os.path.dirname(path)
+    if parent:  # bare filename → dirname is "" → nothing to create
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(existing, f, indent=2)
+    print(f"[bakeoff] scorecard → {path} ({len(existing)} rows total)")
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def main():
+    ap = argparse.ArgumentParser(description="#1377 capture-backend bake-off driver")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_cfg = sub.add_parser("configure", help="force-select a candidate (per-build dev knobs)")
+    p_cfg.add_argument("candidate", choices=sorted(CANDIDATES))
+
+    sub.add_parser("clear", help="remove bench knobs (restore XPC/.automatic)")
+
+    p_trial = sub.add_parser("trial", help="run one trial on the configured+relaunched app")
+    p_trial.add_argument("candidate", choices=sorted(CANDIDATES))
+    p_trial.add_argument("device_label", help="human label for the selected device, e.g. 'bose-bt'")
+    p_trial.add_argument("--sentence", default=DEFAULT_SENTENCE)
+    p_trial.add_argument("--expect", default=None, help="substring the transcript must contain")
+    p_trial.add_argument("--scorecard", default=DEFAULT_SCORECARD)
+
+    args = ap.parse_args()
+    if args.cmd == "configure":
+        configure_candidate(args.candidate)
+    elif args.cmd == "clear":
+        clear_bench()
+    elif args.cmd == "trial":
+        row = run_trial(
+            args.candidate, args.device_label, sentence=args.sentence, expect=args.expect
+        )
+        write_scorecard([row], args.scorecard)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/RuntimeUAT/capture_bakeoff.py
+++ b/Tests/RuntimeUAT/capture_bakeoff.py
@@ -142,8 +142,9 @@ def _parse_evidence(line):
     """Parse a CAPTURE_EVIDENCE line's `key=value` tokens into a dict.
 
     Source lines (per backend) carry backend/boundUID/boundDeviceID/
-    boundTransport/requestedUID/benchBypass; the manager companion carries
-    backend/requestedUID/policy/generation. Tokens are whitespace-delimited
+    boundTransport/requestedUID/benchBypass (the engine also carries bindOK);
+    the manager companion carries backend/requestedUID/policy/generation.
+    Tokens are whitespace-delimited
     EXCEPT `boundDevice`, whose value is a localized device name that may contain
     spaces — the Swift side emits it LAST, so we take everything from
     `boundDevice=` to end-of-line as its value and tokenize only the prefix."""
@@ -195,6 +196,12 @@ def _device_bound_as_requested(source_ev, requested_uid, fell_back):
         must equal `requested_uid`. This proves the REQUESTED device bound, not
         merely a non-built-in one (a USB/virtual mic would pass a transport-only
         check).
+      - the engine additionally logs `bindOK` (did AudioUnitSetProperty accept
+        the device). A failed set does NOT throw and leaves boundUID == requested
+        anyway, so a specific-device engine trial must ALSO have `bindOK=true`;
+        `bindOK=false` means the HAL rejected the device even though we asked for
+        it (cloud review P2). Candidate A (capture-session) has no `bindOK` —
+        AVCaptureSession's added input IS the bound device, so boundUID suffices.
       - `boundTransport` is a fallback only when a UID could not be resolved
         (`boundUID` absent) → for a specific requested device the transport must
         not be `built_in`.
@@ -209,6 +216,12 @@ def _device_bound_as_requested(source_ev, requested_uid, fell_back):
         return False  # cannot confirm what bound
     bound_uid = source_ev.get("boundUID")
     if bound_uid is not None:
+        # Engine reports whether the HAL actually accepted the device; a failed
+        # set leaves boundUID == requested, so bindOK must gate it. Capture-
+        # session has no bindOK key (None) → boundUID equality alone suffices.
+        bind_ok = source_ev.get("bindOK")
+        if bind_ok is not None and bind_ok != "true":
+            return False
         return bound_uid == requested_uid
     transport = source_ev.get("boundTransport")
     if transport is not None:

--- a/Tests/RuntimeUAT/capture_bakeoff.py
+++ b/Tests/RuntimeUAT/capture_bakeoff.py
@@ -53,6 +53,10 @@ XPC_KEY = "useXPCAudioService"
 
 BT_ROUTE_LOG = os.path.expanduser("~/Library/Logs/EnviousWispr/bt-route.log")
 EVIDENCE_MARKER = "CAPTURE_EVIDENCE"
+# AVCaptureSessionSource logs this when a pinned target UID is not a live device
+# and it silently records the built-in instead. A trial that fell back did NOT
+# capture the requested device, so it must FAIL even if a transcript landed.
+FALLBACK_MARKER = "not found — falling back"
 
 # Checkout root derived from THIS script's location (…/<checkout>/Tests/RuntimeUAT/
 # capture_bakeoff.py → <checkout>), so the scorecard lands in the checkout being
@@ -176,6 +180,38 @@ def read_new_evidence(since_line):
     return records
 
 
+def _fell_back_since(since_line):
+    """True if a pinned-target fallback-to-built-in was logged in the window."""
+    return any(FALLBACK_MARKER in ln for ln in _read_bt_route_lines(since_line))
+
+
+def _device_bound_as_requested(source_ev, requested_uid, fell_back):
+    """Did the trial bind the DEVICE it was asked to (not a fallback / wrong mic)?
+
+    A transcript alone is not enough — a run that fell back to the built-in mic
+    still transcribes fine, so the bench must reject it (cloud review P2). Uses
+    the unforgeable CAPTURE_EVIDENCE:
+      - candidate A logs an explicit `boundUID` → must equal `requested_uid`.
+      - candidate C logs `boundTransport` (device-id path, no UID) → for a
+        specific requested device the transport must not be `built_in`.
+    When no specific device was requested (`auto`/`built_in`), built-in is the
+    correct outcome and the check passes.
+    """
+    if fell_back:
+        return False
+    if requested_uid in ("", "auto", "built_in"):
+        return True  # no specific device asked; built-in is the right result
+    if source_ev is None:
+        return False  # cannot confirm what bound
+    bound_uid = source_ev.get("boundUID")
+    if bound_uid is not None:
+        return bound_uid == requested_uid
+    transport = source_ev.get("boundTransport")
+    if transport is not None:
+        return transport != "built_in"
+    return False  # no device evidence → cannot confirm → fail closed
+
+
 # --- Trial + scorecard -------------------------------------------------------
 
 
@@ -204,11 +240,15 @@ def run_trial(candidate, device_label, sentence=DEFAULT_SENTENCE, expect=None):
 
     backend_ok = bound_backend == expected_backend
     evidence_found = source_ev is not None
-    # Gate: correct non-silent transcript AND the expected backend actually bound.
-    # (Device-match is scored by a human against `bound_device`/`bound_transport`
-    # vs the intended device — auto-matching UIDs across the shared/dev stores is
-    # deliberately out of scope; the log is the truth for review.)
-    gate_pass = bool(transcript_pass) and backend_ok and evidence_found
+    fell_back = _fell_back_since(since)
+    device_ok = _device_bound_as_requested(source_ev, requested_uid, fell_back)
+    # Gate: correct non-silent transcript AND the expected backend actually bound
+    # AND the requested DEVICE actually bound (no built-in fallback / wrong mic).
+    # A transcript captured by the built-in after a fallback is a FAIL, not a pass
+    # (cloud review P2) — the whole point is proving a candidate grabs the target.
+    gate_pass = (
+        bool(transcript_pass) and backend_ok and evidence_found and device_ok and not fell_back
+    )
 
     row = {
         "candidate": candidate,
@@ -223,6 +263,8 @@ def run_trial(candidate, device_label, sentence=DEFAULT_SENTENCE, expect=None):
         "bound_transport": bound_transport,
         "requested_uid": requested_uid,
         "evidence_found": evidence_found,
+        "device_ok": device_ok,
+        "fell_back": fell_back,
         "gate_pass": gate_pass,
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
     }
@@ -240,6 +282,9 @@ def _print_row(row):
           f"ok={row['backend_ok']})")
     print(f"  bound device    = {row['bound_device']}  transport={row['bound_transport']}")
     print(f"  requested uid   = {row['requested_uid']}")
+    print(f"  device bound OK  = {row['device_ok']}   fell_back_to_builtin = {row['fell_back']}")
+    if row["fell_back"] or not row["device_ok"]:
+        print("  WARN: requested device did NOT bind (fallback / wrong mic) — NOT a valid capture")
     print(f"  evidence found  = {row['evidence_found']}")
     if not row["evidence_found"]:
         print("  WARN: no CAPTURE_EVIDENCE — is this a DEBUG dev build with in-process capture?")


### PR DESCRIPTION
Slice 2a of the #1377 Phase 2 capture-backend bake-off. Ships **dormant** behind a DEBUG force policy — the `.automatic` route and the shipped XPC path are byte-identical to today (release build excludes every new symbol). Builds the runtime control plane the bake-off needs and makes the two existing capture engines device-targetable.

## What this adds (all dormant)
- **Runtime force-select control plane** (DEBUG only): `CaptureRouteResolver.debugPolicyOverride()` reads a per-build `defaults` key and pins a candidate engine at runtime — the single injection path, never reachable from `.automatic` (no release setter exists).
- **Candidate A** — `AVCaptureSessionSource` gains an additive `targetDeviceUID` (nil = built-in, unchanged) so it can capture an explicitly chosen device, including a Bluetooth mic.
- **Candidate C** — `AVAudioEngineSource` gains a DEBUG bench bypass of the BT-output crash-dodge so the tap engine can target a BT device under test.
- **Honest capture-side evidence**: each source + the manager emit a DEBUG `CAPTURE_EVIDENCE` line naming the *actual* bound device — the unforgeable in-process bench signal (no `xpc_proxy` masking).
- **Bake-off harness** (`Tests/RuntimeUAT/capture_bakeoff.py`): cold-state driver reusing `wispr_eyes.test_recording`; scores from `app.log` + `bt-route.log`, never the clipboard.

## Tests
- `AudioInputSource` conformance freeze (parametric), force→sourceType mapping, `.automatic` dormancy lock, override-reader mapping, device-target default. 13 new; full suite **2468 green**.

## Live UAT (real Bluetooth hardware, founder's Bose)
- Control plane proven end-to-end: force routing, device targeting, honest evidence (verified via the built-in fallback when the device was absent — no false pass), dormancy, heart path (sub-second).
- **Candidate A captured the Bose cleanly** (`boundDevice=Storm`), transcript landed, no A2DP↔HFP codec switch, 0.71s.
- **Candidate C captured the Bose but triggered the A2DP→HFP codec switch on every record** ("call ended" + output degradation) — a decisive bake-off finding recorded in the results doc; effectively rules candidate C out for the headphones-as-mic case.

Scope note: new `CaptureSourceType`/`CaptureSourcePolicy` cases and the AUHAL/VoiceProcessingIO conformers land in slices 2b/2c; the `:504`/`:550` non-switch consumers need no change here (2a adds no new enum cases).

Part of #1377. Part of epic #1374.