### PR TITLE
feat(pipeline): model-load boundary miss keeps its own bridged Sentry identity (#1658)

### DIFF
--- a/Sources/EnviousWisprCore/SentryCaptureBoundaryError.swift
+++ b/Sources/EnviousWisprCore/SentryCaptureBoundaryError.swift
@@ -98,4 +98,33 @@ extension SentryCaptureBoundaryError {
     (error as? any Error & StableSentryErrorIdentity)
       ?? SentryCaptureBoundaryError.unexpectedHeartControlFailure
   }
+
+  /// Row 7 (#1658): the kernel's `modelLoadError` write site. A non-conforming
+  /// model-load error — in practice the XPC last-resort raw `NSError`
+  /// (`ASRManagerProxy`, reached when neither typed reconstructor recognizes the
+  /// bridged domain/code) — keeps its own bridged identity instead of falling to
+  /// the generic `KernelFallbackSentryError.modelLoadFailed` read-side fallback.
+  package static func normalizingModelLoadFailure(
+    _ error: any Error
+  ) -> any Error & StableSentryErrorIdentity {
+    if let stable = error as? any Error & StableSentryErrorIdentity {
+      return stable
+    }
+    return UnrecognizedModelLoadSentryError(error)
+  }
+}
+
+/// Preserves the legacy bridged identity for a model-load failure that reached the
+/// kernel without its own `StableSentryErrorIdentity` (#1658). A struct, not a
+/// `SentryCaptureBoundaryError` case: the descriptor carries the raw error's own
+/// dynamic `domain#code`, which would break that enum's fixed-literal charter.
+package struct UnrecognizedModelLoadSentryError:
+  Error, StableSentryErrorIdentity, Sendable, Equatable
+{
+  package let sentryFingerprintDescriptor: String
+  package let sentrySemanticID = "asr.unrecognized_model_load_failure"
+
+  package init(_ error: any Error) {
+    sentryFingerprintDescriptor = SentryErrorDescriptor.bridged(error)
+  }
 }

--- a/Sources/EnviousWisprCore/StableSentryErrorIdentity.swift
+++ b/Sources/EnviousWisprCore/StableSentryErrorIdentity.swift
@@ -29,3 +29,19 @@ public protocol StableSentryErrorIdentity {
   /// it never enters the fingerprint, so it is safe to rename.
   var sentrySemanticID: String { get }
 }
+
+/// The legacy descriptor for errors without an explicit `StableSentryErrorIdentity` —
+/// the single authority for the bridged `domain#code` rule described above, including
+/// the guard that swaps a Swift local-scope type's mangled bridge domain for its bare
+/// type name. `SentryBreadcrumb.structuredDescriptor` delegates its non-conforming
+/// branch here; `UnrecognizedModelLoadSentryError` pins its descriptor from it
+/// (#1658). **PINNED behaviour — shipped fingerprints depend on this exact output.**
+package enum SentryErrorDescriptor {
+  package static func bridged(_ error: any Error) -> String {
+    let ns = error as NSError
+    if ns.domain.contains("(unknown context at ") {
+      return "\(type(of: error))#\(ns.code)"
+    }
+    return "\(ns.domain)#\(ns.code)"
+  }
+}

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2303,13 +2303,12 @@ final class RecordingSessionKernel {
     if stopLatched { return .stopped }
     if cancelRequested { return .cancelled }
     if adapter.readiness == .ready { return .ready }
-    // #1525 PR J-1: identical cast pattern to `captureFailureError` above
-    // (§4) — a miss (the rare XPC last-resort raw error,
-    // `ASRManagerProxy.swift:222-229`) leaves the property nil and the
-    // read-side `KernelFallbackSentryError.modelLoadFailed` fallback fires.
-    // Restoring that rare case's own identity is PR J-2 (#1658).
+    // #1658 PR J-2: preserve an already-stable model-load error unchanged;
+    // normalize the XPC last-resort raw NSError into an explicit stable
+    // identity so its own domain#code survives to Sentry.
     if let thrownError {
-      telemetryState.modelLoadError = thrownError as? (any Error & StableSentryErrorIdentity)
+      telemetryState.modelLoadError =
+        SentryCaptureBoundaryError.normalizingModelLoadFailure(thrownError)
     }
     return .loadFailed
   }

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -249,11 +249,7 @@ public enum SentryBreadcrumb {
     if let stable = error as? any StableSentryErrorIdentity {
       return stable.sentryFingerprintDescriptor
     }
-    let ns = error as NSError
-    if ns.domain.contains("(unknown context at ") {
-      return "\(type(of: error))#\(ns.code)"
-    }
-    return "\(ns.domain)#\(ns.code)"
+    return SentryErrorDescriptor.bridged(error)
   }
 
   /// Stable Sentry grouping key for a handled error: namespace + category + the

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -739,6 +739,32 @@ import Testing
       recorder.captureErrors.first?.errorDescription == "CoreML model failed to compile")
   }
 
+  /// #1658 PR J-2: pins the defensive nil-property fallback identity. Both current
+  /// production adapters enforce ready-or-throw, so a nil `modelLoadError` at
+  /// `.loadFailed` is not a demonstrated production path — but the sink's fallback
+  /// must keep its shipped identity if one ever reaches it.
+  @Test(".failed(.modelLoadFailed) with modelLoadError nil emits the fixed fallback identity")
+  func failedModelLoadFailedNilPropertyUsesFallbackIdentity() {
+    var capturedIdentity: String?
+    var capturedDescriptor: String?
+    var captureCount = 0
+    let sink = KernelLifecycleTelemetrySink(
+      backend: .parakeet,
+      audioCapture: FakeAudioCapture(),
+      context: KernelSessionContext(),
+      captureTelemetry: CaptureTelemetryState(),
+      telemetryState: KernelTelemetryState(),
+      captureError: { error, _, _, _ in
+        captureCount += 1
+        capturedIdentity = error.sentrySemanticID
+        capturedDescriptor = error.sentryFingerprintDescriptor
+      })
+    sink.emit(.failed(.modelLoadFailed))
+    #expect(captureCount == 1)
+    #expect(capturedDescriptor == "EnviousWispr#-10")
+    #expect(capturedIdentity == "kernel.model_load_failed")
+  }
+
   @Test(".failed(.captureStartFailed) emits .audioCaptureFailed captureError")
   func failedCaptureStartFailedEmission() {
     let recorder = Recorder()

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -204,22 +204,24 @@ import Testing
       context.clock.drainPending()
     }
 
-    // MARK: #1525 PR J-1 — modelLoadError cast-miss falls back to KernelFallbackSentryError
+    // MARK: #1658 PR J-2 — a non-conforming modelLoadError keeps its own bridged identity
 
     @Test(
-      "a genuine load failure with a non-conforming error leaves modelLoadError nil and the lifecycle sink still fires exactly one event under the fixed fallback identity"
+      "a genuine load failure with a raw NSError normalizes at the write site and the lifecycle sink fires exactly one event under the raw error's own domain#code identity"
     )
-    func modelLoadFailedNonConformingFallsBackToKernelFallbackIdentity() async {
-      struct OpaqueLoadError: Error, Sendable {}
-      let (_, wrapper) = makeWrapper(behavior: .failLoad(OpaqueLoadError()))
+    func modelLoadFailedRawNSErrorNormalizesToUnrecognizedModelLoad() async {
+      let raw = NSError(domain: "com.acme.vendor", code: 42)
+      let (_, wrapper) = makeWrapper(behavior: .failLoad(raw))
       let kernel = wrapper.testKernel
 
       await apply(.start, to: wrapper)
 
       #expect(kernel.recordingOutcome == .failed(.modelLoadFailed))
-      // The cast at the write site misses (OpaqueLoadError does not conform to
-      // StableSentryErrorIdentity) — the property stays nil by design (§4).
-      #expect(wrapper.telemetryState.modelLoadError == nil)
+      // The write site normalizes the non-conforming error instead of dropping
+      // it to nil — its bridged domain#code survives as the Sentry identity.
+      #expect(
+        wrapper.telemetryState.modelLoadError?.sentryFingerprintDescriptor
+          == "com.acme.vendor#42")
 
       var capturedIdentity: String?
       var capturedDescriptor: String?
@@ -238,8 +240,8 @@ import Testing
       sink.emit(.failed(.modelLoadFailed))
 
       #expect(captureCount == 1)
-      #expect(capturedDescriptor == "EnviousWispr#-10")
-      #expect(capturedIdentity == "kernel.model_load_failed")
+      #expect(capturedDescriptor == "com.acme.vendor#42")
+      #expect(capturedIdentity == "asr.unrecognized_model_load_failure")
     }
 
     // MARK: #959 — seam routing: ordinary terminal uses cheap cancel(), wedge uses recoverFromWedge()

--- a/Tests/EnviousWisprTests/Pipeline/SentryCaptureBoundaryErrorTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/SentryCaptureBoundaryErrorTests.swift
@@ -82,6 +82,9 @@ struct SentryCaptureBoundaryErrorTests {
     #expect(
       SentryCaptureBoundaryError.normalizingHeartControlFailure(error).sentrySemanticID
         == "already.conforming")
+    #expect(
+      SentryCaptureBoundaryError.normalizingModelLoadFailure(error).sentrySemanticID
+        == "already.conforming")
   }
 
   // MARK: - D. Non-conforming, unrecognized misses fall to the fixed `.unexpected*` identity
@@ -143,5 +146,59 @@ struct SentryCaptureBoundaryErrorTests {
     #expect(
       event.fingerprint == ["handled_error", "asr_failed", "com.apple.CoreML#0", Self.env])
     #expect(event.tags?["error.identity"] == "asr.external_coreml")
+  }
+
+  // MARK: - F. #1658 PR J-2 — .normalizingModelLoadFailure preserves the raw bridged identity
+
+  @Test("normalizingModelLoadFailure(raw NSError) matches the raw error's own fingerprint")
+  func modelLoadRawNSErrorMatchesBridgedFingerprint() {
+    let raw = NSError(domain: "com.acme.vendor", code: 42)
+    let normalized = SentryCaptureBoundaryError.normalizingModelLoadFailure(raw)
+    #expect(normalized.sentryFingerprintDescriptor == SentryBreadcrumb.structuredDescriptor(raw))
+    #expect(normalized.sentryFingerprintDescriptor == "com.acme.vendor#42")
+    #expect(normalized.sentrySemanticID == "asr.unrecognized_model_load_failure")
+  }
+
+  @Test("normalizingModelLoadFailure(second domain/code pair) matches the raw fingerprint")
+  func modelLoadRawNSErrorSecondPairMatchesBridgedFingerprint() {
+    let raw = NSError(domain: "NSCocoaErrorDomain", code: 260)
+    let normalized = SentryCaptureBoundaryError.normalizingModelLoadFailure(raw)
+    #expect(normalized.sentryFingerprintDescriptor == SentryBreadcrumb.structuredDescriptor(raw))
+    #expect(normalized.sentryFingerprintDescriptor == "NSCocoaErrorDomain#260")
+    #expect(normalized.sentrySemanticID == "asr.unrecognized_model_load_failure")
+  }
+
+  @Test(
+    "normalizingModelLoadFailure on a mangled-domain Swift error keeps structuredDescriptor parity")
+  func modelLoadMangledDomainSwiftErrorKeepsParity() {
+    let raw = Opaque()
+    let normalized = SentryCaptureBoundaryError.normalizingModelLoadFailure(raw)
+    #expect(normalized.sentryFingerprintDescriptor == SentryBreadcrumb.structuredDescriptor(raw))
+    #expect(normalized.sentryFingerprintDescriptor == "Opaque#1")
+    #expect(normalized.sentrySemanticID == "asr.unrecognized_model_load_failure")
+  }
+
+  @Test("UnrecognizedModelLoadSentryError equality follows the stored descriptor")
+  func unrecognizedModelLoadEquality() {
+    let a = UnrecognizedModelLoadSentryError(NSError(domain: "com.acme.vendor", code: 42))
+    let b = UnrecognizedModelLoadSentryError(NSError(domain: "com.acme.vendor", code: 42))
+    let c = UnrecognizedModelLoadSentryError(NSError(domain: "com.acme.vendor", code: 43))
+    #expect(a == b)
+    #expect(a != c)
+  }
+
+  @MainActor
+  @Test(
+    "a normalized model-load event carries the production title, fingerprint, and identity tag")
+  func unrecognizedModelLoadEventShape() {
+    let normalized = SentryCaptureBoundaryError.normalizingModelLoadFailure(
+      NSError(domain: "com.acme.vendor", code: 42))
+    let event = SentryBreadcrumb.makeHandledErrorEvent(
+      normalized, category: .modelLoadFailed, stage: "model_load", environment: Self.env)
+    #expect(event.message?.formatted == "model_load_failed: com.acme.vendor#42")
+    #expect(
+      event.fingerprint
+        == ["handled_error", "model_load_failed", "com.acme.vendor#42", Self.env])
+    #expect(event.tags?["error.identity"] == "asr.unrecognized_model_load_failure")
   }
 }


### PR DESCRIPTION
Closes #1658. Part of #1525 (final PR of the stable-error-identity epic; the epic issue is closed explicitly after merge with its Architecture Closeout).

## What

PR J-1 (#1666) narrowed the kernel's model-load telemetry property with a cast-miss-to-nil write site, which cost the one non-conforming producer — the XPC last-resort raw `NSError` branch in `ASRManagerProxy` (reached when neither typed reconstructor recognizes the bridged domain/code) — its own `domain#code` diagnostic identity. This PR restores it:

- **`SentryErrorDescriptor.bridged` (Core, new):** the legacy bridged `domain#code` rule (including the mangled local-scope-domain guard) becomes one Core authority; `SentryBreadcrumb.structuredDescriptor` now delegates its non-conforming branch to it, byte-identical output.
- **`UnrecognizedModelLoadSentryError` (Core, new):** pins the raw error's bridged descriptor at init; `error.identity` tag `asr.unrecognized_model_load_failure`. A struct, not a `SentryCaptureBoundaryError` case — the enum's fixed-literal charter stays intact.
- **`normalizingModelLoadFailure`** joins the seam normalizers; the kernel write site normalizes instead of dropping non-conforming errors to nil. Conforming errors pass through unchanged.
- The read-side `KernelFallbackSentryError.modelLoadFailed` fallback stays for the defensive nil path (both production adapters enforce ready-or-throw), now pinned by a direct sink test.

## Review trail

- Grounded review r1: PROCEED-WITH-REVISIONS — all findings adopted (dedicated struct over a dynamic enum case; Core descriptor authority instead of a 2-line mirror; NSError fixture realism).
- Grounded review r2: PROCEED-AS-PLANNED.
- Local Codex code-diff review: clean, round 1.

## Validation

- Full canonical suite: 3274 tests green (Debug lane); focused runs prove each new/rewritten test executed by name.
- New tests: bridged-descriptor parity vs `structuredDescriptor` (raw NSError ×2, mangled-domain Swift error), conforming passthrough, struct equality, full event-construction shape, kernel write-site normalization (`com.acme.vendor#42` end-to-end), sink nil-property fallback pin (`EnviousWispr#-10`).
- `scripts/check-dependency-direction.sh` clean across 15 modules.
- Live UAT: not separately fault-injected — the changed path is unreachable without injection (same accepted rationale as J-1's unit-tested fallback contract); the post-merge rebuild-from-main healthy check covers heart-path non-regression.

Lane: Code | Tier: SMALL (Pipeline telemetry; test obligations applied)
