### PR TITLE
test(settings): assert exact provider monogram values, not just non-empty

### DIFF
--- a/Tests/EnviousWisprTests/Settings/ProviderLogoTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderLogoTests.swift
@@ -30,11 +30,22 @@ struct ProviderLogoTests {
     #expect(ProviderLogoSVG.templateImage("") == nil)
   }
 
-  @Test("Monograms are non-empty for the SVG-backed providers")
-  func monogramsPresent() {
-    #expect(!ProviderLogoSVG.monogram(for: .openAI).isEmpty)
-    #expect(!ProviderLogoSVG.monogram(for: .gemini).isEmpty)
-    #expect(!ProviderLogoSVG.monogram(for: .ollama).isEmpty)
-    #expect(!ProviderLogoSVG.monogram(for: .egOne).isEmpty)
+  @Test("Monograms identify the correct provider (#1597)")
+  func monogramsMatchProviders() {
+    // #1597: the prior version only checked `.isEmpty`, so swapping two
+    // providers' monograms (or returning the same letter for every provider)
+    // would still pass. Assert the exact contract instead.
+    #expect(ProviderLogoSVG.monogram(for: .openAI) == "OA")
+    #expect(ProviderLogoSVG.monogram(for: .gemini) == "G")
+    #expect(ProviderLogoSVG.monogram(for: .ollama) == "OL")
+    #expect(ProviderLogoSVG.monogram(for: .egOne) == "EG")
+    // Codex review flagged this as codifying a broken empty Apple fallback --
+    // verified that's a DIFFERENT bug (#1613): `appleMark`'s SF-Symbol-unavailable
+    // branch hardcodes `monogram("")` directly and never calls this static
+    // function for `.appleIntelligence` at all, so this case is unreached by
+    // production today. Asserting its actual current value here doesn't lock in
+    // #1613's fix; that fix doesn't touch this function.
+    #expect(ProviderLogoSVG.monogram(for: .appleIntelligence) == "")
+    #expect(ProviderLogoSVG.monogram(for: .none) == "--")
   }
 }


### PR DESCRIPTION
Part of #1591

Closes #1597

## What

`monogramsPresent` only checked `.isEmpty` for each provider's monogram. Swapping two providers' monograms (or returning the same letter for every provider) would still pass — a real user-visible bug the test could not detect.

## Fix

Assert the exact mapping verified against `AIPolishProviderRail.swift:331-339`.

## Codex review (both local and cloud) flagged the Apple assertion

Both reviews said asserting `.appleIntelligence == ""` codifies a broken empty fallback. Investigated: that's real, but a **different** bug, filed separately as #1613 — `appleMark`'s SF-Symbol-unavailable branch hardcodes `monogram("")` directly and never calls `ProviderLogoSVG.monogram(for:)` for the Apple case at all, so this function's `.appleIntelligence` branch is unreached by production today. Fixing #1613 doesn't touch this function. Documented in the test itself; round 2 review came back clean.

## Proof

Mutation-proved: swapping the OpenAI/Gemini monogram literals in production now fails this test; reverting returns the full suite to green.

`council-skip: zero-blast-radius (test-only change, values verified against production, both review rounds clean)`