### PR TITLE
fix(ui): Settings survives Check for Updates; recording timer stops resetting mid-session

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppWindowCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppWindowCoordinator.swift
@@ -92,12 +92,49 @@ final class AppWindowCoordinator {
   /// toolbar wordmark is the identity). Preferring the scene identifier, with a
   /// blank-title fallback, means titled system dialogs (Sparkle's attended-update
   /// window, save/open panels — all of which carry non-empty titles) never match.
-  private func isMainWindow(_ window: NSWindow) -> Bool {
+  private static func matchesMainWindowIdentity(_ window: NSWindow) -> Bool {
     // The main window carries the app name as its title (visually suppressed by
     // the principal toolbar item, but still set for the Window menu / VoiceOver).
     // Match on it: onboarding ("Setup"), Sparkle's update dialog, and save/open
     // panels all carry different titles, so none is mistaken for the main window.
     window.styleMask.contains(.titled) && window.title == AppConstants.appName
+  }
+
+  private func isMainWindow(_ window: NSWindow) -> Bool {
+    Self.matchesMainWindowIdentity(window)
+  }
+
+  /// #1392: the pure presentation decision, input-driven so it's testable
+  /// without touching real `NSWindow`/`NSApp` state. A window "counts" if it
+  /// matches the main-window identity AND is visible, minimized, or the
+  /// whole app is Cmd+H-hidden — not just currently onscreen. Bare
+  /// `isVisible` alone would revert to accessory (and effectively strand the
+  /// window) if the user minimized Settings or hid the app while an attended
+  /// update check was in flight (#1392 r1 finding).
+  static func isMainWindowPresented(
+    windowStates: [(matchesIdentity: Bool, isVisible: Bool, isMiniaturized: Bool)],
+    appIsHidden: Bool
+  ) -> Bool {
+    windowStates.contains { state in
+      state.matchesIdentity && (state.isVisible || state.isMiniaturized || appIsHidden)
+    }
+  }
+
+  /// #1392: whether the user still has a main app window right now. Static
+  /// and state-free — callers that don't own a window reference (Sparkle's
+  /// attended-update-session-end hook) can check without a new stored
+  /// dependency. Thin snapshot wrapper around the pure decision above; Live
+  /// UAT is what proves this wrapper's real-`NSApp` snapshot is correct.
+  static func isMainWindowPresented() -> Bool {
+    isMainWindowPresented(
+      windowStates: NSApp.windows.map {
+        (
+          matchesIdentity: matchesMainWindowIdentity($0), isVisible: $0.isVisible,
+          isMiniaturized: $0.isMiniaturized
+        )
+      },
+      appIsHidden: NSApp.isHidden
+    )
   }
 
   /// Remove both window-close observers. Called once from

--- a/Sources/EnviousWisprAppKit/App/AppWindowCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppWindowCoordinator.swift
@@ -106,17 +106,27 @@ final class AppWindowCoordinator {
 
   /// #1392: the pure presentation decision, input-driven so it's testable
   /// without touching real `NSWindow`/`NSApp` state. A window "counts" if it
-  /// matches the main-window identity AND is visible, minimized, or the
-  /// whole app is Cmd+H-hidden — not just currently onscreen. Bare
-  /// `isVisible` alone would revert to accessory (and effectively strand the
-  /// window) if the user minimized Settings or hid the app while an attended
-  /// update check was in flight (#1392 r1 finding).
+  /// matches the main-window identity AND is visible or minimized — not just
+  /// currently onscreen. Bare `isVisible` alone would revert to accessory
+  /// (and effectively strand the window) if the user minimized Settings
+  /// while an attended update check was in flight (#1392 r1 finding).
+  ///
+  /// r2 correction (code-diff review): deliberately does NOT also treat
+  /// "the whole app is Cmd+H-hidden" as presence. A window the user already
+  /// closed can still linger in `NSApp.windows` in a hidden-but-retained
+  /// state (SwiftUI single-instance `Window(id:)` scenes may keep the
+  /// underlying `NSWindow` around to support instant reopen); an app-wide
+  /// hidden flag can't distinguish that from a genuinely-still-open window
+  /// the user merely Cmd+H'd. Reverting to accessory while the app is
+  /// Cmd+H-hidden is accepted, documented behavior (Live UAT preface above)
+  /// — the user explicitly hid the whole app, so losing the Dock icon is not
+  /// a regression, and this check only ever needs to protect a window the
+  /// user can currently see or reach via the Dock/minimized state.
   static func isMainWindowPresented(
-    windowStates: [(matchesIdentity: Bool, isVisible: Bool, isMiniaturized: Bool)],
-    appIsHidden: Bool
+    windowStates: [(matchesIdentity: Bool, isVisible: Bool, isMiniaturized: Bool)]
   ) -> Bool {
     windowStates.contains { state in
-      state.matchesIdentity && (state.isVisible || state.isMiniaturized || appIsHidden)
+      state.matchesIdentity && (state.isVisible || state.isMiniaturized)
     }
   }
 
@@ -132,9 +142,7 @@ final class AppWindowCoordinator {
           matchesIdentity: matchesMainWindowIdentity($0), isVisible: $0.isVisible,
           isMiniaturized: $0.isMiniaturized
         )
-      },
-      appIsHidden: NSApp.isHidden
-    )
+      })
   }
 
   /// Remove both window-close observers. Called once from

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -195,9 +195,15 @@ final class DictationLifecycleCoordinator {
   /// current intent, so a redundant identical push is dropped (#930).
   private func showOverlayIntent(_ intent: OverlayIntent) {
     let audioCapture = self.audioCapture
+    // #1393: resolve the active driver the same way `activeTelemetryTarget()`
+    // does, so the overlay's elapsed-time provider reads from whichever
+    // backend is actually recording.
+    let backend = activeCaptureBackend() ?? lastCapturingBackend
+    let driver = backend == .whisperKit ? whisperKitKernelDriver : kernelDriver
     recordingOverlay.show(
       intent: intent,
       audioLevelProvider: { audioCapture.audioLevel },
+      recordingElapsedProvider: { [weak driver] in driver?.recordingElapsedSeconds },
       isRecordingLocked: recordingLockedAccess.get()
     )
   }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -224,6 +224,12 @@ final class RecordingStarter {
     recordingOverlay.show(
       intent: .recording(audioLevel: 0),
       audioLevelProvider: { [audioCapture] in audioCapture.audioLevel },
+      // #1393: this is the FIRST `.recording` overlay push (fires before
+      // `DictationLifecycleCoordinator` sees any state change), so it must
+      // carry the real provider itself — the panel's identical-intent dedup
+      // guard means whatever is passed here is what actually renders for the
+      // whole recording if a later push is a no-op duplicate.
+      recordingElapsedProvider: { [weak active] in active?.recordingElapsedSeconds },
       isRecordingLocked: false
     )
     let pttStart = ContinuousClock.now
@@ -244,9 +250,12 @@ final class RecordingStarter {
       )
       let nsError = error as NSError
       let noMic =
-        nsError.domain == AudioError.errorDomain && nsError.code == AudioError.noBuiltInMicrophoneFound.errorCode
+        nsError.domain == AudioError.errorDomain
+        && nsError.code == AudioError.noBuiltInMicrophoneFound.errorCode
       active.setExternalError(
-        noMic ? "No microphone found. Please connect a microphone." : "Microphone unavailable — try again.")
+        noMic
+          ? "No microphone found. Please connect a microphone."
+          : "Microphone unavailable — try again.")
       return
     }
     guard !Task.isCancelled else {

--- a/Sources/EnviousWisprAppKit/App/LiveRecordingState.swift
+++ b/Sources/EnviousWisprAppKit/App/LiveRecordingState.swift
@@ -2,6 +2,7 @@ import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprPipeline
+import Foundation
 import Observation
 
 /// PR7 of epic #763. Owns the "what is happening with dictation right now"
@@ -70,6 +71,15 @@ final class LiveRecordingState {
   /// the former root state getter.
   var audioLevel: Float {
     audioCapture.audioLevel
+  }
+
+  /// #1393: monotonic elapsed recording time, mirroring `pipelineState`'s
+  /// exact backend-branching shape.
+  var recordingElapsedSeconds: TimeInterval? {
+    if asrManager.activeBackendType == .whisperKit {
+      return whisperKitKernelDriver.recordingElapsedSeconds
+    }
+    return kernelDriver.recordingElapsedSeconds
   }
 
   /// In-flight transcript from the active pipeline. Live fallback in

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -129,6 +129,7 @@ final class RecordingOverlayPanel {
   /// Guards against identical intents to prevent flicker.
   func show(
     intent: OverlayIntent, audioLevelProvider: @escaping () -> Float = { 0 },
+    recordingElapsedProvider: @escaping () -> TimeInterval? = { nil },
     isRecordingLocked: Bool = false
   ) {
     let isRecordingIntent: Bool = if case .recording = intent { true } else { false }
@@ -155,7 +156,9 @@ final class RecordingOverlayPanel {
           .announcement: "Recording started",
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
-      show(audioLevelProvider: audioLevelProvider, isRecordingLocked: isRecordingLocked)
+      show(
+        audioLevelProvider: audioLevelProvider, recordingElapsedProvider: recordingElapsedProvider,
+        isRecordingLocked: isRecordingLocked)
     case .processing(let label):
       NSAccessibility.post(
         element: NSApp.mainWindow as Any,
@@ -317,12 +320,17 @@ final class RecordingOverlayPanel {
 
   // MARK: - Legacy API (internal)
 
-  func show(audioLevelProvider: @escaping () -> Float, isRecordingLocked: Bool = false) {
+  func show(
+    audioLevelProvider: @escaping () -> Float,
+    recordingElapsedProvider: @escaping () -> TimeInterval? = { nil },
+    isRecordingLocked: Bool = false
+  ) {
     if panel != nil {
       // A panel already exists (e.g., "Starting..." polishing panel).
       // Transition to recording — mirrors transitionToPolishing() in reverse.
       transitionToRecording(
-        audioLevelProvider: audioLevelProvider, isRecordingLocked: isRecordingLocked)
+        audioLevelProvider: audioLevelProvider, recordingElapsedProvider: recordingElapsedProvider,
+        isRecordingLocked: isRecordingLocked)
       return
     }
     // Cancel any lingering deferred work from a prior session that wasn't
@@ -344,7 +352,9 @@ final class RecordingOverlayPanel {
     let work = DispatchWorkItem { [weak self] in
       guard let self, self.generation == token else { return }
       self.pendingCreateWork = nil
-      self.createPanel(audioLevelProvider: audioLevelProvider, isRecordingLocked: isRecordingLocked)
+      self.createPanel(
+        audioLevelProvider: audioLevelProvider, recordingElapsedProvider: recordingElapsedProvider,
+        isRecordingLocked: isRecordingLocked)
     }
     pendingCreateWork = work
     DispatchQueue.main.async(execute: work)
@@ -373,13 +383,16 @@ final class RecordingOverlayPanel {
   }
 
   private func createPanel(
-    audioLevelProvider: @escaping () -> Float, isRecordingLocked: Bool = false, y: CGFloat? = nil
+    audioLevelProvider: @escaping () -> Float,
+    recordingElapsedProvider: @escaping () -> TimeInterval? = { nil },
+    isRecordingLocked: Bool = false, y: CGFloat? = nil
   ) {
     guard panel == nil else { return }
 
     lockState.isLocked = isRecordingLocked
     let overlayView = RecordingOverlayView(
       audioLevelProvider: audioLevelProvider,
+      recordingElapsedProvider: recordingElapsedProvider,
       lockState: lockState,
       noticeState: noticeState
     )
@@ -633,7 +646,9 @@ final class RecordingOverlayPanel {
   /// Mirrors transitionToPolishing() — tears down the current panel and creates
   /// a recording panel at the same position on the next run loop cycle.
   private func transitionToRecording(
-    audioLevelProvider: @escaping () -> Float, isRecordingLocked: Bool = false
+    audioLevelProvider: @escaping () -> Float,
+    recordingElapsedProvider: @escaping () -> TimeInterval? = { nil },
+    isRecordingLocked: Bool = false
   ) {
     guard let existingPanel = panel else { return }
     clearRecordingNotice()  // #1060 (Codex P3): fresh session starts with no stale notice.
@@ -657,7 +672,8 @@ final class RecordingOverlayPanel {
       guard let self, self.generation == token else { return }
       self.pendingCreateWork = nil
       self.createPanel(
-        audioLevelProvider: audioLevelProvider, isRecordingLocked: isRecordingLocked)
+        audioLevelProvider: audioLevelProvider, recordingElapsedProvider: recordingElapsedProvider,
+        isRecordingLocked: isRecordingLocked)
     }
     pendingCreateWork = work
     DispatchQueue.main.async(execute: work)
@@ -1184,13 +1200,15 @@ private struct DistressCapsuleBackground: View {
 /// Compact recording indicator overlay.
 struct RecordingOverlayView: View {
   let audioLevelProvider: () -> Float
+  /// #1393: monotonic elapsed recording time, read from the shared kernel
+  /// source of truth instead of a per-view-instance stamp — a panel-recreate
+  /// (e.g. `transitionToRecording`) must not reset the displayed timer.
+  let recordingElapsedProvider: () -> TimeInterval?
   var lockState: OverlayLockState
   /// #1060: transient notice banner shown inside the recording capsule.
   var noticeState: OverlayNoticeState
   @State private var audioLevel: Float = 0
   @State private var elapsed: TimeInterval = 0
-
-  private let startTime = Date()
 
   var body: some View {
     VStack(spacing: 6) {
@@ -1231,7 +1249,7 @@ struct RecordingOverlayView: View {
     .task {
       while !Task.isCancelled {
         audioLevel = audioLevelProvider()
-        elapsed = Date().timeIntervalSince(startTime)
+        elapsed = recordingElapsedProvider() ?? 0
         try? await Task.sleep(for: .milliseconds(50))
       }
     }

--- a/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
@@ -134,8 +134,13 @@ extension SparkleUpdateController: @preconcurrency SPUStandardUserDriverDelegate
     NSApp.activate()
   }
 
-  /// Return to accessory mode when the entire update session ends.
+  /// Return to accessory mode when the entire update session ends — but only
+  /// if the user doesn't still have a main app window open (#1392). This
+  /// hook fires on every attended-check outcome (dismissed, error, or an
+  /// update found), so an unconditional revert here would take Settings down
+  /// with it whenever the user checked for updates from inside it.
   func standardUserDriverWillFinishUpdateSession() {
+    guard !AppWindowCoordinator.isMainWindowPresented() else { return }
     NSApp.setActivationPolicy(.accessory)
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
@@ -16,7 +16,6 @@ struct StatusView: View {
   @Environment(DictationRuntime.self) private var dictationRuntime
   @Environment(\.asrManager) private var asrManagerEnv
   @State private var elapsed: TimeInterval = 0
-  @State private var recordingStart: Date?
 
   /// Force-unwrapped: `EnviousWisprApp` always injects a real instance into the
   /// environment (see `AppEnvironmentKeys.swift`).
@@ -187,16 +186,12 @@ struct StatusView: View {
     .animation(.easeInOut(duration: 0.3), value: liveRecordingState.pipelineState)
     .task(id: liveRecordingState.pipelineState == .recording) {
       guard liveRecordingState.pipelineState == .recording else {
-        recordingStart = nil
+        elapsed = 0
         return
       }
-      elapsed = 0
-      recordingStart = Date()
       while !Task.isCancelled {
+        elapsed = liveRecordingState.recordingElapsedSeconds ?? 0
         try? await Task.sleep(for: .seconds(1))
-        if let start = recordingStart {
-          elapsed = Date().timeIntervalSince(start)
-        }
       }
     }
   }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -616,6 +616,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       interruptionCause: kernel.lastAudioInterruptionCause)
   }
 
+  /// #1393: the pipeline's own single source of truth for monotonic elapsed
+  /// recording time. `nil` outside an active/just-finished session.
+  public var recordingElapsedSeconds: TimeInterval? { kernel.recordingElapsedSeconds }
+
   /// The transcript the `store` closure built for the last completed session.
   public var currentTranscript: Transcript? { outcome.transcript }
 

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -354,7 +354,7 @@ final class RecordingSessionKernel {
   /// must not pad accidental taps past the discard threshold.
   private var recordingStartedAtTick: UInt64?
 
-  /// #1393: monotonic elapsed time since the current recording began, immune
+  /// #1393: monotonic elapsed time since the CURRENT recording began, immune
   /// to wall-clock/timezone/NTP changes. Reuses `recordingStartedAtTick`
   /// above rather than adding a second monotonic authority — same stamp
   /// site, same clear site, same "visible-recording start" semantic the
@@ -364,8 +364,19 @@ final class RecordingSessionKernel {
   /// quantization), but a broken or adversarially-injected clock should fail
   /// to `0` for this newly user-facing value, not silently wrap into a huge
   /// duration.
+  ///
+  /// Gated on `state == .recording` (cloud review P2, PR #1507): the overlay
+  /// panel's FIRST `.recording` push (`RecordingStarter.start()`) installs
+  /// its provider before `start(config:)` ever runs — while `.recording` is
+  /// still `recordingStartedAtTick` from the PRIOR session, not yet cleared
+  /// by this session's `resetSessionState()`. Without this gate, a second
+  /// PTT press would briefly render the previous recording's stale elapsed
+  /// time during prewarm instead of `0:00`. Both StatusView and the overlay
+  /// already independently gate their OWN reads on `pipelineState ==
+  /// .recording`, so this is redundant-but-safe for them and is the actual
+  /// fix for the two overlay call sites that read before that guard exists.
   var recordingElapsedSeconds: TimeInterval? {
-    guard let start = recordingStartedAtTick else { return nil }
+    guard state == .recording, let start = recordingStartedAtTick else { return nil }
     let now = currentTick()
     guard now >= start else { return 0 }
     return TimeInterval(now - start) * KernelFinalizationWiring.tickDurationSeconds

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -354,6 +354,23 @@ final class RecordingSessionKernel {
   /// must not pad accidental taps past the discard threshold.
   private var recordingStartedAtTick: UInt64?
 
+  /// #1393: monotonic elapsed time since the current recording began, immune
+  /// to wall-clock/timezone/NTP changes. Reuses `recordingStartedAtTick`
+  /// above rather than adding a second monotonic authority — same stamp
+  /// site, same clear site, same "visible-recording start" semantic the
+  /// discard gate already relies on. Checked comparison, not wrapping
+  /// subtraction: production `currentTick()` cannot realistically regress
+  /// below `start` (monotonic `systemUptime`, same-process, non-decreasing
+  /// quantization), but a broken or adversarially-injected clock should fail
+  /// to `0` for this newly user-facing value, not silently wrap into a huge
+  /// duration.
+  var recordingElapsedSeconds: TimeInterval? {
+    guard let start = recordingStartedAtTick else { return nil }
+    let now = currentTick()
+    guard now >= start else { return 0 }
+    return TimeInterval(now - start) * KernelFinalizationWiring.tickDurationSeconds
+  }
+
   /// Logical-tick value at the `→ stopping` transition (PR-4.5 #4, Codex r1).
   /// The visible-recording elapsed used by the #4 discard gate is computed
   /// as `(stoppingStartedAtTick - recordingStartedAtTick)`, NOT against

--- a/Tests/EnviousWisprTests/App/AppWindowCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/AppWindowCoordinatorTests.swift
@@ -121,17 +121,18 @@ struct AppWindowCoordinatorTests {
     #expect(dismissedCount == 1, "close fires the icon-refresh seam exactly once")
   }
 
-  // MARK: - #1392: isMainWindowPresented(windowStates:appIsHidden:)
+  // MARK: - #1392: isMainWindowPresented(windowStates:)
 
   /// Input-driven pure decision — no real `NSWindow`/`NSApp` state, matching
   /// this suite's existing convention (real window-server behavior is Live
-  /// UAT-only, per the file header above).
+  /// UAT-only, per the file header above). r2 (code-diff review): dropped
+  /// the app-hidden broadening a stale/closed-but-retained window could
+  /// exploit — presence is `isVisible || isMiniaturized` only now.
 
   @Test("matching visible window is presented")
   func isMainWindowPresentedTrueForVisible() {
     let present = AppWindowCoordinator.isMainWindowPresented(
-      windowStates: [(matchesIdentity: true, isVisible: true, isMiniaturized: false)],
-      appIsHidden: false
+      windowStates: [(matchesIdentity: true, isVisible: true, isMiniaturized: false)]
     )
     #expect(present)
   }
@@ -139,35 +140,34 @@ struct AppWindowCoordinatorTests {
   @Test("matching minimized window is still presented — #1392 r1 finding")
   func isMainWindowPresentedTrueForMinimized() {
     let present = AppWindowCoordinator.isMainWindowPresented(
-      windowStates: [(matchesIdentity: true, isVisible: false, isMiniaturized: true)],
-      appIsHidden: false
+      windowStates: [(matchesIdentity: true, isVisible: false, isMiniaturized: true)]
     )
     #expect(present, "a minimized window still exists — isVisible alone is the wrong proxy")
   }
 
-  @Test("matching window counts as presented while the whole app is Cmd+H-hidden")
-  func isMainWindowPresentedTrueWhenAppHidden() {
+  @Test("a matching but neither-visible-nor-minimized window is not presented — #1392 r2 finding")
+  func isMainWindowPresentedFalseForHiddenNotMinimized() {
+    // Covers a stale/closed-but-retained `NSWindow` still enumerable in
+    // `NSApp.windows`: it must never count as presented on its own, even
+    // though a real app-hide would ALSO put a genuinely-open window in this
+    // exact (isVisible: false, isMiniaturized: false) shape — that's the
+    // accepted tradeoff (Live UAT preface above), not a regression.
     let present = AppWindowCoordinator.isMainWindowPresented(
-      windowStates: [(matchesIdentity: true, isVisible: false, isMiniaturized: false)],
-      appIsHidden: true
+      windowStates: [(matchesIdentity: true, isVisible: false, isMiniaturized: false)]
     )
-    #expect(present)
+    #expect(!present)
   }
 
   @Test("no matching window in the list is not presented")
   func isMainWindowPresentedFalseWhenAbsent() {
-    let present = AppWindowCoordinator.isMainWindowPresented(
-      windowStates: [],
-      appIsHidden: false
-    )
+    let present = AppWindowCoordinator.isMainWindowPresented(windowStates: [])
     #expect(!present)
   }
 
   @Test("only a non-matching window (Sparkle's dialog) present is not presented")
   func isMainWindowPresentedFalseForNonMatchingOnly() {
     let present = AppWindowCoordinator.isMainWindowPresented(
-      windowStates: [(matchesIdentity: false, isVisible: true, isMiniaturized: false)],
-      appIsHidden: false
+      windowStates: [(matchesIdentity: false, isVisible: true, isMiniaturized: false)]
     )
     #expect(!present, "a titled-but-differently-named window (Sparkle's dialog) must not count")
   }

--- a/Tests/EnviousWisprTests/App/AppWindowCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/AppWindowCoordinatorTests.swift
@@ -120,4 +120,55 @@ struct AppWindowCoordinatorTests {
     coordinator.closeOnboardingWindow()
     #expect(dismissedCount == 1, "close fires the icon-refresh seam exactly once")
   }
+
+  // MARK: - #1392: isMainWindowPresented(windowStates:appIsHidden:)
+
+  /// Input-driven pure decision — no real `NSWindow`/`NSApp` state, matching
+  /// this suite's existing convention (real window-server behavior is Live
+  /// UAT-only, per the file header above).
+
+  @Test("matching visible window is presented")
+  func isMainWindowPresentedTrueForVisible() {
+    let present = AppWindowCoordinator.isMainWindowPresented(
+      windowStates: [(matchesIdentity: true, isVisible: true, isMiniaturized: false)],
+      appIsHidden: false
+    )
+    #expect(present)
+  }
+
+  @Test("matching minimized window is still presented — #1392 r1 finding")
+  func isMainWindowPresentedTrueForMinimized() {
+    let present = AppWindowCoordinator.isMainWindowPresented(
+      windowStates: [(matchesIdentity: true, isVisible: false, isMiniaturized: true)],
+      appIsHidden: false
+    )
+    #expect(present, "a minimized window still exists — isVisible alone is the wrong proxy")
+  }
+
+  @Test("matching window counts as presented while the whole app is Cmd+H-hidden")
+  func isMainWindowPresentedTrueWhenAppHidden() {
+    let present = AppWindowCoordinator.isMainWindowPresented(
+      windowStates: [(matchesIdentity: true, isVisible: false, isMiniaturized: false)],
+      appIsHidden: true
+    )
+    #expect(present)
+  }
+
+  @Test("no matching window in the list is not presented")
+  func isMainWindowPresentedFalseWhenAbsent() {
+    let present = AppWindowCoordinator.isMainWindowPresented(
+      windowStates: [],
+      appIsHidden: false
+    )
+    #expect(!present)
+  }
+
+  @Test("only a non-matching window (Sparkle's dialog) present is not presented")
+  func isMainWindowPresentedFalseForNonMatchingOnly() {
+    let present = AppWindowCoordinator.isMainWindowPresented(
+      windowStates: [(matchesIdentity: false, isVisible: true, isMiniaturized: false)],
+      appIsHidden: false
+    )
+    #expect(!present, "a titled-but-differently-named window (Sparkle's dialog) must not count")
+  }
 }

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -48,6 +48,22 @@ struct LiveRecordingStateTests {
     #expect(state.pipelineState == .error("wk-marker"))
   }
 
+  @Test(
+    "recordingElapsedSeconds routes through asrManager.activeBackendType, mirroring pipelineState")
+  func recordingElapsedSecondsRoutesByBackend() {
+    let state = makeState()
+    // #1393: same routing shape as `pipelineState` above. Both drivers stay
+    // at `.idle` here (real FSM-driven `.recording` transitions are Live
+    // UAT territory per this file's own header comment, same limitation
+    // `pipelineState`'s own "recording" case has), so both branches read
+    // `nil` — this proves the routing selects the right driver's property
+    // without crashing, not a distinguishing nonzero value.
+    state.asrManager.setInitialBackendType(.parakeet)
+    #expect(state.recordingElapsedSeconds == nil)
+    state.asrManager.setInitialBackendType(.whisperKit)
+    #expect(state.recordingElapsedSeconds == nil)
+  }
+
   @Test("audioLevel reads through the audioCapture existential")
   func audioLevelReadsAudioCapture() {
     let audio = SettableAudioCapture()

--- a/Tests/EnviousWisprTests/Architecture/LiveRecordingStateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/LiveRecordingStateCeilingsTests.swift
@@ -66,13 +66,22 @@ import Testing
       """)
   }
 
+  // #1393: raised 100 → 120 for `recordingElapsedSeconds` (a computed
+  // property mirroring `pipelineState`'s existing branch shape, exposing the
+  // kernel's own monotonic elapsed-recording value so `StatusView` and the
+  // recording overlay stop each stamping their own per-view clock — the
+  // #1393 timer-reset-on-History-tab root cause) plus the `Foundation`
+  // import that property's `TimeInterval` return type needs. No new
+  // collaborator, no new `func` (still a computed property, count stays 0
+  // per `nonPrivateMethodCount` above); only the paper-line ceiling moves.
+  // Deterministic rule: actual 109 + 10 → round up to nearest 5 = 120.
   @Test func lineCountCeiling() throws {
     let source = try CeilingsTestSupport.source(at: Self.sourcePath)
     let count = CeilingsTestSupport.lineCount(in: source)
     #expect(
-      count <= 100,
+      count <= 120,
       """
-      LiveRecordingState line count exceeded: \(count) > 100. \
+      LiveRecordingState line count exceeded: \(count) > 120. \
       Ratchet down if implementation came in lower; raise only via Bible §30.
       """)
   }
@@ -83,7 +92,7 @@ import Testing
     let allowed: Set<String> = [
       "EnviousWisprASR", "EnviousWisprAudio",
       "EnviousWisprCore", "EnviousWisprPipeline",
-      "Observation",
+      "Foundation", "Observation",
     ]
     let extras = actual.subtracting(allowed)
     #expect(

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -110,10 +110,20 @@ import Testing
     // bail on a raced engine (mirrors the existing recovery re-check). Two bare
     // `let entryBackend` captures + two guard blocks; no new collaborator (count
     // stays ≤ 7). Deterministic rule: actual 503 + 10 → round up to nearest 5 = 515.
+    // #1393: raised 515 → 535 for the `recordingElapsedProvider` argument (and
+    // its explanatory comment) on the recording overlay's FIRST `.recording`
+    // push — this call site runs before `DictationLifecycleCoordinator` ever
+    // sees a state change, so it must carry the real elapsed-time provider
+    // itself or the panel's identical-intent dedup guard would leave the
+    // floating pill stuck on the default `nil` provider for the whole
+    // recording (the #1393 timer-reset bug, second instance, found by Codex
+    // Grounded Review round 1). No new collaborator or method; only the
+    // paper-line ceiling moves. Deterministic rule: actual 522 + 10 → round
+    // up to nearest 5 = 535.
     #expect(
-      count <= 515,
+      count <= 535,
       """
-      RecordingStarter line count exceeded: \(count) > 515. \
+      RecordingStarter line count exceeded: \(count) > 535. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -104,6 +104,18 @@ import Testing
     #expect(h.driver.state == .recording)
   }
 
+  @Test("recordingElapsedSeconds passes through the kernel's value")
+  func recordingElapsedSecondsPassesThrough() async throws {
+    let h = makeDriver()
+    #expect(h.driver.recordingElapsedSeconds == nil, "idle → nil, matching the kernel directly")
+
+    try await h.driver.handle(event: .toggleRecording(.testDefault()))
+    await drainUntil { h.kernel.state == .recording }
+
+    #expect(h.driver.recordingElapsedSeconds != nil)
+    #expect(h.driver.recordingElapsedSeconds == h.kernel.recordingElapsedSeconds)
+  }
+
   @Test("handle(.toggleRecording) while recording requests a stop")
   func toggleRecordingWhileActiveStops() async throws {
     let h = makeDriver()

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -235,6 +235,99 @@ import Testing
       #expect(kernel.deliveredTranscript == "raw asr text")
       #expect(kernel.pasteCount == 1)
     }
+
+    // MARK: #1393 — recordingElapsedSeconds (reuses recordingStartedAtTick)
+
+    @Test("recordingElapsedSeconds is nil before recording begins")
+    func recordingElapsedSecondsNilBeforeRecording() async {
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      #expect(kernel.state == .idle)
+      #expect(kernel.recordingElapsedSeconds == nil)
+    }
+
+    @Test("recordingElapsedSeconds is near-zero immediately at the recording transition")
+    func recordingElapsedSecondsNearZeroAtTransition() async {
+      let (_, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await apply(.start, to: wrapper)
+      #expect(kernel.state == .recording)
+      #expect(kernel.recordingElapsedSeconds == 0)
+    }
+
+    @Test("recordingElapsedSeconds advances by exactly tickDelta × tickDurationSeconds")
+    func recordingElapsedSecondsAdvancesByExactTickDelta() async {
+      let (context, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await apply(.start, to: wrapper)
+      #expect(kernel.state == .recording)
+
+      context.clock.advance(by: 30)  // 30 ticks × 0.1s = 3.0s
+      #expect(kernel.recordingElapsedSeconds == 3.0)
+
+      context.clock.advance(by: 20)  // +20 ticks = 5.0s total
+      #expect(kernel.recordingElapsedSeconds == 5.0)
+    }
+
+    @Test("recordingElapsedSeconds preserves the same origin throughout one session")
+    func recordingElapsedSecondsPreservesOriginThroughoutSession() async {
+      let (context, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await apply(.start, to: wrapper)
+      context.clock.advance(by: 10)
+      let firstReading = kernel.recordingElapsedSeconds
+
+      // Reading twice in a row (no state change, no new session) must not
+      // re-stamp the origin — this is the r2/r3 characterization of the exact
+      // per-view reset bug #1393 fixes, asserted at the kernel level.
+      let secondReading = kernel.recordingElapsedSeconds
+      #expect(firstReading == secondReading)
+      #expect(firstReading == 1.0)  // 10 ticks × 0.1s
+    }
+
+    @Test("recordingElapsedSeconds returns to nil after the next session's reset")
+    func recordingElapsedSecondsNilAfterNextSessionReset() async {
+      let (context, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      await apply(.start, to: wrapper)
+      context.clock.advance(by: 10)
+      #expect(kernel.recordingElapsedSeconds != nil)
+
+      await apply(.cancel, to: wrapper)  // recording → cancelled (terminal)
+      await apply(.reset, to: wrapper)  // cancelled → idle
+      #expect(kernel.state == .idle)
+      // `resetSessionState()` (which clears `recordingStartedAtTick`) runs
+      // from `start(config:)`, not from `.reset` — the value deliberately
+      // stays set through the prior session's terminal + `.reset` (matches
+      // `recordingStartedAtDate`'s existing lifecycle, both consumers only
+      // ever read while `pipelineState == .recording` so this is never
+      // observed as wrong). Assert that instead of a premature nil.
+      #expect(
+        kernel.recordingElapsedSeconds != nil, "value persists until the NEXT session's start")
+
+      // A fresh session starts its own origin at zero again, not carrying
+      // the prior session's elapsed time forward.
+      await apply(.start, to: wrapper)
+      #expect(kernel.recordingElapsedSeconds == 0)
+    }
+
+    // Note: the r3 checked-comparison guard (`guard now >= start else { return
+    // 0 }`) protects against a broken/adversarially-injected clock returning a
+    // tick below the stamped start. This is not exercised here: the shared
+    // `FakeClock` this suite (and the wider simulator harness) depends on is
+    // intentionally monotonic-only (`advance(by:)`, no way to move backward),
+    // and Codex Grounded Review round 3 confirmed no production path can
+    // regress `currentTick()` below `recordingStartedAtTick` either (monotonic
+    // `systemUptime`, same-process, non-decreasing quantization). Adding
+    // backward-clock capability to the shared `FakeClock` for this one
+    // defensive-only branch was judged disproportionate; the guard's
+    // correctness is covered by code inspection (Grounded Review r3) instead
+    // of an automated test.
   }
 
 #endif  // DEBUG (RecordingSessionKernel FSM-invariant tests — testForceTransition / testActiveTaskCount hooks)

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -289,8 +289,10 @@ import Testing
       #expect(firstReading == 1.0)  // 10 ticks × 0.1s
     }
 
-    @Test("recordingElapsedSeconds returns to nil after the next session's reset")
-    func recordingElapsedSecondsNilAfterNextSessionReset() async {
+    @Test(
+      "recordingElapsedSeconds goes nil the instant state leaves .recording, and a fresh session starts at zero"
+    )
+    func recordingElapsedSecondsNilOutsideRecordingAndFreshOnNextStart() async {
       let (context, wrapper) = makeWrapper()
       let kernel = wrapper.testKernel
 
@@ -298,17 +300,19 @@ import Testing
       context.clock.advance(by: 10)
       #expect(kernel.recordingElapsedSeconds != nil)
 
+      // r2 (cloud review P2, PR #1507): gated on `state == .recording`, not
+      // merely on `recordingStartedAtTick` being set. `recordingStartedAtTick`
+      // itself still isn't cleared until the NEXT session's `start(config:)`
+      // (unchanged internal lifecycle — the discard gate at `:2247`/`:2660`
+      // still needs it), but the PUBLIC `recordingElapsedSeconds` value now
+      // correctly goes nil the moment state leaves `.recording`, closing the
+      // exact stale-value window the overlay's first pill push could hit.
       await apply(.cancel, to: wrapper)  // recording → cancelled (terminal)
+      #expect(kernel.recordingElapsedSeconds == nil, "gated on .recording, not on the raw tick")
+
       await apply(.reset, to: wrapper)  // cancelled → idle
       #expect(kernel.state == .idle)
-      // `resetSessionState()` (which clears `recordingStartedAtTick`) runs
-      // from `start(config:)`, not from `.reset` — the value deliberately
-      // stays set through the prior session's terminal + `.reset` (matches
-      // `recordingStartedAtDate`'s existing lifecycle, both consumers only
-      // ever read while `pipelineState == .recording` so this is never
-      // observed as wrong). Assert that instead of a premature nil.
-      #expect(
-        kernel.recordingElapsedSeconds != nil, "value persists until the NEXT session's start")
+      #expect(kernel.recordingElapsedSeconds == nil)
 
       // A fresh session starts its own origin at zero again, not carrying
       // the prior session's elapsed time forward.


### PR DESCRIPTION
## Summary
- **#1392** — clicking "Check for Updates" in Settings no longer closes the Settings window. The Sparkle delegate hook that ends every attended-check session (regardless of outcome) now checks whether a main app window is still presented (visible or minimized) before reverting the app to menu-bar-only mode, instead of doing so unconditionally.
- **#1393** — the recording timer no longer resets to zero when opening the History tab mid-recording (or on a floating-pill panel recreate). Both the main window and the recording overlay now read elapsed time from the recording engine's own existing monotonic tick-based clock instead of each stamping a private per-view "start" timestamp.

Both are small, independent, real early-adopter (Reddit/MacApps) bug reports, bundled into one release. Full process: council coverage review (2 rounds) → Codex Grounded Review on the plan (5 rounds to PROCEED-AS-PLANNED, including a design change from a proposed new monotonic stamp to reusing the kernel's existing tick authority) → local Codex code-diff review on the implementation (2 rounds to clean, one real P2 finding fixed) → full logic-test suite (2824 tests) → Live UAT on the rebuilt dev app for both fixes.

## Test plan
- [x] Full Xcode logic-test suite green (2824 tests, `scripts/xcode-test.sh`)
- [x] New unit tests: `AppWindowCoordinatorTests` (5 cases for the presented-window decision), `RecordingSessionKernelTests` (5 cases for `recordingElapsedSeconds`), `KernelDictationDriverTests` (1 passthrough case), `LiveRecordingStateTests` (1 routing case)
- [x] Local Codex code-diff review clean (2 rounds)
- [x] Live UAT: Settings survives dismissing Sparkle's dialog after "Check for Updates"
- [x] Live UAT: recording timer correctly shows real elapsed time (not reset) on both the floating pill and the main window's History tab, opened mid-recording