### PR TITLE
feat(settings): warn proactively when a cloud provider has no working key (#1455)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -151,17 +151,23 @@ struct AIPolishSettingsView: View {
   @State private var geminiKey: String = ""
   @State private var validationStatus: String = ""
   /// #1455: whether a NON-EMPTY key is currently persisted in Keychain, for
-  /// the missing-key notice. Deliberately a cached flag updated only at the 3
-  /// real mutation points (onAppear load, successful save, successful clear)
-  /// rather than a live Keychain re-read inside the view body (Codex r4
-  /// finding: `retrieve()` does side-effecting legacy-key migration + file
-  /// I/O + telemetry, so calling it on every render, including every typed
+  /// the missing-key notice. Cached, updated only at the 3 real mutation
+  /// points (onAppear load, successful save, successful clear) rather than a
+  /// live Keychain re-read inside the view body (Codex r4 finding:
+  /// `retrieve()` does side-effecting legacy-key migration + file I/O +
+  /// telemetry, so calling it on every render, including every typed
   /// character, would re-run that work needlessly and could re-report a
-  /// failed legacy cleanup repeatedly). Defaults false only until `onAppear`
-  /// resolves, matching the existing `openAIKey`/`geminiKey` fields' own
-  /// fail-to-empty convention on the same read.
-  @State private var openAIKeySaved = false
-  @State private var geminiKeySaved = false
+  /// failed legacy cleanup repeatedly).
+  ///
+  /// THREE states, not two (Codex r5 finding): `nil` = not yet determined or
+  /// the read failed for ANY reason (locked Keychain, I/O error, the legacy-
+  /// migration fallback inside `retrieve()` failing its own separate way —
+  /// deliberately not narrowed to one specific thrown case, since a failure
+  /// anywhere in that path should read as "unknown," never as "confirmed
+  /// absent"). Only an explicit `false` (a successful read that came back
+  /// empty) is allowed to show the notice; `nil` and `true` both suppress it.
+  @State private var openAIKeySaved: Bool?
+  @State private var geminiKeySaved: Bool?
 
   private var isCloudProvider: Bool {
     settings.llmProvider == .openAI || settings.llmProvider == .gemini
@@ -324,7 +330,11 @@ struct AIPolishSettingsView: View {
       // Keychain would also read as a false "definitely no key" rather than
       // "couldn't check." `openAIKeySaved`/`geminiKeySaved` cache a CONFIRMED
       // read, updated only at the 3 real mutation points.
-      let savedKeyIsEmpty = settings.llmProvider == .openAI ? !openAIKeySaved : !geminiKeySaved
+      // Explicit `== false` (not `!x`): `nil` (unknown) and `true` (confirmed
+      // present) must both suppress the notice, only a confirmed-empty read
+      // shows it.
+      let savedKeyIsEmpty =
+        (settings.llmProvider == .openAI ? openAIKeySaved : geminiKeySaved) == false
       if savedKeyIsEmpty {
         InsetNotice(
           text:
@@ -457,12 +467,24 @@ struct AIPolishSettingsView: View {
       }
     }
     .onAppear {
-      let storedOpenAIKey = try? keychainManager.retrieve(key: KeychainManager.openAIKeyID)
-      openAIKey = storedOpenAIKey ?? ""
-      openAIKeySaved = !(storedOpenAIKey ?? "").isEmpty
-      let storedGeminiKey = try? keychainManager.retrieve(key: KeychainManager.geminiKeyID)
-      geminiKey = storedGeminiKey ?? ""
-      geminiKeySaved = !(storedGeminiKey ?? "").isEmpty
+      // A thrown read leaves `openAIKey`/`geminiKey` at their existing
+      // fail-to-empty convention (unchanged from before #1455), but
+      // deliberately does NOT touch `openAIKeySaved`/`geminiKeySaved` — a
+      // failed read is "unknown," not "confirmed absent" (Codex r5 finding).
+      do {
+        let stored = try keychainManager.retrieve(key: KeychainManager.openAIKeyID)
+        openAIKey = stored
+        openAIKeySaved = !stored.isEmpty
+      } catch {
+        openAIKey = ""
+      }
+      do {
+        let stored = try keychainManager.retrieve(key: KeychainManager.geminiKeyID)
+        geminiKey = stored
+        geminiKeySaved = !stored.isEmpty
+      } catch {
+        geminiKey = ""
+      }
       if settings.llmProvider == .ollama {
         llmDiscovery.loadCachedModels(for: .ollama)
         Task {

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -295,20 +295,25 @@ struct AIPolishSettingsView: View {
   private var providerSubConfig: some View {
     if isCloudProvider {
       // #1455: proactive nudge, not reactive, scoped narrowly to the one
-      // unambiguous case: the field is genuinely empty, nothing saved, nothing
-      // typed. Deliberately NOT keyed off `currentProviderStatus.tone` (Codex
-      // r1 + r2 findings): `.needsSetup` also covers mid-validation and
-      // `.error` also covers a transient network/provider failure while
-      // checking a perfectly good saved key — this banner's flat "without a
-      // key" wording would be false in both. Reading the live field text
-      // directly sidesteps every validation-state edge case: Save is disabled
-      // while the field is empty (see Save button below), so a non-empty
-      // field always means the user has typed or already has something saved,
-      // and the banner steps aside the instant that happens, valid or not
-      // (an invalid key still gets its own specific message from
-      // `validationBadge` right below).
-      let keyIsEmpty = settings.llmProvider == .openAI ? openAIKey.isEmpty : geminiKey.isEmpty
-      if keyIsEmpty {
+      // unambiguous case: nothing is actually SAVED yet. Deliberately NOT
+      // keyed off `currentProviderStatus.tone` (Codex r1 + r2 findings):
+      // `.needsSetup` also covers mid-validation and `.error` also covers a
+      // transient network/provider failure while checking a perfectly good
+      // saved key — this banner's flat "without a key" wording would be false
+      // in both. Also deliberately NOT keyed off the live `openAIKey`/
+      // `geminiKey` text (Codex r3 finding): those track what's TYPED, not
+      // what's PERSISTED, and polish reads only from Keychain — a user who
+      // types but never clicks Save, or whose save fails, would wrongly lose
+      // the warning before cleanup is actually usable. Re-reading Keychain
+      // directly (the same call `.onAppear` already makes) is the one signal
+      // that can't drift from what polish will actually use; this re-evaluates
+      // on every body re-render, including the one `saveKey`/`clearKey`
+      // trigger via their own `validationStatus` state change.
+      let savedKeyIsEmpty =
+        (try? keychainManager.retrieve(
+          key: settings.llmProvider == .openAI
+            ? KeychainManager.openAIKeyID : KeychainManager.geminiKeyID))?.isEmpty ?? true
+      if savedKeyIsEmpty {
         InsetNotice(
           text:
             "Dictation still works, but without a key, cleanup falls back to your raw, unedited text every time.",

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -468,13 +468,22 @@ struct AIPolishSettingsView: View {
     }
     .onAppear {
       // A thrown read leaves `openAIKey`/`geminiKey` at their existing
-      // fail-to-empty convention (unchanged from before #1455), but
-      // deliberately does NOT touch `openAIKeySaved`/`geminiKeySaved` — a
-      // failed read is "unknown," not "confirmed absent" (Codex r5 finding).
+      // fail-to-empty convention (unchanged from before #1455).
+      // `errSecItemNotFound` is `KeyStoreError`'s deliberate shared vocabulary
+      // for genuine absence across BOTH the Keychain and legacy-file paths
+      // (`FileLegacyKeyStore.retrieve`'s own comment: "callers can tell
+      // 'never saved a key' apart from 'saved a key we then failed to
+      // read'") — confirmed by reading both call sites, not assumed (Codex r6
+      // finding: r5's blanket catch left this case `nil` too, hiding the
+      // warning for exactly the fresh-install, never-entered-a-key user this
+      // feature exists for). Every OTHER thrown error stays `nil` (unknown).
       do {
         let stored = try keychainManager.retrieve(key: KeychainManager.openAIKeyID)
         openAIKey = stored
         openAIKeySaved = !stored.isEmpty
+      } catch KeyStoreError.retrieveFailed(let status) where status == errSecItemNotFound {
+        openAIKey = ""
+        openAIKeySaved = false
       } catch {
         openAIKey = ""
       }
@@ -482,6 +491,9 @@ struct AIPolishSettingsView: View {
         let stored = try keychainManager.retrieve(key: KeychainManager.geminiKeyID)
         geminiKey = stored
         geminiKeySaved = !stored.isEmpty
+      } catch KeyStoreError.retrieveFailed(let status) where status == errSecItemNotFound {
+        geminiKey = ""
+        geminiKeySaved = false
       } catch {
         geminiKey = ""
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -294,18 +294,21 @@ struct AIPolishSettingsView: View {
   @ViewBuilder
   private var providerSubConfig: some View {
     if isCloudProvider {
-      // #1455: proactive nudge, not reactive. Reuses the SAME status this
-      // engine's header chip already reads (`currentProviderStatus`, driven by
-      // `llmDiscovery.keyValidationState` + whether a key is present) — so it
-      // disappears the instant a key validates, with no separate state to keep
-      // in sync. Deliberately `.needsSetup`/`.error` only, NOT `.ready` negated
-      // (Codex r1 finding): a saved-but-not-yet-rechecked key on Settings open
-      // is `.idle` + keyPresent, which the SAME mapping reads as `.unavailable`
-      // ("Not checked"), not `.ready` — `!= .ready` would wrongly warn every
-      // returning user with a perfectly good key. `.needsSetup` covers both
-      // genuine absence (`.idle` + no key) and mid-validation; `.error` covers
-      // a confirmed-bad key — both cases genuinely fall back to raw text.
-      if currentProviderStatus.tone == .needsSetup || currentProviderStatus.tone == .error {
+      // #1455: proactive nudge, not reactive, scoped narrowly to the one
+      // unambiguous case: the field is genuinely empty, nothing saved, nothing
+      // typed. Deliberately NOT keyed off `currentProviderStatus.tone` (Codex
+      // r1 + r2 findings): `.needsSetup` also covers mid-validation and
+      // `.error` also covers a transient network/provider failure while
+      // checking a perfectly good saved key — this banner's flat "without a
+      // key" wording would be false in both. Reading the live field text
+      // directly sidesteps every validation-state edge case: Save is disabled
+      // while the field is empty (see Save button below), so a non-empty
+      // field always means the user has typed or already has something saved,
+      // and the banner steps aside the instant that happens, valid or not
+      // (an invalid key still gets its own specific message from
+      // `validationBadge` right below).
+      let keyIsEmpty = settings.llmProvider == .openAI ? openAIKey.isEmpty : geminiKey.isEmpty
+      if keyIsEmpty {
         InsetNotice(
           text:
             "Dictation still works, but without a key, cleanup falls back to your raw, unedited text every time.",

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -150,6 +150,18 @@ struct AIPolishSettingsView: View {
   @State private var openAIKey: String = ""
   @State private var geminiKey: String = ""
   @State private var validationStatus: String = ""
+  /// #1455: whether a NON-EMPTY key is currently persisted in Keychain, for
+  /// the missing-key notice. Deliberately a cached flag updated only at the 3
+  /// real mutation points (onAppear load, successful save, successful clear)
+  /// rather than a live Keychain re-read inside the view body (Codex r4
+  /// finding: `retrieve()` does side-effecting legacy-key migration + file
+  /// I/O + telemetry, so calling it on every render, including every typed
+  /// character, would re-run that work needlessly and could re-report a
+  /// failed legacy cleanup repeatedly). Defaults false only until `onAppear`
+  /// resolves, matching the existing `openAIKey`/`geminiKey` fields' own
+  /// fail-to-empty convention on the same read.
+  @State private var openAIKeySaved = false
+  @State private var geminiKeySaved = false
 
   private var isCloudProvider: Bool {
     settings.llmProvider == .openAI || settings.llmProvider == .gemini
@@ -304,15 +316,15 @@ struct AIPolishSettingsView: View {
       // `geminiKey` text (Codex r3 finding): those track what's TYPED, not
       // what's PERSISTED, and polish reads only from Keychain — a user who
       // types but never clicks Save, or whose save fails, would wrongly lose
-      // the warning before cleanup is actually usable. Re-reading Keychain
-      // directly (the same call `.onAppear` already makes) is the one signal
-      // that can't drift from what polish will actually use; this re-evaluates
-      // on every body re-render, including the one `saveKey`/`clearKey`
-      // trigger via their own `validationStatus` state change.
-      let savedKeyIsEmpty =
-        (try? keychainManager.retrieve(
-          key: settings.llmProvider == .openAI
-            ? KeychainManager.openAIKeyID : KeychainManager.geminiKeyID))?.isEmpty ?? true
+      // the warning before cleanup is actually usable. Also deliberately NOT a
+      // live Keychain re-read inside the body (Codex r4 finding): `retrieve()`
+      // does side-effecting legacy-key migration + file I/O + telemetry, so
+      // running it on every render (every keystroke) redoes that work and can
+      // re-report a failed legacy cleanup repeatedly; a locked/unavailable
+      // Keychain would also read as a false "definitely no key" rather than
+      // "couldn't check." `openAIKeySaved`/`geminiKeySaved` cache a CONFIRMED
+      // read, updated only at the 3 real mutation points.
+      let savedKeyIsEmpty = settings.llmProvider == .openAI ? !openAIKeySaved : !geminiKeySaved
       if savedKeyIsEmpty {
         InsetNotice(
           text:
@@ -445,8 +457,12 @@ struct AIPolishSettingsView: View {
       }
     }
     .onAppear {
-      openAIKey = (try? keychainManager.retrieve(key: KeychainManager.openAIKeyID)) ?? ""
-      geminiKey = (try? keychainManager.retrieve(key: KeychainManager.geminiKeyID)) ?? ""
+      let storedOpenAIKey = try? keychainManager.retrieve(key: KeychainManager.openAIKeyID)
+      openAIKey = storedOpenAIKey ?? ""
+      openAIKeySaved = !(storedOpenAIKey ?? "").isEmpty
+      let storedGeminiKey = try? keychainManager.retrieve(key: KeychainManager.geminiKeyID)
+      geminiKey = storedGeminiKey ?? ""
+      geminiKeySaved = !(storedGeminiKey ?? "").isEmpty
       if settings.llmProvider == .ollama {
         llmDiscovery.loadCachedModels(for: .ollama)
         Task {
@@ -558,12 +574,14 @@ struct AIPolishSettingsView: View {
         Button("Save") {
           if isOpenAI {
             guard saveKey(key: openAIKey, keychainId: KeychainManager.openAIKeyID) else { return }
+            openAIKeySaved = !openAIKey.isEmpty
             Task {
               await llmDiscovery.validateKeyAndDiscoverModels(
                 provider: .openAI, settings: settings, source: .save)
             }
           } else {
             guard saveKey(key: geminiKey, keychainId: KeychainManager.geminiKeyID) else { return }
+            geminiKeySaved = !geminiKey.isEmpty
             Task {
               await llmDiscovery.validateKeyAndDiscoverModels(
                 provider: .gemini, settings: settings, source: .save)
@@ -578,9 +596,11 @@ struct AIPolishSettingsView: View {
           if isOpenAI {
             guard clearKey(keychainId: KeychainManager.openAIKeyID) else { return }
             openAIKey = ""
+            openAIKeySaved = false
           } else {
             guard clearKey(keychainId: KeychainManager.geminiKeyID) else { return }
             geminiKey = ""
+            geminiKeySaved = false
           }
           llmDiscovery.reset()
         }

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -294,6 +294,21 @@ struct AIPolishSettingsView: View {
   @ViewBuilder
   private var providerSubConfig: some View {
     if isCloudProvider {
+      // #1455: proactive nudge, not reactive. Reuses the SAME status this
+      // engine's header chip already reads (`currentProviderStatus`, driven by
+      // `llmDiscovery.keyValidationState` + whether a key is present) — so it
+      // disappears the instant a key validates, with no separate state to keep
+      // in sync. Shown for every non-ready reason (no key / invalid / mid-
+      // validation), not just "no key at all": an invalid key also falls back
+      // to raw text and deserves the same explanation.
+      if currentProviderStatus.tone != .ready {
+        InsetNotice(
+          text:
+            "Dictation still works, but without a key, cleanup falls back to your raw, unedited text every time.",
+          systemImage: "exclamationmark.triangle",
+          tint: .stWarning
+        )
+      }
       apiKeyRow
       if settings.llmProvider == .openAI {
         Link(

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -298,10 +298,14 @@ struct AIPolishSettingsView: View {
       // engine's header chip already reads (`currentProviderStatus`, driven by
       // `llmDiscovery.keyValidationState` + whether a key is present) — so it
       // disappears the instant a key validates, with no separate state to keep
-      // in sync. Shown for every non-ready reason (no key / invalid / mid-
-      // validation), not just "no key at all": an invalid key also falls back
-      // to raw text and deserves the same explanation.
-      if currentProviderStatus.tone != .ready {
+      // in sync. Deliberately `.needsSetup`/`.error` only, NOT `.ready` negated
+      // (Codex r1 finding): a saved-but-not-yet-rechecked key on Settings open
+      // is `.idle` + keyPresent, which the SAME mapping reads as `.unavailable`
+      // ("Not checked"), not `.ready` — `!= .ready` would wrongly warn every
+      // returning user with a perfectly good key. `.needsSetup` covers both
+      // genuine absence (`.idle` + no key) and mid-validation; `.error` covers
+      // a confirmed-bad key — both cases genuinely fall back to raw text.
+      if currentProviderStatus.tone == .needsSetup || currentProviderStatus.tone == .error {
         InsetNotice(
           text:
             "Dictation still works, but without a key, cleanup falls back to your raw, unedited text every time.",


### PR DESCRIPTION
## Summary

Splits #1455 per founder direction: builds the proactive half now (warn before the user dictates and fails), defers the reactive repeated-failure nudge until real telemetry volume justifies designing it (checked live: only 9 total polish-failure events across 4-5 users in the 6 days since #1446 shipped that telemetry, not enough signal yet).

Adds a plain-English notice in AI Polish settings, right above the API key field, whenever OpenAI or Gemini is selected and no working key is actually saved. Mockup options and founder's chosen direction (Option A: inline banner at the point of the fix) in chat history.

## What it says

"Dictation still works, but without a key, cleanup falls back to your raw, unedited text every time."

## Review history

7 rounds of Codex code-diff review. Every single round through r6 found a real, distinct correctness bug in what looked like a tiny 15-line change — the ground truth for "does this user have a usable key" turned out to be genuinely subtle:
- r1: warned returning users with a perfectly good, just-not-yet-rechecked saved key
- r2: the wording ("without a key") could be false during a transient network hiccup while checking a real key
- r3: tracked what was *typed*, not what's *persisted* — a user who typed but never clicked Save would wrongly lose the warning
- r4: read Keychain live inside the view's render path on every keystroke (side-effecting: legacy-key migration, file I/O, telemetry) and treated a locked/unavailable Keychain as "definitely no key"
- r5: still collapsed "unknown" into "confirmed absent" in the tri-state's error handling
- r6 (P1): the fix for r5 went too far the other way and hid the warning for the *exact* case the feature exists for, a brand-new user who's never entered a key at all
- r7: clean

Final design: a cached three-state value (unknown / confirmed present / confirmed absent), updated only at the three real mutation points (settings-open, successful save, successful clear), reading the same Keychain error vocabulary (`errSecItemNotFound`) the codebase already uses elsewhere to distinguish "never saved" from "saved but unreadable."

## Test plan

- [x] Builds clean, dev app rebuilt and relaunched on the final reviewed code
- [x] Codex code-diff review — clean (r7)
- [x] Live-verified the show/hide mechanism on the real running app (banner present while a key is mid-validation, absent once a key is confirmed valid)
- [x] Verified the fresh-install "no key at all" path directly against the actual Keychain source rather than by clearing a real saved test key
