### PR TITLE
fix(llm): dedupe output_classifier_load_failed Sentry alerts to at most once per process

### DIFF
--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -792,41 +792,37 @@ public final class WisprBootstrapper {
   private static func prewarmOutputClassifierIfNeeded(
     holder: OutputClassifierHolder, provider: LLMProvider
   ) {
-    guard provider == .appleIntelligence, holder.classifier == nil else { return }
+    guard provider == .appleIntelligence else { return }
     Task {
-      guard let resourceURL = Bundle.main.resourceURL else {
-        await AppLogger.shared.log(
-          "[OutputClassifier] preWarm skipped: no bundle resourceURL — fail open",
-          level: .info, category: "LLM")
-        return
-      }
       let start = DispatchTime.now()
-      do {
-        // `load` is nonisolated-async → the heavy compile/load runs off the main
-        // actor (SE-0338); the holder is set back on the main actor here.
-        let classifier = try await CoreMLOutputClassifier.load(resourceURL: resourceURL)
-        holder.classifier = classifier
-        let elapsedMs = Int(
-          Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
-        await AppLogger.shared.log(
-          "[OutputClassifier] preWarm complete latency_ms=\(elapsedMs)",
-          level: .info, category: "LLM")
-      } catch {
-        let reason = (error as? OutputClassifierError)?.reason.rawValue ?? "load_failed"
-        let elapsedMs = Int(
-          Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
-        await AppLogger.shared.log(
-          "[OutputClassifier] preWarm failed reason=\(reason) — fail open to raw/sync-filtered polish",
-          level: .info, category: "LLM")
+      let outcome = await holder.beginLoadIfNeeded {
+        guard let resourceURL = Bundle.main.resourceURL else {
+          throw OutputClassifierError.disabled(.missingFile)
+        }
+        return try await CoreMLOutputClassifier.load(resourceURL: resourceURL)
+      }
+      let elapsedMs = Int(
+        Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
+      let plan = OutputClassifierEmissionPolicy.forOutcome(outcome)
+      if let logMessage = plan.logMessage {
+        await AppLogger.shared.log(logMessage, level: .info, category: "LLM")
+      }
+      if let category = plan.postHogErrorCategory {
         // #1177 (Telemetry Bible Phase 8): the polish path silently lost its safety
-        // net. Population event for the aggregate fail-open rate + a handled error
-        // (this retries on every provider switch, so a genuinely broken model becomes
-        // a recurring issue grouped per-reason). @MainActor static → direct emit.
+        // net. Population event for the aggregate fail-open rate, tagged by which
+        // of the three observation units this is (#1452 — see
+        // `OutputClassifierEmissionPolicy`). @MainActor static → direct emit.
         TelemetryService.shared.limbFailureObserved(
           limb: "output_safety", operation: "classifier_prewarm", result: "fell_open",
-          errorCategory: reason, durationMs: elapsedMs)
+          errorCategory: category, durationMs: plan.attemptedRealLoad ? elapsedMs : nil)
+      }
+      if let sentryReason = plan.sentryReason {
+        // #1452: at most one alert per process per disablement — repeated
+        // provider-switch triggers after this point return
+        // `.skippedPermanentlyDisabled` and never reach this branch again.
         SentryBreadcrumb.captureError(
-          error, category: .outputClassifierLoadFailed, stage: "llm", fingerprintDetail: reason)
+          OutputClassifierError.disabled(sentryReason), category: .outputClassifierLoadFailed,
+          stage: "llm", fingerprintDetail: sentryReason.rawValue)
       }
     }
   }
@@ -1040,5 +1036,52 @@ private struct ActionWirer: View {
           menuBarController.updateIcon()
         }
       }
+  }
+}
+
+/// Pure mapping from a classifier-load outcome to what `WisprBootstrapper`
+/// should log, count, and alert. Colocated with the sole caller
+/// (`prewarmOutputClassifierIfNeeded`); stateless and dependency-free (no
+/// `TelemetryService`/`SentryBreadcrumb` import) so the outcome→emission
+/// decision — the actual alert-dedup contract — is independently unit-testable
+/// without touching Sentry or PostHog. #1452.
+struct OutputClassifierEmissionPolicy: Equatable {
+  let logMessage: String?
+  let postHogErrorCategory: String?
+  let sentryReason: OutputClassifierDisabledReason?
+  /// True only when this call actually attempted a load (so `elapsedMs` is a
+  /// real, meaningful duration) — false for suppressed repeats, which measure
+  /// nothing because no load was attempted. Kept as an explicit field rather
+  /// than inferring it from `sentryReason == nil`, which is also nil for
+  /// `.failedRetryable` (a real attempt that just isn't alert-worthy).
+  let attemptedRealLoad: Bool
+
+  static func forOutcome(_ outcome: OutputClassifierAttemptOutcome) -> Self {
+    switch outcome {
+    case .skippedAlreadyReady, .skippedLoadInProgress:
+      return .init(
+        logMessage: nil, postHogErrorCategory: nil, sentryReason: nil, attemptedRealLoad: false)
+    case .succeeded:
+      return .init(
+        logMessage: "[OutputClassifier] preWarm complete", postHogErrorCategory: nil,
+        sentryReason: nil, attemptedRealLoad: true)
+    case .skippedPermanentlyDisabled(let reason):
+      // Suppressed repeat: counted (unit = "provider-triggered observation of an
+      // already-disabled classifier"), never re-alerted — this IS the fix.
+      return .init(
+        logMessage: nil, postHogErrorCategory: "suppressed_repeat:\(reason.rawValue)",
+        sentryReason: nil, attemptedRealLoad: false)
+    case .failedFirstTime(let reason):
+      return .init(
+        logMessage: "[OutputClassifier] preWarm failed reason=\(reason.rawValue) — fail open",
+        postHogErrorCategory: "attempted_load:\(reason.rawValue)", sentryReason: reason,
+        attemptedRealLoad: true)
+    case .failedRetryable(let category):
+      // Not the classifier's fault (cancellation / unknown transient error) — counted,
+      // never alerted, and the holder itself already allows a later retry.
+      return .init(
+        logMessage: nil, postHogErrorCategory: "retryable:\(category)", sentryReason: nil,
+        attemptedRealLoad: true)
+    }
   }
 }

--- a/Sources/EnviousWisprLLM/CoreMLOutputClassifier.swift
+++ b/Sources/EnviousWisprLLM/CoreMLOutputClassifier.swift
@@ -54,15 +54,26 @@ public actor CoreMLOutputClassifier: OutputClassifierProtocol {
         contractURL: contractURL,
         tokenizerJSONURL: tokenizerJSON,
         tokenizerConfigURL: tokenizerConfig)
+    } catch is CancellationError {
+      throw CancellationError()
     } catch {
       throw OutputClassifierError.disabled(.contractHashMismatch)
     }
-    let contract = try TokenizerContract.load(from: contractURL)
+    let contract: TokenizerContract
+    do {
+      contract = try TokenizerContract.load(from: contractURL)
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      throw OutputClassifierError.disabled(.contractHashMismatch)
+    }
 
     // 3. Tokenizer via the public local-folder API (NOT the internal AutoTokenizer).
     let tokenizer: TokenizerWrapper
     do {
       tokenizer = try await AutoTokenizerWrapper.from(modelFolder: tokenizerFolder, strict: true)
+    } catch is CancellationError {
+      throw CancellationError()
     } catch {
       throw OutputClassifierError.disabled(.tokenizerLoadFailed)
     }
@@ -90,6 +101,8 @@ public actor CoreMLOutputClassifier: OutputClassifierProtocol {
       }
     } catch let error as OutputClassifierError {
       throw error
+    } catch is CancellationError {
+      throw CancellationError()
     } catch {
       throw OutputClassifierError.disabled(.modelLoadFailed)
     }

--- a/Sources/EnviousWisprLLM/OutputClassifierProtocol.swift
+++ b/Sources/EnviousWisprLLM/OutputClassifierProtocol.swift
@@ -14,6 +14,18 @@ public protocol OutputClassifierProtocol: Sendable {
   func score(input: String, polished: String) async throws -> Double
 }
 
+/// Outcome of one `OutputClassifierHolder.beginLoadIfNeeded` call. Drives
+/// whether the caller alerts Sentry, counts a PostHog event, or does nothing
+/// (`OutputClassifierEmissionPolicy.forOutcome`, `WisprBootstrapper.swift`).
+public enum OutputClassifierAttemptOutcome: Sendable, Equatable {
+  case skippedAlreadyReady
+  case skippedLoadInProgress
+  case skippedPermanentlyDisabled(reason: OutputClassifierDisabledReason)
+  case succeeded
+  case failedFirstTime(reason: OutputClassifierDisabledReason)
+  case failedRetryable(errorCategory: String)
+}
+
 /// Reference holder so the async-prewarmed classifier becomes visible to the
 /// per-polish construction site once loading completes.
 ///
@@ -26,9 +38,57 @@ public protocol OutputClassifierProtocol: Sendable {
 /// Mirrors the `CoordinatorHolder` pattern (swift-patterns nsapp-delegate-env).
 @MainActor
 public final class OutputClassifierHolder {
-  public var classifier: OutputClassifierProtocol?
+  private enum LoadState {
+    case notStarted
+    case loading
+    case ready(OutputClassifierProtocol)
+    case disabled(OutputClassifierDisabledReason)
+  }
+
+  private var state: LoadState
+
+  /// Read-only view for the one existing consumer (`LLMPolishStep`);
+  /// non-nil only in `.ready`. Preserves the exact pre-existing read contract.
+  public var classifier: OutputClassifierProtocol? {
+    guard case .ready(let classifier) = state else { return nil }
+    return classifier
+  }
 
   public init(classifier: OutputClassifierProtocol? = nil) {
-    self.classifier = classifier
+    state = classifier.map(LoadState.ready) ?? .notStarted
+  }
+
+  /// Single entry point for both trigger sites. Coalesces concurrent callers
+  /// (state-gate-over-recheck: `.loading` is set BEFORE the `await`, so a
+  /// second caller arriving during the suspension sees `.loading` and no-ops
+  /// — no re-check window). `OutputClassifierError` (the closed, typed set
+  /// `CoreMLOutputClassifier.load` maps every known failure into) is the only
+  /// thing that permanently disables the holder for the rest of this process.
+  /// `CancellationError` and any other unmapped error reset to `.notStarted`
+  /// so a later trigger may retry — neither is evidence the classifier itself
+  /// is broken.
+  public func beginLoadIfNeeded(
+    loader: @Sendable () async throws -> OutputClassifierProtocol
+  ) async -> OutputClassifierAttemptOutcome {
+    switch state {
+    case .ready: return .skippedAlreadyReady
+    case .loading: return .skippedLoadInProgress
+    case .disabled(let reason): return .skippedPermanentlyDisabled(reason: reason)
+    case .notStarted: state = .loading
+    }
+    do {
+      let classifier = try await loader()
+      state = .ready(classifier)
+      return .succeeded
+    } catch let error as OutputClassifierError {
+      state = .disabled(error.reason)
+      return .failedFirstTime(reason: error.reason)
+    } catch is CancellationError {
+      state = .notStarted
+      return .failedRetryable(errorCategory: "cancelled")
+    } catch {
+      state = .notStarted
+      return .failedRetryable(errorCategory: "unknown_load_error")
+    }
   }
 }

--- a/Tests/EnviousWisprTests/App/OutputClassifierEmissionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/App/OutputClassifierEmissionPolicyTests.swift
@@ -1,0 +1,106 @@
+import EnviousWisprLLM
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1452: `OutputClassifierEmissionPolicy.forOutcome` is the actual
+/// alert-dedup contract — the outcome→emission decision `WisprBootstrapper`
+/// executes. Exhaustively covers all 6 `OutputClassifierAttemptOutcome` cases
+/// so a wrong `switch` arm (e.g. alerting on a suppressed repeat) fails here
+/// instead of only being discoverable by reading the switch statement.
+@Suite("OutputClassifierEmissionPolicy.forOutcome")
+struct OutputClassifierEmissionPolicyTests {
+
+  @Test("skippedAlreadyReady: no log, no PostHog, no Sentry, no real load")
+  func skippedAlreadyReady() {
+    let plan = OutputClassifierEmissionPolicy.forOutcome(.skippedAlreadyReady)
+    #expect(plan.logMessage == nil)
+    #expect(plan.postHogErrorCategory == nil)
+    #expect(plan.sentryReason == nil)
+    #expect(plan.attemptedRealLoad == false)
+  }
+
+  @Test("skippedLoadInProgress: no log, no PostHog, no Sentry, no real load")
+  func skippedLoadInProgress() {
+    let plan = OutputClassifierEmissionPolicy.forOutcome(.skippedLoadInProgress)
+    #expect(plan.logMessage == nil)
+    #expect(plan.postHogErrorCategory == nil)
+    #expect(plan.sentryReason == nil)
+    #expect(plan.attemptedRealLoad == false)
+  }
+
+  @Test("succeeded: logs, no PostHog, no Sentry, real load")
+  func succeeded() {
+    let plan = OutputClassifierEmissionPolicy.forOutcome(.succeeded)
+    #expect(plan.logMessage != nil)
+    #expect(plan.postHogErrorCategory == nil)
+    #expect(plan.sentryReason == nil)
+    #expect(plan.attemptedRealLoad == true)
+  }
+
+  @Test(
+    "skippedPermanentlyDisabled: PostHog counts it as suppressed_repeat, NEVER alerts Sentry, no real load"
+  )
+  func skippedPermanentlyDisabled() {
+    let plan = OutputClassifierEmissionPolicy.forOutcome(
+      .skippedPermanentlyDisabled(reason: .fixtureSelfTestFailed))
+    #expect(plan.logMessage == nil)
+    #expect(plan.postHogErrorCategory == "suppressed_repeat:fixture_selftest_failed")
+    #expect(plan.sentryReason == nil)  // this IS the fix — no re-alert
+    #expect(plan.attemptedRealLoad == false)
+  }
+
+  @Test(
+    "failedFirstTime: logs, PostHog counts attempted_load, Sentry alerts exactly this once, real load"
+  )
+  func failedFirstTime() {
+    let plan = OutputClassifierEmissionPolicy.forOutcome(
+      .failedFirstTime(reason: .modelLoadFailed))
+    #expect(plan.logMessage != nil)
+    #expect(plan.postHogErrorCategory == "attempted_load:model_load_failed")
+    #expect(plan.sentryReason == .modelLoadFailed)
+    #expect(plan.attemptedRealLoad == true)
+  }
+
+  @Test("failedRetryable: PostHog counts it as retryable, NEVER alerts Sentry, real load")
+  func failedRetryable() {
+    let plan = OutputClassifierEmissionPolicy.forOutcome(
+      .failedRetryable(errorCategory: "cancelled"))
+    #expect(plan.logMessage == nil)
+    #expect(plan.postHogErrorCategory == "retryable:cancelled")
+    #expect(plan.sentryReason == nil)
+    #expect(plan.attemptedRealLoad == true)
+  }
+
+  @Test("attemptedRealLoad is true for exactly the 3 outcomes that ran a real load")
+  func attemptedRealLoadPartitionsCorrectly() {
+    let outcomes: [(OutputClassifierAttemptOutcome, Bool)] = [
+      (.skippedAlreadyReady, false),
+      (.skippedLoadInProgress, false),
+      (.skippedPermanentlyDisabled(reason: .missingFile), false),
+      (.succeeded, true),
+      (.failedFirstTime(reason: .missingFile), true),
+      (.failedRetryable(errorCategory: "unknown_load_error"), true),
+    ]
+    for (outcome, expected) in outcomes {
+      #expect(OutputClassifierEmissionPolicy.forOutcome(outcome).attemptedRealLoad == expected)
+    }
+  }
+
+  @Test("sentryReason is non-nil for exactly one outcome: failedFirstTime")
+  func sentryReasonOnlyOnFailedFirstTime() {
+    let outcomes: [OutputClassifierAttemptOutcome] = [
+      .skippedAlreadyReady,
+      .skippedLoadInProgress,
+      .skippedPermanentlyDisabled(reason: .missingFile),
+      .succeeded,
+      .failedFirstTime(reason: .missingFile),
+      .failedRetryable(errorCategory: "cancelled"),
+    ]
+    let alertingOutcomes = outcomes.filter {
+      OutputClassifierEmissionPolicy.forOutcome($0).sentryReason != nil
+    }
+    #expect(alertingOutcomes.count == 1)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -329,14 +329,24 @@ import Testing
   /// runs the one-time legacy launch table after the first-run baseline. All
   /// retirement logic lives on the coordinator, not here. Cap by deterministic
   /// rule (actual 1041 + ~2, rounded up to nearest 5 = 1045).
+  /// Ratcheted 1045→1090 in #1452 (2026-07-11): `prewarmOutputClassifierIfNeeded`
+  /// rewritten to call `holder.beginLoadIfNeeded` and execute the new
+  /// `OutputClassifierEmissionPolicy.forOutcome` plan (dedupes the
+  /// `output_classifier_load_failed` Sentry alert to at most once per process
+  /// per disablement); the pure `OutputClassifierEmissionPolicy` struct is
+  /// appended as a free-standing top-level type AFTER the class's closing
+  /// brace, so it adds zero stored properties / methods to the composition
+  /// root itself (stored-property and method ceilings above are unchanged) —
+  /// only the file's physical line count grows. Cap by deterministic rule
+  /// (actual 1088 + ~2, rounded up to nearest 5 = 1090).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1045,
+      lineCount <= 1090,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1045. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1090. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/LLM/OutputClassifierContractTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OutputClassifierContractTests.swift
@@ -69,6 +69,37 @@ import Testing
     }
   }
 
+  @Test(
+    "malformed contract JSON never leaks a raw decoding error out of CoreMLOutputClassifier.load (#1452)"
+  )
+  func malformedContractSurfacesAsClassifierError() async throws {
+    // Minimal resourceURL layout CoreMLOutputClassifier.load expects: only the
+    // tokenizer-folder files matter here — the malformed contract fails before
+    // the model-load steps are ever reached.
+    let resourceURL = FileManager.default.temporaryDirectory.appending(
+      path: "output-classifier-malformed-contract-\(UUID().uuidString)")
+    let tokenizerFolder = resourceURL.appending(
+      path: OutputClassifierManifest.tokenizerFolderName)
+    try FileManager.default.createDirectory(
+      at: tokenizerFolder, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: resourceURL) }
+
+    try Data("not valid json".utf8).write(
+      to: tokenizerFolder.appending(path: OutputClassifierManifest.contractFileName))
+    try Data().write(to: tokenizerFolder.appending(path: "tokenizer.json"))
+    try Data().write(to: tokenizerFolder.appending(path: "tokenizer_config.json"))
+
+    do {
+      _ = try await CoreMLOutputClassifier.load(resourceURL: resourceURL)
+      Issue.record("expected OutputClassifierError.disabled(.contractHashMismatch), got success")
+    } catch let error as OutputClassifierError {
+      #expect(error.reason == .contractHashMismatch)
+    } catch {
+      Issue.record(
+        "expected OutputClassifierError.disabled(.contractHashMismatch), got raw \(error)")
+    }
+  }
+
   @Test("committed .mlpackage combined SHA matches the manifest constant")
   func mlpackageDigestMatchesManifest() throws {
     let pkg = OutputClassifierTestPaths.mlpackage

--- a/Tests/EnviousWisprTests/LLM/OutputClassifierHolderStateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OutputClassifierHolderStateTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #1452: `OutputClassifierHolder`'s process-lifetime state machine. Proves the
+/// actual acceptance criterion — at most one terminal `.failedFirstTime` per
+/// process per disablement, concurrent triggers coalesce onto one load, and a
+/// non-classifier-fault error (cancellation / unmapped) stays retryable —
+/// without touching CoreML, Sentry, or PostHog at all (the loader is a fake
+/// closure injected via `beginLoadIfNeeded`).
+@MainActor
+@Suite("OutputClassifierHolder state machine")
+struct OutputClassifierHolderStateTests {
+
+  /// A trivial `OutputClassifierProtocol` for the `.succeeded` path — never
+  /// scored in these tests, only used to prove `.classifier` becomes non-nil.
+  private struct StubClassifier: OutputClassifierProtocol {
+    func score(input: String, polished: String) async throws -> Double { 0 }
+  }
+
+  /// Counts loader invocations across concurrent/sequential calls.
+  private actor CallSpy {
+    private(set) var count = 0
+    func recordCall() { count += 1 }
+  }
+
+  /// Gate a parked loader awaits; the test releases it after observing the
+  /// loader has actually started (signal-based, no `Task.sleep` — mirrors
+  /// `LLMPolishReentrancyTests.ReleaseGate`).
+  private actor ReleaseGate {
+    private var released = false
+    private var waiter: CheckedContinuation<Void, Never>?
+    func release() {
+      released = true
+      waiter?.resume()
+      waiter = nil
+    }
+    func wait() async {
+      if released { return }
+      await withCheckedContinuation { waiter = $0 }
+    }
+  }
+
+  @Test("successful load: succeeded, classifier becomes non-nil")
+  func successfulLoad() async throws {
+    let holder = OutputClassifierHolder()
+    let spy = CallSpy()
+    let outcome = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      return StubClassifier()
+    }
+    #expect(outcome == .succeeded)
+    #expect(holder.classifier != nil)
+    #expect(await spy.count == 1)
+  }
+
+  @Test("typed OutputClassifierError: failedFirstTime, classifier stays nil")
+  func typedErrorFailsFirstTime() async throws {
+    let holder = OutputClassifierHolder()
+    let outcome = await holder.beginLoadIfNeeded {
+      throw OutputClassifierError.disabled(.fixtureSelfTestFailed)
+    }
+    #expect(outcome == .failedFirstTime(reason: .fixtureSelfTestFailed))
+    #expect(holder.classifier == nil)
+  }
+
+  @Test(
+    "repeat call after a typed-error failure: skippedPermanentlyDisabled, loader not invoked again")
+  func repeatAfterTypedErrorSkips() async throws {
+    let holder = OutputClassifierHolder()
+    let spy = CallSpy()
+    let first = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      throw OutputClassifierError.disabled(.modelLoadFailed)
+    }
+    #expect(first == .failedFirstTime(reason: .modelLoadFailed))
+
+    let second = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      throw OutputClassifierError.disabled(.modelLoadFailed)
+    }
+    #expect(second == .skippedPermanentlyDisabled(reason: .modelLoadFailed))
+    #expect(await spy.count == 1)
+  }
+
+  @Test("repeat call after success: skippedAlreadyReady, loader not invoked again")
+  func repeatAfterSuccessSkips() async throws {
+    let holder = OutputClassifierHolder()
+    let spy = CallSpy()
+    let first = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      return StubClassifier()
+    }
+    #expect(first == .succeeded)
+
+    let second = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      return StubClassifier()
+    }
+    #expect(second == .skippedAlreadyReady)
+    #expect(await spy.count == 1)
+  }
+
+  @Test(
+    "concurrent trigger while a load is in flight: the second caller coalesces, never invokes its own loader"
+  )
+  func concurrentTriggerCoalesces() async throws {
+    let holder = OutputClassifierHolder()
+    let spy = CallSpy()
+    let gate = ReleaseGate()
+    let started = AsyncStream.makeStream(of: Void.self)
+    let startedContinuation = started.continuation
+
+    // First call: parks on the gate after signaling it has actually started
+    // the load (proves `state == .loading` before the second call runs).
+    let firstTask = Task { @MainActor in
+      await holder.beginLoadIfNeeded {
+        await spy.recordCall()
+        startedContinuation.yield(())
+        startedContinuation.finish()
+        await gate.wait()
+        return StubClassifier()
+      }
+    }
+
+    var iterator = started.stream.makeAsyncIterator()
+    _ = await iterator.next()  // first call is parked inside its loader
+
+    // Second call arrives while the first is still loading — must coalesce
+    // without ever calling its own loader.
+    let secondOutcome = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      return StubClassifier()
+    }
+    #expect(secondOutcome == .skippedLoadInProgress)
+    #expect(await spy.count == 1)  // only the first call's loader ran
+
+    await gate.release()
+    let firstOutcome = await firstTask.value
+    #expect(firstOutcome == .succeeded)
+    #expect(holder.classifier != nil)
+    #expect(await spy.count == 1)
+  }
+
+  @Test("CancellationError: failedRetryable, a later call retries")
+  func cancellationIsRetryable() async throws {
+    let holder = OutputClassifierHolder()
+    let spy = CallSpy()
+    let first = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      throw CancellationError()
+    }
+    #expect(first == .failedRetryable(errorCategory: "cancelled"))
+    #expect(holder.classifier == nil)
+
+    let second = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      return StubClassifier()
+    }
+    #expect(second == .succeeded)
+    #expect(await spy.count == 2)  // retried — not permanently disabled
+  }
+
+  @Test("unmapped error: failedRetryable, a later call retries")
+  func unmappedErrorIsRetryable() async throws {
+    struct SomeOtherError: Error {}
+    let holder = OutputClassifierHolder()
+    let spy = CallSpy()
+    let first = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      throw SomeOtherError()
+    }
+    #expect(first == .failedRetryable(errorCategory: "unknown_load_error"))
+    #expect(holder.classifier == nil)
+
+    let second = await holder.beginLoadIfNeeded {
+      await spy.recordCall()
+      return StubClassifier()
+    }
+    #expect(second == .succeeded)
+    #expect(await spy.count == 2)
+  }
+
+  /// The remaining 7 `OutputClassifierDisabledReason` variants not already
+  /// covered by `typedErrorFailsFirstTime` (`.fixtureSelfTestFailed`) — proves
+  /// the reason is preserved through to `.failedFirstTime` for every case in
+  /// the closed set `CoreMLOutputClassifier.load` can throw.
+  @Test(
+    "typed OutputClassifierError preserves reason through to failedFirstTime",
+    arguments: [
+      OutputClassifierDisabledReason.contractHashMismatch,
+      .missingFile,
+      .unsupportedFamily,
+      .shapeMismatch,
+      .inferenceError,
+      .tokenizerLoadFailed,
+      .modelLoadFailed,
+    ]
+  )
+  func typedErrorPreservesReason(_ reason: OutputClassifierDisabledReason) async throws {
+    let holder = OutputClassifierHolder()
+    let outcome = await holder.beginLoadIfNeeded {
+      throw OutputClassifierError.disabled(reason)
+    }
+    #expect(outcome == .failedFirstTime(reason: reason))
+  }
+}


### PR DESCRIPTION
## Summary
- One broken Mac can produce 78+ Sentry events from one underlying condition because `OutputClassifierHolder`'s bare optional conflates "never tried," "loading," and "permanently failed" — every provider-switch retries the load and re-alerts.
- Replaces it with a private process-lifetime state machine (`notStarted`/`loading`/`ready`/`disabled`) that coalesces concurrent load triggers and alerts Sentry at most once per process per disablement. Cancellation and unmapped errors stay retryable (not classifier-fault); PostHog keeps counting all three observation units under distinct tags.
- `WisprBootstrapper` executes a new pure `OutputClassifierEmissionPolicy` function so the outcome→alert/count/log decision is independently unit-tested, not just eyeballed.
- Zero user-visible behavior change — the classifier's fail-open polish path is byte-identical before and after.

Plan (5 rounds of Codex grounded review to PROCEED-AS-PLANNED): `docs/feature-requests/issue-1452-2026-07-11-classifier-alert-dedup.md`. Closes #1452.

## Test plan
- [x] `scripts/xcode-test.sh` — full suite green (2880 tests), including the two new suites (`OutputClassifierHolder state machine`, `OutputClassifierEmissionPolicy.forOutcome`) and a new `CoreMLOutputClassifier` regression test for the previously-unwrapped `TokenizerContract.load` call
- [x] Local `codex review --base origin/main` — clean, no findings
- [x] Dev build rebuilt + relaunched; ran a full live dictation end-to-end with no crash (Live UAT is N for this ticket per the plan's preface — no user-visible surface to drive; this is the sole runtime smoke check)