### PR TITLE
fix(asr): honor prior-text flag in S5 benchmark

### DIFF
--- a/Sources/EnviousWisprASR/TailBenchmarkHarness.swift
+++ b/Sources/EnviousWisprASR/TailBenchmarkHarness.swift
@@ -328,14 +328,15 @@ public enum TailBenchmarkHarness {
   /// prompt, run once more over the now-complete audio. Text before the buffer
   /// (`scrolledOutText`) is kept verbatim; the decode's output replaces the
   /// in-buffer committed + retained hypothesis (single decode, no stitching).
-  private static func armS5(model: TailBenchmarkModel, id: String, snap: BenchmarkSnapshot)
+  static func armS5(model: TailBenchmarkModel, id: String, snap: BenchmarkSnapshot)
     async -> TailArmOutput
   {
     let start = CFAbsoluteTimeGetCurrent()
     var opts = model.baseOptions
     opts.clipTimestamps = [snap.bufferStartSec]
     opts.windowClipTime = 0
-    if !snap.scrolledOutText.isEmpty {
+    opts.promptTokens = nil
+    if model.conditionOnPriorText, !snap.scrolledOutText.isEmpty {
       opts.promptTokens = model.kit.encodeText(
         WhisperKitStreamingSession.promptSuffix(of: snap.scrolledOutText))
     }

--- a/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitStreamingSession.swift
@@ -199,9 +199,9 @@ package actor WhisperKitStreamingSession: WhisperKitIncrementalSession {
   /// `DecodingOptions.promptTokens` (`condition_on_previous_text`). In UFAL
   /// buffer mode only text scrolled OUT of the window is eligible. #1276
   /// investigation: decoding a tail BLIND (no prior-text context) is the cause
-  /// of the trailing "thank you" hallucination. ON in the shipped construction
-  /// (`WhisperKitBackend.makeStreamingSession`); the parameter default stays
-  /// OFF so tests and callers opt in explicitly.
+  /// of the trailing "thank you" hallucination. OFF in the shipped construction
+  /// (`WhisperKitBackend.makeStreamingSession`) after the model benchmark found
+  /// it wedge-prone; the parameter default also stays OFF.
   private let conditionOnPriorText: Bool
 
   /// When true, confirmation runs the UFAL whisper_streaming architecture

--- a/Tests/EnviousWisprASRTests/TailBenchmarkHarnessTests.swift
+++ b/Tests/EnviousWisprASRTests/TailBenchmarkHarnessTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@preconcurrency import WhisperKit
+
+@testable import EnviousWisprASR
+
+@Suite("Tail benchmark S5 prompt eligibility")
+struct TailBenchmarkHarnessTests {
+  private actor FakeDecoder: WhisperKitTranscribing {
+    private(set) var seenPromptTokens: [[Int]?] = []
+
+    nonisolated func encodeText(_ text: String) -> [Int] { [101, 202] }
+
+    func transcribe(audioArray: [Float], decodeOptions: DecodingOptions?) async throws
+      -> [TranscriptionResult]
+    {
+      seenPromptTokens.append(decodeOptions?.promptTokens)
+      return []
+    }
+  }
+
+  private struct PromptCase: Sendable {
+    let conditionOnPriorText: Bool
+    let scrolledOutText: String
+    let expectedPromptTokens: [Int]?
+  }
+
+  @Test(
+    "S5 respects every prior-text flag and text combination",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1327",
+      "S5 benchmark ignored the prior-text flag"))
+  func promptEligibilityCrossProduct() async {
+    let cases = [
+      PromptCase(
+        conditionOnPriorText: false, scrolledOutText: "earlier words",
+        expectedPromptTokens: nil),
+      PromptCase(
+        conditionOnPriorText: false, scrolledOutText: "",
+        expectedPromptTokens: nil),
+      PromptCase(
+        conditionOnPriorText: true, scrolledOutText: "earlier words",
+        expectedPromptTokens: [101, 202]),
+      PromptCase(
+        conditionOnPriorText: true, scrolledOutText: "",
+        expectedPromptTokens: nil),
+    ]
+
+    for testCase in cases {
+      var baseOptions = DecodingOptions()
+      baseOptions.promptTokens = [999]
+      let decoder = FakeDecoder()
+      let model = TailBenchmarkModel(
+        kit: decoder, baseOptions: baseOptions,
+        conditionOnPriorText: testCase.conditionOnPriorText)
+      let snapshot = BenchmarkSnapshot(
+        samples: [], sampleCount: 0, contentHash: 0, confirmedText: "earlier words",
+        lastConfirmedSec: 0, lastDecodeSampleCount: 0, decodeCount: 0,
+        totalDecodeTimeMs: 0, unconfirmedSegments: [], bufferStartSec: 0,
+        scrolledOutText: testCase.scrolledOutText)
+
+      _ = await TailBenchmarkHarness.armS5(model: model, id: "fixture", snap: snapshot)
+
+      #expect(
+        await decoder.seenPromptTokens == [testCase.expectedPromptTokens],
+        "condition=\(testCase.conditionOnPriorText) textEmpty=\(testCase.scrolledOutText.isEmpty)")
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- Make S5 clear inherited prompt tokens before its final decode.
- Add prior-text tokens only when the benchmark flag is enabled and prior text exists.
- Cover all four flag and text combinations with a direct regression test.
- Correct the nearby comment to reflect that prior-text conditioning ships off.

## Why

S5 previously added prior text whenever text existed, even when the benchmark model disabled that option. That made the no-prompt benchmark arm measure a prompted algorithm.

## Validation

- Focused regression test: red with 3 expected failures before the fix, then green.
- Full logic suite: 2,667 tests passed.
- Xcode Release build: passed.
- Dev app: compiled, signed, deployed, and launched from this worktree.
- Local Codex diff review: clean, no regressions found.
- Live dictation UAT: skipped. A sibling worktree replaced the single shared dev app during the run, so the result could not be attributed to this branch. The changed benchmark arm is not reachable from the app; feature correctness is covered by the focused test.

Closes #1327
