### PR TITLE
feat(asr): same-source download retry + wedge-cancel for model delivery (#1405 Phase 2, #1371)

### DIFF
--- a/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
@@ -155,7 +155,7 @@
   "sources": [
     {
       "id": "our_copy",
-      "baseURL": "https://models.enviouslabs.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/resolve/main/"
+      "baseURL": "https://models.enviouslabs.co/parakeet/FluidInference/parakeet-tdt-0.6b-v3-coreml/"
     },
     {
       "id": "backup",
@@ -172,5 +172,5 @@
     "diskHeadroomFactor": "2.2",
     "evictPreviousRevisions": false
   },
-  "manifestDigest": "9b2ac8f4a96845506f75e653605be369fd2762ba9f7ae60a27ab8991000e4581"
+  "manifestDigest": "edbd8592cc8316b5aa3a82de81c0855af9d0463a7e2bf8a5a1fe8569af497676"
 }

--- a/Sources/EnviousWisprCore/LoadProgressWatcher.swift
+++ b/Sources/EnviousWisprCore/LoadProgressWatcher.swift
@@ -70,6 +70,10 @@ public final class LoadProgressWatcher {
   private var maxGapSeconds: TimeInterval = 0
   private var signalCount: Int = 0
   private var fired = false
+  /// #1405: true while the last observed tick was an ACTIVE download phase, so
+  /// the next non-download tick can reset the attempt once at the
+  /// download->load boundary (clean load slate, deadline counts from there).
+  private var wasInDownloadPhase = false
   private var continuation: CheckedContinuation<Void, Never>?
   /// Require two observed progress signals before ratio-based silence can fire.
   /// This keeps the 800ms floor from becoming a standalone timeout after only
@@ -106,6 +110,14 @@ public final class LoadProgressWatcher {
   private let listingPhase: String?
   private let listingStallDeadlineSeconds: TimeInterval?
 
+  /// #1405: phases whose stall detection the DOWNLOADER owns (via its request
+  /// idle timeout), NOT this load-watchdog. While the observed phase is in this
+  /// set the watcher stays parked — it never fires and keeps its attempt
+  /// baseline fresh, so load-stall detection starts clean at the
+  /// download->load transition. Empty (default) preserves the pure-load
+  /// behavior for callers that never watch a download.
+  private let downloadOwnedPhases: Set<String>
+
   public init(
     currentTime: @escaping @MainActor () -> TimeInterval = {
       ProcessInfo.processInfo.systemUptime
@@ -113,13 +125,15 @@ public final class LoadProgressWatcher {
     requiresObservedGap: Bool = true,
     listingPhase: String? = nil,
     listingStallDeadlineSeconds: TimeInterval? = nil,
-    silenceFloorSeconds: TimeInterval = 0.8
+    silenceFloorSeconds: TimeInterval = 0.8,
+    downloadOwnedPhases: Set<String> = []
   ) {
     self.currentTime = currentTime
     self.requiresObservedGap = requiresObservedGap
     self.listingPhase = listingPhase
     self.listingStallDeadlineSeconds = listingStallDeadlineSeconds
     self.floorSeconds = silenceFloorSeconds
+    self.downloadOwnedPhases = downloadOwnedPhases
   }
 
   /// Begin a new attempt. Resets all per-attempt state.
@@ -133,6 +147,7 @@ public final class LoadProgressWatcher {
     maxGapSeconds = 0
     signalCount = 0
     fired = false
+    wasInDownloadPhase = false
     // continuation intentionally left untouched: a prior consumer may still be
     // awaiting wedged() and must be resumed by the caller before start().
   }
@@ -158,6 +173,37 @@ public final class LoadProgressWatcher {
   public func observeTick(observedMtime: Date?, observedPhase: String) {
     guard !fired else { return }
     let now = currentTime()
+
+    // #1405: while an ACTIVE download is in flight, the fetcher owns
+    // transfer-stall (its own request idle timeout), so the load-watchdog must
+    // not judge it. "Active" requires a FRESH signal (observedMtime != nil):
+    // a STALE progress file left on the download phase by a prior interrupted
+    // attempt passes observedMtime == nil and must NOT park — otherwise a new
+    // warm-up that hangs before writing would be suppressed forever
+    // (code-diff review). Park = never fire; do not touch the attempt baseline
+    // here, so a slow multi-minute download cannot false-fire the deadline.
+    if observedMtime != nil, downloadOwnedPhases.contains(observedPhase) {
+      wasInDownloadPhase = true
+      lastObservedMtime = observedMtime
+      return
+    }
+
+    // download -> load transition: the first non-download tick after a parked
+    // download starts the LOAD attempt fresh. This gives load-stall detection a
+    // clean slate (the long download does not bleed into its gates) and makes
+    // the pre-first-signal deadline count from HERE — so a load that wedges
+    // without ever writing progress after the download is still recovered.
+    if wasInDownloadPhase {
+      wasInDownloadPhase = false
+      attemptStartedAt = now
+      firstSignalAt = nil
+      lastSignalAt = nil
+      maxGapSeconds = 0
+      signalCount = 0
+      lastObservedMtime = observedMtime
+      lastObservedPhase = observedPhase
+      return
+    }
 
     // Detect a "real" signal by mtime advance.
     if let mtime = observedMtime, mtime != lastObservedMtime {
@@ -305,6 +351,17 @@ public enum ModelLoadStallPolicy {
   /// file while the remote host's repo-file-listing call is in flight. The
   /// wedge guard keys its single-signal stall gate on this token.
   public static let listingPhase = "Preparing download..."
+
+  /// The exact phase string the delivery layer writes while the model files
+  /// are actively downloading (the whole HEAD+GET+retry+failover fetch runs
+  /// under this one state). #1405: the fetcher owns its own stall detection
+  /// via its request idle timeout (`ManifestFetchTask.requestTimeout`), so the
+  /// sessionless wedge guard must NOT judge this phase — it would fight the
+  /// fetcher's legitimate retry/backoff/Retry-After waits (the P2 cascade).
+  /// The guard passes this to `downloadOwnedPhases`; single authority so the
+  /// phase writer (`ParakeetModelDelivery.bridgeToProgressFile`) and the guard
+  /// can never drift on the literal.
+  public static let downloadingPhase = "Downloading speech model..."
 
   /// PROVISIONAL listing-stall deadline (plan §3a, issue #1339): fires only
   /// on ABSENCE of progress in the listing window (one signal then silence,

--- a/Sources/EnviousWisprModelDelivery/ChunkAppendDelegate.swift
+++ b/Sources/EnviousWisprModelDelivery/ChunkAppendDelegate.swift
@@ -40,7 +40,15 @@ final class ChunkAppendDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
   private var response: HTTPURLResponse?
   private var writeError: Error?
   private var selfCancelReason: SelfCancelReason?
+  /// The continuation + completion handoff is guarded by `handoffLock` (not the
+  /// delegate queue): in the pre-start cancellation window `invalidateAndCancel()`
+  /// can deliver `didCompleteWithError` BEFORE `run()` installs the continuation,
+  /// so a completion that arrives first is stashed in `pendingCompletion` and the
+  /// continuation picks it up — otherwise the awaiter (and any cancel drain)
+  /// would hang forever (#1405 Codex r2).
+  private let handoffLock = NSLock()
   private var continuation: CheckedContinuation<Outcome, Error>?
+  private var pendingCompletion: Result<Outcome, Error>?
 
   struct Outcome {
     let response: HTTPURLResponse
@@ -71,10 +79,29 @@ final class ChunkAppendDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
     // serial delivery (EG-1 Codex r5 P1).
     let session = URLSession(configuration: Self.configuration, delegate: self, delegateQueue: nil)
     defer { session.finishTasksAndInvalidate() }
+    // Create the data task BEFORE installing the cancellation handler. If the
+    // enclosing Task is already cancelled on arrival, `withTaskCancellationHandler`
+    // may run `onCancel` (→ `invalidateAndCancel()`) before the operation body;
+    // creating the task there would throw "Task created in a session that has
+    // been invalidated" and crash. #1371's new cancel-on-wedge makes that window
+    // reachable. Creating it up front means the task always exists before any
+    // invalidation; a post-invalidation `resume()` is a safe no-op that completes
+    // as cancelled.
+    let dataTask = session.dataTask(with: request)
     return try await withTaskCancellationHandler {
-      try await withCheckedThrowingContinuation { cont in
+      try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Outcome, Error>) in
+        handoffLock.lock()
+        // Completion already delivered (cancel won the pre-start window)? Take it
+        // now instead of installing a continuation nothing will resume.
+        if let pending = pendingCompletion {
+          pendingCompletion = nil
+          handoffLock.unlock()
+          cont.resume(with: pending)
+          return
+        }
         continuation = cont
-        session.dataTask(with: request).resume()
+        handoffLock.unlock()
+        dataTask.resume()
       }
     } onCancel: {
       session.invalidateAndCancel()
@@ -167,27 +194,34 @@ final class ChunkAppendDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
   func urlSession(
     _ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?
   ) {
-    guard let cont = continuation else { return }
-    continuation = nil
+    let result: Result<Outcome, Error>
     if let writeError {
-      cont.resume(throwing: writeError)
-      return
-    }
-    // A REAL transport error mid-body must throw — the partial is a valid
-    // resume point, and returning "success" here would route it into checksum
-    // verification, which deletes it (EG-1 Codex r3). Only OUR deliberate
-    // self-cancel returns the response for status/length mapping.
-    if let error, selfCancelReason == nil {
-      cont.resume(throwing: error)
-      return
-    }
-    if let response {
+      result = .failure(writeError)
+    } else if let error, selfCancelReason == nil {
+      // A REAL transport error mid-body must throw — the partial is a valid
+      // resume point, and returning "success" here would route it into checksum
+      // verification, which deletes it (EG-1 Codex r3). Only OUR deliberate
+      // self-cancel returns the response for status/length mapping.
+      result = .failure(error)
+    } else if let response {
       onBytesWritten(written)
-      cont.resume(
-        returning: Outcome(
+      result = .success(
+        Outcome(
           response: response, selfCancelReason: selfCancelReason, bytesReceived: bytesReceived))
-      return
+    } else {
+      result = .failure(error ?? URLError(.unknown))
     }
-    cont.resume(throwing: error ?? URLError(.unknown))
+    // Hand off under the lock: if `run()` has not installed the continuation yet
+    // (pre-start cancellation window), stash the result for it to pick up so the
+    // completion is never dropped (#1405 Codex r2).
+    handoffLock.lock()
+    if let cont = continuation {
+      continuation = nil
+      handoffLock.unlock()
+      cont.resume(with: result)
+    } else {
+      pendingCompletion = result
+      handoffLock.unlock()
+    }
   }
 }

--- a/Sources/EnviousWisprModelDelivery/DeliveryTypes.swift
+++ b/Sources/EnviousWisprModelDelivery/DeliveryTypes.swift
@@ -30,11 +30,25 @@ public struct DeliveryFailure: Error, Sendable, Equatable {
   /// The source whose failure terminated the attempt (nil when no source was
   /// involved, e.g. preflight rejection).
   public let failingSourceID: String?
+  /// Phase 2 (#1405): true when this is a transient network/HTTP condition
+  /// worth a bounded same-source retry (with Range-resume) before failover.
+  /// Stamped at failure construction (transport classifier / HTTP-status sites)
+  /// so the failover loop reads one structured flag, never re-parses `detail`.
+  /// Not part of the D3/§7 telemetry taxonomy — a retry-policy hint only.
+  public let retryableTransient: Bool
+  /// Phase 2 (#1405): server-directed wait in seconds parsed from a 429/503
+  /// `Retry-After` header, when present; nil otherwise.
+  public let retryAfter: TimeInterval?
 
-  public init(reason: DeliveryFailureClass, detail: String? = nil, failingSourceID: String? = nil) {
+  public init(
+    reason: DeliveryFailureClass, detail: String? = nil, failingSourceID: String? = nil,
+    retryableTransient: Bool = false, retryAfter: TimeInterval? = nil
+  ) {
     self.reason = reason
     self.detail = detail
     self.failingSourceID = failingSourceID
+    self.retryableTransient = retryableTransient
+    self.retryAfter = retryAfter
   }
 }
 

--- a/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
+++ b/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
@@ -60,10 +60,10 @@ struct ManifestFetchTask {
   private static let maxNetworkRetries = 3
   private static let backoffBaseSeconds: TimeInterval = 1
   private static let backoffCapSeconds: TimeInterval = 8
-  /// Honor `Retry-After` only up to a cap safely below the 15 s transfer-silence
-  /// wedge floor (`LoadProgressWatcher.transferSilenceFloorSeconds`); a longer
-  /// server-directed delay fails over to backup rather than a silent wait that
-  /// would trip the stall guard (#1405 Codex r2).
+  /// Honor `Retry-After` only up to a bounded cap; a longer server-directed
+  /// delay fails over to backup rather than parking the download on a broken or
+  /// hostile server. (Transfer-stall itself is owned by the request idle
+  /// timeout `requestTimeout`, not this cap — #1405.)
   private static let retryAfterCapSeconds: TimeInterval = 10
 
   /// Full-jitter exponential backoff: `random(0, min(cap, base·2^attempt))`.
@@ -160,6 +160,14 @@ struct ManifestFetchTask {
           let result = try await fetchOneFile(
             file, from: source, to: stagedURL,
             progressBase: completedBytes)
+          // Accepted P3 (code-diff review): on the transient-retry-then-resume
+          // path a FAILED attempt's partial bytes are staged but not added here
+          // (only the successful tail's `bytesReceived` counts), so
+          // `attemptCompleted(bytesDownloadedBucket:)` can under-count on a
+          // mid-file recovery. This is coarse telemetry only (4 buckets spanning
+          // 50MB–600MB+); a lost mid-file partial almost never crosses a bucket
+          // boundary on the ~470MB model, and it never affects the download
+          // itself. Not worth per-attempt byte plumbing on the hot fetch path.
           bytesDownloaded += result.bytesReceived
 
           // Hash gate BEFORE this file counts (invariant 1).
@@ -194,9 +202,9 @@ struct ManifestFetchTask {
           // Phase 2 (#1405): bounded same-source retry for transient network/
           // HTTP failures BEFORE advancing the source — keep the staged partial
           // so `fetchOneFile` resumes via Range (same source ⇒ same ETag ⇒
-          // valid). Honor `Retry-After` up to a cap below the wedge floor; a
-          // longer server-directed delay is NOT sat on (it would trip the stall
-          // guard) — fall through to failover instead (Codex r2).
+          // valid). Honor `Retry-After` up to a bounded cap so a broken/hostile
+          // server-directed delay cannot park the download indefinitely; a
+          // longer delay falls through to failover instead.
           let retryAfterTooLong = (failure.retryAfter ?? 0) > Self.retryAfterCapSeconds
           if failure.retryableTransient, networkRetriesUsed < Self.maxNetworkRetries,
             !retryAfterTooLong
@@ -205,24 +213,6 @@ struct ManifestFetchTask {
               failure.retryAfter
               ?? Self.backoffDelay(attempt: networkRetriesUsed, jitter: jitterFraction())
             networkRetriesUsed += 1
-            // A retry is liveness, not a stall: re-emit current progress before
-            // the wait so the transfer-silence wedge guard
-            // (`LoadProgressWatcher.transferSilenceFloorSeconds`, 15 s) sees the
-            // download is alive. Without this tick, repeated `Retry-After` waits
-            // (each under the 10 s per-sleep cap) accumulate uninterrupted
-            // silence past the floor, tripping `recoverFromWedge()` — which now
-            // cancels delivery (#1371) — before the bounded retries / failover
-            // can finish (cloud-review PR #1410 P2). Each sleep is ≤ cap, so one
-            // tick per sleep keeps every silent gap under the floor; a genuinely
-            // hung request (no response, no tick) still wedges as intended.
-            // Report verified files PLUS the bytes already staged for this
-            // file's Range resume — never drop back to verified-only, which
-            // would blip the UI backward and regrow the disk reservation until
-            // resume corrected it (code-diff r1 P2).
-            let stagedInFlight =
-              ((try? FileManager.default.attributesOfItem(atPath: stagedURL.path)[.size]
-                as? Int64) ?? nil) ?? 0
-            onProgress(completedBytes + min(stagedInFlight, file.sizeBytes), manifest.totalBytes)
             do {
               try await backoffSleep(delay)
             } catch is CancellationError {

--- a/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
+++ b/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
@@ -34,10 +34,83 @@ struct ManifestFetchTask {
   let onProgress: @Sendable (_ bytesWritten: Int64, _ totalBytes: Int64) -> Void
   let onSourceFailover: @Sendable (DeliveryFailureClass) -> Void
 
+  /// Phase 2 (#1405): the inter-attempt backoff sleep, injectable so tests
+  /// advance it without wall-clock waits (`swift-patterns` timing-seam-shapes;
+  /// `swift-testing-patterns` signal-based-test-waits). Throwing + cancellable —
+  /// a cancel landing here unwinds as `.cancelled`, never a retry/failover.
+  /// `var` (not `let`) so the synthesized memberwise init exposes it as a
+  /// defaulted parameter for injection; never mutated after construction.
+  var backoffSleep: @Sendable (_ seconds: TimeInterval) async throws -> Void = { seconds in
+    try await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
+  }
+  /// Phase 2 (#1405): full-jitter fraction in [0, 1]; injectable for
+  /// deterministic backoff-bound tests. `var` for the same memberwise-init
+  /// reason as `backoffSleep`.
+  var jitterFraction: @Sendable () -> Double = { Double.random(in: 0...1) }
+
   /// EG-1's shipped transport dials (`EGOneModelStore.swift:398,465`) — idle
   /// transport timeouts with shipped precedent, not new wall-clock deadlines.
   private static let requestTimeout: TimeInterval = 60
   private static let headTimeout: TimeInterval = 30
+
+  // MARK: - Phase 2 (#1405) same-source retry dials
+
+  /// Industry consensus (`download-resilience-standards.md` §1, HF-Hub-analog):
+  /// N=4 attempts per source = 1 initial + `maxNetworkRetries`.
+  private static let maxNetworkRetries = 3
+  private static let backoffBaseSeconds: TimeInterval = 1
+  private static let backoffCapSeconds: TimeInterval = 8
+  /// Honor `Retry-After` only up to a cap safely below the 15 s transfer-silence
+  /// wedge floor (`LoadProgressWatcher.transferSilenceFloorSeconds`); a longer
+  /// server-directed delay fails over to backup rather than a silent wait that
+  /// would trip the stall guard (#1405 Codex r2).
+  private static let retryAfterCapSeconds: TimeInterval = 10
+
+  /// Full-jitter exponential backoff: `random(0, min(cap, base·2^attempt))`.
+  static func backoffDelay(attempt: Int, jitter: Double) -> TimeInterval {
+    let window = min(backoffCapSeconds, backoffBaseSeconds * pow(2, Double(attempt)))
+    return jitter * window
+  }
+
+  /// URLError codes that are transient-unreachable and worth a same-source
+  /// retry — connection lost / cannot-connect / cannot-find-host / DNS. NOT
+  /// `.notConnectedToInternet` (-1009, genuinely offline: retry is futile).
+  private static let transientUnreachableCodes: Set<Int> = [
+    URLError.Code.networkConnectionLost.rawValue,
+    URLError.Code.cannotConnectToHost.rawValue,
+    URLError.Code.cannotFindHost.rawValue,
+    URLError.Code.dnsLookupFailed.rawValue,
+  ]
+
+  /// Parse a `Retry-After` header (RFC 9110 §10.2.3): delay-seconds integer or
+  /// an HTTP-date. Returns seconds-to-wait (≥ 0), or nil if absent/unparseable.
+  static func retryAfterSeconds(from response: HTTPURLResponse) -> TimeInterval? {
+    guard
+      let raw = response.value(forHTTPHeaderField: "Retry-After")?
+        .trimmingCharacters(in: .whitespaces), !raw.isEmpty
+    else { return nil }
+    if let seconds = TimeInterval(raw) { return max(0, seconds) }
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    if let date = formatter.date(from: raw) { return max(0, date.timeIntervalSinceNow) }
+    return nil
+  }
+
+  /// Build a non-success-HTTP `DeliveryFailure`, stamping retryability +
+  /// `Retry-After` in one place for BOTH the GET and HEAD non-success sites
+  /// (#1405 Codex r1/r2). 429/5xx are transient-retryable; 4xx are not.
+  static func httpStatusFailure(
+    status: Int, detail: String, response: HTTPURLResponse, sourceID: String?
+  ) -> DeliveryFailure {
+    let cls = classifyHTTPStatus(status)
+    let retryable = cls == .source5xx
+    return DeliveryFailure(
+      reason: cls, detail: detail, failingSourceID: sourceID,
+      retryableTransient: retryable,
+      retryAfter: retryable ? retryAfterSeconds(from: response) : nil)
+  }
 
   func run() async throws -> Outcome {
     let fm = FileManager.default
@@ -78,6 +151,9 @@ struct ManifestFetchTask {
       // r7 findings 1/2).
       var fetched = false
       var localRetryUsed = false
+      // Phase 2 (#1405): per-file network-retry budget, independent of the
+      // local-byte retry above (a 416-local retry never consumes it).
+      var networkRetriesUsed = 0
       while !fetched {
         let source = sources[sourceIndex]
         do {
@@ -115,6 +191,29 @@ struct ManifestFetchTask {
           if failure.detail?.hasPrefix("length_mismatch_html") == true {
             sawHTMLInterception = true
           }
+          // Phase 2 (#1405): bounded same-source retry for transient network/
+          // HTTP failures BEFORE advancing the source — keep the staged partial
+          // so `fetchOneFile` resumes via Range (same source ⇒ same ETag ⇒
+          // valid). Honor `Retry-After` up to a cap below the wedge floor; a
+          // longer server-directed delay is NOT sat on (it would trip the stall
+          // guard) — fall through to failover instead (Codex r2).
+          let retryAfterTooLong = (failure.retryAfter ?? 0) > Self.retryAfterCapSeconds
+          if failure.retryableTransient, networkRetriesUsed < Self.maxNetworkRetries,
+            !retryAfterTooLong
+          {
+            let delay =
+              failure.retryAfter
+              ?? Self.backoffDelay(attempt: networkRetriesUsed, jitter: jitterFraction())
+            networkRetriesUsed += 1
+            do {
+              try await backoffSleep(delay)
+            } catch is CancellationError {
+              // A cancel during backoff unwinds as .cancelled — never a retry
+              // or failover (cooperative cancel, invariant 5).
+              throw DeliveryFailure(reason: .cancelled, failingSourceID: source.id)
+            }
+            continue
+          }
           guard sourceIndex + 1 < sources.count else {
             // All sources exhausted: terminal. The captive-portal signature
             // (both sources length/hash-failed with HTML observed) gets the
@@ -128,6 +227,9 @@ struct ManifestFetchTask {
           }
           sourceIndex += 1
           sourcesUsed = 2
+          // Retry budget is PER SOURCE (#1405 §6): the backup gets its own N
+          // transient retries, so reset the counter on failover (Codex r1 P2).
+          networkRetriesUsed = 0
           onSourceFailover(failure.reason)
         }
       }
@@ -248,9 +350,9 @@ struct ManifestFetchTask {
         throw DeliveryFailure(
           reason: .source4xx, detail: "http_416_local", failingSourceID: source.id)
       }
-      throw DeliveryFailure(
-        reason: Self.classifyHTTPStatus(status), detail: "http_\(status)",
-        failingSourceID: source.id)
+      throw Self.httpStatusFailure(
+        status: status, detail: "http_\(status)", response: outcome.response,
+        sourceID: source.id)
     }
 
     return FileFetchResult(bytesReceived: outcome.bytesReceived, usedLocalBytes: existingBytes > 0)
@@ -313,9 +415,9 @@ struct ManifestFetchTask {
     // identity — treating it as identity deletes a resumable partial (EG-1
     // Codex r15). Throw instead: the partial survives, retry re-validates.
     guard (200...299).contains(http.statusCode) else {
-      throw DeliveryFailure(
-        reason: Self.classifyHTTPStatus(http.statusCode), detail: "head_\(http.statusCode)",
-        failingSourceID: sourceID)
+      throw Self.httpStatusFailure(
+        status: http.statusCode, detail: "head_\(http.statusCode)", response: http,
+        sourceID: sourceID)
     }
     let length = http.value(forHTTPHeaderField: "Content-Length").flatMap { Int64($0) }
     return (http.value(forHTTPHeaderField: "ETag"), length)
@@ -329,12 +431,16 @@ struct ManifestFetchTask {
       switch URLError.Code(rawValue: ns.code) {
       case .timedOut:
         return DeliveryFailure(
-          reason: .sourceTimeout, detail: "urlerror_\(ns.code)", failingSourceID: sourceID)
+          reason: .sourceTimeout, detail: "urlerror_\(ns.code)", failingSourceID: sourceID,
+          retryableTransient: true)
       case .cancelled:
         return DeliveryFailure(reason: .cancelled, failingSourceID: sourceID)
       default:
+        // Transient-unreachable codes (conn lost / cannot-connect / no-host /
+        // DNS) retry; genuine-offline (-1009) and other codes fail over (#1405).
         return DeliveryFailure(
-          reason: .sourceUnreachable, detail: "urlerror_\(ns.code)", failingSourceID: sourceID)
+          reason: .sourceUnreachable, detail: "urlerror_\(ns.code)", failingSourceID: sourceID,
+          retryableTransient: Self.transientUnreachableCodes.contains(ns.code))
       }
     }
     if Self.isDiskWriteError(ns) {

--- a/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
+++ b/Sources/EnviousWisprModelDelivery/ManifestFetchTask.swift
@@ -205,6 +205,24 @@ struct ManifestFetchTask {
               failure.retryAfter
               ?? Self.backoffDelay(attempt: networkRetriesUsed, jitter: jitterFraction())
             networkRetriesUsed += 1
+            // A retry is liveness, not a stall: re-emit current progress before
+            // the wait so the transfer-silence wedge guard
+            // (`LoadProgressWatcher.transferSilenceFloorSeconds`, 15 s) sees the
+            // download is alive. Without this tick, repeated `Retry-After` waits
+            // (each under the 10 s per-sleep cap) accumulate uninterrupted
+            // silence past the floor, tripping `recoverFromWedge()` — which now
+            // cancels delivery (#1371) — before the bounded retries / failover
+            // can finish (cloud-review PR #1410 P2). Each sleep is ≤ cap, so one
+            // tick per sleep keeps every silent gap under the floor; a genuinely
+            // hung request (no response, no tick) still wedges as intended.
+            // Report verified files PLUS the bytes already staged for this
+            // file's Range resume — never drop back to verified-only, which
+            // would blip the UI backward and regrow the disk reservation until
+            // resume corrected it (code-diff r1 P2).
+            let stagedInFlight =
+              ((try? FileManager.default.attributesOfItem(atPath: stagedURL.path)[.size]
+                as? Int64) ?? nil) ?? 0
+            onProgress(completedBytes + min(stagedInFlight, file.sizeBytes), manifest.totalBytes)
             do {
               try await backoffSleep(delay)
             } catch is CancellationError {

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -124,14 +124,14 @@ package final class SessionlessLoadWedgeGuard {
     self.watcher = LoadProgressWatcher(
       listingPhase: ModelLoadStallPolicy.listingPhase,
       listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
-      // #1339 drill regression (2026-07-05): this guard watches an INTERNET
-      // TRANSFER, and the default 0.8s XPC-beat silence floor let the ratio
-      // gate fire during the 445MB encoder object's legitimate cold
-      // first-byte gap (~3-5s), killing a healthy fresh-install download —
-      // and its recovery (generation bump) cancels the whole load. The
-      // transfer floor rides out cold-TTFB while still surfacing a genuinely
-      // dead mid-stream transfer within seconds.
-      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds
+      // #1339 raised this floor for cold-TTFB tolerance while the guard still
+      // judged the transfer. #1405 hands transfer-stall ownership back to the
+      // fetcher's own request idle timeout: the guard now stays PARKED during
+      // the download phase (`downloadOwnedPhases`), so this floor governs only
+      // the listing + model-load phases. Left at 15s (harmless for those; a
+      // genuine load wedge is silence orders of magnitude larger).
+      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds,
+      downloadOwnedPhases: [ModelLoadStallPolicy.downloadingPhase]
     )
   }
 

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -408,6 +408,11 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   func recoverFromWedge() async {
     await discardSession()
     asrManager.cancelInFlightLoad()
+    // #1371/#1405: the wedge can fire while the delivery download is still in
+    // flight (warm-up awaits delivery BEFORE any ASR load), so cancel it too —
+    // otherwise a stalled/retrying download stays parked and the Retry path
+    // never surfaces. No-op when nothing is downloading.
+    await delivery?.cancel()
   }
 
   // MARK: ASREngineAdapter — cleanup

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -408,11 +408,11 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   func recoverFromWedge() async {
     await discardSession()
     asrManager.cancelInFlightLoad()
-    // #1371/#1405: the wedge can fire while the delivery download is still in
-    // flight (warm-up awaits delivery BEFORE any ASR load), so cancel it too —
-    // otherwise a stalled/retrying download stays parked and the Retry path
-    // never surfaces. No-op when nothing is downloading.
-    await delivery?.cancel()
+    // #1405: this recovery is now for MODEL-LOAD wedges only. The download owns
+    // its own stall detection (the fetcher's request idle timeout), and the
+    // wedge guard stays parked during the download phase — so a download is
+    // never in flight here. The #1371 `delivery.cancel()` that used to live
+    // here was the external canceller that fought the fetcher's retry; removed.
   }
 
   // MARK: ASREngineAdapter — cleanup

--- a/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
@@ -59,6 +59,14 @@ public final class ParakeetDeliveryHandle {
     await controller.repair(registration)
   }
 
+  /// #1371/#1405 Phase 2: cancel the in-flight delivery download. `warmUp()`
+  /// awaits delivery BEFORE any ASR load, so a warm-up wedge must cancel the
+  /// download (cooperative, typed) or a stalled/retrying fetch stays parked
+  /// instead of surfacing the Retry path. No-op if nothing is in flight.
+  public func cancel() async {
+    _ = await controller.cancel(registration.manifest.identity)
+  }
+
   /// D5 §1: the `enabled=false` bypass is proven by telemetry from the ONE
   /// site that takes it (the adapter's legacy branch).
   public func noteLegacyPathActive() {

--- a/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
@@ -92,12 +92,17 @@ public final class ParakeetDeliveryHandle {
     case .verifying:
       file.write(fraction: 0.5, phase: "Verifying download...", detail: "")
     case .admitted:
-      // #1405 download->load boundary: move the phase OFF the download phase
-      // the instant delivery completes, so the load-wedge guard un-parks and
-      // resumes judging the model LOAD (a load that hangs before writing its
-      // own progress must still be recoverable). Fraction stays at the 0.5
-      // download/load handoff; the load's own progress overwrites this.
-      file.write(fraction: 0.5, phase: "Loading speech model...", detail: "")
+      // #1405 download->load boundary: CLEAR the progress file the instant
+      // delivery completes. This moves the phase off the download phase so the
+      // load-wedge guard un-parks and resumes judging the model LOAD — but
+      // unlike WRITING a "loading" phase, clearing leaves NO signal, so the
+      // guard's pre-first-signal deadline still covers a load that wedges
+      // before emitting its own progress. Critical on the marker fast path
+      // (cache hit), where `.admitted` is reached with no prior write, so a
+      // phantom signal here would be the ONLY signal and would defeat that
+      // deadline (cloud-review P1). The load's own progress repopulates the
+      // file; onboarding's checklist advances off warm-up readiness, not this.
+      ProgressFile.shared.clear()
     case .notReady, .cancelled, .failed:
       break
     }

--- a/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
@@ -59,14 +59,6 @@ public final class ParakeetDeliveryHandle {
     await controller.repair(registration)
   }
 
-  /// #1371/#1405 Phase 2: cancel the in-flight delivery download. `warmUp()`
-  /// awaits delivery BEFORE any ASR load, so a warm-up wedge must cancel the
-  /// download (cooperative, typed) or a stalled/retrying fetch stays parked
-  /// instead of surfacing the Retry path. No-op if nothing is in flight.
-  public func cancel() async {
-    _ = await controller.cancel(registration.manifest.identity)
-  }
-
   /// D5 §1: the `enabled=false` bypass is proven by telemetry from the ONE
   /// site that takes it (the adapter's legacy branch).
   public func noteLegacyPathActive() {
@@ -87,18 +79,26 @@ public final class ParakeetDeliveryHandle {
     case .preparing(let validating):
       file.write(
         fraction: 0,
-        phase: validating ? "Checking speech model files..." : "Preparing download...",
+        phase: validating ? "Checking speech model files..." : ModelLoadStallPolicy.listingPhase,
         detail: "")
     case .downloading(let fraction, let bytesWritten, let totalBytes):
       let mb = Int(Double(bytesWritten) / 1_048_576)
       let totalMB = Int(Double(totalBytes) / 1_048_576)
       file.write(
         fraction: fraction * 0.5,
-        phase: "Downloading speech model...",
+        // Single authority for this literal (the wedge guard parks on it, #1405).
+        phase: ModelLoadStallPolicy.downloadingPhase,
         detail: "\(mb) MB of \(totalMB) MB (\(Int(fraction * 100))%)")
     case .verifying:
       file.write(fraction: 0.5, phase: "Verifying download...", detail: "")
-    case .notReady, .admitted, .cancelled, .failed:
+    case .admitted:
+      // #1405 download->load boundary: move the phase OFF the download phase
+      // the instant delivery completes, so the load-wedge guard un-parks and
+      // resumes judging the model LOAD (a load that hangs before writing its
+      // own progress must still be recoverable). Fraction stays at the 0.5
+      // download/load handoff; the load's own progress overwrites this.
+      file.write(fraction: 0.5, phase: "Loading speech model...", detail: "")
+    case .notReady, .cancelled, .failed:
       break
     }
   }

--- a/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
+++ b/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
@@ -477,6 +477,71 @@ struct LoadProgressWatcherTests {
     watcher.stop()
   }
 
+  @Test("#1405: the guard stays parked during the download phase, but load-stall still fires after")
+  func downloadPhaseIsParkedThenLoadStallStillFires() async {
+    let clock = ManualClock()
+    let watcher = LoadProgressWatcher(
+      currentTime: { clock.now },
+      listingPhase: ModelLoadStallPolicy.listingPhase,
+      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
+      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds,
+      downloadOwnedPhases: [ModelLoadStallPolicy.downloadingPhase])
+    watcher.start()
+    // A long, totally silent (frozen) FRESH download — far past the 15s transfer
+    // floor AND the 120s listing deadline. The fetcher's own idle timeout owns
+    // transfer-stall, so the load-watchdog must never fire during the download.
+    watcher.observeTick(
+      observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.downloadingPhase)
+    clock.tick(seconds: 600)
+    watcher.observeTick(
+      observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.downloadingPhase)
+    #expect(!watcher.hasFired, "a silent fresh download must never fire the load-watchdog")
+
+    // Delivery completes -> the phase leaves the download phase (the #1405
+    // boundary marker writes "Loading speech model..."). The transition resets
+    // the attempt so the long download does not bleed into the load gates.
+    clock.tick(seconds: 0.5)
+    watcher.observeTick(observedMtime: mtime(1), observedPhase: "Loading speech model...")
+    // The LOAD then produces two of its own signals and genuinely wedges.
+    clock.tick(seconds: 0.5)
+    watcher.observeTick(observedMtime: mtime(2), observedPhase: "Loading speech model...")
+    clock.tick(seconds: 0.5)
+    watcher.observeTick(observedMtime: mtime(3), observedPhase: "Loading speech model...")
+    clock.tick(seconds: 30)
+    watcher.observeTick(observedMtime: mtime(3), observedPhase: "Loading speech model...")
+    #expect(watcher.hasFired, "a real load wedge AFTER the download must still fire")
+    watcher.stop()
+  }
+
+  @Test("#1405 (code-diff): a STALE download-phase file must NOT park — the deadline still fires")
+  func staleDownloadPhaseDoesNotSuppressTheGuard() async {
+    // Regression: a prior interrupted attempt leaves the progress file on the
+    // download phase. The guard arms; the poll passes observedMtime == nil
+    // (mtime == the stale baseline, i.e. no fresh write) but the stale phase
+    // string. Parking on the phase alone would reset the deadline every tick
+    // and suppress the guard forever. A new warm-up that hangs before writing
+    // any fresh progress must still fire the pre-first-signal deadline.
+    let clock = ManualClock()
+    let watcher = LoadProgressWatcher(
+      currentTime: { clock.now },
+      listingPhase: ModelLoadStallPolicy.listingPhase,
+      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
+      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds,
+      downloadOwnedPhases: [ModelLoadStallPolicy.downloadingPhase])
+    watcher.start()
+    // Stale file: phase says downloading, but there is NO fresh signal (nil).
+    watcher.observeTick(observedMtime: nil, observedPhase: ModelLoadStallPolicy.downloadingPhase)
+    clock.tick(seconds: 119)
+    watcher.observeTick(observedMtime: nil, observedPhase: ModelLoadStallPolicy.downloadingPhase)
+    #expect(!watcher.hasFired, "just under the pre-first-signal deadline: no fire yet")
+    clock.tick(seconds: 2)
+    watcher.observeTick(observedMtime: nil, observedPhase: ModelLoadStallPolicy.downloadingPhase)
+    #expect(
+      watcher.hasFired,
+      "a stale download phase must not suppress the pre-first-signal deadline")
+    watcher.stop()
+  }
+
   @Test("#1339 drill regression: the DEFAULT 0.8s floor still fires on the same gap (opt-in fix)")
   func defaultFloorStillFiresOnColdGap() async {
     // Negative pair for the test above: without the injected transfer floor,

--- a/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
+++ b/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
@@ -497,19 +497,50 @@ struct LoadProgressWatcherTests {
       observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.downloadingPhase)
     #expect(!watcher.hasFired, "a silent fresh download must never fire the load-watchdog")
 
-    // Delivery completes -> the phase leaves the download phase (the #1405
-    // boundary marker writes "Loading speech model..."). The transition resets
+    // Delivery completes -> #1405 CLEARS the progress file (boundary), so the
+    // next tick sees no file (mtime nil, empty phase). The transition resets
     // the attempt so the long download does not bleed into the load gates.
     clock.tick(seconds: 0.5)
-    watcher.observeTick(observedMtime: mtime(1), observedPhase: "Loading speech model...")
+    watcher.observeTick(observedMtime: nil, observedPhase: "")
     // The LOAD then produces two of its own signals and genuinely wedges.
     clock.tick(seconds: 0.5)
-    watcher.observeTick(observedMtime: mtime(2), observedPhase: "Loading speech model...")
+    watcher.observeTick(observedMtime: mtime(1), observedPhase: "Loading speech model...")
     clock.tick(seconds: 0.5)
-    watcher.observeTick(observedMtime: mtime(3), observedPhase: "Loading speech model...")
+    watcher.observeTick(observedMtime: mtime(2), observedPhase: "Loading speech model...")
     clock.tick(seconds: 30)
-    watcher.observeTick(observedMtime: mtime(3), observedPhase: "Loading speech model...")
+    watcher.observeTick(observedMtime: mtime(2), observedPhase: "Loading speech model...")
     #expect(watcher.hasFired, "a real load wedge AFTER the download must still fire")
+    watcher.stop()
+  }
+
+  @Test("#1405 (cloud-review P1): a cleared boundary preserves the pre-first-signal deadline")
+  func clearedBoundaryPreservesPreFirstSignalDeadline() async {
+    // The download completes and the boundary CLEARS the progress file. If the
+    // model LOAD then wedges before emitting ANY progress of its own (e.g. a
+    // cache-hit marker fast path where `.admitted` is the only delivery event),
+    // the file stays empty. Clearing leaves NO signal — so the pre-first-signal
+    // deadline must still fire (a phantom "Loading..." signal would have
+    // defeated it, the P1 regression).
+    let clock = ManualClock()
+    let watcher = LoadProgressWatcher(
+      currentTime: { clock.now },
+      listingPhase: ModelLoadStallPolicy.listingPhase,
+      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
+      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds,
+      downloadOwnedPhases: [ModelLoadStallPolicy.downloadingPhase])
+    watcher.start()
+    // A brief real download, then the cleared boundary.
+    watcher.observeTick(
+      observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.downloadingPhase)
+    clock.tick(seconds: 5)
+    watcher.observeTick(observedMtime: nil, observedPhase: "")  // #1405 boundary clear
+    // The load never writes; the file stays empty. Deadline must still fire.
+    clock.tick(seconds: 119)
+    watcher.observeTick(observedMtime: nil, observedPhase: "")
+    #expect(!watcher.hasFired, "just under the deadline from the boundary: no fire yet")
+    clock.tick(seconds: 2)
+    watcher.observeTick(observedMtime: nil, observedPhase: "")
+    #expect(watcher.hasFired, "a load that never writes after the boundary must still fire")
     watcher.stop()
   }
 

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
@@ -151,7 +151,9 @@ enum ManifestFixture {
   /// Swift loader MUST both reproduce it (one canonicalization, two
   /// implementations — a drift here would reject a valid manifest at
   /// runtime).
-  static let goldenDigest = "9b2ac8f4a96845506f75e653605be369fd2762ba9f7ae60a27ab8991000e4581"
+  // Updated 2026-07-07 (#1405 Phase 2): `our_copy` baseURL repointed to the
+  // edge-cached `/parakeet/` path; digest recomputed via the same canonicalization.
+  static let goldenDigest = "edbd8592cc8316b5aa3a82de81c0855af9d0463a7e2bf8a5a1fe8569af497676"
 
   @Test func shippedManifestLoadsAndMatchesGoldenDigest() throws {
     let data = try Data(contentsOf: Self.shippedManifestURL)

--- a/Tests/EnviousWisprTests/ModelDelivery/ManifestFetchTaskTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ManifestFetchTaskTests.swift
@@ -127,13 +127,12 @@ final class DeliveryStubProtocol: URLProtocol {
     manifest: DeliveryManifest, staging: URL, components: Set<String>? = nil,
     backoffSleep: @escaping @Sendable (TimeInterval) async throws -> Void = { _ in },
     jitter: @escaping @Sendable () -> Double = { 1.0 },
-    onProgress: @escaping @Sendable (Int64, Int64) -> Void = { _, _ in },
     onFailover: @escaping @Sendable (DeliveryFailureClass) -> Void = { _ in }
   ) -> ManifestFetchTask {
     ManifestFetchTask(
       manifest: manifest, stagingDirectory: staging, sources: manifest.sources,
       componentsToFetch: components ?? Set(manifest.files.map(\.component)),
-      verifiedInPlaceBytes: 0, onProgress: onProgress, onSourceFailover: onFailover,
+      verifiedInPlaceBytes: 0, onProgress: { _, _ in }, onSourceFailover: onFailover,
       backoffSleep: backoffSleep, jitterFraction: jitter)
   }
 
@@ -678,49 +677,14 @@ final class DeliveryStubProtocol: URLProtocol {
     }
   }
 
-  /// (j) PR #1410 P2: repeated `Retry-After` waits (each under the per-sleep
-  /// cap) must NOT accumulate uninterrupted progress-file silence past the 15 s
-  /// wedge floor. Each backoff wait is immediately preceded by a liveness tick
-  /// (`onProgress` re-emit) so the transfer-silence guard sees the download is
-  /// alive and never trips `recoverFromWedge()` mid-retry. Without the tick, two
-  /// `Retry-After: 5` waits would be one silent 10 s+ gap the guard reads as a
-  /// stall.
-  @Test func retryWaitsEmitLivenessTicksSoTheWedgeGuardSeesProgress() async throws {
-    let (manifest, file, staging) = try single()
-    try await withStubs {
-      // 503 (Retry-After 5) → 503 (Retry-After 5) → success, all same source.
-      DeliveryStubProtocol.enqueue(
-        url: mirrorURL(file),
-        .init(status: 503, headers: ["Retry-After": "5"], body: Data()))
-      DeliveryStubProtocol.enqueue(
-        url: mirrorURL(file),
-        .init(status: 503, headers: ["Retry-After": "5"], body: Data()))
-      DeliveryStubProtocol.enqueue(url: mirrorURL(file), okStub(file))
-      let log = EventLog()
-      let outcome = try await task(
-        manifest: manifest, staging: staging,
-        backoffSleep: { _ in log.append("sleep") },
-        onProgress: { _, _ in log.append("tick") }
-      ).run()
-      #expect(outcome.sourcesUsed == 1, "the retries resolve on the same source")
-      let events = log.all
-      let sleepIndices = events.indices.filter { events[$0] == "sleep" }
-      #expect(sleepIndices.count == 2, "two transient failures → two backoff waits")
-      for i in sleepIndices {
-        #expect(
-          i > 0 && events[i - 1] == "tick",
-          "every backoff wait is immediately preceded by a liveness tick")
-      }
-    }
-  }
-
-  /// #1371: a warm-up wedge must cancel the IN-FLIGHT delivery download (not
-  /// just the ASR load), or a stalled/retrying fetch stays parked and the Retry
-  /// path never surfaces. Lives in THIS serialized suite (not the adapter's) so
-  /// it does not race the shared `DeliveryStubProtocol` global with the other
-  /// stub-driven tests. Real controller + handle; the download starts then hangs.
+  /// #1405: a MODEL-LOAD wedge recovery must NOT cancel an in-flight delivery
+  /// download — the download owns its own stall detection (the fetcher's request
+  /// idle timeout) and the wedge guard stays parked during the download phase.
+  /// This is the inverse of the reverted #1371 behavior: `recoverFromWedge()`
+  /// leaves a running download untouched. Lives in THIS serialized suite (not
+  /// the adapter's) so it does not race the shared `DeliveryStubProtocol` global.
   @MainActor
-  @Test func recoverFromWedgeCancelsInFlightDelivery() async throws {
+  @Test func recoverFromWedgeLeavesInFlightDeliveryRunning() async throws {
     let root = FileManager.default.temporaryDirectory
       .appendingPathComponent("wedge-\(UUID().uuidString)", isDirectory: true)
     let install = root.appendingPathComponent("install", isDirectory: true)
@@ -762,14 +726,23 @@ final class DeliveryStubProtocol: URLProtocol {
     }
     let warm = Task { @MainActor in try? await adapter.warmUp() }
     await inflight.wait()
-    await adapter.recoverFromWedge()
-    _ = await warm.value
 
+    // A model-LOAD wedge recovery must leave the in-flight download alone.
+    await adapter.recoverFromWedge()
     let state = await controller.state(of: registration.manifest.identity)
-    guard case .cancelled = state else {
-      Issue.record("expected .cancelled after wedge recovery, got \(state)")
+    guard case .downloading = state else {
+      let detail =
+        "recoverFromWedge must leave the in-flight download running "
+        + "(delivery owns its own stall detection), got \(state)"
+      Issue.record(Comment(rawValue: detail))
+      _ = await controller.cancel(registration.manifest.identity)
+      _ = await warm.value
       return
     }
+
+    // Cleanup: the stub hangs forever, so cancel explicitly to unblock warmUp.
+    _ = await controller.cancel(registration.manifest.identity)
+    _ = await warm.value
   }
 }
 
@@ -817,14 +790,4 @@ private final class DelayBox: @unchecked Sendable {
   private var delays: [TimeInterval] = []
   func record(_ delay: TimeInterval) { lock.withLock { delays.append(delay) } }
   var all: [TimeInterval] { lock.withLock { delays } }
-}
-
-/// Ordered log of liveness-tick vs backoff-sleep events, used to prove a
-/// progress tick precedes every retry wait (PR #1410 P2: the wedge guard must
-/// see the download is alive across repeated Retry-After waits).
-private final class EventLog: @unchecked Sendable {
-  private let lock = NSLock()
-  private var events: [String] = []
-  func append(_ event: String) { lock.withLock { events.append(event) } }
-  var all: [String] { lock.withLock { events } }
 }

--- a/Tests/EnviousWisprTests/ModelDelivery/ManifestFetchTaskTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ManifestFetchTaskTests.swift
@@ -1,7 +1,9 @@
+import EnviousWisprASR
 import Foundation
 import Testing
 
 @testable import EnviousWisprModelDelivery
+@testable import EnviousWisprPipeline
 
 // MARK: - URLProtocol stub (transport-semantics tests)
 
@@ -12,6 +14,24 @@ final class DeliveryStubProtocol: URLProtocol {
     let status: Int
     let headers: [String: String]
     let body: Data
+    /// Phase 2 (#1405): script a transport-level failure (e.g. a timeout) so
+    /// same-source retry can be exercised. When set, the stub fails instead of
+    /// responding.
+    var error: URLError?
+    /// Phase 2 (#1371): after sending the response + body, leave the request
+    /// in-flight (never finish) so an in-flight-download cancel can be exercised.
+    var hangAfterBody: Bool
+
+    init(
+      status: Int, headers: [String: String], body: Data, error: URLError? = nil,
+      hangAfterBody: Bool = false
+    ) {
+      self.status = status
+      self.headers = headers
+      self.body = body
+      self.error = error
+      self.hangAfterBody = hangAfterBody
+    }
   }
 
   nonisolated(unsafe) static var stubs: [String: [Stub]] = [:]
@@ -36,6 +56,10 @@ final class DeliveryStubProtocol: URLProtocol {
   override class func canInit(with request: URLRequest) -> Bool { true }
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
+  /// Guards against a double-completion when `stopLoading()` fires on an
+  /// already-completed request (normal finish or scripted failure).
+  private var didComplete = false
+
   override func startLoading() {
     Self.lock.lock()
     if let range = request.value(forHTTPHeaderField: "Range") {
@@ -45,7 +69,13 @@ final class DeliveryStubProtocol: URLProtocol {
     let stub = Self.stubs[key]?.isEmpty == false ? Self.stubs[key]!.removeFirst() : nil
     Self.lock.unlock()
     guard let stub else {
+      didComplete = true
       client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+      return
+    }
+    if let error = stub.error {
+      didComplete = true
+      client?.urlProtocol(self, didFailWithError: error)
       return
     }
     let response = HTTPURLResponse(
@@ -55,10 +85,21 @@ final class DeliveryStubProtocol: URLProtocol {
     if !stub.body.isEmpty {
       client?.urlProtocol(self, didLoad: stub.body)
     }
+    if stub.hangAfterBody {
+      return  // leave the request in-flight; stopLoading() completes it on cancel
+    }
+    didComplete = true
     client?.urlProtocolDidFinishLoading(self)
   }
 
-  override func stopLoading() {}
+  override func stopLoading() {
+    // A hung request that is now being cancelled must complete, or the caller's
+    // cancel drain barrier waits forever (#1371 test).
+    if !didComplete {
+      didComplete = true
+      client?.urlProtocol(self, didFailWithError: URLError(.cancelled))
+    }
+  }
 }
 
 /// Transport semantics of the generalized delegate + per-file fetch loop:
@@ -83,12 +124,16 @@ final class DeliveryStubProtocol: URLProtocol {
   }
 
   private func task(
-    manifest: DeliveryManifest, staging: URL, components: Set<String>? = nil
+    manifest: DeliveryManifest, staging: URL, components: Set<String>? = nil,
+    backoffSleep: @escaping @Sendable (TimeInterval) async throws -> Void = { _ in },
+    jitter: @escaping @Sendable () -> Double = { 1.0 },
+    onFailover: @escaping @Sendable (DeliveryFailureClass) -> Void = { _ in }
   ) -> ManifestFetchTask {
     ManifestFetchTask(
       manifest: manifest, stagingDirectory: staging, sources: manifest.sources,
       componentsToFetch: components ?? Set(manifest.files.map(\.component)),
-      verifiedInPlaceBytes: 0, onProgress: { _, _ in }, onSourceFailover: { _ in })
+      verifiedInPlaceBytes: 0, onProgress: { _, _ in }, onSourceFailover: onFailover,
+      backoffSleep: backoffSleep, jitterFraction: jitter)
   }
 
   @Test func happyPathFetchesVerifiesAllFiles() async throws {
@@ -345,6 +390,26 @@ final class DeliveryStubProtocol: URLProtocol {
     #expect(classify(NSError(domain: "Custom", code: 1)) == .unknown)
   }
 
+  /// Phase 2 (#1405) retry-gate truth table (adversarial matcher-set rule): the
+  /// retryable partition must retry every transient code and NOT retry
+  /// genuine-offline / disk / permission / unknown.
+  @Test func transportRetryablePartition() {
+    func retryable(_ error: Error) -> Bool {
+      ManifestFetchTask.classifyTransportError(error, sourceID: nil).retryableTransient
+    }
+    // Retryable: timeout + transient-unreachable family.
+    #expect(retryable(URLError(.timedOut)) == true)
+    #expect(retryable(URLError(.networkConnectionLost)) == true)
+    #expect(retryable(URLError(.cannotConnectToHost)) == true)
+    #expect(retryable(URLError(.cannotFindHost)) == true)
+    #expect(retryable(URLError(.dnsLookupFailed)) == true)
+    // NOT retryable: genuinely offline (the critical boundary), disk, perm.
+    #expect(retryable(URLError(.notConnectedToInternet)) == false)
+    #expect(
+      retryable(NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError)) == false)
+    #expect(retryable(NSError(domain: "Custom", code: 1)) == false)
+  }
+
   @Test func httpStatusClassification() {
     #expect(ManifestFetchTask.classifyHTTPStatus(429) == .source5xx)  // throttle = retryable-ish
     #expect(ManifestFetchTask.classifyHTTPStatus(500) == .source5xx)
@@ -353,4 +418,362 @@ final class DeliveryStubProtocol: URLProtocol {
     #expect(ManifestFetchTask.classifyHTTPStatus(416) == .source4xx)
     #expect(ManifestFetchTask.classifyHTTPStatus(301) == .unknown)  // redirects are transport-level
   }
+
+  /// Phase 2 (#1405): HTTP-status failures stamp retryability + `Retry-After`.
+  @Test func httpStatusRetryabilityAndRetryAfter() {
+    func failure(_ status: Int, retryAfter: String? = nil) -> DeliveryFailure {
+      var headers: [String: String] = [:]
+      if let retryAfter { headers["Retry-After"] = retryAfter }
+      let response = HTTPURLResponse(
+        url: URL(string: "https://x.invalid")!, statusCode: status, httpVersion: nil,
+        headerFields: headers)!
+      return ManifestFetchTask.httpStatusFailure(
+        status: status, detail: "http_\(status)", response: response, sourceID: nil)
+    }
+    #expect(failure(503).retryableTransient == true)
+    #expect(failure(429).retryableTransient == true)
+    #expect(failure(500).retryableTransient == true)
+    #expect(failure(404).retryableTransient == false)
+    // 4xx never carries a Retry-After even if the header is present.
+    #expect(failure(404, retryAfter: "5").retryAfter == nil)
+    #expect(failure(503, retryAfter: "5").retryAfter == 5)
+  }
+
+  /// Phase 2 (#1405): `Retry-After` parsing — BOTH the delay-seconds and the
+  /// HTTP-date forms (RFC 9110 §10.2.3).
+  @Test func retryAfterParsesBothForms() {
+    func parse(_ value: String) -> TimeInterval? {
+      let response = HTTPURLResponse(
+        url: URL(string: "https://x.invalid")!, statusCode: 503, httpVersion: nil,
+        headerFields: ["Retry-After": value])!
+      return ManifestFetchTask.retryAfterSeconds(from: response)
+    }
+    #expect(parse("5") == 5)
+    #expect(parse("0") == 0)
+    #expect(parse("garbage") == nil)
+    #expect(parse("") == nil)
+    // HTTP-date ~100 s in the future parses to a positive, bounded delay.
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    let dateForm = parse(formatter.string(from: Date().addingTimeInterval(100)))
+    #expect(dateForm != nil)
+    if let dateForm { #expect(dateForm > 90 && dateForm <= 100) }
+  }
+
+  // MARK: Phase 2 (#1405) same-source retry — integration
+
+  private typealias FileSpec = (path: String, content: Data, component: String)
+
+  private func single() throws -> (DeliveryManifest, FileSpec, URL) {
+    let file = ManifestFixture.smallFiles[0]
+    return (try ManifestFixture.manifest(files: [file]), file, try makeStaging())
+  }
+  private func mirrorURL(_ file: FileSpec) -> String {
+    "https://mirror.invalid.example/base/\(file.path)"
+  }
+  private func backupURL(_ file: FileSpec) -> String {
+    "https://upstream.invalid.example/base/\(file.path)"
+  }
+  private func timeoutStub() -> DeliveryStubProtocol.Stub {
+    .init(status: 200, headers: [:], body: Data(), error: URLError(.timedOut))
+  }
+  private func okStub(_ file: FileSpec, status: Int = 200)
+    -> DeliveryStubProtocol.Stub
+  {
+    .init(
+      status: status, headers: ["Content-Length": String(file.content.count)], body: file.content)
+  }
+
+  /// (a) A transient timeout retries the SAME source (resume) and completes —
+  /// no failover.
+  @Test func retryThenSucceedsSameSourceNoFailover() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      DeliveryStubProtocol.enqueue(url: mirrorURL(file), timeoutStub())
+      DeliveryStubProtocol.enqueue(url: mirrorURL(file), okStub(file))
+      let failovers = FailoverBox()
+      let outcome = try await task(
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+      ).run()
+      #expect(outcome.sourcesUsed == 1)
+      #expect(outcome.finalSourceID == "our_copy")
+      #expect(failovers.all.isEmpty, "a transient timeout retries same-source, never fails over")
+    }
+  }
+
+  /// (b) N=4 attempts (1 + 3 retries) exhausted → fail over to backup once.
+  @Test func retriesExhaustedThenFailover() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      for _ in 0..<4 { DeliveryStubProtocol.enqueue(url: mirrorURL(file), timeoutStub()) }
+      DeliveryStubProtocol.enqueue(url: backupURL(file), okStub(file))
+      let failovers = FailoverBox()
+      let outcome = try await task(
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+      ).run()
+      #expect(outcome.sourcesUsed == 2)
+      #expect(outcome.finalSourceID == "backup")
+      #expect(failovers.all == [.sourceTimeout])
+    }
+  }
+
+  /// (b2) The retry budget is PER SOURCE: after the mirror exhausts its budget
+  /// and fails over, the backup gets its OWN retries (Codex r1 P2 regression).
+  @Test func backupGetsItsOwnRetryBudgetAfterFailover() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      for _ in 0..<4 { DeliveryStubProtocol.enqueue(url: mirrorURL(file), timeoutStub()) }
+      // Backup times out ONCE then succeeds — only possible if its budget reset.
+      DeliveryStubProtocol.enqueue(url: backupURL(file), timeoutStub())
+      DeliveryStubProtocol.enqueue(url: backupURL(file), okStub(file))
+      let failovers = FailoverBox()
+      let outcome = try await task(
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+      ).run()
+      #expect(outcome.sourcesUsed == 2)
+      #expect(outcome.finalSourceID == "backup")
+      #expect(
+        failovers.all == [.sourceTimeout], "one failover; the backup then retried on its own budget"
+      )
+    }
+  }
+
+  /// (c) A genuinely-offline error (-1009) fails over IMMEDIATELY — it must not
+  /// consume a same-source retry (the mirror's second stub stays untouched).
+  @Test func offlineFailsOverWithoutSameSourceRetry() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      DeliveryStubProtocol.enqueue(
+        url: mirrorURL(file),
+        .init(status: 200, headers: [:], body: Data(), error: URLError(.notConnectedToInternet)))
+      // If offline WRONGLY retried, this success would be consumed on the mirror.
+      DeliveryStubProtocol.enqueue(url: mirrorURL(file), okStub(file))
+      DeliveryStubProtocol.enqueue(url: backupURL(file), okStub(file))
+      let failovers = FailoverBox()
+      let outcome = try await task(
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+      ).run()
+      #expect(outcome.sourcesUsed == 2, "offline must fail over, not retry the mirror")
+      #expect(outcome.finalSourceID == "backup")
+      #expect(failovers.all == [.sourceUnreachable])
+    }
+  }
+
+  /// (e) Backoff is bounded by the full-jitter window `min(8, 2^n)`; jitter=1.0
+  /// yields exactly [1, 2, 4] for the three retries.
+  @Test func retryBackoffBoundedByFullJitterWindow() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      for _ in 0..<3 { DeliveryStubProtocol.enqueue(url: mirrorURL(file), timeoutStub()) }
+      DeliveryStubProtocol.enqueue(url: mirrorURL(file), okStub(file))
+      let delays = DelayBox()
+      let outcome = try await task(
+        manifest: manifest, staging: staging,
+        backoffSleep: { delays.record($0) }, jitter: { 1.0 }
+      ).run()
+      #expect(delays.all == [1, 2, 4])
+      #expect(outcome.sourcesUsed == 1)
+    }
+  }
+
+  /// (f) A cancel landing during the backoff sleep unwinds as `.cancelled` —
+  /// never a retry or failover.
+  @Test func cancelDuringBackoffUnwindsAsCancelled() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      DeliveryStubProtocol.enqueue(url: mirrorURL(file), timeoutStub())
+      let entered = TestSignal()
+      let sleepSeam: @Sendable (TimeInterval) async throws -> Void = { _ in
+        await entered.fire()
+        try await Task.sleep(nanoseconds: .max)  // settle: suspends until the run task is cancelled (cancel is the signal)
+      }
+      let fetch = task(manifest: manifest, staging: staging, backoffSleep: sleepSeam)
+      let runTask = Task { try await fetch.run() }
+      await entered.wait()
+      runTask.cancel()
+      do {
+        _ = try await runTask.value
+        Issue.record("expected cancellation to propagate")
+      } catch let failure as DeliveryFailure {
+        #expect(failure.reason == .cancelled)
+      } catch is CancellationError {
+        // Also an acceptable cancelled unwind.
+      }
+    }
+  }
+
+  /// (g) `Retry-After` (≤ cap) is honored OVER the computed backoff.
+  @Test func retryAfterHonoredOverComputedBackoff() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      DeliveryStubProtocol.enqueue(
+        url: mirrorURL(file),
+        .init(status: 503, headers: ["Retry-After": "5"], body: Data()))
+      DeliveryStubProtocol.enqueue(url: mirrorURL(file), okStub(file))
+      let delays = DelayBox()
+      let outcome = try await task(
+        manifest: manifest, staging: staging,
+        backoffSleep: { delays.record($0) }, jitter: { 1.0 }
+      ).run()
+      #expect(delays.all == [5], "server Retry-After overrides backoff(0)=1")
+      #expect(outcome.sourcesUsed == 1)
+    }
+  }
+
+  /// (h) The local-byte (416) retry and the network retry use INDEPENDENT
+  /// budgets: a 416-local retry plus a full network-retry budget (3) all resolve
+  /// on the SAME source. Shared budgets would fail over on the 3rd timeout.
+  @Test func localAndNetworkRetryBudgetsAreIndependent() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      // Seed a partial + matching identity so the first attempt resumes.
+      let stagedURL = staging.appendingPathComponent(file.path)
+      try FileManager.default.createDirectory(
+        at: stagedURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try file.content.prefix(7).write(to: stagedURL)
+      let identity = ["etag": "\"e\"", "contentLength": file.content.count] as [String: Any]
+      try JSONSerialization.data(withJSONObject: identity)
+        .write(to: URL(fileURLWithPath: stagedURL.path + ".resume.json"))
+
+      let url = mirrorURL(file)
+      // HEAD identity (200) → ranged GET 416 (local retry) → 3 timeouts (network
+      // retries) → success. All on the mirror.
+      DeliveryStubProtocol.enqueue(
+        url: url,
+        .init(
+          status: 200, headers: ["Content-Length": String(file.content.count), "ETag": "\"e\""],
+          body: Data()))
+      DeliveryStubProtocol.enqueue(url: url, .init(status: 416, headers: [:], body: Data()))
+      for _ in 0..<3 { DeliveryStubProtocol.enqueue(url: url, timeoutStub()) }
+      DeliveryStubProtocol.enqueue(url: url, okStub(file))
+      let failovers = FailoverBox()
+      let outcome = try await task(
+        manifest: manifest, staging: staging, onFailover: { failovers.record($0) }
+      ).run()
+      #expect(outcome.sourcesUsed == 1, "independent budgets keep it on one source")
+      #expect(failovers.all.isEmpty)
+    }
+  }
+
+  /// (i) A `Retry-After` LONGER than the wedge-floor cap fails over instead of
+  /// sitting in a silent wait (that would trip the stall guard).
+  @Test func longRetryAfterFailsOverInsteadOfWaiting() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      DeliveryStubProtocol.enqueue(
+        url: mirrorURL(file),
+        .init(status: 503, headers: ["Retry-After": "60"], body: Data()))
+      DeliveryStubProtocol.enqueue(url: backupURL(file), okStub(file))
+      let delays = DelayBox()
+      let outcome = try await task(
+        manifest: manifest, staging: staging, backoffSleep: { delays.record($0) },
+        onFailover: { _ in }
+      ).run()
+      #expect(delays.all.isEmpty, "a long Retry-After must not wait")
+      #expect(outcome.sourcesUsed == 2)
+      #expect(outcome.finalSourceID == "backup")
+    }
+  }
+
+  /// #1371: a warm-up wedge must cancel the IN-FLIGHT delivery download (not
+  /// just the ASR load), or a stalled/retrying fetch stays parked and the Retry
+  /// path never surfaces. Lives in THIS serialized suite (not the adapter's) so
+  /// it does not race the shared `DeliveryStubProtocol` global with the other
+  /// stub-driven tests. Real controller + handle; the download starts then hangs.
+  @MainActor
+  @Test func recoverFromWedgeCancelsInFlightDelivery() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("wedge-\(UUID().uuidString)", isDirectory: true)
+    let install = root.appendingPathComponent("install", isDirectory: true)
+    let metadata = root.appendingPathComponent("metadata", isDirectory: true)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+    let host = "https://wedge.invalid.example/\(UUID().uuidString)/"
+    let files = ManifestFixture.smallFiles
+    let manifest = try DeliveryManifest.load(
+      from: ManifestFixture.manifestJSON(
+        files: files,
+        sources: [["id": "our_copy", "baseURL": host], ["id": "backup", "baseURL": host]]))
+    let registration = DeliveryRegistration(
+      manifest: manifest, installDirectory: install, metadataDirectory: metadata)
+    let suite = "test.wedge.\(UUID().uuidString)"
+    let controller = ModelDeliveryController(
+      defaults: UserDefaults(suiteName: suite)!, availableDiskBytes: { _ in .max })
+    let handle = ParakeetDeliveryHandle(
+      controller: controller, registration: registration,
+      defaults: UserDefaults(suiteName: suite)!)
+    let adapter = ParakeetEngineAdapter(asrManager: StubParakeetASRManager(), delivery: handle)
+
+    DeliveryStubProtocol.reset()
+    ChunkAppendDelegate.protocolClassesForTesting = [DeliveryStubProtocol.self]
+    let firstURL = URL(string: host)!.appendingPathComponent(files[0].path).absoluteString
+    DeliveryStubProtocol.enqueue(
+      url: firstURL,
+      .init(
+        status: 200, headers: ["Content-Length": "9999999"], body: Data([1, 2, 3]),
+        hangAfterBody: true))
+
+    let inflight = WedgeSignal()
+    await controller.addStateObserver { _, state in
+      if case .downloading = state { Task { await inflight.fire() } }
+    }
+    let warm = Task { @MainActor in try? await adapter.warmUp() }
+    await inflight.wait()
+    await adapter.recoverFromWedge()
+    _ = await warm.value
+
+    let state = await controller.state(of: registration.manifest.identity)
+    guard case .cancelled = state else {
+      Issue.record("expected .cancelled after wedge recovery, got \(state)")
+      return
+    }
+  }
+}
+
+/// Minimal async signal for the #1371 in-flight-cancel test.
+private actor WedgeSignal {
+  private var fired = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+  func fire() {
+    fired = true
+    for waiter in waiters { waiter.resume() }
+    waiters = []
+  }
+  func wait() async {
+    if fired { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+}
+
+/// Minimal async signal for the cancel-during-backoff test.
+private actor TestSignal {
+  private var fired = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+  func fire() {
+    fired = true
+    for waiter in waiters { waiter.resume() }
+    waiters = []
+  }
+  func wait() async {
+    if fired { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+}
+
+/// Records source-failover reasons across the concurrent fetch.
+private final class FailoverBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var reasons: [DeliveryFailureClass] = []
+  func record(_ reason: DeliveryFailureClass) { lock.withLock { reasons.append(reason) } }
+  var all: [DeliveryFailureClass] { lock.withLock { reasons } }
+}
+
+/// Records the backoff delays the retry loop asked the (injected) sleep for.
+private final class DelayBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var delays: [TimeInterval] = []
+  func record(_ delay: TimeInterval) { lock.withLock { delays.append(delay) } }
+  var all: [TimeInterval] { lock.withLock { delays } }
 }

--- a/Tests/EnviousWisprTests/ModelDelivery/ManifestFetchTaskTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ManifestFetchTaskTests.swift
@@ -127,12 +127,13 @@ final class DeliveryStubProtocol: URLProtocol {
     manifest: DeliveryManifest, staging: URL, components: Set<String>? = nil,
     backoffSleep: @escaping @Sendable (TimeInterval) async throws -> Void = { _ in },
     jitter: @escaping @Sendable () -> Double = { 1.0 },
+    onProgress: @escaping @Sendable (Int64, Int64) -> Void = { _, _ in },
     onFailover: @escaping @Sendable (DeliveryFailureClass) -> Void = { _ in }
   ) -> ManifestFetchTask {
     ManifestFetchTask(
       manifest: manifest, stagingDirectory: staging, sources: manifest.sources,
       componentsToFetch: components ?? Set(manifest.files.map(\.component)),
-      verifiedInPlaceBytes: 0, onProgress: { _, _ in }, onSourceFailover: onFailover,
+      verifiedInPlaceBytes: 0, onProgress: onProgress, onSourceFailover: onFailover,
       backoffSleep: backoffSleep, jitterFraction: jitter)
   }
 
@@ -677,6 +678,42 @@ final class DeliveryStubProtocol: URLProtocol {
     }
   }
 
+  /// (j) PR #1410 P2: repeated `Retry-After` waits (each under the per-sleep
+  /// cap) must NOT accumulate uninterrupted progress-file silence past the 15 s
+  /// wedge floor. Each backoff wait is immediately preceded by a liveness tick
+  /// (`onProgress` re-emit) so the transfer-silence guard sees the download is
+  /// alive and never trips `recoverFromWedge()` mid-retry. Without the tick, two
+  /// `Retry-After: 5` waits would be one silent 10 s+ gap the guard reads as a
+  /// stall.
+  @Test func retryWaitsEmitLivenessTicksSoTheWedgeGuardSeesProgress() async throws {
+    let (manifest, file, staging) = try single()
+    try await withStubs {
+      // 503 (Retry-After 5) → 503 (Retry-After 5) → success, all same source.
+      DeliveryStubProtocol.enqueue(
+        url: mirrorURL(file),
+        .init(status: 503, headers: ["Retry-After": "5"], body: Data()))
+      DeliveryStubProtocol.enqueue(
+        url: mirrorURL(file),
+        .init(status: 503, headers: ["Retry-After": "5"], body: Data()))
+      DeliveryStubProtocol.enqueue(url: mirrorURL(file), okStub(file))
+      let log = EventLog()
+      let outcome = try await task(
+        manifest: manifest, staging: staging,
+        backoffSleep: { _ in log.append("sleep") },
+        onProgress: { _, _ in log.append("tick") }
+      ).run()
+      #expect(outcome.sourcesUsed == 1, "the retries resolve on the same source")
+      let events = log.all
+      let sleepIndices = events.indices.filter { events[$0] == "sleep" }
+      #expect(sleepIndices.count == 2, "two transient failures → two backoff waits")
+      for i in sleepIndices {
+        #expect(
+          i > 0 && events[i - 1] == "tick",
+          "every backoff wait is immediately preceded by a liveness tick")
+      }
+    }
+  }
+
   /// #1371: a warm-up wedge must cancel the IN-FLIGHT delivery download (not
   /// just the ASR load), or a stalled/retrying fetch stays parked and the Retry
   /// path never surfaces. Lives in THIS serialized suite (not the adapter's) so
@@ -709,11 +746,15 @@ final class DeliveryStubProtocol: URLProtocol {
     DeliveryStubProtocol.reset()
     ChunkAppendDelegate.protocolClassesForTesting = [DeliveryStubProtocol.self]
     let firstURL = URL(string: host)!.appendingPathComponent(files[0].path).absoluteString
+    // Real Content-Length + a PARTIAL body so the length gate ALLOWS the
+    // response and the transfer stays genuinely in-flight (a mismatched length
+    // would fast-fail before any hang, leaving the cancel to race retry churn
+    // instead of a real hung download — code-diff r1 P2).
     DeliveryStubProtocol.enqueue(
       url: firstURL,
       .init(
-        status: 200, headers: ["Content-Length": "9999999"], body: Data([1, 2, 3]),
-        hangAfterBody: true))
+        status: 200, headers: ["Content-Length": String(files[0].content.count)],
+        body: Data([1, 2, 3]), hangAfterBody: true))
 
     let inflight = WedgeSignal()
     await controller.addStateObserver { _, state in
@@ -776,4 +817,14 @@ private final class DelayBox: @unchecked Sendable {
   private var delays: [TimeInterval] = []
   func record(_ delay: TimeInterval) { lock.withLock { delays.append(delay) } }
   var all: [TimeInterval] { lock.withLock { delays } }
+}
+
+/// Ordered log of liveness-tick vs backoff-sleep events, used to prove a
+/// progress tick precedes every retry wait (PR #1410 P2: the wedge guard must
+/// see the download is alive across repeated Retry-After waits).
+private final class EventLog: @unchecked Sendable {
+  private let lock = NSLock()
+  private var events: [String] = []
+  func append(_ event: String) { lock.withLock { events.append(event) } }
+  var all: [String] { lock.withLock { events } }
 }


### PR DESCRIPTION
## What this does

Phase 2 of the model-delivery resilience work (#1405): make the first-run speech-model download recover on its own from a slow or stalled connection (the far-from-origin P0), instead of an external watchdog cancelling it.

**This PR pivoted mid-review** from a "liveness-tick" compensation approach to the root fix. The pivot and every number were validated by Codex grounded review (3 rounds → PROCEED-AS-PLANNED) and the diff by local Codex code-diff review (3 rounds → clean). Plan: `docs/feature-requests/issue-1405-2026-07-08-downloader-owns-stall.md`.

## Root cause (why the pivot)

The load-wedge guard (`LoadProgressWatcher`, born #445 for the model-LOAD await) was retrofitted by #1339 onto the download and #1371 wired its recovery to **cancel** the download — preempting the fetcher's own request idle timeout (`requestTimeout = 60s`) at 15s and fighting its legitimate retry/backoff/Retry-After waits. Every review P2 in the compensation approach was a shim for that fight.

## The fix (net deletion — no new timeout number)

- **The wedge guard stays parked during the download phase** (new `downloadOwnedPhases` on `LoadProgressWatcher`). It reverts to its #445 model-LOAD-only role; the fetcher's existing 60s idle timeout owns transfer-stall. Parking requires a FRESH signal (a stale progress file can't suppress the guard), resets the load slate once at the download→load boundary, and `.admitted` writes a "Loading…" phase so the guard resumes for the load.
- **Reverted #1371** (`delivery.cancel()` in `recoverFromWedge`) and deleted the now-dead handle seam.
- **Deleted the liveness tick + non-regression shim** and the Retry-After "below the wedge floor" rationale.
- **Kept** the proven 60s timeout, same-source retry, exponential backoff + jitter, Retry-After honoring, ordered failover, per-file resume, and the fast-path manifest repoint.

## Validation

- Codex grounded review (plan): 3 rounds → PROCEED-AS-PLANNED.
- Local Codex code-diff review: 3 rounds → clean ("no clear introduced bugs").
- Full logic suite: **2470 tests green** — including the watchdog stays parked through a 600s download, still fires on a real load wedge after, a stale progress file no longer suppresses it, `recoverFromWedge` LEAVES an in-flight download running, and every retry/failover/resume path.
- Heart-path dictation Live UAT: healthy (~2s, no everyday regression).
- **Live fault-proxy stall drill (the real German-user scenario):** froze a real first-run Parakeet download for 61s. The watchdog stayed **silent** the entire time (old 15s watchdog would have cancelled it); at ~60s the fetcher's own idle timeout fired → retried → **resumed and completed the ~483MB download from the same fast path** with no failover and no user action. `Model delivery admitted` at t≈61s, zero wedge fires.

## Accepted, documented

- P3 (telemetry): the transient-retry-then-resume path under-counts a failed attempt's staged bytes in the coarse `bytesDownloadedBucket`; never crosses a bucket boundary on the ~470MB model; documented at the site rather than adding per-attempt plumbing to the hot fetch path.

Part of #1405
Closes #1371