### PR TITLE
feat(llm): ship EG-1's real sharded delivery manifest (#1417)

### DIFF
--- a/Sources/EnviousWispr/Resources/eg1-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/eg1-delivery-manifest.json
@@ -3,7 +3,7 @@
   "identity": {
     "family": "eg_one",
     "name": "eg-1",
-    "revision": "v1",
+    "revision": "v2-sharded",
     "variant": "q5km",
     "runtimeABI": "llamacpp-eg1-v1"
   },
@@ -12,15 +12,64 @@
   },
   "files": [
     {
-      "path": "eg-1-v1-q5km.gguf",
-      "installPath": "eg-1-v1.gguf",
-      "sizeBytes": 2889511680,
-      "sha256": "3343fc1a30a3e82df7499a4775ef73dd6e28dea1cc39bb58197ec0b66ec874f6",
-      "component": "eg-1-v1.gguf"
+      "path": "v2-sharded/eg-1-v1-00001-of-00008.gguf",
+      "installPath": "eg-1-v1-00001-of-00008.gguf",
+      "sizeBytes": 399884576,
+      "sha256": "77fecf22dabbcb441bb44b8e1f5c6cba7a3f728bc5c22ff76dfb97fd5fbe55af",
+      "component": "eg-1-v1-00001-of-00008.gguf"
+    },
+    {
+      "path": "v2-sharded/eg-1-v1-00002-of-00008.gguf",
+      "installPath": "eg-1-v1-00002-of-00008.gguf",
+      "sizeBytes": 395007008,
+      "sha256": "0808f51149fc30587741c90fa8d026dabdba336a8d9dcc456b8069dd09052c9f",
+      "component": "eg-1-v1-00002-of-00008.gguf"
+    },
+    {
+      "path": "v2-sharded/eg-1-v1-00003-of-00008.gguf",
+      "installPath": "eg-1-v1-00003-of-00008.gguf",
+      "sizeBytes": 393972896,
+      "sha256": "feb7d533d28cb7ca28aaa3d5b0152ff55cb5c5930ae701ec9c726b2d2ee3a1ab",
+      "component": "eg-1-v1-00003-of-00008.gguf"
+    },
+    {
+      "path": "v2-sharded/eg-1-v1-00004-of-00008.gguf",
+      "installPath": "eg-1-v1-00004-of-00008.gguf",
+      "sizeBytes": 397618336,
+      "sha256": "d0a2171e05f94623bef61ae823d38b85bae0a5c3a68d4299142c4d1fa7529bd4",
+      "component": "eg-1-v1-00004-of-00008.gguf"
+    },
+    {
+      "path": "v2-sharded/eg-1-v1-00005-of-00008.gguf",
+      "installPath": "eg-1-v1-00005-of-00008.gguf",
+      "sizeBytes": 389508864,
+      "sha256": "f9753de7d96d209e6172ddaaf702eaffd72145cf2f3950965503724fba39ef57",
+      "component": "eg-1-v1-00005-of-00008.gguf"
+    },
+    {
+      "path": "v2-sharded/eg-1-v1-00006-of-00008.gguf",
+      "installPath": "eg-1-v1-00006-of-00008.gguf",
+      "sizeBytes": 388606432,
+      "sha256": "d0107bf94efdd18735d7325fe3037b9e00b738471b53f5e1b0d17861ff07eb8d",
+      "component": "eg-1-v1-00006-of-00008.gguf"
+    },
+    {
+      "path": "v2-sharded/eg-1-v1-00007-of-00008.gguf",
+      "installPath": "eg-1-v1-00007-of-00008.gguf",
+      "sizeBytes": 397168384,
+      "sha256": "917ad0a83d94a10a8d46113936de56b9fb868241024519b31cb0d612e3e247f3",
+      "component": "eg-1-v1-00007-of-00008.gguf"
+    },
+    {
+      "path": "v2-sharded/eg-1-v1-00008-of-00008.gguf",
+      "installPath": "eg-1-v1-00008-of-00008.gguf",
+      "sizeBytes": 127746048,
+      "sha256": "83c5c80b3c97c94fe9d5c2d903f0a1511e2a4d600091a18a5a2143f99d9ab286",
+      "component": "eg-1-v1-00008-of-00008.gguf"
     }
   ],
   "optionalFiles": [],
-  "totalBytes": 2889511680,
+  "totalBytes": 2889512544,
   "sources": [
     {
       "id": "our_copy",
@@ -32,10 +81,11 @@
     "url": "https://models.enviouslabs.co/eg1/EG-1-MODEL-LICENSE.txt"
   },
   "admission": {
-    "layout": "singleFile",
+    "layout": "componentSet",
     "installLocation": "polishModelsCache",
     "diskHeadroomFactor": "2.2",
-    "evictPreviousRevisions": false
+    "evictPreviousRevisions": true,
+    "entrypointFile": "eg-1-v1-00001-of-00008.gguf"
   },
-  "manifestDigest": "e3776d8863b791b120c58a1831b6e90474277753e8e0e78a6b62eac4816133c6"
+  "manifestDigest": "07550d07e242aa660393f5e62d36106ed7916ffa8852d9fb66f5420854a6b70d"
 }

--- a/Sources/EnviousWispr/Resources/eg1-manifest.json
+++ b/Sources/EnviousWispr/Resources/eg1-manifest.json
@@ -1,9 +1,9 @@
 {
   "modelName": "eg-1",
-  "version": "v1",
+  "version": "v2-sharded",
   "contextTokens": 16384,
   "promptTemplateID": "eg1-v1",
   "minAppVersion": "2.3.0",
-  "downloadURL": "https://models.enviouslabs.co/eg1/eg-1-v1-q5km.gguf",
+  "downloadURL": "https://models.enviouslabs.co/eg1/v2-sharded/eg-1-v1-00001-of-00008.gguf",
   "licenseURL": "https://models.enviouslabs.co/eg1/EG-1-MODEL-LICENSE.txt"
 }

--- a/Tests/EnviousWisprTests/ModelDelivery/InstallPathDecouplingTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/InstallPathDecouplingTests.swift
@@ -225,7 +225,12 @@ private enum InstallPathFixture {
     repoRoot.appendingPathComponent("Sources/EnviousWispr/Resources/eg1-manifest.json")
   }
 
-  static let goldenDigest = "e3776d8863b791b120c58a1831b6e90474277753e8e0e78a6b62eac4816133c6"
+  // #1417: EG-1 shipped its sharded revision (v2-sharded, 8 componentSet
+  // files) — golden digest updated to match. Recomputed via the real
+  // DeliveryManifest.canonicalDigest algorithm against the authored manifest,
+  // first cross-checked against the OLD single-file manifest's known-good
+  // digest to prove the recompute technique was faithful before trusting it.
+  static let goldenDigest = "07550d07e242aa660393f5e62d36106ed7916ffa8852d9fb66f5420854a6b70d"
 
   @Test func shippedDeliveryManifestLoadsAndMatchesGoldenDigest() throws {
     let data = try Data(contentsOf: Self.deliveryManifestURL)
@@ -233,11 +238,20 @@ private enum InstallPathFixture {
     #expect(manifest.manifestDigest == Self.goldenDigest)
     #expect(try DeliveryManifest.canonicalDigest(of: data) == Self.goldenDigest)
     #expect(manifest.identity.family == .egOne)
-    #expect(manifest.files.count == 1)
-    let file = try #require(manifest.files.first)
-    #expect(file.path == "eg-1-v1-q5km.gguf")  // server object key
-    #expect(file.resolvedInstallPath == "eg-1-v1.gguf")  // local runtime name
-    #expect(file.component == "eg-1-v1.gguf")
+    #expect(manifest.identity.revision == "v2-sharded")
+    #expect(manifest.admission.layout == "componentSet")
+    #expect(manifest.files.count == 8)
+    #expect(manifest.totalBytes == manifest.files.reduce(0) { $0 + $1.sizeBytes })
+    for file in manifest.files {
+      #expect(
+        file.sizeBytes <= 450_000_000, "\(file.path) exceeds the cache-eligible shard ceiling")
+    }
+    let entrypointPath = try #require(manifest.resolvedEntrypointPath)
+    #expect(entrypointPath == "eg-1-v1-00001-of-00008.gguf")
+    let entrypointFile = try #require(
+      manifest.files.first { $0.resolvedInstallPath == entrypointPath })
+    #expect(entrypointFile.path == "v2-sharded/eg-1-v1-00001-of-00008.gguf")  // server object key
+    #expect(entrypointFile.component == "eg-1-v1-00001-of-00008.gguf")
     #expect(manifest.sources.map(\.id) == ["our_copy"])
   }
 


### PR DESCRIPTION
## Summary
- Lands the real production-data rollout for EG-1 CDN sharding: the code groundwork (`entrypointFile` / `resolvedEntrypointPath`) shipped separately in #1420; this PR ships the real sharded manifest that groundwork was built to consume.
- Real EG-1 model (verified byte-identical to the shipped manifest's hash before splitting) split into 8 shards via `llama-gguf-split`, all under 400MB (well under Cloudflare's 512MB cache-eligible ceiling).
- All 8 shards uploaded to R2 under a new versioned sub-path (`/eg1/v2-sharded/`) that structurally cannot collide with the legacy monolithic file's path.
- Cloudflare Cache Rule + Transform Rule applied, scoped only to the new sub-path, alongside the existing untouched Parakeet rule.
- Manifest digest computed via the real production `canonicalDigest()` algorithm (copied source, Foundation-only deps), first proven correct by reproducing the shipped manifest's known-good digest before trusting it on the new one.

## Live validation performed
- Local: `llama-server` (real shipping binary) booted off shard 1 from local disk, auto-discovered all 8 siblings, answered a real completion correctly.
- Remote: every shard verified via HEAD + full download + SHA-256 from the live public URL; cache MISS→HIT confirmed on repeat GET; legacy monolithic URL confirmed untouched (size + first-MB hash match).
- End-to-end app UAT: a dev build with an existing legacy EG-1 install correctly detected the mismatch (UI showed "Not installed"), a real "Download EG-1" click fetched all 8 shards from the live CDN, old file was cleanly evicted only after the new revision fully verified and promoted, `llama-server` booted off the new install, and a real dictation produced correct EG-1-polished output (444ms polish latency, consistent with EG-1's known warm-inference baseline — confirms real model inference, not a fallback or skip).

## Test plan
- [x] `swift test` — all EG-1/delivery-manifest tests pass (29/29); full suite 2491/2493 (2 unrelated pre-existing timing-sensitive flakes, confirmed passing in isolation, zero overlap with this diff)
- [x] Local Codex code-diff review: clean, no findings
- [x] Local Codex grounded review of the production-data steps (shard generation → R2 upload): PROCEED-AS-PLANNED, no findings
- [x] Live UAT: legacy-upgrade path fully exercised end-to-end against real production infrastructure (see above)
- [ ] Cloud review gate (Codex GitHub bot) — pending

Release is intentionally NOT cut in this PR — merging lands the code on `main`, but shipping a version update (which triggers a one-time ~2.7GB re-download for existing EG-1 users) is a separate decision.