### PR TITLE
test(app): assert exact payload on all 4 Sparkle update-stage events, not just the first (#1628)

### DIFF
--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -617,11 +617,11 @@ struct SparkleUpdateControllerTests {
     }
 
     @Test("the 4 download/verify stage events fire with version + is_critical")
-    func stageEventsFire() async {
-      let box = EventBox()
+    func stageEventsFire() throws {
+      let waiter = TelemetryEventWaiter()
       let originalHook = TelemetryService.shared.testEventHook
       TelemetryService.shared.testEventHook = { @Sendable event in
-        Task { @MainActor in box.events.append(event) }
+        MainActor.assumeIsolated { waiter.record(event) }
       }
       defer { TelemetryService.shared.testEventHook = originalHook }
 
@@ -630,18 +630,27 @@ struct SparkleUpdateControllerTests {
       TelemetryService.shared.updateVerifyStarted(version: "2.1.4", isCritical: false)
       TelemetryService.shared.updateVerifyCompleted(version: "2.1.4", isCritical: false)
 
-      await Task.yield()
-      await Task.yield()
+      let expected: [(name: String, version: String, isCritical: Bool)] = [
+        ("update.download_started", "2.1.4", true),
+        ("update.download_completed", "2.1.4", true),
+        ("update.verify_started", "2.1.4", false),
+        ("update.verify_completed", "2.1.4", false),
+      ]
 
-      let names = Set(box.events.map { $0.name })
-      #expect(
-        names.isSuperset(of: [
-          "update.download_started", "update.download_completed",
-          "update.verify_started", "update.verify_completed",
-        ]))
-      let dl = box.events.first { $0.name == "update.download_started" }
-      #expect(dl?.stringProps["version"] == "2.1.4")
-      #expect(dl?.boolProps["is_critical"] == true)
+      for (name, version, isCritical) in expected {
+        let event = try #require(
+          waiter.events.first { $0.name == name },
+          "Missing telemetry event \(name)."
+        )
+        #expect(
+          event.stringProps["version"] == version,
+          "\(name) should carry version \(version)."
+        )
+        #expect(
+          event.boolProps["is_critical"] == isCritical,
+          "\(name) should carry is_critical=\(isCritical)."
+        )
+      }
     }
 
     @Test("the cycle event carries version_staleness_bucket")


### PR DESCRIPTION
Part of #1621, closes #1628.

The test fired all 4 download/verify stage events and claimed all 4 carry
version + is_critical, but only checked those field values on
update.download_started — name-set membership was checked for the other 3.
A broken wrapper for any of those 3 (wrong version, wrong is_critical) stayed
green.

Replaced the flaky-prone double-`Task.yield()` async drain with this
codebase's established signal-based `TelemetryEventWaiter` pattern (already
used elsewhere for exactly this class of test), then asserted each of the 4
events' exact version + is_critical values individually.

Plan, grounding, and Codex grounded-review sign-off are in #1628's issue
body.

## Validation
- Mutation-proved: hardcoded `update.verify_started`'s isCritical parameter
  to always emit `true` regardless of the caller's argument, confirmed the
  per-event assertion for that specific event catches it with a clear
  message naming which event and field failed. Reverted, confirmed green.
- Full local test suite green (3115 tests).
- Local `codex review` clean.