### PR TITLE
refactor(ui): one narrator for the post-completion + advisory warning family (Part of #1511)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -1,4 +1,18 @@
 import EnviousWisprCore
+import EnviousWisprPipeline
+
+/// #1567 (heartpath E3): a typed fact for an in-panel recording notice rendered
+/// through `RecordingOverlayPanel.flashRecordingNotice`. Distinct from
+/// `.warning`: these appear inside the LIVE recording panel, not as a
+/// post-completion pill, so they carry their own family rather than a
+/// `RecordingWarningReason`. Lives in AppKit — the panel and its callers are the
+/// only code that touches it; it never crosses into Pipeline.
+enum RecordingNoticeReason: Equatable, Sendable {
+  /// Within the last minute before the 60-minute cap. Persistent (nil dismiss).
+  case approachingCap
+  /// The VAD model can't load, so silence auto-stop is off. Timed (4 s dismiss).
+  case autoStopUnavailable
+}
 
 /// #1558 (E1) / #1564 (E2). The single, stateless authority that turns the
 /// engine's typed facts into the customer-facing words shown on the pill, the
@@ -88,6 +102,49 @@ enum DictationNarrator {
       return "Transcribing"
     case .polishing:
       return "Polishing"
+    }
+  }
+
+  // MARK: - Post-completion + advisory warnings (E3, #1567)
+
+  /// Founder-LOCKED 2026-07-15. Unchanged from today EXCEPT two approved
+  /// cleanups: model-not-downloaded drops a banned em-dash and polish-failed
+  /// drops a literal `--` — each becomes a clean two-sentence form.
+  static func copy(for reason: RecordingWarningReason) -> String {
+    switch reason {
+    case .modelNotDownloaded(let engineLabel):
+      return "\(engineLabel) isn't downloaded yet. Open Settings to download it."
+    case .polishFailed:
+      return "Polish failed. Using raw text."
+    case .historySaveFailed(let reason):
+      return "Couldn't save to history: \(reason)"
+    case .salvagedBeginning:
+      return "Beginning of dictation was unclear and was skipped"
+    case .interruptedTail(let disclosure, let alsoTrimmedLead):
+      switch (disclosure, alsoTrimmedLead) {
+      case (.deviceRemoved, true):
+        return "Microphone disconnected. Words may be missing."
+      case (.deviceRemoved, false):
+        return "Microphone disconnected. Text may be cut short."
+      case (.otherInterruption, true):
+        return "Recording interrupted. Words may be missing."
+      case (.otherInterruption, false):
+        return "Recording interrupted. Text may be cut short."
+      }
+    }
+  }
+
+  // MARK: - In-panel recording notices (E3, #1567)
+
+  /// Founder-LOCKED unchanged (2026-07-15). Authored here even though these
+  /// render through `flashRecordingNotice` (a live-panel banner), not the
+  /// `.warning` pill — one voice, two render paths.
+  static func copy(for reason: RecordingNoticeReason) -> String {
+    switch reason {
+    case .approachingCap:
+      return "Recording auto-stops in under a minute (60-minute cap)"
+    case .autoStopUnavailable:
+      return "Auto-stop on silence is unavailable right now"
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/ColdPressGuard.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/ColdPressGuard.swift
@@ -66,9 +66,7 @@ enum ColdPressGuard {
       case .ready:
         overlay.show(intent: .engineReady)
       case .notInstalled:
-        overlay.show(
-          intent: .warning(message: "\(label) isn't downloaded yet — open Settings to download it.")
-        )
+        overlay.show(intent: .warning(reason: .modelNotDownloaded(engineLabel: label)))
       case .notReady:
         // Switched but not ready (failed warm / transient block): clear the
         // caching pill; the next press retries via the cold-press path.

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -211,9 +211,10 @@ final class DictationLifecycleCoordinator {
   /// #1060: within the last minute before the cap. Show a PERSISTENT in-panel
   /// banner (no auto-dismiss) that stays until the recording stops; cleared by the
   /// transition out of recording. "Under a minute" reads accurately for the whole
-  /// window, so no countdown or late-fire guard is needed. Copy lives here.
+  /// window, so no countdown or late-fire guard is needed. `DictationNarrator`
+  /// owns the copy.
   private func showApproachingCapWarning(remainingSeconds: TimeInterval) {
-    recordingOverlay.flashRecordingNotice("Recording auto-stops in under a minute (60-minute cap)")
+    recordingOverlay.flashRecordingNotice(reason: .approachingCap)
     TelemetryService.shared.recordingCapWarningShown(
       backend: lastCapturingBackend == .whisperKit ? "whisperKit" : "parakeet",
       capSeconds: TimingConstants.maxRecordingDuration)
@@ -407,7 +408,7 @@ final class DictationLifecycleCoordinator {
     postCompletionWarningTask?.cancel()
   }
 
-  private func schedulePostCompletionWarning(message: String) {
+  private func schedulePostCompletionWarning(reason: RecordingWarningReason) {
     postCompletionWarningTask?.cancel()
     postCompletionWarningTask = Task { @MainActor [weak self] in
       try? await Task.sleep(for: .milliseconds(400))
@@ -416,15 +417,16 @@ final class DictationLifecycleCoordinator {
       let parakeetComplete = self.kernelDriver.state == .complete
       let whisperKitComplete = self.whisperKitKernelDriver.state == .complete
       guard parakeetComplete || whisperKitComplete else { return }
-      self.recordingOverlay.show(intent: .warning(message: message))
+      self.recordingOverlay.show(intent: .warning(reason: reason))
     }
   }
 
   // MARK: - State-handler factory
 
-  /// #1408: the closure bodies and every notice literal live in
-  /// `PipelineStateChangeHandlerFactory`; this hands it the coordinator-owned
-  /// seams they reach back into. Extracted rather than grown in place — the
+  /// #1408: the closure bodies live in `PipelineStateChangeHandlerFactory`; this
+  /// hands it the coordinator-owned seams they reach back into. #1567: the factory
+  /// now forwards typed `RecordingWarningReason` facts and `DictationNarrator`
+  /// owns every user-facing sentence. Extracted rather than grown in place — the
   /// coordinator sat at its line ceiling, which is exactly the signal that
   /// ceiling exists to send.
   private func makeStateChangeHandler(backendLabel: String) -> PipelineStateChangeHandler {
@@ -434,8 +436,8 @@ final class DictationLifecycleCoordinator {
       deps: .init(
         showOverlay: { [weak self] intent in self?.showOverlayIntent(intent) },
         cancelPendingWarning: { [weak self] in self?.postCompletionWarningTask?.cancel() },
-        schedulePostCompletionWarning: { [weak self] message in
-          self?.schedulePostCompletionWarning(message: message)
+        schedulePostCompletionWarning: { [weak self] reason in
+          self?.schedulePostCompletionWarning(reason: reason)
         },
         appendTranscript: { [weak self] t in self?.transcriptCoordinator.append(t) },
         onDurableSave: { [weak self] sid in self?.onDurableSave(sid) },

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/PipelineStateChangeHandlerFactory.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/PipelineStateChangeHandlerFactory.swift
@@ -6,14 +6,11 @@ import Foundation
 /// #1408: assembles a `PipelineStateChangeHandler` from the AppKit-owned seams
 /// its closures need, so `DictationLifecycleCoordinator` stays a thin wiring site
 /// (the same move #1434 made for `DictationCompletedReporting`). Pure closure
-/// assembly — no state, no decisions; the pure planner owns which effect fires
-/// and this file owns what each one says.
+/// assembly — no state, no decisions; the pure planner owns which effect fires.
 ///
-/// **The post-completion notice literals live HERE, one per site.** They are
-/// wired at the factory rather than hardcoded inside the shared
-/// `schedulePostCompletionWarning` mechanism, so the single warning slot stays a
-/// generic mechanism and each caller owns its own words. No em-dashes: this copy
-/// is user-facing.
+/// #1567 (heartpath E3): these closures translate each typed planner effect into
+/// a typed `RecordingWarningReason`; `DictationNarrator` owns every user-facing
+/// sentence. No literals live here anymore.
 @MainActor
 enum PipelineStateChangeHandlerFactory {
   /// The coordinator-owned seams the handler's closures reach back into. Passed
@@ -24,8 +21,9 @@ enum PipelineStateChangeHandlerFactory {
     let showOverlay: @MainActor (OverlayIntent) -> Void
     let cancelPendingWarning: @MainActor () -> Void
     /// The generic single-slot post-completion pill. Last-writer-wins by design;
-    /// the planner guarantees exactly one caller per completion.
-    let schedulePostCompletionWarning: @MainActor (String) -> Void
+    /// the planner guarantees exactly one caller per completion. #1567: carries a
+    /// typed `RecordingWarningReason`; `DictationNarrator` authors the sentence.
+    let schedulePostCompletionWarning: @MainActor (RecordingWarningReason) -> Void
     let appendTranscript: @MainActor (Transcript) -> Void
     /// #1063 PR1: the durable save landed, so this session's spool + key can go.
     let onDurableSave: @MainActor (String) -> Void
@@ -42,7 +40,7 @@ enum PipelineStateChangeHandlerFactory {
       showOverlay: { intent in deps.showOverlay(intent) },
       cancelPendingWarning: { deps.cancelPendingWarning() },
       schedulePolishFailedWarning: {
-        deps.schedulePostCompletionWarning("Polish failed -- using raw text")
+        deps.schedulePostCompletionWarning(.polishFailed)
       },
       appendCompletedTranscript: { t in
         deps.appendTranscript(t)
@@ -64,39 +62,22 @@ enum PipelineStateChangeHandlerFactory {
       },
       // #1167: history-save-failed pill (post-completion warning slot, ~400 ms).
       scheduleHistorySaveFailedWarning: { reason in
-        deps.schedulePostCompletionWarning("Couldn't save to history: \(reason)")
+        deps.schedulePostCompletionWarning(.historySaveFailed(reason: reason))
       },
       // #1434: salvaged-lead disclosure pill — the degraded-lead retry recovered
       // this dictation by trimming a poisoned opening, so the pasted text is
       // missing its lead.
       scheduleSalvagedLeadWarning: {
-        deps.schedulePostCompletionWarning("Beginning of dictation was unclear and was skipped")
+        deps.schedulePostCompletionWarning(.salvagedBeginning)
       },
       // #1408: capture died mid-recording and the pasted text is what survived.
-      // The disclosure picks the sentence family: only a VERIFIED device removal
-      // may say "Microphone disconnected"; every other interruption gets the
-      // neutral "Recording interrupted" (grounded review A1 — a non-disconnect
-      // salvage must not paste truncated text silently). When the lead was ALSO
-      // trimmed this take lost both ends, so the copy stops claiming the loss is
-      // only at the end. All four strings fit the pill's single line (~49
-      // characters before it truncates). The microphone pair is founder-approved
-      // (2026-07-09); the neutral pair is provisional pending founder sign-off
-      // (plan §21.3) and must not ship in a release before that lands.
+      // Forward the two typed facts unchanged; `DictationNarrator` picks the
+      // sentence family (only a VERIFIED device removal may say "Microphone
+      // disconnected"; a non-disconnect salvage gets the neutral wording) and the
+      // both-ends-lost variant. The four sentences are founder-LOCKED (2026-07-15).
       scheduleInterruptionWarning: { disclosure, alsoTrimmedLead in
-        let message: String
-        switch disclosure {
-        case .deviceRemoved:
-          message =
-            alsoTrimmedLead
-            ? "Microphone disconnected. Words may be missing."
-            : "Microphone disconnected. Text may be cut short."
-        case .otherInterruption:
-          message =
-            alsoTrimmedLead
-            ? "Recording interrupted. Words may be missing."
-            : "Recording interrupted. Text may be cut short."
-        }
-        deps.schedulePostCompletionWarning(message)
+        deps.schedulePostCompletionWarning(
+          .interruptedTail(disclosure: disclosure, alsoTrimmedLead: alsoTrimmedLead))
       }
     )
   }

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -191,7 +191,9 @@ final class RecordingOverlayPanel {
         accessibilityToastShownThisSession = true
         showAccessibilityToast()
       }
-    case .warning(let message):
+    case .warning(let reason):
+      // #1567: the narrator is the sole author of the sentence.
+      let message = DictationNarrator.copy(for: reason)
       NSAccessibility.post(
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
@@ -410,12 +412,13 @@ final class RecordingOverlayPanel {
   /// #1060: flash a transient banner over the LIVE recording pill (a second line
   /// inside the same capsule), then auto-clear. No-op unless a recording panel is
   /// live — leaves `panel`, `currentIntent`, and `generation` untouched (no
-  /// teardown → no #930 flicker). The App layer owns the copy string.
-  func flashRecordingNotice(_ message: String, dismissAfter: Double? = nil) {
+  /// teardown → no #930 flicker). #1567: carries a typed `RecordingNoticeReason`;
+  /// `DictationNarrator` owns the copy.
+  func flashRecordingNotice(reason: RecordingNoticeReason, dismissAfter: Double? = nil) {
     guard panel != nil, case .recording = currentIntent else { return }
     noticeDismissWork?.cancel()
     noticeDismissWork = nil
-    noticeState.message = message
+    noticeState.message = DictationNarrator.copy(for: reason)
     // #1060: nil dismissAfter = persist until the recording ends. The cap warning
     // stays the whole final minute and is cleared by the transition out of
     // recording (transitionToPolishing) or hide(). A non-nil value auto-dismisses.

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -225,12 +225,11 @@ public final class WisprBootstrapper {
     let vadSource = KernelDictationDriverFactory.makeSharedVADSignalSource(
       audioCapture: audioCapture)
     // #1224 (#1543): the VAD source reports a typed readiness FACT when the
-    // bundled model can't load; the App shell authors the user-facing sentence
-    // via the existing in-panel notice (no-ops if no recording panel is
-    // showing). Same copy the deleted XPC path used.
+    // bundled model can't load. The App shell emits a typed in-panel notice and
+    // `DictationNarrator` owns the user-facing sentence (#1567). The notice
+    // no-ops when no recording panel is showing.
     vadSource.onAutoStopUnavailableNotice = { [weak recordingOverlay] in
-      recordingOverlay?.flashRecordingNotice(
-        "Auto-stop on silence is unavailable right now", dismissAfter: 4.0)
+      recordingOverlay?.flashRecordingNotice(reason: .autoStopUnavailable, dismissAfter: 4.0)
     }
 
     // PR-4b.4 of #827: Parakeet recordings flow through the kernel via the

--- a/Sources/EnviousWisprLLM/PolishFailureReason.swift
+++ b/Sources/EnviousWisprLLM/PolishFailureReason.swift
@@ -289,7 +289,7 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
   /// outcome rather than a hard failure. Keyed off the single `LeadIn.skipped.text`
   /// constant that `composedMessage` also uses, so it can never drift from the
   /// notice it inspects. The completion planner uses this to suppress the
-  /// transient "Polish failed -- using raw text" overlay for skips (the in-window
+  /// transient "Polish failed. Using raw text." overlay for skips (the in-window
   /// notice still shows the actionable "AI cleanup skipped: ..." message). A
   /// legacy raw message or the Apple Intelligence "AI polish failed: ..." string
   /// is correctly treated as NOT a skip, so its hard-failure toast still fires.

--- a/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangeHandler.swift
@@ -38,10 +38,9 @@ public final class PipelineStateChangeHandler {
   private let scheduleHistorySaveFailedWarning: @MainActor (String) -> Void
   /// #1434: schedule the transient salvaged-lead disclosure pill.
   private let scheduleSalvagedLeadWarning: @MainActor () -> Void
-  /// #1408: schedule the transient interruption disclosure pill. The disclosure
-  /// picks the sentence family (mic-disconnect vs neutral) and the flag picks
-  /// between the tail-only and both-ends-lost copies; the caller owns all four
-  /// literals (the message is wired at the factory site, never in here).
+  /// #1408: schedule the transient interruption disclosure pill. The callback
+  /// carries the two typed facts (disclosure + also-trimmed-lead) unchanged;
+  /// #1567: `DictationNarrator` owns all four sentences.
   private let scheduleInterruptionWarning:
     @MainActor (_ disclosure: CompletionInterruptionDisclosure, _ alsoTrimmedLead: Bool) -> Void
 

--- a/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
+++ b/Sources/EnviousWisprPipeline/PipelineStateChangePlanner.swift
@@ -12,7 +12,7 @@ enum PipelineStateSideEffect: Equatable, Sendable {
   /// non-complete transition — mirrors the former root-state file behavior.
   case cancelPendingWarning
 
-  /// Schedule the "Polish failed -- using raw text" warning 400 ms after
+  /// Schedule the "Polish failed. Using raw text." warning 400 ms after
   /// completion. Emitted ONLY on `.complete` when a polish error was recorded
   /// AND the paste did not fall back to clipboard-only.
   case schedulePolishFailedWarning
@@ -128,7 +128,7 @@ enum PipelineStateChangePlanner {
         // #945: a "skipped" notice (no key yet, too long, timed out) is not a
         // hard failure — the in-window banner shows the actionable
         // "AI cleanup skipped: ..." message, but the transient
-        // "Polish failed -- using raw text" overlay would contradict it, so
+        // "Polish failed. Using raw text." overlay would contradict it, so
         // suppress it for skips. Real failures (and the unchanged Apple
         // Intelligence / legacy strings) still schedule the warning.
         // #1167: a history-save failure takes the single post-completion

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -23,9 +23,9 @@ import Foundation
 /// nil (no value) = a normal completion, nothing to disclose. The two cases
 /// split on the ONLY evidence axis the pipeline has: was the input device
 /// verified removed (`isDeviceLoss`), or did capture die some other way with
-/// the microphone, as far as we know, still attached. Copy for each cell lives
-/// at the factory (`PipelineStateChangeHandlerFactory`), the single copy
-/// authority for post-completion notices.
+/// the microphone, as far as we know, still attached. Completed-warning copy is
+/// authored only by `DictationNarrator` in AppKit; the factory forwards typed
+/// `RecordingWarningReason` facts (#1567, heartpath E3).
 public enum CompletionInterruptionDisclosure: Equatable, Sendable {
   /// Core Audio confirmed the input device went away mid-recording.
   case deviceRemoved
@@ -40,6 +40,27 @@ public enum CompletionInterruptionDisclosure: Equatable, Sendable {
     guard let cause else { return nil }
     self = cause.isDeviceLoss ? .deviceRemoved : .otherInterruption
   }
+}
+
+/// #1567 (heartpath E3): a typed fact explaining a post-completion or advisory
+/// warning rendered through `OverlayIntent.warning`. The engine/coordinator
+/// emits this; `DictationNarrator` in AppKit authors the user-facing words.
+/// Lives in Pipeline because `.interruptedTail` carries a
+/// `CompletionInterruptionDisclosure` (a Pipeline type) and `OverlayIntent` —
+/// its only consumer — is also Pipeline.
+public enum RecordingWarningReason: Equatable, Sendable {
+  /// The SELECTED ASR engine isn't downloaded yet. Carries its display name.
+  case modelNotDownloaded(engineLabel: String)
+  /// AI polish failed; the raw transcript was pasted instead.
+  case polishFailed
+  /// The dictation was pasted but the history write threw. Carries the reason.
+  case historySaveFailed(reason: String)
+  /// The degraded-lead retry recovered this take by trimming a poisoned opening.
+  case salvagedBeginning
+  /// Capture died mid-recording; the pasted text is what survived. `disclosure`
+  /// picks the sentence family (verified device removal vs neutral);
+  /// `alsoTrimmedLead` is true when the take ALSO lost its opening (#1408/#1434).
+  case interruptedTail(disclosure: CompletionInterruptionDisclosure, alsoTrimmedLead: Bool)
 }
 
 /// Events the recording driver handles.
@@ -69,8 +90,10 @@ public enum OverlayIntent: Equatable, Sendable {
   /// inline Grant button. Auto-dismissed after about 6 seconds.
   case accessibilityToast
   /// Transient warning notice for degraded-but-delivered results (e.g. polish failed).
-  /// Orange icon, auto-dismissed by the overlay panel after 2.5 seconds.
-  case warning(message: String)
+  /// #1567 (heartpath E3): carries a TYPED `RecordingWarningReason`;
+  /// `DictationNarrator` in AppKit authors the sentence. Orange icon,
+  /// auto-dismissed by the overlay panel after 2.5 seconds.
+  case warning(reason: RecordingWarningReason)
   /// Transient error notice for a terminal capture / transcription failure.
   /// #1558: carries a TYPED reason; `DictationNarrator` authors the
   /// sentence. Auto-dismissed by the overlay panel after 3 seconds.

--- a/Tests/EnviousWisprTests/App/BluetoothAwarenessPresenterTests.swift
+++ b/Tests/EnviousWisprTests/App/BluetoothAwarenessPresenterTests.swift
@@ -134,7 +134,7 @@ private func emitEquals(
   @Test func gate_requiresHiddenSlot() {
     let h = Harness()
     h.isBluetooth = true
-    h.currentIntent = .warning(message: "x")  // another overlay owns the slot
+    h.currentIntent = .warning(reason: .polishFailed)  // another overlay owns the slot
     let p = h.makePresenter()
     p.reconcile(trigger: .launch)
     #expect(h.showCount == 0)  // never replaces a live overlay

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -2,6 +2,7 @@ import EnviousWisprCore
 import Testing
 
 @testable import EnviousWisprAppKit
+@testable import EnviousWisprPipeline
 
 /// #1558 (E1) / #1564 (E2). Freezes the copy contract: `DictationNarrator` is
 /// the SOLE author of the founder-locked sentences and processing labels, no
@@ -128,5 +129,80 @@ import Testing
           !copy.contains("\u{2014}") && !copy.contains("\u{2013}"), "\(phase) copy has a dash")
       }
     }
+  }
+
+  // MARK: - Post-completion + advisory warnings (E3, #1567)
+
+  /// Every `RecordingWarningReason` maps to its founder-locked sentence. The
+  /// four interrupted-tail cells and the two interpolated reasons are pinned
+  /// byte-exact; the two cleanups (model-not-downloaded, polish-failed) are the
+  /// only strings that changed from today.
+  @Test("warning reasons map to their exact founder-locked sentences")
+  func warningReasonsMapToLockedCopy() {
+    #expect(
+      DictationNarrator.copy(for: .modelNotDownloaded(engineLabel: "Parakeet"))
+        == "Parakeet isn't downloaded yet. Open Settings to download it.")
+    #expect(DictationNarrator.copy(for: .polishFailed) == "Polish failed. Using raw text.")
+    #expect(
+      DictationNarrator.copy(for: .historySaveFailed(reason: "disk is full"))
+        == "Couldn't save to history: disk is full")
+    #expect(
+      DictationNarrator.copy(for: .salvagedBeginning)
+        == "Beginning of dictation was unclear and was skipped")
+    #expect(
+      DictationNarrator.copy(
+        for: .interruptedTail(disclosure: .deviceRemoved, alsoTrimmedLead: false))
+        == "Microphone disconnected. Text may be cut short.")
+    #expect(
+      DictationNarrator.copy(
+        for: .interruptedTail(disclosure: .deviceRemoved, alsoTrimmedLead: true))
+        == "Microphone disconnected. Words may be missing.")
+    #expect(
+      DictationNarrator.copy(
+        for: .interruptedTail(disclosure: .otherInterruption, alsoTrimmedLead: false))
+        == "Recording interrupted. Text may be cut short.")
+    #expect(
+      DictationNarrator.copy(
+        for: .interruptedTail(disclosure: .otherInterruption, alsoTrimmedLead: true))
+        == "Recording interrupted. Words may be missing.")
+  }
+
+  /// Only a VERIFIED device removal may name the microphone. If this fails, a
+  /// user whose engine died with the mic still attached is being lied to.
+  @Test("the neutral interruption family never mentions the microphone")
+  func neutralInterruptionNeverClaimsTheMicrophone() {
+    for alsoTrimmedLead in [false, true] {
+      let copy = DictationNarrator.copy(
+        for: .interruptedTail(disclosure: .otherInterruption, alsoTrimmedLead: alsoTrimmedLead))
+      #expect(!copy.localizedCaseInsensitiveContains("microphone"))
+      #expect(!copy.localizedCaseInsensitiveContains("mic"))
+    }
+  }
+
+  /// The two founder cleanups: no banned em/en dash, no literal `--`, and the
+  /// second clause capitalizes (a true two-sentence form).
+  @Test("the cleaned-up warning sentences drop the dash and double-hyphen")
+  func cleanedWarningSentencesAreClean() {
+    let cleaned = [
+      DictationNarrator.copy(for: .modelNotDownloaded(engineLabel: "EG-1")),
+      DictationNarrator.copy(for: .polishFailed),
+    ]
+    for copy in cleaned {
+      #expect(!copy.contains("\u{2014}") && !copy.contains("\u{2013}"), "\(copy) has a dash")
+      #expect(!copy.contains(" -- "), "\(copy) has a literal double-hyphen")
+    }
+    #expect(DictationNarrator.copy(for: .polishFailed).contains(". Using"))
+  }
+
+  // MARK: - In-panel recording notices (E3, #1567)
+
+  @Test("recording notices map to their exact founder-locked sentences")
+  func recordingNoticesMapToLockedCopy() {
+    #expect(
+      DictationNarrator.copy(for: RecordingNoticeReason.approachingCap)
+        == "Recording auto-stops in under a minute (60-minute cap)")
+    #expect(
+      DictationNarrator.copy(for: RecordingNoticeReason.autoStopUnavailable)
+        == "Auto-stop on silence is unavailable right now")
   }
 }

--- a/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
@@ -9,24 +9,21 @@ import Testing
 @testable import EnviousWisprAppKit
 @testable import EnviousWisprPipeline
 
-// MARK: - #1408 A1 — the post-completion interruption copy matrix
+// MARK: - #1408 A1 / #1567 E3 — the post-completion interruption REASON matrix
 
-/// The factory is the SINGLE copy authority for the interruption pill (plan
-/// §21.2 A1). These tests drive a factory-built handler end to end and pin the
-/// EXACT sentence for each (disclosure × lead-trim) cell, so the copy cannot
-/// drift and only a verified device removal can ever claim the microphone.
-///
-/// The two "Microphone disconnected" strings are founder-approved (2026-07-09).
-/// The two "Recording interrupted" strings are provisional pending founder
-/// sign-off (plan §21.3); when the wording lands, this file is the one place
-/// the tests change.
+/// The factory forwards a typed `RecordingWarningReason` for each planner effect;
+/// #1567 moved the sentence authoring to `DictationNarrator` (the copy oracle now
+/// lives in `DictationNarratorTests`). These tests drive a factory-built handler
+/// end to end and pin the EXACT reason for each (disclosure × lead-trim) cell, so
+/// the disclosure→reason mapping cannot drift and only a verified device removal
+/// can ever be forwarded as `.deviceRemoved`.
 @MainActor
-@Suite("PipelineStateChangeHandlerFactory — interruption copy matrix (#1408)")
+@Suite("PipelineStateChangeHandlerFactory — interruption reason matrix (#1408/#1567)")
 struct PipelineStateChangeHandlerFactoryCopyTests {
 
   @MainActor
   private final class WarningBox {
-    var messages: [String] = []
+    var reasons: [RecordingWarningReason] = []
   }
 
   /// A factory-built handler whose only live seam is the warning recorder.
@@ -62,7 +59,7 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
     let deps = PipelineStateChangeHandlerFactory.Deps(
       showOverlay: { _ in },
       cancelPendingWarning: {},
-      schedulePostCompletionWarning: { box.messages.append($0) },
+      schedulePostCompletionWarning: { box.reasons.append($0) },
       appendTranscript: { _ in },
       onDurableSave: { _ in },
       inputMode: { nil },
@@ -70,16 +67,16 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
     return PipelineStateChangeHandlerFactory.make(backendLabel: "parakeet", deps: deps)
   }
 
-  private static let expectedCopy: [(CompletionInterruptionDisclosure, Bool, String)] = [
-    (.deviceRemoved, false, "Microphone disconnected. Text may be cut short."),
-    (.deviceRemoved, true, "Microphone disconnected. Words may be missing."),
-    (.otherInterruption, false, "Recording interrupted. Text may be cut short."),
-    (.otherInterruption, true, "Recording interrupted. Words may be missing."),
+  private static let cells: [(CompletionInterruptionDisclosure, Bool)] = [
+    (.deviceRemoved, false),
+    (.deviceRemoved, true),
+    (.otherInterruption, false),
+    (.otherInterruption, true),
   ]
 
-  @Test("each (disclosure × lead-trim) cell schedules its exact sentence")
-  func copyMatrixIsExact() {
-    for (disclosure, alsoTrimmedLead, expected) in Self.expectedCopy {
+  @Test("each (disclosure × lead-trim) cell forwards its exact interruptedTail reason")
+  func reasonMatrixIsExact() {
+    for (disclosure, alsoTrimmedLead) in Self.cells {
       let box = WarningBox()
       let handler = makeHandler(recording: box)
       handler.handle(
@@ -92,29 +89,8 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
         salvagedLead: alsoTrimmedLead,
         interruptionDisclosure: disclosure)
       #expect(
-        box.messages == [expected],
+        box.reasons == [.interruptedTail(disclosure: disclosure, alsoTrimmedLead: alsoTrimmedLead)],
         "disclosure=\(disclosure) alsoTrimmedLead=\(alsoTrimmedLead)")
-    }
-  }
-
-  /// Only a VERIFIED removal may name the microphone. If this ever fails, a
-  /// user whose engine died with the mic still attached is being lied to.
-  @Test("the neutral family never mentions the microphone")
-  func neutralCopyNeverClaimsTheMicrophone() {
-    for (disclosure, alsoTrimmedLead, expected) in Self.expectedCopy
-    where disclosure == .otherInterruption {
-      _ = alsoTrimmedLead
-      #expect(!expected.localizedCaseInsensitiveContains("microphone"))
-      #expect(!expected.localizedCaseInsensitiveContains("mic"))
-    }
-  }
-
-  /// Rule 6: no em/en-dashes in user-facing copy.
-  @Test("no em or en dashes in any interruption sentence")
-  func noDashesInCopy() {
-    for (_, _, expected) in Self.expectedCopy {
-      #expect(!expected.contains("\u{2014}"))
-      #expect(!expected.contains("\u{2013}"))
     }
   }
 
@@ -132,6 +108,6 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
       historySaveReason: nil,
       salvagedLead: false,
       interruptionDisclosure: nil)
-    #expect(box.messages.isEmpty)
+    #expect(box.reasons.isEmpty)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/LimbFailureFallbackTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LimbFailureFallbackTests.swift
@@ -37,7 +37,7 @@ struct LimbFailureFallbackTests {
     #expect(result.context.text == raw)
     #expect(result.context.polishedText == nil)
     // Polish-failure surface: the error message reaches the caller so the
-    // overlay can show "Polish failed -- using raw text".
+    // overlay can show "Polish failed. Using raw text.".
     #expect(result.polishError == "Polish failed -- test failure")
   }
 


### PR DESCRIPTION
Heartpath step 6c (E3) — Part 3 of 4 of the "one voice" decomposition (D-029). Closes #1567.

## What changes
Every post-completion + advisory recording word moves to the single `DictationNarrator`, closing the last two String escape paths:
- `OverlayIntent.warning(message: String)` → `.warning(reason: RecordingWarningReason)` (Pipeline, next to `CompletionInterruptionDisclosure`).
- `flashRecordingNotice(_ message: String)` → `flashRecordingNotice(reason: RecordingNoticeReason)` (AppKit) — for the 60-minute cap banner **and** the auto-stop-unavailable notice.

The three/four scattered string authors are deleted (`PipelineStateChangeHandlerFactory`, `ColdPressGuard`, the cap banner, the `WisprBootstrapper` auto-stop notice). The Pipeline planner/handler already emit typed effects and keep their logic; only stale comments were updated.

Two founder-locked copy cleanups (2026-07-15):
- `"… isn't downloaded yet — open Settings to download it."` → `"… isn't downloaded yet. Open Settings to download it."` (banned em-dash → period)
- `"Polish failed -- using raw text"` → `"Polish failed. Using raw text."` (literal `--` → period)

Every other warning/notice string is byte-identical, including the four "Microphone disconnected / Recording interrupted…" salvage lines (the previously-provisional neutral pair is now founder-signed-off).

**Scoreboard: recording-copy authors 7 → 3** (retires all four scattered warning/advisory authors; adds none — the narrator already exists). Remaining: `DictationNarrator`, `RecordingOverlayPanel`, `MainWindowView` (E4 → 1).

## Validation
- Grounded review (Codex): PROCEED-AS-PLANNED after 3 rounds. r1 caught a second in-panel advisory the first plan missed (`WisprBootstrapper` auto-stop) and corrected the scoreboard arithmetic.
- Logic tests: 2989 green, incl. new `DictationNarrator` warning/notice goldens (all 8 warning outputs + 2 notices, byte-exact) and the migrated interruption reason matrix.
- Local Codex diff review: clean, no actionable issues.
- Live UAT: normal dictation completes cleanly (`TOTAL 0.757s`), Polishing pill renders, correct paste, no spurious warning. Failure-path rendered-copy leg SKIPPED (needs a forced classified failure); the exact strings are byte-pinned by the golden tests.
- REFACTOR tier; display-path only; single-commit revert.

Plan: `docs/feature-requests/issue-1567-2026-07-15-e3-warning-narrator.md` (gitignored). Parent: #1511.