### PR TITLE
fix(pipeline): route confident non-text paste refusals to breadcrumb, not Sentry alert

### DIFF
--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -408,25 +408,32 @@ internal final class PasteCascadeExecutor {
       return
     case .clipboardOnly(let tiers, let focus, let bundle, let accessibilityTrusted, let diagnostics):
       let tierStrings = tiers.map(\.rawValue)
-      let err = HeartPathError.pasteCascadeClipboardFallback(
+      let extra = Self.clipboardOnlyTelemetryExtra(
         tiersAttempted: tierStrings,
-        focusClassification: focus.telemetryLabel,
-        targetBundleID: bundle
+        focus: focus,
+        targetBundleID: bundle,
+        accessibilityTrusted: accessibilityTrusted,
+        targetDiagnostics: diagnostics,
+        tierFailures: tierFailures,
+        focusClass: focusClass
       )
-      SentryBreadcrumb.captureError(
-        err,
-        category: .pasteFailed,
-        stage: "paste",
-        extra: Self.clipboardOnlyTelemetryExtra(
-          tiersAttempted: tierStrings,
-          focus: focus,
-          targetBundleID: bundle,
-          accessibilityTrusted: accessibilityTrusted,
-          targetDiagnostics: diagnostics,
-          tierFailures: tierFailures,
-          focusClass: focusClass
+      if Self.isExpectedNonTextRefusal(
+        focus: focus, roleSource: diagnostics.roleSource, focusClass: focusClass
+      ) {
+        SentryBreadcrumb.add(
+          stage: "paste",
+          message: "paste.outcome=clipboard_only_no_target",
+          level: .info,
+          data: extra
         )
-      )
+      } else {
+        let err = HeartPathError.pasteCascadeClipboardFallback(
+          tiersAttempted: tierStrings,
+          focusClassification: focus.telemetryLabel,
+          targetBundleID: bundle
+        )
+        SentryBreadcrumb.captureError(err, category: .pasteFailed, stage: "paste", extra: extra)
+      }
     case .cgEventCreationFailed(let accessibilityTrusted):
       let err = HeartPathError.pasteCGEventCreationFailed(
         accessibilityTrusted: accessibilityTrusted)
@@ -452,6 +459,30 @@ internal final class PasteCascadeExecutor {
         ]
       )
     }
+  }
+
+  /// True when the cascade confidently identified the focused target,
+  /// correctly determined it isn't a text field, AND the Tier 2c menu probe
+  /// positively confirmed no real paste target exists — a working-as-intended
+  /// decline, not a failure. False in every other case keeps the existing
+  /// alert-creating path, since anything short of that full confirmation is
+  /// a case that could indicate a real, scaling defect (#1430).
+  ///
+  /// Requires exact confirmation (`focusClass == "no_paste_target"`) rather
+  /// than defaulting an absent probe result to "no target": `canAttemptKeyPaste`
+  /// is always false for `.nonText`, so Tier 2c's menu probe is the ONLY paste
+  /// attempt for non-text targets, and `focusClass` is nil whenever that probe
+  /// never ran or never resolved — activation timeout, a terminated target
+  /// app, or no target app captured at all (Codex code-diff review r2) — none
+  /// of which is a confirmed refusal. `"non_text_with_paste_target"` means the
+  /// probe found a real, enabled paste target and pressing it failed — also a
+  /// real failure, not a refusal (Codex code-diff review r1). Any other/future
+  /// focusClass label fails closed the same way, matching the roleSource
+  /// invariant above.
+  internal static func isExpectedNonTextRefusal(
+    focus: PasteFocusClassification, roleSource: String, focusClass: String?
+  ) -> Bool {
+    focus == .nonText && roleSource == "captured_target" && focusClass == "no_paste_target"
   }
 
   internal static func clipboardOnlyTelemetryExtra(

--- a/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteTelemetryPayloadTests.swift
@@ -127,6 +127,97 @@ struct PasteTelemetryPayloadTests {
     assertNoContentLikeKeys(noTarget)
   }
 
+  @Test("absent menu probe keeps full alerting, does not default to downgrade (Codex code-diff r2)")
+  func absentMenuProbeKeepsAlerting() {
+    // focusClass is nil whenever Tier 2c's probe never ran or never resolved:
+    // activation timeout, a terminated target app, or no target app captured
+    // at all. None of these confirm "no real target" -- only an explicit
+    // "no_paste_target" result does, so nil must NOT default to a downgrade.
+    #expect(
+      PasteCascadeExecutor.isExpectedNonTextRefusal(
+        focus: .nonText, roleSource: "captured_target", focusClass: nil
+      ) == false
+    )
+  }
+
+  @Test("confident non-text refusal with a confirmed-no-target probe downgrades")
+  func confirmedNoTargetProbeDowngrades() {
+    #expect(
+      PasteCascadeExecutor.isExpectedNonTextRefusal(
+        focus: .nonText, roleSource: "captured_target", focusClass: "no_paste_target"
+      ) == true
+    )
+  }
+
+  @Test("menu probe finding a real paste target keeps full alerting (Codex code-diff r1)")
+  func menuProbeFoundRealTargetKeepsAlerting() {
+    // Tier 2c found an enabled Edit > Paste item and pressing it failed
+    // (tierFailures["menu_paste"] == "press_failed") -- a real paste failure,
+    // not a no-target refusal, even though the earlier AX role read said
+    // non-text with high confidence.
+    #expect(
+      PasteCascadeExecutor.isExpectedNonTextRefusal(
+        focus: .nonText, roleSource: "captured_target",
+        focusClass: "non_text_with_paste_target"
+      ) == false
+    )
+  }
+
+  @Test("failed role identification keeps full alerting")
+  func failedRoleIdentificationKeepsAlerting() {
+    #expect(
+      PasteCascadeExecutor.isExpectedNonTextRefusal(
+        focus: .nonText, roleSource: "unavailable", focusClass: nil
+      ) == false
+    )
+  }
+
+  @Test("missing target keeps full alerting regardless of roleSource")
+  func missingTargetKeepsAlerting() {
+    #expect(
+      PasteCascadeExecutor.isExpectedNonTextRefusal(
+        focus: .missing, roleSource: "captured_target", focusClass: nil
+      ) == false
+    )
+  }
+
+  @Test("text field focus keeps full alerting regardless of roleSource")
+  func textFieldFocusKeepsAlerting() {
+    #expect(
+      PasteCascadeExecutor.isExpectedNonTextRefusal(
+        focus: .textField, roleSource: "captured_target", focusClass: nil
+      ) == false
+    )
+  }
+
+  @Test("unrecognized roleSource string fails closed to full alerting")
+  func unrecognizedRoleSourceFailsClosed() {
+    // Guards against an unrelated future rename of the "captured_target"
+    // literal elsewhere silently reopening the false-positive noise (#1430).
+    #expect(
+      PasteCascadeExecutor.isExpectedNonTextRefusal(
+        focus: .nonText, roleSource: "ax_success", focusClass: nil
+      ) == false
+    )
+    #expect(
+      PasteCascadeExecutor.isExpectedNonTextRefusal(
+        focus: .nonText, roleSource: "", focusClass: nil
+      ) == false
+    )
+  }
+
+  @Test("unrecognized focusClass string fails closed to full alerting")
+  func unrecognizedFocusClassFailsClosed() {
+    // Guards the same fail-closed invariant for the focusClass corroboration:
+    // an unrelated future label added to MenuPasteProbe must not silently
+    // reopen the false-positive noise by being mistaken for "no target".
+    #expect(
+      PasteCascadeExecutor.isExpectedNonTextRefusal(
+        focus: .nonText, roleSource: "captured_target", focusClass: "some_future_label"
+      ) == false
+    )
+  }
+
   private func assertNoContentLikeKeys(_ extra: [String: Any]) {
     for key in extra.keys {
       let lower = key.lowercased()


### PR DESCRIPTION
## Summary
- The paste cascade fired a full Sentry alert (`captureError`) for every clipboard-only outcome, including when it correctly and confidently determined the focused element wasn't a text field. Two live incidents (#980, #1332) showed this is the dominant source of false-positive bug tickets from the automated Sentry-triage bot — one fingerprint grew to 130 users while ~99% were confident, correct non-text refusals, not real failures.
- Adds `isExpectedNonTextRefusal(focus:roleSource:focusClass:)`, mirroring the existing `.clipboardOnlyAccessibilityDenied` breadcrumb-downgrade pattern one branch below. Downgrades to an info breadcrumb only when the cascade (a) confidently read the focused element's role as non-text AND (b) Tier 2c's menu-paste probe positively confirmed no real paste target exists. Every other case — role identification failure, a real paste target that failed to receive the paste, an ambiguous/unresolved probe result — keeps full Sentry alerting unchanged.
- Empirically validated against live production Sentry data (not assumed): on app versions where the corroborating menu probe fully exists, confirmed-no-target resolution was 100% (96/96 and 6/6 events) with zero ambiguous cases, closing the concern that the strict condition might under-deliver on the original goal.

## Review trail
- Plan: `docs/feature-requests/issue-1430-2026-07-09-suppress-paste-telemetry.md` (local, not in this diff — Council + 2 rounds of Codex grounded review reached PROCEED-AS-PLANNED; founder approved Gate 2 on 2026-07-09).
- Build-phase: 4 rounds of local `codex review`. Round 1 and round 2 findings fixed (a real paste-attempt-and-fail case, then an over-permissive absent-signal default) and verified with new boundary tests. Round 3 found a narrower, pre-existing ambiguity one layer below this change (in the already-shipped Tier 2c menu-probe telemetry itself) — documented as an explicit accepted risk in the plan and filed as follow-up #1435, since properly closing it touches a different module and a different field's contract than this fix's declared scope. Round 4: clean, no new findings.
- Live UAT: dictated into Finder with its file list focused (a known non-text target) on the rebuilt dev app. Clipboard-only delivery confirmed working exactly as before (text landed on the clipboard, no crash, no overlay-stuck) — the app log shows `tier=clipboard_only, app=com.apple.finder` with the expected "non-text element focused, falling back to clipboard-only" trace. This is a telemetry-only change; it does not alter paste delivery behavior.

## Test plan
- [x] `scripts/xcode-test.sh` — 2522 tests passing, including 8 new/updated boundary tests on `isExpectedNonTextRefusal` covering: confirmed no-target (downgrade), a real paste target that failed (keep alerting), an absent/unresolved probe (keep alerting), unrecognized `roleSource`/`focusClass` values (fail closed), and existing regression coverage unmodified.
- [x] `swift build -c release` — exit 0.
- [x] Live UAT via `wispr_eyes.test_recording()` — heart path confirmed unaffected (see Review trail above).
- [x] Local `codex review` — 4 rounds, converged clean (round 3's finding documented as an accepted risk with follow-up #1435).
- [ ] Cloud review (`chatgpt-codex-connector[bot]`) — pending.

Closes #1430.