### PR TITLE
fix(worker): drop tier_a's redundant dev-exclusion subquery, degrade instead of failing the report

### DIFF
--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -118,6 +118,22 @@ Two independent signals, matching `workers/product-health`'s posture:
    (EnviousNotes) AND makes the worker return a non-2xx status, which turns
    the GitHub Actions job red. You will see BOTH the Discord notice and a
    GitHub Actions failure.
+
+   **One deliberate exception: `tier_a` degrades instead of failing (#1655).**
+   It is the polish-provider *settings* lookup, and `resolveBuckets` already
+   falls back per user (settings → actual dictation → shipped default), so an
+   empty `tier_a` still yields a complete breakdown. If it exhausts its retry
+   on a transient PostHog status (502/503/504), the report is still posted with
+   a note near the top: "today's polish-provider breakdown is approximate
+   because the settings lookup was temporarily unavailable." Read that note as
+   "this day's provider split leans on runtime signal rather than configured
+   choice," not as "the report is wrong."
+
+   This exception is scoped tightly. Only `tier_a`, and only on an exhausted
+   502/503/504 — an auth failure, a malformed query, a bad response shape, or
+   any ordinary programming error still fails the whole report loudly, because
+   a silently "approximate" report that hides a real defect is worse than no
+   report at all. Every other query remains fail-loud.
 2. **If Discord itself is unreachable/erroring**, the GitHub Actions job
    still goes red (the one failure mode with no Discord-side notice —
    GitHub's own failure-run email is the signal here).

--- a/workers/daily-report/live-query-smoke.mjs
+++ b/workers/daily-report/live-query-smoke.mjs
@@ -46,6 +46,7 @@ console.log({
   totalUsers: data.totalUsers,
   engineAndTierBRowCount: data.engineAndTierB.length,
   tierARowCount: data.tierA.length,
+  tierADegraded: data.tierADegraded, // true => tier-a exhausted its retry; breakdown is approximate (#1655)
   geo: data.geo,
   top5Counts: data.top5.map((u) => u.n), // values only, no distinct_id
 });

--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -160,27 +160,31 @@ function sqlIdList(ids) {
   return ids.map((id) => `'${String(id).replace(/'/g, "''")}'`).join(", ");
 }
 
-/** Polish tier-a: latest value across the UNION of settings.snapshot and
- * settings.changed{setting='llm_provider'}, bounded to a LITERAL list of
- * already-known active-user ids (plan §3.3 row 4, r2 precision fix) rather
- * than a re-evaluated subquery - the subquery form (distinct_id IN
- * (activeUsersSubquery)) repeated twice inside this UNION timed out (HTTP
- * 504) against production PostHog; the literal-list form is the exact
- * pattern already validated empirically during planning. */
+/** Polish tier-a: latest llm_provider across settings.snapshot and
+ * settings.changed, restricted to a literal list of already-known active-user
+ * ids (rather than a re-evaluated subquery, which timed out).
+ *
+ * Deliberately uses the production-environment predicate rather than full PROD.
+ * Every active id came from engineAndTierBSql, which already applied full PROD,
+ * including the whole-history dev-ID exclusion. Repeating that exclusion twice
+ * inside this UNION adds substantial work without changing results. Live A/B
+ * verification found identical provider attribution for all active users.
+ * This argument is local to tier-a; every other query keeps full PROD. */
 function tierASqlFor(activeIds, endTs) {
   const ids = sqlIdList(activeIds);
+  const envOnly = "properties.environment = 'production'";
   return `
     SELECT distinct_id, argMax(value, ts) AS provider
     FROM (
       SELECT distinct_id, properties.llm_provider AS value, timestamp AS ts
       FROM events
-      WHERE event = 'settings.snapshot' AND ${PROD}
+      WHERE event = 'settings.snapshot' AND ${envOnly}
         AND distinct_id IN (${ids})
         AND timestamp < '${endTs}'
       UNION ALL
       SELECT distinct_id, properties.to AS value, timestamp AS ts
       FROM events
-      WHERE event = 'settings.changed' AND properties.setting = 'llm_provider' AND ${PROD}
+      WHERE event = 'settings.changed' AND properties.setting = 'llm_provider' AND ${envOnly}
         AND distinct_id IN (${ids})
         AND timestamp < '${endTs}'
     )
@@ -201,6 +205,21 @@ function tierASqlFor(activeIds, endTs) {
 // this cannot produce a duplicate or confusing failure notice.
 const RETRYABLE_POSTHOG_STATUSES = new Set([502, 503, 504]);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Carries the query name and HTTP status alongside the message, so a caller
+ * can distinguish an exhausted transient failure (which tier-a is allowed to
+ * degrade on) from an auth failure, a malformed query, or a bad response
+ * shape (which must stay loud). Message text is unchanged from the plain
+ * Error it replaces - existing assertions and the production failure notice
+ * both depend on it (#1655). */
+export class PostHogQueryError extends Error {
+  constructor(queryName, status) {
+    super(`PostHog query ${queryName} HTTP ${status}`);
+    this.name = "PostHogQueryError";
+    this.queryName = queryName;
+    this.status = status;
+  }
+}
 
 export async function hogql(
   env,
@@ -247,7 +266,7 @@ export async function hogql(
     }
 
     if (attempt === 2 || !RETRYABLE_POSTHOG_STATUSES.has(status)) {
-      throw new Error(`PostHog query ${queryName} HTTP ${status}`);
+      throw new PostHogQueryError(queryName, status);
     }
     await sleepFn(retryDelayMs);
   }
@@ -282,7 +301,10 @@ function rowsToObjects(res) {
   });
 }
 
-export async function fetchReportData(env, win, endUTC) {
+// `hogqlOpts` forwards the same injection bag `hogql` already accepts, so tests
+// can drive the retry path without a real 1.5s delay per retry - the pattern
+// the hogql unit tests already use. Production passes nothing.
+export async function fetchReportData(env, win, endUTC, hogqlOpts = {}) {
   const endTs = sqlTimestamp(endUTC);
   const activeUsers = activeUsersSubquery(win);
 
@@ -347,20 +369,42 @@ export async function fetchReportData(env, win, endUTC) {
   // passing it to tier-a as a literal IN-list instead of a subquery.
   const [installs, onboardActivate, totals, engineAndTierB, geo, top5] = await runLimited(
     [
-      () => hogql(env, installsSql, "installs"),
-      () => hogql(env, onboardActivateSql, "onboard_activate"),
-      () => hogql(env, totalsSql, "totals"),
-      () => hogql(env, engineAndTierBSql, "engine_and_tier_b"),
-      () => hogql(env, geoSql, "geo"),
-      () => hogql(env, top5Sql, "top5"),
+      () => hogql(env, installsSql, "installs", hogqlOpts),
+      () => hogql(env, onboardActivateSql, "onboard_activate", hogqlOpts),
+      () => hogql(env, totalsSql, "totals", hogqlOpts),
+      () => hogql(env, engineAndTierBSql, "engine_and_tier_b", hogqlOpts),
+      () => hogql(env, geoSql, "geo", hogqlOpts),
+      () => hogql(env, top5Sql, "top5", hogqlOpts),
     ],
     2
   );
 
   const activeIds = (engineAndTierB.results || []).map((row) => row[0]);
-  const tierA = activeIds.length
-    ? await hogql(env, tierASqlFor(activeIds, endTs), "tier_a")
-    : { results: [], columns: [] };
+  // tier-a is an ENRICHMENT: resolveBuckets already falls back
+  // tierA -> tier_b_provider -> DEFAULT_PROVIDER per user, so an empty tier-a
+  // still yields a complete breakdown. A tier-a failure must therefore degrade
+  // that one attribution tier rather than discard an otherwise-complete report.
+  // On 2026-07-18 all six batched queries succeeded and were discarded because
+  // tier-a timed out (#1655).
+  //
+  // ONLY an exhausted retryable status degrades. Anything else - auth, bad SQL,
+  // a malformed response, a programming error - stays loud: a silently
+  // "approximate" report that hides a real defect is worse than no report.
+  let tierA = { results: [], columns: [] };
+  let tierADegraded = false;
+  if (activeIds.length) {
+    try {
+      tierA = await hogql(env, tierASqlFor(activeIds, endTs), "tier_a", hogqlOpts);
+    } catch (err) {
+      const isExpectedTransientFailure =
+        err instanceof PostHogQueryError &&
+        err.queryName === "tier_a" &&
+        RETRYABLE_POSTHOG_STATUSES.has(err.status);
+      if (!isExpectedTransientFailure) throw err;
+      tierADegraded = true;
+      console.log(`daily-report tier_a degraded after retries: HTTP ${err.status}`);
+    }
+  }
 
   return {
     freshInstalls: installs.results[0][0],
@@ -370,6 +414,7 @@ export async function fetchReportData(env, win, endUTC) {
     totalUsers: rowsToObjects(totals)[0]?.total_users ?? 0,
     engineAndTierB: rowsToObjects(engineAndTierB),
     tierA: rowsToObjects(tierA),
+    tierADegraded,
     geo: rowsToObjects(geo),
     top5: rowsToObjects(top5),
   };
@@ -453,6 +498,16 @@ function formatWeekdayDate(dateStr) {
 
 export function buildMessage(dateStr, data, buckets) {
   const lines = [`EnviousWispr Daily Report, ${formatWeekdayDate(dateStr)}`, ""];
+
+  // Near the TOP deliberately: the tail is truncated at 1990 chars below, so a
+  // note appended at the end could be silently cut off on exactly the busy days
+  // when the report is longest (#1655).
+  if (data.tierADegraded) {
+    lines.push(
+      "Note: today's polish-provider breakdown is approximate because the settings lookup was temporarily unavailable.",
+      ""
+    );
+  }
 
   lines.push(
     `New installs: ${data.freshInstalls}. People who finished setup today: ${data.onboarded}. Of those, ${data.activated} also dictated today.`,

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -8,6 +8,8 @@ import {
   buildMessage,
   hogql,
   runLimited,
+  fetchReportData,
+  PostHogQueryError,
 } from "../src/index.js";
 
 // ---- easternYesterdayWindowUTC ----
@@ -337,4 +339,174 @@ test("hogql: throws with the query name after exhausting retries on repeated 504
     /PostHog query engine_and_tier_b HTTP 504/
   );
   assert.equal(calls, 2, "expected exactly 2 attempts total");
+});
+
+// ---- tier-a fail-soft boundary (#1655) ----
+//
+// These MUST drive fetchReportData, not hogql in isolation: the defect they
+// guard against (a blanket catch silently swallowing real errors) lives in
+// fetchReportData's catch, so a test that only exercises hogql would pass even
+// with the guard broken. fetchReportData calls hogql without an injectable
+// fetchFn, so the mock is installed on globalThis.fetch and dispatches on the
+// query name the worker puts in the request body.
+
+/** Installs a global fetch that lets every batch query succeed and lets the
+ * caller decide what tier-a (or a named other query) does. Returns a restore fn. */
+function mockPostHog({ failQuery, failWith }) {
+  const realFetch = globalThis.fetch;
+  const seen = [];
+  globalThis.fetch = async (_url, init) => {
+    const name = JSON.parse(init.body).name; // "daily_report_<queryName>"
+    const queryName = name.replace(/^daily_report_/, "");
+    seen.push(queryName);
+    if (queryName === failQuery) {
+      if (failWith instanceof Error) throw failWith;
+      return fakeResponse(failWith);
+    }
+    // engine_and_tier_b must return a non-empty id list, or tier-a is skipped
+    // entirely and the degrade path is never reached.
+    if (queryName === "engine_and_tier_b") {
+      return fakeResponse(200, { results: [["u1", "parakeet", null]], columns: ["distinct_id", "engine", "tier_b_provider"] });
+    }
+    if (queryName === "tier_a") {
+      return fakeResponse(200, { results: [["u1", "openai"]], columns: ["distinct_id", "provider"] });
+    }
+    return fakeResponse(200, { results: [[0]], columns: ["c"] });
+  };
+  return { restore: () => (globalThis.fetch = realFetch), seen };
+}
+
+const TEST_ENV = { POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" };
+const TEST_WIN = "timestamp >= '2026-07-17 04:00:00' AND timestamp < '2026-07-18 04:00:00'";
+const TEST_END = new Date("2026-07-18T04:00:00Z");
+
+test("tier-a: an exhausted 504 degrades instead of failing the whole report", async () => {
+  const mock = mockPostHog({ failQuery: "tier_a", failWith: 504 });
+  try {
+    const data = await fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} });
+    assert.equal(data.tierADegraded, true, "expected the degraded flag to be set");
+    assert.deepEqual(data.tierA, [], "expected tier-a to fall back to empty rows");
+    // The report itself must still be intact - this is the whole point.
+    assert.equal(data.engineAndTierB.length, 1, "the successful batch data must survive");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("tier-a: 502 and 503 also degrade (the note wording covers all three)", async () => {
+  for (const status of [502, 503]) {
+    const mock = mockPostHog({ failQuery: "tier_a", failWith: status });
+    try {
+      const data = await fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} });
+      assert.equal(data.tierADegraded, true, `expected HTTP ${status} to degrade`);
+    } finally {
+      mock.restore();
+    }
+  }
+});
+
+test("tier-a: a NON-retryable HTTP failure still throws (no silent swallow)", async () => {
+  const mock = mockPostHog({ failQuery: "tier_a", failWith: 401 });
+  try {
+    await assert.rejects(
+      () => fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} }),
+      (err) => {
+        assert.ok(err instanceof PostHogQueryError, "expected the original structured error");
+        assert.equal(err.status, 401);
+        return true;
+      },
+      "an auth failure must NOT be disguised as an approximate report"
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test("tier-a: an ordinary Error still throws (no silent swallow)", async () => {
+  const boom = new TypeError("undefined is not a function");
+  const mock = mockPostHog({ failQuery: "tier_a", failWith: boom });
+  try {
+    await assert.rejects(
+      () => fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} }),
+      (err) => {
+        assert.equal(err, boom, "expected the ORIGINAL error, unwrapped and unswallowed");
+        return true;
+      },
+      "a programming error must NOT be disguised as an approximate report"
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test("a failure in a query OTHER than tier-a still fails the whole report", async () => {
+  const mock = mockPostHog({ failQuery: "totals", failWith: 504 });
+  try {
+    await assert.rejects(
+      () => fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} }),
+      /PostHog query totals HTTP 504/,
+      "fail-soft is scoped to tier-a only"
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test("a clean run leaves tierADegraded false", async () => {
+  const mock = mockPostHog({ failQuery: null });
+  try {
+    const data = await fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} });
+    assert.equal(data.tierADegraded, false);
+    assert.equal(data.tierA.length, 1);
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---- degraded note placement (#1655) ----
+
+test("degraded note appears near the top, above the truncation point", () => {
+  // A long report: enough geo/top5 volume to push the tail past the 1990-char
+  // cap, proving the note survives exactly when it matters most.
+  const data = {
+    ...GOLDEN_DATA,
+    tierADegraded: true,
+    geo: Array.from({ length: 60 }, (_, i) => ({ country: `Country-With-A-Long-Name-${i}`, n: i })),
+  };
+  const msg = buildMessage("2026-07-17", data, GOLDEN_BUCKETS);
+
+  assert.match(msg, /polish-provider breakdown is approximate/);
+  assert.ok(msg.length <= 1990, "message must respect the Discord cap");
+  const noteIndex = msg.indexOf("Note: today's polish-provider breakdown");
+  assert.ok(noteIndex >= 0 && noteIndex < 200, `note must be near the top, was at ${noteIndex}`);
+});
+
+test("no degraded note on a clean run", () => {
+  const msg = buildMessage("2026-07-17", { ...GOLDEN_DATA, tierADegraded: false }, GOLDEN_BUCKETS);
+  assert.doesNotMatch(msg, /approximate/);
+});
+
+// ---- load-bearing coupling guard (#1655) ----
+//
+// tier-a may omit PROD's dev-ID exclusion ONLY because activeIds already came
+// from a full-PROD query. If a future edit breaks that coupling, the omission
+// silently becomes a correctness bug rather than a redundancy removal.
+
+test("source guardrail: tier-a may omit dev exclusion only while active ids come from full PROD", async () => {
+  const fs = await import("node:fs");
+  const src = fs.readFileSync(new URL("../src/index.js", import.meta.url), "utf8");
+
+  const engineQuery = src.match(/const engineAndTierBSql = `([\s\S]*?)`;/)?.[1];
+  assert.ok(engineQuery, "expected engineAndTierBSql");
+  assert.match(engineQuery, /\$\{PROD\}/);
+
+  const tierAFunction = src.match(/function tierASqlFor\([\s\S]*?\n}\n/)?.[0];
+  assert.ok(tierAFunction, "expected tierASqlFor");
+  assert.match(tierAFunction, /properties\.environment = 'production'/);
+  assert.doesNotMatch(tierAFunction, /\$\{PROD\}/);
+  assert.equal(
+    (tierAFunction.match(/distinct_id IN \(\$\{ids\}\)/g) || []).length,
+    2,
+    "both tier-a UNION branches must remain restricted to the pre-filtered active-id list"
+  );
 });


### PR DESCRIPTION
Part of #1655

## Why #1588 didn't stick

#1588 capped our query concurrency and shipped correctly (Cloudflare version
`a2cae379`, `2026-07-17T14:58:28Z`). The very next scheduled run still failed on
`tier_a`.

It could never have helped: `tier_a` runs sequentially **after**
`await runLimited(...)` resolves, so it was never in the oversubscribed batch.
Reproducing the 504 with `tier_a` running **alone** confirms the cause is
per-query cost, not our request volume. (Shared-project contention with
EnviousStaging remains possible and is not something we control — reducing this
query's cost is our available lever against both.)

## Root cause

`PROD` embeds an unbounded dev-exclusion subquery, and `tierASqlFor`
interpolated it into **both** branches of a `UNION ALL` — the anti-pattern
already documented for this worker. #1449 resolved the *active-user* subquery
to a literal id list but left the *dev-exclusion* subquery duplicated. The
documented root cause was half-fixed, and the code comment read as though it
were fully fixed.

The exclusion is redundant here: every id in the literal `IN (...)` list came
from `engineAndTierBSql`, which already applied full `PROD`.

## Measured (live production, interleaved A/B, 6 rounds each)

| Shape | median | max | 504s |
|---|---|---|---|
| Before | 5.97s | 11.18s | 1/6 |
| After | ~2.6-3.2s | 3.00s | 0/6 |

Verified **result-identical** by capturing the SQL the shipped code actually
builds, running it against production, and diffing: 57/57 users, 0 missing,
0 changed.

**No time bound**, deliberately. Measured gain was ~0.44s and it risks
attribution drift if a snapshot is ever missing. Not worth it.

## Second defect: failure was total

A `tier_a` timeout discarded six already-successful queries. `resolveBuckets`
already falls back per user (settings → actual dictation → shipped default), so
an empty `tier_a` still yields a complete breakdown.

`tier_a` now degrades on an **exhausted 502/503/504 only**, via a structured
`PostHogQueryError`. Auth failures, bad SQL, malformed responses, and ordinary
programming errors still fail the whole report loudly — a silently "approximate"
report that hides a real defect is worse than no report. Every other query stays
fail-loud.

The degraded note sits near the **top**: `buildMessage` truncates the tail at
1990 chars, so an appended note would be cut off on exactly the busy days when
the report is longest.

## Tests: 23 → 32

New tests drive `fetchReportData`, **not** `hogql` in isolation — the guard
lives in `fetchReportData`'s catch, so a hogql-only test would pass with it
broken. Covers: 504/502/503 degrade; non-retryable 401 still throws; an ordinary
`Error` still throws; a non-tier_a failure still fails the report; note
placement above the truncation point.

Adds a source-scanning test locking the coupling the whole redundancy argument
rests on: `tier_a` may omit the dev exclusion **only** while `activeIds` come
from a full-`PROD` query.

Also: tests inject a no-op sleep (the pattern the existing `hogql` tests use),
cutting the suite from 6.1s to 80ms.

## Also updated

- README failure-visibility section — it claimed any query failure fails the
  report, no longer true.
- `live-query-smoke.mjs` surfaces `tierADegraded`.

## Review

- Grounded review: 3 rounds → PROCEED-AS-PLANNED
- Code-diff review: clean, no actionable bugs
- Out of scope: #1589 (sibling workers have the same shapes)

## Blast radius

Worker-only. No app code, no user-facing surface, no release path.
