### PR TITLE
refactor(audio): move dead-air classifier to Core, add stall failure-mode field

### DIFF
--- a/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
+++ b/Sources/EnviousWisprAudio/AVAudioEngineSource.swift
@@ -515,7 +515,8 @@ final class AVAudioEngineSource: AudioInputSource {
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: preferredInputDeviceIDOverride.isEmpty
         ? nil : preferredInputDeviceIDOverride,
-      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+      failureMode: .noBuffers
     )
     onCaptureStalled?(ctx)
   }

--- a/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
+++ b/Sources/EnviousWisprAudio/AVCaptureSessionSource.swift
@@ -380,7 +380,8 @@ final class AVCaptureSessionSource: AudioInputSource {
       tapInstalled: true,
       formatMismatchObserved: delegate?.didObserveFormatMismatch ?? false,
       inputDeviceUIDPreferred: nil,
-      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID()
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+      failureMode: .noBuffers
     )
     onCaptureStalled?(ctx)
   }

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -406,6 +406,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       inputDeviceUIDPreferred: preferredInputDeviceIDOverride.isEmpty
         ? nil : preferredInputDeviceIDOverride,
       inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+      failureMode: .noBuffers,
       selectedTransport: currentResolvedRoute?.selected,
       effectiveTransport: currentResolvedRoute?.effective,
       routeReason: currentResolvedRoute?.routeReason,

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -710,6 +710,7 @@ final class HALDeviceInputSource: AudioInputSource {
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: targetDeviceUID,
       inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+      failureMode: .noBuffers,
       // #1434: the stall fires BEFORE stopCapture(), so the source stamps its
       // own live rate/divergence here — the stop-time metadata object does
       // not exist yet. (The XPC proxy's host-side watchdog leaves these nil.)

--- a/Sources/EnviousWisprCore/CaptureStallContext.swift
+++ b/Sources/EnviousWisprCore/CaptureStallContext.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+/// Discriminates why a capture-stall watchdog fired. `.noBuffers` is today's
+/// only producer (no audio buffers arrived before the watchdog window
+/// elapsed); `.allZeroFromStart` and `.becameZeroMidCapture` are added by
+/// #1317 PR2 for the "device running but feeding all-zero audio" harness
+/// glitch, distinct from a genuinely dead/muted/removed device. String-backed
+/// so the raw value doubles as the Sentry wire value — `.noBuffers` keeps
+/// today's literal string (`"stall_window_elapsed"`) so PR1 introduces zero
+/// telemetry change.
+public enum CaptureStallFailureMode: String, Sendable, Hashable {
+  case noBuffers = "stall_window_elapsed"
+  case allZeroFromStart = "all_zero_from_start"
+  case becameZeroMidCapture = "became_zero_mid_capture"
+}
+
 /// Context attached to a stalled-capture telemetry event. Built by an audio
 /// source (`AVAudioEngineSource`, `AVCaptureSessionSource`, or `AudioCaptureProxy`)
 /// at watchdog-fire time and consumed by the pipeline's emission site.
@@ -17,6 +31,10 @@ public struct CaptureStallContext: Sendable {
   public let formatMismatchObserved: Bool
   public let inputDeviceUIDPreferred: String?
   public let inputDeviceUIDSystemDefault: String?
+  /// Why the watchdog fired. Required (no default) so every producer states
+  /// it explicitly and the compiler catches a missed site when a new failure
+  /// mode is added (#1317).
+  public let failureMode: CaptureStallFailureMode
   // #1376: resolved-route transports, populated where the resolver decision is
   // available (the XPC proxy stall path). The direct-source stall paths leave
   // these nil. Low-cardinality transport/reason strings; no PII.
@@ -50,6 +68,7 @@ public struct CaptureStallContext: Sendable {
     formatMismatchObserved: Bool,
     inputDeviceUIDPreferred: String?,
     inputDeviceUIDSystemDefault: String?,
+    failureMode: CaptureStallFailureMode,
     selectedTransport: String? = nil,
     effectiveTransport: String? = nil,
     routeReason: String? = nil,
@@ -72,6 +91,7 @@ public struct CaptureStallContext: Sendable {
     self.formatMismatchObserved = formatMismatchObserved
     self.inputDeviceUIDPreferred = inputDeviceUIDPreferred
     self.inputDeviceUIDSystemDefault = inputDeviceUIDSystemDefault
+    self.failureMode = failureMode
     self.selectedTransport = selectedTransport
     self.effectiveTransport = effectiveTransport
     self.routeReason = routeReason
@@ -103,6 +123,7 @@ public struct CaptureStallContext: Sendable {
       formatMismatchObserved: formatMismatchObserved,
       inputDeviceUIDPreferred: inputDeviceUIDPreferred,
       inputDeviceUIDSystemDefault: inputDeviceUIDSystemDefault,
+      failureMode: failureMode,
       selectedTransport: selectedTransport,
       effectiveTransport: effectiveTransport,
       routeReason: routeReason,

--- a/Sources/EnviousWisprCore/RawAudioDeadAirClassifier.swift
+++ b/Sources/EnviousWisprCore/RawAudioDeadAirClassifier.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Shared dead-air (no recoverable speech) classifier for raw capture audio.
+/// Moved out of `RecordingSessionKernel` (#1317 PR1) so `EnviousWisprAudio`'s
+/// app-side all-zero detector and the kernel's own `#964` no-speech gate read
+/// the same authority instead of two independent implementations drifting
+/// apart.
+public enum RawAudioDeadAirClassifier {
+  /// Empirical dead-air energy thresholds for the #964 no-speech gate. See
+  /// `isDeadAir`. Deliberately LOW — these reject only genuine silence, not
+  /// an audible-but-faint utterance (measured -35 dB room noise peaks at
+  /// 0.0178, above a real whisper at 0.0109, so signal level alone can't
+  /// split faint speech from noise — Parakeet is the arbiter past this
+  /// floor).
+  public enum DeadAirFloor {
+    /// Peak absolute amplitude (linear, Float32). ~ -44 dBFS.
+    public static let peak: Float = 0.006
+    /// Whole-buffer RMS.
+    public static let rms: Float = 0.00125
+    /// Loudest 40 ms window RMS — catches a faint word inside a mostly-silent
+    /// buffer where the whole-buffer RMS stays low.
+    public static let windowRms: Float = 0.002
+    /// 40 ms at 16 kHz.
+    public static let windowSamples = 640
+  }
+
+  /// True when a raw capture buffer is dead air (no recoverable speech) for
+  /// the #964 gate: when Silero reports zero segments the kernel skips ASR
+  /// ONLY if the raw audio is also below every `DeadAirFloor` threshold.
+  /// Otherwise it falls through and lets Parakeet decide. Pure + static so
+  /// the boundary cases (just-below / just-above each threshold) unit-test
+  /// without a kernel.
+  public static func isDeadAir(_ samples: [Float], peak: Float) -> Bool {
+    guard peak < DeadAirFloor.peak else { return false }
+    guard !samples.isEmpty else { return true }
+    var sumSquares: Float = 0
+    for s in samples { sumSquares += s * s }
+    let rms = (sumSquares / Float(samples.count)).squareRoot()
+    guard rms < DeadAirFloor.rms else { return false }
+    // Loudest non-overlapping 40 ms window. A faint word lifts a local
+    // window's RMS even when most of the buffer is silence around it; tiled
+    // windows keep this bounded at O(n).
+    let window = DeadAirFloor.windowSamples
+    guard samples.count >= window else { return rms < DeadAirFloor.windowRms }
+    var maxWindowRms = rms
+    var i = 0
+    while i + window <= samples.count {
+      var ss: Float = 0
+      for j in i..<(i + window) { ss += samples[j] * samples[j] }
+      let wr = (ss / Float(window)).squareRoot()
+      if wr > maxWindowRms { maxWindowRms = wr }
+      i += window
+    }
+    return maxWindowRms < DeadAirFloor.windowRms
+  }
+}

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -54,10 +54,12 @@ final class HeartPathTelemetryEmitter {
 
   // MARK: - Per-session dedup state
 
-  /// One Sentry event per wedge incident even though the stall watchdog and
-  /// the rawSamples-empty branch both observe the same session. Reset on
-  /// session-id change.
-  private var stallEventAlreadyCaptured: Bool = false
+  /// One Sentry event per (session, failure mode) even though the stall
+  /// watchdog and the rawSamples-empty branch both observe the same session.
+  /// A `Set` (not a single Bool, #1317 PR1) so a later failure mode for the
+  /// same session — e.g. `becameZeroMidCapture` after an earlier `noBuffers`
+  /// — is not hidden by the first mode's dedup. Reset on session-id change.
+  private var capturedStallModes: Set<CaptureStallFailureMode> = []
   private var lastObservedCaptureSession: UInt64 = 0
   /// Set when the proxy's reply-path swallowed an XPC failure. The
   /// rawSamples-empty branch dedups against this so we emit
@@ -92,8 +94,7 @@ final class HeartPathTelemetryEmitter {
     isActivelyCapturing: Bool
   ) -> Bool {
     resetIfNewSession(ctx.sessionID)
-    guard !stallEventAlreadyCaptured else { return false }
-    stallEventAlreadyCaptured = true
+    guard capturedStallModes.insert(ctx.failureMode).inserted else { return false }
 
     let extras = SentryAudioExtras.buildCaptureExtras(
       route: ctx.route,
@@ -102,7 +103,7 @@ final class HeartPathTelemetryEmitter {
       isActivelyCapturing: isActivelyCapturing,
       inputDeviceUIDPreferred: ctx.inputDeviceUIDPreferred,
       inputDeviceUIDSystemDefault: ctx.inputDeviceUIDSystemDefault,
-      failureMode: "stall_window_elapsed",
+      failureMode: ctx.failureMode.rawValue,
       stallContext: ctx,
       selectedTransport: ctx.selectedTransport,
       effectiveTransport: ctx.effectiveTransport,
@@ -174,9 +175,9 @@ final class HeartPathTelemetryEmitter {
   /// Mirrors the prior in-pipeline `emitNoAudioCapturedEvent` call sites.
   func noAudioCaptured(ctx: NoAudioContext) {
     resetIfNewSession(ctx.sessionID)
-    if stallEventAlreadyCaptured || xpcReplyFailedThisSession {
+    if !capturedStallModes.isEmpty || xpcReplyFailedThisSession {
       let dedupedFrom =
-        stallEventAlreadyCaptured ? "audio_capture_stalled" : "xpc_reply_failed"
+        !capturedStallModes.isEmpty ? "audio_capture_stalled" : "xpc_reply_failed"
       addBreadcrumb(
         "recording",
         dedupedBreadcrumbMessage,
@@ -292,7 +293,7 @@ final class HeartPathTelemetryEmitter {
   private func resetIfNewSession(_ sessionID: UInt64) {
     guard sessionID != lastObservedCaptureSession else { return }
     lastObservedCaptureSession = sessionID
-    stallEventAlreadyCaptured = false
+    capturedStallModes.removeAll()
     xpcReplyFailedThisSession = false
   }
 }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2781,52 +2781,20 @@ final class RecordingSessionKernel {
     samples.reduce(Float(0)) { max($0, abs($1)) }
   }
 
-  /// Empirical dead-air energy thresholds for the #964 no-speech gate. See
-  /// `rawAudioIsDeadAir`. Deliberately LOW — these reject only genuine silence,
-  /// not an audible-but-faint utterance (measured -35 dB room noise peaks at
-  /// 0.0178, above a real whisper at 0.0109, so signal level alone can't split
-  /// faint speech from noise — Parakeet is the arbiter past this floor).
-  enum DeadAirFloor {
-    /// Peak absolute amplitude (linear, Float32). ~ -44 dBFS.
-    static let peak: Float = 0.006
-    /// Whole-buffer RMS.
-    static let rms: Float = 0.00125
-    /// Loudest 40 ms window RMS — catches a faint word inside a mostly-silent
-    /// buffer where the whole-buffer RMS stays low.
-    static let windowRms: Float = 0.002
-    /// 40 ms at 16 kHz.
-    static let windowSamples = 640
-  }
+  /// The pure peak/RMS/non-overlapping-640-tile dead-air math now lives in
+  /// `EnviousWisprCore.RawAudioDeadAirClassifier` (#1317 PR1) so
+  /// `EnviousWisprAudio`'s app-side all-zero detector shares the same
+  /// authority instead of a second implementation. This alias + forwarder
+  /// keep every existing kernel and test call site (`DeadAirFloor.peak`,
+  /// `rawAudioIsDeadAir(...)`) source-compatible.
+  typealias DeadAirFloor = RawAudioDeadAirClassifier.DeadAirFloor
 
   /// True when a raw capture buffer is dead air (no recoverable speech) for the
-  /// #964 gate: when Silero reports zero segments we skip ASR ONLY if the raw
-  /// audio is also below every `DeadAirFloor` threshold. Otherwise the kernel
-  /// falls through and lets Parakeet decide. Pure + static so the boundary
-  /// cases (just-below / just-above each threshold) unit-test without a kernel.
+  /// #964 gate. Forwards to the shared `EnviousWisprCore` classifier.
   nonisolated static func rawAudioIsDeadAir(_ samples: [Float], peak: Float)
     -> Bool
   {
-    guard peak < DeadAirFloor.peak else { return false }
-    guard !samples.isEmpty else { return true }
-    var sumSquares: Float = 0
-    for s in samples { sumSquares += s * s }
-    let rms = (sumSquares / Float(samples.count)).squareRoot()
-    guard rms < DeadAirFloor.rms else { return false }
-    // Loudest non-overlapping 40 ms window. A faint word lifts a local window's
-    // RMS even when most of the buffer is silence around it; tiled windows keep
-    // this bounded at O(n).
-    let window = DeadAirFloor.windowSamples
-    guard samples.count >= window else { return rms < DeadAirFloor.windowRms }
-    var maxWindowRms = rms
-    var i = 0
-    while i + window <= samples.count {
-      var ss: Float = 0
-      for j in i..<(i + window) { ss += samples[j] * samples[j] }
-      let wr = (ss / Float(window)).squareRoot()
-      if wr > maxWindowRms { maxWindowRms = wr }
-      i += window
-    }
-    return maxWindowRms < DeadAirFloor.windowRms
+    RawAudioDeadAirClassifier.isDeadAir(samples, peak: peak)
   }
 
   /// Fraction of non-overlapping 40 ms windows in `slice` whose RMS clears the

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -181,7 +181,8 @@ enum DictationRuntimeFixtures {
       tapInstalled: true,
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: nil,
-      inputDeviceUIDSystemDefault: nil
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: .noBuffers
     )
   }
 

--- a/Tests/EnviousWisprTests/Core/HeartPathContextsTests.swift
+++ b/Tests/EnviousWisprTests/Core/HeartPathContextsTests.swift
@@ -18,7 +18,8 @@ struct HeartPathContextsTests {
       tapInstalled: true,
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: "BuiltInMicrophoneDevice",
-      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice"
+      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice",
+      failureMode: .noBuffers
     )
     #expect(ctx.sessionID == 42)
     #expect(ctx.firedAtUptimeNs - ctx.armedAtUptimeNs == 800_000_000)

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -123,7 +123,8 @@ struct HeartPathTelemetryEmitterTests {
       tapInstalled: true,
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: nil,
-      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice"
+      inputDeviceUIDSystemDefault: "BuiltInMicrophoneDevice",
+      failureMode: .noBuffers
     )
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -126,7 +126,8 @@ struct HeartPathTelemetryWiringTests {
       tapInstalled: true,
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: nil,
-      inputDeviceUIDSystemDefault: nil
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: .noBuffers
     )
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
@@ -253,7 +253,8 @@ import Testing
         tapInstalled: true,
         formatMismatchObserved: false,
         inputDeviceUIDPreferred: nil,
-        inputDeviceUIDSystemDefault: nil)
+        inputDeviceUIDSystemDefault: nil,
+        failureMode: .noBuffers)
       kernel.externalCaptureStalled(crossDomain)
       await wrapper.drainReadyWork()
 

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -278,7 +278,8 @@ final class FakeAudioCapture: AudioCaptureInterface {
       tapInstalled: true,
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: nil,
-      inputDeviceUIDSystemDefault: nil)
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: .noBuffers)
   }
 
   /// Fire the XPC service-error callback (C6 — XPC capture crash). This is the

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -117,7 +117,8 @@ struct DedupSurvivesStallTests {
       tapInstalled: true,
       formatMismatchObserved: false,
       inputDeviceUIDPreferred: nil,
-      inputDeviceUIDSystemDefault: nil
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: .noBuffers
     )
   }
 }

--- a/Tests/EnviousWisprTests/Services/HeartPathErrorTests.swift
+++ b/Tests/EnviousWisprTests/Services/HeartPathErrorTests.swift
@@ -14,7 +14,8 @@ struct HeartPathErrorTests {
       route: "bt", sourceType: "av_capture_session",
       engineStartedSuccessfully: true, tapInstalled: true,
       formatMismatchObserved: false,
-      inputDeviceUIDPreferred: nil, inputDeviceUIDSystemDefault: nil
+      inputDeviceUIDPreferred: nil, inputDeviceUIDSystemDefault: nil,
+      failureMode: .noBuffers
     )
     let sessionCtx = CaptureSessionInterruptionContext(
       kind: .wasInterrupted, reasonCode: 1,

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
@@ -56,7 +56,8 @@ struct SentryAudioExtrasTests {
     )
     #expect(extras["capture.preferred_input_set"] as? Bool == false)
     #expect(extras["capture.input_device_uid_preferred"] is NSNull)
-    #expect(extras["capture.input_device_uid_system_default"] as? String == "BuiltInMicrophoneDevice")
+    #expect(
+      extras["capture.input_device_uid_system_default"] as? String == "BuiltInMicrophoneDevice")
     #expect(extras["capture.input_device_divergence"] as? Bool == false)
   }
 
@@ -105,7 +106,8 @@ struct SentryAudioExtrasTests {
       tapInstalled: true,
       formatMismatchObserved: true,
       inputDeviceUIDPreferred: nil,
-      inputDeviceUIDSystemDefault: nil
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: .noBuffers
     )
     let extras = SentryAudioExtras.buildCaptureExtras(
       route: ctx.route,


### PR DESCRIPTION
## Summary
PR1 of the #1317 dead-mic fix, staged as 3 shippable PRs (see plan §16 on disk, checkpoint comment on the issue). This PR is pure foundation with **zero behavior change**:

- Moves the pure peak/RMS/640-tile dead-air classification math out of `RecordingSessionKernel` into `EnviousWisprCore.RawAudioDeadAirClassifier`, so the app-side all-zero detector landing in PR2 can share the same authority instead of duplicating it (`EnviousWisprAudio` cannot depend on `EnviousWisprPipeline`, so the shared logic has to live in `EnviousWisprCore`, which both already depend on).
- Adds `CaptureStallFailureMode` as a required field on `CaptureStallContext` so every producer states its failure reason explicitly; only `.noBuffers` exists today, and its wire value preserves the exact string Sentry already sees (`"stall_window_elapsed"`), so this PR changes no telemetry.
- `HeartPathTelemetryEmitter` reads that field instead of a hardcoded string, and dedups per-failure-mode via a `Set` instead of a single `Bool`, so a later distinct failure mode in the same session (added in PR2/PR3) won't be hidden behind an earlier one.

Part of #1317 (not closing it — PR3 does).

## Test plan
- [x] `swift build` sanity check clean
- [x] `scripts/xcode-test.sh` full Debug-lane suite: 2,863 tests, 0 failures (empirically proves zero behavior change, not just asserts it)
- [x] Local `codex review --base origin/main`: clean, no actionable regression
- [x] No UAT needed — no runtime behavior change in this PR