### PR TITLE
feat(user): atomic commit for a reviewed Custom Words import (PR-F2b, #1665)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -51,6 +51,34 @@ final class CustomWordsCoordinator {
     }
   }
 
+  /// Outcome of a reviewed Custom Words import (#1665). `.stale` is not a
+  /// failure the user caused — the list changed while Review was open, so the
+  /// sheet re-compares against the current list instead of writing.
+  enum CustomWordsImportCommitOutcome: Sendable, Equatable {
+    case committed(CustomWordsImportCommitReceipt)
+    case stale
+    case failed(message: String)
+  }
+
+  /// Apply a reviewed import in one atomic write. Fires `onWordsChanged`
+  /// exactly once, and only when something actually changed.
+  func commitImport(_ plan: CustomWordsImportCommitPlan) -> CustomWordsImportCommitOutcome {
+    do {
+      let receipt = try manager.commitImport(plan, to: &customWords)
+      if !plan.isEmpty {
+        onWordsChanged?(customWords)
+      }
+      customWordError = nil
+      return .committed(receipt)
+    } catch CustomWordsImportCommitError.staleLibrary {
+      customWordError = nil
+      return .stale
+    } catch {
+      customWordError = error.localizedDescription
+      return .failed(message: error.localizedDescription)
+    }
+  }
+
   /// Bulk-add for the contacts import (#636). Returns the IDs actually created
   /// (for the import log), or nil on failure (check `customWordError`).
   func addBatch(_ words: [CustomWord]) -> [UUID]? {

--- a/Sources/EnviousWisprPostProcessing/CustomWordsImportCommit.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsImportCommit.swift
@@ -1,0 +1,132 @@
+import EnviousWisprCore
+import Foundation
+
+// Atomic commit for a reviewed Custom Words import (#1665, epic #1619 PR-F2b).
+//
+// One write applies every approved addition AND replacement, or nothing at
+// all. `addBatch` cannot express Replace, and two writes would be exactly the
+// partial-commit failure this epic exists to avoid.
+//
+// KEY SPACE: everything here is a PERSISTENCE question — "would these occupy
+// the same slot in stored data?" — so it uses the persistence key that mirrors
+// `CustomWordsManager`'s own dedup and `WordCorrector`'s lookup, never the
+// compare engine's stronger matching key (PR-F2a, #1661).
+
+/// The effective word list Review was built from, used to detect a library
+/// that changed underneath an open review.
+package struct CustomWordsImportLibrarySnapshot: Sendable, Equatable {
+  /// Per-word identity + tuning, deliberately excluding usage history
+  /// (`frequencyUsed` / `lastUsed`) and the runtime-only `source` tag: a
+  /// dictation that merely bumped a counter must not invalidate a review.
+  private struct Entry: Sendable, Hashable {
+    let id: UUID
+    let canonical: String
+    let aliases: [String]
+    let category: WordCategory
+    let priority: Int
+    let forceReplace: Bool
+    let caseSensitive: Bool
+    let minSimilarityOverride: Double?
+
+    init(_ word: CustomWord) {
+      id = word.id
+      canonical = word.canonical
+      aliases = word.aliases
+      category = word.category
+      priority = word.priority
+      forceReplace = word.forceReplace
+      caseSensitive = word.caseSensitive
+      minSimilarityOverride = word.minSimilarityOverride
+    }
+  }
+
+  private let entries: Set<Entry>
+
+  /// `words` must be the EFFECTIVE list (active built-ins + user words), which
+  /// is what the coordinator publishes and what Review renders — never the raw
+  /// user-words array, which would mismatch every baseline by the built-ins.
+  package init(words: [CustomWord]) {
+    entries = Set(words.map(Entry.init))
+  }
+
+  /// Order-independent, keyed by id. Built-in ids are minted per launch but
+  /// stable within a process, and both sides of any comparison live in one
+  /// process run.
+  package func semanticallyMatches(_ words: [CustomWord]) -> Bool {
+    entries == Set(words.map(Entry.init))
+  }
+}
+
+/// One approved Replace: the local word to overwrite, and the imported values.
+package struct CustomWordsImportReplacement: Sendable, Equatable {
+  package let existingID: UUID
+  package let candidate: CustomWordsImportCandidate
+
+  package init(existingID: UUID, candidate: CustomWordsImportCandidate) {
+    self.existingID = existingID
+    self.candidate = candidate
+  }
+}
+
+package struct CustomWordsImportCommitPlan: Sendable, Equatable {
+  package let baseline: CustomWordsImportLibrarySnapshot
+  package let additions: [CustomWordsImportCandidate]
+  package let replacements: [CustomWordsImportReplacement]
+
+  package init(
+    baseline: CustomWordsImportLibrarySnapshot,
+    additions: [CustomWordsImportCandidate],
+    replacements: [CustomWordsImportReplacement]
+  ) {
+    self.baseline = baseline
+    self.additions = additions
+    self.replacements = replacements
+  }
+
+  /// True when the commit would change nothing — an all-Skip confirm. Such a
+  /// commit writes no file and takes no backup.
+  package var isEmpty: Bool { additions.isEmpty && replacements.isEmpty }
+}
+
+package struct CustomWordsImportCommitReceipt: Sendable, Equatable {
+  package let addedIDs: [UUID]
+  package let replacedIDs: [UUID]
+  /// Aliases dropped by enforcement, covering source aliases AND colliding
+  /// `suggestedAliases`. The AI channel gets no compare-time disclosure, so
+  /// this receipt is its only reporting path.
+  package let droppedAliasCollisions: [CustomWordsImportAliasCollision]
+
+  package init(
+    addedIDs: [UUID],
+    replacedIDs: [UUID],
+    droppedAliasCollisions: [CustomWordsImportAliasCollision]
+  ) {
+    self.addedIDs = addedIDs
+    self.replacedIDs = replacedIDs
+    self.droppedAliasCollisions = droppedAliasCollisions
+  }
+}
+
+/// `LocalizedError` because the coordinator surfaces `localizedDescription`
+/// straight to the user — without it they would get Foundation's generic
+/// "operation could not be completed" instead of being told, truthfully, that
+/// nothing was changed.
+package enum CustomWordsImportCommitError: LocalizedError, Sendable, Equatable {
+  /// The library changed underneath the open review — nothing was written.
+  case staleLibrary
+  /// The plan references a word that is not in the library, or is malformed.
+  case invalidPlan
+  /// The existing file exists but could not be read — fail closed (PR-P0).
+  case unreadableLibrary
+
+  package var errorDescription: String? {
+    switch self {
+    case .staleLibrary:
+      return "Your word list changed while you were reviewing. Nothing was imported."
+    case .invalidPlan:
+      return "This import could not be applied. Nothing was changed."
+    case .unreadableLibrary:
+      return "Your saved words could not be read. Nothing was imported. Try again."
+    }
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -733,8 +733,15 @@ public final class CustomWordsManager {
 
     var result = words
     var dropped: [CustomWordsImportAliasCollision] = []
+    // Last wins, and the list must not be assumed id-unique. Renaming a
+    // built-in stores a user override carrying the built-in's OWN id while
+    // `mergedWords` keeps showing the built-in (its canonical no longer
+    // matches any user word), so within one process the two share an id and
+    // `uniqueKeysWithValues` would trap on a state the manager itself creates.
+    // `mergedWords` returns built-ins first, so last-wins resolves to the
+    // user's own word — the one an import can legitimately touch.
     let indexByID = Dictionary(
-      uniqueKeysWithValues: result.indices.map { (result[$0].id, $0) })
+      result.indices.map { (result[$0].id, $0) }, uniquingKeysWith: { _, last in last })
     for id in touchedOrder {
       guard let index = indexByID[id] else { continue }
       let word = result[index]

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -552,19 +552,28 @@ public final class CustomWordsManager {
       let merged = Self.applyReplace(existing: existing, candidate: replacement.candidate)
       guard !merged.canonical.isEmpty else { throw CustomWordsImportCommitError.invalidPlan }
 
+      // A built-in stays hidden only while some user word still carries its
+      // canonical, so a Replace that MOVES the canonical away has to retire the
+      // built-in too — otherwise it reappears beside the replacement and the
+      // user gets two words where they approved one.
+      //
+      // This is checked before the branch on purpose: it applies whether the
+      // override is being created now (built-in never edited) or already exists
+      // in `file.words` (built-in edited earlier, which is why the canonical
+      // still matches). Guarding only the create case leaves the identical bug
+      // reachable through the update case.
+      if let builtin = Self.builtinDefaults.first(where: {
+        $0.word.canonical.caseInsensitiveCompare(existing.canonical) == .orderedSame
+      }),
+        builtin.word.canonical.caseInsensitiveCompare(merged.canonical) != .orderedSame,
+        !file.deletedBuiltinIds.contains(builtin.id)
+      {
+        file.deletedBuiltinIds.append(builtin.id)
+      }
+
       if let index = file.words.firstIndex(where: { $0.id == existing.id }) {
         file.words[index] = merged
       } else {
-        // Replacing a built-in: store a user override AND tombstone the
-        // built-in. `mergedWords` only hides a built-in whose canonical still
-        // matches a user word, so without the tombstone a Replace that CHANGES
-        // the canonical would leave the original built-in visible alongside the
-        // override — two words where the user approved one.
-        if let builtin = Self.builtinDefaults.first(where: {
-          $0.word.canonical.caseInsensitiveCompare(existing.canonical) == .orderedSame
-        }), !file.deletedBuiltinIds.contains(builtin.id) {
-          file.deletedBuiltinIds.append(builtin.id)
-        }
         file.words.append(merged)
       }
       replacedIDs.append(existing.id)

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -501,6 +501,301 @@ public final class CustomWordsManager {
     words = mergedWords(file: file)
   }
 
+  // MARK: - Import commit (#1665, epic #1619 PR-F2b)
+
+  /// Apply a reviewed import — additions AND replacements — in ONE atomic
+  /// write, or write nothing at all. Built on PR-P0's strict loader: an
+  /// existing-but-unreadable file fails closed, touching neither disk nor the
+  /// caller's list.
+  ///
+  /// Every key comparison here is a PERSISTENCE question, so it uses
+  /// `importPersistenceKey` (this type's own `trimmed.lowercased()` dedup
+  /// rule), never the compare engine's stronger matching key (PR-F2a).
+  package func commitImport(
+    _ plan: CustomWordsImportCommitPlan, to words: inout [CustomWord]
+  ) throws -> CustomWordsImportCommitReceipt {
+    // (1) Strict read — fail closed on an unreadable/corrupted existing file.
+    var file: CustomWordsFile
+    do {
+      file = try loadFileForMutation()
+    } catch {
+      throw CustomWordsImportCommitError.unreadableLibrary
+    }
+
+    // (2) Stale check against the EFFECTIVE list Review was built from.
+    let effective = mergedWords(file: file)
+    guard plan.baseline.semanticallyMatches(effective) else {
+      throw CustomWordsImportCommitError.staleLibrary
+    }
+
+    // An all-Skip confirm changes nothing: no backup, no write.
+    guard !plan.isEmpty else {
+      return CustomWordsImportCommitReceipt(
+        addedIDs: [], replacedIDs: [], droppedAliasCollisions: [])
+    }
+
+    // (3) Replacements. `existingID` may name a built-in, which lives in
+    // `builtinDefaults` rather than `file.words`.
+    //
+    // Two replacements aimed at the SAME existing word are rejected, not
+    // silently resolved: both would apply against the original entry and the
+    // later one would quietly win, so the user would get an import they did
+    // not approve while the receipt claimed both landed.
+    guard Set(plan.replacements.map(\.existingID)).count == plan.replacements.count else {
+      throw CustomWordsImportCommitError.invalidPlan
+    }
+    var replacedIDs: [UUID] = []
+    for replacement in plan.replacements {
+      guard let existing = effective.first(where: { $0.id == replacement.existingID }) else {
+        throw CustomWordsImportCommitError.invalidPlan
+      }
+      let merged = Self.applyReplace(existing: existing, candidate: replacement.candidate)
+      guard !merged.canonical.isEmpty else { throw CustomWordsImportCommitError.invalidPlan }
+
+      if let index = file.words.firstIndex(where: { $0.id == existing.id }) {
+        file.words[index] = merged
+      } else {
+        // Replacing a built-in: store a user override AND tombstone the
+        // built-in. `mergedWords` only hides a built-in whose canonical still
+        // matches a user word, so without the tombstone a Replace that CHANGES
+        // the canonical would leave the original built-in visible alongside the
+        // override — two words where the user approved one.
+        if let builtin = Self.builtinDefaults.first(where: {
+          $0.word.canonical.caseInsensitiveCompare(existing.canonical) == .orderedSame
+        }), !file.deletedBuiltinIds.contains(builtin.id) {
+          file.deletedBuiltinIds.append(builtin.id)
+        }
+        file.words.append(merged)
+      }
+      replacedIDs.append(existing.id)
+    }
+
+    // (4) Additions — fresh UUID each; unspecified fields take type defaults,
+    // since there is no existing word to preserve from.
+    var addedIDs: [UUID] = []
+    for candidate in plan.additions {
+      let word = Self.makeAddition(from: candidate)
+      guard !word.canonical.isEmpty else { throw CustomWordsImportCommitError.invalidPlan }
+      file.words.append(word)
+      addedIDs.append(word.id)
+    }
+
+    let touchedIDs = Set(addedIDs + replacedIDs)
+
+    // (5) Canonical uniqueness, and no imported canonical may land on an alias
+    // held by a different word this import did not replace. F2c never offers a
+    // decision that produces either shape, so reaching here means a bad plan.
+    var resulting = mergedWords(file: file)
+    var seenCanonicals: [String: UUID] = [:]
+    for word in resulting {
+      let key = Self.importPersistenceKey(word.canonical)
+      if let owner = seenCanonicals[key], owner != word.id {
+        throw CustomWordsImportCommitError.invalidPlan
+      }
+      seenCanonicals[key] = word.id
+    }
+    for word in resulting where touchedIDs.contains(word.id) {
+      let canonicalKey = Self.importPersistenceKey(word.canonical)
+      for other in resulting where other.id != word.id && !touchedIDs.contains(other.id) {
+        if other.aliases.contains(where: { Self.importPersistenceKey($0) == canonicalKey }) {
+          throw CustomWordsImportCommitError.invalidPlan
+        }
+      }
+    }
+
+    // (6) Alias enforcement on the APPLIED result, so two replacements in one
+    // plan are covered, not just additions. Only words this import touched can
+    // lose an alias — an untouched word is not this import's to edit.
+    // Touched words are resolved in APPLY order (replacements in plan order,
+    // then additions), not the merged library's own order — otherwise which of
+    // two claimants keeps a shared alias would depend on incidental storage
+    // order rather than on the plan the user approved.
+    let (filtered, dropped) = Self.enforceAliases(
+      on: resulting, touchedOrder: replacedIDs + addedIDs)
+    for word in filtered where touchedIDs.contains(word.id) {
+      if let index = file.words.firstIndex(where: { $0.id == word.id }) {
+        file.words[index].aliases = word.aliases
+      }
+    }
+
+    // (7) Best-effort backup, then ONE save. A backup failure logs and
+    // proceeds: correctness comes from the atomic write and the strict loader,
+    // not from the backup existing.
+    writePreImportBackup()
+    try saveFile(file)
+
+    // (8) Publish only after the write succeeded.
+    resulting = mergedWords(file: file)
+    words = resulting
+    return CustomWordsImportCommitReceipt(
+      addedIDs: addedIDs, replacedIDs: replacedIDs, droppedAliasCollisions: dropped)
+  }
+
+  /// This type's own dedup rule, named so the import path cannot accidentally
+  /// reach for the compare engine's stronger matching key (PR-F2a).
+  static func importPersistenceKey(_ s: String) -> String {
+    s.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  }
+
+  /// Field-level Replace, per the adopted plan's table. `id`, `frequencyUsed`,
+  /// and `lastUsed` are always preserved; `canonical` is always taken; every
+  /// other field is taken ONLY when the source actually supplied it, so a
+  /// source with no opinion can never blank hand-tuned configuration.
+  /// `suggestedAliases` are never applied on Replace — a machine guess must
+  /// not overwrite hand-tuned aliases.
+  static func applyReplace(
+    existing: CustomWord, candidate: CustomWordsImportCandidate
+  ) -> CustomWord {
+    func supplied<Value>(_ field: CustomWordsImportField<Value>, else fallback: Value) -> Value {
+      if case .supplied(let value) = field { return value }
+      return fallback
+    }
+    let aliases = supplied(candidate.aliases, else: existing.aliases)
+    return CustomWord(
+      id: existing.id,
+      canonical: candidate.canonical.trimmingCharacters(in: .whitespacesAndNewlines),
+      aliases: Self.sanitizeAliases(aliases),
+      category: supplied(candidate.category, else: existing.category),
+      priority: supplied(candidate.priority, else: existing.priority),
+      forceReplace: supplied(candidate.forceReplace, else: existing.forceReplace),
+      caseSensitive: supplied(candidate.caseSensitive, else: existing.caseSensitive),
+      source: .user,
+      frequencyUsed: existing.frequencyUsed,
+      lastUsed: existing.lastUsed,
+      minSimilarityOverride: supplied(
+        candidate.minSimilarityOverride, else: existing.minSimilarityOverride)
+    )
+  }
+
+  /// A new word from a candidate. Unspecified fields fall back to the type's
+  /// own defaults — there is no existing word to preserve from. Add is the ONE
+  /// place AI `suggestedAliases` are persisted, after the source's own spellings.
+  static func makeAddition(from candidate: CustomWordsImportCandidate) -> CustomWord {
+    func supplied<Value>(_ field: CustomWordsImportField<Value>, else fallback: Value) -> Value {
+      if case .supplied(let value) = field { return value }
+      return fallback
+    }
+    let sourceAliases = supplied(candidate.aliases, else: [])
+    var union = sanitizeAliases(sourceAliases)
+    var seen = Set(union.map(importPersistenceKey))
+    for suggestion in sanitizeAliases(candidate.suggestedAliases)
+    where seen.insert(importPersistenceKey(suggestion)).inserted {
+      union.append(suggestion)
+    }
+    return CustomWord(
+      canonical: candidate.canonical.trimmingCharacters(in: .whitespacesAndNewlines),
+      aliases: union,
+      category: supplied(candidate.category, else: .general),
+      priority: supplied(candidate.priority, else: 0),
+      forceReplace: supplied(candidate.forceReplace, else: false),
+      caseSensitive: supplied(candidate.caseSensitive, else: false),
+      source: .user,
+      minSimilarityOverride: supplied(candidate.minSimilarityOverride, else: nil)
+    )
+  }
+
+  private static func sanitizeAliases(_ aliases: [String]) -> [String] {
+    aliases
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+  }
+
+  /// Guarantees no alias this import touched is left ambiguous, whatever
+  /// Review believed. Precedence, in order: a word's own canonical beats its
+  /// own redundant alias (dropped silently, it is not ambiguity); any other
+  /// word's canonical beats an alias; an untouched incumbent's alias beats any
+  /// imported one; among touched words, earlier in `touchedOrder` wins.
+  ///
+  /// `touchedOrder` is the APPLY order, so a shared alias resolves by the plan
+  /// the user approved rather than by incidental storage order.
+  static func enforceAliases(
+    on words: [CustomWord], touchedOrder: [UUID]
+  ) -> (words: [CustomWord], dropped: [CustomWordsImportAliasCollision]) {
+    let touchedIDs = Set(touchedOrder)
+    var canonicalOwners: [String: UUID] = [:]
+    for word in words {
+      let key = importPersistenceKey(word.canonical)
+      if canonicalOwners[key] == nil { canonicalOwners[key] = word.id }
+    }
+
+    // Untouched words register first and are never modified, so an incumbent
+    // alias always outranks an imported one. Among two untouched words sharing
+    // an alias the LAST one wins, mirroring `WordCorrector.buildLookups`'s
+    // unconditional assignment (WordCorrector.swift:180-205) — the receipt's
+    // `heldBy` has to name the word that really holds the trigger.
+    var aliasOwners: [String: UUID] = [:]
+    for word in words where !touchedIDs.contains(word.id) {
+      for alias in word.aliases {
+        let key = importPersistenceKey(alias)
+        if !key.isEmpty { aliasOwners[key] = word.id }
+      }
+    }
+
+    var result = words
+    var dropped: [CustomWordsImportAliasCollision] = []
+    let indexByID = Dictionary(
+      uniqueKeysWithValues: result.indices.map { (result[$0].id, $0) })
+    for id in touchedOrder {
+      guard let index = indexByID[id] else { continue }
+      let word = result[index]
+      let canonicalKey = importPersistenceKey(word.canonical)
+      var kept: [String] = []
+      for alias in word.aliases {
+        let key = importPersistenceKey(alias)
+        if key.isEmpty { continue }
+        // Redundant with the word's own canonical: silently removed, never
+        // reported — it is not an ambiguity anyone needs to hear about.
+        if key == canonicalKey { continue }
+        if let owner = canonicalOwners[key], owner != word.id {
+          dropped.append(CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
+          continue
+        }
+        if let owner = aliasOwners[key] {
+          if owner != word.id {
+            dropped.append(CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
+          }
+          continue
+        }
+        aliasOwners[key] = word.id
+        kept.append(alias)
+      }
+      result[index].aliases = kept
+    }
+    return (result, dropped)
+  }
+
+  /// Timestamped copy of the current file before a changing commit. Purely a
+  /// convenience recovery path — failures are logged, never fatal. No retention
+  /// policy in v1; an accumulating set of backups is an accepted, named scope cut.
+  ///
+  /// Never overwrites an existing backup. Two commits inside the same second
+  /// would otherwise collide on the filename, and destroying the earlier
+  /// pre-import state is the one thing this recovery path must not do.
+  private func writePreImportBackup() {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: fileURL.path) else { return }
+    let stamp = ISO8601DateFormatter().string(from: Date())
+      .replacingOccurrences(of: ":", with: "-")
+    let directory = fileURL.deletingLastPathComponent()
+    var backupURL = directory.appendingPathComponent("custom-words.backup-\(stamp).json")
+    var suffix = 2
+    while fm.fileExists(atPath: backupURL.path), suffix < 1000 {
+      backupURL = directory.appendingPathComponent(
+        "custom-words.backup-\(stamp)-\(suffix).json")
+      suffix += 1
+    }
+    do {
+      try fm.copyItem(at: fileURL, to: backupURL)
+    } catch {
+      Task {
+        await AppLogger.shared.log(
+          "CustomWordsManager: pre-import backup failed: \(error.localizedDescription)",
+          level: .info, category: "CustomWords"
+        )
+      }
+    }
+  }
+
   public func update(word: CustomWord, in words: inout [CustomWord]) throws {
     guard let index = words.firstIndex(where: { $0.id == word.id }) else { return }
     let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
@@ -1,0 +1,598 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1665 (PR-F2b) — atomic import commit. Every test drives a real manager
+/// against a temp file, so "one write or none" is verified against disk, not
+/// a mock.
+@MainActor
+@Suite("CustomWordsImportCommit")
+struct CustomWordsImportCommitTests {
+
+  // MARK: - Harness
+
+  private func makeManager() -> (CustomWordsManager, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-import-commit-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent("custom-words.json")
+    return (CustomWordsManager(fileURL: url), url)
+  }
+
+  /// Seeds user words and returns the effective list the coordinator would hold.
+  private func seed(
+    _ manager: CustomWordsManager, _ words: [CustomWord]
+  ) throws -> [CustomWord] {
+    var live = manager.load() ?? []
+    _ = try manager.addBatch(words, to: &live)
+    return live
+  }
+
+  private func candidate(
+    _ canonical: String,
+    aliases: CustomWordsImportField<[String]> = .unspecified,
+    suggestedAliases: [String] = [],
+    category: CustomWordsImportField<WordCategory> = .unspecified,
+    priority: CustomWordsImportField<Int> = .unspecified,
+    forceReplace: CustomWordsImportField<Bool> = .unspecified,
+    caseSensitive: CustomWordsImportField<Bool> = .unspecified,
+    minSimilarityOverride: CustomWordsImportField<Double?> = .unspecified
+  ) -> CustomWordsImportCandidate {
+    CustomWordsImportCandidate(
+      canonical: canonical, aliases: aliases, suggestedAliases: suggestedAliases,
+      category: category, priority: priority, forceReplace: forceReplace,
+      caseSensitive: caseSensitive, minSimilarityOverride: minSimilarityOverride)
+  }
+
+  private func plan(
+    baseline: [CustomWord],
+    additions: [CustomWordsImportCandidate] = [],
+    replacements: [CustomWordsImportReplacement] = []
+  ) -> CustomWordsImportCommitPlan {
+    CustomWordsImportCommitPlan(
+      baseline: CustomWordsImportLibrarySnapshot(words: baseline),
+      additions: additions, replacements: replacements)
+  }
+
+  // MARK: - Atomicity and staleness
+
+  @Test("a mixed add and replace lands as one committed file state")
+  func mixedAddAndReplaceUsesOneCommittedFileState() throws {
+    let (manager, url) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Qualtrics")])
+    let target = try #require(live.first { $0.canonical == "Qualtrics" })
+
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        additions: [candidate("Kubernetes")],
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: target.id, candidate: candidate("Qualtrics XM"))
+        ]),
+      to: &live)
+
+    #expect(receipt.addedIDs.count == 1)
+    #expect(receipt.replacedIDs == [target.id])
+    #expect(live.contains { $0.canonical == "Kubernetes" })
+    #expect(live.contains { $0.canonical == "Qualtrics XM" })
+    #expect(live.contains { $0.canonical == "Qualtrics" } == false)
+
+    // Both changes are in the same on-disk state.
+    let onDisk = try #require(CustomWordsManager(fileURL: url).load())
+    #expect(onDisk.contains { $0.canonical == "Kubernetes" })
+    #expect(onDisk.contains { $0.canonical == "Qualtrics XM" })
+  }
+
+  @Test("a replacement preserves the existing id and usage history")
+  func replacementPreservesExistingIDAndUsageHistory() throws {
+    let (manager, _) = makeManager()
+    let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+    var live = try seed(
+      manager,
+      [CustomWord(canonical: "Qualtrics", frequencyUsed: 7, lastUsed: stamp)])
+    let target = try #require(live.first { $0.canonical == "Qualtrics" })
+
+    _ = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: target.id, candidate: candidate("Qualtrics XM"))
+        ]),
+      to: &live)
+
+    let updated = try #require(live.first { $0.id == target.id })
+    #expect(updated.canonical == "Qualtrics XM")
+    #expect(updated.frequencyUsed == 7)
+    #expect(updated.lastUsed == stamp)
+  }
+
+  @Test("a semantic change under an open review returns stale without writing")
+  func semanticLibraryChangeReturnsStaleWithoutWrite() throws {
+    let (manager, url) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Qualtrics")])
+    let staleBaseline = live
+
+    // Someone edits the list after Review was built.
+    _ = try seed(manager, [CustomWord(canonical: "Interloper")])
+    var current = try #require(manager.load())
+
+    #expect(throws: CustomWordsImportCommitError.staleLibrary) {
+      _ = try manager.commitImport(
+        plan(baseline: staleBaseline, additions: [candidate("Kubernetes")]),
+        to: &current)
+    }
+    let onDisk = try #require(CustomWordsManager(fileURL: url).load())
+    #expect(onDisk.contains { $0.canonical == "Kubernetes" } == false)
+    live = onDisk
+    #expect(live.isEmpty == false)
+  }
+
+  @Test("a usage-history-only change does not stale the review")
+  func unrelatedUsageHistoryChangeDoesNotReturnStale() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Qualtrics")])
+    let baseline = live
+
+    // Same words, different usage counters — the snapshot excludes these.
+    var bumped = live
+    for index in bumped.indices {
+      bumped[index].frequencyUsed += 3
+      bumped[index].lastUsed = Date(timeIntervalSince1970: 1_700_000_000)
+    }
+    live = bumped
+
+    let receipt = try manager.commitImport(
+      plan(baseline: baseline, additions: [candidate("Kubernetes")]), to: &live)
+    #expect(receipt.addedIDs.count == 1)
+  }
+
+  @Test("an all-skipped confirm writes nothing at all")
+  func confirmWithAllSkippedWritesNothing() throws {
+    let (manager, url) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Qualtrics")])
+    let before = try Data(contentsOf: url)
+
+    let receipt = try manager.commitImport(plan(baseline: live), to: &live)
+    #expect(receipt.addedIDs.isEmpty)
+    #expect(receipt.replacedIDs.isEmpty)
+    #expect(try Data(contentsOf: url) == before)
+    // No backup for a no-op commit.
+    let siblings = try FileManager.default.contentsOfDirectory(
+      atPath: url.deletingLastPathComponent().path)
+    #expect(siblings.contains { $0.hasPrefix("custom-words.backup-") } == false)
+  }
+
+  @Test("no existing file is a legitimate first import")
+  func noExistingFileTreatsCommitAsFirstImport() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    let receipt = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    #expect(receipt.addedIDs.count == 1)
+    #expect(live.contains { $0.canonical == "Kubernetes" })
+  }
+
+  @Test("a plan naming a word that is not in the library is rejected")
+  func planReferencingAnUnknownWordIsRejected() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Qualtrics")])
+    #expect(throws: CustomWordsImportCommitError.invalidPlan) {
+      _ = try manager.commitImport(
+        plan(
+          baseline: live,
+          replacements: [
+            CustomWordsImportReplacement(existingID: UUID(), candidate: candidate("Nope"))
+          ]),
+        to: &live)
+    }
+  }
+
+  // MARK: - Field-level Replace semantics
+
+  @Test("replace with unspecified fields preserves every hand-tuned value")
+  func replaceWithUnspecifiedFieldsPreservesExistingConfiguration() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(
+      manager,
+      [
+        CustomWord(
+          canonical: "Qualtrics", aliases: ["qualtrix"], category: .brand, priority: 5,
+          forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.9)
+      ])
+    let target = try #require(live.first { $0.canonical == "Qualtrics" })
+
+    _ = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: target.id, candidate: candidate("Qualtrics XM"))
+        ]),
+      to: &live)
+
+    let updated = try #require(live.first { $0.id == target.id })
+    #expect(updated.canonical == "Qualtrics XM")  // canonical is always taken
+    #expect(updated.aliases == ["qualtrix"])
+    #expect(updated.category == .brand)
+    #expect(updated.priority == 5)
+    #expect(updated.forceReplace == true)
+    #expect(updated.caseSensitive == true)
+    #expect(updated.minSimilarityOverride == 0.9)
+  }
+
+  @Test("replace with supplied fields overwrites the existing values")
+  func replaceWithSuppliedFieldsOverwritesExisting() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(
+      manager,
+      [
+        CustomWord(
+          canonical: "Qualtrics", aliases: ["qualtrix"], category: .brand, priority: 5,
+          forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.9)
+      ])
+    let target = try #require(live.first { $0.canonical == "Qualtrics" })
+
+    _ = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: target.id,
+            candidate: candidate(
+              "Qualtrics", aliases: .supplied(["qxm"]), category: .supplied(.general),
+              priority: .supplied(1), forceReplace: .supplied(false),
+              caseSensitive: .supplied(false), minSimilarityOverride: .supplied(0.5)))
+        ]),
+      to: &live)
+
+    let updated = try #require(live.first { $0.id == target.id })
+    #expect(updated.aliases == ["qxm"])
+    #expect(updated.category == .general)
+    #expect(updated.priority == 1)
+    #expect(updated.forceReplace == false)
+    #expect(updated.caseSensitive == false)
+    #expect(updated.minSimilarityOverride == 0.5)
+  }
+
+  @Test("only the backup format can authoritatively clear aliases and strictness")
+  func suppliedEmptyAndSuppliedNilDeliberatelyClear() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(
+      manager,
+      [CustomWord(canonical: "Qualtrics", aliases: ["qualtrix"], minSimilarityOverride: 0.9)])
+    let target = try #require(live.first { $0.canonical == "Qualtrics" })
+
+    _ = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: target.id,
+            candidate: candidate(
+              "Qualtrics", aliases: .supplied([]), minSimilarityOverride: .supplied(nil)))
+        ]),
+      to: &live)
+
+    let updated = try #require(live.first { $0.id == target.id })
+    #expect(updated.aliases.isEmpty)
+    #expect(updated.minSimilarityOverride == nil)
+  }
+
+  @Test("AI suggestions never apply on replace")
+  func suggestedAliasesNeverApplyOnReplace() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Qualtrics", aliases: ["qualtrix"])])
+    let target = try #require(live.first { $0.canonical == "Qualtrics" })
+
+    _ = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: target.id,
+            candidate: candidate("Qualtrics", suggestedAliases: ["kwaltrics"]))
+        ]),
+      to: &live)
+
+    let updated = try #require(live.first { $0.id == target.id })
+    #expect(updated.aliases == ["qualtrix"])
+  }
+
+  @Test("an addition unions source and suggested aliases, source spellings first")
+  func additionUnionsSourceAndSuggestedAliasesDeduplicated() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(
+        baseline: live,
+        additions: [
+          candidate(
+            "Qualtrics", aliases: .supplied(["qualtrix"]),
+            suggestedAliases: ["QUALTRIX", "kwaltrics"])
+        ]),
+      to: &live)
+
+    let added = try #require(live.first { $0.canonical == "Qualtrics" })
+    // QUALTRIX deduplicates against the source spelling, which wins.
+    #expect(added.aliases == ["qualtrix", "kwaltrics"])
+  }
+
+  @Test("an addition with unspecified fields falls back to the type defaults")
+  func additionWithUnspecifiedFieldsFallsBackToTypeDefaults() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+
+    let added = try #require(live.first { $0.canonical == "Kubernetes" })
+    #expect(added.category == .general)
+    #expect(added.priority == 0)
+    #expect(added.forceReplace == false)
+    #expect(added.caseSensitive == false)
+    #expect(added.minSimilarityOverride == nil)
+    #expect(added.aliases.isEmpty)
+  }
+
+  // MARK: - Alias enforcement
+
+  @Test("an alias already held by another word is dropped, not the word")
+  func collidingAliasIsDroppedNotWordOnCommit() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Anika", aliases: ["annie"])])
+
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        additions: [candidate("Annabelle", aliases: .supplied(["Annie", "belle"]))]),
+      to: &live)
+
+    let added = try #require(live.first { $0.canonical == "Annabelle" })
+    #expect(added.aliases == ["belle"])  // the word survives, the alias does not
+    #expect(receipt.droppedAliasCollisions.map(\.alias) == ["Annie"])
+  }
+
+  @Test("an untouched incumbent alias always beats an imported one")
+  func incumbentLibraryAliasAlwaysWinsOverImportedAlias() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Anika", aliases: ["annie"])])
+    let incumbent = try #require(live.first { $0.canonical == "Anika" })
+
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Zed", aliases: .supplied(["annie"]))]),
+      to: &live)
+
+    let untouched = try #require(live.first { $0.id == incumbent.id })
+    #expect(untouched.aliases == ["annie"])  // never edited by the import
+    let added = try #require(live.first { $0.canonical == "Zed" })
+    #expect(added.aliases.isEmpty)
+  }
+
+  @Test("when two new words share an alias the first in plan order keeps it")
+  func firstCandidateInPlanOrderWinsWhenTwoNewCandidatesShareAnAlias() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        additions: [
+          candidate("Anika", aliases: .supplied(["annie"])),
+          candidate("Annabelle", aliases: .supplied(["Annie"])),
+        ]),
+      to: &live)
+
+    #expect(try #require(live.first { $0.canonical == "Anika" }).aliases == ["annie"])
+    #expect(try #require(live.first { $0.canonical == "Annabelle" }).aliases.isEmpty)
+    #expect(receipt.droppedAliasCollisions.map(\.alias) == ["Annie"])
+  }
+
+  @Test("an alias equal to another word's canonical is dropped")
+  func importedAliasCollidingWithAnotherCanonicalDropsTheAlias() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Anika")])
+    let receipt = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Zed", aliases: .supplied(["anika"]))]),
+      to: &live)
+
+    #expect(try #require(live.first { $0.canonical == "Zed" }).aliases.isEmpty)
+    #expect(receipt.droppedAliasCollisions.count == 1)
+  }
+
+  @Test("an alias equal to its own canonical is removed silently, not reported")
+  func aliasEqualToItsOwnCanonicalIsSilentlyRemovedNotReportedAsADrop() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        additions: [candidate("Anika", aliases: .supplied(["ANIKA", "annie"]))]),
+      to: &live)
+
+    #expect(try #require(live.first { $0.canonical == "Anika" }).aliases == ["annie"])
+    #expect(receipt.droppedAliasCollisions.isEmpty)
+  }
+
+  @Test("two replacements sharing an alias are both covered by enforcement")
+  func twoReplacementsSharingAnAliasKeepOnlyTheFirstInPlanOrder() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(
+      manager, [CustomWord(canonical: "First"), CustomWord(canonical: "Second")])
+    let first = try #require(live.first { $0.canonical == "First" })
+    let second = try #require(live.first { $0.canonical == "Second" })
+
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: first.id,
+            candidate: candidate("First", aliases: .supplied(["shared"]))),
+          CustomWordsImportReplacement(
+            existingID: second.id,
+            candidate: candidate("Second", aliases: .supplied(["Shared"]))),
+        ]),
+      to: &live)
+
+    #expect(try #require(live.first { $0.id == first.id }).aliases == ["shared"])
+    #expect(try #require(live.first { $0.id == second.id }).aliases.isEmpty)
+    #expect(receipt.droppedAliasCollisions.map(\.alias) == ["Shared"])
+  }
+
+  @Test("two replacements aimed at the same word are rejected without writing")
+  func repeatedReplacementTargetIsRejected() throws {
+    let (manager, url) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Qualtrics")])
+    let target = try #require(live.first { $0.canonical == "Qualtrics" })
+    let before = try Data(contentsOf: url)
+
+    #expect(throws: CustomWordsImportCommitError.invalidPlan) {
+      _ = try manager.commitImport(
+        self.plan(
+          baseline: live,
+          replacements: [
+            CustomWordsImportReplacement(
+              existingID: target.id, candidate: self.candidate("First Win")),
+            CustomWordsImportReplacement(
+              existingID: target.id, candidate: self.candidate("Second Win")),
+          ]),
+        to: &live)
+    }
+    // Both would have applied against the same original entry, so the later one
+    // would silently win an import the user never approved.
+    #expect(try Data(contentsOf: url) == before)
+  }
+
+  @Test("a shared alias resolves by plan order, not by storage order")
+  func sharedAliasBetweenReplacementsResolvesByPlanOrderNotStorageOrder() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(
+      manager, [CustomWord(canonical: "Alpha"), CustomWord(canonical: "Zeta")])
+    let alpha = try #require(live.first { $0.canonical == "Alpha" })
+    let zeta = try #require(live.first { $0.canonical == "Zeta" })
+
+    // Plan order is deliberately the REVERSE of storage order, so a resolver
+    // walking the stored library would keep the wrong claimant.
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: zeta.id, candidate: candidate("Zeta", aliases: .supplied(["shared"]))),
+          CustomWordsImportReplacement(
+            existingID: alpha.id, candidate: candidate("Alpha", aliases: .supplied(["Shared"]))),
+        ]),
+      to: &live)
+
+    #expect(try #require(live.first { $0.id == zeta.id }).aliases == ["shared"])
+    #expect(try #require(live.first { $0.id == alpha.id }).aliases.isEmpty)
+    #expect(receipt.droppedAliasCollisions.map(\.alias) == ["Shared"])
+  }
+
+  @Test("when two untouched words share an alias the receipt names the runtime winner")
+  func receiptNamesTheRuntimeWinningIncumbentAliasOwner() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(
+      manager,
+      [
+        CustomWord(canonical: "Earlier", aliases: ["annie"]),
+        CustomWord(canonical: "Later", aliases: ["annie"]),
+      ])
+    let later = try #require(live.first { $0.canonical == "Later" })
+
+    let receipt = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Zed", aliases: .supplied(["Annie"]))]),
+      to: &live)
+
+    // WordCorrector assigns aliases unconditionally, so the LATER word holds
+    // the trigger at runtime — naming the earlier one would misinform.
+    #expect(receipt.droppedAliasCollisions.map(\.heldBy) == [later.id])
+  }
+
+  @Test("commit failures carry an honest user-facing message")
+  func commitErrorsHaveLocalizedDescriptions() {
+    for error in [
+      CustomWordsImportCommitError.staleLibrary,
+      .invalidPlan,
+      .unreadableLibrary,
+    ] {
+      let message = error.localizedDescription
+      #expect(message.isEmpty == false)
+      // Every one must state that nothing was applied, and must not fall back
+      // to Foundation's generic text.
+      #expect(message.lowercased().contains("nothing"))
+      #expect(message.contains("couldn’t be completed") == false)
+    }
+  }
+
+  @Test("a second commit in the same second does not destroy the first backup")
+  func backupsInTheSameSecondDoNotOverwriteEachOther() throws {
+    let (manager, url) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Original")])
+
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("First")]), to: &live)
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Second")]), to: &live)
+
+    let siblings = try FileManager.default.contentsOfDirectory(
+      atPath: url.deletingLastPathComponent().path)
+    let backups = siblings.filter { $0.hasPrefix("custom-words.backup-") }
+    #expect(backups.count == 2)
+
+    // The oldest backup must still hold the true pre-import state.
+    let states = try backups.map { name -> [String] in
+      let backupURL = url.deletingLastPathComponent().appendingPathComponent(name)
+      let loaded = try #require(CustomWordsManager(fileURL: backupURL).load())
+      return loaded.map(\.canonical)
+    }
+    #expect(states.contains { $0.contains("Original") && !$0.contains("First") })
+  }
+
+  // MARK: - Built-ins
+
+  @Test("replacing a built-in leaves exactly one word, not the built-in plus an override")
+  func replacingABuiltinRetiresTheBuiltinInsteadOfDuplicatingIt() throws {
+    let (manager, _) = makeManager()
+    var live = try #require(manager.load())
+    let builtin = try #require(live.first)
+    let originalCount = live.count
+
+    _ = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: builtin.id,
+            candidate: candidate("\(builtin.canonical) Renamed"))
+        ]),
+      to: &live)
+
+    #expect(live.count == originalCount)
+    #expect(live.contains { $0.canonical == "\(builtin.canonical) Renamed" })
+    #expect(live.contains { $0.canonical == builtin.canonical } == false)
+  }
+
+  // MARK: - Backup
+
+  @Test("a changing commit writes a backup first")
+  func backupFileWrittenBeforeNonEmptyCommit() throws {
+    let (manager, url) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Qualtrics")])
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+
+    let siblings = try FileManager.default.contentsOfDirectory(
+      atPath: url.deletingLastPathComponent().path)
+    let backups = siblings.filter { $0.hasPrefix("custom-words.backup-") }
+    #expect(backups.count == 1)
+
+    // The backup holds the PRE-commit state.
+    let backupURL = url.deletingLastPathComponent().appendingPathComponent(backups[0])
+    let backed = try #require(CustomWordsManager(fileURL: backupURL).load())
+    #expect(backed.contains { $0.canonical == "Kubernetes" } == false)
+    #expect(backed.contains { $0.canonical == "Qualtrics" })
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
@@ -575,6 +575,37 @@ struct CustomWordsImportCommitTests {
     #expect(live.contains { $0.canonical == builtin.canonical } == false)
   }
 
+  @Test("an import survives a library where a renamed built-in duplicates its own ID")
+  func importSurvivesDuplicateIDsFromARenamedBuiltin() throws {
+    let (manager, _) = makeManager()
+    var live = try #require(manager.load())
+    let builtin = try #require(live.first)
+
+    // Renaming a built-in stores a user override carrying the built-in's OWN
+    // UUID, while `mergedWords` keeps showing the built-in (its canonical no
+    // longer matches any user word). Within this process the two therefore
+    // share an id. A later re-read is what surfaces the pair to a caller.
+    //
+    // That duplicate is itself the bug in #1670, so the `count == 2` guard
+    // below is a precondition, not a desired outcome: fixing #1670 will make
+    // it fail. When that lands, keep the commit assertions and build the
+    // duplicate directly instead — this test defends commitImport against a
+    // non-unique list, whatever produced it.
+    var renamed = builtin
+    renamed.canonical = "\(builtin.canonical) Renamed"
+    try manager.update(word: renamed, in: &live)
+
+    let reloaded = try #require(manager.load())
+    #expect(reloaded.filter { $0.id == builtin.id }.count == 2)
+
+    var working = reloaded
+    let receipt = try manager.commitImport(
+      plan(baseline: reloaded, additions: [candidate("Kubernetes")]), to: &working)
+
+    #expect(receipt.addedIDs.count == 1)
+    #expect(working.contains { $0.canonical == "Kubernetes" })
+  }
+
   // MARK: - Backup
 
   @Test("a changing commit writes a backup first")

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
@@ -575,6 +575,77 @@ struct CustomWordsImportCommitTests {
     #expect(live.contains { $0.canonical == builtin.canonical } == false)
   }
 
+  @Test("replacing an existing built-in override that moves the canonical retires the built-in")
+  func replacingAnExistingOverrideThatRenamesRetiresTheBuiltin() throws {
+    let (manager, _) = makeManager()
+    var live = try #require(manager.load())
+    let builtin = try #require(live.first)
+    let originalCount = live.count
+
+    // Edit the built-in WITHOUT renaming it. `update` stores a user override
+    // in `file.words` and no tombstone, because the unchanged canonical still
+    // hides the built-in — so the list stays the same size.
+    var edited = builtin
+    edited.aliases = builtin.aliases + ["extra alias"]
+    try manager.update(word: edited, in: &live)
+    let reloaded = try #require(manager.load())
+    #expect(reloaded.count == originalCount)
+
+    // Now a reviewed Replace moves the canonical away. The override already
+    // lives in `file.words`, so this takes the indexed branch rather than the
+    // create-an-override branch — the built-in must still be retired.
+    var working = reloaded
+    let existing = try #require(reloaded.first { $0.id == builtin.id })
+    _ = try manager.commitImport(
+      plan(
+        baseline: reloaded,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: existing.id,
+            candidate: candidate("\(builtin.canonical) Renamed"))
+        ]),
+      to: &working)
+
+    #expect(working.count == originalCount)
+    #expect(working.contains { $0.canonical == "\(builtin.canonical) Renamed" })
+    #expect(working.contains { $0.canonical == builtin.canonical } == false)
+  }
+
+  @Test("a replace that keeps the built-in's canonical does not retire the built-in")
+  func replacingABuiltinWithoutRenamingLeavesItRestorable() throws {
+    let (manager, url) = makeManager()
+    var live = try #require(manager.load())
+    let builtin = try #require(live.first)
+    let originalCount = live.count
+
+    // Same canonical, new aliases: the override keeps hiding the built-in on
+    // its own, so recording a tombstone would persist a deletion the user
+    // never performed. Retiring is reserved for a canonical that MOVES away,
+    // which is the only case where the built-in would otherwise resurface.
+    _ = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(
+            existingID: builtin.id,
+            candidate: candidate(builtin.canonical, aliases: .supplied(["fresh alias"])))
+        ]),
+      to: &live)
+
+    #expect(live.count == originalCount)
+
+    let file = try #require(
+      try? JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+    let tombstones = file["deletedBuiltinIds"] as? [String] ?? []
+    #expect(tombstones.isEmpty)
+
+    // The override carries the new aliases and is the only word with this
+    // canonical — the built-in is hidden, not duplicated and not retired.
+    let matching = live.filter { $0.canonical == builtin.canonical }
+    #expect(matching.count == 1)
+    #expect(matching.first?.aliases.contains("fresh alias") == true)
+  }
+
   @Test("an import survives a library where a renamed built-in duplicates its own ID")
   func importSurvivesDuplicateIDsFromARenamedBuiltin() throws {
     let (manager, _) = makeManager()


### PR DESCRIPTION
Part of #1619. Closes #1665.

PR-F2b of the adopted v5 plan: the one write path that applies a reviewed import.

## What

Everything the user approved lands in a single save, or nothing does. `addBatch` is additions-only and cannot express Replace, and splitting it across two writes would be exactly the partial commit this epic exists to prevent.

- **PostProcessing** — `CustomWordsImportCommit.swift`: library snapshot (for stale detection), replacement, commit plan, receipt, typed errors.
- **`CustomWordsManager.commitImport(_:to:)`** — strict read on P0's fail-closed loader, stale check against the effective list, replacements, additions, canonical-uniqueness recheck, alias-collision enforcement, best-effort backup, ONE save, publish only after the write succeeds.
- **AppKit** — a thin coordinator wrapper mapping the outcome and firing the existing change broadcast exactly once, only when something actually changed.

## Key space

Every comparison here is a **persistence** question, so all of it uses the manager's own `trimmed.lowercased()` rule — never the compare engine's stronger matching key. That is the split established in #1661 (F2a) and now written into the plan for the PRs that follow.

## One correctness fix beyond the plan's text

Replacing a **built-in** word now tombstones the built-in as well as writing the user override. The merge only hides a built-in whose canonical still matches a user word, so a Replace that *changed* the canonical would have left the original sitting beside the replacement — two words where the user approved one.

Mutation-proved: with the tombstone removed, the built-in test reports 12 words where 11 are expected and the original is still present, and **only** that test reddens. Restored, all 21 pass.

## Validation

- Full Debug suite green on this branch rebased onto merged main: **3,276 tests**.
- 26 tests in the new suite, run against a real temp-file-backed manager rather than a mock.
- Local Codex review to clean (5 findings, all fixed): arbitrary collision winner, a coalescing path that could drop a backup word, alias-owner precedence mirroring `WordCorrector`, an `Int.max` overflow trap, and an order-coincidental test that passed only because storage order happened to match plan order.

## Not in this PR

No UI reaches `commitImport` yet — PR-F2c (Review & Merge) is the caller, and it is the first piece that makes the flow walkable end to end. Two fine-tuning items are documented as fast-follows rather than chased here, per the founder's calibration for this epic: #1663 (fuzzy-distance scale) and #1667 (the no-space canonical surface, which needs a single shared authority across all six lookup surfaces).
