### PR TITLE
refactor(services): pin ModelLoadWatchdog.WedgeError's Sentry identity (Part of #1525)

### DIFF
--- a/Sources/EnviousWisprCore/ModelLoadWatchdog.swift
+++ b/Sources/EnviousWisprCore/ModelLoadWatchdog.swift
@@ -30,6 +30,24 @@ public enum ModelLoadWatchdog {
   }
 }
 
+// MARK: - Sentry identity
+
+/// Pins `WedgeError`'s Sentry grouping key to the exact string it has been
+/// sending in production, so a future second case/shape can never renumber
+/// it (#1525 PR B). Not derived — measured against shipping code and
+/// cross-checked against the live Sentry issue title (ENVIOUSWISPR-30,
+/// `docs/sentry-identity-refactor/BIBLE.md` §2.5.5). `WedgeError` has one
+/// shape today, so there is nothing to reorder yet; this pin closes the
+/// latent risk before a second shape is ever added, mirroring
+/// `HeartPathError`'s shipped pattern (#1524).
+extension ModelLoadWatchdog.WedgeError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    "EnviousWisprCore.ModelLoadWatchdog.WedgeError#1"
+  }
+
+  public var sentrySemanticID: String { "modelload.wedge" }
+}
+
 /// #1388 step 1: thrown from `loadModel()` when the in-flight load was
 /// deliberately cancelled — a user Cancel during onboarding install, or the
 /// wedge guard's teardown (both route through `cancelInFlightLoad()`).

--- a/Tests/EnviousWisprTests/Services/ModelLoadWatchdogSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Services/ModelLoadWatchdogSentryIdentityTests.swift
@@ -1,0 +1,135 @@
+import EnviousWisprCore
+import Foundation
+import Sentry
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1525 PR B — `ModelLoadWatchdog.WedgeError`'s Sentry identity is PINNED,
+/// mirroring `HeartPathError`'s shipped pattern (#1524,
+/// `StableSentryErrorIdentityTests.swift`). `WedgeError` has one shape today
+/// (a struct, not an enum), so there is no ordinal-reorder risk yet — this
+/// pin closes the latent risk before a second shape is ever added.
+///
+/// The expected string is not re-derived here: it was MEASURED against
+/// shipping code and cross-checked against the live Sentry issue title
+/// (ENVIOUSWISPR-30, `docs/sentry-identity-refactor/BIBLE.md` §2.5.5). This
+/// suite is the lock — any drift in the shipped identity reddens.
+///
+/// `environment` is passed explicitly throughout: the default reads the
+/// bundle identifier, and a test runner's bundle is not production.
+@Suite("ModelLoadWatchdog.WedgeError Sentry stable identity (#1525 PR B)")
+struct ModelLoadWatchdogSentryIdentityTests {
+
+  private static let env = "production"
+  private static let descriptor = "EnviousWisprCore.ModelLoadWatchdog.WedgeError#1"
+  private static let semanticID = "modelload.wedge"
+
+  /// The two live production categories this type is captured under
+  /// (`RecordingStarter.swift:356`, `KernelDictationDriver.swift:220`,
+  /// `KernelLifecycleTelemetrySink.swift:564`) — different categories,
+  /// same descriptor, kept separate by the category component of the
+  /// fingerprint.
+  private static let liveCategories: [SentryBreadcrumb.ErrorCategory] = [
+    .pipelinePostConditionFailed,
+    .modelLoadWedged,
+  ]
+
+  // MARK: - A. Pin lock
+
+  @Test("both live capture-site shapes keep the exact production fingerprint")
+  func pinLock() {
+    for stage in ["post_condition", "model_load"] {
+      let error = ModelLoadWatchdog.WedgeError(stage: stage)
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == Self.descriptor)
+      for category in Self.liveCategories {
+        #expect(
+          SentryBreadcrumb.handledErrorFingerprint(
+            for: category, error: error, environment: Self.env)
+            == ["handled_error", category.rawValue, Self.descriptor, Self.env])
+      }
+    }
+  }
+
+  @Test("the single declared identity is unique within WedgeError")
+  func identityIsUniqueWithinType() {
+    let errors = [ModelLoadWatchdog.WedgeError()]
+
+    #expect(
+      Set(errors.map(\.sentryFingerprintDescriptor)).count == errors.count
+    )
+    #expect(
+      Set(errors.map(\.sentrySemanticID)).count == errors.count
+    )
+  }
+
+  // MARK: - B. The property that matters
+
+  /// A deterministic `CustomNSError` — its bridged domain/code are declared,
+  /// not inferred from enum layout, so this test asserts the override
+  /// itself and never depends on the compiler behaviour the design exists
+  /// to escape.
+  private struct StableFixtureError: Error, CustomNSError, StableSentryErrorIdentity {
+    static let errorDomain = "fixture.raw"
+    var errorCode: Int { 10 }
+    let sentryFingerprintDescriptor = "fixture.pinned#modelload"
+    let sentrySemanticID = "fixture.semantic"
+  }
+
+  @Test("the explicit identity overrides the bridged NSError identity")
+  func explicitIdentityOverridesBridge() {
+    let error = StableFixtureError()
+    let bridged = error as NSError
+
+    #expect(bridged.domain == "fixture.raw")
+    #expect(bridged.code == 10)
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "fixture.pinned#modelload")
+  }
+
+  // MARK: - C. Dev/prod split survives the pin
+
+  @Test("environment keeps the same descriptor's dev and prod fingerprints separate")
+  func devProdSplitSurvives() {
+    let error = ModelLoadWatchdog.WedgeError()
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: .modelLoadWedged, error: error, environment: "production")
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: .modelLoadWedged, error: error, environment: "development")
+
+    #expect(prod != dev)
+    #expect(prod.last == "production")
+    #expect(dev.last == "development")
+  }
+
+  // MARK: - D. Event-construction contract
+
+  @MainActor
+  @Test("a pinned error's event carries the production title, fingerprint and identity tag")
+  func pinnedErrorEventShape() {
+    let error = ModelLoadWatchdog.WedgeError()
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .modelLoadWedged, stage: "asr", environment: Self.env)
+
+    #expect(event.message?.formatted == "model_load_wedged: \(Self.descriptor)")
+    #expect(
+      event.fingerprint == ["handled_error", "model_load_wedged", Self.descriptor, Self.env])
+    #expect(event.tags?["pipeline.stage"] == "asr")
+    #expect(event.tags?["error.category"] == "model_load_wedged")
+    #expect(event.tags?["error.identity"] == Self.semanticID)
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -3)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .modelLoadFailed, stage: "asr", environment: Self.env)
+
+    #expect(event.message?.formatted == "model_load_failed: EnviousWispr#-3")
+    #expect(
+      event.fingerprint == ["handled_error", "model_load_failed", "EnviousWispr#-3", Self.env])
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}


### PR DESCRIPTION
## Summary

PR B of the Sentry stable-identity migration ladder (#1525, plan of record `docs/sentry-identity-refactor/BIBLE.md`, PR A shipped in #1534). Conforms `ModelLoadWatchdog.WedgeError` — the highest-value unmigrated type, currently ENVIOUSWISPR-30 at 161 users / 183 events and still escalating — to the already-shipped `StableSentryErrorIdentity` protocol, pinning its measured production descriptor exactly as it already sends. Mirrors `HeartPathError`'s shipped pattern (#1524).

- Pin: `sentryFingerprintDescriptor = "EnviousWisprCore.ModelLoadWatchdog.WedgeError#1"` (measured against pre-change `main`, cross-checked against the live Sentry issue title).
- New: `sentrySemanticID = "modelload.wedge"`.
- Zero behavior change beyond the new `error.identity` Sentry event tag. Descriptor, fingerprint, categories, and existing Sentry grouping are unchanged.

## Process

- Council: SKIPPED per `workflow-process.md` RULE: council-skip-codex-grounded-review-settled (mechanical application of a settled, 3x-proven pattern).
- Grounded review: 3 rounds, PROCEED-AS-PLANNED. Rounds 1-2 caught real defects: an overclaimed Live UAT repro (network interruption during model download doesn't reach either detector — delivery happens before `loadModel`), a model-unload-policy gap that would have routed the repro through warm-respawn instead of the sessionless guard, and several overclaimed consumer/signal/lifecycle wording issues. All fixed and verified. Audits: `docs/audits/2026-07-13-pr-b-grounded-review-r{1,2,3}.txt` (gitignored, available on request).
- Code-diff review: clean, no actionable findings. `docs/audits/2026-07-13-pr-b-code-diff-review-r1.txt`.
- Full local test suite: 2946 tests green (2940 baseline + 6 new).
- Release build: succeeded.

## Live UAT (dev-only)

Real repro, no fault-injection lever existed for this specific wedge type so one was built from the existing `force_xpc_kill` + PTT primitives (`Tests/RuntimeUAT/faultInjection.py`), per Codex's grounded-review-verified recipe:

1. Set "Unload model after" to "After 5 minutes" (restored to "Never" after).
2. `force_xpc_kill` while idle (drops the resident model).
3. PTT press → cold sessionless warm-up, confirmed armed via `app.log`: `press blocked — engine not ready`, `[WedgeGuard] armed reason=cold_press`.
4. SIGSTOP the freshly-spawned `EnviousWisprASRService` helper (armed via a pre-press watcher thread) so it produces genuine silence, not a typed transport error.
5. Waited past the 120s gate-A deadline. Fired exactly on schedule: `[WedgeGuard] sessionless wedge fired reason=cold_press backend=parakeet ... silence_ms=120023`.
6. Confirmed directly in Sentry (not just `app.log`): the dev event carries the pinned descriptor, `error.identity: modelload.wedge` tag, `environment: development`, and **reused the pre-existing ENVIOUSWISPR-2Q issue (occurrences 5→6, not a new split issue)**.
7. App returned to a clean idle state — heart path unaffected. Model-unload policy and helper process both restored/resumed.

## Test plan

- [x] `scripts/xcode-test.sh` — 2946 tests, 0 failures
- [x] `EnviousWispr-Release` build succeeded
- [x] Codex grounded review — PROCEED-AS-PLANNED (3 rounds)
- [x] Codex diff review — clean
- [x] Live UAT — pinned identity confirmed directly in Sentry, zero re-grouping