### PR TITLE
test(hotkey): make suspend/resume idempotence test assert real state

### DIFF
--- a/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
+++ b/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
@@ -158,12 +158,28 @@ import Testing
     fx.hotkeyService.stop()
   }
 
-  @Test func suspendAndResumeAreSafeToCallRepeatedly() {
+  @Test func suspendAndResumeAreIdempotentAndObservable() {
+    // #1592: the prior version of this test called suspend()/resume() with
+    // zero #expect calls, and after only install() (never startIfEnabled()),
+    // isEnabled stayed false — HotkeyService.suspend()/resume() both guard on
+    // isEnabled, so every call silently no-op'd. It passed regardless of
+    // whether suspend/resume worked, were inverted, or were deleted.
     let fx = Self.makeFixture()
-    fx.controller.install()
+    fx.settings.hotkeyEnabled = true
+    fx.controller.startIfEnabled()
+    #expect(fx.hotkeyService.isEnabled == true)
+    #expect(fx.hotkeyService.isSuspended == false)
+
     fx.controller.suspend()
-    fx.controller.suspend()
+    #expect(fx.hotkeyService.isSuspended == true)
+    fx.controller.suspend()  // idempotent: already suspended, must stay suspended
+    #expect(fx.hotkeyService.isSuspended == true)
+
     fx.controller.resume()
-    fx.controller.resume()
+    #expect(fx.hotkeyService.isSuspended == false)
+    fx.controller.resume()  // idempotent: already resumed, must stay resumed
+    #expect(fx.hotkeyService.isSuspended == false)
+
+    fx.hotkeyService.stop()
   }
 }


### PR DESCRIPTION
Part of #1591

Closes #1592

## What

`HotkeyControllerInstallTests.suspendAndResumeAreSafeToCallRepeatedly` called `suspend()`/`resume()` with zero assertions, and only after `install()` (never `startIfEnabled()`) — `HotkeyService.suspend()`/`resume()` both guard on `isEnabled`, which stays `false` without a real `start()`, so every call silently no-op'd. It passed whether suspend/resume worked, were inverted, or were deleted.

## Fix

Drive `isEnabled` true first via `startIfEnabled()`, then assert `isSuspended` after each suspend/resume call, including the repeated-call idempotence case.

## Proof

Mutation-tested locally: removing `HotkeyService.suspend()`'s `isSuspended = true` assignment turns this test red; reverting turns it green; no other test in the file is affected either way.

No production code touched.

`council-skip: zero-blast-radius (test-only assertion strengthening, single file, no new symbols, drawn directly from a Codex-verified audit finding — no design/coverage question for council to weigh in on)`