### PR TITLE
Honor system default input for auto capture

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AudioDeviceList.swift
+++ b/Sources/EnviousWisprAppKit/App/AudioDeviceList.swift
@@ -5,6 +5,7 @@ import Observation
 @MainActor @Observable
 final class AudioDeviceList {
   var availableInputDevices: [AudioInputDevice] = []
+  var onDevicesChanged: (([AudioInputDevice]) -> Void)?
   private var deviceMonitor: AudioDeviceMonitor?
 
   init() {
@@ -16,5 +17,6 @@ final class AudioDeviceList {
 
   func refresh() {
     availableInputDevices = AudioDeviceEnumerator.allInputDevices()
+    onDevicesChanged?(availableInputDevices)
   }
 }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -242,7 +242,11 @@ final class RecordingStarter {
         stage: "recording", message: "preWarm failed — start aborted",
         level: .warning, data: ["error": String(describing: error)]
       )
-      active.setExternalError("Microphone unavailable — try again.")
+      let nsError = error as NSError
+      let noMic =
+        nsError.domain == AudioError.errorDomain && nsError.code == AudioError.noBuiltInMicrophoneFound.errorCode
+      active.setExternalError(
+        noMic ? "No microphone found. Please connect a microphone." : "Microphone unavailable — try again.")
       return
     }
     guard !Task.isCancelled else {

--- a/Sources/EnviousWisprAppKit/App/InputDevicePreferencePolicy.swift
+++ b/Sources/EnviousWisprAppKit/App/InputDevicePreferencePolicy.swift
@@ -1,0 +1,20 @@
+enum InputDevicePreferencePolicy {
+  static func reconciled(
+    preferredOverride: String,
+    selectedUID: String,
+    connectedUIDs: Set<String>
+  ) -> (preferredOverride: String, selectedUID: String) {
+    if !preferredOverride.isEmpty {
+      if connectedUIDs.contains(preferredOverride) {
+        return (preferredOverride, preferredOverride)
+      }
+      return ("", preferredOverride)
+    }
+
+    if !selectedUID.isEmpty, connectedUIDs.contains(selectedUID) {
+      return (selectedUID, selectedUID)
+    }
+
+    return ("", selectedUID)
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/InputDevicePreferenceReconciler.swift
+++ b/Sources/EnviousWisprAppKit/App/InputDevicePreferenceReconciler.swift
@@ -1,0 +1,34 @@
+import EnviousWisprAudio
+import EnviousWisprServices
+
+@MainActor
+final class InputDevicePreferenceReconciler {
+  private let settings: SettingsManager
+
+  init(settings: SettingsManager) {
+    self.settings = settings
+  }
+
+  func reconcile(availableDevices: [AudioInputDevice]) {
+    let connectedUIDs = Set(availableDevices.map(\.uid))
+    let reconciled = InputDevicePreferencePolicy.reconciled(
+      preferredOverride: settings.preferredInputDeviceIDOverride,
+      selectedUID: settings.selectedInputDeviceUID,
+      connectedUIDs: connectedUIDs
+    )
+
+    let preferredChanged = reconciled.preferredOverride != settings.preferredInputDeviceIDOverride
+    let selectedChanged = reconciled.selectedUID != settings.selectedInputDeviceUID
+    guard preferredChanged || selectedChanged else { return }
+
+    settings.isApplyingSystemWrite = true
+    defer { settings.isApplyingSystemWrite = false }
+
+    if preferredChanged {
+      settings.preferredInputDeviceIDOverride = reconciled.preferredOverride
+    }
+    if selectedChanged {
+      settings.selectedInputDeviceUID = reconciled.selectedUID
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -61,6 +61,7 @@ public final class WisprBootstrapper {
   /// EnviousWisprAppCeilingsTests).
   let modelDelivery: ModelDeliveryHome
   let audioDeviceList: AudioDeviceList
+  let inputDevicePreferenceReconciler: InputDevicePreferenceReconciler
   let aiAvailability: AIAvailabilityCoordinator
   let keychainManager: KeychainManager
   let llmDiscovery: LLMModelDiscoveryCoordinator
@@ -97,6 +98,12 @@ public final class WisprBootstrapper {
     let keychainManager = KeychainManager(telemetrySink: .live)
     let recordingOverlay = RecordingOverlayPanel()
     let audioDeviceList = AudioDeviceList()
+    let inputDevicePreferenceReconciler = InputDevicePreferenceReconciler(settings: settings)
+    audioDeviceList.onDevicesChanged = { [weak inputDevicePreferenceReconciler] devices in
+      inputDevicePreferenceReconciler?.reconcile(availableDevices: devices)
+    }
+    inputDevicePreferenceReconciler.reconcile(
+      availableDevices: audioDeviceList.availableInputDevices)
     let captureTelemetry = CaptureTelemetryState()
     let customWordsCoordinator = CustomWordsCoordinator()
     // #636: contacts-import orchestrator (opt-in import + bulk-remove + background
@@ -683,6 +690,7 @@ public final class WisprBootstrapper {
     self.egOneRuntime = egOneRuntime
     self.modelDelivery = modelDelivery
     self.audioDeviceList = audioDeviceList
+    self.inputDevicePreferenceReconciler = inputDevicePreferenceReconciler
     self.aiAvailability = aiAvailability
     self.keychainManager = keychainManager
     self.llmDiscovery = llmDiscovery

--- a/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
@@ -12,18 +12,23 @@ struct AudioSettingsView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(AudioDeviceList.self) private var audioDeviceList
 
-  /// True when "Auto" is selected and the current audio output is Bluetooth, so
-  /// the pipeline prefers the built-in mic (a BT headset can't record and play
-  /// at once). Surfaces as the green "Built-in Mic preferred" pill.
-  private var builtInMicPreferred: Bool {
+  private var autoInputDeviceName: String? {
     guard settings.preferredInputDeviceIDOverride.isEmpty,
-      let outputID = AudioDeviceEnumerator.defaultOutputDeviceID()
-    else { return false }
-    return AudioDeviceEnumerator.isBluetoothDevice(outputID)
+      let defaultID = AudioDeviceEnumerator.defaultInputDeviceID()
+    else { return nil }
+    return audioDeviceList.availableInputDevices.first { $0.id == defaultID }?.name
   }
 
   var body: some View {
+    let settingsManager = settings
     @Bindable var settings = settings
+    let inputDeviceSelection = Binding<String>(
+      get: { settingsManager.preferredInputDeviceIDOverride },
+      set: { newValue in
+        settingsManager.preferredInputDeviceIDOverride = newValue
+        settingsManager.selectedInputDeviceUID = newValue
+      }
+    )
 
     SettingsContentView {
       // The frozen-per-recording rule covers every control on this page, so it
@@ -34,10 +39,10 @@ struct AudioSettingsView: View {
         icon: "mic",
         header: "Input Device",
         description:
-          "Select which microphone to use for recording. \"Auto\" prefers the built-in mic when Bluetooth audio output is active."
+          "Select which microphone to use for recording. \"Auto\" follows the input device currently selected in macOS."
       ) {
         HStack(spacing: 10) {
-          Picker("", selection: $settings.preferredInputDeviceIDOverride) {
+          Picker("", selection: inputDeviceSelection) {
             Text("Auto").tag("")
             ForEach(audioDeviceList.availableInputDevices) { device in
               Text(device.name).tag(device.uid)
@@ -46,8 +51,8 @@ struct AudioSettingsView: View {
           .labelsHidden()
           .frame(maxWidth: 340, alignment: .leading)
 
-          if builtInMicPreferred {
-            StatusPill(text: "Built-in Mic preferred")
+          if let autoInputDeviceName {
+            StatusPill(text: "Using \(autoInputDeviceName)")
           }
 
           Spacer(minLength: 0)
@@ -86,7 +91,7 @@ struct AudioSettingsView: View {
 }
 
 /// Small status chip: a coloured dot plus a short label, used to annotate a
-/// control's live state (e.g. "Built-in Mic preferred").
+/// control's live state (e.g. the current system-default microphone).
 private struct StatusPill: View {
   let text: String
   var tint: Color = .stSuccess
@@ -94,11 +99,11 @@ private struct StatusPill: View {
   var body: some View {
     HStack(spacing: 6) {
       Circle().fill(tint).frame(width: 7, height: 7).accessibilityHidden(true)
-      Text(text).font(.stHelper).foregroundStyle(tint)
+      Text(text).font(.stHelper).foregroundStyle(tint).lineLimit(1).truncationMode(.tail)
     }
+    .frame(maxWidth: 220)
     .padding(.horizontal, 10)
     .padding(.vertical, 6)
     .background(tint.opacity(0.12), in: Capsule())
-    .fixedSize()
   }
 }

--- a/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
+++ b/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
@@ -25,16 +25,26 @@ enum AudioBufferProcessor {
 }
 
 /// Errors that can occur during audio operations.
-public enum AudioError: LocalizedError, Sendable {
+public enum AudioError: LocalizedError, CustomNSError, Sendable {
   case formatCreationFailed(source: String = "unknown")
   case alreadyCapturing
   case noBuiltInMicrophoneFound
+
+  public static let errorDomain = "EnviousWisprAudio.AudioError"
+
+  public var errorCode: Int {
+    switch self {
+    case .formatCreationFailed: return 1
+    case .alreadyCapturing: return 2
+    case .noBuiltInMicrophoneFound: return 3
+    }
+  }
 
   public var errorDescription: String? {
     switch self {
     case .formatCreationFailed: return "Failed to create audio format."
     case .alreadyCapturing: return "Audio capture is already active."
-    case .noBuiltInMicrophoneFound: return "No built-in microphone found."
+    case .noBuiltInMicrophoneFound: return "No microphone found. Please connect a microphone."
     }
   }
 

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -158,15 +158,34 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// the device selection that produced THIS decision), then fire
   /// `onRouteResolved` changed-only. The single write path so `lastRouteDecision`
   /// and `currentResolvedRoute` never disagree.
-  private func adoptRouteDecision(_ decision: CaptureRouteDecision, prior: CaptureRouteDecision?) {
-    lastRouteDecision = decision
-    currentResolvedRoute = ResolvedRouteTransports.derive(
+  private func resolvedRouteTransports(
+    for decision: CaptureRouteDecision,
+    actualBoundTransport: String? = nil
+  ) -> ResolvedRouteTransports {
+    ResolvedRouteTransports.derive(
       decision: decision,
       preferredInputDeviceIDOverride: preferredInputDeviceIDOverride,
-      selectedInputDeviceUID: selectedInputDeviceUID
+      selectedInputDeviceUID: selectedInputDeviceUID,
+      actualBoundTransport: actualBoundTransport
     )
+  }
+
+  private func adoptRouteDecision(
+    _ decision: CaptureRouteDecision,
+    prior: CaptureRouteDecision?,
+    actualBoundTransport: String? = nil
+  ) {
+    lastRouteDecision = decision
+    currentResolvedRoute = resolvedRouteTransports(
+      for: decision, actualBoundTransport: actualBoundTransport)
     guard CaptureRouteDecision.routeResolvedChanged(from: prior, to: decision) else { return }
     onRouteResolved?(decision, prior.map { $0.sourceType != decision.sourceType } ?? false)
+  }
+
+  private func refreshResolvedRoute(actualBoundTransport: String?) {
+    guard let decision = lastRouteDecision else { return }
+    currentResolvedRoute = resolvedRouteTransports(
+      for: decision, actualBoundTransport: actualBoundTransport)
   }
 
   public init() {}
@@ -180,6 +199,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     source.onLifecycleSignal = onLifecycleSignal
     onLifecycleSignal?("manager_prepare_entered")
     try await source.prepare()
+    if let halSource = source as? HALDeviceInputSource {
+      refreshResolvedRoute(actualBoundTransport: halSource.actualBoundTransport)
+    }
     onLifecycleSignal?("manager_prepare_completed")
   }
 
@@ -561,13 +583,19 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         // Candidate D (#1377 slice 2b): same stale-target trap as candidate A
         // above — a warm HAL source from a forced trial must not be reused
         // once the override clears (or changes device).
-        if configMatch, let halSource = existing as? HALDeviceInputSource {
-          let wantsTarget =
-            decision.reason == .forcedHALDeviceInput ? effectiveInputDeviceUID() : ""
-          let normalize: (String?) -> String = { ($0?.isEmpty ?? true) ? "" : $0! }
-          configMatch = normalize(halSource.targetDeviceUID) == normalize(wantsTarget)
-        }
       #endif
+      if configMatch, let halSource = existing as? HALDeviceInputSource {
+        var wantsTarget = decision.effectiveDeviceUID
+        #if DEBUG
+          if decision.reason == .forcedHALDeviceInput {
+            wantsTarget = effectiveInputDeviceUID()
+          }
+        #endif
+        let normalize: (String?) -> String = { ($0?.isEmpty ?? true) ? "" : $0! }
+        configMatch =
+          normalize(halSource.targetDeviceUID) == normalize(wantsTarget)
+          && halSource.boundDeviceMatchesResolvedTargetForReuse()
+      }
 
       if configMatch {
         // Route and config unchanged, reuse warm source. This applies to the
@@ -578,7 +606,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         // record. Config changes that DO warrant a rebuild (candidate switch →
         // different sourceType; device change; a stale forced capture-session
         // target) are already caught by the `configMatch` checks above.
-        adoptRouteDecision(decision, prior: priorRouteDecision)
+        let actualBoundTransport = (existing as? HALDeviceInputSource)?.actualBoundTransport
+        adoptRouteDecision(
+          decision, prior: priorRouteDecision, actualBoundTransport: actualBoundTransport)
         Self.btRouteLog("Reusing warm \(Self.backendLabel(for: decision.sourceType)) source")
         return existing
       }
@@ -641,11 +671,11 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       source = engineSource
     case .halDeviceInput:
       let halSource = HALDeviceInputSource()
+      halSource.targetDeviceUID = decision.effectiveDeviceUID
       #if DEBUG
         // Candidate D (#1377 slice 2b, reinstated 2026-07-08): under a
         // force-case, pin the AUHAL source to the user-selected device. Only
-        // ever reachable via `.forceHALDeviceInput` — `.automatic` never
-        // emits `.halDeviceInput`.
+        // ever reachable via `.forceHALDeviceInput`.
         if decision.reason == .forcedHALDeviceInput {
           halSource.targetDeviceUID = effectiveInputDeviceUID()
         }

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -95,17 +95,11 @@ public enum AudioDeviceEnumerator {
     return stringProperty(for: id, selector: kAudioDevicePropertyDeviceUID)
   }
 
-  #if DEBUG
-    /// The persistent UID of a specific device ID. Used ONLY by the #1377
-    /// bake-off capture-evidence line (candidate C / engine path), which knows
-    /// the bound device by its numeric CoreAudio ID and needs the UID to prove
-    /// EXACT device binding — not just a non-built-in transport. Mirrors
-    /// `defaultInputDeviceUID()` but for an arbitrary device ID. DEBUG-only:
-    /// the only caller is the engine source's bench evidence.
-    static func inputDeviceUID(for deviceID: AudioDeviceID) -> String? {
-      stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceUID)
-    }
-  #endif
+  /// The persistent UID of a specific device ID. Used when a source knows the
+  /// bound numeric CoreAudio ID and needs the stable UID for telemetry evidence.
+  static func inputDeviceUID(for deviceID: AudioDeviceID) -> String? {
+    stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceUID)
+  }
 
   // MARK: - Bluetooth & Smart Device Selection
 
@@ -309,8 +303,13 @@ public final class AudioDeviceMonitor: Sendable {
   }
 
   private func startListening() {
-    var propertyAddress = AudioObjectPropertyAddress(
+    var devicesAddress = AudioObjectPropertyAddress(
       mSelector: kAudioHardwarePropertyDevices,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    var defaultInputAddress = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDefaultInputDevice,
       mScope: kAudioObjectPropertyScopeGlobal,
       mElement: kAudioObjectPropertyElementMain
     )
@@ -323,7 +322,13 @@ public final class AudioDeviceMonitor: Sendable {
 
     AudioObjectAddPropertyListenerBlock(
       AudioObjectID(kAudioObjectSystemObject),
-      &propertyAddress,
+      &devicesAddress,
+      nil,
+      block
+    )
+    AudioObjectAddPropertyListenerBlock(
+      AudioObjectID(kAudioObjectSystemObject),
+      &defaultInputAddress,
       nil,
       block
     )
@@ -332,15 +337,26 @@ public final class AudioDeviceMonitor: Sendable {
   private func stopListening() {
     guard let block = listenerBlock else { return }
 
-    var propertyAddress = AudioObjectPropertyAddress(
+    var devicesAddress = AudioObjectPropertyAddress(
       mSelector: kAudioHardwarePropertyDevices,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    var defaultInputAddress = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDefaultInputDevice,
       mScope: kAudioObjectPropertyScopeGlobal,
       mElement: kAudioObjectPropertyElementMain
     )
 
     AudioObjectRemovePropertyListenerBlock(
       AudioObjectID(kAudioObjectSystemObject),
-      &propertyAddress,
+      &devicesAddress,
+      nil,
+      block
+    )
+    AudioObjectRemovePropertyListenerBlock(
+      AudioObjectID(kAudioObjectSystemObject),
+      &defaultInputAddress,
       nil,
       block
     )

--- a/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
+++ b/Sources/EnviousWisprAudio/CaptureRouteResolver.swift
@@ -18,17 +18,15 @@ enum CaptureSourcePolicy: Sendable {
 public enum CaptureSourceType: Sendable {
   case audioEngine
   case captureSession
-  /// Dormant candidate D (#1377 slice 2b) — only reachable via
-  /// `.forceHALDeviceInput`.
+  /// HAL-backed input source; follows the live system-default input when no
+  /// target UID is supplied.
   case halDeviceInput
 }
 
 /// Machine-readable reason for the route decision. Used for telemetry.
 public enum CaptureRouteReason: String, Sendable {
   case btOutputAutoInput
-  case btOutputUserSelectedBTMic
-  case btOutputUserSelectedBuiltIn
-  case btOutputUserSelectedWired
+  case btOutputUserSelectedDevice
   case noBTAutoInput
   case noBTUserSelectedDevice
   case forcedEngine
@@ -48,9 +46,8 @@ extension CaptureRouteReason {
     switch self {
     case .noBTAutoInput, .noBTUserSelectedDevice:
       return "built_in_mic"
-    case .btOutputAutoInput, .btOutputUserSelectedBuiltIn,
-      .btOutputUserSelectedBTMic, .btOutputUserSelectedWired:
-      return "capture_session_bt"
+    case .btOutputAutoInput, .btOutputUserSelectedDevice:
+      return "hal_device_input"
     case .forcedEngine, .fallbackToEngine:
       return "audio_engine"
     case .forcedCaptureSession:
@@ -83,20 +80,28 @@ public struct CaptureRouteDecision: Sendable {
   public let reason: CaptureRouteReason
   public let rationale: String
   public let vpAvailable: Bool
+  /// Backend-level fallback only: whether this decision may switch to a
+  /// different `CaptureSourceType`. Device-level fallback inside a backend is
+  /// owned by that source.
   public let fallbackAllowed: Bool
+  /// Concrete device UID for HALDeviceInputSource. Nil means follow the live
+  /// system-default input device at prepare time.
+  public let effectiveDeviceUID: String?
 
   public init(
     sourceType: CaptureSourceType,
     reason: CaptureRouteReason,
     rationale: String,
     vpAvailable: Bool,
-    fallbackAllowed: Bool
+    fallbackAllowed: Bool,
+    effectiveDeviceUID: String? = nil
   ) {
     self.sourceType = sourceType
     self.reason = reason
     self.rationale = rationale
     self.vpAvailable = vpAvailable
     self.fallbackAllowed = fallbackAllowed
+    self.effectiveDeviceUID = effectiveDeviceUID
   }
 }
 
@@ -108,6 +113,8 @@ public struct CaptureRouteDecision: Sendable {
 struct CaptureRouteResolver {
 
   var policy: CaptureSourcePolicy = .automatic
+  var defaultOutputDeviceID: () -> AudioDeviceID? = AudioDeviceEnumerator.defaultOutputDeviceID
+  var isBluetoothOutputDevice: (AudioDeviceID) -> Bool = AudioDeviceEnumerator.isBluetoothDevice
 
   /// Resolve which capture source to use.
   ///
@@ -151,8 +158,8 @@ struct CaptureRouteResolver {
     -> CaptureRouteDecision
   {
     let btOutputActive: Bool
-    if let outID = AudioDeviceEnumerator.defaultOutputDeviceID() {
-      btOutputActive = AudioDeviceEnumerator.isBluetoothDevice(outID)
+    if let outID = defaultOutputDeviceID() {
+      btOutputActive = isBluetoothOutputDevice(outID)
     } else {
       btOutputActive = false
     }
@@ -178,41 +185,23 @@ struct CaptureRouteResolver {
       }
     }
 
-    // BT output active — use AVCaptureSession to avoid A2DP→SCO switch.
-    // Do NOT re-enter AVAudioEngine path under BT output regardless of user preference.
-    let reason: CaptureRouteReason
-    let rationale: String
-
-    if preferredInputDeviceUID.isEmpty {
-      reason = .btOutputAutoInput
-      rationale = "BT output active, auto input — capture session with built-in mic"
-    } else {
-      // Check if user's preferred device is BT
-      let prefDeviceID = AudioDeviceEnumerator.deviceID(forUID: preferredInputDeviceUID)
-      let prefIsBT = prefDeviceID.map { AudioDeviceEnumerator.isBluetoothDevice($0) } ?? false
-
-      if prefIsBT {
-        reason = .btOutputUserSelectedBTMic
-        rationale =
-          "BT output active, user selected BT mic — override to capture session with built-in mic (crash prevention)"
-      } else {
-        // User selected built-in or wired — still use capture session under BT output
-        let isBuiltIn =
-          prefDeviceID.map {
-            AudioDeviceEnumerator.transportType(for: $0) == kAudioDeviceTransportTypeBuiltIn
-          } ?? false
-        reason = isBuiltIn ? .btOutputUserSelectedBuiltIn : .btOutputUserSelectedWired
-        rationale =
-          "BT output active, user selected \(isBuiltIn ? "built-in" : "wired") device — capture session"
-      }
-    }
+    // BT output active: use the low-level device source. It opens the chosen
+    // input directly, so there is no aggregate-device workaround left here.
+    let effectiveDeviceUID = preferredInputDeviceUID.isEmpty ? nil : preferredInputDeviceUID
+    let reason: CaptureRouteReason =
+      preferredInputDeviceUID.isEmpty ? .btOutputAutoInput : .btOutputUserSelectedDevice
+    let rationale =
+      preferredInputDeviceUID.isEmpty
+      ? "BT output active, auto input: HAL device source follows system default"
+      : "BT output active, explicit device pick: HAL device source targets \(preferredInputDeviceUID)"
 
     return CaptureRouteDecision(
-      sourceType: .captureSession,
+      sourceType: .halDeviceInput,
       reason: reason,
       rationale: rationale,
       vpAvailable: false,
-      fallbackAllowed: !btOutputActive  // Only fall back if BT is not active
+      fallbackAllowed: false,
+      effectiveDeviceUID: effectiveDeviceUID
     )
   }
 }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -243,9 +243,8 @@ private final class HALRenderContext: @unchecked Sendable {
 /// #1377 candidate D, reinstated 2026-07-08 to spike against candidate A
 /// (`AVCaptureSessionSource`) on real Bluetooth hardware. Opens ANY device
 /// directly by `AudioDeviceID` (built-in, wired, or Bluetooth) via
-/// `kAudioOutputUnitProperty_CurrentDevice` — no `AVCaptureSession` /
-/// `AVAudioEngine` aggregate-device layer, so there is no
-/// `CADefaultDeviceAggregate` for the force-built-in crash-dodge to avoid.
+/// `kAudioOutputUnitProperty_CurrentDevice`, without an `AVCaptureSession` or
+/// `AVAudioEngine` aggregate-device layer.
 ///
 /// Format conversion is done EXPLICITLY, not by AUHAL: AUHAL input does NOT
 /// resample (Apple QA1777 — "does not provide sample rate conversion" for
@@ -298,11 +297,12 @@ final class HALDeviceInputSource: AudioInputSource {
     return status == noErr && running != 0
   }
 
-  /// Target capture device UID. Nil = built-in mic, same default-nil contract
-  /// as `AVCaptureSessionSource.targetDeviceUID` (#1377 candidate A). Only
-  /// ever set under `CaptureSourcePolicy.forceHALDeviceInput`; `.automatic`
-  /// never emits this candidate, so it is unreachable outside the bake-off.
+  /// Target capture device UID. Nil means follow the live system default input.
   var targetDeviceUID: String?
+
+  var resolveDeviceIDForUID: (String) -> AudioDeviceID? = AudioDeviceEnumerator.deviceID(forUID:)
+  var defaultInputDeviceIDProvider: () -> AudioDeviceID? =
+    AudioDeviceEnumerator.defaultInputDeviceID
 
   // MARK: - Private state
 
@@ -320,11 +320,25 @@ final class HALDeviceInputSource: AudioInputSource {
   private var stoppedFlag: HALStoppedFlag?
   private var isRecovering = false
 
-  #if DEBUG
-    private var boundDeviceID: AudioDeviceID?
-    private var boundUID: String?
-    private var lastBindOK = true
-  #endif
+  private var boundDeviceID: AudioDeviceID?
+  private var boundUID: String?
+  private var boundTransport: String?
+  private var lastBindOK = true
+
+  var actualBoundTransport: String? { boundTransport }
+
+  func resolvedDeviceIDForTesting() -> AudioDeviceID? {
+    resolveDeviceID()
+  }
+
+  func setBoundDeviceIDForTesting(_ deviceID: AudioDeviceID?) {
+    boundDeviceID = deviceID
+  }
+
+  func boundDeviceMatchesResolvedTargetForReuse() -> Bool {
+    guard let boundDeviceID else { return false }
+    return boundDeviceID == resolveDeviceID()
+  }
 
   private static let listenerQueue = DispatchQueue(
     label: "com.enviouswispr.audio.hal-device-listener"
@@ -393,9 +407,7 @@ final class HALDeviceInputSource: AudioInputSource {
       unit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0,
       &pinnedDevice, UInt32(MemoryLayout<AudioDeviceID>.size))
     let bindOK = status == noErr
-    #if DEBUG
-      lastBindOK = bindOK
-    #endif
+    lastBindOK = bindOK
     guard bindOK else {
       AudioComponentInstanceDispose(unit)
       throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.set_device")
@@ -525,15 +537,12 @@ final class HALDeviceInputSource: AudioInputSource {
     self.consumerThread = Self.makeConsumerThread(context: context)
     registerDeviceIsAliveListener(deviceID: deviceID)
 
-    #if DEBUG
-      boundDeviceID = deviceID
-      boundUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
-      AudioCaptureManager.btRouteLog(
-        "HALDeviceInputSource: prepared with device \(deviceID) (uid=\(boundUID ?? "unknown"))"
-      )
-    #else
-      AudioCaptureManager.btRouteLog("HALDeviceInputSource: prepared with device \(deviceID)")
-    #endif
+    boundDeviceID = deviceID
+    boundUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
+    boundTransport = AudioDeviceEnumerator.transportLabel(for: deviceID)
+    AudioCaptureManager.btRouteLog(
+      "HALDeviceInputSource: prepared with device \(deviceID) (uid=\(boundUID ?? "unknown"))"
+    )
   }
 
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
@@ -572,10 +581,9 @@ final class HALDeviceInputSource: AudioInputSource {
     /// Capture-side actual-bound-device evidence (#1377 §3.5), same shape as
     /// the other two conformers so `capture_bakeoff.py` parses it unchanged.
     private func logBenchCaptureEvidence() {
-      let boundTransport =
-        boundDeviceID.flatMap { AudioDeviceEnumerator.transportLabel(for: $0) } ?? "unknown"
+      let evidenceBoundTransport = boundTransport ?? "unknown"
       AudioCaptureManager.btRouteLog(
-        "CAPTURE_EVIDENCE backend=hal_device_input boundUID=\(boundUID ?? "unknown") boundDeviceID=\(boundDeviceID.map(String.init) ?? "nil") boundTransport=\(boundTransport) bindOK=\(lastBindOK) requestedUID=\(targetDeviceUID ?? "built_in")"
+        "CAPTURE_EVIDENCE backend=hal_device_input boundUID=\(boundUID ?? "unknown") boundDeviceID=\(boundDeviceID.map(String.init) ?? "nil") boundTransport=\(evidenceBoundTransport) bindOK=\(lastBindOK) requestedUID=\(targetDeviceUID ?? "system_default")"
       )
     }
   #endif
@@ -698,25 +706,21 @@ final class HALDeviceInputSource: AudioInputSource {
     unmanagedContext = nil
     stoppedFlag = nil
     consumerThread = nil
-    #if DEBUG
-      boundDeviceID = nil
-      boundUID = nil
-    #endif
+    boundDeviceID = nil
+    boundUID = nil
+    boundTransport = nil
   }
 
   // MARK: - Private: device resolution
 
-  /// Resolve the pinned target device, falling back to built-in with the
-  /// SAME log-text fragment `AVCaptureSessionSource` uses ("not found —
-  /// falling back") so `capture_bakeoff.py`'s `FALLBACK_MARKER` catches it
-  /// unchanged for this candidate too.
+  /// Resolve the pinned target device, falling back to the live system default.
   private func resolveDeviceID() -> AudioDeviceID? {
     if let uid = targetDeviceUID, !uid.isEmpty {
-      if let id = AudioDeviceEnumerator.deviceID(forUID: uid) { return id }
+      if let id = resolveDeviceIDForUID(uid) { return id }
       AudioCaptureManager.btRouteLog(
-        "HALDeviceInputSource: target device uid=\(uid) not found — falling back to built-in")
+        "HALDeviceInputSource: target device uid=\(uid) not found — falling back to system default")
     }
-    return AudioDeviceEnumerator.builtInMicrophoneDeviceID()
+    return defaultInputDeviceIDProvider()
   }
 
   /// Read the device's OWN native stream format directly from the HAL device

--- a/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
+++ b/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
@@ -7,10 +7,8 @@ import CoreAudio
 /// read this one value instead of re-deriving from raw inputs
 /// (`telemetry-observes-resolved-value-deny-by-default`).
 ///
-/// `routeResolutionSource` is the constant `"app_derived"` this phase: the value
-/// reflects the app-side resolver DECISION, not a helper-observed hardware
-/// binding. Phase 3 introduces `"helper_reported"` when the truly device-bound
-/// transport crosses the capture-helper seam.
+/// `routeResolutionSource` is `"app_derived"` unless the caller supplies the
+/// actual transport reported by the bound capture source.
 public struct ResolvedRouteTransports: Sendable, Equatable {
   /// Transport of the user's picked device, or `"unknown"` on Auto / unmappable.
   public let selected: String
@@ -22,13 +20,13 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
   /// `failedNoFallback`); absent otherwise. The presence IS the signal.
   public let routeFallbackReason: String?
   /// `explicit` when the user pinned a device, `auto` when on system-default,
-  /// `unknown` reserved. Separates the trust-breach cohort (explicit BT pick
-  /// forced to built-in) from the endorsed-policy cohort (Auto → built-in).
+  /// `unknown` reserved. Separates explicit user picks from Auto's system-default
+  /// policy.
   public let inputSelectionMode: String
   /// Transport of the current default OUTPUT device (`"unknown"` if unreadable).
   /// The forced-built-in workaround only triggers under Bluetooth output.
   public let outputTransport: String
-  /// How the value was obtained: `"app_derived"` this phase.
+  /// How the value was obtained: `"app_derived"` or `"helper_reported"`.
   public let routeResolutionSource: String
 
   public init(
@@ -56,7 +54,8 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
   public static func derive(
     decision: CaptureRouteDecision,
     preferredInputDeviceIDOverride: String,
-    selectedInputDeviceUID: String
+    selectedInputDeviceUID: String,
+    actualBoundTransport: String? = nil
   ) -> ResolvedRouteTransports {
     // The user's EXPLICIT pick is the settings mic picker, which binds to
     // `preferredInputDeviceIDOverride` ("Auto" = empty) — AND the route resolver
@@ -74,10 +73,12 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
       : (AudioDeviceEnumerator.transportLabel(forUID: preferredInputDeviceIDOverride) ?? "unknown")
 
     let effective: String
+    let usedActualBoundTransport: Bool
     switch decision.sourceType {
     case .captureSession:
       // The capture-session path opens the built-in mic only today (bible R4).
       effective = "built_in"
+      usedActualBoundTransport = false
     case .audioEngine:
       // Mirror AVAudioEngineSource's device resolution exactly: the preferred
       // override, else the stored selection, else the system-default input
@@ -94,23 +95,23 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
       } else {
         effective = "unknown"
       }
+      usedActualBoundTransport = false
     case .halDeviceInput:
-      // Dormant candidate D (#1377 slice 2b) — only reachable via
-      // `.forceHALDeviceInput`. A resolvable pin reports its own transport
-      // (mirrors the pinned device HALDeviceInputSource actually opens). With
-      // NO pin (or a stale one), `HALDeviceInputSource.resolveDeviceID()`
-      // falls back to the literal built-in mic — same as
-      // `AVCaptureSessionSource`'s fallback, NOT "whatever the system default
-      // happens to be" the way `AVAudioEngineSource` falls back. Reporting
-      // the system-default transport here would be wrong whenever the
-      // default input isn't built-in (cloud review P2).
-      let halUID =
-        preferredInputDeviceIDOverride.isEmpty
-        ? selectedInputDeviceUID : preferredInputDeviceIDOverride
-      if !halUID.isEmpty, let label = AudioDeviceEnumerator.transportLabel(forUID: halUID) {
-        effective = label
+      if let actualBoundTransport {
+        effective = actualBoundTransport
+        usedActualBoundTransport = true
       } else {
-        effective = "built_in"
+        let halUID =
+          preferredInputDeviceIDOverride.isEmpty
+          ? selectedInputDeviceUID : preferredInputDeviceIDOverride
+        if !halUID.isEmpty, let label = AudioDeviceEnumerator.transportLabel(forUID: halUID) {
+          effective = label
+        } else if let defaultID = AudioDeviceEnumerator.defaultInputDeviceID() {
+          effective = AudioDeviceEnumerator.transportLabel(for: defaultID) ?? "unknown"
+        } else {
+          effective = "unknown"
+        }
+        usedActualBoundTransport = false
       }
     }
 
@@ -129,7 +130,7 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
       routeFallbackReason: fallbackReason,
       inputSelectionMode: selectionMode,
       outputTransport: outputTransport,
-      routeResolutionSource: "app_derived"
+      routeResolutionSource: usedActualBoundTransport ? "helper_reported" : "app_derived"
     )
   }
 }

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -37,6 +37,7 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
   var warmEnginePolicy: WarmEnginePolicy = .off
+  var preWarmError: Error?
   /// #1063 PR1: counts `abortPreWarm()` so the release-during-recovery-arm guard
   /// (Codex code-diff r2 P2) can assert the prewarmed engine is torn down.
   private(set) var abortPreWarmCallCount = 0
@@ -51,7 +52,9 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
   func buildEngine(noiseSuppression: Bool) {}
-  func preWarm() async throws {}
+  func preWarm() async throws {
+    if let preWarmError { throw preWarmError }
+  }
   func abortPreWarm() { abortPreWarmCallCount += 1 }
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
     true

--- a/Tests/EnviousWisprTests/App/InputDevicePreferenceReconcilerTests.swift
+++ b/Tests/EnviousWisprTests/App/InputDevicePreferenceReconcilerTests.swift
@@ -1,0 +1,129 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprAudio
+@testable import EnviousWisprServices
+
+@MainActor
+@Suite("Input device preference reconciliation — #1378")
+struct InputDevicePreferenceReconcilerTests {
+  init() { _ = NSApplication.shared }
+
+  private static func freshSuite() -> UserDefaults {
+    let name = "ew.inputDevicePreferenceTest." + UUID().uuidString
+    let defaults = UserDefaults(suiteName: name)!
+    defaults.removePersistentDomain(forName: name)
+    return defaults
+  }
+
+  private static func device(_ uid: String) -> AudioInputDevice {
+    AudioInputDevice(id: 1, name: uid, uid: uid)
+  }
+
+  @Test(
+    "policy covers full preferred x selected grid",
+    arguments: [
+      ("", "", ["connected"], "", ""),
+      ("", "connected", ["connected"], "connected", "connected"),
+      ("", "missing", ["connected"], "", "missing"),
+      ("connected", "", ["connected"], "connected", "connected"),
+      ("connected", "connected", ["connected"], "connected", "connected"),
+      ("connected", "missing", ["connected"], "connected", "connected"),
+      ("missing", "", ["connected"], "", "missing"),
+      ("missing", "connected", ["connected"], "", "missing"),
+      ("missing", "missing", ["connected"], "", "missing"),
+    ])
+  func policyGrid(
+    preferred: String,
+    selected: String,
+    connected: [String],
+    expectedPreferred: String,
+    expectedSelected: String
+  ) {
+    let result = InputDevicePreferencePolicy.reconciled(
+      preferredOverride: preferred,
+      selectedUID: selected,
+      connectedUIDs: Set(connected)
+    )
+
+    #expect(result.preferredOverride == expectedPreferred)
+    #expect(result.selectedUID == expectedSelected)
+  }
+
+  @Test("reconciler writes only when values change")
+  func reconcilerWritesOnlyWhenValuesChange() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    settings.preferredInputDeviceIDOverride = "usb"
+    settings.selectedInputDeviceUID = "usb"
+
+    var changes: [SettingsManager.SettingKey] = []
+    settings.onChange = { changes.append($0) }
+
+    let reconciler = InputDevicePreferenceReconciler(settings: settings)
+    reconciler.reconcile(availableDevices: [Self.device("usb")])
+
+    #expect(changes.isEmpty)
+  }
+
+  @Test("launch reconcile closes the gap before the next hardware notification")
+  func explicitLaunchReconcileClosesInitialGap() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    settings.preferredInputDeviceIDOverride = "usb"
+    settings.selectedInputDeviceUID = ""
+    let audioDeviceList = AudioDeviceList()
+    audioDeviceList.availableInputDevices = [Self.device("usb")]
+
+    let reconciler = InputDevicePreferenceReconciler(settings: settings)
+    audioDeviceList.onDevicesChanged = { devices in
+      reconciler.reconcile(availableDevices: devices)
+    }
+    reconciler.reconcile(availableDevices: audioDeviceList.availableInputDevices)
+
+    #expect(settings.preferredInputDeviceIDOverride == "usb")
+    #expect(settings.selectedInputDeviceUID == "usb")
+  }
+
+  @Test("automatic reconciliation marks changed writes as system writes")
+  func changedWritesAreSystemWrites() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    settings.preferredInputDeviceIDOverride = "usb"
+    settings.selectedInputDeviceUID = ""
+
+    var sources: [Bool] = []
+    settings.onChange = { _ in sources.append(settings.isApplyingSystemWrite) }
+
+    let reconciler = InputDevicePreferenceReconciler(settings: settings)
+    reconciler.reconcile(availableDevices: [Self.device("usb")])
+
+    #expect(sources == [true])
+    #expect(settings.isApplyingSystemWrite == false)
+  }
+
+  @Test("disconnected explicit pick returns to Auto but remains remembered")
+  func disconnectedExplicitPickReturnsToAutoButStaysRemembered() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    settings.preferredInputDeviceIDOverride = "gone"
+    settings.selectedInputDeviceUID = "old"
+
+    let reconciler = InputDevicePreferenceReconciler(settings: settings)
+    reconciler.reconcile(availableDevices: [])
+
+    #expect(settings.preferredInputDeviceIDOverride == "")
+    #expect(settings.selectedInputDeviceUID == "gone")
+  }
+
+  @Test("system fallback to Auto does not clear the remembered device")
+  func systemFallbackDoesNotClearRememberedDevice() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    settings.preferredInputDeviceIDOverride = "usb"
+    settings.selectedInputDeviceUID = "usb"
+
+    let reconciler = InputDevicePreferenceReconciler(settings: settings)
+    reconciler.reconcile(availableDevices: [])
+
+    #expect(settings.preferredInputDeviceIDOverride == "")
+    #expect(settings.selectedInputDeviceUID == "usb")
+  }
+}

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -175,6 +175,31 @@ import Testing
     #expect(fx.lastRecordingResult.polishError == nil)
   }
 
+  @Test("raw no-microphone prewarm error surfaces distinct copy")
+  func rawNoMicrophonePrewarmErrorSurfacesDistinctCopy() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+    fx.audio.preWarmError = AudioError.noBuiltInMicrophoneFound
+
+    await fx.starter.start()
+
+    #expect(fx.kernelDriver.state == .error("No microphone found. Please connect a microphone."))
+  }
+
+  @Test("XPC-sanitized no-microphone prewarm error surfaces distinct copy")
+  func sanitizedNoMicrophonePrewarmErrorSurfacesDistinctCopy() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+    fx.audio.preWarmError = XPCErrorSanitizer.sanitizeForXPC(
+      AudioError.noBuiltInMicrophoneFound)
+
+    await fx.starter.start()
+
+    #expect(fx.kernelDriver.state == .error("No microphone found. Please connect a microphone."))
+  }
+
   /// The old `toggleAndStartBothRefreshAccessibilityStatus` had ZERO `#expect` —
   /// it only checked crash-freedom, so deleting the AX re-arm block from
   /// `start()`/`toggle()` left it green. This injects a counting spy and asserts

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -142,13 +142,18 @@ import Testing
   ///   Pipeline handle) and the settings UI (Cancel/Resume) — same shape as
   ///   `egOneRuntime` above. The Phase 2 plan §3b/§14 named this +1 as the
   ///   accepted cost; pre-#1348 count was at the cap (34).
+  /// - 35 → 36 in #1378 (2026-07-08): App-owned
+  ///   `inputDevicePreferenceReconciler` keeps the microphone picker honest
+  ///   when connected devices or the system default input change. The decision
+  ///   rule lives in a pure policy function; the bootstrapper stores only the
+  ///   app-lifetime wiring object.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 35,
+      count <= 36,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 35. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 36. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.
@@ -305,14 +310,19 @@ import Testing
   /// limb; all logic lives in the adapter/runtime, not here. Cap by the
   /// deterministic rule (post-change actual 976 + ~2, rounded up to nearest
   /// 5 = 980).
+  /// Ratcheted 980→995 in #1378 (2026-07-08): the composition root constructs
+  /// `InputDevicePreferenceReconciler`, wires `AudioDeviceList.onDevicesChanged`,
+  /// and performs the required launch-time reconcile after callback wiring.
+  /// Policy remains outside the root. Cap by deterministic rule (actual 984
+  /// + 10, rounded up to nearest 5 = 995).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 980,
+      lineCount <= 995,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 980. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 995. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Audio/AudioErrorIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioErrorIdentityTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+@testable import EnviousWisprCore
+
+@Suite("AudioError identity — #1378")
+struct AudioErrorIdentityTests {
+
+  @Test("no-microphone error has stable NSError identity")
+  func noMicrophoneNSErrorIdentity() {
+    let error = AudioError.noBuiltInMicrophoneFound as NSError
+    #expect(error.domain == AudioError.errorDomain)
+    #expect(error.code == AudioError.noBuiltInMicrophoneFound.errorCode)
+    #expect(error.localizedDescription == "No microphone found. Please connect a microphone.")
+  }
+
+  @Test("XPC sanitizer preserves no-microphone domain and code")
+  func xpcSanitizerPreservesNoMicrophoneIdentity() {
+    let sanitized = XPCErrorSanitizer.sanitizeForXPC(AudioError.noBuiltInMicrophoneFound)
+    #expect(sanitized.domain == AudioError.errorDomain)
+    #expect(sanitized.code == AudioError.noBuiltInMicrophoneFound.errorCode)
+    #expect(sanitized.localizedDescription == "No microphone found. Please connect a microphone.")
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
@@ -1,3 +1,4 @@
+import CoreAudio
 import Foundation
 import Testing
 
@@ -105,15 +106,15 @@ struct AVCaptureSessionSourceDeviceTargetTests {
   }
 }
 
-// #1377 slice 2b (reinstated 2026-07-08) — locks candidate D's identical
-// additive device-target contract to candidate A's: default nil (built-in),
-// pinned UID reflected. WHICH device actually binds is hardware-dependent and
-// proven by the bake-off Live UAT (the founder's Bose headset spike), not here.
+// #1377 slice 2b / #1378 — locks candidate D's additive device-target contract:
+// default nil follows the live system-default input, and a pinned UID is
+// reflected. WHICH device actually binds is hardware-dependent and proven by
+// Live UAT, not here.
 @MainActor
 @Suite("HALDeviceInputSource device target — #1377")
 struct HALDeviceInputSourceDeviceTargetTests {
 
-  @Test("default target is nil (automatic path leaves it built-in)")
+  @Test("default target is nil (automatic path follows system default)")
   func defaultTargetIsNil() {
     let source = HALDeviceInputSource()
     #expect(source.targetDeviceUID == nil)
@@ -124,5 +125,67 @@ struct HALDeviceInputSourceDeviceTargetTests {
     let source = HALDeviceInputSource()
     source.targetDeviceUID = "BC-87-FA-9C-7E-71:input"
     #expect(source.targetDeviceUID == "BC-87-FA-9C-7E-71:input")
+  }
+
+  @Test("nil target resolves to current system default input")
+  func nilTargetResolvesToDefaultInput() {
+    let source = HALDeviceInputSource()
+    source.defaultInputDeviceIDProvider = { 42 }
+    #expect(source.resolvedDeviceIDForTesting() == 42)
+  }
+
+  @Test("unresolvable target falls back to current system default input")
+  func missingTargetFallsBackToDefaultInput() {
+    let source = HALDeviceInputSource()
+    source.targetDeviceUID = "gone"
+    source.resolveDeviceIDForUID = { _ in nil }
+    source.defaultInputDeviceIDProvider = { 42 }
+    #expect(source.resolvedDeviceIDForTesting() == 42)
+  }
+
+  @Test("resolvable target wins over system default input")
+  func resolvedTargetWins() {
+    let source = HALDeviceInputSource()
+    source.targetDeviceUID = "present"
+    source.resolveDeviceIDForUID = { uid in uid == "present" ? 99 : nil }
+    source.defaultInputDeviceIDProvider = { 42 }
+    #expect(source.resolvedDeviceIDForTesting() == 99)
+  }
+
+  @Test("warm automatic source is reusable while bound to current system default")
+  func automaticReuseMatchesCurrentDefault() {
+    let source = HALDeviceInputSource()
+    source.defaultInputDeviceIDProvider = { 42 }
+    source.setBoundDeviceIDForTesting(42)
+
+    #expect(source.boundDeviceMatchesResolvedTargetForReuse())
+  }
+
+  @Test("warm automatic source rejects stale system default")
+  func automaticReuseRejectsStaleDefault() {
+    let source = HALDeviceInputSource()
+    var currentDefault: AudioDeviceID = 42
+    source.defaultInputDeviceIDProvider = { currentDefault }
+    source.setBoundDeviceIDForTesting(42)
+
+    currentDefault = 43
+
+    #expect(!source.boundDeviceMatchesResolvedTargetForReuse())
+  }
+
+  @Test("warm explicit source follows fallback default when target is missing")
+  func explicitMissingTargetReuseTracksFallbackDefault() {
+    let source = HALDeviceInputSource()
+    source.targetDeviceUID = "missing"
+    source.resolveDeviceIDForUID = { _ in nil }
+    var currentDefault: AudioDeviceID = 42
+    source.defaultInputDeviceIDProvider = { currentDefault }
+    source.setBoundDeviceIDForTesting(42)
+
+    #expect(source.boundDeviceMatchesResolvedTargetForReuse())
+
+    currentDefault = 43
+
+    #expect(!source.boundDeviceMatchesResolvedTargetForReuse())
   }
 }

--- a/Tests/EnviousWisprTests/Audio/CaptureRouteResolverTests.swift
+++ b/Tests/EnviousWisprTests/Audio/CaptureRouteResolverTests.swift
@@ -1,0 +1,57 @@
+import CoreAudio
+import Testing
+
+@testable import EnviousWisprAudio
+
+@MainActor
+@Suite("CaptureRouteResolver — #1378")
+struct CaptureRouteResolverTests {
+  private func resolver(btOutputActive: Bool) -> CaptureRouteResolver {
+    var resolver = CaptureRouteResolver()
+    resolver.defaultOutputDeviceID = { 1 }
+    resolver.isBluetoothOutputDevice = { _ in btOutputActive }
+    return resolver
+  }
+
+  @Test("non-BT output keeps Auto on AVAudioEngine")
+  func nonBTOutputAutoUsesEngine() {
+    let decision = resolver(btOutputActive: false).resolve(
+      preferredInputDeviceUID: "", noiseSuppression: false)
+
+    #expect(decision.sourceType == .audioEngine)
+    #expect(decision.reason == .noBTAutoInput)
+    #expect(decision.effectiveDeviceUID == nil)
+  }
+
+  @Test("non-BT output keeps explicit picks on AVAudioEngine")
+  func nonBTOutputExplicitUsesEngine() {
+    let decision = resolver(btOutputActive: false).resolve(
+      preferredInputDeviceUID: "usb-mic", noiseSuppression: false)
+
+    #expect(decision.sourceType == .audioEngine)
+    #expect(decision.reason == .noBTUserSelectedDevice)
+    #expect(decision.effectiveDeviceUID == nil)
+  }
+
+  @Test("BT output Auto uses HAL device input with nil target")
+  func btOutputAutoUsesHALWithSystemDefaultTarget() {
+    let decision = resolver(btOutputActive: true).resolve(
+      preferredInputDeviceUID: "", noiseSuppression: false)
+
+    #expect(decision.sourceType == .halDeviceInput)
+    #expect(decision.reason == .btOutputAutoInput)
+    #expect(decision.effectiveDeviceUID == nil)
+    #expect(decision.fallbackAllowed == false)
+  }
+
+  @Test("BT output explicit pick uses HAL device input and carries UID")
+  func btOutputExplicitUsesHALWithTarget() {
+    let decision = resolver(btOutputActive: true).resolve(
+      preferredInputDeviceUID: "airpods-input", noiseSuppression: false)
+
+    #expect(decision.sourceType == .halDeviceInput)
+    #expect(decision.reason == .btOutputUserSelectedDevice)
+    #expect(decision.effectiveDeviceUID == "airpods-input")
+    #expect(decision.fallbackAllowed == false)
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
+++ b/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
@@ -24,8 +24,7 @@ struct ResolvedRouteTransportsGridTests {
     "derive is total over the sourceType × reason grid",
     arguments: [CaptureSourceType.audioEngine, .captureSession, .halDeviceInput],
     [
-      CaptureRouteReason.btOutputAutoInput, .btOutputUserSelectedBTMic,
-      .btOutputUserSelectedBuiltIn, .btOutputUserSelectedWired, .noBTAutoInput,
+      CaptureRouteReason.btOutputAutoInput, .btOutputUserSelectedDevice, .noBTAutoInput,
       .noBTUserSelectedDevice, .forcedEngine, .forcedCaptureSession,
       .fallbackToEngine, .failedNoFallback,
     ])
@@ -40,11 +39,8 @@ struct ResolvedRouteTransportsGridTests {
     #expect((r.routeFallbackReason != nil) == isFallbackRung)
     if isFallbackRung { #expect(r.routeFallbackReason == reason.rawValue) }
 
-    // The capture-session path opens the built-in mic only today (bible R4).
-    // HALDeviceInputSource's no-pin fallback is the SAME literal built-in mic
-    // (cloud review P2 on PR #1418 — the prior system-default-style fallback
-    // here didn't match what the source actually opens).
-    if source == .captureSession || source == .halDeviceInput {
+    // The capture-session path still opens the built-in mic.
+    if source == .captureSession {
       #expect(r.effective == "built_in")
     }
 
@@ -57,27 +53,32 @@ struct ResolvedRouteTransportsGridTests {
     #expect(!r.effective.isEmpty)
   }
 
-  @Test("explicit Bluetooth pick under BT output: mode=explicit, effective forced to built_in")
-  func explicitBTMicForcedToBuiltIn() {
-    // The core invisible divergence: the user explicitly picked a Bluetooth mic,
-    // but the capture-session route forces the built-in mic. The fake UID does
-    // not resolve to a live device, so `selected` is "unknown", yet the SELECTION
-    // MODE is explicit because the user pinned a device.
+  @Test("explicit Bluetooth pick under BT output: mode=explicit, route reason is unified")
+  func explicitBTMicUsesUnifiedReason() {
     let r = ResolvedRouteTransports.derive(
-      decision: makeDecision(.captureSession, .btOutputUserSelectedBTMic),
+      decision: makeDecision(.halDeviceInput, .btOutputUserSelectedDevice),
       preferredInputDeviceIDOverride: "fake-bt-uid", selectedInputDeviceUID: "")
     #expect(r.inputSelectionMode == "explicit")
-    #expect(r.effective == "built_in")
-    #expect(r.routeReason == "btOutputUserSelectedBTMic")
+    #expect(r.routeReason == "btOutputUserSelectedDevice")
   }
 
-  @Test("wired pick under BT output also yields effective=built_in (non-intended class)")
+  @Test("bound HAL transport wins over live re-derivation")
+  func boundHALTransportWins() {
+    let r = ResolvedRouteTransports.derive(
+      decision: makeDecision(.halDeviceInput, .btOutputAutoInput),
+      preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "",
+      actualBoundTransport: "bluetooth")
+    #expect(r.effective == "bluetooth")
+    #expect(r.routeResolutionSource == "helper_reported")
+  }
+
+  @Test("wired pick under BT output uses unified explicit reason")
   func wiredUnderBTOutput() {
     let r = ResolvedRouteTransports.derive(
-      decision: makeDecision(.captureSession, .btOutputUserSelectedWired),
+      decision: makeDecision(.halDeviceInput, .btOutputUserSelectedDevice),
       preferredInputDeviceIDOverride: "fake-wired-uid", selectedInputDeviceUID: "")
-    #expect(r.effective == "built_in")
     #expect(r.inputSelectionMode == "explicit")
+    #expect(r.routeReason == "btOutputUserSelectedDevice")
   }
 
   @Test("selection mode follows the settings picker; a bare selectedInputDeviceUID stays Auto")
@@ -111,7 +112,7 @@ struct ResolvedRouteTransportsGridTests {
     // preferredInputDeviceIDOverride set (the picker) → explicit, and the
     // resolver saw the same value, so route_reason is a user-selected reason.
     let r = ResolvedRouteTransports.derive(
-      decision: makeDecision(.captureSession, .btOutputUserSelectedBTMic),
+      decision: makeDecision(.halDeviceInput, .btOutputUserSelectedDevice),
       preferredInputDeviceIDOverride: "fake-bt-uid", selectedInputDeviceUID: "")
     #expect(r.inputSelectionMode == "explicit")
   }

--- a/Tests/EnviousWisprTests/Audio/RouteResolvedProducerTests.swift
+++ b/Tests/EnviousWisprTests/Audio/RouteResolvedProducerTests.swift
@@ -35,7 +35,7 @@ struct RouteResolvedProducerTests {
   @Test("re-fires when the reason differs (same sourceType)")
   func reasonChanged() {
     let prior = decision(.captureSession, .btOutputAutoInput)
-    let next = decision(.captureSession, .btOutputUserSelectedBTMic)
+    let next = decision(.captureSession, .btOutputUserSelectedDevice)
     #expect(CaptureRouteDecision.routeResolvedChanged(from: prior, to: next))
   }
 

--- a/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
@@ -31,14 +31,14 @@ struct DictationCompletedRouteFieldsTests {
       TelemetryService.shared.reportDictationCompleted(
         transcript: Transcript(text: "hello"), inputMode: "ptt",
         selectedTransport: "bluetooth", effectiveTransport: "built_in",
-        routeReason: "btOutputUserSelectedBTMic",
+        routeReason: "btOutputUserSelectedDevice",
         inputSelectionMode: "explicit", outputTransport: "bluetooth",
         routeResolutionSource: "app_derived")
 
       let props = box.event?.stringProps
       #expect(props?["selected_transport"] == "bluetooth")
       #expect(props?["effective_transport"] == "built_in")
-      #expect(props?["route_reason"] == "btOutputUserSelectedBTMic")
+      #expect(props?["route_reason"] == "btOutputUserSelectedDevice")
       #expect(props?["input_selection_mode"] == "explicit")
       #expect(props?["output_transport"] == "bluetooth")
       #expect(props?["route_resolution_source"] == "app_derived")

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasRouteTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasRouteTests.swift
@@ -20,13 +20,13 @@ struct SentryAudioExtrasRouteTests {
       isActivelyCapturing: true, inputDeviceUIDPreferred: nil,
       inputDeviceUIDSystemDefault: nil, failureMode: "no_audio_captured",
       selectedTransport: "bluetooth", effectiveTransport: "built_in",
-      routeReason: "btOutputUserSelectedBTMic", routeFallbackReason: nil,
+      routeReason: "btOutputUserSelectedDevice", routeFallbackReason: nil,
       inputSelectionMode: "explicit", outputTransport: "bluetooth",
       routeResolutionSource: "app_derived")
 
     #expect(extras["capture.selected_transport"] as? String == "bluetooth")
     #expect(extras["capture.effective_transport"] as? String == "built_in")
-    #expect(extras["capture.route_reason"] as? String == "btOutputUserSelectedBTMic")
+    #expect(extras["capture.route_reason"] as? String == "btOutputUserSelectedDevice")
     #expect(extras["capture.input_selection_mode"] as? String == "explicit")
     #expect(extras["capture.output_transport"] as? String == "bluetooth")
     #expect(extras["capture.route_resolution_source"] as? String == "app_derived")


### PR DESCRIPTION
## Summary
- Auto input under Bluetooth output now follows the macOS system input using the HAL input source.
- Explicit stale or missing input choices safely fall back to the current system default.
- Warm HAL input reuse now checks the current resolved/default input, so a warm mic cannot pin the old source after the user changes input.

Fixes #1378
Closes #1426

## Validation
- scripts/xcode-test.sh --release: passed Debug lane and Release lane; Release executed 2311 tests after the final rebase.
- swift test --filter HALDeviceInputSourceDeviceTargetTests: passed.
- ~/.claude/bin/codex-5.5 review --base origin/main: no clear actionable bugs found after the warm-source fix.
- git diff --check: clean.

Note: Xcode still prints the existing CoreSimulator out-of-date warning, but the macOS test lanes passed.