### PR TITLE
test(pipeline): gate DEBUG-hook #1358 recovery tests for the release lane

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
@@ -19,9 +19,20 @@ import Testing
 // End-to-end "a filler-only RECORDING lands in `.noSpeech`" is covered
 // transitively: the wiring returns "" for a filler-only chain result (see
 // `wiringFillerOnlyReturnsEmpty`), the kernel branch routes "" → `.noSpeech`
-// (code), the transition is legal (`finalizingAllowedTerminalSet`), and the
+// (code), the transition is legal (`Issue1358EmptyRecoveryFSMTests`), and the
 // observable outcome is a breadcrumb, not a Sentry capture
 // (`KernelLifecycleTelemetrySinkTests.noSpeechEmptyAfterProcessingEmission`).
+//
+// SPLIT into two suites so the config-independent core keeps running in the
+// post-merge RELEASE lane (ci-pipeline.md RULE: release-tests-run-post-merge):
+//   • `Issue1358EmptyRecoveryTests` (this suite) — pure classifier / floor /
+//     wiring tests. Runs in BOTH debug and release.
+//   • `Issue1358EmptyRecoveryFSMTests` (below, `#if DEBUG`) — the FSM-legality,
+//     interrupted-floor, and diagnostic archive-relabel tests, which use
+//     `#if DEBUG`-only members of `RecordingSessionKernel` (`testForceTransition`
+//     / `testSetInterruptionCause` / `testInterruptedTerminalFloor` and the
+//     debug-only `relabeledArchiveOutcome`), so that suite must be gated (release
+//     compiles with `DEBUG` undefined and those members vanish).
 
 @MainActor
 @Suite("#1358 empty-after-processing recovery")
@@ -68,7 +79,8 @@ struct Issue1358EmptyRecoveryTests {
     // The classifier never reads `fillerRemovalEnabled`; a bare filler is never
     // floored even when a NON-filler step emptied the deterministic text.
     #expect(
-      KernelFinalizationWiring.emptyOutputRecoveryFloor(deterministicText: "", rawASR: "uh") == "")
+      KernelFinalizationWiring.emptyOutputRecoveryFloor(deterministicText: "", rawASR: "uh") == ""
+    )
     // A real word emptied by a step IS recovered.
     #expect(
       KernelFinalizationWiring.emptyOutputRecoveryFloor(deterministicText: "", rawASR: "hello")
@@ -133,87 +145,6 @@ struct Issue1358EmptyRecoveryTests {
     #expect(outcome.polishFallbackReason == nil)
   }
 
-  // MARK: FSM legality — the finalizing safe-point set
-
-  @Test(
-    "finalizing legal terminal set is exactly {.completed, .failed, .noSpeech, .audioInterrupted}",
-    .bug(
-      "https://github.com/saurabhav88/EnviousWispr/issues/1358",
-      "an illegal finalizing → noSpeech/audioInterrupted would silently wedge the session"
-    ))
-  func finalizingAllowedTerminalSet() {
-    // The four legal terminals — each on a fresh kernel walked to finalizing
-    // (a successful transition leaves finalizing).
-    for terminal in [
-      RecordingSessionState.completed, .failed(.asrEmpty), .noSpeech, .audioInterrupted,
-    ] {
-      let kernel = freshKernelAtFinalizing()
-      #expect(
-        kernel.testForceTransition(to: terminal) == true,
-        "\(terminal) must be a legal terminal from finalizing")
-    }
-    // Every other target is rejected (the safe point holds). All false on one
-    // kernel since a rejected transition leaves it in finalizing.
-    let kernel = freshKernelAtFinalizing()
-    for forbidden in [
-      RecordingSessionState.idle, .preparing, .warmingUp, .recording, .stopping,
-      .transcribing, .finalizing, .cancelled, .discarded, .asrInterrupted,
-    ] {
-      #expect(
-        kernel.testForceTransition(to: forbidden) == false,
-        "\(forbidden) must be rejected from finalizing")
-      #expect(kernel.state == .finalizing, "a rejected transition leaves the safe point intact")
-    }
-  }
-
-  // MARK: Interrupted floor (#1408 spool retention)
-
-  @Test(
-    "an interrupted empty finalize floors .noSpeech → .audioInterrupted (retain spool), else unchanged"
-  )
-  func interruptedEmptyFloorsToAudioInterrupted() {
-    // With an interruption cause, the empty no-speech is floored UP so the
-    // #1408 crash-recovery spool is retained.
-    let interrupted = freshKernelAtFinalizing()
-    interrupted.testSetInterruptionCause(.xpcConnectionLost)
-    #expect(interrupted.testInterruptedTerminalFloor(.noSpeech) == .audioInterrupted)
-
-    // With no interruption, the clean cold-mic filler stays quiet no-speech.
-    let clean = freshKernelAtFinalizing()
-    clean.testSetInterruptionCause(nil)
-    #expect(clean.testInterruptedTerminalFloor(.noSpeech) == .noSpeech)
-  }
-
-  // MARK: Diagnostic-archive relabel (code-diff r2)
-
-  @Test(
-    "archive relabel: filler-only .noSpeech archives as .noSpeech, not .finalizationFailed")
-  func archiveOutcomeRelabel() {
-    let transcript = ASREngineOutcome.transcript(
-      ASRResult(
-        text: "uh", language: nil, duration: 0.1, processingTime: 0.05, backendType: .parakeet))
-    // A normal completion keeps its base label.
-    #expect(
-      RecordingSessionKernel.relabeledArchiveOutcome(
-        base: .completed, effectiveOutcome: transcript,
-        reachedCompleted: true, reachedNoSpeech: false) == .completed)
-    // #1358: a filler-only capture emptied by processing → quiet no-speech, NOT a failure.
-    #expect(
-      RecordingSessionKernel.relabeledArchiveOutcome(
-        base: .completed, effectiveOutcome: transcript,
-        reachedCompleted: false, reachedNoSpeech: true) == .noSpeech)
-    // Empty-after-polish `.failed` / superseded mid-finalize stays finalizationFailed.
-    #expect(
-      RecordingSessionKernel.relabeledArchiveOutcome(
-        base: .completed, effectiveOutcome: transcript,
-        reachedCompleted: false, reachedNoSpeech: false) == .finalizationFailed)
-    // A non-`.transcript` decode keeps its base label untouched.
-    #expect(
-      RecordingSessionKernel.relabeledArchiveOutcome(
-        base: .noSpeech, effectiveOutcome: .empty(hadSpeechEvidence: false),
-        reachedCompleted: false, reachedNoSpeech: true) == .noSpeech)
-  }
-
   // MARK: Helpers
 
   private func makeSteps() -> LimbSteps {
@@ -250,23 +181,6 @@ struct Issue1358EmptyRecoveryTests {
       currentTime: { ProcessInfo.processInfo.systemUptime },
       telemetryState: KernelTelemetryState())
   }
-
-  /// A fresh kernel legally walked to `.finalizing`.
-  private func freshKernelAtFinalizing() -> RecordingSessionKernel {
-    let clock = FakeClock()
-    let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
-    let wrapper = KernelRecordingSession(
-      engine: engine, capture: FakeAudioCapture(), vad: FakeVADSignalSource(),
-      clock: clock, paste: FakePasteTarget())
-    let kernel = wrapper.testKernel
-    _ = kernel.testForceTransition(to: .preparing)
-    _ = kernel.testForceTransition(to: .warmingUp)
-    _ = kernel.testForceTransition(to: .recording)
-    _ = kernel.testForceTransition(to: .stopping)
-    _ = kernel.testForceTransition(to: .transcribing)
-    _ = kernel.testForceTransition(to: .finalizing)
-    return kernel
-  }
 }
 
 /// Returns an empty polish result so the empty-output floor is exercised — the
@@ -287,3 +201,115 @@ private struct EmptyPolisher: TranscriptPolisher {
 private final class SavedBox {
   var transcript: Transcript?
 }
+
+// MARK: - FSM legality + interrupted floor (DEBUG-only hooks)
+//
+// These drive the kernel through `testForceTransition` / `testSetInterruptionCause`
+// / `testInterruptedTerminalFloor`, which are `#if DEBUG`-only on
+// `RecordingSessionKernel` — so this suite is gated exactly like
+// `RecordingSessionKernelTests` and `RecordingSessionKernelExternalInterruptionTests`.
+
+#if DEBUG
+
+  @MainActor
+  @Suite("#1358 empty-after-processing recovery — FSM (DEBUG hooks)")
+  struct Issue1358EmptyRecoveryFSMTests {
+
+    @Test(
+      "finalizing legal terminal set is exactly {.completed, .failed, .noSpeech, .audioInterrupted}",
+      .bug(
+        "https://github.com/saurabhav88/EnviousWispr/issues/1358",
+        "an illegal finalizing → noSpeech/audioInterrupted would silently wedge the session"
+      ))
+    func finalizingAllowedTerminalSet() {
+      // The four legal terminals — each on a fresh kernel walked to finalizing
+      // (a successful transition leaves finalizing).
+      for terminal in [
+        RecordingSessionState.completed, .failed(.asrEmpty), .noSpeech, .audioInterrupted,
+      ] {
+        let kernel = freshKernelAtFinalizing()
+        #expect(
+          kernel.testForceTransition(to: terminal) == true,
+          "\(terminal) must be a legal terminal from finalizing")
+      }
+      // Every other target is rejected (the safe point holds). All false on one
+      // kernel since a rejected transition leaves it in finalizing.
+      let kernel = freshKernelAtFinalizing()
+      for forbidden in [
+        RecordingSessionState.idle, .preparing, .warmingUp, .recording, .stopping,
+        .transcribing, .finalizing, .cancelled, .discarded, .asrInterrupted,
+      ] {
+        #expect(
+          kernel.testForceTransition(to: forbidden) == false,
+          "\(forbidden) must be rejected from finalizing")
+        #expect(kernel.state == .finalizing, "a rejected transition leaves the safe point intact")
+      }
+    }
+
+    @Test(
+      "an interrupted empty finalize floors .noSpeech → .audioInterrupted (retain spool), else unchanged"
+    )
+    func interruptedEmptyFloorsToAudioInterrupted() {
+      // With an interruption cause, the empty no-speech is floored UP so the
+      // #1408 crash-recovery spool is retained.
+      let interrupted = freshKernelAtFinalizing()
+      interrupted.testSetInterruptionCause(.xpcConnectionLost)
+      #expect(interrupted.testInterruptedTerminalFloor(.noSpeech) == .audioInterrupted)
+
+      // With no interruption, the clean cold-mic filler stays quiet no-speech.
+      let clean = freshKernelAtFinalizing()
+      clean.testSetInterruptionCause(nil)
+      #expect(clean.testInterruptedTerminalFloor(.noSpeech) == .noSpeech)
+    }
+
+    // MARK: Diagnostic-archive relabel (code-diff r2)
+    // `relabeledArchiveOutcome` + the dictation-audio-archive feature are
+    // `#if DEBUG`-only (diagnostic capture), so this test lives in the gated suite.
+
+    @Test(
+      "archive relabel: filler-only .noSpeech archives as .noSpeech, not .finalizationFailed")
+    func archiveOutcomeRelabel() {
+      let transcript = ASREngineOutcome.transcript(
+        ASRResult(
+          text: "uh", language: nil, duration: 0.1, processingTime: 0.05, backendType: .parakeet))
+      // A normal completion keeps its base label.
+      #expect(
+        RecordingSessionKernel.relabeledArchiveOutcome(
+          base: .completed, effectiveOutcome: transcript,
+          reachedCompleted: true, reachedNoSpeech: false) == .completed)
+      // #1358: a filler-only capture emptied by processing → quiet no-speech, NOT a failure.
+      #expect(
+        RecordingSessionKernel.relabeledArchiveOutcome(
+          base: .completed, effectiveOutcome: transcript,
+          reachedCompleted: false, reachedNoSpeech: true) == .noSpeech)
+      // Empty-after-polish `.failed` / superseded mid-finalize stays finalizationFailed.
+      #expect(
+        RecordingSessionKernel.relabeledArchiveOutcome(
+          base: .completed, effectiveOutcome: transcript,
+          reachedCompleted: false, reachedNoSpeech: false) == .finalizationFailed)
+      // A non-`.transcript` decode keeps its base label untouched.
+      #expect(
+        RecordingSessionKernel.relabeledArchiveOutcome(
+          base: .noSpeech, effectiveOutcome: .empty(hadSpeechEvidence: false),
+          reachedCompleted: false, reachedNoSpeech: true) == .noSpeech)
+    }
+
+    /// A fresh kernel legally walked to `.finalizing`.
+    private func freshKernelAtFinalizing() -> RecordingSessionKernel {
+      let clock = FakeClock()
+      let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
+      let wrapper = KernelRecordingSession(
+        engine: engine, capture: FakeAudioCapture(), vad: FakeVADSignalSource(),
+        clock: clock, paste: FakePasteTarget())
+      let kernel = wrapper.testKernel
+      _ = kernel.testForceTransition(to: .preparing)
+      _ = kernel.testForceTransition(to: .warmingUp)
+      _ = kernel.testForceTransition(to: .recording)
+      _ = kernel.testForceTransition(to: .stopping)
+      _ = kernel.testForceTransition(to: .transcribing)
+      _ = kernel.testForceTransition(to: .finalizing)
+      return kernel
+    }
+  }
+
+#endif  // DEBUG (#1358 FSM suite — shares the testForceTransition gating posture)


### PR DESCRIPTION
## Problem
`Issue1358EmptyRecoveryTests` (from #1496) drove the kernel through `testForceTransition` / `testSetInterruptionCause` / `testInterruptedTerminalFloor` and called `relabeledArchiveOutcome` — all `#if DEBUG`-only members of `RecordingSessionKernel` (the FSM test hooks and the diagnostic dictation-audio-archive helper). The suite was **not** `#if DEBUG`-gated, so it compiled in every debug run (PR checks + local `xcode-test.sh`) but broke the **release** test compile, which runs **only post-merge** (`ci-pipeline.md` RULE: release-tests-run-post-merge; `DEBUG` undefined in Release). Main post-merge went red starting at the #1496 merge.

No user-facing effect — the shipped #1358 fix code is correct and unchanged. This is a test-compilation gate only.

## Fix
Split the file so the config-independent tests keep running in the release lane, gating only what needs DEBUG members:
- `Issue1358EmptyRecoveryTests` (ungated) — classifier / recovery-floor / wiring (History==clipboard) tests. Run in **both** debug and release.
- `Issue1358EmptyRecoveryFSMTests` (`#if DEBUG`) — FSM-legality, interrupted-floor, and archive-relabel tests (use DEBUG-only kernel members).

Codex (exec) pinpointed the exact release compile error (`RecordingSessionKernel has no member relabeledArchiveOutcome`) from the release build log — the whole audio-archive feature is DEBUG-only, so the archive test also moved into the gated suite.

## Validation
- `scripts/xcode-test.sh --release` → **TEST SUCCEEDED, Release lane 2535 tests** (the pure #1358 tests now run in release; only the DEBUG-hook tests are gated out).
- Debug: 8 tests across both suites pass.
- Codex diff review clean ("correctly gates tests that depend on DEBUG-only kernel APIs while keeping configuration-independent recovery tests available in Release").

Unbreaks the `main` post-merge Release lane.
