### PR TITLE
docs(llm): correct PolishMode routing comment for #1255 cloud-fixed path

### DIFF
--- a/Sources/EnviousWisprCore/PolishMode.swift
+++ b/Sources/EnviousWisprCore/PolishMode.swift
@@ -1,12 +1,14 @@
 /// Output formatting mode for LLM polish.
 ///
 /// IMPORTANT — this is INTERNAL ROUTING, not a user-facing feature. There is no
-/// Settings toggle, no picker, no "choose your mode" UX. Every dictation is
-/// auto-classified by `TranscriptAnalyzer` based on length and structure cues,
-/// and the resulting case drives which formatting clause is appended to the
-/// polish prompt. Treat the enum as an implementation detail of the polish
-/// pipeline — tests validate the OUTPUT behavior (list → bullets, short text →
-/// one paragraph), not the enum value selected.
+/// Settings toggle, no picker, no "choose your mode" UX. Since #1255 only the
+/// generic-Ollama path (`.openAIProse` / `.gemmaFewShot`) is auto-classified by
+/// `TranscriptAnalyzer`; OpenAI, Gemini, and EG-1 are forced to `.message` by
+/// `DefaultPromptPlanner` and their builders ignore the mode entirely (the cloud
+/// fixed v6 prompt decides formatting in-prompt, with no appended clause). Treat
+/// the enum as an implementation detail of the polish pipeline — tests validate
+/// the OUTPUT behavior (list → bullets, short text → one paragraph), not the enum
+/// value selected.
 public enum PolishMode: String, Sendable {
   /// Short text (<35 words, no structure cues). One paragraph, no formatting.
   case inline


### PR DESCRIPTION
## What
The `PolishMode` doc comment claimed *every* dictation is auto-classified by `TranscriptAnalyzer`. Since #1255 that holds only for the generic-Ollama path (`.openAIProse` / `.gemmaFewShot`); OpenAI, Gemini, and EG-1 are forced to `.message` by `DefaultPromptPlanner` and their builders ignore the mode (cloud fixed v6 decides formatting in-prompt, no appended clause).

## Why
Surfaced during a knowledge-file terseness audit of `polish-eval.md`: the knowledge file and this code comment disagreed. Fixed the knowledge side already; this aligns the last stale copy so the two agree (DRY).

## Scope
Comment-only. No runtime code, no symbols, no tests changed. Zero-blast-radius (`council-skip: zero-blast-radius (comment)`). Codex diff review: clean ("accurately matches the current prompt routing and builder behavior").