### PR TITLE
feat(llm): one-time model relocation + EG-1 rehome to the owned model home (#1386 PR-1)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -161,6 +161,9 @@ enum EGOneDeliveryWiring {
     // ...and taking the removal back restores it, so the durable intent never
     // outlives the decision that set it.
     runtime.onModelRemovalCancelled = { migrator.markLegacyForReplacement(relocation) }
+    // ONE cleanup, reachable from both ways the replacement can be admitted: the
+    // automatic migration, and a user-initiated Download after that migration failed.
+    runtime.legacyCleanup = { try await migrator.cleanUpLegacy(relocation) }
     Task { @MainActor in
       let outcome = await migrator.migrate(relocation)
 
@@ -186,9 +189,7 @@ enum EGOneDeliveryWiring {
       switch intent ?? (legacyNeedsReplacing ? .replace : nil) {
       case .replace:
         runtime.sweepStaleServersAtLaunch()
-        runtime.startLegacyLayoutMigration {
-          try await migrator.cleanUpLegacy(relocation)
-        }
+        runtime.startLegacyLayoutMigration()
       case .remove:
         // The user removed EG-1 while a legacy artifact was still stranded. Finish
         // the removal they asked for, and fetch NOTHING.

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -62,15 +62,24 @@ enum EGOneDeliveryWiring {
     let legacyDirectory = appSupport.appendingPathComponent(
       "EnviousWispr/PolishModels", isDirectory: true)
 
-    // With the kill switch off, nothing may MUTATE model bytes — but the model
-    // must still LOAD, so we read from wherever the bytes already are. Pointing a
+    // With the kill switch off, nothing may MUTATE model bytes — but the model must
+    // still LOAD, so we read from wherever a usable copy actually is. Pointing a
     // disabled build at the owned home would leave an unmigrated user staring at
     // "not installed" while their model sat untouched in the old one: that is a
     // second failure, not a rollback.
+    //
+    // Pick by ADMISSION, never by directory existence. A relocation that failed
+    // partway leaves a half-populated `Models/eg-1` beside a perfectly good
+    // `PolishModels`, and "the folder is there" would choose the broken one —
+    // breaking EG-1 in exactly the scenario the kill switch exists to rescue
+    // (Codex PR-1 review r10). Falls back to the legacy home when neither is
+    // admitted, so a disabled build still reads from where the bytes were.
     let installDirectory: URL = {
       guard !EGOneDeliveryAdapter.isDeliveryEnabled() else { return ownedDirectory }
-      return FileManager.default.fileExists(atPath: ownedDirectory.path)
-        ? ownedDirectory : legacyDirectory
+      return ModelRelocationMigrator.admittedLocation(
+        manifest: manifest,
+        candidates: [ownedDirectory, legacyDirectory],
+        metadataDirectory: metadataDirectory) ?? legacyDirectory
     }()
 
     let registration = DeliveryRegistration(

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -57,10 +57,22 @@ enum EGOneDeliveryWiring {
       "EnviousWispr/ModelDelivery", isDirectory: true)
     // One app-owned home for every model: EG-1 leaves its one-off
     // `PolishModels` subfolder and sits beside the speech engines.
-    let installDirectory = appSupport.appendingPathComponent(
+    let ownedDirectory = appSupport.appendingPathComponent(
       "EnviousWispr/Models/eg-1", isDirectory: true)
     let legacyDirectory = appSupport.appendingPathComponent(
       "EnviousWispr/PolishModels", isDirectory: true)
+
+    // With the kill switch off, nothing may MUTATE model bytes — but the model
+    // must still LOAD, so we read from wherever the bytes already are. Pointing a
+    // disabled build at the owned home would leave an unmigrated user staring at
+    // "not installed" while their model sat untouched in the old one: that is a
+    // second failure, not a rollback.
+    let installDirectory: URL = {
+      guard !EGOneDeliveryAdapter.isDeliveryEnabled() else { return ownedDirectory }
+      return FileManager.default.fileExists(atPath: ownedDirectory.path)
+        ? ownedDirectory : legacyDirectory
+    }()
+
     let registration = DeliveryRegistration(
       manifest: manifest,
       installDirectory: installDirectory,
@@ -74,7 +86,11 @@ enum EGOneDeliveryWiring {
       relocation: ModelRelocationMigrator.RelocationPlan(
         manifest: manifest,
         oldLocations: [legacyDirectory],
-        destination: installDirectory,
+        // Always the OWNED home: the relocation plan describes where the bytes
+        // SHOULD end up, and `startLaunchTransition` refuses to run it at all when
+        // the kill switch is off. (A disabled build's registration may read from
+        // the legacy dir above; that is a load path, not a destination.)
+        destination: ownedDirectory,
         metadataDirectory: metadataDirectory,
         trustedLegacyArtifacts: trustedLegacyArtifacts,
         // The retired EGOneModelStore downloaded IN PLACE, leaving a `.partial`
@@ -105,6 +121,21 @@ enum EGOneDeliveryWiring {
     relocation: ModelRelocationMigrator.RelocationPlan,
     providerIsEGOne: Bool
   ) {
+    // The delivery kill switch is the operational rollback control: with it off,
+    // NOTHING may mutate model bytes. Relocation runs before every other delivery
+    // call, so it has to honor the flag itself — otherwise it would move and delete
+    // files precisely when someone had reached for the lever to stop exactly that
+    // (Codex PR-1 review r8). Flag off ⇒ behave as we did before #1386: no
+    // relocation, no cleanup, load from wherever the bytes already are.
+    guard EGOneDeliveryAdapter.isDeliveryEnabled() else {
+      if providerIsEGOne {
+        runtime.startIfActiveProvider()
+      } else {
+        runtime.sweepStaleServersAtLaunch()
+      }
+      return
+    }
+
     let migrator = ModelRelocationMigrator()
     // A Remove retires any pending replacement: the stranded artifact becomes a
     // plain delete, so a failed cleanup can never resurrect a model the user threw

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -173,15 +173,22 @@ enum EGOneDeliveryWiring {
         // The user removed EG-1 while a legacy artifact was still stranded. Finish
         // the removal they asked for, and fetch NOTHING.
         //
-        // Both halves, in this order, and the token clears LAST. The token is the
-        // only durable record that a Remove is owed; `cleanUpLegacy` clears it. So
-        // the delivery removal must be AWAITED first — clearing the token while a
-        // fire-and-forget removal was still running would, on a crash in that
-        // window, leave the newly-admitted 2.9 GB model installed with no record
-        // left to retry from, and the UI still reporting it present (Codex PR-1
-        // review r14). Both halves are idempotent, so a crash before the token
-        // clears simply repeats them on the next launch.
-        await runtime.removeModelAwaitingCompletion()
+        // Both halves, in this order, and the token clears LAST — but ONLY if the
+        // first half actually succeeded.
+        //
+        // The token is the sole durable record that a Remove is owed, and
+        // `cleanUpLegacy` is what clears it. So the delivery removal is AWAITED
+        // (clearing the token while a fire-and-forget removal was still running
+        // would lose the Remove to a crash in that window — r14), and its OUTCOME is
+        // checked (clearing the token after a FAILED removal would strand model
+        // remnants on disk with nothing left to honor the user's Remove — r15).
+        //
+        // A failed removal keeps the token and everything it records, so the next
+        // launch tries again. Both halves are idempotent, so repeating them is free.
+        guard case .removed = await runtime.removeModelAwaitingCompletion() else {
+          runtime.sweepStaleServersAtLaunch()
+          return
+        }
         try? await migrator.cleanUpLegacy(relocation)
         runtime.sweepStaleServersAtLaunch()
       case nil:

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -169,15 +169,17 @@ enum EGOneDeliveryWiring {
 
       // The OUTCOME drives this launch; the token drives RECOVERY across launches.
       //
-      // Journaling can fail (unwritable metadata directory, a failed atomic write).
-      // If we keyed only off the token, that failure would silently skip the
-      // replacement and then try to activate a monolith this build cannot load —
-      // EG-1 unavailable, with nothing started to fix it (Codex PR-1 review r17).
-      // So a classification that found a trusted legacy artifact starts the
-      // replacement whether or not the note got written. Cleanup stays safe by
-      // construction: `cleanUpLegacy` deletes nothing without a token, so a failed
-      // write costs a leaked old file until a launch that can journal, never an
-      // unauthorized deletion.
+      // The two cannot disagree: `migrate` reports `.trustedLegacyPending` ONLY once the
+      // token is durably written, and returns `.unrecognized` — do nothing, touch
+      // nothing — when it cannot write it (GitHub cloud review, PR #1497).
+      //
+      // That supersedes r17 ("start the replacement even if journalling failed") and is
+      // the correct version of its intent. An unjournaled replacement could never be
+      // admitted ANYWAY: the token and the admission marker share this one metadata
+      // directory, so a filesystem refusing the token refuses the marker too. Starting a
+      // 2.9 GB download that cannot be admitted — and that would leave a later Remove
+      // with no token to flip, resurrecting the model on the next launch — is strictly
+      // worse than waiting for a launch that can journal.
       let intent = migrator.pendingLegacyIntent(relocation)
       let legacyNeedsReplacing: Bool
       if case .trustedLegacyPending = outcome {

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -76,7 +76,15 @@ enum EGOneDeliveryWiring {
         oldLocations: [legacyDirectory],
         destination: installDirectory,
         metadataDirectory: metadataDirectory,
-        trustedLegacyArtifacts: trustedLegacyArtifacts))
+        trustedLegacyArtifacts: trustedLegacyArtifacts,
+        // The retired EGOneModelStore downloaded IN PLACE, leaving a `.partial`
+        // (up to ~2.9 GB) and a resume sidecar in PolishModels. The adapter's own
+        // sweep only ever looks at its CURRENT install dir, so the moment that
+        // dir moves to Models/eg-1 nothing would ever reclaim them — a user
+        // interrupted mid-download would carry those gigabytes forever, and the
+        // replacement download's disk preflight could fail because of them.
+        // (Codex PR-1 review r3; this is the leftover half of #1363.)
+        staleSidecarSuffixes: [".partial", ".resume.json"]))
   }
 
   /// Launch transition. Relocation runs BEFORE EG-1 activates, so nothing loads

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -106,17 +106,29 @@ enum EGOneDeliveryWiring {
     providerIsEGOne: Bool
   ) {
     let migrator = ModelRelocationMigrator()
+    // A Remove retires any pending replacement: the stranded artifact becomes a
+    // plain delete, so a failed cleanup can never resurrect a model the user threw
+    // away.
+    runtime.onModelRemoved = { migrator.markLegacyForRemoval(relocation) }
     Task { @MainActor in
       _ = await migrator.migrate(relocation)
-      if migrator.pendingLegacyArtifact(relocation) != nil {
+      switch migrator.pendingLegacyIntent(relocation) {
+      case .replace:
         runtime.sweepStaleServersAtLaunch()
         runtime.startLegacyLayoutMigration {
           try await migrator.cleanUpLegacy(relocation)
         }
-      } else if providerIsEGOne {
-        runtime.startIfActiveProvider()
-      } else {
+      case .remove:
+        // The user removed EG-1 while a legacy artifact was still stranded. Finish
+        // the delete they asked for and fetch NOTHING.
+        try? await migrator.cleanUpLegacy(relocation)
         runtime.sweepStaleServersAtLaunch()
+      case nil:
+        if providerIsEGOne {
+          runtime.startIfActiveProvider()
+        } else {
+          runtime.sweepStaleServersAtLaunch()
+        }
       }
     }
   }

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -1,0 +1,104 @@
+import EnviousWisprLLM
+import EnviousWisprModelDelivery
+import Foundation
+
+/// EG-1's delivery + relocation wiring (#1386 PR-1), extracted from
+/// `WisprBootstrapper` so the composition root stays a composer rather than
+/// growing a migration brain (`architecture-rules.md` keep-central-types-thin;
+/// the bootstrapper is line-ceilinged for exactly this reason).
+///
+/// Owns two things and nothing else:
+///  1. WHERE EG-1's bytes live — the app-owned `EnviousWispr/Models/eg-1`, and
+///     the legacy `PolishModels` home they came from.
+///  2. WHEN the launch transition runs — relocate first, then either replace a
+///     superseded layout or activate normally.
+enum EGOneDeliveryWiring {
+
+  /// The one previously-shipped EG-1 layout. Every released build installs a
+  /// single monolithic `eg-1-v1.gguf`; it cannot satisfy the current 8-shard
+  /// manifest (#1417's sharding is in no released tag). Those bytes ARE ours —
+  /// we shipped them and hold their digest — so the contract's automatic-
+  /// replacement clause permits replacing them with no user click, but only ever
+  /// verify-before-delete.
+  static let trustedLegacyArtifacts = ["eg-1-v1.gguf"]
+
+  struct Wired {
+    let adapter: EGOneDeliveryAdapter
+    let registration: DeliveryRegistration
+    let relocation: ModelRelocationMigrator.RelocationPlan
+  }
+
+  /// Build EG-1's registration + adapter + relocation plan against the owned
+  /// model home. Returns nil when the bundled manifest cannot be read (a RED
+  /// limb state, never a crash).
+  ///
+  /// `@MainActor` because `EGOneDeliveryAdapter` is: the composition root
+  /// already runs there, so this is the adapter's isolation, not a new hop.
+  @MainActor
+  static func wire(
+    controller: ModelDeliveryController,
+    version: String?,
+    appSupport: URL
+  ) -> Wired? {
+    guard let manifest = try? DeliveryManifest.loadBundled(resource: "eg1-delivery-manifest")
+    else { return nil }
+    let metadataDirectory = appSupport.appendingPathComponent(
+      "EnviousWispr/ModelDelivery", isDirectory: true)
+    // One app-owned home for every model: EG-1 leaves its one-off
+    // `PolishModels` subfolder and sits beside the speech engines.
+    let installDirectory = appSupport.appendingPathComponent(
+      "EnviousWispr/Models/eg-1", isDirectory: true)
+    let legacyDirectory = appSupport.appendingPathComponent(
+      "EnviousWispr/PolishModels", isDirectory: true)
+    let registration = DeliveryRegistration(
+      manifest: manifest,
+      installDirectory: installDirectory,
+      metadataDirectory: metadataDirectory)
+    return Wired(
+      adapter: EGOneDeliveryAdapter(
+        controller: controller,
+        registration: registration,
+        version: version ?? manifest.identity.revision),
+      registration: registration,
+      relocation: ModelRelocationMigrator.RelocationPlan(
+        manifest: manifest,
+        oldLocations: [legacyDirectory],
+        destination: installDirectory,
+        metadataDirectory: metadataDirectory,
+        trustedLegacyArtifacts: trustedLegacyArtifacts))
+  }
+
+  /// Launch transition. Relocation runs BEFORE EG-1 activates, so nothing loads
+  /// a model out of a directory that is about to move.
+  ///
+  /// Deliberately LIMB-scoped: Parakeet and WhisperKit are NOT gated behind
+  /// this, and the multi-GB legacy replacement runs outside it entirely. A
+  /// polish download that blocked the speech engines would be a self-inflicted
+  /// heart outage.
+  ///
+  /// A pending token means a superseded layout is still on disk awaiting
+  /// replacement — either classified just now, or admitted on an earlier launch
+  /// whose cleanup did not finish. Both reconcile through the same path, which
+  /// is why crash recovery needs no separate branch.
+  @MainActor
+  static func startLaunchTransition(
+    runtime: EGOneRuntime,
+    relocation: ModelRelocationMigrator.RelocationPlan,
+    providerIsEGOne: Bool
+  ) {
+    let migrator = ModelRelocationMigrator()
+    Task { @MainActor in
+      _ = await migrator.migrate(relocation)
+      if migrator.pendingLegacyArtifact(relocation) != nil {
+        runtime.sweepStaleServersAtLaunch()
+        runtime.startLegacyLayoutMigration {
+          try migrator.cleanUpLegacy(relocation)
+        }
+      } else if providerIsEGOne {
+        runtime.startIfActiveProvider()
+      } else {
+        runtime.sweepStaleServersAtLaunch()
+      }
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -162,8 +162,28 @@ enum EGOneDeliveryWiring {
     // outlives the decision that set it.
     runtime.onModelRemovalCancelled = { migrator.markLegacyForReplacement(relocation) }
     Task { @MainActor in
-      _ = await migrator.migrate(relocation)
-      switch migrator.pendingLegacyIntent(relocation) {
+      let outcome = await migrator.migrate(relocation)
+
+      // The OUTCOME drives this launch; the token drives RECOVERY across launches.
+      //
+      // Journaling can fail (unwritable metadata directory, a failed atomic write).
+      // If we keyed only off the token, that failure would silently skip the
+      // replacement and then try to activate a monolith this build cannot load —
+      // EG-1 unavailable, with nothing started to fix it (Codex PR-1 review r17).
+      // So a classification that found a trusted legacy artifact starts the
+      // replacement whether or not the note got written. Cleanup stays safe by
+      // construction: `cleanUpLegacy` deletes nothing without a token, so a failed
+      // write costs a leaked old file until a launch that can journal, never an
+      // unauthorized deletion.
+      let intent = migrator.pendingLegacyIntent(relocation)
+      let legacyNeedsReplacing: Bool
+      if case .trustedLegacyPending = outcome {
+        legacyNeedsReplacing = true
+      } else {
+        legacyNeedsReplacing = false
+      }
+
+      switch intent ?? (legacyNeedsReplacing ? .replace : nil) {
       case .replace:
         runtime.sweepStaleServersAtLaunch()
         runtime.startLegacyLayoutMigration {

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -103,7 +103,7 @@ enum EGOneDeliveryWiring {
       if migrator.pendingLegacyArtifact(relocation) != nil {
         runtime.sweepStaleServersAtLaunch()
         runtime.startLegacyLayoutMigration {
-          try migrator.cleanUpLegacy(relocation)
+          try await migrator.cleanUpLegacy(relocation)
         }
       } else if providerIsEGOne {
         runtime.startIfActiveProvider()

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -150,6 +150,9 @@ enum EGOneDeliveryWiring {
     // plain delete, so a failed cleanup can never resurrect a model the user threw
     // away.
     runtime.onModelRemoved = { migrator.markLegacyForRemoval(relocation) }
+    // ...and taking the removal back restores it, so the durable intent never
+    // outlives the decision that set it.
+    runtime.onModelRemovalCancelled = { migrator.markLegacyForReplacement(relocation) }
     Task { @MainActor in
       _ = await migrator.migrate(relocation)
       switch migrator.pendingLegacyIntent(relocation) {

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -20,7 +20,18 @@ enum EGOneDeliveryWiring {
   /// we shipped them and hold their digest — so the contract's automatic-
   /// replacement clause permits replacing them with no user click, but only ever
   /// verify-before-delete.
-  static let trustedLegacyArtifacts = ["eg-1-v1.gguf"]
+  ///
+  /// Size + digest are the SHIPPED values, lifted from the last monolithic
+  /// manifest (`eg1-manifest.json` at tag v2.3.2, and the pre-#1417 delivery
+  /// manifest, which agree). They are what makes this artifact identifiable as
+  /// OURS: a same-named file we did not ship fails the hash and is never
+  /// touched. Do not "simplify" this back to a filename match.
+  static let trustedLegacyArtifacts = [
+    ModelRelocationMigrator.TrustedLegacyArtifact(
+      name: "eg-1-v1.gguf",
+      sizeBytes: 2_889_511_680,
+      sha256: "3343fc1a30a3e82df7499a4775ef73dd6e28dea1cc39bb58197ec0b66ec874f6")
+  ]
 
   struct Wired {
     let adapter: EGOneDeliveryAdapter

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -62,24 +62,32 @@ enum EGOneDeliveryWiring {
     let legacyDirectory = appSupport.appendingPathComponent(
       "EnviousWispr/PolishModels", isDirectory: true)
 
-    // With the kill switch off, nothing may MUTATE model bytes — but the model must
-    // still LOAD, so we read from wherever a usable copy actually is. Pointing a
-    // disabled build at the owned home would leave an unmigrated user staring at
-    // "not installed" while their model sat untouched in the old one: that is a
-    // second failure, not a rollback.
+    // With the kill switch off, nothing may MUTATE model bytes — so we read from
+    // wherever a usable copy already is. Pick by ADMISSION, never by directory
+    // existence: a relocation that failed partway leaves a half-populated
+    // `Models/eg-1` beside a perfectly good `PolishModels`, and "the folder is
+    // there" would choose the broken one (Codex PR-1 review r10). Both are real
+    // candidates — a machine that downloaded shards before this change has them in
+    // the legacy home.
     //
-    // Pick by ADMISSION, never by directory existence. A relocation that failed
-    // partway leaves a half-populated `Models/eg-1` beside a perfectly good
-    // `PolishModels`, and "the folder is there" would choose the broken one —
-    // breaking EG-1 in exactly the scenario the kill switch exists to rescue
-    // (Codex PR-1 review r10). Falls back to the legacy home when neither is
-    // admitted, so a disabled build still reads from where the bytes were.
+    // WHAT THE KILL SWITCH DOES AND DOES NOT PROMISE (Codex PR-1 review r14).
+    // It guarantees: no model bytes are moved, deleted, or fetched. It does NOT
+    // guarantee that polish keeps working — and for one cohort it cannot. A user
+    // still on the previously-shipped MONOLITH has bytes this build is structurally
+    // unable to load: the runtime boots the manifest's entrypoint, and the bundled
+    // manifest is sharded, so no directory choice can make an `eg-1-v1.gguf`
+    // loadable. Restoring that would mean shipping the old manifest AND the old load
+    // path alongside the new ones, permanently — dual-format support for a rollback
+    // lever. That is not worth it. With the switch off, such a user gets raw text
+    // (EG-1 is a limb) and their model is left completely untouched; flipping the
+    // switch back on runs the migration and polish returns. Nothing is lost, only
+    // deferred. Do not "fix" this by resurrecting the monolithic load path.
     let installDirectory: URL = {
       guard !EGOneDeliveryAdapter.isDeliveryEnabled() else { return ownedDirectory }
       return ModelRelocationMigrator.admittedLocation(
         manifest: manifest,
         candidates: [ownedDirectory, legacyDirectory],
-        metadataDirectory: metadataDirectory) ?? legacyDirectory
+        metadataDirectory: metadataDirectory) ?? ownedDirectory
     }()
 
     let registration = DeliveryRegistration(
@@ -165,13 +173,15 @@ enum EGOneDeliveryWiring {
         // The user removed EG-1 while a legacy artifact was still stranded. Finish
         // the removal they asked for, and fetch NOTHING.
         //
-        // `removeModel()` too, not just the legacy delete: a crash between writing
-        // the `.remove` intent and the delivery removal completing would otherwise
-        // leave the newly-admitted shards installed forever, with the UI still
-        // reporting the model as present — the user's explicit Remove silently
-        // undone by a crash (Codex PR-1 review r7). Both halves are idempotent, so
-        // re-running them after a clean removal costs nothing.
-        runtime.removeModel()
+        // Both halves, in this order, and the token clears LAST. The token is the
+        // only durable record that a Remove is owed; `cleanUpLegacy` clears it. So
+        // the delivery removal must be AWAITED first — clearing the token while a
+        // fire-and-forget removal was still running would, on a crash in that
+        // window, leave the newly-admitted 2.9 GB model installed with no record
+        // left to retry from, and the UI still reporting it present (Codex PR-1
+        // review r14). Both halves are idempotent, so a crash before the token
+        // clears simply repeats them on the next launch.
+        await runtime.removeModelAwaitingCompletion()
         try? await migrator.cleanUpLegacy(relocation)
         runtime.sweepStaleServersAtLaunch()
       case nil:

--- a/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneDeliveryWiring.swift
@@ -120,7 +120,15 @@ enum EGOneDeliveryWiring {
         }
       case .remove:
         // The user removed EG-1 while a legacy artifact was still stranded. Finish
-        // the delete they asked for and fetch NOTHING.
+        // the removal they asked for, and fetch NOTHING.
+        //
+        // `removeModel()` too, not just the legacy delete: a crash between writing
+        // the `.remove` intent and the delivery removal completing would otherwise
+        // leave the newly-admitted shards installed forever, with the UI still
+        // reporting the model as present — the user's explicit Remove silently
+        // undone by a crash (Codex PR-1 review r7). Both halves are idempotent, so
+        // re-running them after a clean removal costs nothing.
+        runtime.removeModel()
         try? await migrator.cleanUpLegacy(relocation)
         runtime.sweepStaleServersAtLaunch()
       case nil:

--- a/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
@@ -23,6 +23,13 @@ enum EGOneTelemetryBridge {
           TelemetryService.shared.egOneDownloadEvent(
             name: "health_changed",
             properties: ["from": from, "to": to, "reason": reason ?? "none"])
+        case .legacyMigrationCleanupFailed:
+          // The replacement set IS admitted and polish works; only the delete of
+          // the superseded artifact failed. The next launch retries it from the
+          // durable token, so this is a disk-hygiene signal, not a user-visible
+          // failure. No path is carried (telemetry privacy boundary).
+          TelemetryService.shared.egOneDownloadEvent(
+            name: "legacy_migration_cleanup_failed", properties: [:])
         }
       }
     }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -168,35 +168,33 @@ public final class WisprBootstrapper {
     // adapter owns the delivery manifest (fetch/install/content identity).
     let egOneManifest = try? EGOneManifest.loadBundled()
     let egOneServerBinaryURL = Bundle.main.url(forResource: "llama-server", withExtension: nil)
-    var egOneAdapter: EGOneDeliveryAdapter?
-    if let deliveryManifest = try? DeliveryManifest.loadBundled(resource: "eg1-delivery-manifest") {
-      let appSupport = FileManager.default.urls(
-        for: .applicationSupportDirectory, in: .userDomainMask)[0]
-      let registration = DeliveryRegistration(
-        manifest: deliveryManifest,
-        // The existing user's install dir — unchanged, so a byte-correct file
-        // is adopted in place with zero re-download (#1348 Decision C/F).
-        installDirectory: appSupport.appendingPathComponent(
-          "EnviousWispr/PolishModels", isDirectory: true),
-        metadataDirectory: appSupport.appendingPathComponent(
-          "EnviousWispr/ModelDelivery", isDirectory: true))
-      egOneAdapter = EGOneDeliveryAdapter(
-        controller: modelDelivery.controller,
-        registration: registration,
-        version: egOneManifest?.version ?? deliveryManifest.identity.revision)
+    // Where EG-1's bytes live and when its launch transition runs: owned by
+    // `EGOneDeliveryWiring` (#1386), not by this composer.
+    let egOneWiring = EGOneDeliveryWiring.wire(
+      controller: modelDelivery.controller,
+      version: egOneManifest?.version,
+      appSupport: FileManager.default.urls(
+        for: .applicationSupportDirectory, in: .userDomainMask)[0])
+    if let egOneWiring {
       // Seed EG-1's first-run telemetry baseline before its first attempt
       // (#1348 §16.2). Session-granularity approximation (same async-Task shape
       // as Parakeet's own baseline); a rare early event stamps first_run=false.
       let delivery = modelDelivery
+      let registration = egOneWiring.registration
       Task { await delivery.recordFirstRunBaseline(for: registration) }
     }
     let egOneRuntime = EGOneRuntime(
-      manifest: egOneManifest, serverBinaryURL: egOneServerBinaryURL, delivery: egOneAdapter)
+      manifest: egOneManifest, serverBinaryURL: egOneServerBinaryURL,
+      delivery: egOneWiring?.adapter)
     egOneRuntime.isActiveProvider = { [weak settings] in settings?.llmProvider == .egOne }
     egOneRuntime.onEvent = EGOneTelemetryBridge.handler
     // Exactly one path sweeps orphans — a detached sweep alongside a spawn
     // would race it and kill the fresh server (Codex r10 P1).
-    if settings.llmProvider == .egOne {
+    if let relocation = egOneWiring?.relocation {
+      EGOneDeliveryWiring.startLaunchTransition(
+        runtime: egOneRuntime, relocation: relocation,
+        providerIsEGOne: settings.llmProvider == .egOne)
+    } else if settings.llmProvider == .egOne {
       egOneRuntime.startIfActiveProvider()
     } else {
       egOneRuntime.sweepStaleServersAtLaunch()

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -983,7 +983,7 @@ struct AIPolishSettingsView: View {
     switch egOne.installState {
     case .notInstalled:
       HStack {
-        Text("One-time download: 2.7 GB")
+        Text("One-time download: 2.9 GB")
           .font(.stHelper)
           .foregroundStyle(Color.stTextSecondary)
         Spacer()
@@ -992,7 +992,7 @@ struct AIPolishSettingsView: View {
     case .downloading(let fraction):
       VStack(alignment: .leading, spacing: 4) {
         ProgressView(value: max(0, min(1, fraction))) {
-          Text("Downloading EG-1 (2.7 GB)")
+          Text("Downloading EG-1 (2.9 GB)")
             .font(.stHelper)
         }
         Button("Cancel") { egOne.cancelDownload() }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -134,6 +134,14 @@ public final class EGOneDeliveryAdapter {
     return await controller.admitIfComplete(registration)
   }
 
+  /// Is the current manifest's set admitted right now? The re-check the legacy
+  /// migration performs immediately before deleting a superseded artifact
+  /// (#1386): a delete is authorized ONLY by CURRENT admission, never by a
+  /// journal phase, a file-presence check, or a stale `.admitted` outcome.
+  public func isAdmitted() async -> Bool {
+    await controller.isAdmitted(registration)
+  }
+
   /// One-shot repair after a cache-only load failure (§16.5); no-op when
   /// disabled.
   public func repair() async -> ModelDeliveryController.DeliveryOutcome {

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -98,11 +98,20 @@ public final class EGOneDeliveryAdapter {
   }
 
   /// The D5 kill-switch, read fresh per call (relaunch-free). Disabled ⇒ no
-  /// delivery mutation (#1363 §16.6). Internal: EG-1's flag gates only the
-  /// adapter's own ensure/repair/remove (unlike Parakeet, whose engine adapter
-  /// reads the flag to choose the cache-only load path).
+  /// delivery mutation (#1363 §16.6). EG-1's flag gates the adapter's own
+  /// ensure/repair/remove — and, since #1386, the relocation that runs BEFORE any
+  /// of them.
   private func isEnabled() -> Bool {
-    defaults.object(forKey: DeliveryFlags.key("enabled", family: .egOne)) as? Bool ?? true
+    Self.isDeliveryEnabled(defaults: defaults)
+  }
+
+  /// The same kill-switch, readable by the composition root BEFORE the relocation
+  /// runs. Without this the migrator would happily move and delete model files
+  /// while delivery mutation is explicitly disabled — defeating the operational
+  /// rollback control precisely when someone reached for it (Codex PR-1 review r8).
+  nonisolated public static func isDeliveryEnabled(defaults: UserDefaults? = nil) -> Bool {
+    let store = defaults ?? UserDefaults(suiteName: DeliveryFlags.suiteName) ?? .standard
+    return store.object(forKey: DeliveryFlags.key("enabled", family: .egOne)) as? Bool ?? true
   }
 
   /// Ensure EG-1's bytes are admitted, fetching/adopting as needed. When

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -260,6 +260,12 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// "replace me" to "delete me". Nil in tests and when no relocation is wired.
   public var onModelRemoved: (@MainActor () -> Void)?
 
+  /// The inverse: the user took the removal back by re-selecting EG-1, so the
+  /// stranded artifact is owed a replacement again. The in-memory `removalPending`
+  /// flag and the durable intent must move TOGETHER — clearing one without the other
+  /// leaves them to disagree exactly when a crash makes it matter.
+  public var onModelRemovalCancelled: (@MainActor () -> Void)?
+
   /// Called on terminal pipeline states (alongside the deactivation retry).
   /// Idempotent: no-op unless a removal is actually pending.
   public func retryPendingRemoval() {
@@ -385,6 +391,12 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     // itself then bails on a blocker — otherwise remove-during-recording
     // followed by re-selecting EG-1 still deletes the model the user just
     // re-picked once the recording ends (#1271 seam review P1).
+    //
+    // The DURABLE intent has to move with the in-memory flag (#1386): a Remove
+    // already flipped the pending legacy artifact's token to "delete me", and
+    // clearing only the flag would leave that token to delete the model on the next
+    // launch — after the user had taken the removal back (Codex PR-1 review r13).
+    if removalPending { onModelRemovalCancelled?() }
     removalPending = false
     guard let manifest, activationBlockers.isEmpty else {
       // Blocked manifest = spawn will never run this session, so its

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -273,6 +273,23 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     removeModel()
   }
 
+  /// `removeModel()` that the caller can AWAIT.
+  ///
+  /// The launch-time removal-recovery path needs the delivery removal to have
+  /// actually completed before it clears the durable token — otherwise it clears the
+  /// only record of the user's Remove while a fire-and-forget task is still deleting
+  /// the model, and a crash in that window leaves the model installed with nothing
+  /// left to retry from (Codex PR-1 review r14). Same work, same order; the caller
+  /// just gets to know when it is done.
+  public func removeModelAwaitingCompletion() async {
+    guard let delivery else { return }
+    removalPending = false
+    activationGeneration += 1
+    onModelRemoved?()
+    await server.stop()
+    _ = await delivery.remove()
+  }
+
   /// Replace a previously-shipped layout we recognize but can no longer load
   /// (EG-1's monolithic `eg-1-v1.gguf` vs the current 8-shard set) — #1386 PR-1.
   ///

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -286,6 +286,13 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// Run the pending legacy cleanup, if any, after an admission. Idempotent and safe
   /// to call on every successful download: with no token pending it does nothing.
   private func runLegacyCleanupIfNeeded() async {
+    // A deferred Remove outranks the cleanup. `cleanUpLegacy` clears the token, which
+    // is the only DURABLE record that a Remove is owed — `removalPending` is merely
+    // in-memory. Clearing it here (e.g. a Download completing while a recording still
+    // pins the model) would leave a crash before `retryPendingRemoval` with the model
+    // installed and no record of the user's action. Let the removal path, which orders
+    // removal-then-cleanup, own both.
+    guard !removalPending else { return }
     guard let legacyCleanup, let delivery, await delivery.isAdmitted() else { return }
     do {
       try await legacyCleanup()
@@ -388,6 +395,30 @@ public final class EGOneRuntime: EGOneEndpointProviding {
 
       // Nothing may hold the old artifact open when it is unlinked.
       await server.stop()
+
+      // A Remove pressed during the transition is honored BEFORE the cleanup, not
+      // after (GitHub cloud review, PR #1497).
+      //
+      // `cleanUpLegacy()` deletes the legacy artifact AND clears the token — and the
+      // token is the only durable record that a Remove is owed. Running it first
+      // would clear that record while the shards were still installed, so a crash,
+      // quit, or failed delivery removal in that window would leave the newly
+      // admitted model on disk with nothing left to honor the user's action.
+      //
+      // The launch-time `.remove` branch already gets this right: remove the shards,
+      // check the outcome, and only then clear the token (r14/r15). This is the same
+      // rule on the in-flight path — the SAME bug family, on the parallel path, which
+      // is exactly how everything else in this PR went wrong.
+      if removalPending {
+        isMigratingLegacyLayout = false
+        guard case .removed = await removeModelAwaitingCompletion() else {
+          // Removal failed: the token still says `.remove`, the legacy artifact is
+          // still here, and the next launch retries the whole thing.
+          return
+        }
+        try? await cleanUpLegacy()
+        return
+      }
 
       do {
         try await cleanUpLegacy()

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -286,20 +286,50 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// Run the pending legacy cleanup, if any, after an admission. Idempotent and safe
   /// to call on every successful download: with no token pending it does nothing.
   private func runLegacyCleanupIfNeeded() async {
-    // A deferred Remove outranks the cleanup. `cleanUpLegacy` clears the token, which
-    // is the only DURABLE record that a Remove is owed — `removalPending` is merely
-    // in-memory. Clearing it here (e.g. a Download completing while a recording still
-    // pins the model) would leave a crash before `retryPendingRemoval` with the model
-    // installed and no record of the user's action. Let the removal path, which orders
-    // removal-then-cleanup, own both.
-    guard !removalPending else { return }
-    guard let legacyCleanup, let delivery, await delivery.isAdmitted() else { return }
+    guard let legacyCleanup, let delivery, !isMigratingLegacyLayout else { return }
+    guard await delivery.isAdmitted() else { return }
+
+    // HOLD THE GATE — do not merely check `removalPending` and then await.
+    //
+    // `cleanUpLegacy` hashes and deletes multiple GB, so it suspends for a long time.
+    // A bare `guard !removalPending` before that await is a check-then-act across a
+    // suspension point: a Remove landing DURING the cleanup would not be deferred (the
+    // gate was not held), so it would flip the token to `.remove` and start deleting
+    // the shards while this cleanup was still running and about to clear that very
+    // token (GitHub cloud review, PR #1497 — a race my own previous fix introduced).
+    //
+    // Holding the gate makes `removeModel()` DEFER instead, which is the house rule for
+    // exactly this shape: refuse in an invalid state via a flag the owner checks, never
+    // re-check right before acting (`swift-concurrency-patterns.md`
+    // state-gate-over-recheck). The deferral is then honored below, in the safe order.
+    isMigratingLegacyLayout = true
+    defer { isMigratingLegacyLayout = false }
+
+    // A Remove already pending BEFORE the cleanup: removal first, then cleanup — the
+    // token is the only durable record that a Remove is owed, and cleanUpLegacy clears
+    // it.
+    if removalPending {
+      isMigratingLegacyLayout = false
+      guard case .removed = await removeModelAwaitingCompletion() else { return }
+      try? await legacyCleanup()
+      return
+    }
+
     do {
       try await legacyCleanup()
     } catch {
       // The replacement is admitted and usable; the token survives for a next-launch
       // retry. Never fatal.
       onEvent?(.legacyMigrationCleanupFailed)
+    }
+
+    // A Remove that landed DURING the cleanup was deferred by the gate. Honor it now.
+    // The legacy artifact is gone by this point, so what remains is an ordinary
+    // in-session Remove of the shards — the same durability every EG-1 Remove has ever
+    // had, and no longer entangled with the migration's durable record.
+    if removalPending {
+      isMigratingLegacyLayout = false
+      removeModel()
     }
   }
 

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -238,11 +238,21 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     }
     removalPending = false
     activationGeneration += 1
+    // The user threw the model away, so a still-stranded legacy artifact is now
+    // owed a plain DELETE rather than a replacement. Without this, a legacy delete
+    // that failed would be re-read on the next launch as "a replacement is owed"
+    // and would silently re-download gigabytes of a model the user just removed
+    // (#1386; found while fixing Codex PR-1 review r6).
+    onModelRemoved?()
     Task {
       await self.server.stop()
       _ = await delivery.remove()
     }
   }
+
+  /// Set by the composition root: flips any pending legacy-artifact intent from
+  /// "replace me" to "delete me". Nil in tests and when no relocation is wired.
+  public var onModelRemoved: (@MainActor () -> Void)?
 
   /// Called on terminal pipeline states (alongside the deactivation retry).
   /// Idempotent: no-op unless a removal is actually pending.
@@ -301,15 +311,22 @@ public final class EGOneRuntime: EGOneEndpointProviding {
         try await cleanUpLegacy()
       } catch {
         // Deleting the superseded artifact failed — but the REPLACEMENT is
-        // admitted and perfectly usable, so polish must come back. We stopped the
-        // server a moment ago to unlink safely; leaving it stopped here would
-        // switch polish off for the rest of the session over a failed `rm` the
-        // next launch will retry anyway (Codex PR-1 review r5).
-        //
-        // Legacy bytes stay put; the token survives for that retry. The deferred
-        // removal is deliberately NOT run: there is a live cleanup owed on this
-        // path, and honoring a Remove through it would tangle the two.
+        // admitted and usable. Legacy bytes stay put; the durable token survives
+        // for a next-launch retry.
         onEvent?(.legacyMigrationCleanupFailed)
+        // An explicit Remove the user pressed during the transition outranks
+        // everything here. `activateAndProbe()` CLEARS `removalPending` (it treats
+        // re-selecting EG-1 as cancelling a deferred removal), so reactivating
+        // first would silently discard the user's action and leave the model
+        // installed (Codex PR-1 review r6 — a bug my own r5 fix introduced).
+        if removalPending {
+          isMigratingLegacyLayout = false
+          removeModel()
+          return
+        }
+        // No Remove pending: bring polish back. We stopped the server a moment ago
+        // to unlink safely, and leaving it stopped would switch polish off for the
+        // rest of the session over a failed `rm` (Codex PR-1 review r5).
         if isActiveProvider?() == true { activateAndProbe() }
         return
       }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -294,15 +294,33 @@ public final class EGOneRuntime: EGOneEndpointProviding {
 
       let outcome = await delivery.ensureAvailable()
       guard case .admitted = outcome else {
-        // Not admitted: token and legacy bytes both survive untouched; the next
-        // launch retries. Deliberately does NOT run a deferred removal — there
-        // is nothing new to remove, and the legacy copy is not ours to drop.
+        // The replacement did not arrive (failed, cancelled, out of disk). Legacy
+        // bytes survive untouched and the next launch retries.
+        //
+        // UNLESS the user hit Remove while it was downloading. That Remove was
+        // deferred by the gate, and dropping it here would lose it twice over: the
+        // model stays installed against the user's explicit action, AND the token
+        // still says `.replace`, so the next launch would re-download the very
+        // model they just threw away (Codex PR-1 review r9). Honor it — this is
+        // the last exit that did not.
+        if removalPending {
+          isMigratingLegacyLayout = false
+          removeModel()
+        }
         return
       }
       // CURRENT admission is the only thing that authorizes the delete — never
       // the `.admitted` we just read (it can be stale by now), never a
-      // file-presence check.
-      guard await delivery.isAdmitted() else { return }
+      // file-presence check. (The likeliest way it goes stale is a Remove that
+      // landed in this very window and deleted the shards — so a deferred removal
+      // must be honored here too, for the same reason as the exit above.)
+      guard await delivery.isAdmitted() else {
+        if removalPending {
+          isMigratingLegacyLayout = false
+          removeModel()
+        }
+        return
+      }
 
       // Nothing may hold the old artifact open when it is unlinked.
       await server.stop()

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -300,9 +300,17 @@ public final class EGOneRuntime: EGOneEndpointProviding {
       do {
         try await cleanUpLegacy()
       } catch {
-        // Admitted shards stay usable; legacy bytes stay put; token survives for
-        // a next-launch retry. Do NOT run the deferred removal on this path.
+        // Deleting the superseded artifact failed — but the REPLACEMENT is
+        // admitted and perfectly usable, so polish must come back. We stopped the
+        // server a moment ago to unlink safely; leaving it stopped here would
+        // switch polish off for the rest of the session over a failed `rm` the
+        // next launch will retry anyway (Codex PR-1 review r5).
+        //
+        // Legacy bytes stay put; the token survives for that retry. The deferred
+        // removal is deliberately NOT run: there is a live cleanup owed on this
+        // path, and honoring a Remove through it would tangle the two.
         onEvent?(.legacyMigrationCleanupFailed)
+        if isActiveProvider?() == true { activateAndProbe() }
         return
       }
 

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -234,6 +234,12 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     // would otherwise race this delete into a both-copies-gone state (#1386).
     if isPinnedInFlight?() == true || isMigratingLegacyLayout {
       removalPending = true
+      // Persist the intent NOW, not when the deferral is finally honored. The flag
+      // above is in-memory: if the app quits or crashes while the removal is still
+      // deferred, the durable token would still read `.replace` and the next launch
+      // would re-download the 2.9 GB model the user just deleted (Codex PR-1 review
+      // r11). Idempotent, and a no-op when no legacy artifact is pending.
+      onModelRemoved?()
       return
     }
     removalPending = false

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -208,11 +208,17 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     }
     Task {
       let outcome = await delivery.ensureAvailable()
+      guard case .admitted = outcome else { return }
+      // A retry after a failed automatic migration lands HERE, not in the migration
+      // path — so the superseded artifact's cleanup has to run here too, or the old
+      // 2.9 GB model sits on disk until the next launch (Codex PR-1 review r20).
+      // No-op when nothing is owed.
+      await runLegacyCleanupIfNeeded()
       // A user-initiated download that completes while EG-1 is the selected
       // provider boots the server now, not at next relaunch (#1271 Codex r2).
       // Explicit here (not reactive from the state stream) so it fires exactly
       // once per completed download.
-      if case .admitted = outcome, isActiveProvider?() == true {
+      if isActiveProvider?() == true {
         activateAndProbe()
       }
     }
@@ -266,6 +272,30 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// leaves them to disagree exactly when a crash makes it matter.
   public var onModelRemovalCancelled: (@MainActor () -> Void)?
 
+  /// Deletes a superseded legacy artifact once its replacement is admitted. Set by
+  /// the composition root; a no-op when nothing is owed (it is driven by the durable
+  /// token, so calling it when no cleanup is pending costs nothing).
+  ///
+  /// Held here rather than passed per-call because BOTH ways the replacement can be
+  /// admitted must run it: the automatic migration, and the user clicking Download
+  /// after that migration failed. Without the second, a retry in the same session
+  /// installs the new model and leaves the old 2.9 GB one on disk until relaunch
+  /// (Codex PR-1 review r20).
+  public var legacyCleanup: (@Sendable () async throws -> Void)?
+
+  /// Run the pending legacy cleanup, if any, after an admission. Idempotent and safe
+  /// to call on every successful download: with no token pending it does nothing.
+  private func runLegacyCleanupIfNeeded() async {
+    guard let legacyCleanup, let delivery, await delivery.isAdmitted() else { return }
+    do {
+      try await legacyCleanup()
+    } catch {
+      // The replacement is admitted and usable; the token survives for a next-launch
+      // retry. Never fatal.
+      onEvent?(.legacyMigrationCleanupFailed)
+    }
+  }
+
   /// Called on terminal pipeline states (alongside the deactivation retry).
   /// Idempotent: no-op unless a removal is actually pending.
   public func retryPendingRemoval() {
@@ -315,10 +345,10 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// The caller must NOT hold the migration latch across this — it is a
   /// multi-GB network transfer, and blocking the speech engines behind a polish
   /// download would be a self-inflicted heart outage.
-  public func startLegacyLayoutMigration(
-    cleanUpLegacy: @escaping @Sendable () async throws -> Void
-  ) {
-    guard let delivery, !isMigratingLegacyLayout else { return }
+  public func startLegacyLayoutMigration() {
+    guard let delivery, let cleanUpLegacy = legacyCleanup, !isMigratingLegacyLayout else {
+      return
+    }
     isMigratingLegacyLayout = true
     Task {
       // `defer` owns the release: it runs on EVERY exit — success, throw, or

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -22,6 +22,11 @@ public protocol EGOneEndpointProviding: AnyObject {
 /// identical states never re-fire).
 public enum EGOneRuntimeEvent: Sendable, Equatable {
   case healthChanged(from: String, to: String, reason: String?)
+  /// The replacement set was admitted, but deleting the superseded legacy
+  /// artifact failed (#1386). Not user-facing and not an error for the user:
+  /// polish works on the new set; the durable token survives and the next
+  /// launch retries the delete. Carries NO path (telemetry privacy boundary).
+  case legacyMigrationCleanupFailed
 }
 
 /// Single owner of the EG-1 inference server and its delivery adapter (#1271,
@@ -75,6 +80,19 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// still needs it.
   public var isPinnedInFlight: (@MainActor () -> Bool)?
   private var removalPending = false
+
+  /// The legacy-layout migration cleanup gate (#1386 PR-1). Held from before the
+  /// automatic `ensureAvailable()` that replaces a previously-shipped layout
+  /// until its legacy artifact is resolved — which is LATER than the controller's
+  /// own single-flight, because that clears when the fetch returns `.admitted`,
+  /// while the delete still lies ahead.
+  ///
+  /// Without this gate: cleanup re-checks admission → the user hits Remove →
+  /// Remove deletes the marker and every new shard → cleanup, already past its
+  /// check, deletes the legacy artifact. Both copies gone. So while the gate is
+  /// held, `removeModel()` defers through the EXISTING `removalPending` path (the
+  /// same deferral a recording already uses) instead of calling `remove`.
+  public private(set) var isMigratingLegacyLayout = false
 
   public let manifest: EGOneManifest?
   private let delivery: EGOneDeliveryAdapter?
@@ -211,7 +229,10 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// (#1271 matrix gap 3; same defer shape as switch-away deactivation).
   public func removeModel() {
     guard let delivery else { return }
-    if isPinnedInFlight?() == true {
+    // Same deferral, two reasons: a recording froze `.egOne` and still needs the
+    // artifact, OR a legacy-layout migration is mid-transition and its cleanup
+    // would otherwise race this delete into a both-copies-gone state (#1386).
+    if isPinnedInFlight?() == true || isMigratingLegacyLayout {
       removalPending = true
       return
     }
@@ -228,6 +249,72 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   public func retryPendingRemoval() {
     guard removalPending else { return }
     removeModel()
+  }
+
+  /// Replace a previously-shipped layout we recognize but can no longer load
+  /// (EG-1's monolithic `eg-1-v1.gguf` vs the current 8-shard set) — #1386 PR-1.
+  ///
+  /// Silent and automatic: the founder-approved policy for a TRUSTED
+  /// app-managed asset (contract § Automatic replacement of installed model
+  /// assets). No click, no prompt. While it runs, polish is simply unavailable
+  /// and dictation falls back to raw text — EG-1 is a limb, and that is the
+  /// Heart & Limbs contract, not a regression.
+  ///
+  /// Ordering is the whole point:
+  ///   fetch → CURRENT-admission re-check → stop server → delete legacy → clear
+  ///   token → release gate.
+  /// The legacy bytes are deleted ONLY after the replacement is admitted, so a
+  /// failed / cancelled / disk-full run leaves them intact for the next launch
+  /// to retry. `cleanUpLegacy` is injected by the composition root (it owns the
+  /// migrator + plan); this runtime owns the GATE and the ORDER.
+  ///
+  /// The caller must NOT hold the migration latch across this — it is a
+  /// multi-GB network transfer, and blocking the speech engines behind a polish
+  /// download would be a self-inflicted heart outage.
+  public func startLegacyLayoutMigration(
+    cleanUpLegacy: @escaping @Sendable () async throws -> Void
+  ) {
+    guard let delivery, !isMigratingLegacyLayout else { return }
+    isMigratingLegacyLayout = true
+    Task {
+      // `defer` owns the release: it runs on EVERY exit — success, throw, or
+      // cancellation. Without it, a throwing delete would strand the gate and
+      // leave Remove disabled for the rest of the process (#1386 Codex r6).
+      defer { isMigratingLegacyLayout = false }
+
+      let outcome = await delivery.ensureAvailable()
+      guard case .admitted = outcome else {
+        // Not admitted: token and legacy bytes both survive untouched; the next
+        // launch retries. Deliberately does NOT run a deferred removal — there
+        // is nothing new to remove, and the legacy copy is not ours to drop.
+        return
+      }
+      // CURRENT admission is the only thing that authorizes the delete — never
+      // the `.admitted` we just read (it can be stale by now), never a
+      // file-presence check.
+      guard await delivery.isAdmitted() else { return }
+
+      // Nothing may hold the old artifact open when it is unlinked.
+      await server.stop()
+
+      do {
+        try await cleanUpLegacy()
+      } catch {
+        // Admitted shards stay usable; legacy bytes stay put; token survives for
+        // a next-launch retry. Do NOT run the deferred removal on this path.
+        onEvent?(.legacyMigrationCleanupFailed)
+        return
+      }
+
+      // A Remove the user pressed during the transition was deferred by the
+      // gate; honor it now, against the newly-admitted shards.
+      if removalPending {
+        isMigratingLegacyLayout = false
+        removeModel()
+        return
+      }
+      if isActiveProvider?() == true { activateAndProbe() }
+    }
   }
 
   /// Monotonic activation token (#1271 Codex r5): ONLY `deactivate()` /

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -273,21 +273,26 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     removeModel()
   }
 
-  /// `removeModel()` that the caller can AWAIT.
+  /// `removeModel()` that the caller can AWAIT, and whose OUTCOME it can read.
   ///
-  /// The launch-time removal-recovery path needs the delivery removal to have
-  /// actually completed before it clears the durable token — otherwise it clears the
-  /// only record of the user's Remove while a fire-and-forget task is still deleting
-  /// the model, and a crash in that window leaves the model installed with nothing
-  /// left to retry from (Codex PR-1 review r14). Same work, same order; the caller
-  /// just gets to know when it is done.
-  public func removeModelAwaitingCompletion() async {
-    guard let delivery else { return }
+  /// The launch-time removal-recovery path needs both. It must know the removal
+  /// actually completed before it clears the durable token — clearing it while a
+  /// fire-and-forget task was still deleting would lose the user's Remove to a crash
+  /// (Codex PR-1 review r14) — and it must know whether the removal SUCCEEDED, since
+  /// clearing the only retry record after a failed delete strands model remnants on
+  /// disk with nothing left to honor the removal (r15).
+  ///
+  /// Same work, same order as `removeModel()`; the caller just gets to know when it
+  /// finished and how it went.
+  public func removeModelAwaitingCompletion() async -> ModelDeliveryController.RemoveOutcome {
+    guard let delivery else {
+      return .failed(DeliveryFailure(reason: .unknown, detail: "no_delivery_adapter"))
+    }
     removalPending = false
     activationGeneration += 1
     onModelRemoved?()
     await server.stop()
-    _ = await delivery.remove()
+    return await delivery.remove()
   }
 
   /// Replace a previously-shipped layout we recognize but can no longer load

--- a/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
+++ b/Sources/EnviousWisprModelDelivery/CacheAdmission.swift
@@ -183,6 +183,37 @@ struct CacheAdmission {
     try JSONEncoder().encode(marker).write(to: markerURL, options: .atomic)
   }
 
+  /// Stamp the admission marker for a set that is ALREADY in place, touching nothing
+  /// on disk (#1386).
+  ///
+  /// This is step (4) of `promoteAndAdmit` and nothing else — no promotion, and
+  /// crucially NO orphan cleanup. Used only to RESTORE an admission that a failed
+  /// promotion invalidated: the bytes were validated moments earlier and never moved,
+  /// so re-stamping them is honest, while running the full promote would prune every
+  /// unlisted entry from that directory and delete a user's unrelated files (Codex
+  /// PR-1 review r18).
+  ///
+  /// Never a substitute for `promoteAndAdmit` on a normal path: it admits what is
+  /// there without proving it, so the caller must have just proven it.
+  func stampAdmissionForVerifiedSet() throws {
+    let fm = FileManager.default
+    var stamps: [AdmissionMarker.FileStamp] = []
+    for file in manifest.files {
+      let url = installDirectory.appendingPathComponent(file.resolvedInstallPath)
+      let attrs = try fm.attributesOfItem(atPath: url.path)
+      guard let size = attrs[.size] as? Int64, size == file.sizeBytes,
+        let mtime = (attrs[.modificationDate] as? Date)?.timeIntervalSince1970
+      else {
+        throw DeliveryFailure(reason: .cacheRepairFailed, detail: "restore_stamp:\(file.component)")
+      }
+      stamps.append(.init(path: file.resolvedInstallPath, sizeBytes: size, mtime: mtime))
+    }
+    try fm.createDirectory(at: metadataDirectory, withIntermediateDirectories: true)
+    let marker = AdmissionMarker(
+      manifestDigest: manifest.manifestDigest, admittedAt: Date(), files: stamps)
+    try JSONEncoder().encode(marker).write(to: markerURL, options: .atomic)
+  }
+
   /// Whether ANY manifest file of this component exists in the install dir
   /// (distinguishes repair-of-damage from a cold first download).
   func componentHasAnyFile(_ component: String) -> Bool {

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -111,9 +111,24 @@ public struct ModelRelocationMigrator: Sendable {
   /// `<metadata-dir>/<cache-key>.relocation.json` — the durable token. Survives
   /// relaunch so a crash mid-transition is reconcilable, and so the legacy
   /// cleanup can be retried on a later launch if it throws.
+  /// What the pending legacy artifact is waiting FOR. A path alone is not enough:
+  /// the same stranded file means "replace me" before the user asks for the model
+  /// to be removed, and "just delete me" afterwards. Without this, a Remove whose
+  /// legacy delete failed would be resurrected on the next launch — we would see
+  /// the old file, conclude a replacement was owed, and silently re-download
+  /// gigabytes of a model the user explicitly deleted.
+  public enum LegacyIntent: String, Codable, Sendable {
+    /// Fetch the current manifest's bytes, then delete this.
+    case replace
+    /// The user removed the model. Delete this; fetch NOTHING.
+    case remove
+  }
+
   struct Token: Codable, Equatable {
     /// Absolute path of the legacy artifact awaiting cleanup.
     let legacyPath: String
+    /// Defaults to `.replace` for a token written before intent existed.
+    var intent: LegacyIntent = .replace
     /// Size and digest of the artifact we VERIFIED at classification time. BOTH
     /// are re-checked immediately before the delete. Size alone is not enough: a
     /// same-size corruption or a same-size manual replacement would slip through
@@ -264,6 +279,29 @@ public struct ModelRelocationMigrator: Sendable {
       token.manifestDigest == plan.manifest.manifestDigest
     else { return nil }
     return URL(fileURLWithPath: token.legacyPath)
+  }
+
+  /// What the pending artifact is waiting for — `nil` when nothing is pending.
+  public func pendingLegacyIntent(_ plan: RelocationPlan) -> LegacyIntent? {
+    guard let token = readToken(plan: plan),
+      token.manifestDigest == plan.manifest.manifestDigest
+    else { return nil }
+    return token.intent
+  }
+
+  /// The user removed this model. The stranded legacy artifact is now owed a
+  /// plain DELETE, not a replacement — so if its delete fails and we retry on a
+  /// later launch, we delete it and fetch nothing, instead of resurrecting a
+  /// model the user threw away.
+  ///
+  /// No-op when nothing is pending (an ordinary Remove with no legacy artifact).
+  public func markLegacyForRemoval(_ plan: RelocationPlan) {
+    guard var token = readToken(plan: plan),
+      token.manifestDigest == plan.manifest.manifestDigest,
+      token.intent != .remove
+    else { return }
+    token.intent = .remove
+    writeToken(token, plan: plan)
   }
 
   // MARK: - Internals

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -108,9 +108,6 @@ public struct ModelRelocationMigrator: Sendable {
     case unrecognized
   }
 
-  /// `<metadata-dir>/<cache-key>.relocation.json` — the durable token. Survives
-  /// relaunch so a crash mid-transition is reconcilable, and so the legacy
-  /// cleanup can be retried on a later launch if it throws.
   /// What the pending legacy artifact is waiting FOR. A path alone is not enough:
   /// the same stranded file means "replace me" before the user asks for the model
   /// to be removed, and "just delete me" afterwards. Without this, a Remove whose
@@ -124,6 +121,9 @@ public struct ModelRelocationMigrator: Sendable {
     case remove
   }
 
+  /// `<metadata-dir>/<cache-key>.relocation.json` — the durable token. Survives
+  /// relaunch so a crash mid-transition is reconcilable, and so the legacy cleanup
+  /// can be retried on a later launch if it throws.
   struct Token: Codable, Equatable {
     /// Absolute path of the legacy artifact awaiting cleanup.
     let legacyPath: String
@@ -190,7 +190,7 @@ public struct ModelRelocationMigrator: Sendable {
     // sitting in an old location are provably redundant, so finish the job that
     // crash interrupted (Codex PR-1 review r7).
     if admission.isAdmitted() {
-      reconcileOldLocations(plan)
+      await reconcileOldLocations(plan)
       return .noop
     }
 
@@ -252,8 +252,9 @@ public struct ModelRelocationMigrator: Sendable {
     }
     guard admission.isAdmitted() else { return .unrecognized }
 
-    // Only now is the old copy provably redundant.
-    reconcileOldLocations(plan)
+    // Only now is the old copy provably redundant — and we just proved which
+    // components are byte-exact, so pass them rather than re-hashing multiple GB.
+    await reconcileOldLocations(plan, verifiedComponents: validation.verifiedComponents)
     return .relocated
   }
 
@@ -269,15 +270,41 @@ public struct ModelRelocationMigrator: Sendable {
   /// cannot account for. The directory itself goes only when nothing of the user's
   /// remains in it. A trusted-legacy artifact is deliberately NOT touched here: its
   /// deletion is governed by the durable token, never by this sweep.
-  private func reconcileOldLocations(_ plan: RelocationPlan) {
+  /// - Parameter verifiedComponents: components already PROVEN (this call) to be a
+  ///   byte-exact copy of the manifest. Pass them from the relocation path, which
+  ///   just validated them, to avoid re-hashing multiple GB. Pass nil on the
+  ///   crash-recovery path, where nothing has been proven yet and the old bytes must
+  ///   earn their deletion by digest.
+  private func reconcileOldLocations(
+    _ plan: RelocationPlan, verifiedComponents: Set<String>? = nil
+  ) async {
     let fm = FileManager.default
-    let roots = CacheAdmission.componentRoots(of: plan.manifest).sorted()
     for oldDirectory in plan.oldLocations {
       guard oldDirectory.standardizedFileURL != plan.destination.standardizedFileURL,
         fm.fileExists(atPath: oldDirectory.path)
       else { continue }
+
       sweepStaleSidecars(in: oldDirectory, plan: plan)
-      for root in roots {
+
+      // Delete ONLY components we have proven are the copy we reproduced. A
+      // filename match is not proof: the old directory could hold corrupt,
+      // truncated, or hand-replaced bytes under a shard's name, and deleting those
+      // because the name lines up is the provenance rule broken by the very code
+      // that enforces it (Codex PR-1 review r11). Whatever fails the hash is left
+      // exactly where it is.
+      let verified: Set<String>
+      if let verifiedComponents {
+        verified = verifiedComponents
+      } else {
+        let gate = CacheAdmission(
+          manifest: plan.manifest,
+          installDirectory: oldDirectory,
+          metadataDirectory: plan.metadataDirectory)
+        verified = await gate.validateExistingCache().verifiedComponents
+      }
+
+      let roots = componentRoots(of: verified, in: plan.manifest)
+      for root in roots.sorted() {
         try? fm.removeItem(at: oldDirectory.appendingPathComponent(root))
       }
       if let remaining = try? fm.contentsOfDirectory(atPath: oldDirectory.path),
@@ -286,6 +313,19 @@ public struct ModelRelocationMigrator: Sendable {
         try? fm.removeItem(at: oldDirectory)
       }
     }
+  }
+
+  /// Top-level on-disk roots belonging to the given (verified) components only.
+  private func componentRoots(of components: Set<String>, in manifest: DeliveryManifest) -> Set<
+    String
+  > {
+    Set(
+      manifest.files
+        .filter { components.contains($0.component) }
+        .map { file in
+          let p = file.resolvedInstallPath
+          return p.contains("/") ? String(p.split(separator: "/")[0]) : p
+        })
   }
 
   // MARK: - Legacy cleanup (runs ONLY after the replacement is admitted)

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -250,18 +250,30 @@ public struct ModelRelocationMigrator: Sendable {
       return .unrecognized
     }
 
-    // Re-stamp admission against the NEW install directory. A same-volume
-    // rename preserves size+mtime, so this is the marker fast path; a
-    // cross-volume copy rehashes once, which `promoteAndAdmit` handles.
+    // Re-stamp admission against the NEW install directory.
+    //
+    // There is ONE admission marker per model, and `promoteAndAdmit` deletes it
+    // first (so no stale marker can ever bless a half-promoted set). That means a
+    // throw anywhere inside leaves the INTACT source no longer admitted — and the
+    // kill-switch fallback, which picks by admission, could then find no usable copy
+    // and report EG-1 unavailable even though a perfect one is sitting right there
+    // (Codex PR-1 review r17). So if promotion fails, put the source's admission
+    // back: its bytes were validated moments ago and are untouched.
     do {
       try admission.promoteAndAdmit(
         stagedComponents: [],
         stagingDirectory: plan.destination,
         untouchedComponents: validation.verifiedComponents)
     } catch {
+      restoreAdmission(
+        of: oldAdmission, components: validation.verifiedComponents, at: oldDirectory)
       return .unrecognized
     }
-    guard admission.isAdmitted() else { return .unrecognized }
+    guard admission.isAdmitted() else {
+      restoreAdmission(
+        of: oldAdmission, components: validation.verifiedComponents, at: oldDirectory)
+      return .unrecognized
+    }
 
     // Only now is the old copy provably redundant — and we just proved which
     // components are byte-exact, so pass them rather than re-hashing multiple GB.
@@ -433,6 +445,25 @@ public struct ModelRelocationMigrator: Sendable {
   }
 
   // MARK: - Internals
+
+  /// Re-admit an intact source after a failed promotion to the destination.
+  ///
+  /// There is one marker per model, and promotion deletes it before it does anything
+  /// that can throw. Without this, a failed promotion silently un-admits a perfectly
+  /// good copy: the bytes stay, but nothing that picks by admission — including the
+  /// kill-switch fallback — can find them again (Codex PR-1 review r17).
+  ///
+  /// Best-effort by nature: if re-admission ALSO fails we are on a filesystem that is
+  /// refusing writes, and the bytes are still there to be re-validated (and
+  /// re-admitted) on the next launch. We never delete anything on this path.
+  private func restoreAdmission(
+    of admission: CacheAdmission, components: Set<String>, at directory: URL
+  ) {
+    try? admission.promoteAndAdmit(
+      stagedComponents: [],
+      stagingDirectory: directory,
+      untouchedComponents: components)
+  }
 
   /// Delete a retired downloader's scratch files from an old location.
   ///

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -14,11 +14,11 @@ import Foundation
 /// Two outcomes matter, and they are NOT the same thing:
 ///
 /// 1. **Relocatable** — the old directory holds bytes that satisfy the CURRENT
-///    manifest. Same-volume rename into the destination, then validate the
-///    admission marker against the new registration before the old directory is
-///    dropped. Zero re-download. (Marker stamps store RELATIVE install paths +
-///    size + mtime, and a rename preserves mtimes, so the marker survives the
-///    move — `CacheAdmission.isAdmitted`.)
+///    manifest. The set is REPRODUCED at the destination (APFS clone: instant,
+///    no extra space) with the source left completely intact, re-admitted there,
+///    and only then is the old directory dropped. Zero re-download, and the
+///    source stays a valid fallback at every instant — so a crash mid-relocation
+///    can never leave both sides partial.
 ///
 /// 2. **Trusted-legacy** — the old directory holds a PREVIOUSLY-SHIPPED layout
 ///    that cannot satisfy the current manifest (EG-1's monolithic
@@ -106,11 +106,14 @@ public struct ModelRelocationMigrator: Sendable {
   struct Token: Codable, Equatable {
     /// Absolute path of the legacy artifact awaiting cleanup.
     let legacyPath: String
-    /// Size of the artifact we VERIFIED at classification time. Re-checked
-    /// immediately before the delete: if the file changed underneath us between
-    /// classification and cleanup, it is no longer the artifact we proved was
-    /// ours, and we do not delete it.
+    /// Size and digest of the artifact we VERIFIED at classification time. BOTH
+    /// are re-checked immediately before the delete. Size alone is not enough: a
+    /// same-size corruption or a same-size manual replacement would slip through
+    /// a byte-count check and we would delete bytes we can no longer prove are
+    /// ours (Codex PR-1 review r2). The delete is minutes after classification —
+    /// a whole model download — so the file genuinely can change in between.
     let legacySizeBytes: Int64
+    let legacySHA256: String
     /// Manifest digest this token was minted against — a token from a different
     /// revision must never authorize a delete under the current one.
     let manifestDigest: String
@@ -120,9 +123,10 @@ public struct ModelRelocationMigrator: Sendable {
 
   // MARK: - Migration (runs inside the migration latch, before any engine loads)
 
-  /// Classify and, where possible, relocate. Filesystem only: fast (stat +
-  /// rename), never a network transfer — the caller must NOT hold the migration
-  /// latch across a download.
+  /// Classify and, where possible, relocate. Filesystem only — never a network
+  /// transfer, so the caller must NOT hold the migration latch across a
+  /// download. Hashes at most one candidate (size gates first), so the common
+  /// launch is a stat and nothing more.
   public func migrate(_ plan: RelocationPlan) async -> Outcome {
     let fm = FileManager.default
     let admission = CacheAdmission(
@@ -145,6 +149,7 @@ public struct ModelRelocationMigrator: Sendable {
         Token(
           legacyPath: legacy.url.path,
           legacySizeBytes: legacy.artifact.sizeBytes,
+          legacySHA256: legacy.artifact.sha256,
           manifestDigest: plan.manifest.manifestDigest),
         plan: plan)
       return .trustedLegacyPending(legacy.url)
@@ -195,7 +200,7 @@ public struct ModelRelocationMigrator: Sendable {
   /// Throws on a failed delete so the caller can retain the token and retry on a
   /// later launch — never clears the token on a failure. Idempotent: an
   /// already-absent legacy file clears the token and returns.
-  public func cleanUpLegacy(_ plan: RelocationPlan) throws {
+  public func cleanUpLegacy(_ plan: RelocationPlan) async throws {
     let fm = FileManager.default
     guard let token = readToken(plan: plan) else { return }
     // A token minted against a different revision must not authorize a delete.
@@ -203,18 +208,23 @@ public struct ModelRelocationMigrator: Sendable {
       clearToken(plan: plan)
       return
     }
+    let url = URL(fileURLWithPath: token.legacyPath)
     if fm.fileExists(atPath: token.legacyPath) {
-      // The file must still be the artifact we PROVED was ours at classification
-      // time. If it changed underneath us (user swapped it, a partial write
-      // truncated it), it is no longer identifiable as ours — leave it, and drop
-      // the token so we never revisit it. Cheap stat, not a re-hash: the
-      // expensive proof was done once, at classification.
-      let size = (try? fm.attributesOfItem(atPath: token.legacyPath)[.size]) as? Int64
-      guard size == token.legacySizeBytes else {
+      // The file must STILL be the artifact we proved was ours. Classification
+      // happened before a multi-GB download, so minutes have passed and the file
+      // genuinely can have changed underneath us. Re-prove identity by digest,
+      // not by byte count — a same-size corruption or replacement passes a size
+      // check and would otherwise cost the user bytes we cannot identify.
+      // Size is the cheap gate; the hash is the proof.
+      guard CacheAdmission.sizeMatches(url: url, expected: token.legacySizeBytes),
+        await CacheAdmission.streamingSHA256(of: url) == token.legacySHA256
+      else {
+        // No longer identifiable as ours: leave the bytes alone and drop the
+        // token so we never revisit them.
         clearToken(plan: plan)
         return
       }
-      try fm.removeItem(atPath: token.legacyPath)
+      try fm.removeItem(at: url)
     }
     clearToken(plan: plan)
   }

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -270,17 +270,28 @@ public struct ModelRelocationMigrator: Sendable {
 
   /// Delete a retired downloader's scratch files from an old location.
   ///
-  /// Strictly suffix-matched, and the suffixes are scratch-only — a model file
-  /// is never a candidate. This is the one thing we DO delete from the old home
-  /// without proving a digest, because a `.partial` is by definition an
-  /// incomplete artifact that nothing can load, and leaving it costs the user
-  /// gigabytes that no future code path will ever reclaim.
+  /// The scratch we reclaim must belong to an artifact WE know: a sidecar is only
+  /// a candidate when its name is `<known artifact><suffix>` — where the known
+  /// artifacts are this manifest's own install names and the trusted legacy
+  /// layouts we shipped. A bare suffix match would reach `custom-model.partial`,
+  /// which belongs to someone else's model and is not ours to reclaim (Codex PR-1
+  /// review r4).
+  ///
+  /// This is the one thing we delete from the old home without proving a digest,
+  /// and that is defensible only because a `.partial` of a KNOWN artifact is by
+  /// construction an incomplete file nothing can load — while leaving it costs the
+  /// user gigabytes that no future code path will ever look for again.
   private func sweepStaleSidecars(in directory: URL, plan: RelocationPlan) {
-    guard !plan.staleSidecarSuffixes.isEmpty,
-      let entries = try? FileManager.default.contentsOfDirectory(atPath: directory.path)
-    else { return }
-    for entry in entries where plan.staleSidecarSuffixes.contains(where: { entry.hasSuffix($0) }) {
-      try? FileManager.default.removeItem(at: directory.appendingPathComponent(entry))
+    guard !plan.staleSidecarSuffixes.isEmpty else { return }
+    let fm = FileManager.default
+    let knownArtifacts =
+      plan.manifest.files.map(\.resolvedInstallPath) + plan.trustedLegacyArtifacts.map(\.name)
+    for artifact in knownArtifacts {
+      for suffix in plan.staleSidecarSuffixes {
+        let sidecar = directory.appendingPathComponent(artifact + suffix)
+        guard fm.fileExists(atPath: sidecar.path) else { continue }
+        try? fm.removeItem(at: sidecar)
+      }
     }
   }
 

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -191,12 +191,24 @@ public struct ModelRelocationMigrator: Sendable {
     // crash interrupted (Codex PR-1 review r7).
     if admission.isAdmitted() {
       await reconcileOldLocations(plan)
+      // ...and a stranded trusted artifact is STILL owed a cleanup, even here.
+      //
+      // The replacement now proceeds whether or not the note got written (r17), so a
+      // model can end up admitted with NO token. If this fast path just returned,
+      // every later launch would take it, `reconcileOldLocations` deliberately never
+      // touches a trusted-legacy artifact, and the 2.9 GB monolith would sit on the
+      // user's disk forever with nothing left that would ever look for it (Codex PR-1
+      // review r19). Re-journal it so cleanup can still reclaim it.
+      if let oldDirectory = firstExistingOldLocation(plan),
+        let legacy = await trustedLegacyArtifact(in: oldDirectory, plan: plan)
+      {
+        journalTrustedLegacy(legacy, plan: plan)
+        return .trustedLegacyPending(legacy.url)
+      }
       return .noop
     }
 
-    guard let oldDirectory = plan.oldLocations.first(where: { fm.fileExists(atPath: $0.path) }),
-      oldDirectory.standardizedFileURL != plan.destination.standardizedFileURL
-    else { return .noop }
+    guard let oldDirectory = firstExistingOldLocation(plan) else { return .noop }
 
     // Stale download sidecars from a retired downloader (an interrupted
     // multi-GB `.partial` and its resume file) are stranded the moment the
@@ -211,24 +223,7 @@ public struct ModelRelocationMigrator: Sendable {
     // A previously-shipped layout we recognize: do NOT move it, do NOT load it,
     // do NOT delete it. Record the token and let the caller replace it.
     if let legacy = await trustedLegacyArtifact(in: oldDirectory, plan: plan) {
-      // Re-classification must NOT overwrite a decision the user already made.
-      //
-      // If a previous launch recorded `.remove` and the delete then failed, the
-      // artifact is still here — so we land here again, and writing a fresh token
-      // would reset the intent to its `.replace` default and re-download the 2.9 GB
-      // model the user threw away. That is the resurrection bug (r6) sneaking back
-      // in through classification (Codex PR-1 review r16). Carry a current-revision
-      // token's intent forward; only a token from another revision, or no token at
-      // all, starts fresh.
-      let intent = pendingLegacyIntent(plan) ?? .replace
-      writeToken(
-        Token(
-          legacyPath: legacy.url.path,
-          intent: intent,
-          legacySizeBytes: legacy.artifact.sizeBytes,
-          legacySHA256: legacy.artifact.sha256,
-          manifestDigest: plan.manifest.manifestDigest),
-        plan: plan)
+      journalTrustedLegacy(legacy, plan: plan)
       return .trustedLegacyPending(legacy.url)
     }
 
@@ -443,6 +438,35 @@ public struct ModelRelocationMigrator: Sendable {
   }
 
   // MARK: - Internals
+
+  private func firstExistingOldLocation(_ plan: RelocationPlan) -> URL? {
+    plan.oldLocations.first {
+      $0.standardizedFileURL != plan.destination.standardizedFileURL
+        && FileManager.default.fileExists(atPath: $0.path)
+    }
+  }
+
+  /// Record that a trusted legacy artifact is owed a cleanup. Called from BOTH
+  /// classification paths, so the journalling rule lives in one place.
+  ///
+  /// Never overwrites a decision the user already made: if a previous launch recorded
+  /// `.remove` and the delete then failed, the artifact is still here and we land here
+  /// again — writing a fresh token would reset the intent to its `.replace` default
+  /// and re-download the 2.9 GB model the user threw away (Codex PR-1 review r16).
+  /// Carry a current-revision token's intent forward; only a token from another
+  /// revision, or none at all, starts fresh.
+  private func journalTrustedLegacy(
+    _ legacy: (url: URL, artifact: TrustedLegacyArtifact), plan: RelocationPlan
+  ) {
+    writeToken(
+      Token(
+        legacyPath: legacy.url.path,
+        intent: pendingLegacyIntent(plan) ?? .replace,
+        legacySizeBytes: legacy.artifact.sizeBytes,
+        legacySHA256: legacy.artifact.sha256,
+        manifestDigest: plan.manifest.manifestDigest),
+      plan: plan)
+  }
 
   /// Re-admit an intact source after a failed promotion to the destination.
   ///

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -211,9 +211,20 @@ public struct ModelRelocationMigrator: Sendable {
     // A previously-shipped layout we recognize: do NOT move it, do NOT load it,
     // do NOT delete it. Record the token and let the caller replace it.
     if let legacy = await trustedLegacyArtifact(in: oldDirectory, plan: plan) {
+      // Re-classification must NOT overwrite a decision the user already made.
+      //
+      // If a previous launch recorded `.remove` and the delete then failed, the
+      // artifact is still here — so we land here again, and writing a fresh token
+      // would reset the intent to its `.replace` default and re-download the 2.9 GB
+      // model the user threw away. That is the resurrection bug (r6) sneaking back
+      // in through classification (Codex PR-1 review r16). Carry a current-revision
+      // token's intent forward; only a token from another revision, or no token at
+      // all, starts fresh.
+      let intent = pendingLegacyIntent(plan) ?? .replace
       writeToken(
         Token(
           legacyPath: legacy.url.path,
+          intent: intent,
           legacySizeBytes: legacy.artifact.sizeBytes,
           legacySHA256: legacy.artifact.sha256,
           manifestDigest: plan.manifest.manifestDigest),

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -144,6 +144,29 @@ public struct ModelRelocationMigrator: Sendable {
 
   public init() {}
 
+  /// The first candidate directory that currently holds an ADMITTED copy of this
+  /// manifest — or nil when none does.
+  ///
+  /// Existence is not validity. A relocation that failed partway leaves a
+  /// half-populated destination directory sitting next to a perfectly good source,
+  /// and a caller that picks by "does the folder exist" would choose the broken one
+  /// (Codex PR-1 review r10). This is what the delivery kill switch consults to
+  /// decide where a no-mutation build should READ from, so it has to be the real
+  /// admission check — cheap (marker + size + mtime, no rehash) and synchronous.
+  public static func admittedLocation(
+    manifest: DeliveryManifest,
+    candidates: [URL],
+    metadataDirectory: URL
+  ) -> URL? {
+    candidates.first { candidate in
+      CacheAdmission(
+        manifest: manifest,
+        installDirectory: candidate,
+        metadataDirectory: metadataDirectory
+      ).isAdmitted()
+    }
+  }
+
   // MARK: - Migration (runs inside the migration latch, before any engine loads)
 
   /// Classify and, where possible, relocate. Filesystem only — never a network

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -202,7 +202,7 @@ public struct ModelRelocationMigrator: Sendable {
       if let oldDirectory = firstExistingOldLocation(plan),
         let legacy = await trustedLegacyArtifact(in: oldDirectory, plan: plan)
       {
-        journalTrustedLegacy(legacy, plan: plan)
+        guard journalTrustedLegacy(legacy, plan: plan) else { return .unrecognized }
         return .trustedLegacyPending(legacy.url)
       }
       return .noop
@@ -223,7 +223,14 @@ public struct ModelRelocationMigrator: Sendable {
     // A previously-shipped layout we recognize: do NOT move it, do NOT load it,
     // do NOT delete it. Record the token and let the caller replace it.
     if let legacy = await trustedLegacyArtifact(in: oldDirectory, plan: plan) {
-      journalTrustedLegacy(legacy, plan: plan)
+      // Could not journal ⇒ start NOTHING. The token and the admission marker share
+      // this metadata directory, so a filesystem that refuses the token would refuse
+      // the marker too: the replacement could download 2.9 GB and never be admitted.
+      // Worse, an unjournaled replacement that DID land would have no token for a later
+      // Remove to flip, so the next launch would reclassify the monolith as `.replace`
+      // and re-download a model the user deleted (GitHub cloud review, PR #1497).
+      // Treated as absent: nothing moved, nothing deleted, retry next launch.
+      guard journalTrustedLegacy(legacy, plan: plan) else { return .unrecognized }
       return .trustedLegacyPending(legacy.url)
     }
 
@@ -455,9 +462,11 @@ public struct ModelRelocationMigrator: Sendable {
   /// and re-download the 2.9 GB model the user threw away (Codex PR-1 review r16).
   /// Carry a current-revision token's intent forward; only a token from another
   /// revision, or none at all, starts fresh.
+  /// Returns false when the token could NOT be persisted — the caller must then treat
+  /// the artifact as absent and start nothing (see `migrate`).
   private func journalTrustedLegacy(
     _ legacy: (url: URL, artifact: TrustedLegacyArtifact), plan: RelocationPlan
-  ) {
+  ) -> Bool {
     writeToken(
       Token(
         legacyPath: legacy.url.path,
@@ -572,11 +581,23 @@ public struct ModelRelocationMigrator: Sendable {
       "\(plan.manifest.identity.cacheKey).relocation.json")
   }
 
-  private func writeToken(_ token: Token, plan: RelocationPlan) {
+  /// Returns false if the token could not be persisted.
+  ///
+  /// A silent failure here is not survivable: the token is the only durable record of
+  /// what is owed on the legacy artifact, so an unjournaled classification that still
+  /// drove a replacement would lose a later Remove and resurrect the model on the next
+  /// launch (GitHub cloud review, PR #1497).
+  @discardableResult
+  private func writeToken(_ token: Token, plan: RelocationPlan) -> Bool {
     let url = tokenURL(plan: plan)
-    try? FileManager.default.createDirectory(
-      at: plan.metadataDirectory, withIntermediateDirectories: true)
-    try? JSONEncoder().encode(token).write(to: url, options: .atomic)
+    do {
+      try FileManager.default.createDirectory(
+        at: plan.metadataDirectory, withIntermediateDirectories: true)
+      try JSONEncoder().encode(token).write(to: url, options: .atomic)
+      return true
+    } catch {
+      return false
+    }
   }
 
   private func readToken(plan: RelocationPlan) -> Token? {

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -1,3 +1,4 @@
+import Darwin  // clonefile(2): APFS copy-on-write clone (see `relocate`).
 import EnviousWisprCore
 import Foundation
 
@@ -33,6 +34,26 @@ import Foundation
 /// never deletes an unrecognized foreign copy at all.
 public struct ModelRelocationMigrator: Sendable {
 
+  /// A layout WE shipped, identified by what it IS, not what it is called.
+  ///
+  /// The filename alone is not identity. A corrupt, hand-edited, or unrelated
+  /// file that happens to be named `eg-1-v1.gguf` is NOT ours, and the
+  /// provenance rule forbids deleting bytes we cannot prove we shipped — so the
+  /// digest is the gate, and a mismatch drops the file into the untouchable
+  /// `unrecognized` class.
+  public struct TrustedLegacyArtifact: Sendable, Equatable {
+    /// On-disk name inside the legacy directory.
+    public let name: String
+    public let sizeBytes: Int64
+    public let sha256: String
+
+    public init(name: String, sizeBytes: Int64, sha256: String) {
+      self.name = name
+      self.sizeBytes = sizeBytes
+      self.sha256 = sha256
+    }
+  }
+
   /// One model's relocation descriptor. Journaling/crash-safety is written once
   /// here and reused per family rather than reimplemented per engine.
   public struct RelocationPlan: Sendable {
@@ -44,17 +65,18 @@ public struct ModelRelocationMigrator: Sendable {
     public let destination: URL
     /// Where admission markers live (unchanged by relocation).
     public let metadataDirectory: URL
-    /// Relative filenames of previously-shipped layouts that this build can no
-    /// longer load but DOES recognize as its own (e.g. `["eg-1-v1.gguf"]`).
-    /// Presence of one of these in an old location ⇒ trusted-legacy outcome.
-    public let trustedLegacyArtifacts: [String]
+    /// Previously-shipped layouts this build can no longer load but DOES
+    /// recognize as its own. Identity is the DIGEST, never the filename: a
+    /// same-named file we did not ship is a stranger's, and strangers are never
+    /// deleted (the provenance rule — Codex PR-1 review P2).
+    public let trustedLegacyArtifacts: [TrustedLegacyArtifact]
 
     public init(
       manifest: DeliveryManifest,
       oldLocations: [URL],
       destination: URL,
       metadataDirectory: URL,
-      trustedLegacyArtifacts: [String] = []
+      trustedLegacyArtifacts: [TrustedLegacyArtifact] = []
     ) {
       self.manifest = manifest
       self.oldLocations = oldLocations
@@ -84,6 +106,11 @@ public struct ModelRelocationMigrator: Sendable {
   struct Token: Codable, Equatable {
     /// Absolute path of the legacy artifact awaiting cleanup.
     let legacyPath: String
+    /// Size of the artifact we VERIFIED at classification time. Re-checked
+    /// immediately before the delete: if the file changed underneath us between
+    /// classification and cleanup, it is no longer the artifact we proved was
+    /// ours, and we do not delete it.
+    let legacySizeBytes: Int64
     /// Manifest digest this token was minted against — a token from a different
     /// revision must never authorize a delete under the current one.
     let manifestDigest: String
@@ -113,11 +140,14 @@ public struct ModelRelocationMigrator: Sendable {
 
     // A previously-shipped layout we recognize: do NOT move it, do NOT load it,
     // do NOT delete it. Record the token and let the caller replace it.
-    if let legacy = trustedLegacyArtifact(in: oldDirectory, plan: plan) {
+    if let legacy = await trustedLegacyArtifact(in: oldDirectory, plan: plan) {
       writeToken(
-        Token(legacyPath: legacy.path, manifestDigest: plan.manifest.manifestDigest),
+        Token(
+          legacyPath: legacy.url.path,
+          legacySizeBytes: legacy.artifact.sizeBytes,
+          manifestDigest: plan.manifest.manifestDigest),
         plan: plan)
-      return .trustedLegacyPending(legacy)
+      return .trustedLegacyPending(legacy.url)
     }
 
     // Does the old directory satisfy the CURRENT manifest? Validate in place
@@ -174,6 +204,16 @@ public struct ModelRelocationMigrator: Sendable {
       return
     }
     if fm.fileExists(atPath: token.legacyPath) {
+      // The file must still be the artifact we PROVED was ours at classification
+      // time. If it changed underneath us (user swapped it, a partial write
+      // truncated it), it is no longer identifiable as ours — leave it, and drop
+      // the token so we never revisit it. Cheap stat, not a re-hash: the
+      // expensive proof was done once, at classification.
+      let size = (try? fm.attributesOfItem(atPath: token.legacyPath)[.size]) as? Int64
+      guard size == token.legacySizeBytes else {
+        clearToken(plan: plan)
+        return
+      }
       try fm.removeItem(atPath: token.legacyPath)
     }
     clearToken(plan: plan)
@@ -190,40 +230,55 @@ public struct ModelRelocationMigrator: Sendable {
 
   // MARK: - Internals
 
-  /// A recognized previously-shipped artifact in `directory`, if any. Only the
-  /// exact filenames this build ships as `trustedLegacyArtifacts` qualify — an
-  /// unrecognized file is never treated as ours.
-  private func trustedLegacyArtifact(in directory: URL, plan: RelocationPlan) -> URL? {
-    let fm = FileManager.default
-    for name in plan.trustedLegacyArtifacts {
-      let url = directory.appendingPathComponent(name)
-      if fm.fileExists(atPath: url.path) { return url }
+  /// A previously-shipped artifact in `directory` that we can PROVE is ours.
+  ///
+  /// The filename is only the lookup key; the digest is the identity (Codex PR-1
+  /// review P2). A file named `eg-1-v1.gguf` that we did not ship — corrupt,
+  /// truncated, hand-replaced, or someone else's — fails the hash and falls
+  /// through to `unrecognized`, where it is never moved, loaded, or deleted.
+  /// Size is the cheap gate so the multi-GB hash runs only on a real candidate.
+  private func trustedLegacyArtifact(in directory: URL, plan: RelocationPlan) async
+    -> (url: URL, artifact: TrustedLegacyArtifact)?
+  {
+    for artifact in plan.trustedLegacyArtifacts {
+      let url = directory.appendingPathComponent(artifact.name)
+      guard CacheAdmission.sizeMatches(url: url, expected: artifact.sizeBytes),
+        await CacheAdmission.streamingSHA256(of: url) == artifact.sha256
+      else { continue }
+      return (url, artifact)
     }
     return nil
   }
 
-  /// Move every manifest-listed file from `source` into `destination`. Same
-  /// volume ⇒ rename (instant, mtime preserved). Cross-volume ⇒ copy, leaving
-  /// the source intact for the caller to drop after admission.
+  /// Reproduce every manifest-listed component at `destination`, leaving the
+  /// source COMPLETELY INTACT. The source is dropped by the caller only after
+  /// the destination is admitted — verify-before-delete, applied to the move
+  /// itself (Codex PR-1 review P2).
   ///
-  /// Journal-free by construction: nothing is deleted here, so a crash mid-move
-  /// leaves the old copy intact and a partially-populated destination that the
-  /// next launch's admission check rejects and rebuilds.
+  /// This is deliberately NOT a rename. A per-component `moveItem` removes each
+  /// component from the source as it goes, so a crash (or a later component's
+  /// failure) leaves BOTH directories partial: the destination is unadmittable
+  /// and the source no longer validates, so the next launch classifies a
+  /// perfectly good model as `unrecognized` and re-downloads it. Copying keeps
+  /// the source a complete, valid fallback at every instant.
+  ///
+  /// Copying multiple GB would normally be the expensive choice — except on
+  /// APFS, where `clonefile(2)` makes a copy-on-write clone: no bytes are moved,
+  /// no extra space is used, and it returns immediately. We clone when we can and
+  /// fall back to a real copy (a different volume, or a non-APFS filesystem)
+  /// where we cannot.
   private func relocate(from source: URL, to destination: URL, manifest: DeliveryManifest) throws {
     let fm = FileManager.default
     try fm.createDirectory(at: destination, withIntermediateDirectories: true)
-    for root in CacheAdmission.componentRoots(of: manifest) {
+    // Sorted, not set-order: a deterministic sequence makes a partial-failure
+    // reproducible in a test instead of depending on hash ordering.
+    for root in CacheAdmission.componentRoots(of: manifest).sorted() {
       let from = source.appendingPathComponent(root)
       let to = destination.appendingPathComponent(root)
       guard fm.fileExists(atPath: from.path) else { continue }
       if fm.fileExists(atPath: to.path) { try fm.removeItem(at: to) }
-      do {
-        try fm.moveItem(at: from, to: to)
-      } catch {
-        // Cross-volume (or any rename refusal): copy instead. The source stays
-        // put; the caller drops it only after the destination is admitted.
-        try fm.copyItem(at: from, to: to)
-      }
+      if clonefile(from.path, to.path, 0) == 0 { continue }
+      try fm.copyItem(at: from, to: to)
     }
   }
 

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -1,0 +1,250 @@
+import EnviousWisprCore
+import Foundation
+
+/// One-time relocation of model bytes from a legacy on-disk home into the
+/// app-owned `EnviousWispr/Models/<family>` layout (#1386, ModelDelivery epic
+/// #1348 Phase 4).
+///
+/// Sibling of `CacheAdmission`, and deliberately NOT an actor: every call runs
+/// from the composition root before any engine loads (the migration latch), so
+/// there is exactly one caller. Pure filesystem; no networking, no hashing of
+/// its own (it delegates verification to `CacheAdmission`).
+///
+/// Two outcomes matter, and they are NOT the same thing:
+///
+/// 1. **Relocatable** — the old directory holds bytes that satisfy the CURRENT
+///    manifest. Same-volume rename into the destination, then validate the
+///    admission marker against the new registration before the old directory is
+///    dropped. Zero re-download. (Marker stamps store RELATIVE install paths +
+///    size + mtime, and a rename preserves mtimes, so the marker survives the
+///    move — `CacheAdmission.isAdmitted`.)
+///
+/// 2. **Trusted-legacy** — the old directory holds a PREVIOUSLY-SHIPPED layout
+///    that cannot satisfy the current manifest (EG-1's monolithic
+///    `eg-1-v1.gguf` vs the current 8-shard `componentSet`). These bytes are a
+///    *trusted app-managed asset* — we shipped them and hold their digest — so
+///    the contract's automatic-replacement clause permits replacing them
+///    without asking. The migrator does NOT move, load, or delete them: it
+///    records a durable pending-cleanup token and returns. The caller starts the
+///    replacement fetch and deletes the legacy bytes ONLY after the new set is
+///    admitted (verify-before-delete).
+///
+/// The migrator never deletes anything it has not proven replaceable, and it
+/// never deletes an unrecognized foreign copy at all.
+public struct ModelRelocationMigrator: Sendable {
+
+  /// One model's relocation descriptor. Journaling/crash-safety is written once
+  /// here and reused per family rather than reimplemented per engine.
+  public struct RelocationPlan: Sendable {
+    /// Delivery identity of the model being rehomed (also the token/journal key).
+    public let manifest: DeliveryManifest
+    /// Where the bytes used to live (checked in order; first hit wins).
+    public let oldLocations: [URL]
+    /// The app-owned destination — the new registration's install directory.
+    public let destination: URL
+    /// Where admission markers live (unchanged by relocation).
+    public let metadataDirectory: URL
+    /// Relative filenames of previously-shipped layouts that this build can no
+    /// longer load but DOES recognize as its own (e.g. `["eg-1-v1.gguf"]`).
+    /// Presence of one of these in an old location ⇒ trusted-legacy outcome.
+    public let trustedLegacyArtifacts: [String]
+
+    public init(
+      manifest: DeliveryManifest,
+      oldLocations: [URL],
+      destination: URL,
+      metadataDirectory: URL,
+      trustedLegacyArtifacts: [String] = []
+    ) {
+      self.manifest = manifest
+      self.oldLocations = oldLocations
+      self.destination = destination
+      self.metadataDirectory = metadataDirectory
+      self.trustedLegacyArtifacts = trustedLegacyArtifacts
+    }
+  }
+
+  public enum Outcome: Sendable, Equatable {
+    /// Nothing to do: destination already holds this model, or no old copy exists.
+    case noop
+    /// Old bytes satisfied the current manifest and were moved into place.
+    case relocated
+    /// A previously-shipped layout we recognize is present at this URL. It has
+    /// NOT been moved, loaded, or deleted. The caller must fetch the current
+    /// manifest's bytes and, only once admitted, call `cleanUpLegacy`.
+    case trustedLegacyPending(URL)
+    /// Old bytes exist but match neither the current manifest nor a trusted
+    /// legacy layout. Untouched, never loaded. Treated as absent.
+    case unrecognized
+  }
+
+  /// `<metadata-dir>/<cache-key>.relocation.json` — the durable token. Survives
+  /// relaunch so a crash mid-transition is reconcilable, and so the legacy
+  /// cleanup can be retried on a later launch if it throws.
+  struct Token: Codable, Equatable {
+    /// Absolute path of the legacy artifact awaiting cleanup.
+    let legacyPath: String
+    /// Manifest digest this token was minted against — a token from a different
+    /// revision must never authorize a delete under the current one.
+    let manifestDigest: String
+  }
+
+  public init() {}
+
+  // MARK: - Migration (runs inside the migration latch, before any engine loads)
+
+  /// Classify and, where possible, relocate. Filesystem only: fast (stat +
+  /// rename), never a network transfer — the caller must NOT hold the migration
+  /// latch across a download.
+  public func migrate(_ plan: RelocationPlan) async -> Outcome {
+    let fm = FileManager.default
+    let admission = CacheAdmission(
+      manifest: plan.manifest,
+      installDirectory: plan.destination,
+      metadataDirectory: plan.metadataDirectory)
+
+    // Destination already good — the common case on every launch after the
+    // first. Cheap marker check, no rehash.
+    if admission.isAdmitted() { return .noop }
+
+    guard let oldDirectory = plan.oldLocations.first(where: { fm.fileExists(atPath: $0.path) }),
+      oldDirectory.standardizedFileURL != plan.destination.standardizedFileURL
+    else { return .noop }
+
+    // A previously-shipped layout we recognize: do NOT move it, do NOT load it,
+    // do NOT delete it. Record the token and let the caller replace it.
+    if let legacy = trustedLegacyArtifact(in: oldDirectory, plan: plan) {
+      writeToken(
+        Token(legacyPath: legacy.path, manifestDigest: plan.manifest.manifestDigest),
+        plan: plan)
+      return .trustedLegacyPending(legacy)
+    }
+
+    // Does the old directory satisfy the CURRENT manifest? Validate in place
+    // before moving a single byte — we relocate proven-good bytes only.
+    let oldAdmission = CacheAdmission(
+      manifest: plan.manifest,
+      installDirectory: oldDirectory,
+      metadataDirectory: plan.metadataDirectory)
+    let validation = await oldAdmission.validateExistingCache()
+    guard validation.failedComponents.isEmpty, !validation.verifiedComponents.isEmpty else {
+      return .unrecognized
+    }
+
+    do {
+      try relocate(from: oldDirectory, to: plan.destination, manifest: plan.manifest)
+    } catch {
+      // The old copy is untouched on any throw; next launch retries.
+      return .unrecognized
+    }
+
+    // Re-stamp admission against the NEW install directory. A same-volume
+    // rename preserves size+mtime, so this is the marker fast path; a
+    // cross-volume copy rehashes once, which `promoteAndAdmit` handles.
+    do {
+      try admission.promoteAndAdmit(
+        stagedComponents: [],
+        stagingDirectory: plan.destination,
+        untouchedComponents: validation.verifiedComponents)
+    } catch {
+      return .unrecognized
+    }
+    guard admission.isAdmitted() else { return .unrecognized }
+
+    // Only now is the old home provably redundant.
+    try? fm.removeItem(at: oldDirectory)
+    return .relocated
+  }
+
+  // MARK: - Legacy cleanup (runs ONLY after the replacement is admitted)
+
+  /// Delete the trusted-legacy bytes and clear the token. The caller MUST have
+  /// confirmed the new set is admitted and stopped any runtime holding the old
+  /// file open (deleting a file an engine has mmap'd is a SIGBUS).
+  ///
+  /// Throws on a failed delete so the caller can retain the token and retry on a
+  /// later launch — never clears the token on a failure. Idempotent: an
+  /// already-absent legacy file clears the token and returns.
+  public func cleanUpLegacy(_ plan: RelocationPlan) throws {
+    let fm = FileManager.default
+    guard let token = readToken(plan: plan) else { return }
+    // A token minted against a different revision must not authorize a delete.
+    guard token.manifestDigest == plan.manifest.manifestDigest else {
+      clearToken(plan: plan)
+      return
+    }
+    if fm.fileExists(atPath: token.legacyPath) {
+      try fm.removeItem(atPath: token.legacyPath)
+    }
+    clearToken(plan: plan)
+  }
+
+  /// The pending legacy artifact, if a cleanup is still owed for THIS revision.
+  /// Drives next-launch reconciliation.
+  public func pendingLegacyArtifact(_ plan: RelocationPlan) -> URL? {
+    guard let token = readToken(plan: plan),
+      token.manifestDigest == plan.manifest.manifestDigest
+    else { return nil }
+    return URL(fileURLWithPath: token.legacyPath)
+  }
+
+  // MARK: - Internals
+
+  /// A recognized previously-shipped artifact in `directory`, if any. Only the
+  /// exact filenames this build ships as `trustedLegacyArtifacts` qualify — an
+  /// unrecognized file is never treated as ours.
+  private func trustedLegacyArtifact(in directory: URL, plan: RelocationPlan) -> URL? {
+    let fm = FileManager.default
+    for name in plan.trustedLegacyArtifacts {
+      let url = directory.appendingPathComponent(name)
+      if fm.fileExists(atPath: url.path) { return url }
+    }
+    return nil
+  }
+
+  /// Move every manifest-listed file from `source` into `destination`. Same
+  /// volume ⇒ rename (instant, mtime preserved). Cross-volume ⇒ copy, leaving
+  /// the source intact for the caller to drop after admission.
+  ///
+  /// Journal-free by construction: nothing is deleted here, so a crash mid-move
+  /// leaves the old copy intact and a partially-populated destination that the
+  /// next launch's admission check rejects and rebuilds.
+  private func relocate(from source: URL, to destination: URL, manifest: DeliveryManifest) throws {
+    let fm = FileManager.default
+    try fm.createDirectory(at: destination, withIntermediateDirectories: true)
+    for root in CacheAdmission.componentRoots(of: manifest) {
+      let from = source.appendingPathComponent(root)
+      let to = destination.appendingPathComponent(root)
+      guard fm.fileExists(atPath: from.path) else { continue }
+      if fm.fileExists(atPath: to.path) { try fm.removeItem(at: to) }
+      do {
+        try fm.moveItem(at: from, to: to)
+      } catch {
+        // Cross-volume (or any rename refusal): copy instead. The source stays
+        // put; the caller drops it only after the destination is admitted.
+        try fm.copyItem(at: from, to: to)
+      }
+    }
+  }
+
+  private func tokenURL(plan: RelocationPlan) -> URL {
+    plan.metadataDirectory.appendingPathComponent(
+      "\(plan.manifest.identity.cacheKey).relocation.json")
+  }
+
+  private func writeToken(_ token: Token, plan: RelocationPlan) {
+    let url = tokenURL(plan: plan)
+    try? FileManager.default.createDirectory(
+      at: plan.metadataDirectory, withIntermediateDirectories: true)
+    try? JSONEncoder().encode(token).write(to: url, options: .atomic)
+  }
+
+  private func readToken(plan: RelocationPlan) -> Token? {
+    guard let data = try? Data(contentsOf: tokenURL(plan: plan)) else { return nil }
+    return try? JSONDecoder().decode(Token.self, from: data)
+  }
+
+  private func clearToken(plan: RelocationPlan) {
+    try? FileManager.default.removeItem(at: tokenURL(plan: plan))
+  }
+}

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -254,7 +254,8 @@ public struct ModelRelocationMigrator: Sendable {
 
     // Only now is the old copy provably redundant — and we just proved which
     // components are byte-exact, so pass them rather than re-hashing multiple GB.
-    await reconcileOldLocations(plan, verifiedComponents: validation.verifiedComponents)
+    await reconcileOldLocations(
+      plan, provenSource: (url: oldDirectory, components: validation.verifiedComponents))
     return .relocated
   }
 
@@ -270,13 +271,15 @@ public struct ModelRelocationMigrator: Sendable {
   /// cannot account for. The directory itself goes only when nothing of the user's
   /// remains in it. A trusted-legacy artifact is deliberately NOT touched here: its
   /// deletion is governed by the durable token, never by this sweep.
-  /// - Parameter verifiedComponents: components already PROVEN (this call) to be a
-  ///   byte-exact copy of the manifest. Pass them from the relocation path, which
-  ///   just validated them, to avoid re-hashing multiple GB. Pass nil on the
-  ///   crash-recovery path, where nothing has been proven yet and the old bytes must
-  ///   earn their deletion by digest.
+  /// - Parameter provenSource: the ONE directory whose components were just proven
+  ///   byte-exact (the relocation source), so we do not re-hash multiple GB to
+  ///   delete what we literally just validated. Every OTHER old location earns its
+  ///   deletion independently — a proof about one directory says nothing about the
+  ///   bytes in another, and reusing it there would delete unverified files under a
+  ///   matching name (Codex PR-1 review r12). Nil on the crash-recovery path, where
+  ///   nothing has been proven at all.
   private func reconcileOldLocations(
-    _ plan: RelocationPlan, verifiedComponents: Set<String>? = nil
+    _ plan: RelocationPlan, provenSource: (url: URL, components: Set<String>)? = nil
   ) async {
     let fm = FileManager.default
     for oldDirectory in plan.oldLocations {
@@ -287,14 +290,16 @@ public struct ModelRelocationMigrator: Sendable {
       sweepStaleSidecars(in: oldDirectory, plan: plan)
 
       // Delete ONLY components we have proven are the copy we reproduced. A
-      // filename match is not proof: the old directory could hold corrupt,
+      // filename match is not proof: an old directory could hold corrupt,
       // truncated, or hand-replaced bytes under a shard's name, and deleting those
       // because the name lines up is the provenance rule broken by the very code
       // that enforces it (Codex PR-1 review r11). Whatever fails the hash is left
       // exactly where it is.
       let verified: Set<String>
-      if let verifiedComponents {
-        verified = verifiedComponents
+      if let provenSource,
+        provenSource.url.standardizedFileURL == oldDirectory.standardizedFileURL
+      {
+        verified = provenSource.components
       } else {
         let gate = CacheAdmission(
           manifest: plan.manifest,

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -265,13 +265,11 @@ public struct ModelRelocationMigrator: Sendable {
         stagingDirectory: plan.destination,
         untouchedComponents: validation.verifiedComponents)
     } catch {
-      restoreAdmission(
-        of: oldAdmission, components: validation.verifiedComponents, at: oldDirectory)
+      restoreAdmission(of: oldAdmission)
       return .unrecognized
     }
     guard admission.isAdmitted() else {
-      restoreAdmission(
-        of: oldAdmission, components: validation.verifiedComponents, at: oldDirectory)
+      restoreAdmission(of: oldAdmission)
       return .unrecognized
     }
 
@@ -455,14 +453,15 @@ public struct ModelRelocationMigrator: Sendable {
   ///
   /// Best-effort by nature: if re-admission ALSO fails we are on a filesystem that is
   /// refusing writes, and the bytes are still there to be re-validated (and
-  /// re-admitted) on the next launch. We never delete anything on this path.
-  private func restoreAdmission(
-    of admission: CacheAdmission, components: Set<String>, at directory: URL
-  ) {
-    try? admission.promoteAndAdmit(
-      stagedComponents: [],
-      stagingDirectory: directory,
-      untouchedComponents: components)
+  /// re-admitted) on the next launch.
+  ///
+  /// Stamps the marker ONLY — it must NOT run a full promotion. Promotion prunes every
+  /// entry the manifest does not name, so recovering the source's admission that way
+  /// would delete the user's unrelated files from the legacy directory: the recovery
+  /// path breaking the very preservation guarantee the rest of this type enforces
+  /// (Codex PR-1 review r18). Nothing on this path deletes anything, ever.
+  private func restoreAdmission(of admission: CacheAdmission) {
+    try? admission.stampAdmissionForVerifiedSet()
   }
 
   /// Delete a retired downloader's scratch files from an old location.

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -70,19 +70,27 @@ public struct ModelRelocationMigrator: Sendable {
     /// same-named file we did not ship is a stranger's, and strangers are never
     /// deleted (the provenance rule — Codex PR-1 review P2).
     public let trustedLegacyArtifacts: [TrustedLegacyArtifact]
+    /// Filename suffixes of a retired downloader's scratch files (e.g.
+    /// `[".partial", ".resume.json"]`). Swept from the old locations during
+    /// migration — once the install directory moves, nothing else will ever look
+    /// there again, so an interrupted multi-GB download would be stranded on the
+    /// user's disk forever. NEVER a model suffix: only genuine scratch.
+    public let staleSidecarSuffixes: [String]
 
     public init(
       manifest: DeliveryManifest,
       oldLocations: [URL],
       destination: URL,
       metadataDirectory: URL,
-      trustedLegacyArtifacts: [TrustedLegacyArtifact] = []
+      trustedLegacyArtifacts: [TrustedLegacyArtifact] = [],
+      staleSidecarSuffixes: [String] = []
     ) {
       self.manifest = manifest
       self.oldLocations = oldLocations
       self.destination = destination
       self.metadataDirectory = metadataDirectory
       self.trustedLegacyArtifacts = trustedLegacyArtifacts
+      self.staleSidecarSuffixes = staleSidecarSuffixes
     }
   }
 
@@ -142,6 +150,16 @@ public struct ModelRelocationMigrator: Sendable {
       oldDirectory.standardizedFileURL != plan.destination.standardizedFileURL
     else { return .noop }
 
+    // Stale download sidecars from a retired downloader (an interrupted
+    // multi-GB `.partial` and its resume file) are stranded the moment the
+    // install directory moves: the engine only ever sweeps its CURRENT dir, so
+    // nothing would ever look here again. Left behind, they silently cost the
+    // user gigabytes and can fail the replacement download's disk preflight.
+    // Swept before classification, because the trusted-legacy path returns
+    // early and that is exactly the case where a stranded partial exists.
+    // Never a model file — only the named sidecar suffixes.
+    sweepStaleSidecars(in: oldDirectory, plan: plan)
+
     // A previously-shipped layout we recognize: do NOT move it, do NOT load it,
     // do NOT delete it. Record the token and let the caller replace it.
     if let legacy = await trustedLegacyArtifact(in: oldDirectory, plan: plan) {
@@ -186,8 +204,18 @@ public struct ModelRelocationMigrator: Sendable {
     }
     guard admission.isAdmitted() else { return .unrecognized }
 
-    // Only now is the old home provably redundant.
-    try? fm.removeItem(at: oldDirectory)
+    // Only now is the old copy provably redundant — and only the parts of it we
+    // actually reproduced. Deleting the whole directory would take anything ELSE
+    // in it with us: a foreign model, a user's own file, something we never
+    // validated and never copied. We do not delete what we cannot account for
+    // (Codex PR-1 review r3 P1).
+    for root in CacheAdmission.componentRoots(of: plan.manifest).sorted() {
+      try? fm.removeItem(at: oldDirectory.appendingPathComponent(root))
+    }
+    // The directory itself goes only if nothing of the user's remains in it.
+    if let remaining = try? fm.contentsOfDirectory(atPath: oldDirectory.path), remaining.isEmpty {
+      try? fm.removeItem(at: oldDirectory)
+    }
     return .relocated
   }
 
@@ -239,6 +267,22 @@ public struct ModelRelocationMigrator: Sendable {
   }
 
   // MARK: - Internals
+
+  /// Delete a retired downloader's scratch files from an old location.
+  ///
+  /// Strictly suffix-matched, and the suffixes are scratch-only — a model file
+  /// is never a candidate. This is the one thing we DO delete from the old home
+  /// without proving a digest, because a `.partial` is by definition an
+  /// incomplete artifact that nothing can load, and leaving it costs the user
+  /// gigabytes that no future code path will ever reclaim.
+  private func sweepStaleSidecars(in directory: URL, plan: RelocationPlan) {
+    guard !plan.staleSidecarSuffixes.isEmpty,
+      let entries = try? FileManager.default.contentsOfDirectory(atPath: directory.path)
+    else { return }
+    for entry in entries where plan.staleSidecarSuffixes.contains(where: { entry.hasSuffix($0) }) {
+      try? FileManager.default.removeItem(at: directory.appendingPathComponent(entry))
+    }
+  }
 
   /// A previously-shipped artifact in `directory` that we can PROVE is ours.
   ///

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -395,11 +395,29 @@ public struct ModelRelocationMigrator: Sendable {
   ///
   /// No-op when nothing is pending (an ordinary Remove with no legacy artifact).
   public func markLegacyForRemoval(_ plan: RelocationPlan) {
+    setIntent(.remove, plan: plan)
+  }
+
+  /// The user took the removal back (they re-selected the model). The stranded
+  /// artifact is owed a REPLACEMENT again, not a delete.
+  ///
+  /// Without this, `removalPending` is cleared in memory but the durable token still
+  /// reads `.remove` — so a failed replacement download followed by a relaunch would
+  /// delete the model the user had just re-chosen (Codex PR-1 review r13). The
+  /// in-memory flag and the durable intent must move together or they will disagree
+  /// exactly when a crash makes it matter.
+  public func markLegacyForReplacement(_ plan: RelocationPlan) {
+    setIntent(.replace, plan: plan)
+  }
+
+  /// No-op when nothing is pending, when the token belongs to another revision, or
+  /// when the intent already matches.
+  private func setIntent(_ intent: LegacyIntent, plan: RelocationPlan) {
     guard var token = readToken(plan: plan),
       token.manifestDigest == plan.manifest.manifestDigest,
-      token.intent != .remove
+      token.intent != intent
     else { return }
-    token.intent = .remove
+    token.intent = intent
     writeToken(token, plan: plan)
   }
 

--- a/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelRelocationMigrator.swift
@@ -159,7 +159,17 @@ public struct ModelRelocationMigrator: Sendable {
 
     // Destination already good — the common case on every launch after the
     // first. Cheap marker check, no rehash.
-    if admission.isAdmitted() { return .noop }
+    //
+    // NOT a bare early-return: a crash between `promoteAndAdmit` (which writes the
+    // destination marker) and the old-copy cleanup below would land here forever
+    // after, leaving a duplicate multi-GB model in the old home that nothing ever
+    // revisits. Because the destination IS admitted, any of OUR components still
+    // sitting in an old location are provably redundant, so finish the job that
+    // crash interrupted (Codex PR-1 review r7).
+    if admission.isAdmitted() {
+      reconcileOldLocations(plan)
+      return .noop
+    }
 
     guard let oldDirectory = plan.oldLocations.first(where: { fm.fileExists(atPath: $0.path) }),
       oldDirectory.standardizedFileURL != plan.destination.standardizedFileURL
@@ -219,19 +229,40 @@ public struct ModelRelocationMigrator: Sendable {
     }
     guard admission.isAdmitted() else { return .unrecognized }
 
-    // Only now is the old copy provably redundant — and only the parts of it we
-    // actually reproduced. Deleting the whole directory would take anything ELSE
-    // in it with us: a foreign model, a user's own file, something we never
-    // validated and never copied. We do not delete what we cannot account for
-    // (Codex PR-1 review r3 P1).
-    for root in CacheAdmission.componentRoots(of: plan.manifest).sorted() {
-      try? fm.removeItem(at: oldDirectory.appendingPathComponent(root))
-    }
-    // The directory itself goes only if nothing of the user's remains in it.
-    if let remaining = try? fm.contentsOfDirectory(atPath: oldDirectory.path), remaining.isEmpty {
-      try? fm.removeItem(at: oldDirectory)
-    }
+    // Only now is the old copy provably redundant.
+    reconcileOldLocations(plan)
     return .relocated
+  }
+
+  /// Drop the parts of an old location that the ADMITTED destination has made
+  /// redundant. Safe to run at any time once the destination is admitted, which is
+  /// exactly why it is also the crash-recovery path: a process that died between
+  /// admitting the destination and cleaning the source resumes here on its next
+  /// launch instead of leaving a duplicate multi-GB model behind forever.
+  ///
+  /// Removes ONLY the component roots we reproduced. Deleting the whole directory
+  /// would take anything else in it with us — a foreign model, a user's own file,
+  /// something we never validated and never copied — and we do not delete what we
+  /// cannot account for. The directory itself goes only when nothing of the user's
+  /// remains in it. A trusted-legacy artifact is deliberately NOT touched here: its
+  /// deletion is governed by the durable token, never by this sweep.
+  private func reconcileOldLocations(_ plan: RelocationPlan) {
+    let fm = FileManager.default
+    let roots = CacheAdmission.componentRoots(of: plan.manifest).sorted()
+    for oldDirectory in plan.oldLocations {
+      guard oldDirectory.standardizedFileURL != plan.destination.standardizedFileURL,
+        fm.fileExists(atPath: oldDirectory.path)
+      else { continue }
+      sweepStaleSidecars(in: oldDirectory, plan: plan)
+      for root in roots {
+        try? fm.removeItem(at: oldDirectory.appendingPathComponent(root))
+      }
+      if let remaining = try? fm.contentsOfDirectory(atPath: oldDirectory.path),
+        remaining.isEmpty
+      {
+        try? fm.removeItem(at: oldDirectory)
+      }
+    }
   }
 
   // MARK: - Legacy cleanup (runs ONLY after the replacement is admitted)

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -244,4 +244,27 @@ import Testing
     #expect(EGOneDeliveryAdapter.mapFailure(.permissionDenied) == .http)
     #expect(EGOneDeliveryAdapter.mapFailure(.unknown) == .http)
   }
+
+  /// The kill switch is the operational rollback control: with it off, NOTHING may
+  /// mutate model bytes. #1386's relocation runs before every other delivery call,
+  /// so the composition root has to be able to read the flag BEFORE it starts —
+  /// otherwise the migrator would move and delete files precisely when someone had
+  /// reached for the lever to stop exactly that. (Codex PR-1 review r8.)
+  @Test func killSwitchIsReadableBeforeAnyRelocationRuns() throws {
+    let suite = "eg1-killswitch-\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suite))
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let key = DeliveryFlags.key("enabled", family: .egOne)
+
+    // Default (unset) is enabled — a fresh install migrates.
+    #expect(EGOneDeliveryAdapter.isDeliveryEnabled(defaults: defaults))
+
+    defaults.set(false, forKey: key)
+    #expect(
+      EGOneDeliveryAdapter.isDeliveryEnabled(defaults: defaults) == false,
+      "with delivery disabled the relocation must not run at all")
+
+    defaults.set(true, forKey: key)
+    #expect(EGOneDeliveryAdapter.isDeliveryEnabled(defaults: defaults))
+  }
 }

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -325,6 +325,30 @@ import Testing
     #expect(exists(dirs.old.appendingPathComponent("eg-1-v1.gguf")))
   }
 
+  /// The sweep may only reclaim scratch belonging to an artifact WE know. Someone
+  /// else's interrupted download happens to end in `.partial` too — it is not ours
+  /// to delete, and a bare suffix match would have taken it. (Codex PR-1 review r4.)
+  @Test func sidecarSweepNeverReclaimsAnotherModelsScratch() async throws {
+    let dirs = try makeDirs()
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
+    try write(Data(repeating: 0x7, count: 64), under: dirs.old, path: "eg-1-v1.gguf.partial")
+    // Not ours: a different model's interrupted download, same suffix.
+    let stranger = dirs.old.appendingPathComponent("custom-model.gguf.partial")
+    try write(Data(repeating: 0x9, count: 64), under: dirs.old, path: "custom-model.gguf.partial")
+    let p = ModelRelocationMigrator.RelocationPlan(
+      manifest: try ManifestFixture.manifest(files: ManifestFixture.smallFiles),
+      oldLocations: [dirs.old],
+      destination: dirs.new,
+      metadataDirectory: dirs.metadata,
+      trustedLegacyArtifacts: [Self.legacyArtifact],
+      staleSidecarSuffixes: [".partial", ".resume.json"])
+
+    _ = await ModelRelocationMigrator().migrate(p)
+
+    #expect(!exists(dirs.old.appendingPathComponent("eg-1-v1.gguf.partial")), "ours is reclaimed")
+    #expect(exists(stranger), "another model's scratch is not ours to delete")
+  }
+
   // MARK: - Unrecognized (never ours, never touched)
 
   /// Bytes that match neither the current manifest nor a layout we shipped are

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -271,6 +271,60 @@ import Testing
     #expect(gate.isAdmitted())
   }
 
+  /// Relocation must remove only what it actually reproduced. The old directory
+  /// can hold things that are not ours — a foreign model, a user's own file —
+  /// and deleting the whole directory would take them with it. (Codex PR-1
+  /// review r3 P1.)
+  @Test func relocationNeverDeletesUnrelatedFilesInTheOldDirectory() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: dirs.old, path: f.path) }
+    // Something of the user's, sitting in the same folder. Not ours, never
+    // validated, never copied.
+    let bystander = dirs.old.appendingPathComponent("someone-elses-model.gguf")
+    try write(Data("not ours".utf8), under: dirs.old, path: "someone-elses-model.gguf")
+    let p = try plan(files: files, dirs: dirs)
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+
+    #expect(outcome == .relocated)
+    #expect(exists(bystander), "a file we never validated must survive relocation")
+    // What we DID reproduce is gone from the old home.
+    for f in files {
+      #expect(!exists(dirs.old.appendingPathComponent(f.path)))
+    }
+    // The directory itself survives precisely because the bystander is still in it.
+    #expect(exists(dirs.old))
+  }
+
+  /// A retired downloader's scratch files are stranded the moment the install
+  /// directory moves — nothing will ever look in the old home again. They must be
+  /// swept, including on the trusted-legacy path, which is exactly the case where
+  /// an interrupted multi-GB `.partial` exists. (Codex PR-1 review r3 P2 / #1363.)
+  @Test func staleDownloadSidecarsAreSweptFromTheOldHome() async throws {
+    let dirs = try makeDirs()
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
+    // An interrupted download from the retired store, plus its resume file.
+    try write(Data(repeating: 0x7, count: 4096), under: dirs.old, path: "eg-1-v1.gguf.partial")
+    try write(Data("{}".utf8), under: dirs.old, path: "eg-1-v1.gguf.resume.json")
+    let p = ModelRelocationMigrator.RelocationPlan(
+      manifest: try ManifestFixture.manifest(files: ManifestFixture.smallFiles),
+      oldLocations: [dirs.old],
+      destination: dirs.new,
+      metadataDirectory: dirs.metadata,
+      trustedLegacyArtifacts: [Self.legacyArtifact],
+      staleSidecarSuffixes: [".partial", ".resume.json"])
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+
+    #expect(outcome == .trustedLegacyPending(dirs.old.appendingPathComponent("eg-1-v1.gguf")))
+    #expect(!exists(dirs.old.appendingPathComponent("eg-1-v1.gguf.partial")), "partial reclaimed")
+    #expect(
+      !exists(dirs.old.appendingPathComponent("eg-1-v1.gguf.resume.json")), "resume reclaimed")
+    // The MODEL is not scratch: it survives, awaiting its verified replacement.
+    #expect(exists(dirs.old.appendingPathComponent("eg-1-v1.gguf")))
+  }
+
   // MARK: - Unrecognized (never ours, never touched)
 
   /// Bytes that match neither the current manifest nor a layout we shipped are

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -622,6 +622,45 @@ import Testing
       "re-classification must not resurrect a model the user removed")
   }
 
+  /// The delete itself can FAIL — a read-only parent directory, a permissions problem.
+  /// When it does, the token MUST survive: it is the only record that a cleanup is
+  /// still owed, and without it the legacy model is stranded forever. The next launch
+  /// retries from it.
+  ///
+  /// This is the migrator half of the runtime's cleanup-failure branch (which is not
+  /// unit-testable — see the PR's named gap).
+  @Test func aFailedDeleteRetainsTheTokenForRetry() async throws {
+    let dirs = try makeDirs()
+    let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+    _ = await migrator.migrate(p)
+    #expect(migrator.pendingLegacyArtifact(p) == monolith)
+
+    // Unlinking a file needs write permission on its PARENT — deny it.
+    try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dirs.old.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o700], ofItemAtPath: dirs.old.path)
+    }
+
+    await #expect(throws: (any Error).self) {
+      try await migrator.cleanUpLegacy(p)
+    }
+
+    #expect(exists(monolith), "the artifact survives a failed delete")
+    #expect(
+      migrator.pendingLegacyArtifact(p) == monolith,
+      "and the token MUST survive it too, or the model is stranded forever")
+
+    // Permissions restored: the retry succeeds and clears the token.
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dirs.old.path)
+    try await migrator.cleanUpLegacy(p)
+    #expect(!exists(monolith))
+    #expect(migrator.pendingLegacyArtifact(p) == nil)
+  }
+
   /// Marking a removal when nothing is pending is a plain no-op — an ordinary
   /// Remove on a machine with no legacy artifact must not invent one.
   @Test func markingRemovalWithNoPendingArtifactIsANoop() async throws {

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -286,6 +286,37 @@ import Testing
     }
   }
 
+  /// Crash-recovery cleanup must still EARN its deletions. If the old directory
+  /// holds corrupt or hand-replaced bytes under a name the manifest happens to use,
+  /// deleting them because the name lines up is the provenance rule broken by the
+  /// very code that enforces it. (Codex PR-1 review r11.)
+  @Test func recoveryCleanupNeverDeletesUnverifiedBytesUnderAMatchingName() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    // Destination: the real, admitted model.
+    for f in files { try write(f.content, under: dirs.new, path: f.path) }
+    let p = try plan(files: files, dirs: dirs)
+    let gate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.new, metadataDirectory: dirs.metadata)
+    let validation = await gate.validateExistingCache()
+    try gate.promoteAndAdmit(
+      stagedComponents: [], stagingDirectory: dirs.new,
+      untouchedComponents: validation.verifiedComponents)
+    #expect(gate.isAdmitted())
+
+    // Old home: bytes that are NOT ours, wearing a manifest filename.
+    let victim = files[0]
+    try write(Data("not the bytes we shipped".utf8), under: dirs.old, path: victim.path)
+    let impostor = dirs.old.appendingPathComponent(victim.path)
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+
+    #expect(outcome == .noop)
+    #expect(
+      exists(impostor),
+      "unverified bytes must survive cleanup even when their filename matches ours")
+  }
+
   /// An already-admitted destination is the common case on every launch after
   /// the first: cheap no-op, no rehash, nothing touched.
   @Test func admittedDestinationIsANoop() async throws {

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -349,6 +349,45 @@ import Testing
     #expect(exists(stranger), "another model's scratch is not ours to delete")
   }
 
+  /// A Remove during the transition retires the pending REPLACEMENT. If the legacy
+  /// delete then fails, the next launch must finish the DELETE and fetch nothing —
+  /// otherwise we would see the stranded file, conclude a replacement was owed, and
+  /// silently re-download gigabytes of a model the user explicitly threw away.
+  /// (Found while fixing Codex PR-1 review r6.)
+  @Test func removeRetiresThePendingReplacementSoNothingIsResurrected() async throws {
+    let dirs = try makeDirs()
+    let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+    _ = await migrator.migrate(p)
+    #expect(migrator.pendingLegacyIntent(p) == .replace)
+
+    // The user hits Remove.
+    migrator.markLegacyForRemoval(p)
+
+    #expect(
+      migrator.pendingLegacyIntent(p) == .remove,
+      "a Remove must retire the replacement, not merely defer it")
+    // The next launch honors the delete...
+    try await migrator.cleanUpLegacy(p)
+    #expect(!exists(monolith))
+    #expect(migrator.pendingLegacyIntent(p) == nil, "and nothing remains pending to re-fetch")
+  }
+
+  /// Marking a removal when nothing is pending is a plain no-op — an ordinary
+  /// Remove on a machine with no legacy artifact must not invent one.
+  @Test func markingRemovalWithNoPendingArtifactIsANoop() async throws {
+    let dirs = try makeDirs()
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+
+    migrator.markLegacyForRemoval(p)
+
+    #expect(migrator.pendingLegacyIntent(p) == nil)
+    #expect(migrator.pendingLegacyArtifact(p) == nil)
+  }
+
   // MARK: - Unrecognized (never ours, never touched)
 
   /// Bytes that match neither the current manifest nor a layout we shipped are

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -355,6 +355,60 @@ import Testing
     }
   }
 
+  /// A failed promotion must not silently un-admit an intact source.
+  ///
+  /// There is one admission marker per model, and promotion deletes it before doing
+  /// work that can throw. If that work fails, the source's bytes are still perfect —
+  /// but nothing that picks by ADMISSION (including the kill-switch fallback) can
+  /// find them any more, so EG-1 would report unavailable with a flawless copy
+  /// sitting right there. (Codex PR-1 review r17.)
+  @Test func failedPromotionRestoresTheSourceAdmission() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: dirs.old, path: f.path) }
+    let p = try plan(files: files, dirs: dirs)
+
+    // The source starts out admitted (a machine that downloaded before this change).
+    let sourceGate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.old, metadataDirectory: dirs.metadata)
+    let validation = await sourceGate.validateExistingCache()
+    try sourceGate.promoteAndAdmit(
+      stagedComponents: [], stagingDirectory: dirs.old,
+      untouchedComponents: validation.verifiedComponents)
+    #expect(sourceGate.isAdmitted())
+
+    // Make PROMOTION fail — not the copy. Promotion prunes orphans (anything in the
+    // destination the manifest does not name), so an orphan directory we cannot
+    // delete throws from inside promoteAndAdmit, AFTER it has already dropped the
+    // shared admission marker. That is precisely the window this test exists for.
+    try FileManager.default.createDirectory(at: dirs.new, withIntermediateDirectories: true)
+    let orphan = dirs.new.appendingPathComponent("not-in-the-manifest", isDirectory: true)
+    try FileManager.default.createDirectory(at: orphan, withIntermediateDirectories: true)
+    try write(Data("x".utf8), under: orphan, path: "stuck.bin")
+    // No write permission on the orphan dir: its contents cannot be removed.
+    try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: orphan.path)
+    defer {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: orphan.path)
+    }
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+
+    #expect(outcome != .relocated)
+    #expect(
+      sourceGate.isAdmitted(),
+      "an intact source must remain ADMITTED when promotion fails, or the fallback cannot find it")
+    // The invariant that actually matters: SOME usable copy is still findable by
+    // admission. (The destination may also validate here — the clone succeeded and
+    // only the orphan prune failed — and loading from it is perfectly fine. What must
+    // never happen is BOTH going un-admitted, which is what leaves EG-1 unavailable
+    // with a flawless model on disk.)
+    #expect(
+      ModelRelocationMigrator.admittedLocation(
+        manifest: p.manifest, candidates: [dirs.new, dirs.old],
+        metadataDirectory: dirs.metadata) != nil,
+      "the fallback must still find a usable copy after a failed promotion")
+  }
+
   /// An already-admitted destination is the common case on every launch after
   /// the first: cheap no-op, no rehash, nothing touched.
   @Test func admittedDestinationIsANoop() async throws {

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Testing
 
@@ -28,10 +29,21 @@ import Testing
     try content.write(to: url)
   }
 
+  /// The bytes of the previously-shipped layout, and the descriptor that proves
+  /// they are ours. Identity is the DIGEST — the filename is only a lookup key.
+  private static let legacyBytes = Data("the-model-we-actually-shipped".utf8)
+
+  private static var legacyArtifact: ModelRelocationMigrator.TrustedLegacyArtifact {
+    .init(
+      name: "eg-1-v1.gguf",
+      sizeBytes: Int64(legacyBytes.count),
+      sha256: SHA256.hash(data: legacyBytes).map { String(format: "%02x", $0) }.joined())
+  }
+
   private func plan(
     files: [(path: String, content: Data, component: String)],
     dirs: (old: URL, new: URL, metadata: URL),
-    legacy: [String] = ["eg-1-v1.gguf"]
+    legacy: [ModelRelocationMigrator.TrustedLegacyArtifact] = [legacyArtifact]
   ) throws -> ModelRelocationMigrator.RelocationPlan {
     ModelRelocationMigrator.RelocationPlan(
       manifest: try ManifestFixture.manifest(files: files),
@@ -53,7 +65,7 @@ import Testing
   @Test func trustedLegacyMonolithIsRecordedAndLeftUntouched() async throws {
     let dirs = try makeDirs()
     let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
-    try write(Data("shipped-model-bytes".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
     let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
     let migrator = ModelRelocationMigrator()
 
@@ -74,7 +86,7 @@ import Testing
   /// next launch can retry rather than losing the only copy.
   @Test func pendingTokenSurvivesRelaunchWhenReplacementNeverArrives() async throws {
     let dirs = try makeDirs()
-    try write(Data("shipped-model-bytes".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
     let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
 
     _ = await ModelRelocationMigrator().migrate(p)
@@ -89,7 +101,7 @@ import Testing
   @Test func cleanUpLegacyDeletesTheArtifactAndIsIdempotent() async throws {
     let dirs = try makeDirs()
     let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
-    try write(Data("shipped-model-bytes".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
     let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
     let migrator = ModelRelocationMigrator()
     _ = await migrator.migrate(p)
@@ -108,7 +120,7 @@ import Testing
   @Test func tokenFromAnotherRevisionNeverAuthorizesADelete() async throws {
     let dirs = try makeDirs()
     let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
-    try write(Data("shipped-model-bytes".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
     let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
     let migrator = ModelRelocationMigrator()
     _ = await migrator.migrate(p)
@@ -122,7 +134,96 @@ import Testing
     #expect(exists(monolith), "a foreign-revision token must not delete our bytes")
   }
 
+  /// The filename is NOT identity. A file sitting at the legacy path with the
+  /// legacy NAME but bytes we never shipped — corrupt, truncated, hand-swapped,
+  /// or someone else's — must fail the digest and be treated as a stranger:
+  /// never tokenized, never deleted. (Codex PR-1 review P2.)
+  @Test func sameNamedFileWeDidNotShipIsNeverTrustedAndNeverDeleted() async throws {
+    let dirs = try makeDirs()
+    let impostor = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Data("NOT the bytes we shipped".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+
+    let outcome = await migrator.migrate(p)
+
+    #expect(outcome == .unrecognized, "a same-named file we did not ship is not ours")
+    #expect(migrator.pendingLegacyArtifact(p) == nil, "and must never be marked for deletion")
+    // Even if a caller ignored the outcome and ran cleanup anyway, the absent
+    // token means nothing is deleted.
+    try migrator.cleanUpLegacy(p)
+    #expect(exists(impostor), "bytes we cannot prove are ours are never deleted")
+  }
+
+  /// If the legacy file CHANGES between classification and cleanup, it is no
+  /// longer the artifact we proved was ours — so we leave it alone rather than
+  /// delete something we can no longer identify.
+  @Test func legacyArtifactMutatedAfterClassificationIsNotDeleted() async throws {
+    let dirs = try makeDirs()
+    let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+    _ = await migrator.migrate(p)
+    #expect(migrator.pendingLegacyArtifact(p) != nil)
+
+    // Something replaced the file after we classified it.
+    try write(Data("swapped out from under us".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    try migrator.cleanUpLegacy(p)
+
+    #expect(exists(monolith), "a changed artifact is no longer identifiable as ours")
+    #expect(migrator.pendingLegacyArtifact(p) == nil, "and the stale token is dropped")
+  }
+
   // MARK: - Relocatable (a dev machine whose shards already sit in the old home)
+
+  /// The source must remain a COMPLETE, valid fallback until the destination is
+  /// admitted. A relocation that removed components from the source as it went
+  /// would leave both sides partial on a crash, turning a good model into an
+  /// `unrecognized` one and forcing a re-download. (Codex PR-1 review P2.)
+  ///
+  /// Proven by interrupting: pre-create a DIRECTORY at one component's
+  /// destination path so its copy fails, then assert the source is still whole.
+  @Test func interruptedRelocationLeavesTheSourceComplete() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: dirs.old, path: f.path) }
+    let p = try plan(files: files, dirs: dirs)
+
+    // Block the LAST component in the (deterministic, sorted) relocation order,
+    // so at least one component has already been reproduced at the destination
+    // when the failure hits. Blocking the FIRST would prove nothing: a
+    // move-based relocation that fails immediately never touches the source, so
+    // the test would pass against the very bug it exists to catch.
+    let victimRoot = CacheAdmission.componentRoots(of: p.manifest).sorted().last!
+    let blocker = dirs.new.appendingPathComponent(victimRoot, isDirectory: true)
+    try FileManager.default.createDirectory(at: blocker, withIntermediateDirectories: true)
+    try write(Data("blocker".utf8), under: blocker, path: "occupied/blocker.bin")
+    // Deny writes so removeItem/copy into it fails.
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o500], ofItemAtPath: blocker.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o700], ofItemAtPath: blocker.path)
+    }
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+
+    // Whatever the outcome, the invariant is absolute: the source still holds a
+    // complete, valid copy, so the next launch can retry from it.
+    #expect(outcome != .relocated)
+    for f in files {
+      #expect(
+        exists(dirs.old.appendingPathComponent(f.path)),
+        "source must stay complete when relocation cannot finish")
+    }
+    let sourceGate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.old, metadataDirectory: dirs.metadata)
+    let validation = await sourceGate.validateExistingCache()
+    #expect(
+      validation.failedComponents.isEmpty,
+      "the source must still validate against the manifest — it is the fallback")
+  }
 
   /// Bytes that satisfy the CURRENT manifest are moved, re-admitted at the new
   /// home, and the old home is dropped — with zero fetch.

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -391,12 +391,22 @@ import Testing
       try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: orphan.path)
     }
 
+    // Something of the user's, in the legacy directory. The RECOVERY path must not
+    // touch it: re-admitting the source by running a full promotion would prune every
+    // unlisted entry and delete this (Codex PR-1 review r18) — the recovery breaking
+    // the preservation guarantee the rest of the migrator enforces.
+    let bystander = dirs.old.appendingPathComponent("users-own-file.bin")
+    try write(Data("mine".utf8), under: dirs.old, path: "users-own-file.bin")
+
     let outcome = await ModelRelocationMigrator().migrate(p)
 
     #expect(outcome != .relocated)
     #expect(
       sourceGate.isAdmitted(),
       "an intact source must remain ADMITTED when promotion fails, or the fallback cannot find it")
+    #expect(
+      exists(bystander),
+      "restoring admission must not delete unrelated files from the legacy directory")
     // The invariant that actually matters: SOME usable copy is still findable by
     // admission. (The destination may also validate here — the clone succeeded and
     // only the orphan prune failed — and loading from it is perfectly fine. What must

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -317,6 +317,44 @@ import Testing
       "unverified bytes must survive cleanup even when their filename matches ours")
   }
 
+  /// A proof about ONE directory says nothing about the bytes in another. When a
+  /// plan lists several old locations, the relocation source's validation must not
+  /// authorize deletions in the others — those earn their own. EG-1 ships one old
+  /// location today, so this is the API being made safe BEFORE the remaining engines
+  /// add a second. (Codex PR-1 review r12.)
+  @Test func proofForOneOldLocationNeverAuthorizesDeletionInAnother() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    // Old location A: the genuine copy (this becomes the relocation source).
+    for f in files { try write(f.content, under: dirs.old, path: f.path) }
+    // Old location B: same filenames, bytes we never shipped.
+    let otherOld = dirs.old.deletingLastPathComponent()
+      .appendingPathComponent("PolishModels-2", isDirectory: true)
+    try FileManager.default.createDirectory(at: otherOld, withIntermediateDirectories: true)
+    for f in files {
+      try write(Data("not the bytes we shipped".utf8), under: otherOld, path: f.path)
+    }
+
+    let p = ModelRelocationMigrator.RelocationPlan(
+      manifest: try ManifestFixture.manifest(files: files),
+      oldLocations: [dirs.old, otherOld],
+      destination: dirs.new,
+      metadataDirectory: dirs.metadata,
+      trustedLegacyArtifacts: [Self.legacyArtifact])
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+
+    #expect(outcome == .relocated)
+    // The proven source is cleaned up...
+    for f in files { #expect(!exists(dirs.old.appendingPathComponent(f.path))) }
+    // ...while the OTHER location's unverified bytes survive untouched.
+    for f in files {
+      #expect(
+        exists(otherOld.appendingPathComponent(f.path)),
+        "a proof about one directory must never authorize deleting another's bytes")
+    }
+  }
+
   /// An already-admitted destination is the common case on every launch after
   /// the first: cheap no-op, no rehash, nothing touched.
   @Test func admittedDestinationIsANoop() async throws {

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -106,12 +106,12 @@ import Testing
     let migrator = ModelRelocationMigrator()
     _ = await migrator.migrate(p)
 
-    try migrator.cleanUpLegacy(p)
+    try await migrator.cleanUpLegacy(p)
     #expect(!exists(monolith))
     #expect(migrator.pendingLegacyArtifact(p) == nil)
 
     // Second run: already-absent artifact, already-cleared token. No throw.
-    try migrator.cleanUpLegacy(p)
+    try await migrator.cleanUpLegacy(p)
     #expect(migrator.pendingLegacyArtifact(p) == nil)
   }
 
@@ -129,7 +129,7 @@ import Testing
     let otherRevision = try plan(
       files: [(path: "vocab.json", content: Data("different".utf8), component: "vocab.json")],
       dirs: dirs)
-    try migrator.cleanUpLegacy(otherRevision)
+    try await migrator.cleanUpLegacy(otherRevision)
 
     #expect(exists(monolith), "a foreign-revision token must not delete our bytes")
   }
@@ -151,14 +151,19 @@ import Testing
     #expect(migrator.pendingLegacyArtifact(p) == nil, "and must never be marked for deletion")
     // Even if a caller ignored the outcome and ran cleanup anyway, the absent
     // token means nothing is deleted.
-    try migrator.cleanUpLegacy(p)
+    try await migrator.cleanUpLegacy(p)
     #expect(exists(impostor), "bytes we cannot prove are ours are never deleted")
   }
 
   /// If the legacy file CHANGES between classification and cleanup, it is no
   /// longer the artifact we proved was ours — so we leave it alone rather than
   /// delete something we can no longer identify.
-  @Test func legacyArtifactMutatedAfterClassificationIsNotDeleted() async throws {
+  ///
+  /// The replacement is deliberately the SAME BYTE COUNT as the original. A
+  /// size-only guard passes here and deletes the file; only re-hashing catches
+  /// it. That is the whole finding (Codex PR-1 review r2), and classification
+  /// happens a whole model-download before the delete, so the window is real.
+  @Test func sameSizeMutationBetweenClassificationAndCleanupIsNotDeleted() async throws {
     let dirs = try makeDirs()
     let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
     try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
@@ -167,12 +172,16 @@ import Testing
     _ = await migrator.migrate(p)
     #expect(migrator.pendingLegacyArtifact(p) != nil)
 
-    // Something replaced the file after we classified it.
-    try write(Data("swapped out from under us".utf8), under: dirs.old, path: "eg-1-v1.gguf")
-    try migrator.cleanUpLegacy(p)
+    // Same length, different bytes — invisible to a byte-count check.
+    let impostor = Data(repeating: 0x41, count: Self.legacyBytes.count)
+    #expect(impostor.count == Self.legacyBytes.count)
+    try write(impostor, under: dirs.old, path: "eg-1-v1.gguf")
 
-    #expect(exists(monolith), "a changed artifact is no longer identifiable as ours")
-    #expect(migrator.pendingLegacyArtifact(p) == nil, "and the stale token is dropped")
+    try await migrator.cleanUpLegacy(p)
+
+    #expect(exists(monolith), "a same-size swap is still not the artifact we proved was ours")
+    #expect(try Data(contentsOf: monolith) == impostor, "and its bytes are untouched")
+    #expect(migrator.pendingLegacyArtifact(p) == nil, "the stale token is dropped")
   }
 
   // MARK: - Relocatable (a dev machine whose shards already sit in the old home)

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -422,6 +422,40 @@ import Testing
     #expect(migrator.pendingLegacyArtifact(p) == nil)
   }
 
+  /// Existence is not validity. A relocation that failed partway leaves a
+  /// half-populated destination beside an intact source; a disabled (kill-switched)
+  /// build must read from the ADMITTED one, not from whichever directory happens to
+  /// exist — otherwise the rollback breaks EG-1 in exactly the scenario it exists to
+  /// rescue. (Codex PR-1 review r10.)
+  @Test func admittedLocationIgnoresAHalfPopulatedDirectory() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    // Intact, admitted copy in the OLD home.
+    for f in files { try write(f.content, under: dirs.old, path: f.path) }
+    let manifest = try ManifestFixture.manifest(files: files)
+    let oldGate = CacheAdmission(
+      manifest: manifest, installDirectory: dirs.old, metadataDirectory: dirs.metadata)
+    let validation = await oldGate.validateExistingCache()
+    try oldGate.promoteAndAdmit(
+      stagedComponents: [], stagingDirectory: dirs.old,
+      untouchedComponents: validation.verifiedComponents)
+    #expect(oldGate.isAdmitted())
+
+    // The new home EXISTS but holds only part of the model — what a relocation that
+    // died halfway leaves behind.
+    try write(files[0].content, under: dirs.new, path: files[0].path)
+    #expect(exists(dirs.new))
+
+    let chosen = ModelRelocationMigrator.admittedLocation(
+      manifest: manifest,
+      candidates: [dirs.new, dirs.old],
+      metadataDirectory: dirs.metadata)
+
+    #expect(
+      chosen == dirs.old,
+      "must choose the admitted copy, not the directory that merely exists")
+  }
+
   // MARK: - Unrecognized (never ours, never touched)
 
   /// Bytes that match neither the current manifest nor a layout we shipped are

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -661,6 +661,37 @@ import Testing
     #expect(migrator.pendingLegacyArtifact(p) == nil)
   }
 
+  /// If the token cannot be PERSISTED, the classification must start nothing.
+  ///
+  /// An unjournaled replacement could never be admitted anyway — the token and the
+  /// admission marker share one metadata directory — and if it somehow did land, a later
+  /// Remove would have no token to flip, so the next launch would reclassify the monolith
+  /// as `.replace` and re-download a model the user deleted. Treated as absent: nothing
+  /// moved, nothing deleted, retry next launch. (GitHub cloud review, PR #1497.)
+  @Test func aClassificationThatCannotBeJournaledStartsNothing() async throws {
+    let dirs = try makeDirs()
+    let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+
+    // The metadata directory refuses writes — the token cannot be persisted.
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o500], ofItemAtPath: dirs.metadata.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o700], ofItemAtPath: dirs.metadata.path)
+    }
+
+    let migrator = ModelRelocationMigrator()
+    let outcome = await migrator.migrate(p)
+
+    #expect(
+      outcome == .unrecognized,
+      "an unjournaled classification must not drive a replacement")
+    #expect(migrator.pendingLegacyArtifact(p) == nil, "and nothing is pending")
+    #expect(exists(monolith), "the model is untouched — nothing moved, nothing deleted")
+  }
+
   /// Marking a removal when nothing is pending is a plain no-op — an ordinary
   /// Remove on a machine with no legacy artifact must not invent one.
   @Test func markingRemovalWithNoPendingArtifactIsANoop() async throws {

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -419,6 +419,40 @@ import Testing
       "the fallback must still find a usable copy after a failed promotion")
   }
 
+  /// The replacement can complete without a note ever being written (journalling is
+  /// allowed to fail — r17). If the admitted fast path then just returned, every later
+  /// launch would take it, and the 2.9 GB legacy model would sit on the user's disk
+  /// forever with nothing left that would ever look for it. The fast path must
+  /// re-journal a stranded artifact. (Codex PR-1 review r19.)
+  @Test func admittedDestinationStillJournalsAStrandedLegacyArtifact() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    // The replacement landed and is admitted...
+    for f in files { try write(f.content, under: dirs.new, path: f.path) }
+    let p = try plan(files: files, dirs: dirs)
+    let gate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.new, metadataDirectory: dirs.metadata)
+    let validation = await gate.validateExistingCache()
+    try gate.promoteAndAdmit(
+      stagedComponents: [], stagingDirectory: dirs.new,
+      untouchedComponents: validation.verifiedComponents)
+    #expect(gate.isAdmitted())
+
+    // ...but the legacy model is still there and NO token was ever written.
+    let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
+    let migrator = ModelRelocationMigrator()
+    #expect(migrator.pendingLegacyArtifact(p) == nil, "precondition: nothing journaled")
+
+    let outcome = await migrator.migrate(p)
+
+    #expect(outcome == .trustedLegacyPending(monolith))
+    #expect(
+      migrator.pendingLegacyArtifact(p) == monolith,
+      "a stranded artifact must be re-journaled, or it is stranded forever")
+    #expect(exists(monolith), "and it is still not deleted before its cleanup runs")
+  }
+
   /// An already-admitted destination is the common case on every launch after
   /// the first: cheap no-op, no rehash, nothing touched.
   @Test func admittedDestinationIsANoop() async throws {

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprModelDelivery
+
+/// Relocation tests (#1386 PR-1). The migrator's whole contract is about what
+/// SURVIVES a failure, so that is what these assert: old bytes are never
+/// deleted before a verified replacement is admitted, and bytes we cannot
+/// identify are never touched at all.
+@Suite struct ModelRelocationMigratorTests {
+
+  private func makeDirs() throws -> (old: URL, new: URL, metadata: URL) {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("reloc-\(UUID().uuidString)", isDirectory: true)
+    let old = root.appendingPathComponent("PolishModels", isDirectory: true)
+    let new = root.appendingPathComponent("Models/eg-1", isDirectory: true)
+    let metadata = root.appendingPathComponent("ModelDelivery", isDirectory: true)
+    for dir in [old, new, metadata] {
+      try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+    return (old, new, metadata)
+  }
+
+  private func write(_ content: Data, under root: URL, path: String) throws {
+    let url = root.appendingPathComponent(path)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try content.write(to: url)
+  }
+
+  private func plan(
+    files: [(path: String, content: Data, component: String)],
+    dirs: (old: URL, new: URL, metadata: URL),
+    legacy: [String] = ["eg-1-v1.gguf"]
+  ) throws -> ModelRelocationMigrator.RelocationPlan {
+    ModelRelocationMigrator.RelocationPlan(
+      manifest: try ManifestFixture.manifest(files: files),
+      oldLocations: [dirs.old],
+      destination: dirs.new,
+      metadataDirectory: dirs.metadata,
+      trustedLegacyArtifacts: legacy)
+  }
+
+  private func exists(_ url: URL) -> Bool {
+    FileManager.default.fileExists(atPath: url.path)
+  }
+
+  // MARK: - Trusted legacy (every shipped EG-1 user: a monolith, not the shards)
+
+  /// The founder-critical case. A previously-shipped monolith is OURS, but this
+  /// build cannot load it. It must be left exactly where it is — not moved, not
+  /// deleted — and a durable token must record that a replacement is owed.
+  @Test func trustedLegacyMonolithIsRecordedAndLeftUntouched() async throws {
+    let dirs = try makeDirs()
+    let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Data("shipped-model-bytes".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+
+    let outcome = await migrator.migrate(p)
+
+    #expect(outcome == .trustedLegacyPending(monolith))
+    #expect(exists(monolith), "the legacy model must survive classification")
+    #expect(migrator.pendingLegacyArtifact(p) == monolith)
+    // Nothing was fetched or admitted, so nothing may have been promoted.
+    let gate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.new, metadataDirectory: dirs.metadata)
+    #expect(gate.isAdmitted() == false)
+  }
+
+  /// Verify-before-delete, stated as a test: cleanup must be a no-op until the
+  /// replacement is actually admitted... and the caller is what enforces that.
+  /// Here we prove the token SURVIVES a migrate that admitted nothing, so the
+  /// next launch can retry rather than losing the only copy.
+  @Test func pendingTokenSurvivesRelaunchWhenReplacementNeverArrives() async throws {
+    let dirs = try makeDirs()
+    try write(Data("shipped-model-bytes".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+
+    _ = await ModelRelocationMigrator().migrate(p)
+    // A fresh migrator == a fresh process. The token is durable, not in-memory.
+    let afterRelaunch = ModelRelocationMigrator()
+    #expect(afterRelaunch.pendingLegacyArtifact(p) != nil)
+    #expect(exists(dirs.old.appendingPathComponent("eg-1-v1.gguf")))
+  }
+
+  /// Cleanup deletes the legacy bytes and clears the token. Idempotent: running
+  /// it again (a crash between delete and token-clear) must not throw.
+  @Test func cleanUpLegacyDeletesTheArtifactAndIsIdempotent() async throws {
+    let dirs = try makeDirs()
+    let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Data("shipped-model-bytes".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+    _ = await migrator.migrate(p)
+
+    try migrator.cleanUpLegacy(p)
+    #expect(!exists(monolith))
+    #expect(migrator.pendingLegacyArtifact(p) == nil)
+
+    // Second run: already-absent artifact, already-cleared token. No throw.
+    try migrator.cleanUpLegacy(p)
+    #expect(migrator.pendingLegacyArtifact(p) == nil)
+  }
+
+  /// A token minted against a DIFFERENT revision must never authorize a delete
+  /// under the current one — otherwise an EG-2 build could drop EG-1's bytes.
+  @Test func tokenFromAnotherRevisionNeverAuthorizesADelete() async throws {
+    let dirs = try makeDirs()
+    let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Data("shipped-model-bytes".utf8), under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+    _ = await migrator.migrate(p)
+
+    // Same cache key, different manifest digest (one file's bytes differ).
+    let otherRevision = try plan(
+      files: [(path: "vocab.json", content: Data("different".utf8), component: "vocab.json")],
+      dirs: dirs)
+    try migrator.cleanUpLegacy(otherRevision)
+
+    #expect(exists(monolith), "a foreign-revision token must not delete our bytes")
+  }
+
+  // MARK: - Relocatable (a dev machine whose shards already sit in the old home)
+
+  /// Bytes that satisfy the CURRENT manifest are moved, re-admitted at the new
+  /// home, and the old home is dropped — with zero fetch.
+  @Test func currentManifestBytesAreRelocatedAndReadmitted() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: dirs.old, path: f.path) }
+    let p = try plan(files: files, dirs: dirs)
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+
+    #expect(outcome == .relocated)
+    let gate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.new, metadataDirectory: dirs.metadata)
+    #expect(gate.isAdmitted(), "relocated bytes must be admitted at the new home")
+    for f in files { #expect(exists(dirs.new.appendingPathComponent(f.path))) }
+    #expect(!exists(dirs.old), "the old home is redundant once the new one is admitted")
+  }
+
+  /// An already-admitted destination is the common case on every launch after
+  /// the first: cheap no-op, no rehash, nothing touched.
+  @Test func admittedDestinationIsANoop() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: dirs.new, path: f.path) }
+    let p = try plan(files: files, dirs: dirs)
+    let gate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.new, metadataDirectory: dirs.metadata)
+    let validation = await gate.validateExistingCache()
+    try gate.promoteAndAdmit(
+      stagedComponents: [], stagingDirectory: dirs.new,
+      untouchedComponents: validation.verifiedComponents)
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+    #expect(outcome == .noop)
+    #expect(gate.isAdmitted())
+  }
+
+  // MARK: - Unrecognized (never ours, never touched)
+
+  /// Bytes that match neither the current manifest nor a layout we shipped are
+  /// foreign. We cannot prove what they are, so we never move, load, or delete
+  /// them — the provenance rule, in one test.
+  @Test func unrecognizedBytesAreLeftStrictlyAlone() async throws {
+    let dirs = try makeDirs()
+    let stranger = dirs.old.appendingPathComponent("somebody-elses-model.gguf")
+    try write(Data("not ours".utf8), under: dirs.old, path: "somebody-elses-model.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+
+    let outcome = await migrator.migrate(p)
+
+    #expect(outcome == .unrecognized)
+    #expect(exists(stranger), "foreign bytes must never be deleted")
+    #expect(migrator.pendingLegacyArtifact(p) == nil, "and never marked for cleanup")
+    let gate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.new, metadataDirectory: dirs.metadata)
+    #expect(gate.isAdmitted() == false)
+  }
+
+  /// A corrupt/partial copy of the current manifest is not relocatable and is
+  /// not a trusted legacy layout: treated as absent, left in place, never
+  /// admitted (the #1339 poison class).
+  @Test func corruptCurrentManifestCopyIsNotRelocated() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: dirs.old, path: f.path) }
+    // Corrupt one file's bytes: size may match, hash will not.
+    let victim = files[0]
+    try write(
+      Data(repeating: 0xFF, count: victim.content.count), under: dirs.old, path: victim.path)
+    let p = try plan(files: files, dirs: dirs)
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+
+    #expect(outcome == .unrecognized)
+    let gate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.new, metadataDirectory: dirs.metadata)
+    #expect(gate.isAdmitted() == false, "corrupt bytes must never be admitted")
+  }
+}

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -501,6 +501,29 @@ import Testing
     #expect(exists(monolith), "and the model they re-chose is still there to replace")
   }
 
+  /// A Remove that could not finish must SURVIVE re-classification. The next launch
+  /// re-runs migrate() before anything reads the token; if classification rewrote the
+  /// token from scratch it would reset the intent to `.replace` and re-download the
+  /// model the user deleted — the resurrection bug climbing back in through the
+  /// classifier. (Codex PR-1 review r16.)
+  @Test func reclassificationPreservesAnUnfinishedRemoval() async throws {
+    let dirs = try makeDirs()
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+    _ = await migrator.migrate(p)
+    migrator.markLegacyForRemoval(p)
+    #expect(migrator.pendingLegacyIntent(p) == .remove)
+
+    // The delete failed; the artifact is still here. Next launch re-classifies it.
+    let nextLaunch = ModelRelocationMigrator()
+    _ = await nextLaunch.migrate(p)
+
+    #expect(
+      nextLaunch.pendingLegacyIntent(p) == .remove,
+      "re-classification must not resurrect a model the user removed")
+  }
+
   /// Marking a removal when nothing is pending is a plain no-op — an ordinary
   /// Remove on a machine with no legacy artifact must not invent one.
   @Test func markingRemovalWithNoPendingArtifactIsANoop() async throws {

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -252,6 +252,40 @@ import Testing
     #expect(!exists(dirs.old), "the old home is redundant once the new one is admitted")
   }
 
+  /// The crash window that would cost a user gigabytes forever: the process dies
+  /// AFTER the destination is admitted but BEFORE the old copy is cleaned up. The
+  /// next launch sees an admitted destination — and must still finish the cleanup
+  /// rather than early-returning and leaving a duplicate multi-GB model on disk
+  /// that nothing will ever look at again. (Codex PR-1 review r7.)
+  @Test func admittedDestinationStillReconcilesALeftoverOldCopy() async throws {
+    let dirs = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    // Simulate the interrupted state directly: destination admitted, source still
+    // fully populated — exactly what a crash between the two steps leaves behind.
+    for f in files {
+      try write(f.content, under: dirs.new, path: f.path)
+      try write(f.content, under: dirs.old, path: f.path)
+    }
+    let p = try plan(files: files, dirs: dirs)
+    let gate = CacheAdmission(
+      manifest: p.manifest, installDirectory: dirs.new, metadataDirectory: dirs.metadata)
+    let validation = await gate.validateExistingCache()
+    try gate.promoteAndAdmit(
+      stagedComponents: [], stagingDirectory: dirs.new,
+      untouchedComponents: validation.verifiedComponents)
+    #expect(gate.isAdmitted())
+
+    let outcome = await ModelRelocationMigrator().migrate(p)
+
+    #expect(outcome == .noop)
+    #expect(gate.isAdmitted(), "the admitted destination is untouched")
+    for f in files {
+      #expect(
+        !exists(dirs.old.appendingPathComponent(f.path)),
+        "the duplicate left by the crash must be reclaimed, not stranded forever")
+    }
+  }
+
   /// An already-admitted destination is the common case on every launch after
   /// the first: cheap no-op, no rehash, nothing touched.
   @Test func admittedDestinationIsANoop() async throws {

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelRelocationMigratorTests.swift
@@ -478,6 +478,29 @@ import Testing
     #expect(migrator.pendingLegacyIntent(p) == nil, "and nothing remains pending to re-fetch")
   }
 
+  /// The user removes the model, then takes it back by re-selecting it. The durable
+  /// intent must follow: leaving it at `.remove` would delete the model on the next
+  /// launch after they had explicitly re-chosen it. (Codex PR-1 review r13.)
+  @Test func takingTheRemovalBackRestoresTheReplacementIntent() async throws {
+    let dirs = try makeDirs()
+    let monolith = dirs.old.appendingPathComponent("eg-1-v1.gguf")
+    try write(Self.legacyBytes, under: dirs.old, path: "eg-1-v1.gguf")
+    let p = try plan(files: ManifestFixture.smallFiles, dirs: dirs)
+    let migrator = ModelRelocationMigrator()
+    _ = await migrator.migrate(p)
+
+    migrator.markLegacyForRemoval(p)
+    #expect(migrator.pendingLegacyIntent(p) == .remove)
+
+    // They re-select EG-1: the removal is taken back.
+    migrator.markLegacyForReplacement(p)
+
+    #expect(
+      migrator.pendingLegacyIntent(p) == .replace,
+      "a cancelled removal must not survive as a durable delete")
+    #expect(exists(monolith), "and the model they re-chose is still there to replace")
+  }
+
   /// Marking a removal when nothing is pending is a plain no-op — an ordinary
   /// Remove on a machine with no legacy artifact must not invent one.
   @Test func markingRemovalWithNoPendingArtifactIsANoop() async throws {


### PR DESCRIPTION
First of four PRs unifying on-device model storage under one app-owned home
(`~/Library/Application Support/EnviousWispr/Models/`). Proven here on the lowest-risk
engine: EG-1 is a limb, so a failure degrades polish to raw text and never touches
dictation.

Part of #1386 (ModelDelivery epic #1348, Phase 4). Plan:
`docs/feature-requests/issue-1386-2026-07-07-model-storage-unification-APPROVED.md`
(grounded review r1-r7, PROCEED-AS-PLANNED).

## What this does

- **New `ModelRelocationMigrator`** (ModelDelivery). Classifies an old model home as:
  - **relocatable** — satisfies the current manifest: validate, reproduce at the new
    home via `clonefile(2)` (APFS copy-on-write: instant, no extra disk), re-admit,
    then drop the old copy;
  - **trusted-legacy** — a layout WE shipped that this build can no longer load:
    record a durable token, touch nothing;
  - **unrecognized** — foreign bytes: never moved, never loaded, never deleted.
- **EG-1 moves** from `EnviousWispr/PolishModels` to `EnviousWispr/Models/eg-1`.
- **Every shipped EG-1 install is the monolithic `eg-1-v1.gguf`**, which cannot satisfy
  the current 8-shard manifest (#1417's sharding is in no released tag). Those bytes are
  a *trusted app-managed asset* — we shipped them and hold their digest — so they are
  replaced silently and automatically per the contract's automatic-replacement clause,
  but only ever **verify-before-delete**: the monolith survives untouched until all 8
  shards are admitted.
- **Polish falls back to raw text during that one migration download.** EG-1 is a limb;
  this is the Heart & Limbs contract, not a regression. Founder-approved; disclosed in
  the release notes (a release blocker for the coordinated release).
- **Reclaims the retired store's stranded `.partial`** (up to ~2.9 GB) from the old home
  — the leftover half of #1363, which this PR would otherwise have made permanent.
- Corrected two stale UI strings: EG-1 is 2.9 GB, not 2.7 GB.

## The invariants this PR is actually about

Almost all of the work here is failure-path behavior. Four invariants, each enforced
structurally rather than remembered:

1. **Nothing is deleted without proving the bytes are ours, by digest, for that
   directory.** A filename is not an identity; a proof about one directory says nothing
   about another. Four deletion sites, all gated.
2. **Verify before delete, always.** The old copy survives until the replacement is
   admitted. A failed / cancelled / disk-full / crashed run leaves it intact and retries.
3. **The durable token records what is owed AND why.** In-memory state and the token move
   together, so a crash cannot resurrect a model the user deleted, nor delete one they
   took back.
4. **A user's Remove is never lost.** Every exit from the transition honors it; every
   admission path completes its cleanup.

## Review

21 rounds of `codex review`, 28 defects fixed, all in the failure / rollback / crash
paths (the happy path was correct from the first commit). Final round: *"No actionable
correctness issues were found in the diff."* Audits in `docs/audits/2026-07-11-1386-pr1-codereview-r*.txt`.

Notable: the delivery kill switch (`modelDelivery.egOne.enabled`) is honored **before**
any relocation — without that, the one lever that stops model-byte mutation would have
been defeated by the new code that mutates model bytes.

## Tests

2754 green. 24 new migrator tests, each verified to FAIL against the pre-fix code before
being accepted (twice, a test passed against the bug and had to be rewritten).

**Named gap:** the runtime's cleanup-failure branch has no unit test — `EGOneRuntime`
owns a real llama-server process and takes a concrete adapter, so nothing in the suite
constructs it, and adding that seam does not belong in this PR. It is covered by Live
UAT instead, by making the legacy artifact undeletable and asserting polish still
returns.

## Not in this PR

Parakeet and WhisperKit keep their current homes (PR-2/PR-3/PR-4). No downloader
resilience code: retry/backoff/failover remain #1410's, inherited untouched.
