### PR TITLE
test(asr): assert the exact language-flip event, not a loose count + partial check

### DIFF
--- a/Tests/EnviousWisprASRTests/R2/R2CharacterizationTests.swift
+++ b/Tests/EnviousWisprASRTests/R2/R2CharacterizationTests.swift
@@ -1,5 +1,5 @@
-import EnviousWisprCore
 import Darwin
+import EnviousWisprCore
 import Foundation
 import Testing
 
@@ -350,12 +350,18 @@ struct R2CharacterizationTests {
       windowProbs: ["de": 0.90, "en": 0.30], voicedDuration: 4.0, mode: .auto
     )
     let events = received.snapshot()
-    // At least one flip event from en->de; PR 2 must keep this contract alive.
-    #expect(events.count >= 1)
-    if let firstFlip = events.first {
-      #expect(firstFlip.fromLang == "en")
-      #expect(firstFlip.toLang == "de")
-    }
+    // #1598: the prior version asserted `count >= 1` (tolerates a duplicate
+    // emission) and only checked the first event's fromLang/toLang, ignoring
+    // confidenceBoth entirely. Empirically confirmed (not derived by hand):
+    // exactly ONE event fires, from the second call — the third call re-accepts
+    // "de" and does not emit a second flip (registerFlipFlopCandidate's
+    // `prior.lang != lang` guard blocks same-lang re-accepts). Asserting the
+    // full Equatable event list catches a duplicate emitter or a wrong
+    // confidenceBoth that the old count/partial-field check could not.
+    #expect(
+      events == [
+        LanguageFlipEvent(fromLang: "en", toLang: "de", confidenceBoth: 0.92)
+      ])
   }
 
   /// `evaluateForTesting` does NOT call `emitPassiveChipIfNeeded`. The passive


### PR DESCRIPTION
Part of #1591

Closes #1598

## What

`onLanguageFlipFiresOnTwoStrongDifferentLangs` asserted `events.count >= 1` (tolerates a duplicate emission) and only checked the first event's `fromLang`/`toLang`, never `confidenceBoth`.

## Fix

Empirically confirmed the real fired events (ran the test with a debug print first, then locked in the exact result — did not derive by hand and guess): exactly ONE event fires, from the second `evaluateForTesting` call. Asserts the full `Equatable` event list.

## Proof

Mutation-proved: forcing the emitter to send `confidenceBoth: 0` instead of the real average now fails this test; reverting returns the full suite to green.

`council-skip: zero-blast-radius (test-only change, value verified empirically not derived, clean grounded review)`