### PR TITLE
feat(observability): show Dev vs Release build type on every Sentry alert (#1470)

### DIFF
--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -335,8 +335,8 @@ export function scoreFromEvents(eventLookup) {
   // Keep production release builds only. Require buildType === "release" (not merely
   // "not debug") so an event whose app.build_type tag is absent — older versions, an
   // untagged process — is NOT silently trusted as a release; that matches how
-  // classifySource treats the same missing metadata as unknown. When no event clears
-  // this bar, scoreFromEvents returns null and severity falls open to webhook counts.
+  // classifyBuildType treats the same missing metadata as not-release. When no event
+  // clears this bar, scoreFromEvents returns null and severity falls open to webhook counts.
   const production = events.filter(
     (e) => e && e.environment === "production" && e.buildType === "release"
   );
@@ -702,10 +702,23 @@ export function buildEmbedFromLookup(eventLookup, { issueId, title, permalink, t
       : null;
 
   if (!events || events.length === 0) {
-    return buildFailOpenEmbed({ issueId, title, permalink, timesSeen, userCount, priority });
+    // Degraded/empty event data → classifyBuildType returns "unknown".
+    return buildFailOpenEmbed({ issueId, title, permalink, timesSeen, userCount, priority, buildType: "unknown" });
   }
 
-  const rep = events[0];
+  const buildType = classifyBuildType(eventLookup);
+  // Show metadata from the event that best represents WHY the issue got its label,
+  // so the headline/version/system never contradict the tag. Events are newest-first,
+  // so find() picks the newest such event:
+  //   release → the confirmed real-user event
+  //   dev     → the dev event (all events are dev here)
+  //   unknown → the unclassifiable (not-confidently-dev) event that made it untrusted,
+  //             never the dev-noise event that would read as "just my testing"
+  const rep =
+    (buildType === "release" && events.find(isReleaseEvent)) ||
+    (buildType === "dev" && events.find(isDevEvent)) ||
+    (buildType === "unknown" && events.find((e) => !isDevEvent(e))) ||
+    events[0];
   const metadata = {
     category: rep.category,
     stage: rep.stage,
@@ -715,7 +728,7 @@ export function buildEmbedFromLookup(eventLookup, { issueId, title, permalink, t
     osVersion: rep.osVersion,
     deviceModel: rep.deviceModel,
   };
-  return buildEnrichedEmbed({ issueId, title, permalink, timesSeen, userCount, priority, metadata });
+  return buildEnrichedEmbed({ issueId, title, permalink, timesSeen, userCount, priority, metadata, buildType });
 }
 
 export function truncate(value, max = FIELD_MAX_CHARS) {
@@ -724,18 +737,47 @@ export function truncate(value, max = FIELD_MAX_CHARS) {
 }
 
 /**
- * Three-state source classifier (#1229). Never defaults missing metadata to
- * "real user" — an older app version or partial tags read as unknown.
+ * Build-type of the whole issue, from all fetched events (#1470 follow-up).
+ * "release" if ANY event is a real user on a production release build — a mixed
+ * issue that reached real users reads Release, matching how severity scores the
+ * production partition. "dev" if there is no such event but some event is
+ * development/debug (your own testing). "unknown" for degraded/empty event data.
+ * The single authority for the Dev-vs-Release label shown in the alert.
  */
-export function classifySource(metadata) {
-  const { environment, buildType } = metadata ?? {};
-  if (environment === "development" || buildType === "debug") {
-    return "🧪 Your test build (dev/debug)";
+// Per-event signals over the (environment × app.build_type) matrix:
+//   release: production + release build      → a confirmed real user
+//   dev:     debug build OR development env  → confidently your own testing (debug
+//            is authoritative even if the env tag says production)
+// Anything else (e.g. a release build with a missing environment tag, or a
+// production event with a missing build type) is UNCLASSIFIABLE and may be a real user.
+const isReleaseEvent = (e) => e && e.environment === "production" && e.buildType === "release";
+const isDevEvent = (e) => e && (e.buildType === "debug" || e.environment === "development");
+
+export function classifyBuildType(eventLookup) {
+  if (!eventLookup || eventLookup.status !== "complete" || !Array.isArray(eventLookup.events)) {
+    return "unknown";
   }
-  if (environment === "production" && buildType === "release") {
-    return "👤 Real user (release)";
-  }
-  return "❓ Unknown source (metadata missing)";
+  const events = eventLookup.events;
+  // A confirmed real user wins. Otherwise call it Dev ONLY when every event is
+  // confidently dev — a single unclassifiable (possibly-real-user) event keeps the
+  // whole issue Unknown rather than masking it as your testing.
+  if (events.some(isReleaseEvent)) return "release";
+  if (events.length > 0 && events.every(isDevEvent)) return "dev";
+  return "unknown";
+}
+
+/** Short tag for the alert title: Release / Dev / Unknown build. */
+export function buildTypeTag(buildType) {
+  if (buildType === "release") return "Release";
+  if (buildType === "dev") return "Dev";
+  return "Unknown build";
+}
+
+/** Longer source label for the embed body. */
+export function sourceLabelFor(buildType) {
+  if (buildType === "release") return "👤 Release (real users)";
+  if (buildType === "dev") return "🧪 Dev build (your testing)";
+  return "❓ Unknown build";
 }
 
 /** Readable headline: prefer the safe error.category tag over a possibly-stale title. */
@@ -752,13 +794,13 @@ export function metadataFields(metadata) {
   return { what, system };
 }
 
-export function buildEnrichedEmbed({ issueId, title, permalink, timesSeen, userCount, priority, metadata }) {
+export function buildEnrichedEmbed({ issueId, title, permalink, timesSeen, userCount, priority, metadata, buildType = "unknown" }) {
   const { what, system } = metadataFields(metadata);
   return {
-    title: `[Sentry ${priority}] ${truncate(readableHeadline(title, metadata))}`,
+    title: `[Sentry ${priority} · ${buildTypeTag(buildType)}] ${truncate(readableHeadline(title, metadata))}`,
     color: DISCORD_COLOR[priority] ?? DISCORD_COLOR.P3,
     fields: [
-      { name: "Source", value: classifySource(metadata), inline: true },
+      { name: "Source", value: sourceLabelFor(buildType), inline: true },
       { name: "What", value: truncate(what), inline: true },
       {
         name: "Impact",
@@ -774,12 +816,12 @@ export function buildEnrichedEmbed({ issueId, title, permalink, timesSeen, userC
   };
 }
 
-export function buildFailOpenEmbed({ issueId, title, permalink, timesSeen, userCount, priority }) {
+export function buildFailOpenEmbed({ issueId, title, permalink, timesSeen, userCount, priority, buildType = "unknown" }) {
   return {
-    title: `[Sentry ${priority}] ${truncate(title)}`,
+    title: `[Sentry ${priority} · ${buildTypeTag(buildType)}] ${truncate(title)}`,
     color: DISCORD_COLOR[priority] ?? DISCORD_COLOR.P3,
     fields: [
-      { name: "Source", value: "❓ Unknown source (Sentry fetch failed)", inline: true },
+      { name: "Source", value: `${sourceLabelFor(buildType)} (Sentry fetch failed)`, inline: true },
       {
         name: "Impact",
         value: `Sentry issue totals: ${userCount} user(s) · ${timesSeen} occurrences`,

--- a/workers/sentry-triage/test/index.test.js
+++ b/workers/sentry-triage/test/index.test.js
@@ -11,8 +11,10 @@ import {
   parseNextCursor,
   pageHasExactTicket,
   buildEmbedFromLookup,
+  classifyBuildType,
+  buildTypeTag,
+  sourceLabelFor,
   truncate,
-  classifySource,
   readableHeadline,
   metadataFields,
   buildEnrichedEmbed,
@@ -84,6 +86,20 @@ test("decideNotification: incomplete events -> post with webhook-fallback displa
   });
   assert.equal(r.post, true);
   assert.equal(r.priority, "P2");
+  assert.equal(r.countSource, "webhook-fallback");
+});
+
+test("decideNotification: dev-only issue still posts (dev builds alert too)", () => {
+  // No production-release event -> scoreFromEvents null -> webhook fallback -> posts.
+  const r = decideNotification({
+    action: "created",
+    issue: { level: "error", userCount: "1", count: "3" },
+    eventLookup: { status: "complete", events: [rec({ environment: "development", buildType: "debug" })] },
+    ticketLookup: { status: "complete", openExactMarker: false },
+    throttleLookup: { status: "complete", value: null },
+    now: NOW,
+  });
+  assert.equal(r.post, true);
   assert.equal(r.countSource, "webhook-fallback");
 });
 
@@ -434,7 +450,7 @@ test("pageHasExactTicket: empty/missing bodies and non-array input are safe", ()
 
 // ─────────────────────────────── buildEmbedFromLookup ─────────────────────────
 
-test("buildEmbedFromLookup: complete lookup -> enriched embed with source label", () => {
+test("buildEmbedFromLookup: complete release lookup -> Release tag in title + source", () => {
   const events = [
     rec({ environment: "production", buildType: "release", category: "paste_failed", stage: "paste", release: "com.enviouswispr.app@2.3.1" }),
   ];
@@ -442,18 +458,66 @@ test("buildEmbedFromLookup: complete lookup -> enriched embed with source label"
     { status: "complete", events },
     { issueId: "123", title: "[REDACTED]", permalink: "https://x/123/", timesSeen: 5, userCount: 2, priority: "P2" }
   );
-  assert.equal(embed.title, "[Sentry P2] paste_failed");
+  assert.equal(embed.title, "[Sentry P2 · Release] paste_failed");
   const source = embed.fields.find((f) => f.name === "Source");
-  assert.equal(source.value, "👤 Real user (release)");
+  assert.equal(source.value, "👤 Release (real users)");
 });
 
-test("buildEmbedFromLookup: degraded lookup -> fail-open embed", () => {
+test("buildEmbedFromLookup: mixed issue labeled Release renders the release event's metadata, not the newest dev event", () => {
+  // Newest event is dev; a release event exists -> label Release, and Version/System
+  // must come from the release event so the alert is not misleading.
+  const events = [
+    rec({ environment: "development", buildType: "debug", release: "com.enviouswispr.app@9.9.9", category: "dev_noise", osVersion: "99.0.0", deviceModel: "DevMac" }),
+    rec({ environment: "production", buildType: "release", release: "com.enviouswispr.app@2.3.1", category: "paste_failed", osVersion: "26.6.0", deviceModel: "Mac16,8" }),
+  ];
+  const embed = buildEmbedFromLookup(
+    { status: "complete", events },
+    { issueId: "123", title: "t", permalink: "https://x/123/", timesSeen: 5, userCount: 2, priority: "P2" }
+  );
+  assert.equal(embed.title, "[Sentry P2 · Release] paste_failed");
+  const version = embed.fields.find((f) => f.name === "Version");
+  assert.equal(version.value, "com.enviouswispr.app@2.3.1");
+  const system = embed.fields.find((f) => f.name === "System");
+  assert.match(system.value, /Mac16,8/);
+  assert.ok(!version.value.includes("9.9.9"), "must not show the dev event's release");
+});
+
+test("buildEmbedFromLookup: dev-only lookup -> Dev tag in title + source", () => {
+  const events = [rec({ environment: "development", buildType: "debug", category: "paste_failed" })];
+  const embed = buildEmbedFromLookup(
+    { status: "complete", events },
+    { issueId: "123", title: "boom", permalink: "https://x/123/", timesSeen: 3, userCount: 1, priority: "P3" }
+  );
+  assert.equal(embed.title, "[Sentry P3 · Dev] paste_failed");
+  const source = embed.fields.find((f) => f.name === "Source");
+  assert.equal(source.value, "🧪 Dev build (your testing)");
+});
+
+test("buildEmbedFromLookup: Unknown-labeled mixed issue renders the unclassifiable event, not the newest dev event", () => {
+  // Newest event is dev; the reason it's Unknown is an unclassifiable (possibly real
+  // user) event. The alert must surface that event's metadata, not the dev noise.
+  const events = [
+    rec({ environment: "development", buildType: "debug", release: "com.enviouswispr.app@9.9.9", category: "dev_noise", osVersion: "99.0.0", deviceModel: "DevMac" }),
+    rec({ environment: "production", buildType: null, release: "com.enviouswispr.app@2.3.1", category: "paste_failed", osVersion: "26.6.0", deviceModel: "Mac16,8" }),
+  ];
+  const embed = buildEmbedFromLookup(
+    { status: "complete", events },
+    { issueId: "123", title: "t", permalink: "https://x/123/", timesSeen: 5, userCount: 2, priority: "P2" }
+  );
+  assert.equal(embed.title, "[Sentry P2 · Unknown build] paste_failed");
+  const version = embed.fields.find((f) => f.name === "Version");
+  assert.equal(version.value, "com.enviouswispr.app@2.3.1");
+  assert.ok(!version.value.includes("9.9.9"), "must not show the dev event's release");
+});
+
+test("buildEmbedFromLookup: degraded lookup -> Unknown build fail-open embed", () => {
   const embed = buildEmbedFromLookup(
     { status: "unavailable" },
     { issueId: "123", title: "boom", permalink: "https://x/123/", timesSeen: 1, userCount: 1, priority: "P3" }
   );
+  assert.equal(embed.title, "[Sentry P3 · Unknown build] boom");
   const source = embed.fields.find((f) => f.name === "Source");
-  assert.equal(source.value, "❓ Unknown source (Sentry fetch failed)");
+  assert.match(source.value, /Unknown build/);
 });
 
 // ─────────────────────────────── existing embed helpers ───────────────────────
@@ -467,13 +531,79 @@ test("truncate: short passes through, long capped with ellipsis, non-string unch
   assert.equal(truncate(null), null);
 });
 
-test("classifySource: dev/debug -> test build, prod+release -> real user, else unknown", () => {
-  assert.equal(classifySource({ environment: "development", buildType: "release" }), "🧪 Your test build (dev/debug)");
-  assert.equal(classifySource({ environment: null, buildType: "debug" }), "🧪 Your test build (dev/debug)");
-  assert.equal(classifySource({ environment: "production", buildType: "release" }), "👤 Real user (release)");
-  assert.equal(classifySource({ environment: "production", buildType: null }), "❓ Unknown source (metadata missing)");
-  assert.equal(classifySource({}), "❓ Unknown source (metadata missing)");
-  assert.equal(classifySource(undefined), "❓ Unknown source (metadata missing)");
+test("classifyBuildType: any real-user release event -> release (even if mixed with dev)", () => {
+  const events = [
+    rec({ environment: "development", buildType: "debug" }),
+    rec({ environment: "production", buildType: "release" }),
+  ];
+  assert.equal(classifyBuildType({ status: "complete", events }), "release");
+});
+
+test("classifyBuildType: only non-production dev/debug events -> dev", () => {
+  assert.equal(classifyBuildType({ status: "complete", events: [rec({ environment: "development", buildType: "debug" })] }), "dev");
+  assert.equal(classifyBuildType({ status: "complete", events: [rec({ environment: null, buildType: "debug" })] }), "dev");
+});
+
+test("classifyBuildType: production event with missing buildType is not release -> unknown", () => {
+  // Consistent with severity: a production event lacking app.build_type is not trusted as release.
+  assert.equal(classifyBuildType({ status: "complete", events: [rec({ environment: "production", buildType: null })] }), "unknown");
+});
+
+test("classifyBuildType: dev event + unclassifiable production event -> unknown, not dev", () => {
+  // A possibly-real-user production event must not be masked as Dev just because a
+  // dev event is also present.
+  const events = [
+    rec({ environment: "development", buildType: "debug" }),
+    rec({ environment: "production", buildType: null }),
+  ];
+  assert.equal(classifyBuildType({ status: "complete", events }), "unknown");
+});
+
+test("classifyBuildType: debug build wins over a production env tag -> dev", () => {
+  // buildType=debug is the authoritative dev signal even if environment says production.
+  assert.equal(classifyBuildType({ status: "complete", events: [rec({ environment: "production", buildType: "debug" })] }), "dev");
+});
+
+test("classifyBuildType: dev event + unclassifiable release event (null env) -> unknown, not dev", () => {
+  // A release build with a missing environment tag may be a real user; a dev event
+  // alongside it must not downgrade the whole issue to Dev. Dev requires EVERY event
+  // to be confidently dev.
+  const events = [
+    rec({ environment: "development", buildType: "debug" }),
+    rec({ environment: null, buildType: "release" }),
+  ];
+  assert.equal(classifyBuildType({ status: "complete", events }), "unknown");
+});
+
+test("classifyBuildType: full single-event environment x buildType matrix", () => {
+  const one = (environment, buildType) =>
+    classifyBuildType({ status: "complete", events: [rec({ environment, buildType })] });
+  // release build only counts as Release in production; anywhere else it is not a confirmed real user
+  assert.equal(one("production", "release"), "release");
+  assert.equal(one("production", "debug"), "dev"); // debug authoritative
+  assert.equal(one("production", null), "unknown"); // untagged production = possibly real user
+  assert.equal(one("development", "release"), "dev"); // dev env = testing
+  assert.equal(one("development", "debug"), "dev");
+  assert.equal(one("development", null), "dev");
+  assert.equal(one(null, "debug"), "dev"); // debug build, unknown env = testing
+  assert.equal(one(null, "release"), "unknown"); // release build, unknown env = can't confirm real user
+  assert.equal(one(null, null), "unknown");
+});
+
+test("classifyBuildType: degraded or empty lookup -> unknown", () => {
+  assert.equal(classifyBuildType({ status: "unavailable" }), "unknown");
+  assert.equal(classifyBuildType({ status: "incomplete" }), "unknown");
+  assert.equal(classifyBuildType({ status: "complete", events: [] }), "unknown");
+  assert.equal(classifyBuildType(null), "unknown");
+});
+
+test("buildTypeTag / sourceLabelFor: crisp Dev vs Release wording", () => {
+  assert.equal(buildTypeTag("release"), "Release");
+  assert.equal(buildTypeTag("dev"), "Dev");
+  assert.equal(buildTypeTag("unknown"), "Unknown build");
+  assert.match(sourceLabelFor("release"), /Release/);
+  assert.match(sourceLabelFor("dev"), /Dev build/);
+  assert.match(sourceLabelFor("unknown"), /Unknown/);
 });
 
 test("readableHeadline: prefers category, falls back to title", () => {
@@ -490,7 +620,7 @@ test("metadataFields: joins category/stage and os/device, falls back to unknown"
   assert.equal(b.system, "unknown");
 });
 
-test("buildEnrichedEmbed: readable headline, real-user source, no em/en dash", () => {
+test("buildEnrichedEmbed: readable headline, Release tag, no em/en dash", () => {
   const embed = buildEnrichedEmbed({
     issueId: "456",
     title: "[REDACTED]",
@@ -498,19 +628,21 @@ test("buildEnrichedEmbed: readable headline, real-user source, no em/en dash", (
     timesSeen: 1,
     userCount: 1,
     priority: "P2",
-    metadata: { category: "paste_failed", environment: "production", buildType: "release", release: "com.enviouswispr.app@2.3.1" },
+    metadata: { category: "paste_failed", release: "com.enviouswispr.app@2.3.1" },
+    buildType: "release",
   });
-  assert.equal(embed.title, "[Sentry P2] paste_failed");
+  assert.equal(embed.title, "[Sentry P2 · Release] paste_failed");
   assert.ok(!embed.title.includes("REDACTED"));
   const text = JSON.stringify(embed);
   assert.ok(!text.includes("—"), "no em-dash");
   assert.ok(!text.includes("–"), "no en-dash");
 });
 
-test("buildFailOpenEmbed: unknown source + details-unavailable note", () => {
+test("buildFailOpenEmbed: Unknown build source + details-unavailable note", () => {
   const embed = buildFailOpenEmbed({ issueId: "789", title: "t", permalink: "https://x/789/", timesSeen: 2, userCount: 1, priority: "P3" });
+  assert.equal(embed.title, "[Sentry P3 · Unknown build] t");
   const source = embed.fields.find((f) => f.name === "Source");
-  assert.equal(source.value, "❓ Unknown source (Sentry fetch failed)");
+  assert.match(source.value, /Unknown build/);
   const details = embed.fields.find((f) => f.name === "Details");
   assert.match(details.value, /unavailable/i);
 });


### PR DESCRIPTION
## What & why

Follow-up to #1470 (worker-as-notifier). The founder asked for Sentry alerts to clearly say **Dev vs Release**. Dev-build issues already alerted (there is no dev filter in the post decision), but the build-type label was buried in a wordy Source field derived from a single event.

## Change

- New `classifyBuildType(eventLookup)` — the single authority for the label:
  - **Release** if ANY event is a real user on a production release build (matches how severity scores the production partition, so a mixed issue reads Release).
  - **Dev** if only dev/debug events exist (your own testing).
  - **Unknown build** for degraded/empty event data.
- Surface it as a crisp tag in the alert **title**: `[Sentry P2 · Release]` / `[Sentry P2 · Dev]` / `[Sentry P2 · Unknown build]`, and as the Source field.
- Removed the events[0]-based `classifySource` so there is one build-type authority.
- Characterization test locks that dev-only issues still post.

Isolated to the embed/labeling layer; `decideNotification` and the post/suppress policy are unchanged.

## Validation

48 worker unit tests green (`node --test`). Local Codex diff review clean. Deploy + a staged dev-payload replay after merge.

Part of #1470.
