### PR TITLE
fix(worker): stop clearing the sentry-triage throttle on resolved/archived

### DIFF
--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -109,7 +109,7 @@ async function verifyHmac(body, sigHeader, secret) {
 
 // ── Main triage handler (orchestration only) ───────────────────────────────────
 
-async function handleTriage(body, env) {
+export async function handleTriage(body, env) {
   let payload;
   try {
     payload = JSON.parse(body);
@@ -151,15 +151,16 @@ async function handleTriage(body, env) {
 
   const kvKey = `sentry:${issueId}`;
 
-  // Terminal actions are handled before any network lookup. Deleting the throttle
-  // key ensures a later regression does not inherit a stale notification throttle.
+  // Terminal actions post nothing and need no KV write. The throttle key is
+  // deliberately left alone: Rule 7's explicit regression bypass (`action ===
+  // "unresolved" && issue?.substatus === "regressed"`) already lets a genuine
+  // regression post regardless of a stored throttle, so clearing the key here
+  // served no purpose for that case — it only let a bare resolved -> unresolved
+  // flap (no substatus:regressed) read as `stored == null` at Rule 7 and re-buzz
+  // inside the throttle window (#1485). The stored entry's own TTL
+  // (KV_TTL_SECONDS) reclaims it once the window is long past.
   if (action === "resolved" || action === "archived") {
-    try {
-      await env.SENTRY_DEDUP.delete(kvKey);
-    } catch (err) {
-      console.error(`[sentry-triage] KV delete failed for ${issueId}:`, err.message);
-    }
-    console.log(`[sentry-triage] Issue ${issueId} ${action} — throttle cleared, no post`);
+    console.log(`[sentry-triage] Issue ${issueId} ${action} — no post`);
     return;
   }
 

--- a/workers/sentry-triage/test/index.test.js
+++ b/workers/sentry-triage/test/index.test.js
@@ -3,6 +3,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  handleTriage,
   decideNotification,
   scoreFromEvents,
   normalizeRelease,
@@ -213,6 +214,49 @@ test("decideNotification: bare unresolved (not regressed) still respects an acti
   });
   assert.equal(r.post, false);
   assert.equal(r.reason, "throttled");
+});
+
+// The two tests above/below pair up to cover #1485: `decideNotification` only
+// respects a stored throttle if `handleTriage` actually leaves it in KV. A
+// resolved/archived webhook used to delete it unconditionally, which made a
+// later bare-unresolved flap read as `stored == null` and bypass rule 7 —
+// these confirm the KV entry now survives the terminal webhook.
+function fakeKV(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    async get(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    async put(key, value) {
+      store.set(key, value);
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+  };
+}
+
+test("handleTriage: resolved leaves a stored throttle intact", async () => {
+  const kvKey = "sentry:123";
+  const stored = JSON.stringify({ lastNotifiedAt: NOW - 1000, priority: "P2" });
+  const kv = fakeKV({ [kvKey]: stored });
+  const body = JSON.stringify({ action: "resolved", data: { issue: { id: "123" } } });
+
+  await handleTriage(body, { SENTRY_DEDUP: kv });
+
+  assert.equal(kv.store.get(kvKey), stored);
+});
+
+test("handleTriage: archived leaves a stored throttle intact", async () => {
+  const kvKey = "sentry:456";
+  const stored = JSON.stringify({ lastNotifiedAt: NOW - 1000, priority: "P1" });
+  const kv = fakeKV({ [kvKey]: stored });
+  const body = JSON.stringify({ action: "archived", data: { issue: { id: "456" } } });
+
+  await handleTriage(body, { SENTRY_DEDUP: kv });
+
+  assert.equal(kv.store.get(kvKey), stored);
 });
 
 test("decideNotification: unsupported action -> suppress", () => {


### PR DESCRIPTION
## Summary
- A resolved/archived Sentry webhook deleted the per-issue KV throttle entry before any decision ran. Rule 7's own regression bypass already posts regardless of stored throttle state, so the delete served no purpose there — it only let a bare resolved -> unresolved flap (no `substatus:regressed`) read the wiped key as `stored == null` and re-buzz inside the throttle window, defeating the throttle's stated purpose.
- Leaves the KV entry alone on terminal actions; its own TTL still reclaims it. `decideNotification` is restored as the single owner of throttle policy.
- Exported `handleTriage` for direct testing; added two tests proving a stored throttle survives both `resolved` and `archived` webhooks (pairs with the existing "bare unresolved... still respects an active throttle" test on `decideNotification`).

Lane: Worker. Tier: SMALL.

## Test plan
- [x] `node --test` — 60/60 passing (58 existing + 2 new)
- [x] `codex review` — clean, no findings
- [ ] Cloud review

Closes #1485