### PR TITLE
feat(llm): teach EG-1's delivery manifest to support sharded files (#1417)

### DIFF
--- a/Sources/EnviousWispr/Resources/eg1-manifest.json
+++ b/Sources/EnviousWispr/Resources/eg1-manifest.json
@@ -1,8 +1,6 @@
 {
   "modelName": "eg-1",
   "version": "v1",
-  "sha256": "3343fc1a30a3e82df7499a4775ef73dd6e28dea1cc39bb58197ec0b66ec874f6",
-  "sizeBytes": 2889511680,
   "contextTokens": 16384,
   "promptTemplateID": "eg1-v1",
   "minAppVersion": "2.3.0",

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -63,7 +63,13 @@ public final class EGOneDeliveryAdapter {
     let installDir = registration.installDirectory
     let installPath = installedArtifactURL.path
     let partialPath = installPath + ".partial"
-    let expectedSize = registration.manifest.files.first?.sizeBytes
+    // #1417: `partialPath` is always named after the ENTRYPOINT file
+    // (`resolvedEntrypointPath`, one file), so the size it's compared against
+    // must be that same file's own size — never a sum across every shard (a
+    // `.partial` named after shard 1 can only ever contain shard 1's bytes).
+    let expectedSize = registration.manifest.files.first(where: {
+      $0.resolvedInstallPath == registration.manifest.resolvedEntrypointPath
+    })?.sizeBytes
     // (1) Promote a complete current-version partial; a size-mismatched or
     //     already-installed one falls through to the sweep below.
     if fm.fileExists(atPath: partialPath), !fm.fileExists(atPath: installPath),
@@ -81,13 +87,13 @@ public final class EGOneDeliveryAdapter {
   }
 
   /// The verified on-disk model location the runtime boots llama-server from:
-  /// the install dir joined with the resolved install path (contract §4b —
-  /// the LOCAL name `eg-1-v1.gguf`, never the fetch key). Valid only after an
-  /// `.admitted` outcome.
+  /// the install dir joined with the manifest's resolved entrypoint (contract
+  /// §4b — the LOCAL name, never the fetch key; #1417: for a sharded manifest
+  /// this is shard 1's install name, `llama-server` auto-loads the rest). Valid
+  /// only after an `.admitted` outcome. Thin consumer of
+  /// `DeliveryManifest.resolvedEntrypointPath` — no fallback logic of its own.
   public var installedArtifactURL: URL {
-    let installName =
-      registration.manifest.files.first?.resolvedInstallPath
-      ?? registration.manifest.files.first?.path ?? ""
+    let installName = registration.manifest.resolvedEntrypointPath ?? ""
     return registration.installDirectory.appendingPathComponent(installName)
   }
 

--- a/Sources/EnviousWisprLLM/EGOne/EGOneManifest.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneManifest.swift
@@ -25,12 +25,6 @@ public struct EGOneManifest: Codable, Sendable, Equatable {
   /// Artifact version, e.g. "v1". Part of the on-disk filename so model
   /// updates are atomic swaps, never in-place rewrites.
   public let version: String
-  /// SHA-256 of the GGUF artifact (lowercase hex). BLOCKING: a file that
-  /// does not hash to this value is never served (deleted, re-downloaded).
-  public let sha256: String
-  /// Exact artifact size in bytes. Used for the disk-space preflight and
-  /// as a cheap first-pass integrity check before hashing.
-  public let sizeBytes: Int64
   /// Context window (tokens) to launch the server with (`-c`). Sized from
   /// the 2026-07-02 length-ladder data; never below the product's
   /// max-dictation needs so nothing is silently truncated.
@@ -42,20 +36,22 @@ public struct EGOneManifest: Codable, Sendable, Equatable {
   /// Minimum app version that can run this artifact (informational in
   /// Phase 1; enforced when remote manifests arrive).
   public let minAppVersion: String
-  /// HTTPS download URL for the GGUF artifact.
+  /// HTTPS URL for the GGUF artifact (#1417: repointed to shard 1's URL for a
+  /// sharded EG-1 revision — an https-scheme sanity check only via
+  /// `activationBlockers()`, never used to fetch or verify bytes; the
+  /// delivery manifest's per-shard hash is the sole verification authority,
+  /// see contract invariant 1).
   public let downloadURL: URL
   /// HTTPS URL of the EG-1 model license that governs the artifact.
   public let licenseURL: URL?
 
   public init(
-    modelName: String, version: String, sha256: String, sizeBytes: Int64,
+    modelName: String, version: String,
     contextTokens: Int, promptTemplateID: String, minAppVersion: String,
     downloadURL: URL, licenseURL: URL? = nil
   ) {
     self.modelName = modelName
     self.version = version
-    self.sha256 = sha256
-    self.sizeBytes = sizeBytes
     self.contextTokens = contextTokens
     self.promptTemplateID = promptTemplateID
     self.minAppVersion = minAppVersion

--- a/Sources/EnviousWisprModelDelivery/DeliveryManifest.swift
+++ b/Sources/EnviousWisprModelDelivery/DeliveryManifest.swift
@@ -50,6 +50,13 @@ public struct DeliveryManifest: Codable, Sendable, Equatable {
     /// exactly this. Integers and strings are canonicalization-safe.
     public let diskHeadroomFactor: String
     public let evictPreviousRevisions: Bool
+    /// Schema v1.2, additive (#1417): names the ONE `File.resolvedInstallPath`
+    /// the runtime boots/loads from when a manifest lists multiple files (a
+    /// `componentSet` layout with several shards, e.g. EG-1's split GGUF).
+    /// ABSENT ⇒ every existing manifest (single-file, or Parakeet's
+    /// componentSet with no single "the" entrypoint) is byte-identical and
+    /// its digest unchanged.
+    public let entrypointFile: String?
 
     public var headroomFactor: Double { Double(diskHeadroomFactor) ?? 2.2 }
   }
@@ -151,6 +158,17 @@ public struct DeliveryManifest: Codable, Sendable, Equatable {
     guard let factor = Double(admission.diskHeadroomFactor), factor >= 1.0 else {
       throw ManifestError.structurallyInvalid("diskHeadroomFactor must parse as a number >= 1.0")
     }
+    // #1417: a declared entrypointFile must resolve to a real files[] entry —
+    // fail closed at manifest-validation time (authoring/build), never at
+    // runtime boot. Duplicate resolvedInstallPath values are already rejected
+    // above, so "more than one match" cannot happen here.
+    if let entrypointFile = admission.entrypointFile {
+      guard files.contains(where: { $0.resolvedInstallPath == entrypointFile }) else {
+        throw ManifestError.structurallyInvalid(
+          "admission.entrypointFile \(entrypointFile) does not match any files[].resolvedInstallPath"
+        )
+      }
+    }
   }
 
   /// Canonical digest per D2 §2: SHA-256 over the canonical JSON (sorted keys,
@@ -170,6 +188,22 @@ public struct DeliveryManifest: Codable, Sendable, Equatable {
     let canonical = try JSONSerialization.data(
       withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
     return SHA256.hash(data: canonical).map { String(format: "%02x", $0) }.joined()
+  }
+
+  /// The single owner of "which file does the runtime boot/load from" (#1417):
+  /// `admission.entrypointFile` matched to its `resolvedInstallPath` when
+  /// present, else `files.first?.resolvedInstallPath` (the pre-existing
+  /// single-file behavior, unchanged). `nil` only if `files` is empty, which
+  /// cannot happen for a structurally-valid (already-admitted) manifest.
+  /// Consumers (e.g. `EGOneDeliveryAdapter.installedArtifactURL`) read this
+  /// property rather than re-deriving the fallback rule themselves.
+  public var resolvedEntrypointPath: String? {
+    if let entrypointFile = admission.entrypointFile,
+      let match = files.first(where: { $0.resolvedInstallPath == entrypointFile })
+    {
+      return match.resolvedInstallPath
+    }
+    return files.first?.resolvedInstallPath
   }
 
   /// Files grouped by their repair/atomicity component, in stable path order.

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Testing
 
@@ -62,20 +63,109 @@ import Testing
       manifest: manifest, installDirectory: install, metadataDirectory: metadata)
   }
 
+  /// A synthetic componentSet manifest (2 shards + `entrypointFile`),
+  /// independent of the real shipped manifest (still single-file until the
+  /// shard-authoring step, #1417 §3.5) — proves `installedArtifactURL` and
+  /// `migrateLegacyStoreArtifacts`'s size check against an ACTUALLY sharded
+  /// manifest, not just the current single-file one.
+  private func shardedFixtureRegistration(install: URL, metadata: URL) throws
+    -> DeliveryRegistration
+  {
+    func sha256(_ data: Data) -> String {
+      SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+    func fileObject(_ path: String, _ data: Data) -> [String: Any] {
+      ["path": path, "sizeBytes": data.count, "sha256": sha256(data), "component": path]
+    }
+    let shard1 = Data(count: 1000)
+    let shard2 = Data(count: 2000)
+    var object: [String: Any] = [
+      "schemaVersion": 1,
+      "identity": [
+        "family": "eg_one", "name": "eg-1", "revision": "v2-sharded", "variant": "q5km",
+        "runtimeABI": "llamacpp-test",
+      ],
+      "files": [
+        fileObject("eg-1-00001-of-00002.gguf", shard1),
+        fileObject("eg-1-00002-of-00002.gguf", shard2),
+      ],
+      "optionalFiles": [] as [Any],
+      "totalBytes": shard1.count + shard2.count,
+      "sources": [["id": "our_copy", "baseURL": "https://mirror.invalid.example/eg1/"]],
+      "admission": [
+        "layout": "componentSet", "installLocation": "test",
+        "diskHeadroomFactor": "2.2", "evictPreviousRevisions": false,
+        "entrypointFile": "eg-1-00001-of-00002.gguf",
+      ] as [String: Any],
+    ]
+    let canonical = try JSONSerialization.data(
+      withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+    object["manifestDigest"] = sha256(canonical)
+    let manifest = try DeliveryManifest.load(
+      from: try JSONSerialization.data(withJSONObject: object))
+    return DeliveryRegistration(
+      manifest: manifest, installDirectory: install, metadataDirectory: metadata)
+  }
+
+  @MainActor
+  @Test func installedArtifactURLResolvesToEntrypointShardForComponentSetManifest() throws {
+    let dirs = try makeTempDirs()
+    defer { dirs.cleanup() }
+    let registration = try shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+    let adapter = EGOneDeliveryAdapter(
+      controller: ModelDeliveryController(), registration: registration, version: "v2-sharded")
+    #expect(adapter.installedArtifactURL.lastPathComponent == "eg-1-00001-of-00002.gguf")
+  }
+
+  @MainActor
+  @Test func migrateLegacyStoreArtifactsSizeCheckUsesEntrypointSizeNotSum() throws {
+    let dirs = try makeTempDirs()
+    defer { dirs.cleanup() }
+    let registration = try shardedFixtureRegistration(
+      install: dirs.install, metadata: dirs.metadata)
+    let entrypointPath = try #require(registration.manifest.resolvedEntrypointPath)
+    // Entrypoint shard (shard 1) is 1000 bytes; shard 2 is 2000; sum is 3000.
+    // A `.partial` sized to the SUM would be wrong — it can only ever contain
+    // shard 1's own bytes. Size it to 1000 (shard 1's own size) and confirm
+    // the migration recognizes it as complete and promotes.
+    let partial = dirs.install.appendingPathComponent("\(entrypointPath).partial")
+    #expect(FileManager.default.createFile(atPath: partial.path, contents: nil))
+    let handle = try FileHandle(forWritingTo: partial)
+    try handle.truncate(atOffset: 1000)
+    try handle.close()
+
+    _ = EGOneDeliveryAdapter(
+      controller: ModelDeliveryController(), registration: registration, version: "v2-sharded")
+
+    #expect(
+      FileManager.default.fileExists(
+        atPath: dirs.install.appendingPathComponent(entrypointPath).path),
+      "the entrypoint-sized (not sum-sized) partial was promoted")
+    #expect(!FileManager.default.fileExists(atPath: partial.path))
+  }
+
   @MainActor
   @Test func completeLegacyPartialIsPromotedNotDeleted() throws {
     let dirs = try makeTempDirs()
     defer { dirs.cleanup() }
     let registration = try eg1Registration(install: dirs.install, metadata: dirs.metadata)
-    let expectedSize = try #require(registration.manifest.files.first?.sizeBytes)
+    // #1417: derive the expected install name and size from
+    // `resolvedEntrypointPath` — never a hardcoded legacy literal — so this
+    // test stays correct once the shipped manifest becomes N shards (the
+    // entrypoint's own name/size then, same as today's single file now).
+    let entrypointPath = try #require(registration.manifest.resolvedEntrypointPath)
+    let expectedSize = try #require(
+      registration.manifest.files.first(where: { $0.resolvedInstallPath == entrypointPath })?
+        .sizeBytes)
     // A completed-but-not-installed download: full-size .partial, no install
     // file. The .partial must REPORT the manifest's expected size (~2.9 GB) so
     // the migration's size-match promote branch fires — but as a SPARSE file
     // (truncate, no allocation) so the test never materializes gigabytes of RAM
     // or disk on CI (cloud-review P1). The migration promotes via rename (O(1)),
     // never a byte copy, so a sparse source is faithful.
-    let partial = dirs.install.appendingPathComponent("eg-1-v1.gguf.partial")
-    let resume = dirs.install.appendingPathComponent("eg-1-v1.gguf.resume.json")
+    let partial = dirs.install.appendingPathComponent("\(entrypointPath).partial")
+    let resume = dirs.install.appendingPathComponent("\(entrypointPath).resume.json")
     #expect(FileManager.default.createFile(atPath: partial.path, contents: nil))
     let handle = try FileHandle(forWritingTo: partial)
     try handle.truncate(atOffset: UInt64(expectedSize))
@@ -87,7 +177,7 @@ import Testing
 
     let fm = FileManager.default
     // Promoted to the install name (so adoption can verify + admit offline).
-    #expect(fm.fileExists(atPath: dirs.install.appendingPathComponent("eg-1-v1.gguf").path))
+    #expect(fm.fileExists(atPath: dirs.install.appendingPathComponent(entrypointPath).path))
     #expect(!fm.fileExists(atPath: partial.path))
     #expect(!fm.fileExists(atPath: resume.path), "stale resume sidecar removed")
   }
@@ -97,8 +187,9 @@ import Testing
     let dirs = try makeTempDirs()
     defer { dirs.cleanup() }
     let registration = try eg1Registration(install: dirs.install, metadata: dirs.metadata)
+    let entrypointPath = try #require(registration.manifest.resolvedEntrypointPath)
     // An interrupted download: short .partial, no install file.
-    let partial = dirs.install.appendingPathComponent("eg-1-v1.gguf.partial")
+    let partial = dirs.install.appendingPathComponent("\(entrypointPath).partial")
     try Data(count: 4096).write(to: partial)
 
     _ = EGOneDeliveryAdapter(
@@ -107,7 +198,7 @@ import Testing
     let fm = FileManager.default
     // Reclaimed (no partial install file left behind); no bogus install created.
     #expect(!fm.fileExists(atPath: partial.path))
-    #expect(!fm.fileExists(atPath: dirs.install.appendingPathComponent("eg-1-v1.gguf").path))
+    #expect(!fm.fileExists(atPath: dirs.install.appendingPathComponent(entrypointPath).path))
   }
 
   @MainActor

--- a/Tests/EnviousWisprTests/LLM/EGOneManifestTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneManifestTests.swift
@@ -14,8 +14,8 @@ struct EGOneManifestTests {
     downloadURL: String = "https://models.enviouslabs.co/eg1/eg-1-v1-q5km.gguf"
   ) -> EGOneManifest {
     EGOneManifest(
-      modelName: modelName, version: "v1", sha256: String(repeating: "a", count: 64),
-      sizeBytes: 1000, contextTokens: 32768, promptTemplateID: promptTemplateID,
+      modelName: modelName, version: "v1",
+      contextTokens: 32768, promptTemplateID: promptTemplateID,
       minAppVersion: "2.3.0", downloadURL: URL(string: downloadURL)!)
   }
 
@@ -84,11 +84,9 @@ struct EGOneManifestTests {
     for token in forbidden {
       #expect(!manifest.downloadURL.absoluteString.lowercased().contains(token))
     }
-    #expect(manifest.sha256.count == 64)
-    #expect(manifest.sha256.allSatisfy { $0.isHexDigit })
-    // Not a degenerate hash (all one character = placeholder smell).
-    #expect(Set(manifest.sha256).count > 4)
-    #expect(manifest.sizeBytes > 1_000_000_000)  // a real 4B-model GGUF
+    // sha256/sizeBytes removed (#1417 §3.6): dead fields with no runtime
+    // reader, superseded by the delivery manifest's own per-shard
+    // verification (ManifestFetchTask/CacheAdmission, contract invariant 1).
     #expect(manifest.modelName == LLMProvider.egOneModelName)
     #expect(manifest.promptFamily != nil)
     #expect(manifest.activationBlockers().isEmpty)

--- a/Tests/EnviousWisprTests/ModelDelivery/InstallPathDecouplingTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/InstallPathDecouplingTests.swift
@@ -17,7 +17,8 @@ private enum InstallPathFixture {
   /// One-file manifest with an explicit `installPath` (nil ⇒ field omitted).
   static func json(
     path: String, installPath: String?, component: String, content: Data,
-    extraFiles: [(path: String, installPath: String?, component: String, content: Data)] = []
+    extraFiles: [(path: String, installPath: String?, component: String, content: Data)] = [],
+    entrypointFile: String? = nil, layout: String = "singleFile"
   ) throws -> Data {
     func fileObject(_ p: String, _ ip: String?, _ c: String, _ data: Data) -> [String: Any] {
       var obj: [String: Any] = [
@@ -27,6 +28,11 @@ private enum InstallPathFixture {
       return obj
     }
     let all = [(path, installPath, component, content)] + extraFiles
+    var admission: [String: Any] = [
+      "layout": layout, "installLocation": "test",
+      "diskHeadroomFactor": "2.2", "evictPreviousRevisions": false,
+    ]
+    if let entrypointFile { admission["entrypointFile"] = entrypointFile }
     let object: [String: Any] = [
       "schemaVersion": 1,
       "identity": [
@@ -37,10 +43,7 @@ private enum InstallPathFixture {
       "optionalFiles": [] as [Any],
       "totalBytes": all.reduce(0) { $0 + $1.3.count },
       "sources": [["id": "our_copy", "baseURL": "https://mirror.invalid.example/eg1/"]],
-      "admission": [
-        "layout": "singleFile", "installLocation": "test",
-        "diskHeadroomFactor": "2.2", "evictPreviousRevisions": false,
-      ] as [String: Any],
+      "admission": admission,
     ]
     let canonical = try JSONSerialization.data(
       withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
@@ -63,6 +66,42 @@ private enum InstallPathFixture {
     // Orphan roots (a local concern) derive from the install name, never the
     // fetch key — else cleanup could delete the preserved file.
     #expect(CacheAdmission.componentRoots(of: manifest) == ["eg-1-v1.gguf"])
+  }
+
+  // MARK: - resolvedEntrypointPath (#1417, schema v1.2)
+
+  // entrypointFile present ⇒ resolvedEntrypointPath resolves to that specific
+  // file among N, not just `.first`.
+  @Test func resolvedEntrypointPathHonorsExplicitEntrypoint() throws {
+    let data = try InstallPathFixture.json(
+      path: "eg-1-00001-of-00002.gguf", installPath: nil, component: "eg-1-00001-of-00002.gguf",
+      content: Data("shard1".utf8),
+      extraFiles: [
+        ("eg-1-00002-of-00002.gguf", nil, "eg-1-00002-of-00002.gguf", Data("shard2".utf8))
+      ],
+      entrypointFile: "eg-1-00001-of-00002.gguf", layout: "componentSet")
+    let manifest = try DeliveryManifest.load(from: data)
+    #expect(manifest.resolvedEntrypointPath == "eg-1-00001-of-00002.gguf")
+  }
+
+  // entrypointFile ABSENT on a multi-file manifest ⇒ falls back to `.first`
+  // (regression: the pre-#1417 behavior, now generalized to N files).
+  @Test func resolvedEntrypointPathFallsBackToFirstWhenAbsent() throws {
+    let data = try InstallPathFixture.json(
+      path: "a.gguf", installPath: nil, component: "a.gguf", content: Data("a".utf8),
+      extraFiles: [("b.gguf", nil, "b.gguf", Data("b".utf8))],
+      layout: "componentSet")
+    let manifest = try DeliveryManifest.load(from: data)
+    #expect(manifest.resolvedEntrypointPath == "a.gguf")
+  }
+
+  // entrypointFile naming a non-existent files[] entry fails at manifest
+  // validation (authoring/build time), never at runtime boot.
+  @Test func entrypointFileNotMatchingAnyFileFailsValidation() throws {
+    let data = try InstallPathFixture.json(
+      path: "a.gguf", installPath: nil, component: "a.gguf", content: Data("a".utf8),
+      entrypointFile: "does-not-exist.gguf", layout: "componentSet")
+    #expect(throws: (any Error).self) { try DeliveryManifest.load(from: data) }
   }
 
   // (c) absent installPath ⇒ resolvedInstallPath == path (v1 back-compat).
@@ -210,26 +249,34 @@ private enum InstallPathFixture {
       "eg1-delivery-manifest.json must be listed in the app target's resources")
   }
 
-  /// 3-axis agreement (#1363 §16.7): the delivery manifest and the runtime
-  /// `EGOneManifest` must never drift on fetch, install, or content identity.
+  /// Identity + fetch agreement (#1417 §3.6, revised from the #1363 3-axis
+  /// version): the runtime `EGOneManifest`'s `sha256`/`sizeBytes` were
+  /// removed as dead fields (no runtime reader, superseded by the delivery
+  /// manifest's own per-file hash/size verification — contract invariant 1),
+  /// so a 1:1 content-identity check against them no longer has a single
+  /// counterpart once the delivery manifest lists N shards. What must still
+  /// agree: model identity (name/version), and the runtime `downloadURL`
+  /// matches the manifest's ENTRYPOINT file's fetch URL — today's single
+  /// file; shard 1's URL once EG-1 ships sharded (same assertion, no rewrite
+  /// needed at that point since it reads `resolvedEntrypointPath` generically).
   @Test func deliveryManifestAgreesWithRuntimeManifest() throws {
     let delivery = try DeliveryManifest.load(from: Data(contentsOf: Self.deliveryManifestURL))
     let runtime =
       try JSONSerialization.jsonObject(
         with: Data(contentsOf: Self.runtimeManifestURL)) as! [String: Any]
-    let file = try #require(delivery.files.first)
-    let ourCopy = try #require(delivery.sources.first { $0.id == "our_copy" })
 
-    // Fetch axis: baseURL + path reconstructs the runtime downloadURL.
-    let reconstructed = ourCopy.baseURL.appendingPathComponent(file.path).absoluteString
-    #expect(reconstructed == (runtime["downloadURL"] as? String))
-    // Install axis: resolvedInstallPath == runtime artifactFileName
-    // (modelName-version.gguf).
+    // Identity axis: modelName/version must agree between the two manifests.
     let modelName = runtime["modelName"] as! String
     let version = runtime["version"] as! String
-    #expect(file.resolvedInstallPath == "\(modelName)-\(version).gguf")
-    // Content axis: sha256 + sizeBytes are identical.
-    #expect(file.sha256 == (runtime["sha256"] as? String))
-    #expect(file.sizeBytes == Int64(runtime["sizeBytes"] as! Int))
+    #expect(delivery.identity.name == modelName)
+    #expect(delivery.identity.revision == version)
+
+    // Fetch axis: the runtime downloadURL matches the ENTRYPOINT file's URL.
+    let entrypointPath = try #require(delivery.resolvedEntrypointPath)
+    let entrypointFile = try #require(
+      delivery.files.first { $0.resolvedInstallPath == entrypointPath })
+    let ourCopy = try #require(delivery.sources.first { $0.id == "our_copy" })
+    let reconstructed = ourCopy.baseURL.appendingPathComponent(entrypointFile.path).absoluteString
+    #expect(reconstructed == (runtime["downloadURL"] as? String))
   }
 }


### PR DESCRIPTION
## Summary
- Adds an optional `entrypointFile` field to the delivery manifest schema (v1.2, additive) plus `DeliveryManifest.resolvedEntrypointPath` — the single owner of "which file does the runtime boot from" — so EG-1 can adopt the shared delivery engine's already-proven `componentSet` layout (same pattern as Parakeet's 23-file manifest) for CDN caching.
- `EGOneDeliveryAdapter`'s two single-file assumptions (`installedArtifactURL`, `migrateLegacyStoreArtifacts`'s size check) become thin consumers of that property instead of re-deriving the fallback rule themselves.
- Removes `EGOneManifest`'s dead `sha256`/`sizeBytes` fields — no runtime reader; the delivery manifest's own per-file hash/size verification is the sole integrity authority.
- Code-only, behavior-identical for the current single-file manifest (verified: `resolvedEntrypointPath` falls back to `.first`, byte-for-byte the same result as before this change).
- The real sharded `eg1-delivery-manifest.json` (actual shard files via `gguf-split`, R2 upload, Cloudflare Cache Rule) is a separate, later production-data step requiring explicit founder go — out of scope here.

Plan: `docs/feature-requests/issue-1417-2026-07-08-eg1-cdn-sharding.md` (10 grounded-review rounds to PROCEED-AS-PLANNED, Gate 2 approved).

## Test plan
- [x] `./scripts/xcode-test.sh` — full suite green, 2493 tests
- [x] Local `codex review --base origin/main` — clean, no findings
- [x] Rebuilt dev app from this branch, relaunched
- [x] Live UAT: real dictation through the rebuilt app confirms `LLM polish requested/complete: provider=egOne, model=eg-1` end-to-end (ASR → correction → EG-1 polish → paste, 1.088s total) — the entrypoint-resolution code path loads and serves EG-1 correctly post-rebuild
- [ ] Cloud review gate (evaluate before arming auto-merge)

Closes #1417