### PR TITLE
refactor(recovery): one deletion owner + root-cause telemetry (Part of #1464)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -170,6 +170,7 @@ enum DictationNarrator {
     case .cachingModel(engineLabel: _): return "Getting dictation ready, one moment"
     case .engineReady: return "Dictation ready. Press to start."
     case .recoveringLastRecording: return "Recovering your last recording. Press Discard to skip."
+    case .recoverySucceeded: return recoverySucceededText
     case .bluetoothAwareness:
       return "Bluetooth microphone detected. Wait a moment before speaking on a cold start."
     }
@@ -189,6 +190,12 @@ enum DictationNarrator {
   /// The recovery pill's CONTAINER accessibility label (no ellipsis — distinct
   /// bytes from `recoveryTitle`). VoiceOver reads it as the group's spoken status.
   static let recoveryAccessibilityLabel = "Recovering your last recording"
+  /// #1464 — the recovery SUCCESS notice (green `.recoverySucceeded` pill).
+  /// Title + subtitle for the visual pill; `recoverySucceededText` is the single
+  /// spoken VoiceOver sentence. No em-dash (Rule 6). Founder-approved 2026-07-16.
+  static let recoverySucceededTitle = "Recovered your last recording"
+  static let recoverySucceededSubtitle = "Saved to History"
+  static let recoverySucceededText = "Recovered your last recording. Saved to History."
   static let loadingModelStatus = "Loading model..."  // main-window body (ASCII ellipsis)
   static let loadingModelBadge = "Loading model\u{2026}"  // toolbar badge (Unicode ellipsis)
   static let loadingModelSidebar = "Loading Model"  // sidebar row (title-case, no ellipsis)

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -91,18 +91,18 @@ final class DictationLifecycleCoordinator {
   /// default no-op keeps recovery-off behavior. Keeps the Pipeline recovery-unaware.
   var onDurableSave: (String) -> Void = { _ in }
 
-  /// #1063 PR2 — fires when a recording reaches a NON-`.completed` terminal,
-  /// carrying this session's `recoverySessionID` (or nil if recovery was off) and
-  /// the terminal KIND. `DictationRuntime` sets it to `RecoveryCoordinator
-  /// .handleRecordingEndedWithoutDurableSave(recoverySessionID:terminal:)`, which
-  /// deletes a DISCARD-terminal spool now and RETAINS a FAILURE-terminal spool for
-  /// next-launch recovery. Driven by the kernel's RAW terminal transition (via the
-  /// driver's `onSessionEndedWithoutSave`), NOT the externalError-pinnable published
-  /// state — so it never fires for `.completed` (whose save path runs `onDurableSave`)
-  /// and the error pin can't trigger an early delete. Off-cap `var` closure,
-  /// default no-op keeps recovery-off behavior. (PR1's published-state cleanup
-  /// branch is replaced by this signal.)
-  var onRecordingEndedWithoutDurableSave: (String?, RecordingTerminalKind) -> Void = { _, _ in }
+  /// #1063 PR2 / #1464 — fires when a recording reaches a NON-`.completed`
+  /// terminal, carrying this session's `recoverySessionID` (or nil if recovery was
+  /// off) and the narrow `RecordingRecoveryEnding` the driver projected.
+  /// `DictationRuntime` sets it to `RecoveryCoordinator
+  /// .handleRecordingEndedWithoutDurableSave(recoverySessionID:ending:)`, which
+  /// applies the sole delete-versus-retain predicate. Driven by the kernel's RAW
+  /// terminal transition (via the driver's `onSessionEndedWithoutSave`), NOT the
+  /// externalError-pinnable published state — so it never fires for `.completed`
+  /// (whose save path runs `onDurableSave`) and the error pin can't trigger an
+  /// early delete. Off-cap `var` closure, default no-op keeps recovery-off
+  /// behavior. (PR1's published-state cleanup branch is replaced by this signal.)
+  var onRecordingEndedWithoutDurableSave: (String?, RecordingRecoveryEnding) -> Void = { _, _ in }
 
   /// #1171 — fired on every pipeline state change (both drivers). The composition
   /// root binds it to `EngineCoordinator.poke(.driverStateChanged)` so the
@@ -163,11 +163,11 @@ final class DictationLifecycleCoordinator {
     // recovery id + terminal KIND. Routed to the recovery cleanup (discard deletes,
     // failure retains). Distinct from `onStateChange` (the pinnable published
     // state) — keyed off the kernel terminal so it never fires during `.finalizing`.
-    kernelDriver.onSessionEndedWithoutSave = { [weak self] id, kind in
-      self?.onRecordingEndedWithoutDurableSave(id, kind)
+    kernelDriver.onSessionEndedWithoutSave = { [weak self] id, ending in
+      self?.onRecordingEndedWithoutDurableSave(id, ending)
     }
-    whisperKitKernelDriver.onSessionEndedWithoutSave = { [weak self] id, kind in
-      self?.onRecordingEndedWithoutDurableSave(id, kind)
+    whisperKitKernelDriver.onSessionEndedWithoutSave = { [weak self] id, ending in
+      self?.onRecordingEndedWithoutDurableSave(id, ending)
     }
     // #930: the overlay-only sub-status channel. A `.transcribing` →
     // `.polishing` flip mid-`.finalizing` does NOT change the public

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -137,11 +137,11 @@ final class DictationRuntime {
       },
       // #1063 PR1 (Codex r3): a PTT release or concurrent-toggle stop landing in
       // the arm window mints no session, so the lifecycle coordinator sees no
-      // terminal state — the starter cleans the armed spool/key directly. PR2: it
-      // passes this take's id, and a pre-start abort is always a discard.
+      // terminal state — the starter cleans the armed spool/key directly. #1464:
+      // a pre-start abort has no `RecordingOutcome`, so it routes to the dedicated
+      // coordinator entry point (always a discard — nothing was captured).
       cleanupRecoveryArm: { id in
-        recoveryCoordinator.handleRecordingEndedWithoutDurableSave(
-          recoverySessionID: id, terminal: .discard)
+        recoveryCoordinator.handlePreStartAbort(recoverySessionID: id)
       },
       // #1063 PR2: the recording gate — a press while recovery holds the shared
       // engine mints no session (shows the "recovering" pill).
@@ -160,12 +160,12 @@ final class DictationRuntime {
     dictationLifecycleCoordinator.onDurableSave = { id in
       recoveryCoordinator.handleDurableSave(recoverySessionID: id)
     }
-    // #1063 PR2: a recording that ends at a non-saved terminal routes to recovery
-    // cleanup by KIND — a discard terminal deletes the spool now; a failure
-    // terminal RETAINS it so the next launch recovers the audio.
-    dictationLifecycleCoordinator.onRecordingEndedWithoutDurableSave = { id, kind in
+    // #1063 PR2 / #1464: a recording that ends at a non-saved terminal routes to
+    // recovery cleanup — the coordinator's predicate deletes a discard/no-speech/
+    // user-cancel ending now and RETAINS a fault ending for next-launch recovery.
+    dictationLifecycleCoordinator.onRecordingEndedWithoutDurableSave = { id, ending in
       recoveryCoordinator.handleRecordingEndedWithoutDurableSave(
-        recoverySessionID: id, terminal: kind)
+        recoverySessionID: id, ending: ending)
     }
     let hotkeyController = HotkeyController(
       hotkeyService: hotkeyService,

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
@@ -42,10 +42,10 @@ final class RecordingFinalizer {
     try await $0.handle(event: .requestStop)
   }
   var cancelRecordingDispatch: @MainActor (KernelDictationDriver) async -> Void = {
-    // #1063 PR2: this is the genuine USER cancel path (the cancel button →
+    // #1063 PR2 / #1464: this is the genuine USER cancel path (the cancel button →
     // `RecordingFinalizer.cancel()`), so a recovery spool is DELETED, not retained.
     // The settings-rebuild system cancel uses `cancelRecording()`'s retain default.
-    await $0.cancelRecording(disposition: .discard)
+    await $0.cancelRecording(disposition: .user)
   }
 
   /// Read accessor exposed to `RecordingStarter` so the start path's

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -265,6 +265,24 @@ final class RecordingOverlayPanel {
           icon: .ready
         ).frame(width: 240, height: 44),
         width: 240, height: 44, dismissAfter: 1.5)
+    case .recoverySucceeded:
+      // #1464: standalone green success notice after a leftover recording landed
+      // in History. Mirrors `.engineReady` (launch-visible, green `.ready` icon),
+      // with a subtitle for "where to find it" and a slightly longer dwell.
+      NSAccessibility.post(
+        element: NSApp.mainWindow as Any,
+        notification: .announcementRequested,
+        userInfo: [
+          .announcement: spokenAnnouncement,
+          .priority: NSAccessibilityPriorityLevel.high.rawValue as NSNumber,
+        ])
+      presentTransientNotice(
+        content: ColdStartNoticeView(
+          title: DictationNarrator.recoverySucceededTitle,
+          subtitle: DictationNarrator.recoverySucceededSubtitle,
+          icon: .ready
+        ).frame(width: 300, height: 56),
+        width: 300, height: 56, dismissAfter: 3.0)
     case .recoveringLastRecording:
       NSAccessibility.post(
         element: NSApp.mainWindow as Any,

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -10,12 +10,17 @@ import Foundation
 /// - **Arm** a recording: mint a durable per-recording id, generate + DURABLY
 ///   store the per-session key, snapshot record-time settings, and produce the
 ///   opaque directive the in-process capture manager writes the encrypted spool from.
+/// - **Sole spool/key destructor (#1464):** every delete goes through the private
+///   `destroySpoolAndKey` helper. The replayer no longer deletes; the driver no
+///   longer classifies. Two exhaustive predicates decide delete-versus-retain —
+///   `shouldDeleteOnLiveEnding` (a live recording that ended without a durable
+///   save) and `shouldDeleteAfterReplay` (a launch replay attempt).
 /// - **Clean up on success:** once a recording's transcript is durably saved,
 ///   delete that session's spool file + key.
-/// - **Clean up on a non-saved ending (PR2):** route the kernel's terminal
-///   signal — a DISCARD terminal (cancel / no-speech / too-short) deletes the
-///   spool now; a FAILURE terminal (pipeline / audio / engine fault) RETAINS it
-///   so the audio is recovered on the next launch.
+/// - **Clean up on a non-saved ending:** apply `shouldDeleteOnLiveEnding` to the
+///   narrow `RecordingRecoveryEnding` — discard / no-speech / user-cancel delete
+///   now; a fault ending (pipeline / audio / engine / system-cancel) RETAINS the
+///   spool so the audio is recovered on the next launch.
 /// - **Scan + recover on launch (PR2):** find orphan spools, dedup any already
 ///   in History, then — behind a blocking "recovering your last recording" pill
 ///   that holds new recordings off the one shared engine — replay each orphan
@@ -66,6 +71,12 @@ final class RecoveryCoordinator {
   /// switch deferred because it arrived while recovery held the shared engine
   /// applies now. Set by the root.
   var onRecoveryComplete: (() -> Void)?
+
+  /// #1464 — fired after each `.recovered` replay result (a leftover recording
+  /// landed in History). The composition root binds it to the standalone
+  /// recovery-success overlay notice. Set by the root; nil in tests that don't
+  /// exercise the notice.
+  var onRecoverySucceeded: (() -> Void)?
 
   /// #1171 — whether an engine switch is in flight. The composition root binds
   /// this to `EngineCoordinator.isSwitching` (setter injection, like
@@ -195,48 +206,98 @@ final class RecoveryCoordinator {
     return (recoverySessionID, payload)
   }
 
+  /// The SOLE spool+key destructor (#1464). Deletes the spool file (which also
+  /// clears its attempt marker) SYNCHRONOUSLY — it is cheap local FS, and a
+  /// follow-up scan / the dedup + discard callers must see it gone at once — then
+  /// destroys the per-session key OFF the MainActor (the key store can be securityd
+  /// IPC, `keychain-not-mainactor`). Best-effort + idempotent (`try?`), so a
+  /// double-delete or a concurrently-removed spool is a harmless no-op. Returns the
+  /// detached key-delete work so tests can await completion; callers may discard it.
+  @discardableResult
+  private func destroySpoolAndKey(id: String) -> Task<Void, Never> {
+    try? makeSpoolStore().delete(recoverySessionID: id)
+    let keyStore = self.keyStore
+    return Task.detached(priority: .utility) {
+      try? keyStore.delete(for: id)
+    }
+  }
+
+  /// Delete-versus-retain for a live recording that ended without a durable save
+  /// (#1464). Reproduces the former driver `endedWithoutSaveKind` mapping EXACTLY:
+  /// delete when there is nothing worth keeping (discard / no-speech) or the user
+  /// asked to drop it; RETAIN when the captured audio is the user's words a fault
+  /// cut short. Static + internal so the split is unit-tested directly
+  /// (`matcher-set-adversarial-tests`).
+  static func shouldDeleteOnLiveEnding(_ ending: RecordingRecoveryEnding) -> Bool {
+    switch ending {
+    case .discarded, .noSpeech:
+      return true
+    case .failed, .audioInterrupted, .asrInterrupted, .noTransport:
+      return false
+    case .cancelled(.user):
+      return true
+    case .cancelled(.systemOrFault):
+      return false
+    }
+  }
+
+  /// Delete-versus-retain after a launch replay attempt (#1464). Delete a recovered
+  /// (saved) or unrecoverable orphan and a crash-loop `.abandoned` one; RETAIN a
+  /// History-save failure (the audio is still good, §3.3). `.aborted` (the user
+  /// discarded — already deleted by `discardActiveRecovery`) and `.deferred` (the
+  /// marker was never written — keep for a future launch) delete nothing here.
+  /// Static + internal for direct adversarial testing.
+  static func shouldDeleteAfterReplay(_ outcome: RecoveryReplayOutcome) -> Bool {
+    switch outcome {
+    case .recovered, .abandoned:
+      return true
+    case .failed(.unrecoverable):
+      return true
+    case .failed(.save), .failed(.saveMarkerClearFailed):
+      return false
+    case .aborted, .deferred:
+      return false
+    }
+  }
+
   /// A recording's transcript was durably saved — delete that session's spool +
   /// key. Best-effort, off the user's path, idempotent. Returns the detached
   /// work so tests can await it; callers discard it.
   @discardableResult
   func handleDurableSave(recoverySessionID id: String) -> Task<Void, Never> {
     if armedSessionID == id { armedSessionID = nil }
-    let keyStore = self.keyStore
-    let makeSpoolStore = self.makeSpoolStore
-    return Task.detached(priority: .utility) {
-      try? makeSpoolStore().delete(recoverySessionID: id)
-      try? keyStore.delete(for: id)
-    }
+    return destroySpoolAndKey(id: id)
   }
 
   /// A recording ended at a terminal state WITHOUT a durable transcript save
-  /// (#1063 PR2). Routes on the terminal KIND:
-  /// - `discard` (cancel / no-speech / too-short, or a pre-start abort): the app
-  ///   is alive and there is nothing worth recovering — delete the spool + key now
-  ///   instead of letting non-saved recordings accumulate on a long-running app.
-  /// - `failure` (pipeline / audio / engine fault): the captured audio is the
-  ///   user's words — RETAIN the spool so the next launch recovers it.
+  /// (#1063 PR2 / #1464). Applies `shouldDeleteOnLiveEnding` to the narrow
+  /// `RecordingRecoveryEnding` the driver projected: a delete ending (discard /
+  /// no-speech / user-cancel) destroys the spool + key now; a retain ending
+  /// (pipeline / audio / engine / system-cancel) keeps it for the next launch.
   /// Idempotent + best-effort; a no-op when `id` is nil. Always clears the live-
   /// recording protection (the recording is over). Returns the detached delete
-  /// work (discard only) so tests can await it.
+  /// work (delete endings only) so tests can await it.
   @discardableResult
   func handleRecordingEndedWithoutDurableSave(
-    recoverySessionID id: String?, terminal: RecordingTerminalKind
+    recoverySessionID id: String?, ending: RecordingRecoveryEnding
   ) -> Task<Void, Never>? {
     guard let id else { return nil }
     if armedSessionID == id { armedSessionID = nil }
-    switch terminal {
-    case .discard:
-      let keyStore = self.keyStore
-      let makeSpoolStore = self.makeSpoolStore
-      return Task.detached(priority: .utility) {
-        try? makeSpoolStore().delete(recoverySessionID: id)
-        try? keyStore.delete(for: id)
-      }
-    case .failure:
-      // Retain the spool + key — recovered on the next launch.
-      return nil
-    }
+    guard Self.shouldDeleteOnLiveEnding(ending) else { return nil }
+    return destroySpoolAndKey(id: id)
+  }
+
+  /// A record-press aborted BEFORE a kernel session was minted (a PTT release or
+  /// concurrent-toggle stop in the arm window, or a stale recovery gate) — no
+  /// `RecordingOutcome` fires, so this is the ONLY cleanup signal (#1464). Always a
+  /// discard: nothing was captured. Clears the live-recording protection and
+  /// destroys the just-armed spool/key through the sole destructor. Idempotent +
+  /// best-effort; a no-op when `id` is nil. Returns the detached work for tests.
+  @discardableResult
+  func handlePreStartAbort(recoverySessionID id: String?) -> Task<Void, Never>? {
+    guard let id else { return nil }
+    if armedSessionID == id { armedSessionID = nil }
+    return destroySpoolAndKey(id: id)
   }
 
   /// On launch, scan for orphan spools and recover them behind the blocking pill
@@ -307,9 +368,9 @@ final class RecoveryCoordinator {
       if alreadySaved.contains(id) {
         // Saved in a prior run's save→delete crash window: delete WITHOUT
         // re-transcribing (the dedup MUST precede any append — History forbids a
-        // duplicate id). Spool delete also clears the attempt marker.
-        try? store.delete(recoverySessionID: id)
-        Task.detached(priority: .utility) { try? keyStore.delete(for: id) }
+        // duplicate id). Routed through the sole destructor (#1464); these ids are
+        // never appended to `recoverable`, so the async delete never races a replay.
+        destroySpoolAndKey(id: id)
       } else {
         recoverable.append(id)
       }
@@ -343,6 +404,12 @@ final class RecoveryCoordinator {
         self?.recoveryGeneration != generationAtStart
       }
       activeRecoveryID = nil
+      // #1464: the coordinator is the sole destructor — the replayer no longer
+      // deletes, so apply the replay predicate now that `replay()` has returned.
+      // (`.aborted` deletes nothing here: `discardActiveRecovery` already did.)
+      if Self.shouldDeleteAfterReplay(outcome) { destroySpoolAndKey(id: id) }
+      // Post the standalone success notice for a recording that landed in History.
+      if case .recovered = outcome { onRecoverySucceeded?() }
       // A Discard ends the whole hold; remaining orphans (rare) wait for the next
       // launch. Every other outcome continues to the next orphan.
       if outcome == .aborted { break }
@@ -371,10 +438,9 @@ final class RecoveryCoordinator {
     guard isRecovering, let id = activeRecoveryID else { return }
     recoveryGeneration &+= 1
     resetEngine()
-    let store = makeSpoolStore()
-    try? store.delete(recoverySessionID: id)
-    let keyStore = self.keyStore
-    Task.detached(priority: .utility) { try? keyStore.delete(for: id) }
+    // Route through the sole destructor (#1464). The post-replay predicate sees
+    // `.aborted` for this id and does NO second delete.
+    destroySpoolAndKey(id: id)
     activeRecoveryID = nil
     TelemetryService.shared.recoveryCompleted(outcome: "discarded")
   }

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -8,10 +8,15 @@ import Foundation
 
 /// The terminal outcome of one orphan's recovery attempt (#1063 PR2). The
 /// `discarded` outcome is owned by `RecoveryCoordinator` (it deletes + emits on
-/// Discard), never produced by the replayer.
+/// Discard), never produced by the replayer. #1464: the replayer no longer
+/// destroys the spool/key — it returns this outcome and `RecoveryCoordinator`
+/// (the sole destructor) applies the delete-versus-retain predicate.
 enum RecoveryReplayOutcome: Equatable {
   case recovered
-  case failed
+  /// The attempt failed. The payload tells the coordinator whether to delete
+  /// (Camp A / a Camp B *candidate* Phase 1 does not yet retain) or RETAIN (a
+  /// History-write failure — the audio is still good, §3.3).
+  case failed(RecoveryReplayFailure)
   case abandoned
   /// A Discard bumped the recovery generation mid-flight: drop the result, save
   /// nothing. The coordinator already deleted the spool/key/marker.
@@ -19,6 +24,23 @@ enum RecoveryReplayOutcome: Equatable {
   /// The attempt marker could not be written, so recovery was deferred WITHOUT
   /// risking an un-guarded attempt — the spool stays for a future launch.
   case deferred
+}
+
+/// Why a replay `.failed`, carried to `RecoveryCoordinator` so it can apply the
+/// sole destruction predicate (#1464). The fine-grained telemetry reason is
+/// emitted by the replayer itself; this payload carries only the retain-vs-delete
+/// distinction plus the class, so a test can assert the exact returned outcome.
+enum RecoveryReplayFailure: Equatable {
+  /// The recording could not be turned into text — key / decrypt / reconstruct /
+  /// empty-samples / model-load / transcribe / empty-text. DELETE.
+  case unrecoverable
+  /// The transcript was produced but the History write threw; the audio is still
+  /// good. RETAIN for a next-launch retry — the attempt marker was cleared.
+  case save(RecoveryFailureClass)
+  /// As `.save`, but clearing the attempt marker ALSO threw — RETAIN this launch,
+  /// next-launch retry durability not guaranteed (the marker survives, so a
+  /// future launch may treat the spool as a crashed attempt).
+  case saveMarkerClearFailed(RecoveryFailureClass)
 }
 
 /// Per-orphan recovery execution seam — lets `RecoveryCoordinator` drive scan /
@@ -38,10 +60,15 @@ protocol RecoverySpoolReplaying: AnyObject {
 /// transcribe on the shared engine, polish under record-time settings, and save a
 /// non-auto-pasting "Recovered" transcript to History.
 ///
-/// Strict LIMB: every failure path deletes the orphan and surfaces "couldn't
-/// recover" via telemetry/breadcrumb — it never throws into the heart path. One
-/// attempt only: a per-spool marker written BEFORE the risky load/transcribe means
-/// a recovery that crashed the app is abandoned (not retried) on the next launch.
+/// Strict LIMB: every failure path surfaces "couldn't recover" via
+/// telemetry/breadcrumb and never throws into the heart path. #1464: it no longer
+/// destroys the spool/key — it returns a typed outcome and `RecoveryCoordinator`
+/// (the sole destructor) deletes or retains. It KEEPS the attempt-marker lifecycle
+/// (the crash-loop guard): one attempt only — a per-spool marker written BEFORE the
+/// risky load/transcribe means a recovery that crashed the app is abandoned (not
+/// retried) on the next launch. On a History-save failure it clears that marker
+/// itself so the RETAINED spool replays next launch rather than reading as
+/// abandoned (§3.3).
 @MainActor
 final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   private let asrManager: any ASRManagerInterface
@@ -58,7 +85,6 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// version, not the terms — recovery promises normal-quality, not byte-exact).
   private let currentVocabulary:
     @MainActor () -> (corrector: CorrectorVocabulary, polish: PolishVocabulary)
-  private let onCleanupFinished: @Sendable (String) -> Void
 
   init(
     asrManager: any ASRManagerInterface,
@@ -69,7 +95,6 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     keychainManager: KeychainManager,
     outputClassifierHolder: OutputClassifierHolder,
     egOneRuntime: (any EGOneEndpointProviding)? = nil,
-    onCleanupFinished: @escaping @Sendable (String) -> Void = { _ in },
     currentVocabulary: @escaping @MainActor () -> (
       corrector: CorrectorVocabulary, polish: PolishVocabulary
     )
@@ -82,7 +107,6 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     self.keychainManager = keychainManager
     self.outputClassifierHolder = outputClassifierHolder
     self.egOneRuntime = egOneRuntime
-    self.onCleanupFinished = onCleanupFinished
     self.currentVocabulary = currentVocabulary
   }
 
@@ -103,13 +127,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     let spoolStore = makeSpoolStore()
 
     // One-attempt crash-loop guard: a marker already present means a prior attempt
-    // crashed the app — abandon (delete + log), never retry.
+    // crashed the app — abandon (log + emit), never retry. #1464: the coordinator
+    // deletes on `.abandoned`; the replayer no longer destroys.
     if spoolStore.hasAttemptMarker(for: id) {
-      cleanUp(id, spoolStore: spoolStore)
       SentryBreadcrumb.captureError(
         RecoveryReplayError.abandonedAfterAttempt,
         category: .recoveryAbandonedAfterAttempt, stage: "recovery")
-      TelemetryService.shared.recoveryCompleted(outcome: "abandoned", reason: "crash_loop")
+      TelemetryService.shared.recoveryCompleted(outcome: "abandoned", reason: .crashLoop)
       return .abandoned
     }
     // Write the marker DURABLY before any risky load/transcribe (warm-up included).
@@ -120,30 +144,49 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       SentryBreadcrumb.add(
         stage: "recovery", message: "attempt-marker write failed — deferring recovery",
         level: .warning, data: ["error": String(describing: error)])
+      TelemetryService.shared.recoveryCompleted(outcome: "deferred", reason: .markerWriteFailed)
       return .deferred
     }
 
     // Retrieve the per-session key off the MainActor (`keychain-not-mainactor`).
+    // #1464: split a MISSING key (`key_missing`) from a store READ failure
+    // (`key_read_failed`) — the `try?` that swallowed both is gone.
     let keyStore = self.keyStore
-    let keyData: Data? = await Task.detached(priority: .utility) {
-      try? keyStore.retrieve(for: id)
+    let keyResult: Result<Data, any Error> = await Task.detached(priority: .utility) {
+      Result { try keyStore.retrieve(for: id) }
     }.value
     if isAborted() { return .aborted }
-    guard let keyData else {
-      return await fail(
-        id, spoolStore: spoolStore, reason: "decrypt", category: .recoveryDecryptFailed)
+    let keyData: Data
+    switch keyResult {
+    case .success(let data):
+      keyData = data
+    case .failure(let error):
+      let reason: RecoveryTelemetryReason =
+        (error as? RecoveryKeyStoreError) == .notFound ? .keyMissing : .keyReadFailed
+      return failUnrecoverable(reason: reason, category: .recoveryDecryptFailed)
     }
 
     // Decrypt + reconstruct the valid prefix off the MainActor (heavy for a long
-    // take). `recover` fails closed on a cipher-mode mismatch.
+    // take). `recover` fails closed on a cipher-mode mismatch. #1464: a THROW
+    // before a `RecoveredSpool` exists is `reconstruction_failed`; a spool that
+    // decodes to an EMPTY authenticated prefix is `empty_or_unreadable_samples`.
+    // Neither emits `audio_decrypted` (its absence IS the "not reconstructed"
+    // signal); a NON-EMPTY prefix continues below with `audio_decrypted=true`.
     let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: keyData)
-    let recovered: RecoveredSpool? = await Task.detached(priority: .utility) {
-      try? spoolStore.recover(recoverySessionID: id, cipher: cipher)
+    let recoverResult: Result<RecoveredSpool, any Error> = await Task.detached(priority: .utility) {
+      Result { try spoolStore.recover(recoverySessionID: id, cipher: cipher) }
     }.value
     if isAborted() { return .aborted }
-    guard let recovered, !recovered.samples.isEmpty else {
-      return await fail(
-        id, spoolStore: spoolStore, reason: "decrypt", category: .recoveryDecryptFailed)
+    let recovered: RecoveredSpool
+    switch recoverResult {
+    case .success(let spool):
+      recovered = spool
+    case .failure:
+      return failUnrecoverable(reason: .reconstructionFailed, category: .recoveryDecryptFailed)
+    }
+    guard !recovered.samples.isEmpty else {
+      return failUnrecoverable(
+        reason: .emptyOrUnreadableSamples, category: .recoveryDecryptFailed)
     }
 
     // Transcribe on the shared engine (batch). The marker already covers warm-up.
@@ -162,10 +205,11 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       try await asrManager.loadModel()
     } catch {
       // Discard hard-resets the engine, which can throw here — that's an abort,
-      // not a recovery failure (don't delete/log; the coordinator owns cleanup).
+      // not a recovery failure (don't log/emit; the coordinator owns cleanup).
       if isAborted() { return .aborted }
-      return await fail(
-        id, spoolStore: spoolStore, reason: "transcribe", category: .recoveryTranscribeFailed)
+      return failUnrecoverable(
+        reason: .modelLoadFailed, failureClass: Self.classify(error),
+        reconstructedSampleCount: recovered.samples.count, category: .recoveryTranscribeFailed)
     }
     // Discard during the model load: bail BEFORE the expensive batch transcribe.
     if isAborted() { return .aborted }
@@ -176,13 +220,17 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       // A Discard-driven engine reset kills the in-flight transcribe and surfaces
       // here as a throw — treat it as an abort (the user discarded), not a failure.
       if isAborted() { return .aborted }
-      return await fail(
-        id, spoolStore: spoolStore, reason: "transcribe", category: .recoveryTranscribeFailed)
+      return failUnrecoverable(
+        reason: .transcribeError, failureClass: Self.classify(error),
+        reconstructedSampleCount: recovered.samples.count, category: .recoveryTranscribeFailed)
     }
     if isAborted() { return .aborted }
     guard !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-      return await fail(
-        id, spoolStore: spoolStore, reason: "empty", category: .recoveryTranscribeFailed)
+      // Empty text on good audio: a Camp B *candidate* (genuine silence vs a
+      // transcribe hiccup are indistinguishable here) — no error, so no class.
+      return failUnrecoverable(
+        reason: .emptyText, reconstructedSampleCount: recovered.samples.count,
+        category: .recoveryTranscribeFailed)
     }
 
     // Polish under the recording's record-time settings (raw-fallback floor
@@ -223,20 +271,36 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     // is no `await` between here and `append`, so a Discard cannot interleave a
     // stale save (the uncancellable-transcribe stale-save guard, Codex REV-2 R2).
     if isAborted() { return .aborted }
+    let spoolSeconds = Int(recoveredSeconds.rounded())
     do {
       try transcriptStore.save(transcript)
     } catch {
+      // §3.3 (#1464) — a History-write failure is NOT audio loss. RETAIN the spool
+      // (the coordinator does not delete `.save`) and clear the attempt marker so
+      // the next launch REPLAYS instead of reading the spool as a crashed attempt.
+      // The clear can throw (`RecoverySpoolStore.deleteAttemptMarker`); if it does,
+      // retain THIS launch but do not claim durable next-launch retry.
+      let failureClass = Self.classify(error)
       SentryBreadcrumb.add(
-        stage: "recovery", message: "recovered transcript save failed",
+        stage: "recovery", message: "recovered transcript save failed — retaining spool",
         level: .warning, data: ["error": String(describing: error)])
-      cleanUp(id, spoolStore: spoolStore)
-      TelemetryService.shared.recoveryCompleted(outcome: "failed", reason: "save")
-      return .failed
+      do {
+        try spoolStore.deleteAttemptMarker(for: id)
+        TelemetryService.shared.recoveryCompleted(
+          outcome: "failed", reason: .saveFailed, failureClass: failureClass,
+          audioDecrypted: true, spoolSeconds: spoolSeconds)
+        return .failed(.save(failureClass))
+      } catch {
+        TelemetryService.shared.recoveryCompleted(
+          outcome: "failed", reason: .markerClearFailed, failureClass: failureClass,
+          audioDecrypted: true, spoolSeconds: spoolSeconds)
+        return .failed(.saveMarkerClearFailed(failureClass))
+      }
     }
     transcriptCoordinator.append(transcript)
 
-    // Success: delete spool (+ marker) + key.
-    cleanUp(id, spoolStore: spoolStore)
+    // Success. #1464: the coordinator deletes the spool (+ marker) + key on
+    // `.recovered` and posts the success notice; the replayer only reports.
     TelemetryService.shared.recoveryCompleted(
       outcome: "recovered",
       recoveredSeconds: Int(recoveredSeconds.rounded()),
@@ -244,30 +308,45 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     return .recovered
   }
 
-  /// Delete + log a failed orphan (one attempt — no keep-for-retry in PR2).
-  private func fail(
-    _ id: String, spoolStore: RecoverySpoolStore, reason: String,
+  /// Emit the failure breadcrumb + telemetry and return `.failed(.unrecoverable)`.
+  /// Does NOT delete — the coordinator is the sole destructor (#1464), deleting on
+  /// `.unrecoverable`. `reconstructedSampleCount` present ⇒ authenticated
+  /// reconstruction succeeded, so emit `audio_decrypted=true`, the spool-seconds
+  /// bucket, and `camp_b_candidate=true` (good audio, failed downstream — the only
+  /// case a future retry could help). Absent ⇒ omit both (never `audio_decrypted
+  /// =false`).
+  private func failUnrecoverable(
+    reason: RecoveryTelemetryReason,
+    failureClass: RecoveryFailureClass? = nil,
+    reconstructedSampleCount: Int? = nil,
     category: SentryBreadcrumb.ErrorCategory
-  ) async -> RecoveryReplayOutcome {
-    cleanUp(id, spoolStore: spoolStore)
+  ) -> RecoveryReplayOutcome {
     SentryBreadcrumb.captureError(
-      RecoveryReplayError.failed(reason), category: category, stage: "recovery")
-    TelemetryService.shared.recoveryCompleted(outcome: "failed", reason: reason)
-    return .failed
+      RecoveryReplayError.failed(reason.rawValue), category: category, stage: "recovery")
+    let spoolSeconds = reconstructedSampleCount.map {
+      Int((Double($0) / AudioConstants.sampleRate).rounded())
+    }
+    TelemetryService.shared.recoveryCompleted(
+      outcome: "failed",
+      reason: reason,
+      failureClass: failureClass,
+      audioDecrypted: reconstructedSampleCount != nil ? true : nil,
+      campBCandidate: reconstructedSampleCount != nil ? true : nil,
+      spoolSeconds: spoolSeconds)
+    return .failed(.unrecoverable)
   }
 
-  /// Delete a spool (which also clears its attempt marker) and destroy its key.
-  private func cleanUp(_ id: String, spoolStore: RecoverySpoolStore) {
-    try? spoolStore.delete(recoverySessionID: id)
-    let keyStore = self.keyStore
-    let onCleanupFinished = self.onCleanupFinished
-    // A plain Task inherits MainActor and would run synchronous key-store I/O on
-    // the UI executor. A task group adds no ownership value for one operation,
-    // and @concurrent cannot annotate the dependency's synchronous API.
-    Task.detached(priority: .utility) {
-      try? keyStore.delete(for: id)
-      onCleanupFinished(id)
-    }
+  /// Map a caught ASR/storage error to the narrow telemetry failure class (#1464).
+  /// The `NSError` domain/code is INPUT only — never emitted. Starts narrow
+  /// (D-030): only the two host-side wrappers are reliably typed — the default ASR
+  /// engine crosses XPC, which bridges everything else to an opaque `NSError` and
+  /// collapses decode causes into one string. `.notReady` is reserved for a Phase 2
+  /// in-process producer (`ASRError` is ASR-module-internal, kept isolated per
+  /// D-028); an unrecognized error is `.other`.
+  private static func classify(_ error: any Error) -> RecoveryFailureClass {
+    if error is XPCASRTransportError { return .xpcUnreachable }
+    if error is ASRLoadSupersededError { return .cancelled }
+    return .other
   }
 
   private static func transcriptionOptions(for settings: RecordingSettingsSnapshot?)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -539,6 +539,11 @@ public final class WisprBootstrapper {
     recordingOverlay.setDiscardRecoveryHandler { [weak recoveryCoordinator] in
       recoveryCoordinator?.discardActiveRecovery()
     }
+    // #1464: after a leftover recording lands in History, post the standalone green
+    // success notice (the `.recovered` path was silent before).
+    recoveryCoordinator.onRecoverySucceeded = { [weak recordingOverlay] in
+      recordingOverlay?.show(intent: .recoverySucceeded)
+    }
     // #1171 — the single owner of ASR-engine selection, status, and switching.
     // Reads the user's choice + active engine + readiness LIVE (no stored "want"
     // copies); serializes switches through one mailbox; defers while a pipeline is

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -329,7 +329,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// keeps the Pipeline recovery-unaware. The first param is the optional
   /// `recoverySessionID` (nil when recovery was off for the take).
   @ObservationIgnored
-  public var onSessionEndedWithoutSave: (@MainActor (String?, RecordingTerminalKind) -> Void)?
+  public var onSessionEndedWithoutSave: (@MainActor (String?, RecordingRecoveryEnding) -> Void)?
 
   /// Fire-once latch for `onSessionEndedWithoutSave` (#1548 D1). Tracks the
   /// `currentSessionID` the ended-without-save check last fired for, so a
@@ -340,18 +340,19 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   @ObservationIgnored
   private var lastEndedWithoutSaveSessionID: SessionID?
 
-  /// #1063 PR2 (Codex terminal-kind matrix) — disposition for the CURRENT
-  /// session's `.cancelled` terminal. `.cancelled` is reached by BOTH a genuine
-  /// user cancel (`RecordingFinalizer.cancel()` → `cancelRecording(disposition:
-  /// .discard)`) AND fault/system cancels that route through `kernel.cancel()`
-  /// (active `reset()`, `setTerminalReason()`, the settings-rebuild cancel). A user
-  /// cancel should DELETE the spool; a fault cancel should RETAIN recoverable
-  /// audio. Defaults to `.failure` (RETAIN) so any cancel NOT explicitly attributed
-  /// as a user discard conservatively keeps the audio. Set at the `cancelRecording`
-  /// call site, consumed + reset at the `.cancelled` signal fire, and reset on each
-  /// new session start.
+  /// #1063 PR2 / #1464 — the origin attributed to the CURRENT session's
+  /// `.cancelled` terminal. `.cancelled` is reached by BOTH a genuine user cancel
+  /// (`RecordingFinalizer.cancel()` → `cancelRecording(disposition: .user)`) AND
+  /// fault/system cancels that route through `kernel.cancel()` (active `reset()`,
+  /// `setTerminalReason()`, the settings-rebuild cancel). A user cancel should
+  /// DELETE the spool; a fault cancel should RETAIN recoverable audio. Defaults to
+  /// `.systemOrFault` (RETAIN) so any cancel NOT explicitly attributed as a user
+  /// discard conservatively keeps the audio. Set at the `cancelRecording` call
+  /// site, consumed + reset at the `.cancelled` signal fire, and reset on each new
+  /// session start. Projected into `RecordingRecoveryEnding.cancelled(_)` for the
+  /// coordinator's delete-versus-retain predicate.
   @ObservationIgnored
-  private var pendingCancelDisposition: RecordingTerminalKind = .failure
+  private var pendingCancelOrigin: RecordingCancelOrigin = .systemOrFault
 
   /// Fired by the finalizing-sub-status observer (`observeDisplayOnlyOverlay`)
   /// whenever the overlay's intent should refresh because of a `.transcribing`
@@ -680,12 +681,12 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// on its own is fire-and-latch: it triggers the recording-exit path or sets
   /// `cancelRequested`, but the actual transition to `.cancelled` /
   /// `.discarded` happens on the forward path's next yield.
-  /// `disposition` (#1063 PR2) attributes a `.cancelled` terminal for crash
-  /// recovery: `.discard` (genuine USER cancel — delete the spool) vs the
-  /// default `.failure` (a system cancel — RETAIN recoverable audio). The
-  /// user-cancel path passes `.discard`; system cancels use the retain default.
-  public func cancelRecording(disposition: RecordingTerminalKind = .failure) async {
-    pendingCancelDisposition = disposition
+  /// `disposition` (#1063 PR2 / #1464) attributes a `.cancelled` terminal for
+  /// crash recovery: `.user` (genuine USER cancel — delete the spool) vs the
+  /// default `.systemOrFault` (a system cancel — RETAIN recoverable audio). The
+  /// user-cancel path passes `.user`; system cancels use the retain default.
+  public func cancelRecording(disposition: RecordingCancelOrigin = .systemOrFault) async {
+    pendingCancelOrigin = disposition
     kernel.cancel()
     await awaitKernelTerminal()
   }
@@ -1005,11 +1006,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         // closures to read at finalize time (the wiring's optional-chained
         // reads were always-nil in production until this PR — finding #6).
         lastTerminalReason = nil
-        // #1063 PR2: a fresh session starts with the conservative cancel
-        // disposition (RETAIN) — only a genuine user cancel during this session
-        // flips it to discard. Prevents a stale user-discard from a prior session
-        // leaking onto this session's fault-cancel.
-        pendingCancelDisposition = .failure
+        // #1063 PR2: a fresh session starts with the conservative cancel origin
+        // (RETAIN) — only a genuine user cancel during this session flips it to
+        // `.user`. Prevents a stale user-discard from a prior session leaking onto
+        // this session's fault-cancel.
+        pendingCancelOrigin = .systemOrFault
         outcome.transcript = nil
         outcome.polishError = nil
         outcome.rawText = nil
@@ -1246,38 +1247,52 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     guard let outcome = kernel.recordingOutcome else { return }
     guard kernel.currentSessionID != lastEndedWithoutSaveSessionID else { return }
     lastEndedWithoutSaveSessionID = kernel.currentSessionID
-    let kind: RecordingTerminalKind?
+    let ending: RecordingRecoveryEnding?
     if case .cancelled = outcome {
       // `.cancelled` is ambiguous (Codex terminal-kind matrix): a genuine user
       // cancel DELETES, but a fault/system cancel (active reset, external-error,
       // settings rebuild) RETAINS recoverable audio. Resolve via the per-cancel
-      // disposition attributed at the `kernel.cancel()` call site; consume + reset
-      // to the conservative default so a stale user-discard can't leak to a later
-      // fault cancel.
-      kind = pendingCancelDisposition
-      pendingCancelDisposition = .failure
+      // origin attributed at the `kernel.cancel()` call site; consume + reset to
+      // the conservative default so a stale user-discard can't leak to a later
+      // fault cancel. The delete-versus-retain decision itself lives in the
+      // coordinator's predicate (#1464) — the driver only projects the origin.
+      ending = .cancelled(pendingCancelOrigin)
+      pendingCancelOrigin = .systemOrFault
     } else {
-      kind = Self.endedWithoutSaveKind(for: outcome)
+      ending = Self.recoveryEnding(for: outcome)
     }
-    guard let kind else { return }
-    onSessionEndedWithoutSave?(context.config?.recoverySessionID, kind)
+    guard let ending else { return }
+    onSessionEndedWithoutSave?(context.config?.recoverySessionID, ending)
   }
 
-  /// Classify the UNAMBIGUOUS non-`.completed` outcomes for the crash-recovery
-  /// cleanup signal. `.cancelled` is EXCLUDED (returns nil) — it is ambiguous
-  /// (user discard vs fault/system retain) and resolved at the fire site via
-  /// `pendingCancelDisposition`. Also nil for `.completed` (durable save ran).
-  /// Exhaustive so a new `RecordingOutcome` forces a routing decision. Internal
-  /// (not private) so the split is unit-tested directly
-  /// (`matcher-set-adversarial-tests`). #1548 D1: keyed by outcome, not state.
-  static func endedWithoutSaveKind(for outcome: RecordingOutcome)
-    -> RecordingTerminalKind?
+  /// Project the non-`.completed` terminal `RecordingOutcome` into the narrow
+  /// public `RecordingRecoveryEnding` the crash-recovery cleanup signal crosses
+  /// into AppKit with (#1464). The kernel has ALREADY floored an interrupted
+  /// `.discarded`/`.noSpeech`/`.failed(.noAudioCaptured)` to `.audioInterrupted`
+  /// upstream (`RecordingSessionKernel.interruptedTerminalFloor`), so those reach
+  /// here already as `.audioInterrupted`. Payloads are dropped — the coordinator's
+  /// predicate keys only on the terminal FAMILY, never `DiscardReason`/
+  /// `NoSpeechSource`, keeping the internal enum inside Pipeline. `.cancelled` is
+  /// EXCLUDED (returns nil) — resolved at the fire site via `pendingCancelOrigin`.
+  /// Also nil for `.completed` (durable save ran). Exhaustive so a new
+  /// `RecordingOutcome` forces a routing decision. Internal (not private) so the
+  /// split is unit-tested directly (`matcher-set-adversarial-tests`).
+  static func recoveryEnding(for outcome: RecordingOutcome)
+    -> RecordingRecoveryEnding?
   {
     switch outcome {
-    case .discarded, .noSpeech:
-      return .discard
-    case .failed, .audioInterrupted, .asrInterrupted, .noTransport:
-      return .failure
+    case .discarded:
+      return .discarded
+    case .noSpeech:
+      return .noSpeech
+    case .failed:
+      return .failed
+    case .audioInterrupted:
+      return .audioInterrupted
+    case .asrInterrupted:
+      return .asrInterrupted
+    case .noTransport:
+      return .noTransport
     case .cancelled, .completed:
       return nil
     }

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -126,6 +126,14 @@ public enum OverlayIntent: Equatable, Sendable {
   /// wait." No session is minted. Auto-dismissed after a few seconds; re-shown
   /// on each blocked press.
   case recoveringLastRecording
+  /// Crash-recovery SUCCESS notice (#1464). A standalone, launch-visible green
+  /// "recovered your last recording" pill posted after a leftover recording lands
+  /// in History — the `.recovered` path was silent before. A DEDICATED case (not
+  /// `.warning`, which shows an orange triangle + a "Warning" announcement, and not
+  /// `flashRecordingNotice`, which no-ops without a live recording panel):
+  /// `DictationNarrator` authors the copy and the panel renders it with the green
+  /// ready/success presentation. No associated value; auto-dismissed by the panel.
+  case recoverySucceeded
   /// Bluetooth cold-start education card (#1480). Shown once per launch when the
   /// configured input is a Bluetooth microphone and dictation is idle, sitting in
   /// the same top-middle slot as the recording pill. Unlike every other intent it
@@ -136,18 +144,39 @@ public enum OverlayIntent: Equatable, Sendable {
   case bluetoothAwareness
 }
 
-/// Why a recording ended at a terminal state WITHOUT a durable transcript save,
-/// classified for the crash-recovery cleanup signal (#1063 PR2). Derived from
-/// the kernel's terminal `RecordingSessionState` by `KernelDictationDriver`.
+/// The user-versus-fault attribution of a `.cancelled` recording terminal — the
+/// only outcome whose recovery disposition is ambiguous (#1464). A genuine user
+/// cancel DELETES the spool; a fault/system cancel RETAINS the recoverable audio.
+/// Kept narrow and public so the driver can project it across the Pipeline →
+/// AppKit boundary without leaking the internal `RecordingOutcome`.
+public enum RecordingCancelOrigin: Equatable, Sendable {
+  case user
+  case systemOrFault
+}
+
+/// The narrow PUBLIC projection of a recording's terminal `RecordingOutcome` that
+/// the crash-recovery cleanup signal needs (#1464). The internal `RecordingOutcome`
+/// (and its `DiscardReason` / `NoSpeechSource` payloads) stays inside Pipeline;
+/// `KernelDictationDriver` maps the already-floored outcome into this before it
+/// crosses into AppKit, where `RecoveryCoordinator` applies the SOLE
+/// delete-versus-retain predicate:
 ///
-/// - `discard`: the user (or the absence of speech) ended it — `.cancelled`,
-///   `.discarded`, `.noSpeech`. Nothing worth recovering: delete the spool now.
-/// - `failure`: a pipeline / audio / engine fault ended it — `.failed`,
-///   `.audioInterrupted`, `.asrInterrupted`. The captured audio is the user's
-///   words they wanted: RETAIN the spool so it is recovered on the next launch.
-public enum RecordingTerminalKind: Equatable, Sendable {
-  case discard
-  case failure
+/// - delete: `.discarded`, `.noSpeech`, `.cancelled(.user)` — nothing worth
+///   recovering, or the user asked to drop it.
+/// - retain: `.failed`, `.audioInterrupted`, `.asrInterrupted`, `.noTransport`,
+///   `.cancelled(.systemOrFault)` — the captured audio is the user's words; keep
+///   the spool so the next launch recovers it.
+///
+/// `.completed` is not representable here — a durable save has its own cleanup
+/// callback (`handleDurableSave`).
+public enum RecordingRecoveryEnding: Equatable, Sendable {
+  case discarded
+  case noSpeech
+  case failed
+  case audioInterrupted
+  case asrInterrupted
+  case noTransport
+  case cancelled(RecordingCancelOrigin)
 }
 
 /// Issue #285 — heart-path telemetry callbacks that the former root state routes to

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2894,8 +2894,8 @@ final class RecordingSessionKernel {
   /// **One rule: an interrupted recording that ends with no transcript lands on
   /// `.audioInterrupted`, whatever interrupted it.**
   ///
-  /// `.discarded` / `.noSpeech` DELETE the spool (`RecordingTerminalKind
-  /// .discard`). Letting an interrupted session reach either would destroy the
+  /// `.discarded` / `.noSpeech` DELETE the spool (they project to a delete ending;
+  /// #1464). Letting an interrupted session reach either would destroy the
   /// crash-recovery copy of audio the user can still get back on next launch —
   /// converting "recoverable" into "gone." Safety does not get to depend on which
   /// interruption fired, so this holds for every cause including the duration cap.
@@ -2914,7 +2914,7 @@ final class RecordingSessionKernel {
   /// `isDeviceLoss` draw one layer up.
   ///
   /// `.cancelled` is NEVER floored: an explicit user cancel is honored, and its
-  /// retain/delete disposition belongs to `pendingCancelDisposition`. Every other
+  /// retain/delete disposition belongs to the driver's `pendingCancelOrigin`. Every other
   /// `.failed(reason)` (`.asrEmpty`, `.asrFailed`, `.captureStartFailed`,
   /// `.modelLoadFailed`) keeps its own honest reason and is already spool-retaining.
   private func interruptedTerminalFloor(
@@ -3569,11 +3569,12 @@ final class RecordingSessionKernel {
       lastStopReason = reason
     }
 
-    /// #1408: surface the terminal floor as a pure function so a test can prove
-    /// it covers EVERY outcome whose `RecordingTerminalKind` is `.discard`.
-    /// The floor's mapped set and `KernelDictationDriver.endedWithoutSaveKind`'s
-    /// discard set are two lists of the same fact; without this seam they can
-    /// drift, and a new spool-deleting outcome would silently escape the floor.
+    /// #1408: surface the terminal floor as a pure function so a test can prove it
+    /// covers EVERY outcome that would delete the spool. The floor's mapped set and
+    /// the coordinator's spool-deleting endings (`KernelDictationDriver.recovery
+    /// Ending` → `RecoveryCoordinator.shouldDeleteOnLiveEnding`, #1464) are two lists
+    /// of the same fact; without this seam they can drift, and a new spool-deleting
+    /// outcome would silently escape the floor.
     func testInterruptedTerminalFloor(_ outcome: RecordingOutcome)
       -> RecordingOutcome
     {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -47,6 +47,39 @@ public enum ApiKeyValidationSource: String, Sendable {
   case modelDiscovery = "model_discovery"
 }
 
+/// #1464 — the root cause behind one crash-recovery attempt's `recovery.completed`
+/// event. Closed + typed so the retain-vs-delete-on-failure policy (deferred to
+/// Phase 3) can be chosen from real field data instead of a coarse stage. Privacy:
+/// a category only — the underlying `NSError` domain/code/description is classifier
+/// INPUT and is NEVER emitted (`sentry-operations.md` telemetry-privacy boundary).
+public enum RecoveryTelemetryReason: String, Sendable {
+  case keyMissing = "key_missing"
+  case keyReadFailed = "key_read_failed"
+  /// A spool file/header read THREW before a `RecoveredSpool` existed.
+  case reconstructionFailed = "reconstruction_failed"
+  /// Reconstruction returned no authenticated sample prefix.
+  case emptyOrUnreadableSamples = "empty_or_unreadable_samples"
+  case modelLoadFailed = "model_load_failed"
+  case transcribeError = "transcribe_error"
+  case emptyText = "empty_text"
+  case saveFailed = "save_failed"
+  case markerWriteFailed = "marker_write_failed"
+  case markerClearFailed = "marker_clear_failed"
+  case crashLoop = "crash_loop"
+}
+
+/// #1464 — the narrow failure CLASS behind a transcription-stage recovery failure,
+/// the prime Camp B (good audio, transient hiccup) suspects. Starts deliberately
+/// narrow (D-030 / plan §3.2): widen only when Phase 2 producer tests prove a new
+/// class stays distinguishable after the ASR XPC wrapper collapses decode errors.
+/// The `NSError` domain/code is the classifier INPUT, never emitted.
+public enum RecoveryFailureClass: String, Sendable {
+  case xpcUnreachable = "xpc_unreachable"
+  case cancelled
+  case notReady = "not_ready"
+  case other
+}
+
 /// Thin wrapper — type-safe event names, no business logic.
 /// Limb: observes facts from domain objects, publishes to PostHog.
 @MainActor
@@ -915,18 +948,48 @@ public final class TelemetryService {
   }
 
   /// One leftover recording finished its recovery attempt. `outcome` is one of
-  /// `recovered` / `discarded` / `failed` / `abandoned`; `reason` tags a failure
-  /// (`decrypt` / `transcribe` / `empty`); durations are bucketed; `polishFellBack`
-  /// is true when the recovered text landed raw (polish skipped/failed).
+  /// `recovered` / `discarded` / `failed` / `abandoned` / `deferred`. #1464:
+  /// `reason` is the TYPED root cause; `failureClass` narrows a transcription-stage
+  /// failure; `audioDecrypted` is emitted (true) ONLY once authenticated
+  /// reconstruction returned non-empty samples — its ABSENCE is the "not
+  /// reconstructed" signal, so it is NEVER emitted false; `campBCandidate` flags a
+  /// failure on good audio (a possible transient hiccup). Durations are bucketed;
+  /// `polishFellBack` is true when the recovered text landed raw.
   public func recoveryCompleted(
     outcome: String,
-    reason: String? = nil,
+    reason: RecoveryTelemetryReason? = nil,
+    failureClass: RecoveryFailureClass? = nil,
+    audioDecrypted: Bool? = nil,
+    campBCandidate: Bool? = nil,
     recoveredSeconds: Int? = nil,
     spoolSeconds: Int? = nil,
     polishFellBack: Bool? = nil
   ) {
+    #if DEBUG
+      // Mirror the PostHog property set below by exact production spelling so the
+      // typed threading is unit-testable through `testEventHook` (#1464).
+      var hookStringProps: [String: String] = ["outcome": outcome]
+      if let reason { hookStringProps["reason"] = reason.rawValue }
+      if let failureClass { hookStringProps["failure_class"] = failureClass.rawValue }
+      if let recoveredSeconds {
+        hookStringProps["recovered_seconds_bucket"] = Self.recoverySecondsBucket(recoveredSeconds)
+      }
+      if let spoolSeconds {
+        hookStringProps["spool_seconds_bucket"] = Self.recoverySecondsBucket(spoolSeconds)
+      }
+      var hookBoolProps: [String: Bool] = [:]
+      if let audioDecrypted { hookBoolProps["audio_decrypted"] = audioDecrypted }
+      if let campBCandidate { hookBoolProps["camp_b_candidate"] = campBCandidate }
+      if let polishFellBack { hookBoolProps["polish_fell_back"] = polishFellBack }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "recovery.completed", stringProps: hookStringProps, boolProps: hookBoolProps))
+    #endif
     var properties: [String: Any] = ["outcome": outcome]
-    if let reason { properties["reason"] = reason }
+    if let reason { properties["reason"] = reason.rawValue }
+    if let failureClass { properties["failure_class"] = failureClass.rawValue }
+    if let audioDecrypted { properties["audio_decrypted"] = audioDecrypted }
+    if let campBCandidate { properties["camp_b_candidate"] = campBCandidate }
     if let recoveredSeconds {
       properties["recovered_seconds_bucket"] = Self.recoverySecondsBucket(recoveredSeconds)
     }

--- a/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
@@ -157,23 +157,26 @@ import Testing
   /// fire it: its save path owns deletion via `onDurableSave`. Drives the real
   /// `install()`-wired `onStateChange` for BOTH backends.
   /// #1063 PR2: `install()` wires the driver's kernel-terminal signal
-  /// (`onSessionEndedWithoutSave`, carrying the recovery id + terminal KIND) to the
-  /// coordinator's recovery-cleanup closure. (The "never for `.completed`" guard now
-  /// lives in the driver — it simply never fires this signal for `.completed` — so it
-  /// is covered by the driver's own terminal-kind test, not here.)
+  /// (`onSessionEndedWithoutSave`, carrying the recovery id + the narrow
+  /// `RecordingRecoveryEnding`) to the coordinator's recovery-cleanup closure. (The
+  /// "never for `.completed`" guard now lives in the driver — it simply never fires
+  /// this signal for `.completed` — so it is covered by the driver's own projection
+  /// test, not here.)
   @Test func sessionEndedWithoutSaveSignalRoutesToRecoveryCleanup() {
     for backend in ["parakeet", "whisperKit"] {
       let fx = Self.makeCoordinator()
-      var calls: [(String?, RecordingTerminalKind)] = []
-      fx.coordinator.onRecordingEndedWithoutDurableSave = { id, kind in calls.append((id, kind)) }
+      var calls: [(String?, RecordingRecoveryEnding)] = []
+      fx.coordinator.onRecordingEndedWithoutDurableSave = { id, ending in
+        calls.append((id, ending))
+      }
       fx.coordinator.install()
       let driver = backend == "whisperKit" ? fx.whisperKitKernelDriver : fx.kernelDriver
 
-      driver.onSessionEndedWithoutSave?("sid-1", .discard)
-      driver.onSessionEndedWithoutSave?(nil, .failure)
+      driver.onSessionEndedWithoutSave?("sid-1", .discarded)
+      driver.onSessionEndedWithoutSave?(nil, .failed)
       #expect(calls.count == 2, "\(backend): both signals routed")
-      #expect(calls[0].0 == "sid-1" && calls[0].1 == .discard)
-      #expect(calls[1].0 == nil && calls[1].1 == .failure)
+      #expect(calls[0].0 == "sid-1" && calls[0].1 == .discarded)
+      #expect(calls[1].0 == nil && calls[1].1 == .failed)
     }
   }
 }

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -231,6 +231,7 @@ import Testing
         .recoveringLastRecording,
         "Recovering your last recording. Press Discard to skip."
       ),
+      (.recoverySucceeded, "Recovered your last recording. Saved to History."),
       (
         .bluetoothAwareness,
         "Bluetooth microphone detected. Wait a moment before speaking on a cold start."
@@ -255,6 +256,10 @@ import Testing
     #expect(DictationNarrator.recoveryTitle == "Recovering your last recording…")
     #expect(DictationNarrator.recoverySubtitle == "Saved to History when it's done")
     #expect(DictationNarrator.recoveryAccessibilityLabel == "Recovering your last recording")
+    #expect(DictationNarrator.recoverySucceededTitle == "Recovered your last recording")
+    #expect(DictationNarrator.recoverySucceededSubtitle == "Saved to History")
+    #expect(
+      DictationNarrator.recoverySucceededText == "Recovered your last recording. Saved to History.")
     #expect(DictationNarrator.loadingModelStatus == "Loading model...")
     #expect(DictationNarrator.loadingModelBadge == "Loading model\u{2026}")
     #expect(DictationNarrator.loadingModelSidebar == "Loading Model")

--- a/Tests/EnviousWisprTests/App/RecoverySuccessNoticeOverlayTests.swift
+++ b/Tests/EnviousWisprTests/App/RecoverySuccessNoticeOverlayTests.swift
@@ -1,0 +1,38 @@
+import AppKit
+import EnviousWisprPipeline
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1464 — the crash-recovery SUCCESS notice is a DEDICATED `.recoverySucceeded`
+/// overlay intent that must render at LAUNCH, where there is no live recording
+/// panel (the `.recovered` path runs from `scanAndRecover`). `currentIntent` is
+/// mutated synchronously in `show(intent:)`; panel creation is deferred, so these
+/// assertions hold headless. The green-pill pixels are proven by Live UAT.
+@Suite @MainActor struct RecoverySuccessNoticeOverlayTests {
+  /// `show(intent:)` posts an AX announcement against `NSApp.mainWindow`; touch
+  /// `NSApplication.shared` so the headless host has a non-nil `NSApp`.
+  init() { _ = NSApplication.shared }
+
+  @Test("the success notice is accepted with no prior panel (launch-visible, not a no-op)")
+  func recoverySucceededAcceptedFromLaunch() {
+    let overlay = RecordingOverlayPanel()
+    // No `show(...)` first — mirrors launch recovery with no live recording panel.
+    overlay.show(intent: .recoverySucceeded)
+    #expect(
+      overlay.currentIntent == .recoverySucceeded,
+      "a dedicated intent routed through the standalone launch-visible notice path")
+    overlay.hide()
+    #expect(overlay.currentIntent == .hidden)
+  }
+
+  @Test("a recording supersedes the success notice synchronously (single slot)")
+  func recordingSupersedesSuccessNotice() {
+    let overlay = RecordingOverlayPanel()
+    overlay.show(intent: .recoverySucceeded)
+    overlay.show(intent: .recording(audioLevel: 0))
+    #expect(overlay.currentIntent == .recording(audioLevel: 0))
+    overlay.hide()
+    #expect(overlay.currentIntent == .hidden)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
@@ -100,8 +100,8 @@ import Testing
     // #1063 PR2 (crash-recovery replay): raised 400 → 415. The published-state
     // `.idle`/`.error` cleanup branch was REPLACED by wiring the driver's
     // kernel-terminal signal (`onSessionEndedWithoutSave`, carrying the recovery
-    // id + terminal KIND) to the recovery-cleanup closure in `install()`; the
-    // closure type widened to `(String?, RecordingTerminalKind) -> Void`. No new
+    // id + the narrow ending) to the recovery-cleanup closure in `install()`; the
+    // closure type widened to `(String?, RecordingRecoveryEnding) -> Void`. No new
     // collaborator (count stays ≤ 11). Deterministic rule: actual 404 + 10 → 415.
     // #1171 (Telemetry Bible Phase 2): raised 415 → 430 for the two-line
     // `settingsSync.retryDeferredBackendSwitch(settings:)` call added to BOTH the

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -339,14 +339,20 @@ import Testing
   /// root itself (stored-property and method ceilings above are unchanged) —
   /// only the file's physical line count grows. Cap by deterministic rule
   /// (actual 1088 + ~2, rounded up to nearest 5 = 1090).
+  /// Ratcheted 1090→1100 in #1464 (2026-07-16, recovery telemetry-first Phase 1):
+  /// the composition root binds `recoveryCoordinator.onRecoverySucceeded` to post
+  /// the standalone green recovery-success overlay notice (the `.recovered` path
+  /// was silent before). No new stored property; a 4-line closure binding beside
+  /// the existing Discard-handler wiring. Cap by deterministic rule (actual 1094 +
+  /// ~2, rounded up to nearest 5 = 1100).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1090,
+      lineCount <= 1100,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1090. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1100. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
@@ -4,58 +4,58 @@ import Testing
 
 @testable import EnviousWisprPipeline
 
-/// #1063 PR2 / #1548 D1 — the crash-recovery cleanup signal classifies each
-/// concluded session's `RecordingOutcome` as DISCARD (delete the spool) or
-/// FAILURE (retain for next-launch recovery). `matcher-set-adversarial-tests`:
-/// every outcome is exercised in BOTH semantic classes, and `.completed` /
-/// `.cancelled` map to nil so the signal never fires for a saved take or is
-/// left to the dynamic cancel disposition.
+/// #1063 PR2 / #1548 D1 / #1464 — the driver projects each concluded session's
+/// internal `RecordingOutcome` into the narrow public `RecordingRecoveryEnding`
+/// that crosses into AppKit, where `RecoveryCoordinator` applies the sole
+/// delete-versus-retain predicate. This suite freezes the PROJECTION (the family
+/// mapping, payloads dropped); the delete/retain split is frozen separately in the
+/// coordinator predicate tests. `matcher-set-adversarial-tests`: every outcome is
+/// exercised, and `.completed` / `.cancelled` map to nil (a saved take never
+/// fires; a cancel is resolved dynamically via `pendingCancelOrigin`).
 @MainActor
-@Suite("Kernel terminal-kind split (#1063 PR2, #1548 D1)")
+@Suite("Kernel recovery-ending projection (#1063 PR2, #1548 D1, #1464)")
 struct KernelTerminalKindTests {
 
-  @Test("unambiguous discard outcomes → .discard (delete the spool)")
+  @Test("discard-family outcomes project to their narrow ending, payload dropped")
   func discardOutcomes() {
     #expect(
-      KernelDictationDriver.endedWithoutSaveKind(for: .discarded(.tooShort)) == .discard)
+      KernelDictationDriver.recoveryEnding(for: .discarded(.tooShort)) == .discarded)
     #expect(
-      KernelDictationDriver.endedWithoutSaveKind(for: .discarded(.releasedBeforeRecording))
-        == .discard)
-    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .noSpeech(.vadGate)) == .discard)
+      KernelDictationDriver.recoveryEnding(for: .discarded(.releasedBeforeRecording))
+        == .discarded)
+    #expect(KernelDictationDriver.recoveryEnding(for: .noSpeech(.vadGate)) == .noSpeech)
     #expect(
-      KernelDictationDriver.endedWithoutSaveKind(for: .noSpeech(.asrEmptyNoSpeech)) == .discard)
+      KernelDictationDriver.recoveryEnding(for: .noSpeech(.asrEmptyNoSpeech)) == .noSpeech)
   }
 
-  @Test("failure outcomes → .failure (RETAIN the recoverable audio)")
+  @Test("fault-family outcomes project to their narrow ending, payload dropped")
   func failureOutcomes() {
     #expect(
-      KernelDictationDriver.endedWithoutSaveKind(for: .failed(.asrFailed)) == .failure)
+      KernelDictationDriver.recoveryEnding(for: .failed(.asrFailed)) == .failed)
     #expect(
-      KernelDictationDriver.endedWithoutSaveKind(for: .audioInterrupted(.engineLost))
-        == .failure)
+      KernelDictationDriver.recoveryEnding(for: .audioInterrupted(.engineLost))
+        == .audioInterrupted)
     #expect(
-      KernelDictationDriver.endedWithoutSaveKind(for: .audioInterrupted(nil)) == .failure)
+      KernelDictationDriver.recoveryEnding(for: .audioInterrupted(nil)) == .audioInterrupted)
     #expect(
-      KernelDictationDriver.endedWithoutSaveKind(for: .asrInterrupted(wasRecording: true))
-        == .failure)
+      KernelDictationDriver.recoveryEnding(for: .asrInterrupted(wasRecording: true))
+        == .asrInterrupted)
     #expect(
-      KernelDictationDriver.endedWithoutSaveKind(for: .asrInterrupted(wasRecording: false))
-        == .failure)
-    // #1548 D1: the new no-transport outcome RETAINS (parity with
-    // `.failed(.noAudioCaptured)`, its telemetry projection).
-    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .noTransport) == .failure)
+      KernelDictationDriver.recoveryEnding(for: .asrInterrupted(wasRecording: false))
+        == .asrInterrupted)
+    #expect(KernelDictationDriver.recoveryEnding(for: .noTransport) == .noTransport)
   }
 
-  @Test(".cancelled is excluded from the STATIC map (ambiguous — resolved dynamically)")
+  @Test(".cancelled is excluded from the projection (resolved dynamically at the fire site)")
   func cancelledIsDynamic() {
-    // `.cancelled` is reached by both a user cancel (delete) and a fault/system
-    // cancel (retain), so the static map returns nil and the fire site resolves it
-    // via the per-cancel disposition (Codex terminal-kind matrix).
-    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .cancelled) == nil)
+    // `.cancelled` is reached by both a user cancel and a fault/system cancel, so
+    // the static projection returns nil and the fire site injects the origin from
+    // `pendingCancelOrigin` into `.cancelled(_)` (Codex terminal-kind matrix).
+    #expect(KernelDictationDriver.recoveryEnding(for: .cancelled) == nil)
   }
 
   @Test(".completed never fires the signal (durable save ran)")
   func completedIsNil() {
-    #expect(KernelDictationDriver.endedWithoutSaveKind(for: .completed) == nil)
+    #expect(KernelDictationDriver.recoveryEnding(for: .completed) == nil)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
@@ -3,7 +3,20 @@ import EnviousWisprCore
 import Foundation
 import Testing
 
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprPipeline
+
+/// #1464 — does this concluded outcome delete the crash-recovery spool? Composes
+/// the two real authorities the floor must stay ahead of: the driver's projection
+/// (`recoveryEnding`) into the narrow public ending, then the coordinator's sole
+/// delete-versus-retain predicate (`shouldDeleteOnLiveEnding`). `.completed` /
+/// `.cancelled` project to nil (a saved take / a dynamically-resolved cancel) and
+/// are never floor-coupled — they return false here.
+@MainActor
+private func deletesRecoverySpool(_ outcome: RecordingOutcome) -> Bool {
+  guard let ending = KernelDictationDriver.recoveryEnding(for: outcome) else { return false }
+  return RecoveryCoordinator.shouldDeleteOnLiveEnding(ending)
+}
 
 // MARK: - #1408 — salvage a dictation whose capture was interrupted mid-recording
 //
@@ -130,7 +143,7 @@ import Testing
 
       #expect(wrapper.testKernel.recordingOutcome == .discarded(.tooShort))
       #expect(
-        KernelDictationDriver.endedWithoutSaveKind(for: .discarded(.tooShort)) == .discard,
+        deletesRecoverySpool(.discarded(.tooShort)),
         "an ordinary too-short tap is still safe to delete")
     }
 
@@ -146,7 +159,7 @@ import Testing
 
       #expect(wrapper.testKernel.recordingOutcome == .audioInterrupted(.engineLost))
       #expect(
-        KernelDictationDriver.endedWithoutSaveKind(for: .audioInterrupted(.engineLost)) == .failure,
+        !deletesRecoverySpool(.audioInterrupted(.engineLost)),
         "the floor must convert the spool-deleting terminal into a spool-retaining one")
     }
 
@@ -264,7 +277,7 @@ import Testing
         terminal.kind == .completed || terminal.kind == .audioInterrupted,
         "salvage produced a third terminal: \(String(describing: terminal))")
       if terminal.kind != .completed, let outcome = terminal {
-        #expect(KernelDictationDriver.endedWithoutSaveKind(for: outcome) == .failure)
+        #expect(!deletesRecoverySpool(outcome))
       }
     }
 
@@ -272,7 +285,7 @@ import Testing
     /// and cancels has asked us to throw the take away; flooring `.cancelled`
     /// would override an explicit instruction to protect data the user just told
     /// us to discard. Its retain/delete disposition belongs to the driver's
-    /// `pendingCancelDisposition`, not to the floor.
+    /// `pendingCancelOrigin`, not to the floor.
     @Test("an explicit cancel during a salvage is honored, never floored")
     func explicitCancelDuringSalvageIsNotFloored() async {
       // `slowFinalize` dwells inside `.transcribing`, which is how the inventory
@@ -296,17 +309,17 @@ import Testing
       #expect(wrapper.testKernel.recordingOutcome == .cancelled)
       #expect(context.paste.pasteCount == 0)
       #expect(
-        KernelDictationDriver.endedWithoutSaveKind(for: .cancelled) == nil,
-        "`.cancelled` is resolved dynamically by pendingCancelDisposition, not the static map")
+        KernelDictationDriver.recoveryEnding(for: .cancelled) == nil,
+        "`.cancelled` is resolved dynamically by pendingCancelOrigin, not the static projection")
     }
 
     /// Every ending outcome the FSM can conclude with (#1548 D1: the ending
     /// category moved off the state onto `RecordingOutcome`). `RecordingOutcome`
     /// has associated values so it cannot be `CaseIterable`; this list is the
-    /// manual mirror, and `KernelDictationDriver.endedWithoutSaveKind` is an
-    /// exhaustive switch, so a new outcome forces a decision there and gets
-    /// caught here. Payloads are arbitrary valid values — the floor + the kind
-    /// split only read the category, never the reason.
+    /// manual mirror, and `KernelDictationDriver.recoveryEnding` is an exhaustive
+    /// switch, so a new outcome forces a decision there and gets caught here.
+    /// Payloads are arbitrary valid values — the floor + the projection only read
+    /// the category, never the reason.
     private static let allTerminals: [RecordingOutcome] = [
       .completed, .cancelled, .discarded(.tooShort), .noSpeech(.vadGate),
       .audioInterrupted(nil), .asrInterrupted(wasRecording: false), .noTransport,
@@ -316,9 +329,10 @@ import Testing
       .failed(.emptyAfterProcessing), .failed(.captureStalled),
     ]
 
-    /// The floor's mapped set and the driver's `.discard` set are two lists of
-    /// one fact: "this terminal deletes the crash-recovery spool." They live in
-    /// different types and can drift. This test couples them, so adding a new
+    /// The floor's mapped set and the coordinator's spool-deleting endings are two
+    /// lists of one fact: "this terminal deletes the crash-recovery spool." They
+    /// live in different types (Pipeline floor + AppKit predicate) and can drift.
+    /// This test couples them through the two real authorities, so adding a new
     /// spool-deleting terminal without flooring it reddens here rather than
     /// silently destroying a user's only surviving copy of a dictation.
     @Test("the floor covers EVERY terminal that would delete the spool")
@@ -328,7 +342,7 @@ import Testing
       let kernel = wrapper.testKernel
 
       for terminal in Self.allTerminals {
-        let deletesSpool = KernelDictationDriver.endedWithoutSaveKind(for: terminal) == .discard
+        let deletesSpool = deletesRecoverySpool(terminal)
         let floored = kernel.testInterruptedTerminalFloor(terminal)
         if deletesSpool {
           #expect(

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -7,12 +7,14 @@ import Testing
 @testable import EnviousWisprAppKit
 @testable import EnviousWisprServices
 
-/// The host-side `RecoveryCoordinator` (#1063 PR2): arms a recording's encrypted
-/// spool with a DURABLY-stored key, deletes the spool + key on a durable save,
-/// routes a non-saved terminal by KIND (discard deletes, failure retains), and on
-/// launch scans + recovers orphans behind a blocking gate (single-flight, dedup,
-/// generation-guarded discard, `defer`-cleared gate). A fake replayer drives the
-/// scan/gate/generation logic; temp-dir stores keep the tests isolated.
+/// The host-side `RecoveryCoordinator` (#1063 PR2 / #1464): arms a recording's
+/// encrypted spool with a DURABLY-stored key, and is the SOLE spool/key destructor
+/// — it applies two exhaustive predicates (`shouldDeleteOnLiveEnding` for a live
+/// non-saved ending, `shouldDeleteAfterReplay` for a launch replay outcome), so the
+/// replayer no longer deletes. On launch it scans + recovers orphans behind a
+/// blocking gate (single-flight, dedup, generation-guarded discard, `defer`-cleared
+/// gate) and posts a success notice. A fake replayer drives the scan/gate/
+/// generation logic; temp-dir stores keep the tests isolated.
 @MainActor
 @Suite("Recovery coordinator (#1063)")
 struct RecoveryCoordinatorTests {
@@ -150,31 +152,40 @@ struct RecoveryCoordinatorTests {
     #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
   }
 
-  // MARK: - Non-saved terminal routing (terminal-kind split)
+  // MARK: - Non-saved terminal routing (#1464 live-ending predicate)
 
-  @Test("a DISCARD terminal deletes the spool + key")
+  @Test("a delete ending (discard/no-speech/user-cancel) deletes the spool + key")
   func discardTerminalDeletes() async throws {
     let h = Self.makeHarness()
-    let id = "discard-\(UUID().uuidString)"
-    try Self.writeSpool(h.spoolStore, id)
-    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
-    await h.coordinator.handleRecordingEndedWithoutDurableSave(
-      recoverySessionID: id, terminal: .discard)?.value
-    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
-    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+    for ending in [RecordingRecoveryEnding.discarded, .noSpeech, .cancelled(.user)] {
+      let id = "del-\(UUID().uuidString)"
+      try Self.writeSpool(h.spoolStore, id)
+      try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+      await h.coordinator.handleRecordingEndedWithoutDurableSave(
+        recoverySessionID: id, ending: ending)?.value
+      #expect(
+        !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+        "\(ending) should delete the spool")
+      #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+    }
   }
 
-  @Test("a FAILURE terminal RETAINS the spool + key for next-launch recovery")
+  @Test("a retain ending (fault / system-cancel) RETAINS the spool + key")
   func failureTerminalRetains() async throws {
     let h = Self.makeHarness()
-    let id = "failure-\(UUID().uuidString)"
-    try Self.writeSpool(h.spoolStore, id)
-    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
-    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
-      recoverySessionID: id, terminal: .failure)
-    #expect(task == nil, "failure retains — no delete work")
-    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
-    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+    let retainEndings: [RecordingRecoveryEnding] = [
+      .failed, .audioInterrupted, .asrInterrupted, .noTransport, .cancelled(.systemOrFault),
+    ]
+    for ending in retainEndings {
+      let id = "keep-\(UUID().uuidString)"
+      try Self.writeSpool(h.spoolStore, id)
+      try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+      let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+        recoverySessionID: id, ending: ending)
+      #expect(task == nil, "\(ending) retains — no delete work")
+      #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+      #expect((try? h.keyStore.retrieve(for: id)) != nil)
+    }
   }
 
   @Test("non-saved cleanup is a no-op when id is nil")
@@ -182,7 +193,121 @@ struct RecoveryCoordinatorTests {
     let h = Self.makeHarness()
     #expect(
       h.coordinator.handleRecordingEndedWithoutDurableSave(
-        recoverySessionID: nil, terminal: .discard) == nil)
+        recoverySessionID: nil, ending: .discarded) == nil)
+  }
+
+  // MARK: - #1464 delete/retain predicates (adversarial: every case in both classes)
+
+  @Test("shouldDeleteOnLiveEnding: delete endings delete, retain endings retain")
+  func liveEndingPredicate() {
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.discarded))
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.noSpeech))
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.cancelled(.user)))
+    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.failed))
+    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.audioInterrupted))
+    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.asrInterrupted))
+    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.noTransport))
+    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.cancelled(.systemOrFault)))
+  }
+
+  @Test(
+    "shouldDeleteAfterReplay: recovered/abandoned/unrecoverable delete; save/aborted/deferred retain"
+  )
+  func replayOutcomePredicate() {
+    #expect(RecoveryCoordinator.shouldDeleteAfterReplay(.recovered))
+    #expect(RecoveryCoordinator.shouldDeleteAfterReplay(.abandoned))
+    #expect(RecoveryCoordinator.shouldDeleteAfterReplay(.failed(.unrecoverable)))
+    #expect(!RecoveryCoordinator.shouldDeleteAfterReplay(.failed(.save(.other))))
+    #expect(!RecoveryCoordinator.shouldDeleteAfterReplay(.failed(.saveMarkerClearFailed(.other))))
+    #expect(!RecoveryCoordinator.shouldDeleteAfterReplay(.aborted))
+    #expect(!RecoveryCoordinator.shouldDeleteAfterReplay(.deferred))
+  }
+
+  // MARK: - #1464 sole destructor: post-replay deletion + success notice + pre-start abort
+
+  /// The key delete is detached; poll on the OBSERVABLE signal (key gone) with a
+  /// bounded deadline — the same idiom the key-only-sweep tests below use. The loop
+  /// condition IS the signal; the sleep is only the poll interval.
+  private static func awaitKeyDeleted(_ keyStore: RecoveryKeyStore, id: String) async {
+    for _ in 0..<200 where (try? keyStore.retrieve(for: id)) != nil {
+      try? await Task.sleep(for: .milliseconds(5))  // settle: poll interval; loop cond is the signal
+    }
+  }
+
+  @Test("the coordinator deletes the spool + key after a .recovered replay")
+  func recoveredReplayDeletes() async throws {
+    let h = Self.makeHarness()
+    let id = "rec-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    h.replayer.outcomeByDefault = .recovered
+    await h.coordinator.scanAndRecover()
+    await Self.awaitKeyDeleted(h.keyStore, id: id)
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+  }
+
+  @Test("the coordinator deletes after an unrecoverable replay")
+  func unrecoverableReplayDeletes() async throws {
+    let h = Self.makeHarness()
+    let id = "unrec-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    h.replayer.outcomeByDefault = .failed(.unrecoverable)
+    await h.coordinator.scanAndRecover()
+    await Self.awaitKeyDeleted(h.keyStore, id: id)
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+  }
+
+  @Test("the coordinator RETAINS the spool + key after a save-failure replay (§3.3)")
+  func saveFailureReplayRetains() async throws {
+    let h = Self.makeHarness()
+    let id = "save-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    h.replayer.outcomeByDefault = .failed(.save(.other))
+    await h.coordinator.scanAndRecover()
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "a History-save failure retains the spool for next-launch retry")
+    #expect((try? h.keyStore.retrieve(for: id)) != nil, "and retains the key")
+  }
+
+  @Test("onRecoverySucceeded fires once per .recovered orphan, never on failure")
+  func successCallbackFires() async throws {
+    let h = Self.makeHarness()
+    var successCount = 0
+    h.coordinator.onRecoverySucceeded = { successCount += 1 }
+    try Self.writeSpool(h.spoolStore, "s-\(UUID().uuidString)")
+    h.replayer.outcomeByDefault = .recovered
+    await h.coordinator.scanAndRecover()
+    #expect(successCount == 1, "recovered ⇒ one success notice")
+
+    let h2 = Self.makeHarness()
+    var failCount = 0
+    h2.coordinator.onRecoverySucceeded = { failCount += 1 }
+    try Self.writeSpool(h2.spoolStore, "f-\(UUID().uuidString)")
+    h2.replayer.outcomeByDefault = .failed(.unrecoverable)
+    await h2.coordinator.scanAndRecover()
+    #expect(failCount == 0, "a failed recovery posts no success notice")
+  }
+
+  @Test("pre-start abort deletes the just-armed spool + key")
+  func preStartAbortDeletes() async throws {
+    let h = Self.makeHarness()
+    let id = "abort-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    await h.coordinator.handlePreStartAbort(recoverySessionID: id)?.value
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+  }
+
+  @Test("pre-start abort is a no-op when id is nil")
+  func preStartAbortNoopWhenNil() {
+    let h = Self.makeHarness()
+    #expect(h.coordinator.handlePreStartAbort(recoverySessionID: nil) == nil)
   }
 
   // MARK: - Launch scan + recover
@@ -251,7 +376,7 @@ struct RecoveryCoordinatorTests {
   @Test("gate ends cleared even when every orphan fails (defer backstop, R1)")
   func scanGateClearedOnAllFailures() async throws {
     let h = Self.makeHarness()
-    h.replayer.outcomeByDefault = .failed
+    h.replayer.outcomeByDefault = .failed(.unrecoverable)
     try Self.writeSpool(h.spoolStore, "orphan-\(UUID().uuidString)")
     await h.coordinator.scanAndRecover()
     #expect(!h.coordinator.isRecovering)
@@ -416,6 +541,6 @@ struct RecoveryCoordinatorTests {
     #expect(result == nil, "a failed durable key store disables recovery for the take")
     #expect(
       coordinator.handleRecordingEndedWithoutDurableSave(
-        recoverySessionID: nil, terminal: .discard) == nil)
+        recoverySessionID: nil, ending: .discarded) == nil)
   }
 }

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -10,17 +10,22 @@ import Testing
 @testable import EnviousWisprServices
 @testable import EnviousWisprStorage
 
-/// The per-orphan `RecoverySpoolReplayer` (#1063 PR2): decrypt → transcribe →
-/// polish → save a non-auto-pasting "Recovered" transcript, ONE attempt with a
-/// crash-loop marker, and a generation guard that drops a discarded-but-in-flight
-/// result before saving. Driven against a real encrypted spool on disk + a fake
-/// batch ASR.
+/// The per-orphan `RecoverySpoolReplayer` (#1063 PR2 / #1464): decrypt →
+/// transcribe → polish → save a non-auto-pasting "Recovered" transcript, ONE
+/// attempt with a crash-loop marker, and a generation guard that drops a
+/// discarded-but-in-flight result before saving. #1464: the replayer NO LONGER
+/// destroys the spool/key — the coordinator (sole destructor) does that after
+/// `replay()` returns — so these tests assert the outcome + typed telemetry + that
+/// the spool/key REMAIN. The one exception is the §3.3 save-failure fix: the
+/// replayer clears its OWN attempt marker so a retained spool replays next launch.
+/// `.serialized` — the telemetry tests set the process-global `testEventHook`.
 @MainActor
-@Suite("Recovery spool replayer (#1063 PR2)")
+@Suite("Recovery spool replayer (#1063 PR2, #1464)", .serialized)
 struct RecoverySpoolReplayerTests {
 
-  /// Minimal batch-ASR fake: returns a canned result, counts calls, and runs an
-  /// optional hook when `transcribe` is entered (to simulate a mid-flight Discard).
+  /// Minimal batch-ASR fake: returns a canned result, counts calls, runs an
+  /// optional hook when `transcribe`/`loadModel` is entered (to simulate a
+  /// mid-flight Discard or a filesystem flip), and can throw a scripted error.
   final class FakeBatchASR: ASRManagerInterface {
     var activeBackendType: ASRBackendType = .parakeet
     var isModelLoaded = false
@@ -35,6 +40,8 @@ struct RecoverySpoolReplayerTests {
     var cannedText = "hello recovered world"
     var onTranscribe: (() -> Void)?
     var onLoadModel: (() -> Void)?
+    /// When set, `transcribe` throws it instead of returning a result.
+    var transcribeError: (any Error)?
 
     func loadModel() async throws {
       isModelLoaded = true
@@ -48,6 +55,7 @@ struct RecoverySpoolReplayerTests {
     {
       transcribeCallCount += 1
       onTranscribe?()
+      if let transcribeError { throw transcribeError }
       return ASRResult(
         text: cannedText, language: options.language, duration: 1, processingTime: 1,
         backendType: activeBackendType)
@@ -63,11 +71,30 @@ struct RecoverySpoolReplayerTests {
     func cancelInFlightLoad() {}
   }
 
+  /// Thread-safe telemetry capture (the hook is `@Sendable`, process-global).
+  final class TelemetryBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [CapturedTelemetryEvent] = []
+    func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
+    func recoveryEvents() -> [CapturedTelemetryEvent] {
+      lock.withLock { stored.filter { $0.name == "recovery.completed" } }
+    }
+  }
+
   private static func tempDir() -> URL {
     let dir = FileManager.default.temporaryDirectory
       .appendingPathComponent("ew-replayer-\(UUID().uuidString)", isDirectory: true)
     try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
     return dir
+  }
+
+  /// A transcript directory whose PARENT is a regular FILE, so `TranscriptStore
+  /// .save` can never open its temp file — a deterministic save failure with no
+  /// timing (#1464 §3.3 tests).
+  private static func unwritableTranscriptDir() throws -> URL {
+    let blocker = tempDir().appendingPathComponent("blocker")
+    try Data([0]).write(to: blocker)
+    return blocker.appendingPathComponent("transcripts", isDirectory: true)
   }
 
   private static func key(_ byte: UInt8 = 7) -> Data {
@@ -93,19 +120,18 @@ struct RecoverySpoolReplayerTests {
     let replayer: RecoverySpoolReplayer
     let asr: FakeBatchASR
     let spoolStore: RecoverySpoolStore
+    let spoolDir: URL
     let keyStore: RecoveryKeyStore
     let transcriptStore: TranscriptStore
     let transcriptCoordinator: TranscriptCoordinator
-    let cleanupEvents: AsyncStream<String>
   }
 
-  private static func makeHarness() -> Harness {
+  private static func makeHarness(transcriptDir: URL? = nil) -> Harness {
     let spoolDir = tempDir()
     let keyStore = RecoveryKeyStore(backend: .file, fileDirectory: tempDir())
-    let transcriptStore = TranscriptStore(directory: tempDir())
+    let transcriptStore = TranscriptStore(directory: transcriptDir ?? tempDir())
     let transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
     let asr = FakeBatchASR()
-    let (cleanupEvents, cleanupContinuation) = AsyncStream.makeStream(of: String.self)
     let replayer = RecoverySpoolReplayer(
       asrManager: asr,
       keyStore: keyStore,
@@ -114,13 +140,11 @@ struct RecoverySpoolReplayerTests {
       transcriptCoordinator: transcriptCoordinator,
       keychainManager: KeychainManager(),
       outputClassifierHolder: OutputClassifierHolder(),
-      onCleanupFinished: { cleanupContinuation.yield($0) },
       currentVocabulary: { (.empty, .empty) })
     return Harness(
       replayer: replayer, asr: asr,
-      spoolStore: RecoverySpoolStore(directory: spoolDir), keyStore: keyStore,
-      transcriptStore: transcriptStore, transcriptCoordinator: transcriptCoordinator,
-      cleanupEvents: cleanupEvents)
+      spoolStore: RecoverySpoolStore(directory: spoolDir), spoolDir: spoolDir, keyStore: keyStore,
+      transcriptStore: transcriptStore, transcriptCoordinator: transcriptCoordinator)
   }
 
   /// Write a real encrypted spool + store its key, so the replayer can decrypt it.
@@ -137,14 +161,24 @@ struct RecoverySpoolReplayerTests {
     await withCheckedContinuation { c in writer.finalize(reason: .cleanFinalized) { c.resume() } }
   }
 
-  @Test("happy path: orphan recovered → saved as isRecovered, spool + key deleted")
+  /// Set the process-global telemetry hook for the duration of `body`, capturing
+  /// every emission. Restores the hook after (the suite is `.serialized`).
+  private static func capturingTelemetry(
+    _ body: () async throws -> Void
+  ) async rethrows -> TelemetryBox {
+    let box = TelemetryBox()
+    TelemetryService.shared.testEventHook = { @Sendable e in box.add(e) }
+    defer { TelemetryService.shared.testEventHook = nil }
+    try await body()
+    return box
+  }
+
+  @Test("happy path: orphan recovered → saved as isRecovered; replayer does NOT delete")
   func happyPath() async throws {
     let h = Self.makeHarness()
     let id = "ok-\(UUID().uuidString)"
     try await Self.seedSpool(h, id: id, samples: [0.1, 0.2, 0.3])
     let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
-    var cleanupIterator = h.cleanupEvents.makeAsyncIterator()
-    #expect(await cleanupIterator.next() == id)
     #expect(outcome == .recovered)
     #expect(h.asr.transcribeCallCount == 1)
     let saved = h.transcriptCoordinator.transcripts
@@ -152,11 +186,13 @@ struct RecoverySpoolReplayerTests {
     #expect(saved.first?.isRecovered == true)
     #expect(saved.first?.recoverySessionID == id)
     #expect(saved.first?.displayText.contains("hello") == true)
-    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
-    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+    // #1464: the replayer no longer destroys — the coordinator deletes after this
+    // returns, so the spool + key are STILL PRESENT here.
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
   }
 
-  @Test("one-attempt guard: a marker present on entry ABANDONS (no transcribe, deleted)")
+  @Test("one-attempt guard: a marker present on entry ABANDONS (no transcribe, no delete)")
   func markerPresentAbandons() async throws {
     let h = Self.makeHarness()
     let id = "loop-\(UUID().uuidString)"
@@ -167,7 +203,8 @@ struct RecoverySpoolReplayerTests {
     #expect(outcome == .abandoned)
     #expect(h.asr.transcribeCallCount == 0, "never re-transcribe a recording that crashed us")
     #expect(h.transcriptCoordinator.transcripts.isEmpty)
-    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    // The coordinator deletes on `.abandoned`; the replayer leaves the spool.
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
   }
 
   @Test("the attempt marker is written BEFORE transcribe (crash-loop guard armed)")
@@ -183,7 +220,7 @@ struct RecoverySpoolReplayerTests {
     #expect(markerPresentAtTranscribe, "marker must exist before the risky transcribe runs")
   }
 
-  @Test("decrypt fail (missing key) → failed, deleted, no transcribe")
+  @Test("missing key → failed(.unrecoverable), no transcribe, spool retained")
   func missingKeyFails() async throws {
     let h = Self.makeHarness()
     let id = "nokey-\(UUID().uuidString)"
@@ -191,10 +228,10 @@ struct RecoverySpoolReplayerTests {
     // Destroy the key so decrypt fails closed.
     try h.keyStore.delete(for: id)
     let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
-    #expect(outcome == .failed)
+    #expect(outcome == .failed(.unrecoverable))
     #expect(h.asr.transcribeCallCount == 0)
     #expect(h.transcriptCoordinator.transcripts.isEmpty)
-    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
   }
 
   @Test("Discard during transcribe drops the result — nothing saved (generation guard, R2)")
@@ -226,12 +263,6 @@ struct RecoverySpoolReplayerTests {
 
   @Test("a recovered transcript with NO polish output carries no provider/model stamp (#1305)")
   func nilPolishCarriesNoProviderStamp() async throws {
-    // The snapshot's llmProvider/llmModel describe what was CONFIGURED at
-    // record time, not what ran. This spool's snapshot disables polish
-    // (provider "none"), so `polishedText` is nil — the saved transcript must
-    // not be labeled with any provider, matching the live path's
-    // no-stamp-on-skip contract. Pre-#1305 the replayer stamped the snapshot
-    // values unconditionally.
     let h = Self.makeHarness()
     let id = "stamp-\(UUID().uuidString)"
     try await Self.seedSpool(h, id: id, samples: [0.3, 0.2])
@@ -241,5 +272,107 @@ struct RecoverySpoolReplayerTests {
     #expect(saved.polishedText == nil)
     #expect(saved.llmProvider == nil)
     #expect(saved.llmModel == nil)
+  }
+
+  // MARK: - #1464 §3.3 save-failure retains + clears marker
+
+  @Test("save failure RETAINS the spool + key and clears the marker → .failed(.save)")
+  func saveFailureRetainsAndClearsMarker() async throws {
+    let h = Self.makeHarness(transcriptDir: try Self.unwritableTranscriptDir())
+    let id = "savefail-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.2, 0.4])
+    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    #expect(outcome == .failed(.save(.other)))
+    // The audio is still good — RETAIN it for a next-launch retry, and the marker
+    // must be cleared so the retained spool replays (not read as abandoned).
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+    #expect(!h.spoolStore.hasAttemptMarker(for: id), "marker cleared so next launch replays")
+  }
+
+  @Test("save failure whose marker-clear ALSO throws → .failed(.saveMarkerClearFailed), retained")
+  func saveFailureMarkerClearAlsoFails() async throws {
+    let h = Self.makeHarness(transcriptDir: try Self.unwritableTranscriptDir())
+    let id = "markerfail-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.5])
+    defer { _ = chmod(h.spoolDir.path, 0o700) }  // restore so temp cleanup/GC can proceed
+    // The marker is written before transcribe; flip the spool dir read-only DURING
+    // transcribe so the post-save `deleteAttemptMarker` (removeItem) throws EACCES.
+    h.asr.onTranscribe = { _ = chmod(h.spoolDir.path, 0o500) }
+    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    #expect(outcome == .failed(.saveMarkerClearFailed(.other)))
+    // Retained THIS launch even though next-launch durability is not guaranteed.
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+  }
+
+  // MARK: - #1464 root-cause telemetry
+
+  @Test("missing-key failure emits key_missing and OMITS audio_decrypted / camp_b_candidate")
+  func telemetryKeyMissingOmitsDecrypt() async throws {
+    let h = Self.makeHarness()
+    let id = "tel-nokey-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.6])
+    try h.keyStore.delete(for: id)
+    let box = await Self.capturingTelemetry {
+      _ = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    }
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["outcome"] == "failed")
+    #expect(e.stringProps["reason"] == "key_missing")
+    #expect(e.boolProps["audio_decrypted"] == nil, "not reconstructed ⇒ never emit audio_decrypted")
+    #expect(e.boolProps["camp_b_candidate"] == nil)
+    #expect(e.stringProps["spool_seconds_bucket"] == nil)
+  }
+
+  @Test("transcribe failure on good audio is a Camp B candidate with a failure class")
+  func telemetryTranscribeFailIsCampBCandidate() async throws {
+    let h = Self.makeHarness()
+    let id = "tel-xpc-\(UUID().uuidString)"
+    try await Self.seedSpool(h, id: id, samples: [0.1, 0.2, 0.3])
+    h.asr.transcribeError = XPCASRTransportError.serviceUnreachable
+    let box = await Self.capturingTelemetry {
+      _ = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    }
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["outcome"] == "failed")
+    #expect(e.stringProps["reason"] == "transcribe_error")
+    #expect(e.stringProps["failure_class"] == "xpc_unreachable")
+    #expect(e.boolProps["audio_decrypted"] == true, "reconstruction succeeded ⇒ audio_decrypted")
+    #expect(
+      e.boolProps["camp_b_candidate"] == true, "good audio, failed transcribe ⇒ camp B candidate")
+    #expect(e.stringProps["spool_seconds_bucket"] != nil, "bucket derived from reconstructed count")
+    // Privacy: never a raw NSError domain/code/description on the wire.
+    #expect(e.stringProps["domain"] == nil && e.intProps["code"] == nil)
+    #expect(e.stringProps.values.allSatisfy { !$0.contains("serviceUnreachable") })
+  }
+
+  @Test("deferred (attempt-marker write failed) emits marker_write_failed")
+  func telemetryDeferredEmitsMarkerWriteFailed() async throws {
+    // A spool dir whose PARENT is a regular FILE: the store's re-enforced mkdir is a
+    // soft no-op, but `writeAttemptMarker` can't open its temp file → the replay
+    // defers BEFORE any risky work, so no seeded spool is needed. (chmod-based
+    // read-only can't force this — the store re-chmods the dir to 0700 on init.)
+    let blocker = Self.tempDir().appendingPathComponent("blocker")
+    try Data([0]).write(to: blocker)
+    let badSpoolDir = blocker.appendingPathComponent("spools", isDirectory: true)
+    let transcriptStore = TranscriptStore(directory: Self.tempDir())
+    let replayer = RecoverySpoolReplayer(
+      asrManager: FakeBatchASR(),
+      keyStore: RecoveryKeyStore(backend: .file, fileDirectory: Self.tempDir()),
+      makeSpoolStore: { RecoverySpoolStore(directory: badSpoolDir) },
+      transcriptStore: transcriptStore,
+      transcriptCoordinator: TranscriptCoordinator(store: transcriptStore),
+      keychainManager: KeychainManager(),
+      outputClassifierHolder: OutputClassifierHolder(),
+      currentVocabulary: { (.empty, .empty) })
+    let id = "tel-defer-\(UUID().uuidString)"
+    let box = await Self.capturingTelemetry {
+      let outcome = await replayer.replay(recoverySessionID: id, isAborted: { false })
+      #expect(outcome == .deferred)
+    }
+    let e = try #require(box.recoveryEvents().first)
+    #expect(e.stringProps["outcome"] == "deferred")
+    #expect(e.stringProps["reason"] == "marker_write_failed")
   }
 }

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -71,15 +71,20 @@ struct RecoverySpoolReplayerTests {
     func cancelInFlightLoad() {}
   }
 
-  /// Thread-safe telemetry capture (the hook is `@Sendable`, process-global).
-  final class TelemetryBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var stored: [CapturedTelemetryEvent] = []
-    func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
-    func recoveryEvents() -> [CapturedTelemetryEvent] {
-      lock.withLock { stored.filter { $0.name == "recovery.completed" } }
+  #if DEBUG
+    /// Thread-safe telemetry capture (the hook is `@Sendable`, process-global).
+    /// `CapturedTelemetryEvent` + `testEventHook` are DEBUG-only, so everything that
+    /// touches them is gated — the Release test-target compile (build-check,
+    /// ENABLE_TESTABILITY without DEBUG) must not reference them.
+    final class TelemetryBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func add(_ e: CapturedTelemetryEvent) { lock.withLock { stored.append(e) } }
+      func recoveryEvents() -> [CapturedTelemetryEvent] {
+        lock.withLock { stored.filter { $0.name == "recovery.completed" } }
+      }
     }
-  }
+  #endif
 
   private static func tempDir() -> URL {
     let dir = FileManager.default.temporaryDirectory
@@ -161,17 +166,19 @@ struct RecoverySpoolReplayerTests {
     await withCheckedContinuation { c in writer.finalize(reason: .cleanFinalized) { c.resume() } }
   }
 
-  /// Set the process-global telemetry hook for the duration of `body`, capturing
-  /// every emission. Restores the hook after (the suite is `.serialized`).
-  private static func capturingTelemetry(
-    _ body: () async throws -> Void
-  ) async rethrows -> TelemetryBox {
-    let box = TelemetryBox()
-    TelemetryService.shared.testEventHook = { @Sendable e in box.add(e) }
-    defer { TelemetryService.shared.testEventHook = nil }
-    try await body()
-    return box
-  }
+  #if DEBUG
+    /// Set the process-global telemetry hook for the duration of `body`, capturing
+    /// every emission. Restores the hook after (the suite is `.serialized`).
+    private static func capturingTelemetry(
+      _ body: () async throws -> Void
+    ) async rethrows -> TelemetryBox {
+      let box = TelemetryBox()
+      TelemetryService.shared.testEventHook = { @Sendable e in box.add(e) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      try await body()
+      return box
+    }
+  #endif
 
   @Test("happy path: orphan recovered → saved as isRecovered; replayer does NOT delete")
   func happyPath() async throws {
@@ -307,72 +314,79 @@ struct RecoverySpoolReplayerTests {
   }
 
   // MARK: - #1464 root-cause telemetry
+  // Gated on DEBUG: these read emissions through `testEventHook` (DEBUG-only), so
+  // the Release test-target compile (build-check) never references it.
+  #if DEBUG
 
-  @Test("missing-key failure emits key_missing and OMITS audio_decrypted / camp_b_candidate")
-  func telemetryKeyMissingOmitsDecrypt() async throws {
-    let h = Self.makeHarness()
-    let id = "tel-nokey-\(UUID().uuidString)"
-    try await Self.seedSpool(h, id: id, samples: [0.6])
-    try h.keyStore.delete(for: id)
-    let box = await Self.capturingTelemetry {
-      _ = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    @Test("missing-key failure emits key_missing and OMITS audio_decrypted / camp_b_candidate")
+    func telemetryKeyMissingOmitsDecrypt() async throws {
+      let h = Self.makeHarness()
+      let id = "tel-nokey-\(UUID().uuidString)"
+      try await Self.seedSpool(h, id: id, samples: [0.6])
+      try h.keyStore.delete(for: id)
+      let box = await Self.capturingTelemetry {
+        _ = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+      }
+      let e = try #require(box.recoveryEvents().first)
+      #expect(e.stringProps["outcome"] == "failed")
+      #expect(e.stringProps["reason"] == "key_missing")
+      #expect(
+        e.boolProps["audio_decrypted"] == nil, "not reconstructed ⇒ never emit audio_decrypted")
+      #expect(e.boolProps["camp_b_candidate"] == nil)
+      #expect(e.stringProps["spool_seconds_bucket"] == nil)
     }
-    let e = try #require(box.recoveryEvents().first)
-    #expect(e.stringProps["outcome"] == "failed")
-    #expect(e.stringProps["reason"] == "key_missing")
-    #expect(e.boolProps["audio_decrypted"] == nil, "not reconstructed ⇒ never emit audio_decrypted")
-    #expect(e.boolProps["camp_b_candidate"] == nil)
-    #expect(e.stringProps["spool_seconds_bucket"] == nil)
-  }
 
-  @Test("transcribe failure on good audio is a Camp B candidate with a failure class")
-  func telemetryTranscribeFailIsCampBCandidate() async throws {
-    let h = Self.makeHarness()
-    let id = "tel-xpc-\(UUID().uuidString)"
-    try await Self.seedSpool(h, id: id, samples: [0.1, 0.2, 0.3])
-    h.asr.transcribeError = XPCASRTransportError.serviceUnreachable
-    let box = await Self.capturingTelemetry {
-      _ = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    @Test("transcribe failure on good audio is a Camp B candidate with a failure class")
+    func telemetryTranscribeFailIsCampBCandidate() async throws {
+      let h = Self.makeHarness()
+      let id = "tel-xpc-\(UUID().uuidString)"
+      try await Self.seedSpool(h, id: id, samples: [0.1, 0.2, 0.3])
+      h.asr.transcribeError = XPCASRTransportError.serviceUnreachable
+      let box = await Self.capturingTelemetry {
+        _ = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+      }
+      let e = try #require(box.recoveryEvents().first)
+      #expect(e.stringProps["outcome"] == "failed")
+      #expect(e.stringProps["reason"] == "transcribe_error")
+      #expect(e.stringProps["failure_class"] == "xpc_unreachable")
+      #expect(e.boolProps["audio_decrypted"] == true, "reconstruction succeeded ⇒ audio_decrypted")
+      #expect(
+        e.boolProps["camp_b_candidate"] == true, "good audio, failed transcribe ⇒ camp B candidate")
+      #expect(
+        e.stringProps["spool_seconds_bucket"] != nil, "bucket derived from reconstructed count")
+      // Privacy: never a raw NSError domain/code/description on the wire.
+      #expect(e.stringProps["domain"] == nil && e.intProps["code"] == nil)
+      #expect(e.stringProps.values.allSatisfy { !$0.contains("serviceUnreachable") })
     }
-    let e = try #require(box.recoveryEvents().first)
-    #expect(e.stringProps["outcome"] == "failed")
-    #expect(e.stringProps["reason"] == "transcribe_error")
-    #expect(e.stringProps["failure_class"] == "xpc_unreachable")
-    #expect(e.boolProps["audio_decrypted"] == true, "reconstruction succeeded ⇒ audio_decrypted")
-    #expect(
-      e.boolProps["camp_b_candidate"] == true, "good audio, failed transcribe ⇒ camp B candidate")
-    #expect(e.stringProps["spool_seconds_bucket"] != nil, "bucket derived from reconstructed count")
-    // Privacy: never a raw NSError domain/code/description on the wire.
-    #expect(e.stringProps["domain"] == nil && e.intProps["code"] == nil)
-    #expect(e.stringProps.values.allSatisfy { !$0.contains("serviceUnreachable") })
-  }
 
-  @Test("deferred (attempt-marker write failed) emits marker_write_failed")
-  func telemetryDeferredEmitsMarkerWriteFailed() async throws {
-    // A spool dir whose PARENT is a regular FILE: the store's re-enforced mkdir is a
-    // soft no-op, but `writeAttemptMarker` can't open its temp file → the replay
-    // defers BEFORE any risky work, so no seeded spool is needed. (chmod-based
-    // read-only can't force this — the store re-chmods the dir to 0700 on init.)
-    let blocker = Self.tempDir().appendingPathComponent("blocker")
-    try Data([0]).write(to: blocker)
-    let badSpoolDir = blocker.appendingPathComponent("spools", isDirectory: true)
-    let transcriptStore = TranscriptStore(directory: Self.tempDir())
-    let replayer = RecoverySpoolReplayer(
-      asrManager: FakeBatchASR(),
-      keyStore: RecoveryKeyStore(backend: .file, fileDirectory: Self.tempDir()),
-      makeSpoolStore: { RecoverySpoolStore(directory: badSpoolDir) },
-      transcriptStore: transcriptStore,
-      transcriptCoordinator: TranscriptCoordinator(store: transcriptStore),
-      keychainManager: KeychainManager(),
-      outputClassifierHolder: OutputClassifierHolder(),
-      currentVocabulary: { (.empty, .empty) })
-    let id = "tel-defer-\(UUID().uuidString)"
-    let box = await Self.capturingTelemetry {
-      let outcome = await replayer.replay(recoverySessionID: id, isAborted: { false })
-      #expect(outcome == .deferred)
+    @Test("deferred (attempt-marker write failed) emits marker_write_failed")
+    func telemetryDeferredEmitsMarkerWriteFailed() async throws {
+      // A spool dir whose PARENT is a regular FILE: the store's re-enforced mkdir is a
+      // soft no-op, but `writeAttemptMarker` can't open its temp file → the replay
+      // defers BEFORE any risky work, so no seeded spool is needed. (chmod-based
+      // read-only can't force this — the store re-chmods the dir to 0700 on init.)
+      let blocker = Self.tempDir().appendingPathComponent("blocker")
+      try Data([0]).write(to: blocker)
+      let badSpoolDir = blocker.appendingPathComponent("spools", isDirectory: true)
+      let transcriptStore = TranscriptStore(directory: Self.tempDir())
+      let replayer = RecoverySpoolReplayer(
+        asrManager: FakeBatchASR(),
+        keyStore: RecoveryKeyStore(backend: .file, fileDirectory: Self.tempDir()),
+        makeSpoolStore: { RecoverySpoolStore(directory: badSpoolDir) },
+        transcriptStore: transcriptStore,
+        transcriptCoordinator: TranscriptCoordinator(store: transcriptStore),
+        keychainManager: KeychainManager(),
+        outputClassifierHolder: OutputClassifierHolder(),
+        currentVocabulary: { (.empty, .empty) })
+      let id = "tel-defer-\(UUID().uuidString)"
+      let box = await Self.capturingTelemetry {
+        let outcome = await replayer.replay(recoverySessionID: id, isAborted: { false })
+        #expect(outcome == .deferred)
+      }
+      let e = try #require(box.recoveryEvents().first)
+      #expect(e.stringProps["outcome"] == "deferred")
+      #expect(e.stringProps["reason"] == "marker_write_failed")
     }
-    let e = try #require(box.recoveryEvents().first)
-    #expect(e.stringProps["outcome"] == "deferred")
-    #expect(e.stringProps["reason"] == "marker_write_failed")
-  }
+
+  #endif
 }

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
@@ -102,6 +102,39 @@ struct RecoverySpoolStoreTests {
     #expect(recovered.truncated)
   }
 
+  /// #1464 §3.3 — a crash spool is torn BY DEFINITION. The existing tests tamper a
+  /// full final frame or gap the marker; this covers a LITERALLY truncated final
+  /// frame (the process died mid-write, leaving only the first bytes of the last
+  /// frame). Recovery must keep the valid prefix and report `truncated`.
+  @Test("a literally truncated final frame keeps the valid prefix (crash mid-write)")
+  func recoverKeepsPrefixOnTruncatedFinalFrame() throws {
+    let store = makeStore()
+    let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
+    let c0: [Float] = [0.1, 0.2, 0.3]
+    let c1: [Float] = [0.4, 0.5]
+    let c2: [Float] = [0.6, 0.7, 0.8]
+
+    var data = try RecoverySpoolFileFormat.encodeHeader(
+      RecoverySpoolHeader(
+        cipher: .aesGcm256, recoverySessionID: "torn",
+        createdAt: Date(timeIntervalSince1970: 0), appVersion: "1.0",
+        encryptedSettings: try cipher.sealSettings(snapshot())))
+    data.append(
+      try cipher.encodeAudioFrame(samples: c0, chunkIndex: 0, startSample: 0, nonceCounter: 1))
+    data.append(
+      try cipher.encodeAudioFrame(samples: c1, chunkIndex: 1, startSample: 3, nonceCounter: 2))
+    // The crash cut the final frame mid-write: append only its first few bytes.
+    let full = try cipher.encodeAudioFrame(
+      samples: c2, chunkIndex: 2, startSample: 5, nonceCounter: 3)
+    data.append(full.prefix(4))
+    try data.write(to: store.spoolURL(for: "torn"))
+
+    let recovered = try store.recover(recoverySessionID: "torn", cipher: cipher)
+    #expect(recovered.samples == c0 + c1)
+    #expect(recovered.frameCount == 2)
+    #expect(recovered.truncated)
+  }
+
   @Test("an out-of-sequence terminal marker is truncation, not a clean stop")
   func outOfSequenceMarkerIsTruncation() throws {
     let store = makeStore()


### PR DESCRIPTION
## What & why

Phase 1 of the telemetry-first recovery reshape (#1464, part of the heartpath refactor #1511). Two moves that preserve every keep/delete result **except one intentional bugfix**:

1. **One deletion owner.** Spool/key destruction was spread across three places that had to agree by hand (the replayer, the driver's terminal classifier, and the coordinator). Now `RecoveryCoordinator` is the sole destructor: one private helper + two exhaustive predicates (one for a live recording's ending, one for a launch replay's outcome). `RecordingTerminalKind` + `endedWithoutSaveKind` are deleted; the driver projects the outcome into a narrow public `RecordingRecoveryEnding` so the internal enum never leaks into AppKit.
2. **Root-cause telemetry.** `recovery.completed` now reports a typed reason (not a coarse stage), flags "recording truly gone" vs "good audio, transient transcription hiccup" candidates (`audio_decrypted` + `camp_b_candidate`), never emits raw error detail, and closes the one failure path that was silent before. This is what lets Phase 2/3 decide the retain-vs-retry policy from real field data instead of guessing.

**One net behavior change (a bugfix):** a History-write failure now **retains** the recoverable audio and clears the attempt marker so the next launch replays it — previously it was deleted.

Also included (founder-approved): a small green "Recovered your last recording. Saved to History." notice on the previously-silent success path.

## Validation

- **3,008 tests pass** (full suite), including a real-encrypted-spool replayer suite, real-spool coordinator deletion tests, both delete/retain predicates tested adversarially, per-reason/per-class telemetry through the test hook, the save-retain + forced marker-clear-failure paths, and a launch-visible success-notice render test.
- **Local Codex code-diff review: clean** (no actionable defects).
- **Live crash-recovery UAT on the running dev build:** armed a recording, killed the app mid-recording (orphaned a real 266KB encrypted spool), relaunched → the recording transcribed and landed in History (`isRecovered: true`), and the spool + key were deleted by the new single destructor. A normal dictation also confirmed the refactored durable-save deletion path runs healthy live (0.99s end-to-end).

Part of #1464
Part of #1511
