### PR TITLE
feat(observability): pin Sentry identity for the kernel fallback enum + AudioError

### DIFF
--- a/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
+++ b/Sources/EnviousWisprAudio/AudioBufferProcessor.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+import EnviousWisprCore
 
 /// Handles audio format conversion and buffer processing.
 enum AudioBufferProcessor {
@@ -57,6 +58,27 @@ public enum AudioError: LocalizedError, CustomNSError, Sendable {
       return source
     case .alreadyCapturing, .noBuiltInMicrophoneFound:
       return nil
+    }
+  }
+}
+
+// MARK: - Sentry identity
+
+/// Adds explicit Sentry identity using the EXISTING `CustomNSError`
+/// `errorDomain` and exhaustive `errorCode` switch. `AudioError`'s NSError
+/// bridge, localized behavior, Sentry title, and grouping fingerprint remain
+/// unchanged. The only new Sentry wire field is the readable `error.identity`
+/// metadata tag required by PR J's future compile-time guard.
+extension AudioError: StableSentryErrorIdentity {
+  public var sentryFingerprintDescriptor: String {
+    "\(Self.errorDomain)#\(errorCode)"
+  }
+
+  public var sentrySemanticID: String {
+    switch self {
+    case .formatCreationFailed: return "audio.format_creation_failed"
+    case .alreadyCapturing: return "audio.already_capturing"
+    case .noBuiltInMicrophoneFound: return "audio.no_built_in_microphone_found"
     }
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -859,11 +859,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       // comment-aware, so this comment must avoid the banned token too.)
       let backendLabel = adapter.engineIdentity.displayName
       captureErrorSink(
-        NSError(
-          domain: "EnviousWispr", code: -3,
-          userInfo: [
-            NSLocalizedDescriptionKey: "ASR XPC service crashed (\(backendLabel))"
-          ]),
+        KernelFallbackSentryError.xpcServiceError(backendLabel: backendLabel),
         .xpcServiceError, "asr",
         ["was_recording": false, "backend": backendID], nil)
       setTerminalReason(.asrInterrupted)

--- a/Sources/EnviousWisprPipeline/KernelFallbackSentryError.swift
+++ b/Sources/EnviousWisprPipeline/KernelFallbackSentryError.swift
@@ -1,0 +1,71 @@
+import EnviousWisprCore
+import Foundation
+
+/// Exhaustive replacement for the raw `NSError(domain: "EnviousWispr", code:
+/// ...)` fallback literals in `KernelLifecycleTelemetrySink` and
+/// `KernelDictationDriver` (#1525 PR I-A). Each case pins the exact string
+/// already sent in production — measured, not derived — so adding, removing,
+/// or reordering a case here can never re-point a shipped Sentry issue onto
+/// another's. `.xpcServiceError` is constructed at TWO call sites (the
+/// lifecycle sink's `.asrInterrupted` handler and the driver's direct-emit
+/// fallback when routing doesn't reach the sink) — both use this ONE case.
+enum KernelFallbackSentryError: Error, LocalizedError, Sendable {
+  case xpcServiceError(backendLabel: String)
+  case modelLoadFailed
+  case captureStartFailed
+  case noMicrophoneFound
+  case transcriptionFailed
+  case permissionDenied
+  case prepareFailed
+
+  var errorDescription: String? {
+    switch self {
+    case .xpcServiceError(let backendLabel):
+      return "ASR XPC service crashed (\(backendLabel))"
+    case .modelLoadFailed:
+      return "Model load failed"
+    case .captureStartFailed:
+      return "Recording failed"
+    case .noMicrophoneFound:
+      return "No usable microphone device was found"
+    case .transcriptionFailed:
+      return "Transcription failed"
+    case .permissionDenied:
+      return "Microphone permission denied"
+    case .prepareFailed:
+      return "Prepare failed"
+    }
+  }
+}
+
+// MARK: - Sentry identity
+
+/// Pins each case's Sentry grouping key to the exact string it has been
+/// sending in production (#1525 PR I-A), mirroring `HeartPathError`'s shipped
+/// pattern (#1524). The switch is exhaustive, so a new case cannot compile
+/// until it declares an identity.
+extension KernelFallbackSentryError: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String {
+    switch self {
+    case .xpcServiceError: return "EnviousWispr#-3"
+    case .modelLoadFailed: return "EnviousWispr#-10"
+    case .captureStartFailed: return "EnviousWispr#-11"
+    case .noMicrophoneFound: return "EnviousWispr#-16"
+    case .transcriptionFailed: return "EnviousWispr#-13"
+    case .permissionDenied: return "EnviousWispr#-14"
+    case .prepareFailed: return "EnviousWispr#-15"
+    }
+  }
+
+  var sentrySemanticID: String {
+    switch self {
+    case .xpcServiceError: return "kernel.xpc_service_error"
+    case .modelLoadFailed: return "kernel.model_load_failed"
+    case .captureStartFailed: return "kernel.capture_start_failed"
+    case .noMicrophoneFound: return "kernel.no_microphone_found"
+    case .transcriptionFailed: return "kernel.transcription_failed"
+    case .permissionDenied: return "kernel.permission_denied"
+    case .prepareFailed: return "kernel.prepare_failed"
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -305,11 +305,7 @@ final class KernelLifecycleTelemetrySink {
       let bv = backend.rawValue
       let backendLabel = backend == .whisperKit ? "WhisperKit" : "Parakeet"
       emitCaptureError(
-        NSError(
-          domain: "EnviousWispr", code: -3,
-          userInfo: [
-            NSLocalizedDescriptionKey: "ASR XPC service crashed (\(backendLabel))"
-          ]),
+        KernelFallbackSentryError.xpcServiceError(backendLabel: backendLabel),
         .xpcServiceError, "asr",
         ["was_recording": wasRecording, "backend": bv],
         snapshot: recordingSnapshot())
@@ -586,9 +582,7 @@ final class KernelLifecycleTelemetrySink {
       // the error is somehow absent.
       let modelError =
         telemetryState.modelLoadError
-        ?? NSError(
-          domain: "EnviousWispr", code: -10,
-          userInfo: [NSLocalizedDescriptionKey: "Model load failed"])
+        ?? KernelFallbackSentryError.modelLoadFailed
       emitCaptureError(
         modelError,
         .modelLoadFailed, "asr",
@@ -596,9 +590,7 @@ final class KernelLifecycleTelemetrySink {
     case .captureStartFailed:
       let error =
         telemetryState.captureFailureError
-        ?? NSError(
-          domain: "EnviousWispr", code: -11,
-          userInfo: [NSLocalizedDescriptionKey: "Recording failed"])
+        ?? KernelFallbackSentryError.captureStartFailed
       emitCaptureError(
         error,
         .audioCaptureFailed, "recording",
@@ -609,9 +601,7 @@ final class KernelLifecycleTelemetrySink {
       // held-release drop can still be watched post-ship.
       let error =
         telemetryState.captureFailureError
-        ?? NSError(
-          domain: "EnviousWispr", code: -16,
-          userInfo: [NSLocalizedDescriptionKey: "No usable microphone device was found"])
+        ?? KernelFallbackSentryError.noMicrophoneFound
       emitCaptureError(
         error,
         .audioCaptureFailed, "recording",
@@ -647,9 +637,7 @@ final class KernelLifecycleTelemetrySink {
     case .asrFailed, .asrWedged:
       let error =
         telemetryState.transcriptionFailureError
-        ?? NSError(
-          domain: "EnviousWispr", code: -13,
-          userInfo: [NSLocalizedDescriptionKey: "Transcription failed"])
+        ?? KernelFallbackSentryError.transcriptionFailed
       emitCaptureError(
         error,
         .asrFailed, "transcription",
@@ -658,9 +646,7 @@ final class KernelLifecycleTelemetrySink {
     case .permissionDenied:
       let error =
         telemetryState.captureFailureError
-        ?? NSError(
-          domain: "EnviousWispr", code: -14,
-          userInfo: [NSLocalizedDescriptionKey: "Microphone permission denied"])
+        ?? KernelFallbackSentryError.permissionDenied
       emitCaptureError(
         error,
         .audioCaptureFailed, "recording",
@@ -668,9 +654,7 @@ final class KernelLifecycleTelemetrySink {
     case .prepareFailed:
       let error =
         telemetryState.captureFailureError
-        ?? NSError(
-          domain: "EnviousWispr", code: -15,
-          userInfo: [NSLocalizedDescriptionKey: "Prepare failed"])
+        ?? KernelFallbackSentryError.prepareFailed
       emitCaptureError(
         error,
         .audioCaptureFailed, "recording",

--- a/Tests/EnviousWisprTests/Pipeline/KernelFallbackSentryErrorIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFallbackSentryErrorIdentityTests.swift
@@ -1,0 +1,190 @@
+import EnviousWisprCore
+import Foundation
+import Sentry
+import Testing
+
+@testable import EnviousWisprAudio
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprServices
+
+/// #1525 PR I-A — `KernelFallbackSentryError` (replacing the 8 raw
+/// `NSError(domain: "EnviousWispr", code: ...)` construction sites across
+/// `KernelLifecycleTelemetrySink.swift` and `KernelDictationDriver.swift`) and
+/// `AudioError` (`AudioBufferProcessor.swift`) have PINNED Sentry identities,
+/// mirroring `HeartPathError`'s shipped pattern (#1524).
+///
+/// `KernelFallbackSentryError`'s 7 descriptors are not re-derived: they were
+/// MEASURED against the shipping literals (`EnviousWispr#-3/-10/-11/-13/-14/-15/-16`)
+/// and cross-checked against live Sentry — `-3` has TWO live issues (ENVIOUSWISPR-3G
+/// development, ENVIOUSWISPR-29 production, split by the fingerprint's environment
+/// component, not a duplicate). `AudioError`'s descriptors were already stable
+/// through explicit `CustomNSError` codes 1/2/3. This conformance preserves its
+/// NSError bridge, Sentry title, and fingerprint; it only adds the readable
+/// `error.identity` metadata tag and satisfies PR J's future compile-time
+/// requirement.
+///
+/// `environment` is passed explicitly throughout: the default reads the bundle
+/// identifier, and a test runner's bundle is not production.
+@Suite("Kernel fallback + AudioError Sentry stable identity (#1525 PR I-A)")
+struct KernelFallbackSentryErrorIdentityTests {
+
+  private static let env = "production"
+
+  // MARK: - A. Pin lock — KernelFallbackSentryError
+
+  @Test("every KernelFallbackSentryError case keeps the exact production fingerprint")
+  func kernelFallbackPinLock() {
+    let cases: [(KernelFallbackSentryError, String, SentryBreadcrumb.ErrorCategory)] = [
+      (.xpcServiceError(backendLabel: "WhisperKit"), "EnviousWispr#-3", .xpcServiceError),
+      (.modelLoadFailed, "EnviousWispr#-10", .modelLoadFailed),
+      (.captureStartFailed, "EnviousWispr#-11", .audioCaptureFailed),
+      (.noMicrophoneFound, "EnviousWispr#-16", .audioCaptureFailed),
+      (.transcriptionFailed, "EnviousWispr#-13", .asrFailed),
+      (.permissionDenied, "EnviousWispr#-14", .audioCaptureFailed),
+      (.prepareFailed, "EnviousWispr#-15", .audioCaptureFailed),
+    ]
+    for (error, descriptor, category) in cases {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(
+        SentryBreadcrumb.handledErrorFingerprint(for: category, error: error, environment: Self.env)
+          == ["handled_error", category.rawValue, descriptor, Self.env])
+    }
+  }
+
+  @Test("xpcServiceError's associated backendLabel never changes the pinned descriptor")
+  func xpcServiceErrorIgnoresBackendLabel() {
+    let whisperKit = KernelFallbackSentryError.xpcServiceError(backendLabel: "WhisperKit")
+    let parakeet = KernelFallbackSentryError.xpcServiceError(backendLabel: "Parakeet")
+    #expect(
+      SentryBreadcrumb.structuredDescriptor(whisperKit)
+        == SentryBreadcrumb.structuredDescriptor(parakeet))
+    #expect(whisperKit.errorDescription == "ASR XPC service crashed (WhisperKit)")
+    #expect(parakeet.errorDescription == "ASR XPC service crashed (Parakeet)")
+  }
+
+  @Test("all 7 declared KernelFallbackSentryError identities are unique")
+  func kernelFallbackIdentitiesAreUnique() {
+    let cases: [KernelFallbackSentryError] = [
+      .xpcServiceError(backendLabel: "WhisperKit"), .modelLoadFailed, .captureStartFailed,
+      .noMicrophoneFound, .transcriptionFailed, .permissionDenied, .prepareFailed,
+    ]
+    #expect(Set(cases.map(\.sentryFingerprintDescriptor)).count == cases.count)
+    #expect(Set(cases.map(\.sentrySemanticID)).count == cases.count)
+  }
+
+  // MARK: - B. Pin lock — AudioError
+
+  @Test("every AudioError case keeps the exact production fingerprint")
+  func audioErrorPinLock() {
+    let cases: [(AudioError, String)] = [
+      (.formatCreationFailed(source: "test"), "EnviousWisprAudio.AudioError#1"),
+      (.alreadyCapturing, "EnviousWisprAudio.AudioError#2"),
+      (.noBuiltInMicrophoneFound, "EnviousWisprAudio.AudioError#3"),
+    ]
+    for (error, descriptor) in cases {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(
+        SentryBreadcrumb.handledErrorFingerprint(
+          for: .audioCaptureFailed, error: error, environment: Self.env)
+          == ["handled_error", "audio_capture_failed", descriptor, Self.env])
+    }
+  }
+
+  @Test("all 3 declared AudioError identities are unique")
+  func audioErrorIdentitiesAreUnique() {
+    let cases: [AudioError] = [
+      .formatCreationFailed(), .alreadyCapturing, .noBuiltInMicrophoneFound,
+    ]
+    #expect(Set(cases.map(\.sentryFingerprintDescriptor)).count == cases.count)
+    #expect(Set(cases.map(\.sentrySemanticID)).count == cases.count)
+  }
+
+  // MARK: - C. The property that matters
+
+  /// A deterministic `CustomNSError` — its bridged domain/code are declared,
+  /// not inferred from enum layout, so this test asserts the override itself
+  /// and never depends on the compiler behaviour the design escapes.
+  private struct StableFixtureError: Error, CustomNSError, StableSentryErrorIdentity {
+    static let errorDomain = "fixture.raw"
+    var errorCode: Int { 40 }
+    let sentryFingerprintDescriptor = "fixture.pinned#kernelfallback"
+    let sentrySemanticID = "fixture.semantic"
+  }
+
+  @Test("the explicit identity overrides the bridged NSError identity")
+  func explicitIdentityOverridesBridge() {
+    let error = StableFixtureError()
+    let bridged = error as NSError
+
+    #expect(bridged.domain == "fixture.raw")
+    #expect(bridged.code == 40)
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "fixture.pinned#kernelfallback")
+  }
+
+  // MARK: - D. Dev/prod split survives the pin
+
+  @Test("environment keeps the same descriptor's dev and prod fingerprints separate")
+  func devProdSplitSurvives() {
+    let error = KernelFallbackSentryError.xpcServiceError(backendLabel: "Parakeet")
+    let prod = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: error, environment: "production")
+    let dev = SentryBreadcrumb.handledErrorFingerprint(
+      for: .xpcServiceError, error: error, environment: "development")
+
+    #expect(prod != dev)
+    #expect(prod.last == "production")
+    #expect(dev.last == "development")
+  }
+
+  // MARK: - E. Event-construction contract
+
+  @MainActor
+  @Test(
+    "KernelFallbackSentryError's event carries the production title, fingerprint and identity tag")
+  func kernelFallbackEventShape() {
+    let error = KernelFallbackSentryError.xpcServiceError(backendLabel: "WhisperKit")
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .xpcServiceError, stage: "asr", environment: Self.env)
+
+    #expect(event.message?.formatted == "xpc_service_error: EnviousWispr#-3")
+    #expect(
+      event.fingerprint == ["handled_error", "xpc_service_error", "EnviousWispr#-3", Self.env])
+    #expect(event.tags?["pipeline.stage"] == "asr")
+    #expect(event.tags?["error.category"] == "xpc_service_error")
+    #expect(event.tags?["error.identity"] == "kernel.xpc_service_error")
+  }
+
+  @MainActor
+  @Test("AudioError's event carries the production title, fingerprint and identity tag")
+  func audioErrorEventShape() {
+    let error = AudioError.noBuiltInMicrophoneFound
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .audioCaptureFailed, stage: "recording", environment: Self.env)
+
+    #expect(
+      event.message?.formatted
+        == "audio_capture_failed: EnviousWisprAudio.AudioError#3")
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "audio_capture_failed", "EnviousWisprAudio.AudioError#3", Self.env,
+        ])
+    #expect(event.tags?["error.identity"] == "audio.no_built_in_microphone_found")
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -99)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: .xpcServiceError, stage: "asr", environment: Self.env)
+
+    #expect(event.message?.formatted == "xpc_service_error: EnviousWispr#-99")
+    #expect(
+      event.fingerprint == ["handled_error", "xpc_service_error", "EnviousWispr#-99", Self.env])
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}


### PR DESCRIPTION
## Summary
- Replaces 8 raw `NSError(domain: "EnviousWispr", code: ...)` fallback construction sites (`KernelLifecycleTelemetrySink` x7, `KernelDictationDriver` x1) with a new `KernelFallbackSentryError` enum whose 7 cases pin the exact descriptor strings already shipping today — measured, not derived — so future case reordering/additions/removals can never re-point a live Sentry issue onto another's.
- Adds `StableSentryErrorIdentity` conformance to the pre-existing `AudioError` type (already `CustomNSError` with explicit codes 1/2/3) for PR J's future compile-time guard — no behavior change.
- PR I-A of the #1525 mini-ladder (I-A/I-B/I-C), the lowest-risk/most mechanical slice. Council skipped per `council-skip: codex-grounded-review settled the only structural fork, no user surface, no design ambiguity remaining` (Codex grounded review r1 confirmed this is defensible).

## Validation
- New 10-test suite (`KernelFallbackSentryErrorIdentityTests.swift`), all passing through the canonical Xcode test runner.
- Full Debug-lane suite: 3129 tests passing. Full Release-lane suite: 2871 tests passing.
- Codex grounded review (plan): PROCEED-WITH-REVISIONS r1 — all 4 findings applied (narrowed visibility from `public` to `internal`, corrected two stale "no-op" comments, fixed mini-ladder council-skip wording).
- Local Codex diff review: clean, "No actionable bugs found."
- Live UAT (dev-only): ran the existing `A3_asr_xpc_kill` fault-injection scenario — real ASR XPC kill mid-dictation. Confirmed in Sentry: the `xpcServiceError` case reused its existing dev issue (ENVIOUSWISPR-3G, occurrences 7→8, same descriptor `EnviousWispr#-3`), now carrying the new `error.identity: kernel.xpc_service_error` tag, with the corresponding production issue untouched.

## Test plan
- [x] Full Debug + Release test suites green
- [x] Codex grounded review (plan) to PROCEED-AS-PLANNED-equivalent (all revisions applied)
- [x] Local Codex diff review clean
- [x] Live UAT: real XPC-kill fault injection, confirmed via Sentry
- [ ] GitHub Codex cloud review (evaluate after PR opens)