### PR TITLE
fix(telemetry): stage-classify Sparkle update failures so install_failed stops over-firing

### DIFF
--- a/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
@@ -461,16 +461,6 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
         source: source,
         errorCode: errorCodeString,
         stage: stage.rawValue,
-        // Codex code-diff review (round 1, #1447): `source` is set as early
-        // as a bare "Check for Updates" menu click or Sparkle's own default
-        // dialog being shown — well before any real install action — so
-        // this reads `true` on cycles where the user never asked to
-        // install anything, only to check. Diagnostic/defensive signal
-        // only, not a precise "install actually began" flag; a precise
-        // flag would need new state set exactly in `willInstallUpdate`/
-        // `willInstallUpdateOnQuit`, which this issue's plan explicitly
-        // declined (no new stored property).
-        installIntentSeen: source != "unknown",
         checkKind: checkKind,
         currentAppVersion: currentAppVersion
       )

--- a/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
@@ -461,6 +461,15 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
         source: source,
         errorCode: errorCodeString,
         stage: stage.rawValue,
+        // Codex code-diff review (round 1, #1447): `source` is set as early
+        // as a bare "Check for Updates" menu click or Sparkle's own default
+        // dialog being shown — well before any real install action — so
+        // this reads `true` on cycles where the user never asked to
+        // install anything, only to check. Diagnostic/defensive signal
+        // only, not a precise "install actually began" flag; a precise
+        // flag would need new state set exactly in `willInstallUpdate`/
+        // `willInstallUpdateOnQuit`, which this issue's plan explicitly
+        // declined (no new stored property).
         installIntentSeen: source != "unknown",
         checkKind: checkKind,
         currentAppVersion: currentAppVersion

--- a/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
@@ -260,6 +260,47 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
     return ![1001, 4007, 4008].contains(error.code)
   }
 
+  /// Issue #1447: coarse cycle-failure stage, one case per Sparkle's own
+  /// phase grouping in `SUErrors.h`. `validation` covers Sparkle's
+  /// "Extraction phase errors" (unarchiving, signature, validation).
+  enum SparkleFailureStage: String, CaseIterable {
+    case appcast
+    case download
+    case validation
+    case install
+    case unknown
+  }
+
+  /// Issue #1447: maps Sparkle's numeric error-code ranges to a coarse
+  /// cycle-failure stage. Codes below 1000 (configuration/API-misuse setup
+  /// errors), 5000+ (API misuse), and any non-Sparkle domain map to
+  /// `.unknown` rather than guessing a bucket — matches the domain guard
+  /// already used by `isReportableSparkleInstallFailure`. A future Sparkle
+  /// code landing inside an already-classified range inherits that range's
+  /// stage (accepted scope limit, not a gap).
+  static func failureStage(_ error: NSError?) -> SparkleFailureStage {
+    guard let error, error.domain == "SUSparkleErrorDomain" else { return .unknown }
+    switch error.code {
+    case 1000...1999: return .appcast
+    case 2000...2999: return .download
+    case 3000...3999: return .validation
+    case 4000...4999: return .install
+    default: return .unknown
+    }
+  }
+
+  /// Issue #1447: preserve the legacy `update.install_failed` event for
+  /// foreign-domain errors, because their stage cannot be determined and
+  /// `isReportableSparkleInstallFailure` already treats them as reportable
+  /// today — suppressing them here would be a new, unproven-safe
+  /// regression. Suppress only when Sparkle-domain evidence positively
+  /// says the failure was NOT install-stage.
+  static func shouldEmitLegacyInstallFailure(
+    error: NSError, stage: SparkleFailureStage
+  ) -> Bool {
+    error.domain != "SUSparkleErrorDomain" || stage == .install
+  }
+
   /// Issue #847 Phase 1: extract Sparkle's no-update reason from the error
   /// userInfo. Guarded — returns nil unless the error is a Sparkle SUNoUpdateError
   /// (code 1001 with the `SUSparkleErrorDomain` domain). Sparkle attaches
@@ -405,16 +446,36 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
     // SUInstallationAuthorizeLaterError = 4008 (user chose install later).
     // All three reach this callback via SPUUpdater.m:810-812. Non-Sparkle
     // errors with the same numeric codes still emit (domain guard).
+    //
+    // Issue #1447: stage-classify every reportable abort into
+    // update.cycle_failed, then narrow update.install_failed to fire only
+    // when shouldEmitLegacyInstallFailure says the failure is genuinely
+    // install-stage (or foreign-domain, where stage can't be proven and
+    // legacy behavior is preserved rather than risking a false negative).
     if let nsError = error as NSError?, Self.isReportableSparkleInstallFailure(nsError) {
-      TelemetryService.shared.updateInstallFailed(
+      let stage = Self.failureStage(nsError)
+      let errorCodeString = "\(nsError.domain).\(nsError.code)"
+      TelemetryService.shared.updateCycleFailed(
         version: version,
         isCritical: isCritical,
         source: source,
-        errorCode: "\(nsError.domain).\(nsError.code)",
-        noUpdateReason: noUpdateReason,
+        errorCode: errorCodeString,
+        stage: stage.rawValue,
+        installIntentSeen: source != "unknown",
         checkKind: checkKind,
         currentAppVersion: currentAppVersion
       )
+      if Self.shouldEmitLegacyInstallFailure(error: nsError, stage: stage) {
+        TelemetryService.shared.updateInstallFailed(
+          version: version,
+          isCritical: isCritical,
+          source: source,
+          errorCode: errorCodeString,
+          noUpdateReason: noUpdateReason,
+          checkKind: checkKind,
+          currentAppVersion: currentAppVersion
+        )
+      }
     }
     // Issue #739: do NOT call noteResolved here. Sparkle's "cycle finished"
     // fires on cancel/skip/error/install-on-quit-scheduled alike. Widget state

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1811,7 +1811,6 @@ public final class TelemetryService {
     source: String,
     errorCode: String,
     stage: String,
-    installIntentSeen: Bool,
     checkKind: String,
     currentAppVersion: String
   ) {
@@ -1827,7 +1826,7 @@ public final class TelemetryService {
             "check_kind": checkKind,
             "current_app_version": currentAppVersion,
           ],
-          boolProps: ["is_critical": isCritical, "install_intent_seen": installIntentSeen]
+          boolProps: ["is_critical": isCritical]
         ))
     #endif
     PostHogSDK.shared.capture(
@@ -1838,7 +1837,6 @@ public final class TelemetryService {
         "source": source,
         "error_code": errorCode,
         "stage": stage,
-        "install_intent_seen": installIntentSeen,
         "check_kind": checkKind,
         "current_app_version": currentAppVersion,
       ]

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1801,6 +1801,50 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("update.install_failed", properties: props)
   }
 
+  /// Issue #1447: fires for every reportable (non-benign) Sparkle cycle
+  /// abort, stage-tagged. Sibling to `updateInstallFailed` but not gated to
+  /// install-stage only — this is the correctly-labeled event that
+  /// `update.install_failed` was over-firing under before this fix.
+  public func updateCycleFailed(
+    version: String,
+    isCritical: Bool,
+    source: String,
+    errorCode: String,
+    stage: String,
+    installIntentSeen: Bool,
+    checkKind: String,
+    currentAppVersion: String
+  ) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "update.cycle_failed",
+          stringProps: [
+            "version": version,
+            "source": source,
+            "error_code": errorCode,
+            "stage": stage,
+            "check_kind": checkKind,
+            "current_app_version": currentAppVersion,
+          ],
+          boolProps: ["is_critical": isCritical, "install_intent_seen": installIntentSeen]
+        ))
+    #endif
+    PostHogSDK.shared.capture(
+      "update.cycle_failed",
+      properties: [
+        "version": version,
+        "is_critical": isCritical,
+        "source": source,
+        "error_code": errorCode,
+        "stage": stage,
+        "install_intent_seen": installIntentSeen,
+        "check_kind": checkKind,
+        "current_app_version": currentAppVersion,
+      ]
+    )
+  }
+
   public func updateInstallCancelled(version: String, isCritical: Bool, source: String) {
     #if DEBUG
       testEventHook?(

--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -197,6 +197,16 @@ struct SparkleUpdateControllerTests {
         checkKind: "background",
         currentAppVersion: "v-host"
       )
+      TelemetryService.shared.updateCycleFailed(
+        version: "v1",
+        isCritical: false,
+        source: "menu",
+        errorCode: "SUSparkleErrorDomain.1005",
+        stage: "appcast",
+        installIntentSeen: true,
+        checkKind: "background",
+        currentAppVersion: "v-host"
+      )
 
       // Drain the Task hops scheduled by each test hook firing.
       await Task.yield()
@@ -210,6 +220,7 @@ struct SparkleUpdateControllerTests {
         "update.install_completed",
         "update.install_cancelled",
         "update.install_failed",
+        "update.cycle_failed",
       ]
       let actualNames = Set(captured.map(\.name))
       #expect(
@@ -234,6 +245,13 @@ struct SparkleUpdateControllerTests {
             "check_kind", "current_app_version", "error_code", "source", "version",
           ])
         #expect(evt.boolProps.keys.sorted() == ["is_critical"])
+      }
+      if let evt = captured.first(where: { $0.name == "update.cycle_failed" }) {
+        #expect(
+          evt.stringProps.keys.sorted() == [
+            "check_kind", "current_app_version", "error_code", "source", "stage", "version",
+          ])
+        #expect(evt.boolProps.keys.sorted() == ["install_intent_seen", "is_critical"])
       }
     }
 
@@ -274,6 +292,112 @@ struct SparkleUpdateControllerTests {
     func classifier_nonSparkleDomain1001_isTrue() {
       let error = NSError(domain: "NSURLErrorDomain", code: 1001)
       #expect(SparkleUpdateController.isReportableSparkleInstallFailure(error) == true)
+    }
+
+    // MARK: - #1447: failureStage + shouldEmitLegacyInstallFailure classifiers (Layer A)
+    //
+    // Pure-function tests, same rationale as the #846 block above: the
+    // delegate callback itself cannot be constructed/invoked in tests
+    // (SPUUpdater.init unavailable). These prove the classify → route
+    // DECISION; the callback's wiring of that decision is verified by
+    // code-diff inspection, not a runtime test (see the plan doc for #1447).
+
+    nonisolated static let failureStageCases:
+      [(code: Int, domain: String, expected: SparkleUpdateController.SparkleFailureStage)] = [
+        (1, "SUSparkleErrorDomain", .unknown),
+        (7, "SUSparkleErrorDomain", .unknown),
+        (1000, "SUSparkleErrorDomain", .appcast),
+        (1001, "SUSparkleErrorDomain", .appcast),
+        (1003, "SUSparkleErrorDomain", .appcast),
+        (1005, "SUSparkleErrorDomain", .appcast),
+        (1007, "SUSparkleErrorDomain", .appcast),
+        (2000, "SUSparkleErrorDomain", .download),
+        (2001, "SUSparkleErrorDomain", .download),
+        (3000, "SUSparkleErrorDomain", .validation),
+        (3001, "SUSparkleErrorDomain", .validation),
+        (3002, "SUSparkleErrorDomain", .validation),
+        (4000, "SUSparkleErrorDomain", .install),
+        (4005, "SUSparkleErrorDomain", .install),
+        (4007, "SUSparkleErrorDomain", .install),
+        (4008, "SUSparkleErrorDomain", .install),
+        (4012, "SUSparkleErrorDomain", .install),
+        (5000, "SUSparkleErrorDomain", .unknown),
+        (4005, "NSCocoaErrorDomain", .unknown),
+      ]
+
+    @Test(
+      "failureStage maps every SUErrors.h range to its documented bucket",
+      arguments: failureStageCases)
+    func failureStageMapsCorrectly(
+      _ c: (code: Int, domain: String, expected: SparkleUpdateController.SparkleFailureStage)
+    ) {
+      let error = NSError(domain: c.domain, code: c.code)
+      #expect(SparkleUpdateController.failureStage(error) == c.expected)
+    }
+
+    @Test("failureStage: nil error returns .unknown")
+    func failureStage_nilError_returnsUnknown() {
+      #expect(SparkleUpdateController.failureStage(nil) == .unknown)
+    }
+
+    nonisolated static let legacyRoutingCases: [(domain: String, code: Int, expected: Bool)] = [
+      ("NSCocoaErrorDomain", 512, true),  // foreign domain — legacy behavior preserved (#1447 fix)
+      ("NSPOSIXErrorDomain", 28, true),  // foreign domain — legacy behavior preserved
+      ("SUSparkleErrorDomain", 4005, true),  // genuinely install-stage
+      ("SUSparkleErrorDomain", 1005, false),  // Sparkle-domain, positively NOT install-stage
+      ("SUSparkleErrorDomain", 2001, false),  // Sparkle-domain, positively NOT install-stage
+      ("SUSparkleErrorDomain", 5000, false),  // Sparkle-domain, unknown-but-not-install
+    ]
+
+    @Test(
+      "shouldEmitLegacyInstallFailure preserves foreign domains, narrows known Sparkle non-install stages",
+      arguments: legacyRoutingCases)
+    func legacyInstallFailureRouting(_ c: (domain: String, code: Int, expected: Bool)) {
+      let error = NSError(domain: c.domain, code: c.code)
+      // Derive stage from the real classifier rather than hand-picking one,
+      // so the test can't assert an impossible error/stage combination.
+      let stage = SparkleUpdateController.failureStage(error)
+      #expect(
+        SparkleUpdateController.shouldEmitLegacyInstallFailure(error: error, stage: stage)
+          == c.expected)
+    }
+
+    // MARK: - #1447: updateCycleFailed telemetry-hook (Layer B — emission shape only)
+
+    @Test("updateCycleFailed propagates stage and install_intent_seen to hook")
+    func updateCycleFailed_propagatesToHook() async {
+      let box = EventBox()
+      let originalHook = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        Task { @MainActor in box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = originalHook }
+
+      TelemetryService.shared.updateCycleFailed(
+        version: "v1",
+        isCritical: false,
+        source: "menu",
+        errorCode: "SUSparkleErrorDomain.1005",
+        stage: "appcast",
+        installIntentSeen: true,
+        checkKind: "background",
+        currentAppVersion: "v-host"
+      )
+
+      await Task.yield()
+      await Task.yield()
+
+      let captured = box.events
+      let evt = captured.first(where: { $0.name == "update.cycle_failed" })
+      #expect(evt != nil, "update.cycle_failed event should be captured")
+      #expect(evt?.stringProps["stage"] == "appcast")
+      #expect(evt?.stringProps["error_code"] == "SUSparkleErrorDomain.1005")
+      #expect(evt?.boolProps["install_intent_seen"] == true)
+      #expect(
+        evt?.stringProps.keys.sorted() == [
+          "check_kind", "current_app_version", "error_code", "source", "stage", "version",
+        ])
+      #expect(evt?.boolProps.keys.sorted() == ["install_intent_seen", "is_critical"])
     }
 
     // MARK: - #846: telemetry-hook smoke (Layer B)

--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -203,7 +203,6 @@ struct SparkleUpdateControllerTests {
         source: "menu",
         errorCode: "SUSparkleErrorDomain.1005",
         stage: "appcast",
-        installIntentSeen: true,
         checkKind: "background",
         currentAppVersion: "v-host"
       )
@@ -251,7 +250,7 @@ struct SparkleUpdateControllerTests {
           evt.stringProps.keys.sorted() == [
             "check_kind", "current_app_version", "error_code", "source", "stage", "version",
           ])
-        #expect(evt.boolProps.keys.sorted() == ["install_intent_seen", "is_critical"])
+        #expect(evt.boolProps.keys.sorted() == ["is_critical"])
       }
     }
 
@@ -364,7 +363,7 @@ struct SparkleUpdateControllerTests {
 
     // MARK: - #1447: updateCycleFailed telemetry-hook (Layer B — emission shape only)
 
-    @Test("updateCycleFailed propagates stage and install_intent_seen to hook")
+    @Test("updateCycleFailed propagates stage to hook")
     func updateCycleFailed_propagatesToHook() async {
       let box = EventBox()
       let originalHook = TelemetryService.shared.testEventHook
@@ -379,7 +378,6 @@ struct SparkleUpdateControllerTests {
         source: "menu",
         errorCode: "SUSparkleErrorDomain.1005",
         stage: "appcast",
-        installIntentSeen: true,
         checkKind: "background",
         currentAppVersion: "v-host"
       )
@@ -392,12 +390,11 @@ struct SparkleUpdateControllerTests {
       #expect(evt != nil, "update.cycle_failed event should be captured")
       #expect(evt?.stringProps["stage"] == "appcast")
       #expect(evt?.stringProps["error_code"] == "SUSparkleErrorDomain.1005")
-      #expect(evt?.boolProps["install_intent_seen"] == true)
       #expect(
         evt?.stringProps.keys.sorted() == [
           "check_kind", "current_app_version", "error_code", "source", "stage", "version",
         ])
-      #expect(evt?.boolProps.keys.sorted() == ["install_intent_seen", "is_critical"])
+      #expect(evt?.boolProps.keys.sorted() == ["is_critical"])
     }
 
     // MARK: - #846: telemetry-hook smoke (Layer B)


### PR DESCRIPTION
## Summary
- `update.install_failed` fired 942x/30d in production but only 9 were genuine install-stage failures — 933 (99%) were pre-install aborts (App Translocation, disk-image, download-stage errors) mislabeled under the wrong event.
- Adds a pure `SparkleFailureStage` classifier over Sparkle's own `SUErrors.h` numeric code ranges, emits a new `update.cycle_failed{stage}` event for every reportable abort, and narrows `update.install_failed` to fire for Sparkle-domain install-stage failures plus foreign-domain failures whose stage can't be proven (preserving today's conservative behavior for the case where we genuinely don't know the stage, rather than risking a false negative).
- Telemetry-only. No user-facing behavior change.

## Process
- Plan: `docs/feature-requests/issue-1447-2026-07-11-update-cycle-failed-stage.md` (gitignored, local).
- Council (GPT + Gemini, coverage-only): both independently flagged a real regression in the first draft (foreign-domain errors would have silently stopped firing `update.install_failed`) — fixed before implementation.
- Grounded Review (Codex, 4 rounds): confirmed the fix, tightened wording, reached PROCEED-AS-PLANNED.
- Local code-diff review (Codex, 3 rounds): rounds 1-2 both flagged that the bonus `install_intent_seen` diagnostic field was misleading (fires `true` for a bare "Check for Updates" click); removed it entirely rather than patch around it. Round 3 clean.
- 27 new/updated unit tests (table-driven classifier + routing-decision coverage over every `SUErrors.h` constant, plus telemetry-hook emission-shape tests). Full suite: 2812 tests green.
- Live UAT: real "Check for Updates" menu click on the rebuilt dev app, exercised the exact touched code path with no crash/error.

## Test plan
- [x] `scripts/xcode-test.sh` full suite green (2812 tests)
- [x] `scripts/xcode-test.sh --filter EnviousWisprTests/SparkleUpdateControllerTests` (27 tests)
- [x] Local Codex code-diff review clean (round 3)
- [x] Live UAT: real update check, no regression on the ordinary no-update path