### PR TITLE
feat(audio): detect the mic-harness all-zero glitch and end the take honestly

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -268,8 +268,13 @@ final class DictationLifecycleCoordinator {
       // completion; `.deviceRemoved` = verified removal (may say "Microphone
       // disconnected"); `.otherInterruption` = salvaged with the mic, as far as
       // we know, still attached (neutral copy). The factory owns the sentences.
-      interruptionDisclosure: CompletionInterruptionDisclosure(
-        cause: kernelDriver.lastAudioInterruptionCause)
+      // #1317: a `becameZeroMidCapture` completion never stamps an
+      // `EngineInterruptionCause` (§3.4 — no synthesized cause), so it is
+      // read directly off the zero-signal side-channel instead of going
+      // through `CompletionInterruptionDisclosure.init(cause:)` (§3.5).
+      interruptionDisclosure: kernelDriver.lastZeroSignalFailureMode == .becameZeroMidCapture
+        ? .otherInterruption
+        : CompletionInterruptionDisclosure(cause: kernelDriver.lastAudioInterruptionCause)
     )
     // PR7 of #763 — push polish error to the post-recording result home so
     // views can read `lastRecordingResult.polishError` without reaching
@@ -322,8 +327,12 @@ final class DictationLifecycleCoordinator {
       historySaved: whisperKitKernelDriver.lastHistorySaved,
       historySaveReason: whisperKitKernelDriver.lastHistorySaveReason,
       salvagedLead: whisperKitKernelDriver.lastSalvagedLeadTrimMs != nil,
-      interruptionDisclosure: CompletionInterruptionDisclosure(
-        cause: whisperKitKernelDriver.lastAudioInterruptionCause)
+      // #1317: see the Parakeet handler above for why this reads the
+      // zero-signal side-channel first.
+      interruptionDisclosure: whisperKitKernelDriver.lastZeroSignalFailureMode
+        == .becameZeroMidCapture
+        ? .otherInterruption
+        : CompletionInterruptionDisclosure(cause: whisperKitKernelDriver.lastAudioInterruptionCause)
     )
     lastRecordingResult.polishError = whisperKitKernelDriver.lastPolishError
     dispatchChipLifecycle(

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -100,6 +100,17 @@ public protocol AudioCaptureInterface: AnyObject {
   /// active source in direct mode; constant for the proxy.
   var captureSourceType: String { get }
 
+  /// #1317 (cloud review P2, PR #1512, round 2): input device resolved and
+  /// frozen at the moment THIS session's engine actually started capturing
+  /// (including any internal retry) — not a live re-read of
+  /// `preferredInputDeviceIDOverride`/`selectedInputDeviceUID`, which a
+  /// mid-session settings change can already have moved past. The pipeline
+  /// layer's zero-signal device discriminator (§3.0) reads this so its
+  /// STOP-time backstop evaluates the device the session actually captured
+  /// from — only the concrete capture layer knows exactly when and how many
+  /// times an engine-start attempt actually ran. Default `nil` (fail closed).
+  var zeroSignalDiscriminatorDeviceID: AudioDeviceID? { get }
+
   // Configuration properties (read-write)
   var noiseSuppressionEnabled: Bool { get set }
   var selectedInputDeviceUID: String { get set }
@@ -138,4 +149,11 @@ extension AudioCaptureInterface {
   public func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
     try await beginCapturePhase(recoveryPayload: nil)
   }
+
+  /// #1317: fail-closed default so every existing conformer (test fakes,
+  /// simulator doubles) that has no reason to track this stays
+  /// source-compatible. Real capture backends (`AudioCaptureProxy`,
+  /// `AudioCaptureManager`) override it with the device frozen at their own
+  /// engine-start moment.
+  public var zeroSignalDiscriminatorDeviceID: AudioDeviceID? { nil }
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -111,6 +111,16 @@ public protocol AudioCaptureInterface: AnyObject {
   /// times an engine-start attempt actually ran. Default `nil` (fail closed).
   var zeroSignalDiscriminatorDeviceID: AudioDeviceID? { get }
 
+  /// #1317 (cloud review round 2, P2): true once a reactive zero-signal
+  /// check this session observed a candidate buffer while the device was
+  /// ineligible (muted). The kernel's STOP-time backstop must fail closed
+  /// once this is true even if the device's LIVE state has since become
+  /// eligible (the user unmuted right before releasing does not undo that
+  /// the silent stretch itself was genuinely muted). Default `false` —
+  /// conformers with no reactive per-buffer detector (there is nothing to
+  /// observe) correctly never set it.
+  var zeroSignalDiscriminatorSawIneligible: Bool { get }
+
   // Configuration properties (read-write)
   var noiseSuppressionEnabled: Bool { get set }
   var selectedInputDeviceUID: String { get set }
@@ -156,4 +166,9 @@ extension AudioCaptureInterface {
   /// `AudioCaptureManager`) override it with the device frozen at their own
   /// engine-start moment.
   public var zeroSignalDiscriminatorDeviceID: AudioDeviceID? { nil }
+
+  /// #1317 (cloud review round 2, P2): default `false` — test fakes and
+  /// `AudioCaptureManager` (no reactive per-buffer detector) have nothing to
+  /// latch. `AudioCaptureProxy` overrides it with its own session-scoped latch.
+  public var zeroSignalDiscriminatorSawIneligible: Bool { false }
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -111,14 +111,17 @@ public protocol AudioCaptureInterface: AnyObject {
   /// times an engine-start attempt actually ran. Default `nil` (fail closed).
   var zeroSignalDiscriminatorDeviceID: AudioDeviceID? { get }
 
-  /// #1317 (cloud review round 2, P2): true once a reactive zero-signal
-  /// check this session observed a candidate buffer while the device was
+  /// #1317 (cloud review round 2, P2; scope narrowed round 3, P2): true
+  /// once a reactive zero-signal check observed a candidate buffer,
+  /// somewhere in the CURRENT trailing all-zero run, while the device was
   /// ineligible (muted). The kernel's STOP-time backstop must fail closed
   /// once this is true even if the device's LIVE state has since become
   /// eligible (the user unmuted right before releasing does not undo that
-  /// the silent stretch itself was genuinely muted). Default `false` —
-  /// conformers with no reactive per-buffer detector (there is nothing to
-  /// observe) correctly never set it.
+  /// THAT silent stretch was genuinely muted) — but scoped to the current
+  /// run only, so an earlier resolved mute elsewhere in the same recording
+  /// can't blind the backstop to a later, unrelated genuine failure.
+  /// Default `false` — conformers with no reactive per-buffer detector
+  /// (there is nothing to observe) correctly never set it.
   var zeroSignalDiscriminatorSawIneligible: Bool { get }
 
   // Configuration properties (read-write)

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -21,6 +21,31 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// production writes stay inside this file.
   public internal(set) var isCapturing = false
 
+  /// #1317 (cloud review P2, PR #1512, round 2): device resolved via
+  /// `AudioDeviceEnumerator.resolveEffectiveInputDevice` and frozen at the
+  /// TOP of `startEnginePhase()` — the same synchronous turn `resolveSource()`
+  /// itself reads `preferredInputDeviceIDOverride`/`selectedInputDeviceUID`
+  /// to build/reuse a source, so this mirrors the device the engine actually
+  /// binds to for THIS attempt (re-freezes naturally on a kernel-driven
+  /// rebuild retry, since that re-invokes `startEnginePhase()`). Exposed via
+  /// `AudioCaptureInterface.zeroSignalDiscriminatorDeviceID` so the pipeline
+  /// layer's STOP-time backstop reads this SAME frozen value instead of
+  /// independently re-resolving (which cannot see this class's retries) —
+  /// it does so AFTER capture has already ended — a normal `stopCapture()`
+  /// OR any interruption teardown path, both of which run their own
+  /// cleanup BEFORE the kernel's read happens (the kernel falls through a
+  /// salvageable interruption into the SAME normal stop tail that reads
+  /// this). INVARIANT: no teardown path may clear this field — the next
+  /// `startEnginePhase()` overwrites it for the next session, and nothing
+  /// ever reads a stale cross-session value in between, so clearing it
+  /// early only ever loses the CURRENT session's read (cloud review round
+  /// 6 P1 caught this in `stopCapture()`; round 7 P2 caught the same class
+  /// in the interruption path — audit every write site against this
+  /// invariant before adding a new one).
+  private var effectiveDiscriminatorDeviceID: AudioDeviceID?
+
+  public var zeroSignalDiscriminatorDeviceID: AudioDeviceID? { effectiveDiscriminatorDeviceID }
+
   /// Current audio level (0.0 - 1.0) for waveform visualization.
   public private(set) var audioLevel: Float = 0.0
 
@@ -256,6 +281,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   // MARK: - AudioCaptureInterface
 
   public func startEnginePhase() async throws {
+    // #1317 (cloud review P2, round 2): freeze the discriminator device NOW,
+    // same synchronous turn `resolveSource()` reads the live UID properties.
+    effectiveDiscriminatorDeviceID = AudioDeviceEnumerator.resolveEffectiveInputDevice(
+      preferredOverride: preferredInputDeviceIDOverride, selected: selectedInputDeviceUID)
     // Re-evaluate route on every recording start — BT state may have changed.
     onLifecycleSignal?("manager_resolve_source_entered")
     let source = resolveSource()
@@ -316,6 +345,11 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         self.activeSource.map({ ObjectIdentifier($0) }) == sourceID
       else { return }
       self.isCapturing = false
+      // #1317 (cloud review P2, round 7): NOT cleared here — see the
+      // field's doc comment. A teardown-time clear here can race the
+      // kernel's STOP-time read the same way `stopCapture()` did (round 6
+      // P1): the kernel falls through interruption exits into the SAME
+      // normal stop tail when the interruption's audio is salvageable.
       self.audioLevel = 0.0
       self.onEngineInterrupted?(cause)
     }
@@ -386,6 +420,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     let stopMetadata = source.captureStopMetadata
 
     isCapturing = false
+    // #1317 (cloud review P1, round 6): do NOT clear `effectiveDiscriminatorDeviceID`
+    // here — the kernel's STOP-time backstop reads `zeroSignalDiscriminatorDeviceID`
+    // AFTER this `stopCapture()` call returns. The next `startEnginePhase()`
+    // already overwrites it for the next session.
     audioLevel = 0.0
 
     // Deactivate capture but keep engine warm. The tap stays installed and the

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+import CoreAudio
 import EnviousWisprCore
 import Foundation
 
@@ -181,6 +182,34 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   /// into the next session.
   private var captureStartUptimeNs: UInt64 = 0
 
+  /// #1317 (cloud review P2, PR #1512, round 2): device resolved via
+  /// `AudioDeviceEnumerator.resolveEffectiveInputDevice` and frozen inside
+  /// `awaitStartEnginePhaseReply` — the same synchronous snapshot used for
+  /// THIS attempt's XPC `preferredDeviceUID`/`selectedDeviceUID` send
+  /// (including retries, since that whole function re-runs on resend).
+  /// `evaluateDeadAirDetector` evaluates the alive/mute discriminator
+  /// against THIS device, not a live re-read — a device switch applied
+  /// mid-recording (settings apply immediately; the active capture source
+  /// does not rebuild until the next recording) must not retroactively
+  /// change which device this session's zero-signal check evaluates.
+  /// `nil` if no session has started, or none could be resolved. Exposed
+  /// via `AudioCaptureInterface.zeroSignalDiscriminatorDeviceID` so the
+  /// pipeline layer's STOP-time backstop reads this SAME frozen value —
+  /// which it does AFTER capture has already ended — a normal `stopCapture()`
+  /// OR any interruption/line-death teardown path, both of which run their
+  /// own cleanup BEFORE the kernel's read happens (the kernel falls through
+  /// a salvageable interruption into the SAME normal stop tail that reads
+  /// this). INVARIANT: no teardown path may clear this field — the next
+  /// `startEnginePhase()` overwrites it for the next session, and nothing
+  /// ever reads a stale cross-session value in between, so clearing it
+  /// early only ever loses the CURRENT session's read (cloud review round
+  /// 6 P1 caught this in `stopCapture()`; round 7 P2 caught the same class
+  /// in both files' interruption paths — audit every write site against
+  /// this invariant before adding a new one).
+  private var effectiveDiscriminatorDeviceID: AudioDeviceID?
+
+  public var zeroSignalDiscriminatorDeviceID: AudioDeviceID? { effectiveDiscriminatorDeviceID }
+
   // MARK: - Capture-liveness watchdog (issue #285)
 
   /// Private serial queue that fires the stall `DispatchWorkItem`.
@@ -300,13 +329,22 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   }
 
   private func awaitStartEnginePhaseReply(operationID: String) async throws {
+    // #1317 (cloud review P2, round 2): snapshot the UIDs used for THIS
+    // specific attempt (including retries — this whole function re-runs on
+    // each retry) and freeze the discriminator device against that SAME
+    // snapshot, not a live re-read at some later point. This is the moment
+    // closest to the actual XPC device bind.
+    let preferredUID = preferredInputDeviceIDOverride
+    let selectedUID = selectedInputDeviceUID
+    effectiveDiscriminatorDeviceID = AudioDeviceEnumerator.resolveEffectiveInputDevice(
+      preferredOverride: preferredUID, selected: selectedUID)
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
       let guard_ = OneShotContinuation(cont)
       serviceProxy { proxy in
         proxy.startEnginePhase(
           operationID: operationID,
-          preferredDeviceUID: self.preferredInputDeviceIDOverride,
-          selectedDeviceUID: self.selectedInputDeviceUID
+          preferredDeviceUID: preferredUID,
+          selectedDeviceUID: selectedUID
         ) { nsError in
           if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
         }
@@ -357,6 +395,11 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
     isCapturing = true
     captureStartUptimeNs = DispatchTime.now().uptimeNanoseconds  // #455
+    // #1317: `effectiveDiscriminatorDeviceID` is NOT (re-)frozen here — it is
+    // already frozen by `awaitStartEnginePhaseReply` (round 2 fix), which ran
+    // as part of the preceding `startEnginePhase()` (or this call's own
+    // retry-prefix on a resend). Re-freezing here would re-read live UIDs at
+    // a LATER point, reintroducing the exact race cloud review flagged.
     hasReceivedBufferThisSession = false
     deadAirDetector = DeadAirStreamingDetector()
     captureStallReported = false
@@ -463,9 +506,13 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       return
     }
 
+    // #1317 (cloud review P2, round 2): evaluate against the device FROZEN
+    // inside `awaitStartEnginePhaseReply` at engine-start, not a live
+    // re-read — `preferredInputDeviceIDOverride`/`selectedInputDeviceUID`
+    // can already reflect a device the user switched to mid-recording,
+    // before the active capture source itself rebuilds.
     guard
-      let deviceID = AudioDeviceEnumerator.resolveEffectiveInputDevice(
-        preferredOverride: preferredInputDeviceIDOverride, selected: selectedInputDeviceUID),
+      let deviceID = effectiveDiscriminatorDeviceID,
       ZeroSignalDeviceDiscriminator.isEligible(deviceID: deviceID)
     else { return }
 
@@ -544,6 +591,12 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     isCapturing = false
     activeCaptureOperationID = nil  // #1408 A3: session over, relay echoes are stale now
     captureStartUptimeNs = 0  // #455
+    // #1317 (cloud review P1, round 6): do NOT clear `effectiveDiscriminatorDeviceID`
+    // here — `RecordingSessionKernel` reads `zeroSignalDiscriminatorDeviceID`
+    // via the STOP-time backstop AFTER this `stopCapture()` call returns.
+    // Clearing it here made the backstop permanently see `nil` and silently
+    // disabled it on every real capture. The next `startEnginePhase()`
+    // already overwrites it for the next session.
     audioLevel = 0
     bufferContinuation?.finish()
     bufferContinuation = nil
@@ -1058,6 +1111,11 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
       isCapturing = false
       activeCaptureOperationID = nil  // #1408 A3
       captureStartUptimeNs = 0  // #455
+      // #1317 (cloud review P2, round 7): NOT cleared here — see the field's
+      // doc comment. A teardown-time clear (this method, an interruption
+      // path) can race the kernel's STOP-time read the same way `stopCapture()`
+      // did (round 6 P1): the kernel falls through interruption exits into
+      // the SAME normal stop tail when the interruption's audio is salvageable.
       audioLevel = 0
       captureGeneration &+= 1
       bufferContinuation?.finish()
@@ -1397,6 +1455,9 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
         self.isCapturing = false
         self.activeCaptureOperationID = nil  // #1408 A3
         self.captureStartUptimeNs = 0  // #455
+        // #1317 (cloud review P2, round 7): NOT cleared here — see the
+        // field's doc comment; same reasoning as the sibling teardown block
+        // above.
         self.audioLevel = 0
         self.captureGeneration &+= 1
         self.bufferContinuation?.finish()

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -194,6 +194,23 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
   /// for the active session reaches us. Reset to false when arming.
   private var hasReceivedBufferThisSession: Bool = false
 
+  /// #1317: per-capture-generation all-zero harness-glitch detector state.
+  /// Reset alongside `hasReceivedBufferThisSession` at every fresh
+  /// `beginCapturePhase`.
+  private var deadAirDetector = DeadAirStreamingDetector()
+
+  /// #1317 (Codex code-diff review r3): `AudioCaptureInterface.onCaptureStalled`
+  /// is documented as at-most-once per session, but the no-buffer watchdog
+  /// (`captureStallWatchdogFired`) and the all-zero detector
+  /// (`evaluateDeadAirDetector`) are two INDEPENDENT firing paths, each
+  /// guarded only by its own state (`hasReceivedBufferThisSession` /
+  /// `deadAirDetector.fired`). A delayed-buffer race — the watchdog fires on
+  /// zero buffers, then late buffers arrive before the async stop completes
+  /// and happen to cross the all-zero threshold — could fire BOTH,
+  /// duplicating the callback and its telemetry. This flag is the ONE shared
+  /// latch both paths check-and-set before calling `onCaptureStalled`.
+  private var captureStallReported = false
+
   /// 16kHz mono Float32 format used for buffer reconstruction.
   /// Matches AudioCaptureManager.targetSampleRate / targetChannels.
   nonisolated(unsafe) private static let targetFormat = AVAudioFormat(
@@ -341,6 +358,8 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     isCapturing = true
     captureStartUptimeNs = DispatchTime.now().uptimeNanoseconds  // #455
     hasReceivedBufferThisSession = false
+    deadAirDetector = DeadAirStreamingDetector()
+    captureStallReported = false
     armCaptureStallWatchdog()
     return stream
   }
@@ -393,6 +412,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     guard activeCaptureGeneration == armedSession else { return }
     guard isCapturing else { return }
     guard !hasReceivedBufferThisSession else { return }
+    guard !captureStallReported else { return }
 
     let ctx = CaptureStallContext(
       sessionID: armedSession,
@@ -407,6 +427,63 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
         ? nil : preferredInputDeviceIDOverride,
       inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
       failureMode: .noBuffers,
+      selectedTransport: currentResolvedRoute?.selected,
+      effectiveTransport: currentResolvedRoute?.effective,
+      routeReason: currentResolvedRoute?.routeReason,
+      routeFallbackReason: currentResolvedRoute?.routeFallbackReason,
+      inputSelectionMode: currentResolvedRoute?.inputSelectionMode,
+      outputTransport: currentResolvedRoute?.outputTransport,
+      routeResolutionSource: currentResolvedRoute?.routeResolutionSource
+    )
+    captureStallReported = true
+    onCaptureStalled?(ctx)
+  }
+
+  /// #1317: feed this buffer's raw samples into the per-generation all-zero
+  /// harness-glitch detector; when it crosses a confidence threshold, run the
+  /// §3.0 device-alive + not-muted discriminator and — only if it passes —
+  /// fire `onCaptureStalled` with the matching failure mode. A muted or
+  /// mute-unknown device fails closed: no fire, today's honest no-speech
+  /// path is untouched, and the next buffer re-evaluates (mute state can
+  /// legitimately change mid-recording).
+  private func evaluateDeadAirDetector(buffer: AVAudioPCMBuffer, sessionID: UInt64) {
+    guard !deadAirDetector.fired, !captureStallReported,
+      let channelData = buffer.floatChannelData
+    else { return }
+    let frameCount = Int(buffer.frameLength)
+    guard frameCount > 0 else { return }
+    deadAirDetector.ingest(UnsafeBufferPointer(start: channelData[0], count: frameCount))
+
+    let mode: CaptureStallFailureMode
+    if deadAirDetector.isAllZeroFromStart {
+      mode = .allZeroFromStart
+    } else if deadAirDetector.isBecameZeroMidCapture {
+      mode = .becameZeroMidCapture
+    } else {
+      return
+    }
+
+    guard
+      let deviceID = AudioDeviceEnumerator.resolveEffectiveInputDevice(
+        preferredOverride: preferredInputDeviceIDOverride, selected: selectedInputDeviceUID),
+      ZeroSignalDeviceDiscriminator.isEligible(deviceID: deviceID)
+    else { return }
+
+    deadAirDetector.fired = true
+    captureStallReported = true
+    let ctx = CaptureStallContext(
+      sessionID: sessionID,
+      armedAtUptimeNs: captureStartUptimeNs,
+      firedAtUptimeNs: DispatchTime.now().uptimeNanoseconds,
+      route: currentAudioRoute,
+      sourceType: "xpc_proxy",
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: preferredInputDeviceIDOverride.isEmpty
+        ? nil : preferredInputDeviceIDOverride,
+      inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+      failureMode: mode,
       selectedTransport: currentResolvedRoute?.selected,
       effectiveTransport: currentResolvedRoute?.effective,
       routeReason: currentResolvedRoute?.routeReason,
@@ -1284,6 +1361,11 @@ extension AudioCaptureProxy: AudioServiceClientProtocol {
           return
         }
       #endif
+      // #1317: mid-recording all-zero harness-glitch detector. After the
+      // generation guard, on the already-reconstructed float buffer, before
+      // yielding — no new XPC callback, no RT-thread work (§3.1).
+      self.evaluateDeadAirDetector(
+        buffer: safeBuffer, sessionID: self.activeCaptureGeneration)
       self.hasReceivedBufferThisSession = true
       self.audioLevel = audioLevel
       self.bufferContinuation?.yield(safeBuffer)

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -210,21 +210,25 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
   public var zeroSignalDiscriminatorDeviceID: AudioDeviceID? { effectiveDiscriminatorDeviceID }
 
-  /// #1317 (cloud review round 2, P2): true once THIS session's reactive
-  /// detector has observed a zero-signal-candidate buffer while the device
-  /// discriminator was ineligible (muted, or mute-unknown). The device's
-  /// mute state can change mid-recording — the discriminator legitimately
-  /// re-checks it live on every buffer — but a STOP-time discriminator
-  /// check that ONLY reads the CURRENT (possibly since-unmuted) state would
-  /// mislabel a recording that was genuinely muted during its silent
-  /// stretch as the harness glitch, just because the user unmuted right
-  /// before releasing. This latch makes that earlier ineligible result
-  /// stick: once true, the STOP-time backstop fails closed for the rest of
-  /// the session regardless of the device's current live state. Reset in
-  /// `beginCapturePhase` alongside `deadAirDetector` (same session-scope as
-  /// the reactive detector itself); per the invariant on
-  /// `effectiveDiscriminatorDeviceID` above, no teardown path may clear it
-  /// early.
+  /// #1317 (cloud review round 2, P2; scope narrowed round 3, P2): true
+  /// once the CURRENT trailing all-zero run (not the whole session — see
+  /// below) has been observed while the device discriminator was
+  /// ineligible (muted, or mute-unknown). The device's mute state can
+  /// change mid-recording — the discriminator legitimately re-checks it
+  /// live on every buffer — but a STOP-time discriminator check that ONLY
+  /// reads the CURRENT (possibly since-unmuted) state would mislabel a
+  /// recording that was genuinely muted during its silent stretch as the
+  /// harness glitch, just because the user unmuted right before releasing.
+  /// This latch makes that earlier ineligible result stick for THAT run.
+  /// Scoped to the current run, not session-wide: `evaluateDeadAirDetector`
+  /// clears it the moment a non-zero sample breaks the trailing zero-run
+  /// (`consecutiveExactZeroSuffix` resets), because an earlier resolved
+  /// mute must not blind the backstop to a later, unrelated genuine
+  /// zero-signal failure elsewhere in the same recording (round 3: a
+  /// session-wide latch did exactly that). Reset in `beginCapturePhase`
+  /// alongside `deadAirDetector` (same session-scope as the reactive
+  /// detector itself); per the invariant on `effectiveDiscriminatorDeviceID`
+  /// above, no teardown path may clear it early.
   private var sawIneligibleZeroSignalDuringSession = false
 
   public var zeroSignalDiscriminatorSawIneligible: Bool { sawIneligibleZeroSignalDuringSession }
@@ -515,7 +519,19 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     else { return }
     let frameCount = Int(buffer.frameLength)
     guard frameCount > 0 else { return }
+    let suffixBefore = deadAirDetector.consecutiveExactZeroSuffix
     deadAirDetector.ingest(UnsafeBufferPointer(start: channelData[0], count: frameCount))
+    // #1317 (cloud review round 3, P2): a non-zero sample anywhere in this
+    // buffer breaks the trailing zero-run — `consecutiveExactZeroSuffix`
+    // after ingest is then strictly less than `suffixBefore + frameCount`
+    // (it only counts zeros AFTER the last non-zero sample). Any earlier
+    // ineligible (muted) result applied to THAT run, not this new one, so it
+    // must not suppress detection of a later, unrelated zero-signal failure
+    // (an earlier accidental mute-then-unmute must not blind the backstop
+    // to a genuine harness glitch later in the same recording).
+    if deadAirDetector.consecutiveExactZeroSuffix != suffixBefore + frameCount {
+      sawIneligibleZeroSignalDuringSession = false
+    }
 
     let mode: CaptureStallFailureMode
     if deadAirDetector.isAllZeroFromStart {

--- a/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureProxy.swift
@@ -210,6 +210,25 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
 
   public var zeroSignalDiscriminatorDeviceID: AudioDeviceID? { effectiveDiscriminatorDeviceID }
 
+  /// #1317 (cloud review round 2, P2): true once THIS session's reactive
+  /// detector has observed a zero-signal-candidate buffer while the device
+  /// discriminator was ineligible (muted, or mute-unknown). The device's
+  /// mute state can change mid-recording — the discriminator legitimately
+  /// re-checks it live on every buffer — but a STOP-time discriminator
+  /// check that ONLY reads the CURRENT (possibly since-unmuted) state would
+  /// mislabel a recording that was genuinely muted during its silent
+  /// stretch as the harness glitch, just because the user unmuted right
+  /// before releasing. This latch makes that earlier ineligible result
+  /// stick: once true, the STOP-time backstop fails closed for the rest of
+  /// the session regardless of the device's current live state. Reset in
+  /// `beginCapturePhase` alongside `deadAirDetector` (same session-scope as
+  /// the reactive detector itself); per the invariant on
+  /// `effectiveDiscriminatorDeviceID` above, no teardown path may clear it
+  /// early.
+  private var sawIneligibleZeroSignalDuringSession = false
+
+  public var zeroSignalDiscriminatorSawIneligible: Bool { sawIneligibleZeroSignalDuringSession }
+
   // MARK: - Capture-liveness watchdog (issue #285)
 
   /// Private serial queue that fires the stall `DispatchWorkItem`.
@@ -403,6 +422,7 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     hasReceivedBufferThisSession = false
     deadAirDetector = DeadAirStreamingDetector()
     captureStallReported = false
+    sawIneligibleZeroSignalDuringSession = false
     armCaptureStallWatchdog()
     return stream
   }
@@ -514,7 +534,14 @@ public final class AudioCaptureProxy: AudioCaptureInterface {
     guard
       let deviceID = effectiveDiscriminatorDeviceID,
       ZeroSignalDeviceDiscriminator.isEligible(deviceID: deviceID)
-    else { return }
+    else {
+      // #1317 (cloud review round 2, P2): a zero-signal-candidate buffer was
+      // observed while ineligible (muted) — latch it so the STOP-time
+      // backstop can't later see a since-unmuted live state and misclassify
+      // this genuinely-muted stretch as the harness glitch.
+      sawIneligibleZeroSignalDuringSession = true
+      return
+    }
 
     deadAirDetector.fired = true
     captureStallReported = true

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -87,6 +87,29 @@ public enum AudioDeviceEnumerator {
     return devices.first(where: { $0.uid == uid })?.id
   }
 
+  /// #1317 §3.0: resolves the ONE `AudioDeviceID` a capture session is
+  /// actually using, for the all-zero harness-glitch discriminator's
+  /// device-alive + not-muted read. Same precedence `AudioCaptureManager`
+  /// already applies for effective-device comparison: the bound override
+  /// wins when set, else the user's selected UID, else the system default.
+  /// Returns nil when none resolves to a live device — callers must fail
+  /// closed on nil (§3.0: mute-unknown fails closed, never treated as
+  /// unmuted).
+  ///
+  /// An explicit UID that fails to resolve does NOT fall back to the system
+  /// default (Codex code-diff review): a vanished explicitly-selected device
+  /// is a hardware-removal case, out of #1317's scope, and substituting an
+  /// unrelated device's alive/mute state would misclassify that removal as
+  /// the software harness glitch. Only the ABSENCE of an explicit UID (the
+  /// user is on system-default / "Auto") falls through to the default.
+  public static func resolveEffectiveInputDevice(
+    preferredOverride: String, selected: String
+  ) -> AudioDeviceID? {
+    let uid = !preferredOverride.isEmpty ? preferredOverride : selected
+    guard !uid.isEmpty else { return defaultInputDeviceID() }
+    return deviceID(forUID: uid)
+  }
+
   /// Returns the UID of the current system-default input device, or nil if
   /// none. Used by Sentry extras (`capture.input_device_uid_system_default`)
   /// so divergence vs the preferred device is measured correctly.

--- a/Sources/EnviousWisprAudio/CoreAudioDeviceLiveness.swift
+++ b/Sources/EnviousWisprAudio/CoreAudioDeviceLiveness.swift
@@ -74,3 +74,79 @@ public enum CoreAudioDeviceLiveness {
     return interpret(status: status, isAlive: isAlive)
   }
 }
+
+/// #1317. What Core Audio told us when we asked whether an input device is
+/// muted at the OS/process level. A running, alive device legitimately
+/// zero-fills its stream while muted — this is the discriminator that keeps
+/// the #1317 harness-glitch detector from misfiring on a genuinely muted mic
+/// (out of scope; no hardware-mute UX is built here, §3.0).
+public enum DeviceMuteState: Sendable, Equatable {
+  /// `Mute` answered yes — a running device zero-filling by design, not a
+  /// harness glitch.
+  case muted
+  /// `Mute` answered no.
+  case unmuted
+  /// Core Audio failed the query, or it doesn't support the property (common
+  /// on devices with no hardware mute control). We do NOT know whether the
+  /// device is muted, so the caller must fail closed — same posture as
+  /// `DeviceLiveness.unverified`.
+  case unverified
+}
+
+/// The single home for reading `kAudioDevicePropertyMute` on the INPUT scope
+/// and turning the result into a `DeviceMuteState`. Mirrors
+/// `CoreAudioDeviceLiveness`'s split (pure `interpret` + `classify` read) so
+/// the decision unit-tests across the whole status space without a real
+/// device.
+public enum CoreAudioDeviceMute {
+
+  /// The pure decision, split out for boundary testing.
+  ///
+  /// - Parameter isMuted: the out-parameter as Core Audio left it. Meaningful
+  ///   ONLY when `status == noErr`; on every other status it is still its
+  ///   zero initializer and is deliberately not read.
+  public static func interpret(status: OSStatus, isMuted: UInt32) -> DeviceMuteState {
+    switch status {
+    case noErr:
+      return isMuted == 0 ? .unmuted : .muted
+
+    // Many input devices (most built-in mics) have no hardware mute control
+    // and simply don't implement this property — that is NOT evidence the
+    // device is unmuted, so it must fail closed to `.unverified`, same as
+    // any other non-`noErr` status.
+    default:
+      return .unverified
+    }
+  }
+
+  /// Performs the read against Core Audio and interprets it. INPUT scope
+  /// (not global) — `kAudioDevicePropertyMute` on the global scope answers a
+  /// different (usually unsupported) question for an input-only device.
+  public static func classify(deviceID: AudioDeviceID) -> DeviceMuteState {
+    var isMuted: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var addr = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyMute,
+      mScope: kAudioObjectPropertyScopeInput,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    guard AudioObjectHasProperty(deviceID, &addr) else { return .unverified }
+    let status = AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &isMuted)
+    return interpret(status: status, isMuted: isMuted)
+  }
+}
+
+/// #1317 §3.0: the single, shared "is this device eligible for harness-glitch
+/// recovery" decision — device `.alive` AND NOT muted. Both the app-side
+/// reactive detector (`AudioCaptureProxy`) and the kernel's STOP-time
+/// classification read through this ONE function so the discriminator has a
+/// single authority, not two independent alive+mute combinations.
+public enum ZeroSignalDeviceDiscriminator {
+  /// Fails closed: any non-`.alive` liveness or non-`.unmuted` mute state —
+  /// including `.unverified` — returns false. #1317 adds no hardware-mute
+  /// UX; ambiguity must never be read as "safe to run harness recovery."
+  public static func isEligible(deviceID: AudioDeviceID) -> Bool {
+    CoreAudioDeviceLiveness.classify(deviceID: deviceID) == .alive
+      && CoreAudioDeviceMute.classify(deviceID: deviceID) == .unmuted
+  }
+}

--- a/Sources/EnviousWisprAudio/DeadAirStreamingDetector.swift
+++ b/Sources/EnviousWisprAudio/DeadAirStreamingDetector.swift
@@ -1,0 +1,78 @@
+import EnviousWisprCore
+
+/// #1317: per-capture-generation streaming state for the app-side all-zero
+/// harness-glitch detector. Maintains, incrementally as buffers arrive, the
+/// SAME statistics `RawAudioDeadAirClassifier.isDeadAir` would compute over
+/// the full concatenated sample array up to this point — so a streaming
+/// classification made buffer-by-buffer agrees with a one-shot classification
+/// made over the same samples after the fact, even when a 40 ms tile boundary
+/// falls across two buffers (the split-buffer-boundary equivalence test).
+///
+/// Tiles are non-overlapping and capture-start-aligned (index 0 of the whole
+/// capture, not per-buffer) — a sliding window would classify differently and
+/// break that equivalence (`RawAudioDeadAirClassifier.isDeadAir`'s own
+/// non-overlapping semantics, mirrored here).
+struct DeadAirStreamingDetector {
+  private(set) var totalSampleCount = 0
+  private(set) var consecutiveExactZeroSuffix = 0
+  private(set) var runningPeak: Float = 0
+  private var runningSumSquares: Double = 0
+  private var partialTileCount = 0
+  private var partialTileSumSquares: Float = 0
+  private(set) var maxCompletedTileRms: Float = 0
+  /// Latches true the first time the accumulated prefix is evaluated as NOT
+  /// dead air. One-way: does not un-set as later trailing zeros dilute the
+  /// running whole-prefix average — "was there ever real signal" is the
+  /// question, not "is the average right now above the floor."
+  private(set) var meaningfulSignalSeen = false
+  /// Set once a mode has been reported so the caller ingests without
+  /// re-evaluating a capture already handed off for recovery.
+  var fired = false
+
+  private var window: Int { RawAudioDeadAirClassifier.DeadAirFloor.windowSamples }
+
+  mutating func ingest(_ samples: UnsafeBufferPointer<Float>) {
+    guard !fired else { return }
+    for s in samples {
+      totalSampleCount += 1
+      let a = abs(s)
+      if a > runningPeak { runningPeak = a }
+      runningSumSquares += Double(s) * Double(s)
+      consecutiveExactZeroSuffix = s == 0 ? consecutiveExactZeroSuffix + 1 : 0
+      partialTileSumSquares += s * s
+      partialTileCount += 1
+      if partialTileCount == window {
+        let tileRms = (partialTileSumSquares / Float(window)).squareRoot()
+        if tileRms > maxCompletedTileRms { maxCompletedTileRms = tileRms }
+        partialTileCount = 0
+        partialTileSumSquares = 0
+      }
+    }
+    updateMeaningfulSignalSeen()
+  }
+
+  private mutating func updateMeaningfulSignalSeen() {
+    guard !meaningfulSignalSeen, totalSampleCount > 0 else { return }
+    let rms = Float((runningSumSquares / Double(totalSampleCount)).squareRoot())
+    let floor = RawAudioDeadAirClassifier.DeadAirFloor.self
+    let isDeadAirSoFar =
+      runningPeak < floor.peak
+      && rms < floor.rms
+      && maxCompletedTileRms < floor.windowRms
+    if !isDeadAirSoFar { meaningfulSignalSeen = true }
+  }
+
+  /// `total received >= minimumTranscriptionSamples AND every received
+  /// sample exactly zero` (#1317 §3.1).
+  var isAllZeroFromStart: Bool {
+    totalSampleCount >= AudioConstants.minimumTranscriptionSamples
+      && consecutiveExactZeroSuffix == totalSampleCount
+  }
+
+  /// `meaningfulSignalSeen was set, then a sustained suffix of >=
+  /// minimumTranscriptionSamples CONSECUTIVE exact-zero samples` (#1317 §3.1).
+  var isBecameZeroMidCapture: Bool {
+    meaningfulSignalSeen
+      && consecutiveExactZeroSuffix >= AudioConstants.minimumTranscriptionSamples
+  }
+}

--- a/Sources/EnviousWisprCore/RawAudioDeadAirClassifier.swift
+++ b/Sources/EnviousWisprCore/RawAudioDeadAirClassifier.swift
@@ -30,7 +30,8 @@ public enum RawAudioDeadAirClassifier {
   /// Otherwise it falls through and lets Parakeet decide. Pure + static so
   /// the boundary cases (just-below / just-above each threshold) unit-test
   /// without a kernel.
-  public static func isDeadAir(_ samples: [Float], peak: Float) -> Bool {
+  public static func isDeadAir<C: RandomAccessCollection>(_ samples: C, peak: Float) -> Bool
+  where C.Element == Float, C.Index == Int {
     guard peak < DeadAirFloor.peak else { return false }
     guard !samples.isEmpty else { return true }
     var sumSquares: Float = 0
@@ -39,17 +40,20 @@ public enum RawAudioDeadAirClassifier {
     guard rms < DeadAirFloor.rms else { return false }
     // Loudest non-overlapping 40 ms window. A faint word lifts a local
     // window's RMS even when most of the buffer is silence around it; tiled
-    // windows keep this bounded at O(n).
+    // windows keep this bounded at O(n). Indices are offset from
+    // `samples.startIndex`, not 0 — an `ArraySlice` (e.g. a prefix view into
+    // a larger buffer, #1317 cloud review) does NOT start at index 0, so raw
+    // `0..<window`-style indexing would read the wrong elements or trap.
     let window = DeadAirFloor.windowSamples
     guard samples.count >= window else { return rms < DeadAirFloor.windowRms }
     var maxWindowRms = rms
-    var i = 0
-    while i + window <= samples.count {
+    var windowStart = samples.startIndex
+    while windowStart + window <= samples.endIndex {
       var ss: Float = 0
-      for j in i..<(i + window) { ss += samples[j] * samples[j] }
+      for j in windowStart..<(windowStart + window) { ss += samples[j] * samples[j] }
       let wr = (ss / Float(window)).squareRoot()
       if wr > maxWindowRms { maxWindowRms = wr }
-      i += window
+      windowStart += window
     }
     return maxWindowRms < DeadAirFloor.windowRms
   }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -872,6 +872,16 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   public var lastAudioInterruptionCause: EngineInterruptionCause? {
     kernel.lastAudioInterruptionCause
   }
+  /// #1317: non-nil when the most recent recording was classified as the
+  /// mic-harness all-zero glitch (`allZeroFromStart` = the `.zeroSignal`
+  /// pill; `becameZeroMidCapture` = a normal completion whose disclosure
+  /// must say "may be missing its tail" instead of the interruption-cause
+  /// derived sentence, since no `EngineInterruptionCause` is ever stamped
+  /// for this path, §3.5). LIVE pass-through from the kernel; never
+  /// persisted.
+  public var lastZeroSignalFailureMode: CaptureStallFailureMode? {
+    kernel.zeroSignalFailureMode
+  }
   /// #1376: the resolved-route transports for the most recent recording, for
   /// the App layer's `dictation.completed` telemetry. LIVE pass-through from the
   /// kernel; never persisted. Low-cardinality transport/reason strings only.
@@ -1499,6 +1509,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       return "No speech detected. Your clipboard is unchanged. Try again."
     case .captureStalled:
       return "No audio detected — try again."
+    case .zeroSignal:
+      // #1317 PR2: the harness delivered all-zero audio from a running,
+      // unmuted mic. Honest, no auto-reset yet — PR3 adds the rebuild and
+      // upgrades this to "Mic problem. Resetting it."
+      return "Couldn't hear your mic. Try again."
     }
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -407,6 +407,13 @@ public enum KernelDictationDriverFactory {
       zombieZeroPeakTelemetry: { ctx in
         emitter.zombieZeroPeak(ctx: ctx)
       },
+      // #1317 §3.6 N4: the kernel's STOP-time classification does not
+      // traverse the reactive WedgeRecoveryRouter funnel, so it submits its
+      // own event through this closure — wired to the SAME emitter authority
+      // the reactive path uses (per-mode dedup makes a duplicate safe).
+      stopTimeZeroSignalTelemetry: { ctx in
+        emitter.stallFired(ctx: ctx, isActivelyCapturing: false)
+      },
       recordingStoppedTelemetry: { sampleCount in
         telemetryRelay.emitRecordingStopped(sampleCount: sampleCount)
       },

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -669,6 +669,13 @@ final class KernelLifecycleTelemetrySink {
       // fire → Sentry double-counts. Skip-not-share is preferred over an
       // explicit shared dedup contract (scope creep for PR-4b.2).
       break
+    case .zeroSignal:
+      // #1317: same posture as `.captureStalled` above — NO second Sentry
+      // emission. `HeartPathTelemetryEmitter.stallFired(ctx:)` already owns
+      // the classified event, submitted either through the reactive
+      // `WedgeRecoveryRouter` funnel or the kernel's STOP-time telemetry
+      // closure (§3.6 N4). The lifecycle event still fires here.
+      break
     case .noAudioCaptured:
       // Build the rich `NoAudioContext` (route, active-capture, source,
       // device IDs) and route through the injected sink. Default impl

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -36,6 +36,12 @@ final class KernelTelemetryState {
   /// copy. Cleared ONLY by `resetForNewSession()` below — a second clearer would
   /// let a stale cause leak into the next session and mis-fire the floor.
   var interruptionCause: EngineInterruptionCause?
+  /// #1317: the classified zero-signal failure mode for this session (nil =
+  /// never classified). Stamped once, by whichever classification wins
+  /// (reactive `.zeroSignal` exit OR STOP-time, §3.6) — drives the
+  /// `.zeroSignal` pill for `allZeroFromStart` and the partial-capture
+  /// disclosure for `becameZeroMidCapture` (§3.5).
+  var zeroSignalFailureMode: CaptureStallFailureMode?
 
   func resetForNewSession(polishEnabled: Bool) {
     self.polishEnabled = polishEnabled
@@ -49,6 +55,7 @@ final class KernelTelemetryState {
     modelLoadError = nil
     captureHealth = nil
     interruptionCause = nil
+    zeroSignalFailureMode = nil
   }
 }
 

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -218,12 +218,13 @@ final class RecordingSessionKernel {
   /// injected (not a direct `AudioDeviceEnumerator`/`ZeroSignalDeviceDiscriminator`
   /// call) so deterministic kernel tests can substitute a fake instead of
   /// depending on the test machine's real microphone state. The production
-  /// default resolves the SAME bound/selected/default precedence the
-  /// reactive detector uses (`AudioCaptureInterface.preferredInputDeviceIDOverride`
-  /// / `.selectedInputDeviceUID`) — the device the session actually captured
-  /// from, not unconditionally the system default (Codex code-diff review:
-  /// a selected non-default mic muted while the system default happens to
-  /// be alive+unmuted must not misclassify as eligible).
+  /// default checks `audioCapture.zeroSignalDiscriminatorDeviceID` — the
+  /// device the CAPTURE LAYER froze at its own engine-start moment (cloud
+  /// review P2 round 2, PR #1512: only that layer sees its own internal
+  /// retries, so the kernel defers to it instead of independently freezing
+  /// its own snapshot, which could still race a mid-startup device switch).
+  /// Alive/mute status is still re-checked live against that frozen device
+  /// on every call — only the device IDENTITY is frozen, not its mute state.
   private let zeroSignalDeviceEligible: @MainActor () -> Bool
   private let recordingStoppedTelemetry: @MainActor (_ sampleCount: Int) -> Void
   private let markPipelineTimingStart: @MainActor () -> Void
@@ -429,6 +430,15 @@ final class RecordingSessionKernel {
   private var stoppingStartedAtTick: UInt64?
   private var recordingStartedAtDate: Date?
 
+  /// #1317 (cloud review P2, PR #1512): `DispatchTime.now().uptimeNanoseconds`
+  /// at the `→ recording` transition. `CaptureStallContext.armedAtUptimeNs`
+  /// shares this clock domain (not `recordingStartedAtDate`'s wall clock) —
+  /// the STOP-time zero-signal backstop needs a real arm time so
+  /// `SentryAudioExtras.buildCaptureExtras`'s `capture.stall.window_ms`
+  /// reflects THIS recording's length, not machine uptime. `nil` outside
+  /// `.recording`; reset on every session start alongside `recordingStartedAtDate`.
+  private var recordingStartedAtUptimeNs: UInt64?
+
   /// Fired at most once per recording when the VAD seam reports the recording is
   /// approaching `maxRecordingDuration` (#1060), carrying the remaining seconds.
   /// ADVISORY: the kernel does NOT stop on this (that is the separate stop
@@ -600,13 +610,12 @@ final class RecordingSessionKernel {
     minimumRecordingTicks: Int = 5,
     zombieZeroPeakTelemetry: @escaping @MainActor (ZeroPeakContext) -> Void = { _ in },
     stopTimeZeroSignalTelemetry: @escaping @MainActor (CaptureStallContext) -> Void = { _ in },
-    // #1317 (Codex code-diff review): nil default resolves inside `init`
-    // against the `audioCapture` PARAMETER (a default expression cannot
-    // reference a sibling parameter) — using the SAME bound/selected/default
-    // precedence the reactive detector uses (`AudioCaptureInterface` already
-    // exposes `preferredInputDeviceIDOverride`/`selectedInputDeviceUID`, so
-    // this checks the device the session actually captured from, not
-    // unconditionally the system default).
+    // #1317 (cloud review P2 round 2, PR #1512): nil default resolves inside
+    // `init` against the `audioCapture` PARAMETER's own
+    // `zeroSignalDiscriminatorDeviceID` — the device the capture layer
+    // itself froze at its engine-start moment (see that protocol property's
+    // doc for why the kernel defers to it instead of independently
+    // resolving `preferredInputDeviceIDOverride`/`selectedInputDeviceUID`).
     zeroSignalDeviceEligible: (@MainActor () -> Bool)? = nil,
     recordingStoppedTelemetry: @escaping @MainActor (_ sampleCount: Int) -> Void = { _ in },
     markPipelineTimingStart: @escaping @MainActor () -> Void = {},
@@ -627,14 +636,17 @@ final class RecordingSessionKernel {
     self.minimumRecordingTicks = minimumRecordingTicks
     self.zombieZeroPeakTelemetry = zombieZeroPeakTelemetry
     self.stopTimeZeroSignalTelemetry = stopTimeZeroSignalTelemetry
+    // #1317 (cloud review P2 round 2, PR #1512): the default reads
+    // `audioCapture.zeroSignalDiscriminatorDeviceID` — the device the
+    // capture layer itself froze at the moment its engine actually started
+    // (including any of ITS OWN retries, which this kernel cannot see) —
+    // instead of independently re-resolving `preferredInputDeviceIDOverride`/
+    // `selectedInputDeviceUID`, which only reflects the kernel's OWN view
+    // and can already differ from what actually got captured.
     self.zeroSignalDeviceEligible =
       zeroSignalDeviceEligible
       ?? {
-        guard
-          let deviceID = AudioDeviceEnumerator.resolveEffectiveInputDevice(
-            preferredOverride: audioCapture.preferredInputDeviceIDOverride,
-            selected: audioCapture.selectedInputDeviceUID)
-        else { return false }
+        guard let deviceID = audioCapture.zeroSignalDiscriminatorDeviceID else { return false }
         return ZeroSignalDeviceDiscriminator.isEligible(deviceID: deviceID)
       }
     self.recordingStoppedTelemetry = recordingStoppedTelemetry
@@ -1070,6 +1082,7 @@ final class RecordingSessionKernel {
     // Recording.
     transition(to: .recording)
     recordingStartedAtDate = Date()
+    recordingStartedAtUptimeNs = DispatchTime.now().uptimeNanoseconds
     lastStopReason = nil  // #1060: clear prior session's stop reason.
     lastSalvagedLeadTrimMs = nil  // #1434: clear prior session's salvage marker.
     lastCaptureHealth = nil  // #1434: clear prior session's capture health.
@@ -1276,7 +1289,7 @@ final class RecordingSessionKernel {
       stopTimeZeroSignalTelemetry(
         CaptureStallContext(
           sessionID: audioCapture.currentCaptureSessionID,
-          armedAtUptimeNs: 0,
+          armedAtUptimeNs: recordingStartedAtUptimeNs ?? DispatchTime.now().uptimeNanoseconds,
           firedAtUptimeNs: DispatchTime.now().uptimeNanoseconds,
           route: audioCapture.currentAudioRoute,
           sourceType: "stop_time_classification",
@@ -2729,6 +2742,7 @@ final class RecordingSessionKernel {
     recordingStartedAtTick = nil
     stoppingStartedAtTick = nil
     recordingStartedAtDate = nil
+    recordingStartedAtUptimeNs = nil
     loadTickCount = 0
     finalizeTickCount = 0
     loadAttemptStartedAtTick = 0

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1201,7 +1201,7 @@ final class RecordingSessionKernel {
     // capture-teardown latency does not count as visible-recording time.
     stoppingStartedAtTick = currentTick()
     captureLifecycle = .stopping
-    let captureResult = await audioCapture.stopCapture()
+    var captureResult = await audioCapture.stopCapture()
     // Guard BEFORE touching kernel state — if a new session started while
     // `stopCapture()` was suspended, these fields belong to that session now
     // (Codex P2-round4 stale-completion guard).
@@ -1322,8 +1322,30 @@ final class RecordingSessionKernel {
         finishTerminal(.failed(.zeroSignal), sid: sid)
         return
       }
-      // .becameZeroMidCapture: fall through unchanged — ASR transcribes the
-      // non-zero prefix already in captureResult.samples (§3.4).
+      // .becameZeroMidCapture: fall through — trimmed below (§3.4).
+    }
+
+    // #1317 fast-follow (cloud review PR #1512 + live UAT repro): trim the
+    // confirmed trailing zero suffix out of the salvaged capture ONCE, here —
+    // the single point downstream of BOTH ways `.becameZeroMidCapture` gets
+    // confirmed (the reactive mid-capture detector, stamped at
+    // `telemetryState.zeroSignalFailureMode` above before `captureResult`
+    // even existed; or the STOP-time backstop just above) and upstream of
+    // every consumer that would otherwise average the zero suffix into a
+    // real-speech decision — the no-speech dead-air gate below, whose
+    // whole-buffer RMS a long zero suffix can dilute under a quiet real
+    // utterance's own floor (the reported bug: real words silently
+    // discarded). Device-eligibility for the STOP-time branch was already
+    // checked in the `if` above; the reactive branch was already
+    // eligibility-gated when `AudioCaptureProxy` stamped it (§3.0).
+    if telemetryState.zeroSignalFailureMode == .becameZeroMidCapture {
+      let suffixCount = Self.trailingZeroSuffixCount(captureResult.samples)
+      if suffixCount > 0 {
+        captureResult = CaptureResult(
+          samples: Array(captureResult.samples.dropLast(suffixCount)),
+          vadSegments: captureResult.vadSegments,
+          metadata: captureResult.metadata)
+      }
     }
 
     // GAP 3 app.log parity: captured-sample-count log (TP:725-729) —
@@ -1429,7 +1451,18 @@ final class RecordingSessionKernel {
     // the bundled source when present (XPC works out of the box today);
     // fall back to the seam for direct-mode (which PR-4b wires up).
     let xpcSegments = captureResult.vadSegments
-    let vadSegments = !xpcSegments.isEmpty ? xpcSegments : vad.speechSegmentsAtStop()
+    let rawVadSegments = !xpcSegments.isEmpty ? xpcSegments : vad.speechSegmentsAtStop()
+    // #1317 fast-follow (Grounded Review r1): an OPEN segment (speech never
+    // resolved to silence before the recording ended) finalizes its end at
+    // the ORIGINAL full sample count — the zero-signal reactive detector's
+    // 1s confidence window can fire before the VAD silence timeout (1.5s
+    // default) ever closes it. Clamp every segment into the buffer's ACTUAL
+    // (possibly zero-suffix-trimmed above) coordinate space so
+    // `vadSpeechDurationMs` / the adapter's `voicedDurationSec` / LID window
+    // count never count samples that no longer exist — `SampleFilter` and
+    // WhisperKit's own backend already clamp defensively so this was never a
+    // crash risk, only a silently-inflated-duration one.
+    let vadSegments = Self.clampSegments(rawVadSegments, to: captureResult.samples.count)
     // PR-5 Rung 2B (#827): push the kernel-computed VAD speech segments to
     // the adapter at finalize-time, BEFORE the kernel-side conditioning
     // runs. The second engine (Rung 3) derives engine-specific decode
@@ -2962,6 +2995,36 @@ final class RecordingSessionKernel {
     RawAudioDeadAirClassifier.isDeadAir(samples, peak: peak)
   }
 
+  /// #1317 fast-follow: exact count of trailing exact-zero samples — the one
+  /// authority both `classifyZeroSignalAtStop` (below) and the post-capture
+  /// `.becameZeroMidCapture` trim in `runForwardPath` use, so the trim
+  /// boundary can never disagree with the classification decision that named
+  /// the session `.becameZeroMidCapture` in the first place.
+  nonisolated static func trailingZeroSuffixCount(_ samples: [Float]) -> Int {
+    var count = 0
+    for s in samples.reversed() {
+      if s == 0 { count += 1 } else { break }
+    }
+    return count
+  }
+
+  /// #1317 fast-follow (Grounded Review r1): clamps every segment's
+  /// start/end into `[0, sampleCount]`, dropping a segment that no longer
+  /// has any span once clamped. Pure so the boundary cases (in-range,
+  /// dangling past the boundary, entirely past the boundary) unit-test
+  /// without a kernel. See the call site in `runForwardPath` for why an
+  /// open VAD segment can reference a sample count the buffer no longer has.
+  nonisolated static func clampSegments(_ segments: [SpeechSegment], to sampleCount: Int)
+    -> [SpeechSegment]
+  {
+    segments.compactMap { segment in
+      let start = max(0, min(segment.startSample, sampleCount))
+      let end = max(start, min(segment.endSample, sampleCount))
+      guard end > start else { return nil }
+      return SpeechSegment(startSample: start, endSample: end)
+    }
+  }
+
   /// #1317 §3.6 STOP-win row: one-shot classification of a COMPLETE capture
   /// against the same all-zero rules the app-side streaming detector applies
   /// buffer-by-buffer (§3.1) — the backstop for a session whose STOP raced
@@ -2975,10 +3038,7 @@ final class RecordingSessionKernel {
     if samples.allSatisfy({ $0 == 0 }) {
       return .allZeroFromStart
     }
-    var suffixZeroCount = 0
-    for s in samples.reversed() {
-      if s == 0 { suffixZeroCount += 1 } else { break }
-    }
+    let suffixZeroCount = Self.trailingZeroSuffixCount(samples)
     guard suffixZeroCount >= AudioConstants.minimumTranscriptionSamples else { return nil }
     let prefixCount = samples.count - suffixZeroCount
     guard prefixCount > 0 else { return nil }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -35,6 +35,11 @@ public enum RecordingFailureReason: Equatable, Sendable {
   case asrWedged
   case emptyAfterProcessing
   case captureStalled
+  /// #1317: the mic HARNESS delivered all-zero audio from a running,
+  /// unmuted device — distinct from `.captureStalled` (no buffers at all).
+  /// Fires only for `.allZeroFromStart`; `.becameZeroMidCapture` completes
+  /// normally with the salvaged prefix (§3.5).
+  case zeroSignal
 }
 
 /// The 14 recording-session FSM states (PR-1 §B.1.1). Seven are terminal.
@@ -201,6 +206,25 @@ final class RecordingSessionKernel {
   // MARK: Telemetry fan-out
 
   private let zombieZeroPeakTelemetry: @MainActor (ZeroPeakContext) -> Void
+  /// #1317 §3.6 N4: STOP-time zero-signal classification runs INSIDE the
+  /// kernel after `stopCapture()` and does not traverse the reactive
+  /// `WedgeRecoveryRouter` funnel that the app-side detector's event rides —
+  /// so it submits its own event through this closure, wired to the SAME
+  /// `HeartPathTelemetryEmitter.stallFired` authority the reactive path
+  /// uses. The emitter's per-mode dedup makes a duplicate submission (both
+  /// paths agreeing on the same session + mode) safe.
+  private let stopTimeZeroSignalTelemetry: @MainActor (CaptureStallContext) -> Void
+  /// #1317 §3.0/§3.6: the STOP-time device-alive/not-muted discriminator,
+  /// injected (not a direct `AudioDeviceEnumerator`/`ZeroSignalDeviceDiscriminator`
+  /// call) so deterministic kernel tests can substitute a fake instead of
+  /// depending on the test machine's real microphone state. The production
+  /// default resolves the SAME bound/selected/default precedence the
+  /// reactive detector uses (`AudioCaptureInterface.preferredInputDeviceIDOverride`
+  /// / `.selectedInputDeviceUID`) — the device the session actually captured
+  /// from, not unconditionally the system default (Codex code-diff review:
+  /// a selected non-default mic muted while the system default happens to
+  /// be alive+unmuted must not misclassify as eligible).
+  private let zeroSignalDeviceEligible: @MainActor () -> Bool
   private let recordingStoppedTelemetry: @MainActor (_ sampleCount: Int) -> Void
   private let markPipelineTimingStart: @MainActor () -> Void
   private let markASRTimingStart: @MainActor (_ streaming: Bool) -> Void
@@ -266,6 +290,17 @@ final class RecordingSessionKernel {
   /// `resetForNewSession()`, which `start(config:)` calls before `.preparing`.
   var lastAudioInterruptionCause: EngineInterruptionCause? {
     telemetryState.interruptionCause
+  }
+
+  /// #1317: which zero-signal failure mode this session was classified as, or
+  /// `nil` if it never was. Stamped once by the winning classification
+  /// (reactive `.zeroSignal` exit OR STOP-time), cleared per session in
+  /// `KernelTelemetryState.resetForNewSession`. Drives both the
+  /// `.zeroSignal` pill (`allZeroFromStart`) and the partial-capture
+  /// disclosure (`becameZeroMidCapture`) — read-through to
+  /// `KernelTelemetryState.zeroSignalFailureMode`, the single home (§3.5).
+  var zeroSignalFailureMode: CaptureStallFailureMode? {
+    telemetryState.zeroSignalFailureMode
   }
 
   /// #1434: per-session stabilization outcome (set at the pre-capture
@@ -539,6 +574,10 @@ final class RecordingSessionKernel {
     case vadAutoStop
     case maxDuration
     case captureStall
+    /// #1317: the all-zero harness-glitch exit, dedicated (not `.captureStall`,
+    /// which discards the captured result — this exit runs the normal stop
+    /// path so a `.becameZeroMidCapture` prefix survives, §3.2).
+    case zeroSignal(CaptureStallFailureMode)
     case audioInterruption
     case asrInterruption
     case cancel
@@ -560,6 +599,15 @@ final class RecordingSessionKernel {
     wedgeStallTicks: Int = 2,
     minimumRecordingTicks: Int = 5,
     zombieZeroPeakTelemetry: @escaping @MainActor (ZeroPeakContext) -> Void = { _ in },
+    stopTimeZeroSignalTelemetry: @escaping @MainActor (CaptureStallContext) -> Void = { _ in },
+    // #1317 (Codex code-diff review): nil default resolves inside `init`
+    // against the `audioCapture` PARAMETER (a default expression cannot
+    // reference a sibling parameter) — using the SAME bound/selected/default
+    // precedence the reactive detector uses (`AudioCaptureInterface` already
+    // exposes `preferredInputDeviceIDOverride`/`selectedInputDeviceUID`, so
+    // this checks the device the session actually captured from, not
+    // unconditionally the system default).
+    zeroSignalDeviceEligible: (@MainActor () -> Bool)? = nil,
     recordingStoppedTelemetry: @escaping @MainActor (_ sampleCount: Int) -> Void = { _ in },
     markPipelineTimingStart: @escaping @MainActor () -> Void = {},
     markASRTimingStart: @escaping @MainActor (_ streaming: Bool) -> Void = { _ in },
@@ -578,6 +626,17 @@ final class RecordingSessionKernel {
     self.wedgeStallTicks = wedgeStallTicks
     self.minimumRecordingTicks = minimumRecordingTicks
     self.zombieZeroPeakTelemetry = zombieZeroPeakTelemetry
+    self.stopTimeZeroSignalTelemetry = stopTimeZeroSignalTelemetry
+    self.zeroSignalDeviceEligible =
+      zeroSignalDeviceEligible
+      ?? {
+        guard
+          let deviceID = AudioDeviceEnumerator.resolveEffectiveInputDevice(
+            preferredOverride: audioCapture.preferredInputDeviceIDOverride,
+            selected: audioCapture.selectedInputDeviceUID)
+        else { return false }
+        return ZeroSignalDeviceDiscriminator.isEligible(deviceID: deviceID)
+      }
     self.recordingStoppedTelemetry = recordingStoppedTelemetry
     self.markPipelineTimingStart = markPipelineTimingStart
     self.markASRTimingStart = markASRTimingStart
@@ -1064,6 +1123,27 @@ final class RecordingSessionKernel {
     case .captureStall:
       finishTerminal(.failed(.captureStalled), sid: sid)
       return
+    case .zeroSignal(let mode):
+      // #1317. Stamp the side-channel BEFORE the terminal — the pill mapper
+      // and the driver's partial-capture disclosure both read it (§3.5).
+      telemetryState.zeroSignalFailureMode = mode
+      switch mode {
+      case .noBuffers:
+        // Unreachable by construction: `externalCaptureStalled` routes
+        // `.noBuffers` to `.captureStall`, never to `.zeroSignal` (§3.2).
+        // Fail safely rather than silently mis-terminating.
+        finishTerminal(.failed(.captureStalled), sid: sid)
+        return
+      case .allZeroFromStart:
+        // Nothing to salvage — honest terminal, no normal-stop tail (§3.4).
+        finishTerminal(.failed(.zeroSignal), sid: sid)
+        return
+      case .becameZeroMidCapture:
+        // Fall through into the normal stop tail below so ASR transcribes
+        // the non-zero prefix already captured (§3.4). The rebuild (PR3)
+        // and the partial-capture disclosure both read the stamped mode.
+        break
+      }
     case .userStop, .vadAutoStop, .maxDuration:
       break
     }
@@ -1178,6 +1258,51 @@ final class RecordingSessionKernel {
       return
     }
 
+    // #1317 §3.6 STOP-win row: only when the reactive detector never fired
+    // for this session (raced by STOP, or the capture was too short to reach
+    // its own confidence threshold). MUST run before the no-speech gate
+    // below (N1) — that gate would otherwise swallow an all-zero capture as
+    // ordinary quiet-room silence. `zeroSignalDeviceEligible` resolves the
+    // SAME bound/selected/default precedence the reactive detector uses —
+    // the device the session actually captured from (Codex code-diff
+    // review: checking unconditionally the system default would misclassify
+    // a selected non-default mic that's genuinely muted while the system
+    // default happens to be alive+unmuted).
+    if telemetryState.zeroSignalFailureMode == nil,
+      let mode = Self.classifyZeroSignalAtStop(captureResult.samples),
+      zeroSignalDeviceEligible()
+    {
+      telemetryState.zeroSignalFailureMode = mode
+      stopTimeZeroSignalTelemetry(
+        CaptureStallContext(
+          sessionID: audioCapture.currentCaptureSessionID,
+          armedAtUptimeNs: 0,
+          firedAtUptimeNs: DispatchTime.now().uptimeNanoseconds,
+          route: audioCapture.currentAudioRoute,
+          sourceType: "stop_time_classification",
+          engineStartedSuccessfully: true,
+          tapInstalled: true,
+          formatMismatchObserved: false,
+          inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
+            ? nil : audioCapture.preferredInputDeviceIDOverride,
+          inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+          failureMode: mode,
+          selectedTransport: audioCapture.currentResolvedRoute?.selected,
+          effectiveTransport: audioCapture.currentResolvedRoute?.effective,
+          routeReason: audioCapture.currentResolvedRoute?.routeReason,
+          routeFallbackReason: audioCapture.currentResolvedRoute?.routeFallbackReason,
+          inputSelectionMode: audioCapture.currentResolvedRoute?.inputSelectionMode,
+          outputTransport: audioCapture.currentResolvedRoute?.outputTransport,
+          routeResolutionSource: audioCapture.currentResolvedRoute?.routeResolutionSource
+        ))
+      if mode == .allZeroFromStart {
+        finishTerminal(.failed(.zeroSignal), sid: sid)
+        return
+      }
+      // .becameZeroMidCapture: fall through unchanged — ASR transcribes the
+      // non-zero prefix already in captureResult.samples (§3.4).
+    }
+
     // GAP 3 app.log parity: captured-sample-count log (TP:725-729) —
     // gives debug-mode log readers the duration of the visible recording
     // before any VAD / conditioning runs.
@@ -1211,10 +1336,17 @@ final class RecordingSessionKernel {
           rawSampleCount: captureResult.samples.count,
           peakAudioLevel: rawPeakAudioLevel
         )
-        emitZombieZeroPeakIfNeeded(
-          rawSamples: captureResult.samples,
-          peakAudioLevel: rawPeakAudioLevel
-        )
+        // #1317 N2: a classified zero-signal session emits ONLY the new
+        // failure-mode event — never the legacy zombie telemetry too.
+        // `zombie_engine_zero_peak` stays the fallback for an exact-zero
+        // capture that was NOT confidently classified (mute/liveness
+        // ambiguity fails closed above, §3.6).
+        if telemetryState.zeroSignalFailureMode == nil {
+          emitZombieZeroPeakIfNeeded(
+            rawSamples: captureResult.samples,
+            peakAudioLevel: rawPeakAudioLevel
+          )
+        }
         // GAP 3 app.log parity: emit the VAD filtered log here too — for
         // dead-air `.confirmedNoSpeech`, conditioner never runs (we return
         // below), so the filtered count is 0 by definition. Without this, the
@@ -2145,10 +2277,18 @@ final class RecordingSessionKernel {
   /// `SessionID`), so the guard is on kernel terminal state, not ID
   /// equality — the App-side `WedgeRecoveryRouter` already filters by
   /// capture session via its own `isCurrentSession(ctx.sessionID)` check.
+  ///
+  /// #1317 §3.2: routes by `ctx.failureMode` — `.noBuffers` keeps today's
+  /// `.captureStall` exit; `.allZeroFromStart` / `.becameZeroMidCapture` take
+  /// the dedicated `.zeroSignal` exit (normal stop path, prefix survives).
   func externalCaptureStalled(_ ctx: CaptureStallContext) {
-    _ = ctx
     guard !state.isTerminal else { return }
-    deliverRecordingExitIfCurrent(.captureStall, sid: currentSessionID)
+    switch ctx.failureMode {
+    case .noBuffers:
+      deliverRecordingExitIfCurrent(.captureStall, sid: currentSessionID)
+    case .allZeroFromStart, .becameZeroMidCapture:
+      deliverRecordingExitIfCurrent(.zeroSignal(ctx.failureMode), sid: currentSessionID)
+    }
   }
 
   /// The buffer-handoff callback (PR-3 plan §3.4 — reuses the shipped
@@ -2261,6 +2401,7 @@ final class RecordingSessionKernel {
     case .vadAutoStop: lastStopReason = "vad_auto_stop"
     case .maxDuration: lastStopReason = "max_duration"
     case .captureStall: lastStopReason = "capture_stall"
+    case .zeroSignal(let mode): lastStopReason = "zero_signal_\(mode.rawValue)"
     case .audioInterruption: lastStopReason = "audio_interruption"
     case .asrInterruption: lastStopReason = "asr_interruption"
     case .cancel: lastStopReason = "cancel"
@@ -2795,6 +2936,32 @@ final class RecordingSessionKernel {
     -> Bool
   {
     RawAudioDeadAirClassifier.isDeadAir(samples, peak: peak)
+  }
+
+  /// #1317 §3.6 STOP-win row: one-shot classification of a COMPLETE capture
+  /// against the same all-zero rules the app-side streaming detector applies
+  /// buffer-by-buffer (§3.1) — the backstop for a session whose STOP raced
+  /// the detector, or whose capture was too short to reach the detector's
+  /// own confidence threshold before it ended. Pure + nonisolated so the
+  /// boundary cases unit-test without a kernel. Sample-shape only — the
+  /// caller still runs the §3.0 device-alive/not-muted discriminator before
+  /// trusting the result.
+  nonisolated static func classifyZeroSignalAtStop(_ samples: [Float]) -> CaptureStallFailureMode? {
+    guard samples.count >= AudioConstants.minimumTranscriptionSamples else { return nil }
+    if samples.allSatisfy({ $0 == 0 }) {
+      return .allZeroFromStart
+    }
+    var suffixZeroCount = 0
+    for s in samples.reversed() {
+      if s == 0 { suffixZeroCount += 1 } else { break }
+    }
+    guard suffixZeroCount >= AudioConstants.minimumTranscriptionSamples else { return nil }
+    let prefixCount = samples.count - suffixZeroCount
+    guard prefixCount > 0 else { return nil }
+    let prefix = Array(samples[0..<prefixCount])
+    let prefixPeak = prefix.reduce(Float(0)) { max($0, abs($1)) }
+    guard !RawAudioDeadAirClassifier.isDeadAir(prefix, peak: prefixPeak) else { return nil }
+    return .becameZeroMidCapture
   }
 
   /// Fraction of non-overlapping 40 ms windows in `slice` whose RMS clears the

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -224,7 +224,12 @@ final class RecordingSessionKernel {
   /// retries, so the kernel defers to it instead of independently freezing
   /// its own snapshot, which could still race a mid-startup device switch).
   /// Alive/mute status is still re-checked live against that frozen device
-  /// on every call — only the device IDENTITY is frozen, not its mute state.
+  /// on every call — only the device IDENTITY is frozen, not its mute
+  /// state — EXCEPT that `zeroSignalDiscriminatorSawIneligible` (cloud
+  /// review round 2, second P2) short-circuits to ineligible if the device
+  /// was EVER seen muted during this session's own zero-signal candidate
+  /// buffers, so a since-unmuted live re-check can't override an earlier
+  /// genuine mute.
   private let zeroSignalDeviceEligible: @MainActor () -> Bool
   private let recordingStoppedTelemetry: @MainActor (_ sampleCount: Int) -> Void
   private let markPipelineTimingStart: @MainActor () -> Void
@@ -642,10 +647,15 @@ final class RecordingSessionKernel {
     // (including any of ITS OWN retries, which this kernel cannot see) —
     // instead of independently re-resolving `preferredInputDeviceIDOverride`/
     // `selectedInputDeviceUID`, which only reflects the kernel's OWN view
-    // and can already differ from what actually got captured.
+    // and can already differ from what actually got captured. Also checks
+    // `zeroSignalDiscriminatorSawIneligible` FIRST (cloud review round 2,
+    // second P2): a live re-check here would only see the device's CURRENT
+    // mute state, which can already have changed since a genuinely-muted
+    // silent stretch — that earlier ineligible result must stick.
     self.zeroSignalDeviceEligible =
       zeroSignalDeviceEligible
       ?? {
+        guard !audioCapture.zeroSignalDiscriminatorSawIneligible else { return false }
         guard let deviceID = audioCapture.zeroSignalDiscriminatorDeviceID else { return false }
         return ZeroSignalDeviceDiscriminator.isEligible(deviceID: deviceID)
       }
@@ -2972,7 +2982,12 @@ final class RecordingSessionKernel {
     guard suffixZeroCount >= AudioConstants.minimumTranscriptionSamples else { return nil }
     let prefixCount = samples.count - suffixZeroCount
     guard prefixCount > 0 else { return nil }
-    let prefix = Array(samples[0..<prefixCount])
+    // #1317 (cloud review P2): a slice view, not `Array(samples[..<prefixCount])`
+    // — a 60-minute capture's prefix can be hundreds of MB; copying it just to
+    // compute peak/dead-air stats doubles the already-held buffer in the stop
+    // path. `isDeadAir` is generic over `RandomAccessCollection` for exactly
+    // this call.
+    let prefix = samples[0..<prefixCount]
     let prefixPeak = prefix.reduce(Float(0)) { max($0, abs($1)) }
     guard !RawAudioDeadAirClassifier.isDeadAir(prefix, peak: prefixPeak) else { return nil }
     return .becameZeroMidCapture

--- a/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
@@ -114,10 +114,19 @@ import Testing
     // transition in both handlers (the coordinator now owns deferred-switch
     // application + status refresh). Still a `var` closure (collaboratorCount stays
     // ≤ 11). Deterministic rule: actual 434 + 10 → round up to nearest 5 = 445.
+    // #1317 (2026-07-11): raised 445 → 460. Both per-backend `interruptionDisclosure:`
+    // arguments gained a one-line ternary reading `kernelDriver`/
+    // `whisperKitKernelDriver.lastZeroSignalFailureMode` before falling back to the
+    // existing `CompletionInterruptionDisclosure(cause:)` construction — a
+    // `becameZeroMidCapture` completion never stamps an `EngineInterruptionCause`
+    // (§3.4), so the disclosure has to be read off the zero-signal side-channel
+    // instead. No new collaborator: both driver properties are already-owned
+    // collaborators (collaboratorCount stays ≤ 11); no new method (nonPrivateMethodCount
+    // unchanged). Deterministic rule: actual 446 + 10 → round up to nearest 5 = 460.
     #expect(
-      count <= 445,
+      count <= 460,
       """
-      DictationLifecycleCoordinator line count exceeded: \(count) > 445. \
+      DictationLifecycleCoordinator line count exceeded: \(count) > 460. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Audio/AudioDeviceEnumeratorResolveTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioDeviceEnumeratorResolveTests.swift
@@ -1,0 +1,38 @@
+import CoreAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1317 §3.0 — `resolveEffectiveInputDevice` feeds the harness-glitch
+// discriminator. Codex code-diff review (round 2): an explicit UID that
+// fails to resolve (the selected/bound device vanished — a hardware-removal
+// case, out of #1317's scope) must fail CLOSED, not silently substitute the
+// system-default device's alive/mute state for a different microphone.
+@Suite("AudioDeviceEnumerator.resolveEffectiveInputDevice (#1317)")
+struct AudioDeviceEnumeratorResolveTests {
+
+  private let nonexistentUID = "com.enviouswispr.test.nonexistent-device-uid"
+
+  @Test("no explicit selection (both empty) falls through to the system default")
+  func noExplicitSelectionUsesDefault() {
+    let resolved = AudioDeviceEnumerator.resolveEffectiveInputDevice(
+      preferredOverride: "", selected: "")
+    #expect(resolved == AudioDeviceEnumerator.defaultInputDeviceID())
+  }
+
+  @Test(
+    "an explicit preferred override that does not resolve fails closed (nil), never the default")
+  func vanishedPreferredOverrideFailsClosed() {
+    let resolved = AudioDeviceEnumerator.resolveEffectiveInputDevice(
+      preferredOverride: nonexistentUID, selected: "")
+    #expect(resolved == nil)
+  }
+
+  @Test("an explicit selected UID that does not resolve fails closed (nil), never the default")
+  func vanishedSelectedUIDFailsClosed() {
+    let resolved = AudioDeviceEnumerator.resolveEffectiveInputDevice(
+      preferredOverride: "", selected: nonexistentUID)
+    #expect(resolved == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/CoreAudioDeviceMuteTests.swift
+++ b/Tests/EnviousWisprTests/Audio/CoreAudioDeviceMuteTests.swift
@@ -1,0 +1,63 @@
+import CoreAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1317 §3.0 — the mute read that discriminates a genuinely muted mic (a
+// running, alive device legitimately zero-filling by design) from the
+// mic-HARNESS glitch (a running, alive, UNMUTED device zero-filling because
+// the capture pipe broke). #1317 adds no hardware-mute UX; the whole point of
+// `.unverified` here is fail-closed — ambiguity must never be read as
+// "unmuted, safe to run harness recovery."
+@Suite("Core Audio device-mute classification (#1317)")
+struct CoreAudioDeviceMuteTests {
+
+  // MARK: - The three answers
+
+  @Test("noErr + isMuted == 1 → muted")
+  func mutedWhenCoreAudioSaysYes() {
+    #expect(CoreAudioDeviceMute.interpret(status: noErr, isMuted: 1) == .muted)
+  }
+
+  @Test("noErr + isMuted == 0 → unmuted")
+  func unmutedWhenCoreAudioSaysNo() {
+    #expect(CoreAudioDeviceMute.interpret(status: noErr, isMuted: 0) == .unmuted)
+  }
+
+  /// Most built-in mics have no hardware mute control and simply don't
+  /// implement `kAudioDevicePropertyMute` — that silence must fail closed,
+  /// never read as "confirmed unmuted."
+  @Test(
+    "any non-noErr status → unverified, never an unmuted claim",
+    arguments: [
+      kAudioHardwareBadObjectError,
+      kAudioHardwareBadPropertySizeError,
+      kAudioHardwareUnknownPropertyError,
+      kAudioHardwareNotRunningError,
+      kAudioHardwareUnspecifiedError,
+      OSStatus(-1),
+    ])
+  func unverifiedOnAnyFailure(status: OSStatus) {
+    #expect(CoreAudioDeviceMute.interpret(status: status, isMuted: 0) == .unverified)
+  }
+
+  /// A failed read must not be rescued by a stale non-zero out-parameter —
+  /// the status is the authority, `isMuted` only meaningful under `noErr`.
+  @Test("a failed read ignores isMuted entirely")
+  func failedReadDoesNotConsultIsMuted() {
+    #expect(
+      CoreAudioDeviceMute.interpret(status: kAudioHardwareNotRunningError, isMuted: 0)
+        == .unverified)
+  }
+
+  // MARK: - Against the real system
+
+  /// Guards the premise the pure cases are built on: a nonexistent device ID
+  /// has no property to read, so the classifier must fail closed rather than
+  /// crash or default to "unmuted."
+  @Test("a nonexistent device ID classifies as unverified on the real Core Audio")
+  func nonexistentDeviceIsUnverifiedAgainstRealCoreAudio() {
+    #expect(CoreAudioDeviceMute.classify(deviceID: AudioDeviceID(999_999)) == .unverified)
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/DeadAirStreamingDetectorTests.swift
+++ b/Tests/EnviousWisprTests/Audio/DeadAirStreamingDetectorTests.swift
@@ -165,4 +165,53 @@ struct DeadAirStreamingDetectorTests {
     #expect(whole.isAllZeroFromStart == chunked.isAllZeroFromStart)
     #expect(whole.isAllZeroFromStart)
   }
+
+  // MARK: - RawAudioDeadAirClassifier.isDeadAir generic-slice equivalence
+
+  /// #1317 (cloud review round 2, P2): `classifyZeroSignalAtStop` was
+  /// changed to pass an `ArraySlice` prefix view instead of copying into a
+  /// new `Array`, which required widening `isDeadAir` to a generic
+  /// `RandomAccessCollection`. An `ArraySlice`'s indices are offset from
+  /// the PARENT array's start, not zero-based — the windowed-RMS loop must
+  /// use `startIndex`/`endIndex`, not raw `0..<count` arithmetic, or it
+  /// reads the wrong elements (or traps) for any non-zero-offset slice.
+  /// This proves array and a non-zero-offset slice of the SAME values agree.
+  @Test("isDeadAir agrees for an Array and a non-zero-offset ArraySlice of the same values")
+  func isDeadAirAgreesForArrayAndOffsetSlice() {
+    var padded = [Float](repeating: 0.05, count: 1_000)  // clears every floor
+    padded.append(contentsOf: [Float](repeating: 0, count: threshold))  // quiet prefix content
+    let sliceStart = 1_000
+    let slice = padded[sliceStart...]
+    let array = Array(slice)
+    #expect(slice.startIndex == sliceStart)  // sanity: genuinely non-zero-offset
+
+    let arrayPeak = array.reduce(Float(0)) { max($0, abs($1)) }
+    let slicePeak = slice.reduce(Float(0)) { max($0, abs($1)) }
+    #expect(arrayPeak == slicePeak)
+
+    let arrayResult = RawAudioDeadAirClassifier.isDeadAir(array, peak: arrayPeak)
+    let sliceResult = RawAudioDeadAirClassifier.isDeadAir(slice, peak: slicePeak)
+    #expect(arrayResult == sliceResult)
+  }
+
+  /// Same equivalence claim, but with a loud window positioned so an
+  /// off-by-index-base bug would tile the WRONG 640-sample windows and
+  /// silently produce a false `isDeadAir == true` (the danger case, since
+  /// this feeds a fail-open decision) instead of just crashing.
+  @Test("isDeadAir agrees for an Array and an ArraySlice with a loud embedded window")
+  func isDeadAirAgreesForArrayAndOffsetSliceWithLoudWindow() {
+    var padded = [Float](repeating: 0, count: 1_000)
+    var body = [Float](repeating: 0, count: threshold)
+    for i in 2_000..<2_640 { body[i] = 0.05 }  // one loud tile-aligned-in-body window
+    padded.append(contentsOf: body)
+    let slice = padded[1_000...]
+    let array = Array(slice)
+    #expect(slice.startIndex == 1_000)
+
+    let peak: Float = 0.05
+    let arrayResult = RawAudioDeadAirClassifier.isDeadAir(array, peak: peak)
+    let sliceResult = RawAudioDeadAirClassifier.isDeadAir(slice, peak: peak)
+    #expect(arrayResult == sliceResult)
+    #expect(!arrayResult)  // the loud window must be found, not silently missed
+  }
 }

--- a/Tests/EnviousWisprTests/Audio/DeadAirStreamingDetectorTests.swift
+++ b/Tests/EnviousWisprTests/Audio/DeadAirStreamingDetectorTests.swift
@@ -1,0 +1,168 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1317 §3.1 — the app-side mid-recording all-zero harness-glitch detector.
+// Streaming, buffer-by-buffer, so these boundary cases matter twice: once for
+// the classification rules themselves, and once for the EQUIVALENCE claim
+// that a streaming classification agrees with a one-shot classification made
+// after the fact over the same concatenated samples — the plan's split-buffer
+// tile test (a 640-sample tile straddling two proxy callbacks must not
+// classify differently than the same audio delivered in one buffer).
+@Suite("Dead-air streaming detector (#1317)")
+struct DeadAirStreamingDetectorTests {
+
+  private let threshold = AudioConstants.minimumTranscriptionSamples  // 16_000
+
+  private func ingestWhole(_ samples: [Float]) -> DeadAirStreamingDetector {
+    var detector = DeadAirStreamingDetector()
+    samples.withUnsafeBufferPointer { detector.ingest($0) }
+    return detector
+  }
+
+  /// Ingests `samples` split into `chunkSize`-sized buffers (the last chunk
+  /// may be shorter), simulating real proxy delivery where buffer boundaries
+  /// do not align to the 640-sample tile grid.
+  private func ingestChunked(_ samples: [Float], chunkSize: Int) -> DeadAirStreamingDetector {
+    var detector = DeadAirStreamingDetector()
+    var i = 0
+    while i < samples.count {
+      let end = min(i + chunkSize, samples.count)
+      let slice = Array(samples[i..<end])
+      slice.withUnsafeBufferPointer { detector.ingest($0) }
+      i = end
+    }
+    return detector
+  }
+
+  // MARK: - allZeroFromStart
+
+  @Test("every sample exactly zero, at threshold → allZeroFromStart")
+  func allZeroFromStartAtThreshold() {
+    let detector = ingestWhole([Float](repeating: 0, count: threshold))
+    #expect(detector.isAllZeroFromStart)
+    #expect(!detector.isBecameZeroMidCapture)
+  }
+
+  @Test("every sample exactly zero, BELOW threshold → not yet confident")
+  func allZeroBelowThresholdNotYetConfident() {
+    let detector = ingestWhole([Float](repeating: 0, count: threshold - 1))
+    #expect(!detector.isAllZeroFromStart)
+  }
+
+  // MARK: - No false alarm on genuine quiet-room noise
+
+  /// The discriminator is exact-zero, not amplitude — ANY non-zero noise,
+  /// however tiny, must never read as the harness glitch. Uses the same
+  /// uniform-0.001 shape `RecordingSessionKernelDeadAirFloorTests` uses for
+  /// "dead air but not silence" — below every `RawAudioDeadAirClassifier`
+  /// floor, yet not literally zero.
+  @Test("uniform tiny non-zero noise never triggers allZeroFromStart")
+  func quietRoomNoiseNeverFalseAlarms() {
+    let detector = ingestWhole([Float](repeating: 0.001, count: threshold * 2))
+    #expect(!detector.isAllZeroFromStart)
+    #expect(!detector.isBecameZeroMidCapture)
+  }
+
+  @Test("a single non-zero sample among zeros breaks allZeroFromStart")
+  func oneNonZeroSampleBreaksAllZeroFromStart() {
+    var samples = [Float](repeating: 0, count: threshold)
+    samples[threshold / 2] = 0.01
+    let detector = ingestWhole(samples)
+    #expect(!detector.isAllZeroFromStart)
+  }
+
+  // MARK: - becameZeroMidCapture
+
+  @Test("meaningful signal then a sustained zero suffix → becameZeroMidCapture")
+  func meaningfulThenZeroBecomesMidCapture() {
+    var samples = [Float](repeating: 0.1, count: 4_000)  // clearly above every floor
+    samples.append(contentsOf: [Float](repeating: 0, count: threshold))
+    let detector = ingestWhole(samples)
+    #expect(detector.meaningfulSignalSeen)
+    #expect(detector.isBecameZeroMidCapture)
+    #expect(!detector.isAllZeroFromStart)
+  }
+
+  @Test("meaningful signal then a zero suffix BELOW threshold → not yet confident")
+  func meaningfulThenShortZeroSuffixNotYetConfident() {
+    var samples = [Float](repeating: 0.1, count: 4_000)
+    samples.append(contentsOf: [Float](repeating: 0, count: threshold - 1))
+    let detector = ingestWhole(samples)
+    #expect(detector.meaningfulSignalSeen)
+    #expect(!detector.isBecameZeroMidCapture)
+  }
+
+  @Test("dead-air-floor noise then zero — no meaningful signal, so no becameZeroMidCapture")
+  func deadAirNoiseThenZeroIsNotBecameZeroMidCapture() {
+    var samples = [Float](repeating: 0.001, count: 4_000)  // below every dead-air floor
+    samples.append(contentsOf: [Float](repeating: 0, count: threshold))
+    let detector = ingestWhole(samples)
+    #expect(!detector.meaningfulSignalSeen)
+    #expect(!detector.isBecameZeroMidCapture)
+  }
+
+  @Test(
+    "zero suffix that never resumes non-zero, with no prior signal, stays allZeroFromStart-only")
+  func zeroSuffixWithoutPriorSignalIsNotBecameZero() {
+    let detector = ingestWhole([Float](repeating: 0, count: threshold))
+    #expect(!detector.meaningfulSignalSeen)
+    #expect(!detector.isBecameZeroMidCapture)
+    #expect(detector.isAllZeroFromStart)
+  }
+
+  @Test("meaningful signal that never goes to zero triggers neither mode")
+  func continuousSignalTriggersNeitherMode() {
+    let detector = ingestWhole([Float](repeating: 0.1, count: threshold * 2))
+    #expect(detector.meaningfulSignalSeen)
+    #expect(!detector.isAllZeroFromStart)
+    #expect(!detector.isBecameZeroMidCapture)
+  }
+
+  // MARK: - Split-buffer-boundary equivalence (the plan's mandatory test)
+
+  /// A capture-start-aligned 640-sample tile split across two buffer
+  /// callbacks must classify identically to the same audio delivered whole.
+  /// The burst is NOT tile-aligned (starts at 3_700, not a multiple of 640)
+  /// so the buffer split at `chunkSize: 500` guarantees at least one 640
+  /// tile straddles two `ingest` calls.
+  @Test("a tile split across two buffers agrees with one-shot classification")
+  func splitBufferTileAgreesWithWholeArray() {
+    var samples = [Float](repeating: 0, count: threshold)
+    // A burst clearing every RawAudioDeadAirClassifier floor, straddling
+    // multiple non-tile-aligned buffer boundaries when chunked at 500.
+    for i in 3_700..<4_340 { samples[i] = 0.05 }
+    samples.append(contentsOf: [Float](repeating: 0, count: threshold))
+
+    let whole = ingestWhole(samples)
+    let chunked = ingestChunked(samples, chunkSize: 500)
+
+    #expect(whole.meaningfulSignalSeen == chunked.meaningfulSignalSeen)
+    #expect(whole.isAllZeroFromStart == chunked.isAllZeroFromStart)
+    #expect(whole.isBecameZeroMidCapture == chunked.isBecameZeroMidCapture)
+    #expect(whole.totalSampleCount == chunked.totalSampleCount)
+    #expect(whole.consecutiveExactZeroSuffix == chunked.consecutiveExactZeroSuffix)
+
+    // And both streaming results agree with a direct one-shot classification
+    // of the meaningful prefix via the shared authority the plan requires
+    // streaming stats to match (§3.1).
+    let prefix = Array(samples[0..<4_340])
+    let prefixPeak = prefix.reduce(Float(0)) { max($0, abs($1)) }
+    let prefixIsDeadAir = RawAudioDeadAirClassifier.isDeadAir(prefix, peak: prefixPeak)
+    #expect(whole.meaningfulSignalSeen == !prefixIsDeadAir)
+  }
+
+  /// Same equivalence claim, but for audio that never crosses the
+  /// meaningful-signal floor at all — the all-dead-air whole capture must
+  /// also agree at every chunk size.
+  @Test("split-buffer equivalence holds for a whole all-zero capture too")
+  func splitBufferAgreesForAllZeroCapture() {
+    let samples = [Float](repeating: 0, count: threshold + 500)
+    let whole = ingestWhole(samples)
+    let chunked = ingestChunked(samples, chunkSize: 333)  // deliberately not a 640 divisor
+    #expect(whole.isAllZeroFromStart == chunked.isAllZeroFromStart)
+    #expect(whole.isAllZeroFromStart)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelDeadAirFloorTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelDeadAirFloorTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 import Testing
 
@@ -120,5 +121,100 @@ struct RecordingSessionKernelDeadAirFloorTests {
     for i in samples.indices { samples[i] = (i % 7 == 0) ? 0.0008 : 0.0002 }
     #expect(peak(samples) < RecordingSessionKernel.DeadAirFloor.peak)
     #expect(isDeadAir(samples))
+  }
+
+  // MARK: - trailingZeroSuffixCount (#1317 fast-follow)
+
+  @Test("trailingZeroSuffixCount: no trailing zero is 0")
+  func trailingZeroSuffixCountNoZeroIsZero() {
+    #expect(RecordingSessionKernel.trailingZeroSuffixCount([0.1, 0.2, 0.3]) == 0)
+  }
+
+  @Test("trailingZeroSuffixCount: counts only the trailing run, not an interior zero")
+  func trailingZeroSuffixCountStopsAtFirstNonZeroFromEnd() {
+    #expect(RecordingSessionKernel.trailingZeroSuffixCount([0.1, 0, 0.2, 0, 0]) == 2)
+  }
+
+  @Test("trailingZeroSuffixCount: an all-zero buffer counts every sample")
+  func trailingZeroSuffixCountAllZero() {
+    #expect(
+      RecordingSessionKernel.trailingZeroSuffixCount([Float](repeating: 0, count: 100)) == 100)
+  }
+
+  @Test("trailingZeroSuffixCount: an empty buffer is 0")
+  func trailingZeroSuffixCountEmpty() {
+    #expect(RecordingSessionKernel.trailingZeroSuffixCount([]) == 0)
+  }
+
+  // MARK: - classifyZeroSignalAtStop dilution guard (#1317 fast-follow)
+  //
+  // Cloud review's own example: "16k samples around 0.0013" — an amplitude
+  // that clears the whole-buffer RMS floor (0.00125) ALONE (see
+  // `rmsJustAboveIsNotDeadAir` above) but, once diluted by an appended
+  // exact-zero suffix, drags the combined whole-buffer RMS below the floor,
+  // falling through to the loudest-window check — which this same amplitude
+  // (0.0013 < the 0.002 window floor) ALSO fails. That is the reported bug:
+  // a real quiet utterance silently discarded once the mic-glitch's zero
+  // tail is averaged in. `classifyZeroSignalAtStop` must still recognize
+  // this shape (it evaluates the prefix alone); the trim (proven below and
+  // exercised end-to-end in ZeroSignalRecoveryTests) is what keeps the
+  // no-speech gate from re-diluting it downstream.
+
+  @Test(
+    "classifyZeroSignalAtStop: a quiet prefix that clears the RMS floor alone still classifies as becameZeroMidCapture"
+  )
+  func classifyZeroSignalAtStopRecognizesQuietPrefix() {
+    var samples = [Float](repeating: 0.0013, count: 16_000)
+    samples.append(contentsOf: [Float](repeating: 0, count: 16_000))
+    #expect(RecordingSessionKernel.classifyZeroSignalAtStop(samples) == .becameZeroMidCapture)
+  }
+
+  @Test(
+    "the zero-suffix dilution is real (whole buffer reads dead air) and trimming to the prefix fixes it"
+  )
+  func wholeBufferDilutionIsRealAndTrimFixesIt() {
+    var samples = [Float](repeating: 0.0013, count: 16_000)
+    samples.append(contentsOf: [Float](repeating: 0, count: 16_000))
+    // Before the trim: the kernel's no-speech gate sees this whole buffer —
+    // dead air, incorrectly (the reported bug).
+    #expect(isDeadAir(samples))
+    // After the trim the fast-follow now applies before that gate runs: the
+    // same prefix alone is NOT dead air — the words survive.
+    let suffixCount = RecordingSessionKernel.trailingZeroSuffixCount(samples)
+    let trimmed = Array(samples.dropLast(suffixCount))
+    #expect(!isDeadAir(trimmed))
+  }
+
+  // MARK: - clampSegments (#1317 fast-follow, Grounded Review r1)
+
+  @Test("clampSegments: an in-range segment passes through unchanged")
+  func clampSegmentsInRangePassesThrough() {
+    let result = RecordingSessionKernel.clampSegments(
+      [SpeechSegment(startSample: 0, endSample: 8_000)], to: 24_000)
+    #expect(result.count == 1)
+    #expect(result[0].startSample == 0)
+    #expect(result[0].endSample == 8_000)
+  }
+
+  @Test(
+    "clampSegments: an open segment finalized at the original full sample count is clamped to the trim boundary"
+  )
+  func clampSegmentsClampsOpenSegmentPastTrimBoundary() {
+    // Mirrors SilenceDetector.finalizeSegments closing an open segment at
+    // the ORIGINAL raw sample count when the zero-signal reactive detector's
+    // 1s confidence window fires before VAD's own 1.5s silence timeout ever
+    // closes the segment (Grounded Review r1).
+    let result = RecordingSessionKernel.clampSegments(
+      [SpeechSegment(startSample: 0, endSample: 24_000)], to: 8_000)
+    #expect(result.count == 1)
+    #expect(result[0].startSample == 0)
+    #expect(result[0].endSample == 8_000)
+  }
+
+  @Test("clampSegments: a segment starting entirely past the trim boundary is dropped")
+  func clampSegmentsDropsSegmentEntirelyPastBoundary() {
+    let result = RecordingSessionKernel.clampSegments(
+      [SpeechSegment(startSample: 20_000, endSample: 24_000)], to: 8_000)
+    #expect(result.isEmpty)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FSMState.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FSMState.swift
@@ -23,6 +23,7 @@ enum FSMFailureReason: Equatable, Sendable {
   case asrWedged
   case emptyAfterProcessing
   case captureStalled
+  case zeroSignal
 }
 
 /// The recording-session FSM states (PR-1 §B.1.1). Seven are terminal:

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -122,6 +122,13 @@ final class LimbInjectionBox {
   var storageWriteFails = false
 }
 
+/// #1317: reference-type holder so `stopTimeZeroSignalTelemetry`'s closure
+/// (constructed before `self` fully exists, same constraint `LimbInjectionBox`
+/// works around) can append fired contexts without capturing `self`.
+final class StopTimeZeroSignalTelemetryLog {
+  var fired: [CaptureStallContext] = []
+}
+
 @MainActor
 final class KernelRecordingSession: RecordingSessionDriving {
   private let kernel: RecordingSessionKernel
@@ -138,6 +145,13 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// this wrapper mirrors that by constructing it once and passing it in.
   let telemetryState = KernelTelemetryState()
 
+  private let stopTimeTelemetryLog = StopTimeZeroSignalTelemetryLog()
+  /// #1317: `CaptureStallContext`s the kernel's STOP-time classification
+  /// submitted via `stopTimeZeroSignalTelemetry`, in fire order. Lets a test
+  /// assert exactly one classified event fired (dedup) without a real
+  /// `HeartPathTelemetryEmitter`.
+  var stopTimeZeroSignalTelemetryFired: [CaptureStallContext] { stopTimeTelemetryLog.fired }
+
   init(
     engine: FakeEngine,
     capture: FakeAudioCapture,
@@ -147,11 +161,18 @@ final class KernelRecordingSession: RecordingSessionDriving {
     // #1408: the floor's regression guard needs the minimum-recording gate ARMED
     // (the inventory zeroes it, see the note at the `minimumRecordingTicks`
     // argument below). Defaulted so every existing scenario is unchanged.
-    minimumRecordingTicks: Int = 0
+    minimumRecordingTicks: Int = 0,
+    // #1317: deterministic by default (`true`) — real scenarios exercising
+    // the muted/unknown fail-closed path override this explicitly. Avoids
+    // every other test in the 38-scenario inventory depending on the test
+    // machine's real microphone/mute state via the kernel's production
+    // default (real CoreAudio calls).
+    zeroSignalDeviceEligible: @escaping @MainActor () -> Bool = { true }
   ) {
     self.vad = vad
     let limb = self.limb
     let telemetryState = self.telemetryState
+    let stopTimeTelemetryLog = self.stopTimeTelemetryLog
     self.kernel = RecordingSessionKernel(
       adapter: engine,
       audioCapture: capture,
@@ -186,6 +207,10 @@ final class KernelRecordingSession: RecordingSessionDriving {
       // minimum-recording threshold would discard most scenarios. The
       // dedicated #4 coverage lives in `ConductorParitySeamTests`.
       minimumRecordingTicks: minimumRecordingTicks,
+      stopTimeZeroSignalTelemetry: { [stopTimeTelemetryLog] ctx in
+        stopTimeTelemetryLog.fired.append(ctx)
+      },
+      zeroSignalDeviceEligible: zeroSignalDeviceEligible,
       telemetryState: telemetryState)
   }
 
@@ -341,6 +366,7 @@ final class KernelRecordingSession: RecordingSessionDriving {
     case .asrWedged: return .asrWedged
     case .emptyAfterProcessing: return .emptyAfterProcessing
     case .captureStalled: return .captureStalled
+    case .zeroSignal: return .zeroSignal
     }
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
@@ -1,0 +1,213 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - #1317 zero-signal (mic-harness all-zero glitch) kernel routing
+//
+// Drives the REAL `RecordingSessionKernel` through the simulator fakes.
+// Covers both classification paths the plan names: the REACTIVE exit (the
+// app-side detector already fired, delivered via `externalCaptureStalled`)
+// and the STOP-win backstop (the detector never fired — capture ended before
+// its own confidence threshold, or STOP raced it — so the kernel classifies
+// the complete `captureResult.samples` itself at stop time, §3.6).
+//
+// `zeroSignalDeviceEligible` is injected per-scenario (deterministic — never
+// depends on the test machine's real microphone/mute state).
+
+@MainActor
+@Suite("RecordingSessionKernel — zero-signal recovery (#1317)")
+struct ZeroSignalRecoveryTests {
+
+  private let threshold = AudioConstants.minimumTranscriptionSamples  // 16_000
+
+  private struct Context {
+    let wrapper: KernelRecordingSession
+    let engine: FakeEngine
+    let capture: FakeAudioCapture
+    let vad: FakeVADSignalSource
+  }
+
+  private func makeContext(
+    zeroSignalDeviceEligible: @escaping @MainActor () -> Bool = { true }
+  ) -> Context {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste,
+      zeroSignalDeviceEligible: zeroSignalDeviceEligible)
+    return Context(wrapper: wrapper, engine: engine, capture: capture, vad: vad)
+  }
+
+  private func stallContext(
+    _ ctx: Context, failureMode: CaptureStallFailureMode
+  ) -> CaptureStallContext {
+    CaptureStallContext(
+      sessionID: ctx.capture.currentCaptureSessionID,
+      armedAtUptimeNs: 0,
+      firedAtUptimeNs: 0,
+      route: "fake",
+      sourceType: ctx.capture.captureSourceType,
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: failureMode)
+  }
+
+  private func startToRecording(_ ctx: Context) async {
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+  }
+
+  // MARK: - Reactive exit: allZeroFromStart
+
+  @Test("reactive allZeroFromStart → the honest zero-signal terminal, no salvage")
+  func reactiveAllZeroFromStartFinishesHonestly() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+
+    ctx.wrapper.testKernel.externalCaptureStalled(
+      stallContext(ctx, failureMode: .allZeroFromStart))
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .failed(.zeroSignal))
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .allZeroFromStart)
+    #expect(ctx.wrapper.testKernel.deliveredTranscript == nil)
+  }
+
+  @Test("reactive noBuffers is UNCHANGED — still the existing captureStall terminal")
+  func reactiveNoBuffersUnaffected() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+
+    ctx.wrapper.testKernel.externalCaptureStalled(stallContext(ctx, failureMode: .noBuffers))
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .failed(.captureStalled))
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
+  }
+
+  // MARK: - Reactive exit: becameZeroMidCapture — normal-stop-path salvage
+
+  @Test("reactive becameZeroMidCapture completes normally, transcribing the captured prefix")
+  func reactiveBecameZeroMidCaptureSalvagesPrefix() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: 8_000, amplitude: 0.2)
+    ctx.vad.evidence = .voiced
+    ctx.vad.segments = [SpeechSegment(startSample: 0, endSample: 8_000)]
+
+    ctx.wrapper.testKernel.externalCaptureStalled(
+      stallContext(ctx, failureMode: .becameZeroMidCapture))
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .completed)
+    #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .becameZeroMidCapture)
+  }
+
+  // MARK: - STOP-win: the detector never fired, classify at stop
+
+  @Test("STOP-win: an all-zero capture at stop classifies as zeroSignal, not ordinary no-speech")
+  func stopWinAllZeroClassifies() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech
+
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .failed(.zeroSignal))
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .allZeroFromStart)
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.count == 1)
+    #expect(
+      ctx.wrapper.stopTimeZeroSignalTelemetryFired.first?.failureMode == .allZeroFromStart)
+  }
+
+  @Test("STOP-win: meaningful prefix then zero suffix at stop salvages and completes")
+  func stopWinBecameZeroCompletesWithSalvage() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: 8_000, amplitude: 0.2)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .voiced
+    ctx.vad.segments = [SpeechSegment(startSample: 0, endSample: 8_000)]
+
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .completed)
+    #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .becameZeroMidCapture)
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.count == 1)
+  }
+
+  // MARK: - Fail-closed: muted / mute-unknown device never runs recovery
+
+  @Test(
+    "STOP-win: an all-zero capture on an ineligible device (muted or unverified) stays ordinary no-speech"
+  )
+  func stopWinFailsClosedWhenDeviceNotEligible() async {
+    let ctx = makeContext(zeroSignalDeviceEligible: { false })
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech
+
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .noSpeech)
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+  }
+
+  // MARK: - No false alarm: a genuine quiet room stays no-speech
+
+  @Test("quiet-room tiny non-zero noise at stop is untouched — still ordinary no-speech")
+  func quietRoomNoiseStaysNoSpeech() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+    // Below every dead-air floor, but never exactly zero.
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.001)
+    ctx.vad.evidence = .confirmedNoSpeech
+
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .noSpeech)
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+  }
+
+  // MARK: - Exactly one classified event (Set-dedup, §3.6 N4)
+
+  @Test("a reactive win before stop means STOP-time classification never re-submits")
+  func reactiveWinSuppressesStopTimeResubmission() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+    // The reactive exit already stamped the side-channel; feed the SAME
+    // shape of samples so, if the STOP-time guard were missing, it would
+    // also confidently classify — proving the `telemetryState
+    // .zeroSignalFailureMode == nil` guard is what suppresses the second
+    // submission, not an accidental sample-shape mismatch.
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech
+
+    ctx.wrapper.testKernel.externalCaptureStalled(
+      stallContext(ctx, failureMode: .allZeroFromStart))
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .failed(.zeroSignal))
+    // STOP-time telemetry never fires for a reactive win — the reactive
+    // path's own event rides the WedgeRecoveryRouter funnel instead (§3.6).
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
@@ -150,6 +150,76 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.count == 1)
   }
 
+  // MARK: - Fast-follow: the zero-suffix trim (#1317, cloud review + live UAT repro)
+  //
+  // Reported bug: without the trim, a QUIET (but real) prefix's whole-buffer
+  // RMS clears the dead-air floor on its own, but gets diluted below it once
+  // the mic-glitch's zero suffix is averaged in — so the no-speech gate
+  // discards real words instead of transcribing them. Live UAT reproduced
+  // this with real speech ("saffron comet velvet anchor") on 2026-07-11.
+  // `0.0013` is the exact amplitude from the cloud reviewer's own example
+  // (see RecordingSessionKernelDeadAirFloorTests for the pure-math proof).
+
+  @Test(
+    "STOP-win: a quiet prefix that would be diluted below the dead-air floor by the zero suffix is trimmed and survives"
+  )
+  func stopWinQuietPrefixSurvivesZeroSuffixDilution() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.0013)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech  // Silero abstains on the quiet prefix
+
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .completed)
+    #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .becameZeroMidCapture)
+  }
+
+  @Test(
+    "reactive becameZeroMidCapture: a quiet prefix that would be diluted below the dead-air floor by the zero suffix is trimmed and survives"
+  )
+  func reactiveQuietPrefixSurvivesZeroSuffixDilution() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.0013)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech
+
+    ctx.wrapper.testKernel.externalCaptureStalled(
+      stallContext(ctx, failureMode: .becameZeroMidCapture))
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .completed)
+    #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .becameZeroMidCapture)
+    // The reactive win must still suppress STOP-time re-classification (§3.6 N4).
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+  }
+
+  @Test(
+    "STOP-win: an open VAD segment reaching past the trim boundary is clamped, not left dangling"
+  )
+  func stopWinClampsOpenSegmentPastTrimBoundary() async {
+    let ctx = makeContext()
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: 8_000, amplitude: 0.2)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .voiced
+    // An OPEN segment that never resolved to silence before the zero-signal
+    // detector fired — its end still references the ORIGINAL (pre-trim)
+    // full sample count (Grounded Review r1).
+    ctx.vad.segments = [SpeechSegment(startSample: 0, endSample: 8_000 + threshold)]
+
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .completed)
+    #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
+  }
+
   // MARK: - Fail-closed: muted / mute-unknown device never runs recovery
 
   @Test(


### PR DESCRIPTION
## Summary
PR2 of the #1317 dead-mic fix, staged as 3 shippable PRs (plan §16 on disk, checkpoint comments on the issue; PR1 shipped as #1508). This PR adds **detection and an honest terminal** for the software mic-HARNESS glitch — the capture pipeline delivering all-zero audio from a device that is still up and unmuted — as distinct from a genuinely dead/muted mic (out of scope, fails closed) or the existing no-buffer stall (unchanged). **No auto-rebuild yet** — that's PR3.

- An app-side streaming detector watches every accepted audio buffer for an all-zero signature, using the same math the app already trusts for its existing silence detection (so a burst split across two buffer deliveries classifies identically to the same audio read all at once — proven by test).
- A new check reads whether the microphone is muted at the hardware/OS level (something the app didn't check before) and refuses to act unless the mic is confirmed both alive and unmuted — any ambiguity means no action, so a genuinely muted mic (out of scope) or a mic that just disappeared never gets mislabeled as this glitch.
- When the mic is all-zero from the very start of a press, the user now sees an honest message ("Couldn't hear your mic. Try again.") instead of silence.
- When real speech was captured before the glitch hit mid-recording, that speech is still transcribed and delivered normally — nothing is thrown away.
- A backstop at the end of a recording catches the rare case where the live detector didn't get a chance to fire (very short recordings, or a race with the user releasing the key).
- A genuinely quiet room is untouched — the check only looks for literal digital silence, not just quiet audio, so it can't be confused with someone recording in a quiet space.

Part of #1317 (not closing it — PR3 adds the auto-rebuild and closes).

## Review process
4 local Codex code-diff rounds. 3 real findings caught and fixed (each with a regression test where testable without a live XPC harness):
- r1: the end-of-recording backstop checked the wrong microphone (system default instead of the one actually selected)
- r2: the device-resolution helper silently fell back to the default mic when an explicitly selected mic had vanished (would have mislabeled a real hardware removal as this software glitch)
- r3: the new detector and the pre-existing no-buffer stall check could both fire for the same recording under a narrow timing race, double-reporting; added one shared guard
- r4: clean, no further findings

## Test plan
- [x] Full local suite: 2,890 tests, Debug lane, all green (including 4 new focused test files covering the detector logic, the device-mute read, the device-resolution fail-closed behavior, and full kernel-level routing)
- [x] Local `codex review --base origin/main`: clean after 3 fix rounds
- [ ] Live UAT (both mic routes, both ASR backends) — pending before merge, per this PR's own exit criteria (unlike PR1, this PR changes runtime behavior)