### PR TITLE
feat(audio): reinstate capture-backend bake-off slice 2b — candidate D (#1377)

### DIFF
--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -517,12 +517,18 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         preferredInputDeviceUID: preferredInputDeviceIDOverride,
         noiseSuppression: noiseSuppressionEnabled
       )
-      let existingIsEngine = existing is AVAudioEngineSource
-      let wantsEngine = decision.sourceType == .audioEngine
+      // Non-switch consumer of `CaptureSourceType` (#1377 §6 audit point) — a
+      // new candidate must be added here explicitly; the compiler cannot
+      // force this equality-style mapping the way it forces the `switch`
+      // below. `existingSourceType == decision.sourceType` (three-way, not a
+      // boolean) so a captureSession↔halDeviceInput mismatch is never
+      // silently read as a match, which a plain "is engine" boolean would do
+      // once a third candidate exists.
+      let existingSourceType = Self.sourceType(of: existing)
 
       // Check full config signature, not just source type.
       // Device/VP changes between recordings must trigger rebuild.
-      var configMatch = existingIsEngine == wantsEngine
+      var configMatch = existingSourceType == decision.sourceType
       if configMatch, let engineSource = existing as? AVAudioEngineSource {
         // Compare effective device selection: preferredInputDeviceIDOverride
         // takes priority, fall back to selectedInputDeviceUID when empty.
@@ -552,6 +558,15 @@ public final class AudioCaptureManager: AudioCaptureInterface {
           let normalize: (String?) -> String = { ($0?.isEmpty ?? true) ? "" : $0! }
           configMatch = normalize(captureSource.targetDeviceUID) == normalize(wantsTarget)
         }
+        // Candidate D (#1377 slice 2b): same stale-target trap as candidate A
+        // above — a warm HAL source from a forced trial must not be reused
+        // once the override clears (or changes device).
+        if configMatch, let halSource = existing as? HALDeviceInputSource {
+          let wantsTarget =
+            decision.reason == .forcedHALDeviceInput ? effectiveInputDeviceUID() : ""
+          let normalize: (String?) -> String = { ($0?.isEmpty ?? true) ? "" : $0! }
+          configMatch = normalize(halSource.targetDeviceUID) == normalize(wantsTarget)
+        }
       #endif
 
       if configMatch {
@@ -564,7 +579,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         // different sourceType; device change; a stale forced capture-session
         // target) are already caught by the `configMatch` checks above.
         adoptRouteDecision(decision, prior: priorRouteDecision)
-        Self.btRouteLog("Reusing warm \(wantsEngine ? "engine" : "capture session") source")
+        Self.btRouteLog("Reusing warm \(Self.backendLabel(for: decision.sourceType)) source")
         return existing
       }
       // Route changed (e.g., BT connected/disconnected) — synchronous teardown.
@@ -586,7 +601,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     )
     Task {
       await AppLogger.shared.log(
-        "Capture route: \(decision.reason.rawValue) → \(decision.sourceType == .captureSession ? "AVCaptureSession" : "AVAudioEngine"), VP=\(decision.vpAvailable)",
+        "Capture route: \(decision.reason.rawValue) → \(Self.backendLabel(for: decision.sourceType)), VP=\(decision.vpAvailable)",
         level: .info, category: "Audio"
       )
     }
@@ -624,10 +639,46 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         }
       #endif
       source = engineSource
+    case .halDeviceInput:
+      let halSource = HALDeviceInputSource()
+      #if DEBUG
+        // Candidate D (#1377 slice 2b, reinstated 2026-07-08): under a
+        // force-case, pin the AUHAL source to the user-selected device. Only
+        // ever reachable via `.forceHALDeviceInput` — `.automatic` never
+        // emits `.halDeviceInput`.
+        if decision.reason == .forcedHALDeviceInput {
+          halSource.targetDeviceUID = effectiveInputDeviceUID()
+        }
+      #endif
+      source = halSource
     }
 
     activeSource = source
     return source
+  }
+
+  /// Maps a concrete `any AudioInputSource` instance to its `CaptureSourceType`
+  /// tag. The non-switch consumer `resolveSource()` uses for warm-reuse
+  /// compatibility (#1377 §6 audit point) — a plain `is AVAudioEngineSource`
+  /// boolean silently treats every non-engine source as equivalent once a
+  /// third candidate exists, so this maps each concrete type explicitly.
+  private static func sourceType(of source: any AudioInputSource) -> CaptureSourceType? {
+    if source is AVAudioEngineSource { return .audioEngine }
+    if source is AVCaptureSessionSource { return .captureSession }
+    if source is HALDeviceInputSource { return .halDeviceInput }
+    return nil
+  }
+
+  /// Human-readable backend label for logging. Single authority so a new
+  /// candidate cannot be silently mislabeled by a stale two-way ternary
+  /// (#1377 §6 audit point — non-switch consumers compile silently on a new
+  /// enum case and must be audited, not trusted to the compiler).
+  private static func backendLabel(for sourceType: CaptureSourceType) -> String {
+    switch sourceType {
+    case .captureSession: return "AVCaptureSession"
+    case .audioEngine: return "AVAudioEngine"
+    case .halDeviceInput: return "HALDeviceInput"
+    }
   }
 
   #if DEBUG

--- a/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
+++ b/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
@@ -8,12 +8,19 @@ enum CaptureSourcePolicy: Sendable {
   case automatic
   case forceEngine
   case forceCaptureSession
+  /// #1377 slice 2b (reinstated 2026-07-08) — force-select candidate D
+  /// (`HALDeviceInputSource`) for the bake-off spike. `.automatic` never
+  /// emits this; unreachable outside the bench.
+  case forceHALDeviceInput
 }
 
 /// Which capture backend to use.
 public enum CaptureSourceType: Sendable {
   case audioEngine
   case captureSession
+  /// Dormant candidate D (#1377 slice 2b) — only reachable via
+  /// `.forceHALDeviceInput`.
+  case halDeviceInput
 }
 
 /// Machine-readable reason for the route decision. Used for telemetry.
@@ -26,6 +33,7 @@ public enum CaptureRouteReason: String, Sendable {
   case noBTUserSelectedDevice
   case forcedEngine
   case forcedCaptureSession
+  case forcedHALDeviceInput
   case fallbackToEngine
   case failedNoFallback
 }
@@ -47,6 +55,8 @@ extension CaptureRouteReason {
       return "audio_engine"
     case .forcedCaptureSession:
       return "capture_session"
+    case .forcedHALDeviceInput:
+      return "hal_device_input"
     case .failedNoFallback:
       return "failed"
     }
@@ -119,6 +129,14 @@ struct CaptureRouteResolver {
         sourceType: .captureSession,
         reason: .forcedCaptureSession,
         rationale: "Policy override: forced capture session",
+        vpAvailable: false,
+        fallbackAllowed: false
+      )
+    case .forceHALDeviceInput:
+      return CaptureRouteDecision(
+        sourceType: .halDeviceInput,
+        reason: .forcedHALDeviceInput,
+        rationale: "Policy override: forced HAL device input (#1377 candidate D spike)",
         vpAvailable: false,
         fallbackAllowed: false
       )
@@ -221,6 +239,7 @@ struct CaptureRouteResolver {
       switch raw {
       case "forceEngine": return .forceEngine
       case "forceCaptureSession": return .forceCaptureSession
+      case "forceHALDeviceInput": return .forceHALDeviceInput
       default: return nil
       }
     }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -350,17 +350,25 @@ final class HALDeviceInputSource: AudioInputSource {
       slotCount: Self.ringSlotCount, capacityPerSlot: Int(Self.maxFramesPerSlice))
     let stopped = HALStoppedFlag()
     let fwd = PreRollForwarder()
-    self.forwarder = fwd
     let consumerQueue = DispatchQueue(
       label: "com.enviouswispr.audio.hal-consumer", qos: .userInteractive)
     let context = HALRenderContext(
       audioUnit: unit, scratch: scratch, ring: ring, stopped: stopped,
       liveness: captureLiveness, forwarder: fwd, consumerQueue: consumerQueue)
-    self.renderContext = context
-    self.stoppedFlag = stopped
-
     let unmanaged = Unmanaged.passRetained(context)
-    self.unmanagedContext = unmanaged
+
+    // No `self.*` assignment above this line: every failure branch below must
+    // release `unmanaged` + deallocate `scratch` + dispose `unit` and leave
+    // `self` untouched (still a fresh, never-prepared instance) so a caller
+    // that retries `prepare()` or calls `teardownUnit()` never double-releases
+    // state this attempt never actually committed.
+    func failPrepare(_ source: String) -> Error {
+      unmanaged.release()
+      scratch[0].mData?.deallocate()
+      scratch.unsafeMutablePointer.deallocate()
+      AudioComponentInstanceDispose(unit)
+      return AudioError.formatCreationFailed(source: source)
+    }
 
     var callbackStruct = AURenderCallbackStruct(
       inputProc: halRenderProc,
@@ -370,16 +378,12 @@ final class HALDeviceInputSource: AudioInputSource {
       unit, kAudioOutputUnitProperty_SetInputCallback, kAudioUnitScope_Global, 0,
       &callbackStruct, UInt32(MemoryLayout<AURenderCallbackStruct>.size))
     guard status == noErr else {
-      unmanaged.release()
-      AudioComponentInstanceDispose(unit)
-      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.set_callback")
+      throw failPrepare("HALDeviceInputSource.prepare.set_callback")
     }
 
     status = AudioUnitInitialize(unit)
     guard status == noErr else {
-      unmanaged.release()
-      AudioComponentInstanceDispose(unit)
-      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.initialize")
+      throw failPrepare("HALDeviceInputSource.prepare.initialize")
     }
     onLifecycleSignal?("hal_configure_completed")
 
@@ -387,12 +391,16 @@ final class HALDeviceInputSource: AudioInputSource {
     status = AudioOutputUnitStart(unit)
     guard status == noErr else {
       AudioUnitUninitialize(unit)
-      unmanaged.release()
-      AudioComponentInstanceDispose(unit)
-      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.start")
+      throw failPrepare("HALDeviceInputSource.prepare.start")
     }
     onLifecycleSignal?("hal_start_completed")
 
+    // Committed — every fallible step succeeded, so this is the one place
+    // `self` state is assigned for this attempt.
+    self.forwarder = fwd
+    self.renderContext = context
+    self.stoppedFlag = stopped
+    self.unmanagedContext = unmanaged
     self.audioUnit = unit
     registerDeviceIsAliveListener(deviceID: deviceID)
 

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -78,15 +78,24 @@ private final class HALSampleRing: @unchecked Sendable {
     }
   }
 
-  /// Non-RT drain of one chunk. Called from the consumer queue only.
-  func pop() -> (samples: [Float], level: Float)? {
-    lock.withLockUnchecked { _ -> (samples: [Float], level: Float)? in
+  /// Non-RT drain of one chunk into a caller-owned, reused scratch buffer
+  /// (must be at least `capacityPerSlot` long). The lock's critical section
+  /// is a bounded memcpy only — same shape as `push()`'s. Building the final
+  /// `[Float]`/`AVAudioPCMBuffer` the caller actually needs happens AFTER
+  /// unlocking, in the caller. This lock is shared with the RT `push()`
+  /// side, so any allocation done while holding it could block the render
+  /// callback behind the consumer (Codex review r2 P2) — moving the
+  /// allocation out is what closes that.
+  func pop(into destination: inout [Float]) -> (count: Int, level: Float)? {
+    lock.withLockUnchecked { _ -> (count: Int, level: Float)? in
       guard occupied > 0 else { return nil }
       let slot = slots[readIdx]
-      let samples = Array(UnsafeBufferPointer(start: slot.storage, count: slot.count))
+      destination.withUnsafeMutableBufferPointer { dst in
+        dst.baseAddress!.update(from: slot.storage, count: slot.count)
+      }
       readIdx = (readIdx + 1) % slots.count
       occupied -= 1
-      return (samples, slot.level)
+      return (slot.count, slot.level)
     }
   }
 }
@@ -116,6 +125,11 @@ private final class HALRenderContext: @unchecked Sendable {
   /// watchdog closure via `wasReceived()` on `liveness` instead — kept here
   /// only so the consumer can skip the cross-thread mark after the first hit.
   var bufferSeenThisSession = false
+  /// Reused destination for `ring.pop(into:)` — sized once to `capacityFrames`
+  /// so the drain's bounded memcpy (shared lock with the RT `push()` side)
+  /// never allocates; the per-chunk `[Float]`/`AVAudioPCMBuffer` `forward()`
+  /// needs is built AFTER that copy returns, outside the lock.
+  private var popScratch: [Float]
 
   init(
     audioUnit: AudioUnit,
@@ -133,6 +147,7 @@ private final class HALRenderContext: @unchecked Sendable {
     self.stopped = stopped
     self.liveness = liveness
     self.forwarder = forwarder
+    self.popScratch = [Float](repeating: 0, count: capacityFrames)
   }
 
   /// Drain everything currently in the ring and forward through
@@ -140,10 +155,11 @@ private final class HALRenderContext: @unchecked Sendable {
   /// same per-chunk allocation shape `AVAudioEngineSource`'s tap handler and
   /// `AVCaptureSessionSource`'s delegate already use on their own callback
   /// queues — here it runs one hop off the true HAL IO thread instead of on
-  /// it, since this function is called from `consumerQueue`, never directly
-  /// from the render callback).
+  /// it, since this function is called from the dedicated consumer thread,
+  /// never directly from the render callback).
   func drainAndForward() {
-    while let (samples, level) = ring.pop() {
+    while let (count, level) = ring.pop(into: &popScratch) {
+      let samples = Array(popScratch.prefix(count))
       guard !bufferSeenThisSession else {
         forward(samples: samples, level: level)
         continue
@@ -700,27 +716,32 @@ private func halRenderProc(
   let context = Unmanaged<HALRenderContext>.fromOpaque(inRefCon).takeUnretainedValue()
   guard !context.stopped.isSet() else { return noErr }
 
-  // Reset to full capacity before every render — `AudioUnitRender` can shrink
-  // `mDataByteSize` to the actual bytes written, so a stale smaller value
-  // from a prior callback would otherwise silently persist (Codex review r1
-  // P1 context: never trust the buffer's byte size to still read "full").
-  let byteCapacity = context.capacityFrames * MemoryLayout<Float>.size
+  // Clamp BEFORE calling AudioUnitRender, not just after: if
+  // `kAudioUnitProperty_MaximumFramesPerSlice` was ignored or the hardware
+  // supplies more than `capacityFrames`, asking AudioUnitRender to write
+  // `inNumberFrames` into a buffer only `capacityFrames` long is a write-side
+  // overflow the post-render `min(...)` cannot undo (Codex review r2 P2 — the
+  // read-side clamp alone was insufficient). Never render more than the
+  // scratch buffer actually holds; a device that oversizes its slice loses
+  // the excess of that one callback rather than overflowing.
+  let clampedFrames = min(inNumberFrames, UInt32(context.capacityFrames))
+  let byteCapacity = Int(clampedFrames) * MemoryLayout<Float>.size
+  // Reset every render — `AudioUnitRender` can shrink `mDataByteSize` to the
+  // actual bytes written, so a stale smaller value from a prior callback
+  // would otherwise silently persist (Codex review r1 P1 context).
   context.scratch[0].mDataByteSize = UInt32(byteCapacity)
 
   let status = AudioUnitRender(
-    context.audioUnit, ioActionFlags, inTimeStamp, 1, inNumberFrames,
+    context.audioUnit, ioActionFlags, inTimeStamp, 1, clampedFrames,
     context.scratch.unsafeMutablePointer)
   guard status == noErr else { return status }
   guard !context.stopped.isSet() else { return noErr }
 
   guard let data = context.scratch[0].mData else { return noErr }
-  // Clamp to what the buffer can actually hold AND what AudioUnitRender
-  // reports it actually wrote — never trust `inNumberFrames` alone. A device
-  // slice larger than `kAudioUnitProperty_MaximumFramesPerSlice` (property
-  // set failed, or hardware ignored it) would otherwise read past the
-  // preallocated scratch buffer (Codex review r1 P1).
+  // Clamp again to what AudioUnitRender reports it actually wrote — never
+  // trust the requested frame count alone.
   let renderedFrames = Int(context.scratch[0].mDataByteSize) / MemoryLayout<Float>.size
-  let frameCount = min(Int(inNumberFrames), context.capacityFrames, renderedFrames)
+  let frameCount = min(Int(clampedFrames), renderedFrames)
   guard frameCount > 0 else { return noErr }
   let floatPtr = data.assumingMemoryBound(to: Float.self)
 

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -186,26 +186,32 @@ private final class HALRenderContext: @unchecked Sendable {
           channelData[0].update(from: src.baseAddress!, count: count)
         }
       }
-      guard !bufferSeenThisSession else {
-        forward(nativeBuffer: nativeBuffer)
-        continue
+      // Liveness marks only once `forward` has actually converted AND routed
+      // a buffer downstream — never on mere receipt of a native-rate chunk
+      // (cloud review P2). Marking on receipt would let a converter that
+      // silently fails on every call (e.g. an unexpected format edge case)
+      // permanently defeat the "no audio detected" stall watchdog, since
+      // `bufferSeenThisSession` only ever flips once per recording.
+      let routed = forward(nativeBuffer: nativeBuffer)
+      if routed, !bufferSeenThisSession {
+        liveness.markReceived()
+        bufferSeenThisSession = true
       }
-      liveness.markReceived()
-      bufferSeenThisSession = true
-      forward(nativeBuffer: nativeBuffer)
     }
   }
 
   /// Resample `nativeBuffer` (the device's real rate) to `targetFormat`
   /// (16kHz mono, what the pipeline expects) and forward the converted
-  /// samples — never the raw native-rate ones (cloud review P2).
-  private func forward(nativeBuffer: AVAudioPCMBuffer) {
+  /// samples — never the raw native-rate ones (cloud review P2). Returns
+  /// whether a converted buffer actually reached `forwarder.route`.
+  @discardableResult
+  private func forward(nativeBuffer: AVAudioPCMBuffer) -> Bool {
     let ratio = targetFormat.sampleRate / nativeFormat.sampleRate
     let outputFrameCount = AVAudioFrameCount(Double(nativeBuffer.frameLength) * ratio) + 1
     guard outputFrameCount > 0,
       let convertedBuffer = AVAudioPCMBuffer(
         pcmFormat: targetFormat, frameCapacity: outputFrameCount)
-    else { return }
+    else { return false }
 
     var error: NSError?
     nonisolated(unsafe) var inputConsumed = false
@@ -218,13 +224,14 @@ private final class HALRenderContext: @unchecked Sendable {
       outStatus.pointee = .haveData
       return nativeBuffer
     }
-    guard error == nil, convertedBuffer.frameLength > 0 else { return }
+    guard error == nil, convertedBuffer.frameLength > 0 else { return false }
 
     let level = AudioBufferProcessor.calculateRMS(convertedBuffer)
-    guard let channelData = convertedBuffer.floatChannelData else { return }
+    guard let channelData = convertedBuffer.floatChannelData else { return false }
     let frameCount = Int(convertedBuffer.frameLength)
     let samples = Array(UnsafeBufferPointer(start: channelData[0], count: frameCount))
     forwarder.route(samples: samples, level: level, buffer: convertedBuffer)
+    return true
   }
 
   func resetSession() {
@@ -849,8 +856,13 @@ private func halRenderProc(
   for i in 0..<frameCount { sum += floatPtr[i] * floatPtr[i] }
   let level = (sum / Float(frameCount)).squareRoot()
 
-  context.ring.push(floatPtr, count: frameCount, level: level)
-  context.semaphore.signal()
+  // Only wake the consumer when a chunk was actually enqueued — a dropped
+  // push (ring full, consumer lagging) has nothing for `drainAndForward` to
+  // do, so signaling anyway just spins the consumer thread on empty work
+  // (cloud review P2).
+  if context.ring.push(floatPtr, count: frameCount, level: level) {
+    context.semaphore.signal()
+  }
 
   return noErr
 }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -98,11 +98,20 @@ private final class HALSampleRing: @unchecked Sendable {
 private final class HALRenderContext: @unchecked Sendable {
   let audioUnit: AudioUnit
   let scratch: UnsafeMutableAudioBufferListPointer
+  /// Frame capacity `scratch` was allocated for. The render callback clamps
+  /// every read to this (never to the hardware-reported `inNumberFrames`
+  /// alone) — see the RT-safety comment on `halRenderProc` (Codex review r1
+  /// P1: a larger-than-configured slice must never read past the allocation).
+  let capacityFrames: Int
   let ring: HALSampleRing
   let stopped: HALStoppedFlag
   let liveness: HALCaptureLivenessFlag
   let forwarder: PreRollForwarder
-  let consumerQueue: DispatchQueue
+  /// Signaled once per rendered chunk; the dedicated consumer thread blocks
+  /// on this instead of the render callback dispatching work (Codex review r1
+  /// P2: `DispatchQueue.async` from the HAL IO thread can allocate/lock —
+  /// signaling a semaphore is the RT-safe wake primitive).
+  let semaphore = DispatchSemaphore(value: 0)
   /// Set once per session by the callback consumer; read by the MainActor
   /// watchdog closure via `wasReceived()` on `liveness` instead — kept here
   /// only so the consumer can skip the cross-thread mark after the first hit.
@@ -111,19 +120,19 @@ private final class HALRenderContext: @unchecked Sendable {
   init(
     audioUnit: AudioUnit,
     scratch: UnsafeMutableAudioBufferListPointer,
+    capacityFrames: Int,
     ring: HALSampleRing,
     stopped: HALStoppedFlag,
     liveness: HALCaptureLivenessFlag,
-    forwarder: PreRollForwarder,
-    consumerQueue: DispatchQueue
+    forwarder: PreRollForwarder
   ) {
     self.audioUnit = audioUnit
     self.scratch = scratch
+    self.capacityFrames = capacityFrames
     self.ring = ring
     self.stopped = stopped
     self.liveness = liveness
     self.forwarder = forwarder
-    self.consumerQueue = consumerQueue
   }
 
   /// Drain everything currently in the ring and forward through
@@ -179,11 +188,14 @@ private final class HALRenderContext: @unchecked Sendable {
 /// from the hardware's native format for us — no `AVAudioConverter` needed.
 ///
 /// RT-safety: the render callback (`halRenderProc`, true HAL IO thread) does
-/// `AudioUnitRender` into a preallocated scratch buffer, then a fixed-size
-/// memcpy into `HALSampleRing` (locked, bounded, no allocation) — see
-/// `keep-preroll-lock-minimal`. The heavier work (building an
-/// `AVAudioPCMBuffer`, calling `PreRollForwarder.route()`) happens on
-/// `consumerQueue`, one hop off the IO thread, mirroring where the other two
+/// `AudioUnitRender` into a preallocated scratch buffer (every read clamped to
+/// its actual capacity, never trusting `inNumberFrames` alone), then a
+/// fixed-size memcpy into `HALSampleRing` (locked, bounded, no allocation) —
+/// see `keep-preroll-lock-minimal`. It wakes a dedicated consumer thread via
+/// `DispatchSemaphore.signal()` (RT-safe; `DispatchQueue.async` is NOT — it
+/// can allocate/lock on the calling thread). The heavier work (building an
+/// `AVAudioPCMBuffer`, calling `PreRollForwarder.route()`) happens on that
+/// consumer thread, one hop off the IO thread, mirroring where the other two
 /// conformers already do that same per-chunk allocation (their tap/delegate
 /// callbacks, which are themselves not the literal IO thread).
 @MainActor
@@ -233,6 +245,10 @@ final class HALDeviceInputSource: AudioInputSource {
   private var deviceIsAliveListenerDeviceID: AudioDeviceID?
   private var deviceIsAliveListenerBlock: AudioObjectPropertyListenerBlock?
   private var forwarder: PreRollForwarder?
+  /// Dedicated thread draining `HALRenderContext.ring` off the HAL IO thread.
+  /// Retained only to keep it alive; its loop exits on its own once
+  /// `teardownUnit()` signals the semaphore after the stop flag is set.
+  private var consumerThread: Thread?
   private let captureLiveness = HALCaptureLivenessFlag()
   private var stoppedFlag: HALStoppedFlag?
   private var isRecovering = false
@@ -331,9 +347,19 @@ final class HALDeviceInputSource: AudioInputSource {
     }
 
     var maxFrames = Self.maxFramesPerSlice
-    AudioUnitSetProperty(
+    let maxFramesStatus = AudioUnitSetProperty(
       unit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0,
       &maxFrames, UInt32(MemoryLayout<UInt32>.size))
+    if maxFramesStatus != noErr {
+      // Non-fatal: the render callback clamps every read to the scratch
+      // buffer's actual capacity regardless, so a device that ignores this
+      // property still can't overrun — it just silently drops any frames
+      // beyond capacity per callback. Logged (not RT-path) so the bake-off
+      // evidence shows it happened.
+      AudioCaptureManager.btRouteLog(
+        "HALDeviceInputSource: kAudioUnitProperty_MaximumFramesPerSlice set failed (status=\(maxFramesStatus)) — render callback still clamps to scratch capacity"
+      )
+    }
 
     let scratch = AudioBufferList.allocate(maximumBuffers: 1)
     let scratchStorage = UnsafeMutableRawPointer.allocate(
@@ -350,11 +376,9 @@ final class HALDeviceInputSource: AudioInputSource {
       slotCount: Self.ringSlotCount, capacityPerSlot: Int(Self.maxFramesPerSlice))
     let stopped = HALStoppedFlag()
     let fwd = PreRollForwarder()
-    let consumerQueue = DispatchQueue(
-      label: "com.enviouswispr.audio.hal-consumer", qos: .userInteractive)
     let context = HALRenderContext(
-      audioUnit: unit, scratch: scratch, ring: ring, stopped: stopped,
-      liveness: captureLiveness, forwarder: fwd, consumerQueue: consumerQueue)
+      audioUnit: unit, scratch: scratch, capacityFrames: Int(Self.maxFramesPerSlice),
+      ring: ring, stopped: stopped, liveness: captureLiveness, forwarder: fwd)
     let unmanaged = Unmanaged.passRetained(context)
 
     // No `self.*` assignment above this line: every failure branch below must
@@ -402,6 +426,7 @@ final class HALDeviceInputSource: AudioInputSource {
     self.stoppedFlag = stopped
     self.unmanagedContext = unmanaged
     self.audioUnit = unit
+    self.consumerThread = Self.makeConsumerThread(context: context)
     registerDeviceIsAliveListener(deviceID: deviceID)
 
     #if DEBUG
@@ -541,10 +566,18 @@ final class HALDeviceInputSource: AudioInputSource {
     stoppedFlag?.set()
     removeDeviceIsAliveListener()
     if let unit = audioUnit {
+      // Synchronous per Apple docs — blocks until the IO thread has genuinely
+      // stopped calling the render callback, so nothing below can race a live
+      // `halRenderProc` invocation.
       AudioOutputUnitStop(unit)
       AudioUnitUninitialize(unit)
       AudioComponentInstanceDispose(unit)
     }
+    // Wake the consumer thread (blocked on the semaphore) so it observes
+    // `stoppedFlag` and exits its loop. No RT callback can signal again after
+    // `AudioOutputUnitStop` returned above, so this is the FINAL signal —
+    // the thread drains anything left, sees `stopped.isSet()`, and returns.
+    renderContext?.semaphore.signal()
     if let unmanagedContext {
       unmanagedContext.release()
     }
@@ -556,6 +589,7 @@ final class HALDeviceInputSource: AudioInputSource {
     renderContext = nil
     unmanagedContext = nil
     stoppedFlag = nil
+    consumerThread = nil
     #if DEBUG
       boundDeviceID = nil
       boundUID = nil
@@ -630,6 +664,26 @@ final class HALDeviceInputSource: AudioInputSource {
       "HALDeviceInputSource: device \(deviceID) went away — interrupting")
     onInterrupted?()
   }
+
+  /// A dedicated thread that blocks on `context.semaphore` and drains the
+  /// ring off the HAL IO thread. Signaling a semaphore (not
+  /// `DispatchQueue.async`) from the render callback is the RT-safe wake
+  /// primitive (Codex review r1 P2) — `async` enqueue can allocate/lock on
+  /// the calling (IO) thread. Exits on its own once `teardownUnit()` signals
+  /// after `stoppedFlag` is set — never joined, never needs to be.
+  nonisolated private static func makeConsumerThread(context: HALRenderContext) -> Thread {
+    let thread = Thread {
+      while true {
+        context.semaphore.wait()
+        context.drainAndForward()
+        if context.stopped.isSet() { break }
+      }
+    }
+    thread.name = "com.enviouswispr.audio.hal-consumer"
+    thread.qualityOfService = .userInteractive
+    thread.start()
+    return thread
+  }
 }
 
 /// The AUHAL render callback — runs on the real HAL IO thread. Must not
@@ -646,6 +700,13 @@ private func halRenderProc(
   let context = Unmanaged<HALRenderContext>.fromOpaque(inRefCon).takeUnretainedValue()
   guard !context.stopped.isSet() else { return noErr }
 
+  // Reset to full capacity before every render — `AudioUnitRender` can shrink
+  // `mDataByteSize` to the actual bytes written, so a stale smaller value
+  // from a prior callback would otherwise silently persist (Codex review r1
+  // P1 context: never trust the buffer's byte size to still read "full").
+  let byteCapacity = context.capacityFrames * MemoryLayout<Float>.size
+  context.scratch[0].mDataByteSize = UInt32(byteCapacity)
+
   let status = AudioUnitRender(
     context.audioUnit, ioActionFlags, inTimeStamp, 1, inNumberFrames,
     context.scratch.unsafeMutablePointer)
@@ -653,15 +714,22 @@ private func halRenderProc(
   guard !context.stopped.isSet() else { return noErr }
 
   guard let data = context.scratch[0].mData else { return noErr }
+  // Clamp to what the buffer can actually hold AND what AudioUnitRender
+  // reports it actually wrote — never trust `inNumberFrames` alone. A device
+  // slice larger than `kAudioUnitProperty_MaximumFramesPerSlice` (property
+  // set failed, or hardware ignored it) would otherwise read past the
+  // preallocated scratch buffer (Codex review r1 P1).
+  let renderedFrames = Int(context.scratch[0].mDataByteSize) / MemoryLayout<Float>.size
+  let frameCount = min(Int(inNumberFrames), context.capacityFrames, renderedFrames)
+  guard frameCount > 0 else { return noErr }
   let floatPtr = data.assumingMemoryBound(to: Float.self)
-  let frameCount = Int(inNumberFrames)
 
   var sum: Float = 0
   for i in 0..<frameCount { sum += floatPtr[i] * floatPtr[i] }
-  let level = frameCount > 0 ? (sum / Float(frameCount)).squareRoot() : 0
+  let level = (sum / Float(frameCount)).squareRoot()
 
   context.ring.push(floatPtr, count: frameCount, level: level)
-  context.consumerQueue.async { context.drainAndForward() }
+  context.semaphore.signal()
 
   return noErr
 }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -1,0 +1,659 @@
+@preconcurrency import AVFoundation
+import AudioToolbox
+import CoreAudio
+import EnviousWisprCore
+import os
+
+/// Cross-thread set-once latch for "did any buffer reach the delegate this
+/// session." Mirrors `AVCaptureSessionSource`'s `CaptureLivenessFlag` (a
+/// private type per file, so not shared directly).
+private final class HALCaptureLivenessFlag: Sendable {
+  private let _lock = OSAllocatedUnfairLock(initialState: false)
+  func markReceived() { _lock.withLock { $0 = true } }
+  func wasReceived() -> Bool { _lock.withLock { $0 } }
+  func reset() { _lock.withLock { $0 = false } }
+}
+
+/// Cross-thread stop latch the RT render callback checks before touching
+/// anything else. Set from teardown paths; the callback bails immediately.
+private final class HALStoppedFlag: Sendable {
+  private let _lock = OSAllocatedUnfairLock(initialState: false)
+  func set() { _lock.withLock { $0 = true } }
+  func isSet() -> Bool { _lock.withLock { $0 } }
+  func reset() { _lock.withLock { $0 = false } }
+}
+
+/// Fixed-capacity SPSC ring of pre-allocated raw sample chunks. The AUHAL
+/// render callback (the real HAL IO thread — a harder real-time context than
+/// the tap/delegate queues the other two conformers run on) pushes without
+/// allocating; a queue we own drains and hands chunks to `PreRollForwarder`
+/// off the IO thread. The locked region is a fixed-size memcpy only, matching
+/// `keep-preroll-lock-minimal`. A lagging consumer drops the newest chunk
+/// (ring full) rather than blocking the IO thread — matches the RT contract:
+/// no allocation, no blocking, ever.
+private final class HALSampleRing: @unchecked Sendable {
+  private struct Slot {
+    let storage: UnsafeMutablePointer<Float>
+    var count: Int = 0
+    var level: Float = 0
+  }
+
+  private var slots: [Slot]
+  private let capacityPerSlot: Int
+  private var writeIdx = 0
+  private var readIdx = 0
+  private var occupied = 0
+  private let lock = OSAllocatedUnfairLock(initialState: ())
+
+  init(slotCount: Int, capacityPerSlot: Int) {
+    self.capacityPerSlot = capacityPerSlot
+    self.slots = (0..<slotCount).map { _ in
+      Slot(storage: .allocate(capacity: capacityPerSlot))
+    }
+  }
+
+  deinit {
+    for slot in slots { slot.storage.deallocate() }
+  }
+
+  /// RT-safe push. Called from the HAL IO thread inside the render callback.
+  /// Returns false (dropped chunk) if the ring is full — never blocks.
+  ///
+  /// `withLockUnchecked` (not `withLock`) because the body captures
+  /// `UnsafePointer<Float>`, which is not `Sendable`; safety here comes from
+  /// the lock itself serializing the one RT producer against the one
+  /// non-RT consumer, not from the compiler's Sendable check.
+  @discardableResult
+  func push(_ data: UnsafePointer<Float>, count: Int, level: Float) -> Bool {
+    let n = min(count, capacityPerSlot)
+    guard n > 0 else { return false }
+    return lock.withLockUnchecked { _ in
+      guard occupied < slots.count else { return false }
+      slots[writeIdx].storage.update(from: data, count: n)
+      slots[writeIdx].count = n
+      slots[writeIdx].level = level
+      writeIdx = (writeIdx + 1) % slots.count
+      occupied += 1
+      return true
+    }
+  }
+
+  /// Non-RT drain of one chunk. Called from the consumer queue only.
+  func pop() -> (samples: [Float], level: Float)? {
+    lock.withLockUnchecked { _ -> (samples: [Float], level: Float)? in
+      guard occupied > 0 else { return nil }
+      let slot = slots[readIdx]
+      let samples = Array(UnsafeBufferPointer(start: slot.storage, count: slot.count))
+      readIdx = (readIdx + 1) % slots.count
+      occupied -= 1
+      return (samples, slot.level)
+    }
+  }
+}
+
+/// The RT-callback-reachable context, passed by raw pointer via `Unmanaged`
+/// (an `AURenderCallback` is `@convention(c)` and cannot capture Swift state).
+/// Holds only what the render callback and its off-IO-thread consumer need;
+/// deliberately NOT `@MainActor` so neither hop requires actor isolation.
+private final class HALRenderContext: @unchecked Sendable {
+  let audioUnit: AudioUnit
+  let scratch: UnsafeMutableAudioBufferListPointer
+  let ring: HALSampleRing
+  let stopped: HALStoppedFlag
+  let liveness: HALCaptureLivenessFlag
+  let forwarder: PreRollForwarder
+  let consumerQueue: DispatchQueue
+  /// Set once per session by the callback consumer; read by the MainActor
+  /// watchdog closure via `wasReceived()` on `liveness` instead — kept here
+  /// only so the consumer can skip the cross-thread mark after the first hit.
+  var bufferSeenThisSession = false
+
+  init(
+    audioUnit: AudioUnit,
+    scratch: UnsafeMutableAudioBufferListPointer,
+    ring: HALSampleRing,
+    stopped: HALStoppedFlag,
+    liveness: HALCaptureLivenessFlag,
+    forwarder: PreRollForwarder,
+    consumerQueue: DispatchQueue
+  ) {
+    self.audioUnit = audioUnit
+    self.scratch = scratch
+    self.ring = ring
+    self.stopped = stopped
+    self.liveness = liveness
+    self.forwarder = forwarder
+    self.consumerQueue = consumerQueue
+  }
+
+  /// Drain everything currently in the ring and forward through
+  /// `PreRollForwarder`, reconstructing an `AVAudioPCMBuffer` per chunk (the
+  /// same per-chunk allocation shape `AVAudioEngineSource`'s tap handler and
+  /// `AVCaptureSessionSource`'s delegate already use on their own callback
+  /// queues — here it runs one hop off the true HAL IO thread instead of on
+  /// it, since this function is called from `consumerQueue`, never directly
+  /// from the render callback).
+  func drainAndForward() {
+    while let (samples, level) = ring.pop() {
+      guard !bufferSeenThisSession else {
+        forward(samples: samples, level: level)
+        continue
+      }
+      liveness.markReceived()
+      bufferSeenThisSession = true
+      forward(samples: samples, level: level)
+    }
+  }
+
+  private func forward(samples: [Float], level: Float) {
+    guard
+      let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false),
+      let buffer = AVAudioPCMBuffer(
+        pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))
+    else { return }
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    if let channelData = buffer.floatChannelData {
+      samples.withUnsafeBufferPointer { src in
+        channelData[0].update(from: src.baseAddress!, count: samples.count)
+      }
+    }
+    forwarder.route(samples: samples, level: level, buffer: buffer)
+  }
+
+  func resetSession() {
+    bufferSeenThisSession = false
+  }
+}
+
+/// AUHAL (`kAudioUnitSubType_HALOutput`) input-only audio capture source —
+/// #1377 candidate D, reinstated 2026-07-08 to spike against candidate A
+/// (`AVCaptureSessionSource`) on real Bluetooth hardware. Opens ANY device
+/// directly by `AudioDeviceID` (built-in, wired, or Bluetooth) via
+/// `kAudioOutputUnitProperty_CurrentDevice` — no `AVCaptureSession` /
+/// `AVAudioEngine` aggregate-device layer, so there is no
+/// `CADefaultDeviceAggregate` for the force-built-in crash-dodge to avoid.
+///
+/// Format conversion is done BY AUHAL: setting the client (output-scope,
+/// element 1) stream format to 16kHz mono Float32 makes CoreAudio resample
+/// from the hardware's native format for us — no `AVAudioConverter` needed.
+///
+/// RT-safety: the render callback (`halRenderProc`, true HAL IO thread) does
+/// `AudioUnitRender` into a preallocated scratch buffer, then a fixed-size
+/// memcpy into `HALSampleRing` (locked, bounded, no allocation) — see
+/// `keep-preroll-lock-minimal`. The heavier work (building an
+/// `AVAudioPCMBuffer`, calling `PreRollForwarder.route()`) happens on
+/// `consumerQueue`, one hop off the IO thread, mirroring where the other two
+/// conformers already do that same per-chunk allocation (their tap/delegate
+/// callbacks, which are themselves not the literal IO thread).
+@MainActor
+final class HALDeviceInputSource: AudioInputSource {
+
+  // MARK: - AudioInputSource callbacks
+
+  var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onInterrupted: (() -> Void)?
+  var onLifecycleSignal: (@Sendable (String) -> Void)?
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  /// No `AVCaptureSession` layer — stays nil, matching `AVAudioEngineSource`.
+  var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
+  private(set) var captureGeneration: UInt64 = 0
+
+  nonisolated let captureSourceType: String = "hal_device_input"
+
+  private static let stallQueue = DispatchQueue(
+    label: "com.enviouswispr.audio.capture-stall.hal"
+  )
+  private var stallWorkItem: DispatchWorkItem?
+
+  // MARK: - State
+
+  private(set) var isCapturing = false
+  var isRunning: Bool {
+    guard let audioUnit else { return false }
+    var running: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    let status = AudioUnitGetProperty(
+      audioUnit, kAudioOutputUnitProperty_IsRunning, kAudioUnitScope_Global, 0, &running, &size)
+    return status == noErr && running != 0
+  }
+
+  /// Target capture device UID. Nil = built-in mic, same default-nil contract
+  /// as `AVCaptureSessionSource.targetDeviceUID` (#1377 candidate A). Only
+  /// ever set under `CaptureSourcePolicy.forceHALDeviceInput`; `.automatic`
+  /// never emits this candidate, so it is unreachable outside the bake-off.
+  var targetDeviceUID: String?
+
+  // MARK: - Private state
+
+  private var audioUnit: AudioUnit?
+  private var renderContext: HALRenderContext?
+  private var unmanagedContext: Unmanaged<HALRenderContext>?
+  private var deviceIsAliveListenerDeviceID: AudioDeviceID?
+  private var deviceIsAliveListenerBlock: AudioObjectPropertyListenerBlock?
+  private var forwarder: PreRollForwarder?
+  private let captureLiveness = HALCaptureLivenessFlag()
+  private var stoppedFlag: HALStoppedFlag?
+  private var isRecovering = false
+
+  #if DEBUG
+    private var boundDeviceID: AudioDeviceID?
+    private var boundUID: String?
+    private var lastBindOK = true
+  #endif
+
+  private static let listenerQueue = DispatchQueue(
+    label: "com.enviouswispr.audio.hal-device-listener"
+  )
+
+  private static let targetFormat = AVAudioFormat(
+    commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false
+  )!
+
+  /// Frames per slice AUHAL is configured for; bounds the scratch buffer.
+  private static let maxFramesPerSlice: UInt32 = 4096
+  private static let ringSlotCount = 16
+
+  // MARK: - Lifecycle
+
+  func prepare() async throws {
+    guard audioUnit == nil else {
+      onLifecycleSignal?("hal_prepare_already_running")
+      return
+    }
+
+    onLifecycleSignal?("hal_find_device_entered")
+    let deviceID = resolveDeviceID()
+    guard let deviceID else { throw AudioError.noBuiltInMicrophoneFound }
+    onLifecycleSignal?("hal_find_device_completed")
+
+    onLifecycleSignal?("hal_configure_entered")
+    var desc = AudioComponentDescription(
+      componentType: kAudioUnitType_Output,
+      componentSubType: kAudioUnitSubType_HALOutput,
+      componentManufacturer: kAudioUnitManufacturer_Apple,
+      componentFlags: 0,
+      componentFlagsMask: 0
+    )
+    guard let component = AudioComponentFindNext(nil, &desc) else {
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.find_component")
+    }
+
+    var unit: AudioUnit?
+    var status = AudioComponentInstanceNew(component, &unit)
+    guard status == noErr, let unit else {
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.instance_new")
+    }
+
+    // Enable input on element 1, disable output on element 0 — input-only.
+    var enableIO: UInt32 = 1
+    status = AudioUnitSetProperty(
+      unit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1,
+      &enableIO, UInt32(MemoryLayout<UInt32>.size))
+    guard status == noErr else {
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.enable_input")
+    }
+    var disableIO: UInt32 = 0
+    status = AudioUnitSetProperty(
+      unit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, 0,
+      &disableIO, UInt32(MemoryLayout<UInt32>.size))
+    guard status == noErr else {
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.disable_output")
+    }
+
+    // Pin the device — this is the whole point: any device, no aggregate.
+    var pinnedDevice = deviceID
+    status = AudioUnitSetProperty(
+      unit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0,
+      &pinnedDevice, UInt32(MemoryLayout<AudioDeviceID>.size))
+    let bindOK = status == noErr
+    #if DEBUG
+      lastBindOK = bindOK
+    #endif
+    guard bindOK else {
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.set_device")
+    }
+
+    // Client format on the input element's OUTPUT scope — what our render
+    // callback receives. AUHAL resamples the hardware's native format to
+    // this for us.
+    var clientFormat = Self.targetFormat.streamDescription.pointee
+    status = AudioUnitSetProperty(
+      unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1,
+      &clientFormat, UInt32(MemoryLayout<AudioStreamBasicDescription>.size))
+    guard status == noErr else {
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.stream_format")
+    }
+
+    var maxFrames = Self.maxFramesPerSlice
+    AudioUnitSetProperty(
+      unit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0,
+      &maxFrames, UInt32(MemoryLayout<UInt32>.size))
+
+    let scratch = AudioBufferList.allocate(maximumBuffers: 1)
+    let scratchStorage = UnsafeMutableRawPointer.allocate(
+      byteCount: Int(Self.maxFramesPerSlice) * MemoryLayout<Float>.size,
+      alignment: MemoryLayout<Float>.alignment
+    )
+    scratch[0] = AudioBuffer(
+      mNumberChannels: 1,
+      mDataByteSize: Self.maxFramesPerSlice * UInt32(MemoryLayout<Float>.size),
+      mData: scratchStorage
+    )
+
+    let ring = HALSampleRing(
+      slotCount: Self.ringSlotCount, capacityPerSlot: Int(Self.maxFramesPerSlice))
+    let stopped = HALStoppedFlag()
+    let fwd = PreRollForwarder()
+    self.forwarder = fwd
+    let consumerQueue = DispatchQueue(
+      label: "com.enviouswispr.audio.hal-consumer", qos: .userInteractive)
+    let context = HALRenderContext(
+      audioUnit: unit, scratch: scratch, ring: ring, stopped: stopped,
+      liveness: captureLiveness, forwarder: fwd, consumerQueue: consumerQueue)
+    self.renderContext = context
+    self.stoppedFlag = stopped
+
+    let unmanaged = Unmanaged.passRetained(context)
+    self.unmanagedContext = unmanaged
+
+    var callbackStruct = AURenderCallbackStruct(
+      inputProc: halRenderProc,
+      inputProcRefCon: unmanaged.toOpaque()
+    )
+    status = AudioUnitSetProperty(
+      unit, kAudioOutputUnitProperty_SetInputCallback, kAudioUnitScope_Global, 0,
+      &callbackStruct, UInt32(MemoryLayout<AURenderCallbackStruct>.size))
+    guard status == noErr else {
+      unmanaged.release()
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.set_callback")
+    }
+
+    status = AudioUnitInitialize(unit)
+    guard status == noErr else {
+      unmanaged.release()
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.initialize")
+    }
+    onLifecycleSignal?("hal_configure_completed")
+
+    onLifecycleSignal?("hal_start_entered")
+    status = AudioOutputUnitStart(unit)
+    guard status == noErr else {
+      AudioUnitUninitialize(unit)
+      unmanaged.release()
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.start")
+    }
+    onLifecycleSignal?("hal_start_completed")
+
+    self.audioUnit = unit
+    registerDeviceIsAliveListener(deviceID: deviceID)
+
+    #if DEBUG
+      boundDeviceID = deviceID
+      boundUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
+    #endif
+    AudioCaptureManager.btRouteLog(
+      "HALDeviceInputSource: prepared with device \(deviceID) (uid=\(AudioDeviceEnumerator.inputDeviceUID(for: deviceID) ?? "unknown"))"
+    )
+  }
+
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    guard !isCapturing else { throw AudioError.alreadyCapturing }
+    guard let fwd = forwarder else {
+      throw AudioError.formatCreationFailed(
+        source: "HALDeviceInputSource.startCapture.missing_forwarder")
+    }
+
+    let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
+      self.streamContinuation = continuation
+    }
+
+    _ = fwd.activate(
+      onSamples: self.onSamples,
+      onBuffer: self.onBufferCaptured,
+      continuation: self.streamContinuation,
+      logPrefix: "HALDeviceInputSource"
+    )
+
+    captureGeneration &+= 1
+    captureLiveness.reset()
+    renderContext?.resetSession()
+    armCaptureStallWatchdog()
+
+    isCapturing = true
+    #if DEBUG
+      logBenchCaptureEvidence()
+    #endif
+    return stream
+  }
+
+  private var streamContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+
+  #if DEBUG
+    /// Capture-side actual-bound-device evidence (#1377 §3.5), same shape as
+    /// the other two conformers so `capture_bakeoff.py` parses it unchanged.
+    private func logBenchCaptureEvidence() {
+      let boundTransport =
+        boundDeviceID.flatMap { AudioDeviceEnumerator.transportLabel(for: $0) } ?? "unknown"
+      AudioCaptureManager.btRouteLog(
+        "CAPTURE_EVIDENCE backend=hal_device_input boundUID=\(boundUID ?? "unknown") boundDeviceID=\(boundDeviceID.map(String.init) ?? "nil") boundTransport=\(boundTransport) bindOK=\(lastBindOK) requestedUID=\(targetDeviceUID ?? "built_in")"
+      )
+    }
+  #endif
+
+  private func armCaptureStallWatchdog() {
+    stallWorkItem?.cancel()
+    let armedSession = captureGeneration
+    let armedAtNs = DispatchTime.now().uptimeNanoseconds
+    let item = Self.makeStallWorkItem(
+      armedSession: armedSession, armedAtNs: armedAtNs, source: self)
+    stallWorkItem = item
+    Self.stallQueue.asyncAfter(
+      deadline: .now() + .milliseconds(TimingConstants.audioCaptureStallWindowMs), execute: item)
+  }
+
+  nonisolated private static func makeStallWorkItem(
+    armedSession: UInt64, armedAtNs: UInt64, source: HALDeviceInputSource
+  ) -> DispatchWorkItem {
+    return DispatchWorkItem { [weak source] in
+      Task { @MainActor [weak source] in
+        source?.captureStallWatchdogFired(armedSession: armedSession, armedAtNs: armedAtNs)
+      }
+    }
+  }
+
+  private func captureStallWatchdogFired(armedSession: UInt64, armedAtNs: UInt64) {
+    guard captureGeneration == armedSession else { return }
+    guard isCapturing else { return }
+    guard !captureLiveness.wasReceived() else { return }
+
+    let ctx = CaptureStallContext(
+      sessionID: armedSession,
+      armedAtUptimeNs: armedAtNs,
+      firedAtUptimeNs: DispatchTime.now().uptimeNanoseconds,
+      route: "hal_device_input",
+      sourceType: "hal_device_input",
+      engineStartedSuccessfully: isRunning,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: targetDeviceUID,
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+    )
+    onCaptureStalled?(ctx)
+  }
+
+  func deactivateCapture() {
+    stallWorkItem?.cancel()
+    stallWorkItem = nil
+    forwarder?.returnToPreRoll()
+    isCapturing = false
+    streamContinuation = nil
+    AudioCaptureManager.btRouteLog(
+      "HALDeviceInputSource deactivated — unit stays warm, pre-roll capturing")
+  }
+
+  func stop() async -> [Float] {
+    stallWorkItem?.cancel()
+    stallWorkItem = nil
+    forwarder?.stop()
+    forwarder = nil
+    isCapturing = false
+    streamContinuation = nil
+    teardownUnit()
+    // Source does not own samples — manager accumulates via onSamples callback.
+    return []
+  }
+
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
+    // AUHAL's client format is fixed at the property we set — CoreAudio does
+    // the SRC internally, so there is no format renegotiation to wait out.
+    return true
+  }
+
+  func abortPrepare() {
+    guard audioUnit != nil, !isCapturing else { return }
+    teardownUnit()
+  }
+
+  func rebuild() {
+    teardownUnit()
+  }
+
+  // MARK: - Private: teardown
+
+  private func teardownUnit() {
+    stoppedFlag?.set()
+    removeDeviceIsAliveListener()
+    if let unit = audioUnit {
+      AudioOutputUnitStop(unit)
+      AudioUnitUninitialize(unit)
+      AudioComponentInstanceDispose(unit)
+    }
+    if let unmanagedContext {
+      unmanagedContext.release()
+    }
+    if let context = renderContext {
+      context.scratch[0].mData?.deallocate()
+      context.scratch.unsafeMutablePointer.deallocate()
+    }
+    audioUnit = nil
+    renderContext = nil
+    unmanagedContext = nil
+    stoppedFlag = nil
+    #if DEBUG
+      boundDeviceID = nil
+      boundUID = nil
+    #endif
+  }
+
+  // MARK: - Private: device resolution
+
+  /// Resolve the pinned target device, falling back to built-in with the
+  /// SAME log-text fragment `AVCaptureSessionSource` uses ("not found —
+  /// falling back") so `capture_bakeoff.py`'s `FALLBACK_MARKER` catches it
+  /// unchanged for this candidate too.
+  private func resolveDeviceID() -> AudioDeviceID? {
+    if let uid = targetDeviceUID, !uid.isEmpty {
+      if let id = AudioDeviceEnumerator.deviceID(forUID: uid) { return id }
+      AudioCaptureManager.btRouteLog(
+        "HALDeviceInputSource: target device uid=\(uid) not found — falling back to built-in")
+    }
+    return AudioDeviceEnumerator.builtInMicrophoneDeviceID()
+  }
+
+  // MARK: - Private: disconnect handling
+
+  /// Mirrors `AVAudioEngineSource.handleEngineConfigurationChange`'s
+  /// `kAudioDevicePropertyDeviceIsAlive` check — device-vanished is engine-
+  /// independent per #1377 bake-off findings, so candidate D needs the same
+  /// detection. Fires `onInterrupted()`; the accumulated `capturedSamples`
+  /// salvage (manager-owned) is what actually saves the partial dictation.
+  private func registerDeviceIsAliveListener(deviceID: AudioDeviceID) {
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyDeviceIsAlive,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+      Task { @MainActor [weak self] in
+        self?.handleDeviceMayHaveVanished(deviceID: deviceID)
+      }
+    }
+    let status = AudioObjectAddPropertyListenerBlock(deviceID, &addr, Self.listenerQueue, block)
+    if status == noErr {
+      deviceIsAliveListenerDeviceID = deviceID
+      deviceIsAliveListenerBlock = block
+    }
+  }
+
+  private func removeDeviceIsAliveListener() {
+    guard let deviceID = deviceIsAliveListenerDeviceID, let block = deviceIsAliveListenerBlock
+    else { return }
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyDeviceIsAlive,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    AudioObjectRemovePropertyListenerBlock(deviceID, &addr, Self.listenerQueue, block)
+    deviceIsAliveListenerDeviceID = nil
+    deviceIsAliveListenerBlock = nil
+  }
+
+  private func handleDeviceMayHaveVanished(deviceID: AudioDeviceID) {
+    guard isCapturing, !isRecovering else { return }
+    var isAlive: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyDeviceIsAlive,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &isAlive)
+    guard isAlive == 0 else { return }
+    AudioCaptureManager.btRouteLog(
+      "HALDeviceInputSource: device \(deviceID) went away — interrupting")
+    onInterrupted?()
+  }
+}
+
+/// The AUHAL render callback — runs on the real HAL IO thread. Must not
+/// allocate, lock for long, or log. `inRefCon` is the `HALRenderContext`
+/// passed via `Unmanaged` from `prepare()`.
+private func halRenderProc(
+  inRefCon: UnsafeMutableRawPointer,
+  ioActionFlags: UnsafeMutablePointer<AudioUnitRenderActionFlags>,
+  inTimeStamp: UnsafePointer<AudioTimeStamp>,
+  inBusNumber: UInt32,
+  inNumberFrames: UInt32,
+  ioData: UnsafeMutablePointer<AudioBufferList>?
+) -> OSStatus {
+  let context = Unmanaged<HALRenderContext>.fromOpaque(inRefCon).takeUnretainedValue()
+  guard !context.stopped.isSet() else { return noErr }
+
+  let status = AudioUnitRender(
+    context.audioUnit, ioActionFlags, inTimeStamp, 1, inNumberFrames,
+    context.scratch.unsafeMutablePointer)
+  guard status == noErr else { return status }
+  guard !context.stopped.isSet() else { return noErr }
+
+  guard let data = context.scratch[0].mData else { return noErr }
+  let floatPtr = data.assumingMemoryBound(to: Float.self)
+  let frameCount = Int(inNumberFrames)
+
+  var sum: Float = 0
+  for i in 0..<frameCount { sum += floatPtr[i] * floatPtr[i] }
+  let level = frameCount > 0 ? (sum / Float(frameCount)).squareRoot() : 0
+
+  context.ring.push(floatPtr, count: frameCount, level: level)
+  context.consumerQueue.async { context.drainAndForward() }
+
+  return noErr
+}

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -116,6 +116,17 @@ private final class HALRenderContext: @unchecked Sendable {
   let stopped: HALStoppedFlag
   let liveness: HALCaptureLivenessFlag
   let forwarder: PreRollForwarder
+  /// The device's OWN native rate (mono Float32 non-interleaved) — what the
+  /// client format was set to, and what `ring` samples actually are. AUHAL
+  /// input does NOT resample (Apple QA1777: "does not provide sample rate
+  /// conversion" for input on macOS) — cloud review P2 caught the prior
+  /// version assuming a silent 16kHz resample that only happened to work
+  /// because the Bose's Bluetooth profile is already 16kHz natively.
+  let nativeFormat: AVAudioFormat
+  let targetFormat: AVAudioFormat
+  /// Resamples `nativeFormat` → `targetFormat` on the consumer thread —
+  /// mirrors `AVAudioEngineSource`'s own `AVAudioConverter` usage exactly.
+  let converter: AVAudioConverter
   /// Signaled once per rendered chunk; the dedicated consumer thread blocks
   /// on this instead of the render callback dispatching work (Codex review r1
   /// P2: `DispatchQueue.async` from the HAL IO thread can allocate/lock —
@@ -138,7 +149,10 @@ private final class HALRenderContext: @unchecked Sendable {
     ring: HALSampleRing,
     stopped: HALStoppedFlag,
     liveness: HALCaptureLivenessFlag,
-    forwarder: PreRollForwarder
+    forwarder: PreRollForwarder,
+    nativeFormat: AVAudioFormat,
+    targetFormat: AVAudioFormat,
+    converter: AVAudioConverter
   ) {
     self.audioUnit = audioUnit
     self.scratch = scratch
@@ -147,6 +161,9 @@ private final class HALRenderContext: @unchecked Sendable {
     self.stopped = stopped
     self.liveness = liveness
     self.forwarder = forwarder
+    self.nativeFormat = nativeFormat
+    self.targetFormat = targetFormat
+    self.converter = converter
     self.popScratch = [Float](repeating: 0, count: capacityFrames)
   }
 
@@ -158,32 +175,56 @@ private final class HALRenderContext: @unchecked Sendable {
   /// it, since this function is called from the dedicated consumer thread,
   /// never directly from the render callback).
   func drainAndForward() {
-    while let (count, level) = ring.pop(into: &popScratch) {
-      let samples = Array(popScratch.prefix(count))
+    while let (count, _) = ring.pop(into: &popScratch) {
+      guard
+        let nativeBuffer = AVAudioPCMBuffer(
+          pcmFormat: nativeFormat, frameCapacity: AVAudioFrameCount(count))
+      else { continue }
+      nativeBuffer.frameLength = AVAudioFrameCount(count)
+      if let channelData = nativeBuffer.floatChannelData {
+        popScratch.withUnsafeBufferPointer { src in
+          channelData[0].update(from: src.baseAddress!, count: count)
+        }
+      }
       guard !bufferSeenThisSession else {
-        forward(samples: samples, level: level)
+        forward(nativeBuffer: nativeBuffer)
         continue
       }
       liveness.markReceived()
       bufferSeenThisSession = true
-      forward(samples: samples, level: level)
+      forward(nativeBuffer: nativeBuffer)
     }
   }
 
-  private func forward(samples: [Float], level: Float) {
-    guard
-      let format = AVAudioFormat(
-        commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false),
-      let buffer = AVAudioPCMBuffer(
-        pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))
+  /// Resample `nativeBuffer` (the device's real rate) to `targetFormat`
+  /// (16kHz mono, what the pipeline expects) and forward the converted
+  /// samples — never the raw native-rate ones (cloud review P2).
+  private func forward(nativeBuffer: AVAudioPCMBuffer) {
+    let ratio = targetFormat.sampleRate / nativeFormat.sampleRate
+    let outputFrameCount = AVAudioFrameCount(Double(nativeBuffer.frameLength) * ratio) + 1
+    guard outputFrameCount > 0,
+      let convertedBuffer = AVAudioPCMBuffer(
+        pcmFormat: targetFormat, frameCapacity: outputFrameCount)
     else { return }
-    buffer.frameLength = AVAudioFrameCount(samples.count)
-    if let channelData = buffer.floatChannelData {
-      samples.withUnsafeBufferPointer { src in
-        channelData[0].update(from: src.baseAddress!, count: samples.count)
+
+    var error: NSError?
+    nonisolated(unsafe) var inputConsumed = false
+    converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
+      if inputConsumed {
+        outStatus.pointee = .noDataNow
+        return nil
       }
+      inputConsumed = true
+      outStatus.pointee = .haveData
+      return nativeBuffer
     }
-    forwarder.route(samples: samples, level: level, buffer: buffer)
+    guard error == nil, convertedBuffer.frameLength > 0 else { return }
+
+    let level = AudioBufferProcessor.calculateRMS(convertedBuffer)
+    guard let channelData = convertedBuffer.floatChannelData else { return }
+    let frameCount = Int(convertedBuffer.frameLength)
+    let samples = Array(UnsafeBufferPointer(start: channelData[0], count: frameCount))
+    forwarder.route(samples: samples, level: level, buffer: convertedBuffer)
   }
 
   func resetSession() {
@@ -199,9 +240,12 @@ private final class HALRenderContext: @unchecked Sendable {
 /// `AVAudioEngine` aggregate-device layer, so there is no
 /// `CADefaultDeviceAggregate` for the force-built-in crash-dodge to avoid.
 ///
-/// Format conversion is done BY AUHAL: setting the client (output-scope,
-/// element 1) stream format to 16kHz mono Float32 makes CoreAudio resample
-/// from the hardware's native format for us — no `AVAudioConverter` needed.
+/// Format conversion is done EXPLICITLY, not by AUHAL: AUHAL input does NOT
+/// resample (Apple QA1777 — "does not provide sample rate conversion" for
+/// input on macOS), so the client format is set to the hardware's own native
+/// rate (mono Float32), and an `AVAudioConverter` resamples to the pipeline's
+/// 16kHz on the consumer thread, mirroring `AVAudioEngineSource`'s own
+/// converter usage.
 ///
 /// RT-safety: the render callback (`halRenderProc`, true HAL IO thread) does
 /// `AudioUnitRender` into a preallocated scratch buffer (every read clamped to
@@ -350,10 +394,35 @@ final class HALDeviceInputSource: AudioInputSource {
       throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.set_device")
     }
 
+    // AUHAL input does NOT resample (Apple QA1777: "does not provide sample
+    // rate conversion" for input on macOS) — query the HARDWARE's actual
+    // native rate and set the client format to MATCH it (mono/Float32 is
+    // still safely convertible; sample RATE is not). Resampling to the
+    // pipeline's 16kHz happens explicitly via AVAudioConverter on the
+    // consumer thread (cloud review P2 on PR #1418 — the prior version
+    // assumed a silent resample that only worked by coincidence on the
+    // Bose, whose Bluetooth profile happens to already be 16kHz).
+    guard let nativeASBD = Self.queryNativeStreamFormat(deviceID: deviceID) else {
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(
+        source: "HALDeviceInputSource.prepare.query_native_format")
+    }
+    guard
+      let nativeFormat = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32, sampleRate: nativeASBD.mSampleRate, channels: 1,
+        interleaved: false)
+    else {
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.native_format")
+    }
+    guard let converter = AVAudioConverter(from: nativeFormat, to: Self.targetFormat) else {
+      AudioComponentInstanceDispose(unit)
+      throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.converter")
+    }
+
     // Client format on the input element's OUTPUT scope — what our render
-    // callback receives. AUHAL resamples the hardware's native format to
-    // this for us.
-    var clientFormat = Self.targetFormat.streamDescription.pointee
+    // callback receives, at the hardware's own rate.
+    var clientFormat = nativeFormat.streamDescription.pointee
     status = AudioUnitSetProperty(
       unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1,
       &clientFormat, UInt32(MemoryLayout<AudioStreamBasicDescription>.size))
@@ -362,7 +431,11 @@ final class HALDeviceInputSource: AudioInputSource {
       throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.stream_format")
     }
 
-    var maxFrames = Self.maxFramesPerSlice
+    // Scratch/ring capacity scales with the native rate — a fixed 4096-frame
+    // buffer sized for 16kHz would be too small at 44.1/48kHz. 300ms of
+    // headroom at whatever rate the hardware actually runs.
+    let capacityFrames = max(Int(Self.maxFramesPerSlice), Int(nativeFormat.sampleRate * 0.3))
+    var maxFrames = UInt32(capacityFrames)
     let maxFramesStatus = AudioUnitSetProperty(
       unit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0,
       &maxFrames, UInt32(MemoryLayout<UInt32>.size))
@@ -379,22 +452,22 @@ final class HALDeviceInputSource: AudioInputSource {
 
     let scratch = AudioBufferList.allocate(maximumBuffers: 1)
     let scratchStorage = UnsafeMutableRawPointer.allocate(
-      byteCount: Int(Self.maxFramesPerSlice) * MemoryLayout<Float>.size,
+      byteCount: capacityFrames * MemoryLayout<Float>.size,
       alignment: MemoryLayout<Float>.alignment
     )
     scratch[0] = AudioBuffer(
       mNumberChannels: 1,
-      mDataByteSize: Self.maxFramesPerSlice * UInt32(MemoryLayout<Float>.size),
+      mDataByteSize: UInt32(capacityFrames * MemoryLayout<Float>.size),
       mData: scratchStorage
     )
 
-    let ring = HALSampleRing(
-      slotCount: Self.ringSlotCount, capacityPerSlot: Int(Self.maxFramesPerSlice))
+    let ring = HALSampleRing(slotCount: Self.ringSlotCount, capacityPerSlot: capacityFrames)
     let stopped = HALStoppedFlag()
     let fwd = PreRollForwarder()
     let context = HALRenderContext(
-      audioUnit: unit, scratch: scratch, capacityFrames: Int(Self.maxFramesPerSlice),
-      ring: ring, stopped: stopped, liveness: captureLiveness, forwarder: fwd)
+      audioUnit: unit, scratch: scratch, capacityFrames: capacityFrames,
+      ring: ring, stopped: stopped, liveness: captureLiveness, forwarder: fwd,
+      nativeFormat: nativeFormat, targetFormat: Self.targetFormat, converter: converter)
     let unmanaged = Unmanaged.passRetained(context)
 
     // No `self.*` assignment above this line: every failure branch below must
@@ -627,6 +700,24 @@ final class HALDeviceInputSource: AudioInputSource {
         "HALDeviceInputSource: target device uid=\(uid) not found — falling back to built-in")
     }
     return AudioDeviceEnumerator.builtInMicrophoneDeviceID()
+  }
+
+  /// Read the device's OWN native stream format directly from the HAL device
+  /// object (`kAudioDevicePropertyStreamFormat`, input scope) — the ground
+  /// truth for what rate the hardware actually runs at, queried BEFORE we
+  /// overwrite the AudioUnit's client-side format with our own request.
+  private static func queryNativeStreamFormat(deviceID: AudioDeviceID)
+    -> AudioStreamBasicDescription?
+  {
+    var format = AudioStreamBasicDescription()
+    var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyStreamFormat,
+      mScope: kAudioDevicePropertyScopeInput,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &format)
+    return status == noErr ? format : nil
   }
 
   // MARK: - Private: disconnect handling

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -632,12 +632,10 @@ final class HALDeviceInputSource: AudioInputSource {
   }
 
   func stop() async -> [Float] {
-    stallWorkItem?.cancel()
-    stallWorkItem = nil
     forwarder?.stop()
     forwarder = nil
-    isCapturing = false
     streamContinuation = nil
+    // teardownUnit() cancels stallWorkItem and drops isCapturing.
     teardownUnit()
     // Source does not own samples — manager accumulates via onSamples callback.
     return []
@@ -661,6 +659,18 @@ final class HALDeviceInputSource: AudioInputSource {
   // MARK: - Private: teardown
 
   private func teardownUnit() {
+    // Single authority for "this unit is going away" — every caller (normal
+    // stop, abort, rebuild, AND device-vanish) must disarm the stall
+    // watchdog and drop `isCapturing`, mirroring
+    // `AVAudioEngineSource.emergencyTeardown()`'s same reset (its comment:
+    // "isCapturing flips false ... which guards a late-fired watchdog").
+    // Without this, a device-vanish mid-recording left the watchdog armed
+    // and `isCapturing` stuck true — a late-firing watchdog could fire
+    // `onCaptureStalled` after `onInterrupted` already handled the session,
+    // and a same-second retry would see `alreadyCapturing` (cloud review P2).
+    stallWorkItem?.cancel()
+    stallWorkItem = nil
+    isCapturing = false
     stoppedFlag?.set()
     removeDeviceIsAliveListener()
     if let unit = audioUnit {

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -448,10 +448,12 @@ final class HALDeviceInputSource: AudioInputSource {
     #if DEBUG
       boundDeviceID = deviceID
       boundUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
+      AudioCaptureManager.btRouteLog(
+        "HALDeviceInputSource: prepared with device \(deviceID) (uid=\(boundUID ?? "unknown"))"
+      )
+    #else
+      AudioCaptureManager.btRouteLog("HALDeviceInputSource: prepared with device \(deviceID)")
     #endif
-    AudioCaptureManager.btRouteLog(
-      "HALDeviceInputSource: prepared with device \(deviceID) (uid=\(AudioDeviceEnumerator.inputDeviceUID(for: deviceID) ?? "unknown"))"
-    )
   }
 
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
@@ -678,6 +680,13 @@ final class HALDeviceInputSource: AudioInputSource {
     guard isAlive == 0 else { return }
     AudioCaptureManager.btRouteLog(
       "HALDeviceInputSource: device \(deviceID) went away — interrupting")
+    // Tear down BEFORE firing onInterrupted (mirrors AVAudioEngineSource's
+    // emergencyTeardown-then-onInterrupted order). Without this, `isRunning`
+    // still reports true (we never called AudioOutputUnitStop), so the
+    // manager's warm-reuse check would try to resume capture on a HAL unit
+    // bound to a device that no longer exists on the NEXT recording instead
+    // of rebuilding fresh (cloud review P2).
+    teardownUnit()
     onInterrupted?()
   }
 

--- a/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
+++ b/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
@@ -96,19 +96,21 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
       }
     case .halDeviceInput:
       // Dormant candidate D (#1377 slice 2b) — only reachable via
-      // `.forceHALDeviceInput`, which pins the same effective device the
-      // engine path would (preferred override, else stored selection); mirror
-      // that resolution rather than hardcoding built-in, since D — unlike
-      // today's capture-session automatic path — targets the real pick.
+      // `.forceHALDeviceInput`. A resolvable pin reports its own transport
+      // (mirrors the pinned device HALDeviceInputSource actually opens). With
+      // NO pin (or a stale one), `HALDeviceInputSource.resolveDeviceID()`
+      // falls back to the literal built-in mic — same as
+      // `AVCaptureSessionSource`'s fallback, NOT "whatever the system default
+      // happens to be" the way `AVAudioEngineSource` falls back. Reporting
+      // the system-default transport here would be wrong whenever the
+      // default input isn't built-in (cloud review P2).
       let halUID =
         preferredInputDeviceIDOverride.isEmpty
         ? selectedInputDeviceUID : preferredInputDeviceIDOverride
       if !halUID.isEmpty, let label = AudioDeviceEnumerator.transportLabel(forUID: halUID) {
         effective = label
-      } else if let defaultID = AudioDeviceEnumerator.defaultInputDeviceID() {
-        effective = AudioDeviceEnumerator.transportLabel(for: defaultID) ?? "unknown"
       } else {
-        effective = "unknown"
+        effective = "built_in"
       }
     }
 

--- a/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
+++ b/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
@@ -94,6 +94,22 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
       } else {
         effective = "unknown"
       }
+    case .halDeviceInput:
+      // Dormant candidate D (#1377 slice 2b) — only reachable via
+      // `.forceHALDeviceInput`, which pins the same effective device the
+      // engine path would (preferred override, else stored selection); mirror
+      // that resolution rather than hardcoding built-in, since D — unlike
+      // today's capture-session automatic path — targets the real pick.
+      let halUID =
+        preferredInputDeviceIDOverride.isEmpty
+        ? selectedInputDeviceUID : preferredInputDeviceIDOverride
+      if !halUID.isEmpty, let label = AudioDeviceEnumerator.transportLabel(forUID: halUID) {
+        effective = label
+      } else if let defaultID = AudioDeviceEnumerator.defaultInputDeviceID() {
+        effective = AudioDeviceEnumerator.transportLabel(for: defaultID) ?? "unknown"
+      } else {
+        effective = "unknown"
+      }
     }
 
     let fallbackReason: String? =

--- a/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
@@ -29,12 +29,15 @@ struct AudioInputSourceConformanceFreezeTests {
   enum ConformerKind: String, CaseIterable, Sendable {
     case audioEngine
     case captureSession
+    /// Candidate D (#1377 slice 2b, reinstated 2026-07-08).
+    case halDeviceInput
   }
 
   private func make(_ kind: ConformerKind) -> any AudioInputSource {
     switch kind {
     case .audioEngine: return AVAudioEngineSource()
     case .captureSession: return AVCaptureSessionSource()
+    case .halDeviceInput: return HALDeviceInputSource()
     }
   }
 
@@ -44,6 +47,7 @@ struct AudioInputSourceConformanceFreezeTests {
     switch kind {
     case .audioEngine: return "av_audio_engine"
     case .captureSession: return "av_capture_session"
+    case .halDeviceInput: return "hal_device_input"
     }
   }
 
@@ -96,6 +100,28 @@ struct AVCaptureSessionSourceDeviceTargetTests {
   @Test("a pinned target UID is reflected")
   func pinnedTargetReflected() {
     let source = AVCaptureSessionSource()
+    source.targetDeviceUID = "BC-87-FA-9C-7E-71:input"
+    #expect(source.targetDeviceUID == "BC-87-FA-9C-7E-71:input")
+  }
+}
+
+// #1377 slice 2b (reinstated 2026-07-08) — locks candidate D's identical
+// additive device-target contract to candidate A's: default nil (built-in),
+// pinned UID reflected. WHICH device actually binds is hardware-dependent and
+// proven by the bake-off Live UAT (the founder's Bose headset spike), not here.
+@MainActor
+@Suite("HALDeviceInputSource device target — #1377")
+struct HALDeviceInputSourceDeviceTargetTests {
+
+  @Test("default target is nil (automatic path leaves it built-in)")
+  func defaultTargetIsNil() {
+    let source = HALDeviceInputSource()
+    #expect(source.targetDeviceUID == nil)
+  }
+
+  @Test("a pinned target UID is reflected")
+  func pinnedTargetReflected() {
+    let source = HALDeviceInputSource()
     source.targetDeviceUID = "BC-87-FA-9C-7E-71:input"
     #expect(source.targetDeviceUID == "BC-87-FA-9C-7E-71:input")
   }

--- a/Tests/EnviousWisprTests/Audio/CaptureBakeoffControlPlaneTests.swift
+++ b/Tests/EnviousWisprTests/Audio/CaptureBakeoffControlPlaneTests.swift
@@ -48,6 +48,14 @@ import Testing
         CaptureRouteResolver.debugPolicyOverride(defaults: defaults) == .forceCaptureSession)
     }
 
+    @Test("forceHALDeviceInput string → .forceHALDeviceInput")
+    func forceHALDeviceInputMaps() {
+      let defaults = makeDefaults()
+      defaults.set("forceHALDeviceInput", forKey: CaptureRouteResolver.debugPolicyOverrideKey)
+      #expect(
+        CaptureRouteResolver.debugPolicyOverride(defaults: defaults) == .forceHALDeviceInput)
+    }
+
     @Test("unknown string → nil (never silently forces a candidate)")
     func garbageIsNil() {
       let defaults = makeDefaults()
@@ -79,18 +87,28 @@ struct CaptureRouteResolverForceMappingTests {
     #expect(d.reason == .forcedCaptureSession)
   }
 
+  @Test("forceHALDeviceInput policy → .halDeviceInput / .forcedHALDeviceInput (no hardware)")
+  func forceHALDeviceInputDecision() {
+    var resolver = CaptureRouteResolver()
+    resolver.policy = .forceHALDeviceInput
+    let d = resolver.resolve(preferredInputDeviceUID: "", noiseSuppression: false)
+    #expect(d.sourceType == .halDeviceInput)
+    #expect(d.reason == .forcedHALDeviceInput)
+  }
+
   // Dormancy lock: whatever the test machine's audio hardware, the `.automatic`
-  // route only ever yields a SHIPPING capture backend. When slices 2b/2c add
-  // `.halDeviceInput` / `.voiceProcessingIO`, this assertion stays the two
-  // shipping cases, so it guards that the automatic route never emits a dormant
-  // candidate (the §4 invariant) — hardware-independent because it asserts
-  // membership, not a specific device-derived result.
+  // route only ever yields a SHIPPING capture backend. `.halDeviceInput`
+  // (slice 2b, reinstated 2026-07-08) is dormant — this assertion stays the
+  // two shipping cases, so it guards that the automatic route never emits a
+  // dormant candidate (the §4 invariant) — hardware-independent because it
+  // asserts membership, not a specific device-derived result.
   @Test("automatic route only ever emits a shipping backend (dormancy)")
   func automaticNeverEmitsDormantCase() {
     var resolver = CaptureRouteResolver()  // .automatic by default
     for pref in ["", "some-device-uid"] {
       let d = resolver.resolve(preferredInputDeviceUID: pref, noiseSuppression: false)
       #expect(d.sourceType == .audioEngine || d.sourceType == .captureSession)
+      #expect(d.sourceType != .halDeviceInput)
     }
   }
 }

--- a/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
+++ b/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
@@ -22,7 +22,7 @@ struct ResolvedRouteTransportsGridTests {
 
   @Test(
     "derive is total over the sourceType × reason grid",
-    arguments: [CaptureSourceType.audioEngine, .captureSession],
+    arguments: [CaptureSourceType.audioEngine, .captureSession, .halDeviceInput],
     [
       CaptureRouteReason.btOutputAutoInput, .btOutputUserSelectedBTMic,
       .btOutputUserSelectedBuiltIn, .btOutputUserSelectedWired, .noBTAutoInput,

--- a/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
+++ b/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
@@ -41,7 +41,12 @@ struct ResolvedRouteTransportsGridTests {
     if isFallbackRung { #expect(r.routeFallbackReason == reason.rawValue) }
 
     // The capture-session path opens the built-in mic only today (bible R4).
-    if source == .captureSession { #expect(r.effective == "built_in") }
+    // HALDeviceInputSource's no-pin fallback is the SAME literal built-in mic
+    // (cloud review P2 on PR #1418 — the prior system-default-style fallback
+    // here didn't match what the source actually opens).
+    if source == .captureSession || source == .halDeviceInput {
+      #expect(r.effective == "built_in")
+    }
 
     // Empty UIDs → Auto; no user-selected transport.
     #expect(r.inputSelectionMode == "auto")

--- a/Tests/RuntimeUAT/capture_bakeoff.py
+++ b/Tests/RuntimeUAT/capture_bakeoff.py
@@ -66,7 +66,7 @@ _CHECKOUT_ROOT = os.path.dirname(
 )
 DEFAULT_SCORECARD = os.path.join(_CHECKOUT_ROOT, ".validation", "capture-bakeoff-scorecard.json")
 
-# candidate -> force policy + expected backend tag. Extend for D/E in 2b/2c.
+# candidate -> force policy + expected backend tag. Extend for E in 2c.
 CANDIDATES = {
     "A": {
         "policy": "forceCaptureSession",
@@ -77,6 +77,13 @@ CANDIDATES = {
         "policy": "forceEngine",
         "backend": "av_audio_engine",
         "desc": "AVAudioEngine, device-override",
+    },
+    # Reinstated 2026-07-08 (slice 2b) — spiked against A per the competitive
+    # research in docs/audits/2026-07-08-capture-engine-competitive-research.md.
+    "D": {
+        "policy": "forceHALDeviceInput",
+        "backend": "hal_device_input",
+        "desc": "AUHAL (kAudioUnitSubType_HALOutput), device-targeted",
     },
 }
 


### PR DESCRIPTION
## Summary
- Reinstates #1377 slice 2b (candidate D, dropped earlier in the bake-off) after founder review + competitive research refuted the assumption that ruled it out.
- New `HALDeviceInputSource` conformer (AUHAL / `kAudioUnitSubType_HALOutput`) added behind the existing bake-off control plane — dormant, reachable only via `CaptureSourcePolicy.forceHALDeviceInput`, same shape as candidates A/C shipped in #1407. Zero user-facing change; `.automatic` route is unaffected.
- Live-tested on the founder's real Bluetooth hardware across the full stress matrix candidate A originally cleared (rapid-fire spam, 30s idle-teardown timer, Spotify/Zoom/Google Meet contention, both ASR engines) — all passed. Full results in `docs/audits/2026-07-07-capture-bakeoff-results.md` § DECISION REVISED (local-only doc, not part of this diff).
- **Candidate D is now the adopted Phase 3 capture backend**, replacing candidate A. #1378 will be re-planned around it separately.

Three rounds of local Codex code-diff review found and fixed real defects before this was considered clean:
- A use-after-release bug in `prepare()`'s failure paths (self-review catch, before Codex saw it).
- A write-side buffer-overrun risk (the render callback could ask `AudioUnitRender` to write more frames than the scratch buffer holds).
- A heap allocation happening while holding a lock shared with the real-time audio callback thread (could block the RT thread behind a slow consumer).

## Test plan
- [x] `swift build` — full package build green.
- [x] `scripts/xcode-test.sh` — full suite green (2472 tests, no regressions).
- [x] `scripts/check-dependency-direction.sh` — clean, no new module deps (AUHAL uses system frameworks only).
- [x] Live UAT on real Bluetooth hardware (Bose headset) — device binding, rapid-fire, idle-timer, Spotify/Zoom/Google Meet contention, both ASR engines, mid-recording disconnect (matches candidate A's known #1408 gap, not a regression).
- [x] Codex code-diff review — 3 local rounds, clean on the confirming pass.