### PR TITLE
refactor(services): pin RecoveryReplayError + RecoveryArmError's Sentry identity

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -112,7 +112,7 @@ final class RecoveryCoordinator {
     self.resetEngine = resetEngine
   }
 
-  private enum RecoveryArmError: Error { case keyStoreFailed }
+  enum RecoveryArmError: Error { case keyStoreFailed }
 
   /// Build the recovery directive for a recording about to start, or nil when
   /// recovery is off / could not arm (capture is byte-identical either way).
@@ -378,4 +378,16 @@ final class RecoveryCoordinator {
     activeRecoveryID = nil
     TelemetryService.shared.recoveryCompleted(outcome: "discarded")
   }
+}
+
+// MARK: - Sentry identity
+
+/// Pins the single case's Sentry grouping key to the exact pre-migration
+/// string measured while the nested type remained genuinely `private`
+/// (#1525 PR C), mirroring `HeartPathError`'s shipped pattern. The
+/// pre-migration 90-day Sentry cross-check found no matching issue, so no
+/// live title was available as a second source for this case.
+extension RecoveryCoordinator.RecoveryArmError: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String { "RecoveryArmError#0" }
+  var sentrySemanticID: String { "recovery.arm_key_store_failed" }
 }

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -86,7 +86,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     self.currentVocabulary = currentVocabulary
   }
 
-  private enum RecoveryReplayError: Error {
+  enum RecoveryReplayError: Error {
     case abandonedAfterAttempt
     case failed(String)
   }
@@ -281,5 +281,37 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   private static func lockedLanguage(_ mode: LanguageMode?) -> String? {
     if case .locked(let code) = mode { return code }
     return nil
+  }
+}
+
+// MARK: - Sentry identity
+
+/// Pins each case's Sentry grouping key to its exact pre-migration string
+/// already observed in Sentry (#1525 PR C), mirroring `HeartPathError`'s
+/// shipped pattern.
+///
+/// The descriptors are NOT derived — they were MEASURED with this type still
+/// `private` (widened to `internal` in this same PR, only after measuring —
+/// widening first would have corrupted the baseline, see plan §2.5.4) and
+/// cross-checked against the live Sentry issue titles (ENVIOUSWISPR-2R/1Z/2N/
+/// 2M/20). A `private`-or-narrower type's bridged domain falls back to the
+/// bare simple type name (`SentryBreadcrumb.structuredDescriptor`'s
+/// `(unknown context at ...)` branch — proven by the shipped
+/// `SentryEventSanitizerTests.nestedPrivateErrorDescriptorNormalizes`
+/// fixture), never the module- or class-qualified name — so `internal`
+/// widening never changes what was already shipping.
+extension RecoverySpoolReplayer.RecoveryReplayError: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String {
+    switch self {
+    case .abandonedAfterAttempt: return "RecoveryReplayError#1"
+    case .failed: return "RecoveryReplayError#0"
+    }
+  }
+
+  var sentrySemanticID: String {
+    switch self {
+    case .abandonedAfterAttempt: return "recovery.replay_abandoned_after_attempt"
+    case .failed: return "recovery.replay_failed"
+    }
   }
 }

--- a/Tests/EnviousWisprTests/Services/RecoverySentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Services/RecoverySentryIdentityTests.swift
@@ -1,0 +1,182 @@
+import EnviousWisprCore
+import Foundation
+import Sentry
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprServices
+
+/// #1525 PR C — `RecoverySpoolReplayer.RecoveryReplayError` and
+/// `RecoveryCoordinator.RecoveryArmError`'s Sentry identities are PINNED,
+/// mirroring `HeartPathError`'s shipped pattern (#1524) and
+/// `ModelLoadWatchdog.WedgeError`'s (#1525 PR B,
+/// `ModelLoadWatchdogSentryIdentityTests.swift`).
+///
+/// The three expected descriptor strings are not re-derived here. All were
+/// MEASURED against pre-change shipping code while both types stayed genuinely
+/// `private`; widening happened only after the throwaway probe ran. The two
+/// `RecoveryReplayError` descriptors were also cross-checked against live
+/// Sentry issue titles and per-issue environments (ENVIOUSWISPR-2R/2N
+/// production; ENVIOUSWISPR-1Z/2M/20 development). No `RecoveryArmError`
+/// issue existed, so its measured descriptor had no live-title cross-check.
+/// This suite is the lock — any drift in the shipped identity reddens.
+///
+/// `environment` is passed explicitly throughout: the default reads the
+/// bundle identifier, and a test runner's bundle is not production.
+@Suite("Recovery errors Sentry stable identity (#1525 PR C)")
+struct RecoverySentryIdentityTests {
+
+  private static let env = "production"
+
+  // MARK: - A. Pin lock — RecoveryReplayError
+
+  @Test("RecoveryReplayError keeps the exact production fingerprint per case")
+  func replayPinLock() {
+    let abandoned: RecoverySpoolReplayer.RecoveryReplayError = .abandonedAfterAttempt
+    #expect(SentryBreadcrumb.structuredDescriptor(abandoned) == "RecoveryReplayError#1")
+    #expect(
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .recoveryAbandonedAfterAttempt, error: abandoned, environment: Self.env)
+        == ["handled_error", "recovery_abandoned_after_attempt", "RecoveryReplayError#1", Self.env]
+    )
+
+    // `.failed` carries an associated reason string ("decrypt" / "transcribe" /
+    // "empty" at the real call sites) that never enters the fingerprint — the
+    // category param alone splits these into separate live issues (confirmed:
+    // ENVIOUSWISPR-2N/2M on recovery_decrypt_failed, ENVIOUSWISPR-2R/1Z on
+    // recovery_transcribe_failed, both sharing descriptor #0).
+    for reason in ["decrypt", "transcribe", "empty"] {
+      let failed: RecoverySpoolReplayer.RecoveryReplayError = .failed(reason)
+      #expect(SentryBreadcrumb.structuredDescriptor(failed) == "RecoveryReplayError#0")
+      for category: SentryBreadcrumb.ErrorCategory in [
+        .recoveryDecryptFailed, .recoveryTranscribeFailed,
+      ] {
+        #expect(
+          SentryBreadcrumb.handledErrorFingerprint(
+            for: category, error: failed, environment: Self.env)
+            == ["handled_error", category.rawValue, "RecoveryReplayError#0", Self.env])
+      }
+    }
+  }
+
+  @Test("RecoveryReplayError's two declared identities are unique within the type")
+  func replayIdentityIsUniqueWithinType() {
+    let errors: [RecoverySpoolReplayer.RecoveryReplayError] = [
+      .abandonedAfterAttempt, .failed("decrypt"),
+    ]
+
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == errors.count)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == errors.count)
+  }
+
+  // MARK: - B. Pin lock — RecoveryArmError
+
+  @Test("RecoveryArmError keeps the exact measured fingerprint")
+  func armPinLock() {
+    let error: RecoveryCoordinator.RecoveryArmError = .keyStoreFailed
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "RecoveryArmError#0")
+    #expect(
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .recoveryKeyStoreFailed, error: error, environment: Self.env)
+        == ["handled_error", "recovery_key_store_failed", "RecoveryArmError#0", Self.env])
+  }
+
+  @Test("RecoveryArmError's single declared identity is unique within the type")
+  func armIdentityIsUniqueWithinType() {
+    let errors: [RecoveryCoordinator.RecoveryArmError] = [.keyStoreFailed]
+
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == errors.count)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == errors.count)
+  }
+
+  // MARK: - C. The property that matters
+
+  /// A deterministic `CustomNSError` — its bridged domain/code are declared,
+  /// not inferred from enum layout, so this test asserts the override itself
+  /// and never depends on the compiler behaviour the design escapes.
+  private struct StableFixtureError: Error, CustomNSError, StableSentryErrorIdentity {
+    static let errorDomain = "fixture.raw"
+    var errorCode: Int { 10 }
+    let sentryFingerprintDescriptor = "fixture.pinned#recovery"
+    let sentrySemanticID = "fixture.semantic"
+  }
+
+  @Test("the explicit identity overrides the bridged NSError identity")
+  func explicitIdentityOverridesBridge() {
+    let error = StableFixtureError()
+    let bridged = error as NSError
+
+    #expect(bridged.domain == "fixture.raw")
+    #expect(bridged.code == 10)
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "fixture.pinned#recovery")
+  }
+
+  // MARK: - D. Dev/prod split survives the pin
+
+  @Test("environment keeps the same descriptor's dev and prod fingerprints separate")
+  func devProdSplitSurvives() {
+    let error: RecoverySpoolReplayer.RecoveryReplayError = .abandonedAfterAttempt
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: .recoveryAbandonedAfterAttempt, error: error, environment: "production")
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: .recoveryAbandonedAfterAttempt, error: error, environment: "development")
+
+    #expect(prod != dev)
+    #expect(prod.last == "production")
+    #expect(dev.last == "development")
+  }
+
+  // MARK: - E. Event-construction contract
+
+  @MainActor
+  @Test("a pinned replay error's event carries the production title, fingerprint and identity tag")
+  func pinnedReplayErrorEventShape() {
+    let error: RecoverySpoolReplayer.RecoveryReplayError = .abandonedAfterAttempt
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .recoveryAbandonedAfterAttempt, stage: "recovery", environment: Self.env)
+
+    #expect(event.message?.formatted == "recovery_abandoned_after_attempt: RecoveryReplayError#1")
+    #expect(
+      event.fingerprint
+        == ["handled_error", "recovery_abandoned_after_attempt", "RecoveryReplayError#1", Self.env]
+    )
+    #expect(event.tags?["pipeline.stage"] == "recovery")
+    #expect(event.tags?["error.category"] == "recovery_abandoned_after_attempt")
+    #expect(event.tags?["error.identity"] == "recovery.replay_abandoned_after_attempt")
+  }
+
+  @MainActor
+  @Test("a pinned arm error's event carries the production title, fingerprint and identity tag")
+  func pinnedArmErrorEventShape() {
+    let error: RecoveryCoordinator.RecoveryArmError = .keyStoreFailed
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .recoveryKeyStoreFailed, stage: "recording", environment: Self.env)
+
+    #expect(event.message?.formatted == "recovery_key_store_failed: RecoveryArmError#0")
+    #expect(
+      event.fingerprint
+        == ["handled_error", "recovery_key_store_failed", "RecoveryArmError#0", Self.env])
+    #expect(event.tags?["pipeline.stage"] == "recording")
+    #expect(event.tags?["error.category"] == "recovery_key_store_failed")
+    #expect(event.tags?["error.identity"] == "recovery.arm_key_store_failed")
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -3)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .recoveryDecryptFailed, stage: "recovery", environment: Self.env)
+
+    #expect(event.message?.formatted == "recovery_decrypt_failed: EnviousWispr#-3")
+    #expect(
+      event.fingerprint == [
+        "handled_error", "recovery_decrypt_failed", "EnviousWispr#-3", Self.env,
+      ]
+    )
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SentryEventSanitizerTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryEventSanitizerTests.swift
@@ -39,11 +39,13 @@ private enum FileScopeFixtureError: Error {
   case boom
 }
 
-/// Wrapper exposing a `private`-nested fixture reproducing the shape of
-/// `RecoveryReplayError` / `RecoveryArmError` / `NilCollaboratorError` (all
-/// `private` nested inside their owning type). The real types are `private`
-/// in other modules and unreachable from this test file (#1229) — this
-/// fixture exercises the identical `(unknown context at $ptr)` branch.
+/// Wrapper exposing a `private`-nested fixture that reproduces
+/// `RecoveryReplayError` / `RecoveryArmError`'s pre-#1525-PR-C shape (both
+/// were `private` nested inside their owning type; PR C later widened them
+/// to `internal` so their pins can be tested directly, `RecoverySentryIdentityTests.swift`)
+/// and `NilCollaboratorError`'s current shape (still `private`, unmigrated).
+/// This fixture continues to cover the generic `(unknown context at $ptr)`
+/// normalization branch (#1229).
 private struct NestedFixtureWrapper {
   private enum NestedFixtureError: Error {
     case boom


### PR DESCRIPTION
## Summary
- Part of #1525 (Sentry stable-identity migration, PR C of the ladder). Conforms `RecoverySpoolReplayer.RecoveryReplayError` (2 cases) and `RecoveryCoordinator.RecoveryArmError` (1 case) to `StableSentryErrorIdentity`, pinning their measured pre-migration descriptors (`RecoveryReplayError#0`/`#1`, `RecoveryArmError#0`) exactly as already shipping.
- `RecoveryReplayError` already has 5 live Sentry issue groups (2 production, 3 development) sharing two ordinal-derived descriptors — this closes the same latent re-grouping risk #1524 fixed for `HeartPathError` and PR B fixed for `ModelLoadWatchdog.WedgeError`.
- Both types widen from `private` to `internal` (matching sibling type `RecoveryReplayOutcome` in the same file) so their pins can be directly tested, mirroring `HeartPathError`/`WedgeError`'s shipped test shape. Measurement was done while both types stayed genuinely `private` (a temporary same-file, type-erasing accessor avoided the access-widening-before-measuring trap that would corrupt the baseline), then cross-checked per-issue against live Sentry environments.

## Plan + review
- Plan: `docs/feature-requests/issue-1525-2026-07-13-pr-c-recovery-identity.md`
- Grounded review: 5 rounds to PROCEED-AS-PLANNED (`docs/audits/2026-07-13-pr-c-grounded-review-r{1..5}.txt`) — round 1 caught a wrong Live UAT file path and a wrong "all 5 production" environment claim (actually 2 production + 3 development, verified per-issue via `get_sentry_resource`); rounds 2-4 were small doc-precision fixes.
- Local Codex diff review: clean ("No actionable defects were found").

## Live UAT (dev-only, all 3 confirmed directly in Sentry)
- `RecoveryArmError.keyStoreFailed`: forced the real durable key-store failure via the recovery-key directory. Created its first-ever Sentry issue (ENVIOUSWISPR-3Q), correct descriptor/tags/environment.
- `RecoveryReplayError.abandonedAfterAttempt`: fabricated a genuine orphan spool + attempt marker, relaunched. Reused the pre-existing dev issue ENVIOUSWISPR-20 (2→3 occurrences) — not a split.
- `RecoveryReplayError.failed`: fabricated an orphan spool with no matching key. Reused the pre-existing dev issue ENVIOUSWISPR-2M (3→4 occurrences) — not a split.
- All fabricated files were cleaned up automatically by the app's own recovery logic; all manually-swapped state (recovery-key directory) was restored.

## Test plan
- [x] `scripts/xcode-test.sh` full suite: 2955/2955 green
- [x] Release build (`EnviousWispr-Release`) succeeded
- [x] `scripts/check-dependency-direction.sh` clean
- [x] Local Codex diff review clean
- [x] Live UAT: all 3 cases confirmed in Sentry (zero re-grouping)