### PR TITLE
refactor(observability): shared test fixture + injectable keychain telemetry factory (Part of #1525)

### DIFF
--- a/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
+++ b/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
@@ -7,37 +7,68 @@ import Foundation
 /// grounded review r2: the Core type must not name Services types). The App composition
 /// root injects `.live`; every other site uses `.noop`.
 extension LLMTelemetrySink {
-  /// Maps the Core-owned callbacks onto the real telemetry homes. Both are
+  /// #1525 PR I-C: per-instance injectable reporters, following this project's own
+  /// existing `KernelDictationDriverFactory.HeartPathCaptureErrorSink` precedent — a
+  /// typealias'd reporter signature + a named production-default constant + an
+  /// injectable factory parameter — so a test can construct its own sink and assert
+  /// both effects without installing a process-global mutable delegate across an
+  /// `await` (`swift-patterns.md` RULE: tests-no-process-global-mutable-delegate).
+  package typealias LimbFailureReporter = @MainActor (
+    _ limb: String, _ operation: String, _ result: String,
+    _ errorCategory: String, _ durationMs: Int?
+  ) -> Void
+
+  package typealias HandledErrorReporter = @MainActor (
+    _ error: any Error, _ category: SentryBreadcrumb.ErrorCategory, _ stage: String,
+    _ extra: [String: Any]?, _ fingerprintDetail: String?
+  ) -> Void
+
+  package static let defaultLimbFailureReporter: LimbFailureReporter = {
+    limb, operation, result, errorCategory, durationMs in
+    TelemetryService.shared.limbFailureObserved(
+      limb: limb, operation: operation, result: result,
+      errorCategory: errorCategory, durationMs: durationMs)
+  }
+
+  package static let defaultHandledErrorReporter: HandledErrorReporter = {
+    error, category, stage, extra, fingerprintDetail in
+    SentryBreadcrumb.captureError(
+      error, category: category, stage: stage, extra: extra,
+      fingerprintDetail: fingerprintDetail)
+  }
+
+  /// Maps the Core-owned callbacks onto the real telemetry homes. Both reporters are
   /// `@MainActor` (`TelemetryService` / `SentryBreadcrumb`), and the sink's callers run
   /// off the main actor (A6's `Task.detached`, the off-MainActor Keychain cleanup), so
   /// each closure hops to the main run loop via `DispatchQueue.main.async`
   /// (NOT `Task { @MainActor }`, which may run on the current cycle — gotchas-audio
   /// `dispatch-main-for-runloop-deferral`) and runs the emit there. Fire-and-forget:
   /// telemetry lost to an immediate quit is acceptable; a limb never blocks the heart.
-  public static let live = LLMTelemetrySink(
-    limbFailure: { limb, operation, result, errorCategory, durationMs in
-      DispatchQueue.main.async {
-        MainActor.assumeIsolated {
-          TelemetryService.shared.limbFailureObserved(
-            limb: limb, operation: operation, result: result,
-            errorCategory: errorCategory, durationMs: durationMs)
+  package static func makeLive(
+    limbFailureReporter: @escaping LimbFailureReporter = defaultLimbFailureReporter,
+    handledErrorReporter: @escaping HandledErrorReporter = defaultHandledErrorReporter
+  ) -> LLMTelemetrySink {
+    LLMTelemetrySink(
+      limbFailure: { limb, operation, result, errorCategory, durationMs in
+        DispatchQueue.main.async {
+          MainActor.assumeIsolated {
+            limbFailureReporter(limb, operation, result, errorCategory, durationMs)
+          }
         }
-      }
-    },
-    legacyKeyCleanupFailed: { error, account in
-      DispatchQueue.main.async {
-        MainActor.assumeIsolated {
-          // Population event (aggregate cleanup-failure rate) + the security-relevant
-          // handled error (per-incident detail). Account name only, never key material.
-          TelemetryService.shared.limbFailureObserved(
-            limb: "keychain", operation: "legacy_cleanup", result: "failed",
-            errorCategory: "delete_failed", durationMs: nil)
-          SentryBreadcrumb.captureError(
-            error, category: .legacyKeyCleanupFailed, stage: "keychain",
-            extra: ["account": account],
-            // Split distinct accounts into their own issue (low cardinality: 2 keys).
-            fingerprintDetail: account)
+      },
+      legacyKeyCleanupFailed: { error, account in
+        DispatchQueue.main.async {
+          MainActor.assumeIsolated {
+            // Population event (aggregate cleanup-failure rate) + the security-relevant
+            // handled error (per-incident detail). Account name only, never key material.
+            limbFailureReporter(
+              "keychain", "legacy_cleanup", "failed", "delete_failed", nil)
+            handledErrorReporter(
+              error, .legacyKeyCleanupFailed, "keychain", ["account": account], account)
+          }
         }
-      }
-    })
+      })
+  }
+
+  public static let live = makeLive()
 }

--- a/Tests/EnviousWisprTests/App/HeartControlRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/App/HeartControlRecoveryTests.swift
@@ -69,8 +69,7 @@ struct HeartControlRecoveryTests {
     let locked = LockedCallCounter()
     let recovery = makeRecovery(hideCalls: hide, lockedCalls: locked, backend: "whisperkit")
     withSentrySpy { spy in
-      struct E: Error {}
-      recovery.logDispatchFailure(E(), op: "stop")
+      recovery.logDispatchFailure(TestStableSentryError(), op: "stop")
       #expect(spy.calls.count == 1)
       #expect(spy.calls.first?.category == .pipelineDispatchFailed)
       #expect(spy.calls.first?.stage == "recording")
@@ -105,9 +104,8 @@ struct HeartControlRecoveryTests {
     let sink = ErrorSurfaceSpy()
     let recovery = makeRecovery(hideCalls: hide, lockedCalls: locked, backend: "parakeet")
     withSentrySpy { spy in
-      struct BoomError: Error {}
       recovery.recover(
-        error: BoomError(), op: "toggle", reason: .modelWedged,
+        error: TestStableSentryError(), op: "toggle", reason: .modelWedged,
         setTerminalReason: sink.setTerminalReason)
       #expect(spy.calls.count == 1)
       #expect(spy.calls.first?.extra?["op"] as? String == "toggle")
@@ -145,9 +143,8 @@ struct HeartControlRecoveryTests {
     let sink = ErrorSurfaceSpy()
     let recovery = makeRecovery(hideCalls: hide, lockedCalls: locked)
     withSentrySpy { spy in
-      struct E: Error {}
       recovery.recover(
-        error: E(), op: "toggle-from-prewarm", reason: .modelWedged,
+        error: TestStableSentryError(), op: "toggle-from-prewarm", reason: .modelWedged,
         setTerminalReason: sink.setTerminalReason)
       #expect(spy.calls.first?.extra?["op"] as? String == "toggle-from-prewarm")
     }

--- a/Tests/EnviousWisprTests/LLM/Phase8LimbTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/LLM/Phase8LimbTelemetryTests.swift
@@ -67,7 +67,7 @@ import Testing
     func noopSinkSilent() {
       let box = capture {
         LLMTelemetrySink.noop.limbFailure("x", "y", "failed", "z", 1)
-        LLMTelemetrySink.noop.legacyKeyCleanupFailed(URLError(.timedOut), "acct")
+        LLMTelemetrySink.noop.legacyKeyCleanupFailed(TestStableSentryError(), "acct")
       }
       #expect(box.named("limb.failure_observed").isEmpty)
     }
@@ -77,7 +77,7 @@ import Testing
       let spy = SinkSpy()
       let sink = spy.makeSink()
       sink.limbFailure("llm_prewarm", "prewarm", "failed", "openAI_-1001", 10)
-      sink.legacyKeyCleanupFailed(URLError(.timedOut), "openai-api-key")
+      sink.legacyKeyCleanupFailed(TestStableSentryError(), "openai-api-key")
       #expect(spy.limbs == ["llm_prewarm"])
       #expect(spy.cleanups == ["openai-api-key"])
     }

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
@@ -1,10 +1,10 @@
 import EnviousWisprCore
 import EnviousWisprLLM
-import EnviousWisprServices
 import Foundation
 import Testing
 
 @testable import EnviousWisprPipeline
+@testable import EnviousWisprServices
 
 /// #945: the runner's classify -> composed-notice + telemetry path. These run a
 /// REAL `LLMPolishStep` (with an injected throwing polisher) through the runner,
@@ -27,6 +27,7 @@ struct TextProcessingRunnerCaptureTests {
   @MainActor
   final class CaptureSpy {
     struct Call {
+      let error: any Error
       let category: SentryBreadcrumb.ErrorCategory
       let stage: String
       let extra: [String: Any]?
@@ -41,7 +42,7 @@ struct TextProcessingRunnerCaptureTests {
     ) {
       calls.append(
         Call(
-          category: category, stage: stage, extra: extra, tags: tags,
+          error: error, category: category, stage: stage, extra: extra, tags: tags,
           fingerprintDetail: fingerprintDetail))
     }
   }
@@ -356,6 +357,42 @@ struct TextProcessingRunnerCaptureTests {
     #expect(call.stage == "polish")
     #expect(call.fingerprintDetail == "bad_request")
     #expect(records.calls.first?.reason == "bad_request")
+  }
+
+  @Test(
+    "an unrecognized URLError pages us with a stable fingerprint through the real capture path (#1525 PR I-C)"
+  )
+  func unrecognizedURLErrorAlertsWithStableFingerprint() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
+    // .badURL is not in PolishFailureReason.from's recognized connectivity-code
+    // set (PolishFailureReason.swift:345-352), so it falls to `.unknown` — the
+    // alerting channel, unlike .notConnectedToInternet's `.providerUnreachable`
+    // in `cloudUnreachableIsCountedNotPaged` above.
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") { URLError(.badURL) }
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(spy.calls.count == 1)
+    let call = try #require(spy.calls.first)
+    #expect(call.category == .polishProviderFailed)
+    #expect(call.fingerprintDetail == "unknown")
+    #expect(records.calls.first?.reason == "unknown")
+
+    // Runtime proof on the supported macOS Swift/Foundation toolchain (#1525 PR I-C):
+    // boxing `URLError` as `any Error` produces an `NSError` dynamic value, so a
+    // `StableSentryErrorIdentity` conformance is unreachable through this path.
+    // The existing `NSError` fallback already produces the stable descriptor.
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      call.error, category: call.category, stage: call.stage, extra: call.extra,
+      tags: call.tags, fingerprintDetail: call.fingerprintDetail, environment: "test")
+    #expect(
+      event.fingerprint == [
+        "handled_error", "polish_provider_failed", "NSURLErrorDomain#-1000", "unknown", "test",
+      ])
+    #expect(event.tags?["error.identity"] == nil)
   }
 
   // MARK: - Timeout

--- a/Tests/EnviousWisprTests/Services/LLMTelemetrySinkLiveTests.swift
+++ b/Tests/EnviousWisprTests/Services/LLMTelemetrySinkLiveTests.swift
@@ -1,0 +1,158 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1525 PR I-C: end-to-end proof that `LLMTelemetrySink.makeLive(...)` maps a real
+/// `legacyKeyCleanupFailed` call onto BOTH production effects — the `limb.failure_observed`
+/// population event and the `legacyKeyCleanupFailed` handled-error capture — using a real,
+/// conforming `KeyStoreError`. Constructs its own sink instance via per-instance injected
+/// reporters (no process-global mutable delegate — `swift-patterns.md` RULE:
+/// tests-no-process-global-mutable-delegate), mirroring `KernelDictationDriverFactory`'s
+/// existing `HeartPathCaptureErrorSink` precedent.
+@Suite("LLMTelemetrySink.makeLive production adapter (#1525 PR I-C)")
+@MainActor
+struct LLMTelemetrySinkLiveTests {
+  private struct CapturedLimbFailure {
+    let limb: String
+    let operation: String
+    let result: String
+    let errorCategory: String
+    let durationMs: Int?
+  }
+
+  private struct CapturedHandledError {
+    let error: any Error
+    let category: SentryBreadcrumb.ErrorCategory
+    let stage: String
+    let extra: [String: Any]?
+    let fingerprintDetail: String?
+  }
+
+  /// Per-test, per-instance waiter — no process-global state. Both reporters fire
+  /// synchronously, back-to-back, inside the SAME `DispatchQueue.main.async` hop
+  /// (`limbFailureReporter` then `handledErrorReporter`), so awaiting the handled-error
+  /// reporter's arrival is sufficient: the limb-failure reporter has already run by then.
+  ///
+  /// Codex r5 finding: an unconditional `withCheckedContinuation` here would hang the
+  /// test forever if a future regression stopped the adapter invoking the reporter —
+  /// `awaitHandled` takes a bounded deadline instead (`swift-patterns.md`
+  /// `tests-no-unconditional-continuation-await`), throwing `TimeoutError` on expiry so
+  /// a broken wire fails fast with a clear signal instead of hanging the whole suite.
+  private final class ResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var limb: CapturedLimbFailure?
+    private var handled: CapturedHandledError?
+    private var continuation: CheckedContinuation<Void, any Error>?
+
+    func recordLimb(_ value: CapturedLimbFailure) {
+      lock.lock()
+      limb = value
+      lock.unlock()
+    }
+
+    func recordHandled(_ value: CapturedHandledError) {
+      lock.lock()
+      handled = value
+      let pending = continuation
+      continuation = nil
+      lock.unlock()
+      pending?.resume()
+    }
+
+    func snapshot() -> (CapturedLimbFailure?, CapturedHandledError?) {
+      lock.lock()
+      defer { lock.unlock() }
+      return (limb, handled)
+    }
+
+    /// Synchronous — called only from inside the continuation closures below, never
+    /// directly in an async body (`NSLock.lock`/`.unlock` are unavailable from
+    /// asynchronous contexts under strict concurrency checking). Returns whether the
+    /// continuation was armed (false means it was already resumed synchronously).
+    private func armWaiter(_ continuation: CheckedContinuation<Void, any Error>) -> Bool {
+      lock.lock()
+      if handled != nil {
+        lock.unlock()
+        continuation.resume()
+        return false
+      }
+      self.continuation = continuation
+      lock.unlock()
+      return true
+    }
+
+    private func timeoutWaiter(seconds: Double) {
+      lock.lock()
+      let pending = continuation
+      continuation = nil
+      lock.unlock()
+      pending?.resume(throwing: TimeoutError(seconds: seconds))
+    }
+
+    func awaitHandled(timeout: Duration = .seconds(5)) async throws {
+      let seconds =
+        Double(timeout.components.seconds) + Double(timeout.components.attoseconds) / 1e18
+      try await withCheckedThrowingContinuation { continuation in
+        guard armWaiter(continuation) else { return }
+        Task { [weak self] in
+          // deadline-fallback: fail fast if the handled-error reporter never fires
+          try? await Task.sleep(for: timeout)
+          self?.timeoutWaiter(seconds: seconds)
+        }
+      }
+    }
+  }
+
+  @Test(
+    "legacyKeyCleanupFailed reports both the population event and the handled error, with the real KeyStoreError identity"
+  )
+  func legacyKeyCleanupFailedReportsBothEffects() async throws {
+    let box = ResultBox()
+    let sink = LLMTelemetrySink.makeLive(
+      limbFailureReporter: { limb, operation, result, errorCategory, durationMs in
+        box.recordLimb(
+          CapturedLimbFailure(
+            limb: limb, operation: operation, result: result,
+            errorCategory: errorCategory, durationMs: durationMs))
+      },
+      handledErrorReporter: { error, category, stage, extra, fingerprintDetail in
+        box.recordHandled(
+          CapturedHandledError(
+            error: error, category: category, stage: stage, extra: extra,
+            fingerprintDetail: fingerprintDetail))
+      })
+
+    sink.legacyKeyCleanupFailed(KeyStoreError.deleteFailed(-1), "test-account")
+
+    try await box.awaitHandled()
+    let (limb, handled) = box.snapshot()
+
+    let limbFailure = try #require(limb)
+    #expect(limbFailure.limb == "keychain")
+    #expect(limbFailure.operation == "legacy_cleanup")
+    #expect(limbFailure.result == "failed")
+    #expect(limbFailure.errorCategory == "delete_failed")
+    #expect(limbFailure.durationMs == nil)
+
+    let handledError = try #require(handled)
+    #expect(handledError.category == .legacyKeyCleanupFailed)
+    #expect(handledError.stage == "keychain")
+    #expect(handledError.extra?["account"] as? String == "test-account")
+    #expect(handledError.fingerprintDetail == "test-account")
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      handledError.error, category: handledError.category, stage: handledError.stage,
+      extra: handledError.extra, fingerprintDetail: handledError.fingerprintDetail,
+      environment: "test")
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "legacy_key_cleanup_failed",
+          "EnviousWisprLLM.KeyStoreError#2", "test-account", "test",
+        ])
+    #expect(event.tags?["error.identity"] == "keystore.delete_failed")
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SentryAudioEnvironmentTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioEnvironmentTests.swift
@@ -6,10 +6,6 @@ import Testing
 @Suite("SentryBreadcrumb audio environment")
 @MainActor
 struct SentryAudioEnvironmentTests {
-  private struct DummyError: LocalizedError {
-    var errorDescription: String? { "dummy" }
-  }
-
   private final class ExtraBox: @unchecked Sendable {
     private let lock = NSLock()
     private var extra: [String: Any]?
@@ -41,7 +37,7 @@ struct SentryAudioEnvironmentTests {
       defer { SentryBreadcrumb.captureErrorDelegate = prior }
 
       SentryBreadcrumb.captureError(
-        DummyError(),
+        TestStableSentryError(),
         category: .audioCaptureFailed,
         stage: "audio",
         extra: ["caller": "kept"]
@@ -69,7 +65,7 @@ struct SentryAudioEnvironmentTests {
       defer { SentryBreadcrumb.captureErrorDelegate = prior }
 
       SentryBreadcrumb.captureError(
-        DummyError(),
+        TestStableSentryError(),
         category: .audioCaptureFailed,
         stage: "audio",
         extra: ["audio_environment": ["snapshot_status": "caller"]]
@@ -92,7 +88,7 @@ struct SentryAudioEnvironmentTests {
       defer { SentryBreadcrumb.captureErrorDelegate = prior }
 
       SentryBreadcrumb.captureError(
-        DummyError(),
+        TestStableSentryError(),
         category: .audioCaptureFailed,
         stage: "audio",
         extra: ["caller": "kept"]
@@ -116,7 +112,7 @@ struct SentryAudioEnvironmentTests {
       defer { SentryBreadcrumb.captureErrorDelegate = prior }
 
       SentryBreadcrumb.captureError(
-        DummyError(),
+        TestStableSentryError(),
         category: .audioCaptureFailed,
         stage: "audio",
         extra: ["caller": "kept"]
@@ -136,7 +132,8 @@ struct SentryAudioEnvironmentTests {
     SentryBreadcrumb.withAudioEnvironmentProvider({
       ["snapshot_status": "inner"]
     }) {
-      #expect(SentryBreadcrumb.audioEnvironmentProvider?()?["snapshot_status"] as? String == "inner")
+      #expect(
+        SentryBreadcrumb.audioEnvironmentProvider?()?["snapshot_status"] as? String == "inner")
     }
 
     #expect(SentryBreadcrumb.audioEnvironmentProvider?()?["snapshot_status"] as? String == "outer")

--- a/Tests/EnviousWisprTests/Support/TestStableSentryError.swift
+++ b/Tests/EnviousWisprTests/Support/TestStableSentryError.swift
@@ -1,0 +1,19 @@
+import EnviousWisprCore
+
+/// Shared conforming fixture for tests that need a generic, real `StableSentryErrorIdentity`
+/// value without asserting per-case semantics (#1525 PR I-C). Use a bespoke per-file fixture
+/// instead when a test specifically asserts override precedence, per-case identity, or
+/// underlying-error preservation — this fixture is for seams that only need "a conforming
+/// error", not "this specific error's identity."
+struct TestStableSentryError: Error, StableSentryErrorIdentity {
+  let sentryFingerprintDescriptor: String
+  let sentrySemanticID: String
+
+  init(
+    descriptor: String = "TestStableSentryError#0",
+    semanticID: String = "test.stable_sentry_error"
+  ) {
+    self.sentryFingerprintDescriptor = descriptor
+    self.sentrySemanticID = semanticID
+  }
+}


### PR DESCRIPTION
## Summary
- PR I-C of the #1525 Sentry stable-error-identity migration mini-ladder (I-A shipped, I-B in progress).
- Rolls out the shared `TestStableSentryError` conforming test fixture across recovery and audio-environment tests, replacing bespoke local `Error` structs (`DummyError`, `BoomError`, local `struct E`).
- Refactors `LLMTelemetrySink.live` into an injectable `makeLive(limbFailureReporter:handledErrorReporter:)` factory so a test can prove the real keychain-cleanup adapter emits both its population event and its handled-error capture with the correct stable identity, without a process-global mutable delegate.
- Locks `URLError`'s existing behavior with a real-path proof test: boxing `URLError` as `any Error` produces an `NSError` dynamic value, so a `StableSentryErrorIdentity` conformance would be unreachable through the detection pattern every Sentry capture site uses. The existing `NSError` fallback already produces the correct, stable descriptor, so no production code change was needed for `URLError` itself.

## Test plan
- [x] `scripts/xcode-test.sh` — 3149 tests, 0 failures, exit 0.
- [x] Local `codex review --base origin/main` — clean, no actionable defects.
- [x] `scripts/build-dev-app.sh` — build succeeded, dev app relaunched.
- [x] Live UAT: N — this PR's only production edit is the behavior-preserving refactor of the already-reachable `LLMTelemetrySink.legacyKeyCleanupFailed` adapter into an injectable factory; its existing main-queue hop and production reporters remain unchanged. `captureProviderInitError` is already conformant and live-verified under PR E (ENVIOUSWISPR-3X). The remaining edits are test-only fixture and proof work, while `HeartControlRecovery` remains production-inert and `URLError` receives no production change. No new user-observable behavior is introduced.

Part of #1525
