### PR TITLE
feat(worker): Phase 10 product-health telemetry alerts (#1179)

### DIFF
--- a/workers/product-health/live-query-smoke.mjs
+++ b/workers/product-health/live-query-smoke.mjs
@@ -13,6 +13,9 @@ import {
   evaluateAFM,
   evaluateTranscription,
   evaluateVolume,
+  evaluateOnboardingAbandon,
+  evaluateBackendTranscription,
+  evaluateOnboardingBlackout,
   buildMessage,
 } from "./src/index.js";
 
@@ -36,10 +39,13 @@ if (!data.latencyDays.length) fail("latency query returned no days");
 if (!data.volumeDays.length) fail("volume query returned no days");
 if (!(Number(data.seven.dictations_7d) > 0)) fail("7d dictations is zero - filter or window bug");
 if (!(Number(data.seven.paste_total) > 0)) fail("7d paste_total is zero - filter or window bug");
+if (!data.onboardingDays.length) fail("onboarding query returned no days");
+if (!Object.keys(data.backendTranscriptionDays).length) fail("backend transcription query returned no backends");
 // fallback_reason is expected all-null pre-release: afm_fr_rows may be 0.
 console.log("columns OK; denominators non-zero.");
 console.log("7d:", JSON.stringify(data.seven));
 console.log("latency days:", data.latencyDays.length, "volume days:", data.volumeDays.length);
+console.log("onboarding days:", data.onboardingDays.length, "backends:", Object.keys(data.backendTranscriptionDays));
 console.log("afm_fr_rows (expect 0 pre-release):", data.seven.afm_fr_rows);
 
 const results = {
@@ -48,8 +54,16 @@ const results = {
   afm: evaluateAFM(data.seven),
   transcription: evaluateTranscription(data.seven),
   volume: evaluateVolume(data.volumeDays, data.t1ref),
+  onboardingAbandon: evaluateOnboardingAbandon(data.onboardingDays, data.t1ref),
+  backendTranscription: evaluateBackendTranscription(data.backendTranscriptionDays, data.t1ref),
+  onboardingBlackout: evaluateOnboardingBlackout(data.onboardingDays, data.t1ref),
 };
 console.log("t1ref (PostHog clock):", data.t1ref);
-console.log("\nstates:", Object.fromEntries(Object.entries(results).map(([k, v]) => [k, v.state])));
+console.log(
+  "\nstates:",
+  Object.fromEntries(
+    Object.entries(results).map(([k, v]) => [k, Array.isArray(v) ? v.map((row) => `${row.backend}:${row.state}`) : v.state])
+  )
+);
 console.log("\n--- heartbeat preview (NOT posted) ---");
-console.log(buildMessage(results, data.versions));
+console.log(buildMessage(results, data.versions, data.onboardingVersions, data.backendVersions));

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -634,6 +634,13 @@ export function buildMessage(r, versions = [], onboardingVersions = [], backendV
       }
       note(`transcription-${row.backend}`, row);
     }
+    if (r.backendTranscription.length === 0 && !r.backendAttributionBlackout) {
+      // Codex r5 review finding: an empty result during a genuinely
+      // low-volume period (not blackout, since aggregate volume is also
+      // low) never reaches the loop above, so the metric silently vanished
+      // from evaluated/skipped/alerts instead of reading as skipped.
+      note("transcription-backend", { state: "skipped-low-volume" });
+    }
     if (r.backendAttributionBlackout) {
       // Total backend-attribution blackout (Codex review finding): the query
       // matched zero (day, backend) groups despite healthy overall dictation

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -153,11 +153,17 @@ export async function fetchHealth(env) {
 
   // 5) Phase 10 (#1179): per-day onboarding funnel, 21 complete days (covers
   //    the rolling baseline AND the fast path AND the blackout's 9-day need).
+  // `onboarding.started` fires ONLY on the "Get Started" click
+  // (OnboardingV2View.swift:670); `onboarding.abandoned` can fire earlier, on
+  // a welcome-screen close BEFORE that click (OnboardingProgress.swift's
+  // `begin()` runs at presentation, not at Get-Started) — that session never
+  // emitted `started`. Excluding `screen = 'welcome'` abandons matches the
+  // denominator to sessions that actually started (Codex review finding).
   const onboardingSql = `
     SELECT toDate(timestamp) AS day,
            countIf(event = 'onboarding.started') AS started,
            countIf(event = 'onboarding.completed') AS completed,
-           countIf(event = 'onboarding.abandoned') AS abandoned
+           countIf(event = 'onboarding.abandoned' AND properties.screen != 'welcome') AS abandoned
     FROM events
     WHERE ${PROD}
       AND event IN ('onboarding.started', 'onboarding.completed', 'onboarding.abandoned')
@@ -191,6 +197,13 @@ export async function fetchHealth(env) {
       AND timestamp >= ${DAY} - INTERVAL 21 DAY AND timestamp < ${DAY}
     GROUP BY ver ORDER BY onboarding_abandon DESC LIMIT 5`;
 
+  // LIMIT is generous (not per-backend) headroom, not a per-backend cap: a
+  // global LIMIT 10 could let one high-volume backend's rows crowd out a
+  // second backend's rows entirely, since `topVersionsFor` filters BY backend
+  // only after this query returns (Codex review finding). Two backends today
+  // (Parakeet, WhisperKit) with `limit: 3` displayed each means 40 comfortably
+  // covers both without a per-backend-ranked subquery this codebase has no
+  // other precedent for.
   const backendVersionSql = `
     SELECT properties.app_version AS ver,
            properties.backend AS backend,
@@ -198,7 +211,7 @@ export async function fetchHealth(env) {
     FROM events
     WHERE ${PROD} AND event = 'pipeline.failed' AND properties.stage = 'transcription'
       AND timestamp >= ${DAY} - INTERVAL 14 DAY AND timestamp < ${DAY}
-    GROUP BY ver, backend ORDER BY backend_trans_fail DESC LIMIT 10`;
+    GROUP BY ver, backend ORDER BY backend_trans_fail DESC LIMIT 40`;
 
   const [latency, seven, volume, versions, ref, onboarding, backendTranscription, onboardingVersions, backendVersions] =
     await Promise.all([
@@ -350,8 +363,16 @@ export function evaluateOnboardingAbandon(rows, expectedT1, TH = THRESHOLDS.onbo
     return started >= TH.fastMinStarted && num(row.abandoned) / started > TH.share;
   });
   if (fastCrossing) {
+    // Report the fast-window's OWN rate, not the rolling total — the alert
+    // text must name the numbers that actually triggered it (Codex review
+    // finding: a healthy rolling share can otherwise read alongside a fast
+    // crossing and contradict the stated threshold).
+    const fastStarted = fastRows.reduce((sum, row) => sum + num(row.started), 0);
+    const fastAbandoned = fastRows.reduce((sum, row) => sum + num(row.abandoned), 0);
     return { state: "alerting", rollingShare: totalStarted > 0 ? totalAbandoned / totalStarted : 0,
-      fastCrossing: true, totalStarted, totalAbandoned };
+      fastCrossing: true, fastStarted, fastAbandoned,
+      fastShare: fastStarted > 0 ? fastAbandoned / fastStarted : 0,
+      totalStarted, totalAbandoned };
   }
 
   if (totalStarted < TH.minStarted) {
@@ -379,7 +400,15 @@ export function evaluateBackendTranscription(perBackendDays, expectedT1, TH = TH
     });
     const rollingShare = attempts > 0 ? fails / attempts : 0;
     if (fastCrossing) {
-      return { backend, state: "alerting", rollingShare, fastCrossing: true, fails, dictations, attempts };
+      // Same fix as evaluateOnboardingAbandon: report the fast-window's own
+      // rate, not the rolling 14-day rate, when the fast path is what fired.
+      const fastDictations = fastRows.reduce((sum, row) => sum + num(row.dictations), 0);
+      const fastFails = fastRows.reduce((sum, row) => sum + num(row.fails), 0);
+      const fastAttempts = fastDictations + fastFails;
+      return { backend, state: "alerting", rollingShare, fastCrossing: true,
+        fastDictations, fastFails, fastAttempts,
+        fastShare: fastAttempts > 0 ? fastFails / fastAttempts : 0,
+        fails, dictations, attempts };
     }
 
     if (attempts < TH.minAttempts) {
@@ -491,12 +520,15 @@ export function buildMessage(r, versions = [], onboardingVersions = [], backendV
   if (r.onboardingAbandon) {
     if (r.onboardingAbandon.state === "alerting") {
       const tv = topVersionsFor(onboardingVersions, "onboarding_abandon");
-      const rate = pct(r.onboardingAbandon.rollingShare);
-      const via = r.onboardingAbandon.fastCrossing ? "fast 2-day crossing" : "rolling 21-day crossing";
+      // Report the window that actually crossed (Codex review finding: a
+      // fast-only crossing must not display the healthy rolling total).
+      const ev = r.onboardingAbandon;
+      const windowText = ev.fastCrossing
+        ? `${pct(ev.fastShare)} (${ev.fastAbandoned}/${ev.fastStarted}, fast 2-day crossing)`
+        : `${pct(ev.rollingShare)} (${ev.totalAbandoned}/${ev.totalStarted}, prev 21d, rolling crossing)`;
       alerts.push(
-        `onboarding abandon ${rate} (${r.onboardingAbandon.totalAbandoned}/${r.onboardingAbandon.totalStarted}, ` +
-        `prev 21d, via ${via}), threshold >${pct(THRESHOLDS.onboardingAbandon.share)}, baseline ~37%.` +
-        (tv ? ` Top versions ${tv}.` : "")
+        `onboarding abandon ${windowText}, threshold >${pct(THRESHOLDS.onboardingAbandon.share)}, ` +
+        `baseline ~37%.` + (tv ? ` Top versions ${tv}.` : "")
       );
     }
     note("onboarding-abandon", r.onboardingAbandon);
@@ -507,10 +539,12 @@ export function buildMessage(r, versions = [], onboardingVersions = [], backendV
     for (const row of r.backendTranscription) {
       if (row.state === "alerting") {
         const tv = topVersionsFor(backendVersions, "backend_trans_fail", { backend: row.backend });
-        const rate = pct(row.rollingShare);
-        const via = row.fastCrossing ? "fast 2-day crossing" : "rolling 14-day crossing";
+        // Same fix: name the window that actually crossed.
+        const windowText = row.fastCrossing
+          ? `${pct(row.fastShare)} (${row.fastFails}/${row.fastAttempts}, fast 2-day crossing)`
+          : `${pct(row.rollingShare)} (${row.fails}/${row.attempts}, prev 14d, rolling crossing)`;
         alerts.push(
-          `${row.backend} transcription failure ${rate} (${row.fails}/${row.attempts}, prev 14d, via ${via}), ` +
+          `${row.backend} transcription failure ${windowText}, ` +
           `threshold >${pct(THRESHOLDS.backendTranscription.share)}.` + (tv ? ` Top versions ${tv}.` : "")
         );
       }
@@ -575,12 +609,20 @@ export function buildMessage(r, versions = [], onboardingVersions = [], backendV
   const h1Line = " Crash/error-rate monitoring lives in Sentry's own alert rules (see Error Spike >5/hr), not in this report.";
   const heartbeat = `${head}. T-1: ${t1d} dictations${ratioStr}. ${coverage}${driftStr}${h1Line}`;
 
-  let content = heartbeat;
-  if (alerts.length) {
-    content += "\n\n" + alerts.map((a) => "* " + a).join("\n") + `\n${DASHBOARD}`;
+  if (!alerts.length) return heartbeat;
+
+  // Discord content cap is 2000 chars. A blind character slice can cut mid-
+  // alert and silently drop the dashboard link, hiding the very alerts most
+  // worth seeing (Codex review finding) — drop whole alerts from the end
+  // instead, always keeping the heartbeat and the dashboard link.
+  for (let keep = alerts.length; keep > 0; keep--) {
+    const omitted = alerts.length - keep;
+    const trailer = omitted > 0 ? `\n(${omitted} more alert(s) omitted; see dashboard)` : "";
+    const trial =
+      heartbeat + "\n\n" + alerts.slice(0, keep).map((a) => "* " + a).join("\n") + trailer + `\n${DASHBOARD}`;
+    if (trial.length <= 1990) return trial;
   }
-  // Discord content cap is 2000 chars.
-  return content.length > 1990 ? content.slice(0, 1987) + "..." : content;
+  return `${heartbeat}\n\n${alerts.length} alert(s) triggered; see ${DASHBOARD}`.slice(0, 1990);
 }
 
 // ----- Run ----------------------------------------------------------------

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -159,6 +159,20 @@ export async function fetchHealth(env) {
   // `begin()` runs at presentation, not at Get-Started) — that session never
   // emitted `started`. Excluding `screen = 'welcome'` abandons matches the
   // denominator to sessions that actually started (Codex review finding).
+  //
+  // Known residual limitation (Codex review, second round): a user who
+  // reopens the reused onboarding window after abandoning past `welcome` (via
+  // "Continue Setup...") gets a FRESH in-memory session per `begin()`
+  // (`OnboardingProgress.swift`) without a fresh `onboarding.started`, since
+  // that event fires only from the "Get Started" button and the reused
+  // window resumes at the last observed screen. Each such reopen-then-close
+  // adds one non-welcome abandon with no matching start. Fixing this fully
+  // requires either a new started-per-reopen event (violates this phase's
+  // explicit no-new-app-telemetry non-goal) or query-side session pairing
+  // this worker's HogQL has no other precedent for. Accepted, matching the
+  // project's own precedent for telemetry-model ambiguities it cannot
+  // perfectly resolve from existing events (e.g. the paste-only-copy
+  // ambiguity `evaluateVolume` already accepts, #1130).
   const onboardingSql = `
     SELECT toDate(timestamp) AS day,
            countIf(event = 'onboarding.started') AS started,
@@ -191,7 +205,7 @@ export async function fetchHealth(env) {
   //    window (§3 Design "Per-release segmentation").
   const onboardingVersionSql = `
     SELECT properties.app_version AS ver,
-           countIf(event = 'onboarding.abandoned') AS onboarding_abandon
+           countIf(event = 'onboarding.abandoned' AND properties.screen != 'welcome') AS onboarding_abandon
     FROM events
     WHERE ${PROD} AND event = 'onboarding.abandoned'
       AND timestamp >= ${DAY} - INTERVAL 21 DAY AND timestamp < ${DAY}

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -175,17 +175,24 @@ export async function fetchHealth(env) {
   // ambiguity `evaluateVolume` already accepts, #1130).
   // `abandonedRaw` (no screen filter) alongside the filtered `abandoned`:
   // ClickHouse's `!=` is NULL-unsafe, so if `properties.screen` ever stops
-  // emitting (schema drift, Codex review finding), every abandon silently
-  // reads as "welcome" and gets excluded — `abandoned` would read a healthy
-  // zero while abandon activity is actually still happening. Comparing the
-  // two catches that: real abandon volume with zero passing the filter is
-  // itself the drift signal.
+  // emitting (schema drift), every abandon silently reads as "welcome" and
+  // gets excluded — `abandoned` would read a healthy zero while abandon
+  // activity is actually still happening.
+  //
+  // `abandonedMissingScreen` counts the drift signal DIRECTLY (NULL/empty
+  // `properties.screen`) rather than inferring it from `abandonedRaw -
+  // abandoned` (Codex r4 review finding): a legitimate concentration of
+  // abandons on the real "welcome" screen also produces `abandonedRaw > 0`
+  // with `abandoned === 0`, which is healthy, correctly-tagged data, not
+  // drift, and the old raw-vs-filtered inference could not tell the two
+  // apart.
   const onboardingSql = `
     SELECT toDate(timestamp) AS day,
            countIf(event = 'onboarding.started') AS started,
            countIf(event = 'onboarding.completed') AS completed,
            countIf(event = 'onboarding.abandoned' AND properties.screen != 'welcome') AS abandoned,
-           countIf(event = 'onboarding.abandoned') AS abandonedRaw
+           countIf(event = 'onboarding.abandoned') AS abandonedRaw,
+           countIf(event = 'onboarding.abandoned' AND (properties.screen IS NULL OR properties.screen = '')) AS abandonedMissingScreen
     FROM events
     WHERE ${PROD}
       AND event IN ('onboarding.started', 'onboarding.completed', 'onboarding.abandoned')
@@ -374,21 +381,24 @@ function completeDayWindow(rows, expectedT1, count) {
 }
 
 export function evaluateOnboardingAbandon(rows, expectedT1, TH = THRESHOLDS.onboardingAbandon) {
-  // rows: per-day {day, started, abandoned, abandonedRaw}, any order — mirrors evaluateLatency's `days` shape.
+  // rows: per-day {day, started, abandoned, abandonedRaw, abandonedMissingScreen}, any order — mirrors evaluateLatency's `days` shape.
   const totalStarted = rows.reduce((sum, row) => sum + num(row.started), 0);
   const totalAbandoned = rows.reduce((sum, row) => sum + num(row.abandoned), 0);
   const totalAbandonedRaw = rows.reduce((sum, row) => sum + num(row.abandonedRaw), 0);
+  const totalAbandonedMissingScreen = rows.reduce(
+    (sum, row) => sum + num(row.abandonedMissingScreen), 0);
 
-  // Screen-attribution drift, checked FIRST (Codex review finding): if
-  // `properties.screen` stops emitting, ClickHouse's NULL-unsafe `!=` makes
-  // every abandon silently read as "welcome," so `abandoned` reads a healthy
-  // zero while real abandon volume (`abandonedRaw`) keeps happening. A
-  // drifted denominator makes every rate below meaningless, so this check
-  // runs before the fast path and the low-volume guard.
-  if (totalAbandonedRaw >= TH.minStarted && totalAbandoned === 0) {
+  // Screen-attribution drift, checked FIRST: alert directly on missing/empty
+  // `properties.screen` volume, not on `abandonedRaw - abandoned` (Codex r4
+  // review finding — that difference is also nonzero when abandons
+  // legitimately concentrate on the real "welcome" screen, which is healthy,
+  // correctly-tagged data, not drift). A drifted denominator makes every
+  // rate below meaningless, so this check runs before the fast path and the
+  // low-volume guard.
+  if (totalAbandonedMissingScreen >= TH.minStarted) {
     return {
       state: "alerting", attributionDrift: true, fastCrossing: false,
-      totalStarted, totalAbandoned, totalAbandonedRaw,
+      totalStarted, totalAbandoned, totalAbandonedRaw, totalAbandonedMissingScreen,
     };
   }
 
@@ -569,12 +579,14 @@ export function buildMessage(r, versions = [], onboardingVersions = [], backendV
   if (r.onboardingAbandon) {
     const ev = r.onboardingAbandon;
     if (ev.state === "alerting" && ev.attributionDrift) {
-      // Screen-attribution drift (Codex review finding): distinct wording,
-      // no version attribution (this is a schema-drift signal, not a rate).
+      // Screen-attribution drift: distinct wording, no version attribution
+      // (this is a schema-drift signal, not a rate). Names the missing-screen
+      // count directly (Codex r4 review finding), not the raw total, so the
+      // alert cannot fire on a legitimate all-welcome concentration.
       alerts.push(
-        `onboarding abandon attribution lost: ${ev.totalAbandonedRaw} onboarding.abandoned events ` +
-        `fired over the prev 21d but 0 carried a usable properties.screen (excluded as "welcome") ` +
-        `(properties.screen may have stopped emitting or been renamed).`
+        `onboarding abandon attribution lost: ${ev.totalAbandonedMissingScreen} of ` +
+        `${ev.totalAbandonedRaw} onboarding.abandoned events over the prev 21d had no usable ` +
+        `properties.screen (properties.screen may have stopped emitting or been renamed).`
       );
     } else if (ev.state === "alerting") {
       // Report the window that actually crossed (Codex review finding: a

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -173,11 +173,19 @@ export async function fetchHealth(env) {
   // project's own precedent for telemetry-model ambiguities it cannot
   // perfectly resolve from existing events (e.g. the paste-only-copy
   // ambiguity `evaluateVolume` already accepts, #1130).
+  // `abandonedRaw` (no screen filter) alongside the filtered `abandoned`:
+  // ClickHouse's `!=` is NULL-unsafe, so if `properties.screen` ever stops
+  // emitting (schema drift, Codex review finding), every abandon silently
+  // reads as "welcome" and gets excluded — `abandoned` would read a healthy
+  // zero while abandon activity is actually still happening. Comparing the
+  // two catches that: real abandon volume with zero passing the filter is
+  // itself the drift signal.
   const onboardingSql = `
     SELECT toDate(timestamp) AS day,
            countIf(event = 'onboarding.started') AS started,
            countIf(event = 'onboarding.completed') AS completed,
-           countIf(event = 'onboarding.abandoned' AND properties.screen != 'welcome') AS abandoned
+           countIf(event = 'onboarding.abandoned' AND properties.screen != 'welcome') AS abandoned,
+           countIf(event = 'onboarding.abandoned') AS abandonedRaw
     FROM events
     WHERE ${PROD}
       AND event IN ('onboarding.started', 'onboarding.completed', 'onboarding.abandoned')
@@ -366,9 +374,23 @@ function completeDayWindow(rows, expectedT1, count) {
 }
 
 export function evaluateOnboardingAbandon(rows, expectedT1, TH = THRESHOLDS.onboardingAbandon) {
-  // rows: per-day {day, started, abandoned}, any order — mirrors evaluateLatency's `days` shape.
+  // rows: per-day {day, started, abandoned, abandonedRaw}, any order — mirrors evaluateLatency's `days` shape.
   const totalStarted = rows.reduce((sum, row) => sum + num(row.started), 0);
   const totalAbandoned = rows.reduce((sum, row) => sum + num(row.abandoned), 0);
+  const totalAbandonedRaw = rows.reduce((sum, row) => sum + num(row.abandonedRaw), 0);
+
+  // Screen-attribution drift, checked FIRST (Codex review finding): if
+  // `properties.screen` stops emitting, ClickHouse's NULL-unsafe `!=` makes
+  // every abandon silently read as "welcome," so `abandoned` reads a healthy
+  // zero while real abandon volume (`abandonedRaw`) keeps happening. A
+  // drifted denominator makes every rate below meaningless, so this check
+  // runs before the fast path and the low-volume guard.
+  if (totalAbandonedRaw >= TH.minStarted && totalAbandoned === 0) {
+    return {
+      state: "alerting", attributionDrift: true, fastCrossing: false,
+      totalStarted, totalAbandoned, totalAbandonedRaw,
+    };
+  }
 
   // Fast path checked FIRST and independently — see canonical contract O1.
   const fastRows = completeDayWindow(rows, expectedT1, TH.fastDays);
@@ -404,6 +426,19 @@ export function evaluateBackendTranscription(perBackendDays, expectedT1, TH = TH
     const dictations = rows.reduce((sum, row) => sum + num(row.dictations), 0);
     const fails = rows.reduce((sum, row) => sum + num(row.fails), 0);
     const attempts = dictations + fails;
+
+    // Backend-attribution drift, checked FIRST (Codex review finding): "unknown"
+    // is a synthetic bucket `groupByBackend` assigns when BOTH asr_backend and
+    // backend are absent — never a real backend name. Meaningful volume there
+    // means the attribution tag itself stopped emitting; the per-backend split
+    // this metric promises has silently degraded to an aggregate, which must
+    // alert rather than read as just another (possibly "evaluated-ok") backend.
+    if (backend === "unknown" && attempts >= TH.minAttempts) {
+      return {
+        backend, state: "alerting", attributionDrift: true, fastCrossing: false,
+        fails, dictations, attempts,
+      };
+    }
 
     const fastRows = completeDayWindow(rows, expectedT1, TH.fastDays);
     const fastCrossing = fastRows.every((row) => {
@@ -532,37 +567,70 @@ export function buildMessage(r, versions = [], onboardingVersions = [], backendV
 
   // Onboarding abandon (Phase 10, #1179)
   if (r.onboardingAbandon) {
-    if (r.onboardingAbandon.state === "alerting") {
-      const tv = topVersionsFor(onboardingVersions, "onboarding_abandon");
+    const ev = r.onboardingAbandon;
+    if (ev.state === "alerting" && ev.attributionDrift) {
+      // Screen-attribution drift (Codex review finding): distinct wording,
+      // no version attribution (this is a schema-drift signal, not a rate).
+      alerts.push(
+        `onboarding abandon attribution lost: ${ev.totalAbandonedRaw} onboarding.abandoned events ` +
+        `fired over the prev 21d but 0 carried a usable properties.screen (excluded as "welcome") ` +
+        `(properties.screen may have stopped emitting or been renamed).`
+      );
+    } else if (ev.state === "alerting") {
       // Report the window that actually crossed (Codex review finding: a
       // fast-only crossing must not display the healthy rolling total).
-      const ev = r.onboardingAbandon;
       const windowText = ev.fastCrossing
         ? `${pct(ev.fastShare)} (${ev.fastAbandoned}/${ev.fastStarted}, fast 2-day crossing)`
         : `${pct(ev.rollingShare)} (${ev.totalAbandoned}/${ev.totalStarted}, prev 21d, rolling crossing)`;
+      // Version attribution only matches the metric's own 21-day window —
+      // a fast (2-day) crossing must not misattribute to it (Codex review
+      // finding: an older high-volume release can otherwise be blamed for a
+      // regression confined to the last 2 days).
+      const tv = ev.fastCrossing ? "" : topVersionsFor(onboardingVersions, "onboarding_abandon");
       alerts.push(
         `onboarding abandon ${windowText}, threshold >${pct(THRESHOLDS.onboardingAbandon.share)}, ` +
         `baseline ~37%.` + (tv ? ` Top versions ${tv}.` : "")
       );
     }
-    note("onboarding-abandon", r.onboardingAbandon);
+    note("onboarding-abandon", ev);
   }
 
   // Per-backend transcription (Phase 10, #1179)
   if (r.backendTranscription) {
     for (const row of r.backendTranscription) {
-      if (row.state === "alerting") {
-        const tv = topVersionsFor(backendVersions, "backend_trans_fail", { backend: row.backend });
-        // Same fix: name the window that actually crossed.
+      if (row.state === "alerting" && row.attributionDrift) {
+        // Backend-attribution drift (Codex review finding): distinct wording,
+        // no version attribution.
+        alerts.push(
+          `transcription backend attribution lost: ${row.attempts} dictation/failure events ` +
+          `over the prev 14d carried no usable asr_backend or backend tag ` +
+          `(the per-backend split has degraded to an aggregate).`
+        );
+      } else if (row.state === "alerting") {
+        // Same fix as onboarding-abandon: name the window that actually
+        // crossed, and only attribute versions to a matching window.
         const windowText = row.fastCrossing
           ? `${pct(row.fastShare)} (${row.fastFails}/${row.fastAttempts}, fast 2-day crossing)`
           : `${pct(row.rollingShare)} (${row.fails}/${row.attempts}, prev 14d, rolling crossing)`;
+        const tv = row.fastCrossing
+          ? ""
+          : topVersionsFor(backendVersions, "backend_trans_fail", { backend: row.backend });
         alerts.push(
           `${row.backend} transcription failure ${windowText}, ` +
           `threshold >${pct(THRESHOLDS.backendTranscription.share)}.` + (tv ? ` Top versions ${tv}.` : "")
         );
       }
       note(`transcription-${row.backend}`, row);
+    }
+    if (r.backendAttributionBlackout) {
+      // Total backend-attribution blackout (Codex review finding): the query
+      // matched zero (day, backend) groups despite healthy overall dictation
+      // volume — the per-backend split vanished entirely rather than reading
+      // as merely quiet.
+      alerts.push(
+        `transcription backend attribution blackout: 0 backend rows over the prev 14d despite ` +
+        `healthy aggregate 7d dictation volume (asr_backend/backend may have stopped emitting entirely).`
+      );
     }
   }
 
@@ -652,6 +720,17 @@ async function runHealth(env) {
     throw err;
   }
 
+  const backendTranscription = evaluateBackendTranscription(data.backendTranscriptionDays, data.t1ref);
+  // Backend-attribution blackout (Codex review finding): an empty result here
+  // means the query matched zero (day, backend) groups at all — every row's
+  // backend tag AND every dictation/failure vanished together. The existing
+  // aggregate transcription metric's own 7-day dictation count is proof this
+  // worker already has of real activity; if it's healthy while this metric's
+  // per-backend split came back with nothing, that split has silently gone
+  // dark rather than merely being quiet, so it must alert, not disappear.
+  const backendAttributionBlackout =
+    backendTranscription.length === 0 && num(data.seven.dictations_7d) >= THRESHOLDS.transcription.minDictations;
+
   const results = {
     latency: evaluateLatency(data.latencyDays),
     paste: evaluatePaste(data.seven),
@@ -659,7 +738,8 @@ async function runHealth(env) {
     transcription: evaluateTranscription(data.seven),
     volume: evaluateVolume(data.volumeDays, data.t1ref),
     onboardingAbandon: evaluateOnboardingAbandon(data.onboardingDays, data.t1ref),
-    backendTranscription: evaluateBackendTranscription(data.backendTranscriptionDays, data.t1ref),
+    backendTranscription,
+    backendAttributionBlackout,
     onboardingBlackout: evaluateOnboardingBlackout(data.onboardingDays, data.t1ref),
   };
   const message = buildMessage(results, data.versions, data.onboardingVersions, data.backendVersions);

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -27,6 +27,13 @@ export const THRESHOLDS = {
   afm: { minFrRows: 50, minDiscards: 10, share: 0.15 },
   transcription: { minDictations: 200, share: 0.05 },
   volume: { activeBaselineAvg: 20 },
+  // Phase 10 (#1179): calibrated 2026-07-15 against real 21d/14d baselines
+  // (see plan section 1). onboardingAbandon/backendTranscription each carry a
+  // rolling share/minN pair AND a fast-path pair (2-day sustained crossing,
+  // checked first and independently — canonical contract O1/B1 in the plan).
+  onboardingAbandon: { minStarted: 30, share: 0.5, fastMinStarted: 8, fastDays: 2 },
+  backendTranscription: { minAttempts: 200, share: 0.08, fastMinAttempts: 20, fastDays: 2 },
+  onboardingBlackout: { recentDays: 2, baselineDays: 7, activeBaselineAvg: 8, terminalMinStarted: 8 },
 };
 
 export default {
@@ -144,13 +151,67 @@ export async function fetchHealth(env) {
   // must look T-1 up by date rather than trust the newest row.
   const refSql = `SELECT toString(toDate(toStartOfDay(now()) - INTERVAL 1 DAY)) AS t1`;
 
-  const [latency, seven, volume, versions, ref] = await Promise.all([
-    hogql(env, latencySql),
-    hogql(env, sevenDaySql),
-    hogql(env, volumeSql),
-    hogql(env, versionSql),
-    hogql(env, refSql),
-  ]);
+  // 5) Phase 10 (#1179): per-day onboarding funnel, 21 complete days (covers
+  //    the rolling baseline AND the fast path AND the blackout's 9-day need).
+  const onboardingSql = `
+    SELECT toDate(timestamp) AS day,
+           countIf(event = 'onboarding.started') AS started,
+           countIf(event = 'onboarding.completed') AS completed,
+           countIf(event = 'onboarding.abandoned') AS abandoned
+    FROM events
+    WHERE ${PROD}
+      AND event IN ('onboarding.started', 'onboarding.completed', 'onboarding.abandoned')
+      AND timestamp >= ${DAY} - INTERVAL 21 DAY AND timestamp < ${DAY}
+    GROUP BY day ORDER BY day DESC`;
+
+  // 6) Phase 10 (#1179): per-day, per-backend transcription attempts, 14
+  //    complete days. Backend enumeration comes from EITHER event's backend
+  //    tag (dictation.completed's asr_backend, pipeline.failed's backend) —
+  //    canonical contract B2: an active backend with zero matching failures
+  //    still gets a row (fails: 0), never silently drops.
+  const backendTranscriptionSql = `
+    SELECT toDate(timestamp) AS day,
+           coalesce(properties.asr_backend, properties.backend) AS backend,
+           countIf(event = 'dictation.completed') AS dictations,
+           countIf(event = 'pipeline.failed' AND properties.stage = 'transcription') AS fails
+    FROM events
+    WHERE ${PROD}
+      AND ((event = 'dictation.completed')
+        OR (event = 'pipeline.failed' AND properties.stage = 'transcription'))
+      AND timestamp >= ${DAY} - INTERVAL 14 DAY AND timestamp < ${DAY}
+    GROUP BY day, backend ORDER BY day DESC`;
+
+  // 7) Phase 10 (#1179) per-release segmentation, matching each metric's own
+  //    window (§3 Design "Per-release segmentation").
+  const onboardingVersionSql = `
+    SELECT properties.app_version AS ver,
+           countIf(event = 'onboarding.abandoned') AS onboarding_abandon
+    FROM events
+    WHERE ${PROD} AND event = 'onboarding.abandoned'
+      AND timestamp >= ${DAY} - INTERVAL 21 DAY AND timestamp < ${DAY}
+    GROUP BY ver ORDER BY onboarding_abandon DESC LIMIT 5`;
+
+  const backendVersionSql = `
+    SELECT properties.app_version AS ver,
+           properties.backend AS backend,
+           countIf(event = 'pipeline.failed' AND properties.stage = 'transcription') AS backend_trans_fail
+    FROM events
+    WHERE ${PROD} AND event = 'pipeline.failed' AND properties.stage = 'transcription'
+      AND timestamp >= ${DAY} - INTERVAL 14 DAY AND timestamp < ${DAY}
+    GROUP BY ver, backend ORDER BY backend_trans_fail DESC LIMIT 10`;
+
+  const [latency, seven, volume, versions, ref, onboarding, backendTranscription, onboardingVersions, backendVersions] =
+    await Promise.all([
+      hogql(env, latencySql),
+      hogql(env, sevenDaySql),
+      hogql(env, volumeSql),
+      hogql(env, versionSql),
+      hogql(env, refSql),
+      hogql(env, onboardingSql),
+      hogql(env, backendTranscriptionSql),
+      hogql(env, onboardingVersionSql),
+      hogql(env, backendVersionSql),
+    ]);
 
   return {
     latencyDays: rowsToObjects(latency),
@@ -158,7 +219,20 @@ export async function fetchHealth(env) {
     volumeDays: rowsToObjects(volume),
     versions: rowsToObjects(versions),
     t1ref: (rowsToObjects(ref)[0] || {}).t1,
+    onboardingDays: rowsToObjects(onboarding),
+    backendTranscriptionDays: groupByBackend(rowsToObjects(backendTranscription)),
+    onboardingVersions: rowsToObjects(onboardingVersions),
+    backendVersions: rowsToObjects(backendVersions),
   };
+}
+
+function groupByBackend(rows) {
+  const grouped = {};
+  for (const row of rows) {
+    const backend = row.backend || "unknown";
+    (grouped[backend] || (grouped[backend] = [])).push(row);
+  }
+  return grouped;
 }
 
 function rowsToObjects(res) {
@@ -249,6 +323,93 @@ export function evaluateVolume(days, expectedT1, TH = THRESHOLDS.volume) {
   };
 }
 
+// Reconstructs `count` TRUE calendar days ending at `expectedT1`, filling any
+// day with zero events (which emits no row at all — same gap evaluateVolume's
+// own t1ref lookup already works around) with an empty stub rather than
+// silently skipping it.
+function completeDayWindow(rows, expectedT1, count) {
+  const byDay = new Map(rows.map((row) => [String(row.day), row]));
+  const end = new Date(`${expectedT1}T00:00:00Z`);
+  return Array.from({ length: count }, (_, index) => {
+    const day = new Date(end);
+    day.setUTCDate(day.getUTCDate() - index);
+    const key = day.toISOString().slice(0, 10);
+    return byDay.get(key) || { day: key };
+  });
+}
+
+export function evaluateOnboardingAbandon(rows, expectedT1, TH = THRESHOLDS.onboardingAbandon) {
+  // rows: per-day {day, started, abandoned}, any order — mirrors evaluateLatency's `days` shape.
+  const totalStarted = rows.reduce((sum, row) => sum + num(row.started), 0);
+  const totalAbandoned = rows.reduce((sum, row) => sum + num(row.abandoned), 0);
+
+  // Fast path checked FIRST and independently — see canonical contract O1.
+  const fastRows = completeDayWindow(rows, expectedT1, TH.fastDays);
+  const fastCrossing = fastRows.every((row) => {
+    const started = num(row.started);
+    return started >= TH.fastMinStarted && num(row.abandoned) / started > TH.share;
+  });
+  if (fastCrossing) {
+    return { state: "alerting", rollingShare: totalStarted > 0 ? totalAbandoned / totalStarted : 0,
+      fastCrossing: true, totalStarted, totalAbandoned };
+  }
+
+  if (totalStarted < TH.minStarted) {
+    return { state: "skipped-low-volume", fastCrossing: false, totalStarted, totalAbandoned };
+  }
+  const rollingShare = totalAbandoned / totalStarted;
+  return { state: rollingShare > TH.share ? "alerting" : "evaluated-ok",
+    rollingShare, fastCrossing: false, totalStarted, totalAbandoned };
+}
+
+export function evaluateBackendTranscription(perBackendDays, expectedT1, TH = THRESHOLDS.backendTranscription) {
+  // perBackendDays: { [backend]: per-day {day, fails, dictations} rows } —
+  // backend enumeration: see canonical contract B2.
+  return Object.entries(perBackendDays).map(([backend, rows]) => {
+    const dictations = rows.reduce((sum, row) => sum + num(row.dictations), 0);
+    const fails = rows.reduce((sum, row) => sum + num(row.fails), 0);
+    const attempts = dictations + fails;
+
+    const fastRows = completeDayWindow(rows, expectedT1, TH.fastDays);
+    const fastCrossing = fastRows.every((row) => {
+      const dayDictations = num(row.dictations);
+      const dayFails = num(row.fails);
+      const dayAttempts = dayDictations + dayFails;
+      return dayAttempts >= TH.fastMinAttempts && dayFails / dayAttempts > TH.share;
+    });
+    const rollingShare = attempts > 0 ? fails / attempts : 0;
+    if (fastCrossing) {
+      return { backend, state: "alerting", rollingShare, fastCrossing: true, fails, dictations, attempts };
+    }
+
+    if (attempts < TH.minAttempts) {
+      return { backend, state: "skipped-low-volume", fastCrossing: false, fails, dictations, attempts };
+    }
+    return { backend, state: rollingShare > TH.share ? "alerting" : "evaluated-ok",
+      rollingShare, fastCrossing: false, fails, dictations, attempts };
+  }).sort((a, b) => a.backend.localeCompare(b.backend));
+}
+
+export function evaluateOnboardingBlackout(rows, expectedT1, TH = THRESHOLDS.onboardingBlackout) {
+  const recent = completeDayWindow(rows, expectedT1, TH.recentDays);
+  const baselineEnd = new Date(`${expectedT1}T00:00:00Z`);
+  baselineEnd.setUTCDate(baselineEnd.getUTCDate() - TH.recentDays);
+  const baseline = completeDayWindow(rows, baselineEnd.toISOString().slice(0, 10), TH.baselineDays);
+
+  const recentStarted = recent.reduce((sum, row) => sum + num(row.started), 0);
+  const recentTerminals = recent.reduce((sum, row) => sum + num(row.completed) + num(row.abandoned), 0);
+  const baselineAvg = baseline.reduce((sum, row) => sum + num(row.started), 0) / TH.baselineDays;
+
+  // (a) Entry point itself broke: zero starts against a real trailing baseline.
+  const entryPointDown = recentStarted === 0 && baselineAvg >= TH.activeBaselineAvg;
+  // (b) Terminal events stopped firing despite starts continuing (schema drift) —
+  // NOT "nobody abandoned" (a low/zero abandon count with healthy completions is GOOD).
+  const terminalDrift = recentStarted >= TH.terminalMinStarted && recentTerminals === 0;
+
+  return { state: entryPointDown || terminalDrift ? "alerting" : "evaluated-ok",
+    entryPointDown, terminalDrift, recentStarted, recentTerminals, baselineAvg };
+}
+
 function num(v) {
   const n = typeof v === "string" ? parseFloat(v) : v;
   return Number.isFinite(n) ? n : 0;
@@ -258,18 +419,19 @@ function pct(x) {
   return (x * 100).toFixed(1) + "%";
 }
 
-function topVersionsFor(versions, key) {
+function topVersionsFor(versions, key, { backend = null, limit = 3 } = {}) {
   return versions
-    .filter((v) => num(v[key]) > 0)
+    .filter((row) => backend == null || row.backend === backend)
+    .filter((row) => num(row[key]) > 0)
     .sort((a, b) => num(b[key]) - num(a[key]))
-    .slice(0, 3)
-    .map((v) => `${v.ver || "unknown"}: ${num(v[key])}`)
+    .slice(0, limit)
+    .map((row) => `${row.ver || "unknown"}: ${num(row[key])}`)
     .join(", ");
 }
 
 // ----- Message ------------------------------------------------------------
 
-export function buildMessage(r, versions = []) {
+export function buildMessage(r, versions = [], onboardingVersions = [], backendVersions = []) {
   const alerts = [];
   const evaluated = [];
   const skipped = [];
@@ -325,6 +487,60 @@ export function buildMessage(r, versions = []) {
   }
   note("transcription", r.transcription);
 
+  // Onboarding abandon (Phase 10, #1179)
+  if (r.onboardingAbandon) {
+    if (r.onboardingAbandon.state === "alerting") {
+      const tv = topVersionsFor(onboardingVersions, "onboarding_abandon");
+      const rate = pct(r.onboardingAbandon.rollingShare);
+      const via = r.onboardingAbandon.fastCrossing ? "fast 2-day crossing" : "rolling 21-day crossing";
+      alerts.push(
+        `onboarding abandon ${rate} (${r.onboardingAbandon.totalAbandoned}/${r.onboardingAbandon.totalStarted}, ` +
+        `prev 21d, via ${via}), threshold >${pct(THRESHOLDS.onboardingAbandon.share)}, baseline ~37%.` +
+        (tv ? ` Top versions ${tv}.` : "")
+      );
+    }
+    note("onboarding-abandon", r.onboardingAbandon);
+  }
+
+  // Per-backend transcription (Phase 10, #1179)
+  if (r.backendTranscription) {
+    for (const row of r.backendTranscription) {
+      if (row.state === "alerting") {
+        const tv = topVersionsFor(backendVersions, "backend_trans_fail", { backend: row.backend });
+        const rate = pct(row.rollingShare);
+        const via = row.fastCrossing ? "fast 2-day crossing" : "rolling 14-day crossing";
+        alerts.push(
+          `${row.backend} transcription failure ${rate} (${row.fails}/${row.attempts}, prev 14d, via ${via}), ` +
+          `threshold >${pct(THRESHOLDS.backendTranscription.share)}.` + (tv ? ` Top versions ${tv}.` : "")
+        );
+      }
+      note(`transcription-${row.backend}`, row);
+    }
+  }
+
+  // Onboarding blackout (Phase 10, #1179) — evaluated-ok/alerting only, no
+  // low-volume/dark states, so it participates in `note()`'s evaluated bucket
+  // like the rate metrics, but can never land in skipped/dark.
+  if (r.onboardingBlackout) {
+    if (r.onboardingBlackout.state === "alerting") {
+      if (r.onboardingBlackout.entryPointDown) {
+        alerts.push(
+          `onboarding entry point down: 0 starts over the trailing 48h while the 7-day ` +
+          `baseline average is ${r.onboardingBlackout.baselineAvg.toFixed(1)}/day ` +
+          `(possible onboarding-screen crash or telemetry blackout).`
+        );
+      }
+      if (r.onboardingBlackout.terminalDrift) {
+        alerts.push(
+          `onboarding terminal drift: ${r.onboardingBlackout.recentStarted} starts over the trailing 48h ` +
+          `but neither onboarding.completed nor onboarding.abandoned fired ` +
+          `(a terminal event may have stopped emitting).`
+        );
+      }
+    }
+    note("onboarding-blackout", r.onboardingBlackout);
+  }
+
   // Volume / integrity
   if (r.volume.state === "alerting") {
     if (r.volume.zeroAlert) {
@@ -354,7 +570,10 @@ export function buildMessage(r, versions = []) {
     (dark.length ? ` Dark: ${dark.join(", ")}.` : "") +
     (skipped.length ? ` Skipped (low volume): ${skipped.join(", ")}.` : "");
   const head = alerts.length ? "EnviousWispr health - ALERT" : "EnviousWispr health - OK";
-  const heartbeat = `${head}. T-1: ${t1d} dictations${ratioStr}. ${coverage}${driftStr}`;
+  // H1 (canonical contract H1): a static pointer, every run — this worker does
+  // NOT deliver crash-free-session-rate or per-version crash regression.
+  const h1Line = " Crash/error-rate monitoring lives in Sentry's own alert rules (see Error Spike >5/hr), not in this report.";
+  const heartbeat = `${head}. T-1: ${t1d} dictations${ratioStr}. ${coverage}${driftStr}${h1Line}`;
 
   let content = heartbeat;
   if (alerts.length) {
@@ -383,8 +602,11 @@ async function runHealth(env) {
     afm: evaluateAFM(data.seven),
     transcription: evaluateTranscription(data.seven),
     volume: evaluateVolume(data.volumeDays, data.t1ref),
+    onboardingAbandon: evaluateOnboardingAbandon(data.onboardingDays, data.t1ref),
+    backendTranscription: evaluateBackendTranscription(data.backendTranscriptionDays, data.t1ref),
+    onboardingBlackout: evaluateOnboardingBlackout(data.onboardingDays, data.t1ref),
   };
-  const message = buildMessage(results, data.versions);
+  const message = buildMessage(results, data.versions, data.onboardingVersions, data.backendVersions);
 
   const ok = await postToDiscord(env.DISCORD_WEBHOOK_URL, message);
   if (!ok) throw new Error("Discord post failed");

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -485,7 +485,12 @@ export function evaluateOnboardingBlackout(rows, expectedT1, TH = THRESHOLDS.onb
   const baseline = completeDayWindow(rows, baselineEnd.toISOString().slice(0, 10), TH.baselineDays);
 
   const recentStarted = recent.reduce((sum, row) => sum + num(row.started), 0);
-  const recentTerminals = recent.reduce((sum, row) => sum + num(row.completed) + num(row.abandoned), 0);
+  // Raw (unfiltered) abandon count (Codex r6 review finding): the
+  // welcome-screen-excluded `abandoned` field exists for the ABANDON-SHARE
+  // metric's denominator, not for "did any terminal event fire at all." Using
+  // it here means screen-attribution drift (abandoned reads 0 while
+  // abandonedRaw keeps firing) would falsely present as terminal drift too.
+  const recentTerminals = recent.reduce((sum, row) => sum + num(row.completed) + num(row.abandonedRaw), 0);
   const baselineAvg = baseline.reduce((sum, row) => sum + num(row.started), 0) / TH.baselineDays;
 
   // (a) Entry point itself broke: zero starts against a real trailing baseline.

--- a/workers/product-health/test/health.test.js
+++ b/workers/product-health/test/health.test.js
@@ -521,6 +521,14 @@ test("message: per-backend transcription alerts name the backend and skip clean 
   assert.match(msg, /Evaluated:.*transcription-parakeet/);
 });
 
+test("message: empty per-backend result during genuine low volume reports skipped, not silence (Codex r5 fix)", () => {
+  const msg = buildMessage(
+    results({ backendTranscription: [], backendAttributionBlackout: false })
+  );
+  assert.match(msg, /Skipped \(low volume\):.*transcription-backend/);
+  assert.ok(!msg.includes("attribution blackout"));
+});
+
 test("message: onboarding-blackout entry-point-down and terminal-drift render distinct wording", () => {
   const entryDown = buildMessage(
     results({ onboardingBlackout: { state: "alerting", entryPointDown: true, terminalDrift: false, recentStarted: 0, recentTerminals: 0, baselineAvg: 12 } })

--- a/workers/product-health/test/health.test.js
+++ b/workers/product-health/test/health.test.js
@@ -369,11 +369,21 @@ test("onboarding blackout (b): healthy sessions, zero abandons -> not flagged", 
 });
 
 test("onboarding blackout (b): terminal drift (starts continue, no terminal fires) -> flagged", () => {
-  const rows = [{ day: "2026-07-15", started: 10, completed: 0, abandoned: 0 }];
+  const rows = [{ day: "2026-07-15", started: 10, completed: 0, abandoned: 0, abandonedRaw: 0 }];
   const ev = evaluateOnboardingBlackout(rows, "2026-07-15");
   assert.equal(ev.state, "alerting");
   assert.equal(ev.terminalDrift, true);
   assert.equal(ev.entryPointDown, false);
+});
+
+test("onboarding blackout (b): screen-attribution drift does NOT falsely present as terminal drift (Codex r6 fix)", () => {
+  // Real abandon events fired (abandonedRaw) but properties.screen dropped,
+  // so the welcome-filtered `abandoned` reads 0 — a terminal event DID fire,
+  // this must not read as "terminal events stopped firing."
+  const rows = [{ day: "2026-07-15", started: 10, completed: 0, abandoned: 0, abandonedRaw: 8 }];
+  const ev = evaluateOnboardingBlackout(rows, "2026-07-15");
+  assert.equal(ev.terminalDrift, false);
+  assert.equal(ev.recentTerminals, 8);
 });
 
 test("onboarding blackout (b): insufficient recent activity -> not flagged", () => {

--- a/workers/product-health/test/health.test.js
+++ b/workers/product-health/test/health.test.js
@@ -300,6 +300,9 @@ test("onboarding abandon: fast regression only, healthy rolling average -> alert
   assert.equal(ev.state, "alerting");
   assert.equal(ev.fastCrossing, true);
   assert.ok(ev.rollingShare < THRESHOLDS.onboardingAbandon.share, "rolling share must stay healthy");
+  assert.equal(ev.fastStarted, 20);
+  assert.equal(ev.fastAbandoned, 12);
+  assert.equal(ev.fastShare, 0.6, "fast-window share must reflect only the crossing window, not the rolling total");
 });
 
 // ---- Phase 10 (#1179): onboarding blackout ----
@@ -403,6 +406,9 @@ test("backend transcription: fast-path regression, backend-scoped", () => {
   const [ev] = evaluateBackendTranscription(perBackendDays, "2026-07-15");
   assert.equal(ev.state, "alerting");
   assert.equal(ev.fastCrossing, true);
+  assert.equal(ev.fastAttempts, 50);
+  assert.equal(ev.fastFails, 30);
+  assert.equal(ev.fastShare, 0.6, "fast-window share must reflect only the crossing window, not the rolling total");
 });
 
 test("backend transcription: anti-masking, active backend with zero failures stays visible", () => {
@@ -423,10 +429,38 @@ test("message: H1 static pointer appears every run", () => {
 
 test("message: onboarding-abandon alert renders and is not double-counted as evaluated", () => {
   const msg = buildMessage(
-    results({ onboardingAbandon: { state: "alerting", rollingShare: 0.6, fastCrossing: true, totalStarted: 20, totalAbandoned: 12 } })
+    results({
+      onboardingAbandon: {
+        state: "alerting", fastCrossing: true, fastStarted: 10, fastAbandoned: 6, fastShare: 0.6,
+        rollingShare: 0.145, totalStarted: 220, totalAbandoned: 32,
+      },
+    })
   );
   assert.match(msg, /onboarding abandon 60\.0%/);
   assert.ok(!msg.includes("Evaluated: onboarding-abandon"));
+});
+
+test("message: onboarding-abandon fast crossing does not report the healthy rolling rate", () => {
+  const msg = buildMessage(
+    results({
+      onboardingAbandon: {
+        state: "alerting", fastCrossing: true, fastStarted: 10, fastAbandoned: 6, fastShare: 0.6,
+        rollingShare: 0.145, totalStarted: 220, totalAbandoned: 32,
+      },
+    })
+  );
+  assert.match(msg, /fast 2-day crossing/);
+  assert.ok(!msg.includes("14.5%"), "must not display the healthy rolling share when the fast path fired");
+});
+
+test("message: onboarding-abandon rolling crossing reports the rolling window", () => {
+  const msg = buildMessage(
+    results({
+      onboardingAbandon: { state: "alerting", fastCrossing: false, rollingShare: 0.6, totalStarted: 40, totalAbandoned: 24 },
+    })
+  );
+  assert.match(msg, /rolling crossing/);
+  assert.match(msg, /60\.0%/);
 });
 
 test("message: per-backend transcription alerts name the backend and skip clean backends", () => {
@@ -454,4 +488,26 @@ test("message: onboarding-blackout entry-point-down and terminal-drift render di
   );
   assert.match(terminalDrift, /onboarding terminal drift/);
   assert.ok(!terminalDrift.includes("entry point down"));
+});
+
+test("message: many simultaneous alerts drop whole alerts from the end, never the dashboard link", () => {
+  // Manufacture enough alerting metrics that the naive character slice would
+  // have cut mid-alert (Codex review finding) — assert the dashboard link and
+  // heartbeat always survive, and any drop is announced, never silent.
+  const longVersion = "v9.9.9-a-very-long-version-identifier-to-pad-the-message-length-out";
+  const backendTranscription = Array.from({ length: 20 }, (_, i) => ({
+    backend: `backend-${i}-${longVersion}`,
+    state: "alerting",
+    fastCrossing: false,
+    rollingShare: 0.5,
+    fails: 500,
+    dictations: 500,
+    attempts: 1000,
+  }));
+  const msg = buildMessage(results({ backendTranscription }));
+  assert.ok(msg.length <= 2000, `message must respect the Discord cap, got ${msg.length}`);
+  assert.match(msg, /https:\/\/us\.posthog\.com\/project\/\d+\/dashboard\/\d+/, "dashboard link must always survive truncation");
+  if (msg.includes("more alert(s) omitted")) {
+    assert.match(msg, /\d+ more alert\(s\) omitted; see dashboard/);
+  }
 });

--- a/workers/product-health/test/health.test.js
+++ b/workers/product-health/test/health.test.js
@@ -305,6 +305,20 @@ test("onboarding abandon: fast regression only, healthy rolling average -> alert
   assert.equal(ev.fastShare, 0.6, "fast-window share must reflect only the crossing window, not the rolling total");
 });
 
+test("onboarding abandon: screen-attribution drift (real raw volume, zero passes the filter) -> alert", () => {
+  const rows = [{ day: "2026-07-15", started: 100, abandoned: 0, abandonedRaw: 40 }];
+  const ev = evaluateOnboardingAbandon(rows, "2026-07-15");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.attributionDrift, true);
+  assert.equal(ev.totalAbandonedRaw, 40);
+});
+
+test("onboarding abandon: low but real raw abandon volume with zero filtered does NOT trip drift (below floor)", () => {
+  const rows = [{ day: "2026-07-15", started: 100, abandoned: 0, abandonedRaw: 5 }];
+  const ev = evaluateOnboardingAbandon(rows, "2026-07-15");
+  assert.notEqual(ev.attributionDrift, true);
+});
+
 // ---- Phase 10 (#1179): onboarding blackout ----
 function baselineDays(startedPerDay) {
   return ["2026-07-13", "2026-07-12", "2026-07-11", "2026-07-10", "2026-07-09", "2026-07-08", "2026-07-07"].map(
@@ -420,6 +434,19 @@ test("backend transcription: anti-masking, active backend with zero failures sta
   assert.equal(evs[0].fails, 0);
 });
 
+test("backend transcription: attribution drift, unknown backend with material volume -> alert", () => {
+  const perBackendDays = { unknown: [{ day: "2026-07-15", dictations: 250, fails: 20 }] };
+  const [ev] = evaluateBackendTranscription(perBackendDays, "2026-07-15");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.attributionDrift, true);
+});
+
+test("backend transcription: unknown backend with trivial volume does NOT trip drift (below minAttempts)", () => {
+  const perBackendDays = { unknown: [{ day: "2026-07-15", dictations: 5, fails: 0 }] };
+  const [ev] = evaluateBackendTranscription(perBackendDays, "2026-07-15");
+  assert.notEqual(ev.attributionDrift, true);
+});
+
 // ---- message: Phase 10 additions ----
 test("message: H1 static pointer appears every run", () => {
   const msg = buildMessage(results());
@@ -510,4 +537,50 @@ test("message: many simultaneous alerts drop whole alerts from the end, never th
   if (msg.includes("more alert(s) omitted")) {
     assert.match(msg, /\d+ more alert\(s\) omitted; see dashboard/);
   }
+});
+
+test("message: onboarding screen-attribution drift renders distinct wording, no version attribution", () => {
+  const msg = buildMessage(
+    results({
+      onboardingAbandon: { state: "alerting", attributionDrift: true, fastCrossing: false, totalStarted: 100, totalAbandoned: 0, totalAbandonedRaw: 40 },
+    }),
+    [], [{ ver: "v2.1.4", onboarding_abandon: 40 }]
+  );
+  assert.match(msg, /onboarding abandon attribution lost/);
+  assert.ok(!msg.includes("v2.1.4"), "attribution-drift alert must not attach version data to a broken denominator");
+});
+
+test("message: backend attribution drift (unknown backend) renders distinct wording", () => {
+  const msg = buildMessage(
+    results({
+      backendTranscription: [
+        { backend: "unknown", state: "alerting", attributionDrift: true, fastCrossing: false, fails: 20, dictations: 250, attempts: 270 },
+      ],
+    })
+  );
+  assert.match(msg, /transcription backend attribution lost/);
+});
+
+test("message: backend attribution blackout (empty result set) renders and alerts", () => {
+  const msg = buildMessage(results({ backendTranscription: [], backendAttributionBlackout: true }));
+  assert.match(msg, /transcription backend attribution blackout/);
+  assert.match(msg, /health - ALERT/);
+});
+
+test("message: fast-crossing alerts omit version attribution (window mismatch, Codex review finding)", () => {
+  const onboardingMsg = buildMessage(
+    results({ onboardingAbandon: { state: "alerting", fastCrossing: true, fastStarted: 10, fastAbandoned: 6, fastShare: 0.6, rollingShare: 0.1, totalStarted: 300, totalAbandoned: 30 } }),
+    [], [{ ver: "v2.1.4", onboarding_abandon: 40 }]
+  );
+  assert.ok(!onboardingMsg.includes("v2.1.4"), "a fast (2-day) crossing must not attribute to a 21-day version query");
+
+  const backendMsg = buildMessage(
+    results({
+      backendTranscription: [
+        { backend: "parakeet", state: "alerting", fastCrossing: true, fastFails: 20, fastDictations: 10, fastAttempts: 30, fastShare: 0.67, rollingShare: 0.05, fails: 50, dictations: 950, attempts: 1000 },
+      ],
+    }),
+    [], [], [{ ver: "v2.1.4", backend: "parakeet", backend_trans_fail: 40 }]
+  );
+  assert.ok(!backendMsg.includes("v2.1.4"), "a fast (2-day) crossing must not attribute to a 14-day version query");
 });

--- a/workers/product-health/test/health.test.js
+++ b/workers/product-health/test/health.test.js
@@ -305,18 +305,35 @@ test("onboarding abandon: fast regression only, healthy rolling average -> alert
   assert.equal(ev.fastShare, 0.6, "fast-window share must reflect only the crossing window, not the rolling total");
 });
 
-test("onboarding abandon: screen-attribution drift (real raw volume, zero passes the filter) -> alert", () => {
-  const rows = [{ day: "2026-07-15", started: 100, abandoned: 0, abandonedRaw: 40 }];
+test("onboarding abandon: screen-attribution drift (missing-screen volume crosses floor) -> alert", () => {
+  const rows = [
+    { day: "2026-07-15", started: 100, abandoned: 0, abandonedRaw: 40, abandonedMissingScreen: 40 },
+  ];
   const ev = evaluateOnboardingAbandon(rows, "2026-07-15");
   assert.equal(ev.state, "alerting");
   assert.equal(ev.attributionDrift, true);
   assert.equal(ev.totalAbandonedRaw, 40);
+  assert.equal(ev.totalAbandonedMissingScreen, 40);
 });
 
-test("onboarding abandon: low but real raw abandon volume with zero filtered does NOT trip drift (below floor)", () => {
-  const rows = [{ day: "2026-07-15", started: 100, abandoned: 0, abandonedRaw: 5 }];
+test("onboarding abandon: low but real missing-screen volume does NOT trip drift (below floor)", () => {
+  const rows = [
+    { day: "2026-07-15", started: 100, abandoned: 0, abandonedRaw: 5, abandonedMissingScreen: 5 },
+  ];
   const ev = evaluateOnboardingAbandon(rows, "2026-07-15");
   assert.notEqual(ev.attributionDrift, true);
+});
+
+test("onboarding abandon: legitimate all-welcome concentration does NOT trip drift (Codex r4 false-positive fix)", () => {
+  // Real raw volume, zero passes the "not welcome" filter, but every one of
+  // those events genuinely carries screen = 'welcome' (abandonedMissingScreen
+  // stays 0) — healthy, correctly-tagged data, not schema drift.
+  const rows = [
+    { day: "2026-07-15", started: 100, abandoned: 0, abandonedRaw: 40, abandonedMissingScreen: 0 },
+  ];
+  const ev = evaluateOnboardingAbandon(rows, "2026-07-15");
+  assert.notEqual(ev.attributionDrift, true);
+  assert.equal(ev.state, "evaluated-ok");
 });
 
 // ---- Phase 10 (#1179): onboarding blackout ----
@@ -542,11 +559,12 @@ test("message: many simultaneous alerts drop whole alerts from the end, never th
 test("message: onboarding screen-attribution drift renders distinct wording, no version attribution", () => {
   const msg = buildMessage(
     results({
-      onboardingAbandon: { state: "alerting", attributionDrift: true, fastCrossing: false, totalStarted: 100, totalAbandoned: 0, totalAbandonedRaw: 40 },
+      onboardingAbandon: { state: "alerting", attributionDrift: true, fastCrossing: false, totalStarted: 100, totalAbandoned: 0, totalAbandonedRaw: 40, totalAbandonedMissingScreen: 40 },
     }),
     [], [{ ver: "v2.1.4", onboarding_abandon: 40 }]
   );
   assert.match(msg, /onboarding abandon attribution lost/);
+  assert.match(msg, /40 of 40 onboarding\.abandoned events/);
   assert.ok(!msg.includes("v2.1.4"), "attribution-drift alert must not attach version data to a broken denominator");
 });
 

--- a/workers/product-health/test/health.test.js
+++ b/workers/product-health/test/health.test.js
@@ -9,6 +9,9 @@ import {
   evaluateAFM,
   evaluateTranscription,
   evaluateVolume,
+  evaluateOnboardingAbandon,
+  evaluateBackendTranscription,
+  evaluateOnboardingBlackout,
   buildMessage,
 } from "../src/index.js";
 
@@ -260,4 +263,195 @@ test("message: stays within Discord 2000-char cap", () => {
     })
   );
   assert.ok(msg.length <= 2000);
+});
+
+// ---- Phase 10 (#1179): onboarding abandon ----
+test("onboarding abandon: low volume -> skipped", () => {
+  const rows = [{ day: "2026-07-14", started: 10, abandoned: 2 }];
+  assert.equal(evaluateOnboardingAbandon(rows, "2026-07-15").state, "skipped-low-volume");
+});
+
+test("onboarding abandon: normal -> ok", () => {
+  const rows = [
+    { day: "2026-07-15", started: 50, abandoned: 15 },
+    { day: "2026-07-14", started: 50, abandoned: 15 },
+  ];
+  assert.equal(evaluateOnboardingAbandon(rows, "2026-07-15").state, "evaluated-ok");
+});
+
+test("onboarding abandon: rolling regression only (recent 2 days healthy, older days bad) -> alert", () => {
+  const rows = [
+    { day: "2026-07-15", started: 5, abandoned: 4 },
+    { day: "2026-07-14", started: 5, abandoned: 4 },
+    { day: "2026-07-01", started: 30, abandoned: 17 },
+  ];
+  const ev = evaluateOnboardingAbandon(rows, "2026-07-15");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.fastCrossing, false);
+});
+
+test("onboarding abandon: fast regression only, healthy rolling average -> alert via fastCrossing", () => {
+  const rows = [
+    { day: "2026-07-15", started: 10, abandoned: 6 },
+    { day: "2026-07-14", started: 10, abandoned: 6 },
+    { day: "2026-07-01", started: 200, abandoned: 20 },
+  ];
+  const ev = evaluateOnboardingAbandon(rows, "2026-07-15");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.fastCrossing, true);
+  assert.ok(ev.rollingShare < THRESHOLDS.onboardingAbandon.share, "rolling share must stay healthy");
+});
+
+// ---- Phase 10 (#1179): onboarding blackout ----
+function baselineDays(startedPerDay) {
+  return ["2026-07-13", "2026-07-12", "2026-07-11", "2026-07-10", "2026-07-09", "2026-07-08", "2026-07-07"].map(
+    (day) => ({ day, started: startedPerDay, completed: Math.max(0, startedPerDay - 2), abandoned: 1 })
+  );
+}
+
+test("onboarding blackout (a): entry point down (active baseline) -> flagged", () => {
+  const rows = baselineDays(10); // avg 10 >= activeBaselineAvg(8), T-1/T-2 absent -> recentStarted 0
+  const ev = evaluateOnboardingBlackout(rows, "2026-07-15");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.entryPointDown, true);
+  assert.equal(ev.terminalDrift, false);
+});
+
+test("onboarding blackout (a): inactive baseline -> not flagged", () => {
+  const rows = baselineDays(5); // avg 5 < activeBaselineAvg(8)
+  const ev = evaluateOnboardingBlackout(rows, "2026-07-15");
+  assert.equal(ev.state, "evaluated-ok");
+  assert.equal(ev.entryPointDown, false);
+});
+
+test("onboarding blackout (b): healthy sessions, zero abandons -> not flagged", () => {
+  const rows = [
+    { day: "2026-07-15", started: 10, completed: 10, abandoned: 0 },
+    { day: "2026-07-14", started: 10, completed: 10, abandoned: 0 },
+  ];
+  const ev = evaluateOnboardingBlackout(rows, "2026-07-15");
+  assert.equal(ev.state, "evaluated-ok");
+  assert.equal(ev.terminalDrift, false);
+});
+
+test("onboarding blackout (b): terminal drift (starts continue, no terminal fires) -> flagged", () => {
+  const rows = [{ day: "2026-07-15", started: 10, completed: 0, abandoned: 0 }];
+  const ev = evaluateOnboardingBlackout(rows, "2026-07-15");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.terminalDrift, true);
+  assert.equal(ev.entryPointDown, false);
+});
+
+test("onboarding blackout (b): insufficient recent activity -> not flagged", () => {
+  const rows = [{ day: "2026-07-15", started: 5, completed: 0, abandoned: 0 }];
+  const ev = evaluateOnboardingBlackout(rows, "2026-07-15");
+  assert.equal(ev.state, "evaluated-ok");
+  assert.equal(ev.terminalDrift, false);
+});
+
+// ---- Phase 10 (#1179): per-backend transcription ----
+test("backend transcription: Parakeet low volume -> skipped", () => {
+  const perBackendDays = { parakeet: [{ day: "2026-07-15", dictations: 50, fails: 5 }] };
+  const [ev] = evaluateBackendTranscription(perBackendDays, "2026-07-15");
+  assert.equal(ev.backend, "parakeet");
+  assert.equal(ev.state, "skipped-low-volume");
+});
+
+test("backend transcription: catastrophic all-failure fast window -> alert, not suppressed as low volume", () => {
+  const perBackendDays = {
+    parakeet: [
+      { day: "2026-07-15", dictations: 0, fails: 25 },
+      { day: "2026-07-14", dictations: 0, fails: 25 },
+    ],
+  };
+  const [ev] = evaluateBackendTranscription(perBackendDays, "2026-07-15");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.fastCrossing, true);
+});
+
+test("backend transcription: WhisperKit at its real-world volume -> correctly evaluated, not skipped", () => {
+  const perBackendDays = {
+    whisperkit: [
+      { day: "2026-07-15", dictations: 35, fails: 2 },
+      { day: "2026-07-14", dictations: 35, fails: 2 },
+      { day: "2026-06-20", dictations: 400, fails: 20 },
+    ],
+  };
+  const [ev] = evaluateBackendTranscription(perBackendDays, "2026-07-15");
+  assert.equal(ev.state, "evaluated-ok");
+});
+
+test("backend transcription: one backend regresses, the other doesn't", () => {
+  const perBackendDays = {
+    parakeet: [{ day: "2026-07-15", dictations: 300, fails: 5 }],
+    whisperkit: [{ day: "2026-07-15", dictations: 250, fails: 150 }],
+  };
+  const evs = evaluateBackendTranscription(perBackendDays, "2026-07-15");
+  const parakeet = evs.find((e) => e.backend === "parakeet");
+  const whisperkit = evs.find((e) => e.backend === "whisperkit");
+  assert.equal(parakeet.state, "evaluated-ok");
+  assert.equal(whisperkit.state, "alerting");
+});
+
+test("backend transcription: fast-path regression, backend-scoped", () => {
+  const perBackendDays = {
+    parakeet: [
+      { day: "2026-07-15", dictations: 10, fails: 15 },
+      { day: "2026-07-14", dictations: 10, fails: 15 },
+    ],
+  };
+  const [ev] = evaluateBackendTranscription(perBackendDays, "2026-07-15");
+  assert.equal(ev.state, "alerting");
+  assert.equal(ev.fastCrossing, true);
+});
+
+test("backend transcription: anti-masking, active backend with zero failures stays visible", () => {
+  const perBackendDays = { onlybackend: [{ day: "2026-07-15", dictations: 250, fails: 0 }] };
+  const evs = evaluateBackendTranscription(perBackendDays, "2026-07-15");
+  assert.equal(evs.length, 1);
+  assert.equal(evs[0].backend, "onlybackend");
+  assert.equal(evs[0].state, "evaluated-ok");
+  assert.equal(evs[0].fails, 0);
+});
+
+// ---- message: Phase 10 additions ----
+test("message: H1 static pointer appears every run", () => {
+  const msg = buildMessage(results());
+  assert.match(msg, /Sentry's own alert rules/);
+  assert.match(msg, /Error Spike >5\/hr/);
+});
+
+test("message: onboarding-abandon alert renders and is not double-counted as evaluated", () => {
+  const msg = buildMessage(
+    results({ onboardingAbandon: { state: "alerting", rollingShare: 0.6, fastCrossing: true, totalStarted: 20, totalAbandoned: 12 } })
+  );
+  assert.match(msg, /onboarding abandon 60\.0%/);
+  assert.ok(!msg.includes("Evaluated: onboarding-abandon"));
+});
+
+test("message: per-backend transcription alerts name the backend and skip clean backends", () => {
+  const msg = buildMessage(
+    results({
+      backendTranscription: [
+        { backend: "parakeet", state: "evaluated-ok", rollingShare: 0.02, fastCrossing: false, fails: 5, dictations: 300, attempts: 305 },
+        { backend: "whisperkit", state: "alerting", rollingShare: 0.3, fastCrossing: false, fails: 60, dictations: 140, attempts: 200 },
+      ],
+    })
+  );
+  assert.match(msg, /whisperkit transcription failure 30\.0%/);
+  assert.ok(!msg.includes("parakeet transcription failure"));
+  assert.match(msg, /Evaluated:.*transcription-parakeet/);
+});
+
+test("message: onboarding-blackout entry-point-down and terminal-drift render distinct wording", () => {
+  const entryDown = buildMessage(
+    results({ onboardingBlackout: { state: "alerting", entryPointDown: true, terminalDrift: false, recentStarted: 0, recentTerminals: 0, baselineAvg: 12 } })
+  );
+  assert.match(entryDown, /onboarding entry point down/);
+
+  const terminalDrift = buildMessage(
+    results({ onboardingBlackout: { state: "alerting", entryPointDown: false, terminalDrift: true, recentStarted: 10, recentTerminals: 0, baselineAvg: 12 } })
+  );
+  assert.match(terminalDrift, /onboarding terminal drift/);
+  assert.ok(!terminalDrift.includes("entry point down"));
 });


### PR DESCRIPTION
## Summary

Phase 10 of #1179: extends the daily product-health Discord heartbeat with three new checks, all following the worker's existing pattern (pure evaluator functions + unit tests + message builder), no new app-side telemetry.

- **Onboarding abandonment** — alerts when users are quitting the setup flow at a meaningfully higher rate than normal, both a slow-creeping regression and a sudden 2-day spike.
- **Per-backend transcription health** — same failure-rate alerting the worker already does in aggregate, now broken out per speech-recognition backend, so one backend quietly failing can't hide behind the other's healthy numbers.
- **Onboarding blackout / attribution-drift detectors** — catches the alert system silently going blind (the tracking data it depends on stops flowing correctly) rather than misreporting a real problem as "all clear."

## Review history

7 rounds of Codex code-diff review; last 3 rounds each found and fixed a genuine edge case in the new drift-detection logic (a legitimate concentration of exits at the very first screen being misread as broken tracking; an empty result silently vanishing from the health report instead of reporting as skipped; the blackout check using the wrong underlying count). Round 7 came back clean. 61 unit tests passing.

## Test plan

- [x] `node --test test/health.test.js` — 61/61 passing
- [x] Codex code-diff review — clean (r7)
- [ ] Live PostHog smoke test (`live-query-smoke.mjs`) — blocked, needs a re-authenticated key fetch
- [ ] Production deploy (`wrangler deploy`) — blocked, Cloudflare login expired

Both blockers need a quick interactive re-login on this machine; not something I can do from here. Ready to run both the moment that's done.
