### PR TITLE
refactor(services): pin OutputClassifierError's Sentry identity (Part of #1525)

### DIFF
--- a/Sources/EnviousWisprLLM/OutputClassifierManifest.swift
+++ b/Sources/EnviousWisprLLM/OutputClassifierManifest.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 
 /// Canonical constants for the on-device output-safety classifier (#832/#913 PR8).
@@ -103,4 +104,36 @@ public enum OutputClassifierError: Error, Sendable, CustomStringConvertible {
     }
   }
   public var description: String { "OutputClassifier disabled: \(reason.rawValue)" }
+}
+
+// MARK: - Sentry identity
+
+/// Pins the case's Sentry grouping key to the exact string it has been
+/// sending in production, so the identity survives any future add/remove of
+/// a case (#1525 PR D; mirrors `HeartPathError`/`ModelLoadWatchdog.WedgeError`).
+///
+/// The descriptor below is NOT derived — it was MEASURED against shipping
+/// code and cross-checked against the live Sentry issue titles
+/// (`docs/audits/2026-07-14-1525-pr-d-preflight.md`). Only one case exists
+/// today, so the associated `OutputClassifierDisabledReason` never enters
+/// this descriptor — it splits Sentry issues only via `fingerprintDetail`
+/// (the reason's raw value), passed separately at the capture site.
+///
+/// NEVER change this shipped `sentryFingerprintDescriptor`: it would split
+/// this error's 3 existing production Sentry issues in two. A NEW case gets
+/// a fresh unused string, never `#0`. The switch is exhaustive, so a new case
+/// cannot compile until it declares an identity — the same guardrail
+/// `HeartPathError` uses.
+extension OutputClassifierError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    switch self {
+    case .disabled: return "EnviousWisprLLM.OutputClassifierError#0"
+    }
+  }
+
+  public var sentrySemanticID: String {
+    switch self {
+    case .disabled: return "outputclassifier.disabled"
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/LLM/OutputClassifierSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OutputClassifierSentryIdentityTests.swift
@@ -1,0 +1,133 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+@testable import EnviousWisprServices
+
+/// #1525 PR D — `OutputClassifierError`'s Sentry identity is PINNED, mirroring
+/// `HeartPathError`'s shipped pattern (#1524) and `ModelLoadWatchdog.WedgeError`'s
+/// (PR B). One case exists today (`.disabled(reason)`), so there is no
+/// ordinal-reorder risk yet — this pin closes the latent risk before a second
+/// case is ever added.
+///
+/// The expected string is not re-derived here: it was MEASURED against
+/// shipping code and cross-checked against the 3 live Sentry issue titles
+/// (`docs/audits/2026-07-14-1525-pr-d-preflight.md`). This suite is the lock —
+/// any drift in the shipped identity reddens.
+///
+/// `environment` is passed explicitly throughout: the default reads the
+/// bundle identifier, and a test runner's bundle is not production.
+@Suite("OutputClassifierError Sentry stable identity (#1525 PR D)")
+struct OutputClassifierSentryIdentityTests {
+
+  private static let env = "production"
+  private static let descriptor = "EnviousWisprLLM.OutputClassifierError#0"
+  private static let semanticID = "outputclassifier.disabled"
+  private static let category = SentryBreadcrumb.ErrorCategory.outputClassifierLoadFailed
+
+  /// The 8 disablement reasons the type's associated value can carry. All
+  /// must measure to the SAME descriptor (§2.5 premise 1) — only
+  /// `fingerprintDetail` (the reason's raw value) differentiates them.
+  private static let allReasons: [OutputClassifierDisabledReason] = [
+    .contractHashMismatch, .missingFile, .unsupportedFamily, .fixtureSelfTestFailed,
+    .shapeMismatch, .inferenceError, .tokenizerLoadFailed, .modelLoadFailed,
+  ]
+
+  // MARK: - A. Pin lock
+
+  @Test("every disablement reason keeps the exact production fingerprint")
+  func pinLock() {
+    for reason in Self.allReasons {
+      let error = OutputClassifierError.disabled(reason)
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == Self.descriptor)
+      #expect(
+        SentryBreadcrumb.handledErrorFingerprint(
+          for: Self.category, error: error, detail: reason.rawValue, environment: Self.env)
+          == ["handled_error", Self.category.rawValue, Self.descriptor, reason.rawValue, Self.env]
+      )
+    }
+  }
+
+  @Test("the single declared identity is unique within OutputClassifierError")
+  func identityIsUniqueWithinType() {
+    let errors = Self.allReasons.map(OutputClassifierError.disabled)
+
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 1)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 1)
+  }
+
+  // MARK: - B. The property that matters
+
+  /// A deterministic `CustomNSError` — its bridged domain/code are declared,
+  /// not inferred from enum layout, so this test asserts the override itself
+  /// and never depends on the compiler behaviour the design escapes.
+  private struct StableFixtureError: Error, CustomNSError, StableSentryErrorIdentity {
+    static let errorDomain = "fixture.raw"
+    var errorCode: Int { 20 }
+    let sentryFingerprintDescriptor = "fixture.pinned#outputclassifier"
+    let sentrySemanticID = "fixture.semantic"
+  }
+
+  @Test("the explicit identity overrides the bridged NSError identity")
+  func explicitIdentityOverridesBridge() {
+    let error = StableFixtureError()
+    let bridged = error as NSError
+
+    #expect(bridged.domain == "fixture.raw")
+    #expect(bridged.code == 20)
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "fixture.pinned#outputclassifier")
+  }
+
+  // MARK: - C. Dev/prod split survives the pin
+
+  @Test("environment keeps the same descriptor's dev and prod fingerprints separate")
+  func devProdSplitSurvives() {
+    let error = OutputClassifierError.disabled(.missingFile)
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: Self.category, error: error, detail: "missing_file", environment: "production")
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: Self.category, error: error, detail: "missing_file", environment: "development")
+
+    #expect(prod != dev)
+    #expect(prod.last == "production")
+    #expect(dev.last == "development")
+  }
+
+  // MARK: - D. Event-construction contract
+
+  @MainActor
+  @Test("a pinned error's event carries the production title, fingerprint and identity tag")
+  func pinnedErrorEventShape() {
+    let error = OutputClassifierError.disabled(.tokenizerLoadFailed)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "llm", fingerprintDetail: "tokenizer_load_failed",
+      environment: Self.env)
+
+    #expect(event.message?.formatted == "output_classifier_load_failed: \(Self.descriptor)")
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "output_classifier_load_failed", Self.descriptor,
+          "tokenizer_load_failed", Self.env,
+        ])
+    #expect(event.tags?["pipeline.stage"] == "llm")
+    #expect(event.tags?["error.category"] == "output_classifier_load_failed")
+    #expect(event.tags?["error.identity"] == Self.semanticID)
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -3)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "llm", environment: Self.env)
+
+    #expect(
+      event.fingerprint
+        == ["handled_error", "output_classifier_load_failed", "EnviousWispr#-3", Self.env])
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}


### PR DESCRIPTION
## Summary
- Conforms `OutputClassifierError` to `StableSentryErrorIdentity`, pinning its measured production descriptor (`EnviousWisprLLM.OutputClassifierError#0`) exactly as it already ships via an exhaustive switch (mirrors `HeartPathError`'s guardrail — a future second case cannot compile without declaring its own identity).
- Mirrors PR A (#1534), PR B (#1535), PR C (#1537) in the same ladder (docs/sentry-identity-refactor/BIBLE.md).
- No behavior change: same capture site, category, stage, fingerprintDetail. Only new surface is the `error.identity` tag.

## Validation
- Full local suite: 2902/2902 green (incl. 6 new pin-lock/event-shape tests).
- `check-dependency-direction.sh`: clean (14 modules).
- Release build (`EnviousWispr-Release`): succeeded.
- Codex grounded review: 2 rounds, PROCEED-AS-PLANNED (5 findings, all fixed and re-verified — dominant finding was catching a non-exhaustive-switch defect in the first draft).
- Codex local diff review: clean, no actionable defects.
- Live UAT (dev-only): forced a real `missing_file` failure — created the first-ever development Sentry issue (ENVIOUSWISPR-3W) with the pinned descriptor and `error.identity: outputclassifier.disabled` tag; the 3 existing production issues (ENVIOUSWISPR-25/-1M/-2Z) were untouched.

Part of #1525.