### PR TITLE
fix(audio): deliver the dictation immediately when the microphone dies mid-recording

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
@@ -40,7 +40,10 @@ enum DictationCompletedReporting {
       captureRateDivergenceDetected: whenTrue(health?.rateDivergenceDetected),
       captureFormatStabilized: health?.formatStabilized,
       captureRebuiltForFormat: whenTrue(health?.captureRebuiltForFormat),
-      salvagedLeadTrimMs: driver.lastSalvagedLeadTrimMs)
+      salvagedLeadTrimMs: driver.lastSalvagedLeadTrimMs,
+      // #1408: which interruption cut this dictation short. `stop_reason` already
+      // says one did; this names it. Absent on an uninterrupted completion.
+      interruptedBy: driver.lastAudioInterruptionCause?.rawValue)
   }
 
   private static func positive(_ value: Int?) -> Int? {

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -257,7 +257,13 @@ final class DictationLifecycleCoordinator {
       currentTranscript: kernelDriver.currentTranscript,
       historySaved: kernelDriver.lastHistorySaved,
       historySaveReason: kernelDriver.lastHistorySaveReason,
-      salvagedLead: kernelDriver.lastSalvagedLeadTrimMs != nil
+      salvagedLead: kernelDriver.lastSalvagedLeadTrimMs != nil,
+      // #1408 (A1): the full typed disclosure, not a Bool. nil = normal
+      // completion; `.deviceRemoved` = verified removal (may say "Microphone
+      // disconnected"); `.otherInterruption` = salvaged with the mic, as far as
+      // we know, still attached (neutral copy). The factory owns the sentences.
+      interruptionDisclosure: CompletionInterruptionDisclosure(
+        cause: kernelDriver.lastAudioInterruptionCause)
     )
     // PR7 of #763 — push polish error to the post-recording result home so
     // views can read `lastRecordingResult.polishError` without reaching
@@ -309,7 +315,9 @@ final class DictationLifecycleCoordinator {
       currentTranscript: whisperKitKernelDriver.currentTranscript,
       historySaved: whisperKitKernelDriver.lastHistorySaved,
       historySaveReason: whisperKitKernelDriver.lastHistorySaveReason,
-      salvagedLead: whisperKitKernelDriver.lastSalvagedLeadTrimMs != nil
+      salvagedLead: whisperKitKernelDriver.lastSalvagedLeadTrimMs != nil,
+      interruptionDisclosure: CompletionInterruptionDisclosure(
+        cause: whisperKitKernelDriver.lastAudioInterruptionCause)
     )
     lastRecordingResult.polishError = whisperKitKernelDriver.lastPolishError
     dispatchChipLifecycle(
@@ -399,46 +407,24 @@ final class DictationLifecycleCoordinator {
 
   // MARK: - State-handler factory
 
+  /// #1408: the closure bodies and every notice literal live in
+  /// `PipelineStateChangeHandlerFactory`; this hands it the coordinator-owned
+  /// seams they reach back into. Extracted rather than grown in place — the
+  /// coordinator sat at its line ceiling, which is exactly the signal that
+  /// ceiling exists to send.
   private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
-    // #1060: this handler's driver — completion telemetry reads its length + stop reason.
     let driver = backendLabel == "whisperKit" ? whisperKitKernelDriver : kernelDriver
-    return PipelineStateChangeHandler(
-      showOverlay: { [weak self] intent in self?.showOverlayIntent(intent) },
-      cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
-      schedulePolishFailedWarning: { [weak self] in
-        self?.schedulePostCompletionWarning(message: "Polish failed -- using raw text")
-      },
-      appendCompletedTranscript: { [weak self] t in
-        self?.transcriptCoordinator.append(t)
-        // #1063 PR1: the save is durable by `.complete`; delete this session's
-        // spool + key. nil unless recovery was armed for this take.
-        if let sid = t.recoverySessionID { self?.onDurableSave(sid) }
-      },
-      reportDictationCompleted: { [weak self] t in
-        guard let self else { return }
-        // #1376/#1434: route + capture-health + salvage argument assembly
-        // lives in `DictationCompletedReporting` (thin-factory discipline).
-        DictationCompletedReporting.report(
-          transcript: t, inputMode: self.settings.recordingMode.rawValue, driver: driver)
-      },
-      reportPipelineFailed: { msg in
-        TelemetryService.shared.pipelineFailed(
-          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
-          recoverable: false, backend: backendLabel)
-      },
-      // #1167: history-save-failed pill (post-completion warning slot, ~400 ms).
-      scheduleHistorySaveFailedWarning: { [weak self] reason in
-        self?.schedulePostCompletionWarning(message: "Couldn't save to history: \(reason)")
-      },
-      // #1434: salvaged-lead disclosure pill — the degraded-lead retry
-      // recovered this dictation by trimming a poisoned opening, so the
-      // pasted text is missing its lead. Same generic post-completion
-      // mechanism as the two pills above; the message is wired HERE, never
-      // hardcoded into a shared closure (Codex r2 rev 5).
-      scheduleSalvagedLeadWarning: { [weak self] in
-        self?.schedulePostCompletionWarning(
-          message: "Beginning of dictation was unclear and was skipped")
-      }
-    )
+    return PipelineStateChangeHandlerFactory.make(
+      backendLabel: backendLabel,
+      deps: .init(
+        showOverlay: { [weak self] intent in self?.showOverlayIntent(intent) },
+        cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
+        schedulePostCompletionWarning: { [weak self] message in
+          self?.schedulePostCompletionWarning(message: message)
+        },
+        appendTranscript: { [weak self] t in self?.transcriptCoordinator.append(t) },
+        onDurableSave: { [weak self] sid in self?.onDurableSave(sid) },
+        inputMode: { [weak self] in self?.settings.recordingMode.rawValue },
+        driver: driver))
   }
 }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/PipelineStateChangeHandlerFactory.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/PipelineStateChangeHandlerFactory.swift
@@ -1,0 +1,103 @@
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+
+/// #1408: assembles a `PipelineStateChangeHandler` from the AppKit-owned seams
+/// its closures need, so `DictationLifecycleCoordinator` stays a thin wiring site
+/// (the same move #1434 made for `DictationCompletedReporting`). Pure closure
+/// assembly — no state, no decisions; the pure planner owns which effect fires
+/// and this file owns what each one says.
+///
+/// **The post-completion notice literals live HERE, one per site.** They are
+/// wired at the factory rather than hardcoded inside the shared
+/// `schedulePostCompletionWarning` mechanism, so the single warning slot stays a
+/// generic mechanism and each caller owns its own words. No em-dashes: this copy
+/// is user-facing.
+@MainActor
+enum PipelineStateChangeHandlerFactory {
+  /// The coordinator-owned seams the handler's closures reach back into. Passed
+  /// as closures rather than a coordinator reference so the coordinator's own
+  /// methods stay `private` (its non-private-method ceiling is exactly full) and
+  /// the handler cannot reach anything it was not handed.
+  struct Deps {
+    let showOverlay: @MainActor (OverlayIntent) -> Void
+    let cancelPendingWarning: @MainActor () -> Void
+    /// The generic single-slot post-completion pill. Last-writer-wins by design;
+    /// the planner guarantees exactly one caller per completion.
+    let schedulePostCompletionWarning: @MainActor (String) -> Void
+    let appendTranscript: @MainActor (Transcript) -> Void
+    /// #1063 PR1: the durable save landed, so this session's spool + key can go.
+    let onDurableSave: @MainActor (String) -> Void
+    /// `nil` once the coordinator is gone, so a completion racing teardown emits
+    /// nothing rather than reporting an empty input mode.
+    let inputMode: @MainActor () -> String?
+    /// This handler's driver — completion telemetry reads its length, stop
+    /// reason, route, capture health, and salvage markers (#1060, #1376, #1434).
+    let driver: KernelDictationDriver
+  }
+
+  static func make(backendLabel: String, deps: Deps) -> PipelineStateChangeHandler {
+    PipelineStateChangeHandler(
+      showOverlay: { intent in deps.showOverlay(intent) },
+      cancelPendingWarning: { deps.cancelPendingWarning() },
+      schedulePolishFailedWarning: {
+        deps.schedulePostCompletionWarning("Polish failed -- using raw text")
+      },
+      appendCompletedTranscript: { t in
+        deps.appendTranscript(t)
+        // #1063 PR1: the save is durable by `.complete`; delete this session's
+        // spool + key. nil unless recovery was armed for this take.
+        if let sid = t.recoverySessionID { deps.onDurableSave(sid) }
+      },
+      reportDictationCompleted: { t in
+        guard let inputMode = deps.inputMode() else { return }
+        // #1376/#1434: route + capture-health + salvage argument assembly lives
+        // in `DictationCompletedReporting` (thin-factory discipline).
+        DictationCompletedReporting.report(
+          transcript: t, inputMode: inputMode, driver: deps.driver)
+      },
+      reportPipelineFailed: { msg in
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
+          recoverable: false, backend: backendLabel)
+      },
+      // #1167: history-save-failed pill (post-completion warning slot, ~400 ms).
+      scheduleHistorySaveFailedWarning: { reason in
+        deps.schedulePostCompletionWarning("Couldn't save to history: \(reason)")
+      },
+      // #1434: salvaged-lead disclosure pill — the degraded-lead retry recovered
+      // this dictation by trimming a poisoned opening, so the pasted text is
+      // missing its lead.
+      scheduleSalvagedLeadWarning: {
+        deps.schedulePostCompletionWarning("Beginning of dictation was unclear and was skipped")
+      },
+      // #1408: capture died mid-recording and the pasted text is what survived.
+      // The disclosure picks the sentence family: only a VERIFIED device removal
+      // may say "Microphone disconnected"; every other interruption gets the
+      // neutral "Recording interrupted" (grounded review A1 — a non-disconnect
+      // salvage must not paste truncated text silently). When the lead was ALSO
+      // trimmed this take lost both ends, so the copy stops claiming the loss is
+      // only at the end. All four strings fit the pill's single line (~49
+      // characters before it truncates). The microphone pair is founder-approved
+      // (2026-07-09); the neutral pair is provisional pending founder sign-off
+      // (plan §21.3) and must not ship in a release before that lands.
+      scheduleInterruptionWarning: { disclosure, alsoTrimmedLead in
+        let message: String
+        switch disclosure {
+        case .deviceRemoved:
+          message =
+            alsoTrimmedLead
+            ? "Microphone disconnected. Words may be missing."
+            : "Microphone disconnected. Text may be cut short."
+        case .otherInterruption:
+          message =
+            alsoTrimmedLead
+            ? "Recording interrupted. Words may be missing."
+            : "Recording interrupted. Text may be cut short."
+        }
+        deps.schedulePostCompletionWarning(message)
+      }
+    )
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -204,7 +204,14 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       llmProvider: textOutcome.polishedText != nil ? recovered.settings?.llmProvider : nil,
       llmModel: textOutcome.polishedText != nil ? recovered.settings?.llmModel : nil,
       recoverySessionID: id,
-      isRecovered: true)
+      isRecovered: true,
+      // #1408: unknown, never guessed. The spool's own `RecoverySpoolTermination
+      // Reason` is a WRITER-side reason (its `.interrupted` means the helper
+      // process exited); a mic disconnect leaves the helper alive, so it never
+      // appears there and cannot answer "was the input device removed." `true`
+      // would lie for app-crash recovery, `false` for a retained disconnect
+      // spool. `isRecovered: true` above is the honest abnormal-exit signal.
+      inputDeviceWasRemoved: nil)
 
     // FINAL abort check immediately before the SYNCHRONOUS save + append — there
     // is no `await` between here and `append`, so a Discard cannot interleave a

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
@@ -121,6 +121,26 @@ struct TranscriptRowView: View {
           .accessibilityLabel("Recovered recording")
         }
 
+        if transcript.inputDeviceWasRemoved == true {
+          // #1408 — the microphone died mid-recording and this is what survived,
+          // so the text may be cut short. `stWarning`, not `stSuccess`:
+          // "Recovered" is good news, "Interrupted" is not. Icon + text (never
+          // color-only). The crossed-out mic names the event the user watched
+          // happen; `scissors` would read as if they trimmed it themselves —
+          // and it renders ONLY for a verified removal, never for other
+          // interruption causes (the field takes the strictest predicate).
+          HStack(spacing: 2) {
+            Image(systemName: "mic.slash.circle")
+            Text("Interrupted")
+          }
+          .font(.caption2)
+          .padding(.horizontal, 5)
+          .padding(.vertical, 2)
+          .background(Color.stWarning.opacity(0.15), in: Capsule())
+          .foregroundStyle(.stWarning)
+          .accessibilityLabel("Interrupted recording")
+        }
+
         if transcript.polishedText != nil {
           HStack(spacing: 2) {
             Image(systemName: "sparkles")

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -92,7 +92,7 @@ final class AVAudioEngineSource: AudioInputSource {
 
   var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onInterrupted: (() -> Void)?
+  var onInterrupted: ((EngineInterruptionCause) -> Void)?
   var onLifecycleSignal: (@Sendable (String) -> Void)?
 
   // MARK: - Round-4 telemetry (issue #285) — capture liveness watchdog.
@@ -178,7 +178,10 @@ final class AVAudioEngineSource: AudioInputSource {
     return CaptureStopMetadata(nativeRateHz: rate)
   }
 
-  // NOTE: onPartialSamples removed — manager owns capturedSamples and handles partial recovery.
+  // NOTE: onPartialSamples removed — the manager owns `capturedSamples` and keeps
+  // holding them across a device disconnect. It does not itself recover anything:
+  // #1408 made `RecordingSessionKernel` decide, at the recording exit, whether the
+  // interruption left recoverable audio and to transcribe it if so.
 
   // MARK: - Constants
 
@@ -671,34 +674,41 @@ final class AVAudioEngineSource: AudioInputSource {
         level: .info, category: "Audio"
       )
       emergencyTeardown()
-      onInterrupted?()
+      // #1408: we could not resolve a device id, so we never ran the
+      // `DeviceIsAlive` check and cannot claim the microphone went away.
+      onInterrupted?(.engineLost)
       return
     }
 
-    var isAlive: UInt32 = 0
-    var size = UInt32(MemoryLayout<UInt32>.size)
-    var addr = AudioObjectPropertyAddress(
-      mSelector: kAudioDevicePropertyDeviceIsAlive,
-      mScope: kAudioObjectPropertyScopeGlobal,
-      mElement: kAudioObjectPropertyElementMain
-    )
-    AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &isAlive)
-
-    if isAlive == 0 {
+    switch CoreAudioDeviceLiveness.classify(deviceID: deviceID) {
+    case .removed:
       await AppLogger.shared.log(
         "Audio device \(deviceID) is dead — performing emergency teardown",
         level: .info, category: "Audio"
       )
       emergencyTeardown()
-      onInterrupted?()
-      return
-    }
+      // #1408: Core Audio confirms the device is gone. This is the ONE site in
+      // this source entitled to claim the user's microphone disconnected.
+      onInterrupted?(.deviceRemoved)
 
-    await AppLogger.shared.log(
-      "Audio engine config changed — device \(deviceID) still alive (Bluetooth codec switch), attempting graceful recovery",
-      level: .info, category: "Audio"
-    )
-    await recoverFromCodecSwitch()
+    case .unverified:
+      await AppLogger.shared.log(
+        "Audio device \(deviceID) liveness unverified — performing emergency teardown",
+        level: .info, category: "Audio"
+      )
+      emergencyTeardown()
+      // #1408: the capture is broken either way, so tear down and salvage as
+      // before — but Core Audio never confirmed the device left, so we do not
+      // say it did.
+      onInterrupted?(.engineLost)
+
+    case .alive:
+      await AppLogger.shared.log(
+        "Audio engine config changed — device \(deviceID) still alive (Bluetooth codec switch), attempting graceful recovery",
+        level: .info, category: "Audio"
+      )
+      await recoverFromCodecSwitch()
+    }
   }
 
   private func recoverFromCodecSwitch() async {
@@ -726,7 +736,9 @@ final class AVAudioEngineSource: AudioInputSource {
     guard stabilized else {
       btCrashLogger.error("Recovery: format stabilization timed out — emergency teardown")
       emergencyTeardown()
-      onInterrupted?()
+      // #1408: the device is alive (we checked above); our engine could not
+      // re-stabilize. Not a disconnect.
+      onInterrupted?(.engineLost)
       return
     }
 
@@ -804,7 +816,8 @@ final class AVAudioEngineSource: AudioInputSource {
     } catch {
       btCrashLogger.error("Recovery failed: \(error.localizedDescription) — emergency teardown")
       emergencyTeardown()
-      onInterrupted?()
+      // #1408: the device is alive; our engine failed to restart. Not a disconnect.
+      onInterrupted?(.engineLost)
     }
   }
 

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -93,7 +93,7 @@ final class AVCaptureSessionSource: AudioInputSource {
 
   var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onInterrupted: (() -> Void)?
+  var onInterrupted: ((EngineInterruptionCause) -> Void)?
   var onLifecycleSignal: (@Sendable (String) -> Void)?
 
   // MARK: - Round-4 telemetry (issue #285) — stall watchdog + interruption ctx.
@@ -561,7 +561,7 @@ final class AVCaptureSessionSource: AudioInputSource {
       MainActor.assumeIsolated {
         guard let self else { return }
         self.emitCaptureSessionInterruption(kind: .wasInterrupted, notification: notification)
-        self.onInterrupted?()
+        self.onInterrupted?(.captureSessionLost)
       }
     }
 
@@ -573,7 +573,7 @@ final class AVCaptureSessionSource: AudioInputSource {
       MainActor.assumeIsolated {
         guard let self else { return }
         self.emitCaptureSessionInterruption(kind: .runtimeError, notification: notification)
-        self.onInterrupted?()
+        self.onInterrupted?(.captureSessionLost)
       }
     }
 

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -27,6 +27,14 @@ public protocol AudioCaptureInterface: AnyObject {
   /// (issue #1174 A3).
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)? { get set }
   var onVADAutoStop: (() -> Void)? { get set }
+  /// Fires when the manager's hard sample-count backstop (3660s) trips — a
+  /// NORMAL auto-stop, not a loss (#1408 A3; it used to masquerade as
+  /// `onEngineInterrupted(.maxDurationReached)`). The graceful 3600s wall-clock
+  /// cap lives host-side in `VADMonitorLoop` and never fires this; this
+  /// callback exists so the backstop reaches the same typed `.maxDuration`
+  /// stop route when the graceful cap wedges. Single-owner:
+  /// `CaptureVADSignalSource` claims it alongside `onVADAutoStop`.
+  var onMaxDurationReached: (() -> Void)? { get set }
 
   // Telemetry callbacks (round-4 additions for #285 heart-path Sentry coverage).
   // Producers: source backends (`AVAudioEngineSource`, `AVCaptureSessionSource`,

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -16,8 +16,10 @@ import os
 @MainActor
 @Observable
 public final class AudioCaptureManager: AudioCaptureInterface {
-  /// Current recording state.
-  public private(set) var isCapturing = false
+  /// Current recording state. `internal(set)` (not `private(set)`) solely so
+  /// the #1408 A3 backstop test can arm `ingestSamples` without real hardware;
+  /// production writes stay inside this file.
+  public internal(set) var isCapturing = false
 
   /// Current audio level (0.0 - 1.0) for waveform visualization.
   public private(set) var audioLevel: Float = 0.0
@@ -36,6 +38,19 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// Called when service-side VAD detects sustained silence after speech.
   /// No-op for in-process capture — VAD runs in the pipeline's monitorVAD() loop instead.
   public var onVADAutoStop: (() -> Void)?
+
+  /// #1408 A3: called on the main actor when the hard sample-count backstop
+  /// trips (a normal auto-stop, never a loss — it used to fire
+  /// `onEngineInterrupted(.maxDurationReached)`). The manager has already
+  /// stopped appending (`isCapturing = false`, its memory protection, which
+  /// holds even with a dead host); the consumer routes this into the same typed
+  /// `.maxDuration` stop the graceful wall-clock cap uses.
+  public var onMaxDurationReached: (() -> Void)?
+
+  /// #1408 A3: the backstop threshold, instance-scoped so tests can inject a
+  /// tiny limit (the production value is 58,560,000 samples — unreachable in a
+  /// unit test). Production never touches it.
+  var maxRecordingSamplesLimit: Int = AudioCaptureManager.maxRecordingSamples
 
   /// Optional fine-grained lifecycle signal used by the XPC service to publish
   /// phase ticks while a proxy is waiting on a lifecycle reply.
@@ -229,42 +244,32 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // Source identity check prevents stale callbacks from a replaced source
     // (e.g., pre-warm source replaced by startEnginePhase) from modifying state.
     let sourceID = ObjectIdentifier(source)
-    let maxSamples = Self.maxRecordingSamples
     source.onSamples = { [weak self] samples, level in
       Task { @MainActor in
         guard let self, self.isCapturing,
           self.activeSource.map({ ObjectIdentifier($0) }) == sourceID
         else { return }
-        self.audioLevel = level
-        self.capturedSamples.append(contentsOf: samples)
-        if self.capturedSamples.count >= maxSamples {
-          await AppLogger.shared.log(
-            "Max recording duration reached (\(Self.maxRecordingDurationSeconds)s) — auto-stopping",
-            level: .info, category: "Audio"
-          )
-          self.isCapturing = false
-          self.audioLevel = 0.0
-          // Direct-mode 60-min cap — a normal auto-stop, never captured as a loss.
-          self.onEngineInterrupted?(.maxDurationReached)
-        }
+        self.ingestSamples(samples, level: level)
       }
     }
     source.onBufferCaptured = onBufferCaptured
-    // Direct mode: an AVCaptureSession interruption is already captured by
-    // `onCaptureSessionInterruption` (→ `.audioCaptureFailed`), so tag it
-    // `.captureSessionLost` (suppress). An AVAudioEngine device disconnect has
-    // no other owner → `.engineLost` (capture). Resolve the discriminator to a
-    // value at bind time so the closure captures only the `Bool` (no strong
-    // `source` capture / retain cycle — matches the `sourceID`-only pattern).
-    let interruptionCause: EngineInterruptionCause =
-      source is AVCaptureSessionSource ? .captureSessionLost : .engineLost
-    source.onInterrupted = { [weak self] in
+    // (The `ingestSamples` body lives below `stopCapture()` — extracted so the
+    // #1408 A3 backstop is unit-testable with an injected `maxRecordingSamplesLimit`.)
+    // #1408: the SOURCE names the cause; the manager only forwards it. This used
+    // to be inferred from the source's class (`source is AVCaptureSessionSource
+    // ? .captureSessionLost : .engineLost`), which cannot distinguish a device
+    // that was verified gone (`.deviceRemoved`) from an engine that merely failed
+    // to recover (`.engineLost`) — both live inside `AVAudioEngineSource`. Only
+    // the source runs the `kAudioDevicePropertyDeviceIsAlive` check, so only the
+    // source can answer. Passing the cause as a parameter also means the closure
+    // captures no `source` reference at all.
+    source.onInterrupted = { [weak self] cause in
       guard let self,
         self.activeSource.map({ ObjectIdentifier($0) }) == sourceID
       else { return }
       self.isCapturing = false
       self.audioLevel = 0.0
-      self.onEngineInterrupted?(interruptionCause)
+      self.onEngineInterrupted?(cause)
     }
 
     // Forward heart-path telemetry callbacks (issue #285) — direct capture
@@ -356,6 +361,36 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     let samples = capturedSamples
     capturedSamples = []
     return CaptureResult(samples: samples, metadata: stopMetadata)
+  }
+
+  /// Append a batch of converted samples and enforce the hard sample-count
+  /// backstop (#1408 A3). Extracted from the `onSamples` wiring so the backstop
+  /// is unit-testable with an injected `maxRecordingSamplesLimit`; the wiring
+  /// closure owns the source-identity check, this owns the state change.
+  ///
+  /// The backstop is the LAST-DITCH memory protection behind the graceful
+  /// 3600s wall-clock cap (`VADMonitorLoop`, host-side): it stops appending
+  /// locally (`isCapturing = false` — the closure's guard goes quiet, so the
+  /// callback fires at most once) even when the host that would drive a normal
+  /// stop is gone, then signals a NORMAL `.maxDuration` stop through
+  /// `onMaxDurationReached` — never an engine interruption; no cause is
+  /// stamped, no loss is claimed. A later `stopCapture()` still returns the
+  /// accumulated samples (it has no `isCapturing` guard).
+  func ingestSamples(_ samples: [Float], level: Float) {
+    guard isCapturing else { return }
+    audioLevel = level
+    capturedSamples.append(contentsOf: samples)
+    if capturedSamples.count >= maxRecordingSamplesLimit {
+      isCapturing = false
+      audioLevel = 0.0
+      Task {
+        await AppLogger.shared.log(
+          "Max recording duration reached (\(Self.maxRecordingDurationSeconds)s) — auto-stopping",
+          level: .info, category: "Audio"
+        )
+      }
+      onMaxDurationReached?()
+    }
   }
 
   public func rebuildEngine() {

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -47,6 +47,9 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   public var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   public var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   public var onVADAutoStop: (() -> Void)?
+  /// #1408 A3: the helper's hard sample-count backstop, relayed as a normal
+  /// auto-stop event (`maxDurationReachedTriggered`), never an interruption.
+  public var onMaxDurationReached: (() -> Void)?
 
   // MARK: - Round-4 telemetry callbacks (issue #285)
 
@@ -144,6 +147,14 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   /// The generation that was active when the current capture session began.
   /// Set in beginCapturePhase, compared in audioBufferCaptured.
   private var activeCaptureGeneration: UInt64 = 0
+
+  /// #1408 A3 (Codex code-diff r6): the begin `operationID` that owns the live
+  /// session, nil outside one. The helper echoes it in
+  /// `maxDurationReachedTriggered`; equality against this field is the
+  /// session-identity check the generation counters cannot provide (both are
+  /// CURRENT fields, equal during any active session). Set on successful
+  /// begin; cleared wherever `isCapturing` goes false.
+  private var activeCaptureOperationID: String?
 
   /// #455: uptime-ns at the moment `beginCapturePhase` flipped `isCapturing`
   /// to true. Read in the XPC interrupt/invalidate handlers to surface
@@ -301,6 +312,12 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     ) { operationID in
       try await self.awaitBeginCaptureReply(
         operationID: operationID, recoveryPayload: recoveryPayload)
+      // #1408 A3 (Codex code-diff r6): remember which begin op owns this
+      // session — the max-duration relay echoes it, and a mismatch is a stale
+      // event from an EARLIER session that must not stop this one. Set only on
+      // the SUCCESSFUL attempt (a #1194 retry mints a fresh id; the helper
+      // stored whichever begin actually ran).
+      self.activeCaptureOperationID = operationID
     }
 
     isCapturing = true
@@ -429,6 +446,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     }
 
     isCapturing = false
+    activeCaptureOperationID = nil  // #1408 A3: session over, relay echoes are stale now
     captureStartUptimeNs = 0  // #455
     audioLevel = 0
     bufferContinuation?.finish()
@@ -942,6 +960,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       stallWorkItem?.cancel()
       stallWorkItem = nil
       isCapturing = false
+      activeCaptureOperationID = nil  // #1408 A3
       captureStartUptimeNs = 0  // #455
       audioLevel = 0
       captureGeneration &+= 1
@@ -1204,17 +1223,19 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
         self.stallWorkItem?.cancel()
         self.stallWorkItem = nil
         self.isCapturing = false
+        self.activeCaptureOperationID = nil  // #1408 A3
         self.captureStartUptimeNs = 0  // #455
         self.audioLevel = 0
         self.captureGeneration &+= 1
         self.bufferContinuation?.finish()
         self.bufferContinuation = nil
         // The service relays ALL its interruptions through this one channel.
-        // Every loss cause collapses to `.engineLost` (no other owner across the
-        // XPC boundary — there is no capture-session relay, so an XPC-mode
-        // AVCaptureSession interruption must be captured here too); only the hard
-        // max-duration cap is preserved so it stays suppressed exactly as in
-        // direct mode (issue #1174 A3).
+        // `.deviceRemoved` survives intact (the helper ran the liveness check);
+        // every other loss cause collapses to `.engineLost` (no other owner
+        // across the XPC boundary — there is no capture-session relay, so an
+        // XPC-mode AVCaptureSession interruption must be captured here too).
+        // The hard max-duration cap no longer travels here at all (#1408 A3:
+        // `maxDurationReachedTriggered` is its own event channel).
         self.onEngineInterrupted?(EngineInterruptionCause.hostCause(forRelayedRawValue: cause))
       }
       // #1194: the former `needsReinit = true` here is deleted with nothing
@@ -1232,6 +1253,25 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
         self.captureGeneration == self.activeCaptureGeneration
       else { return }
       self.onVADAutoStop?()
+    }
+  }
+
+  /// #1408 A3: the helper's hard sample-count backstop tripped — a normal
+  /// auto-stop, never a loss. Stale-fire protection goes one step past
+  /// `vadAutoStopTriggered` above (Codex code-diff r6): the event carries the
+  /// begin `operationID` that owns the emitting capture, and a mismatch against
+  /// the ACTIVE session's begin op is a delayed relay from an EARLIER session —
+  /// swallowed, so it can never stop a later recording. (The generation compare
+  /// alone cannot answer that: both fields are CURRENT state, equal during any
+  /// active session.)
+  nonisolated public func maxDurationReachedTriggered(operationID: String) {
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      guard self.isCapturing,
+        let active = self.activeCaptureOperationID,
+        operationID == active
+      else { return }
+      self.onMaxDurationReached?()
     }
   }
 }

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -15,7 +15,12 @@ protocol AudioInputSource: AnyObject {
   // Callbacks — set by AudioCaptureManager before start
   var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)? { get set }
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }
-  var onInterrupted: (() -> Void)? { get set }
+  /// #1408: the source names WHY capture stopped. It is the only layer that can:
+  /// only the source knows whether it ran the `kAudioDevicePropertyDeviceIsAlive`
+  /// check and saw the device gone, versus whether its engine simply failed to
+  /// recover with the device still attached. The manager used to infer this from
+  /// the source's CLASS, which cannot tell those two apart.
+  var onInterrupted: ((EngineInterruptionCause) -> Void)? { get set }
   var onLifecycleSignal: (@Sendable (String) -> Void)? { get set }
 
   /// Liveness-watchdog callback — fires once per capture session if zero

--- a/Sources/EnviousWisprAudio/CoreAudioDeviceLiveness.swift
+++ b/Sources/EnviousWisprAudio/CoreAudioDeviceLiveness.swift
@@ -1,0 +1,76 @@
+import CoreAudio
+
+/// #1408. What Core Audio told us when we asked whether an input device is still
+/// there. The third case is the one that matters: "we could not find out" is not
+/// the same answer as "it is gone," and only the latter may reach the user.
+public enum DeviceLiveness: Sendable, Equatable {
+  /// `DeviceIsAlive` answered yes. A Bluetooth codec switch, not a disconnect.
+  case alive
+
+  /// The device is gone: either it reported dead, or its object no longer
+  /// resolves. Entitles the caller to `.deviceRemoved`.
+  case removed
+
+  /// Core Audio failed the query for a reason that does not name a missing
+  /// device. We know the capture is broken; we do NOT know the microphone left.
+  case unverified
+}
+
+/// The single home for reading `kAudioDevicePropertyDeviceIsAlive` and turning
+/// the result into a `DeviceLiveness`.
+///
+/// Two capture sources ask this question (`AVAudioEngineSource` on an engine
+/// config change, `HALDeviceInputSource` from its liveness listener) and both
+/// used to inline the read, ignore the returned `OSStatus`, and test the
+/// `isAlive` out-parameter alone. That is wrong in BOTH directions once the
+/// answer drives user-facing copy:
+///
+/// - `isAlive` is a zero-initialized out-parameter. On any failed read it stays
+///   zero, so an unchecked read reports "dead" for a transient error and would
+///   stamp a permanent crossed-out-microphone badge on a recording whose
+///   microphone never left (Codex review r3).
+/// - But a REMOVED device's `AudioDeviceID` stops naming a valid object, so the
+///   query for a genuinely unplugged mic returns `kAudioHardwareBadObjectError`
+///   rather than `noErr` + `isAlive == 0`. Treating every non-`noErr` status as
+///   "unverified" would therefore suppress the disconnect notice on exactly the
+///   case #1408 exists for. Verified empirically: querying a nonexistent
+///   `AudioDeviceID` returns `'!obj'` and leaves `isAlive` at zero.
+public enum CoreAudioDeviceLiveness {
+
+  /// The pure decision, split out so it can be tested across the whole status
+  /// space without a real device to unplug.
+  ///
+  /// - Parameter isAlive: the out-parameter as Core Audio left it. Meaningful
+  ///   ONLY when `status == noErr`; on every other status it is still its zero
+  ///   initializer and is deliberately not read.
+  public static func interpret(status: OSStatus, isAlive: UInt32) -> DeviceLiveness {
+    switch status {
+    case noErr:
+      return isAlive == 0 ? .removed : .alive
+
+    // The ID does not name a live object / device. A removed device's ID is
+    // invalidated, so this IS the disconnect — not a failure to observe one.
+    case kAudioHardwareBadObjectError, kAudioHardwareBadDeviceError:
+      return .removed
+
+    // Anything else (bad property size, unknown property, an in-flight HAL
+    // reconfiguration): the read failed for a reason that says nothing about
+    // whether the device is present. Never claim a disconnect from here.
+    default:
+      return .unverified
+    }
+  }
+
+  /// Performs the read against Core Audio and interprets it.
+  public static func classify(deviceID: AudioDeviceID) -> DeviceLiveness {
+    var isAlive: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyDeviceIsAlive,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &isAlive)
+    return interpret(status: status, isAlive: isAlive)
+  }
+}

--- a/Sources/EnviousWisprAudio/EngineInterruptionCause.swift
+++ b/Sources/EnviousWisprAudio/EngineInterruptionCause.swift
@@ -4,15 +4,31 @@
 ///
 /// This is a CLASSIFICATION value, not heart-path control flow: the kernel still
 /// resets / stops identically for every case. Only the telemetry capture gate
-/// reads it (issue #1174 A3). The cause's job is to SUPPRESS the three causes
+/// reads it (issue #1174 A3). The cause's job is to SUPPRESS the two causes
 /// already accounted for elsewhere and CAPTURE everything else — every other
 /// recording-losing interruption is a genuine lost dictation with no other owner.
 public enum EngineInterruptionCause: String, Sendable, Equatable, CaseIterable {
-  /// A recording-losing audio interruption with no other owner — the gap A3
-  /// closes. Set by `AVAudioEngineSource` device disconnects (direct mode) and
-  /// by the XPC service relay (`AudioCaptureProxy.engineInterrupted(cause:)`),
-  /// which funnels ALL service-side interruptions through one channel because the
-  /// XPC client protocol has no capture-session callback. CAPTURED.
+  /// #1408. The user's input device is VERIFIED GONE: `CoreAudioDeviceLiveness`
+  /// classified it `.removed` — the device reported itself dead, or its object
+  /// no longer resolves at all. A Bluetooth headset that walks out of range, a
+  /// USB mic unplugged mid-sentence.
+  ///
+  /// This is the ONLY cause that entitles us to tell the user their microphone
+  /// disconnected. It was split out of `.engineLost`, which had come to mean both
+  /// "the device vanished" and "the engine could not recover" — a conflation that
+  /// would have put a permanent crossed-out-microphone badge on a recording whose
+  /// microphone never left. CAPTURED (a recording-losing interruption with no
+  /// other owner, exactly like `.engineLost`).
+  case deviceRemoved = "device_removed"
+
+  /// The capture engine died or failed to recover, with the device still attached
+  /// as far as we can tell: a format-stabilization timeout during codec-switch
+  /// recovery, a failed engine restart, or a config change with no resolvable
+  /// device id. Also the catch-all the XPC relay collapses unknown causes into.
+  /// A recording-losing interruption with no other owner — the gap #1174 A3
+  /// closes. CAPTURED.
+  ///
+  /// Does NOT mean the microphone went away. Use `.deviceRemoved` for that.
   case engineLost = "engine_lost"
 
   /// A DIRECT-mode `AVCaptureSession` interruption. Already captured by
@@ -24,20 +40,94 @@ public enum EngineInterruptionCause: String, Sendable, Equatable, CaseIterable {
   /// captured by `onXPCServiceError` → `.xpcServiceError`. NOT re-captured.
   case xpcConnectionLost = "xpc_connection_lost"
 
-  /// Direct-mode 60-minute max-duration cap (a normal auto-stop, not a loss).
-  /// NOT captured.
-  case maxDurationReached = "max_duration_reached"
+  // `.maxDurationReached` was DELETED (#1408 A3): the hard duration cap is a
+  // normal auto-stop, not an engine interruption. It now signals through
+  // `onMaxDurationReached` → `CaptureVADSignalSource.noteMaxDurationReached()`
+  // → the kernel's typed `.maxDuration` exit — the same route the graceful
+  // wall-clock cap has always used. Every case left here is a genuine
+  // capture-losing interruption.
 }
 
 extension EngineInterruptionCause {
+  /// #1408. Does the capture manager still hold `capturedSamples` after this
+  /// interruption — i.e. can the recording be transcribed rather than thrown away?
+  ///
+  /// Deliberately NOT the same question as "does this cause already have a
+  /// telemetry owner" (the doc comments above): the two disagree on
+  /// `.captureSessionLost`, which is suppressed for capture purposes yet leaves
+  /// the manager alive and holding audio; `.xpcConnectionLost` is the only
+  /// cause whose sample owner is gone.
+  ///
+  /// The single authority for that question: the kernel's salvage guard and
+  /// `KernelLifecycleTelemetrySink`'s `salvage_attempted` both read it, so the
+  /// switch is never copied. Exhaustive on purpose — a fifth cause must fail to
+  /// compile rather than silently default to "recoverable."
+  public var hasRecoverableAudio: Bool {
+    switch self {
+    case .deviceRemoved, .engineLost, .captureSessionLost: true
+    case .xpcConnectionLost: false
+    }
+  }
+
+  /// #1408. Did the user's INPUT DEVICE go away — the event the "Microphone
+  /// disconnected" pill and the History "Interrupted" badge describe?
+  ///
+  /// A THIRD question, distinct from both `hasRecoverableAudio` and the
+  /// telemetry-capture set above. `.engineLost` and `.captureSessionLost` also
+  /// interrupt capture and are also salvaged, but no microphone is known to
+  /// have disconnected. Showing that user a disconnect notice, or badging
+  /// their transcript with a crossed-out microphone, would be a lie. The salvage
+  /// still happens; only the microphone claim is withheld, and telemetry still
+  /// carries the real cause in `interrupted_by`.
+  ///
+  /// Exactly one cause earns it, and every exclusion is a claim we cannot back:
+  /// - `.engineLost` also covers a recovery timeout and a failed engine restart,
+  ///   with the device still attached.
+  /// - `.captureSessionLost` is raised for `AVCaptureSessionWasInterrupted` for
+  ///   ANY reason and for every `AVCaptureSessionRuntimeError`, mic still there.
+  /// - `.xpcConnectionLost` means OUR helper process died.
+  ///
+  /// Only `.deviceRemoved` is backed by evidence — a `CoreAudioDeviceLiveness`
+  /// classification of `.removed`. So it is the only cause allowed to say
+  /// "Microphone disconnected" or to leave a permanent crossed-out-microphone
+  /// badge on a transcript. A liveness read that merely FAILED is `.unverified`
+  /// there and arrives here as `.engineLost`, precisely so a transient Core
+  /// Audio error cannot manufacture a disconnect.
+  ///
+  /// Drives user-facing surfaces ONLY. Never gate salvage on this: every cause
+  /// above except `.xpcConnectionLost` still has its audio and is still salvaged.
+  public var isDeviceLoss: Bool {
+    switch self {
+    case .deviceRemoved: true
+    case .engineLost, .captureSessionLost, .xpcConnectionLost: false
+    }
+  }
+
   /// Maps a cause RELAYED across the XPC boundary (its raw value) to the cause the
-  /// host should fire. Across XPC there is no capture-session relay, so every loss
-  /// cause collapses to `.engineLost` — on the host side it has no other owner, so
-  /// it must be captured. Only the non-loss `.maxDurationReached` cap is preserved
-  /// so the host suppresses it exactly as direct mode does. Unknown / legacy raw
-  /// values default to `.engineLost` (fail toward visibility). Issue #1174 A3.
+  /// host should fire. Unknown / legacy raw values default to `.engineLost` (fail
+  /// toward visibility). Issue #1174 A3.
+  ///
+  /// One cause survives the crossing intact:
+  /// - `.deviceRemoved` (#1408), because the helper ran the liveness check and
+  ///   the host cannot re-run it — the device is already gone. Collapsing it
+  ///   would throw away the ONE piece of evidence that entitles the app to tell
+  ///   the user their microphone disconnected. The helper's capture backend IS
+  ///   the shipping one (`useXPCAudioService` defaults true), so this is the path
+  ///   a real Bluetooth disconnect actually takes.
+  ///
+  /// (`max_duration_reached` no longer exists as a cause (#1408 A3); a legacy
+  /// raw value from a stale helper maps to `.engineLost` like every other
+  /// unknown — helper and host ship in one bundle, so skew cannot happen in
+  /// practice.)
+  ///
+  /// Everything else collapses to `.engineLost`: across XPC there is no
+  /// capture-session relay, so on the host side those have no other owner and
+  /// must still be captured.
   public static func hostCause(forRelayedRawValue raw: String) -> EngineInterruptionCause {
     let relayed = EngineInterruptionCause(rawValue: raw) ?? .engineLost
-    return relayed == .maxDurationReached ? .maxDurationReached : .engineLost
+    switch relayed {
+    case .deviceRemoved: return relayed
+    case .engineLost, .captureSessionLost, .xpcConnectionLost: return .engineLost
+    }
   }
 }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -306,7 +306,7 @@ final class HALDeviceInputSource: AudioInputSource {
 
   var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-  var onInterrupted: (() -> Void)?
+  var onInterrupted: ((EngineInterruptionCause) -> Void)?
   var onLifecycleSignal: (@Sendable (String) -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   /// No `AVCaptureSession` layer — stays nil, matching `AVAudioEngineSource`.
@@ -929,11 +929,12 @@ final class HALDeviceInputSource: AudioInputSource {
 
   // MARK: - Private: disconnect handling
 
-  /// Mirrors `AVAudioEngineSource.handleEngineConfigurationChange`'s
-  /// `kAudioDevicePropertyDeviceIsAlive` check — device-vanished is engine-
-  /// independent per #1377 bake-off findings, so candidate D needs the same
-  /// detection. Fires `onInterrupted()`; the accumulated `capturedSamples`
-  /// salvage (manager-owned) is what actually saves the partial dictation.
+  /// Mirrors `AVAudioEngineSource.handleEngineConfigurationChange`'s liveness
+  /// check (both go through `CoreAudioDeviceLiveness`) — device-vanished is
+  /// engine-independent per #1377 bake-off findings, so candidate D needs the same
+  /// detection. Fires `onInterrupted()`; the manager keeps holding the accumulated
+  /// `capturedSamples`, and #1408 made `RecordingSessionKernel` transcribe them at
+  /// the recording exit. The kernel saves the partial dictation, not the manager.
   private func registerDeviceIsAliveListener(deviceID: AudioDeviceID) {
     var addr = AudioObjectPropertyAddress(
       mSelector: kAudioDevicePropertyDeviceIsAlive,
@@ -1051,17 +1052,18 @@ final class HALDeviceInputSource: AudioInputSource {
 
   private func handleDeviceMayHaveVanished(deviceID: AudioDeviceID) {
     guard isCapturing, !isRecovering else { return }
-    var isAlive: UInt32 = 0
-    var size = UInt32(MemoryLayout<UInt32>.size)
-    var addr = AudioObjectPropertyAddress(
-      mSelector: kAudioDevicePropertyDeviceIsAlive,
-      mScope: kAudioObjectPropertyScopeGlobal,
-      mElement: kAudioObjectPropertyElementMain
-    )
-    AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &isAlive)
-    guard isAlive == 0 else { return }
+    let liveness = CoreAudioDeviceLiveness.classify(deviceID: deviceID)
+    guard liveness != .alive else { return }
+
+    // #1408: `.removed` is Core Audio confirming the device is gone, and earns
+    // the "Microphone disconnected" notice. `.unverified` means the read itself
+    // failed for a reason that says nothing about the device — the capture is
+    // still broken, so tear down and salvage exactly the same way, but report
+    // the honest cause so we never badge a mic that never left.
+    let cause: EngineInterruptionCause = liveness == .removed ? .deviceRemoved : .engineLost
     AudioCaptureManager.btRouteLog(
-      "HALDeviceInputSource: device \(deviceID) went away — interrupting")
+      "HALDeviceInputSource: device \(deviceID) \(liveness == .removed ? "went away" : "liveness unverified") — interrupting (\(cause.rawValue))"
+    )
     // Tear down BEFORE firing onInterrupted (mirrors AVAudioEngineSource's
     // emergencyTeardown-then-onInterrupted order). Without this, `isRunning`
     // still reports true (we never called AudioOutputUnitStop), so the
@@ -1069,7 +1071,7 @@ final class HALDeviceInputSource: AudioInputSource {
     // bound to a device that no longer exists on the NEXT recording instead
     // of rebuilding fresh (cloud review P2).
     teardownUnit()
-    onInterrupted?()
+    onInterrupted?(cause)
   }
 
   /// A dedicated thread that blocks on `context.semaphore` and drains the

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -52,6 +52,15 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
   /// (the writer is also idempotent; this avoids even queuing the second call).
   private var recoveryFinalized: Bool = false
 
+  /// #1408 A3 (Codex code-diff r6): the `operationID` of the begin op that owns
+  /// the LIVE capture. Echoed in `maxDurationReachedTriggered` so the host can
+  /// reject a maximally delayed relay that would otherwise stop a LATER
+  /// recording. Overwritten by every `beginCapture`; never cleared — a stale
+  /// value is inert because the proxy compares against ITS active begin op,
+  /// which is nil outside a session. MainActor-confined (written in
+  /// `beginCapture`'s MainActor task, read in the manager callback).
+  private var activeBeginOperationID: String?
+
   /// Get or create the capture manager on MainActor, wiring callbacks on first creation.
   @MainActor
   private var captureManager: AudioCaptureManager {
@@ -92,16 +101,31 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
     }
 
     // Engine interruption callback: fires on @MainActor. Relay the cause's raw
-    // value across XPC so the host can suppress the non-loss max-duration cap
-    // while still capturing genuine losses. The host collapses every loss cause
-    // to `.engineLost` (AVCaptureSession interruptions have no separate relay
-    // across the boundary, so they have no other owner there) and suppresses
-    // only `.maxDurationReached`. See `AudioCaptureProxy.engineInterrupted(cause:)`
-    // (issue #1174 A3).
+    // value across XPC. The host preserves `.deviceRemoved` (the helper ran the
+    // liveness check; the host cannot re-run it) and collapses every other loss
+    // cause to `.engineLost` (AVCaptureSession interruptions have no separate
+    // relay across the boundary, so they have no other owner there). See
+    // `AudioCaptureProxy.engineInterrupted(cause:)` (issue #1174 A3; the
+    // max-duration cap left this channel in #1408 A3 — it relays via
+    // `maxDurationReachedTriggered` below).
     manager.onEngineInterrupted = { [weak self] cause in
       let raw = cause.rawValue
       self?.xpcSendQueue.async { [weak self] in
         self?.clientProxy?.engineInterrupted(cause: raw)
+      }
+    }
+
+    // #1408 A3: the hard sample-count backstop is a NORMAL auto-stop, relayed
+    // on its own event channel (beside `vadAutoStopTriggered`) — never through
+    // the interruption relay above. The manager has already stopped appending
+    // locally, so helper memory stays bounded even if this event never lands.
+    manager.onMaxDurationReached = { [weak self] in
+      // Snapshot the owning begin op on the MainActor (where it is written)
+      // BEFORE hopping to the send queue.
+      guard let self else { return }
+      let owningOperationID = self.activeBeginOperationID ?? ""
+      self.xpcSendQueue.async { [weak self] in
+        self?.clientProxy?.maxDurationReachedTriggered(operationID: owningOperationID)
       }
     }
   }
@@ -214,6 +238,11 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
     nonisolated(unsafe) let safeReply = reply
     Task { @MainActor in
       signal.emit(stage: "audio.begin_capture.main_actor")
+      // #1408 A3 (Codex code-diff r6): remember which begin op owns the live
+      // capture so the max-duration relay can carry session identity — the
+      // host rejects an echo that does not match its ACTIVE begin op, so a
+      // maximally delayed callback can never stop a LATER recording.
+      self.activeBeginOperationID = operationID
       let previousLifecycleSignal = self.captureManager.onLifecycleSignal
       self.captureManager.onLifecycleSignal = { phase in
         signal.emit(stage: "audio.begin_capture.\(phase)")

--- a/Sources/EnviousWisprCore/AudioServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/AudioServiceProtocol.swift
@@ -93,14 +93,24 @@ import Foundation
   /// No header or metadata — just the raw sample bytes.
   func audioBufferCaptured(_ data: Data, frameCount: Int, audioLevel: Float)
 
-  /// The audio engine was interrupted (device disconnect, emergency teardown, max-duration cap).
+  /// The audio engine was interrupted (device disconnect, emergency teardown).
   /// The proxy should transition pipelines to error state. `cause` is the
-  /// `EngineInterruptionCause` raw value so the host can suppress the telemetry
-  /// capture for the non-loss `max_duration_reached` cap while still capturing
-  /// genuine losses (issue #1174 A3). Unknown / legacy values map to
-  /// `engine_lost` at the host.
+  /// `EngineInterruptionCause` raw value: `device_removed` survives the
+  /// crossing (the helper ran the liveness check); unknown / legacy values map
+  /// to `engine_lost` at the host (issue #1174 A3). The max-duration cap does
+  /// NOT travel here (#1408 A3 — see `maxDurationReachedTriggered`).
   func engineInterrupted(cause: String)
 
   /// Service-side VAD detected sustained silence after speech — auto-stop should trigger.
   func vadAutoStopTriggered()
+
+  /// The service-side hard sample-count backstop (3660s) tripped — a NORMAL
+  /// auto-stop, not a loss (#1408 A3). Service→host EVENT delivery (like
+  /// `vadAutoStopTriggered`, unlike configuration — no replay on reconnect).
+  /// The host routes it into the same typed `.maxDuration` stop the graceful
+  /// wall-clock cap uses. `operationID` is the begin op that owns the emitting
+  /// capture (Codex code-diff r6): the host rejects a mismatch against its
+  /// ACTIVE begin op, so a maximally delayed event cannot stop a later
+  /// recording.
+  func maxDurationReachedTriggered(operationID: String)
 }

--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -224,6 +224,18 @@ public struct Transcript: Codable, Identifiable, Sendable {
   /// after an abnormal exit — drives the History "Recovered" badge. Optional so
   /// legacy JSON decodes to nil (treated as not-recovered). #1063.
   public let isRecovered: Bool?
+  /// True when this recording's input device was VERIFIED REMOVED mid-recording
+  /// (`EngineInterruptionCause.isDeviceLoss`) and this transcript is what
+  /// survived — drives the History "Interrupted" badge (a crossed-out mic, so it
+  /// takes the strictest predicate: the icon must never claim a removal that was
+  /// not verified). `false` covers both normal takes and takes interrupted by a
+  /// non-removal cause; `nil` means unknown, which is what a spool-recovered
+  /// transcript gets (the spool records why the WRITER exited, not why the
+  /// recording ended). Optional so pre-#1408 JSON decodes to nil (synthesized
+  /// `Codable`, no custom decode). #1408; renamed from `isInterrupted` pre-ship
+  /// (grounded review: the old name promised every interruption while the value
+  /// carried one).
+  public let inputDeviceWasRemoved: Bool?
 
   public init(
     id: UUID = UUID(),
@@ -238,7 +250,8 @@ public struct Transcript: Codable, Identifiable, Sendable {
     llmModel: String? = nil,
     metrics: ExecutionMetrics? = nil,
     recoverySessionID: String? = nil,
-    isRecovered: Bool? = nil
+    isRecovered: Bool? = nil,
+    inputDeviceWasRemoved: Bool? = nil
   ) {
     self.id = id
     self.text = text
@@ -253,6 +266,7 @@ public struct Transcript: Codable, Identifiable, Sendable {
     self.metrics = metrics
     self.recoverySessionID = recoverySessionID
     self.isRecovered = isRecovered
+    self.inputDeviceWasRemoved = inputDeviceWasRemoved
   }
 
   /// The text to display — polished if available, otherwise raw.

--- a/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
@@ -132,13 +132,20 @@ package final class CaptureVADSignalSource: VADSignalSource {
     segmentsProvider = provider
   }
 
-  /// Claim sole ownership of `AudioCaptureInterface.onVADAutoStop` (PR-4 §3.5).
-  /// The XPC service-side detector fires this callback; the kernel no longer
-  /// binds it directly (`bindCaptureCallbacks` dropped that wiring).
+  /// Claim sole ownership of `AudioCaptureInterface.onVADAutoStop` AND
+  /// `onMaxDurationReached` (PR-4 §3.5; #1408 A3). The XPC service-side
+  /// detector fires the first; the manager's hard sample-count backstop fires
+  /// the second — both funnel into the ONE typed `VADStopSignal` route, so the
+  /// kernel receives the same session-stamped, stale-drop-protected stop
+  /// signal whichever mechanism noticed first. The kernel no longer binds
+  /// either directly (`bindCaptureCallbacks` dropped that wiring).
   func bind(audioCapture: any AudioCaptureInterface) {
     self.audioCapture = audioCapture
     audioCapture.onVADAutoStop = { [weak self] in
       self?.noteAutoStopTriggered()
+    }
+    audioCapture.onMaxDurationReached = { [weak self] in
+      self?.noteMaxDurationReached()
     }
   }
 

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -498,7 +498,8 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   public var state: PipelineState {
     Self.pipelineState(
       for: kernel.state, externalError: lastExternalError,
-      failureDetail: kernel.lastFailureDetail)
+      failureDetail: kernel.lastFailureDetail,
+      interruptionCause: kernel.lastAudioInterruptionCause)
   }
 
   /// The transcript the `store` closure built for the last completed session.
@@ -676,7 +677,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // `.audioInterrupted` from here, so the lifecycle sink's
       // `.audioInterrupted` handler never fires.
       SentryBreadcrumb.updateRecordingState(active: false)
-      setExternalError(InterruptionMessages.micDisconnected)
+      setExternalError(InterruptionMessages.message(for: cause))
     case .idle, .completed, .failed, .cancelled, .discarded, .noSpeech,
       .audioInterrupted, .asrInterrupted:
       // Already idle / terminal — no useful action. Router-stale calls
@@ -746,6 +747,13 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// kernel; never persisted. Reason strings only, never user content.
   public var lastStopReason: String? { kernel.lastStopReason }
   public var lastRecordingDurationSeconds: Double? { kernel.lastRecordingDurationSeconds }
+  /// #1408: non-nil when the most recent recording's capture was interrupted
+  /// mid-flight (device died, cap reached). Drives the disconnect disclosure pill
+  /// and `dictation.completed.interrupted_by`. LIVE pass-through from the kernel;
+  /// never persisted; a low-cardinality reason string, no user content.
+  public var lastAudioInterruptionCause: EngineInterruptionCause? {
+    kernel.lastAudioInterruptionCause
+  }
   /// #1376: the resolved-route transports for the most recent recording, for
   /// the App layer's `dictation.completed` telemetry. LIVE pass-through from the
   /// kernel; never persisted. Low-cardinality transport/reason strings only.
@@ -838,7 +846,8 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       return .error(
         message: Self.failureMessage(reason, detail: kernel.lastFailureDetail))
     case .audioInterrupted:
-      return .interruption(message: InterruptionMessages.micDisconnected)
+      return .interruption(
+        message: InterruptionMessages.message(for: kernel.lastAudioInterruptionCause))
     case .asrInterrupted:
       return .error(message: Self.asrInterruptedMessage)
     }
@@ -1278,9 +1287,14 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// when present and falls back to the parity-bare string when nil. The
   /// driver's instance `state` getter threads `kernel.lastFailureDetail`
   /// through; existing test callers pass nil for byte-parity coverage.
+  /// `interruptionCause` selects the audio-interruption sentence (#1408). It
+  /// defaults to nil, which yields the neutral "Recording interrupted" line —
+  /// never a disconnect claim. Only the instance `state` getter has a kernel to
+  /// read the real cause from; test callers keep the byte-parity default.
   public static func pipelineState(
     for state: RecordingSessionState, externalError: String?,
-    failureDetail: String? = nil
+    failureDetail: String? = nil,
+    interruptionCause: EngineInterruptionCause? = nil
   ) -> PipelineState {
     if let externalError {
       return .error(externalError)
@@ -1318,7 +1332,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     case .failed(let reason):
       return .error(failureMessage(reason, detail: failureDetail))
     case .audioInterrupted:
-      return .error(InterruptionMessages.micDisconnected)
+      return .error(InterruptionMessages.message(for: interruptionCause))
     case .asrInterrupted:
       return .error(asrInterruptedMessage)
     }

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -266,7 +266,19 @@ struct KernelFinalizationWiring {
         // key once this save is durable. `isRecovered` is false — this is the
         // live take, not a rescued one.
         recoverySessionID: context.config?.recoverySessionID,
-        isRecovered: false)
+        isRecovered: false,
+        // #1408: the mic died mid-recording and this is the salvaged take. Read
+        // from the SAME shared `KernelTelemetryState` this closure already
+        // captures for `historySaveFailed` — the kernel stamped the cause before
+        // the exit, and nothing clears it until the next `start(config:)`. No
+        // widened `store` signature; the holder is the single home.
+        //
+        // `isDeviceLoss`, NOT `!= nil`. An engine that failed to recover and a
+        // broad capture-session failure are salvaged too, and badging those
+        // transcripts with a permanent crossed-out microphone would tell the user
+        // something that did not happen. This badge is durable and unfixable
+        // after the fact, so it takes the strictest predicate.
+        inputDeviceWasRemoved: telemetryState.interruptionCause?.isDeviceLoss == true)
       outcome.transcript = transcript
       do {
         try save(transcript)

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -71,6 +71,13 @@ final class KernelLifecycleTelemetrySink {
   /// rich payload.
   typealias NoAudioCapturedSink = @MainActor (_ ctx: NoAudioContext) -> Void
 
+  /// #1408: the non-paging counter that gives salvage a denominator. Injected
+  /// like every other sink so tests observe the emission without PostHog.
+  typealias AudioCaptureInterruptedSink = @MainActor (
+    _ cause: String, _ salvageAttempted: Bool, _ salvageSucceeded: Bool,
+    _ terminalState: String, _ backend: String, _ recordingDurationMs: Int?
+  ) -> Void
+
   // MARK: Identity + read sources
 
   private let backend: ASRBackendType
@@ -95,6 +102,7 @@ final class KernelLifecycleTelemetrySink {
   /// recorder pattern observes the emission via its `captureError`
   /// injection.
   private let noAudioCapturedRich: NoAudioCapturedSink?
+  private let audioCaptureInterrupted: AudioCaptureInterruptedSink
 
   init(
     backend: ASRBackendType,
@@ -136,7 +144,13 @@ final class KernelLifecycleTelemetrySink {
       SentryBreadcrumb.captureError(
         error, category: category, stage: stage, extra: extra, snapshot: snapshot)
     },
-    noAudioCapturedRich: NoAudioCapturedSink? = nil
+    noAudioCapturedRich: NoAudioCapturedSink? = nil,
+    audioCaptureInterrupted: @escaping AudioCaptureInterruptedSink = {
+      cause, attempted, succeeded, terminal, backend, durationMs in
+      TelemetryService.shared.audioCaptureInterrupted(
+        cause: cause, salvageAttempted: attempted, salvageSucceeded: succeeded,
+        terminalState: terminal, backend: backend, recordingDurationMs: durationMs)
+    }
   ) {
     self.backend = backend
     self.audioCapture = audioCapture
@@ -153,6 +167,7 @@ final class KernelLifecycleTelemetrySink {
     self.captureError = captureError
     self.captureErrorWithSnapshot = captureErrorWithSnapshot
     self.noAudioCapturedRich = noAudioCapturedRich
+    self.audioCaptureInterrupted = audioCaptureInterrupted
   }
 
   /// Switch over the 12-case lifecycle vocabulary and emit each PR-1 §B.7.2
@@ -161,6 +176,7 @@ final class KernelLifecycleTelemetrySink {
   /// mapping table — preserved where the sink can read, deferred where rich
   /// kernel-side wiring would be required (§2.2 non-goals).
   func emit(_ event: KernelLifecycleEvent) {
+    emitAudioCaptureInterruptedIfNeeded(for: event)
     switch event {
     case .pipelineStartingUp:
       // PR-5 Rung 5 Pass 2 #1 — parity with OLD
@@ -239,16 +255,23 @@ final class KernelLifecycleTelemetrySink {
       emitFailed(reason)
 
     case .audioInterrupted(let cause):
-      // Capture the lost dictation ONLY for `.engineLost` — a recording-losing
-      // audio interruption with no other owner (issue #1174 A3). The three other
-      // causes are already accounted for: `.captureSessionLost` by
-      // `captureSessionInterrupted`, `.xpcConnectionLost` by `onXPCServiceError`,
-      // and `.maxDurationReached` is a normal auto-stop, not a loss. Category is
+      // Capture the lost dictation ONLY for the two causes with no other owner
+      // (issue #1174 A3): `.engineLost` and, since #1408, `.deviceRemoved` — the
+      // verified-disconnect half that used to hide inside `.engineLost`. Both are
+      // genuine unowned losses, so splitting the cause must not halve the alert.
+      // The other two are already accounted for: `.captureSessionLost` by
+      // `captureSessionInterrupted`, `.xpcConnectionLost` by `onXPCServiceError`.
+      // (`.maxDurationReached` was deleted by #1408 A3 — the cap is a normal
+      // auto-stop and no longer stamps a cause at all.) Category is
       // `.audioCaptureFailed` (matching the `captureSessionInterrupted` sibling),
       // never `.xpcServiceError` — a benign device disconnect must not page the
       // "XPC Service Crash >1/hr" alert.
+      //
+      // NOTE: reaching this terminal at all now means salvage did not produce a
+      // transcript. A salvaged dictation ends `.completed` and never lands here,
+      // so this emit no longer fires for a recording the user actually received.
       switch cause {
-      case .engineLost:
+      case .engineLost, .deviceRemoved:
         let snapshot = recordingSnapshot()
         emitCaptureError(
           HeartPathError.audioEngineInterrupted(
@@ -257,7 +280,7 @@ final class KernelLifecycleTelemetrySink {
           .audioCaptureFailed, "audio",
           ["was_recording": true, "backend": backend.rawValue],
           snapshot: snapshot)
-      case .captureSessionLost, .xpcConnectionLost, .maxDurationReached:
+      case .captureSessionLost, .xpcConnectionLost:
         break
       }
       updateRecordingState(false, nil, nil)
@@ -317,6 +340,46 @@ final class KernelLifecycleTelemetrySink {
       // The kernel state observer still tracks the `.cancelled` transition —
       // only the telemetry emission is omitted.
       break
+    }
+  }
+
+  /// #1408: emit the interruption counter exactly once per interrupted session,
+  /// at whatever terminal that session reaches. ONE site, not one per arm: a
+  /// salvage can end `.completed`, `.audioInterrupted` (the floor), `.cancelled`
+  /// (the user discarded it), or `.failed` (the audio came back but decoded to
+  /// nothing), and a per-arm emit would quietly miss whichever arm nobody thought
+  /// of. `terminalStateLabel` is exhaustive, so a new terminal must decide.
+  ///
+  /// Reads the same `telemetryState.interruptionCause` the kernel's salvage guard
+  /// reads, and derives `salvage_attempted` from `hasRecoverableAudio` — the one
+  /// authority — never a second copy of that switch.
+  private func emitAudioCaptureInterruptedIfNeeded(for event: KernelLifecycleEvent) {
+    guard let cause = telemetryState.interruptionCause,
+      let terminal = Self.terminalStateLabel(for: event)
+    else { return }
+    audioCaptureInterrupted(
+      cause.rawValue,
+      cause.hasRecoverableAudio,
+      terminal == "completed",
+      terminal,
+      backend.rawValue,
+      telemetryState.recordingSnapshot?.durationMs)
+  }
+
+  /// The terminal each lifecycle event represents, or `nil` for a non-terminal
+  /// event. Exhaustive on purpose.
+  private static func terminalStateLabel(for event: KernelLifecycleEvent) -> String? {
+    switch event {
+    case .pipelineCompleted: "completed"
+    case .failed: "failed"
+    case .audioInterrupted: "audio_interrupted"
+    case .asrInterrupted: "asr_interrupted"
+    case .discarded: "discarded"
+    case .noSpeech: "no_speech"
+    case .cancelled: "cancelled"
+    case .pipelineStartingUp, .modelLoading, .recordingCommitted, .recordingStopped,
+      .transcriptionStarted, .asrCompleted:
+      nil
     }
   }
 

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -1,3 +1,4 @@
+import EnviousWisprAudio
 import EnviousWisprCore
 import Foundation
 
@@ -25,6 +26,16 @@ final class KernelTelemetryState {
   /// guard passes — BEFORE the too-short / no-audio / dead-air early
   /// terminals — so no-audio, asrEmpty, and completed all share it.
   var captureHealth: KernelCaptureHealthTelemetry?
+  /// #1408: the ONE home for "this session's capture was interrupted, by cause X."
+  /// Stamped once per session by `RecordingSessionKernel.externalEngineInterrupted`
+  /// under its first-wins accept condition, and read by four consumers: the
+  /// kernel's salvage guard, the kernel's terminal floor, the History "Interrupted"
+  /// badge (via the `store` closure, which already captures this holder), and this
+  /// module's lifecycle telemetry sink. `RecordingSessionKernel
+  /// .lastAudioInterruptionCause` is a computed read-through to here, not a second
+  /// copy. Cleared ONLY by `resetForNewSession()` below — a second clearer would
+  /// let a stale cause leak into the next session and mis-fire the floor.
+  var interruptionCause: EngineInterruptionCause?
 
   func resetForNewSession(polishEnabled: Bool) {
     self.polishEnabled = polishEnabled
@@ -37,6 +48,7 @@ final class KernelTelemetryState {
     transcriptionFailureError = nil
     modelLoadError = nil
     captureHealth = nil
+    interruptionCause = nil
   }
 }
 

--- a/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
@@ -38,6 +38,12 @@ public final class PipelineStateChangeHandler {
   private let scheduleHistorySaveFailedWarning: @MainActor (String) -> Void
   /// #1434: schedule the transient salvaged-lead disclosure pill.
   private let scheduleSalvagedLeadWarning: @MainActor () -> Void
+  /// #1408: schedule the transient interruption disclosure pill. The disclosure
+  /// picks the sentence family (mic-disconnect vs neutral) and the flag picks
+  /// between the tail-only and both-ends-lost copies; the caller owns all four
+  /// literals (the message is wired at the factory site, never in here).
+  private let scheduleInterruptionWarning:
+    @MainActor (_ disclosure: CompletionInterruptionDisclosure, _ alsoTrimmedLead: Bool) -> Void
 
   public init(
     showOverlay: @escaping ShowOverlay,
@@ -47,7 +53,10 @@ public final class PipelineStateChangeHandler {
     reportDictationCompleted: @escaping @MainActor (Transcript) -> Void,
     reportPipelineFailed: @escaping @MainActor (String) -> Void,
     scheduleHistorySaveFailedWarning: @escaping @MainActor (String) -> Void,
-    scheduleSalvagedLeadWarning: @escaping @MainActor () -> Void = {}
+    scheduleSalvagedLeadWarning: @escaping @MainActor () -> Void = {},
+    scheduleInterruptionWarning: @escaping @MainActor (
+      _ disclosure: CompletionInterruptionDisclosure, _ alsoTrimmedLead: Bool
+    ) -> Void = { _, _ in }
   ) {
     self.showOverlay = showOverlay
     self.cancelPendingWarning = cancelPendingWarning
@@ -57,6 +66,7 @@ public final class PipelineStateChangeHandler {
     self.reportPipelineFailed = reportPipelineFailed
     self.scheduleHistorySaveFailedWarning = scheduleHistorySaveFailedWarning
     self.scheduleSalvagedLeadWarning = scheduleSalvagedLeadWarning
+    self.scheduleInterruptionWarning = scheduleInterruptionWarning
   }
 
   /// Drive the full state-change behavior contract for one pipeline.
@@ -72,7 +82,8 @@ public final class PipelineStateChangeHandler {
     currentTranscript: Transcript?,
     historySaved: Bool,
     historySaveReason: String?,
-    salvagedLead: Bool = false
+    salvagedLead: Bool = false,
+    interruptionDisclosure: CompletionInterruptionDisclosure? = nil
   ) {
     let plan = PipelineStateChangePlanner.plan(
       to: newState,
@@ -84,7 +95,8 @@ public final class PipelineStateChangeHandler {
       hasCurrentTranscript: currentTranscript != nil,
       historySaved: historySaved,
       historySaveReason: historySaveReason,
-      salvagedLead: salvagedLead
+      salvagedLead: salvagedLead,
+      interruptionDisclosure: interruptionDisclosure
     )
     for effect in plan.effects {
       switch effect {
@@ -108,6 +120,8 @@ public final class PipelineStateChangeHandler {
         scheduleHistorySaveFailedWarning(reason)
       case .scheduleSalvagedLeadWarning:
         scheduleSalvagedLeadWarning()
+      case .scheduleInterruptionWarning(let disclosure, let alsoTrimmedLead):
+        scheduleInterruptionWarning(disclosure, alsoTrimmedLead)
       }
     }
   }

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -49,9 +49,25 @@ enum PipelineStateSideEffect: Equatable, Sendable {
   /// the transcript by trimming a poisoned prefix, so the pasted text is
   /// missing its lead, and a trimmed lead can invert meaning invisibly. The
   /// disclosure never touches the pasted text. Shares the single
-  /// post-completion warning slot: history-save-failed > salvaged-lead >
-  /// polish-failed.
+  /// post-completion warning slot: history-save-failed > disconnect >
+  /// salvaged-lead > polish-failed (rank 2 inserted by #1408).
   case scheduleSalvagedLeadWarning
+
+  /// #1408: schedule the transient interruption pill on a completion whose
+  /// capture was interrupted mid-recording. The pasted text is what survived,
+  /// so the user must be told it may be cut short BEFORE they send it. The
+  /// disclosure picks the sentence family: `.deviceRemoved` may say
+  /// "Microphone disconnected"; `.otherInterruption` gets the neutral
+  /// "Recording interrupted" wording (grounded review A1 — a non-disconnect
+  /// salvage must not paste truncated text silently).
+  ///
+  /// `alsoTrimmedLead` is true when this take ALSO lost its opening to the
+  /// degraded-lead retry (#1434). One take can lose both ends, and a plain
+  /// ranking would tell the user only about the tail — so the combined case gets
+  /// its own copy rather than suppressing the lead notice. One effect carrying
+  /// flags, not two effects: the difference is a message, not a mechanism.
+  case scheduleInterruptionWarning(
+    disclosure: CompletionInterruptionDisclosure, alsoTrimmedLead: Bool)
 }
 
 struct PipelineStateChangePlan: Equatable, Sendable {
@@ -88,9 +104,11 @@ enum PipelineStateChangePlanner {
     hasCurrentTranscript: Bool,
     historySaved: Bool,
     historySaveReason: String?,
-    salvagedLead: Bool = false
+    salvagedLead: Bool = false,
+    interruptionDisclosure: CompletionInterruptionDisclosure? = nil
   ) -> PipelineStateChangePlan {
     var effects: [PipelineStateSideEffect] = []
+    let interrupted = interruptionDisclosure != nil
 
     // #1167: a degraded-save completion (delivery ran, history write threw).
     // Only meaningful on `.complete` with a transcript in hand.
@@ -119,16 +137,30 @@ enum PipelineStateChangePlanner {
         // #1434: a salvaged-lead completion also takes the single warning
         // slot ahead of the polish pill (data-loss disclosure beats a
         // formatting notice) — scheduled below, outside this branch.
-        if !historySaveFailed, !salvagedLead, !PolishFailureReason.isSkipNotice(polishError) {
+        // #1408: so does a mid-recording disconnect, for the same reason.
+        if !historySaveFailed, !interrupted, !salvagedLead,
+          !PolishFailureReason.isSkipNotice(polishError)
+        {
           effects.append(.schedulePolishFailedWarning)
         }
       } else {
         resolvedOverlayIntent = pipelineOverlayIntent
       }
-      // #1434: salvaged-lead disclosure. Priority within the single warning
-      // slot: history-save-failed (scheduled in Step 2) > salvaged-lead >
-      // polish-failed (suppressed above when salvaged).
-      if salvagedLead, !historySaveFailed {
+      // Disclosure priority within the single post-completion warning slot:
+      // history-save-failed (scheduled in Step 2) > disconnect > salvaged-lead >
+      // polish-failed (suppressed above). Encoded as explicit suppression
+      // conditions, NOT as array order — `schedulePostCompletionWarning` is
+      // last-writer-wins, so position in this list decides nothing.
+      //
+      // #1408: a take can lose its opening (lead trimmed) AND its ending (mic
+      // died). Suppressing the lead notice under a plain ranking would tell the
+      // user only that the text is cut short, hiding the dropped opening — so
+      // the both-fired case carries its own copy instead.
+      if let disclosure = interruptionDisclosure, !historySaveFailed {
+        effects.append(
+          .scheduleInterruptionWarning(disclosure: disclosure, alsoTrimmedLead: salvagedLead))
+      }
+      if salvagedLead, !historySaveFailed, !interrupted {
         effects.append(.scheduleSalvagedLeadWarning)
       }
     default:

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -1,3 +1,4 @@
+import EnviousWisprAudio
 import EnviousWisprCore
 import Foundation
 
@@ -10,7 +11,55 @@ import Foundation
 
 /// Known interruption message strings used to route .error state to .interruption overlay intent.
 enum InterruptionMessages {
+  /// Shown ONLY when Core Audio confirmed the input device went away.
   static let micDisconnected = "Microphone disconnected"
+
+  /// #1408. Shown for every other interruption: an engine that failed to
+  /// recover with the microphone still attached, a capture-session
+  /// interruption, our own audio helper dying. Says exactly what we know and
+  /// nothing we cannot back.
+  static let recordingInterrupted = "Recording interrupted"
+
+  /// #1408: the SINGLE place that decides which interruption sentence a user
+  /// sees. Three sites in `KernelDictationDriver` render an audio interruption
+  /// (the external-error path, the overlay intent, and the public state mapper);
+  /// all three route here so the sentence cannot drift between them.
+  ///
+  /// A missing cause yields the neutral line. The kernel refuses salvage when it
+  /// reaches an audio-interruption exit with nothing stamped, and an unstamped
+  /// interruption is precisely the case where we have no evidence a microphone
+  /// left — so the default fails toward the claim we can always back.
+  static func message(for cause: EngineInterruptionCause?) -> String {
+    cause?.isDeviceLoss == true ? micDisconnected : recordingInterrupted
+  }
+}
+
+/// #1408 (grounded review A1): what a COMPLETED take discloses about the
+/// interruption that cut it short. Derived from the stamped
+/// `EngineInterruptionCause` at the planner call sites; carried as a typed
+/// value instead of a Bool so a non-disconnect salvage can no longer paste
+/// potentially truncated text with no notice at all.
+///
+/// nil (no value) = a normal completion, nothing to disclose. The two cases
+/// split on the ONLY evidence axis the pipeline has: was the input device
+/// verified removed (`isDeviceLoss`), or did capture die some other way with
+/// the microphone, as far as we know, still attached. Copy for each cell lives
+/// at the factory (`PipelineStateChangeHandlerFactory`), the single copy
+/// authority for post-completion notices.
+public enum CompletionInterruptionDisclosure: Equatable, Sendable {
+  /// Core Audio confirmed the input device went away mid-recording.
+  case deviceRemoved
+  /// Capture was interrupted by anything else: engine lost, capture session
+  /// lost. No claim about the microphone is allowed.
+  case otherInterruption
+
+  /// nil cause → nil disclosure (normal completion). Every stamped cause on a
+  /// COMPLETED take is a disclosure: the take survived an interruption, so the
+  /// pasted text may be missing its tail.
+  public init?(cause: EngineInterruptionCause?) {
+    guard let cause else { return nil }
+    self = cause.isDeviceLoss ? .deviceRemoved : .otherInterruption
+  }
 }
 
 /// Events the recording driver handles.

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -245,13 +245,21 @@ final class RecordingSessionKernel {
   /// time to choose `.vadGate` or `.asrEmptyNoSpeech`. Reset on session start.
   private(set) var lastNoSpeechSource: NoSpeechSource?
 
-  /// Why the audio engine was interrupted for this session, or `nil` if the
-  /// session did not reach `.audioInterrupted`. Stamped immediately BEFORE the
-  /// `→ .audioInterrupted` transition in `externalEngineInterrupted(_:)` (the
-  /// terminal's only path). The observer reads it at lifecycle-event mapping
-  /// time so the sink captures the lost dictation for `.engineLost` only
-  /// (issue #1174 A3). Reset on session start.
-  private(set) var lastAudioInterruptionCause: EngineInterruptionCause?
+  /// Why the audio engine was interrupted for this session, or `nil` if no
+  /// interruption reached the recording exit. Stamped by
+  /// `externalEngineInterrupted(_:)` under its first-wins accept condition.
+  /// The observer reads it at lifecycle-event mapping time so the sink captures
+  /// the lost dictation for `.engineLost` only (issue #1174 A3).
+  ///
+  /// #1408: a non-nil cause NO LONGER implies the session reached
+  /// `.audioInterrupted` — a salvageable interruption now falls through to the
+  /// normal stop tail and can terminate `.completed`. Read-through to
+  /// `KernelTelemetryState.interruptionCause`, the single home shared with the
+  /// finalization wiring and the lifecycle sink; it is cleared there, in
+  /// `resetForNewSession()`, which `start(config:)` calls before `.preparing`.
+  var lastAudioInterruptionCause: EngineInterruptionCause? {
+    telemetryState.interruptionCause
+  }
 
   /// #1434: per-session stabilization outcome (set at the pre-capture
   /// stabilization site; nil until it runs). Read by
@@ -979,8 +987,22 @@ final class RecordingSessionKernel {
       finishTerminal(.cancelled, sid: sid)
       return
     case .audioInterruption:
-      finishTerminal(.audioInterrupted, sid: sid)
-      return
+      // #1408: the device died mid-recording. If the capture manager is still
+      // alive and holding `capturedSamples`, fall through into the normal stop
+      // tail and transcribe what we have — salvage inherits the min-duration
+      // gate, VAD finalize, soft-onset preservation, energetic-tail recovery,
+      // degraded-lead retry and conditioning for free (plan §3.2). Only
+      // `.xpcConnectionLost` (the helper that OWNED the samples is gone) still
+      // fails honestly; the crash-recovery spool owns that case. `nil` cause →
+      // `false` by optional chaining, so an unstamped interruption fails closed.
+      guard lastAudioInterruptionCause?.hasRecoverableAudio == true else {
+        if lastAudioInterruptionCause == nil {
+          log("audio interruption exit with no stamped cause — refusing salvage")
+        }
+        finishTerminal(.audioInterrupted, sid: sid)
+        return
+      }
+      break
     case .asrInterruption:
       finishTerminal(.asrInterrupted, sid: sid)
       return
@@ -1007,6 +1029,13 @@ final class RecordingSessionKernel {
     // (a cancel landing mid-stop) not to fire a second, racing stop — it
     // waits for this one. `resourcesReleased` flips true once the stop
     // genuinely completes, even if the session went terminal meanwhile.
+    // #1408: on a SALVAGED interruption this is the SECOND freeze — the first ran
+    // in `externalEngineInterrupted` before the exit was delivered. Re-freezing is
+    // safe: `currentAudioRoute` derives from `lastRouteDecision`, frozen at
+    // capture-resolve time and never re-resolved by a mid-recording device death,
+    // so both freezes record the SAME pre-disconnect route. Only `durationMs`
+    // advances, by the microseconds between the interrupt and here, which is the
+    // truer figure anyway (audio kept arriving until `stopCapture()` below).
     freezeRecordingSnapshot()
     markPipelineTimingStart()
     transition(to: .stopping)
@@ -2007,12 +2036,12 @@ final class RecordingSessionKernel {
     // pre-transition window — `state` still `.recording` but `recordingExitLatched`
     // already true — has its exit ignored by `deliverRecordingExit`, so it must
     // NOT overwrite the cause/snapshot the terminal will use (cloud review #1207:
-    // an already-owned `.xpcConnectionLost` / `.maxDurationReached` could otherwise
-    // be replaced by a stale `.engineLost` and get falsely captured). The guard
+    // an already-owned `.xpcConnectionLost` could otherwise be replaced by a
+    // stale `.engineLost` and get falsely captured). The guard
     // mirrors `deliverRecordingExitIfCurrent`'s accept condition. The freeze
     // reports real duration / route / backend (mirrors `routeASRInterruption`).
     if state == .recording, !recordingExitLatched {
-      lastAudioInterruptionCause = cause
+      telemetryState.interruptionCause = cause
       freezeRecordingSnapshot()
     }
     deliverRecordingExitIfCurrent(.audioInterruption, sid: currentSessionID)
@@ -2295,12 +2324,63 @@ final class RecordingSessionKernel {
     }
   }
 
+  /// #1408. On a session whose capture was interrupted, any terminal that would
+  /// DELETE the crash-recovery spool must instead land on `.audioInterrupted` — a
+  /// `.failure` terminal that RETAINS it, and precisely the terminal this session
+  /// reached before salvage existed. Salvage may only ever ADD a transcript; it
+  /// must never convert "recoverable on the next launch" into "gone."
+  ///
+  /// Applied ONCE, inside `finishTerminal`, never at the call sites: one of the
+  /// terminals is computed from a ternary (`effectiveSpeechEvidence ?
+  /// .failed(.asrEmpty) : .noSpeech`), so a call-site floor would silently miss
+  /// the post-ASR no-speech path — the exact "salvaged audio transcribed to
+  /// nothing" row this guards. Inert outside an interruption: the cause is
+  /// cleared at session start, before `.preparing`.
+  ///
+  /// **One rule: an interrupted recording that ends with no transcript lands on
+  /// `.audioInterrupted`, whatever interrupted it.**
+  ///
+  /// `.discarded` / `.noSpeech` DELETE the spool (`RecordingTerminalKind
+  /// .discard`). Letting an interrupted session reach either would destroy the
+  /// crash-recovery copy of audio the user can still get back on next launch —
+  /// converting "recoverable" into "gone." Safety does not get to depend on which
+  /// interruption fired, so this holds for every cause including the duration cap.
+  /// `.failed(.noAudioCaptured)` already retains the spool; it is folded in so all
+  /// three no-transcript endings agree, rather than one of them keeping a
+  /// different overlay for no reason a user could name.
+  ///
+  /// This used to be TWO rules, the second gated on `cause.isDeviceLoss`, because
+  /// `.audioInterrupted` rendered "Microphone disconnected" unconditionally and
+  /// that would have been a lie for a duration cap. The cause-aware sentence now
+  /// lives at its own single authority (`InterruptionMessages.message(for:)`), so
+  /// the floor no longer has to encode a copy decision. What the terminal MEANS
+  /// (the spool survives) and what the user READS are separate questions with
+  /// separate owners — which is the same split `hasRecoverableAudio` and
+  /// `isDeviceLoss` draw one layer up.
+  ///
+  /// `.cancelled` is NEVER floored: an explicit user cancel is honored, and its
+  /// retain/delete disposition belongs to `pendingCancelDisposition`. Every other
+  /// `.failed(reason)` (`.asrEmpty`, `.asrFailed`, `.captureStartFailed`,
+  /// `.modelLoadFailed`) keeps its own honest reason and is already spool-retaining.
+  private func interruptedTerminalFloor(
+    _ terminal: RecordingSessionState
+  ) -> RecordingSessionState {
+    guard lastAudioInterruptionCause != nil else { return terminal }
+    switch terminal {
+    case .discarded, .noSpeech, .failed(.noAudioCaptured):
+      return .audioInterrupted
+    default:
+      return terminal
+    }
+  }
+
   /// Reach a terminal state: transition, run nonblocking cleanup, drain the
   /// task bag (PR-1 §B.1.6, PR-3 plan §3.1a — cancel + clear, never `await`).
   /// Discards the adapter's open session and stops the capture engine if
   /// either is still in flight (PR-1 §B.1.3 cleanup column; Codex P1b / P2-r3).
-  private func finishTerminal(_ terminal: RecordingSessionState, sid: SessionID) {
+  private func finishTerminal(_ rawTerminal: RecordingSessionState, sid: SessionID) {
     guard isCurrent(sid) else { return }
+    let terminal = interruptedTerminalFloor(rawTerminal)
     guard transition(to: terminal) else { return }
     audioCapture.onBufferCaptured = nil
     // PR-4b.1: `onEngineInterrupted`, `onCaptureStalled`, and `onXPCServiceError`
@@ -2438,7 +2518,12 @@ final class RecordingSessionKernel {
     discardReason = nil
     didLoadModelThisSession = false
     lastNoSpeechSource = nil
-    lastAudioInterruptionCause = nil
+    // #1408: `lastAudioInterruptionCause` is NOT cleared here. Its storage moved
+    // to `KernelTelemetryState.interruptionCause`, whose `resetForNewSession()`
+    // is the sole clearer — `start(config:)` calls it immediately after this,
+    // before `.preparing`. Two clearers for one field is how a stale cause would
+    // leak into the next session and make the terminal floor mis-fire on a
+    // normal too-short tap.
     isStreamingSession = false
     pasteCount = 0
     forbiddenTransitionRejected = false
@@ -2828,6 +2913,17 @@ final class RecordingSessionKernel {
     /// vs `"Polishing..."`).
     func testSetFinalizingSubStatus(_ status: FinalizingSubStatus) {
       finalizingSubStatus = status
+    }
+
+    /// #1408: surface the terminal floor as a pure function so a test can prove
+    /// it covers EVERY terminal whose `RecordingTerminalKind` is `.discard`.
+    /// The floor's mapped set and `KernelDictationDriver.endedWithoutSaveKind`'s
+    /// discard set are two lists of the same fact; without this seam they can
+    /// drift, and a new spool-deleting terminal would silently escape the floor.
+    func testInterruptedTerminalFloor(_ terminal: RecordingSessionState)
+      -> RecordingSessionState
+    {
+      interruptedTerminalFloor(terminal)
     }
   #endif
 }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -77,13 +77,18 @@ public final class TelemetryService {
     captureNativeRateHz: Double? = nil, captureRingDropCount: Int? = nil,
     captureConverterErrorCount: Int? = nil, captureZeroOutputCount: Int? = nil,
     captureRateDivergenceDetected: Bool? = nil, captureFormatStabilized: Bool? = nil,
-    captureRebuiltForFormat: Bool? = nil, salvagedLeadTrimMs: Int? = nil
+    captureRebuiltForFormat: Bool? = nil, salvagedLeadTrimMs: Int? = nil,
+    // #1408: present only on a salvaged completion — WHICH interruption cut the
+    // recording short. `stop_reason` already says an interruption ended it; this
+    // says which one. Low-cardinality reason string.
+    interruptedBy: String? = nil
   ) {
     #if DEBUG
       var hookStringProps: [String: String] = [
         "input_mode": inputMode,
         "asr_backend": t.backendType.rawValue,
       ]
+      if let ib = interruptedBy { hookStringProps["interrupted_by"] = ib }
       // #1376: mirror the emitted route keys' presence-only semantics so the
       // App → Telemetry threading is unit-testable.
       if let st = selectedTransport { hookStringProps["selected_transport"] = st }
@@ -138,7 +143,8 @@ public final class TelemetryService {
       captureRateDivergenceDetected: captureRateDivergenceDetected,
       captureFormatStabilized: captureFormatStabilized,
       captureRebuiltForFormat: captureRebuiltForFormat,
-      salvagedLeadTrimMs: salvagedLeadTrimMs
+      salvagedLeadTrimMs: salvagedLeadTrimMs,
+      interruptedBy: interruptedBy
     )
     if let e2e = m?.e2eSeconds {
       metricPipelineE2E(
@@ -439,6 +445,43 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("limb.failure_observed", properties: props)
   }
 
+  /// #1408: the microphone died (or the duration cap fired) while a recording was
+  /// in flight. Fires on EVERY such interruption that reaches a recording exit —
+  /// salvaged or not — so `dictation.completed`'s salvage count has a denominator.
+  ///
+  /// Deliberately NOT an error: a walked-away Bluetooth user is not our defect, so
+  /// this must never page, email, or file a ticket (`sentry-vs-posthog-routing`).
+  /// It ships as an observational counter with no threshold, because a threshold
+  /// needs a baseline and we have none yet. Metadata only, never audio-derived.
+  public func audioCaptureInterrupted(
+    cause: String, salvageAttempted: Bool, salvageSucceeded: Bool,
+    terminalState: String, backend: String,
+    recordingDurationMs: Int? = nil
+  ) {
+    var props: [String: Any] = [
+      "cause": cause,
+      "salvage_attempted": salvageAttempted,
+      "salvage_succeeded": salvageSucceeded,
+      "terminal_state": terminalState,
+      "backend": backend,
+    ]
+    if let ms = recordingDurationMs { props["recording_duration_ms"] = ms }
+    #if DEBUG
+      var intProps: [String: Int] = [:]
+      if let ms = recordingDurationMs { intProps["recording_duration_ms"] = ms }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "audio.capture_interrupted",
+          stringProps: [
+            "cause": cause, "terminal_state": terminalState, "backend": backend,
+            "salvage_attempted": String(salvageAttempted),
+            "salvage_succeeded": String(salvageSucceeded),
+          ],
+          intProps: intProps))
+    #endif
+    PostHogSDK.shared.capture("audio.capture_interrupted", properties: props)
+  }
+
   public func dictationCompleted(
     result: String, inputMode: String, asrBackend: String,
     llmProvider: String?, fillerRemoval: Bool,
@@ -459,7 +502,8 @@ public final class TelemetryService {
     captureNativeRateHz: Double? = nil, captureRingDropCount: Int? = nil,
     captureConverterErrorCount: Int? = nil, captureZeroOutputCount: Int? = nil,
     captureRateDivergenceDetected: Bool? = nil, captureFormatStabilized: Bool? = nil,
-    captureRebuiltForFormat: Bool? = nil, salvagedLeadTrimMs: Int? = nil
+    captureRebuiltForFormat: Bool? = nil, salvagedLeadTrimMs: Int? = nil,
+    interruptedBy: String? = nil
   ) {
     var props: [String: Any] = [
       "result": result,
@@ -473,6 +517,9 @@ public final class TelemetryService {
     // + why the recording stopped. Metadata only (telemetry-privacy-boundary).
     if let rec = recordingSeconds { props["recording_seconds"] = String(format: "%.3f", rec) }
     if let sr = stopReason { props["stop_reason"] = sr }
+    // #1408: which interruption cut this dictation short. Present only when the
+    // recording was salvaged after the mic died or the duration cap fired.
+    if let ib = interruptedBy { props["interrupted_by"] = ib }
     // #1434: capture-health facts + salvage marker (fleet visibility across
     // Bluetooth device models; counters omitted when zero at the call site).
     if let rate = captureNativeRateHz { props["capture_native_rate_hz"] = Int(rate) }

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -24,6 +24,7 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -151,6 +151,7 @@ private final class SettableAudioCapture: AudioCaptureInterface {
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?
@@ -203,6 +204,7 @@ private final class ObservableAudioCapture: AudioCaptureInterface {
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?

--- a/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
@@ -1,0 +1,137 @@
+import AppKit
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPipeline
+
+// MARK: - #1408 A1 — the post-completion interruption copy matrix
+
+/// The factory is the SINGLE copy authority for the interruption pill (plan
+/// §21.2 A1). These tests drive a factory-built handler end to end and pin the
+/// EXACT sentence for each (disclosure × lead-trim) cell, so the copy cannot
+/// drift and only a verified device removal can ever claim the microphone.
+///
+/// The two "Microphone disconnected" strings are founder-approved (2026-07-09).
+/// The two "Recording interrupted" strings are provisional pending founder
+/// sign-off (plan §21.3); when the wording lands, this file is the one place
+/// the tests change.
+@MainActor
+@Suite("PipelineStateChangeHandlerFactory — interruption copy matrix (#1408)")
+struct PipelineStateChangeHandlerFactoryCopyTests {
+
+  @MainActor
+  private final class WarningBox {
+    var messages: [String] = []
+  }
+
+  /// A factory-built handler whose only live seam is the warning recorder.
+  /// `inputMode` returns nil so completion telemetry early-returns; the
+  /// transcript carries no recovery session so no cleanup fires.
+  private func makeHandler(recording box: WarningBox) -> PipelineStateChangeHandler {
+    let steps = LimbSteps(
+      wordCorrection: WordCorrectionStep(),
+      fillerRemoval: FillerRemovalStep(),
+      emojiFormatter: EmojiFormatterStep(),
+      inverseTextNormalization: InverseTextNormalizationStep(),
+      llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
+      emojiRestore: EmojiRestoreStep())
+    let outcome = KernelFinalizationOutcome()
+    let context = KernelSessionContext()
+    let adapter = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
+    let kernel = RecordingSessionKernel(
+      adapter: adapter,
+      audioCapture: FakeAudioCapture(),
+      vad: FakeVADSignalSource(),
+      currentTick: { 0 }, sleepTicks: { _ in },
+      processText: { raw, _ in raw },
+      store: { _, _ in }, deliver: { _ in .pasted },
+      minimumRecordingTicks: 0)
+    let observer = KernelHeartPathTelemetryObserver(
+      kernel: kernel, audioCapture: FakeAudioCapture(),
+      emitter: HeartPathTelemetryEmitter(
+        backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
+      emitLifecycleEvent: { _ in })
+    let driver = KernelDictationDriver(
+      kernel: kernel, observer: observer, outcome: outcome,
+      context: context, steps: steps, adapter: adapter)
+    let deps = PipelineStateChangeHandlerFactory.Deps(
+      showOverlay: { _ in },
+      cancelPendingWarning: {},
+      schedulePostCompletionWarning: { box.messages.append($0) },
+      appendTranscript: { _ in },
+      onDurableSave: { _ in },
+      inputMode: { nil },
+      driver: driver)
+    return PipelineStateChangeHandlerFactory.make(backendLabel: "parakeet", deps: deps)
+  }
+
+  private static let expectedCopy: [(CompletionInterruptionDisclosure, Bool, String)] = [
+    (.deviceRemoved, false, "Microphone disconnected. Text may be cut short."),
+    (.deviceRemoved, true, "Microphone disconnected. Words may be missing."),
+    (.otherInterruption, false, "Recording interrupted. Text may be cut short."),
+    (.otherInterruption, true, "Recording interrupted. Words may be missing."),
+  ]
+
+  @Test("each (disclosure × lead-trim) cell schedules its exact sentence")
+  func copyMatrixIsExact() {
+    for (disclosure, alsoTrimmedLead, expected) in Self.expectedCopy {
+      let box = WarningBox()
+      let handler = makeHandler(recording: box)
+      handler.handle(
+        to: PipelineState.complete,
+        pipelineOverlayIntent: .hidden,
+        lastPolishError: nil,
+        currentTranscript: Transcript(text: "hello", backendType: .parakeet),
+        historySaved: true,
+        historySaveReason: nil,
+        salvagedLead: alsoTrimmedLead,
+        interruptionDisclosure: disclosure)
+      #expect(
+        box.messages == [expected],
+        "disclosure=\(disclosure) alsoTrimmedLead=\(alsoTrimmedLead)")
+    }
+  }
+
+  /// Only a VERIFIED removal may name the microphone. If this ever fails, a
+  /// user whose engine died with the mic still attached is being lied to.
+  @Test("the neutral family never mentions the microphone")
+  func neutralCopyNeverClaimsTheMicrophone() {
+    for (disclosure, alsoTrimmedLead, expected) in Self.expectedCopy
+    where disclosure == .otherInterruption {
+      _ = alsoTrimmedLead
+      #expect(!expected.localizedCaseInsensitiveContains("microphone"))
+      #expect(!expected.localizedCaseInsensitiveContains("mic"))
+    }
+  }
+
+  /// Rule 6: no em/en-dashes in user-facing copy.
+  @Test("no em or en dashes in any interruption sentence")
+  func noDashesInCopy() {
+    for (_, _, expected) in Self.expectedCopy {
+      #expect(!expected.contains("\u{2014}"))
+      #expect(!expected.contains("\u{2013}"))
+    }
+  }
+
+  /// A normal completion (nil disclosure) schedules nothing.
+  @Test("a normal completion schedules no interruption pill")
+  func normalCompletionSchedulesNothing() {
+    let box = WarningBox()
+    let handler = makeHandler(recording: box)
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: Transcript(text: "hello", backendType: .parakeet),
+      historySaved: true,
+      historySaveReason: nil,
+      salvagedLead: false,
+      interruptionDisclosure: nil)
+    #expect(box.messages.isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
@@ -245,7 +245,9 @@ import Testing
       Expected exactly one CaptureVADSignalSource construction site — the
       shared App-owned VAD source that both kernel drivers share (PR-5 Rung 5
       / Codex r2 new defect 1). Multiple construction sites would re-bind
-      `audioCapture.onVADAutoStop` and break two-driver auto-stop dispatch.
+      `audioCapture.onVADAutoStop` AND `audioCapture.onMaxDurationReached`
+      (both slots are claimed by `bind`, #1408 A3) and break two-driver
+      auto-stop dispatch.
       \(constructs.joined(separator: "\n"))
       """)
     #expect(

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerMaxDurationBackstopTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerMaxDurationBackstopTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// MARK: - #1408 A3 — the hard sample-count backstop is a NORMAL stop
+
+/// The manager's last-ditch cap (3660s of samples) used to fire
+/// `onEngineInterrupted(.maxDurationReached)` — an interruption that stamped a
+/// cause, floored terminals, and emitted loss telemetry for a recording that
+/// ended normally. It now stops appending locally and fires
+/// `onMaxDurationReached` exactly once, feeding the same typed `.maxDuration`
+/// stop the graceful wall-clock cap uses.
+///
+/// The production threshold is 58,560,000 samples — unreachable in a unit test
+/// — so `maxRecordingSamplesLimit` is instance-injectable (the seam grounded
+/// review r1 demanded; a closure-level test cannot exercise the real check).
+@MainActor
+@Suite("AudioCaptureManager max-duration backstop (#1408 A3)")
+struct AudioCaptureManagerMaxDurationBackstopTests {
+
+  private func makeCappedManager(limit: Int) -> (
+    manager: AudioCaptureManager, fired: () -> Int, interrupted: () -> Int
+  ) {
+    let manager = AudioCaptureManager()
+    manager.maxRecordingSamplesLimit = limit
+    var maxDurationFires = 0
+    var interruptionFires = 0
+    manager.onMaxDurationReached = { maxDurationFires += 1 }
+    manager.onEngineInterrupted = { _ in interruptionFires += 1 }
+    manager.isCapturing = true  // arm ingest without real hardware (internal(set))
+    return (manager, { maxDurationFires }, { interruptionFires })
+  }
+
+  @Test("crossing the limit stops capture and fires onMaxDurationReached exactly once")
+  func capFiresExactlyOnce() {
+    let (manager, fired, interrupted) = makeCappedManager(limit: 8)
+
+    manager.ingestSamples([Float](repeating: 0, count: 5), level: 0.4)
+    #expect(fired() == 0, "below the limit nothing fires")
+    #expect(manager.isCapturing)
+
+    manager.ingestSamples([Float](repeating: 0, count: 5), level: 0.4)
+    #expect(fired() == 1, "crossing the limit fires the normal-stop callback")
+    #expect(!manager.isCapturing, "the backstop stops appending locally")
+    #expect(manager.audioLevel == 0.0)
+
+    // A straggler batch after the cap is ignored (the isCapturing guard is the
+    // exactly-once mechanism, same as the production wiring closure's guard).
+    manager.ingestSamples([Float](repeating: 0, count: 5), level: 0.4)
+    #expect(fired() == 1, "no second fire after the cap")
+    #expect(manager.capturedSamples.count == 10, "post-cap samples are not appended")
+
+    #expect(interrupted() == 0, "the cap must NEVER fire the interruption channel")
+  }
+
+  @Test("the accumulated samples survive the cap and are returned by stopCapture")
+  func samplesSurviveTheCap() async {
+    let (manager, fired, _) = makeCappedManager(limit: 4)
+    manager.ingestSamples([1, 2, 3, 4], level: 0.4)
+    #expect(fired() == 1)
+
+    // stopCapture has no isCapturing guard: the capped recording's audio is
+    // still the user's words and still comes back for transcription.
+    let result = await manager.stopCapture()
+    #expect(result.samples == [1, 2, 3, 4])
+  }
+
+  @Test("ingest is inert while not capturing")
+  func ingestRequiresCapturing() {
+    let manager = AudioCaptureManager()
+    manager.maxRecordingSamplesLimit = 2
+    var fires = 0
+    manager.onMaxDurationReached = { fires += 1 }
+
+    manager.ingestSamples([1, 2, 3], level: 0.5)
+    #expect(manager.capturedSamples.isEmpty)
+    #expect(fires == 0)
+  }
+
+  /// The production threshold invariant: the backstop must sit strictly above
+  /// the graceful wall-clock cap so the graceful stop always wins when healthy.
+  /// (The primary freeze lives in `RecordingCapInvariantTests`; this pins the
+  /// injectable seam's default to the production constant.)
+  @Test("the injectable limit defaults to the production constant")
+  func seamDefaultsToProduction() {
+    let manager = AudioCaptureManager()
+    #expect(manager.maxRecordingSamplesLimit == AudioCaptureManager.maxRecordingSamples)
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureProxyLineOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureProxyLineOwnershipTests.swift
@@ -527,3 +527,29 @@ struct AudioCaptureProxyLineOwnershipTests {
     #expect(proxy.isCapturing == false)
   }
 }
+
+// MARK: - #1408 A3 — max-duration relay stale-fire guard
+
+/// `maxDurationReachedTriggered` carries SESSION IDENTITY (Codex code-diff
+/// r6): the helper echoes the begin `operationID` that owns the emitting
+/// capture, and the proxy fires the callback only while capturing AND the
+/// echo matches the ACTIVE session's begin op. An idle proxy, or an echo from
+/// an earlier session, must swallow the event — a maximally delayed backstop
+/// relay cannot stop a later recording.
+@MainActor
+@Suite("AudioCaptureProxy max-duration relay guard (#1408 A3)")
+struct AudioCaptureProxyMaxDurationRelayTests {
+
+  @Test("an idle proxy swallows a relayed max-duration event")
+  func idleProxySwallowsTheEvent() async {
+    let proxy = AudioCaptureProxy()
+    var fires = 0
+    proxy.onMaxDurationReached = { fires += 1 }
+
+    proxy.maxDurationReachedTriggered(operationID: "op-from-some-session")
+    // The relay hops through one MainActor task; drain it before asserting.
+    for _ in 0..<20 { await Task.yield() }
+
+    #expect(fires == 0, "isCapturing is false — the stale guard must swallow the event")
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/CoreAudioDeviceLivenessTests.swift
+++ b/Tests/EnviousWisprTests/Audio/CoreAudioDeviceLivenessTests.swift
@@ -1,0 +1,109 @@
+import CoreAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1408 — the liveness read that decides whether the app may tell a user their
+// microphone disconnected.
+//
+// Both capture sources used to inline this read, DISCARD the returned `OSStatus`,
+// and branch on the `isAlive` out-parameter alone. `isAlive` is zero-initialized,
+// so every failed read looked exactly like "the device is dead." Once #1408 made
+// that answer drive a pill and a permanent History badge, an unchecked status
+// meant a transient Core Audio error could permanently mislabel a recording whose
+// microphone never left (Codex code-diff review r3).
+//
+// The naive repair — "any non-noErr status means we could not verify removal" —
+// is WRONG in the other direction, and this suite exists mainly to stop someone
+// from applying it. A removed device's `AudioDeviceID` is invalidated, so the
+// query for a genuinely unplugged microphone does not return `noErr` + `isAlive
+// == 0`; it returns `kAudioHardwareBadObjectError`. Collapsing that to
+// "unverified" would suppress the disconnect notice on exactly the case the whole
+// issue exists for.
+@Suite("Core Audio device-liveness classification (#1408)")
+struct CoreAudioDeviceLivenessTests {
+
+  // MARK: - The three answers
+
+  @Test("noErr + isAlive == 1 → alive (a Bluetooth codec switch, not a disconnect)")
+  func aliveWhenCoreAudioSaysYes() {
+    #expect(CoreAudioDeviceLiveness.interpret(status: noErr, isAlive: 1) == .alive)
+  }
+
+  @Test("noErr + isAlive == 0 → removed (the device reported itself dead)")
+  func removedWhenCoreAudioSaysNo() {
+    #expect(CoreAudioDeviceLiveness.interpret(status: noErr, isAlive: 0) == .removed)
+  }
+
+  /// The dominant real-world disconnect path: the device object is gone, so the
+  /// ID no longer names anything. If this ever returns `.unverified`, unplugging
+  /// a USB mic mid-sentence stops showing the disconnect notice.
+  @Test(
+    "a status naming a missing object/device → removed",
+    arguments: [kAudioHardwareBadObjectError, kAudioHardwareBadDeviceError])
+  func removedWhenTheObjectIsGone(status: OSStatus) {
+    #expect(CoreAudioDeviceLiveness.interpret(status: status, isAlive: 0) == .removed)
+  }
+
+  /// Codex r3's finding, locked. These statuses say nothing about whether the
+  /// device is present, and `isAlive` is still its zero initializer underneath
+  /// them — the exact shape that used to read as "dead."
+  @Test(
+    "any other failure → unverified, never a disconnect claim",
+    arguments: [
+      kAudioHardwareBadPropertySizeError,
+      kAudioHardwareUnknownPropertyError,
+      kAudioHardwareNotRunningError,
+      kAudioHardwareUnspecifiedError,
+      kAudioHardwareIllegalOperationError,
+      OSStatus(-1),
+    ])
+  func unverifiedOnATransientFailure(status: OSStatus) {
+    #expect(CoreAudioDeviceLiveness.interpret(status: status, isAlive: 0) == .unverified)
+  }
+
+  /// A failed read must not be rescued by a stale non-zero out-parameter either.
+  /// The status is the authority; `isAlive` is only meaningful under `noErr`.
+  @Test("a failed read ignores isAlive entirely")
+  func failedReadDoesNotConsultIsAlive() {
+    #expect(
+      CoreAudioDeviceLiveness.interpret(status: kAudioHardwareNotRunningError, isAlive: 1)
+        == .unverified)
+    #expect(
+      CoreAudioDeviceLiveness.interpret(status: kAudioHardwareBadObjectError, isAlive: 1)
+        == .removed)
+  }
+
+  // MARK: - The claim boundary
+
+  /// The whole point of the `.unverified` case: only a confirmed removal may
+  /// reach `isDeviceLoss`, which is what gates the pill and the badge. An
+  /// unverified read still interrupts and still salvages — it just stays silent.
+  @Test("only a confirmed removal earns a user-facing disconnect claim")
+  func onlyRemovedEarnsTheClaim() {
+    let causeFor: (DeviceLiveness) -> EngineInterruptionCause = {
+      $0 == .removed ? .deviceRemoved : .engineLost
+    }
+    #expect(causeFor(.removed).isDeviceLoss)
+    #expect(!causeFor(.unverified).isDeviceLoss)
+
+    // ...and neither answer costs the user their dictation.
+    #expect(causeFor(.removed).hasRecoverableAudio)
+    #expect(causeFor(.unverified).hasRecoverableAudio)
+  }
+
+  // MARK: - Against the real system
+
+  /// Guards the premise the pure cases are built on, using the machine's own
+  /// default input device rather than a hand-written status. If Core Audio ever
+  /// stopped answering `kAudioHardwareBadObjectError` for an ID that names
+  /// nothing, `.removed` would be reached through a status this suite never
+  /// enumerates.
+  @Test("a nonexistent device ID classifies as removed on the real Core Audio")
+  func nonexistentDeviceIsRemovedAgainstRealCoreAudio() {
+    #expect(CoreAudioDeviceLiveness.classify(deviceID: AudioDeviceID(999_999)) == .removed)
+    #expect(
+      CoreAudioDeviceLiveness.classify(deviceID: AudioDeviceID(kAudioObjectUnknown)) == .removed)
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/EngineInterruptionCauseTests.swift
+++ b/Tests/EnviousWisprTests/Audio/EngineInterruptionCauseTests.swift
@@ -5,18 +5,30 @@ import Testing
 
 // #1174 A3 — locks the XPC-boundary host-cause remap (Codex PR-5b r1 finding 2).
 // In XPC mode the audio service relays interruptions through one no-cause-typed
-// channel; the host collapses every LOSS cause to `.engineLost` (none has another
-// owner across the boundary) and preserves ONLY the non-loss max-duration cap so
-// it stays suppressed exactly as direct mode does. Unknown / legacy raw values
-// fail toward visibility (`.engineLost`).
+// channel; the host preserves `.deviceRemoved` (#1408 — the helper ran the
+// liveness check, the host cannot re-run it) and collapses every other loss
+// cause to `.engineLost` (none has another owner across the boundary). Unknown /
+// legacy raw values fail toward visibility (`.engineLost`) — including the
+// retired `max_duration_reached` (#1408 A3: the cap is a normal auto-stop and
+// left the interruption channel entirely).
 @Suite("EngineInterruptionCause XPC host remap")
 struct EngineInterruptionCauseTests {
 
-  @Test("max-duration is the only relayed cause the host preserves (suppress)")
-  func maxDurationPreserved() {
+  @Test("device removal is the only relayed cause the host preserves")
+  func deviceRemovalPreserved() {
+    #expect(
+      EngineInterruptionCause.hostCause(forRelayedRawValue: "device_removed")
+        == .deviceRemoved)
+  }
+
+  /// #1408 A3 adversarial row: the RETIRED raw value must not resurrect the
+  /// cap as an interruption — a stale helper relaying it reads as an unknown
+  /// and fails toward visibility like any other legacy value.
+  @Test("the retired max_duration_reached raw value maps to .engineLost")
+  func retiredMaxDurationRawValueIsLegacy() {
     #expect(
       EngineInterruptionCause.hostCause(forRelayedRawValue: "max_duration_reached")
-        == .maxDurationReached)
+        == .engineLost)
   }
 
   @Test("every loss cause collapses to .engineLost across XPC (capture)")

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -65,6 +65,7 @@ private final class ExtrasAudioCapture: AudioCaptureInterface {
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
@@ -69,6 +69,23 @@ import Testing
     #expect(signal == VADStopSignal(kind: .autoStopTriggered, sessionID: sid))
   }
 
+  /// #1408 A3: `bind` claims BOTH callback slots. The manager's hard-cap
+  /// backstop funnels into the SAME typed, session-stamped stop route the
+  /// graceful wall-clock cap uses — a normal `.maxDuration` stop, never an
+  /// engine interruption.
+  @Test("bind claims onMaxDurationReached — the backstop drives a typed stop signal")
+  func bindOwnsMaxDurationCallback() async {
+    let source = CaptureVADSignalSource()
+    let capture = FakeAudioCapture()
+    let sid = SessionID()
+    source.setCurrentSessionID(sid)
+    source.bind(audioCapture: capture)
+    var iterator = source.subscribeStopSignals().makeAsyncIterator()
+    capture.fireMaxDurationReached()  // the manager backstop fires
+    let signal = await iterator.next()
+    #expect(signal == VADStopSignal(kind: .maxDurationReached, sessionID: sid))
+  }
+
   @Test("each signal carries the session current at emit time")
   func sessionStamping() async {
     let source = CaptureVADSignalSource()

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -445,6 +445,7 @@ internal final class FixtureAudioCapture: AudioCaptureInterface {
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -307,6 +307,7 @@ private final class NoOpAudioCapture: AudioCaptureInterface {
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
@@ -209,17 +209,28 @@ import Testing
     // The forced-state fixture has no recording-exit continuation, so the
     // matrix freeze covers only the bridge cases and the no-op cases.
 
-    @Test("handleEngineInterruption: L/S/T/F bridges to driver error (matrix #4)")
-    func engineInterruptionBridgesActiveNonRecording() async {
+    /// #1408: the bridged sentence is CAUSE-AWARE. This test used to inject
+    /// `.engineLost` and demand "Microphone disconnected" — it froze the very
+    /// claim that was false, since an engine that fails to recover leaves the
+    /// microphone plugged in. Both causes are exercised now, so the freeze locks
+    /// the distinction rather than the bug.
+    @Test(
+      "handleEngineInterruption: L/S/T/F bridges to a cause-accurate driver error (matrix #4)",
+      arguments: [
+        (EngineInterruptionCause.deviceRemoved, "Microphone disconnected"),
+        (EngineInterruptionCause.engineLost, "Recording interrupted"),
+      ])
+    func engineInterruptionBridgesActiveNonRecording(
+      cause: EngineInterruptionCause, expected: String
+    ) async {
       for state: RecordingSessionState in [
         .preparing, .warmingUp, .stopping, .transcribing, .finalizing,
       ] {
         let fx = makeFixture()
         await forceState(fx.kernel, to: state)
-        fx.driver.handleEngineInterruption(.engineLost)
+        fx.driver.handleEngineInterruption(cause)
         await drain()
-        // Driver public state must surface the mic-disconnect error.
-        assertDriverIsError(fx.driver, contains: "Microphone disconnected")
+        assertDriverIsError(fx.driver, contains: expected)
       }
     }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelInterruptedTranscriptTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelInterruptedTranscriptTests.swift
@@ -1,0 +1,188 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - #1408 — the History "Interrupted" badge's data path
+//
+// The badge is driven by `Transcript.inputDeviceWasRemoved`, set inside the production
+// `store` closure. That closure sees only `outcome`, `context`, and `adapter` —
+// none of which knows the microphone died. It reads the interruption from the
+// SHARED `KernelTelemetryState` it already captures for `historySaveFailed`.
+//
+// THE TRAP THIS SUITE EXISTS FOR: `KernelTelemetryState` is DEFAULTED to a fresh
+// instance in both `RecordingSessionKernel.init` and `KernelFinalizationWiring
+// .init`. Production passes one shared instance to both. A test that constructs
+// them separately gets TWO holders — and then every badge assertion passes
+// against a holder nobody ever wrote to, while the badge does nothing in the
+// shipped app. So these tests pass the holder explicitly, and the last test
+// guards the production wiring itself.
+
+/// Captures what the production `store` closure handed to `TranscriptStore.save`.
+@MainActor
+final class InterruptedSavedTranscriptBox {
+  var transcript: Transcript?
+}
+
+@MainActor
+@Suite("Interrupted-transcript badge data path (#1408)")
+struct KernelInterruptedTranscriptTests {
+
+  private func makeWiring(
+    telemetryState: KernelTelemetryState,
+    saved: InterruptedSavedTranscriptBox
+  ) -> KernelFinalizationWiring {
+    let engine = FakeEngine(behavior: .batchSuccess(text: "hi"), clock: FakeClock())
+    let outcome = KernelFinalizationOutcome()
+    outcome.rawText = "hi"
+    return KernelFinalizationWiring(
+      outcome: outcome,
+      context: KernelSessionContext(),
+      adapter: engine,
+      steps: LimbSteps(
+        wordCorrection: WordCorrectionStep(),
+        fillerRemoval: FillerRemovalStep(),
+        emojiFormatter: EmojiFormatterStep(),
+        inverseTextNormalization: InverseTextNormalizationStep(),
+        llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
+        emojiRestore: EmojiRestoreStep()),
+      textProcessingRunner: TextProcessingRunner(),
+      save: { saved.transcript = $0 },
+      deliverPaste: { _ in
+        PasteDeliveryResult(
+          tier: .cgEvent, durationMs: 1,
+          outcome: .delivered(tier: .cgEvent, durationMs: 1))
+      },
+      pasteCompletionRegistry: nil,
+      telemetryState: telemetryState)
+  }
+
+  @Test("a salvaged completion saves a transcript flagged interrupted")
+  func salvagedCompletionIsFlagged() async throws {
+    let telemetryState = KernelTelemetryState()
+    let saved = InterruptedSavedTranscriptBox()
+    let wiring = makeWiring(telemetryState: telemetryState, saved: saved)
+
+    // The kernel stamps this before the exit is delivered. `.deviceRemoved` is
+    // the ONLY cause backed by a `DeviceIsAlive` check, so it is the only one
+    // allowed to leave a permanent crossed-out-microphone badge.
+    telemetryState.interruptionCause = .deviceRemoved
+    try await wiring.store("hi", UUID())
+
+    let transcript = try #require(saved.transcript)
+    #expect(transcript.inputDeviceWasRemoved == true)
+    #expect(transcript.isRecovered == false, "a salvage is the live take, not a rescued one")
+  }
+
+  /// The engine died but the microphone never left: a codec-switch recovery that
+  /// timed out, or a failed engine restart. The dictation is still salvaged; it
+  /// just must not be badged as a disconnect it was not.
+  @Test("an engine failure with the mic still attached is NOT badged as a disconnect")
+  func engineFailureWithMicAttachedIsNotBadged() async throws {
+    let telemetryState = KernelTelemetryState()
+    let saved = InterruptedSavedTranscriptBox()
+    let wiring = makeWiring(telemetryState: telemetryState, saved: saved)
+
+    telemetryState.interruptionCause = .engineLost
+    try await wiring.store("hi", UUID())
+
+    #expect(try #require(saved.transcript).inputDeviceWasRemoved == false)
+  }
+
+  /// A capture-session interruption is salvaged exactly like a disconnect, but
+  /// the History badge shows a crossed-out microphone. The session can be
+  /// interrupted for ANY reason with the mic still attached, so the badge must
+  /// stay off. (The duration cap used to sit in this class too; #1408's A3
+  /// rerouted it as a normal `.maxDuration` stop, so it can no longer stamp a
+  /// cause at all.)
+  @Test("a capture-session-loss salvage is NOT badged as a disconnect")
+  func captureSessionLossSalvageIsNotBadged() async throws {
+    let telemetryState = KernelTelemetryState()
+    let saved = InterruptedSavedTranscriptBox()
+    let wiring = makeWiring(telemetryState: telemetryState, saved: saved)
+
+    telemetryState.interruptionCause = .captureSessionLost
+    try await wiring.store("hi", UUID())
+
+    #expect(try #require(saved.transcript).inputDeviceWasRemoved == false)
+  }
+
+  @Test("an ordinary completion saves a transcript that is not flagged")
+  func ordinaryCompletionIsNotFlagged() async throws {
+    let telemetryState = KernelTelemetryState()
+    let saved = InterruptedSavedTranscriptBox()
+    let wiring = makeWiring(telemetryState: telemetryState, saved: saved)
+
+    try await wiring.store("hi", UUID())
+
+    let transcript = try #require(saved.transcript)
+    #expect(transcript.inputDeviceWasRemoved == false)
+  }
+
+  /// `resetForNewSession()` is the SOLE clearer of the cause. If a second clearer
+  /// is ever reintroduced, or this one drops the field, the next dictation after
+  /// an interrupted one would be badged "Interrupted" in History despite being a
+  /// clean take.
+  @Test("resetForNewSession clears the cause, so the next take is not badged")
+  func resetForNewSessionClearsTheCause() async throws {
+    let telemetryState = KernelTelemetryState()
+    let saved = InterruptedSavedTranscriptBox()
+    let wiring = makeWiring(telemetryState: telemetryState, saved: saved)
+
+    telemetryState.interruptionCause = .engineLost
+    telemetryState.resetForNewSession(polishEnabled: false)
+    try await wiring.store("hi", UUID())
+
+    #expect(telemetryState.interruptionCause == nil)
+    #expect(try #require(saved.transcript).inputDeviceWasRemoved == false)
+  }
+}
+
+// MARK: - The shared-holder guard
+
+/// A source-level assertion, in the style of the ceiling tests: the factory pulls
+/// in the real transcript store, paste executor, and ASR machinery, so no unit
+/// test instantiates it. What matters is structural and greppable — exactly ONE
+/// `KernelTelemetryState` is constructed, and the same value reaches the kernel,
+/// the finalization wiring, and the lifecycle sink.
+///
+/// Without this, a refactor that gave any one of the three its own defaulted
+/// holder would silently disable the History badge and the `interrupted_by`
+/// telemetry, and every test above would still pass.
+@Suite("KernelDictationDriverFactory shares one telemetry holder (#1408)")
+struct KernelTelemetryStateSharingTests {
+
+  private static let sourcePath = "Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift"
+
+  @Test("the factory constructs exactly one KernelTelemetryState")
+  func exactlyOneHolderIsConstructed() throws {
+    let source = try String(
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
+    let constructions = source.components(separatedBy: "KernelTelemetryState()").count - 1
+    #expect(
+      constructions == 1,
+      """
+      Expected exactly one `KernelTelemetryState()` in the factory, found \(constructions). \
+      The kernel, the finalization wiring, and the lifecycle sink each DEFAULT to a \
+      fresh holder; production must hand all three the same instance or the History \
+      "Interrupted" badge and `interrupted_by` silently stop working.
+      """)
+  }
+
+  @Test("that one holder is passed to all three consumers")
+  func theHolderIsPassedToEveryConsumer() throws {
+    let source = try String(
+      contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
+    let passes = source.components(separatedBy: "telemetryState: telemetryState").count - 1
+    #expect(
+      passes >= 3,
+      """
+      Expected the shared holder to be passed to the kernel, the finalization wiring, \
+      and the lifecycle sink (>= 3 `telemetryState: telemetryState` arguments), found \(passes).
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -48,12 +48,22 @@ import Testing
       let errorDescription: String
     }
 
+    /// #1408: the non-paging `audio.capture_interrupted` counter.
+    struct AudioCaptureInterruptedCall: Equatable {
+      let cause: String
+      let salvageAttempted: Bool
+      let salvageSucceeded: Bool
+      let terminalState: String
+      let backend: String
+    }
+
     var breadcrumbs: [BreadcrumbCall] = []
     var recordingStates: [RecordingStateCall] = []
     var audioRoutes: [String] = []
     var dictationsInvoked: [DictationInvokedCall] = []
     var modelLoadWedgedBackends: [String] = []
     var captureErrors: [CaptureErrorCall] = []
+    var audioCaptureInterruptions: [AudioCaptureInterruptedCall] = []
   }
 
   // MARK: - Sink construction with recorder seams
@@ -92,6 +102,14 @@ import Testing
         recorder.captureErrors.append(
           Recorder.CaptureErrorCall(
             category: category, stage: stage, errorDescription: error.localizedDescription))
+      },
+      // #1408: injected so no test ever reaches the real PostHog SDK
+      // (`tests-no-process-global-mutable-delegate`).
+      audioCaptureInterrupted: { cause, attempted, succeeded, terminal, backend, _ in
+        recorder.audioCaptureInterruptions.append(
+          Recorder.AudioCaptureInterruptedCall(
+            cause: cause, salvageAttempted: attempted, salvageSucceeded: succeeded,
+            terminalState: terminal, backend: backend))
       })
   }
 
@@ -360,11 +378,12 @@ import Testing
 
   // #1174 A3 — matcher-set-adversarial: the `.audioInterrupted` capture gate
   // flips on the cause. Only `.engineLost` (a lost dictation with no other owner)
-  // captures `.audioCaptureFailed`; the three already-owned causes
-  // (`.captureSessionLost`, `.xpcConnectionLost`, `.maxDurationReached`) must
-  // emit NO captureError, so A3 never double-counts a loss already owned by
-  // `captureSessionInterrupted` / `onXPCServiceError`, and never counts a normal
-  // max-duration auto-stop as a loss. Every case resets recording state.
+  // captures `.audioCaptureFailed`; the two already-owned causes
+  // (`.captureSessionLost`, `.xpcConnectionLost`) must emit NO captureError, so
+  // A3 never double-counts a loss already owned by `captureSessionInterrupted`
+  // / `onXPCServiceError`. (`.maxDurationReached` was deleted by #1408 A3 — the
+  // cap routes as a normal stop and can no longer reach this gate at all.)
+  // Every case resets recording state.
 
   @Test(".audioInterrupted(.engineLost) captures .audioCaptureFailed + resets state")
   func audioInterruptedEngineLostCaptures() {
@@ -382,10 +401,10 @@ import Testing
       ])
   }
 
-  @Test(".audioInterrupted suppresses the three already-owned causes (no double-count)")
+  @Test(".audioInterrupted suppresses the two already-owned causes (no double-count)")
   func audioInterruptedSuppressesOwnedCauses() {
     for cause: EngineInterruptionCause in [
-      .captureSessionLost, .xpcConnectionLost, .maxDurationReached,
+      .captureSessionLost, .xpcConnectionLost,
     ] {
       let recorder = Recorder()
       let sink = makeSink(recorder: recorder)
@@ -401,18 +420,145 @@ import Testing
     }
   }
 
-  @Test("exactly one EngineInterruptionCause captures at the .audioInterrupted terminal")
-  func audioInterruptedExactlyOneCauseCaptures() {
+  @Test("exactly the two unowned-loss causes capture at the .audioInterrupted terminal")
+  func audioInterruptedExactlyTheUnownedLossesCapture() {
     // CaseIterable guard — if a future cause is added, this forces an explicit
     // capture/suppress decision rather than silently inheriting either branch.
-    var capturingCauses: [EngineInterruptionCause] = []
+    var capturingCauses: Set<EngineInterruptionCause> = []
     for cause in EngineInterruptionCause.allCases {
       let recorder = Recorder()
       let sink = makeSink(recorder: recorder)
       sink.emit(.audioInterrupted(cause: cause))
-      if !recorder.captureErrors.isEmpty { capturingCauses.append(cause) }
+      if !recorder.captureErrors.isEmpty { capturingCauses.insert(cause) }
     }
-    #expect(capturingCauses == [.engineLost])
+    // #1408 split `.deviceRemoved` out of `.engineLost`. Both are recording-losing
+    // interruptions with no other owner, so BOTH must still capture — otherwise
+    // the split would silently halve the "audio capture failed" alert.
+    #expect(capturingCauses == [.engineLost, .deviceRemoved])
+  }
+
+  // MARK: - #1408 the interruption counter (the salvage denominator)
+  //
+  // Suppressing `audio_capture_failed` on a salvaged dictation without a
+  // replacement would mean we could count what device death COSTS but not how
+  // often it HAPPENS. `audio.capture_interrupted` is that denominator: one emit
+  // per interrupted session, at whatever terminal it reaches, salvaged or not.
+  // It is deliberately not an error — a Bluetooth user walking away is not our
+  // defect, and this must never page, email, or file a ticket.
+
+  @Test("a salvaged completion emits the counter with salvage_succeeded, and NO capture error")
+  func salvagedCompletionEmitsCounterNotError() {
+    let recorder = Recorder()
+    let telemetryState = KernelTelemetryState()
+    telemetryState.interruptionCause = .engineLost
+    let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+
+    sink.emit(.pipelineCompleted)
+
+    #expect(
+      recorder.audioCaptureInterruptions == [
+        .init(
+          cause: "engine_lost", salvageAttempted: true, salvageSucceeded: true,
+          terminalState: "completed", backend: "parakeet")
+      ])
+    #expect(
+      recorder.captureErrors.isEmpty,
+      "a dictation the user successfully received must not raise a Sentry error")
+  }
+
+  @Test("an unsalvaged interruption emits BOTH the counter and the capture error")
+  func unsalvagedInterruptionEmitsCounterAndError() {
+    let recorder = Recorder()
+    let telemetryState = KernelTelemetryState()
+    telemetryState.interruptionCause = .engineLost
+    let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+
+    sink.emit(.audioInterrupted(cause: .engineLost))
+
+    #expect(
+      recorder.audioCaptureInterruptions == [
+        .init(
+          cause: "engine_lost", salvageAttempted: true, salvageSucceeded: false,
+          terminalState: "audio_interrupted", backend: "parakeet")
+      ])
+    #expect(recorder.captureErrors.count == 1, "the lost dictation is still a real loss")
+  }
+
+  /// The one cause whose samples are gone never attempts salvage — and
+  /// `salvage_attempted` reads the SAME `hasRecoverableAudio` authority the
+  /// kernel's guard reads, never a second copy of that switch.
+  @Test("the unsalvageable cause reports salvage_attempted false")
+  func unsalvageableCauseReportsNoAttempt() {
+    let recorder = Recorder()
+    let telemetryState = KernelTelemetryState()
+    telemetryState.interruptionCause = .xpcConnectionLost
+    let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+
+    sink.emit(.audioInterrupted(cause: .xpcConnectionLost))
+
+    #expect(recorder.audioCaptureInterruptions.count == 1)
+    #expect(recorder.audioCaptureInterruptions[0].salvageAttempted == false)
+    #expect(recorder.audioCaptureInterruptions[0].salvageSucceeded == false)
+  }
+
+  /// A session that was never interrupted must emit nothing. Otherwise the
+  /// denominator counts every dictation and the salvage rate reads as ~100%.
+  @Test("an ordinary completion emits no interruption counter")
+  func ordinaryCompletionEmitsNoCounter() {
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder)
+
+    sink.emit(.pipelineCompleted)
+
+    #expect(recorder.audioCaptureInterruptions.isEmpty)
+  }
+
+  /// One emit per interrupted session, whatever terminal it lands on. A per-arm
+  /// emit would quietly miss the arm nobody thought of — a user cancelling
+  /// mid-salvage, or salvaged audio that decodes to nothing.
+  @Test("every terminal an interrupted session can reach emits exactly one counter")
+  func everyInterruptedTerminalEmitsExactlyOnce() {
+    let terminals: [(KernelLifecycleEvent, String)] = [
+      (.pipelineCompleted, "completed"),
+      (.audioInterrupted(cause: .engineLost), "audio_interrupted"),
+      (.cancelled, "cancelled"),
+      (.failed(.asrEmpty), "failed"),
+      (.noSpeech(.vadGate), "no_speech"),
+      (.discarded(.tooShort), "discarded"),
+    ]
+    for (event, expectedTerminal) in terminals {
+      let recorder = Recorder()
+      let telemetryState = KernelTelemetryState()
+      telemetryState.interruptionCause = .engineLost
+      let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+
+      sink.emit(event)
+
+      #expect(
+        recorder.audioCaptureInterruptions.count == 1,
+        "terminal \(expectedTerminal) must emit exactly one counter")
+      #expect(recorder.audioCaptureInterruptions.first?.terminalState == expectedTerminal)
+    }
+  }
+
+  /// Non-terminal events must not emit, even mid-interruption. Otherwise a single
+  /// session inflates the counter once per lifecycle event it happens to fire.
+  @Test("non-terminal events never emit the interruption counter")
+  func nonTerminalEventsNeverEmitCounter() {
+    let nonTerminals: [KernelLifecycleEvent] = [
+      .pipelineStartingUp, .modelLoading, .recordingCommitted(isStreaming: false),
+      .recordingStopped, .transcriptionStarted, .asrCompleted,
+    ]
+    for event in nonTerminals {
+      let recorder = Recorder()
+      let telemetryState = KernelTelemetryState()
+      telemetryState.interruptionCause = .engineLost
+      let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+
+      sink.emit(event)
+
+      #expect(recorder.audioCaptureInterruptions.isEmpty, "\(event) is not a terminal")
+    }
   }
 
   @Test(".asrInterrupted(wasRecording: true) emits captureError + state(false)")

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
@@ -42,6 +42,9 @@ struct PipelineStateChangeHandlerTests {
     var failedCalls: [String] = []
     /// #1167: reasons passed to the history-save-failed pill.
     var historySaveWarnings: [String] = []
+    /// #1408 A1: (disclosure, alsoTrimmedLead) pairs forwarded to the
+    /// interruption pill callback.
+    var interruptionWarnings: [(CompletionInterruptionDisclosure, Bool)] = []
   }
 
   private static func makeHandler(
@@ -55,7 +58,10 @@ struct PipelineStateChangeHandlerTests {
       appendCompletedTranscript: { callbacks.appendedCalls.append($0) },
       reportDictationCompleted: { callbacks.completedCalls.append($0) },
       reportPipelineFailed: { callbacks.failedCalls.append($0) },
-      scheduleHistorySaveFailedWarning: { callbacks.historySaveWarnings.append($0) }
+      scheduleHistorySaveFailedWarning: { callbacks.historySaveWarnings.append($0) },
+      scheduleInterruptionWarning: { disclosure, alsoTrimmedLead in
+        callbacks.interruptionWarnings.append((disclosure, alsoTrimmedLead))
+      }
     )
   }
 
@@ -325,5 +331,41 @@ struct PipelineStateChangeHandlerTests {
     // Telemetry still fires so the degraded-save dimension is recorded.
     #expect(calls.completedCalls.count == 1)
     #expect(calls.scheduleWarningCount == 0)
+  }
+
+  // MARK: - #1408 A1: interruption-pill forwarding
+
+  /// The handler is a pure dispatcher: the typed effect's payload (which
+  /// sentence family, whether the lead was also lost) must reach the injected
+  /// callback intact — the factory picks the copy from exactly these two values.
+  @Test(
+    "complete + interruption disclosure forwards (disclosure, alsoTrimmedLead) to the callback",
+    arguments: [CompletionInterruptionDisclosure.deviceRemoved, .otherInterruption],
+    [false, true])
+  func interruptionWarningForwardsPayload(
+    disclosure: CompletionInterruptionDisclosure, alsoTrimmedLead: Bool
+  ) {
+    let spy = OverlaySpy()
+    let calls = CallbackRecorder()
+    let handler = Self.makeHandler(overlay: spy, callbacks: calls)
+    let transcript = Self.makeTranscript(pasteTier: "direct")
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: transcript,
+      historySaved: true,
+      historySaveReason: nil,
+      salvagedLead: alsoTrimmedLead,
+      interruptionDisclosure: disclosure
+    )
+
+    #expect(calls.interruptionWarnings.count == 1)
+    #expect(calls.interruptionWarnings.first?.0 == disclosure)
+    #expect(calls.interruptionWarnings.first?.1 == alsoTrimmedLead)
+    // The interruption pill owns the single slot: no other notice fires.
+    #expect(calls.scheduleWarningCount == 0)
+    #expect(calls.historySaveWarnings.isEmpty)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
 import Foundation
@@ -538,6 +539,164 @@ struct PipelineStateChangePlannerTests {
       salvagedLead: true
     )
     #expect(!plan.effects.contains(.scheduleSalvagedLeadWarning))
+  }
+
+  // MARK: - #1408 interruption disclosure + the four-way notice ranking
+
+  /// The single post-completion warning slot is last-writer-wins, so the ranking
+  /// is not array order — it is a set of suppression conditions in this pure
+  /// projection. Parametric over disclosure (nil / .deviceRemoved /
+  /// .otherInterruption) × history-save × lead-trim × polish — the full A1
+  /// validation matrix from plan §21.3.
+  ///
+  /// At most one notice per completion: exactly one whenever any claimant
+  /// applies, none when no claimant applies. No combination may lose a signal.
+  /// The both-ends-lost case (interruption AND lead-trim) is the one that would:
+  /// under a plain ranking the user would hear only that the text was cut short,
+  /// never that the opening was dropped. It gets its own copy instead.
+  @Test(
+    "notice ranking: at most one pill per completion, across the full claimant matrix",
+    arguments: [false, true],
+    [nil, CompletionInterruptionDisclosure.deviceRemoved, .otherInterruption])
+  func noticeRankingIsAtMostOnePill(
+    historySaveFailed: Bool, disclosure: CompletionInterruptionDisclosure?
+  ) {
+    for salvagedLead in [false, true] {
+      for polishFailed in [false, true] {
+        let plan = PipelineStateChangePlanner.plan(
+          to: PipelineState.complete,
+          pipelineOverlayIntent: Self.hiddenIntent,
+          isClipboardFallback: false,
+          isAccessibilityToast: false,
+          lastPolishError: polishFailed ? "polish failed for some reason" : nil,
+          hasCurrentTranscript: true,
+          historySaved: !historySaveFailed,
+          historySaveReason: historySaveFailed ? "disk full" : nil,
+          salvagedLead: salvagedLead,
+          interruptionDisclosure: disclosure
+        )
+        let pills = plan.effects.filter { effect in
+          switch effect {
+          case .scheduleHistorySaveFailedWarning, .scheduleInterruptionWarning,
+            .scheduleSalvagedLeadWarning, .schedulePolishFailedWarning:
+            true
+          default:
+            false
+          }
+        }
+        let label =
+          "historySaveFailed=\(historySaveFailed) disclosure=\(String(describing: disclosure)) "
+          + "salvagedLead=\(salvagedLead) polishFailed=\(polishFailed)"
+
+        // Exactly one pill when any claimant applies, zero when none does.
+        let anyClaimant = historySaveFailed || disclosure != nil || salvagedLead || polishFailed
+        #expect(pills.count == (anyClaimant ? 1 : 0), "\(label) -> \(pills)")
+
+        // Rank 1: the history-save pill always wins the slot.
+        if historySaveFailed {
+          #expect(pills == [.scheduleHistorySaveFailedWarning(reason: "disk full")], "\(label)")
+        } else if let disclosure {
+          // Rank 2: the interruption pill, carrying BOTH the disclosure (which
+          // sentence family) and whether the opening was ALSO lost. This is the
+          // signal that must never be dropped — for `.otherInterruption` too
+          // (grounded review A1: a non-disconnect salvage must not paste
+          // truncated text silently).
+          #expect(
+            pills == [
+              .scheduleInterruptionWarning(disclosure: disclosure, alsoTrimmedLead: salvagedLead)
+            ], "\(label)")
+        } else if salvagedLead {
+          #expect(pills == [.scheduleSalvagedLeadWarning], "\(label)")
+        } else if polishFailed {
+          #expect(pills == [.schedulePolishFailedWarning], "\(label)")
+        }
+      }
+    }
+  }
+
+  @Test(
+    "the both-ends-lost completion gets its own copy, for BOTH sentence families",
+    arguments: [CompletionInterruptionDisclosure.deviceRemoved, .otherInterruption])
+  func bothEndsLostEmitsCombinedNotice(disclosure: CompletionInterruptionDisclosure) {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: true,
+      historySaved: true,
+      historySaveReason: nil,
+      salvagedLead: true,
+      interruptionDisclosure: disclosure
+    )
+    #expect(
+      plan.effects.contains(
+        .scheduleInterruptionWarning(disclosure: disclosure, alsoTrimmedLead: true)))
+    #expect(
+      !plan.effects.contains(
+        .scheduleInterruptionWarning(disclosure: disclosure, alsoTrimmedLead: false)))
+    #expect(!plan.effects.contains(.scheduleSalvagedLeadWarning))
+  }
+
+  @Test("a history-save failure still outranks the interruption pill")
+  func historySaveFailureOutranksInterruption() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: true,
+      historySaved: false,
+      historySaveReason: "disk full",
+      salvagedLead: false,
+      interruptionDisclosure: .deviceRemoved
+    )
+    #expect(plan.effects.contains(.scheduleHistorySaveFailedWarning(reason: "disk full")))
+    #expect(
+      !plan.effects.contains(
+        .scheduleInterruptionWarning(disclosure: .deviceRemoved, alsoTrimmedLead: false)))
+  }
+
+  @Test("a non-complete transition with an interruption schedules no pill")
+  func interruptionPillOnlyOnComplete() {
+    let plan = PipelineStateChangePlanner.plan(
+      to: PipelineState.recording,
+      pipelineOverlayIntent: Self.hiddenIntent,
+      isClipboardFallback: false,
+      isAccessibilityToast: false,
+      lastPolishError: nil,
+      hasCurrentTranscript: false,
+      historySaved: true,
+      historySaveReason: nil,
+      salvagedLead: false,
+      interruptionDisclosure: .deviceRemoved
+    )
+    let hasInterruptionPill = plan.effects.contains { effect in
+      if case .scheduleInterruptionWarning = effect { return true }
+      return false
+    }
+    #expect(!hasInterruptionPill)
+  }
+
+  // MARK: - #1408 A1: the disclosure derivation from the stamped cause
+
+  /// The one mapping the coordinator call sites rely on: nil cause → nil
+  /// disclosure; the verified removal → `.deviceRemoved`; every other cause →
+  /// `.otherInterruption`. Exhaustive over the cause enum so a new case must
+  /// pick a side here at compile time.
+  @Test("CompletionInterruptionDisclosure derives from the cause by isDeviceLoss")
+  func disclosureDerivation() {
+    #expect(CompletionInterruptionDisclosure(cause: nil) == nil)
+    for cause in EngineInterruptionCause.allCases {
+      let disclosure = CompletionInterruptionDisclosure(cause: cause)
+      if cause.isDeviceLoss {
+        #expect(disclosure == .deviceRemoved, "\(cause)")
+      } else {
+        #expect(disclosure == .otherInterruption, "\(cause)")
+      }
+    }
   }
 
   // MARK: - Activity projection integrity

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
@@ -1,0 +1,632 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - #1408 — salvage a dictation whose capture was interrupted mid-recording
+//
+// Before this change, a microphone that died mid-sentence sent the recording
+// straight to `.audioInterrupted` and the audio the capture manager was still
+// holding was never transcribed. Now a salvageable interruption falls through
+// into the normal stop tail.
+//
+// Two properties are under test, and the second is the one that matters:
+//
+//   1. Salvage happens for the causes that leave audio in memory, and does NOT
+//      happen for the one cause whose sample owner is gone.
+//   2. THE FLOOR. Salvage may only ever ADD a transcript. It must never turn a
+//      terminal that RETAINS the crash-recovery spool into one that DELETES it.
+//      Falling through means an interrupted recording now meets the same early
+//      terminals a normal stop does (`.discarded`, `.noSpeech`,
+//      `.failed(.noAudioCaptured)`) — and two of those delete the spool. The
+//      floor maps them back to `.audioInterrupted`, precisely the terminal this
+//      session reached before salvage existed.
+//
+// The floor's proof is a PAIR: identical early-terminal trigger, different exit.
+// A too-short user stop must still `.discarded` (spool deleted, unchanged); a
+// too-short interrupted recording must land `.audioInterrupted` (spool retained).
+
+#if DEBUG
+
+  /// One floored terminal site, as data, so the parametric test names which site
+  /// wedged rather than reporting a bare state mismatch.
+  struct FlooredSite: Sendable, CustomStringConvertible {
+    let name: String
+    let buffers: Int
+    let amplitude: Float
+    let deadAirVAD: Bool
+    var description: String { name }
+  }
+
+  @MainActor
+  @Suite("RecordingSessionKernel — interrupted-capture salvage (#1408)")
+  struct RecordingSessionKernelSalvageTests {
+
+    private func makeWrapper(
+      minimumRecordingTicks: Int = 0,
+      behavior: FakeEngineBehavior = .batchSuccess(text: "hello")
+    ) -> (SimulatorContext, KernelRecordingSession) {
+      let clock = FakeClock()
+      let engine = FakeEngine(behavior: behavior, clock: clock)
+      let capture = FakeAudioCapture()
+      let vad = FakeVADSignalSource()
+      let paste = FakePasteTarget()
+      let wrapper = KernelRecordingSession(
+        engine: engine, capture: capture, vad: vad, clock: clock, paste: paste,
+        minimumRecordingTicks: minimumRecordingTicks)
+      let context = SimulatorContext(
+        sut: wrapper, engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+      return (context, wrapper)
+    }
+
+    /// Start, reach `.recording`, and deliver `bufferCount` real buffers so the
+    /// kernel has audio in hand when the interruption lands.
+    private func startRecording(
+      _ context: SimulatorContext, buffers bufferCount: Int = 1, amplitude: Float = 0.1
+    ) async {
+      await context.sut.apply(.start)
+      await context.sut.drainReadyWork()
+      for _ in 0..<bufferCount { context.capture.deliverBuffer(amplitude: amplitude) }
+      await context.sut.drainReadyWork()
+    }
+
+    // MARK: 1. Salvage happens exactly for the causes that leave audio behind
+
+    /// Every cause whose manager is still alive and holding `capturedSamples`
+    /// must transcribe. Parametric over the predicate's `true` set so a fifth
+    /// cause has to make a decision here as well as at the compiler.
+    @Test(
+      "a salvageable interruption with real audio transcribes and completes",
+      arguments: EngineInterruptionCause.allCases.filter(\.hasRecoverableAudio))
+    func salvageableCauseCompletes(cause: EngineInterruptionCause) async {
+      let (context, wrapper) = makeWrapper()
+      await startRecording(context)
+
+      wrapper.testKernel.externalEngineInterrupted(cause)
+      await wrapper.drainReadyWork()
+
+      #expect(wrapper.testKernel.state == .completed)
+      #expect(context.paste.pasteCount == 1)
+      #expect(wrapper.testKernel.lastAudioInterruptionCause == cause)
+      // The dictation is a salvage, and `stop_reason` says so for free.
+      #expect(wrapper.testKernel.lastStopReason == "audio_interruption")
+    }
+
+    /// The helper process that OWNED the samples is gone. There is nothing to
+    /// transcribe, so we must fail honestly rather than paste an empty string —
+    /// even though a full buffer is sitting in the fake's array. This is the
+    /// adversarial half of `matcher-set-adversarial-tests`: the unsalvageable
+    /// cause is exercised WITH audio present and must still refuse.
+    @Test("the unsalvageable cause refuses salvage even with a full buffer")
+    func xpcConnectionLostRefusesSalvage() async {
+      let (context, wrapper) = makeWrapper()
+      await startRecording(context, buffers: 3)
+
+      wrapper.testKernel.externalEngineInterrupted(.xpcConnectionLost)
+      await wrapper.drainReadyWork()
+
+      #expect(wrapper.testKernel.state == .audioInterrupted)
+      #expect(context.paste.pasteCount == 0)
+      #expect(
+        KernelDictationDriver.endedWithoutSaveKind(for: .audioInterrupted) == .failure,
+        "an unsalvaged interruption must RETAIN the crash-recovery spool")
+    }
+
+    // MARK: 2. The floor — salvage never deletes a spool today's code would keep
+
+    /// The pair that proves the floor. Same early terminal (`bufferCount == 0`
+    /// trips the minimum-recording gate), different exit.
+    ///
+    /// A too-short USER stop keeps discarding, spool deleted, exactly as today.
+    /// A too-short INTERRUPTED recording must NOT discard: without the floor it
+    /// would reach `.discarded`, whose terminal kind is `.discard` — "delete the
+    /// spool now" — destroying the only surviving copy of a recording the user
+    /// never chose to throw away.
+    @Test("a sub-minimum USER stop still discards (the floor is inert outside salvage)")
+    func subMinimumUserStopStillDiscards() async {
+      let (context, wrapper) = makeWrapper()
+      await context.sut.apply(.start)
+      await context.sut.drainReadyWork()
+
+      await context.sut.apply(.stop)
+      await context.sut.drainReadyWork()
+
+      #expect(wrapper.testKernel.state == .discarded)
+      #expect(
+        KernelDictationDriver.endedWithoutSaveKind(for: .discarded) == .discard,
+        "an ordinary too-short tap is still safe to delete")
+    }
+
+    @Test("a sub-minimum INTERRUPTED recording floors to .audioInterrupted, not .discarded")
+    func subMinimumInterruptedFloorsRatherThanDiscards() async {
+      let (_, wrapper) = makeWrapper()
+      await wrapper.apply(.start)
+      await wrapper.drainReadyWork()
+
+      // No buffers delivered — `bufferCountThisSession == 0` trips the same
+      // minimum-recording gate the user-stop test above lands on.
+      wrapper.testKernel.externalEngineInterrupted(.engineLost)
+      await wrapper.drainReadyWork()
+
+      #expect(wrapper.testKernel.state == .audioInterrupted)
+      #expect(
+        KernelDictationDriver.endedWithoutSaveKind(for: .audioInterrupted) == .failure,
+        "the floor must convert the spool-deleting terminal into a spool-retaining one")
+    }
+
+    /// The tick-driven arm of the same gate, with the minimum-recording
+    /// threshold actually ARMED (the scenario inventory zeroes it). No clock is
+    /// advanced, so the elapsed window is below the threshold.
+    @Test("the floor also covers the TIME arm of the minimum-recording gate")
+    func subMinimumByElapsedTicksAlsoFloors() async {
+      let (context, wrapper) = makeWrapper(minimumRecordingTicks: 5)
+      await startRecording(context, buffers: 2)
+
+      wrapper.testKernel.externalEngineInterrupted(.engineLost)
+      await wrapper.drainReadyWork()
+
+      #expect(wrapper.testKernel.state == .audioInterrupted)
+    }
+
+    /// Salvaged audio that transcribes to nothing. Without the floor this lands
+    /// `.noSpeech` → `.discard` → spool deleted. The post-ASR no-speech terminal
+    /// is built from a ternary at its call site, which is exactly why the floor
+    /// lives inside `finishTerminal` rather than at the call sites.
+    @Test("salvaged audio with no speech floors to .audioInterrupted, not .noSpeech")
+    func salvagedAudioWithNoSpeechFloors() async {
+      let (context, wrapper) = makeWrapper()
+      context.vad.evidence = .confirmedNoSpeech
+      // Below the #964 dead-air floor: the VAD gate skips ASR only when the raw
+      // buffer is ALSO dead air, otherwise it transcribes to recover faint speech.
+      await startRecording(context, amplitude: 0.001)
+
+      wrapper.testKernel.externalEngineInterrupted(.engineLost)
+      await wrapper.drainReadyWork()
+
+      #expect(wrapper.testKernel.state == .audioInterrupted)
+      #expect(context.paste.pasteCount == 0)
+    }
+
+    /// The POST-ASR no-speech path, which is a different terminal site from the
+    /// VAD-gate one above: it is built from a ternary
+    /// (`effectiveSpeechEvidence ? .failed(.asrEmpty) : .noSpeech`) that a
+    /// call-site floor cannot wrap and a `grep finishTerminal(.noSpeech` does not
+    /// match. It also transitions from `.transcribing`, not `.stopping` — and
+    /// `.finalizing → .audioInterrupted` is an ILLEGAL transition, so a floor
+    /// applied one step later would be silently rejected and wedge the session
+    /// with no terminal at all. This test proves the rewritten transition is
+    /// accepted and the session actually terminates.
+    @Test("the post-ASR no-speech ternary is floored, and the transition is legal")
+    func postASRNoSpeechTernaryIsFlooredWithoutWedging() async {
+      let (context, wrapper) = makeWrapper(behavior: .empty(hadSpeechEvidence: false))
+      // Above the dead-air floor, so the VAD gate does NOT short-circuit and the
+      // session reaches the adapter, decodes empty, and lands on the ternary.
+      context.vad.evidence = .confirmedNoSpeech
+      await startRecording(context, amplitude: 0.1)
+
+      wrapper.testKernel.externalEngineInterrupted(.engineLost)
+      await wrapper.drainReadyWork()
+
+      #expect(
+        wrapper.testKernel.state == .audioInterrupted,
+        "reached \(wrapper.testKernel.state) — a wedge would leave a non-terminal state")
+      #expect(wrapper.testKernel.state.isTerminal, "the session must not wedge")
+      #expect(context.paste.pasteCount == 0)
+    }
+
+    /// Every terminal the floor rewrites must be reachable from the state its
+    /// call site runs in. A rewrite into an illegal transition is refused by
+    /// `transition(to:)`, `finishTerminal` returns early, and the app hangs with a
+    /// live overlay and no terminal. Drive each floored site for real.
+    @Test(
+      "every floored terminal site actually terminates (no illegal-transition wedge)",
+      arguments: [
+        // (engine behavior, vad evidence, buffers, amplitude) -> each floored site
+        FlooredSite(name: "sub-minimum discard", buffers: 0, amplitude: 0.1, deadAirVAD: false),
+        FlooredSite(name: "VAD-gate no-speech", buffers: 1, amplitude: 0.001, deadAirVAD: true),
+      ])
+    func everyFlooredSiteTerminates(site: FlooredSite) async {
+      let (context, wrapper) = makeWrapper()
+      if site.deadAirVAD { context.vad.evidence = .confirmedNoSpeech }
+      await startRecording(context, buffers: site.buffers, amplitude: site.amplitude)
+
+      wrapper.testKernel.externalEngineInterrupted(.engineLost)
+      await wrapper.drainReadyWork()
+
+      #expect(
+        wrapper.testKernel.state == .audioInterrupted,
+        "\(site.name): reached \(wrapper.testKernel.state)")
+      #expect(wrapper.testKernel.state.isTerminal, "\(site.name): wedged")
+    }
+
+    /// THE INVARIANT. Absent an explicit user cancel, a session whose exit was a
+    /// salvageable interruption terminates in exactly one of two states. There is
+    /// no third outcome, and neither outcome deletes a spool today's code retains.
+    @Test(
+      "invariant: a salvageable interruption ends .completed or .audioInterrupted, never a third state",
+      arguments: EngineInterruptionCause.allCases.filter(\.hasRecoverableAudio), [0, 1, 3])
+    func salvageTerminatesInExactlyTwoStates(
+      cause: EngineInterruptionCause, bufferCount: Int
+    ) async {
+      let (context, wrapper) = makeWrapper()
+      await startRecording(context, buffers: bufferCount)
+
+      wrapper.testKernel.externalEngineInterrupted(cause)
+      await wrapper.drainReadyWork()
+
+      let terminal = wrapper.testKernel.state
+      #expect(
+        terminal == .completed || terminal == .audioInterrupted,
+        "salvage produced a third terminal: \(terminal)")
+      if terminal != .completed {
+        #expect(KernelDictationDriver.endedWithoutSaveKind(for: terminal) == .failure)
+      }
+    }
+
+    /// The one sanctioned third outcome. A user who sees the disconnect notice
+    /// and cancels has asked us to throw the take away; flooring `.cancelled`
+    /// would override an explicit instruction to protect data the user just told
+    /// us to discard. Its retain/delete disposition belongs to the driver's
+    /// `pendingCancelDisposition`, not to the floor.
+    @Test("an explicit cancel during a salvage is honored, never floored")
+    func explicitCancelDuringSalvageIsNotFloored() async {
+      // `slowFinalize` dwells inside `.transcribing`, which is how the inventory
+      // places a cancel deterministically mid-tail (A8). Without it the salvage
+      // runs to `.completed` before a cancel can land.
+      let (context, wrapper) = makeWrapper(
+        behavior: .slowFinalize(ticksToFinal: 4, text: "hello"))
+      await startRecording(context)
+
+      wrapper.testKernel.externalEngineInterrupted(.engineLost)
+      await wrapper.drainReadyWork()
+      #expect(
+        wrapper.testKernel.state == .transcribing,
+        "precondition: the salvage tail must still be in flight, got \(wrapper.testKernel.state)")
+
+      await wrapper.apply(.cancel)
+      await wrapper.drainReadyWork()
+
+      #expect(wrapper.testKernel.state == .cancelled)
+      #expect(context.paste.pasteCount == 0)
+      #expect(
+        KernelDictationDriver.endedWithoutSaveKind(for: .cancelled) == nil,
+        "`.cancelled` is resolved dynamically by pendingCancelDisposition, not the static map")
+    }
+
+    /// Every terminal state the FSM can reach. `RecordingSessionState` has
+    /// associated values so it cannot be `CaseIterable`; this list is the manual
+    /// mirror, and `KernelDictationDriver.endedWithoutSaveKind` is an exhaustive
+    /// switch, so a new state forces a decision there and gets caught here.
+    private static let allTerminals: [RecordingSessionState] = [
+      .completed, .cancelled, .discarded, .noSpeech, .audioInterrupted, .asrInterrupted,
+      .failed(.prepareFailed), .failed(.permissionDenied), .failed(.modelWedged),
+      .failed(.modelLoadFailed), .failed(.captureStartFailed), .failed(.noAudioCaptured),
+      .failed(.asrEmpty), .failed(.asrFailed), .failed(.asrWedged),
+      .failed(.emptyAfterProcessing), .failed(.captureStalled),
+    ]
+
+    /// The floor's mapped set and the driver's `.discard` set are two lists of
+    /// one fact: "this terminal deletes the crash-recovery spool." They live in
+    /// different types and can drift. This test couples them, so adding a new
+    /// spool-deleting terminal without flooring it reddens here rather than
+    /// silently destroying a user's only surviving copy of a dictation.
+    @Test("the floor covers EVERY terminal that would delete the spool")
+    func floorCoversEverySpoolDeletingTerminal() async {
+      let (_, wrapper) = makeWrapper()
+      wrapper.telemetryState.interruptionCause = .engineLost
+      let kernel = wrapper.testKernel
+
+      for terminal in Self.allTerminals {
+        let deletesSpool = KernelDictationDriver.endedWithoutSaveKind(for: terminal) == .discard
+        let floored = kernel.testInterruptedTerminalFloor(terminal)
+        if deletesSpool {
+          #expect(
+            floored == .audioInterrupted,
+            "\(terminal) deletes the spool but the floor let it through")
+        }
+      }
+    }
+
+    /// The floor must not over-reach. A user who cancels has asked us to discard;
+    /// a completion delivered a transcript; every other `.failed` reason is
+    /// already spool-retaining and keeps its own honest cause.
+    @Test("the floor leaves every non-spool-deleting terminal alone, except noAudioCaptured")
+    func floorLeavesOtherTerminalsAlone() async {
+      let (_, wrapper) = makeWrapper()
+      wrapper.telemetryState.interruptionCause = .deviceRemoved
+      let kernel = wrapper.testKernel
+
+      #expect(kernel.testInterruptedTerminalFloor(.completed) == .completed)
+      #expect(
+        kernel.testInterruptedTerminalFloor(.cancelled) == .cancelled,
+        "an explicit user cancel is never overridden")
+      #expect(kernel.testInterruptedTerminalFloor(.asrInterrupted) == .asrInterrupted)
+      #expect(kernel.testInterruptedTerminalFloor(.failed(.asrEmpty)) == .failed(.asrEmpty))
+      #expect(kernel.testInterruptedTerminalFloor(.failed(.asrFailed)) == .failed(.asrFailed))
+      // Folded in with the spool-deleting pair: already retaining, but all three
+      // no-transcript endings land on one terminal so none of them keeps a
+      // different overlay for a reason no user could name.
+      #expect(kernel.testInterruptedTerminalFloor(.failed(.noAudioCaptured)) == .audioInterrupted)
+    }
+
+    // MARK: 2b. The floor is unconditional — the SENTENCE is what varies
+
+    /// SAFETY, for every cause. A spool-deleting terminal is rewritten no matter
+    /// which interruption fired. Letting the cap fall through to `.discarded`
+    /// because "no microphone disconnected" would be a NEW data loss dressed up
+    /// as honesty. The honesty belongs in the message, not the terminal.
+    @Test(
+      "every no-transcript terminal is floored for EVERY recoverable cause",
+      arguments: EngineInterruptionCause.allCases.filter(\.hasRecoverableAudio))
+    func spoolDeletingTerminalsAreFlooredForEveryCause(cause: EngineInterruptionCause) async {
+      let (_, wrapper) = makeWrapper()
+      wrapper.telemetryState.interruptionCause = cause
+      let kernel = wrapper.testKernel
+
+      #expect(kernel.testInterruptedTerminalFloor(.discarded) == .audioInterrupted)
+      #expect(kernel.testInterruptedTerminalFloor(.noSpeech) == .audioInterrupted)
+      #expect(kernel.testInterruptedTerminalFloor(.failed(.noAudioCaptured)) == .audioInterrupted)
+    }
+
+    /// #1408 A3 retired `.maxDurationReached`: the hard cap is a normal
+    /// auto-stop routed through the typed `.maxDuration` exit, so it can no
+    /// longer stamp a cause, reach the floor, or claim an interruption at all.
+    /// This freeze keeps the retirement honest — a resurrected cap case would
+    /// change the enum's shape and redden here before it could lie again.
+    @Test("the cause enum has exactly the four genuine interruption causes")
+    func causeEnumHasNoDurationCap() {
+      #expect(
+        EngineInterruptionCause.allCases == [
+          .deviceRemoved, .engineLost, .captureSessionLost, .xpcConnectionLost,
+        ])
+      #expect(EngineInterruptionCause(rawValue: "max_duration_reached") == nil)
+    }
+
+    /// Outside an interruption the floor is a no-op on every terminal. If it were
+    /// not, an ordinary too-short tap would retain a spool forever.
+    @Test("with no interruption stamped, the floor is the identity function")
+    func floorIsInertWithoutACause() async {
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+      #expect(wrapper.telemetryState.interruptionCause == nil)
+
+      for terminal in Self.allTerminals {
+        #expect(
+          kernel.testInterruptedTerminalFloor(terminal) == terminal,
+          "\(terminal) was rewritten outside an interruption")
+      }
+    }
+
+    // MARK: 3. The single home — one writer, one clearer
+
+    /// The cause now lives on the shared `KernelTelemetryState`, cleared ONLY by
+    /// `resetForNewSession()`. Two clearers would let a stale cause leak into the
+    /// next session, and the floor would then convert an ordinary too-short tap
+    /// into `.audioInterrupted` with a retained spool. This test is the guard.
+    @Test("a fresh session starts with no cause, even after an interrupted one")
+    func causeDoesNotLeakAcrossSessions() async {
+      let (context, wrapper) = makeWrapper()
+      await startRecording(context)
+      wrapper.testKernel.externalEngineInterrupted(.engineLost)
+      await wrapper.drainReadyWork()
+      #expect(wrapper.testKernel.lastAudioInterruptionCause == .engineLost)
+
+      await wrapper.apply(.reset)
+      await wrapper.apply(.start)
+      await wrapper.drainReadyWork()
+
+      #expect(
+        wrapper.testKernel.lastAudioInterruptionCause == nil,
+        "a stale cause would make the next ordinary too-short tap retain a spool")
+
+      // And the floor is genuinely inert again: an ordinary stop discards.
+      await wrapper.apply(.stop)
+      await wrapper.drainReadyWork()
+      #expect(wrapper.testKernel.state == .discarded)
+    }
+
+    /// The kernel's property is a read-through, not a second copy. The finalization
+    /// wiring and the lifecycle sink read the same object, so a divergence here
+    /// would silently disable the History badge and the telemetry.
+    @Test("the kernel's cause reads through to the shared telemetry holder")
+    func kernelCauseReadsThroughToSharedHolder() async {
+      let (context, wrapper) = makeWrapper()
+      await startRecording(context)
+
+      wrapper.testKernel.externalEngineInterrupted(.captureSessionLost)
+      await wrapper.drainReadyWork()
+
+      #expect(wrapper.telemetryState.interruptionCause == .captureSessionLost)
+      #expect(
+        wrapper.testKernel.lastAudioInterruptionCause == wrapper.telemetryState.interruptionCause)
+    }
+
+    /// First-wins. A second interruption arriving in the post-latch window must
+    /// not overwrite the cause the winning exit will be judged by — otherwise an
+    /// already-owned `.xpcConnectionLost` could be replaced by a later
+    /// `.engineLost` and salvage a recording whose samples are gone.
+    @Test("a racing second interruption cannot flip an unsalvageable cause to a salvageable one")
+    func secondInterruptionCannotUnlockSalvage() async {
+      let (context, wrapper) = makeWrapper()
+      await startRecording(context)
+
+      wrapper.testKernel.externalEngineInterrupted(.xpcConnectionLost)
+      wrapper.testKernel.externalEngineInterrupted(.engineLost)
+      await wrapper.drainReadyWork()
+
+      #expect(wrapper.testKernel.lastAudioInterruptionCause == .xpcConnectionLost)
+      #expect(wrapper.testKernel.state == .audioInterrupted)
+      #expect(context.paste.pasteCount == 0)
+    }
+  }
+
+  // MARK: - The predicate itself (#1408)
+
+  @Suite("EngineInterruptionCause.hasRecoverableAudio (#1408)")
+  struct EngineInterruptionCauseRecoverabilityTests {
+
+    /// `salvage_attempted` in telemetry and the kernel's salvage guard read this
+    /// one property. If it ever disagrees with the kernel's behavior, one of the
+    /// two grew a second copy of the switch.
+    @Test("exactly one cause has no recoverable audio")
+    func onlyXPCConnectionLostIsUnrecoverable() {
+      let unrecoverable = EngineInterruptionCause.allCases.filter { !$0.hasRecoverableAudio }
+      #expect(unrecoverable == [.xpcConnectionLost])
+    }
+
+    /// Recoverability is NOT the same question as "does this cause already have a
+    /// telemetry owner." Two causes answer these questions differently, and
+    /// conflating them is how a duplicated switch would drift.
+    @Test("recoverability is not the telemetry-capture set")
+    func recoverabilityDivergesFromCaptureSet() {
+      #expect(EngineInterruptionCause.captureSessionLost.hasRecoverableAudio)
+      #expect(!EngineInterruptionCause.xpcConnectionLost.hasRecoverableAudio)
+      #expect(EngineInterruptionCause.engineLost.hasRecoverableAudio)
+      #expect(EngineInterruptionCause.deviceRemoved.hasRecoverableAudio)
+    }
+
+    /// And `isDeviceLoss` is a THIRD question. A capture-session interruption is
+    /// salvaged like a disconnect but is not one: telling that user "Microphone
+    /// disconnected," or badging their transcript with a crossed-out microphone,
+    /// would describe an event that never happened.
+    @Test("a capture-session loss is recoverable but is NOT a device loss")
+    func captureSessionLossIsRecoverableButNotDeviceLoss() {
+      #expect(EngineInterruptionCause.captureSessionLost.hasRecoverableAudio)
+      #expect(!EngineInterruptionCause.captureSessionLost.isDeviceLoss)
+    }
+
+    /// Exactly one cause is backed by a real `DeviceIsAlive` check. Each exclusion
+    /// is a claim we could not back: `.engineLost` also covers a recovery timeout
+    /// and a failed engine restart with the mic still attached;
+    /// `.captureSessionLost` fires for any capture-session interruption AND every
+    /// runtime error; `.xpcConnectionLost` means our helper died, not the mic.
+    @Test("only .deviceRemoved is a device loss")
+    func deviceLossSetIsExactlyDeviceRemoved() {
+      let deviceLosses = EngineInterruptionCause.allCases.filter(\.isDeviceLoss)
+      #expect(deviceLosses == [.deviceRemoved])
+    }
+
+    /// The split's whole point. `.engineLost` used to mean both of these, and the
+    /// disclosure could not tell them apart.
+    @Test("an engine that failed to recover is salvageable but is not a disconnect")
+    func engineLostIsSalvageableButNotADisconnect() {
+      #expect(EngineInterruptionCause.engineLost.hasRecoverableAudio)
+      #expect(!EngineInterruptionCause.engineLost.isDeviceLoss)
+      #expect(EngineInterruptionCause.deviceRemoved.hasRecoverableAudio)
+      #expect(EngineInterruptionCause.deviceRemoved.isDeviceLoss)
+    }
+
+    /// The helper ran the `DeviceIsAlive` check; the host cannot re-run it because
+    /// the device is already gone. Collapsing `.deviceRemoved` at the XPC boundary
+    /// would throw away the one piece of evidence the disclosure depends on — and
+    /// the helper IS the shipping capture backend, so this is the path a real
+    /// Bluetooth disconnect takes.
+    @Test("the XPC relay preserves a verified removal, and still collapses the rest")
+    func xpcRelayPreservesDeviceRemoved() {
+      #expect(
+        EngineInterruptionCause.hostCause(forRelayedRawValue: "device_removed")
+          == .deviceRemoved)
+      // #1408 A3: the retired cap raw value is a legacy unknown now — it fails
+      // toward visibility like anything else, never resurrects the cap.
+      #expect(
+        EngineInterruptionCause.hostCause(forRelayedRawValue: "max_duration_reached")
+          == .engineLost)
+      #expect(
+        EngineInterruptionCause.hostCause(forRelayedRawValue: "capture_session_lost")
+          == .engineLost)
+      #expect(
+        EngineInterruptionCause.hostCause(forRelayedRawValue: "xpc_connection_lost")
+          == .engineLost)
+      #expect(EngineInterruptionCause.hostCause(forRelayedRawValue: "engine_lost") == .engineLost)
+      // Unknown / legacy raw values fail toward visibility, never toward a
+      // disconnect claim.
+      #expect(
+        EngineInterruptionCause.hostCause(forRelayedRawValue: "from_the_future")
+          == .engineLost)
+    }
+
+    /// The two predicates answer two different questions. If they ever collapse
+    /// into one, this reddens rather than silently changing behavior.
+    @Test("the two predicates are genuinely distinct sets")
+    func predicatesAreDistinct() {
+      let recoverable = Set(EngineInterruptionCause.allCases.filter(\.hasRecoverableAudio))
+      let deviceLoss = Set(EngineInterruptionCause.allCases.filter(\.isDeviceLoss))
+      #expect(recoverable != deviceLoss, "recoverability and device-loss are different questions")
+      // A capture-session loss is salvageable but is not a disconnect...
+      #expect(recoverable.contains(.captureSessionLost))
+      #expect(!deviceLoss.contains(.captureSessionLost))
+      // ...and a dead helper is neither: its samples are gone AND it is our
+      // process that died, not the user's microphone.
+      #expect(!recoverable.contains(.xpcConnectionLost))
+      #expect(!deviceLoss.contains(.xpcConnectionLost))
+      // Device loss is a strict subset of recoverable: if the mic vanished, the
+      // capture manager is still alive and still holding what was said.
+      #expect(deviceLoss.isStrictSubset(of: recoverable))
+    }
+  }
+
+  // MARK: - The interruption sentence
+
+  /// #1408 (Codex code-diff r4, founder-approved copy). `.audioInterrupted` is
+  /// now the single no-transcript terminal for EVERY interruption, so it can no
+  /// longer carry "Microphone disconnected" unconditionally — that string was a
+  /// lie for a recovery failure, the duration cap, and our own helper crashing.
+  ///
+  /// `InterruptionMessages.message(for:)` is the one authority for which sentence
+  /// a user reads, and the three `KernelDictationDriver` render sites all route
+  /// through it. These tests are what keep the claim honest: exactly the causes
+  /// backed by a real Core Audio removal may say a microphone disconnected.
+  @Suite("The interruption sentence never claims more than we know (#1408)")
+  struct InterruptionMessageTests {
+
+    @Test("only a verified device loss says the microphone disconnected")
+    func onlyDeviceLossClaimsADisconnect() {
+      for cause in EngineInterruptionCause.allCases {
+        let sentence = InterruptionMessages.message(for: cause)
+        if cause.isDeviceLoss {
+          #expect(sentence == "Microphone disconnected", "\(cause) earns the claim")
+        } else {
+          #expect(
+            sentence == "Recording interrupted",
+            "\(cause) is not a microphone walking away, so it must not say one did")
+        }
+      }
+    }
+
+    /// The set that may claim a disconnect is exactly the set `isDeviceLoss`
+    /// names. Coupled rather than restated, so a sixth cause cannot quietly
+    /// inherit the disconnect sentence by being added to the wrong list.
+    @Test("the claiming set is exactly the isDeviceLoss set")
+    func claimingSetEqualsDeviceLossSet() {
+      let claims = Set(
+        EngineInterruptionCause.allCases.filter {
+          InterruptionMessages.message(for: $0) == "Microphone disconnected"
+        })
+      let deviceLoss = Set(EngineInterruptionCause.allCases.filter(\.isDeviceLoss))
+      #expect(claims == deviceLoss)
+      #expect(claims == [.deviceRemoved])
+    }
+
+    /// An `.audioInterrupted` terminal with no stamped cause should never be
+    /// reachable (the kernel refuses salvage and logs), but if it ever is, the
+    /// absence of evidence must not read as evidence of a disconnect.
+    @Test("no stamped cause falls back to the neutral line, never a disconnect")
+    func missingCauseIsNeutral() {
+      #expect(InterruptionMessages.message(for: nil) == "Recording interrupted")
+    }
+
+    /// Rule 6: no em-dashes or en-dashes in anything a user reads.
+    @Test("neither sentence carries a dash a human would see")
+    func noDashesInUserFacingCopy() {
+      for sentence in [
+        InterruptionMessages.micDisconnected, InterruptionMessages.recordingInterrupted,
+      ] {
+        #expect(!sentence.contains("\u{2014}"), "em-dash in user-facing copy: \(sentence)")
+        #expect(!sentence.contains("\u{2013}"), "en-dash in user-facing copy: \(sentence)")
+      }
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -75,6 +75,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   // XPC-only telemetry callbacks — a direct (non-XPC) source leaves these nil.
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
@@ -200,6 +201,12 @@ final class FakeAudioCapture: AudioCaptureInterface {
   /// Fire the VAD auto-stop callback.
   func fireVADAutoStop() {
     onVADAutoStop?()
+  }
+
+  /// #1408 A3: fire the hard-cap backstop callback (a normal auto-stop event,
+  /// mirroring the manager/proxy relay).
+  func fireMaxDurationReached() {
+    onMaxDurationReached?()
   }
 
   /// Fire the capture-stall callback (C3 / C4 — the liveness watchdog observed

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -132,15 +132,26 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// inspect kernel internals (`RecordingSessionKernelTests`).
   var testKernel: RecordingSessionKernel { kernel }
 
+  /// The kernel's per-session telemetry side-channel, held so a test can read
+  /// what the kernel stamped (#1408: `interruptionCause`). Production shares ONE
+  /// instance across the kernel, the finalization wiring, and the lifecycle sink;
+  /// this wrapper mirrors that by constructing it once and passing it in.
+  let telemetryState = KernelTelemetryState()
+
   init(
     engine: FakeEngine,
     capture: FakeAudioCapture,
     vad: FakeVADSignalSource,
     clock: FakeClock,
-    paste: FakePasteTarget
+    paste: FakePasteTarget,
+    // #1408: the floor's regression guard needs the minimum-recording gate ARMED
+    // (the inventory zeroes it, see the note at the `minimumRecordingTicks`
+    // argument below). Defaulted so every existing scenario is unchanged.
+    minimumRecordingTicks: Int = 0
   ) {
     self.vad = vad
     let limb = self.limb
+    let telemetryState = self.telemetryState
     self.kernel = RecordingSessionKernel(
       adapter: engine,
       audioCapture: capture,
@@ -170,11 +181,12 @@ final class KernelRecordingSession: RecordingSessionDriving {
         case .clipboardOnly, .none: return .clipboardOnly
         }
       },
-      // PR-4.5 #4 (Codex r3): the simulator's 33-scenario inventory does not
+      // PR-4.5 #4 (Codex r3): the simulator's 38-scenario inventory does not
       // advance the FakeClock between start and stop, so a positive
       // minimum-recording threshold would discard most scenarios. The
       // dedicated #4 coverage lives in `ConductorParitySeamTests`.
-      minimumRecordingTicks: 0)
+      minimumRecordingTicks: minimumRecordingTicks,
+      telemetryState: telemetryState)
   }
 
   // MARK: RecordingSessionDriving — observation

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionKernelScenarioTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionKernelScenarioTests.swift
@@ -35,7 +35,7 @@ struct RecordingSessionKernelScenarioTests {
     #expect(result.passed, "scenario \(scenario.id) (\(scenario.name)): \(result.failures)")
   }
 
-  @Test("the canonical 33-scenario inventory is intact")
+  @Test("the canonical 38-scenario inventory is intact")
   func inventoryComplete() {
     let ids = Set(ScenarioInventory.all.map(\.id))
     #expect(ids == ScenarioInventory.canonicalIDs)

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
@@ -8,7 +8,7 @@ import Foundation
 // `ExpectedOutcome`. The `ScenarioRunner` (this target) executes the steps
 // against a `RecordingSessionDriving` SUT. In PR-2 the SUT is `StubRecordingSession`
 // (harness self-test); from PR-3 it is the real kernel behind a test-side
-// wrapper, and the 33-scenario inventory becomes merge-blocking.
+// wrapper, and the 38-scenario inventory becomes merge-blocking.
 
 /// A session-lifecycle trigger — the kernel's public entry points
 /// (PR-1 §B.1.2 transition table).
@@ -77,10 +77,14 @@ enum CaptureDirective: Sendable {
   case deliverSilentBuffer
   /// Stall the capture stream (no buffers).
   case stall
-  /// Raise an engine interruption (mic disconnect / route change).
+  /// Raise an engine interruption (mic disconnect / route change). The manager
+  /// still holds the captured samples, so #1408 salvages the dictation.
   case interrupt
   /// Change the audio route mid-session.
   case routeChange
+  /// #1408: raise the ONE interruption whose sample owner is gone — the audio
+  /// XPC helper died. Salvage must refuse and the recording must fail honestly.
+  case interruptUnrecoverable
   /// Deny / revoke microphone permission.
   case permissionDenied
   /// Fail capture start.

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - Scenario inventory (epic #827, PR-2 plan §3.8; PR-1 §11.1)
 //
-// The 33 canonical-ID heart-path scenarios, each encoded as data with a full
+// The 38 canonical-ID heart-path scenarios, each encoded as data with a full
 // `ExpectedOutcome`. `ScenarioInventoryTests` asserts the EXACT ID set is
 // present (by ID, not a count — a count passes while a scenario is silently
 // swapped). In PR-2 these are data; from PR-3 the `ScenarioRunner` executes
@@ -24,7 +24,7 @@ import Foundation
 
 enum ScenarioInventory {
 
-  /// All 33 canonical scenarios.
+  /// All 38 canonical scenarios.
   static let all: [Scenario] =
     asrSide + regressionLocks + captureSide + limbSide
 
@@ -352,18 +352,42 @@ enum ScenarioInventory {
       expected: ExpectedOutcome(
         terminalState: .failed(.captureStalled), pasteCount: 0, pasteOutcome: .none,
         transcript: .none, userVisibleError: .recoverableError)),
+    // #1408: the device dies mid-sentence but the capture manager is still
+    // holding what was said. We now transcribe and paste it instead of throwing
+    // it away. This scenario asserted `.audioInterrupted` / pasteCount 0 until
+    // salvage landed — the flip IS the feature.
     Scenario(
-      id: "C5", name: "audio route / device change mid-session",
+      id: "C5", name: "audio route / device change mid-session (salvaged)",
       steps: [.trigger(.start), .capture(.deliverBuffer), .capture(.routeChange)],
       expected: ExpectedOutcome(
-        terminalState: .audioInterrupted, pasteCount: 0, pasteOutcome: .none,
-        transcript: .none, userVisibleError: .interruption)),
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .nonEmpty, userVisibleError: nil)),
     Scenario(
       id: "C6", name: "XPC capture crash / reconnect",
       steps: [.trigger(.start), .capture(.deliverBuffer), .capture(.xpcCrash)],
       expected: ExpectedOutcome(
         terminalState: .asrInterrupted, pasteCount: 0, pasteOutcome: .none,
         transcript: .none, userVisibleError: .recoverableError)),
+    // #1408: the audio helper that OWNED the samples died. Nothing survives in
+    // memory, so salvage must refuse and the recording fails honestly — even
+    // though a buffer was delivered before the crash.
+    Scenario(
+      id: "C7", name: "audio XPC helper dies mid-session (salvage refused)",
+      steps: [.trigger(.start), .capture(.deliverBuffer), .capture(.interruptUnrecoverable)],
+      expected: ExpectedOutcome(
+        terminalState: .audioInterrupted, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .interruption)),
+    // #1408 THE FLOOR: a device that dies before any audio arrives would fall
+    // through to the minimum-recording gate and reach `.discarded`, whose
+    // terminal kind DELETES the crash-recovery spool. The floor maps it back to
+    // `.audioInterrupted`, which retains it. C5 cannot cover this — it delivers a
+    // buffer, and the inventory zeroes the minimum-recording tick threshold.
+    Scenario(
+      id: "C8", name: "device dies before any audio arrives (floored, spool retained)",
+      steps: [.trigger(.start), .capture(.interrupt)],
+      expected: ExpectedOutcome(
+        terminalState: .audioInterrupted, pasteCount: 0, pasteOutcome: .none,
+        transcript: .none, userVisibleError: .interruption)),
   ]
 
   // MARK: Limb-side (L1–L6)
@@ -447,7 +471,7 @@ enum ScenarioInventory {
     "A11", "A12", "A13", "A14", "A15", "A16", "A17", "A18", "A19",
     "A20", "A21", "A22",
     "R1", "R2",
-    "C1", "C2", "C3", "C4", "C5", "C6",
+    "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8",
     "L1", "L2", "L3", "L4", "L5", "L6",
   ]
 }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventoryTests.swift
@@ -8,10 +8,10 @@ import Testing
 @Suite("ScenarioInventory")
 struct ScenarioInventoryTests {
 
-  @Test("the inventory holds exactly the 36 canonical scenarios")
-  func inventoryHoldsThirtySix() {
-    #expect(ScenarioInventory.all.count == 36)
-    #expect(ScenarioInventory.canonicalIDs.count == 36)
+  @Test("the inventory holds exactly the 38 canonical scenarios")
+  func inventoryHoldsThirtyEight() {
+    #expect(ScenarioInventory.all.count == 38)
+    #expect(ScenarioInventory.canonicalIDs.count == 38)
   }
 
   @Test("the inventory's ID set matches the canonical ID set exactly")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -10,7 +10,7 @@ import Foundation
 // `ExpectedOutcome`. Deterministic: one run per scenario is the pass
 // (epic §3a). In PR-2 the SUT is `StubRecordingSession` and only the harness
 // mechanics are exercised; from PR-3 the SUT is the real kernel and the
-// 33-scenario inventory becomes merge-blocking.
+// 38-scenario inventory becomes merge-blocking.
 
 /// The fakes + SUT bundle one scenario runs against.
 @MainActor
@@ -159,8 +159,14 @@ struct ScenarioRunner {
       // match the production path PR-4b.4 wires (App router → driver → kernel).
       kernel?.externalCaptureStalled(context.capture.makeStallContext())
     case .interrupt, .routeChange:
-      // The audio-interruption channel (C5). A genuine engine loss → captured.
-      kernel?.externalEngineInterrupted(.engineLost)
+      // The audio-interruption channel (C5). A verified device removal (the
+      // Bluetooth headset walked away) → captured, and (#1408) salvaged: the
+      // capture manager is still alive and still holding the samples.
+      kernel?.externalEngineInterrupted(.deviceRemoved)
+    case .interruptUnrecoverable:
+      // #1408 (C7): the audio XPC helper that OWNED `capturedSamples` is gone.
+      // Salvage must refuse — there is nothing left in memory to transcribe.
+      kernel?.externalEngineInterrupted(.xpcConnectionLost)
     case .permissionDenied:
       context.capture.permissionDenied = true
     case .startFailure:

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 /// Harness self-test (epic #827, PR-2 plan §11.2 item H).
 /// Exercises `ScenarioRunner` against `StubRecordingSession` and proves the
-/// assertion library reports pass and fail correctly. The 33-scenario
+/// assertion library reports pass and fail correctly. The 38-scenario
 /// inventory does NOT execute in PR-2 (no kernel) — this proves the runner
 /// mechanics so PR-3 inherits a trusted harness.
 @MainActor

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -140,6 +140,7 @@ private final class NeverFinishingAudioCapture: AudioCaptureInterface {
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
   var onCaptureSessionInterruption: ((CaptureSessionInterruptionContext) -> Void)?
   var onXPCServiceError: ((XPCErrorContext) -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitTailPaddingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitTailPaddingTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+
+// MARK: - #1408 premise 2 — an abruptly severed tail decodes like a user stop
+//
+// Salvaging a dictation whose microphone died mid-sentence hands the decoder a
+// buffer that ends abruptly, with no trailing silence. The plan asserted that
+// WhisperKit already handles this identically to a normal user stop, and that
+// the mitigation predates the case. These tests lock that claim so a future
+// "optimization" that makes the pad conditional cannot silently truncate the
+// last words of every salvaged recording.
+//
+// Parakeet is the opposite contract and must stay that way: an RNNT decoder fed
+// trailing silence loops and repeats (`gotchas-audio.md` FACT:
+// parakeet-tail-truncation). These tests do NOT claim Parakeet is never padded —
+// the conditioner's engine-agnostic short-utterance pad is a separate,
+// pre-existing path. The claim is narrower: no TRAILING-SILENCE pad.
+
+@Suite("WhisperKit trailing-silence pad (#1408 premise 2)")
+struct WhisperKitTailPaddingTests {
+
+  private static let sampleRate = 16000
+  private static let expectedPadSamples = Int(0.5 * 16000)
+
+  @Test("the pad appends exactly 500 ms of trailing silence")
+  func padAppendsHalfASecondOfSilence() {
+    let speech = [Float](repeating: 0.4, count: Self.sampleRate)
+    let padded = WhisperKitBackend.padAudioWithSilence(speech)
+
+    #expect(padded.count == speech.count + Self.expectedPadSamples)
+    #expect(Array(padded.prefix(speech.count)) == speech, "the speech must be untouched")
+    #expect(
+      padded.suffix(Self.expectedPadSamples).allSatisfy { $0 == 0 },
+      "the tail must be pure silence, not a repeat of the last frame")
+  }
+
+  /// The salvage case exactly: audio that stops dead, with no decaying tail.
+  /// The pad is what gives the decoder the look-ahead context it needs, and it
+  /// does not depend on the buffer's shape, length, or how the recording ended.
+  @Test(
+    "the pad is unconditional — it does not inspect the buffer",
+    arguments: [0, 1, 160, 16000, 480_000])
+  func padIsUnconditional(sampleCount: Int) {
+    // An abruptly severed tail: full-amplitude right up to the final sample.
+    let abrupt = [Float](repeating: 0.9, count: sampleCount)
+    let padded = WhisperKitBackend.padAudioWithSilence(abrupt)
+
+    #expect(padded.count == sampleCount + Self.expectedPadSamples)
+    #expect(padded.suffix(Self.expectedPadSamples).allSatisfy { $0 == 0 })
+  }
+
+  @Test("padding an empty buffer yields silence rather than trapping")
+  func padOfEmptyBufferIsSilence() {
+    let padded = WhisperKitBackend.padAudioWithSilence([])
+    #expect(padded.count == Self.expectedPadSamples)
+    #expect(padded.allSatisfy { $0 == 0 })
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/TranscriptRecoveryFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/TranscriptRecoveryFieldsTests.swift
@@ -38,5 +38,47 @@ struct TranscriptRecoveryFieldsTests {
     let transcript = Transcript(text: "x")
     #expect(transcript.recoverySessionID == nil)
     #expect(transcript.isRecovered == nil)
+    #expect(transcript.inputDeviceWasRemoved == nil)
+  }
+
+  // MARK: - #1408 `inputDeviceWasRemoved`
+
+  /// The additive-optional pattern again. Rollback safety depends on this: a
+  /// reverted build must decode forward-written JSON by ignoring the unknown key,
+  /// and a pre-#1408 file must decode with `inputDeviceWasRemoved` nil.
+  @Test("a pre-#1408 JSON decodes with inputDeviceWasRemoved nil")
+  func preInterruptedJSONDecodes() throws {
+    let id = UUID().uuidString
+    let legacy = """
+      {"id":"\(id)","text":"hello world","duration":1.5,"processingTime":0.2,\
+      "backendType":"parakeet","createdAt":12345.0,"isRecovered":false}
+      """
+    let transcript = try JSONDecoder().decode(Transcript.self, from: Data(legacy.utf8))
+    #expect(transcript.text == "hello world")
+    #expect(transcript.isRecovered == false)
+    #expect(transcript.inputDeviceWasRemoved == nil)
+  }
+
+  @Test("inputDeviceWasRemoved round-trips through Codable")
+  func interruptedRoundTrips() throws {
+    let original = Transcript(text: "cut short", isRecovered: false, inputDeviceWasRemoved: true)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(Transcript.self, from: data)
+    #expect(decoded.inputDeviceWasRemoved == true)
+    #expect(decoded.isRecovered == false)
+  }
+
+  /// `nil` and `false` are different answers and the History badge must not
+  /// conflate them: a spool-recovered transcript genuinely does not know whether
+  /// the input device was removed, so it carries nil, and the badge (which tests
+  /// `== true`) stays hidden without ever claiming the recording was clean.
+  @Test("nil is unknown, not false")
+  func nilIsUnknownNotFalse() throws {
+    let unknown = Transcript(text: "replayed from a spool", isRecovered: true)
+    let data = try JSONEncoder().encode(unknown)
+    let decoded = try JSONDecoder().decode(Transcript.self, from: data)
+    #expect(decoded.inputDeviceWasRemoved == nil)
+    #expect(decoded.inputDeviceWasRemoved != false)
+    #expect((decoded.inputDeviceWasRemoved == true) == false, "the badge must not render")
   }
 }


### PR DESCRIPTION
## What

A recording interrupted by a device loss was never destroyed (the crash-recovery spool retains it; #1063 recovers it into History at next launch), but the user was never told and the text never arrived at the cursor. The defect was delivery, not preservation. The kernel now transcribes the in-memory samples at the moment of the interruption and pastes the result through the normal completion path whenever the cause left the audio recoverable. The spool stays the crash net behind this, deleted only after the durable save.

Plus three amendments from the corrected-premise grounded review (plan s21, four rounds to PROCEED-AS-PLANNED):

- **A1: typed disclosure.** The planner receives `CompletionInterruptionDisclosure?` (nil / `.deviceRemoved` / `.otherInterruption`) instead of a Bool that carried only device loss, which let a successful `.engineLost` salvage paste potentially truncated text with no notice. Four sentences, one factory; the neutral pair is founder-approved (2026-07-10).
- **A2: truthful field.** `Transcript.isInterrupted` renamed `inputDeviceWasRemoved`; it only ever stored device loss, so `false` landed on takes that WERE interrupted. Unshipped field, free rename.
- **A3: the duration cap stops masquerading as an interruption.** `.maxDurationReached` deleted from `EngineInterruptionCause`; the manager's 3660s sample-count backstop now rides the same normal-stop route as the graceful 3600s cap via a new client-protocol event carrying session identity (helper echoes the begin operationID; proxy rejects mismatches, so a maximally delayed XPC event can never stop a later recording).

## Validation

- Tier: LARGE (pipeline orchestration + XPC boundary). Lane: Code.
- `scripts/xcode-test.sh` green twice: 2475 + 149 tests, zero failures.
- Local Codex code-diff: r6 found one P2 (relay session identity, fixed); r7 confirming pass clean ("No actionable defects were found").
- Live UAT (2026-07-10, founder present, verdicts from app.log):
  - Acoustic smokes: Parakeet 0.511s and WhisperKit 1.593s, both PASS.
  - Device-loss legs, founder speaking, Bluetooth cut mid-dictation at ~8s: AirPods Pro 3 x WhisperKit, AirPods Pro 3 x Parakeet, Storm x Parakeet, Storm x WhisperKit, all PASS: salvage pasted 0.57s to 3.1s after the cut, `inputDeviceWasRemoved=true` on every record, spool written and deleted after durable save.
  - Premise-1 gate PASS: all four salvaged transcripts end cleanly with the tail absent, zero garbled tails.
  - Sub-minimum take (0.76s captured): salvage refused, terminal `audioInterrupted`, no paste, disclosure shown, spool retained.
  - Disclosure pill and History badge confirmed visually by founder.
  - Overnight negatives: helper-kill refusal (`.xpcConnectionLost`), spool disposition both ways, cold recovery consuming an orphan on relaunch.
- Known separate items: #1464 (cold-path deletion-policy consolidation + failed-replay disposition, live instance recorded there); EG-1 toggle-off/on polish regression reported by founder this morning, to be filed separately.

Closes #1408
