### PR TITLE
test: assert exact values across 4 low-severity weak-proxy checks (#1629)

### DIFF
--- a/Tests/EnviousWisprTests/LLM/OllamaModelCatalogTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaModelCatalogTests.swift
@@ -50,7 +50,7 @@ struct OllamaModelCatalogTests {
   @Test("handles case insensitivity")
   func parsesCaseInsensitive() {
     #expect(OllamaSetupService.parseParameterSize("3b") == 3.0)
-    #expect(OllamaSetupService.parseParameterSize("500m") != nil)
+    #expect(OllamaSetupService.parseParameterSize("500m") == 0.5)
   }
 
   // MARK: - EG-1 curated-private catalog visibility (#1269)
@@ -108,11 +108,15 @@ struct OllamaModelCatalogTests {
   }
 
   @Test("unknown custom model still gets inferred metadata (unchanged behavior)")
-  func unknownModelInferred() {
+  func unknownModelInferred() throws {
     let catalog = OllamaSetupService.dynamicCatalog(from: [downloaded("someones-finetune:7b")])
-    let row = catalog.first { $0.name == "someones-finetune:7b" }
-    #expect(row != nil)
-    #expect(row?.isDownloaded == true)
+    let row = try #require(catalog.first { $0.name == "someones-finetune:7b" })
+
+    #expect(row.displayName == "Someones Finetune")
+    #expect(row.parameterCount == "4B")
+    #expect(row.qualityTier == .medium)
+    #expect(row.downloadSize == "2.7 GB")
+    #expect(row.isDownloaded == true)
   }
 
   // MARK: - Canonical Name

--- a/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
+++ b/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
@@ -83,7 +83,6 @@ actor StubWhisperKitBackend: WhisperKitBackendDriving {
     isReady = true
   }
 
-
   func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws
     -> ASRResult
   {
@@ -245,7 +244,7 @@ extension IncrementalResult {
   }
 }
 
-enum StubBackendError: Error, Sendable {
+enum StubBackendError: Error, Sendable, Equatable {
   case prepareFailed
   case decodeFailed
 }

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -440,7 +440,7 @@ import Testing
       Issue.record("expected .failed(.decodeFailed), got \(outcome)")
       return
     }
-    #expect(adapter.lastFailureError != nil)
+    #expect((adapter.lastFailureError as? StubBackendError) == .decodeFailed)
   }
 
   // MARK: Finalize — LID

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -198,7 +198,7 @@ struct RecoverySpoolReplayerTests {
     #expect(saved.count == 1)
     #expect(saved.first?.isRecovered == true)
     #expect(saved.first?.recoverySessionID == id)
-    #expect(saved.first?.displayText.contains("hello") == true)
+    #expect(saved.first?.displayText == "hello recovered world")
     // #1464: the replayer no longer destroys — the coordinator deletes after this
     // returns, so the spool + key are STILL PRESENT here.
     #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))

--- a/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
@@ -41,7 +41,7 @@ struct RecoveryTextProcessorTests {
     let processor = RecoveryTextProcessor(keychainManager: KeychainManager())
     processor.applySettings(snapshot(fillerRemoval: true))
     let outcome = await processor.process(rawText: "the code is two zero three")
-    #expect(outcome.text.contains("203"))  // the chain demonstrably transformed the text
+    #expect(outcome.text == "the code is 203")
     #expect(outcome.polishedText == nil)  // provider .none ⇒ no polish
     #expect(outcome.polishError == nil)
   }
@@ -68,7 +68,7 @@ struct RecoveryTextProcessorTests {
     parakeet.applySettings(
       snapshot(fillerRemoval: false, backendType: .parakeet, lidCapable: false))
     let parakeetOut = await parakeet.process(rawText: spoken)
-    #expect(parakeetOut.text.contains("203"))
+    #expect(parakeetOut.text == "call me at 203")
 
     // LID engine (WhisperKit) with unknown language: ITN skips → text untouched.
     let whisperKit = RecoveryTextProcessor(keychainManager: KeychainManager())


### PR DESCRIPTION
Part of #1621, closes #1629.

Four independent weak assertions bundled into one PR since each is low
severity and needs no multi-round review:

1. WhisperKit decode-failure test now checks `lastFailureError` equals the
   specific `StubBackendError` case, not just non-nil.
2. Ollama case-insensitive parameter-size parsing now checks the exact
   parsed value (`0.5`), not just non-nil.
3. Unknown-model catalog inference now checks the exact inferred
   `displayName`, `parameterCount`, `qualityTier`, and `downloadSize`, not
   just existence.
4. Recovery text-processing tests now assert the exact expected sentence
   instead of a substring/existence check, for both `RecoveryTextProcessor`
   and `RecoverySpoolReplayer`.

Plan, grounding, and Codex grounded-review sign-off (2 rounds,
PROCEED-AS-PLANNED) are in #1629's issue body.

## Validation
- Mutation-proved all 4 independently: (1) swapped the stored error's
  runtime type, confirmed the exact-case assertion catches it; (2) broke
  the "M" suffix multiplier, confirmed the exact-value assertion catches it
  (the old non-nil check would NOT have, since the mutated value is still
  non-nil); (3) widened the quality-tier threshold, confirmed the
  exact-value assertions catch it; (4) duplicated the ITN digit-read output
  and appended a marker to `displayText`, confirmed the exact-match
  assertions catch both (the old substring/contains checks would NOT have,
  since "203" and "hello" both still appear in the corrupted output). All 4
  reverted, confirmed green.
- Full local test suite green (3088 tests).
- Local `codex review` clean: "The changes strengthen test assertions
  without altering production behavior. The affected tests and full test
  suite pass, and no actionable regressions were found."