### PR TITLE
fix(update): one-click recovery from App Translocation (#1451)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -59,6 +59,9 @@ final class AppLifecycleCoordinator {
   private let menuBarController: MenuBarController
   private let appWindowCoordinator: AppWindowCoordinator
   private let hotkeyService: HotkeyService
+  // #1451: launch-time App Translocation recovery limb. Called once on launch;
+  // never a prerequisite for anything below it.
+  private let applicationRelocationCoordinator: ApplicationRelocationCoordinator
 
   init(
     settings: SettingsManager,
@@ -78,6 +81,7 @@ final class AppLifecycleCoordinator {
     menuBarController: MenuBarController,
     appWindowCoordinator: AppWindowCoordinator,
     hotkeyService: HotkeyService,
+    applicationRelocationCoordinator: ApplicationRelocationCoordinator,
     // #1176: captured in the onboarding-dismiss closure below (NOT stored — keeps
     // this coordinator's stored-property ceiling clean).
     onboardingProgress: OnboardingProgress
@@ -99,6 +103,7 @@ final class AppLifecycleCoordinator {
     self.menuBarController = menuBarController
     self.appWindowCoordinator = appWindowCoordinator
     self.hotkeyService = hotkeyService
+    self.applicationRelocationCoordinator = applicationRelocationCoordinator
     // Icon-refresh seam: the window coordinator's two onboarding-dismiss
     // callsites route through this closure. Was wired in `AppDelegate.attach`
     // before PR-B.4.
@@ -125,6 +130,12 @@ final class AppLifecycleCoordinator {
     if settings.onboardingState == .completed {
       NSApp.setActivationPolicy(.accessory)
     }
+
+    // #1451: recover from App Translocation. Runs on EVERY launch (NOT gated by
+    // onboarding — the 14 stuck users already finished onboarding), returns
+    // immediately after scheduling any prompt, and is a limb: it never blocks
+    // the launch sequence below.
+    applicationRelocationCoordinator.evaluateAndOfferIfNeeded()
 
     // #879: the launch-preload telemetry callback wiring was removed. The
     // launch warm-up now routes through `KernelDictationDriver.ensureEngineWarm

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
@@ -217,8 +217,12 @@ public final class CenteredRelocationPresenter: RelocationPresenting {
 
 /// The safe verdict for an app already sitting at the destination.
 public enum ExistingDestinationDecision: Equatable, Sendable {
-  /// Same-or-newer, verified copy → open it, never downgrade or overwrite.
+  /// Same-or-newer, verified copy, NOT running → open it fresh, never downgrade
+  /// or overwrite.
   case openExisting
+  /// Same-or-newer, verified copy that is ALREADY running → activate it, never
+  /// spawn a duplicate (cloud Codex review #1490).
+  case activateRunning
   /// Older copy currently running → refuse; never downgrade to it and a running
   /// bundle cannot be safely overwritten (Codex r2 P1).
   case refuseRunningOlder
@@ -258,8 +262,10 @@ public struct FileManagerApplicationMover: ApplicationMoving {
     guard signatureValid else { return .conflict }
     let cmp = UpdateAvailabilityService.compareVersions(existingVersion, currentVersion)
     if cmp >= 0 {
-      // Same-or-newer, verified: open it, never downgrade or overwrite.
-      return .openExisting
+      // Same-or-newer, verified: activate it if already running (never
+      // duplicate — cloud #1490), otherwise open it fresh. Never downgrade or
+      // overwrite.
+      return isRunning ? .activateRunning : .openExisting
     }
     // Older, verified: replace when safe, refuse when it is running (a running
     // bundle cannot be overwritten and must not be downgraded to).
@@ -299,8 +305,13 @@ public struct FileManagerApplicationMover: ApplicationMoving {
         isRunning: isRunning, signatureValid: signatureValid)
       {
       case .openExisting:
-        // Same-or-newer, verified: open it, do not downgrade or overwrite.
+        // Same-or-newer, verified, not running: open it fresh, do not downgrade
+        // or overwrite.
         return .success(.existingUsable(destination))
+      case .activateRunning:
+        // Same-or-newer, verified, already running: activate it, never spawn a
+        // duplicate (cloud Codex review #1490).
+        return .success(.existingRunning(destination))
       case .refuseRunningOlder:
         // Older + running: never downgrade to it, and a running bundle cannot be
         // safely overwritten. Keep the current app alive (Codex r2 P1).
@@ -404,6 +415,17 @@ public struct NSWorkspaceRelocationRelauncher: RelocationRelaunching {
         continuation.resume(returning: error == nil && app != nil)
       }
     }
+  }
+
+  public func activateRunning(_ url: URL) async -> Bool {
+    // Bring the already-running instance at this exact URL to the front; never
+    // spawn a new one (cloud Codex review #1490).
+    let target = url.standardizedFileURL
+    let running = NSWorkspace.shared.runningApplications.first {
+      $0.bundleURL?.standardizedFileURL == target
+    }
+    guard let app = running else { return false }
+    return app.activate()
   }
 }
 

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
@@ -1,0 +1,517 @@
+import AppKit
+import EnviousWisprServices
+import Foundation
+import Security
+import SwiftUI
+
+// Issue #1451: production wiring for the App Translocation recovery limb.
+// Pure policy + seam protocols live in ApplicationRelocationCoordinator.swift;
+// every side-effecting implementation (UserDefaults, NSAlert, FileManager,
+// NSWorkspace, the ack-file handshake, TelemetryService) lives here so the
+// coordinator's logic stays unit-testable with fakes.
+
+// MARK: - Suppression store
+
+/// `UserDefaults`-backed "Not Now" memory. Missing keys mean "never declined"
+/// (safe for every existing user). `@unchecked Sendable`: `UserDefaults` is
+/// documented thread-safe; the struct holds only that reference.
+public struct UserDefaultsRelocationSuppressionStore: RelocationSuppressionStore,
+  @unchecked Sendable
+{
+  private let defaults: UserDefaults
+  static let lastDeclinedAtKey = "ew.relocation.lastDeclinedAt"
+  static let lastDeclinedVersionKey = "ew.relocation.lastDeclinedBundleVersion"
+
+  public init(defaults: UserDefaults = .standard) { self.defaults = defaults }
+
+  public func lastDecline() -> (at: Date, version: String)? {
+    guard
+      let at = defaults.object(forKey: Self.lastDeclinedAtKey) as? Date,
+      let version = defaults.string(forKey: Self.lastDeclinedVersionKey)
+    else { return nil }
+    return (at, version)
+  }
+
+  public func recordDecline(at: Date, version: String) {
+    defaults.set(at, forKey: Self.lastDeclinedAtKey)
+    defaults.set(version, forKey: Self.lastDeclinedVersionKey)
+  }
+
+  public func clear() {
+    defaults.removeObject(forKey: Self.lastDeclinedAtKey)
+    defaults.removeObject(forKey: Self.lastDeclinedVersionKey)
+  }
+}
+
+// MARK: - Presenter (centered card)
+
+/// A borderless, self-sizing panel that can become key so its SwiftUI buttons
+/// receive clicks. Native rounding + shadow come from `.titled` +
+/// `fullSizeContentView` with the title bar hidden.
+private final class RelocationCardPanel: NSPanel {
+  override var canBecomeKey: Bool { true }
+}
+
+/// Shared centered card chrome: app icon on top, centered title + body, then a
+/// vertical stack of actions. Replaces the stock left-aligned `NSAlert` layout
+/// (#1451 design polish — founder 2026-07-10). All copy is dash-free.
+private struct RelocationCard<Actions: View>: View {
+  let title: String
+  let message: String
+  var showsSpinner: Bool = false
+  @ViewBuilder var actions: () -> Actions
+
+  var body: some View {
+    VStack(spacing: 18) {
+      Image(nsImage: NSApp.applicationIconImage ?? NSImage())
+        .resizable().aspectRatio(contentMode: .fit)
+        .frame(width: 80, height: 80)
+      Text(title)
+        .font(.system(size: 24, weight: .bold))
+        .multilineTextAlignment(.center)
+      Text(message)
+        .font(.system(size: 17))
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+      if showsSpinner {
+        ProgressView().controlSize(.regular).padding(.top, 4)
+      }
+      VStack(spacing: 10) { actions() }
+        .padding(.top, 10)
+    }
+    .padding(28)
+    .frame(width: 400)
+  }
+}
+
+/// Centered-card prompt + progress + failure surfaces for the relocation flow.
+@MainActor
+public final class CenteredRelocationPresenter: RelocationPresenting {
+  private var progressPanel: NSPanel?
+
+  /// Brand accent (#7c3aed) — the primary action's fill.
+  private static let accent = Color(red: 124.0 / 255, green: 58.0 / 255, blue: 237.0 / 255)
+  private static let moveResponse = NSApplication.ModalResponse(rawValue: 1001)
+  private static let notNowResponse = NSApplication.ModalResponse(rawValue: 1002)
+
+  public init() {}
+
+  /// Builds a chromeless, self-sizing, centered card panel around a SwiftUI view.
+  private func makeCardPanel<Content: View>(_ content: Content) -> NSPanel {
+    let panel = RelocationCardPanel(
+      contentRect: NSRect(x: 0, y: 0, width: 320, height: 220),
+      styleMask: [.titled, .fullSizeContentView], backing: .buffered, defer: false)
+    panel.titleVisibility = .hidden
+    panel.titlebarAppearsTransparent = true
+    panel.standardWindowButton(.closeButton)?.isHidden = true
+    panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
+    panel.standardWindowButton(.zoomButton)?.isHidden = true
+    panel.isMovableByWindowBackground = true
+    panel.isReleasedWhenClosed = false
+    panel.level = .modalPanel
+    let host = NSHostingView(rootView: content)
+    panel.contentView = host
+    panel.setContentSize(host.fittingSize)
+    panel.center()
+    return panel
+  }
+
+  public func present() async -> RelocationChoice {
+    let card = RelocationCard(
+      title: "Finish setting up EnviousWispr",
+      message:
+        "EnviousWispr is running from a temporary location, so it cannot receive updates. "
+        + "EnviousWispr can fix this and reopen automatically."
+    ) {
+      VStack(spacing: 10) {
+        Button {
+          NSApp.stopModal(withCode: Self.moveResponse)
+        } label: {
+          Text("Move EnviousWispr")
+            .font(.system(size: 17, weight: .semibold))
+            .frame(maxWidth: .infinity).padding(.vertical, 4)
+        }
+        .buttonStyle(.borderedProminent).controlSize(.large).tint(Self.accent)
+        Button {
+          NSApp.stopModal(withCode: Self.notNowResponse)
+        } label: {
+          Text("Not Now")
+            .font(.system(size: 17, weight: .medium))
+            .frame(maxWidth: .infinity).padding(.vertical, 4)
+        }
+        .buttonStyle(.bordered).controlSize(.large)
+      }
+    }
+    let panel = makeCardPanel(card)
+    NSApp.activate(ignoringOtherApps: true)
+    panel.makeKeyAndOrderFront(nil)
+    let response = NSApp.runModal(for: panel)
+    panel.orderOut(nil)
+    return response == Self.moveResponse ? .move : .notNow
+  }
+
+  public func showProgress() {
+    let card = RelocationCard(
+      title: "Moving EnviousWispr",
+      message: "Installing to your Applications folder. EnviousWispr will reopen automatically.",
+      showsSpinner: true
+    ) { EmptyView() }
+    let panel = makeCardPanel(card)
+    panel.makeKeyAndOrderFront(nil)
+    progressPanel = panel
+  }
+
+  public func dismissProgress() {
+    progressPanel?.orderOut(nil)
+    progressPanel = nil
+  }
+
+  public func showFailure(_ failure: RelocationFailure) {
+    dismissProgress()
+    let (title, message) = Self.failureCopy(failure)
+    let card = RelocationCard(title: title, message: message) {
+      Button {
+        NSApp.stopModal()
+      } label: {
+        Text("OK")
+          .font(.system(size: 17, weight: .semibold))
+          .frame(maxWidth: .infinity).padding(.vertical, 4)
+      }
+      .buttonStyle(.borderedProminent).controlSize(.large).tint(Self.accent)
+    }
+    let panel = makeCardPanel(card)
+    NSApp.activate(ignoringOtherApps: true)
+    panel.makeKeyAndOrderFront(nil)
+    NSApp.runModal(for: panel)
+    panel.orderOut(nil)
+  }
+
+  private static func failureCopy(_ failure: RelocationFailure) -> (String, String) {
+    switch failure {
+    case .diskFull:
+      return (
+        "Not enough space to move EnviousWispr.",
+        "Nothing was changed. Free up some space, then reopen EnviousWispr to try again."
+      )
+    case .destinationRunning:
+      return (
+        "Another copy of EnviousWispr is already open.",
+        "Nothing was changed. Quit the other copy, then reopen EnviousWispr to finish moving it."
+      )
+    case .destinationConflict:
+      return (
+        "A different app is already in that Applications spot.",
+        "Nothing was changed. EnviousWispr is still working. You can move it yourself in Finder anytime."
+      )
+    default:
+      return (
+        "We couldn't move EnviousWispr.",
+        "Nothing was changed. EnviousWispr is still working. Reopen it anytime to try again."
+      )
+    }
+  }
+}
+
+// MARK: - Mover
+
+/// The safe verdict for an app already sitting at the destination.
+public enum ExistingDestinationDecision: Equatable, Sendable {
+  /// Same-or-newer, verified copy → open it, never downgrade or overwrite.
+  case openExisting
+  /// Older copy currently running → refuse; never downgrade to it and a running
+  /// bundle cannot be safely overwritten (Codex r2 P1).
+  case refuseRunningOlder
+  /// Older copy, not running → stage + atomic replace.
+  case replace
+  /// Different app, un-inspectable, or any copy (older or newer) that fails the
+  /// signature gate → never delete, overwrite, or launch it.
+  case conflict
+}
+
+/// Copies the running bundle into the destination and resolves any existing
+/// copy safely: same-or-newer/running → open it (`.existingUsable`); older →
+/// atomic `replaceItemAt` after staging + signature validation on the
+/// destination volume (never Trash-first); absent → move staged into place.
+public struct FileManagerApplicationMover: ApplicationMoving {
+  /// Our Developer ID Team ID (scripts/build-release-dmg.sh TEAM_ID). The staged
+  /// copy must satisfy `anchor apple generic` + this signing identity before it
+  /// replaces anything.
+  static let teamID = "9UT54V24XG"
+
+  public init() {}
+
+  /// Pure conflict-resolution matrix for a bundle already at the destination.
+  /// Extracted so the routing that a Codex r2 P1 slipped through (downgrading to
+  /// an older running copy) is unit-tested independently of the filesystem.
+  static func decideExistingDestination(
+    existingBundleIdentifier: String?, expectedBundleIdentifier: String,
+    existingVersion: String, currentVersion: String,
+    isRunning: Bool, signatureValid: Bool
+  ) -> ExistingDestinationDecision {
+    guard existingBundleIdentifier == expectedBundleIdentifier else { return .conflict }
+    // Never act on a bundle we cannot verify as genuinely ours — not launch it
+    // (open-existing) and not destroy it (replace). A plist id/version is not
+    // proof of identity; an unsigned, corrupted, or impostor bundle squatting
+    // our path and id must be left untouched (Codex r1 P2 + r3 P2). The rare
+    // corrupted-real-install case falls to a Finder-move escape.
+    guard signatureValid else { return .conflict }
+    let cmp = UpdateAvailabilityService.compareVersions(existingVersion, currentVersion)
+    if cmp >= 0 {
+      // Same-or-newer, verified: open it, never downgrade or overwrite.
+      return .openExisting
+    }
+    // Older, verified: replace when safe, refuse when it is running (a running
+    // bundle cannot be overwritten and must not be downgraded to).
+    return isRunning ? .refuseRunningOlder : .replace
+  }
+
+  public func install(
+    source: URL, destination: URL,
+    expectedBundleIdentifier: String, currentVersion: String
+  ) async -> Result<InstallResolution, RelocationFailure> {
+    let fm = FileManager.default
+    let destParent = destination.deletingLastPathComponent()
+
+    // Ensure the Applications parent exists (creates ~/Applications for the
+    // user-domain fallback). Never requires admin.
+    if !fm.fileExists(atPath: destParent.path) {
+      do { try fm.createDirectory(at: destParent, withIntermediateDirectories: true) } catch {
+        return .failure(.destinationCreation)
+      }
+    }
+
+    // Resolve an existing bundle at the destination BEFORE copying. The pure
+    // decision lives in `decideExistingDestination` (unit-tested matrix); this
+    // block only gathers the observable facts and acts on the verdict.
+    if fm.fileExists(atPath: destination.path) {
+      let existing = Bundle(url: destination)
+      let existingVersion =
+        existing?.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "0"
+      let isRunning = Self.isRunning(bundleIdentifier: expectedBundleIdentifier, at: destination)
+      // Signature is only load-bearing for the open-existing verdict; compute it
+      // once here so the decision function stays pure.
+      let signatureValid = Self.hasValidSignature(destination)
+      switch Self.decideExistingDestination(
+        existingBundleIdentifier: existing?.bundleIdentifier,
+        expectedBundleIdentifier: expectedBundleIdentifier,
+        existingVersion: existingVersion, currentVersion: currentVersion,
+        isRunning: isRunning, signatureValid: signatureValid)
+      {
+      case .openExisting:
+        // Same-or-newer, verified: open it, do not downgrade or overwrite.
+        return .success(.existingUsable(destination))
+      case .refuseRunningOlder:
+        // Older + running: never downgrade to it, and a running bundle cannot be
+        // safely overwritten. Keep the current app alive (Codex r2 P1).
+        return .failure(.destinationRunning)
+      case .conflict:
+        // Different app, un-inspectable, or a same-or-newer copy that fails the
+        // signature gate — never delete, overwrite, or launch it (Codex r1 P2).
+        return .failure(.destinationConflict)
+      case .replace:
+        break  // Older + not running → stage + atomic replace below.
+      }
+    }
+
+    // Stage on the SAME volume as the destination so the swap can be atomic.
+    let staging = destParent.appendingPathComponent(
+      ".EnviousWispr.installing-\(UUID().uuidString).app")
+    defer { try? fm.removeItem(at: staging) }
+    do {
+      try fm.copyItem(at: source, to: staging)
+    } catch {
+      let ns = error as NSError
+      if ns.domain == NSCocoaErrorDomain && ns.code == NSFileWriteOutOfSpaceError {
+        return .failure(.diskFull)
+      }
+      return .failure(.stagingCopy)
+    }
+
+    // Structural validation.
+    guard
+      Self.isStructurallyValid(
+        staging, expectedBundleIdentifier: expectedBundleIdentifier, currentVersion: currentVersion)
+    else { return .failure(.stagedBundleInvalid) }
+
+    // A4: code-signature validity + our signing identity, before overwrite.
+    guard Self.hasValidSignature(staging) else { return .failure(.signatureInvalid) }
+
+    // Place it: atomic replace when a destination exists, else move in.
+    do {
+      if fm.fileExists(atPath: destination.path) {
+        _ = try fm.replaceItemAt(destination, withItemAt: staging)
+      } else {
+        try fm.moveItem(at: staging, to: destination)
+      }
+    } catch {
+      return .failure(.unknown)
+    }
+    return .success(.installed(destination))
+  }
+
+  static func isRunning(bundleIdentifier: String, at url: URL) -> Bool {
+    NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+      .contains { $0.bundleURL?.standardizedFileURL == url.standardizedFileURL }
+  }
+
+  static func isStructurallyValid(
+    _ url: URL, expectedBundleIdentifier: String, currentVersion: String
+  ) -> Bool {
+    guard let bundle = Bundle(url: url),
+      bundle.bundleIdentifier == expectedBundleIdentifier,
+      bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String == currentVersion,
+      FileManager.default.isExecutableFile(
+        atPath: url.appendingPathComponent("Contents/MacOS/EnviousWispr").path)
+    else { return false }
+    return true
+  }
+
+  static func hasValidSignature(_ url: URL) -> Bool {
+    var staticCode: SecStaticCode?
+    guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
+      let code = staticCode
+    else { return false }
+    // Validity anchored to Apple's chain AND our Developer ID Team ID.
+    let requirementText =
+      "anchor apple generic and certificate leaf[subject.OU] = \"\(teamID)\"" as CFString
+    var requirement: SecRequirement?
+    guard SecRequirementCreateWithString(requirementText, [], &requirement) == errSecSuccess,
+      let req = requirement
+    else { return false }
+    return SecStaticCodeCheckValidity(code, [], req) == errSecSuccess
+  }
+}
+
+// MARK: - Relauncher
+
+/// Launches the installed copy as a NEW instance carrying the relaunch marker +
+/// attempt ID. Both instances run briefly; the original terminates only after
+/// the handshake confirms (A1).
+public struct NSWorkspaceRelocationRelauncher: RelocationRelaunching {
+  public init() {}
+
+  public func relaunch(_ installedURL: URL, attemptID: String) async -> Bool {
+    let config = NSWorkspace.OpenConfiguration()
+    config.createsNewApplicationInstance = true
+    config.activates = true
+    config.environment = [
+      "EW_RELOCATION_RELAUNCH": "1",
+      "EW_RELOCATION_ATTEMPT_ID": attemptID,
+    ]
+    return await withCheckedContinuation { continuation in
+      NSWorkspace.shared.openApplication(at: installedURL, configuration: config) { app, error in
+        continuation.resume(returning: error == nil && app != nil)
+      }
+    }
+  }
+}
+
+// MARK: - Handshake (ack file)
+
+/// The relaunched child writes a per-attempt ack file; the original polls for
+/// it (signal = file appearance) up to a bounded deadline. Keyed by attempt ID
+/// so a stale ack from a prior attempt can never confirm a new one, and it only
+/// confirms when the child reports healthy AT THE EXACT destination path (A2).
+public struct FileRelocationHandshake: RelocationHandshaking {
+  private let directory: URL
+  private let pollInterval: TimeInterval
+
+  private struct Ack: Codable {
+    let resolvedPath: String
+    let healthy: Bool
+  }
+
+  public init(
+    directory: URL = FileRelocationHandshake.defaultDirectory, pollInterval: TimeInterval = 0.15
+  ) {
+    self.directory = directory
+    self.pollInterval = pollInterval
+  }
+
+  public static var defaultDirectory: URL {
+    let base =
+      FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+      ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+      .appendingPathComponent("Library/Application Support", isDirectory: true)
+    return base.appendingPathComponent("EnviousWispr", isDirectory: true)
+  }
+
+  private func ackURL(_ attemptID: String) -> URL {
+    directory.appendingPathComponent("relocation-ack-\(attemptID).json")
+  }
+
+  public func writeAck(attemptID: String, resolvedPath: String, healthy: Bool) {
+    let fm = FileManager.default
+    try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+    guard let data = try? JSONEncoder().encode(Ack(resolvedPath: resolvedPath, healthy: healthy))
+    else { return }
+    try? data.write(to: ackURL(attemptID), options: .atomic)
+  }
+
+  public func awaitAck(attemptID: String, destination: URL, timeout: TimeInterval) async -> Bool {
+    let url = ackURL(attemptID)
+    let deadline = Date().addingTimeInterval(timeout)
+    defer { try? FileManager.default.removeItem(at: url) }
+    while Date() < deadline {
+      if let data = try? Data(contentsOf: url),
+        let ack = try? JSONDecoder().decode(Ack.self, from: data)
+      {
+        return ack.healthy
+          && ack.resolvedPath == destination.standardizedFileURL.path
+      }
+      try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+    }
+    return false
+  }
+}
+
+// MARK: - Telemetry sink
+
+/// Forwards to `TelemetryService` (same actor) with bounded, low-cardinality
+/// properties. Pre-update recovery stage — deliberately NOT `update.install_*`,
+/// preserving #1447's producer-stage separation.
+@MainActor
+public struct TelemetryServiceRelocationSink: RelocationTelemetrySink {
+  public init() {}
+  public func offered(reason: String, destinationScope: String) {
+    TelemetryService.shared.updateRelocationOffered(
+      reason: reason, destinationScope: destinationScope)
+  }
+  public func accepted(reason: String, destinationScope: String) {
+    TelemetryService.shared.updateRelocationAccepted(
+      reason: reason, destinationScope: destinationScope)
+  }
+  public func declined(reason: String) {
+    TelemetryService.shared.updateRelocationDeclined(reason: reason)
+  }
+  public func failed(reason: String, failureClass: String) {
+    TelemetryService.shared.updateRelocationFailed(reason: reason, failureClass: failureClass)
+  }
+  public func relaunched(reason: String, destinationScope: String, relaunchConfirmed: Bool) {
+    TelemetryService.shared.updateRelocationRelaunched(
+      reason: reason, destinationScope: destinationScope, relaunchConfirmed: relaunchConfirmed)
+  }
+}
+
+// MARK: - Live factory
+
+extension ApplicationRelocationCoordinator {
+  /// Production wiring. `AppLifecycleCoordinator` constructs this once via
+  /// `WisprBootstrapper` and calls `evaluateAndOfferIfNeeded()` on launch.
+  @MainActor
+  public static func live() -> ApplicationRelocationCoordinator {
+    ApplicationRelocationCoordinator(
+      env: .live(),
+      detector: ApplicationLocationDetector(),
+      suppression: UserDefaultsRelocationSuppressionStore(),
+      presenter: CenteredRelocationPresenter(),
+      mover: FileManagerApplicationMover(),
+      relauncher: NSWorkspaceRelocationRelauncher(),
+      handshake: FileRelocationHandshake(),
+      telemetry: TelemetryServiceRelocationSink(),
+      terminate: { NSApp.terminate(nil) },
+      flushTelemetry: { TelemetryService.shared.flushTelemetry(reason: .relocation) }
+    )
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
@@ -315,10 +315,17 @@ public final class ApplicationRelocationCoordinator {
     // (detection STILL runs — the marker suppresses a second dialog, never
     // detection, so a failed move cannot masquerade as healthy) and return.
     if let attemptID = env.relaunchAttemptID {
+      let healthy = state == .healthy
       handshake.writeAck(
         attemptID: attemptID,
         resolvedPath: env.bundleURL.standardizedFileURL.path,
-        healthy: state == .healthy)
+        healthy: healthy)
+      // If the move did not clear the blocking location, the original process
+      // stays alive as the authoritative copy (its handshake fails). Quit this
+      // redundant child rather than leave two blocked instances running (cloud
+      // Codex review #1490). Healthy child lives on as the new app; the two
+      // branches are mutually exclusive, so there is never zero or two copies.
+      if !healthy { terminate() }
       return
     }
 

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
@@ -96,15 +96,21 @@ public enum RelocationFailure: String, Error, Sendable {
 
 /// What the mover did with the chosen destination.
 public enum InstallResolution: Equatable, Sendable {
-  /// We staged, validated, and placed our own copy at this URL.
+  /// We staged, validated, and placed our own copy at this URL → launch fresh +
+  /// handshake.
   case installed(URL)
-  /// A same-identity, same-or-newer healthy copy already existed here; the
-  /// coordinator should simply open it rather than overwrite.
+  /// A same-identity, same-or-newer healthy copy already exists here but is NOT
+  /// running → launch it fresh + handshake.
   case existingUsable(URL)
+  /// A same-identity, same-or-newer healthy copy is ALREADY RUNNING here →
+  /// activate that instance and terminate self; never spawn a duplicate, and no
+  /// handshake is needed (the copy is verified and already live). Cloud Codex
+  /// review #1490.
+  case existingRunning(URL)
 
   public var url: URL {
     switch self {
-    case .installed(let u), .existingUsable(let u): return u
+    case .installed(let u), .existingUsable(let u), .existingRunning(let u): return u
     }
   }
 }
@@ -192,6 +198,9 @@ public protocol ApplicationMoving: Sendable {
 /// Launches the installed copy with the relaunch marker + attempt ID.
 public protocol RelocationRelaunching: Sendable {
   func relaunch(_ installedURL: URL, attemptID: String) async -> Bool
+  /// Bring an ALREADY-running instance at this URL to the front (no new
+  /// instance). Returns false if no such running instance is found.
+  func activateRunning(_ url: URL) async -> Bool
 }
 
 /// Waits (signal-based, bounded) for the relaunched copy to write its health
@@ -396,10 +405,30 @@ public final class ApplicationRelocationCoordinator {
       presenter.dismissProgress()
       telemetry.failed(reason: reason, failureClass: failure.rawValue)
       presenter.showFailure(failure)
+    case .success(.existingRunning(let url)):
+      // A verified same-or-newer copy is already running: bring it to the front
+      // and terminate this translocated duplicate. No new instance, no
+      // handshake (cloud Codex review #1490).
+      await activateAndHandOff(reason: reason, destination: destination, runningURL: url)
     case .success(let resolution):
       await relaunchAndHandOff(
         reason: reason, destination: destination, installedURL: resolution.url)
     }
+  }
+
+  /// The good copy is already running: activate it, then terminate self. If it
+  /// cannot be activated, keep the current process alive and report failure.
+  private func activateAndHandOff(reason: String, destination: Destination, runningURL: URL) async {
+    guard await relauncher.activateRunning(runningURL) else {
+      presenter.dismissProgress()
+      telemetry.failed(reason: reason, failureClass: RelocationFailure.relaunchRejected.rawValue)
+      presenter.showFailure(.relaunchRejected)
+      return
+    }
+    telemetry.relaunched(
+      reason: reason, destinationScope: destination.scope, relaunchConfirmed: true)
+    flushTelemetry()
+    terminate()
   }
 
   /// Relaunch, then wait for the new instance's health ack BEFORE terminating

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator.swift
@@ -1,0 +1,436 @@
+import AppKit
+import Darwin
+import EnviousWisprServices
+import Foundation
+import Security
+
+// Issue #1451: one-click recovery from macOS App Translocation.
+//
+// When macOS runs a still-quarantined EnviousWispr from a randomized read-only
+// mount (launched off a DMG or from ~/Downloads without being moved in Finder),
+// Sparkle aborts before it even fetches the appcast — 14 production users could
+// never auto-update and got no explanation. This coordinator detects only the
+// conditions Sparkle itself treats as update-blocking, offers a one-click move
+// into a writable Applications folder, relaunches, and — critically — waits for
+// the newly launched copy to hand back a health confirmation before the current
+// (only known-good) process terminates. Every failure leaves the current
+// process usable: this is a launch-time LIMB, never a prerequisite for menu-bar
+// setup, hotkeys, dictation, or onboarding.
+//
+// Design + amendment rationale (handshake A1, presentation-only marker A2,
+// atomic replace A3, signature validation A4, bounded flush A5, no original
+// deletion A6, honest-scope A7, quarantine untouched): see
+// docs/feature-requests/issue-1451-2026-07-10-app-translocation-recovery.md.
+
+// MARK: - Location state
+
+/// Whether the current bundle sits where Sparkle's pre-appcast location gate
+/// would refuse to update. Mirrors pinned Sparkle 2.9.3 `SUHost` logic
+/// (`SUHost.m:174` read-only, `:185` translocated). A Sparkle upgrade requires
+/// re-validating this mapping (plan A7).
+public enum ApplicationLocationState: Equatable, Sendable {
+  /// Bundle is on a writable, non-translocated volume. Sparkle can update.
+  case healthy
+  /// Bundle path is under `/AppTranslocation/` (Sparkle code 1005).
+  case translocated
+  /// Bundle volume is `MNT_RDONLY`, e.g. a mounted DMG (Sparkle code 1003).
+  case readOnlyVolume
+  /// `statfs` failed. Fail open — never block launch on a detector error.
+  case detectionFailed
+
+  /// True only for the two conditions that actually block Sparkle updates.
+  public var isUpdateBlocking: Bool {
+    self == .translocated || self == .readOnlyVolume
+  }
+
+  /// Bounded, low-cardinality telemetry reason. `nil` when not update-blocking.
+  public var reasonLabel: String? {
+    switch self {
+    case .translocated: return "translocated"
+    case .readOnlyVolume: return "read_only_volume"
+    case .healthy, .detectionFailed: return nil
+    }
+  }
+}
+
+/// Pure, injectable detector. Deliberately mirrors Sparkle's own observable
+/// conditions rather than calling Sparkle's internal `SUHost` or the private
+/// `SecTranslocate*` SPI (no public SDK header, no macOS 14–26 availability
+/// contract).
+public struct ApplicationLocationDetector: Sendable {
+  public init() {}
+
+  public func state(for bundleURL: URL) -> ApplicationLocationState {
+    let standardizedPath = bundleURL.standardizedFileURL.path
+    // Path-segment match, not substring — a user folder literally named
+    // "AppTranslocation" elsewhere in the path must not false-positive.
+    if standardizedPath.split(separator: "/").contains("AppTranslocation") {
+      return .translocated
+    }
+    var fileSystem = statfs()
+    let ok = bundleURL.path.withCString { statfs($0, &fileSystem) }
+    guard ok == 0 else { return .detectionFailed }
+    if (UInt32(fileSystem.f_flags) & UInt32(MNT_RDONLY)) != 0 {
+      return .readOnlyVolume
+    }
+    return .healthy
+  }
+}
+
+// MARK: - Outcomes
+
+/// Bounded failure classification for UX copy, logs, and telemetry. No raw
+/// paths, usernames, or free-form filesystem detail crosses this boundary.
+public enum RelocationFailure: String, Error, Sendable {
+  case destinationCreation
+  case destinationRunning
+  case stagingCopy
+  case stagedBundleInvalid
+  case signatureInvalid
+  case destinationConflict
+  case diskFull
+  case relaunchRejected
+  case relaunchUnconfirmed
+  case unknown
+}
+
+/// What the mover did with the chosen destination.
+public enum InstallResolution: Equatable, Sendable {
+  /// We staged, validated, and placed our own copy at this URL.
+  case installed(URL)
+  /// A same-identity, same-or-newer healthy copy already existed here; the
+  /// coordinator should simply open it rather than overwrite.
+  case existingUsable(URL)
+
+  public var url: URL {
+    switch self {
+    case .installed(let u), .existingUsable(let u): return u
+    }
+  }
+}
+
+/// Terminal result of one launch-time evaluation.
+public enum ApplicationRelocationOutcome: Equatable, Sendable {
+  case notNeeded
+  case suppressed
+  case declined
+  case relaunched(destination: URL)
+  case continuedAfterFailure(RelocationFailure)
+}
+
+/// User's answer to the one-click prompt.
+public enum RelocationChoice: Equatable, Sendable {
+  case move
+  case notNow
+}
+
+// MARK: - Seams
+
+/// Launch-time facts. Injected so tests never read the real process bundle or
+/// environment.
+public struct RelocationEnvironment: Sendable {
+  public let bundleURL: URL
+  public let bundleIdentifier: String
+  public let currentVersion: String
+  /// Non-nil when THIS process is the relaunched copy (A1/A2): the attempt ID
+  /// the original passed via `EW_RELOCATION_ATTEMPT_ID`. Presence means "report
+  /// your health back, do not prompt."
+  public let relaunchAttemptID: String?
+
+  public init(
+    bundleURL: URL, bundleIdentifier: String, currentVersion: String,
+    relaunchAttemptID: String?
+  ) {
+    self.bundleURL = bundleURL
+    self.bundleIdentifier = bundleIdentifier
+    self.currentVersion = currentVersion
+    self.relaunchAttemptID = relaunchAttemptID
+  }
+
+  /// Production environment read from the running process.
+  @MainActor public static func live() -> RelocationEnvironment {
+    let env = ProcessInfo.processInfo.environment
+    let isRelaunch = env["EW_RELOCATION_RELAUNCH"] == "1"
+    let attemptID = isRelaunch ? env["EW_RELOCATION_ATTEMPT_ID"] : nil
+    let version =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
+    return RelocationEnvironment(
+      bundleURL: Bundle.main.bundleURL,
+      bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.enviouswispr.app",
+      currentVersion: version,
+      relaunchAttemptID: attemptID)
+  }
+}
+
+/// Persists the "Not Now" decline so healthy users are not nagged. Backed by
+/// `UserDefaults` in production; a fake in tests.
+public protocol RelocationSuppressionStore: Sendable {
+  func lastDecline() -> (at: Date, version: String)?
+  func recordDecline(at: Date, version: String)
+  func clear()
+}
+
+/// Presents the one-click prompt and (later) progress/failure surfaces. Live
+/// impl uses `NSAlert`; tests inject a scripted choice.
+@MainActor public protocol RelocationPresenting {
+  func present() async -> RelocationChoice
+  func showProgress()
+  func dismissProgress()
+  func showFailure(_ failure: RelocationFailure)
+}
+
+/// Copies + installs the bundle into the destination, resolving any existing
+/// copy safely (atomic replace / backup-restore, never Trash-first). Runs its
+/// blocking filesystem work off the main actor.
+public protocol ApplicationMoving: Sendable {
+  func install(
+    source: URL, destination: URL,
+    expectedBundleIdentifier: String, currentVersion: String
+  ) async -> Result<InstallResolution, RelocationFailure>
+}
+
+/// Launches the installed copy with the relaunch marker + attempt ID.
+public protocol RelocationRelaunching: Sendable {
+  func relaunch(_ installedURL: URL, attemptID: String) async -> Bool
+}
+
+/// Waits (signal-based, bounded) for the relaunched copy to write its health
+/// ack. Returns true only when the new instance reports healthy at the exact
+/// destination for THIS attempt.
+public protocol RelocationHandshaking: Sendable {
+  func awaitAck(attemptID: String, destination: URL, timeout: TimeInterval) async -> Bool
+  /// Called by the relaunched child to report its own health (A2).
+  func writeAck(attemptID: String, resolvedPath: String, healthy: Bool)
+}
+
+/// Bounded `update.relocation_*` telemetry. Live impl forwards to
+/// `TelemetryService` (also `@MainActor`) synchronously; tests record.
+@MainActor public protocol RelocationTelemetrySink {
+  func offered(reason: String, destinationScope: String)
+  func accepted(reason: String, destinationScope: String)
+  func declined(reason: String)
+  func failed(reason: String, failureClass: String)
+  func relaunched(reason: String, destinationScope: String, relaunchConfirmed: Bool)
+}
+
+// MARK: - Coordinator
+
+/// App-shell, process-lifecycle limb (owner of the whole relocation policy;
+/// `AppLifecycleCoordinator` only calls it — plan §3b/§3c). Single authority for
+/// detection, decline cadence, destination choice, move state, conflict
+/// handling, the relaunch handshake, and termination ordering.
+@MainActor
+public final class ApplicationRelocationCoordinator {
+  private let env: RelocationEnvironment
+  private let detector: ApplicationLocationDetector
+  private let suppression: RelocationSuppressionStore
+  private let presenter: RelocationPresenting
+  private let mover: any ApplicationMoving
+  private let relauncher: any RelocationRelaunching
+  private let handshake: any RelocationHandshaking
+  private let telemetry: any RelocationTelemetrySink
+  private let now: @Sendable () -> Date
+  private let terminate: @MainActor () -> Void
+  private let handshakeTimeout: TimeInterval
+  /// A5: non-blocking, best-effort flush called just before terminate. PostHog's
+  /// flush only schedules delivery and unsent events persist to disk, so this
+  /// never delays the handoff and any straggler delivers from the relocated
+  /// copy — strictly better than a blocking flush with a timeout.
+  private let flushTelemetry: @MainActor () -> Void
+  private let makeAttemptID: @Sendable () -> String
+
+  /// Re-prompt cadence: a "Not Now" is honored for seven days or until the
+  /// bundle version changes, whichever comes first.
+  static let declineCooldown: TimeInterval = 7 * 24 * 60 * 60
+
+  private var moveInProgress = false
+
+  /// The scheduled presentation/move task from the most recent
+  /// `evaluateAndOfferIfNeeded()`. Exposed so tests can deterministically await
+  /// the full flow; production never reads it.
+  private(set) var pendingWork: Task<Void, Never>?
+
+  public init(
+    env: RelocationEnvironment,
+    detector: ApplicationLocationDetector,
+    suppression: RelocationSuppressionStore,
+    presenter: RelocationPresenting,
+    mover: any ApplicationMoving,
+    relauncher: any RelocationRelaunching,
+    handshake: any RelocationHandshaking,
+    telemetry: any RelocationTelemetrySink,
+    now: @escaping @Sendable () -> Date = Date.init,
+    terminate: @escaping @MainActor () -> Void,
+    handshakeTimeout: TimeInterval = 8,
+    flushTelemetry: @escaping @MainActor () -> Void = {},
+    makeAttemptID: @escaping @Sendable () -> String = { UUID().uuidString }
+  ) {
+    self.env = env
+    self.detector = detector
+    self.suppression = suppression
+    self.presenter = presenter
+    self.mover = mover
+    self.relauncher = relauncher
+    self.handshake = handshake
+    self.telemetry = telemetry
+    self.now = now
+    self.terminate = terminate
+    self.handshakeTimeout = handshakeTimeout
+    self.flushTelemetry = flushTelemetry
+    self.makeAttemptID = makeAttemptID
+  }
+
+  /// Called once from `AppLifecycleCoordinator.runDidFinishLaunching()`. Returns
+  /// immediately after scheduling any presentation; never blocks launch, copies,
+  /// shells, hits the network, or waits for a relaunch inline.
+  public func evaluateAndOfferIfNeeded() {
+    var state = detector.state(for: env.bundleURL)
+
+    #if DEBUG
+      // DEBUG-only preview/UAT trigger: force a blocking state so the prompt
+      // renders on an ordinary (healthy) dev launch. Compiled out of release, so
+      // it can never affect shipped behavior. A real move is still gated by the
+      // signature check, which a self-signed dev build fails — so this previews
+      // the cards without risking an actual relocation.
+      if let forced = ProcessInfo.processInfo.environment["EW_RELOCATION_FORCE_STATE"] {
+        switch forced {
+        case "translocated": state = .translocated
+        case "readOnlyVolume": state = .readOnlyVolume
+        case "healthy": state = .healthy
+        default: break
+        }
+      }
+    #endif
+
+    // A1/A2: this process is the relaunched child. Report health via the ack
+    // (detection STILL runs — the marker suppresses a second dialog, never
+    // detection, so a failed move cannot masquerade as healthy) and return.
+    if let attemptID = env.relaunchAttemptID {
+      handshake.writeAck(
+        attemptID: attemptID,
+        resolvedPath: env.bundleURL.standardizedFileURL.path,
+        healthy: state == .healthy)
+      return
+    }
+
+    guard state.isUpdateBlocking else {
+      // A healthy launch clears any stale decline marker so a user who later
+      // regresses is offered fresh.
+      suppression.clear()
+      return
+    }
+
+    guard !moveInProgress, shouldOffer(now: now()) else { return }
+    guard let reason = state.reasonLabel else { return }
+
+    let destination = Self.chooseDestination(appName: env.bundleURL.lastPathComponent)
+    telemetry.offered(reason: reason, destinationScope: destination.scope)
+
+    // Present on the next main-loop turn: the app can become active first, and
+    // launch continues without awaiting this.
+    pendingWork = Task { @MainActor [weak self] in
+      await self?.presentAndHandle(state: state, destination: destination)
+    }
+  }
+
+  // MARK: Cadence
+
+  /// True when we may show the prompt: never declined, or the decline is stale
+  /// (>7d) or from a different version. No permanent "don't ask again" — that
+  /// would knowingly leave updates broken forever.
+  func shouldOffer(now: Date) -> Bool {
+    guard let decline = suppression.lastDecline() else { return true }
+    if decline.version != env.currentVersion { return true }
+    return now.timeIntervalSince(decline.at) >= Self.declineCooldown
+  }
+
+  // MARK: Destination
+
+  struct Destination: Sendable {
+    let url: URL
+    let scope: String  // "system_applications" | "user_applications"
+  }
+
+  /// `/Applications` when directly writable by the current user (admins), else
+  /// `~/Applications` (standard users). Never requests admin credentials.
+  static func chooseDestination(appName: String) -> Destination {
+    let system = URL(fileURLWithPath: "/Applications", isDirectory: true)
+    if FileManager.default.isWritableFile(atPath: system.path) {
+      return Destination(url: system.appendingPathComponent(appName), scope: "system_applications")
+    }
+    let userApps =
+      FileManager.default.urls(for: .applicationDirectory, in: .userDomainMask).first
+      ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+      .appendingPathComponent("Applications", isDirectory: true)
+    return Destination(
+      url: userApps.appendingPathComponent(appName), scope: "user_applications")
+  }
+
+  // MARK: Flow
+
+  private func presentAndHandle(state: ApplicationLocationState, destination: Destination) async {
+    guard let reason = state.reasonLabel else { return }
+    switch await presenter.present() {
+    case .notNow:
+      suppression.recordDecline(at: now(), version: env.currentVersion)
+      telemetry.declined(reason: reason)
+    case .move:
+      telemetry.accepted(reason: reason, destinationScope: destination.scope)
+      await performMove(reason: reason, destination: destination)
+    }
+  }
+
+  private func performMove(reason: String, destination: Destination) async {
+    guard !moveInProgress else { return }
+    moveInProgress = true
+    defer { moveInProgress = false }
+
+    presenter.showProgress()
+
+    let result = await mover.install(
+      source: env.bundleURL, destination: destination.url,
+      expectedBundleIdentifier: env.bundleIdentifier, currentVersion: env.currentVersion)
+
+    switch result {
+    case .failure(let failure):
+      presenter.dismissProgress()
+      telemetry.failed(reason: reason, failureClass: failure.rawValue)
+      presenter.showFailure(failure)
+    case .success(let resolution):
+      await relaunchAndHandOff(
+        reason: reason, destination: destination, installedURL: resolution.url)
+    }
+  }
+
+  /// Relaunch, then wait for the new instance's health ack BEFORE terminating
+  /// the current (only known-good) process. NSWorkspace acceptance alone is not
+  /// a sufficient handoff boundary (A1).
+  private func relaunchAndHandOff(reason: String, destination: Destination, installedURL: URL) async
+  {
+    let attemptID = makeAttemptID()
+    guard await relauncher.relaunch(installedURL, attemptID: attemptID) else {
+      presenter.dismissProgress()
+      telemetry.failed(reason: reason, failureClass: RelocationFailure.relaunchRejected.rawValue)
+      presenter.showFailure(.relaunchRejected)
+      return
+    }
+
+    let confirmed = await handshake.awaitAck(
+      attemptID: attemptID, destination: installedURL, timeout: handshakeTimeout)
+    guard confirmed else {
+      // The new copy never confirmed healthy at the destination. Keep the
+      // current process alive rather than strand the user with no working app.
+      presenter.dismissProgress()
+      telemetry.failed(
+        reason: reason, failureClass: RelocationFailure.relaunchUnconfirmed.rawValue)
+      presenter.showFailure(.relaunchUnconfirmed)
+      return
+    }
+
+    telemetry.relaunched(
+      reason: reason, destinationScope: destination.scope, relaunchConfirmed: true)
+    // A5: best-effort, non-blocking flush; never delays the handoff.
+    flushTelemetry()
+    terminate()
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/UpdateCoordinator.swift
@@ -310,8 +310,9 @@ final class UpdateCoordinator {
       defaults.removeObject(forKey: Self.kLastAttemptSource)
     }
 
-    // Bundle version compare via the service's helper.
-    let cmp = service.compareVersions(currentBundleVersion, attemptVersion)
+    // Bundle version compare via the single version-comparison authority
+    // (#1451: now `static` on the service).
+    let cmp = UpdateAvailabilityService.compareVersions(currentBundleVersion, attemptVersion)
     if cmp == 0 {
       // Bundle matches the attempted version exactly → install completed.
       return .completed(version: attemptVersion, source: attemptSource)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -639,6 +639,9 @@ public final class WisprBootstrapper {
       )
     )
 
+    // #1451: App Translocation recovery limb, driven from the launch sequence.
+    let applicationRelocationCoordinator = ApplicationRelocationCoordinator.live()
+
     // PR-B.4 of #763: process-lifecycle home. Constructed last. It receives the
     // 10 specific homes it reads.
     let appLifecycleCoordinator = AppLifecycleCoordinator(
@@ -659,6 +662,7 @@ public final class WisprBootstrapper {
       menuBarController: menuBarController,
       appWindowCoordinator: appWindowCoordinator,
       hotkeyService: hotkeyService,
+      applicationRelocationCoordinator: applicationRelocationCoordinator,
       onboardingProgress: onboardingProgress
     )
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1520,6 +1520,81 @@ public final class TelemetryService {
     )
   }
 
+  // MARK: - App relocation (issue #1451)
+  //
+  // Pre-update recovery stage: the app is running from a translocated /
+  // read-only location that blocks Sparkle before the appcast is fetched. These
+  // are deliberately NOT `update.install_*` — that name stays reserved for real
+  // install-stage failures (#1447 producer-stage separation). All properties are
+  // bounded, low-cardinality; no paths, usernames, or free-form strings.
+  //   reason ∈ {translocated, read_only_volume}
+  //   destination_scope ∈ {system_applications, user_applications}
+  //   failure_class = RelocationFailure raw value
+
+  public func updateRelocationOffered(reason: String, destinationScope: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.relocation_offered",
+          stringProps: ["reason": reason, "destination_scope": destinationScope]))
+    #endif
+    PostHogSDK.shared.capture(
+      "update.relocation_offered",
+      properties: ["reason": reason, "destination_scope": destinationScope])
+  }
+
+  public func updateRelocationAccepted(reason: String, destinationScope: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.relocation_accepted",
+          stringProps: ["reason": reason, "destination_scope": destinationScope]))
+    #endif
+    PostHogSDK.shared.capture(
+      "update.relocation_accepted",
+      properties: ["reason": reason, "destination_scope": destinationScope])
+  }
+
+  public func updateRelocationDeclined(reason: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.relocation_declined", stringProps: ["reason": reason]))
+    #endif
+    PostHogSDK.shared.capture("update.relocation_declined", properties: ["reason": reason])
+  }
+
+  public func updateRelocationFailed(reason: String, failureClass: String) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.relocation_failed",
+          stringProps: ["reason": reason, "failure_class": failureClass]))
+    #endif
+    PostHogSDK.shared.capture(
+      "update.relocation_failed",
+      properties: ["reason": reason, "failure_class": failureClass])
+  }
+
+  public func updateRelocationRelaunched(
+    reason: String, destinationScope: String, relaunchConfirmed: Bool
+  ) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.relocation_relaunched",
+          stringProps: ["reason": reason, "destination_scope": destinationScope],
+          boolProps: ["relaunch_confirmed": relaunchConfirmed]))
+    #endif
+    PostHogSDK.shared.capture(
+      "update.relocation_relaunched",
+      properties: [
+        "reason": reason,
+        "destination_scope": destinationScope,
+        "relaunch_confirmed": relaunchConfirmed,
+      ])
+  }
+
   /// Issue #958: a proactive launch/foreground trigger evaluated, whether it
   /// actually fired a background check, and why. Emitted on EVERY return path.
   /// Bounded cardinality: `trigger ∈ {launch, foreground}`, `fired ∈ {true,false}`,
@@ -1744,6 +1819,10 @@ public final class TelemetryService {
   public enum FlushReason: String {
     case updateInstall = "update_install"
     case appTerminate = "app_terminate"
+    // #1451: the original process is about to terminate after handing off to the
+    // relocated copy. Non-blocking; unsent events persist to disk and deliver
+    // from the relaunched instance.
+    case relocation = "relocation"
   }
 
   /// Late-bound context for a flush, supplied by a provider closure (mirrors

--- a/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
+++ b/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
@@ -101,7 +101,7 @@ public final class UpdateAvailabilityService {
     // While `.resolving`, only react to a strictly-newer version.
     if case .resolving = state {
       if let inflight = persistedPending(),
-        compareVersions(update.versionString, inflight.versionString) <= 0
+        Self.compareVersions(update.versionString, inflight.versionString) <= 0
       {
         return
       }
@@ -192,7 +192,7 @@ public final class UpdateAvailabilityService {
 
   func rehydratePendingIfNewer() {
     guard let pending = persistedPending() else { return }
-    let cmp = compareVersions(pending.versionString, currentBundleVersion)
+    let cmp = Self.compareVersions(pending.versionString, currentBundleVersion)
     if cmp > 0 {
       state = .available(pending)
       // Issue #739: post-#739 no in-app caller invokes dismissForSession, so
@@ -214,7 +214,13 @@ public final class UpdateAvailabilityService {
   /// Production tags are enforced `^[0-9]+\.[0-9]+\.[0-9]+$` per release.yml,
   /// so a simple split-by-dot integer compare is sufficient.
   /// Returns: -1 if a < b, 0 if equal, +1 if a > b.
-  public func compareVersions(_ a: String, _ b: String) -> Int {
+  ///
+  /// #1451: promoted to `static` so it is the single version-comparison
+  /// authority — `ApplicationMover` reuses it to decide older-vs-newer at the
+  /// relocation destination without needing an `UpdateAvailabilityService`
+  /// instance. Pure function; no instance state was ever read. `nonisolated` so
+  /// off-actor callers (the relocation mover) can reuse it.
+  nonisolated public static func compareVersions(_ a: String, _ b: String) -> Int {
     let aParts = a.split(separator: ".").map { Int($0) ?? 0 }
     let bParts = b.split(separator: ".").map { Int($0) ?? 0 }
     let count = max(aParts.count, bParts.count)

--- a/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
@@ -1,0 +1,393 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1451 — App Translocation recovery. Pure-policy + flow tests with fakes for
+/// every side-effecting seam. The detector is exercised through crafted bundle
+/// URLs (a `/AppTranslocation/` path segment forces `.translocated` before
+/// `statfs`; a writable existing dir is `.healthy`).
+@MainActor
+@Suite("ApplicationRelocationCoordinator")
+struct ApplicationRelocationCoordinatorTests {
+
+  // MARK: Fakes
+
+  final class FakeSuppression: RelocationSuppressionStore, @unchecked Sendable {
+    var stored: (at: Date, version: String)?
+    var clearCount = 0
+    func lastDecline() -> (at: Date, version: String)? { stored }
+    func recordDecline(at: Date, version: String) { stored = (at, version) }
+    func clear() {
+      clearCount += 1
+      stored = nil
+    }
+  }
+
+  @MainActor final class FakePresenter: RelocationPresenting {
+    var choice: RelocationChoice = .move
+    var progressShown = 0
+    var progressDismissed = 0
+    var failures: [RelocationFailure] = []
+    func present() async -> RelocationChoice { choice }
+    func showProgress() { progressShown += 1 }
+    func dismissProgress() { progressDismissed += 1 }
+    func showFailure(_ failure: RelocationFailure) { failures.append(failure) }
+  }
+
+  final class FakeMover: ApplicationMoving, @unchecked Sendable {
+    var result: Result<InstallResolution, RelocationFailure>
+    private(set) var calls = 0
+    init(_ result: Result<InstallResolution, RelocationFailure>) { self.result = result }
+    func install(
+      source: URL, destination: URL, expectedBundleIdentifier: String, currentVersion: String
+    ) async -> Result<InstallResolution, RelocationFailure> {
+      calls += 1
+      return result
+    }
+  }
+
+  final class FakeRelauncher: RelocationRelaunching, @unchecked Sendable {
+    var success = true
+    private(set) var lastAttemptID: String?
+    func relaunch(_ installedURL: URL, attemptID: String) async -> Bool {
+      lastAttemptID = attemptID
+      return success
+    }
+  }
+
+  final class FakeHandshake: RelocationHandshaking, @unchecked Sendable {
+    var ackHealthy = true
+    private(set) var writes: [(attemptID: String, path: String, healthy: Bool)] = []
+    func awaitAck(attemptID: String, destination: URL, timeout: TimeInterval) async -> Bool {
+      ackHealthy
+    }
+    func writeAck(attemptID: String, resolvedPath: String, healthy: Bool) {
+      writes.append((attemptID, resolvedPath, healthy))
+    }
+  }
+
+  @MainActor final class FakeTelemetry: RelocationTelemetrySink {
+    var offeredEvents: [(String, String)] = []
+    var acceptedEvents: [(String, String)] = []
+    var declinedEvents: [String] = []
+    var failedEvents: [(String, String)] = []
+    var relaunchedEvents: [(String, String, Bool)] = []
+    func offered(reason: String, destinationScope: String) {
+      offeredEvents.append((reason, destinationScope))
+    }
+    func accepted(reason: String, destinationScope: String) {
+      acceptedEvents.append((reason, destinationScope))
+    }
+    func declined(reason: String) { declinedEvents.append(reason) }
+    func failed(reason: String, failureClass: String) {
+      failedEvents.append((reason, failureClass))
+    }
+    func relaunched(reason: String, destinationScope: String, relaunchConfirmed: Bool) {
+      relaunchedEvents.append((reason, destinationScope, relaunchConfirmed))
+    }
+  }
+
+  final class TerminateBox: @unchecked Sendable { var count = 0 }
+
+  // MARK: Fixtures
+
+  static let translocatedURL = URL(
+    fileURLWithPath: "/private/var/folders/ab/AppTranslocation/XYZ/d/EnviousWispr.app")
+  static var healthyURL: URL { URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true) }
+
+  struct Harness {
+    let coordinator: ApplicationRelocationCoordinator
+    let suppression: FakeSuppression
+    let presenter: FakePresenter
+    let mover: FakeMover
+    let relauncher: FakeRelauncher
+    let handshake: FakeHandshake
+    let telemetry: FakeTelemetry
+    let terminate: TerminateBox
+  }
+
+  static func makeHarness(
+    bundleURL: URL,
+    version: String = "2.3.0",
+    relaunchAttemptID: String? = nil,
+    moverResult: Result<InstallResolution, RelocationFailure> = .success(
+      .installed(URL(fileURLWithPath: "/Applications/EnviousWispr.app"))),
+    now: Date = Date(timeIntervalSince1970: 1_000_000)
+  ) -> Harness {
+    let suppression = FakeSuppression()
+    let presenter = FakePresenter()
+    let mover = FakeMover(moverResult)
+    let relauncher = FakeRelauncher()
+    let handshake = FakeHandshake()
+    let telemetry = FakeTelemetry()
+    let terminate = TerminateBox()
+    let coordinator = ApplicationRelocationCoordinator(
+      env: RelocationEnvironment(
+        bundleURL: bundleURL, bundleIdentifier: "com.enviouswispr.app",
+        currentVersion: version, relaunchAttemptID: relaunchAttemptID),
+      detector: ApplicationLocationDetector(),
+      suppression: suppression,
+      presenter: presenter,
+      mover: mover,
+      relauncher: relauncher,
+      handshake: handshake,
+      telemetry: telemetry,
+      now: { now },
+      terminate: { terminate.count += 1 },
+      makeAttemptID: { "attempt-1" })
+    return Harness(
+      coordinator: coordinator, suppression: suppression, presenter: presenter, mover: mover,
+      relauncher: relauncher, handshake: handshake, telemetry: telemetry, terminate: terminate)
+  }
+
+  // MARK: Detection
+
+  @Test("detector: /AppTranslocation/ path segment is translocated")
+  func detectTranslocated() {
+    #expect(ApplicationLocationDetector().state(for: Self.translocatedURL) == .translocated)
+  }
+
+  @Test("detector: writable existing dir is healthy")
+  func detectHealthy() {
+    #expect(ApplicationLocationDetector().state(for: Self.healthyURL) == .healthy)
+  }
+
+  @Test("detector: non-existent path fails open, never blocking")
+  func detectFailsOpen() {
+    let missing = URL(fileURLWithPath: "/no/such/path/\(UUID().uuidString)/EnviousWispr.app")
+    let state = ApplicationLocationDetector().state(for: missing)
+    #expect(state == .detectionFailed)
+    #expect(state.isUpdateBlocking == false)
+  }
+
+  // MARK: Destination
+
+  @Test("destination: keeps app name and a bounded scope")
+  func destinationScope() {
+    let dest = ApplicationRelocationCoordinator.chooseDestination(appName: "EnviousWispr.app")
+    #expect(dest.url.lastPathComponent == "EnviousWispr.app")
+    #expect(["system_applications", "user_applications"].contains(dest.scope))
+  }
+
+  // MARK: Cadence
+
+  @Test("cadence: never declined -> offer")
+  func cadenceFresh() {
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL)
+    #expect(h.coordinator.shouldOffer(now: Date(timeIntervalSince1970: 1_000_000)))
+  }
+
+  @Test("cadence: declined yesterday, same version -> suppress")
+  func cadenceRecentDecline() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL, version: "2.3.0", now: now)
+    h.suppression.stored = (at: now.addingTimeInterval(-24 * 60 * 60), version: "2.3.0")
+    #expect(h.coordinator.shouldOffer(now: now) == false)
+  }
+
+  @Test("cadence: declined 8 days ago -> offer again")
+  func cadenceStaleDecline() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL, version: "2.3.0", now: now)
+    h.suppression.stored = (at: now.addingTimeInterval(-8 * 24 * 60 * 60), version: "2.3.0")
+    #expect(h.coordinator.shouldOffer(now: now))
+  }
+
+  @Test("cadence: version changed -> offer even within 7 days")
+  func cadenceVersionChanged() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL, version: "2.4.0", now: now)
+    h.suppression.stored = (at: now.addingTimeInterval(-60 * 60), version: "2.3.0")
+    #expect(h.coordinator.shouldOffer(now: now))
+  }
+
+  // MARK: Healthy launch
+
+  @Test("healthy launch: no prompt, clears stale decline, no telemetry")
+  func healthyLaunchClears() async {
+    let h = Self.makeHarness(bundleURL: Self.healthyURL)
+    h.suppression.stored = (at: Date(timeIntervalSince1970: 1), version: "old")
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.suppression.clearCount == 1)
+    #expect(h.telemetry.offeredEvents.isEmpty)
+    #expect(h.presenter.progressShown == 0)
+  }
+
+  // MARK: Relaunched-child ack path (A2)
+
+  @Test("relaunch child: healthy destination writes healthy ack, never prompts")
+  func childAckHealthy() async {
+    let h = Self.makeHarness(bundleURL: Self.healthyURL, relaunchAttemptID: "attempt-1")
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.handshake.writes.count == 1)
+    #expect(h.handshake.writes.first?.healthy == true)
+    #expect(h.telemetry.offeredEvents.isEmpty)  // no prompt on the child path
+    #expect(h.presenter.progressShown == 0)
+  }
+
+  @Test("relaunch child: still-blocked destination writes UNhealthy ack (A2 no masking)")
+  func childAckStillBad() async {
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL, relaunchAttemptID: "attempt-1")
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.handshake.writes.count == 1)
+    #expect(h.handshake.writes.first?.healthy == false)
+  }
+
+  // MARK: Decline
+
+  @Test("Not Now: records decline + declined telemetry, no move")
+  func declineFlow() async {
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL)
+    h.presenter.choice = .notNow
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.offeredEvents.count == 1)
+    #expect(h.telemetry.declinedEvents == ["translocated"])
+    #expect(h.suppression.stored?.version == "2.3.0")
+    #expect(h.mover.calls == 0)
+    #expect(h.terminate.count == 0)
+  }
+
+  // MARK: Move success + handshake (A1)
+
+  @Test("Move accepted -> install -> ack healthy -> relaunched telemetry + terminate")
+  func moveSuccessConfirmed() async {
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL)
+    h.presenter.choice = .move
+    h.handshake.ackHealthy = true
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.telemetry.acceptedEvents.count == 1)
+    #expect(h.mover.calls == 1)
+    #expect(h.relauncher.lastAttemptID == "attempt-1")
+    #expect(h.telemetry.relaunchedEvents.count == 1)
+    #expect(h.telemetry.relaunchedEvents.first?.2 == true)  // relaunch_confirmed
+    #expect(h.terminate.count == 1)
+    #expect(h.presenter.failures.isEmpty)
+  }
+
+  // MARK: Handshake failure keeps the original alive (A1)
+
+  @Test("ack unconfirmed -> original NEVER terminates, reports relaunchUnconfirmed")
+  func moveAckTimeout() async {
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL)
+    h.handshake.ackHealthy = false
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.terminate.count == 0)  // the only known-good copy stays alive
+    #expect(h.telemetry.relaunchedEvents.isEmpty)
+    #expect(h.telemetry.failedEvents.map(\.1) == ["relaunchUnconfirmed"])
+    #expect(h.presenter.failures == [.relaunchUnconfirmed])
+  }
+
+  @Test("relaunch rejected -> failure, no terminate")
+  func relaunchRejected() async {
+    let h = Self.makeHarness(bundleURL: Self.translocatedURL)
+    h.relauncher.success = false
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.terminate.count == 0)
+    #expect(h.telemetry.failedEvents.map(\.1) == ["relaunchRejected"])
+    #expect(h.presenter.failures == [.relaunchRejected])
+  }
+
+  // MARK: Move failure
+
+  @Test("mover failure -> showFailure, dismiss progress, no terminate")
+  func moveFailure() async {
+    let h = Self.makeHarness(
+      bundleURL: Self.translocatedURL, moverResult: .failure(.diskFull))
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.terminate.count == 0)
+    #expect(h.telemetry.failedEvents.map(\.1) == ["diskFull"])
+    #expect(h.presenter.failures == [.diskFull])
+    #expect(h.presenter.progressDismissed >= 1)
+    #expect(h.telemetry.relaunchedEvents.isEmpty)
+  }
+
+  // MARK: Existing-destination conflict matrix (Codex r2 P1 regression guard)
+
+  @Test("existing-destination: different bundle id -> conflict, never touched")
+  func decideDifferentIdentity() {
+    let d = FileManagerApplicationMover.decideExistingDestination(
+      existingBundleIdentifier: "com.someone.else",
+      expectedBundleIdentifier: "com.enviouswispr.app",
+      existingVersion: "9.9.9", currentVersion: "2.3.0", isRunning: false, signatureValid: true)
+    #expect(d == .conflict)
+  }
+
+  @Test("existing-destination: newer verified copy -> open it (no downgrade)")
+  func decideNewerVerified() {
+    let d = FileManagerApplicationMover.decideExistingDestination(
+      existingBundleIdentifier: "com.enviouswispr.app",
+      expectedBundleIdentifier: "com.enviouswispr.app",
+      existingVersion: "2.4.0", currentVersion: "2.3.0", isRunning: true, signatureValid: true)
+    #expect(d == .openExisting)
+  }
+
+  @Test("existing-destination: equal version verified -> open it")
+  func decideEqualVerified() {
+    let d = FileManagerApplicationMover.decideExistingDestination(
+      existingBundleIdentifier: "com.enviouswispr.app",
+      expectedBundleIdentifier: "com.enviouswispr.app",
+      existingVersion: "2.3.0", currentVersion: "2.3.0", isRunning: false, signatureValid: true)
+    #expect(d == .openExisting)
+  }
+
+  @Test("existing-destination: same-or-newer but BAD signature -> conflict (never launch)")
+  func decideNewerBadSignature() {
+    let d = FileManagerApplicationMover.decideExistingDestination(
+      existingBundleIdentifier: "com.enviouswispr.app",
+      expectedBundleIdentifier: "com.enviouswispr.app",
+      existingVersion: "2.5.0", currentVersion: "2.3.0", isRunning: false, signatureValid: false)
+    #expect(d == .conflict)
+  }
+
+  @Test("existing-destination: OLDER + running -> refuse, do NOT downgrade (Codex r2 P1)")
+  func decideOlderRunning() {
+    let d = FileManagerApplicationMover.decideExistingDestination(
+      existingBundleIdentifier: "com.enviouswispr.app",
+      expectedBundleIdentifier: "com.enviouswispr.app",
+      existingVersion: "2.2.0", currentVersion: "2.3.0", isRunning: true, signatureValid: true)
+    #expect(d == .refuseRunningOlder)
+  }
+
+  @Test("existing-destination: OLDER + not running + verified -> replace")
+  func decideOlderNotRunning() {
+    let d = FileManagerApplicationMover.decideExistingDestination(
+      existingBundleIdentifier: "com.enviouswispr.app",
+      expectedBundleIdentifier: "com.enviouswispr.app",
+      existingVersion: "2.2.0", currentVersion: "2.3.0", isRunning: false, signatureValid: true)
+    #expect(d == .replace)
+  }
+
+  @Test(
+    "existing-destination: OLDER + not running + BAD signature -> conflict, never overwrite (Codex r3 P2)"
+  )
+  func decideOlderBadSignature() {
+    let d = FileManagerApplicationMover.decideExistingDestination(
+      existingBundleIdentifier: "com.enviouswispr.app",
+      expectedBundleIdentifier: "com.enviouswispr.app",
+      existingVersion: "2.2.0", currentVersion: "2.3.0", isRunning: false, signatureValid: false)
+    #expect(d == .conflict)
+  }
+
+  // MARK: existingUsable still handshakes (never terminate blind)
+
+  @Test("existingUsable: still relaunches + requires ack before terminate")
+  func existingUsableHandshakes() async {
+    let dest = URL(fileURLWithPath: "/Applications/EnviousWispr.app")
+    let h = Self.makeHarness(
+      bundleURL: Self.translocatedURL, moverResult: .success(.existingUsable(dest)))
+    h.handshake.ackHealthy = true
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.relauncher.lastAttemptID == "attempt-1")
+    #expect(h.terminate.count == 1)
+  }
+}

--- a/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
@@ -236,6 +236,7 @@ struct ApplicationRelocationCoordinatorTests {
     #expect(h.handshake.writes.first?.healthy == true)
     #expect(h.telemetry.offeredEvents.isEmpty)  // no prompt on the child path
     #expect(h.presenter.progressShown == 0)
+    #expect(h.terminate.count == 0)  // healthy child lives on as the new app
   }
 
   @Test("relaunch child: still-blocked destination writes UNhealthy ack (A2 no masking)")
@@ -245,6 +246,9 @@ struct ApplicationRelocationCoordinatorTests {
     await h.coordinator.pendingWork?.value
     #expect(h.handshake.writes.count == 1)
     #expect(h.handshake.writes.first?.healthy == false)
+    // Still-blocked child quits itself; the original stays the authoritative
+    // copy (cloud #1490). Never two blocked instances.
+    #expect(h.terminate.count == 1)
   }
 
   // MARK: Decline

--- a/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/ApplicationRelocationCoordinatorTests.swift
@@ -49,18 +49,28 @@ struct ApplicationRelocationCoordinatorTests {
 
   final class FakeRelauncher: RelocationRelaunching, @unchecked Sendable {
     var success = true
+    var activateSuccess = true
     private(set) var lastAttemptID: String?
+    private(set) var relaunchCalls = 0
+    private(set) var activatedURL: URL?
     func relaunch(_ installedURL: URL, attemptID: String) async -> Bool {
+      relaunchCalls += 1
       lastAttemptID = attemptID
       return success
+    }
+    func activateRunning(_ url: URL) async -> Bool {
+      activatedURL = url
+      return activateSuccess
     }
   }
 
   final class FakeHandshake: RelocationHandshaking, @unchecked Sendable {
     var ackHealthy = true
+    private(set) var awaitCalls = 0
     private(set) var writes: [(attemptID: String, path: String, healthy: Bool)] = []
     func awaitAck(attemptID: String, destination: URL, timeout: TimeInterval) async -> Bool {
-      ackHealthy
+      awaitCalls += 1
+      return ackHealthy
     }
     func writeAck(attemptID: String, resolvedPath: String, healthy: Bool) {
       writes.append((attemptID, resolvedPath, healthy))
@@ -321,13 +331,24 @@ struct ApplicationRelocationCoordinatorTests {
     #expect(d == .conflict)
   }
 
-  @Test("existing-destination: newer verified copy -> open it (no downgrade)")
+  @Test("existing-destination: newer verified, NOT running -> open fresh (no downgrade)")
   func decideNewerVerified() {
     let d = FileManagerApplicationMover.decideExistingDestination(
       existingBundleIdentifier: "com.enviouswispr.app",
       expectedBundleIdentifier: "com.enviouswispr.app",
-      existingVersion: "2.4.0", currentVersion: "2.3.0", isRunning: true, signatureValid: true)
+      existingVersion: "2.4.0", currentVersion: "2.3.0", isRunning: false, signatureValid: true)
     #expect(d == .openExisting)
+  }
+
+  @Test(
+    "existing-destination: newer verified + ALREADY running -> activate, never duplicate (cloud #1490)"
+  )
+  func decideNewerRunning() {
+    let d = FileManagerApplicationMover.decideExistingDestination(
+      existingBundleIdentifier: "com.enviouswispr.app",
+      expectedBundleIdentifier: "com.enviouswispr.app",
+      existingVersion: "2.4.0", currentVersion: "2.3.0", isRunning: true, signatureValid: true)
+    #expect(d == .activateRunning)
   }
 
   @Test("existing-destination: equal version verified -> open it")
@@ -389,5 +410,34 @@ struct ApplicationRelocationCoordinatorTests {
     await h.coordinator.pendingWork?.value
     #expect(h.relauncher.lastAttemptID == "attempt-1")
     #expect(h.terminate.count == 1)
+  }
+
+  // MARK: existingRunning activates the live copy, never duplicates (cloud #1490)
+
+  @Test(
+    "existingRunning: activates the running copy, no fresh launch, no handshake, then terminates")
+  func existingRunningActivates() async {
+    let dest = URL(fileURLWithPath: "/Applications/EnviousWispr.app")
+    let h = Self.makeHarness(
+      bundleURL: Self.translocatedURL, moverResult: .success(.existingRunning(dest)))
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.relauncher.activatedURL == dest)  // brought the live copy to front
+    #expect(h.relauncher.relaunchCalls == 0)  // NO duplicate instance spawned
+    #expect(h.handshake.awaitCalls == 0)  // no handshake needed for an already-live copy
+    #expect(h.telemetry.relaunchedEvents.first?.2 == true)
+    #expect(h.terminate.count == 1)  // this translocated duplicate quits
+  }
+
+  @Test("existingRunning: activate failure keeps the original alive")
+  func existingRunningActivateFailure() async {
+    let dest = URL(fileURLWithPath: "/Applications/EnviousWispr.app")
+    let h = Self.makeHarness(
+      bundleURL: Self.translocatedURL, moverResult: .success(.existingRunning(dest)))
+    h.relauncher.activateSuccess = false
+    h.coordinator.evaluateAndOfferIfNeeded()
+    await h.coordinator.pendingWork?.value
+    #expect(h.terminate.count == 0)
+    #expect(h.telemetry.failedEvents.map(\.1) == ["relaunchRejected"])
   }
 }

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -29,6 +29,12 @@ import Testing
 /// `runDidFinishLaunching` for the opt-in launch sync only. Allowlist 19 → 20
 /// (3 owned `var` + 17 injected `let`); non-private method count unchanged at 3.
 /// A narrow new coordinator, not god-object accretion (issue-636 §3b).
+/// Bible §30 entry (#1451, 2026-07-10): `applicationRelocationCoordinator` added
+/// — the App Translocation recovery limb. Injected `let`, called once by
+/// `runDidFinishLaunching` (`evaluateAndOfferIfNeeded()`); the coordinator owns
+/// all relocation policy, so this is one narrow delegation, not accretion (§3b).
+/// Allowlist 20 → 21 (3 owned `var` + 18 injected `let`); non-private method
+/// count unchanged at 3.
 @Suite struct AppLifecycleCoordinatorCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift"
@@ -54,6 +60,7 @@ import Testing
     "menuBarController",
     "appWindowCoordinator",
     "hotkeyService",
+    "applicationRelocationCoordinator",
   ]
 
   @Test func storedPropertyNamesMatchAllowlist() throws {
@@ -66,7 +73,7 @@ import Testing
       extras.isEmpty && missing.isEmpty,
       """
       AppLifecycleCoordinator stored-property set drifted from the \
-      20-name allowlist. Unexpected: \(extras.sorted()). Missing: \
+      21-name allowlist. Unexpected: \(extras.sorted()). Missing: \
       \(missing.sorted()). Adding a stored property is god-object drift — \
       raising the allowlist requires a Bible §30 entry. Removing one means \
       this allowlist must shrink in the same PR.

--- a/Tests/EnviousWisprTests/Services/TelemetryFlushReasonTests.swift
+++ b/Tests/EnviousWisprTests/Services/TelemetryFlushReasonTests.swift
@@ -37,10 +37,13 @@ import Testing
 
     @Test("FlushReason raw values are the bounded expected set")
     func flushReasonRawValuesBounded() {
-      // `.updateInstall` (Sparkle pre-relaunch) + `.appTerminate` (normal quit,
-      // Phase 1) are the only live reasons; a crash reason is intentionally absent.
+      // `.updateInstall` (Sparkle pre-relaunch), `.appTerminate` (normal quit,
+      // Phase 1), and `.relocation` (#1451, pre-terminate handoff after an App
+      // Translocation self-move) are the live reasons; a crash reason is
+      // intentionally absent.
       #expect(TelemetryService.FlushReason.updateInstall.rawValue == "update_install")
       #expect(TelemetryService.FlushReason.appTerminate.rawValue == "app_terminate")
+      #expect(TelemetryService.FlushReason.relocation.rawValue == "relocation")
     }
 
     @MainActor

--- a/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/UpdateAvailabilityServiceTests.swift
@@ -176,12 +176,13 @@ struct UpdateAvailabilityServiceTests {
 
   @Test("compareVersions handles standard semver ordering")
   func versionCompare() {
-    let (s, _) = Self.makeService()
-    #expect(s.compareVersions("2.4.0", "2.4.1") == -1)
-    #expect(s.compareVersions("2.4.1", "2.4.0") == 1)
-    #expect(s.compareVersions("2.4.0", "2.4.0") == 0)
-    #expect(s.compareVersions("2.4.10", "2.4.9") == 1)  // numeric, not lexical
-    #expect(s.compareVersions("3.0.0", "2.99.99") == 1)
+    // #1451: `compareVersions` is now `static` (single version-comparison
+    // authority; `ApplicationMover` reuses it).
+    #expect(UpdateAvailabilityService.compareVersions("2.4.0", "2.4.1") == -1)
+    #expect(UpdateAvailabilityService.compareVersions("2.4.1", "2.4.0") == 1)
+    #expect(UpdateAvailabilityService.compareVersions("2.4.0", "2.4.0") == 0)
+    #expect(UpdateAvailabilityService.compareVersions("2.4.10", "2.4.9") == 1)  // numeric, not lexical
+    #expect(UpdateAvailabilityService.compareVersions("3.0.0", "2.99.99") == 1)
   }
 
   // MARK: - .resolving watchdog


### PR DESCRIPTION
Closes #1451.

## What & why
14 production users could never auto-update: macOS runs a still-quarantined app from a read-only, translocated location, so Sparkle aborts before it even fetches the appcast, and they got no explanation. This adds a launch-time recovery limb: detect the exact Sparkle-blocking location, offer a one-click move into a writable Applications folder, relaunch, and confirm the new copy is healthy before the original exits. Every failure leaves the current app usable.

We chose the one-click self-move over the guided "quit and drag it yourself" notice (see the issue thread) — enterprise-grade Mac apps recover in one click, and the filesystem risk is handled structurally.

## Safety design
- **Handshake before handoff:** the original never terminates until the relaunched copy writes a health ack (correct path + not-blocked). Timeout → original stays alive, reports failure.
- **Presentation-only relaunch marker:** the relaunched copy still runs detection, so a failed move can't masquerade as healthy.
- **Signature gate on every touch:** an existing copy is signature-validated (Developer ID + Team ID) before we open OR overwrite it; older running copies are refused (no downgrade); unverifiable bundles are never launched or deleted.
- **Atomic install:** stage on the destination volume, `replaceItemAt` (never Trash-first). No admin, no private SPI, no quarantine stripping, no original-file deletion.

## Presentation
Custom centered SwiftUI card (icon-on-top, centered title/body, brand-accent primary, large readable type) — not a stock left-aligned NSAlert. `EW_RELOCATION_FORCE_STATE` is a DEBUG-only preview trigger, compiled out of release.

## Validation
- 24 unit tests (detection, decline cadence, the handshake success/timeout/reject paths, the existing-destination conflict matrix, telemetry).
- Local `codex review` iterated to clean (r5: no findings); 4 real defects caught + fixed across earlier rounds.
- Full app test gate green.
- **Live UAT on a signed build:** real read-only launch → centered prompt → Move → signature-validated install to /Applications → handshake handoff → original exited → moved copy verified update-capable (Sparkle no longer blocked). Founder-approved dialog design.

Tier MEDIUM · Lane Code. No release cut in this change.
