### PR TITLE
fix(worker): clean version + real OS/device in Sentry Discord alerts

### DIFF
--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -382,6 +382,25 @@ export function normalizeRelease(release) {
   return { key: `${tuple[0]}.${tuple[1]}.${tuple[2]}`, tuple };
 }
 
+/**
+ * Human-readable version for the embed. Sentry stores the release as
+ * "com.enviouswispr.app@2.3.1"; show just "2.3.1". Falls back to the part after
+ * the last "@" for a non-semver release, and "unknown" when there is no release.
+ */
+export function displayVersion(release) {
+  if (typeof release !== "string" || release.length === 0) return "unknown";
+  const norm = normalizeRelease(release);
+  if (norm) return norm.key;
+  const at = release.lastIndexOf("@");
+  return at >= 0 ? release.slice(at + 1) : release;
+}
+
+/** Render an OS value as "macOS X", tolerating a source that already includes the prefix. */
+export function formatOs(osVersion) {
+  if (!osVersion) return null;
+  return /^macos/i.test(osVersion) ? osVersion : `macOS ${osVersion}`;
+}
+
 function compareRelease(a, b) {
   for (let i = 0; i < 3; i++) {
     if (a.tuple[i] !== b.tuple[i]) return a.tuple[i] - b.tuple[i];
@@ -469,8 +488,11 @@ export function extractEventRecord(event) {
     userId: event?.user?.id ?? null,
     category: tagValue("error.category"),
     stage: tagValue("pipeline.stage"),
-    osVersion: event?.contexts?.os?.version ?? null,
-    deviceModel: event?.contexts?.device?.model ?? null,
+    // The compact events-list endpoint returns contexts:null; OS/device live in
+    // tags there (os="macOS 26.6.0", device="Mac16,8"). Read tags first, keep the
+    // contexts path as a defensive fallback for any richer event serialization.
+    osVersion: tagValue("os") ?? event?.contexts?.os?.version ?? null,
+    deviceModel: tagValue("device") ?? event?.contexts?.device?.model ?? null,
   };
 }
 
@@ -788,9 +810,7 @@ export function readableHeadline(title, metadata) {
 export function metadataFields(metadata) {
   const what = [metadata.category, metadata.stage].filter(Boolean).join(" / ") || "unknown";
   const system =
-    [metadata.osVersion ? `macOS ${metadata.osVersion}` : null, metadata.deviceModel]
-      .filter(Boolean)
-      .join(", ") || "unknown";
+    [formatOs(metadata.osVersion), metadata.deviceModel].filter(Boolean).join(", ") || "unknown";
   return { what, system };
 }
 
@@ -807,7 +827,7 @@ export function buildEnrichedEmbed({ issueId, title, permalink, timesSeen, userC
         value: `Sentry issue totals: ${userCount} user(s) · ${timesSeen} occurrences`,
         inline: true,
       },
-      { name: "Version", value: truncate(metadata.release ?? "unknown"), inline: true },
+      { name: "Version", value: truncate(displayVersion(metadata.release)), inline: true },
       { name: "System", value: truncate(system), inline: true },
       { name: "Sentry", value: `[${issueId}](${permalink})`, inline: true },
     ],

--- a/workers/sentry-triage/test/index.test.js
+++ b/workers/sentry-triage/test/index.test.js
@@ -6,6 +6,8 @@ import {
   decideNotification,
   scoreFromEvents,
   normalizeRelease,
+  displayVersion,
+  formatOs,
   classifySeverity,
   extractEventRecord,
   parseNextCursor,
@@ -338,6 +340,30 @@ test("normalizeRelease: junk / non-string -> null", () => {
   assert.equal(normalizeRelease(undefined), null);
 });
 
+// ─────────────────────────────── displayVersion ───────────────────────────────
+
+test("displayVersion: strips the bundle prefix to a clean semver", () => {
+  assert.equal(displayVersion("com.enviouswispr.app@2.3.1"), "2.3.1");
+  assert.equal(displayVersion("2.3.1"), "2.3.1");
+  assert.equal(displayVersion("2.3.1+build47"), "2.3.1");
+});
+
+test("displayVersion: non-semver keeps the part after @; empty/missing -> unknown", () => {
+  assert.equal(displayVersion("com.enviouswispr.app@nightly"), "nightly");
+  assert.equal(displayVersion("nightly"), "nightly");
+  assert.equal(displayVersion(null), "unknown");
+  assert.equal(displayVersion(""), "unknown");
+});
+
+// ─────────────────────────────── formatOs ─────────────────────────────────────
+
+test("formatOs: adds macOS prefix only when absent", () => {
+  assert.equal(formatOs("macOS 26.6.0"), "macOS 26.6.0");
+  assert.equal(formatOs("26.6.0"), "macOS 26.6.0");
+  assert.equal(formatOs(null), null);
+  assert.equal(formatOs(undefined), null);
+});
+
 // ─────────────────────────────── classifySeverity ─────────────────────────────
 
 test("classifySeverity: threshold ladder", () => {
@@ -359,7 +385,8 @@ function rawEvent(tags = {}, extra = {}) {
   };
 }
 
-test("extractEventRecord: reads release/env/buildType/level/category/stage from tags", () => {
+test("extractEventRecord: reads release/env/buildType/level/category/stage/os/device from tags (real compact-endpoint shape, contexts:null)", () => {
+  // Mirrors the actual events-list payload: OS/device arrive as tags, contexts is null.
   const r = extractEventRecord(
     rawEvent(
       {
@@ -369,8 +396,10 @@ test("extractEventRecord: reads release/env/buildType/level/category/stage from 
         level: "error",
         "error.category": "paste_failed",
         "pipeline.stage": "paste",
+        os: "macOS 26.6.0",
+        device: "Mac16,8",
       },
-      { user: { id: "user-42" }, contexts: { os: { version: "26.6.0" }, device: { model: "Mac16,8" } } }
+      { user: { id: "user-42" }, contexts: null }
     )
   );
   assert.equal(r.release, "com.enviouswispr.app@2.3.1");
@@ -380,6 +409,14 @@ test("extractEventRecord: reads release/env/buildType/level/category/stage from 
   assert.equal(r.userId, "user-42");
   assert.equal(r.category, "paste_failed");
   assert.equal(r.stage, "paste");
+  assert.equal(r.osVersion, "macOS 26.6.0");
+  assert.equal(r.deviceModel, "Mac16,8");
+});
+
+test("extractEventRecord: falls back to contexts for os/device when tags are absent", () => {
+  const r = extractEventRecord(
+    rawEvent({}, { contexts: { os: { version: "26.6.0" }, device: { model: "Mac16,8" } } })
+  );
   assert.equal(r.osVersion, "26.6.0");
   assert.equal(r.deviceModel, "Mac16,8");
 });
@@ -476,7 +513,7 @@ test("buildEmbedFromLookup: mixed issue labeled Release renders the release even
   );
   assert.equal(embed.title, "[Sentry P2 · Release] paste_failed");
   const version = embed.fields.find((f) => f.name === "Version");
-  assert.equal(version.value, "com.enviouswispr.app@2.3.1");
+  assert.equal(version.value, "2.3.1");
   const system = embed.fields.find((f) => f.name === "System");
   assert.match(system.value, /Mac16,8/);
   assert.ok(!version.value.includes("9.9.9"), "must not show the dev event's release");
@@ -506,7 +543,7 @@ test("buildEmbedFromLookup: Unknown-labeled mixed issue renders the unclassifiab
   );
   assert.equal(embed.title, "[Sentry P2 · Unknown build] paste_failed");
   const version = embed.fields.find((f) => f.name === "Version");
-  assert.equal(version.value, "com.enviouswispr.app@2.3.1");
+  assert.equal(version.value, "2.3.1");
   assert.ok(!version.value.includes("9.9.9"), "must not show the dev event's release");
 });
 
@@ -612,12 +649,16 @@ test("readableHeadline: prefers category, falls back to title", () => {
 });
 
 test("metadataFields: joins category/stage and os/device, falls back to unknown", () => {
-  const a = metadataFields({ category: "paste_failed", stage: "paste", osVersion: "26.6.0", deviceModel: "Mac16,8" });
+  // Real tag path: osVersion already carries the "macOS" prefix -> no double prefix.
+  const a = metadataFields({ category: "paste_failed", stage: "paste", osVersion: "macOS 26.6.0", deviceModel: "Mac16,8" });
   assert.equal(a.what, "paste_failed / paste");
   assert.equal(a.system, "macOS 26.6.0, Mac16,8");
-  const b = metadataFields({});
-  assert.equal(b.what, "unknown");
-  assert.equal(b.system, "unknown");
+  // Contexts fallback path: bare version gets the prefix added.
+  const b = metadataFields({ osVersion: "26.6.0", deviceModel: "Mac16,8" });
+  assert.equal(b.system, "macOS 26.6.0, Mac16,8");
+  const c = metadataFields({});
+  assert.equal(c.what, "unknown");
+  assert.equal(c.system, "unknown");
 });
 
 test("buildEnrichedEmbed: readable headline, Release tag, no em/en dash", () => {
@@ -633,6 +674,8 @@ test("buildEnrichedEmbed: readable headline, Release tag, no em/en dash", () => 
   });
   assert.equal(embed.title, "[Sentry P2 · Release] paste_failed");
   assert.ok(!embed.title.includes("REDACTED"));
+  const version = embed.fields.find((f) => f.name === "Version");
+  assert.equal(version.value, "2.3.1", "version is cleaned, not the raw bundle@semver tag");
   const text = JSON.stringify(embed);
   assert.ok(!text.includes("—"), "no em-dash");
   assert.ok(!text.includes("–"), "no en-dash");


### PR DESCRIPTION
## What

Two display bugs in the Sentry-triage Discord alert:

- **Version** rendered the raw Sentry release tag `com.enviouswispr.app@2.3.1`. Now shows `2.3.1` via a `displayVersion` helper that reuses the existing `normalizeRelease` cleaner (no duplicate parse).
- **System** rendered `unknown`. Root cause, confirmed against the live Sentry API: the events-list endpoint returns `contexts: null`, so `event.contexts.os.version` / `.device.model` were always null. The same events carry OS/device as **tags** (`os="macOS 26.6.0"`, `device="Mac16,8"`). `extractEventRecord` now reads tags first, keeping the `contexts` path as a defensive fallback. Added `formatOs` so a tag value that already says "macOS" doesn't become "macOS macOS 26.6.0".

The `extractEventRecord`/`metadataFields` tests had been written against a synthetic `contexts` payload the real API never returns — corrected to the real tag-based shape, plus a fallback test.

## Validation

- 58 unit tests pass (was 54; +4 for `displayVersion`, `formatOs`, real-shape extraction, contexts fallback).
- Local Codex diff review: clean, no findings.
- Empirically grounded against a live Sentry event (issue 7603091833): confirmed `contexts:null` and the `os`/`device`/`release` tag values.

## Lane

Worker. `workers/sentry-triage/` only.

Part of #1470.
