### PR TITLE
refactor(delivery): extract the legacy-retirement mechanism EG-1 and WhisperKit both need (Part of #1386)

### DIFF
--- a/Sources/EnviousWisprLLM/EGOne/EGOneLegacyUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneLegacyUpgradeCoordinator.swift
@@ -44,12 +44,10 @@ public final class EGOneLegacyUpgradeCoordinator {
 
   public var onEvent: (@MainActor @Sendable (Event) -> Void)?
 
-  private enum Fingerprint {
-    case absent
-    case match
-    case mismatch
-    case unreadable
-  }
+  /// EG-1's local vocabulary is now the shared one (#1386 PR-2a). The mechanism moved to
+  /// `LegacyRetirement`; this policy did not. Kept as an alias so this file's call sites and
+  /// its 29 tests read exactly as before.
+  private typealias Fingerprint = LegacyRetirement.SetVerdict
 
   private let appSupportDirectory: URL
   private let defaults: UserDefaults
@@ -59,7 +57,9 @@ public final class EGOneLegacyUpgradeCoordinator {
     @MainActor @Sendable () async -> ModelDeliveryController.DeliveryOutcome
   private let currentModelIsAdmitted: @MainActor @Sendable () async -> Bool
 
-  private let hashFile: @Sendable (URL) async throws -> String
+  /// nil in production: `LegacyRetirement` then hashes the descriptor it verified, so the
+  /// digest and the identity provably describe one inode. Tests inject a closure.
+  private let hashFile: (@Sendable (URL) async throws -> String)?
   private let writeMarker: @MainActor @Sendable (URL) -> Bool
   private let removeItem: @MainActor @Sendable (URL) throws -> Void
 
@@ -116,7 +116,7 @@ public final class EGOneLegacyUpgradeCoordinator {
     self.trustedArtifact = trustedArtifact
     self.ensureCurrentModel = ensureCurrentModel
     self.currentModelIsAdmitted = currentModelIsAdmitted
-    self.hashFile = hashFile ?? Self.streamingSHA256
+    self.hashFile = hashFile
     self.writeMarker = writeMarker ?? Self.atomicWriteMarker
     self.removeItem = removeItem ?? { try FileManager.default.removeItem(at: $0) }
   }
@@ -277,30 +277,23 @@ public final class EGOneLegacyUpgradeCoordinator {
     }
   }
 
+  /// Delegates to the shared mechanism (#1386 PR-2a). EG-1's artifact is a single flat file,
+  /// so it passes a one-element set and reads the roll-up.
+  ///
+  /// A thrown error here is a cancellation and nothing else: `LegacyRetirement.fingerprint`
+  /// classifies every other failure into a verdict and rethrows only `CancellationError`.
+  /// EG-1 exposes no cancellation path for its preparation task today, so this branch is
+  /// unreachable from EG-1 — but it must stay honest rather than fold a cancel into
+  /// `.unreadable`, which would write a permanent decline for a user who asked us to stop.
   private func fingerprintLegacyArtifact() async -> Fingerprint {
-    let url = legacyArtifactURL
-    let fm = FileManager.default
-
-    guard fm.fileExists(atPath: url.path) else { return .absent }
-
-    let values: URLResourceValues
+    let file = LegacyRetirement.TrustedFile(
+      relativePath: trustedArtifact.name,
+      sizeBytes: trustedArtifact.sizeBytes,
+      sha256: trustedArtifact.sha256)
     do {
-      values = try url.resourceValues(
-        forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey])
-    } catch {
-      return .unreadable
-    }
-
-    guard values.isSymbolicLink != true,
-      values.isRegularFile == true,
-      let fileSize = values.fileSize,
-      Int64(fileSize) == trustedArtifact.sizeBytes
-    else {
-      return .mismatch
-    }
-
-    do {
-      return try await hashFile(url) == trustedArtifact.sha256 ? .match : .mismatch
+      let verdicts = try await LegacyRetirement.fingerprint(
+        root: oldStoreDirectory, files: [file], hashFile: hashFile)
+      return LegacyRetirement.rollUp(verdicts)
     } catch {
       return .unreadable
     }
@@ -384,31 +377,7 @@ public final class EGOneLegacyUpgradeCoordinator {
   }
 
   private static func atomicWriteMarker(_ url: URL) -> Bool {
-    do {
-      try FileManager.default.createDirectory(
-        at: url.deletingLastPathComponent(),
-        withIntermediateDirectories: true
-      )
-      try Data().write(to: url, options: .atomic)
-      return true
-    } catch {
-      return false
-    }
+    LegacyRetirement.writeMarkerAtomically(url)
   }
 
-  private nonisolated static func streamingSHA256(of url: URL) async throws -> String {
-    try await Task.detached(priority: .utility) {
-      let handle = try FileHandle(forReadingFrom: url)
-      defer { try? handle.close() }
-
-      var hasher = SHA256()
-      while true {
-        try Task.checkCancellation()
-        let chunk = try handle.read(upToCount: 4 * 1_024 * 1_024) ?? Data()
-        if chunk.isEmpty { break }
-        hasher.update(data: chunk)
-      }
-      return hasher.finalize().map { String(format: "%02x", $0) }.joined()
-    }.value
-  }
 }

--- a/Sources/EnviousWisprModelDelivery/LegacyArtifactRetirement.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyArtifactRetirement.swift
@@ -1,0 +1,591 @@
+import CryptoKit
+import Foundation
+
+/// The shared mechanism for retiring a legacy on-disk artifact we can prove is ours.
+///
+/// Pure mechanism, **per-entry**, no store policy. EG-1 and WhisperKit both call it and
+/// each keeps its own store knowledge: EG-1's old-store layout and sidecar sweeps have no
+/// business in a type that also serves a foreign Hugging Face cache, and WhisperKit's
+/// Documents/TCC concerns must never leak into EG-1.
+///
+/// Extracted from `EGOneLegacyUpgradeCoordinator` (#1386 PR-2a), which keeps 100% of its
+/// policy and calls this for the mechanism. That coordinator's 29 tests are this
+/// extraction's oracle and must pass unmodified.
+public enum LegacyRetirement {
+
+  // MARK: - Inputs
+
+  /// A file we can prove is ours: a manifest-pinned path, size, and digest.
+  public struct TrustedFile: Sendable, Equatable {
+    /// Path relative to the retirement root. May contain `/` — the WhisperKit manifest
+    /// nests up to three components deep (e.g. `AudioEncoder.mlmodelc/analytics/coremldata.bin`).
+    public let relativePath: String
+    public let sizeBytes: Int64
+    public let sha256: String
+
+    public init(relativePath: String, sizeBytes: Int64, sha256: String) {
+      self.relativePath = relativePath
+      self.sizeBytes = sizeBytes
+      self.sha256 = sha256
+    }
+  }
+
+  /// Cheap identity of a file, captured without reading it.
+  ///
+  /// `dev`+`inode` is what makes this identity rather than a path: a path can be relinked
+  /// between the moment we fingerprint it and the moment we unlink it, and deleting by path
+  /// alone would then destroy a file we never examined.
+  public struct FileIdentity: Sendable, Equatable {
+    public let device: Int32
+    public let inode: UInt64
+    public let sizeBytes: Int64
+    /// Whole seconds AND nanoseconds. Second-granularity alone is not identity: a file
+    /// rewritten in place with different bytes of the same length within the same second
+    /// would compare equal, and we would then delete bytes we never hashed.
+    public let modifiedAtSeconds: Int64
+    public let modifiedAtNanoseconds: Int64
+    /// Inode change time. Catches metadata-only edits that leave mtime untouched — `mtime`
+    /// is writable via `utimes`, `ctime` is not.
+    public let changedAtSeconds: Int64
+    public let changedAtNanoseconds: Int64
+
+    public init(
+      device: Int32, inode: UInt64, sizeBytes: Int64,
+      modifiedAtSeconds: Int64, modifiedAtNanoseconds: Int64,
+      changedAtSeconds: Int64, changedAtNanoseconds: Int64
+    ) {
+      self.device = device
+      self.inode = inode
+      self.sizeBytes = sizeBytes
+      self.modifiedAtSeconds = modifiedAtSeconds
+      self.modifiedAtNanoseconds = modifiedAtNanoseconds
+      self.changedAtSeconds = changedAtSeconds
+      self.changedAtNanoseconds = changedAtNanoseconds
+    }
+  }
+
+  /// What we concluded about the SET. Deliberately identity-free: a 24-file aggregate has no
+  /// truthful single identity, and returning some arbitrary member's would be a lie a caller
+  /// could act on. Identities live on the per-entry verdicts, where they are true.
+  public enum SetVerdict: Sendable, Equatable {
+    case absent
+    case match
+    case mismatch
+    case unreadable
+  }
+
+  /// What we concluded about one entry.
+  public enum EntryVerdict: Sendable, Equatable {
+    /// Nothing is there. `ENOENT`/`ENOTDIR` only — never a permission or I/O failure.
+    case absent
+    /// Ours, with the identity captured at the moment we proved it.
+    case match(FileIdentity)
+    /// Not our bytes, or the path is not shaped the way our manifest says. Permanent.
+    case mismatch
+    /// We could not tell. Permission, TCC, I/O, or an iCloud stub whose bytes are not on
+    /// this Mac. Retryable in principle.
+    case unreadable
+  }
+
+  // MARK: - Fingerprint
+
+  /// Classify every trusted file under `root`, hashing only what earns it.
+  ///
+  /// `async throws` is deliberate and load-bearing: a `CancellationError` MUST reach the
+  /// caller as a thrown error rather than collapsing into `.unreadable`. Callers persist a
+  /// declined record from `.unreadable`, so conflating the two would let a user who pressed
+  /// Cancel permanently brand their own good copy as un-examinable.
+  ///
+  /// - Parameter hashFile: injected so tests can drive it; production passes `streamingSHA256`.
+  /// - Parameter hashFile: test/override seam. When nil (production), the digest is taken
+  ///   from the same descriptor the identity came from — see `fingerprintOne`.
+  public static func fingerprint(
+    root: URL,
+    files: [TrustedFile],
+    hashFile: (@Sendable (URL) async throws -> String)? = nil
+  ) async throws -> [String: EntryVerdict] {
+    var verdicts: [String: EntryVerdict] = [:]
+    verdicts.reserveCapacity(files.count)
+
+    for file in files {
+      // The cancellation contract belongs to `fingerprint`, not to whoever happens to hash.
+      // An all-absent or all-size-mismatch set never reaches the hasher, and a cancel landing
+      // just after the last digest would otherwise be swallowed — either way the caller would
+      // go on to delete and refetch after the user said stop.
+      try Task.checkCancellation()
+      verdicts[file.relativePath] = try await fingerprintOne(
+        root: root, file: file, hashFile: hashFile)
+    }
+    try Task.checkCancellation()
+    return verdicts
+  }
+
+  /// A relative path we are willing to walk at all.
+  ///
+  /// `..` is the hole this closes: it `lstat`s as a perfectly ordinary directory, so a
+  /// component walk waves it through and the leaf lands outside the root — where this type
+  /// would then hash a stranger's file, call it a match, and unlink it. Our manifests are
+  /// pinned and contain no traversal, but this is a public deletion primitive and must not
+  /// depend on its callers being careful.
+  private static func isWalkablePath(_ relativePath: String) -> Bool {
+    guard !relativePath.isEmpty, !relativePath.hasPrefix("/") else { return false }
+    let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
+    guard !components.isEmpty else { return false }
+    return components.allSatisfy { $0 != ".." && $0 != "." && !$0.isEmpty }
+  }
+
+  private static func fingerprintOne(
+    root: URL,
+    file: TrustedFile,
+    hashFile: (@Sendable (URL) async throws -> String)?
+  ) async throws -> EntryVerdict {
+    // Not `.absent`: a traversing path is a statement about the manifest, not about the disk.
+    guard isWalkablePath(file.relativePath) else { return .mismatch }
+    // The root itself is a component. The walk below starts at the root's CHILDREN, so a
+    // root that is itself a symlink (`cache/legacy -> ~/Documents/foreign`) would never be
+    // inspected, and every file "under" it would be outside the intended store.
+    switch classifyIntermediate(at: root) {
+    case .ok: break
+    // A missing store is `.absent`, never `.mismatch`: the ~465 users who never had the
+    // model must not have a permanent decline persisted for a copy they never owned.
+    case .absent: return .absent
+    case .unreadable: return .unreadable
+    case .mismatch: return .mismatch
+    }
+
+    // Walk every component with lstat before touching the leaf. Checking only the final
+    // file follows an escaping parent symlink — and unlike an import, which merely READS
+    // through such a link, we DELETE through it. This carries the guard out of
+    // `ModelDeliveryController.importLocalCandidate` before that primitive is retired.
+    var walk = root
+    for component in file.relativePath.split(separator: "/").dropLast() {
+      walk.appendPathComponent(String(component))
+      switch classifyIntermediate(at: walk) {
+      case .ok: continue
+      case .absent: return .absent
+      case .mismatch: return .mismatch
+      case .unreadable: return .unreadable
+      }
+    }
+
+    let url = root.appendingPathComponent(file.relativePath)
+    let name = (file.relativePath as NSString).lastPathComponent
+
+    // Open ONCE, through a pinned parent, and do everything through this descriptor:
+    // identity, size, type, and the hash itself.
+    //
+    // Hashing by path after `lstat`ing by path proves nothing about the file we then delete.
+    // A concurrent writer in the shared cache can swap the path to a decoy holding trusted
+    // bytes, let us hash THAT, then restore the original — whose identity still matches what
+    // we captured, so `unlinkUnchanged` deletes bytes that were never hashed. Binding both
+    // proofs to one descriptor makes the identity and the digest describe the same inode by
+    // construction: whatever happens to the NAME afterwards, the fd still refers to the file
+    // we actually read.
+    let dirfd: Int32
+    switch openParentDirectory(root: root, relativePath: file.relativePath) {
+    case .opened(let opened): dirfd = opened
+    // `lstat` succeeds on a directory we may not open, so the walk above cannot see a
+    // permission wall — only this can. Classify it, never collapse it to `.mismatch`.
+    case .failed(let code): return verdict(forOpenErrno: code)
+    }
+    defer { close(dirfd) }
+
+    let fd = openat(dirfd, name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+    guard fd >= 0 else {
+      // ELOOP means the leaf is a symlink: not our file, and a permanent answer.
+      if errno == ELOOP { return .mismatch }
+      return errno == ENOENT || errno == ENOTDIR ? .absent : .unreadable
+    }
+    defer { close(fd) }
+
+    var info = Foundation.stat()
+    guard fstat(fd, &info) == 0 else { return .unreadable }
+    guard (info.st_mode & S_IFMT) == S_IFREG else { return .mismatch }
+    let captured = identity(of: info)
+    guard captured.sizeBytes == file.sizeBytes else { return .mismatch }
+    // An iCloud stub reports the real size while its bytes live in the cloud. The foreign
+    // cache sits in ~/Documents, which users can have synced, so hashing one would quietly
+    // pull 1.6 GB down to answer a question we ask on every launch. `.unreadable` is the
+    // honest verdict: we genuinely cannot read it, and it may become readable later.
+    guard !isDatalessStub(fd: fd, fallback: url) else { return .unreadable }
+
+    do {
+      let digest = try await hash(fd: fd, url: url, using: hashFile)
+      return digest == file.sha256 ? .match(captured) : .mismatch
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      return .unreadable
+    }
+  }
+
+  /// Production hashes the descriptor we verified; an injected seam (tests, EG-1 overrides)
+  /// still gets the URL, because a test fixture has no concurrent writer to race it.
+  private static func hash(
+    fd: Int32, url: URL, using injected: (@Sendable (URL) async throws -> String)?
+  ) async throws -> String {
+    if let injected { return try await injected(url) }
+    return try await streamingSHA256(fd: fd)
+  }
+
+  /// Every intermediate component is a real directory, right now.
+  /// Open the directory holding `relativePath`, walking component by component with
+  /// `openat` + `O_NOFOLLOW` from a pinned root descriptor.
+  ///
+  /// This is the single answer to a whole family of defects. `O_NOFOLLOW` protects only the
+  /// FINAL component, so `open("<root>/a/b/c.bin", O_NOFOLLOW)` happily follows a symlink at
+  /// `a` or `b` — and an `lstat` walk beforehand cannot help, because the path is resolved
+  /// again, from scratch, at open time. Every ancestor is a TOCTOU window.
+  ///
+  /// Walking with `openat` closes the family at once: each step is relative to a descriptor
+  /// we already hold, so once a directory is pinned, nothing done to its NAME can redirect
+  /// us. What we open is what we walked.
+  ///
+  /// This does NOT make the `lstat` walk redundant, and the two are not interchangeable. The
+  /// walk classifies (absent vs unreadable vs mismatch — the verdict vocabulary callers
+  /// depend on); this pins (races). A static symlinked ancestor is refused by either one, so
+  /// no test discriminates them; the pinning earns its place against the window BETWEEN the
+  /// walk and the open, which is exactly the kind of defect a test cannot stage and a reader
+  /// cannot see. Keep both.
+  ///
+  /// - Returns: a directory descriptor the caller must close, or nil if any component is
+  ///   missing, is a link, or is not a directory.
+  private enum ParentOpen {
+    case opened(Int32)
+    /// Carries the failing `errno` so the caller can classify. `close` clobbers `errno`, so
+    /// it is captured at the point of failure, not read afterwards.
+    case failed(Int32)
+  }
+
+  private static func openParentDirectory(root: URL, relativePath: String) -> ParentOpen {
+    guard isWalkablePath(relativePath) else { return .failed(EINVAL) }
+
+    var current = open(root.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+    guard current >= 0 else { return .failed(errno) }
+
+    for component in relativePath.split(separator: "/").dropLast() {
+      let next = openat(
+        current, String(component), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+      let failure = next < 0 ? errno : 0
+      close(current)
+      guard next >= 0 else { return .failed(failure) }
+      current = next
+    }
+    return .opened(current)
+  }
+
+  /// Map an `open`/`openat` failure to a verdict. Same errno vocabulary as the `lstat` walk:
+  /// only "nothing there" is `.absent`, only a link or a non-directory is a permanent
+  /// `.mismatch`, and anything else — permission, TCC, I/O — is "we cannot tell".
+  private static func verdict(forOpenErrno code: Int32) -> EntryVerdict {
+    switch code {
+    case ENOENT, ENOTDIR: return .absent
+    case ELOOP, EINVAL: return .mismatch
+    default: return .unreadable
+    }
+  }
+
+  /// Is this an iCloud placeholder whose bytes are not on this Mac?
+  ///
+  /// Ported from `ModelDeliveryController.importLocalCandidate`, which refuses these as
+  /// `.datalessPlaceholder`. It is the seventh of that primitive's guards and the one this
+  /// extraction had missed.
+  /// Asked of the descriptor we opened (via `F_GETPATH`), not the path we were handed, so a
+  /// leaf swapped after `open` cannot make us answer about a different file.
+  ///
+  /// This is a hydration guard, not a safety guard: iCloud status has no fd-based API, so
+  /// `F_GETPATH` is the closest binding available. If it were ever wrong the cost is a slow
+  /// hash or a spurious `.unreadable`, both recoverable (L4 re-examines) — it can never cause
+  /// a wrong deletion, because deletion is gated by identity, not by this.
+  private static func isDatalessStub(fd: Int32, fallback: URL) -> Bool {
+    var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+    let url =
+      fcntl(fd, F_GETPATH, &buffer) == 0
+      ? URL(fileURLWithPath: String(cString: buffer)) : fallback
+    guard
+      let values = try? url.resourceValues(forKeys: [
+        .isUbiquitousItemKey, .ubiquitousItemDownloadingStatusKey,
+      ])
+    else { return false }
+    guard values.isUbiquitousItem == true else { return false }
+    return values.ubiquitousItemDownloadingStatus != .current
+  }
+
+  /// A root we are willing to walk at all: a real directory, not a link to one.
+  private static func rootIsARealDirectory(_ root: URL) -> Bool {
+    guard let info = lstatIdentity(at: root) else { return false }
+    return info.isDirectoryNotLink
+  }
+
+  private static func pathIsFreeOfLinks(root: URL, relativePath: String) -> Bool {
+    guard isWalkablePath(relativePath), rootIsARealDirectory(root) else { return false }
+    var walk = root
+    for component in relativePath.split(separator: "/").dropLast() {
+      walk.appendPathComponent(String(component))
+      guard let info = lstatIdentity(at: walk), info.isDirectoryNotLink else { return false }
+    }
+    return true
+  }
+
+  private enum IntermediateVerdict { case ok, absent, mismatch, unreadable }
+
+  private static func classifyIntermediate(at url: URL) -> IntermediateVerdict {
+    guard let info = lstatIdentity(at: url) else {
+      return errno == ENOENT || errno == ENOTDIR ? .absent : .unreadable
+    }
+    // A symlink or a non-directory where the manifest says a directory belongs is not our
+    // tree, whatever it points at.
+    return info.isDirectoryNotLink ? .ok : .mismatch
+  }
+
+  // MARK: - Roll-up
+
+  /// Reduce per-entry verdicts to one answer for the set. Deterministic and total.
+  ///
+  /// Order matters: `unreadable` outranks `mismatch` because "we could not tell" must never
+  /// be reported as "we can tell, and it is not ours" — the second is permanent, the first
+  /// is not. Every other mixture, including `match`+`absent` (a partially-deleted set), is
+  /// `mismatch`: a partial match is not our artifact.
+  public static func rollUp(_ verdicts: [String: EntryVerdict]) -> SetVerdict {
+    // Empty in, absent out: no entries examined means nothing is there to retire. Stated
+    // rather than left to fall through, because "total" is a promise the caller relies on.
+    guard !verdicts.isEmpty else { return .absent }
+    let values = Array(verdicts.values)
+
+    if values.contains(where: {
+      if case .unreadable = $0 { return true }
+      return false
+    }) {
+      return .unreadable
+    }
+    if values.allSatisfy({
+      if case .absent = $0 { return true }
+      return false
+    }) {
+      return .absent
+    }
+    if values.allSatisfy({
+      if case .match = $0 { return true }
+      return false
+    }) {
+      return .match
+    }
+    return .mismatch
+  }
+
+  // MARK: - Unlink
+
+  /// Unlink only what still matches the identity we captured, and report what we preserved.
+  ///
+  /// Re-`lstat`s immediately before each unlink: the file may have been relinked or rewritten
+  /// since the fingerprint, and the whole point of `FileIdentity` is that we refuse to delete
+  /// a file we did not examine.
+  /// - Parameter removeItem: test seam only. When nil (production), removal goes through
+  ///   `unlinkat` against a directory handle — see `unlinkVerified`.
+  @discardableResult
+  public static func unlinkUnchanged(
+    root: URL,
+    verdicts: [String: EntryVerdict],
+    removeItem: ((URL) throws -> Void)? = nil
+  ) -> (unlinked: [String], preserved: [String]) {
+    var unlinked: [String] = []
+    var preserved: [String] = []
+
+    for relativePath in verdicts.keys.sorted() {
+      guard case .match(let captured) = verdicts[relativePath] else {
+        preserved.append(relativePath)
+        continue
+      }
+      // Re-walk the intermediates, not just the leaf. `lstat` declines to follow only the
+      // FINAL component, so an intermediate directory swapped for a symlink after the
+      // fingerprint would silently redirect this removal outside the root. The identity check
+      // below already refuses the redirected file, but a delete path must not depend on a
+      // second guard catching what the first one let through.
+      guard pathIsFreeOfLinks(root: root, relativePath: relativePath) else {
+        preserved.append(relativePath)
+        continue
+      }
+      let url = root.appendingPathComponent(relativePath)
+      guard let now = lstatIdentity(at: url), now.isRegularFileNotLink,
+        now.identity == captured
+      else {
+        preserved.append(relativePath)
+        continue
+      }
+      if removeItem == nil, unlinkVerified(root: root, relativePath: relativePath, is: captured) {
+        unlinked.append(relativePath)
+        continue
+      }
+      if let removeItem {
+        do {
+          try removeItem(url)
+          unlinked.append(relativePath)
+        } catch {
+          preserved.append(relativePath)
+        }
+        continue
+      }
+      preserved.append(relativePath)
+    }
+    return (unlinked, preserved)
+  }
+
+  /// Re-verify identity through a *directory handle*, then `unlinkat` against that same
+  /// handle.
+  ///
+  /// A path-based `removeItem` resolves the whole path again at delete time, so anything that
+  /// moved underneath us between the check and the delete is silently followed. Holding an
+  /// `O_DIRECTORY | O_NOFOLLOW` handle to the parent pins the directory: `fstatat` and
+  /// `unlinkat` then address the same directory object regardless of what happens to the path
+  /// above it, which removes the intermediate-swap race entirely.
+  ///
+  /// **What remains, and why it is not closable here.** POSIX offers no "unlink this exact
+  /// inode" call: between `fstatat` and `unlinkat` a writer can still swap the name. The
+  /// window is now a few instructions against a pinned directory rather than a full path
+  /// re-resolution, and this is the shared-cache residual the plan already accepts (§8.1) —
+  /// a foreign writer racing us in `~/Documents/huggingface` can defeat any identity check,
+  /// because the check and the delete cannot be made one atom. Do not "fix" this with a lock:
+  /// we do not own the other writer.
+  private static func unlinkVerified(
+    root: URL, relativePath: String, is captured: FileIdentity
+  ) -> Bool {
+    let name = (relativePath as NSString).lastPathComponent
+    guard case .opened(let dirfd) = openParentDirectory(root: root, relativePath: relativePath)
+    else { return false }
+    defer { close(dirfd) }
+
+    var info = Foundation.stat()
+    guard fstatat(dirfd, name, &info, AT_SYMLINK_NOFOLLOW) == 0,
+      (info.st_mode & S_IFMT) == S_IFREG,
+      identity(of: info) == captured
+    else { return false }
+
+    return unlinkat(dirfd, name, 0) == 0
+  }
+
+  // MARK: - Containment
+
+  /// Is `candidate` genuinely inside `root`, after resolving both?
+  ///
+  /// Resolve-then-compare, never compare-then-resolve: a symlink that escapes the root
+  /// compares fine as a string and escapes in fact.
+  public static func isContained(_ candidate: URL, within root: URL) -> Bool {
+    let resolvedRoot = root.resolvingSymlinksInPath().standardizedFileURL
+    let resolvedCandidate = candidate.resolvingSymlinksInPath().standardizedFileURL
+    return resolvedCandidate.path == resolvedRoot.path
+      || resolvedCandidate.path.hasPrefix(resolvedRoot.path + "/")
+  }
+
+  // MARK: - Marker
+
+  /// Write a zero-byte marker atomically. Returns false rather than throwing: a caller that
+  /// cannot write the marker must delete nothing, and that is a decision, not an error.
+  /// `Data.write(options: .atomic)` already writes to a temporary file and renames it into
+  /// place; hand-rolling that dance around `replaceItemAt` would add failure modes without
+  /// adding atomicity. This is EG-1's shipped implementation, moved verbatim.
+  public static func writeMarkerAtomically(_ url: URL) -> Bool {
+    do {
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try Data().write(to: url, options: .atomic)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /// Clear a marker. Idempotent: clearing an absent marker is success, because the
+  /// postcondition the caller needs — no marker on disk — already holds.
+  public static func clearMarker(_ url: URL) throws {
+    do {
+      try FileManager.default.removeItem(at: url)
+    } catch CocoaError.fileNoSuchFile {
+      return
+    } catch let error as NSError
+      where error.domain == NSPOSIXErrorDomain && error.code == Int(ENOENT)
+    {
+      return
+    }
+  }
+
+  // MARK: - Hashing
+
+  /// SHA-256 in 4 MB chunks, off the calling actor, and **actually cancellable**.
+  ///
+  /// Two requirements pull in opposite directions, which is how the original got it wrong.
+  /// The read must leave the caller's actor — callers are `@MainActor` coordinators, and
+  /// hashing 1.6 GB on the main actor would freeze the UI, which is why the original reached
+  /// for `Task.detached`. But a detached task does **not** inherit cancellation, so its
+  /// `checkCancellation` could never observe the parent's cancel and the read ran to
+  /// completion after the user asked us to stop.
+  ///
+  /// Keep the detached task for the isolation; add the link it was missing.
+  /// Hash an already-open descriptor. `dup` because the reader takes ownership, and the
+  /// caller's `defer { close(fd) }` must stay correct.
+  static func streamingSHA256(fd: Int32) async throws -> String {
+    let duplicate = dup(fd)
+    guard duplicate >= 0 else { throw POSIXError(.EBADF) }
+    guard lseek(duplicate, 0, SEEK_SET) == 0 else {
+      close(duplicate)
+      throw POSIXError(.ESPIPE)
+    }
+    let handle = FileHandle(fileDescriptor: duplicate, closeOnDealloc: true)
+    return try await streamingSHA256(handle: handle)
+  }
+
+  public static func streamingSHA256(of url: URL) async throws -> String {
+    try await streamingSHA256(handle: try FileHandle(forReadingFrom: url))
+  }
+
+  private static func streamingSHA256(handle: FileHandle) async throws -> String {
+    let work = Task.detached(priority: .utility) {
+      defer { try? handle.close() }
+
+      var hasher = SHA256()
+      while true {
+        try Task.checkCancellation()
+        let chunk = try handle.read(upToCount: 4 * 1_024 * 1_024) ?? Data()
+        if chunk.isEmpty { break }
+        hasher.update(data: chunk)
+      }
+      return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+    return try await withTaskCancellationHandler {
+      try await work.value
+    } onCancel: {
+      work.cancel()
+    }
+  }
+
+  // MARK: - lstat
+
+  private struct StatInfo {
+    let identity: FileIdentity
+    let isRegularFileNotLink: Bool
+    let isDirectoryNotLink: Bool
+  }
+
+  private static func identity(of info: Foundation.stat) -> FileIdentity {
+    FileIdentity(
+      device: info.st_dev,
+      inode: UInt64(info.st_ino),
+      sizeBytes: Int64(info.st_size),
+      modifiedAtSeconds: Int64(info.st_mtimespec.tv_sec),
+      modifiedAtNanoseconds: Int64(info.st_mtimespec.tv_nsec),
+      changedAtSeconds: Int64(info.st_ctimespec.tv_sec),
+      changedAtNanoseconds: Int64(info.st_ctimespec.tv_nsec))
+  }
+
+  /// `lstat`, never `stat`: it must describe the link itself, not what the link aims at.
+  private static func lstatIdentity(at url: URL) -> StatInfo? {
+    var info = Foundation.stat()
+    guard lstat(url.path, &info) == 0 else { return nil }
+    let mode = info.st_mode & S_IFMT
+    return StatInfo(
+      identity: identity(of: info),
+      isRegularFileNotLink: mode == S_IFREG,
+      isDirectoryNotLink: mode == S_IFDIR)
+  }
+}

--- a/Sources/EnviousWisprModelDelivery/LegacyArtifactRetirement.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyArtifactRetirement.swift
@@ -275,12 +275,19 @@ public enum LegacyRetirement {
   }
 
   /// Map an `open`/`openat` failure to a verdict. Same errno vocabulary as the `lstat` walk:
-  /// only "nothing there" is `.absent`, only a link or a non-directory is a permanent
+  /// only "nothing there" is `.absent`, a link or a wrong-shaped component is a permanent
   /// `.mismatch`, and anything else — permission, TCC, I/O — is "we cannot tell".
+  ///
+  /// `ENOTDIR` is a mismatch, not an absence, and the distinction is not pedantic. It means
+  /// something IS occupying a component and it is not a directory — bytes we cannot identify,
+  /// sitting in the model path. Calling that `.absent` would let a whole set roll up to
+  /// "nothing here", so policy would fall silent instead of refusing, and unknown bytes would
+  /// read as an empty store. The static `lstat` classifier already answers `.mismatch` for
+  /// exactly this shape; only the race reaches here, and it must not answer differently.
   private static func verdict(forOpenErrno code: Int32) -> EntryVerdict {
     switch code {
-    case ENOENT, ENOTDIR: return .absent
-    case ELOOP, EINVAL: return .mismatch
+    case ENOENT: return .absent
+    case ENOTDIR, ELOOP, EINVAL: return .mismatch
     default: return .unreadable
     }
   }
@@ -331,7 +338,10 @@ public enum LegacyRetirement {
 
   private static func classifyIntermediate(at url: URL) -> IntermediateVerdict {
     guard let info = lstatIdentity(at: url) else {
-      return errno == ENOENT || errno == ENOTDIR ? .absent : .unreadable
+      // Same split as `verdict(forOpenErrno:)`: ENOTDIR means an ancestor exists and is not a
+      // directory, which is a shape we refuse, not an absence.
+      if errno == ENOENT { return .absent }
+      return errno == ENOTDIR ? .mismatch : .unreadable
     }
     // A symlink or a non-directory where the manifest says a directory belongs is not our
     // tree, whatever it points at.

--- a/Tests/EnviousWisprTests/ModelDelivery/LegacyRetirementTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/LegacyRetirementTests.swift
@@ -1,0 +1,681 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import EnviousWisprModelDelivery
+
+/// #1386 PR-2a. Covers L3 (deletion authority), L8 (path safety), L9 (cancellation is not a
+/// verdict) from the plan's §1.
+///
+/// Every refusal here is silent by design, which is exactly where a false green hides: a test
+/// asserting "did not crash" cannot tell "refused correctly" from "never ran". So every
+/// refusal case asserts a **positive** — the named file still exists, the hash count is zero,
+/// the verdict is the specific one claimed.
+@Suite struct LegacyRetirementTests {
+
+  // MARK: - Fixtures
+
+  private func makeRoot() throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("legacy-retirement-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+  }
+
+  private func digest(_ data: Data) -> String {
+    SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+  }
+
+  @discardableResult
+  private func stage(_ root: URL, _ relativePath: String, _ bytes: Data) throws -> URL {
+    let url = root.appendingPathComponent(relativePath)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try bytes.write(to: url)
+    return url
+  }
+
+  private func trusted(_ relativePath: String, _ bytes: Data) -> LegacyRetirement.TrustedFile {
+    LegacyRetirement.TrustedFile(
+      relativePath: relativePath, sizeBytes: Int64(bytes.count), sha256: digest(bytes))
+  }
+
+  private func identityOf(_ url: URL) -> LegacyRetirement.FileIdentity {
+    var st = stat()
+    _ = lstat(url.path, &st)
+    return LegacyRetirement.FileIdentity(
+      device: st.st_dev, inode: UInt64(st.st_ino), sizeBytes: Int64(st.st_size),
+      modifiedAtSeconds: Int64(st.st_mtimespec.tv_sec),
+      modifiedAtNanoseconds: Int64(st.st_mtimespec.tv_nsec),
+      changedAtSeconds: Int64(st.st_ctimespec.tv_sec),
+      changedAtNanoseconds: Int64(st.st_ctimespec.tv_nsec))
+  }
+
+  /// Counts hashes so "we never hashed it" is provable rather than assumed.
+  private actor HashSpy {
+    private(set) var count = 0
+
+    func hash(_ url: URL) async throws -> String {
+      count += 1
+      return try await LegacyRetirement.streamingSHA256(of: url)
+    }
+
+    /// The `@Sendable` closure `fingerprint` takes, bound to this actor.
+    nonisolated var callback: @Sendable (URL) async throws -> String {
+      { url in try await self.hash(url) }
+    }
+  }
+
+  // MARK: - L8: path safety
+
+  @Test func honestNestedPathMatchesAtFullManifestDepth() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // The real manifest nests three deep, e.g. AudioEncoder.mlmodelc/analytics/coremldata.bin.
+    let bytes = Data("weights".utf8)
+    try stage(root, "AudioEncoder.mlmodelc/analytics/coremldata.bin", bytes)
+
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("AudioEncoder.mlmodelc/analytics/coremldata.bin", bytes)])
+
+    guard case .match = verdicts["AudioEncoder.mlmodelc/analytics/coremldata.bin"] else {
+      Issue.record("an honest nested path must match: \(verdicts)")
+      return
+    }
+  }
+
+  @Test func symlinkAtAnIntermediateComponentIsMismatchAndIsNeverHashed() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // The bytes are real and correct — only the PATH lies. An escape via an intermediate
+    // component is the case that checking the leaf alone cannot see, and we DELETE through
+    // these paths, so a follow here would destroy a file outside the root.
+    let bytes = Data("weights".utf8)
+    let elsewhere = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: elsewhere) }
+    try stage(elsewhere, "analytics/coremldata.bin", bytes)
+
+    let container = root.appendingPathComponent("AudioEncoder.mlmodelc", isDirectory: true)
+    try FileManager.default.createDirectory(at: container, withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(
+      at: container.appendingPathComponent("analytics"),
+      withDestinationURL: elsewhere.appendingPathComponent("analytics"))
+
+    let spy = HashSpy()
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root,
+      files: [trusted("AudioEncoder.mlmodelc/analytics/coremldata.bin", bytes)],
+      hashFile: spy.callback)
+
+    #expect(verdicts["AudioEncoder.mlmodelc/analytics/coremldata.bin"] == .mismatch)
+    #expect(await spy.count == 0, "a path we refuse must never be read")
+    #expect(
+      FileManager.default.fileExists(
+        atPath: elsewhere.appendingPathComponent("analytics/coremldata.bin").path),
+      "the escaped file must be untouched")
+  }
+
+  @Test func symlinkedLeafIsMismatchEvenWhenItPointsAtCorrectBytes() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let bytes = Data("weights".utf8)
+    let elsewhere = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: elsewhere) }
+    let real = try stage(elsewhere, "real.bin", bytes)
+    try FileManager.default.createSymbolicLink(
+      at: root.appendingPathComponent("leaf.bin"), withDestinationURL: real)
+
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("leaf.bin", bytes)])
+
+    #expect(verdicts["leaf.bin"] == .mismatch, "lstat must describe the link, not its target")
+  }
+
+  @Test func nonDirectoryWhereADirectoryBelongsIsMismatch() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // A regular file sitting where the manifest says a directory goes: not our tree.
+    try stage(root, "AudioEncoder.mlmodelc", Data("not a directory".utf8))
+
+    let bytes = Data("weights".utf8)
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("AudioEncoder.mlmodelc/coremldata.bin", bytes)])
+
+    #expect(verdicts["AudioEncoder.mlmodelc/coremldata.bin"] == .mismatch)
+  }
+
+  @Test func missingFileIsAbsentAndIsNeverHashed() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let spy = HashSpy()
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("gone.bin", Data("x".utf8))], hashFile: spy.callback)
+
+    #expect(verdicts["gone.bin"] == .absent)
+    #expect(await spy.count == 0)
+  }
+
+  @Test func missingIntermediateIsAbsentNotMismatch() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // ENOTDIR/ENOENT on the way down means nothing is there — not that someone else's bytes
+    // are. `.mismatch` would be a permanent decline for a copy that simply does not exist.
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("nope.mlmodelc/analytics/coremldata.bin", Data("x".utf8))])
+
+    #expect(verdicts["nope.mlmodelc/analytics/coremldata.bin"] == .absent)
+  }
+
+  @Test func unreadableDirectoryIsUnreadableNotAbsent() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let bytes = Data("weights".utf8)
+    try stage(root, "locked/coremldata.bin", bytes)
+    let locked = root.appendingPathComponent("locked", isDirectory: true)
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: locked.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o755], ofItemAtPath: locked.path)
+    }
+
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("locked/coremldata.bin", bytes)])
+
+    // This is the distinction `FileManager.fileExists` cannot make: it answers false for both
+    // "missing" and "cannot look". Calling this `.absent` would silently drop a real copy.
+    #expect(
+      verdicts["locked/coremldata.bin"] == .unreadable,
+      "permission denial is 'cannot tell', never 'nothing there'")
+  }
+
+  @Test func sizeMismatchIsNeverHashed() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    try stage(root, "a.bin", Data("longer than expected".utf8))
+    let spy = HashSpy()
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("a.bin", Data("short".utf8))], hashFile: spy.callback)
+
+    #expect(verdicts["a.bin"] == .mismatch)
+    #expect(await spy.count == 0, "size gates hashing — 1.6 GB is never read speculatively")
+  }
+
+  @Test func aTraversingPathIsRefusedAndNeverReachesTheDiskOutsideTheRoot() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // `..` lstats as a perfectly ordinary directory, so a component walk waves it through and
+    // the leaf lands outside the root — where this type would hash a stranger's file, call it
+    // a match, and unlink it. Our manifests are pinned and carry no traversal; this is a
+    // public deletion primitive and must not rely on its callers being careful.
+    let bytes = Data("victim".utf8)
+    let outside = root.deletingLastPathComponent()
+      .appendingPathComponent("victim-\(UUID().uuidString).bin")
+    try bytes.write(to: outside)
+    defer { try? FileManager.default.removeItem(at: outside) }
+
+    let spy = HashSpy()
+    let escaping = "../\(outside.lastPathComponent)"
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted(escaping, bytes)], hashFile: spy.callback)
+
+    #expect(verdicts[escaping] == .mismatch, "a traversing path is refused, not classified")
+    #expect(await spy.count == 0)
+
+    let result = LegacyRetirement.unlinkUnchanged(root: root, verdicts: verdicts)
+    #expect(result.unlinked.isEmpty)
+    #expect(FileManager.default.fileExists(atPath: outside.path), "the outside file survives")
+  }
+
+  @Test func anAbsolutePathIsRefused() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let bytes = Data("x".utf8)
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("/etc/hosts", bytes)])
+
+    #expect(verdicts["/etc/hosts"] == .mismatch)
+  }
+
+  @Test func aSameSecondRewriteOfEqualLengthIsNotMistakenForTheVerifiedFile() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let mine = Data("aaaa".utf8)
+    let url = try stage(root, "a.bin", mine)
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("a.bin", mine)])
+
+    // Same length, different bytes, same wall-clock second, written in place so the inode
+    // does not change. Second-granularity mtime cannot see this; nanoseconds and ctime can.
+    let handle = try FileHandle(forWritingTo: url)
+    try handle.seek(toOffset: 0)
+    try handle.write(contentsOf: Data("bbbb".utf8))
+    try handle.close()
+
+    let result = LegacyRetirement.unlinkUnchanged(root: root, verdicts: verdicts)
+
+    #expect(result.unlinked.isEmpty, "bytes we never hashed must never be deleted")
+    #expect(result.preserved == ["a.bin"])
+    #expect(try Data(contentsOf: url) == Data("bbbb".utf8))
+  }
+
+  // MARK: - L9: cancellation is not a verdict
+
+  @Test func cancellationPropagatesAndIsNeverClassified() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let bytes = Data("weights".utf8)
+    try stage(root, "a.bin", bytes)
+
+    // Conflating a cancel with `.unreadable` would let a user who pressed Cancel permanently
+    // brand their own good copy as un-examinable — the caller persists a declined record from
+    // that verdict. So the cancel must arrive as a throw, not as an answer.
+    var thrown: Error?
+    do {
+      _ = try await LegacyRetirement.fingerprint(root: root, files: [trusted("a.bin", bytes)]) {
+        _ in throw CancellationError()
+      }
+    } catch {
+      thrown = error
+    }
+
+    #expect(thrown is CancellationError, "a cancel must reach the caller as a cancel")
+  }
+
+  @Test func aGenericHashFailureStillClassifiesUnreadable() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    struct Boom: Error {}
+    let bytes = Data("weights".utf8)
+    try stage(root, "a.bin", bytes)
+
+    // The other half of L9: only cancellation is special. An ordinary I/O failure is still a
+    // verdict, or EG-1's unreadable-monolith behavior would change.
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("a.bin", bytes)]
+    ) { _ in throw Boom() }
+
+    #expect(verdicts["a.bin"] == .unreadable)
+  }
+
+  @Test func streamingHashStopsWhenTheCallerCancels() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // 24 MB: enough to span several 4 MB chunks so a cancel can land mid-read.
+    let big = Data(repeating: 0x41, count: 24 * 1_024 * 1_024)
+    let url = try stage(root, "big.bin", big)
+
+    let task = Task { try await LegacyRetirement.streamingSHA256(of: url) }
+    task.cancel()
+
+    var thrown: Error?
+    do { _ = try await task.value } catch { thrown = error }
+
+    // The detached hash inherits nothing; without the explicit cancellation handler this read
+    // would run to completion after the caller gave up.
+    #expect(thrown is CancellationError)
+  }
+
+  @Test func streamingHashMatchesCryptoKitOverAMultiChunkFile() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let big = Data((0..<(9 * 1_024 * 1_024)).map { UInt8($0 % 251) })
+    let url = try stage(root, "big.bin", big)
+
+    let streamed = try await LegacyRetirement.streamingSHA256(of: url)
+
+    #expect(streamed == digest(big), "chunking must not change the digest")
+  }
+
+  @Test func theDigestComesFromTheDescriptorNotTheName() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // Hashing by path after lstat-ing by path proves nothing about the file we then delete:
+    // a writer can swap the name to a decoy holding trusted bytes, let us hash THAT, restore
+    // the original, and we delete bytes we never read. Binding both proofs to one descriptor
+    // is what closes it. Unlinking the name mid-flight is the cheapest way to prove the read
+    // follows the inode: if the digest still lands, it did not come from the path.
+    let bytes = Data("weights".utf8)
+    let url = try stage(root, "a.bin", bytes)
+
+    let fd = open(url.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+    #expect(fd >= 0)
+    defer { close(fd) }
+    try FileManager.default.removeItem(at: url)
+
+    let digest = try await LegacyRetirement.streamingSHA256(fd: fd)
+
+    #expect(digest == self.digest(bytes), "the read follows the inode, not the name")
+    #expect(!FileManager.default.fileExists(atPath: url.path))
+  }
+
+  @Test func aMissingRootIsAbsentNotMismatch() async throws {
+    let root = try makeRoot()
+    try FileManager.default.removeItem(at: root)
+
+    // The ~465 users who never had this model must not get a permanent decline persisted
+    // for a copy they never owned. `.mismatch` would say "we looked, it is not ours".
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("a.bin", Data("x".utf8))])
+
+    #expect(verdicts["a.bin"] == .absent)
+  }
+
+  // MARK: - L3: roll-up is deterministic and total
+
+  @Test func rollUpIsAbsentOnlyWhenEveryEntryIsAbsent() {
+    #expect(LegacyRetirement.rollUp(["a": .absent, "b": .absent]) == .absent)
+    #expect(LegacyRetirement.rollUp([:]) == .absent)
+  }
+
+  @Test func rollUpIsMatchOnlyWhenEveryEntryMatches() {
+    let id = LegacyRetirement.FileIdentity(
+      device: 1, inode: 2, sizeBytes: 3, modifiedAtSeconds: 4, modifiedAtNanoseconds: 5,
+      changedAtSeconds: 6, changedAtNanoseconds: 7)
+    #expect(LegacyRetirement.rollUp(["a": .match(id), "b": .match(id)]) == .match)
+  }
+
+  @Test func rollUpCarriesNoSetLevelIdentity() {
+    // `SetVerdict` deliberately has no payload: a 24-file aggregate has no truthful single
+    // identity, and handing back some arbitrary member's would be a lie a caller could act on.
+    let id = LegacyRetirement.FileIdentity(
+      device: 1, inode: 2, sizeBytes: 3, modifiedAtSeconds: 4, modifiedAtNanoseconds: 5,
+      changedAtSeconds: 6, changedAtNanoseconds: 7)
+    #expect(LegacyRetirement.rollUp(["a": .match(id)]) == LegacyRetirement.SetVerdict.match)
+  }
+
+  @Test func partialMatchRollsUpToMismatch() {
+    let id = LegacyRetirement.FileIdentity(
+      device: 1, inode: 2, sizeBytes: 3, modifiedAtSeconds: 4, modifiedAtNanoseconds: 5,
+      changedAtSeconds: 6, changedAtNanoseconds: 7)
+    // The crash-mid-delete shape. A partial match is not our artifact — without a marker it
+    // must delete nothing. `match + absent` is the case a naive "any match wins" gets wrong.
+    #expect(LegacyRetirement.rollUp(["a": .match(id), "b": .absent]) == .mismatch)
+    #expect(LegacyRetirement.rollUp(["a": .match(id), "b": .mismatch]) == .mismatch)
+    #expect(LegacyRetirement.rollUp(["a": .absent, "b": .mismatch]) == .mismatch)
+  }
+
+  @Test func unreadableOutranksEveryOtherVerdict() {
+    let id = LegacyRetirement.FileIdentity(
+      device: 1, inode: 2, sizeBytes: 3, modifiedAtSeconds: 4, modifiedAtNanoseconds: 5,
+      changedAtSeconds: 6, changedAtNanoseconds: 7)
+    // "Cannot tell" must never be reported as "can tell, and it is not ours": the second is a
+    // permanent decline, the first is retryable.
+    #expect(LegacyRetirement.rollUp(["a": .unreadable, "b": .match(id)]) == .unreadable)
+    #expect(LegacyRetirement.rollUp(["a": .unreadable, "b": .mismatch]) == .unreadable)
+    #expect(LegacyRetirement.rollUp(["a": .unreadable, "b": .absent]) == .unreadable)
+  }
+
+  // MARK: - L3: unlink only what we examined
+
+  @Test func unlinkRemovesMatchesAndPreservesEverythingElse() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let mine = Data("mine".utf8)
+    try stage(root, "mine.bin", mine)
+    try stage(root, "theirs.bin", Data("theirs".utf8))
+
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root,
+      files: [trusted("mine.bin", mine), trusted("theirs.bin", Data("expected".utf8))])
+    let result = LegacyRetirement.unlinkUnchanged(root: root, verdicts: verdicts)
+
+    #expect(result.unlinked == ["mine.bin"])
+    #expect(result.preserved == ["theirs.bin"])
+    #expect(!FileManager.default.fileExists(atPath: root.appendingPathComponent("mine.bin").path))
+    #expect(
+      FileManager.default.fileExists(atPath: root.appendingPathComponent("theirs.bin").path),
+      "bytes we could not identify must survive")
+  }
+
+  @Test func anEntryRewrittenAfterFingerprintIsPreservedNotDeleted() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let bytes = Data("mine".utf8)
+    let url = try stage(root, "a.bin", bytes)
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("a.bin", bytes)])
+
+    // Someone replaces the file between our proof and our delete. Identity — not the path —
+    // is what stops us destroying a file we never examined.
+    try FileManager.default.removeItem(at: url)
+    try Data("someone else's file, same name".utf8).write(to: url)
+
+    let result = LegacyRetirement.unlinkUnchanged(root: root, verdicts: verdicts)
+
+    #expect(result.unlinked.isEmpty)
+    #expect(result.preserved == ["a.bin"])
+    #expect(
+      try Data(contentsOf: url) == Data("someone else's file, same name".utf8),
+      "the replacement must be intact")
+  }
+
+  @Test func anIntermediateSwappedForASymlinkAfterFingerprintIsNotDeletedThrough() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let elsewhere = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: elsewhere) }
+
+    let bytes = Data("mine".utf8)
+    try stage(root, "dir/a.bin", bytes)
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("dir/a.bin", bytes)])
+
+    // The path was honest when we proved it. Between the proof and the delete, the
+    // intermediate directory becomes a symlink pointing somewhere else. `lstat` declines to
+    // follow only the FINAL component, so a path-based remove would traverse this.
+    let victim = try stage(elsewhere, "a.bin", bytes)
+    try FileManager.default.removeItem(at: root.appendingPathComponent("dir"))
+    try FileManager.default.createSymbolicLink(
+      at: root.appendingPathComponent("dir"), withDestinationURL: elsewhere)
+
+    let result = LegacyRetirement.unlinkUnchanged(root: root, verdicts: verdicts)
+
+    #expect(result.unlinked.isEmpty)
+    #expect(result.preserved == ["dir/a.bin"])
+    #expect(
+      FileManager.default.fileExists(atPath: victim.path),
+      "a file outside the root must survive a swapped intermediate")
+  }
+
+  @Test func aFailedRemoveReportsThePathAsPreserved() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let bytes = Data("mine".utf8)
+    try stage(root, "a.bin", bytes)
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("a.bin", bytes)])
+
+    struct Boom: Error {}
+    let result = LegacyRetirement.unlinkUnchanged(
+      root: root, verdicts: verdicts, removeItem: { _ in throw Boom() })
+
+    // A delete that threw must never be reported as unlinked — the caller keeps the marker
+    // and replays on that basis.
+    #expect(result.unlinked.isEmpty)
+    #expect(result.preserved == ["a.bin"])
+  }
+
+  @Test func aSymlinkedRootIsRefusedForBothFingerprintAndUnlink() async throws {
+    let real = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: real) }
+    let holder = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: holder) }
+
+    // The walk starts at the root's CHILDREN, so a root that is itself a link was never
+    // inspected: `cache/legacy -> ~/Documents/foreign` would put every "contained" file
+    // outside the intended store, and we delete what we match.
+    let bytes = Data("victim".utf8)
+    try stage(real, "a.bin", bytes)
+    let linkedRoot = holder.appendingPathComponent("legacy")
+    try FileManager.default.createSymbolicLink(at: linkedRoot, withDestinationURL: real)
+
+    let spy = HashSpy()
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: linkedRoot, files: [trusted("a.bin", bytes)], hashFile: spy.callback)
+
+    #expect(verdicts["a.bin"] == .mismatch, "a symlinked root is not a store we may retire")
+    #expect(await spy.count == 0)
+
+    let result = LegacyRetirement.unlinkUnchanged(
+      root: linkedRoot, verdicts: ["a.bin": .match(identityOf(real.appendingPathComponent("a.bin")))])
+    #expect(result.unlinked.isEmpty)
+    #expect(
+      FileManager.default.fileExists(atPath: real.appendingPathComponent("a.bin").path),
+      "files behind a linked root must survive")
+  }
+
+  @Test func productionRemovalGoesThroughUnlinkatNotAPathRemove() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // No `removeItem` seam: this is the production path. It must still delete a real match,
+    // which is what proves `unlinkVerified` is wired rather than silently preserving.
+    let bytes = Data("mine".utf8)
+    let url = try stage(root, "dir/a.bin", bytes)
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("dir/a.bin", bytes)])
+
+    let result = LegacyRetirement.unlinkUnchanged(root: root, verdicts: verdicts)
+
+    #expect(result.unlinked == ["dir/a.bin"])
+    #expect(!FileManager.default.fileExists(atPath: url.path))
+  }
+
+  @Test func aGrandparentSwappedForALinkAfterTheWalkCannotRedirectTheDelete() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let elsewhere = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: elsewhere) }
+
+    // Depth matters: `O_NOFOLLOW` guards only the FINAL component, so swapping the immediate
+    // PARENT is refused even by a naive path open, and a test that swaps the parent passes
+    // with or without the fix. The real hole is a swapped GRANDPARENT -- in
+    // `open("<root>/a/b", O_NOFOLLOW)`, only `b` is guarded and `a` is followed.
+    //
+    // What this test does and does not prove, stated because the difference is easy to
+    // over-claim. Falsified both ways: remove BOTH the lstat walk and the openat pinning and
+    // this deletes the file outside the root, so it guards real behavior. Remove only the
+    // openat pinning and it still passes, because the lstat walk refuses this STATIC case on
+    // its own. The openat walk's marginal value is the RACE between that walk and the open,
+    // which no deterministic test can stage without an injection seam. So: this is a genuine
+    // regression test for the static case, and it is NOT evidence for the pinning. Do not
+    // delete the pinning on the strength of this test staying green.
+    let bytes = Data("mine".utf8)
+    try stage(root, "a/b/c.bin", bytes)
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root, files: [trusted("a/b/c.bin", bytes)])
+    guard case .match = verdicts["a/b/c.bin"] else {
+      Issue.record("fixture must match before the swap")
+      return
+    }
+
+    // Move the whole subtree out and leave a link named `a` pointing at it. The leaf's inode
+    // is unchanged, so the identity check still matches: only pinning the ancestors refuses.
+    let victimTree = elsewhere.appendingPathComponent("a")
+    try FileManager.default.moveItem(at: root.appendingPathComponent("a"), to: victimTree)
+    try FileManager.default.createSymbolicLink(
+      at: root.appendingPathComponent("a"), withDestinationURL: victimTree)
+
+    let result = LegacyRetirement.unlinkUnchanged(root: root, verdicts: verdicts)
+
+    #expect(result.unlinked.isEmpty)
+    #expect(
+      FileManager.default.fileExists(atPath: victimTree.appendingPathComponent("b/c.bin").path),
+      "the file must survive: it now lives outside the retirement root")
+  }
+
+  // MARK: - Containment
+
+  @Test func containmentAcceptsAnHonestNestedPathAndRejectsAnEscape() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    #expect(LegacyRetirement.isContained(root.appendingPathComponent("a/b"), within: root))
+    #expect(LegacyRetirement.isContained(root, within: root))
+    #expect(!LegacyRetirement.isContained(root.appendingPathComponent("../escape"), within: root))
+  }
+
+  @Test func containmentRejectsASymlinkEscapingTheRoot() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let elsewhere = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: elsewhere) }
+
+    // Resolve-then-compare: this escapes in fact while comparing fine as a string.
+    let link = root.appendingPathComponent("out")
+    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: elsewhere)
+
+    #expect(!LegacyRetirement.isContained(link, within: root))
+  }
+
+  // MARK: - Marker
+
+  @Test func markerWritesReadsAndClearsIdempotently() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let marker = root.appendingPathComponent("nested/deeper/owed")
+    #expect(LegacyRetirement.writeMarkerAtomically(marker), "must create intermediate dirs")
+    #expect(FileManager.default.fileExists(atPath: marker.path))
+    #expect(try Data(contentsOf: marker).isEmpty, "the marker is zero-byte")
+
+    try LegacyRetirement.clearMarker(marker)
+    #expect(!FileManager.default.fileExists(atPath: marker.path))
+
+    // Clearing an absent marker is success: the postcondition the caller needs already holds.
+    try LegacyRetirement.clearMarker(marker)
+  }
+
+  @Test func markerWriteReportsFailureRatherThanThrowing() throws {
+    // A caller that cannot write the marker must delete nothing — that is a decision it makes
+    // from a Bool, not an error it catches.
+    let unwritable = URL(fileURLWithPath: "/System/nope-\(UUID().uuidString)/owed")
+    #expect(!LegacyRetirement.writeMarkerAtomically(unwritable))
+  }
+
+  // MARK: - OS semantic (freezes §8.3)
+
+  @Test func unlinkingAMappedFileLeavesTheMappingReadable() throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let payload = Data(repeating: 0x5A, count: 64 * 1_024)
+    let url = try stage(root, "mapped.bin", payload)
+
+    let fd = open(url.path, O_RDONLY)
+    #expect(fd >= 0)
+    defer { close(fd) }
+    let mapped = mmap(nil, payload.count, PROT_READ, MAP_PRIVATE, fd, 0)
+    #expect(mapped != MAP_FAILED)
+    defer { munmap(mapped, payload.count) }
+
+    try FileManager.default.removeItem(at: url)
+
+    // Removing a directory entry does not invalidate an existing mapping; the inode lives
+    // until the last reference closes. This design only unlinks — it never truncates or
+    // rewrites in place, which is what actually SIGBUSes. Frozen here so a future session
+    // cannot re-derive the folklore from memory and rebuild a design around it.
+    let seen = UnsafeRawBufferPointer(start: mapped, count: payload.count)
+    #expect(seen.allSatisfy { $0 == 0x5A }, "the mapping must survive the unlink")
+    #expect(!FileManager.default.fileExists(atPath: url.path))
+  }
+}

--- a/Tests/EnviousWisprTests/ModelDelivery/LegacyRetirementTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/LegacyRetirementTests.swift
@@ -148,6 +148,25 @@ import Testing
     #expect(verdicts["AudioEncoder.mlmodelc/coremldata.bin"] == .mismatch)
   }
 
+  @Test func aDeepPathUnderARegularFileIsMismatchNotAbsent() async throws {
+    let root = try makeRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // A regular file occupies a component, and the manifest expects a directory two levels
+    // deeper -- so the stat/open fails with ENOTDIR, not ENOENT. Those are different facts:
+    // ENOENT is "nothing there", ENOTDIR is "something is there and it is the wrong shape".
+    // Calling it absent would let a whole set roll up to "nothing here", so policy would fall
+    // silent instead of refusing, and unknown bytes sitting in the model path would read as
+    // an empty store.
+    try stage(root, "AudioEncoder.mlmodelc", Data("a file, not a directory".utf8))
+
+    let verdicts = try await LegacyRetirement.fingerprint(
+      root: root,
+      files: [trusted("AudioEncoder.mlmodelc/analytics/coremldata.bin", Data("x".utf8))])
+
+    #expect(verdicts["AudioEncoder.mlmodelc/analytics/coremldata.bin"] == .mismatch)
+  }
+
   @Test func missingFileIsAbsentAndIsNeverHashed() async throws {
     let root = try makeRoot()
     defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## What this is

Part of #1386 (epic #1348, Phase 4), sliced per founder ruling 2026-07-17: the WhisperKit convergence became three PRs, one per verb — **delete a folder** (2a+2b), **download a folder** (2b), **add a button** (2c). This is the first: the shared *mechanism*, with EG-1 moved onto it. **No user-visible change.**

EG-1 already knows how to retire an artifact it can prove is ours: fingerprint against a trusted manifest, mark, unlink, refetch. WhisperKit needs exactly that, over 24 nested files instead of one flat one. Copying it would give us two implementations of the same proof; generalizing the whole coordinator would drag EG-1's old-store policy and WhisperKit's Documents/TCC concerns into one type. So: **mechanism shared, policy separate.**

## The claim, and its oracle

**EG-1's 29 existing tests pass UNMODIFIED** — `Test run with 29 tests in 1 suite passed`, and `git diff --name-only -- Tests/EnviousWisprTests/LLM/` returns zero files. That is the entire claim of a behavior-neutral refactor: one that needed its tests edited would not be behavior-neutral. EG-1 shrank by 27 lines and kept 100% of its policy.

Full suite: **2,888 + 154 tests green.** Local Codex code-diff review: **clean** (round 5, after 4 rounds of real findings).

## Eight defects found and fixed, every one able to delete a file we never proved was ours

This PR's job is deleting a user's 1.6 GB model. Every round of review found a deletion bug; that is why there were five rounds.

| # | Defect | What it did |
|---|---|---|
| 1 | symlinked intermediate | hashed a stranger's file, called it ours, deleted it |
| 2 | `..` traversal | escaped the root entirely (probe: resolved to `/tmp`) |
| 3 | same-second rewrite | deleted bytes never hashed |
| 4 | symlinked root | the whole store could point outside |
| 5 | path-based delete | followed anything swapped underneath |
| 6 | cancel-as-verdict | permanent false "unreadable" on a user's good model |
| 7 | iCloud stub | silently hydrate 1.6 GB from iCloud, every launch, forever |
| 8 | **hash not bound to the file** | **deleted bytes never verified** |

**#8 broke the type's central promise.** "We only delete what we examined" was false: checking and hashing were two separate lookups by name, so a writer could swap in a decoy holding trusted bytes, let us hash *that*, restore the original, and we would delete a file we never read. Fingerprint now opens **once** and takes identity, size, type and digest from that one descriptor — the two proofs describe the same inode by construction.

**The pattern was the real finding.** Six deletion bugs in three rounds was not six accidents: `importLocalCandidate` — the primitive 2b deletes — already had all of this, and salvaging it piecemeal meant re-deriving its guards one review round at a time. Its own comments say *"same sub-second mtime"* and warn that cleanup would *"delete manifest-named files at the link's TARGET, somewhere the user never pointed us."* Findings 2, 3 and 4 were already solved in the code being deleted. That is exactly what `port-proven-patterns-wholesale` forbids. So I stopped patching, inventoried all seven of its guards, and ported the remainder — the missing one was the iCloud stub, which matters more here than it did there, because this cache lives under `~/Documents` where users sync.

Round 4's four findings likewise shared one root — `O_NOFOLLOW` guards only the *final* component, so every path open followed a swapped **ancestor** — and got one fix: an `openat` walk from a pinned root descriptor.

## Honesty notes

- **The swapped-ancestor test does not prove the `openat` pinning.** Falsified both ways: remove both the `lstat` walk and the pinning and it deletes a file outside the root (so it guards real behavior); remove only the pinning and it still passes, because the `lstat` walk refuses that *static* case alone. The pinning exists for the race *between* the walk and the open, which no deterministic test can stage without an injection seam. Both guards stay, and the code says why.
- **One residual is irreducible.** POSIX has no "unlink this exact inode" call, so a few instructions still separate the identity check from the `unlinkat`. That is the shared-cache residual the plan already accepts (§8.1/8.1a, founder-ruled): a foreign writer racing us inside `~/Documents/huggingface` can defeat any identity check. Not lockable — we do not own the other writer.
- **L4 (the declined record) is deliberately NOT here.** It needs identities for *non-matching* entries, which classification does not produce, and its only consumer is 2b. Shipping it now would add an unused persistence seam.

## Test plan

- `scripts/xcode-test.sh` — 2,888 + 154 green
- EG-1's 29, unmodified — the oracle
- 34 new, all asserting **positives**: these refusals are silent by design, and "did not crash" cannot tell a correct refusal from a path that never ran
- Includes an `mmap`/`unlink` test freezing the POSIX semantic the withdrawn design was built on a misreading of

Plan: `docs/feature-requests/issue-1386-2026-07-17-pr2-retire-refetch-v2.md` (gitignored, root worktree).
