### PR TITLE
fix(llm): per-model OpenAI request shape + self-healing param strip (#1330)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -156,7 +156,7 @@ struct AIPolishSettingsView: View {
   }
 
   private var isReasoningModel: Bool {
-    settings.llmProvider.supportsReasoning(model: settings.llmModel)
+    settings.llmProvider.modelCapabilities(model: settings.llmModel).supportsReasoning
   }
 
   private var showModelSection: Bool {

--- a/Sources/EnviousWisprCore/LLMResult.swift
+++ b/Sources/EnviousWisprCore/LLMResult.swift
@@ -42,18 +42,6 @@ extension LLMProvider {
     case .none: return ""
     }
   }
-
-  /// Whether this provider + model combination supports reasoning/thinking controls.
-  public func supportsReasoning(model: String) -> Bool {
-    switch self {
-    case .gemini:
-      return model.hasPrefix("gemini-2.5") || model.hasPrefix("gemini-3")
-    case .openAI:
-      return model.hasPrefix("o1") || model.hasPrefix("o3") || model.hasPrefix("o4")
-    case .ollama, .appleIntelligence, .egOne, .none:
-      return false
-    }
-  }
 }
 
 /// Per-polish telemetry sidecar produced by AFM polish (#429; single-prompt since #1072).

--- a/Sources/EnviousWisprLLM/LLMModelCapabilities.swift
+++ b/Sources/EnviousWisprLLM/LLMModelCapabilities.swift
@@ -1,0 +1,96 @@
+import EnviousWisprCore
+import Foundation
+
+/// Per-model request-shape capabilities for cloud LLM providers (#1330).
+///
+/// One authority for three INDEPENDENT facts about a model. They must stay
+/// independent: GPT-5.4-mini accepts `temperature: 0` yet is a reasoning
+/// model, and `gpt-5-chat-latest` is Chat-Completions-capable yet
+/// non-reasoning — collapsing these into one "is reasoning" bit is the
+/// conflation that produced the silent gpt-5.5 polish outage (#1330).
+///
+/// Consumers: `LLMPolishStep.resolveThinkingConfig` and
+/// `AIPolishSettingsView.isReasoningModel` read `supportsReasoning`;
+/// `OpenAIConnector` reads `temperaturePolicy` and preflights
+/// `supportsChatCompletions`; `LLMModelDiscovery` filters the picker on
+/// `supportsChatCompletions`.
+public struct LLMModelCapabilities: Sendable, Equatable {
+  public enum TemperaturePolicy: Sendable, Equatable {
+    /// Classic chat models: send `temperature: 0` for deterministic polish.
+    case include
+    /// Reasoning-shape models: never send `temperature`. GPT-5.5 rejects a
+    /// non-default temperature even when no reasoning-effort field is
+    /// present (11/11 rejections, #1330), so omission is unconditional.
+    /// A conditional policy would recreate the failure after an effort
+    /// strip. Models that tolerate the field, such as GPT-5.4-mini, remain
+    /// API-compatible when it is omitted, but their output behavior may
+    /// change because the provider default is not temperature zero.
+    case omit
+  }
+
+  public let supportsReasoning: Bool
+  public let temperaturePolicy: TemperaturePolicy
+  /// Primary-endpoint (Chat Completions) eligibility. Meaningful for
+  /// `.openAI` only — Responses-API-only families (`-pro`, codex) can never
+  /// be called by our connector. Other providers return `false` as a
+  /// documented constant; nothing consults the field for them.
+  public let supportsChatCompletions: Bool
+
+  public init(
+    supportsReasoning: Bool,
+    temperaturePolicy: TemperaturePolicy,
+    supportsChatCompletions: Bool
+  ) {
+    self.supportsReasoning = supportsReasoning
+    self.temperaturePolicy = temperaturePolicy
+    self.supportsChatCompletions = supportsChatCompletions
+  }
+}
+
+extension LLMProvider {
+  /// Resolve the request-shape capability profile for `model`.
+  ///
+  /// Static knowledge, deliberately: OpenAI publishes no machine-readable
+  /// per-model parameter rules (their models endpoint returns IDs only), so
+  /// a "live rules lookup" cannot exist. The runtime containment for this
+  /// table going stale is `OpenAIConnector`'s unsupported-param
+  /// strip-and-retry, which self-heals a mismatch in one extra round-trip
+  /// and memoizes it for the rest of the process.
+  public func modelCapabilities(model: String) -> LLMModelCapabilities {
+    let id = model.lowercased()
+
+    switch self {
+    case .openAI:
+      // Chat-tuned variants (gpt-5-chat-latest) are non-reasoning even
+      // though they carry the gpt-5 prefix.
+      let isChatVariant = id.contains("-chat")
+      let isReasoning =
+        id.hasPrefix("o1")
+        || id.hasPrefix("o3")
+        || id.hasPrefix("o4")
+        || (id.hasPrefix("gpt-5") && !isChatVariant)
+
+      let isResponsesOnly = id.contains("codex") || id.contains("-pro")
+
+      return LLMModelCapabilities(
+        supportsReasoning: isReasoning,
+        temperaturePolicy: isReasoning ? .omit : .include,
+        supportsChatCompletions: !isResponsesOnly
+      )
+
+    case .gemini:
+      return LLMModelCapabilities(
+        supportsReasoning: id.hasPrefix("gemini-2.5") || id.hasPrefix("gemini-3"),
+        temperaturePolicy: .include,
+        supportsChatCompletions: false
+      )
+
+    case .ollama, .appleIntelligence, .egOne, .none:
+      return LLMModelCapabilities(
+        supportsReasoning: false,
+        temperaturePolicy: .include,
+        supportsChatCompletions: false
+      )
+    }
+  }
+}

--- a/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
+++ b/Sources/EnviousWisprLLM/LLMModelDiscovery.swift
@@ -188,19 +188,31 @@ public struct LLMModelDiscovery: Sendable {
 
     return models.compactMap { model -> (id: String, displayName: String)? in
       guard let id = model["id"] as? String else { return nil }
-      // Only include chat-capable models (gpt- and o- prefixes)
-      guard
-        id.hasPrefix("gpt-") || id.hasPrefix("o-") || id.hasPrefix("o1") || id.hasPrefix("o3")
-          || id.hasPrefix("o4")
-      else { return nil }
-      // Skip realtime, audio, and search models
-      let skipPatterns = ["realtime", "audio", "search", "transcribe"]
-      if skipPatterns.contains(where: { id.contains($0) }) { return nil }
+      guard Self.isOpenAIChatCompletionCandidate(id) else { return nil }
       let displayName = id.replacingOccurrences(of: "-", with: " ")
         .split(separator: " ").map { $0.prefix(1).uppercased() + $0.dropFirst() }.joined(
           separator: " ")
       return (id: id, displayName: displayName)
     }
+  }
+
+  /// Whether an OpenAI model id belongs in the picker's candidate list.
+  /// Owns the OpenAI-specific prefix and modality checks and consults the
+  /// capability authority for endpoint eligibility, so Responses-API-only
+  /// families (-pro, codex) never appear as permanently locked rows (#1330).
+  /// Shared alias ("latest") and version-duplicate ("-001") filtering stays
+  /// in `filterModels` — it applies to every provider, not just OpenAI.
+  static func isOpenAIChatCompletionCandidate(_ modelID: String) -> Bool {
+    let id = modelID.lowercased()
+    // Only chat-capable text models (gpt- and o- prefixes).
+    guard
+      id.hasPrefix("gpt-") || id.hasPrefix("o-") || id.hasPrefix("o1") || id.hasPrefix("o3")
+        || id.hasPrefix("o4")
+    else { return false }
+    // Skip non-text modalities.
+    let skipPatterns = ["realtime", "audio", "search", "transcribe"]
+    if skipPatterns.contains(where: { id.contains($0) }) { return false }
+    return LLMProvider.openAI.modelCapabilities(model: id).supportsChatCompletions
   }
 
   private func probeOpenAI(modelID: String, apiKey: String) async -> Bool {

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -1,13 +1,46 @@
 import EnviousWisprCore
 import Foundation
+import os
 
 /// OpenAI Chat Completions API connector for transcript polishing.
+///
+/// Request shape is per-model (#1330): `LLMModelCapabilities` decides whether
+/// `temperature` is serialized, and a bounded unsupported-param
+/// strip-and-retry self-heals the static table against provider-side drift
+/// (one extra round-trip, memoized per model for the rest of the process).
 public struct OpenAIConnector: TranscriptPolisher {
+  /// Transport seam: one physical HTTP exchange. Injected by tests to script
+  /// reject/succeed sequences; production always uses the shared session.
+  typealias RequestExecutor = @Sendable (
+    URLRequest,
+    LLMTaskMetricsCollector
+  ) async throws -> (Data, URLResponse)
+
   private let keychainManager: KeychainManager
+  private let requestExecutor: RequestExecutor
   private let baseURL = "https://api.openai.com/v1/chat/completions"
+
+  /// Params the strip-retry may remove after a qualifying 400. Never
+  /// `model`/`messages`/`max_completion_tokens` — stripping the cap would
+  /// unbound cost, and the others are the request itself.
+  static let strippableParams: Set<String> = ["temperature", "reasoning_effort"]
+
+  /// Process-lifetime memo of params each exact model id rejected, so the
+  /// one-round-trip adaptation tax is paid once per model per app run.
+  /// Never persisted: an OpenAI-side fix resets on relaunch.
+  private static let paramMemo = OSAllocatedUnfairLock<[String: Set<String>]>(initialState: [:])
 
   public init(keychainManager: KeychainManager = KeychainManager()) {
     self.keychainManager = keychainManager
+    self.requestExecutor = { request, collector in
+      try await LLMNetworkSession.shared.session.data(for: request, delegate: collector)
+    }
+  }
+
+  /// Test seam. Production callers use the public init.
+  init(keychainManager: KeychainManager, requestExecutor: @escaping RequestExecutor) {
+    self.keychainManager = keychainManager
+    self.requestExecutor = requestExecutor
   }
 
   public func polish(
@@ -16,35 +49,26 @@ public struct OpenAIConnector: TranscriptPolisher {
     config: LLMProviderConfig,
     onToken: (@Sendable (String) -> Void)?
   ) async throws -> LLMResult {
+    // Key first: a user must have a usable key before model compatibility
+    // becomes the actionable failure (missing/rejected/unreadable-key
+    // precedence, #1330 grounded review r4).
     let apiKey = try getAPIKey(config: config)
+
+    // Responses-API-only families (-pro, codex) can never succeed on Chat
+    // Completions; fail deterministically with the model-unavailable notice
+    // instead of a doomed network call (today only HTTP 404 maps there, and
+    // the provider may answer 400 instead).
+    let capabilities = LLMProvider.openAI.modelCapabilities(model: config.model)
+    guard capabilities.supportsChatCompletions else {
+      throw LLMError.classified(.modelUnavailable)
+    }
 
     let messages: [[String: String]] = [
       ["role": "system", "content": instructions.systemPrompt],
       ["role": "user", "content": text],
     ]
 
-    var body: [String: Any] = [
-      "model": config.model,
-      "messages": messages,
-      "max_completion_tokens": config.maxTokens,
-      "temperature": config.temperature,
-      "store": false,
-    ]
-    if let reasoningEffort = config.reasoningEffort {
-      body["reasoning_effort"] = reasoningEffort
-    }
-
-    guard let url = URL(string: baseURL) else {
-      throw LLMError.requestFailed("Invalid OpenAI URL")
-    }
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.httpBody = try JSONSerialization.data(withJSONObject: body)
-    request.timeoutInterval = 60
-
-    return try await performWithRetry(request: request, config: config)
+    return try await performWithRetry(apiKey: apiKey, messages: messages, config: config)
   }
 
   public func polish(
@@ -72,17 +96,61 @@ public struct OpenAIConnector: TranscriptPolisher {
     )
   }
 
+  // MARK: - Request construction
+
+  /// Build the Chat Completions body for `config`, honoring the model's
+  /// temperature policy and any omissions (memoized or same-call strips).
+  /// Static and pure for fixture testing.
+  static func makeRequestBody(
+    config: LLMProviderConfig,
+    messages: [[String: String]],
+    omitting: Set<String> = []
+  ) -> [String: Any] {
+    let capabilities = LLMProvider.openAI.modelCapabilities(model: config.model)
+
+    var body: [String: Any] = [
+      "model": config.model,
+      "messages": messages,
+      "max_completion_tokens": config.maxTokens,
+      "store": false,
+    ]
+    if capabilities.temperaturePolicy == .include && !omitting.contains("temperature") {
+      body["temperature"] = config.temperature
+    }
+    if let reasoningEffort = config.reasoningEffort, !omitting.contains("reasoning_effort") {
+      body["reasoning_effort"] = reasoningEffort
+    }
+    return body
+  }
+
+  private func makeRequest(
+    apiKey: String, body: [String: Any]
+  ) throws -> URLRequest {
+    guard let url = URL(string: baseURL) else {
+      throw LLMError.requestFailed("Invalid OpenAI URL")
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+    request.timeoutInterval = 60
+    return request
+  }
+
   // MARK: - Retry
 
   private func performWithRetry(
-    request: URLRequest,
+    apiKey: String,
+    messages: [[String: String]],
     config: LLMProviderConfig,
     maxRetries: Int = LLMRetryPolicy.defaultMaxRetries,
     delays: [UInt64] = LLMRetryPolicy.defaultDelays
   ) async throws -> LLMResult {
-    // Allocate the call number once per logical polish. Retries reuse the
-    // same number so logs never mistake a retried polish for multiple
-    // independent calls (Codex review finding P3).
+    // Allocate the call number once per logical polish. Transient retries
+    // AND shape-strip re-issues reuse the same number so logs never mistake
+    // one logical polish for multiple independent calls; each physical
+    // request still emits its own metrics line via executeOnce.
     let callNumber = LLMNetworkSession.shared.nextCallNumber()
     var lastError: Error?
     for attempt in 0...maxRetries {
@@ -97,76 +165,189 @@ public struct OpenAIConnector: TranscriptPolisher {
         try await Task.sleep(nanoseconds: delay)
       }
 
-      let collector = LLMTaskMetricsCollector()
-      var statusForLog = "pending"
       do {
-        defer {
-          let line = LLMTaskMetricsCollector.format(
-            provider: "openai", model: config.model, callNumber: callNumber,
-            status: statusForLog, metrics: collector.metrics
-          )
-          Task { await AppLogger.shared.log(line, level: .info, category: "LLM") }
-        }
-        let data: Data
-        let response: URLResponse
-        do {
-          (data, response) = try await LLMNetworkSession.shared.session.data(
-            for: request, delegate: collector
-          )
-        } catch {
-          statusForLog = "error:\(Self.shortError(error))"
-          throw error
-        }
-        guard let httpResponse = response as? HTTPURLResponse else {
-          statusForLog = "error:non_http_response"
-          throw LLMError.requestFailed("Invalid response")
-        }
-        statusForLog = String(httpResponse.statusCode)
-        switch httpResponse.statusCode {
-        case 200:
-          // Parse inside the defer scope so a malformed 200 payload
-          // (e.g. content-moderation refusal, unexpected schema)
-          // updates statusForLog to error_after_200 before the
-          // metrics line is written (Codex GitHub review P2).
-          do {
-            return try Self.parseSuccess(data: data, config: config)
-          } catch {
-            statusForLog = "error_after_200:\(Self.shortError(error))"
-            throw error
+        // Inner shape loop: a qualifying unsupported-param 400 rebuilds the
+        // body without the rejected param and re-issues immediately. Bounded
+        // by the allowlist size; does not consume a transient attempt.
+        var stripsThisCall = 0
+        while true {
+          let omitting = Self.memoizedOmissions(model: config.model)
+          let body = Self.makeRequestBody(
+            config: config, messages: messages, omitting: omitting)
+          let sentStrippable = Self.strippableParams.filter { body[$0] != nil }
+          let request = try makeRequest(apiKey: apiKey, body: body)
+
+          switch try await executeOnce(
+            request: request, config: config, callNumber: callNumber)
+          {
+          case .success(let result):
+            return result
+
+          case .httpFailure(let statusCode, let bodyString):
+            if statusCode == 400,
+              stripsThisCall < Self.strippableParams.count,
+              let param = Self.strippableParam(
+                fromErrorBody: bodyString, sentParams: sentStrippable)
+            {
+              stripsThisCall += 1
+              let firstStripForModel = Self.recordOmission(model: config.model, param: param)
+              if firstStripForModel {
+                Task {
+                  await AppLogger.shared.log(
+                    "OpenAI request shape adapted model=\(config.model) omitted_param=\(param)",
+                    level: .info, category: "LLM"
+                  )
+                }
+              }
+              continue
+            }
+
+            // #945: read the body INSIDE the error arm so the classifier can
+            // split the ambiguous pairs (out-of-credits vs rate-limited on
+            // 429; too-long vs generic 400).
+            #if DEBUG
+              let truncated = String(bodyString.prefix(200))
+              Task {
+                await AppLogger.shared.log(
+                  "OpenAI HTTP \(statusCode): \(truncated)",
+                  level: .verbose, category: "LLM"
+                )
+              }
+            #else
+              Task {
+                await AppLogger.shared.log(
+                  "OpenAI HTTP \(statusCode)",
+                  level: .verbose, category: "LLM"
+                )
+              }
+            #endif
+            throw LLMError.classified(
+              Self.classify(statusCode: statusCode, bodyString: bodyString))
           }
-        default:
-          // #945: read the body INSIDE the error arm so the classifier can split
-          // the ambiguous pairs (out-of-credits vs rate-limited on 429; too-long
-          // vs generic 400). `data` is already in hand from the call above.
-          let bodyString = String(data: data, encoding: .utf8) ?? ""
-          #if DEBUG
-            let truncated = String(bodyString.prefix(200))
-            Task {
-              await AppLogger.shared.log(
-                "OpenAI HTTP \(httpResponse.statusCode): \(truncated)",
-                level: .verbose, category: "LLM"
-              )
-            }
-          #else
-            Task {
-              await AppLogger.shared.log(
-                "OpenAI HTTP \(httpResponse.statusCode)",
-                level: .verbose, category: "LLM"
-              )
-            }
-          #endif
-          throw LLMError.classified(
-            Self.classify(statusCode: httpResponse.statusCode, bodyString: bodyString))
         }
       } catch {
-        if statusForLog == "pending" {
-          statusForLog = "error:\(Self.shortError(error))"
-        }
         lastError = error
         if !LLMRetryPolicy.isRetryable(error) { throw error }
       }
     }
     throw lastError ?? LLMError.requestFailed("All retries exhausted")
+  }
+
+  /// One physical HTTP exchange. Owns its own metrics collector, status
+  /// token, and metrics-line defer, so every request — transient retry or
+  /// shape-strip re-issue — emits exactly one task_metrics line under the
+  /// shared logical call number.
+  private enum AttemptOutcome {
+    case success(LLMResult)
+    case httpFailure(statusCode: Int, body: String)
+  }
+
+  private func executeOnce(
+    request: URLRequest,
+    config: LLMProviderConfig,
+    callNumber: Int
+  ) async throws -> AttemptOutcome {
+    let collector = LLMTaskMetricsCollector()
+    var statusForLog = "pending"
+    defer {
+      let line = LLMTaskMetricsCollector.format(
+        provider: "openai", model: config.model, callNumber: callNumber,
+        status: statusForLog, metrics: collector.metrics
+      )
+      Task { await AppLogger.shared.log(line, level: .info, category: "LLM") }
+    }
+
+    let data: Data
+    let response: URLResponse
+    do {
+      (data, response) = try await requestExecutor(request, collector)
+    } catch {
+      statusForLog = "error:\(Self.shortError(error))"
+      throw error
+    }
+    guard let httpResponse = response as? HTTPURLResponse else {
+      statusForLog = "error:non_http_response"
+      throw LLMError.requestFailed("Invalid response")
+    }
+    statusForLog = String(httpResponse.statusCode)
+
+    if httpResponse.statusCode == 200 {
+      // Parse inside the defer scope so a malformed 200 payload
+      // (e.g. content-moderation refusal, unexpected schema)
+      // updates statusForLog to error_after_200 before the
+      // metrics line is written (Codex GitHub review P2).
+      do {
+        return .success(try Self.parseSuccess(data: data, config: config))
+      } catch {
+        statusForLog = "error_after_200:\(Self.shortError(error))"
+        throw error
+      }
+    }
+
+    return .httpFailure(
+      statusCode: httpResponse.statusCode,
+      body: String(data: data, encoding: .utf8) ?? ""
+    )
+  }
+
+  // MARK: - Unsupported-param recovery
+
+  private struct OpenAIErrorEnvelope: Decodable {
+    struct APIError: Decodable {
+      let type: String?
+      let param: String?
+      let code: String?
+    }
+    let error: APIError
+  }
+
+  /// Extract the parameter a 400 body rejects, iff it qualifies for the
+  /// strip-retry: allowlisted, actually sent, and the structured error does
+  /// not contradict the unsupported-param reading. `code` MAY be absent —
+  /// the public API reference does not document the 400 schema and our
+  /// recorded evidence proves only `param` (#1330) — so fail open on a
+  /// missing code and closed on a contradicting one.
+  static func strippableParam(
+    fromErrorBody body: String,
+    sentParams: Set<String>
+  ) -> String? {
+    let allowedCodes: Set<String> = ["unsupported_parameter", "unsupported_value"]
+
+    guard
+      let data = body.data(using: .utf8),
+      let envelope = try? JSONDecoder().decode(OpenAIErrorEnvelope.self, from: data),
+      let param = envelope.error.param,
+      Self.strippableParams.contains(param),
+      sentParams.contains(param)
+    else {
+      return nil
+    }
+    guard envelope.error.type == nil || envelope.error.type == "invalid_request_error" else {
+      return nil
+    }
+    guard envelope.error.code == nil || allowedCodes.contains(envelope.error.code!) else {
+      return nil
+    }
+    return param
+  }
+
+  static func memoizedOmissions(model: String) -> Set<String> {
+    paramMemo.withLock { $0[model] ?? [] }
+  }
+
+  /// Record a rejected param for `model`. Returns true when newly learned
+  /// (first strip for this model+param this run), so callers log once.
+  @discardableResult
+  static func recordOmission(model: String, param: String) -> Bool {
+    paramMemo.withLock { memo in
+      memo[model, default: []].insert(param).inserted
+    }
+  }
+
+  /// Test hook: clear learned omissions for one model so scripted transport
+  /// tests stay independent even though the memo is process-global.
+  static func resetOmissions(model: String) {
+    _ = paramMemo.withLock { $0.removeValue(forKey: model) }
   }
 
   /// Parse a successful OpenAI 200 response into an LLMResult.

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -697,7 +697,9 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
 
   /// Resolve thinking/reasoning config based on provider, model, and user toggle.
   private func resolveThinkingConfig() -> (thinkingBudget: Int?, reasoningEffort: String?) {
-    guard llmProvider.supportsReasoning(model: llmModel) else { return (nil, nil) }
+    guard llmProvider.modelCapabilities(model: llmModel).supportsReasoning else {
+      return (nil, nil)
+    }
     switch llmProvider {
     case .gemini:
       return (useExtendedThinking ? LLMConstants.defaultThinkingBudget : 0, nil)

--- a/Tests/EnviousWisprTests/LLM/LLMProviderCapabilityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMProviderCapabilityTests.swift
@@ -1,0 +1,94 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #1330: the capability authority. Reasoning support, temperature policy,
+/// and Chat Completions eligibility are three INDEPENDENT facts — the
+/// adversarial rows below each place a model in its non-intended class
+/// (matcher-set discipline): a reasoning-prefixed chat variant, a
+/// gpt-prefixed Responses-only model, a classic model that must keep
+/// temperature.
+@Suite("LLM model capability authority")
+struct LLMProviderCapabilityTests {
+
+  private func caps(_ model: String) -> LLMModelCapabilities {
+    LLMProvider.openAI.modelCapabilities(model: model)
+  }
+
+  // MARK: - Reasoning family (gpt-5 generation + o-series)
+
+  @Test(arguments: [
+    "gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5.1", "gpt-5.5",
+    "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+    "o1", "o1-mini", "o3", "o3-mini", "o4-mini",
+  ])
+  func reasoningFamilySupportsReasoningAndOmitsTemperature(model: String) {
+    let c = caps(model)
+    #expect(c.supportsReasoning)
+    #expect(c.temperaturePolicy == .omit)
+    #expect(c.supportsChatCompletions)
+  }
+
+  // MARK: - Classic family keeps temperature and gets no reasoning controls
+
+  @Test(arguments: ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-nano", "chatgpt-4o-latest"])
+  func classicFamilyIncludesTemperatureWithoutReasoning(model: String) {
+    let c = caps(model)
+    #expect(!c.supportsReasoning)
+    #expect(c.temperaturePolicy == .include)
+    #expect(c.supportsChatCompletions)
+  }
+
+  // MARK: - Adversarial: reasoning-prefixed but chat-tuned
+
+  @Test func gpt5ChatVariantIsNotReasoning() {
+    let c = caps("gpt-5-chat-latest")
+    #expect(!c.supportsReasoning)
+    #expect(c.temperaturePolicy == .include)
+    #expect(c.supportsChatCompletions)
+  }
+
+  // MARK: - Adversarial: gpt-prefixed but Responses-API-only
+
+  @Test(arguments: ["gpt-5-pro", "gpt-5.5-pro-2026-04-23", "gpt-5-codex", "gpt-5.3-codex-spark"])
+  func responsesOnlyFamiliesAreNotChatCompletionsEligible(model: String) {
+    #expect(!caps(model).supportsChatCompletions)
+  }
+
+  // MARK: - Case-insensitive matching (persisted strings may vary)
+
+  @Test func matchingIsCaseInsensitive() {
+    #expect(caps("GPT-5.6-Sol").supportsReasoning)
+    #expect(!caps("GPT-5-Pro").supportsChatCompletions)
+  }
+
+  // MARK: - Empty / unknown ids fail safe as classic
+
+  @Test func emptyAndUnknownIdsAreClassicShaped() {
+    for model in ["", "some-future-model"] {
+      let c = caps(model)
+      #expect(!c.supportsReasoning)
+      #expect(c.temperaturePolicy == .include)
+    }
+  }
+
+  // MARK: - Other providers
+
+  @Test func geminiReasoningPrefixesPreserved() {
+    #expect(LLMProvider.gemini.modelCapabilities(model: "gemini-2.5-pro").supportsReasoning)
+    #expect(LLMProvider.gemini.modelCapabilities(model: "gemini-3-flash").supportsReasoning)
+    #expect(!LLMProvider.gemini.modelCapabilities(model: "gemini-2.0-flash").supportsReasoning)
+    // Gemini models always keep temperature.
+    #expect(
+      LLMProvider.gemini.modelCapabilities(model: "gemini-2.5-pro").temperaturePolicy == .include)
+  }
+
+  @Test func localProvidersNeverReasonAndKeepTemperature() {
+    for provider in [LLMProvider.ollama, .appleIntelligence, .egOne, .none] {
+      let c = provider.modelCapabilities(model: "anything")
+      #expect(!c.supportsReasoning)
+      #expect(c.temperaturePolicy == .include)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/OpenAILiveSweepTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAILiveSweepTests.swift
@@ -1,0 +1,71 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #1330 ship gate: every OpenAI model the picker would offer must polish
+/// successfully through the SHIPPED connector with the founder's real key.
+///
+/// LIVE test — network + spend (sub-cent per model). Disabled unless
+/// `EW_OPENAI_LIVE_SWEEP=1`, so CI and ordinary local runs never execute it.
+/// Run: `TEST_RUNNER_EW_OPENAI_LIVE_SWEEP=1 scripts/xcode-test.sh --filter
+/// EnviousWisprTests/OpenAILiveSweepTests` (xcodebuild forwards TEST_RUNNER_-
+/// prefixed vars into the test process). The DEBUG test bundle's key store is
+/// the dev file store, so the key is the founder's local mirror file.
+@Suite(
+  "OpenAI all-models live sweep",
+  .enabled(if: ProcessInfo.processInfo.environment["EW_OPENAI_LIVE_SWEEP"] == "1"))
+struct OpenAILiveSweepTests {
+
+  @Test(.timeLimit(.minutes(10)))
+  func everyOfferedModelPolishesSuccessfully() async throws {
+    let keychain = KeychainManager()
+    let apiKey = try keychain.retrieve(key: KeychainManager.openAIKeyID)
+
+    // The exact candidate population the picker offers: live models list
+    // through the shipped filter + availability probe.
+    let discovered = try await LLMModelDiscovery().discoverModels(provider: .openAI, apiKey: apiKey)
+    let offered = discovered.filter(\.isAvailable)
+    #expect(!offered.isEmpty, "discovery returned no available models — sweep cannot run")
+
+    let connector = OpenAIConnector(keychainManager: keychain)
+    var failures: [String] = []
+    var report: [String] = []
+
+    for model in offered {
+      // Mirror LLMPolishStep's config decisions for this model.
+      let capabilities = LLMProvider.openAI.modelCapabilities(model: model.id)
+      let config = LLMProviderConfig(
+        model: model.id,
+        apiKeyKeychainId: KeychainManager.openAIKeyID,
+        maxTokens: capabilities.supportsReasoning ? LLMConstants.defaultMaxTokens : 512,
+        temperature: 0,
+        thinkingBudget: nil,
+        reasoningEffort: capabilities.supportsReasoning ? "low" : nil
+      )
+
+      let start = ContinuousClock.now
+      do {
+        let result = try await connector.polish(
+          text: "so um I think we should uh probably move the meeting to thursday afternoon",
+          instructions: .default, config: config, onToken: nil)
+        let elapsed = ContinuousClock.now - start
+        let strips = OpenAIConnector.memoizedOmissions(model: model.id)
+        let stripNote = strips.isEmpty ? "" : " adapted=\(strips.sorted().joined(separator: "+"))"
+        report.append(
+          "PASS \(model.id) \(elapsed)\(stripNote) -> \(result.polishedText.prefix(60))")
+        if result.polishedText.isEmpty { failures.append("\(model.id): empty polish") }
+      } catch {
+        let elapsed = ContinuousClock.now - start
+        failures.append("\(model.id): \(error) after \(elapsed)")
+        report.append("FAIL \(model.id) \(elapsed) \(error)")
+      }
+    }
+
+    print("=== OpenAI live sweep (\(offered.count) offered models) ===")
+    for line in report { print(line) }
+
+    #expect(failures.isEmpty, "sweep failures: \(failures.joined(separator: " | "))")
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/OpenAIParamStripTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAIParamStripTests.swift
@@ -1,0 +1,314 @@
+import EnviousWisprCore
+import Foundation
+import Security
+import Testing
+import os
+
+@testable import EnviousWisprLLM
+
+/// #1330: the unsupported-param strip-and-retry. The parser fixtures pin the
+/// qualification rules (allowlisted param, actually sent, structured error
+/// does not contradict); the scripted transport tests prove the CONNECTOR
+/// actually re-issues a rebuilt request, bounds the strips, memoizes per
+/// model, and preflights Responses-only models without touching transport.
+///
+/// Every scripted test uses a UNIQUE model id: the memo is process-global
+/// mutable state, and sharing fixture models across parallel tests is the
+/// flake class of swift-patterns RULE: tests-no-process-global-mutable-delegate.
+@Suite("OpenAI unsupported-param strip-retry")
+struct OpenAIParamStripTests {
+
+  // MARK: - Parser fixtures
+
+  /// Reconstructed from the exact recorded #1330 message, type, and param.
+  /// (The issue does not preserve a complete verbatim JSON body with `code`;
+  /// the code variants below cover present, missing, null, contradictory.)
+  private static let recordedTemperatureRejection = """
+    {"error": {"message": "Unsupported value: 'temperature' does not support 0 with this model. \
+    Only the default (1) value is supported.", "type": "invalid_request_error", \
+    "param": "temperature", "code": "unsupported_value"}}
+    """
+
+  @Test func recordedRejectionYieldsTemperature() {
+    let param = OpenAIConnector.strippableParam(
+      fromErrorBody: Self.recordedTemperatureRejection, sentParams: ["temperature"])
+    #expect(param == "temperature")
+  }
+
+  @Test func unsupportedParameterCodeQualifies() {
+    let body = """
+      {"error": {"message": "Unsupported parameter: 'reasoning_effort'.", \
+      "type": "invalid_request_error", "param": "reasoning_effort", \
+      "code": "unsupported_parameter"}}
+      """
+    #expect(
+      OpenAIConnector.strippableParam(fromErrorBody: body, sentParams: ["reasoning_effort"])
+        == "reasoning_effort")
+  }
+
+  @Test func missingCodeStillQualifies() {
+    // The public API reference does not document the 400 schema; fail open
+    // on an absent code when param + type agree.
+    let body = """
+      {"error": {"message": "'temperature' is not supported.", \
+      "type": "invalid_request_error", "param": "temperature"}}
+      """
+    #expect(
+      OpenAIConnector.strippableParam(fromErrorBody: body, sentParams: ["temperature"])
+        == "temperature")
+  }
+
+  @Test func nullCodeStillQualifies() {
+    let body = """
+      {"error": {"message": "'temperature' is not supported.", \
+      "type": "invalid_request_error", "param": "temperature", "code": null}}
+      """
+    #expect(
+      OpenAIConnector.strippableParam(fromErrorBody: body, sentParams: ["temperature"])
+        == "temperature")
+  }
+
+  @Test func contradictingCodeDisqualifies() {
+    let body = """
+      {"error": {"message": "too long", "type": "invalid_request_error", \
+      "param": "temperature", "code": "context_length_exceeded"}}
+      """
+    #expect(
+      OpenAIConnector.strippableParam(fromErrorBody: body, sentParams: ["temperature"]) == nil)
+  }
+
+  @Test func contradictingTypeDisqualifies() {
+    let body = """
+      {"error": {"message": "nope", "type": "server_error", "param": "temperature", \
+      "code": "unsupported_value"}}
+      """
+    #expect(
+      OpenAIConnector.strippableParam(fromErrorBody: body, sentParams: ["temperature"]) == nil)
+  }
+
+  @Test func paramNotSentDisqualifies() {
+    #expect(
+      OpenAIConnector.strippableParam(
+        fromErrorBody: Self.recordedTemperatureRejection, sentParams: []) == nil)
+  }
+
+  @Test func nonAllowlistedParamDisqualifies() {
+    let body = """
+      {"error": {"message": "bad messages", "type": "invalid_request_error", \
+      "param": "messages", "code": "unsupported_value"}}
+      """
+    #expect(
+      OpenAIConnector.strippableParam(fromErrorBody: body, sentParams: ["messages"]) == nil)
+  }
+
+  @Test func malformedJSONDisqualifies() {
+    #expect(
+      OpenAIConnector.strippableParam(
+        fromErrorBody: "<html>Bad gateway</html>", sentParams: ["temperature"]) == nil)
+  }
+
+  // MARK: - Memo
+
+  @Test func memoRecordsOnceAndPreOmits() {
+    let model = "gpt-4o-memo-test-\(UUID().uuidString)"
+    #expect(OpenAIConnector.memoizedOmissions(model: model).isEmpty)
+    #expect(OpenAIConnector.recordOmission(model: model, param: "temperature"))
+    // Idempotent double-insert: second record is NOT newly learned.
+    #expect(!OpenAIConnector.recordOmission(model: model, param: "temperature"))
+    #expect(OpenAIConnector.memoizedOmissions(model: model) == ["temperature"])
+    OpenAIConnector.resetOmissions(model: model)
+    #expect(OpenAIConnector.memoizedOmissions(model: model).isEmpty)
+  }
+
+  // MARK: - Scripted transport
+
+  private struct PopulatedKeyStore: LegacyKeyFileStorage {
+    func store(key: String, value: String) throws {}
+    func retrieve(key: String) throws -> String { "sk-test-not-a-real-key" }
+    func delete(key: String) throws {}
+  }
+
+  private struct EmptyKeyStore: LegacyKeyFileStorage {
+    func store(key: String, value: String) throws {}
+    func retrieve(key: String) throws -> String {
+      throw KeyStoreError.retrieveFailed(errSecItemNotFound)
+    }
+    func delete(key: String) throws {}
+  }
+
+  private func populatedKeychain() -> KeychainManager {
+    KeychainManager(backend: .legacyFiles, legacyStore: PopulatedKeyStore())
+  }
+
+  private func config(model: String, reasoningEffort: String? = nil) -> LLMProviderConfig {
+    LLMProviderConfig(
+      model: model, apiKeyKeychainId: "openai-api-key", maxTokens: 512,
+      temperature: 0, thinkingBudget: nil, reasoningEffort: reasoningEffort)
+  }
+
+  private static let endpoint = URL(string: "https://api.openai.com/v1/chat/completions")!
+
+  private static func response(_ code: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: endpoint, statusCode: code, httpVersion: nil, headerFields: nil)!
+  }
+
+  private static let successBody = Data(
+    #"{"choices": [{"message": {"content": "Polished."}, "finish_reason": "stop"}]}"#.utf8)
+
+  private static func rejection(param: String) -> Data {
+    Data(
+      """
+      {"error": {"message": "Unsupported value: '\(param)'.", \
+      "type": "invalid_request_error", "param": "\(param)", "code": "unsupported_value"}}
+      """.utf8)
+  }
+
+  /// Scripted executor: pops one result per physical request, records each
+  /// request body. The yield before returning satisfies
+  /// swift-patterns RULE: fake-executor-must-yield-before-throw (the fake
+  /// completes synchronously; production transport always suspends).
+  private final class ScriptedTransport: Sendable {
+    private let state: OSAllocatedUnfairLock<(script: [(Data, HTTPURLResponse)], bodies: [Data])>
+
+    init(script: [(Data, HTTPURLResponse)]) {
+      state = OSAllocatedUnfairLock(initialState: (script: script, bodies: []))
+    }
+
+    var requestCount: Int { state.withLock { $0.bodies.count } }
+
+    func sentBody(_ index: Int) -> [String: Any] {
+      let data = state.withLock { $0.bodies[index] }
+      return (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+
+    func executor() -> OpenAIConnector.RequestExecutor {
+      { request, _ in
+        await Task.yield()
+        return try self.state.withLock { state in
+          state.bodies.append(request.httpBody ?? Data())
+          guard !state.script.isEmpty else {
+            throw URLError(.badServerResponse)
+          }
+          let (data, response) = state.script.removeFirst()
+          return (data, response)
+        }
+      }
+    }
+  }
+
+  private func connector(_ transport: ScriptedTransport) -> OpenAIConnector {
+    OpenAIConnector(keychainManager: populatedKeychain(), requestExecutor: transport.executor())
+  }
+
+  @Test func temperatureRejectionStripsAndSucceedsInTwoRequests() async throws {
+    let model = "gpt-4o-strip-a-\(UUID().uuidString)"
+    defer { OpenAIConnector.resetOmissions(model: model) }
+    let transport = ScriptedTransport(script: [
+      (Self.rejection(param: "temperature"), Self.response(400)),
+      (Self.successBody, Self.response(200)),
+    ])
+
+    let result = try await connector(transport).polish(
+      text: "hello", instructions: .default, config: config(model: model), onToken: nil)
+
+    #expect(result.polishedText == "Polished.")
+    #expect(transport.requestCount == 2)
+    #expect(transport.sentBody(0)["temperature"] as? Double == 0)
+    #expect(transport.sentBody(1)["temperature"] == nil)
+  }
+
+  @Test func doubleRejectionStripsBothParamsInThreeRequests() async throws {
+    let model = "gpt-4o-strip-b-\(UUID().uuidString)"
+    defer { OpenAIConnector.resetOmissions(model: model) }
+    let transport = ScriptedTransport(script: [
+      (Self.rejection(param: "reasoning_effort"), Self.response(400)),
+      (Self.rejection(param: "temperature"), Self.response(400)),
+      (Self.successBody, Self.response(200)),
+    ])
+
+    let result = try await connector(transport).polish(
+      text: "hello", instructions: .default,
+      config: config(model: model, reasoningEffort: "low"), onToken: nil)
+
+    #expect(result.polishedText == "Polished.")
+    #expect(transport.requestCount == 3)
+    #expect(transport.sentBody(2)["temperature"] == nil)
+    #expect(transport.sentBody(2)["reasoning_effort"] == nil)
+  }
+
+  @Test func nonQualifying400ThrowsClassifiedAfterOneRequest() async {
+    let model = "gpt-4o-strip-c-\(UUID().uuidString)"
+    defer { OpenAIConnector.resetOmissions(model: model) }
+    let transport = ScriptedTransport(script: [
+      (Data(#"{"error": {"message": "malformed request"}}"#.utf8), Self.response(400))
+    ])
+
+    do {
+      _ = try await connector(transport).polish(
+        text: "hello", instructions: .default, config: config(model: model), onToken: nil)
+      Issue.record("expected classified badRequest")
+    } catch let LLMError.classified(reason) {
+      #expect(reason == .badRequest)
+    } catch {
+      Issue.record("unexpected error: \(error)")
+    }
+    #expect(transport.requestCount == 1)
+  }
+
+  @Test func secondPolishPreOmitsViaMemoWithoutA400() async throws {
+    let model = "gpt-4o-strip-d-\(UUID().uuidString)"
+    defer { OpenAIConnector.resetOmissions(model: model) }
+    let firstTransport = ScriptedTransport(script: [
+      (Self.rejection(param: "temperature"), Self.response(400)),
+      (Self.successBody, Self.response(200)),
+    ])
+    _ = try await connector(firstTransport).polish(
+      text: "hello", instructions: .default, config: config(model: model), onToken: nil)
+    #expect(firstTransport.requestCount == 2)
+
+    let secondTransport = ScriptedTransport(script: [
+      (Self.successBody, Self.response(200))
+    ])
+    let result = try await connector(secondTransport).polish(
+      text: "again", instructions: .default, config: config(model: model), onToken: nil)
+
+    #expect(result.polishedText == "Polished.")
+    #expect(secondTransport.requestCount == 1)
+    #expect(secondTransport.sentBody(0)["temperature"] == nil)
+  }
+
+  // MARK: - Responses-only preflight (key precedence preserved)
+
+  @Test func responsesOnlyModelWithValidKeyFailsLocallyWithZeroRequests() async {
+    let transport = ScriptedTransport(script: [])
+
+    do {
+      _ = try await connector(transport).polish(
+        text: "hello", instructions: .default, config: config(model: "gpt-5-pro"), onToken: nil)
+      Issue.record("expected classified modelUnavailable")
+    } catch let LLMError.classified(reason) {
+      #expect(reason == .modelUnavailable)
+    } catch {
+      Issue.record("unexpected error: \(error)")
+    }
+    #expect(transport.requestCount == 0)
+  }
+
+  @Test func responsesOnlyModelWithMissingKeyReportsKeyFirst() async {
+    let transport = ScriptedTransport(script: [])
+    let connector = OpenAIConnector(
+      keychainManager: KeychainManager(backend: .legacyFiles, legacyStore: EmptyKeyStore()),
+      requestExecutor: transport.executor())
+
+    do {
+      _ = try await connector.polish(
+        text: "hello", instructions: .default, config: config(model: "gpt-5-pro"), onToken: nil)
+      Issue.record("expected classified apiKeyMissing")
+    } catch let LLMError.classified(reason) {
+      #expect(reason == .apiKeyMissing)
+    } catch {
+      Issue.record("unexpected error: \(error)")
+    }
+    #expect(transport.requestCount == 0)
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/OpenAIRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAIRequestBodyTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 import Testing
 
@@ -24,4 +25,72 @@ struct OpenAIRequestBodyTests {
     let body = LLMModelDiscovery.makeOpenAIProbeRequestBody(modelID: "gpt-5-mini")
     #expect(body["model"] as? String == "gpt-5-mini")
   }
+
+  // MARK: - Polish request body per family (#1330)
+
+  private func config(model: String, reasoningEffort: String? = nil) -> LLMProviderConfig {
+    LLMProviderConfig(
+      model: model, apiKeyKeychainId: "openai-api-key", maxTokens: 512,
+      temperature: 0, thinkingBudget: nil, reasoningEffort: reasoningEffort)
+  }
+
+  private let messages: [[String: String]] = [
+    ["role": "system", "content": "polish"], ["role": "user", "content": "hello"],
+  ]
+
+  @Test func classicModelSendsTemperatureZeroAndNoEffort() {
+    let body = OpenAIConnector.makeRequestBody(
+      config: config(model: "gpt-4o-mini"), messages: messages)
+    #expect(body["temperature"] as? Double == 0)
+    #expect(body["reasoning_effort"] == nil)
+    #expect(body["max_completion_tokens"] as? Int == 512)
+    #expect(body["store"] as? Bool == false)
+  }
+
+  @Test func reasoningModelOmitsTemperatureAndSendsEffort() {
+    let body = OpenAIConnector.makeRequestBody(
+      config: config(model: "gpt-5.6-sol", reasoningEffort: "low"), messages: messages)
+    #expect(body["temperature"] == nil)
+    #expect(body["reasoning_effort"] as? String == "low")
+  }
+
+  @Test func reasoningModelWithoutEffortStillOmitsTemperature() {
+    // The gpt-5.5 evidence: temperature is rejected even when no
+    // reasoning-effort field is present, so omission is unconditional.
+    let body = OpenAIConnector.makeRequestBody(
+      config: config(model: "gpt-5.5"), messages: messages)
+    #expect(body["temperature"] == nil)
+    #expect(body["reasoning_effort"] == nil)
+  }
+
+  @Test func omittingSetRemovesParamsRegardlessOfFamily() {
+    let body = OpenAIConnector.makeRequestBody(
+      config: config(model: "gpt-4o-mini", reasoningEffort: "low"),
+      messages: messages,
+      omitting: ["temperature", "reasoning_effort"])
+    #expect(body["temperature"] == nil)
+    #expect(body["reasoning_effort"] == nil)
+    // Never strippable: the request itself.
+    #expect(body["model"] as? String == "gpt-4o-mini")
+    #expect(body["max_completion_tokens"] as? Int == 512)
+  }
+
+  // MARK: - Discovery candidate predicate (#1330)
+
+  @Test(arguments: ["gpt-5.6-sol", "gpt-5.6-luna", "gpt-4o-mini", "o3", "o4-mini", "gpt-5.5"])
+  func chatCapableModelsAreCandidates(id: String) {
+    #expect(LLMModelDiscovery.isOpenAIChatCompletionCandidate(id))
+  }
+
+  @Test(arguments: [
+    "gpt-5-pro", "gpt-5.5-pro-2026-04-23", "gpt-5-codex",
+    "gpt-4o-realtime-preview", "gpt-4o-audio-preview", "gpt-5-search-api",
+    "gpt-4o-transcribe", "dall-e-3", "text-embedding-3-small",
+  ])
+  func nonCandidatesAreExcluded(id: String) {
+    #expect(!LLMModelDiscovery.isOpenAIChatCompletionCandidate(id))
+  }
+  // Alias ("latest") and version-duplicate ("-001") filtering is
+  // deliberately NOT this predicate's job — `filterModels` owns it for all
+  // providers, so gpt-5-chat-latest is excluded there, not here.
 }


### PR DESCRIPTION
Closes #1330

## What

BYOK OpenAI polish silently failed (HTTP 400, 11/11) on every gpt-5.x model: the connector sent `temperature: 0` unconditionally and recognized reasoning controls only for o1/o3/o4.

- **One capability authority** (`LLMModelCapabilities`, EnviousWisprLLM) owns three independent per-model facts: reasoning support, temperature policy, Chat Completions eligibility. Core's `supportsReasoning` is deleted; the pipeline guard and the Deep-reasoning toggle consume the new authority.
- **Per-family request shape:** classic models keep `temperature: 0`; reasoning-shape models (gpt-5.x incl. the new gpt-5.6 sol/terra/luna, o-series) omit temperature and send `reasoning_effort` low/medium with `defaultMaxTokens` headroom.
- **Self-healing strip-retry:** a 400 naming an allowlisted param we sent (`temperature`/`reasoning_effort`, tolerant of absent `error.code`) strips it and re-issues within the same logical call (same call number; each physical request emits its own task_metrics line via `executeOnce`), memoized per model per process. Future provider drift degrades to one extra round-trip once, instead of silent total feature loss.
- **Deterministic preflight:** Responses-API-only models (`-pro`, codex) throw the model-unavailable notice locally after key retrieval (key-error precedence preserved), zero network. Discovery filters them from the picker via the same authority.

## Validation

- Full suite: 2,842 tests green; new suites: capability matrix, request-body/family fixtures, scripted transport retry sequences (injectable executor, unique-model memo isolation), key-vs-model precedence.
- **All-models live sweep (ship criterion): 45/45 picker-offered models polish successfully with a real key; zero adaptations needed** (static table currently exact); artifacts in the validation run dir.
- Live UAT (wispr-eyes, app.log verdicts): gpt-4o-mini 1.07s / gpt-5.5 1.61s / gpt-5.6-sol 1.64s end-to-end, all status=200.
- Quality regression receipt (gpt-5.4-mini, 302 stratified type-B cases, same judge, same cases): 89.4% pass vs 84.4% recorded reasoning-off baseline; criticals 5 -> 3; median polish 947ms (budget 5s).
- Eval-harness carve-out: no prompt text change, no Python mirror/baseline recapture (polish-eval.md RULE: manual-swift-python-sync).
- Plan: docs/feature-requests/issue-1330-2026-07-11-openai-model-families.md (grounded review r5 PROCEED-AS-PLANNED; audits in docs/audits/).
