### PR TITLE
fix(asr): remove install-phase false wedge, fix load cancel/death contract, add install Cancel (#1388)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -11,6 +11,11 @@ public struct ASRLoadSupersededError: Error, Equatable {
   public init() {}
 }
 
+// #1388: `ASRLoadCancelledError` (the deliberate-cancel resume for
+// `cancelInFlightLoad()`) lives in EnviousWisprCore beside
+// `ModelLoadWatchdog.WedgeError` — the pipeline driver classifies on it and
+// does not import this module.
+
 /// Abstraction over ASR management — enables swapping between in-process and XPC implementations.
 ///
 /// `ASRManager` (in-process) and `ASRManagerProxy` (XPC) both conform to this protocol.

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -199,6 +199,14 @@ public final class ASRManagerProxy: ASRManagerInterface {
         let guard_ = OneShotContinuationASR(cont)
         registeredCompletion = guard_
         self.pendingLoadCompletion = guard_
+        // #1388 (cloud review P1): era of the connection this call goes out
+        // on. A LATE per-call error handler — queued behind the invalidation
+        // that already resumed this load — must not recycle the SUCCESSOR's
+        // fresh connection after the adapter's retry installed it. Same
+        // whole-body era rule as the interruption/invalidation handlers; the
+        // duplicate `guard_` resume below stays harmless either way (this
+        // era's one-shot, not the successor's).
+        let callEraID = self.connection.map(ObjectIdentifier.init)
         self.serviceProxy { proxy in
           let cacheOnly = self.parakeetCacheOnly && self.activeBackendType == .parakeet
           proxy.loadModel(backendType: self.activeBackendType.rawValue, cacheOnly: cacheOnly) {
@@ -207,8 +215,13 @@ public final class ASRManagerProxy: ASRManagerInterface {
           }
         } onProxyError: {
           // #1348: force a helper recycle so the next attempt reconnects to
-          // the current bundle binary (grounded r2 blocker 1).
-          self.recycleConnectionAfterProxyError()
+          // the current bundle binary (grounded r2 blocker 1) — era-gated
+          // (#1388): only while OUR connection is still current (or cleared
+          // with no successor yet).
+          let currentEraID = self.connection.map(ObjectIdentifier.init)
+          if currentEraID == nil || currentEraID == callEraID {
+            self.recycleConnectionAfterProxyError()
+          }
           guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
         }
       }

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -44,6 +44,18 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// Single-flight guard: if a load is already in progress, callers await it instead of starting a new one.
   private var inFlightLoadTask: Task<Void, any Error>?
 
+  /// #1388 step 1: the pending `loadModel()` continuation's resume-once guard,
+  /// reachable by EVERY completion source — the XPC reply, the per-call proxy
+  /// error, the invalidation/interruption handlers, and an explicit
+  /// `cancelInFlightLoad()`. Production proved the per-call error handler does
+  /// NOT reliably fire for a pending reply on invalidate/death (119 of 126
+  /// wedge fires reached no terminal outcome — the await hung and the caller's
+  /// guard slot leaked), so the connection handlers resume this directly.
+  /// `OneShotContinuationASR` guarantees exactly one resume; the
+  /// identity-guarded clear in `loadModel()` prevents a superseded load's exit
+  /// from clobbering a retry's freshly registered guard.
+  private var pendingLoadCompletion: OneShotContinuationASR<Void>?
+
   /// #959 readiness-integrity token. Monotonic; `loadModel()` captures it at the
   /// start of its load and refuses to write `isModelLoaded = true` if it changed
   /// before the load completes (throws `ASRLoadSupersededError`). Bumped by
@@ -112,6 +124,11 @@ public final class ASRManagerProxy: ASRManagerInterface {
   var needsReinitForTesting: Bool { needsReinit }
   var hasConnectionForTesting: Bool { connection != nil }
 
+  /// #1388 test accessor: whether a pending load completion is registered.
+  /// The contract test asserts it is cleared on every `loadModel` exit.
+  // periphery:ignore - test seam
+  var hasPendingLoadCompletionForTesting: Bool { pendingLoadCompletion != nil }
+
   /// Invalidate whatever load is current: bump the generation so an in-flight
   /// `loadModel()` completion (even one whose `isModelLoaded` is still `false`)
   /// is superseded, and log the `ready → notReady` transition tagged with cause.
@@ -168,8 +185,20 @@ public final class ASRManagerProxy: ASRManagerInterface {
       // only on the success path; an XPC error left the timer alive forever.
       defer { self.stopProgressPolling() }
 
+      // #1388 step 1: register the continuation guard so the connection
+      // handlers and `cancelInFlightLoad()` can complete the load. The clear
+      // is identity-guarded: a superseded load's exit must not clobber the
+      // guard a retry registered after it (same trap as `activeLoadTaskID`).
+      var registeredCompletion: OneShotContinuationASR<Void>?
+      defer {
+        if let registered = registeredCompletion, self.pendingLoadCompletion === registered {
+          self.pendingLoadCompletion = nil
+        }
+      }
       try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
         let guard_ = OneShotContinuationASR(cont)
+        registeredCompletion = guard_
+        self.pendingLoadCompletion = guard_
         self.serviceProxy { proxy in
           let cacheOnly = self.parakeetCacheOnly && self.activeBackendType == .parakeet
           proxy.loadModel(backendType: self.activeBackendType.rawValue, cacheOnly: cacheOnly) {
@@ -492,6 +521,16 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// This is the programmatic equivalent of the user manually quitting and
   /// relaunching the app — same recovery mechanism, no user effort required.
   public func cancelInFlightLoad() {
+    // #1388 step 1: resume the pending load continuation FIRST, with the
+    // dedicated cancellation error, so (a) `loadModel`'s await always reaches
+    // a terminal outcome — before this contract the invalidation handler
+    // never resumed it and `ensureEngineWarm` hung forever — and (b) the
+    // cancel CAUSE wins over the death cause the invalidation handler would
+    // stamp (the one-shot guard drops the handler's later duplicate resume).
+    // Deliberately NOT a transport error: the adapter's one-shot transport
+    // retry would silently restart a load the user just cancelled.
+    pendingLoadCompletion?.resume(throwing: ASRLoadCancelledError())
+    pendingLoadCompletion = nil
     // #959: supersede the current load FIRST so its completion can't resurrect
     // readiness after this teardown (always destructive — no no-op guard here).
     invalidateCurrentLoadGeneration(cause: "recoverFromWedge")
@@ -542,8 +581,12 @@ public final class ASRManagerProxy: ASRManagerInterface {
     conn.remoteObjectInterface = NSXPCInterface(with: ASRServiceProtocol.self)
     conn.exportedInterface = NSXPCInterface(with: ASRServiceClientProtocol.self)
 
-    conn.interruptionHandler = Self.makeInterruptionHandler(proxy: self)
-    conn.invalidationHandler = Self.makeInvalidationHandler(proxy: self)
+    // #1388: handlers carry their own connection for the era guard — a late
+    // handler from a RETIRED connection must not resume a successor load's
+    // pending completion (same trap class as `recycleConnectionAfterProxyError`'s
+    // detach, code-diff r5 P2).
+    conn.interruptionHandler = Self.makeInterruptionHandler(proxy: self, connection: conn)
+    conn.invalidationHandler = Self.makeInvalidationHandler(proxy: self, connection: conn)
 
     conn.resume()
     connection = conn
@@ -650,15 +693,40 @@ public final class ASRManagerProxy: ASRManagerInterface {
     }
   }
 
-  nonisolated private static func makeInterruptionHandler(proxy: ASRManagerProxy) -> @Sendable () ->
+  nonisolated private static func makeInterruptionHandler(
+    proxy: ASRManagerProxy, connection: NSXPCConnection
+  ) -> @Sendable () ->
     Void
   {
+    // NSXPCConnection is not Sendable; the era guard only needs IDENTITY, so
+    // carry the Sendable ObjectIdentifier instead of the object.
+    let eraID = ObjectIdentifier(connection)
     return { [weak proxy] in
       Task { @MainActor [weak proxy] in
         guard let proxy else { return }
         let wasStreaming = proxy.isStreaming
         let wasLoaded = proxy.isModelLoaded
         let wasInFlight = proxy.inFlightLoadTask != nil
+        // #1388 step 1: a service death mid-load must FAIL the pending load —
+        // the per-call error handler is not guaranteed to fire for a pending
+        // reply, and before this contract the await simply hung. Typed as the
+        // transport error so the adapter's one-shot retry reconnects to the
+        // respawned helper (the designed stale-helper recovery). A deliberate
+        // cancel already resumed this with the cancellation error first; the
+        // one-shot guard drops this duplicate.
+        //
+        // Era guard: only the CURRENT connection's death may touch proxy
+        // state — a retired connection's late handler racing a fast retry
+        // must not kill the successor's freshly registered guard, supersede
+        // the successor's generation, or clear the successor's flags (Codex
+        // r3 P2 on #1388: the guard originally covered only the resume; the
+        // trailing mutations read LIVE state and clobbered the successor).
+        // Current era = the proxy's live connection is still this handler's
+        // connection, or was cleared with no successor established yet.
+        let currentEraID = proxy.connection.map(ObjectIdentifier.init)
+        guard currentEraID == nil || currentEraID == eraID else { return }
+        proxy.pendingLoadCompletion?.resume(throwing: XPCASRTransportError.serviceUnreachable)
+        proxy.pendingLoadCompletion = nil
         // #959: supersede the current/in-flight load (and log the ready→notReady
         // cause) BEFORE clearing `isModelLoaded`, so the cause log fires and a
         // load completing after this teardown cannot resurrect a false `.ready`.
@@ -686,14 +754,28 @@ public final class ASRManagerProxy: ASRManagerInterface {
     }
   }
 
-  nonisolated private static func makeInvalidationHandler(proxy: ASRManagerProxy) -> @Sendable () ->
+  nonisolated private static func makeInvalidationHandler(
+    proxy: ASRManagerProxy, connection: NSXPCConnection
+  ) -> @Sendable () ->
     Void
   {
+    let eraID = ObjectIdentifier(connection)
     return { [weak proxy] in
       Task { @MainActor [weak proxy] in
         guard let proxy else { return }
         let wasActive = proxy.isStreaming || proxy.isModelLoaded
         let wasInFlight = proxy.inFlightLoadTask != nil
+        // #1388 step 1: same as the interruption handler — an invalidated
+        // connection must fail the pending load with the typed transport
+        // error (duplicate resumes are dropped by the one-shot guard), under
+        // the same era guard. The guard covers the WHOLE body (Codex r3 P2):
+        // a retired connection's late handler must not kill a successor load,
+        // supersede the successor's generation, nil the successor connection,
+        // or flag reinit against it.
+        let currentEraID = proxy.connection.map(ObjectIdentifier.init)
+        guard currentEraID == nil || currentEraID == eraID else { return }
+        proxy.pendingLoadCompletion?.resume(throwing: XPCASRTransportError.serviceUnreachable)
+        proxy.pendingLoadCompletion = nil
         // #959: same as the interruption handler — supersede current/in-flight
         // load + log cause BEFORE clearing `isModelLoaded`.
         if wasActive || wasInFlight {
@@ -717,7 +799,10 @@ public final class ASRManagerProxy: ASRManagerInterface {
 
 /// Thread-safe one-shot continuation guard — duplicate of AudioCaptureProxy's version.
 /// Duplicated per architecture rule: "duplication is allowed when it protects independence."
-private final class OneShotContinuationASR<T: Sendable>: @unchecked Sendable {
+/// `internal` (was private) since #1388: the resume-once contract test pins
+/// first-resume-wins directly (the cancel cause must beat the invalidation
+/// handler's later death cause).
+final class OneShotContinuationASR<T: Sendable>: @unchecked Sendable {
   private var continuation: CheckedContinuation<T, any Error>?
   private let lock = NSLock()
 

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -94,7 +94,10 @@ public actor ParakeetBackend: ASRBackend {
           detail =
             "\(downloadedMB) MB of \(Self.totalDownloadMB) MB (\(Int(downloadPct * 100))%)"
         case .compiling(let modelName):
-          phase = "Installing model..."
+          // Single authority for this token too (#1388): the host-side
+          // watcher's install OBSERVATION keys on it for the warm-up success
+          // telemetry (install duration + longest internal silence).
+          phase = ModelLoadStallPolicy.installPhase
           detail = modelName
         }
         callback(progress.fractionCompleted, phase, detail)

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -203,4 +203,13 @@ final class DictationRuntime {
   func ensureActiveEngineWarmForOnboarding() async -> EngineWarmupOutcome {
     await starter.activeDriver.ensureEngineWarm(reason: .onboarding)
   }
+
+  /// #1388 step 3 — the onboarding install Cancel button's seam. Cancels the
+  /// in-flight warm-up load; the awaiting `ensureEngineWarm` resolves as
+  /// `.cancelled` (never a failure), and onboarding renders the calm
+  /// "Try setup again" state. Safe against a just-completed load — the
+  /// adapter's in-flight gate makes it a no-op then.
+  func cancelActiveEngineWarmupForOnboarding() async {
+    await starter.activeDriver.cancelSessionlessWarmup()
+  }
 }

--- a/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
@@ -337,6 +337,13 @@ final class EngineCoordinator {
         TelemetryService.shared.engineWarm(
           engine: backend.rawValue, durationMs: ms, outcome: "failed")
         TelemetryService.shared.engineSwitchFailed(engine: backend.rawValue, reason: "warm_failed")
+      case .cancelled:
+        // #1388: a deliberate cancel (user Cancel during the onboarding
+        // install, which shares the single-flighted load this warm joined) is
+        // a choice, not a failure — no failed switch phase, no
+        // engine_switch_failed. The next genuine poke/press re-attempts.
+        TelemetryService.shared.engineWarm(
+          engine: backend.rawValue, durationMs: ms, outcome: "cancelled")
       }
       // Readiness changed with NO kernel state transition, so `onStateChange`
       // would miss it — self-poke so the published status reflects it AND any

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -65,6 +65,53 @@ final class OnboardingV2ViewModel {
   var rawErrorDetails: String?
   var retryCount = 0
 
+  /// #1388: true after the user cancelled the install. Renders the calm
+  /// "Try setup again" state (NOT the error panel) and keeps the `.task`
+  /// auto-start from re-kicking the download until the user chooses to.
+  /// Cleared by `retryDownload()`.
+  var setupCancelled = false
+
+  /// #1388 (founder UAT): instant UI acknowledgment of a Cancel press —
+  /// renders "Cancelling…" while the cooperative cancel (~2s drain) resolves,
+  /// so the user never re-aims at a button that is about to change identity.
+  /// Set by the checklist's Cancel action; cleared when the warm-up outcome
+  /// lands in `startSetup` (whatever the outcome — a cancel that raced a
+  /// just-completed load resolves `.ready`, and the beats play honestly).
+  var cancelRequested = false
+
+  /// #1388 (UAT-found, latent on main): the setup workflow, owned HERE so a
+  /// window disappear/reappear cannot kill it. Before this, `startSetup` ran
+  /// inside the view's `.task`, and any window churn during the install
+  /// (auto-open re-present, activation-policy flip, restoration) cancelled
+  /// that task: the in-flight warm-up's outcome then arrived into a cancelled
+  /// context and was silently dropped, while the replacement task's `.pending`
+  /// guard refused to re-enter — checklist frozen on step 1 forever, Cancel a
+  /// no-op. On fast installs the outcome won the race, which is why short
+  /// warm-cache runs never showed it. The view's `.task` now only KICKS this
+  /// owned task; churn re-fires the kick, which finds the live workflow and
+  /// stands down.
+  @ObservationIgnored private(set) var setupTask: Task<Void, Never>?
+
+  /// Start the setup workflow if none is live and the checklist is genuinely
+  /// at the start line. Safe to call repeatedly (every view re-appear).
+  func kickSetupIfNeeded(
+    warmUp: @escaping @MainActor () async -> EngineWarmupOutcome, settings: SettingsManager
+  ) {
+    guard setupTask == nil else { return }
+    guard currentScreen == .settingUp,
+      setupPhase == .checklist,
+      downloadError == nil,
+      // #1388: after a user Cancel, setup restarts only on the user's
+      // explicit "Try setup again" (retryDownload clears the flag).
+      !setupCancelled,
+      case .pending = checklistStatuses[0]
+    else { return }
+    setupTask = Task { @MainActor in
+      await self.startSetup(warmUp: warmUp, settings: settings)
+      self.setupTask = nil
+    }
+  }
+
   /// ViewModel-owned progress state, polled from ASR manager.
   /// SwiftUI can't observe @Observable properties through protocol existentials
   /// (asrManager is typed as `any ASRManagerInterface`), so we poll and copy.
@@ -157,12 +204,31 @@ final class OnboardingV2ViewModel {
     let outcome = await warmUp()
     stopProgressPolling()
     allowSleep()
+    // #1388: the outcome has landed — the "Cancelling…" acknowledgment (if
+    // any) is over regardless of which way it resolved.
+    cancelRequested = false
 
-    // Window may have closed during the warm-up — leave onboardingState as
-    // .settingUp so the next launch re-runs the checklist from scratch (the
-    // model load itself is single-flighted, so it keeps loading in the
-    // background and the relaunch finds it ready / joins it).
+    // #1388: this now runs inside the viewModel-OWNED `setupTask` (see
+    // `kickSetupIfNeeded`), which no view-lifecycle event cancels — window
+    // churn mid-install can no longer drop the outcome on the floor. The
+    // check stays as a guard for any future explicit `setupTask?.cancel()`;
+    // a window that truly closes just lets the workflow run to completion in
+    // the background (the load is single-flighted either way), and the next
+    // open resumes from whatever state it reached.
     if Task.isCancelled { return }
+
+    // #1388: a user Cancel is a choice, not a failure — no error copy, no
+    // `step_blocked`, no failure telemetry (the driver already emitted
+    // `install_cancelled`). Reset to the calm pre-start state; the
+    // "Try setup again" button re-kicks via `retryDownload()`.
+    if case .cancelled = outcome {
+      installQuip = ""
+      stopQuipTimer()
+      checklistStatuses = [.pending, .pending, .pending]
+      listingPhaseSince = nil
+      setupCancelled = true
+      return
+    }
 
     if case .failed(let error) = outcome {
       let friendly = Self.friendlyError(error)
@@ -214,6 +280,9 @@ final class OnboardingV2ViewModel {
     // timestamp from the failed attempt must not flash "Still working" at
     // second zero of the retry.
     listingPhaseSince = nil
+    // #1388: a retry after a user Cancel re-arms the auto-start.
+    setupCancelled = false
+    cancelRequested = false
     retryCount += 1
   }
 
@@ -308,12 +377,13 @@ final class OnboardingV2ViewModel {
       return ModelDeliveryCopy.message(reason: delivery.reason, detail: delivery.detail)
     }
 
-    // #1339: the sessionless stall guard classifies a detected listing stall
-    // as a WedgeError — surface the stall-specific message, not a raw
-    // transport string. (The download did not fail outright; the source hung.)
+    // #1388: after gate (B)'s removal a WedgeError can only mean gate (A) —
+    // the service reported no progress whatsoever inside the deadline. That
+    // is a setup failure, not a network diagnosis; the old "check your
+    // internet connection or VPN" copy was factually wrong on the install
+    // phase (which runs with networking disabled) and is deleted.
     if error is ModelLoadWatchdog.WedgeError {
-      return
-        "Setup is taking longer than expected. Check your internet connection or VPN, then try again."
+      return "Setup didn't finish. Try again, and if it keeps happening, restart the app."
     }
 
     let desc = error.localizedDescription.lowercased()
@@ -462,16 +532,18 @@ struct OnboardingV2View: View {
     // hotkey_config) advance via `checklistStatuses` while `setupPhase` stays
     // `.checklist`, so re-sync on each beat so the abandon reports the real sub-step.
     .onChange(of: viewModel.checklistStatuses) { syncProgressBox() }
-    // setupPhase is intentionally excluded from the id: changing phase at the end of
-    // startSetup must NOT cancel the running task. currentScreen + retryCount are
-    // sufficient triggers — retryCount bumps on retry, currentScreen bumps on navigation.
+    // #1388 (UAT-found, latent on main): this `.task` used to RUN the setup
+    // workflow, so SwiftUI cancelling it (window churn: re-present,
+    // activation-policy flip, restoration) froze the checklist mid-install —
+    // the warm-up outcome landed in a cancelled task and the replacement's
+    // `.pending` guard refused re-entry. It now only KICKS the
+    // viewModel-owned workflow; the eligibility guard lives in
+    // `kickSetupIfNeeded`, where a live workflow makes re-kicks a no-op.
+    // setupPhase is intentionally excluded from the id: changing phase at the
+    // end of startSetup must NOT re-trigger. currentScreen + retryCount are
+    // sufficient — retryCount bumps on retry, currentScreen on navigation.
     .task(id: "\(viewModel.currentScreen)-\(viewModel.retryCount)") {
-      guard viewModel.currentScreen == .settingUp,
-        viewModel.setupPhase == .checklist,
-        viewModel.downloadError == nil,
-        case .pending = viewModel.checklistStatuses[0]
-      else { return }
-      await viewModel.startSetup(
+      viewModel.kickSetupIfNeeded(
         warmUp: { await dictationRuntime.ensureActiveEngineWarmForOnboarding() },
         settings: settings)
     }
@@ -629,6 +701,10 @@ private struct SettingUpScreenV2: View {
 
 private struct ChecklistPhaseView: View {
   var viewModel: OnboardingV2ViewModel
+  // #1388 step 3: the install Cancel routes through the runtime's warm-up
+  // seam (DictationRuntime is an app-wide @Environment home per
+  // state-ownership; feature-local DI would re-thread it through two inits).
+  @Environment(DictationRuntime.self) private var dictationRuntime
 
   private static let items: [(title: String, subtitle: String)] = [
     ("Setting up speech model", "One-time setup"),
@@ -701,10 +777,57 @@ private struct ChecklistPhaseView: View {
           }
         }
         .padding(.top, 4)
+      } else if viewModel.setupCancelled {
+        // #1388: post-Cancel state — calm, not an error. The downloaded model
+        // files are preserved; retrying resumes from wherever setup got to.
+        VStack(spacing: 8) {
+          Text("Setup paused. Start it again whenever you're ready.")
+            .font(.obCaption)
+            .foregroundStyle(Color.obTextSecondary)
+            .multilineTextAlignment(.center)
+
+          Button("Try setup again") { viewModel.retryDownload() }
+            .buttonStyle(OnboardingButtonStyle())
+        }
+        .padding(.top, 4)
+      } else if viewModel.checklistStatuses[0].isInProgress {
+        // #1388 step 3: the sanctioned long-wait control is Cancel — the app
+        // never decides "too slow" for a progressing install anymore, the
+        // user does. Quiet affordance: the wait is normal, not alarming.
+        //
+        // #1388 (founder UAT): acknowledge the press INSTANTLY. The cancel
+        // drains cooperatively (~2s), and a still-spinning installer after a
+        // Cancel click reads as "it ignored me" — the founder panic-clicked
+        // and hit "Try setup again" that had replaced the button under the
+        // cursor. Matches the delivery contract's D6 state 11 ("acknowledgment
+        // is instant by design").
+        if viewModel.cancelRequested {
+          Text("Cancelling…")
+            .font(.obCaption)
+            .foregroundStyle(Color.obTextTertiary)
+            .padding(.top, 4)
+        } else {
+          Button("Cancel") { cancelInstall() }
+            .font(.obCaption)
+            .foregroundStyle(Color.obTextTertiary)
+            .buttonStyle(.plain)
+            .padding(.top, 4)
+        }
       }
 
       Spacer()
     }
+  }
+
+  /// #1388: cancel the in-flight install. The running `startSetup` observes
+  /// the warm-up resolve as `.cancelled` and renders the paused state — this
+  /// action never mutates checklist state itself (single writer stays the
+  /// view model's outcome handling). `cancelRequested` is UI acknowledgment
+  /// only ("Cancelling…"), cleared by `startSetup` when the outcome lands.
+  private func cancelInstall() {
+    viewModel.cancelRequested = true
+    let runtime = dictationRuntime
+    Task { await runtime.cancelActiveEngineWarmupForOnboarding() }
   }
 
   /// Returns live status text for the model setup row.

--- a/Sources/EnviousWisprCore/LoadProgressWatcher.swift
+++ b/Sources/EnviousWisprCore/LoadProgressWatcher.swift
@@ -12,7 +12,8 @@ import Foundation
 /// =========
 /// The watcher consumes the existing 8Hz progress polling stream from
 /// `ASRManagerProxy.startProgressPolling`. On every tick it tracks per-attempt
-/// inter-signal cadence using a monotonic clock. The trigger fires when both:
+/// inter-signal cadence using a monotonic clock. The post-signal silence gate
+/// ("gate B") fires when both:
 ///
 ///   - silence > 800ms floor (matches `AVCaptureSessionSource` first-buffer
 ///     liveness latch, the only foreground-user-watching silence threshold
@@ -20,17 +21,20 @@ import Foundation
 ///   - silence > 5x the worst inter-signal gap observed so far in this
 ///     attempt (statistical "definitely abnormal" ratio).
 ///
-/// Threshold self-calibrates per-attempt to whatever cadence Parakeet's loader
-/// naturally has on this machine, in this phase. Healthy fast loads stay well
-/// below their own observed cadence ratio. A real wedge produces silence
-/// orders of magnitude larger than anything observed during the same attempt.
-///
-/// Pre-first-signal coverage
-/// =========================
-/// If no progress signal is ever observed (XPC service crashes pre-listing),
-/// the watcher does NOT fire. Today's indefinite-hang behavior persists.
-/// Adding pre-first-signal coverage requires a defended first-signal-latency
-/// duration, which we don't have data for. Deferred per plan §2.2.
+/// Where the self-calibration premise holds — and where it does not (#1388)
+/// ========================================================================
+/// The per-attempt ratio assumes the phase's work units are roughly
+/// homogeneous, so observed cadence predicts future cadence. That holds for
+/// the XPC-operation MILESTONE stream (`XPCOperationSignalWatcher`) — our own
+/// service emits signals at points we choose, on a ~ms beat. It does NOT hold
+/// for work-progress streams with heterogeneous units: the CoreML install
+/// phase emits ~52 ticks ~1.5s apart for the small models, then goes silent
+/// for one ~445MB encoder taking ~20x longer — the ratio is trained on the
+/// wrong distribution, the floor becomes the sole trigger, and every fire is
+/// a false positive (126/126 in production, #1388). Callers watching such a
+/// stream pass `postSignalSilenceGateEnabled: false` and keep only gate (A):
+/// the pre-first-signal / single-signal listing deadline, which detects "the
+/// service reported nothing whatsoever" — a real, unambiguous condition.
 ///
 /// Concurrency
 /// ===========
@@ -70,11 +74,16 @@ public final class LoadProgressWatcher {
   private var maxGapSeconds: TimeInterval = 0
   private var signalCount: Int = 0
   private var fired = false
-  /// #1405: true while the last observed tick was an ACTIVE download phase, so
-  /// the next non-download tick can reset the attempt once at the
-  /// download->load boundary (clean load slate, deadline counts from there).
-  private var wasInDownloadPhase = false
   private var continuation: CheckedContinuation<Void, Never>?
+
+  /// #1388: install-phase observation (telemetry ONLY — no gate reads these).
+  /// Tracks when the injected `installPhase` first/last produced a signal and
+  /// the longest gap between its signals, so the warm-up success event can
+  /// record the true install duration and its longest internal silence —
+  /// the distribution gate (B) used to truncate at 15s.
+  private var installFirstSignalAt: TimeInterval?
+  private var installLastSignalAt: TimeInterval?
+  private var installMaxGapSeconds: TimeInterval = 0
   /// Require two observed progress signals before ratio-based silence can fire.
   /// This keeps the 800ms floor from becoming a standalone timeout after only
   /// one lifecycle tick. XPC lifecycle operations keep this safer default:
@@ -110,13 +119,34 @@ public final class LoadProgressWatcher {
   private let listingPhase: String?
   private let listingStallDeadlineSeconds: TimeInterval?
 
-  /// #1405: phases whose stall detection the DOWNLOADER owns (via its request
-  /// idle timeout), NOT this load-watchdog. While the observed phase is in this
-  /// set the watcher stays parked — it never fires and keeps its attempt
-  /// baseline fresh, so load-stall detection starts clean at the
-  /// download->load transition. Empty (default) preserves the pure-load
-  /// behavior for callers that never watch a download.
+  /// #1388: whether the post-signal silence gates (gate B — the floor + ratio
+  /// evaluation) run at all. Default `true` preserves the XPC-operation
+  /// watcher's behavior byte-for-byte. The model-load guard passes `false`:
+  /// its signal is a heterogeneous work-progress stream where the
+  /// self-calibration premise fails (see the header), so it keeps only
+  /// gate (A) — the pre-first-signal / single-signal listing deadline.
+  private let postSignalSilenceGateEnabled: Bool
+
+  /// #1388: the exact phase string of the CoreML install ("compiling") phase,
+  /// for the install observation above. Observation only — never a gate input.
+  private let installPhase: String?
+
+  /// #1405 (retained through #1388 — Codex r2 P1): phases OWNED by the
+  /// download fetcher, whose own request idle timeout is the stall authority.
+  /// While the observed phase is in this set (with a FRESH signal), the
+  /// watcher is parked — it never fires and does not accumulate load-attempt
+  /// state; the first non-download tick after a parked download RESETS the
+  /// attempt so gate (A)'s pre-first-signal deadline counts from the
+  /// download→load boundary. #1388's first cut deleted this with gate (B),
+  /// which silently blinded gate (A) on fresh installs: download ticks
+  /// counted as load signals, so a service that hung before its first LOAD
+  /// signal was undetectable. Parking protects gate (A), not just gate (B).
   private let downloadOwnedPhases: Set<String>
+
+  /// #1405: true while the last observed tick was an ACTIVE download phase, so
+  /// the next non-download tick can reset the attempt once at the
+  /// download→load boundary (clean load slate, deadline counts from there).
+  private var wasInDownloadPhase = false
 
   public init(
     currentTime: @escaping @MainActor () -> TimeInterval = {
@@ -126,6 +156,8 @@ public final class LoadProgressWatcher {
     listingPhase: String? = nil,
     listingStallDeadlineSeconds: TimeInterval? = nil,
     silenceFloorSeconds: TimeInterval = 0.8,
+    postSignalSilenceGateEnabled: Bool = true,
+    installPhase: String? = nil,
     downloadOwnedPhases: Set<String> = []
   ) {
     self.currentTime = currentTime
@@ -133,6 +165,8 @@ public final class LoadProgressWatcher {
     self.listingPhase = listingPhase
     self.listingStallDeadlineSeconds = listingStallDeadlineSeconds
     self.floorSeconds = silenceFloorSeconds
+    self.postSignalSilenceGateEnabled = postSignalSilenceGateEnabled
+    self.installPhase = installPhase
     self.downloadOwnedPhases = downloadOwnedPhases
   }
 
@@ -147,6 +181,9 @@ public final class LoadProgressWatcher {
     maxGapSeconds = 0
     signalCount = 0
     fired = false
+    installFirstSignalAt = nil
+    installLastSignalAt = nil
+    installMaxGapSeconds = 0
     wasInDownloadPhase = false
     // continuation intentionally left untouched: a prior consumer may still be
     // awaiting wedged() and must be resumed by the caller before start().
@@ -188,11 +225,12 @@ public final class LoadProgressWatcher {
       return
     }
 
-    // download -> load transition: the first non-download tick after a parked
+    // download → load transition: the first non-download tick after a parked
     // download starts the LOAD attempt fresh. This gives load-stall detection a
     // clean slate (the long download does not bleed into its gates) and makes
     // the pre-first-signal deadline count from HERE — so a load that wedges
-    // without ever writing progress after the download is still recovered.
+    // without ever writing progress after the download is still recovered
+    // (gate A; Codex r2 P1 on #1388).
     if wasInDownloadPhase {
       wasInDownloadPhase = false
       attemptStartedAt = now
@@ -200,6 +238,9 @@ public final class LoadProgressWatcher {
       lastSignalAt = nil
       maxGapSeconds = 0
       signalCount = 0
+      installFirstSignalAt = nil
+      installLastSignalAt = nil
+      installMaxGapSeconds = 0
       lastObservedMtime = observedMtime
       lastObservedPhase = observedPhase
       return
@@ -218,6 +259,15 @@ public final class LoadProgressWatcher {
       lastObservedMtime = mtime
       lastObservedPhase = observedPhase
       signalCount += 1
+      // #1388: install-phase observation (telemetry only, never a gate input).
+      if let install = installPhase, observedPhase == install {
+        if let last = installLastSignalAt {
+          let gap = now - last
+          if gap > installMaxGapSeconds { installMaxGapSeconds = gap }
+        }
+        if installFirstSignalAt == nil { installFirstSignalAt = now }
+        installLastSignalAt = now
+      }
       return
     }
 
@@ -248,6 +298,15 @@ public final class LoadProgressWatcher {
       fire()
       return
     }
+    // #1388: everything below is gate (B) — the post-signal silence
+    // evaluation. Disabled for the model-load guard (heterogeneous work
+    // units break the self-calibration premise; see the header). Gate (A)
+    // above remains that caller's only detector, so a load that goes quiet
+    // AFTER its first signal, with the service alive, is deliberately no
+    // longer auto-detected — the user-facing control for a long wait is
+    // Cancel, and the install telemetry now records the real distribution.
+    guard postSignalSilenceGateEnabled else { return }
+
     // Codex finding (2026-05-07): require at least one observed inter-signal
     // gap before the ratio gate is meaningful. With only one signal observed,
     // `maxGapSeconds == 0` and the threshold collapses to the floor alone —
@@ -316,6 +375,22 @@ public final class LoadProgressWatcher {
   // periphery:ignore - test seam
   public var hasFired: Bool { fired }
 
+  /// #1388: the install-phase observation for the warm-up success telemetry.
+  /// `nil` until the injected `installPhase` produced at least one signal.
+  /// `silenceMaxMs` is tail-inclusive — the longest silence is often BETWEEN
+  /// the last install tick and completion (the large encoder is the final
+  /// work unit and emits nothing after), so the gap from the last install
+  /// signal to the read time competes with the observed inter-signal max.
+  /// Read at warm-up completion; reading later would overstate the tail.
+  public var installObservation: InstallPhaseObservation? {
+    guard let first = installFirstSignalAt, let last = installLastSignalAt else { return nil }
+    let now = currentTime()
+    return InstallPhaseObservation(
+      durationMs: Int((now - first) * 1000),
+      silenceMaxMs: Int(max(installMaxGapSeconds, now - last) * 1000)
+    )
+  }
+
   /// Snapshot of the watcher's per-attempt state. Used by the pipeline to
   /// stamp the `wedge_detected` telemetry payload with diagnostic context.
   public var snapshot: WatcherSnapshot {
@@ -363,6 +438,35 @@ public enum ModelLoadStallPolicy {
   /// can never drift on the literal.
   public static let downloadingPhase = "Downloading speech model..."
 
+  /// The exact phase string the delivery layer writes while validating an
+  /// existing cache (`.preparing(validating: true)`), and while SHA-verifying
+  /// a completed download (`.verifying`). #1388 (Codex r4): these are
+  /// delivery-owned work like the download — their ticks must PARK the
+  /// sessionless wedge guard, not count as load signals, or a service that
+  /// hangs after `.admitted` clears the file is undetectable on the
+  /// cache/validation path (no download phase ever ran to trigger the
+  /// boundary reset). Local hashing has no watchdog of its own — a hang
+  /// inside these phases is accepted-undetected (disk-level pathology; the
+  /// removed gate (B) only ever covered it by accident), and gate (A)
+  /// re-arms at the boundary reset the moment the phase moves on.
+  public static let validatingCachePhase = "Checking speech model files..."
+  public static let verifyingDownloadPhase = "Verifying download..."
+
+  /// Every delivery-owned phase the sessionless wedge guard parks on. The
+  /// listing phase is deliberately NOT here: gate (A)'s single-signal listing
+  /// deadline exists precisely to judge a hanging listing (#1339).
+  public static var deliveryParkedPhases: Set<String> {
+    [downloadingPhase, validatingCachePhase, verifyingDownloadPhase]
+  }
+
+  /// The exact phase string the XPC service writes while CoreML compiles the
+  /// downloaded model (the "install" the onboarding checklist shows).
+  /// #1388: the watcher's install OBSERVATION keys on this token to record
+  /// install duration + longest internal silence on the warm-up success
+  /// event. Observation only — no gate reads it. Single authority with the
+  /// phase writer (`ParakeetBackend`).
+  public static let installPhase = "Installing model..."
+
   /// PROVISIONAL listing-stall deadline (plan §3a, issue #1339): fires only
   /// on ABSENCE of progress in the listing window (one signal then silence,
   /// or no signal at all) — never on a progressing transfer. Defended by
@@ -370,16 +474,25 @@ public enum ModelLoadStallPolicy {
   /// abandonment floor observed in production is 7 minutes (420s). Tuned
   /// post-ship via the `model_download.listing_ms` probe; source-aware
   /// deadlines (our-copy ~8-10s) arrive with the mirror-first source work.
+  ///
+  /// #1388 removed `transferSilenceFloorSeconds` (the 15s gate-B floor): the
+  /// post-signal silence gate no longer runs on the model-load path at all,
+  /// so the constant lost its only consumer. This deadline is the surviving
+  /// duration dial.
   public static let listingStallDeadlineSeconds: TimeInterval = 120
+}
 
-  /// Minimum mid-stream silence before a download-watching ratio gate may
-  /// fire. Defended by the 2026-07-05 Live UAT drill (#1339): a COLD edge
-  /// read of the 445MB encoder object produced a legitimate multi-second
-  /// first-byte gap, and the 0.8s XPC-beat floor let a ~2.5s ratio threshold
-  /// kill a healthy fresh-install download. 15s comfortably clears observed
-  /// cold-TTFB (~3-5s) while still surfacing a genuinely dead mid-stream
-  /// transfer fast. PROVISIONAL — tuned post-ship from download telemetry.
-  public static let transferSilenceFloorSeconds: TimeInterval = 15
+/// #1388: install-phase observation captured by `LoadProgressWatcher` for the
+/// warm-up success telemetry (`install_duration_ms` / `install_silence_max_ms`
+/// on `coldstart.warmup_completed`). Pure observation — nothing gates on it.
+public struct InstallPhaseObservation: Sendable {
+  public let durationMs: Int
+  public let silenceMaxMs: Int
+
+  public init(durationMs: Int, silenceMaxMs: Int) {
+    self.durationMs = durationMs
+    self.silenceMaxMs = silenceMaxMs
+  }
 }
 
 /// Diagnostic snapshot of a `LoadProgressWatcher`'s per-attempt state.

--- a/Sources/EnviousWisprCore/ModelLoadWatchdog.swift
+++ b/Sources/EnviousWisprCore/ModelLoadWatchdog.swift
@@ -29,3 +29,19 @@ public enum ModelLoadWatchdog {
     public var description: String { "model load wedged at stage=\(stage)" }
   }
 }
+
+/// #1388 step 1: thrown from `loadModel()` when the in-flight load was
+/// deliberately cancelled — a user Cancel during onboarding install, or the
+/// wedge guard's teardown (both route through `cancelInFlightLoad()`).
+/// Deliberately NOT a transport error: the adapter's one-shot transport
+/// retry (`ParakeetEngineAdapter.loadModelWithTransportRecovery`) retries any
+/// transport error, which would silently restart a load the user just
+/// cancelled. The two causes share this resume vehicle but never an outcome:
+/// `KernelDictationDriver.ensureEngineWarm` classifies a guard fire
+/// (`didFire`) as `WedgeError`/`.failed` FIRST; only a user-initiated cancel
+/// maps to `EngineWarmupOutcome.cancelled`. Lives in Core beside `WedgeError`
+/// so the ASR layer (thrower) and the pipeline driver (classifier) share it
+/// without a new cross-module import.
+public struct ASRLoadCancelledError: Error, Equatable {
+  public init() {}
+}

--- a/Sources/EnviousWisprPipeline/ASREngineOptionalCapabilities.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineOptionalCapabilities.swift
@@ -21,3 +21,14 @@ import Foundation
 protocol ASREngineLanguageIdentifying: AnyObject {
   var lastLanguageDetection: LanguageDetectionResult? { get }
 }
+
+/// #1388 step 3: adapters whose sessionless warm-up includes a cancellable
+/// DELIVERY (download) stage in addition to the in-flight model load. The
+/// onboarding install Cancel discovers this via `as?` so it can cancel
+/// whichever stage the warm-up is currently awaiting. The plain session
+/// cancel (`cancel()`) deliberately does NOT touch the delivery — a
+/// cancelled recording must not kill a first-run download in progress.
+@MainActor
+protocol ASREngineWarmupCancelling: AnyObject {
+  func cancelSessionlessWarmup() async
+}

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -49,9 +49,19 @@ public enum EngineWarmupReason: Sendable {
 /// readiness); onboarding consumes `.failed` to drive its "download failed →
 /// Retry" UX, which needs the underlying error. Not `Sendable` — produced and
 /// consumed on the `@MainActor`.
+///
+/// #1388: `.cancelled` is a user-chosen terminal, NOT a failure. A user's
+/// Cancel during the onboarding install (or a task cancellation of the
+/// surrounding warm-up) must never surface the error UI, emit
+/// `coldstart.warmup_failed`, or block the onboarding step. Classification
+/// order is contractual: a wedge-guard fire (`didFire`) wins as
+/// `WedgeError`/`.failed` FIRST — a guard teardown resumes the load via the
+/// same cancellation error a user Cancel does, but a detector verdict is a
+/// failure, a user cancel is a choice.
 public enum EngineWarmupOutcome {
   case ready
   case failed(any Error)
+  case cancelled
 }
 
 /// Resume-once latch for `KernelDictationDriver.awaitKernelTerminal`. A
@@ -100,8 +110,21 @@ struct LimbSteps {
 /// On a wedge it emits the existing `.modelLoadWedged` captured event +
 /// PostHog `wedge_detected` (same payload fields as the session path), then
 /// drives the existing heavy recovery (`adapter.recoverFromWedge()` →
-/// `cancelInFlightLoad` → XPC invalidation), which unblocks the parked load
-/// with a throw that `ensureEngineWarm` classifies via `didFire`.
+/// `cancelInFlightLoad` → XPC invalidation). #1388 step 1 made that teardown
+/// actually complete the parked load: `cancelInFlightLoad` resumes the
+/// pending continuation with `ASRLoadCancelledError` (before #1388 nothing
+/// resumed it — the await hung, the guard slot leaked, and 119 of 126
+/// production fires reached no terminal outcome). `ensureEngineWarm`'s
+/// classification then maps `didFire` to `WedgeError` — a detector verdict
+/// stays a failure; only a user-initiated cancel maps to `.cancelled`.
+///
+/// #1388 also removed gate (B) — the post-signal silence gate — from this
+/// guard's watcher: the CoreML install phase has ~20x-heterogeneous work
+/// units, so the self-calibrated ratio was trained on the wrong distribution
+/// and the 15s floor was the sole trigger on all 126 production fires, every
+/// one a false positive on a healthy compile. Gate (A) survives: no signal
+/// whatsoever inside `listingStallDeadlineSeconds` is a real, unambiguous
+/// dead-service condition.
 ///
 /// Stale-file trap (mirrors the host proxy's 2026-05-07 Codex finding): the
 /// guard arms BEFORE `loadModel()` clears the progress file, so early reads
@@ -124,16 +147,31 @@ package final class SessionlessLoadWedgeGuard {
     self.watcher = LoadProgressWatcher(
       listingPhase: ModelLoadStallPolicy.listingPhase,
       listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
-      // #1339 raised this floor for cold-TTFB tolerance while the guard still
-      // judged the transfer. #1405 hands transfer-stall ownership back to the
-      // fetcher's own request idle timeout: the guard now stays PARKED during
-      // the download phase (`downloadOwnedPhases`), so this floor governs only
-      // the listing + model-load phases. Left at 15s (harmless for those; a
-      // genuine load wedge is silence orders of magnitude larger).
-      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds,
-      downloadOwnedPhases: [ModelLoadStallPolicy.downloadingPhase]
+      // #1388: gate (B) OFF for the model-load application — its work-progress
+      // stream has ~20x-heterogeneous units (CoreML compile), so the
+      // post-signal silence gate false-fired on every healthy cold install.
+      // Gate (A) — the listing deadline above — is this guard's only detector.
+      postSignalSilenceGateEnabled: false,
+      // Observation only: install duration + longest internal silence for the
+      // warm-up success telemetry (the distribution gate (B) used to truncate).
+      installPhase: ModelLoadStallPolicy.installPhase,
+      // #1405 parking, RETAINED through #1388 (Codex r2 P1) and widened to
+      // ALL delivery-owned phases (Codex r4 P2): delivery ticks — download,
+      // cache validation, SHA verify — must not count as load signals, or
+      // gate (A)'s pre-first-signal deadline is satisfied by delivery work
+      // and a service that hangs before its first LOAD signal becomes
+      // undetectable. The transition reset restarts the deadline at the
+      // delivery→load boundary. The listing phase stays JUDGED (its
+      // single-signal deadline is gate (A)'s listing variant). (First cut
+      // deleted parking as "gate-B-only plumbing" — wrong: it protects
+      // gate (A) too.)
+      downloadOwnedPhases: ModelLoadStallPolicy.deliveryParkedPhases
     )
   }
+
+  /// #1388: install-phase observation for the warm-up success telemetry.
+  /// Read by `ensureEngineWarm` at completion (before disarm).
+  var installObservation: InstallPhaseObservation? { watcher.installObservation }
 
   func arm() {
     watcher.start()
@@ -443,9 +481,16 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       try await adapter.warmUp()
       residentModelLostWhileIdle = false  // #959: load succeeded — drop stale marker.
       let ms = Self.elapsedMs(since: start)
+      // #1388: un-truncated install-phase observation. With gate (B) removed
+      // there is no auto-abort at 15s, so the success event finally records
+      // what real installs look like (duration + longest internal silence).
+      // Nil when no guard covered this warm-up (WhisperKit, in-process debug).
+      let install = observedGuard?.installObservation
       TelemetryService.shared.coldStartWarmupCompleted(
         engine: engine, reason: reason.telemetryToken, durationMs: ms,
-        inferenceWarmupMs: adapter.lastWarmupInferenceMs)
+        inferenceWarmupMs: adapter.lastWarmupInferenceMs,
+        installDurationMs: install?.durationMs,
+        installSilenceMaxMs: install?.silenceMaxMs)
       if reason == .launch {
         TelemetryService.shared.launchModelPreloadCompleted(
           backend: engine, result: warmupInFlight ? "joined_in_flight" : "success",
@@ -453,20 +498,89 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       }
       return .ready
     } catch {
-      // #1339: a guard fire tears down the parked load via XPC invalidation,
-      // so the throw seen here is a transport/supersession error — classify it
-      // as the wedge it actually is so onboarding shows the stall-specific
-      // copy + Retry instead of a raw transport string.
-      let classified: any Error =
-        (observedGuard?.didFire == true) ? ModelLoadWatchdog.WedgeError() : error
-      TelemetryService.shared.coldStartWarmupFailed(
-        engine: engine, reason: reason.telemetryToken,
-        error: String(describing: classified))
-      if reason == .launch {
-        TelemetryService.shared.launchModelPreloadCompleted(
-          backend: engine, result: "failed", durationMs: Self.elapsedMs(since: start))
+      let ms = Self.elapsedMs(since: start)
+      switch Self.classifyWarmupThrow(error, guardFired: observedGuard?.didFire == true) {
+      case .wedge:
+        // A guard fire is a detector VERDICT — with gate (B) removed this can
+        // only be gate (A): the service reported nothing whatsoever inside
+        // the deadline. Classified as the wedge it actually is so onboarding
+        // shows the setup-failure copy + Retry, not a raw transport string.
+        let classified: any Error = ModelLoadWatchdog.WedgeError()
+        TelemetryService.shared.coldStartWarmupFailed(
+          engine: engine, reason: reason.telemetryToken,
+          error: String(describing: classified))
+        if reason == .launch {
+          TelemetryService.shared.launchModelPreloadCompleted(
+            backend: engine, result: "failed", durationMs: ms)
+        }
+        return .failed(classified)
+      case .cancelled:
+        // A deliberate cancel (user Cancel via `cancelInFlightLoad`, or a
+        // cancelled surrounding task / delivery download cancel) is a CHOICE:
+        // never `warmup_failed`, never the error UI. `install_cancelled` is
+        // the population signal for how often users bail out of the wait.
+        TelemetryService.shared.installCancelled(
+          engine: engine, reason: reason.telemetryToken, durationMs: ms)
+        if reason == .launch {
+          TelemetryService.shared.launchModelPreloadCompleted(
+            backend: engine, result: "cancelled", durationMs: ms)
+        }
+        return .cancelled
+      case .failure:
+        // Everything else is a genuine failure with the true underlying
+        // error (typed transport error on service death — step 1 made that
+        // path actually resume; before #1388 it hung with no outcome).
+        TelemetryService.shared.coldStartWarmupFailed(
+          engine: engine, reason: reason.telemetryToken,
+          error: String(describing: error))
+        if reason == .launch {
+          TelemetryService.shared.launchModelPreloadCompleted(
+            backend: engine, result: "failed", durationMs: ms)
+        }
+        return .failed(error)
       }
-      return .failed(classified)
+    }
+  }
+
+  /// #1388: how a warm-up throw maps to a terminal outcome.
+  package enum WarmupThrowClassification: Equatable {
+    case wedge
+    case cancelled
+    case failure
+  }
+
+  /// #1388: pure classification for a warm-up throw. The ORDER is contractual
+  /// (plan §4/§9): (1) a wedge-guard fire wins — a guard teardown resumes the
+  /// load via the same cancellation error a user Cancel uses (shared resume
+  /// vehicle, so the auto transport-retry can never resurrect either), but a
+  /// detector verdict is a failure while a user cancel is a choice; (2) only
+  /// then does the cancellation error (or a cancelled surrounding task) map
+  /// to `.cancelled`; (3) everything else is a genuine failure. Static + pure
+  /// so the boundary matrix is unit-testable without a live guard (the
+  /// guard's fire path needs real time + the shared progress file; the
+  /// mid-load service-kill fault drill covers that integration).
+  package static func classifyWarmupThrow(
+    _ error: any Error, guardFired: Bool
+  ) -> WarmupThrowClassification {
+    if guardFired { return .wedge }
+    if error is ASRLoadCancelledError || error is CancellationError { return .cancelled }
+    return .failure
+  }
+
+  /// #1388 step 3: cancel the in-flight sessionless warm-up (the onboarding
+  /// install Cancel button's seam). Engines with a cancellable delivery stage
+  /// (Parakeet) cancel BOTH halves — the download fetch and the in-flight
+  /// load; others fall back to the plain model-preserving discard.
+  /// `cancelInFlightLoad()` resumes the pending load with the dedicated
+  /// cancellation error, which the classification above maps to `.cancelled`
+  /// (the guard did not fire). Safe against a just-completed load — the
+  /// adapter's in-flight gate and the delivery controller's
+  /// completion-wins-the-race handling both make it a no-op then.
+  public func cancelSessionlessWarmup() async {
+    if let cancelling = adapter as? ASREngineWarmupCancelling {
+      await cancelling.cancelSessionlessWarmup()
+    } else {
+      await adapter.cancel()
     }
   }
 

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -177,7 +177,17 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
     do {
       try await loadModelWithTransportRecovery()
-    } catch let error where deliveryActive && !(error is ASRLoadSupersededError) {
+    } catch let error
+      where deliveryActive
+      && !(error is ASRLoadSupersededError)
+      // #1388 (Codex r3 P1): a user Cancel must NOT fall into the repair
+      // retry — repairing an intact cache succeeds and silently restarts the
+      // install the user just cancelled (the founder watched exactly this
+      // ~2s resurrection live). Same policy as the transport-recovery catch:
+      // cancellation propagates untouched.
+      && !(error is ASRLoadCancelledError)
+      && !(error is CancellationError)
+    {
       // One-shot load-miss repair (#1348 grounded r1 revision 7): a
       // cache-only load failure (raced deletion, missed corruption) gets ONE
       // revalidate/repair pass and ONE retry; a second failure is terminal.
@@ -201,6 +211,13 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// after an app update) already recycled the connection in the proxy's
   /// errorHandler; the retry connects to the freshly spawned helper. A
   /// second transport failure propagates.
+  ///
+  /// #1388 retry-vs-cancel policy (this adapter's side of the contract): the
+  /// catch matches ONLY transport errors, so `ASRLoadCancelledError` — a user
+  /// Cancel or the wedge guard's teardown — propagates without a retry. That
+  /// is load-bearing, not incidental: the cancel resume was deliberately
+  /// typed as a non-transport error so this one-shot recovery can never
+  /// silently restart a load the user just cancelled. Do not widen the catch.
   private func loadModelWithTransportRecovery() async throws {
     do {
       try await asrManager.loadModel()
@@ -413,6 +430,17 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     // wedge guard stays parked during the download phase — so a download is
     // never in flight here. The #1371 `delivery.cancel()` that used to live
     // here was the external canceller that fought the fetcher's retry; removed.
+  }
+
+  /// #1388 step 3 — the onboarding install Cancel. Cancels BOTH stages the
+  /// sessionless warm-up can be awaiting: the delivery fetch (download half)
+  /// and the in-flight model load (install half). Distinct from `cancel()`
+  /// above, the kernel's session discard, which deliberately does NOT touch
+  /// the delivery — a cancelled recording must not kill a first-run download
+  /// running in the background.
+  func cancelSessionlessWarmup() async {
+    await delivery?.cancelActiveFetch()
+    await cancel()
   }
 
   // MARK: ASREngineAdapter — cleanup
@@ -643,3 +671,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 }
 
 extension ParakeetEngineAdapter: ASREngineTelemetryProviding {}
+
+// #1388 step 3: opt in to the warm-up cancel capability (the method itself
+// lives with the other lifecycle methods above).
+extension ParakeetEngineAdapter: ASREngineWarmupCancelling {}

--- a/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
@@ -59,6 +59,16 @@ public final class ParakeetDeliveryHandle {
     await controller.repair(registration)
   }
 
+  /// #1388 step 3: user Cancel during the DOWNLOAD portion of the onboarding
+  /// install. Cooperative — resolves after the live attempt fully drains
+  /// (controller D4 §3), and the adapter's awaiting `ensureAvailable()` then
+  /// returns `.cancelled`, surfacing as `EngineWarmupOutcome.cancelled`.
+  /// No-op when nothing is in flight. This is USER intent, unlike the
+  /// removed #1371 watchdog canceller that fought the fetcher's retry policy.
+  public func cancelActiveFetch() async {
+    _ = await controller.cancel(registration.manifest.identity)
+  }
+
   /// D5 §1: the `enabled=false` bypass is proven by telemetry from the ONE
   /// site that takes it (the adapter's legacy branch).
   public func noteLegacyPathActive() {
@@ -79,7 +89,10 @@ public final class ParakeetDeliveryHandle {
     case .preparing(let validating):
       file.write(
         fraction: 0,
-        phase: validating ? "Checking speech model files..." : ModelLoadStallPolicy.listingPhase,
+        // Single authority for both literals: the wedge guard PARKS on the
+        // validating phase and JUDGES the listing phase (#1388 Codex r4).
+        phase: validating
+          ? ModelLoadStallPolicy.validatingCachePhase : ModelLoadStallPolicy.listingPhase,
         detail: "")
     case .downloading(let fraction, let bytesWritten, let totalBytes):
       let mb = Int(Double(bytesWritten) / 1_048_576)
@@ -90,7 +103,8 @@ public final class ParakeetDeliveryHandle {
         phase: ModelLoadStallPolicy.downloadingPhase,
         detail: "\(mb) MB of \(totalMB) MB (\(Int(fraction * 100))%)")
     case .verifying:
-      file.write(fraction: 0.5, phase: "Verifying download...", detail: "")
+      // Single authority for the literal (the wedge guard parks on it, #1388).
+      file.write(fraction: 0.5, phase: ModelLoadStallPolicy.verifyingDownloadPhase, detail: "")
     case .admitted:
       // #1405 download->load boundary: CLEAR the progress file the instant
       // delivery completes. This moves the phase off the download phase so the

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -601,8 +601,14 @@ public final class TelemetryService {
   /// silent warm-up inference's own duration (nested inside `durationMs`, not
   /// additive) — absent/nil for Parakeet and for pre-#1275 rows. Query by
   /// presence; no consumer branches on magnitude.
+  /// #1388: `installDurationMs` / `installSilenceMaxMs` record the CoreML
+  /// install phase un-truncated (the removed 15s gate used to abort before
+  /// the distribution was observable). Nil when no wedge guard covered the
+  /// warm-up (WhisperKit, in-process debug) and for pre-#1388 rows. Query by
+  /// presence, never `!= 0`.
   public func coldStartWarmupCompleted(
-    engine: String, reason: String, durationMs: Int, inferenceWarmupMs: Int? = nil
+    engine: String, reason: String, durationMs: Int, inferenceWarmupMs: Int? = nil,
+    installDurationMs: Int? = nil, installSilenceMaxMs: Int? = nil
   ) {
     var properties: [String: Any] = [
       "engine": engine,
@@ -613,7 +619,29 @@ public final class TelemetryService {
     if let inferenceWarmupMs {
       properties["inference_warmup_ms"] = inferenceWarmupMs
     }
+    if let installDurationMs {
+      properties["install_duration_ms"] = installDurationMs
+    }
+    if let installSilenceMaxMs {
+      properties["install_silence_max_ms"] = installSilenceMaxMs
+    }
     PostHogSDK.shared.capture("coldstart.warmup_completed", properties: properties)
+  }
+
+  /// #1388: a warm-up ended because the user (or a cancelled surrounding task)
+  /// chose to stop it — NOT a failure. Never pairs with
+  /// `coldstart.warmup_failed` or `onboarding.step_blocked`; the population
+  /// signal for how often users bail out of the install wait now that a
+  /// Cancel control exists. Privacy: timing/state only.
+  public func installCancelled(engine: String, reason: String, durationMs: Int) {
+    PostHogSDK.shared.capture(
+      "install_cancelled",
+      properties: [
+        "engine": engine,
+        "reason": reason,
+        "duration_ms": durationMs,
+        "$value": Double(durationMs) / 1000.0,
+      ])
   }
 
   /// Cold-boot warm-up failed — the engine stays not-ready and the next press

--- a/Tests/EnviousWisprASRTests/ASRManagerProxyLoadCompletionTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerProxyLoadCompletionTests.swift
@@ -1,0 +1,100 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+
+/// #1388 step 1 — the pending-load completion contract.
+///
+/// Production proved the per-call XPC error handler does NOT reliably fire for
+/// a pending `loadModel` reply on invalidate/death: 119 of 126 wedge fires
+/// reached no terminal outcome — the await hung and the caller's guard slot
+/// leaked. The fix registers the load's one-shot continuation guard on the
+/// proxy (`pendingLoadCompletion`) so EVERY completion source can resume it:
+/// the XPC reply, the per-call proxy error, the invalidation/interruption
+/// handlers, and an explicit `cancelInFlightLoad()`.
+///
+/// These tests pin the deterministic parts of that contract. The mid-flight
+/// integration (kill the real ASR service during a real `loadModel`) is
+/// runtime-only by nature and lives in the fault-injection drill
+/// (`Tests/RuntimeUAT/faultInjection.py`, the #1388 mid-load kill scenario).
+@MainActor
+@Suite("ASRManagerProxy — #1388 load completion contract")
+struct ASRManagerProxyLoadCompletionTests {
+
+  @Test("cancelInFlightLoad with no load in flight is a safe no-op")
+  func cancelWithNoLoadIsNoOp() {
+    let proxy = ASRManagerProxy(connectionPreflight: { _ in })
+    #expect(proxy.hasPendingLoadCompletionForTesting == false)
+    proxy.cancelInFlightLoad()
+    #expect(proxy.hasPendingLoadCompletionForTesting == false)
+    #expect(proxy.isModelLoaded == false)
+  }
+
+  @Test("loadModel clears the pending completion on a thrown exit (no stale guard)")
+  func pendingCompletionClearedOnThrow() async {
+    // No-op preflight → nil connection → the real `serviceProxy` nil branch
+    // fires `onProxyError` → the continuation resumes `serviceUnreachable`.
+    // The identity-guarded defer must then clear the registered guard: a
+    // stale non-nil guard here would let a LATER cancel/invalidation resume a
+    // continuation that already completed (the one-shot drops it, but the
+    // registration leak would still mask real pending state).
+    let proxy = ASRManagerProxy(connectionPreflight: { _ in })
+    await #expect(throws: XPCASRTransportError.self) {
+      try await proxy.loadModel()
+    }
+    #expect(proxy.hasPendingLoadCompletionForTesting == false)
+  }
+
+  @Test("resume-once: the cancel cause beats a later death cause (first resume wins)")
+  func firstResumeWinsCancelBeatsDeath() async {
+    // The exact production ordering `cancelInFlightLoad` relies on: it resumes
+    // the pending guard with the cancellation error FIRST, then invalidates
+    // the connection — whose invalidation handler later attempts a duplicate
+    // resume with `serviceUnreachable`. The one-shot guard must deliver the
+    // FIRST cause and drop the second, or a user Cancel would surface as a
+    // service death (and the adapter's transport retry would resurrect it).
+    let thrown: any Error = await withCheckedContinuation { outer in
+      Task { @MainActor in
+        do {
+          try await withCheckedThrowingContinuation {
+            (cont: CheckedContinuation<Void, any Error>) in
+            let oneShot = OneShotContinuationASR(cont)
+            oneShot.resume(throwing: ASRLoadCancelledError())
+            oneShot.resume(throwing: XPCASRTransportError.serviceUnreachable)
+          }
+          Issue.record("the continuation must throw, not return")
+          outer.resume(returning: CancellationError())
+        } catch {
+          outer.resume(returning: error)
+        }
+      }
+    }
+    #expect(
+      thrown is ASRLoadCancelledError,
+      "the first resume (cancel) must win; the death duplicate must be dropped")
+  }
+
+  @Test("resume-once: a death cause is delivered when it arrives first")
+  func deathCauseDeliveredWhenFirst() async {
+    let thrown: any Error = await withCheckedContinuation { outer in
+      Task { @MainActor in
+        do {
+          try await withCheckedThrowingContinuation {
+            (cont: CheckedContinuation<Void, any Error>) in
+            let oneShot = OneShotContinuationASR(cont)
+            oneShot.resume(throwing: XPCASRTransportError.serviceUnreachable)
+            oneShot.resume(throwing: ASRLoadCancelledError())
+          }
+          Issue.record("the continuation must throw, not return")
+          outer.resume(returning: CancellationError())
+        } catch {
+          outer.resume(returning: error)
+        }
+      }
+    }
+    #expect(
+      thrown is XPCASRTransportError,
+      "a genuine death that resumes first is the true cause and must be delivered")
+  }
+}

--- a/Tests/EnviousWisprTests/App/OnboardingSetupKickTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingSetupKickTests.swift
@@ -1,0 +1,118 @@
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+#if DEBUG
+
+  /// #1388 (UAT-found, latent on main) — the onboarding install workflow is
+  /// owned by the view model (`kickSetupIfNeeded` / `setupTask`), not the
+  /// view's `.task`. Before this, window churn mid-install cancelled the view
+  /// task; the warm-up outcome was dropped and the replacement task's
+  /// `.pending` guard refused re-entry — checklist frozen on step 1 forever.
+  /// These tests lock the ownership contract: a live workflow makes re-kicks
+  /// a no-op, and the workflow drives the checklist to completion regardless
+  /// of what happened to its kicker.
+  @MainActor
+  @Suite("Onboarding setup kick", .serialized)
+  struct OnboardingSetupKickTests {
+
+    @MainActor
+    private final class Counter {
+      var value = 0
+    }
+
+    /// A SettingsManager backed by a fresh ephemeral suite (never touches the
+    /// real shared store).
+    private func makeSettings() -> SettingsManager {
+      SettingsManager(defaults: UserDefaults(suiteName: "ewtest.\(UUID().uuidString)")!)
+    }
+
+    private func makeReadyViewModel() -> OnboardingV2ViewModel {
+      let vm = OnboardingV2ViewModel()
+      vm.currentScreen = .settingUp
+      vm.setupPhase = .checklist
+      return vm
+    }
+
+    @Test(
+      "re-kick while the workflow is live is a no-op, and the owned workflow completes (churn-freeze regression)"
+    )
+    func kickIsSingleFlightAndSurvivesKicker() async throws {
+      let vm = makeReadyViewModel()
+      let settings = makeSettings()
+      let warmUpCalls = Counter()
+      // Signal-gated warm-up: suspends until the test releases the gate, so
+      // the mid-install re-kick lands while the workflow is genuinely live.
+      let (gate, gateCont) = AsyncStream.makeStream(of: Void.self)
+
+      vm.kickSetupIfNeeded(
+        warmUp: {
+          warmUpCalls.value += 1
+          var it = gate.makeAsyncIterator()
+          _ = await it.next()
+          return .ready
+        },
+        settings: settings)
+      let workflow = vm.setupTask
+      #expect(workflow != nil)
+      // The owned Task is enqueued, not yet running — yield until the workflow
+      // has genuinely entered the install (signal: statuses flip inProgress),
+      // so the re-kick below lands mid-install, not before the start line.
+      var spins = 0
+      while !vm.checklistStatuses[0].isInProgress, spins < 10_000 {
+        await Task.yield()
+        spins += 1
+      }
+      #expect(vm.checklistStatuses[0].isInProgress)
+
+      // The churn: the view re-appears and kicks again mid-install. Must be a
+      // no-op — before the fix the equivalent path left the checklist frozen.
+      vm.kickSetupIfNeeded(warmUp: { .ready }, settings: settings)
+      #expect(warmUpCalls.value == 1)
+
+      gateCont.yield(())
+      await workflow?.value
+      #expect(warmUpCalls.value == 1)
+      #expect(vm.checklistStatuses == [.completed, .completed, .completed])
+      #expect(vm.setupPhase == .permissions)
+      #expect(settings.onboardingState == .needsPermissions)
+      #expect(vm.setupTask == nil)
+    }
+
+    @Test("cancelled outcome pauses calmly; auto re-kick stays paused; retry re-arms")
+    func cancelledPausesAndRetryRearms() async throws {
+      let vm = makeReadyViewModel()
+      let settings = makeSettings()
+
+      vm.kickSetupIfNeeded(warmUp: { .cancelled }, settings: settings)
+      // The instant "Cancelling…" acknowledgment a real press would set.
+      vm.cancelRequested = true
+      let first = vm.setupTask
+      await first?.value
+      #expect(vm.setupCancelled)
+      #expect(!vm.cancelRequested)
+      #expect(vm.checklistStatuses == [.pending, .pending, .pending])
+      #expect(vm.downloadError == nil)
+      #expect(vm.setupTask == nil)
+
+      // A churn re-kick after the Cancel must NOT restart the install — only
+      // the user's explicit "Try setup again" may.
+      vm.kickSetupIfNeeded(warmUp: { .ready }, settings: settings)
+      #expect(vm.setupTask == nil)
+
+      vm.retryDownload()
+      #expect(!vm.setupCancelled)
+      vm.kickSetupIfNeeded(warmUp: { .ready }, settings: settings)
+      let retried = vm.setupTask
+      #expect(retried != nil)
+      await retried?.value
+      #expect(vm.checklistStatuses == [.completed, .completed, .completed])
+      #expect(vm.setupTask == nil)
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
@@ -27,6 +27,11 @@ import Testing
 ///   `isEngineSwitching`, `beginMinting`, `endMinting`) plus their doc
 ///   comments. No new stored property, collaborator, or method — pure init
 ///   wiring; collaborator/closure-injected/method caps unchanged.
+/// - #1388: non-private method cap 7 → 8, line cap 215 → 216 for
+///   `cancelActiveEngineWarmupForOnboarding()` — the onboarding install
+///   Cancel's seam, the exact cancel twin of #879's
+///   `ensureActiveEngineWarmForOnboarding` (same thin forward to
+///   `starter.activeDriver`, no new state, no new collaborator).
 @Suite struct DictationRuntimeCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift"
@@ -68,14 +73,18 @@ import Testing
     // uses the same shared `ensureEngineWarm` as every other warm-up site. It is
     // a thin forward to `starter.activeDriver.ensureEngineWarm(.onboarding)`, no
     // new state.
+    // #1388: raised 7 → 8 for `cancelActiveEngineWarmupForOnboarding()` — the
+    // install Cancel's seam, #879's cancel twin (thin forward to
+    // `starter.activeDriver.cancelSessionlessWarmup()`, no new state).
     #expect(
-      count <= 7,
+      count <= 8,
       """
-      DictationRuntime non-private method ceiling exceeded: \(count) > 7 \
+      DictationRuntime non-private method ceiling exceeded: \(count) > 8 \
       non-private `func` declarations. PR10 baseline: \
       startHotkeyServiceIfEnabled, suspendHotkeys, resumeHotkeys, \
       toggleRecording, cancelRecording, resetActivePipeline; #879 added \
-      ensureActiveEngineWarmForOnboarding. Raising the ceiling requires a \
+      ensureActiveEngineWarmForOnboarding; #1388 added \
+      cancelActiveEngineWarmupForOnboarding. Raising the ceiling requires a \
       Bible §30 entry.
       """)
   }
@@ -85,16 +94,18 @@ import Testing
       contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      count <= 215,
+      count <= 216,
       """
-      DictationRuntime line count exceeded: \(count) > 215. \
+      DictationRuntime line count exceeded: \(count) > 216. \
       Raise via Bible §30 only. PR10 ratcheted 100 → 200 to absorb the \
       7-collab field block + 6 façade methods + DR.init body building the \
       recording subsystem (HeartControlRecovery + Finalizer + Starter + \
       HotkeyController) and calling `hotkeyController.install()` internally. \
       #1171 ratcheted 200 → 215 for the four EngineCoordinator pass-through \
       init parameters (ensureSelectedReadyForPress, isEngineSwitching, \
-      beginMinting, endMinting) + their doc comments — no new state.
+      beginMinting, endMinting) + their doc comments — no new state. \
+      #1388 ratcheted 215 → 216 for cancelActiveEngineWarmupForOnboarding \
+      (#879's cancel twin — thin forward, no new state).
       """)
   }
 

--- a/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
+++ b/Tests/EnviousWisprTests/Core/LoadProgressWatcherTests.swift
@@ -441,126 +441,107 @@ struct LoadProgressWatcherTests {
     watcher.stop()
   }
 
-  @Test(
-    "#1339 drill regression: a cold big-file first-byte gap does NOT fire with the transfer floor"
-  )
-  func coldFirstByteGapDoesNotFireWithTransferFloor() async {
-    // The 2026-07-05 Live UAT drill shape: dense ticks from listing + small
-    // files (~0.5s cadence), then the 445MB object's COLD first-byte gap of
-    // ~3s. With the 0.8s floor the ratio threshold (0.5s x 5 = 2.5s) killed
-    // the healthy download; the transfer floor (15s) must ride the gap out.
-    let clock = ManualClock()
-    let watcher = LoadProgressWatcher(
+  // MARK: - #1388 gate (B) removal — the model-load guard's configuration
+  //
+  // The #1339 transfer-floor drill tests were deleted here: they pinned
+  // gate (B) on the model-load path, which #1388 removed outright (the 15s
+  // floor false-fired on every healthy CoreML compile — 126/126 production
+  // events). The #1405 `downloadOwnedPhases` parking is RETAINED (Codex r2
+  // P1 on #1388: parking protects gate (A), not just gate (B) — without it,
+  // download ticks satisfy the pre-first-signal deadline and a service that
+  // hangs before its first LOAD signal is undetectable); its tests below are
+  // adapted to the gate-A-only guard configuration.
+
+  /// Watcher configured exactly like the #1388 sessionless warm-up guard:
+  /// gate (A) listing deadline only, gate (B) disabled, install observation,
+  /// delivery-phase parking retained (#1405; Codex r2 P1 + r4 P2 on #1388).
+  private func modelLoadGuardShapedWatcher(_ clock: ManualClock) -> LoadProgressWatcher {
+    LoadProgressWatcher(
       currentTime: { clock.now },
       listingPhase: ModelLoadStallPolicy.listingPhase,
       listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
-      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds)
-    watcher.start()
-    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
-    for i in 1..<10 {
-      clock.tick(seconds: 0.5)
-      watcher.observeTick(observedMtime: mtime(i), observedPhase: "Downloading model files...")
-    }
-    // Cold first-byte gap: 3s of silence — the ratio gate (2.5s) is met but
-    // the 15s transfer floor holds.
-    clock.tick(seconds: 3)
-    watcher.observeTick(observedMtime: mtime(9), observedPhase: "Downloading model files...")
-    #expect(!watcher.hasFired, "a cold first-byte gap must never kill a healthy download")
-    // Boundary: total silence just below the floor — still no fire.
-    clock.tick(seconds: 11.9)
-    watcher.observeTick(observedMtime: mtime(9), observedPhase: "Downloading model files...")
-    #expect(!watcher.hasFired, "total silence just below the transfer floor must not fire")
-    // A genuinely dead mid-stream transfer still fires once past the floor.
-    clock.tick(seconds: 0.2)
-    watcher.observeTick(observedMtime: mtime(9), observedPhase: "Downloading model files...")
-    #expect(watcher.hasFired, "true mid-stream death past the transfer floor must fire")
-    watcher.stop()
+      postSignalSilenceGateEnabled: false,
+      installPhase: ModelLoadStallPolicy.installPhase,
+      downloadOwnedPhases: ModelLoadStallPolicy.deliveryParkedPhases)
   }
 
-  @Test("#1405: the guard stays parked during the download phase, but load-stall still fires after")
-  func downloadPhaseIsParkedThenLoadStallStillFires() async {
+  @Test(
+    "#1388 (Codex r4 P2): cache-validation ticks park too — a post-admission hang on the cache path still fires gate (A)"
+  )
+  func cacheValidationTicksDoNotBlindGateA() async {
+    // The cache path never enters the download phase: delivery writes
+    // "Checking speech model files..." ticks, then `.admitted` clears the
+    // file. If those ticks counted as load signals, a service that hangs
+    // before its first LOAD signal would satisfy the pre-first-signal
+    // deadline and be undetectable.
     let clock = ManualClock()
-    let watcher = LoadProgressWatcher(
-      currentTime: { clock.now },
-      listingPhase: ModelLoadStallPolicy.listingPhase,
-      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
-      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds,
-      downloadOwnedPhases: [ModelLoadStallPolicy.downloadingPhase])
+    let watcher = modelLoadGuardShapedWatcher(clock)
     watcher.start()
-    // A long, totally silent (frozen) FRESH download — far past the 15s transfer
-    // floor AND the 120s listing deadline. The fetcher's own idle timeout owns
-    // transfer-stall, so the load-watchdog must never fire during the download.
-    watcher.observeTick(
-      observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.downloadingPhase)
-    clock.tick(seconds: 600)
-    watcher.observeTick(
-      observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.downloadingPhase)
-    #expect(!watcher.hasFired, "a silent fresh download must never fire the load-watchdog")
-
-    // Delivery completes -> #1405 CLEARS the progress file (boundary), so the
-    // next tick sees no file (mtime nil, empty phase). The transition resets
-    // the attempt so the long download does not bleed into the load gates.
+    // Cache validation: fresh ticks under the validating phase.
+    for i in 0..<4 {
+      clock.tick(seconds: 1)
+      watcher.observeTick(
+        observedMtime: mtime(i), observedPhase: ModelLoadStallPolicy.validatingCachePhase)
+    }
+    #expect(!watcher.hasFired, "cache validation must never fire the load guard")
+    // `.admitted` clears the file; the service then hangs with no load signal.
     clock.tick(seconds: 0.5)
     watcher.observeTick(observedMtime: nil, observedPhase: "")
-    // The LOAD then produces two of its own signals and genuinely wedges.
-    clock.tick(seconds: 0.5)
-    watcher.observeTick(observedMtime: mtime(1), observedPhase: "Loading speech model...")
-    clock.tick(seconds: 0.5)
-    watcher.observeTick(observedMtime: mtime(2), observedPhase: "Loading speech model...")
-    clock.tick(seconds: 30)
-    watcher.observeTick(observedMtime: mtime(2), observedPhase: "Loading speech model...")
-    #expect(watcher.hasFired, "a real load wedge AFTER the download must still fire")
-    watcher.stop()
-  }
-
-  @Test("#1405 (cloud-review P1): a cleared boundary preserves the pre-first-signal deadline")
-  func clearedBoundaryPreservesPreFirstSignalDeadline() async {
-    // The download completes and the boundary CLEARS the progress file. If the
-    // model LOAD then wedges before emitting ANY progress of its own (e.g. a
-    // cache-hit marker fast path where `.admitted` is the only delivery event),
-    // the file stays empty. Clearing leaves NO signal — so the pre-first-signal
-    // deadline must still fire (a phantom "Loading..." signal would have
-    // defeated it, the P1 regression).
-    let clock = ManualClock()
-    let watcher = LoadProgressWatcher(
-      currentTime: { clock.now },
-      listingPhase: ModelLoadStallPolicy.listingPhase,
-      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
-      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds,
-      downloadOwnedPhases: [ModelLoadStallPolicy.downloadingPhase])
-    watcher.start()
-    // A brief real download, then the cleared boundary.
-    watcher.observeTick(
-      observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.downloadingPhase)
-    clock.tick(seconds: 5)
-    watcher.observeTick(observedMtime: nil, observedPhase: "")  // #1405 boundary clear
-    // The load never writes; the file stays empty. Deadline must still fire.
     clock.tick(seconds: 119)
     watcher.observeTick(observedMtime: nil, observedPhase: "")
-    #expect(!watcher.hasFired, "just under the deadline from the boundary: no fire yet")
+    #expect(!watcher.hasFired, "just under the post-boundary deadline: no fire yet")
     clock.tick(seconds: 2)
     watcher.observeTick(observedMtime: nil, observedPhase: "")
-    #expect(watcher.hasFired, "a load that never writes after the boundary must still fire")
+    #expect(
+      watcher.hasFired,
+      "a service that never signals after cache admission must fire gate (A)")
     watcher.stop()
   }
 
-  @Test("#1405 (code-diff): a STALE download-phase file must NOT park — the deadline still fires")
-  func staleDownloadPhaseDoesNotSuppressTheGuard() async {
-    // Regression: a prior interrupted attempt leaves the progress file on the
-    // download phase. The guard arms; the poll passes observedMtime == nil
-    // (mtime == the stale baseline, i.e. no fresh write) but the stale phase
-    // string. Parking on the phase alone would reset the deadline every tick
-    // and suppress the guard forever. A new warm-up that hangs before writing
-    // any fresh progress must still fire the pre-first-signal deadline.
+  @Test(
+    "#1405/#1388 (Codex r2 P1): download ticks park the guard; a load that never signals after the boundary still fires gate (A)"
+  )
+  func downloadTicksDoNotBlindGateA() async {
+    // THE regression Codex r2 caught: with parking deleted, download ticks
+    // counted as load signals, so gate (A)'s pre-first-signal deadline was
+    // already satisfied when the service hung before its first LOAD signal —
+    // no detector left. Parking + the boundary reset restore gate (A)'s
+    // coverage without resurrecting gate (B).
     let clock = ManualClock()
-    let watcher = LoadProgressWatcher(
-      currentTime: { clock.now },
-      listingPhase: ModelLoadStallPolicy.listingPhase,
-      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds,
-      silenceFloorSeconds: ModelLoadStallPolicy.transferSilenceFloorSeconds,
-      downloadOwnedPhases: [ModelLoadStallPolicy.downloadingPhase])
+    let watcher = modelLoadGuardShapedWatcher(clock)
     watcher.start()
-    // Stale file: phase says downloading, but there is NO fresh signal (nil).
+    // A real download: fresh ticks under the download-owned phase, running
+    // far past the 120s deadline — parked, must never fire.
+    for i in 0..<30 {
+      clock.tick(seconds: 10)
+      watcher.observeTick(
+        observedMtime: mtime(i), observedPhase: ModelLoadStallPolicy.downloadingPhase)
+    }
+    #expect(!watcher.hasFired, "an active download must never fire the load guard")
+    // Delivery completes and clears the progress file (the boundary). The
+    // service then hangs WITHOUT ever writing a load signal.
+    clock.tick(seconds: 0.5)
+    watcher.observeTick(observedMtime: nil, observedPhase: "")
+    clock.tick(seconds: 119)
+    watcher.observeTick(observedMtime: nil, observedPhase: "")
+    #expect(!watcher.hasFired, "just under the post-boundary deadline: no fire yet")
+    clock.tick(seconds: 2)
+    watcher.observeTick(observedMtime: nil, observedPhase: "")
+    #expect(
+      watcher.hasFired,
+      "a service that never signals after the download boundary must fire gate (A)")
+    watcher.stop()
+  }
+
+  @Test("#1405 (retained): a STALE download-phase file must NOT park — gate (A) still fires")
+  func staleDownloadPhaseDoesNotSuppressTheGuard() async {
+    // A prior interrupted attempt leaves the progress file on the download
+    // phase. The guard arms; the poll passes observedMtime == nil (no fresh
+    // write) with the stale phase string. Parking on the phase alone would
+    // suppress the deadline forever.
+    let clock = ManualClock()
+    let watcher = modelLoadGuardShapedWatcher(clock)
+    watcher.start()
     watcher.observeTick(observedMtime: nil, observedPhase: ModelLoadStallPolicy.downloadingPhase)
     clock.tick(seconds: 119)
     watcher.observeTick(observedMtime: nil, observedPhase: ModelLoadStallPolicy.downloadingPhase)
@@ -573,25 +554,137 @@ struct LoadProgressWatcherTests {
     watcher.stop()
   }
 
-  @Test("#1339 drill regression: the DEFAULT 0.8s floor still fires on the same gap (opt-in fix)")
-  func defaultFloorStillFiresOnColdGap() async {
-    // Negative pair for the test above: without the injected transfer floor,
-    // the identical signal shape fires at the ratio threshold. Locks the fix
-    // as opt-in — XPC lifecycle watchers keep the 0.8s beat unchanged.
+  @Test(
+    "#1405/#1388: after the boundary, healthy load signals keep the guard quiet (gate B stays gone)"
+  )
+  func boundaryThenHealthyLoadSignalsStayQuiet() async {
+    // The download→load transition resets the attempt; the load then signals
+    // and goes long-silent (the compile shape). With gate (B) removed this
+    // must NOT fire — the silence-after-signals verdict belongs to no one.
     let clock = ManualClock()
-    let watcher = LoadProgressWatcher(
-      currentTime: { clock.now },
-      listingPhase: ModelLoadStallPolicy.listingPhase,
-      listingStallDeadlineSeconds: ModelLoadStallPolicy.listingStallDeadlineSeconds)
+    let watcher = modelLoadGuardShapedWatcher(clock)
+    watcher.start()
+    watcher.observeTick(
+      observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.downloadingPhase)
+    clock.tick(seconds: 30)
+    watcher.observeTick(
+      observedMtime: mtime(1), observedPhase: ModelLoadStallPolicy.downloadingPhase)
+    // Boundary clear, then two genuine load signals, then a huge silence.
+    clock.tick(seconds: 0.5)
+    watcher.observeTick(observedMtime: nil, observedPhase: "")
+    clock.tick(seconds: 1)
+    watcher.observeTick(observedMtime: mtime(2), observedPhase: ModelLoadStallPolicy.installPhase)
+    clock.tick(seconds: 1.5)
+    watcher.observeTick(observedMtime: mtime(3), observedPhase: ModelLoadStallPolicy.installPhase)
+    clock.tick(seconds: 600)
+    watcher.observeTick(observedMtime: mtime(3), observedPhase: ModelLoadStallPolicy.installPhase)
+    #expect(
+      !watcher.hasFired,
+      "post-signal silence must never fire the model-load guard (gate B removed)")
+    watcher.stop()
+  }
+
+  @Test("#1388: the compile-shaped sequence (dense ticks, then long silence) does NOT fire")
+  func compileShapedSequenceDoesNotFire() async {
+    // The production false-positive shape: ~52 install ticks ~1.5s apart
+    // (small models), then one silent ~60s stretch (the ~445MB encoder).
+    // Gate (B) false-fired on this at 15s in 126/126 production events; with
+    // the guard's config it must ride the silence out to completion.
+    let clock = ManualClock()
+    let watcher = modelLoadGuardShapedWatcher(clock)
     watcher.start()
     watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
-    for i in 1..<10 {
-      clock.tick(seconds: 0.5)
-      watcher.observeTick(observedMtime: mtime(i), observedPhase: "Downloading model files...")
+    for i in 1...52 {
+      clock.tick(seconds: 1.5)
+      watcher.observeTick(observedMtime: mtime(i), observedPhase: ModelLoadStallPolicy.installPhase)
     }
-    clock.tick(seconds: 3)
-    watcher.observeTick(observedMtime: mtime(9), observedPhase: "Downloading model files...")
-    #expect(watcher.hasFired, "the default floor lets the ratio gate fire on a 3s gap")
+    // The heterogeneous unit: 60s of silence inside the install phase.
+    for _ in 0..<60 {
+      clock.tick(seconds: 1)
+      watcher.observeTick(
+        observedMtime: mtime(52), observedPhase: ModelLoadStallPolicy.installPhase)
+    }
+    #expect(
+      !watcher.hasFired,
+      "a slow-but-progressing install must never be aborted (the #1388 defect)")
+    watcher.stop()
+  }
+
+  @Test("#1388: with gate (B) disabled, post-signal silence NEVER fires — however long")
+  func gateBDisabledNeverFiresOnPostSignalSilence() async {
+    let clock = ManualClock()
+    let watcher = modelLoadGuardShapedWatcher(clock)
+    watcher.start()
+    // Two signals establish an observed gap (the old gate-B arming shape).
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.installPhase)
+    clock.tick(seconds: 1)
+    watcher.observeTick(observedMtime: mtime(1), observedPhase: ModelLoadStallPolicy.installPhase)
+    // The ACCEPTED residual risk, pinned deliberately: an install that hangs
+    // after its first signal with the service alive is no longer auto-detected
+    // (Cancel is the user-facing control; telemetry records the distribution).
+    clock.tick(seconds: 10_000)
+    watcher.observeTick(observedMtime: mtime(1), observedPhase: ModelLoadStallPolicy.installPhase)
+    #expect(
+      !watcher.hasFired,
+      "gate (B) is removed for this caller — no silence duration may fire post-signal")
+    watcher.stop()
+  }
+
+  @Test("#1388: gate (A) still fires with the guard config — zero signals past the deadline")
+  func gateAStillFiresWithGuardConfig() async {
+    let clock = ManualClock()
+    let watcher = modelLoadGuardShapedWatcher(clock)
+    watcher.start()
+    for _ in 0..<10 {
+      clock.tick(seconds: 13)  // crosses the 120s deadline
+      watcher.observeTick(observedMtime: nil, observedPhase: "")
+    }
+    #expect(
+      watcher.hasFired,
+      "a service that never reports anything is the one condition gate (A) owns")
+    watcher.stop()
+  }
+
+  @Test("#1388: install observation records duration and tail-inclusive max silence")
+  func installObservationRecordsDurationAndSilence() async {
+    let clock = ManualClock()
+    let watcher = modelLoadGuardShapedWatcher(clock)
+    watcher.start()
+    // Non-install signals first — must not count toward the install stats.
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: ModelLoadStallPolicy.listingPhase)
+    clock.tick(seconds: 2)
+    #expect(watcher.installObservation == nil, "no install signal yet — observation must be nil")
+    // Install: signals at t=2, 4, 9 (gaps 2 and 5), then an 8s tail to read time.
+    watcher.observeTick(observedMtime: mtime(1), observedPhase: ModelLoadStallPolicy.installPhase)
+    clock.tick(seconds: 2)
+    watcher.observeTick(observedMtime: mtime(2), observedPhase: ModelLoadStallPolicy.installPhase)
+    clock.tick(seconds: 5)
+    watcher.observeTick(observedMtime: mtime(3), observedPhase: ModelLoadStallPolicy.installPhase)
+    clock.tick(seconds: 8)
+    let obs = watcher.installObservation
+    #expect(obs?.durationMs == 15_000, "install duration = first install signal to read time")
+    #expect(
+      obs?.silenceMaxMs == 8_000,
+      "tail silence (8s) exceeds the observed inter-signal max (5s) and must win")
+    watcher.stop()
+  }
+
+  @Test("#1388: default init keeps gate (B) — the XPC-operation watcher is unchanged")
+  func defaultInitKeepsGateB() async {
+    // The opt-out is scoped to the model-load guard. The default configuration
+    // (XPCOperationSignalWatcher's) must keep firing exactly as before —
+    // same shape as `bothGatesFire`, pinned here as the #1388 non-regression.
+    let clock = ManualClock()
+    let watcher = LoadProgressWatcher(currentTime: { clock.now })
+    watcher.start()
+    watcher.observeTick(observedMtime: mtime(0), observedPhase: "op")
+    clock.tick(seconds: 0.150)
+    watcher.observeTick(observedMtime: mtime(1), observedPhase: "op")
+    clock.tick(seconds: 0.150)
+    watcher.observeTick(observedMtime: mtime(2), observedPhase: "op")
+    clock.tick(seconds: 0.810)
+    watcher.observeTick(observedMtime: mtime(2), observedPhase: "op")
+    #expect(watcher.hasFired, "the default (XPC-operation) configuration keeps gate (B) intact")
     watcher.stop()
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprServices
@@ -467,6 +468,67 @@ import Testing
       return
     }
     #expect(h.adapter.readiness != .ready)
+  }
+
+  // MARK: #1388 — terminal classification (user Cancel vs guard verdict vs failure)
+
+  @Test("#1388: the cancellation error maps to .cancelled — never .failed")
+  func warmupCancellationErrorMapsToCancelled() async {
+    let h = makeDriver(behavior: .failLoad(ASRLoadCancelledError()))
+    let outcome = await h.driver.ensureEngineWarm(reason: .onboarding)
+    guard case .cancelled = outcome else {
+      Issue.record("a user Cancel must surface as .cancelled, got \(outcome)")
+      return
+    }
+    #expect(h.adapter.readiness != .ready)
+  }
+
+  @Test("#1388: a cancelled surrounding task (CancellationError) also maps to .cancelled")
+  func warmupTaskCancellationMapsToCancelled() async {
+    let h = makeDriver(behavior: .failLoad(CancellationError()))
+    let outcome = await h.driver.ensureEngineWarm(reason: .onboarding)
+    guard case .cancelled = outcome else {
+      Issue.record("a cancelled task / delivery cancel must surface as .cancelled, got \(outcome)")
+      return
+    }
+  }
+
+  @Test("#1388: a genuine failure keeps the true underlying error")
+  func warmupGenuineFailureKeepsUnderlyingError() async {
+    struct BoomError: Error {}
+    let h = makeDriver(behavior: .failLoad(BoomError()))
+    let outcome = await h.driver.ensureEngineWarm(reason: .onboarding)
+    guard case .failed(let error) = outcome else {
+      Issue.record("expected .failed, got \(outcome)")
+      return
+    }
+    #expect(error is BoomError, "the failure path must propagate the true cause, unwrapped")
+  }
+
+  @Test("#1388 boundary: classification order — a guard fire beats the cancellation error")
+  func classificationOrderGuardFireBeatsCancellation() {
+    // The contractual matrix (plan §4/§9): the guard's verdict wins FIRST even
+    // though its teardown resumes the load with the SAME cancellation error a
+    // user Cancel uses; only a user cancel (no fire) maps to .cancelled. Pure
+    // function — the live guard's fire path needs real time + the shared
+    // progress file, which the mid-load service-kill fault drill covers.
+    typealias Classify = KernelDictationDriver
+    #expect(
+      Classify.classifyWarmupThrow(ASRLoadCancelledError(), guardFired: true) == .wedge,
+      "guard-triggered teardown must stay a failure (WedgeError), never .cancelled")
+    #expect(
+      Classify.classifyWarmupThrow(ASRLoadCancelledError(), guardFired: false) == .cancelled)
+    #expect(
+      Classify.classifyWarmupThrow(CancellationError(), guardFired: false) == .cancelled)
+    #expect(
+      Classify.classifyWarmupThrow(XPCASRTransportError.serviceUnreachable, guardFired: true)
+        == .wedge)
+    #expect(
+      Classify.classifyWarmupThrow(XPCASRTransportError.serviceUnreachable, guardFired: false)
+        == .failure,
+      "genuine service death (no guard fire) is a failure with the transport error")
+    #expect(
+      Classify.classifyWarmupThrow(ASRLoadSupersededError(), guardFired: false) == .failure)
   }
 
   // MARK: #1339 — sessionless wedge-guard topology

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -64,6 +64,10 @@ enum FakeEngineBehavior: Sendable {
   case crashOnFinalize
   /// `finalize()` always returns `.cancelled`.
   case cancelled
+  /// #1388: `warmUp()` throws the given error immediately — drives the
+  /// driver's terminal-classification tests (cancel vs failure) with an
+  /// exact error type instead of the wedge behaviors' `ASREngineError`.
+  case failLoad(any Error & Sendable)
 }
 
 @MainActor
@@ -270,6 +274,9 @@ final class FakeEngine: ASREngineAdapter {
         loadWedgeContinuation = continuation
       }
       throw ASREngineError.wedged
+    case .failLoad(let error):
+      readiness = .notReady
+      throw error
     default:
       readiness = .ready
     }
@@ -365,6 +372,10 @@ final class FakeEngine: ASREngineAdapter {
     case .wedgeOnLoad:
       // The load wedged; A4 cancels before finalize (handled by the
       // post-cancel branch above). A defensive finalize surfaces a load failure.
+      outcome = .failed(.loadFailed)
+    case .failLoad:
+      // #1388: the load threw before any session could begin; a defensive
+      // finalize surfaces a load failure (same stance as .wedgeOnLoad).
       outcome = .failed(.loadFailed)
     }
     isTerminal = true

--- a/Tests/RuntimeUAT/SCENARIOS.md
+++ b/Tests/RuntimeUAT/SCENARIOS.md
@@ -130,6 +130,13 @@ Arm `force_audio_wedge_start(1)` while idle, then press record. The next START o
 
 **Negative control:** arm `force_audio_wedge_start(2)` — the retry wedges too, exhausting the single-retry budget; the press fails with today's error UX and app.log shows `outcome=exhausted`. (Equivalently: remove the `withStartRetry` catch in `AudioCaptureProxy`.)
 
+### A11_asr_kill_mid_model_load (Lane A — model-load, #1388)
+Backends: parakeet. Budget: 30s. Mechanism: model-load.
+
+Kill the ASR XPC connection while the model is LOADING — not mid-stream (A3's shape) and not a user cancel (A8a's shape). Sequence: `force_xpc_kill` drops the resident model; a record press then drives the cold sessionless warm-up (`ensureEngineWarm(.coldPress)`) with a real in-flight `loadModel`; a second `force_xpc_kill` lands ~0.4s into it. The #1388 step-1 contract requires the invalidation handler to resume the pending load continuation with the typed transport error, so the warm-up reaches a terminal outcome and the adapter's one-shot transport retry reconnects to the respawned helper. Verdict: pipeline reaches a terminal token, no helper leak, the recovery dictation PASSES, and the wedge guard did NOT fire (`wedge_guard_fired == False` — the kill produces a typed error, not a detector-owned silence).
+
+**Negative control:** remove the `pendingLoadCompletion` resume from `ASRManagerProxy`'s invalidation handler — the warm-up await hangs, `isLoadInFlight` never clears, readiness pins at `warming`, and every subsequent press is blocked (the recovery dictation fails). This is precisely the pre-#1388 production defect (119 of 126 wedge fires with no terminal outcome).
+
 ### B1_bluetooth_route_flip (Lane B — bt-route, founder-required)
 Backends: both. Budget: 15s. Mechanism: bt-route.
 

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -316,6 +316,23 @@ _RIGHT_CMD_KEYCODE = 54
 _ESC_KEYCODE = 53
 
 
+def _ptt_keycode() -> int:
+    """The app's configured PTT key (shared-suite `toggleKeyCode`), falling
+    back to Right Command. The dev bundle reads the founder's REAL settings
+    (#923), so a hardcoded keycode silently misses when the configured key
+    differs — 2026-07-09: taps posted Right Cmd (54) while the configured key
+    was Right Option (61); zero presses reached the app and the A11 recovery
+    cycle failed without exercising anything."""
+    try:
+        out = subprocess.run(
+            ["defaults", "read", "com.enviouswispr.app", "toggleKeyCode"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return int(out.stdout.strip())
+    except Exception:
+        return _RIGHT_CMD_KEYCODE
+
+
 def _import_simulate_input():
     """Lazy import so this module loads even if Quartz isn't available."""
     here = Path(__file__).resolve().parent
@@ -334,16 +351,18 @@ def _active_state() -> str:
 
 
 def _tap_rcmd(hold_s: float = 0.05) -> None:
-    """Single Right-Cmd press+release. Hold time matches a quick PTT tap.
+    """Single PTT-key press+release (configured key via `_ptt_keycode`).
+    Hold time matches a quick PTT tap.
 
     HotkeyService treats a single tap-and-release with a 500 ms debounce —
     if no second press arrives, it fires onStopRecording. Use double-tap to
     enter hands-free locked mode for sustained recording.
     """
     sim = _import_simulate_input()
-    sim.modifier_down(_RIGHT_CMD_KEYCODE)
+    keycode = _ptt_keycode()
+    sim.modifier_down(keycode)
     time.sleep(hold_s)
-    sim.modifier_up(_RIGHT_CMD_KEYCODE)
+    sim.modifier_up(keycode)
 
 
 def _start_recording_locked(*, gap_s: float = 0.25, settle_s: float = 0.8,
@@ -1193,6 +1212,90 @@ def A10_audio_start_wedge_retry(**_) -> dict:
         "forced_wedge_logged": "forced wedge (DEBUG)" in tail,
         "line_death_logged": "line death" in tail and "cause=wedged" in tail,
         "retry_recovered": "start retry resolved" in tail and "outcome=recovered" in tail,
+    }
+
+
+@scenario(
+    ScenarioMeta(
+        name="A11_asr_kill_mid_model_load",
+        lane="A",
+        family="model-load",
+        backends=["parakeet"],
+        runtime_budget_seconds=30.0,
+        founder_required=False,
+        negative_control="Remove the pendingLoadCompletion resume from ASRManagerProxy's invalidation handler; the warm-up await hangs, isLoadInFlight never clears, and the recovery dictation stays blocked on a permanent 'warming' readiness (the #1388 119/126 defect)",
+        description="ASR XPC connection invalidated mid-MODEL-LOAD (not mid-stream, A3's shape) — the pending load continuation must resume with the typed transport error, the warm-up must reach a terminal outcome, and the next dictation must succeed",
+    )
+)
+def A11_asr_kill_mid_model_load(**_) -> dict:
+    """User behavior: the speech service dies while the model is LOADING
+    (cold press / launch warm-up), not while streaming. Before #1388 step 1
+    the pending load reply was never resumed on invalidation: the warm-up
+    await hung, the guard slot leaked, and no terminal telemetry ever fired
+    (119 of 126 production wedge fires reached no outcome). The contract now
+    requires the invalidation handler to resume the pending continuation
+    with `serviceUnreachable`; the adapter's one-shot transport retry then
+    reconnects to the respawned helper, so the user-visible outcome is a
+    clean recovery or an honest error — never a stuck 'warming' state.
+
+    #1388 notes:
+    - The first force_xpc_kill drops the resident model (the invalidation
+      handler clears isModelLoaded), so the next press takes the COLD path
+      and drives a real in-flight loadModel.
+    - The second force_xpc_kill lands ~0.4s into that load; Parakeet's load
+      floor is multi-second, so the mid-load window is comfortable. This is
+      a deliberate RACE PLACEMENT (the A8a precedent), not a wait-for-done —
+      there is no signal for "the load is now mid-flight" by design.
+    - Verdict is signal-based: pipeline state must reach a terminal token
+      and the recovery dictation must PASS (before the fix, the leaked
+      isLoadInFlight pinned readiness at 'warming' and blocked every
+      subsequent press — the discriminating oracle). The wedge guard must
+      NOT fire during the drill (the kill produces a typed error path, not
+      a silence the detector should claim).
+    """
+    log_offset = APP_LOG_PATH.stat().st_size if APP_LOG_PATH.exists() else 0
+    pre_helpers = list_xpc_service_pids()
+    # 1. Drop the resident model so the next press drives a real cold load.
+    reply_unload = force_xpc_kill()
+    time.sleep(1.0)  # settle: async invalidation handler must clear isModelLoaded before the press
+    # 2. A PTT press on the cold engine takes the BLOCKED cold-press path and
+    #    drives ensureEngineWarm(.coldPress) — the sessionless warm-up this
+    #    drill targets. First-run learning (2026-07-09): the MENU tap does NOT
+    #    take this path after an idle-reap kill — the #959 design lets a menu
+    #    press mint a session with an in-session re-warm, which is A3's shape,
+    #    not this drill's. Only the PTT press logs "press blocked" and arms
+    #    the sessionless guard.
+    _tap_rcmd()
+    time.sleep(0.2)  # settle: deliberate race placement inside the load window (A8a precedent)
+    # 3. Kill the service mid-load. On a warm file cache the cached load can
+    #    complete in <1s, so the kill may land AFTER completion — that run is
+    #    a benign miss, reported honestly via window_hit below, not a pass
+    #    that silently proved nothing.
+    reply_kill = force_xpc_kill()
+    terminated = assert_terminated(timeout_s=15.0)
+    leak = assert_no_xpc_leak(pre_helpers)
+    # 4. The contract's user-visible proof: dictation works after the fault.
+    #    The recovery window must ride out the post-kill respawn + reload
+    #    (multi-second); presses during 'warming' are refused by design.
+    time.sleep(8.0)  # settle: ride out the post-kill service respawn + model reload before the recovery cycle
+    recovery = _assert_dictation_recovers()
+
+    tail = ""
+    if APP_LOG_PATH.exists():
+        with open(APP_LOG_PATH, "r", errors="replace") as f:
+            f.seek(log_offset)
+            tail = f.read()
+    return {
+        "reply_unload": reply_unload,
+        "reply_kill": reply_kill,
+        **terminated,
+        **leak,
+        **recovery,
+        "wedge_guard_fired": "[WedgeGuard] sessionless wedge fired" in tail,
+        # The drill exercised its target seam only if the press was BLOCKED
+        # (sessionless path armed) — otherwise the kill landed on a different
+        # shape and this run proved recovery only.
+        "window_hit": "press blocked" in tail and "armed reason=cold_press" in tail,
     }
 
 


### PR DESCRIPTION
## What

Fixes the install-phase false wedge: production forensics (14d) showed 117/126 sessionless wedge fires happened during the CoreML INSTALL phase (networking disabled) — every one a false positive — and 119/126 reached no terminal outcome because the guard teardown never resumed the pending load continuation.

**Step 1 — load completion contract.** `ASRManagerProxy.pendingLoadCompletion` (resume-once) is resumed by every terminal source: XPC reply, per-call error handler, interruption/invalidation handlers (era-guarded, whole-body — a retired connection's late handler can't touch successor state), and explicit cancel. Typed causes: service death → `serviceUnreachable` (adapter's one-shot transport retry reconnects to the respawned helper); user Cancel → `ASRLoadCancelledError` (non-transport, so neither the transport retry nor the delivery repair retry can resurrect a cancelled load).

**Step 2 — gate B removed from the model-load guard.** The post-signal silence ratio assumes homogeneous work units; the CoreML compile emits ~52 dense ticks then one ~20x-longer silent unit, so the gate false-fired on every healthy install. Gate A (120s no-signal deadline + single-signal listing variant) survives, and the #1405 delivery-phase parking is retained AND widened to all delivery-owned phases (`ModelLoadStallPolicy.deliveryParkedPhases`: downloading + cache-validating + SHA-verifying) — delivery ticks must not satisfy gate A's deadline, or a service that hangs before its first load signal is undetectable.

**Step 3 — user Cancel during onboarding install.** New `EngineWarmupOutcome.cancelled` terminal (never a failure: no `warmup_failed`, no `step_blocked`, no error UI). Calm "Setup paused" state + "Try setup again"; instant "Cancelling…" acknowledgment on press (the ~2s cooperative drain invited panic re-clicks).

**Step 4 — copy + telemetry.** No more VPN-blaming copy; un-truncated install telemetry (`install_duration_ms` / `install_silence_max_ms` on `coldstart.warmup_completed`); `install_cancelled` event.

**Live-UAT-found fix (latent on main).** The onboarding setup workflow ran inside the view's SwiftUI `.task`; window churn mid-install cancelled it, the warm-up outcome was dropped, and the replacement task's `.pending` guard refused re-entry — checklist frozen on step 1 forever with Cancel dead. The workflow is now OWNED by the view model (`kickSetupIfNeeded`/`setupTask`); the view's `.task` only kicks it; re-kicks while live are no-ops.

## Review routing

Local `codex review` ran 5 rounds to clean: r1 clean pre-UAT; r2 caught the parking deletion blinding gate A (fixed + boundary tests); r3 caught the repair-retry resurrecting a user Cancel and the era guard covering only the resume (both fixed); r4 widened parking to the cache/validation phases (fixed + test); r5 clean. DictationRuntime ceilings ratcheted 7→8 methods / 215→216 lines for the Cancel seam (#879's cancel twin; Bible-changelog entry in the ceilings test).

## Validation

- Full logic suite green: 2,375 tests / 277 suites (plus 153 release-lane).
- Phase 3 `validate-pr.sh` → `check-validation.sh --strict` PASS (Code lane).
- Live UAT on the final build: fresh-install zero-wedge run (472MB download + SHA verify in ~5s via the edge-cached mirror; install completes; no guard fire), A11 kill-mid-load drill PASS (`window_hit: true`, honest terminal error, no helper leak, recovery dictation PASS), founder-driven cancel/retry ×3 (instant acknowledgment, calm pause, retry completes, no phantom restart), heart-path dictation PASS (0.787s).

Closes #1388
