### PR TITLE
test(app): assert engine.switch_superseded's exact from/to payload

### DIFF
--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
@@ -437,7 +437,7 @@ struct EngineCoordinatorTests {
     }
 
     @Test("a superseded switch emits engine.switch_superseded")
-    func telemetrySuperseded() async {
+    func telemetrySuperseded() async throws {
       let waiter = TelemetryEventWaiter()
       TelemetryService.shared.testEventHook = { @Sendable e in
         MainActor.assumeIsolated { waiter.record(e) }
@@ -456,7 +456,12 @@ struct EngineCoordinatorTests {
       _ = await enginePoll { c.isSwitching }
       latch.release()
       _ = await enginePoll { fake.active == .parakeet && !c.isSwitching }
-      #expect(waiter.events.contains { $0.name == "engine.switch_superseded" })
+      // #1599: the prior assertion only checked the event NAME occurred, so a
+      // reversed or missing from/to payload would still pass. `want` was
+      // whisperKit when the switch was superseded back to parakeet mid-await.
+      let event = try #require(waiter.events.first { $0.name == "engine.switch_superseded" })
+      #expect(event.stringProps["from"] == "whisperKit")
+      #expect(event.stringProps["to"] == "parakeet")
     }
 
     @Test("a failed warm emits engine.warm(failed) + engine.switch_failed")


### PR DESCRIPTION
Part of #1591

Closes #1599

## What

`telemetrySuperseded` only asserted the event NAME occurred, not the payload. A reversed or missing `from`/`to` value would still pass.

## Fix

Verified the call site (`EngineCoordinator.swift:289`) and test scenario: the switch targets whisperKit, gets superseded back to parakeet mid-await, so `from: "whisperKit"`, `to: "parakeet"`. Test now requires the event and asserts both exact values.

## Proof

Mutation-proved: swapping the from/to arguments at the call site now fails this test; reverting returns the full suite to green. Codex review clean.

`council-skip: zero-blast-radius (test-only change, values verified against the real call site, clean grounded review)`