### PR TITLE
refactor(ui): one narrator authors every recording-lifecycle status word (Closes #1569) (Part of #1511)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
+++ b/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
@@ -56,18 +56,18 @@ final class BackendMetadata {
   func statusText(for state: PipelineState) -> String {
     if asrManager.activeBackendType == .whisperKit {
       switch state {
-      case .loadingModel: return "Loading Model"
-      case .recording: return "Recording"
+      case .loadingModel: return DictationNarrator.loadingModelSidebar
+      case .recording: return DictationNarrator.recordingStatus
       case .transcribing: return DictationNarrator.shortCopy(for: .transcribing)
       case .polishing: return DictationNarrator.shortCopy(for: .polishing)
-      case .error: return "Error"
+      case .error: return DictationNarrator.errorStatus
       default: break
       }
     } else {
-      if state == .recording { return "Recording" }
+      if state == .recording { return DictationNarrator.recordingStatus }
       if state == .transcribing { return DictationNarrator.shortCopy(for: .transcribing) }
       if state == .polishing { return DictationNarrator.shortCopy(for: .polishing) }
-      if case .error = state { return "Error" }
+      if case .error = state { return DictationNarrator.errorStatus }
     }
     return asrManager.isModelLoaded ? "Loaded" : "Unloaded"
   }

--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -28,8 +28,11 @@ enum RecordingNoticeReason: Equatable, Sendable {
 /// injected instance only if a test ever needs to swap the mapping.
 ///
 /// Renamed from `TerminalNoticePresenter` in E2 once it began authoring more
-/// than terminal notices. As later parts move their families here it becomes
-/// the SOLE voice (heartpath step 6, "one voice").
+/// than terminal notices. As of E4 (#1569) it is the SOLE voice (heartpath
+/// step 6, "one voice" COMPLETE): every recording-lifecycle status/notice
+/// literal — spoken announcements, status pills, the window/badge/sidebar status
+/// words, and the recovery container AX label — is authored here and nowhere
+/// else. The renderers (panel, main window, sidebar) are pure presenters.
 enum DictationNarrator {
 
   // MARK: - Terminal failures / interruptions (E1)
@@ -147,4 +150,49 @@ enum DictationNarrator {
       return "Auto-stop on silence is unavailable right now"
     }
   }
+
+  // MARK: - Spoken announcements (E4, #1569) — the app's VoiceOver voice.
+
+  /// The single authority for every VoiceOver announcement the recording overlay
+  /// posts. The panel keeps choosing the AX priority + target element; the words
+  /// live here. Words byte-identical to today (founder-locked 2026-07-15).
+  static func announcement(for intent: OverlayIntent) -> String {
+    switch intent {
+    case .hidden: return "Recording complete"
+    case .recording(audioLevel: _): return "Recording started"
+    case .processing(phase: _): return "Processing transcription"
+    case .clipboardFallback: return "Text copied to clipboard"
+    case .accessibilityToast: return "Accessibility permission needed for auto-paste"
+    case .warning(let reason): return "Warning: \(copy(for: reason))"
+    case .error(let reason): return "Error: \(copy(for: reason))"
+    case .interruption(let reason): return "Interruption: \(copy(for: reason))"
+    case .passiveChip(let payload): return "Detected \(payload.displayName)"
+    case .cachingModel(engineLabel: _): return "Getting dictation ready, one moment"
+    case .engineReady: return "Dictation ready. Press to start."
+    case .recoveringLastRecording: return "Recovering your last recording. Press Discard to skip."
+    case .bluetoothAwareness:
+      return "Bluetooth microphone detected. Wait a moment before speaking on a cold start."
+    }
+  }
+
+  // MARK: - Fixed status-pill + window/badge/sidebar copy (E4, #1569). Byte-identical.
+
+  static let coldStartTitle = "Getting dictation ready…"
+  static func coldStartSubtitle(engineLabel: String) -> String {
+    "\(engineLabel) is warming up after a restart"
+  }
+  static let readyTitle = "Ready — press to dictate"  // dash kept (founder 2026-07-15)
+  static let clipboardFallbackText = "Copied. Press \u{2318}V to paste"
+  static let accessibilityToastText = "Auto-paste needs Accessibility"
+  static let recoveryTitle = "Recovering your last recording…"
+  static let recoverySubtitle = "Saved to History when it's done"
+  /// The recovery pill's CONTAINER accessibility label (no ellipsis — distinct
+  /// bytes from `recoveryTitle`). VoiceOver reads it as the group's spoken status.
+  static let recoveryAccessibilityLabel = "Recovering your last recording"
+  static let loadingModelStatus = "Loading model..."  // main-window body (ASCII ellipsis)
+  static let loadingModelBadge = "Loading model\u{2026}"  // toolbar badge (Unicode ellipsis)
+  static let loadingModelSidebar = "Loading Model"  // sidebar row (title-case, no ellipsis)
+  /// Shared by the toolbar badge and the sidebar row — one word, one authority.
+  static let recordingStatus = "Recording"
+  static let errorStatus = "Error"  // sidebar row + main-window `.error` heading (single word)
 }

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -138,13 +138,16 @@ final class RecordingOverlayPanel {
     else { return }
     self.isRecordingLocked = isRecordingLocked
     currentIntent = intent
+    // #1569 (E4): the narrator is the sole author of the spoken announcement;
+    // the panel keeps choosing the per-case AX priority + target element.
+    let spokenAnnouncement = DictationNarrator.announcement(for: intent)
     switch intent {
     case .hidden:
       NSAccessibility.post(
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Recording complete",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
         ])
       hide()
@@ -153,7 +156,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Recording started",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       show(
@@ -164,7 +167,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Processing transcription",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
         ])
       showPolishing(label: DictationNarrator.copy(for: phase))
@@ -173,7 +176,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Text copied to clipboard",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       showClipboardFallback()
@@ -182,7 +185,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Accessibility permission needed for auto-paste",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       if accessibilityToastShownThisSession || accessibilityWarningDismissedProvider() {
@@ -198,7 +201,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Warning: \(message)",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
         ])
       showWarning(message: message)
@@ -209,7 +212,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Error: \(message)",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       showError(message: message)
@@ -219,7 +222,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Interruption: \(message)",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       showNotification(message: message, style: .interruption)
@@ -228,7 +231,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Detected \(payload.displayName)",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
         ])
       showPassiveChip(payload: payload)
@@ -237,13 +240,13 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Getting dictation ready, one moment",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
         ])
       presentTransientNotice(
         content: ColdStartNoticeView(
-          title: "Getting dictation ready…",
-          subtitle: "\(engineLabel) is warming up after a restart",
+          title: DictationNarrator.coldStartTitle,
+          subtitle: DictationNarrator.coldStartSubtitle(engineLabel: engineLabel),
           icon: .spinner
         ).frame(width: 300, height: 56),
         width: 300, height: 56, dismissAfter: 2.0)
@@ -252,12 +255,12 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Dictation ready. Press to start.",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       presentTransientNotice(
         content: ColdStartNoticeView(
-          title: "Ready — press to dictate",
+          title: DictationNarrator.readyTitle,
           subtitle: nil,
           icon: .ready
         ).frame(width: 240, height: 44),
@@ -267,7 +270,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement: "Recovering your last recording. Press Discard to skip.",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
         ])
       presentTransientNotice(
@@ -281,8 +284,7 @@ final class RecordingOverlayPanel {
         element: NSApp.mainWindow as Any,
         notification: .announcementRequested,
         userInfo: [
-          .announcement:
-            "Bluetooth microphone detected. Wait a moment before speaking on a cold start.",
+          .announcement: spokenAnnouncement,
           .priority: NSAccessibilityPriorityLevel.medium.rawValue as NSNumber,
         ])
       showBluetoothAwareness()
@@ -443,7 +445,7 @@ final class RecordingOverlayPanel {
   func showClipboardFallback() {
     guard panel == nil else {
       // Transition from existing panel (recording/polishing) to clipboard notice
-      transitionToPolishing(label: "Copied. Press \u{2318}V to paste")
+      transitionToPolishing(label: DictationNarrator.clipboardFallbackText)
       scheduleAutoDismiss()
       return
     }
@@ -455,7 +457,7 @@ final class RecordingOverlayPanel {
     let work = DispatchWorkItem { [weak self] in
       guard let self, self.generation == token else { return }
       self.pendingCreateWork = nil
-      self.createPolishingPanel(label: "Copied. Press \u{2318}V to paste")
+      self.createPolishingPanel(label: DictationNarrator.clipboardFallbackText)
       self.scheduleAutoDismiss()
     }
     pendingCreateWork = work
@@ -1521,7 +1523,7 @@ struct AccessibilityToastView: View {
       Image(systemName: "lock.shield.fill")
         .foregroundStyle(.orange)
         .font(.system(size: 16))
-      Text("Auto-paste needs Accessibility")
+      Text(DictationNarrator.accessibilityToastText)
         .font(.system(size: 13, weight: .medium))
         .foregroundStyle(.white)
       Spacer(minLength: 8)
@@ -1557,10 +1559,10 @@ struct RecoveryNoticeView: View {
         .controlSize(.small)
         .accessibilityHidden(true)
       VStack(alignment: .leading, spacing: 1) {
-        Text("Recovering your last recording…")
+        Text(DictationNarrator.recoveryTitle)
           .font(.system(size: 13, weight: .medium))
           .foregroundStyle(.white)
-        Text("Saved to History when it's done")
+        Text(DictationNarrator.recoverySubtitle)
           .font(.system(size: 11))
           .foregroundStyle(.white.opacity(0.7))
       }
@@ -1581,6 +1583,6 @@ struct RecoveryNoticeView: View {
     .padding(.vertical, 10)
     .background(OverlayCapsuleBackground())
     .accessibilityElement(children: .contain)
-    .accessibilityLabel("Recovering your last recording")
+    .accessibilityLabel(DictationNarrator.recoveryAccessibilityLabel)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
@@ -42,7 +42,7 @@ struct StatusView: View {
         VStack(spacing: 12) {
           ProgressView()
             .controlSize(.large)
-          Text("Loading model...")
+          Text(DictationNarrator.loadingModelStatus)
             .font(.title2)
           Text("This may take a moment on first run.")
             .font(.caption)
@@ -172,7 +172,7 @@ struct StatusView: View {
 
       case .error(let reason):
         ContentUnavailableView {
-          Label("Error", systemImage: "exclamationmark.triangle")
+          Label(DictationNarrator.errorStatus, systemImage: "exclamationmark.triangle")
         } description: {
           // #1558: the narrator is the sole author; no raw detail reaches here.
           Text(DictationNarrator.copy(for: reason))
@@ -292,13 +292,13 @@ struct StatusBadge: View {
           Image(systemName: "mic.fill")
             .foregroundStyle(.stError)
             .symbolEffect(.pulse)
-          Text("Recording")
+          Text(DictationNarrator.recordingStatus)
             .foregroundStyle(.secondary)
         }
         .font(.caption)
 
       case .loadingModel:
-        progressLabel("Loading model\u{2026}")
+        progressLabel(DictationNarrator.loadingModelBadge)
 
       case .transcribing:
         progressLabel(DictationNarrator.statusBadgeCopy(for: .transcribing))

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -205,4 +205,76 @@ import Testing
       DictationNarrator.copy(for: RecordingNoticeReason.autoStopUnavailable)
         == "Auto-stop on silence is unavailable right now")
   }
+
+  // MARK: - Spoken announcements + fixed status copy (E4, #1569)
+
+  /// Every `OverlayIntent` case maps to its exact spoken announcement — the words
+  /// VoiceOver reads, byte-identical to the panel's retired inline literals. The
+  /// three message-bearing cases compose the narrator's own reason copy.
+  @Test("every overlay intent maps to its exact spoken announcement")
+  func announcementsAreByteExact() {
+    let chip = LanguageChipPayload(
+      lang: "es", displayName: "Spanish", state: .askToLock, generation: 0)
+    let cases: [(OverlayIntent, String)] = [
+      (.hidden, "Recording complete"),
+      (.recording(audioLevel: 0.5), "Recording started"),
+      (.processing(phase: .transcribing), "Processing transcription"),
+      (.clipboardFallback, "Text copied to clipboard"),
+      (.accessibilityToast, "Accessibility permission needed for auto-paste"),
+      (.warning(reason: .polishFailed), "Warning: Polish failed. Using raw text."),
+      (.error(reason: .prepareFailed), "Error: Audio capture error. Try again."),
+      (.interruption(reason: .deviceRemoved), "Interruption: Microphone disconnected."),
+      (.passiveChip(payload: chip), "Detected Spanish"),
+      (.cachingModel(engineLabel: "Parakeet"), "Getting dictation ready, one moment"),
+      (.engineReady, "Dictation ready. Press to start."),
+      (
+        .recoveringLastRecording,
+        "Recovering your last recording. Press Discard to skip."
+      ),
+      (
+        .bluetoothAwareness,
+        "Bluetooth microphone detected. Wait a moment before speaking on a cold start."
+      ),
+    ]
+    for (intent, want) in cases {
+      #expect(DictationNarrator.announcement(for: intent) == want)
+    }
+  }
+
+  /// The fixed status-pill / window / badge / sidebar copy is byte-identical to
+  /// today's retired renderer literals (founder-locked 2026-07-15).
+  @Test("fixed status copy accessors are byte-exact")
+  func fixedStatusCopyByteExact() {
+    #expect(DictationNarrator.coldStartTitle == "Getting dictation ready…")
+    #expect(
+      DictationNarrator.coldStartSubtitle(engineLabel: "Parakeet")
+        == "Parakeet is warming up after a restart")
+    #expect(DictationNarrator.readyTitle == "Ready — press to dictate")
+    #expect(DictationNarrator.clipboardFallbackText == "Copied. Press \u{2318}V to paste")
+    #expect(DictationNarrator.accessibilityToastText == "Auto-paste needs Accessibility")
+    #expect(DictationNarrator.recoveryTitle == "Recovering your last recording…")
+    #expect(DictationNarrator.recoverySubtitle == "Saved to History when it's done")
+    #expect(DictationNarrator.recoveryAccessibilityLabel == "Recovering your last recording")
+    #expect(DictationNarrator.loadingModelStatus == "Loading model...")
+    #expect(DictationNarrator.loadingModelBadge == "Loading model\u{2026}")
+    #expect(DictationNarrator.loadingModelSidebar == "Loading Model")
+    #expect(DictationNarrator.recordingStatus == "Recording")
+    #expect(DictationNarrator.errorStatus == "Error")
+  }
+
+  /// The byte-distinct render forms must stay distinct: the main-window body uses
+  /// ASCII `...`, the toolbar badge uses the single Unicode ellipsis, and the
+  /// recovery container AX label drops the ellipsis the visible title carries.
+  @Test("the distinct render forms keep their exact byte differences")
+  func distinctRenderFormsStayDistinct() {
+    #expect(DictationNarrator.loadingModelStatus != DictationNarrator.loadingModelBadge)
+    #expect(DictationNarrator.loadingModelStatus.contains("..."))
+    #expect(DictationNarrator.loadingModelBadge.contains("\u{2026}"))
+    #expect(!DictationNarrator.loadingModelBadge.contains("..."))
+    // The sidebar form is title-case, distinct from the body form.
+    #expect(DictationNarrator.loadingModelSidebar != DictationNarrator.loadingModelStatus)
+    // The recovery AX label has no ellipsis; the visible title does.
+    #expect(DictationNarrator.recoveryAccessibilityLabel != DictationNarrator.recoveryTitle)
+    #expect(!DictationNarrator.recoveryAccessibilityLabel.contains("…"))
+  }
 }


### PR DESCRIPTION
Heartpath step 6 ("one voice") — **final part (E4)**. `DictationNarrator` becomes the SOLE author of every recording-lifecycle status/notice literal; the four renderers become pure presenters.

## What moved into the narrator
- **`RecordingOverlayPanel`**: the 13 VoiceOver announcements (one `announcement(for: OverlayIntent)` authority), the cold-start / ready / clipboard-fallback / accessibility-toast / recovery pill copy, and the recovery pill's **container** AX label.
- **`MainWindowView` + `StatusBadge`**: `"Loading model..."`, `"Recording"`, `"Loading model…"`, and the `.error` state heading `Label("Error")`.
- **`BackendMetadata.statusText(for:)`**: the sidebar's `"Loading Model"` / `"Recording"` / `"Error"` (an incomplete E2 cutover — the phase words there already routed through the narrator). `"Loaded"`/`"Unloaded"` engine-health readouts stay.

## Doctrine
- **Scoreboard: recording-lifecycle status/notice authors 4 → 1.** The four post-E3 authors (panel, main-window/badge family, `BackendMetadata`, and the narrator) collapse to just `DictationNarrator`. Step 6 COMPLETE.
- **Words byte-identical** (founder-locked 2026-07-15 — the "Ready — press to dictate" dash is deliberately kept). Zero user-facing copy changes.
- **No new payload / no reshaped public case** — the narrator gains functions keyed on the already-typed `OverlayIntent` / `PipelineState` cases.
- Out of family (retained by their owners): interactive feature cards (Bluetooth education #1480, language chip), button labels, per-control AX labels, empty-state screen headings (`"Ready to Transcribe"` / `"Transcription Complete"`, no narrator twin), the AI-polish provider-status `"Error"`, and menu-bar controls.

## Validation
- Grounded review: PROCEED-AS-PLANNED after 5 rounds (each round tightened the author inventory: sidebar row → recovery AX label → `.error` heading; final sweep confirmed no other author).
- Logic suite: **2992 tests pass** (+3 new byte-exact `DictationNarrator` goldens covering all 13 announcements + every status accessor + the distinct render forms).
- Local Codex diff-review: clean.
- Live UAT (dev build): normal dictation completes in 0.839s, exact transcript, "Polishing…" pill, clean paste, no spurious pill.
- Grep gates: zero lifecycle status literals remain outside `DictationNarrator` (the only leftover matches are a benchmark tool's progress readout and telemetry breadcrumbs — out of family).

Council skipped (D-021). Plan: `docs/feature-requests/issue-1569-2026-07-15-e4-renderer-cutover.md`.