### PR TITLE
feat(user): Custom Words import contract + compare engine (PR-F2a, #1661)

### DIFF
--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+// Canonical shared contract for Custom Words import (#1661, epic #1619 PR-F2a).
+//
+// Every import source — Paste, Upload, each Smart Import competitor adapter,
+// and the EnviousWispr backup format — implements `CustomWordsImportSource`
+// and returns `CustomWordsImportBatch`. Nothing downstream (compare engine,
+// Review screen, commit) knows which source produced a candidate. Lives in
+// Core because the file-import and smart-import leaf modules depend only on
+// Core, and LLM / PostProcessing / AppKit all need these types too.
+
+/// Core-level Apple Intelligence availability value for the import flow.
+/// PR-P1's connector check returns this; the import UI says so honestly when
+/// it is unavailable (unlike AI Polish, whose silent skip is deliberate —
+/// nobody asked polish for suggestions, but an importing user did).
+package enum AppleIntelligenceAvailability: Sendable, Equatable {
+  case available
+  case unavailable(reason: AIFailureReason, message: String)
+}
+
+/// Authority carrier for the six conditional fields on an import candidate.
+///
+/// `.unspecified` means the source has NO OPINION — on Replace, the existing
+/// word's hand-tuned value is preserved untouched. `.supplied` means the
+/// source is authoritative — on Replace its value is applied, INCLUDING
+/// authoritative clears: `.supplied([])` empties aliases and
+/// `.supplied(nil)` clears `minSimilarityOverride`. Only the EnviousWispr
+/// backup format ever emits either clear; every other source maps "no data
+/// in this row" to `.unspecified`, never to an instruction to clear.
+/// A plain Optional cannot represent "supplied: nil", which is what forced
+/// this enum (plan round 9).
+package enum CustomWordsImportField<Value: Sendable & Hashable>: Sendable, Hashable {
+  case unspecified
+  case supplied(Value)
+}
+
+/// Transient import candidate. Deliberately CANNOT carry `source`,
+/// `frequencyUsed`, or `lastUsed`, so no adapter can import another Mac's
+/// usage history. `id` is review-row identity only — a committed Replace
+/// keeps the existing word's UUID, and a committed Add mints a fresh one.
+package struct CustomWordsImportCandidate: Identifiable, Sendable, Hashable {
+  package let id: UUID
+  package var canonical: String
+  package var aliases: CustomWordsImportField<[String]>
+  /// AI-enrichment output (PR-P1). NEVER authoritative: applied only on Add,
+  /// never on Replace, so a machine guess cannot overwrite hand-tuned aliases.
+  package var suggestedAliases: [String]
+  package var category: CustomWordsImportField<WordCategory>
+  package var priority: CustomWordsImportField<Int>
+  package var forceReplace: CustomWordsImportField<Bool>
+  package var caseSensitive: CustomWordsImportField<Bool>
+  /// `.supplied(nil)` = authoritative "no per-term override" (backup
+  /// round-trip); `.unspecified` = the source knows nothing about strictness.
+  package var minSimilarityOverride: CustomWordsImportField<Double?>
+
+  package init(
+    id: UUID = UUID(),
+    canonical: String,
+    aliases: CustomWordsImportField<[String]> = .unspecified,
+    suggestedAliases: [String] = [],
+    category: CustomWordsImportField<WordCategory> = .unspecified,
+    priority: CustomWordsImportField<Int> = .unspecified,
+    forceReplace: CustomWordsImportField<Bool> = .unspecified,
+    caseSensitive: CustomWordsImportField<Bool> = .unspecified,
+    minSimilarityOverride: CustomWordsImportField<Double?> = .unspecified
+  ) {
+    self.id = id
+    self.canonical = canonical
+    self.aliases = aliases
+    self.suggestedAliases = suggestedAliases
+    self.category = category
+    self.priority = priority
+    self.forceReplace = forceReplace
+    self.caseSensitive = caseSensitive
+    self.minSimilarityOverride = minSimilarityOverride
+  }
+}
+
+/// One notices side-channel for a batch — never a second `warnings` field.
+package enum CustomWordsImportNotice: Sendable, Equatable {
+  /// Produced by the shared enrichment stage (PR-P1) in the Paste and Upload flows.
+  case appleIntelligenceUnavailable(AppleIntelligenceAvailability)
+  /// Produced by the shared enrichment stage (PR-P1).
+  case suggestionsPartiallyUnavailable(count: Int)
+  /// Produced by the shared enrichment stage when the per-import
+  /// suggestion-call budget is exhausted; `remainingCount` = candidates that
+  /// proceeded without suggestions.
+  case suggestionBudgetReached(remainingCount: Int)
+  /// Upload-only row-level parse warning.
+  case fileParseWarning(rowNumber: Int, reason: String)
+}
+
+package struct CustomWordsImportBatch: Sendable, Equatable {
+  /// Stable adapter identifier (`ImportFileParser.identifier` /
+  /// `SmartImportSourceDescriptor.id` / "paste" / "backup") — the value
+  /// telemetry emits; never a filename or display string.
+  package let sourceID: String
+  /// What the UI shows ("Wispr Flow", "CSV file", …); never emitted to telemetry.
+  package let sourceDisplayName: String
+  package let candidates: [CustomWordsImportCandidate]
+  package let notices: [CustomWordsImportNotice]
+
+  package init(
+    sourceID: String,
+    sourceDisplayName: String,
+    candidates: [CustomWordsImportCandidate],
+    notices: [CustomWordsImportNotice] = []
+  ) {
+    self.sourceID = sourceID
+    self.sourceDisplayName = sourceDisplayName
+    self.candidates = candidates
+    self.notices = notices
+  }
+}
+
+package protocol CustomWordsImportSource: Sendable {
+  func loadCandidates() async throws -> CustomWordsImportBatch
+}

--- a/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
@@ -1,0 +1,540 @@
+import EnviousWisprCore
+import Foundation
+
+// Compare/dedup engine for Custom Words import (#1661, epic #1619 PR-F2a).
+//
+// Classifies imported candidates against the existing library. Detection and
+// disclosure only: alias collisions recorded here are informational — the
+// commit step (PR-F2b) is the safety guarantee that a colliding alias is
+// never persisted. Fully decision-agnostic: `compare` runs BEFORE any Review
+// decision exists, so nothing here consults one.
+
+/// Conservative, explicit-opt-in fuzzy matching policy. `.disabled` can never
+/// match: no canonical meets an infinite minimum length.
+package struct CustomWordsImportFuzzyPolicy: Sendable, Equatable {
+  package let minimumLength: Int
+  package let maximumEditDistance: Int
+
+  package static let disabled = CustomWordsImportFuzzyPolicy(
+    minimumLength: .max, maximumEditDistance: 0)
+
+  package init(minimumLength: Int, maximumEditDistance: Int) {
+    self.minimumLength = minimumLength
+    self.maximumEditDistance = maximumEditDistance
+  }
+}
+
+package enum CustomWordsImportClassification: Sendable, Equatable {
+  case new
+  case exact(existing: CustomWord)
+  case variant(existing: CustomWord, matchedAlias: String)
+  /// Edit-distance spelling similarity, not phonetic "sounds-alike".
+  case fuzzy(existing: CustomWord, distance: Int)
+  /// ≥2 equally-valid matches. Homogeneous by construction: the staged
+  /// classification order means the matches are all exact-kind, all
+  /// variant-kind, or all fuzzy-kind, never mixed. Ordered deterministically
+  /// (normalized canonical, then UUID) for stable display — the tie-break
+  /// orders the list instead of silently electing a winner.
+  case ambiguous(matches: [CustomWordsImportAmbiguousMatch])
+}
+
+package struct CustomWordsImportAmbiguousMatch: Sendable, Equatable {
+  package enum Kind: Sendable, Equatable {
+    /// Two or more existing words whose canonicals are distinct to the
+    /// persistence layer but identical under this engine's stronger matching
+    /// key. `CustomWordsManager` dedups on `trimmed.lowercased()` only, so
+    /// `"Claude Code"` / `"Claude  Code"` and precomposed / decomposed
+    /// spellings of the same word can all legitimately coexist on disk.
+    case exact
+    case variant(matchedAlias: String)
+    case fuzzy(distance: Int)
+  }
+
+  package let existing: CustomWord
+  package let kind: Kind
+
+  package init(existing: CustomWord, kind: Kind) {
+    self.existing = existing
+    self.kind = kind
+  }
+}
+
+package struct CustomWordsImportAliasCollision: Sendable, Equatable {
+  package let alias: String
+  /// The winning existing-word or incoming-candidate owner. For a
+  /// canonical-over-alias collision this MAY be a LATER candidate — every
+  /// incoming canonical is registered before any imported alias is checked,
+  /// so an earlier candidate's alias can lose to a later candidate's
+  /// canonical; "earlier candidate always wins" only holds for
+  /// alias-vs-alias precedence, not canonical-vs-alias.
+  package let heldBy: UUID
+
+  package init(alias: String, heldBy: UUID) {
+    self.alias = alias
+    self.heldBy = heldBy
+  }
+}
+
+package struct CustomWordsImportComparison: Identifiable, Sendable, Equatable {
+  package let candidate: CustomWordsImportCandidate
+  package let classification: CustomWordsImportClassification
+  package let collidingAliases: [CustomWordsImportAliasCollision]
+
+  package var id: UUID { candidate.id }
+
+  package init(
+    candidate: CustomWordsImportCandidate,
+    classification: CustomWordsImportClassification,
+    collidingAliases: [CustomWordsImportAliasCollision]
+  ) {
+    self.candidate = candidate
+    self.classification = classification
+    self.collidingAliases = collidingAliases
+  }
+}
+
+/// Off-MainActor comparison. Takes `existingWords` as a value-type snapshot —
+/// staleness against a changing library is the commit step's concern (F2b),
+/// never this actor's.
+package actor CustomWordsImportCompareEngine {
+  package init() {}
+
+  package func compare(
+    candidates: [CustomWordsImportCandidate],
+    against existingWords: [CustomWord],
+    fuzzyPolicy: CustomWordsImportFuzzyPolicy
+  ) async throws -> [CustomWordsImportComparison] {
+    // Every stage below checks cancellation, not just the final loop: Upload
+    // admits up to 25,000 rows, so coalescing and collision detection are
+    // real work a cancelled sheet must be able to abandon promptly.
+    try Task.checkCancellation()
+    let coalesced = try Self.coalesceDuplicates(candidates)
+
+    // Existing-library lookups, built once per call.
+    // Canonical surfaces map to ALL their owners, not one. The manager dedups
+    // canonicals on `trimmed.lowercased()` (CustomWordsManager.swift:425-427)
+    // — a WEAKER key than this engine's, which also collapses internal
+    // whitespace and precomposes Unicode. So `"Claude Code"` / `"Claude  Code"`
+    // (and precomposed / decomposed spellings) can both be present on disk and
+    // collapse to one key here. Keeping only the first would silently elect an
+    // arbitrary replacement target — exactly what the ambiguous classification
+    // exists to prevent.
+    var existingCanonicalOwners: [String: [CustomWord]] = [:]
+    for word in existingWords {
+      existingCanonicalOwners[Self.normalize(word.canonical), default: []].append(word)
+    }
+    // Nothing prevents two existing words from sharing an alias (only
+    // canonicals are deduped), so alias surfaces map to ALL their owners.
+    var existingAliasOwners: [String: [(word: CustomWord, alias: String)]] = [:]
+    for word in existingWords {
+      for alias in word.aliases {
+        existingAliasOwners[Self.normalize(alias), default: []].append((word, alias))
+      }
+    }
+
+    // Fuzzy is the only stage that scans the library word by word, so the
+    // existing side is normalized, eligibility-filtered, and BUCKETED BY
+    // LENGTH once here instead of per candidate. Two strings within edit
+    // distance d differ in length by at most d, so a candidate only ever has
+    // to look at buckets [len-d, len+d] — the rest cannot match by
+    // definition. Without this, an import at Upload's 25,000-row cap against
+    // a comparable library would scan every existing word for every
+    // candidate (~625M checks) and re-normalize the same canonicals on each
+    // pass. Built only when the policy can match, so a disabled policy pays
+    // nothing.
+    //
+    // Residual, deliberately not solved here (#1663): within the eligible
+    // buckets the scan is still linear, so a pathological library (tens of
+    // thousands of same-length words) still degrades. A real sublinear
+    // structure is only worth building once fuzzy is known to ship and its
+    // thresholds are measured — both are open founder decisions, and
+    // optimising against guessed thresholds risks the wrong structure.
+    var fuzzyIndexByLength: [Int: [FuzzyCandidateWord]] = [:]
+    if fuzzyPolicy.maximumEditDistance > 0 {
+      for word in existingWords {
+        let key = Self.normalize(word.canonical)
+        guard key.count >= fuzzyPolicy.minimumLength, Self.isLettersOnly(key) else { continue }
+        fuzzyIndexByLength[key.count, default: []].append(
+          FuzzyCandidateWord(word: word, key: key))
+      }
+    }
+
+    let collisions = try Self.detectAliasCollisions(
+      coalesced: coalesced, existingWords: existingWords)
+
+    var results: [CustomWordsImportComparison] = []
+    results.reserveCapacity(coalesced.count)
+    for candidate in coalesced {
+      try Task.checkCancellation()
+      let classification = Self.classify(
+        candidate: candidate,
+        existingCanonicalOwners: existingCanonicalOwners,
+        existingAliasOwners: existingAliasOwners,
+        fuzzyIndexByLength: fuzzyIndexByLength,
+        fuzzyPolicy: fuzzyPolicy
+      )
+      results.append(
+        CustomWordsImportComparison(
+          candidate: candidate,
+          classification: classification,
+          collidingAliases: collisions[candidate.id] ?? []
+        ))
+    }
+    return results
+  }
+
+  // MARK: - Normalization
+  //
+  // TWO keys, deliberately, because two different questions are being asked.
+  // Conflating them caused defects on both sides of the comparison (Codex
+  // review r1 on the library side, r2 on the candidate side), so they are
+  // now named and used strictly where each belongs:
+  //
+  // - `persistenceKey` answers "would these occupy the SAME SLOT in stored
+  //   data?" It mirrors `CustomWordsManager`'s own dedup key exactly
+  //   (`trimmed.lowercased()`, CustomWordsManager.swift:425-427), which is
+  //   also what `WordCorrector` looks up (`alias.lowercased()`,
+  //   WordCorrector.swift:180-214) on already-trim-sanitized aliases. Used
+  //   for candidate coalescing and alias-collision detection — both are
+  //   questions about persistence and correction-map slots.
+  //
+  // - `normalize` answers "does the user MEAN the same word?" It is
+  //   deliberately stronger: it also precomposes Unicode and collapses
+  //   internal whitespace, so `café` typed either way, and a stray double
+  //   space, still match. Used only for classification.
+  //
+  // Because `normalize` is strictly stronger, two words distinct under
+  // `persistenceKey` can collapse under it — that is real, and it is why
+  // multi-owner canonical matches classify `ambiguous` rather than electing
+  // an arbitrary winner.
+
+  /// Persistence/correction-slot key. Mirrors `CustomWordsManager`'s dedup.
+  package static func persistenceKey(_ s: String) -> String {
+    s.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  }
+
+  /// Matching key. Case-fold, precompose, trim, collapse internal whitespace
+  /// — NOTHING else. Punctuation is never stripped: `C`, `C++`, `C#`,
+  /// `.NET`, and `node.js` must stay distinct.
+  package static func normalize(_ s: String) -> String {
+    s.folding(options: .caseInsensitive, locale: nil)
+      .precomposedStringWithCanonicalMapping
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .split(whereSeparator: \.isWhitespace)
+      .joined(separator: " ")
+  }
+
+  // MARK: - Duplicate-candidate coalescing
+
+  /// Repeated candidate canonicals coalesce before classification, keeping
+  /// the first row's ID and spelling, so two "New" rows can't silently
+  /// collide at persistence time. Keyed on `persistenceKey`, NOT the
+  /// stronger matching key: two candidates the manager would happily store
+  /// as separate words must stay separate review rows, or a backup holding
+  /// both could never restore the second one. Per field (all six authority carriers),
+  /// the first `.supplied` value in plan order wins, evaluated
+  /// independently; `aliases` unions every `.supplied` list in plan order
+  /// (deduplicated via the normalization key, first spelling wins) and stays
+  /// `.unspecified` only when every duplicate row was `.unspecified`.
+  static func coalesceDuplicates(
+    _ candidates: [CustomWordsImportCandidate]
+  ) throws -> [CustomWordsImportCandidate] {
+    var order: [String] = []
+    var byKey: [String: CustomWordsImportCandidate] = [:]
+
+    for candidate in candidates {
+      try Task.checkCancellation()
+      let key = persistenceKey(candidate.canonical)
+      guard var merged = byKey[key] else {
+        order.append(key)
+        byKey[key] = candidate
+        continue
+      }
+
+      if case .unspecified = merged.aliases {
+        merged.aliases = candidate.aliases
+      } else if case .supplied(let existing) = merged.aliases,
+        case .supplied(let incoming) = candidate.aliases
+      {
+        merged.aliases = .supplied(unionByNormalizationKey(existing, incoming))
+      }
+      merged.suggestedAliases = unionByNormalizationKey(
+        merged.suggestedAliases, candidate.suggestedAliases)
+      if case .unspecified = merged.category { merged.category = candidate.category }
+      if case .unspecified = merged.priority { merged.priority = candidate.priority }
+      if case .unspecified = merged.forceReplace { merged.forceReplace = candidate.forceReplace }
+      if case .unspecified = merged.caseSensitive {
+        merged.caseSensitive = candidate.caseSensitive
+      }
+      if case .unspecified = merged.minSimilarityOverride {
+        merged.minSimilarityOverride = candidate.minSimilarityOverride
+      }
+      byKey[key] = merged
+    }
+    return order.compactMap { byKey[$0] }
+  }
+
+  private static func unionByNormalizationKey(_ first: [String], _ second: [String]) -> [String] {
+    var seen = Set<String>()
+    var result: [String] = []
+    for alias in first + second {
+      let key = persistenceKey(alias)
+      guard !key.isEmpty, seen.insert(key).inserted else { continue }
+      result.append(alias)
+    }
+    return result
+  }
+
+  // MARK: - Classification
+
+  /// Fixed staged order: exact canonical → variant (existing alias) →
+  /// fuzzy (edit distance against existing canonicals only) → new.
+  private static func classify(
+    candidate: CustomWordsImportCandidate,
+    existingCanonicalOwners: [String: [CustomWord]],
+    existingAliasOwners: [String: [(word: CustomWord, alias: String)]],
+    fuzzyIndexByLength: [Int: [FuzzyCandidateWord]],
+    fuzzyPolicy: CustomWordsImportFuzzyPolicy
+  ) -> CustomWordsImportClassification {
+    let key = normalize(candidate.canonical)
+
+    if let owners = existingCanonicalOwners[key], owners.isEmpty == false {
+      if owners.count == 1 {
+        return .exact(existing: owners[0])
+      }
+      // Distinct on disk, identical under this engine's key — no principled
+      // basis to elect one as the replacement target, so surface all of them.
+      let matches = owners.map {
+        CustomWordsImportAmbiguousMatch(existing: $0, kind: .exact)
+      }
+      return .ambiguous(matches: orderedDeterministically(matches))
+    }
+
+    if let owners = existingAliasOwners[key], owners.isEmpty == false {
+      // One word can hold the surface under several alias spellings that
+      // normalize identically — that's still a single owner.
+      var seenWordIDs = Set<UUID>()
+      var uniqueOwners: [(word: CustomWord, alias: String)] = []
+      for owner in owners where seenWordIDs.insert(owner.word.id).inserted {
+        uniqueOwners.append(owner)
+      }
+      if uniqueOwners.count == 1 {
+        return .variant(
+          existing: uniqueOwners[0].word, matchedAlias: uniqueOwners[0].alias)
+      }
+      let matches =
+        uniqueOwners
+        .map {
+          CustomWordsImportAmbiguousMatch(existing: $0.word, kind: .variant(matchedAlias: $0.alias))
+        }
+      return .ambiguous(matches: orderedDeterministically(matches))
+    }
+
+    if let fuzzyResult = fuzzyMatch(
+      candidateKey: key, indexByLength: fuzzyIndexByLength, policy: fuzzyPolicy)
+    {
+      return fuzzyResult
+    }
+
+    return .new
+  }
+
+  /// One existing word, pre-normalized and pre-screened for fuzzy eligibility.
+  /// Its length is the index bucket, so it is not stored again here.
+  struct FuzzyCandidateWord {
+    let word: CustomWord
+    let key: String
+  }
+
+  /// Conservative fuzzy eligibility: policy enabled, both normalized
+  /// canonicals at least the minimum length, both letters-only (digits or
+  /// punctuation exclude the fuzzy path entirely), aliases never a fuzzy
+  /// surface. A distance tie across multiple existing words is ambiguity.
+  /// The library side arrives pre-normalized, pre-filtered, and bucketed by
+  /// length; only buckets within the maximum distance are visited, since a
+  /// larger length gap cannot be bridged by that many edits.
+  private static func fuzzyMatch(
+    candidateKey: String,
+    indexByLength: [Int: [FuzzyCandidateWord]],
+    policy: CustomWordsImportFuzzyPolicy
+  ) -> CustomWordsImportClassification? {
+    guard policy.maximumEditDistance > 0 else { return nil }
+    guard candidateKey.count >= policy.minimumLength else { return nil }
+    guard isLettersOnly(candidateKey) else { return nil }
+
+    let candidateLength = candidateKey.count
+    var best: [(word: CustomWord, distance: Int)] = []
+    // Optional rather than a `maximumEditDistance + 1` sentinel: this type's
+    // own vocabulary already includes extreme values (`.disabled` uses
+    // `minimumLength: .max`), and the symmetric `maximumEditDistance: .max`
+    // would overflow that addition and trap before matching anything. No
+    // arithmetic on the policy means no such trap, and no policy value has to
+    // be rejected to stay safe.
+    var bestDistance: Int?
+    // Walk the BUCKETS, not a numeric length range: the number of distinct
+    // word lengths is tiny, whereas a numeric range built from a policy with
+    // an extreme distance would iterate unboundedly. Result order is
+    // unaffected by dictionary iteration order — a single best match is
+    // unique, and ties are sorted by `orderedDeterministically` before return.
+    for (length, entries) in indexByLength {
+      guard abs(length - candidateLength) <= policy.maximumEditDistance else { continue }
+      for entry in entries {
+        guard
+          let distance = editDistance(candidateKey, entry.key, cap: policy.maximumEditDistance),
+          distance >= 1
+        else { continue }
+        let word = entry.word
+        guard let current = bestDistance else {
+          bestDistance = distance
+          best = [(word, distance)]
+          continue
+        }
+        if distance < current {
+          bestDistance = distance
+          best = [(word, distance)]
+        } else if distance == current {
+          best.append((word, distance))
+        }
+      }
+    }
+
+    guard best.isEmpty == false else { return nil }
+    if best.count == 1 {
+      return .fuzzy(existing: best[0].word, distance: best[0].distance)
+    }
+    let matches =
+      best
+      .map {
+        CustomWordsImportAmbiguousMatch(existing: $0.word, kind: .fuzzy(distance: $0.distance))
+      }
+    return .ambiguous(matches: orderedDeterministically(matches))
+  }
+
+  private static func orderedDeterministically(
+    _ matches: [CustomWordsImportAmbiguousMatch]
+  ) -> [CustomWordsImportAmbiguousMatch] {
+    matches.sorted { a, b in
+      let ka = normalize(a.existing.canonical)
+      let kb = normalize(b.existing.canonical)
+      if ka != kb { return ka < kb }
+      return a.existing.id.uuidString < b.existing.id.uuidString
+    }
+  }
+
+  private static func isLettersOnly(_ s: String) -> Bool {
+    s.isEmpty == false && s.allSatisfy(\.isLetter)
+  }
+
+  /// Levenshtein distance with a cap: returns nil when the distance exceeds
+  /// `cap`, so long unrelated strings exit early.
+  static func editDistance(_ a: String, _ b: String, cap: Int) -> Int? {
+    let aChars = Array(a)
+    let bChars = Array(b)
+    if abs(aChars.count - bChars.count) > cap { return nil }
+    if aChars.isEmpty { return bChars.count <= cap ? bChars.count : nil }
+    if bChars.isEmpty { return aChars.count <= cap ? aChars.count : nil }
+
+    var previous = Array(0...bChars.count)
+    var current = [Int](repeating: 0, count: bChars.count + 1)
+    for i in 1...aChars.count {
+      current[0] = i
+      var rowMinimum = current[0]
+      for j in 1...bChars.count {
+        let substitution = previous[j - 1] + (aChars[i - 1] == bChars[j - 1] ? 0 : 1)
+        current[j] = min(previous[j] + 1, current[j - 1] + 1, substitution)
+        rowMinimum = min(rowMinimum, current[j])
+      }
+      if rowMinimum > cap { return nil }
+      swap(&previous, &current)
+    }
+    let distance = previous[bChars.count]
+    return distance <= cap ? distance : nil
+  }
+
+  // MARK: - Alias-collision detection (decision-agnostic; disclosure only)
+
+  /// Keyed on `persistenceKey` throughout, not the matching key: a collision
+  /// is a claim about two entries fighting over the same slot in stored data
+  /// and in `WordCorrector`'s lookup map, and both use the manager's weaker
+  /// key. Using the stronger matching key here would flag pairs that never
+  /// actually collide at runtime.
+  ///
+  /// The corrected algorithm (plan rounds 5-7):
+  /// 1. One canonical-ownership set from every existing word's canonical AND
+  ///    every incoming candidate's canonical; existing-library ownership
+  ///    always sorts first, then incoming plan order.
+  /// 2. Each candidate's SOURCE aliases in plan order (never
+  ///    `suggestedAliases` — enrichment has not run at compare time; a
+  ///    colliding suggestion is enforced-and-receipted at commit instead).
+  ///    An alias equal to its OWN candidate's canonical is redundant, not a
+  ///    collision — silently normalized away, never reported.
+  /// 3. Canonical ownership is checked FIRST; a match records the WINNING
+  ///    canonical owner and the alias is never registered below.
+  /// 4. Alias-ownership: incumbent (existing-library) aliases always win over
+  ///    any import; among two incumbents sharing an alias the LATER one wins
+  ///    (mirroring `WordCorrector`'s last-write-wins map build); among
+  ///    imported aliases, first-in-plan-order wins. Only the LOSING candidate
+  ///    is flagged — the winner's alias is not at risk.
+  /// 5. Otherwise the candidate owns that alias surface for the batch.
+  static func detectAliasCollisions(
+    coalesced: [CustomWordsImportCandidate],
+    existingWords: [CustomWord]
+  ) throws -> [UUID: [CustomWordsImportAliasCollision]] {
+    var canonicalOwners: [String: UUID] = [:]
+    for word in existingWords {
+      let key = persistenceKey(word.canonical)
+      if canonicalOwners[key] == nil { canonicalOwners[key] = word.id }
+    }
+    for candidate in coalesced {
+      let key = persistenceKey(candidate.canonical)
+      if canonicalOwners[key] == nil { canonicalOwners[key] = candidate.id }
+    }
+
+    // Incumbent aliases: LAST writer wins, mirroring runtime rather than
+    // this function's own first-wins convention. When two existing words
+    // share an alias, `WordCorrector.buildLookups` assigns unconditionally
+    // (`singleAliasMap[key] = word.canonical`, WordCorrector.swift:180-214,
+    // whose own debug line reads "using <later canonical>"), so the later
+    // word is the one that actually claims the trigger. Reporting the
+    // earlier one would name a word that is not really holding the alias,
+    // and F2c's Replace-target suppression compares against this exact id.
+    var aliasOwners: [String: UUID] = [:]
+    for word in existingWords {
+      for alias in word.aliases {
+        let key = persistenceKey(alias)
+        if key.isEmpty == false { aliasOwners[key] = word.id }
+      }
+    }
+
+    var collisions: [UUID: [CustomWordsImportAliasCollision]] = [:]
+    for candidate in coalesced {
+      try Task.checkCancellation()
+      guard case .supplied(let sourceAliases) = candidate.aliases else { continue }
+      let ownCanonicalKey = persistenceKey(candidate.canonical)
+      for alias in sourceAliases {
+        let key = persistenceKey(alias)
+        if key.isEmpty || key == ownCanonicalKey { continue }
+        // A candidate only ever owns its OWN canonical surface, which the
+        // `key == ownCanonicalKey` guard above already consumed — so any
+        // canonical owner found here is necessarily a different word.
+        if let canonicalOwner = canonicalOwners[key] {
+          collisions[candidate.id, default: []].append(
+            CustomWordsImportAliasCollision(alias: alias, heldBy: canonicalOwner))
+          continue
+        }
+        // Likewise, a candidate can only already own an alias surface via an
+        // earlier alias of its own, which is a duplicate spelling rather than
+        // a collision — skip it without flagging.
+        if let aliasOwner = aliasOwners[key] {
+          if aliasOwner != candidate.id {
+            collisions[candidate.id, default: []].append(
+              CustomWordsImportAliasCollision(alias: alias, heldBy: aliasOwner))
+          }
+          continue
+        }
+        aliasOwners[key] = candidate.id
+      }
+    }
+    return collisions
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
@@ -459,52 +459,65 @@ package actor CustomWordsImportCompareEngine {
   /// key. Using the stronger matching key here would flag pairs that never
   /// actually collide at runtime.
   ///
-  /// The corrected algorithm (plan rounds 5-7):
-  /// 1. One canonical-ownership set from every existing word's canonical AND
-  ///    every incoming candidate's canonical; existing-library ownership
-  ///    always sorts first, then incoming plan order.
-  /// 2. Each candidate's SOURCE aliases in plan order (never
-  ///    `suggestedAliases` — enrichment has not run at compare time; a
-  ///    colliding suggestion is enforced-and-receipted at commit instead).
-  ///    An alias equal to its OWN candidate's canonical is redundant, not a
-  ///    collision — silently normalized away, never reported.
-  /// 3. Canonical ownership is checked FIRST; a match records the WINNING
-  ///    canonical owner and the alias is never registered below.
-  /// 4. Alias-ownership: incumbent (existing-library) aliases always win over
-  ///    any import; among two incumbents sharing an alias the LATER one wins
-  ///    (mirroring `WordCorrector`'s last-write-wins map build); among
-  ///    imported aliases, first-in-plan-order wins. Only the LOSING candidate
-  ///    is flagged — the winner's alias is not at risk.
-  /// 5. Otherwise the candidate owns that alias surface for the batch.
+  /// `heldBy` must name the word that ACTUALLY holds the trigger, because it
+  /// drives both the inline note ("X already uses it") and F2c's suppression
+  /// check. So ownership mirrors `WordCorrector.buildLookups`
+  /// (WordCorrector.swift:176-215) rather than any convention of this file's
+  /// own — two rounds of review found invented conventions disagreeing with
+  /// runtime, in opposite directions:
+  ///
+  /// - Among two EXISTING words sharing an alias, the corrector assigns
+  ///   unconditionally, so the LATER word wins (its own debug line reads
+  ///   "using <later canonical>").
+  /// - When a key is held by an existing ALIAS *and* an existing CANONICAL,
+  ///   the ALIAS wins: the corrector builds every alias first, then SKIPS any
+  ///   canonical whose key an alias already owns ("Canonical 'X' skipped: key
+  ///   already maps to..."). A canonical-first order would name a word whose
+  ///   own spelling the corrector never even reaches.
+  ///
+  /// Lookup order for an imported alias, first match wins:
+  /// 1. existing alias owner (the runtime holder), 2. existing canonical
+  /// owner, 3. an incoming candidate's canonical, 4. an earlier imported
+  /// alias. Otherwise this candidate claims the surface for the batch.
+  ///
+  /// A candidate's SOURCE aliases only, in plan order — never
+  /// `suggestedAliases`, since enrichment has not run at compare time and a
+  /// colliding suggestion is enforced-and-receipted at commit instead. An
+  /// alias equal to its OWN candidate's canonical is redundant, not a
+  /// collision, and is dropped silently. Only the LOSING side is ever
+  /// flagged; a winner's alias is not at risk.
   static func detectAliasCollisions(
     coalesced: [CustomWordsImportCandidate],
     existingWords: [CustomWord]
   ) throws -> [UUID: [CustomWordsImportAliasCollision]] {
-    var canonicalOwners: [String: UUID] = [:]
-    for word in existingWords {
-      let key = persistenceKey(word.canonical)
-      if canonicalOwners[key] == nil { canonicalOwners[key] = word.id }
-    }
-    for candidate in coalesced {
-      let key = persistenceKey(candidate.canonical)
-      if canonicalOwners[key] == nil { canonicalOwners[key] = candidate.id }
-    }
-
-    // Incumbent aliases: LAST writer wins, mirroring runtime rather than
-    // this function's own first-wins convention. When two existing words
-    // share an alias, `WordCorrector.buildLookups` assigns unconditionally
-    // (`singleAliasMap[key] = word.canonical`, WordCorrector.swift:180-214,
-    // whose own debug line reads "using <later canonical>"), so the later
-    // word is the one that actually claims the trigger. Reporting the
-    // earlier one would name a word that is not really holding the alias,
-    // and F2c's Replace-target suppression compares against this exact id.
-    var aliasOwners: [String: UUID] = [:]
+    // Existing aliases: last writer wins, per the corrector's unconditional
+    // assignment.
+    var existingAliasOwners: [String: UUID] = [:]
     for word in existingWords {
       for alias in word.aliases {
         let key = persistenceKey(alias)
-        if key.isEmpty == false { aliasOwners[key] = word.id }
+        if key.isEmpty == false { existingAliasOwners[key] = word.id }
       }
     }
+    var existingCanonicalOwners: [String: UUID] = [:]
+    for word in existingWords {
+      let key = persistenceKey(word.canonical)
+      if existingCanonicalOwners[key] == nil { existingCanonicalOwners[key] = word.id }
+    }
+    // Incoming canonicals are not in the library yet, so they rank below every
+    // incumbent surface — but still above another candidate's alias, since all
+    // canonicals are registered before any imported alias is checked.
+    var candidateCanonicalOwners: [String: UUID] = [:]
+    for candidate in coalesced {
+      let key = persistenceKey(candidate.canonical)
+      if candidateCanonicalOwners[key] == nil { candidateCanonicalOwners[key] = candidate.id }
+    }
+
+    func incumbentOwner(of key: String) -> UUID? {
+      existingAliasOwners[key] ?? existingCanonicalOwners[key]
+    }
+
+    var importedAliasOwners: [String: UUID] = [:]
 
     var collisions: [UUID: [CustomWordsImportAliasCollision]] = [:]
     for candidate in coalesced {
@@ -514,25 +527,31 @@ package actor CustomWordsImportCompareEngine {
       for alias in sourceAliases {
         let key = persistenceKey(alias)
         if key.isEmpty || key == ownCanonicalKey { continue }
-        // A candidate only ever owns its OWN canonical surface, which the
-        // `key == ownCanonicalKey` guard above already consumed — so any
-        // canonical owner found here is necessarily a different word.
-        if let canonicalOwner = canonicalOwners[key] {
+        // Incumbents first — an existing alias outranks an existing canonical,
+        // mirroring the corrector's build order. Neither can be this candidate.
+        if let owner = incumbentOwner(of: key) {
           collisions[candidate.id, default: []].append(
-            CustomWordsImportAliasCollision(alias: alias, heldBy: canonicalOwner))
+            CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
           continue
         }
-        // Likewise, a candidate can only already own an alias surface via an
-        // earlier alias of its own, which is a duplicate spelling rather than
-        // a collision — skip it without flagging.
-        if let aliasOwner = aliasOwners[key] {
-          if aliasOwner != candidate.id {
+        // A candidate only ever owns its OWN canonical surface, which the
+        // `key == ownCanonicalKey` guard already consumed, so any candidate
+        // canonical found here belongs to a different row.
+        if let owner = candidateCanonicalOwners[key] {
+          collisions[candidate.id, default: []].append(
+            CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
+          continue
+        }
+        // A candidate can already own an alias surface only via an earlier
+        // alias of its own — a duplicate spelling, not a collision.
+        if let owner = importedAliasOwners[key] {
+          if owner != candidate.id {
             collisions[candidate.id, default: []].append(
-              CustomWordsImportAliasCollision(alias: alias, heldBy: aliasOwner))
+              CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
           }
           continue
         }
-        aliasOwners[key] = candidate.id
+        importedAliasOwners[key] = candidate.id
       }
     }
     return collisions

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
@@ -441,6 +441,24 @@ struct CustomWordsImportCompareEngineTests {
       ])
   }
 
+  @Test("a key held by both an existing alias and an existing canonical names the alias owner")
+  func keyHeldByBothAnExistingAliasAndCanonicalReportsTheAliasOwner() async throws {
+    // The corrector builds every alias into the lookup FIRST, then skips any
+    // canonical whose key an alias already owns (WordCorrector.swift:176-215,
+    // "Canonical 'X' skipped: key already maps to..."). So when both kinds of
+    // owner exist, the alias owner is the real holder — naming the canonical
+    // owner would point at a word the corrector never reaches for that key.
+    let canonicalHolder = CustomWord(canonical: "Annie")
+    let aliasHolder = CustomWord(canonical: "Anika", aliases: ["annie"])
+    let results = try await compare(
+      [candidate("Zed", aliases: .supplied(["Annie"]))],
+      against: [canonicalHolder, aliasHolder])
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "Annie", heldBy: aliasHolder.id)
+      ])
+  }
+
   @Test("aliases that differ only by internal whitespace do not collide")
   func aliasesDifferingOnlyByInternalWhitespaceAreNotFlagged() async throws {
     // Collisions are a claim about the stored/correction-map slot, which uses

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
@@ -1,0 +1,592 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1661 (PR-F2a) — compare/dedup engine. Pure classification coverage: the
+/// engine takes the library as a value snapshot, so every test is hermetic.
+/// The adversarial fuzzy pairs (Saurabh/Sarah, OpenAI/OpenAPI, C++/C#) are
+/// the acceptance bar for the founder's pending threshold decision (bible §8
+/// risk register): the mock-up's unvalidated placeholder (length ≥5,
+/// distance ≤3) FAILS that bar, which is frozen below as documentation.
+@Suite("CustomWordsImportCompareEngine")
+struct CustomWordsImportCompareEngineTests {
+
+  // MARK: - Helpers
+
+  private func word(
+    _ canonical: String, aliases: [String] = [], id: UUID = UUID()
+  ) -> CustomWord {
+    CustomWord(id: id, canonical: canonical, aliases: aliases)
+  }
+
+  private func candidate(
+    _ canonical: String,
+    aliases: CustomWordsImportField<[String]> = .unspecified,
+    id: UUID = UUID()
+  ) -> CustomWordsImportCandidate {
+    CustomWordsImportCandidate(id: id, canonical: canonical, aliases: aliases)
+  }
+
+  private func compare(
+    _ candidates: [CustomWordsImportCandidate],
+    against existing: [CustomWord],
+    policy: CustomWordsImportFuzzyPolicy = .disabled
+  ) async throws -> [CustomWordsImportComparison] {
+    try await CustomWordsImportCompareEngine().compare(
+      candidates: candidates, against: existing, fuzzyPolicy: policy)
+  }
+
+  /// A conservative candidate policy that PASSES the adversarial bar:
+  /// length ≥7 excludes OpenAI (6) and Sarah (5); distance ≤1 excludes
+  /// Saurabh→Sarah (2) independently.
+  private static let conservativeCandidatePolicy = CustomWordsImportFuzzyPolicy(
+    minimumLength: 7, maximumEditDistance: 1)
+
+  /// The mock-up's unvalidated placeholder (bible §5.3). Ships nowhere as-is.
+  private static let mockupPlaceholderPolicy = CustomWordsImportFuzzyPolicy(
+    minimumLength: 5, maximumEditDistance: 3)
+
+  // MARK: - Classification basics
+
+  @Test("unknown canonical classifies new")
+  func newCanonicalClassifiesNew() async throws {
+    let results = try await compare(
+      [candidate("Qualtrics")], against: [word("Claude Code")])
+    #expect(results.count == 1)
+    #expect(results[0].classification == .new)
+    #expect(results[0].collidingAliases.isEmpty)
+  }
+
+  @Test("case and whitespace variations classify exact")
+  func caseAndWhitespaceCanonicalClassifiesExact() async throws {
+    let existing = word("Claude Code")
+    let results = try await compare(
+      [candidate("  claude   CODE ")], against: [existing])
+    #expect(results[0].classification == .exact(existing: existing))
+  }
+
+  @Test("canonical matching an existing alias classifies variant with the matched alias")
+  func canonicalMatchingExistingAliasClassifiesVariant() async throws {
+    let existing = word("Parvati", aliases: ["Pavarthi", "Parvathi"])
+    let results = try await compare([candidate("pavarthi")], against: [existing])
+    #expect(
+      results[0].classification == .variant(existing: existing, matchedAlias: "Pavarthi"))
+  }
+
+  @Test("composed and decomposed unicode forms classify exact")
+  func unicodeComposedAndDecomposedFormsClassifyExact() async throws {
+    let existing = word("caf\u{00E9}")  // é precomposed
+    let results = try await compare(
+      [candidate("cafe\u{0301}")], against: [existing])  // e + combining acute
+    #expect(results[0].classification == .exact(existing: existing))
+  }
+
+  // MARK: - Fuzzy
+
+  @Test("one-edit canonical classifies fuzzy when policy allows")
+  func oneEditCanonicalClassifiesFuzzyWhenPolicyAllows() async throws {
+    let existing = word("Kubernetes")
+    let results = try await compare(
+      [candidate("Kubernetez")], against: [existing],
+      policy: CustomWordsImportFuzzyPolicy(minimumLength: 5, maximumEditDistance: 1))
+    #expect(results[0].classification == .fuzzy(existing: existing, distance: 1))
+  }
+
+  @Test("a fuzzy match of different length is found across length buckets")
+  func fuzzyMatchOfDifferentLengthIsFoundAcrossBuckets() async throws {
+    // The library side is bucketed by length for speed. Every other fuzzy
+    // test compares equal-length words, so all of them would still pass if
+    // bucketing only ever looked at the candidate's own bucket — this one
+    // fails in that case. Deletion (9 chars vs 10) and insertion (11 vs 10).
+    let shorter = CustomWord(canonical: "Kubernete")
+    let longer = CustomWord(canonical: "Kuberneteses")
+    let policy = CustomWordsImportFuzzyPolicy(minimumLength: 5, maximumEditDistance: 1)
+
+    let deletion = try await compare(
+      [candidate("Kubernetes")], against: [shorter], policy: policy)
+    #expect(deletion[0].classification == .fuzzy(existing: shorter, distance: 1))
+
+    let insertion = try await compare(
+      [candidate("Kubernetese")], against: [longer], policy: policy)
+    #expect(insertion[0].classification == .fuzzy(existing: longer, distance: 1))
+  }
+
+  @Test("an extreme maximum distance does not trap")
+  func extremeMaximumEditDistanceDoesNotTrap() async throws {
+    // `.disabled` already uses `minimumLength: .max`, so extreme values are
+    // in this type's vocabulary; the symmetric distance value must not crash.
+    let policy = CustomWordsImportFuzzyPolicy(minimumLength: 1, maximumEditDistance: .max)
+    let empty = try await compare([candidate("Kubernetes")], against: [], policy: policy)
+    #expect(empty[0].classification == .new)
+
+    let existing = CustomWord(canonical: "Kubernetez")
+    let populated = try await compare(
+      [candidate("Kubernetes")], against: [existing], policy: policy)
+    #expect(populated[0].classification == .fuzzy(existing: existing, distance: 1))
+  }
+
+  @Test("a length gap wider than the maximum distance is never a fuzzy match")
+  func lengthGapWiderThanMaximumDistanceNeverMatches() async throws {
+    let results = try await compare(
+      [candidate("Kubernetes")], against: [CustomWord(canonical: "Kubern")],
+      policy: CustomWordsImportFuzzyPolicy(minimumLength: 5, maximumEditDistance: 2))
+    #expect(results[0].classification == .new)
+  }
+
+  @Test("candidate below the minimum length never fuzzy-matches")
+  func shortCandidateNeverFuzzyMatches() async throws {
+    let results = try await compare(
+      [candidate("Kube")], against: [word("Kubz")],
+      policy: CustomWordsImportFuzzyPolicy(minimumLength: 5, maximumEditDistance: 2))
+    #expect(results[0].classification == .new)
+  }
+
+  @Test("fuzzy boundary: exactly the maximum distance matches")
+  func fuzzyBoundaryAtMaximumDistanceMatches() async throws {
+    let existing = word("Kubernetes")
+    // Kubernetes -> Kubernetiz: two substitutions.
+    let results = try await compare(
+      [candidate("Kubernetiz")], against: [existing],
+      policy: CustomWordsImportFuzzyPolicy(minimumLength: 5, maximumEditDistance: 2))
+    #expect(results[0].classification == .fuzzy(existing: existing, distance: 2))
+  }
+
+  @Test("fuzzy boundary: one past the maximum distance does not match")
+  func fuzzyBoundaryBeyondMaximumDistanceDoesNotMatch() async throws {
+    let results = try await compare(
+      [candidate("Kubernetiz")], against: [word("Kubernetes")],
+      policy: CustomWordsImportFuzzyPolicy(minimumLength: 5, maximumEditDistance: 1))
+    #expect(results[0].classification == .new)
+  }
+
+  @Test("disabled policy never fuzzy-matches anything")
+  func disabledPolicyNeverFuzzyMatches() async throws {
+    let results = try await compare(
+      [candidate("Kubernetez")], against: [word("Kubernetes")], policy: .disabled)
+    #expect(results[0].classification == .new)
+  }
+
+  // MARK: - Punctuation and adversarial pairs
+
+  @Test("technical punctuation stays distinct: no exact, variant, or fuzzy collapse")
+  func technicalPunctuationRemainsDistinct() async throws {
+    let library = [word("C"), word("C++"), word("C#"), word(".NET"), word("node.js")]
+    // Even under a deliberately permissive policy, punctuation excludes the
+    // fuzzy path (letters-only rule), and normalization never strips it.
+    let permissive = CustomWordsImportFuzzyPolicy(minimumLength: 1, maximumEditDistance: 3)
+    let results = try await compare(
+      [candidate("C++"), candidate("C#"), candidate("nodejs")],
+      against: library, policy: permissive)
+    #expect(results[0].classification == .exact(existing: library[1]))  // C++ is itself,
+    #expect(results[1].classification == .exact(existing: library[2]))  // never C#
+    // "nodejs" is letters-only, but "node.js" is not, so fuzzy is excluded
+    // from BOTH sides and no other stage matches.
+    #expect(results[2].classification == .new)
+  }
+
+  @Test("adversarial brand pairs do not match under the conservative candidate policy")
+  func adversarialBrandPairsDoNotMatchUnderConservativePolicy() async throws {
+    let results = try await compare(
+      [candidate("Saurabh"), candidate("OpenAI")],
+      against: [word("Sarah"), word("OpenAPI")],
+      policy: Self.conservativeCandidatePolicy)
+    #expect(results[0].classification == .new)
+    #expect(results[1].classification == .new)
+  }
+
+  @Test("documentation: the mock-up placeholder policy fails the adversarial bar")
+  func mockupPlaceholderPolicyFailsTheAdversarialBar() async throws {
+    // Frozen as evidence for the pending founder threshold decision: under
+    // the demo's (≥5, ≤3) placeholder, both real-world distinct pairs are
+    // flagged as fuzzy duplicates. This freezes WHY the placeholder cannot
+    // ship uncalibrated; it does not bless the behavior.
+    let sarah = word("Sarah")
+    let openAPI = word("OpenAPI")
+    let results = try await compare(
+      [candidate("Saurabh"), candidate("OpenAI")],
+      against: [sarah, openAPI],
+      policy: Self.mockupPlaceholderPolicy)
+    #expect(results[0].classification == .fuzzy(existing: sarah, distance: 2))
+    #expect(results[1].classification == .fuzzy(existing: openAPI, distance: 1))
+  }
+
+  // MARK: - Ambiguity
+
+  @Test("canonical matching an alias owned by two existing words classifies ambiguous with both")
+  func canonicalMatchingAliasOwnedByTwoExistingWordsClassifiesAmbiguousWithBothMatches()
+    async throws
+  {
+    let zeta = word("Zeta", aliases: ["annie"])
+    let alpha = word("Alpha", aliases: ["Annie"])
+    let results = try await compare([candidate("annie")], against: [zeta, alpha])
+    guard case .ambiguous(let matches) = results[0].classification else {
+      Issue.record("expected ambiguous, got \(results[0].classification)")
+      return
+    }
+    #expect(matches.count == 2)
+    #expect(matches[0].existing == alpha)  // ordered by normalized canonical
+    #expect(matches[1].existing == zeta)
+    #expect(matches[0].kind == .variant(matchedAlias: "Annie"))
+  }
+
+  @Test("canonicals distinct on disk but identical under the import key classify ambiguous")
+  func canonicalsCollapsingUnderTheImportKeyClassifyAmbiguousNotArbitraryExact() async throws {
+    // `CustomWordsManager` dedups on `trimmed.lowercased()`, so these two are
+    // legitimately distinct in persisted data; this engine's key collapses
+    // them. Electing either one as "the" exact match would let Review offer
+    // to replace a word the user never meant.
+    let singleSpace = CustomWord(canonical: "Claude Code")
+    let doubleSpace = CustomWord(canonical: "Claude  Code")
+    let results = try await compare(
+      [candidate("claude code")], against: [singleSpace, doubleSpace])
+    guard case .ambiguous(let matches) = results[0].classification else {
+      Issue.record("expected ambiguous, got \(results[0].classification)")
+      return
+    }
+    #expect(matches.count == 2)
+    #expect(matches.allSatisfy { $0.kind == .exact })
+    #expect(Set(matches.map(\.existing.id)) == Set([singleSpace.id, doubleSpace.id]))
+  }
+
+  @Test("decomposed and precomposed duplicates on disk also classify ambiguous")
+  func unicodeDuplicatesOnDiskClassifyAmbiguous() async throws {
+    let precomposed = CustomWord(canonical: "caf\u{00E9}")
+    let decomposed = CustomWord(canonical: "cafe\u{0301}")
+    let results = try await compare(
+      [candidate("café")], against: [precomposed, decomposed])
+    guard case .ambiguous(let matches) = results[0].classification else {
+      Issue.record("expected ambiguous, got \(results[0].classification)")
+      return
+    }
+    #expect(matches.count == 2)
+  }
+
+  @Test("a single canonical owner still classifies exact, not ambiguous")
+  func singleCanonicalOwnerStaysExact() async throws {
+    let only = CustomWord(canonical: "Claude Code")
+    let results = try await compare(
+      [candidate("claude code")], against: [only, CustomWord(canonical: "Qualtrics")])
+    #expect(results[0].classification == .exact(existing: only))
+  }
+
+  @Test("single-owner alias match stays variant, not ambiguous")
+  func singleOwnerAliasMatchStaysVariantNotAmbiguous() async throws {
+    let owner = word("Parvati", aliases: ["annie"])
+    let results = try await compare(
+      [candidate("annie")], against: [owner, word("Zeta", aliases: ["zed"])])
+    #expect(results[0].classification == .variant(existing: owner, matchedAlias: "annie"))
+  }
+
+  @Test("fuzzy tie at equal minimal distance classifies ambiguous")
+  func fuzzyTieAtEqualMinimalDistanceClassifiesAmbiguous() async throws {
+    let first = word("Clarab")
+    let second = word("Clarac")
+    let results = try await compare(
+      [candidate("Claraz")], against: [second, first],
+      policy: CustomWordsImportFuzzyPolicy(minimumLength: 5, maximumEditDistance: 1))
+    guard case .ambiguous(let matches) = results[0].classification else {
+      Issue.record("expected ambiguous, got \(results[0].classification)")
+      return
+    }
+    #expect(matches.count == 2)
+    #expect(matches[0].existing == first)  // deterministic order despite library order
+    #expect(matches[1].existing == second)
+    #expect(matches[0].kind == .fuzzy(distance: 1))
+  }
+
+  @Test("unique minimal fuzzy distance stays fuzzy even when farther matches exist")
+  func uniqueMinimalFuzzyDistanceStaysFuzzyEvenWhenFartherMatchesExist() async throws {
+    let close = word("Clarab")
+    let farther = word("Clarxyz")
+    let results = try await compare(
+      [candidate("Claraz")], against: [farther, close],
+      policy: CustomWordsImportFuzzyPolicy(minimumLength: 5, maximumEditDistance: 3))
+    #expect(results[0].classification == .fuzzy(existing: close, distance: 1))
+  }
+
+  @Test("ambiguous match list order is deterministic regardless of library order")
+  func ambiguousMatchListOrderIsDeterministic() async throws {
+    let alpha = word("Alpha", aliases: ["shared"])
+    let zeta = word("Zeta", aliases: ["shared"])
+    for library in [[alpha, zeta], [zeta, alpha]] {
+      let results = try await compare([candidate("shared")], against: library)
+      guard case .ambiguous(let matches) = results[0].classification else {
+        Issue.record("expected ambiguous, got \(results[0].classification)")
+        return
+      }
+      #expect(matches.map(\.existing) == [alpha, zeta])
+    }
+  }
+
+  // MARK: - Duplicate-candidate coalescing
+
+  @Test("repeated incoming canonical coalesces to the first row, unioning supplied aliases")
+  func repeatedIncomingCanonicalCoalescesAndMergesAliases() async throws {
+    let first = candidate("Kubernetes", aliases: .supplied(["k8s"]))
+    let second = candidate("kubernetes", aliases: .supplied(["kube", "K8S"]))
+    let results = try await compare([first, second], against: [])
+    #expect(results.count == 1)
+    #expect(results[0].candidate.id == first.id)
+    #expect(results[0].candidate.canonical == "Kubernetes")
+    // K8S deduplicates against k8s via the normalization key; first spelling wins.
+    #expect(results[0].candidate.aliases == .supplied(["k8s", "kube"]))
+  }
+
+  @Test("candidates the manager would store separately stay separate review rows")
+  func candidatesDistinctUnderThePersistenceKeyAreNotCoalesced() async throws {
+    // The backup round-trip regression: `CustomWordsManager` dedups on
+    // `trimmed.lowercased()`, so a library can hold BOTH of these, and an
+    // export of that library contains both. Coalescing on the stronger
+    // matching key would merge them into one row and make the second word
+    // impossible to restore.
+    let first = candidate("Claude Code")
+    let second = candidate("Claude  Code")
+    let results = try await compare([first, second], against: [])
+    #expect(results.count == 2)
+    #expect(results.map(\.candidate.canonical) == ["Claude Code", "Claude  Code"])
+    #expect(results.allSatisfy { $0.classification == .new })
+  }
+
+  @Test("coalescing keeps the first supplied value per field, independently")
+  func coalescedDuplicatesKeepFirstSuppliedFieldPerFieldIndependently() async throws {
+    var first = candidate("Kubernetes")
+    first.priority = .supplied(5)
+    var second = candidate("KUBERNETES")
+    second.category = .supplied(.brand)
+    second.priority = .supplied(9)
+    second.caseSensitive = .supplied(true)
+    let results = try await compare([first, second], against: [])
+    #expect(results.count == 1)
+    let merged = results[0].candidate
+    #expect(merged.priority == .supplied(5))  // first row's supplied value wins
+    #expect(merged.category == .supplied(.brand))  // first row had no opinion
+    #expect(merged.caseSensitive == .supplied(true))
+    #expect(merged.forceReplace == .unspecified)  // nobody supplied it
+  }
+
+  @Test("coalescing distinguishes unspecified from supplied-nil strictness override")
+  func coalescingDistinguishesUnspecifiedFromSuppliedNilMinSimilarityOverride() async throws {
+    var first = candidate("Kubernetes")
+    first.minSimilarityOverride = .unspecified
+    var second = candidate("kubernetes")
+    second.minSimilarityOverride = .supplied(nil)  // authoritative "no override"
+    let results = try await compare([first, second], against: [])
+    #expect(results[0].candidate.minSimilarityOverride == .supplied(nil))
+  }
+
+  @Test("coalesced aliases stay unspecified only when every duplicate row was unspecified")
+  func coalescedDuplicatesUnionSuppliedAliasesAndStayUnspecifiedWhenAllRowsAreUnspecified()
+    async throws
+  {
+    let allUnspecified = try await compare(
+      [candidate("Kubernetes"), candidate("kubernetes")], against: [])
+    #expect(allUnspecified[0].candidate.aliases == .unspecified)
+
+    let oneSupplied = try await compare(
+      [candidate("Kubernetes"), candidate("kubernetes", aliases: .supplied(["k8s"]))],
+      against: [])
+    #expect(oneSupplied[0].candidate.aliases == .supplied(["k8s"]))
+  }
+
+  // MARK: - Alias-collision detection (disclosure only)
+
+  @Test("candidate alias matching a different existing word's alias is flagged")
+  func candidateAliasMatchingDifferentExistingWordIsFlaggedAsCollision() async throws {
+    let incumbent = word("Anika", aliases: ["annie"])
+    let results = try await compare(
+      [candidate("Annabelle", aliases: .supplied(["Annie"]))], against: [incumbent])
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "Annie", heldBy: incumbent.id)
+      ])
+  }
+
+  @Test("a variant match's own matched alias is the reason for the match, not a collision")
+  func candidateAliasMatchingItsOwnClassifiedMatchIsNotFlagged() async throws {
+    let existing = word("Parvati", aliases: ["Pavarthi"])
+    let results = try await compare([candidate("pavarthi")], against: [existing])
+    #expect(
+      results[0].classification == .variant(existing: existing, matchedAlias: "Pavarthi"))
+    #expect(results[0].collidingAliases.isEmpty)
+  }
+
+  @Test("new candidate with an alias matching any existing word is flagged")
+  func newCandidateWithAliasMatchingAnyExistingWordIsFlagged() async throws {
+    let incumbent = word("Anika", aliases: ["annie"])
+    let results = try await compare(
+      [candidate("Zed", aliases: .supplied(["annie", "zeddy"]))], against: [incumbent])
+    #expect(results[0].classification == .new)
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "annie", heldBy: incumbent.id)
+      ])
+  }
+
+  @Test("when two existing words share an alias, the collision names the runtime winner")
+  func sharedIncumbentAliasReportsTheRuntimeWinningOwner() async throws {
+    // `WordCorrector.buildLookups` assigns the alias map unconditionally
+    // (WordCorrector.swift:180-214), so the LATER word claims the trigger at
+    // runtime — its own collision log says "using <later canonical>". The
+    // reported owner has to match that, or F2c's Replace-target suppression
+    // compares against a word that is not really holding the alias.
+    let earlier = CustomWord(canonical: "Anika", aliases: ["annie"])
+    let later = CustomWord(canonical: "Annabelle", aliases: ["annie"])
+    let results = try await compare(
+      [candidate("Zed", aliases: .supplied(["Annie"]))], against: [earlier, later])
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "Annie", heldBy: later.id)
+      ])
+  }
+
+  @Test("aliases that differ only by internal whitespace do not collide")
+  func aliasesDifferingOnlyByInternalWhitespaceAreNotFlagged() async throws {
+    // Collisions are a claim about the stored/correction-map slot, which uses
+    // the manager's weaker key — these two never actually collide at runtime,
+    // so flagging them would be a false positive.
+    let incumbent = CustomWord(canonical: "Anika", aliases: ["New York"])
+    let results = try await compare(
+      [candidate("Zed", aliases: .supplied(["New  York"]))], against: [incumbent])
+    #expect(results[0].collidingAliases.isEmpty)
+  }
+
+  @Test("non-colliding aliases are not flagged")
+  func nonCollidingAliasesAreNotFlagged() async throws {
+    let results = try await compare(
+      [candidate("Zed", aliases: .supplied(["zeddy", "zedster"]))],
+      against: [word("Anika", aliases: ["annie"])])
+    #expect(results[0].collidingAliases.isEmpty)
+  }
+
+  @Test("an alias owned by the candidate's own exact match IS still flagged here, by design")
+  func aliasOwnedByTheCandidatesOwnExactMatchIsFlaggedForF2cToSuppress() async throws {
+    // DELIBERATE, per the adopted plan (PR-F2a §alias-collision detection):
+    // F2a is decision-agnostic — it runs before any Review decision exists,
+    // so it cannot know the user will pick Replace and make this harmless.
+    // It records the collision naming the matched word; **F2c** suppresses
+    // the inline note when the row's Decision is Replace and `heldBy` is the
+    // word being replaced, and F2b's enforcement evaluates the applied
+    // result (where the word owns its own alias and nothing is dropped).
+    // This test exists so the behavior reads as a design assignment rather
+    // than an oversight — a reviewer flagged it as a false positive, which
+    // it is at the DISPLAY layer, and the display layer is F2c's.
+    let existing = CustomWord(canonical: "Parvati", aliases: ["Pavarthi"])
+    let results = try await compare(
+      [candidate("Parvati", aliases: .supplied(["Pavarthi"]))], against: [existing])
+    #expect(results[0].classification == .exact(existing: existing))
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "Pavarthi", heldBy: existing.id)
+      ])
+  }
+
+  @Test("a candidate's own duplicate alias spellings are not flagged against itself")
+  func candidateOwnDuplicateAliasSpellingsAreNotFlaggedAgainstItself() async throws {
+    let results = try await compare(
+      [candidate("Annabelle", aliases: .supplied(["annie", "ANNIE", "Annie"]))],
+      against: [])
+    #expect(results[0].collidingAliases.isEmpty)
+  }
+
+  @Test("a candidate with no supplied aliases produces no collisions")
+  func candidateWithUnspecifiedAliasesProducesNoCollisions() async throws {
+    let results = try await compare(
+      [candidate("Annabelle")], against: [word("Anika", aliases: ["annabelle"])])
+    #expect(results[0].collidingAliases.isEmpty)
+  }
+
+  @Test("two incoming candidates sharing an alias flag only the later candidate")
+  func twoIncomingCandidatesSharingAnAliasFlagsOnlyTheLaterCandidateAgainstTheEarlierOwner()
+    async throws
+  {
+    let earlier = candidate("Anika", aliases: .supplied(["annie"]))
+    let later = candidate("Annabelle", aliases: .supplied(["Annie"]))
+    let results = try await compare([earlier, later], against: [])
+    #expect(results[0].collidingAliases.isEmpty)  // the winner's alias is not at risk
+    #expect(
+      results[1].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "Annie", heldBy: earlier.id)
+      ])
+  }
+
+  @Test("candidate alias matching an existing canonical is flagged")
+  func candidateAliasMatchingAnExistingCanonicalIsFlagged() async throws {
+    let incumbent = word("Anika")
+    let results = try await compare(
+      [candidate("Annabelle", aliases: .supplied(["anika"]))], against: [incumbent])
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "anika", heldBy: incumbent.id)
+      ])
+  }
+
+  @Test("candidate alias equal to its own canonical is normalized away, not flagged")
+  func candidateAliasEqualToItsOwnCanonicalIsNormalizedAwayNotFlagged() async throws {
+    let results = try await compare(
+      [candidate("Anika", aliases: .supplied(["ANIKA", "annie"]))], against: [])
+    #expect(results[0].collidingAliases.isEmpty)
+  }
+
+  @Test(
+    "alias colliding with both a canonical and another candidate's alias reports the canonical owner"
+  )
+  func aliasCollidingWithBothACanonicalAndAnotherCandidateAliasReportsTheCanonicalOwner()
+    async throws
+  {
+    // "anika" is simultaneously an existing CANONICAL and an earlier
+    // candidate's alias; canonical ownership is checked first, so the
+    // existing word wins, and the earlier candidate's identical alias was
+    // itself flagged against that canonical rather than registered as an
+    // alias owner.
+    let incumbent = word("Anika")
+    let earlier = candidate("Zed", aliases: .supplied(["anika"]))
+    let later = candidate("Annabelle", aliases: .supplied(["Anika"]))
+    let results = try await compare([earlier, later], against: [incumbent])
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "anika", heldBy: incumbent.id)
+      ])
+    #expect(
+      results[1].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "Anika", heldBy: incumbent.id)
+      ])
+  }
+
+  @Test("earlier candidate's alias loses to a later candidate's canonical")
+  func
+    earlierCandidateAliasMatchingLaterCandidateCanonicalFlagsEarlierAliasAgainstLaterCanonicalOwner()
+    async throws
+  {
+    // Every incoming canonical is registered before any imported alias is
+    // checked, so plan order does not protect the earlier alias here.
+    let earlier = candidate("Zed", aliases: .supplied(["annabelle"]))
+    let later = candidate("Annabelle")
+    let results = try await compare([earlier, later], against: [])
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "annabelle", heldBy: later.id)
+      ])
+    #expect(results[1].collidingAliases.isEmpty)
+  }
+
+  // MARK: - Cancellation
+
+  @Test("cancelled compare throws and returns nothing")
+  func cancelledCompareThrowsAndReturnsNothing() async throws {
+    let engine = CustomWordsImportCompareEngine()
+    let candidates = (0..<5).map { candidate("word\($0)") }
+    // Cancel from INSIDE the task before compare runs — deterministic, no
+    // race against task startup (a post-creation cancel() can lose to a
+    // fast compare and flake).
+    let task = Task { () -> [CustomWordsImportComparison] in
+      withUnsafeCurrentTask { $0?.cancel() }
+      return try await engine.compare(
+        candidates: candidates, against: [], fuzzyPolicy: .disabled)
+    }
+    await #expect(throws: CancellationError.self) {
+      _ = try await task.value
+    }
+  }
+}


### PR DESCRIPTION
Part of #1619 (PR-F2a in the adopted v5 plan). Closes #1661.

Tier: REFACTOR | Lane: Code | Modules: Core, PostProcessing

## What

The canonical shared import contract plus the compare/dedup engine every import source will feed into. No persistence, no UI, no `CustomWordsManager` change, no production consumer yet — the same complete-tested-unit-without-a-caller pattern PR-F1 established, not an unused seam.

**`Sources/EnviousWisprCore/CustomWordsImportContract.swift`** — `AppleIntelligenceAvailability`, the `CustomWordsImportField` authority carrier, `CustomWordsImportCandidate`, `CustomWordsImportNotice`, `CustomWordsImportBatch`, `CustomWordsImportSource`. Core placement is load-bearing: the File Import and Smart Import leaf modules depend only on Core and could not import PostProcessing. The candidate type deliberately cannot carry `source`, `frequencyUsed`, or `lastUsed`, so no adapter can import another Mac's usage history.

**`Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift`** — fuzzy policy, the five-way classification, ambiguous-match and alias-collision types, and the `actor` itself.

- Staged classification, fixed order: exact canonical → variant (candidate canonical equals an existing alias) → fuzzy (capped Levenshtein against existing canonicals only) → new.
- **Ambiguity is represented, never tie-broken away.** Two existing words can legitimately share an alias (the library enforces canonical uniqueness only), and two canonicals can sit at the same minimal fuzzy distance. Both classify `ambiguous` carrying every equally-valid match, deterministically ordered (normalized canonical, then UUID) — the tie-break orders the list instead of silently electing a winner Review would then offer to replace.
- **Normalization never strips punctuation** — case-fold, precompose, trim, collapse internal whitespace, nothing else, so `C` / `C++` / `C#` / `.NET` / `node.js` stay distinct.
- Fuzzy is conservative and opt-in: policy must be enabled, both sides meet a minimum length, both are letters-only, aliases are never a fuzzy surface.
- Duplicate-candidate coalescing is per-field first-`.supplied`, evaluated independently, with aliases unioned in plan order.
- Alias-collision detection is fully decision-agnostic (it runs before any Review decision exists) and covers all three surfaces: candidate-vs-library, candidate-vs-candidate, and alias-vs-canonical with canonical-before-alias precedence. Detection and disclosure only — enforcement is PR-F2b's job.

## Deltas vs. the adopted plan, and why

Two changes made during self-review rather than shipped as written:

1. **Cancellation covers every stage, not just the classification loop.** The plan sketched `Task.checkCancellation()` in the final loop; coalescing and collision detection are also real work at Upload's 25,000-row admission cap, so both are now cancellable too. `coalesceDuplicates` and `detectAliasCollisions` became `throws` accordingly.
2. **Dropped an unreachable branch** in the collision detector. A candidate can only ever own its own canonical surface, which the preceding self-canonical guard already consumes, so the "canonical owner is me" case could not be reached; the intent is now stated as a comment where the reasoning lives.

Grounding confirmed against current main rather than assumed: `WordCorrector.swift:180-214` really does insert aliases before canonicals and skip a canonical whose key an alias already owns (the reason alias collisions matter at all); `CustomWordsManager` really does dedup canonicals case-insensitively and nothing else; `Project.swift` really does establish one package-access identifier, so `package` suffices with no module-graph edit.

Owner audit: no existing normalizer covers this capability. `InverseTextNormalizer.normalize` is number/date/money text normalization, and `WordCorrector`'s `.lowercased()` keys serve the runtime correction lane with different semantics. This is the first owner of the import matching key, deliberately not merged with either.

## Tests

`CustomWordsImportCompareEngineTests` — 43 tests: every classification, both ambiguity kinds plus their deterministic ordering, the strictly-worse-match case that must stay `fuzzy`, per-field and `.supplied(nil)`-vs-`.unspecified` coalescing, all alias-collision surfaces including three not-a-collision cases, cancellation, and the adversarial matcher set (`Saurabh`/`Sarah`, `OpenAI`/`OpenAPI`, `C++`/`C#` must never match).

One test is deliberately documentary: `mockupPlaceholderPolicyFailsTheAdversarialBar` freezes the fact that the mock-up's inherited placeholder thresholds (length ≥5, distance ≤3) flag **both** adversarial pairs as duplicates. That is evidence for the founder's still-pending threshold decision (bible §8 risk register), not a blessing of the behavior — the engine takes the policy as a parameter and ships with `.disabled` available, so no threshold is baked in by this PR.

## Validation

- Full local Debug suite green via the worktree's own `scripts/xcode-test.sh`.
- Local `codex review` to clean before push.
- **No Live UAT arm:** this PR ships no user-reachable surface (no UI, no persistence, no production caller). Validated by unit tests plus Debug/Release compilation; recorded as validly skipped rather than silently omitted.

## Review outcome (5 local rounds, findings converging 2/2/1/1/1)

Root cause behind rounds 1-2: **one normalization key doing two jobs.** Split into a persistence key (mirrors the manager's dedup and the corrector's lookup — owns coalescing and collision detection) and a matching key (adds Unicode precomposition and whitespace collapse — owns classification only). Table and the rule for later PRs are in the plan; F2b's uniqueness recheck and alias enforcement are persistence questions.

Critical fixes adopted: an arbitrary word being elected as the exact match when two library canonicals collapse under the matching key (now ambiguous, with a new `.exact` match kind); coalescing merging two candidates a backup legitimately contains, which made restoring that backup lose the second word; collisions naming the wrong owner when two existing words share an alias (now mirrors the corrector's real last-write-wins precedence); and an overflow trap on an extreme policy distance.

Declined with reasoning: exempting aliases owned by the replacement target. Real at the display layer, but the plan assigns that suppression to F2c, the only stage that knows the chosen decision. Frozen in a test naming the assignment.

Documented as a fast follow rather than solved: #1663, fuzzy scale at the 25k cap. Bounded here (pre-normalized, length-bucketed) but still linear within a bucket; a real index is only worth building once fuzzy is known to ship and its thresholds are measured, both open founder decisions.
