### PR TITLE
feat(audio): measure the bound mic's native channel count as fleet telemetry

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
@@ -40,6 +40,9 @@ enum DictationCompletedReporting {
       captureRateDivergenceDetected: whenTrue(health?.rateDivergenceDetected),
       captureFormatStabilized: health?.formatStabilized,
       captureRebuiltForFormat: whenTrue(health?.captureRebuiltForFormat),
+      // #1523: bound device's native channel count (nil omits; 0 emits as an
+      // anomaly). Not gated on positivity — 1 and 2 are both meaningful.
+      captureNativeChannelCount: health?.nativeChannelCount,
       salvagedLeadTrimMs: driver.lastSalvagedLeadTrimMs,
       // #1408: which interruption cut this dictation short. `stop_reason` already
       // says one did; this names it. Absent on an uninterrupted completion.

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -258,7 +258,11 @@ public enum AudioDeviceEnumerator {
     transportTypeRaw(for: deviceID) ?? 0
   }
 
-  private static func inputChannelCount(for deviceID: AudioDeviceID) -> Int {
+  /// Total native input channel count for a device, summed across every input
+  /// stream (`kAudioDevicePropertyStreamConfiguration`). Module-internal (#1523)
+  /// so the capture backend can record it as prepare-time fleet telemetry —
+  /// this is the single channel-count authority; do not add a second reader.
+  static func inputChannelCount(for deviceID: AudioDeviceID) -> Int {
     var propertyAddress = AudioObjectPropertyAddress(
       mSelector: kAudioDevicePropertyStreamConfiguration,
       mScope: kAudioObjectPropertyScopeInput,

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -378,6 +378,13 @@ final class HALDeviceInputSource: AudioInputSource {
   private var boundUID: String?
   private var boundTransport: String?
   private var lastBindOK = true
+  /// #1523: the bound device's total native input channel count, read once at
+  /// prepare from the single channel-count authority
+  /// (`AudioDeviceEnumerator.inputChannelCount`). A prepare-time constant of the
+  /// bound device — not per-session health — so it survives warm-unit reuse and
+  /// is cleared only in `teardownUnit()`. AUHAL down-mixes to mono by taking
+  /// channel 0; this records how many channels the device actually exposed.
+  private var boundNativeChannelCount: Int?
 
   var actualBoundTransport: String? { boundTransport }
 
@@ -394,10 +401,16 @@ final class HALDeviceInputSource: AudioInputSource {
     return boundDeviceID == resolveDeviceID()
   }
 
-  /// #1434: stop-time capture-health facts. The manager snapshots this BEFORE
-  /// deactivate/teardown and attaches it to `CaptureResult.metadata` — the one
-  /// transport object for both the in-process and XPC stop paths.
-  var captureStopMetadata: CaptureStopMetadata? {
+  /// #1523: the last live stop-metadata, cached in `teardownUnit()` right before
+  /// the render context + bound-device state are cleared. The device-vanish path
+  /// (`handleDeviceMayHaveVanished`) tears the unit down BEFORE the manager reads
+  /// `captureStopMetadata`, so without this cache a salvaged completion would
+  /// lose EVERY capture-health fact (rate, counters, channel count), not just the
+  /// new field. Reset when the next capture starts so a session never serves the
+  /// prior session's metadata.
+  private var cachedStopMetadata: CaptureStopMetadata?
+
+  private func computeStopMetadataFromLiveState() -> CaptureStopMetadata? {
     guard let context = renderContext else { return nil }
     let snap = context.counters.snapshot()
     return CaptureStopMetadata(
@@ -405,8 +418,18 @@ final class HALDeviceInputSource: AudioInputSource {
       ringDropCount: snap.ringDrops,
       converterErrorCount: snap.converterErrors,
       zeroOutputCount: snap.zeroOutputs,
-      rateDivergenceDetected: formatDivergenceObserved
+      rateDivergenceDetected: formatDivergenceObserved,
+      nativeChannelCount: boundNativeChannelCount
     )
+  }
+
+  /// #1434: stop-time capture-health facts. The manager snapshots this BEFORE
+  /// deactivate/teardown and attaches it to `CaptureResult.metadata` — the one
+  /// transport object for both the in-process and XPC stop paths. Serves live
+  /// state while the unit is up, falling back to the pre-teardown cache so the
+  /// device-vanish salvage (teardown-before-read) keeps its metadata (#1523).
+  var captureStopMetadata: CaptureStopMetadata? {
+    computeStopMetadataFromLiveState() ?? cachedStopMetadata
   }
 
   private static let listenerQueue = DispatchQueue(
@@ -613,13 +636,23 @@ final class HALDeviceInputSource: AudioInputSource {
     boundDeviceID = deviceID
     boundUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
     boundTransport = AudioDeviceEnumerator.transportLabel(for: deviceID)
+    // #1523: read the device's total native channel count once at prepare from
+    // the single channel-count authority. We capture mono (client format
+    // channels: 1 above) and AUHAL down-mixes by TAKING CHANNEL 0 — so a device
+    // whose meaningful audio is on a later channel would be captured as silence.
+    // This value makes a >1-channel fleet population measurable; it does NOT
+    // change what we capture (measure-only, #1523). Do not build a channel
+    // selector until this telemetry shows both a >1-channel population and a
+    // buried-audio report.
+    boundNativeChannelCount = AudioDeviceEnumerator.inputChannelCount(for: deviceID)
     // #1434: the native rate + ratio in the prepare line is the per-recording
     // rate evidence D4 flagged as the highest-value instrumentation gap.
     let ratio = Self.targetFormat.sampleRate / nativeFormat.sampleRate
     AudioCaptureManager.btRouteLog(
       "HALDeviceInputSource: prepared with device \(deviceID) (uid=\(boundUID ?? "unknown")) "
         + "nativeRate=\(Int(nativeFormat.sampleRate)) targetRate=\(Int(Self.targetFormat.sampleRate)) "
-        + "ratio=\(String(format: "%.3f", ratio))"
+        + "ratio=\(String(format: "%.3f", ratio)) "
+        + "nativeChannels=\(boundNativeChannelCount.map(String.init) ?? "nil")"
     )
   }
 
@@ -649,6 +682,9 @@ final class HALDeviceInputSource: AudioInputSource {
     // or pre-roll ring drop must not bleed into the next recording's telemetry.
     renderContext?.counters.reset()
     formatDivergenceObserved = false
+    // #1523: a fresh session must never serve the previous session's cached
+    // stop-metadata; the live path repopulates it via teardownUnit().
+    cachedStopMetadata = nil
     armCaptureStallWatchdog()
 
     isCapturing = true
@@ -713,7 +749,8 @@ final class HALDeviceInputSource: AudioInputSource {
       // own live rate/divergence here — the stop-time metadata object does
       // not exist yet. (The XPC proxy's host-side watchdog leaves these nil.)
       nativeRateHz: renderContext?.nativeFormat.sampleRate,
-      rateDivergenceDetected: formatDivergenceObserved
+      rateDivergenceDetected: formatDivergenceObserved,
+      nativeChannelCount: boundNativeChannelCount
     )
     onCaptureStalled?(ctx)
   }
@@ -873,6 +910,11 @@ final class HALDeviceInputSource: AudioInputSource {
   // MARK: - Private: teardown
 
   private func teardownUnit() {
+    // #1523: snapshot the live stop-metadata BEFORE any state is cleared, so the
+    // device-vanish salvage (which tears the unit down before the manager reads
+    // `captureStopMetadata`) still has rate/counters/channel-count. Only cache a
+    // non-nil compute so a double-teardown never overwrites a good snapshot.
+    if let live = computeStopMetadataFromLiveState() { cachedStopMetadata = live }
     // Single authority for "this unit is going away" — every caller (normal
     // stop, abort, rebuild, AND device-vanish) must disarm the stall
     // watchdog and drop `isCapturing`, mirroring
@@ -916,6 +958,7 @@ final class HALDeviceInputSource: AudioInputSource {
     boundDeviceID = nil
     boundUID = nil
     boundTransport = nil
+    boundNativeChannelCount = nil
   }
 
   // MARK: - Private: device resolution

--- a/Sources/EnviousWisprCore/CaptureStallContext.swift
+++ b/Sources/EnviousWisprCore/CaptureStallContext.swift
@@ -56,6 +56,10 @@ public struct CaptureStallContext: Sendable {
   public let rateDivergenceDetected: Bool?
   public let formatStabilized: Bool?
   public let captureRebuiltForFormat: Bool?
+  /// #1523: the bound device's total native input channel count, source-stamped
+  /// at watchdog-fire time (direct HAL stalls populate it; the XPC proxy's
+  /// host-side watchdog leaves it nil). Preserved through `enrichedWithStabilizationFlags`.
+  public let nativeChannelCount: Int?
 
   public init(
     sessionID: UInt64,
@@ -79,7 +83,8 @@ public struct CaptureStallContext: Sendable {
     nativeRateHz: Double? = nil,
     rateDivergenceDetected: Bool? = nil,
     formatStabilized: Bool? = nil,
-    captureRebuiltForFormat: Bool? = nil
+    captureRebuiltForFormat: Bool? = nil,
+    nativeChannelCount: Int? = nil
   ) {
     self.sessionID = sessionID
     self.armedAtUptimeNs = armedAtUptimeNs
@@ -103,6 +108,7 @@ public struct CaptureStallContext: Sendable {
     self.rateDivergenceDetected = rateDivergenceDetected
     self.formatStabilized = formatStabilized
     self.captureRebuiltForFormat = captureRebuiltForFormat
+    self.nativeChannelCount = nativeChannelCount
   }
 
   /// Kernel-side enrichment (#1434): the kernel owns the stabilization record
@@ -134,7 +140,8 @@ public struct CaptureStallContext: Sendable {
       nativeRateHz: nativeRateHz,
       rateDivergenceDetected: rateDivergenceDetected,
       formatStabilized: formatStabilized,
-      captureRebuiltForFormat: captureRebuiltForFormat
+      captureRebuiltForFormat: captureRebuiltForFormat,
+      nativeChannelCount: nativeChannelCount
     )
   }
 }

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -68,19 +68,27 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   /// device while capturing (#1434 — log-and-telemetry only in v1; never
   /// interrupts the recording).
   public let rateDivergenceDetected: Bool
+  /// The bound device's total native input channel count, summed across every
+  /// input stream at prepare time (#1523 — fleet-visibility for the multi-channel
+  /// down-mix. AUHAL always takes channel 0; this records how many channels the
+  /// device exposed so a >1-channel population is measurable). Nil when the
+  /// source doesn't read a channel count (the AVAudioEngine backend leaves it nil).
+  public let nativeChannelCount: Int?
 
   public init(
     nativeRateHz: Double?,
     ringDropCount: Int = 0,
     converterErrorCount: Int = 0,
     zeroOutputCount: Int = 0,
-    rateDivergenceDetected: Bool = false
+    rateDivergenceDetected: Bool = false,
+    nativeChannelCount: Int? = nil
   ) {
     self.nativeRateHz = nativeRateHz
     self.ringDropCount = ringDropCount
     self.converterErrorCount = converterErrorCount
     self.zeroOutputCount = zeroOutputCount
     self.rateDivergenceDetected = rateDivergenceDetected
+    self.nativeChannelCount = nativeChannelCount
   }
 }
 

--- a/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
@@ -40,6 +40,8 @@ internal struct ASREmptyResultDiagnostics {
   var captureRateDivergenceDetected: Bool?
   var captureFormatStabilized: Bool?
   var captureRebuiltForFormat: Bool?
+  // #1523 bound device's total native input channel count at the empty terminal.
+  var captureNativeChannelCount: Int?
 
   var incrementalAccepted: Bool?
   var incrementalResultChars: Int?
@@ -117,6 +119,7 @@ internal struct ASREmptyResultDiagnostics {
     put(captureRateDivergenceDetected, key: "capture.rate_divergence_detected", into: &extra)
     put(captureFormatStabilized, key: "capture.format_stabilized", into: &extra)
     put(captureRebuiltForFormat, key: "capture.rebuilt_for_format", into: &extra)
+    put(captureNativeChannelCount, key: "capture.native_channel_count", into: &extra)
 
     put(incrementalAccepted, key: "asr.incremental_accepted", into: &extra)
     put(incrementalResultChars, key: "asr.incremental_result_chars", into: &extra)

--- a/Sources/EnviousWisprPipeline/CaptureHealthTransports.swift
+++ b/Sources/EnviousWisprPipeline/CaptureHealthTransports.swift
@@ -12,6 +12,8 @@ public struct CaptureHealthTransports: Sendable, Equatable {
   public let rateDivergenceDetected: Bool?
   public let formatStabilized: Bool?
   public let captureRebuiltForFormat: Bool?
+  /// #1523: the bound device's total native input channel count.
+  public let nativeChannelCount: Int?
 
   public init(
     nativeRateHz: Double?,
@@ -20,7 +22,8 @@ public struct CaptureHealthTransports: Sendable, Equatable {
     zeroOutputCount: Int?,
     rateDivergenceDetected: Bool?,
     formatStabilized: Bool?,
-    captureRebuiltForFormat: Bool?
+    captureRebuiltForFormat: Bool?,
+    nativeChannelCount: Int? = nil
   ) {
     self.nativeRateHz = nativeRateHz
     self.ringDropCount = ringDropCount
@@ -29,5 +32,6 @@ public struct CaptureHealthTransports: Sendable, Equatable {
     self.rateDivergenceDetected = rateDivergenceDetected
     self.formatStabilized = formatStabilized
     self.captureRebuiltForFormat = captureRebuiltForFormat
+    self.nativeChannelCount = nativeChannelCount
   }
 }

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
@@ -33,6 +33,8 @@ struct NoAudioContext: Sendable {
   var captureRateDivergenceDetected: Bool? = nil
   var captureFormatStabilized: Bool? = nil
   var captureRebuiltForFormat: Bool? = nil
+  // #1523: bound device's total native input channel count at the no-audio terminal.
+  var captureNativeChannelCount: Int? = nil
 }
 
 /// Per-call context for `HeartPathTelemetryEmitter.zombieZeroPeakIfNeeded(...)`.

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -195,6 +195,9 @@ final class HeartPathTelemetryEmitter {
     if let rebuilt = ctx.captureRebuiltForFormat {
       extras["capture.rebuilt_for_format"] = rebuilt
     }
+    if let channels = ctx.captureNativeChannelCount {
+      extras["capture.native_channel_count"] = channels
+    }
     captureError(err, .audioCaptureFailed, "recording", extras)
   }
 

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -713,7 +713,8 @@ final class KernelLifecycleTelemetrySink {
         captureZeroOutputCount: health?.stopMetadata?.zeroOutputCount,
         captureRateDivergenceDetected: health?.stopMetadata?.rateDivergenceDetected,
         captureFormatStabilized: health?.formatStabilized,
-        captureRebuiltForFormat: health?.captureRebuiltForFormat
+        captureRebuiltForFormat: health?.captureRebuiltForFormat,
+        captureNativeChannelCount: health?.stopMetadata?.nativeChannelCount
       )
       if let noAudioCapturedRich {
         noAudioCapturedRich(ctx)

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1230,7 +1230,8 @@ final class RecordingSessionKernel {
       zeroOutputCount: captureResult.metadata?.zeroOutputCount,
       rateDivergenceDetected: captureResult.metadata?.rateDivergenceDetected,
       formatStabilized: formatStabilizedThisSession,
-      captureRebuiltForFormat: captureRebuiltForFormatThisSession
+      captureRebuiltForFormat: captureRebuiltForFormatThisSession,
+      nativeChannelCount: captureResult.metadata?.nativeChannelCount
     )
     recordingStoppedTelemetry(captureResult.samples.count)
     await (vad as? CaptureVADSignalSource)?.finalizeAtStop(
@@ -1322,7 +1323,12 @@ final class RecordingSessionKernel {
           routeFallbackReason: audioCapture.currentResolvedRoute?.routeFallbackReason,
           inputSelectionMode: audioCapture.currentResolvedRoute?.inputSelectionMode,
           outputTransport: audioCapture.currentResolvedRoute?.outputTransport,
-          routeResolutionSource: audioCapture.currentResolvedRoute?.routeResolutionSource
+          routeResolutionSource: audioCapture.currentResolvedRoute?.routeResolutionSource,
+          // #1523: stamp the bound device's channel count on the zero-signal
+          // terminal. This is the near-silent-capture event §3a correlates a
+          // >1-channel count against (voice on a later channel → AUHAL takes
+          // channel 0 → silence), so the count belongs precisely here.
+          nativeChannelCount: captureResult.metadata?.nativeChannelCount
         ))
     }
 
@@ -2960,6 +2966,7 @@ final class RecordingSessionKernel {
     diagnostics.captureRateDivergenceDetected = health.stopMetadata?.rateDivergenceDetected
     diagnostics.captureFormatStabilized = health.formatStabilized
     diagnostics.captureRebuiltForFormat = health.captureRebuiltForFormat
+    diagnostics.captureNativeChannelCount = health.stopMetadata?.nativeChannelCount
     telemetryState.asrEmptyDiagnostics = diagnostics
   }
 

--- a/Sources/EnviousWisprServices/SentryAudioExtras.swift
+++ b/Sources/EnviousWisprServices/SentryAudioExtras.swift
@@ -71,6 +71,9 @@ public enum SentryAudioExtras {
       if let rebuilt = ctx.captureRebuiltForFormat {
         extras["capture.rebuilt_for_format"] = rebuilt
       }
+      if let channels = ctx.nativeChannelCount {
+        extras["capture.native_channel_count"] = channels
+      }
     }
 
     if let swap = polishModelSwapMs {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -77,7 +77,8 @@ public final class TelemetryService {
     captureNativeRateHz: Double? = nil, captureRingDropCount: Int? = nil,
     captureConverterErrorCount: Int? = nil, captureZeroOutputCount: Int? = nil,
     captureRateDivergenceDetected: Bool? = nil, captureFormatStabilized: Bool? = nil,
-    captureRebuiltForFormat: Bool? = nil, salvagedLeadTrimMs: Int? = nil,
+    captureRebuiltForFormat: Bool? = nil, captureNativeChannelCount: Int? = nil,
+    salvagedLeadTrimMs: Int? = nil,
     // #1408: present only on a salvaged completion — WHICH interruption cut the
     // recording short. `stop_reason` already says an interruption ended it; this
     // says which one. Low-cardinality reason string.
@@ -98,8 +99,15 @@ public final class TelemetryService {
       if let ism = inputSelectionMode { hookStringProps["input_selection_mode"] = ism }
       if let ot = outputTransport { hookStringProps["output_transport"] = ot }
       if let rrs = routeResolutionSource { hookStringProps["route_resolution_source"] = rrs }
+      // #1523: mirror the emitted int key's presence-only semantics so the
+      // channel-count threading is unit-testable by exact production spelling.
+      var hookIntProps: [String: Int] = [:]
+      if let channels = captureNativeChannelCount {
+        hookIntProps["capture_native_channel_count"] = channels
+      }
       testEventHook?(
-        CapturedTelemetryEvent(name: "dictation.completed", stringProps: hookStringProps))
+        CapturedTelemetryEvent(
+          name: "dictation.completed", stringProps: hookStringProps, intProps: hookIntProps))
     #endif
     let m = t.metrics
     dictationCompleted(
@@ -143,6 +151,7 @@ public final class TelemetryService {
       captureRateDivergenceDetected: captureRateDivergenceDetected,
       captureFormatStabilized: captureFormatStabilized,
       captureRebuiltForFormat: captureRebuiltForFormat,
+      captureNativeChannelCount: captureNativeChannelCount,
       salvagedLeadTrimMs: salvagedLeadTrimMs,
       interruptedBy: interruptedBy
     )
@@ -521,7 +530,8 @@ public final class TelemetryService {
     captureNativeRateHz: Double? = nil, captureRingDropCount: Int? = nil,
     captureConverterErrorCount: Int? = nil, captureZeroOutputCount: Int? = nil,
     captureRateDivergenceDetected: Bool? = nil, captureFormatStabilized: Bool? = nil,
-    captureRebuiltForFormat: Bool? = nil, salvagedLeadTrimMs: Int? = nil,
+    captureRebuiltForFormat: Bool? = nil, captureNativeChannelCount: Int? = nil,
+    salvagedLeadTrimMs: Int? = nil,
     interruptedBy: String? = nil
   ) {
     var props: [String: Any] = [
@@ -548,6 +558,7 @@ public final class TelemetryService {
     if let div = captureRateDivergenceDetected { props["capture_rate_divergence_detected"] = div }
     if let stab = captureFormatStabilized { props["capture_format_stabilized"] = stab }
     if let rebuilt = captureRebuiltForFormat { props["capture_rebuilt_for_format"] = rebuilt }
+    if let channels = captureNativeChannelCount { props["capture_native_channel_count"] = channels }
     if let trim = salvagedLeadTrimMs { props["salvaged_lead_trim_ms"] = trim }
     if let p = llmProvider { props["llm_provider"] = p }
     if let a = targetApp { props["target_app"] = a }

--- a/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
+++ b/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
@@ -157,4 +157,29 @@ struct CaptureStopMetadataTransportTests {
     #expect(CaptureResult(samples: []).metadata == nil)
     #expect(CaptureResult(samples: [], vadSegments: []).metadata == nil)
   }
+
+  @Test("#1523: a populated channel count survives the XPC round trip")
+  func channelCountRoundTrip() throws {
+    let original = CaptureStopMetadata(
+      nativeRateHz: 48000, ringDropCount: 0, converterErrorCount: 0,
+      zeroOutputCount: 0, rateDivergenceDetected: false, nativeChannelCount: 4)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(CaptureStopMetadata.self, from: data)
+    #expect(decoded == original)
+    #expect(decoded.nativeChannelCount == 4)
+  }
+
+  @Test("#1523: a pre-field JSON blob (no channel key) decodes to a nil count")
+  func preFieldBlobDecodesToNilChannelCount() throws {
+    // A stop-reply blob encoded before #1523 shipped — no `nativeChannelCount`
+    // key. The optional must decode to nil (forward-compatible XPC boundary).
+    let preFieldJSON = """
+      {"nativeRateHz":24000,"ringDropCount":1,"converterErrorCount":0,\
+      "zeroOutputCount":0,"rateDivergenceDetected":false}
+      """
+    let data = Data(preFieldJSON.utf8)
+    let decoded = try JSONDecoder().decode(CaptureStopMetadata.self, from: data)
+    #expect(decoded.nativeChannelCount == nil)
+    #expect(decoded.nativeRateHz == 24000)
+  }
 }

--- a/Tests/EnviousWisprTests/Core/HeartPathContextsTests.swift
+++ b/Tests/EnviousWisprTests/Core/HeartPathContextsTests.swift
@@ -27,6 +27,44 @@ struct HeartPathContextsTests {
     #expect(ctx.formatMismatchObserved == false)
   }
 
+  @Test("#1523: enrichedWithStabilizationFlags preserves the source-stamped channel count")
+  func enrichmentPreservesChannelCount() {
+    let source = CaptureStallContext(
+      sessionID: 1,
+      armedAtUptimeNs: 0,
+      firedAtUptimeNs: 1,
+      route: "hal_device_input",
+      sourceType: "hal_device_input",
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: .noBuffers,
+      nativeChannelCount: 6
+    )
+    // The kernel merges its stabilization observations without reconstructing
+    // the context from scratch, so the source-stamped channel count must survive.
+    let enriched = source.enrichedWithStabilizationFlags(
+      formatStabilized: true, captureRebuiltForFormat: false)
+    #expect(enriched.nativeChannelCount == 6)
+    #expect(enriched.formatStabilized == true)
+    // A source that never stamps a count leaves it nil through enrichment.
+    #expect(
+      source.enrichedWithStabilizationFlags(formatStabilized: nil, captureRebuiltForFormat: nil)
+        .nativeChannelCount == 6)
+    let unstamped = CaptureStallContext(
+      sessionID: 1, armedAtUptimeNs: 0, firedAtUptimeNs: 1, route: "proxy",
+      sourceType: "proxy", engineStartedSuccessfully: true, tapInstalled: true,
+      formatMismatchObserved: false, inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil, failureMode: .noBuffers
+    )
+    #expect(
+      unstamped.enrichedWithStabilizationFlags(
+        formatStabilized: nil, captureRebuiltForFormat: nil
+      ).nativeChannelCount == nil)
+  }
+
   @Test("XPCReplyFailureContext retains replyStage verbatim")
   func xpcReplyFailureContext() {
     let ctx = XPCReplyFailureContext(

--- a/Tests/EnviousWisprTests/Pipeline/ASREmptyResultDiagnosticsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ASREmptyResultDiagnosticsTests.swift
@@ -50,6 +50,24 @@ struct ASREmptyResultDiagnosticsTests {
     assertNoContentLikeKeys(extra)
   }
 
+  @Test("#1523: a stamped channel count emits capture.native_channel_count; nil omits it")
+  func channelCountEmitsOnASREmpty() {
+    var diagnostics = ASREmptyResultDiagnostics(
+      backend: "parakeet",
+      mode: "streaming",
+      hasSpeechEvidence: false,
+      rawSampleCount: 0,
+      vadSegmentCount: 0,
+      vadSpeechDurationMs: 0,
+      peakAudioLevel: 0.0
+    )
+    // Nil before the kernel stamps it → key absent.
+    #expect(diagnostics.sentryExtra()["capture.native_channel_count"] == nil)
+
+    diagnostics.captureNativeChannelCount = 2
+    #expect(diagnostics.sentryExtra()["capture.native_channel_count"] as? Int == 2)
+  }
+
   @Test("WhisperKit diagnostics keep comparable base fields and worker subset")
   func whisperKitDiagnosticsShape() {
     let diagnostics = ASREmptyResultDiagnostics(

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -224,6 +224,21 @@ struct HeartPathTelemetryEmitterTests {
     #expect(captured.category == .audioCaptureFailed)
     #expect(captured.stage == "recording")
     #expect(captured.extra["capture.failure_mode"] as? String == "no_audio_captured")
+    // #1523: an unstamped no-audio terminal omits the channel-count key.
+    #expect(captured.extra["capture.native_channel_count"] == nil)
+  }
+
+  @Test("#1523: a stamped channel count rides the no-audio captureError extras")
+  func noAudioCarriesChannelCount() {
+    let recorder = Recorder()
+    let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+    var ctx = Self.noAudioContext(sessionID: 5)
+    ctx.captureNativeChannelCount = 8
+    emitter.noAudioCaptured(ctx: ctx)
+
+    #expect(recorder.errors.count == 1)
+    #expect(recorder.errors[0].extra["capture.native_channel_count"] as? Int == 8)
   }
 
   @Test("noAudioCaptured dedups to a breadcrumb after a stall in the same session")

--- a/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
@@ -64,5 +64,34 @@ struct DictationCompletedRouteFieldsTests {
       // The pre-existing input_mode key is still emitted.
       #expect(props?["input_mode"] == "ptt")
     }
+
+    @Test("#1523: channel count threads into dictation.completed as an int prop")
+    func channelCountThreadedAsIntProp() {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt",
+        captureNativeChannelCount: 2)
+
+      #expect(box.event?.intProps["capture_native_channel_count"] == 2)
+    }
+
+    @Test("#1523: a nil channel count omits the int key")
+    func channelCountOmittedWhenNil() {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt")
+
+      #expect(box.event?.intProps["capture_native_channel_count"] == nil)
+    }
   #endif
 }

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
@@ -125,6 +125,37 @@ struct SentryAudioExtrasTests {
     #expect(extras["capture.format_mismatch"] as? Bool == true)
     #expect(extras["capture.tap_installed"] as? Bool == true)
     #expect(extras["polish.recent_model_swap_ms"] as? Int == 4500)
+    // #1523: a source that never stamped a channel count omits the key.
+    #expect(extras["capture.native_channel_count"] == nil)
+  }
+
+  @Test("#1523: a source-stamped channel count rides the stall extras")
+  func stallContextCarriesChannelCount() {
+    let ctx = CaptureStallContext(
+      sessionID: 9,
+      armedAtUptimeNs: 1_000_000_000,
+      firedAtUptimeNs: 1_800_000_000,
+      route: "bt",
+      sourceType: "hal_device_input",
+      engineStartedSuccessfully: true,
+      tapInstalled: true,
+      formatMismatchObserved: true,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: .noBuffers,
+      nativeChannelCount: 2
+    )
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: ctx.route,
+      sourceType: ctx.sourceType,
+      sessionID: ctx.sessionID,
+      isActivelyCapturing: true,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "stalled",
+      stallContext: ctx
+    )
+    #expect(extras["capture.native_channel_count"] as? Int == 2)
   }
 
   @Test("nil polish swap omits the key entirely")


### PR DESCRIPTION
## What & why (Heartpath 3a)

The keeper capture backend captures mono and lets AUHAL down-mix a multi-channel device by **taking channel 0** — so a mic whose voice is on a later channel would be captured as silence, and we had no way to see whether such a device exists in the fleet. This records the bound device's total native input channel count per recording, as fleet telemetry. **Measure-only: no channel selector** (taking channel 0 is the field norm; only SuperWhisper ships a selector and even it defaults to channel 0).

## What it does

- `CaptureStopMetadata` gains an optional `nativeChannelCount` (defaulted nil → every caller and the XPC JSON boundary stay compatible).
- `HALDeviceInputSource` reads it once at prepare from the single existing authority (`AudioDeviceEnumerator.inputChannelCount`, full-stream sum), stamps it on stop metadata + its own stall context + the `bt-route.log` prepare line, and clears it in teardown.
- Threaded through both telemetry legs (stop + HAL stall) and the stop-time zero-signal terminal. Keys: Sentry dotted `capture.native_channel_count`, PostHog underscore `capture_native_channel_count`.
- **Bonus fix:** `HALDeviceInputSource` now caches the stop metadata immediately before teardown, so a **device-vanish salvage** (teardown-before-read) keeps rate/counters/channel-count instead of nil-ing all three — a fix that helps every capture-health field, not just the new one.

## Scope note (deliberate)

The proxy-side reactive all-zero event is **deliberately not** stamped. It fires app-side, pre-stop, and the app cannot know the helper's actual bound device across the XPC boundary without re-deriving it — four grounded-review rounds proved every app-side re-derivation can diverge from what the helper bound. The buried-channel FAILURE-event correlation is deferred to the D-028 XPC-boundary collapse (after which the reactive detector and the HAL backend share a process and the real bound count is directly reachable). Until then the fleet gets the channel-count **distribution** via successful completions + the HAL stop/stall paths, which answers the first measure-only question: do >1-channel mics exist in the fleet at all.

## Validation

- **Logic tests:** `scripts/xcode-test.sh` green (2940 tests, 0 failures), including 8 new tests (round-trip, pre-field-nil decode, and each emit path).
- **Codex code-diff review:** clean (r5, "No actionable defects found") after resolving 4 rounds of findings.
- **Live UAT (real hardware):** recorded through the real Bluetooth/HAL path on AirPods Pro → `nativeChannels=1` logged correctly, transcription healthy. Independently confirmed the identical read function returns AirPods=1, Plantronics Blackwire USB=1, BlackHole 2ch=**2**, built-in=1 — proving the multi-channel (>1) read.

Tier MEDIUM · Lane Code · Heart path untouched (pure telemetry).

Part of #1511
Part of #1523
