### PR TITLE
chore(release): bump version to 2.4.0

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.1</string>
+	<string>2.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.1</string>
+	<string>2.4.0</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -13,6 +13,73 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.4.0
+
+    Entry(
+      id: "model-download-improvements",
+      icon: "arrow.down.circle",
+      title: "Download improvements",
+      description:
+        "We revamped how the speech and polish models download, and where they are stored on disk. Downloads are faster, resume on their own if your connection drops, and can be cancelled if they stall.",
+      version: "2.4.0"
+    ),
+    Entry(
+      id: "bluetooth-usb-audio-support",
+      icon: "waveform.badge.mic",
+      title: "Proper Bluetooth and USB audio support",
+      description:
+        "EnviousWispr now properly supports Bluetooth and USB microphones, including on Mac mini. We also rebuilt the entire infrastructure around our sound capture engine to be far more robust, so recording no longer fails quietly when a microphone misbehaves.",
+      version: "2.4.0"
+    ),
+    Entry(
+      id: "recording-sound-cues",
+      icon: "speaker.wave.2",
+      title: "Customizable sound cues",
+      description:
+        "Optional chimes when recording starts and stops. Twelve to choose from, soft to loud. Off by default.",
+      version: "2.4.0"
+    ),
+    Entry(
+      id: "recording-pill-position",
+      icon: "rectangle.topthird.inset.filled",
+      title: "Choose your recording pill location",
+      description:
+        "Move the recording pill to the top or bottom of your screen and it remembers.",
+      version: "2.4.0"
+    ),
+    Entry(
+      id: "larger-menu-bar-icon",
+      icon: "menubar.arrow.up.rectangle",
+      title: "Larger menu bar icon",
+      description:
+        "The menu bar icon is now larger and easier to spot.",
+      version: "2.4.0"
+    ),
+    Entry(
+      id: "open-source-licenses",
+      icon: "doc.text",
+      title: "Open Source Licenses",
+      description:
+        "A new screen in Settings so the open source licenses EnviousWispr is built on are always available to read in the app.",
+      version: "2.4.0"
+    ),
+    Entry(
+      id: "openai-model-support",
+      icon: "sparkles",
+      title: "All OpenAI models now properly supported",
+      description:
+        "OpenAI changed how its API calls work. We fixed them so their full library of models can be used for cloud polishing. This also includes smaller fixes, such as making sure you are notified if you forget to enter your API key.",
+      version: "2.4.0"
+    ),
+    Entry(
+      id: "recording-timer-reset",
+      icon: "timer",
+      title: "Timer bug addressed",
+      description:
+        "The timer no longer resets when you swap between screens.",
+      version: "2.4.0"
+    ),
+
     // MARK: - v2.3.2
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.3.2"
+  public static let currentContentVersion = "2.4.0"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -59,6 +59,7 @@ struct WhatsNewContentTests {
     // untouched by #1493; asserting the real sequence is the falsifiable version.
     #expect(
       WhatsNewContent.versions == [
+        "2.4.0",
         "2.3.2", "2.3.1", "2.3.0",
         "2.2.1", "2.2.0",
         "2.1.4", "2.1.3", "2.1.2", "2.1.1", "2.1.0",


### PR DESCRIPTION
## Summary

Version bump to v2.4.0 with What's New entries for the user-visible changes shipped since the
last release.

This is a large release: 120 commits on `main` since the `v2.3.2` tag. Note that `v2.3.2` was a
hotfix cut off-main (it carried only the #1353 microphone fix), so everything else merged since
`v2.3.1` ships here for the first time. `Info.plist` was still on `2.3.1` for that reason.

Headline themes: the audio-capture rebuild (#1511), model delivery moving off the bundled
monolith (#1386), Bluetooth/AirPods capture fixes, and new settings for sound cues and pill
position.

## Changes

- `Info.plist` — `CFBundleShortVersionString` / `CFBundleVersion` → `2.4.0`
- `WhatsNewConstants.currentContentVersion` → `2.4.0`
- `WhatsNewContent.swift` — 8 new entries under `// MARK: - v2.4.0`
- `WhatsNewContentTests.versionsAreNewestFirst` — expected sequence gains `2.4.0` at the head

## Test plan

- [x] `scripts/xcode-test.sh --filter EnviousWisprTests/WhatsNewContentTests` — 8 tests pass
- [x] `scripts/build-dev-app.sh` — built and launched; bundle reports `2.4.0`
- [ ] `build-check` CI passes on this PR
- [ ] Tag `v2.4.0` after merge triggers the release pipeline

### Note on the local full-suite run

A full local run from this `/tmp` worktree reports 6 failures in `EngineIdentityFreezeTests`,
`OutputClassifierContractTests`, and `WhisperKitGatedLoadFreezeTests`. These are **not** caused by
this change and are a worktree-location artifact:

- A clean, unmodified worktree at the same commit (`23039a1a`) in `/tmp` fails the same 6.
- The same commit at the normal repo path passes all of them.
- `main` @ `23039a1a` is green on CI.

Cause: these freeze tests derive the repo root from `#filePath` by trimming four path components,
which mis-resolves for a `/tmp` checkout — the failure prints offenders as `/privateSources/...`,
i.e. a root of `/private`. Filed separately rather than fixed here to keep the release bump clean.
