### PR TITLE
fix(pipeline): route AFM polish cancellation to a breadcrumb, not a Sentry alert

### DIFF
--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -115,6 +115,8 @@ public enum SentryBreadcrumb {
     level: SentryLevel = .info,
     data: [String: Any]? = nil
   ) {
+    // Test spy hook — invoked synchronously before SDK dispatch. Production sets nil.
+    Self.breadcrumbDelegate?(stage, message, level, data)
     let crumb = Breadcrumb(level: level, category: "pipeline.\(stage)")
     crumb.message = message
     crumb.type = "default"
@@ -263,7 +265,21 @@ public enum SentryBreadcrumb {
   /// Capture an Apple Intelligence polish generation failure on this event
   /// (#429; the router `polish_mode`/`polish_router_basis` fields were dropped in
   /// #1072 when the dual router was removed).
+  ///
+  /// A `CancellationError` is a clean unwind, not a failure: when the AFM polish
+  /// budget expires, the task group cancels the in-flight generation, and
+  /// `AppleIntelligenceConnector.polish()`'s catch-all wraps that cancellation as
+  /// an `AFMPolishError`. The user still gets clean text via the runner's silent
+  /// skip, so the cancellation earns a breadcrumb, never an alerting event (#1438).
   public static func captureAFMPolishError(_ error: any Error) {
+    if error is CancellationError {
+      add(
+        stage: "polish",
+        message: "AFM polish cancelled; treating as non-alerting unwind",
+        level: .info
+      )
+      return
+    }
     captureError(error, category: .generationFailed, stage: "polish")
   }
 
@@ -415,4 +431,10 @@ extension SentryBreadcrumb {
   /// to the captured Sentry event.
   public nonisolated(unsafe) static var captureErrorTagsDelegate:
     (@Sendable ([String: String]) -> Void)?
+
+  /// Optional test-only delegate invoked synchronously on every `add` call before
+  /// the real Sentry SDK is touched — including the trail entry `captureError`
+  /// leaves alongside a captured event. Production code never reads it.
+  public nonisolated(unsafe) static var breadcrumbDelegate:
+    (@Sendable (String, String, SentryLevel, [String: Any]?) -> Void)?
 }

--- a/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
@@ -23,7 +23,8 @@ import Testing
 ///   4b. The OR formula `pipelineFellBackToRaw = filter || validator`.
 ///   4c. The pipeline-side degradation `metadata == nil ? nil : pipelineFellBackToRaw`.
 ///   5. AFMPolishError wraps the underlying error, and `captureAFMPolishError`
-///      records a `generationFailed` / `polish` Sentry event.
+///      records a `generationFailed` / `polish` Sentry event — except for a
+///      cancellation, which is downgraded to a breadcrumb (#1438).
 ///   7. #1050 `polishFallbackReason` honest disaggregation.
 @MainActor
 @Suite("AFM polish telemetry — #1072")
@@ -471,6 +472,67 @@ struct DualModePolishTelemetryTests {
     // Router fields were removed in #1072 — the event no longer carries them.
     #expect(captured?.extra["polish_mode"] == nil)
     #expect(captured?.extra["polish_router_basis"] == nil)
+  }
+
+  @Test(
+    "captureAFMPolishError downgrades a cancellation to a breadcrumb",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1438",
+      "AFM cancellation fired a full Sentry alert")
+  )
+  func afmPolishCancellationDowngradedToBreadcrumb() {
+    final class SpyBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var _polishErrorCaptureCount = 0
+      private var _breadcrumbs: [(stage: String, message: String)] = []
+      var polishErrorCaptureCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _polishErrorCaptureCount
+      }
+      var breadcrumbs: [(stage: String, message: String)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _breadcrumbs
+      }
+      func recordPolishErrorCapture() {
+        lock.lock()
+        defer { lock.unlock() }
+        _polishErrorCaptureCount += 1
+      }
+      func recordBreadcrumb(stage: String, message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        _breadcrumbs.append((stage: stage, message: message))
+      }
+    }
+
+    let spy = SpyBox()
+    let priorErrorDelegate = SentryBreadcrumb.captureErrorDelegate
+    let priorBreadcrumbDelegate = SentryBreadcrumb.breadcrumbDelegate
+    SentryBreadcrumb.captureErrorDelegate = { _, category, stage, _ in
+      guard category == .generationFailed, stage == "polish" else { return }
+      spy.recordPolishErrorCapture()
+    }
+    SentryBreadcrumb.breadcrumbDelegate = { stage, message, _, _ in
+      spy.recordBreadcrumb(stage: stage, message: message)
+    }
+    defer {
+      SentryBreadcrumb.captureErrorDelegate = priorErrorDelegate
+      SentryBreadcrumb.breadcrumbDelegate = priorBreadcrumbDelegate
+    }
+
+    SentryBreadcrumb.captureAFMPolishError(CancellationError())
+
+    // Half 1: a cancelled polish is a clean unwind, never an alerting event.
+    #expect(spy.polishErrorCaptureCount == 0)
+    // Half 2: it still leaves a trail entry, matching the #979 downgrade precedent.
+    // Both spies filter to this call's own signature: the delegates are process
+    // globals, so an unrelated sibling emit must not redden this test.
+    let cancellationCrumbs = spy.breadcrumbs.filter {
+      $0.stage == "polish" && $0.message.contains("AFM polish cancelled")
+    }
+    #expect(cancellationCrumbs.count == 1)
   }
 
   // MARK: - 6. PolishMetadata Codable roundtrip


### PR DESCRIPTION
Closes #1438.

## What was wrong

`SentryBreadcrumb.captureAFMPolishError` fired a full `.error`-level `generation_failed` event for **any** `AFMPolishError`, including one whose underlying cause is a bare `Swift.CancellationError`.

That happens on **every** Apple Intelligence polish timeout:

1. `TextProcessingRunner` races polish under `withThrowingTimeout` (`TextProcessingRunner.swift:123-125`).
2. The budget wins → the task group implicitly cancels the still-running operation task.
3. `AppleIntelligenceConnector.polish()`'s catch-all (`AppleIntelligenceConnector.swift:386-388`) wraps the resulting `CancellationError` into `AFMPolishError` with no exemption.
4. `LLMPolishStep.process()` (`LLMPolishStep.swift:395-398`) captures it to Sentry **before rethrowing**.

So the alert fires one layer down, *inside the doomed cancelled task*, and `TextProcessingRunner`'s own `isAppleIntelligencePolishTimeout` silent-skip branch — which is correct and never changed — never gets the chance to suppress it. It only ever sees the `TimeoutError` the task group hands back.

The runner already treats bare `CancellationError` as a clean non-alerting unwind everywhere else it can see it (`catch is CancellationError { throw CancellationError() }`, `TextProcessingRunner.swift:151-152`). This capture site was the one place that didn't honor that.

**Impact:** ~80 events across 30+ users over 30 days, all noise. Users were never affected — they got clean deterministic text with no "AI polish failed" banner the entire time. Two prior closed duplicates (#809, #982) each independently confirmed the fingerprint is `AFMPolishError` wrapping `Swift.CancellationError` from real production Sentry data; #982's closing comment named this exact fix but left it unshipped.

## The fix

Filter `CancellationError` out of the capture and route it to a breadcrumb, matching the established downgrade precedent (#979 `asr_empty_result`, #1055 AFM timeout/context-overflow). Every other underlying error type keeps firing the full event, byte-identical.

## Observability is not reduced

Downgrading the Sentry *alert* does not cost aggregate visibility into AFM timeout rate. `TextProcessingRunner.swift:309-311` already emits a separate PostHog signal, unconditionally on this branch and independent of anything the Sentry path does:

`TelemetryService.shared.polishSkipped(provider: .appleIntelligence, reason: "context_window_timeout")` → `llm.polish_skipped`

This PR touches only the Sentry alerting side. The rate signal is untouched.

## Testing

New regression test asserts **both halves** of the contract: no alerting event captured, *and* a breadcrumb recorded with the expected stage and message.

Proven falsifiable rather than merely green — with the fix reverted, both assertions fail:

```
✘ Expectation failed: (spy.polishErrorCaptureCount → 1) == 0
✘ Expectation failed: (cancellationCrumbs.count → 0) == 1
```

Adds a `breadcrumbDelegate` test seam mirroring the existing `captureErrorDelegate` idiom in the same file, so the positive half is observable. Both spies filter to this call's own signature, since the delegates are process globals and an unrelated sibling emit must not redden the test (`swift-patterns.md` RULE: tests-no-process-global-mutable-delegate).

- Full logic suite green (2,374 tests / 276 suites), plus the 149-test release lane.
- Local `codex review` clean on the first pass.
- Live UAT: N — no transcript, timing, or UI surface changes; there is no reliable way to force a genuine 10s AFM stall, and the user-visible silent-skip path is unchanged and already covered by `TextProcessingRunnerTests`.

## Unrelated pre-existing failure found

`CaptureRouteResolverForceMappingTests.automaticNeverEmitsDormantCase` fails on any machine with Bluetooth audio output as default, and does so identically on clean `main` @ `d976d1d`. Not caused by this PR. Filed as #1442 with a fix direction.

## Post-release verification

Sentry `generation_failed: CancellationError` under the `polish` stage should drop to zero for releases containing this fix (pre-fix events remain, scoped by release). PostHog `llm.polish_skipped` / `skip_reason=context_window_timeout` should continue at its pre-existing rate, proving the aggregate signal survived untouched. Non-cancellation `generation_failed` AFM events unaffected in both count and rate.

## Blast radius

`SentryBreadcrumb.swift` (one method body + one test-only static var) and one test file. `LLMPolishStep`, `AppleIntelligenceConnector`, and `TextProcessingRunner` are read for context but **not** edited. Rollback is a single-commit revert.

Plan: `docs/feature-requests/issue-1438-2026-07-09-afm-cancellation-sentry-noise.md` (council coverage round + 3 rounds of Codex grounded review to PROCEED-AS-PLANNED).