### PR TITLE
fix(pipeline): end filler-only captures quietly instead of a failed pill (#1358)

### DIFF
--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -19,12 +19,15 @@ public struct ExecutionMetrics: Codable, Sendable {
   /// not just the filter result.
   public var polishFilterTripped: String?
   public var polishFellBackToRaw: Bool?
-  /// #1050 honest disaggregation of `polishFellBackToRaw`. Populated only for AFM
-  /// polish (nil for cloud / pre-#1050 records); nil also when polish CHANGED the
-  /// text (not a fallback). `no_change` (benign — model returned input unchanged),
-  /// `guard_discard` (`EnviousOutputFilter` caught bad output), or
+  /// #1050 honest disaggregation of `polishFellBackToRaw`. Populated for AFM
+  /// polish (nil for cloud / pre-#1050 records) and for the #1358 empty-output
+  /// recovery (any provider); nil also when polish CHANGED the text (not a
+  /// fallback). `no_change` (benign — model returned input unchanged),
+  /// `guard_discard` (`EnviousOutputFilter` caught bad output),
   /// `validator_discard` (`validatePolishOutput` caught bad output — invisible to
-  /// `polishFilterTripped`). Invariant: present iff `polishFellBackToRaw == true`.
+  /// `polishFilterTripped`), or `empty_output_floor` (#1358 — the limb chain
+  /// produced empty text and the wiring delivered a deterministic raw floor).
+  /// Invariant: present iff `polishFellBackToRaw == true`.
   public var polishFallbackReason: String?
   /// Deterministic ITN telemetry (#145). Populated per dictation; nil on
   /// pre-#145 transcripts on disk (additive optional Codable, back-compatible).

--- a/Sources/EnviousWisprPipeline/FillerRemovalStep.swift
+++ b/Sources/EnviousWisprPipeline/FillerRemovalStep.swift
@@ -30,9 +30,26 @@ public final class FillerRemovalStep: TextProcessingStep {
 
   public init() {}
 
+  /// The single filler-stripping transform (#1358): regex replace + `\s{2,}`
+  /// collapse + whitespace/newline trim, applied exactly once. Returns the input
+  /// UNCHANGED when the regex is unavailable. This is the one authority for
+  /// "what does removing fillers leave"; `process()` and
+  /// `TextLexicalContent.hasLexicalContentAfterRemovingFillers` both call it so
+  /// there is never a second filler algorithm.
+  public static func removingFillers(from text: String) -> String {
+    guard let pattern = fillerPattern else { return text }
+    let range = NSRange(text.startIndex..., in: text)
+    let cleaned = pattern.stringByReplacingMatches(
+      in: text, range: range, withTemplate: ""
+    )
+    return cleaned.replacingOccurrences(
+      of: #"\s{2,}"#, with: " ", options: .regularExpression
+    ).trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
   public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
     let text = context.text
-    guard let pattern = Self.fillerPattern else {
+    guard Self.fillerPattern != nil else {
       Task {
         await AppLogger.shared.log(
           "FillerRemoval: skipped — regex unavailable",
@@ -41,14 +58,7 @@ public final class FillerRemovalStep: TextProcessingStep {
       }
       return context
     }
-    let range = NSRange(text.startIndex..., in: text)
-    let cleaned = pattern.stringByReplacingMatches(
-      in: text, range: range, withTemplate: ""
-    )
-    // Collapse multiple spaces and trim
-    let result = cleaned.replacingOccurrences(
-      of: #"\s{2,}"#, with: " ", options: .regularExpression
-    ).trimmingCharacters(in: .whitespacesAndNewlines)
+    let result = Self.removingFillers(from: text)
 
     let removedCount = (text.count - result.count)
     if removedCount > 0 {

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -235,7 +235,30 @@ struct KernelFinalizationWiring {
       outcome.polishFallbackReason = ctx.polishFallbackReason
       outcome.polishError = result.polishError
       outcome.polishDurationSeconds = CFAbsoluteTimeGetCurrent() - start
-      return ctx.polishedText ?? ctx.text
+
+      // #1358: the display text after the limb chain. `ctx.polishedText ?? ctx.text`
+      // can be empty two ways for a short dictation: polish returned "" (no
+      // empty guard in `validatePolishOutput` below 10 input words) with an
+      // intact post-ITN floor `ctx.text`, OR a deterministic step emptied
+      // `ctx.text` itself (bare filler, or word-correction on malformed data).
+      // Deliver the first non-empty deterministic floor and STAMP the side-
+      // channels so store()/deliver()/metrics/recovery all read ONE identical
+      // value; return "" only when nothing lexical remains — the kernel routes
+      // that to the quiet `.noSpeech` terminal (mirrors the #979 downgrade).
+      if !(ctx.polishedText ?? ctx.text).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        return ctx.polishedText ?? ctx.text  // unchanged happy path
+      }
+      let floor = Self.emptyOutputRecoveryFloor(deterministicText: ctx.text, rawASR: raw)
+      if !floor.isEmpty {
+        outcome.rawText = floor
+        outcome.polishedText = nil  // the "" polish never persists; History == clipboard
+        // Preserve the invariant `(polishFallbackReason != nil) == pipelineFellBackToRaw`
+        // (`TextProcessingStep.swift`). `llmProvider`/`llmModel`/`polishMetadata`
+        // are retained — honest facts that a polish was attempted.
+        outcome.pipelineFellBackToRaw = true
+        outcome.polishFallbackReason = "empty_output_floor"
+      }
+      return floor
     }
 
     // store — build the Transcript exactly as TranscriptFinalizer.swift:129
@@ -381,6 +404,27 @@ struct KernelFinalizationWiring {
     return polishedText == nil || pipelineFellBackToRaw || polishedText == rawText
   }
 
+  /// #1358: given an EMPTY limb-chain display result, the deterministic recovery
+  /// floor to deliver. First non-empty of: the post-ITN `deterministicText`
+  /// (polish returned empty but the word-corrected/ITN'd text is intact — the
+  /// #145 floor), else the raw ASR when it still holds lexical content after
+  /// filler-stripping (a step erased a real word), else "" — which the kernel
+  /// routes to the quiet `.noSpeech` terminal.
+  ///
+  /// The raw-ASR rank ALWAYS strips fillers (via `TextLexicalContent`) regardless
+  /// of the `fillerRemovalEnabled` toggle: pasting a bare filler as a recovery
+  /// floor is never desired (founder directive 2026-07-11). Pure + `@MainActor`
+  /// (the filler classifier reads the shared regex). Tested parametrically.
+  @MainActor
+  static func emptyOutputRecoveryFloor(deterministicText: String, rawASR: String) -> String {
+    let deterministicFloor = deterministicText.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !deterministicFloor.isEmpty { return deterministicFloor }
+    if TextLexicalContent.hasLexicalContentAfterRemovingFillers(rawASR) {
+      return rawASR.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    return ""
+  }
+
   private static func updateTranscriptMetrics(
     outcome: KernelFinalizationOutcome,
     context: KernelSessionContext,
@@ -402,6 +446,16 @@ struct KernelFinalizationWiring {
       rawText: outcome.rawText,
       pipelineFellBackToRaw: outcome.pipelineFellBackToRaw)
 
+    // The fallback fields were historically AFM-only (`polishMetadata != nil`);
+    // cloud/no-polish fallback reasons stay suppressed. #1358 adds a provider-
+    // agnostic producer — the empty-output recovery floor stamps
+    // `empty_output_floor` with no `polishMetadata` — so let THAT reason through
+    // the AFM gate (and only that reason) so the recovery is observable in
+    // telemetry without changing behavior for existing reasons. The pair is
+    // gated together, so the `(reason != nil) == fellBackToRaw` invariant holds.
+    let emitFallbackFields =
+      outcome.polishMetadata != nil || outcome.polishFallbackReason == "empty_output_floor"
+
     transcript.metrics = ExecutionMetrics(
       asrLatencySeconds: asrLatency,
       llmLatencySeconds: outcome.polishDurationSeconds,
@@ -412,8 +466,8 @@ struct KernelFinalizationWiring {
       streamingMode: outcome.streamingMode,
       e2eSeconds: e2e,
       polishFilterTripped: outcome.polishMetadata?.filterTripped,
-      polishFellBackToRaw: outcome.polishMetadata == nil ? nil : outcome.pipelineFellBackToRaw,
-      polishFallbackReason: outcome.polishMetadata == nil ? nil : outcome.polishFallbackReason,
+      polishFellBackToRaw: emitFallbackFields ? outcome.pipelineFellBackToRaw : nil,
+      polishFallbackReason: emitFallbackFields ? outcome.polishFallbackReason : nil,
       itnRan: outcome.itnRan,
       itnChanged: outcome.itnChanged,
       itnFloorDelivered: itnFloorDelivered,

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -332,6 +332,13 @@ final class KernelLifecycleTelemetrySink {
             "mode": telemetryState.noSpeechTelemetry?.mode
               ?? (outcome.streamingMode ? "streaming" : "batch"),
           ])
+      case .emptyAfterProcessing:
+        // #1358: the limb chain produced no lexical content (bare filler /
+        // non-speech artifact). Breadcrumb only — NOT a `heart_path_finalization`
+        // Sentry capture (mirrors the #979 asr-empty downgrade).
+        breadcrumb(
+          "processing", "Text processing produced no lexical content",
+          ["backend": backend.rawValue])
       }
 
     case .cancelled:

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -114,6 +114,13 @@ enum NoSpeechSource: Equatable, Sendable {
   /// ASR returned empty text on a path where VAD did NOT firmly say speech
   /// (`TP:902` — "ASR empty (no speech detected)").
   case asrEmptyNoSpeech
+  /// #1358: the limb chain produced no lexical content (a bare filler / non-
+  /// speech artifact — the recognizer's whole output was a filler like "uh").
+  /// The finalization wiring already delivered any recoverable deterministic
+  /// floor as non-empty, so an empty result here is genuinely no-speech — end
+  /// quietly instead of a `.failed(.emptyAfterProcessing)` heart-path capture
+  /// (mirrors the #979 asr-empty Sentry downgrade).
+  case emptyAfterProcessing
 }
 
 /// Kernel-side model-load wedge payload. The old pipeline used
@@ -1703,17 +1710,17 @@ final class RecordingSessionKernel {
         }
         // #1434: label from the EFFECTIVE outcome (the salvage path rebinds it
         // to the retry's `.transcript`), never the primary `.empty`.
-        var archiveOutcome = Self.dictationArchiveOutcome(
-          for: archiveEffectiveOutcome, effectiveSpeechEvidence: archiveSpeechEvidence)
         // A `.transcript` decode whose finalization did NOT reach `.completed`
-        // (empty after polish → `.failed(.emptyAfterProcessing)`, or superseded
-        // mid-finalize) is not a real completion — relabel so it stays distinct
-        // from normal completions in the metadata (Codex r6 P3). `runFinalizing`
-        // has already run by here, so `state` holds the terminal verdict.
-        // #1434: applies to salvaged deliveries too via the effective outcome.
-        if case .transcript = archiveEffectiveOutcome, !(isCurrent(sid) && state == .completed) {
-          archiveOutcome = .finalizationFailed
-        }
+        // is not a real completion — relabel so it stays distinct in the archive
+        // metadata (Codex r6 P3). `runFinalizing` has already run by here, so
+        // `state` holds the terminal verdict. #1434: applies to salvaged
+        // deliveries too via the effective outcome.
+        let archiveOutcome = Self.relabeledArchiveOutcome(
+          base: Self.dictationArchiveOutcome(
+            for: archiveEffectiveOutcome, effectiveSpeechEvidence: archiveSpeechEvidence),
+          effectiveOutcome: archiveEffectiveOutcome,
+          reachedCompleted: isCurrent(sid) && state == .completed,
+          reachedNoSpeech: isCurrent(sid) && state == .noSpeech)
         let archiveClass = archiveClassification
         let archiveBackend = adapter.engineIdentity.backendType.rawValue
         let archiveSettingsOptIn = dictationAudioArchiveOptInProvider()
@@ -1756,6 +1763,24 @@ final class RecordingSessionKernel {
       }
     }
 
+    /// Relabel the archive outcome for a `.transcript` decode whose finalization
+    /// did NOT reach `.completed`. #1358: a filler-only capture emptied by the
+    /// text steps now ends `.noSpeech` (quiet, not a failure) — archive it as
+    /// `.noSpeech` so diagnostic triage isn't skewed. An empty-after-polish
+    /// `.failed(.emptyAfterProcessing)` or a superseded mid-finalize decode
+    /// stays `.finalizationFailed`. Non-`.transcript` and completed decodes keep
+    /// their base label. Pure so a test can freeze the mapping (Codex r6 P3,
+    /// #1358 code-diff r2).
+    nonisolated static func relabeledArchiveOutcome(
+      base: DictationAudioArchive.Outcome,
+      effectiveOutcome: ASREngineOutcome,
+      reachedCompleted: Bool,
+      reachedNoSpeech: Bool
+    ) -> DictationAudioArchive.Outcome {
+      guard case .transcript = effectiveOutcome, !reachedCompleted else { return base }
+      return reachedNoSpeech ? .noSpeech : .finalizationFailed
+    }
+
     /// Whether the conditioned batch buffer (`asrSamples`) is the buffer the
     /// engine actually decoded — true ONLY for a conditioned-batch decode: a
     /// batch session, or a streaming session that fell back to batch rescue. A
@@ -1794,8 +1819,16 @@ final class RecordingSessionKernel {
     guard isCurrent(sid) else { return }
 
     // Empty after the limb steps — clipboard untouched (PR-1 §B.1.2).
+    // #1358: the finalization wiring already delivered any recoverable
+    // deterministic floor (post-ITN text, else lexical raw ASR) as non-empty,
+    // so an empty result here is genuinely non-lexical (a bare filler / non-
+    // speech artifact). End quietly as no-speech — never a heart-path failure
+    // (mirrors the #979 asr-empty downgrade). If the capture was interrupted,
+    // `interruptedTerminalFloor` floors this to `.audioInterrupted` to retain
+    // the #1408 crash-recovery spool.
     if processed.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-      finishTerminal(.failed(.emptyAfterProcessing), sid: sid)
+      lastNoSpeechSource = .emptyAfterProcessing
+      finishTerminal(.noSpeech, sid: sid)
       return
     }
 
@@ -2324,9 +2357,15 @@ final class RecordingSessionKernel {
         return false
       }
     case .finalizing:
-      // Safe point — only `completed` or a `failed` delivery outcome.
+      // Safe point — a delivery outcome (`completed`/`failed`) OR a legitimate
+      // no-delivery discovery. #1358: the limb chain can empty the transcript
+      // (bare filler / non-speech artifact) → `.noSpeech`; and if that capture
+      // was interrupted, `interruptedTerminalFloor` floors `.noSpeech` up to
+      // `.audioInterrupted` (retain the #1408 spool), so that floored terminal
+      // must be legal too or `finishTerminal` would silently never terminate.
+      // None of these is the cancel/interruption COMMAND the safe point blocks.
       switch next {
-      case .completed, .failed:
+      case .completed, .failed, .noSpeech, .audioInterrupted:
         return true
       default:
         return false
@@ -2906,6 +2945,12 @@ final class RecordingSessionKernel {
     }
     func testSetTranscriptionFailureError(_ error: (any Error)?) {
       telemetryState.transcriptionFailureError = error
+    }
+    /// #1358: pre-seed the interruption cause so a test can exercise
+    /// `interruptedTerminalFloor` (which reads `lastAudioInterruptionCause`)
+    /// without driving a real mid-recording interruption.
+    func testSetInterruptionCause(_ cause: EngineInterruptionCause?) {
+      telemetryState.interruptionCause = cause
     }
 
     /// Test-only recording-snapshot accessors. Used by Div 8 coverage to

--- a/Sources/EnviousWisprPipeline/TextLexicalContent.swift
+++ b/Sources/EnviousWisprPipeline/TextLexicalContent.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Lexical-content classification for the #1358 raw-ASR recovery floor.
+///
+/// When the limb chain empties the transcript, `KernelFinalizationWiring`'s
+/// `processText` uses this to decide whether the raw ASR still holds a real
+/// word worth delivering (a step over-deleted lexical content) versus a bare
+/// filler / non-speech artifact that must end quietly as no-speech.
+///
+/// It delegates to the ONE filler transform (`FillerRemovalStep.removingFillers`)
+/// so there is never a second filler algorithm. It ALWAYS strips fillers
+/// regardless of the `fillerRemovalEnabled` setting — the raw floor is a
+/// defensive recovery for erased real content, and pasting a bare filler as a
+/// recovery floor is never desired (founder directive 2026-07-11).
+public enum TextLexicalContent {
+  /// `true` iff removing fillers from `text` leaves at least one alphanumeric
+  /// scalar (a letter or digit). "uh" → false; "OK" / "1988" / "I" → true;
+  /// "..." → false; "uh OK" → true.
+  @MainActor
+  public static func hasLexicalContentAfterRemovingFillers(_ text: String) -> Bool {
+    let stripped = FillerRemovalStep.removingFillers(from: text)
+    return stripped.unicodeScalars.contains { CharacterSet.alphanumerics.contains($0) }
+  }
+}

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -27,9 +27,12 @@ public struct TextProcessingContext: Sendable {
   /// `pipelineFellBackToRaw` boolean (#1050). Nil when polish changed the text
   /// (not a fallback). One of `no_change` (model returned the input unchanged —
   /// benign), `guard_discard` (connector `EnviousOutputFilter` tripped — genuine
-  /// misbehavior caught; `polishMetadata.filterTripped` names which), or
+  /// misbehavior caught; `polishMetadata.filterTripped` names which),
   /// `validator_discard` (model differed but `validatePolishOutput` substituted
-  /// the original — genuine catch the `filter_tripped` signal cannot see).
+  /// the original — genuine catch the `filter_tripped` signal cannot see), or
+  /// `empty_output_floor` (#1358 — the limb chain produced empty text and
+  /// `KernelFinalizationWiring` delivered a deterministic raw floor; stamped by
+  /// the wiring, not by `LLMPolishStep.polishFallbackReason`).
   /// Invariant: `(polishFallbackReason != nil) == pipelineFellBackToRaw`.
   public var polishFallbackReason: String?
 

--- a/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
@@ -1,0 +1,289 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - #1358 — empty-after-processing recovery
+//
+// When the limb chain empties the transcript, the finalization wiring delivers
+// the first non-empty deterministic floor (post-ITN text, else lexical raw ASR)
+// with History == clipboard, and only a truly non-lexical result routes to the
+// quiet `.noSpeech` terminal (never a `heart_path_finalization` failure). The
+// two illegal safe-point transitions the fix needs (`.noSpeech` and its
+// interruption-floored `.audioInterrupted`) are made legal so nothing wedges.
+//
+// End-to-end "a filler-only RECORDING lands in `.noSpeech`" is covered
+// transitively: the wiring returns "" for a filler-only chain result (see
+// `wiringFillerOnlyReturnsEmpty`), the kernel branch routes "" → `.noSpeech`
+// (code), the transition is legal (`finalizingAllowedTerminalSet`), and the
+// observable outcome is a breadcrumb, not a Sentry capture
+// (`KernelLifecycleTelemetrySinkTests.noSpeechEmptyAfterProcessingEmission`).
+
+@MainActor
+@Suite("#1358 empty-after-processing recovery")
+struct Issue1358EmptyRecoveryTests {
+
+  // MARK: TextLexicalContent (the raw-floor classifier)
+
+  @Test(
+    "hasLexicalContentAfterRemovingFillers: fillers/punctuation → false, real words/digits → true",
+    arguments: [
+      ("uh", false), ("um", false), ("hmm", false), ("mm", false),
+      ("...", false), ("", false), ("   ", false),
+      ("OK", true), ("hi", true), ("no", true), ("I", true),
+      ("1988", true), ("8", true), ("uh OK", true), ("hello there", true),
+    ])
+  func lexicalClassifier(input: String, expected: Bool) {
+    #expect(TextLexicalContent.hasLexicalContentAfterRemovingFillers(input) == expected)
+  }
+
+  // MARK: emptyOutputRecoveryFloor (the pure floor decision)
+
+  @Test(
+    "emptyOutputRecoveryFloor: post-ITN floor wins, else lexical raw, else empty (→ no-speech)",
+    arguments: [
+      // (deterministicText, rawASR, expectedFloor)
+      ("hello there", "uh", "hello there"),  // rank 2 wins even when raw is filler
+      ("203", "two zero three", "203"),  // rank 2 (polish erased, post-ITN intact)
+      ("", "hello", "hello"),  // rank 3 — a step erased a real word
+      ("   ", "  no  ", "no"),  // whitespace deterministic → rank 3, trimmed
+      ("", "1988", "1988"),  // rank 3 digit
+      ("", "uh", ""),  // filler-only → route to .noSpeech
+      ("", "uh...", ""),  // filler + punctuation → .noSpeech
+      ("", "", ""),  // nothing → .noSpeech
+    ])
+  func recoveryFloor(deterministicText: String, rawASR: String, expectedFloor: String) {
+    #expect(
+      KernelFinalizationWiring.emptyOutputRecoveryFloor(
+        deterministicText: deterministicText, rawASR: rawASR) == expectedFloor)
+  }
+
+  @Test(
+    "the raw floor strips fillers regardless of the filler-removal toggle (deliberate, #1358)")
+  func rawFloorIsToggleIndependent() {
+    // The classifier never reads `fillerRemovalEnabled`; a bare filler is never
+    // floored even when a NON-filler step emptied the deterministic text.
+    #expect(
+      KernelFinalizationWiring.emptyOutputRecoveryFloor(deterministicText: "", rawASR: "uh") == "")
+    // A real word emptied by a step IS recovered.
+    #expect(
+      KernelFinalizationWiring.emptyOutputRecoveryFloor(deterministicText: "", rawASR: "hello")
+        == "hello")
+  }
+
+  // MARK: Wiring integration — polish returns empty (finding 3)
+
+  @Test(
+    "polish returns empty with an intact post-ITN floor → floor delivered, History == clipboard",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1358",
+      "empty polish erased short dictations"
+    ))
+  func wiringPolishEmptyDeliversFloorConsistently() async throws {
+    let outcome = KernelFinalizationOutcome()
+    let saved = SavedBox()
+    let steps = makeSteps()
+    // Polish ON with an empty-returning polisher; >3 words so it is not bypassed.
+    steps.llmPolish.llmProvider = .openAI
+    steps.llmPolish.llmModel = "gpt-4o-mini"
+    steps.llmPolish.makePolisher = { _, _, _ in EmptyPolisher() }
+    let wiring = makeWiring(outcome: outcome, steps: steps, save: { saved.transcript = $0 })
+
+    let input = "please clean up this sentence now"
+    let result = try await wiring.processText(input) {}
+    try await wiring.store(result, UUID())
+    _ = await wiring.deliver(result)
+
+    // Delivered the post-ITN floor, not the empty polish.
+    #expect(result == input)
+    // Side-channels stamped so store/deliver/metrics all agree.
+    #expect(outcome.rawText == input)
+    #expect(outcome.polishedText == nil)
+    #expect(outcome.pipelineFellBackToRaw == true)
+    #expect(outcome.polishFallbackReason == "empty_output_floor")
+    // The polish attempt is still recorded honestly (not erased).
+    #expect(outcome.llmProvider == LLMProvider.openAI.rawValue)
+    #expect(outcome.llmModel == "gpt-4o-mini")
+    // History == clipboard: the persisted transcript text equals the delivered text.
+    #expect(saved.transcript?.text == input)
+    #expect(saved.transcript?.polishedText == nil)
+    // The recovery signal reaches telemetry even though this is a CLOUD provider
+    // (no AFM `polishMetadata`) — the metrics gate lets `empty_output_floor`
+    // through so the defensive recovery is observable.
+    let metrics = try #require(outcome.transcript?.metrics)
+    #expect(metrics.polishFellBackToRaw == true)
+    #expect(metrics.polishFallbackReason == "empty_output_floor")
+  }
+
+  @Test("a filler-only chain result returns empty from processText (kernel routes → .noSpeech)")
+  func wiringFillerOnlyReturnsEmpty() async throws {
+    let outcome = KernelFinalizationOutcome()
+    let steps = makeSteps()
+    steps.fillerRemoval.fillerRemovalEnabled = true  // the shipped default
+    let wiring = makeWiring(outcome: outcome, steps: steps)
+
+    // Filler removal empties "uh"; the raw floor is non-lexical → "".
+    let result = try await wiring.processText("uh") {}
+    #expect(result.isEmpty)
+    // No floor stamped — nothing to recover.
+    #expect(outcome.polishFallbackReason == nil)
+  }
+
+  // MARK: FSM legality — the finalizing safe-point set
+
+  @Test(
+    "finalizing legal terminal set is exactly {.completed, .failed, .noSpeech, .audioInterrupted}",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1358",
+      "an illegal finalizing → noSpeech/audioInterrupted would silently wedge the session"
+    ))
+  func finalizingAllowedTerminalSet() {
+    // The four legal terminals — each on a fresh kernel walked to finalizing
+    // (a successful transition leaves finalizing).
+    for terminal in [
+      RecordingSessionState.completed, .failed(.asrEmpty), .noSpeech, .audioInterrupted,
+    ] {
+      let kernel = freshKernelAtFinalizing()
+      #expect(
+        kernel.testForceTransition(to: terminal) == true,
+        "\(terminal) must be a legal terminal from finalizing")
+    }
+    // Every other target is rejected (the safe point holds). All false on one
+    // kernel since a rejected transition leaves it in finalizing.
+    let kernel = freshKernelAtFinalizing()
+    for forbidden in [
+      RecordingSessionState.idle, .preparing, .warmingUp, .recording, .stopping,
+      .transcribing, .finalizing, .cancelled, .discarded, .asrInterrupted,
+    ] {
+      #expect(
+        kernel.testForceTransition(to: forbidden) == false,
+        "\(forbidden) must be rejected from finalizing")
+      #expect(kernel.state == .finalizing, "a rejected transition leaves the safe point intact")
+    }
+  }
+
+  // MARK: Interrupted floor (#1408 spool retention)
+
+  @Test(
+    "an interrupted empty finalize floors .noSpeech → .audioInterrupted (retain spool), else unchanged"
+  )
+  func interruptedEmptyFloorsToAudioInterrupted() {
+    // With an interruption cause, the empty no-speech is floored UP so the
+    // #1408 crash-recovery spool is retained.
+    let interrupted = freshKernelAtFinalizing()
+    interrupted.testSetInterruptionCause(.xpcConnectionLost)
+    #expect(interrupted.testInterruptedTerminalFloor(.noSpeech) == .audioInterrupted)
+
+    // With no interruption, the clean cold-mic filler stays quiet no-speech.
+    let clean = freshKernelAtFinalizing()
+    clean.testSetInterruptionCause(nil)
+    #expect(clean.testInterruptedTerminalFloor(.noSpeech) == .noSpeech)
+  }
+
+  // MARK: Diagnostic-archive relabel (code-diff r2)
+
+  @Test(
+    "archive relabel: filler-only .noSpeech archives as .noSpeech, not .finalizationFailed")
+  func archiveOutcomeRelabel() {
+    let transcript = ASREngineOutcome.transcript(
+      ASRResult(
+        text: "uh", language: nil, duration: 0.1, processingTime: 0.05, backendType: .parakeet))
+    // A normal completion keeps its base label.
+    #expect(
+      RecordingSessionKernel.relabeledArchiveOutcome(
+        base: .completed, effectiveOutcome: transcript,
+        reachedCompleted: true, reachedNoSpeech: false) == .completed)
+    // #1358: a filler-only capture emptied by processing → quiet no-speech, NOT a failure.
+    #expect(
+      RecordingSessionKernel.relabeledArchiveOutcome(
+        base: .completed, effectiveOutcome: transcript,
+        reachedCompleted: false, reachedNoSpeech: true) == .noSpeech)
+    // Empty-after-polish `.failed` / superseded mid-finalize stays finalizationFailed.
+    #expect(
+      RecordingSessionKernel.relabeledArchiveOutcome(
+        base: .completed, effectiveOutcome: transcript,
+        reachedCompleted: false, reachedNoSpeech: false) == .finalizationFailed)
+    // A non-`.transcript` decode keeps its base label untouched.
+    #expect(
+      RecordingSessionKernel.relabeledArchiveOutcome(
+        base: .noSpeech, effectiveOutcome: .empty(hadSpeechEvidence: false),
+        reachedCompleted: false, reachedNoSpeech: true) == .noSpeech)
+  }
+
+  // MARK: Helpers
+
+  private func makeSteps() -> LimbSteps {
+    LimbSteps(
+      wordCorrection: WordCorrectionStep(),
+      fillerRemoval: FillerRemovalStep(),
+      emojiFormatter: EmojiFormatterStep(),
+      inverseTextNormalization: InverseTextNormalizationStep(),
+      llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
+      emojiRestore: EmojiRestoreStep())
+  }
+
+  private func makeWiring(
+    outcome: KernelFinalizationOutcome = KernelFinalizationOutcome(),
+    steps: LimbSteps? = nil,
+    save: @escaping @MainActor (Transcript) throws -> Void = { _ in }
+  ) -> KernelFinalizationWiring {
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true)
+    return KernelFinalizationWiring(
+      outcome: outcome,
+      context: context,
+      adapter: ParakeetEngineAdapter(asrManager: StubParakeetASRManager()),
+      steps: steps ?? makeSteps(),
+      textProcessingRunner: TextProcessingRunner(
+        timeoutExecutor: FakeTimeoutExecutor(throwBelowSeconds: 0).run),
+      save: save,
+      deliverPaste: { _ in
+        PasteDeliveryResult(
+          tier: .cgEvent, durationMs: 1,
+          outcome: .delivered(tier: .cgEvent, durationMs: 1))
+      },
+      pasteCompletionRegistry: nil,
+      currentTime: { ProcessInfo.processInfo.systemUptime },
+      telemetryState: KernelTelemetryState())
+  }
+
+  /// A fresh kernel legally walked to `.finalizing`.
+  private func freshKernelAtFinalizing() -> RecordingSessionKernel {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: FakeAudioCapture(), vad: FakeVADSignalSource(),
+      clock: clock, paste: FakePasteTarget())
+    let kernel = wrapper.testKernel
+    _ = kernel.testForceTransition(to: .preparing)
+    _ = kernel.testForceTransition(to: .warmingUp)
+    _ = kernel.testForceTransition(to: .recording)
+    _ = kernel.testForceTransition(to: .stopping)
+    _ = kernel.testForceTransition(to: .transcribing)
+    _ = kernel.testForceTransition(to: .finalizing)
+    return kernel
+  }
+}
+
+/// Returns an empty polish result so the empty-output floor is exercised — the
+/// short-input analogue of the validator gap (`validatePolishOutput` has no
+/// empty guard below 10 input words).
+private struct EmptyPolisher: TranscriptPolisher {
+  func polish(
+    text: String,
+    instructions: PolishInstructions,
+    config: LLMProviderConfig,
+    onToken: (@Sendable (String) -> Void)?
+  ) async throws -> LLMResult {
+    LLMResult(polishedText: "")
+  }
+}
+
+@MainActor
+private final class SavedBox {
+  var transcript: Transcript?
+}

--- a/Tests/EnviousWisprTests/Pipeline/Issue1358FillerEmptyReproTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Issue1358FillerEmptyReproTests.swift
@@ -1,0 +1,83 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// The founder's real one-at-a-time dictations that DELIVERED (2026-07-11). None of
+// these may ever be emptied by filler removal. File-scope so @Test argument access is
+// not actor-isolated.
+private let realWordsThatDelivered: [String] = [
+  "Okay.", "Sounds good.", "Hi.", "Hello.", "No.", "No.", "Yeah.",
+  "A B.", "See.", "D.", "Gee.", "1988.", "27.", "25.", "Eight.",
+  "OK", "no", "hi", "I", "yes", "8",
+]
+
+// Bare filler captures — the cold-mic artifact class. Expected to collapse to empty.
+private let fillerOnlyCaptures: [String] = [
+  "uh", "um", "umm", "uhh", "hmm", "mm", "mhm", "mmm", "ah", "er",
+  "uh.", "Um.", "Mm-", "hmm...",
+]
+
+// MARK: - #1358 reproduction — "text processing can erase meaningful 2-4 char transcripts"
+//
+// EMPIRICAL REPRODUCTION (founder directive 2026-07-11: replicate the bug against the
+// REAL shipped step, do not trust the Sentry auto-triage narrative).
+//
+// Hypothesis under test: the eraser is FillerRemovalStep (ON by default —
+// SettingsDefaultValues.fillerRemovalEnabled = true), NOT the AI polish (polish is
+// skipped on short dictations). A cold-mic quick press yields an ASR best-guess that
+// is a bare filler token ("uh"/"um"/"mm"...). FillerRemovalStep has no empty-floor, so
+// the whole utterance collapses to "". TranscriptFinalizer then trims to empty and
+// throws FinalizationError.emptyAfterProcessing — a heart-path finalization failure
+// with no transcript delivered.
+//
+// This suite runs the real step over the founder's live dictation battery + the filler
+// tokens and records, for each input, whether it survives the same trim the finalizer
+// applies (trimmingCharacters(in: .whitespacesAndNewlines)). It asserts:
+//   (1) real short words the founder confirmed work are NEVER emptied, and
+//   (2) filler-only captures DO collapse to empty (reproducing the failure precondition).
+@MainActor
+@Suite("#1358 filler-removal empties short transcripts (reproduction)")
+struct Issue1358FillerEmptyReproTests {
+
+  /// Mirrors TranscriptFinalizer.swift:130 — the trim whose emptiness throws.
+  private func finalTrim(_ s: String) -> String {
+    s.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private func runFiller(_ input: String) async throws -> String {
+    let step = FillerRemovalStep()
+    step.fillerRemovalEnabled = true  // shipped default
+    let ctx = try await step.process(TextProcessingContext(text: input, language: nil))
+    return ctx.text
+  }
+
+  @Test(
+    "real short words the founder confirmed are never erased", arguments: realWordsThatDelivered)
+  func realWordSurvives(_ word: String) async throws {
+    let out = finalTrim(try await runFiller(word))
+    #expect(!out.isEmpty, "REGRESSION: filler removal erased a real word: \"\(word)\" -> \"\"")
+  }
+
+  @Test(
+    "bare filler captures collapse to empty (reproduces the failure precondition)",
+    arguments: fillerOnlyCaptures)
+  func fillerCollapsesToEmpty(_ filler: String) async throws {
+    let out = finalTrim(try await runFiller(filler))
+    #expect(
+      out.isEmpty,
+      "Expected filler-only \"\(filler)\" to collapse to empty (the emptyAfterProcessing precondition); got \"\(out)\""
+    )
+  }
+
+  // Partial-strip of a repeated filler leaves a fragment rather than empty — this is
+  // why "Mm-mm" from the recognizer delivered "Mm-" in a build with filler removal ON
+  // (regex strips only the trailing token). Same cold-mic filler-artifact class; documents
+  // that the empty-collapse is the fully-bare-filler subset, not every filler capture.
+  @Test("repeated filler partially strips to a fragment, not empty")
+  func repeatedFillerLeavesFragment() async throws {
+    #expect(finalTrim(try await runFiller("Mm-mm")) == "Mm-")
+    #expect(finalTrim(try await runFiller("mm-hmm")) == "mm-")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -632,6 +632,29 @@ import Testing
       ])
   }
 
+  @Test(
+    ".noSpeech(.emptyAfterProcessing) emits the #1358 processing breadcrumb, NOT a heart-path capture",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1358",
+      "filler-only capture must end quietly, no Sentry error"
+    ))
+  func noSpeechEmptyAfterProcessingEmission() {
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder)
+    sink.emit(.noSpeech(.emptyAfterProcessing))
+    // Breadcrumb only — mirrors the #979 asr-empty downgrade. The old bug fired
+    // a `heart_path_finalization` `emitCaptureError`; this must NOT.
+    #expect(
+      recorder.breadcrumbs == [
+        .init(
+          stage: "processing", message: "Text processing produced no lexical content",
+          dataKeys: ["backend"])
+      ])
+    #expect(
+      recorder.captureErrors.isEmpty,
+      "no heart_path_finalization Sentry capture for a quiet no-speech outcome")
+  }
+
   @Test(".cancelled emits NOTHING (PR-1 §B.7.4 only-one-new-event rule)")
   func cancelledEmitsNothing() {
     let recorder = Recorder()


### PR DESCRIPTION
## Problem
A cold-mic quick press whose recognizer output is a bare filler ("uh", "mm") was wiped to empty by the always-on filler-removal step. The kernel then ended the session as `.failed(.emptyAfterProcessing)` — an error pill AND a `heart_path_finalization` Sentry capture (10+ production users). Nothing was recoverable there: the real word was already lost upstream on the cold-mic clip.

## Fix
When the limb chain yields empty, `KernelFinalizationWiring.processText` now delivers the first non-empty deterministic floor (post-ITN `ctx.text`, else lexical raw ASR), **stamped into the persisted side-channels** so History and clipboard read one identical value. Only a truly non-lexical result routes to the existing quiet `.noSpeech` terminal (breadcrumb only, mirrors the #979 asr-empty downgrade) — no error pill, no Sentry capture.

This also closes the polish-returns-empty window (`validatePolishOutput` has no empty guard below 10 input words) via the post-ITN floor, **without touching polish**.

## Hardening (why the fix lives where it does)
- The floor decision lives in the wiring because `store` builds the persisted `Transcript` from `outcome.rawText`/`outcome.polishedText` side-channels, not the kernel argument — a kernel-local reassignment would desync History from the clipboard.
- Made `.finalizing → {.noSpeech, .audioInterrupted}` legal: the empty terminal and its #1408 interruption-floored form would otherwise silently wedge the session.
- Empty-output recovery telemetry (`empty_output_floor`) now reaches metrics for any provider (was AFM-gated).
- Diagnostic-archive relabel routes filler-only `.noSpeech` to the `.noSpeech` archive label, not `.finalizationFailed`.

## Validation
- 2741 logic tests green (`scripts/xcode-test.sh`), including a new reproduction suite (35 real/filler cases) + `Issue1358EmptyRecovery`.
- Codex code-diff review clean (2 findings folded: telemetry visibility, archive labeling).
- Live UAT: a real short word ("Okay.") delivers sub-second (0.469s total), no error pill, heart path intact.
- Filler-only → quiet no-speech is unit-proven (wiring returns empty, kernel routes `.noSpeech`, breadcrumb not Sentry).

Closes #1358
