### PR TITLE
feat(observability): normalize AFM/WhisperKit/Parakeet/XPC raw errors (Part of #1525)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -94,11 +94,27 @@ let package = Package(
       ],
       path: "Sources/EnviousWisprServices"
     ),
+    // #1525 PR I-B: isolates FluidAudio's raw error-classification behind a
+    // small, internal-only target. `FluidAudio` exports a struct literally
+    // named `FluidAudio` that shadows module-qualified lookup, and a bare
+    // unqualified `ASRError` inside `EnviousWisprASR` silently resolves to the
+    // app's OWN `ASRError` type instead (`swift-patterns.md` RULE:
+    // fluidaudio-unqualified-symbols) — this target is the one place that
+    // safely names FluidAudio's error types. No library product: nothing
+    // outside this package needs to import it.
+    .target(
+      name: "EnviousWisprFluidAudioBridge",
+      dependencies: [
+        "FluidAudio"
+      ],
+      path: "Sources/EnviousWisprFluidAudioBridge"
+    ),
     .target(
       name: "EnviousWisprASR",
       dependencies: [
         "EnviousWisprCore",
         "EnviousWisprAudio",
+        "EnviousWisprFluidAudioBridge",
         .product(name: "WhisperKit", package: "argmax-oss-swift"),
         "FluidAudio",
       ],
@@ -205,6 +221,9 @@ let package = Package(
       dependencies: [
         "EnviousWisprCore",
         "EnviousWisprASR",
+        // #1525 PR I-B: the bridge classification tests import this directly,
+        // not transitively through EnviousWisprASR.
+        "EnviousWisprFluidAudioBridge",
         "FluidAudio",
       ],
       path: "Tests/EnviousWisprASRTests"

--- a/Package.swift
+++ b/Package.swift
@@ -209,6 +209,9 @@ let package = Package(
         "EnviousWisprPipeline",
         "EnviousWisprStorage",
         "EnviousWisprAudio",
+        // #1525 PR I-B (Codex cloud review): ParakeetTranscriptionSentryErrorTests /
+        // ParakeetModelLoadSentryErrorTests import this directly.
+        "EnviousWisprFluidAudioBridge",
         // #919: link the app-shell code from the library, NOT the app target,
         // so `swift test` / `xcodebuild test` never launch the app.
         "EnviousWisprAppKit",

--- a/Project.swift
+++ b/Project.swift
@@ -242,11 +242,22 @@ let project = Project(
         .package(product: "PostHog"),
         .package(product: "Sentry"),
       ]),
+    // #1525 PR I-B: isolates FluidAudio's raw error-classification behind a
+    // small, internal-only leaf. Consumed only by EnviousWisprASR and its
+    // test target, so it is declared explicitly there rather than added to
+    // the shared `firstPartyTargetDeps` engine set (same pattern as
+    // EnviousWisprContacts above).
+    firstPartyLibrary(
+      "EnviousWisprFluidAudioBridge",
+      dependencies: [
+        .package(product: "FluidAudio")
+      ]),
     firstPartyLibrary(
       "EnviousWisprASR",
       dependencies: [
         .target(name: "EnviousWisprCore"),
         .target(name: "EnviousWisprAudio"),
+        .target(name: "EnviousWisprFluidAudioBridge"),
         .package(product: "WhisperKit"),
         .package(product: "FluidAudio"),
       ]),
@@ -439,6 +450,9 @@ let project = Project(
       dependencies: [
         .target(name: "EnviousWisprCore"),
         .target(name: "EnviousWisprASR"),
+        // #1525 PR I-B: the bridge classification tests import this
+        // directly, not transitively through EnviousWisprASR.
+        .target(name: "EnviousWisprFluidAudioBridge"),
         .package(product: "WhisperKit"),
         // Static-link FluidAudio: the test bundle links EnviousWisprASR (a
         // static framework that uses FluidAudio), so its symbols must be

--- a/Project.swift
+++ b/Project.swift
@@ -434,6 +434,9 @@ let project = Project(
         // HelperObservabilityConfigTests imports the module directly; Xcode test
         // targets need every direct import as a declared edge (#1174).
         .target(name: "EnviousWisprObservabilityCore"),
+        // #1525 PR I-B (Codex cloud review): ParakeetTranscriptionSentryErrorTests /
+        // ParakeetModelLoadSentryErrorTests import this directly.
+        .target(name: "EnviousWisprFluidAudioBridge"),
         .package(product: "FluidAudio"),
         .package(product: "Sparkle"),
       ],

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -972,6 +972,18 @@ package enum XPCASRTransportError: LocalizedError, CustomNSError, Sendable, Equa
     }
   }
 
+  /// #1525 PR I-B (Codex cloud review): `CustomNSError`'s default `errorUserInfo`
+  /// is empty, and an empty `userInfo` does not survive the XPC boundary's
+  /// NSSecureCoding archive round-trip with `errorDescription` intact — the
+  /// receiving process's `(error as NSError).localizedDescription` falls back to
+  /// Foundation's generic "operation couldn't be completed" message. Populating
+  /// `NSLocalizedDescriptionKey` here bakes the description directly into
+  /// `userInfo`, which IS preserved through the round-trip (confirmed via a
+  /// direct `NSKeyedArchiver`/`NSKeyedUnarchiver` probe this session).
+  package var errorUserInfo: [String: Any] {
+    [NSLocalizedDescriptionKey: errorDescription ?? ""]
+  }
+
   /// Codex r2 finding #1: two EXISTING callers (`ParakeetEngineAdapter`'s
   /// stale-helper retry, `RecoverySpoolReplayer`'s recovery classification)
   /// type-check `is XPCASRTransportError` and assume it means "the XPC

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -219,7 +219,17 @@ public final class ASRManagerProxy: ASRManagerInterface {
           let cacheOnly = self.parakeetCacheOnly && self.activeBackendType == .parakeet
           proxy.loadModel(backendType: self.activeBackendType.rawValue, cacheOnly: cacheOnly) {
             nsError in
-            if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
+            // #1525 PR I-B: reconstruct the typed, conforming error from the
+            // surviving NSError domain/code before throwing to the adapter.
+            if let error = nsError {
+              let reconstructed: any Error =
+                ParakeetModelLoadSentryError(reconstructingFrom: error).map { $0 as any Error }
+                ?? XPCASRTransportError(reconstructingFrom: error).map { $0 as any Error }
+                ?? error
+              guard_.resume(throwing: reconstructed)
+            } else {
+              guard_.resume()
+            }
           }
         } onProxyError: {
           // #1348: force a helper recycle so the next attempt reconnects to
@@ -393,8 +403,19 @@ public final class ASRManagerProxy: ASRManagerInterface {
     }
     let data = audioSamples.withUnsafeBytes { Data($0) }
     let language = options.language ?? ""
-    let speechSegmentsData =
-      options.speechSegments.isEmpty ? nil : try JSONEncoder().encode(options.speechSegments)
+    let speechSegmentsData: Data?
+    if options.speechSegments.isEmpty {
+      speechSegmentsData = nil
+    } else {
+      do {
+        speechSegmentsData = try JSONEncoder().encode(options.speechSegments)
+      } catch {
+        // #1525 PR I-B: a request-encoding failure never reaches the service
+        // at all — pin its own identity rather than bridging via the raw
+        // JSONEncoder error's ordinal-derived NSError.
+        throw XPCASRTransportError.requestEncodingFailed(error.localizedDescription)
+      }
+    }
 
     let (resultData, error): (Data?, NSError?) = try await withCheckedThrowingContinuation {
       (cont: CheckedContinuation<(Data?, NSError?), any Error>) in
@@ -413,14 +434,25 @@ public final class ASRManagerProxy: ASRManagerInterface {
     }
 
     if let error {
-      throw error
+      // #1525 PR I-B: reconstruct the typed, conforming error from the
+      // surviving NSError domain/code before throwing to the adapter.
+      let reconstructed: any Error =
+        ParakeetTranscriptionSentryError(reconstructingFrom: error).map { $0 as any Error }
+        ?? XPCASRTransportError(reconstructingFrom: error).map { $0 as any Error }
+        ?? error
+      throw reconstructed
     }
-    guard let resultData,
-      let result = try? PropertyListDecoder().decode(ASRResult.self, from: resultData)
-    else {
-      throw ASRError.transcriptionFailed("Failed to decode ASR result from XPC service")
+    guard let resultData else {
+      throw XPCASRTransportError.responseDecodingFailed("XPC ASR service returned no result data.")
     }
-    return result
+    do {
+      return try PropertyListDecoder().decode(ASRResult.self, from: resultData)
+    } catch {
+      // #1525 PR I-B (§3.3c): a response-CODEC failure, not "the ASR backend
+      // failed to transcribe" — belongs on the transport authority, not
+      // ASRError.transcriptionFailed's bridged group.
+      throw XPCASRTransportError.responseDecodingFailed(error.localizedDescription)
+    }
   }
 
   // MARK: - ASRManagerInterface: Streaming
@@ -450,7 +482,16 @@ public final class ASRManagerProxy: ASRManagerInterface {
           language: language,
           enableTimestamps: enableTimestamps
         ) { nsError in
-          if let error = nsError { guard_.resume(throwing: error) } else { guard_.resume() }
+          // #1525 PR I-B (Codex cloud review): reconstruct the typed,
+          // conforming error before throwing to the adapter, matching
+          // loadModel/transcribe/finalizeStreaming's reconstruction.
+          if let error = nsError {
+            let reconstructed: any Error =
+              XPCASRTransportError(reconstructingFrom: error).map { $0 as any Error } ?? error
+            guard_.resume(throwing: reconstructed)
+          } else {
+            guard_.resume()
+          }
         }
       } onProxyError: {
         guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
@@ -486,14 +527,25 @@ public final class ASRManagerProxy: ASRManagerInterface {
     isStreaming = false
 
     if let error {
-      throw error
+      // #1525 PR I-B: reconstruct the typed, conforming error from the
+      // surviving NSError domain/code before throwing to the adapter.
+      let reconstructed: any Error =
+        ParakeetTranscriptionSentryError(reconstructingFrom: error).map { $0 as any Error }
+        ?? XPCASRTransportError(reconstructingFrom: error).map { $0 as any Error }
+        ?? error
+      throw reconstructed
     }
-    guard let resultData,
-      let result = try? PropertyListDecoder().decode(ASRResult.self, from: resultData)
-    else {
-      throw ASRError.transcriptionFailed("Failed to decode ASR result from XPC service")
+    guard let resultData else {
+      throw XPCASRTransportError.responseDecodingFailed("XPC ASR service returned no result data.")
     }
-    return result
+    do {
+      return try PropertyListDecoder().decode(ASRResult.self, from: resultData)
+    } catch {
+      // #1525 PR I-B (§3.3c): a response-CODEC failure, not "the ASR backend
+      // failed to transcribe" — belongs on the transport authority, not
+      // ASRError.transcriptionFailed's bridged group.
+      throw XPCASRTransportError.responseDecodingFailed(error.localizedDescription)
+    }
   }
 
   public func cancelStreaming() async {
@@ -862,31 +914,127 @@ extension OneShotContinuationASR where T == Void {
 // `package` (#1348 Phase 2): ParakeetEngineAdapter's one-shot stale-helper
 // retry matches on this type — narrowest visibility that crosses the module
 // (architecture-rules minimize-visibility).
-package enum XPCASRTransportError: LocalizedError {
+//
+// #1525 PR I-B: widened from the single `.serviceUnreachable` case to cover
+// every XPC/codec transport failure — a physically different failure class
+// from "the ASR backend itself failed to transcribe" (which belongs on
+// `ParakeetTranscriptionSentryError`/`ParakeetModelLoadSentryError` instead).
+// `CustomNSError` conforms because some of these cases originate service-side
+// and must survive the XPC round-trip, unlike `.serviceUnreachable` (purely
+// client-local, never crosses XPC).
+package enum XPCASRTransportError: LocalizedError, CustomNSError, Sendable, Equatable {
   case serviceUnreachable
+  /// `ASRManagerProxy`'s client-side `speechSegments` JSONEncoder failure —
+  /// never crosses XPC (fails before the send).
+  case requestEncodingFailed(String)
+  /// Service's "Data size mismatch" early guard (was a raw `NSError(domain:
+  /// "ASRService", code: -2, ...)`).
+  case invalidSamplePayload(String)
+  /// Service's JSONDecoder failure decoding the incoming request.
+  case requestDecodingFailed(String)
+  /// Service's "No model loaded" early guard (was a raw `NSError(domain:
+  /// "ASRService", code: -3, ...)`). LIVE: ENVIOUSWISPR-3S.
+  case modelNotLoaded
+  /// Service's PropertyListEncoder failure encoding the outgoing response.
+  case responseEncodingFailed(String)
+  /// Client's XPC result-decode failure (§3.3c) — never crosses XPC itself;
+  /// the decode happens AFTER the XPC round-trip completes.
+  case responseDecodingFailed(String)
+
+  package static let errorDomain = "EnviousWisprASR.XPCASRTransportError"
+
+  /// Wire-level NSError/XPC-bridge identity only — does NOT control Sentry
+  /// grouping (`sentryFingerprintDescriptor` below is the sole authority for
+  /// that). `.serviceUnreachable` keeps its already-pinned `0`;
+  /// `.invalidSamplePayload`/`.modelNotLoaded` keep the exact codes their
+  /// predecessor raw NSErrors used, for wire-level continuity.
+  package var errorCode: Int {
+    switch self {
+    case .serviceUnreachable: return 0
+    case .requestEncodingFailed: return 1
+    case .invalidSamplePayload: return -2
+    case .requestDecodingFailed: return 2
+    case .modelNotLoaded: return -3
+    case .responseEncodingFailed: return 3
+    case .responseDecodingFailed: return 4
+    }
+  }
 
   package var errorDescription: String? {
     switch self {
     case .serviceUnreachable: return "XPC ASR service is unreachable."
+    case .requestEncodingFailed(let d): return d
+    case .invalidSamplePayload(let d): return d
+    case .requestDecodingFailed(let d): return d
+    case .modelNotLoaded: return "No model loaded."
+    case .responseEncodingFailed(let d): return d
+    case .responseDecodingFailed(let d): return d
+    }
+  }
+
+  /// Codex r2 finding #1: two EXISTING callers (`ParakeetEngineAdapter`'s
+  /// stale-helper retry, `RecoverySpoolReplayer`'s recovery classification)
+  /// type-check `is XPCASRTransportError` and assume it means "the XPC
+  /// service is unreachable" — widening this enum with 6 new codec/transport
+  /// cases silently breaks that assumption. Both narrow to this instead.
+  package var isServiceUnreachable: Bool {
+    if case .serviceUnreachable = self { return true }
+    return false
+  }
+
+  /// Reconstructs the typed, conforming error from an NSError that survived
+  /// the XPC round-trip. Returns `nil` if the domain doesn't match.
+  package init?(reconstructingFrom error: NSError) {
+    guard error.domain == Self.errorDomain else { return nil }
+    let d = error.localizedDescription
+    switch error.code {
+    case 0: self = .serviceUnreachable
+    case 1: self = .requestEncodingFailed(d)
+    case -2: self = .invalidSamplePayload(d)
+    case 2: self = .requestDecodingFailed(d)
+    case -3: self = .modelNotLoaded
+    case 3: self = .responseEncodingFailed(d)
+    case 4: self = .responseDecodingFailed(d)
+    default: return nil
     }
   }
 }
 
-/// #1525 PR G. Pins the single case's exact measured current wire identity
-/// (`docs/audits/2026-07-14-1525-pr-g-preflight.md` §1). `package` matches
-/// this type's own package visibility (mirrors `KeyStoreError`'s PR-F
-/// pattern — a bare `var` would default to `internal` and fail to compile
-/// against a `package` enclosing type). NEVER change this string once shipped.
+/// #1525 PR G/PR I-B. Pins each case's exact wire identity.
+/// `.serviceUnreachable`'s string is measured
+/// (`docs/audits/2026-07-14-1525-pr-g-preflight.md` §1); `.modelNotLoaded`'s
+/// is measured live (§3.5: ENVIOUSWISPR-3S, `"ASRService#-3"` — MUST NOT
+/// change). `package` matches this type's own package visibility (mirrors
+/// `KeyStoreError`'s PR-F pattern — a bare `var` would default to `internal`
+/// and fail to compile against a `package` enclosing type). NEVER change
+/// these strings once shipped.
 extension XPCASRTransportError: StableSentryErrorIdentity {
   package var sentryFingerprintDescriptor: String {
     switch self {
     case .serviceUnreachable: return "EnviousWisprASR.XPCASRTransportError#0"
+    case .requestEncodingFailed: return "EnviousWisprASR.XPCASRTransportError#1"
+    // No live history found for "ASRService#-2" — safe to pin defensively.
+    case .invalidSamplePayload: return "ASRService#-2"
+    case .requestDecodingFailed: return "EnviousWisprASR.XPCASRTransportError#2"
+    // LIVE: ENVIOUSWISPR-3S, 1u/1e, production — must not change.
+    case .modelNotLoaded: return "ASRService#-3"
+    case .responseEncodingFailed: return "EnviousWisprASR.XPCASRTransportError#3"
+    // §3.3c: a genuine grouping SPLIT out of ASRError.transcriptionFailed's
+    // bridged group — no live measurement run against this specific
+    // descriptor yet (§3.5's "remaining work"), so this is a fresh pin.
+    case .responseDecodingFailed: return "EnviousWisprASR.XPCASRTransportError#4"
     }
   }
 
   package var sentrySemanticID: String {
     switch self {
     case .serviceUnreachable: return "xpc.asr_service_unreachable"
+    case .requestEncodingFailed: return "xpc.request_encoding_failed"
+    case .invalidSamplePayload: return "xpc.invalid_sample_payload"
+    case .requestDecodingFailed: return "xpc.request_decoding_failed"
+    case .modelNotLoaded: return "xpc.model_not_loaded"
+    case .responseEncodingFailed: return "xpc.response_encoding_failed"
+    case .responseDecodingFailed: return "xpc.response_decoding_failed"
     }
   }
 }

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -1,5 +1,6 @@
 @preconcurrency import AVFoundation
 import EnviousWisprCore
+import EnviousWisprFluidAudioBridge
 @preconcurrency import FluidAudio
 
 // Disambiguate from FluidAudio.ASRResult — we always mean our own type.
@@ -105,21 +106,32 @@ public actor ParakeetBackend: ASRBackend {
     }
 
     Self.configureOfflineMode(cacheOnly: cacheOnly)
-    let loadedModels: AsrModels
-    if cacheOnly {
-      // Delivery-managed: the default cache was admitted by the host's hash
-      // gate before this call; enforceOffline (armed above) turns any gap
-      // into a typed throw the host maps to its repair path.
-      loadedModels = try await AsrModels.loadFromCache(version: .v3, progressHandler: handler)
-    } else {
-      loadedModels = try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
-    }
-    self.fluidModels = loadedModels
+    do {
+      let loadedModels: AsrModels
+      if cacheOnly {
+        // Delivery-managed: the default cache was admitted by the host's hash
+        // gate before this call; enforceOffline (armed above) turns any gap
+        // into a typed throw the host maps to its repair path.
+        loadedModels = try await AsrModels.loadFromCache(version: .v3, progressHandler: handler)
+      } else {
+        loadedModels = try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
+      }
+      self.fluidModels = loadedModels
 
-    let manager = AsrManager(config: .default)
-    // v0.15.4 API: initialize(models:) became loadModels(_:).
-    try await manager.loadModels(loadedModels)
-    self.fluidAsrManager = manager
+      let manager = AsrManager(config: .default)
+      // v0.15.4 API: initialize(models:) became loadModels(_:).
+      try await manager.loadModels(loadedModels)
+      self.fluidAsrManager = manager
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      // #1525 PR I-B: unlike `transcribe`'s catch below, a non-recognized error
+      // here does NOT stay raw — model loading's own genuinely-non-vendor
+      // errors (a plain CocoaError/CoreML error from inside AsrModels'
+      // own loading calls) are still model-load failures, not a different
+      // physical class, so they normalize to `.unknownLoadFailure` too.
+      throw ParakeetModelLoadSentryError(normalizingLoadError: error)
+    }
 
     isReady = true
   }
@@ -135,17 +147,31 @@ public actor ParakeetBackend: ASRBackend {
     // `source:` parameter is gone. Language hint intentionally NOT passed in PR-2
     // (parity with the d5fcca4 behavior); G7 language propagation ships in PR-4.
     var decoderState = TdtDecoderState.make(decoderLayers: await manager.decoderLayerCount)
-    let fluidResult = try await manager.transcribe(audioSamples, decoderState: &decoderState)
-    let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+    do {
+      let fluidResult = try await manager.transcribe(audioSamples, decoderState: &decoderState)
+      let elapsed = CFAbsoluteTimeGetCurrent() - startTime
 
-    return ASRResult(
-      text: fluidResult.text,
-      language: "en",
-      duration: fluidResult.duration,
-      processingTime: elapsed,
-      backendType: .parakeet,
-      tokenTimingSummary: Self.tokenTimingSummary(from: fluidResult.tokenTimings)
-    )
+      return ASRResult(
+        text: fluidResult.text,
+        language: "en",
+        duration: fluidResult.duration,
+        processingTime: elapsed,
+        backendType: .parakeet,
+        tokenTimingSummary: Self.tokenTimingSummary(from: fluidResult.tokenTimings)
+      )
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      // #1525 PR I-B: pin a stable identity for a recognized FluidAudio error;
+      // a non-FluidAudio error (e.g. a raw CoreML failure) stays raw and
+      // unchanged, still bridging via today's default NSError path — it is a
+      // different physical failure class this PR does not touch (§3.5:
+      // com.apple.CoreML#0, confirmed live and unaffected).
+      if let kind = classifyFluidAudioASRError(error) {
+        throw ParakeetTranscriptionSentryError(mapping: kind)
+      }
+      throw error
+    }
   }
 
   /// Numbers-only summary of FluidAudio token timings for tail-clip diagnostics (#1232).

--- a/Sources/EnviousWisprASR/ParakeetModelLoadSentryError.swift
+++ b/Sources/EnviousWisprASR/ParakeetModelLoadSentryError.swift
@@ -49,6 +49,18 @@ enum ParakeetModelLoadSentryError: Error, LocalizedError, CustomNSError, Sendabl
     }
   }
 
+  /// #1525 PR I-B (Codex cloud review): `CustomNSError`'s default `errorUserInfo`
+  /// is empty, and an empty `userInfo` does not survive the XPC boundary's
+  /// NSSecureCoding archive round-trip with `errorDescription` intact — the
+  /// receiving process's `(error as NSError).localizedDescription` falls back to
+  /// Foundation's generic "operation couldn't be completed" message. Populating
+  /// `NSLocalizedDescriptionKey` here bakes the description directly into
+  /// `userInfo`, which IS preserved through the round-trip (confirmed via a
+  /// direct `NSKeyedArchiver`/`NSKeyedUnarchiver` probe this session).
+  var errorUserInfo: [String: Any] {
+    [NSLocalizedDescriptionKey: errorDescription ?? ""]
+  }
+
   init(mapping kind: FluidAudioModelLoadErrorKind) {
     switch kind {
     case .modelsModelNotFound(let d): self = .modelsModelNotFound(d)

--- a/Sources/EnviousWisprASR/ParakeetModelLoadSentryError.swift
+++ b/Sources/EnviousWisprASR/ParakeetModelLoadSentryError.swift
@@ -1,0 +1,142 @@
+import EnviousWisprCore
+import EnviousWisprFluidAudioBridge
+import Foundation
+
+/// #1525 PR I-B: pinned Sentry identity for a raw throw out of `ParakeetBackend
+/// .prepare`'s 3 FluidAudio model-load calls. Separate from `ParakeetTranscriptionSentryError`
+/// — different physical failure class and Sentry category, same reasoning WhisperKit
+/// load/decode stay separate from Parakeet transcription.
+enum ParakeetModelLoadSentryError: Error, LocalizedError, CustomNSError, Sendable, Equatable {
+  case modelsModelNotFound(String)
+  case modelsDownloadFailed(String)
+  case modelsLoadingFailed(String)
+  case modelsCompilationFailed(String)
+  case offlineNetworkDisabled(String)
+  case offlineModelMissing(String)
+  case hfInvalidResponse(String)
+  case hfRateLimited(String)
+  case hfDownloadFailed(String)
+  case hfModelNotFound(String)
+  case hfHtmlErrorResponse(String)
+  case unknownLoadFailure(String)
+
+  static let errorDomain = "EnviousWisprASR.ParakeetModelLoadSentryError"
+
+  var errorCode: Int {
+    switch self {
+    case .modelsModelNotFound: return 0
+    case .modelsDownloadFailed: return 1
+    case .modelsLoadingFailed: return 2
+    case .modelsCompilationFailed: return 3
+    case .offlineNetworkDisabled: return 4
+    case .offlineModelMissing: return 5
+    case .hfInvalidResponse: return 6
+    case .hfRateLimited: return 7
+    case .hfDownloadFailed: return 8
+    case .hfModelNotFound: return 9
+    case .hfHtmlErrorResponse: return 10
+    case .unknownLoadFailure: return 11
+    }
+  }
+
+  var errorDescription: String? {
+    switch self {
+    case .modelsModelNotFound(let d), .modelsDownloadFailed(let d), .modelsLoadingFailed(let d),
+      .modelsCompilationFailed(let d), .offlineNetworkDisabled(let d), .offlineModelMissing(let d),
+      .hfInvalidResponse(let d), .hfRateLimited(let d), .hfDownloadFailed(let d),
+      .hfModelNotFound(let d), .hfHtmlErrorResponse(let d), .unknownLoadFailure(let d):
+      return d
+    }
+  }
+
+  init(mapping kind: FluidAudioModelLoadErrorKind) {
+    switch kind {
+    case .modelsModelNotFound(let d): self = .modelsModelNotFound(d)
+    case .modelsDownloadFailed(let d): self = .modelsDownloadFailed(d)
+    case .modelsLoadingFailed(let d): self = .modelsLoadingFailed(d)
+    case .modelsCompilationFailed(let d): self = .modelsCompilationFailed(d)
+    case .offlineNetworkDisabled(let d): self = .offlineNetworkDisabled(d)
+    case .offlineModelMissing(let d): self = .offlineModelMissing(d)
+    case .hfInvalidResponse(let d): self = .hfInvalidResponse(d)
+    case .hfRateLimited(let d): self = .hfRateLimited(d)
+    case .hfDownloadFailed(let d): self = .hfDownloadFailed(d)
+    case .hfModelNotFound(let d): self = .hfModelNotFound(d)
+    case .hfHtmlErrorResponse(let d): self = .hfHtmlErrorResponse(d)
+    case .unknownLoadFailure(let d): self = .unknownLoadFailure(d)
+    }
+  }
+
+  /// The production catch site's actual normalization logic, extracted so it is
+  /// directly testable — `ParakeetBackend` has no test-injection seam for model
+  /// loading, so a test "recreating the same catch pattern" would test copied test
+  /// code, not production.
+  init(normalizingLoadError error: any Error) {
+    if let kind = classifyFluidAudioModelLoadError(error) {
+      self.init(mapping: kind)
+    } else {
+      self = .unknownLoadFailure(error.localizedDescription)
+    }
+  }
+
+  /// Reconstructs the typed, conforming error from an NSError that survived the XPC
+  /// round-trip. Returns `nil` if the domain doesn't match.
+  init?(reconstructingFrom error: NSError) {
+    guard error.domain == Self.errorDomain else { return nil }
+    let d = error.localizedDescription
+    switch error.code {
+    case 0: self = .modelsModelNotFound(d)
+    case 1: self = .modelsDownloadFailed(d)
+    case 2: self = .modelsLoadingFailed(d)
+    case 3: self = .modelsCompilationFailed(d)
+    case 4: self = .offlineNetworkDisabled(d)
+    case 5: self = .offlineModelMissing(d)
+    case 6: self = .hfInvalidResponse(d)
+    case 7: self = .hfRateLimited(d)
+    case 8: self = .hfDownloadFailed(d)
+    case 9: self = .hfModelNotFound(d)
+    case 10: self = .hfHtmlErrorResponse(d)
+    case 11: self = .unknownLoadFailure(d)
+    default: return nil
+    }
+  }
+}
+
+extension ParakeetModelLoadSentryError: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String {
+    // No live Sentry measurement has been run against these case-level descriptors
+    // yet (§3.5's "remaining work" — never distinctly constructed before this PR).
+    // Every case below is a fresh, defensive pin.
+    switch self {
+    case .modelsModelNotFound: return "FluidAudio.AsrModelsError#0"
+    case .modelsDownloadFailed: return "FluidAudio.AsrModelsError#1"
+    case .modelsLoadingFailed: return "FluidAudio.AsrModelsError#2"
+    case .modelsCompilationFailed: return "FluidAudio.AsrModelsError#3"
+    case .offlineNetworkDisabled: return "FluidAudio.DownloadUtils.OfflineError#0"
+    case .offlineModelMissing: return "FluidAudio.DownloadUtils.OfflineError#1"
+    case .hfInvalidResponse: return "FluidAudio.DownloadUtils.HuggingFaceDownloadError#0"
+    case .hfRateLimited: return "FluidAudio.DownloadUtils.HuggingFaceDownloadError#1"
+    case .hfDownloadFailed: return "FluidAudio.DownloadUtils.HuggingFaceDownloadError#2"
+    case .hfModelNotFound: return "FluidAudio.DownloadUtils.HuggingFaceDownloadError#3"
+    case .hfHtmlErrorResponse: return "FluidAudio.DownloadUtils.HuggingFaceDownloadError#4"
+    case .unknownLoadFailure:
+      return "EnviousWisprASR.ParakeetModelLoadSentryError.unknownLoadFailure"
+    }
+  }
+
+  var sentrySemanticID: String {
+    switch self {
+    case .modelsModelNotFound: return "parakeet_load.models_model_not_found"
+    case .modelsDownloadFailed: return "parakeet_load.models_download_failed"
+    case .modelsLoadingFailed: return "parakeet_load.models_loading_failed"
+    case .modelsCompilationFailed: return "parakeet_load.models_compilation_failed"
+    case .offlineNetworkDisabled: return "parakeet_load.offline_network_disabled"
+    case .offlineModelMissing: return "parakeet_load.offline_model_missing"
+    case .hfInvalidResponse: return "parakeet_load.hf_invalid_response"
+    case .hfRateLimited: return "parakeet_load.hf_rate_limited"
+    case .hfDownloadFailed: return "parakeet_load.hf_download_failed"
+    case .hfModelNotFound: return "parakeet_load.hf_model_not_found"
+    case .hfHtmlErrorResponse: return "parakeet_load.hf_html_error_response"
+    case .unknownLoadFailure: return "parakeet_load.unknown_load_failure"
+    }
+  }
+}

--- a/Sources/EnviousWisprASR/ParakeetTranscriptionSentryError.swift
+++ b/Sources/EnviousWisprASR/ParakeetTranscriptionSentryError.swift
@@ -1,0 +1,114 @@
+import EnviousWisprCore
+import EnviousWisprFluidAudioBridge
+import Foundation
+
+/// #1525 PR I-B: pinned Sentry identity for FluidAudio's raw `ASRError` (transcription
+/// path), built from `FluidAudioASRErrorKind` — never from `FluidAudio.ASRError` directly
+/// (see `EnviousWisprFluidAudioBridge`'s naming-trap doc comment). `CustomNSError`
+/// conforms so the app-owned domain/code automatically applies the moment anything
+/// downstream does `error as NSError` (exactly what `XPCErrorSanitizer.sanitizeForXPC`
+/// already does) — no manual bridging call needed.
+enum ParakeetTranscriptionSentryError: Error, LocalizedError, CustomNSError, Sendable, Equatable {
+  case notInitialized(String)
+  case invalidAudioData(String)
+  case modelLoadFailed(String)
+  case processingFailed(String)
+  case modelCompilationFailed(String)
+  case unsupportedPlatform(String)
+  case streamingConversionFailed(String)
+  case fileAccessFailed(String)
+  case unknownTranscriptionFailure(String)
+
+  static let errorDomain = "EnviousWisprASR.ParakeetTranscriptionSentryError"
+
+  var errorCode: Int {
+    switch self {
+    case .notInitialized: return 0
+    case .invalidAudioData: return 1
+    case .modelLoadFailed: return 2
+    case .processingFailed: return 3
+    case .modelCompilationFailed: return 4
+    case .unsupportedPlatform: return 5
+    case .streamingConversionFailed: return 6
+    case .fileAccessFailed: return 7
+    case .unknownTranscriptionFailure: return 8
+    }
+  }
+
+  var errorDescription: String? {
+    switch self {
+    case .notInitialized(let d), .invalidAudioData(let d), .modelLoadFailed(let d),
+      .processingFailed(let d), .modelCompilationFailed(let d), .unsupportedPlatform(let d),
+      .streamingConversionFailed(let d), .fileAccessFailed(let d),
+      .unknownTranscriptionFailure(let d):
+      return d
+    }
+  }
+
+  init(mapping kind: FluidAudioASRErrorKind) {
+    switch kind {
+    case .notInitialized(let d): self = .notInitialized(d)
+    case .invalidAudioData(let d): self = .invalidAudioData(d)
+    case .modelLoadFailed(let d): self = .modelLoadFailed(d)
+    case .processingFailed(let d): self = .processingFailed(d)
+    case .modelCompilationFailed(let d): self = .modelCompilationFailed(d)
+    case .unsupportedPlatform(let d): self = .unsupportedPlatform(d)
+    case .streamingConversionFailed(let d): self = .streamingConversionFailed(d)
+    case .fileAccessFailed(let d): self = .fileAccessFailed(d)
+    case .unknownFutureCase(let d): self = .unknownTranscriptionFailure(d)
+    }
+  }
+
+  /// Reconstructs the typed, conforming error from an NSError that survived the XPC
+  /// round-trip (domain/code preserved by `XPCErrorSanitizer.sanitizeForXPC`). Returns
+  /// `nil` if the domain doesn't match — a genuinely unrelated XPC-layer error.
+  init?(reconstructingFrom error: NSError) {
+    guard error.domain == Self.errorDomain else { return nil }
+    let d = error.localizedDescription
+    switch error.code {
+    case 0: self = .notInitialized(d)
+    case 1: self = .invalidAudioData(d)
+    case 2: self = .modelLoadFailed(d)
+    case 3: self = .processingFailed(d)
+    case 4: self = .modelCompilationFailed(d)
+    case 5: self = .unsupportedPlatform(d)
+    case 6: self = .streamingConversionFailed(d)
+    case 7: self = .fileAccessFailed(d)
+    case 8: self = .unknownTranscriptionFailure(d)
+    default: return nil
+    }
+  }
+}
+
+extension ParakeetTranscriptionSentryError: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String {
+    // No live Sentry history found for a "FluidAudio.ASRError"-identified descriptor
+    // in a 90-day search — every case below is a defensive pin.
+    switch self {
+    case .notInitialized: return "FluidAudio.ASRError#0"
+    case .invalidAudioData: return "FluidAudio.ASRError#1"
+    case .modelLoadFailed: return "FluidAudio.ASRError#2"
+    case .processingFailed: return "FluidAudio.ASRError#3"
+    case .modelCompilationFailed: return "FluidAudio.ASRError#4"
+    case .unsupportedPlatform: return "FluidAudio.ASRError#5"
+    case .streamingConversionFailed: return "FluidAudio.ASRError#6"
+    case .fileAccessFailed: return "FluidAudio.ASRError#7"
+    case .unknownTranscriptionFailure:
+      return "EnviousWisprASR.ParakeetTranscriptionSentryError.unknownTranscriptionFailure"
+    }
+  }
+
+  var sentrySemanticID: String {
+    switch self {
+    case .notInitialized: return "parakeet_transcribe.not_initialized"
+    case .invalidAudioData: return "parakeet_transcribe.invalid_audio_data"
+    case .modelLoadFailed: return "parakeet_transcribe.model_load_failed"
+    case .processingFailed: return "parakeet_transcribe.processing_failed"
+    case .modelCompilationFailed: return "parakeet_transcribe.model_compilation_failed"
+    case .unsupportedPlatform: return "parakeet_transcribe.unsupported_platform"
+    case .streamingConversionFailed: return "parakeet_transcribe.streaming_conversion_failed"
+    case .fileAccessFailed: return "parakeet_transcribe.file_access_failed"
+    case .unknownTranscriptionFailure: return "parakeet_transcribe.unknown_transcription_failure"
+    }
+  }
+}

--- a/Sources/EnviousWisprASR/ParakeetTranscriptionSentryError.swift
+++ b/Sources/EnviousWisprASR/ParakeetTranscriptionSentryError.swift
@@ -45,6 +45,18 @@ enum ParakeetTranscriptionSentryError: Error, LocalizedError, CustomNSError, Sen
     }
   }
 
+  /// #1525 PR I-B (Codex cloud review): `CustomNSError`'s default `errorUserInfo`
+  /// is empty, and an empty `userInfo` does not survive the XPC boundary's
+  /// NSSecureCoding archive round-trip with `errorDescription` intact — the
+  /// receiving process's `(error as NSError).localizedDescription` falls back to
+  /// Foundation's generic "operation couldn't be completed" message. Populating
+  /// `NSLocalizedDescriptionKey` here bakes the description directly into
+  /// `userInfo`, which IS preserved through the round-trip (confirmed via a
+  /// direct `NSKeyedArchiver`/`NSKeyedUnarchiver` probe this session).
+  var errorUserInfo: [String: Any] {
+    [NSLocalizedDescriptionKey: errorDescription ?? ""]
+  }
+
   init(mapping kind: FluidAudioASRErrorKind) {
     switch kind {
     case .notInitialized(let d): self = .notInitialized(d)

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -393,7 +393,16 @@ public actor WhisperKitBackend: ASRBackend {
     // deferred for lack of a defended-timeout distribution — NOT for lack of
     // timing data. Do NOT wrap this in a wall-clock timeout
     // (timeout-numbers-need-distribution-evidence).
-    let kit = try await WhisperKit(config)
+    let kit: WhisperKit
+    do {
+      kit = try await WhisperKit(config)
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      // #1525 PR I-B: pin a stable Sentry identity for this raw throw instead
+      // of bridging via Swift's ordinal-derived NSError.
+      throw WhisperKitModelLoadSentryError(normalizingLoadError: error)
+    }
     // #1386: prove what tokenizer WhisperKit actually resolved to, not merely
     // what was requested — the same disk-based discriminator the bundled-
     // tokenizer regression test uses (WhisperTokenizerBundleTests.swift). A

--- a/Sources/EnviousWisprASR/WhisperKitModelLoadSentryError.swift
+++ b/Sources/EnviousWisprASR/WhisperKitModelLoadSentryError.swift
@@ -1,0 +1,108 @@
+import EnviousWisprCore
+import Foundation
+import WhisperKit
+
+/// #1525 PR I-B: pinned Sentry identity for a raw throw out of `WhisperKitBackend
+/// .performLoad`'s `WhisperKit(config)` call. Deliberately NOT an extension of
+/// `EnviousWisprASR.ASRError` — WhisperKit's own `WhisperError` is an 11-case,
+/// `@frozen` taxonomy distinct from the app-level `ASRError`, and `.transcriptionFailed`
+/// already has a permanently pinned identity for the DECODE path (a different failure
+/// class from model LOADING).
+///
+/// Mirrors `WhisperError`'s 11 cases plus `.unknownLoadFailure` for any non-`WhisperError`
+/// throw from the init (e.g. a CoreML/filesystem error). Every case carries the original
+/// error's description as an associated `String`.
+enum WhisperKitModelLoadSentryError: Error, LocalizedError, Sendable, Equatable {
+  case tokenizerUnavailable(String)
+  case modelsUnavailable(String)
+  case audioProcessingFailed(String)
+  case decodingLogitsFailed(String)
+  case segmentingFailed(String)
+  case loadAudioFailed(String)
+  case prepareDecoderInputsFailed(String)
+  case transcriptionFailed(String)
+  case decodingFailed(String)
+  case microphoneUnavailable(String)
+  case initializationError(String)
+  case unknownLoadFailure(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .tokenizerUnavailable(let d), .modelsUnavailable(let d), .audioProcessingFailed(let d),
+      .decodingLogitsFailed(let d), .segmentingFailed(let d), .loadAudioFailed(let d),
+      .prepareDecoderInputsFailed(let d), .transcriptionFailed(let d), .decodingFailed(let d),
+      .microphoneUnavailable(let d), .initializationError(let d), .unknownLoadFailure(let d):
+      return d
+    }
+  }
+
+  init(mapping error: WhisperError) {
+    // WhisperError's own errorDescription logs each message as a side effect
+    // (WhisperError.swift); localizedDescription route avoids double-logging.
+    let d = error.localizedDescription
+    switch error {
+    case .tokenizerUnavailable: self = .tokenizerUnavailable(d)
+    case .modelsUnavailable: self = .modelsUnavailable(d)
+    case .audioProcessingFailed: self = .audioProcessingFailed(d)
+    case .decodingLogitsFailed: self = .decodingLogitsFailed(d)
+    case .segmentingFailed: self = .segmentingFailed(d)
+    case .loadAudioFailed: self = .loadAudioFailed(d)
+    case .prepareDecoderInputsFailed: self = .prepareDecoderInputsFailed(d)
+    case .transcriptionFailed: self = .transcriptionFailed(d)
+    case .decodingFailed: self = .decodingFailed(d)
+    case .microphoneUnavailable: self = .microphoneUnavailable(d)
+    case .initializationError: self = .initializationError(d)
+    }
+  }
+
+  /// The production catch site's actual normalization logic, extracted so it is
+  /// directly testable — `performLoad`'s `testSeams` early return makes the real
+  /// catch unreachable from a unit test, so a test that "recreated the same catch
+  /// pattern" inline would exercise copied test code, not production.
+  init(normalizingLoadError error: any Error) {
+    if let whisperError = error as? WhisperError {
+      self.init(mapping: whisperError)
+    } else {
+      self = .unknownLoadFailure(error.localizedDescription)
+    }
+  }
+}
+
+extension WhisperKitModelLoadSentryError: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String {
+    // No live Sentry history found for a "WhisperError"-identified descriptor
+    // in a 90-day search — every case below is a defensive pin.
+    switch self {
+    case .tokenizerUnavailable: return "WhisperKit.WhisperError#0"
+    case .modelsUnavailable: return "WhisperKit.WhisperError#1"
+    case .audioProcessingFailed: return "WhisperKit.WhisperError#2"
+    case .decodingLogitsFailed: return "WhisperKit.WhisperError#3"
+    case .segmentingFailed: return "WhisperKit.WhisperError#4"
+    case .loadAudioFailed: return "WhisperKit.WhisperError#5"
+    case .prepareDecoderInputsFailed: return "WhisperKit.WhisperError#6"
+    case .transcriptionFailed: return "WhisperKit.WhisperError#7"
+    case .decodingFailed: return "WhisperKit.WhisperError#8"
+    case .microphoneUnavailable: return "WhisperKit.WhisperError#9"
+    case .initializationError: return "WhisperKit.WhisperError#10"
+    case .unknownLoadFailure:
+      return "EnviousWisprASR.WhisperKitModelLoadSentryError.unknownLoadFailure"
+    }
+  }
+
+  var sentrySemanticID: String {
+    switch self {
+    case .tokenizerUnavailable: return "whisperkit_load.tokenizer_unavailable"
+    case .modelsUnavailable: return "whisperkit_load.models_unavailable"
+    case .audioProcessingFailed: return "whisperkit_load.audio_processing_failed"
+    case .decodingLogitsFailed: return "whisperkit_load.decoding_logits_failed"
+    case .segmentingFailed: return "whisperkit_load.segmenting_failed"
+    case .loadAudioFailed: return "whisperkit_load.load_audio_failed"
+    case .prepareDecoderInputsFailed: return "whisperkit_load.prepare_decoder_inputs_failed"
+    case .transcriptionFailed: return "whisperkit_load.transcription_failed"
+    case .decodingFailed: return "whisperkit_load.decoding_failed"
+    case .microphoneUnavailable: return "whisperkit_load.microphone_unavailable"
+    case .initializationError: return "whisperkit_load.initialization_error"
+    case .unknownLoadFailure: return "whisperkit_load.unknown_load_failure"
+    }
+  }
+}

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -123,16 +123,16 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
   ) {
     nonisolated(unsafe) let safeReply = reply
 
-    // Validate input
+    // Validate input. Stays exactly here — synchronous, before the Task —
+    // only its payload normalizes (#1525 PR I-B, Codex r2: moving this into
+    // the `do` block would delay the reply onto the main actor, a real
+    // scheduling change this PR must not make).
     guard data.count == sampleCount * MemoryLayout<Float>.size else {
-      safeReply(
-        nil,
-        NSError(
-          domain: "ASRService", code: -2,
-          userInfo: [
-            NSLocalizedDescriptionKey:
-              "Data size mismatch: expected \(sampleCount * MemoryLayout<Float>.size), got \(data.count)"
-          ]))
+      let error = XPCASRTransportError.invalidSamplePayload(
+        "Data size mismatch: expected \(sampleCount * MemoryLayout<Float>.size), got \(data.count)"
+      )
+      // XPC error sanitization boundary.
+      safeReply(nil, XPCErrorSanitizer.sanitizeForXPC(error))
       return
     }
 
@@ -144,33 +144,42 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
           return Array(raw.bindMemory(to: Float.self))
         }
 
-        let speechSegments =
-          if let speechSegmentsData {
-            try JSONDecoder().decode([SpeechSegment].self, from: speechSegmentsData)
-          } else {
-            [SpeechSegment]()
+        let speechSegments: [SpeechSegment]
+        if let speechSegmentsData {
+          do {
+            speechSegments = try JSONDecoder().decode(
+              [SpeechSegment].self, from: speechSegmentsData)
+          } catch {
+            // #1525 PR I-B: a request-decoding failure, not a transcription
+            // failure — belongs on the transport authority.
+            throw XPCASRTransportError.requestDecodingFailed(error.localizedDescription)
           }
+        } else {
+          speechSegments = []
+        }
         let options = TranscriptionOptions(
           language: language.isEmpty ? nil : language,
           enableTimestamps: enableTimestamps,
           speechSegments: speechSegments
         )
 
-        // Route to the active backend
-        let result: EnviousWisprCore.ASRResult
-        if let parakeet = self.parakeetBackend {
-          result = try await parakeet.transcribe(audioSamples: samples, options: options)
-        } else {
-          safeReply(
-            nil,
-            NSError(
-              domain: "ASRService", code: -3,
-              userInfo: [NSLocalizedDescriptionKey: "No model loaded"]))
-          return
+        // Route to the active backend. Already inside the `do` block, so
+        // converting this to a throw is a legitimate in-place normalization
+        // — no scheduling change (#1525 PR I-B).
+        guard let parakeet = self.parakeetBackend else {
+          throw XPCASRTransportError.modelNotLoaded
         }
+        let result = try await parakeet.transcribe(audioSamples: samples, options: options)
 
         // Encode ASRResult → Data via PropertyListEncoder
-        let encoded = try PropertyListEncoder().encode(result)
+        let encoded: Data
+        do {
+          encoded = try PropertyListEncoder().encode(result)
+        } catch {
+          // #1525 PR I-B: a response-encoding failure, not a transcription
+          // failure — belongs on the transport authority.
+          throw XPCASRTransportError.responseEncodingFailed(error.localizedDescription)
+        }
         safeReply(encoded, nil)
       } catch {
         // XPC error sanitization boundary.
@@ -191,10 +200,10 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
     signal.emit(stage: "asr.start_streaming.received")
     guard let parakeet = parakeetBackend else {
       signal.emit(stage: "asr.start_streaming.failed", detail: "no_parakeet_model")
-      reply(
-        NSError(
-          domain: "ASRService", code: -3,
-          userInfo: [NSLocalizedDescriptionKey: "No Parakeet model loaded for streaming"]))
+      // #1525 PR I-B (Codex cloud review): same "no model loaded" condition
+      // transcribeSamples already normalizes — reuse its pinned identity
+      // rather than a raw NSError.
+      reply(XPCErrorSanitizer.sanitizeForXPC(XPCASRTransportError.modelNotLoaded))
       return
     }
 
@@ -239,11 +248,10 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
 
   func finalizeStreaming(reply: @escaping (Data?, NSError?) -> Void) {
     guard isStreamingActive, let parakeet = parakeetBackend else {
-      reply(
-        nil,
-        NSError(
-          domain: "ASRService", code: -3,
-          userInfo: [NSLocalizedDescriptionKey: "No active streaming session"]))
+      // #1525 PR I-B (Codex cloud review): reuse the same pinned "no model
+      // loaded" identity as transcribeSamples/startStreaming — a caller
+      // reaching this guard has no active session to finalize either way.
+      reply(nil, XPCErrorSanitizer.sanitizeForXPC(XPCASRTransportError.modelNotLoaded))
       return
     }
 
@@ -252,7 +260,15 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
       do {
         let result = try await parakeet.finalizeStreaming()
         self.isStreamingActive = false
-        let encoded = try PropertyListEncoder().encode(result)
+        let encoded: Data
+        do {
+          encoded = try PropertyListEncoder().encode(result)
+        } catch {
+          // #1525 PR I-B (Codex cloud review): a response-encoding failure,
+          // not a transcription failure — belongs on the transport authority,
+          // same as transcribeSamples's encode site.
+          throw XPCASRTransportError.responseEncodingFailed(error.localizedDescription)
+        }
         safeReply(encoded, nil)
       } catch {
         self.isStreamingActive = false

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -355,7 +355,12 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// in-process producer (`ASRError` is ASR-module-internal, kept isolated per
   /// D-028); an unrecognized error is `.other`.
   private static func classify(_ error: any Error) -> RecoveryFailureClass {
-    if error is XPCASRTransportError { return .xpcUnreachable }
+    // #1525 PR I-B: narrowed from a bare type-check — the 6 new
+    // codec/transport cases are transport/codec failures, not "XPC
+    // unreachable," and mislabeling them would corrupt recovery telemetry.
+    if let transport = error as? XPCASRTransportError, transport.isServiceUnreachable {
+      return .xpcUnreachable
+    }
     if error is ASRLoadSupersededError { return .cancelled }
     return .other
   }

--- a/Sources/EnviousWisprFluidAudioBridge/FluidAudioASRErrorKind.swift
+++ b/Sources/EnviousWisprFluidAudioBridge/FluidAudioASRErrorKind.swift
@@ -1,0 +1,35 @@
+@preconcurrency import FluidAudio
+
+/// #1525 PR I-B: classifies FluidAudio's raw `ASRError` (transcription path) into a
+/// plain, name-collision-free value. This target exists because `FluidAudio` exports
+/// a struct literally named `FluidAudio` that shadows module-qualified lookup, and a
+/// bare unqualified `ASRError` inside `EnviousWisprASR` silently resolves to the app's
+/// OWN `ASRError` type instead (`swift-patterns.md` RULE: fluidaudio-unqualified-symbols) —
+/// this is the one module that safely names FluidAudio's own `ASRError`.
+package enum FluidAudioASRErrorKind: Sendable, Equatable {
+  case notInitialized(String)
+  case invalidAudioData(String)
+  case modelLoadFailed(String)
+  case processingFailed(String)
+  case modelCompilationFailed(String)
+  case unsupportedPlatform(String)
+  case streamingConversionFailed(String)
+  case fileAccessFailed(String)
+  case unknownFutureCase(String)
+}
+
+package func classifyFluidAudioASRError(_ error: any Error) -> FluidAudioASRErrorKind? {
+  guard let error = error as? ASRError else { return nil }  // unambiguous here: this module declares no other ASRError
+  let description = error.localizedDescription
+  switch error {
+  case .notInitialized: return .notInitialized(description)
+  case .invalidAudioData: return .invalidAudioData(description)
+  case .modelLoadFailed: return .modelLoadFailed(description)
+  case .processingFailed: return .processingFailed(description)
+  case .modelCompilationFailed: return .modelCompilationFailed(description)
+  case .unsupportedPlatform: return .unsupportedPlatform(description)
+  case .streamingConversionFailed: return .streamingConversionFailed(description)
+  case .fileAccessFailed: return .fileAccessFailed(description)
+  @unknown default: return .unknownFutureCase(description)
+  }
+}

--- a/Sources/EnviousWisprFluidAudioBridge/FluidAudioModelLoadErrorKind.swift
+++ b/Sources/EnviousWisprFluidAudioBridge/FluidAudioModelLoadErrorKind.swift
@@ -1,0 +1,53 @@
+@preconcurrency import FluidAudio
+
+/// #1525 PR I-B: classifies FluidAudio's raw model-load errors (`ParakeetBackend.prepare`,
+/// not the transcribe path — see `FluidAudioASRErrorKind`). Three separate, unrelated
+/// FluidAudio error enums can escape model loading; each needs its own `as?` probe.
+/// `AsrModelsError.modelNotFound`/`.downloadFailed` and
+/// `HuggingFaceDownloadError.modelNotFound`/`.downloadFailed` collide by case NAME
+/// across enums (different payloads), so every case below is prefixed by its source enum.
+package enum FluidAudioModelLoadErrorKind: Sendable, Equatable {
+  case modelsModelNotFound(String)
+  case modelsDownloadFailed(String)
+  case modelsLoadingFailed(String)
+  case modelsCompilationFailed(String)
+  case offlineNetworkDisabled(String)
+  case offlineModelMissing(String)
+  case hfInvalidResponse(String)
+  case hfRateLimited(String)
+  case hfDownloadFailed(String)
+  case hfModelNotFound(String)
+  case hfHtmlErrorResponse(String)
+  case unknownLoadFailure(String)
+}
+
+package func classifyFluidAudioModelLoadError(_ error: any Error) -> FluidAudioModelLoadErrorKind? {
+  let description = error.localizedDescription
+  if let e = error as? AsrModelsError {
+    switch e {
+    case .modelNotFound: return .modelsModelNotFound(description)
+    case .downloadFailed: return .modelsDownloadFailed(description)
+    case .loadingFailed: return .modelsLoadingFailed(description)
+    case .modelCompilationFailed: return .modelsCompilationFailed(description)
+    @unknown default: return .unknownLoadFailure(description)
+    }
+  }
+  if let e = error as? DownloadUtils.OfflineError {
+    switch e {
+    case .networkDisabled: return .offlineNetworkDisabled(description)
+    case .modelMissing: return .offlineModelMissing(description)
+    @unknown default: return .unknownLoadFailure(description)
+    }
+  }
+  if let e = error as? DownloadUtils.HuggingFaceDownloadError {
+    switch e {
+    case .invalidResponse: return .hfInvalidResponse(description)
+    case .rateLimited: return .hfRateLimited(description)
+    case .downloadFailed: return .hfDownloadFailed(description)
+    case .modelNotFound: return .hfModelNotFound(description)
+    case .htmlErrorResponse: return .hfHtmlErrorResponse(description)
+    @unknown default: return .unknownLoadFailure(description)
+    }
+  }
+  return nil  // none of the 3 named vendor types — caller maps this to .unknownLoadFailure too
+}

--- a/Sources/EnviousWisprLLM/AFMGenerationSentryError.swift
+++ b/Sources/EnviousWisprLLM/AFMGenerationSentryError.swift
@@ -1,0 +1,102 @@
+import EnviousWisprCore
+import Foundation
+
+#if canImport(FoundationModels)
+  import FoundationModels
+#endif
+
+/// #1525 PR I-B: pinned Sentry identity for Apple's `FoundationModels.LanguageModelSession
+/// .GenerationError`, whose 9 cases otherwise bridge via Swift's ordinal-derived `NSError`
+/// identity (`StableSentryErrorIdentity`'s own doc comment explains why that is unstable).
+/// Framework-free by design — no `FoundationModels` import at file scope — so it stays
+/// usable from macOS-14-compatible call sites; only the mapping initializer below needs
+/// the framework, gated the same way `AppleIntelligenceConnector.polish()` gates its own
+/// FoundationModels use.
+///
+/// `internal` visibility (default, no modifier): nothing outside `EnviousWisprLLM` needs to
+/// name this type. It only ever surfaces as `AFMPolishError.underlying`, already typed as
+/// plain existential `Error` at the module boundary.
+///
+/// Each case carries the original error's description as an associated `String` —
+/// `TextProcessingRunner.swift:378` surfaces `"AI polish failed: " + error.localizedDescription`
+/// to the user for some AFM failures, so a bare no-payload case would regress that
+/// customer-visible text. The description travels with the case but is never part of the
+/// fingerprint or semantic ID.
+enum AFMGenerationSentryError: Error, LocalizedError, Sendable, Equatable {
+  case assetsUnavailable(String)
+  case guardrailViolation(String)
+  case unsupportedGuide(String)
+  case unsupportedLanguageOrLocale(String)
+  case decodingFailure(String)
+  case rateLimited(String)
+  case concurrentRequests(String)
+  case refusal(String)
+  case unknownFutureCase(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .assetsUnavailable(let d), .guardrailViolation(let d), .unsupportedGuide(let d),
+      .unsupportedLanguageOrLocale(let d), .decodingFailure(let d), .rateLimited(let d),
+      .concurrentRequests(let d), .refusal(let d), .unknownFutureCase(let d):
+      return d
+    }
+  }
+}
+
+#if canImport(FoundationModels)
+  @available(macOS 26.0, *)
+  extension AFMGenerationSentryError {
+    /// The ONLY site that constructs this type from the concrete Apple type — the
+    /// caller (`AppleIntelligenceConnector.generateGuardingContextWindow`) has
+    /// already intercepted `.exceededContextWindowSize` before calling this, so
+    /// that branch below is unreachable in practice but still must satisfy the
+    /// exhaustive switch.
+    init(mapping error: LanguageModelSession.GenerationError) {
+      let d = error.localizedDescription
+      switch error {
+      case .exceededContextWindowSize: self = .unknownFutureCase(d)  // unreachable — caller intercepts this case first
+      case .assetsUnavailable: self = .assetsUnavailable(d)
+      case .guardrailViolation: self = .guardrailViolation(d)
+      case .unsupportedGuide: self = .unsupportedGuide(d)
+      case .unsupportedLanguageOrLocale: self = .unsupportedLanguageOrLocale(d)
+      case .decodingFailure: self = .decodingFailure(d)
+      case .rateLimited: self = .rateLimited(d)
+      case .concurrentRequests: self = .concurrentRequests(d)
+      case .refusal: self = .refusal(d)
+      @unknown default: self = .unknownFutureCase(d)
+      }
+    }
+  }
+#endif
+
+extension AFMGenerationSentryError: StableSentryErrorIdentity {
+  var sentryFingerprintDescriptor: String {
+    switch self {
+    case .assetsUnavailable: return "FoundationModels.LanguageModelSession.GenerationError#1"
+    case .guardrailViolation: return "FoundationModels.LanguageModelSession.GenerationError#2"
+    case .unsupportedGuide: return "FoundationModels.LanguageModelSession.GenerationError#3"
+    case .unsupportedLanguageOrLocale:
+      // LIVE: ENVIOUSWISPR-2J, 5u/12e, production — must not change.
+      return "FoundationModels.LanguageModelSession.GenerationError#4"
+    case .decodingFailure: return "FoundationModels.LanguageModelSession.GenerationError#5"
+    case .rateLimited: return "FoundationModels.LanguageModelSession.GenerationError#6"
+    case .concurrentRequests: return "FoundationModels.LanguageModelSession.GenerationError#7"
+    case .refusal: return "FoundationModels.LanguageModelSession.GenerationError#8"
+    case .unknownFutureCase: return "EnviousWisprLLM.AFMGenerationSentryError.unknownFutureCase"
+    }
+  }
+
+  var sentrySemanticID: String {
+    switch self {
+    case .assetsUnavailable: return "afm.assets_unavailable"
+    case .guardrailViolation: return "afm.guardrail_violation"
+    case .unsupportedGuide: return "afm.unsupported_guide"
+    case .unsupportedLanguageOrLocale: return "afm.unsupported_language_or_locale"
+    case .decodingFailure: return "afm.decoding_failure"
+    case .rateLimited: return "afm.rate_limited"
+    case .concurrentRequests: return "afm.concurrent_requests"
+    case .refusal: return "afm.refusal"
+    case .unknownFutureCase: return "afm.unknown_future_case"
+    }
+  }
+}

--- a/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
@@ -700,7 +700,9 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
           }
           throw AFMContextWindowExceeded(stage: .caught)
         }
-        throw genErr
+        // #1525 PR I-B: every other GenerationError case gets a pinned Sentry
+        // identity instead of bridging via Swift's ordinal-derived NSError.
+        throw AFMGenerationSentryError(mapping: genErr)
       }
     }
 

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -221,7 +221,10 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   private func loadModelWithTransportRecovery() async throws {
     do {
       try await asrManager.loadModel()
-    } catch is XPCASRTransportError {
+    } catch let error as XPCASRTransportError where error.isServiceUnreachable {
+      // #1525 PR I-B: narrowed from a bare type-check — the 6 new
+      // codec/transport cases are not stale-helper-retry-eligible; retrying
+      // a reload for, say, `.requestDecodingFailed` would mask a real bug.
       try await asrManager.loadModel()
     }
   }

--- a/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
+++ b/Tests/EnviousWisprASRTests/FluidAudioBridgeClassificationTests.swift
@@ -1,0 +1,173 @@
+import EnviousWisprCore
+@preconcurrency import FluidAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprFluidAudioBridge
+
+/// #1525 PR I-B — classification-completeness tests for the bridge that isolates
+/// FluidAudio's raw error taxonomies (`ASRError`, `AsrModelsError`,
+/// `DownloadUtils.OfflineError`, `DownloadUtils.HuggingFaceDownloadError`) behind
+/// name-collision-free values. Lives in this CONSUMING test target, not inside the
+/// bridge target itself (Codex r9). Both types' `@unknown default`/catch-all
+/// branches are code-inspection-only guarantees — no real FluidAudio SDK value
+/// can exercise them with the currently pinned fork version.
+@Suite("FluidAudio error classification (#1525 PR I-B)")
+struct FluidAudioBridgeClassificationTests {
+
+  // MARK: - FluidAudioASRErrorKind (transcription path, 8 real cases)
+
+  @Test("classifyFluidAudioASRError maps every real ASRError case")
+  func classifiesAllASRErrorCases() {
+    let cases: [(ASRError, FluidAudioASRErrorKind)] = [
+      (.notInitialized, .notInitialized(ASRError.notInitialized.localizedDescription)),
+      (.invalidAudioData, .invalidAudioData(ASRError.invalidAudioData.localizedDescription)),
+      (.modelLoadFailed, .modelLoadFailed(ASRError.modelLoadFailed.localizedDescription)),
+      (
+        .processingFailed("x"),
+        .processingFailed(ASRError.processingFailed("x").localizedDescription)
+      ),
+      (
+        .modelCompilationFailed,
+        .modelCompilationFailed(ASRError.modelCompilationFailed.localizedDescription)
+      ),
+      (
+        .unsupportedPlatform("x"),
+        .unsupportedPlatform(ASRError.unsupportedPlatform("x").localizedDescription)
+      ),
+      (
+        .streamingConversionFailed(NSError(domain: "fixture", code: 1)),
+        .streamingConversionFailed(
+          ASRError.streamingConversionFailed(NSError(domain: "fixture", code: 1))
+            .localizedDescription)
+      ),
+      (
+        .fileAccessFailed(URL(fileURLWithPath: "/tmp/x"), NSError(domain: "fixture", code: 2)),
+        .fileAccessFailed(
+          ASRError.fileAccessFailed(
+            URL(fileURLWithPath: "/tmp/x"), NSError(domain: "fixture", code: 2)
+          ).localizedDescription)
+      ),
+    ]
+    for (vendorError, expected) in cases {
+      #expect(classifyFluidAudioASRError(vendorError) == expected)
+    }
+  }
+
+  @Test("classifyFluidAudioASRError returns nil for a non-ASRError")
+  func returnsNilForNonASRError() {
+    struct OtherError: Error {}
+    #expect(classifyFluidAudioASRError(OtherError()) == nil)
+  }
+
+  // MARK: - FluidAudioModelLoadErrorKind (model-load path, 11 real cases across 3 enums)
+
+  @Test("classifyFluidAudioModelLoadError maps every real AsrModelsError case")
+  func classifiesAllAsrModelsErrorCases() {
+    let cases: [(AsrModelsError, FluidAudioModelLoadErrorKind)] = [
+      (
+        .modelNotFound("m", URL(fileURLWithPath: "/tmp/m")),
+        .modelsModelNotFound(
+          AsrModelsError.modelNotFound("m", URL(fileURLWithPath: "/tmp/m")).localizedDescription)
+      ),
+      (
+        .downloadFailed("d"),
+        .modelsDownloadFailed(AsrModelsError.downloadFailed("d").localizedDescription)
+      ),
+      (
+        .loadingFailed("l"),
+        .modelsLoadingFailed(AsrModelsError.loadingFailed("l").localizedDescription)
+      ),
+      (
+        .modelCompilationFailed("c"),
+        .modelsCompilationFailed(AsrModelsError.modelCompilationFailed("c").localizedDescription)
+      ),
+    ]
+    for (vendorError, expected) in cases {
+      #expect(classifyFluidAudioModelLoadError(vendorError) == expected)
+    }
+  }
+
+  @Test("classifyFluidAudioModelLoadError maps every real DownloadUtils.OfflineError case")
+  func classifiesAllOfflineErrorCases() {
+    let cases: [(DownloadUtils.OfflineError, FluidAudioModelLoadErrorKind)] = [
+      (
+        .networkDisabled(operation: "downloadRepo(x)"),
+        .offlineNetworkDisabled(
+          DownloadUtils.OfflineError.networkDisabled(operation: "downloadRepo(x)")
+            .localizedDescription)
+      ),
+      (
+        .modelMissing(repo: "r", missing: ["a.mlmodel"]),
+        .offlineModelMissing(
+          DownloadUtils.OfflineError.modelMissing(repo: "r", missing: ["a.mlmodel"])
+            .localizedDescription)
+      ),
+    ]
+    for (vendorError, expected) in cases {
+      #expect(classifyFluidAudioModelLoadError(vendorError) == expected)
+    }
+  }
+
+  @Test(
+    "classifyFluidAudioModelLoadError maps every real DownloadUtils.HuggingFaceDownloadError case"
+  )
+  func classifiesAllHuggingFaceDownloadErrorCases() {
+    let cases: [(DownloadUtils.HuggingFaceDownloadError, FluidAudioModelLoadErrorKind)] = [
+      (
+        .invalidResponse,
+        .hfInvalidResponse(
+          DownloadUtils.HuggingFaceDownloadError.invalidResponse.localizedDescription)
+      ),
+      (
+        .rateLimited(statusCode: 429, message: "slow down"),
+        .hfRateLimited(
+          DownloadUtils.HuggingFaceDownloadError.rateLimited(
+            statusCode: 429, message: "slow down"
+          ).localizedDescription)
+      ),
+      (
+        .downloadFailed(path: "p", underlying: NSError(domain: "fixture", code: 3)),
+        .hfDownloadFailed(
+          DownloadUtils.HuggingFaceDownloadError.downloadFailed(
+            path: "p", underlying: NSError(domain: "fixture", code: 3)
+          ).localizedDescription)
+      ),
+      (
+        .modelNotFound(path: "p"),
+        .hfModelNotFound(
+          DownloadUtils.HuggingFaceDownloadError.modelNotFound(path: "p").localizedDescription)
+      ),
+      (
+        .htmlErrorResponse(path: "p", snippet: "<html>"),
+        .hfHtmlErrorResponse(
+          DownloadUtils.HuggingFaceDownloadError.htmlErrorResponse(path: "p", snippet: "<html>")
+            .localizedDescription)
+      ),
+    ]
+    for (vendorError, expected) in cases {
+      #expect(classifyFluidAudioModelLoadError(vendorError) == expected)
+    }
+  }
+
+  @Test("classifyFluidAudioModelLoadError returns nil for none of the 3 named vendor types")
+  func returnsNilForNonVendorModelLoadError() {
+    struct OtherError: Error {}
+    #expect(classifyFluidAudioModelLoadError(OtherError()) == nil)
+  }
+
+  /// #1525 PR I-B naming-trap regression: a future accidental reintroduction of
+  /// `ASRError`/`FluidAudio.ASRError` inside `EnviousWisprASR` would be caught by
+  /// THAT module failing to compile or silently never matching — this test proves
+  /// the bridge itself (the durable fix) correctly resolves FluidAudio's real
+  /// `ASRError`, not some shadowing type, by asserting a case that only exists on
+  /// the real vendor enum.
+  @Test("the bridge resolves FluidAudio's real ASRError, not a shadowing type")
+  func resolvesRealFluidAudioType() {
+    let kind = classifyFluidAudioASRError(ASRError.notInitialized)
+    guard case .notInitialized = kind else {
+      Issue.record("expected .notInitialized, got \(String(describing: kind))")
+      return
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/ASR/ASRClusterSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ASRClusterSentryIdentityTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 
 @testable import EnviousWisprASR
+@testable import EnviousWisprPipeline
 @testable import EnviousWisprServices
 
 /// #1525 PR G — `ASRError`, `XPCASRTransportError`, and `ASRLoadSupersededError`'s
@@ -65,6 +66,77 @@ struct ASRClusterSentryIdentityTests {
     #expect(
       SentryBreadcrumb.structuredDescriptor(error) == "EnviousWisprASR.XPCASRTransportError#0")
     #expect(error.sentrySemanticID == "xpc.asr_service_unreachable")
+  }
+
+  /// #1525 PR I-B: `.modelNotLoaded`'s descriptor is measured LIVE
+  /// (ENVIOUSWISPR-3S) — MUST NOT change. The other 5 are fresh, defensive
+  /// pins (`.invalidSamplePayload` measured as a type-level "no history"
+  /// negative result, §3.5).
+  private static let xpcTransportPins: [(XPCASRTransportError, String, String)] = [
+    (.serviceUnreachable, "EnviousWisprASR.XPCASRTransportError#0", "xpc.asr_service_unreachable"),
+    (
+      .requestEncodingFailed("x"), "EnviousWisprASR.XPCASRTransportError#1",
+      "xpc.request_encoding_failed"
+    ),
+    (.invalidSamplePayload("x"), "ASRService#-2", "xpc.invalid_sample_payload"),
+    (
+      .requestDecodingFailed("x"), "EnviousWisprASR.XPCASRTransportError#2",
+      "xpc.request_decoding_failed"
+    ),
+    (.modelNotLoaded, "ASRService#-3", "xpc.model_not_loaded"),
+    (
+      .responseEncodingFailed("x"), "EnviousWisprASR.XPCASRTransportError#3",
+      "xpc.response_encoding_failed"
+    ),
+    (
+      .responseDecodingFailed("x"), "EnviousWisprASR.XPCASRTransportError#4",
+      "xpc.response_decoding_failed"
+    ),
+  ]
+
+  @Test("every XPCASRTransportError case keeps its exact pinned fingerprint")
+  func xpcTransportErrorAllCasesPinLock() {
+    for (error, descriptor, semanticID) in Self.xpcTransportPins {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(error.sentrySemanticID == semanticID)
+    }
+  }
+
+  @Test("all 7 declared XPCASRTransportError identities are unique")
+  func xpcTransportErrorIdentitiesAreUnique() {
+    let errors = Self.xpcTransportPins.map(\.0)
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 7)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 7)
+  }
+
+  @Test("only .serviceUnreachable is isServiceUnreachable")
+  func onlyServiceUnreachableIsServiceUnreachable() {
+    for (error, _, _) in Self.xpcTransportPins {
+      if case .serviceUnreachable = error {
+        #expect(error.isServiceUnreachable)
+      } else {
+        #expect(!error.isServiceUnreachable)
+      }
+    }
+  }
+
+  @Test("XPCASRTransportError round-trips through its NSError bridge for every case")
+  func xpcTransportErrorNSErrorRoundTrip() {
+    for (error, _, _) in Self.xpcTransportPins {
+      let bridged = error as NSError
+      #expect(bridged.domain == XPCASRTransportError.errorDomain)
+      guard let reconstructed = XPCASRTransportError(reconstructingFrom: bridged) else {
+        Issue.record("reconstruction failed for \(error)")
+        continue
+      }
+      #expect(reconstructed == error)
+    }
+  }
+
+  @Test("reconstructingFrom returns nil for an unrelated NSError domain")
+  func xpcTransportErrorReconstructionRejectsForeignDomain() {
+    let foreign = NSError(domain: "SomeOtherDomain", code: 0)
+    #expect(XPCASRTransportError(reconstructingFrom: foreign) == nil)
   }
 
   @Test("ASRLoadSupersededError keeps its exact measured fingerprint")
@@ -145,5 +217,23 @@ struct ASRClusterSentryIdentityTests {
     #expect(
       event.fingerprint == ["handled_error", "asr_failed", "EnviousWispr#-3", Self.env])
     #expect(event.tags?["error.identity"] == nil)
+  }
+
+  /// #1525 PR I-B: `.modelNotLoaded` is the one confirmed-live new
+  /// XPCASRTransportError case (ENVIOUSWISPR-3S) — its event must preserve
+  /// the exact `"ASRService#-3"` descriptor.
+  @MainActor
+  @Test(
+    "the confirmed-live .modelNotLoaded case's event carries the exact preserved production fingerprint"
+  )
+  func modelNotLoadedEventShape() {
+    let error = XPCASRTransportError.modelNotLoaded
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "transcription", environment: Self.env)
+
+    #expect(
+      event.fingerprint == ["handled_error", "asr_failed", "ASRService#-3", Self.env])
+    #expect(event.tags?["error.identity"] == "xpc.model_not_loaded")
   }
 }

--- a/Tests/EnviousWisprTests/ASR/ASRClusterSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ASRClusterSentryIdentityTests.swift
@@ -139,6 +139,22 @@ struct ASRClusterSentryIdentityTests {
     #expect(XPCASRTransportError(reconstructingFrom: foreign) == nil)
   }
 
+  /// #1525 PR I-B (Codex cloud review): a plain `as NSError` cast is not enough —
+  /// Foundation's special "boxed Swift LocalizedError" bridging survives a same-
+  /// process cast but NOT an actual XPC-style archive round-trip (confirmed via a
+  /// direct `NSKeyedArchiver`/`NSKeyedUnarchiver` probe this session). Only
+  /// `errorUserInfo` populating `NSLocalizedDescriptionKey` survives that.
+  @Test("localizedDescription survives an actual NSSecureCoding archive round-trip")
+  func xpcTransportErrorLocalizedDescriptionSurvivesArchiveRoundTrip() throws {
+    let error = XPCASRTransportError.responseDecodingFailed("a real transport description")
+    let bridged = error as NSError
+    let data = try NSKeyedArchiver.archivedData(
+      withRootObject: bridged, requiringSecureCoding: true)
+    let decoded = try #require(
+      try NSKeyedUnarchiver.unarchivedObject(ofClass: NSError.self, from: data))
+    #expect(decoded.localizedDescription == "a real transport description")
+  }
+
   @Test("ASRLoadSupersededError keeps its exact measured fingerprint")
   func asrLoadSupersededErrorPinLock() {
     let error = ASRLoadSupersededError()

--- a/Tests/EnviousWisprTests/ASR/ParakeetModelLoadSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ParakeetModelLoadSentryErrorTests.swift
@@ -1,0 +1,167 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprFluidAudioBridge
+@testable import EnviousWisprServices
+
+/// #1525 PR I-B — `ParakeetModelLoadSentryError`'s Sentry identity is PINNED,
+/// mirroring `KeyStoreError`'s shipped pattern (PR F). No live Sentry measurement
+/// has been run against these case-level descriptors (§3.5's "remaining work") —
+/// every case is a fresh, defensive pin.
+@Suite("ParakeetModelLoadSentryError Sentry stable identity (#1525 PR I-B)")
+struct ParakeetModelLoadSentryErrorTests {
+
+  private static let env = "production"
+  private static let category = SentryBreadcrumb.ErrorCategory.modelLoadFailed
+
+  private static let pins: [(ParakeetModelLoadSentryError, String, String)] = [
+    (
+      .modelsModelNotFound("x"), "FluidAudio.AsrModelsError#0",
+      "parakeet_load.models_model_not_found"
+    ),
+    (
+      .modelsDownloadFailed("x"), "FluidAudio.AsrModelsError#1",
+      "parakeet_load.models_download_failed"
+    ),
+    (
+      .modelsLoadingFailed("x"), "FluidAudio.AsrModelsError#2",
+      "parakeet_load.models_loading_failed"
+    ),
+    (
+      .modelsCompilationFailed("x"), "FluidAudio.AsrModelsError#3",
+      "parakeet_load.models_compilation_failed"
+    ),
+    (
+      .offlineNetworkDisabled("x"), "FluidAudio.DownloadUtils.OfflineError#0",
+      "parakeet_load.offline_network_disabled"
+    ),
+    (
+      .offlineModelMissing("x"), "FluidAudio.DownloadUtils.OfflineError#1",
+      "parakeet_load.offline_model_missing"
+    ),
+    (
+      .hfInvalidResponse("x"), "FluidAudio.DownloadUtils.HuggingFaceDownloadError#0",
+      "parakeet_load.hf_invalid_response"
+    ),
+    (
+      .hfRateLimited("x"), "FluidAudio.DownloadUtils.HuggingFaceDownloadError#1",
+      "parakeet_load.hf_rate_limited"
+    ),
+    (
+      .hfDownloadFailed("x"), "FluidAudio.DownloadUtils.HuggingFaceDownloadError#2",
+      "parakeet_load.hf_download_failed"
+    ),
+    (
+      .hfModelNotFound("x"), "FluidAudio.DownloadUtils.HuggingFaceDownloadError#3",
+      "parakeet_load.hf_model_not_found"
+    ),
+    (
+      .hfHtmlErrorResponse("x"), "FluidAudio.DownloadUtils.HuggingFaceDownloadError#4",
+      "parakeet_load.hf_html_error_response"
+    ),
+    (
+      .unknownLoadFailure("x"), "EnviousWisprASR.ParakeetModelLoadSentryError.unknownLoadFailure",
+      "parakeet_load.unknown_load_failure"
+    ),
+  ]
+
+  // MARK: - A. Pin lock
+
+  @Test("every case keeps its exact pinned fingerprint")
+  func pinLock() {
+    for (error, descriptor, semanticID) in Self.pins {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(error.sentrySemanticID == semanticID)
+    }
+  }
+
+  @Test("all 12 declared identities are unique")
+  func identitiesAreUnique() {
+    let errors = Self.pins.map(\.0)
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 12)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 12)
+  }
+
+  // MARK: - B. Mapping completeness — built from FluidAudioModelLoadErrorKind
+
+  @Test(
+    "init(mapping:) maps every FluidAudioModelLoadErrorKind case, preserving its description"
+  )
+  func mappingCompleteness() {
+    let cases: [(FluidAudioModelLoadErrorKind, ParakeetModelLoadSentryError)] = [
+      (.modelsModelNotFound("a"), .modelsModelNotFound("a")),
+      (.modelsDownloadFailed("b"), .modelsDownloadFailed("b")),
+      (.modelsLoadingFailed("c"), .modelsLoadingFailed("c")),
+      (.modelsCompilationFailed("d"), .modelsCompilationFailed("d")),
+      (.offlineNetworkDisabled("e"), .offlineNetworkDisabled("e")),
+      (.offlineModelMissing("f"), .offlineModelMissing("f")),
+      (.hfInvalidResponse("g"), .hfInvalidResponse("g")),
+      (.hfRateLimited("h"), .hfRateLimited("h")),
+      (.hfDownloadFailed("i"), .hfDownloadFailed("i")),
+      (.hfModelNotFound("j"), .hfModelNotFound("j")),
+      (.hfHtmlErrorResponse("k"), .hfHtmlErrorResponse("k")),
+      (.unknownLoadFailure("l"), .unknownLoadFailure("l")),
+    ]
+    for (kind, expected) in cases {
+      #expect(ParakeetModelLoadSentryError(mapping: kind) == expected)
+    }
+  }
+
+  // MARK: - C. Mapping completeness — the real production normalizer
+
+  @Test(
+    "init(normalizingLoadError:) recognizes a real FluidAudio model-load vendor error"
+  )
+  func normalizingLoadErrorRecognizesVendorError() {
+    // classifyFluidAudioModelLoadError only recognizes AsrModelsError/OfflineError/
+    // HuggingFaceDownloadError — a genuinely non-vendor error normalizes to
+    // .unknownLoadFailure, tested below.
+    struct SyntheticNonVendorError: Error, LocalizedError {
+      var errorDescription: String? { "a synthetic CoreML-shaped model-load failure" }
+    }
+    let result = ParakeetModelLoadSentryError(normalizingLoadError: SyntheticNonVendorError())
+    #expect(result == .unknownLoadFailure("a synthetic CoreML-shaped model-load failure"))
+  }
+
+  // MARK: - D. NSError round-trip (survives the XPC boundary)
+
+  @Test("ParakeetModelLoadSentryError round-trips through its NSError bridge for every case")
+  func nsErrorRoundTrip() {
+    for (error, _, _) in Self.pins {
+      let bridged = error as NSError
+      #expect(bridged.domain == ParakeetModelLoadSentryError.errorDomain)
+      guard let reconstructed = ParakeetModelLoadSentryError(reconstructingFrom: bridged) else {
+        Issue.record("reconstruction failed for \(error)")
+        continue
+      }
+      #expect(reconstructed == error)
+    }
+  }
+
+  @Test("reconstructingFrom returns nil for an unrelated NSError domain")
+  func reconstructionRejectsForeignDomain() {
+    let foreign = NSError(domain: "SomeOtherDomain", code: 0)
+    #expect(ParakeetModelLoadSentryError(reconstructingFrom: foreign) == nil)
+  }
+
+  // MARK: - E. Event-construction contract
+
+  @MainActor
+  @Test("a Parakeet model-load-failure event carries the pinned fingerprint and identity tag")
+  func parakeetModelLoadFailureEventShape() {
+    let error = ParakeetModelLoadSentryError.hfRateLimited("boom")
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "asr", environment: Self.env)
+
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "model_load_failed",
+          "FluidAudio.DownloadUtils.HuggingFaceDownloadError#1", Self.env,
+        ])
+    #expect(event.tags?["error.identity"] == "parakeet_load.hf_rate_limited")
+  }
+}

--- a/Tests/EnviousWisprTests/ASR/ParakeetModelLoadSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ParakeetModelLoadSentryErrorTests.swift
@@ -146,6 +146,22 @@ struct ParakeetModelLoadSentryErrorTests {
     #expect(ParakeetModelLoadSentryError(reconstructingFrom: foreign) == nil)
   }
 
+  /// #1525 PR I-B (Codex cloud review): a plain `as NSError` cast is not enough —
+  /// Foundation's special "boxed Swift LocalizedError" bridging survives a same-
+  /// process cast but NOT an actual XPC-style archive round-trip (confirmed via a
+  /// direct `NSKeyedArchiver`/`NSKeyedUnarchiver` probe this session). Only
+  /// `errorUserInfo` populating `NSLocalizedDescriptionKey` survives that.
+  @Test("localizedDescription survives an actual NSSecureCoding archive round-trip")
+  func localizedDescriptionSurvivesArchiveRoundTrip() throws {
+    let error = ParakeetModelLoadSentryError.hfRateLimited("a real vendor description")
+    let bridged = error as NSError
+    let data = try NSKeyedArchiver.archivedData(
+      withRootObject: bridged, requiringSecureCoding: true)
+    let decoded = try #require(
+      try NSKeyedUnarchiver.unarchivedObject(ofClass: NSError.self, from: data))
+    #expect(decoded.localizedDescription == "a real vendor description")
+  }
+
   // MARK: - E. Event-construction contract
 
   @MainActor

--- a/Tests/EnviousWisprTests/ASR/ParakeetTranscriptionSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ParakeetTranscriptionSentryErrorTests.swift
@@ -94,6 +94,23 @@ struct ParakeetTranscriptionSentryErrorTests {
     }
   }
 
+  /// #1525 PR I-B (Codex cloud review): a plain `as NSError` cast is not enough —
+  /// Foundation's special "boxed Swift LocalizedError" bridging survives a same-
+  /// process cast but NOT an actual XPC-style archive round-trip (confirmed via a
+  /// direct `NSKeyedArchiver`/`NSKeyedUnarchiver` probe this session). Only
+  /// `errorUserInfo` populating `NSLocalizedDescriptionKey` survives that. This
+  /// test proves the fix, not just the same-process cast.
+  @Test("localizedDescription survives an actual NSSecureCoding archive round-trip")
+  func localizedDescriptionSurvivesArchiveRoundTrip() throws {
+    let error = ParakeetTranscriptionSentryError.processingFailed("a real vendor description")
+    let bridged = error as NSError
+    let data = try NSKeyedArchiver.archivedData(
+      withRootObject: bridged, requiringSecureCoding: true)
+    let decoded = try #require(
+      try NSKeyedUnarchiver.unarchivedObject(ofClass: NSError.self, from: data))
+    #expect(decoded.localizedDescription == "a real vendor description")
+  }
+
   @Test("reconstructingFrom returns nil for an unrelated NSError domain")
   func reconstructionRejectsForeignDomain() {
     let foreign = NSError(domain: "SomeOtherDomain", code: 0)

--- a/Tests/EnviousWisprTests/ASR/ParakeetTranscriptionSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ParakeetTranscriptionSentryErrorTests.swift
@@ -1,0 +1,117 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprFluidAudioBridge
+@testable import EnviousWisprServices
+
+/// #1525 PR I-B — `ParakeetTranscriptionSentryError`'s Sentry identity is PINNED,
+/// mirroring `KeyStoreError`'s shipped pattern (PR F). No live Sentry history found
+/// for a "FluidAudio.ASRError"-identified descriptor in a 90-day search — every
+/// case is a defensive pin. `com.apple.CoreML#0` (a genuinely non-FluidAudio error)
+/// is confirmed UNAFFECTED by this type (§3.5) — it stays raw, never reaches here.
+@Suite("ParakeetTranscriptionSentryError Sentry stable identity (#1525 PR I-B)")
+struct ParakeetTranscriptionSentryErrorTests {
+
+  private static let env = "production"
+  private static let category = SentryBreadcrumb.ErrorCategory.asrFailed
+
+  private static let pins: [(ParakeetTranscriptionSentryError, String, String)] = [
+    (.notInitialized("x"), "FluidAudio.ASRError#0", "parakeet_transcribe.not_initialized"),
+    (.invalidAudioData("x"), "FluidAudio.ASRError#1", "parakeet_transcribe.invalid_audio_data"),
+    (.modelLoadFailed("x"), "FluidAudio.ASRError#2", "parakeet_transcribe.model_load_failed"),
+    (.processingFailed("x"), "FluidAudio.ASRError#3", "parakeet_transcribe.processing_failed"),
+    (
+      .modelCompilationFailed("x"), "FluidAudio.ASRError#4",
+      "parakeet_transcribe.model_compilation_failed"
+    ),
+    (
+      .unsupportedPlatform("x"), "FluidAudio.ASRError#5", "parakeet_transcribe.unsupported_platform"
+    ),
+    (
+      .streamingConversionFailed("x"), "FluidAudio.ASRError#6",
+      "parakeet_transcribe.streaming_conversion_failed"
+    ),
+    (.fileAccessFailed("x"), "FluidAudio.ASRError#7", "parakeet_transcribe.file_access_failed"),
+    (
+      .unknownTranscriptionFailure("x"),
+      "EnviousWisprASR.ParakeetTranscriptionSentryError.unknownTranscriptionFailure",
+      "parakeet_transcribe.unknown_transcription_failure"
+    ),
+  ]
+
+  // MARK: - A. Pin lock
+
+  @Test("every case keeps its exact pinned fingerprint")
+  func pinLock() {
+    for (error, descriptor, semanticID) in Self.pins {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(error.sentrySemanticID == semanticID)
+    }
+  }
+
+  @Test("all 9 declared identities are unique")
+  func identitiesAreUnique() {
+    let errors = Self.pins.map(\.0)
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 9)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 9)
+  }
+
+  // MARK: - B. Mapping completeness — built from FluidAudioASRErrorKind
+
+  @Test("init(mapping:) maps every FluidAudioASRErrorKind case, preserving its description")
+  func mappingCompleteness() {
+    let cases: [(FluidAudioASRErrorKind, ParakeetTranscriptionSentryError)] = [
+      (.notInitialized("a"), .notInitialized("a")),
+      (.invalidAudioData("b"), .invalidAudioData("b")),
+      (.modelLoadFailed("c"), .modelLoadFailed("c")),
+      (.processingFailed("d"), .processingFailed("d")),
+      (.modelCompilationFailed("e"), .modelCompilationFailed("e")),
+      (.unsupportedPlatform("f"), .unsupportedPlatform("f")),
+      (.streamingConversionFailed("g"), .streamingConversionFailed("g")),
+      (.fileAccessFailed("h"), .fileAccessFailed("h")),
+      (.unknownFutureCase("i"), .unknownTranscriptionFailure("i")),
+    ]
+    for (kind, expected) in cases {
+      #expect(ParakeetTranscriptionSentryError(mapping: kind) == expected)
+    }
+  }
+
+  // MARK: - C. NSError round-trip (survives the XPC boundary)
+
+  @Test("ParakeetTranscriptionSentryError round-trips through its NSError bridge for every case")
+  func nsErrorRoundTrip() {
+    for (error, _, _) in Self.pins {
+      let bridged = error as NSError
+      #expect(bridged.domain == ParakeetTranscriptionSentryError.errorDomain)
+      guard let reconstructed = ParakeetTranscriptionSentryError(reconstructingFrom: bridged)
+      else {
+        Issue.record("reconstruction failed for \(error)")
+        continue
+      }
+      #expect(reconstructed == error)
+    }
+  }
+
+  @Test("reconstructingFrom returns nil for an unrelated NSError domain")
+  func reconstructionRejectsForeignDomain() {
+    let foreign = NSError(domain: "SomeOtherDomain", code: 0)
+    #expect(ParakeetTranscriptionSentryError(reconstructingFrom: foreign) == nil)
+  }
+
+  // MARK: - D. Event-construction contract
+
+  @MainActor
+  @Test("a Parakeet transcription-failure event carries the pinned fingerprint and identity tag")
+  func parakeetTranscriptionFailureEventShape() {
+    let error = ParakeetTranscriptionSentryError.processingFailed("boom")
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "transcription", environment: Self.env)
+
+    #expect(
+      event.fingerprint == ["handled_error", "asr_failed", "FluidAudio.ASRError#3", Self.env])
+    #expect(event.tags?["error.identity"] == "parakeet_transcribe.processing_failed")
+  }
+}

--- a/Tests/EnviousWisprTests/ASR/WhisperKitModelLoadSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/ASR/WhisperKitModelLoadSentryErrorTests.swift
@@ -1,0 +1,160 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+import WhisperKit
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprServices
+
+/// #1525 PR I-B — `WhisperKitModelLoadSentryError`'s Sentry identity is PINNED,
+/// mirroring `KeyStoreError`'s shipped pattern (PR F). No live Sentry history found
+/// for a "WhisperError"-identified descriptor in a 90-day search — every case is a
+/// defensive pin.
+@Suite("WhisperKitModelLoadSentryError Sentry stable identity (#1525 PR I-B)")
+struct WhisperKitModelLoadSentryErrorTests {
+
+  private static let env = "production"
+  private static let category = SentryBreadcrumb.ErrorCategory.modelLoadFailed
+
+  private static let pins: [(WhisperKitModelLoadSentryError, String, String)] = [
+    (
+      .tokenizerUnavailable("x"), "WhisperKit.WhisperError#0",
+      "whisperkit_load.tokenizer_unavailable"
+    ),
+    (.modelsUnavailable("x"), "WhisperKit.WhisperError#1", "whisperkit_load.models_unavailable"),
+    (
+      .audioProcessingFailed("x"), "WhisperKit.WhisperError#2",
+      "whisperkit_load.audio_processing_failed"
+    ),
+    (
+      .decodingLogitsFailed("x"), "WhisperKit.WhisperError#3",
+      "whisperkit_load.decoding_logits_failed"
+    ),
+    (.segmentingFailed("x"), "WhisperKit.WhisperError#4", "whisperkit_load.segmenting_failed"),
+    (.loadAudioFailed("x"), "WhisperKit.WhisperError#5", "whisperkit_load.load_audio_failed"),
+    (
+      .prepareDecoderInputsFailed("x"), "WhisperKit.WhisperError#6",
+      "whisperkit_load.prepare_decoder_inputs_failed"
+    ),
+    (
+      .transcriptionFailed("x"), "WhisperKit.WhisperError#7", "whisperkit_load.transcription_failed"
+    ),
+    (.decodingFailed("x"), "WhisperKit.WhisperError#8", "whisperkit_load.decoding_failed"),
+    (
+      .microphoneUnavailable("x"), "WhisperKit.WhisperError#9",
+      "whisperkit_load.microphone_unavailable"
+    ),
+    (
+      .initializationError("x"), "WhisperKit.WhisperError#10",
+      "whisperkit_load.initialization_error"
+    ),
+    (
+      .unknownLoadFailure("x"),
+      "EnviousWisprASR.WhisperKitModelLoadSentryError.unknownLoadFailure",
+      "whisperkit_load.unknown_load_failure"
+    ),
+  ]
+
+  // MARK: - A. Pin lock
+
+  @Test("every case keeps its exact pinned fingerprint")
+  func pinLock() {
+    for (error, descriptor, semanticID) in Self.pins {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(error.sentrySemanticID == semanticID)
+    }
+  }
+
+  @Test("all 12 declared identities are unique")
+  func identitiesAreUnique() {
+    let errors = Self.pins.map(\.0)
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 12)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 12)
+  }
+
+  // MARK: - B. Mapping completeness — the real production normalizer
+
+  @Test(
+    "init(normalizingLoadError:) maps every real WhisperError case, preserving its description"
+  )
+  func mappingCompletenessForRealWhisperErrors() {
+    let cases: [(WhisperError, WhisperKitModelLoadSentryError)] = [
+      (
+        .tokenizerUnavailable("a"),
+        .tokenizerUnavailable(WhisperError.tokenizerUnavailable("a").localizedDescription)
+      ),
+      (
+        .modelsUnavailable("b"),
+        .modelsUnavailable(WhisperError.modelsUnavailable("b").localizedDescription)
+      ),
+      (
+        .audioProcessingFailed("c"),
+        .audioProcessingFailed(WhisperError.audioProcessingFailed("c").localizedDescription)
+      ),
+      (
+        .decodingLogitsFailed("d"),
+        .decodingLogitsFailed(WhisperError.decodingLogitsFailed("d").localizedDescription)
+      ),
+      (
+        .segmentingFailed("e"),
+        .segmentingFailed(WhisperError.segmentingFailed("e").localizedDescription)
+      ),
+      (
+        .loadAudioFailed("f"),
+        .loadAudioFailed(WhisperError.loadAudioFailed("f").localizedDescription)
+      ),
+      (
+        .prepareDecoderInputsFailed("g"),
+        .prepareDecoderInputsFailed(
+          WhisperError.prepareDecoderInputsFailed("g").localizedDescription)
+      ),
+      (
+        .transcriptionFailed("h"),
+        .transcriptionFailed(WhisperError.transcriptionFailed("h").localizedDescription)
+      ),
+      (
+        .decodingFailed("i"), .decodingFailed(WhisperError.decodingFailed("i").localizedDescription)
+      ),
+      (
+        .microphoneUnavailable("j"),
+        .microphoneUnavailable(WhisperError.microphoneUnavailable("j").localizedDescription)
+      ),
+      (
+        .initializationError("k"),
+        .initializationError(WhisperError.initializationError("k").localizedDescription)
+      ),
+    ]
+    for (vendorError, expected) in cases {
+      #expect(WhisperKitModelLoadSentryError(normalizingLoadError: vendorError) == expected)
+    }
+  }
+
+  /// A genuinely non-`WhisperError` throw (e.g. a CoreML/filesystem error) normalizes
+  /// to `.unknownLoadFailure`, preserving `localizedDescription` exactly — Codex r5
+  /// finding: NOT `String(describing:)`, which can produce debug-formatted output.
+  @Test(
+    "a non-WhisperError throw normalizes to unknownLoadFailure with its exact localizedDescription")
+  func nonWhisperErrorNormalizesToUnknownLoadFailure() {
+    struct SyntheticNonVendorError: Error, LocalizedError {
+      var errorDescription: String? { "a synthetic CoreML-shaped failure" }
+    }
+    let result = WhisperKitModelLoadSentryError(normalizingLoadError: SyntheticNonVendorError())
+    #expect(result == .unknownLoadFailure("a synthetic CoreML-shaped failure"))
+  }
+
+  // MARK: - C. Event-construction contract
+
+  @MainActor
+  @Test("a WhisperKit load-failure event carries the pinned fingerprint and identity tag")
+  func whisperKitLoadFailureEventShape() {
+    let error = WhisperKitModelLoadSentryError.initializationError("boom")
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "asr", environment: Self.env)
+
+    #expect(
+      event.fingerprint
+        == ["handled_error", "model_load_failed", "WhisperKit.WhisperError#10", Self.env])
+    #expect(event.tags?["error.identity"] == "whisperkit_load.initialization_error")
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/AFMGenerationSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/LLM/AFMGenerationSentryErrorTests.swift
@@ -1,0 +1,171 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+@testable import EnviousWisprServices
+
+#if canImport(FoundationModels)
+  import FoundationModels
+#endif
+
+/// #1525 PR I-B — `AFMGenerationSentryError`'s Sentry identity is PINNED, mirroring
+/// `KeyStoreError`'s shipped pattern (PR F). `.unsupportedLanguageOrLocale`'s
+/// descriptor is measured LIVE (ENVIOUSWISPR-2J, §3.5) — MUST NOT change. The
+/// other 7 real cases + `.unknownFutureCase` are defensive pins (no confirmed
+/// production trigger in a 90-day search).
+@Suite("AFMGenerationSentryError Sentry stable identity (#1525 PR I-B)")
+struct AFMGenerationSentryErrorTests {
+
+  private static let env = "production"
+  private static let category = SentryBreadcrumb.ErrorCategory.generationFailed
+
+  private static let pins: [(AFMGenerationSentryError, String, String)] = [
+    (
+      .assetsUnavailable("x"), "FoundationModels.LanguageModelSession.GenerationError#1",
+      "afm.assets_unavailable"
+    ),
+    (
+      .guardrailViolation("x"), "FoundationModels.LanguageModelSession.GenerationError#2",
+      "afm.guardrail_violation"
+    ),
+    (
+      .unsupportedGuide("x"), "FoundationModels.LanguageModelSession.GenerationError#3",
+      "afm.unsupported_guide"
+    ),
+    (
+      .unsupportedLanguageOrLocale("x"), "FoundationModels.LanguageModelSession.GenerationError#4",
+      "afm.unsupported_language_or_locale"
+    ),
+    (
+      .decodingFailure("x"), "FoundationModels.LanguageModelSession.GenerationError#5",
+      "afm.decoding_failure"
+    ),
+    (
+      .rateLimited("x"), "FoundationModels.LanguageModelSession.GenerationError#6",
+      "afm.rate_limited"
+    ),
+    (
+      .concurrentRequests("x"), "FoundationModels.LanguageModelSession.GenerationError#7",
+      "afm.concurrent_requests"
+    ),
+    (.refusal("x"), "FoundationModels.LanguageModelSession.GenerationError#8", "afm.refusal"),
+    (
+      .unknownFutureCase("x"), "EnviousWisprLLM.AFMGenerationSentryError.unknownFutureCase",
+      "afm.unknown_future_case"
+    ),
+  ]
+
+  // MARK: - A. Pin lock
+
+  @Test("every case keeps its exact measured/pinned fingerprint")
+  func pinLock() {
+    for (error, descriptor, semanticID) in Self.pins {
+      #expect(SentryBreadcrumb.structuredDescriptor(error) == descriptor)
+      #expect(error.sentrySemanticID == semanticID)
+    }
+  }
+
+  @Test("all 9 declared identities are unique")
+  func identitiesAreUnique() {
+    let errors = Self.pins.map(\.0)
+    #expect(Set(errors.map(\.sentryFingerprintDescriptor)).count == 9)
+    #expect(Set(errors.map(\.sentrySemanticID)).count == 9)
+  }
+
+  // MARK: - B. Description preservation
+
+  @Test("errorDescription preserves the original error's description, never the fingerprint")
+  func errorDescriptionPreservesOriginalText() {
+    let error = AFMGenerationSentryError.unsupportedLanguageOrLocale(
+      "The requested language is not supported.")
+    #expect(error.errorDescription == "The requested language is not supported.")
+  }
+
+  #if canImport(FoundationModels)
+    // MARK: - C. Mapping completeness (macOS 26+ only — needs the real vendor type)
+
+    @available(macOS 26.0, *)
+    @Test(
+      "every real GenerationError case maps to its expected AFMGenerationSentryError case, preserving the description"
+    )
+    func mappingCompleteness() {
+      // GenerationError's errorDescription returns Apple's OWN fixed per-case
+      // message, NOT the Context's debugDescription — so the expected value is
+      // derived from each constructed vendor error's own localizedDescription,
+      // not a shared constant.
+      let ctx = LanguageModelSession.GenerationError.Context(debugDescription: "unused")
+      let refusal = LanguageModelSession.GenerationError.Refusal(transcriptEntries: [])
+      let vendorErrors: [LanguageModelSession.GenerationError] = [
+        .assetsUnavailable(ctx),
+        .guardrailViolation(ctx),
+        .unsupportedGuide(ctx),
+        .unsupportedLanguageOrLocale(ctx),
+        .decodingFailure(ctx),
+        .rateLimited(ctx),
+        .concurrentRequests(ctx),
+        .refusal(refusal, ctx),
+      ]
+      let expectedMappers: [(String) -> AFMGenerationSentryError] = [
+        { .assetsUnavailable($0) },
+        { .guardrailViolation($0) },
+        { .unsupportedGuide($0) },
+        { .unsupportedLanguageOrLocale($0) },
+        { .decodingFailure($0) },
+        { .rateLimited($0) },
+        { .concurrentRequests($0) },
+        { .refusal($0) },
+      ]
+      for (vendor, makeExpected) in zip(vendorErrors, expectedMappers) {
+        let expected = makeExpected(vendor.localizedDescription)
+        #expect(AFMGenerationSentryError(mapping: vendor) == expected)
+      }
+    }
+
+    @available(macOS 26.0, *)
+    @Test("exceededContextWindowSize maps to unknownFutureCase (unreachable in practice)")
+    func exceededContextWindowSizeMapsToUnknownFutureCase() {
+      let ctx = LanguageModelSession.GenerationError.Context(debugDescription: "x")
+      let mapped = AFMGenerationSentryError(mapping: .exceededContextWindowSize(ctx))
+      if case .unknownFutureCase = mapped {
+        // expected
+      } else {
+        Issue.record("expected .unknownFutureCase, got \(mapped)")
+      }
+    }
+  #endif
+
+  // MARK: - D. Event-construction contract (the confirmed-live case)
+
+  @MainActor
+  @Test(
+    "the confirmed-live .unsupportedLanguageOrLocale case's event carries the production fingerprint and identity tag"
+  )
+  func unsupportedLanguageOrLocaleEventShape() {
+    let error = AFMGenerationSentryError.unsupportedLanguageOrLocale("x")
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "polish", environment: Self.env)
+
+    #expect(
+      event.fingerprint
+        == [
+          "handled_error", "generation_failed",
+          "FoundationModels.LanguageModelSession.GenerationError#4", Self.env,
+        ])
+    #expect(event.tags?["error.identity"] == "afm.unsupported_language_or_locale")
+  }
+
+  @MainActor
+  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  func nonConformingErrorEventUnchanged() {
+    let error = NSError(domain: "EnviousWispr", code: -3)
+
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      error, category: Self.category, stage: "polish", environment: Self.env)
+
+    #expect(
+      event.fingerprint == ["handled_error", "generation_failed", "EnviousWispr#-3", Self.env])
+    #expect(event.tags?["error.identity"] == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -70,6 +70,43 @@ import Testing
     #expect(manager.loadModelCount == 0)
   }
 
+  // MARK: Stale-helper transport recovery (#1525 PR I-B)
+
+  @Test("warmUp() retries once and succeeds after XPCASRTransportError.serviceUnreachable")
+  func warmUpRetriesOnServiceUnreachable() async throws {
+    let manager = StubParakeetASRManager()
+    manager.loadModelError = XPCASRTransportError.serviceUnreachable
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    try await adapter.warmUp()
+    #expect(manager.loadModelCount == 2)
+    #expect(manager.isModelLoaded)
+  }
+
+  /// #1525 PR I-B narrowing-regression: `XPCASRTransportError`'s 6 new
+  /// codec/transport cases are NOT "the XPC service is unreachable" — a bare
+  /// `catch is XPCASRTransportError` would have retried a reload for, say,
+  /// `.requestDecodingFailed`, masking a real codec bug.
+  @Test(
+    "warmUp() does NOT retry on the new XPCASRTransportError cases — they propagate",
+    arguments: [
+      XPCASRTransportError.requestEncodingFailed("x"),
+      .invalidSamplePayload("x"),
+      .requestDecodingFailed("x"),
+      .modelNotLoaded,
+      .responseEncodingFailed("x"),
+      .responseDecodingFailed("x"),
+    ]
+  )
+  func warmUpDoesNotRetryOnNewTransportCases(error: XPCASRTransportError) async throws {
+    let manager = StubParakeetASRManager()
+    manager.loadModelError = error
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    await #expect(throws: XPCASRTransportError.self) {
+      try await adapter.warmUp()
+    }
+    #expect(manager.loadModelCount == 1)
+  }
+
   // MARK: Streaming finalize + batch rescue (§3.2a)
 
   @Test("finalize: streaming success returns the streaming transcript")
@@ -521,8 +558,17 @@ final class StubParakeetASRManager: ASRManagerInterface {
   // yield-polling (#875).
   private var finalizeStreamingWaiters = CountWaiters("finalizeStreamingCount")
 
+  /// #1525 PR I-B: when set, `loadModel()` throws it on the NEXT call only,
+  /// then clears itself — lets a test exercise `loadModelWithTransportRecovery`'s
+  /// one-shot retry (a retry that SUCCEEDS second time) without looping forever.
+  var loadModelError: (any Error)?
+
   func loadModel() async throws {
     loadModelCount += 1
+    if let error = loadModelError {
+      loadModelError = nil
+      throw error
+    }
     if gateLoadModel {
       await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in loadGate = c }
     }

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -365,6 +365,33 @@ struct RecoverySpoolReplayerTests {
       #expect(e.stringProps.values.allSatisfy { !$0.contains("serviceUnreachable") })
     }
 
+    /// #1525 PR I-B narrowing-regression: `XPCASRTransportError`'s 6 new
+    /// codec/transport cases are NOT "XPC unreachable" — a bare `is
+    /// XPCASRTransportError` type-check would have misclassified them,
+    /// corrupting recovery telemetry.
+    @Test(
+      "the new XPCASRTransportError cases classify as .other, not .xpcUnreachable",
+      arguments: [
+        XPCASRTransportError.requestEncodingFailed("x"),
+        .invalidSamplePayload("x"),
+        .requestDecodingFailed("x"),
+        .modelNotLoaded,
+        .responseEncodingFailed("x"),
+        .responseDecodingFailed("x"),
+      ]
+    )
+    func telemetryNewTransportCasesClassifyAsOther(error: XPCASRTransportError) async throws {
+      let h = Self.makeHarness()
+      let id = "tel-xpc-new-\(UUID().uuidString)"
+      try await Self.seedSpool(h, id: id, samples: [0.1, 0.2, 0.3])
+      h.asr.transcribeError = error
+      let box = await Self.capturingTelemetry {
+        _ = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+      }
+      let e = try #require(box.recoveryEvents().first)
+      #expect(e.stringProps["failure_class"] == "other")
+    }
+
     @Test("deferred (attempt-marker write failed) emits marker_write_failed")
     func telemetryDeferredEmitsMarkerWriteFailed() async throws {
       // A spool dir whose PARENT is a regular FILE: the store's re-enforced mkdir is a

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -9,7 +9,8 @@
 #   EnviousWisprAppKit     -> Core, Storage, PostProcessing, Audio, Services, ASR, LLM, Pipeline, Contacts (app-shell library; #919, top of stack)
 #   EnviousWisprASRService -> Core, ASR, Audio, ObservabilityCore (XPC executable; the audio capture XPC service was removed at #1543)
 #   EnviousWisprPipeline   -> Core, ASR, Audio, LLM, PostProcessing, Services, Storage
-#   EnviousWisprASR        -> Core, Audio
+#   EnviousWisprASR        -> Core, Audio, FluidAudioBridge
+#   EnviousWisprFluidAudioBridge -> (no app deps; internal FluidAudio vendor-error classifier leaf; #1525 PR I-B)
 #   EnviousWisprServices   -> Core, ObservabilityCore
 #   EnviousWisprLLM        -> Core, ModelDelivery
 #   EnviousWisprAudio      -> Core
@@ -30,7 +31,8 @@ permitted_imports_for() {
     EnviousWisprCore)              echo "" ;;
     EnviousWisprObservabilityCore) echo "" ;;
     EnviousWisprAudio)             echo "EnviousWisprCore" ;;
-    EnviousWisprASR)               echo "EnviousWisprCore EnviousWisprAudio" ;;
+    EnviousWisprFluidAudioBridge)  echo "" ;;
+    EnviousWisprASR)               echo "EnviousWisprCore EnviousWisprAudio EnviousWisprFluidAudioBridge" ;;
     EnviousWisprPostProcessing)    echo "EnviousWisprCore" ;;
     EnviousWisprContacts)          echo "EnviousWisprCore" ;;
     EnviousWisprStorage)           echo "EnviousWisprCore" ;;


### PR DESCRIPTION
## Summary
- PR I-B of the #1525 Sentry stable-error-identity migration mini-ladder (I-A and I-C shipped).
- Five concern-specific `StableSentryErrorIdentity` conformers replace raw, ordinal-derived NSError bridging across the AFM/ASR boundary:
  - `AFMGenerationSentryError`: pins Apple `FoundationModels.LanguageModelSession.GenerationError`'s 8 non-context-window cases. Preserves live production issue ENVIOUSWISPR-2J (`.unsupportedLanguageOrLocale`).
  - `WhisperKitModelLoadSentryError`: normalizes `WhisperKitBackend.performLoad`'s raw model-load throw.
  - New internal target `EnviousWisprFluidAudioBridge` (package visibility, no library product): isolates FluidAudio's raw error classification behind name-collision-free values, since FluidAudio exports a struct literally named `FluidAudio` that shadows module-qualified lookup inside `EnviousWisprASR`.
  - `ParakeetTranscriptionSentryError` + `ParakeetModelLoadSentryError`: normalize both of `ParakeetBackend`'s raw-error producers.
  - `XPCASRTransportError` (PR G) widened from 1 case to 7: every XPC/codec transport failure as its own concern, distinct from "the ASR backend failed to transcribe." Preserves live production issue ENVIOUSWISPR-3S (`.modelNotLoaded`). Two existing consumers narrowed to `.isServiceUnreachable` so the new cases aren't misclassified.
- 12 rounds of Codex grounded review converged this plan, including catching the review-baseline branch sitting one commit behind sibling PR I-A (fixed by fast-forwarding, not rewording).
- Local `codex review` (post-commit) found the streaming XPC paths (`startStreaming`/`finalizeStreaming`) still emitted raw errors — fixed in the same PR by reusing the already-pinned cases plus adding client-side reconstruction.

## Test plan
- [x] `scripts/xcode-test.sh` — 3188 tests, 0 failures, exit 0 (run twice: once before, once after the streaming-XPC fix).
- [x] `scripts/check-dependency-direction.sh` — clean across 16 modules (new bridge target registered).
- [x] Local `codex review --base origin/main` — 2 rounds, both clean after the streaming-XPC fix landed.
- [x] `scripts/build-dev-app.sh` — build succeeded, dev app relaunched (3 times: initial, injection test, final clean state).
- [x] Live UAT — all 3 required checks pass:
  - AFM injection repro: DEBUG-only env-gated injection at the `GenerationError` mapping seam (reverted before final commit, `git diff` confirmed empty). Confirmed in Sentry: new development-environment issue **ENVIOUSWISPR-45** created with descriptor `FoundationModels.LanguageModelSession.GenerationError#4` and tag `error.identity: afm.unsupported_language_or_locale`. Production issue **ENVIOUSWISPR-2J** confirmed UNCHANGED (12 occurrences, 5 users, same last-seen 2026-07-13, both before and after).
  - Parakeet (XPC-backed) dictation: confirmed via app log, `backend=parakeet`, full pipeline completed (ASR→polish→paste).
  - WhisperKit (in-process) dictation: confirmed via app log, `backend=whisperKit`, full pipeline completed, content match PASS.

## Architecture DoD (REFACTOR tier — new SPM target + new dependency edge)
- New target `EnviousWisprFluidAudioBridge`: correct module placement (internal FluidAudio-vendor-error classification leaf), `package` visibility, no unnecessary library product.
- Dependency direction: `EnviousWisprASR -> EnviousWisprFluidAudioBridge` (downward edge, same direction as every other vendor-bridging dependency); `check-dependency-direction.sh` updated and passing.
- Raw dictation still completes when optional AFM/limb polish fails (confirmed via Live UAT: the AFM injection test still pasted the raw transcript successfully).
- No coordinator/central file absorbs new domain logic.

Part of #1525
