### PR TITLE
content(website): improve trust and attribution

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,16 +1,17 @@
 # EnviousWispr
 
-> The fastest voice-to-text on macOS. Hold a hotkey, speak, release. Polished text lands on your clipboard or pastes directly. Runs entirely on-device with Parakeet (English) or WhisperKit (multilingual). No cloud, no account, no subscription. Free download.
+> Free, private voice-to-text for macOS. Hold a hotkey, speak, release. Polished text lands on your clipboard or pastes directly. Transcription runs on-device with Parakeet (25 European languages) or WhisperKit (99 languages). Optional AI polish can stay on-device with EG-1, Apple Intelligence, or Ollama; OpenAI and Gemini are optional bring-your-own-key cloud providers. No account, no subscription. Free download.
 
 Maker: Envious Labs LLC (Connecticut, USA). Founder: Saurabh Vaish.
 License: GNU General Public License v3 (GPLv3, open source on GitHub).
 Platform: macOS 14 (Sonoma) or later, Apple Silicon only.
-Last-updated: 2026-06-06
+Last-updated: 2026-07-10
 
 ## Product
 
 - [How it works](https://enviouswispr.com/how-it-works/): The end-to-end pipeline: hotkey hold, audio capture, on-device ASR, optional LLM polish, clipboard or paste-to-app delivery.
 - [Homepage](https://enviouswispr.com/): Download, screenshots, core value proposition, system requirements (Apple Silicon, macOS 14+).
+- [Best dictation apps for Mac](https://enviouswispr.com/compare/best-dictation-apps-for-mac/): A practical 2026 guide to six Mac dictation options, with honest picks by workflow.
 - [Compare to alternatives](https://enviouswispr.com/compare/): Index of comparison pages vs WisprFlow, Superwhisper, Apple Dictation, Dragon, MacWhisper, Otter.ai, and others.
 
 ## Comparisons
@@ -34,12 +35,14 @@ Last-updated: 2026-06-06
 - [Dictate in a whisper: soft and quiet speech](https://enviouswispr.com/blog/dictate-in-a-whisper-soft-speech/): Capturing quiet, whispered, and far-from-the-mic speech so you can dictate at night or in a shared office without raising your voice.
 - [Say it, get it formatted: dates, numbers, emails](https://enviouswispr.com/blog/spoken-text-formatting-dates-numbers-emails/): On-device conversion of spoken numbers, dates, times, money, percentages, phone numbers, emails, and web addresses into typed form, before any AI step.
 - [Speaking emoji in your dictation](https://enviouswispr.com/blog/speak-emoji-dictation/): Say "thumbs up emoji" to get the glyph; trigger-word based, 1,500+ emoji, runs on-device, never converts a bare word by accident.
+- [Dictate for a full hour](https://enviouswispr.com/blog/you-can-now-dictate-for-a-full-hour/): How EnviousWispr handles a single hour-long dictation on-device, with a warning before the limit and no lost transcript at the stop.
 
 ## Privacy and architecture
 
 - [On-device vs cloud dictation privacy](https://enviouswispr.com/blog/on-device-vs-cloud-dictation-privacy/): What each architecture does with your voice data and what that means for privacy.
 - [macOS dictation, offline and private](https://enviouswispr.com/blog/macos-dictation-offline-private/): How offline dictation works and why it matters.
 - [Voice coding on macOS without the cloud](https://enviouswispr.com/blog/voice-coding-macos-without-cloud/): Dictating code locally without sending to a remote server.
+- [Engineering small models for on-device dictation polish](https://enviouswispr.com/blog/on-device-dictation-polishing-small-models/): Benchmark-backed research on the reliability layers behind local dictation cleanup and the path to EG-1.
 
 ## Use cases
 
@@ -48,7 +51,6 @@ Last-updated: 2026-06-06
 - [Dictation for developers: code reviews and PRs](https://enviouswispr.com/blog/dictation-for-developers-code-reviews/): PR descriptions and review comments by voice.
 - [Dictation for writers: skip the blank page](https://enviouswispr.com/blog/dictation-for-writers-skip-blank-page/): First-draft workflow for writers.
 - [Voice input for RSI: keyboard-free workflow](https://enviouswispr.com/blog/voice-input-rsi-keyboard-free-workflow/): Accessibility and hands-free typing.
-- [Hands-free typing when a toddler climbs you](https://enviouswispr.com/blog/hands-free-typing-toddler-climbs-you/): Parent-friendly use case.
 - [Dictation for parents who type one-handed](https://enviouswispr.com/blog/dictation-parents-type-one-handed/): One-handed parenting workflow.
 - [Dictation for remote workers tired of typing](https://enviouswispr.com/blog/dictation-remote-workers-tired-of-typing/): Remote work fatigue.
 - [Switched typing to dictating git commits](https://enviouswispr.com/blog/switched-typing-to-dictating-git-commits/): Git commit message workflow.
@@ -64,7 +66,7 @@ Last-updated: 2026-06-06
 
 ## Behind the scenes
 
-- [Building commercial software solo with Claude Code](https://enviouswispr.com/blog/building-commercial-software-solo-with-claude-code/): How the app is built (one founder + Claude Code).
+- [The state of our solo Claude Code system](https://enviouswispr.com/blog/claude-code-system-june-2026/): A June 2026 update on how one founder builds and validates EnviousWispr with Claude Code.
 - [Moving Whisper off the Neural Engine](https://enviouswispr.com/blog/whisperkit-neural-engine-to-gpu/): Why we moved the Whisper-based engine from the Neural Engine to the GPU, with cold-start measurements (about 109 seconds down to about 13).
 - [Welcome to EnviousWispr](https://enviouswispr.com/blog/welcome-to-enviouswispr/): Launch post.
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -210,7 +210,7 @@ const jsonLdFaq = JSON.stringify({
       <p class="hero-sub">Free private AI dictation for macOS. The fastest free, private way to turn your voice into polished text on Mac. On-device, on Apple Silicon, your voice never leaves your device.</p>
 
       <div class="hero-ctas reveal" style="--i:3">
-        <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary">
+        <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-primary" data-download-source="hero">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Download Free
         </a>
@@ -502,56 +502,26 @@ const jsonLdFaq = JSON.stringify({
   </section>
 
   <!-- ═══════════════════════════════════════════════════════
-       Testimonials
+       Public launch discussion
        ═══════════════════════════════════════════════════════ -->
-  <section class="section" id="testimonials" aria-labelledby="testimonials-heading">
+  <section class="section" id="community" aria-labelledby="community-heading">
     <div class="container">
       <div class="section-head reveal">
-        <div class="section-label-pill amber">Early Users</div>
-        <h2 class="section-title" id="testimonials-heading">What people are saying</h2>
-        <p class="section-sub">From professionals to students, EnviousWispr fits every workflow.</p>
+        <div class="section-label-pill amber">Community</div>
+        <h2 class="section-title" id="community-heading">Public launch discussion</h2>
+        <p class="section-sub">The original launch post and its full public conversation are available on Reddit.</p>
       </div>
 
-      <div class="testimonials-grid reveal-stagger">
-        <div class="testimonial-card reveal" style="--i:0">
-          <div class="testimonial-stars" role="img" aria-label="5 stars">
-            <span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span>
-          </div>
-          <p class="testimonial-quote">"I use it for every email now. I just ramble out loud and it gives me something clean I can actually send. I've cut my inbox time in half."</p>
-          <div class="testimonial-author">
-            <div class="author-avatar av-1" aria-hidden="true">SM</div>
-            <div>
-              <div class="author-name">Sarah M.</div>
-              <div class="author-title">Product Manager, San Francisco</div>
-            </div>
-          </div>
+      <div class="community-discussion-card reveal">
+        <div class="community-mark" aria-hidden="true">r/</div>
+        <div class="community-copy">
+          <h3>EnviousWispr on r/macapps</h3>
+          <p>Read the launch post, questions, feedback, and founder replies in the original public thread.</p>
         </div>
-        <div class="testimonial-card reveal" style="--i:1">
-          <div class="testimonial-stars" role="img" aria-label="5 stars">
-            <span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span>
-          </div>
-          <p class="testimonial-quote">"As a developer, I dictate commit messages and code comments. It nails my technical vocabulary, and my recordings never leave my Mac."</p>
-          <div class="testimonial-author">
-            <div class="author-avatar av-2" aria-hidden="true">JR</div>
-            <div>
-              <div class="author-name">James R.</div>
-              <div class="author-title">Senior Engineer, Remote</div>
-            </div>
-          </div>
-        </div>
-        <div class="testimonial-card reveal" style="--i:2">
-          <div class="testimonial-stars" role="img" aria-label="5 stars">
-            <span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span><span class="star" aria-hidden="true">&#9733;</span>
-          </div>
-          <p class="testimonial-quote">"I write all my essays by talking first. EnviousWispr turns my stream-of-consciousness into paragraphs I can actually use."</p>
-          <div class="testimonial-author">
-            <div class="author-avatar av-3" aria-hidden="true">AP</div>
-            <div>
-              <div class="author-name">Anika P.</div>
-              <div class="author-title">Graduate Student, Chicago</div>
-            </div>
-          </div>
-        </div>
+        <a href="https://www.reddit.com/r/macapps/comments/1uobt7v/os_enviouswispr_wispr_flow_but_free_opensource/" class="community-link">
+          <span>Read the discussion on r/macapps</span>
+          <span class="external-note">External link &#8599;</span>
+        </a>
       </div>
     </div>
   </section>
@@ -632,7 +602,7 @@ const jsonLdFaq = JSON.stringify({
         <p>Free download. No account required. No credit card.</p>
 
         <div class="cta-btns">
-          <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-cta-primary">
+          <a href="https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg" class="btn-cta-primary" data-download-source="bottom-cta">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
             Download EnviousWispr
           </a>
@@ -1014,29 +984,29 @@ const jsonLdFaq = JSON.stringify({
 .privacy-card-3 p { font-size: 14px; color: var(--text-2); line-height: 1.65; }
 
 /* ═══════════════════════════════════════════════════════
-   Testimonials
+   Public launch discussion
    ═══════════════════════════════════════════════════════ */
-.testimonials-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 20px; }
-.testimonial-card {
-  background: white; border-radius: var(--radius-card); padding: 32px 28px;
-  border: 1.5px solid var(--border);
-  transition: border-color 0.2s, box-shadow 0.2s, transform 0.25s;
+.community-discussion-card {
+  max-width: 900px; margin: 0 auto; padding: 28px 30px;
+  display: grid; grid-template-columns: auto minmax(0,1fr) auto; align-items: center; gap: 22px;
+  background: white; border: 1.5px solid var(--border); border-radius: var(--radius-card);
 }
-.testimonial-card:hover { border-color: var(--border-hover); box-shadow: 0 8px 32px rgba(124,58,237,0.09); transform: translateY(-3px); }
-.testimonial-stars { display: flex; gap: 3px; margin-bottom: 16px; }
-.star { color: var(--amber); font-size: 15px; }
-.testimonial-quote { font-size: 15px; line-height: 1.75; color: var(--text-2); margin-bottom: 24px; font-style: italic; }
-.testimonial-author { display: flex; align-items: center; gap: 14px; }
-.author-avatar {
-  width: 40px; height: 40px; border-radius: 50%;
-  display: flex; align-items: center; justify-content: center;
-  font-size: 14px; font-weight: 800; color: white; flex-shrink: 0;
+.community-mark {
+  width: 52px; height: 52px; border-radius: 16px; display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0; color: white; background: linear-gradient(135deg,#ff4500,#ff7a45);
+  font-size: 18px; font-weight: 800;
 }
-.av-1 { background: linear-gradient(135deg,#7c3aed,#4169e1); }
-.av-2 { background: linear-gradient(135deg,#00c880,#1e90ff); }
-.av-3 { background: linear-gradient(135deg,#ff8c00,#ff2a40); }
-.author-name { font-size: 14px; font-weight: 700; color: var(--text); }
-.author-title { font-size: 12px; color: var(--text-3); margin-top: 2px; }
+.community-copy h3 { font-size: 18px; font-weight: 750; margin-bottom: 6px; }
+.community-copy p { color: var(--text-2); font-size: 14px; line-height: 1.6; }
+.community-link {
+  min-height: 48px; padding: 10px 16px; display: inline-flex; flex-direction: column; align-items: flex-start; justify-content: center;
+  color: var(--accent); background: var(--accent-light); border: 1px solid rgba(124,58,237,0.18); border-radius: 12px;
+  font-size: 13px; font-weight: 700; line-height: 1.35; text-decoration: none;
+  transition: border-color 0.2s, background 0.2s;
+}
+.community-link:hover { border-color: var(--accent); background: #eee7ff; }
+.community-link:focus-visible { outline: 3px solid rgba(124,58,237,0.35); outline-offset: 3px; }
+.external-note { color: var(--text-3); font-family: var(--font-mono); font-size: 10px; font-weight: 600; margin-top: 3px; }
 
 /* ═══════════════════════════════════════════════════════
    CTA Section
@@ -1078,7 +1048,8 @@ const jsonLdFaq = JSON.stringify({
 }
 @media(max-width:900px) {
   .modes-grid { grid-template-columns: 1fr; }
-  .testimonials-grid { grid-template-columns: 1fr; }
+  .community-discussion-card { grid-template-columns: auto minmax(0,1fr); }
+  .community-link { grid-column: 1 / -1; align-items: center; }
   .privacy-grid-3 { grid-template-columns: 1fr; }
   .cta-inner h2 { font-size: 40px; }
   .cta-inner { padding: 48px 28px; }
@@ -1089,6 +1060,7 @@ const jsonLdFaq = JSON.stringify({
   .hero-ctas { flex-direction: column; align-items: stretch; }
   .btn-primary,.btn-secondary,.btn-cta-primary { justify-content: center; }
   .benefits-grid { grid-template-columns: 1fr; }
+  .community-discussion-card { padding: 24px 20px; gap: 16px; }
 
 }
 </style>


### PR DESCRIPTION
## Summary

- replace three placeholder testimonials with a neutral, clearly external link to the public r/macapps launch discussion
- add explicit `hero` and `bottom-cta` attribution to the two homepage download buttons
- refresh `llms.txt` with current language/model facts and high-value discovery pages, removing one dead legacy link

## Validation

- Content lane detected and declared
- Astro build: 57 pages
- Internal link check: 57 HTML pages
- `llms.txt` target check: 47 URLs
- Download-link lint + self-test: pass
- Desktop 1280px and mobile 390x844 visual QA: pass
- Grounded committed-diff review: `VERDICT: CLEAN`

## External repository metadata

- GitHub topic corrected from `source-available` to `open-source` and verified live

Refs #538