### PR TITLE
test(audio): dead-mic proof bench (Part of #1317)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -296,10 +296,7 @@
       let parts = inner.split(separator: ",", maxSplits: 2, omittingEmptySubsequences: false)
       guard parts.count == 3 else { return nil }
       guard let mode = DebugZeroFillArm.Mode(rawValue: String(parts[0])) else { return nil }
-      // n must be non-negative: a negative threshold flows to the controller's
-      // `zeroAfter` boundary branch as a negative start index (`-1..<count`), which
-      // crashes the capture thread when PreRollForwarder indexes the array.
-      guard let n = Int(parts[1]), n >= 0 else { return nil }
+      guard let n = Int(parts[1]) else { return nil }
       let trialID = String(parts[2])
       guard !trialID.isEmpty else { return nil }
       return DebugZeroFillArm(mode: mode, n: n, trialID: trialID)

--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -278,7 +278,8 @@
             "OK armed=\(status.armed) hit=\(status.hit) trial=\(status.trialID) "
             + "mode=\(status.mode) zeroed=\(status.zeroedSampleCount) "
             + "source_incarnation=\(status.sourceIncarnation) "
-            + "xpc_generation=\(status.xpcGeneration)"
+            + "xpc_generation=\(status.xpcGeneration) "
+            + "capture_source=\(status.captureSourceType)"
         }
         return "ERR unknown_command"
       }

--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -24,7 +24,9 @@
   ///   Token file is deleted on `stop()`.
   /// - Fixed command set (no arbitrary RPC, no method invocation, no shell escape):
   ///   `force_proxy_buffer_drop(N)`, `force_audio_wedge_start(N)`,
-  ///   `force_cancel`, `force_xpc_kill`, `force_audio_xpc_kill`, `query_state`.
+  ///   `force_cancel`, `force_xpc_kill`, `force_audio_xpc_kill`, `query_state`,
+  ///   `force_zero_fill(mode,N,trialID)`, `query_fault_status(trialID)` (#1317
+  ///   proof-bench; the last two drive the DEBUG all-zero injector across the helper).
   /// - Each command dispatches to `@MainActor` via `Task { @MainActor in ... }`
   ///   so command handling matches the actor isolation of the seams it drives.
   ///
@@ -253,8 +255,59 @@
           audioProxy.forceWedgeNextStartOps = n
           return "OK"
         }
+        // #1317 proof-bench: force_zero_fill(mode,N,trialID) — arm the DEBUG
+        // all-zero injector in the HELPER process (real service-side sample
+        // substitution, unlike the host-side force_proxy_buffer_drop). mode ∈
+        // {zero_from_start, zero_after_samples, zero_next_samples}; N is the LIVE
+        // sample threshold/budget (ignored for zero_from_start); trialID
+        // correlates the later query_fault_status.
+        if let arm = parseZeroFillArm(cmd) {
+          guard let audioProxy else { return "ERR no_dependency" }
+          let ok = await audioProxy.debugArmZeroFill(arm)
+          return ok ? "OK" : "ERR arm_failed"
+        }
+        // #1317 proof-bench: query_fault_status(trialID) — read the merged fault
+        // status (helper injector fields + proxy XPC generation). Fails CLOSED to
+        // ERR on any missing/malformed/absent-generation condition, and on a trial
+        // id mismatch. "armed" is never evidence of "hit".
+        if let trialID = parseStringArgCommand(cmd, prefix: "query_fault_status(") {
+          guard let audioProxy else { return "ERR no_dependency" }
+          guard let status = await audioProxy.debugFaultStatus() else { return "ERR no_status" }
+          guard status.trialID == trialID else { return "ERR trial_mismatch" }
+          return
+            "OK armed=\(status.armed) hit=\(status.hit) trial=\(status.trialID) "
+            + "mode=\(status.mode) zeroed=\(status.zeroedSampleCount) "
+            + "source_incarnation=\(status.sourceIncarnation) "
+            + "xpc_generation=\(status.xpcGeneration)"
+        }
         return "ERR unknown_command"
       }
+    }
+
+    /// Parse `force_zero_fill(<mode>,<N>,<trialID>)` into a `DebugZeroFillArm`.
+    /// Returns nil if the command is not this shape or any field is invalid — the
+    /// caller then falls through to `ERR unknown_command`. Only the first two commas
+    /// split (`maxSplits: 2`), so trialID is the final unsplit field and may itself
+    /// contain commas; it must be non-empty.
+    private func parseZeroFillArm(_ cmd: String) -> DebugZeroFillArm? {
+      let prefix = "force_zero_fill("
+      guard cmd.hasPrefix(prefix), cmd.hasSuffix(")") else { return nil }
+      let inner = cmd.dropFirst(prefix.count).dropLast()
+      let parts = inner.split(separator: ",", maxSplits: 2, omittingEmptySubsequences: false)
+      guard parts.count == 3 else { return nil }
+      guard let mode = DebugZeroFillArm.Mode(rawValue: String(parts[0])) else { return nil }
+      guard let n = Int(parts[1]) else { return nil }
+      let trialID = String(parts[2])
+      guard !trialID.isEmpty else { return nil }
+      return DebugZeroFillArm(mode: mode, n: n, trialID: trialID)
+    }
+
+    /// Parse `<prefix><arg>)` into the single string argument. Returns nil when the
+    /// command is not this shape or the argument is empty.
+    private func parseStringArgCommand(_ cmd: String, prefix: String) -> String? {
+      guard cmd.hasPrefix(prefix), cmd.hasSuffix(")") else { return nil }
+      let inner = String(cmd.dropFirst(prefix.count).dropLast())
+      return inner.isEmpty ? nil : inner
     }
 
     /// Parse `<prefix>N)` into N for the parameterized commands.

--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -296,7 +296,10 @@
       let parts = inner.split(separator: ",", maxSplits: 2, omittingEmptySubsequences: false)
       guard parts.count == 3 else { return nil }
       guard let mode = DebugZeroFillArm.Mode(rawValue: String(parts[0])) else { return nil }
-      guard let n = Int(parts[1]) else { return nil }
+      // n must be non-negative: a negative threshold flows to the controller's
+      // `zeroAfter` boundary branch as a negative start index (`-1..<count`), which
+      // crashes the capture thread when PreRollForwarder indexes the array.
+      guard let n = Int(parts[1]), n >= 0 else { return nil }
       let trialID = String(parts[2])
       guard !trialID.isEmpty else { return nil }
       return DebugZeroFillArm(mode: mode, n: n, trialID: trialID)

--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -164,6 +164,10 @@ final class AVAudioEngineSource: AudioInputSource {
   private var isRecovering = false
   private var forwarder: PreRollForwarder?
 
+  #if DEBUG
+    var debugZeroFillController: DebugZeroFillController?
+  #endif
+
   /// Called when an audio device operation fails.
   var onDeviceError: ((String) -> Void)?
 
@@ -375,6 +379,9 @@ final class AVAudioEngineSource: AudioInputSource {
 
     let fwd = PreRollForwarder()
     self.forwarder = fwd
+    #if DEBUG
+      fwd.debugZeroFillController = debugZeroFillController
+    #endif
 
     let tapHandler = Self.makeTapHandler(
       audioConverter: audioConverter,

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -132,6 +132,10 @@ final class AVCaptureSessionSource: AudioInputSource {
   private var forwarder: PreRollForwarder?
 
   #if DEBUG
+    var debugZeroFillController: DebugZeroFillController?
+  #endif
+
+  #if DEBUG
     /// The device actually bound at cold `prepare()`, retained so the per-capture
     /// bench evidence (#1377 §3.5) can re-emit it on a warm-reuse trial where
     /// `prepare()` early-returns. The session keeps this exact input across warm
@@ -213,6 +217,9 @@ final class AVCaptureSessionSource: AudioInputSource {
     // startCapture() activates live forwarding.
     let fwd = PreRollForwarder()
     self.forwarder = fwd
+    #if DEBUG
+      fwd.debugZeroFillController = debugZeroFillController
+    #endif
     let preRollDelegate = CaptureDelegate(
       targetFormat: Self.targetFormat,
       forwarder: fwd,

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -125,6 +125,20 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// Either AVAudioEngineSource (no BT) or AVCaptureSessionSource (BT output active).
   private var activeSource: (any AudioInputSource)?
 
+  #if DEBUG
+    /// #1317 proof-bench: the single DEBUG-only all-zero injector, handed to every
+    /// source on install so it can substitute digital silence at the forwarder.
+    /// Compiled out of release.
+    let debugZeroFillController = DebugZeroFillController()
+
+    /// #1317 proof-bench: monotonic, manager-owned resource generation — the
+    /// freshness oracle for `fresh_pipe_proven`. NOT `ObjectIdentifier(activeSource)`
+    /// (rebuild destroys resources while retaining the object) and NOT the
+    /// capture-session id (which advances per capture even on warm reuse). Increments
+    /// only on new-source install, destructive `rebuildEngine()`, and `buildEngine()`.
+    private(set) var debugSourceIncarnation: UInt64 = 0
+  #endif
+
   /// Issue #285 — mirror of `activeSource.captureGeneration` / `captureSourceType`
   /// captured at session start, so pipeline Sentry extras still resolve a real
   /// session id + backend tag after `stopCapture()` synchronously tears down
@@ -395,6 +409,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   public func rebuildEngine() {
     activeSource?.rebuild()
+    #if DEBUG
+      debugSourceIncarnation += 1  // destructive rebuild of the active source's resources
+    #endif
   }
 
   public func buildEngine(noiseSuppression: Bool) {
@@ -405,11 +422,18 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // buildEngine only creates an AVAudioEngine object, doesn't start it or install taps).
     if let engineSource = activeSource as? AVAudioEngineSource {
       engineSource.buildEngine(noiseSuppression: noiseSuppression)
+      #if DEBUG
+        debugSourceIncarnation += 1  // AVAudioEngine resources replaced on the active source
+      #endif
     } else {
       // Tear down any existing non-engine source before replacing
       activeSource?.rebuild()
       let engineSource = AVAudioEngineSource()
       engineSource.buildEngine(noiseSuppression: noiseSuppression)
+      #if DEBUG
+        engineSource.debugZeroFillController = debugZeroFillController
+        debugSourceIncarnation += 1  // new engine source installed
+      #endif
       activeSource = engineSource
     }
   }
@@ -722,6 +746,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       source = halSource
     }
 
+    #if DEBUG
+      source.debugZeroFillController = debugZeroFillController
+      debugSourceIncarnation += 1  // new source installed at the activeSource authority
+    #endif
     activeSource = source
     return source
   }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -142,7 +142,13 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// path. Translates the Core wire enum into the controller's associated-value
     /// `Mode` here so the injector type stays module-internal. `package` access:
     /// reachable from the handler in `EnviousWisprAudioService` (same SPM package).
-    package func debugArmZeroFill(mode: DebugZeroFillArm.Mode, n: Int, trialID: String) {
+    /// Returns false (arms nothing) for a negative budget. This is the RT-safety
+    /// chokepoint for EVERY arm path — endpoint, proxy, and the XPC handler that
+    /// decodes a `DebugZeroFillArm` straight from JSON — so a negative `n` cannot
+    /// reach the controller (where it would emit a negative range and crash the
+    /// capture thread on index). The endpoint parser also rejects it at the edge.
+    package func debugArmZeroFill(mode: DebugZeroFillArm.Mode, n: Int, trialID: String) -> Bool {
+      guard n >= 0 else { return false }
       let controllerMode: DebugZeroFillController.Mode
       switch mode {
       case .zeroFromStart: controllerMode = .zeroFromStart
@@ -150,9 +156,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       case .zeroNextSamples: controllerMode = .zeroNext(budget: n)
       case .disarmed:
         debugZeroFillController.disarm()
-        return
+        return true
       }
       debugZeroFillController.arm(mode: controllerMode, trialID: trialID)
+      return true
     }
 
     /// #1317 proof-bench (DEBUG only): snapshot the injector status plus the

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -137,6 +137,30 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// capture-session id (which advances per capture even on warm reuse). Increments
     /// only on new-source install, destructive `rebuildEngine()`, and `buildEngine()`.
     private(set) var debugSourceIncarnation: UInt64 = 0
+
+    /// #1317 proof-bench (DEBUG only): arm the injector from the DEBUG XPC fault
+    /// path. Translates the Core wire enum into the controller's associated-value
+    /// `Mode` here so the injector type stays module-internal. `package` access:
+    /// reachable from the handler in `EnviousWisprAudioService` (same SPM package).
+    package func debugArmZeroFill(mode: DebugZeroFillArm.Mode, n: Int, trialID: String) {
+      let controllerMode: DebugZeroFillController.Mode
+      switch mode {
+      case .zeroFromStart: controllerMode = .zeroFromStart
+      case .zeroAfterSamples: controllerMode = .zeroAfter(threshold: n)
+      case .zeroNextSamples: controllerMode = .zeroNext(budget: n)
+      }
+      debugZeroFillController.arm(mode: controllerMode, trialID: trialID)
+    }
+
+    /// #1317 proof-bench (DEBUG only): snapshot the injector status plus the
+    /// manager's monotonic source-incarnation generation (the `fresh_pipe_proven`
+    /// oracle). Combines both manager-owned facts in one atomic read.
+    package func debugFaultStatusSnapshot() -> DebugFaultServiceStatus {
+      let s = debugZeroFillController.status()
+      return DebugFaultServiceStatus(
+        armed: s.armed, hit: s.hit, trialID: s.trialID, mode: s.mode,
+        zeroedSampleCount: s.zeroedSampleCount, sourceIncarnation: debugSourceIncarnation)
+    }
   #endif
 
   /// Issue #285 — mirror of `activeSource.captureGeneration` / `captureSourceType`

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -142,13 +142,13 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// path. Translates the Core wire enum into the controller's associated-value
     /// `Mode` here so the injector type stays module-internal. `package` access:
     /// reachable from the handler in `EnviousWisprAudioService` (same SPM package).
-    /// Returns false (arms nothing) for a negative budget. This is the RT-safety
-    /// chokepoint for EVERY arm path — endpoint, proxy, and the XPC handler that
-    /// decodes a `DebugZeroFillArm` straight from JSON — so a negative `n` cannot
-    /// reach the controller (where it would emit a negative range and crash the
-    /// capture thread on index). The endpoint parser also rejects it at the edge.
-    package func debugArmZeroFill(mode: DebugZeroFillArm.Mode, n: Int, trialID: String) -> Bool {
-      guard n >= 0 else { return false }
+    /// `n` is intentionally NOT validated here: the controller's range math is
+    /// provably safe for any `Int`, including negatives (`zeroAfter` short-circuits
+    /// on `startSeen >= threshold`; `zeroNext` guards `startSeen < budget`), so a
+    /// negative budget zeroes-all or nothing but never emits a negative range.
+    /// Proven by `DebugZeroFillControllerTests.negativeBudgetIsSafe`. Do not re-add
+    /// an `n >= 0` guard — a Codex round claimed a crash here that does not exist.
+    package func debugArmZeroFill(mode: DebugZeroFillArm.Mode, n: Int, trialID: String) {
       let controllerMode: DebugZeroFillController.Mode
       switch mode {
       case .zeroFromStart: controllerMode = .zeroFromStart
@@ -156,10 +156,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       case .zeroNextSamples: controllerMode = .zeroNext(budget: n)
       case .disarmed:
         debugZeroFillController.disarm()
-        return true
+        return
       }
       debugZeroFillController.arm(mode: controllerMode, trialID: trialID)
-      return true
     }
 
     /// #1317 proof-bench (DEBUG only): snapshot the injector status plus the

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -148,6 +148,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       case .zeroFromStart: controllerMode = .zeroFromStart
       case .zeroAfterSamples: controllerMode = .zeroAfter(threshold: n)
       case .zeroNextSamples: controllerMode = .zeroNext(budget: n)
+      case .disarmed:
+        debugZeroFillController.disarm()
+        return
       }
       debugZeroFillController.arm(mode: controllerMode, trialID: trialID)
     }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -168,7 +168,8 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       let s = debugZeroFillController.status()
       return DebugFaultServiceStatus(
         armed: s.armed, hit: s.hit, trialID: s.trialID, mode: s.mode,
-        zeroedSampleCount: s.zeroedSampleCount, sourceIncarnation: debugSourceIncarnation)
+        zeroedSampleCount: s.zeroedSampleCount, sourceIncarnation: debugSourceIncarnation,
+        captureSourceType: activeSource?.captureSourceType ?? "none")
     }
   #endif
 

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -435,7 +435,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   }
 
   public func rebuildEngine() {
-    activeSource?.rebuild()
+    // Only a real rebuild advances the incarnation: with no active source nothing
+    // is destroyed, so a bump here would falsely satisfy `fresh_pipe_proven`.
+    guard let source = activeSource else { return }
+    source.rebuild()
     #if DEBUG
       debugSourceIncarnation += 1  // destructive rebuild of the active source's resources
     #endif

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -16,6 +16,7 @@ import Foundation
     package let zeroedSampleCount: Int
     package let sourceIncarnation: UInt64
     package let xpcGeneration: UInt64
+    package let captureSourceType: String
   }
 #endif
 
@@ -1105,7 +1106,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       return DebugFaultStatus(
         armed: s.armed, hit: s.hit, trialID: s.trialID, mode: s.mode,
         zeroedSampleCount: s.zeroedSampleCount, sourceIncarnation: s.sourceIncarnation,
-        xpcGeneration: xpcGeneration)
+        xpcGeneration: xpcGeneration, captureSourceType: s.captureSourceType)
     }
   #endif
 

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -1055,6 +1055,15 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     /// `DebugFaultEndpoint` (`force_zero_fill(...)`).
     package func debugArmZeroFill(_ arm: DebugZeroFillArm) async -> Bool {
       guard let payload = try? JSONEncoder().encode(arm) else { return false }
+      // A freshly launched debug app with noise-suppression default OFF never
+      // called `buildEngine`, so no audio XPC line exists yet; the harness arms
+      // BEFORE the first recording, so `serviceProxy` would hit `onProxyError`
+      // and fail closed with `ERR arm_failed` before any helper is spawned.
+      // Bring the line up first — `acquireConnection()` is idempotent (returns
+      // the live line if one already exists), and the subsequent start reuses
+      // this same slot, so the helper we arm is the helper that will record.
+      // Cloud review PR #1504.
+      _ = acquireConnection()
       // One-shot guard (like `stopCapture`): a reply followed by a per-call
       // transport error (or vice versa) would otherwise resume twice and trap.
       let ok: Bool? = try? await withCheckedThrowingContinuation {

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -2,6 +2,23 @@
 import EnviousWisprCore
 import Foundation
 
+#if DEBUG
+  /// #1317 proof-bench (DEBUG only): the endpoint-facing fault status — the
+  /// helper's `DebugFaultServiceStatus` fields plus the proxy's own live XPC
+  /// generation. Built only by `AudioCaptureProxy.debugFaultStatus()`; a `nil`
+  /// return there means fail-closed (`ERR`), never a defaulted instance of this.
+  /// `package` access: read by `DebugFaultEndpoint` in the app target.
+  package struct DebugFaultStatus: Sendable {
+    package let armed: Bool
+    package let hit: Bool
+    package let trialID: String
+    package let mode: String
+    package let zeroedSampleCount: Int
+    package let sourceIncarnation: UInt64
+    package let xpcGeneration: UInt64
+  }
+#endif
+
 /// XPC-backed implementation of `AudioCaptureInterface`.
 ///
 /// Bridges the in-process `AudioCaptureInterface` contract to XPC calls against the
@@ -1027,6 +1044,58 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       guard let live = slot.current else { return }
       reportLineDeath(
         generation: live.generation, cause: .invalidated, wasCapturing: isCapturing)
+    }
+
+    // MARK: - #1317 proof-bench arm/status channel
+
+    /// Arm the DEBUG all-zero injector in the helper. Returns `true` only on a
+    /// helper `OK` reply; ANY failure (no live line, transport error, arm error)
+    /// returns `false` so the endpoint fails closed. `package` access: driven by
+    /// `DebugFaultEndpoint` (`force_zero_fill(...)`).
+    package func debugArmZeroFill(_ arm: DebugZeroFillArm) async -> Bool {
+      guard let payload = try? JSONEncoder().encode(arm) else { return false }
+      // Mirror `waitForFormatStabilization`: exactly one of {reply, onProxyError}
+      // fires for a reply-bearing call, so a plain continuation is safe here.
+      return await withCheckedContinuation { cont in
+        serviceProxy { proxy in
+          proxy.debugArmZeroFill(payload) { error in
+            cont.resume(returning: error == nil)
+          }
+        } onProxyError: {
+          cont.resume(returning: false)
+        }
+      }
+    }
+
+    /// Read the injector's fault status from the helper and merge the proxy's own
+    /// live XPC generation. Returns `nil` — never a defaulted status — on any
+    /// no-connection / transport / decode failure OR when there is no live line to
+    /// source an XPC generation from (absent-generation ⇒ fail closed ⇒ `ERR`).
+    /// "Armed" is not evidence of "hit"; the caller reads `hit` for that.
+    package func debugFaultStatus() async -> DebugFaultStatus? {
+      // Snapshot the live generation FIRST; a nil line means no fresh-pipe
+      // evidence exists, which is itself a fail-closed outcome.
+      guard let xpcGeneration = slot.current?.generation else { return nil }
+      let serviceStatus: DebugFaultServiceStatus? = await withCheckedContinuation { cont in
+        serviceProxy { proxy in
+          proxy.debugFaultStatus { data, _ in
+            guard let data,
+              let decoded = try? JSONDecoder().decode(DebugFaultServiceStatus.self, from: data)
+            else {
+              cont.resume(returning: nil)
+              return
+            }
+            cont.resume(returning: decoded)
+          }
+        } onProxyError: {
+          cont.resume(returning: nil)
+        }
+      }
+      guard let s = serviceStatus else { return nil }
+      return DebugFaultStatus(
+        armed: s.armed, hit: s.hit, trialID: s.trialID, mode: s.mode,
+        zeroedSampleCount: s.zeroedSampleCount, sourceIncarnation: s.sourceIncarnation,
+        xpcGeneration: xpcGeneration)
     }
   #endif
 

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -1054,17 +1054,20 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     /// `DebugFaultEndpoint` (`force_zero_fill(...)`).
     package func debugArmZeroFill(_ arm: DebugZeroFillArm) async -> Bool {
       guard let payload = try? JSONEncoder().encode(arm) else { return false }
-      // Mirror `waitForFormatStabilization`: exactly one of {reply, onProxyError}
-      // fires for a reply-bearing call, so a plain continuation is safe here.
-      return await withCheckedContinuation { cont in
+      // One-shot guard (like `stopCapture`): a reply followed by a per-call
+      // transport error (or vice versa) would otherwise resume twice and trap.
+      let ok: Bool? = try? await withCheckedThrowingContinuation {
+        (cont: CheckedContinuation<Bool, any Error>) in
+        let guard_ = OneShotContinuation(cont)
         serviceProxy { proxy in
           proxy.debugArmZeroFill(payload) { error in
-            cont.resume(returning: error == nil)
+            guard_.resume(returning: error == nil)
           }
         } onProxyError: {
-          cont.resume(returning: false)
+          guard_.resume(returning: false)
         }
       }
+      return ok ?? false
     }
 
     /// Read the injector's fault status from the helper and merge the proxy's own
@@ -1076,21 +1079,28 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       // Snapshot the live generation FIRST; a nil line means no fresh-pipe
       // evidence exists, which is itself a fail-closed outcome.
       guard let xpcGeneration = slot.current?.generation else { return nil }
-      let serviceStatus: DebugFaultServiceStatus? = await withCheckedContinuation { cont in
-        serviceProxy { proxy in
-          proxy.debugFaultStatus { data, _ in
-            guard let data,
-              let decoded = try? JSONDecoder().decode(DebugFaultServiceStatus.self, from: data)
-            else {
-              cont.resume(returning: nil)
-              return
+      // One-shot guard against a reply/error double-resume (see `debugArmZeroFill`).
+      // `try?` yields a double optional (continuation payload is itself optional);
+      // `?? nil` flattens it back to `DebugFaultServiceStatus?`.
+      let serviceStatus: DebugFaultServiceStatus? =
+        (try? await withCheckedThrowingContinuation {
+          (cont: CheckedContinuation<DebugFaultServiceStatus?, any Error>) in
+          let guard_ = OneShotContinuation(cont)
+          serviceProxy { proxy in
+            proxy.debugFaultStatus { data, _ in
+              guard let data,
+                let decoded = try? JSONDecoder().decode(
+                  DebugFaultServiceStatus.self, from: data)
+              else {
+                guard_.resume(returning: nil)
+                return
+              }
+              guard_.resume(returning: decoded)
             }
-            cont.resume(returning: decoded)
+          } onProxyError: {
+            guard_.resume(returning: nil)
           }
-        } onProxyError: {
-          cont.resume(returning: nil)
-        }
-      }
+        }) ?? nil
       guard let s = serviceStatus else { return nil }
       return DebugFaultStatus(
         armed: s.armed, hit: s.hit, trialID: s.trialID, mode: s.mode,

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -64,6 +64,16 @@ protocol AudioInputSource: AnyObject {
   func abortPrepare()
   func rebuild()
 
+  #if DEBUG
+    /// #1317 proof-bench: DEBUG-only all-zero injector, assigned by
+    /// `AudioCaptureManager` on every new-source installation before `prepare()`
+    /// can construct a forwarder. Each conformer stores it and passes it into every
+    /// `PreRollForwarder` it creates. Declared as a REQUIREMENT (no default) so the
+    /// compiler forces every conformer to participate — a newly-added source cannot
+    /// silently bypass the injector. Compiled out of release.
+    var debugZeroFillController: DebugZeroFillController? { get set }
+  #endif
+
   /// #1434: stop-time capture-health facts (native rate, drop/error counters,
   /// divergence flag) the manager attaches to `CaptureResult.metadata`.
   /// Declared as a REQUIREMENT (not extension-only) so existential calls

--- a/Sources/EnviousWisprAudio/DebugZeroFillController.swift
+++ b/Sources/EnviousWisprAudio/DebugZeroFillController.swift
@@ -1,0 +1,148 @@
+#if DEBUG
+  import Foundation
+  import os
+
+  /// DEBUG-only controller that substitutes captured audio with digital silence
+  /// (exactly `0.0`) to reproduce the production `zombie_engine_zero_peak` dead-mic
+  /// failure (#1317) on command. Test seam only — the whole type is compiled out of
+  /// release (`#if DEBUG`), armed only when the fault endpoint is active.
+  ///
+  /// Owned by `AudioCaptureManager`, passed into every `PreRollForwarder`. Armed from
+  /// MainActor (via the DEBUG XPC fault path) and consumed on capture threads, so it
+  /// carries its own lock. It NEVER rebuilds, recovers, or messages the UI — it only
+  /// decides which samples become zero and records that it did.
+  ///
+  /// Modes (sample-count based, not source-dependent buffer counts):
+  /// - `.zeroFromStart` — zeroes drained pre-roll, activation delta, AND every live
+  ///   sample. The only mode that touches pre-roll.
+  /// - `.zeroAfter(threshold:)` — zeroes every live sample once `threshold` live
+  ///   samples have committed (pre-roll and the leading `threshold` samples pass through).
+  /// - `.zeroNext(budget:)` — zeroes the next `budget` live samples after arming, then
+  ///   restores real audio (bounded-zero-then-restore).
+  ///
+  /// `zeroAfter`/`zeroNext` budgets count only LIVE (post-activation) samples, so idle
+  /// warm-engine pre-roll cannot consume the requested lead or bounded-zero budget.
+  final class DebugZeroFillController: @unchecked Sendable {
+
+    enum Mode: Sendable, Equatable {
+      case zeroFromStart
+      case zeroAfter(threshold: Int)
+      case zeroNext(budget: Int)
+    }
+
+    /// Which forwarding path is asking. `zeroFromStart` zeroes both; every other
+    /// mode leaves `.preRollDrain` untouched.
+    enum Context: Sendable { case preRollDrain, live }
+
+    struct Status: Sendable {
+      let armed: Bool
+      let hit: Bool
+      let trialID: String
+      let mode: String
+      let zeroedSampleCount: Int
+    }
+
+    private struct State {
+      var mode: Mode?
+      var trialID: String = ""
+      var armed = false
+      var hit = false
+      var zeroedSampleCount = 0
+      var liveSamplesSeen = 0
+    }
+
+    private let lock = OSAllocatedUnfairLock(initialState: State())
+
+    // MARK: - Arm / disarm (MainActor caller, but lock-guarded for safety)
+
+    func arm(mode: Mode, trialID: String) {
+      lock.withLock { s in
+        s.mode = mode
+        s.trialID = trialID
+        s.armed = true
+        s.hit = false
+        s.zeroedSampleCount = 0
+        s.liveSamplesSeen = 0
+      }
+    }
+
+    func disarm() {
+      lock.withLock { s in s = State() }
+    }
+
+    func status() -> Status {
+      lock.withLock { s in
+        Status(
+          armed: s.armed,
+          hit: s.hit,
+          trialID: s.trialID,
+          mode: s.mode.map(Self.modeTag) ?? "none",
+          zeroedSampleCount: s.zeroedSampleCount
+        )
+      }
+    }
+
+    // MARK: - Zero-range decision (capture-thread caller)
+
+    /// Decide which contiguous sub-range `[start, end)` of a `count`-sample chunk to
+    /// zero, given the forwarding context, advancing live-sample accounting. Returns
+    /// `nil` when nothing in this chunk is zeroed. A boundary chunk returns a partial
+    /// range so the caller recomputes level from the transformed samples rather than
+    /// reporting a false `0.0`.
+    func zeroRange(count: Int, context: Context) -> Range<Int>? {
+      guard count > 0 else { return nil }
+      return lock.withLock { s -> Range<Int>? in
+        guard s.armed, let mode = s.mode else { return nil }
+        switch mode {
+        case .zeroFromStart:
+          if context == .live { s.liveSamplesSeen += count }
+          s.zeroedSampleCount += count
+          s.hit = true
+          return 0..<count
+
+        case .zeroAfter(let threshold):
+          guard context == .live else { return nil }  // pre-roll passes through
+          let startSeen = s.liveSamplesSeen
+          s.liveSamplesSeen += count
+          if startSeen >= threshold {
+            s.zeroedSampleCount += count
+            s.hit = true
+            return 0..<count
+          }
+          let boundary = threshold - startSeen  // first zeroed index within this chunk
+          guard boundary < count else { return nil }
+          s.zeroedSampleCount += (count - boundary)
+          s.hit = true
+          return boundary..<count
+
+        case .zeroNext(let budget):
+          guard context == .live else { return nil }  // pre-roll passes through
+          let startSeen = s.liveSamplesSeen
+          s.liveSamplesSeen += count
+          guard startSeen < budget else { return nil }  // budget spent → restore
+          let end = min(count, budget - startSeen)
+          s.zeroedSampleCount += end
+          s.hit = true
+          return 0..<end
+        }
+      }
+    }
+
+    /// True when this armed mode zeroes the pre-roll drain (only `.zeroFromStart`).
+    var zeroesPreRoll: Bool {
+      lock.withLock { s in
+        guard s.armed, let mode = s.mode else { return false }
+        if case .zeroFromStart = mode { return true }
+        return false
+      }
+    }
+
+    static func modeTag(_ m: Mode) -> String {
+      switch m {
+      case .zeroFromStart: return "zero_from_start"
+      case .zeroAfter: return "zero_after_samples"
+      case .zeroNext: return "zero_next_samples"
+      }
+    }
+  }
+#endif

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -364,6 +364,10 @@ final class HALDeviceInputSource: AudioInputSource {
     HALDeviceInputSource.queryNativeStreamFormat(deviceID: deviceID)?.mSampleRate
   }
   private var forwarder: PreRollForwarder?
+
+  #if DEBUG
+    var debugZeroFillController: DebugZeroFillController?
+  #endif
   /// Dedicated thread draining `HALRenderContext.ring` off the HAL IO thread.
   /// Retained only to keep it alive; its loop exits on its own once
   /// `teardownUnit()` signals the semaphore after the stop flag is set.
@@ -550,6 +554,9 @@ final class HALDeviceInputSource: AudioInputSource {
     let ring = HALSampleRing(slotCount: Self.ringSlotCount, capacityPerSlot: capacityFrames)
     let stopped = HALStoppedFlag()
     let fwd = PreRollForwarder()
+    #if DEBUG
+      fwd.debugZeroFillController = debugZeroFillController
+    #endif
     let context = HALRenderContext(
       audioUnit: unit, scratch: scratch, capacityFrames: capacityFrames,
       ring: ring, stopped: stopped, liveness: captureLiveness, forwarder: fwd,

--- a/Sources/EnviousWisprAudio/PreRollForwarder.swift
+++ b/Sources/EnviousWisprAudio/PreRollForwarder.swift
@@ -44,6 +44,13 @@ final class PreRollForwarder: @unchecked Sendable {
   private let capacity: Int
   private let lock: OSAllocatedUnfairLock<State>
 
+  #if DEBUG
+    /// #1317 proof-bench: DEBUG-only all-zero injector. Set by the owning source
+    /// (which received it from `AudioCaptureManager`) when it constructs the
+    /// forwarder. Nil means ordinary forwarding. Compiled out of release.
+    var debugZeroFillController: DebugZeroFillController?
+  #endif
+
   // MARK: - Init
 
   /// Create a forwarder with a preallocated ring buffer.
@@ -93,6 +100,30 @@ final class PreRollForwarder: @unchecked Sendable {
     case .store, .drop:
       break
     case .forward(let onSamples, let onBuffer, let continuation):
+      #if DEBUG
+        // #1317 proof-bench: substitute digital silence for the zeroed range,
+        // transforming BOTH the sample array and the PCM buffer, and recomputing
+        // level (0.0 only for a fully-zero chunk; recomputed RMS on a boundary
+        // chunk). Same delivery cadence/frame-count; content only.
+        if let ctl = debugZeroFillController,
+          let range = ctl.zeroRange(count: samples.count, context: .live)
+        {
+          var zeroed = samples
+          for i in range { zeroed[i] = 0 }
+          if let ch = buffer.floatChannelData {
+            let n = Int(buffer.frameLength)
+            for i in range where i < n { ch[0][i] = 0 }
+          }
+          let level: Float =
+            zeroed.contains(where: { $0 != 0 })
+            ? (zeroed.reduce(Float(0)) { $0 + $1 * $1 } / Float(zeroed.count)).squareRoot()
+            : 0
+          onSamples?(zeroed, level)
+          onBuffer?(buffer)
+          continuation?.yield(buffer)
+          return
+        }
+      #endif
       onSamples?(samples, level)
       onBuffer?(buffer)
       continuation?.yield(buffer)
@@ -169,13 +200,23 @@ final class PreRollForwarder: @unchecked Sendable {
     continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?,
     logPrefix: String
   ) -> Int {
-    let preRollSamples = beginActivation(
+    var preRollSamples = beginActivation(
       onSamples: onSamples,
       onBuffer: onBuffer,
       continuation: continuation
     )
 
     if !preRollSamples.isEmpty {
+      #if DEBUG
+        // #1317 proof-bench: zero_from_start also zeroes the drained pre-roll and
+        // activation delta, so real audio captured before arming cannot leak into a
+        // zero-from-start trial. Other modes leave pre-roll untouched.
+        if let ctl = debugZeroFillController,
+          let range = ctl.zeroRange(count: preRollSamples.count, context: .preRollDrain)
+        {
+          for i in range { preRollSamples[i] = 0 }
+        }
+      #endif
       Self.feedPreRoll(
         preRollSamples, onSamples: onSamples, onBuffer: onBuffer, continuation: continuation)
       AudioCaptureManager.btRouteLog(
@@ -186,8 +227,15 @@ final class PreRollForwarder: @unchecked Sendable {
         "\(logPrefix) pre-roll empty: no samples buffered during setup")
     }
 
-    let delta = commitCapture()
+    var delta = commitCapture()
     if !delta.isEmpty {
+      #if DEBUG
+        if let ctl = debugZeroFillController,
+          let range = ctl.zeroRange(count: delta.count, context: .preRollDrain)
+        {
+          for i in range { delta[i] = 0 }
+        }
+      #endif
       Self.feedPreRoll(delta, onSamples: onSamples, onBuffer: onBuffer, continuation: continuation)
       AudioCaptureManager.btRouteLog("\(logPrefix) pre-roll delta: \(delta.count) samples")
     }

--- a/Sources/EnviousWisprAudio/PreRollForwarder.swift
+++ b/Sources/EnviousWisprAudio/PreRollForwarder.swift
@@ -105,14 +105,23 @@ final class PreRollForwarder: @unchecked Sendable {
         // transforming BOTH the sample array and the PCM buffer, and recomputing
         // level (0.0 only for a fully-zero chunk; recomputed RMS on a boundary
         // chunk). Same delivery cadence/frame-count; content only.
+        // Confirm a writable Float32 mono buffer whose frame count matches the
+        // sample array BEFORE asking the controller for a range — `zeroRange`
+        // advances state and records the hit, so an unsupported buffer shape must
+        // not consume the injector or claim a hit while the array and PCM diverge.
+        // `zeroRange` is last in the chain (short-circuit) so it runs only when the
+        // buffer can be zeroed identically to the array.
         if let ctl = debugZeroFillController,
+          let ch = buffer.floatChannelData,
+          Int(buffer.frameLength) == samples.count,
+          buffer.format.commonFormat == .pcmFormatFloat32,
+          buffer.format.channelCount == 1,
           let range = ctl.zeroRange(count: samples.count, context: .live)
         {
           var zeroed = samples
-          for i in range { zeroed[i] = 0 }
-          if let ch = buffer.floatChannelData {
-            let n = Int(buffer.frameLength)
-            for i in range where i < n { ch[0][i] = 0 }
+          for i in range {
+            zeroed[i] = 0
+            ch[0][i] = 0
           }
           let level: Float =
             zeroed.contains(where: { $0 != 0 })

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -336,6 +336,38 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
     }
   }
 
+  #if DEBUG
+    // MARK: - #1317 proof-bench DEBUG fault channel (compiled out of release)
+
+    func debugArmZeroFill(_ payload: Data, reply: @escaping (NSError?) -> Void) {
+      nonisolated(unsafe) let safeReply = reply
+      Task { @MainActor in
+        do {
+          let arm = try JSONDecoder().decode(DebugZeroFillArm.self, from: payload)
+          self.captureManager.debugArmZeroFill(mode: arm.mode, n: arm.n, trialID: arm.trialID)
+          safeReply(nil)
+        } catch {
+          // XPC error sanitization boundary.
+          safeReply(XPCErrorSanitizer.sanitizeForXPC(error))
+        }
+      }
+    }
+
+    func debugFaultStatus(reply: @escaping (Data?, NSError?) -> Void) {
+      nonisolated(unsafe) let safeReply = reply
+      Task { @MainActor in
+        let status = self.captureManager.debugFaultStatusSnapshot()
+        do {
+          let data = try JSONEncoder().encode(status)
+          safeReply(data, nil)
+        } catch {
+          // XPC error sanitization boundary. Never reply a default/empty status.
+          safeReply(nil, XPCErrorSanitizer.sanitizeForXPC(error))
+        }
+      }
+    }
+  #endif
+
   // MARK: - VAD (Step 5)
 
   func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -344,7 +344,17 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
       Task { @MainActor in
         do {
           let arm = try JSONDecoder().decode(DebugZeroFillArm.self, from: payload)
-          self.captureManager.debugArmZeroFill(mode: arm.mode, n: arm.n, trialID: arm.trialID)
+          guard
+            self.captureManager.debugArmZeroFill(
+              mode: arm.mode, n: arm.n, trialID: arm.trialID)
+          else {
+            // XPC error sanitization boundary.
+            safeReply(
+              NSError(
+                domain: "DebugZeroFill", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "negative sample count"]))
+            return
+          }
           safeReply(nil)
         } catch {
           // XPC error sanitization boundary.

--- a/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
+++ b/Sources/EnviousWisprAudioService/AudioServiceHandler.swift
@@ -344,17 +344,7 @@ final class AudioServiceHandler: NSObject, AudioServiceProtocol, @unchecked Send
       Task { @MainActor in
         do {
           let arm = try JSONDecoder().decode(DebugZeroFillArm.self, from: payload)
-          guard
-            self.captureManager.debugArmZeroFill(
-              mode: arm.mode, n: arm.n, trialID: arm.trialID)
-          else {
-            // XPC error sanitization boundary.
-            safeReply(
-              NSError(
-                domain: "DebugZeroFill", code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "negative sample count"]))
-            return
-          }
+          self.captureManager.debugArmZeroFill(mode: arm.mode, n: arm.n, trialID: arm.trialID)
           safeReply(nil)
         } catch {
           // XPC error sanitization boundary.

--- a/Sources/EnviousWisprCore/AudioServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/AudioServiceProtocol.swift
@@ -81,6 +81,21 @@ import Foundation
   /// Return speech segments detected by service-side VAD.
   /// Reply carries Data of packed [Int32 startIndex, Int32 endIndex] pairs.
   func getVADSegments(reply: @escaping (Data) -> Void)
+
+  #if DEBUG
+    // MARK: - #1317 proof-bench DEBUG fault channel (compiled out of release)
+
+    /// Arm the DEBUG all-zero injector in the helper. `payload` is a JSON-encoded
+    /// `DebugZeroFillArm`. Reply carries an `NSError` on decode/arm failure, nil on
+    /// success. The whole method is `#if DEBUG` on BOTH the proxy (client) and the
+    /// handler (service), so the runtime `NSXPCInterface` matches in every build.
+    func debugArmZeroFill(_ payload: Data, reply: @escaping (NSError?) -> Void)
+
+    /// Read the injector's fault status from the helper. Reply's first `Data` is a
+    /// JSON-encoded `DebugFaultServiceStatus`; on encode failure the `Data` is nil
+    /// and the `NSError` is set. Never returns a default/empty status silently.
+    func debugFaultStatus(reply: @escaping (Data?, NSError?) -> Void)
+  #endif
 }
 
 /// XPC protocol: callbacks from audio service to host app.

--- a/Sources/EnviousWisprCore/DebugFaultPayloads.swift
+++ b/Sources/EnviousWisprCore/DebugFaultPayloads.swift
@@ -52,10 +52,15 @@
     /// Monotonic manager-owned resource generation — the `fresh_pipe_proven`
     /// oracle. NOT the capture-session id.
     package let sourceIncarnation: UInt64
+    /// Low-cardinality tag of the ACTIVE capture backend the injector is riding
+    /// (`av_audio_engine` / `hal_device_input` / `av_capture_session` / `none`),
+    /// so the scorecard records WHICH mic route each trial ran on — the built-in
+    /// vs Bluetooth path cannot otherwise be distinguished in the evidence.
+    package let captureSourceType: String
 
     package init(
       armed: Bool, hit: Bool, trialID: String, mode: String,
-      zeroedSampleCount: Int, sourceIncarnation: UInt64
+      zeroedSampleCount: Int, sourceIncarnation: UInt64, captureSourceType: String
     ) {
       self.armed = armed
       self.hit = hit
@@ -63,6 +68,7 @@
       self.mode = mode
       self.zeroedSampleCount = zeroedSampleCount
       self.sourceIncarnation = sourceIncarnation
+      self.captureSourceType = captureSourceType
     }
   }
 #endif

--- a/Sources/EnviousWisprCore/DebugFaultPayloads.swift
+++ b/Sources/EnviousWisprCore/DebugFaultPayloads.swift
@@ -21,6 +21,10 @@
       case zeroFromStart = "zero_from_start"
       case zeroAfterSamples = "zero_after_samples"
       case zeroNextSamples = "zero_next_samples"
+      /// Clears any armed fault (disarms the controller). Lets the bench restore a
+      /// clean pipe for a positive-control take, so "no canary on the dead take" is
+      /// distinguishable from "TTS/ASR broken." `n`/`trialID` are ignored.
+      case disarmed = "disarmed"
     }
 
     package let mode: Mode

--- a/Sources/EnviousWisprCore/DebugFaultPayloads.swift
+++ b/Sources/EnviousWisprCore/DebugFaultPayloads.swift
@@ -1,0 +1,64 @@
+#if DEBUG
+  import Foundation
+
+  /// #1317 proof-bench (DEBUG only): JSON wire payloads for the DEBUG all-zero
+  /// injector's XPC arm/status channel. They cross the `@objc AudioServiceProtocol`
+  /// boundary as `Data` (the protocol is `@objc`, so only plist types travel
+  /// directly). Whole file compiled out of release.
+  ///
+  /// `package` access: shared across `EnviousWisprCore`, `EnviousWisprAudio`
+  /// (proxy + manager), `EnviousWisprAudioService` (handler), and
+  /// `EnviousWisprAppKit` (`DebugFaultEndpoint`) — all one SPM package. Matches
+  /// the existing DEBUG-seam access level (`AudioCaptureProxy.forceStallRemainingBuffers`).
+
+  /// Arm request: which zero-fill mode, its sample budget/threshold, and the
+  /// trial id the harness correlates status against.
+  package struct DebugZeroFillArm: Codable, Sendable {
+    /// Wire form of `DebugZeroFillController.Mode`. `AudioCaptureManager` (service
+    /// side) translates this into the controller's associated-value enum — the
+    /// controller type itself stays module-internal.
+    package enum Mode: String, Codable, Sendable {
+      case zeroFromStart = "zero_from_start"
+      case zeroAfterSamples = "zero_after_samples"
+      case zeroNextSamples = "zero_next_samples"
+    }
+
+    package let mode: Mode
+    /// Threshold (for `zeroAfterSamples`) or budget (for `zeroNextSamples`) in
+    /// LIVE samples. Ignored for `zeroFromStart`.
+    package let n: Int
+    package let trialID: String
+
+    package init(mode: Mode, n: Int, trialID: String) {
+      self.mode = mode
+      self.n = n
+      self.trialID = trialID
+    }
+  }
+
+  /// Service-side status snapshot returned across XPC. The proxy merges its own
+  /// `ConnectionSlot.current.generation` on top of these fields before handing a
+  /// complete status to the endpoint; `armed` is never evidence of `hit`.
+  package struct DebugFaultServiceStatus: Codable, Sendable {
+    package let armed: Bool
+    package let hit: Bool
+    package let trialID: String
+    package let mode: String
+    package let zeroedSampleCount: Int
+    /// Monotonic manager-owned resource generation — the `fresh_pipe_proven`
+    /// oracle. NOT the capture-session id.
+    package let sourceIncarnation: UInt64
+
+    package init(
+      armed: Bool, hit: Bool, trialID: String, mode: String,
+      zeroedSampleCount: Int, sourceIncarnation: UInt64
+    ) {
+      self.armed = armed
+      self.hit = hit
+      self.trialID = trialID
+      self.mode = mode
+      self.zeroedSampleCount = zeroedSampleCount
+      self.sourceIncarnation = sourceIncarnation
+    }
+  }
+#endif

--- a/Tests/EnviousWisprTests/Audio/DebugZeroFillControllerTests.swift
+++ b/Tests/EnviousWisprTests/Audio/DebugZeroFillControllerTests.swift
@@ -1,0 +1,92 @@
+#if DEBUG
+  import Testing
+
+  @testable import EnviousWisprAudio
+
+  /// #1317 proof-bench: the all-zero injector's zero-range math, especially boundary
+  /// chunks where only part of a chunk is zeroed (so the caller recomputes level
+  /// instead of reporting a false 0.0).
+  @Suite("DebugZeroFillController")
+  struct DebugZeroFillControllerTests {
+
+    @Test("not armed → never zeroes")
+    func notArmed() {
+      let c = DebugZeroFillController()
+      #expect(c.zeroRange(count: 640, context: .live) == nil)
+      #expect(c.zeroRange(count: 640, context: .preRollDrain) == nil)
+      #expect(c.zeroesPreRoll == false)
+      #expect(c.status().hit == false)
+    }
+
+    @Test("zero_from_start zeroes live AND pre-roll, whole chunk")
+    func zeroFromStart() {
+      let c = DebugZeroFillController()
+      c.arm(mode: .zeroFromStart, trialID: "t1")
+      #expect(c.zeroesPreRoll == true)
+      #expect(c.zeroRange(count: 640, context: .preRollDrain) == 0..<640)
+      #expect(c.zeroRange(count: 640, context: .live) == 0..<640)
+      let s = c.status()
+      #expect(s.hit == true)
+      #expect(s.trialID == "t1")
+      #expect(s.mode == "zero_from_start")
+      #expect(s.zeroedSampleCount == 1280)
+    }
+
+    @Test("zero_after leaves pre-roll and the leading live samples untouched")
+    func zeroAfterPreRollAndLead() {
+      let c = DebugZeroFillController()
+      c.arm(mode: .zeroAfter(threshold: 1000), trialID: "t2")
+      #expect(c.zeroesPreRoll == false)
+      // pre-roll always passes through for zero_after
+      #expect(c.zeroRange(count: 5000, context: .preRollDrain) == nil)
+      // first 640 live (seen 0→640, < 1000) → untouched
+      #expect(c.zeroRange(count: 640, context: .live) == nil)
+    }
+
+    @Test("zero_after boundary chunk zeroes only the tail past the threshold")
+    func zeroAfterBoundary() {
+      let c = DebugZeroFillController()
+      c.arm(mode: .zeroAfter(threshold: 1000), trialID: "t3")
+      _ = c.zeroRange(count: 640, context: .live)  // seen → 640
+      // next chunk spans the threshold: seen 640, threshold 1000 → boundary at 360
+      #expect(c.zeroRange(count: 640, context: .live) == 360..<640)
+      // subsequent chunk fully past threshold → whole chunk
+      #expect(c.zeroRange(count: 640, context: .live) == 0..<640)
+      #expect(c.status().zeroedSampleCount == (640 - 360) + 640)
+    }
+
+    @Test("zero_next zeroes a bounded budget then restores")
+    func zeroNextBounded() {
+      let c = DebugZeroFillController()
+      c.arm(mode: .zeroNext(budget: 800), trialID: "t4")
+      // pre-roll untouched
+      #expect(c.zeroRange(count: 640, context: .preRollDrain) == nil)
+      // first live chunk fully within budget
+      #expect(c.zeroRange(count: 640, context: .live) == 0..<640)
+      // second chunk: 160 left in budget → zero [0,160), rest restored
+      #expect(c.zeroRange(count: 640, context: .live) == 0..<160)
+      // budget spent → restore
+      #expect(c.zeroRange(count: 640, context: .live) == nil)
+      #expect(c.status().zeroedSampleCount == 800)
+    }
+
+    @Test("zero-count chunk is a no-op")
+    func zeroCount() {
+      let c = DebugZeroFillController()
+      c.arm(mode: .zeroFromStart, trialID: "t5")
+      #expect(c.zeroRange(count: 0, context: .live) == nil)
+    }
+
+    @Test("disarm clears all state")
+    func disarm() {
+      let c = DebugZeroFillController()
+      c.arm(mode: .zeroFromStart, trialID: "t6")
+      _ = c.zeroRange(count: 640, context: .live)
+      c.disarm()
+      #expect(c.status().armed == false)
+      #expect(c.status().hit == false)
+      #expect(c.status().zeroedSampleCount == 0)
+      #expect(c.zeroRange(count: 640, context: .live) == nil)
+    }
+  }
+#endif

--- a/Tests/EnviousWisprTests/Audio/DebugZeroFillControllerTests.swift
+++ b/Tests/EnviousWisprTests/Audio/DebugZeroFillControllerTests.swift
@@ -77,6 +77,30 @@
       #expect(c.zeroRange(count: 0, context: .live) == nil)
     }
 
+    @Test("negative threshold/budget never produces a negative range (no RT crash)")
+    func negativeBudgetIsSafe() {
+      // Bypass the upstream parser/manager guards and hand the controller a
+      // negative threshold/budget directly — this is what would crash the capture
+      // thread if the range math were unsafe. Assert every returned range has a
+      // non-negative lower bound across several chunks.
+      let after = DebugZeroFillController()
+      after.arm(mode: .zeroAfter(threshold: -1), trialID: "neg1")
+      for _ in 0..<4 {
+        if let r = after.zeroRange(count: 640, context: .live) {
+          #expect(r.lowerBound >= 0)
+          #expect(r.upperBound <= 640)
+        }
+      }
+      let next = DebugZeroFillController()
+      next.arm(mode: .zeroNext(budget: -1), trialID: "neg2")
+      for _ in 0..<4 {
+        if let r = next.zeroRange(count: 640, context: .live) {
+          #expect(r.lowerBound >= 0)
+          #expect(r.upperBound <= 640)
+        }
+      }
+    }
+
     @Test("disarm clears all state")
     func disarm() {
       let c = DebugZeroFillController()

--- a/Tests/RuntimeUAT/SCENARIOS.md
+++ b/Tests/RuntimeUAT/SCENARIOS.md
@@ -42,6 +42,7 @@ run_scenario("A5_proxy_buffer_drop_watchdog")
 | Cancel during WhisperKit model load leaves state inconsistent | A8b_cancel_during_whisperkit_load | model-load |
 | Switching backend mid-record aborts active recording | A9_backend_switch_mid_record | backend-switch |
 | BT codec switch mid-record corrupts state | B1_bluetooth_route_flip (founder-required) | bt-route |
+| Dead/zombie mic delivers all-zero audio, treated as no-speech (#1317) | Z1_all_zero_from_start / Z2_valid_then_all_zero / Z3_bounded_zero_then_restore | dead-mic |
 
 ## Index by scenario name
 
@@ -148,6 +149,27 @@ Founder physically toggles AirPods (or other BT input) power off/on during an ac
 
 **Negative control:** remove the BT route handler in `AudioDeviceManager` / capture-session-interruption flow. Recording behaves incorrectly on real BT toggle (audio cuts out, pipeline stuck).
 
+### Z1_all_zero_from_start (Lane A — dead-mic, #1317)
+Backends: both. Budget: 45s. Mechanism: dead-mic.
+
+Arm the DEBUG all-zero injector from the first captured sample: the whole take is digital silence (exactly `0.0`), reproducing the production `zombie_engine_zero_peak` dead-mic fault where a live-but-dead mic pipe delivers zeros. Assert the app handles the dead take HONESTLY (the app-owned no-speech log marker fires, no fabricated text) and the injector actually hit (`hit=true, zeroed>0`), then a disarmed control take recovers the canary phrase. Two-class result: a product failure with valid evidence is a real measurement; missing identity/arm/hit/log evidence is INVALID, never a pass.
+
+**Negative control:** make the injector a no-op (skip the zero-range application in `PreRollForwarder`), and the fault never fires — `hit=false`, evidence INVALID, the trial cannot be scored (it does not silently pass).
+
+### Z2_valid_then_all_zero (Lane A — dead-mic, #1317)
+Backends: both. Budget: 45s. Mechanism: dead-mic.
+
+Real audio for the first N live samples (`lead_samples`, default 16000 ≈ 1s), then all-zero forever. Exercises the content-blind liveness path — buffers keep flowing at full cadence, just zeroed, so the no-buffer watchdog stays satisfied. Assert the lead audio left a raw-ASR trace (`raw_text_preserved`) and the injector hit.
+
+**Negative control:** same as Z1 — a no-op injector leaves `hit=false` and INVALID evidence.
+
+### Z3_bounded_zero_then_restore (Lane A — dead-mic, #1317)
+Backends: both. Budget: 35s. Mechanism: dead-mic.
+
+Zero the first N live samples (`zero_samples`, default 8000 ≈ 0.5s) then restore real audio inside the same take. Assert the take recovers the canary in-session — the pipe is not poisoned by a transient dead start — and the injector hit.
+
+**Negative control:** hold the zero forever (drop the bounded-restore) and the canary never appears; `recovered_in_session=false`.
+
 ## Wire protocol
 
 The DEBUG endpoint accepts text, line-delimited:
@@ -171,6 +193,8 @@ Fixed command set (no arbitrary RPC):
 | `force_xpc_kill` | Invalidate `ASRManagerProxy` connection mid-stream |
 | `force_audio_xpc_kill` | Invalidate `AudioCaptureProxy` connection mid-stream |
 | `query_state` | Return current pipeline + backend state (one line, no side effects) |
+| `force_zero_fill(mode,N,trialID)` | #1317: arm the DEBUG all-zero injector in the HELPER (real service-side sample substitution at `PreRollForwarder`). `mode` ∈ {`zero_from_start`, `zero_after_samples`, `zero_next_samples`, `disarmed`}; `N` = LIVE-sample threshold/budget; `trialID` correlates the status query. |
+| `query_fault_status(trialID)` | #1317: read the merged fault status (helper injector fields + proxy XPC generation). Fails CLOSED to `ERR` on any missing/malformed/absent-generation condition or trial-id mismatch. `armed` is not evidence of `hit`. |
 
 ## Adding a new scenario
 

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -209,6 +209,86 @@ def force_audio_wedge_start(n: int) -> str:
     return send(f"force_audio_wedge_start({n})")
 
 
+# ─────────────────── #1317 proof-bench: zero-fill injector client ───────────────
+#
+# The proof bench reproduces the production dead-mic fault (all-zero / "digital
+# silence" audio, `zombie_engine_zero_peak`) deterministically, proves the
+# injector actually fired, and measures whether the running build handles a dead
+# take HONESTLY (no fabricated text) vs silently. Every gate fails CLOSED: a
+# missing artifact is INVALID evidence, never a defaulted pass.
+
+# Fixed canary phrase for the log-backed recovery oracle. Four uncommon-but-real
+# English words → strong ASR targets that will not appear by accident. Newness is
+# proven by a rotation-safe LogCursor, not by phrase uniqueness.
+CANARY_PHRASE = "saffron comet velvet anchor"
+CANARY_TOKENS = frozenset({"saffron", "comet", "velvet", "anchor"})
+
+APP_LOG_PATH = Path("~/Library/Logs/EnviousWispr/app.log").expanduser()
+
+# App-owned honest-handling marker for a dead take: the pipeline detected no
+# speech and skipped ASR instead of fabricating text. Peak is 0.0000 for a fully
+# zero-filled take. (RecordingSessionKernel.swift:1206-1210.)
+NO_SPEECH_MARKER = "VAD gate: no speech, skipping ASR"
+
+
+def arm_zero_fill(mode: str, n: int, trial_id: str) -> str:
+    """Arm the DEBUG all-zero injector in the helper. `mode` ∈ {zero_from_start,
+    zero_after_samples, zero_next_samples, disarmed}; `n` is the LIVE-sample
+    threshold/budget (ignored for zero_from_start/disarmed); `trial_id` correlates
+    the later query_fault_status. Returns the raw reply ("OK" / "ERR ...")."""
+    return send(f"force_zero_fill({mode},{n},{trial_id})")
+
+
+def disarm_zero_fill(trial_id: str = "clear") -> str:
+    """Clear any armed fault so a clean pipe returns for a positive-control take."""
+    return send(f"force_zero_fill(disarmed,0,{trial_id})")
+
+
+def query_fault_status(trial_id: str) -> dict:
+    """Read the merged fault status for `trial_id`. Returns a parsed dict on OK, or
+    {"ok": False, "error": <reply>} on any ERR / malformed reply. FAILS CLOSED: a
+    missing field or unparseable value is an error, never a defaulted 0/False."""
+    return _parse_fault_status(send(f"query_fault_status({trial_id})"))
+
+
+def _parse_bool(s: str) -> bool:
+    # Swift `Bool` string interpolation is lowercase "true"/"false".
+    if s == "true":
+        return True
+    if s == "false":
+        return False
+    raise ValueError(f"not a bool: {s!r}")
+
+
+def _parse_fault_status(reply: str) -> dict:
+    if not reply.startswith("OK "):
+        return {"ok": False, "error": reply}
+    fields: dict[str, str] = {}
+    for tok in reply[3:].split():
+        if "=" not in tok:
+            return {"ok": False, "error": f"malformed token {tok!r} in {reply!r}"}
+        k, v = tok.split("=", 1)
+        fields[k] = v
+    required = {"armed", "hit", "trial", "mode", "zeroed",
+                "source_incarnation", "xpc_generation"}
+    missing = required - fields.keys()
+    if missing:
+        return {"ok": False, "error": f"missing fields {sorted(missing)} in {reply!r}"}
+    try:
+        return {
+            "ok": True,
+            "armed": _parse_bool(fields["armed"]),
+            "hit": _parse_bool(fields["hit"]),
+            "trial": fields["trial"],
+            "mode": fields["mode"],
+            "zeroed": int(fields["zeroed"]),
+            "source_incarnation": int(fields["source_incarnation"]),
+            "xpc_generation": int(fields["xpc_generation"]),
+        }
+    except ValueError as e:
+        return {"ok": False, "error": f"unparseable status {reply!r}: {e}"}
+
+
 # ──────────────────────────── helpers ────────────────────────────
 
 
@@ -618,6 +698,314 @@ class _TTSAudio:
             except Exception:
                 self._proc.kill()
         return False
+
+
+# ─────────────────── #1317 proof-bench: build-identity manifest ──────────────
+#
+# Before any zero-fill trial is trusted, the harness proves the SINGLE running app
+# is exactly the build a manifest describes: one PID, its executable path == the
+# manifest path, and app + both embedded XPC helper SHA-256 hashes match. Two dev
+# builds share bundle id `com.enviouswispr.app.dev`, so the two A/B arms run
+# sequentially and identity is verified per trial (dev-bundle-id-collision).
+# Source SHA is manifest provenance stamped at build time, NOT inferred from
+# Info.plist (build-dev-app.sh stamps no git SHA).
+
+# Our two embedded XPC executables inside the .app. Sparkle's Downloader/Installer
+# are excluded — not ours.
+_APP_EXE_REL = "Contents/MacOS/EnviousWispr"
+_AUDIO_HELPER_REL = (
+    "Contents/XPCServices/EnviousWisprAudioService.xpc/Contents/MacOS/"
+    "EnviousWisprAudioService"
+)
+_ASR_HELPER_REL = (
+    "Contents/XPCServices/EnviousWisprASRService.xpc/Contents/MacOS/"
+    "EnviousWisprASRService"
+)
+
+
+def compute_sha256(path) -> str:
+    import hashlib
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def discover_bundle_executables(bundle_path) -> dict:
+    """Absolute paths of our three executables inside the .app:
+    {app, audio_helper, asr_helper}. Raises if any is missing."""
+    bundle = Path(bundle_path)
+    paths = {
+        "app": bundle / _APP_EXE_REL,
+        "audio_helper": bundle / _AUDIO_HELPER_REL,
+        "asr_helper": bundle / _ASR_HELPER_REL,
+    }
+    for label, p in paths.items():
+        if not p.exists():
+            raise RuntimeError(f"bundle missing {label} executable at {p}")
+    return {k: str(v) for k, v in paths.items()}
+
+
+def write_build_manifest(
+    bundle_path: str,
+    source_ref: str,
+    source_sha: str,
+    clean_tree: bool,
+    contract_version: str,
+    out_path: str,
+) -> dict:
+    """Stamp a build manifest AFTER a build: absolute exe paths + SHA-256 for the
+    app and both XPC helpers, plus source provenance. Written by run_gauntlet.py
+    per A/B arm; read by verify_running_identity."""
+    import json
+    exes = discover_bundle_executables(bundle_path)
+    manifest = {
+        "bundle_path": str(Path(bundle_path).resolve()),
+        "app_path": exes["app"],
+        "app_sha256": compute_sha256(exes["app"]),
+        "audio_helper_path": exes["audio_helper"],
+        "audio_helper_sha256": compute_sha256(exes["audio_helper"]),
+        "asr_helper_path": exes["asr_helper"],
+        "asr_helper_sha256": compute_sha256(exes["asr_helper"]),
+        "app_bundle_id": _bundle_identifier(bundle_path),
+        "source_ref": source_ref,
+        "source_sha": source_sha,
+        "clean_tree": clean_tree,
+        "contract_version": contract_version,
+    }
+    Path(out_path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return manifest
+
+
+def _bundle_identifier(bundle_path) -> str:
+    plist = Path(bundle_path) / "Contents" / "Info.plist"
+    try:
+        out = subprocess.check_output(
+            ["/usr/libexec/PlistBuddy", "-c", "Print :CFBundleIdentifier", str(plist)],
+            text=True,
+        )
+        return out.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return ""
+
+
+def load_manifest(path) -> dict:
+    import json
+    with open(path) as f:
+        return json.load(f)
+
+
+def _running_app_executable_path(pid: int) -> str:
+    """argv[0] of the running app = its executable path (open-launched apps carry
+    the full path). Proves the running PID is the build we hashed."""
+    out = subprocess.check_output(["ps", "-o", "command=", "-p", str(pid)], text=True).strip()
+    marker = ".app/Contents/MacOS/EnviousWispr"
+    idx = out.find(marker)
+    return out if idx == -1 else out[: idx + len(marker)]
+
+
+def verify_running_identity(manifest: dict) -> dict:
+    """Fail-closed identity gate. Returns an evidence dict with a top-level
+    `identity_ok` boolean plus every sub-check, so a failure names itself. Any
+    ambiguity (0 or >1 PID, path mismatch, hash mismatch, read error) → not ok."""
+    ev: dict = {"identity_ok": False, "checks": {}}
+    try:
+        out = subprocess.check_output(["pgrep", "-x", APP_NAME], text=True)
+    except subprocess.CalledProcessError:
+        ev["reason"] = "no EnviousWispr process running"
+        return ev
+    pids = [int(p) for p in out.split() if p.strip()]
+    ev["checks"]["app_pid_count"] = len(pids)
+    if len(pids) != 1:
+        ev["reason"] = f"expected exactly 1 app PID, found {len(pids)}: {pids}"
+        return ev
+    pid = pids[0]
+    ev["pid"] = pid
+
+    exe_path = _running_app_executable_path(pid)
+    ev["running_exe_path"] = exe_path
+    ev["checks"]["exe_path_matches"] = exe_path == manifest.get("app_path")
+
+    try:
+        hash_checks = {
+            "app": compute_sha256(manifest["app_path"]) == manifest["app_sha256"],
+            "audio_helper": (
+                compute_sha256(manifest["audio_helper_path"])
+                == manifest["audio_helper_sha256"]),
+            "asr_helper": (
+                compute_sha256(manifest["asr_helper_path"])
+                == manifest["asr_helper_sha256"]),
+        }
+    except (OSError, KeyError) as e:
+        ev["reason"] = f"hash/manifest read failed: {e}"
+        return ev
+    ev["checks"]["hashes"] = hash_checks
+    ev["source_ref"] = manifest.get("source_ref")
+    ev["source_sha"] = manifest.get("source_sha")
+
+    ev["identity_ok"] = ev["checks"]["exe_path_matches"] and all(hash_checks.values())
+    if not ev["identity_ok"]:
+        ev["reason"] = "running build does not match manifest (see checks)"
+    return ev
+
+
+# ─────────────────── #1317 proof-bench: canary log oracle ────────────────────
+
+
+class LogCursor:
+    """Rotation-safe cursor over app.log. Snapshots end-of-file at construction;
+    `new_text()` returns only bytes appended since. On rotation (inode change or
+    shrink) it re-reads the whole current file so a fresh entry is never missed.
+    Fail-closed: a read error yields ''."""
+
+    def __init__(self, path=APP_LOG_PATH):
+        self.path = Path(path)
+        self._offset, self._inode = self._stat()
+
+    def _stat(self):
+        try:
+            st = self.path.stat()
+            return st.st_size, st.st_ino
+        except OSError:
+            return 0, -1
+
+    def new_text(self) -> str:
+        try:
+            st = self.path.stat()
+        except OSError:
+            return ""
+        rotated = (st.st_ino != self._inode) or (st.st_size < self._offset)
+        start = 0 if rotated else self._offset
+        try:
+            with open(self.path, "rb") as f:
+                f.seek(start)
+                data = f.read()
+        except OSError:
+            return ""
+        return data.decode("utf-8", errors="replace")
+
+
+def _normalize_tokens(text: str) -> set:
+    import re
+    return set(re.sub(r"[^a-z0-9]+", " ", text.lower()).split())
+
+
+def assert_canary_recovers(cursor: LogCursor) -> dict:
+    """Positive oracle for a recovery/control take. Requires, in text appended
+    since `cursor`: (1) a NEW `CORRECTION_DEBUG [RAW ASR]` line whose normalized
+    tokens contain ALL canary tokens, AND (2) a NEW `Pipeline timing TOTAL`
+    marker. Clipboard and a plain `idle` state are NOT accepted."""
+    text = cursor.new_text()
+    raw_asr_lines: list[str] = []
+    timing_seen = False
+    canary_line = None
+    for line in text.splitlines():
+        if "CORRECTION_DEBUG [RAW ASR]" in line:
+            raw = line.split("CORRECTION_DEBUG [RAW ASR]", 1)[1].strip()
+            raw_asr_lines.append(raw)
+            if CANARY_TOKENS <= _normalize_tokens(raw):
+                canary_line = raw
+        if "Pipeline timing TOTAL" in line:
+            timing_seen = True
+    return {
+        "canary_ok": canary_line is not None and timing_seen,
+        "raw_asr_new_entry": bool(raw_asr_lines),
+        "canary_tokens_matched": canary_line is not None,
+        "pipeline_timing_new": timing_seen,
+        "matched_raw_asr": canary_line,
+        "new_raw_asr_count": len(raw_asr_lines),
+    }
+
+
+def assert_dead_take_honest(cursor: LogCursor) -> dict:
+    """Negative oracle for a dead (zero-filled) take. HONEST handling = the app
+    emitted the no-speech marker (app-owned log line, not merely pipeline state)
+    AND fabricated NO canary text. A dead take that yields the canary would mean
+    text invented from silence — always a failure."""
+    text = cursor.new_text()
+    no_speech_seen = False
+    fabricated_canary = False
+    for line in text.splitlines():
+        if NO_SPEECH_MARKER in line:
+            no_speech_seen = True
+        if "CORRECTION_DEBUG [RAW ASR]" in line:
+            raw = line.split("CORRECTION_DEBUG [RAW ASR]", 1)[1]
+            if CANARY_TOKENS <= _normalize_tokens(raw):
+                fabricated_canary = True
+    return {
+        "honest_no_speech_marker": no_speech_seen,
+        "fabricated_canary": fabricated_canary,
+        "handled_honestly": no_speech_seen and not fabricated_canary,
+    }
+
+
+def _canary_take(*, record_seconds: float = 3.0, settle_timeout_s: float = 8.0) -> dict:
+    """Run ONE locked dictation take with the canary spoken via TTS, a LogCursor
+    open across it. Returns cursor text via both oracles + the terminal state so
+    the caller scores dead-take honesty and control-take recovery from the SAME
+    take shape."""
+    state = _active_state()
+    if "error" in state or "recording" in state:
+        _tap_rcmd()
+        time.sleep(0.8)  # settle: let a stray non-idle state clear before entering lock
+    cursor = LogCursor()
+    if not _start_recording_locked():
+        return {
+            "reached_recording": False,
+            "terminal_state": _active_state(),
+            "recovers": {"canary_ok": False},
+            "dead_honest": {"handled_honestly": False},
+        }
+    with _TTSAudio(CANARY_PHRASE):
+        time.sleep(record_seconds)  # settle: TTS playback window (live-audio UAT cadence)
+    _stop_recording_locked(settle_s=0.5)
+    deadline = time.monotonic() + settle_timeout_s
+    final = ""
+    while time.monotonic() < deadline:
+        final = _active_state()
+        if "complete" in final or final == "idle" or "error" in final:
+            break
+        time.sleep(0.1)  # settle: poll interval; loop breaks on terminal state signal
+    return {
+        "reached_recording": True,
+        "terminal_state": final,
+        "recovers": assert_canary_recovers(cursor),
+        "dead_honest": assert_dead_take_honest(cursor),
+    }
+
+
+# ─────────────────── #1317 proof-bench: evidence / trial schema ──────────────
+
+
+def _require_manifest(kwargs: dict) -> Optional[dict]:
+    """The manifest is mandatory: no manifest ⇒ no trusted identity ⇒ INVALID
+    evidence. run_gauntlet.py passes `manifest_path`; an ad-hoc CLI run can set
+    EW_BENCH_MANIFEST."""
+    mp = kwargs.get("manifest_path") or os.environ.get("EW_BENCH_MANIFEST")
+    if not mp:
+        return None
+    return load_manifest(mp)
+
+
+def _invalid_evidence(reason: str, **extra) -> dict:
+    return {
+        "evidence_valid": False,
+        "evidence": {"reason": reason, **extra},
+        "assertions": {},
+    }
+
+
+def _arm_and_prove_hit(mode: str, n: int, trial: str) -> dict:
+    """Arm the injector and snapshot the pre-fault status. Hit is proven AFTER the
+    take by the caller re-querying. Returns {"armed_ok", "arm_reply", "pre_status"}."""
+    reply = arm_zero_fill(mode, n, trial)
+    pre = query_fault_status(trial)
+    return {
+        "arm_reply": reply,
+        "armed_ok": reply == "OK" and pre.get("ok") and pre.get("armed") is True,
+        "pre_status": pre,
+    }
 
 
 # ──────────────────────────── Lane A scenarios ────────────────────────────
@@ -1326,7 +1714,154 @@ def B1_bluetooth_route_flip(*, founder_present: bool = False, **_) -> dict:
     return assert_terminated(timeout_s=15.0)
 
 
+# ─────────────────── #1317 proof-bench: dead-mic zero-fill scenarios ─────────
+#
+# Deterministic runtime cells scored A/B in Phase 1. Each returns the two-class
+# schema {evidence_valid, evidence, assertions}: a product FAILURE with valid
+# evidence is a real measurement; missing/ambiguous evidence is INVALID (never a
+# defaulted pass). `n` (LIVE-sample budgets) are kwargs so the live A/B run tunes
+# them against real TTS cadence without editing this file.
+
+
+def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
+                     kwargs: dict, extra_assertions=None) -> dict:
+    """Shared dead-mic trial: identity gate → arm+pre-status → fault take → HIT
+    proof → optional disarmed control take → scored assertions. Fails closed at
+    every gate."""
+    manifest = _require_manifest(kwargs)
+    if manifest is None:
+        return _invalid_evidence(
+            "no manifest (set EW_BENCH_MANIFEST or pass manifest_path)")
+    identity = verify_running_identity(manifest)
+    if not identity["identity_ok"]:
+        return _invalid_evidence("identity mismatch", identity=identity)
+
+    arm = _arm_and_prove_hit(mode, n, trial)
+    if not arm["armed_ok"]:
+        return _invalid_evidence("arm ack/pre-status failed", arm=arm, identity=identity)
+    inc_pre = arm["pre_status"]["source_incarnation"]
+
+    fault_take = _canary_take()
+
+    post = query_fault_status(trial)
+    hit_ok = bool(post.get("ok")) and post.get("hit") is True and post.get("zeroed", 0) > 0
+    if not hit_ok:
+        return _invalid_evidence(
+            "injector arm acked but never hit", post_status=post, arm=arm,
+            identity=identity)
+    inc_post = post["source_incarnation"]
+
+    control = None
+    if do_control:
+        disarm_zero_fill(trial)
+        control = _canary_take()
+
+    assertions = {
+        "dead_take_handled_honestly": fault_take["dead_honest"]["handled_honestly"],
+        "dead_take_fabricated_text": fault_take["dead_honest"]["fabricated_canary"],
+        "recovered_in_session": fault_take["recovers"]["canary_ok"],
+        # No rebuild is triggered here, so a changed incarnation would only come
+        # from a recovery mechanism (follow-up plan). Honest measurement.
+        "fresh_pipe_proven": inc_post != inc_pre,
+    }
+    if control is not None:
+        assertions["next_press_works"] = control["recovers"]["canary_ok"]
+    if extra_assertions is not None:
+        assertions.update(extra_assertions(fault_take, control))
+
+    return {
+        "evidence_valid": True,
+        "evidence": {
+            "identity": identity,
+            "arm": arm,
+            "post_status": post,
+            "source_incarnation_pre": inc_pre,
+            "source_incarnation_post": inc_post,
+            "fault_take": fault_take,
+            "control_take": control,
+            "trial_id": trial,
+            "mode": mode,
+            "n": n,
+        },
+        "assertions": assertions,
+    }
+
+
+def _trial_id(prefix: str) -> str:
+    return f"{prefix}-{int(time.monotonic() * 1000)}"
+
+
+@scenario(ScenarioMeta(
+    name="Z1_all_zero_from_start", lane="A", family="dead-mic", backends=["both"],
+    runtime_budget_seconds=45.0, founder_required=False,
+    negative_control="disarmed control take MUST recover the canary; the dead take "
+    "must NOT fabricate it",
+    description="Arm zero-fill from the first sample: the take is fully dead. Assert "
+    "the app handles it honestly (no-speech marker, no fabricated text) and the "
+    "injector hit, then a disarmed control take recovers the canary."))
+def Z1_all_zero_from_start(**kwargs) -> dict:
+    return _zero_fill_trial(
+        mode="zero_from_start", n=0, trial=_trial_id("Z1"), do_control=True,
+        kwargs=kwargs)
+
+
+@scenario(ScenarioMeta(
+    name="Z2_valid_then_all_zero", lane="A", family="dead-mic", backends=["both"],
+    runtime_budget_seconds=45.0, founder_required=False,
+    negative_control="lead audio must leave a raw-ASR trace; the zeroed tail must not "
+    "extend it with fabricated tokens",
+    description="Real audio for the first N live samples, then all-zero forever. "
+    "Exercises the content-blind liveness path (buffers keep flowing, just zero). "
+    "Assert lead audio was preserved (a raw-ASR entry exists) and the injector hit."))
+def Z2_valid_then_all_zero(*, lead_samples: int = 16000, **kwargs) -> dict:
+    def _extra(fault_take, _control):
+        return {"raw_text_preserved": fault_take["recovers"]["raw_asr_new_entry"]}
+    return _zero_fill_trial(
+        mode="zero_after_samples", n=lead_samples, trial=_trial_id("Z2"),
+        do_control=True, kwargs=kwargs, extra_assertions=_extra)
+
+
+@scenario(ScenarioMeta(
+    name="Z3_bounded_zero_then_restore", lane="A", family="dead-mic", backends=["both"],
+    runtime_budget_seconds=35.0, founder_required=False,
+    negative_control="the canary must appear AFTER the zero budget, proving the pipe "
+    "self-heals when real audio resumes",
+    description="Zero the first N live samples then restore real audio inside the same "
+    "take. Assert the take recovers the canary in-session (the pipe is not poisoned by "
+    "a transient dead start) and the injector hit."))
+def Z3_bounded_zero_then_restore(*, zero_samples: int = 8000, **kwargs) -> dict:
+    return _zero_fill_trial(
+        mode="zero_next_samples", n=zero_samples, trial=_trial_id("Z3"),
+        do_control=False, kwargs=kwargs)
+
+
 # ──────────────────────────── CLI entry ────────────────────────────
+
+
+# Required assertions per proof-bench scenario: the must-be-true product claims
+# for THIS build to "pass" the cell in a strict standalone run. A valid-evidence
+# product failure still exits nonzero here; the A/B baseline mode (run_gauntlet.py)
+# is what continues through product failures to build the full scorecard.
+_REQUIRED_ASSERTIONS = {
+    "Z1_all_zero_from_start": ["dead_take_handled_honestly", "next_press_works"],
+    "Z2_valid_then_all_zero": ["raw_text_preserved", "next_press_works"],
+    "Z3_bounded_zero_then_restore": ["recovered_in_session"],
+}
+
+
+def evaluate_trial(name: str, inner: dict) -> tuple[bool, str]:
+    """(passed, reason) for a scenario result under the strict contract: evidence
+    must be valid AND every required assertion true. Legacy scenarios with no
+    evidence schema always pass (they carry their own inline verdicts)."""
+    if "evidence_valid" not in inner:
+        return True, "legacy scenario (no evidence schema)"
+    if not inner.get("evidence_valid"):
+        return False, f"EVIDENCE INVALID: {inner.get('evidence', {}).get('reason')}"
+    required = _REQUIRED_ASSERTIONS.get(name, [])
+    failed = [a for a in required if not inner.get("assertions", {}).get(a)]
+    if failed:
+        return False, f"required assertions failed: {failed}"
+    return True, "ok"
 
 
 def main(argv: list[str]) -> int:
@@ -1335,8 +1870,12 @@ def main(argv: list[str]) -> int:
         return 0
     cmd = argv[0]
     if cmd == "run" and len(argv) >= 2:
-        result = run_scenario(argv[1])
-        print(result)
+        wrapped = run_scenario(argv[1])
+        print(wrapped)
+        passed, reason = evaluate_trial(argv[1], wrapped.get("result", {}))
+        if not passed:
+            print(reason, file=sys.stderr)
+            return 1
         return 0
     if cmd == "query":
         print(query_state())

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -1836,11 +1836,18 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
                 arm=arm, identity=identity)
         control = _canary_take()
 
+    # A bumped source incarnation only proves RECOVERY if a source already
+    # existed when we sampled inc_pre. With warm-engine policy off (source torn
+    # down after the previous stop), the fault take's ordinary startEnginePhase()
+    # installs the first source and bumps the incarnation — a normal cold start,
+    # not recovery. Gate on a source being present at inc_pre (capture_source !=
+    # "none") so a cold-start install can never masquerade as fresh_pipe_proven.
+    # Baseline (no recovery) must read False; the follow-up fix's recovery is the
+    # only thing that can bump the incarnation of an already-installed source.
+    pre_source_present = arm["pre_status"].get("capture_source", "none") != "none"
     assertions = {
         "recovered_in_session": fault_take["recovers"]["canary_ok"],
-        # No rebuild is triggered here, so a changed incarnation would only come
-        # from a recovery mechanism (follow-up plan). Honest measurement.
-        "fresh_pipe_proven": inc_post != inc_pre,
+        "fresh_pipe_proven": pre_source_present and inc_post != inc_pre,
     }
     # Dead-take honesty is only meaningful for a FULLY dead take (zero_from_start).
     # A partial shape (zero_after / zero_next) legitimately contains real audio, so
@@ -1863,6 +1870,7 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
             "post_status": post,
             "source_incarnation_pre": inc_pre,
             "source_incarnation_post": inc_post,
+            "pre_source_present": pre_source_present,
             "fault_take": fault_take,
             "control_take": control,
             "disarm_reply": disarm_reply,

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -37,6 +37,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -776,6 +777,11 @@ def write_build_manifest(
         "asr_helper_path": exes["asr_helper"],
         "asr_helper_sha256": compute_sha256(exes["asr_helper"]),
         "app_bundle_id": _bundle_identifier(bundle_path),
+        # Build time = the hashed app executable's mtime. verify_running_identity
+        # requires the running PID to have started at/after this, so a stale
+        # process left over from an earlier build cannot pass identity when a
+        # fresh build has been copied over the same shared-bundle-id path.
+        "built_at_epoch": os.path.getmtime(exes["app"]),
         "source_ref": source_ref,
         "source_sha": source_sha,
         "clean_tree": clean_tree,
@@ -812,6 +818,22 @@ def _running_app_executable_path(pid: int) -> str:
     return out if idx == -1 else out[: idx + len(marker)]
 
 
+def _proc_start_epoch(pid: int):
+    """Epoch seconds when PID started, or None on any failure. `ps -o lstart=` in
+    the C locale gives a stable `Sat Jul 11 15:36:48 2026`. Used to prove the
+    RUNNING image is the build we hashed: a stale process (image A) left running
+    when a new build (image B) is copied over the same shared-bundle-id path would
+    otherwise pass identity — argv[0] path matches and the on-disk hash matches
+    manifest B — while actually executing image A. Its start predates B's build."""
+    try:
+        raw = subprocess.check_output(
+            ["ps", "-o", "lstart=", "-p", str(pid)], text=True,
+            env={**os.environ, "LC_ALL": "C"}).strip()
+        return datetime.strptime(raw, "%a %b %d %H:%M:%S %Y").timestamp()
+    except (subprocess.CalledProcessError, ValueError, OSError):
+        return None
+
+
 def verify_running_identity(manifest: dict) -> dict:
     """Fail-closed identity gate. Returns an evidence dict with a top-level
     `identity_ok` boolean plus every sub-check, so a failure names itself. Any
@@ -834,6 +856,21 @@ def verify_running_identity(manifest: dict) -> dict:
     ev["running_exe_path"] = exe_path
     ev["checks"]["exe_path_matches"] = exe_path == manifest.get("app_path")
 
+    # Running-image freshness: the PID must have started at/after the build we
+    # hashed. Without this, a stale process still executing an OLDER image passes
+    # (same argv[0] path, and the on-disk file the hash reads is already the NEW
+    # build) — the shared-bundle-id worktree trap. `ps` start time is
+    # second-resolution; allow 2s slack against the sub-second file mtime.
+    built_at = manifest.get("built_at_epoch")
+    start_epoch = _proc_start_epoch(pid)
+    ev["proc_start_epoch"] = start_epoch
+    ev["built_at_epoch"] = built_at
+    ev["checks"]["running_image_fresh"] = (
+        isinstance(built_at, (int, float))
+        and start_epoch is not None
+        and start_epoch >= built_at - 2
+    )
+
     try:
         hash_checks = {
             "app": compute_sha256(manifest["app_path"]) == manifest["app_sha256"],
@@ -851,7 +888,11 @@ def verify_running_identity(manifest: dict) -> dict:
     ev["source_ref"] = manifest.get("source_ref")
     ev["source_sha"] = manifest.get("source_sha")
 
-    ev["identity_ok"] = ev["checks"]["exe_path_matches"] and all(hash_checks.values())
+    ev["identity_ok"] = (
+        ev["checks"]["exe_path_matches"]
+        and ev["checks"]["running_image_fresh"]
+        and all(hash_checks.values())
+    )
     if not ev["identity_ok"]:
         ev["reason"] = "running build does not match manifest (see checks)"
     return ev

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -270,7 +270,7 @@ def _parse_fault_status(reply: str) -> dict:
         k, v = tok.split("=", 1)
         fields[k] = v
     required = {"armed", "hit", "trial", "mode", "zeroed",
-                "source_incarnation", "xpc_generation"}
+                "source_incarnation", "xpc_generation", "capture_source"}
     missing = required - fields.keys()
     if missing:
         return {"ok": False, "error": f"missing fields {sorted(missing)} in {reply!r}"}
@@ -284,6 +284,7 @@ def _parse_fault_status(reply: str) -> dict:
             "zeroed": int(fields["zeroed"]),
             "source_incarnation": int(fields["source_incarnation"]),
             "xpc_generation": int(fields["xpc_generation"]),
+            "capture_source": fields["capture_source"],
         }
     except ValueError as e:
         return {"ok": False, "error": f"unparseable status {reply!r}: {e}"}

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -854,36 +854,55 @@ def verify_running_identity(manifest: dict) -> dict:
 
 
 class LogCursor:
-    """Rotation-safe cursor over app.log. Snapshots end-of-file at construction;
-    `new_text()` returns only bytes appended since. On rotation (inode change or
-    shrink) it re-reads the whole current file so a fresh entry is never missed.
-    Fail-closed: a read error yields ''."""
+    """Rotation-safe cursor over app.log. Holds the file OPEN at construction and
+    reads appended bytes from that fd, which FOLLOWS the inode through a rename —
+    so final evidence written to the renamed (rotated-away) file is not lost, which
+    a pathname-only cursor would miss. If the pathname later points at a NEW inode
+    (real rename rotation), the fresh file's bytes are appended too. `new_text()`
+    accumulates, so repeated calls are idempotent (two oracles read one take).
+    Fail-closed: a read error contributes nothing rather than raising."""
 
     def __init__(self, path=APP_LOG_PATH):
         self.path = Path(path)
-        self._offset, self._inode = self._stat()
-
-    def _stat(self):
+        self._file = None
+        self._inode = -1
+        self._buffer = b""
         try:
-            st = self.path.stat()
-            return st.st_size, st.st_ino
+            self._file = open(self.path, "rb")  # noqa: SIM115 — held across reads
+            self._inode = os.fstat(self._file.fileno()).st_ino
+            self._file.seek(0, os.SEEK_END)
         except OSError:
-            return 0, -1
+            if self._file is not None:
+                self._file.close()
+            self._file = None
 
     def new_text(self) -> str:
+        # Accumulate appended bytes from the held fd (follows a rename via inode).
+        if self._file is not None:
+            try:
+                self._buffer += self._file.read()
+            except OSError:
+                pass
+        # If the pathname now resolves to a NEW inode, a real rotation happened;
+        # read that fresh file WHOLE each call (not accumulated → no double count).
+        rotated_tail = b""
         try:
-            st = self.path.stat()
+            if self.path.stat().st_ino != self._inode:
+                with open(self.path, "rb") as nf:
+                    rotated_tail = nf.read()
         except OSError:
-            return ""
-        rotated = (st.st_ino != self._inode) or (st.st_size < self._offset)
-        start = 0 if rotated else self._offset
-        try:
-            with open(self.path, "rb") as f:
-                f.seek(start)
-                data = f.read()
-        except OSError:
-            return ""
-        return data.decode("utf-8", errors="replace")
+            pass
+        return (self._buffer + rotated_tail).decode("utf-8", errors="replace")
+
+    def close(self) -> None:
+        if self._file is not None:
+            try:
+                self._file.close()
+            finally:
+                self._file = None
+
+    def __del__(self):
+        self.close()
 
 
 def _normalize_tokens(text: str) -> set:
@@ -967,12 +986,14 @@ def _canary_take(*, record_seconds: float = 3.0, settle_timeout_s: float = 8.0) 
         if "complete" in final or final == "idle" or "error" in final:
             break
         time.sleep(0.1)  # settle: poll interval; loop breaks on terminal state signal
-    return {
+    result = {
         "reached_recording": True,
         "terminal_state": final,
         "recovers": assert_canary_recovers(cursor),
         "dead_honest": assert_dead_take_honest(cursor),
     }
+    cursor.close()
+    return result
 
 
 # ─────────────────── #1317 proof-bench: evidence / trial schema ──────────────
@@ -1752,8 +1773,16 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
     inc_post = post["source_incarnation"]
 
     control = None
+    disarm_reply = None
     if do_control:
-        disarm_zero_fill(trial)
+        # A failed disarm means the pipe is still poisoned, so a control take that
+        # cannot hear the canary is MISSING EVIDENCE, not a product failure — fail
+        # closed to INVALID rather than scoring next_press_works=False.
+        disarm_reply = disarm_zero_fill(trial)
+        if disarm_reply != "OK":
+            return _invalid_evidence(
+                "disarm ack failed", disarm_reply=disarm_reply, post_status=post,
+                arm=arm, identity=identity)
         control = _canary_take()
 
     assertions = {
@@ -1779,6 +1808,7 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
             "source_incarnation_post": inc_post,
             "fault_take": fault_take,
             "control_take": control,
+            "disarm_reply": disarm_reply,
             "trial_id": trial,
             "mode": mode,
             "n": n,

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -735,8 +735,14 @@ def compute_sha256(path) -> str:
 
 def discover_bundle_executables(bundle_path) -> dict:
     """Absolute paths of our three executables inside the .app:
-    {app, audio_helper, asr_helper}. Raises if any is missing."""
-    bundle = Path(bundle_path)
+    {app, audio_helper, asr_helper}. Raises if any is missing.
+
+    abspath (NOT resolve): verify_running_identity compares app_path against the
+    argv[0] that `ps` reports for an `open`-launched app, which is absolute but
+    symlink-UNresolved. resolve() could expand a symlink/firmlink and diverge
+    from that argv[0], turning the intended build into invalid evidence when the
+    caller passes the documented relative --bundle. Cloud review PR #1504."""
+    bundle = Path(os.path.abspath(bundle_path))
     paths = {
         "app": bundle / _APP_EXE_REL,
         "audio_helper": bundle / _AUDIO_HELPER_REL,

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -1745,10 +1745,13 @@ def B1_bluetooth_route_flip(*, founder_present: bool = False, **_) -> dict:
 
 
 def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
-                     kwargs: dict, extra_assertions=None) -> dict:
+                     kwargs: dict, extra_assertions=None,
+                     fault_record_seconds: float = 3.0) -> dict:
     """Shared dead-mic trial: identity gate → arm+pre-status → fault take → HIT
     proof → optional disarmed control take → scored assertions. Fails closed at
-    every gate."""
+    every gate. `fault_record_seconds` lengthens the fault take so a "real audio
+    then dead" shape (zero_after) gets enough real speech PAST the TTS onset gap
+    before the mic goes dead."""
     manifest = _require_manifest(kwargs)
     if manifest is None:
         return _invalid_evidence(
@@ -1762,7 +1765,7 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
         return _invalid_evidence("arm ack/pre-status failed", arm=arm, identity=identity)
     inc_pre = arm["pre_status"]["source_incarnation"]
 
-    fault_take = _canary_take()
+    fault_take = _canary_take(record_seconds=fault_record_seconds)
 
     post = query_fault_status(trial)
     hit_ok = bool(post.get("ok")) and post.get("hit") is True and post.get("zeroed", 0) > 0
@@ -1786,13 +1789,19 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
         control = _canary_take()
 
     assertions = {
-        "dead_take_handled_honestly": fault_take["dead_honest"]["handled_honestly"],
-        "dead_take_fabricated_text": fault_take["dead_honest"]["fabricated_canary"],
         "recovered_in_session": fault_take["recovers"]["canary_ok"],
         # No rebuild is triggered here, so a changed incarnation would only come
         # from a recovery mechanism (follow-up plan). Honest measurement.
         "fresh_pipe_proven": inc_post != inc_pre,
     }
+    # Dead-take honesty is only meaningful for a FULLY dead take (zero_from_start).
+    # A partial shape (zero_after / zero_next) legitimately contains real audio, so
+    # the no-speech marker won't fire and any captured text is NOT "fabricated" —
+    # emitting those assertions there would mislabel correct behavior (the Z3
+    # false-"fabricated" the first live run showed).
+    if mode == "zero_from_start":
+        assertions["dead_take_handled_honestly"] = fault_take["dead_honest"]["handled_honestly"]
+        assertions["dead_take_fabricated_text"] = fault_take["dead_honest"]["fabricated_canary"]
     if control is not None:
         assertions["next_press_works"] = control["recovers"]["canary_ok"]
     if extra_assertions is not None:
@@ -1842,13 +1851,19 @@ def Z1_all_zero_from_start(**kwargs) -> dict:
     "extend it with fabricated tokens",
     description="Real audio for the first N live samples, then all-zero forever. "
     "Exercises the content-blind liveness path (buffers keep flowing, just zero). "
-    "Assert lead audio was preserved (a raw-ASR entry exists) and the injector hit."))
-def Z2_valid_then_all_zero(*, lead_samples: int = 16000, **kwargs) -> dict:
+    "Assert lead audio was preserved (a raw-ASR entry exists) and the injector hit. "
+    "Default lead is 3s / take is 6s: empirically (2026-07-11) a 1s lead landed on "
+    "the TTS onset gap and produced no transcript — the app preserves pre-death "
+    "speech fine given a real lead, so the window must clear the onset gap."))
+def Z2_valid_then_all_zero(*, lead_samples: int = 48000, **kwargs) -> dict:
     def _extra(fault_take, _control):
         return {"raw_text_preserved": fault_take["recovers"]["raw_asr_new_entry"]}
+    # lead 48000 (~3s real, past the ~0.5s TTS onset gap); fault take 6s so a real
+    # dead tail follows the lead and the injector actually hits.
     return _zero_fill_trial(
         mode="zero_after_samples", n=lead_samples, trial=_trial_id("Z2"),
-        do_control=True, kwargs=kwargs, extra_assertions=_extra)
+        do_control=True, kwargs=kwargs, extra_assertions=_extra,
+        fault_record_seconds=6.0)
 
 
 @scenario(ScenarioMeta(

--- a/Tests/RuntimeUAT/run_gauntlet.py
+++ b/Tests/RuntimeUAT/run_gauntlet.py
@@ -7,15 +7,31 @@ bad scenario silently invalidates every subsequent "pass" because the app
 is already broken.
 
 Usage:
+    # Legacy Lane A gauntlet (health-check between scenarios):
     python3 Tests/RuntimeUAT/run_gauntlet.py --backend parakeet
     python3 Tests/RuntimeUAT/run_gauntlet.py --backend whisperKit
 
+    # #1317 dead-mic proof bench (one build; needs a stamped manifest):
+    python3 Tests/RuntimeUAT/run_gauntlet.py dead-mic \
+        --manifest /tmp/bench/candidate.manifest.json \
+        --backend parakeet --label candidate --scorecard /tmp/bench/candidate.json
+
+    # Stamp a build manifest AFTER building an A/B arm:
+    python3 Tests/RuntimeUAT/run_gauntlet.py write-manifest \
+        --bundle "build/EnviousWispr Local.app" --source-ref v2.3.2 \
+        --source-sha $(git rev-parse HEAD) --clean-tree \
+        --contract-version zerofill-v1 --out /tmp/bench/candidate.manifest.json
+
 The bundle must already be running with EW_FAULT_INJECTION=1 set
-(via the wispr-rebuild-debug skill).
+(via the wispr-rebuild-debug skill). The A/B comparison is two dead-mic runs
+(one per build, sequential — shared bundle id) plus a diff of the two
+scorecards; this runner owns per-build execution, manifest stamping, and
+aggregation (no third runner, per plan §3c).
 """
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 import time
 from pathlib import Path
@@ -27,10 +43,19 @@ if str(HERE) not in sys.path:
 from faultInjection import (  # noqa: E402
     _assert_dictation_recovers,
     _parse_query_state,
+    evaluate_trial,
     list_xpc_service_pids,
     query_state,
     run_scenario,
+    write_build_manifest,
 )
+
+# #1317 deterministic dead-mic cells scored A/B in Phase 1.
+DEAD_MIC_SCENARIOS = [
+    "Z1_all_zero_from_start",
+    "Z2_valid_then_all_zero",
+    "Z3_bounded_zero_then_restore",
+]
 
 
 PARAKEET_GAUNTLET = [
@@ -105,7 +130,112 @@ def health_check(backend_key: str) -> dict:
     }
 
 
+def run_dead_mic_bench(manifest_path: str, backend: str, label: str) -> dict:
+    """#1317 dead-mic proof bench against the currently running build. Baseline
+    mode: a valid-evidence PRODUCT failure is recorded and does NOT abort the run
+    (so the full scorecard is produced); an INVALID-evidence trial flags the whole
+    bench invalid (nonzero exit). The running app must already be on `backend`;
+    this runner records the label, it does not switch backends."""
+    print(f"=== #1317 dead-mic bench — build={label} backend={backend} ===")
+    print(f"manifest: {manifest_path}")
+    print(f"pre-state: {query_state()}")
+
+    cells = []
+    any_invalid = False
+    for i, name in enumerate(DEAD_MIC_SCENARIOS, 1):
+        print(f"\n--- [{i}/{len(DEAD_MIC_SCENARIOS)}] {name} ---")
+        t0 = time.monotonic()
+        try:
+            wrapped = run_scenario(name, manifest_path=manifest_path)
+            inner = wrapped.get("result", {})
+        except Exception as e:  # noqa: BLE001 — a raising scenario is invalid evidence
+            print(f"  scenario raised: {type(e).__name__}: {e}")
+            cells.append({
+                "scenario": name, "evidence_valid": False, "passed": False,
+                "reason": f"scenario raised {type(e).__name__}: {e}",
+                "elapsed_seconds": time.monotonic() - t0,
+                "assertions": {}, "evidence": {},
+            })
+            any_invalid = True
+            continue
+
+        passed, reason = evaluate_trial(name, inner)
+        ev_valid = bool(inner.get("evidence_valid", True))
+        if not ev_valid:
+            any_invalid = True
+        cells.append({
+            "scenario": name,
+            "evidence_valid": ev_valid,
+            "passed": passed,
+            "reason": reason,
+            "elapsed_seconds": wrapped.get("elapsed_seconds"),
+            "assertions": inner.get("assertions", {}),
+            "evidence": inner.get("evidence", {}),
+        })
+        tag = "OK" if passed else ("INVALID" if not ev_valid else "PRODUCT-FAIL")
+        print(f"  {tag}  {reason}")
+        print(f"  assertions={inner.get('assertions', {})}")
+
+    print(f"\nfinal-state: {query_state()}")
+    return {
+        "label": label,
+        "backend": backend,
+        "manifest_path": manifest_path,
+        "any_invalid": any_invalid,
+        "cells": cells,
+    }
+
+
+def _write_scorecard(bench: dict, out_path: str) -> None:
+    Path(out_path).write_text(
+        json.dumps(bench, indent=2, default=str) + "\n", encoding="utf-8")
+    print(f"\nscorecard written: {out_path}")
+
+
+def _cmd_dead_mic(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="run_gauntlet.py dead-mic")
+    p.add_argument("--manifest", required=True, help="build manifest JSON path")
+    p.add_argument("--backend", choices=["parakeet", "whisperKit"], default="parakeet")
+    p.add_argument("--label", required=True, help="build label, e.g. candidate / v2.3.2")
+    p.add_argument("--scorecard", help="write the JSON scorecard here")
+    args = p.parse_args(argv)
+    bench = run_dead_mic_bench(args.manifest, args.backend, args.label)
+    if args.scorecard:
+        _write_scorecard(bench, args.scorecard)
+    n_invalid = sum(1 for c in bench["cells"] if not c["evidence_valid"])
+    n_fail = sum(1 for c in bench["cells"] if c["evidence_valid"] and not c["passed"])
+    print(f"\n=== bench summary: {len(bench['cells'])} cells, "
+          f"{n_invalid} invalid-evidence, {n_fail} product-fail ===")
+    # Baseline contract: nonzero only when any trial has INVALID evidence.
+    return 1 if bench["any_invalid"] else 0
+
+
+def _cmd_write_manifest(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="run_gauntlet.py write-manifest")
+    p.add_argument("--bundle", required=True, help="path to the built .app")
+    p.add_argument("--source-ref", required=True, help="git ref/tag the build came from")
+    p.add_argument("--source-sha", required=True, help="full commit SHA")
+    p.add_argument("--clean-tree", action="store_true", help="working tree was clean")
+    p.add_argument("--contract-version", required=True, help="injector contract version")
+    p.add_argument("--out", required=True, help="manifest JSON output path")
+    args = p.parse_args(argv)
+    manifest = write_build_manifest(
+        bundle_path=args.bundle, source_ref=args.source_ref, source_sha=args.source_sha,
+        clean_tree=args.clean_tree, contract_version=args.contract_version, out_path=args.out)
+    print(f"manifest written: {args.out}")
+    print(f"  app_sha256={manifest['app_sha256'][:16]}…  "
+          f"audio={manifest['audio_helper_sha256'][:16]}…  "
+          f"asr={manifest['asr_helper_sha256'][:16]}…")
+    return 0
+
+
 def main(argv: list[str]) -> int:
+    # Subcommand routing; no subcommand ⇒ legacy Lane A gauntlet (back-compat).
+    if argv and argv[0] == "dead-mic":
+        return _cmd_dead_mic(argv[1:])
+    if argv and argv[0] == "write-manifest":
+        return _cmd_write_manifest(argv[1:])
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--backend", choices=["parakeet", "whisperKit"],
                         default="parakeet")

--- a/Tests/RuntimeUAT/run_gauntlet.py
+++ b/Tests/RuntimeUAT/run_gauntlet.py
@@ -138,7 +138,36 @@ def run_dead_mic_bench(manifest_path: str, backend: str, label: str) -> dict:
     this runner records the label, it does not switch backends."""
     print(f"=== #1317 dead-mic bench — build={label} backend={backend} ===")
     print(f"manifest: {manifest_path}")
-    print(f"pre-state: {query_state()}")
+    pre_state = query_state()
+    print(f"pre-state: {pre_state}")
+
+    # Fail closed if the running app is NOT on the requested backend. This runner
+    # does not switch backends; without this guard it would run every scenario
+    # against whatever is active while stamping the requested `--backend` into the
+    # scorecard — a mislabeled result is invalid evidence, not a valid one.
+    active_backend = _parse_query_state(pre_state).get("backend", "").lstrip(".").lower()
+    if active_backend != backend.lower():
+        reason = (
+            f"requested backend={backend} but running app is on "
+            f"'{active_backend or 'unknown'}' (query_state: {pre_state!r}); "
+            "switch the app's backend before running this bench")
+        print(f"  INVALID  {reason}")
+        return {
+            "label": label,
+            "backend": backend,
+            "manifest_path": manifest_path,
+            "any_invalid": True,
+            "cells": [{
+                "scenario": "backend_precondition",
+                "evidence_valid": False,
+                "passed": False,
+                "reason": reason,
+                "elapsed_seconds": 0.0,
+                "assertions": {},
+                "evidence": {"active_backend": active_backend,
+                             "requested_backend": backend},
+            }],
+        }
 
     cells = []
     any_invalid = False


### PR DESCRIPTION
## What this is

Part of **#1317** (P1: silent all-zero recordings get no recovery or user feedback). This PR lands **only the proof bench** — a DEBUG-only test instrument that reproduces the production dead-mic fault on command, proves it fired, and measures whether the app handles it honestly. **No production behavior changes.** The reactive recovery + user feedback fix lands in a follow-up PR that uses this bench to prove it beats the release build offline, before any user sees it.

## Why the bench first

The founder's hard constraint on this heart-path fix is "prove it empirically before shipping — no guinea-pigging the 100 users." This bench is that proof instrument. Merging it separately keeps the fix PR a clean, production-only diff and puts the harness on `main` where the fix can validate against it.

## What it does

- **Injector core** (`DebugZeroFillController`, `#if DEBUG`): forces all-zero ("digital silence") audio from start, after a threshold, or for a bounded budget — the exact production dead-mic signature. Proven index-safe for negative inputs (`DebugZeroFillControllerTests.negativeBudgetIsSafe`).
- **Wired into all three capture sources** via the single fan-out point (`PreRollForwarder.route`), behind buffer-shape guards so an unsupported buffer never claims a fault hit.
- **DEBUG XPC arm/status channel** so the harness can arm a fault and read back what actually happened (armed / hit / zeroed-sample-count / source-incarnation / **capture source type**).
- **Fail-closed Python harness** (`Tests/RuntimeUAT/faultInjection.py`, `run_gauntlet.py`): scenarios Z1 (dead from start), Z2 (real speech then dead), Z3 (brief dead then recover), negative controls, build-manifest stamping, running-identity verification, and a JSON scorecard whose exit contract fails only on invalid evidence.

## Validation

- All 2820 Debug-lane tests pass (`scripts/xcode-test.sh`).
- Codex grounded review: **PROCEED-AS-IS** (audits `docs/audits/2026-07-11-1317-grounded-review-r*.txt`).
- Runtime-verified live last session on built-in **and** Bluetooth routes (`capture_source=hal_device_input` confirmed on BT).
- Everything new is `#if DEBUG` — release builds are unaffected.

## Empirical finding this bench established

Today's build handles a dead mic **honestly but does not auto-recover**: Z1 → honest no-speech (no fabrication, next press works), Z2 → pre-death speech preserved, Z3 → self-heals in-session. It does **not** rebuild a fully-dead warm engine mid-session or tell the user — which is exactly what the #1317 fix adds.

Part of #1317.
