### PR TITLE
fix(telemetry): stop hand-spelling asr_backend, read it from the enum

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -101,9 +101,7 @@ final class DictationRuntime {
     let heartControlRecovery = HeartControlRecovery(
       hideOverlay: { [recordingOverlay] in recordingOverlay.show(intent: .hidden) },
       setLocked: { locked in recordingLockedAccess.set(locked) },
-      backend: { [asrManager] in
-        asrManager.activeBackendType == .whisperKit ? "whisperkit" : "parakeet"
-      }
+      backend: { [asrManager] in asrManager.activeBackendType.rawValue }
     )
     let finalizer = RecordingFinalizer(
       kernelDriver: kernelDriver,

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -175,7 +175,8 @@ final class RecordingStarter {
   /// guard.
   func start() async {
     dictationLifecycleCoordinator?.cancelPendingWarning()
-    let isWhisperKit = asrManager.activeBackendType == .whisperKit
+    let backend = asrManager.activeBackendType
+    let isWhisperKit = backend == .whisperKit
     let active: KernelDictationDriver = isWhisperKit ? whisperKitKernelDriver : kernelDriver
     // PR-7 (#827): snapshot engine readiness BEFORE prewarm so the cold-start
     // log cohorts warm/cold/mid-flight; snapshot-at-entry avoids retro-labeling.
@@ -191,8 +192,7 @@ final class RecordingStarter {
     // using. Takes precedence over the cold-engine gate below (same shape).
     if isRecovering() {
       recordingOverlay.show(intent: .recoveringLastRecording)
-      TelemetryService.shared.recoveryPressBlocked(
-        asrBackend: isWhisperKit ? "whisperkit" : "parakeet")
+      TelemetryService.shared.recoveryPressBlocked(asrBackend: backend.rawValue)
       return
     }
     // #1171 — start-of-recording safety: never record on an engine other than the
@@ -213,7 +213,7 @@ final class RecordingStarter {
     if readinessAtEntry != .ready {
       let warmRespawn = ColdPressGuard.resolveNotReadyPress(
         overlay: recordingOverlay, active: active,
-        backendTag: isWhisperKit ? "whisperkit" : "parakeet",
+        backendTag: backend.rawValue,
         readiness: readinessAtEntry, modelUnloadPolicy: settings.modelUnloadPolicy)
       if !warmRespawn { return }
     }
@@ -368,7 +368,7 @@ final class RecordingStarter {
       SentryBreadcrumb.captureError(
         ModelLoadWatchdog.WedgeError(stage: "post_condition"),
         category: .pipelinePostConditionFailed, stage: "recording",
-        extra: ["backend": isWhisperKit ? "whisperkit" : "parakeet"]
+        extra: ["backend": backend.rawValue]
       )
       recordingOverlay.show(intent: .hidden)
       recordingLockedAccess.set(false)
@@ -382,7 +382,7 @@ final class RecordingStarter {
     }
     Task {
       await AppLogger.shared.log(
-        "COLD-START [RecordingStarter] PTT-to-recording: total=\(totalMs)ms preWarm=\(preWarmMs)ms startRecording=\(totalMs - preWarmMs)ms backend=\(isWhisperKit ? "whisperkit" : "parakeet") engineReadinessAtPTT=\(readinessAtEntry.coldStartCohortToken)",
+        "COLD-START [RecordingStarter] PTT-to-recording: total=\(totalMs)ms preWarm=\(preWarmMs)ms startRecording=\(totalMs - preWarmMs)ms backend=\(backend.rawValue) engineReadinessAtPTT=\(readinessAtEntry.coldStartCohortToken)",
         level: .info, category: "Pipeline"
       )
     }
@@ -394,7 +394,8 @@ final class RecordingStarter {
   /// snapshot picks up the right paste capability.
   func toggle(source: TriggerSource) async {
     dictationLifecycleCoordinator?.cancelPendingWarning()
-    let isWK = asrManager.activeBackendType == .whisperKit
+    let backend = asrManager.activeBackendType
+    let isWK = backend == .whisperKit
     let active: KernelDictationDriver = isWK ? whisperKitKernelDriver : kernelDriver
     let isStartingFromIdle =
       !(isWK ? whisperKitKernelDriver.state.isActive : kernelDriver.state.isActive)
@@ -406,7 +407,7 @@ final class RecordingStarter {
       // `isStartingFromIdle`).
       if isRecovering() {
         recordingOverlay.show(intent: .recoveringLastRecording)
-        TelemetryService.shared.recoveryPressBlocked(asrBackend: isWK ? "whisperkit" : "parakeet")
+        TelemetryService.shared.recoveryPressBlocked(asrBackend: backend.rawValue)
         return
       }
       // #1171 — start-of-recording safety, same as the PTT path: never record on
@@ -423,7 +424,7 @@ final class RecordingStarter {
         // #879 pill. Same decision helper as the PTT path.
         isWarmRespawn = ColdPressGuard.resolveNotReadyPress(
           overlay: recordingOverlay, active: active,
-          backendTag: isWK ? "whisperkit" : "parakeet",
+          backendTag: backend.rawValue,
           readiness: active.engineReadiness, modelUnloadPolicy: settings.modelUnloadPolicy)
         if !isWarmRespawn { return }
       }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -348,8 +348,7 @@ public final class WisprBootstrapper {
 
     // Restore persisted backend selection synchronously (no race with first record).
     asrManager.setInitialBackendType(settings.selectedBackend)
-    SentryBreadcrumb.updateASRBackend(
-      settings.selectedBackend == .whisperKit ? "whisperkit" : "parakeet")
+    SentryBreadcrumb.updateASRBackend(settings.selectedBackend.rawValue)
 
     // #1173: settings-change telemetry observer. `emitBaseline` re-emits the
     // comprehensive `settings.snapshot` at onboarding-completion (fixes the
@@ -569,7 +568,7 @@ public final class WisprBootstrapper {
         },
         performSwitch: { [asrManager] backend in
           await asrManager.switchBackend(to: backend)
-          SentryBreadcrumb.updateASRBackend(backend == .whisperKit ? "whisperkit" : "parakeet")
+          SentryBreadcrumb.updateASRBackend(backend.rawValue)
         },
         warm: { [kernelDriver, whisperKitKernelDriver] backend in
           await (backend == .whisperKit ? whisperKitKernelDriver : kernelDriver)

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -79,7 +79,7 @@ public enum SentryBreadcrumb {
   /// Update recording state on global scope. Present on fatal crashes.
   /// - Parameters:
   ///   - active: Whether recording is in progress.
-  ///   - backend: "parakeet" or "whisperkit" (nil when stopping).
+  ///   - backend: "parakeet" or "whisperKit" (nil when stopping).
   ///   - isStreaming: Whether streaming ASR is active (nil when stopping).
   public static func updateRecordingState(
     active: Bool,

--- a/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
@@ -54,7 +54,7 @@ import Testing
     let hcr = HeartControlRecovery(
       hideOverlay: { overlay.show(intent: .hidden) },
       setLocked: { locked in lockAccess.set(locked) },
-      backend: { asr.activeBackendType == .whisperKit ? "whisperkit" : "parakeet" }
+      backend: { asr.activeBackendType.rawValue }
     )
     let finalizer = RecordingFinalizer(
       kernelDriver: pipeline,

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -79,7 +79,7 @@ import Testing
     let hcr = HeartControlRecovery(
       hideOverlay: { overlay.show(intent: .hidden) },
       setLocked: { locked in lockAccess.set(locked) },
-      backend: { asr.activeBackendType == .whisperKit ? "whisperkit" : "parakeet" }
+      backend: { asr.activeBackendType.rawValue }
     )
     let finalizer = RecordingFinalizer(
       kernelDriver: pipeline,

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -120,10 +120,20 @@ import Testing
     // Grounded Review round 1). No new collaborator or method; only the
     // paper-line ceiling moves. Deterministic rule: actual 522 + 10 → round
     // up to nearest 5 = 535.
+    // #1580: raised 535 → 550 for a `backend`/`isWhisperKit`-shape local in
+    // both `start()` and `toggle(source:)` (`let backend = asrManager.
+    // activeBackendType`), named so `backend.rawValue` reads the wire spelling
+    // once instead of nine call sites each re-typing a "whisperkit" : "parakeet"
+    // ternary that had drifted into two different casings. `start()`'s new
+    // local nets zero (it lets an already-wrapped call collapse back to one
+    // line); `toggle(source:)`'s has no such call to collapse against, so it
+    // adds one line net. No new collaborator or method; only the paper-line
+    // ceiling moves. Deterministic rule: actual 536 + 10 → round up to
+    // nearest 5 = 550.
     #expect(
-      count <= 535,
+      count <= 550,
       """
-      RecordingStarter line count exceeded: \(count) > 535. \
+      RecordingStarter line count exceeded: \(count) > 550. \
       Raise via Bible §30 only.
       """)
   }


### PR DESCRIPTION
## Summary
- `coldstart.press_blocked` / `recovery.press_blocked` emitted `whisperkit` (lowercase k) while `dictation.completed` / `settings.snapshot` / `onboarding.completed` emitted `whisperKit` (the enum's rawValue) — an exact-match analytics query on one spelling silently undercounted by ~45% with no error.
- Nine call sites hand-typed a `"whisperkit" : "parakeet"` ternary instead of reading `ASRBackendType.rawValue`, which already carries the single correct spelling. Replaced every one with a direct read of the enum, removing the whole class of drift rather than adding a second copy to keep in sync.
- Introduced a `backend`/`isWhisperKit` local in both `start()` and `toggle(source:)` so `backend.rawValue` reads the spelling once per function. Bumped the `RecordingStarterCeilingsTests` line ceiling 535 -> 550 (file's own deterministic rule) with a Bible-changelog entry, since `toggle(source:)`'s addition has no already-wrapped call to collapse against and nets +1 line.

Lane: Code. Tier: SMALL (zero new types/APIs/control-flow, literal-to-property-read substitution only).

## Test plan
- [x] Full suite (`scripts/xcode-test.sh`): 2,893 tests / 328 suites passing, including the bumped ceiling test
- [x] `codex review` — clean, no findings
- [x] Live UAT: dev app rebuilt from this branch, real dictation via `wispr_eyes.test_recording()` — heart path intact, transcription correct
- [ ] Cloud review

Closes #1580