### PR TITLE
ci: measure and report code coverage on the debug lane

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -176,6 +176,8 @@ jobs:
             -configuration Debug \
             -derivedDataPath "$DERIVED_DATA_PATH" \
             -destination 'platform=macOS,arch=arm64' \
+            -resultBundlePath "$GITHUB_WORKSPACE/xcode-test-debug.xcresult" \
+            -enableCodeCoverage YES \
             ARCHS=arm64 \
             ONLY_ACTIVE_ARCH=YES \
             VALID_ARCHS=arm64 | tee xcode-test-debug.log
@@ -190,6 +192,46 @@ jobs:
             exit 1
           fi
           echo "==> Xcode executed $TESTS_RUN tests (debug)"
+
+      # #1600 (CI-test-audit finding): coverage was never measured anywhere in
+      # CI, so nobody could ask "which production branches actually execute"
+      # with a number. Informational only — no percentage gate; coverage
+      # measures execution, not assertion quality, so a threshold here would
+      # invite padding tests to hit a number rather than testing real behavior.
+      # Never allowed to fail the required build-debug lane: continue-on-error
+      # at the step level, plus internal fail-open logic with no `set -e`.
+      - name: Coverage summary (debug, informational only)
+        if: steps.changes.outputs.needs_build == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          REPORT=$(xcrun xccov view --report --json "$GITHUB_WORKSPACE/xcode-test-debug.xcresult" 2>/dev/null) || true
+          if [ -z "$REPORT" ]; then
+            echo "==> Coverage summary unavailable (xccov produced no output)"
+            exit 0
+          fi
+          # Codex review: the report's root `.lineCoverage` aggregates EVERY
+          # instrumented target, including the .xctest bundles themselves and
+          # third-party static libraries (FluidAudio alone carries ~45k
+          # executable lines) — inflating/diluting the number away from actual
+          # Sources/ coverage. Every first-party module is named
+          # `EnviousWispr*` 1:1 with its Sources/ directory (frameworks + the
+          # thin app shell + the ASR XPC service); filter to those and exclude
+          # .xctest/.bundle to isolate real production-code coverage.
+          FIRST_PARTY=$(echo "$REPORT" | jq '
+            [.targets[] | select(.name | startswith("EnviousWispr"))
+              | select((.name | endswith(".xctest")) or (.name | endswith(".bundle")) | not)]
+            | {covered: (map(.coveredLines) | add // 0), executable: (map(.executableLines) | add // 0)}
+          ' 2>/dev/null)
+          COVERED=$(echo "$FIRST_PARTY" | jq -r '.covered // empty' 2>/dev/null)
+          EXECUTABLE=$(echo "$FIRST_PARTY" | jq -r '.executable // empty' 2>/dev/null)
+          if [ -n "$COVERED" ] && [ -n "$EXECUTABLE" ] && [ "$EXECUTABLE" -gt 0 ]; then
+            PCT_DISPLAY=$(awk -v c="$COVERED" -v e="$EXECUTABLE" 'BEGIN{printf "%.1f", (c/e)*100}')
+            echo "==> Debug-lane first-party line coverage: ${PCT_DISPLAY}% (${COVERED}/${EXECUTABLE} lines)"
+            echo "Debug-lane first-party line coverage: **${PCT_DISPLAY}%** (${COVERED}/${EXECUTABLE} lines — Sources/ only, excludes test bundles and third-party deps; informational, no gate)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "==> Coverage summary unavailable (could not parse xccov JSON or no first-party targets found)"
+          fi
 
   # Release lane: Xcode release build + Release test-target compile +
   # FoundationModels compile probe. Runs in parallel with build-debug (issue


### PR DESCRIPTION
Part of #1591

Closes #1600

## What

Zero `-enableCodeCoverage`/`xccov`/`llvm-cov`/`profdata` references existed anywhere in CI. Nobody could quantify which production branches actually execute — coverage isn't proof of quality, but its total absence meant the question couldn't even be asked with a number.

## Fix

Added `-enableCodeCoverage YES` + `-resultBundlePath` to the debug lane's test invocation, then a new step reporting a first-party line-coverage percentage to the step summary. **Informational only — no gate**: a threshold would invite padding tests to hit a number instead of testing real behavior, which is the opposite of what this whole epic is about.

## Codex caught a real measurement bug

Round 1: the naive `.lineCoverage` root aggregate mixes in the test bundles themselves and third-party static libraries (FluidAudio alone carries ~45k executable lines) — materially misleading for a step whose point is "how much of OUR code executes." Fixed by filtering to `EnviousWispr*`-named targets (1:1 with `Sources/` directories) excluding `.xctest`/`.bundle`.

Verified twice against the real tool, not simulated: ran the actual `xcodebuild -enableCodeCoverage YES` locally, produced a real `.xcresult`, and ran the exact jq pipeline (both broken and fixed versions) against its real JSON to confirm the fix.

Round 2: clean.

## Proof

`actionlint` clean. Both of `build-check`'s own self-tests (`classify-changes.sh --self-test`, `check-pr-check-fetch-depth.sh`) pass unaffected. Never allowed to fail the required lane (`continue-on-error` + internal fail-open shell logic).

`council-skip: zero-blast-radius (CI-only change, informational, no gate, drawn directly from a Codex-verified audit finding, iterated through 2 clean review rounds)`