### PR TITLE
feat(settings): remembered top/bottom position for the recording pill

### DIFF
--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -193,6 +193,8 @@ final class PipelineSettingsSync {
       break  // #1247: kernel pulls this live via `dictationAudioArchiveOptInProvider` — no push needed here.
     case .appearance:
       break  // UI-only; applied to NSApp.appearance by the app shell (#1047).
+    case .overlayPillPosition:
+      break  // #1341: UI-only; read at fresh panel creation.
     case .showBluetoothTips:
       break  // #1480: UI-only; read by BluetoothAwarenessPresenter, no pipeline sync.
     }

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -172,6 +172,21 @@ final class RecordingOverlayPanel {
   /// as a glitch (founder feedback, live-tested 2026-07-17). A fresh
   /// appearance in `showPanel` stays instant on purpose: there is no "old
   /// position" for a brand-new panel to visibly jump from.
+  ///
+  /// SCOPE: Bottom only (founder decision, 2026-07-17). Top's fresh-Y formula
+  /// is a fixed offset from the menu bar, so it was never affected by the
+  /// bug this feature exists to fix (the Dock-reservation gap only shows up
+  /// at the BOTTOM of a fullscreen Space). Reacting for Top too surfaced a
+  /// real but narrow bug: Top's origin gets height-clamped so a tall panel
+  /// (the 92pt recording capsule) doesn't poke above the screen, and an
+  /// inherited-y transition to a SHORTER panel (the ~44pt polishing pill)
+  /// carries that taller clamp forward — a later Space change would then
+  /// recompute the clamp for the shorter height and visibly jump the panel
+  /// (Codex grounded review r6). Rather than chase that height/clamp
+  /// interaction through more rounds for an edge that was never broken,
+  /// Top is excluded from reactive repositioning entirely; the founder
+  /// explicitly asked not to touch Top's existing behavior in the first
+  /// place.
   private func repositionForActiveSpaceChange() {
     // Reuses whichever edge THIS panel was actually created with — never
     // `positionProvider()` live — so a settings change made while the panel
@@ -180,7 +195,7 @@ final class RecordingOverlayPanel {
     // would also desync the SwiftUI content's baked-in `.frame(alignment:)`
     // from wherever the window got repositioned to, reintroducing the
     // recording/polishing misalignment bug this same PR fixed.
-    guard let panel, let position = activePanelPosition else { return }
+    guard let panel, let position = activePanelPosition, position == .bottom else { return }
     if wasManuallyDragged { return }
     // The pill supports drag-to-relocate (`isMovableByWindowBackground`) —
     // if the panel's live origin no longer matches the spot WE last put it,

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -94,6 +94,17 @@ final class RecordingOverlayPanel {
   /// forget to wire it.
   private let positionProvider: () -> OverlayPillPosition
 
+  /// The Top/Bottom edge actually chosen for the CURRENT panel, captured once
+  /// at fresh-appearance time. `repositionForActiveSpaceChange()` reuses this
+  /// — never re-reads `positionProvider()` — so that changing the setting
+  /// while a panel is visible can't retroactively snap it to the other edge
+  /// mid-Space-swipe (Codex grounded review, 2026-07-17); the SwiftUI content
+  /// alignment baked in at creation time (`createPanel`'s `.frame(alignment:)`)
+  /// would otherwise mismatch the edge the panel got repositioned to,
+  /// reintroducing the recording/polishing misalignment bug this same PR
+  /// fixed. `nil` when nothing is showing.
+  private var activePanelPosition: OverlayPillPosition?
+
   /// #1341 follow-up: fullscreen state is a per-Space property, and macOS
   /// treats going fullscreen as switching to a NEW Space/"desktop" rather than
   /// changing the current one. A panel that started in windowed mode and then
@@ -140,7 +151,14 @@ final class RecordingOverlayPanel {
   /// appearance in `showPanel` stays instant on purpose: there is no "old
   /// position" for a brand-new panel to visibly jump from.
   private func repositionForActiveSpaceChange() {
-    guard let panel else { return }
+    // Reuses whichever edge THIS panel was actually created with — never
+    // `positionProvider()` live — so a settings change made while the panel
+    // is already visible can't retroactively snap it to the other edge on
+    // the next Space swipe (Codex grounded review, 2026-07-17). Doing so
+    // would also desync the SwiftUI content's baked-in `.frame(alignment:)`
+    // from wherever the window got repositioned to, reintroducing the
+    // recording/polishing misalignment bug this same PR fixed.
+    guard let panel, let position = activePanelPosition else { return }
     guard
       let targetScreen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
         ?? NSScreen.main
@@ -150,19 +168,22 @@ final class RecordingOverlayPanel {
     let resolvedHeight = panel.frame.height
     let x = targetScreen.visibleFrame.midX - resolvedWidth / 2
     let panelY = clampedOriginY(
-      requestedY: computeRequestedY(on: targetScreen), resolvedHeight: resolvedHeight,
-      on: targetScreen)
+      requestedY: computeRequestedY(on: targetScreen, position: position),
+      resolvedHeight: resolvedHeight, on: targetScreen)
     panel.setFrame(
       NSRect(x: x, y: panelY, width: resolvedWidth, height: resolvedHeight),
       display: true, animate: true
     )
   }
 
-  /// Shared Top/Bottom fresh-position formula — used both when a panel first
+  /// Shared Top/Bottom position formula — used both when a panel first
   /// appears and when `repositionForActiveSpaceChange()` re-anchors a panel
-  /// that is already showing.
-  private func computeRequestedY(on screen: NSScreen) -> CGFloat {
-    switch positionProvider() {
+  /// that is already showing. Takes `position` explicitly (never reads
+  /// `positionProvider()` itself) so callers control whether they want the
+  /// live setting (fresh appearance) or the edge already committed to the
+  /// current panel (Space-change reposition).
+  private func computeRequestedY(on screen: NSScreen, position: OverlayPillPosition) -> CGFloat {
+    switch position {
     case .top: return screen.visibleFrame.maxY - 60
     // #1341 follow-up: `visibleFrame` is Dock-reserved space as this
     // background app sees it — it does NOT shrink when a DIFFERENT app is in
@@ -872,6 +893,13 @@ final class RecordingOverlayPanel {
     hostingView.frame = size
     p.contentView = hostingView
 
+    // Captured on EVERY call (fresh or inherited-`y`) so `activePanelPosition`
+    // always reflects whichever edge is governing the panel that's about to be
+    // visible — `repositionForActiveSpaceChange()` reuses this instead of
+    // re-reading `positionProvider()` live (Codex grounded review, 2026-07-17).
+    let position = positionProvider()
+    activePanelPosition = position
+
     let x = targetScreen.visibleFrame.midX - resolvedWidth / 2
     let requestedY: CGFloat
     if let y {
@@ -881,7 +909,7 @@ final class RecordingOverlayPanel {
       // transition) always keeps its current position regardless of setting.
       // `repositionForActiveSpaceChange()` is what keeps an ALREADY-showing
       // panel correct as the user swipes between Spaces mid-recording.
-      requestedY = computeRequestedY(on: targetScreen)
+      requestedY = computeRequestedY(on: targetScreen, position: position)
     }
     let panelY = clampedOriginY(
       requestedY: requestedY, resolvedHeight: resolvedHeight, on: targetScreen)
@@ -904,8 +932,22 @@ final class RecordingOverlayPanel {
   /// keyboard-focused window) so a fullscreen Space on one display never
   /// pushes the pill into Dock territory on a different, non-fullscreen
   /// display.
+  ///
+  /// KNOWN SCOPE BOUNDARY (Codex grounded review, 2026-07-17): without
+  /// Accessibility trust this always returns `false`, so Bottom keeps the
+  /// pre-existing Dock-safe `visibleFrame.minY` position in fullscreen for
+  /// those users — same as before this fix, not worse. EnviousWispr already
+  /// treats an Accessibility-denied user as a first-class supported flow
+  /// (`PasteCascadeExecutor`'s clipboard-only fallback), so this doesn't
+  /// regress anyone; it just doesn't reach that subset yet. The other two
+  /// permission-free signals investigated (`CGWindowListCopyWindowInfo`,
+  /// `NSApplication.currentSystemPresentationOptions`) don't reliably work
+  /// either (see the two paragraphs above and 2026-07-17 session notes) — a
+  /// real permission-independent fix would mean requesting Screen Recording
+  /// access, which is a product scope decision, not something to fold into
+  /// a positioning bug fix.
   private func isFrontmostAppFullScreen(on screen: NSScreen) -> Bool {
-    guard screen == NSScreen.main,
+    guard screen == NSScreen.main, AXIsProcessTrusted(),
       let frontApp = NSWorkspace.shared.frontmostApplication
     else { return false }
     let axApp = AXUIElementCreateApplication(frontApp.processIdentifier)
@@ -1089,6 +1131,7 @@ final class RecordingOverlayPanel {
 
     guard let panelToClose = panel else { return }
     panel = nil
+    activePanelPosition = nil
 
     // Flush pending CA transactions before releasing the panel.
     // RecordingOverlayView has a running .task loop updating audioLevel every 50ms

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -86,6 +86,16 @@ final class RecordingOverlayPanel {
   private var bluetoothAwarenessCloseHandler: (() -> Void)?
   private var bluetoothAwarenessAdjustSettingsHandler: (() -> Void)?
 
+  /// #1341: where a FRESH panel opens (Top or Bottom of the active screen).
+  /// Read once per fresh appearance inside `showPanel`; never live-patches an
+  /// already-showing panel. Injected via the initializer rather than a mutable
+  /// setter so the composition root cannot forget to wire it.
+  private let positionProvider: () -> OverlayPillPosition
+
+  init(positionProvider: @escaping () -> OverlayPillPosition = { .top }) {
+    self.positionProvider = positionProvider
+  }
+
   // MARK: - Intent-driven API
 
   func setGrantHandler(_ handler: @escaping () -> Void) {
@@ -669,8 +679,8 @@ final class RecordingOverlayPanel {
   }
 
   /// Transition an existing panel from polishing/processing to recording mode.
-  /// Mirrors transitionToPolishing() — tears down the current panel and creates
-  /// a recording panel at the same position on the next run loop cycle.
+  /// A fresh recording starts a new presentation and re-anchors to the user's
+  /// configured Top or Bottom position on the next run-loop cycle.
   private func transitionToRecording(
     audioLevelProvider: @escaping () -> Float,
     recordingElapsedProvider: @escaping () -> TimeInterval? = { nil },
@@ -678,11 +688,10 @@ final class RecordingOverlayPanel {
   ) {
     guard let existingPanel = panel else { return }
     clearRecordingNotice()  // #1060 (Codex P3): fresh session starts with no stale notice.
-    // The recording pill always appears at its canonical top slot — do NOT inherit
-    // the outgoing panel's origin. A taller panel (e.g. the #1480 Bluetooth card)
-    // sits lower, so reusing its origin would drop the pill to mid-screen (#1480
-    // live UAT). A fresh recording is a new lifecycle, not a continuation of the
-    // superseded panel, so it re-anchors to the default position.
+    // A fresh recording is a new lifecycle, so it does not inherit the outgoing
+    // panel's origin. `showPanel(y: nil)` re-anchors it to the user's configured
+    // Top or Bottom position. A taller panel (e.g. the #1480 Bluetooth card) sits
+    // lower, so reusing its origin would drop the pill to mid-screen (#1480 live UAT).
     panel = nil
     autoDismissTask?.cancel()
     autoDismissTask = nil
@@ -758,7 +767,17 @@ final class RecordingOverlayPanel {
     p.contentView = hostingView
 
     let x = targetScreen.visibleFrame.midX - resolvedWidth / 2
-    let requestedY = y ?? (targetScreen.visibleFrame.maxY - 60)
+    let requestedY: CGFloat
+    if let y {
+      requestedY = y
+    } else {
+      // #1341: fresh appearance only — an inherited `y` (mid-session
+      // transition) always keeps its current position regardless of setting.
+      switch positionProvider() {
+      case .top: requestedY = targetScreen.visibleFrame.maxY - 60
+      case .bottom: requestedY = targetScreen.visibleFrame.minY + 20
+      }
+    }
     // #1060 (Codex P2): keep the whole panel within the visible frame. The
     // recording pill's frame is tall enough to host the cap-warning banner, and
     // positioning by the bottom origin would push the top above the visible

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -893,22 +893,26 @@ final class RecordingOverlayPanel {
     hostingView.frame = size
     p.contentView = hostingView
 
-    // Captured on EVERY call (fresh or inherited-`y`) so `activePanelPosition`
-    // always reflects whichever edge is governing the panel that's about to be
-    // visible — `repositionForActiveSpaceChange()` reuses this instead of
-    // re-reading `positionProvider()` live (Codex grounded review, 2026-07-17).
-    let position = positionProvider()
-    activePanelPosition = position
-
     let x = targetScreen.visibleFrame.midX - resolvedWidth / 2
     let requestedY: CGFloat
     if let y {
       requestedY = y
+      // #1341 follow-up: inherited `y` means this panel is CONTINUING the
+      // same on-screen presentation (e.g. recording -> polishing), not
+      // starting a new one — `activePanelPosition` is deliberately left
+      // untouched here. Re-reading `positionProvider()` on this path was a
+      // real bug (Codex grounded review r3, 2026-07-17): a setting change
+      // made while the panel was visible would get picked up on the NEXT
+      // inherited-y transition, desyncing `activePanelPosition` from the
+      // edge the panel's SwiftUI content is actually aligned for, and the
+      // next Space swipe would then jump the panel to the wrong edge.
     } else {
-      // #1341: fresh appearance only — an inherited `y` (mid-session
-      // transition) always keeps its current position regardless of setting.
-      // `repositionForActiveSpaceChange()` is what keeps an ALREADY-showing
-      // panel correct as the user swipes between Spaces mid-recording.
+      // #1341: fresh appearance only — captures the edge for THIS panel's
+      // lifetime. `repositionForActiveSpaceChange()` reuses it; an inherited
+      // `y` transition above leaves it alone; only a fresh appearance is
+      // allowed to change which edge `activePanelPosition` points at.
+      let position = positionProvider()
+      activePanelPosition = position
       requestedY = computeRequestedY(on: targetScreen, position: position)
     }
     let panelY = clampedOriginY(

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -87,13 +87,109 @@ final class RecordingOverlayPanel {
   private var bluetoothAwarenessAdjustSettingsHandler: (() -> Void)?
 
   /// #1341: where a FRESH panel opens (Top or Bottom of the active screen).
-  /// Read once per fresh appearance inside `showPanel`; never live-patches an
-  /// already-showing panel. Injected via the initializer rather than a mutable
-  /// setter so the composition root cannot forget to wire it.
+  /// The Top/Bottom SETTING itself is read once per fresh appearance inside
+  /// `showPanel` — flipping the setting mid-recording does not retroactively
+  /// move an already-showing panel between Top and Bottom. Injected via the
+  /// initializer rather than a mutable setter so the composition root cannot
+  /// forget to wire it.
   private let positionProvider: () -> OverlayPillPosition
+
+  /// #1341 follow-up: fullscreen state is a per-Space property, and macOS
+  /// treats going fullscreen as switching to a NEW Space/"desktop" rather than
+  /// changing the current one. A panel that started in windowed mode and then
+  /// follows the user (`.canJoinAllSpaces`) into a fullscreen Space — or back
+  /// out — keeps its ORIGINAL Y forever unless something re-runs the position
+  /// math. Observing Space changes and repositioning the live panel (same
+  /// Top/Bottom setting, freshly evaluated fullscreen state) is what makes the
+  /// pill track the user across a trackpad swipe between Spaces mid-recording
+  /// instead of freezing at whatever was correct for the Space it started in.
+  /// Written once in `init` before any other access is possible, read once in
+  /// `deinit` after which nothing else can touch it — a single-touch lifecycle
+  /// handoff, not a shared-mutation risk. `deinit` is nonisolated even on a
+  /// `@MainActor` class, so the property needs this to be readable there.
+  private nonisolated(unsafe) var spaceChangeObserver: NSObjectProtocol?
 
   init(positionProvider: @escaping () -> OverlayPillPosition = { .top }) {
     self.positionProvider = positionProvider
+    // Same `queue: .main` + `MainActor.assumeIsolated` shape as
+    // `UpdateTriggerCoordinator.start()`'s wake observer — the notification
+    // center guarantees this callback runs on the main thread, so hopping
+    // through a `Task` first only adds a scheduling round-trip and delays how
+    // fast the pill can react to the Space switch.
+    spaceChangeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+      forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated { self?.repositionForActiveSpaceChange() }
+    }
+  }
+
+  deinit {
+    if let spaceChangeObserver {
+      NSWorkspace.shared.notificationCenter.removeObserver(spaceChangeObserver)
+    }
+  }
+
+  /// Recompute and apply the current panel's frame using the same formula as
+  /// a fresh appearance. No-op when nothing is showing. Only geometry moves —
+  /// elapsed timer, audio level, and every other piece of live state are
+  /// untouched. Animated (`animate: true`): repositioning a panel that is
+  /// ALREADY visible and settled needs to read as an intentional glide, not a
+  /// snap-to-new-spot jump — the panel is already on-screen at its old
+  /// position by the time this notification fires, so an instant jump reads
+  /// as a glitch (founder feedback, live-tested 2026-07-17). A fresh
+  /// appearance in `showPanel` stays instant on purpose: there is no "old
+  /// position" for a brand-new panel to visibly jump from.
+  private func repositionForActiveSpaceChange() {
+    guard let panel else { return }
+    guard
+      let targetScreen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+        ?? NSScreen.main
+        ?? NSScreen.screens.first
+    else { return }
+    let resolvedWidth = panel.frame.width
+    let resolvedHeight = panel.frame.height
+    let x = targetScreen.visibleFrame.midX - resolvedWidth / 2
+    let panelY = clampedOriginY(
+      requestedY: computeRequestedY(on: targetScreen), resolvedHeight: resolvedHeight,
+      on: targetScreen)
+    panel.setFrame(
+      NSRect(x: x, y: panelY, width: resolvedWidth, height: resolvedHeight),
+      display: true, animate: true
+    )
+  }
+
+  /// Shared Top/Bottom fresh-position formula — used both when a panel first
+  /// appears and when `repositionForActiveSpaceChange()` re-anchors a panel
+  /// that is already showing.
+  private func computeRequestedY(on screen: NSScreen) -> CGFloat {
+    switch positionProvider() {
+    case .top: return screen.visibleFrame.maxY - 60
+    // #1341 follow-up: `visibleFrame` is Dock-reserved space as this
+    // background app sees it — it does NOT shrink when a DIFFERENT app is in
+    // native fullscreen and the Dock is actually hidden from view. Confirmed
+    // empirically (2026-07-17): `visibleFrame` stayed identical between
+    // windowed and fullscreen, leaving an ~85pt unused gap between the pill
+    // and the true screen bottom during fullscreen. When the frontmost app is
+    // genuinely fullscreen on this screen, drop all the way to the true
+    // screen edge instead; otherwise keep the existing Dock-safe flush
+    // position.
+    case .bottom:
+      return isFrontmostAppFullScreen(on: screen) ? screen.frame.minY : screen.visibleFrame.minY
+    }
+  }
+
+  /// #1060 (Codex P2): keep the whole panel within the visible frame. The
+  /// recording pill's frame is tall enough to host the cap-warning banner, and
+  /// positioning by the bottom origin would push the top above the visible
+  /// frame (clipping under the menu bar) on a normal recording start. Clamp so
+  /// the top never exceeds the frame — small panels (≤ the default 60pt
+  /// offset) are unaffected. Shared by fresh appearance and by
+  /// `repositionForActiveSpaceChange()` so the guard can't drift between them.
+  private func clampedOriginY(requestedY: CGFloat, resolvedHeight: CGFloat, on screen: NSScreen)
+    -> CGFloat
+  {
+    let maxOriginY = screen.visibleFrame.maxY - resolvedHeight - 8
+    return min(requestedY, maxOriginY)
   }
 
   // MARK: - Intent-driven API
@@ -432,10 +528,20 @@ final class RecordingOverlayPanel {
       noticeState: noticeState
     )
     // Fixed frame accommodating normal (185x44), locked (120x64), and the #1060
-    // notice-banner expansion (a 2-line banner under the pill). Content is
-    // centered and the capsule self-sizes; showPanel clamps the origin so the
-    // taller frame never clips under the menu bar (Codex P2).
-    .frame(width: 185, height: 92)
+    // notice-banner expansion (a 2-line banner under the pill); showPanel clamps
+    // the origin so the taller frame never clips under the menu bar (Codex P2).
+    // #1341 follow-up: in Top position content stays centered (unchanged
+    // behavior). In Bottom position content is bottom-aligned so the panel's Y
+    // origin IS the pill's visible bottom edge — without this, the 92pt frame
+    // centered a ~44pt capsule, leaving 24pt of invisible space below it, which
+    // both muted the Bottom offset change and made the polishing pill (which has
+    // no such gap) visibly misaligned with the recording pill it replaces. A
+    // notice banner now grows upward from the stable bottom edge instead of
+    // pushing the capsule down.
+    .frame(
+      width: 185, height: 92,
+      alignment: positionProvider() == .bottom ? .bottom : .center
+    )
     showPanel(content: overlayView, width: 185, height: 92, y: y)
   }
 
@@ -773,23 +879,55 @@ final class RecordingOverlayPanel {
     } else {
       // #1341: fresh appearance only — an inherited `y` (mid-session
       // transition) always keeps its current position regardless of setting.
-      switch positionProvider() {
-      case .top: requestedY = targetScreen.visibleFrame.maxY - 60
-      case .bottom: requestedY = targetScreen.visibleFrame.minY + 20
-      }
+      // `repositionForActiveSpaceChange()` is what keeps an ALREADY-showing
+      // panel correct as the user swipes between Spaces mid-recording.
+      requestedY = computeRequestedY(on: targetScreen)
     }
-    // #1060 (Codex P2): keep the whole panel within the visible frame. The
-    // recording pill's frame is tall enough to host the cap-warning banner, and
-    // positioning by the bottom origin would push the top above the visible
-    // frame (clipping under the menu bar) on a normal recording start. Clamp the
-    // origin so the top never exceeds the frame. Small panels (≤ the default
-    // 60 pt offset) are unaffected.
-    let maxOriginY = targetScreen.visibleFrame.maxY - resolvedHeight - 8
-    let panelY = min(requestedY, maxOriginY)
+    let panelY = clampedOriginY(
+      requestedY: requestedY, resolvedHeight: resolvedHeight, on: targetScreen)
     p.setFrameOrigin(NSPoint(x: x, y: panelY))
 
     p.orderFrontRegardless()
     self.panel = p
+  }
+
+  /// #1341: is the CURRENT frontmost app genuinely in native macOS fullscreen
+  /// on `screen`? `NSScreen.visibleFrame` does not answer this for a
+  /// background/accessory app — it keeps reporting the regular-desktop
+  /// Dock reservation regardless of another app's fullscreen state (confirmed
+  /// empirically 2026-07-17; `NSApplication.currentSystemPresentationOptions`
+  /// also does not update for `LSUIElement` apps — a known AppKit limitation).
+  /// The Accessibility attribute on the frontmost app's own focused window is
+  /// the one signal that actually flips correctly, and is available to us
+  /// because EnviousWispr is non-sandboxed and already holds Accessibility
+  /// trust for paste. Gated to `screen == .main` (the screen holding the
+  /// keyboard-focused window) so a fullscreen Space on one display never
+  /// pushes the pill into Dock territory on a different, non-fullscreen
+  /// display.
+  private func isFrontmostAppFullScreen(on screen: NSScreen) -> Bool {
+    guard screen == NSScreen.main,
+      let frontApp = NSWorkspace.shared.frontmostApplication
+    else { return false }
+    let axApp = AXUIElementCreateApplication(frontApp.processIdentifier)
+    var focusedWindow: AnyObject?
+    guard
+      AXUIElementCopyAttributeValue(axApp, kAXFocusedWindowAttribute as CFString, &focusedWindow)
+        == .success,
+      let focusedWindow
+    else { return false }
+    // `AXUIElement` is a CFTypeRef-family type: neither `as!` nor `as?` performs
+    // a real dynamic type check here (verified empirically — both silently
+    // "succeed" on a wrong CF type instead of crashing or returning nil), so a
+    // checked cast would only be misleading. `kAXFocusedWindowAttribute` is
+    // documented to always yield an AXUIElement on `.success`; the subsequent
+    // AX call is what actually fails gracefully if that contract is ever broken.
+    let window = focusedWindow as! AXUIElement
+    var fullScreenValue: AnyObject?
+    guard
+      AXUIElementCopyAttributeValue(window, "AXFullScreen" as CFString, &fullScreenValue)
+        == .success
+    else { return false }
+    return (fullScreenValue as? Bool) ?? false
   }
 
   /// Update the lock state reactively. Called by the former root state when

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -105,6 +105,16 @@ final class RecordingOverlayPanel {
   /// fixed. `nil` when nothing is showing.
   private var activePanelPosition: OverlayPillPosition?
 
+  /// The origin WE last set programmatically, whether from a fresh appearance
+  /// or a prior Space-change reposition. The panel has `isMovableByWindowBackground
+  /// = true` (an existing, user-facing drag-to-relocate feature) — comparing
+  /// the panel's LIVE origin against this before an automatic reposition is
+  /// how `repositionForActiveSpaceChange()` tells "the user dragged this"
+  /// apart from "nothing has touched it since we last placed it," so a Space
+  /// swipe never silently undoes a manual drag (Codex grounded review r4,
+  /// 2026-07-17). `nil` when nothing is showing.
+  private var lastProgrammaticOrigin: NSPoint?
+
   /// #1341 follow-up: fullscreen state is a per-Space property, and macOS
   /// treats going fullscreen as switching to a NEW Space/"desktop" rather than
   /// changing the current one. A panel that started in windowed mode and then
@@ -159,6 +169,15 @@ final class RecordingOverlayPanel {
     // from wherever the window got repositioned to, reintroducing the
     // recording/polishing misalignment bug this same PR fixed.
     guard let panel, let position = activePanelPosition else { return }
+    // The pill supports drag-to-relocate (`isMovableByWindowBackground`) —
+    // if the panel's live origin no longer matches the spot WE last put it,
+    // the user moved it since, and an automatic Space-change reposition must
+    // not silently undo that (Codex grounded review r4, 2026-07-17). Stays
+    // wherever the user left it for the rest of this presentation; the next
+    // fresh appearance re-anchors normally.
+    if let lastProgrammaticOrigin, !panel.frame.origin.isApproximately(lastProgrammaticOrigin) {
+      return
+    }
     guard
       let targetScreen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
         ?? NSScreen.main
@@ -174,6 +193,7 @@ final class RecordingOverlayPanel {
       NSRect(x: x, y: panelY, width: resolvedWidth, height: resolvedHeight),
       display: true, animate: true
     )
+    lastProgrammaticOrigin = NSPoint(x: x, y: panelY)
   }
 
   /// Shared Top/Bottom position formula — used both when a panel first
@@ -918,6 +938,7 @@ final class RecordingOverlayPanel {
     let panelY = clampedOriginY(
       requestedY: requestedY, resolvedHeight: resolvedHeight, on: targetScreen)
     p.setFrameOrigin(NSPoint(x: x, y: panelY))
+    lastProgrammaticOrigin = NSPoint(x: x, y: panelY)
 
     p.orderFrontRegardless()
     self.panel = p
@@ -1136,6 +1157,7 @@ final class RecordingOverlayPanel {
     guard let panelToClose = panel else { return }
     panel = nil
     activePanelPosition = nil
+    lastProgrammaticOrigin = nil
 
     // Flush pending CA transactions before releasing the panel.
     // RecordingOverlayView has a running .task loop updating audioLevel every 50ms
@@ -1149,6 +1171,16 @@ final class RecordingOverlayPanel {
     // The local `panelToClose` retain keeps the panel alive through the flush.
     CATransaction.flush()
     panelToClose.close()
+  }
+}
+
+extension NSPoint {
+  /// #1341: origin comparison for drag detection — a strict `==` would false-
+  /// positive on the sub-point floating-point noise `setFrame`/display-scale
+  /// rounding can introduce between what we requested and what AppKit reports
+  /// back, reading as "the user dragged it" when nothing moved.
+  fileprivate func isApproximately(_ other: NSPoint, tolerance: CGFloat = 0.5) -> Bool {
+    abs(x - other.x) <= tolerance && abs(y - other.y) <= tolerance
   }
 }
 

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -105,15 +105,27 @@ final class RecordingOverlayPanel {
   /// fixed. `nil` when nothing is showing.
   private var activePanelPosition: OverlayPillPosition?
 
-  /// The origin WE last set programmatically, whether from a fresh appearance
-  /// or a prior Space-change reposition. The panel has `isMovableByWindowBackground
-  /// = true` (an existing, user-facing drag-to-relocate feature) — comparing
-  /// the panel's LIVE origin against this before an automatic reposition is
-  /// how `repositionForActiveSpaceChange()` tells "the user dragged this"
-  /// apart from "nothing has touched it since we last placed it," so a Space
-  /// swipe never silently undoes a manual drag (Codex grounded review r4,
-  /// 2026-07-17). `nil` when nothing is showing.
+  /// The origin WE last set programmatically. Used only to DETECT a manual
+  /// drag (`isMovableByWindowBackground = true`, an existing feature) by
+  /// comparing against the panel's live origin — `wasManuallyDragged` below
+  /// is the authoritative, sticky record of that fact once detected. `nil`
+  /// when nothing is showing.
   private var lastProgrammaticOrigin: NSPoint?
+
+  /// True once the user has manually dragged the panel during the CURRENT
+  /// presentation. Sticky and carried across inherited-`y` transitions (e.g.
+  /// recording -> polishing) on purpose: those transitions tear down and
+  /// recreate the `NSPanel` object, but from the user's perspective it's the
+  /// same pill continuing, so "I dragged this" must not be forgotten just
+  /// because a new window object got created underneath it. Checked BEFORE
+  /// `lastProgrammaticOrigin` comparison in both `repositionForActiveSpaceChange()`
+  /// and the inherited-`y` capture — a continuous origin-comparison alone was
+  /// tried first and broke twice (Codex grounded review r4 found the Space-
+  /// change path re-anchoring over a drag; r5 found the SAME root cause one
+  /// level up, an inherited-`y` transition silently re-baselining
+  /// `lastProgrammaticOrigin` to the dragged spot and erasing the signal).
+  /// Reset to `false` only on a genuine fresh appearance (`y == nil`).
+  private var wasManuallyDragged = false
 
   /// #1341 follow-up: fullscreen state is a per-Space property, and macOS
   /// treats going fullscreen as switching to a NEW Space/"desktop" rather than
@@ -169,6 +181,7 @@ final class RecordingOverlayPanel {
     // from wherever the window got repositioned to, reintroducing the
     // recording/polishing misalignment bug this same PR fixed.
     guard let panel, let position = activePanelPosition else { return }
+    if wasManuallyDragged { return }
     // The pill supports drag-to-relocate (`isMovableByWindowBackground`) —
     // if the panel's live origin no longer matches the spot WE last put it,
     // the user moved it since, and an automatic Space-change reposition must
@@ -176,6 +189,7 @@ final class RecordingOverlayPanel {
     // wherever the user left it for the rest of this presentation; the next
     // fresh appearance re-anchors normally.
     if let lastProgrammaticOrigin, !panel.frame.origin.isApproximately(lastProgrammaticOrigin) {
+      wasManuallyDragged = true
       return
     }
     guard
@@ -926,6 +940,17 @@ final class RecordingOverlayPanel {
       // inherited-y transition, desyncing `activePanelPosition` from the
       // edge the panel's SwiftUI content is actually aligned for, and the
       // next Space swipe would then jump the panel to the wrong edge.
+      //
+      // Same reasoning applies to drag detection (Codex grounded review r5,
+      // 2026-07-17): if the outgoing panel's Y no longer matches where WE
+      // last put it, the user dragged it, and that fact must survive into
+      // the new panel object this transition creates — check and latch
+      // `wasManuallyDragged` HERE, before `lastProgrammaticOrigin` gets
+      // rewritten below to the (possibly dragged) inherited position, or the
+      // mismatch that proves the drag happened is gone for good.
+      if let lastProgrammaticOrigin, abs(y - lastProgrammaticOrigin.y) > 0.5 {
+        wasManuallyDragged = true
+      }
     } else {
       // #1341: fresh appearance only — captures the edge for THIS panel's
       // lifetime. `repositionForActiveSpaceChange()` reuses it; an inherited
@@ -934,6 +959,10 @@ final class RecordingOverlayPanel {
       let position = positionProvider()
       activePanelPosition = position
       requestedY = computeRequestedY(on: targetScreen, position: position)
+      // A genuinely NEW presentation starts clean — any earlier drag doesn't
+      // carry over, matching the existing "position resets on next
+      // appearance" contract the settings copy already promises.
+      wasManuallyDragged = false
     }
     let panelY = clampedOriginY(
       requestedY: requestedY, resolvedHeight: resolvedHeight, on: targetScreen)
@@ -1158,6 +1187,7 @@ final class RecordingOverlayPanel {
     panel = nil
     activePanelPosition = nil
     lastProgrammaticOrigin = nil
+    wasManuallyDragged = false
 
     // Flush pending CA transactions before releasing the panel.
     // RecordingOverlayView has a running .task loop updating audioLevel every 50ms

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -36,6 +36,7 @@ enum SettingsProjection {
     case streamingASR = "streaming_asr"
     case warmEnginePolicy = "warm_engine_policy"
     case appearance = "appearance"
+    case overlayPillPosition = "overlay_pill_position"
     case toggleHotkeyShape = "toggle_hotkey_shape"
     case pushToTalkHotkeyShape = "push_to_talk_hotkey_shape"
     case cancelHotkeyShape = "cancel_hotkey_shape"
@@ -77,6 +78,7 @@ enum SettingsProjection {
     case .useStreamingASR: return .streamingASR
     case .warmEnginePolicy: return .warmEnginePolicy
     case .appearance: return .appearance
+    case .overlayPillPosition: return .overlayPillPosition
     case .toggleKeyCode, .toggleModifiers: return .toggleHotkeyShape
     case .pushToTalkKeyCode, .pushToTalkModifiers: return .pushToTalkHotkeyShape
     case .cancelKeyCode, .cancelModifiers: return .cancelHotkeyShape
@@ -117,6 +119,7 @@ enum SettingsProjection {
     case .streamingASR: return onOff(settings.useStreamingASR)
     case .warmEnginePolicy: return settings.warmEnginePolicy.rawValue
     case .appearance: return settings.appearancePreference.rawValue
+    case .overlayPillPosition: return settings.overlayPillPosition.rawValue
     case .toggleHotkeyShape: return hotkeyShape(settings.toggleKeyCode)
     case .pushToTalkHotkeyShape: return hotkeyShape(settings.pushToTalkKeyCode)
     case .cancelHotkeyShape: return hotkeyShape(settings.cancelKeyCode)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -96,7 +96,7 @@ public final class WisprBootstrapper {
     // composition root. This is the ONLY KeychainManager that gets `.live`; it carries
     // the sink for the legacy-key-cleanup (Q3.3) + cloud-prewarm (A6) quiet limbs.
     let keychainManager = KeychainManager(telemetrySink: .live)
-    let recordingOverlay = RecordingOverlayPanel()
+    let recordingOverlay = RecordingOverlayPanel(positionProvider: { settings.overlayPillPosition })
     let audioDeviceList = AudioDeviceList()
     let inputDevicePreferenceReconciler = InputDevicePreferenceReconciler(settings: settings)
     audioDeviceList.onDevicesChanged = { [weak inputDevicePreferenceReconciler] devices in

--- a/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
@@ -32,6 +32,22 @@ struct AppearanceSettingsView: View {
           }
         }
       }
+
+      // #1341: where the recording pill and status notices open on screen.
+      BrandedPanel(
+        icon: "rectangle.portrait.and.arrow.right",
+        header: "Recording Indicator Position",
+        description:
+          "Choose where the recording pill and status notices appear. Changes apply the next time one appears."
+      ) {
+        BrandedSegmentedPicker(
+          options: [
+            ("Top", "arrow.up.to.line", OverlayPillPosition.top),
+            ("Bottom", "arrow.down.to.line", OverlayPillPosition.bottom),
+          ],
+          selection: $settings.overlayPillPosition
+        )
+      }
     }
   }
 }

--- a/Sources/EnviousWisprCore/SettingsEnums.swift
+++ b/Sources/EnviousWisprCore/SettingsEnums.swift
@@ -17,3 +17,11 @@ public enum AppearancePreference: String, CaseIterable, Sendable {
   case light
   case dark
 }
+
+/// Where the recording pill (and every transient overlay sharing its window —
+/// polishing, warnings, cold-start notices, the Bluetooth card) appears on
+/// screen. Persisted by rawValue; unknown/missing values resolve to `.top`.
+public enum OverlayPillPosition: String, CaseIterable, Sendable {
+  case top
+  case bottom
+}

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -16,6 +16,10 @@ enum SettingsDefaultValues {
   /// Default appearance follows the macOS system setting.
   static let appearancePreference: AppearancePreference = .system
 
+  // #1341: recording pill / status notices default to the top of the screen,
+  // matching the fixed position every existing install already sees.
+  static let overlayPillPosition: OverlayPillPosition = .top
+
   // #923: AI polish is ON by default, Apple Intelligence. Previously the cold
   // fallback was `.none` and onboarding wrote `.appleIntelligence` separately,
   // which made the real default ambiguous. Apple Intelligence is on-device; on

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -42,6 +42,7 @@ public final class SettingsManager {
     case useStreamingASR
     case warmEnginePolicy
     case appearance
+    case overlayPillPosition
     case showBluetoothTips
   }
 
@@ -77,7 +78,7 @@ public final class SettingsManager {
     "isDebugModeEnabled", "isDictationAudioArchiveEnabled", "debugLogLevel",
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
     "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
-    "useStreamingASR", "warmEnginePolicy", "appearancePreference",
+    "useStreamingASR", "warmEnginePolicy", "appearancePreference", "overlayPillPosition",
     "showBluetoothTips",
     WhatsNewConstants.lastSeenVersionDefaultsKey,
   ]
@@ -370,6 +371,16 @@ public final class SettingsManager {
     didSet {
       defaults.set(appearancePreference.rawValue, forKey: "appearancePreference")
       onChange?(.appearance)
+    }
+  }
+
+  /// #1341: where the recording pill and status notices appear on screen.
+  /// UI-only — read once at fresh-panel-creation time by `RecordingOverlayPanel`,
+  /// never live-patched into an already-showing panel; pipeline sync is a no-op.
+  public var overlayPillPosition: OverlayPillPosition {
+    didSet {
+      defaults.set(overlayPillPosition.rawValue, forKey: "overlayPillPosition")
+      onChange?(.overlayPillPosition)
     }
   }
 
@@ -717,6 +728,11 @@ public final class SettingsManager {
       AppearancePreference(
         rawValue: defaults.string(forKey: "appearancePreference") ?? ""
       ) ?? SettingsDefaultValues.appearancePreference
+
+    overlayPillPosition =
+      OverlayPillPosition(
+        rawValue: defaults.string(forKey: "overlayPillPosition") ?? ""
+      ) ?? SettingsDefaultValues.overlayPillPosition
 
     showBluetoothTips =
       defaults.object(forKey: "showBluetoothTips") as? Bool

--- a/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
@@ -82,6 +82,18 @@ import Testing
       #expect(d.first?.stringProps["source"] == "user")
     }
 
+    @Test("overlay pill position emits a delta (#1341)")
+    func overlayPillPositionDelta() {
+      let (settings, telemetry, box, _) = makeHarness()
+      defer { TelemetryService.shared.testEventHook = nil }
+      settings.overlayPillPosition = .bottom
+      telemetry.flush()
+      let d = deltas(box, setting: "overlay_pill_position")
+      #expect(d.count == 1)
+      #expect(d.first?.stringProps["from"] == "top")
+      #expect(d.first?.stringProps["to"] == "bottom")
+    }
+
     @Test("Two settings in one window emit two deltas")
     func twoSettingsTwoDeltas() {
       let (settings, telemetry, box, _) = makeHarness()

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -99,6 +99,32 @@ struct SettingsDefaultsRoutingTests {
     #expect(SettingsManager(defaults: suite).appearancePreference == .system)
   }
 
+  // MARK: - Overlay pill position (#1341)
+
+  @Test("overlay pill position defaults to .top on a fresh install")
+  func overlayPillPositionDefaultsToTop() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    #expect(settings.overlayPillPosition == .top)
+  }
+
+  @Test("overlay pill position persists to the injected store and is in the unified key set")
+  func overlayPillPositionPersists() {
+    let suite = Self.freshSuite()
+    let settings = SettingsManager(defaults: suite)
+    settings.overlayPillPosition = .bottom
+    #expect(suite.string(forKey: "overlayPillPosition") == "bottom")
+    // Reload from the same store → the choice survives.
+    #expect(SettingsManager(defaults: suite).overlayPillPosition == .bottom)
+    #expect(SettingsManager.unifiedDefaultsKeys.contains("overlayPillPosition"))
+  }
+
+  @Test("an unparseable stored overlay pill position falls back to .top")
+  func overlayPillPositionUnparseableFallsBack() {
+    let suite = Self.freshSuite()
+    suite.set("sideways", forKey: "overlayPillPosition")
+    #expect(SettingsManager(defaults: suite).overlayPillPosition == .top)
+  }
+
   #if DEBUG
     // AFM adapter PoC dev knob — a per-build contract: writes to .standard (not
     // the injected store) and stays out of the unified key set. DEBUG-gated


### PR DESCRIPTION
## Summary

- Adds a Top/Bottom setting for where the recording pill and status notices appear, remembered across restarts (Closes #1341).
- Fixes the pill sitting too high in fullscreen (macOS reports the same Dock-reserved safe area to a background app regardless of another app's fullscreen state — detected via the frontmost app's Accessibility fullscreen attribute instead, gated to Accessibility-trusted users).
- The pill now stays correctly positioned as the user swipes between a fullscreen Space and the regular desktop mid-recording (Bottom position only — Top's existing behavior is untouched per founder direction).
- Preserves a manual drag of the pill across that same Space-change reactivity, so switching desktops never silently undoes where the user moved it.
- Fixes a pre-existing recording/polishing pill misalignment (bottom-anchor vs. center-anchor inside the panel frame) surfaced while tuning the Bottom offset against a competing app's positioning.

## Review history

7 rounds of local Codex diff review. Rounds 2–6 each found a real, narrow edge case in the new Space-change reactivity (setting changed mid-recording, an inherited-transition panel losing tracked state, a manual drag getting overwritten, and a Top-specific height/clamp interaction) — round 6's finding led to intentionally scoping the reactive-repositioning feature to Bottom only, since Top was never affected by the underlying bug this PR fixes. Round 7 is clean.

## Test plan

- [x] 3012 tests pass locally (`scripts/xcode-test.sh`)
- [x] Live UAT: windowed mode Top/Bottom positioning confirmed correct
- [x] Live UAT: fullscreen Bottom positioning confirmed correct (real screenshots, annotated against true screen edge)
- [x] Live UAT: mid-recording Space swipe (windowed ↔ fullscreen) confirmed correct, with smooth animated reposition instead of a jump
- [x] Live UAT: manual drag preserved across Space changes
- [x] 7 rounds of local Codex diff review, clean on the final round