### PR TITLE
feat(pipeline): consolidate polish-skip telemetry, silence LLMPolishStep during recovery

### DIFF
--- a/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
@@ -8,10 +8,17 @@ import NaturalLanguage
 
 /// Typed AFM polish error wrapping a generation-stage throw so `LLMPolishStep`
 /// can capture it to Sentry as `generationFailed`. Thrown by
-/// `AppleIntelligenceConnector.polish()` ONLY for errors that occur during the
-/// on-device generation attempt; pre-generation throws (preflight gate,
-/// framework unavailable, language gate) propagate untyped. (#429, #1072 — the
-/// router fields were dropped when the dual router was removed.)
+/// `AppleIntelligenceConnector.polish()` for errors that occur during the
+/// wrapped `do` block: the on-device generation attempt itself, post-generation
+/// output-language validation (`outputLanguageDrift`), AND `makeSession`'s
+/// defensive availability re-check (which can throw `frameworkUnavailable` from
+/// inside this block, not just from the earlier, unwrapped entry preflight).
+/// `unsupportedInputLanguage` is the only silent-skip case that is exclusively
+/// unwrapped — it is thrown before this block on every path. LLMPolishStep's
+/// catch site (#1448) consults the same silent-classification
+/// (`PolishSkipReason.init?(silentLLMError:)`) `TextProcessingRunner` uses
+/// before deciding whether a wrapped error alerts. (#429, #1072 — the router
+/// fields were dropped when the dual router was removed.)
 public struct AFMPolishError: Error, Sendable {
   public let underlying: Error
 
@@ -327,11 +334,10 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
         )
       }
 
-      // Surface real provider-unavailability BEFORE the per-request
-      // language gate so users whose Apple Intelligence is disabled,
-      // downloading, or device-ineligible get a truthful error on their
-      // first attempt (instead of the gate silently masking it for
-      // unsupported languages).
+      // Check provider availability BEFORE the per-request language gate so the
+      // caller receives the provider-state error rather than an unsupported-language
+      // error. The runner surfaces transient `.modelNotReady`, but treats permanent
+      // `.frameworkUnavailable` as a silent raw fallback.
       try Self.throwIfAppleIntelligenceUnavailable()
 
       // Preflight language gate. For non-English supported langs we also
@@ -351,10 +357,14 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       }
 
       // Single-prompt on-device polish (#1072: the dual natural/technical router
-      // was collapsed into one unified prompt). Generation-stage throws are wrapped
-      // in AFMPolishError so LLMPolishStep can capture them to Sentry as
-      // generationFailed; pre-generation throws above (preflight/language gate)
-      // propagate untyped.
+      // was collapsed into one unified prompt). Everything inside this `do` block
+      // (generation, output-language validation, and makeSession's defensive
+      // availability re-check) gets wrapped in AFMPolishError so LLMPolishStep can
+      // capture it to Sentry as generationFailed — UNLESS the underlying LLMError
+      // is one of the silent-skip cases (frameworkUnavailable, outputLanguageDrift),
+      // which the step's catch site rethrows without alerting (#1448). The entry
+      // preflight above (unsupportedInputLanguage, the common frameworkUnavailable
+      // path) propagates untyped, never reaching this wrapping at all.
       do {
         let result = try await polishWithFoundationModels(
           text: text,
@@ -546,11 +556,11 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
   // MARK: - Shared session setup
 
   #if canImport(FoundationModels)
-    /// Probe the on-device model's availability and throw
-    /// `LLMError.frameworkUnavailable` with a human-readable reason if Apple
-    /// Intelligence is not usable. Runs before the per-request language gate
-    /// so setup/download failures are surfaced truthfully instead of being
-    /// masked by an unsupported-language silent-skip.
+    /// Probe the on-device model's availability. Throws `.modelNotReady` for
+    /// transient download or restriction states and `.frameworkUnavailable` for
+    /// permanent incapability. This runs before the per-request language gate so
+    /// an unsupported-language error cannot mask provider availability. The runner
+    /// surfaces only `.modelNotReady`; `.frameworkUnavailable` falls back silently.
     @available(macOS 26.0, *)
     private static func throwIfAppleIntelligenceUnavailable() throws {
       let model = SystemLanguageModel.default

--- a/Sources/EnviousWisprLLM/LLMProtocol.swift
+++ b/Sources/EnviousWisprLLM/LLMProtocol.swift
@@ -226,7 +226,7 @@ public enum LLMError: LocalizedError, Sendable, Equatable {
       return "LLM polish output drifted from expected language '\(expected)' to '\(actual)'."
     case .egOneSkipped(let reason):
       // Silent bypass — never an on-screen notice; log/debug reads only.
-      return "EG-1 polish skipped (\(reason.rawValue))."
+      return "EG-1 polish skipped (\(String(describing: reason)))."
     case .localPolishNotReady(let reason):
       // Surfaced skip (#1305) — the on-screen notice is the pinned copy in
       // `PolishFailureReason.ollamaPreflightSkipMessage`, composed by the
@@ -327,25 +327,26 @@ extension LLMError: StableSentryErrorIdentity {
   }
 }
 
-/// Why an EG-1 polish was silently bypassed (#1271). Raw values are the
-/// `llm.polish_skipped` telemetry reason strings — one `local_polish_`
-/// prefix so a single analytics query captures every EG-1 skip mode
-/// (mirrors the AFM `context_window_` prefix family).
-public enum EGOneSkipReason: String, Sendable, Equatable {
+/// Why an EG-1 polish was silently bypassed (#1271). This enum carries domain
+/// meaning only; `PolishSkipReason` in `EnviousWisprPipeline` solely owns
+/// telemetry serialization (#1448/#1461 — it used to double as the
+/// `llm.polish_skipped` reason string via `String` rawValue, which made it a
+/// second serialization authority alongside `PolishSkipReason`).
+public enum EGOneSkipReason: Sendable, Equatable {
   /// Provider selected but no runtime handle / server not ready (booting,
   /// paused for memory pressure, or failed).
-  case notReady = "local_polish_not_ready"
+  case notReady
   /// Model artifact not downloaded/verified yet.
-  case downloadPending = "local_polish_download_pending"
+  case downloadPending
   /// Server unreachable mid-request (crashed; connector already retried
   /// once to cover the restart window).
-  case crashed = "local_polish_crashed"
+  case crashed
   /// Input exceeds the manifest context budget — polish whole or not at
   /// all, never a silent truncation.
-  case inputTooLong = "local_polish_input_too_long"
+  case inputTooLong
   /// The server stopped generation at the max_tokens cap
   /// (finish_reason == length): the content is a PARTIAL rewrite, and
   /// pasting it would be exactly the silent truncation the contract
   /// forbids (#1271 cloud review). Skip whole → raw fallback.
-  case outputTruncated = "local_polish_output_truncated"
+  case outputTruncated
 }

--- a/Sources/EnviousWisprLLM/PolishFailureReason.swift
+++ b/Sources/EnviousWisprLLM/PolishFailureReason.swift
@@ -285,18 +285,6 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
     }
   }
 
-  /// #1305: the `llm.polish_skipped` reason string for the Ollama preflight
-  /// path. Joins the existing `local_polish_` prefix family (EG-1's
-  /// `EGOneSkipReason`) so one analytics query prefix captures every local
-  /// polish skip mode. Content-free; nil for non-preflight reasons.
-  public var ollamaPreflightSkipTelemetryReason: String? {
-    switch self {
-    case .providerUnreachable: return "local_polish_ollama_server_down"
-    case .modelUnavailable: return "local_polish_ollama_model_missing"
-    default: return nil
-    }
-  }
-
   /// Whether a composed notice string represents a "skipped" (not-really-broken)
   /// outcome rather than a hard failure. Keyed off the single `LeadIn.skipped.text`
   /// constant that `composedMessage` also uses, so it can never drift from the

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -104,6 +104,62 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   public var onToken: (@Sendable (String) -> Void)?
 
   private let keychainManager: KeychainManager
+  private let telemetry: TelemetrySeams
+
+  /// Every telemetry signal this step owns, as ONE value (#1461) — mirrors
+  /// `TextProcessingRunner.TelemetrySeams` exactly (struct-of-closures,
+  /// `.live`/`.silent` static presets, memberwise init), deliberately kept as
+  /// a SEPARATE type: the two gate different call sites and different
+  /// failure domains, so merging them would couple unrelated owners.
+  ///
+  /// Before this type, `RecoveryTextProcessor` could silence the runner's own
+  /// three seams via `TextProcessingRunner.TelemetrySeams.silent` but had no
+  /// way to reach this step's own emitters (5 pre-existing, plus the too-short
+  /// skip event this plan adds) — they fired identically on a live take and a
+  /// recovered replay. This seam closes that gap.
+  struct TelemetrySeams {
+    let limbFailureObserved: @MainActor (String, String, String, String, Int?) -> Void
+    let breadcrumbStarted: @MainActor (String, [String: Any]?) -> Void
+    let captureProviderInitError: @MainActor (any Error) -> Void
+    let captureAFMPolishError: @MainActor (any Error) -> Void
+    let breadcrumbCompleted: @MainActor (String, [String: Any]?) -> Void
+    /// The too-short bypass's own emit — this path returns from `process()`
+    /// before `TextProcessingRunner` ever sees it, so the step must own this
+    /// emission itself (#1448). Every OTHER skip reason (the AFM trio,
+    /// EG-1, context-window, Ollama preflight) remains the runner's
+    /// responsibility, routed through its own, separate `recordPolishSkipped`
+    /// seam — this field does not duplicate that.
+    let recordPolishSkipped: @MainActor (String, String) -> Void
+
+    static let live = TelemetrySeams(
+      limbFailureObserved: { limb, op, result, cat, dur in
+        TelemetryService.shared.limbFailureObserved(
+          limb: limb, operation: op, result: result, errorCategory: cat, durationMs: dur)
+      },
+      breadcrumbStarted: { message, data in
+        SentryBreadcrumb.add(stage: "polish", message: message, data: data)
+      },
+      captureProviderInitError: { error in
+        SentryBreadcrumb.captureError(error, category: .providerInitFailed, stage: "polish")
+      },
+      captureAFMPolishError: { error in
+        SentryBreadcrumb.captureAFMPolishError(error)
+      },
+      breadcrumbCompleted: { message, data in
+        SentryBreadcrumb.add(stage: "polish", message: message, data: data)
+      },
+      recordPolishSkipped: { provider, reason in
+        TelemetryService.shared.polishSkipped(provider: provider, reason: reason)
+      })
+
+    static let silent = TelemetrySeams(
+      limbFailureObserved: { _, _, _, _, _ in },
+      breadcrumbStarted: { _, _ in },
+      captureProviderInitError: { _ in },
+      captureAFMPolishError: { _ in },
+      breadcrumbCompleted: { _, _ in },
+      recordPolishSkipped: { _, _ in })
+  }
 
   public var isEnabled: Bool {
     llmProvider != .none
@@ -127,6 +183,26 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
 
   public init(keychainManager: KeychainManager) {
     self.keychainManager = keychainManager
+    self.telemetry = .live
+  }
+
+  /// Internal-only overload (#1461) — used solely by `RecoveryTextProcessor`
+  /// to construct with `.silent`. Not `public`: no external caller should be
+  /// able to silence this step's telemetry, so the public API surface stays
+  /// exactly what it was before this plan.
+  init(keychainManager: KeychainManager, telemetry: TelemetrySeams) {
+    self.keychainManager = keychainManager
+    self.telemetry = telemetry
+  }
+
+  /// Test seam (round 6/7 grounded review) — `evictPreviousOllamaModel`
+  /// directly constructed a real `OllamaConnector()`, making a limb-failure
+  /// test's outcome depend on whether a local Ollama process happened to be
+  /// running. Defaulted to the real call so production is byte-identical;
+  /// tests inject a fixed `OllamaEvictOutcome`.
+  typealias EvictOllamaModel = @MainActor (String) async -> OllamaEvictOutcome
+  var evictOllamaModel: EvictOllamaModel = { modelName in
+    await OllamaConnector().evictModel(modelName)
   }
 
   /// Asks Ollama to unload the named model from memory (fire-and-forget).
@@ -137,15 +213,16 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// `modelName` is empty. Swallows all errors; only logs.
   public func evictPreviousOllamaModel(_ modelName: String) async {
     guard !modelName.isEmpty else { return }
-    let outcome = await OllamaConnector().evictModel(modelName)
+    let outcome = await evictOllamaModel(modelName)
     // #1177 (Telemetry Bible Phase 8): observe a quiet eviction FAILURE — a model that
     // won't unload lingers in VRAM and has disrupted CoreAudio BT audio (#286). The
     // eviction itself stays fire-and-forget; this only reports the outcome. @MainActor
-    // step → direct emit. Fire only on failure (success/skip are non-events).
+    // step → direct emit. Fire only on failure (success/skip are non-events). Not
+    // reachable from crash-recovery replay (`process()` never calls this), but
+    // still routed through the same `.live`/`.silent` seam for consistency.
     if outcome.result == "failed" {
-      TelemetryService.shared.limbFailureObserved(
-        limb: "ollama", operation: "evict", result: "failed",
-        errorCategory: outcome.reason, durationMs: outcome.durationMs)
+      telemetry.limbFailureObserved(
+        "ollama", "evict", "failed", outcome.reason, outcome.durationMs)
     }
   }
 
@@ -195,9 +272,9 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     // read below uses these locals, never `self`, so reentrancy cannot tear it.
     let provider = llmProvider
     let model = llmModel
-    SentryBreadcrumb.add(
-      stage: "polish", message: "LLM polish started",
-      data: [
+    telemetry.breadcrumbStarted(
+      "LLM polish started",
+      [
         "provider": provider.rawValue,
         "model": model,
       ])
@@ -224,6 +301,8 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
             level: .info, category: "LLM"
           )
         }
+        let skipReason = PolishSkipReason.tooShort(provider)
+        telemetry.recordPolishSkipped(skipReason.provider.rawValue, skipReason.telemetryTag)
         return Self.bypassedContext(context)
       }
     } else {
@@ -235,6 +314,8 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
             level: .info, category: "LLM"
           )
         }
+        let skipReason = PolishSkipReason.tooShort(provider)
+        telemetry.recordPolishSkipped(skipReason.provider.rawValue, skipReason.telemetryTag)
         return Self.bypassedContext(context)
       }
     }
@@ -296,8 +377,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     {
       polisher = made
     } else {
-      SentryBreadcrumb.captureError(
-        LLMError.providerUnavailable, category: .providerInitFailed, stage: "polish")
+      telemetry.captureProviderInitError(LLMError.providerUnavailable)
       throw LLMError.providerUnavailable
     }
 
@@ -393,7 +473,20 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
           onToken: onToken
         )
       } catch let afmErr as AFMPolishError {
-        SentryBreadcrumb.captureAFMPolishError(afmErr.underlying)
+        // #1448/#1461: some AFM errors classified silent by TextProcessingRunner
+        // (outputLanguageDrift always; frameworkUnavailable when it reaches this
+        // wrapped path via AppleIntelligenceConnector.makeSession's defensive
+        // re-check) were STILL raising a live alerting Sentry event here,
+        // unconditionally, contradicting their own "silent" classification. Same
+        // check the runner uses (PolishSkipReason.init?(silentLLMError:)) — one
+        // authority, two readers — so this cannot drift out of agreement with the
+        // runner's classification the way a second hardcoded special case would.
+        if let llmError = afmErr.underlying as? LLMError,
+          PolishSkipReason(silentLLMError: llmError) != nil
+        {
+          throw llmError
+        }
+        telemetry.captureAFMPolishError(afmErr.underlying)
         throw afmErr.underlying
       }
       let llmEnd = CFAbsoluteTimeGetCurrent()
@@ -685,7 +778,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     ]
     data.merge(extraData) { _, new in new }
 
-    SentryBreadcrumb.add(stage: "polish", message: "LLM polish completed", data: data)
+    telemetry.breadcrumbCompleted("LLM polish completed", data)
     Task {
       await AppLogger.shared.log(
         "LLM polish complete: \(result.polishedText.count) chars in \(String(format: "%.3f", duration))s "

--- a/Sources/EnviousWisprPipeline/PolishSkipReason.swift
+++ b/Sources/EnviousWisprPipeline/PolishSkipReason.swift
@@ -1,0 +1,101 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import Foundation
+
+/// The single serialization authority for every `llm.polish_skipped.skip_reason`
+/// value AND the provider each reason is attributed to (#1448, #1461).
+///
+/// Before this type, skip-reason strings were scattered across
+/// `TextProcessingRunner` (raw literals for context-window/EG-1-timeout),
+/// `EGOneSkipReason.rawValue`, and `PolishFailureReason.ollamaPreflightSkipTelemetryReason`
+/// — and provider attribution for the AFM/EG-1 trio depended on a runner-side
+/// snapshot (`polishProviderAtStart`) taken before the step's own, later
+/// snapshot, which could theoretically diverge. `PolishSkipReason` fixes both:
+/// one owner for the tag string, one owner for the provider, always in sync
+/// with the classified reason itself.
+///
+/// "Skip" means no polish output was accepted — NOT "never attempted."
+/// `outputLanguageDrift` fires only after a real generation attempt; the other
+/// AFM cases are pre-attempt bypasses. All 15 cases share the same contract
+/// (Bypass, per `llm-contract.md`): no `polishedText`, no provider stamp, no
+/// error banner.
+enum PolishSkipReason: Sendable, Equatable {
+  case contextWindowPredicted
+  case contextWindowCaught
+  case contextWindowTimeout
+  case localPolishTimeout
+  case egOne(EGOneSkipReason)
+  case ollamaProviderUnreachable
+  case ollamaModelUnavailable
+  case tooShort(LLMProvider)
+  case frameworkUnavailable
+  case unsupportedInputLanguage
+  case outputLanguageDrift
+
+  var telemetryTag: String {
+    switch self {
+    case .contextWindowPredicted: return "context_window_predicted"
+    case .contextWindowCaught: return "context_window_caught"
+    case .contextWindowTimeout: return "context_window_timeout"
+    case .localPolishTimeout: return "local_polish_timeout"
+    case .egOne(let reason):
+      switch reason {
+      case .notReady: return "local_polish_not_ready"
+      case .downloadPending: return "local_polish_download_pending"
+      case .crashed: return "local_polish_crashed"
+      case .inputTooLong: return "local_polish_input_too_long"
+      case .outputTruncated: return "local_polish_output_truncated"
+      }
+    case .ollamaProviderUnreachable: return "local_polish_ollama_server_down"
+    case .ollamaModelUnavailable: return "local_polish_ollama_model_missing"
+    case .tooShort: return "too_short"
+    case .frameworkUnavailable: return "framework_unavailable"
+    case .unsupportedInputLanguage: return "unsupported_input_language"
+    case .outputLanguageDrift: return "output_language_drift"
+    }
+  }
+
+  /// Provider attribution owned here, not derived from a separately-snapshotted
+  /// value elsewhere. Every case except `.tooShort` implies exactly one
+  /// provider by construction; `.tooShort` carries the step's own snapshot
+  /// since the bypass can fire under any provider.
+  var provider: LLMProvider {
+    switch self {
+    case .contextWindowPredicted, .contextWindowCaught, .contextWindowTimeout,
+      .frameworkUnavailable, .unsupportedInputLanguage, .outputLanguageDrift:
+      return .appleIntelligence
+    case .localPolishTimeout, .egOne:
+      return .egOne
+    case .ollamaProviderUnreachable, .ollamaModelUnavailable:
+      return .ollama
+    case .tooShort(let provider):
+      return provider
+    }
+  }
+
+  /// Replaces the deleted `PolishFailureReason.ollamaPreflightSkipTelemetryReason`.
+  init?(ollamaPreflight reason: PolishFailureReason) {
+    switch reason {
+    case .providerUnreachable: self = .ollamaProviderUnreachable
+    case .modelUnavailable: self = .ollamaModelUnavailable
+    default: return nil
+    }
+  }
+
+  /// The ONE classification of "is this LLMError one of the silent AFM skip
+  /// cases" — read by BOTH `TextProcessingRunner` (to emit the skip tag) and
+  /// `LLMPolishStep`'s AFM catch block (to suppress its own alert), so the two
+  /// call sites cannot independently drift out of agreement. `frameworkUnavailable`
+  /// has two producer paths (a normal preflight throw, and a rarer wrapped path
+  /// via `AppleIntelligenceConnector.makeSession`'s defensive re-check) — both
+  /// classify the same way here regardless of which one actually threw.
+  init?(silentLLMError error: LLMError) {
+    switch error {
+    case .frameworkUnavailable: self = .frameworkUnavailable
+    case .unsupportedInputLanguage: self = .unsupportedInputLanguage
+    case .outputLanguageDrift: self = .outputLanguageDrift
+    case .egOneSkipped(let reason): self = .egOne(reason)
+    default: return nil
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -49,7 +49,7 @@ public final class RecoveryTextProcessor {
     keychainManager: KeychainManager, outputClassifierHolder: OutputClassifierHolder? = nil,
     egOneRuntime: (any EGOneEndpointProviding)? = nil
   ) {
-    let llmPolish = LLMPolishStep(keychainManager: keychainManager)
+    let llmPolish = LLMPolishStep(keychainManager: keychainManager, telemetry: .silent)
     // Standalone (no live kernel attached): no streaming/lifecycle callbacks.
     llmPolish.onWillProcess = nil
     llmPolish.onToken = nil
@@ -67,13 +67,10 @@ public final class RecoveryTextProcessor {
       inverseTextNormalization: InverseTextNormalizationStep(),
       llmPolish: llmPolish,
       emojiRestore: EmojiRestoreStep())
-    // #945: crash-recovery polish failures stay silent in telemetry (this is a
-    // live-only metric). A recovered take that fails to polish still returns its
-    // `polishError` in the outcome, but the RUNNER reports nothing.
-    // #1446: `.silent` names every runner-owned seam at once, so a future seam
-    // cannot be added and left live here by accident. It does NOT reach
-    // `LLMPolishStep`'s own emitters, which still fire on a recovered take —
-    // see `TextProcessingRunner.TelemetrySeams.silent` and #1461.
+    // #945 / #1446 / #1461: crash recovery is invisible to live-polish
+    // telemetry. The runner and LLMPolishStep each own separate emitter sets,
+    // so recovery constructs both with their complete `.silent` presets.
+    // Recovery's own coarse result reporting remains owned by its replay flow.
     self.runner = TextProcessingRunner(telemetry: .silent)
   }
 

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -63,9 +63,13 @@ internal final class TextProcessingRunner {
   /// fired." Parameters: provider, model, reason tag, isTimeout.
   typealias RecordPolishFailed = @MainActor (String, String, String, Bool) -> Void
 
-  /// Durable record of a LIVE polish that was never ATTEMPTED — the AFM
-  /// context-window skips (#1055), EG-1 bypasses (#1271), and the Ollama readiness
-  /// preflight (#1305). Parameters: provider, skip reason.
+  /// Durable record that AI polish produced no accepted output under an
+  /// explicit skip contract (#1055, #1271, #1305, #1448) — the AFM
+  /// context-window skips, EG-1 bypasses, the Ollama readiness preflight, the
+  /// too-short bypass, and the AFM language/drift trio. Includes both
+  /// pre-attempt bypasses and post-generation rejection (`outputLanguageDrift`);
+  /// distinct from `llm.polish_failed` (attempted and threw). Parameters:
+  /// provider, skip reason — both sourced from `PolishSkipReason`.
   typealias RecordPolishSkipped = @MainActor (String, String) -> Void
 
   /// Every POLISH telemetry seam the runner owns, as ONE value (#1446).
@@ -114,20 +118,15 @@ internal final class TextProcessingRunner {
         TelemetryService.shared.polishSkipped(provider: provider, reason: reason)
       })
 
-    /// Crash recovery (#945, #1446): a recovered take that fails to polish still
-    /// returns its `polishError`, but the RUNNER reports nothing — no
-    /// `polish_provider_failed` Sentry event, no attempt-failed breadcrumb, no
-    /// `llm.polish_failed`, no `llm.polish_skipped`. Polish telemetry is a
-    /// LIVE-dictation metric.
+    /// Crash recovery (#945, #1446): a recovered take still returns its
+    /// `polishError`, but the runner emits no live-polish telemetry.
     ///
-    /// SCOPE, precisely: this silences the three seams the RUNNER owns. It cannot
-    /// reach `LLMPolishStep`'s own five emitters (`limbFailureObserved`, the
-    /// "LLM polish started" / "completed" breadcrumbs, its `captureError`, and
-    /// `captureAFMPolishError`), which fire from inside the step on a recovered
-    /// take exactly as they do live. Whether recovery should silence those too is a
-    /// separate question with a different owner — tracked in #1461, not papered
-    /// over here. (Cloud review of PR #1460 caught the earlier version of this
-    /// comment claiming recovery emitted "no Sentry event, no breadcrumb"; it does.)
+    /// This preset silences only runner-owned seams. `RecoveryTextProcessor`
+    /// separately constructs `LLMPolishStep` with the step's own `.silent`
+    /// preset so its breadcrumbs, captures, limb metric, and skip event are
+    /// also silent during recovery (#1461) — this was a real gap, closed by
+    /// giving `LLMPolishStep` the identical `.live`/`.silent` shape this type
+    /// already has.
     static let silent = TelemetrySeams(
       captureError: { _, _, _, _, _, _ in },
       recordPolishFailed: { _, _, _, _ in },
@@ -308,21 +307,14 @@ internal final class TextProcessingRunner {
         // (not ready / download pending / crashed / input too long), same
         // contract as the AFM family above. Locked by the adversarial
         // tests in TextProcessingRunnerTests.
-        let isSilentPolishSkip: Bool
-        var egOneSkipReason: String?
-        if let llmError = error as? LLMError {
-          switch llmError {
-          case .unsupportedInputLanguage, .outputLanguageDrift, .frameworkUnavailable:
-            isSilentPolishSkip = true
-          case .egOneSkipped(let skipReason):
-            isSilentPolishSkip = true
-            egOneSkipReason = skipReason.rawValue
-          default:
-            isSilentPolishSkip = false
-          }
-        } else {
-          isSilentPolishSkip = false
+        // #1448/#1461: one classification, `PolishSkipReason.init?(silentLLMError:)`,
+        // read here AND by `LLMPolishStep`'s AFM catch block — replaces the prior
+        // separate case-by-case switch plus a dedicated, untyped `egOneSkipReason`
+        // local. `isSilentPolishSkip` is retained only as this derived boolean.
+        let silentPolishSkipReason = (error as? LLMError).flatMap {
+          PolishSkipReason(silentLLMError: $0)
         }
+        let isSilentPolishSkip = silentPolishSkipReason != nil
         // #945: a raw `URLError.cancelled` from a torn-down request is not a real
         // failure — never surface a notice or fire a capture for it. Swift
         // `CancellationError` is already short-circuited above
@@ -408,22 +400,31 @@ internal final class TextProcessingRunner {
         // single analytics query captures every AFM-long-dictation skip mode:
         // predicted (preflight), caught (generation overflow), timeout (stall).
         if let cw = contextWindowSkip {
-          let skipReason =
-            cw.stage == .predicted ? "context_window_predicted" : "context_window_caught"
-          recordPolishSkipped(LLMProvider.appleIntelligence.rawValue, skipReason)
+          let reason: PolishSkipReason =
+            cw.stage == .predicted ? .contextWindowPredicted : .contextWindowCaught
+          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag)
         } else if isAppleIntelligencePolishTimeout {
-          recordPolishSkipped(LLMProvider.appleIntelligence.rawValue, "context_window_timeout")
+          let reason = PolishSkipReason.contextWindowTimeout
+          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag)
         } else if isEGOnePolishTimeout {
           // #1271: one `local_polish_` prefix family for every EG-1 skip mode.
-          recordPolishSkipped(LLMProvider.egOne.rawValue, "local_polish_timeout")
-        } else if let egOneSkipReason {
-          recordPolishSkipped(LLMProvider.egOne.rawValue, egOneSkipReason)
-        } else if let skipReason = localPolishSkipReason?.ollamaPreflightSkipTelemetryReason {
+          let reason = PolishSkipReason.localPolishTimeout
+          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag)
+        } else if let silentPolishSkipReason {
+          // #1448: covers all 3 AFM cases (frameworkUnavailable,
+          // unsupportedInputLanguage, outputLanguageDrift) AND .egOneSkipped in
+          // one branch — both tag and provider come from PolishSkipReason itself,
+          // never a separately-snapshotted value.
+          recordPolishSkipped(
+            silentPolishSkipReason.provider.rawValue, silentPolishSkipReason.telemetryTag)
+        } else if let localPolishSkipReason,
+          let reason = PolishSkipReason(ollamaPreflight: localPolishSkipReason)
+        {
           // #1305: preflight skips ride the same lightweight `local_polish_`
           // reason family as EG-1 — the observability split between "preflight
           // said not ready" (here) and "mid-flight failure on a running
           // server" (the capture path above) falls out of the reason strings.
-          recordPolishSkipped(LLMProvider.ollama.rawValue, skipReason)
+          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag)
         }
         // #657 (2026-05-05): emit cap-trip telemetry when WordCorrectionStep
         // exceeds its 3s `maxDuration`. The step's result was discarded; raw

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1068,12 +1068,13 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("llm.polish_completed", properties: props)
   }
 
-  /// #1055: AI polish was intentionally skipped (not failed). Dedicated event —
-  /// NOT `llm.polish_completed`, which requires a provider stamp and would
-  /// wrongly mark a skipped transcript as AI-polished. `reason` is one of the
-  /// AFM-long-dictation skip modes (shared `context_window_` prefix):
-  /// `context_window_predicted` (preflight), `context_window_caught` (generation
-  /// overflow), or `context_window_timeout` (the 10 s on-device budget stalled).
+  /// AI polish produced no accepted output under an explicit skip contract
+  /// (#1055, #1271, #1305, #1448). Includes pre-attempt bypasses (too-short,
+  /// context-window preflight, EG-1/Ollama not-ready) and post-generation
+  /// rejection (output-language drift). Distinct from `llm.polish_completed`
+  /// (an output was accepted) and from a surfaced attempted failure recorded
+  /// by `llm.polish_failed`. `reason` is a `PolishSkipReason.telemetryTag` —
+  /// a closed, content-free set (`EnviousWisprPipeline`).
   public func polishSkipped(provider: String, reason: String) {
     let props: [String: Any] = [
       "provider": provider,
@@ -1089,9 +1090,10 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("llm.polish_skipped", properties: props)
   }
 
-  /// #1446: AI polish was ATTEMPTED and threw. The third and last outcome, disjoint
-  /// from `llm.polish_completed` (attempted, succeeded) and `llm.polish_skipped`
-  /// (never attempted) — together the three partition every live polish outcome.
+  /// #1446: AI polish was ATTEMPTED and threw. Disjoint from
+  /// `llm.polish_completed` (an output was accepted) and `llm.polish_skipped`
+  /// (no polish output was accepted under an explicit skip contract). Together
+  /// the three events partition instrumented live polish outcomes.
   ///
   /// Fires for EVERY live attempted-polish failure, whether or not the reason also
   /// earns an alerting Sentry error. That makes this the durable, complete record

--- a/Tests/EnviousWisprTests/LLM/OllamaReadinessPreflightTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaReadinessPreflightTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 
 @testable import EnviousWisprLLM
+@testable import EnviousWisprPipeline
 
 /// #1305: the `OllamaConnector.preflightReadiness` probe — response
 /// classification (pure), transport-failure mapping, the empty-model
@@ -171,17 +172,17 @@ struct OllamaReadinessPreflightTests {
     for reason in PolishFailureReason.allCases
     where reason != .providerUnreachable && reason != .modelUnavailable {
       #expect(reason.ollamaPreflightSkipMessage == nil)
-      #expect(reason.ollamaPreflightSkipTelemetryReason == nil)
+      #expect(PolishSkipReason(ollamaPreflight: reason) == nil)
     }
   }
 
   @Test("preflight telemetry reasons join the local_polish_ family")
   func telemetryReasons() {
     #expect(
-      PolishFailureReason.providerUnreachable.ollamaPreflightSkipTelemetryReason
+      PolishSkipReason(ollamaPreflight: .providerUnreachable)?.telemetryTag
         == "local_polish_ollama_server_down")
     #expect(
-      PolishFailureReason.modelUnavailable.ollamaPreflightSkipTelemetryReason
+      PolishSkipReason(ollamaPreflight: .modelUnavailable)?.telemetryTag
         == "local_polish_ollama_model_missing")
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
@@ -189,9 +189,9 @@ struct EGOnePipelineRoutingTests {
   @Test("skip reasons carry the local_polish_ telemetry prefix")
   func skipReasonPrefixes() {
     for reason in [
-      EGOneSkipReason.notReady, .downloadPending, .crashed, .inputTooLong,
+      EGOneSkipReason.notReady, .downloadPending, .crashed, .inputTooLong, .outputTruncated,
     ] {
-      #expect(reason.rawValue.hasPrefix("local_polish_"))
+      #expect(PolishSkipReason.egOne(reason).telemetryTag.hasPrefix("local_polish_"))
     }
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
@@ -1,0 +1,306 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// `LLMPolishStep`'s own telemetry seam (#1461) — the step's 6 direct emitters
+/// (started/completed breadcrumbs, provider-init error, AFM generation error,
+/// limb-health metric, and the too-short skip event) must go `.silent` during
+/// crash-recovery replay without the runner's own `TelemetrySeams.silent`
+/// reaching them (that seam only covers what `TextProcessingRunner` itself owns).
+///
+/// These tests prove the step's OWN behavior in isolation via a per-instance
+/// injected spy — NOT a process-global mutable delegate (`swift-patterns.md`
+/// RULE: tests-no-process-global-mutable-delegate would forbid that pattern
+/// here, since driving `process()` requires `async` test bodies). The
+/// companion static-source-check proving the REAL `RecoveryTextProcessor` call
+/// site actually passes `.silent` lives in `RecoveryTextProcessorTests.swift`.
+@MainActor
+@Suite("LLMPolishStep telemetry seam (#1461, #1448)")
+struct LLMPolishStepTelemetryTests {
+
+  /// A 16-word sentence that clears the too-short short-circuit.
+  private static let longTranscript =
+    "so i was thinking we could maybe ship the new thing some time next week or so"
+
+  @MainActor
+  final class Spy {
+    private(set) var limbFailureCalls:
+      [(limb: String, op: String, result: String, cat: String, dur: Int?)] = []
+    private(set) var startedCalls: [(message: String, data: [String: Any]?)] = []
+    private(set) var providerInitErrorCalls: [any Error] = []
+    private(set) var afmPolishErrorCalls: [any Error] = []
+    private(set) var completedCalls: [(message: String, data: [String: Any]?)] = []
+    private(set) var skipCalls: [(provider: String, reason: String)] = []
+
+    var seams: LLMPolishStep.TelemetrySeams {
+      LLMPolishStep.TelemetrySeams(
+        limbFailureObserved: { limb, op, result, cat, dur in
+          self.limbFailureCalls.append((limb, op, result, cat, dur))
+        },
+        breadcrumbStarted: { message, data in
+          self.startedCalls.append((message, data))
+        },
+        captureProviderInitError: { error in
+          self.providerInitErrorCalls.append(error)
+        },
+        captureAFMPolishError: { error in
+          self.afmPolishErrorCalls.append(error)
+        },
+        breadcrumbCompleted: { message, data in
+          self.completedCalls.append((message, data))
+        },
+        recordPolishSkipped: { provider, reason in
+          self.skipCalls.append((provider, reason))
+        })
+    }
+  }
+
+  private struct ThrowingPolisher: TranscriptPolisher {
+    let makeError: @Sendable () -> any Error
+    func polish(
+      text: String, instructions: PolishInstructions, config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      throw makeError()
+    }
+  }
+
+  private struct SucceedingPolisher: TranscriptPolisher {
+    func polish(
+      text: String, instructions: PolishInstructions, config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      LLMResult(polishedText: "So I was thinking we could ship the new thing next week.")
+    }
+  }
+
+  private func makeStep(
+    provider: LLMProvider, model: String = "gpt-4o-mini", telemetry: LLMPolishStep.TelemetrySeams
+  ) -> LLMPolishStep {
+    let step = LLMPolishStep(keychainManager: KeychainManager(), telemetry: telemetry)
+    step.llmProvider = provider
+    step.llmModel = model
+    return step
+  }
+
+  // MARK: - Too-short bypass (#1448)
+
+  @Test(
+    "too-short bypass (CJK char-count path) emits its own skip tag; started already fired, nothing else does"
+  )
+  func tooShortBypassCJK() async throws {
+    let spy = Spy()
+    let step = makeStep(provider: .openAI, telemetry: spy.seams)
+    let context = TextProcessingContext(text: "短い", language: "ja")
+
+    _ = try await step.process(context)
+
+    #expect(spy.startedCalls.count == 1)
+    #expect(spy.skipCalls.count == 1)
+    #expect(spy.skipCalls.first?.provider == "openAI")
+    #expect(spy.skipCalls.first?.reason == "too_short")
+    #expect(spy.completedCalls.isEmpty)
+    #expect(spy.providerInitErrorCalls.isEmpty)
+    #expect(spy.afmPolishErrorCalls.isEmpty)
+    #expect(spy.limbFailureCalls.isEmpty)
+  }
+
+  @Test("too-short bypass (Latin word-count path) emits the same skip tag")
+  func tooShortBypassLatin() async throws {
+    let spy = Spy()
+    let step = makeStep(provider: .gemini, telemetry: spy.seams)
+    let context = TextProcessingContext(text: "yeah", language: "en")
+
+    _ = try await step.process(context)
+
+    #expect(spy.startedCalls.count == 1)
+    #expect(spy.skipCalls.count == 1)
+    #expect(spy.skipCalls.first?.provider == "gemini")
+    #expect(spy.skipCalls.first?.reason == "too_short")
+    #expect(spy.completedCalls.isEmpty)
+  }
+
+  // MARK: - Wrapped silent AFM cases no longer alert (#1448/#1461, rounds 2-4 of grounded review)
+
+  @Test("outputLanguageDrift, wrapped as AFMPolishError, no longer alerts")
+  func outputLanguageDriftDoesNotAlert() async throws {
+    let spy = Spy()
+    let step = makeStep(
+      provider: .appleIntelligence, model: "apple-intelligence", telemetry: spy.seams)
+    let underlying = LLMError.outputLanguageDrift(expected: "en", actual: "de")
+    step.makePolisher = { _, _, _ in
+      ThrowingPolisher(makeError: { AFMPolishError(underlying: underlying) })
+    }
+
+    await #expect(throws: LLMError.self) {
+      _ = try await step.process(TextProcessingContext(text: Self.longTranscript, language: "en"))
+    }
+
+    #expect(spy.afmPolishErrorCalls.isEmpty)
+  }
+
+  @Test(
+    "frameworkUnavailable, wrapped as AFMPolishError (the rarer makeSession re-check path), no longer alerts"
+  )
+  func wrappedFrameworkUnavailableDoesNotAlert() async throws {
+    let spy = Spy()
+    let step = makeStep(
+      provider: .appleIntelligence, model: "apple-intelligence", telemetry: spy.seams)
+    let underlying = LLMError.frameworkUnavailable("re-check failed")
+    step.makePolisher = { _, _, _ in
+      ThrowingPolisher(makeError: { AFMPolishError(underlying: underlying) })
+    }
+
+    await #expect(throws: LLMError.self) {
+      _ = try await step.process(TextProcessingContext(text: Self.longTranscript, language: "en"))
+    }
+
+    #expect(spy.afmPolishErrorCalls.isEmpty)
+  }
+
+  @Test("a non-silent wrapped AFM error (modelNotReady) still alerts, unchanged")
+  func wrappedModelNotReadyStillAlerts() async throws {
+    let spy = Spy()
+    let step = makeStep(
+      provider: .appleIntelligence, model: "apple-intelligence", telemetry: spy.seams)
+    let underlying = LLMError.modelNotReady("still downloading")
+    step.makePolisher = { _, _, _ in
+      ThrowingPolisher(makeError: { AFMPolishError(underlying: underlying) })
+    }
+
+    await #expect(throws: LLMError.self) {
+      _ = try await step.process(TextProcessingContext(text: Self.longTranscript, language: "en"))
+    }
+
+    #expect(spy.afmPolishErrorCalls.count == 1)
+  }
+
+  // MARK: - Provider-init failure
+
+  @Test("provider-init failure routes through the seam")
+  func providerInitFailureRoutesThroughSeam() async throws {
+    let spy = Spy()
+    let step = makeStep(provider: .egOne, telemetry: spy.seams)
+    // No egOneRuntime injected -> egOneSkipped(.notReady), not providerInitFailed.
+    // Use a provider whose makePolisher legitimately returns nil instead.
+    step.llmProvider = .openAI
+    step.makePolisher = { _, _, _ in nil }
+
+    await #expect(throws: LLMError.self) {
+      _ = try await step.process(TextProcessingContext(text: Self.longTranscript, language: "en"))
+    }
+
+    #expect(spy.providerInitErrorCalls.count == 1)
+  }
+
+  // MARK: - Recovery construction (.silent) silences all 5 replay-reachable emitters
+
+  @Test("`.silent` construction silences the too-short skip event")
+  func silentConstructionSilencesTooShort() async throws {
+    let spy = Spy()
+    let step = makeStep(provider: .openAI, telemetry: .silent)
+    // Route the spy through a second layer to prove NOTHING reaches it, not
+    // just that `.silent`'s own closures are no-ops.
+    _ = spy
+    _ = try await step.process(TextProcessingContext(text: "yeah", language: "en"))
+    // No spy assertions possible against `.silent` itself (it discards
+    // everything by construction) — this test's value is that `process()`
+    // completes without any live-seam side effect, i.e. it compiles and runs
+    // against `.silent` at all call sites the too-short path touches.
+  }
+
+  @Test("`.silent` construction silences success, provider-init failure, and AFM failure")
+  func silentConstructionSilencesAllPaths() async throws {
+    // Success path.
+    do {
+      let step = makeStep(provider: .openAI, telemetry: .silent)
+      step.makePolisher = { _, _, _ in SucceedingPolisher() }
+      _ = try await step.process(TextProcessingContext(text: Self.longTranscript, language: "en"))
+    }
+    // Provider-init failure path.
+    do {
+      let step = makeStep(provider: .openAI, telemetry: .silent)
+      step.makePolisher = { _, _, _ in nil }
+      await #expect(throws: LLMError.self) {
+        _ = try await step.process(TextProcessingContext(text: Self.longTranscript, language: "en"))
+      }
+    }
+    // AFM failure path.
+    do {
+      let step = makeStep(
+        provider: .appleIntelligence, model: "apple-intelligence", telemetry: .silent)
+      step.makePolisher = { _, _, _ in
+        ThrowingPolisher(makeError: { AFMPolishError(underlying: LLMError.modelNotReady("x")) })
+      }
+      await #expect(throws: LLMError.self) {
+        _ = try await step.process(TextProcessingContext(text: Self.longTranscript, language: "en"))
+      }
+    }
+    // None of the above can be asserted against a spy (that's the point of
+    // `.silent`); this test's value is that every path still compiles and
+    // completes normally when constructed with `.silent`, exercising the
+    // exact seam plumbing `RecoveryTextProcessor` uses.
+  }
+
+  // MARK: - `limbFailureObserved` — deterministic via the injectable eviction seam
+
+  @Test("limb-health metric fires on a failed eviction, with `.live`; silent with `.silent`")
+  func limbFailureObservedIsDeterministic() async throws {
+    let failedOutcome = OllamaEvictOutcome(result: "failed", durationMs: 42, reason: "http_500")
+
+    let spy = Spy()
+    let liveStep = makeStep(provider: .ollama, telemetry: spy.seams)
+    liveStep.evictOllamaModel = { _ in failedOutcome }
+    await liveStep.evictPreviousOllamaModel("some-model")
+
+    #expect(spy.limbFailureCalls.count == 1)
+    #expect(spy.limbFailureCalls.first?.limb == "ollama")
+    #expect(spy.limbFailureCalls.first?.op == "evict")
+    #expect(spy.limbFailureCalls.first?.result == "failed")
+    #expect(spy.limbFailureCalls.first?.cat == "http_500")
+    #expect(spy.limbFailureCalls.first?.dur == 42)
+
+    let silentSpy = Spy()
+    let silentStep = makeStep(provider: .ollama, telemetry: .silent)
+    silentStep.evictOllamaModel = { _ in failedOutcome }
+    await silentStep.evictPreviousOllamaModel("some-model")
+    // `.silent` discards everything; nothing to assert against `silentSpy`
+    // (it was never wired to `silentStep`) — the value here is that
+    // `.silent` construction + a failed eviction outcome together produce
+    // zero observable side effects, which is what `.silent` promises.
+    _ = silentSpy
+  }
+
+  @Test("a successful eviction never fires the limb metric, `.live` or `.silent`")
+  func limbFailureObservedSkipsOnSuccess() async throws {
+    let successOutcome = OllamaEvictOutcome(result: "unloaded", durationMs: 10, reason: "http_200")
+    let spy = Spy()
+    let step = makeStep(provider: .ollama, telemetry: spy.seams)
+    step.evictOllamaModel = { _ in successOutcome }
+
+    await step.evictPreviousOllamaModel("some-model")
+
+    #expect(spy.limbFailureCalls.isEmpty)
+  }
+
+  // MARK: - Successful polish
+
+  @Test("a successful polish fires the completed breadcrumb, never the skip/failure seams")
+  func successfulPolishFiresCompletedOnly() async throws {
+    let spy = Spy()
+    let step = makeStep(provider: .openAI, telemetry: spy.seams)
+    step.makePolisher = { _, _, _ in SucceedingPolisher() }
+
+    _ = try await step.process(TextProcessingContext(text: Self.longTranscript, language: "en"))
+
+    #expect(spy.startedCalls.count == 1)
+    #expect(spy.completedCalls.count == 1)
+    #expect(spy.skipCalls.isEmpty)
+    #expect(spy.providerInitErrorCalls.isEmpty)
+    #expect(spy.afmPolishErrorCalls.isEmpty)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
@@ -442,29 +442,114 @@ struct TextProcessingRunnerCaptureTests {
 
   /// The on-device skips that degrade quietly to raw text (#1080, #1055): a Mac
   /// that cannot run Apple Intelligence at all, and the per-request language gates.
-  nonisolated static let silentAFMSkips: [LLMError] = [
-    .frameworkUnavailable("pre-macOS-26"),
-    .unsupportedInputLanguage("de"),
-    .outputLanguageDrift(expected: "en", actual: "de"),
+  /// #1448: all three now ALSO emit a `llm.polish_skipped` tag (they previously
+  /// emitted nothing at all — the exact gap #1448 fixes).
+  nonisolated static let silentAFMSkips: [(LLMError, String)] = [
+    (.frameworkUnavailable("pre-macOS-26"), "framework_unavailable"),
+    (.unsupportedInputLanguage("de"), "unsupported_input_language"),
+    (.outputLanguageDrift(expected: "en", actual: "de"), "output_language_drift"),
   ]
 
   @Test(
-    "a SILENT Apple Intelligence skip is counted by nothing — it is not a failure",
+    "a SILENT Apple Intelligence skip is counted as a failure by nothing, but now emits its skip tag",
     arguments: silentAFMSkips)
-  func appleIntelligenceSilentSkipsAreNotCounted(error: LLMError) async throws {
+  func appleIntelligenceSilentSkipsAreNotCounted(error: LLMError, tag: String) async throws {
     let spy = CaptureSpy()
     let records = RecordSpy()
-    let runner = makeRunner(spy, records)
+    let skips = SkipSpy()
+    let runner = makeRunner(spy, records, skips)
     let step = makeStep(provider: .appleIntelligence, model: "apple-intelligence") { error }
 
     let result = try await runner.run(
       rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
 
-    // Raw deterministic text, no pill, and nothing reported: these degrade quietly
-    // by design (#1080, #1055). Counting them would inflate the failure rate.
+    // Raw deterministic text, no pill, and no FAILURE reported: these degrade
+    // quietly by design (#1080, #1055). Counting them as failures would inflate
+    // the failure rate.
     #expect(result.polishError == nil)
     #expect(spy.calls.isEmpty)
     #expect(records.calls.isEmpty)
+    // #1448: but a skip tag now DOES fire, so the previously-null
+    // `dictation.completed.llm_provider` for these dictations gets a reason.
+    #expect(skips.calls.count == 1)
+    #expect(skips.calls.first?.provider == "appleIntelligence")
+    #expect(skips.calls.first?.reason == tag)
+  }
+
+  @Test(
+    "provider attribution comes from PolishSkipReason, never a stale runner-side snapshot",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1448",
+      "a runner-side provider snapshot taken before the step's own, later snapshot could diverge from it"
+    )
+  )
+  func providerAttributionSurvivesRunnerToStepHandoff() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let skips = SkipSpy()
+    let runner = makeRunner(spy, records, skips)
+    // Configured as .openAI when the runner takes its pre-await snapshot
+    // (`polishProviderAtStart`); `onWillProcess` then flips it to `.egOne`
+    // BEFORE the step takes its OWN, later snapshot inside `process()`. With
+    // `egOneRuntime` nil, the step throws `.egOneSkipped(.notReady)`. If the
+    // emitted provider still came from the runner's stale snapshot, this would
+    // wrongly report "openAI" instead of "egOne".
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
+      LLMError.egOneSkipped(.notReady)
+    }
+    step.llmProvider = .openAI
+    step.onWillProcess = { step.llmProvider = .egOne }
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(spy.calls.isEmpty)
+    #expect(records.calls.isEmpty)
+    #expect(skips.calls.count == 1)
+    #expect(skips.calls.first?.provider == "egOne")
+    #expect(skips.calls.first?.reason == "local_polish_not_ready")
+  }
+
+  // MARK: - Existing 11 tags unchanged after consolidation
+
+  @Test(
+    "context-window and Ollama-preflight skip tags are byte-identical after routing through PolishSkipReason"
+  )
+  func existingSkipTagsUnchanged() async throws {
+    // Context-window predicted / caught (#1055).
+    for (stage, tag) in [
+      (AFMContextWindowExceeded.Stage.predicted, "context_window_predicted"),
+      (.caught, "context_window_caught"),
+    ] {
+      let skips = SkipSpy()
+      let runner = makeRunner(CaptureSpy(), RecordSpy(), skips)
+      let step = makeStep(provider: .appleIntelligence, model: "apple-intelligence") {
+        AFMContextWindowExceeded(stage: stage)
+      }
+      _ = try await runner.run(
+        rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+      #expect(skips.calls.count == 1)
+      #expect(skips.calls.first?.provider == "appleIntelligence")
+      #expect(skips.calls.first?.reason == tag)
+    }
+
+    // Ollama preflight not-ready (#1305): server down / model missing.
+    for (readiness, tag) in [
+      (OllamaReadiness.serverDown, "local_polish_ollama_server_down"),
+      (.modelMissing, "local_polish_ollama_model_missing"),
+    ] {
+      let skips = SkipSpy()
+      let runner = makeRunner(CaptureSpy(), RecordSpy(), skips)
+      let step = makeStep(provider: .ollama, model: "llama3.2") {
+        LLMError.requestFailed("unused")
+      }
+      step.ollamaReadinessProbe = { _ in readiness }
+      _ = try await runner.run(
+        rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+      #expect(skips.calls.count == 1)
+      #expect(skips.calls.first?.provider == "ollama")
+      #expect(skips.calls.first?.reason == tag)
+    }
   }
 
   @Test(
@@ -518,11 +603,12 @@ struct TextProcessingRunnerCaptureTests {
     #expect(records.calls.isEmpty)
   }
 
-  @Test("a successful polish fires no telemetry")
+  @Test("a successful polish fires neither runner-owned skip nor failure telemetry")
   func successNoCapture() async throws {
     let spy = CaptureSpy()
     let records = RecordSpy()
-    let runner = makeRunner(spy, records)
+    let skips = SkipSpy()
+    let runner = makeRunner(spy, records, skips)
     let step = LLMPolishStep(keychainManager: KeychainManager())
     step.llmProvider = .openAI
     step.llmModel = "gpt-4o-mini"
@@ -534,6 +620,7 @@ struct TextProcessingRunnerCaptureTests {
     #expect(result.polishError == nil)
     #expect(spy.calls.isEmpty)
     #expect(records.calls.isEmpty)
+    #expect(skips.calls.isEmpty)
   }
 
   /// Polisher that returns clean text (no throw) for the success-path test.

--- a/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
@@ -164,6 +164,40 @@ struct RecoveryTextProcessorTests {
     #expect(handRolledSeams.isEmpty, "recovery must name .silent, not per-seam closures")
   }
 
+  /// #1461: `TextProcessingRunner.TelemetrySeams.silent` only ever covered the
+  /// RUNNER's own three seams — it cannot reach `LLMPolishStep`'s own emitters,
+  /// which fired identically on a live take and a recovered replay until this
+  /// plan gave the step its own `.live`/`.silent` seam. Same static-source-check
+  /// pattern as `recoveryWiresTheSilentSeams` above, not a process-global hook
+  /// (`swift-patterns.md` RULE: tests-no-process-global-mutable-delegate) —
+  /// deliberately proving the real construction call site, not just that
+  /// `.silent` behaves correctly in isolation (that's `LLMPolishStepTelemetryTests`).
+  @Test(
+    "RecoveryTextProcessor silences LLMPolishStep's own telemetry via .silent, not per-seam closures",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/1461",
+      "LLMPolishStep's own emitters must not leak into crash recovery")
+  )
+  func recoveryWiresLLMPolishStepSilent() throws {
+    let path = repoRoot().appending(
+      path: "Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift")
+    let source = try String(contentsOf: path, encoding: .utf8)
+    let code = source.split(separator: "\n")
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.hasPrefix("//") }
+      .joined(separator: " ")
+
+    let buildsStepFromSilent = code.contains(
+      "LLMPolishStep(keychainManager: keychainManager, telemetry: .silent)")
+    let handRolledSeams = [
+      "limbFailureObserved:", "breadcrumbStarted:", "captureProviderInitError:",
+      "captureAFMPolishError:", "breadcrumbCompleted:", "recordPolishSkipped:",
+    ].filter { code.contains($0) }
+
+    #expect(buildsStepFromSilent)
+    #expect(handRolledSeams.isEmpty, "recovery must name .silent, not per-seam closures")
+  }
+
   /// Repo root, anchored off `#filePath` — this file lives at
   /// `Tests/EnviousWisprTests/Recovery/`, four levels below the root.
   private func repoRoot() -> URL {


### PR DESCRIPTION
## Summary
- One `PolishSkipReason` authority now owns both the telemetry tag and provider attribution for every polish-skip outcome (11 pre-existing + 4 new: too-short, `frameworkUnavailable`, `unsupportedInputLanguage`, `outputLanguageDrift`), replacing scattered raw literals, `EGOneSkipReason`'s own `String` rawValue, and `PolishFailureReason.ollamaPreflightSkipTelemetryReason`.
- `LLMPolishStep` gains a live/silent telemetry seam mirroring `TextProcessingRunner`'s, silenced during crash-recovery replay via a new internal-only constructor overload — closing #1461's gap where the step's own 5 emitters fired identically on live and recovered takes.
- Fixes two pre-existing bugs found while grounding this plan: `outputLanguageDrift` (always) and `frameworkUnavailable` (via `AppleIntelligenceConnector.makeSession`'s defensive re-check path) were unconditionally firing a live alerting Sentry event despite being classified silent by the runner. Both now consult the same `PolishSkipReason.init?(silentLLMError:)` classification the runner uses.

Closes #1448, Closes #1461

## Plan
`docs/feature-requests/issue-1448-2026-07-15-polish-skip-reasons-and-1461-recovery-silence.md` — 5 revisions through Codex grounded review (rounds 1-7), converging from an initial sibling-enum design to full consolidation after finding an incomplete consolidation, a genuine pre-existing alert bug (in two parts), and a provider-attribution precision gap.

## Test plan
- [x] `scripts/xcode-test.sh` — 2981 tests, TEST SUCCEEDED
- [x] `EnviousWispr-Release` Xcode scheme — BUILD SUCCEEDED
- [x] New tests: `LLMPolishStepTelemetryTests.swift` (11 tests), extended `TextProcessingRunnerCaptureTests.swift`, `RecoveryTextProcessorTests.swift` (new wiring canary for `LLMPolishStep`'s `.silent` construction), `EGOnePipelineRoutingTests.swift`, `OllamaReadinessPreflightTests.swift`
- [x] Local `codex review` clean — no actionable correctness issues
- [x] No Live UAT — pure telemetry/observability change plus one internal error-classification fix; zero user-visible text or paste behavior change