### PR TITLE
feat(services): compile-time guard narrows Sentry capture to conforming errors

### DIFF
--- a/Sources/EnviousWisprAppKit/App/HeartControlRecovery.swift
+++ b/Sources/EnviousWisprAppKit/App/HeartControlRecovery.swift
@@ -23,8 +23,12 @@ struct HeartControlRecovery {
 
   func logDispatchFailure(_ error: any Error, op: String) {
     guard !(error is CancellationError) else { return }
+    // Row 11 (#1525 PR J-1): production-inert today (only `.preWarm` can
+    // actually throw here) — normalize anyway so a future implementation
+    // change that starts throwing something real still alerts.
     SentryBreadcrumb.captureError(
-      error, category: .pipelineDispatchFailed, stage: "recording",
+      SentryCaptureBoundaryError.normalizingHeartControlFailure(error),
+      category: .pipelineDispatchFailed, stage: "recording",
       extra: ["op": op, "backend": backend()])
   }
 
@@ -35,7 +39,8 @@ struct HeartControlRecovery {
     let isCancellation = error is CancellationError
     if !isCancellation {
       SentryBreadcrumb.captureError(
-        error, category: .pipelineDispatchFailed, stage: "recording",
+        SentryCaptureBoundaryError.normalizingHeartControlFailure(error),
+        category: .pipelineDispatchFailed, stage: "recording",
         extra: ["op": op, "backend": backend()])
     }
     hideOverlay()

--- a/Sources/EnviousWisprCore/SentryCaptureBoundaryError.swift
+++ b/Sources/EnviousWisprCore/SentryCaptureBoundaryError.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Closed, exhaustive boundary-violation identity for #1525 PR J-1's compile-time guard.
+/// Every case is a FIXED literal — the two associated-`Int` cases carry an OS/vendor's
+/// own stable numeric code for the one proven external family each represents, never our
+/// own ordinal. A future error type must still be given a real `StableSentryErrorIdentity`
+/// conformance to reach `captureError` through its normal path; this type exists only for
+/// the small number of seams named below, each of which normalizes explicitly at ONE
+/// reviewed call site. Reusing an existing `.unexpected*` case for a genuinely new class of
+/// error is possible (this enum cannot prevent that by itself) but requires the author to
+/// explicitly choose to misuse a "should never happen" case rather than give their new type
+/// a real conformance — a visible, reviewable choice, not a silent one.
+package enum SentryCaptureBoundaryError: Error, StableSentryErrorIdentity, Sendable, Equatable {
+  /// Row 5: raw `URLError` reaching `TextProcessingRunner`'s polish-alerting seam.
+  case urlTransport(code: Int)
+  /// Row 8: Parakeet's raw-vendor transcription passthrough when the domain is CoreML.
+  case coreML(code: Int)
+  case unexpectedGenerationFailure  // rows 5 (non-URLError branch) and 9 (AFM)
+  case unexpectedTranscriptionFailure  // row 8 (non-CoreML)
+  case unexpectedLegacyKeyCleanupFailure  // row 10
+  case unexpectedHeartControlFailure  // row 11
+
+  package var sentryFingerprintDescriptor: String {
+    switch self {
+    case .urlTransport(let code): return "NSURLErrorDomain#\(code)"
+    case .coreML(let code): return "com.apple.CoreML#\(code)"
+    case .unexpectedGenerationFailure:
+      return "EnviousWisprCore.SentryCaptureBoundaryError.unexpected_generation_failure"
+    case .unexpectedTranscriptionFailure:
+      return "EnviousWisprCore.SentryCaptureBoundaryError.unexpected_transcription_failure"
+    case .unexpectedLegacyKeyCleanupFailure:
+      return "EnviousWisprCore.SentryCaptureBoundaryError.unexpected_legacy_key_cleanup_failure"
+    case .unexpectedHeartControlFailure:
+      return "EnviousWisprCore.SentryCaptureBoundaryError.unexpected_heart_control_failure"
+    }
+  }
+
+  package var sentrySemanticID: String {
+    switch self {
+    case .urlTransport: return "polish.external_url_transport"
+    case .coreML: return "asr.external_coreml"
+    case .unexpectedGenerationFailure: return "boundary.unexpected_generation_failure"
+    case .unexpectedTranscriptionFailure: return "boundary.unexpected_transcription_failure"
+    case .unexpectedLegacyKeyCleanupFailure: return "boundary.unexpected_legacy_key_cleanup_failure"
+    case .unexpectedHeartControlFailure: return "boundary.unexpected_heart_control_failure"
+    }
+  }
+}
+
+// MARK: - Seam normalizers
+
+/// One normalizer per seam that stays generic (`any Error`) and must produce a
+/// conforming value before calling the narrowed `SentryBreadcrumb.captureError`.
+/// Each keeps an already-conforming value unchanged; only a genuine miss falls to
+/// this enum. Living beside the cases they construct keeps the boundary
+/// vocabulary and its normalization logic a single authority (§3c) rather than
+/// five ad-hoc cast-or-fallback copies at each call site.
+extension SentryCaptureBoundaryError {
+  /// Rows 5/9: cloud-polish transport errors and AFM generation failures. A raw
+  /// `URLError` preserves its exact historical fingerprint; anything else
+  /// non-conforming becomes the shared "unexpected generation failure" identity.
+  package static func normalizingGenerationFailure(
+    _ error: any Error
+  ) -> any Error & StableSentryErrorIdentity {
+    if let stable = error as? any Error & StableSentryErrorIdentity { return stable }
+    if let urlError = error as? URLError {
+      return SentryCaptureBoundaryError.urlTransport(code: urlError.code.rawValue)
+    }
+    return SentryCaptureBoundaryError.unexpectedGenerationFailure
+  }
+
+  /// Row 8: Parakeet's raw-vendor transcription passthrough. A raw CoreML
+  /// `NSError` preserves its exact historical fingerprint; anything else
+  /// non-conforming becomes the shared "unexpected transcription failure" identity.
+  package static func normalizingTranscriptionFailure(
+    _ error: any Error
+  ) -> any Error & StableSentryErrorIdentity {
+    if let stable = error as? any Error & StableSentryErrorIdentity { return stable }
+    let ns = error as NSError
+    if ns.domain == "com.apple.CoreML" {
+      return SentryCaptureBoundaryError.coreML(code: ns.code)
+    }
+    return SentryCaptureBoundaryError.unexpectedTranscriptionFailure
+  }
+
+  /// Row 10: the legacy plaintext API-key cleanup failure seam.
+  package static func normalizingLegacyKeyCleanupFailure(
+    _ error: any Error
+  ) -> any Error & StableSentryErrorIdentity {
+    (error as? any Error & StableSentryErrorIdentity)
+      ?? SentryCaptureBoundaryError.unexpectedLegacyKeyCleanupFailure
+  }
+
+  /// Row 11: `HeartControlRecovery`'s two dispatch-failure methods.
+  package static func normalizingHeartControlFailure(
+    _ error: any Error
+  ) -> any Error & StableSentryErrorIdentity {
+    (error as? any Error & StableSentryErrorIdentity)
+      ?? SentryCaptureBoundaryError.unexpectedHeartControlFailure
+  }
+}

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -30,7 +30,7 @@ final class HeartPathTelemetryEmitter {
   // MARK: - Sinks (closure-based; default wires SentryBreadcrumb)
 
   typealias CaptureErrorSink = @MainActor (
-    _ error: any Error,
+    _ error: any Error & StableSentryErrorIdentity,
     _ category: SentryBreadcrumb.ErrorCategory,
     _ stage: String,
     _ extra: [String: Any]?

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -48,7 +48,7 @@ public enum KernelDictationDriverFactory {
   /// cancellation "zero Sentry errors" test catches a regression through any
   /// path — not only the emitter (Codex review #875).
   package typealias HeartPathCaptureErrorSink = @MainActor (
-    _ error: any Error,
+    _ error: any Error & StableSentryErrorIdentity,
     _ category: SentryBreadcrumb.ErrorCategory,
     _ stage: String,
     _ extra: [String: Any]?,

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -47,14 +47,14 @@ final class KernelLifecycleTelemetrySink {
   ) -> Void
 
   typealias CaptureErrorSink = @MainActor (
-    _ error: any Error,
+    _ error: any Error & StableSentryErrorIdentity,
     _ category: SentryBreadcrumb.ErrorCategory,
     _ stage: String,
     _ extra: [String: Any]?
   ) -> Void
 
   typealias SnapshotCaptureErrorSink = @MainActor (
-    _ error: any Error,
+    _ error: any Error & StableSentryErrorIdentity,
     _ category: SentryBreadcrumb.ErrorCategory,
     _ stage: String,
     _ extra: [String: Any]?,
@@ -536,7 +536,7 @@ final class KernelLifecycleTelemetrySink {
   }
 
   private func emitCaptureError(
-    _ error: any Error,
+    _ error: any Error & StableSentryErrorIdentity,
     _ category: SentryBreadcrumb.ErrorCategory,
     _ stage: String,
     _ extra: [String: Any]?,
@@ -635,11 +635,17 @@ final class KernelLifecycleTelemetrySink {
           "capture_session_id": Int(audioCapture.currentCaptureSessionID),
         ])
     case .asrFailed, .asrWedged:
+      // Row 8 (#1525 PR J-1): `transcriptionFailureError` stays `(any Error)?`
+      // because Parakeet's raw-vendor passthrough can be a non-conforming
+      // CoreML error (the recognized FluidAudio path already conforms). A
+      // conforming value (including the `KernelFallbackSentryError` default)
+      // passes through unchanged; a genuine miss becomes `.coreML`/
+      // `.unexpectedTranscriptionFailure` — never a silent drop.
       let error =
         telemetryState.transcriptionFailureError
         ?? KernelFallbackSentryError.transcriptionFailed
       emitCaptureError(
-        error,
+        SentryCaptureBoundaryError.normalizingTranscriptionFailure(error),
         .asrFailed, "transcription",
         ["backend": backend.rawValue],
         snapshot: recordingSnapshot())

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -12,7 +12,7 @@ final class KernelTelemetryState {
   var noSpeechTelemetry: KernelNoSpeechTelemetry?
   var asrEmptyDiagnostics: ASREmptyResultDiagnostics?
   var asrCompletedTelemetry: KernelASRCompletedTelemetry?
-  var captureFailureError: (any Error)?
+  var captureFailureError: (any Error & StableSentryErrorIdentity)?
   /// #1167: set by the best-effort `store` closure when the durable history save
   /// throws. The lifecycle sink reads it to withhold the "transcript durably
   /// saved" success marker on a degraded-save completion. The operational source
@@ -20,7 +20,7 @@ final class KernelTelemetryState {
   /// NOT this telemetry mirror.
   var historySaveFailed = false
   var transcriptionFailureError: (any Error)?
-  var modelLoadError: (any Error)?
+  var modelLoadError: (any Error & StableSentryErrorIdentity)?
   /// #1434: the ONE capture-health record every post-stop consumer reads.
   /// Stamped immediately after `stopCapture()` returns + the stale-session
   /// guard passes — BEFORE the too-short / no-audio / dead-air early

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -120,7 +120,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   struct TelemetrySeams {
     let limbFailureObserved: @MainActor (String, String, String, String, Int?) -> Void
     let breadcrumbStarted: @MainActor (String, [String: Any]?) -> Void
-    let captureProviderInitError: @MainActor (any Error) -> Void
+    let captureProviderInitError: @MainActor (any Error & StableSentryErrorIdentity) -> Void
     let captureAFMPolishError: @MainActor (any Error) -> Void
     let breadcrumbCompleted: @MainActor (String, [String: Any]?) -> Void
     /// The too-short bypass's own emit — this path returns from `process()`

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -998,7 +998,11 @@ final class RecordingSessionKernel {
       try await audioCapture.startEnginePhase()
     } catch {
       guard isCurrent(sid) else { return }
-      telemetryState.captureFailureError = error
+      // #1525 PR J-1: the write-site static type is `any Error` (an untyped
+      // `throws` surface), so an intersection cast is required before
+      // narrowing — a miss leaves the property nil and the read-side
+      // `KernelFallbackSentryError` fallback fires (§4).
+      telemetryState.captureFailureError = error as? (any Error & StableSentryErrorIdentity)
       finishTerminal(.failed(Self.classifyCaptureStartError(error)), sid: sid)
       return
     }
@@ -1033,7 +1037,9 @@ final class RecordingSessionKernel {
         try await audioCapture.startEnginePhase()
       } catch {
         guard isCurrent(sid) else { return }
-        telemetryState.captureFailureError = error
+        // #1525 PR J-1: see the identical cast note at the first
+        // `startEnginePhase()` catch above.
+        telemetryState.captureFailureError = error as? (any Error & StableSentryErrorIdentity)
         finishTerminal(.failed(Self.classifyCaptureStartError(error)), sid: sid)
         return
       }
@@ -1139,7 +1145,9 @@ final class RecordingSessionKernel {
     } catch {
       guard isCurrent(sid) else { return }
       audioCapture.onBufferCaptured = nil
-      telemetryState.captureFailureError = error
+      // #1525 PR J-1: see the identical cast note at the capture-start
+      // catches above.
+      telemetryState.captureFailureError = error as? (any Error & StableSentryErrorIdentity)
       finishTerminal(.failed(.captureStartFailed), sid: sid)
       return
     }
@@ -2295,7 +2303,14 @@ final class RecordingSessionKernel {
     if stopLatched { return .stopped }
     if cancelRequested { return .cancelled }
     if adapter.readiness == .ready { return .ready }
-    if let thrownError { telemetryState.modelLoadError = thrownError }
+    // #1525 PR J-1: identical cast pattern to `captureFailureError` above
+    // (§4) — a miss (the rare XPC last-resort raw error,
+    // `ASRManagerProxy.swift:222-229`) leaves the property nil and the
+    // read-side `KernelFallbackSentryError.modelLoadFailed` fallback fires.
+    // Restoring that rare case's own identity is PR J-2 (#1658).
+    if let thrownError {
+      telemetryState.modelLoadError = thrownError as? (any Error & StableSentryErrorIdentity)
+    }
     return .loadFailed
   }
 

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -98,8 +98,12 @@ internal final class TextProcessingRunner {
     /// Production: alerting Sentry events plus the counted `llm.polish_*` events.
     static let live = TelemetrySeams(
       captureError: { error, category, stage, extra, tags, fingerprintDetail in
+        // Row 5 (#1525 PR J-1): the seam stays generic (a raw `URLError` from
+        // cloud polish is a proven, genuinely-reachable non-conforming value)
+        // — normalize before calling the narrowed `SentryBreadcrumb.captureError`.
         SentryBreadcrumb.captureError(
-          error, category: category, stage: stage, extra: extra, tags: tags,
+          SentryCaptureBoundaryError.normalizingGenerationFailure(error),
+          category: category, stage: stage, extra: extra, tags: tags,
           fingerprintDetail: fingerprintDetail)
       },
       recordPolishFailed: { provider, model, reason, isTimeout in

--- a/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
+++ b/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
@@ -19,7 +19,8 @@ extension LLMTelemetrySink {
   ) -> Void
 
   package typealias HandledErrorReporter = @MainActor (
-    _ error: any Error, _ category: SentryBreadcrumb.ErrorCategory, _ stage: String,
+    _ error: any Error & StableSentryErrorIdentity, _ category: SentryBreadcrumb.ErrorCategory,
+    _ stage: String,
     _ extra: [String: Any]?, _ fingerprintDetail: String?
   ) -> Void
 
@@ -63,8 +64,12 @@ extension LLMTelemetrySink {
             // handled error (per-incident detail). Account name only, never key material.
             limbFailureReporter(
               "keychain", "legacy_cleanup", "failed", "delete_failed", nil)
+            // Row 10 (#1525 PR J-1): normalize before calling the narrowed
+            // reporter — the production conformer always converts, but the
+            // write-site static type is `any Error` (untyped `throws`).
             handledErrorReporter(
-              error, .legacyKeyCleanupFailed, "keychain", ["account": account], account)
+              SentryCaptureBoundaryError.normalizingLegacyKeyCleanupFailure(error),
+              .legacyKeyCleanupFailed, "keychain", ["account": account], account)
           }
         }
       })

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -143,7 +143,7 @@ public enum SentryBreadcrumb {
   ///     without this they would all merge into one issue). Pass the stable reason
   ///     tag so each cause gets its own Sentry issue (#945).
   public static func captureError(
-    _ error: any Error,
+    _ error: any Error & StableSentryErrorIdentity,
     category: ErrorCategory,
     stage: String,
     extra: [String: Any]? = nil,
@@ -189,7 +189,7 @@ public enum SentryBreadcrumb {
   /// Stays `@MainActor` (unlike the pure fingerprint helpers): `mergedExtra` invokes
   /// the `@MainActor` audio-environment provider.
   static func makeHandledErrorEvent(
-    _ error: any Error,
+    _ error: any Error & StableSentryErrorIdentity,
     category: ErrorCategory,
     stage: String,
     extra: [String: Any]? = nil,
@@ -206,10 +206,10 @@ public enum SentryBreadcrumb {
       "error.category": category.rawValue,
     ]
     // Readable name for the pinned identity. Metadata only — never in the
-    // fingerprint, so renaming it can never re-group an issue (#1524).
-    if let stable = error as? any StableSentryErrorIdentity {
-      eventTags["error.identity"] = stable.sentrySemanticID
-    }
+    // fingerprint, so renaming it can never re-group an issue (#1524). The
+    // parameter is already narrowed to a conforming type (#1525 PR J-1), so no
+    // cast is needed here.
+    eventTags["error.identity"] = error.sentrySemanticID
     for (key, value) in tags {
       eventTags[key] = value
     }
@@ -319,7 +319,9 @@ public enum SentryBreadcrumb {
       )
       return
     }
-    captureError(error, category: .generationFailed, stage: "polish")
+    captureError(
+      SentryCaptureBoundaryError.normalizingGenerationFailure(error),
+      category: .generationFailed, stage: "polish")
   }
 
   // MARK: - Apple Intelligence Diagnostics

--- a/Tests/EnviousWisprTests/ASR/ASRClusterSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ASRClusterSentryIdentityTests.swift
@@ -222,17 +222,17 @@ struct ASRClusterSentryIdentityTests {
     #expect(event.tags?["error.identity"] == "asr.transcription_failed")
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: Self.category, stage: "transcription", environment: Self.env)
-
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint == ["handled_error", "asr_failed", "EnviousWispr#-3", Self.env])
-    #expect(event.tags?["error.identity"] == nil)
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: Self.category, error: error, environment: Self.env)
+        == ["handled_error", "asr_failed", "EnviousWispr#-3", Self.env])
   }
 
   /// #1525 PR I-B: `.modelNotLoaded` is the one confirmed-live new

--- a/Tests/EnviousWisprTests/App/HeartControlRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/App/HeartControlRecoveryTests.swift
@@ -136,6 +136,40 @@ struct HeartControlRecoveryTests {
       "cancellation must NOT surface a user-facing error")
   }
 
+  /// Row 11 (#1525 PR J-1): production-inert today (only `.preWarm` can throw here), but a
+  /// miss must still normalize to the fixed `.unexpectedHeartControlFailure` identity so a
+  /// future implementation change that starts throwing something real still alerts.
+  @Test("logDispatchFailure normalizes a non-conforming error to .unexpectedHeartControlFailure")
+  func logDispatchFailureNormalizesNonConformingToUnexpected() {
+    struct OpaqueError: Error {}
+    let hide = HideCallCounter()
+    let locked = LockedCallCounter()
+    let recovery = makeRecovery(hideCalls: hide, lockedCalls: locked)
+    withSentrySpy { spy in
+      recovery.logDispatchFailure(OpaqueError(), op: "stop")
+      #expect(
+        (spy.calls.first?.error as? any StableSentryErrorIdentity)?.sentrySemanticID
+          == "boundary.unexpected_heart_control_failure")
+    }
+  }
+
+  @Test("recover normalizes a non-conforming error to .unexpectedHeartControlFailure")
+  func recoverNormalizesNonConformingToUnexpected() {
+    struct OpaqueError: Error {}
+    let hide = HideCallCounter()
+    let locked = LockedCallCounter()
+    let sink = ErrorSurfaceSpy()
+    let recovery = makeRecovery(hideCalls: hide, lockedCalls: locked)
+    withSentrySpy { spy in
+      recovery.recover(
+        error: OpaqueError(), op: "toggle", reason: .modelWedged,
+        setTerminalReason: sink.setTerminalReason)
+      #expect(
+        (spy.calls.first?.error as? any StableSentryErrorIdentity)?.sentrySemanticID
+          == "boundary.unexpected_heart_control_failure")
+    }
+  }
+
   @Test("recover passes op string verbatim — distinguishes call sites at triage time")
   func recoverPassesOpVerbatim() {
     let hide = HideCallCounter()

--- a/Tests/EnviousWisprTests/LLM/AFMGenerationSentryErrorTests.swift
+++ b/Tests/EnviousWisprTests/LLM/AFMGenerationSentryErrorTests.swift
@@ -156,16 +156,16 @@ struct AFMGenerationSentryErrorTests {
     #expect(event.tags?["error.identity"] == "afm.unsupported_language_or_locale")
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: Self.category, stage: "polish", environment: Self.env)
-
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint == ["handled_error", "generation_failed", "EnviousWispr#-3", Self.env])
-    #expect(event.tags?["error.identity"] == nil)
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: Self.category, error: error, environment: Self.env)
+        == ["handled_error", "generation_failed", "EnviousWispr#-3", Self.env])
   }
 }

--- a/Tests/EnviousWisprTests/LLM/KeyStoreErrorSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/KeyStoreErrorSentryIdentityTests.swift
@@ -124,17 +124,16 @@ struct KeyStoreErrorSentryIdentityTests {
     #expect(event.tags?["error.identity"] == "keystore.delete_failed")
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: Self.category, stage: "keychain", environment: Self.env)
-
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: Self.category, error: error, environment: Self.env)
         == ["handled_error", "legacy_key_cleanup_failed", "EnviousWispr#-3", Self.env])
-    #expect(event.tags?["error.identity"] == nil)
   }
 }

--- a/Tests/EnviousWisprTests/LLM/LLMErrorSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMErrorSentryIdentityTests.swift
@@ -143,17 +143,16 @@ struct LLMErrorSentryIdentityTests {
     #expect(otherEvent.fingerprint?.dropLast(2) == event.fingerprint?.dropLast(2))
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: .polishProviderFailed, stage: "polish", environment: Self.env)
-
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .polishProviderFailed, error: error, environment: Self.env)
         == ["handled_error", "polish_provider_failed", "EnviousWispr#-3", Self.env])
-    #expect(event.tags?["error.identity"] == nil)
   }
 }

--- a/Tests/EnviousWisprTests/LLM/OutputClassifierSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OutputClassifierSentryIdentityTests.swift
@@ -117,17 +117,16 @@ struct OutputClassifierSentryIdentityTests {
     #expect(event.tags?["error.identity"] == Self.semanticID)
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: Self.category, stage: "llm", environment: Self.env)
-
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: Self.category, error: error, environment: Self.env)
         == ["handled_error", "output_classifier_load_failed", "EnviousWispr#-3", Self.env])
-    #expect(event.tags?["error.identity"] == nil)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/ASREngineClusterSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ASREngineClusterSentryIdentityTests.swift
@@ -179,16 +179,16 @@ struct ASREngineClusterSentryIdentityTests {
     #expect(event.tags?["error.identity"] == "xpc.operation_signal_wedge")
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: Self.modelLoadCategory, stage: "asr", environment: Self.env)
-
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint == ["handled_error", "model_load_failed", "EnviousWispr#-3", Self.env])
-    #expect(event.tags?["error.identity"] == nil)
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: Self.modelLoadCategory, error: error, environment: Self.env)
+        == ["handled_error", "model_load_failed", "EnviousWispr#-3", Self.env])
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DualModePolishTelemetryTests.swift
@@ -545,6 +545,38 @@ struct DualModePolishTelemetryTests {
     #expect(cancellationCrumbs.count == 1)
   }
 
+  @Test(
+    "captureAFMPolishError normalizes a non-conforming error to .unexpectedGenerationFailure (#1525 PR J-1)"
+  )
+  func afmPolishErrorNormalizesNonConformingToUnexpected() {
+    struct OpaqueAFMError: Error {}
+    final class CaptureBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var _identity: String?
+      var identity: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _identity
+      }
+      func record(_ identity: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        _identity = identity
+      }
+    }
+
+    let box = CaptureBox()
+    let prior = SentryBreadcrumb.captureErrorDelegate
+    SentryBreadcrumb.captureErrorDelegate = { error, _, _, _ in
+      box.record((error as? any StableSentryErrorIdentity)?.sentrySemanticID)
+    }
+    defer { SentryBreadcrumb.captureErrorDelegate = prior }
+
+    SentryBreadcrumb.captureAFMPolishError(OpaqueAFMError())
+
+    #expect(box.identity == "boundary.unexpected_generation_failure")
+  }
+
   // MARK: - 6. PolishMetadata Codable roundtrip
 
   @Test("PolishMetadata roundtrips through Codable")

--- a/Tests/EnviousWisprTests/Pipeline/KernelFallbackSentryErrorIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFallbackSentryErrorIdentityTests.swift
@@ -174,17 +174,16 @@ struct KernelFallbackSentryErrorIdentityTests {
     #expect(event.tags?["error.identity"] == "audio.no_built_in_microphone_found")
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -99)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: .xpcServiceError, stage: "asr", environment: Self.env)
-
-    #expect(event.message?.formatted == "xpc_service_error: EnviousWispr#-99")
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-99")
     #expect(
-      event.fingerprint == ["handled_error", "xpc_service_error", "EnviousWispr#-99", Self.env])
-    #expect(event.tags?["error.identity"] == nil)
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .xpcServiceError, error: error, environment: Self.env)
+        == ["handled_error", "xpc_service_error", "EnviousWispr#-99", Self.env])
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -714,13 +714,21 @@ import Testing
     #expect(recorder.captureErrors.first?.stage == "asr")
   }
 
+  /// #1525 PR J-1: `modelLoadError` narrowed to `(any Error & StableSentryErrorIdentity)?`
+  /// — a bare `NSError` no longer type-checks here. This fixture preserves the test's
+  /// intent (assert the real thrown error's message reaches the captured event, not a
+  /// synthesized placeholder) while conforming.
+  private struct FixtureModelLoadError: Error, LocalizedError, StableSentryErrorIdentity {
+    let sentryFingerprintDescriptor = "WhisperKit#42"
+    let sentrySemanticID = "test.fixture_model_load_error"
+    var errorDescription: String? { "CoreML model failed to compile" }
+  }
+
   @Test(".failed(.modelLoadFailed) surfaces the real thrown error (Pass 2 #2)")
   func failedModelLoadFailedUsesRealError() {
     let recorder = Recorder()
     let state = KernelTelemetryState()
-    state.modelLoadError = NSError(
-      domain: "WhisperKit", code: 42,
-      userInfo: [NSLocalizedDescriptionKey: "CoreML model failed to compile"])
+    state.modelLoadError = FixtureModelLoadError()
     let sink = makeSink(recorder: recorder, telemetryState: state)
     sink.emit(.failed(.modelLoadFailed))
     #expect(recorder.captureErrors.count == 1)
@@ -834,6 +842,34 @@ import Testing
     #expect(recorder.captureErrors.count == 1)
     #expect(recorder.captureErrors.first?.category == .asrFailed)
     #expect(recorder.captureErrors.first?.stage == "transcription")
+  }
+
+  /// Row 8 (#1525 PR J-1): `transcriptionFailureError` stays `(any Error)?` because
+  /// Parakeet's raw-vendor passthrough can be a non-conforming, non-CoreML error too.
+  /// A miss must still fire exactly one event under the fixed `.unexpectedTranscriptionFailure`
+  /// identity — never silently drop the alert.
+  @Test(
+    ".failed(.asrFailed) with a non-CoreML raw transcription error normalizes to .unexpectedTranscriptionFailure"
+  )
+  func failedASRFailedNonCoreMLNormalizesToUnexpected() {
+    struct OpaqueTranscriptionError: Error {}
+    var capturedIdentity: String?
+    var captureCount = 0
+    let state = KernelTelemetryState()
+    state.transcriptionFailureError = OpaqueTranscriptionError()
+    let sink = KernelLifecycleTelemetrySink(
+      backend: .parakeet,
+      audioCapture: FakeAudioCapture(),
+      context: KernelSessionContext(),
+      captureTelemetry: CaptureTelemetryState(),
+      telemetryState: state,
+      captureError: { error, _, _, _ in
+        captureCount += 1
+        capturedIdentity = error.sentrySemanticID
+      })
+    sink.emit(.failed(.asrFailed))
+    #expect(captureCount == 1)
+    #expect(capturedIdentity == "boundary.unexpected_transcription_failure")
   }
 
   @Test(".failed(.permissionDenied) emits .audioCaptureFailed captureError")

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -1,3 +1,6 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 import Testing
 
@@ -199,6 +202,44 @@ import Testing
       #expect(kernel.testActiveTaskCount == 0)
 
       context.clock.drainPending()
+    }
+
+    // MARK: #1525 PR J-1 — modelLoadError cast-miss falls back to KernelFallbackSentryError
+
+    @Test(
+      "a genuine load failure with a non-conforming error leaves modelLoadError nil and the lifecycle sink still fires exactly one event under the fixed fallback identity"
+    )
+    func modelLoadFailedNonConformingFallsBackToKernelFallbackIdentity() async {
+      struct OpaqueLoadError: Error, Sendable {}
+      let (_, wrapper) = makeWrapper(behavior: .failLoad(OpaqueLoadError()))
+      let kernel = wrapper.testKernel
+
+      await apply(.start, to: wrapper)
+
+      #expect(kernel.recordingOutcome == .failed(.modelLoadFailed))
+      // The cast at the write site misses (OpaqueLoadError does not conform to
+      // StableSentryErrorIdentity) — the property stays nil by design (§4).
+      #expect(wrapper.telemetryState.modelLoadError == nil)
+
+      var capturedIdentity: String?
+      var capturedDescriptor: String?
+      var captureCount = 0
+      let sink = KernelLifecycleTelemetrySink(
+        backend: .parakeet,
+        audioCapture: FakeAudioCapture(),
+        context: KernelSessionContext(),
+        captureTelemetry: CaptureTelemetryState(),
+        telemetryState: wrapper.telemetryState,
+        captureError: { error, _, _, _ in
+          captureCount += 1
+          capturedIdentity = error.sentrySemanticID
+          capturedDescriptor = error.sentryFingerprintDescriptor
+        })
+      sink.emit(.failed(.modelLoadFailed))
+
+      #expect(captureCount == 1)
+      #expect(capturedDescriptor == "EnviousWispr#-10")
+      #expect(capturedIdentity == "kernel.model_load_failed")
     }
 
     // MARK: #959 — seam routing: ordinary terminal uses cheap cancel(), wedge uses recoverFromWedge()

--- a/Tests/EnviousWisprTests/Pipeline/SentryCaptureBoundaryErrorTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/SentryCaptureBoundaryErrorTests.swift
@@ -1,0 +1,147 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1525 PR J-1 — `SentryCaptureBoundaryError` is the closed-world boundary-violation
+/// identity that lets `SentryBreadcrumb.captureError`/`makeHandledErrorEvent` narrow from
+/// `any Error` to `any Error & StableSentryErrorIdentity` without silently dropping the
+/// small number of genuinely-external, genuinely-reachable non-conforming producers.
+///
+/// `.urlTransport`/`.coreML` MUST preserve the exact historical fallback descriptor for
+/// their one proven external family — this suite locks that parity against
+/// `SentryBreadcrumb.handledErrorFingerprint`'s pre-existing NSError-bridge fallback,
+/// which stays generic (`any Error`) and is not touched by this PR.
+@Suite("SentryCaptureBoundaryError (#1525 PR J-1)")
+struct SentryCaptureBoundaryErrorTests {
+
+  private static let env = "production"
+
+  // MARK: - A. .urlTransport parity against the pre-normalization raw URLError
+
+  @Test("normalizingGenerationFailure(.badURL) matches the raw URLError's own fingerprint")
+  func urlTransportMatchesRawURLErrorBadURL() {
+    let raw = URLError(.badURL)
+    let normalized = SentryCaptureBoundaryError.normalizingGenerationFailure(raw)
+    #expect(normalized.sentryFingerprintDescriptor == SentryBreadcrumb.structuredDescriptor(raw))
+    #expect(normalized.sentryFingerprintDescriptor == "NSURLErrorDomain#-1000")
+    #expect(normalized.sentrySemanticID == "polish.external_url_transport")
+  }
+
+  @Test(
+    "normalizingGenerationFailure(.notConnectedToInternet) matches the raw URLError's own fingerprint"
+  )
+  func urlTransportMatchesRawURLErrorNotConnected() {
+    let raw = URLError(.notConnectedToInternet)
+    let normalized = SentryCaptureBoundaryError.normalizingGenerationFailure(raw)
+    #expect(normalized.sentryFingerprintDescriptor == SentryBreadcrumb.structuredDescriptor(raw))
+    #expect(normalized.sentryFingerprintDescriptor == "NSURLErrorDomain#-1009")
+    #expect(normalized.sentrySemanticID == "polish.external_url_transport")
+  }
+
+  // MARK: - B. .coreML parity against the pre-normalization raw CoreML NSError
+
+  @Test("normalizingTranscriptionFailure(CoreML#0) matches the raw NSError's own fingerprint")
+  func coreMLMatchesRawNSErrorCodeZero() {
+    let raw = NSError(domain: "com.apple.CoreML", code: 0)
+    let normalized = SentryCaptureBoundaryError.normalizingTranscriptionFailure(raw)
+    #expect(normalized.sentryFingerprintDescriptor == SentryBreadcrumb.structuredDescriptor(raw))
+    #expect(normalized.sentryFingerprintDescriptor == "com.apple.CoreML#0")
+    #expect(normalized.sentrySemanticID == "asr.external_coreml")
+  }
+
+  @Test("normalizingTranscriptionFailure(CoreML#9) matches the raw NSError's own fingerprint")
+  func coreMLMatchesRawNSErrorCodeNine() {
+    let raw = NSError(domain: "com.apple.CoreML", code: 9)
+    let normalized = SentryCaptureBoundaryError.normalizingTranscriptionFailure(raw)
+    #expect(normalized.sentryFingerprintDescriptor == SentryBreadcrumb.structuredDescriptor(raw))
+    #expect(normalized.sentryFingerprintDescriptor == "com.apple.CoreML#9")
+    #expect(normalized.sentrySemanticID == "asr.external_coreml")
+  }
+
+  // MARK: - C. Already-conforming values pass through unchanged
+
+  private struct AlreadyConforming: Error, StableSentryErrorIdentity {
+    let sentryFingerprintDescriptor = "Already#1"
+    let sentrySemanticID = "already.conforming"
+  }
+
+  @Test("every normalizer passes an already-conforming value through unchanged")
+  func alreadyConformingPassesThroughUnchanged() {
+    let error = AlreadyConforming()
+    #expect(
+      SentryCaptureBoundaryError.normalizingGenerationFailure(error).sentrySemanticID
+        == "already.conforming")
+    #expect(
+      SentryCaptureBoundaryError.normalizingTranscriptionFailure(error).sentrySemanticID
+        == "already.conforming")
+    #expect(
+      SentryCaptureBoundaryError.normalizingLegacyKeyCleanupFailure(error).sentrySemanticID
+        == "already.conforming")
+    #expect(
+      SentryCaptureBoundaryError.normalizingHeartControlFailure(error).sentrySemanticID
+        == "already.conforming")
+  }
+
+  // MARK: - D. Non-conforming, unrecognized misses fall to the fixed `.unexpected*` identity
+
+  private struct Opaque: Error {}
+
+  @Test("normalizingGenerationFailure on a non-URLError miss falls to .unexpectedGenerationFailure")
+  func generationFailureMissFallsToUnexpected() {
+    let normalized = SentryCaptureBoundaryError.normalizingGenerationFailure(Opaque())
+    #expect(normalized.sentrySemanticID == "boundary.unexpected_generation_failure")
+  }
+
+  @Test(
+    "normalizingTranscriptionFailure on a non-CoreML miss falls to .unexpectedTranscriptionFailure"
+  )
+  func transcriptionFailureMissFallsToUnexpected() {
+    let normalized = SentryCaptureBoundaryError.normalizingTranscriptionFailure(Opaque())
+    #expect(normalized.sentrySemanticID == "boundary.unexpected_transcription_failure")
+  }
+
+  @Test(
+    "normalizingLegacyKeyCleanupFailure on a miss falls to .unexpectedLegacyKeyCleanupFailure"
+  )
+  func legacyKeyCleanupFailureMissFallsToUnexpected() {
+    let normalized = SentryCaptureBoundaryError.normalizingLegacyKeyCleanupFailure(Opaque())
+    #expect(normalized.sentrySemanticID == "boundary.unexpected_legacy_key_cleanup_failure")
+  }
+
+  @Test("normalizingHeartControlFailure on a miss falls to .unexpectedHeartControlFailure")
+  func heartControlFailureMissFallsToUnexpected() {
+    let normalized = SentryCaptureBoundaryError.normalizingHeartControlFailure(Opaque())
+    #expect(normalized.sentrySemanticID == "boundary.unexpected_heart_control_failure")
+  }
+
+  // MARK: - E. Full event-construction shape through the narrowed captureError entry point
+
+  @MainActor
+  @Test(
+    "a normalized .urlTransport event carries the production title, fingerprint, and identity tag")
+  func urlTransportEventShape() {
+    let normalized = SentryCaptureBoundaryError.normalizingGenerationFailure(URLError(.badURL))
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      normalized, category: .polishProviderFailed, stage: "polish", environment: Self.env)
+    #expect(event.message?.formatted == "polish_provider_failed: NSURLErrorDomain#-1000")
+    #expect(
+      event.fingerprint
+        == ["handled_error", "polish_provider_failed", "NSURLErrorDomain#-1000", Self.env])
+    #expect(event.tags?["error.identity"] == "polish.external_url_transport")
+  }
+
+  @MainActor
+  @Test("a normalized .coreML event carries the production title, fingerprint, and identity tag")
+  func coreMLEventShape() {
+    let normalized = SentryCaptureBoundaryError.normalizingTranscriptionFailure(
+      NSError(domain: "com.apple.CoreML", code: 0))
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      normalized, category: .asrFailed, stage: "transcription", environment: Self.env)
+    #expect(event.message?.formatted == "asr_failed: com.apple.CoreML#0")
+    #expect(
+      event.fingerprint == ["handled_error", "asr_failed", "com.apple.CoreML#0", Self.env])
+    #expect(event.tags?["error.identity"] == "asr.external_coreml")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
@@ -385,14 +385,39 @@ struct TextProcessingRunnerCaptureTests {
     // boxing `URLError` as `any Error` produces an `NSError` dynamic value, so a
     // `StableSentryErrorIdentity` conformance is unreachable through this path.
     // The existing `NSError` fallback already produces the stable descriptor.
+    //
+    // #1525 PR J-1: `makeHandledErrorEvent` is now narrowed, so the spy-captured
+    // raw error must go through the SAME normalization the runner's `.live` seam
+    // applies before calling it — proving the boundary preserves this exact
+    // historical fingerprint, not a fresh assumption about what it does.
+    let normalized = SentryCaptureBoundaryError.normalizingGenerationFailure(call.error)
     let event = SentryBreadcrumb.makeHandledErrorEvent(
-      call.error, category: call.category, stage: call.stage, extra: call.extra,
+      normalized, category: call.category, stage: call.stage, extra: call.extra,
       tags: call.tags, fingerprintDetail: call.fingerprintDetail, environment: "test")
     #expect(
       event.fingerprint == [
         "handled_error", "polish_provider_failed", "NSURLErrorDomain#-1000", "unknown", "test",
       ])
-    #expect(event.tags?["error.identity"] == nil)
+    #expect(event.tags?["error.identity"] == "polish.external_url_transport")
+  }
+
+  @Test(
+    "an unrecognized non-URLError error normalizes to .unexpectedGenerationFailure (#1525 PR J-1)"
+  )
+  func unrecognizedNonURLErrorNormalizesToUnexpectedGenerationFailure() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
+    struct OpaqueError: Error {}
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") { OpaqueError() }
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+
+    #expect(spy.calls.count == 1)
+    let call = try #require(spy.calls.first)
+    let normalized = SentryCaptureBoundaryError.normalizingGenerationFailure(call.error)
+    #expect(normalized.sentrySemanticID == "boundary.unexpected_generation_failure")
   }
 
   // MARK: - Timeout

--- a/Tests/EnviousWisprTests/Services/LLMTelemetrySinkLiveTests.swift
+++ b/Tests/EnviousWisprTests/Services/LLMTelemetrySinkLiveTests.swift
@@ -24,7 +24,9 @@ struct LLMTelemetrySinkLiveTests {
   }
 
   private struct CapturedHandledError {
-    let error: any Error
+    // #1525 PR J-1: `HandledErrorReporter` narrowed — the stored field must
+    // match so the value can be replayed into `makeHandledErrorEvent` below.
+    let error: any Error & StableSentryErrorIdentity
     let category: SentryBreadcrumb.ErrorCategory
     let stage: String
     let extra: [String: Any]?
@@ -154,5 +156,38 @@ struct LLMTelemetrySinkLiveTests {
           "EnviousWisprLLM.KeyStoreError#2", "test-account", "test",
         ])
     #expect(event.tags?["error.identity"] == "keystore.delete_failed")
+  }
+
+  /// Row 10 (#1525 PR J-1): the production conformer always converts (`legacyStore
+  /// .delete(key:)`'s only real implementation throws `KeyStoreError`), but the write-site
+  /// static type is `any Error` (untyped `throws`) — a genuine miss must still alert under
+  /// the fixed `.unexpectedLegacyKeyCleanupFailure` identity, never drop silently.
+  @Test(
+    "a non-conforming cleanup error still reports both effects, normalized to .unexpectedLegacyKeyCleanupFailure"
+  )
+  func legacyKeyCleanupFailedNonConformingNormalizesToUnexpected() async throws {
+    struct OpaqueCleanupError: Error {}
+    let box = ResultBox()
+    let sink = LLMTelemetrySink.makeLive(
+      limbFailureReporter: { limb, operation, result, errorCategory, durationMs in
+        box.recordLimb(
+          CapturedLimbFailure(
+            limb: limb, operation: operation, result: result,
+            errorCategory: errorCategory, durationMs: durationMs))
+      },
+      handledErrorReporter: { error, category, stage, extra, fingerprintDetail in
+        box.recordHandled(
+          CapturedHandledError(
+            error: error, category: category, stage: stage, extra: extra,
+            fingerprintDetail: fingerprintDetail))
+      })
+
+    sink.legacyKeyCleanupFailed(OpaqueCleanupError(), "test-account")
+
+    try await box.awaitHandled()
+    let (_, handled) = box.snapshot()
+
+    let handledError = try #require(handled)
+    #expect(handledError.error.sentrySemanticID == "boundary.unexpected_legacy_key_cleanup_failure")
   }
 }

--- a/Tests/EnviousWisprTests/Services/ModelLoadWatchdogSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Services/ModelLoadWatchdogSentryIdentityTests.swift
@@ -119,17 +119,16 @@ struct ModelLoadWatchdogSentryIdentityTests {
     #expect(event.tags?["error.identity"] == Self.semanticID)
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: .modelLoadFailed, stage: "asr", environment: Self.env)
-
-    #expect(event.message?.formatted == "model_load_failed: EnviousWispr#-3")
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint == ["handled_error", "model_load_failed", "EnviousWispr#-3", Self.env])
-    #expect(event.tags?["error.identity"] == nil)
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .modelLoadFailed, error: error, environment: Self.env)
+        == ["handled_error", "model_load_failed", "EnviousWispr#-3", Self.env])
   }
 }

--- a/Tests/EnviousWisprTests/Services/PRHLeftoverErrorsSentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Services/PRHLeftoverErrorsSentryIdentityTests.swift
@@ -231,20 +231,19 @@ struct PRHLeftoverErrorsSentryIdentityTests {
     #expect(event.tags?["error.identity"] == "emoji.restore_under_restore")
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: .pipelineDispatchFailed, stage: "recording", environment: Self.env)
-
-    #expect(event.message?.formatted == "pipeline_dispatch_failed: EnviousWispr#-3")
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint == [
-        "handled_error", "pipeline_dispatch_failed", "EnviousWispr#-3", Self.env,
-      ]
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .pipelineDispatchFailed, error: error, environment: Self.env)
+        == [
+          "handled_error", "pipeline_dispatch_failed", "EnviousWispr#-3", Self.env,
+        ]
     )
-    #expect(event.tags?["error.identity"] == nil)
   }
 }

--- a/Tests/EnviousWisprTests/Services/RecoverySentryIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Services/RecoverySentryIdentityTests.swift
@@ -163,20 +163,19 @@ struct RecoverySentryIdentityTests {
     #expect(event.tags?["error.identity"] == "recovery.arm_key_store_failed")
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: .recoveryDecryptFailed, stage: "recovery", environment: Self.env)
-
-    #expect(event.message?.formatted == "recovery_decrypt_failed: EnviousWispr#-3")
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint == [
-        "handled_error", "recovery_decrypt_failed", "EnviousWispr#-3", Self.env,
-      ]
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .recoveryDecryptFailed, error: error, environment: Self.env)
+        == [
+          "handled_error", "recovery_decrypt_failed", "EnviousWispr#-3", Self.env,
+        ]
     )
-    #expect(event.tags?["error.identity"] == nil)
   }
 }

--- a/Tests/EnviousWisprTests/Services/StableSentryErrorIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Services/StableSentryErrorIdentityTests.swift
@@ -165,17 +165,16 @@ struct StableSentryErrorIdentityTests {
     #expect(event.tags?["error.identity"] == "heartpath.paste_cascade_clipboard_fallback")
   }
 
-  @MainActor
-  @Test("a non-conforming error's event is unchanged and carries no identity tag")
+  @Test(
+    "a non-conforming error's descriptor and fingerprint are unchanged (#1525 PR J-1: makeHandledErrorEvent narrowed — structuredDescriptor/handledErrorFingerprint stay generic)"
+  )
   func nonConformingErrorEventUnchanged() {
     let error = NSError(domain: "EnviousWispr", code: -3)
 
-    let event = SentryBreadcrumb.makeHandledErrorEvent(
-      error, category: .xpcServiceError, stage: "audio", environment: Self.env)
-
-    #expect(event.message?.formatted == "xpc_service_error: EnviousWispr#-3")
+    #expect(SentryBreadcrumb.structuredDescriptor(error) == "EnviousWispr#-3")
     #expect(
-      event.fingerprint == ["handled_error", "xpc_service_error", "EnviousWispr#-3", Self.env])
-    #expect(event.tags?["error.identity"] == nil)
+      SentryBreadcrumb.handledErrorFingerprint(
+        for: .xpcServiceError, error: error, environment: Self.env)
+        == ["handled_error", "xpc_service_error", "EnviousWispr#-3", Self.env])
   }
 }


### PR DESCRIPTION
## Summary
- Narrows `SentryBreadcrumb.captureError`/`makeHandledErrorEvent` from `any Error` to `any Error & StableSentryErrorIdentity`, so a future app-owned error type reaching Sentry without a pinned identity fails to compile instead of silently reintroducing #1524's enum-ordinal re-grouping bug.
- Adds `SentryCaptureBoundaryError` (Core) — a closed-world identity for the handful of seams whose real producer can be a genuinely-external (raw `URLError`, raw CoreML error) or defensive non-conforming value. Every other seam narrows for free because its real producer already conforms.
- `KernelTelemetryState.captureFailureError`/`.modelLoadError` narrow identically; a cast miss on the rare `modelLoadError` XPC last-resort case falls to the existing `KernelFallbackSentryError` read-side fallback (still alerts, less grouping specificity until #1658, PR J-2).

Part of #1525. Split from the original combined PR J plan after Grounded Review found the same contract-restatement defect recurring 4 rounds running; the founder's resolution was to split the rare `modelLoadError` XPC-case identity work into a separate follow-up (#1658) so this PR's contract stays singular.

## Test plan
- [x] `swift build` + `swift build --build-tests`: 0 errors.
- [x] `scripts/xcode-test.sh --release`: Debug lane 3224 tests, Release lane 2964 tests, zero failures.
- [x] `scripts/check-dependency-direction.sh`: clean across 15 modules.
- [x] Local `codex review --base origin/main`: clean, no actionable findings.
- [x] Live UAT (dev-only, temporary `#if DEBUG` fault injections, fully reverted — clean `git diff` confirmed):
  - Raw `URLError` through the polish-alerting path → new Sentry issue ENVIOUSWISPR-46 (`polish_provider_failed: NSURLErrorDomain#-1000`, `error.identity: polish.external_url_transport`), fired once.
  - Raw CoreML error through Parakeet batch transcription → new Sentry issue ENVIOUSWISPR-47 (`asr_failed: com.apple.CoreML#0`, `error.identity: asr.external_coreml`), fired twice (matching two live dictations).
  - AFM regression check: the pre-existing AFM Sentry issue (ENVIOUSWISPR-45) incremented from 1 to 3 events with an **unchanged** descriptor (`FoundationModels.LanguageModelSession.GenerationError#4`) — proves no re-grouping.
  - Healthy dictation on both Parakeet and WhisperKit backends (with real Apple Intelligence polish) completed normally post-revert.