### PR TITLE
refactor(ui): one narrator for terminal error + interruption pill copy (Part of #1511)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -28,6 +28,10 @@ final class RecordingStarter {
   /// reference an init param) is today's block; a test injects a counting spy.
   let accessibilityRefresh: @MainActor () -> Void
 
+  /// #1558 — narrow live mic-permission check the prewarm error router reads so a
+  /// denied-permission start surfaces "Microphone access is off." Bound in init.
+  let micPermissionDenied: @MainActor () -> Bool
+
   /// Arms the crash-recovery limb for a recording about to start, returning the
   /// durable session id + opaque directive payload (nil when recovery is off or
   /// could not arm). A bare closure so it stays off this start-path home's
@@ -162,6 +166,7 @@ final class RecordingStarter {
         perms.refreshAccessibilityStatus()
         if !perms.hasAccessibilityPermission { perms.restartMonitoringIfNeeded() }
       }
+    self.micPermissionDenied = { perms.microphonePermissionIsDenied }
   }
 
   /// Hotkey PTT start path. Mirrors the former root-state file (pre-PR10):
@@ -248,12 +253,21 @@ final class RecordingStarter {
         stage: "recording", message: "preWarm failed — start aborted",
         level: .warning, data: ["error": String(describing: error)]
       )
-      let nsError = error as NSError
-      let noMic =
-        nsError.domain == AudioError.errorDomain
-        && nsError.code == AudioError.noBuiltInMicrophoneFound.errorCode
-      // #1558: emit a TYPED reason; the presenter authors the sentence.
-      active.setTerminalReason(noMic ? .noMicrophoneFound : .micWouldNotOpen)
+      // #1558: emit a TYPED reason (presenter authors the sentence). A denied
+      // mic is the real, user-actionable cause of a prewarm failure regardless
+      // of the thrown error's wording, so it is checked FIRST; only then fall
+      // back to no-device vs generic capture failure.
+      let reason: TerminalNoticeReason
+      if micPermissionDenied() {
+        reason = .permissionDenied
+      } else {
+        let nsError = error as NSError
+        let noMic =
+          nsError.domain == AudioError.errorDomain
+          && nsError.code == AudioError.noBuiltInMicrophoneFound.errorCode
+        reason = noMic ? .noMicrophoneFound : .micWouldNotOpen
+      }
+      active.setTerminalReason(reason)
       return
     }
     guard !Task.isCancelled else {

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -252,10 +252,8 @@ final class RecordingStarter {
       let noMic =
         nsError.domain == AudioError.errorDomain
         && nsError.code == AudioError.noBuiltInMicrophoneFound.errorCode
-      active.setExternalError(
-        noMic
-          ? "No microphone found. Please connect a microphone."
-          : "Microphone unavailable — try again.")
+      // #1558: emit a TYPED reason; the presenter authors the sentence.
+      active.setTerminalReason(noMic ? .noMicrophoneFound : .micWouldNotOpen)
       return
     }
     guard !Task.isCancelled else {
@@ -326,8 +324,8 @@ final class RecordingStarter {
     } catch {
       heartControlRecovery.recover(
         error: error, op: "toggle-from-prewarm",
-        message: ModelLoadWatchdog.userMessage,
-        setExternalError: active.setExternalError)
+        reason: .modelWedged,
+        setTerminalReason: active.setTerminalReason)
       return
     }
     let totalMs = Self.elapsedMs(since: pttStart)
@@ -360,7 +358,7 @@ final class RecordingStarter {
       )
       recordingOverlay.show(intent: .hidden)
       recordingLockedAccess.set(false)
-      active.setExternalError(ModelLoadWatchdog.userMessage)
+      active.setTerminalReason(.modelWedged)
       return
     }
     if !pipelineActive && !pipelineInError && userStoppedDuringStart {
@@ -468,8 +466,8 @@ final class RecordingStarter {
     } catch {
       heartControlRecovery.recover(
         error: error, op: "toggle",
-        message: ModelLoadWatchdog.userMessage,
-        setExternalError: active.setExternalError)
+        reason: .modelWedged,
+        setTerminalReason: active.setTerminalReason)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/HeartControlRecovery.swift
+++ b/Sources/EnviousWisprAppKit/App/HeartControlRecovery.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
 
@@ -7,8 +8,9 @@ import Foundation
 /// Two shapes:
 /// - `logDispatchFailure` — log only. Use when the caller has already reset overlay + lock
 ///   before the dispatch (Stop, WhisperKit Cancel paths).
-/// - `recover` — full recovery: log, hide overlay, clear lock, surface user-facing message
-///   via the driver's `setExternalError` closure. Use when the caller has NOT pre-reset state (Toggle paths).
+/// - `recover` — full recovery: log, hide overlay, clear lock, surface the terminal notice
+///   via the driver's `setTerminalReason` closure (#1558: a TYPED reason, not English — the
+///   presenter authors the sentence). Use when the caller has NOT pre-reset state (Toggle paths).
 ///
 /// `CancellationError` is treated as a coordinated unwind in both shapes: skipped from the
 /// log (mirrors prior inline behavior at the former root-state file pre-warm catch), but `recover`
@@ -27,8 +29,8 @@ struct HeartControlRecovery {
   }
 
   func recover(
-    error: any Error, op: String, message: String,
-    setExternalError: @MainActor (String) -> Void
+    error: any Error, op: String, reason: TerminalNoticeReason,
+    setTerminalReason: @MainActor (TerminalNoticeReason) -> Void
   ) {
     let isCancellation = error is CancellationError
     if !isCancellation {
@@ -39,7 +41,7 @@ struct HeartControlRecovery {
     hideOverlay()
     setLocked(false)
     if !isCancellation {
-      setExternalError(message)
+      setTerminalReason(reason)
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -200,7 +200,9 @@ final class RecordingOverlayPanel {
           .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
         ])
       showWarning(message: message)
-    case .error(let message):
+    case .error(let reason):
+      // #1558: the presenter is the sole author of the sentence.
+      let message = TerminalNoticePresenter.copy(for: reason)
       NSAccessibility.post(
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
@@ -209,7 +211,8 @@ final class RecordingOverlayPanel {
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       showError(message: message)
-    case .interruption(let message):
+    case .interruption(let reason):
+      let message = TerminalNoticePresenter.copy(for: reason)
       NSAccessibility.post(
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,

--- a/Sources/EnviousWisprAppKit/App/TerminalNoticePresenter.swift
+++ b/Sources/EnviousWisprAppKit/App/TerminalNoticePresenter.swift
@@ -1,0 +1,43 @@
+import EnviousWisprCore
+
+/// #1558 (heartpath E1). The single, stateless authority that turns a typed
+/// `TerminalNoticeReason` into the customer-facing sentence shown on the pill
+/// and the main window when a dictation could not complete or was cut short.
+///
+/// This is the "what we say" half of the one-voice split: the engine emits the
+/// fact (`TerminalNoticeReason`), this presenter — and ONLY this presenter —
+/// authors the English. It lives in AppKit because the engine modules that
+/// produce the reason sit below AppKit and cannot author UI copy without
+/// inverting dependency direction. Stateless (an `enum` with a static func):
+/// neither stored nor environment-injected. Promote to an injected instance
+/// only if a test ever needs to swap the mapping.
+///
+/// The six sentences are founder-LOCKED (issue #1558, 2026-07-15). The design
+/// rule: `[Category] error. Try again.` = our bug, just retry (a deliberate
+/// self-triage channel — a user reporting "Transcription error" names the stage
+/// with no logs); a plain sentence = a true event that happened. Raw internal
+/// detail never reaches here — it stays owned by the producer's Sentry site.
+enum TerminalNoticePresenter {
+  static func copy(for reason: TerminalNoticeReason) -> String {
+    switch reason {
+    // Our-fault start / capture failures → retry.
+    case .prepareFailed, .modelWedged, .modelLoadFailed, .captureStartFailed,
+      .micWouldNotOpen, .captureStalled, .zeroSignal:
+      return "Audio capture error. Try again."
+    // Our-fault transcribe failures (incl. "couldn't catch that") → retry.
+    case .asrFailed, .asrWedged, .asrInterrupted, .noAudioCaptured,
+      .asrEmptyWithSpeech, .emptyAfterProcessing, .unknown:
+      return "Transcription error. Try again."
+    // User-actionable.
+    case .permissionDenied:
+      return "Microphone access is off."
+    case .noMicrophoneFound:
+      return "No microphone found. Please connect one."
+    // Informational interruptions (audio was saved).
+    case .deviceRemoved:
+      return "Microphone disconnected."
+    case .engineLost, .unknownInterruption:
+      return "Recording interrupted."
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
@@ -170,11 +170,12 @@ struct StatusView: View {
           }
         }
 
-      case .error(let msg):
+      case .error(let reason):
         ContentUnavailableView {
           Label("Error", systemImage: "exclamationmark.triangle")
         } description: {
-          Text(msg)
+          // #1558: the presenter is the sole author; no raw detail reaches here.
+          Text(TerminalNoticePresenter.copy(for: reason))
         } actions: {
           Button("Try Again") {
             dictationRuntime.resetActivePipeline()

--- a/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
+++ b/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
@@ -44,7 +44,10 @@ public enum AudioError: LocalizedError, CustomNSError, Sendable {
     switch self {
     case .formatCreationFailed: return "Failed to create audio format."
     case .alreadyCapturing: return "Audio capture is already active."
-    case .noBuiltInMicrophoneFound: return "No microphone found. Please connect a microphone."
+    // #1558: diagnostic-only text. The customer sentence ("No microphone
+    // found. Please connect one.") lives ONLY in `TerminalNoticePresenter`;
+    // this description is Sentry / diagnostic copy, never shown on a pill.
+    case .noBuiltInMicrophoneFound: return "No usable microphone device was found."
     }
   }
 

--- a/Sources/EnviousWisprCore/AppSettings.swift
+++ b/Sources/EnviousWisprCore/AppSettings.swift
@@ -21,7 +21,7 @@ public enum PipelineState: Equatable, Sendable {
   case transcribing
   case polishing
   case complete
-  case error(String)
+  case error(TerminalNoticeReason)
 
   public var isActive: Bool {
     switch self {

--- a/Sources/EnviousWisprCore/ModelLoadWatchdog.swift
+++ b/Sources/EnviousWisprCore/ModelLoadWatchdog.swift
@@ -9,14 +9,12 @@ import Foundation
 /// cancel, fresh helper on next press).
 ///
 /// The wall-clock `deadlineMs` constant from the prior design is gone; the
-/// trigger is now signal-based (`LoadProgressWatcher`). `WedgeError` and
-/// `userMessage` remain because the recovery surface (Sentry event +
-/// user-visible "tap to retry" overlay) is unchanged.
+/// trigger is now signal-based (`LoadProgressWatcher`). `WedgeError` remains
+/// because the recovery surface (Sentry event + the user-visible retry
+/// overlay) is unchanged. #1558 removed the `userMessage` copy constant: a
+/// wedge now maps to the typed `TerminalNoticeReason.modelWedged`, and the
+/// AppKit presenter authors the sentence.
 public enum ModelLoadWatchdog {
-  /// User-visible recovery message shown when the watcher fires.
-  /// Set on the active pipeline via `setExternalError(...)` after recovery.
-  public static let userMessage: String = "Speech engine isn't responding, tap to retry."
-
   /// Synthetic error type used when capturing the wedge to Sentry.
   /// The wedge is silent (no thrown error from the underlying call); we
   /// fabricate one so the existing `SentryBreadcrumb.captureError(...)` API

--- a/Sources/EnviousWisprCore/PipelineStateProtocol.swift
+++ b/Sources/EnviousWisprCore/PipelineStateProtocol.swift
@@ -12,7 +12,7 @@ public enum PipelineActivity: Equatable, Sendable {
   case recording
   case processing
   case complete
-  case error(String)
+  case error(TerminalNoticeReason)
 }
 
 /// Narrow protocol the planner / handler consume. Backends' concrete enums
@@ -36,7 +36,7 @@ extension PipelineState: PipelineStateProtocol {
     case .recording: return .recording
     case .transcribing, .polishing: return .processing
     case .complete: return .complete
-    case .error(let msg): return .error(msg)
+    case .error(let reason): return .error(reason)
     }
   }
 }

--- a/Sources/EnviousWisprCore/TerminalNoticeReason.swift
+++ b/Sources/EnviousWisprCore/TerminalNoticeReason.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// #1558 (heartpath E1). A presentation-neutral, typed enumeration of the
+/// distinct terminal-failure / interruption FACTS the UI narrates when a
+/// dictation could not complete or was cut short.
+///
+/// This is the "what happened" half of the one-voice split: the engine
+/// (Pipeline / AppKit-side start path) maps its internal outcomes into exactly
+/// one case here, and a single stateless presenter in AppKit
+/// (`TerminalNoticePresenter`) maps a case to the customer sentence. Keeping the
+/// fact separate from the sentence is the whole point — if the engine emitted
+/// the six customer buckets it would be making the presentation decision this
+/// refactor is centralising.
+///
+/// Lives in `EnviousWisprCore` (the bottom module) because both Core-level
+/// state carriers — `PipelineState.error` and `PipelineActivity.error` — hold
+/// it, and Core cannot reference the Pipeline/Audio types the reasons are
+/// mapped FROM without inverting dependency direction.
+///
+/// `String`-raw so the telemetry boundary can read a stable code without
+/// re-deriving one. The raw value is NEVER shown to a user: it is the stable
+/// PostHog `pipeline.failed.error_code`; Sentry keeps its existing
+/// producer-owned taxonomy. Customer copy lives ONLY in the AppKit presenter.
+public enum TerminalNoticeReason: String, Equatable, Sendable, CaseIterable {
+  // Start / capture-stage failures → "Audio capture error. Try again."
+  case prepareFailed = "prepare_failed"
+  case modelWedged = "model_wedged"
+  case modelLoadFailed = "model_load_failed"
+  case captureStartFailed = "capture_start_failed"
+  case micWouldNotOpen = "mic_would_not_open"
+  case captureStalled = "capture_stalled"
+  case zeroSignal = "zero_signal"
+
+  // Transcribe-stage failures → "Transcription error. Try again."
+  case asrFailed = "asr_failed"
+  case asrWedged = "asr_wedged"
+  case asrInterrupted = "asr_interrupted"
+  case noAudioCaptured = "no_audio_captured"
+  case asrEmptyWithSpeech = "asr_empty_with_speech"
+  case emptyAfterProcessing = "empty_after_processing"
+
+  // User-actionable
+  case permissionDenied = "permission_denied"
+  case noMicrophoneFound = "no_microphone_found"
+
+  // Informational interruptions (audio saved)
+  case deviceRemoved = "device_removed"
+  case engineLost = "engine_lost"
+  /// A capture interruption arrived with no stamped `EngineInterruptionCause`
+  /// (nil). Narrates as the neutral "Recording interrupted." — the same choice
+  /// the retired `InterruptionMessages` made for a nil cause.
+  case unknownInterruption = "unknown_interruption"
+
+  /// Reserved typed fallback with no current producer. Both engine maps are
+  /// exhaustive (no `default`), so this is never the result of an unmapped
+  /// enum case; any future explicit producer must own its own telemetry first.
+  case unknown
+}

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1519,6 +1519,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     case .modelWedged: return .modelWedged
     case .modelLoadFailed: return .modelLoadFailed
     case .captureStartFailed: return .captureStartFailed
+    case .noMicrophoneFound: return .noMicrophoneFound
     case .noAudioCaptured: return .noAudioCaptured
     case .asrEmpty: return .asrEmptyWithSpeech
     case .asrFailed: return .asrFailed

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -276,10 +276,12 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// and the frontmost app / focused element at recording start.
   private let context: KernelSessionContext
 
-  /// External-error surface (PR-4 §3.7). `kernel.cancel()` alone maps to a
-  /// `.hidden` overlay, so the driver owns the error state pushed in from
-  /// outside (`setExternalError`). Cleared on the next start / reset.
-  private var lastExternalError: String?
+  /// External-error surface (PR-4 §3.7; #1558 typed). `kernel.cancel()` alone
+  /// maps to a `.hidden` overlay, so the driver owns the terminal reason pushed
+  /// in from outside (`setTerminalReason`). Carries a TYPED
+  /// `TerminalNoticeReason`, never authored English — the AppKit presenter
+  /// speaks the sentence. Cleared on the next start / reset.
+  private var lastTerminalReason: TerminalNoticeReason?
 
   /// #959 — set by `ASREventRouter` when the OS reaps this engine's idle ASR
   /// service while a resident model was loaded (readiness drops to `.notReady`
@@ -342,7 +344,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// session's `.cancelled` terminal. `.cancelled` is reached by BOTH a genuine
   /// user cancel (`RecordingFinalizer.cancel()` → `cancelRecording(disposition:
   /// .discard)`) AND fault/system cancels that route through `kernel.cancel()`
-  /// (active `reset()`, `setExternalError()`, the settings-rebuild cancel). A user
+  /// (active `reset()`, `setTerminalReason()`, the settings-rebuild cancel). A user
   /// cancel should DELETE the spool; a fault cancel should RETAIN recoverable
   /// audio. Defaults to `.failure` (RETAIN) so any cancel NOT explicitly attributed
   /// as a user discard conservatively keeps the audio. Set at the `cancelRecording`
@@ -403,7 +405,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     self.adapter = adapter
     self.captureErrorSink = captureErrorSink
     self.lastFiredState = Self.pipelineState(
-      for: kernel.state, outcome: kernel.recordingOutcome, externalError: nil)
+      for: kernel.state, outcome: kernel.recordingOutcome, externalReason: nil)
     self.lastEndedWithoutSaveSessionID = nil
   }
 
@@ -616,8 +618,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     Self.pipelineState(
       for: kernel.state, outcome: kernel.recordingOutcome,
       deliveringPhase: kernel.deliveringPhase,
-      externalError: lastExternalError,
-      failureDetail: kernel.lastFailureDetail,
+      externalReason: lastTerminalReason,
       interruptionCause: kernel.lastAudioInterruptionCause)
   }
 
@@ -698,9 +699,9 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// "Try Again" button, which renders only when the driver's
   /// `pipelineState` is `.error`. Most `.error` mappings come from
   /// terminal kernel states (`.failed`, `.audioInterrupted`,
-  /// `.asrInterrupted`), but `lastExternalError` can also surface
+  /// `.asrInterrupted`), but `lastTerminalReason` can also surface
   /// `.error` while the kernel is still in an active state — the mic
-  /// disconnect / ASR crash paths route through `setExternalError(...)`
+  /// disconnect / ASR crash paths route through `setTerminalReason(...)`
   /// from `.preparing`, `.warmingUp`, `.stopping`, `.transcribing`, and
   /// `.finalizing` (see `handleEngineInterruption` / `handleASRServiceInterruption`).
   /// Active-state `reset()` is therefore a real production path, not a
@@ -717,11 +718,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// completion from an active state, use `cancelRecording()` + `reset()`
   /// (async-then-sync), or wait for the kernel-state observer to fire
   /// with the terminal state. The external-error surface that "Try Again"
-  /// re-enters from is cleared synchronously here via `lastExternalError =
+  /// re-enters from is cleared synchronously here via `lastTerminalReason =
   /// nil`, so the user-visible `.error` resolves immediately even when the
   /// kernel itself takes another tick to reach `.idle`.
   public func reset() {
-    lastExternalError = nil
+    lastTerminalReason = nil
     if !Self.isTerminal(kernel.state) {
       // Best-effort: request cancellation. Caller-visible state will not
       // reach `.idle` synchronously from `.recording` / `.transcribing` —
@@ -747,7 +748,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // Clear the post-recording polish error alongside the transcript — both
       // are last-session outcome fields surfaced publicly (`currentTranscript`
       // / `lastPolishError`). Idle-gated (not unconditional like
-      // `lastExternalError`) for the same reason as the transcript: a `reset()`
+      // `lastTerminalReason`) for the same reason as the transcript: a `reset()`
       // that no-ops because the kernel sits in `.finalizing` must leave the
       // in-flight outcome intact for completion telemetry. Without this, a
       // prior session's "AI polish failed" surface lingered into the next
@@ -786,7 +787,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// `handleEngineInterruption()` (old Parakeet pipeline)
   /// was state-agnostic: emit Sentry+PostHog state change, cancel cleanup,
   /// flip UI to the mic-disconnect error. Bridge matrix #4 ports the old
-  /// behavior for those states via `setExternalError`.
+  /// behavior for those states via `setTerminalReason`.
   public func handleEngineInterruption(_ cause: EngineInterruptionCause) {
     switch kernel.state {
     case .live:
@@ -796,7 +797,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // `.audioInterrupted` from here (§5.2 parity), so the lifecycle sink's
       // `.audioInterrupted` handler never fires.
       SentryBreadcrumb.updateRecordingState(active: false)
-      setExternalError(InterruptionMessages.message(for: cause))
+      setTerminalReason(Self.terminalNoticeReason(for: cause))
     case .idle:
       // Already idle / concluded — no useful action. Router-stale calls
       // land here.
@@ -814,7 +815,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// was state-agnostic: always emit the `xpc_service_error` Sentry event +
   /// flip the UI to the ASR-crash error. Bridge matrix #2 ports the old
   /// behavior for `.preparing`, `.warmingUp`, `.stopping`, `.finalizing`
-  /// via direct Sentry emission + `setExternalError`.
+  /// via direct Sentry emission + `setTerminalReason`.
   public func handleASRServiceInterruption() {
     // `.live` and `.delivering(.transcribing)` route to the kernel FSM; every
     // other active state (including the `delivering(.finalizing(_))` safe point)
@@ -857,7 +858,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
           ]),
         .xpcServiceError, "asr",
         ["was_recording": false, "backend": backendID], nil)
-      setExternalError(Self.asrInterruptedMessage)
+      setTerminalReason(.asrInterrupted)
     }
   }
 
@@ -922,8 +923,8 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   }
 
   public var overlayIntent: OverlayIntent {
-    if let lastExternalError {
-      return .error(message: lastExternalError)
+    if let lastTerminalReason {
+      return .error(reason: lastTerminalReason)
     }
     // A concluded session carries its ending category on `recordingOutcome`
     // (state has returned to `.idle`, #1548 D1). The ending pill reads from the
@@ -933,20 +934,18 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       case .completed, .cancelled, .discarded, .noSpeech:
         return .hidden
       case .failed(let reason):
-        // Thread `kernel.lastFailureDetail` so the overlay surfaces the same
-        // enriched "Model load failed: <detail>" / "Recording failed: <detail>"
-        // / "Transcription failed: <detail>" string the `state` getter does.
-        return .error(
-          message: Self.failureMessage(reason, detail: kernel.lastFailureDetail))
+        // #1558: emit the TYPED reason; the raw detail stays owned by the
+        // producer's Sentry site and never reaches the pill.
+        return .error(reason: Self.terminalNoticeReason(for: reason))
       case .noTransport:
-        // Existing "No audio captured" copy (locked projection, §4 / §7) — no
-        // new user-facing string.
-        return .error(message: Self.failureMessage(.noAudioCaptured, detail: nil))
+        // No audio transport arrived — same "no audio to turn into text"
+        // outcome as an empty buffer (parity with the prior "No audio captured").
+        return .error(reason: .noAudioCaptured)
       case .audioInterrupted:
         return .interruption(
-          message: InterruptionMessages.message(for: kernel.lastAudioInterruptionCause))
+          reason: Self.terminalNoticeReason(for: kernel.lastAudioInterruptionCause))
       case .asrInterrupted:
-        return .error(message: Self.asrInterruptedMessage)
+        return .error(reason: .asrInterrupted)
       }
     }
     switch kernel.state {
@@ -1007,7 +1006,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         // `context.config` for the wiring's `processText` / `deliver`
         // closures to read at finalize time (the wiring's optional-chained
         // reads were always-nil in production until this PR — finding #6).
-        lastExternalError = nil
+        lastTerminalReason = nil
         // #1063 PR2: a fresh session starts with the conservative cancel
         // disposition (RETAIN) — only a genuine user cancel during this session
         // flips it to discard. Prevents a stale user-discard from a prior session
@@ -1065,7 +1064,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     case .cancelRecording:
       kernel.cancel()
     case .reset:
-      lastExternalError = nil
+      lastTerminalReason = nil
       kernel.reset()
       // Same guard as the sync `reset()` method above — only clear once the
       // kernel actually lands at idle, so a `.reset` event arriving during
@@ -1080,7 +1079,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       }
       // PR-4.5 #9 (Codex r5): when the kernel is already idle, `reset()` is a
       // no-op, so the kernel-state observation does NOT fire. After
-      // `setExternalError` parked the observer on `.error`, that observer
+      // `setTerminalReason` parked the observer on `.error`, that observer
       // would stay stuck. Driving the fan-out directly mirrors the #9 fix on
       // the error-set side.
       fireStateChangeIfNeeded()
@@ -1092,7 +1091,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// start / reset clears it.
   ///
   /// PR-4.5 #9: also fires `onStateChange` directly with the mapped `.error`
-  /// state. The state mapper reads `lastExternalError`, so the *driver's*
+  /// state. The state mapper reads `lastTerminalReason`, so the *driver's*
   /// public state did change; but the kernel-state observer at
   /// `observeKernelState` only fires when `kernel.state` itself changes. When
   /// `kernel.cancel()` is a no-op (kernel already idle / terminal — common
@@ -1100,10 +1099,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// runs and the lifecycle coordinator never learns about the error. Direct
   /// fire-through ensures the error reaches the overlay / hotkey teardown
   /// path regardless of kernel-state movement.
-  public func setExternalError(_ message: String) {
+  public func setTerminalReason(_ reason: TerminalNoticeReason) {
     kernel.cancel()
     outcome.transcript = nil
-    lastExternalError = message
+    lastTerminalReason = reason
     fireStateChangeIfNeeded()
   }
 
@@ -1434,16 +1433,14 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// states. `state.isActive` is `true` for every active kernel state, which
   /// the `PipelineSettingsSync` backend-switch guard depends on (§3.13).
   ///
-  /// `failureDetail` is the underlying-error `localizedDescription` for the
-  /// three reasons the old Parakeet pipeline embedded into its error strings
-  /// (model load, recording start, transcription); the static map embeds it
-  /// when present and falls back to the parity-bare string when nil. The
-  /// driver's instance `state` getter threads `kernel.lastFailureDetail`
-  /// through; existing test callers pass nil for byte-parity coverage.
-  /// `interruptionCause` selects the audio-interruption sentence (#1408). It
-  /// defaults to nil, which yields the neutral "Recording interrupted" line —
-  /// never a disconnect claim. Only the instance `state` getter has a kernel to
-  /// read the real cause from; test callers keep the byte-parity default.
+  /// #1558: `externalReason` and the outcome map now yield a TYPED
+  /// `TerminalNoticeReason`; the AppKit presenter authors the sentence, so the
+  /// raw underlying-error detail (once embedded here as
+  /// "Model load failed: <detail>") never reaches a user surface — it stays
+  /// owned by the producer's Sentry site. `interruptionCause` selects the
+  /// audio-interruption reason (#1408): nil yields `.unknownInterruption` (the
+  /// neutral "Recording interrupted." line), never a disconnect claim. Only the
+  /// instance `state` getter has a kernel to read the real cause from.
   // Internal (was public): the signature now names the internal
   // `RecordingOutcome` / `DeliveringPhase` types. No App-layer caller exists
   // (only same-module `state` getter + `@testable` tests); the App reads the
@@ -1452,16 +1449,14 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     for state: RecordingSessionState,
     outcome: RecordingOutcome?,
     deliveringPhase: DeliveringPhase = .transcribing,
-    externalError: String?,
-    failureDetail: String? = nil,
+    externalReason: TerminalNoticeReason?,
     interruptionCause: EngineInterruptionCause? = nil
   ) -> PipelineState {
-    if let externalError {
-      return .error(externalError)
+    if let externalReason {
+      return .error(externalReason)
     }
     // A concluded session's public state comes from `recordingOutcome` (state
-    // has returned to `.idle`, #1548 D1). Byte-parity with the old terminal-state
-    // mapping.
+    // has returned to `.idle`, #1548 D1).
     if let outcome {
       switch outcome {
       case .completed:
@@ -1469,13 +1464,13 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       case .cancelled, .discarded, .noSpeech:
         return .idle
       case .failed(let reason):
-        return .error(failureMessage(reason, detail: failureDetail))
+        return .error(terminalNoticeReason(for: reason))
       case .noTransport:
-        return .error(failureMessage(.noAudioCaptured, detail: nil))
+        return .error(.noAudioCaptured)
       case .audioInterrupted:
-        return .error(InterruptionMessages.message(for: interruptionCause))
+        return .error(terminalNoticeReason(for: interruptionCause))
       case .asrInterrupted:
-        return .error(asrInterruptedMessage)
+        return .error(.asrInterrupted)
       }
     }
     switch state {
@@ -1509,55 +1504,41 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     }
   }
 
-  /// Mirrors the shipped the old Parakeet pipeline string verbatim (em-dash
-  /// included) — PR-4 parity; the em-dash cleanup is a separate content change.
-  static let asrInterruptedMessage = "Transcription service crashed — please try again"
-
-  /// User-facing message for a `failed` terminal. The plan does not enumerate
-  /// this map; each message mirrors today's the old Parakeet pipeline string for
-  /// the equivalent failure verbatim (parity — PR-4's bar is "user feels
-  /// nothing change"), or a sensible message where the kernel splits a reason
-  /// today's pipeline did not name distinctly. The `captureStalled` em-dash is
-  /// preserved to match the shipped string byte-for-byte; fixing it is a
-  /// separate content-lane change, out of PR-4 scope.
-  static func failureMessage(_ reason: RecordingFailureReason, detail: String? = nil)
-    -> String
+  /// #1558: map a kernel `RecordingFailureReason` to the typed, presentation-
+  /// neutral `TerminalNoticeReason`. PURE — no telemetry side effect (this map
+  /// is read from BOTH the state and overlay projections, so emitting here
+  /// would double-fire; the raw error is already captured at its producer's
+  /// Sentry site). Total over all 12 cases (no `default`), so a new
+  /// `RecordingFailureReason` reds the build until it is assigned a reason.
+  nonisolated static func terminalNoticeReason(for reason: RecordingFailureReason)
+    -> TerminalNoticeReason
   {
     switch reason {
-    case .prepareFailed:
-      return "Couldn't start dictation. Please try again."
-    case .permissionDenied:
-      return "Microphone permission denied."
-    case .modelWedged:
-      return ModelLoadWatchdog.userMessage
-    case .modelLoadFailed:
-      // Old Parakeet pipeline shape: "Model load failed: <error.localizedDescription>"
-      // (TP:440-445). Fall back to the bare string when no detail is captured.
-      return detail.map { "Model load failed: \($0)" } ?? "Model load failed."
-    case .captureStartFailed:
-      // Old Parakeet pipeline shape: "Recording failed: <error.localizedDescription>"
-      // (TP:577-588).
-      return detail.map { "Recording failed: \($0)" } ?? "Recording failed."
-    case .noAudioCaptured:
-      return "No audio captured"
-    case .asrEmpty:
-      return "Couldn't catch that -- try again"
-    case .asrFailed:
-      // Old Parakeet pipeline shape: "Transcription failed: <error.localizedDescription>"
-      // (TP:1045-1051).
-      return detail.map { "Transcription failed: \($0)" } ?? "Transcription failed."
-    case .asrWedged:
-      return "Transcription stalled. Please try again."
-    case .emptyAfterProcessing:
-      return "No speech detected. Your clipboard is unchanged. Try again."
-    case .captureStalled:
-      return "No audio detected — try again."
-    case .zeroSignal:
-      // #1317 PR3: the harness delivered all-zero audio from a running,
-      // unmuted mic. The kernel has already requested the capture-pipeline
-      // rebuild by the time this failure is mapped, so the copy states what
-      // the app is actually doing (founder-chosen wording).
-      return "Mic problem. Resetting it."
+    case .prepareFailed: return .prepareFailed
+    case .permissionDenied: return .permissionDenied
+    case .modelWedged: return .modelWedged
+    case .modelLoadFailed: return .modelLoadFailed
+    case .captureStartFailed: return .captureStartFailed
+    case .noAudioCaptured: return .noAudioCaptured
+    case .asrEmpty: return .asrEmptyWithSpeech
+    case .asrFailed: return .asrFailed
+    case .asrWedged: return .asrWedged
+    case .emptyAfterProcessing: return .emptyAfterProcessing
+    case .captureStalled: return .captureStalled
+    case .zeroSignal: return .zeroSignal
+    }
+  }
+
+  /// #1558: map a stamped `EngineInterruptionCause` (optional) to the typed
+  /// interruption reason. `nil` → `.unknownInterruption` (neutral line), the
+  /// same choice the retired `InterruptionMessages` made. Exhaustive.
+  nonisolated static func terminalNoticeReason(for cause: EngineInterruptionCause?)
+    -> TerminalNoticeReason
+  {
+    switch cause {
+    case .some(.deviceRemoved): return .deviceRemoved
+    case .some(.engineLost): return .engineLost
+    case .none: return .unknownInterruption
     }
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -603,6 +603,19 @@ final class KernelLifecycleTelemetrySink {
         error,
         .audioCaptureFailed, "recording",
         captureFailureExtra(error: error, failureMode: "thrown_start"))
+    case .noMicrophoneFound:
+      // #1558: no usable input device on the toggle/menu start path. Keeps the
+      // `audio_capture_failed` cluster populated (distinct `failureMode`) so the
+      // held-release drop can still be watched post-ship.
+      let error =
+        telemetryState.captureFailureError
+        ?? NSError(
+          domain: "EnviousWispr", code: -16,
+          userInfo: [NSLocalizedDescriptionKey: "No usable microphone device was found"])
+      emitCaptureError(
+        error,
+        .audioCaptureFailed, "recording",
+        captureFailureExtra(error: error, failureMode: "no_microphone_found"))
     case .asrEmpty:
       // #979: ASR-empty on non-speech (ambient noise trips VAD, engine
       // correctly returns empty) is an EXPECTED outcome, not an error.

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -609,13 +609,13 @@ final class KernelLifecycleTelemetrySink {
       // Evidence: 7 organic capture pairs all ambient non-speech (energy-mod
       // 0.08-0.19, no inter-word pauses); founder repro "airplane, light taps";
       // SuperWhisper logs the same condition and treats it as a soft notice.
-      // The user already sees "Couldn't catch that" from the terminal STATE
-      // (KernelDictationDriver), independent of this emit. Downgrade from a
-      // Sentry error (which flagged a non-bug AND auto-filed issues via the
-      // Sentry->GitHub triage) to a context-only breadcrumb. Frequency still
-      // lives in PostHog pipeline.failed (error_code "Couldn't catch that --
-      // try again"); engineering evidence still lives in the DEBUG
-      // DictationAudioArchive. Both untouched.
+      // The user already sees the terminal notice ("Transcription error. Try
+      // again.", #1558) from the terminal STATE (KernelDictationDriver),
+      // independent of this emit. Downgrade from a Sentry error (which flagged
+      // a non-bug AND auto-filed issues via the Sentry->GitHub triage) to a
+      // context-only breadcrumb. Frequency still lives in PostHog
+      // pipeline.failed (error_code "asr_empty_with_speech"); engineering
+      // evidence still lives in the DEBUG DictationAudioArchive. Both remain intact.
       breadcrumb(
         "asr", "ASR returned empty text despite speech evidence",
         telemetryState.asrEmptyDiagnostics?.sentryExtra() ?? ["backend": backend.rawValue])

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -193,9 +193,12 @@ enum PipelineStateChangePlanner {
       }
     }
 
-    // Step 3 — error-path telemetry.
-    if case .error(let msg) = newState.activity {
-      effects.append(.reportPipelineFailed(errorCode: msg))
+    // Step 3 — error-path telemetry. #1558: the payload is now a typed
+    // `TerminalNoticeReason`; its stable `rawValue` is the PostHog
+    // `pipeline.failed.error_code`. String only at the telemetry boundary — no
+    // customer copy, no user payload.
+    if case .error(let reason) = newState.activity {
+      effects.append(.reportPipelineFailed(errorCode: reason.rawValue))
     }
 
     return PipelineStateChangePlan(effects: effects)

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -9,29 +9,10 @@ import Foundation
 // PR-9 of #827 — `KernelDictationDriver` is the single concrete driver and the
 // App consumes it directly. `KernelOwnershipFreezeTests` keeps it deleted.
 
-/// Known interruption message strings used to route .error state to .interruption overlay intent.
-enum InterruptionMessages {
-  /// Shown ONLY when Core Audio confirmed the input device went away.
-  static let micDisconnected = "Microphone disconnected"
-
-  /// #1408. Shown for every other interruption: an engine that failed to
-  /// recover with the microphone still attached, or a capture-session
-  /// interruption. Says exactly what we know and nothing we cannot back.
-  static let recordingInterrupted = "Recording interrupted"
-
-  /// #1408: the SINGLE place that decides which interruption sentence a user
-  /// sees. Three sites in `KernelDictationDriver` render an audio interruption
-  /// (the external-error path, the overlay intent, and the public state mapper);
-  /// all three route here so the sentence cannot drift between them.
-  ///
-  /// A missing cause yields the neutral line. The kernel refuses salvage when it
-  /// reaches an audio-interruption exit with nothing stamped, and an unstamped
-  /// interruption is precisely the case where we have no evidence a microphone
-  /// left — so the default fails toward the claim we can always back.
-  static func message(for cause: EngineInterruptionCause?) -> String {
-    cause?.isDeviceLoss == true ? micDisconnected : recordingInterrupted
-  }
-}
+// #1558 (heartpath E1): `InterruptionMessages` — the former single authority
+// for interruption copy — was deleted. The driver now stamps a typed
+// `TerminalNoticeReason` (`.deviceRemoved` / `.engineLost` / `.unknownInterruption`)
+// and `TerminalNoticePresenter` in AppKit authors the sentence.
 
 /// #1408 (grounded review A1): what a COMPLETED take discloses about the
 /// interruption that cut it short. Derived from the stamped
@@ -88,12 +69,14 @@ public enum OverlayIntent: Equatable, Sendable {
   /// Transient warning notice for degraded-but-delivered results (e.g. polish failed).
   /// Orange icon, auto-dismissed by the overlay panel after 2.5 seconds.
   case warning(message: String)
-  /// Transient error notice shown when ASR fails despite speech evidence.
-  /// Auto-dismissed by the overlay panel after 3 seconds.
-  case error(message: String)
-  /// Transient interruption notice shown when the recording device disconnects.
-  /// Distress lips (red pulse) with reason text, auto-dismissed after 2 seconds.
-  case interruption(message: String)
+  /// Transient error notice for a terminal capture / transcription failure.
+  /// #1558: carries a TYPED reason; `TerminalNoticePresenter` authors the
+  /// sentence. Auto-dismissed by the overlay panel after 3 seconds.
+  case error(reason: TerminalNoticeReason)
+  /// Transient interruption notice shown when the recording was cut short
+  /// (device removed, or engine lost with the mic still attached). #1558:
+  /// carries a TYPED reason. Distress lips (red pulse), auto-dismissed after 2 seconds.
+  case interruption(reason: TerminalNoticeReason)
   /// Passive language-lock discoverability chip surfaced post-dictation when the
   /// detector observed N consecutive high-confidence accepts of the same non-English
   /// language. Renders State A (strikes 1+2: Lock + Dismiss) or State B (strike 3:

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -535,26 +535,12 @@ final class RecordingSessionKernel {
   /// `failed(.modelWedged)` so Sentry/PostHog keep the old payload shape.
   private(set) var modelLoadWedgeTelemetry: KernelModelLoadWedgeTelemetry?
 
-  /// User-visible detail for the current `.failed(reason)` state, if any —
-  /// the underlying error's `localizedDescription` for the three reasons the
-  /// old Parakeet pipeline embedded into its error strings (TP:440-445,
-  /// TP:577-588, TP:1045-1051). `nil` when the kernel is not in a
-  /// detail-bearing failed state, OR when no underlying error was captured.
-  /// Reading scope is intentionally narrow: this is the user-message
-  /// enrichment seam, not a general error-introspection API.
-  var lastFailureDetail: String? {
-    guard case .failed(let reason) = recordingOutcome else { return nil }
-    switch reason {
-    case .modelLoadFailed:
-      return telemetryState.modelLoadError?.localizedDescription
-    case .captureStartFailed:
-      return telemetryState.captureFailureError?.localizedDescription
-    case .asrFailed:
-      return telemetryState.transcriptionFailureError?.localizedDescription
-    default:
-      return nil
-    }
-  }
+  // #1558: the UI-only `lastFailureDetail` accessor was deleted. It existed to
+  // enrich a user-facing "Model load failed: <detail>" string; that string is
+  // gone (the presenter authors the sentence, the raw error goes to Sentry
+  // only). The underlying telemetry fields (`modelLoadError`,
+  // `captureFailureError`, `transcriptionFailureError`) remain — they still
+  // feed `KernelLifecycleTelemetrySink`'s Sentry capture.
 
   /// The session task bag, keyed by `SessionID` (PR-1 §B.1.6). Reaching a
   /// terminal state cancels and clears it — nonblocking (PR-3 plan §3.1a).
@@ -2915,7 +2901,8 @@ final class RecordingSessionKernel {
   /// This used to be TWO rules, the second gated on `cause.isDeviceLoss`, because
   /// `.audioInterrupted` rendered "Microphone disconnected" unconditionally and
   /// that would have been a lie for a duration cap. The cause-aware sentence now
-  /// lives at its own single authority (`InterruptionMessages.message(for:)`), so
+  /// lives at its own single authority (#1558: the driver stamps a typed
+  /// `TerminalNoticeReason` and `TerminalNoticePresenter` authors the copy), so
   /// the floor no longer has to encode a copy decision. What the terminal MEANS
   /// (the spool survives) and what the user READS are separate questions with
   /// separate owners — which is the same split `hasRecoverableAudio` and
@@ -3519,19 +3506,8 @@ final class RecordingSessionKernel {
     /// "no active task references remain after a terminal state" invariant.
     var testActiveTaskCount: Int { taskBag.count }
 
-    /// Test-only telemetry-error setters. Unit tests that need to assert the
-    /// `lastFailureDetail` mapping reach the underlying telemetry fields
-    /// through these hooks rather than driving a real warm-up / capture /
-    /// transcription failure.
-    func testSetModelLoadError(_ error: (any Error)?) {
-      telemetryState.modelLoadError = error
-    }
-    func testSetCaptureFailureError(_ error: (any Error)?) {
-      telemetryState.captureFailureError = error
-    }
-    func testSetTranscriptionFailureError(_ error: (any Error)?) {
-      telemetryState.transcriptionFailureError = error
-    }
+    // #1558: the three `testSet*Error` hooks that fed the deleted
+    // `lastFailureDetail` mapping test were removed with it — dead scaffolding.
     /// #1358: pre-seed the interruption cause so a test can exercise
     /// `interruptedTerminalFloor` (which reads `lastAudioInterruptionCause`)
     /// without driving a real mid-recording interruption.

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -30,6 +30,11 @@ public enum RecordingFailureReason: Equatable, Sendable {
   case modelWedged
   case modelLoadFailed
   case captureStartFailed
+  /// #1558 (cloud review P2 #1563): a start-stage failure where NO usable input
+  /// device was found — distinct from the generic `.captureStartFailed` so the
+  /// toggle/menu path surfaces the actionable "No microphone found." notice, the
+  /// same as the prewarm (PTT) path already does AppKit-side.
+  case noMicrophoneFound
   case noAudioCaptured
   case asrEmpty
   case asrFailed
@@ -994,7 +999,7 @@ final class RecordingSessionKernel {
     } catch {
       guard isCurrent(sid) else { return }
       telemetryState.captureFailureError = error
-      finishTerminal(.failed(classifyCaptureStartError(error)), sid: sid)
+      finishTerminal(.failed(Self.classifyCaptureStartError(error)), sid: sid)
       return
     }
     guard isCurrent(sid) else { return }
@@ -1029,7 +1034,7 @@ final class RecordingSessionKernel {
       } catch {
         guard isCurrent(sid) else { return }
         telemetryState.captureFailureError = error
-        finishTerminal(.failed(classifyCaptureStartError(error)), sid: sid)
+        finishTerminal(.failed(Self.classifyCaptureStartError(error)), sid: sid)
         return
       }
       guard isCurrent(sid) else { return }
@@ -3429,7 +3434,16 @@ final class RecordingSessionKernel {
       / Int(AudioConstants.sampleRate)
   }
 
-  private func classifyCaptureStartError(_ error: Error) -> RecordingFailureReason {
+  // Pure classification (no instance state) — `nonisolated static` so it is
+  // directly unit-testable via `@testable`.
+  nonisolated static func classifyCaptureStartError(_ error: Error) -> RecordingFailureReason {
+    // #1558 (cloud review P2 #1563): a missing input device on the toggle/menu
+    // start path throws `AudioError.noBuiltInMicrophoneFound`. Classify it
+    // distinctly so it surfaces "No microphone found." (parity with the prewarm
+    // path's AppKit-side handling), not the generic capture error.
+    if let audioError = error as? AudioError, case .noBuiltInMicrophoneFound = audioError {
+      return .noMicrophoneFound
+    }
     // The capture seam surfaces permission revocation distinctly from a
     // generic engine-start failure (PR-1 §B.1.2).
     let description = String(describing: error).lowercased()

--- a/Sources/EnviousWisprServices/PermissionsService.swift
+++ b/Sources/EnviousWisprServices/PermissionsService.swift
@@ -35,10 +35,32 @@ public final class PermissionsService {
   /// to the live no-prompt system check in production.
   private let accessibilityReader: () -> Bool
 
-  public init(accessibilityReader: @escaping () -> Bool = { AXIsProcessTrusted() }) {
+  /// Injected mirror of `accessibilityReader` for the microphone status, so the
+  /// start-path error router (#1558) is testable; defaults to the live
+  /// no-prompt system check.
+  private let microphoneReader: () -> AVAuthorizationStatus
+
+  public init(
+    accessibilityReader: @escaping () -> Bool = { AXIsProcessTrusted() },
+    microphoneReader: @escaping () -> AVAuthorizationStatus = {
+      AVCaptureDevice.authorizationStatus(for: .audio)
+    }
+  ) {
     self.accessibilityReader = accessibilityReader
-    microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+    self.microphoneReader = microphoneReader
+    microphoneStatus = microphoneReader()
     accessibilityGranted = accessibilityReader()
+  }
+
+  /// #1558: live microphone-denied check for the start-path error router. A
+  /// prewarm failure while permission is denied or restricted must map to the
+  /// actionable "Microphone access is off." notice, not the generic retry.
+  /// Reads live (not the cached snapshot) so a mid-session revoke is honored.
+  public var microphonePermissionIsDenied: Bool {
+    switch microphoneReader() {
+    case .denied, .restricted: return true
+    default: return false
+    }
   }
 
   /// Request microphone access. Returns true if granted.

--- a/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/ASREventRouterTests.swift
@@ -96,7 +96,7 @@ struct ASREventRouterTests {
 
       // Walk the kernel FSM through the legal edges so it lands in
       // `.finalizing`; the public mapping at
-      // KernelDictationDriver.pipelineState(for:externalError:) returns
+      // KernelDictationDriver.pipelineState(for:externalReason:) returns
       // `.polishing` for that state, which is the safe-point window the
       // router must NOT interrupt on ASR XPC crash.
       let kernel = driver.kernelForTesting

--- a/Tests/EnviousWisprTests/App/BackendMetadataTests.swift
+++ b/Tests/EnviousWisprTests/App/BackendMetadataTests.swift
@@ -161,7 +161,7 @@ struct BackendMetadataTests {
   func statusTextParakeetError() {
     let bm = makeBackendMetadata()
     bm.asrManager.setInitialBackendType(.parakeet)
-    #expect(bm.statusText(for: .error("boom")) == "Error")
+    #expect(bm.statusText(for: .error(.modelWedged)) == "Error")
   }
 
   @Test("statusText Parakeet: .idle falls back to model-loaded label")

--- a/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
@@ -128,7 +128,7 @@ import Testing
   @Test func parakeetTerminalStatesClearRecordingLock() {
     let fx = Self.makeCoordinator()
     fx.coordinator.install()
-    for terminal in [PipelineState.idle, .complete, .error("boom")] {
+    for terminal in [PipelineState.idle, .complete, .error(.modelWedged)] {
       fx.recordingLocked.isLocked = true
       fx.kernelDriver.onStateChange?(terminal)
       #expect(
@@ -140,7 +140,7 @@ import Testing
   @Test func whisperKitTerminalStatesClearRecordingLock() {
     let fx = Self.makeCoordinator()
     fx.coordinator.install()
-    for terminal in [PipelineState.idle, .complete, .error("boom")] {
+    for terminal in [PipelineState.idle, .complete, .error(.modelWedged)] {
       fx.recordingLocked.isLocked = true
       fx.whisperKitKernelDriver.onStateChange?(terminal)
       #expect(

--- a/Tests/EnviousWisprTests/App/HeartControlRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/App/HeartControlRecoveryTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 import Testing
 
@@ -12,19 +13,19 @@ import Testing
 /// other error must produce the full diagnostic trail.
 ///
 /// PR-9 (#827) deleted the `DictationPipeline` protocol; `recover` now takes a
-/// narrow `setExternalError` closure, so the old `FakePipeline` conformer is
-/// replaced by this minimal error-surface spy.
+/// narrow `setTerminalReason` closure (#1558: a typed reason, not English), so
+/// the old `FakePipeline` conformer is replaced by this minimal reason spy.
 @Suite("HeartControlRecovery (#585)")
 @MainActor
 struct HeartControlRecoveryTests {
 
-  /// `@MainActor` so `setExternalError` matches the `recover` parameter's
-  /// `@MainActor (String) -> Void` type (which is implicitly `Sendable` in
+  /// `@MainActor` so `setTerminalReason` matches the `recover` parameter's
+  /// `@MainActor (TerminalNoticeReason) -> Void` type (implicitly `Sendable` in
   /// Swift 6); production passes a `@MainActor` driver method for the same reason.
   @MainActor
   final class ErrorSurfaceSpy {
-    var calls: [String] = []
-    func setExternalError(_ message: String) { calls.append(message) }
+    var calls: [TerminalNoticeReason] = []
+    func setTerminalReason(_ reason: TerminalNoticeReason) { calls.append(reason) }
   }
 
   final class CaptureSpy: @unchecked Sendable {
@@ -106,15 +107,15 @@ struct HeartControlRecoveryTests {
     withSentrySpy { spy in
       struct BoomError: Error {}
       recovery.recover(
-        error: BoomError(), op: "toggle", message: "Try again.",
-        setExternalError: sink.setExternalError)
+        error: BoomError(), op: "toggle", reason: .modelWedged,
+        setTerminalReason: sink.setTerminalReason)
       #expect(spy.calls.count == 1)
       #expect(spy.calls.first?.extra?["op"] as? String == "toggle")
       #expect(spy.calls.first?.extra?["backend"] as? String == "parakeet")
     }
     #expect(hide.count == 1, "overlay must be hidden")
     #expect(locked.values == [false], "lock must be cleared")
-    #expect(sink.calls == ["Try again."])
+    #expect(sink.calls == [.modelWedged])
   }
 
   @Test(
@@ -126,8 +127,8 @@ struct HeartControlRecoveryTests {
     let recovery = makeRecovery(hideCalls: hide, lockedCalls: locked)
     withSentrySpy { spy in
       recovery.recover(
-        error: CancellationError(), op: "toggle", message: "Try again.",
-        setExternalError: sink.setExternalError)
+        error: CancellationError(), op: "toggle", reason: .modelWedged,
+        setTerminalReason: sink.setTerminalReason)
       #expect(spy.calls.isEmpty, "CancellationError must not capture to Sentry")
     }
     #expect(hide.count == 1, "overlay must still be hidden so user UI isn't stuck")
@@ -146,8 +147,8 @@ struct HeartControlRecoveryTests {
     withSentrySpy { spy in
       struct E: Error {}
       recovery.recover(
-        error: E(), op: "toggle-from-prewarm", message: "",
-        setExternalError: sink.setExternalError)
+        error: E(), op: "toggle-from-prewarm", reason: .modelWedged,
+        setTerminalReason: sink.setTerminalReason)
       #expect(spy.calls.first?.extra?["op"] as? String == "toggle-from-prewarm")
     }
   }

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -39,13 +39,13 @@ struct LiveRecordingStateTests {
     // The prior test left both drivers .idle, so it stayed green even if the
     // router ignored activeBackendType, inverted the condition, or read the
     // wrong driver in the WhisperKit arm.
-    state.whisperKitKernelDriver.setExternalError("wk-marker")
+    state.whisperKitKernelDriver.setTerminalReason(.deviceRemoved)
     // Parakeet arm → reads the (error-free) parakeet driver → .idle.
     state.asrManager.setInitialBackendType(.parakeet)
     #expect(state.pipelineState == .idle)
-    // WhisperKit arm → reads the WhisperKit driver → .error("wk-marker").
+    // WhisperKit arm → reads the WhisperKit driver → .error(.deviceRemoved).
     state.asrManager.setInitialBackendType(.whisperKit)
-    #expect(state.pipelineState == .error("wk-marker"))
+    #expect(state.pipelineState == .error(.deviceRemoved))
   }
 
   @Test(

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -48,7 +48,7 @@ struct MenuBarControllerTests {
 
   @Test("iconState: error → error")
   func iconStateError() {
-    #expect(MenuBarController.iconState(fixture(pipelineState: .error("boom"))) == .error)
+    #expect(MenuBarController.iconState(fixture(pipelineState: .error(.modelWedged))) == .error)
   }
 
   @Test("iconState: complete → idle (no special icon)")

--- a/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
@@ -183,21 +183,21 @@ import Testing
     // and reset-neither regressions alike.
     do {  // Parakeet active.
       let fx = Self.makeFixture()
-      fx.kernelDriver.setExternalError("parakeet-err")
-      fx.whisperKitKernelDriver.setExternalError("whisperkit-err")
+      fx.kernelDriver.setTerminalReason(.modelWedged)
+      fx.whisperKitKernelDriver.setTerminalReason(.asrFailed)
       fx.asr.activeBackendType = .parakeet
       fx.finalizer.resetActive()
       #expect(fx.kernelDriver.state == .idle)
-      #expect(fx.whisperKitKernelDriver.state == .error("whisperkit-err"))
+      #expect(fx.whisperKitKernelDriver.state == .error(.asrFailed))
     }
     do {  // WhisperKit active.
       let fx = Self.makeFixture()
-      fx.kernelDriver.setExternalError("parakeet-err")
-      fx.whisperKitKernelDriver.setExternalError("whisperkit-err")
+      fx.kernelDriver.setTerminalReason(.modelWedged)
+      fx.whisperKitKernelDriver.setTerminalReason(.asrFailed)
       fx.asr.activeBackendType = .whisperKit
       fx.finalizer.resetActive()
       #expect(fx.whisperKitKernelDriver.state == .idle)
-      #expect(fx.kernelDriver.state == .error("parakeet-err"))
+      #expect(fx.kernelDriver.state == .error(.modelWedged))
     }
   }
 }

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import AppKit
 import EnviousWisprCore
 import EnviousWisprLLM
@@ -46,7 +47,8 @@ import Testing
     accessibilityRefresh: (@MainActor () -> Void)? = nil,
     releaseDuringRecoveryArm: Bool = false,
     isRecovering: Bool = false,
-    recoveringDuringArm: Bool = false
+    recoveringDuringArm: Bool = false,
+    micStatus: AVAuthorizationStatus = .authorized
   ) -> Fixture {
     // `RecordingOverlayPanel.show(intent: .recording, ...)` posts an
     // `NSAccessibility` notification against `NSApp.mainWindow`. `NSApp`
@@ -68,7 +70,7 @@ import Testing
     let settings = SettingsManager(
       defaults: UserDefaults(suiteName: "ew-test-\(UUID().uuidString)")!)
     let overlay = RecordingOverlayPanel()
-    let permissions = PermissionsService()
+    let permissions = PermissionsService(microphoneReader: { micStatus })
     let lockBox = TestRecordingLockedBox()
     let lockAccess = DictationLifecycleCoordinator.RecordingLockedAccess(
       get: { lockBox.isLocked },
@@ -198,6 +200,24 @@ import Testing
     await fx.starter.start()
 
     #expect(fx.kernelDriver.state == .error(.noMicrophoneFound))
+  }
+
+  @Test(
+    "a prewarm failure while mic permission is denied surfaces the actionable permission notice, not the generic capture error (cloud review P2 #1563)"
+  )
+  func permissionDeniedPrewarmSurfacesPermissionNotice() async {
+    // Mic permission is denied; the prewarm error itself is a generic capture
+    // failure (not a no-device error). #1558: permission is the real,
+    // user-actionable cause and must win — the user should see "Microphone
+    // access is off.", never the generic "Audio capture error. Try again."
+    let fx = Self.makeFixture(micStatus: .denied)
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+    fx.audio.preWarmError = NSError(domain: "SomeGenericCapture", code: 99)
+
+    await fx.starter.start()
+
+    #expect(fx.kernelDriver.state == .error(.permissionDenied))
   }
 
   /// The old `toggleAndStartBothRefreshAccessibilityStatus` had ZERO `#expect` —

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -184,7 +184,7 @@ import Testing
 
     await fx.starter.start()
 
-    #expect(fx.kernelDriver.state == .error("No microphone found. Please connect a microphone."))
+    #expect(fx.kernelDriver.state == .error(.noMicrophoneFound))
   }
 
   @Test("XPC-sanitized no-microphone prewarm error surfaces distinct copy")
@@ -197,7 +197,7 @@ import Testing
 
     await fx.starter.start()
 
-    #expect(fx.kernelDriver.state == .error("No microphone found. Please connect a microphone."))
+    #expect(fx.kernelDriver.state == .error(.noMicrophoneFound))
   }
 
   /// The old `toggleAndStartBothRefreshAccessibilityStatus` had ZERO `#expect` —

--- a/Tests/EnviousWisprTests/App/TerminalNoticePresenterTests.swift
+++ b/Tests/EnviousWisprTests/App/TerminalNoticePresenterTests.swift
@@ -1,0 +1,70 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1558 (heartpath E1). Freezes the copy contract: the presenter is the SOLE
+/// author of the six founder-locked terminal-notice sentences, and no reason
+/// leaks raw internal detail.
+@Suite struct TerminalNoticePresenterTests {
+
+  @Test("every reason maps to its exact founder-locked sentence")
+  func everyReasonMapsToLockedCopy() {
+    let expected: [TerminalNoticeReason: String] = [
+      // Audio capture error bucket (our-fault start / capture).
+      .prepareFailed: "Audio capture error. Try again.",
+      .modelWedged: "Audio capture error. Try again.",
+      .modelLoadFailed: "Audio capture error. Try again.",
+      .captureStartFailed: "Audio capture error. Try again.",
+      .micWouldNotOpen: "Audio capture error. Try again.",
+      .captureStalled: "Audio capture error. Try again.",
+      .zeroSignal: "Audio capture error. Try again.",
+      // Transcription error bucket (our-fault transcribe).
+      .asrFailed: "Transcription error. Try again.",
+      .asrWedged: "Transcription error. Try again.",
+      .asrInterrupted: "Transcription error. Try again.",
+      .noAudioCaptured: "Transcription error. Try again.",
+      .asrEmptyWithSpeech: "Transcription error. Try again.",
+      .emptyAfterProcessing: "Transcription error. Try again.",
+      .unknown: "Transcription error. Try again.",
+      // User-actionable.
+      .permissionDenied: "Microphone access is off.",
+      .noMicrophoneFound: "No microphone found. Please connect one.",
+      // Informational interruptions.
+      .deviceRemoved: "Microphone disconnected.",
+      .engineLost: "Recording interrupted.",
+      .unknownInterruption: "Recording interrupted.",
+    ]
+    // The map must cover EVERY case — a new reason with no expected entry fails
+    // here rather than silently defaulting.
+    for reason in TerminalNoticeReason.allCases {
+      guard let want = expected[reason] else {
+        Issue.record("no expected copy for \(reason) — add it to the locked set")
+        continue
+      }
+      #expect(TerminalNoticePresenter.copy(for: reason) == want)
+    }
+  }
+
+  @Test("no sentence carries raw internal detail (the retired leak prefixes)")
+  func noRawDetailLeak() {
+    let bannedPrefixes = [
+      "Model load failed:", "Recording failed:", "Transcription failed:",
+      "Speech engine isn't responding",  // old ModelLoadWatchdog.userMessage
+    ]
+    for reason in TerminalNoticeReason.allCases {
+      let copy = TerminalNoticePresenter.copy(for: reason)
+      for banned in bannedPrefixes {
+        #expect(!copy.contains(banned), "\(reason) copy must not contain '\(banned)'")
+      }
+    }
+  }
+
+  @Test("the six sentences use no em/en dashes (in-app copy rule)")
+  func noDashesInCopy() {
+    for reason in TerminalNoticeReason.allCases {
+      let copy = TerminalNoticePresenter.copy(for: reason)
+      #expect(!copy.contains("\u{2014}") && !copy.contains("\u{2013}"), "\(reason) copy has a dash")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
@@ -58,7 +58,7 @@ import Testing
     _ = driver.currentSessionConfig
     driver.onStateChange = { _ in }
     driver.onOverlayIntentChange = { _ in }  // #930 — App-consumed overlay channel
-    driver.setExternalError("probe")
+    driver.setTerminalReason(.modelWedged)
     driver.handleEngineInterruption(.engineLost)
     driver.handleASRServiceInterruption()
     driver.reset()

--- a/Tests/EnviousWisprTests/Audio/AudioErrorIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioErrorIdentityTests.swift
@@ -12,7 +12,7 @@ struct AudioErrorIdentityTests {
     let error = AudioError.noBuiltInMicrophoneFound as NSError
     #expect(error.domain == AudioError.errorDomain)
     #expect(error.code == AudioError.noBuiltInMicrophoneFound.errorCode)
-    #expect(error.localizedDescription == "No microphone found. Please connect a microphone.")
+    #expect(error.localizedDescription == "No usable microphone device was found.")
   }
 
   @Test("XPC sanitizer preserves no-microphone domain and code")
@@ -20,6 +20,6 @@ struct AudioErrorIdentityTests {
     let sanitized = XPCErrorSanitizer.sanitizeForXPC(AudioError.noBuiltInMicrophoneFound)
     #expect(sanitized.domain == AudioError.errorDomain)
     #expect(sanitized.code == AudioError.noBuiltInMicrophoneFound.errorCode)
-    #expect(sanitized.localizedDescription == "No microphone found. Please connect a microphone.")
+    #expect(sanitized.localizedDescription == "No usable microphone device was found.")
   }
 }

--- a/Tests/EnviousWisprTests/Core/PipelineStateTelemetryLabelTests.swift
+++ b/Tests/EnviousWisprTests/Core/PipelineStateTelemetryLabelTests.swift
@@ -18,12 +18,12 @@ struct PipelineStateTelemetryLabelTests {
     #expect(PipelineState.transcribing.telemetryLabel == "transcribing")
     #expect(PipelineState.polishing.telemetryLabel == "polishing")
     #expect(PipelineState.complete.telemetryLabel == "complete")
-    #expect(PipelineState.error("boom").telemetryLabel == "error")
+    #expect(PipelineState.error(.modelWedged).telemetryLabel == "error")
   }
 
   @Test("error label is independent of the associated message")
   func errorLabelIgnoresMessage() {
-    #expect(PipelineState.error("").telemetryLabel == "error")
-    #expect(PipelineState.error("some failure").telemetryLabel == "error")
+    #expect(PipelineState.error(.asrFailed).telemetryLabel == "error")
+    #expect(PipelineState.error(.deviceRemoved).telemetryLabel == "error")
   }
 }

--- a/Tests/EnviousWisprTests/EnviousWisprTests.swift
+++ b/Tests/EnviousWisprTests/EnviousWisprTests.swift
@@ -19,7 +19,7 @@ struct PipelineStateTests {
 
   @Test("error is not active")
   func errorIsNotActive() {
-    #expect(!PipelineState.error("something broke").isActive)
+    #expect(!PipelineState.error(.modelWedged).isActive)
   }
 
   @Test(
@@ -36,8 +36,8 @@ struct PipelineStateTests {
 
   @Test("equality for error states")
   func errorEquality() {
-    #expect(PipelineState.error("a") == PipelineState.error("a"))
-    #expect(PipelineState.error("a") != PipelineState.error("b"))
+    #expect(PipelineState.error(.modelWedged) == PipelineState.error(.modelWedged))
+    #expect(PipelineState.error(.modelWedged) != PipelineState.error(.asrFailed))
   }
 
   @Test("equality for non-error states")

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -771,7 +771,7 @@ FINDINGS
 
 2. Heart-path contract mismatch in the old Parakeet pipeline's `stopAndTranscribe()`:
    a thrown ASR error currently lands in the outer `catch` and sets
-   `.error("Transcription failed: ...")` without any fallback paste. That contradicts the
+   `.error(.asrFailed)` without any fallback paste. That contradicts the
    stated requirement that the heart path never fails and should still deliver something.
 
 3. Heart-vs-limb ambiguity in `TranscriptFinalizer.finalize(...)`:

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
@@ -131,10 +131,11 @@ import Testing
     // MARK: Helper — assert PipelineState equality (custom because
     // .error(_) holds an associated value)
 
-    private func assertDriverIsError(_ driver: KernelDictationDriver, contains: String) {
-      if case .error(let msg) = driver.state {
-        #expect(
-          msg.contains(contains), "expected .error containing \"\(contains)\", got \"\(msg)\"")
+    private func assertDriverIsError(
+      _ driver: KernelDictationDriver, reason expected: TerminalNoticeReason
+    ) {
+      if case .error(let reason) = driver.state {
+        #expect(reason == expected, "expected .error(\(expected)), got .error(\(reason))")
       } else {
         Issue.record("expected .error, got \(driver.state)")
       }
@@ -199,10 +200,10 @@ import Testing
         await place(fx.kernel, in: placement)
         fx.driver.handleASRServiceInterruption()
         await drain()
-        // The driver's setExternalError sets the .error state; the kernel
+        // The driver's setTerminalReason sets the .error state; the kernel
         // may be parked at any of several states depending on cancel
         // semantics, but the driver's public state must be .error.
-        assertDriverIsError(fx.driver, contains: "Transcription service crashed")
+        assertDriverIsError(fx.driver, reason: .asrInterrupted)
       }
     }
 
@@ -227,19 +228,19 @@ import Testing
     // The forced-state fixture has no recording-exit continuation, so the
     // matrix freeze covers only the bridge cases and the no-op cases.
 
-    /// #1408: the bridged sentence is CAUSE-AWARE. This test used to inject
+    /// #1408 / #1558: the bridged REASON is CAUSE-AWARE. This test used to inject
     /// `.engineLost` and demand "Microphone disconnected" — it froze the very
     /// claim that was false, since an engine that fails to recover leaves the
     /// microphone plugged in. Both causes are exercised now, so the freeze locks
-    /// the distinction rather than the bug.
+    /// the distinction rather than the bug. Copy is frozen in the presenter test.
     @Test(
       "handleEngineInterruption: L/S/T/F bridges to a cause-accurate driver error (matrix #4)",
       arguments: [
-        (EngineInterruptionCause.deviceRemoved, "Microphone disconnected"),
-        (EngineInterruptionCause.engineLost, "Recording interrupted"),
+        (EngineInterruptionCause.deviceRemoved, TerminalNoticeReason.deviceRemoved),
+        (EngineInterruptionCause.engineLost, TerminalNoticeReason.engineLost),
       ])
     func engineInterruptionBridgesActiveNonRecording(
-      cause: EngineInterruptionCause, expected: String
+      cause: EngineInterruptionCause, expected: TerminalNoticeReason
     ) async {
       for placement: Placement in [
         .arming, .stopping, .deliveringTranscribing, .deliveringFinalizing,
@@ -248,7 +249,7 @@ import Testing
         await place(fx.kernel, in: placement)
         fx.driver.handleEngineInterruption(cause)
         await drain()
-        assertDriverIsError(fx.driver, contains: expected)
+        assertDriverIsError(fx.driver, reason: expected)
       }
     }
 
@@ -281,16 +282,16 @@ import Testing
       // The old test ended in `_ = fx.driver.state  // no crash on read`, which
       // stayed green even if reset() stopped nil-ing lastExternalError (the
       // getter is pure and cannot crash). This pins the real reset() contract.
-      fx.driver.setExternalError("boom")
-      #expect(fx.driver.state == .error("boom"))
+      fx.driver.setTerminalReason(.modelWedged)
+      #expect(fx.driver.state == .error(.modelWedged))
       fx.driver.reset()
       await drain()
       // reset() nils lastExternalError synchronously, so the external-error
       // short-circuit no longer applies. kernel.cancel from .preparing leaves
       // the kernel ~.preparing in this forced-state fixture (no forward path to
       // consume the cancel flag), so the public state falls back to the mapped
-      // kernel state — crucially NOT .error("boom").
-      #expect(fx.driver.state != .error("boom"))
+      // kernel state — crucially NOT .error(.modelWedged).
+      #expect(fx.driver.state != .error(.modelWedged))
     }
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverSurfaceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverSurfaceTests.swift
@@ -45,7 +45,7 @@ import Testing
     @Test("cancelRecording() drives the kernel cancel path")
     func cancelRecordingForwardsToKernel() async {
       let driver = makeDriver()
-      driver.setExternalError("boom")  // parks kernel + flips external error
+      driver.setTerminalReason(.modelWedged)  // parks kernel + flips external error
       await driver.cancelRecording()
       // After cancel, the kernel is idle or terminal. external error stays
       // (only reset/start clears); the surface signal is "no exception, no
@@ -58,10 +58,10 @@ import Testing
     @Test("reset() clears the external-error surface")
     func resetClearsExternalError() {
       let driver = makeDriver()
-      driver.setExternalError("boom")
+      driver.setTerminalReason(.modelWedged)
       if case .error = driver.state {
       } else {
-        Issue.record("setExternalError should park driver in .error")
+        Issue.record("setTerminalReason should park driver in .error")
       }
       driver.reset()
       // The state mapper returns .idle from the kernel's resting state once

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -25,10 +25,10 @@ import Testing
       -> PipelineState
     {
       KernelDictationDriver.pipelineState(
-        for: s, outcome: nil, deliveringPhase: phase, externalError: nil)
+        for: s, outcome: nil, deliveringPhase: phase, externalReason: nil)
     }
     func mappedOutcome(_ o: RecordingOutcome) -> PipelineState {
-      KernelDictationDriver.pipelineState(for: .idle, outcome: o, externalError: nil)
+      KernelDictationDriver.pipelineState(for: .idle, outcome: o, externalReason: nil)
     }
     // In-flight states (#1548 D1) — every active state must report `isActive` so
     // the backend-switch guard (`PipelineSettingsSync`, §3.13) sees the kernel
@@ -59,46 +59,34 @@ import Testing
     }
   }
 
-  @Test("an external error overrides the mapped state")
-  func externalErrorOverridesState() {
+  @Test("an external reason overrides the mapped state")
+  func externalReasonOverridesState() {
     #expect(
-      KernelDictationDriver.pipelineState(for: .idle, outcome: nil, externalError: "boom")
-        == .error("boom"))
+      KernelDictationDriver.pipelineState(for: .idle, outcome: nil, externalReason: .modelWedged)
+        == .error(.modelWedged))
     #expect(
-      KernelDictationDriver.pipelineState(for: .live, outcome: nil, externalError: "boom")
-        == .error("boom"))
+      KernelDictationDriver.pipelineState(for: .live, outcome: nil, externalReason: .modelWedged)
+        == .error(.modelWedged))
   }
 
-  @Test("failureMessage mirrors the shipped strings for the equivalent failures")
-  func failureMessages() {
-    #expect(KernelDictationDriver.failureMessage(.asrEmpty) == "Couldn't catch that -- try again")
-    #expect(KernelDictationDriver.failureMessage(.noAudioCaptured) == "No audio captured")
+  // #1558: the driver's `failureMessage` string-authoring was deleted. Reason
+  // mapping is proven in `TerminalNoticeReasonMappingTests`; customer copy in
+  // `TerminalNoticePresenterTests`. What remains here is that the outcome map
+  // yields the correct TYPED reason (no raw detail).
+  @Test("the failed-outcome map yields the typed reason, not an authored string")
+  func failedOutcomeYieldsTypedReason() {
     #expect(
-      KernelDictationDriver.failureMessage(.emptyAfterProcessing)
-        == "No speech detected. Your clipboard is unchanged. Try again.")
-  }
-
-  @Test("failureMessage embeds error detail for the three TP-parity reasons (Div 4)")
-  func failureMessagesWithDetail() {
-    // Parity with the old Parakeet pipeline at TP:440-445 / TP:577-588 / TP:1045-1051:
-    // include `error.localizedDescription` when present.
+      KernelDictationDriver.pipelineState(
+        for: .idle, outcome: .failed(.asrEmpty), externalReason: nil)
+        == .error(.asrEmptyWithSpeech))
     #expect(
-      KernelDictationDriver.failureMessage(.modelLoadFailed, detail: "out of memory")
-        == "Model load failed: out of memory")
+      KernelDictationDriver.pipelineState(
+        for: .idle, outcome: .failed(.modelLoadFailed), externalReason: nil)
+        == .error(.modelLoadFailed))
     #expect(
-      KernelDictationDriver.failureMessage(.captureStartFailed, detail: "device busy")
-        == "Recording failed: device busy")
-    #expect(
-      KernelDictationDriver.failureMessage(.asrFailed, detail: "stream closed")
-        == "Transcription failed: stream closed")
-    // No detail → byte-parity with the bare strings.
-    #expect(KernelDictationDriver.failureMessage(.modelLoadFailed) == "Model load failed.")
-    #expect(KernelDictationDriver.failureMessage(.captureStartFailed) == "Recording failed.")
-    #expect(KernelDictationDriver.failureMessage(.asrFailed) == "Transcription failed.")
-    // Other reasons ignore the detail (out-of-scope for parity).
-    #expect(
-      KernelDictationDriver.failureMessage(.asrEmpty, detail: "irrelevant")
-        == "Couldn't catch that -- try again")
+      KernelDictationDriver.pipelineState(
+        for: .idle, outcome: .noTransport, externalReason: nil)
+        == .error(.noAudioCaptured))
   }
 
   // MARK: handle(event:) -> kernel triggers
@@ -160,20 +148,20 @@ import Testing
 
   // MARK: External-error surface
 
-  @Test("setExternalError surfaces .error on state and overlay")
-  func setExternalErrorSurfaces() {
+  @Test("setTerminalReason surfaces .error on state and overlay (typed)")
+  func setTerminalReasonSurfaces() {
     let h = makeDriver()
-    h.driver.setExternalError("device unplugged")
-    #expect(h.driver.state == .error("device unplugged"))
-    #expect(h.driver.overlayIntent == .error(message: "device unplugged"))
+    h.driver.setTerminalReason(.deviceRemoved)
+    #expect(h.driver.state == .error(.deviceRemoved))
+    #expect(h.driver.overlayIntent == .error(reason: .deviceRemoved))
   }
 
-  @Test("a new start clears the external error")
-  func startClearsExternalError() async throws {
+  @Test("a new start clears the external terminal reason")
+  func startClearsTerminalReason() async throws {
     let h = makeDriver()
-    h.driver.setExternalError("device unplugged")
+    h.driver.setTerminalReason(.deviceRemoved)
     try await startDriverToLive(h)
-    #expect(h.driver.state != .error("device unplugged"))
+    #expect(h.driver.state != .error(.deviceRemoved))
   }
 
   // MARK: currentTranscript / lastPolishError side-channel
@@ -207,23 +195,19 @@ import Testing
   }
 
   #if DEBUG
-    @Test("overlayIntent surfaces failure detail (Div 4 — overlay parity)")
-    func overlayIntentEnrichedDetail() {
+    @Test("a failed terminal surfaces the TYPED reason — no raw detail leak (#1558)")
+    func failedTerminalSurfacesTypedReasonNoRawLeak() {
       let h = makeDriver()
-      h.kernel.testSetModelLoadError(
-        NSError(
-          domain: "test", code: 1,
-          userInfo: [NSLocalizedDescriptionKey: "vram exhausted"]))
       // Conclude on .failed(.modelLoadFailed) — the ending category is an
-      // outcome now, not an FSM state (#1548 D1).
+      // outcome now, not an FSM state (#1548 D1). #1558: the driver no longer
+      // reads a raw `localizedDescription`; the state and overlay carry the
+      // TYPED reason and the presenter authors clean copy.
       #expect(h.kernel.testForceTransition(to: .arming))
       h.kernel.testForceConclude(.failed(.modelLoadFailed))
-      // Both the lifecycle-coordinator state read AND the visible overlay
-      // must carry the enriched detail; an unenriched overlay was the bug
-      // Codex flagged on the initial Div 4 patch.
-      #expect(h.driver.state == .error("Model load failed: vram exhausted"))
-      #expect(
-        h.driver.overlayIntent == .error(message: "Model load failed: vram exhausted"))
+      // The state and overlay carry the typed reason; no String detail exists to
+      // leak. Customer copy is proven in `TerminalNoticePresenterTests` (AppKit).
+      #expect(h.driver.state == .error(.modelLoadFailed))
+      #expect(h.driver.overlayIntent == .error(reason: .modelLoadFailed))
     }
 
     @Test(

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -741,6 +741,18 @@ import Testing
     #expect(recorder.captureErrors.first?.stage == "recording")
   }
 
+  @Test(".failed(.noMicrophoneFound) emits .audioCaptureFailed captureError (#1558)")
+  func failedNoMicrophoneFoundEmission() {
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder)
+    sink.emit(.failed(.noMicrophoneFound))
+    // Keeps the audio_capture_failed cluster populated (distinct failureMode)
+    // so the held-release drop stays observable post-ship.
+    #expect(recorder.captureErrors.count == 1)
+    #expect(recorder.captureErrors.first?.category == .audioCaptureFailed)
+    #expect(recorder.captureErrors.first?.stage == "recording")
+  }
+
   @Test(
     ".failed(.asrEmpty) downgrades to a breadcrumb, emits NO captureError (#979)",
     .bug("https://github.com/saurabhav88/EnviousWispr/issues/979", "ASR-empty non-bug"))

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangeHandlerTests.swift
@@ -259,8 +259,8 @@ struct PipelineStateChangeHandlerTests {
     let handler = Self.makeHandler(overlay: spy, callbacks: calls)
 
     handler.handle(
-      to: PipelineState.error("mic_disconnected"),
-      pipelineOverlayIntent: .error(message: "mic_disconnected"),
+      to: PipelineState.error(.deviceRemoved),
+      pipelineOverlayIntent: .error(reason: .deviceRemoved),
       lastPolishError: nil,
       currentTranscript: nil,
       historySaved: true,
@@ -269,8 +269,8 @@ struct PipelineStateChangeHandlerTests {
 
     #expect(calls.cancelWarningCount == 1)
     #expect(
-      spy.calls == [OverlaySpy.Call(intent: .error(message: "mic_disconnected"))])
-    #expect(calls.failedCalls == ["mic_disconnected"])
+      spy.calls == [OverlaySpy.Call(intent: .error(reason: .deviceRemoved))])
+    #expect(calls.failedCalls == [TerminalNoticeReason.deviceRemoved.rawValue])
     #expect(calls.appendedCalls.count == 0)
     #expect(calls.completedCalls.isEmpty)
   }

--- a/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PipelineStateChangePlannerTests.swift
@@ -225,7 +225,7 @@ struct PipelineStateChangePlannerTests {
   @Test("non-complete transitions cancel pending warning")
   func nonCompleteTransitionsCancelWarning() {
     let nonCompleteStates: [PipelineState] = [
-      .idle, .loadingModel, .recording, .transcribing, .polishing, .error("boom"),
+      .idle, .loadingModel, .recording, .transcribing, .polishing, .error(.modelWedged),
     ]
     for state in nonCompleteStates {
       let plan = PipelineStateChangePlanner.plan(
@@ -263,7 +263,7 @@ struct PipelineStateChangePlannerTests {
       (.transcribing, .processing(label: "Transcribing...")),
       (.polishing, .processing(label: "Polishing...")),
       (.recording, .recording(audioLevel: 0)),
-      (.error("boom"), .error(message: "boom")),
+      (.error(.modelWedged), .error(reason: .modelWedged)),
     ]
     for (state, intent) in pairs {
       let plan = PipelineStateChangePlanner.plan(
@@ -293,8 +293,8 @@ struct PipelineStateChangePlannerTests {
   @Test("error state emits reportPipelineFailed with error code")
   func errorStateEmitsReportPipelineFailed() {
     let plan = PipelineStateChangePlanner.plan(
-      to: PipelineState.error("mic_disconnected"),
-      pipelineOverlayIntent: .error(message: "mic_disconnected"),
+      to: PipelineState.error(.deviceRemoved),
+      pipelineOverlayIntent: .error(reason: .deviceRemoved),
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: nil,
@@ -302,9 +302,9 @@ struct PipelineStateChangePlannerTests {
       historySaved: true,
       historySaveReason: nil
     )
-    #expect(plan.effects.contains(.reportPipelineFailed(errorCode: "mic_disconnected")))
+    #expect(plan.effects.contains(.reportPipelineFailed(errorCode: TerminalNoticeReason.deviceRemoved.rawValue)))
     #expect(plan.effects.contains(.cancelPendingWarning))
-    #expect(plan.effects.contains(.showOverlay(.error(message: "mic_disconnected"))))
+    #expect(plan.effects.contains(.showOverlay(.error(reason: .deviceRemoved))))
     // error must not trigger .complete-path effects.
     #expect(!plan.effects.contains(.appendCompletedTranscript))
     #expect(!plan.effects.contains(.reportDictationCompleted))
@@ -401,8 +401,8 @@ struct PipelineStateChangePlannerTests {
   @Test("error plan produces cancel, show, report order")
   func errorEffectOrder() {
     let plan = PipelineStateChangePlanner.plan(
-      to: PipelineState.error("bad"),
-      pipelineOverlayIntent: .error(message: "bad"),
+      to: PipelineState.error(.modelWedged),
+      pipelineOverlayIntent: .error(reason: .modelWedged),
       isClipboardFallback: false,
       isAccessibilityToast: false,
       lastPolishError: nil,
@@ -413,8 +413,8 @@ struct PipelineStateChangePlannerTests {
     #expect(
       plan.effects == [
         .cancelPendingWarning,
-        .showOverlay(.error(message: "bad")),
-        .reportPipelineFailed(errorCode: "bad"),
+        .showOverlay(.error(reason: .modelWedged)),
+        .reportPipelineFailed(errorCode: TerminalNoticeReason.modelWedged.rawValue),
       ])
   }
 
@@ -709,7 +709,7 @@ struct PipelineStateChangePlannerTests {
     #expect(PipelineState.transcribing.activity == .processing)
     #expect(PipelineState.polishing.activity == .processing)
     #expect(PipelineState.complete.activity == .complete)
-    #expect(PipelineState.error("x").activity == .error("x"))
+    #expect(PipelineState.error(.modelWedged).activity == .error(.modelWedged))
   }
 
   // PR-5 Rung 5 (#827) deleted: WhisperKit's bespoke state-activity mapping

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
@@ -536,58 +536,49 @@ import Testing
   /// longer carry "Microphone disconnected" unconditionally — that string was a
   /// lie for a recovery failure, the duration cap, and our own helper crashing.
   ///
-  /// `InterruptionMessages.message(for:)` is the one authority for which sentence
-  /// a user reads, and the three `KernelDictationDriver` render sites all route
-  /// through it. These tests are what keep the claim honest: exactly the causes
-  /// backed by a real Core Audio removal may say a microphone disconnected.
-  @Suite("The interruption sentence never claims more than we know (#1408)")
-  struct InterruptionMessageTests {
+  /// #1558: the interruption copy authority moved from `InterruptionMessages`
+  /// to the typed map (`KernelDictationDriver.terminalNoticeReason(for:)`) plus
+  /// the AppKit presenter. These tests keep the claim honest at the TYPED-reason
+  /// layer: only a verified device loss earns the disconnect reason; the
+  /// customer sentence itself is frozen in `TerminalNoticePresenterTests`.
+  @Suite("The interruption reason never claims more than we know (#1408 / #1558)")
+  struct InterruptionReasonTests {
 
-    @Test("only a verified device loss says the microphone disconnected")
-    func onlyDeviceLossClaimsADisconnect() {
+    @Test("only a verified device loss maps to the disconnect reason")
+    func onlyDeviceLossMapsToDisconnectReason() {
       for cause in EngineInterruptionCause.allCases {
-        let sentence = InterruptionMessages.message(for: cause)
+        let reason = KernelDictationDriver.terminalNoticeReason(for: cause)
         if cause.isDeviceLoss {
-          #expect(sentence == "Microphone disconnected", "\(cause) earns the claim")
+          #expect(reason == .deviceRemoved, "\(cause) earns the disconnect reason")
         } else {
           #expect(
-            sentence == "Recording interrupted",
-            "\(cause) is not a microphone walking away, so it must not say one did")
+            reason == .engineLost,
+            "\(cause) is not a microphone walking away, so it must not claim one did")
         }
       }
     }
 
-    /// The set that may claim a disconnect is exactly the set `isDeviceLoss`
-    /// names. Coupled rather than restated, so a sixth cause cannot quietly
-    /// inherit the disconnect sentence by being added to the wrong list.
-    @Test("the claiming set is exactly the isDeviceLoss set")
-    func claimingSetEqualsDeviceLossSet() {
+    /// The set mapping to `.deviceRemoved` is exactly the `isDeviceLoss` set —
+    /// coupled, so a new cause cannot inherit the disconnect reason by accident.
+    @Test("the disconnect-reason set is exactly the isDeviceLoss set")
+    func disconnectReasonSetEqualsDeviceLossSet() {
       let claims = Set(
         EngineInterruptionCause.allCases.filter {
-          InterruptionMessages.message(for: $0) == "Microphone disconnected"
+          KernelDictationDriver.terminalNoticeReason(for: $0) == .deviceRemoved
         })
       let deviceLoss = Set(EngineInterruptionCause.allCases.filter(\.isDeviceLoss))
       #expect(claims == deviceLoss)
       #expect(claims == [.deviceRemoved])
     }
 
-    /// An `.audioInterrupted` terminal with no stamped cause should never be
-    /// reachable (the kernel refuses salvage and logs), but if it ever is, the
-    /// absence of evidence must not read as evidence of a disconnect.
-    @Test("no stamped cause falls back to the neutral line, never a disconnect")
+    /// A no-stamped-cause interruption should never be reachable (the kernel
+    /// refuses salvage and logs), but if it ever is, the absence of evidence
+    /// must map to the neutral reason, never a disconnect.
+    @Test("no stamped cause falls back to the neutral reason, never a disconnect")
     func missingCauseIsNeutral() {
-      #expect(InterruptionMessages.message(for: nil) == "Recording interrupted")
-    }
-
-    /// Rule 6: no em-dashes or en-dashes in anything a user reads.
-    @Test("neither sentence carries a dash a human would see")
-    func noDashesInUserFacingCopy() {
-      for sentence in [
-        InterruptionMessages.micDisconnected, InterruptionMessages.recordingInterrupted,
-      ] {
-        #expect(!sentence.contains("\u{2014}"), "em-dash in user-facing copy: \(sentence)")
-        #expect(!sentence.contains("\u{2013}"), "en-dash in user-facing copy: \(sentence)")
-      }
+      #expect(
+        KernelDictationDriver.terminalNoticeReason(for: EngineInterruptionCause?.none)
+          == .unknownInterruption)
     }
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -401,6 +401,11 @@ final class KernelRecordingSession: RecordingSessionDriving {
     case .modelWedged: return .modelWedged
     case .modelLoadFailed: return .modelLoadFailed
     case .captureStartFailed: return .captureStartFailed
+    // #1558: the simulator's FSM taxonomy does not distinguish a no-device
+    // start failure from a generic capture-start failure — both drive the FSM
+    // identically here. The user-facing distinction is proven in
+    // TerminalNoticeReasonMappingTests / KernelLifecycleTelemetrySinkTests.
+    case .noMicrophoneFound: return .captureStartFailed
     case .noAudioCaptured: return .noAudioCaptured
     case .asrEmpty: return .asrEmpty
     case .asrFailed: return .asrFailed

--- a/Tests/EnviousWisprTests/Pipeline/TerminalNoticeReasonMappingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TerminalNoticeReasonMappingTests.swift
@@ -1,0 +1,48 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1558 (heartpath E1). Freezes the engine → typed-reason maps: every
+/// `RecordingFailureReason` and every `EngineInterruptionCause?` lands on the
+/// intended `TerminalNoticeReason`. Both maps are exhaustive (no `default`), so
+/// a new source case reds the build until it is assigned here.
+@Suite struct TerminalNoticeReasonMappingTests {
+
+  @Test("every RecordingFailureReason maps to its typed reason")
+  func failureReasonMapping() {
+    let cases: [(RecordingFailureReason, TerminalNoticeReason)] = [
+      (.prepareFailed, .prepareFailed),
+      (.permissionDenied, .permissionDenied),
+      (.modelWedged, .modelWedged),
+      (.modelLoadFailed, .modelLoadFailed),
+      (.captureStartFailed, .captureStartFailed),
+      (.noAudioCaptured, .noAudioCaptured),
+      (.asrEmpty, .asrEmptyWithSpeech),
+      (.asrFailed, .asrFailed),
+      (.asrWedged, .asrWedged),
+      (.emptyAfterProcessing, .emptyAfterProcessing),
+      (.captureStalled, .captureStalled),
+      (.zeroSignal, .zeroSignal),
+    ]
+    for (reason, expected) in cases {
+      #expect(KernelDictationDriver.terminalNoticeReason(for: reason) == expected)
+    }
+  }
+
+  @Test("interruption cause maps: deviceRemoved / engineLost / nil → neutral")
+  func interruptionCauseMapping() {
+    #expect(
+      KernelDictationDriver.terminalNoticeReason(for: EngineInterruptionCause.deviceRemoved)
+        == .deviceRemoved)
+    #expect(
+      KernelDictationDriver.terminalNoticeReason(for: EngineInterruptionCause.engineLost)
+        == .engineLost)
+    // A nil cause narrates as the neutral interruption (matches the retired
+    // InterruptionMessages nil handling).
+    #expect(
+      KernelDictationDriver.terminalNoticeReason(for: EngineInterruptionCause?.none)
+        == .unknownInterruption)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/TerminalNoticeReasonMappingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TerminalNoticeReasonMappingTests.swift
@@ -1,5 +1,6 @@
 import EnviousWisprAudio
 import EnviousWisprCore
+import Foundation
 import Testing
 
 @testable import EnviousWisprPipeline
@@ -18,6 +19,7 @@ import Testing
       (.modelWedged, .modelWedged),
       (.modelLoadFailed, .modelLoadFailed),
       (.captureStartFailed, .captureStartFailed),
+      (.noMicrophoneFound, .noMicrophoneFound),
       (.noAudioCaptured, .noAudioCaptured),
       (.asrEmpty, .asrEmptyWithSpeech),
       (.asrFailed, .asrFailed),
@@ -29,6 +31,25 @@ import Testing
     for (reason, expected) in cases {
       #expect(KernelDictationDriver.terminalNoticeReason(for: reason) == expected)
     }
+  }
+
+  @Test("classifyCaptureStartError distinguishes no-device, permission, and generic (P2 #1563)")
+  func captureStartErrorClassification() {
+    // A missing input device must classify distinctly so the toggle/menu path
+    // surfaces "No microphone found.", not the generic capture error.
+    #expect(
+      RecordingSessionKernel.classifyCaptureStartError(AudioError.noBuiltInMicrophoneFound)
+        == .noMicrophoneFound)
+    // Permission and generic classifications are unchanged.
+    #expect(
+      RecordingSessionKernel.classifyCaptureStartError(
+        NSError(
+          domain: "x", code: 1,
+          userInfo: [NSLocalizedDescriptionKey: "microphone permission denied"]))
+        == .permissionDenied)
+    #expect(
+      RecordingSessionKernel.classifyCaptureStartError(NSError(domain: "x", code: 2))
+        == .captureStartFailed)
   }
 
   @Test("interruption cause maps: deviceRemoved / engineLost / nil → neutral")

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -68,12 +68,12 @@ struct DedupSurvivesStallTests {
     // First stall in session 1 — emitter fires (no prior dedup); the kernel's
     // recording-exit continuation resumes the forward-path coroutine, which
     // then transitions to `.failed(.captureStalled)` (driver maps to
-    // `.error("No audio detected -- try again.")`). The transition is async
+    // `.error(.captureStalled)`). The transition is async
     // because the forward path runs in a separate Task — poll until it lands.
     pipeline.handleCaptureStall(Self.stallContext(sessionID: 1))
-    await stateWaiter.wait(for: .error("No audio detected — try again."))
+    await stateWaiter.wait(for: .error(.captureStalled))
     #expect(
-      pipeline.state == .error("No audio detected — try again."),
+      pipeline.state == .error(.captureStalled),
       "first stall in session 1 must flip state to .error")
 
     // Reset to idle so we can start session 2. `cancelRecording()` is a
@@ -96,9 +96,9 @@ struct DedupSurvivesStallTests {
     // to .error. If dedup state had leaked across recordings, state would
     // remain .recording and this test would fail.
     pipeline.handleCaptureStall(Self.stallContext(sessionID: 2))
-    await stateWaiter.wait(for: .error("No audio detected — try again."))
+    await stateWaiter.wait(for: .error(.captureStalled))
     #expect(
-      pipeline.state == .error("No audio detected — try again."),
+      pipeline.state == .error(.captureStalled),
       "stall in fresh session 2 must fire — dedup state must not survive restart")
 
     await pipeline.cancelRecording()
@@ -162,7 +162,7 @@ private final class NeverFinishingAudioCapture: AudioCaptureInterface {
     currentCaptureSessionID += 1
     // #1548 D2: reaching `.live` no longer needs a buffer (the forward path
     // transitions sequentially). But THIS scenario is a stall AFTER audio arrives —
-    // a genuine capture-stall ("No audio detected — try again."), not a dead-mic
+    // a genuine capture-stall (.captureStalled), not a dead-mic
     // no-transport. So deliver ONE buffer to make `bufferCountThisSession > 0`,
     // which is what routes the later `.noBuffers` stall to `.captureStall` instead
     // of `.noTransport`. Then the stream parks, holding `.live`.


### PR DESCRIPTION
Part of #1511 (heartpath refactor, step 6a / E1 of the "one voice" 4-part decomposition). Closes #1558.

## What this does

Introduces a stateless `TerminalNoticePresenter` (AppKit) as the **sole author** of the six founder-locked terminal-failure / interruption pill sentences. The engine stops shipping pre-authored English upward and emits a **typed `TerminalNoticeReason`** (new Core enum) instead; the AppKit presenter translates it. Scoreboard: **6 copy authors → 5**.

The six sentences (locked, issue #1558):
- `Audio capture error. Try again.` — our-fault start/capture failures
- `Transcription error. Try again.` — our-fault transcribe failures (incl. "couldn't catch that")
- `Microphone access is off.` — permission denied
- `No microphone found. Please connect one.` — no usable device
- `Microphone disconnected.` — device verified gone (audio saved)
- `Recording interrupted.` — engine failed, device present (audio saved)

## The headline win: the raw-error-string leak is gone

`KernelDictationDriver.failureMessage` used to interpolate raw internal error detail straight onto the pill and main window (`Model load failed: <localizedDescription>`). That authoring path is **deleted**, along with `InterruptionMessages`, `asrInterruptedMessage`, `RecordingSessionKernel.lastFailureDetail` (+ its three test-only setters), and `ModelLoadWatchdog.userMessage`. The raw detail now stays owned by the existing producer Sentry sites (the reason maps are pure — no telemetry side-effect, so no double-emit). The typed reason's `rawValue` is the stable PostHog `pipeline.failed` error_code.

## Design

Engine emits fact → AppKit says sentence. `OverlayIntent.error/.interruption` and the Core `PipelineState`/`PipelineActivity` `.error` carriers are retyped `String` → `TerminalNoticeReason`. The carrier lives in Core because both Core-level state enums hold it; putting a Pipeline type there would invert dependency direction. This **improves** dependency direction — Pipeline no longer produces UI sentences.

## Validation

- **Logic tests:** `scripts/xcode-test.sh` green — **2964 tests**. Two new suites freeze the contract: `TerminalNoticePresenterTests` (every reason → its exact sentence; no raw-detail-prefix leak; no dashes) and `TerminalNoticeReasonMappingTests` (every `RecordingFailureReason` + `EngineInterruptionCause?` → typed reason). ~18 existing test files migrated to the typed reason.
- **Grounded review:** Codex `PROCEED-AS-PLANNED` after 4 rounds (7 → 3 → 2 → 0 findings). Council skipped (heartpath D-021).
- **Codex code-diff review:** clean, no findings — "the typed terminal-reason migration is complete across producers, state carriers, telemetry, and UI consumers; structure is sound; dependency checks passed; 98 focused tests passed."
- **Live UAT (verdict from `app.log`, per RULE: uat-verdicts-from-app-log):** dev app launches clean (no crash — the Core retype does not break init). The heart path runs end-to-end on real audio (capture → VAD → ASR → terminal), and the retyped state machine routes real terminals correctly: a `noSpeech` take mapped to idle (silent, no error pill) and a real `failed(.asrEmpty)` take was processed without crash — the exact path that now surfaces `.error(.asrEmptyWithSpeech)` → "Transcription error. Try again." A clean successful text-paste was not obtainable because the TTS-over-speaker→mic loopback audio was too quiet for Parakeet to decode (`peak 0.03–0.10`, max −7 dB) — a documented harness/environment limit, not a regression.

## Blast radius

Core (2 enums), Pipeline (`OverlayIntent`, driver maps, deletions), AppKit (presenter + render consumers). Not touched: audio capture, recovery/spool, FSM states, WhisperKit setup state, LLM/polish copy. Rollback is a clean squash-revert (no persisted-state migration).

## Not in this PR (deliberate)

The "Open Settings" deep-link button on the permission pill, and root-causing `vad#prepare_failed` (197 users) — both separate follow-up issues. E2/E3/E4 (progress labels, warnings, renderer cutover) are the other message families.

Plan (local-only, `docs/` gitignored): `docs/feature-requests/issue-1558-2026-07-15-e1-one-narrator.md`.
