### PR TITLE
refactor(services): pin the ASR/XPC error cluster's Sentry identity (Part of #1525)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -11,6 +11,27 @@ public struct ASRLoadSupersededError: Error, Equatable {
   public init() {}
 }
 
+/// #1525 PR G. Pins this struct's exact measured current wire identity
+/// (`docs/audits/2026-07-14-1525-pr-g-preflight.md` §1) — a fixed string,
+/// not a switch (this struct has no stored fields at all). Traced through
+/// every production `warmUp()` caller: no currently reachable Sentry
+/// capture path exists today (sessionless prewarm logs only; the launch/
+/// prewarm classifier routes to non-Sentry telemetry; the session-owned
+/// path's 3 supersession sources — cancelInFlightLoad(), unloadModel(), a
+/// real switchBackend(to:) — are each already absorbed by earlier guards or
+/// structurally deferred). This type represents an EXPECTED supersede
+/// outcome, not necessarily a real failure, and it is pinned defensively so
+/// a future capture site or topology change inherits a stable identity
+/// rather than a runtime-assigned constant. NEVER change this string once
+/// shipped.
+extension ASRLoadSupersededError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    "EnviousWisprASR.ASRLoadSupersededError#1"
+  }
+
+  public var sentrySemanticID: String { "asr.load_superseded" }
+}
+
 // #1388: `ASRLoadCancelledError` (the deliberate-cancel resume for
 // `cancelInFlightLoad()`) lives in EnviousWisprCore beside
 // `ModelLoadWatchdog.WedgeError` — the pipeline driver classifies on it and

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -858,3 +858,22 @@ package enum XPCASRTransportError: LocalizedError {
     }
   }
 }
+
+/// #1525 PR G. Pins the single case's exact measured current wire identity
+/// (`docs/audits/2026-07-14-1525-pr-g-preflight.md` §1). `package` matches
+/// this type's own package visibility (mirrors `KeyStoreError`'s PR-F
+/// pattern — a bare `var` would default to `internal` and fail to compile
+/// against a `package` enclosing type). NEVER change this string once shipped.
+extension XPCASRTransportError: StableSentryErrorIdentity {
+  package var sentryFingerprintDescriptor: String {
+    switch self {
+    case .serviceUnreachable: return "EnviousWisprASR.XPCASRTransportError#0"
+    }
+  }
+
+  package var sentrySemanticID: String {
+    switch self {
+    case .serviceUnreachable: return "xpc.asr_service_unreachable"
+    }
+  }
+}

--- a/Sources/EnviousWisprASR/ASRProtocol.swift
+++ b/Sources/EnviousWisprASR/ASRProtocol.swift
@@ -89,3 +89,30 @@ enum ASRError: LocalizedError, Sendable {
     }
   }
 }
+
+/// #1525 PR G. Pins each case's exact measured current wire identity
+/// (`docs/audits/2026-07-14-1525-pr-g-preflight.md` §1) — never re-derive.
+/// `.transcriptionFailed` measured as `#0` despite being declared fourth.
+/// Treat that as observed wire behavior, not a rule to re-derive from
+/// payload shape or declaration order. `internal` (bare `var`) matches this
+/// type's own internal visibility. NEVER change any of these strings once
+/// shipped.
+extension ASRError: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String {
+    switch self {
+    case .notReady: return "EnviousWisprASR.ASRError#1"
+    case .streamingNotSupported: return "EnviousWisprASR.ASRError#2"
+    case .streamingTimeout: return "EnviousWisprASR.ASRError#3"
+    case .transcriptionFailed: return "EnviousWisprASR.ASRError#0"
+    }
+  }
+
+  var sentrySemanticID: String {
+    switch self {
+    case .notReady: return "asr.not_ready"
+    case .streamingNotSupported: return "asr.streaming_not_supported"
+    case .streamingTimeout: return "asr.streaming_timeout"
+    case .transcriptionFailed: return "asr.transcription_failed"
+    }
+  }
+}

--- a/Sources/EnviousWisprCore/XPCOperationSignalFile.swift
+++ b/Sources/EnviousWisprCore/XPCOperationSignalFile.swift
@@ -164,3 +164,24 @@ public struct XPCOperationSignalWedgeError: LocalizedError, Sendable {
     "\(service) XPC operation wedged during \(stage) after signal phase \(observedPhase)"
   }
 }
+
+/// #1525 PR G. Pins this struct's exact measured current wire identity
+/// (`docs/audits/2026-07-14-1525-pr-g-preflight.md` §1). A plain
+/// non-switching property matches this one-shape struct and the shipped
+/// `ModelLoadWatchdog.WedgeError` pattern. Its stored diagnostic fields
+/// (`service`/`stage`/`observedPhase`) do not enter the descriptor. This
+/// descriptor has 2 live production issues riding on it (ENVIOUSWISPR-22,
+/// ENVIOUSWISPR-1B, 3 users total) from a producer
+/// (`AudioCaptureProxy.swift`) deleted the same day this PR was drafted
+/// (`f1b2a331`, #1546) — the surviving ASR-side throw site
+/// (`ASRManagerProxy.swift:660`) reaches only a breadcrumb today, not a
+/// Sentry issue, so this pin preserves dormant history against bridging
+/// changes rather than protecting an active path. NEVER change this string
+/// once shipped.
+extension XPCOperationSignalWedgeError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    "EnviousWisprCore.XPCOperationSignalWedgeError#1"
+  }
+
+  public var sentrySemanticID: String { "xpc.operation_signal_wedge" }
+}

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -111,6 +111,36 @@ public enum ASREngineError: Error, Sendable {
   case wedged
 }
 
+/// #1525 PR G. Pins each case's exact measured current wire identity
+/// (`docs/audits/2026-07-14-1525-pr-g-preflight.md` §1) — plain declaration
+/// order, no payload-shape anomaly (all 4 cases carry no associated value).
+/// `.wedged` has a kernel capture route (`RecordingSessionKernel`'s
+/// finalize cadence-stall detector) but it cannot arm against either real
+/// production adapter today — both `ParakeetEngineAdapter` and
+/// `WhisperKitEngineAdapter` return `nil` for `finalizeProgress`, the signal
+/// the detector requires (only the test-only `FakeEngine` exposes it). All
+/// 4 cases are pinned defensively. `public` matches this type's own public
+/// visibility. NEVER change any of these strings once shipped.
+extension ASREngineError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    switch self {
+    case .loadFailed: return "EnviousWisprPipeline.ASREngineError#0"
+    case .decodeFailed: return "EnviousWisprPipeline.ASREngineError#1"
+    case .engineCrashed: return "EnviousWisprPipeline.ASREngineError#2"
+    case .wedged: return "EnviousWisprPipeline.ASREngineError#3"
+    }
+  }
+
+  public var sentrySemanticID: String {
+    switch self {
+    case .loadFailed: return "asrengine.load_failed"
+    case .decodeFailed: return "asrengine.decode_failed"
+    case .engineCrashed: return "asrengine.engine_crashed"
+    case .wedged: return "asrengine.wedged"
+    }
+  }
+}
+
 /// The normalized outcome of one `finalize()` call (PR-1 §B.2.1). The kernel
 /// consumes exactly one of these per session and never sees an engine-specific
 /// result type.

--- a/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
@@ -15,6 +15,20 @@ public struct ParakeetDeliveryError: Error, Equatable {
   }
 }
 
+/// #1525 PR G. Pins this struct's exact measured current wire identity
+/// (`docs/audits/2026-07-14-1525-pr-g-preflight.md` §1) — a fixed string,
+/// not a switch, confirmed empirically constant across all 10
+/// `DeliveryFailureClass` reasons. Reaches Sentry via the model-load-failed
+/// path when Parakeet delivery cannot be ensured available. NEVER change
+/// this string once shipped.
+extension ParakeetDeliveryError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    "EnviousWisprPipeline.ParakeetDeliveryError#1"
+  }
+
+  public var sentrySemanticID: String { "parakeet.delivery_failed" }
+}
+
 /// Pipeline-side handle for the Parakeet delivery stage (#1348 Phase 2): the
 /// one object the adapter talks to. Owns the flag read (one authority for
 /// "is delivery on"), the ProgressFile bridge for the DOWNLOAD phase (the

--- a/Tests/EnviousWisprTests/ASR/ASRClusterSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ASRClusterSentryIdentityTests.swift
@@ -1,0 +1,149 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprServices
+
+/// #1525 PR G — `ASRError`, `XPCASRTransportError`, and `ASRLoadSupersededError`'s
+/// Sentry identities are PINNED, mirroring `KeyStoreError`'s shipped pattern (PR F).
+///
+/// `ASRError.transcriptionFailed` measured as `#0` despite being declared fourth —
+/// an observed anomaly, not a rule to re-derive. `XPCASRTransportError` and
+/// `ASRLoadSupersededError` are pinned defensively (preflight §3: plausible but
+/// unproven, and no currently reachable capture path, respectively).
+///
+/// The expected strings are not re-derived here: they were MEASURED against
+/// shipping code (`docs/audits/2026-07-14-1525-pr-g-preflight.md`). This suite is
+/// the lock — any drift in the shipped identity reddens.
+///
+/// `environment` is passed explicitly throughout: the default reads the bundle
+/// identifier, and a test runner's bundle is not production.
+@Suite(
+  "ASRError / XPCASRTransportError / ASRLoadSupersededError Sentry stable identity (#1525 PR G)")
+struct ASRClusterSentryIdentityTests {
+
+  private static let env = "production"
+  private static let category = SentryBreadcrumb.ErrorCategory.asrFailed
+
+  private static let asrErrorPins: [(ASRError, String, String)] = [
+    (.notReady, "EnviousWisprASR.ASRError#1", "asr.not_ready"),
+    (.streamingNotSupported, "EnviousWisprASR.ASRError#2", "asr.streaming_not_supported"),
+    (.streamingTimeout, "EnviousWisprASR.ASRError#3", "asr.streaming_timeout"),
+    (.transcriptionFailed("x"), "EnviousWisprASR.ASRError#0", "asr.transcription_failed"),
+  ]
+
+  // MARK: - A. Pin lock — ASRError
+
+  @Test("every ASRError case keeps its exact measured production fingerprint")
+  func asrErrorPinLock() {
+    for (error, descriptor, semanticID) in Self.asrErrorPins {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(error.sentrySemanticID == semanticID)
+      #expect(
+        SentryBreadcrumb.handledErrorFingerprint(
+          for: Self.category, error: error, environment: Self.env)
+          == ["handled_error", Self.category.rawValue, descriptor, Self.env]
+      )
+    }
+  }
+
+  @Test("all 4 declared ASRError identities are unique")
+  func asrErrorIdentitiesAreUnique() {
+    let errors = Self.asrErrorPins.map(\.0)
+
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 4)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 4)
+  }
+
+  // MARK: - B. Pin lock — XPCASRTransportError, ASRLoadSupersededError
+
+  @Test("XPCASRTransportError.serviceUnreachable keeps its exact measured fingerprint")
+  func xpcasrTransportErrorPinLock() {
+    let error = XPCASRTransportError.serviceUnreachable
+
+    #expect(
+      SentryBreadcrumb.structuredDescriptor(error) == "EnviousWisprASR.XPCASRTransportError#0")
+    #expect(error.sentrySemanticID == "xpc.asr_service_unreachable")
+  }
+
+  @Test("ASRLoadSupersededError keeps its exact measured fingerprint")
+  func asrLoadSupersededErrorPinLock() {
+    let error = ASRLoadSupersededError()
+
+    #expect(
+      SentryBreadcrumb.structuredDescriptor(error) == "EnviousWisprASR.ASRLoadSupersededError#1")
+    #expect(error.sentrySemanticID == "asr.load_superseded")
+  }
+
+  // MARK: - C. The property that matters
+
+  /// A deterministic `CustomNSError` — its bridged domain/code are declared,
+  /// not inferred from enum layout, so this test asserts the override itself
+  /// and never depends on the compiler behaviour the design escapes.
+  private struct StableFixtureError: Error, CustomNSError, StableSentryErrorIdentity {
+    static let errorDomain = "fixture.raw"
+    var errorCode: Int { 30 }
+    let sentryFingerprintDescriptor = "fixture.pinned#asr"
+    let sentrySemanticID = "fixture.semantic"
+  }
+
+  @Test("the explicit identity overrides the bridged NSError identity")
+  func explicitIdentityOverridesBridge() {
+    let error = StableFixtureError()
+    let bridged = error as NSError
+
+    #expect(bridged.domain == "fixture.raw")
+    #expect(bridged.code == 30)
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "fixture.pinned#asr")
+  }
+
+  // MARK: - D. Dev/prod split survives the pin
+
+  @Test("environment keeps the same descriptor's dev and prod fingerprints separate")
+  func devProdSplitSurvives() {
+    let error = ASRError.transcriptionFailed("x")
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: Self.category, error: error, environment: "production")
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: Self.category, error: error, environment: "development")
+
+    #expect(prod != dev)
+    #expect(prod.last == "production")
+    #expect(dev.last == "development")
+  }
+
+  // MARK: - E. Event-construction contract
+
+  @MainActor
+  @Test(
+    "the confirmed-reachable .transcriptionFailed case's event carries the production title, fingerprint and identity tag"
+  )
+  func transcriptionFailedEventShape() {
+    let error = ASRError.transcriptionFailed("x")
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "transcription", environment: Self.env)
+
+    #expect(event.message?.formatted == "asr_failed: EnviousWisprASR.ASRError#0")
+    #expect(
+      event.fingerprint
+        == ["handled_error", "asr_failed", "EnviousWisprASR.ASRError#0", Self.env])
+    #expect(event.tags?["pipeline.stage"] == "transcription")
+    #expect(event.tags?["error.category"] == "asr_failed")
+    #expect(event.tags?["error.identity"] == "asr.transcription_failed")
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -3)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "transcription", environment: Self.env)
+
+    #expect(
+      event.fingerprint == ["handled_error", "asr_failed", "EnviousWispr#-3", Self.env])
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/ASREngineClusterSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ASREngineClusterSentryIdentityTests.swift
@@ -1,0 +1,194 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprModelDelivery
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprServices
+
+/// #1525 PR G — `ASREngineError`, `XPCOperationSignalWedgeError`, and
+/// `ParakeetDeliveryError`'s Sentry identities are PINNED, mirroring
+/// `ModelLoadWatchdog.WedgeError`'s shipped pattern (PR B) for the two structs.
+///
+/// `ASREngineError` measures to plain declaration order (`#0`-`#3`) — but none of
+/// its 4 cases is currently reachable against a real production adapter today
+/// (preflight §3: `.decodeFailed` is superseded before capture, `.wedged` cannot
+/// arm against either real adapter, `.loadFailed`/`.engineCrashed` have no
+/// producer). `XPCOperationSignalWedgeError` measures as `#1` and carries 2 real
+/// production issues (ENVIOUSWISPR-22, ENVIOUSWISPR-1B) from a producer deleted
+/// this morning — this suite's pin lock asserts the EXACT string that matches
+/// those issues verbatim. `ParakeetDeliveryError` measures as `#1`, confirmed
+/// constant across all 10 `DeliveryFailureClass` reasons, and is a confirmed
+/// current capture route.
+///
+/// The expected strings are not re-derived here: they were MEASURED against
+/// shipping code (`docs/audits/2026-07-14-1525-pr-g-preflight.md`). This suite is
+/// the lock — any drift in the shipped identity reddens.
+@Suite(
+  "ASREngineError / XPCOperationSignalWedgeError / ParakeetDeliveryError Sentry stable identity (#1525 PR G)"
+)
+struct ASREngineClusterSentryIdentityTests {
+
+  private static let env = "production"
+  private static let asrCategory = SentryBreadcrumb.ErrorCategory.asrFailed
+  private static let audioCategory = SentryBreadcrumb.ErrorCategory.audioCaptureFailed
+  private static let modelLoadCategory = SentryBreadcrumb.ErrorCategory.modelLoadFailed
+
+  private static let asrEnginePins: [(ASREngineError, String, String)] = [
+    (.loadFailed, "EnviousWisprPipeline.ASREngineError#0", "asrengine.load_failed"),
+    (.decodeFailed, "EnviousWisprPipeline.ASREngineError#1", "asrengine.decode_failed"),
+    (.engineCrashed, "EnviousWisprPipeline.ASREngineError#2", "asrengine.engine_crashed"),
+    (.wedged, "EnviousWisprPipeline.ASREngineError#3", "asrengine.wedged"),
+  ]
+
+  // MARK: - A. Pin lock — ASREngineError
+
+  @Test("every ASREngineError case keeps its exact measured production fingerprint")
+  func asrEnginePinLock() {
+    for (error, descriptor, semanticID) in Self.asrEnginePins {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(error.sentrySemanticID == semanticID)
+      #expect(
+        SentryBreadcrumb.handledErrorFingerprint(
+          for: Self.asrCategory, error: error, environment: Self.env)
+          == ["handled_error", Self.asrCategory.rawValue, descriptor, Self.env]
+      )
+    }
+  }
+
+  @Test("all 4 declared ASREngineError identities are unique")
+  func asrEngineIdentitiesAreUnique() {
+    let errors = Self.asrEnginePins.map(\.0)
+
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 4)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 4)
+  }
+
+  // MARK: - B. Pin lock — XPCOperationSignalWedgeError, ParakeetDeliveryError
+
+  @Test("XPCOperationSignalWedgeError keeps the exact string matching its 2 live production issues")
+  func xpcOperationSignalWedgeErrorPinLock() {
+    let error = XPCOperationSignalWedgeError(
+      service: "ASR", stage: "start_streaming", observedPhase: "loading")
+
+    #expect(
+      SentryBreadcrumb.structuredDescriptor(error)
+        == "EnviousWisprCore.XPCOperationSignalWedgeError#1")
+    #expect(error.sentrySemanticID == "xpc.operation_signal_wedge")
+  }
+
+  @Test("ParakeetDeliveryError keeps the same descriptor across every DeliveryFailureClass reason")
+  func parakeetDeliveryErrorPinLock() {
+    let reasons: [DeliveryFailureClass] = [
+      .sourceUnreachable, .sourceTimeout, .source5xx, .source4xx, .integrityMismatch,
+      .insufficientDisk, .permissionDenied, .cacheRepairFailed, .cancelled, .unknown,
+    ]
+
+    for reason in reasons {
+      let error = ParakeetDeliveryError(DeliveryFailure(reason: reason))
+      #expect(
+        SentryBreadcrumb.structuredDescriptor(error)
+          == "EnviousWisprPipeline.ParakeetDeliveryError#1")
+      #expect(error.sentrySemanticID == "parakeet.delivery_failed")
+    }
+  }
+
+  // MARK: - C. The property that matters
+
+  /// A deterministic `CustomNSError` — its bridged domain/code are declared,
+  /// not inferred from enum layout, so this test asserts the override itself
+  /// and never depends on the compiler behaviour the design escapes.
+  private struct StableFixtureError: Error, CustomNSError, StableSentryErrorIdentity {
+    static let errorDomain = "fixture.raw"
+    var errorCode: Int { 40 }
+    let sentryFingerprintDescriptor = "fixture.pinned#asrengine"
+    let sentrySemanticID = "fixture.semantic"
+  }
+
+  @Test("the explicit identity overrides the bridged NSError identity")
+  func explicitIdentityOverridesBridge() {
+    let error = StableFixtureError()
+    let bridged = error as NSError
+
+    #expect(bridged.domain == "fixture.raw")
+    #expect(bridged.code == 40)
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "fixture.pinned#asrengine")
+  }
+
+  // MARK: - D. Dev/prod split survives the pin
+
+  @Test("environment keeps the same descriptor's dev and prod fingerprints separate")
+  func devProdSplitSurvives() {
+    let error = ParakeetDeliveryError(DeliveryFailure(reason: .sourceUnreachable))
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: Self.modelLoadCategory, error: error, environment: "production")
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: Self.modelLoadCategory, error: error, environment: "development")
+
+    #expect(prod != dev)
+    #expect(prod.last == "production")
+    #expect(dev.last == "development")
+  }
+
+  // MARK: - E. Event-construction contract
+
+  @MainActor
+  @Test(
+    "the confirmed-reachable ParakeetDeliveryError event carries the production title, fingerprint and identity tag"
+  )
+  func parakeetDeliveryErrorEventShape() {
+    let error = ParakeetDeliveryError(DeliveryFailure(reason: .sourceUnreachable))
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.modelLoadCategory, stage: "asr", environment: Self.env)
+
+    #expect(
+      event.message?.formatted == "model_load_failed: EnviousWisprPipeline.ParakeetDeliveryError#1"
+    )
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "model_load_failed", "EnviousWisprPipeline.ParakeetDeliveryError#1",
+          Self.env,
+        ])
+    #expect(event.tags?["pipeline.stage"] == "asr")
+    #expect(event.tags?["error.category"] == "model_load_failed")
+    #expect(event.tags?["error.identity"] == "parakeet.delivery_failed")
+  }
+
+  @MainActor
+  @Test(
+    "the historical-live XPCOperationSignalWedgeError event carries the exact string matching ENVIOUSWISPR-22/-1B"
+  )
+  func xpcOperationSignalWedgeErrorEventShape() {
+    let error = XPCOperationSignalWedgeError(
+      service: "Audio", stage: "stop_capture", observedPhase: "draining")
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.audioCategory, stage: "audio", environment: "development")
+
+    #expect(
+      event.message?.formatted
+        == "audio_capture_failed: EnviousWisprCore.XPCOperationSignalWedgeError#1")
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "audio_capture_failed",
+          "EnviousWisprCore.XPCOperationSignalWedgeError#1", "development",
+        ])
+    #expect(event.tags?["error.identity"] == "xpc.operation_signal_wedge")
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -3)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.modelLoadCategory, stage: "asr", environment: Self.env)
+
+    #expect(
+      event.fingerprint == ["handled_error", "model_load_failed", "EnviousWispr#-3", Self.env])
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}


### PR DESCRIPTION
## Summary

Part of #1525 (Sentry stable-identity ladder, PR G of 10). Conforms six ASR/XPC-transport error types — `ASRError`, `ASREngineError`, `XPCASRTransportError`, `XPCOperationSignalWedgeError`, `ParakeetDeliveryError`, `ASRLoadSupersededError` — to `StableSentryErrorIdentity`, pinning each measured wire descriptor instead of letting it derive from Swift's bridged `NSError` code.

- `ASRError` repeats the payload-shape-grouping anomaly first seen in `LLMError` (PR E): `.transcriptionFailed` measures as `#0` despite being declared fourth.
- `XPCOperationSignalWedgeError` carries real production weight: 2 live issues (3 users) from a producer deleted by this morning's audio-capture-in-process collapse (`f1b2a331`, #1546). The pin preserves that history against future bridging changes even though no code path can generate a new event today.
- `XPCTransportError` (originally in scope per the epic doc) is confirmed out of scope — its only declaring file was deleted by the same commit.

Grounded review ran 4 rounds to PROCEED-AS-PLANNED (`docs/audits/2026-07-14-pr-g-grounded-review-r{1,2,3,4}.txt`). Round 1 corrected two material errors in the original draft: `ASREngineError.wedged` is not reachable against either real production adapter today (both return `nil` for the finalize-progress signal the kernel's wedge detector requires), and `ASRLoadSupersededError`'s reachability, first presented as ambiguous, resolved to "no currently reachable Sentry capture path" after tracing every production `warmUp()` caller and all three supersession sources.

Live UAT (dev-only, reverted before commit): a temporary fault injection forced `ASRError.transcriptionFailed` on its confirmed-reachable batch-decode path. Created the type's first-ever Sentry issue (`ENVIOUSWISPR-40`), descriptor `EnviousWisprASR.ASRError#0`, tag `error.identity: asr.transcription_failed`, category `asr_failed`, `environment: development`.

## Test plan

- [x] `scripts/xcode-test.sh` (Debug, 2932 tests) and `--release` (2689 tests) — full suite green, 17 new tests.
- [x] `scripts/check-dependency-direction.sh` — clean across 14 modules.
- [x] Live UAT: fault-injected `ASRError.transcriptionFailed`, confirmed in Sentry (`ENVIOUSWISPR-40`).
- [x] Local `codex review` — clean, no actionable findings.
- [ ] Cloud Codex review.
