### PR TITLE
fix(audio): AirPods degraded-capture fix — real format stabilization, degraded-lead salvage, fleet telemetry

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
@@ -1,0 +1,53 @@
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+
+/// #1434: assembles the `dictation.completed` report from a driver's
+/// post-completion pass-throughs (route, capture health, salvage marker) so
+/// `DictationLifecycleCoordinator`'s state-handler factory stays a thin wiring
+/// site. Pure argument mapping — no state, no decisions beyond the
+/// omit-when-zero convention for counters/flags.
+@MainActor
+enum DictationCompletedReporting {
+  static func report(
+    transcript: Transcript,
+    inputMode: String,
+    driver: KernelDictationDriver
+  ) {
+    let route = driver.lastResolvedRoute
+    let health = driver.lastCaptureHealth
+    TelemetryService.shared.reportDictationCompleted(
+      transcript: transcript, inputMode: inputMode,
+      recordingSeconds: driver.lastRecordingDurationSeconds,
+      stopReason: driver.lastStopReason,
+      historySaveStatus: driver.lastHistorySaved ? "succeeded" : "failed",  // #1167
+      historySaveErrorClass: driver.lastHistorySaveErrorClass,
+      // #1376: effective-device telemetry — which mic was selected vs used.
+      selectedTransport: route?.selected,
+      effectiveTransport: route?.effective,
+      routeReason: route?.routeReason,
+      routeFallbackReason: route?.routeFallbackReason,
+      inputSelectionMode: route?.inputSelectionMode,
+      outputTransport: route?.outputTransport,
+      routeResolutionSource: route?.routeResolutionSource,
+      // #1434: capture-health facts + salvage marker. Counters/flags ride
+      // only when non-zero/true (omit-when-zero keeps the event lean).
+      captureNativeRateHz: health?.nativeRateHz,
+      captureRingDropCount: positive(health?.ringDropCount),
+      captureConverterErrorCount: positive(health?.converterErrorCount),
+      captureZeroOutputCount: positive(health?.zeroOutputCount),
+      captureRateDivergenceDetected: whenTrue(health?.rateDivergenceDetected),
+      captureFormatStabilized: health?.formatStabilized,
+      captureRebuiltForFormat: whenTrue(health?.captureRebuiltForFormat),
+      salvagedLeadTrimMs: driver.lastSalvagedLeadTrimMs)
+  }
+
+  private static func positive(_ value: Int?) -> Int? {
+    value.flatMap { $0 > 0 ? $0 : nil }
+  }
+
+  private static func whenTrue(_ value: Bool?) -> Bool? {
+    value.flatMap { $0 ? true : nil }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -256,7 +256,8 @@ final class DictationLifecycleCoordinator {
       lastPolishError: kernelDriver.lastPolishError,
       currentTranscript: kernelDriver.currentTranscript,
       historySaved: kernelDriver.lastHistorySaved,
-      historySaveReason: kernelDriver.lastHistorySaveReason
+      historySaveReason: kernelDriver.lastHistorySaveReason,
+      salvagedLead: kernelDriver.lastSalvagedLeadTrimMs != nil
     )
     // PR7 of #763 — push polish error to the post-recording result home so
     // views can read `lastRecordingResult.polishError` without reaching
@@ -307,7 +308,8 @@ final class DictationLifecycleCoordinator {
       lastPolishError: whisperKitKernelDriver.lastPolishError,
       currentTranscript: whisperKitKernelDriver.currentTranscript,
       historySaved: whisperKitKernelDriver.lastHistorySaved,
-      historySaveReason: whisperKitKernelDriver.lastHistorySaveReason
+      historySaveReason: whisperKitKernelDriver.lastHistorySaveReason,
+      salvagedLead: whisperKitKernelDriver.lastSalvagedLeadTrimMs != nil
     )
     lastRecordingResult.polishError = whisperKitKernelDriver.lastPolishError
     dispatchChipLifecycle(
@@ -414,21 +416,10 @@ final class DictationLifecycleCoordinator {
       },
       reportDictationCompleted: { [weak self] t in
         guard let self else { return }
-        let route = driver.lastResolvedRoute
-        TelemetryService.shared.reportDictationCompleted(
-          transcript: t, inputMode: self.settings.recordingMode.rawValue,
-          recordingSeconds: driver.lastRecordingDurationSeconds,
-          stopReason: driver.lastStopReason,
-          historySaveStatus: driver.lastHistorySaved ? "succeeded" : "failed",  // #1167
-          historySaveErrorClass: driver.lastHistorySaveErrorClass,
-          // #1376: effective-device telemetry — which mic was selected vs used.
-          selectedTransport: route?.selected,
-          effectiveTransport: route?.effective,
-          routeReason: route?.routeReason,
-          routeFallbackReason: route?.routeFallbackReason,
-          inputSelectionMode: route?.inputSelectionMode,
-          outputTransport: route?.outputTransport,
-          routeResolutionSource: route?.routeResolutionSource)
+        // #1376/#1434: route + capture-health + salvage argument assembly
+        // lives in `DictationCompletedReporting` (thin-factory discipline).
+        DictationCompletedReporting.report(
+          transcript: t, inputMode: self.settings.recordingMode.rawValue, driver: driver)
       },
       reportPipelineFailed: { msg in
         TelemetryService.shared.pipelineFailed(
@@ -438,6 +429,15 @@ final class DictationLifecycleCoordinator {
       // #1167: history-save-failed pill (post-completion warning slot, ~400 ms).
       scheduleHistorySaveFailedWarning: { [weak self] reason in
         self?.schedulePostCompletionWarning(message: "Couldn't save to history: \(reason)")
+      },
+      // #1434: salvaged-lead disclosure pill — the degraded-lead retry
+      // recovered this dictation by trimming a poisoned opening, so the
+      // pasted text is missing its lead. Same generic post-completion
+      // mechanism as the two pills above; the message is wired HERE, never
+      // hardcoded into a shared closure (Codex r2 rev 5).
+      scheduleSalvagedLeadWarning: { [weak self] in
+        self?.schedulePostCompletionWarning(
+          message: "Beginning of dictation was unclear and was skipped")
       }
     )
   }

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -167,6 +167,17 @@ final class AVAudioEngineSource: AudioInputSource {
   /// Called when an audio device operation fails.
   var onDeviceError: ((String) -> Void)?
 
+  /// #1434: stop-time capture health. The engine path exposes the input
+  /// node's live rate only (its converter/ring internals predate the counter
+  /// instrumentation and have their own, battle-tested diagnostics); nil when
+  /// the engine isn't running.
+  var captureStopMetadata: CaptureStopMetadata? {
+    guard engine.isRunning else { return nil }
+    let rate = engine.inputNode.outputFormat(forBus: 0).sampleRate
+    guard rate > 0 else { return nil }
+    return CaptureStopMetadata(nativeRateHz: rate)
+  }
+
   // NOTE: onPartialSamples removed — manager owns capturedSamples and handles partial recovery.
 
   // MARK: - Constants

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -327,6 +327,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // synchronously (#285).
     cachedCaptureGeneration = source.captureGeneration
     cachedSourceType = source.captureSourceType
+    // #1434: capture-health snapshot must ALSO precede teardown — with
+    // warmEnginePolicy == .off, scheduleWarmEngineTeardown() below destroys
+    // the render context this reads from.
+    let stopMetadata = source.captureStopMetadata
 
     isCapturing = false
     audioLevel = 0.0
@@ -351,7 +355,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // In-process path returns empty vadSegments; pipeline owns its own SilenceDetector.
     let samples = capturedSamples
     capturedSamples = []
-    return CaptureResult(samples: samples)
+    return CaptureResult(samples: samples, metadata: stopMetadata)
   }
 
   public func rebuildEngine() {
@@ -580,9 +584,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
           let normalize: (String?) -> String = { ($0?.isEmpty ?? true) ? "" : $0! }
           configMatch = normalize(captureSource.targetDeviceUID) == normalize(wantsTarget)
         }
-        // Candidate D (#1377 slice 2b): same stale-target trap as candidate A
-        // above — a warm HAL source from a forced trial must not be reused
-        // once the override clears (or changes device).
+      // Candidate D (#1377 slice 2b): same stale-target trap as candidate A
+      // above — a warm HAL source from a forced trial must not be reused
+      // once the override clears (or changes device).
       #endif
       if configMatch, let halSource = existing as? HALDeviceInputSource {
         var wantsTarget = decision.effectiveDeviceUID

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -455,9 +455,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
             // #1434: decode the helper's capture-health metadata back into the
             // SAME struct the in-process path attaches — decode failure
             // degrades to nil (diagnostic limb; never fails the stop).
-            let metadata = metadataData.flatMap {
-              try? JSONDecoder().decode(CaptureStopMetadata.self, from: $0)
-            }
+            let metadata = Self.decodeCaptureStopMetadata(metadataData)
             guard_.resume(
               returning: CaptureResult(
                 samples: samples, vadSegments: segments, metadata: metadata))
@@ -1099,6 +1097,19 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   nonisolated private static func dataToFloats(_ data: Data) -> [Float] {
     guard !data.isEmpty, data.count.isMultiple(of: MemoryLayout<Float>.size) else { return [] }
     return data.withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
+  }
+
+  /// Decode the helper's JSON-encoded capture-health metadata (#1434).
+  /// nonisolated: called from XPC reply callbacks which run on XPC dispatch
+  /// queues, not MainActor — decoding inline in a closure literal written
+  /// inside the (MainActor-inherited) reply block traps at runtime because
+  /// the closure inherits MainActor isolation from its lexical context but
+  /// actually runs on the XPC queue; hoisting to a nonisolated static
+  /// function (matching dataToFloats/decodeVADSegments above) breaks that
+  /// inheritance the same way #1434's live UAT crash proved was required.
+  nonisolated private static func decodeCaptureStopMetadata(_ data: Data?) -> CaptureStopMetadata? {
+    guard let data else { return nil }
+    return try? JSONDecoder().decode(CaptureStopMetadata.self, from: data)
   }
 
   /// Decode packed [Int32 start, Int32 end] pairs into SpeechSegment array.

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -449,10 +449,18 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       // retire-only and onXPCReplyFailed is the sole caller-visible signal.
       serviceProxy(
         { proxy in
-          proxy.stopCapture(operationID: operationID) { sampleData, vadData in
+          proxy.stopCapture(operationID: operationID) { sampleData, vadData, metadataData in
             let samples = Self.dataToFloats(sampleData)
             let segments = Self.decodeVADSegments(vadData)
-            guard_.resume(returning: CaptureResult(samples: samples, vadSegments: segments))
+            // #1434: decode the helper's capture-health metadata back into the
+            // SAME struct the in-process path attaches — decode failure
+            // degrades to nil (diagnostic limb; never fails the stop).
+            let metadata = metadataData.flatMap {
+              try? JSONDecoder().decode(CaptureStopMetadata.self, from: $0)
+            }
+            guard_.resume(
+              returning: CaptureResult(
+                samples: samples, vadSegments: segments, metadata: metadata))
           }
         },
         onProxyError: { [weak self] in

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -58,4 +58,17 @@ protocol AudioInputSource: AnyObject {
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
   func abortPrepare()
   func rebuild()
+
+  /// #1434: stop-time capture-health facts (native rate, drop/error counters,
+  /// divergence flag) the manager attaches to `CaptureResult.metadata`.
+  /// Declared as a REQUIREMENT (not extension-only) so existential calls
+  /// dispatch to the conformer, with a nil default below for sources that
+  /// don't track capture health. Synchronous computed property with identical
+  /// sync witnesses — not the async-default trap (`swift-patterns.md` RULE:
+  /// no-sync-witness-with-defaulted-async-protocol-method).
+  var captureStopMetadata: CaptureStopMetadata? { get }
+}
+
+extension AudioInputSource {
+  var captureStopMetadata: CaptureStopMetadata? { nil }
 }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -100,6 +100,25 @@ private final class HALSampleRing: @unchecked Sendable {
   }
 }
 
+/// Per-session capture-health counters (#1434). Incremented from the RT render
+/// callback (ring drops) and the consumer thread (converter errors / zero
+/// output); read + reset from the MainActor source. A single unfair lock keeps
+/// every touch a bounded few-instruction critical section — the same cost
+/// class as `HALSampleRing`'s lock, which the RT contract already accepts.
+private final class HALSessionCounters: Sendable {
+  struct Snapshot {
+    var ringDrops = 0
+    var converterErrors = 0
+    var zeroOutputs = 0
+  }
+  private let state = OSAllocatedUnfairLock(initialState: Snapshot())
+  func incrementRingDrop() { state.withLock { $0.ringDrops += 1 } }
+  func incrementConverterError() { state.withLock { $0.converterErrors += 1 } }
+  func incrementZeroOutput() { state.withLock { $0.zeroOutputs += 1 } }
+  func snapshot() -> Snapshot { state.withLock { $0 } }
+  func reset() { state.withLock { $0 = Snapshot() } }
+}
+
 /// The RT-callback-reachable context, passed by raw pointer via `Unmanaged`
 /// (an `AURenderCallback` is `@convention(c)` and cannot capture Swift state).
 /// Holds only what the render callback and its off-IO-thread consumer need;
@@ -127,6 +146,9 @@ private final class HALRenderContext: @unchecked Sendable {
   /// Resamples `nativeFormat` → `targetFormat` on the consumer thread —
   /// mirrors `AVAudioEngineSource`'s own `AVAudioConverter` usage exactly.
   let converter: AVAudioConverter
+  /// #1434 capture-health counters — RT + consumer threads increment, the
+  /// MainActor source snapshots at stop and resets per session.
+  let counters = HALSessionCounters()
   /// Signaled once per rendered chunk; the dedicated consumer thread blocks
   /// on this instead of the render callback dispatching work (Codex review r1
   /// P2: `DispatchQueue.async` from the HAL IO thread can allocate/lock —
@@ -224,7 +246,20 @@ private final class HALRenderContext: @unchecked Sendable {
       outStatus.pointee = .haveData
       return nativeBuffer
     }
-    guard error == nil, convertedBuffer.frameLength > 0 else { return false }
+    // One-buffer-then-.noDataNow is the documented pull-style streaming idiom
+    // (AVAudioConverter docs), and dropping a zero-frame output is REQUIRED —
+    // forwarding an empty buffer duplicates a timestamp downstream. Both
+    // branches are counted (#1434) so a converter that fails repeatedly is
+    // fleet-visible instead of silent: priming legitimately yields one
+    // zero-frame output; more than ~1 per session is a signal.
+    if error != nil {
+      counters.incrementConverterError()
+      return false
+    }
+    guard convertedBuffer.frameLength > 0 else {
+      counters.incrementZeroOutput()
+      return false
+    }
 
     let level = AudioBufferProcessor.calculateRMS(convertedBuffer)
     guard let channelData = convertedBuffer.floatChannelData else { return false }
@@ -311,6 +346,23 @@ final class HALDeviceInputSource: AudioInputSource {
   private var unmanagedContext: Unmanaged<HALRenderContext>?
   private var deviceIsAliveListenerDeviceID: AudioDeviceID?
   private var deviceIsAliveListenerBlock: AudioObjectPropertyListenerBlock?
+  // #1434: mid-recording format-change listeners — one stored token PER
+  // selector (stream format + nominal rate), same queue + add/remove
+  // lifecycle as the DeviceIsAlive listener above.
+  private var formatListenerDeviceID: AudioDeviceID?
+  private var streamFormatListenerBlock: AudioObjectPropertyListenerBlock?
+  private var nominalRateListenerBlock: AudioObjectPropertyListenerBlock?
+  /// #1434: set (MainActor) when a format-change notification fired while
+  /// capturing AND the re-read rate differs from the prepare-time rate.
+  /// Log-and-telemetry only in v1 — never interrupts the recording. Reset
+  /// per session in `startCapture()`.
+  private var formatDivergenceObserved = false
+  /// #1434 test seam: injectable native-rate reader (mirrors the existing
+  /// `resolveDeviceIDForUID` injection pattern). Defaults to the real
+  /// HAL property query.
+  var nativeRateReader: (AudioDeviceID) -> Double? = { deviceID in
+    HALDeviceInputSource.queryNativeStreamFormat(deviceID: deviceID)?.mSampleRate
+  }
   private var forwarder: PreRollForwarder?
   /// Dedicated thread draining `HALRenderContext.ring` off the HAL IO thread.
   /// Retained only to keep it alive; its loop exits on its own once
@@ -338,6 +390,21 @@ final class HALDeviceInputSource: AudioInputSource {
   func boundDeviceMatchesResolvedTargetForReuse() -> Bool {
     guard let boundDeviceID else { return false }
     return boundDeviceID == resolveDeviceID()
+  }
+
+  /// #1434: stop-time capture-health facts. The manager snapshots this BEFORE
+  /// deactivate/teardown and attaches it to `CaptureResult.metadata` — the one
+  /// transport object for both the in-process and XPC stop paths.
+  var captureStopMetadata: CaptureStopMetadata? {
+    guard let context = renderContext else { return nil }
+    let snap = context.counters.snapshot()
+    return CaptureStopMetadata(
+      nativeRateHz: context.nativeFormat.sampleRate,
+      ringDropCount: snap.ringDrops,
+      converterErrorCount: snap.converterErrors,
+      zeroOutputCount: snap.zeroOutputs,
+      rateDivergenceDetected: formatDivergenceObserved
+    )
   }
 
   private static let listenerQueue = DispatchQueue(
@@ -536,12 +603,18 @@ final class HALDeviceInputSource: AudioInputSource {
     self.audioUnit = unit
     self.consumerThread = Self.makeConsumerThread(context: context)
     registerDeviceIsAliveListener(deviceID: deviceID)
+    registerFormatChangeListeners(deviceID: deviceID)
 
     boundDeviceID = deviceID
     boundUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
     boundTransport = AudioDeviceEnumerator.transportLabel(for: deviceID)
+    // #1434: the native rate + ratio in the prepare line is the per-recording
+    // rate evidence D4 flagged as the highest-value instrumentation gap.
+    let ratio = Self.targetFormat.sampleRate / nativeFormat.sampleRate
     AudioCaptureManager.btRouteLog(
-      "HALDeviceInputSource: prepared with device \(deviceID) (uid=\(boundUID ?? "unknown"))"
+      "HALDeviceInputSource: prepared with device \(deviceID) (uid=\(boundUID ?? "unknown")) "
+        + "nativeRate=\(Int(nativeFormat.sampleRate)) targetRate=\(Int(Self.targetFormat.sampleRate)) "
+        + "ratio=\(String(format: "%.3f", ratio))"
     )
   }
 
@@ -566,6 +639,11 @@ final class HALDeviceInputSource: AudioInputSource {
     captureGeneration &+= 1
     captureLiveness.reset()
     renderContext?.resetSession()
+    // #1434: per-session capture-health state. The warm unit outlives sessions
+    // (deactivateCapture keeps it pre-rolling), so an idle-time format change
+    // or pre-roll ring drop must not bleed into the next recording's telemetry.
+    renderContext?.counters.reset()
+    formatDivergenceObserved = false
     armCaptureStallWatchdog()
 
     isCapturing = true
@@ -624,7 +702,12 @@ final class HALDeviceInputSource: AudioInputSource {
       tapInstalled: true,
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: targetDeviceUID,
-      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+      // #1434: the stall fires BEFORE stopCapture(), so the source stamps its
+      // own live rate/divergence here — the stop-time metadata object does
+      // not exist yet. (The XPC proxy's host-side watchdog leaves these nil.)
+      nativeRateHz: renderContext?.nativeFormat.sampleRate,
+      rateDivergenceDetected: formatDivergenceObserved
     )
     onCaptureStalled?(ctx)
   }
@@ -635,6 +718,17 @@ final class HALDeviceInputSource: AudioInputSource {
     forwarder?.returnToPreRoll()
     isCapturing = false
     streamContinuation = nil
+    // #1434 session stats — dev-visible mirror of the CaptureStopMetadata the
+    // manager reads via `captureStopMetadata` before this call.
+    if let context = renderContext {
+      let snap = context.counters.snapshot()
+      AudioCaptureManager.btRouteLog(
+        "HAL session stats: native=\(Int(context.nativeFormat.sampleRate)) "
+          + "target=\(Int(context.targetFormat.sampleRate)) "
+          + "ringDrops=\(snap.ringDrops) convErrors=\(snap.converterErrors) "
+          + "zeroConvOut=\(snap.zeroOutputs) rateDivergence=\(formatDivergenceObserved)"
+      )
+    }
     AudioCaptureManager.btRouteLog(
       "HALDeviceInputSource deactivated — unit stays warm, pre-roll capturing")
   }
@@ -649,10 +743,101 @@ final class HALDeviceInputSource: AudioInputSource {
     return []
   }
 
+  /// Real settling check (#1434 — replaces a stub whose comment asserted the
+  /// exact claim Apple QA1777 refutes: AUHAL does NOT resample input, so a
+  /// device whose rate is still renegotiating DOES need waiting out).
+  ///
+  /// Two jobs, one contract:
+  /// 1. SETTLED — poll the device's native rate until two consecutive reads
+  ///    agree (mirrors `AVAudioEngineSource.waitForFormatStabilization`'s
+  ///    two-reads-agree shape; Apple forum 770232 documents AirPods reporting
+  ///    a transient wrong rate corrected by a later notification).
+  /// 2. MATCHES — the settled rate must equal the rate this unit's converter
+  ///    was built at in `prepare()`. A settled-but-DIVERGENT rate returns
+  ///    false, which routes into the kernel's existing one-rebuild retry seam
+  ///    (`RecordingSessionKernel` stabilization site) — `prepare()` then
+  ///    re-reads the fresh rate and rebuilds the converter. The kernel makes
+  ///    exactly one rebuild attempt and never re-checks stabilization after
+  ///    it; residual failure is owned by the stall watchdog / ASR-empty paths.
+  ///
+  /// No bound device / no live unit → true (nothing to stabilize; matches the
+  /// manager's no-active-source short-circuit).
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
-    // AUHAL's client format is fixed at the property we set — CoreAudio does
-    // the SRC internally, so there is no format renegotiation to wait out.
-    return true
+    guard let deviceID = boundDeviceID, let context = renderContext else { return true }
+    let preparedRate = context.nativeFormat.sampleRate
+    let stabStart = ContinuousClock.now
+    let outcome = await Self.settleNativeRate(
+      preparedRate: preparedRate,
+      maxWait: maxWait,
+      pollInterval: pollInterval,
+      readRate: { [nativeRateReader] in nativeRateReader(deviceID) },
+      sleep: { try? await Task.sleep(for: $0) }
+    )
+    let elapsed = Self.stabMs(ContinuousClock.now - stabStart)
+    let settledLabel = outcome.settledRate.map { String(Int($0)) } ?? "unstable"
+    AudioCaptureManager.btRouteLog(
+      "HAL formatStab: settled=\(settledLabel) prepared=\(Int(preparedRate)) "
+        + "matches=\(outcome.matchesPrepared) polls=\(outcome.polls) ms=\(elapsed)"
+    )
+    return outcome.matchesPrepared
+  }
+
+  /// Pure settle loop (#1434) — separated from the instance so tests can
+  /// drive it with an injected reader + no-op sleep (`test-timing`: assert on
+  /// the returned value, never the wall clock).
+  ///
+  /// SETTLED = two consecutive reads agree and are non-nil. The result is
+  /// `matchesPrepared` — a settled-but-DIVERGENT rate is deliberately false
+  /// (routes into the kernel's one-rebuild retry seam).
+  struct RateSettleOutcome: Equatable {
+    let settledRate: Double?
+    let matchesPrepared: Bool
+    let polls: Int
+  }
+
+  static func settleNativeRate(
+    preparedRate: Double,
+    maxWait: TimeInterval,
+    pollInterval: TimeInterval,
+    readRate: () -> Double?,
+    sleep: (Duration) async -> Void
+  ) async -> RateSettleOutcome {
+    func outcome(_ settled: Double?, polls: Int) -> RateSettleOutcome {
+      RateSettleOutcome(
+        settledRate: settled,
+        matchesPrepared: settled == preparedRate,
+        polls: polls)
+    }
+    // Fast path: two reads 10ms apart agree (the common already-settled case
+    // returns in ~10ms, keeping the warm PTT path cheap).
+    var lastRate = readRate()
+    await sleep(.milliseconds(10))
+    var currentRate = readRate()
+    if currentRate != nil, currentRate == lastRate {
+      return outcome(currentRate, polls: 0)
+    }
+    // Bounded poll loop — polls is the budget (not wall-clock, so an injected
+    // no-op sleep terminates deterministically).
+    let maxPolls = max(1, Int(maxWait / max(pollInterval, 0.001)))
+    var polls = 0
+    while polls < maxPolls {
+      lastRate = currentRate
+      await sleep(.seconds(pollInterval))
+      polls += 1
+      currentRate = readRate()
+      if currentRate != nil, currentRate == lastRate {
+        return outcome(currentRate, polls: polls)
+      }
+    }
+    // Never settled within the budget — unstable (false → rebuild seam).
+    return outcome(nil, polls: polls)
+  }
+
+  /// Duration → ms for the stabilization log (file-local; the manager's
+  /// equivalent helper is private to it).
+  nonisolated private static func stabMs(_ d: Duration) -> Int {
+    let (seconds, attoseconds) = d.components
+    return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
   }
 
   func abortPrepare() {
@@ -681,6 +866,7 @@ final class HALDeviceInputSource: AudioInputSource {
     isCapturing = false
     stoppedFlag?.set()
     removeDeviceIsAliveListener()
+    removeFormatChangeListeners()
     if let unit = audioUnit {
       // Synchronous per Apple docs — blocks until the IO thread has genuinely
       // stopped calling the render callback, so nothing below can race a live
@@ -777,6 +963,90 @@ final class HALDeviceInputSource: AudioInputSource {
     AudioObjectRemovePropertyListenerBlock(deviceID, &addr, Self.listenerQueue, block)
     deviceIsAliveListenerDeviceID = nil
     deviceIsAliveListenerBlock = nil
+  }
+
+  // MARK: - Private: format-change listeners (#1434)
+
+  /// Mid-recording format/rate-change observation — Apple's documented AirPods
+  /// behavior (forum 770232) is a transient wrong rate corrected via exactly
+  /// these notifications. Structural sibling of `registerDeviceIsAliveListener`:
+  /// one stored token PER selector, the shared `listenerQueue`, and a MainActor
+  /// hop before touching source state. v1 is LOG + FLAG only — a forced
+  /// interruption would discard the dictation (#1408's known gap), converting
+  /// degraded audio into guaranteed total loss.
+  private func registerFormatChangeListeners(deviceID: AudioDeviceID) {
+    var formatAddr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyStreamFormat,
+      mScope: kAudioDevicePropertyScopeInput,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    var rateAddr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyNominalSampleRate,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    let formatBlock: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+      Task { @MainActor [weak self] in
+        self?.handleDeviceFormatMayHaveChanged(deviceID: deviceID, selector: "streamFormat")
+      }
+    }
+    let rateBlock: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+      Task { @MainActor [weak self] in
+        self?.handleDeviceFormatMayHaveChanged(deviceID: deviceID, selector: "nominalRate")
+      }
+    }
+    if AudioObjectAddPropertyListenerBlock(deviceID, &formatAddr, Self.listenerQueue, formatBlock)
+      == noErr
+    {
+      streamFormatListenerBlock = formatBlock
+      formatListenerDeviceID = deviceID
+    }
+    if AudioObjectAddPropertyListenerBlock(deviceID, &rateAddr, Self.listenerQueue, rateBlock)
+      == noErr
+    {
+      nominalRateListenerBlock = rateBlock
+      formatListenerDeviceID = deviceID
+    }
+  }
+
+  private func removeFormatChangeListeners() {
+    guard let deviceID = formatListenerDeviceID else { return }
+    if let block = streamFormatListenerBlock {
+      var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyStreamFormat,
+        mScope: kAudioDevicePropertyScopeInput,
+        mElement: kAudioObjectPropertyElementMain
+      )
+      AudioObjectRemovePropertyListenerBlock(deviceID, &addr, Self.listenerQueue, block)
+      streamFormatListenerBlock = nil
+    }
+    if let block = nominalRateListenerBlock {
+      var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyNominalSampleRate,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+      )
+      AudioObjectRemovePropertyListenerBlock(deviceID, &addr, Self.listenerQueue, block)
+      nominalRateListenerBlock = nil
+    }
+    formatListenerDeviceID = nil
+  }
+
+  /// MainActor handler for either format-change selector. Guarded on
+  /// `isCapturing` (idle/warm changes are the next prepare()'s problem — the
+  /// per-session reset in `startCapture()` keeps them out of telemetry).
+  private func handleDeviceFormatMayHaveChanged(deviceID: AudioDeviceID, selector: String) {
+    guard isCapturing, let context = renderContext else { return }
+    let preparedRate = context.nativeFormat.sampleRate
+    let currentRate = nativeRateReader(deviceID)
+    let diverged = currentRate != nil && currentRate != preparedRate
+    AudioCaptureManager.btRouteLog(
+      "HAL format change (\(selector)) mid-capture: prepared=\(Int(preparedRate)) "
+        + "now=\(currentRate.map { String(Int($0)) } ?? "unknown") diverged=\(diverged)"
+    )
+    if diverged {
+      formatDivergenceObserved = true
+    }
   }
 
   private func handleDeviceMayHaveVanished(deviceID: AudioDeviceID) {
@@ -876,6 +1146,11 @@ private func halRenderProc(
   // (cloud review P2).
   if context.ring.push(floatPtr, count: frameCount, level: level) {
     context.semaphore.signal()
+  } else {
+    // #1434: a dropped chunk is lost audio — count it (bounded lock-inc, same
+    // RT cost class as the ring lock) so a bad recording can prove or rule
+    // out ring overrun instead of the drop staying invisible.
+    context.counters.incrementRingDrop()
   }
 
   return noErr

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -237,7 +237,7 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
     }
   }
 
-  func stopCapture(operationID: String, reply: @escaping (Data, Data) -> Void) {
+  func stopCapture(operationID: String, reply: @escaping (Data, Data, Data?) -> Void) {
     let signal = XPCOperationSignalFile.audio.makeEmitter(operationID: operationID)
     signal.emit(stage: "audio.stop_capture.received")
     nonisolated(unsafe) let safeReply = reply
@@ -278,8 +278,13 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
       }
 
       let sampleData = captureResult.samples.withUnsafeBytes { Data($0) }
+      // #1434: capture-health metadata rides the same atomic reply — the host
+      // proxy decodes it back into the identical `CaptureStopMetadata`, so
+      // both stop paths yield the same `CaptureResult.metadata`. Encode
+      // failure degrades to nil (diagnostic limb; never blocks the reply).
+      let metadataData = captureResult.metadata.flatMap { try? JSONEncoder().encode($0) }
       signal.emit(stage: "audio.stop_capture.reply_ready")
-      safeReply(sampleData, vadData)
+      safeReply(sampleData, vadData, metadataData)
 
       // Crash-recovery limb (AFTER the heart-path reply so it never delays
       // delivery): write the final tail beyond what the poll loop fed, then

--- a/Sources/EnviousWisprCore/AudioServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/AudioServiceProtocol.swift
@@ -56,9 +56,12 @@ import Foundation
 
   /// Stop capture and return accumulated samples + finalized VAD segments atomically.
   /// First Data = raw Float32 sample bytes. Second Data = packed [Int32 start, Int32 end] VAD segment pairs.
+  /// Third Data = JSON-encoded `CaptureStopMetadata` (#1434 capture-health facts), nil when the
+  /// active source doesn't produce one — the proxy decodes it back into the same struct, so both
+  /// the XPC and in-process paths yield an identical `CaptureResult.metadata`.
   /// VAD segments are finalized BEFORE the sample buffer is cleared, preventing the call-order bug
   /// where separate stopCapture/getVADSegments calls produced endSample=0 on open segments.
-  func stopCapture(operationID: String, reply: @escaping (Data, Data) -> Void)
+  func stopCapture(operationID: String, reply: @escaping (Data, Data, Data?) -> Void)
 
   /// Cancel a pre-warmed engine that never began capture.
   func abortPreWarm()

--- a/Sources/EnviousWisprCore/CaptureStallContext.swift
+++ b/Sources/EnviousWisprCore/CaptureStallContext.swift
@@ -27,6 +27,17 @@ public struct CaptureStallContext: Sendable {
   public let inputSelectionMode: String?
   public let outputTransport: String?
   public let routeResolutionSource: String?
+  // #1434: capture-health fields. The stall event fires BEFORE stopCapture()
+  // returns, so it can never read the stop-time `CaptureStopMetadata` — the
+  // SOURCE stamps rate/divergence from its own live state at watchdog-fire
+  // time (direct HAL stalls populate them; the XPC proxy's host-side watchdog
+  // cannot read helper state pre-stop and leaves them nil). Stabilization
+  // flags are kernel-side observations merged in the kernel's stall handler
+  // via `enrichedWithStabilizationFlags` before emission.
+  public let nativeRateHz: Double?
+  public let rateDivergenceDetected: Bool?
+  public let formatStabilized: Bool?
+  public let captureRebuiltForFormat: Bool?
 
   public init(
     sessionID: UInt64,
@@ -45,7 +56,11 @@ public struct CaptureStallContext: Sendable {
     routeFallbackReason: String? = nil,
     inputSelectionMode: String? = nil,
     outputTransport: String? = nil,
-    routeResolutionSource: String? = nil
+    routeResolutionSource: String? = nil,
+    nativeRateHz: Double? = nil,
+    rateDivergenceDetected: Bool? = nil,
+    formatStabilized: Bool? = nil,
+    captureRebuiltForFormat: Bool? = nil
   ) {
     self.sessionID = sessionID
     self.armedAtUptimeNs = armedAtUptimeNs
@@ -64,6 +79,42 @@ public struct CaptureStallContext: Sendable {
     self.inputSelectionMode = inputSelectionMode
     self.outputTransport = outputTransport
     self.routeResolutionSource = routeResolutionSource
+    self.nativeRateHz = nativeRateHz
+    self.rateDivergenceDetected = rateDivergenceDetected
+    self.formatStabilized = formatStabilized
+    self.captureRebuiltForFormat = captureRebuiltForFormat
+  }
+
+  /// Kernel-side enrichment (#1434): the kernel owns the stabilization record
+  /// (private telemetry state) and merges it into the context inside its own
+  /// stall handler; the observer stays a plain forwarder. Source-stamped
+  /// fields are preserved as-is.
+  public func enrichedWithStabilizationFlags(
+    formatStabilized: Bool?, captureRebuiltForFormat: Bool?
+  ) -> CaptureStallContext {
+    CaptureStallContext(
+      sessionID: sessionID,
+      armedAtUptimeNs: armedAtUptimeNs,
+      firedAtUptimeNs: firedAtUptimeNs,
+      route: route,
+      sourceType: sourceType,
+      engineStartedSuccessfully: engineStartedSuccessfully,
+      tapInstalled: tapInstalled,
+      formatMismatchObserved: formatMismatchObserved,
+      inputDeviceUIDPreferred: inputDeviceUIDPreferred,
+      inputDeviceUIDSystemDefault: inputDeviceUIDSystemDefault,
+      selectedTransport: selectedTransport,
+      effectiveTransport: effectiveTransport,
+      routeReason: routeReason,
+      routeFallbackReason: routeFallbackReason,
+      inputSelectionMode: inputSelectionMode,
+      outputTransport: outputTransport,
+      routeResolutionSource: routeResolutionSource,
+      nativeRateHz: nativeRateHz,
+      rateDivergenceDetected: rateDivergenceDetected,
+      formatStabilized: formatStabilized,
+      captureRebuiltForFormat: captureRebuiltForFormat
+    )
   }
 }
 

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -46,15 +46,60 @@ public struct SpeechSegment: Sendable, Codable {
 
 // MARK: - Capture Result
 
+/// Capture-health facts for one recording, assembled by the ACTIVE SOURCE at
+/// stop time (#1434). One object for both the in-process and XPC stop paths —
+/// the XPC stop reply encodes/decodes exactly this struct; telemetry
+/// properties (`capture_native_rate_hz`, the counters) are DERIVED from it,
+/// never plumbed as separate side channels.
+public struct CaptureStopMetadata: Sendable, Codable, Equatable {
+  /// The native rate the capture's converter ran at — the prepare-time read of
+  /// whichever prepare produced this capture (post-rebuild when the format
+  /// stabilization check forced a rebuild). Nil when the source doesn't track
+  /// a native rate.
+  public let nativeRateHz: Double?
+  /// Chunks the RT ring refused because the consumer lagged (drop = lost audio).
+  public let ringDropCount: Int
+  /// AVAudioConverter calls that returned an error (converted chunk lost).
+  public let converterErrorCount: Int
+  /// Converter calls that produced zero output frames (expected once at
+  /// priming; more than ~1 per session is a signal).
+  public let zeroOutputCount: Int
+  /// A stream-format / nominal-rate change notification fired for the bound
+  /// device while capturing (#1434 — log-and-telemetry only in v1; never
+  /// interrupts the recording).
+  public let rateDivergenceDetected: Bool
+
+  public init(
+    nativeRateHz: Double?,
+    ringDropCount: Int = 0,
+    converterErrorCount: Int = 0,
+    zeroOutputCount: Int = 0,
+    rateDivergenceDetected: Bool = false
+  ) {
+    self.nativeRateHz = nativeRateHz
+    self.ringDropCount = ringDropCount
+    self.converterErrorCount = converterErrorCount
+    self.zeroOutputCount = zeroOutputCount
+    self.rateDivergenceDetected = rateDivergenceDetected
+  }
+}
+
 /// Atomic result from stopCapture(): audio samples + VAD speech segments.
 /// Bundling these together eliminates the ordering dependency between
 /// stopCapture() and getVADSegments() across the XPC boundary.
 public struct CaptureResult: Sendable {
   public let samples: [Float]
   public let vadSegments: [SpeechSegment]
-  public init(samples: [Float], vadSegments: [SpeechSegment] = []) {
+  /// Capture-health metadata from the active source (#1434); nil on legacy /
+  /// unpopulated paths.
+  public let metadata: CaptureStopMetadata?
+  public init(
+    samples: [Float], vadSegments: [SpeechSegment] = [],
+    metadata: CaptureStopMetadata? = nil
+  ) {
     self.samples = samples
     self.vadSegments = vadSegments
+    self.metadata = metadata
   }
 }
 

--- a/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
@@ -25,6 +25,22 @@ internal struct ASREmptyResultDiagnostics {
   var batchRescueAttempted: Bool?
   var batchRescueResultChars: Int?
 
+  // #1434 degraded-lead salvage ladder (failure-side record — set on every
+  // ladder run so the fleet sees misses, not just wins). `salvageAbortedReason`
+  // is `retry_failed` / `superseded` when the ladder aborted early.
+  var salvageAttempted: Bool?
+  var salvageCandidateCount: Int?
+  var salvageCandidateTrimsMs: [Int]?
+  var salvageAbortedReason: String?
+  // #1434 capture health at the empty terminal.
+  var captureNativeRateHz: Double?
+  var captureRingDropCount: Int?
+  var captureConverterErrorCount: Int?
+  var captureZeroOutputCount: Int?
+  var captureRateDivergenceDetected: Bool?
+  var captureFormatStabilized: Bool?
+  var captureRebuiltForFormat: Bool?
+
   var incrementalAccepted: Bool?
   var incrementalResultChars: Int?
   var incrementalDecodeCount: Int?
@@ -87,6 +103,20 @@ internal struct ASREmptyResultDiagnostics {
 
     put(batchRescueAttempted, key: "asr.batch_rescue_attempted", into: &extra)
     put(batchRescueResultChars, key: "asr.batch_rescue_result_chars", into: &extra)
+
+    put(salvageAttempted, key: "asr.salvage_attempted", into: &extra)
+    put(salvageCandidateCount, key: "asr.salvage_candidate_count", into: &extra)
+    put(
+      salvageCandidateTrimsMs.map { $0.map(String.init).joined(separator: ",") },
+      key: "asr.salvage_candidate_trims_ms", into: &extra)
+    put(salvageAbortedReason, key: "asr.salvage_aborted_reason", into: &extra)
+    put(captureNativeRateHz, key: "capture.native_rate_hz", into: &extra)
+    put(captureRingDropCount, key: "capture.ring_drop_count", into: &extra)
+    put(captureConverterErrorCount, key: "capture.converter_error_count", into: &extra)
+    put(captureZeroOutputCount, key: "capture.zero_output_count", into: &extra)
+    put(captureRateDivergenceDetected, key: "capture.rate_divergence_detected", into: &extra)
+    put(captureFormatStabilized, key: "capture.format_stabilized", into: &extra)
+    put(captureRebuiltForFormat, key: "capture.rebuilt_for_format", into: &extra)
 
     put(incrementalAccepted, key: "asr.incremental_accepted", into: &extra)
     put(incrementalResultChars, key: "asr.incremental_result_chars", into: &extra)

--- a/Sources/EnviousWisprPipeline/CaptureHealthTransports.swift
+++ b/Sources/EnviousWisprPipeline/CaptureHealthTransports.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// #1434: public transport for the most recent recording's capture-health
+/// facts — the App layer reads it off `KernelDictationDriver` for
+/// `dictation.completed`, mirroring `ResolvedRouteTransports`. Hardware-class
+/// numbers and flags only; no identifiers, no audio, no text.
+public struct CaptureHealthTransports: Sendable, Equatable {
+  public let nativeRateHz: Double?
+  public let ringDropCount: Int?
+  public let converterErrorCount: Int?
+  public let zeroOutputCount: Int?
+  public let rateDivergenceDetected: Bool?
+  public let formatStabilized: Bool?
+  public let captureRebuiltForFormat: Bool?
+
+  public init(
+    nativeRateHz: Double?,
+    ringDropCount: Int?,
+    converterErrorCount: Int?,
+    zeroOutputCount: Int?,
+    rateDivergenceDetected: Bool?,
+    formatStabilized: Bool?,
+    captureRebuiltForFormat: Bool?
+  ) {
+    self.nativeRateHz = nativeRateHz
+    self.ringDropCount = ringDropCount
+    self.converterErrorCount = converterErrorCount
+    self.zeroOutputCount = zeroOutputCount
+    self.rateDivergenceDetected = rateDivergenceDetected
+    self.formatStabilized = formatStabilized
+    self.captureRebuiltForFormat = captureRebuiltForFormat
+  }
+}

--- a/Sources/EnviousWisprPipeline/DegradedLeadDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/DegradedLeadDiagnostics.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Degraded-lead trim-candidate computation for the ASR-empty salvage ladder
+/// (#1434). Pure compute, sibling of `TailClipDiagnostics` — no state, no
+/// side effects, consumed at exactly ONE site (the kernel's `.empty` branch,
+/// AFTER a batch decode already returned empty despite speech evidence).
+///
+/// Background: a Bluetooth voice link that is still settling after mic-open
+/// (AirPods A2DP→HFP renegotiation) can deliver 1-2 s of near-silence plus
+/// packet-loss-concealment chirps before recovering. Parakeet's TDT decoder
+/// collapses to an EMPTY transcript for the whole utterance when fed that
+/// poisoned prefix — offline-proven on the founder's archived failures, where
+/// trimming the degraded lead recovered near-complete sentences (#1434).
+///
+/// The detector finds the boundaries of leading "dead" regions and proposes
+/// up to `maxCandidates` ascending trim points; the kernel retries the decode
+/// at each and delivers the first non-empty transcript. All thresholds were
+/// chosen empirically against the six archived failures + three passes of
+/// 2026-07-09 (issue #1434 documents the harness recipe for re-validation).
+enum DegradedLeadDiagnostics {
+
+  /// Analysis window length. 50 ms at 16 kHz = 800 samples.
+  static let windowSeconds = 0.05
+  /// Window hop. 25 ms — 50% overlap.
+  static let hopSeconds = 0.025
+  /// Speech reference = this percentile of window RMS across the buffer.
+  static let referencePercentile = 90.0
+  /// Reference floor: below this the whole buffer is near-silent and salvage
+  /// is pointless (there is nothing to recover).
+  static let minimumReference: Float = 0.005
+  /// A window is "dead" below reference / 16 (−24 dB).
+  static let deadRatio: Float = 1.0 / 16.0
+  /// A dead run must span at least this long to yield a candidate.
+  static let minimumDeadRunSeconds = 0.4
+  /// Strong-onset candidate: first window at ≥ reference/2 sustained this long.
+  static let strongOnsetRatio: Float = 0.5
+  static let strongOnsetSustainSeconds = 0.2
+  /// Pad subtracted from the strong-onset candidate so the onset itself
+  /// survives the trim.
+  static let strongOnsetPadSeconds = 0.1
+  /// Candidates closer than this to an earlier one are dropped (a retry at
+  /// nearly the same point cannot change the decode).
+  static let dedupeSpacingSeconds = 0.3
+  /// A candidate must leave at least this much audio to be worth decoding.
+  static let minimumRemainingSeconds = 0.7
+  /// Ladder bound — also the retry bound in the kernel.
+  static let maxCandidates = 3
+
+  /// Compute ascending trim candidates (in SAMPLES into `samples`) for a
+  /// buffer whose decode returned empty despite speech evidence. Empty result
+  /// means "nothing to salvage" (buffer near-silent, no qualifying dead runs,
+  /// or every candidate leaves too little audio).
+  static func trimCandidates(samples: [Float], sampleRate: Double) -> [Int] {
+    guard sampleRate > 0, !samples.isEmpty else { return [] }
+    let window = max(1, Int(windowSeconds * sampleRate))
+    let hop = max(1, Int(hopSeconds * sampleRate))
+    guard samples.count > window else { return [] }
+
+    // Window RMS profile.
+    var rms: [Float] = []
+    rms.reserveCapacity((samples.count - window) / hop + 1)
+    var start = 0
+    while start + window <= samples.count {
+      var sum: Float = 0
+      for i in start..<(start + window) {
+        sum += samples[i] * samples[i]
+      }
+      rms.append((sum / Float(window)).squareRoot())
+      start += hop
+    }
+    guard !rms.isEmpty else { return [] }
+
+    // Speech reference (p90 of window RMS), with the near-silent-file guard.
+    let sorted = rms.sorted()
+    let refIndex = min(
+      sorted.count - 1, Int((referencePercentile / 100.0) * Double(sorted.count - 1)))
+    let reference = sorted[refIndex]
+    guard reference >= minimumReference else { return [] }
+
+    let deadThreshold = reference * deadRatio
+    let minDeadWindows = max(1, Int(minimumDeadRunSeconds / hopSeconds))
+
+    // Dead runs ≥ minimumDeadRunSeconds → candidate at each run's END.
+    var runs: [(start: Int, end: Int)] = []  // window indices, end exclusive
+    var runStart: Int?
+    for (i, value) in rms.enumerated() {
+      if value < deadThreshold {
+        if runStart == nil { runStart = i }
+      } else if let s = runStart {
+        if i - s >= minDeadWindows { runs.append((s, i)) }
+        runStart = nil
+      }
+    }
+    if let s = runStart, rms.count - s >= minDeadWindows {
+      runs.append((s, rms.count))
+    }
+    guard !runs.isEmpty else { return [] }
+
+    var candidateSamples: [Int] = []
+    func windowIndexToSample(_ index: Int) -> Int { index * hop }
+    candidateSamples.append(windowIndexToSample(runs[0].end))
+    if runs.count > 1 {
+      candidateSamples.append(windowIndexToSample(runs[runs.count - 1].end))
+    }
+
+    // Strong sustained onset after the last dead run, minus a small pad.
+    let sustainWindows = max(1, Int(strongOnsetSustainSeconds / hopSeconds))
+    let strongThreshold = reference * strongOnsetRatio
+    var i = runs[runs.count - 1].end
+    while i + sustainWindows <= rms.count {
+      if rms[i..<(i + sustainWindows)].allSatisfy({ $0 >= strongThreshold }) {
+        let padded = windowIndexToSample(i) - Int(strongOnsetPadSeconds * sampleRate)
+        candidateSamples.append(max(0, padded))
+        break
+      }
+      i += 1
+    }
+
+    // Ascending, deduped, bounded, and each must leave enough audio.
+    let spacing = Int(dedupeSpacingSeconds * sampleRate)
+    let minRemaining = Int(minimumRemainingSeconds * sampleRate)
+    var result: [Int] = []
+    for candidate in candidateSamples.sorted() {
+      guard candidate > 0 else { continue }
+      guard samples.count - candidate >= minRemaining else { continue }
+      if let last = result.last, candidate - last < spacing { continue }
+      result.append(candidate)
+      if result.count == maxCandidates { break }
+    }
+    return result
+  }
+}

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
@@ -23,6 +23,16 @@ struct NoAudioContext: Sendable {
   var inputSelectionMode: String? = nil
   var outputTransport: String? = nil
   var routeResolutionSource: String? = nil
+  // #1434: capture-health facts at the no-audio terminal — populated from the
+  // kernel's post-stop capture-health record (no-audio fires AFTER
+  // `stopCapture()` returned empty, so the record exists).
+  var captureNativeRateHz: Double? = nil
+  var captureRingDropCount: Int? = nil
+  var captureConverterErrorCount: Int? = nil
+  var captureZeroOutputCount: Int? = nil
+  var captureRateDivergenceDetected: Bool? = nil
+  var captureFormatStabilized: Bool? = nil
+  var captureRebuiltForFormat: Bool? = nil
 }
 
 /// Per-call context for `HeartPathTelemetryEmitter.zombieZeroPeakIfNeeded(...)`.

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -193,27 +193,38 @@ final class HeartPathTelemetryEmitter {
       wasStreaming: ctx.wasStreaming,
       route: ctx.route
     )
-    captureError(
-      err,
-      .audioCaptureFailed,
-      "recording",
-      SentryAudioExtras.buildCaptureExtras(
-        route: ctx.route,
-        sourceType: ctx.captureSourceType,
-        sessionID: ctx.sessionID,
-        isActivelyCapturing: ctx.isActivelyCapturing,
-        inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
-        inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
-        failureMode: "no_audio_captured",
-        selectedTransport: ctx.selectedTransport,
-        effectiveTransport: ctx.effectiveTransport,
-        routeReason: ctx.routeReason,
-        routeFallbackReason: ctx.routeFallbackReason,
-        inputSelectionMode: ctx.inputSelectionMode,
-        outputTransport: ctx.outputTransport,
-        routeResolutionSource: ctx.routeResolutionSource
-      )
+    var extras = SentryAudioExtras.buildCaptureExtras(
+      route: ctx.route,
+      sourceType: ctx.captureSourceType,
+      sessionID: ctx.sessionID,
+      isActivelyCapturing: ctx.isActivelyCapturing,
+      inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
+      inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
+      failureMode: "no_audio_captured",
+      selectedTransport: ctx.selectedTransport,
+      effectiveTransport: ctx.effectiveTransport,
+      routeReason: ctx.routeReason,
+      routeFallbackReason: ctx.routeFallbackReason,
+      inputSelectionMode: ctx.inputSelectionMode,
+      outputTransport: ctx.outputTransport,
+      routeResolutionSource: ctx.routeResolutionSource
     )
+    // #1434: post-stop capture-health on the no-audio terminal (absent → keys
+    // omitted, matching the optional-extras pattern).
+    if let rate = ctx.captureNativeRateHz { extras["capture.native_rate_hz"] = rate }
+    if let drops = ctx.captureRingDropCount { extras["capture.ring_drop_count"] = drops }
+    if let errs = ctx.captureConverterErrorCount {
+      extras["capture.converter_error_count"] = errs
+    }
+    if let zeros = ctx.captureZeroOutputCount { extras["capture.zero_output_count"] = zeros }
+    if let div = ctx.captureRateDivergenceDetected {
+      extras["capture.rate_divergence_detected"] = div
+    }
+    if let stab = ctx.captureFormatStabilized { extras["capture.format_stabilized"] = stab }
+    if let rebuilt = ctx.captureRebuiltForFormat {
+      extras["capture.rebuilt_for_format"] = rebuilt
+    }
+    captureError(err, .audioCaptureFailed, "recording", extras)
   }
 
   /// Emit `zombie_engine_zero_peak` when the VAD gate gets a full recording

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -750,6 +750,16 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// the App layer's `dictation.completed` telemetry. LIVE pass-through from the
   /// kernel; never persisted. Low-cardinality transport/reason strings only.
   public var lastResolvedRoute: ResolvedRouteTransports? { kernel.lastResolvedRoute }
+  /// #1434: non-nil when the most recent completion was a degraded-lead
+  /// SALVAGE (the transcript was recovered by trimming a poisoned opening) —
+  /// drives the post-completion disclosure pill and `dictation.completed`
+  /// salvage fields. LIVE pass-through; never persisted; a number, no content.
+  public var lastSalvagedLeadTrimMs: Int? { kernel.lastSalvagedLeadTrimMs }
+  /// #1434: the capture-health record for the most recent recording (native
+  /// rate, drop/error counters, stabilization flags). LIVE pass-through for
+  /// the App layer's `dictation.completed` telemetry; hardware-class facts
+  /// only, no identifiers.
+  public var lastCaptureHealth: CaptureHealthTransports? { kernel.lastCaptureHealth }
 
   // MARK: Caller-facing event + overlay surface
 

--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -135,8 +135,18 @@ final class KernelHeartPathTelemetryObserver {
   /// Capture-stall telemetry. Reached through the driver's
   /// `HeartPathTelemetryTarget` conformance (PR-4 §3.9).
   /// `HeartPathTelemetryEmitter` dedups per session, so a double-call is harmless.
+  ///
+  /// #1434: the stall fires BEFORE `stopCapture()`, so no stop metadata exists
+  /// yet — the SOURCE stamped rate/divergence into the context; the kernel's
+  /// stabilization observations (private telemetry state) are merged here via
+  /// the kernel's own accessor. The observer stays a forwarder otherwise.
   func handleCaptureStall(_ ctx: CaptureStallContext) {
-    emitter.stallFired(ctx: ctx, isActivelyCapturing: audioCapture.isActivelyCapturing)
+    let stabilization = kernel.captureStabilizationTelemetry
+    let enriched = ctx.enrichedWithStabilizationFlags(
+      formatStabilized: stabilization.formatStabilized,
+      captureRebuiltForFormat: stabilization.rebuiltForFormat
+    )
+    emitter.stallFired(ctx: enriched, isActivelyCapturing: audioCapture.isActivelyCapturing)
   }
 
   func handleXPCReplyFailed(_ ctx: XPCReplyFailureContext) {

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -602,6 +602,9 @@ final class KernelLifecycleTelemetrySink {
       let computedDurationMs = sampleCount * 1000 / Int(AudioConstants.sampleRate)
       let preferredID = audioCapture.preferredInputDeviceIDOverride
       let resolvedRoute = audioCapture.currentResolvedRoute
+      // #1434: the capture-health record was stamped before this terminal
+      // (immediately post-stop), so the no-audio event carries it.
+      let health = telemetryState.captureHealth
       let ctx = NoAudioContext(
         sessionID: audioCapture.currentCaptureSessionID,
         durationMs: max(snapshotDurationMs, computedDurationMs),
@@ -617,7 +620,14 @@ final class KernelLifecycleTelemetrySink {
         routeFallbackReason: resolvedRoute?.routeFallbackReason,
         inputSelectionMode: resolvedRoute?.inputSelectionMode,
         outputTransport: resolvedRoute?.outputTransport,
-        routeResolutionSource: resolvedRoute?.routeResolutionSource
+        routeResolutionSource: resolvedRoute?.routeResolutionSource,
+        captureNativeRateHz: health?.stopMetadata?.nativeRateHz,
+        captureRingDropCount: health?.stopMetadata?.ringDropCount,
+        captureConverterErrorCount: health?.stopMetadata?.converterErrorCount,
+        captureZeroOutputCount: health?.stopMetadata?.zeroOutputCount,
+        captureRateDivergenceDetected: health?.stopMetadata?.rateDivergenceDetected,
+        captureFormatStabilized: health?.formatStabilized,
+        captureRebuiltForFormat: health?.captureRebuiltForFormat
       )
       if let noAudioCapturedRich {
         noAudioCapturedRich(ctx)

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -415,6 +415,16 @@ final class KernelLifecycleTelemetrySink {
       if let v = t.asrLastTokenGapMs { payload["asr_last_token_gap_ms"] = v }
       if let v = t.asrChunked { payload["asr_chunked"] = v }
     }
+    // #1434 degraded-lead salvage (omit-on-nil; set only on a salvaged
+    // completion — Codex review r1 caught these being stamped onto
+    // asrCompletedTelemetry but never read here, so a salvaged completion
+    // was indistinguishable from a normal one in this breadcrumb).
+    if let t = telemetryState.asrCompletedTelemetry {
+      if let v = t.salvageAttempted { payload["salvage_attempted"] = v }
+      if let v = t.salvageCandidateCount { payload["salvage_candidate_count"] = v }
+      if let v = t.salvageSucceededAtTrimMs { payload["salvage_succeeded_at_trim_ms"] = v }
+      if let v = t.salvageRemainingAudioMs { payload["salvage_remaining_audio_ms"] = v }
+    }
     return payload
   }
 

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 
 /// Per-session telemetry side-channel for details that do not belong in the
@@ -19,6 +20,11 @@ final class KernelTelemetryState {
   var historySaveFailed = false
   var transcriptionFailureError: (any Error)?
   var modelLoadError: (any Error)?
+  /// #1434: the ONE capture-health record every post-stop consumer reads.
+  /// Stamped immediately after `stopCapture()` returns + the stale-session
+  /// guard passes — BEFORE the too-short / no-audio / dead-air early
+  /// terminals — so no-audio, asrEmpty, and completed all share it.
+  var captureHealth: KernelCaptureHealthTelemetry?
 
   func resetForNewSession(polishEnabled: Bool) {
     self.polishEnabled = polishEnabled
@@ -30,7 +36,23 @@ final class KernelTelemetryState {
     historySaveFailed = false
     transcriptionFailureError = nil
     modelLoadError = nil
+    captureHealth = nil
   }
+}
+
+/// #1434: one capture-health record per session — helper-side facts from
+/// `CaptureResult.metadata` (stop-time) merged with the kernel's own
+/// stabilization observations (start-time). Every telemetry consumer
+/// (`dictation.completed`, asrEmpty Sentry extra, NoAudio context) reads
+/// this single record instead of N side channels.
+struct KernelCaptureHealthTelemetry {
+  /// From `CaptureResult.metadata` (nil when the source didn't produce one —
+  /// stabilization flags below are still valid then).
+  var stopMetadata: CaptureStopMetadata?
+  /// Kernel-side: did `waitForFormatStabilization` return true pre-capture.
+  var formatStabilized: Bool?
+  /// Kernel-side: did the false path trigger the one rebuild+restart.
+  var captureRebuiltForFormat: Bool?
 }
 
 struct KernelRecordingSnapshotTelemetry {
@@ -104,6 +126,12 @@ struct KernelASRCompletedTelemetry {
   var tailDecodeSec: Double? = nil
   var maxUnconfirmedWindowSec: Double? = nil
   var stopWhileDecodeInFlight: Bool? = nil
+  // #1434 degraded-lead salvage (set only on a salvaged completion; nil →
+  // sink omits). `salvageSucceededAtTrimMs` is the winning candidate's trim.
+  var salvageAttempted: Bool? = nil
+  var salvageCandidateCount: Int? = nil
+  var salvageSucceededAtTrimMs: Int? = nil
+  var salvageRemainingAudioMs: Int? = nil
 }
 
 struct KernelASRAdapterDiagnostics {

--- a/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
@@ -36,6 +36,8 @@ public final class PipelineStateChangeHandler {
   private let reportPipelineFailed: @MainActor (String) -> Void
   /// #1167: schedule the transient "Couldn't save to history: <reason>" pill.
   private let scheduleHistorySaveFailedWarning: @MainActor (String) -> Void
+  /// #1434: schedule the transient salvaged-lead disclosure pill.
+  private let scheduleSalvagedLeadWarning: @MainActor () -> Void
 
   public init(
     showOverlay: @escaping ShowOverlay,
@@ -44,7 +46,8 @@ public final class PipelineStateChangeHandler {
     appendCompletedTranscript: @escaping @MainActor (Transcript) -> Void,
     reportDictationCompleted: @escaping @MainActor (Transcript) -> Void,
     reportPipelineFailed: @escaping @MainActor (String) -> Void,
-    scheduleHistorySaveFailedWarning: @escaping @MainActor (String) -> Void
+    scheduleHistorySaveFailedWarning: @escaping @MainActor (String) -> Void,
+    scheduleSalvagedLeadWarning: @escaping @MainActor () -> Void = {}
   ) {
     self.showOverlay = showOverlay
     self.cancelPendingWarning = cancelPendingWarning
@@ -53,6 +56,7 @@ public final class PipelineStateChangeHandler {
     self.reportDictationCompleted = reportDictationCompleted
     self.reportPipelineFailed = reportPipelineFailed
     self.scheduleHistorySaveFailedWarning = scheduleHistorySaveFailedWarning
+    self.scheduleSalvagedLeadWarning = scheduleSalvagedLeadWarning
   }
 
   /// Drive the full state-change behavior contract for one pipeline.
@@ -67,7 +71,8 @@ public final class PipelineStateChangeHandler {
     lastPolishError: String?,
     currentTranscript: Transcript?,
     historySaved: Bool,
-    historySaveReason: String?
+    historySaveReason: String?,
+    salvagedLead: Bool = false
   ) {
     let plan = PipelineStateChangePlanner.plan(
       to: newState,
@@ -78,7 +83,8 @@ public final class PipelineStateChangeHandler {
       lastPolishError: lastPolishError,
       hasCurrentTranscript: currentTranscript != nil,
       historySaved: historySaved,
-      historySaveReason: historySaveReason
+      historySaveReason: historySaveReason,
+      salvagedLead: salvagedLead
     )
     for effect in plan.effects {
       switch effect {
@@ -100,6 +106,8 @@ public final class PipelineStateChangeHandler {
         reportPipelineFailed(msg)
       case .scheduleHistorySaveFailedWarning(let reason):
         scheduleHistorySaveFailedWarning(reason)
+      case .scheduleSalvagedLeadWarning:
+        scheduleSalvagedLeadWarning()
       }
     }
   }

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -43,6 +43,15 @@ enum PipelineStateSideEffect: Equatable, Sendable {
   /// delivery still ran (best-effort save). Reuses the single post-completion
   /// warning slot, so it is mutually exclusive with `schedulePolishFailedWarning`.
   case scheduleHistorySaveFailedWarning(reason: String)
+
+  /// #1434: schedule the transient "Beginning of dictation was unclear and was
+  /// skipped" pill on a SALVAGED completion — the degraded-lead retry recovered
+  /// the transcript by trimming a poisoned prefix, so the pasted text is
+  /// missing its lead, and a trimmed lead can invert meaning invisibly. The
+  /// disclosure never touches the pasted text. Shares the single
+  /// post-completion warning slot: history-save-failed > salvaged-lead >
+  /// polish-failed.
+  case scheduleSalvagedLeadWarning
 }
 
 struct PipelineStateChangePlan: Equatable, Sendable {
@@ -78,7 +87,8 @@ enum PipelineStateChangePlanner {
     lastPolishError: String?,
     hasCurrentTranscript: Bool,
     historySaved: Bool,
-    historySaveReason: String?
+    historySaveReason: String?,
+    salvagedLead: Bool = false
   ) -> PipelineStateChangePlan {
     var effects: [PipelineStateSideEffect] = []
 
@@ -106,11 +116,20 @@ enum PipelineStateChangePlanner {
         // #1167: a history-save failure takes the single post-completion
         // warning slot (its pill is scheduled in Step 2), so suppress the
         // polish-failed pill when both fired this session.
-        if !historySaveFailed, !PolishFailureReason.isSkipNotice(polishError) {
+        // #1434: a salvaged-lead completion also takes the single warning
+        // slot ahead of the polish pill (data-loss disclosure beats a
+        // formatting notice) — scheduled below, outside this branch.
+        if !historySaveFailed, !salvagedLead, !PolishFailureReason.isSkipNotice(polishError) {
           effects.append(.schedulePolishFailedWarning)
         }
       } else {
         resolvedOverlayIntent = pipelineOverlayIntent
+      }
+      // #1434: salvaged-lead disclosure. Priority within the single warning
+      // slot: history-save-failed (scheduled in Step 2) > salvaged-lead >
+      // polish-failed (suppressed above when salvaged).
+      if salvagedLead, !historySaveFailed {
+        effects.append(.scheduleSalvagedLeadWarning)
       }
     default:
       effects.append(.cancelPendingWarning)

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -253,6 +253,22 @@ final class RecordingSessionKernel {
   /// (issue #1174 A3). Reset on session start.
   private(set) var lastAudioInterruptionCause: EngineInterruptionCause?
 
+  /// #1434: per-session stabilization outcome (set at the pre-capture
+  /// stabilization site; nil until it runs). Read by
+  /// `KernelHeartPathTelemetryObserver` at stall-emit time via
+  /// `captureStabilizationTelemetry` and merged into the post-stop
+  /// capture-health record.
+  private var formatStabilizedThisSession: Bool?
+  private var captureRebuiltForFormatThisSession: Bool?
+
+  /// #1434: kernel-owned stabilization facts for telemetry enrichment. The
+  /// stall event fires BEFORE `stopCapture()` (no stop metadata exists yet),
+  /// so the observer reads these through the kernel instead of the private
+  /// `telemetryState`.
+  var captureStabilizationTelemetry: (formatStabilized: Bool?, rebuiltForFormat: Bool?) {
+    (formatStabilizedThisSession, captureRebuiltForFormatThisSession)
+  }
+
   /// `true` if the kernel started this session in streaming mode. Set
   /// immediately BEFORE `adapter.beginSession(..., streaming:)`. The observer
   /// reads this at `.recording` lifecycle mapping time so the
@@ -362,6 +378,13 @@ final class RecordingSessionKernel {
   /// mid-flight device change cannot tear the recorded value. Overwritten each
   /// session; never persisted.
   private(set) var lastResolvedRoute: ResolvedRouteTransports?
+  /// #1434: non-nil when the most recent completion was a degraded-lead
+  /// salvage — the winning trim in ms. Cleared with `lastStopReason` at the
+  /// next `→ recording` transition (the App layer reads it at `.complete`).
+  private(set) var lastSalvagedLeadTrimMs: Int?
+  /// #1434: capture-health facts of the most recent recording, for the App
+  /// layer's `dictation.completed` telemetry (mirrors `lastResolvedRoute`).
+  private(set) var lastCaptureHealth: CaptureHealthTransports?
 
   /// `true` once the polish step returned a non-empty processed transcript —
   /// the kernel-era equivalent of the point at which the old pipeline called
@@ -806,6 +829,13 @@ final class RecordingSessionKernel {
     let stabilized = await audioCapture.waitForFormatStabilization(
       maxWait: 1.5, pollInterval: 0.2)
     guard isCurrent(sid) else { return }
+    // #1434: record the stabilization outcome for the session's capture-health
+    // telemetry (read at stall-emit by the observer and merged into the
+    // post-stop record at `stopCapture()`). Exactly ONE rebuild attempt below,
+    // and no second stabilization check after it — a still-broken device is
+    // owned by the stall watchdog / ASR-empty paths downstream.
+    formatStabilizedThisSession = stabilized
+    captureRebuiltForFormatThisSession = !stabilized
     if !stabilized {
       audioCapture.rebuildEngine()
       do {
@@ -919,6 +949,8 @@ final class RecordingSessionKernel {
     transition(to: .recording)
     recordingStartedAtDate = Date()
     lastStopReason = nil  // #1060: clear prior session's stop reason.
+    lastSalvagedLeadTrimMs = nil  // #1434: clear prior session's salvage marker.
+    lastCaptureHealth = nil  // #1434: clear prior session's capture health.
     lastRecordingDurationSeconds = nil
     // #1376: snapshot the resolved route AFTER all start retries (this
     // transition is downstream of every startEnginePhase/beginCapturePhase
@@ -990,6 +1022,23 @@ final class RecordingSessionKernel {
     captureLifecycle = .stopped
     resourcesReleased = true
     guard !state.isTerminal else { return }
+    // #1434: stamp the ONE capture-health record NOW — before the too-short /
+    // no-audio / dead-air early terminals below — so no-audio, asrEmpty, and
+    // completed all read the same record (Codex r2 ordering contract).
+    telemetryState.captureHealth = KernelCaptureHealthTelemetry(
+      stopMetadata: captureResult.metadata,
+      formatStabilized: formatStabilizedThisSession,
+      captureRebuiltForFormat: captureRebuiltForFormatThisSession
+    )
+    lastCaptureHealth = CaptureHealthTransports(
+      nativeRateHz: captureResult.metadata?.nativeRateHz,
+      ringDropCount: captureResult.metadata?.ringDropCount,
+      converterErrorCount: captureResult.metadata?.converterErrorCount,
+      zeroOutputCount: captureResult.metadata?.zeroOutputCount,
+      rateDivergenceDetected: captureResult.metadata?.rateDivergenceDetected,
+      formatStabilized: formatStabilizedThisSession,
+      captureRebuiltForFormat: captureRebuiltForFormatThisSession
+    )
     recordingStoppedTelemetry(captureResult.samples.count)
     await (vad as? CaptureVADSignalSource)?.finalizeAtStop(
       rawSampleCount: captureResult.samples.count,
@@ -1339,6 +1388,11 @@ final class RecordingSessionKernel {
     #if DEBUG
       var archiveClassification = "notEvaluated"
       var archiveSpeechEvidence = false
+      // #1434: effective archive inputs. Default to the primary decode's
+      // values; the salvage-success path rebinds them so the archive labels
+      // and replays the SALVAGED delivery (Codex r2 rev 3).
+      var archiveEffectiveOutcome = outcome
+      var salvageArchiveFed: [Float]? = nil
     #endif
 
     switch outcome {
@@ -1442,6 +1496,7 @@ final class RecordingSessionKernel {
       await runFinalizing(sid, asrText: result.text, transcriptID: transcriptID)
     case .empty(let hadSpeechEvidence):
       mergeAdapterDiagnosticsIntoASREmpty()
+      stampCaptureHealthIntoASREmptyDiagnostics()
       // #964 R2: if we reached ASR only because raw energy beat the dead-air
       // floor despite zero VAD segments, an empty decode means fan/room noise —
       // not a failed transcription. Route it to the quiet `.noSpeech` terminal,
@@ -1455,37 +1510,83 @@ final class RecordingSessionKernel {
       #if DEBUG
         archiveSpeechEvidence = effectiveSpeechEvidence
       #endif
-      if !effectiveSpeechEvidence {
-        // Stamp BEFORE the transition so the observer reads the source
-        // at `.noSpeech` mapping time (PR-4b.2 §3.6 r7).
-        lastNoSpeechSource = .asrEmptyNoSpeech
-        telemetryState.noSpeechTelemetry = KernelNoSpeechTelemetry(
-          mode: isStreamingSession ? "streaming" : "batch",
-          rawSampleCount: captureResult.samples.count,
-          peakAudioLevel: rawPeakAudioLevel
-        )
-        // GAP 3 app.log parity: no-speech-no-evidence log (TP:911-915).
-        Task {
-          await AppLogger.shared.log(
-            "No speech detected, returning to idle",
-            level: .info, category: "Pipeline"
-          )
-        }
-      } else {
-        // GAP 3 app.log parity: ASR-empty-despite-evidence log (TP:894-898).
-        let segs = vadSegments.count
-        let speechMs = vadSpeechDurationMs
-        let peak = rawPeakAudioLevel
-        Task {
-          await AppLogger.shared.log(
-            "ASR empty despite speech evidence "
-              + "(segments=\(segs), speechMs=\(speechMs), peak=\(peak))",
-            level: .info, category: "Pipeline"
-          )
+      // #1434 degraded-lead salvage ladder. Runs ONLY where today's outcome is
+      // the user-visible asrEmpty failure: real speech evidence (the #964
+      // energy-only path keeps its quiet noSpeech routing), batch mode, and a
+      // conditioned-batch engine (capability gate — WhisperKit's finalize
+      // decodes its own retained buffer, so the trimmed-batchSamples retry
+      // seam doesn't exist there). A Bluetooth link that is settling can
+      // poison the first 1-2 s and collapse the whole TDT decode; retrying
+      // at ascending trim candidates recovers the rest (offline-proven on
+      // the archived failures).
+      var salvageDelivered = false
+      if effectiveSpeechEvidence, !isStreamingSession,
+        adapter.capabilities.decodesConditionedBatchSamples, !asrSamples.isEmpty
+      {
+        if let salvaged = await attemptDegradedLeadSalvage(sid, samples: asrSamples) {
+          guard isCurrent(sid), !state.isTerminal else { return }
+          let trimMs = salvaged.trimSamples * 1000 / Int(AudioConstants.sampleRate)
+          lastSalvagedLeadTrimMs = trimMs
+          var completed = KernelASRCompletedTelemetry(
+            durationSeconds: salvaged.result.processingTime,
+            charCount: salvaged.result.text
+              .trimmingCharacters(in: .whitespacesAndNewlines).count,
+            mode: "batch",
+            language: salvaged.result.language)
+          completed.salvageAttempted = true
+          completed.salvageCandidateCount = salvaged.candidateCount
+          completed.salvageSucceededAtTrimMs = trimMs
+          completed.salvageRemainingAudioMs =
+            (asrSamples.count - salvaged.trimSamples) * 1000 / Int(AudioConstants.sampleRate)
+          telemetryState.asrCompletedTelemetry = completed
+          #if DEBUG
+            // Effective archive inputs (Codex r2 rev 3 / grounded r1 rev 3):
+            // the post-switch archive must label + replay the SALVAGED
+            // delivery, not the primary empty outcome.
+            archiveClassification = "salvagedLeadTrim(trimMs=\(trimMs))"
+            archiveEffectiveOutcome = .transcript(salvaged.result)
+            salvageArchiveFed = Array(asrSamples[salvaged.trimSamples...])
+          #endif
+          await runFinalizing(sid, asrText: salvaged.result.text, transcriptID: transcriptID)
+          salvageDelivered = true
+        } else {
+          // The ladder awaited — a supersede/cancel during it owns the session.
+          guard isCurrent(sid), !state.isTerminal else { return }
         }
       }
-      finishTerminal(
-        effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech, sid: sid)
+      if !salvageDelivered {
+        if !effectiveSpeechEvidence {
+          // Stamp BEFORE the transition so the observer reads the source
+          // at `.noSpeech` mapping time (PR-4b.2 §3.6 r7).
+          lastNoSpeechSource = .asrEmptyNoSpeech
+          telemetryState.noSpeechTelemetry = KernelNoSpeechTelemetry(
+            mode: isStreamingSession ? "streaming" : "batch",
+            rawSampleCount: captureResult.samples.count,
+            peakAudioLevel: rawPeakAudioLevel
+          )
+          // GAP 3 app.log parity: no-speech-no-evidence log (TP:911-915).
+          Task {
+            await AppLogger.shared.log(
+              "No speech detected, returning to idle",
+              level: .info, category: "Pipeline"
+            )
+          }
+        } else {
+          // GAP 3 app.log parity: ASR-empty-despite-evidence log (TP:894-898).
+          let segs = vadSegments.count
+          let speechMs = vadSpeechDurationMs
+          let peak = rawPeakAudioLevel
+          Task {
+            await AppLogger.shared.log(
+              "ASR empty despite speech evidence "
+                + "(segments=\(segs), speechMs=\(speechMs), peak=\(peak))",
+              level: .info, category: "Pipeline"
+            )
+          }
+        }
+        finishTerminal(
+          effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech, sid: sid)
+      }
     case .cancelled:
       finishTerminal(.cancelled, sid: sid)
     case .failed(.wedged):
@@ -1524,7 +1625,12 @@ final class RecordingSessionKernel {
           && (adapter as? ASREngineTelemetryProviding)?
             .lastASRDiagnostics?.batchRescueAttempted == true
         let archiveFed: [Float]
-        if Self.dictationFedUsesBatchBuffer(
+        if let salvageArchiveFed {
+          // #1434: a salvaged delivery decoded the TRIMMED buffer — archive
+          // that, so the #1237 chunk replay is faithful to what the engine
+          // actually transcribed.
+          archiveFed = salvageArchiveFed
+        } else if Self.dictationFedUsesBatchBuffer(
           decodesConditionedBatch: decodesConditionedBatch,
           isStreaming: isStreamingSession,
           cameFromBatchRescue: cameFromBatchRescue)
@@ -1537,14 +1643,17 @@ final class RecordingSessionKernel {
             rawSamples: captureResult.samples,
             minimumSamples: AudioConstants.minimumTranscriptionSamples)
         }
+        // #1434: label from the EFFECTIVE outcome (the salvage path rebinds it
+        // to the retry's `.transcript`), never the primary `.empty`.
         var archiveOutcome = Self.dictationArchiveOutcome(
-          for: outcome, effectiveSpeechEvidence: archiveSpeechEvidence)
+          for: archiveEffectiveOutcome, effectiveSpeechEvidence: archiveSpeechEvidence)
         // A `.transcript` decode whose finalization did NOT reach `.completed`
         // (empty after polish → `.failed(.emptyAfterProcessing)`, or superseded
         // mid-finalize) is not a real completion — relabel so it stays distinct
         // from normal completions in the metadata (Codex r6 P3). `runFinalizing`
         // has already run by here, so `state` holds the terminal verdict.
-        if case .transcript = outcome, !(isCurrent(sid) && state == .completed) {
+        // #1434: applies to salvaged deliveries too via the effective outcome.
+        if case .transcript = archiveEffectiveOutcome, !(isCurrent(sid) && state == .completed) {
           archiveOutcome = .finalizationFailed
         }
         let archiveClass = archiveClassification
@@ -2324,6 +2433,8 @@ final class RecordingSessionKernel {
     isStreamingSession = false
     pasteCount = 0
     forbiddenTransitionRejected = false
+    formatStabilizedThisSession = nil
+    captureRebuiltForFormatThisSession = nil
   }
 
   /// Derive decode options from the frozen session config's language mode
@@ -2402,6 +2513,87 @@ final class RecordingSessionKernel {
     // method so a future field addition can't silently skip the copy again.
     diagnostics.absorbAdapterDiagnostics(adapterDiagnostics)
     telemetryState.asrEmptyDiagnostics = diagnostics
+  }
+
+  /// #1434: copy the session's capture-health record into the ASR-empty
+  /// diagnostics so the Sentry extra carries rate/counters/stabilization on
+  /// exactly the failure class this bug manifests as.
+  private func stampCaptureHealthIntoASREmptyDiagnostics() {
+    guard var diagnostics = telemetryState.asrEmptyDiagnostics,
+      let health = telemetryState.captureHealth
+    else { return }
+    diagnostics.captureNativeRateHz = health.stopMetadata?.nativeRateHz
+    diagnostics.captureRingDropCount = health.stopMetadata?.ringDropCount
+    diagnostics.captureConverterErrorCount = health.stopMetadata?.converterErrorCount
+    diagnostics.captureZeroOutputCount = health.stopMetadata?.zeroOutputCount
+    diagnostics.captureRateDivergenceDetected = health.stopMetadata?.rateDivergenceDetected
+    diagnostics.captureFormatStabilized = health.formatStabilized
+    diagnostics.captureRebuiltForFormat = health.captureRebuiltForFormat
+    telemetryState.asrEmptyDiagnostics = diagnostics
+  }
+
+  /// #1434: the degraded-lead salvage ladder. Retries the batch decode at up
+  /// to `DegradedLeadDiagnostics.maxCandidates` ascending trim points through
+  /// the kernel's own `finalize` wrapper (wedge detection + stale-session
+  /// guard re-arm per call; `ParakeetEngineAdapter.finalizeBatch` is stateless
+  /// per call with explicit samples). Returns the first non-empty transcript,
+  /// or nil (all candidates empty, no candidates, aborted). Failure-side
+  /// telemetry is stamped here so the fleet sees misses, not only wins.
+  private struct DegradedLeadSalvageSuccess {
+    let result: ASRResult
+    let trimSamples: Int
+    let candidateCount: Int
+  }
+
+  private func attemptDegradedLeadSalvage(
+    _ sid: SessionID, samples: [Float]
+  ) async -> DegradedLeadSalvageSuccess? {
+    let candidates = DegradedLeadDiagnostics.trimCandidates(
+      samples: samples, sampleRate: AudioConstants.sampleRate)
+    let candidatesMs = candidates.map { $0 * 1000 / Int(AudioConstants.sampleRate) }
+    telemetryState.asrEmptyDiagnostics?.salvageAttempted = true
+    telemetryState.asrEmptyDiagnostics?.salvageCandidateCount = candidates.count
+    telemetryState.asrEmptyDiagnostics?.salvageCandidateTrimsMs = candidatesMs
+    guard !candidates.isEmpty else {
+      log("ASR empty salvage: no candidates (lead not degraded or too little audio)")
+      return nil
+    }
+    log("ASR empty salvage: candidates(ms)=\(candidatesMs)")
+    for (index, trim) in candidates.enumerated() {
+      // Re-guard before EACH dispatch — a PTT-cancel/new session mid-ladder
+      // abandons it (the in-flight decode, if any, is dropped by the finalize
+      // wrapper's own stale guard).
+      guard isCurrent(sid), !state.isTerminal else {
+        telemetryState.asrEmptyDiagnostics?.salvageAbortedReason = "superseded"
+        return nil
+      }
+      let retry = await finalize(sid, batchSamples: Array(samples[trim...]))
+      guard isCurrent(sid), !state.isTerminal else {
+        telemetryState.asrEmptyDiagnostics?.salvageAbortedReason = "superseded"
+        return nil
+      }
+      switch retry {
+      case .transcript(let result):
+        log(
+          "ASR empty salvage succeeded: trimMs=\(trim * 1000 / Int(AudioConstants.sampleRate)) "
+            + "candidate=\(index + 1)/\(candidates.count) chars=\(result.text.count)")
+        return DegradedLeadSalvageSuccess(
+          result: result, trimSamples: trim, candidateCount: candidates.count)
+      case .empty:
+        continue
+      case .cancelled:
+        telemetryState.asrEmptyDiagnostics?.salvageAbortedReason = "superseded"
+        return nil
+      case .failed:
+        // The retry path must not upgrade the terminal (the primary decode
+        // already classified this session as empty), but a retry-path
+        // regression must not hide either — record the abort reason.
+        telemetryState.asrEmptyDiagnostics?.salvageAbortedReason = "retry_failed"
+        return nil
+      }
+    }
+    log("ASR empty salvage: all \(candidates.count) candidates decoded empty")
+    return nil
   }
 
   private func peakAudioLevel(in samples: [Float]) -> Float {

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1523,7 +1523,16 @@ final class RecordingSessionKernel {
       if effectiveSpeechEvidence, !isStreamingSession,
         adapter.capabilities.decodesConditionedBatchSamples, !asrSamples.isEmpty
       {
-        if let salvaged = await attemptDegradedLeadSalvage(sid, samples: asrSamples) {
+        let salvageAttemptResult = await attemptDegradedLeadSalvage(sid, samples: asrSamples)
+        // #1434 cloud review: the ladder's retry decode(s) run AFTER the
+        // line-1376 markASRTimingEnd() call for the (empty) primary decode,
+        // so a salvaged completion needs its own, later stamp — otherwise
+        // pipeline.completed's asr_s and the timing logs record only the
+        // primary decode's time, making the retry work invisible in
+        // latency telemetry for exactly the recoveries this path exists
+        // for. Idempotent: outcome.asrEndedAtSeconds is a plain overwrite.
+        markASRTimingEnd()
+        if let salvaged = salvageAttemptResult {
           guard isCurrent(sid), !state.isTerminal else { return }
           let trimMs = salvaged.trimSamples * 1000 / Int(AudioConstants.sampleRate)
           lastSalvagedLeadTrimMs = trimMs

--- a/Sources/EnviousWisprServices/SentryAudioExtras.swift
+++ b/Sources/EnviousWisprServices/SentryAudioExtras.swift
@@ -59,6 +59,18 @@ public enum SentryAudioExtras {
       extras["capture.engine_started_successfully"] = ctx.engineStartedSuccessfully
       extras["capture.tap_installed"] = ctx.tapInstalled
       extras["capture.format_mismatch"] = ctx.formatMismatchObserved
+      // #1434 capture-health at stall time. Source-stamped rate/divergence
+      // (nil on proxy-origin stalls — the host watchdog can't read helper
+      // state pre-stop); kernel-merged stabilization flags. Never counters
+      // (those exist only post-stop).
+      if let rate = ctx.nativeRateHz { extras["capture.native_rate_hz"] = rate }
+      if let div = ctx.rateDivergenceDetected {
+        extras["capture.rate_divergence_detected"] = div
+      }
+      if let stab = ctx.formatStabilized { extras["capture.format_stabilized"] = stab }
+      if let rebuilt = ctx.captureRebuiltForFormat {
+        extras["capture.rebuilt_for_format"] = rebuilt
+      }
     }
 
     if let swap = polishModelSwapMs {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -71,7 +71,13 @@ public final class TelemetryService {
     selectedTransport: String? = nil, effectiveTransport: String? = nil,
     routeReason: String? = nil, routeFallbackReason: String? = nil,
     inputSelectionMode: String? = nil, outputTransport: String? = nil,
-    routeResolutionSource: String? = nil
+    routeResolutionSource: String? = nil,
+    // #1434: capture-health facts + degraded-lead salvage marker. Hardware-
+    // class numbers and flags only (telemetry-privacy-boundary).
+    captureNativeRateHz: Double? = nil, captureRingDropCount: Int? = nil,
+    captureConverterErrorCount: Int? = nil, captureZeroOutputCount: Int? = nil,
+    captureRateDivergenceDetected: Bool? = nil, captureFormatStabilized: Bool? = nil,
+    captureRebuiltForFormat: Bool? = nil, salvagedLeadTrimMs: Int? = nil
   ) {
     #if DEBUG
       var hookStringProps: [String: String] = [
@@ -124,7 +130,15 @@ public final class TelemetryService {
       routeFallbackReason: routeFallbackReason,
       inputSelectionMode: inputSelectionMode,
       outputTransport: outputTransport,
-      routeResolutionSource: routeResolutionSource
+      routeResolutionSource: routeResolutionSource,
+      captureNativeRateHz: captureNativeRateHz,
+      captureRingDropCount: captureRingDropCount,
+      captureConverterErrorCount: captureConverterErrorCount,
+      captureZeroOutputCount: captureZeroOutputCount,
+      captureRateDivergenceDetected: captureRateDivergenceDetected,
+      captureFormatStabilized: captureFormatStabilized,
+      captureRebuiltForFormat: captureRebuiltForFormat,
+      salvagedLeadTrimMs: salvagedLeadTrimMs
     )
     if let e2e = m?.e2eSeconds {
       metricPipelineE2E(
@@ -440,7 +454,12 @@ public final class TelemetryService {
     selectedTransport: String? = nil, effectiveTransport: String? = nil,
     routeReason: String? = nil, routeFallbackReason: String? = nil,
     inputSelectionMode: String? = nil, outputTransport: String? = nil,
-    routeResolutionSource: String? = nil
+    routeResolutionSource: String? = nil,
+    // #1434: capture-health + salvage (absent -> keys omitted).
+    captureNativeRateHz: Double? = nil, captureRingDropCount: Int? = nil,
+    captureConverterErrorCount: Int? = nil, captureZeroOutputCount: Int? = nil,
+    captureRateDivergenceDetected: Bool? = nil, captureFormatStabilized: Bool? = nil,
+    captureRebuiltForFormat: Bool? = nil, salvagedLeadTrimMs: Int? = nil
   ) {
     var props: [String: Any] = [
       "result": result,
@@ -454,6 +473,16 @@ public final class TelemetryService {
     // + why the recording stopped. Metadata only (telemetry-privacy-boundary).
     if let rec = recordingSeconds { props["recording_seconds"] = String(format: "%.3f", rec) }
     if let sr = stopReason { props["stop_reason"] = sr }
+    // #1434: capture-health facts + salvage marker (fleet visibility across
+    // Bluetooth device models; counters omitted when zero at the call site).
+    if let rate = captureNativeRateHz { props["capture_native_rate_hz"] = Int(rate) }
+    if let drops = captureRingDropCount { props["capture_ring_drop_count"] = drops }
+    if let errs = captureConverterErrorCount { props["capture_converter_error_count"] = errs }
+    if let zeros = captureZeroOutputCount { props["capture_zero_output_count"] = zeros }
+    if let div = captureRateDivergenceDetected { props["capture_rate_divergence_detected"] = div }
+    if let stab = captureFormatStabilized { props["capture_format_stabilized"] = stab }
+    if let rebuilt = captureRebuiltForFormat { props["capture_rebuilt_for_format"] = rebuilt }
+    if let trim = salvagedLeadTrimMs { props["salvaged_lead_trim_ms"] = trim }
     if let p = llmProvider { props["llm_provider"] = p }
     if let a = targetApp { props["target_app"] = a }
     if let pr = pasteResult { props["paste_result"] = pr }

--- a/Tests/EnviousWisprTests/Audio/CaptureBakeoffControlPlaneTests.swift
+++ b/Tests/EnviousWisprTests/Audio/CaptureBakeoffControlPlaneTests.swift
@@ -4,8 +4,11 @@ import Testing
 @testable import EnviousWisprAudio
 
 // #1377 slice 2a — locks the capture-backend bake-off control plane: the DEBUG
-// runtime policy override, the force-policy → sourceType mapping, the dormancy
-// invariant (the `.automatic` route never emits a non-shipping backend), and the
+// runtime policy override, the force-policy → sourceType mapping, the
+// no-BT-output vs BT-output-active `.automatic` routing split (`.halDeviceInput`
+// was dormant under `.automatic` at slice 2a; #1427 made it the live BT-output
+// route — see the two `automaticNeverEmitsDormantCaseWithoutBTOutput` /
+// `automaticRoutesToHALWithBTOutput` tests below, #1434), and the
 // additive device-target default (nil = built-in, byte-identical to today).
 //
 // Behavioral capture correctness (which device actually binds, non-silent audio,
@@ -96,19 +99,40 @@ struct CaptureRouteResolverForceMappingTests {
     #expect(d.reason == .forcedHALDeviceInput)
   }
 
-  // Dormancy lock: whatever the test machine's audio hardware, the `.automatic`
-  // route only ever yields a SHIPPING capture backend. `.halDeviceInput`
-  // (slice 2b, reinstated 2026-07-08) is dormant — this assertion stays the
-  // two shipping cases, so it guards that the automatic route never emits a
-  // dormant candidate (the §4 invariant) — hardware-independent because it
-  // asserts membership, not a specific device-derived result.
-  @Test("automatic route only ever emits a shipping backend (dormancy)")
-  func automaticNeverEmitsDormantCase() {
+  // Non-Bluetooth invariant: with no Bluetooth OUTPUT device active, the
+  // `.automatic` route always yields a SHIPPING capture backend, never
+  // `.halDeviceInput`. Hardware-independent via injected closures — #1434
+  // found this test previously read the REAL system default output device
+  // with no override, so it silently depended on the test machine having no
+  // Bluetooth output connected at run time (false whenever a real BT
+  // headset, e.g. AirPods or Bose, is the current system default output).
+  @Test("automatic route with no BT output only ever emits a shipping backend")
+  func automaticNeverEmitsDormantCaseWithoutBTOutput() {
     var resolver = CaptureRouteResolver()  // .automatic by default
+    resolver.defaultOutputDeviceID = { nil }
+    resolver.isBluetoothOutputDevice = { _ in false }
     for pref in ["", "some-device-uid"] {
       let d = resolver.resolve(preferredInputDeviceUID: pref, noiseSuppression: false)
       #expect(d.sourceType == .audioEngine || d.sourceType == .captureSession)
       #expect(d.sourceType != .halDeviceInput)
+    }
+  }
+
+  // Companion case (#1434): with a Bluetooth OUTPUT device active, `.automatic`
+  // is INTENDED to route through `.halDeviceInput` — this is the live,
+  // already-shipped behavior (#1427 "Honor system default input for auto
+  // capture") that #1434's degraded-lead salvage work depends on actually
+  // firing. `resolveAutomatic` in CaptureRouteResolver.swift routes
+  // unconditionally to `.halDeviceInput` once `isBluetoothOutputDevice`
+  // reports true — `.halDeviceInput` is not dormant under real Bluetooth.
+  @Test("automatic route with BT output active routes through HAL device input")
+  func automaticRoutesToHALWithBTOutput() {
+    var resolver = CaptureRouteResolver()  // .automatic by default
+    resolver.defaultOutputDeviceID = { 99 }
+    resolver.isBluetoothOutputDevice = { _ in true }
+    for pref in ["", "some-device-uid"] {
+      let d = resolver.resolve(preferredInputDeviceUID: pref, noiseSuppression: false)
+      #expect(d.sourceType == .halDeviceInput)
     }
   }
 }

--- a/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
+++ b/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
@@ -1,0 +1,119 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// MARK: - #1434 HAL format stabilization (pure settle loop)
+//
+// `HALDeviceInputSource.settleNativeRate` is the separated core of the real
+// `waitForFormatStabilization` (which replaced a stub asserting the claim
+// Apple QA1777 refutes). Tests inject a scripted rate reader + no-op sleep so
+// assertions gate on returned values, never the wall clock (`test-timing`).
+
+@MainActor
+@Suite("HALDeviceInputSource — format stabilization settle loop (#1434)")
+struct HALFormatStabilizationTests {
+
+  /// Scripted reader: returns `readings[n]` for the n-th call, repeating the
+  /// last value once the script is exhausted.
+  private func reader(_ readings: [Double?]) -> () -> Double? {
+    var index = 0
+    return {
+      defer { index += 1 }
+      return index < readings.count ? readings[index] : readings.last ?? nil
+    }
+  }
+
+  private func settle(
+    prepared: Double, readings: [Double?],
+    maxWait: TimeInterval = 1.5, pollInterval: TimeInterval = 0.2
+  ) async -> HALDeviceInputSource.RateSettleOutcome {
+    await HALDeviceInputSource.settleNativeRate(
+      preparedRate: prepared, maxWait: maxWait, pollInterval: pollInterval,
+      readRate: reader(readings), sleep: { _ in })
+  }
+
+  @Test("stable rate matching the prepared rate settles true on the fast path")
+  func stableMatchFastPath() async {
+    let outcome = await settle(prepared: 24000, readings: [24000, 24000])
+    #expect(outcome.matchesPrepared)
+    #expect(outcome.settledRate == 24000)
+    #expect(outcome.polls == 0)
+  }
+
+  @Test("transient wrong read then settle (Apple forum 770232 shape) returns true")
+  func transientWrongReadThenSettle() async {
+    // First read 48000, correcting to 24000 — the documented AirPods pattern.
+    let outcome = await settle(prepared: 24000, readings: [48000, 24000, 24000])
+    #expect(outcome.matchesPrepared)
+    #expect(outcome.settledRate == 24000)
+    #expect(outcome.polls >= 1)
+  }
+
+  @Test("settled-but-DIVERGENT rate returns false — routes into the rebuild seam")
+  func settledDivergentIsFalse() async {
+    let outcome = await settle(prepared: 24000, readings: [16000, 16000])
+    #expect(!outcome.matchesPrepared)
+    #expect(outcome.settledRate == 16000)
+  }
+
+  @Test("never-settling rate exhausts the poll budget and returns false")
+  func neverSettlesIsFalse() async {
+    // Alternating reads never agree twice in a row.
+    var flip = false
+    let outcome = await HALDeviceInputSource.settleNativeRate(
+      preparedRate: 24000, maxWait: 1.5, pollInterval: 0.2,
+      readRate: {
+        flip.toggle()
+        return flip ? 24000 : 16000
+      },
+      sleep: { _ in })
+    #expect(!outcome.matchesPrepared)
+    #expect(outcome.settledRate == nil)
+    // Poll budget = maxWait / pollInterval — bounded, not wall-clock.
+    #expect(outcome.polls == 7)
+  }
+
+  @Test("nil reads (property query failing) never count as settled")
+  func nilReadsNeverSettle() async {
+    let outcome = await settle(prepared: 24000, readings: [nil, nil, nil])
+    #expect(!outcome.matchesPrepared)
+    #expect(outcome.settledRate == nil)
+  }
+
+  @Test("instance wrapper with no bound device returns true (nothing to stabilize)")
+  func unpreparedInstanceReturnsTrue() async {
+    let source = HALDeviceInputSource()
+    let stabilized = await source.waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
+    #expect(stabilized)
+  }
+}
+
+// MARK: - #1434 CaptureStopMetadata transport round-trip
+
+@Suite("CaptureStopMetadata — XPC transport round-trip (#1434)")
+struct CaptureStopMetadataTransportTests {
+
+  @Test("encodes and decodes losslessly (the XPC stop-reply blob)")
+  func codableRoundTrip() throws {
+    let original = CaptureStopMetadata(
+      nativeRateHz: 24000, ringDropCount: 3, converterErrorCount: 1,
+      zeroOutputCount: 2, rateDivergenceDetected: true)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(CaptureStopMetadata.self, from: data)
+    #expect(decoded == original)
+  }
+
+  @Test("nil rate survives the round trip; CaptureResult defaults keep metadata nil")
+  func nilRateAndDefaults() throws {
+    let original = CaptureStopMetadata(nativeRateHz: nil)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(CaptureStopMetadata.self, from: data)
+    #expect(decoded == original)
+    #expect(decoded.nativeRateHz == nil)
+    // Every pre-#1434 constructor compiles unchanged and yields nil metadata.
+    #expect(CaptureResult(samples: []).metadata == nil)
+    #expect(CaptureResult(samples: [], vadSegments: []).metadata == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/DegradedLeadDiagnosticsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DegradedLeadDiagnosticsTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - #1434 degraded-lead trim-candidate detector
+//
+// Pure-compute tests over synthetic 16 kHz buffers shaped like the measured
+// failure signature (healthy burst → near-zero window with faint residue →
+// recovery). Thresholds under test are the empirically chosen constants in
+// `DegradedLeadDiagnostics`; the real-audio validation lives in the issue's
+// offline replay recipe (founder-voice corpus stays local, never committed).
+
+@Suite("DegradedLeadDiagnostics — #1434")
+struct DegradedLeadDiagnosticsTests {
+
+  private let rate = 16000.0
+
+  /// Constant-amplitude segment helper.
+  private func seg(_ seconds: Double, _ amplitude: Float) -> [Float] {
+    [Float](repeating: amplitude, count: Int(seconds * rate))
+  }
+
+  /// The measured failure shape: leading silence, one healthy burst, a long
+  /// near-dead window (−24 dB+ below speech), then recovered speech.
+  private func failureShapedBuffer(deadSeconds: Double) -> [Float] {
+    seg(0.3, 0.001) + seg(0.2, 0.3) + seg(deadSeconds, 0.002) + seg(2.0, 0.25)
+  }
+
+  @Test("failure-shaped buffer yields ascending candidates inside the dead region's wake")
+  func failureShapeYieldsCandidates() {
+    let samples = failureShapedBuffer(deadSeconds: 1.2)
+    let candidates = DegradedLeadDiagnostics.trimCandidates(samples: samples, sampleRate: rate)
+    #expect(!candidates.isEmpty)
+    #expect(candidates == candidates.sorted())
+    #expect(candidates.count <= DegradedLeadDiagnostics.maxCandidates)
+    // Every candidate must leave ≥ the minimum decodable remainder.
+    for c in candidates {
+      #expect(samples.count - c >= Int(DegradedLeadDiagnostics.minimumRemainingSeconds * rate))
+      #expect(c > 0)
+    }
+    // The earliest candidate lands within the dead region or its immediate
+    // wake — never inside the trailing recovered speech's back half.
+    let speechStart = samples.count - Int(1.0 * rate)
+    #expect(candidates[0] < speechStart)
+  }
+
+  @Test("dead-run boundary: a run just below the minimum yields nothing, just above yields")
+  func deadRunBoundary() {
+    // 0.35 s dead run < 0.4 s minimum → no candidate from it.
+    let below = seg(0.5, 0.3) + seg(0.35, 0.002) + seg(1.5, 0.25)
+    #expect(DegradedLeadDiagnostics.trimCandidates(samples: below, sampleRate: rate).isEmpty)
+    // 0.5 s dead run ≥ 0.4 s minimum → candidates appear.
+    let above = seg(0.5, 0.3) + seg(0.5, 0.002) + seg(1.5, 0.25)
+    #expect(!DegradedLeadDiagnostics.trimCandidates(samples: above, sampleRate: rate).isEmpty)
+  }
+
+  @Test("near-silent buffer (reference below floor) yields nothing — salvage is pointless")
+  func nearSilentBufferGuard() {
+    let samples = seg(4.0, 0.002)
+    #expect(DegradedLeadDiagnostics.trimCandidates(samples: samples, sampleRate: rate).isEmpty)
+  }
+
+  @Test("continuously loud buffer yields nothing — no dead run to trim")
+  func allLoudBuffer() {
+    let samples = seg(4.0, 0.25)
+    #expect(DegradedLeadDiagnostics.trimCandidates(samples: samples, sampleRate: rate).isEmpty)
+  }
+
+  @Test("candidate leaving too little audio is dropped")
+  func minimumRemainingGuard() {
+    // Dead run ends 0.5 s before the buffer's end — below the 0.7 s minimum
+    // remainder, so the only would-be candidates are dropped.
+    let samples = seg(0.5, 0.3) + seg(1.0, 0.002) + seg(0.5, 0.25)
+    #expect(DegradedLeadDiagnostics.trimCandidates(samples: samples, sampleRate: rate).isEmpty)
+  }
+
+  @Test("adversarial: a legit mid-dictation pause between loud speech DOES yield candidates")
+  func legitPauseYieldsCandidates() {
+    // matcher-set-adversarial-tests: the non-intended semantic class (a real
+    // pause in healthy dictation) also matches the detector. That is BY
+    // DESIGN — candidates are only ever consumed AFTER the decode already
+    // returned empty (the kernel gate), so the assertion here locks the
+    // detector's behavior, and KernelSalvageRetryTests locks the
+    // only-consumed-post-empty contract.
+    let samples = seg(1.5, 0.25) + seg(1.0, 0.002) + seg(1.5, 0.25)
+    let candidates = DegradedLeadDiagnostics.trimCandidates(samples: samples, sampleRate: rate)
+    #expect(!candidates.isEmpty)
+  }
+
+  @Test(
+    "adversarial lead shapes: soft ramp / quiet first word / noisy floor never trim into sustained voice"
+  )
+  func adversarialLeadShapes() {
+    // Soft-start ramp: rises from quiet to loud with no ≥0.4 s dead run at
+    // −24 dB below p90 — no candidates.
+    var ramp: [Float] = []
+    for i in 0..<Int(2.0 * rate) {
+      ramp.append(0.02 + 0.23 * Float(i) / Float(Int(2.0 * rate)))
+    }
+    #expect(DegradedLeadDiagnostics.trimCandidates(samples: ramp, sampleRate: rate).isEmpty)
+
+    // Quiet first word then loud: the quiet word (−12 dB, above the −24 dB
+    // dead line) must NOT count as dead.
+    let quietFirstWord = seg(0.6, 0.06) + seg(2.4, 0.25)
+    #expect(
+      DegradedLeadDiagnostics.trimCandidates(samples: quietFirstWord, sampleRate: rate).isEmpty)
+
+    // High noise floor with weak speech: floor at half the speech level —
+    // nothing is −24 dB below reference, so nothing trims.
+    let noisy = seg(1.0, 0.1) + seg(2.0, 0.2)
+    #expect(DegradedLeadDiagnostics.trimCandidates(samples: noisy, sampleRate: rate).isEmpty)
+  }
+
+  @Test("candidates are deduped at the minimum spacing and capped")
+  func dedupeAndCap() {
+    // Multiple dead runs → multiple candidate sources; the result must stay
+    // ascending, spaced ≥ dedupeSpacingSeconds, and ≤ maxCandidates.
+    let samples =
+      seg(0.3, 0.3) + seg(0.5, 0.002) + seg(0.4, 0.3) + seg(0.6, 0.002) + seg(2.0, 0.25)
+    let candidates = DegradedLeadDiagnostics.trimCandidates(samples: samples, sampleRate: rate)
+    #expect(candidates.count <= DegradedLeadDiagnostics.maxCandidates)
+    let spacing = Int(DegradedLeadDiagnostics.dedupeSpacingSeconds * rate)
+    for pair in zip(candidates, candidates.dropFirst()) {
+      #expect(pair.1 - pair.0 >= spacing)
+    }
+  }
+
+  @Test("empty and degenerate inputs yield nothing")
+  func degenerateInputs() {
+    #expect(DegradedLeadDiagnostics.trimCandidates(samples: [], sampleRate: rate).isEmpty)
+    #expect(
+      DegradedLeadDiagnostics.trimCandidates(samples: seg(0.01, 0.3), sampleRate: rate).isEmpty)
+    #expect(
+      DegradedLeadDiagnostics.trimCandidates(samples: seg(1.0, 0.3), sampleRate: 0).isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelSalvageRetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelSalvageRetryTests.swift
@@ -1,0 +1,185 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - #1434 degraded-lead salvage ladder (kernel routing)
+//
+// Drives the REAL `RecordingSessionKernel` through the simulator fakes with a
+// buffer shaped like the measured AirPods failure (burst → near-dead window →
+// recovered speech). `FakeEngine.emptyThenScripted` scripts the primary decode
+// empty and the retry outcome; assertions cover delivery, terminal choice,
+// retry bounds, telemetry stamping, and the only-consumed-post-empty contract.
+
+@MainActor
+@Suite("RecordingSessionKernel — degraded-lead salvage (#1434)")
+struct KernelSalvageRetryTests {
+
+  private struct Context {
+    let wrapper: KernelRecordingSession
+    let engine: FakeEngine
+    let capture: FakeAudioCapture
+    let vad: FakeVADSignalSource
+    let paste: FakePasteTarget
+  }
+
+  private func makeContext(behavior: FakeEngineBehavior) -> Context {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: behavior, clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    return Context(wrapper: wrapper, engine: engine, capture: capture, vad: vad, paste: paste)
+  }
+
+  /// Deliver the measured failure shape: 0.5 s healthy speech, 1.0 s near-dead
+  /// window (well below −24 dB of the speech level), 1.5 s recovered speech.
+  /// One VAD segment covers the whole take so the conditioner passes the raw
+  /// buffer through and `asrSamples` keeps the dead-run geometry.
+  private func deliverFailureShapedCapture(_ ctx: Context) {
+    ctx.capture.deliverBuffer(frameCount: 8000, amplitude: 0.3)
+    ctx.capture.deliverBuffer(frameCount: 16000, amplitude: 0.002)
+    ctx.capture.deliverBuffer(frameCount: 24000, amplitude: 0.25)
+    ctx.vad.evidence = .voiced
+    ctx.vad.segments = [SpeechSegment(startSample: 0, endSample: 48000)]
+  }
+
+  private func runToTerminal(_ ctx: Context) async {
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    deliverFailureShapedCapture(ctx)
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+  }
+
+  @Test("empty primary decode + non-empty retry → salvaged completion delivers the retry text")
+  func salvageSucceedsAndDelivers() async throws {
+    let ctx = makeContext(behavior: .emptyThenScripted(text: "salvaged text", emptyCalls: 1))
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.state == .completed)
+    #expect(kernel.deliveredTranscript == "salvaged text")
+    #expect(kernel.pasteCount == 1)
+    // Exactly one retry fired (one candidate from this shape): primary + 1.
+    #expect(ctx.engine.finalizeCallCount == 2)
+    // The retry received a TRIMMED buffer — strictly smaller than the
+    // conditioned capture, still larger than the recovered-speech region
+    // alone (the trim lands at the dead run's wake, not inside speech).
+    let retrySamples = try #require(ctx.engine.lastFinalizeBatchSamples)
+    #expect(retrySamples.count < 48000)
+    #expect(retrySamples.count >= 24000)
+    // The salvage marker the App layer reads for the disclosure pill +
+    // telemetry is set and plausible (trim inside the dead window's span).
+    let trimMs = try #require(kernel.lastSalvagedLeadTrimMs)
+    #expect((500...1600).contains(trimMs))
+  }
+
+  @Test("all retries empty → today's asrEmpty terminal, ladder bounded by the candidate count")
+  func allRetriesEmptyFallsThrough() async {
+    let ctx = makeContext(behavior: .emptyThenScripted(text: "never", emptyCalls: 99))
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.state == .failed(.asrEmpty))
+    #expect(kernel.deliveredTranscript == nil)
+    #expect(kernel.pasteCount == 0)
+    #expect(kernel.lastSalvagedLeadTrimMs == nil)
+    // Bounded: primary + ≤ maxCandidates retries, and ≥ one retry ran.
+    #expect(ctx.engine.finalizeCallCount >= 2)
+    #expect(ctx.engine.finalizeCallCount <= 1 + DegradedLeadDiagnostics.maxCandidates)
+  }
+
+  @Test("retry returning .failed aborts the ladder without upgrading the terminal")
+  func retryFailureAbortsToASREmpty() async {
+    let ctx = makeContext(
+      behavior: .emptyThenScripted(text: "never", emptyCalls: 1, thenFailure: true))
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    // The primary decode classified the session as empty; a retry-path error
+    // must not surface as `.asrFailed`.
+    #expect(kernel.state == .failed(.asrEmpty))
+    #expect(ctx.engine.finalizeCallCount == 2)
+    #expect(kernel.lastSalvagedLeadTrimMs == nil)
+  }
+
+  @Test("no candidates (healthy-shaped capture) → no retry, terminal unchanged from A11")
+  func noCandidatesMeansNoRetry() async {
+    let ctx = makeContext(behavior: .emptyThenScripted(text: "never", emptyCalls: 99))
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    // Continuously loud capture — no dead run, detector yields nothing.
+    ctx.capture.deliverBuffer(frameCount: 48000, amplitude: 0.25)
+    ctx.vad.evidence = .voiced
+    ctx.vad.segments = [SpeechSegment(startSample: 0, endSample: 48000)]
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.state == .failed(.asrEmpty))
+    // Exactly the primary decode — the ladder never dispatched.
+    #expect(ctx.engine.finalizeCallCount == 1)
+  }
+
+  @Test("successful decode never consults the detector — happy path untouched")
+  func happyPathNeverRetries() async {
+    // The failure-shaped capture WOULD produce candidates; a successful decode
+    // must never use them (only-consumed-post-empty contract, the pair to the
+    // detector's adversarial legit-pause test).
+    let ctx = makeContext(behavior: .batchSuccess(text: "normal text"))
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.state == .completed)
+    #expect(kernel.deliveredTranscript == "normal text")
+    #expect(ctx.engine.finalizeCallCount == 1)
+    #expect(kernel.lastSalvagedLeadTrimMs == nil)
+  }
+
+  @Test("energy-only no-segments path keeps its quiet noSpeech routing (#964) — no salvage")
+  func energyOnlyPathExcluded() async {
+    let ctx = makeContext(behavior: .emptyThenScripted(text: "never", emptyCalls: 99))
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    // Audible energy but ZERO VAD segments → the kernel reaches ASR on the
+    // energy path; an empty decode must stay `.noSpeech` and must not retry.
+    deliverFailureShapedCapture(ctx)
+    ctx.vad.evidence = .confirmedNoSpeech
+    ctx.vad.segments = []
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.state == .noSpeech)
+    #expect(ctx.engine.finalizeCallCount == 1)
+    #expect(kernel.lastSalvagedLeadTrimMs == nil)
+  }
+
+  @Test("a fresh session after a salvaged completion starts clean")
+  func sessionAfterSalvageStartsClean() async {
+    let ctx = makeContext(behavior: .emptyThenScripted(text: "salvaged text", emptyCalls: 1))
+    await runToTerminal(ctx)
+    #expect(ctx.wrapper.testKernel.lastSalvagedLeadTrimMs != nil)
+
+    // Second session: normal success. The salvage marker must clear at the
+    // `→ recording` transition (the App layer reads it per-completion), and
+    // the adapter-session bookkeeping from the retry must not leak.
+    ctx.engine.behavior = .batchSuccess(text: "second take")
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    ctx.capture.deliverBuffer(frameCount: 48000, amplitude: 0.25)
+    ctx.vad.evidence = .voiced
+    ctx.vad.segments = [SpeechSegment(startSample: 0, endSample: 48000)]
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.state == .completed)
+    #expect(kernel.deliveredTranscript == "second take")
+    #expect(kernel.lastSalvagedLeadTrimMs == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
@@ -471,6 +471,75 @@ struct PipelineStateChangePlannerTests {
     #expect(!plan.effects.contains(.scheduleHistorySaveFailedWarning(reason: "disk is full")))
   }
 
+  // MARK: - #1434 salvaged-lead disclosure
+
+  @Test("complete + salvaged lead -> salvage pill scheduled in the single warning slot")
+  func salvagedLeadSchedulesPill() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil,
+      salvagedLead: true
+    )
+    #expect(plan.effects.contains(.scheduleSalvagedLeadWarning))
+    #expect(plan.effects.contains(.appendCompletedTranscript))
+  }
+
+  @Test("complete + salvaged lead + polish failed -> salvage pill wins, polish pill suppressed")
+  func salvagedLeadBeatsPolishPill() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: "Polish failed",
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil,
+      salvagedLead: true
+    )
+    #expect(plan.effects.contains(.scheduleSalvagedLeadWarning))
+    #expect(!plan.effects.contains(.schedulePolishFailedWarning))
+  }
+
+  @Test("complete + salvaged lead + history save failed -> history pill wins the single slot")
+  func historyPillBeatsSalvagePill() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: true,
+      historySaved: false,
+      historySaveReason: "disk is full",
+      salvagedLead: true
+    )
+    #expect(plan.effects.contains(.scheduleHistorySaveFailedWarning(reason: "disk is full")))
+    #expect(!plan.effects.contains(.scheduleSalvagedLeadWarning))
+  }
+
+  @Test("non-complete transition with salvaged lead does not schedule the pill")
+  func salvagePillOnlyOnComplete() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.recording,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false,
+      historySaved: true,
+      historySaveReason: nil,
+      salvagedLead: true
+    )
+    #expect(!plan.effects.contains(.scheduleSalvagedLeadWarning))
+  }
+
   // MARK: - Activity projection integrity
 
   @Test("Parakeet state activity mapping is stable")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -64,6 +64,13 @@ enum FakeEngineBehavior: Sendable {
   case crashOnFinalize
   /// `finalize()` always returns `.cancelled`.
   case cancelled
+  /// #1434 salvage-ladder scripting: `finalize()` returns
+  /// `.empty(hadSpeechEvidence: true)` for the first `emptyCalls` calls, then
+  /// `.transcript(text)` — models a primary decode that collapses on a
+  /// degraded lead while a trimmed retry succeeds. `thenFailure` swaps the
+  /// success for `.failed(.engineCrashed)` to exercise the ladder's
+  /// abort-on-retry-failure path.
+  case emptyThenScripted(text: String, emptyCalls: Int, thenFailure: Bool = false)
 }
 
 @MainActor
@@ -366,6 +373,16 @@ final class FakeEngine: ASREngineAdapter {
       // The load wedged; A4 cancels before finalize (handled by the
       // post-cancel branch above). A defensive finalize surfaces a load failure.
       outcome = .failed(.loadFailed)
+    case .emptyThenScripted(let text, let emptyCalls, let thenFailure):
+      // #1434: `finalizeCallCount` was already incremented above, so call N
+      // (1-based) sees finalizeCallCount == N.
+      if finalizeCallCount <= emptyCalls {
+        outcome = .empty(hadSpeechEvidence: true)
+      } else if thenFailure {
+        outcome = .failed(.engineCrashed)
+      } else {
+        outcome = .transcript(makeResult(text: text))
+      }
     }
     isTerminal = true
     // PR-5 Rung 2A: honor the §4 contract, assigning only on .transcript(...).


### PR DESCRIPTION
## Summary

- Fixes the root cause of #1434: a settling Bluetooth voice link (AirPods HFP/SCO renegotiation) can poison the first 1-2s of a capture with near-silence + packet-loss-concealment artifacts. Parakeet's decoder was collapsing to a fully EMPTY transcript for the whole utterance when fed that poisoned lead, losing the entire dictation despite real speech. Fix: a real format-stabilization check (replacing a stub that asserted a false claim), a degraded-lead retry ladder that re-decodes at up to 3 trimmed candidates when the primary decode comes back empty despite speech evidence, and fleet-wide capture-health telemetry (native rate, ring drops, converter errors, rate divergence) so this class of failure is visible going forward.
- Fixes a crash found during tonight's live testing: the reply closure added to decode the new capture-health metadata over XPC was written inline inside a MainActor-inferred closure, but actually runs on the XPC connection's own dispatch queue — trapped on nearly every stopCapture. Hoisted to a `nonisolated static` helper matching the two sibling decode helpers already using that pattern in the same file.
- Fixes a pre-existing flaky/hardware-dependent test (`CaptureRouteResolverForceMappingTests`) that silently depended on no real Bluetooth output being connected on the test machine, and closes a real coverage gap it had (no test asserted `.automatic` actually routes to the HAL device-input backend under real Bluetooth output — the live, already-shipped behavior since #1427 that this whole PR's fix depends on actually firing).
- Fixes a Codex-review finding: salvage-success telemetry fields were stamped but never read by the ASR-completed breadcrumb payload, so a salvaged completion looked identical to a normal one in fleet diagnostics.

## Live UAT (extensive — see #1434 and #1441 for the full evidence trail)

Tested live tonight by the founder across AirPods Pro 3 and Bose, including cold starts, rapid-fire back-to-back dictation, and a 30-second-keep-warm session with a 20-second sustained recording — the longest and cleanest AirPods capture of the whole investigation. Bose confirmed not regressed (measurably smoother startup on this build vs. before). A separate, narrower failure mode (losing leading words on a genuinely cold Bluetooth mic-open, independent of this fix) was found, root-caused, and confirmed to be a shared industry limitation (WisprFlow, SuperWhisper, and a third-party dictation app all reproduce it) — tracked separately as #1441, explicitly not blocking this merge.

## Test plan
- [x] Full logic suite green (2543 tests)
- [x] Local Codex code-diff review clean (multiple rounds, findings addressed)
- [x] Live UAT on real hardware (AirPods Pro 3, Bose) — see #1434
- [x] Build succeeds, dev app rebuilt and relaunched clean

Closes #1434