### PR TITLE
chore(telemetry): retire duplicate metric.pipeline.e2e_seconds event

### DIFF
--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -155,11 +155,6 @@ public final class TelemetryService {
       salvagedLeadTrimMs: salvagedLeadTrimMs,
       interruptedBy: interruptedBy
     )
-    if let e2e = m?.e2eSeconds {
-      metricPipelineE2E(
-        seconds: e2e, inputMode: inputMode, asrBackend: t.backendType.rawValue,
-        llmProvider: t.llmProvider, result: "success")
-    }
     if let asrLat = m?.asrLatencySeconds {
       asrCompleted(
         backend: t.backendType.rawValue, result: "success", coldStart: m?.coldStart ?? false,
@@ -1451,22 +1446,6 @@ public final class TelemetryService {
       if let ms = result.durationMs { props["gate_\(key)_ms"] = ms }
     }
     PostHogSDK.shared.capture("ai_diagnostics.run_completed", properties: props)
-  }
-
-  // MARK: - Metrics
-
-  public func metricPipelineE2E(
-    seconds: Double, inputMode: String, asrBackend: String,
-    llmProvider: String?, result: String
-  ) {
-    var props: [String: Any] = [
-      "input_mode": inputMode,
-      "asr_backend": asrBackend,
-      "result": result,
-      "$value": seconds,
-    ]
-    if let p = llmProvider { props["llm_provider"] = p }
-    PostHogSDK.shared.capture("metric.pipeline.e2e_seconds", properties: props)
   }
 
   // MARK: - Multilingual v1 (language detection lifecycle)


### PR DESCRIPTION
## Summary
- `metric.pipeline.e2e_seconds` fired from the same call site as `dictation.completed`, under the same success condition (`if let e2e = m?.e2eSeconds`) — identical 30-day counts (11,548 events / 280 users, both) confirmed the collapse
- `dictation.completed` already stamps the identical `$value` (`e2eSeconds`) in addition to its own formatted `e2e_seconds` property, so the standalone event carried zero information the other didn't already have
- Repointed the one real consumer (PostHog insight 7521320, "E2E Latency p50/p95" on the Pipeline Performance dashboard) from the deleted event to `dictation.completed`'s existing `$value` — same chart, same math, verified live via the PostHog API before deleting the emitter (confirmed no other insight referenced it)
- Deleted `TelemetryService.metricPipelineE2E` and its call site; removed the stale knowledge-base row

## Test plan
- [x] Full `scripts/xcode-test.sh` suite: 2959 tests, green
- [x] Codex code-diff review: clean, no findings
- [x] Dev app smoke build + launch: no crash
- [x] PostHog insight 7521320 re-fetched post-PATCH: both series now read `dictation.completed`
- Live UAT: N/A — pure telemetry-emission deletion, no user-visible behavior change

Closes #1450