### PR TITLE
feat(ui): lead each What's New item with its specific improvement

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -4,24 +4,11 @@ import Foundation
 /// Static "What's New" content, decoupled from the view layer.
 /// Update WhatsNewConstants.currentContentVersion in Core whenever entries change.
 enum WhatsNewContent {
-  enum Category: String, CaseIterable, Identifiable {
-    case newFeatures = "New Features"
-    case smarterAIPolish = "Smarter AI Polish"
-    case betterOllamaSupport = "Better Ollama Support"
-    case fasterAndMoreReliable = "Faster and More Reliable"
-    case qualityOfLife = "Quality of Life"
-    case privacyAndSecurity = "Privacy and Security"
-
-    var id: String { rawValue }
-    var title: String { rawValue }
-  }
-
   struct Entry: Identifiable, Hashable {
     let id: String
     let icon: String
     let title: String
     let description: String
-    let category: Category
     let version: String
   }
 
@@ -34,7 +21,6 @@ enum WhatsNewContent {
       title: "Fixed: recording could fail every time on a specific microphone",
       description:
         "If you picked a microphone by name instead of leaving it on Automatic, and that microphone was running at a sample rate other than the usual one, EnviousWispr could fail to record with the message \"XPC audio service is unreachable.\" It did not clear up on its own, and reinstalling or updating the app did not help, because the setting that caused it lives in macOS rather than in EnviousWispr. The app now reads the microphone's real settings before it starts listening, so recording works whatever rate your microphone is set to. If you have been stuck on this, updating is enough to fix it.",
-      category: .fasterAndMoreReliable,
       version: "2.3.2"
     ),
 
@@ -46,7 +32,6 @@ enum WhatsNewContent {
       title: "First-run setup downloads are far more reliable",
       description:
         "Setting up EnviousWispr downloads a speech model, and on some networks that download could stall and leave you stuck before you ever got to dictate. We rebuilt how the app fetches it: the download now resumes on its own if your connection drops, falls back to a backup source when needed, and can no longer hang forever. If setup gets interrupted, reopening the app picks up right where it left off instead of starting over.",
-      category: .fasterAndMoreReliable,
       version: "2.3.1"
     ),
 
@@ -58,7 +43,6 @@ enum WhatsNewContent {
       title: "Meet EG-1, our new recommended polish engine",
       description:
         "EnviousWispr now ships its own AI polish model, trained specifically for dictation, and it is remarkably strong: a 94.7% pass rate across our 1,890-case benchmark, edging out the big cloud models. It shines exactly where built-in Apple Intelligence falls short: turning spoken lists into real lists, honoring your mid-sentence self-corrections, and breaking long dictations into clean paragraphs. It is fast, typically polishing a dictation in under a second, and completely offline: download it once and it runs entirely on your Mac, no account, no API key, no internet after setup. EG-1 is our recommended engine going forward.",
-      category: .newFeatures,
       version: "2.3.0"
     ),
     Entry(
@@ -67,7 +51,6 @@ enum WhatsNewContent {
       title: "The All Languages engine, redesigned",
       description:
         "We rebuilt the All Languages engine from the ground up to transcribe live while you speak as well as in one pass at the end of a recording. Your text now lands almost immediately when you stop, no matter how long you talked, first words come through quicker, and the redesign makes the engine more robust: fewer imagined phrases like a stray \"thank you\" during quiet moments, and no more text going missing or repeating in longer recordings. To stream live, pick a specific language in Settings; with Auto-detect on, the engine waits for the full recording so it can identify your language accurately.",
-      category: .newFeatures,
       version: "2.3.0"
     ),
     Entry(
@@ -76,7 +59,6 @@ enum WhatsNewContent {
       title: "Settings got a full visual refresh",
       description:
         "We updated the Settings page to be easier to read and navigate. Settings and History now share one polished, unified look, with roomier spacing, easier-to-read text, and a redesigned AI Polish tab where each engine has its own card with everything you need to set it up.",
-      category: .qualityOfLife,
       version: "2.3.0"
     ),
     Entry(
@@ -85,7 +67,6 @@ enum WhatsNewContent {
       title: "Smoother behavior when Ollama polish is not set up right",
       description:
         "If Ollama polish is selected but not properly set up, say the model is missing or Ollama is not running, the app no longer misbehaves. It tells you clearly what is wrong and delivers your unpolished text right away.",
-      category: .betterOllamaSupport,
       version: "2.3.0"
     ),
     Entry(
@@ -94,7 +75,6 @@ enum WhatsNewContent {
       title: "Smarter built-in number handling",
       description:
         "We improved the always-on, non-AI part of the pipeline that formats spoken numbers. Phrases like \"two hundredth anniversary\" and \"third-largest city\" now come out exactly right instead of turning into odd digit mixes.",
-      category: .fasterAndMoreReliable,
       version: "2.3.0"
     ),
 
@@ -106,7 +86,6 @@ enum WhatsNewContent {
       title: "Long dictations keep every last word",
       description:
         "Fixed a long-standing bug where the end of a longer dictation could go missing if you paused mid-sentence near the finish. The speech engine now catches and recovers those moments, so your closing words always land.",
-      category: .fasterAndMoreReliable,
       version: "2.2.1"
     ),
     Entry(
@@ -115,7 +94,6 @@ enum WhatsNewContent {
       title: "Cloud AI polish got a facelift",
       description:
         "If you bring your own OpenAI or Gemini key, polish just got a major upgrade. We rewrote the prompt from the ground up and benchmarked it across 1,890 real dictation cases: pass rates jumped from about 70% to about 92%. You'll notice the difference most in paragraph breaks when you change topics, spoken lists becoming real lists, cleaner handling of mid-sentence self-corrections, grammar fixes, and emoji staying exactly where you put them.",
-      category: .smarterAIPolish,
       version: "2.2.1"
     ),
 
@@ -127,7 +105,6 @@ enum WhatsNewContent {
       title: "Dark mode has arrived",
       description:
         "EnviousWispr now has a dark mode. Match your system automatically, or pick light or dark yourself in Settings. Easier on the eyes for late-night dictation.",
-      category: .newFeatures,
       version: "2.2.0"
     ),
     Entry(
@@ -136,7 +113,6 @@ enum WhatsNewContent {
       title: "Record for up to an hour at a time",
       description:
         "You can now record for up to a full hour in one go. As you near the limit you get a gentle heads-up, and recording stops cleanly on its own so you never lose what you said.",
-      category: .newFeatures,
       version: "2.2.0"
     ),
     Entry(
@@ -145,7 +121,6 @@ enum WhatsNewContent {
       title: "Sharper on-device polish",
       description:
         "The built-in, fully on-device polish got a real tune-up. It cleans up filler and phrasing more reliably, keeps the natural way you start a sentence, and leaves your wording alone when it should.",
-      category: .smarterAIPolish,
       version: "2.2.0"
     ),
     Entry(
@@ -154,7 +129,6 @@ enum WhatsNewContent {
       title: "Your emoji stay put",
       description:
         "Dictate an emoji and it now stays exactly where you placed it after polish runs. No more emoji going missing or landing in the wrong spot.",
-      category: .smarterAIPolish,
       version: "2.2.0"
     ),
     Entry(
@@ -163,7 +137,6 @@ enum WhatsNewContent {
       title: "Clearer reasons when polish can't finish",
       description:
         "If cloud or on-device AI polish ever cannot finish, EnviousWispr now tells you specifically what happened and what to do, instead of a vague notice. Either way, your clean transcription is always delivered.",
-      category: .smarterAIPolish,
       version: "2.2.0"
     ),
     Entry(
@@ -172,7 +145,6 @@ enum WhatsNewContent {
       title: "Your words survive an unexpected quit",
       description:
         "If the app ever closes in the middle of a dictation, your recording is no longer lost. When you reopen EnviousWispr it quietly picks up where it left off and finishes turning your words into text.",
-      category: .fasterAndMoreReliable,
       version: "2.2.0"
     ),
     Entry(
@@ -181,7 +153,6 @@ enum WhatsNewContent {
       title: "Numbers written the way you would write them",
       description:
         "Numbers now come out the way you would actually type them: small ones spelled out, larger ones as digits, following the same style most newsrooms use. That means less cleanup for you.",
-      category: .fasterAndMoreReliable,
       version: "2.2.0"
     ),
     Entry(
@@ -190,7 +161,6 @@ enum WhatsNewContent {
       title: "No more clipped last words",
       description:
         "We fixed a case where a quick, energetic word or two at the very end of a dictation could get trimmed off. Your full sentence now makes it through.",
-      category: .fasterAndMoreReliable,
       version: "2.2.0"
     ),
     Entry(
@@ -199,7 +169,6 @@ enum WhatsNewContent {
       title: "Pasting never waits on saving",
       description:
         "Even if saving a dictation to your History runs into a snag, your words still land where you are typing. Delivery no longer waits on the archive.",
-      category: .fasterAndMoreReliable,
       version: "2.2.0"
     ),
     Entry(
@@ -208,7 +177,6 @@ enum WhatsNewContent {
       title: "Built for VoiceOver and keyboard navigation",
       description:
         "EnviousWispr now reads cleanly with VoiceOver and is fully operable from the keyboard. Its hotkey recorders, buttons, and update prompts announce themselves clearly and respond to keyboard control.",
-      category: .qualityOfLife,
       version: "2.2.0"
     ),
     Entry(
@@ -217,7 +185,6 @@ enum WhatsNewContent {
       title: "Clearer polish on older Macs",
       description:
         "On Macs that cannot run Apple's on-device polish, EnviousWispr no longer shows a confusing \"polish failed\" note. It simply hands you your clean transcription, and onboarding now explains your polish options up front.",
-      category: .qualityOfLife,
       version: "2.2.0"
     ),
     Entry(
@@ -226,7 +193,6 @@ enum WhatsNewContent {
       title: "Your words stay out of diagnostics",
       description:
         "We added another layer to make sure your dictated words can never end up in crash reports or diagnostics. What you say stays yours.",
-      category: .privacyAndSecurity,
       version: "2.2.0"
     ),
     Entry(
@@ -235,7 +201,6 @@ enum WhatsNewContent {
       title: "Open source, and easy to verify",
       description:
         "EnviousWispr is open source under the GPLv3 license, and every download now points you straight to the full source. You can see exactly what the app does.",
-      category: .privacyAndSecurity,
       version: "2.2.0"
     ),
 
@@ -247,7 +212,6 @@ enum WhatsNewContent {
       title: "Pasting now lands in Word, Excel, and more",
       description:
         "We fixed an issue where in some apps (Word, Excel, Pages, Numbers, OneNote, Sublime Text, Firefox) your dictation would say \"Copied\" but never actually paste. Your words now land in the document like everywhere else.",
-      category: .fasterAndMoreReliable,
       version: "2.1.4"
     ),
     Entry(
@@ -256,7 +220,6 @@ enum WhatsNewContent {
       title: "Small UI tweaks for a cleaner experience",
       description:
         "A tidier sidebar status card, History columns that stay readable in small windows, more reliable update delivery, and an AI badge that only appears when AI actually ran.",
-      category: .qualityOfLife,
       version: "2.1.4"
     ),
 
@@ -268,7 +231,6 @@ enum WhatsNewContent {
       title: "Bring in the names of people you know",
       description:
         "One tap on \"Import from Contacts\" adds the people in your address book to your custom words, so a coworker's or friend's hard-to-spell name comes out right the first time. Everything stays on your Mac. Your contacts are never uploaded. EnviousWispr also quietly learns the common ways each name gets misheard, so it catches those too.",
-      category: .newFeatures,
       version: "2.1.3"
     ),
     Entry(
@@ -277,7 +239,6 @@ enum WhatsNewContent {
       title: "Vocabulary packs for brands and jargon",
       description:
         "Turn on a pack and EnviousWispr recognizes those words and capitalizes them the way they're meant to be written (AngularJS, Nivea, Acosta). Each pack has a searchable list, so you can see every word it covers and the spoken variants it catches.",
-      category: .newFeatures,
       version: "2.1.3"
     ),
     Entry(
@@ -286,7 +247,6 @@ enum WhatsNewContent {
       title: "No more swallowed first press after a break",
       description:
         "If you left the app idle for a while, your next recording could get eaten while it flashed a \"warming up\" notice, even though it was basically ready. It now quietly re-wakes in a fraction of a second and captures your words, including the very first one.",
-      category: .fasterAndMoreReliable,
       version: "2.1.3"
     ),
     Entry(
@@ -295,7 +255,6 @@ enum WhatsNewContent {
       title: "One less Settings tab to hunt through",
       description:
         "The \"Performance\" tab held just one control: how long to keep the engine loaded between recordings. It now sits at the bottom of the Transcription screen, right where it belongs, so Settings has one less place to look.",
-      category: .qualityOfLife,
       version: "2.1.3"
     ),
 
@@ -307,7 +266,6 @@ enum WhatsNewContent {
       title: "EnviousWispr keeps itself current",
       description:
         "The app now looks for new versions on its own: when you open it, when you come back to it, and quietly in the background. So a waiting improvement finds you instead of you having to go looking. There's also a clear \"Check for Updates\" control in Settings if you ever want to look right now.",
-      category: .newFeatures,
       version: "2.1.2"
     ),
     Entry(
@@ -316,7 +274,6 @@ enum WhatsNewContent {
       title: "Soft and distant speech no longer gets dropped",
       description:
         "If you spoke quietly, whispered, or sat back from your mic, EnviousWispr would sometimes capture nothing at all. It now hears those faint and far-away words and writes them down, including a soft first word that used to get clipped off the start.",
-      category: .fasterAndMoreReliable,
       version: "2.1.2"
     ),
     Entry(
@@ -325,7 +282,6 @@ enum WhatsNewContent {
       title: "No more false \"warming up\" notice",
       description:
         "Tapping record again right after a quick tap or a \"changed my mind\" cancel could flash the \"warming up\" notice as if the app were starting cold, even though it was already warm and ready. That stray notice is gone: a warm app just records.",
-      category: .qualityOfLife,
       version: "2.1.2"
     ),
     Entry(
@@ -334,7 +290,6 @@ enum WhatsNewContent {
       title: "Removed a setting that promised something it didn't do",
       description:
         "The \"Recording Environment\" choice (Quiet, Normal, Noisy) sounded like it changed how well the app hears you in different surroundings. It never did that. We removed it so Settings only shows controls that actually do what they say.",
-      category: .qualityOfLife,
       version: "2.1.2"
     ),
 
@@ -346,7 +301,6 @@ enum WhatsNewContent {
       title: "Speak it naturally, see it written",
       description:
         "EnviousWispr now formats what you dictate the way you actually mean it, automatically: phone numbers, money, percentages, years, dates, times, ordinals, decimals, number ranges, emails, and web addresses. Say \"five five five, one two three, four five six seven\" and you get 555-123-4567; \"eighty million dollars\" becomes $80 million; \"nineteen eighty seven\" becomes 1987. It even works when AI polish is turned off.",
-      category: .newFeatures,
       version: "2.1.1"
     ),
     Entry(
@@ -355,7 +309,6 @@ enum WhatsNewContent {
       title: "More reliable updates",
       description:
         "We improved how EnviousWispr installs new versions, so updates land cleanly instead of getting stuck partway. And if an update ever has trouble, the copy you already have keeps working.",
-      category: .fasterAndMoreReliable,
       version: "2.1.1"
     ),
 
@@ -367,7 +320,6 @@ enum WhatsNewContent {
       title: "Polish keeps your words, not your commands",
       description:
         "Dictate something that sounds like an instruction, like \"draft a Slack to Matt about the launch\", and on-device polish used to sometimes go write that message instead of cleaning up what you said. It now recognizes the difference and keeps your actual words.",
-      category: .smarterAIPolish,
       version: "2.1.0"
     ),
     Entry(
@@ -376,7 +328,6 @@ enum WhatsNewContent {
       title: "An honest warm-up, then instant presses",
       description:
         "Right after launch the speech engine takes a moment to warm up. You now see a clear indicator while that happens, instead of a start that looks frozen. Once it is warm, every press begins instantly with no flicker.",
-      category: .fasterAndMoreReliable,
       version: "2.1.0"
     ),
     Entry(
@@ -385,7 +336,6 @@ enum WhatsNewContent {
       title: "Faster WhisperKit transcription",
       description:
         "We moved the WhisperKit speech engine from your Mac's Neural Engine onto its GPU. In our testing that is the faster path for WhisperKit, so transcription warms up and finishes quicker.",
-      category: .fasterAndMoreReliable,
       version: "2.1.0"
     ),
     Entry(
@@ -394,7 +344,6 @@ enum WhatsNewContent {
       title: "A steadier app under the hood",
       description:
         "We finished a major rebuild of how EnviousWispr is assembled and packaged. You won't see it directly, but it makes the app sturdier and lets us ship improvements to you faster and more safely.",
-      category: .fasterAndMoreReliable,
       version: "2.1.0"
     ),
 
@@ -406,7 +355,6 @@ enum WhatsNewContent {
       title: "Speak an emoji",
       description:
         "Say the emoji's name followed by the word \"emoji\" while you dictate, like \"smiley face emoji\" or \"thumbs up emoji\", and EnviousWispr drops the glyph right in.",
-      category: .newFeatures,
       version: "2.0.3"
     ),
     Entry(
@@ -415,7 +363,6 @@ enum WhatsNewContent {
       title: "Smarter language detection",
       description:
         "On the Multi-Language speech engine, EnviousWispr now notices when you keep dictating in the same non-English language and offers to lock it in. A fixed language makes transcription both faster and more accurate.",
-      category: .newFeatures,
       version: "2.0.3"
     ),
     Entry(
@@ -424,7 +371,6 @@ enum WhatsNewContent {
       title: "Newer AI Polish models",
       description:
         "AI Polish now works with the latest models. We recommend Gemini 3.5 Flash, or OpenAI 5.4 mini or nano, for the best balance of speed and quality.",
-      category: .smarterAIPolish,
       version: "2.0.3"
     ),
     Entry(
@@ -433,7 +379,6 @@ enum WhatsNewContent {
       title: "A steadier app under the hood",
       description:
         "We continued a major rebuild of how the app manages itself internally. You won't see it directly, but it makes EnviousWispr more stable and quicker for us to improve.",
-      category: .fasterAndMoreReliable,
       version: "2.0.3"
     ),
 
@@ -445,7 +390,6 @@ enum WhatsNewContent {
       title: "One key to talk",
       description:
         "Push-to-talk now defaults to a single tap of Right Option. Faster to reach than a two-key combo, and easier to remember. You can still remap it in Settings.",
-      category: .qualityOfLife,
       version: "2.0.2"
     ),
     Entry(
@@ -454,7 +398,6 @@ enum WhatsNewContent {
       title: "AI Polish keys live in your keychain",
       description:
         "Your API keys for AI Polish are now stored in your Mac's keychain, the same secure place your other passwords live. Existing keys were moved over automatically.",
-      category: .privacyAndSecurity,
       version: "2.0.2"
     ),
     Entry(
@@ -463,7 +406,6 @@ enum WhatsNewContent {
       title: "Cleaner audio settings",
       description:
         "Removed the noise suppression toggle. It wasn't doing what its name suggested, and a quieter settings panel is one less thing to wonder about.",
-      category: .qualityOfLife,
       version: "2.0.2"
     ),
     Entry(
@@ -472,7 +414,6 @@ enum WhatsNewContent {
       title: "Update reminder stays put",
       description:
         "When a new version is ready, the in-app banner now stays visible until you install. No more dismissing it and forgetting it was there.",
-      category: .qualityOfLife,
       version: "2.0.2"
     ),
 
@@ -484,7 +425,6 @@ enum WhatsNewContent {
       title: "Better error logging",
       description:
         "Improved our error logging so we can spot issues and enhance your experience faster.",
-      category: .fasterAndMoreReliable,
       version: "2.0.1"
     ),
 
@@ -496,7 +436,6 @@ enum WhatsNewContent {
       title: "Welcome to EnviousWispr 2.0",
       description:
         "EnviousWispr 2.0 is about trust. Better text on the first try, sharper memory for your words, and fewer moments where you have to step in.",
-      category: .newFeatures,
       version: "2.0.0"
     ),
     Entry(
@@ -505,7 +444,6 @@ enum WhatsNewContent {
       title: "\"Your Words\" has a real home now",
       description:
         "Learning, Vocab Packs, and Custom Terms each have their own section in Settings. Easier to see what EnviousWispr remembers, what you added yourself, and where to tune it.",
-      category: .newFeatures,
       version: "2.0.0"
     ),
     Entry(
@@ -514,7 +452,6 @@ enum WhatsNewContent {
       title: "Apple Intelligence keeps your voice and your precision",
       description:
         "On-device polish keeps your voice and your precision. Casual notes keep your tone. Code, jargon, and careful business writing keep their precision. Six months of tuning underpins this.",
-      category: .smarterAIPolish,
       version: "2.0.0"
     ),
     Entry(
@@ -523,7 +460,6 @@ enum WhatsNewContent {
       title: "Your custom terms now survive on-device polish",
       description:
         "Words you teach EnviousWispr now carry through to Apple Intelligence polish, not just cloud polish. Product names, client names, and domain terms are far less likely to get cleaned into the wrong thing.",
-      category: .smarterAIPolish,
       version: "2.0.0"
     ),
     Entry(
@@ -532,7 +468,6 @@ enum WhatsNewContent {
       title: "Less fiddling, better polished text",
       description:
         "Formal, Standard, and Friendly are gone. They rarely changed the result and could quietly bypass smart routing on Apple Intelligence. There is now one quality-tuned default that delivers more consistently.",
-      category: .smarterAIPolish,
       version: "2.0.0"
     ),
     Entry(
@@ -541,7 +476,6 @@ enum WhatsNewContent {
       title: "Pick the right polish model faster",
       description:
         "Polish models are now grouped by provider with a short note on what each one is good at. Less hunting, better choices.",
-      category: .smarterAIPolish,
       version: "2.0.0"
     ),
     Entry(
@@ -550,7 +484,6 @@ enum WhatsNewContent {
       title: "Adding a new word is smarter now",
       description:
         "When you add a custom term, EnviousWispr suggests likely spellings and pronunciations to catch. Repetitive or low-quality suggestions are filtered out more aggressively.",
-      category: .smarterAIPolish,
       version: "2.0.0"
     ),
     Entry(
@@ -559,7 +492,6 @@ enum WhatsNewContent {
       title: "Cleaner transcription before polish",
       description:
         "The speech engine is now faster and steadier, especially on longer recordings. Fewer odd substitutions and cleaner raw text before polish even runs.",
-      category: .fasterAndMoreReliable,
       version: "2.0.0"
     ),
     Entry(
@@ -568,7 +500,6 @@ enum WhatsNewContent {
       title: "No more phantom \"Thank you\"",
       description:
         "Silent endings used to occasionally produce a fake \"Thank you.\" That hallucination is now suppressed at the source.",
-      category: .fasterAndMoreReliable,
       version: "2.0.0"
     ),
     Entry(
@@ -577,7 +508,6 @@ enum WhatsNewContent {
       title: "Your first word stays in the transcript",
       description:
         "The opening word of a recording could sometimes disappear. Fixed. Dictation now starts where you start.",
-      category: .fasterAndMoreReliable,
       version: "2.0.0"
     ),
     Entry(
@@ -586,7 +516,6 @@ enum WhatsNewContent {
       title: "Auto language detection actually works",
       description:
         "Leave language on Auto and EnviousWispr will detect what you spoke instead of assuming English. Short clips also decide faster, so quick commands feel snappier.",
-      category: .fasterAndMoreReliable,
       version: "2.0.0"
     ),
     Entry(
@@ -595,7 +524,6 @@ enum WhatsNewContent {
       title: "Stuck model loads recover sooner",
       description:
         "If a speech model gets wedged while loading, EnviousWispr now notices earlier and recovers without the long wait. Slow but healthy loads are left alone.",
-      category: .fasterAndMoreReliable,
       version: "2.0.0"
     ),
     Entry(
@@ -604,7 +532,6 @@ enum WhatsNewContent {
       title: "Custom Words stays fast at scale",
       description:
         "Even very large custom-word lists now stay responsive during polish. Long replacements that used to get dropped now apply correctly, and a failed save no longer throws away what you typed.",
-      category: .fasterAndMoreReliable,
       version: "2.0.0"
     ),
     Entry(
@@ -613,7 +540,6 @@ enum WhatsNewContent {
       title: "Clear help when auto-paste needs access",
       description:
         "If Accessibility permission is missing, EnviousWispr now tells you exactly why paste could not happen and gives you a quick path to fix it. No more silent fallback to the clipboard.",
-      category: .qualityOfLife,
       version: "2.0.0"
     ),
     Entry(
@@ -622,7 +548,6 @@ enum WhatsNewContent {
       title: "Update when you are ready",
       description:
         "New versions show up as a quiet in-app banner instead of an interrupting popup. You stay in flow, then update on your schedule.",
-      category: .qualityOfLife,
       version: "2.0.0"
     ),
     Entry(
@@ -631,7 +556,6 @@ enum WhatsNewContent {
       title: "Stronger privacy, by default",
       description:
         "Cloud polish now opts out of training storage where supported. Crash reports scrub sensitive details before they leave your Mac. Stored files have tighter permissions. Gemini request logging is off. The Privacy section explains what each cloud provider keeps.",
-      category: .privacyAndSecurity,
       version: "2.0.0"
     ),
 
@@ -643,7 +567,6 @@ enum WhatsNewContent {
       title: "Smoother model switching",
       description:
         "Switching between local AI polish models now frees up the previous model cleanly, so your Mac stays responsive and recordings keep working.",
-      category: .betterOllamaSupport,
       version: "1.9.4"
     ),
     Entry(
@@ -652,7 +575,6 @@ enum WhatsNewContent {
       title: "More reliable recordings",
       description:
         "Fewer silent failures. The audio helper now recovers cleanly from a rare crash class, and the microphone bounces back better from bad states after long idle periods or audio interruptions.",
-      category: .fasterAndMoreReliable,
       version: "1.9.4"
     ),
     Entry(
@@ -661,7 +583,6 @@ enum WhatsNewContent {
       title: "Ollama downloads show progress and can be cancelled",
       description:
         "The Manage Models row now shows a live progress bar while an Ollama model downloads, plus a Cancel button. No more wondering whether the download is stuck or how big it is.",
-      category: .betterOllamaSupport,
       version: "1.9.4"
     ),
     Entry(
@@ -670,7 +591,6 @@ enum WhatsNewContent {
       title: "Faster first polish after a pause",
       description:
         "Your first dictation after a quiet stretch now gets polished faster. The pre-warm probe talks to the LLM the same way a real polish does, so the first real call doesn't pay a cold-start tax.",
-      category: .fasterAndMoreReliable,
       version: "1.9.4"
     ),
     Entry(
@@ -679,7 +599,6 @@ enum WhatsNewContent {
       title: "Paste works in more apps",
       description:
         "Dictating into Chrome, Slack, Discord, VS Code, and other Electron-based apps now pastes cleanly even when the focused text field isn't fully reported. Previously the text would sometimes sit on the clipboard instead of landing in place.",
-      category: .fasterAndMoreReliable,
       version: "1.9.4"
     ),
     Entry(
@@ -688,7 +607,6 @@ enum WhatsNewContent {
       title: "Gemma 3 Nano joins the Ollama lineup",
       description:
         "Google's 4B Gemma 3 Nano is now available in the Ollama model picker. A tight on-device option for AI polish when you want speed and privacy and don't need a large model.",
-      category: .betterOllamaSupport,
       version: "1.9.4"
     ),
 
@@ -700,7 +618,6 @@ enum WhatsNewContent {
       title: "Gemma 4 polish works again",
       description:
         "Local AI polish with Gemma 4 was quietly falling back to the raw transcript on every dictation. It now produces cleaned-up output reliably. Fillers are removed, punctuation is added, and lists are formatted, all running offline on your Mac.",
-      category: .betterOllamaSupport,
       version: "1.9.3"
     ),
     Entry(
@@ -709,7 +626,6 @@ enum WhatsNewContent {
       title: "Better support for reasoning models",
       description:
         "Thinking models like Gemma 4, Qwen 3, QwQ, DeepSeek R1, and gpt-oss now have enough room to finish reasoning and still produce a clean polished answer. Smaller local models still run on the tight budget that keeps them fast and reliable.",
-      category: .smarterAIPolish,
       version: "1.9.3"
     ),
 
@@ -721,7 +637,6 @@ enum WhatsNewContent {
       title: "Dictate in 99 languages",
       description:
         "EnviousWispr now auto-detects the language you are speaking and transcribes accordingly. German, Japanese, Arabic, Tamil, Mandarin and 95 others work out of the box with no setting change needed.",
-      category: .newFeatures,
       version: "1.9.2"
     ),
     Entry(
@@ -730,7 +645,6 @@ enum WhatsNewContent {
       title: "Apple Intelligence polish stays in your language",
       description:
         "AI polish with Apple Intelligence now preserves the language you spoke in. German stays German, Korean stays Korean. Languages Apple Intelligence cannot handle are quietly skipped so you always get your raw transcript instead of a silent failure.",
-      category: .smarterAIPolish,
       version: "1.9.2"
     ),
     Entry(
@@ -739,7 +653,6 @@ enum WhatsNewContent {
       title: "WhisperKit captures every word",
       description:
         "Fixed an issue where the last few words of a dictation could be silently dropped when using WhisperKit. Every word now reaches your clipboard.",
-      category: .fasterAndMoreReliable,
       version: "1.9.2"
     ),
     Entry(
@@ -748,7 +661,6 @@ enum WhatsNewContent {
       title: "Ollama handles long dictations",
       description:
         "Local AI polish with large models like Gemma 4 no longer times out on longer recordings. Timeout budgets now adapt to your provider.",
-      category: .betterOllamaSupport,
       version: "1.9.2"
     ),
 
@@ -760,7 +672,6 @@ enum WhatsNewContent {
       title: "What's New tab",
       description:
         "See what changed after every update, right here in Settings. The sidebar icon glows rainbow when there are unread notes.",
-      category: .newFeatures,
       version: "1.9.1"
     ),
     Entry(
@@ -769,7 +680,6 @@ enum WhatsNewContent {
       title: "Smarter paste detection",
       description:
         "Transcribed text now pastes correctly into Slack, Discord, and other Electron apps that were previously missed.",
-      category: .qualityOfLife,
       version: "1.9.1"
     ),
     Entry(
@@ -778,7 +688,6 @@ enum WhatsNewContent {
       title: "Clipboard fallback overlay",
       description:
         "When no text field is selected, your transcription is copied to the clipboard and a notification tells you to press Cmd+V.",
-      category: .qualityOfLife,
       version: "1.9.1"
     ),
 
@@ -790,7 +699,6 @@ enum WhatsNewContent {
       title: "Context-aware prompts",
       description:
         "Each AI provider now gets prompts optimized for its strengths, producing better polish results.",
-      category: .smarterAIPolish,
       version: "1.9.0"
     ),
     Entry(
@@ -799,7 +707,6 @@ enum WhatsNewContent {
       title: "Apple Intelligence guardrails",
       description:
         "AI polish no longer over-edits your text or answers questions instead of polishing them. Five protective rules keep your words intact.",
-      category: .smarterAIPolish,
       version: "1.9.0"
     ),
     Entry(
@@ -808,7 +715,6 @@ enum WhatsNewContent {
       title: "Re-polish from History",
       description:
         "The Enhance button on existing transcripts now works correctly for all speech engine types.",
-      category: .smarterAIPolish,
       version: "1.9.0"
     ),
     Entry(
@@ -817,7 +723,6 @@ enum WhatsNewContent {
       title: "Auto-discover models",
       description:
         "New Ollama models appear automatically once downloaded. No more hardcoded lists.",
-      category: .betterOllamaSupport,
       version: "1.9.0"
     ),
     Entry(
@@ -826,7 +731,6 @@ enum WhatsNewContent {
       title: "Warm-up indicator",
       description:
         "See when your Ollama model is loading into GPU memory with a live status spinner.",
-      category: .betterOllamaSupport,
       version: "1.9.0"
     ),
     Entry(
@@ -835,7 +739,6 @@ enum WhatsNewContent {
       title: "Native API",
       description:
         "Switched to Ollama's native API for better compatibility with reasoning models like Gemma 4.",
-      category: .betterOllamaSupport,
       version: "1.9.0"
     ),
     Entry(
@@ -844,7 +747,6 @@ enum WhatsNewContent {
       title: "Instant first press",
       description:
         "Eliminated the delay on your very first recording. The speech engine warms up at launch.",
-      category: .fasterAndMoreReliable,
       version: "1.9.0"
     ),
     Entry(
@@ -853,7 +755,6 @@ enum WhatsNewContent {
       title: "No more phantom text",
       description:
         "Fixed the #1 reported issue: holding the record button in silence no longer produces hallucinated words.",
-      category: .fasterAndMoreReliable,
       version: "1.9.0"
     ),
     Entry(
@@ -862,7 +763,6 @@ enum WhatsNewContent {
       title: "Whispered speech captured",
       description:
         "Quiet sensitivity mode now correctly captures whispered speech that was previously dropped.",
-      category: .fasterAndMoreReliable,
       version: "1.9.0"
     ),
     Entry(
@@ -871,7 +771,6 @@ enum WhatsNewContent {
       title: "Paste-back fix",
       description:
         "Fixed a macOS 14+ issue where transcribed text sometimes failed to paste into the target app.",
-      category: .fasterAndMoreReliable,
       version: "1.9.0"
     ),
     Entry(
@@ -880,7 +779,6 @@ enum WhatsNewContent {
       title: "Configurable engine timeout",
       description:
         "Choose how long to keep the microphone warm between recordings: 10s, 30s, 60s, or always.",
-      category: .qualityOfLife,
       version: "1.9.0"
     ),
     Entry(
@@ -889,7 +787,6 @@ enum WhatsNewContent {
       title: "Better error messages",
       description:
         "Clearer notifications when something goes wrong, with distinct warnings for partial vs. complete failures.",
-      category: .qualityOfLife,
       version: "1.9.0"
     ),
   ]
@@ -902,17 +799,17 @@ enum WhatsNewContent {
     }
   }
 
-  /// Entries grouped by version (newest first), then by category within each version.
-  static var groupedByVersion:
-    [(version: String, sections: [(category: Category, entries: [Entry])])]
-  {
+  /// Entries grouped by version (newest first). Within a version, entries render in
+  /// SOURCE ORDER: the author controls the sequence by where they place the `Entry`
+  /// in `entries`.
+  ///
+  /// There is no category tier. Each entry is its own titled card, so this order IS
+  /// the hierarchy the user reads, in the app and in the generated GitHub release
+  /// notes alike. Nothing re-sorts or groups it. Author each version
+  /// headline-feature-first: the first entry is that release's pitch.
+  static var entriesByVersion: [(version: String, entries: [Entry])] {
     versions.map { version in
-      let versionEntries = entries.filter { $0.version == version }
-      let sections = Category.allCases.compactMap { category -> (Category, [Entry])? in
-        let items = versionEntries.filter { $0.category == category }
-        return items.isEmpty ? nil : (category, items)
-      }
-      return (version, sections)
+      (version, entries.filter { $0.version == version })
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewSettingsView.swift
@@ -7,29 +7,34 @@ struct WhatsNewSettingsView: View {
   var body: some View {
     SettingsContentView {
       // Page title + subtitle now come from the injected page-header card.
-      ForEach(WhatsNewContent.groupedByVersion, id: \.version) { versionGroup in
+      ForEach(WhatsNewContent.entriesByVersion, id: \.version) { versionGroup in
         // Version header
         Text("v\(versionGroup.version)")
           .settingsRowTitle()
           .padding(.top, 8)
 
-        // Category sections within this version
-        ForEach(versionGroup.sections, id: \.category.id) { section in
-          BrandedSection(header: section.category.title) {
-            ForEach(Array(section.entries.enumerated()), id: \.element.id) { index, entry in
-              BrandedRow(showDivider: index < section.entries.count - 1) {
-                HStack(alignment: .top, spacing: 12) {
-                  Image(systemName: entry.icon)
-                    .font(.system(size: 16))
-                    .foregroundStyle(.stAccent)
-                    .frame(width: 24, alignment: .center)
-                  VStack(alignment: .leading, spacing: 2) {
-                    Text(entry.title)
-                      .settingsRowLabel()
-                    Text(entry.description)
-                      .settingsReadingCopy()
-                  }
-                }
+        // Each entry stands alone: its own specific title as the accent header,
+        // with the card below given entirely to the description. There is no
+        // category tier — the old generic eyebrows ("New Features", "Faster and
+        // More Reliable") repeated down the page and carried no information, so
+        // the eye could not use them to find anything (founder, 2026-07-11).
+        ForEach(versionGroup.entries) { entry in
+          VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 10) {
+              SettingsRowIcon(systemName: entry.icon)
+              Text(entry.title)
+                .font(.stRowTitle)
+                .foregroundStyle(.stAccent)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isHeader)
+            .padding(.leading, 4)
+
+            BrandedSection {
+              BrandedRow(showDivider: false) {
+                Text(entry.description)
+                  .settingsReadingCopy()
               }
             }
           }

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+
+/// What's New had NO Swift test coverage before #1493 — its only guard was the
+/// weekly `render-release-notes.py --self-test` in ci-drift-check, which is not a
+/// per-PR gate. These tests are the Swift-side twin of that self-test: they freeze
+/// the invariants the release-notes renderer and the Settings screen both depend on.
+@Suite("What's New content")
+struct WhatsNewContentTests {
+
+  // MARK: - Grouping preserves every entry
+
+  @Test("entriesByVersion drops no entry")
+  func groupingDropsNothing() {
+    let grouped = WhatsNewContent.entriesByVersion.flatMap(\.entries)
+    #expect(grouped.count == WhatsNewContent.entries.count)
+
+    // Not just the count — the same entries, so a filter bug cannot pass by
+    // coincidentally swapping one entry for another.
+    #expect(Set(grouped.map(\.id)) == Set(WhatsNewContent.entries.map(\.id)))
+  }
+
+  @Test("every entry appears under exactly one version group")
+  func noEntryDuplicated() {
+    let grouped = WhatsNewContent.entriesByVersion.flatMap(\.entries)
+    #expect(Set(grouped.map(\.id)).count == grouped.count)
+  }
+
+  @Test("entry ids are unique")
+  func idsAreUnique() {
+    let ids = WhatsNewContent.entries.map(\.id)
+    #expect(Set(ids).count == ids.count)
+  }
+
+  // MARK: - Order is the hierarchy (no category tier rescues it)
+
+  /// Since the category tier was removed, within-version SOURCE ORDER is exactly
+  /// what the user reads — in the app and in the generated GitHub release notes.
+  /// If this regresses, a release silently stops leading with its headline feature.
+  @Test("within a version, entries stay in source order")
+  func sourceOrderPreserved() {
+    for group in WhatsNewContent.entriesByVersion {
+      let expected = WhatsNewContent.entries
+        .filter { $0.version == group.version }
+        .map(\.id)
+      #expect(group.entries.map(\.id) == expected, "v\(group.version) lost source order")
+    }
+  }
+
+  @Test("versions are newest-first")
+  func versionsAreNewestFirst() {
+    // Assert the real current sequence. This is deliberately NOT a claim about
+    // hypothetical multi-digit components (e.g. 2.3.10 vs 2.3.9): no such version
+    // exists in the array, every current component is a single digit, so this data
+    // physically cannot distinguish numeric from lexical sorting. The comparator is
+    // untouched by #1493; asserting the real sequence is the falsifiable version.
+    #expect(
+      WhatsNewContent.versions == [
+        "2.3.2", "2.3.1", "2.3.0",
+        "2.2.1", "2.2.0",
+        "2.1.4", "2.1.3", "2.1.2", "2.1.1", "2.1.0",
+        "2.0.3", "2.0.2", "2.0.1", "2.0.0",
+        "1.9.4", "1.9.3", "1.9.2", "1.9.1", "1.9.0",
+      ])
+
+    #expect(WhatsNewContent.entriesByVersion.map(\.version) == WhatsNewContent.versions)
+  }
+
+  // MARK: - Release gate
+
+  /// whats-new-protocol.md RULE: whats-new-release-gate — every release ships notes.
+  /// Previously this was only checked by a weekly CI job; now a release that bumps
+  /// the content version without writing an entry fails the test suite immediately.
+  @Test("the current content version has at least one entry")
+  func currentVersionHasEntries() {
+    let current = WhatsNewConstants.currentContentVersion
+    let entries = WhatsNewContent.entries.filter { $0.version == current }
+    #expect(
+      !entries.isEmpty,
+      "currentContentVersion is \(current) but no What's New entry ships for it")
+  }
+
+  @Test("the newest version group IS the current content version")
+  func newestGroupIsCurrentVersion() {
+    #expect(
+      WhatsNewContent.entriesByVersion.first?.version == WhatsNewConstants.currentContentVersion)
+  }
+
+  // MARK: - Content sanity
+
+  /// The title is now the ONLY header on the card, so an empty one leaves an entry
+  /// with no heading at all, and an empty description leaves an empty card.
+  @Test("no entry has an empty title, description, or icon")
+  func noEmptyFields() {
+    for entry in WhatsNewContent.entries {
+      #expect(!entry.title.trimmingCharacters(in: .whitespaces).isEmpty, "\(entry.id): empty title")
+      #expect(
+        !entry.description.trimmingCharacters(in: .whitespaces).isEmpty,
+        "\(entry.id): empty description")
+      #expect(!entry.icon.trimmingCharacters(in: .whitespaces).isEmpty, "\(entry.id): empty icon")
+    }
+  }
+}

--- a/scripts/ci/render-release-notes.py
+++ b/scripts/ci/render-release-notes.py
@@ -3,7 +3,21 @@
 
 Single source of truth: Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
 (the same copy users see in Settings > What's New). This script extracts the entries
-for one version and emits grouped, plain-English markdown for the GitHub release body.
+for one version and emits a flat, plain-English markdown list for the GitHub release body.
+
+Entries render in SOURCE ORDER: whatever order the author placed them in the Swift
+`entries` array is the order the reader gets, here and in the app. There is no category
+grouping (removed 2026-07-11 — the six generic headings repeated down every release and
+carried no information). Source order IS the hierarchy, so a version must be authored
+headline-feature-first.
+
+Parse contract: `title`, `description`, and `version` must be direct, ordinary
+double-quoted Swift literals. This script reads Swift source TEXT, it does not compile it.
+A raw string or a named constant makes the entry fail to parse (--self-test catches that,
+because it asserts the parsed count matches the number of `version:` fields). Concatenation
+silently captures only the first segment, and interpolation emits unresolved Swift source:
+NEITHER is caught by the count check, so both would ship wrong text. Validate by comparing
+parsed values against expected strings, not by counting items alone.
 
 Used by .github/workflows/release.yml. Designed to fail SAFELY: if it cannot produce
 notes for the requested version, it exits non-zero and the workflow falls back to
@@ -28,17 +42,6 @@ CONSTANTS_SWIFT = os.path.join(
     REPO_ROOT, "Sources/EnviousWisprCore/WhatsNewConstants.swift"
 )
 
-# Mirror of WhatsNewContent.Category raw values, in display order.
-CATEGORY_RAW = {
-    "newFeatures": "New Features",
-    "smarterAIPolish": "Smarter AI Polish",
-    "betterOllamaSupport": "Better Ollama Support",
-    "fasterAndMoreReliable": "Faster and More Reliable",
-    "qualityOfLife": "Quality of Life",
-    "privacyAndSecurity": "Privacy and Security",
-}
-CATEGORY_ORDER = list(CATEGORY_RAW.values())
-
 def parse_entries(swift_path):
     with open(swift_path, encoding="utf-8") as fh:
         text = fh.read()
@@ -51,9 +54,8 @@ def parse_entries(swift_path):
     for chunk in text.split("Entry(")[1:]:
         t = re.search(r'title:\s*\n?\s*"((?:[^"\\]|\\.)*)"', chunk, re.DOTALL)
         d = re.search(r'description:\s*\n?\s*"((?:[^"\\]|\\.)*)"', chunk, re.DOTALL)
-        c = re.search(r"category:\s*\.(\w+)", chunk)
         v = re.search(r'version:\s*"([\d.]+)"', chunk)
-        if not (t and d and c and v):
+        if not (t and d and v):
             continue
         title = t.group(1).replace('\\"', '"')
         title = re.sub(r"\s*\\\s*\n\s*", " ", title)
@@ -61,14 +63,7 @@ def parse_entries(swift_path):
         desc = d.group(1).replace('\\"', '"')
         desc = re.sub(r"\s*\\\s*\n\s*", " ", desc)
         desc = re.sub(r"\s+", " ", desc).strip()
-        entries.append(
-            {
-                "title": title,
-                "desc": desc,
-                "category": CATEGORY_RAW.get(c.group(1), c.group(1)),
-                "version": v.group(1),
-            }
-        )
+        entries.append({"title": title, "desc": desc, "version": v.group(1)})
     return entries
 
 
@@ -77,29 +72,18 @@ def version_key(v):
 
 
 def render(entries, version):
+    # Flat list in SOURCE ORDER — `parse_entries` walks the Swift file top-to-bottom,
+    # and `filter` preserves that order, so the author's sequence is the reader's.
+    # No sorting or grouping happens here by design.
     es = [e for e in entries if e["version"] == version]
     if not es:
         return None
-    # Known categories first in canonical display order, then any category present
-    # in the entries but not in CATEGORY_ORDER (e.g. a new WhatsNewContent.Category
-    # case added in Swift) appended in first-appearance order, so an entry is never
-    # silently dropped from release notes.
-    ordered = list(CATEGORY_ORDER)
-    for e in es:
-        if e["category"] not in ordered:
-            ordered.append(e["category"])
     out = []
-    for cat in ordered:
-        ces = [e for e in es if e["category"] == cat]
-        if not ces:
-            continue
-        out.append(f"### {cat}\n")
-        for e in ces:
-            title = e["title"].rstrip()
-            if title and title[-1] not in ".!?":
-                title += "."
-            out.append(f"- **{title}** {e['desc']}")
-        out.append("")
+    for e in es:
+        title = e["title"].rstrip()
+        if title and title[-1] not in ".!?":
+            title += "."
+        out.append(f"- **{title}** {e['desc']}")
     rendered = "\n".join(out).strip()
     return rendered or None
 


### PR DESCRIPTION
Closes #1493.

## What changed

The six generic category eyebrows ("New Features", "Faster and More Reliable") repeated down every page and carried no information, while the one line specific to each change sat buried inside the card. Founder: *"it's hard to quickly find the improvements with repeating headers, it just blurs together."*

Each entry now stands alone: its **specific title is the accent header**, and the card below is given entirely to the description.

The category system is **deleted, not hidden** — from the app, the data model, and the release-notes renderer — so it cannot silently persist. That also removes a cross-language duplication: `render-release-notes.py` kept a hand-maintained mirror of the Swift enum (`CATEGORY_RAW` / `CATEGORY_ORDER`) that had to be updated in lockstep.

**Consequence:** within-version *source order* is now the hierarchy the user reads, in the app and in the GitHub release notes alike. Nothing re-sorts it.

## Founder decisions

1. **No historical reorder.** Flattening shifts within-version order for 6 of 19 past versions; v2.2.1 would demote its headline feature below a bug fix. Founder declined the swap ("no one is going to be scrolling that far back"). Source order ships preserved byte-for-byte.
2. **New binding authoring rule** (`whats-new-protocol.md`): future releases must be authored headline-feature-first, because nothing re-sorts them. Founder: *"for new launches we'll of course lead with the sexy features."*

## Files

| File | Change |
|---|---|
| `WhatsNewContent.swift` | delete `Category`, `Entry.category` (90 entries), `groupedByVersion`; add `entriesByVersion` |
| `WhatsNewSettingsView.swift` | per-entry title + card; reuses `SettingsRowIcon` / `BrandedSection` / `BrandedRow` |
| `render-release-notes.py` | delete the enum mirror, relax the parse guard, emit a flat list. CLI + fail-safe contract unchanged |
| `WhatsNewContentTests.swift` | **new** — What's New previously had zero Swift coverage |

## Validation

- `scripts/xcode-test.sh` green (2729 tests). New suite: 8 tests, all execute.
- **Mutation-tested** the source-order assertion: reversing the filter makes it fail, so it is falsifiable rather than decorative.
- Renderer exercised with the real tool: `--self-test` parses **90** (unchanged), flat output, zero `###` headings, and **parsed-value equality** asserted on the long escaped-quote entry to prove no truncation (the entry-count check alone cannot catch a truncated string).
- Codex grounded review: 5 rounds → PROCEED-AS-PLANNED on a confirming re-run. Codex code-diff review: clean.
- **Live UAT, both themes** (screenshot, not AX — layout/contrast verdict): specific purple titles, zero generic eyebrows, titles share one left edge, cards hold only the fix text.

## Blast radius

One settings screen + one CI script. Zero heart-path contact. Worst case is a release body falling back to auto-generated notes — harmless and revertible in one commit.

Plan: `docs/feature-requests/plan-2026-07-11-whats-new-entry-first-layout.md`
