### PR TITLE
feat(observability): pin Sentry identity for the 4 remaining leftovers (Part of #1525)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/HotkeyController.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/HotkeyController.swift
@@ -119,10 +119,27 @@ final class HotkeyController {
       extra: ["callback": callback])
   }
 
-  private struct NilCollaboratorError: Error, CustomStringConvertible {
+  // `internal` (widened from `private` in #1525 PR H, only after measuring —
+  // widening first would have corrupted the baseline). A `private`-or-narrower
+  // type's bridged domain falls back to the bare simple type name
+  // (`SentryBreadcrumb.structuredDescriptor`'s `(unknown context at ...)`
+  // branch), never the module- or class-qualified name — so this widening
+  // never changes what was already shipping.
+  internal struct NilCollaboratorError: Error, CustomStringConvertible {
     let callback: String
     var description: String {
       "HotkeyController callback \(callback) observed nil collaborator during app lifetime"
     }
   }
+}
+
+// MARK: - Sentry identity
+
+/// Pins the Sentry grouping key to the exact string this type has been
+/// sending in production (#1525 PR H), mirroring `HeartPathError`'s shipped
+/// pattern (#1524). Fresh 90-day Sentry search found no matching issue, so
+/// this pin carries zero re-grouping risk against that window.
+extension HotkeyController.NilCollaboratorError: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String { "NilCollaboratorError#1" }
+  var sentrySemanticID: String { "hotkey.nil_collaborator" }
 }

--- a/Sources/EnviousWisprCore/TaskTimeout.swift
+++ b/Sources/EnviousWisprCore/TaskTimeout.swift
@@ -11,6 +11,21 @@ public struct TimeoutError: Error, CustomStringConvertible {
   }
 }
 
+// MARK: - Sentry identity
+
+/// Pins the Sentry grouping key to the exact string this type has been
+/// sending in production (#1525 PR H), mirroring `HeartPathError`'s shipped
+/// pattern (#1524). One shape today, reused at two capture sites
+/// (`InverseTextNormalizationStep`'s ITN timeout, `TextProcessingRunner`'s
+/// polish timeout) — a struct, so no reorder risk exists yet, but this closes
+/// the latent risk before a second shape is ever added and preserves the live
+/// production issue (ENVIOUSWISPR-32, `polish_provider_failed:
+/// EnviousWisprCore.TimeoutError#1`) cross-checked before pinning.
+extension TimeoutError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String { "EnviousWisprCore.TimeoutError#1" }
+  public var sentrySemanticID: String { "core.timeout" }
+}
+
 /// Run an async operation with a timeout. If the operation doesn't complete
 /// within `seconds`, the child task is cancelled and `TimeoutError` is thrown.
 public func withThrowingTimeout<T: Sendable>(

--- a/Sources/EnviousWisprPipeline/EmojiRestoreStep.swift
+++ b/Sources/EnviousWisprPipeline/EmojiRestoreStep.swift
@@ -124,6 +124,35 @@ final class EmojiRestoreStep: TextProcessingStep {
 /// Marker for the under-restore Sentry anomaly. The `EmojiRestorer` is pure and
 /// never throws, so this is the step's only error signal — surfaced as a
 /// counts-only breadcrumb, never thrown out of `process`.
-private enum EmojiRestoreAnomaly: Error {
+///
+/// `internal` (widened from `private` in #1525 PR H, only after measuring —
+/// widening first would have corrupted the baseline). A `private`-or-narrower
+/// type's bridged domain falls back to the bare simple type name
+/// (`SentryBreadcrumb.structuredDescriptor`'s `(unknown context at ...)`
+/// branch), never the module-qualified name — so this widening never changes
+/// what was already shipping.
+enum EmojiRestoreAnomaly: Error {
   case underRestore
+}
+
+// MARK: - Sentry identity
+
+/// Pins the Sentry grouping key to the exact string this type has been
+/// sending in production (#1525 PR H), mirroring `HeartPathError`'s shipped
+/// pattern (#1524). Fresh 90-day Sentry search found no matching issue, so
+/// this pin carries zero re-grouping risk against that window. The switch is
+/// exhaustive (Codex grounded review r1), so a future second case cannot
+/// silently compile in and inherit `.underRestore`'s identity.
+extension EmojiRestoreAnomaly: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String {
+    switch self {
+    case .underRestore: return "EmojiRestoreAnomaly#0"
+    }
+  }
+
+  var sentrySemanticID: String {
+    switch self {
+    case .underRestore: return "emoji.restore_under_restore"
+    }
+  }
 }

--- a/Sources/EnviousWisprServices/HotkeyTelemetrySink.swift
+++ b/Sources/EnviousWisprServices/HotkeyTelemetrySink.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 
 /// Telemetry Bible Phase 6 (#1175): the injection seam for hotkey/input-silence
@@ -93,4 +94,19 @@ public struct HotkeyRegistrationError: Error, CustomStringConvertible {
     return
       "hotkey registration failed: mechanism=\(mechanism) kind=\(hotkeyKind) os_status=\(status)"
   }
+}
+
+// MARK: - Sentry identity
+
+/// Pins the Sentry grouping key to the exact string this type has been
+/// sending in production (#1525 PR H), mirroring `HeartPathError`'s shipped
+/// pattern (#1524). One shape today (a struct, not an enum), so there is no
+/// ordinal-reorder risk yet — this pin closes the latent risk before a second
+/// shape is ever added. Fresh 90-day Sentry search found no matching issue, so
+/// this pin carries zero re-grouping risk against that window.
+extension HotkeyRegistrationError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    "EnviousWisprServices.HotkeyRegistrationError#1"
+  }
+  public var sentrySemanticID: String { "hotkey.registration_failed" }
 }

--- a/Tests/EnviousWisprTests/Services/PRHLeftoverErrorsSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Services/PRHLeftoverErrorsSentryIdentityTests.swift
@@ -1,0 +1,250 @@
+import EnviousWisprCore
+import Foundation
+import Sentry
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprServices
+
+/// #1525 PR H — the four remaining single-shape app-owned leftovers
+/// (`TimeoutError`, `HotkeyRegistrationError`, `NilCollaboratorError`,
+/// `EmojiRestoreAnomaly`) have PINNED Sentry identities, mirroring
+/// `HeartPathError`'s shipped pattern (#1524) and closing out §3a of
+/// `docs/sentry-identity-refactor/BIBLE.md`.
+///
+/// The four expected descriptor strings are not re-derived here. All were
+/// MEASURED against pre-change shipping code — `NilCollaboratorError` and
+/// `EmojiRestoreAnomaly` while both stayed genuinely `private`; widening
+/// happened only after the throwaway probe ran (same order as PR C's
+/// `RecoveryReplayError`/`RecoveryArmError`). `TimeoutError`'s descriptor was
+/// cross-checked against its live production issue title (ENVIOUSWISPR-32,
+/// `polish_provider_failed: EnviousWisprCore.TimeoutError#1`). Fresh 90-day
+/// Sentry searches found no matching issue for the other three. This suite is
+/// the lock — any drift in the shipped identity reddens.
+///
+/// `environment` is passed explicitly throughout: the default reads the
+/// bundle identifier, and a test runner's bundle is not production.
+@Suite("PR H leftover errors Sentry stable identity (#1525 PR H)")
+struct PRHLeftoverErrorsSentryIdentityTests {
+
+  private static let env = "production"
+
+  // MARK: - A. Pin lock
+
+  @Test("TimeoutError keeps the exact production fingerprint at both live capture sites")
+  func timeoutErrorPinLock() {
+    let error = TimeoutError(seconds: 5)
+    let descriptor = "EnviousWisprCore.TimeoutError#1"
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+
+    #expect(
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .inverseNormalizationTimeout, error: error, environment: Self.env)
+        == ["handled_error", "inverse_normalization_timeout", descriptor, Self.env])
+
+    // The polish path routes through `PolishFailureReason.from(error)` (a
+    // `TimeoutError` classifies to `.timedOut`), and `TextProcessingRunner`
+    // passes its `telemetryTag` ("timed_out") as `fingerprintDetail` — Codex
+    // grounded review r1 caught the first draft omitting this real detail
+    // component (`TextProcessingRunner.swift:354`, `PolishFailureReason.swift:344,128`).
+    #expect(
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .polishProviderFailed, error: error, detail: "timed_out", environment: Self.env)
+        == ["handled_error", "polish_provider_failed", descriptor, "timed_out", Self.env])
+  }
+
+  @Test("HotkeyRegistrationError keeps the exact production fingerprint")
+  func hotkeyRegistrationErrorPinLock() {
+    let error = HotkeyRegistrationError(mechanism: "carbon", hotkeyKind: "toggle", osStatus: -50)
+    #expect(
+      SentryBreadcrumb.structuredDescriptor(error)
+        == "EnviousWisprServices.HotkeyRegistrationError#1"
+    )
+    #expect(
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .hotkeyRegistrationFailed, error: error, detail: "carbon/toggle", environment: Self.env
+      )
+        == [
+          "handled_error", "hotkey_registration_failed",
+          "EnviousWisprServices.HotkeyRegistrationError#1", "carbon/toggle", Self.env,
+        ])
+  }
+
+  @Test("NilCollaboratorError keeps the exact measured fingerprint")
+  func nilCollaboratorErrorPinLock() {
+    let error = HotkeyController.NilCollaboratorError(callback: "onToggleRecording")
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "NilCollaboratorError#1")
+    #expect(
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .pipelineDispatchFailed, error: error, environment: Self.env)
+        == ["handled_error", "pipeline_dispatch_failed", "NilCollaboratorError#1", Self.env])
+  }
+
+  @Test("EmojiRestoreAnomaly keeps the exact measured fingerprint")
+  func emojiRestoreAnomalyPinLock() {
+    let error = EmojiRestoreAnomaly.underRestore
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EmojiRestoreAnomaly#0")
+    #expect(
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .emojiRestoreIncomplete, error: error, environment: Self.env)
+        == ["handled_error", "emoji_restore_incomplete", "EmojiRestoreAnomaly#0", Self.env])
+  }
+
+  @Test("all four declared identities are unique across the batch")
+  func identitiesAreUniqueAcrossBatch() {
+    let descriptors = [
+      TimeoutError(seconds: 1).sentryFingerprintDescriptor,
+      HotkeyRegistrationError(mechanism: "carbon", hotkeyKind: "toggle", osStatus: nil)
+        .sentryFingerprintDescriptor,
+      HotkeyController.NilCollaboratorError(callback: "x").sentryFingerprintDescriptor,
+      EmojiRestoreAnomaly.underRestore.sentryFingerprintDescriptor,
+    ]
+    let semanticIDs = [
+      TimeoutError(seconds: 1).sentrySemanticID,
+      HotkeyRegistrationError(mechanism: "carbon", hotkeyKind: "toggle", osStatus: nil)
+        .sentrySemanticID,
+      HotkeyController.NilCollaboratorError(callback: "x").sentrySemanticID,
+      EmojiRestoreAnomaly.underRestore.sentrySemanticID,
+    ]
+    #expect(Set(descriptors).count == descriptors.count)
+    #expect(Set(semanticIDs).count == semanticIDs.count)
+  }
+
+  // MARK: - B. The property that matters
+
+  /// A deterministic `CustomNSError` — its bridged domain/code are declared,
+  /// not inferred from enum layout, so this test asserts the override itself
+  /// and never depends on the compiler behaviour the design escapes.
+  private struct StableFixtureError: Error, CustomNSError, StableSentryErrorIdentity {
+    static let errorDomain = "fixture.raw"
+    var errorCode: Int { 30 }
+    let sentryFingerprintDescriptor = "fixture.pinned#prh"
+    let sentrySemanticID = "fixture.semantic"
+  }
+
+  @Test("the explicit identity overrides the bridged NSError identity")
+  func explicitIdentityOverridesBridge() {
+    let error = StableFixtureError()
+    let bridged = error as NSError
+
+    #expect(bridged.domain == "fixture.raw")
+    #expect(bridged.code == 30)
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "fixture.pinned#prh")
+  }
+
+  // MARK: - C. Dev/prod split survives the pin
+
+  @Test("environment keeps the same descriptor's dev and prod fingerprints separate")
+  func devProdSplitSurvives() {
+    let error = TimeoutError(seconds: 5)
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: .polishProviderFailed, error: error, environment: "production")
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: .polishProviderFailed, error: error, environment: "development")
+
+    #expect(prod != dev)
+    #expect(prod.last == "production")
+    #expect(dev.last == "development")
+  }
+
+  // MARK: - D. Event-construction contract
+
+  @MainActor
+  @Test("TimeoutError's event carries the production title, fingerprint and identity tag")
+  func timeoutErrorEventShape() {
+    let error = TimeoutError(seconds: 5)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .polishProviderFailed, stage: "polish", fingerprintDetail: "timed_out",
+      environment: Self.env)
+
+    #expect(
+      event.message?.formatted == "polish_provider_failed: EnviousWisprCore.TimeoutError#1")
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "polish_provider_failed", "EnviousWisprCore.TimeoutError#1",
+          "timed_out", Self.env,
+        ])
+    #expect(event.tags?["pipeline.stage"] == "polish")
+    #expect(event.tags?["error.category"] == "polish_provider_failed")
+    #expect(event.tags?["error.identity"] == "core.timeout")
+  }
+
+  @MainActor
+  @Test(
+    "HotkeyRegistrationError's event carries the production title, fingerprint and identity tag")
+  func hotkeyRegistrationErrorEventShape() {
+    let error = HotkeyRegistrationError(mechanism: "carbon", hotkeyKind: "toggle", osStatus: -50)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .hotkeyRegistrationFailed, stage: "input",
+      fingerprintDetail: "carbon/toggle",
+      environment: Self.env)
+
+    #expect(
+      event.message?.formatted
+        == "hotkey_registration_failed: EnviousWisprServices.HotkeyRegistrationError#1")
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "hotkey_registration_failed",
+          "EnviousWisprServices.HotkeyRegistrationError#1", "carbon/toggle", Self.env,
+        ])
+    #expect(event.tags?["pipeline.stage"] == "input")
+    #expect(event.tags?["error.category"] == "hotkey_registration_failed")
+    #expect(event.tags?["error.identity"] == "hotkey.registration_failed")
+  }
+
+  @MainActor
+  @Test("NilCollaboratorError's event carries the production title, fingerprint and identity tag")
+  func nilCollaboratorErrorEventShape() {
+    let error = HotkeyController.NilCollaboratorError(callback: "onToggleRecording")
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .pipelineDispatchFailed, stage: "recording", environment: Self.env)
+
+    #expect(event.message?.formatted == "pipeline_dispatch_failed: NilCollaboratorError#1")
+    #expect(
+      event.fingerprint
+        == ["handled_error", "pipeline_dispatch_failed", "NilCollaboratorError#1", Self.env])
+    #expect(event.tags?["pipeline.stage"] == "recording")
+    #expect(event.tags?["error.category"] == "pipeline_dispatch_failed")
+    #expect(event.tags?["error.identity"] == "hotkey.nil_collaborator")
+  }
+
+  @MainActor
+  @Test("EmojiRestoreAnomaly's event carries the production title, fingerprint and identity tag")
+  func emojiRestoreAnomalyEventShape() {
+    let error = EmojiRestoreAnomaly.underRestore
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .emojiRestoreIncomplete, stage: "emoji_restore", environment: Self.env)
+
+    #expect(event.message?.formatted == "emoji_restore_incomplete: EmojiRestoreAnomaly#0")
+    #expect(
+      event.fingerprint
+        == ["handled_error", "emoji_restore_incomplete", "EmojiRestoreAnomaly#0", Self.env])
+    #expect(event.tags?["pipeline.stage"] == "emoji_restore")
+    #expect(event.tags?["error.category"] == "emoji_restore_incomplete")
+    #expect(event.tags?["error.identity"] == "emoji.restore_under_restore")
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -3)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .pipelineDispatchFailed, stage: "recording", environment: Self.env)
+
+    #expect(event.message?.formatted == "pipeline_dispatch_failed: EnviousWispr#-3")
+    #expect(
+      event.fingerprint == [
+        "handled_error", "pipeline_dispatch_failed", "EnviousWispr#-3", Self.env,
+      ]
+    )
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SentryEventSanitizerTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryEventSanitizerTests.swift
@@ -30,20 +30,23 @@ import Testing
 /// only need the full key-allowlist rebuild if a regulator-grade claim were
 /// required. So the sentinel below is transcript-SHAPED for denylist surfaces.
 
-/// File-scope `private` fixture reproducing the shape of `EmojiRestoreAnomaly`
-/// (`EmojiRestoreStep.swift`) — a file-scope `private` Swift error type. Its
-/// bridged `NSError.domain` carries the same `(unknown context at $ptr)`
-/// artifact as a nested `private` type (#1229; empirically verified via
-/// `swiftc` — the descriptor fix is type-shape-agnostic).
+/// File-scope `private` fixture reproducing `EmojiRestoreAnomaly`
+/// (`EmojiRestoreStep.swift`)'s pre-#1525-PR-H shape — a file-scope `private`
+/// Swift error type (PR H later widened it to `internal` so its pin can be
+/// tested directly, `PRHLeftoverErrorsSentryIdentityTests.swift`). Its bridged
+/// `NSError.domain` carries the same `(unknown context at $ptr)` artifact as a
+/// nested `private` type (#1229; empirically verified via `swiftc` — the
+/// descriptor fix is type-shape-agnostic).
 private enum FileScopeFixtureError: Error {
   case boom
 }
 
 /// Wrapper exposing a `private`-nested fixture that reproduces
-/// `RecoveryReplayError` / `RecoveryArmError`'s pre-#1525-PR-C shape (both
-/// were `private` nested inside their owning type; PR C later widened them
-/// to `internal` so their pins can be tested directly, `RecoverySentryIdentityTests.swift`)
-/// and `NilCollaboratorError`'s current shape (still `private`, unmigrated).
+/// `RecoveryReplayError` / `RecoveryArmError`'s pre-#1525-PR-C shape and
+/// `NilCollaboratorError`'s pre-#1525-PR-H shape — all three were `private`
+/// nested inside their owning type; PR C and PR H later widened them to
+/// `internal` so their pins can be tested directly
+/// (`RecoverySentryIdentityTests.swift`, `PRHLeftoverErrorsSentryIdentityTests.swift`).
 /// This fixture continues to cover the generic `(unknown context at $ptr)`
 /// normalization branch (#1229).
 private struct NestedFixtureWrapper {


### PR DESCRIPTION
## Summary
- PR H of the #1525 Sentry stable-identity ladder (`docs/sentry-identity-refactor/BIBLE.md`). Conforms `TimeoutError`, `HotkeyRegistrationError`, `NilCollaboratorError`, and `EmojiRestoreAnomaly` to `StableSentryErrorIdentity`, closing out §3a — the last of the single-shape app-owned leftovers.
- All 4 pins were measured against shipping code (the two previously-private types measured while still private, before widening — matching PR C's precedent) and cross-checked live: `TimeoutError`'s descriptor matches its one live production issue (ENVIOUSWISPR-32) exactly; the other 3 have no matching issue in a 90-day window.
- Grounded review: 3 rounds, PROCEED-AS-PLANNED. Round 1 caught a non-exhaustive switch on `EmojiRestoreAnomaly` and a missing `"timed_out"` fingerprint detail on the `TimeoutError` polish-path test; round 2 caught two stale comments in an unrelated test file; round 3 confirmed clean.
- Live UAT (dev-only, reverted before commit): fired all 4 real capture sites. Each created or reused a development-environment Sentry issue with the pinned descriptor and `error.identity` tag — ENVIOUSWISPR-41 (`NilCollaboratorError`), -42 (`EmojiRestoreAnomaly`), -43 (`HotkeyRegistrationError`), -44 (`TimeoutError`, ITN path) — without touching the existing production `TimeoutError` issue.

Part of #1525. Next: PR I (boundary normalization) and PR J (compile-time guard).

## Test plan
- [x] `scripts/xcode-test.sh` Debug lane — 3119 tests green
- [x] `scripts/xcode-test.sh --release` — 2861 tests green
- [x] `scripts/check-dependency-direction.sh` — clean across 14 modules
- [x] Codex grounded review — 3 rounds, PROCEED-AS-PLANNED
- [x] Local Codex diff review — no actionable defects
- [x] Live UAT (dev-only) — all 4 types confirmed in Sentry, zero re-grouping