### PR TITLE
fix(audio): harden Bluetooth settle check — validity guard + post-rebuild re-verify (#1445)

### DIFF
--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -749,16 +749,20 @@ final class HALDeviceInputSource: AudioInputSource {
   ///
   /// Two jobs, one contract:
   /// 1. SETTLED — poll the device's native rate until two consecutive reads
-  ///    agree (mirrors `AVAudioEngineSource.waitForFormatStabilization`'s
-  ///    two-reads-agree shape; Apple forum 770232 documents AirPods reporting
-  ///    a transient wrong rate corrected by a later notification).
+  ///    agree AND the agreed rate is usable (`> 0`; #1445 parity with
+  ///    `AVAudioEngineSource.isUsableFormat`). Mirrors
+  ///    `AVAudioEngineSource.waitForFormatStabilization`'s two-reads-agree
+  ///    shape; Apple forum 770232 documents AirPods reporting a transient
+  ///    wrong rate corrected by a later notification.
   /// 2. MATCHES — the settled rate must equal the rate this unit's converter
   ///    was built at in `prepare()`. A settled-but-DIVERGENT rate returns
   ///    false, which routes into the kernel's existing one-rebuild retry seam
   ///    (`RecordingSessionKernel` stabilization site) — `prepare()` then
   ///    re-reads the fresh rate and rebuilds the converter. The kernel makes
-  ///    exactly one rebuild attempt and never re-checks stabilization after
-  ///    it; residual failure is owned by the stall watchdog / ASR-empty paths.
+  ///    exactly one rebuild attempt; since #1445 it re-verifies stabilization
+  ///    once after that rebuild (diagnostic only — a false result does not
+  ///    trigger a second rebuild), and residual failure is owned by the stall
+  ///    watchdog / ASR-empty paths.
   ///
   /// No bound device / no live unit → true (nothing to stabilize; matches the
   /// manager's no-active-source short-circuit).
@@ -786,13 +790,24 @@ final class HALDeviceInputSource: AudioInputSource {
   /// drive it with an injected reader + no-op sleep (`test-timing`: assert on
   /// the returned value, never the wall clock).
   ///
-  /// SETTLED = two consecutive reads agree and are non-nil. The result is
+  /// SETTLED = two consecutive reads agree AND the agreed rate is usable
+  /// (`> 0`). During a device transition `nativeRateReader` can report a
+  /// non-nil `0.0`; two agreeing invalid reads must not read as stable
+  /// (parity with `AVAudioEngineSource.isUsableFormat`, #1473). The result is
   /// `matchesPrepared` — a settled-but-DIVERGENT rate is deliberately false
   /// (routes into the kernel's one-rebuild retry seam).
   struct RateSettleOutcome: Equatable {
     let settledRate: Double?
     let matchesPrepared: Bool
     let polls: Int
+  }
+
+  /// A read only counts toward "settled" when it is non-nil and `> 0` (mirrors
+  /// `AVAudioEngineSource.isUsableFormat`'s rate clause). Rejects zero,
+  /// negatives, and NaN (`Double.nan > 0` is false).
+  nonisolated static func isUsableRate(_ rate: Double?) -> Bool {
+    guard let rate else { return false }
+    return rate > 0
   }
 
   static func settleNativeRate(
@@ -813,7 +828,7 @@ final class HALDeviceInputSource: AudioInputSource {
     var lastRate = readRate()
     await sleep(.milliseconds(10))
     var currentRate = readRate()
-    if currentRate != nil, currentRate == lastRate {
+    if isUsableRate(currentRate), currentRate == lastRate {
       return outcome(currentRate, polls: 0)
     }
     // Bounded poll loop — polls is the budget (not wall-clock, so an injected
@@ -825,7 +840,7 @@ final class HALDeviceInputSource: AudioInputSource {
       await sleep(.seconds(pollInterval))
       polls += 1
       currentRate = readRate()
-      if currentRate != nil, currentRate == lastRate {
+      if isUsableRate(currentRate), currentRate == lastRate {
         return outcome(currentRate, polls: polls)
       }
     }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -837,11 +837,13 @@ final class RecordingSessionKernel {
     let stabilized = await audioCapture.waitForFormatStabilization(
       maxWait: 1.5, pollInterval: 0.2)
     guard isCurrent(sid) else { return }
-    // #1434: record the stabilization outcome for the session's capture-health
-    // telemetry (read at stall-emit by the observer and merged into the
-    // post-stop record at `stopCapture()`). Exactly ONE rebuild attempt below,
-    // and no second stabilization check after it — a still-broken device is
-    // owned by the stall watchdog / ASR-empty paths downstream.
+    // #1434/#1445: record the stabilization outcome for the session's
+    // capture-health telemetry (read at stall-emit by the observer and merged
+    // into the post-stop record at `stopCapture()`). Exactly ONE rebuild
+    // attempt below; #1445 adds one diagnostic re-verify after that rebuild
+    // (no second rebuild) so a rebuild that re-read a still-stale rate is
+    // visible in telemetry instead of being blindly trusted. A still-broken
+    // device is owned by the stall watchdog / ASR-empty paths downstream.
     formatStabilizedThisSession = stabilized
     captureRebuiltForFormatThisSession = !stabilized
     if !stabilized {
@@ -855,6 +857,24 @@ final class RecordingSessionKernel {
         return
       }
       guard isCurrent(sid) else { return }
+      // #1445: re-verify stabilization ONCE after the single rebuild. This is
+      // DIAGNOSTIC only — it records the truer post-rebuild outcome for
+      // capture-health telemetry (previously the pre-rebuild `false` was
+      // trusted blindly). A still-`false` result does NOT trigger a second
+      // rebuild or a new terminal; `captureRebuiltForFormatThisSession` stays
+      // true so a rebuild remains visible. Control then falls through to the
+      // existing stop/cancel latch checks below, which remain the cancel
+      // authority.
+      //
+      // NEAR-INSTANT budget (Codex code-diff P2): because the result is
+      // never acted on and capture proceeds regardless, this must NOT re-pay
+      // the full 1.5s stabilization budget on the exact affected-device path.
+      // A 50 ms snapshot (fast-path read + at most one short poll) captures
+      // "did the rebuild settle it" without adding heart-path PTT latency.
+      let reverified = await audioCapture.waitForFormatStabilization(
+        maxWait: 0.05, pollInterval: 0.05)
+      guard isCurrent(sid) else { return }
+      formatStabilizedThisSession = reverified
     }
     // The capture engine is up — every terminal from here must stop capture.
     captureLifecycle = .active

--- a/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
+++ b/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
@@ -88,6 +88,47 @@ struct HALFormatStabilizationTests {
     let stabilized = await source.waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
     #expect(stabilized)
   }
+
+  // MARK: - #1445 validity guard (parity with AVAudioEngineSource.isUsableFormat)
+
+  @Test("isUsableRate rejects nil, zero, negative, and NaN; accepts positive (#1445)")
+  func isUsableRatePredicate() {
+    #expect(!HALDeviceInputSource.isUsableRate(nil))
+    #expect(!HALDeviceInputSource.isUsableRate(0))
+    #expect(!HALDeviceInputSource.isUsableRate(-1))
+    #expect(!HALDeviceInputSource.isUsableRate(Double.nan))
+    #expect(HALDeviceInputSource.isUsableRate(24000))
+  }
+
+  @Test("two agreeing 0.0 reads do NOT fast-settle; it settles on the later valid rate (#1445)")
+  func invalidZeroTwiceThenValidSettles() async {
+    // Before the guard, two agreeing 0.0 reads settled at polls==0 with an
+    // unusable settledRate. Now they fall through until a usable rate agrees.
+    let outcome = await settle(prepared: 24000, readings: [0.0, 0.0, 24000, 24000])
+    #expect(outcome.matchesPrepared)
+    #expect(outcome.settledRate == 24000)
+    #expect(outcome.polls >= 1)  // proves it did NOT fast-exit on the zeros
+  }
+
+  @Test("a device stuck at 0.0 never settles — invalid reads are not stable (#1445)")
+  func invalidZeroForeverIsUnstable() async {
+    let outcome = await settle(prepared: 24000, readings: [0.0, 0.0])
+    #expect(!outcome.matchesPrepared)
+    #expect(outcome.settledRate == nil)
+  }
+
+  @Test("no bound device short-circuits true WITHOUT reading the device rate (#1445)")
+  func unpreparedDoesNotReadDeviceRate() async {
+    let source = HALDeviceInputSource()
+    var readerCalls = 0
+    source.nativeRateReader = { _ in
+      readerCalls += 1
+      return 24000
+    }
+    let stabilized = await source.waitForFormatStabilization(maxWait: 1.5, pollInterval: 0.2)
+    #expect(stabilized)
+    #expect(readerCalls == 0)  // boundDeviceID/renderContext nil → short-circuit before any read
+  }
 }
 
 // MARK: - #1434 CaptureStopMetadata transport round-trip

--- a/Tests/EnviousWisprTests/Pipeline/KernelFormatStabilizationRebuildTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFormatStabilizationRebuildTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - #1445 kernel format-stabilization rebuild + diagnostic re-verify
+//
+// Change B of #1445: on the pre-capture stabilization site, a non-settled
+// result triggers EXACTLY ONE `rebuildEngine()` + `startEnginePhase()`, and
+// then ONE diagnostic re-verify `waitForFormatStabilization` whose result is
+// written to the session's `formatStabilized` telemetry WITHOUT triggering a
+// second rebuild. These tests drive the real kernel through the injected
+// `FakeAudioCapture` and assert the call counts + the telemetry the observer
+// reads (`captureStabilizationTelemetry`). Deterministic — scripted
+// stabilization results + a continuation gate, never a wall-clock sleep
+// (`test-timing`).
+
+@MainActor
+@Suite("RecordingSessionKernel — #1445 format-stabilization rebuild + re-verify")
+struct KernelFormatStabilizationRebuildTests {
+
+  private func makeWrapper() -> (FakeAudioCapture, KernelRecordingSession) {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    return (capture, wrapper)
+  }
+
+  private func startAndSettle(_ wrapper: KernelRecordingSession) async {
+    await wrapper.apply(.start)
+    await wrapper.drainReadyWork()
+  }
+
+  // Case 1 — a stable device settles on the first check: no rebuild, no re-verify.
+  @Test("stable device: one stabilization check, zero rebuilds")
+  func stableDeviceNoRebuild() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [true]
+
+    await startAndSettle(wrapper)
+
+    #expect(capture.stabilizationCallCount == 1)
+    #expect(capture.rebuildEngineCallCount == 0)
+    let tel = wrapper.testKernel.captureStabilizationTelemetry
+    #expect(tel.formatStabilized == true)
+    #expect(tel.rebuiltForFormat == false)
+  }
+
+  // Case 2 — unstable then stable: one rebuild, one re-verify that succeeds.
+  @Test("unstable-then-stable: exactly one rebuild, re-verify succeeds, capture proceeds")
+  func unstableThenStableOneRebuild() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [false, true]
+
+    await startAndSettle(wrapper)
+
+    #expect(capture.stabilizationCallCount == 2)
+    #expect(capture.rebuildEngineCallCount == 1)
+    #expect(capture.startEnginePhaseCallCount == 2)  // initial + the one rebuild
+    #expect(capture.beginCapturePhaseCallCount == 1)  // capture proceeded
+    let tel = wrapper.testKernel.captureStabilizationTelemetry
+    #expect(tel.formatStabilized == true)  // truer POST-rebuild value
+    #expect(tel.rebuiltForFormat == true)  // a rebuild stays visible
+  }
+
+  // Case 3 — still-unstable after the rebuild: NO second rebuild, honest telemetry.
+  @Test("still-unstable after rebuild: no second rebuild, formatStabilized=false, capture proceeds")
+  func stillUnstableNoSecondRebuild() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [false, false]
+
+    await startAndSettle(wrapper)
+
+    #expect(capture.stabilizationCallCount == 2)  // one initial + one re-verify
+    #expect(capture.rebuildEngineCallCount == 1)  // exactly one rebuild, never two
+    #expect(capture.beginCapturePhaseCallCount == 1)  // best-effort: capture still proceeds
+    let tel = wrapper.testKernel.captureStabilizationTelemetry
+    #expect(tel.formatStabilized == false)  // honest post-rebuild failure
+    #expect(tel.rebuiltForFormat == true)  // the rebuild remains recorded
+  }
+
+  // Case 4 — cancel WHILE the diagnostic re-verify is in flight: the existing
+  // stop/cancel latch after the new await prevents capture from beginning.
+  @Test("cancel during the post-rebuild re-verify: capture never begins, session cancels")
+  func cancelDuringReverify() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [false, true]
+    capture.gateStabilizationCall = 2  // park the re-verify
+
+    await wrapper.apply(.start)  // spawns the forward path (synchronous)
+    await capture.awaitStabilizationGateReached()  // forward path parked at the re-verify
+    #expect(wrapper.testKernel.state == .warmingUp)  // not yet .recording
+
+    wrapper.testKernel.cancel()  // cancelRequested latched pre-recording
+    capture.releaseStabilizationGate()
+    await wrapper.drainReadyWork()
+
+    #expect(wrapper.testKernel.state == .cancelled)
+    #expect(capture.rebuildEngineCallCount == 1)  // rebuild had already happened
+    #expect(capture.stabilizationCallCount == 2)  // the re-verify ran to completion
+    #expect(capture.beginCapturePhaseCallCount == 0)  // the cancel latch stopped capture
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -49,6 +49,26 @@ final class FakeAudioCapture: AudioCaptureInterface {
   private(set) var abortPreWarmCallCount = 0
   private(set) var deliveredBufferCount = 0
 
+  // MARK: #1445 format-stabilization scripting
+
+  /// Scripted results for successive `waitForFormatStabilization` calls. Empty
+  /// (default) => every call returns `true` (stable), preserving every
+  /// pre-#1445 scenario. A `[false, true]` script drives the kernel's
+  /// one-rebuild-then-diagnostic-re-verify path: the first `false` triggers the
+  /// single rebuild, the second is the post-rebuild re-verify.
+  var stabilizationResults: [Bool] = []
+  private(set) var stabilizationCallCount = 0
+  private(set) var rebuildEngineCallCount = 0
+  private(set) var startEnginePhaseCallCount = 0
+
+  /// When set, the Nth (1-based) `waitForFormatStabilization` call parks on a
+  /// continuation until `releaseStabilizationGate()`, letting a test interleave
+  /// a cancel while the post-rebuild re-verify is in flight (#1445).
+  var gateStabilizationCall: Int?
+  private var gateContinuation: CheckedContinuation<Void, Never>?
+  private var gateReachedContinuation: CheckedContinuation<Void, Never>?
+  private var gateReached = false
+
   // MARK: Captured audio
 
   private var accumulatedSamples: [Float] = []
@@ -96,6 +116,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
   // MARK: AudioCaptureInterface — core lifecycle
 
   func startEnginePhase() async throws {
+    startEnginePhaseCallCount += 1
     if permissionDenied { throw FakeCaptureError.permissionDenied }
     if failEngineStart { throw FakeCaptureError.engineStartFailed }
   }
@@ -130,7 +151,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
     return CaptureResult(samples: accumulatedSamples, vadSegments: segments)
   }
 
-  func rebuildEngine() {}
+  func rebuildEngine() { rebuildEngineCallCount += 1 }
 
   func buildEngine(noiseSuppression: Bool) {
     noiseSuppressionEnabled = noiseSuppression
@@ -148,7 +169,32 @@ final class FakeAudioCapture: AudioCaptureInterface {
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async
     -> Bool
   {
-    true
+    stabilizationCallCount += 1
+    let thisCall = stabilizationCallCount
+    let result =
+      thisCall <= stabilizationResults.count
+      ? stabilizationResults[thisCall - 1]
+      : true
+    if let gate = gateStabilizationCall, gate == thisCall {
+      gateReached = true
+      gateReachedContinuation?.resume()
+      gateReachedContinuation = nil
+      await withCheckedContinuation { gateContinuation = $0 }
+    }
+    return result
+  }
+
+  /// Suspend until the gated `waitForFormatStabilization` call has parked (see
+  /// `gateStabilizationCall`). Returns immediately if it already parked.
+  func awaitStabilizationGateReached() async {
+    if gateReached { return }
+    await withCheckedContinuation { gateReachedContinuation = $0 }
+  }
+
+  /// Resume the parked `waitForFormatStabilization` call.
+  func releaseStabilizationGate() {
+    gateContinuation?.resume()
+    gateContinuation = nil
   }
 
   // MARK: AudioCaptureInterface — VAD


### PR DESCRIPTION
Closes #1445. Release 1, Slice 1 of 3 (cleanup). Ships to main **unreleased**; the release waits for Slice 2 (#1480 awareness card) + the reliability sweep, then one founder-live-tested release.

## What this does
Two zero-common-path-cost hardenings on the Bluetooth capture path's format-settle check, closing a gap a cloud reviewer found on PR #1444:

1. **Validity guard (parity with #1473).** `HALDeviceInputSource.settleNativeRate` now counts a rate as "settled" only when it is non-nil **and positive**. A device transiently reporting `0.0` twice no longer falsely settles — it matches the sibling `AVAudioEngineSource.isUsableFormat` hardening already shipped on the built-in-mic path.
2. **Post-rebuild re-verify (diagnostic).** After the kernel's single engine rebuild, it now re-checks stabilization **once** and records the truer outcome in capture-health telemetry, instead of blindly trusting the pre-rebuild result. Still exactly one rebuild. The re-verify is a **near-instant ~50 ms snapshot** (tightened from the full 1.5 s budget per the Codex code-diff review — the result is diagnostic-only, so it must not add heart-path latency on the affected-device path). The existing stop/cancel latch remains the cancel authority.

Not in scope (by design): the AirPods cold-start word loss. That is Bluetooth-link stabilization garble, addressed by Slice 2 (#1480) + Release 2 (#1441). 2026-07-10 live testing confirmed the settle check resolves in ~13 ms and is **not** the cause of the word loss.

## Tests
- 4 new pure settle-loop cases (validity guard: `0.0`-twice, `0.0`-then-valid, `isUsableRate` predicate, no-read short-circuit).
- 4 new kernel orchestration cases (stable → no rebuild; unstable→stable → one rebuild + re-verify; still-unstable → no second rebuild + honest telemetry; cancel-during-re-verify → capture never begins).
- Full suite green (2694 tests).

## Live UAT (founder, AirPods + Bose, keep-warm off)
Settle time 12–13 ms on every recording (unchanged from baseline); no rebuild fired; all dictations transcribed and pasted normally; no heart-path regression. The one slow first-press (2.5 s engine warm-up) was the one-time fresh-launch cost, not this change.

## Review
- Council + Codex grounded review to PROCEED-AS-PLANNED.
- Codex code-diff review: one P2 (diagnostic recheck could add up to 1.5 s on the affected path) — adopted, tightened to the ~50 ms snapshot; re-review clean ("No actionable correctness issues").

Tier SMALL. Single-commit revert; behavior on revert is exactly today's shipped-on-main behavior.