### PR TITLE
feat(llm): retire the shipped EG-1 monolith and rehome fresh installs (#1386 PR-1)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
+++ b/Sources/EnviousWisprAppKit/App/EGOneTelemetryBridge.swift
@@ -27,4 +27,46 @@ enum EGOneTelemetryBridge {
       }
     }
   }
+
+  /// #1386 PR-1: the legacy-upgrade lifecycle (`eg1.legacy_detected` /
+  /// `legacy_retired` / `legacy_retirement_failed` / `replacement_completed` /
+  /// `replacement_declined`). Bounded and content-free: the only properties
+  /// are a fixed failure-reason set and `selected_provider` on detection
+  /// (attached here so the coordinator stays provider-ignorant). Download
+  /// progress/failure stays on the shared `model_delivery.*` funnel — this
+  /// path never duplicates it.
+  static func legacyUpgradeHandler(
+    selectedProvider: @escaping @MainActor @Sendable () -> Bool
+  ) -> @MainActor @Sendable (EGOneLegacyUpgradeCoordinator.Event) -> Void {
+    { event in
+      let name: String
+      let properties: [String: String]
+
+      switch event {
+      case .legacyDetected:
+        name = "legacy_detected"
+        properties = ["selected_provider": selectedProvider() ? "true" : "false"]
+
+      case .legacyRetired:
+        name = "legacy_retired"
+        properties = [:]
+
+      case .legacyRetirementFailed(let reason):
+        name = "legacy_retirement_failed"
+        properties = ["reason": reason.rawValue]
+
+      case .replacementCompleted:
+        name = "replacement_completed"
+        properties = [:]
+
+      case .replacementDeclined:
+        name = "replacement_declined"
+        properties = [:]
+      }
+
+      TelemetryService.shared.egOneDownloadEvent(
+        name: name,
+        properties: properties)
+    }
+  }
 }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -166,29 +166,45 @@ public final class WisprBootstrapper {
     // `isActiveProvider` is a LIVE read (r2). The runtime keeps the EGOne
     // manifest (contextTokens / promptFamily / activation blockers); the
     // adapter owns the delivery manifest (fetch/install/content identity).
+    //
+    // #1386 PR-1 rev2: retire one unsupported shipped EG-1 monolith.
+    // ModelDelivery remains the sole owner of current-model bytes; the
+    // coordinator only recognizes the old file by exact size + digest, records
+    // the owed replacement, deletes it, and asks the adapter for the normal
+    // download. Fresh installs land in the owned `Models/eg-1` home.
     let egOneManifest = try? EGOneManifest.loadBundled()
     let egOneServerBinaryURL = Bundle.main.url(forResource: "llama-server", withExtension: nil)
+    let egOneAppSupport = FileManager.default.urls(
+      for: .applicationSupportDirectory, in: .userDomainMask)[0]
     var egOneAdapter: EGOneDeliveryAdapter?
     if let deliveryManifest = try? DeliveryManifest.loadBundled(resource: "eg1-delivery-manifest") {
-      let appSupport = FileManager.default.urls(
-        for: .applicationSupportDirectory, in: .userDomainMask)[0]
       let registration = DeliveryRegistration(
         manifest: deliveryManifest,
-        // The existing user's install dir — unchanged, so a byte-correct file
-        // is adopted in place with zero re-download (#1348 Decision C/F).
-        installDirectory: appSupport.appendingPathComponent(
-          "EnviousWispr/PolishModels", isDirectory: true),
-        metadataDirectory: appSupport.appendingPathComponent(
+        installDirectory: egOneAppSupport.appendingPathComponent(
+          "EnviousWispr/Models/eg-1", isDirectory: true),
+        metadataDirectory: egOneAppSupport.appendingPathComponent(
           "EnviousWispr/ModelDelivery", isDirectory: true))
-      egOneAdapter = EGOneDeliveryAdapter(
+      let adapter = EGOneDeliveryAdapter(
         controller: modelDelivery.controller,
         registration: registration,
         version: egOneManifest?.version ?? deliveryManifest.identity.revision)
+      egOneAdapter = adapter
+
+      let coordinator = EGOneLegacyUpgradeCoordinator(
+        adapter: adapter,
+        appSupportDirectory: egOneAppSupport)
+      // `selected_provider` rides only on legacy_detected, attached here where
+      // settings is in scope — the coordinator stays provider-ignorant.
+      coordinator.onEvent = EGOneTelemetryBridge.legacyUpgradeHandler(
+        selectedProvider: { [weak settings] in settings?.llmProvider == .egOne })
+
       // Seed EG-1's first-run telemetry baseline before its first attempt
-      // (#1348 §16.2). Session-granularity approximation (same async-Task shape
-      // as Parakeet's own baseline); a rare early event stamps first_run=false.
+      // (#1348 §16.2), then run the one-time legacy launch table.
       let delivery = modelDelivery
-      Task { await delivery.recordFirstRunBaseline(for: registration) }
+      Task {
+        await delivery.recordFirstRunBaseline(for: registration)
+        await coordinator.runLaunch()
+      }
     }
     let egOneRuntime = EGOneRuntime(
       manifest: egOneManifest, serverBinaryURL: egOneServerBinaryURL, delivery: egOneAdapter)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -167,16 +167,17 @@ public final class WisprBootstrapper {
     // manifest (contextTokens / promptFamily / activation blockers); the
     // adapter owns the delivery manifest (fetch/install/content identity).
     //
-    // #1386 PR-1 rev2: retire one unsupported shipped EG-1 monolith.
-    // ModelDelivery remains the sole owner of current-model bytes; the
-    // coordinator only recognizes the old file by exact size + digest, records
-    // the owed replacement, deletes it, and asks the adapter for the normal
-    // download. Fresh installs land in the owned `Models/eg-1` home.
+    // #1386 PR-1 rev2: retire the one shipped EG-1 monolith. The coordinator
+    // recognizes it by exact size + digest, records the owed replacement,
+    // deletes it, and asks the adapter for the normal download; fresh
+    // installs land in the owned `Models/eg-1` home.
     let egOneManifest = try? EGOneManifest.loadBundled()
     let egOneServerBinaryURL = Bundle.main.url(forResource: "llama-server", withExtension: nil)
     let egOneAppSupport = FileManager.default.urls(
       for: .applicationSupportDirectory, in: .userDomainMask)[0]
     var egOneAdapter: EGOneDeliveryAdapter?
+    var egOneLegacyUpgrade:
+      (registration: DeliveryRegistration, coordinator: EGOneLegacyUpgradeCoordinator)?
     if let deliveryManifest = try? DeliveryManifest.loadBundled(resource: "eg1-delivery-manifest") {
       let registration = DeliveryRegistration(
         manifest: deliveryManifest,
@@ -193,23 +194,26 @@ public final class WisprBootstrapper {
       let coordinator = EGOneLegacyUpgradeCoordinator(
         adapter: adapter,
         appSupportDirectory: egOneAppSupport)
-      // `selected_provider` rides only on legacy_detected, attached here where
-      // settings is in scope — the coordinator stays provider-ignorant.
+      // `selected_provider` attaches here (settings in scope); coordinator
+      // stays provider-ignorant.
       coordinator.onEvent = EGOneTelemetryBridge.legacyUpgradeHandler(
         selectedProvider: { [weak settings] in settings?.llmProvider == .egOne })
-
-      // Seed EG-1's first-run telemetry baseline before its first attempt
-      // (#1348 §16.2), then run the one-time legacy launch table.
-      let delivery = modelDelivery
-      Task {
-        await delivery.recordFirstRunBaseline(for: registration)
-        await coordinator.runLaunch()
-      }
+      egOneLegacyUpgrade = (registration, coordinator)
     }
     let egOneRuntime = EGOneRuntime(
       manifest: egOneManifest, serverBinaryURL: egOneServerBinaryURL, delivery: egOneAdapter)
     egOneRuntime.isActiveProvider = { [weak settings] in settings?.llmProvider == .egOne }
     egOneRuntime.onEvent = EGOneTelemetryBridge.handler
+    if let egOneLegacyUpgrade {
+      // First-run baseline (#1348 §16.2) → legacy launch table → the RUNTIME
+      // decides if the completed replacement boots the server (PR #1500 P1).
+      let delivery = modelDelivery
+      Task {
+        await delivery.recordFirstRunBaseline(for: egOneLegacyUpgrade.registration)
+        await egOneLegacyUpgrade.coordinator.runLaunch()
+        egOneRuntime.activateAfterAutomaticReplacementIfNeeded()
+      }
+    }
     // Exactly one path sweeps orphans — a detached sweep alongside a spawn
     // would race it and kill the fresh server (Codex r10 P1).
     if settings.llmProvider == .egOne {

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -983,7 +983,7 @@ struct AIPolishSettingsView: View {
     switch egOne.installState {
     case .notInstalled:
       HStack {
-        Text("One-time download: 2.7 GB")
+        Text("One-time download: 2.9 GB")
           .font(.stHelper)
           .foregroundStyle(Color.stTextSecondary)
         Spacer()
@@ -992,7 +992,7 @@ struct AIPolishSettingsView: View {
     case .downloading(let fraction):
       VStack(alignment: .leading, spacing: 4) {
         ProgressView(value: max(0, min(1, fraction))) {
-          Text("Downloading EG-1 (2.7 GB)")
+          Text("Downloading EG-1 (2.9 GB)")
             .font(.stHelper)
         }
         Button("Cancel") { egOne.cancelDownload() }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneDeliveryAdapter.swift
@@ -33,57 +33,26 @@ public final class EGOneDeliveryAdapter {
     self.registration = registration
     self.version = version
     self.defaults = defaults ?? UserDefaults(suiteName: DeliveryFlags.suiteName) ?? .standard
-    migrateLegacyStoreArtifacts()
   }
 
-  /// One-time migration of the retired `EGOneModelStore`'s in-progress-download
-  /// leftovers (cloud-review P2, PR #1384). The old store downloaded IN PLACE in
-  /// the install dir, leaving a `.partial` + resume sidecar beside the install
-  /// file; the shared engine stages under `ModelDelivery/staging` instead and
-  /// would ignore them — wasting gigabytes and risking a disk-preflight failure
-  /// on the next download. Fast (stat + rename/remove, no hashing):
-  /// - (1) a COMPLETED-but-not-installed CURRENT-version download (full-size
-  ///   `.partial`, no install file) is PROMOTED to the install name so
-  ///   `adoptIfPresent` verifies + admits it offline with NO re-download (a
-  ///   corrupt one is rejected by the admission hash gate and overwritten by the
-  ///   next download; the founder-critical case);
-  /// - (2) EVERY remaining download sidecar (`.partial` / `.resume.json`) in the
-  ///   install dir is swept — including an interrupted legacy download whose
-  ///   version differs from the current manifest (so an EG-2/EG-3 manifest bump
-  ///   does not orphan an old `eg-1-vN.gguf.partial` forever). Safe by
-  ///   construction: the shared engine never stages in the install dir, so a
-  ///   sidecar here is always a retired-store leftover, never an in-flight
-  ///   download. Completed `*.gguf` MODELS are deliberately NOT touched — a
-  ///   superseded model is the user's working polish until the new version
-  ///   downloads, and the engine's promote-time orphan cleanup removes it when
-  ///   the new version is admitted (deleting it here would break polish in the
-  ///   gap and risk the founder's real 2.9 GB install).
-  private func migrateLegacyStoreArtifacts() {
-    let fm = FileManager.default
-    let installDir = registration.installDirectory
-    let installPath = installedArtifactURL.path
-    let partialPath = installPath + ".partial"
-    // #1417: `partialPath` is always named after the ENTRYPOINT file
-    // (`resolvedEntrypointPath`, one file), so the size it's compared against
-    // must be that same file's own size — never a sum across every shard (a
-    // `.partial` named after shard 1 can only ever contain shard 1's bytes).
-    let expectedSize = registration.manifest.files.first(where: {
-      $0.resolvedInstallPath == registration.manifest.resolvedEntrypointPath
-    })?.sizeBytes
-    // (1) Promote a complete current-version partial; a size-mismatched or
-    //     already-installed one falls through to the sweep below.
-    if fm.fileExists(atPath: partialPath), !fm.fileExists(atPath: installPath),
-      let expectedSize,
-      (try? fm.attributesOfItem(atPath: partialPath)[.size]) as? Int64 == expectedSize
-    {
-      try? fm.moveItem(atPath: partialPath, toPath: installPath)
-    }
-    // (2) Sweep all stale download sidecars, any version. Never a `.gguf` model.
-    if let entries = try? fm.contentsOfDirectory(atPath: installDir.path) {
-      for entry in entries where entry.hasSuffix(".partial") || entry.hasSuffix(".resume.json") {
-        try? fm.removeItem(at: installDir.appendingPathComponent(entry))
-      }
-    }
+  // MARK: - Legacy-upgrade hooks (#1386 PR-1)
+
+  /// Installed by `EGOneLegacyUpgradeCoordinator` at the composition root. The
+  /// adapter stays the single delivery doorway; the coordinator's monolith
+  /// retirement runs before any fetch door, and admission/decline outcomes are
+  /// reported back so the owed marker never drifts from delivery reality.
+  private var legacyPrepareBeforeEnsure: (@MainActor @Sendable () async -> Bool)?
+  private var legacyRecordDecline: (@MainActor @Sendable () -> Bool)?
+  private var legacyDidAdmit: (@MainActor @Sendable () -> Void)?
+
+  func installLegacyUpgradeHooks(
+    beforeEnsure: @escaping @MainActor @Sendable () async -> Bool,
+    beforeDecline: @escaping @MainActor @Sendable () -> Bool,
+    onAdmitted: @escaping @MainActor @Sendable () -> Void
+  ) {
+    legacyPrepareBeforeEnsure = beforeEnsure
+    legacyRecordDecline = beforeDecline
+    legacyDidAdmit = onAdmitted
   }
 
   /// The verified on-disk model location the runtime boots llama-server from:
@@ -100,9 +69,15 @@ public final class EGOneDeliveryAdapter {
   /// The D5 kill-switch, read fresh per call (relaunch-free). Disabled ⇒ no
   /// delivery mutation (#1363 §16.6). Internal: EG-1's flag gates only the
   /// adapter's own ensure/repair/remove (unlike Parakeet, whose engine adapter
-  /// reads the flag to choose the cache-only load path).
-  private func isEnabled() -> Bool {
+  /// reads the flag to choose the cache-only load path). Static so the
+  /// legacy-upgrade coordinator reads the SAME key without duplicating it
+  /// (#1386 PR-1).
+  static func isDeliveryEnabled(defaults: UserDefaults) -> Bool {
     defaults.object(forKey: DeliveryFlags.key("enabled", family: .egOne)) as? Bool ?? true
+  }
+
+  private func isEnabled() -> Bool {
+    Self.isDeliveryEnabled(defaults: defaults)
   }
 
   /// Ensure EG-1's bytes are admitted, fetching/adopting as needed. When
@@ -116,7 +91,20 @@ public final class EGOneDeliveryAdapter {
       if await controller.isAdmitted(registration) { return .admitted }
       return .failed(DeliveryFailure(reason: .unknown, detail: "delivery_disabled"))
     }
-    return await controller.ensureModelAvailable(registration)
+
+    // A1 - Every fetch door prepares retirement first and reports admission.
+    if let legacyPrepareBeforeEnsure,
+      !(await legacyPrepareBeforeEnsure())
+    {
+      return .failed(
+        DeliveryFailure(reason: .cacheRepairFailed, detail: "legacy_retirement"))
+    }
+
+    let outcome = await controller.ensureModelAvailable(registration)
+    if case .admitted = outcome {
+      legacyDidAdmit?()
+    }
+    return outcome
   }
 
   /// Adopt an already-present model WITHOUT fetching — the activation path
@@ -131,7 +119,18 @@ public final class EGOneDeliveryAdapter {
       controllerNoteDisabled()
       return await controller.isAdmitted(registration)
     }
-    return await controller.admitIfComplete(registration)
+
+    let admitted = await controller.admitIfComplete(registration)
+    if admitted {
+      legacyDidAdmit?()
+    }
+    return admitted
+  }
+
+  /// Current-cache admission truth, for the legacy-upgrade coordinator's launch
+  /// table (#1386 PR-1). Module-scoped: nothing outside this module needs it.
+  func isAdmitted() async -> Bool {
+    await controller.isAdmitted(registration)
   }
 
   /// One-shot repair after a cache-only load failure (§16.5); no-op when
@@ -142,21 +141,51 @@ public final class EGOneDeliveryAdapter {
       if await controller.isAdmitted(registration) { return .admitted }
       return .failed(DeliveryFailure(reason: .unknown, detail: "delivery_disabled"))
     }
-    return await controller.repair(registration)
+
+    if let legacyPrepareBeforeEnsure,
+      !(await legacyPrepareBeforeEnsure())
+    {
+      return .failed(
+        DeliveryFailure(reason: .cacheRepairFailed, detail: "legacy_retirement"))
+    }
+
+    let outcome = await controller.repair(registration)
+    if case .admitted = outcome {
+      legacyDidAdmit?()
+    }
+    return outcome
   }
 
   /// Cancel any in-flight delivery (Resume-able; staged partials survive).
+  ///
+  /// A2 - Explicit decline is recorded before controller cancellation,
+  /// regardless of the delivery switch (contract §5c.10: the switch guards
+  /// model bytes, never the user's recorded decision). If admission already
+  /// won the race, the verified model simply stays installed.
   public func cancel() async {
+    if let legacyRecordDecline, !legacyRecordDecline() {
+      return
+    }
+
     _ = await controller.cancel(registration.manifest.identity)
   }
 
   /// Evict the model (delete marker + files + staging). Disabled ⇒ no
   /// remove-on-behalf (§16.6): the flag gates all delivery mutation.
+  ///
+  /// A3 - Explicit decline is recorded before the switch is consulted. The
+  /// switch still prevents current-model deletion.
   public func remove() async -> ModelDeliveryController.RemoveOutcome {
+    if let legacyRecordDecline, !legacyRecordDecline() {
+      return .failed(
+        DeliveryFailure(reason: .permissionDenied, detail: "replacement_marker_clear"))
+    }
+
     if !isEnabled() {
       controllerNoteDisabled()
       return .failed(DeliveryFailure(reason: .unknown, detail: "delivery_disabled"))
     }
+
     return await controller.remove(registration)
   }
 
@@ -186,6 +215,14 @@ public final class EGOneDeliveryAdapter {
         Task { @MainActor in
           guard let self, seq > self.lastAppliedInstallSeq else { return }
           self.lastAppliedInstallSeq = seq
+
+          // A4 - Same existing adapter state stream; no second controller
+          // observer. Admission through ANY door (manual Try Again included)
+          // completes the legacy replacement.
+          if case .admitted = state {
+            self.legacyDidAdmit?()
+          }
+
           onState(mapped)
         }
       }
@@ -196,6 +233,7 @@ public final class EGOneDeliveryAdapter {
         await MainActor.run { [weak self] in
           guard let self, seq > self.lastAppliedInstallSeq else { return }
           self.lastAppliedInstallSeq = seq
+          self.legacyDidAdmit?()
           onState(.installed(version: version))
         }
       }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneLegacyUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneLegacyUpgradeCoordinator.swift
@@ -1,0 +1,414 @@
+import CryptoKit
+import EnviousWisprModelDelivery
+import Foundation
+
+/// Retires exactly one unsupported, app-owned EG-1 artifact.
+///
+/// It does not understand current shards, download them, verify them, or admit
+/// them. Those responsibilities stay in EGOneDeliveryAdapter and
+/// ModelDeliveryController.
+@MainActor
+public final class EGOneLegacyUpgradeCoordinator {
+  public struct TrustedArtifact: Sendable, Equatable {
+    public let name: String
+    public let sizeBytes: Int64
+    public let sha256: String
+
+    public init(name: String, sizeBytes: Int64, sha256: String) {
+      self.name = name
+      self.sizeBytes = sizeBytes
+      self.sha256 = sha256
+    }
+  }
+
+  public enum FailureReason: String, Sendable, Equatable {
+    case markerWrite = "marker_write"
+    case delete
+    case unreadable
+    case containment
+  }
+
+  public enum Event: Sendable, Equatable {
+    case legacyDetected
+    case legacyRetired
+    case legacyRetirementFailed(reason: FailureReason)
+    case replacementCompleted
+    case replacementDeclined
+  }
+
+  public static let shippedLegacyArtifact = TrustedArtifact(
+    name: "eg-1-v1.gguf",
+    sizeBytes: 2_889_511_680,
+    sha256: "3343fc1a30a3e82df7499a4775ef73dd6e28dea1cc39bb58197ec0b66ec874f6"
+  )
+
+  public var onEvent: (@MainActor @Sendable (Event) -> Void)?
+
+  private enum Fingerprint {
+    case absent
+    case match
+    case mismatch
+    case unreadable
+  }
+
+  private let appSupportDirectory: URL
+  private let defaults: UserDefaults
+  private let trustedArtifact: TrustedArtifact
+
+  private let ensureCurrentModel:
+    @MainActor @Sendable () async -> ModelDeliveryController.DeliveryOutcome
+  private let currentModelIsAdmitted: @MainActor @Sendable () async -> Bool
+
+  private let hashFile: @Sendable (URL) async throws -> String
+  private let writeMarker: @MainActor @Sendable (URL) -> Bool
+  private let removeItem: @MainActor @Sendable (URL) throws -> Void
+
+  private var preparationTask: Task<Bool, Never>?
+  private var containmentRefused = false
+
+  public convenience init(
+    adapter: EGOneDeliveryAdapter,
+    appSupportDirectory: URL,
+    defaults: UserDefaults? = nil,
+    trustedArtifact: TrustedArtifact = shippedLegacyArtifact
+  ) {
+    self.init(
+      appSupportDirectory: appSupportDirectory,
+      defaults: defaults
+        ?? UserDefaults(suiteName: DeliveryFlags.suiteName)
+        ?? .standard,
+      trustedArtifact: trustedArtifact,
+      ensureCurrentModel: { [weak adapter] in
+        guard let adapter else {
+          return .failed(DeliveryFailure(reason: .unknown, detail: "adapter_released"))
+        }
+        return await adapter.ensureAvailable()
+      },
+      currentModelIsAdmitted: { [weak adapter] in
+        guard let adapter else { return false }
+        return await adapter.isAdmitted()
+      }
+    )
+
+    // The adapter retains these closures, and therefore this coordinator.
+    // The coordinator's adapter closures above are weak: no cycle.
+    adapter.installLegacyUpgradeHooks(
+      beforeEnsure: { [self] in await prepareForDownload() },
+      beforeDecline: { [self] in recordUserDecline() },
+      onAdmitted: { [self] in handleAdmission() }
+    )
+  }
+
+  /// Internal test seam. It changes no production abstraction.
+  init(
+    appSupportDirectory: URL,
+    defaults: UserDefaults,
+    trustedArtifact: TrustedArtifact,
+    ensureCurrentModel:
+      @escaping @MainActor @Sendable () async -> ModelDeliveryController.DeliveryOutcome,
+    currentModelIsAdmitted: @escaping @MainActor @Sendable () async -> Bool,
+    hashFile: (@Sendable (URL) async throws -> String)? = nil,
+    writeMarker: (@MainActor @Sendable (URL) -> Bool)? = nil,
+    removeItem: (@MainActor @Sendable (URL) throws -> Void)? = nil
+  ) {
+    self.appSupportDirectory = appSupportDirectory
+    self.defaults = defaults
+    self.trustedArtifact = trustedArtifact
+    self.ensureCurrentModel = ensureCurrentModel
+    self.currentModelIsAdmitted = currentModelIsAdmitted
+    self.hashFile = hashFile ?? Self.streamingSHA256
+    self.writeMarker = writeMarker ?? Self.atomicWriteMarker
+    self.removeItem = removeItem ?? { try FileManager.default.removeItem(at: $0) }
+  }
+
+  private var oldStoreDirectory: URL {
+    appSupportDirectory.appendingPathComponent(
+      "EnviousWispr/PolishModels", isDirectory: true)
+  }
+
+  private var legacyArtifactURL: URL {
+    oldStoreDirectory.appendingPathComponent(trustedArtifact.name)
+  }
+
+  private var metadataDirectory: URL {
+    appSupportDirectory.appendingPathComponent(
+      "EnviousWispr/ModelDelivery", isDirectory: true)
+  }
+
+  private var owedMarkerURL: URL {
+    metadataDirectory.appendingPathComponent("eg1-v1-replacement-owed")
+  }
+
+  private var isReplacementOwed: Bool {
+    FileManager.default.fileExists(atPath: owedMarkerURL.path)
+  }
+
+  // C1 - One real switch for adapter and coordinator.
+  private var isEnabled: Bool {
+    EGOneDeliveryAdapter.isDeliveryEnabled(defaults: defaults)
+  }
+
+  // C2 - Prepare before the admitted return so an exact reintroduced monolith
+  // is still retired.
+  public func runLaunch() async {
+    guard isEnabled else { return }
+
+    let admitted = await currentModelIsAdmitted()
+
+    guard await prepareForDownload(), !containmentRefused else { return }
+
+    if admitted {
+      handleAdmission()
+      return
+    }
+
+    guard isReplacementOwed else { return }
+
+    // C7 - The existing adapter/controller is the only download door.
+    let outcome = await ensureCurrentModel()
+    if case .admitted = outcome {
+      handleAdmission()
+    }
+  }
+
+  // C3 - Launch and a simultaneous Download click share one fingerprint/delete.
+  func prepareForDownload() async -> Bool {
+    guard isEnabled else { return false }
+
+    if let preparationTask {
+      return await preparationTask.value
+    }
+
+    let task = Task { @MainActor [self] in
+      await prepareOnce()
+    }
+    preparationTask = task
+    let result = await task.value
+    preparationTask = nil
+    return result
+  }
+
+  private func prepareOnce() async -> Bool {
+    guard isEnabled else { return false }
+
+    containmentRefused = false
+
+    // C4 - Compare resolved candidate to a tree built from the resolved root.
+    let resolvedRoot =
+      appSupportDirectory.resolvingSymlinksInPath().standardizedFileURL
+    let canonicalTree = resolvedRoot.appendingPathComponent(
+      "EnviousWispr", isDirectory: true
+    ).standardizedFileURL
+    let resolvedOldStore =
+      oldStoreDirectory.resolvingSymlinksInPath().standardizedFileURL
+    guard resolvedOldStore.path.hasPrefix(canonicalTree.path + "/") else {
+      containmentRefused = true
+      emit(.legacyRetirementFailed(reason: .containment))
+      return true
+    }
+
+    sweepExactRetiredSidecars()
+
+    if isReplacementOwed {
+      return await retireMarkerBackedArtifactIfNeeded()
+    }
+
+    // C4 - Exact path + regular file + size + digest.
+    switch await fingerprintLegacyArtifact() {
+    case .absent, .mismatch:
+      return true
+
+    case .unreadable:
+      emit(.legacyRetirementFailed(reason: .unreadable))
+      return true
+
+    case .match:
+      emit(.legacyDetected)
+
+      // C5 - Marker is the linearization point and precedes unlink.
+      guard writeMarker(owedMarkerURL) else {
+        emit(.legacyRetirementFailed(reason: .markerWrite))
+        return false
+      }
+
+      do {
+        // No suspension occurs between successful marker persistence and unlink.
+        try removeItem(legacyArtifactURL)
+      } catch {
+        // C6 - Keep the marker and block the replacement.
+        emit(.legacyRetirementFailed(reason: .delete))
+        return false
+      }
+
+      emit(.legacyRetired)
+      cleanRetiredStoreMetadataAfterProvenOwnership()
+      return true
+    }
+  }
+
+  private func retireMarkerBackedArtifactIfNeeded() async -> Bool {
+    switch await fingerprintLegacyArtifact() {
+    case .absent:
+      cleanRetiredStoreMetadataAfterProvenOwnership()
+      return true
+
+    case .match:
+      emit(.legacyDetected)
+      do {
+        try removeItem(legacyArtifactURL)
+      } catch {
+        emit(.legacyRetirementFailed(reason: .delete))
+        return false
+      }
+      emit(.legacyRetired)
+      cleanRetiredStoreMetadataAfterProvenOwnership()
+      return true
+
+    case .mismatch:
+      // The marker proves a replacement is owed, but no longer proves these
+      // changed bytes are ours. Preserve them and continue the replacement.
+      return true
+
+    case .unreadable:
+      // It may still be the trusted artifact. Refuse to delete or duplicate it
+      // until it can be classified.
+      emit(.legacyRetirementFailed(reason: .unreadable))
+      return false
+    }
+  }
+
+  private func fingerprintLegacyArtifact() async -> Fingerprint {
+    let url = legacyArtifactURL
+    let fm = FileManager.default
+
+    guard fm.fileExists(atPath: url.path) else { return .absent }
+
+    let values: URLResourceValues
+    do {
+      values = try url.resourceValues(
+        forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey])
+    } catch {
+      return .unreadable
+    }
+
+    guard values.isSymbolicLink != true,
+      values.isRegularFile == true,
+      let fileSize = values.fileSize,
+      Int64(fileSize) == trustedArtifact.sizeBytes
+    else {
+      return .mismatch
+    }
+
+    do {
+      return try await hashFile(url) == trustedArtifact.sha256 ? .match : .mismatch
+    } catch {
+      return .unreadable
+    }
+  }
+
+  private func sweepExactRetiredSidecars() {
+    for name in [
+      "\(trustedArtifact.name).partial",
+      "\(trustedArtifact.name).resume.json",
+    ] {
+      let url = oldStoreDirectory.appendingPathComponent(name)
+      if FileManager.default.fileExists(atPath: url.path) {
+        try? removeItem(url)
+      }
+    }
+    removeOldStoreIfEmpty()
+  }
+
+  private func cleanRetiredStoreMetadataAfterProvenOwnership() {
+    for name in [
+      "installed-manifest.json",
+      "\(trustedArtifact.name).partial",
+      "\(trustedArtifact.name).resume.json",
+    ] {
+      let url = oldStoreDirectory.appendingPathComponent(name)
+      if FileManager.default.fileExists(atPath: url.path) {
+        try? removeItem(url)
+      }
+    }
+    removeOldStoreIfEmpty()
+  }
+
+  private func removeOldStoreIfEmpty() {
+    guard
+      let entries = try? FileManager.default.contentsOfDirectory(
+        at: oldStoreDirectory,
+        includingPropertiesForKeys: nil
+      ),
+      entries.isEmpty
+    else {
+      return
+    }
+    try? removeItem(oldStoreDirectory)
+  }
+
+  // C8 - Admission clears the marker only while model delivery is enabled and
+  // preparation did not refuse the old-store topology.
+  private func handleAdmission() {
+    guard isEnabled, !containmentRefused else { return }
+    let wasOwed = isReplacementOwed
+    guard clearOwedMarker() else { return }
+    if wasOwed {
+      emit(.replacementCompleted)
+    }
+  }
+
+  // C9 - Explicit Cancel/Remove records decline even while delivery is off.
+  func recordUserDecline() -> Bool {
+    let wasOwed = isReplacementOwed
+    guard clearOwedMarker() else { return false }
+    if wasOwed {
+      emit(.replacementDeclined)
+    }
+    return true
+  }
+
+  @discardableResult
+  private func clearOwedMarker() -> Bool {
+    guard isReplacementOwed else { return true }
+    do {
+      try removeItem(owedMarkerURL)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  // C10 - Typed, bounded, content-free events.
+  private func emit(_ event: Event) {
+    onEvent?(event)
+  }
+
+  private static func atomicWriteMarker(_ url: URL) -> Bool {
+    do {
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try Data().write(to: url, options: .atomic)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private nonisolated static func streamingSHA256(of url: URL) async throws -> String {
+    try await Task.detached(priority: .utility) {
+      let handle = try FileHandle(forReadingFrom: url)
+      defer { try? handle.close() }
+
+      var hasher = SHA256()
+      while true {
+        try Task.checkCancellation()
+        let chunk = try handle.read(upToCount: 4 * 1_024 * 1_024) ?? Data()
+        if chunk.isEmpty { break }
+        hasher.update(data: chunk)
+      }
+      return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }.value
+  }
+}

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -282,6 +282,19 @@ public final class EGOneRuntime: EGOneEndpointProviding {
     activateAndProbe()
   }
 
+  /// Automatic legacy replacement completed (#1386 PR-1, PR #1500 cloud P1):
+  /// an explicit activation trigger parallel to a completed user download
+  /// (`startDownload`'s admitted branch). The runtime owns the policy and
+  /// starts only when EG-1 is the live effective provider. Never called
+  /// reactively from the install-state stream (activation-loop precedent
+  /// above). Non-admitted cancellation, failure, or decline boots nothing;
+  /// admission-winning races retain the trusted model and may activate
+  /// normally.
+  public func activateAfterAutomaticReplacementIfNeeded() {
+    guard isActiveProvider?() == true else { return }
+    activateAndProbe()
+  }
+
   /// Orphan reap for no-spawn paths (#1271 confirm round + r11): a crash
   /// bypasses `applicationWillTerminate`, and when nothing spawns this
   /// session (provider not EG-1, model missing, manifest blocked) the

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -322,14 +322,21 @@ import Testing
   /// presenter's own wiring was extracted into `.live(...)` to keep the root lean;
   /// all decision logic lives on the presenter, not here. Cap by deterministic
   /// rule (actual 1018 + 7, rounded up to nearest 5 = 1025).
+  /// Ratcheted 1025→1045 in #1386 PR-1 (2026-07-11): the composition root
+  /// constructs `EGOneLegacyUpgradeCoordinator` over the existing adapter,
+  /// wires its telemetry handler (attaching `selected_provider` here, where
+  /// settings is in scope, so the coordinator stays provider-ignorant), and
+  /// runs the one-time legacy launch table after the first-run baseline. All
+  /// retirement logic lives on the coordinator, not here. Cap by deterministic
+  /// rule (actual 1041 + ~2, rounded up to nearest 5 = 1045).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1025,
+      lineCount <= 1045,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 995. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1045. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -52,7 +52,7 @@ import Testing
   /// A synthetic componentSet manifest (2 shards + `entrypointFile`),
   /// independent of the real shipped manifest — tiny bytes so tests can stage
   /// a REAL admissible cache (zeros, 1000 + 2000 bytes) with no network.
-  fileprivate static func shardedFixtureRegistration(install: URL, metadata: URL) throws
+  static func shardedFixtureRegistration(install: URL, metadata: URL) throws
     -> DeliveryRegistration
   {
     func sha256(_ data: Data) -> String {

--- a/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneDeliveryAdapterTests.swift
@@ -39,11 +39,9 @@ import Testing
     }
   }
 
-  // MARK: - Legacy store partial migration (cloud-review P2, PR #1384)
-
   private func makeTempDirs() throws -> (install: URL, metadata: URL, cleanup: () -> Void) {
     let root = FileManager.default.temporaryDirectory
-      .appendingPathComponent("eg1-migrate-\(UUID().uuidString)", isDirectory: true)
+      .appendingPathComponent("eg1-adapter-\(UUID().uuidString)", isDirectory: true)
     let install = root.appendingPathComponent("PolishModels", isDirectory: true)
     let metadata = root.appendingPathComponent("ModelDelivery", isDirectory: true)
     try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
@@ -51,24 +49,10 @@ import Testing
     return (install, metadata, { try? FileManager.default.removeItem(at: root) })
   }
 
-  /// Build the shipped EG-1 delivery manifest so the adapter's install name +
-  /// expected size are real (`eg-1-v1.gguf`, 2_889_511_680).
-  private func eg1Registration(install: URL, metadata: URL) throws -> DeliveryRegistration {
-    let url = URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent().deletingLastPathComponent()
-      .deletingLastPathComponent().deletingLastPathComponent()
-      .appendingPathComponent("Sources/EnviousWispr/Resources/eg1-delivery-manifest.json")
-    let manifest = try DeliveryManifest.load(from: Data(contentsOf: url))
-    return DeliveryRegistration(
-      manifest: manifest, installDirectory: install, metadataDirectory: metadata)
-  }
-
   /// A synthetic componentSet manifest (2 shards + `entrypointFile`),
-  /// independent of the real shipped manifest (still single-file until the
-  /// shard-authoring step, #1417 §3.5) — proves `installedArtifactURL` and
-  /// `migrateLegacyStoreArtifacts`'s size check against an ACTUALLY sharded
-  /// manifest, not just the current single-file one.
-  private func shardedFixtureRegistration(install: URL, metadata: URL) throws
+  /// independent of the real shipped manifest — tiny bytes so tests can stage
+  /// a REAL admissible cache (zeros, 1000 + 2000 bytes) with no network.
+  fileprivate static func shardedFixtureRegistration(install: URL, metadata: URL) throws
     -> DeliveryRegistration
   {
     func sha256(_ data: Data) -> String {
@@ -111,125 +95,11 @@ import Testing
   @Test func installedArtifactURLResolvesToEntrypointShardForComponentSetManifest() throws {
     let dirs = try makeTempDirs()
     defer { dirs.cleanup() }
-    let registration = try shardedFixtureRegistration(
+    let registration = try Self.shardedFixtureRegistration(
       install: dirs.install, metadata: dirs.metadata)
     let adapter = EGOneDeliveryAdapter(
       controller: ModelDeliveryController(), registration: registration, version: "v2-sharded")
     #expect(adapter.installedArtifactURL.lastPathComponent == "eg-1-00001-of-00002.gguf")
-  }
-
-  @MainActor
-  @Test func migrateLegacyStoreArtifactsSizeCheckUsesEntrypointSizeNotSum() throws {
-    let dirs = try makeTempDirs()
-    defer { dirs.cleanup() }
-    let registration = try shardedFixtureRegistration(
-      install: dirs.install, metadata: dirs.metadata)
-    let entrypointPath = try #require(registration.manifest.resolvedEntrypointPath)
-    // Entrypoint shard (shard 1) is 1000 bytes; shard 2 is 2000; sum is 3000.
-    // A `.partial` sized to the SUM would be wrong — it can only ever contain
-    // shard 1's own bytes. Size it to 1000 (shard 1's own size) and confirm
-    // the migration recognizes it as complete and promotes.
-    let partial = dirs.install.appendingPathComponent("\(entrypointPath).partial")
-    #expect(FileManager.default.createFile(atPath: partial.path, contents: nil))
-    let handle = try FileHandle(forWritingTo: partial)
-    try handle.truncate(atOffset: 1000)
-    try handle.close()
-
-    _ = EGOneDeliveryAdapter(
-      controller: ModelDeliveryController(), registration: registration, version: "v2-sharded")
-
-    #expect(
-      FileManager.default.fileExists(
-        atPath: dirs.install.appendingPathComponent(entrypointPath).path),
-      "the entrypoint-sized (not sum-sized) partial was promoted")
-    #expect(!FileManager.default.fileExists(atPath: partial.path))
-  }
-
-  @MainActor
-  @Test func completeLegacyPartialIsPromotedNotDeleted() throws {
-    let dirs = try makeTempDirs()
-    defer { dirs.cleanup() }
-    let registration = try eg1Registration(install: dirs.install, metadata: dirs.metadata)
-    // #1417: derive the expected install name and size from
-    // `resolvedEntrypointPath` — never a hardcoded legacy literal — so this
-    // test stays correct once the shipped manifest becomes N shards (the
-    // entrypoint's own name/size then, same as today's single file now).
-    let entrypointPath = try #require(registration.manifest.resolvedEntrypointPath)
-    let expectedSize = try #require(
-      registration.manifest.files.first(where: { $0.resolvedInstallPath == entrypointPath })?
-        .sizeBytes)
-    // A completed-but-not-installed download: full-size .partial, no install
-    // file. The .partial must REPORT the manifest's expected size (~2.9 GB) so
-    // the migration's size-match promote branch fires — but as a SPARSE file
-    // (truncate, no allocation) so the test never materializes gigabytes of RAM
-    // or disk on CI (cloud-review P1). The migration promotes via rename (O(1)),
-    // never a byte copy, so a sparse source is faithful.
-    let partial = dirs.install.appendingPathComponent("\(entrypointPath).partial")
-    let resume = dirs.install.appendingPathComponent("\(entrypointPath).resume.json")
-    #expect(FileManager.default.createFile(atPath: partial.path, contents: nil))
-    let handle = try FileHandle(forWritingTo: partial)
-    try handle.truncate(atOffset: UInt64(expectedSize))
-    try handle.close()
-    try Data("{}".utf8).write(to: resume)
-
-    _ = EGOneDeliveryAdapter(
-      controller: ModelDeliveryController(), registration: registration, version: "v1")
-
-    let fm = FileManager.default
-    // Promoted to the install name (so adoption can verify + admit offline).
-    #expect(fm.fileExists(atPath: dirs.install.appendingPathComponent(entrypointPath).path))
-    #expect(!fm.fileExists(atPath: partial.path))
-    #expect(!fm.fileExists(atPath: resume.path), "stale resume sidecar removed")
-  }
-
-  @MainActor
-  @Test func incompleteLegacyPartialIsReclaimed() throws {
-    let dirs = try makeTempDirs()
-    defer { dirs.cleanup() }
-    let registration = try eg1Registration(install: dirs.install, metadata: dirs.metadata)
-    let entrypointPath = try #require(registration.manifest.resolvedEntrypointPath)
-    // An interrupted download: short .partial, no install file.
-    let partial = dirs.install.appendingPathComponent("\(entrypointPath).partial")
-    try Data(count: 4096).write(to: partial)
-
-    _ = EGOneDeliveryAdapter(
-      controller: ModelDeliveryController(), registration: registration, version: "v1")
-
-    let fm = FileManager.default
-    // Reclaimed (no partial install file left behind); no bogus install created.
-    #expect(!fm.fileExists(atPath: partial.path))
-    #expect(!fm.fileExists(atPath: dirs.install.appendingPathComponent(entrypointPath).path))
-  }
-
-  @MainActor
-  @Test func staleOtherVersionSidecarsSweptButModelsKept() throws {
-    // Cloud-review P2 (#1363): a version bump (e.g. EG-2/EG-3 hot-swap) must not
-    // orphan an OLD version's download sidecars forever. The migration sweeps
-    // every .partial/.resume.json in the install dir regardless of version, but
-    // NEVER deletes a completed .gguf model (a superseded model is the user's
-    // working polish until the new one downloads; the founder's real install must
-    // survive).
-    let dirs = try makeTempDirs()
-    defer { dirs.cleanup() }
-    let registration = try eg1Registration(install: dirs.install, metadata: dirs.metadata)
-    let fm = FileManager.default
-    // An interrupted download from a DIFFERENT version + a completed model of
-    // that older version (neither matches the current manifest's v1 name).
-    let staleModel = dirs.install.appendingPathComponent("eg-1-v0.gguf")
-    let stalePartial = dirs.install.appendingPathComponent("eg-1-v0.gguf.partial")
-    let staleResume = dirs.install.appendingPathComponent("eg-1-v0.gguf.resume.json")
-    try Data("old-model-bytes".utf8).write(to: staleModel)
-    try Data(count: 4096).write(to: stalePartial)
-    try Data("{}".utf8).write(to: staleResume)
-
-    _ = EGOneDeliveryAdapter(
-      controller: ModelDeliveryController(), registration: registration, version: "v1")
-
-    #expect(!fm.fileExists(atPath: stalePartial.path), "stale partial swept (any version)")
-    #expect(!fm.fileExists(atPath: staleResume.path), "stale resume sidecar swept (any version)")
-    #expect(
-      fm.fileExists(atPath: staleModel.path),
-      "a completed .gguf model is never deleted by migration")
   }
 
   @Test func failureClassBucketsMatchExistingCopy() {
@@ -243,5 +113,172 @@ import Testing
     #expect(EGOneDeliveryAdapter.mapFailure(.cancelled) == .cancelled)
     #expect(EGOneDeliveryAdapter.mapFailure(.permissionDenied) == .http)
     #expect(EGOneDeliveryAdapter.mapFailure(.unknown) == .http)
+  }
+}
+
+/// Integration of the adapter's decline/admission hooks with the REAL
+/// coordinator and REAL controller (#1386 PR-1): Cancel/Remove persist the
+/// user's decline into the owed marker before any controller work, and
+/// admission through any door clears it. Tiny fixture manifest, zero network.
+@Suite struct EGOneLegacyUpgradeIntegrationTests {
+  private struct Harness {
+    let root: URL
+    let store: UserDefaults
+    let suite: String
+    let adapter: EGOneDeliveryAdapter
+    let coordinator: EGOneLegacyUpgradeCoordinator
+    let controller: ModelDeliveryController
+    let registration: DeliveryRegistration
+    let events: EventBox
+
+    func cleanup() {
+      store.removePersistentDomain(forName: suite)
+      try? FileManager.default.removeItem(at: root)
+    }
+  }
+
+  @MainActor
+  final class EventBox {
+    var events: [EGOneLegacyUpgradeCoordinator.Event] = []
+  }
+
+  private func markerURL(_ root: URL) -> URL {
+    root.appendingPathComponent("EnviousWispr/ModelDelivery/eg1-v1-replacement-owed")
+  }
+
+  @MainActor
+  private func makeHarness() throws -> Harness {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "eg1-integration-\(UUID().uuidString)", isDirectory: true)
+    let install = root.appendingPathComponent("EnviousWispr/Models/eg-1", isDirectory: true)
+    let metadata = root.appendingPathComponent("EnviousWispr/ModelDelivery", isDirectory: true)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+
+    let suite = "eg1-integration-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: install, metadata: metadata)
+    // The actor gets its OWN suite instance (region-moved), never the test
+    // body's — the ModelDeliveryControllerTests isolation pattern.
+    let controller = ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!)
+    let adapter = EGOneDeliveryAdapter(
+      controller: controller, registration: registration, version: "v2-sharded",
+      defaults: store)
+    let coordinator = EGOneLegacyUpgradeCoordinator(
+      adapter: adapter, appSupportDirectory: root, defaults: store)
+    let events = EventBox()
+    coordinator.onEvent = { [events] event in
+      events.events.append(event)
+    }
+    return Harness(
+      root: root, store: store, suite: suite, adapter: adapter,
+      coordinator: coordinator, controller: controller, registration: registration,
+      events: events)
+  }
+
+  private func stageMarker(_ root: URL) throws {
+    let url = markerURL(root)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data().write(to: url)
+  }
+
+  /// Stage byte-valid shard files so `admitIfComplete` can admit offline.
+  private func stageValidShards(_ registration: DeliveryRegistration) throws {
+    try Data(count: 1000).write(
+      to: registration.installDirectory.appendingPathComponent("eg-1-00001-of-00002.gguf"))
+    try Data(count: 2000).write(
+      to: registration.installDirectory.appendingPathComponent("eg-1-00002-of-00002.gguf"))
+  }
+
+  @MainActor
+  @Test func cancelClearsMarkerBeforeControllerCancel() async throws {
+    let h = try makeHarness()
+    defer { h.cleanup() }
+    try stageMarker(h.root)
+
+    await h.adapter.cancel()
+
+    #expect(!FileManager.default.fileExists(atPath: markerURL(h.root).path))
+    #expect(h.events.events == [.replacementDeclined])
+  }
+
+  @MainActor
+  @Test func cancelWhileKillSwitchOffClearsOwedMarkerAndDoesNotResume() async throws {
+    let h = try makeHarness()
+    defer { h.cleanup() }
+    try stageMarker(h.root)
+
+    h.store.set(false, forKey: DeliveryFlags.key("enabled", family: .egOne))
+    await h.adapter.cancel()
+
+    #expect(
+      !FileManager.default.fileExists(atPath: markerURL(h.root).path),
+      "contract §5c.10: the switch never silences an explicit decline")
+    #expect(h.events.events == [.replacementDeclined])
+
+    // Switch back on: the launch table finds no marker and starts nothing.
+    h.store.set(true, forKey: DeliveryFlags.key("enabled", family: .egOne))
+    await h.coordinator.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: markerURL(h.root).path))
+    #expect(await h.controller.isAdmitted(h.registration) == false)
+    #expect(
+      h.events.events == [.replacementDeclined],
+      "no detection, retirement, or completion after the decline")
+  }
+
+  @MainActor
+  @Test func cancelLosingAdmissionRaceLeavesAdmittedModelInstalledAndMarkerCleared()
+    async throws
+  {
+    let h = try makeHarness()
+    defer { h.cleanup() }
+    try stageMarker(h.root)
+    try stageValidShards(h.registration)
+
+    // Admission wins the race first...
+    #expect(await h.adapter.adoptIfPresent())
+    #expect(!FileManager.default.fileExists(atPath: markerURL(h.root).path))
+
+    // ...then the user's Cancel lands late. The verified model stays.
+    await h.adapter.cancel()
+
+    #expect(await h.controller.isAdmitted(h.registration))
+    #expect(!FileManager.default.fileExists(atPath: markerURL(h.root).path))
+  }
+
+  @MainActor
+  @Test func removeClearsMarkerBeforeControllerRemoval() async throws {
+    let h = try makeHarness()
+    defer { h.cleanup() }
+    try stageValidShards(h.registration)
+    #expect(await h.adapter.adoptIfPresent())
+    try stageMarker(h.root)
+
+    let outcome = await h.adapter.remove()
+
+    #expect(outcome == .removed)
+    #expect(!FileManager.default.fileExists(atPath: markerURL(h.root).path))
+    #expect(await h.controller.isAdmitted(h.registration) == false)
+    #expect(h.events.events.contains(.replacementDeclined))
+  }
+
+  @MainActor
+  @Test func manualDownloadAdmissionClearsMarker() async throws {
+    // A user's own Try Again/adoption completing the replacement counts: the
+    // marker clears through the same admission hook, no coordinator launch
+    // pass required.
+    let h = try makeHarness()
+    defer { h.cleanup() }
+    try stageMarker(h.root)
+    try stageValidShards(h.registration)
+
+    #expect(await h.adapter.adoptIfPresent())
+
+    #expect(!FileManager.default.fileExists(atPath: markerURL(h.root).path))
+    #expect(h.events.events.contains(.replacementCompleted))
   }
 }

--- a/Tests/EnviousWisprTests/LLM/EGOneLegacyUpgradeCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneLegacyUpgradeCoordinatorTests.swift
@@ -1,0 +1,827 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+@testable import EnviousWisprModelDelivery
+
+/// The one-time EG-1 monolith retirement (#1386 PR-1): exact-fingerprint
+/// recognition, the owed marker's lifecycle (born once, cleared only by
+/// admission or explicit decline), the containment gate, and crash recovery
+/// from disk truth alone. Every destructive path is proven against its
+/// negative twin: same-size wrong bytes, renamed files, symlinked stores.
+@Suite struct EGOneLegacyUpgradeCoordinatorTests {
+  @MainActor
+  private final class Probe {
+    var admitted = false
+    var ensureCount = 0
+    var ensureOutcome: ModelDeliveryController.DeliveryOutcome =
+      .failed(DeliveryFailure(reason: .sourceUnreachable))
+    var markerExistedAtDelete = false
+    var hashCount = 0
+    var events: [EGOneLegacyUpgradeCoordinator.Event] = []
+  }
+
+  private func digest(_ data: Data) -> String {
+    SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+  }
+
+  private func makeRoot() throws -> URL {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "eg1-legacy-upgrade-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: root, withIntermediateDirectories: true)
+    return root
+  }
+
+  private func oldStore(_ root: URL) -> URL {
+    root.appendingPathComponent("EnviousWispr/PolishModels", isDirectory: true)
+  }
+
+  private func marker(_ root: URL) -> URL {
+    root.appendingPathComponent("EnviousWispr/ModelDelivery/eg1-v1-replacement-owed")
+  }
+
+  private func defaults() throws -> (UserDefaults, String) {
+    let suite = "eg1-legacy-test-\(UUID().uuidString)"
+    return (try #require(UserDefaults(suiteName: suite)), suite)
+  }
+
+  @discardableResult
+  private func stageLegacy(
+    root: URL,
+    name: String = "eg-1-v1.gguf",
+    bytes: Data
+  ) throws -> URL {
+    let directory = oldStore(root)
+    try FileManager.default.createDirectory(
+      at: directory, withIntermediateDirectories: true)
+    let url = directory.appendingPathComponent(name)
+    try bytes.write(to: url)
+    return url
+  }
+
+  private func stageMarker(_ root: URL) throws {
+    let url = marker(root)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data().write(to: url)
+  }
+
+  @MainActor
+  private func coordinator(
+    root: URL,
+    defaults: UserDefaults,
+    bytes: Data,
+    probe: Probe,
+    writeMarker: (@MainActor @Sendable (URL) -> Bool)? = nil,
+    removeItem: (@MainActor @Sendable (URL) throws -> Void)? = nil,
+    hashError: Bool = false
+  ) -> EGOneLegacyUpgradeCoordinator {
+    let subject = EGOneLegacyUpgradeCoordinator(
+      appSupportDirectory: root,
+      defaults: defaults,
+      trustedArtifact: .init(
+        name: "eg-1-v1.gguf",
+        sizeBytes: Int64(bytes.count),
+        sha256: digest(bytes)
+      ),
+      ensureCurrentModel: {
+        probe.ensureCount += 1
+        return probe.ensureOutcome
+      },
+      currentModelIsAdmitted: {
+        probe.admitted
+      },
+      hashFile: { url in
+        await MainActor.run { probe.hashCount += 1 }
+        if hashError { throw CocoaError(.fileReadUnknown) }
+        let data = try Data(contentsOf: url)
+        return SHA256.hash(data: data)
+          .map { String(format: "%02x", $0) }
+          .joined()
+      },
+      writeMarker: writeMarker,
+      removeItem: removeItem
+    )
+    subject.onEvent = { event in
+      probe.events.append(event)
+    }
+    return subject
+  }
+
+  // MARK: - Retirement happy path and its failure twins
+
+  @MainActor
+  @Test func matchingMonolithWritesMarkerBeforeDeleteAndStartsReplacement() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted-legacy".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    let probe = Probe()
+    let markerURL = marker(root)
+
+    let subject = coordinator(
+      root: root,
+      defaults: store,
+      bytes: bytes,
+      probe: probe,
+      removeItem: { url in
+        if url == artifact {
+          probe.markerExistedAtDelete =
+            FileManager.default.fileExists(atPath: markerURL.path)
+        }
+        try FileManager.default.removeItem(at: url)
+      }
+    )
+
+    await subject.runLaunch()
+
+    #expect(probe.markerExistedAtDelete, "marker persistence precedes unlink")
+    #expect(!FileManager.default.fileExists(atPath: artifact.path))
+    #expect(FileManager.default.fileExists(atPath: markerURL.path))
+    #expect(probe.ensureCount == 1)
+    #expect(probe.events == [.legacyDetected, .legacyRetired])
+  }
+
+  @MainActor
+  @Test func markerWriteFailurePreservesMonolithAndBlocksDownload() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted-legacy".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    let probe = Probe()
+
+    let subject = coordinator(
+      root: root,
+      defaults: store,
+      bytes: bytes,
+      probe: probe,
+      writeMarker: { _ in false }
+    )
+
+    await subject.runLaunch()
+
+    #expect(FileManager.default.fileExists(atPath: artifact.path))
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 0)
+    #expect(probe.events.contains(.legacyRetirementFailed(reason: .markerWrite)))
+  }
+
+  @MainActor
+  @Test func matchingMonolithDeleteFailureKeepsMarkerAndBlocksDownload() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    struct Denied: Error {}
+
+    let bytes = Data("trusted-legacy".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    let probe = Probe()
+
+    let subject = coordinator(
+      root: root,
+      defaults: store,
+      bytes: bytes,
+      probe: probe,
+      removeItem: { url in
+        if url == artifact { throw Denied() }
+        try FileManager.default.removeItem(at: url)
+      }
+    )
+
+    await subject.runLaunch()
+
+    #expect(FileManager.default.fileExists(atPath: artifact.path))
+    #expect(FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 0)
+    #expect(probe.events.contains(.legacyRetirementFailed(reason: .delete)))
+  }
+
+  // MARK: - Fingerprint negative controls
+
+  @MainActor
+  @Test func sameSizeWrongBytesAreUntouched() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let trusted = Data("trusted".utf8)
+    let wrong = Data("strange".utf8)
+    #expect(trusted.count == wrong.count)
+
+    let artifact = try stageLegacy(root: root, bytes: wrong)
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: trusted, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(try Data(contentsOf: artifact) == wrong)
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 0)
+    #expect(probe.events.isEmpty)
+  }
+
+  @MainActor
+  @Test func correctBytesUnderRenamedFileAreUntouched() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    let renamed = try stageLegacy(
+      root: root, name: "renamed-eg-1.gguf", bytes: bytes)
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: bytes, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(FileManager.default.fileExists(atPath: renamed.path))
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 0)
+  }
+
+  @MainActor
+  @Test func absentMonolithDoesNotCreateMarkerOrAutoDownload() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 0)
+    #expect(probe.hashCount == 0)
+    #expect(probe.events.isEmpty)
+  }
+
+  @MainActor
+  @Test func unreadableMonolithIsPreservedAndDoesNotBlockManualDownload() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: bytes, probe: probe, hashError: true)
+
+    let prepared = await subject.prepareForDownload()
+
+    #expect(prepared, "an unclassifiable file must not brick manual downloads")
+    #expect(FileManager.default.fileExists(atPath: artifact.path))
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.events.contains(.legacyRetirementFailed(reason: .unreadable)))
+  }
+
+  // MARK: - Marker lifecycle and crash recovery (disk truth alone)
+
+  @MainActor
+  @Test func markerWithoutMonolithResumesReplacement() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stageMarker(root)
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 1)
+    #expect(FileManager.default.fileExists(atPath: marker(root).path))
+  }
+
+  @MainActor
+  @Test func failedReplacementKeepsMarker() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    try stageLegacy(root: root, bytes: bytes)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 1)
+    #expect(FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(!probe.events.contains(.replacementCompleted))
+  }
+
+  @MainActor
+  @Test func admittedReplacementClearsMarker() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stageMarker(root)
+    let probe = Probe()
+    probe.admitted = true
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 0)
+    #expect(probe.events.contains(.replacementCompleted))
+  }
+
+  @MainActor
+  @Test func missedAdmissionClearIsRepairedAtLaunch() async throws {
+    // A prior session admitted the shards but quit before clearing the marker.
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stageMarker(root)
+    let probe = Probe()
+    probe.admitted = true
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.events == [.replacementCompleted])
+  }
+
+  @MainActor
+  @Test func crashRecoveryBeforeMarker() async throws {
+    // Crash before the marker write: disk shows only the monolith, and a fresh
+    // launch simply retries the whole classification.
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: artifact.path))
+    #expect(FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 1)
+  }
+
+  @MainActor
+  @Test func crashRecoveryAfterMarkerBeforeDelete() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    try stageMarker(root)
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: artifact.path))
+    #expect(FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 1)
+  }
+
+  @MainActor
+  @Test func crashRecoveryAfterDeleteBeforeEnsure() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stageMarker(root)
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 1)
+    #expect(FileManager.default.fileExists(atPath: marker(root).path))
+  }
+
+  @MainActor
+  @Test func crashRecoveryMidDownload() async throws {
+    // The controller owns staged-byte resume; the coordinator's whole job on
+    // relaunch is to call the same ensure door again.
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stageMarker(root)
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(probe.ensureCount == 1)
+    #expect(FileManager.default.fileExists(atPath: marker(root).path))
+  }
+
+  @MainActor
+  @Test func crashRecoveryAfterAdmissionBeforeClear() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stageMarker(root)
+    let probe = Probe()
+    probe.admitted = true
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 0)
+  }
+
+  @MainActor
+  @Test func admittedReplacementStillRetiresReintroducedExactMonolith() async throws {
+    // An old production build re-downloaded the monolith after the shards were
+    // already admitted. Launch must still classify and retire it.
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    let probe = Probe()
+    probe.admitted = true
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: artifact.path))
+    #expect(
+      !FileManager.default.fileExists(atPath: marker(root).path),
+      "admission immediately settles the freshly written marker")
+    #expect(probe.ensureCount == 0)
+    #expect(probe.events.contains(.legacyRetired))
+  }
+
+  @MainActor
+  @Test func markerPlusChangedMonolithPreservesUnknownBytesButContinuesReplacement()
+    async throws
+  {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let trusted = Data("trusted".utf8)
+    let changed = Data("strange".utf8)
+    let artifact = try stageLegacy(root: root, bytes: changed)
+    try stageMarker(root)
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: trusted, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(try Data(contentsOf: artifact) == changed)
+    #expect(probe.ensureCount == 1)
+  }
+
+  // MARK: - Kill switch
+
+  @MainActor
+  @Test func killSwitchOffPerformsNoHashWriteDeleteOrEnsure() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    store.set(false, forKey: DeliveryFlags.key("enabled", family: .egOne))
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(FileManager.default.fileExists(atPath: artifact.path))
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.hashCount == 0)
+    #expect(probe.ensureCount == 0)
+    #expect(probe.events.isEmpty)
+  }
+
+  @MainActor
+  @Test func killSwitchBackOnResumesClassification() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    store.set(false, forKey: DeliveryFlags.key("enabled", family: .egOne))
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+    await subject.runLaunch()
+    #expect(FileManager.default.fileExists(atPath: artifact.path))
+
+    store.set(true, forKey: DeliveryFlags.key("enabled", family: .egOne))
+    await subject.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: artifact.path))
+    #expect(FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.ensureCount == 1)
+  }
+
+  // MARK: - Retired-store sidecars
+
+  @MainActor
+  @Test func exactRetiredSidecarsAreSweptButLookalikesRemain() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let directory = oldStore(root)
+    try FileManager.default.createDirectory(
+      at: directory, withIntermediateDirectories: true)
+    let exactPartial = directory.appendingPathComponent("eg-1-v1.gguf.partial")
+    let exactResume = directory.appendingPathComponent("eg-1-v1.gguf.resume.json")
+    let lookalike = directory.appendingPathComponent("eg-1-v1.gguf.partial.bak")
+    let foreign = directory.appendingPathComponent("other.partial")
+    for url in [exactPartial, exactResume, lookalike, foreign] {
+      try Data("x".utf8).write(to: url)
+    }
+
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    _ = await subject.prepareForDownload()
+
+    let fm = FileManager.default
+    #expect(!fm.fileExists(atPath: exactPartial.path))
+    #expect(!fm.fileExists(atPath: exactResume.path))
+    #expect(fm.fileExists(atPath: lookalike.path))
+    #expect(fm.fileExists(atPath: foreign.path))
+  }
+
+  @MainActor
+  @Test func installedManifestIsRemovedOnlyAfterOwnershipProof() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let trusted = Data("trusted".utf8)
+    let wrong = Data("strange".utf8)
+    let directory = oldStore(root)
+    let installedManifest = directory.appendingPathComponent("installed-manifest.json")
+
+    // Unproven: wrong bytes under the exact name. The retired store's own
+    // metadata must survive alongside the unrecognized file.
+    try stageLegacy(root: root, bytes: wrong)
+    try Data("{}".utf8).write(to: installedManifest)
+
+    let probe = Probe()
+    let unproven = coordinator(root: root, defaults: store, bytes: trusted, probe: probe)
+    await unproven.runLaunch()
+    #expect(FileManager.default.fileExists(atPath: installedManifest.path))
+
+    // Proven: exact bytes. Retirement takes the metadata with it.
+    try stageLegacy(root: root, bytes: trusted)
+    let proven = coordinator(root: root, defaults: store, bytes: trusted, probe: probe)
+    await proven.runLaunch()
+    #expect(!FileManager.default.fileExists(atPath: installedManifest.path))
+  }
+
+  // MARK: - Single-flight preparation
+
+  @MainActor
+  @Test func concurrentPrepareCallsJoinOneFingerprint() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    try stageLegacy(root: root, bytes: bytes)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+
+    async let first = subject.prepareForDownload()
+    async let second = subject.prepareForDownload()
+    let results = await [first, second]
+
+    #expect(results == [true, true])
+    #expect(probe.hashCount == 1, "both callers join one fingerprint pass")
+  }
+
+  // MARK: - Containment gate
+
+  @MainActor
+  @Test func normalOldStorePassesContainmentGate() async throws {
+    // The /var -> /private/var regression oracle: the test root itself sits
+    // behind a system symlink, so a naive unresolved-prefix comparison would
+    // false-refuse this store and silently kill state C for every normal Mac.
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+    let artifact = try stageLegacy(root: root, bytes: bytes)
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(!FileManager.default.fileExists(atPath: artifact.path), "retirement ran")
+    #expect(
+      !probe.events.contains(.legacyRetirementFailed(reason: .containment)),
+      "a normal store must never trip the containment gate")
+  }
+
+  @MainActor
+  @Test func symlinkedPolishModelsDirectoryIsUntouched() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+
+    // The trusted artifact lives in an EXTERNAL directory; PolishModels is a
+    // symlink pointing at it.
+    let external = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "eg1-external-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: external) }
+    try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+    let externalArtifact = external.appendingPathComponent("eg-1-v1.gguf")
+    try bytes.write(to: externalArtifact)
+
+    let enviousTree = root.appendingPathComponent("EnviousWispr", isDirectory: true)
+    try FileManager.default.createDirectory(at: enviousTree, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(
+      at: enviousTree.appendingPathComponent("PolishModels"),
+      withDestinationURL: external)
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(FileManager.default.fileExists(atPath: externalArtifact.path))
+    #expect(probe.ensureCount == 0)
+    #expect(probe.hashCount == 0)
+    #expect(probe.events.contains(.legacyRetirementFailed(reason: .containment)))
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+  }
+
+  @MainActor
+  @Test func legacyArtifactEscapingAppSupportIsUntouched() async throws {
+    // The EnviousWispr component itself is a symlink to an external tree.
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let bytes = Data("trusted".utf8)
+
+    let external = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "eg1-external-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: external) }
+    let externalStore = external.appendingPathComponent("PolishModels", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: externalStore, withIntermediateDirectories: true)
+    let externalArtifact = externalStore.appendingPathComponent("eg-1-v1.gguf")
+    try bytes.write(to: externalArtifact)
+
+    try FileManager.default.createSymbolicLink(
+      at: root.appendingPathComponent("EnviousWispr"),
+      withDestinationURL: external)
+
+    let probe = Probe()
+    let subject = coordinator(root: root, defaults: store, bytes: bytes, probe: probe)
+
+    await subject.runLaunch()
+
+    #expect(FileManager.default.fileExists(atPath: externalArtifact.path))
+    #expect(probe.ensureCount == 0)
+    #expect(probe.events.contains(.legacyRetirementFailed(reason: .containment)))
+  }
+
+  @MainActor
+  @Test func sidecarsBehindSymlinkedOldStoreAreUntouched() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    let external = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "eg1-external-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: external) }
+    try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+    let partial = external.appendingPathComponent("eg-1-v1.gguf.partial")
+    let resume = external.appendingPathComponent("eg-1-v1.gguf.resume.json")
+    let partialBytes = Data("partial-bytes".utf8)
+    let resumeBytes = Data("{}".utf8)
+    try partialBytes.write(to: partial)
+    try resumeBytes.write(to: resume)
+
+    let enviousTree = root.appendingPathComponent("EnviousWispr", isDirectory: true)
+    try FileManager.default.createDirectory(at: enviousTree, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(
+      at: enviousTree.appendingPathComponent("PolishModels"),
+      withDestinationURL: external)
+
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    _ = await subject.prepareForDownload()
+
+    #expect(try Data(contentsOf: partial) == partialBytes)
+    #expect(try Data(contentsOf: resume) == resumeBytes)
+    #expect(probe.events.contains(.legacyRetirementFailed(reason: .containment)))
+  }
+
+  // MARK: - Decline
+
+  @MainActor
+  @Test func recordUserDeclineClearsMarkerAndEmitsOnce() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stageMarker(root)
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    #expect(subject.recordUserDecline())
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.events == [.replacementDeclined])
+
+    // Idempotent: a second decline with no marker succeeds and stays silent.
+    #expect(subject.recordUserDecline())
+    #expect(probe.events == [.replacementDeclined])
+  }
+
+  @MainActor
+  @Test func declineWhileKillSwitchOffStillClearsMarker() async throws {
+    // Contract §5c.10: the switch guards model bytes, never the user's
+    // recorded decision.
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let (store, suite) = try defaults()
+    defer { store.removePersistentDomain(forName: suite) }
+
+    try stageMarker(root)
+    store.set(false, forKey: DeliveryFlags.key("enabled", family: .egOne))
+
+    let probe = Probe()
+    let subject = coordinator(
+      root: root, defaults: store, bytes: Data("trusted".utf8), probe: probe)
+
+    #expect(subject.recordUserDecline())
+    #expect(!FileManager.default.fileExists(atPath: marker(root).path))
+    #expect(probe.events == [.replacementDeclined])
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
@@ -1,0 +1,274 @@
+import CryptoKit
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+@testable import EnviousWisprModelDelivery
+
+/// The post-replacement activation trigger (#1386 PR-1 addendum r4, PR #1500
+/// cloud P1): `activateAfterAutomaticReplacementIfNeeded()` starts EG-1 only
+/// when it is the LIVE effective provider at completion time. Real controller,
+/// real adapter, tiny fixture manifest, and a deliberately MISSING server
+/// binary: an activation attempt is unmistakable as the
+/// `server_binary_missing` health transition, while an inactive admitted
+/// state stays `yellow(not_started)`. Signal-based waits only — the health
+/// event stream is the signal; no wall-clock polling.
+@Suite struct EGOneRuntimeReplacementActivationTests {
+  @MainActor
+  private final class ProviderBox {
+    var isEGOneActive: Bool
+    init(_ isEGOneActive: Bool) { self.isEGOneActive = isEGOneActive }
+  }
+
+  /// Event-stream waiter: `next(where:)` suspends until a matching runtime
+  /// health event arrives (or returns a recorded one). The event IS the
+  /// signal; there is no clock.
+  @MainActor
+  private final class HealthSignal {
+    private var waiters:
+      [((EGOneRuntimeEvent) -> Bool, CheckedContinuation<EGOneRuntimeEvent, Never>)] = []
+    private(set) var events: [EGOneRuntimeEvent] = []
+
+    func record(_ event: EGOneRuntimeEvent) {
+      events.append(event)
+      if let index = waiters.firstIndex(where: { $0.0(event) }) {
+        let waiter = waiters.remove(at: index)
+        waiter.1.resume(returning: event)
+      }
+    }
+
+    func next(
+      where predicate: @escaping (EGOneRuntimeEvent) -> Bool
+    ) async -> EGOneRuntimeEvent {
+      if let event = events.first(where: predicate) {
+        return event
+      }
+      return await withCheckedContinuation { continuation in
+        waiters.append((predicate, continuation))
+      }
+    }
+
+    var sawServerBinaryMissing: Bool {
+      events.contains { event in
+        if case .healthChanged(_, _, "server_binary_missing") = event { return true }
+        return false
+      }
+    }
+  }
+
+  private struct Harness {
+    let root: URL
+    let store: UserDefaults
+    let suite: String
+    let adapter: EGOneDeliveryAdapter
+    let runtime: EGOneRuntime
+    let registration: DeliveryRegistration
+    let provider: ProviderBox
+    let signal: HealthSignal
+
+    func cleanup() {
+      store.removePersistentDomain(forName: suite)
+      try? FileManager.default.removeItem(at: root)
+    }
+  }
+
+  private func runtimeManifest() -> EGOneManifest {
+    EGOneManifest(
+      modelName: LLMProvider.egOneModelName,
+      version: "v2-sharded",
+      contextTokens: 4096,
+      promptTemplateID: "eg1-v1",
+      minAppVersion: "0",
+      downloadURL: URL(string: "https://example.invalid/eg1.gguf")!
+    )
+  }
+
+  @MainActor
+  private func makeHarness(egOneActive: Bool) throws -> Harness {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "eg1-activation-\(UUID().uuidString)", isDirectory: true)
+    let install = root.appendingPathComponent("EnviousWispr/Models/eg-1", isDirectory: true)
+    let metadata = root.appendingPathComponent("EnviousWispr/ModelDelivery", isDirectory: true)
+    try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: metadata, withIntermediateDirectories: true)
+
+    let suite = "eg1-activation-\(UUID().uuidString)"
+    let store = try #require(UserDefaults(suiteName: suite))
+
+    let registration = try EGOneDeliveryAdapterMappingTests.shardedFixtureRegistration(
+      install: install, metadata: metadata)
+    let controller = ModelDeliveryController(defaults: UserDefaults(suiteName: suite)!)
+    let adapter = EGOneDeliveryAdapter(
+      controller: controller, registration: registration, version: "v2-sharded",
+      defaults: store)
+
+    let provider = ProviderBox(egOneActive)
+    let signal = HealthSignal()
+    // The binary path exists as a URL but not on disk: activation reaches the
+    // server manager and fails with the precise `server_binary_missing`
+    // signal instead of spawning anything.
+    let missingBinary = root.appendingPathComponent("missing-llama-server")
+    let runtime = EGOneRuntime(
+      manifest: runtimeManifest(), serverBinaryURL: missingBinary, delivery: adapter)
+    runtime.isActiveProvider = { [provider] in provider.isEGOneActive }
+    runtime.onEvent = { event in
+      Task { @MainActor in signal.record(event) }
+    }
+    return Harness(
+      root: root, store: store, suite: suite, adapter: adapter, runtime: runtime,
+      registration: registration, provider: provider, signal: signal)
+  }
+
+  private func stageValidShards(_ registration: DeliveryRegistration) throws {
+    try Data(count: 1000).write(
+      to: registration.installDirectory.appendingPathComponent("eg-1-00001-of-00002.gguf"))
+    try Data(count: 2000).write(
+      to: registration.installDirectory.appendingPathComponent("eg-1-00002-of-00002.gguf"))
+  }
+
+  private func stageMonolith(_ root: URL, bytes: Data) throws {
+    let store = root.appendingPathComponent("EnviousWispr/PolishModels", isDirectory: true)
+    try FileManager.default.createDirectory(at: store, withIntermediateDirectories: true)
+    try bytes.write(to: store.appendingPathComponent("eg-1-v1.gguf"))
+  }
+
+  /// Deterministic settle for ABSENCE assertions: a round-trip through the
+  /// controller actor drains work enqueued before it (actor FIFO), then
+  /// main-actor yields drain the fire-and-forget activation task's
+  /// completion hops. No wall clock.
+  @MainActor
+  private func settle(_ adapter: EGOneDeliveryAdapter) async {
+    _ = await adapter.isAdmitted()
+    for _ in 0..<20 { await Task.yield() }
+  }
+
+  @MainActor
+  @Test func automaticReplacementAdmissionStartsEGOneWhenEffectivelyActive() async throws {
+    let h = try makeHarness(egOneActive: true)
+    defer { h.cleanup() }
+    try stageValidShards(h.registration)
+    #expect(await h.adapter.adoptIfPresent())
+
+    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+
+    let event = await h.signal.next { event in
+      if case .healthChanged(_, _, "server_binary_missing") = event { return true }
+      return false
+    }
+    #expect(
+      event == .healthChanged(from: "yellow", to: "red", reason: "server_binary_missing"))
+  }
+
+  @MainActor
+  @Test func automaticReplacementAdmissionDoesNotStartWhenPolishIsOff() async throws {
+    // Polish off IS provider .none (LLMPolishStep.isEnabled == llmProvider != .none):
+    // the runtime sees the effective predicate as false.
+    let h = try makeHarness(egOneActive: false)
+    defer { h.cleanup() }
+    try stageValidShards(h.registration)
+    #expect(await h.adapter.adoptIfPresent())
+
+    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    await settle(h.adapter)
+
+    #expect(h.runtime.installState == .installed(version: "v2-sharded"))
+    #expect(!h.signal.sawServerBinaryMissing)
+  }
+
+  @MainActor
+  @Test func automaticReplacementAdmissionDoesNotStartWhenAnotherProviderIsActive()
+    async throws
+  {
+    // The runtime sees only the effective-provider Boolean: another active
+    // provider and polish-off are the same false predicate at this layer;
+    // which of the two it was is composition-root policy.
+    let h = try makeHarness(egOneActive: false)
+    defer { h.cleanup() }
+    try stageValidShards(h.registration)
+    #expect(await h.adapter.adoptIfPresent())
+
+    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    await settle(h.adapter)
+
+    #expect(h.runtime.installState == .installed(version: "v2-sharded"))
+    #expect(!h.signal.sawServerBinaryMissing)
+  }
+
+  @MainActor
+  @Test func providerSwitchToEGOneDuringReplacementStartsAfterAdmission() async throws {
+    // Starts as C3 (predicate false); the user switches to EG-1 while the
+    // replacement runs; the predicate is read AT COMPLETION, so the switch
+    // wins. Full replacement flow: monolith retired, staged shards admitted.
+    let h = try makeHarness(egOneActive: false)
+    defer { h.cleanup() }
+    let bytes = Data("trusted".utf8)
+    try stageMonolith(h.root, bytes: bytes)
+    try stageValidShards(h.registration)
+
+    let coordinator = EGOneLegacyUpgradeCoordinator(
+      adapter: h.adapter,
+      appSupportDirectory: h.root,
+      defaults: h.store,
+      trustedArtifact: .init(
+        name: "eg-1-v1.gguf",
+        sizeBytes: Int64(bytes.count),
+        sha256: SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()))
+    await coordinator.runLaunch()
+
+    h.provider.isEGOneActive = true
+    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+
+    _ = await h.signal.next { event in
+      if case .healthChanged(_, _, "server_binary_missing") = event { return true }
+      return false
+    }
+    #expect(h.signal.sawServerBinaryMissing)
+  }
+
+  @MainActor
+  @Test func providerSwitchAwayDuringReplacementDoesNotStartEGOne() async throws {
+    // Starts as C2; the user switches away mid-download; completion must not
+    // boot the engine they just left.
+    let h = try makeHarness(egOneActive: true)
+    defer { h.cleanup() }
+    let bytes = Data("trusted".utf8)
+    try stageMonolith(h.root, bytes: bytes)
+    try stageValidShards(h.registration)
+
+    let coordinator = EGOneLegacyUpgradeCoordinator(
+      adapter: h.adapter,
+      appSupportDirectory: h.root,
+      defaults: h.store,
+      trustedArtifact: .init(
+        name: "eg-1-v1.gguf",
+        sizeBytes: Int64(bytes.count),
+        sha256: SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()))
+    await coordinator.runLaunch()
+
+    h.provider.isEGOneActive = false
+    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    await settle(h.adapter)
+
+    #expect(!h.signal.sawServerBinaryMissing)
+  }
+
+  @MainActor
+  @Test func nonAdmittedCancelledOrFailedReplacementDoesNotStartEGOne() async throws {
+    // Terminal cancellation/failure BEFORE admission: disk truth is "nothing
+    // admitted", so activation's no-fetch adoption settles not-installed and
+    // boots nothing. (Admission-winning cancellation is a valid admitted-model
+    // path — covered by
+    // cancelLosingAdmissionRaceLeavesAdmittedModelInstalledAndMarkerCleared —
+    // and an active-provider runtime may correctly start that admitted model.)
+    let h = try makeHarness(egOneActive: true)
+    defer { h.cleanup() }
+    // No shards staged: adoption cannot admit and must not fetch.
+
+    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    await settle(h.adapter)
+
+    #expect(h.runtime.installState == .notInstalled)
+    #expect(!h.signal.sawServerBinaryMissing)
+  }
+}


### PR DESCRIPTION
## ⚠️ Sequencing constraint (read first)

**This PR must merge before the next release is cut from main.** The delivery-engine EG-1 (sharded manifest + adapter) is in no shipped tag; a release cut before this merge would create the first real users with delivery-engine files in the legacy `PolishModels` location, invalidating this PR's empty-cohort premise (Codex code review r1/r2, CONFIRM-REJECTION on evidence).

## What this does

Every shipped EG-1 owner has a monolithic `eg-1-v1.gguf` (2,889,511,680 bytes) that the current sharded runtime cannot load. Rather than migrate dead bytes:

1. At launch, prove the old file is OURS by exact size + SHA-256 (a same-size or renamed foreign file is never touched).
2. Write one durable `eg1-v1-replacement-owed` marker, then delete the monolith (contract §5c, new in v1.3: delete-first for a cryptographically identified, app-owned, reproducible asset the runtime no longer supports).
3. Let the existing `ModelDeliveryController` download/resume/verify/admit the sharded replacement into the owned `EnviousWispr/Models/eg-1` home. Polish falls back to raw text until admission.
4. Marker clears on admission or explicit user decline (Cancel/Remove → clean "not installed" state, no re-nag). Decline always counts, even with the delivery kill switch off — the switch guards model bytes, never the user's decision.
5. A containment gate (resolved-to-resolved path comparison, firmlink-safe) refuses any old store outside the canonical tree before any deletion.
6. Five bounded, content-free lifecycle telemetry events (`eg1.legacy_detected` w/ `selected_provider`, `legacy_retired`, `legacy_retirement_failed` w/ fixed reason, `replacement_completed`, `replacement_declined`).

One new coordinator owns all of it; `ModelDeliveryController` and `EGOneRuntime` diffs vs main are EMPTY.

## Supersedes #1497

The prior relocation/verify-before-delete implementation (30+ defects across 25 review rounds, root-caused in the 2026-07-11 post-mortem) is abandoned; this is the redesign from the rev2.2 plan of record (3 Codex xhigh rounds + founder-side GPT review, all findings adjudicated).

## Validation

- 2,802 tests green including 31 new (fingerprint negatives, marker lifecycle, crash-recovery table, containment incl. the /var→/private/var firmlink oracle, kill-switch decline, integration against the real controller).
- Codex code-diff review: r1 single finding rejected on tag evidence; r2 CONFIRM-REJECTION + full-diff rescan CLEAN.
- Live UAT with the GENUINE monolith (digest-verified): no-op, reintroduced-monolith (4s retire), kill-switch off/on, full replace with real 2.9 GB download, quit-at-92% resume (5s to admitted), same-size-wrong-bytes negative, kill-9 crash convergence (35s), live dictation through the self-installed model (pipeline 0.574s, log-verified).
- `.validation/runs/2026-07-11T14-15-28Z-d129a4a` strict PASS.

Part of #1386 (epic #1348).
