### PR TITLE
Fix flaky post-merge Release tests

### DIFF
--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -3,9 +3,14 @@ name: Main Post-Merge Check
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/main-post-merge.yml'
+  workflow_dispatch:
 
 concurrency:
-  group: main-post-merge
+  group: main-post-merge-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Shared Xcode-engine constants (#913 PR3).
@@ -21,10 +26,36 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - name: Checkout
+      - name: Checkout PR head
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Checkout push or dispatch ref
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
           fetch-depth: 2
+
+      - name: Verify checked-out revision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          EXPECTED_SHA="$GITHUB_SHA"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            EXPECTED_SHA="$PR_HEAD_SHA"
+          fi
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::Checked out $ACTUAL_SHA, expected $EXPECTED_SHA"
+            exit 1
+          fi
+          echo "==> Running workflow revision $ACTUAL_SHA"
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -34,9 +65,29 @@ jobs:
       - name: Detect code changes
         id: changes
         env:
+          EVENT_NAME: ${{ github.event_name }}
           BEFORE: ${{ github.event.before }}
           AFTER: ${{ github.sha }}
-        run: scripts/ci/classify-changes.sh --push-diff "$BEFORE" "$AFTER"
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            push)
+              scripts/ci/classify-changes.sh --push-diff "$BEFORE" "$AFTER"
+              ;;
+            pull_request)
+              scripts/ci/classify-changes.sh "$BASE_SHA" "$HEAD_SHA"
+              ;;
+            workflow_dispatch)
+              echo "needs_build=true" >> "$GITHUB_OUTPUT"
+              echo "==> Manual diagnostic dispatch requires the full Xcode matrix"
+              ;;
+            *)
+              echo "::error::Unsupported event: $EVENT_NAME"
+              exit 1
+              ;;
+          esac
 
       - name: Verify environment
         if: steps.changes.outputs.needs_build == 'true'
@@ -176,6 +227,7 @@ jobs:
       # `build` step above, so the shippable release artifact stays non-testable
       # and fully optimized. (Mirrors the old `swift test -c release` behavior.)
       - name: Run logic tests (release config, Xcode)
+        id: release-tests
         if: steps.changes.outputs.needs_build == 'true'
         run: |
           set -euo pipefail
@@ -186,10 +238,11 @@ jobs:
             -configuration Release \
             -derivedDataPath "$DERIVED_DATA_PATH" \
             -destination 'platform=macOS,arch=arm64' \
+            -resultBundlePath "$GITHUB_WORKSPACE/xcode-test-release.xcresult" \
             ARCHS=arm64 \
             ONLY_ACTIVE_ARCH=YES \
             VALID_ARCHS=arm64 \
-            ENABLE_TESTABILITY=YES | tee xcode-test-release.log
+            ENABLE_TESTABILITY=YES 2>&1 | tee xcode-test-release.log
 
           # Require a positive executed-test count (see pr-check.yml rationale).
           TESTS_RUN=$(grep -oE "Test run with [0-9]+ test" xcode-test-release.log | grep -oE "[0-9]+" | awk '{s+=$1} END{print s+0}')
@@ -199,11 +252,49 @@ jobs:
           fi
           echo "==> Xcode executed $TESTS_RUN tests (release)"
 
+      - name: Summarize release-test failure
+        if: failure() && steps.release-tests.outcome == 'failure'
+        run: |
+          RESULT_BUNDLE="$GITHUB_WORKSPACE/xcode-test-release.xcresult"
+          if [ ! -d "$RESULT_BUNDLE" ]; then
+            echo "::warning::Release-test xcresult was not created"
+            exit 0
+          fi
+
+          echo "::group::xcresult build summary"
+          xcrun xcresulttool get build-results \
+            --path "$RESULT_BUNDLE" \
+            --compact || echo "::warning::Build summary unavailable; raw xcresult will be uploaded"
+          echo "::endgroup::"
+
+          echo "::group::xcresult test summary"
+          xcrun xcresulttool get test-results summary \
+            --path "$RESULT_BUNDLE" \
+            --compact || echo "::warning::Test summary unavailable; raw xcresult will be uploaded"
+          echo "::endgroup::"
+
+      - name: Upload release-test failure diagnostics
+        if: failure() && steps.release-tests.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: main-release-test-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            xcode-test-release.log
+            xcode-test-release.xcresult
+          if-no-files-found: warn
+          retention-days: 7
+
       # Save only when the build/tests succeeded and the restore was not an exact
       # hit. The primary key carries github.sha, so a first run for this commit
-      # always saves; a rerun of the same commit exact-hits and skips.
+      # always saves; a rerun of the same commit exact-hits and skips. PR and
+      # manual diagnostic runs remain restore-only.
       - name: Save Xcode build cache
-        if: steps.changes.outputs.needs_build == 'true' && success() && steps.xcode-cache.outputs.cache-hit != 'true'
+        if: >-
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          steps.changes.outputs.needs_build == 'true' &&
+          success() &&
+          steps.xcode-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
@@ -216,9 +307,16 @@ jobs:
         if: always()
         env:
           NEEDS_BUILD: ${{ steps.changes.outputs.needs_build }}
+          JOB_STATUS: ${{ job.status }}
         run: |
-          if [ "$NEEDS_BUILD" != "true" ]; then
-            echo "Non-code push (appcast, docs, etc.) — no build needed"
-          else
-            echo "Post-merge full validation passed"
-          fi
+          case "$JOB_STATUS:$NEEDS_BUILD" in
+            success:true)
+              echo "Full validation passed"
+              ;;
+            success:false)
+              echo "Change classified as non-code; full Xcode validation intentionally skipped"
+              ;;
+            *)
+              echo "Full validation did not pass: job_status=$JOB_STATUS needs_build=${NEEDS_BUILD:-unknown}"
+              ;;
+          esac

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -58,6 +58,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// version, not the terms — recovery promises normal-quality, not byte-exact).
   private let currentVocabulary:
     @MainActor () -> (corrector: CorrectorVocabulary, polish: PolishVocabulary)
+  private let onCleanupFinished: @Sendable (String) -> Void
 
   init(
     asrManager: any ASRManagerInterface,
@@ -68,6 +69,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     keychainManager: KeychainManager,
     outputClassifierHolder: OutputClassifierHolder,
     egOneRuntime: (any EGOneEndpointProviding)? = nil,
+    onCleanupFinished: @escaping @Sendable (String) -> Void = { _ in },
     currentVocabulary: @escaping @MainActor () -> (
       corrector: CorrectorVocabulary, polish: PolishVocabulary
     )
@@ -80,6 +82,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     self.keychainManager = keychainManager
     self.outputClassifierHolder = outputClassifierHolder
     self.egOneRuntime = egOneRuntime
+    self.onCleanupFinished = onCleanupFinished
     self.currentVocabulary = currentVocabulary
   }
 
@@ -102,7 +105,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // One-attempt crash-loop guard: a marker already present means a prior attempt
     // crashed the app — abandon (delete + log), never retry.
     if spoolStore.hasAttemptMarker(for: id) {
-      await cleanUp(id, spoolStore: spoolStore)
+      cleanUp(id, spoolStore: spoolStore)
       SentryBreadcrumb.captureError(
         RecoveryReplayError.abandonedAfterAttempt,
         category: .recoveryAbandonedAfterAttempt, stage: "recovery")
@@ -226,14 +229,14 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       SentryBreadcrumb.add(
         stage: "recovery", message: "recovered transcript save failed",
         level: .warning, data: ["error": String(describing: error)])
-      await cleanUp(id, spoolStore: spoolStore)
+      cleanUp(id, spoolStore: spoolStore)
       TelemetryService.shared.recoveryCompleted(outcome: "failed", reason: "save")
       return .failed
     }
     transcriptCoordinator.append(transcript)
 
     // Success: delete spool (+ marker) + key.
-    await cleanUp(id, spoolStore: spoolStore)
+    cleanUp(id, spoolStore: spoolStore)
     TelemetryService.shared.recoveryCompleted(
       outcome: "recovered",
       recoveredSeconds: Int(recoveredSeconds.rounded()),
@@ -246,7 +249,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     _ id: String, spoolStore: RecoverySpoolStore, reason: String,
     category: SentryBreadcrumb.ErrorCategory
   ) async -> RecoveryReplayOutcome {
-    await cleanUp(id, spoolStore: spoolStore)
+    cleanUp(id, spoolStore: spoolStore)
     SentryBreadcrumb.captureError(
       RecoveryReplayError.failed(reason), category: category, stage: "recovery")
     TelemetryService.shared.recoveryCompleted(outcome: "failed", reason: reason)
@@ -254,13 +257,17 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   }
 
   /// Delete a spool (which also clears its attempt marker) and destroy its key.
-  private func cleanUp(_ id: String, spoolStore: RecoverySpoolStore) async {
+  private func cleanUp(_ id: String, spoolStore: RecoverySpoolStore) {
     try? spoolStore.delete(recoverySessionID: id)
     let keyStore = self.keyStore
+    let onCleanupFinished = self.onCleanupFinished
     // A plain Task inherits MainActor and would run synchronous key-store I/O on
     // the UI executor. A task group adds no ownership value for one operation,
     // and @concurrent cannot annotate the dependency's synchronous API.
-    await Task.detached(priority: .utility) { try? keyStore.delete(for: id) }.value
+    Task.detached(priority: .utility) {
+      try? keyStore.delete(for: id)
+      onCleanupFinished(id)
+    }
   }
 
   private static func transcriptionOptions(for settings: RecordingSettingsSnapshot?)

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -102,7 +102,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // One-attempt crash-loop guard: a marker already present means a prior attempt
     // crashed the app — abandon (delete + log), never retry.
     if spoolStore.hasAttemptMarker(for: id) {
-      cleanUp(id, spoolStore: spoolStore)
+      await cleanUp(id, spoolStore: spoolStore)
       SentryBreadcrumb.captureError(
         RecoveryReplayError.abandonedAfterAttempt,
         category: .recoveryAbandonedAfterAttempt, stage: "recovery")
@@ -127,7 +127,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     }.value
     if isAborted() { return .aborted }
     guard let keyData else {
-      return fail(id, spoolStore: spoolStore, reason: "decrypt", category: .recoveryDecryptFailed)
+      return await fail(
+        id, spoolStore: spoolStore, reason: "decrypt", category: .recoveryDecryptFailed)
     }
 
     // Decrypt + reconstruct the valid prefix off the MainActor (heavy for a long
@@ -138,7 +139,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     }.value
     if isAborted() { return .aborted }
     guard let recovered, !recovered.samples.isEmpty else {
-      return fail(id, spoolStore: spoolStore, reason: "decrypt", category: .recoveryDecryptFailed)
+      return await fail(
+        id, spoolStore: spoolStore, reason: "decrypt", category: .recoveryDecryptFailed)
     }
 
     // Transcribe on the shared engine (batch). The marker already covers warm-up.
@@ -159,7 +161,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // Discard hard-resets the engine, which can throw here — that's an abort,
       // not a recovery failure (don't delete/log; the coordinator owns cleanup).
       if isAborted() { return .aborted }
-      return fail(
+      return await fail(
         id, spoolStore: spoolStore, reason: "transcribe", category: .recoveryTranscribeFailed)
     }
     // Discard during the model load: bail BEFORE the expensive batch transcribe.
@@ -171,12 +173,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // A Discard-driven engine reset kills the in-flight transcribe and surfaces
       // here as a throw — treat it as an abort (the user discarded), not a failure.
       if isAborted() { return .aborted }
-      return fail(
+      return await fail(
         id, spoolStore: spoolStore, reason: "transcribe", category: .recoveryTranscribeFailed)
     }
     if isAborted() { return .aborted }
     guard !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-      return fail(id, spoolStore: spoolStore, reason: "empty", category: .recoveryTranscribeFailed)
+      return await fail(
+        id, spoolStore: spoolStore, reason: "empty", category: .recoveryTranscribeFailed)
     }
 
     // Polish under the recording's record-time settings (raw-fallback floor
@@ -223,14 +226,14 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       SentryBreadcrumb.add(
         stage: "recovery", message: "recovered transcript save failed",
         level: .warning, data: ["error": String(describing: error)])
-      cleanUp(id, spoolStore: spoolStore)
+      await cleanUp(id, spoolStore: spoolStore)
       TelemetryService.shared.recoveryCompleted(outcome: "failed", reason: "save")
       return .failed
     }
     transcriptCoordinator.append(transcript)
 
     // Success: delete spool (+ marker) + key.
-    cleanUp(id, spoolStore: spoolStore)
+    await cleanUp(id, spoolStore: spoolStore)
     TelemetryService.shared.recoveryCompleted(
       outcome: "recovered",
       recoveredSeconds: Int(recoveredSeconds.rounded()),
@@ -242,8 +245,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   private func fail(
     _ id: String, spoolStore: RecoverySpoolStore, reason: String,
     category: SentryBreadcrumb.ErrorCategory
-  ) -> RecoveryReplayOutcome {
-    cleanUp(id, spoolStore: spoolStore)
+  ) async -> RecoveryReplayOutcome {
+    await cleanUp(id, spoolStore: spoolStore)
     SentryBreadcrumb.captureError(
       RecoveryReplayError.failed(reason), category: category, stage: "recovery")
     TelemetryService.shared.recoveryCompleted(outcome: "failed", reason: reason)
@@ -251,10 +254,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   }
 
   /// Delete a spool (which also clears its attempt marker) and destroy its key.
-  private func cleanUp(_ id: String, spoolStore: RecoverySpoolStore) {
+  private func cleanUp(_ id: String, spoolStore: RecoverySpoolStore) async {
     try? spoolStore.delete(recoverySessionID: id)
     let keyStore = self.keyStore
-    Task.detached(priority: .utility) { try? keyStore.delete(for: id) }
+    // A plain Task inherits MainActor and would run synchronous key-store I/O on
+    // the UI executor. A task group adds no ownership value for one operation,
+    // and @concurrent cannot annotate the dependency's synchronous API.
+    await Task.detached(priority: .utility) { try? keyStore.delete(for: id) }.value
   }
 
   private static func transcriptionOptions(for settings: RecordingSettingsSnapshot?)

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -243,8 +243,10 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// running, then run the real inference probe. Called on provider
   /// activation and on settings-open. Safe to call concurrently: server start
   /// is idempotent (no-ops if starting/ready) and the last probe wins (#1271
-  /// Codex r6); the generation token handles switch-away.
-  public func activateAndProbe() {
+  /// Codex r6); the generation token handles switch-away. The returned task is
+  /// discardable in production and gives tests the exact completion signal.
+  @discardableResult
+  public func activateAndProbe() -> Task<Void, Never>? {
     // Choosing EG-1 cancels any deferred removal FIRST, even if activation
     // itself then bails on a blocker — otherwise remove-during-recording
     // followed by re-selecting EG-1 still deletes the model the user just
@@ -255,10 +257,10 @@ public final class EGOneRuntime: EGOneEndpointProviding {
       // pre-spawn sweep never reaps a crash orphan; reap here (idle-gated
       // on the server actor, so it cannot touch a live child) (#1271 r11).
       sweepStaleServersAtLaunch()
-      return
+      return nil
     }
     let generation = activationGeneration
-    Task {
+    return Task {
       // First hop back onto the main actor: a switch-to-then-away that beat
       // this task bumped the generation — do not start the server.
       guard generation == self.activationGeneration else { return }
@@ -289,10 +291,11 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// reactively from the install-state stream (activation-loop precedent
   /// above). Non-admitted cancellation, failure, or decline boots nothing;
   /// admission-winning races retain the trusted model and may activate
-  /// normally.
-  public func activateAfterAutomaticReplacementIfNeeded() {
-    guard isActiveProvider?() == true else { return }
-    activateAndProbe()
+  /// normally. Returns the activation task when the live-provider guard passes.
+  @discardableResult
+  public func activateAfterAutomaticReplacementIfNeeded() -> Task<Void, Never>? {
+    guard isActiveProvider?() == true else { return nil }
+    return activateAndProbe()
   }
 
   /// Orphan reap for no-spawn paths (#1271 confirm round + r11): a crash

--- a/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
@@ -133,16 +133,6 @@ import Testing
     try bytes.write(to: store.appendingPathComponent("eg-1-v1.gguf"))
   }
 
-  /// Deterministic settle for ABSENCE assertions: a round-trip through the
-  /// controller actor drains work enqueued before it (actor FIFO), then
-  /// main-actor yields drain the fire-and-forget activation task's
-  /// completion hops. No wall clock.
-  @MainActor
-  private func settle(_ adapter: EGOneDeliveryAdapter) async {
-    _ = await adapter.isAdmitted()
-    for _ in 0..<20 { await Task.yield() }
-  }
-
   @MainActor
   @Test func automaticReplacementAdmissionStartsEGOneWhenEffectivelyActive() async throws {
     let h = try makeHarness(egOneActive: true)
@@ -170,7 +160,6 @@ import Testing
     #expect(await h.adapter.adoptIfPresent())
 
     h.runtime.activateAfterAutomaticReplacementIfNeeded()
-    await settle(h.adapter)
 
     #expect(h.runtime.installState == .installed(version: "v2-sharded"))
     #expect(!h.signal.sawServerBinaryMissing)
@@ -189,7 +178,6 @@ import Testing
     #expect(await h.adapter.adoptIfPresent())
 
     h.runtime.activateAfterAutomaticReplacementIfNeeded()
-    await settle(h.adapter)
 
     #expect(h.runtime.installState == .installed(version: "v2-sharded"))
     #expect(!h.signal.sawServerBinaryMissing)
@@ -248,7 +236,6 @@ import Testing
 
     h.provider.isEGOneActive = false
     h.runtime.activateAfterAutomaticReplacementIfNeeded()
-    await settle(h.adapter)
 
     #expect(!h.signal.sawServerBinaryMissing)
   }
@@ -265,8 +252,8 @@ import Testing
     defer { h.cleanup() }
     // No shards staged: adoption cannot admit and must not fetch.
 
-    h.runtime.activateAfterAutomaticReplacementIfNeeded()
-    await settle(h.adapter)
+    let activation = try #require(h.runtime.activateAfterAutomaticReplacementIfNeeded())
+    await activation.value
 
     #expect(h.runtime.installState == .notInstalled)
     #expect(!h.signal.sawServerBinaryMissing)

--- a/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
@@ -161,6 +161,11 @@ import Testing
 
     h.runtime.activateAfterAutomaticReplacementIfNeeded()
 
+    _ = await h.signal.next { event in
+      if case .healthChanged(_, "yellow", "not_started") = event { return true }
+      return false
+    }
+
     #expect(h.runtime.installState == .installed(version: "v2-sharded"))
     #expect(!h.signal.sawServerBinaryMissing)
   }
@@ -178,6 +183,11 @@ import Testing
     #expect(await h.adapter.adoptIfPresent())
 
     h.runtime.activateAfterAutomaticReplacementIfNeeded()
+
+    _ = await h.signal.next { event in
+      if case .healthChanged(_, "yellow", "not_started") = event { return true }
+      return false
+    }
 
     #expect(h.runtime.installState == .installed(version: "v2-sharded"))
     #expect(!h.signal.sawServerBinaryMissing)

--- a/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneRuntimeReplacementActivationTests.swift
@@ -140,7 +140,7 @@ import Testing
     try stageValidShards(h.registration)
     #expect(await h.adapter.adoptIfPresent())
 
-    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    _ = try #require(h.runtime.activateAfterAutomaticReplacementIfNeeded())
 
     let event = await h.signal.next { event in
       if case .healthChanged(_, _, "server_binary_missing") = event { return true }
@@ -159,7 +159,8 @@ import Testing
     try stageValidShards(h.registration)
     #expect(await h.adapter.adoptIfPresent())
 
-    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    let activation = h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    #expect(activation == nil)
 
     _ = await h.signal.next { event in
       if case .healthChanged(_, "yellow", "not_started") = event { return true }
@@ -182,7 +183,8 @@ import Testing
     try stageValidShards(h.registration)
     #expect(await h.adapter.adoptIfPresent())
 
-    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    let activation = h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    #expect(activation == nil)
 
     _ = await h.signal.next { event in
       if case .healthChanged(_, "yellow", "not_started") = event { return true }
@@ -245,8 +247,9 @@ import Testing
     await coordinator.runLaunch()
 
     h.provider.isEGOneActive = false
-    h.runtime.activateAfterAutomaticReplacementIfNeeded()
+    let activation = h.runtime.activateAfterAutomaticReplacementIfNeeded()
 
+    #expect(activation == nil)
     #expect(!h.signal.sawServerBinaryMissing)
   }
 

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -96,6 +96,7 @@ struct RecoverySpoolReplayerTests {
     let keyStore: RecoveryKeyStore
     let transcriptStore: TranscriptStore
     let transcriptCoordinator: TranscriptCoordinator
+    let cleanupEvents: AsyncStream<String>
   }
 
   private static func makeHarness() -> Harness {
@@ -104,6 +105,7 @@ struct RecoverySpoolReplayerTests {
     let transcriptStore = TranscriptStore(directory: tempDir())
     let transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
     let asr = FakeBatchASR()
+    let (cleanupEvents, cleanupContinuation) = AsyncStream.makeStream(of: String.self)
     let replayer = RecoverySpoolReplayer(
       asrManager: asr,
       keyStore: keyStore,
@@ -112,11 +114,13 @@ struct RecoverySpoolReplayerTests {
       transcriptCoordinator: transcriptCoordinator,
       keychainManager: KeychainManager(),
       outputClassifierHolder: OutputClassifierHolder(),
+      onCleanupFinished: { cleanupContinuation.yield($0) },
       currentVocabulary: { (.empty, .empty) })
     return Harness(
       replayer: replayer, asr: asr,
       spoolStore: RecoverySpoolStore(directory: spoolDir), keyStore: keyStore,
-      transcriptStore: transcriptStore, transcriptCoordinator: transcriptCoordinator)
+      transcriptStore: transcriptStore, transcriptCoordinator: transcriptCoordinator,
+      cleanupEvents: cleanupEvents)
   }
 
   /// Write a real encrypted spool + store its key, so the replayer can decrypt it.
@@ -139,6 +143,8 @@ struct RecoverySpoolReplayerTests {
     let id = "ok-\(UUID().uuidString)"
     try await Self.seedSpool(h, id: id, samples: [0.1, 0.2, 0.3])
     let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    var cleanupIterator = h.cleanupEvents.makeAsyncIterator()
+    #expect(await cleanupIterator.next() == id)
     #expect(outcome == .recovered)
     #expect(h.asr.transcribeCallCount == 1)
     let saved = h.transcriptCoordinator.transcripts


### PR DESCRIPTION
## Summary

- preserve the combined Xcode log and xcresult whenever the Release test step fails
- await terminal recovery-spool cleanup instead of returning while detached key deletion is still running
- make the EG-1 replacement test await the runtime activation task instead of a fixed number of scheduler yields
- run this workflow against its own PR head so the workflow change receives a real pre-merge proof

Closes #1501

## Root cause

The Release bundle was not empty. In every GitHub failure, `xcodebuild` returned exit 65 under `set -euo pipefail`, so the shell exited before the positive executed-test-count guard ran. GitHub console truncation hid the final test records.

An identical local Release run with an explicit xcresult executed 2,571 tests and exposed two load-sensitive failures:

1. `RecoverySpoolReplayerTests/happyPath()` returned before detached key deletion completed.
2. `EGOneRuntimeReplacementActivationTests/nonAdmittedCancelledOrFailedReplacementDoesNotStartEGOne()` used 20 `Task.yield()` calls as a completion proxy for an unstructured activation task.

Both suites passed in isolation, matching the intermittent scheduler/load signature. The same restored cache also preceded both a failed and a successful GitHub run, so a stale cache alone is not causal.

## Guardrail

The positive executed-count check remains in place and unchanged. There is no retry wrapper, `|| true`, or lowered threshold.

## Validation

- `actionlint .github/workflows/main-post-merge.yml`
- `shellcheck -s bash scripts/ci/classify-changes.sh`
- classifier self-test
- focused Recovery suite: Debug 7/7, Release 7/7
- focused EG-1 suite: Debug and Release green; Release 6/6
- exact full Release matrix: 2,571 tests executed, green
- canonical full Debug test run: green
- signed dev-app build and launch: green
- synthetic dictation: green; expected token found, pipeline 1.1s
- strict Phase 3 validation: green (`.validation/runs/2026-07-11T17-11-50Z-559c2cb`)
- local Codex code-diff review: clean (session `019f5227-47c2-7910-bd1f-fa17e382e768`)

## Stability watch

One green run is not enough for an intermittent defect. After merge I will watch **3 consecutive full `main-post-merge` push runs on 3 distinct merged `main` SHAs**. Manual dispatches and reruns do not count. Each counted run must show a positive Release executed-test count. I will keep #1501 open until that watch is complete and add the three run URLs to the closure diagnosis.