### PR TITLE
refactor(services): pin KeyStoreError's Sentry identity (Part of #1525)

### DIFF
--- a/Sources/EnviousWisprLLM/KeychainManager.swift
+++ b/Sources/EnviousWisprLLM/KeychainManager.swift
@@ -428,3 +428,32 @@ package enum KeyStoreError: LocalizedError, Sendable {
     }
   }
 }
+
+extension KeyStoreError: StableSentryErrorIdentity {
+  /// #1525 PR F. Pins each case's exact measured current wire identity
+  /// (`docs/audits/2026-07-14-1525-pr-f-preflight.md` §1) — never re-derive
+  /// from ordinal reasoning. Only `.deleteFailed` (`#2`) is proven to reach
+  /// Sentry today (legacy-key-cleanup path); the other 4 are pinned
+  /// defensively so a future capture site inherits a stable identity
+  /// instead of an ordinal that can silently shift. NEVER change any of
+  /// these strings once shipped.
+  package var sentryFingerprintDescriptor: String {
+    switch self {
+    case .storeFailed: return "EnviousWisprLLM.KeyStoreError#0"
+    case .retrieveFailed: return "EnviousWisprLLM.KeyStoreError#1"
+    case .deleteFailed: return "EnviousWisprLLM.KeyStoreError#2"
+    case .unsupportedKey: return "EnviousWisprLLM.KeyStoreError#3"
+    case .rollbackFailed: return "EnviousWisprLLM.KeyStoreError#4"
+    }
+  }
+
+  package var sentrySemanticID: String {
+    switch self {
+    case .storeFailed: return "keystore.store_failed"
+    case .retrieveFailed: return "keystore.retrieve_failed"
+    case .deleteFailed: return "keystore.delete_failed"
+    case .unsupportedKey: return "keystore.unsupported_key"
+    case .rollbackFailed: return "keystore.rollback_failed"
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/KeyStoreErrorSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/KeyStoreErrorSentryIdentityTests.swift
@@ -1,0 +1,140 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+@testable import EnviousWisprServices
+
+/// #1525 PR F — `KeyStoreError`'s Sentry identity is PINNED, mirroring
+/// `HeartPathError`'s shipped pattern (#1524) and `OutputClassifierError`'s /
+/// `LLMError`'s (PRs D/E). 5 cases exist today; only `.deleteFailed` is
+/// proven to reach Sentry (legacy-key-cleanup path), but the conformance is
+/// exhaustive across all 5 so a future capture site inherits a stable
+/// identity instead of an ordinal that can silently shift.
+///
+/// The expected strings are not re-derived here: they were MEASURED against
+/// shipping code and cross-checked against a fresh 90-day Sentry pull that
+/// found no matching issue (`docs/audits/2026-07-14-1525-pr-f-preflight.md`).
+/// This suite is the lock — any drift in the shipped identity reddens.
+///
+/// `environment` is passed explicitly throughout: the default reads the
+/// bundle identifier, and a test runner's bundle is not production.
+@Suite("KeyStoreError Sentry stable identity (#1525 PR F)")
+struct KeyStoreErrorSentryIdentityTests {
+
+  private static let env = "production"
+  private static let category = SentryBreadcrumb.ErrorCategory.legacyKeyCleanupFailed
+
+  private static let pins: [(KeyStoreError, String, String)] = [
+    (.storeFailed(-1), "EnviousWisprLLM.KeyStoreError#0", "keystore.store_failed"),
+    (.retrieveFailed(-1), "EnviousWisprLLM.KeyStoreError#1", "keystore.retrieve_failed"),
+    (.deleteFailed(-1), "EnviousWisprLLM.KeyStoreError#2", "keystore.delete_failed"),
+    (.unsupportedKey("x"), "EnviousWisprLLM.KeyStoreError#3", "keystore.unsupported_key"),
+    (
+      .rollbackFailed(
+        cleanup: NSError(domain: "fixture.cleanup", code: 1),
+        rollback: NSError(domain: "fixture.rollback", code: 2)),
+      "EnviousWisprLLM.KeyStoreError#4", "keystore.rollback_failed"
+    ),
+  ]
+
+  // MARK: - A. Pin lock
+
+  @Test("every case keeps its exact measured production fingerprint")
+  func pinLock() {
+    for (error, descriptor, semanticID) in Self.pins {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(error.sentrySemanticID == semanticID)
+      #expect(
+        SentryBreadcrumb.handledErrorFingerprint(
+          for: Self.category, error: error, detail: "openai-api-key", environment: Self.env)
+          == ["handled_error", Self.category.rawValue, descriptor, "openai-api-key", Self.env]
+      )
+    }
+  }
+
+  @Test("all 5 declared identities are unique within KeyStoreError")
+  func identitiesAreUnique() {
+    let errors = Self.pins.map(\.0)
+
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 5)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 5)
+  }
+
+  // MARK: - B. The property that matters
+
+  /// A deterministic `CustomNSError` — its bridged domain/code are declared,
+  /// not inferred from enum layout, so this test asserts the override itself
+  /// and never depends on the compiler behaviour the design escapes.
+  private struct StableFixtureError: Error, CustomNSError, StableSentryErrorIdentity {
+    static let errorDomain = "fixture.raw"
+    var errorCode: Int { 20 }
+    let sentryFingerprintDescriptor = "fixture.pinned#keystore"
+    let sentrySemanticID = "fixture.semantic"
+  }
+
+  @Test("the explicit identity overrides the bridged NSError identity")
+  func explicitIdentityOverridesBridge() {
+    let error = StableFixtureError()
+    let bridged = error as NSError
+
+    #expect(bridged.domain == "fixture.raw")
+    #expect(bridged.code == 20)
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "fixture.pinned#keystore")
+  }
+
+  // MARK: - C. Dev/prod split survives the pin
+
+  @Test("environment keeps the same descriptor's dev and prod fingerprints separate")
+  func devProdSplitSurvives() {
+    let error = KeyStoreError.deleteFailed(-1)
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: Self.category, error: error, detail: "openai-api-key", environment: "production")
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: Self.category, error: error, detail: "openai-api-key", environment: "development")
+
+    #expect(prod != dev)
+    #expect(prod.last == "production")
+    #expect(dev.last == "development")
+  }
+
+  // MARK: - D. Event-construction contract
+
+  @MainActor
+  @Test(
+    "the confirmed-live .deleteFailed case's event carries the production title, fingerprint and identity tag"
+  )
+  func deleteFailedEventShape() {
+    let error = KeyStoreError.deleteFailed(-1)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "keychain", fingerprintDetail: "openai-api-key",
+      environment: Self.env)
+
+    #expect(
+      event.message?.formatted == "legacy_key_cleanup_failed: EnviousWisprLLM.KeyStoreError#2")
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "legacy_key_cleanup_failed", "EnviousWisprLLM.KeyStoreError#2",
+          "openai-api-key", Self.env,
+        ])
+    #expect(event.tags?["pipeline.stage"] == "keychain")
+    #expect(event.tags?["error.category"] == "legacy_key_cleanup_failed")
+    #expect(event.tags?["error.identity"] == "keystore.delete_failed")
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -3)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "keychain", environment: Self.env)
+
+    #expect(
+      event.fingerprint
+        == ["handled_error", "legacy_key_cleanup_failed", "EnviousWispr#-3", Self.env])
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}


### PR DESCRIPTION
## Summary
Part of #1525 (Sentry stable-error-identity ladder), PR F of 10.

`KeyStoreError` (5 cases, `Sources/EnviousWisprLLM/KeychainManager.swift:408`) derives its Sentry grouping identity from Swift enum declaration ordinal today — the r1-caught false negative in the ladder's original inventory (it was first miscategorized as "does not reach Sentry"), and a security-relevant path since it covers Keychain cleanup failures. Conforms it to the shipped `StableSentryErrorIdentity` protocol with an exhaustive switch, pinning each case's measured wire string.

Only `.deleteFailed` is proven to reach Sentry today, via the legacy-cleanup path (`LLMTelemetrySink+Live.swift:35`). Fresh 90-day Sentry searches found no matching issue for this type, so pinning it now carries zero re-grouping risk against that window. The other 4 cases are pinned defensively so a future capture site inherits a stable identity instead of an ordinal that can silently shift.

- Grounded review: 6 rounds (`docs/audits/2026-07-14-pr-f-grounded-review-r{1..6}.txt`), PROCEED-AS-PLANNED. Every finding was a precision fix — a real compile blocker (the type is `package`-visibility, so its protocol witnesses must be `package var`, not the bare `var` the first draft used), a Live UAT approach that could not actually fire (dev builds use the `.legacyFiles` backend, never entering the release-only Keychain migration branch), and a safety-critical Live UAT rewrite (the first repro would have deleted the founder's real legacy Gemini credential; fixed to use a disposable, immutable, no-content probe file with a process-level exactly-once latch).
- Local Codex diff review: clean.

## Live UAT (dev-only)
Fired the real `.deleteFailed` producer via a temporary DEBUG-only source injection (fully reverted before this commit — the diff contains only the conformance and its tests), against a disposable immutable probe file (never a real API credential). Confirmed via unified logging (exactly one matching event after opening AI Polish twice, proving the exactly-once latch worked) and a direct Sentry pull:

- Created the type's first-ever Sentry issue **ENVIOUSWISPR-3Z**
- Descriptor: `EnviousWisprLLM.KeyStoreError#2`
- Tag `error.identity: keystore.delete_failed`, category `legacy_key_cleanup_failed`, `environment: development`
- The account extra correctly shows the disposable probe name, never a real credential

## Test plan
- [x] `scripts/xcode-test.sh` — 2915 tests (Debug), 2909 baseline + 6 new, green
- [x] `scripts/xcode-test.sh --release` — 2672 tests, green
- [x] `scripts/check-dependency-direction.sh` — clean across 14 modules
- [x] Local Codex diff review — clean
- [x] Live UAT (dev-only) — confirmed above, first-ever development issue created, zero production issues touched
