### PR TITLE
refactor(services): pin LLMError's Sentry identity (Part of #1525)

### DIFF
--- a/Sources/EnviousWisprLLM/LLMProtocol.swift
+++ b/Sources/EnviousWisprLLM/LLMProtocol.swift
@@ -268,6 +268,65 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
   }
 }
 
+// MARK: - Sentry identity
+
+/// Pins each case's Sentry grouping key to the exact string it has been
+/// sending in production, so the identity survives any future add/remove of
+/// a case (#1525 PR E; mirrors `HeartPathError`/`OutputClassifierError`).
+///
+/// The 13 descriptors below are NOT derived — they were MEASURED against
+/// shipping code (both a throwaway `swift test` and the canonical
+/// `scripts/xcode-test.sh` Xcode-engine run agree) and cross-checked against
+/// live Sentry issue titles (`docs/audits/2026-07-14-1525-pr-e-preflight.md`).
+/// The bridged codes do NOT follow source declaration order — they group by
+/// associated-value payload shape, sequential by declaration order within
+/// each shape group. Live data proves this has already drifted release to
+/// release for `.classified` (`#6` on dist 2.2.1, `#8` on dist 2.3.1) — this
+/// pin freezes it going forward.
+///
+/// NEVER change any of these shipped `sentryFingerprintDescriptor` values:
+/// doing so would split an existing production Sentry issue's history in
+/// two. A NEW case gets a fresh unused number, never a reused one. Both
+/// switches are exhaustive, so a new case cannot compile until it declares
+/// its own identity here.
+extension LLMError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    switch self {
+    case .requestFailed: return "EnviousWisprLLM.LLMError#0"
+    case .modelNotFound: return "EnviousWisprLLM.LLMError#1"
+    case .frameworkUnavailable: return "EnviousWisprLLM.LLMError#2"
+    case .modelNotReady: return "EnviousWisprLLM.LLMError#3"
+    case .unsupportedInputLanguage: return "EnviousWisprLLM.LLMError#4"
+    case .outputLanguageDrift: return "EnviousWisprLLM.LLMError#5"
+    case .egOneSkipped: return "EnviousWisprLLM.LLMError#6"
+    case .localPolishNotReady: return "EnviousWisprLLM.LLMError#7"
+    case .classified: return "EnviousWisprLLM.LLMError#8"
+    case .invalidAPIKey: return "EnviousWisprLLM.LLMError#9"
+    case .rateLimited: return "EnviousWisprLLM.LLMError#10"
+    case .emptyResponse: return "EnviousWisprLLM.LLMError#11"
+    case .providerUnavailable: return "EnviousWisprLLM.LLMError#12"
+    }
+  }
+
+  public var sentrySemanticID: String {
+    switch self {
+    case .requestFailed: return "llm.request_failed"
+    case .modelNotFound: return "llm.model_not_found"
+    case .frameworkUnavailable: return "llm.framework_unavailable"
+    case .modelNotReady: return "llm.model_not_ready"
+    case .unsupportedInputLanguage: return "llm.unsupported_input_language"
+    case .outputLanguageDrift: return "llm.output_language_drift"
+    case .egOneSkipped: return "llm.eg_one_skipped"
+    case .localPolishNotReady: return "llm.local_polish_not_ready"
+    case .classified: return "llm.classified"
+    case .invalidAPIKey: return "llm.invalid_api_key"
+    case .rateLimited: return "llm.rate_limited"
+    case .emptyResponse: return "llm.empty_response"
+    case .providerUnavailable: return "llm.provider_unavailable"
+    }
+  }
+}
+
 /// Why an EG-1 polish was silently bypassed (#1271). Raw values are the
 /// `llm.polish_skipped` telemetry reason strings — one `local_polish_`
 /// prefix so a single analytics query captures every EG-1 skip mode

--- a/Tests/EnviousWisprTests/LLM/LLMErrorSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMErrorSentryIdentityTests.swift
@@ -1,0 +1,159 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+@testable import EnviousWisprServices
+
+/// #1525 PR E — `LLMError`'s Sentry identity is PINNED, mirroring
+/// `HeartPathError`'s shipped pattern (#1524), `ModelLoadWatchdog.WedgeError`'s
+/// (PR B), `RecoveryReplayError`/`RecoveryArmError`'s (PR C), and
+/// `OutputClassifierError`'s (PR D).
+///
+/// The 13 descriptors are not re-derived here: they were MEASURED against
+/// shipping code (both raw `swift test` and the canonical
+/// `scripts/xcode-test.sh` Xcode-engine run agree) and cross-checked against
+/// live Sentry issue titles (`docs/audits/2026-07-14-1525-pr-e-preflight.md`).
+/// This suite is the lock — any drift in the shipped identity reddens.
+///
+/// `environment` is passed explicitly throughout: the default reads the
+/// bundle identifier, and a test runner's bundle is not production.
+@Suite("LLMError Sentry stable identity (#1525 PR E)")
+struct LLMErrorSentryIdentityTests {
+
+  private static let env = "production"
+
+  /// One representative instance per case, paired with its measured
+  /// descriptor number. Associated values are arbitrary — the descriptor is
+  /// a function of case identity alone, never the payload.
+  private static let allCases: [(LLMError, Int)] = [
+    (.requestFailed("x"), 0),
+    (.modelNotFound("x"), 1),
+    (.frameworkUnavailable("x"), 2),
+    (.modelNotReady("x"), 3),
+    (.unsupportedInputLanguage("de"), 4),
+    (.outputLanguageDrift(expected: "de", actual: "en"), 5),
+    (.egOneSkipped(.crashed), 6),
+    (.localPolishNotReady(.providerUnreachable), 7),
+    (.classified(.apiKeyMissing), 8),
+    (.invalidAPIKey, 9),
+    (.rateLimited, 10),
+    (.emptyResponse, 11),
+    (.providerUnavailable, 12),
+  ]
+
+  // MARK: - A. Pin lock
+
+  @Test("every case keeps its exact measured production descriptor")
+  func pinLock() {
+    for (error, ordinal) in Self.allCases {
+      #expect(
+        SentryBreadcrumb.structuredDescriptor(error) == "EnviousWisprLLM.LLMError#\(ordinal)")
+    }
+  }
+
+  @Test("all 13 descriptors and semantic IDs are unique")
+  func identitiesAreUnique() {
+    let errors = Self.allCases.map(\.0)
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 13)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 13)
+  }
+
+  // MARK: - B. The property that matters
+
+  /// A deterministic `CustomNSError` — its bridged domain/code are declared,
+  /// not inferred from enum layout, so this test asserts the override itself
+  /// and never depends on the compiler behaviour the design escapes.
+  private struct StableFixtureError: Error, CustomNSError, StableSentryErrorIdentity {
+    static let errorDomain = "fixture.raw"
+    var errorCode: Int { 20 }
+    let sentryFingerprintDescriptor = "fixture.pinned#llmerror"
+    let sentrySemanticID = "fixture.semantic"
+  }
+
+  @Test("the explicit identity overrides the bridged NSError identity")
+  func explicitIdentityOverridesBridge() {
+    let error = StableFixtureError()
+    let bridged = error as NSError
+
+    #expect(bridged.domain == "fixture.raw")
+    #expect(bridged.code == 20)
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "fixture.pinned#llmerror")
+  }
+
+  // MARK: - C. Dev/prod split survives the pin
+
+  @Test("environment keeps the same descriptor's dev and prod fingerprints separate")
+  func devProdSplitSurvives() {
+    let error = LLMError.classified(.badRequest)
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: .polishProviderFailed, error: error, detail: "bad_request", environment: "production")
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: .polishProviderFailed, error: error, detail: "bad_request", environment: "development")
+
+    #expect(prod != dev)
+    #expect(prod.last == "production")
+    #expect(dev.last == "development")
+  }
+
+  // MARK: - D. Event-construction contract
+
+  @MainActor
+  @Test(
+    "a pinned providerUnavailable event carries the production title, fingerprint, and identity tag"
+  )
+  func providerUnavailableEventShape() {
+    let error = LLMError.providerUnavailable
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .providerInitFailed, stage: "polish", environment: Self.env)
+
+    #expect(event.message?.formatted == "provider_init_failed: EnviousWisprLLM.LLMError#12")
+    #expect(
+      event.fingerprint
+        == ["handled_error", "provider_init_failed", "EnviousWisprLLM.LLMError#12", Self.env])
+    #expect(event.tags?["pipeline.stage"] == "polish")
+    #expect(event.tags?["error.category"] == "provider_init_failed")
+    #expect(event.tags?["error.identity"] == "llm.provider_unavailable")
+  }
+
+  @MainActor
+  @Test("a pinned classified event carries the reason as fingerprintDetail, distinct per reason")
+  func classifiedEventShape() {
+    let error = LLMError.classified(.badRequest)
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .polishProviderFailed, stage: "polish", fingerprintDetail: "bad_request",
+      environment: Self.env)
+
+    #expect(event.message?.formatted == "polish_provider_failed: EnviousWisprLLM.LLMError#8")
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "polish_provider_failed", "EnviousWisprLLM.LLMError#8", "bad_request",
+          Self.env,
+        ])
+    #expect(event.tags?["error.identity"] == "llm.classified")
+
+    // A different reason on the SAME case shares the descriptor but splits
+    // via fingerprintDetail — proves the conformance never collapses #945's
+    // per-reason Sentry issue split.
+    let otherEvent = SentryBreadcrumb.makeHandledErrorEvent(
+      LLMError.classified(.timedOut), category: .polishProviderFailed, stage: "polish",
+      fingerprintDetail: "timed_out", environment: Self.env)
+    #expect(otherEvent.fingerprint != event.fingerprint)
+    #expect(otherEvent.fingerprint?.dropLast(2) == event.fingerprint?.dropLast(2))
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -3)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .polishProviderFailed, stage: "polish", environment: Self.env)
+
+    #expect(
+      event.fingerprint
+        == ["handled_error", "polish_provider_failed", "EnviousWispr#-3", Self.env])
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}


### PR DESCRIPTION
## Summary
- LLMError's 13 cases derive their Sentry grouping identity from the Swift-bridged NSError code (a compiler-assigned ordinal grouped by associated-value payload shape, not declaration order, and NOT a language guarantee).
- Live Sentry data pulled for this PR proves this ordinal has already drifted release to release for `.classified` (computed `LLMError#6` on dist 2.2.1, `LLMError#8` on dist 2.3.1) -- the same case silently splitting its own issue history across two recent shipped releases.
- Conforms `LLMError` to the already-shipped `StableSentryErrorIdentity` protocol with an exhaustive switch pinning each case's measured descriptor, mirroring `HeartPathError` / `ModelLoadWatchdog.WedgeError` / `RecoveryReplayError`+`RecoveryArmError` / `OutputClassifierError` (PRs A-D). Zero behavior change.

## Validation
- Full logic test suite green (2909 tests, Debug lane; 2666 tests, Release lane) via the canonical Xcode-engine `scripts/xcode-test.sh` (both plain and `--release`).
- New suite `LLMErrorSentryIdentityTests.swift`: pin lock (all 13 cases), uniqueness, explicit-override-vs-bridge fixture, dev/prod split, 2 event-construction contracts (providerUnavailable + classified with per-reason fingerprint split), non-conforming-error-unchanged control.
- Grounded review: 3 rounds, `docs/audits/2026-07-14-pr-e-grounded-review-r{1,2,3}.txt` -- PROCEED-AS-PLANNED on r3. All findings were plan-doc precision fixes (producer counts, a historical telemetry-channel-policy resolution, a semantic-ID word-boundary fix); no design defect across any round.
- Local Codex diff review: clean ("no actionable correctness issues").
- Live UAT (dev-only): fired all 3 confirmed-live capture categories via temporary dev-only source injection (reverted before this commit -- diff contains only the conformance + tests):
  - `providerInitFailed` (`.providerUnavailable`): created first-ever dev issue **ENVIOUSWISPR-3X**, `error.identity: llm.provider_unavailable`.
  - `polishProviderFailed` (`.classified(.badRequest)`): reused pre-existing dev issue **ENVIOUSWISPR-2H**, `error.identity: llm.classified`.
  - `generationFailed` (AFM `.emptyResponse`): created first-ever dev issue **ENVIOUSWISPR-3Y**, `error.identity: llm.empty_response`.
  - All 3 events confirmed `environment: development`; the 5 live production `LLMError#8` issues (the real `.classified` traffic) were never touched.

## Test plan
- [x] `scripts/xcode-test.sh` (Debug + `--release`) green
- [x] Codex grounded review PROCEED-AS-PLANNED
- [x] Codex diff review clean
- [x] Live UAT: 3/3 confirmed-live categories fired and verified in dev Sentry
- [ ] Cloud Codex review clean
- [ ] Post-merge: reconfirm the 5 live production `LLMError#8` issues unchanged