### PR TITLE
fix(audio): retire a dead microphone source on a zero-signal take (Part of #1511) (Part of #1520)

### DIFF
--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -114,6 +114,14 @@ public protocol AudioCaptureInterface: AnyObject {
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer>  // periphery:ignore - convenience method combining engine + capture phases
   func stopCapture() async -> CaptureResult
   func rebuildEngine()
+  /// Retire (tear down) the source that captured the session identified by
+  /// `sessionID`, so the next press opens a fresh one. Fenced + idempotent: a
+  /// no-op unless `sessionID` is still the current capture session AND the
+  /// retained source that captured it is still the running active source
+  /// (#1520 / heartpath 5b — a completed zero-signal take must not hand a dead
+  /// Bluetooth link to later takes, and a stale finish must never tear down a
+  /// newer take's source).
+  func retireCapturingSource(sessionID: UInt64)
   func preWarm() async throws
   func abortPreWarm()
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -121,7 +121,8 @@ public protocol AudioCaptureInterface: AnyObject {
   /// (#1520 / heartpath 5b — a completed zero-signal take must not hand a dead
   /// Bluetooth link to later takes, and a stale finish must never tear down a
   /// newer take's source).
-  func retireCapturingSource(sessionID: UInt64)
+  @discardableResult
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult
   func preWarm() async throws
   func abortPreWarm()
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
@@ -155,4 +156,19 @@ extension AudioCaptureInterface {
   /// latch. `AudioCaptureManager` overrides it with its own session-scoped
   /// latch (ported in-process at #1543).
   public var zeroSignalDiscriminatorSawIneligible: Bool { false }
+}
+
+/// Heartpath 5b (#1520): the observational outcome of `retireCapturingSource`.
+/// Only `.retired` means a source was actually torn down; the other five are
+/// fenced no-ops (the take was still zero-signal, but the retained source was
+/// no longer the running active source to retire). The kernel emits this as the
+/// `retire_action` telemetry property and arms the recovery watch ONLY on
+/// `.retired`, so a no-op is never credited with a later recovery.
+public enum ZeroSignalRetireResult: String, Sendable, Equatable {
+  case retired
+  case staleSession = "stale_session"
+  case capturedSourceGone = "captured_source_gone"
+  case activeSourceGone = "active_source_gone"
+  case sourceReplaced = "source_replaced"
+  case sourceNotRunning = "source_not_running"
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -560,30 +560,32 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// stale finish from an older take can never tear down a newer take's source.
   /// Whether the take was silent is decided by the kernel; this method is
   /// device-blame-free.
-  public func retireCapturingSource(sessionID: UInt64) {
+  @discardableResult
+  public func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult {
     guard sessionID == captureSessionCounter else {
       Self.btRouteLog("Zero-signal retire skipped: stale capture session")
-      return
+      return .staleSession
     }
     guard let capturedSource = captureSessionSource else {
       Self.btRouteLog("Zero-signal retire skipped: captured source already gone")
-      return
+      return .capturedSourceGone
     }
     defer { clearCaptureSessionSource(ifMatching: capturedSource) }
     guard let source = activeSource else {
       Self.btRouteLog("Zero-signal retire skipped: active source already gone")
-      return
+      return .activeSourceGone
     }
     guard source === capturedSource else {
       Self.btRouteLog("Zero-signal retire skipped: source was replaced")
-      return
+      return .sourceReplaced
     }
     guard source.isRunning else {
       Self.btRouteLog("Zero-signal retire skipped: source already torn down")
-      return
+      return .sourceNotRunning
     }
     rebuildActiveSource(source)
     Self.btRouteLog("Zero-signal source retired")
+    return .retired
   }
 
   /// The single destructive teardown of the active source, shared by
@@ -620,6 +622,14 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       captureSessionSource = captured
       activeSource = active ?? captured
       captureSessionCounter = sessionID
+    }
+
+    /// Test seam (heartpath 5b): drop the live active source while KEEPING the
+    /// retained capture-session source, so `retireCapturingSource` reaches the
+    /// `.activeSourceGone` branch. The installer's optional `active` argument
+    /// treats nil as "use captured" and cannot construct this state directly.
+    func clearActiveSourceForTesting() {
+      activeSource = nil
     }
   #endif
 

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -156,6 +156,14 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// Always a HALDeviceInputSource — the sole capture backend.
   private var activeSource: (any AudioInputSource)?
 
+  /// Heartpath 5b (#1520): the source object that captured the current session,
+  /// RETAINED (not `ObjectIdentifier` — an address token can alias a freshly
+  /// allocated source after the captured one deallocates). Compared by `===` in
+  /// `retireCapturingSource` so a stale finish can only retire the exact source it
+  /// captured, never a newer take's source. Cleared the moment that source is torn
+  /// down or replaced, so no torn-down source is retained past its lifetime.
+  private var captureSessionSource: (any AudioInputSource)?
+
   #if DEBUG
     /// #1317 proof-bench: the single DEBUG-only all-zero injector, handed to every
     /// source on install so it can substitute digital silence at the forwarder.
@@ -422,6 +430,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // App-lifetime session id (#1543): one increment per live capture session,
     // read by the dead-air ctx, correlation extras, dedup, and the stall filter.
     captureSessionCounter &+= 1
+    captureSessionSource = source  // heartpath 5b: retain the object that owns this session
     captureStartUptimeNs = DispatchTime.now().uptimeNanoseconds
     // Crash-recovery limb: arm the spool from the directive AFTER capture is
     // live (the feed loop guards on `isCapturing`). Fail-open — never throws,
@@ -540,14 +549,79 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   }
 
   public func rebuildEngine() {
-    // Only a real rebuild advances the incarnation: with no active source nothing
-    // is destroyed, so a bump here would falsely satisfy `fresh_pipe_proven`.
     guard let source = activeSource else { return }
+    rebuildActiveSource(source)
+  }
+
+  /// Heartpath 5b (#1520): retire the source that captured `sessionID` so the next
+  /// press opens a fresh one (re-establishing a dead Bluetooth link). Fenced three
+  /// ways and idempotent — a no-op unless this is still the current capture session
+  /// AND the retained captured source is still the running active source, so a
+  /// stale finish from an older take can never tear down a newer take's source.
+  /// Whether the take was silent is decided by the kernel; this method is
+  /// device-blame-free.
+  public func retireCapturingSource(sessionID: UInt64) {
+    guard sessionID == captureSessionCounter else {
+      Self.btRouteLog("Zero-signal retire skipped: stale capture session")
+      return
+    }
+    guard let capturedSource = captureSessionSource else {
+      Self.btRouteLog("Zero-signal retire skipped: captured source already gone")
+      return
+    }
+    defer { clearCaptureSessionSource(ifMatching: capturedSource) }
+    guard let source = activeSource else {
+      Self.btRouteLog("Zero-signal retire skipped: active source already gone")
+      return
+    }
+    guard source === capturedSource else {
+      Self.btRouteLog("Zero-signal retire skipped: source was replaced")
+      return
+    }
+    guard source.isRunning else {
+      Self.btRouteLog("Zero-signal retire skipped: source already torn down")
+      return
+    }
+    rebuildActiveSource(source)
+    Self.btRouteLog("Zero-signal source retired")
+  }
+
+  /// The single destructive teardown of the active source, shared by
+  /// `rebuildEngine()` and `retireCapturingSource`. Only a real rebuild advances
+  /// the incarnation: with no active source nothing is destroyed, so a bump here
+  /// would falsely satisfy `fresh_pipe_proven`.
+  private func rebuildActiveSource(_ source: any AudioInputSource) {
     source.rebuild()
+    clearCaptureSessionSource(ifMatching: source)
     #if DEBUG
       debugSourceIncarnation += 1  // destructive rebuild of the active source's resources
     #endif
   }
+
+  /// Drop the retained capture-session source once it is torn down or replaced, so
+  /// no torn-down source is retained for the rest of the app's life. Matches by
+  /// reference so an older teardown never clears a newer session's retained source.
+  private func clearCaptureSessionSource(ifMatching source: any AudioInputSource) {
+    guard let captured = captureSessionSource, captured === source else { return }
+    captureSessionSource = nil
+  }
+
+  #if DEBUG
+    /// Test seam (heartpath 5b): install `captured` as the retained capture source
+    /// for session `sessionID`, with `active` (defaulting to `captured`) as the
+    /// live active source — without real hardware. Mirrors the `isCapturing`
+    /// internal(set) "arm without hardware" pattern the other manager unit tests
+    /// use, because `beginCapturePhase` needs a real device format a stub cannot
+    /// provide. Lets `AudioCaptureManagerRetireFenceTests` exercise the retire
+    /// fence against the REAL manager state, not a `FakeAudioCapture`.
+    func installCapturedSourceForTesting(
+      _ captured: any AudioInputSource, active: (any AudioInputSource)? = nil, sessionID: UInt64
+    ) {
+      captureSessionSource = captured
+      activeSource = active ?? captured
+      captureSessionCounter = sessionID
+    }
+  #endif
 
   public func preWarm() async throws {
     let preWarmStart = ContinuousClock.now
@@ -636,6 +710,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     idleSince = nil
     guard let source = activeSource else { return }
     activeSource = nil
+    clearCaptureSessionSource(ifMatching: source)  // heartpath 5b: don't retain a torn-down source
     Self.btRouteLog("Warm engine teardown")
     engineStopTask = Task { [weak self] in
       _ = await source.stop()
@@ -743,6 +818,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       Self.btRouteLog("Route changed while warm — tearing down old source")
       existing.rebuild()
       activeSource = nil
+      clearCaptureSessionSource(ifMatching: existing)  // heartpath 5b
     }
 
     let decision = routeResolver.resolve(
@@ -769,6 +845,11 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       source = halSource
     }
 
+    // heartpath 5b: a stopped prior source overwritten here must not stay retained
+    // by the capture-session fence.
+    if let prior = activeSource {
+      clearCaptureSessionSource(ifMatching: prior)
+    }
     #if DEBUG
       source.debugZeroFillController = debugZeroFillController
       debugSourceIncarnation += 1  // new source installed at the activeSource authority

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
@@ -61,3 +61,21 @@ struct ZeroPeakContext: Sendable {
   var outputTransport: String? = nil
   var routeResolutionSource: String? = nil
 }
+
+/// Per-call context for `HeartPathTelemetryEmitter.deadMicRetireAttempted(...)`
+/// (#1520 heartpath 5b). `msSinceLastGood` is deliberately NOT here — the
+/// emitter fills it from its own `CaptureTelemetryState` at emit time.
+struct DeadMicRetireAttemptContext: Sendable {
+  let transport: String
+  let selectedTransport: String?
+  /// `all_zero_from_start` / `became_zero_mid_capture`.
+  let failureShape: String
+  /// The sound said zero but the eligibility-gated stamp did not fire — the
+  /// retire ran on the sample fact alone (the #1520 signature).
+  let healthGuessRefused: Bool
+  /// `WarmEnginePolicy.rawValue` — policy in effect, not per-take reuse.
+  let warmPolicy: String
+  /// `ZeroSignalRetireResult.rawValue` — whether teardown actually ran.
+  let retireAction: String
+  let routeFallbackReason: String?
+}

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -226,6 +226,68 @@ final class HeartPathTelemetryEmitter {
     return true
   }
 
+  /// Heartpath 5b (#1520): a zero-signal take invoked the retire primitive.
+  /// Fans out to a content-free Sentry breadcrumb (context on a LATER Sentry
+  /// event — creates no new issue/alert) AND the countable PostHog event.
+  /// `ms_since_last_good` is filled here from the shared `captureTelemetry`.
+  func deadMicRetireAttempted(ctx: DeadMicRetireAttemptContext) {
+    // Compute once so the breadcrumb and the PostHog event carry an identical
+    // payload — the breadcrumb is the forensic trail beside a LATER Sentry
+    // incident, so it must not omit fields PostHog gets (optional keys omitted
+    // when absent, matching the optional-extras pattern).
+    let msSinceLastGood = captureTelemetry.timeSinceLastSuccessfulRecordingMs()
+    var breadcrumb: [String: Any] = [
+      "transport": ctx.transport,
+      "failure_shape": ctx.failureShape,
+      "retire_action": ctx.retireAction,
+      "health_guess_refused": ctx.healthGuessRefused,
+      "warm_policy": ctx.warmPolicy,
+    ]
+    if let selectedTransport = ctx.selectedTransport {
+      breadcrumb["selected_transport"] = selectedTransport
+    }
+    if let routeFallbackReason = ctx.routeFallbackReason {
+      breadcrumb["route_fallback_reason"] = routeFallbackReason
+    }
+    if let msSinceLastGood { breadcrumb["ms_since_last_good"] = msSinceLastGood }
+    addBreadcrumb("recording", "Dead mic retire attempted", breadcrumb)
+    TelemetryService.shared.deadMicRetireAttempted(
+      transport: ctx.transport,
+      selectedTransport: ctx.selectedTransport,
+      failureShape: ctx.failureShape,
+      healthGuessRefused: ctx.healthGuessRefused,
+      warmPolicy: ctx.warmPolicy,
+      retireAction: ctx.retireAction,
+      msSinceLastGood: msSinceLastGood,
+      routeFallbackReason: ctx.routeFallbackReason)
+  }
+
+  /// Heartpath 5b (#1520): a pending dead-mic watch resolved (a later take
+  /// recovered, or retired again). Same content-free breadcrumb + PostHog
+  /// fan-out. The outcome value is produced by `CaptureTelemetryState`.
+  func deadMicRecovered(outcome: DeadMicRecoveryOutcome) {
+    addBreadcrumb(
+      "recording",
+      "Dead mic recovery observed",
+      [
+        "recovered": outcome.recovered,
+        "resolution": outcome.resolution,
+        "retire_shape": outcome.retireShape,
+        "retire_transport": outcome.retireTransport,
+        "recovery_transport": outcome.recoveryTransport,
+        "transport_changed": outcome.transportChanged,
+        "gap_ms": outcome.gapMs,
+      ])
+    TelemetryService.shared.deadMicRecovery(
+      recovered: outcome.recovered,
+      resolution: outcome.resolution,
+      retireShape: outcome.retireShape,
+      retireTransport: outcome.retireTransport,
+      recoveryTransport: outcome.recoveryTransport,
+      transportChanged: outcome.transportChanged,
+      gapMs: outcome.gapMs)
+  }
+
   // MARK: - Private
 
   /// Per-backend breadcrumb message text. Preserves the historical asymmetry

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -407,6 +407,17 @@ public enum KernelDictationDriverFactory {
       zombieZeroPeakTelemetry: { ctx in
         emitter.zombieZeroPeak(ctx: ctx)
       },
+      // Heartpath 5b (#1520): the SAME shared capture-telemetry state the
+      // lifecycle sink holds — the kernel arms the dead-mic recovery watch on a
+      // real retire, the sink resolves it on a later success. Both dead-mic
+      // closures route to the same emitter method the sink uses.
+      captureTelemetry: captureTelemetry,
+      deadMicRetireAttemptTelemetry: { ctx in
+        emitter.deadMicRetireAttempted(ctx: ctx)
+      },
+      deadMicRecoveryTelemetry: { outcome in
+        emitter.deadMicRecovered(outcome: outcome)
+      },
       // #1317 §3.6 N4: the kernel's STOP-time classification does not
       // traverse the reactive WedgeRecoveryRouter funnel, so it submits its
       // own event through this closure — wired to the SAME emitter authority
@@ -458,7 +469,10 @@ public enum KernelDictationDriverFactory {
       // the emitter so the rich payload (sourceType, isActivelyCapturing,
       // device IDs) AND the stall/XPC-failure dedup contract reach Sentry —
       // both were lost when the sink shipped the basic-error fallback.
-      noAudioCapturedRich: { [emitter] ctx in emitter.noAudioCaptured(ctx: ctx) }
+      noAudioCapturedRich: { [emitter] ctx in emitter.noAudioCaptured(ctx: ctx) },
+      // Heartpath 5b (#1520): later-success recovery resolution → same emitter
+      // method the kernel's later-retire resolution uses.
+      deadMicRecovered: { [emitter] outcome in emitter.deadMicRecovered(outcome: outcome) }
     )
     telemetryRelay.recordingStopped = { [lifecycleSink] sampleCount in
       lifecycleSink.emitRecordingStopped(sampleCount: sampleCount)

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -103,6 +103,11 @@ final class KernelLifecycleTelemetrySink {
   /// injection.
   private let noAudioCapturedRich: NoAudioCapturedSink?
   private let audioCaptureInterrupted: AudioCaptureInterruptedSink
+  /// Heartpath 5b (#1520): emit `audio.dead_mic_recovery` when a durable success
+  /// resolves a pending dead-mic watch (audio flowed again on a later take).
+  /// No-op default so direct sink tests stay source-compatible; the factory
+  /// wires it to the same emitter method the kernel's later-retire path uses.
+  private let deadMicRecovered: @MainActor (DeadMicRecoveryOutcome) -> Void
 
   init(
     backend: ASRBackendType,
@@ -150,7 +155,8 @@ final class KernelLifecycleTelemetrySink {
       TelemetryService.shared.audioCaptureInterrupted(
         cause: cause, salvageAttempted: attempted, salvageSucceeded: succeeded,
         terminalState: terminal, backend: backend, recordingDurationMs: durationMs)
-    }
+    },
+    deadMicRecovered: @escaping @MainActor (DeadMicRecoveryOutcome) -> Void = { _ in }
   ) {
     self.backend = backend
     self.audioCapture = audioCapture
@@ -168,6 +174,7 @@ final class KernelLifecycleTelemetrySink {
     self.captureErrorWithSnapshot = captureErrorWithSnapshot
     self.noAudioCapturedRich = noAudioCapturedRich
     self.audioCaptureInterrupted = audioCaptureInterrupted
+    self.deadMicRecovered = deadMicRecovered
   }
 
   /// Switch over the 12-case lifecycle vocabulary and emit each PR-1 §B.7.2
@@ -248,7 +255,12 @@ final class KernelLifecycleTelemetrySink {
       // ran) must NOT stamp the "transcript durably saved" success marker — gate
       // on the save outcome mirrored on the telemetry side-channel.
       if !telemetryState.historySaveFailed {
-        captureTelemetry.recordSuccessfulRecording()
+        if let recovery = captureTelemetry.recordSuccessfulRecording(
+          recoveryTransport: audioCapture.currentResolvedRoute?.effective ?? "unknown",
+          sessionID: audioCapture.currentCaptureSessionID)
+        {
+          deadMicRecovered(recovery)
+        }
       }
 
     case .failed(let reason):

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1,6 +1,7 @@
 @preconcurrency import AVFoundation
 import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 
 // MARK: - RecordingSessionKernel (epic #827, PR-3; built from PR-1 §B spec)
@@ -233,6 +234,19 @@ final class RecordingSessionKernel {
   // MARK: Telemetry fan-out
 
   private let zombieZeroPeakTelemetry: @MainActor (ZeroPeakContext) -> Void
+  /// Heartpath 5b (#1520): the shared app-level capture-telemetry state. The
+  /// kernel arms the dead-mic recovery watch here on a real retire; the
+  /// lifecycle sink resolves it on a later success. MUST be the same instance
+  /// the lifecycle sink holds or the watch cannot correlate across takes.
+  private let captureTelemetry: CaptureTelemetryState
+  /// Heartpath 5b (#1520): emit `audio.dead_mic_retire_attempted`. Injected
+  /// closure (not a direct emitter dependency), wired by the factory to
+  /// `HeartPathTelemetryEmitter.deadMicRetireAttempted`.
+  private let deadMicRetireAttemptTelemetry: @MainActor (DeadMicRetireAttemptContext) -> Void
+  /// Heartpath 5b (#1520): emit `audio.dead_mic_recovery` for a later-retire
+  /// resolution produced at the retire site. Wired to the SAME emitter method
+  /// the lifecycle sink's later-success resolution uses.
+  private let deadMicRecoveryTelemetry: @MainActor (DeadMicRecoveryOutcome) -> Void
   /// #1317 §3.6 N4: STOP-time zero-signal classification runs INSIDE the
   /// kernel after `stopCapture()` and does not traverse the reactive
   /// `WedgeRecoveryRouter` funnel that the app-side detector's event rides —
@@ -639,6 +653,11 @@ final class RecordingSessionKernel {
     wedgeStallTicks: Int = 2,
     minimumRecordingTicks: Int = 5,
     zombieZeroPeakTelemetry: @escaping @MainActor (ZeroPeakContext) -> Void = { _ in },
+    captureTelemetry: CaptureTelemetryState? = nil,
+    deadMicRetireAttemptTelemetry: @escaping @MainActor (DeadMicRetireAttemptContext) -> Void = {
+      _ in
+    },
+    deadMicRecoveryTelemetry: @escaping @MainActor (DeadMicRecoveryOutcome) -> Void = { _ in },
     stopTimeZeroSignalTelemetry: @escaping @MainActor (CaptureStallContext) -> Void = { _ in },
     // #1317 (cloud review P2 round 2, PR #1512): nil default resolves inside
     // `init` against the `audioCapture` PARAMETER's own
@@ -665,6 +684,9 @@ final class RecordingSessionKernel {
     self.wedgeStallTicks = wedgeStallTicks
     self.minimumRecordingTicks = minimumRecordingTicks
     self.zombieZeroPeakTelemetry = zombieZeroPeakTelemetry
+    self.captureTelemetry = captureTelemetry ?? CaptureTelemetryState()
+    self.deadMicRetireAttemptTelemetry = deadMicRetireAttemptTelemetry
+    self.deadMicRecoveryTelemetry = deadMicRecoveryTelemetry
     self.stopTimeZeroSignalTelemetry = stopTimeZeroSignalTelemetry
     // #1317 (cloud review P2 round 2, PR #1512): the default reads
     // `audioCapture.zeroSignalDiscriminatorDeviceID` — the device the
@@ -1422,8 +1444,39 @@ final class RecordingSessionKernel {
     // in the manager, which logs truthfully; `capturedCaptureSessionID` (snapshotted
     // before the post-stop awaits) pins it to this take so a stale finish can never
     // retire a newer take's source.
-    if signalZeroMode != nil || zeroSignalRecoveryMode != nil {
-      audioCapture.retireCapturingSource(sessionID: capturedCaptureSessionID)
+    if let shapeMode = signalZeroMode ?? zeroSignalRecoveryMode {
+      let retireResult = audioCapture.retireCapturingSource(sessionID: capturedCaptureSessionID)
+      // Route from THIS take's frozen snapshot (`lastResolvedRoute`, set at
+      // go-live after all start retries), NOT a live `currentResolvedRoute` read:
+      // in the fenced `.staleSession` / `.sourceReplaced` races a live read would
+      // describe a NEWER source and misattribute the failed take's transport.
+      let takeRoute = lastResolvedRoute
+      let effectiveTransport = takeRoute?.effective ?? "unknown"
+      // The retire ran on the sample fact alone (no eligibility-gated stamp) —
+      // the #1520 signature. Derived from the already-computed stamp outcome,
+      // never a re-call of `zeroSignalDeviceEligible()` (which reads a
+      // possibly-changed live mute state).
+      let healthGuessRefused = signalZeroMode != nil && zeroSignalRecoveryMode == nil
+      deadMicRetireAttemptTelemetry(
+        DeadMicRetireAttemptContext(
+          transport: effectiveTransport,
+          selectedTransport: takeRoute?.selected,
+          failureShape: shapeMode.rawValue,
+          healthGuessRefused: healthGuessRefused,
+          warmPolicy: audioCapture.warmEnginePolicy.rawValue,
+          retireAction: retireResult.rawValue,
+          routeFallbackReason: takeRoute?.routeFallbackReason))
+      // Arm the recovery watch ONLY when teardown actually ran — a fenced no-op
+      // can never be credited a later recovery. A watch already pending means the
+      // previous retire's later take also retired: emit that as recovered=false.
+      if retireResult == .retired {
+        if let priorOutcome = captureTelemetry.armDeadMicWatch(
+          DeadMicRetireWatch(shape: shapeMode.rawValue, transport: effectiveTransport),
+          sessionID: capturedCaptureSessionID)
+        {
+          deadMicRecoveryTelemetry(priorOutcome)
+        }
+      }
     }
 
     // #1317 / heartpath 5b — the eligibility-gated TERMINAL (unchanged): only an

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1261,6 +1261,10 @@ final class RecordingSessionKernel {
     captureLifecycle = .stopped
     resourcesReleased = true
     guard recordingOutcome == nil else { return }
+    // Heartpath 5b (#1520): capture the session-ownership token NOW, while THIS
+    // take's source is still current, so a stale finish after the awaits below
+    // can only retire the source it actually captured, never a newer take's.
+    let capturedCaptureSessionID = audioCapture.currentCaptureSessionID
     // #1434: stamp the ONE capture-health record NOW — before the too-short /
     // no-audio / dead-air early terminals below — so no-audio, asrEmpty, and
     // completed all read the same record (Codex r2 ordering contract).
@@ -1283,6 +1287,12 @@ final class RecordingSessionKernel {
     await (vad as? CaptureVADSignalSource)?.finalizeAtStop(
       rawSampleCount: captureResult.samples.count
     )
+    // Heartpath 5b (#1520): a cancel during `.stopping` concludes the session
+    // WITHOUT minting a new kernel session id, so `isCurrent(sid)` alone is
+    // insufficient after this await — `recordingOutcome == nil` is the load-bearing
+    // half against a sessionless prewarm installing a source while this
+    // continuation unwinds.
+    guard isCurrent(sid), recordingOutcome == nil else { return }
     let rawPeakAudioLevel = peakAudioLevel(in: captureResult.samples)
 
     // Minimum-recording-duration discard (PR-4.5 #4) — parity with old
@@ -1341,6 +1351,13 @@ final class RecordingSessionKernel {
       return
     }
 
+    // Heartpath 5b (#1520): the pure sample fact (sample-shape-only, device-
+    // independent), computed ONCE below both early terminals. It drives TWO
+    // independent decisions: the eligibility-gated stamp just below (terminal +
+    // telemetry + salvage, unchanged) AND the signal-only source retire further
+    // down (independent of eligibility — the #1520 gap).
+    let signalZeroMode = Self.classifyZeroSignalAtStop(captureResult.samples)
+
     // #1317 §3.6 STOP-win row: only when the reactive detector never fired
     // for this session (raced by STOP, or the capture was too short to reach
     // its own confidence threshold). MUST run before the no-speech gate
@@ -1352,7 +1369,7 @@ final class RecordingSessionKernel {
     // a selected non-default mic that's genuinely muted while the system
     // default happens to be alive+unmuted).
     if telemetryState.zeroSignalFailureMode == nil,
-      let mode = Self.classifyZeroSignalAtStop(captureResult.samples),
+      let mode = signalZeroMode,
       zeroSignalDeviceEligible()
     {
       telemetryState.zeroSignalFailureMode = mode
@@ -1385,34 +1402,10 @@ final class RecordingSessionKernel {
         ))
     }
 
-    // #1317 PR3 — THE single zero-signal recovery site (plan §3.3).
-    //
-    // Every confirmed zero-signal session converges here, and only here:
-    //   * reactive `.allZeroFromStart`   — stamped at the exit switch (:1149)
-    //   * reactive `.becameZeroMidCapture` — stamped at the exit switch
-    //   * STOP-time backstop (either mode) — stamped immediately above
-    // so exactly ONE `rebuildEngine()` request is issued per zero-signal
-    // session. No terminal handler, driver, router, or the `finishTerminal`
-    // cleanup Task may rebuild for zero-signal.
-    //
-    // Placement is load-bearing on BOTH sides:
-    //   * AFTER `stopCapture()` (:1204) — the capture layer deactivates the
-    //     source before its stop reply returns (`AudioCaptureManager:411`), so
-    //     the rebuild cannot race a still-live capture callback.
-    //   * AFTER the too-short / no-audio gates (:1260, :1279) — capture
-    //     samples include PRE-ROLL, so a sub-500ms visible tap can still carry
-    //     >= 16000 samples and reach the detector's threshold. Rebuilding (or
-    //     terminating as zero-signal) above those gates would hijack sessions
-    //     that correctly discard as `.tooShort` today, and would break the
-    //     founder-locked rule that very short dead taps keep today's behaviour.
-    //
-    // `rebuildEngine()` is requested BEFORE `finishTerminal` — which drains the task bag and
-    // flips the UI — to give the request the earliest possible ordering and keep
-    // the next-press race window as small as the synchronous interface allows.
-    // Exhaustive on purpose (no `default`): a future failure mode must make a
-    // deliberate choice here rather than silently inheriting engine recovery.
-    // `.noBuffers` is the ordinary capture stall — the stall watchdog owns it,
-    // and it is never even stamped (:1154). `nil` is the healthy session.
+    // Map the eligibility-gated stamp ONCE — it drives both the retire's stamp arm
+    // and the terminal below. `.noBuffers` is the ordinary capture stall (owned by
+    // the stall watchdog, never stamped); `nil` is the healthy session. Exhaustive
+    // on purpose (no `default`): a future failure mode must make a deliberate choice.
     let zeroSignalRecoveryMode: CaptureStallFailureMode?
     switch telemetryState.zeroSignalFailureMode {
     case .allZeroFromStart: zeroSignalRecoveryMode = .allZeroFromStart
@@ -1420,20 +1413,34 @@ final class RecordingSessionKernel {
     case .noBuffers, nil: zeroSignalRecoveryMode = nil
     }
 
-    if let zeroSignalRecoveryMode {
-      audioCapture.rebuildEngine()  // ← THE single zero-signal rebuild site.
-      log("zero-signal recovery: rebuild requested (\(zeroSignalRecoveryMode.rawValue))")
-      if zeroSignalRecoveryMode == .allZeroFromStart {
-        // Nothing to salvage — take the honest terminal now, still ahead of the
-        // VAD no-speech gate below, which would otherwise report an exact-zero
-        // capture as ordinary quiet-room silence (§3.6 N1).
-        finishTerminal(.failed(.zeroSignal), sid: sid)
-        return
-      }
-      // `.becameZeroMidCapture`: fall through. The mic died mid-take, but the
-      // non-zero prefix is trimmed just below and still transcribed and pasted,
-      // so the user keeps the words they actually said (§3.4).
+    // Heartpath 5b (#1520): retire the source when THIS take was zero-signal by
+    // EITHER confirmation route — the stop-time signal fact (`signalZeroMode`, which
+    // fires even when the device-eligibility guess refused, closing the #1520 gap)
+    // OR the reactive detector's eligibility-gated stamp (which can confirm a
+    // mid-capture zero run whose shape the stop-time samples no longer show — e.g. a
+    // real-speech prefix whose zero suffix was already drained). Fenced + idempotent
+    // in the manager, which logs truthfully; `capturedCaptureSessionID` (snapshotted
+    // before the post-stop awaits) pins it to this take so a stale finish can never
+    // retire a newer take's source.
+    if signalZeroMode != nil || zeroSignalRecoveryMode != nil {
+      audioCapture.retireCapturingSource(sessionID: capturedCaptureSessionID)
     }
+
+    // #1317 / heartpath 5b — the eligibility-gated TERMINAL (unchanged): only an
+    // ELIGIBLE `.allZeroFromStart` takes the honest `.zeroSignal` terminal — ahead of
+    // the VAD no-speech gate that would otherwise report an exact-zero capture as
+    // quiet-room silence (§3.6 N1); an ineligible/quiet all-zero falls through and
+    // stays `.noSpeech`. Placement stays below the too-short / no-audio gates:
+    // capture samples include PRE-ROLL, so a sub-500ms visible tap can still carry
+    // >= 16000 samples; terminating as zero-signal above them would hijack sessions
+    // that correctly discard as `.tooShort` today.
+
+    if zeroSignalRecoveryMode == .allZeroFromStart {
+      finishTerminal(.failed(.zeroSignal), sid: sid)
+      return
+    }
+    // `.becameZeroMidCapture` / `nil`: fall through. On mid-capture the non-zero
+    // prefix is trimmed just below and still transcribed and pasted (§3.4).
 
     // #1317 fast-follow (cloud review PR #1512 + live UAT repro): trim the
     // confirmed trailing zero suffix out of the salvaged capture ONCE, here —

--- a/Sources/EnviousWisprServices/CaptureTelemetryState.swift
+++ b/Sources/EnviousWisprServices/CaptureTelemetryState.swift
@@ -1,16 +1,71 @@
 import Foundation
 
+/// A caller-supplied descriptor of a zero-signal take whose source was actually
+/// retired (`ZeroSignalRetireResult.retired`). The state stamps the arm time
+/// itself, so the kernel supplies only the classification. Heartpath 5b (#1520).
+public struct DeadMicRetireWatch: Sendable, Equatable {
+  /// `all_zero_from_start` / `became_zero_mid_capture`.
+  public let shape: String
+  /// Effective transport at retire time (`bluetooth` / `builtin` / …).
+  public let transport: String
+
+  public init(shape: String, transport: String) {
+    self.shape = shape
+    self.transport = transport
+  }
+}
+
+/// The resolved outcome of a pending `DeadMicRetireWatch`: whether a LATER take
+/// recovered (audio flowed again) or retired again. Emitted as the
+/// `audio.dead_mic_recovery` event. Heartpath 5b (#1520).
+public struct DeadMicRecoveryOutcome: Sendable, Equatable {
+  public let retireShape: String
+  public let retireTransport: String
+  public let recovered: Bool
+  /// `later_success` / `later_retire` — an intervening take can leave the watch
+  /// unresolved, so this is a LATER resolution, not strictly the next take.
+  public let resolution: String
+  public let recoveryTransport: String
+  /// Transport CLASS change only (two Bluetooth devices both read `bluetooth`).
+  public let transportChanged: Bool
+  public let gapMs: Int
+
+  public init(
+    retireShape: String, retireTransport: String, recovered: Bool, resolution: String,
+    recoveryTransport: String, transportChanged: Bool, gapMs: Int
+  ) {
+    self.retireShape = retireShape
+    self.retireTransport = retireTransport
+    self.recovered = recovered
+    self.resolution = resolution
+    self.recoveryTransport = recoveryTransport
+    self.transportChanged = transportChanged
+    self.gapMs = gapMs
+  }
+}
+
 /// App-wide telemetry state for audio capture diagnostics. Owns dedupe state
-/// for zombie-engine zero-peak events (#302).
+/// for zombie-engine zero-peak events (#302) and the cross-take dead-mic
+/// recovery watch (#1520 heartpath 5b).
 ///
 /// Shared across both pipelines so a Parakeet-to-WhisperKit switch does not
 /// reset dedupe, and so `timeSinceLastSuccessfulRecordingMs` is an app-level
-/// baseline rather than pipeline-local.
+/// baseline rather than pipeline-local. The SAME instance must be handed to the
+/// recording kernel (arm-on-retire) and the lifecycle sink (resolve-on-success)
+/// or the watch cannot correlate across takes.
 @MainActor
 public final class CaptureTelemetryState {
   private var lastZombieEmittedAt: ContinuousClock.Instant?
   private var lastZombieRoute: String?
   private var lastSuccessfulRecordingAt: ContinuousClock.Instant?
+
+  /// The single in-flight dead-mic recovery watch (#1520). In-memory only: a
+  /// relaunch drops it, lowering recovery-observation coverage but never
+  /// manufacturing an outcome. `armedSessionID` is the capture session that
+  /// retired — only a DIFFERENT (later) session may resolve the watch, so a
+  /// take that both arms and self-completes cannot fake its own recovery.
+  private var pendingDeadMicWatch:
+    (watch: DeadMicRetireWatch, armedAt: ContinuousClock.Instant, armedSessionID: UInt64)?
 
   private let currentInstant: @MainActor () -> ContinuousClock.Instant
 
@@ -22,11 +77,66 @@ public final class CaptureTelemetryState {
 
   /// Called at transcript save (not paste end) so clipboard-only users are
   /// covered. Resets zombie dedupe so a successful recording sandwiched
-  /// between two zombie events still surfaces the second event.
-  public func recordSuccessfulRecording() {
-    lastSuccessfulRecordingAt = currentInstant()
+  /// between two zombie events still surfaces the second event. Also resolves a
+  /// pending dead-mic watch as `recovered=true` (audio flowed again on a later
+  /// take); returns that outcome for the caller to emit, or nil if none pending.
+  @discardableResult
+  public func recordSuccessfulRecording(recoveryTransport: String, sessionID: UInt64)
+    -> DeadMicRecoveryOutcome?
+  {
+    let now = currentInstant()
+    lastSuccessfulRecordingAt = now
     lastZombieEmittedAt = nil
     lastZombieRoute = nil
+    // Only a LATER take proves recovery. A `becameZeroMidCapture` take arms the
+    // watch at stop AND then completes successfully by salvaging its non-zero
+    // prefix — that same session must NOT resolve its own watch (a false
+    // `recovered=true` that would inflate the metric). Resolve only from a
+    // different session; a same-session completion leaves the watch pending.
+    guard let pending = pendingDeadMicWatch, pending.armedSessionID != sessionID else {
+      return nil
+    }
+    pendingDeadMicWatch = nil
+    return resolve(
+      pending, recovered: true, resolution: "later_success",
+      recoveryTransport: recoveryTransport, now: now)
+  }
+
+  /// Arm a dead-mic recovery watch for a take (identified by `sessionID`) whose
+  /// source was actually retired. If a watch is already pending from a DIFFERENT
+  /// earlier session, the previous retire's later take has itself retired:
+  /// resolve the prior watch as `recovered=false` (`later_retire`) and return
+  /// that outcome for the caller to emit, then store the new watch.
+  @discardableResult
+  public func armDeadMicWatch(_ watch: DeadMicRetireWatch, sessionID: UInt64)
+    -> DeadMicRecoveryOutcome?
+  {
+    let now = currentInstant()
+    var priorOutcome: DeadMicRecoveryOutcome?
+    if let pending = pendingDeadMicWatch, pending.armedSessionID != sessionID {
+      priorOutcome = resolve(
+        pending, recovered: false, resolution: "later_retire",
+        recoveryTransport: watch.transport, now: now)
+    }
+    pendingDeadMicWatch = (watch, now, sessionID)
+    return priorOutcome
+  }
+
+  private func resolve(
+    _ pending: (
+      watch: DeadMicRetireWatch, armedAt: ContinuousClock.Instant, armedSessionID: UInt64
+    ),
+    recovered: Bool, resolution: String, recoveryTransport: String,
+    now: ContinuousClock.Instant
+  ) -> DeadMicRecoveryOutcome {
+    DeadMicRecoveryOutcome(
+      retireShape: pending.watch.shape,
+      retireTransport: pending.watch.transport,
+      recovered: recovered,
+      resolution: resolution,
+      recoveryTransport: recoveryTransport,
+      transportChanged: pending.watch.transport != recoveryTransport,
+      gapMs: millisecondsBetween(pending.armedAt, and: now))
   }
 
   /// Returns true if a zombie event on `route` should emit to Sentry now.
@@ -51,7 +161,13 @@ public final class CaptureTelemetryState {
   /// has never produced a successful recording yet.
   public func timeSinceLastSuccessfulRecordingMs() -> Int? {
     guard let last = lastSuccessfulRecordingAt else { return nil }
-    let elapsed = currentInstant() - last
+    return millisecondsBetween(last, and: currentInstant())
+  }
+
+  private func millisecondsBetween(
+    _ start: ContinuousClock.Instant, and end: ContinuousClock.Instant
+  ) -> Int {
+    let elapsed = end - start
     let (seconds, attoseconds) = elapsed.components
     return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
   }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -510,6 +510,103 @@ public final class TelemetryService {
     PostHogSDK.shared.capture(event, properties: props)
   }
 
+  /// Heartpath 5b (#1520): a completed take came back zero-signal, so the fenced
+  /// retire primitive was invoked. `retireAction` records whether teardown
+  /// actually ran (`retired`) or was a fenced no-op. Content-free by
+  /// construction: closed-vocabulary transport / route / policy / shape strings,
+  /// booleans, and elapsed ms — never transcript, audio, device name, or UID.
+  public func deadMicRetireAttempted(
+    transport: String,
+    selectedTransport: String?,
+    failureShape: String,
+    healthGuessRefused: Bool,
+    warmPolicy: String,
+    retireAction: String,
+    msSinceLastGood: Int?,
+    routeFallbackReason: String?
+  ) {
+    let event = "audio.dead_mic_retire_attempted"
+    var props: [String: Any] = [
+      "transport": transport,
+      "failure_shape": failureShape,
+      "health_guess_refused": healthGuessRefused,
+      "warm_policy": warmPolicy,
+      "retire_action": retireAction,
+    ]
+    if let selectedTransport { props["selected_transport"] = selectedTransport }
+    if let msSinceLastGood { props["ms_since_last_good"] = msSinceLastGood }
+    if let routeFallbackReason { props["route_fallback_reason"] = routeFallbackReason }
+    #if DEBUG
+      var stringProps: [String: String] = [
+        "transport": transport,
+        "failure_shape": failureShape,
+        "warm_policy": warmPolicy,
+        "retire_action": retireAction,
+      ]
+      if let selectedTransport { stringProps["selected_transport"] = selectedTransport }
+      if let routeFallbackReason { stringProps["route_fallback_reason"] = routeFallbackReason }
+      var intProps: [String: Int] = [:]
+      if let msSinceLastGood { intProps["ms_since_last_good"] = msSinceLastGood }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: event, stringProps: stringProps, intProps: intProps,
+          boolProps: ["health_guess_refused": healthGuessRefused]))
+      Task {
+        await AppLogger.shared.log(
+          "dead_mic_retire_attempted transport=\(transport) shape=\(failureShape) "
+            + "action=\(retireAction) health_guess_refused=\(healthGuessRefused) "
+            + "warm_policy=\(warmPolicy)",
+          level: .info, category: "Audio")
+      }
+    #endif
+    PostHogSDK.shared.capture(event, properties: props)
+  }
+
+  /// Heartpath 5b (#1520): a pending dead-mic watch resolved — a LATER take
+  /// either recovered (audio flowed again) or retired again. Same content-free
+  /// boundary as `deadMicRetireAttempted`.
+  public func deadMicRecovery(
+    recovered: Bool,
+    resolution: String,
+    retireShape: String,
+    retireTransport: String,
+    recoveryTransport: String,
+    transportChanged: Bool,
+    gapMs: Int
+  ) {
+    let event = "audio.dead_mic_recovery"
+    let props: [String: Any] = [
+      "recovered": recovered,
+      "resolution": resolution,
+      "retire_shape": retireShape,
+      "retire_transport": retireTransport,
+      "recovery_transport": recoveryTransport,
+      "transport_changed": transportChanged,
+      "gap_ms": gapMs,
+    ]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: event,
+          stringProps: [
+            "resolution": resolution,
+            "retire_shape": retireShape,
+            "retire_transport": retireTransport,
+            "recovery_transport": recoveryTransport,
+          ],
+          intProps: ["gap_ms": gapMs],
+          boolProps: ["recovered": recovered, "transport_changed": transportChanged]))
+      Task {
+        await AppLogger.shared.log(
+          "dead_mic_recovery recovered=\(recovered) resolution=\(resolution) "
+            + "retire_transport=\(retireTransport) recovery_transport=\(recoveryTransport) "
+            + "gap_ms=\(gapMs)",
+          level: .info, category: "Audio")
+      }
+    #endif
+    PostHogSDK.shared.capture(event, properties: props)
+  }
+
   public func dictationCompleted(
     result: String, inputMode: String, asrBackend: String,
     llmProvider: String?, fillerRemoval: Bool,

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -49,6 +49,7 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
+  func retireCapturingSource(sessionID: UInt64) {}
   func preWarm() async throws {
     if let preWarmError { throw preWarmError }
   }

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -49,7 +49,7 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
-  func retireCapturingSource(sessionID: UInt64) {}
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {
     if let preWarmError { throw preWarmError }
   }

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -186,7 +186,7 @@ private final class SettableAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
-  func retireCapturingSource(sessionID: UInt64) {}
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}
   func abortPreWarm() {}
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
@@ -234,7 +234,7 @@ private final class ObservableAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
-  func retireCapturingSource(sessionID: UInt64) {}
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}
   func abortPreWarm() {}
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -186,6 +186,7 @@ private final class SettableAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
+  func retireCapturingSource(sessionID: UInt64) {}
   func preWarm() async throws {}
   func abortPreWarm() {}
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
@@ -233,6 +234,7 @@ private final class ObservableAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
+  func retireCapturingSource(sessionID: UInt64) {}
   func preWarm() async throws {}
   func abortPreWarm() {}
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
@@ -1,0 +1,134 @@
+@preconcurrency import AVFoundation
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// MARK: - Heartpath 5b (#1520) — the zero-signal source-retirement fence.
+//
+// `retireCapturingSource(sessionID:)` must tear down ONLY the source that
+// captured the given session, and ONLY while it is still the running active
+// source. These tests exercise the REAL `AudioCaptureManager` fence (session-id
+// + retained-source `===` + running-state), not a `FakeAudioCapture` — the fake
+// is a pass-through recorder and would test itself, not the guards.
+//
+// State is installed via `installCapturedSourceForTesting` (DEBUG), the same
+// arm-without-hardware shortcut the other manager unit tests use — a stub source
+// cannot drive `beginCapturePhase`, which needs a real device format.
+// `debugSourceIncarnation` is the freshness oracle: it advances exactly once on a
+// real retire and never on a fenced no-op.
+@MainActor
+@Suite("AudioCaptureManager zero-signal retire fence (#1520)")
+struct AudioCaptureManagerRetireFenceTests {
+
+  /// Minimal `AudioInputSource` stub: controllable running-state, records the
+  /// destructive `rebuild()`. All other members are inert.
+  final class StubSource: AudioInputSource {
+    var onSamples: (@Sendable ([Float], Float) -> Void)?
+    var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+    var onInterrupted: ((EngineInterruptionCause) -> Void)?
+    var onLifecycleSignal: (@Sendable (String) -> Void)?
+    var onCaptureStalled: ((CaptureStallContext) -> Void)?
+    var captureGeneration: UInt64 = 0
+    let captureSourceType = "stub"
+    var running = true
+    var isCapturing = false
+    var isRunning: Bool { running }
+    private(set) var rebuildCallCount = 0
+    #if DEBUG
+      var debugZeroFillController: DebugZeroFillController?
+    #endif
+
+    func prepare() async throws {}
+    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+      AsyncStream { $0.finish() }
+    }
+    func stop() async -> [Float] {
+      running = false
+      return []
+    }
+    func deactivateCapture() {}
+    func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
+    {
+      true
+    }
+    func abortPrepare() {}
+    func rebuild() {
+      rebuildCallCount += 1
+      running = false
+    }
+  }
+
+  @Test("matching session + running captured source → retires once, one incarnation bump")
+  func matchingSessionRetiresOnce() {
+    let manager = AudioCaptureManager()
+    let stub = StubSource()
+    manager.installCapturedSourceForTesting(stub, sessionID: 7)
+    let base = manager.debugSourceIncarnation
+
+    manager.retireCapturingSource(sessionID: 7)
+
+    #expect(stub.rebuildCallCount == 1)
+    #expect(manager.debugSourceIncarnation == base + 1)
+  }
+
+  @Test("stale session id → no-op, captured source untouched, no bump")
+  func staleSessionIsInert() {
+    let manager = AudioCaptureManager()
+    let stub = StubSource()
+    manager.installCapturedSourceForTesting(stub, sessionID: 7)
+    let base = manager.debugSourceIncarnation
+
+    manager.retireCapturingSource(sessionID: 6)  // an older take's id
+
+    #expect(stub.rebuildCallCount == 0)
+    #expect(manager.debugSourceIncarnation == base)
+  }
+
+  @Test("captured source replaced by a newer active source → no-op, replacement untouched")
+  func replacedSourceIsInert() {
+    let manager = AudioCaptureManager()
+    let captured = StubSource()
+    let replacement = StubSource()
+    // Same session id, but the ACTIVE source is now a different object than the
+    // one that captured the session (the exact narrow window the retained-`===`
+    // fence closes; the session-id fence alone would let this through).
+    manager.installCapturedSourceForTesting(captured, active: replacement, sessionID: 7)
+
+    manager.retireCapturingSource(sessionID: 7)
+
+    #expect(captured.rebuildCallCount == 0)
+    #expect(replacement.rebuildCallCount == 0)
+  }
+
+  @Test("stopped captured source → no-op, no bump")
+  func stoppedSourceIsInert() {
+    let manager = AudioCaptureManager()
+    let stub = StubSource()
+    stub.running = false  // e.g. an interruption already tore it down
+    manager.installCapturedSourceForTesting(stub, sessionID: 7)
+    let base = manager.debugSourceIncarnation
+
+    manager.retireCapturingSource(sessionID: 7)
+
+    #expect(stub.rebuildCallCount == 0)
+    #expect(manager.debugSourceIncarnation == base)
+  }
+
+  @Test("a real retire clears the retained source — a second retire is inert")
+  func retireClearsRetainedSource() {
+    let manager = AudioCaptureManager()
+    let stub = StubSource()
+    manager.installCapturedSourceForTesting(stub, sessionID: 7)
+
+    manager.retireCapturingSource(sessionID: 7)
+    #expect(stub.rebuildCallCount == 1)
+
+    // The retire cleared `captureSessionSource`, so a repeat hits the
+    // "captured source already gone" guard — proving no stale retain lingers
+    // (the retain-release property, without exposing the private field).
+    manager.retireCapturingSource(sessionID: 7)
+    #expect(stub.rebuildCallCount == 1)  // still 1, not 2
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
@@ -73,8 +73,9 @@ import Testing
       manager.installCapturedSourceForTesting(stub, sessionID: 7)
       let base = manager.debugSourceIncarnation
 
-      manager.retireCapturingSource(sessionID: 7)
+      let result = manager.retireCapturingSource(sessionID: 7)
 
+      #expect(result == .retired)
       #expect(stub.rebuildCallCount == 1)
       #expect(manager.debugSourceIncarnation == base + 1)
     }
@@ -86,8 +87,9 @@ import Testing
       manager.installCapturedSourceForTesting(stub, sessionID: 7)
       let base = manager.debugSourceIncarnation
 
-      manager.retireCapturingSource(sessionID: 6)  // an older take's id
+      let result = manager.retireCapturingSource(sessionID: 6)  // an older take's id
 
+      #expect(result == .staleSession)
       #expect(stub.rebuildCallCount == 0)
       #expect(manager.debugSourceIncarnation == base)
     }
@@ -102,10 +104,28 @@ import Testing
       // fence closes; the session-id fence alone would let this through).
       manager.installCapturedSourceForTesting(captured, active: replacement, sessionID: 7)
 
-      manager.retireCapturingSource(sessionID: 7)
+      let result = manager.retireCapturingSource(sessionID: 7)
 
+      #expect(result == .sourceReplaced)
       #expect(captured.rebuildCallCount == 0)
       #expect(replacement.rebuildCallCount == 0)
+    }
+
+    @Test("active source already gone → no-op, captured source untouched")
+    func activeSourceGoneIsInert() {
+      let manager = AudioCaptureManager()
+      let stub = StubSource()
+      manager.installCapturedSourceForTesting(stub, sessionID: 7)
+      // Drop the live active source while keeping the retained capture source —
+      // the only way to reach the `.activeSourceGone` branch.
+      manager.clearActiveSourceForTesting()
+      let base = manager.debugSourceIncarnation
+
+      let result = manager.retireCapturingSource(sessionID: 7)
+
+      #expect(result == .activeSourceGone)
+      #expect(stub.rebuildCallCount == 0)
+      #expect(manager.debugSourceIncarnation == base)
     }
 
     @Test("stopped captured source → no-op, no bump")
@@ -116,8 +136,9 @@ import Testing
       manager.installCapturedSourceForTesting(stub, sessionID: 7)
       let base = manager.debugSourceIncarnation
 
-      manager.retireCapturingSource(sessionID: 7)
+      let result = manager.retireCapturingSource(sessionID: 7)
 
+      #expect(result == .sourceNotRunning)
       #expect(stub.rebuildCallCount == 0)
       #expect(manager.debugSourceIncarnation == base)
     }
@@ -128,13 +149,13 @@ import Testing
       let stub = StubSource()
       manager.installCapturedSourceForTesting(stub, sessionID: 7)
 
-      manager.retireCapturingSource(sessionID: 7)
+      #expect(manager.retireCapturingSource(sessionID: 7) == .retired)
       #expect(stub.rebuildCallCount == 1)
 
       // The retire cleared `captureSessionSource`, so a repeat hits the
       // "captured source already gone" guard — proving no stale retain lingers
       // (the retain-release property, without exposing the private field).
-      manager.retireCapturingSource(sessionID: 7)
+      #expect(manager.retireCapturingSource(sessionID: 7) == .capturedSourceGone)
       #expect(stub.rebuildCallCount == 1)  // still 1, not 2
     }
   }

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
@@ -5,130 +5,138 @@ import Testing
 
 @testable import EnviousWisprAudio
 
-// MARK: - Heartpath 5b (#1520) — the zero-signal source-retirement fence.
-//
-// `retireCapturingSource(sessionID:)` must tear down ONLY the source that
-// captured the given session, and ONLY while it is still the running active
-// source. These tests exercise the REAL `AudioCaptureManager` fence (session-id
-// + retained-source `===` + running-state), not a `FakeAudioCapture` — the fake
-// is a pass-through recorder and would test itself, not the guards.
-//
-// State is installed via `installCapturedSourceForTesting` (DEBUG), the same
-// arm-without-hardware shortcut the other manager unit tests use — a stub source
-// cannot drive `beginCapturePhase`, which needs a real device format.
-// `debugSourceIncarnation` is the freshness oracle: it advances exactly once on a
-// real retire and never on a fenced no-op.
-@MainActor
-@Suite("AudioCaptureManager zero-signal retire fence (#1520)")
-struct AudioCaptureManagerRetireFenceTests {
+// This suite uses AudioCaptureManager's `#if DEBUG` test seam
+// (`installCapturedSourceForTesting`) and its `debugSourceIncarnation` oracle, so
+// the whole suite is DEBUG-only — the Release test-target lane must not compile it.
+#if DEBUG
 
-  /// Minimal `AudioInputSource` stub: controllable running-state, records the
-  /// destructive `rebuild()`. All other members are inert.
-  final class StubSource: AudioInputSource {
-    var onSamples: (@Sendable ([Float], Float) -> Void)?
-    var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
-    var onInterrupted: ((EngineInterruptionCause) -> Void)?
-    var onLifecycleSignal: (@Sendable (String) -> Void)?
-    var onCaptureStalled: ((CaptureStallContext) -> Void)?
-    var captureGeneration: UInt64 = 0
-    let captureSourceType = "stub"
-    var running = true
-    var isCapturing = false
-    var isRunning: Bool { running }
-    private(set) var rebuildCallCount = 0
-    #if DEBUG
-      var debugZeroFillController: DebugZeroFillController?
-    #endif
+  // MARK: - Heartpath 5b (#1520) — the zero-signal source-retirement fence.
+  //
+  // `retireCapturingSource(sessionID:)` must tear down ONLY the source that
+  // captured the given session, and ONLY while it is still the running active
+  // source. These tests exercise the REAL `AudioCaptureManager` fence (session-id
+  // + retained-source `===` + running-state), not a `FakeAudioCapture` — the fake
+  // is a pass-through recorder and would test itself, not the guards.
+  //
+  // State is installed via `installCapturedSourceForTesting` (DEBUG), the same
+  // arm-without-hardware shortcut the other manager unit tests use — a stub source
+  // cannot drive `beginCapturePhase`, which needs a real device format.
+  // `debugSourceIncarnation` is the freshness oracle: it advances exactly once on a
+  // real retire and never on a fenced no-op.
+  @MainActor
+  @Suite("AudioCaptureManager zero-signal retire fence (#1520)")
+  struct AudioCaptureManagerRetireFenceTests {
 
-    func prepare() async throws {}
-    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
-      AsyncStream { $0.finish() }
+    /// Minimal `AudioInputSource` stub: controllable running-state, records the
+    /// destructive `rebuild()`. All other members are inert.
+    final class StubSource: AudioInputSource {
+      var onSamples: (@Sendable ([Float], Float) -> Void)?
+      var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+      var onInterrupted: ((EngineInterruptionCause) -> Void)?
+      var onLifecycleSignal: (@Sendable (String) -> Void)?
+      var onCaptureStalled: ((CaptureStallContext) -> Void)?
+      var captureGeneration: UInt64 = 0
+      let captureSourceType = "stub"
+      var running = true
+      var isCapturing = false
+      var isRunning: Bool { running }
+      private(set) var rebuildCallCount = 0
+      #if DEBUG
+        var debugZeroFillController: DebugZeroFillController?
+      #endif
+
+      func prepare() async throws {}
+      func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { $0.finish() }
+      }
+      func stop() async -> [Float] {
+        running = false
+        return []
+      }
+      func deactivateCapture() {}
+      func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async
+        -> Bool
+      {
+        true
+      }
+      func abortPrepare() {}
+      func rebuild() {
+        rebuildCallCount += 1
+        running = false
+      }
     }
-    func stop() async -> [Float] {
-      running = false
-      return []
+
+    @Test("matching session + running captured source → retires once, one incarnation bump")
+    func matchingSessionRetiresOnce() {
+      let manager = AudioCaptureManager()
+      let stub = StubSource()
+      manager.installCapturedSourceForTesting(stub, sessionID: 7)
+      let base = manager.debugSourceIncarnation
+
+      manager.retireCapturingSource(sessionID: 7)
+
+      #expect(stub.rebuildCallCount == 1)
+      #expect(manager.debugSourceIncarnation == base + 1)
     }
-    func deactivateCapture() {}
-    func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool
-    {
-      true
+
+    @Test("stale session id → no-op, captured source untouched, no bump")
+    func staleSessionIsInert() {
+      let manager = AudioCaptureManager()
+      let stub = StubSource()
+      manager.installCapturedSourceForTesting(stub, sessionID: 7)
+      let base = manager.debugSourceIncarnation
+
+      manager.retireCapturingSource(sessionID: 6)  // an older take's id
+
+      #expect(stub.rebuildCallCount == 0)
+      #expect(manager.debugSourceIncarnation == base)
     }
-    func abortPrepare() {}
-    func rebuild() {
-      rebuildCallCount += 1
-      running = false
+
+    @Test("captured source replaced by a newer active source → no-op, replacement untouched")
+    func replacedSourceIsInert() {
+      let manager = AudioCaptureManager()
+      let captured = StubSource()
+      let replacement = StubSource()
+      // Same session id, but the ACTIVE source is now a different object than the
+      // one that captured the session (the exact narrow window the retained-`===`
+      // fence closes; the session-id fence alone would let this through).
+      manager.installCapturedSourceForTesting(captured, active: replacement, sessionID: 7)
+
+      manager.retireCapturingSource(sessionID: 7)
+
+      #expect(captured.rebuildCallCount == 0)
+      #expect(replacement.rebuildCallCount == 0)
+    }
+
+    @Test("stopped captured source → no-op, no bump")
+    func stoppedSourceIsInert() {
+      let manager = AudioCaptureManager()
+      let stub = StubSource()
+      stub.running = false  // e.g. an interruption already tore it down
+      manager.installCapturedSourceForTesting(stub, sessionID: 7)
+      let base = manager.debugSourceIncarnation
+
+      manager.retireCapturingSource(sessionID: 7)
+
+      #expect(stub.rebuildCallCount == 0)
+      #expect(manager.debugSourceIncarnation == base)
+    }
+
+    @Test("a real retire clears the retained source — a second retire is inert")
+    func retireClearsRetainedSource() {
+      let manager = AudioCaptureManager()
+      let stub = StubSource()
+      manager.installCapturedSourceForTesting(stub, sessionID: 7)
+
+      manager.retireCapturingSource(sessionID: 7)
+      #expect(stub.rebuildCallCount == 1)
+
+      // The retire cleared `captureSessionSource`, so a repeat hits the
+      // "captured source already gone" guard — proving no stale retain lingers
+      // (the retain-release property, without exposing the private field).
+      manager.retireCapturingSource(sessionID: 7)
+      #expect(stub.rebuildCallCount == 1)  // still 1, not 2
     }
   }
 
-  @Test("matching session + running captured source → retires once, one incarnation bump")
-  func matchingSessionRetiresOnce() {
-    let manager = AudioCaptureManager()
-    let stub = StubSource()
-    manager.installCapturedSourceForTesting(stub, sessionID: 7)
-    let base = manager.debugSourceIncarnation
-
-    manager.retireCapturingSource(sessionID: 7)
-
-    #expect(stub.rebuildCallCount == 1)
-    #expect(manager.debugSourceIncarnation == base + 1)
-  }
-
-  @Test("stale session id → no-op, captured source untouched, no bump")
-  func staleSessionIsInert() {
-    let manager = AudioCaptureManager()
-    let stub = StubSource()
-    manager.installCapturedSourceForTesting(stub, sessionID: 7)
-    let base = manager.debugSourceIncarnation
-
-    manager.retireCapturingSource(sessionID: 6)  // an older take's id
-
-    #expect(stub.rebuildCallCount == 0)
-    #expect(manager.debugSourceIncarnation == base)
-  }
-
-  @Test("captured source replaced by a newer active source → no-op, replacement untouched")
-  func replacedSourceIsInert() {
-    let manager = AudioCaptureManager()
-    let captured = StubSource()
-    let replacement = StubSource()
-    // Same session id, but the ACTIVE source is now a different object than the
-    // one that captured the session (the exact narrow window the retained-`===`
-    // fence closes; the session-id fence alone would let this through).
-    manager.installCapturedSourceForTesting(captured, active: replacement, sessionID: 7)
-
-    manager.retireCapturingSource(sessionID: 7)
-
-    #expect(captured.rebuildCallCount == 0)
-    #expect(replacement.rebuildCallCount == 0)
-  }
-
-  @Test("stopped captured source → no-op, no bump")
-  func stoppedSourceIsInert() {
-    let manager = AudioCaptureManager()
-    let stub = StubSource()
-    stub.running = false  // e.g. an interruption already tore it down
-    manager.installCapturedSourceForTesting(stub, sessionID: 7)
-    let base = manager.debugSourceIncarnation
-
-    manager.retireCapturingSource(sessionID: 7)
-
-    #expect(stub.rebuildCallCount == 0)
-    #expect(manager.debugSourceIncarnation == base)
-  }
-
-  @Test("a real retire clears the retained source — a second retire is inert")
-  func retireClearsRetainedSource() {
-    let manager = AudioCaptureManager()
-    let stub = StubSource()
-    manager.installCapturedSourceForTesting(stub, sessionID: 7)
-
-    manager.retireCapturingSource(sessionID: 7)
-    #expect(stub.rebuildCallCount == 1)
-
-    // The retire cleared `captureSessionSource`, so a repeat hits the
-    // "captured source already gone" guard — proving no stale retain lingers
-    // (the retain-release property, without exposing the private field).
-    manager.retireCapturingSource(sessionID: 7)
-    #expect(stub.rebuildCallCount == 1)  // still 1, not 2
-  }
-}
+#endif

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -84,6 +84,7 @@ private final class ExtrasAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
+  func retireCapturingSource(sessionID: UInt64) {}
   func preWarm() async throws {}
   func abortPreWarm() {}
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -84,7 +84,7 @@ private final class ExtrasAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
-  func retireCapturingSource(sessionID: UInt64) {}
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}
   func abortPreWarm() {}
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -526,7 +526,7 @@ internal final class FixtureAudioCapture: AudioCaptureInterface {
   }
 
   func rebuildEngine() {}
-  func retireCapturingSource(sessionID: UInt64) {}
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
 
   func preWarm() async throws {}
 

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -526,6 +526,7 @@ internal final class FixtureAudioCapture: AudioCaptureInterface {
   }
 
   func rebuildEngine() {}
+  func retireCapturingSource(sessionID: UInt64) {}
 
   func preWarm() async throws {}
 

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -440,7 +440,7 @@ struct HeartPathTelemetryEmitterTests {
     // `time_since_last_successful_recording_ms` key is non-nil. In
     // production at least one successful recording will have happened
     // before the zombie code path can fire.
-    captureTelemetry.recordSuccessfulRecording()
+    captureTelemetry.recordSuccessfulRecording(recoveryTransport: "builtin", sessionID: 1)
     let emitter = Self.makeEmitter(
       backend: .parakeet, captureTelemetry: captureTelemetry, recorder: recorder)
 
@@ -452,6 +452,100 @@ struct HeartPathTelemetryEmitterTests {
       actualKeys == Self.zombieExtraKeys,
       "zombie extras key-set drift: \(actualKeys.symmetricDifference(Self.zombieExtraKeys))")
   }
+
+  // MARK: - Dead-mic telemetry (#1520 heartpath 5b)
+  //
+  // Assert the FEATURE, not the absence of a crash (verify-the-feature-not-the-crash):
+  // each method must add exactly one content-free Sentry breadcrumb (NOT a
+  // standalone captureError — no new issue/alert) AND emit one PostHog event
+  // with the full prop set. The PostHog side is observed via the DEBUG
+  // `testEventHook`, so these two tests are `#if DEBUG`-gated
+  // (swift-testing-debug-seam-needs-if-debug — the Release test lane must not
+  // reference the DEBUG-only hook).
+  #if DEBUG
+    @Test("deadMicRetireAttempted adds one breadcrumb AND one PostHog event with full props")
+    func deadMicRetireAttemptedFansOut() {
+      let recorder = Recorder()
+      let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+      let box = CapturedEventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      emitter.deadMicRetireAttempted(
+        ctx: DeadMicRetireAttemptContext(
+          transport: "bluetooth",
+          selectedTransport: "bluetooth",
+          failureShape: "all_zero_from_start",
+          healthGuessRefused: true,
+          warmPolicy: "seconds30",
+          retireAction: "retired",
+          routeFallbackReason: nil))
+
+      #expect(recorder.breadcrumbs.count == 1)
+      #expect(recorder.breadcrumbs.first?.message == "Dead mic retire attempted")
+      #expect(recorder.breadcrumbs.first?.data["transport"] as? String == "bluetooth")
+      #expect(recorder.breadcrumbs.first?.data["retire_action"] as? String == "retired")
+      // The breadcrumb carries the full diagnostic payload (parity with PostHog).
+      #expect(recorder.breadcrumbs.first?.data["selected_transport"] as? String == "bluetooth")
+      #expect(recorder.breadcrumbs.first?.data["health_guess_refused"] as? Bool == true)
+      #expect(recorder.errors.isEmpty)  // breadcrumb only, no standalone Sentry event
+
+      let captured = box.event
+      #expect(captured?.name == "audio.dead_mic_retire_attempted")
+      #expect(captured?.stringProps["transport"] == "bluetooth")
+      #expect(captured?.stringProps["failure_shape"] == "all_zero_from_start")
+      #expect(captured?.stringProps["warm_policy"] == "seconds30")
+      #expect(captured?.stringProps["retire_action"] == "retired")
+      #expect(captured?.boolProps["health_guess_refused"] == true)
+    }
+
+    @Test("deadMicRecovered adds one breadcrumb AND one PostHog event with full props")
+    func deadMicRecoveredFansOut() {
+      let recorder = Recorder()
+      let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+      let box = CapturedEventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      emitter.deadMicRecovered(
+        outcome: DeadMicRecoveryOutcome(
+          retireShape: "all_zero_from_start",
+          retireTransport: "bluetooth",
+          recovered: true,
+          resolution: "later_success",
+          recoveryTransport: "bluetooth",
+          transportChanged: false,
+          gapMs: 1_200))
+
+      #expect(recorder.breadcrumbs.count == 1)
+      #expect(recorder.breadcrumbs.first?.message == "Dead mic recovery observed")
+      #expect(recorder.breadcrumbs.first?.data["recovered"] as? Bool == true)
+      // The breadcrumb carries retire_shape + gap_ms (parity with PostHog).
+      #expect(recorder.breadcrumbs.first?.data["retire_shape"] as? String == "all_zero_from_start")
+      #expect(recorder.breadcrumbs.first?.data["gap_ms"] as? Int == 1_200)
+      #expect(recorder.errors.isEmpty)
+
+      let captured = box.event
+      #expect(captured?.name == "audio.dead_mic_recovery")
+      #expect(captured?.boolProps["recovered"] == true)
+      #expect(captured?.stringProps["resolution"] == "later_success")
+      #expect(captured?.intProps["gap_ms"] == 1_200)
+    }
+
+    /// Sendable-safe capture box for the DEBUG `testEventHook` (a `@Sendable`
+    /// closure): a `@MainActor` class is implicitly Sendable, mutated via
+    /// `MainActor.assumeIsolated` since the emit is synchronous on the main actor.
+    @MainActor
+    private final class CapturedEventBox {
+      var event: CapturedTelemetryEvent?
+    }
+  #endif
 }
 
 /// Fake monotonic instant clock for tests that need deterministic

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -299,6 +299,7 @@ private final class NoOpAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
+  func retireCapturingSource(sessionID: UInt64) {}
   func preWarm() async throws {}
   func abortPreWarm() {}
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -299,7 +299,7 @@ private final class NoOpAudioCapture: AudioCaptureInterface {
   }
   func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
-  func retireCapturingSource(sessionID: UInt64) {}
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}
   func abortPreWarm() {}
   func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -64,6 +64,7 @@ import Testing
     var modelLoadWedgedBackends: [String] = []
     var captureErrors: [CaptureErrorCall] = []
     var audioCaptureInterruptions: [AudioCaptureInterruptedCall] = []
+    var deadMicRecoveries: [DeadMicRecoveryOutcome] = []
   }
 
   // MARK: - Sink construction with recorder seams
@@ -110,7 +111,8 @@ import Testing
           Recorder.AudioCaptureInterruptedCall(
             cause: cause, salvageAttempted: attempted, salvageSucceeded: succeeded,
             terminalState: terminal, backend: backend))
-      })
+      },
+      deadMicRecovered: { recorder.deadMicRecoveries.append($0) })
   }
 
   // MARK: - Per-event byte-identical event identity
@@ -374,6 +376,60 @@ import Testing
           stage: "pipeline", message: "Pipeline complete",
           dataKeys: ["asr_s", "backend", "e2e_s", "paste_tier", "polish_s"])
       ])
+  }
+
+  // MARK: - Heartpath 5b (#1520): dead-mic recovery forwarding
+
+  @Test(".pipelineCompleted forwards a pending dead-mic recovery outcome")
+  func pipelineCompletedForwardsDeadMicRecovery() {
+    let recorder = Recorder()
+    let captureTelemetry = CaptureTelemetryState()
+    // Arm a watch as if an EARLIER session (5) retired a dead source; the sink's
+    // FakeAudioCapture reports currentCaptureSessionID 0, a different (later)
+    // session, so this completion resolves it.
+    captureTelemetry.armDeadMicWatch(
+      DeadMicRetireWatch(shape: "all_zero_from_start", transport: "bluetooth"), sessionID: 5)
+    let sink = makeSink(recorder: recorder, captureTelemetry: captureTelemetry)
+
+    sink.emit(.pipelineCompleted)
+
+    #expect(recorder.deadMicRecoveries.count == 1)
+    #expect(recorder.deadMicRecoveries.first?.recovered == true)
+    #expect(recorder.deadMicRecoveries.first?.resolution == "later_success")
+  }
+
+  @Test(".pipelineCompleted does NOT resolve a watch armed by the SAME session (#1520 P1)")
+  func sameSessionCompletionDoesNotResolveDeadMicWatch() {
+    let recorder = Recorder()
+    let captureTelemetry = CaptureTelemetryState()
+    // Arm with the SAME session id the sink's FakeAudioCapture reports (0) — the
+    // becameZeroMidCapture take that armed at stop and now self-completes. It
+    // must not fake its own recovery.
+    captureTelemetry.armDeadMicWatch(
+      DeadMicRetireWatch(shape: "became_zero_mid_capture", transport: "bluetooth"), sessionID: 0)
+    let sink = makeSink(recorder: recorder, captureTelemetry: captureTelemetry)
+
+    sink.emit(.pipelineCompleted)
+
+    #expect(recorder.deadMicRecoveries.isEmpty)
+  }
+
+  @Test(".pipelineCompleted with a degraded save does NOT resolve the dead-mic watch")
+  func degradedSaveDoesNotResolveDeadMicWatch() {
+    let recorder = Recorder()
+    let telemetryState = KernelTelemetryState()
+    telemetryState.historySaveFailed = true  // degraded completion, no durable success
+    let captureTelemetry = CaptureTelemetryState()
+    captureTelemetry.armDeadMicWatch(
+      DeadMicRetireWatch(shape: "all_zero_from_start", transport: "bluetooth"), sessionID: 5)
+    let sink = makeSink(
+      recorder: recorder, telemetryState: telemetryState, captureTelemetry: captureTelemetry)
+
+    sink.emit(.pipelineCompleted)
+
+    // A degraded save is not a durable success, so it must not be counted as a
+    // recovery — the watch stays pending.
+    #expect(recorder.deadMicRecoveries.isEmpty)
   }
 
   // #1174 A3 — matcher-set-adversarial: at the `.audioInterrupted` gate both

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -59,6 +59,11 @@ final class FakeAudioCapture: AudioCaptureInterface {
   var stabilizationResults: [Bool] = []
   private(set) var stabilizationCallCount = 0
   private(set) var rebuildEngineCallCount = 0
+  // Heartpath 5b (#1520): record signal-only source retirements + the session ids
+  // they targeted, so the kernel test can assert the retire fired (and NOT the old
+  // eligibility-gated rebuild) on an ineligible zero-signal take.
+  private(set) var retireCapturingSourceCallCount = 0
+  private(set) var retiredCaptureSessionIDs: [UInt64] = []
   private(set) var startEnginePhaseCallCount = 0
 
   /// When set, the Nth (1-based) `waitForFormatStabilization` call parks on a
@@ -146,6 +151,11 @@ final class FakeAudioCapture: AudioCaptureInterface {
   }
 
   func rebuildEngine() { rebuildEngineCallCount += 1 }
+
+  func retireCapturingSource(sessionID: UInt64) {
+    retireCapturingSourceCallCount += 1
+    retiredCaptureSessionIDs.append(sessionID)
+  }
 
   func preWarm() async throws {
     preWarmCallCount += 1

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -64,6 +64,11 @@ final class FakeAudioCapture: AudioCaptureInterface {
   // eligibility-gated rebuild) on an ineligible zero-signal take.
   private(set) var retireCapturingSourceCallCount = 0
   private(set) var retiredCaptureSessionIDs: [UInt64] = []
+  /// Heartpath 5b: the fence outcome this fake returns. Defaults to `.retired`
+  /// so kernel telemetry tests exercise the arming path; set to any no-op result
+  /// (e.g. `.sourceNotRunning`) to exercise the "emit event 1 but do not arm"
+  /// branch.
+  var retireCapturingSourceResult: ZeroSignalRetireResult = .retired
   private(set) var startEnginePhaseCallCount = 0
 
   /// When set, the Nth (1-based) `waitForFormatStabilization` call parks on a
@@ -152,9 +157,10 @@ final class FakeAudioCapture: AudioCaptureInterface {
 
   func rebuildEngine() { rebuildEngineCallCount += 1 }
 
-  func retireCapturingSource(sessionID: UInt64) {
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult {
     retireCapturingSourceCallCount += 1
     retiredCaptureSessionIDs.append(sessionID)
+    return retireCapturingSourceResult
   }
 
   func preWarm() async throws {

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -1,5 +1,6 @@
 import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 
 @testable import EnviousWisprPipeline
@@ -129,6 +130,14 @@ final class StopTimeZeroSignalTelemetryLog {
   var fired: [CaptureStallContext] = []
 }
 
+/// Heartpath 5b (#1520): records the kernel's dead-mic telemetry closures so a
+/// test can assert what fired without a real emitter. Reference type for the
+/// same pre-`self` capture constraint as `StopTimeZeroSignalTelemetryLog`.
+final class DeadMicTelemetryLog {
+  var retireAttempts: [DeadMicRetireAttemptContext] = []
+  var recoveries: [DeadMicRecoveryOutcome] = []
+}
+
 @MainActor
 final class KernelRecordingSession: RecordingSessionDriving {
   private let kernel: RecordingSessionKernel
@@ -152,6 +161,14 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// `HeartPathTelemetryEmitter`.
   var stopTimeZeroSignalTelemetryFired: [CaptureStallContext] { stopTimeTelemetryLog.fired }
 
+  /// Heartpath 5b (#1520): the shared capture-telemetry state, passed to the
+  /// kernel so arm-on-retire works. Production shares the SAME instance with the
+  /// lifecycle sink; kernel-only tests exercise the arm + later-retire path.
+  let captureTelemetry = CaptureTelemetryState()
+  private let deadMicLog = DeadMicTelemetryLog()
+  var deadMicRetireAttempts: [DeadMicRetireAttemptContext] { deadMicLog.retireAttempts }
+  var deadMicRecoveries: [DeadMicRecoveryOutcome] { deadMicLog.recoveries }
+
   init(
     engine: FakeEngine,
     capture: FakeAudioCapture,
@@ -173,6 +190,8 @@ final class KernelRecordingSession: RecordingSessionDriving {
     let limb = self.limb
     let telemetryState = self.telemetryState
     let stopTimeTelemetryLog = self.stopTimeTelemetryLog
+    let captureTelemetry = self.captureTelemetry
+    let deadMicLog = self.deadMicLog
     self.kernel = RecordingSessionKernel(
       adapter: engine,
       audioCapture: capture,
@@ -207,6 +226,13 @@ final class KernelRecordingSession: RecordingSessionDriving {
       // minimum-recording threshold would discard most scenarios. The
       // dedicated #4 coverage lives in `ConductorParitySeamTests`.
       minimumRecordingTicks: minimumRecordingTicks,
+      captureTelemetry: captureTelemetry,
+      deadMicRetireAttemptTelemetry: { [deadMicLog] ctx in
+        deadMicLog.retireAttempts.append(ctx)
+      },
+      deadMicRecoveryTelemetry: { [deadMicLog] outcome in
+        deadMicLog.recoveries.append(outcome)
+      },
       stopTimeZeroSignalTelemetry: { [stopTimeTelemetryLog] ctx in
         stopTimeTelemetryLog.fired.append(ctx)
       },

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -200,6 +200,7 @@ private final class NeverFinishingAudioCapture: AudioCaptureInterface {
     return CaptureResult(samples: [])
   }
   func rebuildEngine() {}
+  func retireCapturingSource(sessionID: UInt64) {}
   func preWarm() async throws {}
   func abortPreWarm() {
     continuation?.finish()

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -200,7 +200,7 @@ private final class NeverFinishingAudioCapture: AudioCaptureInterface {
     return CaptureResult(samples: [])
   }
   func rebuildEngine() {}
-  func retireCapturingSource(sessionID: UInt64) {}
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}
   func abortPreWarm() {
     continuation?.finish()

--- a/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
@@ -70,7 +70,7 @@ struct ZeroSignalRecoveryTests {
 
   // MARK: - Reactive exit: allZeroFromStart
 
-  @Test("reactive allZeroFromStart → the honest zero-signal terminal, no salvage, ONE rebuild")
+  @Test("reactive allZeroFromStart → the honest zero-signal terminal, no salvage, ONE retire")
   func reactiveAllZeroFromStartFinishesHonestly() async {
     let ctx = makeContext()
     await startToRecording(ctx)
@@ -89,8 +89,10 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.recordingOutcome == .failed(.zeroSignal))
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .allZeroFromStart)
     #expect(ctx.wrapper.testKernel.deliveredTranscript == nil)
-    // PR3: the poisoned capture pipeline is reset exactly once.
-    #expect(ctx.capture.rebuildEngineCallCount == 1)
+    // Heartpath 5b: the poisoned source is RETIRED exactly once (fenced signal-only
+    // path); the old eligibility-gated rebuild route is gone.
+    #expect(ctx.capture.retireCapturingSourceCallCount == 1)
+    #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
   @Test(
@@ -226,8 +228,9 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.recordingOutcome == .completed)
     #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .becameZeroMidCapture)
-    // PR3: the mic is reset AND the user still keeps the words they said.
-    #expect(ctx.capture.rebuildEngineCallCount == 1)
+    // Heartpath 5b: the mic is RETIRED AND the user still keeps the words they said.
+    #expect(ctx.capture.retireCapturingSourceCallCount == 1)
+    #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
   // MARK: - STOP-win: the detector never fired, classify at stop
@@ -250,8 +253,9 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.count == 1)
     #expect(
       ctx.wrapper.stopTimeZeroSignalTelemetryFired.first?.failureMode == .allZeroFromStart)
-    // PR3: the STOP-time backstop reaches the same single rebuild site.
-    #expect(ctx.capture.rebuildEngineCallCount == 1)
+    // Heartpath 5b: the STOP-time backstop retires the source once, no rebuild.
+    #expect(ctx.capture.retireCapturingSourceCallCount == 1)
+    #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
   @Test("STOP-win: meaningful prefix then zero suffix at stop salvages and completes")
@@ -273,7 +277,8 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.deliveredTranscript == "hello")
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == .becameZeroMidCapture)
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.count == 1)
-    #expect(ctx.capture.rebuildEngineCallCount == 1)
+    #expect(ctx.capture.retireCapturingSourceCallCount == 1)
+    #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
   // MARK: - Fast-follow: the zero-suffix trim (#1317, cloud review + live UAT repro)
@@ -372,8 +377,13 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.recordingOutcome.kind == .noSpeech)
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
-    // A genuinely MUTED mic is a hardware state, not a harness glitch. Resetting
-    // the engine would not unmute it — fail closed, never rebuild (§3.0).
+    // Heartpath 5b (#1520): the terminal stays honest `.noSpeech` (we never accuse
+    // the mic for a quiet/muted user), but we DO retire the source — a muted mic and
+    // a dead Bluetooth link are indistinguishable, and retiring is a cheap
+    // one-cold-reopen swap that rescues the dead-link-misreported-as-muted case. The
+    // OLD eligibility-gated rebuild never fired here — the #1520 propagation gap.
+    #expect(ctx.capture.retireCapturingSourceCallCount == 1)
+    #expect(ctx.capture.retiredCaptureSessionIDs == [ctx.capture.currentCaptureSessionID])
     #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
@@ -397,7 +407,8 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
     // The false-alarm guard that matters most: a healthy mic in a silent room
-    // must never trigger a capture-pipeline reset.
+    // (tiny non-zero noise, never exact zero) must never be retired or rebuilt.
+    #expect(ctx.capture.retireCapturingSourceCallCount == 0)
     #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
@@ -423,9 +434,10 @@ struct ZeroSignalRecoveryTests {
     // STOP-time telemetry never fires for a reactive win — the reactive
     // path's own event rides the WedgeRecoveryRouter funnel instead (§3.6).
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
-    // Both confirmation routes converge on ONE site, so a session confirmed by
-    // BOTH (had the guard been missing) still rebuilds exactly once.
-    #expect(ctx.capture.rebuildEngineCallCount == 1)
+    // Both confirmation routes converge on ONE retire, so a session confirmed by
+    // BOTH (had the guard been missing) still retires exactly once, no rebuild.
+    #expect(ctx.capture.retireCapturingSourceCallCount == 1)
+    #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
   // MARK: - PR3: the discard gates keep precedence over recovery
@@ -454,21 +466,23 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.testKernel.recordingOutcome.kind == .discarded)
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+    // Discarded as too-short BEFORE the zero-signal region — never retired.
+    #expect(ctx.capture.retireCapturingSourceCallCount == 0)
     #expect(ctx.capture.rebuildEngineCallCount == 0)
   }
 
   // MARK: - PR3: the zero-signal rebuild is independent of the format rebuild
 
   @Test(
-    "a session that ALSO rebuilt for an unstable format still issues exactly one zero-signal rebuild"
+    "a session that ALSO rebuilt for an unstable format still issues exactly one zero-signal retire"
   )
   func formatRebuildAndZeroSignalRebuildAreIndependent() async {
-    // Two different failures at two different lifecycle phases: the capture
-    // START phase rebuilds once for a format that never stabilised
-    // (RecordingSessionKernel:966), and the POST-STOP phase rebuilds once more
-    // because the harness then delivered dead audio. The PR3 invariant is
-    // exactly one ZERO-SIGNAL rebuild — not one rebuild of every kind per
-    // session — so the correct total here is 2.
+    // Two different failures at two different lifecycle phases, now via two
+    // DIFFERENT methods: the capture START phase REBUILDS once for a format that
+    // never stabilised (RecordingSessionKernel:966), and the POST-STOP phase
+    // RETIRES the source once because the harness then delivered dead audio.
+    // Heartpath 5b makes them even more clearly independent — different call sites,
+    // different methods.
     let ctx = makeContext()
     ctx.capture.stabilizationResults = [false, true]
     await startToRecording(ctx)
@@ -482,7 +496,8 @@ struct ZeroSignalRecoveryTests {
     await ctx.wrapper.drainReadyWork()
 
     #expect(ctx.wrapper.testKernel.recordingOutcome == .failed(.zeroSignal))
-    #expect(ctx.capture.rebuildEngineCallCount == 2)  // 1 format + 1 zero-signal
+    #expect(ctx.capture.rebuildEngineCallCount == 1)  // format-stabilization only
+    #expect(ctx.capture.retireCapturingSourceCallCount == 1)  // zero-signal
   }
 
   // MARK: - PR3: a poisoned source is never silently reused across presses
@@ -503,10 +518,11 @@ struct ZeroSignalRecoveryTests {
       await ctx.wrapper.drainReadyWork()
 
       #expect(ctx.wrapper.testKernel.recordingOutcome == .failed(.zeroSignal))
-      // Best-effort convergence (§3.3): the rebuild is fire-and-forget, so a
+      // Best-effort convergence (§3.3): the retire is fire-and-forget, so a
       // still-poisoned source on the next press must re-fire recovery rather
       // than silently hand the user another dead take.
-      #expect(ctx.capture.rebuildEngineCallCount == press)
+      #expect(ctx.capture.retireCapturingSourceCallCount == press)
+      #expect(ctx.capture.rebuildEngineCallCount == 0)
 
       await ctx.wrapper.apply(.reset)
       await ctx.wrapper.drainReadyWork()

--- a/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
@@ -1,5 +1,6 @@
 import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 import Testing
 
@@ -527,5 +528,88 @@ struct ZeroSignalRecoveryTests {
       await ctx.wrapper.apply(.reset)
       await ctx.wrapper.drainReadyWork()
     }
+  }
+
+  // MARK: - Heartpath 5b (#1520): dead-mic retire/recovery telemetry
+
+  @Test("eligible all-zero emits a retire-attempt: action=retired, health_guess_refused=false")
+  func deadMicTelemetryEligibleAllZero() async {
+    let ctx = makeContext()  // eligible by default
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech
+    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.deadMicRetireAttempts.count == 1)
+    let attempt = ctx.wrapper.deadMicRetireAttempts.first
+    #expect(attempt?.retireAction == "retired")
+    #expect(attempt?.failureShape == "all_zero_from_start")
+    // Eligible: the eligibility-gated stamp fired, so the retire did NOT run on
+    // the sample fact alone.
+    #expect(attempt?.healthGuessRefused == false)
+  }
+
+  @Test("ineligible all-zero (the #1520 gap) emits a retire-attempt with health_guess_refused=true")
+  func deadMicTelemetryIneligibleAllZero() async {
+    let ctx = makeContext(zeroSignalDeviceEligible: { false })
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech
+    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.wrapper.deadMicRetireAttempts.count == 1)
+    // The retire ran on the sample fact alone — the eligibility-gated stamp never
+    // fired. This is exactly the case 5b uniquely fixes.
+    #expect(ctx.wrapper.deadMicRetireAttempts.first?.healthGuessRefused == true)
+  }
+
+  @Test("a fenced no-op retire still emits the attempt but arms no recovery watch")
+  func deadMicTelemetryNoOpRetireDoesNotArm() async {
+    let ctx = makeContext()
+    ctx.capture.retireCapturingSourceResult = .sourceNotRunning  // fenced no-op
+
+    for _ in 1...2 {
+      await startToRecording(ctx)
+      ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+      ctx.vad.evidence = .confirmedNoSpeech
+      await ctx.wrapper.drainReadyWork()
+      await ctx.wrapper.apply(.stop)
+      await ctx.wrapper.drainReadyWork()
+      await ctx.wrapper.apply(.reset)
+      await ctx.wrapper.drainReadyWork()
+    }
+
+    #expect(ctx.wrapper.deadMicRetireAttempts.count == 2)  // both dead takes emit
+    #expect(
+      ctx.wrapper.deadMicRetireAttempts.allSatisfy { $0.retireAction == "source_not_running" })
+    // A no-op teardown is never armed, so a later retire can never be credited a
+    // recovery.
+    #expect(ctx.wrapper.deadMicRecoveries.isEmpty)
+  }
+
+  @Test("two consecutive real retires resolve the first as recovered=false, later_retire")
+  func deadMicTelemetryConsecutiveRetiresResolveLaterRetire() async {
+    let ctx = makeContext()  // default fake result is .retired
+
+    for _ in 1...2 {
+      await startToRecording(ctx)
+      ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+      ctx.vad.evidence = .confirmedNoSpeech
+      await ctx.wrapper.drainReadyWork()
+      await ctx.wrapper.apply(.stop)
+      await ctx.wrapper.drainReadyWork()
+      await ctx.wrapper.apply(.reset)
+      await ctx.wrapper.drainReadyWork()
+    }
+
+    // Press 1 armed a watch; press 2's real retire arms over it, resolving press
+    // 1's watch as a NON-recovery (the mic stayed broken).
+    #expect(ctx.wrapper.deadMicRecoveries.count == 1)
+    #expect(ctx.wrapper.deadMicRecoveries.first?.recovered == false)
+    #expect(ctx.wrapper.deadMicRecoveries.first?.resolution == "later_retire")
   }
 }

--- a/Tests/EnviousWisprTests/Services/CaptureTelemetryStateTests.swift
+++ b/Tests/EnviousWisprTests/Services/CaptureTelemetryStateTests.swift
@@ -38,7 +38,7 @@ struct CaptureTelemetryStateTests {
   func successResetsDedupe() {
     let state = CaptureTelemetryState()
     state.markZombieEmitted(route: "bt")
-    state.recordSuccessfulRecording()
+    state.recordSuccessfulRecording(recoveryTransport: "builtin", sessionID: 1)
     #expect(state.shouldEmitZombie(route: "bt", window: .seconds(30)) == true)
   }
 
@@ -46,7 +46,7 @@ struct CaptureTelemetryStateTests {
   func successSetsBaseline() {
     let state = CaptureTelemetryState()
     #expect(state.timeSinceLastSuccessfulRecordingMs() == nil)
-    state.recordSuccessfulRecording()
+    state.recordSuccessfulRecording(recoveryTransport: "builtin", sessionID: 1)
     let ms = state.timeSinceLastSuccessfulRecordingMs()
     #expect(ms != nil)
     #expect((ms ?? -1) >= 0)
@@ -91,9 +91,88 @@ struct CaptureTelemetryStateTests {
     let clock = ManualInstantClock()
     let state = CaptureTelemetryState(currentInstant: { clock.now })
     #expect(state.timeSinceLastSuccessfulRecordingMs() == nil)
-    state.recordSuccessfulRecording()
+    state.recordSuccessfulRecording(recoveryTransport: "builtin", sessionID: 1)
     clock.advance(by: .milliseconds(2_500))
     #expect(state.timeSinceLastSuccessfulRecordingMs() == 2_500)
+  }
+
+  // MARK: - Dead-mic recovery watch (#1520 heartpath 5b)
+
+  @Test("arm then a LATER session's success → recovered=true, later_success, gap from clock")
+  func armThenSuccessRecovers() {
+    let clock = ManualInstantClock()
+    let state = CaptureTelemetryState(currentInstant: { clock.now })
+
+    #expect(
+      state.armDeadMicWatch(
+        DeadMicRetireWatch(shape: "all_zero_from_start", transport: "bluetooth"), sessionID: 1)
+        == nil)
+    clock.advance(by: .milliseconds(1_200))
+    let outcome = state.recordSuccessfulRecording(recoveryTransport: "bluetooth", sessionID: 2)
+
+    #expect(outcome?.recovered == true)
+    #expect(outcome?.resolution == "later_success")
+    #expect(outcome?.retireShape == "all_zero_from_start")
+    #expect(outcome?.retireTransport == "bluetooth")
+    #expect(outcome?.recoveryTransport == "bluetooth")
+    #expect(outcome?.transportChanged == false)
+    #expect(outcome?.gapMs == 1_200)
+  }
+
+  @Test("the SAME session that armed the watch cannot resolve its own recovery (#1520 P1)")
+  func sameSessionCannotResolveItsOwnWatch() {
+    let state = CaptureTelemetryState()
+    // A becameZeroMidCapture take arms the watch at stop (session 7) AND then
+    // completes successfully by salvaging its prefix — the SAME session 7.
+    state.armDeadMicWatch(
+      DeadMicRetireWatch(shape: "became_zero_mid_capture", transport: "bluetooth"), sessionID: 7)
+    // Its own completion must NOT be credited as a recovery.
+    #expect(state.recordSuccessfulRecording(recoveryTransport: "bluetooth", sessionID: 7) == nil)
+    // The watch is still pending: a genuinely later session (8) resolves it.
+    let later = state.recordSuccessfulRecording(recoveryTransport: "bluetooth", sessionID: 8)
+    #expect(later?.recovered == true)
+    #expect(later?.resolution == "later_success")
+  }
+
+  @Test(
+    "arm while a watch is pending → prior resolves recovered=false, later_retire; new watch armed")
+  func armWhilePendingResolvesPriorAsNotRecovered() {
+    let clock = ManualInstantClock()
+    let state = CaptureTelemetryState(currentInstant: { clock.now })
+
+    #expect(
+      state.armDeadMicWatch(
+        DeadMicRetireWatch(shape: "all_zero_from_start", transport: "bluetooth"), sessionID: 1)
+        == nil)
+    clock.advance(by: .milliseconds(800))
+    let prior = state.armDeadMicWatch(
+      DeadMicRetireWatch(shape: "became_zero_mid_capture", transport: "bluetooth"), sessionID: 2)
+
+    #expect(prior?.recovered == false)
+    #expect(prior?.resolution == "later_retire")
+    #expect(prior?.retireShape == "all_zero_from_start")
+    #expect(prior?.gapMs == 800)
+
+    // The new watch is now pending: a later success resolves IT, not the prior.
+    let resolved = state.recordSuccessfulRecording(recoveryTransport: "builtin", sessionID: 3)
+    #expect(resolved?.recovered == true)
+    #expect(resolved?.retireShape == "became_zero_mid_capture")
+    #expect(resolved?.transportChanged == true)  // bluetooth armed → builtin recovered
+  }
+
+  @Test("success with no pending watch → nil (no fabricated outcome)")
+  func successWithNoWatchIsNil() {
+    let state = CaptureTelemetryState()
+    #expect(state.recordSuccessfulRecording(recoveryTransport: "builtin", sessionID: 1) == nil)
+  }
+
+  @Test("transport_changed reflects a transport-class change at resolution")
+  func transportChangedFlag() {
+    let state = CaptureTelemetryState()
+    state.armDeadMicWatch(
+      DeadMicRetireWatch(shape: "all_zero_from_start", transport: "bluetooth"), sessionID: 1)
+    let outcome = state.recordSuccessfulRecording(recoveryTransport: "builtin", sessionID: 2)
+    #expect(outcome?.transportChanged == true)
   }
 }
 


### PR DESCRIPTION
## What

When a completed take delivers zero sound (the signature of a dropped Bluetooth voice link, a muted device, or permission-denied zeroing), the microphone source that captured it is now retired so the next press opens a fresh one and re-establishes the link. Fixes the #1520 propagation harm: previously the retire only fired when a device-liveness guess agreed, and that guess refuses on exactly the dead-Bluetooth case (the device reports alive + unmuted while delivering pure silence), so one dead take was reused for ~30s and became a multi-minute outage.

Part of #1511 (heartpath refactor, step 5b). Part of #1520.

## The change

- The retire fires when the take is zero-signal by **either** route: the stop-time sample fact (device-independent, so it fires even when the eligibility guess refused — the #1520 fix), or the reactive detector's stamp. It no longer depends on the device-blame guess.
- Terminal outcome, telemetry, salvage-trim, and the reactive detector are **unchanged**: an eligible all-zero still shows "Mic problem. Resetting it."; an ineligible/quiet all-zero still shows "you said nothing" — no dishonest copy for a quiet user. Bounded cost: a deliberately-silent user pays one cold reopen on the next press.
- New fenced primitive `retireCapturingSource(sessionID:)` tears down **only** the source that captured the given session and **only** while it is still the running active source — fenced on session id, retained-source reference identity (`===`, not `ObjectIdentifier`), and running-state, so a stale finish can never tear down a newer take's source. It shares one destructive helper (`rebuildActiveSource`) with `rebuildEngine`; the retained source is cleared at every teardown site. A second post-stop barrier (`recordingOutcome == nil`) closes the cancel-during-stopping window.
- The old eligibility-gated `rebuildEngine()` zero-signal call is removed; `rebuildEngine` keeps only its format-stabilization-retry caller.

## Validation

- Logic tests: full suite green (2790 + 154 tests). New: 5 manager-fence tests (session-id / retained-`===` / running-state / retain-release) plus the flipped zero-signal suite — an **ineligible** all-zero now retires, which is the #1520 proof.
- Codex code-diff review: clean, no actionable defects.
- Live UAT (built-in mic): heart path completes end to end, `Pipeline timing TOTAL 0.736s`, zero spurious retires on a normal take.
- **Bluetooth Live UAT pending** — the dead-link reopen (the one case that needs real AirPods hardware) is verified with the founder before merge.

Plan + 4-round grounded review live in `docs/feature-requests/` (local). Council skipped (heartpath D-021).
