### PR TITLE
feat(ui): Bluetooth cold-start awareness card + Microphone settings guide (#1480)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -62,6 +62,11 @@ final class AppLifecycleCoordinator {
   // #1451: launch-time App Translocation recovery limb. Called once on launch;
   // never a prerequisite for anything below it.
   private let applicationRelocationCoordinator: ApplicationRelocationCoordinator
+  // #1480: forwards launch / device-change / pipeline-state facts to the
+  // Bluetooth awareness card's single decision owner. The coordinator carries no
+  // Bluetooth predicate, overlay branching, or once-per-launch state — it only
+  // hands the presenter a `Trigger` fact.
+  private let bluetoothAwarenessPresenter: BluetoothAwarenessPresenter
 
   init(
     settings: SettingsManager,
@@ -82,6 +87,7 @@ final class AppLifecycleCoordinator {
     appWindowCoordinator: AppWindowCoordinator,
     hotkeyService: HotkeyService,
     applicationRelocationCoordinator: ApplicationRelocationCoordinator,
+    bluetoothAwarenessPresenter: BluetoothAwarenessPresenter,
     // #1176: captured in the onboarding-dismiss closure below (NOT stored — keeps
     // this coordinator's stored-property ceiling clean).
     onboardingProgress: OnboardingProgress
@@ -104,6 +110,7 @@ final class AppLifecycleCoordinator {
     self.appWindowCoordinator = appWindowCoordinator
     self.hotkeyService = hotkeyService
     self.applicationRelocationCoordinator = applicationRelocationCoordinator
+    self.bluetoothAwarenessPresenter = bluetoothAwarenessPresenter
     // Icon-refresh seam: the window coordinator's two onboarding-dismiss
     // callsites route through this closure. Was wired in `AppDelegate.attach`
     // before PR-B.4.
@@ -162,6 +169,10 @@ final class AppLifecycleCoordinator {
       if state == .recording {
         self.audioEnvironmentSnapshotter?.recordingStarted()
       }
+      // #1480: any pipeline-state change re-evaluates the Bluetooth card — a
+      // record start supersedes + dismisses it (records `record_started`); a
+      // return to idle lets a not-yet-shown card surface (scenario 4).
+      self.bluetoothAwarenessPresenter.reconcile(trigger: .pipelineStateChanged)
     }
 
     // Start hotkeys now that the event loop is running.
@@ -232,6 +243,13 @@ final class AppLifecycleCoordinator {
         customWordsCoordinator: customWordsCoordinator,
         permissions: permissions
       ).emit()
+
+      // #1480: first launch-time evaluation of the Bluetooth card, after
+      // refreshOnLaunch() settled the launch state. Runs only for completed
+      // onboarding (onboarding owns the window otherwise); the presenter's own
+      // guards re-check Bluetooth / idle / tips-enabled. A headset that connects
+      // later is covered by the device-change ingress.
+      bluetoothAwarenessPresenter.reconcile(trigger: .launch)
     }
 
     // Pre-warm LLM backend with a real inference request.
@@ -289,6 +307,9 @@ final class AppLifecycleCoordinator {
       },
       onAudioDeviceEvent: { [weak self] in
         self?.audioEnvironmentSnapshotter?.audioDeviceEventOccurred()
+        // #1480: a device connect/disconnect/default-change re-evaluates the
+        // Bluetooth card (covers connect-later, and route-off dismissal).
+        self?.bluetoothAwarenessPresenter.reconcile(trigger: .deviceChanged)
       }
     )
   }

--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -171,8 +171,18 @@ final class AppLifecycleCoordinator {
       }
       // #1480: any pipeline-state change re-evaluates the Bluetooth card — a
       // record start supersedes + dismisses it (records `record_started`); a
-      // return to idle lets a not-yet-shown card surface (scenario 4).
-      self.bluetoothAwarenessPresenter.reconcile(trigger: .pipelineStateChanged)
+      // return to idle lets a not-yet-shown card surface (scenario 4). Deferred to
+      // the next run-loop cycle because this callback fires at the TOP of the
+      // pipeline handler, BEFORE the terminal overlay intent clears the recording
+      // pill (cloud review P2); reconcile must observe the settled `.hidden` slot,
+      // else the "Bluetooth connected mid-recording, show when idle returns" case
+      // is suppressed. Mirrors how the language chip surfaces after the overlay
+      // handler (`DictationLifecycleCoordinator.dispatchChipLifecycle`). Card
+      // teardown stays synchronous (single-slot dedup); only this bookkeeping/
+      // show re-check is deferred, so the §3D supersession contract holds.
+      DispatchQueue.main.async { [weak self] in
+        self?.bluetoothAwarenessPresenter.reconcile(trigger: .pipelineStateChanged)
+      }
     }
 
     // Start hotkeys now that the event loop is running.

--- a/Sources/EnviousWisprAppKit/App/BluetoothAwarenessCardView.swift
+++ b/Sources/EnviousWisprAppKit/App/BluetoothAwarenessCardView.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+
+/// #1480: canonical copy for the Bluetooth cold-start education. The three tip
+/// strings are IDENTICAL across the overlay popover and the Microphone-settings
+/// guide (plan §3c — same wording, reviewed together), so both surfaces read
+/// them from here and can never drift. Council-corrected wording (plan §3B/§14):
+/// "after your mic has been idle" not "first dictation"; "keeps follow-up
+/// dictations ready" not "instant"; "usually avoid this startup delay" not
+/// "more reliable". No em/en dashes (brand rule).
+enum BluetoothTipsCopy {
+  // Overlay popover
+  static let cardTitle = "Bluetooth mic detected"
+  static let cardIntro = "Bluetooth microphones can take a moment on a cold start."
+  static let cardFootnote = "Shown once per launch when Bluetooth is your mic"
+  static let gotItButton = "Got it"
+  static let adjustSettingsButton = "Adjust settings"
+  static let closeAccessibilityLabel = "Dismiss Bluetooth tips"
+
+  // Shared tips (identical on both surfaces)
+  static let tipTiming = "After your mic has been idle, wait 1 to 2 seconds before speaking."
+  static let tipReadiness =
+    "Microphone Readiness keeps follow-up dictations ready for up to 30 seconds (on by default)."
+  static let tipHeadphones = "Built-in or wired mics usually avoid this startup delay."
+
+  // SF Symbols for the three tips (same icons on both surfaces).
+  static let iconTiming = "clock"
+  static let iconReadiness = "timer"
+  static let iconHeadphones = "headphones"
+
+  // Microphone-settings guide
+  static let settingsHeader = "When using Bluetooth"
+  static let settingsIntro =
+    "Bluetooth microphones switch into call mode when a recording starts, which takes a moment on a cold start."
+  static let micOrder = "Preferred mic order: Built-in or wired > USB > Bluetooth"
+  static let settingsPS =
+    "Built-in, wired, and USB mics do not have this Bluetooth startup delay."
+  static let showTipsToggle = "Show Bluetooth tips"
+}
+
+// MARK: - BluetoothAwarenessCardView
+
+/// #1480: the once-per-launch Bluetooth cold-start education popover, rendered in
+/// the top-middle overlay slot by `RecordingOverlayPanel`. Theme-aware — every
+/// colour is a dynamic `st*` token (`SettingsDesignTokens.swift`), so it resolves
+/// per `NSApp.appearance` and swaps with the appearance ticker exactly like the
+/// rest of the app.
+///
+/// The view owns NO dismissal state and NO timer: its three buttons forward the
+/// user's tap to `BluetoothAwarenessPresenter` via the injected closures, and the
+/// presenter alone decides teardown + telemetry. Any fade is view-local and
+/// becomes harmless the moment the hosting panel closes (plan §3D supersession
+/// contract — no completion-owned teardown).
+struct BluetoothAwarenessCardView: View {
+  let onGotIt: () -> Void
+  let onClose: () -> Void
+  let onAdjustSettings: () -> Void
+
+  private static let cardWidth: CGFloat = 320
+
+  var body: some View {
+    VStack(spacing: 0) {
+      VStack(spacing: 14) {
+        // Title + intro (centered).
+        VStack(spacing: 6) {
+          Text(BluetoothTipsCopy.cardTitle)
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(.stTextPrimary)
+            .multilineTextAlignment(.center)
+          Text(BluetoothTipsCopy.cardIntro)
+            .font(.system(size: 13))
+            .foregroundStyle(.stTextSecondary)
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+
+        // Tips (left-aligned rows — icon and sentence on the same line).
+        VStack(alignment: .leading, spacing: 12) {
+          tipRow(icon: BluetoothTipsCopy.iconTiming, text: BluetoothTipsCopy.tipTiming)
+          tipRow(icon: BluetoothTipsCopy.iconReadiness, text: BluetoothTipsCopy.tipReadiness)
+          tipRow(icon: BluetoothTipsCopy.iconHeadphones, text: BluetoothTipsCopy.tipHeadphones)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+        // Footnote (centered).
+        Text(BluetoothTipsCopy.cardFootnote)
+          .font(.system(size: 12))
+          .foregroundStyle(.stTextTertiary)
+          .multilineTextAlignment(.center)
+
+        // Actions (centered): primary "Got it" + quiet "Adjust settings".
+        VStack(spacing: 10) {
+          Button(action: onGotIt) {
+            Text(BluetoothTipsCopy.gotItButton)
+              .font(.system(size: 14, weight: .semibold))
+              .foregroundStyle(.white)
+              .padding(.horizontal, 28)
+              .padding(.vertical, 9)
+              .contentShape(Rectangle())
+              .background(Capsule().fill(Color.stAccentSolid))
+          }
+          .buttonStyle(.plain)
+
+          Button(action: onAdjustSettings) {
+            Text(BluetoothTipsCopy.adjustSettingsButton)
+              .font(.system(size: 13, weight: .medium))
+              .foregroundStyle(.stAccent)
+              .contentShape(Rectangle())
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .padding(.horizontal, 20)
+      .padding(.top, 20)
+      .padding(.bottom, 15)
+
+      // Brand rainbow bottom line.
+      rainbowLine
+    }
+    .frame(width: Self.cardWidth)
+    .background(Color.stSectionBg)
+    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: 18, style: .continuous)
+        .strokeBorder(Color.stAccent.opacity(0.18), lineWidth: 1)
+    )
+    .overlay(alignment: .topTrailing) {
+      Button(action: onClose) {
+        Image(systemName: "xmark")
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(.stTextTertiary)
+          .frame(width: 25, height: 25)
+          .contentShape(Rectangle())
+          .background(Color.stAccentLight, in: RoundedRectangle(cornerRadius: 8))
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(BluetoothTipsCopy.closeAccessibilityLabel)
+      .padding(11)
+    }
+    .shadow(color: .black.opacity(0.28), radius: 22, y: 12)
+  }
+
+  private func tipRow(icon: String, text: String) -> some View {
+    HStack(alignment: .center, spacing: 11) {
+      Image(systemName: icon)
+        .font(.system(size: 15, weight: .medium))
+        .foregroundStyle(.stAccent)
+        .frame(width: 34, height: 34)
+        .background(Color.stAccentLight, in: Circle())
+        .overlay(Circle().strokeBorder(Color.stAccent.opacity(0.22), lineWidth: 1))
+        .accessibilityHidden(true)
+      Text(text)
+        .font(.system(size: 13))
+        .foregroundStyle(.stTextBody)
+        .fixedSize(horizontal: false, vertical: true)
+      Spacer(minLength: 0)
+    }
+  }
+
+  private var rainbowLine: some View {
+    LinearGradient(
+      colors: [
+        Color(red: 1.0, green: 0.165, blue: 0.251),  // red
+        Color(red: 1.0, green: 0.549, blue: 0.0),  // orange
+        Color(red: 1.0, green: 0.843, blue: 0.0),  // yellow
+        Color(red: 0.678, green: 1.0, blue: 0.184),  // yellow-green
+        Color(red: 0.0, green: 0.98, blue: 0.604),  // mint
+        Color(red: 0.0, green: 1.0, blue: 1.0),  // cyan
+        Color(red: 0.118, green: 0.565, blue: 1.0),  // dodger blue
+        Color(red: 0.255, green: 0.412, blue: 0.882),  // royal blue
+        Color(red: 0.541, green: 0.169, blue: 0.886),  // purple
+      ],
+      startPoint: .leading,
+      endPoint: .trailing
+    )
+    .frame(height: 2)
+    .opacity(0.92)
+    .accessibilityHidden(true)
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/BluetoothAwarenessPresenter.swift
+++ b/Sources/EnviousWisprAppKit/App/BluetoothAwarenessPresenter.swift
@@ -205,7 +205,10 @@ final class BluetoothAwarenessPresenter {
   /// Resolve whether the CONFIGURED input is Bluetooth using the settings-sync
   /// precedence: `preferredInputDeviceIDOverride` first, `selectedInputDeviceUID`
   /// second, the CoreAudio default only when both are empty (Codex r2/r3). A
-  /// nonempty UID that no longer resolves fails CLOSED (returns false → no card).
+  /// nonempty UID that no longer resolves does NOT fail closed — it falls back to
+  /// the default input, mirroring the capture path's `resolvedDeviceID ??
+  /// defaultInputDeviceID()` so a disconnected pinned device still surfaces the
+  /// card when the real (default) input is Bluetooth (cloud review P2).
   /// Pure over two injected resolvers so the precedence is unit-tested without
   /// real CoreAudio devices; the bootstrapper supplies the live `AudioDeviceEnumerator`
   /// resolvers.

--- a/Sources/EnviousWisprAppKit/App/BluetoothAwarenessPresenter.swift
+++ b/Sources/EnviousWisprAppKit/App/BluetoothAwarenessPresenter.swift
@@ -1,0 +1,255 @@
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+
+/// #1480: owns the once-per-launch Bluetooth cold-start education popover — the
+/// single authority for WHEN it shows, WHEN it is torn down, and the telemetry
+/// for both. Every ingress (launch, audio-device change, pipeline-state change,
+/// onboarding completion, relevant setting change) forwards a `Trigger` fact to
+/// one synchronous `reconcile(trigger:)`; no caller contains "should I show"
+/// logic (plan §3c single-authority).
+///
+/// NOT `@Observable`: it is an internal collaborator, not a SwiftUI environment
+/// home — no view observes it (plan §3C / Codex r1 CF2). Structural template:
+/// `LanguageSuggestionPresenter`. Dependencies are narrow injected closures so
+/// the presenter never knows `RecordingOverlayPanel`'s or `SettingsManager`'s
+/// concrete type (clean test seam).
+///
+/// Three process-lifetime facts (all in-memory, reset every launch = the
+/// once-per-launch cadence; a UserDefaults key for `hasShownThisLaunch` would
+/// wrongly make it once-EVER). Codex r1 Q3: one "shown" flag cannot both prevent
+/// re-show AND dismiss a currently-visible card, so the visible-ownership fact is
+/// tracked separately.
+///
+/// Heart-path: pure limb. All methods no-throw, synchronous, MainActor. Never
+/// blocks or touches the dictation pipeline.
+@MainActor
+final class BluetoothAwarenessPresenter {
+  /// Which ingress asked the presenter to reconcile. Contextual only — the
+  /// decision always re-reads live state, so `reconcile` never branches on the
+  /// trigger; it is recorded on the breadcrumb for debugging which path surfaced
+  /// or dismissed the card.
+  enum Trigger: String, Sendable {
+    case launch
+    case deviceChanged = "device_changed"
+    case pipelineStateChanged = "pipeline_state_changed"
+    case settingChanged = "setting_changed"
+  }
+
+  /// A user tap on one of the card's three affordances.
+  enum UserAction {
+    case gotIt
+    case close
+    case adjustSettings
+  }
+
+  /// Telemetry actions (event name `bt_awareness.<rawValue>`). Fixed vocab.
+  enum Action: String {
+    case shown
+    case dismissed
+    case settingsOpened = "settings_opened"
+    case suppressedBySetting = "suppressed_by_setting"
+  }
+
+  /// Telemetry `dismissed` reasons. Present only on `.dismissed`. Fixed vocab.
+  enum DismissReason: String {
+    case gotIt = "got_it"
+    case recordStarted = "record_started"
+    case routeChanged = "route_changed"
+    case settingDisabled = "setting_disabled"
+    case closed
+  }
+
+  // MARK: - Process-lifetime facts (in-memory; reset each launch)
+
+  /// Has the card ever committed visibly this launch. Prevents re-show; never
+  /// blocks cleanup of a visible card.
+  private var hasShownThisLaunch = false
+  /// Does the presenter currently own the Bluetooth card in the overlay slot.
+  private var isPresented = false
+  /// Telemetry dedup: `suppressed_by_setting` fires at most once per launch.
+  private var hasEmittedSettingSuppressionThisLaunch = false
+
+  // MARK: - Injected dependencies (narrow closures)
+
+  private let readCurrentIntent: @MainActor () -> OverlayIntent
+  private let showOverlay: @MainActor () -> Void
+  /// Hides the overlay ONLY when it currently shows `.bluetoothAwareness`, so it
+  /// never removes a newer recording / processing / warning / error intent.
+  private let hideIfCurrent: @MainActor () -> Void
+  private let effectiveInputIsBluetooth: @MainActor () -> Bool
+  private let dictationIsIdle: @MainActor () -> Bool
+  private let onboardingCompleted: @MainActor () -> Bool
+  private let tipsEnabled: @MainActor () -> Bool
+  private let openMicrophoneSettings: @MainActor () -> Void
+  private let emit: @MainActor (Action, DismissReason?) -> Void
+
+  init(
+    readCurrentIntent: @escaping @MainActor () -> OverlayIntent,
+    showOverlay: @escaping @MainActor () -> Void,
+    hideIfCurrent: @escaping @MainActor () -> Void,
+    effectiveInputIsBluetooth: @escaping @MainActor () -> Bool,
+    dictationIsIdle: @escaping @MainActor () -> Bool,
+    onboardingCompleted: @escaping @MainActor () -> Bool,
+    tipsEnabled: @escaping @MainActor () -> Bool,
+    openMicrophoneSettings: @escaping @MainActor () -> Void,
+    emit: @escaping @MainActor (Action, DismissReason?) -> Void
+  ) {
+    self.readCurrentIntent = readCurrentIntent
+    self.showOverlay = showOverlay
+    self.hideIfCurrent = hideIfCurrent
+    self.effectiveInputIsBluetooth = effectiveInputIsBluetooth
+    self.dictationIsIdle = dictationIsIdle
+    self.onboardingCompleted = onboardingCompleted
+    self.tipsEnabled = tipsEnabled
+    self.openMicrophoneSettings = openMicrophoneSettings
+    self.emit = emit
+  }
+
+  // MARK: - Reconcile
+
+  /// The single show/dismiss decision. Synchronous, no `await`, so no
+  /// check-then-act window exists across a suspension (plan §5 six-class check).
+  ///
+  /// When already presenting, invalidating facts are checked on `isPresented`,
+  /// NOT on `readCurrentIntent()`: recording may already have synchronously
+  /// replaced the intent, so gating the record-started branch on the current
+  /// intent would never fire and the telemetry would be lost (Codex r2). Each
+  /// hide is still guarded by `currentIntent == .bluetoothAwareness` so a newer
+  /// intent is never torn down.
+  func reconcile(trigger: Trigger) {
+    let currentIntent = readCurrentIntent()
+    if isPresented {
+      if !tipsEnabled() {
+        if currentIntent == .bluetoothAwareness { hideIfCurrent() }
+        isPresented = false
+        emit(.dismissed, .settingDisabled)
+        breadcrumb(trigger, "dismissed", reason: DismissReason.settingDisabled.rawValue)
+        return
+      }
+      if !effectiveInputIsBluetooth() {
+        if currentIntent == .bluetoothAwareness { hideIfCurrent() }
+        isPresented = false
+        emit(.dismissed, .routeChanged)
+        breadcrumb(trigger, "dismissed", reason: DismissReason.routeChanged.rawValue)
+        return
+      }
+      if !dictationIsIdle() {
+        // Recording may already own the slot; hide is a no-op then, telemetry still fires.
+        if currentIntent == .bluetoothAwareness { hideIfCurrent() }
+        isPresented = false
+        emit(.dismissed, .recordStarted)
+        breadcrumb(trigger, "dismissed", reason: DismissReason.recordStarted.rawValue)
+        return
+      }
+      if currentIntent != .bluetoothAwareness {
+        // Another overlay replaced us while idle — release ownership silently.
+        isPresented = false
+        return
+      }
+      return
+    }
+
+    // Eligibility is evaluated BEFORE the tips setting so `suppressed_by_setting`
+    // counts only launches where the card WOULD have shown (a Bluetooth user, past
+    // onboarding, idle, slot free) — not every opted-out user with a built-in or
+    // wired mic who would never see it (Codex r2 P2: gating suppression behind the
+    // same eligibility keeps the opt-out metric meaningful).
+    guard !hasShownThisLaunch, onboardingCompleted(), effectiveInputIsBluetooth(),
+      dictationIsIdle(), readCurrentIntent() == .hidden
+    else { return }
+
+    guard tipsEnabled() else {
+      if !hasEmittedSettingSuppressionThisLaunch {
+        hasEmittedSettingSuppressionThisLaunch = true
+        emit(.suppressedBySetting, nil)
+        breadcrumb(trigger, "suppressed_by_setting", reason: nil)
+      }
+      return
+    }
+
+    showOverlay()
+    // Confirm the overlay actually took the intent before committing state (a
+    // concurrent show could have won the single slot in the same run-loop turn).
+    guard readCurrentIntent() == .bluetoothAwareness else { return }
+    hasShownThisLaunch = true
+    isPresented = true
+    emit(.shown, nil)
+    breadcrumb(trigger, "shown", reason: nil)
+  }
+
+  // MARK: - User actions
+
+  /// The card's buttons call this; the presenter alone clears `isPresented`,
+  /// hides only when Bluetooth still owns the slot, emits exactly one event, and
+  /// opens settings for the explicit action (Codex r3 Q2). A call when not
+  /// presenting is a no-op.
+  func handleUserAction(_ action: UserAction) {
+    guard isPresented else { return }
+    if readCurrentIntent() == .bluetoothAwareness { hideIfCurrent() }
+    isPresented = false
+    switch action {
+    case .gotIt:
+      emit(.dismissed, .gotIt)
+    case .close:
+      emit(.dismissed, .closed)
+    case .adjustSettings:
+      emit(.settingsOpened, nil)
+      openMicrophoneSettings()
+    }
+  }
+
+  // MARK: - Configured-input precedence (pure, testable)
+
+  /// Resolve whether the CONFIGURED input is Bluetooth using the settings-sync
+  /// precedence: `preferredInputDeviceIDOverride` first, `selectedInputDeviceUID`
+  /// second, the CoreAudio default only when both are empty (Codex r2/r3). A
+  /// nonempty UID that no longer resolves fails CLOSED (returns false → no card).
+  /// Pure over two injected resolvers so the precedence is unit-tested without
+  /// real CoreAudio devices; the bootstrapper supplies the live `AudioDeviceEnumerator`
+  /// resolvers.
+  /// - Parameters:
+  ///   - defaultInputIsBluetooth: `nil` when there is no resolvable default device.
+  ///   - uidIsBluetooth: `nil` when the UID does not resolve (removed/unknown device).
+  static func computeEffectiveInputIsBluetooth(
+    preferredOverride: String,
+    selectedUID: String,
+    defaultInputIsBluetooth: () -> Bool?,
+    uidIsBluetooth: (String) -> Bool?
+  ) -> Bool {
+    let effectiveUID = preferredOverride.isEmpty ? selectedUID : preferredOverride
+    if effectiveUID.isEmpty {
+      return defaultInputIsBluetooth() ?? false
+    }
+    // A remembered UID that still resolves is authoritative. But one that no longer
+    // resolves is NOT fail-closed: the capture path binds `resolvedDeviceID ??
+    // defaultInputDeviceID()` (AVAudioEngineSource.swift:289), so a disconnected
+    // pinned device actually records through the DEFAULT input. Mirror that — fall
+    // back to the default input's transport so a user whose stale UID resolves to a
+    // Bluetooth default still gets the card (cloud review P2). Otherwise a Bluetooth
+    // user would record through the cold Bluetooth mic and never be warned.
+    if let resolved = uidIsBluetooth(effectiveUID) {
+      return resolved
+    }
+    return defaultInputIsBluetooth() ?? false
+  }
+
+  // MARK: - Helpers
+
+  private func breadcrumb(_ trigger: Trigger, _ outcome: String, reason: String?) {
+    var data: [String: Any] = ["trigger": trigger.rawValue, "outcome": outcome]
+    if let reason { data["reason"] = reason }
+    SentryBreadcrumb.add(stage: "bt_awareness", message: outcome, data: data)
+  }
+}
+
+/// Late-binding holder so the single `settings.onChange` closure — assigned early
+/// in bootstrap, before the presenter's dependencies (overlay, coordinators,
+/// live-recording state) exist — can forward setting-change facts to the presenter
+/// once it is constructed. Mirrors `OutputClassifierHolder` / `UpdateCoordinatorHolder`.
+@MainActor
+final class BluetoothAwarenessPresenterHolder {
+  var presenter: BluetoothAwarenessPresenter?
+  init() {}
+}

--- a/Sources/EnviousWisprAppKit/App/BluetoothAwarenessWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/BluetoothAwarenessWiring.swift
@@ -1,0 +1,66 @@
+import EnviousWisprAudio
+import EnviousWisprServices
+
+extension BluetoothAwarenessPresenter {
+  /// Composition-root factory (#1480): build the Bluetooth card presenter wired
+  /// to the live overlay, settings, recording state, and settings navigation, and
+  /// install the card's three button handlers. Keeps this wiring out of
+  /// `WisprBootstrapper` so the composition root stays lean. The presenter is the
+  /// single decision owner; only the live CoreAudio resolvers and the telemetry
+  /// sink live here.
+  @MainActor
+  static func live(
+    overlay: RecordingOverlayPanel,
+    settings: SettingsManager,
+    liveRecordingState: LiveRecordingState,
+    navigationCoordinator: NavigationCoordinator,
+    appWindowCoordinator: AppWindowCoordinator
+  ) -> BluetoothAwarenessPresenter {
+    let presenter = BluetoothAwarenessPresenter(
+      readCurrentIntent: { [weak overlay] in overlay?.currentIntent ?? .hidden },
+      showOverlay: { [weak overlay] in overlay?.show(intent: .bluetoothAwareness) },
+      hideIfCurrent: { [weak overlay] in
+        if overlay?.currentIntent == .bluetoothAwareness { overlay?.hide() }
+      },
+      effectiveInputIsBluetooth: { [weak settings] in
+        // Predict the CONFIGURED input via the settings precedence (override →
+        // selectedInputDeviceUID → CoreAudio default); a nonempty UID that no
+        // longer resolves fails CLOSED. The precedence is the pure, unit-tested
+        // `computeEffectiveInputIsBluetooth`; only the live resolvers live here
+        // (plan §3 — the capture router stays authoritative for the physical device).
+        guard let settings else { return false }
+        return BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
+          preferredOverride: settings.preferredInputDeviceIDOverride,
+          selectedUID: settings.selectedInputDeviceUID,
+          defaultInputIsBluetooth: {
+            guard let id = AudioDeviceEnumerator.defaultInputDeviceID() else { return nil }
+            return AudioDeviceEnumerator.isBluetoothDevice(id)
+          },
+          uidIsBluetooth: { uid in
+            guard let id = AudioDeviceEnumerator.deviceID(forUID: uid) else { return nil }
+            return AudioDeviceEnumerator.isBluetoothDevice(id)
+          })
+      },
+      // Fail closed (not idle → no card) if the state is somehow unavailable.
+      dictationIsIdle: { [weak liveRecordingState] in
+        !(liveRecordingState?.isDictationActive ?? true)
+      },
+      onboardingCompleted: { [weak settings] in settings?.onboardingState == .completed },
+      tipsEnabled: { [weak settings] in settings?.showBluetoothTips ?? false },
+      openMicrophoneSettings: { [weak navigationCoordinator, weak appWindowCoordinator] in
+        navigationCoordinator?.request(.audio)
+        appWindowCoordinator?.showWindow()
+      },
+      emit: { action, reason in
+        TelemetryService.shared.bluetoothAwareness(
+          action: action.rawValue, reason: reason?.rawValue)
+      }
+    )
+    overlay.setBluetoothAwarenessHandlers(
+      onGotIt: { [weak presenter] in presenter?.handleUserAction(.gotIt) },
+      onClose: { [weak presenter] in presenter?.handleUserAction(.close) },
+      onAdjustSettings: { [weak presenter] in presenter?.handleUserAction(.adjustSettings) }
+    )
+    return presenter
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -209,6 +209,8 @@ final class PipelineSettingsSync {
       break  // #1247: kernel pulls this live via `dictationAudioArchiveOptInProvider` — no push needed here.
     case .appearance:
       break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
+    case .showBluetoothTips:
+      break  // #1480: UI-only; read by BluetoothAwarenessPresenter, no pipeline sync.
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -79,6 +79,13 @@ final class RecordingOverlayPanel {
   private var passiveChipDismissHandler: (() -> Void)?
   private var passiveChipAutoDismissHandler: ((UInt64) -> Void)?
 
+  // #1480 Bluetooth awareness card handlers — installed once by the composition
+  // root, invoked by the card view's three buttons. The presenter owns all
+  // state/teardown/telemetry; these just forward the user's tap.
+  private var bluetoothAwarenessGotItHandler: (() -> Void)?
+  private var bluetoothAwarenessCloseHandler: (() -> Void)?
+  private var bluetoothAwarenessAdjustSettingsHandler: (() -> Void)?
+
   // MARK: - Intent-driven API
 
   func setGrantHandler(_ handler: @escaping () -> Void) {
@@ -104,6 +111,18 @@ final class RecordingOverlayPanel {
     passiveChipLockHandler = onLock
     passiveChipDismissHandler = onDismiss
     passiveChipAutoDismissHandler = onAutoDismiss
+  }
+
+  /// #1480 — wire the Bluetooth awareness card's button actions. Installed once
+  /// by the composition root; each closure routes to `BluetoothAwarenessPresenter`.
+  func setBluetoothAwarenessHandlers(
+    onGotIt: @escaping () -> Void,
+    onClose: @escaping () -> Void,
+    onAdjustSettings: @escaping () -> Void
+  ) {
+    bluetoothAwarenessGotItHandler = onGotIt
+    bluetoothAwarenessCloseHandler = onClose
+    bluetoothAwarenessAdjustSettingsHandler = onAdjustSettings
   }
 
   /// Unified entry point: render the overlay for the given intent.
@@ -249,6 +268,16 @@ final class RecordingOverlayPanel {
           self?.hide()
         }).frame(width: 320, height: 56),
         width: 320, height: 56, dismissAfter: 6.0)
+    case .bluetoothAwareness:
+      NSAccessibility.post(
+        element: NSApp.mainWindow as Any,
+        notification: .announcementRequested,
+        userInfo: [
+          .announcement:
+            "Bluetooth microphone detected. Wait a moment before speaking on a cold start.",
+          .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
+        ])
+      showBluetoothAwareness()
     }
   }
 
@@ -608,8 +637,11 @@ final class RecordingOverlayPanel {
   ) {
     guard let existingPanel = panel else { return }
     clearRecordingNotice()  // #1060 (Codex P3): fresh session starts with no stale notice.
-    let y = existingPanel.frame.origin.y
-
+    // The recording pill always appears at its canonical top slot — do NOT inherit
+    // the outgoing panel's origin. A taller panel (e.g. the #1480 Bluetooth card)
+    // sits lower, so reusing its origin would drop the pill to mid-screen (#1480
+    // live UAT). A fresh recording is a new lifecycle, not a continuation of the
+    // superseded panel, so it re-anchors to the default position.
     panel = nil
     autoDismissTask?.cancel()
     autoDismissTask = nil
@@ -625,7 +657,7 @@ final class RecordingOverlayPanel {
       guard let self, self.generation == token else { return }
       self.pendingCreateWork = nil
       self.createPanel(
-        audioLevelProvider: audioLevelProvider, isRecordingLocked: isRecordingLocked, y: y)
+        audioLevelProvider: audioLevelProvider, isRecordingLocked: isRecordingLocked)
     }
     pendingCreateWork = work
     DispatchQueue.main.async(execute: work)
@@ -772,6 +804,69 @@ final class RecordingOverlayPanel {
       guard let self, self.generation == token else { return }
       self.pendingCreateWork = nil
       self.createPassiveChipPanel(payload: payload, y: y)
+    }
+    pendingCreateWork = work
+    DispatchQueue.main.async(execute: work)
+  }
+
+  /// #1480 — show the Bluetooth cold-start education card. Mirrors
+  /// `showPassiveChip`'s defer-to-next-run-loop + generation-guard shape, but has
+  /// NO auto-dismiss (plan §3D): the card persists until the presenter tears it
+  /// down (record-supersede, Got it / close / Adjust settings, route-off, or the
+  /// tips setting turning off).
+  func showBluetoothAwareness() {
+    guard panel == nil else {
+      transitionToBluetoothAwareness()
+      return
+    }
+    pendingCreateWork?.cancel()
+    pendingCreateWork = nil
+    generation &+= 1
+    let token = generation
+
+    let work = DispatchWorkItem { [weak self] in
+      guard let self, self.generation == token else { return }
+      self.pendingCreateWork = nil
+      self.createBluetoothAwarenessPanel()
+    }
+    pendingCreateWork = work
+    DispatchQueue.main.async(execute: work)
+  }
+
+  private func createBluetoothAwarenessPanel(y: CGFloat? = nil) {
+    guard panel == nil else { return }
+    let onGotIt = bluetoothAwarenessGotItHandler
+    let onClose = bluetoothAwarenessCloseHandler
+    let onAdjust = bluetoothAwarenessAdjustSettingsHandler
+    let view = BluetoothAwarenessCardView(
+      onGotIt: { onGotIt?() },
+      onClose: { onClose?() },
+      onAdjustSettings: { onAdjust?() }
+    )
+    // Fixed width, content-driven height (`fitToContent`) so the multi-row card
+    // is never clipped and adapts to copy length in either appearance.
+    showPanel(content: view, width: 320, height: 0, y: y, fitToContent: true)
+  }
+
+  private func transitionToBluetoothAwareness() {
+    guard let existingPanel = panel else { return }
+    let y = existingPanel.frame.origin.y
+
+    panel = nil
+    autoDismissTask?.cancel()
+    autoDismissTask = nil
+    pendingCreateWork?.cancel()
+    pendingCreateWork = nil
+    CATransaction.flush()
+    existingPanel.close()
+
+    generation &+= 1
+    let token = generation
+
+    let work = DispatchWorkItem { [weak self] in
+      guard let self, self.generation == token else { return }
+      self.pendingCreateWork = nil
+      self.createBluetoothAwarenessPanel(y: y)
     }
     pendingCreateWork = work
     DispatchQueue.main.async(execute: work)

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -84,7 +84,10 @@ enum SettingsProjection {
     case .selectedBackend, .onboardingState, .hasCompletedOnboarding,
       .isDebugModeEnabled, .isDictationAudioArchiveEnabled, .debugLogLevel, .whisperKitLanguage,
       .selectedInputDeviceUID, .noiseSuppression, .preferredInputDeviceIDOverride,
-      .useXPCAudioService:
+      .useXPCAudioService,
+      // #1480: the popover's own lifecycle telemetry (`bt_awareness.*`) owns this
+      // signal, incl. `suppressed_by_setting`; no separate settings.changed delta.
+      .showBluetoothTips:
       return nil
     }
   }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -346,8 +346,15 @@ public final class WisprBootstrapper {
       settingsChangeTelemetry?.flush()
     }
 
+    // #1480: late-binding bridge so this early-assigned onChange closure can
+    // forward setting-change facts to the (later-constructed) presenter.
+    let bluetoothAwarenessPresenterHolder = BluetoothAwarenessPresenterHolder()
+
     settings.onChange = {
-      [weak settingsSync, weak settings, weak settingsChangeTelemetry, outputClassifierHolder] key
+      [
+        weak settingsSync, weak settings, weak settingsChangeTelemetry, outputClassifierHolder,
+        bluetoothAwarenessPresenterHolder
+      ] key
       in
       guard let settingsSync, let settings else { return }
       settingsSync.handleSettingChanged(key, settings: settings)
@@ -365,6 +372,16 @@ public final class WisprBootstrapper {
       if key == .llmProvider {
         WisprBootstrapper.prewarmOutputClassifierIfNeeded(
           holder: outputClassifierHolder, provider: settings.llmProvider)
+      }
+      // #1480: tips on/off, input-device change, and onboarding completion each
+      // re-evaluate the Bluetooth card (dismiss/suppress, route re-check, or
+      // first surface after onboarding).
+      switch key {
+      case .showBluetoothTips, .preferredInputDeviceIDOverride, .selectedInputDeviceUID,
+        .onboardingState:
+        bluetoothAwarenessPresenterHolder.presenter?.reconcile(trigger: .settingChanged)
+      default:
+        break
       }
     }
 
@@ -642,6 +659,18 @@ public final class WisprBootstrapper {
     // #1451: App Translocation recovery limb, driven from the launch sequence.
     let applicationRelocationCoordinator = ApplicationRelocationCoordinator.live()
 
+    // #1480: Bluetooth cold-start card. Single decision owner; ingress facts come
+    // from AppLifecycleCoordinator + settings.onChange. Wiring lives in `.live(...)`;
+    // built before AppLifecycleCoordinator (which stores it).
+    let bluetoothAwarenessPresenter = BluetoothAwarenessPresenter.live(
+      overlay: recordingOverlay,
+      settings: settings,
+      liveRecordingState: liveRecordingState,
+      navigationCoordinator: navigationCoordinator,
+      appWindowCoordinator: appWindowCoordinator
+    )
+    bluetoothAwarenessPresenterHolder.presenter = bluetoothAwarenessPresenter
+
     // PR-B.4 of #763: process-lifecycle home. Constructed last. It receives the
     // 10 specific homes it reads.
     let appLifecycleCoordinator = AppLifecycleCoordinator(
@@ -663,6 +692,7 @@ public final class WisprBootstrapper {
       appWindowCoordinator: appWindowCoordinator,
       hotkeyService: hotkeyService,
       applicationRelocationCoordinator: applicationRelocationCoordinator,
+      bluetoothAwarenessPresenter: bluetoothAwarenessPresenter,
       onboardingProgress: onboardingProgress
     )
 

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -374,12 +374,19 @@ public final class WisprBootstrapper {
           holder: outputClassifierHolder, provider: settings.llmProvider)
       }
       // #1480: tips on/off, input-device change, and onboarding completion each
-      // re-evaluate the Bluetooth card (dismiss/suppress, route re-check, or
-      // first surface after onboarding).
+      // re-evaluate the Bluetooth card (dismiss/suppress, route re-check, or first
+      // surface after onboarding). Deferred to the next run-loop cycle because the
+      // input picker writes `preferredInputDeviceIDOverride` and
+      // `selectedInputDeviceUID` as a synchronous PAIR (AudioSettingsView), so a
+      // reconcile on the first write would read a half-updated selection (cloud
+      // review P2). Deferring coalesces the pair into one evaluation over the
+      // settled state; the second fires and no-ops.
       switch key {
       case .showBluetoothTips, .preferredInputDeviceIDOverride, .selectedInputDeviceUID,
         .onboardingState:
-        bluetoothAwarenessPresenterHolder.presenter?.reconcile(trigger: .settingChanged)
+        DispatchQueue.main.async {
+          bluetoothAwarenessPresenterHolder.presenter?.reconcile(trigger: .settingChanged)
+        }
       default:
         break
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
@@ -86,6 +86,69 @@ struct AudioSettingsView: View {
           }
         }
       }
+
+      // #1480: permanent Bluetooth cold-start guide. Same icons + tip wording as
+      // the once-per-launch popover (BluetoothTipsCopy is the single copy home),
+      // plus the preferred-mic-order line, the authoritative P.S., and the toggle
+      // that turns the popover off (this guide always stays).
+      BrandedPanel(
+        icon: "dot.radiowaves.left.and.right",
+        header: BluetoothTipsCopy.settingsHeader,
+        description: BluetoothTipsCopy.settingsIntro
+      ) {
+        VStack(alignment: .leading, spacing: 14) {
+          VStack(alignment: .leading, spacing: 12) {
+            bluetoothTipRow(icon: BluetoothTipsCopy.iconTiming, text: BluetoothTipsCopy.tipTiming)
+            bluetoothTipRow(
+              icon: BluetoothTipsCopy.iconReadiness, text: BluetoothTipsCopy.tipReadiness)
+            bluetoothTipRow(
+              icon: BluetoothTipsCopy.iconHeadphones, text: BluetoothTipsCopy.tipHeadphones)
+          }
+
+          InsetNotice(
+            text: BluetoothTipsCopy.micOrder,
+            systemImage: "list.bullet",
+            tint: .stAccent
+          )
+
+          Text(BluetoothTipsCopy.settingsPS)
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+          Divider().overlay(Color.stDivider)
+
+          Toggle(isOn: $settings.showBluetoothTips) {
+            VStack(alignment: .leading, spacing: 2) {
+              Text(BluetoothTipsCopy.showTipsToggle).settingsRowLabel()
+              Text("Shows the reminder popover once per launch. This guide always stays.")
+                .font(.stHelper)
+                .foregroundStyle(.stTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+          .toggleStyle(BrandedToggleStyle())
+        }
+      }
+    }
+  }
+
+  /// One tip row in the Bluetooth guide: accent icon badge + sentence, matching
+  /// the popover's rows (same icons, same copy via `BluetoothTipsCopy`).
+  private func bluetoothTipRow(icon: String, text: String) -> some View {
+    HStack(alignment: .center, spacing: 11) {
+      Image(systemName: icon)
+        .font(.system(size: 15, weight: .medium))
+        .foregroundStyle(.stAccent)
+        .frame(width: 34, height: 34)
+        .background(Color.stAccentLight, in: Circle())
+        .overlay(Circle().strokeBorder(Color.stAccent.opacity(0.22), lineWidth: 1))
+        .accessibilityHidden(true)
+      Text(text)
+        .font(.stBody)
+        .foregroundStyle(.stTextBody)
+        .fixedSize(horizontal: false, vertical: true)
+      Spacer(minLength: 0)
     }
   }
 }

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -119,6 +119,14 @@ public enum OverlayIntent: Equatable, Sendable {
   /// wait." No session is minted. Auto-dismissed after a few seconds; re-shown
   /// on each blocked press.
   case recoveringLastRecording
+  /// Bluetooth cold-start education card (#1480). Shown once per launch when the
+  /// configured input is a Bluetooth microphone and dictation is idle, sitting in
+  /// the same top-middle slot as the recording pill. Unlike every other intent it
+  /// has NO auto-dismiss: it persists until the user starts recording (which
+  /// supersedes it via the single-slot dedup), taps "Got it" / close / "Adjust
+  /// settings", the input changes away from Bluetooth, or the tips setting is
+  /// turned off. Its decision + lifecycle are owned by `BluetoothAwarenessPresenter`.
+  case bluetoothAwareness
 }
 
 /// Why a recording ended at a terminal state WITHOUT a durable transcript save,

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -76,4 +76,10 @@ enum SettingsDefaultValues {
 
   static let useStreamingASR = false
   static let warmEnginePolicy: WarmEnginePolicy = .seconds30
+
+  // #1480: show the once-per-launch Bluetooth cold-start education popover when
+  // the configured input is a Bluetooth mic. Default ON — it is light, dismissable,
+  // and only appears for Bluetooth users; the toggle is the annoyance escape hatch.
+  // The permanent Microphone-settings guide stays regardless of this flag.
+  static let showBluetoothTips = true
 }

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -44,6 +44,7 @@ public final class SettingsManager {
     case useStreamingASR
     case warmEnginePolicy
     case appearance
+    case showBluetoothTips
   }
 
   public var onChange: ((SettingKey) -> Void)?
@@ -78,6 +79,7 @@ public final class SettingsManager {
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
     "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
     "useStreamingASR", "warmEnginePolicy", "appearancePreference",
+    "showBluetoothTips",
     WhatsNewConstants.lastSeenVersionDefaultsKey,
   ]
 
@@ -369,6 +371,17 @@ public final class SettingsManager {
     didSet {
       defaults.set(appearancePreference.rawValue, forKey: "appearancePreference")
       onChange?(.appearance)
+    }
+  }
+
+  /// #1480: show the once-per-launch Bluetooth cold-start education popover.
+  /// UI-only — no pipeline sync; `BluetoothAwarenessPresenter` reads it via the
+  /// injected `tipsEnabled` closure and reconciles a visible card off when it
+  /// flips to false. Default ON (`SettingsDefaultValues.showBluetoothTips`).
+  public var showBluetoothTips: Bool {
+    didSet {
+      defaults.set(showBluetoothTips, forKey: "showBluetoothTips")
+      onChange?(.showBluetoothTips)
     }
   }
 
@@ -731,6 +744,10 @@ public final class SettingsManager {
       AppearancePreference(
         rawValue: defaults.string(forKey: "appearancePreference") ?? ""
       ) ?? SettingsDefaultValues.appearancePreference
+
+    showBluetoothTips =
+      defaults.object(forKey: "showBluetoothTips") as? Bool
+      ?? SettingsDefaultValues.showBluetoothTips
 
     // What's New: fresh install (nil) defaults to current version so new users aren't badged.
     let storedWhatsNew =

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -482,6 +482,25 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("audio.capture_interrupted", properties: props)
   }
 
+  /// #1480: the Bluetooth cold-start education card. `action` is one of the
+  /// fixed set `shown` / `dismissed` / `settings_opened` / `suppressed_by_setting`
+  /// (event name `bt_awareness.<action>`); `reason` is present only for `dismissed`
+  /// (`got_it` / `record_started` / `route_changed` / `setting_disabled` /
+  /// `closed`). Content-free by construction: the closed vocab is owned by
+  /// `BluetoothAwarenessPresenter`; no transcript, device name, or user text exists
+  /// on this path.
+  public func bluetoothAwareness(action: String, reason: String?) {
+    let event = "bt_awareness.\(action)"
+    var props: [String: Any] = [:]
+    if let reason { props["reason"] = reason }
+    #if DEBUG
+      var stringProps: [String: String] = [:]
+      if let reason { stringProps["reason"] = reason }
+      testEventHook?(CapturedTelemetryEvent(name: event, stringProps: stringProps))
+    #endif
+    PostHogSDK.shared.capture(event, properties: props)
+  }
+
   public func dictationCompleted(
     result: String, inputMode: String, asrBackend: String,
     llmProvider: String?, fillerRemoval: Bool,

--- a/Tests/EnviousWisprTests/App/BluetoothAwarenessOverlayTests.swift
+++ b/Tests/EnviousWisprTests/App/BluetoothAwarenessOverlayTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import EnviousWisprPipeline
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1480 — the Bluetooth card is a normal single-slot overlay intent: recording
+/// must supersede it synchronously through the existing dedup, and it must never
+/// linger in the intent state. `currentIntent` is mutated synchronously in
+/// `show(intent:)`; panel creation is deferred, so these assertions hold headless.
+@Suite @MainActor struct BluetoothAwarenessOverlayTests {
+  /// `show(intent:)` posts an accessibility announcement against `NSApp.mainWindow`;
+  /// `NSApp` is an implicitly-unwrapped `NSApplication!` that stays nil until
+  /// `NSApplication.shared` is first accessed (AppearanceController.swift note), so
+  /// touching it here keeps the AX post from crashing the headless test host.
+  init() { _ = NSApplication.shared }
+
+  @Test func recordingSupersedesBluetoothCardSynchronously() {
+    let overlay = RecordingOverlayPanel()
+    overlay.show(intent: .bluetoothAwareness)
+    #expect(overlay.currentIntent == .bluetoothAwareness)
+
+    overlay.show(intent: .recording(audioLevel: 0))
+    #expect(overlay.currentIntent == .recording(audioLevel: 0))
+
+    // Cancel the deferred panel-creation work so no NSPanel is built headless.
+    overlay.hide()
+    #expect(overlay.currentIntent == .hidden)
+  }
+
+  @Test func hideClearsBluetoothCardIntent() {
+    let overlay = RecordingOverlayPanel()
+    overlay.show(intent: .bluetoothAwareness)
+    overlay.hide()
+    #expect(overlay.currentIntent == .hidden)
+  }
+}

--- a/Tests/EnviousWisprTests/App/BluetoothAwarenessPresenterTests.swift
+++ b/Tests/EnviousWisprTests/App/BluetoothAwarenessPresenterTests.swift
@@ -1,0 +1,409 @@
+import EnviousWisprPipeline
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1480 — the Bluetooth cold-start card decision owner. The presenter is pure and
+/// synchronous (injected closures, no clock, no `Task.sleep`), so the full §5 fire
+/// matrix is asserted here as event/state transitions.
+
+/// Controllable harness: every injected dependency is a mutable fact, and every
+/// side effect (show / hide / open-settings / emit) is recorded for assertions.
+@MainActor
+private final class Harness {
+  var currentIntent: OverlayIntent = .hidden
+  var isBluetooth = false
+  var isIdle = true
+  var onboardingDone = true
+  var tipsOn = true
+
+  var showCount = 0
+  var hideCount = 0
+  var openSettingsCount = 0
+  var emitted: [(BluetoothAwarenessPresenter.Action, BluetoothAwarenessPresenter.DismissReason?)] =
+    []
+
+  func makePresenter() -> BluetoothAwarenessPresenter {
+    BluetoothAwarenessPresenter(
+      readCurrentIntent: { self.currentIntent },
+      showOverlay: {
+        self.showCount += 1
+        self.currentIntent = .bluetoothAwareness
+      },
+      hideIfCurrent: {
+        if self.currentIntent == .bluetoothAwareness {
+          self.hideCount += 1
+          self.currentIntent = .hidden
+        }
+      },
+      effectiveInputIsBluetooth: { self.isBluetooth },
+      dictationIsIdle: { self.isIdle },
+      onboardingCompleted: { self.onboardingDone },
+      tipsEnabled: { self.tipsOn },
+      openMicrophoneSettings: { self.openSettingsCount += 1 },
+      emit: { action, reason in self.emitted.append((action, reason)) }
+    )
+  }
+
+  var lastEmit: (BluetoothAwarenessPresenter.Action, BluetoothAwarenessPresenter.DismissReason?)? {
+    emitted.last
+  }
+}
+
+private func emitEquals(
+  _ lhs: (BluetoothAwarenessPresenter.Action, BluetoothAwarenessPresenter.DismissReason?)?,
+  _ action: BluetoothAwarenessPresenter.Action,
+  _ reason: BluetoothAwarenessPresenter.DismissReason?
+) -> Bool {
+  guard let lhs else { return false }
+  return lhs.0 == action && lhs.1 == reason
+}
+
+@Suite @MainActor struct BluetoothAwarenessPresenterTests {
+
+  // MARK: - Show / no-show gating (§5 scenarios 1-3, 8, 12)
+
+  @Test func scenario1_launchBluetoothIdle_shows() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    #expect(h.showCount == 1)
+    #expect(h.currentIntent == .bluetoothAwareness)
+    #expect(emitEquals(h.lastEmit, .shown, nil))
+    // Once per launch: a second reconcile does not re-show.
+    p.reconcile(trigger: .deviceChanged)
+    #expect(h.showCount == 1)
+  }
+
+  @Test func scenario2_notBluetoothThenConnects_showsOnce() {
+    let h = Harness()
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)  // not BT
+    #expect(h.showCount == 0)
+    h.isBluetooth = true
+    p.reconcile(trigger: .deviceChanged)  // BT connects later
+    #expect(h.showCount == 1)
+    // Still only once.
+    p.reconcile(trigger: .deviceChanged)
+    #expect(h.showCount == 1)
+  }
+
+  @Test func scenario3_onboardingIncomplete_suppressesUntilComplete() {
+    let h = Harness()
+    h.isBluetooth = true
+    h.onboardingDone = false
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    #expect(h.showCount == 0)
+    h.onboardingDone = true
+    p.reconcile(trigger: .settingChanged)  // onboarding completion re-eval
+    #expect(h.showCount == 1)
+  }
+
+  @Test func scenario4_bluetoothWhileRecording_showsWhenIdleReturns() {
+    let h = Harness()
+    h.isBluetooth = true
+    h.isIdle = false  // recording in flight
+    let p = h.makePresenter()
+    p.reconcile(trigger: .deviceChanged)  // BT connect during recording
+    #expect(h.showCount == 0)
+    h.isIdle = true  // dictation returns to idle
+    p.reconcile(trigger: .pipelineStateChanged)
+    #expect(h.showCount == 1)
+  }
+
+  @Test func gate_requiresHiddenSlot() {
+    let h = Harness()
+    h.isBluetooth = true
+    h.currentIntent = .warning(message: "x")  // another overlay owns the slot
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    #expect(h.showCount == 0)  // never replaces a live overlay
+  }
+
+  // MARK: - Dismissal reasons (§5 scenarios 5-8)
+
+  @Test func scenario5_recordStarted_dismissesWithReason_noHideOfNewerIntent() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)  // shown; currentIntent == .bluetoothAwareness
+    // Recording synchronously replaced the slot before this reconcile ran.
+    h.currentIntent = .recording(audioLevel: 0)
+    h.isIdle = false
+    p.reconcile(trigger: .pipelineStateChanged)
+    #expect(emitEquals(h.lastEmit, .dismissed, .recordStarted))
+    #expect(h.hideCount == 0)  // must NOT tear down the recording pill
+  }
+
+  @Test func scenario5b_recordStarted_hidesWhenCardStillOwnsSlot() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    // Reconcile fired before the pill replaced the card (card still owns slot).
+    h.isIdle = false
+    p.reconcile(trigger: .pipelineStateChanged)
+    #expect(emitEquals(h.lastEmit, .dismissed, .recordStarted))
+    #expect(h.hideCount == 1)  // its own card IS torn down
+  }
+
+  @Test func scenario6_routeChangedAwayFromBluetooth_dismisses() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    h.isBluetooth = false
+    p.reconcile(trigger: .deviceChanged)
+    #expect(emitEquals(h.lastEmit, .dismissed, .routeChanged))
+    #expect(h.hideCount == 1)
+    #expect(h.currentIntent == .hidden)
+  }
+
+  @Test func anotherOverlayReplacedWhileIdle_releasesOwnershipSilently() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    let emitCountAfterShow = h.emitted.count
+    // A different overlay took the slot while still idle + BT.
+    h.currentIntent = .clipboardFallback
+    p.reconcile(trigger: .pipelineStateChanged)
+    #expect(h.emitted.count == emitCountAfterShow)  // no dismiss emit
+    #expect(h.hideCount == 0)  // does not touch the newer overlay
+  }
+
+  // MARK: - Setting suppression (§5 scenario 8)
+
+  @Test func scenario8_tipsOff_neverShows_emitsSuppressedOncePerLaunch() {
+    let h = Harness()
+    h.isBluetooth = true
+    h.tipsOn = false
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    #expect(h.showCount == 0)
+    #expect(emitEquals(h.lastEmit, .suppressedBySetting, nil))
+    let count = h.emitted.count
+    p.reconcile(trigger: .deviceChanged)  // dedup
+    #expect(h.emitted.count == count)
+  }
+
+  @Test func tipsOff_nonBluetooth_noSuppressionEmit() {
+    // Codex r2 P2: an opted-out user on a built-in/wired mic never sees the card,
+    // so no `suppressed_by_setting` must fire (metric counts only eligible users).
+    let h = Harness()
+    h.isBluetooth = false
+    h.tipsOn = false
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    #expect(h.showCount == 0)
+    #expect(h.emitted.isEmpty)
+  }
+
+  @Test func tipsOff_onboardingIncomplete_noSuppressionEmit() {
+    // Suppression is gated on full eligibility, so an onboarding-incomplete BT
+    // user with tips off is not counted either.
+    let h = Harness()
+    h.isBluetooth = true
+    h.tipsOn = false
+    h.onboardingDone = false
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    #expect(h.emitted.isEmpty)
+  }
+
+  @Test func scenario8b_tipsToggledOffWhileVisible_dismissesWithSettingDisabled() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)  // shown
+    h.tipsOn = false
+    p.reconcile(trigger: .settingChanged)
+    #expect(emitEquals(h.lastEmit, .dismissed, .settingDisabled))
+    #expect(h.hideCount == 1)
+    #expect(h.currentIntent == .hidden)
+  }
+
+  // MARK: - User actions (§11 user-action test)
+
+  @Test func gotIt_dismisses_hides_emitsOnce() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    let before = h.emitted.count
+    p.handleUserAction(.gotIt)
+    #expect(h.currentIntent == .hidden)
+    #expect(h.hideCount == 1)
+    #expect(h.emitted.count == before + 1)
+    #expect(emitEquals(h.lastEmit, .dismissed, .gotIt))
+  }
+
+  @Test func close_emitsClosed() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    p.handleUserAction(.close)
+    #expect(emitEquals(h.lastEmit, .dismissed, .closed))
+    #expect(h.hideCount == 1)
+  }
+
+  @Test func adjustSettings_opensSettings_emitsSettingsOpened() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    p.handleUserAction(.adjustSettings)
+    #expect(h.openSettingsCount == 1)
+    #expect(emitEquals(h.lastEmit, .settingsOpened, nil))
+    #expect(h.hideCount == 1)
+  }
+
+  @Test func handleUserAction_whenNotPresented_isNoOp() {
+    let h = Harness()
+    let p = h.makePresenter()
+    p.handleUserAction(.gotIt)
+    #expect(h.emitted.isEmpty)
+    #expect(h.hideCount == 0)
+    #expect(h.openSettingsCount == 0)
+  }
+
+  @Test func adjustSettings_whenNewerIntentOwnsSlot_doesNotHideIt() {
+    let h = Harness()
+    h.isBluetooth = true
+    let p = h.makePresenter()
+    p.reconcile(trigger: .launch)
+    h.currentIntent = .recording(audioLevel: 0)  // pill replaced the card
+    p.handleUserAction(.adjustSettings)
+    #expect(h.hideCount == 0)  // never tears down the recording pill
+    #expect(h.openSettingsCount == 1)
+    #expect(emitEquals(h.lastEmit, .settingsOpened, nil))
+  }
+
+  // MARK: - Effective-input precedence (§11 effective-input test, Codex r2/r3 CF3)
+
+  @Test func effectiveInput_overrideWinsOverBluetoothDefault() {
+    let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
+      preferredOverride: "builtin",
+      selectedUID: "airpods",
+      defaultInputIsBluetooth: { true },
+      uidIsBluetooth: { $0 == "airpods" }  // "builtin" -> false
+    )
+    #expect(result == false)  // explicit non-BT override beats a BT default
+  }
+
+  @Test func effectiveInput_selectedUidBluetoothWhenNoOverride() {
+    let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
+      preferredOverride: "",
+      selectedUID: "airpods",
+      defaultInputIsBluetooth: { false },
+      uidIsBluetooth: { $0 == "airpods" }
+    )
+    #expect(result == true)
+  }
+
+  @Test func effectiveInput_defaultBluetoothWhenBothEmpty() {
+    let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
+      preferredOverride: "",
+      selectedUID: "",
+      defaultInputIsBluetooth: { true },
+      uidIsBluetooth: { _ in false }
+    )
+    #expect(result == true)
+  }
+
+  @Test func effectiveInput_defaultNotBluetoothWhenBothEmpty() {
+    let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
+      preferredOverride: "",
+      selectedUID: "",
+      defaultInputIsBluetooth: { false },
+      uidIsBluetooth: { _ in true }
+    )
+    #expect(result == false)
+  }
+
+  @Test func effectiveInput_unresolvableUid_fallsBackToDefaultBluetooth() {
+    // Cloud review P2: a disconnected pinned device records through the DEFAULT
+    // input (AVAudioEngineSource `resolvedDeviceID ?? defaultInputDeviceID()`), so a
+    // stale UID with a Bluetooth default must show the card, not fail closed.
+    let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
+      preferredOverride: "ghost-device",
+      selectedUID: "",
+      defaultInputIsBluetooth: { true },
+      uidIsBluetooth: { _ in nil }  // removed/unknown device
+    )
+    #expect(result == true)
+  }
+
+  @Test func effectiveInput_unresolvableUid_defaultNotBluetooth_noCard() {
+    // Stale UID but the default input is NOT Bluetooth → no card (no false positive).
+    let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
+      preferredOverride: "ghost-device",
+      selectedUID: "",
+      defaultInputIsBluetooth: { false },
+      uidIsBluetooth: { _ in nil }
+    )
+    #expect(result == false)
+  }
+
+  @Test func effectiveInput_resolvedUidWins_ignoresDefault() {
+    // A UID that DOES resolve is authoritative — the default is not consulted.
+    let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
+      preferredOverride: "builtin",
+      selectedUID: "",
+      defaultInputIsBluetooth: { true },  // default is BT...
+      uidIsBluetooth: { _ in false }  // ...but the pinned built-in resolves non-BT
+    )
+    #expect(result == false)
+  }
+
+  @Test func effectiveInput_noDefaultDevice_failsClosed() {
+    let result = BluetoothAwarenessPresenter.computeEffectiveInputIsBluetooth(
+      preferredOverride: "",
+      selectedUID: "",
+      defaultInputIsBluetooth: { nil },  // no default input device
+      uidIsBluetooth: { _ in true }
+    )
+    #expect(result == false)
+  }
+}
+
+// MARK: - Copy freeze (§11 copy test) + brand dash rule
+
+@Suite struct BluetoothTipsCopyTests {
+  @Test func approvedTipStrings() {
+    #expect(
+      BluetoothTipsCopy.tipTiming
+        == "After your mic has been idle, wait 1 to 2 seconds before speaking.")
+    #expect(
+      BluetoothTipsCopy.tipReadiness
+        == "Microphone Readiness keeps follow-up dictations ready for up to 30 seconds (on by default)."
+    )
+    #expect(
+      BluetoothTipsCopy.tipHeadphones == "Built-in or wired mics usually avoid this startup delay.")
+    #expect(BluetoothTipsCopy.cardTitle == "Bluetooth mic detected")
+    #expect(
+      BluetoothTipsCopy.cardIntro == "Bluetooth microphones can take a moment on a cold start.")
+    #expect(BluetoothTipsCopy.settingsHeader == "When using Bluetooth")
+    #expect(
+      BluetoothTipsCopy.settingsPS
+        == "Built-in, wired, and USB mics do not have this Bluetooth startup delay.")
+  }
+
+  @Test func noEmOrEnDashesInUserFacingCopy() {
+    let strings = [
+      BluetoothTipsCopy.cardTitle, BluetoothTipsCopy.cardIntro, BluetoothTipsCopy.cardFootnote,
+      BluetoothTipsCopy.gotItButton, BluetoothTipsCopy.adjustSettingsButton,
+      BluetoothTipsCopy.tipTiming, BluetoothTipsCopy.tipReadiness, BluetoothTipsCopy.tipHeadphones,
+      BluetoothTipsCopy.settingsHeader, BluetoothTipsCopy.settingsIntro,
+      BluetoothTipsCopy.micOrder, BluetoothTipsCopy.settingsPS, BluetoothTipsCopy.showTipsToggle,
+    ]
+    for s in strings {
+      #expect(!s.contains("\u{2014}"), "em-dash in: \(s)")
+      #expect(!s.contains("\u{2013}"), "en-dash in: \(s)")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/BluetoothAwarenessPresenterTests.swift
+++ b/Tests/EnviousWisprTests/App/BluetoothAwarenessPresenterTests.swift
@@ -114,6 +114,23 @@ private func emitEquals(
     #expect(h.showCount == 1)
   }
 
+  @Test func idleButSlotStillRecording_waitsForClear_thenShows() {
+    // Cloud review P2: the pipeline callback fires before the overlay clears, so
+    // on a just-completed recording dictation is idle while the slot is still
+    // `.recording`. The card must NOT show until the slot is `.hidden` (the guard),
+    // and it DOES show on the deferred re-check once the pill is torn down.
+    let h = Harness()
+    h.isBluetooth = true
+    h.isIdle = true
+    h.currentIntent = .recording(audioLevel: 0)  // terminal overlay not sent yet
+    let p = h.makePresenter()
+    p.reconcile(trigger: .pipelineStateChanged)
+    #expect(h.showCount == 0)  // slot not clear → no show
+    h.currentIntent = .hidden  // overlay handler cleared the pill
+    p.reconcile(trigger: .pipelineStateChanged)  // the deferred re-check
+    #expect(h.showCount == 1)
+  }
+
   @Test func gate_requiresHiddenSlot() {
     let h = Harness()
     h.isBluetooth = true

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -35,6 +35,14 @@ import Testing
 /// all relocation policy, so this is one narrow delegation, not accretion (§3b).
 /// Allowlist 20 → 21 (3 owned `var` + 18 injected `let`); non-private method
 /// count unchanged at 3.
+/// Bible §30 entry (#1480, 2026-07-11): `bluetoothAwarenessPresenter` added — the
+/// Bluetooth cold-start card's decision owner. Injected `let`; the three lifecycle
+/// closures (`onPipelineStateChange`, `onAudioDeviceEvent`, the launch
+/// completed-onboarding block) forward a `Trigger` fact to `reconcile(...)`. The
+/// coordinator carries NO Bluetooth predicate, overlay branching, or once-per-launch
+/// state — all decision logic lives on the presenter (§3b), so this is one narrow
+/// delegation, not accretion. Allowlist 21 → 22 (3 owned `var` + 19 injected `let`);
+/// non-private method count unchanged at 3.
 @Suite struct AppLifecycleCoordinatorCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift"
@@ -61,6 +69,7 @@ import Testing
     "appWindowCoordinator",
     "hotkeyService",
     "applicationRelocationCoordinator",
+    "bluetoothAwarenessPresenter",
   ]
 
   @Test func storedPropertyNamesMatchAllowlist() throws {
@@ -73,7 +82,7 @@ import Testing
       extras.isEmpty && missing.isEmpty,
       """
       AppLifecycleCoordinator stored-property set drifted from the \
-      21-name allowlist. Unexpected: \(extras.sorted()). Missing: \
+      22-name allowlist. Unexpected: \(extras.sorted()). Missing: \
       \(missing.sorted()). Adding a stored property is god-object drift — \
       raising the allowlist requires a Bible §30 entry. Removing one means \
       this allowlist must shrink in the same PR.

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -315,12 +315,19 @@ import Testing
   /// and performs the required launch-time reconcile after callback wiring.
   /// Policy remains outside the root. Cap by deterministic rule (actual 984
   /// + 10, rounded up to nearest 5 = 995).
+  /// Ratcheted 995→1025 in #1480 (2026-07-11): the composition root builds the
+  /// Bluetooth-awareness limb — a late-binding presenter holder, the
+  /// `BluetoothAwarenessPresenter.live(...)` factory call, the injection into
+  /// `AppLifecycleCoordinator`, and the settings.onChange reconcile hookup. The
+  /// presenter's own wiring was extracted into `.live(...)` to keep the root lean;
+  /// all decision logic lives on the presenter, not here. Cap by deterministic
+  /// rule (actual 1018 + 7, rounded up to nearest 5 = 1025).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 995,
+      lineCount <= 1025,
       """
       WisprBootstrapper line count exceeded: \(lineCount) > 995. \
       Raising the ceiling requires a Bible changelog entry.


### PR DESCRIPTION
Part of #1374 (Release 1, Slice 2 of 3). Educates Bluetooth-mic users about the cold-start warm-up so they stop losing their first words.

## What ships
- **Overlay popover** — a new `OverlayIntent.bluetoothAwareness`, shown once per launch in the top-middle overlay slot when the configured input is a Bluetooth mic and dictation is idle. Floats over the user's current app without stealing focus; the recording pill always supersedes it; no auto-dismiss. Theme-aware via the app's dynamic `st*` tokens (light + dark).
- **Permanent Microphone-settings guide** — a "When using Bluetooth" section below Microphone Readiness with the same icons/copy, the preferred-mic-order line, and the authoritative P.S.
- **"Show Bluetooth tips" toggle** (default on) — the annoyance escape hatch; the guide always stays.
- New `BluetoothAwarenessPresenter` owns the single show/dismiss decision (`reconcile`); `bt_awareness.*` telemetry (content-free).

## Validation
- Full logic suite green (2755 + new presenter/overlay/copy/ceiling tests).
- Codex diff review: explicit all-clear on the confirming re-run. One P2 caught + fixed — `suppressed_by_setting` now fires only for users who would actually see the card (Bluetooth + onboarded + idle), not every built-in/wired-mic opt-out.
- Microphone-settings guide verified in **Light** (screenshot) and AX-confirmed in Dark; uses the same proven dynamic tokens as every settings card.

## HELD FOR FOUNDER LIVE UAT before merge
Requires real Bluetooth hardware (per plan §11.1): AirPods + Bose, card fires on a cold Bluetooth press, reads correctly in both light and dark, never opens the window / steals focus / changes the paste target (only "Adjust settings" activates), toggle-off suppresses next launch. Do NOT auto-merge until that passes.
