### PR TITLE
fix(audio): install input tap with hardware format, not stale node output format (#1353)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -26,6 +26,18 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.3.2
+
+    Entry(
+      id: "chosen-microphone-recording-failure",
+      icon: "mic.circle",
+      title: "Fixed: recording could fail every time on a specific microphone",
+      description:
+        "If you picked a microphone by name instead of leaving it on Automatic, and that microphone was running at a sample rate other than the usual one, EnviousWispr could fail to record with the message \"XPC audio service is unreachable.\" It did not clear up on its own, and reinstalling or updating the app did not help, because the setting that caused it lives in macOS rather than in EnviousWispr. The app now reads the microphone's real settings before it starts listening, so recording works whatever rate your microphone is set to. If you have been stuck on this, updating is enough to fix it.",
+      category: .fasterAndMoreReliable,
+      version: "2.3.2"
+    ),
+
     // MARK: - v2.3.1
 
     Entry(

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -173,7 +173,10 @@ final class AVAudioEngineSource: AudioInputSource {
   /// the engine isn't running.
   var captureStopMetadata: CaptureStopMetadata? {
     guard engine.isRunning else { return nil }
-    let rate = engine.inputNode.outputFormat(forBus: 0).sampleRate
+    // Hardware format: after `setInputDevice` binds a device, `outputFormat` lags
+    // the real rate, so reporting it here would tell us 48000 for exactly the
+    // bound-device recordings this telemetry exists to diagnose.
+    let rate = engine.inputNode.inputFormat(forBus: 0).sampleRate
     guard rate > 0 else { return nil }
     return CaptureStopMetadata(nativeRateHz: rate)
   }
@@ -317,13 +320,37 @@ final class AVAudioEngineSource: AudioInputSource {
     btCrashLogger.info("Engine started successfully")
 
     // Install pre-roll tap immediately after engine start.
-    // Format is stable for built-in mic (BT uses AVCaptureSessionSource).
     // The tap routes through a PreRollForwarder that buffers audio until
     // startCapture() activates live forwarding.
+    //
+    // Read the hardware format, not `outputFormat`. `setInputDevice` above binds
+    // a device onto the input node's audio unit; after that bind `outputFormat`
+    // keeps reporting the pre-bind rate while `inputFormat` tracks the device.
+    // `installTap` asserts `format.sampleRate == inputHWFormat.sampleRate` and
+    // raises an uncatchable ObjC exception on mismatch, aborting this helper.
     let tapStart = ContinuousClock.now
     onLifecycleSignal?("engine_preroll_tap_entered")
     let inputNode = engine.inputNode
-    let inputFormat = inputNode.outputFormat(forBus: 0)
+    let inputFormat = inputNode.inputFormat(forBus: 0)
+
+    // A device still transitioning can report 0 Hz / 0 channels here. Feeding
+    // that to AVAudioConverter yields nil, and the guards below must not leave a
+    // running engine with no forwarder: `prepare()` would then short-circuit on
+    // `engine.isRunning` forever and every `startCapture()` would throw
+    // `missing_forwarder` — a permanent wedge.
+    //
+    // Tear down before throwing. `withStartRetry` does NOT retry this (it matches
+    // only a wedged line or `serviceUnreachable`), so THIS recording fails; the
+    // teardown is what lets the NEXT `prepare()` rebuild instead of short-circuiting.
+    // One failed press beats a dead session.
+    guard Self.isUsable(inputFormat) else {
+      btCrashLogger.error(
+        "Pre-roll: hardware format not yet usable (\(inputFormat.sampleRate)Hz/\(inputFormat.channelCount)ch) — tearing down for retry"
+      )
+      teardownEngine()
+      throw AudioError.formatCreationFailed(
+        source: "AVAudioEngineSource.prepare.unusable_hardware_format")
+    }
 
     guard
       let targetFormat = AVAudioFormat(
@@ -333,14 +360,16 @@ final class AVAudioEngineSource: AudioInputSource {
         interleaved: false
       )
     else {
-      btCrashLogger.error("Pre-roll: failed to create target format — tap not installed")
-      return
+      btCrashLogger.error("Pre-roll: failed to create target format — tearing down for retry")
+      teardownEngine()
+      throw AudioError.formatCreationFailed(source: "AVAudioEngineSource.prepare.target_format")
     }
 
     guard let audioConverter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
       btCrashLogger.error(
-        "Pre-roll: failed to create converter from \(inputFormat) — tap not installed")
-      return
+        "Pre-roll: failed to create converter from \(inputFormat) — tearing down for retry")
+      teardownEngine()
+      throw AudioError.formatCreationFailed(source: "AVAudioEngineSource.prepare.converter")
     }
     self.converter = audioConverter
 
@@ -527,16 +556,35 @@ final class AVAudioEngineSource: AudioInputSource {
     return []
   }
 
+  /// A hardware format only counts as settled once it is also usable. During a
+  /// device transition `inputFormat(forBus:)` can report 0 Hz or 0 channels; two
+  /// consecutive *invalid* reads compare equal, so an equality-only check would
+  /// call that "stable" and hand an unusable format to converter creation.
+  nonisolated static func isUsableFormat(sampleRate: Double, channelCount: AVAudioChannelCount)
+    -> Bool
+  {
+    sampleRate > 0 && channelCount > 0
+  }
+
+  private var currentHardwareFormat: AVAudioFormat { engine.inputNode.inputFormat(forBus: 0) }
+
+  nonisolated private static func isUsable(_ format: AVAudioFormat) -> Bool {
+    isUsableFormat(sampleRate: format.sampleRate, channelCount: format.channelCount)
+  }
+
   func waitForFormatStabilization(
     maxWait: TimeInterval = 1.5,
     pollInterval: TimeInterval = 0.2
   ) async -> Bool {
+    // Polls the hardware format — the same accessor the tap install consumes.
+    // Waiting on `outputFormat` while installing from `inputFormat` would gate on
+    // one signal and act on another.
     let stabStart = ContinuousClock.now
     let deadline = Date().addingTimeInterval(maxWait)
-    var lastFormat = engine.inputNode.outputFormat(forBus: 0)
+    var lastFormat = currentHardwareFormat
     try? await Task.sleep(for: .milliseconds(10))
-    let recheck = engine.inputNode.outputFormat(forBus: 0)
-    if recheck == lastFormat {
+    let recheck = currentHardwareFormat
+    if recheck == lastFormat, Self.isUsable(recheck) {
       AudioCaptureManager.btRouteLog(
         "COLD-START formatStab: stable on fast path (\(ms(ContinuousClock.now - stabStart))ms, 0 polls)"
       )
@@ -547,8 +595,8 @@ final class AVAudioEngineSource: AudioInputSource {
     while Date() < deadline {
       try? await Task.sleep(for: .seconds(pollInterval))
       polls += 1
-      let format = engine.inputNode.outputFormat(forBus: 0)
-      if format == lastFormat {
+      let format = currentHardwareFormat
+      if format == lastFormat, Self.isUsable(format) {
         AudioCaptureManager.btRouteLog(
           "COLD-START formatStab: stable after \(polls) polls (\(ms(ContinuousClock.now - stabStart))ms)"
         )
@@ -744,7 +792,10 @@ final class AVAudioEngineSource: AudioInputSource {
 
     do {
       let inputNode = engine.inputNode
-      let inputFormat = inputNode.outputFormat(forBus: 0)
+      // Hardware format, not `outputFormat` — recovery never re-binds the device,
+      // so the bind from `prepare()` still holds and `outputFormat` is still stale.
+      // Same `installTap` assertion applies here. See the tap site in `prepare()`.
+      let inputFormat = inputNode.inputFormat(forBus: 0)
 
       guard
         let targetFormat = AVAudioFormat(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.3.1"
+  public static let currentContentVersion = "2.3.2"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"

--- a/Tests/EnviousWisprTests/Audio/FormatStabilizationValidityTests.swift
+++ b/Tests/EnviousWisprTests/Audio/FormatStabilizationValidityTests.swift
@@ -1,0 +1,63 @@
+import AVFoundation
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+/// `waitForFormatStabilization` declares the hardware format settled when two
+/// consecutive reads agree. Once it polls `inputFormat(forBus:)` (#1353), "agree"
+/// is no longer sufficient: during a device transition that accessor can report
+/// 0 Hz or 0 channels, and two consecutive *invalid* reads compare equal. Calling
+/// that stable hands an unusable format to `AVAudioConverter(from:to:)`, which
+/// returns nil and tears down an otherwise recoverable recording.
+///
+/// The stabilization loop itself needs a live engine and a real device
+/// transition, so it is exercised in Live UAT. The validity predicate it gates
+/// on is pure, and is tested here directly — not reimplemented.
+@Suite struct FormatStabilizationValidityTests {
+
+  @Test func aFullyValidFormatIsUsable() {
+    #expect(AVAudioEngineSource.isUsableFormat(sampleRate: 44100, channelCount: 1))
+    #expect(AVAudioEngineSource.isUsableFormat(sampleRate: 48000, channelCount: 2))
+    #expect(AVAudioEngineSource.isUsableFormat(sampleRate: 16000, channelCount: 1))
+  }
+
+  /// The exact transient Codex flagged: a device mid-transition reporting 0 Hz.
+  @Test func aZeroSampleRateIsNotUsable() {
+    #expect(!AVAudioEngineSource.isUsableFormat(sampleRate: 0, channelCount: 1))
+  }
+
+  /// The sibling transient: rate settles before the channel count does.
+  @Test func aZeroChannelCountIsNotUsable() {
+    #expect(!AVAudioEngineSource.isUsableFormat(sampleRate: 44100, channelCount: 0))
+  }
+
+  @Test func bothZeroIsNotUsable() {
+    #expect(!AVAudioEngineSource.isUsableFormat(sampleRate: 0, channelCount: 0))
+  }
+
+  /// A negative rate is not a rate. Guards against a `!= 0` rewrite.
+  @Test func aNegativeSampleRateIsNotUsable() {
+    #expect(!AVAudioEngineSource.isUsableFormat(sampleRate: -44100, channelCount: 1))
+  }
+
+  /// Boundary: the smallest positive values either side of the threshold.
+  @Test func theUsabilityBoundaryIsStrictlyGreaterThanZero() {
+    #expect(AVAudioEngineSource.isUsableFormat(sampleRate: 0.001, channelCount: 1))
+    #expect(!AVAudioEngineSource.isUsableFormat(sampleRate: 0, channelCount: 1))
+  }
+
+  /// Two *invalid* reads agreeing must not read as settled. This is the whole
+  /// point: equality alone was the defect.
+  @Test func agreementBetweenInvalidReadsIsNotStability() {
+    let previous = (rate: 0.0, channels: AVAudioChannelCount(0))
+    let current = (rate: 0.0, channels: AVAudioChannelCount(0))
+    let agree = previous == current
+    let settled =
+      agree
+      && AVAudioEngineSource.isUsableFormat(
+        sampleRate: current.rate, channelCount: current.channels)
+    #expect(agree, "Fixture must model two agreeing reads for this test to mean anything.")
+    #expect(!settled, "Two agreeing invalid reads were treated as a settled format.")
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/InputTapFormatSourceShapeTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputTapFormatSourceShapeTests.swift
@@ -1,0 +1,374 @@
+import Foundation
+import Testing
+
+/// Mechanical guard for #1353.
+///
+/// `AVAudioEngineSource.prepare()` binds the user's chosen input device onto the
+/// engine input node's audio unit (`kAudioOutputUnitProperty_CurrentDevice`).
+/// After that bind, `inputNode.outputFormat(forBus: 0)` keeps reporting the
+/// pre-bind sample rate while `inputNode.inputFormat(forBus: 0)` tracks the real
+/// device. `installTap` asserts `format.sampleRate == inputHWFormat.sampleRate`
+/// and, on mismatch, raises an ObjC exception that Swift cannot catch — the
+/// audio XPC helper aborts and the user sees "XPC audio service is unreachable"
+/// on every recording until they change the device's rate back by hand.
+///
+/// Reproduced live on v2.3.1: built-in mic pinned at 44100 Hz + an explicit
+/// device selection aborts the helper 100% of the time.
+///
+/// There is no unit-testable seam for the crash itself (it needs a real device
+/// at a non-default rate), so this guard freezes the one property that prevents
+/// it: **every format handed to `installTap` is derived from the hardware
+/// accessor, never from `outputFormat`.**
+@Suite struct InputTapFormatSourceShapeTests {
+
+  static let sourcePath = "Sources/EnviousWisprAudio/AVAudioEngineSource.swift"
+
+  /// The shipped source must install every tap with a hardware-derived format.
+  @Test func everyInstalledTapUsesTheHardwareFormat() throws {
+    let source = try String(contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
+    let sites = tapFormatSites(in: source)
+
+    // Feature-not-crash: a parser that silently matches nothing would "pass".
+    #expect(
+      sites.count == 2,
+      """
+      Expected exactly 2 `installTap` sites in \(Self.sourcePath) (the pre-roll tap in \
+      prepare() and the re-install in recoverFromCodecSwitch()), found \(sites.count). \
+      If a tap site was added or removed, update this count deliberately — do not \
+      relax the parser. If it dropped to 0, the parser is broken and this guard is \
+      no longer protecting anything.
+      """)
+
+    let violations = sites.filter { !$0.isHardwareDerived }
+    #expect(
+      violations.isEmpty,
+      """
+      These `installTap` calls receive a format that is not derived from \
+      `inputFormat(forBus:)`: \(violations.map(\.description).joined(separator: "; ")). \
+      After `setInputDevice` binds a device, `outputFormat` is stale; passing it to \
+      `installTap` aborts the audio XPC helper with an uncatchable ObjC exception \
+      (#1353). Read `inputNode.inputFormat(forBus: 0)` instead.
+      """)
+  }
+
+  /// Stronger, simpler companion to the tap-format guard: this file describes
+  /// the *input* node exclusively, and `outputFormat(forBus:)` lags the bound
+  /// device's real rate. No read of it belongs here — not for the tap, not for
+  /// the stabilization poll, not for stop-time telemetry.
+  @Test func noStaleOutputFormatReadsRemain() throws {
+    let source = try String(contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
+    let offenders = staleAccessorReads(in: source)
+    #expect(
+      offenders.isEmpty,
+      """
+      \(Self.sourcePath) reads `outputFormat(forBus:)`: \(offenders.joined(separator: "; ")). \
+      After `setInputDevice` binds a device, that accessor reports the pre-bind rate \
+      while `inputFormat(forBus:)` tracks the device (#1353). Feeding it to `installTap` \
+      aborts the audio XPC helper; feeding it to telemetry misreports the rate; polling it \
+      in `waitForFormatStabilization` gates on a different signal than the one the tap \
+      install consumes. Use `inputFormat(forBus:)`.
+      """)
+  }
+
+  /// Control for the scan above: it must find a real stale read, and must not
+  /// count one that only appears in a comment. Without this, an empty offender
+  /// list could mean "clean file" or "broken matcher".
+  @Test func staleAccessorScanFindsRealReadsAndIgnoresComments() {
+    let fixture = """
+      // historical note: we used to call outputFormat(forBus: 0) here
+      let rate = engine.inputNode.outputFormat(forBus: 0).sampleRate
+      let hw = engine.inputNode.inputFormat(forBus: 0)
+      """
+    let offenders = staleAccessorReads(in: fixture)
+    #expect(offenders.count == 1, "Expected exactly the one real stale read, got \(offenders)")
+    #expect(offenders.first?.contains("line 2") == true)
+  }
+
+  /// Deliberate-reintroduction fixture: proves the parser flags the exact
+  /// regression. If this stops failing, the guard above cannot be trusted.
+  @Test func parserFlagsTapInstalledWithStaleOutputFormat() {
+    let fixture = """
+      let inputNode = engine.inputNode
+      let inputFormat = inputNode.outputFormat(forBus: 0)
+      inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat, block: tapHandler)
+      """
+    let sites = tapFormatSites(in: fixture)
+    #expect(sites.count == 1)
+    #expect(
+      sites.first?.isHardwareDerived == false,
+      "Parser failed to flag a tap installed with `outputFormat`. The #1353 guard is dead."
+    )
+  }
+
+  /// Allowlist gate: the fixed shape must NOT be flagged, so the guard cannot
+  /// pass by simply rejecting everything.
+  @Test func parserAcceptsTapInstalledWithHardwareFormat() {
+    let fixture = """
+      let inputNode = engine.inputNode
+      let inputFormat = inputNode.inputFormat(forBus: 0)
+      inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat, block: tapHandler)
+      """
+    let sites = tapFormatSites(in: fixture)
+    #expect(sites.count == 1)
+    #expect(sites.first?.isHardwareDerived == true)
+  }
+
+  /// A tap whose format identifier is never bound in the file is unresolvable,
+  /// and unresolvable must mean *fail*, not *pass by omission*.
+  @Test func parserFlagsTapWhoseFormatBindingIsMissing() {
+    let fixture = "inputNode.installTap(onBus: 0, bufferSize: 2048, format: mystery, block: h)"
+    let sites = tapFormatSites(in: fixture)
+    #expect(sites.count == 1)
+    #expect(sites.first?.isHardwareDerived == false)
+  }
+
+  /// An identifier bound from the hardware accessor in one function and the
+  /// stale accessor in another must fail — the check is over *all* bindings of
+  /// the identifier, not the nearest one.
+  @Test func parserFlagsIdentifierBoundFromBothAccessors() {
+    let fixture = """
+      func prepare() {
+        let inputFormat = inputNode.inputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat, block: h)
+      }
+      func recover() {
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+      }
+      """
+    let sites = tapFormatSites(in: fixture)
+    #expect(sites.count == 1)
+    #expect(sites.first?.isHardwareDerived == false)
+  }
+
+  /// A tap whose arguments span several lines must still be seen. A parser that
+  /// misses it would leave `sites.count` at the frozen value and pass while an
+  /// unsafe tap shipped.
+  @Test func parserFlagsMultilineTapInstalledWithStaleOutputFormat() {
+    let fixture = """
+      let inputFormat = inputNode.outputFormat(forBus: 0)
+      inputNode.installTap(
+        onBus: 0,
+        bufferSize: 2048,
+        format: inputFormat,
+        block: tapHandler
+      )
+      """
+    let sites = tapFormatSites(in: fixture)
+    #expect(sites.count == 1, "Multiline `installTap` call was not counted as a site.")
+    #expect(sites.first?.isHardwareDerived == false)
+  }
+
+  @Test func parserAcceptsMultilineTapInstalledWithHardwareFormat() {
+    let fixture = """
+      let inputFormat = inputNode.inputFormat(forBus: 0)
+      inputNode.installTap(
+        onBus: 0,
+        bufferSize: 2048,
+        format: inputFormat,
+        block: tapHandler
+      )
+      """
+    let sites = tapFormatSites(in: fixture)
+    #expect(sites.count == 1)
+    #expect(sites.first?.isHardwareDerived == true)
+  }
+
+  /// The format may be an inline expression rather than a bound identifier.
+  /// Nested parentheses and commas must not truncate the argument.
+  @Test func parserJudgesInlineFormatExpressions() {
+    let stale = "inputNode.installTap(onBus: 0, format: node.outputFormat(forBus: 0), block: h)"
+    let hardware = "inputNode.installTap(onBus: 0, format: node.inputFormat(forBus: 0), block: h)"
+    #expect(tapFormatSites(in: stale).first?.isHardwareDerived == false)
+    #expect(tapFormatSites(in: hardware).first?.isHardwareDerived == true)
+  }
+
+  /// A tap call with no `format:` argument at all is unresolvable, and
+  /// unresolvable means fail.
+  @Test func parserFlagsTapWithNoFormatArgument() {
+    let sites = tapFormatSites(in: "inputNode.installTap(onBus: 0, bufferSize: 2048, block: h)")
+    #expect(sites.count == 1)
+    #expect(sites.first?.isHardwareDerived == false)
+  }
+
+  /// A commented-out or documented `installTap(` is not a call site. Otherwise
+  /// the count assertion in the real-source test would drift on doc edits.
+  @Test func parserIgnoresCommentedOutTapCalls() {
+    let fixture = """
+      // inputNode.installTap(onBus: 0, format: inputFormat, block: h)
+      let inputFormat = inputNode.inputFormat(forBus: 0)
+      inputNode.installTap(onBus: 0, format: inputFormat, block: h)
+      """
+    let sites = tapFormatSites(in: fixture)
+    #expect(sites.count == 1, "A commented-out tap call was counted as a real site.")
+    #expect(sites.first?.isHardwareDerived == true)
+  }
+}
+
+// MARK: - Parser
+
+private struct TapFormatSite {
+  /// The `format:` argument exactly as written, e.g. `inputFormat` or
+  /// `inputNode.inputFormat(forBus: 0)`. Empty when the call has no `format:`
+  /// argument at all.
+  let formatArgument: String
+  /// True only when the format provably comes from the hardware accessor.
+  /// A tap whose format cannot be resolved is *not* hardware-derived: an
+  /// unresolvable tap must fail this guard, never pass by omission.
+  let isHardwareDerived: Bool
+
+  var description: String { "format: \(formatArgument.isEmpty ? "<missing>" : formatArgument)" }
+}
+
+private let hardwareAccessor = "inputFormat(forBus:"
+private let staleAccessor = "outputFormat(forBus:"
+
+/// Every non-comment line reading the stale accessor, as `line N: <text>`.
+private func staleAccessorReads(in source: String) -> [String] {
+  strippingLineComments(source)
+    .split(separator: "\n", omittingEmptySubsequences: false)
+    .enumerated()
+    .filter { $0.element.contains(staleAccessor) }
+    .map { "line \($0.offset + 1): \($0.element.trimmingCharacters(in: .whitespaces))" }
+}
+
+/// Collects every `installTap(…)` call in `source` — including calls whose
+/// arguments span multiple lines — and decides whether each one's `format:`
+/// argument is hardware-derived.
+///
+/// Every `installTap(` token produces exactly one site. Counting is deliberately
+/// independent of whether the `format:` argument resolves, so a call this parser
+/// cannot understand surfaces as a *failure*, not as a silently skipped site.
+///
+/// A bare identifier is resolved against every `let <identifier> = <rhs>` binding
+/// in the file. Resolution is file-wide rather than scope-aware on purpose: a tap
+/// format identifier that is ever bound from the stale accessor anywhere in this
+/// file is a defect regardless of which function does it.
+private func tapFormatSites(in source: String) -> [TapFormatSite] {
+  let code = strippingLineComments(source)
+  let bindings = letBindings(in: code)
+
+  return installTapArgumentLists(in: code).map { arguments in
+    guard let format = argumentValue(labeled: "format", in: arguments) else {
+      return TapFormatSite(formatArgument: "", isHardwareDerived: false)
+    }
+    return TapFormatSite(
+      formatArgument: format,
+      isHardwareDerived: isHardwareDerived(format, bindings: bindings)
+    )
+  }
+}
+
+/// `inputFormat` → look up its bindings. `inputNode.inputFormat(forBus: 0)` →
+/// judge the inline expression directly.
+private func isHardwareDerived(_ format: String, bindings: [String: [String]]) -> Bool {
+  let isBareIdentifier =
+    firstMatch(#"^[A-Za-z_][A-Za-z0-9_]*$"#, in: format, groups: 0) != nil
+  guard isBareIdentifier else { return readsOnlyHardwareAccessor(format) }
+  guard let rhsList = bindings[format], !rhsList.isEmpty else { return false }
+  return rhsList.allSatisfy(readsOnlyHardwareAccessor)
+}
+
+private func readsOnlyHardwareAccessor(_ expression: String) -> Bool {
+  expression.contains(hardwareAccessor) && !expression.contains(staleAccessor)
+}
+
+/// Every `let <name> = <rhs>` in the source, keyed by name. One name may be
+/// bound more than once (different functions), so values are collected.
+private func letBindings(in code: String) -> [String: [String]] {
+  var bindings: [String: [String]] = [:]
+  for line in code.split(separator: "\n", omittingEmptySubsequences: false) {
+    guard
+      let m = firstMatch(
+        #"^\s*let\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)$"#, in: String(line), groups: 2)
+    else { continue }
+    bindings[m[0], default: []].append(m[1])
+  }
+  return bindings
+}
+
+/// The argument list of every `installTap(` call, with balanced parentheses so a
+/// call may span lines and may nest calls inside its arguments.
+private func installTapArgumentLists(in code: String) -> [String] {
+  var lists: [String] = []
+  var searchStart = code.startIndex
+  while let token = code.range(of: "installTap(", range: searchStart..<code.endIndex) {
+    if let body = balancedParenthesesBody(in: code, openParen: code.index(before: token.upperBound))
+    {
+      lists.append(body)
+    } else {
+      // Unbalanced — record an unresolvable site rather than dropping it.
+      lists.append("")
+    }
+    searchStart = token.upperBound
+  }
+  return lists
+}
+
+/// Substring strictly between `openParen` and its matching `)`.
+private func balancedParenthesesBody(in code: String, openParen: String.Index) -> String? {
+  var depth = 0
+  var index = openParen
+  while index < code.endIndex {
+    let character = code[index]
+    if character == "(" { depth += 1 }
+    if character == ")" {
+      depth -= 1
+      if depth == 0 { return String(code[code.index(after: openParen)..<index]) }
+    }
+    index = code.index(after: index)
+  }
+  return nil
+}
+
+/// Value of `label:` in an argument list, splitting only on top-level commas so
+/// a nested call's own commas do not terminate the argument.
+private func argumentValue(labeled label: String, in arguments: String) -> String? {
+  var depth = 0
+  var current = ""
+  var parts: [String] = []
+  for character in arguments {
+    if character == "(" || character == "[" || character == "{" { depth += 1 }
+    if character == ")" || character == "]" || character == "}" { depth -= 1 }
+    if character == "," && depth == 0 {
+      parts.append(current)
+      current = ""
+      continue
+    }
+    current.append(character)
+  }
+  parts.append(current)
+
+  for part in parts {
+    let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.hasPrefix("\(label):") else { continue }
+    return String(trimmed.dropFirst(label.count + 1))
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+  return nil
+}
+
+/// Removes `//` comments so a commented-out or documented `installTap(` is not
+/// mistaken for a real call. Newlines are preserved so line-based binding
+/// matching still sees one declaration per line.
+private func strippingLineComments(_ source: String) -> String {
+  source.split(separator: "\n", omittingEmptySubsequences: false)
+    .map { line -> String in
+      guard let comment = line.range(of: "//") else { return String(line) }
+      return String(line[line.startIndex..<comment.lowerBound])
+    }
+    .joined(separator: "\n")
+}
+
+/// `groups: 0` means "match only, capture nothing".
+private func firstMatch(_ pattern: String, in text: String, groups: Int) -> [String]? {
+  guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+  let range = NSRange(text.startIndex..<text.endIndex, in: text)
+  guard let match = regex.firstMatch(in: text, range: range) else { return nil }
+  guard groups > 0 else { return [] }
+  var captured: [String] = []
+  for i in 1...groups {
+    guard let r = Range(match.range(at: i), in: text) else { return nil }
+    captured.append(String(text[r]))
+  }
+  return captured
+}


### PR DESCRIPTION
Forward-port of the **v2.3.2** hotfix (shipped from the `v2.3.1` tag). Without this, the next release cut from `main` reintroduces the crash.

## The bug

`prepare()` binds the user's chosen input device onto the engine input node's audio unit. After that bind, `inputNode.outputFormat(forBus: 0)` keeps reporting the pre-bind sample rate while `inputFormat(forBus: 0)` tracks the real device. `installTap` asserts the two match and raises an **uncatchable** ObjC exception otherwise: the audio XPC helper aborts and the user sees "XPC audio service is unreachable" on every recording.

The device's nominal rate is machine-global OS state, so it survives relaunch and upgrade. Affected users stayed broken permanently. 13 users in 14 days; 7 never completed another dictation.

## Evidence

Gathered on a real build of the released code, not from reading:

- A standalone harness that binds the built-in mic reports `inputFormat=44100` and `outputFormat=48000` from the same node immediately after the bind.
- **Negative control:** reverting only this accessor and rebuilding reproduces the crash 100% of runs, `Abort trap: 6`, backtrace `NSException -> AVAudioEngineImpl::InstallTapOnNode -> AVAudioEngineSource.prepare()`, matching the users' Sentry stack. Without this control the passing rows below would prove nothing.
- With the fix: bound mic at 44100 Hz completes cold, warm, and warm again; bound mic at 48000 Hz and Auto at 48000 Hz unaffected.

Behavior is unchanged for everyone except users who are currently broken: with no bind both accessors agree, and with a bind whose device already sits at the pre-bind rate they also agree. The change can only differ where it currently crashes.

## Scope beyond the two tap sites

Local Codex review argued, correctly for `main`, that fixing only the tap sites leaves the file incoherent. Both taken:

- `captureStopMetadata` reported `capture_native_rate_hz` from the stale accessor, so it told us 48000 for exactly the bound-device recordings the telemetry exists to diagnose.
- `waitForFormatStabilization` polled the stale accessor while the tap install consumed the hardware one: gating on one signal, acting on another.

A third round then caught that polling the hardware accessor introduced a failure mode the stale one lacked: during a transition it can read 0 Hz / 0 channels, and two consecutive **invalid** reads compare equal. Stability now requires agreement **and** usability; an all-invalid window times out into the existing rebuild path. `isUsableFormat(sampleRate:channelCount:)` is a pure `nonisolated` seam so the predicate is tested against the real symbol rather than a reimplementation.

Still owned by #1353's plan for `main`: consolidating the two tap sites into one paired install/remove helper.

## Tests

- `InputTapFormatSourceShapeTests` — freezes the file at **zero** stale reads, and separately proves every `installTap` format resolves to a hardware-accessor binding. Scans balanced parens so a multiline call counts; yields one site per `installTap(` token independent of whether its `format:` argument resolves, so a call the parser cannot understand **fails** rather than being skipped. Run against the pre-fix source it reports both sites as violations, so it is not a tautology.
- `FormatStabilizationValidityTests` — boundary cases for the usability predicate, including the agreeing-invalid-reads case that motivated it.

When #1353's rework merges the tap sites, the "exactly 2 sites" assertion fails loudly and is updated deliberately. That is the intent.

## Live UAT

On this branch's dev build, mic and device preferences captured before and restored after: Auto at 48000 passes; bound device at 48000 passes; bound device at 44100 passes cold, warm, and warm again. Cold start exercises the changed stabilization poll via `preWarm`. No crash reports produced.

## Known, tracked, not introduced here

- **#1472** — `prepare()` consumes the hardware format before anything checks it is usable; on an invalid transient the converter fails and `prepare()` bare-returns, wedging capture. Already present in shipped v2.3.2. The transient is **unreproduced**; filed with the mechanism verified and the repro left open.
- Changing a bound device's nominal rate **during** capture starves the tap (measured: 44100 frames in the first second, 4410 across the next three) and does not fire `AVAudioEngineConfigurationChange`, so `recoverFromCodecSwitch` never runs. Pre-existing; needs the rate to change mid-recording, which is not what strands users.

Refs #1353
