### PR TITLE
fix(pipeline): alert only on our own polish bugs, count the rest (#1446)

### DIFF
--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -418,11 +418,18 @@ public struct GeminiConnector: TranscriptPolisher {
     }
     do {
       return try keychainManager.retrieve(key: keychainId)
-    } catch {
-      // A keychain id is set but the key could not be read (corrupt/inaccessible
-      // entry). Functionally there is no usable key; re-entering it in Settings
-      // (the `apiKeyMissing` action) fixes both this and the no-key case.
+    } catch KeyStoreError.retrieveFailed(let status) where status == errSecItemNotFound {
+      // No key is stored. NOTE this is the arm a real no-key user takes, not the
+      // `guard` above: `LLMPolishStep` always supplies the fixed key id for a cloud
+      // provider, so `apiKeyKeychainId` is never nil in production (#1446). Classify
+      // by what the STORE says, not by whether an id was passed.
       throw LLMError.classified(.apiKeyMissing)
+    } catch {
+      // A key IS stored but could not be read (corrupt entry, locked Keychain,
+      // missing entitlement, migration bug). The user sees the same notice as the
+      // no-key case — re-entering the key in Settings fixes both — but this one is
+      // OUR defect and keeps its own alerting fingerprint (#1446).
+      throw LLMError.classified(.apiKeyUnreadable)
     }
   }
 }

--- a/Sources/EnviousWisprLLM/KeychainManager.swift
+++ b/Sources/EnviousWisprLLM/KeychainManager.swift
@@ -263,7 +263,13 @@ struct FileLegacyKeyStore: LegacyKeyFileStorage {
     let url = fileURL(for: key)
     let fm = FileManager.default
     guard fm.fileExists(atPath: url.path) else {
-      throw KeyStoreError.retrieveFailed(-1)
+      // #1446: NO key is stored — the user's configuration state, not a defect.
+      // `errSecItemNotFound` is `KeyStoreError`'s shared vocabulary for absence
+      // (`SecurityKeychainItemStore` already reports it), so callers can tell
+      // "never saved a key" apart from "saved a key we then failed to read".
+      // Every OTHER exit below stays `-1`: the file exists but its bytes would
+      // not read back, which IS a defect.
+      throw KeyStoreError.retrieveFailed(errSecItemNotFound)
     }
 
     try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -245,11 +245,18 @@ public struct OpenAIConnector: TranscriptPolisher {
     }
     do {
       return try keychainManager.retrieve(key: keychainId)
-    } catch {
-      // A keychain id is set but the key could not be read (corrupt/inaccessible
-      // entry). Functionally there is no usable key; re-entering it in Settings
-      // (the `apiKeyMissing` action) fixes both this and the no-key case.
+    } catch KeyStoreError.retrieveFailed(let status) where status == errSecItemNotFound {
+      // No key is stored. NOTE this is the arm a real no-key user takes, not the
+      // `guard` above: `LLMPolishStep` always supplies the fixed key id for a cloud
+      // provider, so `apiKeyKeychainId` is never nil in production (#1446). Classify
+      // by what the STORE says, not by whether an id was passed.
       throw LLMError.classified(.apiKeyMissing)
+    } catch {
+      // A key IS stored but could not be read (corrupt entry, locked Keychain,
+      // missing entitlement, migration bug). The user sees the same notice as the
+      // no-key case — re-entering the key in Settings fixes both — but this one is
+      // OUR defect and keeps its own alerting fingerprint (#1446).
+      throw LLMError.classified(.apiKeyUnreadable)
     }
   }
 }

--- a/Sources/EnviousWisprLLM/PolishFailureReason.swift
+++ b/Sources/EnviousWisprLLM/PolishFailureReason.swift
@@ -1,6 +1,32 @@
 import EnviousWisprCore
 import Foundation
 
+/// Which telemetry channel a live polish failure earns (#1446).
+///
+/// `alertingSentryError` means "this is OUR bug." Nothing else earns it.
+///
+/// The predicate is ownership of the CAUSE, not the shape of the error: could a
+/// change to EnviousWispr's own code have prevented this? A user with no key, an
+/// exhausted quota, a revoked key, a blocked-content filter, a five-minute
+/// dictation, an offline laptop, a provider having an outage — none of those are
+/// defects, and none of them should page anyone. They are still worth counting:
+/// the rate of each tells us which walls real users hit, which is a prompt to write
+/// a guide or add in-app guidance, not to open a bug (founder directive
+/// 2026-07-09; `sentry-operations.md` RULE: sentry-for-bugs-posthog-for-behaviour).
+///
+/// Two cases, not three: both are consumed at the single call site in
+/// `TextProcessingRunner`. A third "aggregate alert candidate" state would have no
+/// reader on the day it shipped.
+public enum PolishFailureTelemetryChannel: Sendable, Equatable {
+  /// An alerting Sentry `.error` event, plus the counted `llm.polish_failed`.
+  /// Reserved for EnviousWispr's own defects.
+  case alertingSentryError
+  /// A breadcrumb and the counted `llm.polish_failed` event only. The cause belongs
+  /// to the user or to the provider, so no code change of ours would alter the
+  /// outcome — but the rate is a product signal worth watching.
+  case nonAlertingAnalytics
+}
+
 /// The single catalog/adapter for a cloud or local AI-cleanup failure (#945).
 ///
 /// One closed set of distinguishable failure reasons. Each reason owns everything
@@ -12,10 +38,16 @@ import Foundation
 ///   - `message(provider:)` — the actionable, self-contained user sentence.
 ///   - `composedMessage(provider:)` — `<leadIn> <message>`, the full notice.
 ///   - `isRetryable` — whether a connector's retry loop should retry this.
+///   - `telemetryChannel(provider:)` — whether a live failure pages us or is
+///     merely counted (#1446).
 ///
-/// Adding a future warning is a one-file change here: a new case plus its four
+/// Adding a future warning is a one-file change here: a new case plus its five
 /// properties, and (only if it needs new detection) one branch in a provider's
-/// `classify`. UI, telemetry, the runner, and `LLMError` are untouched.
+/// `classify`. UI, telemetry, the runner, and `LLMError` are untouched. Note that
+/// only `telemetryTag`, `message(provider:)`, and `telemetryChannel(provider:)`
+/// are exhaustive switches the compiler will force you to update; `leadIn` and
+/// `isRetryable` carry a `default:` and will silently absorb a new case, so read
+/// them both before assuming the default is right (#1446).
 ///
 /// `LLMError` carries this through the existing `throws LLMError` contract via the
 /// single `LLMError.classified(_:)` case, so the type is `public` only because
@@ -23,9 +55,15 @@ import Foundation
 /// `internal`. The reason never holds raw provider text (privacy: telemetry and
 /// the user message both use this closed set, never the provider's error body).
 public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
-  /// No API key configured for the selected cloud provider, or the stored key
-  /// could not be read (re-entering it in Settings fixes both).
+  /// No API key configured for the selected cloud provider. A user-configuration
+  /// state, not a defect.
   case apiKeyMissing
+  /// A key IS configured but the stored value could not be read (corrupt or
+  /// inaccessible Keychain entry, entitlement change, migration bug). This is an
+  /// EnviousWispr defect and keeps its own alerting fingerprint, which is the
+  /// whole reason it is split from `apiKeyMissing` (#1446). The user-facing copy
+  /// is deliberately identical: re-entering the key in Settings fixes both.
+  case apiKeyUnreadable
   /// The provider rejected the supplied key (401; Gemini `API_KEY_INVALID`).
   case apiKeyRejected
   /// 403: permissions / billing-disabled / API-disabled / region.
@@ -74,6 +112,7 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
   public var telemetryTag: String {
     switch self {
     case .apiKeyMissing: return "api_key_missing"
+    case .apiKeyUnreadable: return "api_key_unreadable"
     case .apiKeyRejected: return "api_key_rejected"
     case .accessDenied: return "access_denied"
     case .outOfCredits: return "out_of_credits"
@@ -91,11 +130,17 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
     }
   }
 
-  /// "skipped" for the not-really-broken cases (no key yet, too long, timed out);
-  /// "failed" for the rest.
+  /// "skipped" for the not-really-broken cases (no usable key yet, too long, timed
+  /// out); "failed" for the rest.
+  ///
+  /// `apiKeyUnreadable` shares `apiKeyMissing`'s arm on purpose: the user sees the
+  /// same actionable sentence and the same not-broken tone, because re-entering
+  /// the key fixes both. Only the telemetry channel differs (#1446). The shared
+  /// arm makes that parity structural rather than something a `default:` could
+  /// silently break.
   public var leadIn: LeadIn {
     switch self {
-    case .apiKeyMissing, .inputTooLong, .timedOut: return .skipped
+    case .apiKeyMissing, .apiKeyUnreadable, .inputTooLong, .timedOut: return .skipped
     default: return .failed
     }
   }
@@ -111,6 +156,61 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
     }
   }
 
+  /// Which telemetry channel a LIVE polish failure earns (#1446).
+  ///
+  /// `provider` is consulted for exactly ONE reason — `modelUnavailable` — because
+  /// that is the only reason whose MEANING changes with where the provider runs:
+  /// a model the user never pulled into Ollama is their setup, while a cloud model
+  /// our Picker offered and the provider then 404s is a dead id in OUR catalog.
+  /// The gate is `.ollama` specifically, not "any local provider": EG-1's server is
+  /// one WE spawn and manage. (Today EG-1 reaches the runner only through its own
+  /// silent-skip path, so that arm is a guarantee for a future throw, not a live
+  /// one.)
+  ///
+  /// `providerUnreachable` is NOT provider-keyed, though it is tempting. On a cloud
+  /// provider it arrives as `URLError.notConnectedToInternet` / `.dataNotAllowed` /
+  /// `.internationalRoamingOff` / `.networkConnectionLost` — the user's own network,
+  /// VPN, or firewall. Alerting on it would page us for every user who dictates on
+  /// a plane. A genuinely broken base URL or ATS setting is not lost with it: that
+  /// breaks EVERY cloud user at once and shows up as a `llm.polish_failed` rate
+  /// cliff, which is what the durable event exists to make queryable. The same
+  /// argument retires the whole "a spike here MIGHT mean we regressed" school of
+  /// alerting: a real regression moves the rate, and the rate is now measured.
+  ///
+  /// Exhaustive on purpose — no `default:`. A future reason is a compile error
+  /// until it chooses a channel, which is the only completeness guarantee this
+  /// classification gets for free. (Correctness of the choice is a test's job;
+  /// see `PolishFailureReasonTests`.)
+  public func telemetryChannel(provider: LLMProvider) -> PolishFailureTelemetryChannel {
+    switch self {
+    // OUR code: we built the request wrong, mis-parsed the response, failed to
+    // classify the error, could not read a key we had stored, or blew the polish
+    // budget WE set (`timedOut` is our own `TimeoutError`, never a network one).
+    case .badRequest, .emptyResponse, .unknown, .apiKeyUnreadable, .timedOut:
+      return .alertingSentryError
+    // A cloud model id our catalog offered but the provider rejects is a dead id
+    // we shipped; an Ollama model the user never pulled is their setup.
+    case .modelUnavailable:
+      return provider == .ollama ? .nonAlertingAnalytics : .alertingSentryError
+    // Everything the user or the provider owns: their network, machine, key,
+    // account, billing, quota, dictation length, or the provider's own outage and
+    // content rules. No code change of ours alters any of these outcomes.
+    //
+    // These are NOT defects, and treating them as such filed GitHub issues about
+    // nothing (#1421 / #1424 / #1423 / #1422 / #1318). They ARE valuable: the
+    // `llm.polish_failed` rate per reason tells us which walls real users hit, so
+    // we can answer with guides and in-app education (founder directive
+    // 2026-07-09). Analytics is where that question gets answered; Sentry is not.
+    //
+    // (`rateLimitedOrQuota` is the documented blind spot: it would also cover a
+    // retry storm of ours. #1446 §14.2.)
+    case .providerUnreachable, .apiKeyMissing, .apiKeyRejected, .accessDenied,
+      .outOfCredits, .rateLimited, .rateLimitedOrQuota, .providerServerError,
+      .contentBlocked, .inputTooLong:
+      return .nonAlertingAnalytics
+    }
+  }
+
   /// The actionable user sentence (no lead-in). Always rendered with a concrete
   /// provider by the runner; `<Provider>` is the hardcoded display name, never a
   /// user host URL.
@@ -118,7 +218,9 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
     let name = provider.displayName
     let isOllama = provider == .ollama
     switch self {
-    case .apiKeyMissing:
+    case .apiKeyMissing, .apiKeyUnreadable:
+      // One arm, not two: copy parity between the two key reasons is a contract
+      // (#1446), and a shared arm cannot drift the way two arms can.
       return "no \(name) API key set yet. Add one in Settings."
     case .apiKeyRejected:
       return "\(name) rejected your API key. Check or replace it in Settings."
@@ -237,11 +339,17 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
         // #1305: the runner handles this case on its dedicated surfaced-skip
         // arm before reaching here. Defensive unwrap for any other caller.
         return reason
-      case .frameworkUnavailable, .modelNotReady,
+      case .modelNotReady:
+        // The on-device model is not usable yet (still downloading, or
+        // org-restricted). Reached since #1446: an Apple Intelligence failure is
+        // surfaced, not silently skipped, and the runner now classifies it to
+        // count `llm.polish_failed`. `.modelUnavailable` is the truthful reason —
+        // it means exactly "the selected model isn't available".
+        return .modelUnavailable
+      case .frameworkUnavailable,
         .unsupportedInputLanguage, .outputLanguageDrift, .egOneSkipped:
-        // Silent-skip cases the runner never routes here (AFM is excluded;
-        // language gates and EG-1 bypasses, #1271, are silent skips).
-        // Defensive.
+        // Silent-skip cases the runner never routes here (permanent AFM
+        // incapability, language gates, and EG-1 bypasses, #1271). Defensive.
         return .unknown
       }
     }

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -69,8 +69,10 @@ public final class RecoveryTextProcessor {
       emojiRestore: EmojiRestoreStep())
     // #945: crash-recovery polish failures stay silent in telemetry (this is a
     // live-only metric). A recovered take that fails to polish still returns its
-    // `polishError` in the outcome, but no `polish_provider_failed` event fires.
-    self.runner = TextProcessingRunner(captureError: { _, _, _, _, _, _ in })
+    // `polishError` in the outcome, but nothing is reported.
+    // #1446: `.silent` names every seam at once, so a future seam cannot be added
+    // and left live here by accident. See `TextProcessingRunner.TelemetrySeams`.
+    self.runner = TextProcessingRunner(telemetry: .silent)
   }
 
   /// Apply the recording's record-time settings snapshot so recovery replays

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -69,9 +69,11 @@ public final class RecoveryTextProcessor {
       emojiRestore: EmojiRestoreStep())
     // #945: crash-recovery polish failures stay silent in telemetry (this is a
     // live-only metric). A recovered take that fails to polish still returns its
-    // `polishError` in the outcome, but nothing is reported.
-    // #1446: `.silent` names every seam at once, so a future seam cannot be added
-    // and left live here by accident. See `TextProcessingRunner.TelemetrySeams`.
+    // `polishError` in the outcome, but the RUNNER reports nothing.
+    // #1446: `.silent` names every runner-owned seam at once, so a future seam
+    // cannot be added and left live here by accident. It does NOT reach
+    // `LLMPolishStep`'s own emitters, which still fire on a recovered take —
+    // see `TextProcessingRunner.TelemetrySeams.silent` and #1461.
     self.runner = TextProcessingRunner(telemetry: .silent)
   }
 

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -63,22 +63,35 @@ internal final class TextProcessingRunner {
   /// fired." Parameters: provider, model, reason tag, isTimeout.
   typealias RecordPolishFailed = @MainActor (String, String, String, Bool) -> Void
 
-  /// Every telemetry seam the runner owns, as ONE value (#1446).
+  /// Durable record of a LIVE polish that was never ATTEMPTED — the AFM
+  /// context-window skips (#1055), EG-1 bypasses (#1271), and the Ollama readiness
+  /// preflight (#1305). Parameters: provider, skip reason.
+  typealias RecordPolishSkipped = @MainActor (String, String) -> Void
+
+  /// Every POLISH telemetry seam the runner owns, as ONE value (#1446).
   ///
-  /// The point is `silent`. Crash recovery must emit nothing (#945: a live-only
-  /// metric), and when the runner had a single `captureError` seam the caller
-  /// expressed that by passing one no-op closure. Adding a second seam quietly
-  /// broke that: a caller could silence one and leave the other live, with nothing
-  /// to catch it. Bundling them means `silent` is the single place that answers
-  /// "what does silence mean," and the memberwise initializer forces any FUTURE
-  /// seam to be named there before this file compiles.
+  /// The point is `silent`. Crash recovery must emit no polish telemetry (#945: a
+  /// live-only metric), and when the runner had a single `captureError` seam the
+  /// caller expressed that by passing one no-op closure. Adding a second seam
+  /// quietly broke that: a caller could silence one and leave the other live, with
+  /// nothing to catch it. Bundling them means `silent` is the single place that
+  /// answers "what does silence mean," and the memberwise initializer forces any
+  /// FUTURE seam to be named there before this file compiles.
   ///
-  /// So the bug class is not tested for; it is unwritable.
+  /// So the bug class is not tested for; it is unwritable. (`recordPolishSkipped`
+  /// is the third seam, found by the cloud reviewer on PR #1460 while it was still
+  /// calling `TelemetryService.shared` directly — proof the trap is real.)
+  ///
+  /// NOT in here, deliberately: `customWordsTimeoutFired` (#657). That is a
+  /// custom-words performance metric, not polish telemetry, and #945's live-only
+  /// decision is scoped to polish. A recovered take whose word-correction step
+  /// blows its cap SHOULD still report it.
   struct TelemetrySeams {
     let captureError: CaptureError
     let recordPolishFailed: RecordPolishFailed
+    let recordPolishSkipped: RecordPolishSkipped
 
-    /// Production: alerting Sentry events plus the counted `llm.polish_failed`.
+    /// Production: alerting Sentry events plus the counted `llm.polish_*` events.
     static let live = TelemetrySeams(
       captureError: { error, category, stage, extra, tags, fingerprintDetail in
         SentryBreadcrumb.captureError(
@@ -96,20 +109,26 @@ internal final class TextProcessingRunner {
         )
         TelemetryService.shared.polishFailed(
           provider: provider, model: model, reason: reason, isTimeout: isTimeout)
+      },
+      recordPolishSkipped: { provider, reason in
+        TelemetryService.shared.polishSkipped(provider: provider, reason: reason)
       })
 
     /// Crash recovery (#945, #1446): a recovered take that fails to polish still
     /// returns its `polishError`, but emits no Sentry event, no breadcrumb, and no
-    /// `llm.polish_failed`. Polish telemetry is a LIVE-dictation metric.
+    /// `llm.polish_failed` / `llm.polish_skipped`. Polish telemetry is a
+    /// LIVE-dictation metric.
     static let silent = TelemetrySeams(
       captureError: { _, _, _, _, _, _ in },
-      recordPolishFailed: { _, _, _, _ in })
+      recordPolishFailed: { _, _, _, _ in },
+      recordPolishSkipped: { _, _ in })
   }
 
   private let logger: any PipelineLogging
   private let timeoutExecutor: TimeoutExecutor
   private let captureError: CaptureError
   private let recordPolishFailed: RecordPolishFailed
+  private let recordPolishSkipped: RecordPolishSkipped
 
   init(
     logger: any PipelineLogging = AppLoggerAdapter(),
@@ -132,6 +151,7 @@ internal final class TextProcessingRunner {
     self.logger = logger
     self.captureError = telemetry.captureError
     self.recordPolishFailed = telemetry.recordPolishFailed
+    self.recordPolishSkipped = telemetry.recordPolishSkipped
     self.timeoutExecutor = timeoutExecutor
   }
 
@@ -380,25 +400,20 @@ internal final class TextProcessingRunner {
         if let cw = contextWindowSkip {
           let skipReason =
             cw.stage == .predicted ? "context_window_predicted" : "context_window_caught"
-          TelemetryService.shared.polishSkipped(
-            provider: LLMProvider.appleIntelligence.rawValue, reason: skipReason)
+          recordPolishSkipped(LLMProvider.appleIntelligence.rawValue, skipReason)
         } else if isAppleIntelligencePolishTimeout {
-          TelemetryService.shared.polishSkipped(
-            provider: LLMProvider.appleIntelligence.rawValue, reason: "context_window_timeout")
+          recordPolishSkipped(LLMProvider.appleIntelligence.rawValue, "context_window_timeout")
         } else if isEGOnePolishTimeout {
           // #1271: one `local_polish_` prefix family for every EG-1 skip mode.
-          TelemetryService.shared.polishSkipped(
-            provider: LLMProvider.egOne.rawValue, reason: "local_polish_timeout")
+          recordPolishSkipped(LLMProvider.egOne.rawValue, "local_polish_timeout")
         } else if let egOneSkipReason {
-          TelemetryService.shared.polishSkipped(
-            provider: LLMProvider.egOne.rawValue, reason: egOneSkipReason)
+          recordPolishSkipped(LLMProvider.egOne.rawValue, egOneSkipReason)
         } else if let skipReason = localPolishSkipReason?.ollamaPreflightSkipTelemetryReason {
           // #1305: preflight skips ride the same lightweight `local_polish_`
           // reason family as EG-1 — the observability split between "preflight
           // said not ready" (here) and "mid-flight failure on a running
           // server" (the capture path above) falls out of the reason strings.
-          TelemetryService.shared.polishSkipped(
-            provider: LLMProvider.ollama.rawValue, reason: skipReason)
+          recordPolishSkipped(LLMProvider.ollama.rawValue, skipReason)
         }
         // #657 (2026-05-05): emit cap-trip telemetry when WordCorrectionStep
         // exceeds its 3s `maxDuration`. The step's result was discarded; raw

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -115,9 +115,19 @@ internal final class TextProcessingRunner {
       })
 
     /// Crash recovery (#945, #1446): a recovered take that fails to polish still
-    /// returns its `polishError`, but emits no Sentry event, no breadcrumb, and no
-    /// `llm.polish_failed` / `llm.polish_skipped`. Polish telemetry is a
+    /// returns its `polishError`, but the RUNNER reports nothing — no
+    /// `polish_provider_failed` Sentry event, no attempt-failed breadcrumb, no
+    /// `llm.polish_failed`, no `llm.polish_skipped`. Polish telemetry is a
     /// LIVE-dictation metric.
+    ///
+    /// SCOPE, precisely: this silences the three seams the RUNNER owns. It cannot
+    /// reach `LLMPolishStep`'s own five emitters (`limbFailureObserved`, the
+    /// "LLM polish started" / "completed" breadcrumbs, its `captureError`, and
+    /// `captureAFMPolishError`), which fire from inside the step on a recovered
+    /// take exactly as they do live. Whether recovery should silence those too is a
+    /// separate question with a different owner — tracked in #1461, not papered
+    /// over here. (Cloud review of PR #1460 caught the earlier version of this
+    /// comment claiming recovery emitted "no Sentry event, no breadcrumb"; it does.)
     static let silent = TelemetrySeams(
       captureError: { _, _, _, _, _, _ in },
       recordPolishFailed: { _, _, _, _ in },

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -50,18 +50,70 @@ internal final class TextProcessingRunner {
     any Error, SentryBreadcrumb.ErrorCategory, String, [String: Any]?, [String: String], String?
   ) -> Void
 
+  /// Durable, non-alerting record of a LIVE attempted-polish failure (#1446),
+  /// mirroring `captureError`. Production leaves a Sentry breadcrumb and emits the
+  /// counted `llm.polish_failed` event; `RecoveryTextProcessor` injects a no-op
+  /// (the same reason `captureError` is no-op'd there — this is a live-only
+  /// metric, #945); tests inject a spy. Fire-and-forget / non-throwing, so
+  /// telemetry can never break the limb-failure continuation (heart & limbs).
+  ///
+  /// Fires on EVERY live attempted-polish failure, both channels — unlike
+  /// `captureError`, which fires only for the regression-capable subset. That
+  /// asymmetry is what lets a test assert "the durable record exists AND no alert
+  /// fired." Parameters: provider, model, reason tag, isTimeout.
+  typealias RecordPolishFailed = @MainActor (String, String, String, Bool) -> Void
+
+  /// Every telemetry seam the runner owns, as ONE value (#1446).
+  ///
+  /// The point is `silent`. Crash recovery must emit nothing (#945: a live-only
+  /// metric), and when the runner had a single `captureError` seam the caller
+  /// expressed that by passing one no-op closure. Adding a second seam quietly
+  /// broke that: a caller could silence one and leave the other live, with nothing
+  /// to catch it. Bundling them means `silent` is the single place that answers
+  /// "what does silence mean," and the memberwise initializer forces any FUTURE
+  /// seam to be named there before this file compiles.
+  ///
+  /// So the bug class is not tested for; it is unwritable.
+  struct TelemetrySeams {
+    let captureError: CaptureError
+    let recordPolishFailed: RecordPolishFailed
+
+    /// Production: alerting Sentry events plus the counted `llm.polish_failed`.
+    static let live = TelemetrySeams(
+      captureError: { error, category, stage, extra, tags, fingerprintDetail in
+        SentryBreadcrumb.captureError(
+          error, category: category, stage: stage, extra: extra, tags: tags,
+          fingerprintDetail: fingerprintDetail)
+      },
+      recordPolishFailed: { provider, model, reason, isTimeout in
+        // Sibling of LLMPolishStep's "LLM polish started" / "LLM polish completed"
+        // crumbs; the distinct wording keeps this trail entry legible next to
+        // theirs (they also carry `model`).
+        SentryBreadcrumb.add(
+          stage: "polish",
+          message: "LLM polish attempt failed (\(reason)); continuing with deterministic text",
+          data: ["provider": provider, "model": model, "is_timeout": isTimeout]
+        )
+        TelemetryService.shared.polishFailed(
+          provider: provider, model: model, reason: reason, isTimeout: isTimeout)
+      })
+
+    /// Crash recovery (#945, #1446): a recovered take that fails to polish still
+    /// returns its `polishError`, but emits no Sentry event, no breadcrumb, and no
+    /// `llm.polish_failed`. Polish telemetry is a LIVE-dictation metric.
+    static let silent = TelemetrySeams(
+      captureError: { _, _, _, _, _, _ in },
+      recordPolishFailed: { _, _, _, _ in })
+  }
+
   private let logger: any PipelineLogging
   private let timeoutExecutor: TimeoutExecutor
   private let captureError: CaptureError
+  private let recordPolishFailed: RecordPolishFailed
 
   init(
     logger: any PipelineLogging = AppLoggerAdapter(),
-    captureError: @escaping CaptureError = {
-      error, category, stage, extra, tags, fingerprintDetail in
-      SentryBreadcrumb.captureError(
-        error, category: category, stage: stage, extra: extra, tags: tags,
-        fingerprintDetail: fingerprintDetail)
-    },
+    telemetry: TelemetrySeams = .live,
     timeoutExecutor: @escaping TimeoutExecutor = { seconds, op in
       // nonisolated(unsafe) bridges @MainActor `op` to withThrowingTimeout's
       // @Sendable contract. Safety: op is @MainActor and its return value
@@ -78,7 +130,8 @@ internal final class TextProcessingRunner {
     }
   ) {
     self.logger = logger
-    self.captureError = captureError
+    self.captureError = telemetry.captureError
+    self.recordPolishFailed = telemetry.recordPolishFailed
     self.timeoutExecutor = timeoutExecutor
   }
 
@@ -257,38 +310,61 @@ internal final class TextProcessingRunner {
           && !isEGOnePolishTimeout
           && !isCancellationLike
         {
+          let model = polishModelAtStart ?? "unknown"
           if let provider = polishProviderAtStart, provider != .appleIntelligence {
             // Cloud (OpenAI/Gemini) or local (Ollama): classify the specific
             // reason once, then feed it into BOTH the self-contained on-screen
-            // notice and the telemetry reason tag (#945). The capture is
+            // notice and the telemetry reason tag (#945). Both emits are
             // fire-and-forget; the raw transcript/prompt/provider-body never
             // leave the device (the reason set is closed and content-free).
             let reason = PolishFailureReason.from(error)
             polishError = reason.composedMessage(provider: provider)
-            captureError(
-              error,
-              .polishProviderFailed,
-              "polish",
-              [
-                "provider": provider.rawValue,
-                "model": polishModelAtStart ?? "unknown",
-                "is_timeout": isTimeout,
-              ],
-              [
-                "polish.error_case": reason.telemetryTag,
-                "polish.provider": provider.rawValue,
-                "polish.is_timeout": isTimeout ? "true" : "false",
-              ],
-              // Split the Sentry issue per reason: `.classified` bridges every
-              // reason to one NSError code, so the tag alone would merge them.
-              reason.telemetryTag
-            )
+            // #1446: EVERY attempted-and-failed polish gets a durable counted
+            // record, whatever its channel. Sentry alerting is the interrupting
+            // SUBSET below, not the record itself.
+            recordPolishFailed(provider.rawValue, model, reason.telemetryTag, isTimeout)
+            // #1446: alert only where a spike could plausibly mean WE regressed.
+            // A user out of credits, over quota, with no key, or with Ollama shut
+            // down is not a defect: those reasons are counted, never paged. The
+            // reason owns this policy (`telemetryChannel`); the runner only reads
+            // it. Locked by the (reason x provider) matrix test.
+            if reason.telemetryChannel(provider: provider) == .alertingSentryError {
+              captureError(
+                error,
+                .polishProviderFailed,
+                "polish",
+                [
+                  "provider": provider.rawValue,
+                  "model": model,
+                  "is_timeout": isTimeout,
+                ],
+                [
+                  "polish.error_case": reason.telemetryTag,
+                  "polish.provider": provider.rawValue,
+                  "polish.is_timeout": isTimeout ? "true" : "false",
+                ],
+                // Split the Sentry issue per reason: `.classified` bridges every
+                // reason to one NSError code, so the tag alone would merge them.
+                reason.telemetryTag
+              )
+            }
           } else if polishProviderAtStart == .appleIntelligence {
             // Apple Intelligence: preserve today's exact wording byte-for-byte.
             // The view now renders `polishError` verbatim, so the runner owns the
             // "AI polish failed:" prefix here. AFM generation failures are
-            // captured at the polish step, so no capture fires here.
+            // captured at the polish step, so no Sentry capture fires here.
             polishError = "AI polish failed: " + error.localizedDescription
+            // #1446: the durable count MUST still cover this arm. An AFM success
+            // emits `llm.polish_completed`, so omitting its failures would leave
+            // `llm.polish_failed` unable to partition live polish outcomes and
+            // would undercount the on-device failure rate. Only the ALERTING
+            // channel is owned elsewhere (the step's `captureAFMPolishError`);
+            // the count is ours. Silent AFM skips never reach here — they are
+            // excluded by `isSilentPolishSkip` / `contextWindowSkip` /
+            // `isAppleIntelligencePolishTimeout` above.
+            recordPolishFailed(
+              LLMProvider.appleIntelligence.rawValue, model,
+              PolishFailureReason.from(error).telemetryTag, isTimeout)
           } else {
             // No polish-provider snapshot: a non-LLMPolishStep surfacing step
             // (only reachable in tests; production's sole `.surface` step is

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -910,6 +910,35 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("llm.polish_skipped", properties: props)
   }
 
+  /// #1446: AI polish was ATTEMPTED and threw. The third and last outcome, disjoint
+  /// from `llm.polish_completed` (attempted, succeeded) and `llm.polish_skipped`
+  /// (never attempted) — together the three partition every live polish outcome.
+  ///
+  /// Fires for EVERY live attempted-polish failure, whether or not the reason also
+  /// earns an alerting Sentry error. That makes this the durable, complete record
+  /// of the failure rate: no Sentry-union query is needed to compute it. Crash
+  /// recovery deliberately emits nothing (a live-only metric, #945).
+  ///
+  /// `reason` is a `PolishFailureReason.telemetryTag` — a closed, content-free set.
+  /// `model` is catalog metadata, matching what `llm.polish_completed` already
+  /// sends. No transcript, prompt, provider error body, key, or endpoint URL.
+  public func polishFailed(provider: String, model: String, reason: String, isTimeout: Bool) {
+    let props: [String: Any] = [
+      "provider": provider,
+      "model": model,
+      "reason": reason,
+      "is_timeout": isTimeout,
+    ]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "llm.polish_failed",
+          stringProps: ["provider": provider, "model": model, "reason": reason],
+          boolProps: ["is_timeout": isTimeout]))
+    #endif
+    PostHogSDK.shared.capture("llm.polish_failed", properties: props)
+  }
+
   /// #1271: EG-1 native model download funnel + health transitions. Content-
   /// free by construction: model identity comes from OUR manifest, reasons
   /// are a closed string set, and no transcript or prompt content exists on

--- a/Tests/EnviousWisprTests/LLM/ConnectorAPIKeyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/ConnectorAPIKeyTests.swift
@@ -1,0 +1,187 @@
+import EnviousWisprCore
+import Foundation
+import Security
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #1446: `getAPIKey` used to throw `.apiKeyMissing` from BOTH of its exits — the
+/// `guard` that fires when no key was ever configured (the user's own setup) and
+/// the `catch` that fires when a stored key could not be read (a Keychain
+/// migration, entitlement, or corruption bug of OURS). One reason, one Sentry
+/// fingerprint, so a real regression was indistinguishable from a fresh install.
+///
+/// The exhaustive `switch` in `telemetryChannel` proves every reason CHOOSES a
+/// channel; it can never prove that a thrown error is CLASSIFIED as the right
+/// reason. Only these tests can, which is why they exist: if the catch arm ever
+/// reverts to `.apiKeyMissing`, a Keychain regression silently stops paging us
+/// and nothing else in the suite notices.
+///
+/// Both exits are reached with no network: `getAPIKey` is the first statement of
+/// `polish`, so the throw happens before any request is built.
+@Suite("Connector API-key classification")
+struct ConnectorAPIKeyTests {
+
+  /// Stands in for a key that was never saved. Reports absence the way the real
+  /// stores do, with `errSecItemNotFound`.
+  private struct EmptyKeyStore: LegacyKeyFileStorage {
+    func store(key: String, value: String) throws {}
+    func retrieve(key: String) throws -> String {
+      throw KeyStoreError.retrieveFailed(errSecItemNotFound)
+    }
+    func delete(key: String) throws {}
+  }
+
+  /// Stands in for a key that IS stored but cannot be read back: a corrupt entry,
+  /// a locked Keychain, a missing entitlement. `-1` is what both real stores report
+  /// for "the item is there but its bytes would not come back."
+  private struct UnreadableKeyStore: LegacyKeyFileStorage {
+    func store(key: String, value: String) throws { throw KeyStoreError.storeFailed(-1) }
+    func retrieve(key: String) throws -> String { throw KeyStoreError.retrieveFailed(-1) }
+    func delete(key: String) throws {}
+  }
+
+  /// The `.legacyFiles` backend is the DEBUG/dev one (`KeychainManager` fails closed
+  /// away from the production Keychain), so these never touch the founder's real keys.
+  private func emptyKeychain() -> KeychainManager {
+    KeychainManager(backend: .legacyFiles, legacyStore: EmptyKeyStore())
+  }
+
+  private func unreadableKeychain() -> KeychainManager {
+    KeychainManager(backend: .legacyFiles, legacyStore: UnreadableKeyStore())
+  }
+
+  private func config(keychainId: String?) -> LLMProviderConfig {
+    LLMProviderConfig(
+      model: "test-model", apiKeyKeychainId: keychainId, maxTokens: 64,
+      temperature: 0, thinkingBudget: nil, reasoningEffort: nil)
+  }
+
+  // MARK: - No key was ever saved: the user's setup, not a defect
+
+  /// THE production shape, and the one that matters. `LLMPolishStep` hands the
+  /// connector a fixed key id for every cloud provider (`KeychainManager.openAIKeyID`
+  /// / `.geminiKeyID`), whether or not a key was ever saved — so a fresh install with
+  /// cloud polish selected reaches the `catch`, never the `nil` guard. Classifying
+  /// that as `.apiKeyUnreadable` would page us for every no-key user and defeat the
+  /// entire downgrade. Absence must be read from the STORE, not from the id.
+  @Test(
+    "OpenAI with a key id but nothing stored -> apiKeyMissing (never apiKeyUnreadable)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "the no-key path reaches the catch arm, not the nil guard")
+  )
+  func openAIKeyIdButNothingStored() async {
+    let connector = OpenAIConnector(keychainManager: emptyKeychain())
+    await #expect(throws: LLMError.classified(.apiKeyMissing)) {
+      _ = try await connector.polish(
+        text: "hello there", instructions: .default,
+        config: config(keychainId: KeychainManager.openAIKeyID), onToken: nil)
+    }
+  }
+
+  @Test(
+    "Gemini with a key id but nothing stored -> apiKeyMissing (never apiKeyUnreadable)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "the no-key path reaches the catch arm, not the nil guard")
+  )
+  func geminiKeyIdButNothingStored() async {
+    let connector = GeminiConnector(keychainManager: emptyKeychain())
+    await #expect(throws: LLMError.classified(.apiKeyMissing)) {
+      _ = try await connector.polish(
+        text: "hello there", instructions: .default,
+        config: config(keychainId: KeychainManager.geminiKeyID), onToken: nil)
+    }
+  }
+
+  /// The `nil` guard is unreachable in production (see above) but must stay correct
+  /// for any future caller that omits the id.
+  @Test("OpenAI with no configured key id -> apiKeyMissing")
+  func openAINoKeyConfigured() async {
+    let connector = OpenAIConnector(keychainManager: unreadableKeychain())
+    await #expect(throws: LLMError.classified(.apiKeyMissing)) {
+      _ = try await connector.polish(
+        text: "hello there", instructions: .default, config: config(keychainId: nil),
+        onToken: nil)
+    }
+  }
+
+  @Test("Gemini with no configured key id -> apiKeyMissing")
+  func geminiNoKeyConfigured() async {
+    let connector = GeminiConnector(keychainManager: unreadableKeychain())
+    await #expect(throws: LLMError.classified(.apiKeyMissing)) {
+      _ = try await connector.polish(
+        text: "hello there", instructions: .default, config: config(keychainId: nil),
+        onToken: nil)
+    }
+  }
+
+  // MARK: - A key IS configured but cannot be read: our defect, its own fingerprint
+
+  @Test(
+    "OpenAI with a stored-but-unreadable key -> apiKeyUnreadable, not apiKeyMissing",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "a Keychain-read defect hid behind a user-configuration state")
+  )
+  func openAIStoredKeyUnreadable() async {
+    let connector = OpenAIConnector(keychainManager: unreadableKeychain())
+    await #expect(throws: LLMError.classified(.apiKeyUnreadable)) {
+      _ = try await connector.polish(
+        text: "hello there", instructions: .default,
+        config: config(keychainId: KeychainManager.openAIKeyID), onToken: nil)
+    }
+  }
+
+  @Test(
+    "Gemini with a stored-but-unreadable key -> apiKeyUnreadable, not apiKeyMissing",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "a Keychain-read defect hid behind a user-configuration state")
+  )
+  func geminiStoredKeyUnreadable() async {
+    let connector = GeminiConnector(keychainManager: unreadableKeychain())
+    await #expect(throws: LLMError.classified(.apiKeyUnreadable)) {
+      _ = try await connector.polish(
+        text: "hello there", instructions: .default,
+        config: config(keychainId: KeychainManager.geminiKeyID), onToken: nil)
+    }
+  }
+
+  // MARK: - Adversarial: the two exits must not collapse back into one
+
+  @Test("the two key failures are distinguishable to us and identical to the user")
+  func exitsStayDistinct() async throws {
+    // Same connector, same config, same key id — only the STORE's answer differs.
+    // That is the whole distinction, so the test isolates exactly it.
+    let cfg = config(keychainId: KeychainManager.openAIKeyID)
+
+    var missing: PolishFailureReason?
+    do {
+      _ = try await OpenAIConnector(keychainManager: emptyKeychain())
+        .polish(text: "hello there", instructions: .default, config: cfg, onToken: nil)
+    } catch let error as LLMError {
+      missing = PolishFailureReason.from(error)
+    }
+    var unreadable: PolishFailureReason?
+    do {
+      _ = try await OpenAIConnector(keychainManager: unreadableKeychain())
+        .polish(text: "hello there", instructions: .default, config: cfg, onToken: nil)
+    } catch let error as LLMError {
+      unreadable = PolishFailureReason.from(error)
+    }
+
+    let missingReason = try #require(missing)
+    let unreadableReason = try #require(unreadable)
+    #expect(missingReason != unreadableReason)
+    // Different fingerprint, different channel...
+    #expect(missingReason.telemetryTag != unreadableReason.telemetryTag)
+    #expect(missingReason.telemetryChannel(provider: .openAI) == .nonAlertingAnalytics)
+    #expect(unreadableReason.telemetryChannel(provider: .openAI) == .alertingSentryError)
+    // ...but the same sentence on screen, because re-entering the key fixes both.
+    #expect(
+      missingReason.composedMessage(provider: .openAI)
+        == unreadableReason.composedMessage(provider: .openAI))
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
@@ -358,6 +358,45 @@ struct KeychainManagerTests {
         atPath: dir.appendingPathComponent(KeychainManager.openAIKeyID).path))
   }
 
+  /// #1446: absence must be reported as `errSecItemNotFound`, distinctly from a
+  /// generic read failure. The cloud connectors classify on exactly this: absence
+  /// is the user's configuration state (counted, never alerted), while any other
+  /// read failure is a defect of ours (its own alerting Sentry fingerprint). If a
+  /// missing key ever reports a generic `-1` again, every no-key user pages us.
+  @Test(
+    "retrieve of a key that was never stored reports errSecItemNotFound, on both backends",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "a missing key must be distinguishable from an unreadable one")
+  )
+  func retrieveOfAbsentKeyReportsItemNotFound() throws {
+    func statusOfAbsentRetrieve(from manager: KeychainManager) -> OSStatus? {
+      do {
+        _ = try manager.retrieve(key: KeychainManager.openAIKeyID)
+        return nil
+      } catch KeyStoreError.retrieveFailed(let status) {
+        return status
+      } catch {
+        return nil
+      }
+    }
+
+    // Dev / DEBUG backend: no file on disk.
+    let devDir = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: devDir) }
+    let devManager = KeychainManager(
+      backend: .legacyFiles, legacyStore: FileLegacyKeyStore(storageDirectory: devDir))
+    #expect(statusOfAbsentRetrieve(from: devManager) == errSecItemNotFound)
+
+    // Release backend: no Keychain item AND no legacy file to migrate.
+    let releaseDir = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: releaseDir) }
+    let releaseManager = releaseStyleManager(
+      legacyStore: FileLegacyKeyStore(storageDirectory: releaseDir),
+      keychainStore: InMemoryKeychainStore())
+    #expect(statusOfAbsentRetrieve(from: releaseManager) == errSecItemNotFound)
+  }
+
   @Test("release retrieve surfaces non-missing Keychain failures")
   func releaseRetrieveDoesNotFallBackForNonMissingKeychainFailure() throws {
     let dir = try makeTempDirectory()

--- a/Tests/EnviousWisprTests/LLM/PolishFailureReasonTests.swift
+++ b/Tests/EnviousWisprTests/LLM/PolishFailureReasonTests.swift
@@ -16,6 +16,7 @@ struct PolishFailureReasonTests {
     "each reason has its stable low-cardinality telemetry tag",
     arguments: [
       (PolishFailureReason.apiKeyMissing, "api_key_missing"),
+      (.apiKeyUnreadable, "api_key_unreadable"),
       (.apiKeyRejected, "api_key_rejected"),
       (.accessDenied, "access_denied"),
       (.outOfCredits, "out_of_credits"),
@@ -47,6 +48,7 @@ struct PolishFailureReasonTests {
     "not-really-broken reasons lead with 'AI cleanup skipped:'",
     arguments: [
       PolishFailureReason.apiKeyMissing,
+      PolishFailureReason.apiKeyUnreadable,
       PolishFailureReason.inputTooLong,
       PolishFailureReason.timedOut,
     ])
@@ -228,5 +230,212 @@ struct PolishFailureReasonTests {
   func rejectedVsMissingDistinct() {
     #expect(PolishFailureReason.apiKeyRejected.leadIn == .failed)
     #expect(PolishFailureReason.apiKeyMissing.leadIn == .skipped)
+  }
+
+  // MARK: - Telemetry channel (#1446)
+
+  /// OUR bugs, on any provider: a request we built wrong, a response we mis-parsed,
+  /// an error we failed to classify, a key we stored and then could not read, and
+  /// the polish budget WE set expiring. Spelled out longhand rather than derived
+  /// from the production switch, so changing the policy forces a deliberate edit
+  /// here too.
+  private static let alwaysAlerting: Set<PolishFailureReason> = [
+    .badRequest, .emptyResponse, .unknown, .apiKeyUnreadable, .timedOut,
+  ]
+  /// The one reason whose MEANING depends on where the provider runs: a model the
+  /// user never pulled into Ollama is their setup; a cloud model our Picker offered
+  /// and the provider then 404s is a dead id in our catalog.
+  private static let alertingUnlessOllama: Set<PolishFailureReason> = [
+    .modelUnavailable
+  ]
+  /// Everything the user or the provider owns: their network, machine, key, account,
+  /// billing, quota, dictation length, and the provider's own outage and content
+  /// rules. Counted, never paged — no code change of ours alters the outcome, so a
+  /// GitHub issue would have nothing to fix. The COUNT is the point: it tells us
+  /// which walls users hit, which we answer with guides, not commits.
+  private static let neverAlerting: Set<PolishFailureReason> = [
+    .providerUnreachable, .apiKeyMissing, .apiKeyRejected, .accessDenied,
+    .outOfCredits, .rateLimited, .rateLimitedOrQuota, .providerServerError,
+    .contentBlocked, .inputTooLong,
+  ]
+
+  @Test(
+    "the three expectation sets above partition every reason (no case silently untested)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "user-environment polish failures fired alerting Sentry errors")
+  )
+  func channelExpectationSetsPartitionAllCases() {
+    let union = Self.alwaysAlerting.union(Self.alertingUnlessOllama).union(Self.neverAlerting)
+    #expect(union == Set(PolishFailureReason.allCases))
+    let overlap =
+      Self.alwaysAlerting.intersection(Self.alertingUnlessOllama)
+      .union(Self.alwaysAlerting.intersection(Self.neverAlerting))
+      .union(Self.alertingUnlessOllama.intersection(Self.neverAlerting))
+    #expect(overlap.isEmpty)
+  }
+
+  @Test(
+    "every (reason x provider) pair lands in its pinned channel",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "user-environment polish failures fired alerting Sentry errors"),
+    arguments: PolishFailureReason.allCases, [LLMProvider.openAI, .gemini, .ollama]
+  )
+  func telemetryChannelMatrix(reason: PolishFailureReason, provider: LLMProvider) {
+    let expected: PolishFailureTelemetryChannel
+    if Self.alwaysAlerting.contains(reason) {
+      expected = .alertingSentryError
+    } else if Self.alertingUnlessOllama.contains(reason) {
+      expected = provider == .ollama ? .nonAlertingAnalytics : .alertingSentryError
+    } else {
+      expected = .nonAlertingAnalytics
+    }
+    #expect(
+      reason.telemetryChannel(provider: provider) == expected,
+      "\(reason) on \(provider) should be \(expected)")
+  }
+
+  @Test("the provider-keyed reason is the whole point: same reason, opposite channels")
+  func providerKeyedChannelsDiverge() {
+    for reason in Self.alertingUnlessOllama {
+      #expect(reason.telemetryChannel(provider: .ollama) == .nonAlertingAnalytics)
+      #expect(reason.telemetryChannel(provider: .openAI) == .alertingSentryError)
+      #expect(reason.telemetryChannel(provider: .gemini) == .alertingSentryError)
+    }
+  }
+
+  /// A user on a plane, on a train, behind a corporate firewall, or with a VPN up
+  /// must never page us — on ANY provider. `from(_:)` maps every one of these
+  /// `URLError`s onto `.providerUnreachable`, so the channel must hold for all of
+  /// them. This is the founder principle in `sentry-operations.md`
+  /// RULE: sentry-for-bugs-posthog-for-behaviour, which names "network" outright.
+  @Test(
+    "a user network outage is counted, never paged, on every provider",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "cloud providerUnreachable alerted on the user's own network"),
+    arguments: [
+      URLError.Code.notConnectedToInternet,
+      URLError.Code.networkConnectionLost,
+      URLError.Code.dataNotAllowed,
+      URLError.Code.internationalRoamingOff,
+      URLError.Code.cannotFindHost,
+      URLError.Code.cannotConnectToHost,
+      URLError.Code.dnsLookupFailed,
+      URLError.Code.timedOut,
+    ]
+  )
+  func userNetworkOutagesNeverAlert(code: URLError.Code) {
+    let reason = PolishFailureReason.from(URLError(code))
+    #expect(reason == .providerUnreachable)
+    for provider in [LLMProvider.openAI, .gemini, .ollama] {
+      #expect(reason.telemetryChannel(provider: provider) == .nonAlertingAnalytics)
+    }
+  }
+
+  /// The counterpart: OUR polish budget expiring is `TimeoutError`, not a `URLError`,
+  /// and it stays alerting. A budget that shrank or a prompt that ballooned is our
+  /// regression, and the two timeouts must not collapse into one channel.
+  @Test("our own polish-budget timeout still pages us, unlike a network timeout")
+  func ourBudgetTimeoutStillAlerts() {
+    #expect(PolishFailureReason.from(TimeoutError(seconds: 5)) == .timedOut)
+    #expect(
+      PolishFailureReason.timedOut.telemetryChannel(provider: .openAI) == .alertingSentryError)
+    #expect(
+      PolishFailureReason.from(URLError(.timedOut)).telemetryChannel(provider: .openAI)
+        == .nonAlertingAnalytics)
+  }
+
+  @Test("the user- and provider-owned reasons never page us, on any provider")
+  func userEnvironmentReasonsNeverAlert() {
+    for reason in Self.neverAlerting {
+      for provider in [LLMProvider.openAI, .gemini, .ollama] {
+        #expect(reason.telemetryChannel(provider: provider) == .nonAlertingAnalytics)
+      }
+    }
+  }
+
+  /// Four reasons tell the user "AI cleanup skipped" — nothing is broken. Exactly two
+  /// of them still page us, and both are OURS despite the reassuring copy:
+  ///   - `timedOut` — the deadline it blew is a budget WE chose, so a spike means our
+  ///     budget shrank or our prompt ballooned.
+  ///   - `apiKeyUnreadable` — we stored a key and then could not read it back. Its
+  ///     copy is deliberately identical to `apiKeyMissing` (re-entering the key fixes
+  ///     both), but only this one is a defect.
+  /// The other two are the user's own situation and are counted only. Pinned so a
+  /// future tidy-up cannot collapse the notice and the channel into each other: they
+  /// answer different questions — "is the user alarmed?" vs "is this our bug?"
+  @Test("the only reassuring-looking reasons that still page us are the two that are ours")
+  func onlyOurOwnFailuresAlertAmongSkipNotices() {
+    let skipNoticeReasons = PolishFailureReason.allCases.filter { $0.leadIn == .skipped }
+    #expect(
+      Set(skipNoticeReasons) == [.apiKeyMissing, .apiKeyUnreadable, .inputTooLong, .timedOut])
+
+    let alertingSkipNotices = skipNoticeReasons.filter {
+      $0.telemetryChannel(provider: .openAI) == .alertingSentryError
+    }
+    #expect(Set(alertingSkipNotices) == [.timedOut, .apiKeyUnreadable])
+  }
+
+  /// The whole point, stated once: alerting is reserved for OUR bugs.
+  @Test("nothing outside EnviousWispr's own defects can reach the alerting channel")
+  func alertingSetIsExactlyOurBugs() {
+    var alerting: Set<PolishFailureReason> = []
+    for reason in PolishFailureReason.allCases {
+      for provider in [LLMProvider.openAI, .gemini, .ollama] {
+        if reason.telemetryChannel(provider: provider) == .alertingSentryError {
+          alerting.insert(reason)
+        }
+      }
+    }
+    #expect(
+      alerting == [
+        .badRequest, .emptyResponse, .unknown, .apiKeyUnreadable, .timedOut,
+        .modelUnavailable,  // cloud only; Ollama's is the user's un-pulled model
+      ])
+  }
+
+  // MARK: - The apiKeyMissing / apiKeyUnreadable split (#1446)
+
+  @Test(
+    "apiKeyUnreadable is byte-identical to apiKeyMissing everywhere the USER can see",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "a Keychain-read defect hid behind a user-configuration state")
+  )
+  func unreadableKeyCopyParity() {
+    let unreadable = PolishFailureReason.apiKeyUnreadable
+    let missing = PolishFailureReason.apiKeyMissing
+    for provider in [LLMProvider.openAI, .gemini, .ollama] {
+      #expect(unreadable.message(provider: provider) == missing.message(provider: provider))
+      #expect(
+        unreadable.composedMessage(provider: provider)
+          == missing.composedMessage(provider: provider))
+      // The completion planner keys the skip-vs-hard-failure toast off this.
+      #expect(PolishFailureReason.isSkipNotice(unreadable.composedMessage(provider: provider)))
+    }
+    #expect(unreadable.leadIn == missing.leadIn)
+    #expect(unreadable.leadIn == .skipped)
+    #expect(unreadable.isRetryable == missing.isRetryable)
+    #expect(unreadable.isRetryable == false)
+  }
+
+  @Test("...and differs from apiKeyMissing in exactly the two ways that motivated the split")
+  func unreadableKeyTelemetryDiverges() {
+    // A distinct Sentry fingerprint...
+    #expect(PolishFailureReason.apiKeyUnreadable.telemetryTag == "api_key_unreadable")
+    #expect(
+      PolishFailureReason.apiKeyUnreadable.telemetryTag
+        != PolishFailureReason.apiKeyMissing.telemetryTag)
+    // ...and the opposite channel: our defect pages, the user's config does not.
+    for provider in [LLMProvider.openAI, .gemini, .ollama] {
+      #expect(
+        PolishFailureReason.apiKeyUnreadable.telemetryChannel(provider: provider)
+          == .alertingSentryError)
+      #expect(
+        PolishFailureReason.apiKeyMissing.telemetryChannel(provider: provider)
+          == .nonAlertingAnalytics)
+    }
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
@@ -59,10 +59,14 @@ struct EGOnePipelineRoutingTests {
     -> TextProcessingRunResult
   {
     let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
-    // EG-1 skips fire neither seam; the record seam is no-op'd so this suite can
-    // never reach the real PostHog client (#1446).
+    // EG-1 bypasses fire no capture and no failure record; they DO emit a
+    // `llm.polish_skipped`, so that seam stays live. The failure seam is no-op'd
+    // so this suite can never reach the real PostHog failure client (#1446).
     let runner = TextProcessingRunner(
-      telemetry: .init(captureError: spy.sink, recordPolishFailed: { _, _, _, _ in }),
+      telemetry: .init(
+        captureError: spy.sink, recordPolishFailed: { _, _, _, _ in },
+        // This suite asserts on the real `llm.polish_skipped` via testEventHook.
+        recordPolishSkipped: TextProcessingRunner.TelemetrySeams.live.recordPolishSkipped),
       timeoutExecutor: executor.run)
     return try await runner.run(
       rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])

--- a/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
@@ -59,7 +59,11 @@ struct EGOnePipelineRoutingTests {
     -> TextProcessingRunResult
   {
     let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
-    let runner = TextProcessingRunner(captureError: spy.sink, timeoutExecutor: executor.run)
+    // EG-1 skips fire neither seam; the record seam is no-op'd so this suite can
+    // never reach the real PostHog client (#1446).
+    let runner = TextProcessingRunner(
+      telemetry: .init(captureError: spy.sink, recordPolishFailed: { _, _, _, _ in }),
+      timeoutExecutor: executor.run)
     return try await runner.run(
       rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
   }

--- a/Tests/EnviousWisprTests/Pipeline/OllamaReadinessGateTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/OllamaReadinessGateTests.swift
@@ -164,10 +164,15 @@ struct OllamaReadinessGateTests {
   ) async throws -> TextProcessingRunResult {
     let (step, _) = makeStep(probe: probe)
     let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
-    // The preflight path fires neither seam; the record seam is no-op'd so a
-    // future mid-flight test here can never reach the real PostHog client (#1446).
+    // The preflight path fires no capture and no failure record; it DOES emit a
+    // `llm.polish_skipped`, which the tests below assert on via testEventHook, so
+    // that one seam stays live. The failure seam is no-op'd so a future mid-flight
+    // test here can never reach the real PostHog client (#1446).
     let runner = TextProcessingRunner(
-      telemetry: .init(captureError: spy.sink, recordPolishFailed: { _, _, _, _ in }),
+      telemetry: .init(
+        captureError: spy.sink, recordPolishFailed: { _, _, _, _ in },
+        // This suite asserts on the real `llm.polish_skipped` via testEventHook.
+        recordPolishSkipped: TextProcessingRunner.TelemetrySeams.live.recordPolishSkipped),
       timeoutExecutor: executor.run)
     return try await runner.run(
       rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])

--- a/Tests/EnviousWisprTests/Pipeline/OllamaReadinessGateTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/OllamaReadinessGateTests.swift
@@ -164,7 +164,11 @@ struct OllamaReadinessGateTests {
   ) async throws -> TextProcessingRunResult {
     let (step, _) = makeStep(probe: probe)
     let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
-    let runner = TextProcessingRunner(captureError: spy.sink, timeoutExecutor: executor.run)
+    // The preflight path fires neither seam; the record seam is no-op'd so a
+    // future mid-flight test here can never reach the real PostHog client (#1446).
+    let runner = TextProcessingRunner(
+      telemetry: .init(captureError: spy.sink, recordPolishFailed: { _, _, _, _ in }),
+      timeoutExecutor: executor.run)
     return try await runner.run(
       rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
   }

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
@@ -46,6 +46,24 @@ struct TextProcessingRunnerCaptureTests {
     }
   }
 
+  /// Records every durable `llm.polish_failed` record the runner writes (#1446).
+  /// Separate from `CaptureSpy` on purpose: the record fires for EVERY attempted
+  /// failure while the alert fires only for the regression-capable subset, so a
+  /// test can assert "the failure was counted AND nobody was paged."
+  @MainActor
+  final class RecordSpy {
+    struct Call {
+      let provider: String
+      let model: String
+      let reason: String
+      let isTimeout: Bool
+    }
+    private(set) var calls: [Call] = []
+    func sink(_ provider: String, _ model: String, _ reason: String, _ isTimeout: Bool) {
+      calls.append(Call(provider: provider, model: model, reason: reason, isTimeout: isTimeout))
+    }
+  }
+
   /// Polisher that always throws the supplied error. Implements only the legacy
   /// `text:` method; the planner path reaches it via the protocol's default
   /// `envelope:` bridge (same pattern as the reentrancy suite).
@@ -77,19 +95,29 @@ struct TextProcessingRunnerCaptureTests {
     return step
   }
 
-  private func makeRunner(_ spy: CaptureSpy) -> TextProcessingRunner {
+  private func makeRunner(_ spy: CaptureSpy, _ records: RecordSpy = RecordSpy())
+    -> TextProcessingRunner
+  {
     // throwBelowSeconds 0.0 -> the executor runs every step (never injects a
     // timeout); the polisher's own throw drives the failure.
     let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
-    return TextProcessingRunner(captureError: spy.sink, timeoutExecutor: executor.run)
+    return TextProcessingRunner(
+      telemetry: .init(captureError: spy.sink, recordPolishFailed: records.sink),
+      timeoutExecutor: executor.run)
   }
 
   // MARK: - Cloud / local classified failures
 
-  @Test("cloud rejected key -> 'rejected' notice + api_key_rejected tag (one capture)")
+  @Test(
+    "cloud rejected key -> 'rejected' notice, counted, no alert (the user's own key)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "a revoked or mistyped user key is not an EnviousWispr defect")
+  )
   func cloudKeyRejected() async throws {
     let spy = CaptureSpy()
-    let runner = makeRunner(spy)
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
     let step = makeStep(provider: .openAI, model: "gpt-4o-mini") { LLMError.invalidAPIKey }
 
     let result = try await runner.run(
@@ -98,23 +126,60 @@ struct TextProcessingRunnerCaptureTests {
     #expect(
       result.polishError
         == "AI polish failed: OpenAI rejected your API key. Check or replace it in Settings.")
-    #expect(spy.calls.count == 1)
-    let call = try #require(spy.calls.first)
-    #expect(call.category == .polishProviderFailed)
-    #expect(call.stage == "polish")
-    #expect(call.tags["polish.error_case"] == "api_key_rejected")
-    #expect(call.tags["polish.provider"] == "openAI")
-    #expect(call.tags["polish.is_timeout"] == "false")
-    #expect(call.extra?["provider"] as? String == "openAI")
-    #expect(call.extra?["model"] as? String == "gpt-4o-mini")
-    // #945: the reason also splits the Sentry issue (fingerprint discriminator).
-    #expect(call.fingerprintDetail == "api_key_rejected")
+    #expect(spy.calls.isEmpty)
+    #expect(records.calls.count == 1)
+    #expect(records.calls.first?.reason == "api_key_rejected")
+    #expect(records.calls.first?.provider == "openAI")
+    #expect(records.calls.first?.model == "gpt-4o-mini")
+    #expect(records.calls.first?.isTimeout == false)
   }
 
-  @Test("cloud missing key -> skipped lead-in + api_key_missing tag")
+  /// The five reasons downgraded by founder directive 2026-07-09: each is caused by
+  /// the user or the provider, so a GitHub issue would have nothing to fix. Their
+  /// COUNT is the product signal (which walls do users hit), never an alert.
+  nonisolated static let userAndProviderOwnedFailures: [(PolishFailureReason, String)] = [
+    (.providerServerError, "provider_server_error"),
+    (.accessDenied, "access_denied"),
+    (.contentBlocked, "content_blocked"),
+    (.inputTooLong, "input_too_long"),
+    (.apiKeyRejected, "api_key_rejected"),
+  ]
+
+  @Test(
+    "a user- or provider-caused failure is counted and never paged",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "these five filed GitHub issues about nothing"),
+    arguments: userAndProviderOwnedFailures
+  )
+  func userAndProviderFailuresAreCountedNotPaged(
+    reason: PolishFailureReason, tag: String
+  ) async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
+      LLMError.classified(reason)
+    }
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(spy.calls.isEmpty, "\(reason) must never page us")
+    #expect(records.calls.count == 1)
+    #expect(records.calls.first?.reason == tag)
+  }
+
+  @Test(
+    "cloud missing key -> skipped notice, counted, and NOBODY is paged",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "user-environment polish failures fired alerting Sentry errors")
+  )
   func cloudKeyMissing() async throws {
     let spy = CaptureSpy()
-    let runner = makeRunner(spy)
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
     let step = makeStep(provider: .gemini, model: "gemini-2.0-flash") {
       LLMError.classified(.apiKeyMissing)
     }
@@ -122,17 +187,26 @@ struct TextProcessingRunnerCaptureTests {
     let result = try await runner.run(
       rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
 
+    // The notice the user reads is untouched by the downgrade.
     #expect(
       result.polishError == "AI cleanup skipped: no Gemini API key set yet. Add one in Settings.")
-    #expect(spy.calls.count == 1)
-    #expect(spy.calls.first?.tags["polish.error_case"] == "api_key_missing")
-    #expect(spy.calls.first?.tags["polish.provider"] == "gemini")
+    #expect(spy.calls.isEmpty)
+    #expect(records.calls.count == 1)
+    #expect(records.calls.first?.reason == "api_key_missing")
+    #expect(records.calls.first?.provider == "gemini")
+    #expect(records.calls.first?.model == "gemini-2.0-flash")
   }
 
-  @Test("cloud out-of-credits -> billing notice + out_of_credits tag (the mislabel fix)")
+  @Test(
+    "cloud out-of-credits -> billing notice, counted, no alert (71 of 130 events)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "user-environment polish failures fired alerting Sentry errors")
+  )
   func cloudOutOfCredits() async throws {
     let spy = CaptureSpy()
-    let runner = makeRunner(spy)
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
     let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
       LLMError.classified(.outOfCredits)
     }
@@ -143,13 +217,20 @@ struct TextProcessingRunnerCaptureTests {
     #expect(
       result.polishError
         == "AI polish failed: your OpenAI account is out of credits. Check your provider billing.")
-    #expect(spy.calls.first?.tags["polish.error_case"] == "out_of_credits")
+    #expect(spy.calls.isEmpty)
+    #expect(records.calls.first?.reason == "out_of_credits")
   }
 
-  @Test("Ollama unreachable -> Ollama-specific notice + provider_unreachable tag")
+  @Test(
+    "Ollama unreachable -> Ollama notice, counted, no alert (the user's own machine)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "user-environment polish failures fired alerting Sentry errors")
+  )
   func ollamaUnreachable() async throws {
     let spy = CaptureSpy()
-    let runner = makeRunner(spy)
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
     let step = makeStep(provider: .ollama, model: "llama3.2") {
       LLMError.classified(.providerUnreachable)
     }
@@ -159,9 +240,109 @@ struct TextProcessingRunnerCaptureTests {
 
     #expect(
       result.polishError == "AI polish failed: Ollama isn't reachable. Start Ollama and try again.")
-    #expect(spy.calls.first?.tags["polish.error_case"] == "provider_unreachable")
-    #expect(spy.calls.first?.tags["polish.provider"] == "ollama")
-    #expect(spy.calls.first?.extra?["model"] as? String == "llama3.2")
+    #expect(spy.calls.isEmpty)
+    #expect(records.calls.count == 1)
+    #expect(records.calls.first?.reason == "provider_unreachable")
+    #expect(records.calls.first?.provider == "ollama")
+    #expect(records.calls.first?.model == "llama3.2")
+  }
+
+  // MARK: - Provider-awareness: the SAME reason, opposite channels
+
+  @Test(
+    "an offline user on a CLOUD provider is counted, never paged",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "cloud providerUnreachable alerted on the user's own network")
+  )
+  func cloudUnreachableIsCountedNotPaged() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
+    // What a real offline dictation throws, not a hand-made `.classified`.
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
+      URLError(.notConnectedToInternet)
+    }
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(spy.calls.isEmpty)
+    #expect(records.calls.count == 1)
+    #expect(records.calls.first?.reason == "provider_unreachable")
+    #expect(records.calls.first?.provider == "openAI")
+  }
+
+  @Test(
+    "a CLOUD model our catalog offered but the provider 404s pages us; the same on Ollama does not",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "model_unavailable conflated our dead catalog id with a model the user never pulled")
+  )
+  func cloudModelUnavailableAlertsButOllamaDoesNot() async throws {
+    let cloudSpy = CaptureSpy()
+    let cloudRecords = RecordSpy()
+    let cloudStep = makeStep(provider: .gemini, model: "gemini-retired-model") {
+      LLMError.classified(.modelUnavailable)
+    }
+    _ = try await makeRunner(cloudSpy, cloudRecords).run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [cloudStep])
+
+    #expect(cloudSpy.calls.count == 1)
+    #expect(cloudSpy.calls.first?.fingerprintDetail == "model_unavailable")
+    #expect(cloudRecords.calls.count == 1)
+
+    let localSpy = CaptureSpy()
+    let localRecords = RecordSpy()
+    let localStep = makeStep(provider: .ollama, model: "never-pulled") {
+      LLMError.classified(.modelUnavailable)
+    }
+    _ = try await makeRunner(localSpy, localRecords).run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [localStep])
+
+    #expect(localSpy.calls.isEmpty)
+    #expect(localRecords.calls.count == 1)
+    #expect(localRecords.calls.first?.reason == "model_unavailable")
+  }
+
+  @Test("a stored-but-unreadable key pages us with its own fingerprint")
+  func apiKeyUnreadableAlerts() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
+    let step = makeStep(provider: .gemini, model: "gemini-2.0-flash") {
+      LLMError.classified(.apiKeyUnreadable)
+    }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    // Same sentence the no-key user reads; a different fingerprint for us.
+    #expect(
+      result.polishError == "AI cleanup skipped: no Gemini API key set yet. Add one in Settings.")
+    #expect(spy.calls.count == 1)
+    #expect(spy.calls.first?.fingerprintDetail == "api_key_unreadable")
+    #expect(records.calls.first?.reason == "api_key_unreadable")
+  }
+
+  @Test("a malformed request pages us with an unchanged fingerprint")
+  func badRequestAlerts() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
+      LLMError.classified(.badRequest)
+    }
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(spy.calls.count == 1)
+    let call = try #require(spy.calls.first)
+    #expect(call.category == .polishProviderFailed)
+    #expect(call.stage == "polish")
+    #expect(call.fingerprintDetail == "bad_request")
+    #expect(records.calls.first?.reason == "bad_request")
   }
 
   // MARK: - Timeout
@@ -169,10 +350,13 @@ struct TextProcessingRunnerCaptureTests {
   @Test("runner polish-budget timeout -> timed_out tag + is_timeout=true")
   func polishTimeout() async throws {
     let spy = CaptureSpy()
+    let records = RecordSpy()
     // Polish step's cloud budget is 5s; throwing below 6s injects a TimeoutError
     // for it (the executor short-circuits before calling the polisher).
     let executor = FakeTimeoutExecutor(throwBelowSeconds: 6.0)
-    let runner = TextProcessingRunner(captureError: spy.sink, timeoutExecutor: executor.run)
+    let runner = TextProcessingRunner(
+      telemetry: .init(captureError: spy.sink, recordPolishFailed: records.sink),
+      timeoutExecutor: executor.run)
     let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
       LLMError.requestFailed("unused")
     }
@@ -184,6 +368,10 @@ struct TextProcessingRunnerCaptureTests {
     #expect(spy.calls.first?.tags["polish.error_case"] == "timed_out")
     #expect(spy.calls.first?.tags["polish.is_timeout"] == "true")
     #expect(result.polishError?.hasPrefix("AI cleanup skipped:") == true)
+    // #1446: `is_timeout` reaches the durable record too, not only the alert.
+    #expect(records.calls.count == 1)
+    #expect(records.calls.first?.reason == "timed_out")
+    #expect(records.calls.first?.isTimeout == true)
   }
 
   // MARK: - Apple Intelligence is excluded
@@ -191,7 +379,8 @@ struct TextProcessingRunnerCaptureTests {
   @Test("Apple Intelligence keeps today's exact wording and fires NO runner capture")
   func appleIntelligenceExcluded() async throws {
     let spy = CaptureSpy()
-    let runner = makeRunner(spy)
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
     let step = makeStep(provider: .appleIntelligence, model: "apple-intelligence") {
       LLMError.requestFailed("boom")
     }
@@ -202,15 +391,74 @@ struct TextProcessingRunnerCaptureTests {
     #expect(
       result.polishError == "AI polish failed: "
         + LLMError.requestFailed("boom").localizedDescription)
+    // The alerting capture for on-device polish is owned by the polish step
+    // (`captureAFMPolishError`), never by the runner.
     #expect(spy.calls.isEmpty)
+    // #1446: ...but the durable COUNT is the runner's, or `llm.polish_failed`
+    // would not partition live polish outcomes (AFM successes emit
+    // `llm.polish_completed`).
+    #expect(records.calls.count == 1)
+    #expect(records.calls.first?.provider == "appleIntelligence")
+    #expect(records.calls.first?.model == "apple-intelligence")
+    #expect(records.calls.first?.reason == "bad_request")
+  }
+
+  @Test(
+    "an Apple Intelligence model-not-ready failure is counted as model_unavailable",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "surfaced Apple Intelligence failures were absent from llm.polish_failed")
+  )
+  func appleIntelligenceModelNotReadyIsCounted() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
+    let step = makeStep(provider: .appleIntelligence, model: "apple-intelligence") {
+      LLMError.modelNotReady("still downloading")
+    }
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(spy.calls.isEmpty)
+    #expect(records.calls.count == 1)
+    #expect(records.calls.first?.reason == "model_unavailable")
+  }
+
+  /// The on-device skips that degrade quietly to raw text (#1080, #1055): a Mac
+  /// that cannot run Apple Intelligence at all, and the per-request language gates.
+  nonisolated static let silentAFMSkips: [LLMError] = [
+    .frameworkUnavailable("pre-macOS-26"),
+    .unsupportedInputLanguage("de"),
+    .outputLanguageDrift(expected: "en", actual: "de"),
+  ]
+
+  @Test(
+    "a SILENT Apple Intelligence skip is counted by nothing — it is not a failure",
+    arguments: silentAFMSkips)
+  func appleIntelligenceSilentSkipsAreNotCounted(error: LLMError) async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
+    let step = makeStep(provider: .appleIntelligence, model: "apple-intelligence") { error }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    // Raw deterministic text, no pill, and nothing reported: these degrade quietly
+    // by design (#1080, #1055). Counting them would inflate the failure rate.
+    #expect(result.polishError == nil)
+    #expect(spy.calls.isEmpty)
+    #expect(records.calls.isEmpty)
   }
 
   // MARK: - No-false-positive boundary
 
-  @Test("a cancelled cloud request fires no capture and surfaces no notice")
+  @Test("a cancelled cloud request fires no telemetry and surfaces no notice")
   func cancellationLikeIgnored() async throws {
     let spy = CaptureSpy()
-    let runner = makeRunner(spy)
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
     let step = makeStep(provider: .openAI, model: "gpt-4o-mini") { URLError(.cancelled) }
 
     let result = try await runner.run(
@@ -218,12 +466,15 @@ struct TextProcessingRunnerCaptureTests {
 
     #expect(result.polishError == nil)
     #expect(spy.calls.isEmpty)
+    // A torn-down request is not an attempted-and-failed polish.
+    #expect(records.calls.isEmpty)
   }
 
-  @Test("a successful polish fires no capture")
+  @Test("a successful polish fires no telemetry")
   func successNoCapture() async throws {
     let spy = CaptureSpy()
-    let runner = makeRunner(spy)
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
     let step = LLMPolishStep(keychainManager: KeychainManager())
     step.llmProvider = .openAI
     step.llmModel = "gpt-4o-mini"
@@ -234,6 +485,7 @@ struct TextProcessingRunnerCaptureTests {
 
     #expect(result.polishError == nil)
     #expect(spy.calls.isEmpty)
+    #expect(records.calls.isEmpty)
   }
 
   /// Polisher that returns clean text (no throw) for the success-path test.

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
@@ -64,6 +64,17 @@ struct TextProcessingRunnerCaptureTests {
     }
   }
 
+  /// Records every `llm.polish_skipped` the runner writes — polish that was never
+  /// ATTEMPTED (#1055 / #1271 / #1305). The third seam; it must be silenced under
+  /// crash recovery alongside the other two (#1446, cloud review of PR #1460).
+  @MainActor
+  final class SkipSpy {
+    private(set) var calls: [(provider: String, reason: String)] = []
+    func sink(_ provider: String, _ reason: String) {
+      calls.append((provider: provider, reason: reason))
+    }
+  }
+
   /// Polisher that always throws the supplied error. Implements only the legacy
   /// `text:` method; the planner path reaches it via the protocol's default
   /// `envelope:` bridge (same pattern as the reentrancy suite).
@@ -95,14 +106,16 @@ struct TextProcessingRunnerCaptureTests {
     return step
   }
 
-  private func makeRunner(_ spy: CaptureSpy, _ records: RecordSpy = RecordSpy())
-    -> TextProcessingRunner
-  {
+  private func makeRunner(
+    _ spy: CaptureSpy, _ records: RecordSpy = RecordSpy(), _ skips: SkipSpy = SkipSpy()
+  ) -> TextProcessingRunner {
     // throwBelowSeconds 0.0 -> the executor runs every step (never injects a
     // timeout); the polisher's own throw drives the failure.
     let executor = FakeTimeoutExecutor(throwBelowSeconds: 0.0)
     return TextProcessingRunner(
-      telemetry: .init(captureError: spy.sink, recordPolishFailed: records.sink),
+      telemetry: .init(
+        captureError: spy.sink, recordPolishFailed: records.sink,
+        recordPolishSkipped: skips.sink),
       timeoutExecutor: executor.run)
   }
 
@@ -355,7 +368,9 @@ struct TextProcessingRunnerCaptureTests {
     // for it (the executor short-circuits before calling the polisher).
     let executor = FakeTimeoutExecutor(throwBelowSeconds: 6.0)
     let runner = TextProcessingRunner(
-      telemetry: .init(captureError: spy.sink, recordPolishFailed: records.sink),
+      telemetry: .init(
+        captureError: spy.sink, recordPolishFailed: records.sink,
+        recordPolishSkipped: { _, _ in }),
       timeoutExecutor: executor.run)
     let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
       LLMError.requestFailed("unused")
@@ -450,6 +465,39 @@ struct TextProcessingRunnerCaptureTests {
     #expect(result.polishError == nil)
     #expect(spy.calls.isEmpty)
     #expect(records.calls.isEmpty)
+  }
+
+  @Test(
+    "an Apple Intelligence timeout routes its skip through the seam, not TelemetryService",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "llm.polish_skipped bypassed the seams and leaked from crash recovery")
+  )
+  func appleIntelligenceTimeoutSkipRoutesThroughTheSeam() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let skips = SkipSpy()
+    // AFM's polish budget is 10s; throwing below 11s injects a TimeoutError.
+    let executor = FakeTimeoutExecutor(throwBelowSeconds: 11.0)
+    let runner = TextProcessingRunner(
+      telemetry: .init(
+        captureError: spy.sink, recordPolishFailed: records.sink,
+        recordPolishSkipped: skips.sink),
+      timeoutExecutor: executor.run)
+    let step = makeStep(provider: .appleIntelligence, model: "apple-intelligence") {
+      LLMError.requestFailed("unused")
+    }
+
+    let result = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    // An on-device timeout on a long dictation degrades quietly to raw text.
+    #expect(result.polishError == nil)
+    #expect(spy.calls.isEmpty)
+    #expect(records.calls.isEmpty)  // never attempted-and-failed; it was skipped
+    #expect(skips.calls.count == 1)
+    #expect(skips.calls.first?.provider == "appleIntelligence")
+    #expect(skips.calls.first?.reason == "context_window_timeout")
   }
 
   // MARK: - No-false-positive boundary

--- a/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
@@ -154,13 +154,14 @@ struct RecoveryTextProcessorTests {
     // Bound to locals so a failure prints the verdict, not the whole source file.
     let buildsRunnerFromSilent = code.contains("TextProcessingRunner(telemetry: .silent)")
     // Hand-rolled seams here are the regression: they silence what exists today and
-    // silently miss whatever seam is added tomorrow.
-    let handRollsCaptureError = code.contains("captureError:")
-    let handRollsRecordPolishFailed = code.contains("recordPolishFailed:")
+    // silently miss whatever seam is added tomorrow. (`recordPolishSkipped` is the
+    // one that WAS missed — it called TelemetryService directly until the cloud
+    // review of PR #1460 found it.)
+    let handRolledSeams = ["captureError:", "recordPolishFailed:", "recordPolishSkipped:"]
+      .filter { code.contains($0) }
 
     #expect(buildsRunnerFromSilent)
-    #expect(!handRollsCaptureError)
-    #expect(!handRollsRecordPolishFailed)
+    #expect(handRolledSeams.isEmpty, "recovery must name .silent, not per-seam closures")
   }
 
   /// Repo root, anchored off `#filePath` — this file lives at

--- a/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
@@ -1,8 +1,9 @@
 import EnviousWisprCore
-import EnviousWisprLLM
 import EnviousWisprPipeline
 import Foundation
 import Testing
+
+@testable import EnviousWisprLLM
 
 /// The public recovery text-processing seam (#1063 PR0) must run the SAME chain
 /// a live dictation runs, configured by the recording's settings snapshot. With
@@ -93,5 +94,82 @@ struct RecoveryTextProcessorTests {
         languageMode: .locked("es")))
     let outcome = await processor.process(rawText: spoken)
     #expect(outcome.text == spoken)  // Spanish locked ⇒ English ITN skipped
+  }
+
+  // MARK: - Telemetry silence (#945, extended by #1446)
+
+  /// A `KeychainManager` whose reads always throw, driving the cloud connector's
+  /// `getAPIKey` catch arm (`.apiKeyUnreadable`, #1446). The `.legacyFiles` backend
+  /// is the DEBUG/dev one, so the founder's real Keychain is never touched, and the
+  /// throw lands before any network request is built.
+  private struct UnreadableKeyStore: LegacyKeyFileStorage {
+    func store(key: String, value: String) throws { throw KeyStoreError.storeFailed(-1) }
+    func retrieve(key: String) throws -> String { throw KeyStoreError.retrieveFailed(-1) }
+    func delete(key: String) throws {}
+  }
+
+  @Test("a recovered take whose polish fails still lands as deterministic text with its notice")
+  func recoveryPolishFailureFallsBackToRawWithNotice() async {
+    let processor = RecoveryTextProcessor(
+      keychainManager: KeychainManager(backend: .legacyFiles, legacyStore: UnreadableKeyStore()))
+    processor.applySettings(snapshot(fillerRemoval: false, provider: "openAI"))
+
+    // Long enough to clear the polish step's short-transcript short-circuit.
+    let outcome = await processor.process(
+      rawText: "so i was thinking we could maybe ship the new thing some time next week or so")
+
+    #expect(outcome.polishedText == nil)
+    // #1446: `.apiKeyUnreadable` reuses `.apiKeyMissing`'s copy verbatim, so the
+    // split is invisible to the user even on the recovery path.
+    #expect(
+      outcome.polishError == "AI cleanup skipped: no OpenAI API key set yet. Add one in Settings.")
+  }
+
+  /// #945 / #1446: recovery must emit NO polish telemetry — a live-only metric.
+  ///
+  /// Asserted against the source rather than by observing telemetry, deliberately.
+  /// The seams are private to the runner, so the only behavioral observation point
+  /// is a process-global delegate; a negative assertion through one can pass
+  /// vacuously when a sibling suite replaces the hook mid-`await`, which makes it a
+  /// guard that silently stops guarding (`swift-patterns.md`
+  /// `tests-no-process-global-mutable-delegate`). Reading the wiring is race-free
+  /// and strictly stronger: it fails if recovery hand-rolls its own seams, which is
+  /// exactly the mistake `TextProcessingRunner.TelemetrySeams.silent` exists to
+  /// prevent.
+  @Test(
+    "RecoveryTextProcessor silences telemetry via the one .silent value, not per-seam closures",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1446",
+      "a second telemetry seam must not be left live in crash recovery")
+  )
+  func recoveryWiresTheSilentSeams() throws {
+    let path = repoRoot().appending(
+      path: "Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift")
+    let source = try String(contentsOf: path, encoding: .utf8)
+    let code = source.split(separator: "\n")
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.hasPrefix("//") }
+      .joined(separator: " ")
+
+    // Bound to locals so a failure prints the verdict, not the whole source file.
+    let buildsRunnerFromSilent = code.contains("TextProcessingRunner(telemetry: .silent)")
+    // Hand-rolled seams here are the regression: they silence what exists today and
+    // silently miss whatever seam is added tomorrow.
+    let handRollsCaptureError = code.contains("captureError:")
+    let handRollsRecordPolishFailed = code.contains("recordPolishFailed:")
+
+    #expect(buildsRunnerFromSilent)
+    #expect(!handRollsCaptureError)
+    #expect(!handRollsRecordPolishFailed)
+  }
+
+  /// Repo root, anchored off `#filePath` — this file lives at
+  /// `Tests/EnviousWisprTests/Recovery/`, four levels below the root.
+  private func repoRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
   }
 }


### PR DESCRIPTION
## The problem

`TextProcessingRunner` fired an alerting Sentry `.error` for **every** polish failure on the cloud/local path. Over 30 days that is 130 events, of which 118 (91%) are the user's own quota, billing, missing key, or a local Ollama server they had shut down. One user out of credits produced 71 by himself.

The volume trips the standing "AI Failure Spike (>3/hr)" alert, and the daily triage routine files a GitHub issue per fingerprint: #1421 (open), #1424 / #1423 / #1422 / #1318 (all closed by hand as not-a-bug).

The app contradicts itself today: `PolishFailureReason.leadIn` already renders "**AI cleanup skipped:** ..." for `api_key_missing`, `input_too_long`, and `timed_out` — deliberately worded as *not broken* — while the same event pages us at `.error` level.

## The fix

**1. Split a conflated reason.** `getAPIKey` threw `.apiKeyMissing` from both exits: the `guard` for "user never set a key" and the `catch` for "key stored but the Keychain read threw." The second is our defect and was invisible behind the first. New `.apiKeyUnreadable` keeps its own alerting fingerprint; the user-facing copy is byte-identical (a shared switch arm, not a duplicated string).

**2. Alert only on OUR bugs.** `PolishFailureReason.telemetryChannel(provider:)` is the single authority — exhaustive, no `default:`, so a future reason is a compile error until it chooses a channel. The predicate is ownership of the **cause**: could a change to our own code have prevented this?

**3. PostHog becomes the durable record.** New `llm.polish_failed` (provider, model, reason, is_timeout) fires for *every* attempted-and-failed polish, both channels, so the failure rate needs no Sentry∪PostHog union. It completes the partition with `llm.polish_completed` (attempted, succeeded) and `llm.polish_skipped` (never attempted).

### Channels

| | Reasons |
|---|---|
| **Alerting** (our bugs) | `bad_request`, `empty_response`, `unknown` (we built or read it wrong) · `api_key_unreadable` (we stored a key and could not read it back) · `timed_out` (the budget it blew is ours) · `model_unavailable` **on cloud only** |
| **Counted, never paged** | `provider_unreachable`, `api_key_missing`, `api_key_rejected`, `access_denied`, `out_of_credits`, `rate_limited`, `rate_or_quota`, `provider_server_error`, `content_blocked`, `input_too_long` · `model_unavailable` on Ollama |

**~130 → ~9 alerting events / 30d.** Nothing goes dark: every downgraded reason is still counted per-provider per-reason.

`model_unavailable` is the one provider-keyed reason. Cloud model ids come from a Picker fed by our catalog, never user free text, so a provider 404 is a dead id we shipped; an Ollama model the user never pulled is their setup.

## Two defects the review loop caught, both of which would have inverted this change

**Codex r3 — the no-key user would have paged us.** `LLMPolishStep` always supplies the fixed cloud key id, so the `nil` guard is **dead code in production** and a real no-key user reaches the `catch`. Keying the split on the guard (as drafted) would have relabelled every no-key user `.apiKeyUnreadable` → alerting. The enabling fix is one layer down: `FileLegacyKeyStore` reported a missing file and an unreadable one with the same generic `-1`, so absence was unknowable. It now reports absence as `errSecItemNotFound`, the vocabulary `SecurityKeychainItemStore` already used. The new connector tests use the production shape (key id present, nothing stored).

**Codex r4 — the offline user would have paged us.** `from(_:)` maps `URLError.notConnectedToInternet` / `.networkConnectionLost` / `.dataNotAllowed` / `.internationalRoamingOff` onto `.providerUnreachable`. Alerting on it for cloud providers would have paged us for every user dictating on a plane or behind a VPN. A genuinely broken base URL is not lost with it: that breaks *every* cloud user at once and shows as an `llm.polish_failed` rate cliff.

Both share a root: the channel was assigned from the reason's **name**, not from what actually produces it.

## Founder decision during build

The plan's original predicate was "could a *spike* here plausibly mean we regressed," which retained five user- and provider-caused reasons as alerting because they cost ~0 events today. Overruled:

> they're user-caused, not our bugs... it's important for us to know the type of walls our customers hit and use that information to educate them and help them make better decisions within our application, but they shouldn't be treated as bugs... maybe we need to create some guides around it. But it shouldn't trigger GitHub issues for us to go fix things when there's nothing to fix.

Downgraded accordingly: `provider_server_error` (the provider's outage), `access_denied` (403: the user's billing / API access / region), `api_key_rejected` (the user's revoked or mistyped key), `content_blocked` (the provider's content rules on the user's text), `input_too_long` (the user dictated for five minutes). This also retires the plan's own §4 admission that `input_too_long` renders "AI cleanup skipped:" while paging us — the exact self-contradiction the problem statement indicts.

Two reasons still show a reassuring notice **and** alert: `timed_out` and `api_key_unreadable`. Both are genuinely ours. A test pins that pair so a future tidy-up cannot collapse the notice and the channel into each other — they answer different questions ("is the user alarmed?" vs "is this our bug?").

## Recovery silence, made unwritable

`RecoveryTextProcessor` no-ops the runner's telemetry so crash-recovery polish stays silent (#945: a live-only metric). A *second* seam made "silence one, forget the other" writable. The runner's seams are now one `TelemetrySeams` value with `.live` and `.silent` presets: `.silent` is the single place that defines what silence means, and the memberwise initializer forces any future seam to be named there before the file compiles.

The obvious test for this — observing the process-global Sentry/PostHog delegates — was tried and **rejected**: a negative assertion through a global hook passes *vacuously* when a sibling suite swaps the hook out mid-`await` (`swift-patterns.md` `tests-no-process-global-mutable-delegate`). A guard that can silently stop guarding is worse than none, because it reads as coverage. A source-level test pins the wiring instead; it was verified to fail against a deliberately half-silenced recovery.

## Validation

- `scripts/xcode-test.sh` — **2,579 tests, 0 failures**
- Local `codex review` — **6 rounds to clean.** r1/r2 test-globals (fixed structurally), r3 P1 keychain + P2 Apple Intelligence coverage, r4 P1 network, r5 clean, r6 clean after the founder's redesign
- **Live UAT** — real dictation through the dev app with a cloud provider and no stored key:
  - `[TextProcessing] LLM Polish failed: AI polish failed (api_key_missing). after 7.6ms — skipping` ← **the production shape reaching the catch arm and classifying as `api_key_missing`, not `api_key_unreadable`**
  - `Pipeline timing TOTAL: 0.522s (ASR=0.115s, polish=0.100s, paste=0.259s)` — heart path unaffected, deterministic text delivered
  - Founder's real settings (`llmProvider=egOne`, `llmModel=eg-1`) recorded and restored
- `scripts/check-validation.sh --strict` — **PASS** (Code lane)
- "No Sentry event fired" is not observable from the app log; that half is proven by the injected-seam unit tests.

## Zero user-visible change

The notice, its wording, the fail-open to raw text, and the polish outcome are untouched. `.apiKeyUnreadable` reuses `.apiKeyMissing`'s copy verbatim, so `isSkipNotice` and the completion toast behave identically.

## Accepted blind spot

`rate_or_quota` (71 of the 130 events) is downgraded, yet a retry storm or duplicate-request bug of ours would also surface as rate limiting; Gemini's API does not cleanly separate them. Backstop filed as **#1458** (alert on the `llm.polish_failed` rate in `workers/product-health`) — worker lane, separate deploy, and the threshold cannot be calibrated until the event has emitted in production.

## Related

Closes #1446. Follow-ups #1458, #1455. Recurrence family: #1421, #1424, #1423, #1422, #1318, #1391; alert-spike fallout #1401. Same bug class as #1438 / PR #1443 (AFM cancellation), #979 / #1048 (`asr_empty_result`).
