### PR TITLE
test(audio): gate DEBUG-only proxy route-shape test under #if DEBUG (Part of #1511)

### DIFF
--- a/Tests/EnviousWisprTests/Audio/AudioCaptureProxyRouteResolutionShapeTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureProxyRouteResolutionShapeTests.swift
@@ -2,33 +2,41 @@ import Testing
 
 @testable import EnviousWisprAudio
 
-// #1533 (r2 finding 1) — the route flip lives in the shared `CaptureRouteResolver`,
-// which has TWO runtime consumers: the helper-side `AudioCaptureManager` (the
-// authoritative source construction) and the app-side `AudioCaptureProxy`
-// (telemetry-only route facts). The helper consumer is covered by
-// `CaptureRouteResolverTests`; this suite locks the SECOND consumer so it cannot
-// silently disappear — the proxy must still own a working resolver and derive a
-// non-nil app-side route through it.
-@MainActor
-@Suite("AudioCaptureProxy route-resolution shape — #1533")
-struct AudioCaptureProxyRouteResolutionShapeTests {
+// GATED #if DEBUG: this suite calls `AudioCaptureProxy.deriveResolvedRouteForTest()`,
+// a `#if DEBUG`-only seam. Release compiles with DEBUG undefined → that member
+// vanishes → an ungated test file fails to COMPILE in the release-config test
+// lane (exit 65, main-post-merge only). ci-pipeline.md TRAP; #1358 → PR #1498.
+#if DEBUG
 
-  @Test("proxy derives an app-side resolved route through its own resolver")
-  func proxyDerivesTelemetryRoute() {
-    let proxy = AudioCaptureProxy()
-    // Before any derivation the proxy reports the unknown placeholder.
-    #expect(proxy.currentAudioRoute == "unknown")
-    #expect(proxy.currentResolvedRoute == nil)
+  // #1533 (r2 finding 1) — the route flip lives in the shared `CaptureRouteResolver`,
+  // which has TWO runtime consumers: the helper-side `AudioCaptureManager` (the
+  // authoritative source construction) and the app-side `AudioCaptureProxy`
+  // (telemetry-only route facts). The helper consumer is covered by
+  // `CaptureRouteResolverTests`; this suite locks the SECOND consumer so it cannot
+  // silently disappear — the proxy must still own a working resolver and derive a
+  // non-nil app-side route through it.
+  @MainActor
+  @Suite("AudioCaptureProxy route-resolution shape — #1533")
+  struct AudioCaptureProxyRouteResolutionShapeTests {
 
-    proxy.deriveResolvedRouteForTest()
+    @Test("proxy derives an app-side resolved route through its own resolver")
+    func proxyDerivesTelemetryRoute() {
+      let proxy = AudioCaptureProxy()
+      // Before any derivation the proxy reports the unknown placeholder.
+      #expect(proxy.currentAudioRoute == "unknown")
+      #expect(proxy.currentResolvedRoute == nil)
 
-    // The resolver ran and produced telemetry regardless of which output device
-    // is live: a real coarse route label and a resolved-route observation.
-    #expect(proxy.currentAudioRoute != "unknown")
-    #expect(proxy.currentResolvedRoute != nil)
-    // Post-cutover the coarse label is always one of the two surviving reasons'
-    // labels — never the deleted engine's `"audio_engine"`.
-    #expect(["built_in_mic", "hal_device_input"].contains(proxy.currentAudioRoute))
-    #expect(proxy.currentResolvedRoute?.routeReason != nil)
+      proxy.deriveResolvedRouteForTest()
+
+      // The resolver ran and produced telemetry regardless of which output device
+      // is live: a real coarse route label and a resolved-route observation.
+      #expect(proxy.currentAudioRoute != "unknown")
+      #expect(proxy.currentResolvedRoute != nil)
+      // Post-cutover the coarse label is always one of the two surviving reasons'
+      // labels — never the deleted engine's `"audio_engine"`.
+      #expect(["built_in_mic", "hal_device_input"].contains(proxy.currentAudioRoute))
+      #expect(proxy.currentResolvedRoute?.routeReason != nil)
+    }
   }
-}
+
+#endif


### PR DESCRIPTION
Hotfix: main went red post-merge of #1536 (exit 65). `AudioCaptureProxyRouteResolutionShapeTests` calls `deriveResolvedRouteForTest()`, a `#if DEBUG`-only seam, but wasn't itself gated — so the **release-config** test lane fails to compile it → 0 tests → guard fails. Invisible on the PR (debug checks pass); only main-post-merge's release lane catches it. Documented ci-pipeline.md TRAP, same class as #1358 → PR #1498.

Fix: gate the suite in `#if DEBUG` (it only exercises a DEBUG seam). **Verified with `scripts/xcode-test.sh --release` locally: 2685 tests, TEST SUCCEEDED** (was 0). Restores main to green.

Council-skip: zero-blast-radius (test-only #if DEBUG gate, 1 file, single-commit revert).