### PR TITLE
feat(user): Custom Words import sheet shell with DEBUG-only entry (PR-F1, #1657)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Navigation state for the Custom Words import sheet (#1657, epic #1619 PR-F1).
+///
+/// The shell every import source plugs into: it owns only which screen the
+/// sheet shows and which method the user picked. No source adapters, no
+/// compare logic, no persistence, no telemetry — those arrive in later PRs
+/// (F2a compare, F2b commit, F2c review UI, then the real sources), which
+/// drive `showReview()` / `beginWork(_:)` / `showResult(_:)` from real work.
+/// In F1 those transitions are exercised by tests and the DEBUG-only
+/// "Preview import" fixture walk.
+///
+/// Invariant: `selectedMethod` is non-nil exactly while a method's flow is
+/// active; returning to `.methodPicker` (via `goBack()` or `reset()`) clears it.
+@MainActor @Observable
+final class CustomWordsImportFlowModel {
+  enum Step: Equatable {
+    case methodPicker
+    case paste
+    case upload
+    case smartImportAppPicker
+    case review
+    case working(Work)
+    case result(Result)
+  }
+
+  enum Work: Equatable {
+    case loadingCandidates
+    case comparing
+    case committing
+  }
+
+  enum Result: Equatable {
+    case completed(added: Int, replaced: Int)
+    case nothingFound
+    case failed(message: String)
+  }
+
+  enum Method: String, CaseIterable, Identifiable, Sendable {
+    case paste
+    case upload
+    case smartImport
+
+    var id: Self { self }
+
+    /// The input screen this method starts on.
+    var inputStep: Step {
+      switch self {
+      case .paste: return .paste
+      case .upload: return .upload
+      case .smartImport: return .smartImportAppPicker
+      }
+    }
+  }
+
+  private(set) var step: Step = .methodPicker
+  private(set) var selectedMethod: Method?
+
+  /// True exactly where `goBack()` does something — the three input screens
+  /// and review. The sheet's Back button reads this instead of keeping its
+  /// own copy of the per-screen table.
+  var canGoBack: Bool {
+    switch step {
+    case .paste, .upload, .smartImportAppPicker, .review: return true
+    case .methodPicker, .working, .result: return false
+    }
+  }
+
+  /// Method picker → the picked method's input screen. Ignored anywhere else:
+  /// picking a method is only meaningful on the picker.
+  func select(_ method: Method) {
+    guard step == .methodPicker else { return }
+    selectedMethod = method
+    step = method.inputStep
+  }
+
+  /// An input screen or an in-flight working step → review. Ignored until a
+  /// method is selected, so `.review` can always answer "back to where?".
+  func showReview() {
+    guard selectedMethod != nil else { return }
+    switch step {
+    case .paste, .upload, .smartImportAppPicker, .working:
+      step = .review
+    case .methodPicker, .review, .result:
+      break
+    }
+  }
+
+  /// An input screen, review, or another working phase → `.working(work)`.
+  /// Ignored on the picker (no method context) and on a result (terminal).
+  func beginWork(_ work: Work) {
+    switch step {
+    case .paste, .upload, .smartImportAppPicker, .review, .working:
+      step = .working(work)
+    case .methodPicker, .result:
+      break
+    }
+  }
+
+  /// A working step → its terminal result. Results only ever come out of
+  /// work, so this is ignored on every other screen.
+  func showResult(_ result: Result) {
+    guard case .working = step else { return }
+    step = .result(result)
+  }
+
+  /// Explicit per-screen table (adopted plan, PR-F1):
+  /// input screens → `.methodPicker`; `.review` → the selected method's input
+  /// screen; `.working` → no-op (Back is disabled); `.result` → no-op (no
+  /// Back, Done dismisses); `.methodPicker` → no-op.
+  func goBack() {
+    switch step {
+    case .paste, .upload, .smartImportAppPicker:
+      selectedMethod = nil
+      step = .methodPicker
+    case .review:
+      // `showReview()` guarantees a selected method, but stay deterministic
+      // rather than trap if a future caller breaks that assumption.
+      step = selectedMethod?.inputStep ?? .methodPicker
+    case .methodPicker, .working, .result:
+      break
+    }
+  }
+
+  /// Fresh model state: back to the picker with no method selected.
+  func reset() {
+    selectedMethod = nil
+    step = .methodPicker
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -1,0 +1,292 @@
+import SwiftUI
+
+/// The Custom Words import sheet shell (#1657, epic #1619 PR-F1).
+///
+/// One observable model, one root `switch`, one container-level `.animation()`
+/// — the `OnboardingV2View` root-switch pattern without its timers or
+/// permissions logic. Every screen below the method picker is a fixture
+/// placeholder until the real pieces land (F2c wires review/commit; P1/U1/4a
+/// bring real inputs); the sheet is reachable only through the DEBUG-only
+/// "Preview import" button in Your Words, so no release user can see these
+/// placeholders. Deliberately zero `Task`, adapters, compare logic, manager
+/// calls, telemetry, or persistence — dismissing at any point discards the
+/// model and touches nothing.
+struct CustomWordsImportSheet: View {
+  private static let screenTransition: AnyTransition = .asymmetric(
+    insertion: .opacity.combined(with: .offset(y: 20)),
+    removal: .opacity
+  )
+
+  @State private var model = CustomWordsImportFlowModel()
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      header
+
+      ZStack {
+        switch model.step {
+        case .methodPicker:
+          ImportMethodPickerScreen(model: model)
+            .transition(Self.screenTransition)
+        case .paste:
+          ImportPlaceholderScreen(
+            notice: "Paste import arrives with a later update.",
+            model: model
+          )
+          .transition(Self.screenTransition)
+        case .upload:
+          ImportPlaceholderScreen(
+            notice: "File import arrives with a later update.",
+            model: model
+          )
+          .transition(Self.screenTransition)
+        case .smartImportAppPicker:
+          ImportPlaceholderScreen(
+            notice: "Importing from other apps arrives with a later update.",
+            model: model
+          )
+          .transition(Self.screenTransition)
+        case .review:
+          ImportReviewPlaceholderScreen(model: model)
+            .transition(Self.screenTransition)
+        case .working(let work):
+          ImportWorkingScreen(work: work, model: model)
+            .transition(Self.screenTransition)
+        case .result(let result):
+          ImportResultScreen(result: result)
+            .transition(Self.screenTransition)
+        }
+      }
+      .animation(.easeInOut(duration: 0.25), value: model.step)
+
+      footer
+    }
+    .padding(24)
+    .frame(width: 480)
+  }
+
+  private var header: some View {
+    HStack(spacing: 8) {
+      if model.canGoBack {
+        Button("Back") { model.goBack() }
+      }
+      Text(title)
+        .font(.title3)
+        .bold()
+      Spacer(minLength: 0)
+    }
+  }
+
+  @ViewBuilder
+  private var footer: some View {
+    HStack {
+      Spacer()
+      if case .result = model.step {
+        Button("Done") { dismiss() }
+          .keyboardShortcut(.defaultAction)
+          .buttonStyle(.borderedProminent)
+      } else {
+        Button("Cancel") { dismiss() }
+          .keyboardShortcut(.cancelAction)
+      }
+    }
+  }
+
+  private var title: String {
+    switch model.step {
+    case .methodPicker: return "Import words"
+    case .paste: return "Paste words"
+    case .upload: return "Upload a file"
+    case .smartImportAppPicker: return "From another app"
+    case .review: return "Review & Merge"
+    case .working(.loadingCandidates): return "Finding words"
+    case .working(.comparing): return "Checking your list"
+    case .working(.committing): return "Saving"
+    case .result(.completed): return "Import complete"
+    case .result(.nothingFound): return "Nothing to import"
+    case .result(.failed): return "Import didn't finish"
+    }
+  }
+}
+
+// MARK: - Method picker
+
+private struct ImportMethodPickerScreen: View {
+  let model: CustomWordsImportFlowModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("Bring your words in from anywhere. Nothing is added until you review it.")
+        .settingsReadingCopy()
+
+      ImportMethodCard(
+        icon: "doc.on.clipboard",
+        title: "Paste words",
+        subtitle: "Paste a list of words from anywhere."
+      ) {
+        model.select(.paste)
+      }
+      ImportMethodCard(
+        icon: "square.and.arrow.down",
+        title: "Upload a file",
+        subtitle: "Import a backup or a spreadsheet of words."
+      ) {
+        model.select(.upload)
+      }
+      ImportMethodCard(
+        icon: "sparkles",
+        title: "From another app",
+        subtitle: "Bring your dictionary over from another dictation app."
+      ) {
+        model.select(.smartImport)
+      }
+    }
+  }
+}
+
+private struct ImportMethodCard: View {
+  let icon: String
+  let title: String
+  let subtitle: String
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(alignment: .top, spacing: 11) {
+        SettingsRowIcon(systemName: icon)
+        VStack(alignment: .leading, spacing: 3) {
+          Text(title)
+            .font(.stRowLabel)
+            .foregroundStyle(.stTextPrimary)
+          Text(subtitle)
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+        }
+        Spacer(minLength: 0)
+        Image(systemName: "chevron.right")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.stTextTertiary)
+          .accessibilityHidden(true)
+      }
+      .padding(.horizontal, 14)
+      .padding(.vertical, 12)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 10))
+      .overlay(
+        RoundedRectangle(cornerRadius: 10).strokeBorder(Color.stDivider, lineWidth: 1)
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("\(title). \(subtitle)")
+  }
+}
+
+// MARK: - Fixture placeholders (replaced wholesale by later PRs)
+
+/// Shared placeholder for the three input screens. The "Preview" button walks
+/// the fixture flow the way the real source will: input → working → review.
+private struct ImportPlaceholderScreen: View {
+  let notice: String
+  let model: CustomWordsImportFlowModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      InsetNotice(text: notice)
+      Button("Preview finding words") {
+        model.beginWork(.loadingCandidates)
+      }
+    }
+  }
+}
+
+private struct ImportReviewPlaceholderScreen: View {
+  let model: CustomWordsImportFlowModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      InsetNotice(text: "Review & Merge arrives with the compare engine.")
+      Button("Preview saving") {
+        model.beginWork(.committing)
+      }
+    }
+  }
+}
+
+private struct ImportWorkingScreen: View {
+  let work: CustomWordsImportFlowModel.Work
+  let model: CustomWordsImportFlowModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(spacing: 10) {
+        ProgressView()
+          .controlSize(.small)
+        Text(label)
+          .settingsReadingCopy()
+      }
+
+      // Fixture-walk controls: real work drives these transitions from F2c on.
+      VStack(alignment: .leading, spacing: 8) {
+        Button("Preview review") { model.showReview() }
+        Button("Preview success") { model.showResult(.completed(added: 3, replaced: 1)) }
+        Button("Preview nothing found") { model.showResult(.nothingFound) }
+        Button("Preview failure") {
+          model.showResult(.failed(message: "We found their data, but couldn't read it this time."))
+        }
+      }
+    }
+  }
+
+  private var label: String {
+    switch work {
+    case .loadingCandidates: return "Looking for words to import."
+    case .comparing: return "Comparing against your existing words."
+    case .committing: return "Saving your approved changes."
+    }
+  }
+}
+
+private struct ImportResultScreen: View {
+  let result: CustomWordsImportFlowModel.Result
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      Image(systemName: icon)
+        .font(.system(size: 14, weight: .medium))
+        .foregroundStyle(tint)
+        .accessibilityHidden(true)
+      Text(message)
+        .settingsReadingCopy()
+      Spacer(minLength: 0)
+    }
+  }
+
+  private var icon: String {
+    switch result {
+    case .completed: return "checkmark.circle.fill"
+    case .nothingFound: return "info.circle"
+    case .failed: return "exclamationmark.triangle"
+    }
+  }
+
+  private var tint: Color {
+    switch result {
+    case .completed: return .stSuccess
+    case .nothingFound: return .stAccent
+    case .failed: return .stWarning
+    }
+  }
+
+  private var message: String {
+    switch result {
+    case .completed(let added, let replaced):
+      return "Added \(added), replaced \(replaced). Your words are ready to use."
+    case .nothingFound:
+      return "No new words were found, and nothing was changed."
+    case .failed(let message):
+      return message
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -3,6 +3,15 @@ import EnviousWisprPostProcessing
 import EnviousWisprServices
 import SwiftUI
 
+/// Which sheet Your Words is presenting (#1657): the Add-term editor or the
+/// Custom Words import shell. One route + `.sheet(item:)` because the view
+/// now presents two different sheets.
+private enum YourWordsSheetRoute: String, Identifiable {
+  case addTerm
+  case importWords
+  var id: Self { self }
+}
+
 /// Phase 4 (#634) — Your Words settings tab. Replaces the monolithic
 /// `WordFixSettingsView` with a 3-section hub matching the founder-approved
 /// 2026-05-04 mockup. Bible §10.
@@ -14,7 +23,7 @@ import SwiftUI
 struct YourWordsView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
-  @State private var addingNewTerm = false
+  @State private var sheetRoute: YourWordsSheetRoute?
 
   var body: some View {
     @Bindable var settings = settings
@@ -30,10 +39,20 @@ struct YourWordsView: View {
       HStack {
         Spacer()
         Button {
-          addingNewTerm = true
+          sheetRoute = .addTerm
         } label: {
           Label("Add term", systemImage: "plus")
         }
+        #if DEBUG
+          // Import shell fixture walk (#1657). DEBUG-only until a real import
+          // source ships — a release-visible entry whose screens only show
+          // fixtures would ship a broken promise.
+          Button {
+            sheetRoute = .importWords
+          } label: {
+            Label("Preview import", systemImage: "square.and.arrow.down")
+          }
+        #endif
       }
 
       // Master toggle (preserves the Enable custom words switch from the old view)
@@ -59,21 +78,29 @@ struct YourWordsView: View {
       VocabPacksSection()
       CustomTermsSection()
     }
-    .sheet(isPresented: $addingNewTerm) {
-      CustomWordEditSheet(
-        word: CustomWord(canonical: ""),
-        wordSuggestionService: customWordsCoordinator.suggestionService
-      ) { newWord in
-        let trimmedCanonical = newWord.canonical.trimmingCharacters(in: .whitespaces)
-        guard !trimmedCanonical.isEmpty else { return nil }
-        var wordToSave = newWord
-        wordToSave.canonical = trimmedCanonical
-        if let error = customWordsCoordinator.add(wordToSave) {
-          return error
-        }
-        return nil
+    .sheet(item: $sheetRoute) { route in
+      switch route {
+      case .addTerm:
+        CustomWordEditSheet(
+          word: CustomWord(canonical: ""),
+          wordSuggestionService: customWordsCoordinator.suggestionService,
+          onSave: saveNewWord
+        )
+      case .importWords:
+        CustomWordsImportSheet()
       }
     }
+  }
+
+  private func saveNewWord(_ newWord: CustomWord) -> String? {
+    let trimmedCanonical = newWord.canonical.trimmingCharacters(in: .whitespaces)
+    guard !trimmedCanonical.isEmpty else { return nil }
+    var wordToSave = newWord
+    wordToSave.canonical = trimmedCanonical
+    if let error = customWordsCoordinator.add(wordToSave) {
+      return error
+    }
+    return nil
   }
 }
 

--- a/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
@@ -1,0 +1,159 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Unit tests for `CustomWordsImportFlowModel` (#1657, epic #1619 PR-F1).
+/// Pure navigation-state coverage: the model owns no work, no persistence,
+/// and no DEBUG-only members, so Release test builds instantiate it directly.
+@MainActor
+@Suite("CustomWordsImportFlowModel")
+struct CustomWordsImportFlowModelTests {
+  typealias Model = CustomWordsImportFlowModel
+
+  // Literal fixture arrays: `arguments:` collections are evaluated outside
+  // actor isolation, so they must not touch MainActor-isolated statics
+  // (swift-testing-patterns.md, mainactor-arguments rule).
+  nonisolated static let methodCases: [(Model.Method, Model.Step)] = [
+    (.paste, .paste),
+    (.upload, .upload),
+    (.smartImport, .smartImportAppPicker),
+  ]
+  nonisolated static let workCases: [Model.Work] = [
+    .loadingCandidates, .comparing, .committing,
+  ]
+
+  @Test("initial step is the method picker with nothing selected")
+  func initialStepIsMethodPicker() {
+    let model = Model()
+    #expect(model.step == .methodPicker)
+    #expect(model.selectedMethod == nil)
+    #expect(model.canGoBack == false)
+  }
+
+  @Test("select moves to the method's input screen and records the method", arguments: methodCases)
+  func selectMovesToInputAndRecordsMethod(method: Model.Method, inputStep: Model.Step) {
+    let model = Model()
+    model.select(method)
+    #expect(model.step == inputStep)
+    #expect(model.selectedMethod == method)
+    #expect(model.canGoBack == true)
+  }
+
+  @Test("select away from the picker is ignored")
+  func selectAwayFromPickerIsIgnored() {
+    let model = Model()
+    model.select(.paste)
+    model.select(.upload)
+    #expect(model.step == .paste)
+    #expect(model.selectedMethod == .paste)
+  }
+
+  @Test("back from an input screen returns to the method picker", arguments: methodCases)
+  func backFromInputReturnsToMethodPicker(method: Model.Method, inputStep: Model.Step) {
+    let model = Model()
+    model.select(method)
+    #expect(model.step == inputStep)
+    model.goBack()
+    #expect(model.step == .methodPicker)
+    #expect(model.selectedMethod == nil)
+  }
+
+  @Test("back from review returns to the selected method's input screen", arguments: methodCases)
+  func backFromReviewReturnsToSelectedInput(method: Model.Method, inputStep: Model.Step) {
+    let model = Model()
+    model.select(method)
+    model.showReview()
+    #expect(model.step == .review)
+    #expect(model.canGoBack == true)
+    model.goBack()
+    #expect(model.step == inputStep)
+    #expect(model.selectedMethod == method)
+  }
+
+  @Test("back while working is ignored", arguments: workCases)
+  func backWhileWorkingIsIgnored(work: Model.Work) {
+    let model = Model()
+    model.select(.paste)
+    model.beginWork(work)
+    #expect(model.canGoBack == false)
+    model.goBack()
+    #expect(model.step == .working(work))
+    #expect(model.selectedMethod == .paste)
+  }
+
+  @Test("back on a result is ignored: Done dismisses, there is no Back")
+  func backOnResultIsIgnored() {
+    let model = Model()
+    model.select(.paste)
+    model.beginWork(.committing)
+    model.showResult(.nothingFound)
+    #expect(model.canGoBack == false)
+    model.goBack()
+    #expect(model.step == .result(.nothingFound))
+  }
+
+  @Test("reset clears the selected method and returns to the picker")
+  func resetClearsSelectedMethodAndReturnsToPicker() {
+    let model = Model()
+    model.select(.upload)
+    model.showReview()
+    model.reset()
+    #expect(model.step == .methodPicker)
+    #expect(model.selectedMethod == nil)
+  }
+
+  @Test("show review before any method is selected is ignored")
+  func showReviewWithoutMethodIsIgnored() {
+    let model = Model()
+    model.showReview()
+    #expect(model.step == .methodPicker)
+  }
+
+  @Test("begin work is ignored on the picker and on a result")
+  func beginWorkIgnoredOnPickerAndResult() {
+    let model = Model()
+    model.beginWork(.loadingCandidates)
+    #expect(model.step == .methodPicker)
+
+    model.select(.paste)
+    model.beginWork(.committing)
+    model.showResult(.nothingFound)
+    model.beginWork(.loadingCandidates)
+    #expect(model.step == .result(.nothingFound))
+  }
+
+  @Test("show result outside a working step is ignored")
+  func showResultOutsideWorkingIsIgnored() {
+    let model = Model()
+    model.select(.paste)
+    model.showResult(.nothingFound)
+    #expect(model.step == .paste)
+  }
+
+  @Test("a completed result carries the added and replaced counts")
+  func resultCarriesAddedAndReplacedCounts() {
+    let model = Model()
+    model.select(.paste)
+    model.beginWork(.committing)
+    model.showResult(.completed(added: 3, replaced: 1))
+    #expect(model.step == .result(.completed(added: 3, replaced: 1)))
+    #expect(model.step != .result(.completed(added: 1, replaced: 3)))
+  }
+
+  @Test("nothing-found and failure remain distinct results")
+  func nothingFoundAndFailureRemainDistinctResults() {
+    let nothingFound = Model()
+    nothingFound.select(.paste)
+    nothingFound.beginWork(.loadingCandidates)
+    nothingFound.showResult(.nothingFound)
+
+    let failed = Model()
+    failed.select(.paste)
+    failed.beginWork(.loadingCandidates)
+    failed.showResult(.failed(message: "could not read the file"))
+
+    #expect(nothingFound.step == .result(.nothingFound))
+    #expect(failed.step == .result(.failed(message: "could not read the file")))
+    #expect(nothingFound.step != failed.step)
+  }
+}


### PR DESCRIPTION
Part of #1619 (PR-F1 in the adopted v5 plan). Closes #1657.

Tier: SMALL | Lane: Code | Modules: AppKit only

## What

The reusable multi-screen Custom Words import sheet and its navigation state — the shell every later import source (Paste, Upload, Smart Import) plugs into. No production import source, no persistence, no compare logic, no telemetry.

- `CustomWordsImportFlowModel` (`@MainActor @Observable`, `App/`): `Step` / `Work` / `Result` / `Method` exactly per the adopted plan; `select(_:)`, `goBack()` (explicit per-screen table), `reset()`. The model also exposes the generic forward transitions the plan's own test list requires (`showReview()`, `beginWork(_:)`, `showResult(_:)`) — a model with only the three sketched mutators cannot reach `.review`/`.working`/`.result` at all, and these are the transitions F2c/P1 will drive from real work. `canGoBack` is the single authority the sheet's Back button reads, so the goBack table lives in one place.
- `CustomWordsImportSheet` (`Views/Settings/`): one `ZStack` + one `switch model.step` + one container-level `.animation()` — the `OnboardingV2View` root-switch pattern without its timers/permissions logic. All seven screen categories render from fixtures. Reuses existing settings primitives (`SettingsRowIcon`, `InsetNotice`, `settingsReadingCopy`, `st*` tokens); the one new component (`ImportMethodCard`) follows `plain-button-content-shape` (`.contentShape(Rectangle())` before `.buttonStyle(.plain)`).
- `YourWordsView`: the single-purpose `.sheet(isPresented:)` is now a `YourWordsSheetRoute` + `.sheet(item:)`; inline save closure extracted verbatim to `saveNewWord(_:)`. Add Term behavior unchanged. Entry point is `#if DEBUG`-only ("Preview import") until a real source ships.

## Grounding deltas vs. the adopted plan

- The plan cited `YourWordsView.swift:55-69`; the sheet block now sits at 62-76 after #1646's launch-failure banners. Same content, refactored identically.
- `CustomWordEditSheet.onSave` returns `String?` (not an error type); `saveNewWord(_:)` keeps that signature and the closure body byte-identical.

## Async edge cases (six classes, per plan)

Interrupted: closing the sheet discards the model; no task/state survives (there are zero `Task`s). Deleted: n/a — no external data loaded. Mutated: fixture navigation is local-only. Concurrent: repeated presses serialize on `@MainActor`; Back is absent during `.working`. Nil: no optional/weak dependency. Stale: reopening always creates a fresh model at `.methodPicker` (`@State` model owned by the sheet).

## Tests

`CustomWordsImportFlowModelTests` — 13 `@Test` functions (21 cases with parameterization): the plan's full named list plus guard coverage for every ignored transition (`select` off-picker, `showReview` without a method, `showResult` outside working, `beginWork` on picker/result, Back on working/result) and `canGoBack` frozen alongside the table it summarizes. Release test builds instantiate the model directly — no DEBUG-only member exists on it.

## Validation

- Full local suite green via the worktree's own `scripts/xcode-test.sh` (Debug lane; run attached in checks).
- Local `codex review` to clean before push.
- One dev rebuild + manual UAT after Codex clean: fixture walk of every screen, Escape/Cancel/reopen-resets, word list and on-disk `custom-words.json` unchanged.
