### PR TITLE
test(audio): fix flaky ResolvedRouteTransportsGridTests via injectable device seam

### DIFF
--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -103,10 +103,11 @@ public enum AudioDeviceEnumerator {
   /// the software harness glitch. Only the ABSENCE of an explicit UID (the
   /// user is on system-default / "Auto") falls through to the default.
   public static func resolveEffectiveInputDevice(
-    preferredOverride: String, selected: String
+    preferredOverride: String, selected: String,
+    defaultInputDeviceIDProvider: () -> AudioDeviceID? = AudioDeviceEnumerator.defaultInputDeviceID
   ) -> AudioDeviceID? {
     let uid = !preferredOverride.isEmpty ? preferredOverride : selected
-    guard !uid.isEmpty else { return defaultInputDeviceID() }
+    guard !uid.isEmpty else { return defaultInputDeviceIDProvider() }
     return deviceID(forUID: uid)
   }
 

--- a/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
+++ b/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
@@ -55,7 +55,12 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
     decision: CaptureRouteDecision,
     preferredInputDeviceIDOverride: String,
     selectedInputDeviceUID: String,
-    actualBoundTransport: String? = nil
+    actualBoundTransport: String? = nil,
+    defaultInputDeviceID: () -> AudioDeviceID? = AudioDeviceEnumerator.defaultInputDeviceID,
+    defaultOutputDeviceID: () -> AudioDeviceID? = AudioDeviceEnumerator.defaultOutputDeviceID,
+    transportLabelForDevice: (AudioDeviceID) -> String? = AudioDeviceEnumerator.transportLabel(
+      for:),
+    transportLabelForUID: (String) -> String? = AudioDeviceEnumerator.transportLabel(forUID:)
   ) -> ResolvedRouteTransports {
     // The user's EXPLICIT pick is the settings mic picker, which binds to
     // `preferredInputDeviceIDOverride` ("Auto" = empty) — AND the route resolver
@@ -70,7 +75,7 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
     let selected =
       preferredInputDeviceIDOverride.isEmpty
       ? "unknown"
-      : (AudioDeviceEnumerator.transportLabel(forUID: preferredInputDeviceIDOverride) ?? "unknown")
+      : (transportLabelForUID(preferredInputDeviceIDOverride) ?? "unknown")
 
     let effective: String
     let usedActualBoundTransport: Bool
@@ -84,10 +89,10 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
       let engineUID =
         preferredInputDeviceIDOverride.isEmpty
         ? selectedInputDeviceUID : preferredInputDeviceIDOverride
-      if !engineUID.isEmpty, let label = AudioDeviceEnumerator.transportLabel(forUID: engineUID) {
+      if !engineUID.isEmpty, let label = transportLabelForUID(engineUID) {
         effective = label
-      } else if let defaultID = AudioDeviceEnumerator.defaultInputDeviceID() {
-        effective = AudioDeviceEnumerator.transportLabel(for: defaultID) ?? "unknown"
+      } else if let defaultID = defaultInputDeviceID() {
+        effective = transportLabelForDevice(defaultID) ?? "unknown"
       } else {
         effective = "unknown"
       }
@@ -100,10 +105,10 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
         let halUID =
           preferredInputDeviceIDOverride.isEmpty
           ? selectedInputDeviceUID : preferredInputDeviceIDOverride
-        if !halUID.isEmpty, let label = AudioDeviceEnumerator.transportLabel(forUID: halUID) {
+        if !halUID.isEmpty, let label = transportLabelForUID(halUID) {
           effective = label
-        } else if let defaultID = AudioDeviceEnumerator.defaultInputDeviceID() {
-          effective = AudioDeviceEnumerator.transportLabel(for: defaultID) ?? "unknown"
+        } else if let defaultID = defaultInputDeviceID() {
+          effective = transportLabelForDevice(defaultID) ?? "unknown"
         } else {
           effective = "unknown"
         }
@@ -116,8 +121,8 @@ public struct ResolvedRouteTransports: Sendable, Equatable {
       ? decision.reason.rawValue : nil
 
     let outputTransport =
-      AudioDeviceEnumerator.defaultOutputDeviceID()
-      .flatMap { AudioDeviceEnumerator.transportLabel(for: $0) } ?? "unknown"
+      defaultOutputDeviceID()
+      .flatMap { transportLabelForDevice($0) } ?? "unknown"
 
     return ResolvedRouteTransports(
       selected: selected,

--- a/Tests/EnviousWisprTests/Audio/AudioDeviceEnumeratorResolveTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioDeviceEnumeratorResolveTests.swift
@@ -16,9 +16,14 @@ struct AudioDeviceEnumeratorResolveTests {
 
   @Test("no explicit selection (both empty) falls through to the system default")
   func noExplicitSelectionUsesDefault() {
+    // #1529 — inject a fixed fake default device instead of two independent
+    // live CoreAudio reads (one inside the resolver, one in the assertion),
+    // which could disagree if the live default device changed between calls.
+    let fakeDefaultDeviceID = AudioDeviceID(42)
     let resolved = AudioDeviceEnumerator.resolveEffectiveInputDevice(
-      preferredOverride: "", selected: "")
-    #expect(resolved == AudioDeviceEnumerator.defaultInputDeviceID())
+      preferredOverride: "", selected: "",
+      defaultInputDeviceIDProvider: { fakeDefaultDeviceID })
+    #expect(resolved == fakeDefaultDeviceID)
   }
 
   @Test(

--- a/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
+++ b/Tests/EnviousWisprTests/Audio/ResolvedRouteTransportsGridTests.swift
@@ -1,3 +1,4 @@
+import CoreAudio
 import Foundation
 import Testing
 
@@ -19,6 +20,18 @@ struct ResolvedRouteTransportsGridTests {
       sourceType: source, reason: reason, rationale: "test",
       vpAvailable: false, fallbackAllowed: false)
   }
+
+  // #1529 — a fixed fake default device, injected via `derive`'s device-lookup
+  // closures, so tests asserting a specific `effective`/`selected` label never
+  // depend on which mic is actually live on the machine running the suite.
+  private let fakeDefaultDeviceID = AudioDeviceID(42)
+
+  private func fakeDefaultInputDeviceID() -> AudioDeviceID? { fakeDefaultDeviceID }
+  private func fakeDefaultOutputDeviceID() -> AudioDeviceID? { nil }
+  private func fakeTransportLabelForDevice(_ deviceID: AudioDeviceID) -> String? {
+    deviceID == fakeDefaultDeviceID ? "built_in" : nil
+  }
+  private func fakeTransportLabelForUID(_ uid: String) -> String? { nil }
 
   @Test(
     "derive is total over the sourceType × reason grid",
@@ -93,9 +106,15 @@ struct ResolvedRouteTransportsGridTests {
     // The exact misclassification the cloud reviewer flagged: a stored device
     // UID in selectedInputDeviceUID with an empty picker must not emit
     // explicit/bluetooth while route_reason stays Auto. All three agree on Auto.
+    // #1529 — the fake default device is injected so `effective == "built_in"`
+    // holds regardless of which mic is actually live on this machine.
     let r = ResolvedRouteTransports.derive(
       decision: makeDecision(.halDeviceInput, .btOutputAutoInput),
-      preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "fake-bt-uid")
+      preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "fake-bt-uid",
+      defaultInputDeviceID: fakeDefaultInputDeviceID,
+      defaultOutputDeviceID: fakeDefaultOutputDeviceID,
+      transportLabelForDevice: fakeTransportLabelForDevice,
+      transportLabelForUID: fakeTransportLabelForUID)
     #expect(r.inputSelectionMode == "auto")
     #expect(r.selected == "unknown")
     #expect(r.routeReason == "btOutputAutoInput")
@@ -117,12 +136,22 @@ struct ResolvedRouteTransportsGridTests {
     // AVAudioEngineSource resolves a missing pinned UID to nil and captures from
     // the system-default input (`resolvedDeviceID ?? defaultInputDeviceID()`),
     // so the effective transport must match Auto, NOT report "unknown".
+    // #1529 — both calls inject the SAME fake default device so the comparison
+    // is deterministic instead of racing two independent live CoreAudio reads.
     let disconnected = ResolvedRouteTransports.derive(
       decision: makeDecision(.audioEngine, .noBTUserSelectedDevice),
-      preferredInputDeviceIDOverride: "fake-disconnected-uid", selectedInputDeviceUID: "")
+      preferredInputDeviceIDOverride: "fake-disconnected-uid", selectedInputDeviceUID: "",
+      defaultInputDeviceID: fakeDefaultInputDeviceID,
+      defaultOutputDeviceID: fakeDefaultOutputDeviceID,
+      transportLabelForDevice: fakeTransportLabelForDevice,
+      transportLabelForUID: fakeTransportLabelForUID)
     let auto = ResolvedRouteTransports.derive(
       decision: makeDecision(.audioEngine, .noBTAutoInput),
-      preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "")
+      preferredInputDeviceIDOverride: "", selectedInputDeviceUID: "",
+      defaultInputDeviceID: fakeDefaultInputDeviceID,
+      defaultOutputDeviceID: fakeDefaultOutputDeviceID,
+      transportLabelForDevice: fakeTransportLabelForDevice,
+      transportLabelForUID: fakeTransportLabelForUID)
     #expect(disconnected.effective == auto.effective)
     // The user's pick is unavailable, so `selected` stays unknown.
     #expect(disconnected.selected == "unknown")


### PR DESCRIPTION
## What

Closes #1529.

`ResolvedRouteTransports.derive` and `AudioDeviceEnumerator.resolveEffectiveInputDevice` called live CoreAudio device lookups directly, with no injection seam. Three tests asserted a specific device transport (or compared two independent live reads to each other) and only passed on a machine whose live default input device happened to match the assertion — flaky, not a real regression.

## Fix

Added defaulted closure parameters to both functions, mirroring the identical pattern already shipped in `CaptureRouteResolver` (instance-level closures defaulted to the real `AudioDeviceEnumerator` calls). Every existing production call site (`AudioCaptureManager`, `AudioCaptureProxy`) is behavior-identical — they call the unchanged 4-argument surface and get the real CoreAudio defaults. The three affected tests now inject a fixed fake device instead of touching live hardware state.

## Process notes

- Council was skipped this session (founder directive — gcloud business auth expired mid-session); Codex grounded review (plan) and Codex diff review (code) both ran, PROCEED-WITH-REVISIONS → revisions adopted → clean.
- Codex's grounded review found the plan's original caller claims were wrong (real callers are `AudioCaptureManager`/`AudioCaptureProxy`, not the telemetry-context files) and found two additional live-device-coupled tests beyond the one originally scoped; both fixed in this PR rather than deferred, since it's the same root cause and a trivial same-shape fix.
- Falsification-tested: temporarily mismatched the injected fixture's label against the assertion and confirmed the suite fails (exit 65) before restoring — proves the fix is driven by the injected value, not incidentally still reading live state.
- Full local suite (2932 tests) passed; verified both exit code AND log content (not just exit code) given a separate, unrelated test-gate defect under investigation in #1530.

## Test plan

- [x] `scripts/xcode-test.sh --filter EnviousWisprTests/ResolvedRouteTransportsGridTests` — green
- [x] `scripts/xcode-test.sh --filter EnviousWisprTests/AudioDeviceEnumeratorResolveTests` — green
- [x] Falsification probe (mismatched fixture) — correctly fails, exit 65
- [x] Full suite (`scripts/xcode-test.sh`, 2932 tests) — green, log content cross-checked
- [x] Codex diff review — clean, no findings