### PR TITLE
fix(worker): cap daily-report PostHog concurrency, add per-query retry

### DIFF
--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -188,21 +188,89 @@ function tierASqlFor(activeIds, endTs) {
     LIMIT ${PER_USER_LIST_LIMIT}`;
 }
 
-async function hogql(env, sql) {
-  const res = await fetch(`${POSTHOG_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/query/`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${env.POSTHOG_PERSONAL_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ query: { kind: "HogQLQuery", query: sql }, refresh: "blocking" }),
-  });
-  if (!res.ok) {
-    throw new Error(`PostHog query HTTP ${res.status}`);
+// PostHog's project-level rate limit allows only 3 concurrent queries and
+// queues/cancels/times-out (HTTP 502/503/504) anything beyond that (#1588,
+// posthog.com/docs/api/queries + posthog.com/docs/endpoints/rate-limits).
+// `runLimited` below caps our own concurrency under that ceiling; this retry
+// is the second, complementary layer for genuine transient contention (e.g.
+// the project is shared with EnviousStaging - analytics-operations.md FACT:
+// posthog-project-is-shared-with-enviousstaging). It retries exactly once,
+// only on the documented queue-timeout status class, and only ever before
+// any Discord post happens - unlike the deliberately-rejected outer
+// GitHub-Actions-level retry (see the comment in daily-report-ping.yml),
+// this cannot produce a duplicate or confusing failure notice.
+const RETRYABLE_POSTHOG_STATUSES = new Set([502, 503, 504]);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function hogql(
+  env,
+  sql,
+  queryName,
+  { fetchFn = fetch, sleepFn = sleep, retryDelayMs = 1500 } = {}
+) {
+  const url = `${POSTHOG_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/query/`;
+
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const res = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.POSTHOG_PERSONAL_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: { kind: "HogQLQuery", query: sql },
+        refresh: "blocking",
+        name: `daily_report_${queryName}`,
+      }),
+    });
+
+    if (res.ok) {
+      const json = await res.json();
+      if (!json.results) throw new Error(`PostHog query ${queryName} returned no results array`);
+      return json;
+    }
+
+    const status = res.status;
+    if (res.body) {
+      try {
+        await res.body.cancel();
+      } catch (_) {
+        // Best effort: the status remains the authoritative failure, and a
+        // failed cancel must not mask it. Draining/cancelling the failed
+        // body here matters specifically because a retry immediately opens
+        // a NEW outbound request on the same wave - an uncancelled body can
+        // hold its Cloudflare subrequest connection open, and enough of
+        // those piling up across retries could exhaust Cloudflare's own
+        // outbound-connection ceiling and recreate the stall this change
+        // exists to fix (Codex code-diff review, round 2, #1588).
+      }
+    }
+
+    if (attempt === 2 || !RETRYABLE_POSTHOG_STATUSES.has(status)) {
+      throw new Error(`PostHog query ${queryName} HTTP ${status}`);
+    }
+    await sleepFn(retryDelayMs);
   }
-  const json = await res.json();
-  if (!json.results) throw new Error("PostHog query returned no results array");
-  return json;
+}
+
+// Runs `tasks` (zero-arg async thunks) in fixed waves of at most `limit`
+// concurrently, preserving input order in the returned results. Exists
+// because PostHog's project-level query-concurrency ceiling is 3 (#1588) -
+// firing more than that at once gets the excess queued for up to 30s before
+// PostHog cancels/times it out. A failed wave stops later waves from
+// starting, matching `Promise.all`'s existing all-or-nothing contract for
+// the whole batch (already-started requests within a wave still run to
+// completion; a new wave simply never starts).
+export async function runLimited(tasks, limit) {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new TypeError("limit must be a positive integer");
+  }
+  const results = [];
+  for (let start = 0; start < tasks.length; start += limit) {
+    const wave = tasks.slice(start, start + limit);
+    results.push(...(await Promise.all(wave.map((task) => task()))));
+  }
+  return results;
 }
 
 function rowsToObjects(res) {
@@ -264,30 +332,35 @@ export async function fetchReportData(env, win, endUTC) {
     ORDER BY n DESC
     LIMIT 5`;
 
-  // The first 6 queries are fully independent and fire concurrently
-  // (plan §3.3, Gemini's CF-wall-clock-timeout finding). Polish tier-a
-  // (below) is the one exception: an EARLIER version embedded the
-  // active-user bound as a re-evaluated nested subquery inside a UNION and
-  // that measurably timed out against production PostHog (HTTP 504) - two
-  // nested re-scans of the whole PROD filter's dev-exclusion subquery,
-  // twice, inside a UNION, is too expensive. Fixed by resolving the
-  // active-user id list from `engineAndTierB` (already fetched, zero extra
-  // cost) and passing it to tier-a as a literal IN-list instead of a
-  // subquery - the exact pattern already validated empirically during
-  // planning. This is the one query that runs sequentially after the batch;
-  // still well within Cloudflare's execution ceiling (six ~1-3s concurrent
-  // queries, then one more).
-  const [installs, onboardActivate, totals, engineAndTierB, geo, top5] = await Promise.all([
-    hogql(env, installsSql),
-    hogql(env, onboardActivateSql),
-    hogql(env, totalsSql),
-    hogql(env, engineAndTierBSql),
-    hogql(env, geoSql),
-    hogql(env, top5Sql),
-  ]);
+  // These 6 queries are independent, but PostHog allows only 3 concurrent
+  // queries per project (#1588) - `runLimited(..., 2)` runs them in 3 fixed
+  // waves of 2, leaving one slot of headroom for the shared project's other
+  // traffic (EnviousStaging) rather than firing all 6 at once and getting
+  // the excess queued/timed-out. Polish tier-a (below) runs sequentially
+  // *after* all 3 waves finish - it does not need reserved concurrency.
+  // Tier-a has its own history: an EARLIER version embedded the active-user
+  // bound as a re-evaluated nested subquery inside a UNION and that
+  // measurably timed out against production PostHog (HTTP 504) - two nested
+  // re-scans of the whole PROD filter's dev-exclusion subquery, twice,
+  // inside a UNION, is too expensive. Fixed by resolving the active-user id
+  // list from `engineAndTierB` (already fetched, zero extra cost) and
+  // passing it to tier-a as a literal IN-list instead of a subquery.
+  const [installs, onboardActivate, totals, engineAndTierB, geo, top5] = await runLimited(
+    [
+      () => hogql(env, installsSql, "installs"),
+      () => hogql(env, onboardActivateSql, "onboard_activate"),
+      () => hogql(env, totalsSql, "totals"),
+      () => hogql(env, engineAndTierBSql, "engine_and_tier_b"),
+      () => hogql(env, geoSql, "geo"),
+      () => hogql(env, top5Sql, "top5"),
+    ],
+    2
+  );
 
   const activeIds = (engineAndTierB.results || []).map((row) => row[0]);
-  const tierA = activeIds.length ? await hogql(env, tierASqlFor(activeIds, endTs)) : { results: [], columns: [] };
+  const tierA = activeIds.length
+    ? await hogql(env, tierASqlFor(activeIds, endTs), "tier_a")
+    : { results: [], columns: [] };
 
   return {
     freshInstalls: installs.results[0][0],

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -6,6 +6,8 @@ import {
   easternYesterdayWindowUTC,
   resolveBuckets,
   buildMessage,
+  hogql,
+  runLimited,
 } from "../src/index.js";
 
 // ---- easternYesterdayWindowUTC ----
@@ -219,3 +221,120 @@ test("source guardrail: every per-user GROUP BY query has an explicit LIMIT", as
 // without mocking the HogQL engine. It is verified by the pre-deploy
 // live-query smoke (live-query-smoke.mjs) against real production data, and
 // by code review of the tierASql query text in src/index.js.
+
+// ---- runLimited (#1588 - PostHog's 3-concurrent-query project limit) ----
+
+test("runLimited: never exceeds the given concurrency and preserves input order", async () => {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const tasks = [1, 2, 3, 4, 5].map(
+    (n) => () =>
+      new Promise((resolve) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        setTimeout(() => {
+          inFlight -= 1;
+          resolve(n);
+        }, 5);
+      })
+  );
+  const results = await runLimited(tasks, 2);
+  assert.deepEqual(results, [1, 2, 3, 4, 5]);
+  assert.ok(maxInFlight <= 2, `expected at most 2 concurrent tasks, saw ${maxInFlight}`);
+});
+
+test("runLimited: a failed wave rejects and never starts a later wave", async () => {
+  let laterWaveStarted = false;
+  const tasks = [
+    () => Promise.resolve("ok"),
+    () => Promise.reject(new Error("boom")),
+    () => {
+      laterWaveStarted = true;
+      return Promise.resolve("should not run");
+    },
+  ];
+  await assert.rejects(() => runLimited(tasks, 2), /boom/);
+  assert.equal(laterWaveStarted, false);
+});
+
+test("runLimited: rejects a non-positive-integer limit", async () => {
+  await assert.rejects(() => runLimited([() => Promise.resolve(1)], 0), TypeError);
+});
+
+// ---- hogql retry (#1588 - PostHog project concurrency limit / 504s) ----
+
+function fakeResponse(status, body, { onCancel } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    body: onCancel ? { cancel: async () => onCancel() } : undefined,
+  };
+}
+
+test("hogql: retries once on 504 then succeeds, without a real delay", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return calls === 1 ? fakeResponse(504) : fakeResponse(200, { results: [[1]] });
+  };
+  const sleeps = [];
+  const sleepFn = async (ms) => sleeps.push(ms);
+  const json = await hogql({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, "SELECT 1", "test_query", {
+    fetchFn,
+    sleepFn,
+  });
+  assert.deepEqual(json.results, [[1]]);
+  assert.equal(calls, 2);
+  assert.deepEqual(sleeps, [1500]);
+});
+
+// Codex code-diff review, round 2 (#1588): an earlier draft of the retry
+// path left the failed response body uncancelled, which could keep a
+// Cloudflare outbound subrequest connection occupied across retries.
+test("hogql: cancels the failed response body before retrying", async () => {
+  let cancelled = false;
+  const fetchFn = async () => fakeResponse(504, undefined, { onCancel: () => (cancelled = true) });
+  await assert.rejects(
+    () =>
+      hogql({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, "SELECT 1", "test_query", {
+        fetchFn,
+        sleepFn: async () => {
+          // Assert cancellation already happened by the time we'd be sleeping before a retry.
+          assert.equal(cancelled, true, "expected the failed body to be cancelled before the retry delay");
+        },
+      }),
+    /PostHog query test_query HTTP 504/
+  );
+  assert.equal(cancelled, true);
+});
+
+test("hogql: does not retry on a non-transient 4xx status", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return fakeResponse(400);
+  };
+  await assert.rejects(
+    () => hogql({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, "SELECT 1", "test_query", { fetchFn }),
+    /PostHog query test_query HTTP 400/
+  );
+  assert.equal(calls, 1, "must not retry a non-transient status");
+});
+
+test("hogql: throws with the query name after exhausting retries on repeated 504", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return fakeResponse(504);
+  };
+  await assert.rejects(
+    () =>
+      hogql({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, "SELECT 1", "engine_and_tier_b", {
+        fetchFn,
+        sleepFn: async () => {},
+      }),
+    /PostHog query engine_and_tier_b HTTP 504/
+  );
+  assert.equal(calls, 2, "expected exactly 2 attempts total");
+});


### PR DESCRIPTION
## Summary
- The daily-report worker fired 6 HogQL queries at once against a PostHog project whose documented limit is 3 concurrent queries, causing intermittent 504s (2 of the last 9 scheduled runs: 2026-07-14, 2026-07-17).
- Runs the batch in fixed waves of 2 (`runLimited`), adds a bounded retry on 502/503/504 inside `hogql`, and names every query so a future failure identifies which one failed.

## Process
- Root cause + fix researched against PostHog's own docs (context7 + live WebSearch, cross-confirmed).
- Plan: `docs/feature-requests/issue-1588-2026-07-17-daily-report-504-reliability.md`
- Grounded review (Codex): `docs/audits/2026-07-17-1588-daily-report-grounded-review.txt` — PROCEED-WITH-REVISIONS, all revisions applied (softened the root-cause claim, corrected a false "no retry exists" claim, fixed-wave runner, query naming, injected test seams).
- Code-diff review (Codex), 2 rounds: round 2 caught a real P2 (failed retry body never cancelled, could hold a Cloudflare connection open across retries) — fixed with a test proving it; round 3 clean.
- Follow-up filed for the same pattern in two other workers: #1589 (product-health, weekly-digest — no reproduced failure yet, deliberately deferred).

## Test plan
- [x] `node --test` — 23/23 passing (6 new: concurrency cap + order preservation, failed-wave stops later waves, invalid limit rejected, retry-then-succeed, no-retry-on-4xx, retry-exhaustion, body-cancel-before-retry)
- [x] `npx wrangler deploy --dry-run` clean
- [ ] Post-merge: `npx wrangler deploy` from main, then endpoint smoke via the documented `?date=` recovery hit against an already-reported date