### PR TITLE
feat(reports): add daily performance report worker

### DIFF
--- a/.github/workflows/daily-report-ping.yml
+++ b/.github/workflows/daily-report-ping.yml
@@ -1,0 +1,40 @@
+name: Daily Report
+
+# Triggers the daily-report Cloudflare Worker once a day. The worker
+# (workers/daily-report/) posts a plain-English usage summary to Discord.
+# Scheduling lives here (GitHub Actions) rather than a Cloudflare cron
+# because the CF account is at its 5-cron free-plan limit (#1092). The
+# worker computes the Eastern calendar day from its own clock at run time,
+# not from when this cron fires, so a late-running scheduled job still
+# reports the correct day.
+
+on:
+  schedule:
+    - cron: "12 13 * * *"  # ~9:12am EDT / ~8:12am EST daily. Offset minute (not :00): GitHub flags top-of-hour as a high-load window where scheduled runs are delayed/dropped (#1131, product-health precedent).
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Optional YYYY-MM-DD Eastern-date override (manual recovery after a missed run)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger daily-report worker
+        env:
+          TRIGGER_SECRET: ${{ secrets.DAILY_REPORT_TRIGGER_SECRET }}
+          DATE_OVERRIDE: ${{ github.event.inputs.date }}
+        run: |
+          URL="https://enviouswispr-daily-report.saurabhav.workers.dev/"
+          if [ -n "$DATE_OVERRIDE" ]; then
+            URL="${URL}?date=${DATE_OVERRIDE}"
+          fi
+          curl -fsS --retry 3 --retry-delay 10 \
+            -H "x-trigger-secret: ${TRIGGER_SECRET}" \
+            "$URL" \
+            -o /dev/null -w "worker responded HTTP %{http_code}\n"

--- a/.github/workflows/daily-report-ping.yml
+++ b/.github/workflows/daily-report-ping.yml
@@ -34,7 +34,17 @@ jobs:
           if [ -n "$DATE_OVERRIDE" ]; then
             URL="${URL}?date=${DATE_OVERRIDE}"
           fi
-          curl -fsS --retry 3 --retry-delay 10 \
+          # No --retry here (unlike product-health-ping.yml's --retry 3): this
+          # worker posts a Discord failure notice as a SIDE EFFECT before
+          # returning a non-2xx (src/index.js runReport's catch block), so a
+          # blind curl retry on a transient 500/504 could post a duplicate or
+          # confusing "failed" notice, or a false failure notice immediately
+          # followed by a real report if the retry recovers (Codex code-diff
+          # review catch, docs/audits/2026-07-09-1433-daily-report-codex-code-diff.txt).
+          # A single failed attempt already turns this job red (GitHub's own
+          # failure-email signal); manual recovery is the documented ?date=
+          # override (README § Failure visibility), not an automatic retry.
+          curl -fsS \
             -H "x-trigger-secret: ${TRIGGER_SECRET}" \
             "$URL" \
             -o /dev/null -w "worker responded HTTP %{http_code}\n"

--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -1,0 +1,144 @@
+# Daily Report Worker (issue #1433)
+
+A daily Cloudflare Worker that posts a plain-English usage summary to Discord.
+Read-only: it consumes events that already emit to PostHog. It gates nothing,
+alerts on nothing — purely a digest for the founder's morning read.
+
+Plan + full metric-definition rationale (including the two real bugs caught
+during planning and the two grounded-review rounds that shaped the final
+design): `docs/feature-requests/issue-1433-2026-07-09-daily-report.md`.
+
+## What it reports
+
+Covers the previous **complete Eastern calendar day** (midnight to midnight
+`America/New_York`, computed via the JS `Intl` API — correctly DST-aware,
+never a UTC-day approximation).
+
+| Line | Definition |
+|---|---|
+| New installs | Unique `distinct_id`s with `app.launched{is_fresh_install=true}` that day. |
+| People who finished setup | Unique `distinct_id`s with `onboarding.completed` that day. |
+| Of those, also dictated | Same-day activation: of the users who onboarded THAT day, how many ALSO had a successful dictation that same day. Deliberately same-day, not open-ended — a stated simplification, not an oversight. |
+| Total users | Unique `distinct_id`s with a **successful** `dictation.completed` that day. This deliberately EXCLUDES people who launched the app, or attempted a dictation that failed (ASR/paste failure). It is not "everyone who touched the app," it is "everyone who got a working dictation." This worker does not duplicate `workers/product-health`'s separate failure-rate tracking. |
+| Transcription engine, by user | Each user's LATEST dictation that day (`argMax` by timestamp) determines their engine bucket (Parakeet / WhisperKit). Grounded entirely in real per-dictation usage — `asr_backend` is a required, never-null field, so this needs no settings lookup or fallback chain. |
+| AI polishing, by user | Each user's **configured** polish provider, not the runtime outcome of any single dictation. A dictation that silently skipped polish (too-short bypass, EG-1-not-ready, Apple Intelligence permanently unavailable on that Mac, etc. — all legitimate by-design behaviors, not bugs) is NOT counted as "AI off"; it's attributed to whatever the user has selected. "Polish turned off" means only a user whose actual configured setting is `none`. Resolution order: (1) latest value across the union of `settings.snapshot.llm_provider` and `settings.changed{setting='llm_provider'}` — a provider switch mid-session, without relaunching, is picked up correctly; (2) if neither was ever recorded, any non-null provider that actually appears on one of their dictations that day; (3) if neither exists (a brand-new user who dictated before their first settings event fired), the shipped default `appleIntelligence`. |
+| Net total dictations | Total successful-dictation COUNT for the day (volume, not user count — reported separately from the per-user buckets above, never used as their percentage denominator). |
+| Where they are | Top 5 countries by unique dictating user (`$geoip_country_name`); a dictation with no resolvable GeoIP is simply excluded from this one line, not from any other metric. |
+| Top 5 users by dictation volume | The 5 heaviest dictators that day, by count. Values only, never a raw `distinct_id`, in the Discord message. |
+
+Every percentage in the report is `round(bucket_count / total_users * 100)` —
+integer, no decimals. If `total_users` is 0 that day, the whole
+engine/polish section is omitted (no divide-by-zero, no misleading "0%"
+noise on a genuinely empty day).
+
+## Correctness guardrail (why this worker trusts nothing on faith)
+
+An early planning-time bug: a naive PostHog query silently truncated at 100
+rows while the real population was 110. The fix that survived into this
+worker: every per-user bucket count (engine, polish) is checked against an
+INDEPENDENTLY queried `total_users` aggregate before the message is built.
+If the bucket counts don't sum to `total_users`, the worker throws — this
+routes into the same failure path as any other error (see below), so a
+silent undercount can never ship as a normal-looking report.
+
+## Develop / test
+
+```bash
+cd workers/daily-report
+node --test                     # pure query-shape/bucketing/formatting logic, no network
+```
+
+Pre-deploy live-query smoke (runs the real HogQL against production
+PostHog, asserts the completeness check passes, prints the would-be
+message, posts nothing):
+
+```bash
+~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
+  node workers/daily-report/live-query-smoke.mjs [YYYY-MM-DD]
+```
+
+The optional date argument overrides "yesterday" — useful for testing
+against a known day, and mirrors the deployed worker's `?date=` recovery
+parameter (see below).
+
+## Deploy (one-time)
+
+```bash
+cd workers/daily-report
+npx wrangler deploy
+
+# secrets (never committed):
+~/.claude/bin/get-key launch posthog-personal-api-key V -- sh -c 'printf "%s" "$V" | npx wrangler secret put POSTHOG_PERSONAL_API_KEY'
+security find-generic-password -w -a m4pro_sv -s enviouswispr.discord-webhook-session-logs | npx wrangler secret put DISCORD_WEBHOOK_URL
+# TRIGGER_SECRET gates the public trigger; stored in Keychain for the GitHub Action:
+security find-generic-password -w -a m4pro_sv -s enviouswispr.daily-report-trigger-secret | npx wrangler secret put TRIGGER_SECRET
+
+# verify (posts a REAL report to EnviousNotes) - needs the token:
+curl "https://enviouswispr-daily-report.saurabhav.workers.dev/?token=<TRIGGER_SECRET>"
+```
+
+The `fetch` trigger fails closed with 401 if the token is missing or wrong,
+so the public `workers.dev` URL cannot be crawled into spamming Discord.
+
+## Endpoint contract
+
+- Any HTTP method (unrestricted, matches `workers/product-health`).
+- Auth: `x-trigger-secret` header OR `?token=` query param.
+- Optional `?date=YYYY-MM-DD` — Eastern-calendar-date override, for manual
+  recovery after a missed scheduled run (see Failure visibility below). The
+  DATA reported is always for the literal date given, computed the same way
+  as the default "yesterday" path.
+- 401 body: `"unauthorized\n"`. Request body is ignored. Never logs the
+  trigger secret, a PostHog response body, or a Discord response body —
+  only counts, labels, and HTTP status codes.
+
+## Scheduling (GitHub Actions, not a Cloudflare cron)
+
+The Cloudflare account is at its 5-cron free-plan limit (#1092), so the
+daily run is driven by `.github/workflows/daily-report-ping.yml`, which
+curls the secret-gated endpoint. The wall-clock POSTING time drifts by up
+to ~1 hour across the two DST transitions each year (GitHub Actions cron is
+fixed-UTC and cannot itself DST-adjust) — the DATA is unaffected, since the
+Eastern day boundary is computed from `Intl` at run time, never from the
+cron trigger time. Same secret lives as repo secret
+`DAILY_REPORT_TRIGGER_SECRET`:
+
+```bash
+security find-generic-password -w -a m4pro_sv -s enviouswispr.daily-report-trigger-secret \
+  | gh secret set DAILY_REPORT_TRIGGER_SECRET --repo saurabhav88/EnviousWispr
+# run on demand: gh workflow run "Daily Report" --repo saurabhav88/EnviousWispr
+```
+
+## Failure visibility (how you'd know if this breaks)
+
+Two independent signals, matching `workers/product-health`'s posture:
+
+1. **A query or completeness-check failure** posts an explicit "Daily
+   report failed to generate for `<date>`: `<error>`" notice to Discord
+   (EnviousNotes) AND makes the worker return a non-2xx status, which turns
+   the GitHub Actions job red. You will see BOTH the Discord notice and a
+   GitHub Actions failure.
+2. **If Discord itself is unreachable/erroring**, the GitHub Actions job
+   still goes red (the one failure mode with no Discord-side notice —
+   GitHub's own failure-run email is the signal here).
+3. **A missed scheduled run entirely** (GitHub outage, workflow disabled)
+   has no automatic backfill. Recover manually with the `?date=` override
+   once you notice the gap:
+   ```bash
+   curl "https://enviouswispr-daily-report.saurabhav.workers.dev/?token=<TRIGGER_SECRET>&date=2026-07-08"
+   ```
+
+**Duplicate posts are expected, not a bug.** A manual `workflow_dispatch` or
+a GitHub Actions job rerun on a day the scheduled run already posted will
+post a second, real, duplicate report — same accepted tradeoff as
+`workers/product-health`'s own manual-trigger runbook. No idempotency/dedup
+mechanism is built (would need new stateful infrastructure — a Workers KV
+namespace — for a low-stakes internal report).
+
+## Rollback
+
+Delete the GitHub workflow to stop the daily run; `npx wrangler delete
+enviouswispr-daily-report` removes the worker entirely. Revert the PR to
+remove the code. A bad metric definition is a source-level fix + redeploy —
+no data migration involved, this worker is stateless (reads PostHog,
+writes only to Discord).

--- a/workers/daily-report/live-query-smoke.mjs
+++ b/workers/daily-report/live-query-smoke.mjs
@@ -1,0 +1,44 @@
+// Pre-deploy live-query smoke: runs the real HogQL queries against
+// production PostHog, asserts they resolve and the §3.3a completeness check
+// passes, prints the would-be Discord message, posts NOTHING.
+//
+// Usage:
+//   ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
+//     node workers/daily-report/live-query-smoke.mjs [YYYY-MM-DD]
+//
+// An optional date argument overrides "yesterday" (same override the
+// deployed worker's ?date= param uses) for testing against a known day.
+
+import { easternYesterdayWindowUTC, fetchReportData, resolveBuckets, buildMessage } from "./src/index.js";
+
+const env = {
+  POSTHOG_PROJECT_ID: "354235",
+  POSTHOG_PERSONAL_API_KEY: process.env.POSTHOG_KEY,
+};
+if (!env.POSTHOG_PERSONAL_API_KEY) {
+  console.error("POSTHOG_KEY not set - run via get-key launch posthog-personal-api-key POSTHOG_KEY -- ...");
+  process.exit(1);
+}
+
+const dateOverride = process.argv[2] || null;
+const { dateStr, startUTC, endUTC } = easternYesterdayWindowUTC(new Date(), dateOverride);
+const win = `timestamp >= '${startUTC.toISOString().slice(0, 19).replace("T", " ")}' AND timestamp < '${endUTC
+  .toISOString()
+  .slice(0, 19)
+  .replace("T", " ")}'`;
+
+console.log(`Target Eastern day: ${dateStr} (${startUTC.toISOString()} to ${endUTC.toISOString()})`);
+
+const data = await fetchReportData(env, win, endUTC);
+console.log("\n=== raw data ===");
+console.log(JSON.stringify(data, null, 2));
+
+const buckets = resolveBuckets(data); // throws loudly on a completeness mismatch
+console.log("\n=== resolution tiers (would be logged, never posted to Discord) ===");
+console.log(buckets.resolutionSource);
+
+const message = buildMessage(dateStr, data, buckets);
+console.log("\n=== would-be Discord message ===");
+console.log(message);
+
+console.log("\nSmoke OK: queries resolved, completeness check passed, nothing posted.");

--- a/workers/daily-report/live-query-smoke.mjs
+++ b/workers/daily-report/live-query-smoke.mjs
@@ -30,11 +30,29 @@ const win = `timestamp >= '${startUTC.toISOString().slice(0, 19).replace("T", " 
 console.log(`Target Eastern day: ${dateStr} (${startUTC.toISOString()} to ${endUTC.toISOString()})`);
 
 const data = await fetchReportData(env, win, endUTC);
-console.log("\n=== raw data ===");
-console.log(JSON.stringify(data, null, 2));
+
+// Aggregate-only summary. Deliberately does NOT dump `data.engineAndTierB` /
+// `data.tierA` (per-user rows keyed by raw distinct_id) - a Codex cloud
+// review catch (PR #1437): even though distinct_ids are opaque, printing the
+// full per-user array to a local terminal/log is broader exposure than a
+// smoke test needs. Counts/labels only, matching the same posture the
+// deployed worker itself holds to (src/index.js top-of-file privacy note).
+console.log("\n=== aggregate summary (counts/labels only, no per-user rows) ===");
+console.log({
+  freshInstalls: data.freshInstalls,
+  onboarded: data.onboarded,
+  activated: data.activated,
+  netDictations: data.netDictations,
+  totalUsers: data.totalUsers,
+  engineAndTierBRowCount: data.engineAndTierB.length,
+  tierARowCount: data.tierA.length,
+  geo: data.geo,
+  top5Counts: data.top5.map((u) => u.n), // values only, no distinct_id
+});
 
 const buckets = resolveBuckets(data); // throws loudly on a completeness mismatch
-console.log("\n=== resolution tiers (would be logged, never posted to Discord) ===");
+console.log("\n=== resolved buckets + resolution tiers (would be logged, never posted to Discord) ===");
+console.log({ engineBuckets: buckets.engineBuckets, polishBuckets: buckets.polishBuckets });
 console.log(buckets.resolutionSource);
 
 const message = buildMessage(dateStr, data, buckets);

--- a/workers/daily-report/package.json
+++ b/workers/daily-report/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "enviouswispr-daily-report",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -1,0 +1,459 @@
+/**
+ * EnviousWispr Daily Performance Report - Cloudflare Worker (issue #1433)
+ *
+ * Runs once a day via a secret-gated HTTP trigger (scheduling lives in
+ * .github/workflows/daily-report-ping.yml, not a Cloudflare cron - the CF
+ * account is at its 5-cron free-plan limit, see #1092). Reads PostHog events
+ * over the previous COMPLETE Eastern calendar day and posts a plain-English
+ * summary to Discord (EnviousNotes): installs/onboarding/activation, total
+ * active users, transcription-engine choice by user, AI-polish choice by
+ * user (their CONFIGURED choice, not per-dictation runtime outcome - a
+ * dictation that silently skipped polish for a by-design reason still
+ * counts toward whatever provider the user has selected), net dictation
+ * volume, top-5 countries, and the top-5 heaviest users by volume.
+ *
+ * Gates nothing, alerts on nothing - purely a daily digest. Plan + full
+ * metric-definition rationale: docs/feature-requests/issue-1433-2026-07-09-daily-report.md
+ *
+ * Privacy: output and logs are counts / rates / labels only. Never a raw
+ * transcript, a PostHog response body, a Discord response body, or the
+ * trigger secret.
+ */
+
+const POSTHOG_HOST = "https://us.posthog.com";
+
+// Shipped app defaults (SettingsDefaultValues.swift) - the tier-of-last-resort
+// when a user has neither a settings record nor any dictation carrying a
+// signal. See plan §3.3 row 4.
+const DEFAULT_ENGINE = "parakeet";
+const DEFAULT_PROVIDER = "appleIntelligence";
+
+// Per-worker distinct_id list bound. Genuinely a defense-in-depth ceiling,
+// never the primary correctness mechanism - see PROD/completeness check below
+// and plan §3.3a. 5000 is far above any realistic single-day population.
+const PER_USER_LIST_LIMIT = 5000;
+
+export default {
+  async fetch(request, env) {
+    // Manual trigger is secret-gated: the workers.dev URL is public, so an
+    // unauthenticated request must NOT run the report or post to Discord.
+    // Fail closed. Mirrors workers/product-health/src/index.js exactly.
+    const url = new URL(request.url);
+    const provided = url.searchParams.get("token") || request.headers.get("x-trigger-secret");
+    if (!env.TRIGGER_SECRET || provided !== env.TRIGGER_SECRET) {
+      return new Response("unauthorized\n", { status: 401 });
+    }
+    const dateOverride = url.searchParams.get("date"); // optional YYYY-MM-DD Eastern-date recovery override
+    try {
+      const message = await runReport(env, dateOverride);
+      return new Response(message + "\n", { status: 200 });
+    } catch (err) {
+      return new Response("daily report failed: " + err.message + "\n", { status: 500 });
+    }
+  },
+};
+
+// ----- Eastern calendar-day boundary ---------------------------------------
+
+const EASTERN_TZ = "America/New_York";
+
+/**
+ * Returns { dateStr, startUTC, endUTC } for the target Eastern calendar day:
+ * yesterday relative to `now`, or the explicit `dateOverride` (YYYY-MM-DD)
+ * when provided (manual recovery after a missed scheduled run - plan §4-9
+ * failure-mode table). startUTC/endUTC are the true UTC instants of that
+ * day's midnight-to-midnight boundary in America/New_York, computed via the
+ * Intl timezone API (handles EST/EDT correctly, no library dependency).
+ */
+export function easternYesterdayWindowUTC(now = new Date(), dateOverride = null) {
+  const targetDateStr = dateOverride || shiftDateString(easternDateString(now), -1);
+  const startUTC = findUTCForEasternMidnight(targetDateStr);
+  const endUTC = findUTCForEasternMidnight(shiftDateString(targetDateStr, 1));
+  return { dateStr: targetDateStr, startUTC, endUTC };
+}
+
+function easternDateString(date) {
+  // en-CA formats as YYYY-MM-DD.
+  return new Intl.DateTimeFormat("en-CA", { timeZone: EASTERN_TZ }).format(date);
+}
+
+function shiftDateString(dateStr, days) {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const noonUTC = new Date(Date.UTC(y, m - 1, d, 12)); // noon avoids any DST-edge ambiguity
+  noonUTC.setUTCDate(noonUTC.getUTCDate() + days);
+  return noonUTC.toISOString().slice(0, 10);
+}
+
+function findUTCForEasternMidnight(dateStr) {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const naiveUTCMs = Date.UTC(y, m - 1, d, 0, 0, 0);
+  // Converges in one correction: the ET offset is stable across the ~4-5hr
+  // window between a naive-UTC guess and the true instant, except exactly on
+  // a DST-transition calendar day, where a second pass fixes it.
+  // easternOffsetMinutesAt returns a SIGNED offset (negative for ET, e.g.
+  // -300 for EST/-240 for EDT, standard "west of UTC" convention) -
+  // SUBTRACTING it converts local midnight to the real UTC instant.
+  let guessMs = naiveUTCMs;
+  for (let i = 0; i < 2; i++) {
+    const offsetMinutes = easternOffsetMinutesAt(new Date(guessMs));
+    guessMs = naiveUTCMs - offsetMinutes * 60000;
+  }
+  return new Date(guessMs);
+}
+
+/** Signed UTC offset in minutes for America/New_York at `date` (EST=-300, EDT=-240). */
+function easternOffsetMinutesAt(date) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: EASTERN_TZ,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(date);
+  const v = {};
+  for (const p of parts) v[p.type] = p.value;
+  const localAsUTC = Date.UTC(
+    Number(v.year), Number(v.month) - 1, Number(v.day),
+    Number(v.hour), Number(v.minute), Number(v.second)
+  );
+  return (localAsUTC - date.getTime()) / 60000;
+}
+
+function sqlTimestamp(date) {
+  return date.toISOString().slice(0, 19).replace("T", " ");
+}
+
+// ----- PostHog ---------------------------------------------------------------
+
+// Per-distinct_id -dev exclusion (analytics-operations.md RULE:
+// founder-machine-tell-in-distinct-id): a dev build anywhere in an id's
+// history marks the whole id as dogfood. Verbatim shape from
+// workers/product-health/src/index.js.
+const PROD = `properties.environment = 'production'
+  AND distinct_id NOT IN (
+    SELECT distinct_id FROM events
+    WHERE properties.app_version LIKE '%-dev%' )`;
+
+function windowClause(startUTC, endUTC) {
+  return `timestamp >= '${sqlTimestamp(startUTC)}' AND timestamp < '${sqlTimestamp(endUTC)}'`;
+}
+
+/** The day's active-user population (successful dictators) as a reusable
+ * subquery fragment - used once, for the onboarded->activated intersection
+ * (a single subquery evaluation, cheap). NOT reused for polish tier-a: an
+ * earlier version nested this same subquery twice inside a UNION, which
+ * measurably timed out against production PostHog - see the comment above
+ * `tierASqlFor` below for why tier-a instead takes a literal id list. */
+function activeUsersSubquery(win) {
+  return `SELECT DISTINCT distinct_id FROM events
+    WHERE event = 'dictation.completed' AND properties.result = 'success'
+      AND ${PROD} AND ${win}`;
+}
+
+/** Escapes a distinct_id for a HogQL string literal (single-quote doubling,
+ * the standard SQL escape - distinct_ids are opaque PostHog-generated ids,
+ * never user-authored text, so this is a closed, low-risk input class). */
+function sqlIdList(ids) {
+  return ids.map((id) => `'${String(id).replace(/'/g, "''")}'`).join(", ");
+}
+
+/** Polish tier-a: latest value across the UNION of settings.snapshot and
+ * settings.changed{setting='llm_provider'}, bounded to a LITERAL list of
+ * already-known active-user ids (plan §3.3 row 4, r2 precision fix) rather
+ * than a re-evaluated subquery - the subquery form (distinct_id IN
+ * (activeUsersSubquery)) repeated twice inside this UNION timed out (HTTP
+ * 504) against production PostHog; the literal-list form is the exact
+ * pattern already validated empirically during planning. */
+function tierASqlFor(activeIds, endTs) {
+  const ids = sqlIdList(activeIds);
+  return `
+    SELECT distinct_id, argMax(value, ts) AS provider
+    FROM (
+      SELECT distinct_id, properties.llm_provider AS value, timestamp AS ts
+      FROM events
+      WHERE event = 'settings.snapshot' AND ${PROD}
+        AND distinct_id IN (${ids})
+        AND timestamp < '${endTs}'
+      UNION ALL
+      SELECT distinct_id, properties.to AS value, timestamp AS ts
+      FROM events
+      WHERE event = 'settings.changed' AND properties.setting = 'llm_provider' AND ${PROD}
+        AND distinct_id IN (${ids})
+        AND timestamp < '${endTs}'
+    )
+    GROUP BY distinct_id
+    LIMIT ${PER_USER_LIST_LIMIT}`;
+}
+
+async function hogql(env, sql) {
+  const res = await fetch(`${POSTHOG_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/query/`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.POSTHOG_PERSONAL_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: { kind: "HogQLQuery", query: sql }, refresh: "blocking" }),
+  });
+  if (!res.ok) {
+    throw new Error(`PostHog query HTTP ${res.status}`);
+  }
+  const json = await res.json();
+  if (!json.results) throw new Error("PostHog query returned no results array");
+  return json;
+}
+
+function rowsToObjects(res) {
+  const cols = res.columns || [];
+  return (res.results || []).map((row) => {
+    const o = {};
+    cols.forEach((c, i) => (o[c] = row[i]));
+    return o;
+  });
+}
+
+export async function fetchReportData(env, win, endUTC) {
+  const endTs = sqlTimestamp(endUTC);
+  const activeUsers = activeUsersSubquery(win);
+
+  const installsSql = `
+    SELECT uniqExact(distinct_id) FROM events
+    WHERE event = 'app.launched' AND properties.is_fresh_install = true
+      AND ${PROD} AND ${win}`;
+
+  const onboardActivateSql = `
+    SELECT
+      uniqExact(distinct_id) AS onboarded,
+      uniqExactIf(distinct_id, distinct_id IN (${activeUsers})) AS activated
+    FROM events
+    WHERE event = 'onboarding.completed' AND ${PROD} AND ${win}`;
+
+  const totalsSql = `
+    SELECT count() AS net_dictations, uniqExact(distinct_id) AS total_users
+    FROM events
+    WHERE event = 'dictation.completed' AND properties.result = 'success' AND ${PROD} AND ${win}`;
+
+  // Engine (row 3) + polish tier-b fallback (row 4) share the same event
+  // population, so one query resolves both per user.
+  const engineAndTierBSql = `
+    SELECT distinct_id,
+           argMax(properties.asr_backend, timestamp) AS engine,
+           anyIf(properties.llm_provider, properties.llm_provider IS NOT NULL) AS tier_b_provider
+    FROM events
+    WHERE event = 'dictation.completed' AND properties.result = 'success' AND ${PROD} AND ${win}
+    GROUP BY distinct_id
+    LIMIT ${PER_USER_LIST_LIMIT}`;
+
+  const geoSql = `
+    SELECT properties.$geoip_country_name AS country, uniqExact(distinct_id) AS n
+    FROM events
+    WHERE event = 'dictation.completed' AND properties.result = 'success'
+      AND properties.$geoip_country_name IS NOT NULL AND properties.$geoip_country_name != ''
+      AND ${PROD} AND ${win}
+    GROUP BY country
+    ORDER BY n DESC
+    LIMIT 5`;
+
+  const top5Sql = `
+    SELECT distinct_id, count() AS n
+    FROM events
+    WHERE event = 'dictation.completed' AND properties.result = 'success' AND ${PROD} AND ${win}
+    GROUP BY distinct_id
+    ORDER BY n DESC
+    LIMIT 5`;
+
+  // The first 6 queries are fully independent and fire concurrently
+  // (plan §3.3, Gemini's CF-wall-clock-timeout finding). Polish tier-a
+  // (below) is the one exception: an EARLIER version embedded the
+  // active-user bound as a re-evaluated nested subquery inside a UNION and
+  // that measurably timed out against production PostHog (HTTP 504) - two
+  // nested re-scans of the whole PROD filter's dev-exclusion subquery,
+  // twice, inside a UNION, is too expensive. Fixed by resolving the
+  // active-user id list from `engineAndTierB` (already fetched, zero extra
+  // cost) and passing it to tier-a as a literal IN-list instead of a
+  // subquery - the exact pattern already validated empirically during
+  // planning. This is the one query that runs sequentially after the batch;
+  // still well within Cloudflare's execution ceiling (six ~1-3s concurrent
+  // queries, then one more).
+  const [installs, onboardActivate, totals, engineAndTierB, geo, top5] = await Promise.all([
+    hogql(env, installsSql),
+    hogql(env, onboardActivateSql),
+    hogql(env, totalsSql),
+    hogql(env, engineAndTierBSql),
+    hogql(env, geoSql),
+    hogql(env, top5Sql),
+  ]);
+
+  const activeIds = (engineAndTierB.results || []).map((row) => row[0]);
+  const tierA = activeIds.length ? await hogql(env, tierASqlFor(activeIds, endTs)) : { results: [], columns: [] };
+
+  return {
+    freshInstalls: installs.results[0][0],
+    onboarded: rowsToObjects(onboardActivate)[0]?.onboarded ?? 0,
+    activated: rowsToObjects(onboardActivate)[0]?.activated ?? 0,
+    netDictations: rowsToObjects(totals)[0]?.net_dictations ?? 0,
+    totalUsers: rowsToObjects(totals)[0]?.total_users ?? 0,
+    engineAndTierB: rowsToObjects(engineAndTierB),
+    tierA: rowsToObjects(tierA),
+    geo: rowsToObjects(geo),
+    top5: rowsToObjects(top5),
+  };
+}
+
+// ----- Pure resolution + bucketing (unit-tested, no IO) --------------------
+
+/**
+ * Resolves each active user's engine and polish-provider bucket, per the
+ * plan §3.3 rules, and verifies completeness against the independently
+ * queried `totalUsers` (plan §3.3a) - a mismatch means some per-user rows
+ * were silently dropped (the 100-row-truncation bug class) and throws
+ * rather than silently under-reporting.
+ */
+export function resolveBuckets(data) {
+  const tierAByUser = new Map(data.tierA.map((r) => [r.distinct_id, r.provider]));
+  const engineBuckets = {};
+  const polishBuckets = {};
+  let engineCount = 0;
+  let polishCount = 0;
+  const resolutionSource = { settings: 0, actual_dictation: 0, shipped_default: 0 };
+
+  for (const row of data.engineAndTierB) {
+    const engine = row.engine || DEFAULT_ENGINE;
+    engineBuckets[engine] = (engineBuckets[engine] || 0) + 1;
+    engineCount += 1;
+
+    const tierAProvider = tierAByUser.get(row.distinct_id);
+    const provider = tierAProvider || row.tier_b_provider || DEFAULT_PROVIDER;
+    polishBuckets[provider] = (polishBuckets[provider] || 0) + 1;
+    polishCount += 1;
+    if (tierAProvider) resolutionSource.settings += 1;
+    else if (row.tier_b_provider) resolutionSource.actual_dictation += 1;
+    else resolutionSource.shipped_default += 1;
+  }
+
+  if (engineCount !== data.totalUsers || polishCount !== data.totalUsers) {
+    throw new Error(
+      `completeness check failed: engine=${engineCount} polish=${polishCount} totalUsers=${data.totalUsers}`
+    );
+  }
+
+  return { engineBuckets, polishBuckets, resolutionSource };
+}
+
+// ----- Message ---------------------------------------------------------------
+
+const ENGINE_LABELS = { parakeet: "Parakeet", whisperKit: "WhisperKit" };
+const PROVIDER_LABELS = {
+  appleIntelligence: "Apple Intelligence",
+  egOne: "EG-1 (our own model)",
+  gemini: "Gemini",
+  openAI: "OpenAI",
+  ollama: "Ollama",
+  none: "polish turned off",
+};
+
+function pctOf(n, total) {
+  return total > 0 ? `${Math.round((n / total) * 100)}%` : "0%";
+}
+
+function formatBuckets(buckets, labels, total) {
+  return Object.entries(buckets)
+    .filter(([, n]) => n > 0)
+    .sort((a, b) => b[1] - a[1])
+    .map(([key, n]) => `${labels[key] || key} ${n} (${pctOf(n, total)})`)
+    .join(", ");
+}
+
+function formatWeekdayDate(dateStr) {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const noonUTC = new Date(Date.UTC(y, m - 1, d, 12));
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(noonUTC);
+}
+
+export function buildMessage(dateStr, data, buckets) {
+  const lines = [`EnviousWispr Daily Report, ${formatWeekdayDate(dateStr)}`, ""];
+
+  lines.push(
+    `New installs: ${data.freshInstalls}. People who finished setup today: ${data.onboarded}. Of those, ${data.activated} also dictated today.`,
+    ""
+  );
+
+  lines.push(`Total users: ${data.totalUsers} people used the app today.`, "");
+
+  if (data.totalUsers > 0) {
+    const engineLine = formatBuckets(buckets.engineBuckets, ENGINE_LABELS, data.totalUsers);
+    if (engineLine) lines.push(`Transcription engine (by user): ${engineLine}.`, "");
+
+    const polishLine = formatBuckets(buckets.polishBuckets, PROVIDER_LABELS, data.totalUsers);
+    if (polishLine) lines.push(`AI polishing (by user, their selected choice): ${polishLine}.`, "");
+  }
+
+  lines.push(`Net total dictations: ${data.netDictations}.`, "");
+
+  if (data.geo.length) {
+    lines.push(`Where they are: ${data.geo.map((g) => `${g.country} ${g.n}`).join(", ")}.`, "");
+  }
+
+  if (data.top5.length) {
+    lines.push(`Top 5 users by dictation volume: ${data.top5.map((u) => u.n).join(", ")}.`);
+  }
+
+  const content = lines.join("\n").trim();
+  // Discord content cap is 2000 chars.
+  return content.length > 1990 ? content.slice(0, 1987) + "..." : content;
+}
+
+// ----- Discord + run ---------------------------------------------------------
+
+async function postToDiscord(webhookUrl, content) {
+  const res = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content }),
+  });
+  return res.status === 204 || res.status === 200;
+}
+
+async function safePost(env, content) {
+  try {
+    if (env.DISCORD_WEBHOOK_URL) await postToDiscord(env.DISCORD_WEBHOOK_URL, content);
+  } catch (_) {
+    // best-effort failure notice; the caller's throw is what surfaces the failure in logs/CI
+  }
+}
+
+export async function runReport(env, dateOverride = null) {
+  const { dateStr, startUTC, endUTC } = easternYesterdayWindowUTC(new Date(), dateOverride);
+  const win = windowClause(startUTC, endUTC);
+
+  let data, buckets;
+  try {
+    data = await fetchReportData(env, win, endUTC);
+    buckets = resolveBuckets(data);
+    // Resolution-tier logging (Cloudflare log only, never the Discord
+    // message) - plan §3.3a. A spike in shipped_default's share vs
+    // settings/actual_dictation is the telemetry-drift canary.
+    console.log(
+      `daily-report resolution tiers: settings=${buckets.resolutionSource.settings} ` +
+        `actual_dictation=${buckets.resolutionSource.actual_dictation} ` +
+        `shipped_default=${buckets.resolutionSource.shipped_default}`
+    );
+  } catch (err) {
+    // Loud failure: never let a partial/failed run read as a normal report.
+    await safePost(env, `Daily report failed to generate for ${dateStr}: ${err.message}`);
+    throw err;
+  }
+
+  const message = buildMessage(dateStr, data, buckets);
+  const ok = await postToDiscord(env.DISCORD_WEBHOOK_URL, message);
+  if (!ok) throw new Error("Discord post failed");
+  return message;
+}

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -1,0 +1,221 @@
+// Unit tests for the pure date-boundary / bucketing / message-formatting
+// logic (no network). Run: node --test (from workers/daily-report/)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  easternYesterdayWindowUTC,
+  resolveBuckets,
+  buildMessage,
+} from "../src/index.js";
+
+// ---- easternYesterdayWindowUTC ----
+
+test("EDT case: 'now' inside Eastern Daylight Time (UTC-4)", () => {
+  // 2026-07-09 13:12 UTC = 2026-07-09 09:12 EDT -> yesterday = 2026-07-08
+  const now = new Date("2026-07-09T13:12:00Z");
+  const { dateStr, startUTC, endUTC } = easternYesterdayWindowUTC(now);
+  assert.equal(dateStr, "2026-07-08");
+  // Midnight ET on 2026-07-08 during EDT (UTC-4) is 2026-07-08T04:00:00Z.
+  assert.equal(startUTC.toISOString(), "2026-07-08T04:00:00.000Z");
+  assert.equal(endUTC.toISOString(), "2026-07-09T04:00:00.000Z");
+});
+
+test("EST case: 'now' inside Eastern Standard Time (UTC-5)", () => {
+  // 2026-01-15 13:12 UTC = 2026-01-15 08:12 EST -> yesterday = 2026-01-14
+  const now = new Date("2026-01-15T13:12:00Z");
+  const { dateStr, startUTC, endUTC } = easternYesterdayWindowUTC(now);
+  assert.equal(dateStr, "2026-01-14");
+  // Midnight ET on 2026-01-14 during EST (UTC-5) is 2026-01-14T05:00:00Z.
+  assert.equal(startUTC.toISOString(), "2026-01-14T05:00:00.000Z");
+  assert.equal(endUTC.toISOString(), "2026-01-15T05:00:00.000Z");
+});
+
+test("DST-transition-adjacent date (spring forward, 2026-03-08 2am ET)", () => {
+  // The day BEFORE the US spring-forward transition (2026-03-08) is still EST.
+  const now = new Date("2026-03-08T12:00:00Z");
+  const { dateStr, startUTC } = easternYesterdayWindowUTC(now);
+  assert.equal(dateStr, "2026-03-07");
+  assert.equal(startUTC.toISOString(), "2026-03-07T05:00:00.000Z"); // EST offset
+});
+
+test("DST-transition-adjacent date (fall back happens DURING 2026-11-01, at 2am local)", () => {
+  // 2026-11-01 is the fall-back Sunday itself (US clocks set back at 2am
+  // local). Midnight local on that calendar day precedes the transition, so
+  // it is still EDT (UTC-4) -- confirmed against real Intl data (2026-11-01
+  // 00:00Z resolves to Saturday 20:00 ET, i.e. EDT). The transition to EST
+  // happens later the same day; a date-boundary computed from calendar-day
+  // midnight is unaffected by an intraday transition.
+  const now = new Date("2026-11-02T12:00:00Z");
+  const { dateStr, startUTC } = easternYesterdayWindowUTC(now);
+  assert.equal(dateStr, "2026-11-01");
+  assert.equal(startUTC.toISOString(), "2026-11-01T04:00:00.000Z"); // EDT offset (pre-transition)
+});
+
+test("DST-transition-adjacent date (the day AFTER fall-back, 2026-11-02, is EST)", () => {
+  const now = new Date("2026-11-03T12:00:00Z");
+  const { dateStr, startUTC } = easternYesterdayWindowUTC(now);
+  assert.equal(dateStr, "2026-11-02");
+  assert.equal(startUTC.toISOString(), "2026-11-02T05:00:00.000Z"); // EST offset
+});
+
+test("explicit ?date= override replaces the yesterday computation", () => {
+  const now = new Date("2026-07-09T13:12:00Z");
+  const { dateStr, startUTC, endUTC } = easternYesterdayWindowUTC(now, "2026-06-01");
+  assert.equal(dateStr, "2026-06-01");
+  assert.equal(startUTC.toISOString(), "2026-06-01T04:00:00.000Z"); // EDT offset
+  assert.equal(endUTC.toISOString(), "2026-06-02T04:00:00.000Z");
+});
+
+// ---- resolveBuckets ----
+
+function makeData(overrides = {}) {
+  return {
+    totalUsers: 3,
+    engineAndTierB: [
+      { distinct_id: "u1", engine: "parakeet", tier_b_provider: "egOne" },
+      { distinct_id: "u2", engine: "parakeet", tier_b_provider: null },
+      { distinct_id: "u3", engine: "whisperKit", tier_b_provider: null },
+    ],
+    tierA: [{ distinct_id: "u2", provider: "gemini" }],
+    ...overrides,
+  };
+}
+
+test("resolveBuckets: tier-a (settings) wins when present", () => {
+  const { polishBuckets, resolutionSource } = resolveBuckets(makeData());
+  assert.equal(polishBuckets.gemini, 1); // u2 resolved via tier-a
+  assert.equal(resolutionSource.settings, 1);
+});
+
+test("resolveBuckets: tier-b (actual dictation) used when no tier-a", () => {
+  const { polishBuckets, resolutionSource } = resolveBuckets(makeData());
+  assert.equal(polishBuckets.egOne, 1); // u1 resolved via tier-b
+  assert.equal(resolutionSource.actual_dictation, 1);
+});
+
+test("resolveBuckets: shipped default used when neither tier resolves", () => {
+  const { polishBuckets, resolutionSource } = resolveBuckets(makeData());
+  assert.equal(polishBuckets.appleIntelligence, 1); // u3 falls all the way through
+  assert.equal(resolutionSource.shipped_default, 1);
+});
+
+test("resolveBuckets: engine buckets partition totalUsers exactly", () => {
+  const { engineBuckets } = resolveBuckets(makeData());
+  assert.equal(engineBuckets.parakeet, 2);
+  assert.equal(engineBuckets.whisperKit, 1);
+});
+
+test("resolveBuckets: throws on completeness mismatch (the 100-row-truncation class of bug)", () => {
+  const data = makeData({ totalUsers: 999 }); // independently-queried total disagrees with the per-user rows
+  assert.throws(() => resolveBuckets(data), /completeness check failed/);
+});
+
+test("resolveBuckets: zero active users is not a divide-by-zero / throw case", () => {
+  const { engineBuckets, polishBuckets } = resolveBuckets({
+    totalUsers: 0,
+    engineAndTierB: [],
+    tierA: [],
+  });
+  assert.deepEqual(engineBuckets, {});
+  assert.deepEqual(polishBuckets, {});
+});
+
+// ---- buildMessage ----
+// Golden fixture: real production numbers from a live-query-smoke.mjs run
+// against the ACTUAL implemented queries (2026-07-08 Eastern calendar day,
+// captured post-implementation, not the earlier hand-verified planning-time
+// numbers). The engine/polish buckets differ meaningfully from the
+// planning-time hand-check BY DESIGN: this run uses the corrected
+// methodology (direct per-dictation argMax for engine; the
+// settings.snapshot + settings.changed UNION for polish tier-a), which the
+// planning-time numbers predated. The shift itself (e.g. egOne roughly
+// doubling once settings.changed is included) is expected evidence the
+// union fix matters, not a regression.
+
+const GOLDEN_DATA = {
+  freshInstalls: 90,
+  onboarded: 82,
+  activated: 60,
+  netDictations: 1868,
+  totalUsers: 110,
+  geo: [
+    { country: "Germany", n: 66 },
+    { country: "United States", n: 16 },
+    { country: "India", n: 3 },
+    { country: "Austria", n: 3 },
+    { country: "United Kingdom", n: 3 },
+  ],
+  top5: [{ n: 557 }, { n: 139 }, { n: 113 }, { n: 94 }, { n: 70 }],
+};
+
+const GOLDEN_BUCKETS = {
+  engineBuckets: { parakeet: 100, whisperKit: 10 },
+  polishBuckets: { appleIntelligence: 64, egOne: 36, gemini: 4, none: 3, ollama: 2, openAI: 1 },
+};
+
+test("buildMessage: golden fixture matches the founder-approved report shape", () => {
+  const msg = buildMessage("2026-07-08", GOLDEN_DATA, GOLDEN_BUCKETS);
+
+  assert.match(msg, /^EnviousWispr Daily Report, Wednesday, July 8, 2026/);
+  assert.match(msg, /New installs: 90\. People who finished setup today: 82\. Of those, 60 also dictated today\./);
+  assert.doesNotMatch(msg, /for the first time/);
+  assert.doesNotMatch(msg, /out of 90/); // no funnel-bleed wording (r1 fix)
+  assert.match(msg, /Total users: 110 people used the app today\./);
+  // Percentages are against total_users (110), not net_dictations (1868).
+  assert.match(msg, /Parakeet 100 \(91%\)/);
+  assert.match(msg, /WhisperKit 10 \(9%\)/);
+  assert.match(msg, /Apple Intelligence 64 \(58%\)/);
+  assert.match(msg, /EG-1 \(our own model\) 36 \(33%\)/);
+  assert.match(msg, /Net total dictations: 1868\./);
+  assert.match(msg, /Germany 66/);
+  assert.match(msg, /Top 5 users by dictation volume: 557, 139, 113, 94, 70\./);
+  // No em-dashes/en-dashes anywhere (global CLAUDE.md Rule 6).
+  assert.doesNotMatch(msg, /[–—]/);
+});
+
+test("buildMessage: zero-count buckets are omitted, not shown as '(0%)'", () => {
+  const msg = buildMessage("2026-07-08", GOLDEN_DATA, {
+    engineBuckets: { parakeet: 110, whisperKit: 0 },
+    polishBuckets: { appleIntelligence: 110, gemini: 0 },
+  });
+  assert.doesNotMatch(msg, /WhisperKit 0/);
+  assert.doesNotMatch(msg, /Gemini 0/);
+});
+
+test("buildMessage: zero total_users omits the engine/polish section entirely (no divide-by-zero)", () => {
+  const msg = buildMessage("2026-07-08", { ...GOLDEN_DATA, totalUsers: 0 }, { engineBuckets: {}, polishBuckets: {} });
+  assert.doesNotMatch(msg, /Transcription engine/);
+  assert.doesNotMatch(msg, /AI polishing/);
+  assert.match(msg, /Total users: 0 people used the app today\./);
+});
+
+// ---- Source-level guardrail: every list-returning query still carries an
+// explicit LIMIT (defense-in-depth per plan §3.3a; the PRIMARY correctness
+// mechanism is resolveBuckets' completeness check above, not this string
+// check alone - this only guards against a future edit silently dropping
+// the LIMIT that bounds worst-case query cost). ----
+
+test("source guardrail: every per-user GROUP BY query has an explicit LIMIT", async () => {
+  // Matches ANY backtick template literal in the source, not just `const
+  // XSql = \`...\`` assignments -- a query built inside a helper function
+  // (e.g. returned via `return \`...\`` rather than assigned to a const)
+  // must still be caught. An earlier version of this test only matched the
+  // `const` form and would have silently stopped checking tierASqlFor's
+  // query when it was refactored into a function during live-smoke-test
+  // debugging.
+  const fs = await import("node:fs");
+  const src = fs.readFileSync(new URL("../src/index.js", import.meta.url), "utf8");
+  const templateLiterals = src.match(/`[^`]*`/gs) || [];
+  const groupByQueries = templateLiterals.filter((q) => /GROUP BY distinct_id/.test(q));
+  assert.ok(groupByQueries.length >= 3, "expected to find at least 3 per-user GROUP BY queries in the source");
+  for (const body of groupByQueries) {
+    assert.match(body, /LIMIT/, `per-user GROUP BY query missing LIMIT: ${body.slice(0, 80)}...`);
+  }
+});
+
+// Note: the settings.changed-beats-stale-settings.snapshot temporal ordering
+// (plan §3.3 row 4) is expressed as SQL (UNION ALL + argMax(value, timestamp)
+// over the combined stream) and cannot be exercised by a pure JS unit test
+// without mocking the HogQL engine. It is verified by the pre-deploy
+// live-query smoke (live-query-smoke.mjs) against real production data, and
+// by code review of the tierASql query text in src/index.js.

--- a/workers/daily-report/wrangler.toml
+++ b/workers/daily-report/wrangler.toml
@@ -1,0 +1,18 @@
+name = "enviouswispr-daily-report"
+main = "src/index.js"
+compatibility_date = "2026-07-09"
+
+# No [triggers] cron here: the Cloudflare account is at its 5-cron free-plan limit
+# (#1092), so scheduling lives in a GitHub Actions workflow
+# (.github/workflows/daily-report-ping.yml) that pings the secret-gated fetch
+# endpoint daily.
+
+[vars]
+POSTHOG_PROJECT_ID = "354235"
+
+# Secrets (set via `npx wrangler secret put <NAME>`, never in this file):
+#   POSTHOG_PERSONAL_API_KEY  - GCP secret `posthog-personal-api-key`
+#   DISCORD_WEBHOOK_URL       - Keychain `enviouswispr.discord-webhook-session-logs` (EnviousNotes)
+#   TRIGGER_SECRET            - gates the public `fetch` trigger; the GitHub Action sends it as
+#                               the `x-trigger-secret` header (the workers.dev URL is public, so
+#                               the trigger fails closed without it)


### PR DESCRIPTION
## Summary
- New Cloudflare Worker (`workers/daily-report/`), sibling to `workers/product-health/` and `workers/weekly-digest/`, posts a plain-English daily usage report to Discord (EnviousNotes): new installs, onboarding, same-day activation, active users, transcription-engine choice by user, AI-polish choice by user (their configured provider, not per-dictation runtime outcome), net dictation volume, top countries, top-5 heaviest users.
- Scheduled via a new GitHub Actions workflow (`.github/workflows/daily-report-ping.yml`) — the Cloudflare account is at its 5-cron free-plan limit (#1092), same pattern as `product-health-ping.yml`.
- Metric definitions were validated live against real production PostHog data across an extended planning conversation, council review (GPT-5.5 + Gemini-3.1), three rounds of Codex grounded plan review to PROCEED-AS-PLANNED, two rounds of Codex code-diff review (one real finding fixed: a curl retry that could cause duplicate/confusing Discord failure notices), and an adversarial self-review pass.
- Already deployed and verified live: real trigger call returned HTTP 200 and posted a correctly-formatted report to EnviousNotes with numbers matching the local `live-query-smoke.mjs` validation exactly.

Plan: `docs/feature-requests/issue-1433-2026-07-09-daily-report.md`. Closes #1433.

## Test plan
- [x] `node --test` — 16/16 passing (`workers/daily-report/`)
- [x] Pre-deploy live-query smoke against real production PostHog — completeness check passed
- [x] Codex code-diff review — clean on round 2 (round 1 finding fixed)
- [x] Deployed to Cloudflare, secrets set (Cloudflare + GitHub; trigger secret lives in GCP Secret Manager per founder direction, not Keychain)
- [x] Live verification: real trigger call posted a correct report to EnviousNotes
- [ ] `workflow_dispatch` validation of the GitHub Actions side (next step)