### PR TITLE
test(app): assert engine.switch_failed and engine.warm exact payloads (#1622)

### DIFF
--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
@@ -481,10 +481,22 @@ struct EngineCoordinatorTests {
       // `engine.switch_failed` are emitted after the warm attempt returns, while
       // switchPhase flips inside it — the signal mismatch (#1283). History makes
       // the two waits order-independent.
-      _ = try await waiter.waitForEvent(named: "engine.switch_failed")
-      _ = try await waiter.waitForEvent(
+      let failed = try await waiter.waitForEvent(named: "engine.switch_failed")
+      #expect(
+        failed.stringProps == [
+          "engine": "whisperKit",
+          "reason": "warm_failed",
+        ])
+
+      let warm = try await waiter.waitForEvent(
         matching: { $0.name == "engine.warm" && $0.stringProps["outcome"] == "failed" },
         describedAs: "engine.warm(outcome: failed)")
+      #expect(
+        warm.stringProps == [
+          "engine": "whisperKit",
+          "outcome": "failed",
+        ])
+      #expect(warm.intProps["duration_ms"] != nil)
     }
   #endif
 }


### PR DESCRIPTION
Part of #1621, closes #1622.

The `telemetryWarmFailed` test proved `engine.switch_failed` and
`engine.warm(outcome: failed)` fired, but never checked either event's
payload — a wrong `engine` identity or failure `reason` on either event
stayed green. Same defect class already fixed for the neighboring
`telemetrySuperseded` test two tests above in this file (#1599/#1616) — an
incomplete cutover, not a separate bug.

Plan, grounding, and Codex grounded-review sign-off are all in #1622's issue
body (planning session 2026-07-17, PROCEED-AS-PLANNED).

## Validation
- Mutation-proved: changed the production switch-failed reason string to a
  wrong value, confirmed the test goes red at the new assertion, reverted,
  confirmed green.
- Full local test suite green (3088 tests).
- Local Codex diff review: clean, no actionable defects.
