### PR TITLE
fix(user): fail closed when the custom-words file exists but cannot be read (#1646)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -8,6 +8,10 @@ import Observation
 final class CustomWordsCoordinator {
   var customWords: [CustomWord] = []
   var customWordError: String?
+  /// Set when the launch-time load failed (#1646) so Your Words can show an
+  /// honest banner instead of a silent empty list. `.unreadable`: the file is
+  /// intact, nothing was changed. `.corrupted`: it was archived for recovery.
+  private(set) var wordsLoadFailureAtLaunch: CustomWordsInitialLoadFailure?
   let suggestionService = WordSuggestionService()
   /// The reused on-device alias generator, exposed as the narrow protocol so the
   /// composition root can wire it into the contacts-import coordinator without
@@ -22,6 +26,7 @@ final class CustomWordsCoordinator {
   init() {
     self.manager = CustomWordsManager()
     customWords = manager.load() ?? []
+    wordsLoadFailureAtLaunch = manager.lastLoadFailure
   }
 
   /// Test seam (#636): inject a temp-file-backed manager so hermetic tests of
@@ -30,6 +35,7 @@ final class CustomWordsCoordinator {
   package init(manager: CustomWordsManager) {
     self.manager = manager
     customWords = manager.load() ?? []
+    wordsLoadFailureAtLaunch = manager.lastLoadFailure
   }
 
   @discardableResult

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprPostProcessing
 import EnviousWisprServices
 import SwiftUI
 
@@ -19,6 +20,12 @@ struct YourWordsView: View {
     @Bindable var settings = settings
 
     SettingsContentView {
+      // Launch-time load failure (#1646): honest banner instead of a silent
+      // empty list. Two distinct situations, two distinct messages.
+      if let failure = customWordsCoordinator.wordsLoadFailureAtLaunch {
+        WordsLoadFailureBanner(failure: failure)
+      }
+
       // "Add term" action (the page title + description now live in the page header).
       HStack {
         Spacer()
@@ -67,5 +74,44 @@ struct YourWordsView: View {
         return nil
       }
     }
+  }
+}
+
+/// Warning-tinted page banner for a failed launch-time words load (#1646).
+/// Mirrors `FrozenPerRecordingBanner`'s shape with the warning palette.
+private struct WordsLoadFailureBanner: View {
+  let failure: CustomWordsInitialLoadFailure
+
+  private var message: String {
+    switch failure {
+    case .unreadable:
+      return
+        "Your saved words couldn't be read this time. Nothing was changed or deleted. Try relaunching."
+    case .corrupted:
+      return
+        "Your saved words file was damaged and moved aside for recovery. EnviousWispr started with an empty saved list."
+    }
+  }
+
+  var body: some View {
+    HStack(spacing: 9) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.system(size: 14, weight: .medium))
+        .foregroundStyle(.stWarning)
+        .accessibilityHidden(true)
+      Text(message)
+        .font(.stHelper)
+        .foregroundStyle(.stTextBody)
+        .fixedSize(horizontal: false, vertical: true)
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 11)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.stWarningSoft, in: RoundedRectangle(cornerRadius: 10))
+    .overlay(
+      RoundedRectangle(cornerRadius: 10)
+        .strokeBorder(Color.stWarning.opacity(0.25), lineWidth: 1)
+    )
   }
 }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -323,7 +323,10 @@ public final class CustomWordsManager {
       file = loaded
     case .unreadable, .corrupted:
       // Best-effort writer (#1646): requeue instead of dropping so the
-      // increments survive to the next flush attempt.
+      // increments survive to the next flush attempt — and reschedule the
+      // debounce timer, since this method already cancelled it on entry;
+      // without that, a quiet session would strand the requeued increments
+      // in memory until app exit (cloud review, PR #1647).
       for (id, increment) in snapshot {
         var entry =
           pendingIncrements[id]
@@ -332,6 +335,7 @@ public final class CustomWordsManager {
         entry.lastTimestamp = max(entry.lastTimestamp, increment.lastTimestamp)
         pendingIncrements[id] = entry
       }
+      schedulePendingFlush()
       Task {
         await AppLogger.shared.log(
           "CustomWordsManager: flush skipped — words file unreadable; increments requeued",

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -8,6 +8,34 @@ public struct BuiltinWord: Sendable {
   public let word: CustomWord
 }
 
+/// Thrown by the CRUD mutation methods when an EXISTING custom-words file
+/// cannot be read (#1646). Failing closed here is what prevents a mutation
+/// from silently substituting an empty library and writing it over the
+/// user's real one.
+package enum CustomWordsPersistenceError: LocalizedError, Sendable, Equatable {
+  case unreadableExistingFile
+  case corruptedExistingFile
+
+  package var errorDescription: String? {
+    switch self {
+    case .unreadableExistingFile:
+      return "Your saved words could not be read. Nothing was changed. Try again."
+    case .corruptedExistingFile:
+      return
+        "Your saved words file was damaged and moved aside for recovery. No edit or import was applied."
+    }
+  }
+}
+
+/// Why the launch-time `load()` came back nil (#1646), exposed so the
+/// coordinator can show an honest banner instead of a silent empty list.
+/// `.unreadable` means the file is intact but temporarily unreadable;
+/// `.corrupted` means it was undecodable and archived aside for recovery.
+package enum CustomWordsInitialLoadFailure: Sendable, Equatable {
+  case unreadable
+  case corrupted
+}
+
 /// Persists custom words to disk with a two-tier architecture:
 /// - **Built-in defaults**: hardcoded in the app, updatable via app updates
 /// - **User words**: persisted to `custom-words.json`
@@ -167,13 +195,58 @@ public final class CustomWordsManager {
     var words: [CustomWord] = []
   }
 
+  /// `loadFile()`'s result (#1646) — distinguishes the three conditions the
+  /// old `CustomWordsFile?` collapsed into one `nil`, so callers can fail
+  /// closed instead of treating every failure as "the library is empty".
+  private enum CustomWordsLoadResult {
+    case missing  // path does not exist — legitimate first-run state
+    case loaded(CustomWordsFile)  // decoded (current or migrated legacy format)
+    case unreadable(underlying: Error)  // exists, but the I/O read itself failed
+    case corrupted  // exists, readable, undecodable — archived aside
+  }
+
   // MARK: - Public API
 
+  /// Why the most recent `load()` returned nil; nil after a successful load
+  /// or a legitimate first run (#1646). The coordinator reads this once at
+  /// launch to show an honest banner instead of a silent empty list.
+  package private(set) var lastLoadFailure: CustomWordsInitialLoadFailure?
+
   /// Load the effective word list: built-in defaults (minus tombstones) + user words.
-  /// Returns nil only on unrecoverable I/O failure.
+  /// Returns nil only on unrecoverable I/O failure or a corrupted (archived)
+  /// file — `lastLoadFailure` says which (#1646).
   public func load() -> [CustomWord]? {
-    let file = loadFile() ?? CustomWordsFile()
-    return mergedWords(file: file)
+    switch loadFile() {
+    case .missing:
+      lastLoadFailure = nil
+      return mergedWords(file: CustomWordsFile())
+    case .loaded(let file):
+      lastLoadFailure = nil
+      return mergedWords(file: file)
+    case .unreadable:
+      lastLoadFailure = .unreadable
+      return nil
+    case .corrupted:
+      lastLoadFailure = .corrupted
+      return nil
+    }
+  }
+
+  /// The strict read every explicit CRUD mutation uses (#1646). `.missing` is
+  /// a legitimate first run (fresh empty file); an unreadable or corrupted
+  /// existing file throws so the mutation writes nothing and the caller's
+  /// in-memory list stays untouched.
+  private func loadFileForMutation() throws -> CustomWordsFile {
+    switch loadFile() {
+    case .missing:
+      return CustomWordsFile()
+    case .loaded(let file):
+      return file
+    case .unreadable:
+      throw CustomWordsPersistenceError.unreadableExistingFile
+    case .corrupted:
+      throw CustomWordsPersistenceError.corruptedExistingFile
+    }
   }
 
   /// Phase 3b (#631): debounced writer that bumps `frequencyUsed` and
@@ -242,7 +315,31 @@ public final class CustomWordsManager {
     pendingIncrements.removeAll()
     guard !snapshot.isEmpty else { return }
 
-    var file = loadFile() ?? CustomWordsFile()
+    var file: CustomWordsFile
+    switch loadFile() {
+    case .missing:
+      file = CustomWordsFile()
+    case .loaded(let loaded):
+      file = loaded
+    case .unreadable, .corrupted:
+      // Best-effort writer (#1646): requeue instead of dropping so the
+      // increments survive to the next flush attempt.
+      for (id, increment) in snapshot {
+        var entry =
+          pendingIncrements[id]
+          ?? PendingIncrement(count: 0, lastTimestamp: increment.lastTimestamp)
+        entry.count += increment.count
+        entry.lastTimestamp = max(entry.lastTimestamp, increment.lastTimestamp)
+        pendingIncrements[id] = entry
+      }
+      Task {
+        await AppLogger.shared.log(
+          "CustomWordsManager: flush skipped — words file unreadable; increments requeued",
+          level: .info, category: "CustomWords"
+        )
+      }
+      return
+    }
     var changed = false
     for (id, increment) in snapshot {
       guard let idx = file.words.firstIndex(where: { $0.id == id }) else { continue }
@@ -276,7 +373,7 @@ public final class CustomWordsManager {
       })
     else { return }
 
-    var file = loadFile() ?? CustomWordsFile()
+    var file = try loadFileForMutation()
 
     // If this matches a deleted built-in, restore it instead of adding a user word
     if let builtin = Self.builtinDefaults.first(where: {
@@ -313,7 +410,7 @@ public final class CustomWordsManager {
   public func addBatch(_ incoming: [CustomWord], to words: inout [CustomWord]) throws
     -> [UUID]
   {
-    var file = loadFile() ?? CustomWordsFile()
+    var file = try loadFileForMutation()
     // Seed dedupe from BOTH the in-memory merged list and the on-disk file so a
     // stale `words` snapshot can't produce a duplicate at batch scale.
     var seen = Set(words.map { $0.canonical.lowercased() })
@@ -355,7 +452,7 @@ public final class CustomWordsManager {
 
   public func remove(id: UUID, from words: inout [CustomWord]) throws {
     let word = words.first { $0.id == id }
-    var file = loadFile() ?? CustomWordsFile()
+    var file = try loadFileForMutation()
 
     // If this matches a built-in, tombstone it
     if let word = word,
@@ -381,7 +478,7 @@ public final class CustomWordsManager {
   public func removeBatch(ids: [UUID], from words: inout [CustomWord]) throws {
     guard !ids.isEmpty else { return }
     let idSet = Set(ids)
-    var file = loadFile() ?? CustomWordsFile()
+    var file = try loadFileForMutation()
 
     // Tombstone any built-ins whose canonical matches a removed word (mirror
     // remove(id:)). Import-created words are user words, so this is normally
@@ -410,7 +507,7 @@ public final class CustomWordsManager {
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
       .filter { !$0.isEmpty }
 
-    var file = loadFile() ?? CustomWordsFile()
+    var file = try loadFileForMutation()
 
     // Check if this is a built-in word being edited — store as user override
     if let existingIdx = file.words.firstIndex(where: { $0.id == word.id }) {
@@ -439,7 +536,7 @@ public final class CustomWordsManager {
   /// with `words` untouched if nothing matched.
   public func updateBatch(_ updates: [CustomWord], to words: inout [CustomWord]) throws {
     guard !updates.isEmpty else { return }
-    var file = loadFile() ?? CustomWordsFile()
+    var file = try loadFileForMutation()
     var changed = false
     for word in updates {
       let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -461,22 +558,27 @@ public final class CustomWordsManager {
   // MARK: - Private File I/O
 
   /// Single read path — normalizes legacy formats to CustomWordsFile.
-  /// All callers (load, add, remove, save) go through this.
-  private func loadFile() -> CustomWordsFile? {
-    guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
-    guard let data = try? Data(contentsOf: fileURL) else {
+  /// All callers (load, flush, CRUD mutations) go through this. The result
+  /// distinguishes missing / loaded / unreadable / corrupted (#1646) so
+  /// callers can fail closed instead of treating every failure as "empty".
+  private func loadFile() -> CustomWordsLoadResult {
+    guard FileManager.default.fileExists(atPath: fileURL.path) else { return .missing }
+    let data: Data
+    do {
+      data = try Data(contentsOf: fileURL)
+    } catch {
       Task {
         await AppLogger.shared.log(
-          "Failed to read custom words file — returning nil to prevent data loss",
+          "Failed to read custom words file — failing closed to prevent data loss",
           level: .info, category: "CustomWords"
         )
       }
-      return nil
+      return .unreadable(underlying: error)
     }
 
     // Try new versioned wrapper first
     if let file = try? JSONDecoder().decode(CustomWordsFile.self, from: data) {
-      return file
+      return .loaded(file)
     }
 
     // Migrate from old [CustomWord] array format
@@ -489,7 +591,7 @@ public final class CustomWordsManager {
           level: .info, category: "CustomWords"
         )
       }
-      return file
+      return .loaded(file)
     }
 
     // Migrate from old [String] array format
@@ -507,20 +609,35 @@ public final class CustomWordsManager {
           level: .info, category: "CustomWords"
         )
       }
-      return file
+      return .loaded(file)
     }
 
-    // Corrupted — backup and start fresh
+    // Corrupted — archive to a unique sidecar so the next read starts fresh.
+    // `.corrupted` is reported only when the archive actually succeeded; a
+    // failed archive leaves the original bytes in place, so the caller keeps
+    // failing closed (`.unreadable`) instead of being promised a self-heal
+    // that can't happen. Unique name: a second, later corruption event must
+    // not collide with an earlier sidecar (#1646).
     let backup = fileURL.deletingLastPathComponent()
-      .appendingPathComponent("custom-words.json.corrupted")
-    try? FileManager.default.moveItem(at: fileURL, to: backup)
+      .appendingPathComponent("custom-words.json.corrupted-\(UUID().uuidString)")
+    do {
+      try FileManager.default.moveItem(at: fileURL, to: backup)
+    } catch {
+      Task {
+        await AppLogger.shared.log(
+          "Custom words file corrupted and archive failed — failing closed",
+          level: .info, category: "CustomWords"
+        )
+      }
+      return .unreadable(underlying: error)
+    }
     Task {
       await AppLogger.shared.log(
         "Custom words file corrupted, backed up to \(backup.lastPathComponent)",
         level: .info, category: "CustomWords"
       )
     }
-    return nil
+    return .corrupted
   }
 
   /// Persist the custom-words file at 0600.

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
@@ -1,0 +1,448 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPostProcessing
+
+/// #1646 (PR-P0) — fail-closed persistence. `loadFile()` distinguishes
+/// missing / loaded / unreadable / corrupted, and every explicit CRUD mutation
+/// throws without writing when an EXISTING file cannot be read, instead of
+/// silently substituting an empty library and saving it over the real one.
+@MainActor
+@Suite("CustomWordsManager — fail-closed persistence (#1646)")
+struct CustomWordsManagerPersistenceTests {
+  // MARK: - Fixtures
+
+  private static func tempDir() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("EnviousWispr-p0-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  private static func cleanup(_ dir: URL) {
+    // Restore permissions first so removal never fails on a test-tightened dir/file.
+    try? FileManager.default.setAttributes(
+      [.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    if let contents = try? FileManager.default.contentsOfDirectory(atPath: dir.path) {
+      for item in contents {
+        try? FileManager.default.setAttributes(
+          [.posixPermissions: 0o600],
+          ofItemAtPath: dir.appendingPathComponent(item).path)
+      }
+    }
+    try? FileManager.default.removeItem(at: dir)
+  }
+
+  /// A manager whose file already holds one user word ("Kubernetes").
+  private static func seededManager() throws -> (
+    manager: CustomWordsManager, url: URL, dir: URL, words: [CustomWord]
+  ) {
+    let dir = tempDir()
+    let url = dir.appendingPathComponent("custom-words.json")
+    let mgr = CustomWordsManager(fileURL: url)
+    var words = mgr.load() ?? []
+    try mgr.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+    return (mgr, url, dir, words)
+  }
+
+  private static func chmod(_ url: URL, _ mode: Int) {
+    try? FileManager.default.setAttributes(
+      [.posixPermissions: mode], ofItemAtPath: url.path)
+  }
+
+  private static let garbage = Data("not valid json at all {{{".utf8)
+
+  private static func corruptedSidecars(in dir: URL) -> [String] {
+    ((try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? [])
+      .filter { $0.contains(".corrupted-") }
+  }
+
+  // MARK: - Missing file is a legitimate first run
+
+  @Test("Missing file treats as first run across all eight call sites")
+  func missingFileTreatsAsFirstRunAcrossAllEightCallSites() throws {
+    let dir = Self.tempDir()
+    defer { Self.cleanup(dir) }
+    let url = dir.appendingPathComponent("custom-words.json")
+    let mgr = CustomWordsManager(fileURL: url)
+
+    // load(): builtins only, no failure flag.
+    var words = try #require(mgr.load())
+    #expect(mgr.lastLoadFailure == nil)
+    #expect(words.contains { $0.canonical == "EnviousWispr" })
+
+    // All six CRUD mutations succeed against a missing file.
+    try mgr.add(word: CustomWord(canonical: "Alpha Term"), to: &words)
+    let batchIDs = try mgr.addBatch([CustomWord(canonical: "Beta Term")], to: &words)
+    #expect(batchIDs.count == 1)
+    let alpha = try #require(words.first { $0.canonical == "Alpha Term" })
+    var updatedAlpha = alpha
+    updatedAlpha.aliases = ["al fa"]
+    try mgr.update(word: updatedAlpha, in: &words)
+    try mgr.updateBatch([updatedAlpha], to: &words)
+    try mgr.remove(id: alpha.id, from: &words)
+    try mgr.removeBatch(ids: batchIDs, from: &words)
+    #expect(!words.contains { $0.canonical == "Alpha Term" })
+    #expect(!words.contains { $0.canonical == "Beta Term" })
+
+    // flush with an unknown id: silently skipped, no crash, no file requirement.
+    mgr.recordReplacements([UUID()])
+    mgr.flushPendingIncrementsForTesting()
+  }
+
+  // MARK: - Unreadable existing file fails closed (the regression tests)
+
+  @Test(
+    "Unreadable existing file throws without writing",
+    arguments: ["add", "addBatch", "remove", "removeBatch", "update", "updateBatch"])
+  func unreadableExistingFileThrowsWithoutWriting(method: String) throws {
+    let (mgr, url, dir, seeded) = try Self.seededManager()
+    defer { Self.cleanup(dir) }
+    let bytesBefore = try Data(contentsOf: url)
+    var words = seeded
+    let target = try #require(words.first { $0.canonical == "Kubernetes" })
+
+    Self.chmod(url, 0o000)
+    let error = #expect(throws: CustomWordsPersistenceError.self) {
+      switch method {
+      case "add":
+        try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+      case "addBatch":
+        _ = try mgr.addBatch([CustomWord(canonical: "Terraform")], to: &words)
+      case "remove":
+        try mgr.remove(id: target.id, from: &words)
+      case "removeBatch":
+        try mgr.removeBatch(ids: [target.id], from: &words)
+      case "update":
+        try mgr.update(word: target, in: &words)
+      case "updateBatch":
+        try mgr.updateBatch([target], to: &words)
+      default:
+        Issue.record("unknown method \(method)")
+      }
+    }
+    #expect(error == .unreadableExistingFile)
+
+    // Caller's in-memory list untouched; on-disk bytes byte-identical.
+    #expect(words == seeded)
+    Self.chmod(url, 0o600)
+    #expect(try Data(contentsOf: url) == bytesBefore)
+  }
+
+  @Test("Unreadable file keeps failing closed across repeated attempts")
+  func unreadableFileKeepsFailingClosedAcrossRepeatedAttempts() throws {
+    let (mgr, url, dir, seeded) = try Self.seededManager()
+    defer { Self.cleanup(dir) }
+    let bytesBefore = try Data(contentsOf: url)
+    var words = seeded
+
+    Self.chmod(url, 0o000)
+    for _ in 0..<3 {
+      #expect(throws: CustomWordsPersistenceError.unreadableExistingFile) {
+        try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+      }
+    }
+    #expect(words == seeded)
+    Self.chmod(url, 0o600)
+    #expect(try Data(contentsOf: url) == bytesBefore)
+
+    // Once readable again, the same mutation succeeds — retry-safe forever.
+    try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+    #expect(words.contains { $0.canonical == "Terraform" })
+  }
+
+  // MARK: - Corrupted existing file: fails closed once, archives, self-heals
+
+  @Test("Corrupted existing file throws without writing on first attempt")
+  func corruptedExistingFileThrowsWithoutWritingOnFirstAttempt() throws {
+    let dir = Self.tempDir()
+    defer { Self.cleanup(dir) }
+    let url = dir.appendingPathComponent("custom-words.json")
+    try Self.garbage.write(to: url)
+    let mgr = CustomWordsManager(fileURL: url)
+    var words: [CustomWord] = []
+
+    #expect(throws: CustomWordsPersistenceError.corruptedExistingFile) {
+      try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+    }
+    #expect(words.isEmpty)
+    // No new custom-words.json was written by the failed mutation.
+    #expect(!FileManager.default.fileExists(atPath: url.path))
+  }
+
+  @Test("Corrupted file still backs up before throwing")
+  func corruptedFileStillBacksUpBeforeThrowing() throws {
+    let dir = Self.tempDir()
+    defer { Self.cleanup(dir) }
+    let url = dir.appendingPathComponent("custom-words.json")
+    try Self.garbage.write(to: url)
+    let mgr = CustomWordsManager(fileURL: url)
+    var words: [CustomWord] = []
+
+    #expect(throws: CustomWordsPersistenceError.corruptedExistingFile) {
+      try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+    }
+    let sidecars = Self.corruptedSidecars(in: dir)
+    #expect(sidecars.count == 1)
+    if let sidecar = sidecars.first {
+      let archived = try Data(contentsOf: dir.appendingPathComponent(sidecar))
+      #expect(archived == Self.garbage)
+    }
+  }
+
+  @Test("Corrupted file self-heals on the next call after the first corruption encounter")
+  func corruptedFileSelfHealsOnTheNextCallAfterTheFirstCorruptionEncounter() throws {
+    let dir = Self.tempDir()
+    defer { Self.cleanup(dir) }
+    let url = dir.appendingPathComponent("custom-words.json")
+    try Self.garbage.write(to: url)
+    let mgr = CustomWordsManager(fileURL: url)
+    var words: [CustomWord] = []
+
+    // First encounter: a mutation — fails closed, archives.
+    #expect(throws: CustomWordsPersistenceError.corruptedExistingFile) {
+      try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+    }
+    // Second call of EITHER kind succeeds against a fresh empty file.
+    words = try #require(mgr.load())
+    #expect(mgr.lastLoadFailure == nil)
+    try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+    #expect(words.contains { $0.canonical == "Terraform" })
+  }
+
+  @Test("Second corruption uses a unique archive and self-heals again")
+  func secondCorruptionUsesAUniqueArchiveAndSelfHealsAgain() throws {
+    let dir = Self.tempDir()
+    defer { Self.cleanup(dir) }
+    let url = dir.appendingPathComponent("custom-words.json")
+    try Self.garbage.write(to: url)
+    let mgr = CustomWordsManager(fileURL: url)
+
+    // First corruption encounter (a read) archives sidecar #1.
+    #expect(mgr.load() == nil)
+    #expect(Self.corruptedSidecars(in: dir).count == 1)
+
+    // A later, unrelated corruption event must not collide with sidecar #1.
+    try Data("different garbage <<<".utf8).write(to: url)
+    #expect(mgr.load() == nil)
+    #expect(Self.corruptedSidecars(in: dir).count == 2)
+
+    // And it still self-heals.
+    var words = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+    #expect(words.contains { $0.canonical == "Terraform" })
+  }
+
+  @Test("Corrupted archive failure keeps original and fails closed repeatedly")
+  func corruptedArchiveFailureKeepsOriginalAndFailsClosedRepeatedly() throws {
+    let dir = Self.tempDir()
+    defer { Self.cleanup(dir) }
+    let url = dir.appendingPathComponent("custom-words.json")
+    try Self.garbage.write(to: url)
+    let mgr = CustomWordsManager(fileURL: url)
+    var words: [CustomWord] = []
+
+    // Read-only directory: the archive moveItem cannot succeed, so the result
+    // must be .unreadable (permanently retry-safe), never a promised self-heal.
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o500], ofItemAtPath: dir.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    }
+
+    for _ in 0..<2 {
+      #expect(throws: CustomWordsPersistenceError.unreadableExistingFile) {
+        try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+      }
+    }
+    #expect(FileManager.default.fileExists(atPath: url.path))
+    #expect(try Data(contentsOf: url) == Self.garbage)
+    #expect(Self.corruptedSidecars(in: dir).isEmpty)
+  }
+
+  @Test("Launch load can archive corruption before next mutation proceeds")
+  func launchLoadCanArchiveCorruptionBeforeNextMutationProceeds() throws {
+    let dir = Self.tempDir()
+    defer { Self.cleanup(dir) }
+    let url = dir.appendingPathComponent("custom-words.json")
+    try Self.garbage.write(to: url)
+    let mgr = CustomWordsManager(fileURL: url)
+
+    // Launch-style load consumes the one-time corruption encounter.
+    #expect(mgr.load() == nil)
+    #expect(mgr.lastLoadFailure == .corrupted)
+    #expect(Self.corruptedSidecars(in: dir).count == 1)
+
+    // The very next mutation sees .missing and proceeds cleanly — never throws.
+    var words = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Terraform"), to: &words)
+    #expect(words.contains { $0.canonical == "Terraform" })
+  }
+
+  // MARK: - Legacy migrations unchanged
+
+  @Test("Legacy [CustomWord] array format still migrates and loads")
+  func legacyArrayFormatFileStillMigratesAndLoads() throws {
+    let dir = Self.tempDir()
+    defer { Self.cleanup(dir) }
+    let url = dir.appendingPathComponent("custom-words.json")
+    let legacy = [CustomWord(canonical: "LegacyTerm")]
+    try JSONEncoder().encode(legacy).write(to: url)
+    let mgr = CustomWordsManager(fileURL: url)
+
+    let words = try #require(mgr.load())
+    #expect(mgr.lastLoadFailure == nil)
+    #expect(words.contains { $0.canonical == "LegacyTerm" })
+    // Re-saved in the versioned wrapper format.
+    let migrated = try Data(contentsOf: url)
+    #expect(String(data: migrated, encoding: .utf8)?.contains("\"version\"") == true)
+  }
+
+  @Test("Legacy [String] array format still migrates and loads")
+  func legacyStringFormatFileStillMigratesAndLoads() throws {
+    let dir = Self.tempDir()
+    defer { Self.cleanup(dir) }
+    let url = dir.appendingPathComponent("custom-words.json")
+    try JSONEncoder().encode(["LegacyStringTerm", "  "]).write(to: url)
+    let mgr = CustomWordsManager(fileURL: url)
+
+    let words = try #require(mgr.load())
+    #expect(words.contains { $0.canonical == "LegacyStringTerm" })
+    #expect(!words.contains { $0.canonical.isEmpty })
+  }
+
+  // MARK: - Best-effort flush requeues
+
+  @Test("flushPendingIncrements on unreadable file requeues instead of dropping")
+  func flushPendingIncrementsOnUnreadableFileRequeuesInsteadOfDropping() throws {
+    let (mgr, url, dir, seeded) = try Self.seededManager()
+    defer { Self.cleanup(dir) }
+    let target = try #require(seeded.first { $0.canonical == "Kubernetes" })
+
+    mgr.recordReplacements([target.id])
+    Self.chmod(url, 0o000)
+    mgr.flushPendingIncrementsForTesting()  // requeued, not dropped
+
+    Self.chmod(url, 0o600)
+    mgr.flushPendingIncrementsForTesting()  // retried flush lands
+    let words = try #require(mgr.load())
+    let flushed = try #require(words.first { $0.id == target.id })
+    #expect(flushed.frequencyUsed == 1)
+  }
+
+  // MARK: - load() contract
+
+  @Test("load returns nil on unreadable or corrupted, unchanged")
+  func loadReturnsNilOnUnreadableOrCorruptedUnchanged() throws {
+    let (mgr, url, dir, _) = try Self.seededManager()
+    defer { Self.cleanup(dir) }
+
+    Self.chmod(url, 0o000)
+    #expect(mgr.load() == nil)
+    Self.chmod(url, 0o600)
+
+    try Self.garbage.write(to: url)
+    #expect(mgr.load() == nil)
+  }
+
+  @Test("load sets lastLoadFailure to unreadable or corrupted matching the real cause")
+  func loadSetsLastLoadFailureToUnreadableOrCorruptedMatchingTheRealCause() throws {
+    let (mgr, url, dir, _) = try Self.seededManager()
+    defer { Self.cleanup(dir) }
+
+    #expect(mgr.load() != nil)
+    #expect(mgr.lastLoadFailure == nil)
+
+    Self.chmod(url, 0o000)
+    #expect(mgr.load() == nil)
+    #expect(mgr.lastLoadFailure == .unreadable)
+    Self.chmod(url, 0o600)
+
+    try Self.garbage.write(to: url)
+    #expect(mgr.load() == nil)
+    #expect(mgr.lastLoadFailure == .corrupted)
+
+    // Success clears the flag again (post-corruption self-heal).
+    #expect(mgr.load() != nil)
+    #expect(mgr.lastLoadFailure == nil)
+  }
+
+  @Test("Persistence error produces honest localized description")
+  func persistenceErrorProducesHonestLocalizedDescription() {
+    let unreadable = CustomWordsPersistenceError.unreadableExistingFile as Error
+    #expect(unreadable.localizedDescription.contains("Nothing was changed"))
+    let corrupted = CustomWordsPersistenceError.corruptedExistingFile as Error
+    #expect(corrupted.localizedDescription.contains("moved aside for recovery"))
+  }
+}
+
+/// #1646 (PR-P0) — coordinator surfaces the launch-time load failure honestly.
+@MainActor
+@Suite("CustomWordsCoordinator — launch load failure (#1646)")
+struct CustomWordsCoordinatorLaunchFailureTests {
+  private static func tempURL() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("EnviousWispr-p0c-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent("custom-words.json")
+  }
+
+  private static func cleanup(_ url: URL) {
+    try? FileManager.default.setAttributes(
+      [.posixPermissions: 0o600], ofItemAtPath: url.path)
+    try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+  }
+
+  @Test("Unreadable file at launch sets wordsLoadFailure to unreadable with empty words, not error")
+  func unreadableFileAtLaunchSetsWordsLoadFailureToUnreadableWithEmptyWordsNotError() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let mgr = CustomWordsManager(fileURL: url)
+    var words = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: url.path)
+
+    let coordinator = CustomWordsCoordinator(manager: mgr)
+    #expect(coordinator.wordsLoadFailureAtLaunch == .unreadable)
+    #expect(coordinator.customWords.isEmpty)
+    #expect(coordinator.customWordError == nil)
+  }
+
+  @Test("Corrupted file at launch sets wordsLoadFailure to corrupted with empty words, not error")
+  func corruptedFileAtLaunchSetsWordsLoadFailureToCorruptedWithEmptyWordsNotError() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    try Data("not valid json at all {{{".utf8).write(to: url)
+
+    let coordinator = CustomWordsCoordinator(manager: CustomWordsManager(fileURL: url))
+    #expect(coordinator.wordsLoadFailureAtLaunch == .corrupted)
+    #expect(coordinator.customWords.isEmpty)
+    #expect(coordinator.customWordError == nil)
+  }
+
+  @Test("Subsequent add after unreadable launch throws and touches no disk")
+  func subsequentAddAfterUnreadableLaunchThrowsAndTouchesNoDisk() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let mgr = CustomWordsManager(fileURL: url)
+    var words = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+    let bytesBefore = try Data(contentsOf: url)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: url.path)
+
+    let coordinator = CustomWordsCoordinator(manager: mgr)
+    let error = coordinator.add(CustomWord(canonical: "Terraform"))
+    #expect(error != nil)
+    #expect(coordinator.customWordError == error)
+    #expect(coordinator.customWords.isEmpty)
+
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o600], ofItemAtPath: url.path)
+    #expect(try Data(contentsOf: url) == bytesBefore)
+  }
+}


### PR DESCRIPTION
Closes #1646. Part of #1619 (PR-P0 in the adopted v5 plan).

Lane: Code | Tier: MEDIUM | Modules: PostProcessing, AppKit

## What

Fixes a live, already-shipping data-loss bug: `CustomWordsManager.loadFile()` collapsed "no file yet", "file exists but transiently unreadable", and "file exists but undecodable" into one `nil`, and every mutation read via `loadFile() ?? CustomWordsFile()`. A `remove` racing a transiently unreadable `custom-words.json` silently substituted an empty library and wrote it over the user's real word list.

## How

- Private `CustomWordsLoadResult`: `missing` / `loaded` / `unreadable(underlying:)` / `corrupted`; `loadFile()` returns it; all 8 call sites switch on it.
- The six explicit CRUD mutation methods throw `CustomWordsPersistenceError` (package, `LocalizedError`, honest user-facing copy) through one strict-read authority (`loadFileForMutation()`), writing nothing. `.unreadable` is retry-safe forever; `.corrupted` fails closed exactly once, archives the bytes to a unique `custom-words.json.corrupted-<UUID>` sidecar (reported `.corrupted` only when the archive move succeeded, else `.unreadable`), then self-heals.
- `flushPendingIncrements` (best-effort debounced usage writer) requeues increments on an unreadable file instead of dropping them.
- `load()` keeps its `[CustomWord]?` nil-on-failure contract and sets a typed `lastLoadFailure`; `CustomWordsCoordinator` exposes `wordsLoadFailureAtLaunch`; Your Words shows one of two honest launch banners (temporarily unreadable vs. damaged-and-archived) instead of a silent empty list.
- Zero new public API beyond the `LocalizedError` conformance — all six mutation methods already declared `throws`, and every external caller already routes through the coordinator's existing catch.

## Validation

- 18 new tests: parameterized fail-closed regression across all six mutation methods (asserting on-disk bytes byte-identical after the throw), corrupted lifecycle (unique archive, archive-failure fallback to `.unreadable`, launch-consumes-encounter, self-heal, second-corruption uniqueness), legacy `[CustomWord]`/`[String]` migrations unchanged, flush requeue, `load()` contract, honest error copy, coordinator launch flags.
- Falsification probe: temporarily restoring the old fail-open fallback turned the regression tests red exactly on the fail-closed claims (including `updateBatch`'s silent no-op — the old failure shape) and green again after revert.
- Full suite green: 3,137 tests. Local Codex diff review round 1: clean, zero findings (`docs/audits/2026-07-17-p0-1646-codex-diff-r1.txt`).
- Live UAT on the rebuilt dev app: real word list loaded through the new strict loader (no failure lines, no banner), real founder dictations ran the full pipeline including Word Correction at sub-second totals. Failure-path banners covered hermetically — inducing an unreadable state on the real shared words file while the pre-fix production app runs would enact the exact race this PR fixes, so it was deliberately not performed live.
