### PR TITLE
feat(asr): the Remove button — refuse during dictation, then unload and delete in L1 order

### DIFF
--- a/Sources/EnviousWisprASR/WhisperKitSetupService.swift
+++ b/Sources/EnviousWisprASR/WhisperKitSetupService.swift
@@ -202,12 +202,22 @@ public final class WhisperKitSetupService {
       guard let self else { return }
       self.isRemoving = false
       self.removeNotice = notice
-      // Re-detect on EVERY outcome: success lands on Download; a failure may
-      // have partially deleted (marker gone, bytes remaining), and the row
-      // must show disk truth while the notice above it explains the failure
-      // (Codex 2c-r1 P2 — the notice now survives state flips by rendering
-      // outside the state switch).
-      await self.forceDetectState()
+      if notice == nil {
+        // Successful removal is authoritative terminal delivery truth on its
+        // own — probing the controller again would call adoptIfPresent(),
+        // which republishes .notReady and re-enters this exact removal
+        // completion through the delivery observer (the live infinite-loop
+        // bug: Remove -> .notReady -> forceDetectState -> adoptIfPresent ->
+        // .notReady -> repeat forever, pinning the main actor). Apply the
+        // known terminal state directly instead.
+        self.applyDeliveryState(.notDownloaded)
+      } else {
+        // A failure may have partially deleted (marker gone, bytes
+        // remaining), and the row must show disk truth while the notice
+        // above it explains the failure (Codex 2c-r1 P2 — the notice now
+        // survives state flips by rendering outside the state switch).
+        await self.forceDetectState()
+      }
     }
   }
 }

--- a/Sources/EnviousWisprASR/WhisperKitSetupService.swift
+++ b/Sources/EnviousWisprASR/WhisperKitSetupService.swift
@@ -5,8 +5,22 @@ public enum WhisperKitSetupState: Equatable {
   case checking  // initial detection
   case notDownloaded  // model not on disk
   case downloading(progress: Double, status: String)  // actively downloading
+  /// Cancelled mid-download with resumable partials on disk (founder ruling
+  /// 2026-07-17: mirror the Parakeet row — paused, Resume anytime; the shared
+  /// controller keeps the staging partials either way).
+  case paused
   case ready  // model cached locally, ready to use
   case error(String)
+}
+
+/// 2c: the Remove press's inline outcome, rendered in the Settings row that
+/// owns the button (never an overlay — gotchas-audio RULE:
+/// in-panel-notice-not-new-overlay-intent).
+public enum WhisperKitRemoveNotice: Equatable {
+  /// Founder ruling 2.5.4: Remove REFUSES during a dictation — no defer, no
+  /// queue; the user presses again after the dictation ends.
+  case refusedDictationInFlight
+  case failed
 }
 
 /// Presents WhisperKit model setup in Settings. Downloads happen there — NEVER
@@ -45,6 +59,9 @@ public final class WhisperKitSetupService {
   /// Returns whether the cancel was ACCEPTED — false means the coordinator
   /// refused it (a failed marker clear, L1) and the fetch is still running.
   private let cancelActiveDownload: @MainActor () async -> Bool
+  /// 2c: the explicit Remove action. nil notice = removed; a notice = refused
+  /// or failed, rendered inline.
+  private let removeModelAction: @MainActor () async -> WhisperKitRemoveNotice?
 
   /// The default wiring reports "not downloaded" and does nothing: a build with
   /// no delivery wiring must offer no fetch at all rather than quietly resurrect
@@ -52,11 +69,13 @@ public final class WhisperKitSetupService {
   public init(
     readAvailability: @escaping @MainActor () async -> WhisperKitSetupState = { .notDownloaded },
     startDownload: @escaping @MainActor () async -> Bool = { false },
-    cancelActiveDownload: @escaping @MainActor () async -> Bool = { false }
+    cancelActiveDownload: @escaping @MainActor () async -> Bool = { false },
+    removeModelAction: @escaping @MainActor () async -> WhisperKitRemoveNotice? = { .failed }
   ) {
     self.readAvailability = readAvailability
     self.startDownload = startDownload
     self.cancelActiveDownload = cancelActiveDownload
+    self.removeModelAction = removeModelAction
   }
 
   // MARK: - Detection
@@ -105,11 +124,18 @@ public final class WhisperKitSetupService {
   /// instead — no delivery state will ever arrive for it, and leaving the
   /// optimistic "Starting download..." up would stick forever (Codex 2b-r1 P2).
   public func downloadModel() {
+    removeNotice = nil
     setupState = .downloading(progress: 0, status: "Starting download...")
     downloadIntentEpoch += 1
     let epoch = downloadIntentEpoch
     Task { [startDownload, weak self] in
-      guard let self, self.downloadIntentEpoch == epoch else { return }
+      guard let self, self.downloadIntentEpoch == epoch else {
+        // A Cancel outran this task: the download never starts, so no delivery
+        // state will arrive — re-detect to disk truth (paused when partials
+        // exist) instead of leaving "Starting download..." up.
+        await self?.forceDetectState()
+        return
+      }
       if await startDownload() == false {
         await self.forceDetectState()
       }
@@ -124,10 +150,64 @@ public final class WhisperKitSetupService {
     // Invalidate any download intent whose task has not run yet — cancelling
     // downstream cannot reach a request that has not been made.
     downloadIntentEpoch += 1
-    Task { [cancelActiveDownload, weak self] in
-      if await cancelActiveDownload() {
-        await self?.forceDetectState()
-      }
+    Task { [cancelActiveDownload] in
+      // No re-detect on an accepted cancel: the delivery-state projection
+      // publishes the terminal (paused/cancelled) state, and detection would
+      // wipe it back to not-downloaded (Codex 2c-r7 P2). A REFUSED cancel
+      // changes nothing either way.
+      _ = await cancelActiveDownload()
+    }
+  }
+
+  // MARK: - Remove (2c)
+
+  /// The Remove press's inline notice; cleared on the next Remove/Download.
+  public private(set) var removeNotice: WhisperKitRemoveNotice?
+
+  /// True while a removal drain runs (founder ruling 2026-07-17): the row shows
+  /// "Removing model..." and the button is gone, so Remove cannot be spammed at
+  /// the UI (the coordinator already joins duplicates mechanically).
+  public private(set) var isRemoving = false
+
+  /// 2c: session authority, wired by the composition root from the class that
+  /// owns both kernel drivers. nil (not yet wired) REFUSES — fail safe: a
+  /// Remove that cannot prove no dictation is running does not run.
+  public var isDictationInFlight: (@MainActor () -> Bool)?
+
+  /// The user pressed Remove. The refusal check and L1 ordering live behind
+  /// the injected action (wiring -> coordinator); this method only renders:
+  /// success re-detects to Download, refusal/failure shows the inline notice
+  /// and changes nothing else.
+  public func removeModel() {
+    removeNotice = nil
+    // Founder ruling 2.5.4: REFUSE during a dictation — no defer, no queue,
+    // nothing else changes; the user presses again after it ends.
+    //
+    // The check-then-act window is ACCEPTED, not a gap (plan §5c.3, founder-
+    // ruled twice — reviewers keep re-deriving this; do not "fix" it without a
+    // new founder decision). Re-checking at the destructive boundary or an
+    // atomic reservation is a press-path gate: the thing L7 removed. The
+    // seconds-long drain case cannot host a session at all — a live fetch
+    // implies no admitted model, so a press lands on the honest cold-press
+    // pill and never mints a WhisperKit session. What remains is a
+    // milliseconds window no human can aim at.
+    if isDictationInFlight?() != false {
+      removeNotice = .refusedDictationInFlight
+      return
+    }
+    guard !isRemoving else { return }
+    isRemoving = true
+    Task { [removeModelAction, weak self] in
+      let notice = await removeModelAction()
+      guard let self else { return }
+      self.isRemoving = false
+      self.removeNotice = notice
+      // Re-detect on EVERY outcome: success lands on Download; a failure may
+      // have partially deleted (marker gone, bytes remaining), and the row
+      // must show disk truth while the notice above it explains the failure
+      // (Codex 2c-r1 P2 — the notice now survives state flips by rendering
+      // outside the state switch).
+      await self.forceDetectState()
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -71,6 +71,7 @@ final class DictationRuntime {
       },
     isEngineSwitching: @escaping @MainActor () -> Bool = { false },
     beginMinting: @escaping @MainActor () -> Void = {},
+    isSelectedModelInstalled: @escaping @MainActor () -> Bool = { true },
     endMinting: @escaping @MainActor () -> Void = {}
   ) {
     self.dictationLifecycleCoordinator = dictationLifecycleCoordinator
@@ -152,6 +153,7 @@ final class DictationRuntime {
       beginMinting: beginMinting,
       endMinting: endMinting
     )
+    starter.isSelectedModelInstalled = isSelectedModelInstalled
     self.starter = starter
     // #1063 PR1: on a durable transcript save, delete that session's spool + key.
     // Keeps the Pipeline recovery-unaware — the host observes the saved transcript.

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -85,6 +85,11 @@ final class RecordingStarter {
   /// `EngineCoordinator.beginMinting`/`.endMinting`; default no-ops keep legacy/test
   /// construction unchanged.
   let beginMinting: @MainActor () -> Void
+  /// #1386 PR-2c: the selected engine's model-on-disk truth (EngineCoordinator's
+  /// `status.selectedInstalled`), read at press time so a removed model presses
+  /// into the honest not-installed pill. Defaults open (true) — a missing
+  /// authority must not block dictation.
+  var isSelectedModelInstalled: @MainActor () -> Bool = { true }
   let endMinting: @MainActor () -> Void
 
   var heartControlRecovery: HeartControlRecovery
@@ -200,6 +205,17 @@ final class RecordingStarter {
     // applied yet). Show the reactive #879 pill for the selected engine and bail;
     // the user re-presses on the now-correct engine. Recovery precedence above.
     if reconcileSelectedBackendIfNeeded() { return }
+    // #1386 PR-2c (founder): a press while the selected model is REMOVED or
+    // mid-removal mints nothing and shows the honest not-installed pill. One
+    // gate, before any readiness/warm logic — a removal's first instants can
+    // still read "ready", so the readiness path alone cannot cover this.
+    guard isSelectedModelInstalled() else {
+      recordingOverlay.show(
+        intent: .warning(reason: .modelNotDownloaded(engineLabel: active.engineDisplayName)))
+      TelemetryService.shared.coldStartPressBlocked(
+        asrBackend: backend.rawValue, warmupInFlight: false)
+      return
+    }
     lastRecordingResult?.polishError = nil
     // #879 — cold-boot press safety. A press on a not-ready engine must NOT mint
     // a recording session (no audio captured → none discarded). Hand off to the
@@ -419,6 +435,14 @@ final class RecordingStarter {
       // would START on a not-ready engine shows the pill + warms instead of
       // minting a session (the toggle-hotkey is a user press too). A toggle that
       // STOPS an active session is unaffected (guarded by `isStartingFromIdle`).
+      // #1386 PR-2c (founder): same removal/not-installed gate as the PTT path.
+      guard isSelectedModelInstalled() else {
+        recordingOverlay.show(
+          intent: .warning(reason: .modelNotDownloaded(engineLabel: active.engineDisplayName)))
+        TelemetryService.shared.coldStartPressBlocked(
+          asrBackend: backend.rawValue, warmupInFlight: false)
+        return
+      }
       if active.engineReadiness != .ready {
         // #959: warm-respawn falls through to record; genuine cold keeps the
         // #879 pill. Same decision helper as the PTT path.

--- a/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
@@ -167,6 +167,14 @@ final class EngineCoordinator {
   /// (record-start is single-flight on the MainActor). Pairs with `endMinting()`.
   func beginMinting() { isMinting = true }
 
+  /// #1386 PR-2c: the Remove refusal's second read. `currentSessionConfig`
+  /// materializes only at kernel-active, so a start that has committed but not
+  /// yet frozen its config reads as "no session" — this gate covers exactly
+  /// that window (the same gate 5 uses to refuse engine switches mid-start).
+  /// Scoped to WhisperKit: a Parakeet start does not block removing the
+  /// multilingual model.
+  var isMintingWhisperKitSession: Bool { isMinting && status.active == .whisperKit }
+
   /// Called when the record-start path finishes (via `defer`, so it runs on every
   /// exit). Re-pokes so an engine switch deferred during the start window applies
   /// now (or stays deferred behind the live recording, which gate 5 still covers).

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -240,6 +240,14 @@ final class PipelineSettingsSync {
     reconcileEGOneActivation(settings: settings)
   }
 
+  /// #1386 PR-2c: true while a WhisperKit dictation session is in flight —
+  /// the Remove refusal's one read (a session-state READ, not an engine
+  /// write; L7 untouched). Same authority pattern as the EG-1 twin below:
+  /// this class owns both drivers, so it owns the read.
+  func isWhisperKitDictationInFlight() -> Bool {
+    whisperKitKernelDriver.currentSessionConfig != nil
+  }
+
   /// True if either pipeline's frozen `DictationSessionConfig` targets EG-1.
   /// Single authority (#1271 matrix gap 3) — the runtime's Remove Model
   /// defer reads it through the closure the bootstrapper wires.

--- a/Sources/EnviousWisprAppKit/App/WhisperKitDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/WhisperKitDeliveryWiring.swift
@@ -73,6 +73,12 @@ enum WhisperKitDeliveryWiring {
     // The migration must not ship blind: retirement outcomes ride the shared
     // delivery funnel, same wiring shape as EG-1's bridge (#1386 PR-2b).
     retirement?.onEvent = WhisperKitRetirementTelemetryBridge.handler
+    // 2c: the delivery-layer deletion the Remove drain awaits LAST (L1). The
+    // engine-unload seam is assigned by the bootstrapper once the driver
+    // exists — the adapter is constructed after this wiring runs.
+    retirement?.removeFromDelivery = { [weak handle] in
+      await handle?.remove() ?? false
+    }
 
     // Availability is controller admission, never a directory probe. A refused
     // foreign copy is simply not an installed model: it is preserved untouched
@@ -88,6 +94,10 @@ enum WhisperKitDeliveryWiring {
         // to download 1.6 GB they already have. Absent files fail this check
         // instantly, so the common no-model path stays cheap.
         if await handle.adoptIfPresent() { return .ready }
+        // Resumable partials read as PAUSED, not not-downloaded (founder ruling
+        // 2026-07-17): derived from disk, so the paused row survives refreshes
+        // and relaunches alike (Codex 2c-r7 P2).
+        if await handle.hasStagedPartials() { return .paused }
         return .notDownloaded
       },
       // The kill switch is checked HERE, at the fetch door, not only in the copy
@@ -125,6 +135,17 @@ enum WhisperKitDeliveryWiring {
         }
         await handle?.cancelActiveFetch()
         return true
+      },
+      // 2c: Remove routes through the coordinator (L1 order: drain fetch ->
+      // unload -> delete). The dictation-in-flight refusal already happened in
+      // the presentation layer; a nil coordinator (no manifest) can delete
+      // nothing and reports failure honestly.
+      removeModelAction: { [weak retirement] in
+        guard let retirement else { return .failed }
+        switch await retirement.remove() {
+        case .removed: return nil
+        case .refusedMarkerClear, .failed: return .failed
+        }
       })
 
     // One delivery-state stream projected onto the ASR setup states the Settings
@@ -144,7 +165,16 @@ enum WhisperKitDeliveryWiring {
       case .failed(let failure):
         setupService.applyDeliveryState(
           .error(ModelDeliveryCopy.message(reason: failure.reason, detail: failure.detail)))
-      case .cancelled, .notReady:
+      case .cancelled(let resumable):
+        // Founder ruling 2026-07-17: a cancelled download PAUSES — the row says
+        // so and offers Resume (the controller keeps the staging partials).
+        // Non-resumable cancels fall back to detection.
+        if resumable {
+          setupService.applyDeliveryState(.paused)
+        } else {
+          Task { await setupService.forceDetectState() }
+        }
+      case .notReady:
         Task { await setupService.forceDetectState() }
       }
     }

--- a/Sources/EnviousWisprAppKit/App/WhisperKitDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/WhisperKitDeliveryWiring.swift
@@ -150,8 +150,17 @@ enum WhisperKitDeliveryWiring {
 
     // One delivery-state stream projected onto the ASR setup states the Settings
     // row already renders (D6: one stream, two renderers).
+    //
+    // Codex flicker-fix-r2 P2: the .notReady case below awaits a disk read
+    // before applying its result. If a NEWER event (a fresh download start,
+    // success, or failure) arrives and applies while that read is still in
+    // flight, the stale disk-check result must not land on top of it —
+    // `applyGate` bumps on every event and the pending read only applies if
+    // it is still the most recent one when it resolves.
+    let applyGate = NotReadyStaleReadGate()
     handle?.observeState { [weak setupService] state in
       guard let setupService else { return }
+      let generation = applyGate.bump()
       switch state {
       case .preparing:
         setupService.applyDeliveryState(.downloading(progress: 0, status: "Preparing..."))
@@ -168,17 +177,61 @@ enum WhisperKitDeliveryWiring {
       case .cancelled(let resumable):
         // Founder ruling 2026-07-17: a cancelled download PAUSES — the row says
         // so and offers Resume (the controller keeps the staging partials).
-        // Non-resumable cancels fall back to detection.
+        // A non-resumable cancel is also terminal delivery truth on its own —
+        // see the .notReady case below for why re-probing here is the bug,
+        // not the fix.
         if resumable {
           setupService.applyDeliveryState(.paused)
         } else {
-          Task { await setupService.forceDetectState() }
+          setupService.applyDeliveryState(.notDownloaded)
         }
       case .notReady:
-        Task { await setupService.forceDetectState() }
+        // .notReady is terminal delivery truth (nothing admitted, no fetch
+        // attempted) — apply it directly, never by re-probing the controller.
+        // The prior `forceDetectState()` re-probe called readAvailability()
+        // -> adoptIfPresent(), which itself republishes .preparing then
+        // .notReady through this SAME observer, re-entering this case
+        // forever: an unbounded MainActor task loop that pinned the app at
+        // 100%+ CPU and froze the Settings row the moment a real user (or
+        // Remove) reached a genuinely not-installed state. Never re-enter
+        // detection from a push notification the controller just sent —
+        // detection is for the PULL path (.onAppear / backend switch), not
+        // for reacting to the controller's own state stream.
+        //
+        // Codex flicker-fix-r1 P2: `.notReady` carries no resumable flag, so
+        // settling straight on `.notDownloaded` can overwrite a genuinely
+        // paused download shown moments earlier — a stale `.notReady` from
+        // this SAME probe chain can land after the pull path's own `.paused`
+        // read. `hasStagedPartials()` is a pure disk read (never calls
+        // `startAttempt`/`setState`), so checking it here cannot re-enter the
+        // loop above; it only decides which terminal presentation is honest.
+        //
+        // Codex flicker-fix-r2 P2: guard the result against `applyGate` — a
+        // newer event (fresh download start/success/failure) may already
+        // have applied by the time this read resolves, and this stale result
+        // must not overwrite it.
+        Task { @MainActor [weak handle, weak setupService] in
+          guard let handle, let setupService else { return }
+          let hasPartials = await handle.hasStagedPartials()
+          guard applyGate.isCurrent(generation) else { return }
+          setupService.applyDeliveryState(hasPartials ? .paused : .notDownloaded)
+        }
       }
     }
 
     return Wired(backend: backend, retirement: retirement, setupService: setupService)
   }
+}
+
+/// Monotonic freshness guard for the `.notReady` case's async disk read
+/// (Codex flicker-fix-r2 P2): every delivery event bumps the generation;
+/// the pending read only applies its result if no newer event has landed
+/// while it was in flight.
+@MainActor private final class NotReadyStaleReadGate {
+  private var generation = 0
+  func bump() -> Int {
+    generation += 1
+    return generation
+  }
+  func isCurrent(_ candidate: Int) -> Bool { candidate == generation }
 }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -338,6 +338,12 @@ public final class WisprBootstrapper {
     // before `start()` runs any registration (heart-path + bootstrap ordering).
     let hotkeyService = HotkeyService(telemetry: .live)
 
+    // 2c: the Remove drain's engine-unload seam — assignable only now that the
+    // driver (and its adapter) exist; the wiring that built the coordinator ran
+    // before them. L1: the drain awaits this BEFORE the delivery deletion.
+    whisperKitRetirement?.unloadForRemoval = { [weak whisperKitKernelDriver] in
+      await whisperKitKernelDriver?.unloadEngineForRemoval()
+    }
     let settingsSync = PipelineSettingsSync(
       kernelDriver: kernelDriver,
       whisperKitKernelDriver: whisperKitKernelDriver,
@@ -685,6 +691,20 @@ public final class WisprBootstrapper {
       },
       isEngineSwitching: { [weak engineCoordinator] in engineCoordinator?.isSwitching ?? false },
       beginMinting: { [weak engineCoordinator] in engineCoordinator?.beginMinting() },
+      // #1386 PR-2c (founder): a press on a removed/never-installed model shows
+      // the honest not-installed pill — and a model MID-REMOVAL counts as
+      // removed (founder: no new dictations during a removal drain; the drain's
+      // first instants can still read installed+ready). Defaults OPEN on a
+      // missing authority.
+      isSelectedModelInstalled: { [weak engineCoordinator, weak setup] in
+        guard let engineCoordinator else { return true }
+        if engineCoordinator.status.selected == .whisperKit,
+          setup?.whisperKitSetup.isRemoving == true
+        {
+          return false
+        }
+        return engineCoordinator.status.selectedInstalled
+      },
       endMinting: { [weak engineCoordinator] in engineCoordinator?.endMinting() }
     )
 
@@ -808,6 +828,16 @@ public final class WisprBootstrapper {
     // recovery / driver-state pokes) is all set, so the worker drains correctly.
     // At boot active == selected (`setInitialBackendType` above), so the first
     // reconcile is a converged no-op.
+    // 2c: the Remove refusal reads BOTH session authorities from their owners
+    // (Codex 2c-r5 P2): the frozen-config read (PipelineSettingsSync, which
+    // owns both drivers) AND the minting gate (EngineCoordinator, gate 5's
+    // owner) — a start that has committed but not yet frozen its config would
+    // otherwise read as "no session" and let Remove delete under it. nil
+    // either way refuses, fail safe.
+    setup.whisperKitSetup.isDictationInFlight = { [weak settingsSync, weak engineCoordinator] in
+      (settingsSync?.isWhisperKitDictationInFlight() ?? true)
+        || (engineCoordinator?.isMintingWhisperKitSession ?? true)
+    }
     engineCoordinator.start()
 
     // Initialize observability (PostHog + Sentry) unconditionally at launch.

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -115,7 +115,23 @@ struct SpeechEngineSettingsView: View {
       if settings.selectedBackend == .whisperKit {
         BrandedSection(header: "Model Setup") {
           BrandedRow(showDivider: false) {
-            whisperKitSetupContent
+            VStack(alignment: .leading, spacing: 6) {
+              whisperKitSetupContent
+              // Inline, in the section the user is looking at — never an
+              // overlay. Rendered OUTSIDE the state switch: a failed removal
+              // can flip the state to error/not-downloaded, and the notice
+              // must survive that flip (Codex 2c-r1 P2).
+              if let notice = setup.whisperKitSetup.removeNotice {
+                Text(
+                  notice == .refusedDictationInFlight
+                    ? "Finish your current dictation first, then try again."
+                    : "The model could not be removed. Please try again."
+                )
+                .font(.stHelper)
+                .foregroundStyle(.stWarning)
+                .fixedSize(horizontal: false, vertical: true)
+              }
+            }
           }
         }
       }
@@ -376,7 +392,8 @@ struct SpeechEngineSettingsView: View {
       return nil
     case .preparing(let validating):
       return (
-        validating ? "Checking speech model files..." : "Preparing download...", nil, false, nil)
+        validating ? "Checking speech model files..." : "Preparing download...", nil, false, nil
+      )
     case .downloading(_, let bytesWritten, let totalBytes):
       let mb = Int(Double(bytesWritten) / 1_048_576)
       let totalMB = Int(Double(totalBytes) / 1_048_576)
@@ -389,10 +406,10 @@ struct SpeechEngineSettingsView: View {
       return (
         "Speech model download failed.",
         ModelDeliveryCopy.message(reason: failure.reason, detail: failure.detail),
-        false, "Try Again")
+        false, "Try Again"
+      )
     }
   }
-
 
   private func isAutoLanguage(_ mode: LanguageMode) -> Bool {
     if case .auto = mode { return true }
@@ -431,7 +448,7 @@ struct SpeechEngineSettingsView: View {
         whisperKitStepIndicator("Download Model")
 
         Text(
-          "WhisperKit requires a ~1.5 GB model download. It runs fully on your Mac — no internet needed after setup."
+          "WhisperKit requires a ~1.5 GB model download. It runs fully on your Mac, no internet needed after setup."
         )
         .settingsReadingCopy()
 
@@ -474,12 +491,53 @@ struct SpeechEngineSettingsView: View {
         }
       }
 
+    case .paused:
+      VStack(alignment: .leading, spacing: 8) {
+        whisperKitStepIndicator("Download Paused")
+        Text("Download paused. Resume anytime.")
+          .settingsReadingCopy()
+        HStack {
+          Button("Resume") {
+            setup.whisperKitSetup.downloadModel()
+          }
+          .buttonStyle(.borderedProminent)
+          .controlSize(.small)
+          whisperKitRefreshButton
+        }
+      }
+
     case .ready:
-      HStack {
-        Label("Model Ready", systemImage: "checkmark.circle.fill")
-          .foregroundStyle(.stSuccess)
-        Spacer()
-        whisperKitRefreshButton
+      VStack(alignment: .leading, spacing: 6) {
+        HStack {
+          Label("Model Ready", systemImage: "checkmark.circle.fill")
+            .foregroundStyle(.stSuccess)
+          Spacer()
+          // 2c: the way out. An app that installs 1.5 GB must offer deletion.
+          // Removal does NOT switch the selected engine (founder ruling 2.5.5
+          // "no engine swap at all"; L7 freezes engine writes; plan arm 9:
+          // selectedBackend unchanged, next press gives L6's honest state).
+          // Reviewers keep proposing the EG-1-style auto-switch — that is the
+          // design the founder killed; do not restore it without a new ruling.
+          // While the removal drain runs, the button is REPLACED by progress
+          // (founder ruling 2026-07-17: visible, unspammable).
+          if setup.whisperKitSetup.isRemoving {
+            HStack(spacing: 6) {
+              ProgressView()
+                .controlSize(.small)
+              Text("Removing model...")
+                .font(.stHelper)
+                .foregroundStyle(.stTextSecondary)
+            }
+          } else {
+            Button("Remove Model") {
+              setup.whisperKitSetup.removeModel()
+            }
+            .controlSize(.small)
+            .buttonStyle(.borderless)
+            .foregroundStyle(.stError)
+            whisperKitRefreshButton
+          }
+        }
       }
 
     case .error(let message):

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -315,13 +315,31 @@ public actor ModelDeliveryController {
   /// 2c: whether a cancelled download left resumable partials in this
   /// identity's staging area — the disk truth behind the "paused" presentation
   /// (it survives relaunches, unlike any in-memory flag).
+  ///
+  /// Cloud review (PR #1637, two rounds): a metadata-only staging shell must
+  /// not read as resumable. Round 1 excluded `.resume.json` sidecars but
+  /// still counted directory entries as "content" — a nested model layout
+  /// (e.g. `Encoder.mlmodelc/` holding only its own sidecar) walked via
+  /// `subpathsOfDirectory` yields the directory name itself as an entry,
+  /// which passes the suffix filter and reads as resumable even though it
+  /// holds zero real bytes. This walks with resource values instead and
+  /// requires an actual REGULAR FILE with positive size — a directory or an
+  /// empty file proves nothing was downloaded.
   public func hasStagedPartials(_ registration: DeliveryRegistration) -> Bool {
     let staging = stagingDirectory(for: registration)
     guard
-      let entries = try? FileManager.default.contentsOfDirectory(
-        at: staging, includingPropertiesForKeys: nil)
+      let enumerator = FileManager.default.enumerator(
+        at: staging, includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey])
     else { return false }
-    return !entries.isEmpty
+    for case let url as URL in enumerator {
+      guard !url.lastPathComponent.hasSuffix(".resume.json") else { continue }
+      guard
+        let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+        values.isRegularFile == true, let size = values.fileSize, size > 0
+      else { continue }
+      return true
+    }
+    return false
   }
 
   public func remove(_ registration: DeliveryRegistration) async -> RemoveOutcome {
@@ -727,11 +745,7 @@ public actor ModelDeliveryController {
 
   private func hasStagedPartials(identity: ModelIdentity) -> Bool {
     guard let registration = registrationsByIdentity[identity] else { return false }
-    let staging = registration.metadataDirectory
-      .appendingPathComponent("staging", isDirectory: true)
-      .appendingPathComponent(identity.cacheKey, isDirectory: true)
-    let entries = (try? FileManager.default.subpathsOfDirectory(atPath: staging.path)) ?? []
-    return entries.contains { !$0.hasSuffix(".resume.json") }
+    return hasStagedPartials(registration)
   }
 
   private func phaseAtCancel(identity: ModelIdentity) -> String {

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -312,6 +312,18 @@ public actor ModelDeliveryController {
   /// marker + orphan rules (this actor + `CacheAdmission`), never a backend
   /// adapter. Generic — Parakeet has no first-class evict either; EG-1's
   /// adapter calls it after stopping its server.
+  /// 2c: whether a cancelled download left resumable partials in this
+  /// identity's staging area — the disk truth behind the "paused" presentation
+  /// (it survives relaunches, unlike any in-memory flag).
+  public func hasStagedPartials(_ registration: DeliveryRegistration) -> Bool {
+    let staging = stagingDirectory(for: registration)
+    guard
+      let entries = try? FileManager.default.contentsOfDirectory(
+        at: staging, includingPropertiesForKeys: nil)
+    else { return false }
+    return !entries.isEmpty
+  }
+
   public func remove(_ registration: DeliveryRegistration) async -> RemoveOutcome {
     let identity = registration.manifest.identity
     // Drain any live attempt first (reuses the cancel drain barrier); a

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -270,6 +270,13 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// internal-test code in the same module.
   package let adapter: any ASREngineAdapter
 
+  /// 2c: the explicit user-Remove unload, reached through the driver so the
+  /// adapter TYPE stays module-internal. No-op for engines without one
+  /// (Parakeet's removal story is not this PR's).
+  package func unloadEngineForRemoval() async {
+    await (adapter as? WhisperKitEngineAdapter)?.unloadForRemoval()
+  }
+
   /// The per-session context the wiring's closures read (PR-4 §3.3 — "captured
   /// by the driver and threaded into the wiring"). PR-4a holds it; PR-4b's
   /// `handle(.toggleRecording)` is the writer — it records the frozen config

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -960,6 +960,27 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     cachedReadiness = .notReady
   }
 
+  /// #1386 PR-2c. The EXPLICIT user-Remove unload: cancels session/load work
+  /// and any pending policy unload, then AWAITS a full backend unload.
+  /// Deliberately NOT `recoverFromWedge()`: that path is deadline-bounded and
+  /// fail-open — an abandoned unload is acceptable for wedge recovery, but a
+  /// Remove must have the model genuinely released (inference stopped, memory
+  /// and disk reclaimable) before deletion proceeds.
+  ///
+  /// It does NOT drain a wedged CoreML task beyond `unload()`'s own semantics
+  /// (ACCEPTED, plan §5c.2/§6.3 — reviewers re-derive this): deleting under a
+  /// surviving mapping is safe (unlink keeps the inode until the last holder
+  /// exits; no SIGBUS), so the worst case is disk space lingering until the
+  /// wedged task dies. Blocking Remove on an unbounded CoreML drain would
+  /// trade that bounded delay for an unbounded UI hang.
+  package func unloadForRemoval() async {
+    await cancel()
+    modelUnloadTask?.cancel()
+    modelUnloadTask = nil
+    await backend.unload()
+    cachedReadiness = .notReady
+  }
+
   // MARK: ASREngineAdapter — cleanup
 
   /// Apply the model-unload policy. Mirrors

--- a/Sources/EnviousWisprPipeline/WhisperKitLegacyUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitLegacyUpgradeCoordinator.swift
@@ -45,6 +45,19 @@ public final class WhisperKitLegacyUpgradeCoordinator {
   enum CommandKind: Sendable, Equatable {
     case ensure
     case cancel
+    /// 2c: the deliberate one-field seam L5 promised — Remove drains, unloads,
+    /// deletes. Distinguishable from `.cancel` so a duplicate Remove joins and
+    /// a Cancel-during-Remove joins rather than preempting an accepted deletion.
+    case remove
+  }
+
+  /// 2c: the outcome the Settings row renders inline.
+  public enum RemoveOutcome: Sendable, Equatable {
+    case removed
+    /// L1 refusal: the owed marker would not clear; nothing was touched.
+    case refusedMarkerClear
+    /// The delivery layer refused (kill switch off) or failed the deletion.
+    case failed
   }
 
   private let documentsDirectory: URL
@@ -55,6 +68,13 @@ public final class WhisperKitLegacyUpgradeCoordinator {
   private let ensureAvailable: @MainActor @Sendable () async -> Bool
   private let cancelActiveFetch: @MainActor @Sendable () async -> Void
   private let isAdmitted: @MainActor @Sendable () async -> Bool
+  /// 2c: full engine unload before deletion (adapter's `unloadForRemoval`).
+  /// Settable, not init-injected: the adapter is constructed AFTER this
+  /// coordinator (wiring precedes the driver in the composition root), so the
+  /// bootstrapper assigns it once the driver exists. nil-safe default no-ops.
+  public var unloadForRemoval: @MainActor @Sendable () async -> Void = {}
+  /// 2c: the delivery-layer deletion (marker + files + staging). Returns success.
+  public var removeFromDelivery: @MainActor @Sendable () async -> Bool = { false }
   /// The kill switch, read at the TOP of every retirement run — not only at the
   /// fetch door. A rollback (switch off) must refuse the whole operation before
   /// the first disk mutation: retiring the legacy copy and then refusing the
@@ -66,7 +86,8 @@ public final class WhisperKitLegacyUpgradeCoordinator {
   private let hashFile: (@Sendable (URL) async throws -> String)?
   private let removeItem: ((URL) throws -> Void)?
 
-  private var command: (kind: CommandKind, task: Task<Void, Never>, ticket: Int)?
+  private var command:
+    (kind: CommandKind, task: Task<Void, Never>, ticket: Int, removeOutcome: RemoveOutcomeCell?)?
   private var commandTicket = 0
   private var commandGeneration = 0
 
@@ -165,6 +186,12 @@ public final class WhisperKitLegacyUpgradeCoordinator {
   /// with nothing started (Codex 2b-r4 P2). The slot stays occupied until the superseded
   /// work has actually unwound, so "at most one command" holds through the drain too.
   public func cancel() async throws {
+    // L5: Cancel arriving during Remove JOINS it — an accepted deletion cannot
+    // be undone, so preempting the Remove drain would only corrupt its slot.
+    if let current = command, current.kind == .remove {
+      await current.task.value
+      return
+    }
     try LegacyRetirement.clearMarker(owedMarkerURL)
     commandGeneration += 1
     let superseded = command?.task
@@ -175,9 +202,54 @@ public final class WhisperKitLegacyUpgradeCoordinator {
       await cancelActiveFetch()
       if let superseded { _ = await superseded.value }
     }
-    command = (kind: .cancel, task: drain, ticket: ticket)
+    command = (kind: .cancel, task: drain, ticket: ticket, removeOutcome: nil)
     await drain.value
     if command?.ticket == ticket { command = nil }
+  }
+
+  /// 2c: the user pressed Remove (the in-flight dictation refusal happens at
+  /// the CALLER — this coordinator arbitrates delivery commands, not sessions).
+  /// L1 verbatim: marker clear first (refuse everything on failure), one
+  /// non-suspending slice bumps the generation and cancels the stored task,
+  /// then the drain awaits the controller's fetch stop, the superseded work's
+  /// unwind, the engine unload, and finally the deletion. Registered as the
+  /// current command (kind .remove): duplicates join; ensures wait it out.
+  public func remove() async -> RemoveOutcome {
+    // L5: duplicate Remove joins the one in flight and receives the DRAIN'S
+    // OWN outcome — reading the world instead lies when deletion partially
+    // failed (marker gone, bytes remaining reads as "removed"; Codex 2c-r1 P2).
+    if let current = command, current.kind == .remove {
+      let cell = current.removeOutcome
+      await current.task.value
+      // The cell was captured at JOIN time, so a third Remove starting after
+      // the slot clears cannot swap the verdict under this joiner
+      // (Codex 2c-r4 P2 — outcomes are per-drain, never shared state).
+      return cell?.value ?? .failed
+    }
+    do {
+      try LegacyRetirement.clearMarker(owedMarkerURL)
+    } catch {
+      return .refusedMarkerClear
+    }
+    commandGeneration += 1
+    let superseded = command?.task
+    superseded?.cancel()
+    commandTicket += 1
+    let ticket = commandTicket
+    let cell = RemoveOutcomeCell()
+    let drain = Task { [cancelActiveFetch, unloadForRemoval, removeFromDelivery] in
+      await cancelActiveFetch()
+      if let superseded { _ = await superseded.value }
+      await unloadForRemoval()
+      let ok = await removeFromDelivery()
+      // MainActor-serial, set BEFORE the drain completes: this drain's OWN
+      // cell, captured by every joiner at join time.
+      cell.value = ok ? .removed : .failed
+    }
+    command = (kind: .remove, task: drain, ticket: ticket, removeOutcome: cell)
+    await drain.value
+    if command?.ticket == ticket { command = nil }
+    return cell.value
   }
 
   private func joinOrStart(_ kind: CommandKind, _ work: @escaping @Sendable () async -> Void)
@@ -204,7 +276,7 @@ public final class WhisperKitLegacyUpgradeCoordinator {
     commandTicket += 1
     let ticket = commandTicket
     let task = Task { await work() }
-    command = (kind: kind, task: task, ticket: ticket)
+    command = (kind: kind, task: task, ticket: ticket, removeOutcome: nil)
     await task.value
     if command?.ticket == ticket { command = nil }
   }
@@ -414,4 +486,10 @@ public final class WhisperKitLegacyUpgradeCoordinator {
   private func emit(_ event: Event) {
     onEvent?(event)
   }
+}
+
+/// Per-drain removal verdict (MainActor-confined). Bound to its command so a
+/// joiner can never read a different removal's outcome.
+@MainActor final class RemoveOutcomeCell {
+  var value: WhisperKitLegacyUpgradeCoordinator.RemoveOutcome = .failed
 }

--- a/Sources/EnviousWisprPipeline/WhisperKitModelDelivery.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitModelDelivery.swift
@@ -112,6 +112,21 @@ public final class WhisperKitDeliveryHandle {
     _ = await controller.cancel(registration.manifest.identity)
   }
 
+  /// 2c: resumable partials on disk (the paused-row truth).
+  public func hasStagedPartials() async -> Bool {
+    await controller.hasStagedPartials(registration)
+  }
+
+  /// 2c: the user's explicit Remove — marker + files + staging via the shared
+  /// primitive. Kill-switch gated like every delivery mutation (EG-1 §16.6
+  /// precedent: the flag stands down the WHOLE delivery layer, deletions
+  /// included).
+  public func remove() async -> Bool {
+    guard isEnabled() else { return false }
+    if case .removed = await controller.remove(registration) { return true }
+    return false
+  }
+
 }
 
 /// MainActor-serialized "apply only if newer" gate for the sequenced state

--- a/Tests/EnviousWisprTests/ASR/WhisperKitSetupServiceTests.swift
+++ b/Tests/EnviousWisprTests/ASR/WhisperKitSetupServiceTests.swift
@@ -85,17 +85,167 @@ import Testing
     #expect(service.setupState == .notDownloaded)
   }
 
-  /// An ACCEPTED cancel re-detects to honest truth.
-  @Test func anAcceptedCancelReturnsTheRowToDetectedTruth() async throws {
+  /// An ACCEPTED cancel leaves the row to the delivery-state projection —
+  /// re-detecting here wiped the paused presentation (founder ruling
+  /// 2026-07-17; Codex 2c-r7 P2). The projection then publishes paused and it
+  /// STICKS.
+  @Test func anAcceptedCancelLeavesTheRowToTheProjection() async throws {
     let service = WhisperKitSetupService(
       readAvailability: { .notDownloaded },
       cancelActiveDownload: { true })
     service.applyDeliveryState(.downloading(progress: 0.5, status: "Downloading model files..."))
 
     service.cancelDownload()
+    for _ in 0..<100 { await Task.yield() }
+    if case .downloading = service.setupState {} else {
+      Issue.record("cancel itself must not rewrite the row: \(service.setupState)")
+    }
+
+    service.applyDeliveryState(.paused)
+    #expect(service.setupState == .paused, "the projection's paused sticks")
+  }
+
+  // MARK: - 2c: Remove refusal (founder ruling 2.5.4 — refuse, never defer)
+
+  @Test func removeDuringADictationRefusesAndTouchesNothing() async throws {
+    final class Box: @unchecked Sendable { var actionCalls = 0 }
+    let box = Box()
+    let service = WhisperKitSetupService(
+      readAvailability: { .ready },
+      removeModelAction: {
+        box.actionCalls += 1
+        return nil
+      })
+    service.isDictationInFlight = { true }
+
+    service.removeModel()
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(service.removeNotice == .refusedDictationInFlight)
+    #expect(box.actionCalls == 0, "a refusal reaches NOTHING downstream")
+  }
+
+  @Test func endingTheDictationQueuesNoDeferredDeletion() async throws {
+    final class Box: @unchecked Sendable { var actionCalls = 0 }
+    let box = Box()
+    let service = WhisperKitSetupService(
+      readAvailability: { .ready },
+      removeModelAction: {
+        box.actionCalls += 1
+        return nil
+      })
+    final class Flag: @unchecked Sendable { var inFlight = true }
+    let flag = Flag()
+    service.isDictationInFlight = { flag.inFlight }
+
+    service.removeModel()
+    for _ in 0..<50 { await Task.yield() }
+    #expect(service.removeNotice == .refusedDictationInFlight)
+
+    // The dictation ends. NOTHING may fire on its own — the founder's
+    // "what the hell" case. A deliberate second press is required.
+    flag.inFlight = false
+    for _ in 0..<100 { await Task.yield() }
+    #expect(box.actionCalls == 0, "no deferred deletion after the dictation ends")
+
+    service.removeModel()
+    for _ in 0..<100 where box.actionCalls == 0 { await Task.yield() }
+    #expect(box.actionCalls == 1, "the second deliberate press works")
+    #expect(service.removeNotice == nil)
+  }
+
+  @Test func twoRefusalsInARowAccumulateNoState() async throws {
+    final class Box: @unchecked Sendable { var actionCalls = 0 }
+    let box = Box()
+    let service = WhisperKitSetupService(
+      readAvailability: { .ready },
+      removeModelAction: {
+        box.actionCalls += 1
+        return nil
+      })
+    service.isDictationInFlight = { true }
+
+    service.removeModel()
+    service.removeModel()
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(service.removeNotice == .refusedDictationInFlight)
+    #expect(box.actionCalls == 0)
+  }
+
+  @Test func anUnwiredSessionAuthorityRefusesFailSafe() async throws {
+    final class Box: @unchecked Sendable { var actionCalls = 0 }
+    let box = Box()
+    let service = WhisperKitSetupService(
+      readAvailability: { .ready },
+      removeModelAction: {
+        box.actionCalls += 1
+        return nil
+      })
+    // isDictationInFlight never wired (nil): Remove must refuse, not guess.
+
+    service.removeModel()
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(service.removeNotice == .refusedDictationInFlight)
+    #expect(box.actionCalls == 0)
+  }
+
+  @Test func aFailedRemovalShowsTheFailureNoticeAndReDetectsDiskTruth() async throws {
+    let service = WhisperKitSetupService(
+      readAvailability: { .notDownloaded },  // partial deletion: marker gone
+      removeModelAction: { .failed })
+    service.isDictationInFlight = { false }
+
+    service.removeModel()
+    for _ in 0..<200 where service.removeNotice == nil {
+      await Task.yield()
+    }
+    #expect(service.removeNotice == .failed)
+    // The row re-detects to DISK truth alongside the notice (Codex 2c-r1 P2):
+    // the notice explains the failure; the state shows what is actually there.
     for _ in 0..<200 where service.setupState != .notDownloaded {
       await Task.yield()
     }
     #expect(service.setupState == .notDownloaded)
+  }
+
+  // MARK: - 2c founder rulings (2026-07-17)
+
+  @Test func removeCannotBeSpammedWhileTheDrainRuns() async throws {
+    final class Box: @unchecked Sendable {
+      var calls = 0
+      var release: CheckedContinuation<Void, Never>?
+    }
+    let box = Box()
+    let service = WhisperKitSetupService(
+      readAvailability: { .notDownloaded },
+      removeModelAction: {
+        box.calls += 1
+        await withCheckedContinuation { box.release = $0 }
+        return nil
+      })
+    service.isDictationInFlight = { false }
+
+    service.removeModel()
+    for _ in 0..<50 where box.calls == 0 { await Task.yield() }
+    #expect(service.isRemoving, "the row shows Removing while the drain runs")
+
+    // The spam: pressing again while removing reaches NOTHING.
+    service.removeModel()
+    service.removeModel()
+    for _ in 0..<50 { await Task.yield() }
+    #expect(box.calls == 1, "one drain, however many presses")
+
+    box.release?.resume()
+    box.release = nil
+    for _ in 0..<200 where service.isRemoving { await Task.yield() }
+    #expect(service.isRemoving == false, "the Removing state clears when the drain ends")
+  }
+
+  @Test func aResumableCancelPresentsPausedNotNotDownloaded() async throws {
+    let service = WhisperKitSetupService(readAvailability: { .notDownloaded })
+    service.applyDeliveryState(.paused)
+    #expect(service.setupState == .paused, "paused survives as its own presentation")
   }
 }

--- a/Tests/EnviousWisprTests/ASR/WhisperKitSetupServiceTests.swift
+++ b/Tests/EnviousWisprTests/ASR/WhisperKitSetupServiceTests.swift
@@ -56,7 +56,8 @@ import Testing
     service.cancelDownload()
     for _ in 0..<50 { await Task.yield() }
 
-    if case .downloading = service.setupState {} else {
+    if case .downloading = service.setupState {
+    } else {
       Issue.record("refused cancel must not re-detect away: \(service.setupState)")
     }
   }
@@ -97,7 +98,8 @@ import Testing
 
     service.cancelDownload()
     for _ in 0..<100 { await Task.yield() }
-    if case .downloading = service.setupState {} else {
+    if case .downloading = service.setupState {
+    } else {
       Issue.record("cancel itself must not rewrite the row: \(service.setupState)")
     }
 
@@ -208,6 +210,38 @@ import Testing
       await Task.yield()
     }
     #expect(service.setupState == .notDownloaded)
+  }
+
+  /// Live bug (2026-07-17, found on the real dev app): a successful Remove
+  /// used to re-detect unconditionally, which called readAvailability() ->
+  /// adoptIfPresent() -> the delivery controller's own no-fetch probe ->
+  /// publishes .notReady through the SAME observer that re-detects on
+  /// .notReady -> an unbounded MainActor loop that pinned the app at 100%+
+  /// CPU. A successful removal is authoritative on its own: readAvailability
+  /// must never be called again as a side effect of Remove's own completion.
+  @Test func aSuccessfulRemovalNeverReProbesTheController() async throws {
+    final class Box: @unchecked Sendable { var readAvailabilityCalls = 0 }
+    let box = Box()
+    let service = WhisperKitSetupService(
+      readAvailability: {
+        box.readAvailabilityCalls += 1
+        return .ready  // if this fires again, the row would flicker back
+      },
+      removeModelAction: { nil })
+    service.isDictationInFlight = { false }
+
+    service.removeModel()
+    for _ in 0..<200 where service.setupState != .notDownloaded {
+      await Task.yield()
+    }
+    #expect(service.setupState == .notDownloaded)
+    #expect(service.removeNotice == nil)
+
+    // Give any errant re-probe a fair chance to fire before asserting absence.
+    for _ in 0..<200 { await Task.yield() }
+    #expect(
+      box.readAvailabilityCalls == 0,
+      "a successful remove must settle on its own terminal state, never re-probe")
   }
 
   // MARK: - 2c founder rulings (2026-07-17)

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -382,14 +382,23 @@ import Testing
   /// actual 1128 + ~2, rounded up to nearest 5 = 1130. Third application
   /// (same PR, cloud review round 3): the engine-status closure handed to
   /// BackendMetadata added one line — actual 1131 + ~2, rounded to 1135.
+  /// #1386 PR-2c: the two Remove seam assignments (the adapter unload hook,
+  /// assignable only after the driver exists, and the dictation-in-flight
+  /// authority for the refusal) — actual 1142 + ~2, rounded to 1145. Then the
+  /// refusal grew its second authority (the minting gate, Codex 2c-r5 P2):
+  /// actual 1146 + ~2, rounded to 1150. Then the founder's honest-pill ruling
+  /// wired the install read into the press path (isSelectedModelInstalled):
+  /// actual 1151 + ~2, rounded to 1155. Then that read became removal-aware
+  /// (founder: a model mid-removal accepts no dictations; Codex 2c-r7 P1):
+  /// actual 1160 + ~2, rounded to 1165.
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1135,
+      lineCount <= 1165,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1135. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1165. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -130,10 +130,13 @@ import Testing
     // adds one line net. No new collaborator or method; only the paper-line
     // ceiling moves. Deterministic rule: actual 536 + 10 → round up to
     // nearest 5 = 550.
+    // #1386 PR-2c: 550 → 565 for the founder's removal gate — the honest
+    // not-installed pill on BOTH press paths before any readiness logic (a
+    // removal's first instants can still read ready). Actual 560 + ~2 → 565.
     #expect(
-      count <= 550,
+      count <= 565,
       """
-      RecordingStarter line count exceeded: \(count) > 550. \
+      RecordingStarter line count exceeded: \(count) > 565. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/ModelDelivery/ModelDeliveryControllerTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/ModelDeliveryControllerTests.swift
@@ -403,6 +403,58 @@ import Testing
     #expect(outcome == .nothingToCancel)
   }
 
+  /// Cloud review (PR #1637): the public and private staged-partials checks
+  /// used to disagree — the public one (this PR's WhisperKit `.notReady` fix
+  /// depends on it) read a metadata-only staging shell as resumable, while
+  /// the private one `cancel()` already used correctly ignored it. Now one
+  /// implementation backs both.
+  @Test func hasStagedPartialsIgnoresMetadataOnlyStaging() async throws {
+    let registration = try makeRegistration(files: ManifestFixture.smallFiles)
+    let controller = ModelDeliveryController(
+      defaults: testDefaults(), availableDiskBytes: { _ in .max })
+
+    let staging = registration.metadataDirectory
+      .appendingPathComponent("staging", isDirectory: true)
+      .appendingPathComponent(registration.manifest.identity.cacheKey, isDirectory: true)
+    try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+
+    try Data().write(to: staging.appendingPathComponent("state.resume.json"))
+    #expect(
+      await controller.hasStagedPartials(registration) == false,
+      "a resume-tracking file alone is not resumable content")
+
+    try Data([0x01, 0x02, 0x03]).write(to: staging.appendingPathComponent("chunk.bin"))
+    #expect(
+      await controller.hasStagedPartials(registration) == true,
+      "real staged bytes alongside the metadata ARE resumable")
+  }
+
+  /// Cloud review round 2 (PR #1637): a nested model layout (e.g.
+  /// `Encoder.mlmodelc/` holding only its own sidecar) must not read as
+  /// resumable just because the directory itself is an entry, and a
+  /// zero-byte file proves nothing was actually downloaded either.
+  @Test func hasStagedPartialsIgnoresNestedDirectoriesAndEmptyFiles() async throws {
+    let registration = try makeRegistration(files: ManifestFixture.smallFiles)
+    let controller = ModelDeliveryController(
+      defaults: testDefaults(), availableDiskBytes: { _ in .max })
+
+    let staging = registration.metadataDirectory
+      .appendingPathComponent("staging", isDirectory: true)
+      .appendingPathComponent(registration.manifest.identity.cacheKey, isDirectory: true)
+    let nested = staging.appendingPathComponent("Encoder.mlmodelc", isDirectory: true)
+    try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+    try Data().write(to: nested.appendingPathComponent("file.resume.json"))
+    try Data().write(to: nested.appendingPathComponent("empty.bin"))
+    #expect(
+      await controller.hasStagedPartials(registration) == false,
+      "a nested directory holding only a sidecar and an empty file is not resumable content")
+
+    try Data([0x01]).write(to: nested.appendingPathComponent("chunk.bin"))
+    #expect(
+      await controller.hasStagedPartials(registration) == true,
+      "a nested real file with actual bytes IS resumable")
+  }
+
   @Test func telemetryBuckets() {
     #expect(ModelDeliveryController.bytesBucket(10 << 20) == "under_50mb")
     #expect(ModelDeliveryController.bytesBucket(100 << 20) == "50mb_200mb")

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitLegacyUpgradeCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitLegacyUpgradeCoordinatorTests.swift
@@ -33,6 +33,11 @@ import Testing
     var holdCancel = false
     var cancelRelease: CheckedContinuation<Void, Never>?
     var cancelCalls = 0
+    var unloadCalls = 0
+    var removeCalls = 0
+    var removeSucceeds = true
+    /// Collaborator-order log for the L1 ordering assertion.
+    var callOrder: [String] = []
     var events: [WhisperKitLegacyUpgradeCoordinator.Event] = []
 
     init() throws {
@@ -100,6 +105,7 @@ import Testing
       },
       cancelActiveFetch: {
         world.cancelCalls += 1
+        world.callOrder.append("cancelFetch")
         if world.holdCancel {
           await withCheckedContinuation { world.cancelRelease = $0 }
         }
@@ -108,6 +114,15 @@ import Testing
       },
       isDeliveryEnabled: { world.deliveryEnabled })
     coordinator.onEvent = { world.events.append($0) }
+    coordinator.unloadForRemoval = {
+      world.unloadCalls += 1
+      world.callOrder.append("unload")
+    }
+    coordinator.removeFromDelivery = {
+      world.removeCalls += 1
+      world.callOrder.append("remove")
+      return world.removeSucceeds
+    }
     return coordinator
   }
 
@@ -498,5 +513,143 @@ import Testing
     // a rising fetch count is attributable only to the honored Download).
     #expect(world.fetches == 2, "the Download pressed mid-drain is honored afterwards")
     #expect(world.admitted == false)
+  }
+
+  // MARK: - 2c: Remove (L1 order, L5 rows)
+
+  @Test func removeRunsL1VerbatimAndReportsRemoved() async throws {
+    let world = try World()
+    defer { world.cleanUp() }
+    try world.stageForeignCopy()
+    world.admitOnFetch = false
+    let coordinator = makeCoordinator(world)
+    await coordinator.runLaunch()  // leaves an owed marker (fetch failed)
+    world.callOrder.removeAll()
+
+    let outcome = await coordinator.remove()
+
+    #expect(outcome == .removed)
+    #expect(!FileManager.default.fileExists(atPath: world.markerURL.path), "marker cleared FIRST")
+    // L1: controller drain precedes unload precedes deletion.
+    #expect(world.callOrder == ["cancelFetch", "unload", "remove"],
+      "L1 order violated: \(world.callOrder)")
+  }
+
+  @Test func aFailedMarkerClearRefusesTheWholeRemove() async throws {
+    let world = try World()
+    defer { world.cleanUp() }
+    try world.stageForeignCopy()
+    world.admitOnFetch = false
+    let coordinator = makeCoordinator(world)
+    await coordinator.runLaunch()
+
+    let directory = world.markerURL.deletingLastPathComponent()
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o500], ofItemAtPath: directory.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o755], ofItemAtPath: directory.path)
+    }
+    let fetchesBefore = world.fetches
+
+    let outcome = await coordinator.remove()
+
+    // Each of L1's no-clauses, positively: refused outcome, marker intact,
+    // no drain, no unload, no deletion, no new fetch.
+    #expect(outcome == .refusedMarkerClear)
+    #expect(FileManager.default.fileExists(atPath: world.markerURL.path))
+    #expect(world.unloadCalls == 0)
+    #expect(world.removeCalls == 0)
+    #expect(world.fetches == fetchesBefore)
+  }
+
+  @Test func duplicateRemoveJoinsAndDeletesOnce() async throws {
+    let world = try World()
+    defer { world.cleanUp() }
+    try world.stageForeignCopy()
+    world.admitOnFetch = false
+    world.holdCancel = true  // parks the remove drain inside cancelActiveFetch
+    let coordinator = makeCoordinator(world)
+    await coordinator.runLaunch()
+
+    let first = Task { await coordinator.remove() }
+    while world.cancelCalls == 0 { await Task.yield() }
+    let second = Task { await coordinator.remove() }
+    for _ in 0..<20 { await Task.yield() }
+    world.holdCancel = false
+    world.cancelRelease?.resume()
+    world.cancelRelease = nil
+
+    let o1 = await first.value
+    let o2 = await second.value
+    #expect(o1 == .removed)
+    #expect(o2 == .removed, "the join reads the world: model is gone")
+    #expect(world.removeCalls == 1, "one deletion, not two")
+    #expect(world.unloadCalls == 1)
+  }
+
+  @Test func cancelDuringRemoveJoinsAndCannotUndoTheDeletion() async throws {
+    let world = try World()
+    defer { world.cleanUp() }
+    try world.stageForeignCopy()
+    world.admitOnFetch = false
+    world.holdCancel = true
+    let coordinator = makeCoordinator(world)
+    await coordinator.runLaunch()
+
+    let removeTask = Task { await coordinator.remove() }
+    while world.cancelCalls == 0 { await Task.yield() }
+    let cancelTask = Task { try await coordinator.cancel() }
+    for _ in 0..<20 { await Task.yield() }
+    world.holdCancel = false
+    world.cancelRelease?.resume()
+    world.cancelRelease = nil
+
+    let outcome = await removeTask.value
+    try await cancelTask.value
+
+    #expect(outcome == .removed, "a joined Cancel cannot undo the accepted deletion")
+    #expect(world.removeCalls == 1)
+    #expect(world.cancelCalls == 1, "Cancel joined; it did not run its own drain")
+  }
+
+  @Test func duplicateRemoveJoinersReceiveTheDrainsRealOutcomeOnFailure() async throws {
+    let world = try World()
+    defer { world.cleanUp() }
+    try world.stageForeignCopy()
+    world.admitOnFetch = false
+    world.removeSucceeds = false  // deletion fails AFTER marker clear
+    world.holdCancel = true
+    let coordinator = makeCoordinator(world)
+    await coordinator.runLaunch()
+
+    let first = Task { await coordinator.remove() }
+    while world.cancelCalls == 0 { await Task.yield() }
+    let second = Task { await coordinator.remove() }
+    for _ in 0..<20 { await Task.yield() }
+    world.holdCancel = false
+    world.cancelRelease?.resume()
+    world.cancelRelease = nil
+
+    // Codex 2c-r1 P2: the joiner must get the drain's OWN verdict — a
+    // world-read here would say "not admitted, so removed" while bytes remain.
+    let o1 = await first.value
+    let o2 = await second.value
+    #expect(o1 == .failed)
+    #expect(o2 == .failed, "the joiner reports the real failure, not a success")
+  }
+
+  @Test func aFailedDeliveryDeletionReportsFailed() async throws {
+    let world = try World()
+    defer { world.cleanUp() }
+    try world.stageForeignCopy()
+    world.admitOnFetch = false
+    world.removeSucceeds = false
+    let coordinator = makeCoordinator(world)
+    await coordinator.runLaunch()
+
+    let outcome = await coordinator.remove()
+    #expect(outcome == .failed)
+    #expect(world.unloadCalls == 1, "the unload ran; only the deletion failed")
   }
 }


### PR DESCRIPTION
## What

The multilingual engine's Remove button (#1348 Phase 4, plan v2 PR-2c) — plus four founder UX rulings landed in-session (2026-07-17) — plus a real infinite-loop bug found and fixed during live testing.

- **Remove** refuses while a WhisperKit dictation is in flight OR starting (two session authorities composed: the frozen-config read and the coordinator's minting gate; founder ruling 2.5.4 — refuse, never defer, no surprise deletions). After the refusal check it executes L1 verbatim through the coordinator's command slot as the promised `.remove` kind: marker clear first (refuse-all on failure), fetch drain, superseded unwind, full engine unload (`unloadForRemoval()` — a distinct API, deliberately not the fail-open wedge recovery), then the delivery deletion.
- **L5 rows:** duplicate Remove joins with the drain's own per-cell outcome; Cancel-during-Remove joins and cannot undo an accepted deletion; ensures wait out the drain.
- **Founder rulings:** cancelled downloads present as *paused* with Resume, derived from staged partials on disk (survives refresh and relaunch); no Remove button mid-download; "Removing model..." replaces the button while the drain runs (unspammable); a press on a removed/mid-removal model shows the honest not-installed pill on BOTH press paths before any readiness logic — no audio pickup, no session.
- Copy fix: the model-download sentence dropped its em-dash (banned in human-facing copy).
- The L7 file-freeze was amended by the founder for exactly one purpose (the honest-pill press gate in `RecordingStarter`); `ColdPressGuard` ended the PR untouched, `EngineCoordinator` gained one read-only scoped accessor.

## A real bug, found live

Live UAT surfaced a genuine infinite-loop bug, not a test artifact: any transition into the delivery controller's `.notReady` state (Remove's own completion, or simply opening Settings with the model not installed) triggered a re-detection that itself re-entered `.notReady` through the same observer — an unbounded MainActor loop that pinned the app at 100%+ CPU and froze the Settings row. The `.notReady -> forceDetectState()` pattern predates this branch (already on `origin/main` from the merged PR-2b); this PR's Remove path is what first exercised it in live testing.

Fixed by applying terminal delivery notifications directly instead of re-probing the controller. `.notReady` additionally checks staged partials (a pure disk read, never a controller probe) so a genuinely paused download isn't misreported as not-downloaded, and a generation guard protects that async read against a newer event landing while it's in flight. Three rounds of Codex review on the fix itself (the first two caught the staged-partials and stale-read races before they shipped). Root-cause diagnosis: `docs-audit-2026-07-17-pr2c-live-flicker-diagnosis.txt`.

## Review

Eight local Codex rounds on the original Remove-button work, to CLEAN (r8: "no actionable defects"). Adopted: joiner-verdict binding (per-drain outcome cells), paused-vs-detection collision, the minting-window refusal gap, spam/notice presentation. Rejected with recorded rulings at their sites: recovery-vs-migration audio loss (plan §2.4), wedged-CoreML drain before deletion (§5c.2/§6.3), post-removal engine auto-switch (ruling 2.5.5 + L7). Three additional rounds on the flicker-loop fix, to CLEAN.

## Validation

- Full suite green: 3,102 tests, zero failures, run on the final state (rebased onto current main).
- Live UAT, all arms complete:
  - Remove via AX press: files + admission record deleted, row flips to Download, engine selection untouched (L7).
  - The flicker bug itself: reproduced live (CPU pinned, buttons unresponsive), fixed, then reproduced-clean twice after the fix (CPU flat through both a cold "not installed" open and a real Remove on an installed model).
  - Cancel mid-download → paused → Resume: run by the founder directly, several cancel/resume cycles, each resuming immediately from where it left off; no thrashing in the log or CPU at any point.
  - Remove during an active dictation, real speech: refused inline ("Finish your current dictation first, then try again"), the dictation completed and pasted normally underneath the notice, second press afterward would remove cleanly (per unit coverage; not re-run live since the model was left installed for the founder's continued use).
- L7 self-review: zero `selectedBackend` assignments in the diff; `ASREngineAdapter` protocol not widened; `recoverFromWedge()` unchanged.

## Follow-ups filed, not blocking this PR

- #1631 — a pre-existing hands-free double-press bookkeeping gap, surfaced but not caused by this PR's honest-pill gate.
- #1635 — Settings shows "Model Ready" before the engine finishes warming up (pre-existing, all engines, not WhisperKit-specific).

Part of #1386. Part of #1348.
