### PR TITLE
fix(llm): extract platform-independent preflight decision for Apple Intelligence

### DIFF
--- a/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
@@ -320,6 +320,19 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
     }
   #endif
 
+  /// Pure preflight decision: given an already-normalized base code and the
+  /// current allowlist, is this language rejected? No `FoundationModels` type
+  /// involved, so unlike the 3 preflight tests guarded by
+  /// `#available(macOS 26.0, *)` + `SystemLanguageModel.default.availability
+  /// == .available` (which silently no-op on a CI runner without the
+  /// on-device model), this runs identically on every machine (#1596).
+  internal static func unsupportedBaseCode(
+    normalizedBase: String?, supportedLanguages: Set<String>
+  ) -> String? {
+    guard let base = normalizedBase, !supportedLanguages.contains(base) else { return nil }
+    return base
+  }
+
   public func polish(
     text: String,
     instructions: PolishInstructions,
@@ -344,8 +357,8 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       // inject a language-aware prompt clause downstream; for unsupported
       // langs we throw before burning a round trip on an empty generation.
       let normalizedBase = LanguageNormalizer.baseCode(config.detectedLanguage)
-      if let base = normalizedBase,
-        !Self.supportedLanguageProvider().contains(base)
+      if let base = Self.unsupportedBaseCode(
+        normalizedBase: normalizedBase, supportedLanguages: Self.supportedLanguageProvider())
       {
         Task {
           await AppLogger.shared.log(

--- a/Tests/EnviousWisprTests/LLM/AppleIntelligencePolishTests.swift
+++ b/Tests/EnviousWisprTests/LLM/AppleIntelligencePolishTests.swift
@@ -246,6 +246,46 @@ struct OutputLanguageValidatorTests {
   }
 }
 
+// MARK: - Preflight allowlist decision (platform-independent)
+
+/// #1596: the 3 tests in `AppleIntelligencePreflightGateTests` below all
+/// `guard SystemLanguageModel.default.availability == .available else {
+/// return }` — on a CI runner without the on-device model, all 3 silently
+/// no-op and still report green, so a completely broken language gate would
+/// never be caught there. `unsupportedBaseCode` is the pure decision those
+/// tests exercise indirectly; it touches no FoundationModels type, so these
+/// tests run identically on every machine regardless of model availability.
+@Suite("Apple Intelligence: preflight language allowlist (platform-independent)")
+struct UnsupportedBaseCodeTests {
+  @Test("rejects a base code outside the allowlist")
+  func rejectsUnsupported() {
+    #expect(
+      AppleIntelligenceConnector.unsupportedBaseCode(
+        normalizedBase: "ar", supportedLanguages: ["en", "de"]) == "ar")
+  }
+
+  @Test("allows a base code inside the allowlist")
+  func allowsSupported() {
+    #expect(
+      AppleIntelligenceConnector.unsupportedBaseCode(
+        normalizedBase: "de", supportedLanguages: ["en", "de"]) == nil)
+  }
+
+  @Test("nil normalizedBase (Parakeet / no-detection path) is never rejected")
+  func allowsNilBase() {
+    #expect(
+      AppleIntelligenceConnector.unsupportedBaseCode(
+        normalizedBase: nil, supportedLanguages: ["en"]) == nil)
+  }
+
+  @Test("empty allowlist rejects every non-nil base code")
+  func emptyAllowlistRejectsAll() {
+    #expect(
+      AppleIntelligenceConnector.unsupportedBaseCode(
+        normalizedBase: "en", supportedLanguages: []) == "en")
+  }
+}
+
 // MARK: - Preflight gate (FoundationModels-conditional)
 
 #if canImport(FoundationModels)


### PR DESCRIPTION
Part of #1591

Closes #1596

## What

All 3 tests in `AppleIntelligencePreflightGateTests` guard with `SystemLanguageModel.default.availability == .available` before reaching any assertion. On a CI runner without the on-device model available, all 3 silently no-op and still report green — a completely broken language allowlist could never be caught there.

## Fix

Extracted the pure decision (already-normalized base code + allowlist → rejected code or nil) into `AppleIntelligenceConnector.unsupportedBaseCode(normalizedBase:supportedLanguages:)` — no `FoundationModels` type involved, runs on every machine. `polish()`'s preflight now calls this helper instead of inlining the same boolean check, so there's exactly one implementation of the decision.

Added 4 new tests exercising reject/allow/nil/empty-allowlist with no availability guard needed. The 3 existing guarded tests stay as the framework-integration layer.

## Proof

Full suite: 3051 tests (+4), all green. Codex review clean.

`council-skip: zero-blast-radius (small pure-function extraction, behavior-preserving, drawn directly from a Codex-verified audit finding, clean grounded review)`