### PR TITLE
feat(audio): auto-heal the mic-harness all-zero glitch, and say so (Closes #1317)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1510,10 +1510,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     case .captureStalled:
       return "No audio detected — try again."
     case .zeroSignal:
-      // #1317 PR2: the harness delivered all-zero audio from a running,
-      // unmuted mic. Honest, no auto-reset yet — PR3 adds the rebuild and
-      // upgrades this to "Mic problem. Resetting it."
-      return "Couldn't hear your mic. Try again."
+      // #1317 PR3: the harness delivered all-zero audio from a running,
+      // unmuted mic. The kernel has already requested the capture-pipeline
+      // rebuild by the time this failure is mapped, so the copy states what
+      // the app is actually doing (founder-chosen wording).
+      return "Mic problem. Resetting it."
     }
   }
 }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1147,25 +1147,31 @@ final class RecordingSessionKernel {
       finishTerminal(.failed(.captureStalled), sid: sid)
       return
     case .zeroSignal(let mode):
-      // #1317. Stamp the side-channel BEFORE the terminal — the pill mapper
-      // and the driver's partial-capture disclosure both read it (§3.5).
-      telemetryState.zeroSignalFailureMode = mode
       switch mode {
       case .noBuffers:
         // Unreachable by construction: `externalCaptureStalled` routes
         // `.noBuffers` to `.captureStall`, never to `.zeroSignal` (§3.2).
-        // Fail safely rather than silently mis-terminating.
+        // Fail safely rather than silently mis-terminating — and do NOT stamp
+        // the side-channel, so `.noBuffers` can never reach the zero-signal
+        // recovery switch below (PR3 grounded review Q6).
         finishTerminal(.failed(.captureStalled), sid: sid)
         return
-      case .allZeroFromStart:
-        // Nothing to salvage — honest terminal, no normal-stop tail (§3.4).
-        finishTerminal(.failed(.zeroSignal), sid: sid)
-        return
-      case .becameZeroMidCapture:
-        // Fall through into the normal stop tail below so ASR transcribes
-        // the non-zero prefix already captured (§3.4). The rebuild (PR3)
-        // and the partial-capture disclosure both read the stamped mode.
-        break
+      case .allZeroFromStart, .becameZeroMidCapture:
+        // #1317. Stamp the side-channel BEFORE the terminal — the pill mapper
+        // and the driver's partial-capture disclosure both read it (§3.5).
+        //
+        // PR3: BOTH confirmed zero-signal modes now fall through into the
+        // normal stop tail. `.allZeroFromStart` used to take an immediate
+        // terminal here, which was behaviourally identical while there was no
+        // rebuild — but that early return never reaches `stopCapture()` (its
+        // capture stop happens inside `finishTerminal`'s detached cleanup
+        // Task, :2715), so it could never own the single post-stop rebuild
+        // site. Its terminal now fires below, after the stop completes and
+        // after the rebuild request, still BEFORE the VAD no-speech gate that
+        // would otherwise swallow an exact-zero capture as quiet-room silence
+        // (§3.6 N1). `.becameZeroMidCapture` continues into ASR so the
+        // captured prefix is transcribed (§3.4).
+        telemetryState.zeroSignalFailureMode = mode
       }
     case .userStop, .vadAutoStop, .maxDuration:
       break
@@ -1318,11 +1324,57 @@ final class RecordingSessionKernel {
           outputTransport: audioCapture.currentResolvedRoute?.outputTransport,
           routeResolutionSource: audioCapture.currentResolvedRoute?.routeResolutionSource
         ))
-      if mode == .allZeroFromStart {
+    }
+
+    // #1317 PR3 — THE single zero-signal recovery site (plan §3.3).
+    //
+    // Every confirmed zero-signal session converges here, and only here:
+    //   * reactive `.allZeroFromStart`   — stamped at the exit switch (:1149)
+    //   * reactive `.becameZeroMidCapture` — stamped at the exit switch
+    //   * STOP-time backstop (either mode) — stamped immediately above
+    // so exactly ONE `rebuildEngine()` request is issued per zero-signal
+    // session. No terminal handler, driver, router, or the `finishTerminal`
+    // cleanup Task may rebuild for zero-signal.
+    //
+    // Placement is load-bearing on BOTH sides:
+    //   * AFTER `stopCapture()` (:1204) — the capture layer deactivates the
+    //     source before its stop reply returns (`AudioCaptureManager:411`), so
+    //     the rebuild cannot race a still-live capture callback.
+    //   * AFTER the too-short / no-audio gates (:1260, :1279) — capture
+    //     samples include PRE-ROLL, so a sub-500ms visible tap can still carry
+    //     >= 16000 samples and reach the detector's threshold. Rebuilding (or
+    //     terminating as zero-signal) above those gates would hijack sessions
+    //     that correctly discard as `.tooShort` today, and would break the
+    //     founder-locked rule that very short dead taps keep today's behaviour.
+    //
+    // `rebuildEngine()` is fire-and-forget across XPC (`AudioCaptureProxy:687`),
+    // so it is requested BEFORE `finishTerminal` — which drains the task bag and
+    // flips the UI — to give the request the earliest possible ordering and keep
+    // the next-press race window as small as the synchronous interface allows.
+    // Exhaustive on purpose (no `default`): a future failure mode must make a
+    // deliberate choice here rather than silently inheriting engine recovery.
+    // `.noBuffers` is the ordinary capture stall — the stall watchdog owns it,
+    // and it is never even stamped (:1154). `nil` is the healthy session.
+    let zeroSignalRecoveryMode: CaptureStallFailureMode?
+    switch telemetryState.zeroSignalFailureMode {
+    case .allZeroFromStart: zeroSignalRecoveryMode = .allZeroFromStart
+    case .becameZeroMidCapture: zeroSignalRecoveryMode = .becameZeroMidCapture
+    case .noBuffers, nil: zeroSignalRecoveryMode = nil
+    }
+
+    if let zeroSignalRecoveryMode {
+      audioCapture.rebuildEngine()  // ← THE single zero-signal rebuild site.
+      log("zero-signal recovery: rebuild requested (\(zeroSignalRecoveryMode.rawValue))")
+      if zeroSignalRecoveryMode == .allZeroFromStart {
+        // Nothing to salvage — take the honest terminal now, still ahead of the
+        // VAD no-speech gate below, which would otherwise report an exact-zero
+        // capture as ordinary quiet-room silence (§3.6 N1).
         finishTerminal(.failed(.zeroSignal), sid: sid)
         return
       }
-      // .becameZeroMidCapture: fall through — trimmed below (§3.4).
+      // `.becameZeroMidCapture`: fall through. The mic died mid-take, but the
+      // non-zero prefix is trimmed just below and still transcribed and pasted,
+      // so the user keeps the words they actually said (§3.4).
     }
 
     // #1317 fast-follow (cloud review PR #1512 + live UAT repro): trim the

--- a/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
@@ -31,7 +31,8 @@ struct ZeroSignalRecoveryTests {
   }
 
   private func makeContext(
-    zeroSignalDeviceEligible: @escaping @MainActor () -> Bool = { true }
+    zeroSignalDeviceEligible: @escaping @MainActor () -> Bool = { true },
+    minimumRecordingTicks: Int = 0
   ) -> Context {
     let clock = FakeClock()
     let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
@@ -40,6 +41,7 @@ struct ZeroSignalRecoveryTests {
     let paste = FakePasteTarget()
     let wrapper = KernelRecordingSession(
       engine: engine, capture: capture, vad: vad, clock: clock, paste: paste,
+      minimumRecordingTicks: minimumRecordingTicks,
       zeroSignalDeviceEligible: zeroSignalDeviceEligible)
     return Context(wrapper: wrapper, engine: engine, capture: capture, vad: vad)
   }
@@ -68,10 +70,17 @@ struct ZeroSignalRecoveryTests {
 
   // MARK: - Reactive exit: allZeroFromStart
 
-  @Test("reactive allZeroFromStart → the honest zero-signal terminal, no salvage")
+  @Test("reactive allZeroFromStart → the honest zero-signal terminal, no salvage, ONE rebuild")
   func reactiveAllZeroFromStartFinishesHonestly() async {
     let ctx = makeContext()
     await startToRecording(ctx)
+    // The all-zero buffers the app-side detector fired ON. Production always
+    // has these — the detector's whole trigger is zero-valued audio ARRIVING —
+    // so the kernel's own buffer counter is non-zero by the time the reactive
+    // exit lands. (PR3: without them this session would legitimately discard
+    // as `.tooShort` on the zero-buffer branch of the duration gate, which is
+    // exactly what `shortDeadTapDiscardsAndNeverRebuilds` below pins.)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
 
     ctx.wrapper.testKernel.externalCaptureStalled(
       stallContext(ctx, failureMode: .allZeroFromStart))
@@ -80,9 +89,11 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.state == .failed(.zeroSignal))
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .allZeroFromStart)
     #expect(ctx.wrapper.testKernel.deliveredTranscript == nil)
+    // PR3: the poisoned capture pipeline is reset exactly once.
+    #expect(ctx.capture.rebuildEngineCallCount == 1)
   }
 
-  @Test("reactive noBuffers is UNCHANGED — still the existing captureStall terminal")
+  @Test("reactive noBuffers is UNCHANGED — still the existing captureStall terminal, NO rebuild")
   func reactiveNoBuffersUnaffected() async {
     let ctx = makeContext()
     await startToRecording(ctx)
@@ -92,6 +103,9 @@ struct ZeroSignalRecoveryTests {
 
     #expect(ctx.wrapper.testKernel.state == .failed(.captureStalled))
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
+    // An ordinary capture stall is NOT the mic-harness glitch — the stall
+    // watchdog owns it, and PR3 must never reset the engine for it.
+    #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
   // MARK: - Reactive exit: becameZeroMidCapture — normal-stop-path salvage
@@ -111,6 +125,8 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.state == .completed)
     #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .becameZeroMidCapture)
+    // PR3: the mic is reset AND the user still keeps the words they said.
+    #expect(ctx.capture.rebuildEngineCallCount == 1)
   }
 
   // MARK: - STOP-win: the detector never fired, classify at stop
@@ -130,6 +146,8 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.count == 1)
     #expect(
       ctx.wrapper.stopTimeZeroSignalTelemetryFired.first?.failureMode == .allZeroFromStart)
+    // PR3: the STOP-time backstop reaches the same single rebuild site.
+    #expect(ctx.capture.rebuildEngineCallCount == 1)
   }
 
   @Test("STOP-win: meaningful prefix then zero suffix at stop salvages and completes")
@@ -148,6 +166,7 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .becameZeroMidCapture)
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.count == 1)
+    #expect(ctx.capture.rebuildEngineCallCount == 1)
   }
 
   // MARK: - Fast-follow: the zero-suffix trim (#1317, cloud review + live UAT repro)
@@ -237,6 +256,9 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.state == .noSpeech)
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+    // A genuinely MUTED mic is a hardware state, not a harness glitch. Resetting
+    // the engine would not unmute it — fail closed, never rebuild (§3.0).
+    #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
   // MARK: - No false alarm: a genuine quiet room stays no-speech
@@ -255,6 +277,9 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.state == .noSpeech)
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+    // The false-alarm guard that matters most: a healthy mic in a silent room
+    // must never trigger a capture-pipeline reset.
+    #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
   // MARK: - Exactly one classified event (Set-dedup, §3.6 N4)
@@ -279,5 +304,84 @@ struct ZeroSignalRecoveryTests {
     // STOP-time telemetry never fires for a reactive win — the reactive
     // path's own event rides the WedgeRecoveryRouter funnel instead (§3.6).
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+    // Both confirmation routes converge on ONE site, so a session confirmed by
+    // BOTH (had the guard been missing) still rebuilds exactly once.
+    #expect(ctx.capture.rebuildEngineCallCount == 1)
+  }
+
+  // MARK: - PR3: the discard gates keep precedence over recovery
+
+  @Test(
+    "a dead tap too short to clear the duration gate still discards as too-short and NEVER resets the mic"
+  )
+  func shortDeadTapDiscardsAndNeverRebuilds() async {
+    // Capture samples include PRE-ROLL, so a sub-minimum VISIBLE tap can still
+    // carry a full second of (zero) audio — enough for the classifier's
+    // threshold. `minimumRecordingTicks: 5` + a FakeClock that does not advance
+    // between start and stop reproduces exactly that: the samples qualify, the
+    // visible recording does not. Founder-locked (plan §14): very short dead
+    // taps keep today's honest behaviour — no reset message, no engine reset.
+    let ctx = makeContext(minimumRecordingTicks: 5)
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech
+
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .discarded)
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+    #expect(ctx.capture.rebuildEngineCallCount == 0)
+  }
+
+  // MARK: - PR3: the zero-signal rebuild is independent of the format rebuild
+
+  @Test(
+    "a session that ALSO rebuilt for an unstable format still issues exactly one zero-signal rebuild"
+  )
+  func formatRebuildAndZeroSignalRebuildAreIndependent() async {
+    // Two different failures at two different lifecycle phases: the capture
+    // START phase rebuilds once for a format that never stabilised
+    // (RecordingSessionKernel:966), and the POST-STOP phase rebuilds once more
+    // because the harness then delivered dead audio. The PR3 invariant is
+    // exactly one ZERO-SIGNAL rebuild — not one rebuild of every kind per
+    // session — so the correct total here is 2.
+    let ctx = makeContext()
+    ctx.capture.stabilizationResults = [false, true]
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech
+
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.testKernel.state == .failed(.zeroSignal))
+    #expect(ctx.capture.rebuildEngineCallCount == 2)  // 1 format + 1 zero-signal
+  }
+
+  // MARK: - PR3: a poisoned source is never silently reused across presses
+
+  @Test("each consecutive dead press resets the mic again — the poisoned source is never reused")
+  func consecutiveDeadPressesEachRebuild() async {
+    let ctx = makeContext()
+
+    for press in 1...3 {
+      await startToRecording(ctx)
+      ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+      ctx.vad.evidence = .confirmedNoSpeech
+
+      await ctx.wrapper.apply(.stop)
+      await ctx.wrapper.drainReadyWork()
+
+      #expect(ctx.wrapper.testKernel.state == .failed(.zeroSignal))
+      // Best-effort convergence (§3.3): the rebuild is fire-and-forget, so a
+      // still-poisoned source on the next press must re-fire recovery rather
+      // than silently hand the user another dead take.
+      #expect(ctx.capture.rebuildEngineCallCount == press)
+
+      await ctx.wrapper.apply(.reset)
+      await ctx.wrapper.drainReadyWork()
+    }
   }
 }

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -447,6 +447,73 @@ def _tap_rcmd(hold_s: float = 0.05) -> None:
     sim.modifier_up(keycode)
 
 
+def _settle_to_idle(*, timeout_s: float = 12.0) -> bool:
+    """Wait until the app is genuinely idle. Callers that must attribute a LATER
+    terminal state to their OWN take depend on this: without it, a `complete`
+    left over from the previous take reads as "my take already finished"."""
+    deadline = time.monotonic() + timeout_s
+    dismissed = False
+    while time.monotonic() < deadline:
+        st = _active_state()
+        if st == "idle":
+            return True
+        if "recording" in st:
+            _tap_rcmd()  # stop a stray take rather than waiting out its whole length
+        elif "error" in st and not dismissed:
+            # A failure pill (e.g. #1317's "Mic problem. Resetting it.") persists
+            # until dismissed. Leaving it up would make the NEXT take's start
+            # read a stale `error` and conclude that take had already ended —
+            # which is exactly how the control take silently stopped running. One
+            # tap clears it; if that tap instead opens a take, the `recording`
+            # branch above closes it on the next pass, so this converges either
+            # way. `complete` is left alone (it lapses to idle on its own, and a
+            # tap there would START a take).
+            dismissed = True
+            _tap_rcmd()
+        time.sleep(0.15)  # settle: poll interval; loop breaks on the idle signal
+    return _active_state() == "idle"
+
+
+def _start_take_tolerating_self_terminate(*, timeout_s: float = 8.0) -> str:
+    """Enter locked recording for a take that may END ITSELF.
+
+    #1317: on a dead mic the app now fires its own terminal about a second in
+    (detector → reset → failure pill), without waiting for the user to stop. The
+    ordinary `_start_recording_locked()` cannot express that: it samples for a
+    `recording` state and RETRIES when it misses one — and every retry double-tap
+    starts ANOTHER take, so on a fully dead mic it sprays takes and still returns
+    False. This variant watches for EITHER outcome and never blind-retries into a
+    take that already ran.
+
+    Returns "recording" (take is live, caller owns the stop), "self_terminated"
+    (the app already ended it — do NOT tap again, that would start a new take),
+    or "failed" (never got off the ground).
+
+    Precondition: the app is idle, so any terminal observed here is OURS.
+    """
+    deadline = time.monotonic() + timeout_s
+    attempts = 0
+    while time.monotonic() < deadline and attempts < 2:
+        attempts += 1
+        _tap_rcmd()
+        time.sleep(0.25)  # settle: inside HotkeyService's 500ms double-press window
+        _tap_rcmd()
+        inner = time.monotonic() + 3.0
+        while time.monotonic() < inner:
+            st = _active_state()
+            if "recording" in st:
+                time.sleep(0.6)  # settle: HotkeyService lock cooldown before any later tap
+                return "recording"
+            if "error" in st or "complete" in st:
+                return "self_terminated"
+            time.sleep(0.05)  # settle: poll interval; loop breaks on the recording/terminal signal
+        time.sleep(0.4)  # settle: let the tap pair settle before a single retry
+    st = _active_state()
+    if "error" in st or "complete" in st:
+        return "self_terminated"
+    return "recording" if "recording" in st else "failed"
+
+
 def _start_recording_locked(*, gap_s: float = 0.25, settle_s: float = 0.8,
                             timeout_s: float = 4.0,
                             post_lock_dwell_s: float = 0.6) -> bool:
@@ -1012,21 +1079,36 @@ def _canary_take(*, record_seconds: float = 3.0, settle_timeout_s: float = 8.0) 
     open across it. Returns cursor text via both oracles + the terminal state so
     the caller scores dead-take honesty and control-take recovery from the SAME
     take shape."""
-    state = _active_state()
-    if "error" in state or "recording" in state:
-        _tap_rcmd()
-        time.sleep(0.8)  # settle: let a stray non-idle state clear before entering lock
+    # Start from a genuinely idle app, so any terminal we observe below belongs to
+    # OUR take and not to a leftover pill from the previous one.
+    _settle_to_idle()
     cursor = LogCursor()
-    if not _start_recording_locked():
+    started = _start_take_tolerating_self_terminate()
+    if started == "failed":
+        cursor.close()
         return {
             "reached_recording": False,
             "terminal_state": _active_state(),
-            "recovers": {"canary_ok": False},
-            "dead_honest": {"handled_honestly": False},
+            "recovers": {"canary_ok": False, "raw_asr_new_entry": False},
+            "dead_honest": {"handled_honestly": False, "fabricated_canary": False},
         }
-    with _TTSAudio(CANARY_PHRASE):
-        time.sleep(record_seconds)  # settle: TTS playback window (live-audio UAT cadence)
-    _stop_recording_locked(settle_s=0.5)
+    if started == "recording":
+        with _TTSAudio(CANARY_PHRASE):
+            # Speak into the take, but WATCH the app rather than sleeping blind:
+            # on a dead mic it self-terminates mid-window, and the stop tap below
+            # must not land on an app that has already finished — that tap would
+            # START A NEW (all-zero) take whose empty result overwrites the real
+            # evidence in the cursor. Signal, not clock.
+            deadline = time.monotonic() + record_seconds
+            while time.monotonic() < deadline:
+                if "recording" not in _active_state():
+                    break  # the app ended the take itself (dead-mic reset)
+                time.sleep(0.1)  # settle: poll interval; loop breaks on the recording-ended signal
+        # Only WE stop a take the app is still running.
+        if "recording" in _active_state():
+            _stop_recording_locked(settle_s=0.5)
+    # else "self_terminated": the app already ended this take — tapping would
+    # start a new one. The cursor already holds the evidence.
     deadline = time.monotonic() + settle_timeout_s
     final = ""
     while time.monotonic() < deadline:
@@ -1094,6 +1176,19 @@ def _prime_warm_source() -> None:
         return
     time.sleep(1.0)  # settle: let the source install and buffers start flowing
     _stop_recording_locked(settle_s=0.5)
+    # Settle all the way back to IDLE before returning. The priming take is
+    # followed immediately by arming + the fault take, and the double-tap that
+    # enters locked recording is ignored while the app is still finishing this
+    # take (transcribing/pasting, or sitting on a just-completed pill) — the
+    # fault take then never reaches recording, which scores as missing evidence
+    # instead of a product signal. A terminal state is NOT enough here:
+    # `complete` is terminal but still not ready to accept the next lock.
+    deadline = time.monotonic() + 12.0
+    while time.monotonic() < deadline:
+        if _active_state() == "idle":
+            break
+        time.sleep(0.1)  # settle: poll interval; loop breaks on the idle signal
+    time.sleep(0.6)  # settle: HotkeyService lock cooldown before the next double-tap
 
 
 def _arm_and_prove_hit(mode: str, n: int, trial: str) -> dict:
@@ -1853,6 +1948,15 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
     inc_pre = arm["pre_status"]["source_incarnation"]
 
     fault_take = _canary_take(record_seconds=fault_record_seconds)
+    # A take that never entered recording produces the short-form result shape
+    # (no `fabricated_canary`), so scoring it would raise KeyError mid-trial and
+    # abort the scenario. It is MISSING EVIDENCE — the app never got to
+    # demonstrate anything — not a product failure. Fail closed, like every other
+    # gate here.
+    if not fault_take.get("reached_recording"):
+        return _invalid_evidence(
+            "fault take never reached recording (could not enter locked recording)",
+            fault_take=fault_take, arm=arm, identity=identity)
 
     post = query_fault_status(trial)
     hit_ok = bool(post.get("ok")) and post.get("hit") is True and post.get("zeroed", 0) > 0

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -1065,6 +1065,37 @@ def _invalid_evidence(reason: str, **extra) -> dict:
     }
 
 
+def _prime_warm_source() -> None:
+    """Install a warm capture source BEFORE the injector is armed.
+
+    `fresh_pipe_proven` (below) is the oracle for "#1317's recovery really did
+    swap the poisoned capture pipe for a fresh one", and it reads a bump in
+    `source_incarnation`. That bump is only meaningful if a source was ALREADY
+    installed when we snapshot `inc_pre`:
+
+      * `AudioCaptureManager.rebuildEngine()` no-ops (and deliberately does NOT
+        bump the incarnation) when `activeSource` is nil, so with a torn-down
+        pipe a perfect fix would still score `fresh_pipe_proven = False`.
+      * conversely the fault take's own ordinary `startEnginePhase()` installs
+        the first source and bumps the incarnation — a cold start that would
+        masquerade as recovery if we did not require a pre-existing source.
+
+    The shipped warm-engine policy (`AudioCaptureManager.warmEnginePolicy`
+    defaults to `.seconds30`) keeps the source installed for 30s after a take,
+    so ONE short take immediately before arming guarantees the precondition
+    deterministically instead of depending on whatever a previous scenario
+    happened to leave behind. No TTS: we need the source installed, not audio.
+    """
+    state = _active_state()
+    if "error" in state or "recording" in state:
+        _tap_rcmd()
+        time.sleep(0.8)  # settle: clear a stray non-idle state before the priming take
+    if not _start_recording_locked():
+        return
+    time.sleep(1.0)  # settle: let the source install and buffers start flowing
+    _stop_recording_locked(settle_s=0.5)
+
+
 def _arm_and_prove_hit(mode: str, n: int, trial: str) -> dict:
     """Arm the injector and snapshot the pre-fault status. Hit is proven AFTER the
     take by the caller re-querying. Returns {"armed_ok", "arm_reply", "pre_status"}."""
@@ -1794,7 +1825,8 @@ def B1_bluetooth_route_flip(*, founder_present: bool = False, **_) -> dict:
 
 def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
                      kwargs: dict, extra_assertions=None,
-                     fault_record_seconds: float = 3.0) -> dict:
+                     fault_record_seconds: float = 3.0,
+                     require_warm_source: bool = True) -> dict:
     """Shared dead-mic trial: identity gate → arm+pre-status → fault take → HIT
     proof → optional disarmed control take → scored assertions. Fails closed at
     every gate. `fault_record_seconds` lengthens the fault take so a "real audio
@@ -1807,6 +1839,13 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
     identity = verify_running_identity(manifest)
     if not identity["identity_ok"]:
         return _invalid_evidence("identity mismatch", identity=identity)
+
+    # Guarantee a warm source exists BEFORE arming, so `fresh_pipe_proven` is
+    # provable at all (see `_prime_warm_source`). Scenarios whose oracle does not
+    # depend on a rebuild (Z3: the zero budget is under the detector's threshold,
+    # so the take self-heals and recovery must NOT fire) opt out.
+    if require_warm_source:
+        _prime_warm_source()
 
     arm = _arm_and_prove_hit(mode, n, trial)
     if not arm["armed_ok"]:
@@ -1845,6 +1884,16 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
     # Baseline (no recovery) must read False; the follow-up fix's recovery is the
     # only thing that can bump the incarnation of an already-installed source.
     pre_source_present = arm["pre_status"].get("capture_source", "none") != "none"
+    # Fail closed: with no warm source at `inc_pre`, `fresh_pipe_proven` cannot be
+    # proven either way (rebuildEngine() no-ops on a torn-down pipe). Scoring it
+    # False here would report a PRODUCT failure for what is really MISSING
+    # EVIDENCE — the same distinction the disarm-ack gate above enforces.
+    if require_warm_source and not pre_source_present:
+        return _invalid_evidence(
+            "no warm capture source at arm time — fresh_pipe_proven is unprovable "
+            "(priming take failed to install a source, or the warm-engine policy "
+            "tore it down before arming)",
+            arm=arm, identity=identity, post_status=post)
     assertions = {
         "recovered_in_session": fault_take["recovers"]["canary_ok"],
         "fresh_pipe_proven": pre_source_present and inc_post != inc_pre,
@@ -1931,9 +1980,14 @@ def Z2_valid_then_all_zero(*, lead_samples: int = 48000, **kwargs) -> dict:
     "take. Assert the take recovers the canary in-session (the pipe is not poisoned by "
     "a transient dead start) and the injector hit."))
 def Z3_bounded_zero_then_restore(*, zero_samples: int = 8000, **kwargs) -> dict:
+    # 8000 zeroed samples (0.5s) is deliberately BELOW the detector's 16000-sample
+    # (1s) confidence threshold, so #1317's recovery must NOT fire here: the pipe
+    # self-heals when real audio resumes and the take completes normally. This
+    # scenario therefore proves the absence of a false alarm, needs no rebuild,
+    # and opts out of the warm-source precondition.
     return _zero_fill_trial(
         mode="zero_next_samples", n=zero_samples, trial=_trial_id("Z3"),
-        do_control=False, kwargs=kwargs)
+        do_control=False, kwargs=kwargs, require_warm_source=False)
 
 
 # ──────────────────────────── CLI entry ────────────────────────────
@@ -1944,8 +1998,19 @@ def Z3_bounded_zero_then_restore(*, zero_samples: int = 8000, **kwargs) -> dict:
 # product failure still exits nonzero here; the A/B baseline mode (run_gauntlet.py)
 # is what continues through product failures to build the full scorecard.
 _REQUIRED_ASSERTIONS = {
-    "Z1_all_zero_from_start": ["dead_take_handled_honestly", "next_press_works"],
-    "Z2_valid_then_all_zero": ["raw_text_preserved", "next_press_works"],
+    # `fresh_pipe_proven` is #1317 PR3's contract: a confirmed mic-harness glitch
+    # must leave the capture pipe REBUILT, not merely reported. It is required on
+    # exactly the two shapes that trip the detector — a fully dead take (Z1) and a
+    # take that dies mid-way (Z2) — and is the assertion that separates the fixed
+    # build from the baseline, which cannot bump the incarnation of an installed
+    # source. Z3's bounded gap stays below the detector threshold, so it must keep
+    # self-healing WITHOUT a rebuild and does not require it.
+    "Z1_all_zero_from_start": [
+        "dead_take_handled_honestly", "next_press_works", "fresh_pipe_proven",
+    ],
+    "Z2_valid_then_all_zero": [
+        "raw_text_preserved", "next_press_works", "fresh_pipe_proven",
+    ],
     "Z3_bounded_zero_then_restore": ["recovered_in_session"],
 }
 

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -1080,8 +1080,20 @@ def _canary_take(*, record_seconds: float = 3.0, settle_timeout_s: float = 8.0) 
     the caller scores dead-take honesty and control-take recovery from the SAME
     take shape."""
     # Start from a genuinely idle app, so any terminal we observe below belongs to
-    # OUR take and not to a leftover pill from the previous one.
-    _settle_to_idle()
+    # OUR take and not to a leftover pill from the previous one. This is the stated
+    # PRECONDITION of `_start_take_tolerating_self_terminate` — which reads an
+    # `error`/`complete` state as "the take I just started already ended itself".
+    # If we never reached idle, that reading is FALSE EVIDENCE for a take that
+    # never ran, so fail closed rather than proceed on a broken precondition
+    # (cloud review, PR #1518).
+    if not _settle_to_idle():
+        return {
+            "reached_recording": False,
+            "terminal_state": _active_state(),
+            "settle_to_idle_failed": True,
+            "recovers": {"canary_ok": False, "raw_asr_new_entry": False},
+            "dead_honest": {"handled_honestly": False, "fabricated_canary": False},
+        }
     cursor = LogCursor()
     started = _start_take_tolerating_self_terminate()
     if started == "failed":
@@ -1978,6 +1990,14 @@ def _zero_fill_trial(*, mode: str, n: int, trial: str, do_control: bool,
                 "disarm ack failed", disarm_reply=disarm_reply, post_status=post,
                 arm=arm, identity=identity)
         control = _canary_take()
+        # Same fail-closed rule as the fault take: a control take that never got
+        # off the ground proves nothing about the NEXT press. Scoring its absent
+        # canary as `next_press_works=False` would report a product failure for
+        # what is missing evidence (cloud review, PR #1518).
+        if not control.get("reached_recording"):
+            return _invalid_evidence(
+                "control take never reached recording — next_press_works unprovable",
+                control_take=control, arm=arm, identity=identity, post_status=post)
 
     # A bumped source incarnation only proves RECOVERY if a source already
     # existed when we sampled inc_pre. With warm-engine policy off (source torn


### PR DESCRIPTION
Closes #1317. PR3 of 3 (PR1 #1508 foundation, PR2 #1512 detect + honest terminal). **This is the one that heals the mic.**

## What the user gets

A mic that goes silent while looking perfectly healthy (the "mic-harness all-zero glitch") now **resets itself**. The user sees "Mic problem. Resetting it." and their next press just works. Before this PR the app could only tell them something was wrong; the poisoned capture pipe stayed poisoned until they quit the app.

If they had already spoken words before the mic died, they keep those words: the take is salvaged, transcribed and pasted, and the reset happens after their text is safe.

## The single rebuild site

Every confirmed zero-signal session — the reactive detector's exit and the STOP-time backstop, in both failure modes — converges on ONE `rebuildEngine()` request in the forward stop path (plan §3.3).

Reactive `.allZeroFromStart` previously took an immediate terminal at the exit switch. That was invisible while there was no rebuild, but it never reaches `stopCapture()` (its capture stop happens inside `finishTerminal`'s detached cleanup Task), so it could never own the rebuild. Its terminal now fires on the forward path, after the stop and after the rebuild, still ahead of the VAD no-speech gate that would otherwise swallow an exact-zero capture as quiet-room silence (§3.6 N1).

Placement is load-bearing on both sides:
- **After `stopCapture()`** — the capture layer deactivates the source before its stop reply returns (`AudioCaptureManager:441`), so the rebuild cannot race a live capture callback.
- **After the too-short / no-audio gates** — capture samples include PRE-ROLL, so a sub-500ms visible tap can still carry a full second of zero samples. Rebuilding above those gates would hijack sessions that correctly discard today, and would break the founder-locked rule that very short dead taps keep their existing behaviour.

## Evidence

**Unit (2,935 green), and proven load-bearing:** with the rebuild removed, 9 of 14 zero-signal tests fail. Rebuild assertions on every path — exactly 1 on both confirmed modes; exactly 0 on an ordinary capture stall, a muted-or-unverified device, and a quiet room. The format-stabilization rebuild and the zero-signal rebuild are proven independent (2 in one session). Each consecutive dead press re-heals. A short dead tap discards as too-short and never resets.

**Live UAT (manual, on this build):**

| | Built-in mic (`av_audio_engine`) | Bluetooth AirPods (`hal_device_input`) |
|---|---|---|
| Dead mic detected | yes | yes (25,238 zeroed samples) |
| Pipeline rebuilt | yes, exactly once | yes, exactly once |
| Honest pill, no fabricated text | yes | yes |
| **Next press works** | yes | yes, transcribed real speech |

AirPods bind a **different capture backend** than the built-in mic, so this is genuine second-route coverage — and Bluetooth is the route the original Sentry report came in on.

**A/B against baseline `main`, identical harness:** `fresh_pipe_proven` is **False on baseline / True on this build** for both dead-mic shapes, and correctly **False** on the bounded-dropout scenario (which must NOT trigger recovery — the false-alarm guard).

**Reviews:** local Codex clean on a confirming re-run. Its one P1 (make the rebuild an awaited/acknowledged call) was **adjudicated and withdrawn by Codex itself**: the same one-way `rebuildEngine()` + immediate start pattern already ships at `RecordingSessionKernel:966` (format stabilization) and is a strictly more aggressive use of the same ordering; PR3 sends no start at all, so the next start requires a later human press. The adopted plan §3.3 locked this as best-effort-converging (no press friction), and a racing press that still hit a poisoned source would simply re-fire detection and recover.

## Bench

`fresh_pipe_proven` is now a REQUIRED assertion on the two shapes that trip the detector, and is finally provable: a priming take guarantees a warm source at arm time, because `rebuildEngine()` no-ops on a torn-down pipe and would otherwise score a perfect fix as False. Missing warm source is INVALID evidence, never a silent product failure. Also fixes three harness bugs where the bench assumed IT owned the stop (see the second commit) — with #1317 a dead take ends itself, and the harness's stop tap was starting a spurious all-zero take that clobbered the evidence.

**Two bench checks are KNOWN STALE and deliberately left** (founder: the bench needs a rethink, not a patch). Both fail **identically on baseline `main`**, which is how they were proven to be oracle staleness rather than product regressions:
- `dead_take_handled_honestly` demands the no-speech marker; a dead take no longer emits one, because it terminates before the no-speech gate by design. The app is strictly *more* honest now.
- The failure pill is left up after a fault take, so `next_press_works` flaps on both builds.

## Deliberately NOT done

The deferred `cachedSourceType` route-label fallback in `debugFaultStatusSnapshot`. It would make `capture_source` always report a name, defeating the `pre_source_present` cold-start guard that stops an ordinary first-source install from masquerading as recovery — it would corrupt the very oracle this PR depends on, and buys nothing (the bench labels backend elsewhere).

## Known, out of scope

A mic that dies **mid-take** resets the pipe but shows "Recording interrupted. Text may be cut short." rather than "Mic problem. Resetting it." Same fault, two messages. Left alone deliberately: the founder is rethinking the whole failure-message system after this release, and a copy change does not belong in a reliability fix.
