### PR TITLE
chore(dev-tooling): point validate-pr.sh Codex stub text at codex-5.6-sol

### DIFF
--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -288,7 +288,7 @@ case "$DECLARED" in
     else
       cat > "$RUN_DIR/codex-prose.txt" <<EOF
 [STUB — caller must overwrite]
-Run: ~/.claude/bin/codex-5.5 review --base origin/main > $RUN_DIR/codex-prose.txt
+Run: ~/.claude/bin/codex-5.6-sol review --base origin/main > $RUN_DIR/codex-prose.txt
 (fallback if usage-capped: ~/.claude/bin/codex-5.3-spark review --base origin/main > $RUN_DIR/codex-prose.txt)
 Then re-run scripts/validate-pr.sh OR call scripts/attest.sh codex-prose "what I observed"
 EOF
@@ -311,7 +311,7 @@ esac
 echo "==> Phase 3.4: Codex code-diff review (caller's responsibility; MUST be clean BEFORE the smoke + Live UAT rebuild above — script not auto-invoking)"
 if [ ! -s "$RUN_DIR/codex-review.txt" ] && [ "$DECLARED" = "Code" ]; then
   cat > "$RUN_DIR/codex-review-todo.txt" <<EOF
-Run: ~/.claude/bin/codex-5.5 review --base origin/main > $RUN_DIR/codex-review.txt
+Run: ~/.claude/bin/codex-5.6-sol review --base origin/main > $RUN_DIR/codex-review.txt
 (fallback if usage-capped: ~/.claude/bin/codex-5.3-spark review --base origin/main > $RUN_DIR/codex-review.txt)
 EOF
   record_step "codex-review" 1 "Stage 1 stub — caller must run codex review and overwrite codex-review.txt"


### PR DESCRIPTION
## What

`gpt-5.6-sol` shipped 2026-07-09 and replaces `gpt-5.5` as the primary Codex model. The `codex-5.5` launcher is retired (founder decision: Spark stays the sole usage-cap fallback), so the two stub lines in `scripts/validate-pr.sh` that tell a caller to run `~/.claude/bin/codex-5.5 review` now name a script that no longer exists.

This PR repoints both stub lines at `~/.claude/bin/codex-5.6-sol`. The Spark fallback lines are unchanged.

## Why it's this small

The tracked repo has exactly one reference to a codex launcher path:

```
$ git grep -n "codex-5.5" -- scripts/ Sources/ Tests/ .github/
scripts/validate-pr.sh:291:Run: ~/.claude/bin/codex-5.5 review --base origin/main > $RUN_DIR/codex-prose.txt
scripts/validate-pr.sh:314:Run: ~/.claude/bin/codex-5.5 review --base origin/main > $RUN_DIR/codex-review.txt
```

Both are stub text printed to a caller — no control flow, no new symbols. The rest of the `gpt-5.6-sol` cutover (the new launcher, the three PreToolUse hooks, the knowledge files) lives in gitignored local config and ships outside this PR.

## Lane and process

- Lane: **Code** (`scripts/validate-pr.sh` is allowlisted-tracked), but the change is stub text only.
- `council-skip: zero-blast-radius (user-facing copy)` — ≤20 lines, 1 file, no new symbols, no control-flow change, single-commit revert.
- Local `codex review --base origin/main`: **clean**. It independently ran `bash -n`, ShellCheck, and `validate-pr.sh --self-test` (2 passed, 0 failed).
- Precedent: #1294 (`chore(dev-tooling): point validate-pr.sh Codex stub text at the two named model scripts`).

## Validation

- `bash -n scripts/validate-pr.sh` — clean
- `shellcheck scripts/validate-pr.sh` — clean
- `scripts/validate-pr.sh --self-test` — 2 passed, 0 failed
- `git grep "codex-5.5"` over the tracked tree — now returns nothing

## Related local work (not in this diff)

The same cutover generalized the three Codex PreToolUse hooks from a hardcoded three-name allowlist to a launcher-family predicate, so a future `codex-<model>` launcher gates automatically with no hook edit. Eight rounds of Codex grounded review on that work surfaced two pre-existing defects worth recording here:

- the **blocking** self-review gate could be disarmed by merely *mentioning* `SKIP_SELFAUDIT=1` anywhere in a command (it is now anchored to a genuine command-prefix assignment, as the background-pattern hook already was);
- the session-reuse hook read `--ephemeral` and `-C/--cd` from raw command text, so an unrelated mention downgraded a real run or misrouted its session lookup.

Both are fixed in local config, with a 60-assertion cross-hook contract test whose regressions were each verified to fail against the pre-fix code.
