### PR TITLE
ci(workflow): compile Release test targets on the PR gate, not just post-merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 
 ### Build Verification
 - [ ] Dev build passes locally (`scripts/build-dev-app.sh`, Xcode/Tuist engine)
-- [ ] Logic tests pass locally (`scripts/xcode-test.sh`; add `--release` if the PR adds `#if DEBUG`-gated test symbols)
+- [ ] Logic tests pass locally (`scripts/xcode-test.sh`; use `--release` to reproduce a Release-config failure locally)
 - [ ] CI `build-check` status is green
 
 ### Behavioral Testing (Local UAT)

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -191,9 +191,14 @@ jobs:
           fi
           echo "==> Xcode executed $TESTS_RUN tests (debug)"
 
-  # Release lane: Xcode release build + FoundationModels compile probe. Runs in
-  # parallel with build-debug (issue #906). The probe is a standalone macOS-26
-  # SDK compile (~5s). Step-level needs_build gating. (#913 PR3 → Xcode engine.)
+  # Release lane: Xcode release build + Release test-target compile +
+  # FoundationModels compile probe. Runs in parallel with build-debug (issue
+  # #906). The probe is a standalone macOS-26 SDK compile (~5s). The Release
+  # test-target compile (issue #1539) catches a test file that references a
+  # #if DEBUG-only Sources symbol without gating itself — that class compiles
+  # fine in Debug (this lane's sibling `build-debug`) but silently vanishes in
+  # Release, previously surfacing only post-merge in main-post-merge.yml. Step-
+  # level needs_build gating. (#913 PR3 → Xcode engine.)
   build-release:
     runs-on: macos-26
     timeout-minutes: 45
@@ -313,6 +318,43 @@ jobs:
             ARCHS=arm64 \
             ONLY_ACTIVE_ARCH=YES \
             VALID_ARCHS=arm64
+
+      # Compiles (never runs) both Release-config test targets so a test file
+      # that references a #if DEBUG-only Sources symbol without gating itself
+      # fails HERE, on the PR, instead of post-merge in main-post-merge.yml
+      # (issue #1539; recurred twice in 3 days: #1358/#1498, #1536/#1538).
+      # ENABLE_TESTABILITY=YES mirrors main-post-merge.yml's release-test
+      # rationale (Release doesn't enable testability by default); it is NOT
+      # set on the plain `build` step above, so the shippable release artifact
+      # stays non-testable and fully optimized.
+      - name: Build for testing (release, Xcode)
+        id: release-test-build
+        if: steps.changes.outputs.needs_build == 'true'
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          xcodebuild build-for-testing \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_RELEASE_SCHEME" \
+            -configuration Release \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'platform=macOS,arch=arm64' \
+            -resultBundlePath "$GITHUB_WORKSPACE/xcode-build-for-testing-release.xcresult" \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64 \
+            ENABLE_TESTABILITY=YES 2>&1 | tee xcode-build-for-testing-release.log
+
+      - name: Upload release test-build failure evidence
+        if: failure() && steps.release-test-build.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-test-build-failure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            xcode-build-for-testing-release.log
+            xcode-build-for-testing-release.xcresult
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Verify FoundationModels compile probe
         if: steps.changes.outputs.needs_build == 'true'

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -5,11 +5,10 @@ set -euo pipefail
 # (#913 PR7). Canonical replacement for the retired CLT-only `swift-test.sh`
 # (whose header falsely claimed "Xcode is not installed").
 #
-# Mirrors CI exactly: pr-check.yml runs the Debug test lane (the PR `build-check`
-# gate); main-post-merge.yml adds the Release-config lane with
-# ENABLE_TESTABILITY=YES. `--release` runs that second lane locally — required
-# for PRs that add `#if DEBUG`-gated test symbols (the PR gate never compiles
-# tests in release).
+# Mirrors CI: pr-check.yml runs Debug tests and compiles the Release test
+# targets without executing them; main-post-merge.yml additionally runs the
+# Release suite with ENABLE_TESTABILITY=YES. `--release` runs that full
+# Release suite locally for reproduction or stronger pre-push proof.
 #
 # Usage:
 #   scripts/xcode-test.sh                 # Debug lane (matches the PR gate)


### PR DESCRIPTION
## Summary
- The PR `build-check` gate only built the Release app product, never compiling the Release test targets — a test file referencing a `#if DEBUG`-only `Sources/` symbol without gating itself would compile fine in Debug (every PR check green) but fail to compile in Release, and that only surfaced post-merge in `main-post-merge.yml`. Turned main red twice in three days (#1358 → PR #1498, #1536 → PR #1538).
- Adds `xcodebuild build-for-testing` (compile only, never run) to the existing `build-release` job, same scheme/config/`ENABLE_TESTABILITY=YES` `main-post-merge.yml` already proves work, plus a failure-evidence upload step.
- Companion doc updates (`pull_request_template.md`, `scripts/xcode-test.sh` header) demote the local `--release` run from "the only guard" to reproduction/full-suite fallback. Six gitignored `.claude/` knowledge/rule files carrying the same stale premise were also corrected directly in the root checkout (not part of this PR, since `.claude/` is gitignored).

Closes #1539.

## Test plan
- [x] Local negative-path proof with the literal new `xcodebuild build-for-testing` command: fails with the expected `error: value of type 'AudioCaptureProxy' has no member 'deriveResolvedRouteForTest'` against a synthetic ungated `#if DEBUG`-only test reference, then succeeds cleanly (`** TEST BUILD SUCCEEDED **`) once removed.
- [x] Local `codex review --base origin/main`: clean, no blocking defects.
- [ ] This PR's own `build-release` job run is the workflow-evidence-of-execution proof (CI/workflow lane obligation) — verify the new step shows in the Checks tab.
- [ ] Cloud Codex review evaluated before merge.
