### PR TITLE
feat(user): Review & Merge screen for Custom Words import (PR-F2c, #1669)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -71,6 +71,20 @@ final class CustomWordsCoordinator {
       customWordError = nil
       return .committed(receipt)
     } catch CustomWordsImportCommitError.staleLibrary {
+      // Stale means the on-disk list no longer matches what Review was built
+      // from, and the commit threw WITHOUT touching `customWords` — so the
+      // in-memory list is exactly the stale copy that caused this. Refresh it
+      // from disk before returning, or the sheet rebuilds its comparison from
+      // the same stale data, produces identical rows, and fails stale again on
+      // the next confirm: a loop the user cannot escape (cloud review, #1679).
+      //
+      // Fail closed on an unreadable file: keep the current list rather than
+      // clobbering it with an empty one. The commit still reports `.stale`,
+      // which is honest either way — nothing was written.
+      if let refreshed = manager.load(), refreshed != customWords {
+        customWords = refreshed
+        onWordsChanged?(customWords)
+      }
       customWordError = nil
       return .stale
     } catch {

--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -1,19 +1,59 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
 import Foundation
 
-/// Navigation state for the Custom Words import sheet (#1657, epic #1619 PR-F1).
+/// Navigation state and workflow for the Custom Words import sheet
+/// (#1657 PR-F1 shell, #1669 PR-F2c workflow; epic #1619).
 ///
-/// The shell every import source plugs into: it owns only which screen the
-/// sheet shows and which method the user picked. No source adapters, no
-/// compare logic, no persistence, no telemetry — those arrive in later PRs
-/// (F2a compare, F2b commit, F2c review UI, then the real sources), which
-/// drive `showReview()` / `beginWork(_:)` / `showResult(_:)` from real work.
-/// In F1 those transitions are exercised by tests and the DEBUG-only
-/// "Preview import" fixture walk.
+/// Owns which screen the sheet shows, which method the user picked, the review
+/// rows and their decisions, and the load → compare → review → commit
+/// sequence. Real input sources arrive later (P1 paste, U1 upload, 4a smart
+/// import); PR-P1 also inserts its enrichment stage between compare and
+/// review by editing this model directly — no seam is pre-built for it here.
 ///
 /// Invariant: `selectedMethod` is non-nil exactly while a method's flow is
 /// active; returning to `.methodPicker` (via `goBack()` or `reset()`) clears it.
+///
+/// Cancellation is signal-based, never clock-based: every asynchronous stage
+/// carries the generation it started in, and only the current generation may
+/// publish. Dismiss, cancel, and a fresh comparison run each advance it, so a
+/// late completion is discarded rather than applied to a screen that moved on.
 @MainActor @Observable
 final class CustomWordsImportFlowModel {
+  /// The two collaborators the workflow needs, injected as narrow closures
+  /// rather than a coordinator reference so tests drive the flow without
+  /// constructing persistence (`di-narrow-homes`).
+  struct Dependencies {
+    /// The live word list, read fresh at each comparison so a stale-triggered
+    /// rebuild compares against what is actually on disk now.
+    var existingWords: @MainActor () -> [CustomWord]
+    var commit:
+      @MainActor (CustomWordsImportCommitPlan) ->
+        CustomWordsCoordinator.CustomWordsImportCommitOutcome
+    /// Classification, injected so the fuzzy policy this flow passes is
+    /// observable in a test rather than sealed inside the model.
+    var compare:
+      @Sendable ([CustomWordsImportCandidate], [CustomWord], CustomWordsImportFuzzyPolicy)
+        async throws -> [CustomWordsImportComparison]
+
+    /// Production wiring: one compare engine for the sheet's lifetime.
+    static func live(
+      existingWords: @escaping @MainActor () -> [CustomWord],
+      commit: @escaping @MainActor (CustomWordsImportCommitPlan) ->
+        CustomWordsCoordinator.CustomWordsImportCommitOutcome
+    ) -> Dependencies {
+      let engine = CustomWordsImportCompareEngine()
+      return Dependencies(
+        existingWords: existingWords,
+        commit: commit,
+        compare: { candidates, existing, policy in
+          try await engine.compare(
+            candidates: candidates, against: existing, fuzzyPolicy: policy)
+        }
+      )
+    }
+  }
+
   enum Step: Equatable {
     case methodPicker
     case paste
@@ -32,7 +72,12 @@ final class CustomWordsImportFlowModel {
 
   enum Result: Equatable {
     case completed(added: Int, replaced: Int)
+    /// The source produced no candidates at all.
     case nothingFound
+    /// Candidates were found and reviewed, but every one was skipped. Distinct
+    /// from `.nothingFound` because "we found nothing" and "you kept nothing"
+    /// are different things to tell someone.
+    case nothingApproved
     case failed(message: String)
   }
 
@@ -55,6 +100,24 @@ final class CustomWordsImportFlowModel {
 
   private(set) var step: Step = .methodPicker
   private(set) var selectedMethod: Method?
+  private(set) var rows: [CustomWordsImportReviewRow] = []
+  /// Set when a commit failed because the word list changed underneath an open
+  /// review; cleared as soon as the user acts again.
+  private(set) var staleNotice: String?
+  /// Surfaced on the result screen when PR-F2b dropped colliding aliases.
+  private(set) var droppedAliasCollisionCount = 0
+
+  private let dependencies: Dependencies
+  /// The library the open review was built against — PR-F2b re-validates it at
+  /// commit time and refuses the write if it no longer matches.
+  private var baseline = CustomWordsImportLibrarySnapshot(words: [])
+  private var candidates: [CustomWordsImportCandidate] = []
+  private var generation = 0
+  private var activeTask: Task<Void, Never>?
+
+  init(dependencies: Dependencies) {
+    self.dependencies = dependencies
+  }
 
   /// True exactly where `goBack()` does something — the three input screens
   /// and review. The sheet's Back button reads this instead of keeping its
@@ -65,6 +128,14 @@ final class CustomWordsImportFlowModel {
     case .methodPicker, .working, .result: return false
     }
   }
+
+  /// The rows the user has chosen to add. The screen reads this for its
+  /// summary line and to decide whether Confirm does anything.
+  var approvedRows: [CustomWordsImportReviewRow] {
+    rows.filter { $0.decision == .add }
+  }
+
+  // MARK: - Navigation (PR-F1)
 
   /// Method picker → the picked method's input screen. Ignored anywhere else:
   /// picking a method is only meaningful on the picker.
@@ -108,12 +179,19 @@ final class CustomWordsImportFlowModel {
   /// input screens → `.methodPicker`; `.review` → the selected method's input
   /// screen; `.working` → no-op (Back is disabled); `.result` → no-op (no
   /// Back, Done dismisses); `.methodPicker` → no-op.
+  ///
+  /// Leaving review abandons the comparison: the decisions on screen belong to
+  /// a run the user just walked away from, and silently reusing them against a
+  /// later run is exactly the stale-decision replay PR-F2b refuses.
   func goBack() {
     switch step {
     case .paste, .upload, .smartImportAppPicker:
       selectedMethod = nil
       step = .methodPicker
     case .review:
+      abandonWork()
+      rows = []
+      staleNotice = nil
       // `showReview()` guarantees a selected method, but stay deterministic
       // rather than trap if a future caller breaks that assumption.
       step = selectedMethod?.inputStep ?? .methodPicker
@@ -124,7 +202,151 @@ final class CustomWordsImportFlowModel {
 
   /// Fresh model state: back to the picker with no method selected.
   func reset() {
+    abandonWork()
+    rows = []
+    staleNotice = nil
+    droppedAliasCollisionCount = 0
     selectedMethod = nil
     step = .methodPicker
+  }
+
+  /// Sheet dismissal. Nothing is written on the way out; any in-flight stage
+  /// is cancelled and can no longer publish.
+  func cancel() {
+    abandonWork()
+  }
+
+  // MARK: - Workflow (PR-F2c)
+
+  /// Run a source end to end: load its candidates, compare them against the
+  /// current word list, and land on Review.
+  func begin(with source: any CustomWordsImportSource) {
+    guard selectedMethod != nil else { return }
+    let runGeneration = abandonWork()
+    staleNotice = nil
+    droppedAliasCollisionCount = 0
+    rows = []
+    beginWork(.loadingCandidates)
+
+    activeTask = Task { [weak self] in
+      await self?.load(from: source, generation: runGeneration)
+    }
+  }
+
+  /// Apply the current decisions in one atomic write.
+  ///
+  /// The plan is additions-only by construction: `.add` is reachable for
+  /// `.new` rows alone, so no decision in v1 can produce a replacement.
+  func confirm() {
+    guard step == .review else { return }
+    let additions = approvedRows.map(\.comparison.candidate)
+    guard !additions.isEmpty else {
+      beginWork(.committing)
+      showResult(.nothingApproved)
+      return
+    }
+
+    staleNotice = nil
+    beginWork(.committing)
+    let plan = CustomWordsImportCommitPlan(
+      baseline: baseline, additions: additions, replacements: [])
+
+    switch dependencies.commit(plan) {
+    case .committed(let receipt):
+      droppedAliasCollisionCount = receipt.droppedAliasCollisions.count
+      showResult(
+        .completed(added: receipt.addedIDs.count, replaced: receipt.replacedIDs.count))
+    case .stale:
+      recompareAfterStaleCommit()
+    case .failed(let message):
+      showResult(.failed(message: message))
+    }
+  }
+
+  func setDecision(_ decision: CustomWordsImportDecision, forRow id: UUID) {
+    guard let index = rows.firstIndex(where: { $0.id == id }) else { return }
+    // The screen only renders allowed decisions, but the model is the
+    // authority: an action persistence would refuse must not become state.
+    guard rows[index].allowedDecisions.contains(decision) else { return }
+    rows[index].decision = decision
+  }
+
+  // MARK: - Workflow internals
+
+  private func load(from source: any CustomWordsImportSource, generation: Int) async {
+    do {
+      let batch = try await source.loadCandidates()
+      guard isCurrent(generation) else { return }
+      guard !batch.candidates.isEmpty else {
+        showResult(.nothingFound)
+        return
+      }
+      candidates = batch.candidates
+      beginWork(.comparing)
+      await compare(candidates: batch.candidates, generation: generation)
+    } catch is CancellationError {
+      return
+    } catch {
+      guard isCurrent(generation) else { return }
+      showResult(.failed(message: error.localizedDescription))
+    }
+  }
+
+  private func compare(
+    candidates: [CustomWordsImportCandidate], generation: Int
+  ) async {
+    let existing = dependencies.existingWords()
+    do {
+      // Fuzzy matching is OFF in v1 (founder, 2026-07-18). With Replace gone a
+      // similarity match can no longer offer anything — it can only withhold
+      // Add — so a false positive would silently refuse a legitimately
+      // different word with no recourse. The engine keeps the capability; this
+      // caller declines to arm it.
+      let comparisons = try await dependencies.compare(candidates, existing, .disabled)
+      guard isCurrent(generation) else { return }
+      baseline = CustomWordsImportLibrarySnapshot(words: existing)
+      rows = CustomWordsImportReviewRow.rows(from: comparisons, existingWords: existing)
+      showReview()
+    } catch is CancellationError {
+      return
+    } catch {
+      guard isCurrent(generation) else { return }
+      showResult(.failed(message: error.localizedDescription))
+    }
+  }
+
+  /// The word list changed while Review was open. Nothing was written. Rebuild
+  /// the comparison against the current list and return to Review with every
+  /// decision reset — old decisions belong to matches that may no longer exist,
+  /// and replaying them is precisely what PR-F2b's staleness check prevents.
+  private func recompareAfterStaleCommit() {
+    let runGeneration = advanceGeneration()
+    let pending = candidates
+    staleNotice =
+      "Your word list changed while you were reviewing. "
+      + "Nothing was imported — here are the updated matches."
+    beginWork(.comparing)
+
+    activeTask = Task { [weak self] in
+      await self?.compare(candidates: pending, generation: runGeneration)
+    }
+  }
+
+  /// Cancel any in-flight stage and make its completion unpublishable.
+  /// Returns the new generation so a caller starting fresh work can carry it.
+  @discardableResult
+  private func abandonWork() -> Int {
+    activeTask?.cancel()
+    activeTask = nil
+    return advanceGeneration()
+  }
+
+  private func advanceGeneration() -> Int {
+    generation += 1
+    return generation
+  }
+
+  private func isCurrent(_ candidateGeneration: Int) -> Bool {
+    candidateGeneration == generation
   }
 }

--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportReviewRow.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportReviewRow.swift
@@ -135,6 +135,22 @@ struct CustomWordsImportReviewRow: Identifiable, Sendable, Equatable {
     }
   }
 
+  /// Unreachable in v1, deliberately kept: the compare engine only records a
+  /// collision for a candidate whose aliases are `.supplied`
+  /// (`CustomWordsImportCompareEngine.detectAliasCollisions`), and no v1
+  /// source supplies any — every candidate's alias field is `.unspecified`.
+  /// The first real producer is backup restore (PR-E1/U1), which is also when
+  /// this copy first reaches a user. It is written here rather than deferred
+  /// because F2a already ships the detection and the display is a plain
+  /// rendering of it, not new machinery for a hypothetical state.
+  ///
+  /// The wording is deliberately conditional ("may not be"). Whether a given
+  /// alias actually lands depends on which rows the user approves — a
+  /// candidate that lost an alias to another *incoming* candidate wins it back
+  /// if that other row is skipped. Recomputing this per decision change would
+  /// be decision-aware display logic for a case v1 cannot produce; honest
+  /// conditional copy is correct in every future instead. PR-F2b's receipt
+  /// reports what was actually dropped, and the result screen shows that count.
   private static func collisionNote(
     for collisions: [CustomWordsImportAliasCollision],
     namesByID: [UUID: String]
@@ -144,11 +160,11 @@ struct CustomWordsImportReviewRow: Identifiable, Sendable, Equatable {
     // candidate rather than an existing word, in which case there is no name
     // to look up and the honest line just states the outcome.
     if collisions.count == 1, let owner = namesByID[collisions[0].heldBy] {
-      return "The spelling \"\(collisions[0].alias)\" won't be added, "
+      return "The spelling \"\(collisions[0].alias)\" may not be added, "
         + "because \(owner) already uses it."
     }
     let count = collisions.count
     let noun = count == 1 ? "spelling" : "spellings"
-    return "\(count) alternate \(noun) won't be added, because other words already use them."
+    return "\(count) alternate \(noun) may not be added, because other words already use them."
   }
 }

--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportReviewRow.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportReviewRow.swift
@@ -1,0 +1,154 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import Foundation
+
+/// A review decision (#1669, epic #1619 PR-F2c).
+///
+/// v1 offers exactly two (founder scope revision, 2026-07-18). Replace and
+/// Keep Both are deliberately absent: no import source ships yet, so a v1
+/// candidate carries only its main word, and a Replace would rewrite a
+/// hand-tuned entry's spelling on the authority of nothing. Importing *with
+/// your own aliases* is a later version, and arrives as an alias **merge**
+/// offer built on PR-F2b's replacement machinery — not as a revived Replace.
+enum CustomWordsImportDecision: Sendable, Equatable, CaseIterable {
+  case add
+  case skip
+}
+
+/// Result-screen copy, kept out of the view so it can be asserted directly
+/// (#1669). The view renders these strings and adds nothing of its own.
+enum CustomWordsImportResultCopy {
+  static func message(for result: CustomWordsImportFlowModel.Result) -> String {
+    switch result {
+    case .completed(let added, let replaced):
+      // v1 can only add, so the replaced count is mentioned only if a later
+      // flow (backup restore) actually produced one — a v1 user must never
+      // read "replaced 0".
+      let addedPhrase = "Added \(added) \(added == 1 ? "word" : "words")."
+      guard replaced > 0 else { return "\(addedPhrase) Your words are ready to use." }
+      return "\(addedPhrase) Replaced \(replaced). Your words are ready to use."
+    case .nothingFound:
+      return "No words were found, and nothing was changed."
+    case .nothingApproved:
+      return "You skipped everything, so nothing was changed."
+    case .failed(let message):
+      return message
+    }
+  }
+
+  static func droppedCollisionMessage(count: Int) -> String {
+    let noun = count == 1 ? "spelling was" : "spellings were"
+    return "\(count) alternate \(noun) skipped, because other words already use them."
+  }
+}
+
+/// One row on the Review & Merge screen: a comparison, the decision the user
+/// has selected for it, and the pre-resolved copy the screen renders.
+///
+/// Identity is the comparison's own UUID, never an array index, so re-ordering
+/// or a stale-triggered rebuild can never move a decision onto another word.
+///
+/// The two note strings are resolved at build time rather than computed on
+/// demand because naming a collision's owner requires the existing library,
+/// which this row deliberately does not retain.
+struct CustomWordsImportReviewRow: Identifiable, Sendable, Equatable {
+  let comparison: CustomWordsImportComparison
+  /// Non-nil only when the word already exists in some form; this is the
+  /// "you already have this one" line.
+  let matchSummary: String?
+  /// Non-nil when this candidate's aliases would land on a trigger another
+  /// word already owns. Informational only — it never changes which decisions
+  /// are available, and PR-F2b is the guarantee that a colliding alias is
+  /// never persisted.
+  let collisionNote: String?
+  var decision: CustomWordsImportDecision
+
+  var id: UUID { comparison.id }
+  var canonical: String { comparison.candidate.canonical }
+  var allowedDecisions: [CustomWordsImportDecision] {
+    Self.allowedDecisions(for: comparison.classification)
+  }
+  var isAddable: Bool { allowedDecisions.contains(.add) }
+
+  /// Classification-gated, never universal: the screen must not offer an
+  /// action persistence would refuse. Only a genuinely new word can be added;
+  /// every match classification is Skip-only.
+  ///
+  /// `.fuzzy` is unreachable in v1 — the flow passes
+  /// `CustomWordsImportFuzzyPolicy.disabled` — but it is handled here rather
+  /// than trapped, so a future caller that arms the policy cannot produce an
+  /// unhandled row.
+  static func allowedDecisions(
+    for classification: CustomWordsImportClassification
+  ) -> [CustomWordsImportDecision] {
+    switch classification {
+    case .new: return [.add, .skip]
+    case .exact, .variant, .fuzzy, .ambiguous: return [.skip]
+    }
+  }
+
+  static func defaultDecision(
+    for classification: CustomWordsImportClassification
+  ) -> CustomWordsImportDecision {
+    switch classification {
+    case .new: return .add
+    case .exact, .variant, .fuzzy, .ambiguous: return .skip
+    }
+  }
+
+  /// Build the review rows for a completed comparison run.
+  ///
+  /// `existingWords` is needed only to name collision owners; no reference to
+  /// it is retained past this call.
+  static func rows(
+    from comparisons: [CustomWordsImportComparison],
+    existingWords: [CustomWord]
+  ) -> [CustomWordsImportReviewRow] {
+    var namesByID: [UUID: String] = [:]
+    for word in existingWords { namesByID[word.id] = word.canonical }
+
+    return comparisons.map { comparison in
+      CustomWordsImportReviewRow(
+        comparison: comparison,
+        matchSummary: matchSummary(for: comparison.classification),
+        collisionNote: collisionNote(
+          for: comparison.collidingAliases, namesByID: namesByID),
+        decision: defaultDecision(for: comparison.classification)
+      )
+    }
+  }
+
+  private static func matchSummary(
+    for classification: CustomWordsImportClassification
+  ) -> String? {
+    switch classification {
+    case .new:
+      return nil
+    case .exact(let existing):
+      return "You already have \(existing.canonical)."
+    case .variant(let existing, _):
+      return "You already have this, as another spelling of \(existing.canonical)."
+    case .fuzzy(let existing, _):
+      return "This looks like \(existing.canonical), which you already have."
+    case .ambiguous:
+      return "This matches more than one word you already have."
+    }
+  }
+
+  private static func collisionNote(
+    for collisions: [CustomWordsImportAliasCollision],
+    namesByID: [UUID: String]
+  ) -> String? {
+    guard !collisions.isEmpty else { return nil }
+    // Name the owner when we can. A collision can be held by another incoming
+    // candidate rather than an existing word, in which case there is no name
+    // to look up and the honest line just states the outcome.
+    if collisions.count == 1, let owner = namesByID[collisions[0].heldBy] {
+      return "The spelling \"\(collisions[0].alias)\" won't be added, "
+        + "because \(owner) already uses it."
+    }
+    let count = collisions.count
+    let noun = count == 1 ? "spelling" : "spellings"
+    return "\(count) alternate \(noun) won't be added, because other words already use them."
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -73,6 +73,10 @@ struct CustomWordsImportSheet: View {
     }
     .padding(24)
     .frame(width: 480)
+    // The footer's Cancel is not the only way out: closing the settings window
+    // or clearing the sheet route dismisses without it, and an in-flight load
+    // or comparison would otherwise keep running against a sheet that is gone.
+    .onDisappear { model.cancel() }
   }
 
   private var header: some View {

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -1,24 +1,30 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
 import SwiftUI
 
-/// The Custom Words import sheet shell (#1657, epic #1619 PR-F1).
+/// The Custom Words import sheet (#1657 PR-F1 shell, #1669 PR-F2c review).
 ///
 /// One observable model, one root `switch`, one container-level `.animation()`
 /// — the `OnboardingV2View` root-switch pattern without its timers or
-/// permissions logic. Every screen below the method picker is a fixture
-/// placeholder until the real pieces land (F2c wires review/commit; P1/U1/4a
-/// bring real inputs); the sheet is reachable only through the DEBUG-only
-/// "Preview import" button in Your Words, so no release user can see these
-/// placeholders. Deliberately zero `Task`, adapters, compare logic, manager
-/// calls, telemetry, or persistence — dismissing at any point discards the
-/// model and touches nothing.
+/// permissions logic. The three input screens are still placeholders until
+/// their real sources land (P1 paste, U1 upload, 4a smart import); Review and
+/// the commit path are real from F2c on.
+///
+/// The sheet is reachable only through the DEBUG-only "Preview import" button
+/// in Your Words, so no release user can see the remaining placeholders.
+/// Dismissing at any point cancels in-flight work and writes nothing.
 struct CustomWordsImportSheet: View {
   private static let screenTransition: AnyTransition = .asymmetric(
     insertion: .opacity.combined(with: .offset(y: 20)),
     removal: .opacity
   )
 
-  @State private var model = CustomWordsImportFlowModel()
+  @State private var model: CustomWordsImportFlowModel
   @Environment(\.dismiss) private var dismiss
+
+  init(dependencies: CustomWordsImportFlowModel.Dependencies) {
+    _model = State(initialValue: CustomWordsImportFlowModel(dependencies: dependencies))
+  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
@@ -48,14 +54,17 @@ struct CustomWordsImportSheet: View {
           )
           .transition(Self.screenTransition)
         case .review:
-          ImportReviewPlaceholderScreen(model: model)
+          ImportReviewScreen(model: model)
             .transition(Self.screenTransition)
         case .working(let work):
-          ImportWorkingScreen(work: work, model: model)
+          ImportWorkingScreen(work: work)
             .transition(Self.screenTransition)
         case .result(let result):
-          ImportResultScreen(result: result)
-            .transition(Self.screenTransition)
+          ImportResultScreen(
+            result: result,
+            droppedAliasCollisionCount: model.droppedAliasCollisionCount
+          )
+          .transition(Self.screenTransition)
         }
       }
       .animation(.easeInOut(duration: 0.25), value: model.step)
@@ -82,14 +91,37 @@ struct CustomWordsImportSheet: View {
   private var footer: some View {
     HStack {
       Spacer()
-      if case .result = model.step {
+      switch model.step {
+      case .result:
         Button("Done") { dismiss() }
           .keyboardShortcut(.defaultAction)
           .buttonStyle(.borderedProminent)
-      } else {
-        Button("Cancel") { dismiss() }
-          .keyboardShortcut(.cancelAction)
+      case .review:
+        Button("Cancel") {
+          model.cancel()
+          dismiss()
+        }
+        .keyboardShortcut(.cancelAction)
+        Button(confirmTitle) { model.confirm() }
+          .keyboardShortcut(.defaultAction)
+          .buttonStyle(.borderedProminent)
+      case .methodPicker, .paste, .upload, .smartImportAppPicker, .working:
+        Button("Cancel") {
+          model.cancel()
+          dismiss()
+        }
+        .keyboardShortcut(.cancelAction)
       }
+    }
+  }
+
+  /// Names the actual consequence, so Confirm is never a mystery button.
+  private var confirmTitle: String {
+    let count = model.approvedRows.count
+    switch count {
+    case 0: return "Add nothing"
+    case 1: return "Add 1 word"
+    default: return "Add \(count) words"
     }
   }
 
@@ -105,6 +137,7 @@ struct CustomWordsImportSheet: View {
     case .working(.committing): return "Saving"
     case .result(.completed): return "Import complete"
     case .result(.nothingFound): return "Nothing to import"
+    case .result(.nothingApproved): return "Nothing added"
     case .result(.failed): return "Import didn't finish"
     }
   }
@@ -183,10 +216,104 @@ private struct ImportMethodCard: View {
   }
 }
 
-// MARK: - Fixture placeholders (replaced wholesale by later PRs)
+// MARK: - Review & Merge (PR-F2c)
 
-/// Shared placeholder for the three input screens. The "Preview" button walks
-/// the fixture flow the way the real source will: input → working → review.
+private struct ImportReviewScreen: View {
+  let model: CustomWordsImportFlowModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      if let staleNotice = model.staleNotice {
+        InsetNotice(text: staleNotice)
+      }
+
+      Text(summary)
+        .settingsReadingCopy()
+
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 8) {
+          ForEach(model.rows) { row in
+            ImportReviewRowView(row: row) { decision in
+              model.setDecision(decision, forRow: row.id)
+            }
+          }
+        }
+      }
+      .frame(maxHeight: 280)
+    }
+  }
+
+  private var summary: String {
+    let addable = model.rows.filter(\.isAddable).count
+    let existing = model.rows.count - addable
+    switch (addable, existing) {
+    case (0, 0):
+      return "Nothing to review."
+    case (let new, 0):
+      return "\(new) new \(new == 1 ? "word" : "words") found."
+    case (0, let have):
+      return "You already have all \(have) of these."
+    case (let new, let have):
+      return "\(new) new \(new == 1 ? "word" : "words") found. "
+        + "\(have) you already have."
+    }
+  }
+}
+
+private struct ImportReviewRowView: View {
+  let row: CustomWordsImportReviewRow
+  let setDecision: (CustomWordsImportDecision) -> Void
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 11) {
+      VStack(alignment: .leading, spacing: 3) {
+        Text(row.canonical)
+          .font(.stRowLabel)
+          .foregroundStyle(.stTextPrimary)
+        if let matchSummary = row.matchSummary {
+          Text(matchSummary)
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+        }
+        if let collisionNote = row.collisionNote {
+          Text(collisionNote)
+            .font(.stHelper)
+            .foregroundStyle(.stWarning)
+        }
+      }
+      Spacer(minLength: 0)
+
+      if row.isAddable {
+        Toggle(
+          "Add",
+          isOn: Binding(
+            get: { row.decision == .add },
+            set: { setDecision($0 ? .add : .skip) }
+          )
+        )
+        .toggleStyle(.checkbox)
+        .accessibilityLabel("Add \(row.canonical)")
+      } else {
+        Text("Skipped")
+          .font(.stHelper)
+          .foregroundStyle(.stTextTertiary)
+      }
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 10))
+    .overlay(
+      RoundedRectangle(cornerRadius: 10).strokeBorder(Color.stDivider, lineWidth: 1)
+    )
+  }
+}
+
+// MARK: - Input placeholders (replaced wholesale by the real source PRs)
+
+/// Shared placeholder for the three input screens. In DEBUG it walks the real
+/// pipeline using a fixture source, so the whole flow is exercisable before
+/// any real source exists; in a release build there is no way to reach it.
 private struct ImportPlaceholderScreen: View {
   let notice: String
   let model: CustomWordsImportFlowModel
@@ -194,48 +321,25 @@ private struct ImportPlaceholderScreen: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       InsetNotice(text: notice)
-      Button("Preview finding words") {
-        model.beginWork(.loadingCandidates)
-      }
-    }
-  }
-}
-
-private struct ImportReviewPlaceholderScreen: View {
-  let model: CustomWordsImportFlowModel
-
-  var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      InsetNotice(text: "Review & Merge arrives with the compare engine.")
-      Button("Preview saving") {
-        model.beginWork(.committing)
-      }
+      #if DEBUG
+        Button("Preview with sample words") {
+          model.begin(with: CustomWordsImportFixtureSource())
+        }
+      #endif
     }
   }
 }
 
 private struct ImportWorkingScreen: View {
   let work: CustomWordsImportFlowModel.Work
-  let model: CustomWordsImportFlowModel
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      HStack(spacing: 10) {
-        ProgressView()
-          .controlSize(.small)
-        Text(label)
-          .settingsReadingCopy()
-      }
-
-      // Fixture-walk controls: real work drives these transitions from F2c on.
-      VStack(alignment: .leading, spacing: 8) {
-        Button("Preview review") { model.showReview() }
-        Button("Preview success") { model.showResult(.completed(added: 3, replaced: 1)) }
-        Button("Preview nothing found") { model.showResult(.nothingFound) }
-        Button("Preview failure") {
-          model.showResult(.failed(message: "We found their data, but couldn't read it this time."))
-        }
-      }
+    HStack(spacing: 10) {
+      ProgressView()
+        .controlSize(.small)
+      Text(label)
+        .settingsReadingCopy()
+      Spacer(minLength: 0)
     }
   }
 
@@ -250,23 +354,32 @@ private struct ImportWorkingScreen: View {
 
 private struct ImportResultScreen: View {
   let result: CustomWordsImportFlowModel.Result
+  let droppedAliasCollisionCount: Int
 
   var body: some View {
-    HStack(alignment: .firstTextBaseline, spacing: 8) {
-      Image(systemName: icon)
-        .font(.system(size: 14, weight: .medium))
-        .foregroundStyle(tint)
-        .accessibilityHidden(true)
-      Text(message)
-        .settingsReadingCopy()
-      Spacer(minLength: 0)
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Image(systemName: icon)
+          .font(.system(size: 14, weight: .medium))
+          .foregroundStyle(tint)
+          .accessibilityHidden(true)
+        Text(message)
+          .settingsReadingCopy()
+        Spacer(minLength: 0)
+      }
+
+      if droppedAliasCollisionCount > 0, case .completed = result {
+        Text(droppedCollisionMessage)
+          .font(.stHelper)
+          .foregroundStyle(.stTextSecondary)
+      }
     }
   }
 
   private var icon: String {
     switch result {
     case .completed: return "checkmark.circle.fill"
-    case .nothingFound: return "info.circle"
+    case .nothingFound, .nothingApproved: return "info.circle"
     case .failed: return "exclamationmark.triangle"
     }
   }
@@ -274,19 +387,39 @@ private struct ImportResultScreen: View {
   private var tint: Color {
     switch result {
     case .completed: return .stSuccess
-    case .nothingFound: return .stAccent
+    case .nothingFound, .nothingApproved: return .stAccent
     case .failed: return .stWarning
     }
   }
 
-  private var message: String {
-    switch result {
-    case .completed(let added, let replaced):
-      return "Added \(added), replaced \(replaced). Your words are ready to use."
-    case .nothingFound:
-      return "No new words were found, and nothing was changed."
-    case .failed(let message):
-      return message
-    }
+  private var message: String { CustomWordsImportResultCopy.message(for: result) }
+
+  private var droppedCollisionMessage: String {
+    CustomWordsImportResultCopy.droppedCollisionMessage(count: droppedAliasCollisionCount)
   }
 }
+
+// MARK: - DEBUG fixture source
+
+#if DEBUG
+  /// Sample words for the DEBUG preview walk, so the real load → compare →
+  /// review → commit path is exercisable before any production source ships.
+  ///
+  /// Carries main words only, matching the v1 import contract: every authority
+  /// field stays `.unspecified`, so this fixture cannot smuggle in behavior a
+  /// real v1 source would not have.
+  struct CustomWordsImportFixtureSource: CustomWordsImportSource {
+    func loadCandidates() async throws -> CustomWordsImportBatch {
+      CustomWordsImportBatch(
+        sourceID: "debug-fixture",
+        sourceDisplayName: "Sample words",
+        candidates: [
+          CustomWordsImportCandidate(canonical: "Kubernetes"),
+          CustomWordsImportCandidate(canonical: "Anthropic"),
+          CustomWordsImportCandidate(canonical: "EnviousWispr"),
+          CustomWordsImportCandidate(canonical: "Saurabh"),
+        ]
+      )
+    }
+  }
+#endif

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -87,7 +87,15 @@ struct YourWordsView: View {
           onSave: saveNewWord
         )
       case .importWords:
-        CustomWordsImportSheet()
+        // The import flow reads the live list and commits through the same
+        // coordinator every other Your Words mutation uses (#1669) — two
+        // narrow closures rather than handing the sheet the coordinator.
+        CustomWordsImportSheet(
+          dependencies: .live(
+            existingWords: { customWordsCoordinator.customWords },
+            commit: { customWordsCoordinator.commitImport($0) }
+          )
+        )
       }
     }
   }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
@@ -459,9 +459,9 @@ package actor CustomWordsImportCompareEngine {
   /// key. Using the stronger matching key here would flag pairs that never
   /// actually collide at runtime.
   ///
-  /// `heldBy` must name the word that ACTUALLY holds the trigger, because it
-  /// drives both the inline note ("X already uses it") and F2c's suppression
-  /// check. So ownership mirrors `WordCorrector.buildLookups`
+  /// `heldBy` must name the word that ACTUALLY holds the trigger, because the
+  /// Review screen names that owner in its inline note ("X already uses it").
+  /// So ownership mirrors `WordCorrector.buildLookups`
   /// (WordCorrector.swift:176-215) rather than any convention of this file's
   /// own — two rounds of review found invented conventions disagreeing with
   /// runtime, in opposite directions:

--- a/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
@@ -10,6 +10,19 @@ import Testing
 struct CustomWordsImportFlowModelTests {
   typealias Model = CustomWordsImportFlowModel
 
+  /// Navigation-only tests need no real collaborators, but the model requires
+  /// them, so this double fails loudly rather than pretending to work: any
+  /// navigation test that reaches the commit path is a test bug, not a pass.
+  static func makeModel() -> Model {
+    Model(
+      dependencies: .init(
+        existingWords: { [] },
+        commit: { _ in .failed(message: "navigation-only test double") },
+        compare: { _, _, _ in [] }
+      )
+    )
+  }
+
   // Literal fixture arrays: `arguments:` collections are evaluated outside
   // actor isolation, so they must not touch MainActor-isolated statics
   // (swift-testing-patterns.md, mainactor-arguments rule).
@@ -24,7 +37,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("initial step is the method picker with nothing selected")
   func initialStepIsMethodPicker() {
-    let model = Model()
+    let model = Self.makeModel()
     #expect(model.step == .methodPicker)
     #expect(model.selectedMethod == nil)
     #expect(model.canGoBack == false)
@@ -32,7 +45,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("select moves to the method's input screen and records the method", arguments: methodCases)
   func selectMovesToInputAndRecordsMethod(method: Model.Method, inputStep: Model.Step) {
-    let model = Model()
+    let model = Self.makeModel()
     model.select(method)
     #expect(model.step == inputStep)
     #expect(model.selectedMethod == method)
@@ -41,7 +54,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("select away from the picker is ignored")
   func selectAwayFromPickerIsIgnored() {
-    let model = Model()
+    let model = Self.makeModel()
     model.select(.paste)
     model.select(.upload)
     #expect(model.step == .paste)
@@ -50,7 +63,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("back from an input screen returns to the method picker", arguments: methodCases)
   func backFromInputReturnsToMethodPicker(method: Model.Method, inputStep: Model.Step) {
-    let model = Model()
+    let model = Self.makeModel()
     model.select(method)
     #expect(model.step == inputStep)
     model.goBack()
@@ -60,7 +73,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("back from review returns to the selected method's input screen", arguments: methodCases)
   func backFromReviewReturnsToSelectedInput(method: Model.Method, inputStep: Model.Step) {
-    let model = Model()
+    let model = Self.makeModel()
     model.select(method)
     model.showReview()
     #expect(model.step == .review)
@@ -72,7 +85,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("back while working is ignored", arguments: workCases)
   func backWhileWorkingIsIgnored(work: Model.Work) {
-    let model = Model()
+    let model = Self.makeModel()
     model.select(.paste)
     model.beginWork(work)
     #expect(model.canGoBack == false)
@@ -83,7 +96,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("back on a result is ignored: Done dismisses, there is no Back")
   func backOnResultIsIgnored() {
-    let model = Model()
+    let model = Self.makeModel()
     model.select(.paste)
     model.beginWork(.committing)
     model.showResult(.nothingFound)
@@ -94,7 +107,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("reset clears the selected method and returns to the picker")
   func resetClearsSelectedMethodAndReturnsToPicker() {
-    let model = Model()
+    let model = Self.makeModel()
     model.select(.upload)
     model.showReview()
     model.reset()
@@ -104,14 +117,14 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("show review before any method is selected is ignored")
   func showReviewWithoutMethodIsIgnored() {
-    let model = Model()
+    let model = Self.makeModel()
     model.showReview()
     #expect(model.step == .methodPicker)
   }
 
   @Test("begin work is ignored on the picker and on a result")
   func beginWorkIgnoredOnPickerAndResult() {
-    let model = Model()
+    let model = Self.makeModel()
     model.beginWork(.loadingCandidates)
     #expect(model.step == .methodPicker)
 
@@ -124,7 +137,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("show result outside a working step is ignored")
   func showResultOutsideWorkingIsIgnored() {
-    let model = Model()
+    let model = Self.makeModel()
     model.select(.paste)
     model.showResult(.nothingFound)
     #expect(model.step == .paste)
@@ -132,7 +145,7 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("a completed result carries the added and replaced counts")
   func resultCarriesAddedAndReplacedCounts() {
-    let model = Model()
+    let model = Self.makeModel()
     model.select(.paste)
     model.beginWork(.committing)
     model.showResult(.completed(added: 3, replaced: 1))
@@ -142,12 +155,12 @@ struct CustomWordsImportFlowModelTests {
 
   @Test("nothing-found and failure remain distinct results")
   func nothingFoundAndFailureRemainDistinctResults() {
-    let nothingFound = Model()
+    let nothingFound = Self.makeModel()
     nothingFound.select(.paste)
     nothingFound.beginWork(.loadingCandidates)
     nothingFound.showResult(.nothingFound)
 
-    let failed = Model()
+    let failed = Self.makeModel()
     failed.select(.paste)
     failed.beginWork(.loadingCandidates)
     failed.showResult(.failed(message: "could not read the file"))

--- a/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
@@ -22,9 +22,16 @@ struct CustomWordsImportReviewFlowTests {
   // MARK: - Fakes
 
   /// Records what the flow asked for and returns what the test scripted.
-  final class CompareSpy: @unchecked Sendable {
-    // Single-touch handoff: the test writes before the flow runs, the flow
-    // writes once during the run, and the test reads after it completes.
+  ///
+  /// `@MainActor`-isolated rather than `@unchecked Sendable` (code review r3).
+  /// The compare dependency is a nonisolated `@Sendable async` closure, so it
+  /// runs on the generic executor while `settle` reads this spy on the
+  /// MainActor — an unsynchronized cross-executor race that `@unchecked` would
+  /// only have hidden from the compiler. The closure hops to the MainActor for
+  /// every touch instead, which is also what this project's
+  /// no-new-unchecked-sendable rule requires.
+  @MainActor
+  final class CompareSpy {
     var policies: [CustomWordsImportFuzzyPolicy] = []
     var existingSeen: [[CustomWord]] = []
     var results: [[CustomWordsImportComparison]] = []
@@ -52,7 +59,10 @@ struct CustomWordsImportReviewFlowTests {
     }
   }
 
-  final class CommitSpy: @unchecked Sendable {
+  /// `@MainActor`-isolated: the commit dependency is already a `@MainActor`
+  /// closure, so no hop is needed and no unchecked conformance is warranted.
+  @MainActor
+  final class CommitSpy {
     var plans: [CustomWordsImportCommitPlan] = []
     var outcomes: [CustomWordsCoordinator.CustomWordsImportCommitOutcome] = []
     var callCount = 0
@@ -97,15 +107,23 @@ struct CustomWordsImportReviewFlowTests {
         existingWords: { existing },
         commit: { commit.record($0) },
         compare: { _, seen, policy in
-          compare.policies.append(policy)
-          compare.existingSeen.append(seen)
-          if let stream = compare.gateStream {
+          // Every spy touch hops to the MainActor; the gate wait deliberately
+          // happens outside it so the test can hold the call mid-flight
+          // without blocking the actor it needs to make assertions on.
+          let stream = await MainActor.run { () -> AsyncStream<Void>? in
+            compare.policies.append(policy)
+            compare.existingSeen.append(seen)
+            return compare.gateStream
+          }
+          if let stream {
             var iterator = stream.makeAsyncIterator()
             _ = await iterator.next()
           }
-          let result = compare.nextResult()
-          compare.completedCalls += 1
-          return result
+          return await MainActor.run { () -> [CustomWordsImportComparison] in
+            let result = compare.nextResult()
+            compare.completedCalls += 1
+            return result
+          }
         }
       )
     )

--- a/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
@@ -1,0 +1,422 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Review & Merge workflow tests (#1669, epic #1619 PR-F2c).
+///
+/// The v1 contract under test: only a genuinely new word can be added, every
+/// match classification is Skip-only, the compare engine is always called with
+/// fuzzy matching disabled, and a confirmed plan contains additions only.
+///
+/// All asynchrony is driven by explicit signals — a gate the test opens and a
+/// spy the test reads — never by wall-clock sleeps.
+@MainActor
+@Suite("CustomWordsImportReviewFlow")
+struct CustomWordsImportReviewFlowTests {
+  typealias Model = CustomWordsImportFlowModel
+  typealias Row = CustomWordsImportReviewRow
+
+  // MARK: - Fakes
+
+  /// Records what the flow asked for and returns what the test scripted.
+  final class CompareSpy: @unchecked Sendable {
+    // Single-touch handoff: the test writes before the flow runs, the flow
+    // writes once during the run, and the test reads after it completes.
+    var policies: [CustomWordsImportFuzzyPolicy] = []
+    var existingSeen: [[CustomWord]] = []
+    var results: [[CustomWordsImportComparison]] = []
+    var callCount = 0
+    /// Incremented after the gated call resumes and returns its result, so a
+    /// cancellation test can prove the late completion really happened rather
+    /// than passing because the work never ran at all.
+    var completedCalls = 0
+    /// When set, the compare call suspends until the test opens this gate.
+    var gate: AsyncStream<Void>.Continuation?
+    var gateStream: AsyncStream<Void>?
+
+    func nextResult() -> [CustomWordsImportComparison] {
+      defer { callCount += 1 }
+      guard callCount < results.count else { return results.last ?? [] }
+      return results[callCount]
+    }
+  }
+
+  struct StubSource: CustomWordsImportSource {
+    let candidates: [CustomWordsImportCandidate]
+    func loadCandidates() async throws -> CustomWordsImportBatch {
+      CustomWordsImportBatch(
+        sourceID: "test", sourceDisplayName: "Test", candidates: candidates)
+    }
+  }
+
+  final class CommitSpy: @unchecked Sendable {
+    var plans: [CustomWordsImportCommitPlan] = []
+    var outcomes: [CustomWordsCoordinator.CustomWordsImportCommitOutcome] = []
+    var callCount = 0
+
+    func record(_ plan: CustomWordsImportCommitPlan)
+      -> CustomWordsCoordinator.CustomWordsImportCommitOutcome
+    {
+      plans.append(plan)
+      defer { callCount += 1 }
+      guard callCount < outcomes.count else {
+        return outcomes.last ?? .failed(message: "unscripted commit")
+      }
+      return outcomes[callCount]
+    }
+  }
+
+  // MARK: - Builders
+
+  static func candidate(_ canonical: String) -> CustomWordsImportCandidate {
+    CustomWordsImportCandidate(canonical: canonical)
+  }
+
+  static func comparison(
+    _ canonical: String,
+    _ classification: CustomWordsImportClassification,
+    collisions: [CustomWordsImportAliasCollision] = []
+  ) -> CustomWordsImportComparison {
+    CustomWordsImportComparison(
+      candidate: candidate(canonical),
+      classification: classification,
+      collidingAliases: collisions
+    )
+  }
+
+  static func makeModel(
+    existing: [CustomWord] = [],
+    compare: CompareSpy,
+    commit: CommitSpy
+  ) -> Model {
+    Model(
+      dependencies: .init(
+        existingWords: { existing },
+        commit: { commit.record($0) },
+        compare: { _, seen, policy in
+          compare.policies.append(policy)
+          compare.existingSeen.append(seen)
+          if let stream = compare.gateStream {
+            var iterator = stream.makeAsyncIterator()
+            _ = await iterator.next()
+          }
+          let result = compare.nextResult()
+          compare.completedCalls += 1
+          return result
+        }
+      )
+    )
+  }
+
+  /// Drive a source to the review screen. Returns once the flow settles.
+  static func runToReview(
+    _ model: Model, candidates: [CustomWordsImportCandidate]
+  ) async {
+    model.select(.paste)
+    model.begin(with: StubSource(candidates: candidates))
+    await Self.settle(model) { $0.step == .review || $0.step.isResult }
+  }
+
+  /// Signal-based settle: yield until the model reaches the state the caller
+  /// is waiting for. No clock is involved, so a slow CI host cannot flake it.
+  static func settle(_ model: Model, until condition: (Model) -> Bool) async {
+    for _ in 0..<1000 {
+      if condition(model) { return }
+      await Task.yield()
+    }
+  }
+
+  // MARK: - Decision gating
+
+  @Test("a new word offers Add and Skip, and defaults to Add")
+  func newClassificationOffersAddAndSkipAndDefaultsToAdd() {
+    #expect(Row.allowedDecisions(for: .new) == [.add, .skip])
+    #expect(Row.defaultDecision(for: .new) == .add)
+  }
+
+  @Test("an exact match is Skip-only and defaults to Skip")
+  func exactClassificationOffersOnlySkip() {
+    let existing = CustomWord(canonical: "GitHub")
+    #expect(Row.allowedDecisions(for: .exact(existing: existing)) == [.skip])
+    #expect(Row.defaultDecision(for: .exact(existing: existing)) == .skip)
+  }
+
+  @Test("a variant match is Skip-only and defaults to Skip")
+  func variantClassificationOffersOnlySkip() {
+    let existing = CustomWord(canonical: "GitHub", aliases: ["github"])
+    let classification = CustomWordsImportClassification.variant(
+      existing: existing, matchedAlias: "github")
+    #expect(Row.allowedDecisions(for: classification) == [.skip])
+    #expect(Row.defaultDecision(for: classification) == .skip)
+  }
+
+  @Test("an ambiguous match is Skip-only and defaults to Skip")
+  func ambiguousClassificationOffersOnlySkip() {
+    let classification = CustomWordsImportClassification.ambiguous(matches: [
+      CustomWordsImportAmbiguousMatch(existing: CustomWord(canonical: "Anand"), kind: .exact),
+      CustomWordsImportAmbiguousMatch(existing: CustomWord(canonical: "Ananda"), kind: .exact),
+    ])
+    #expect(Row.allowedDecisions(for: classification) == [.skip])
+    #expect(Row.defaultDecision(for: classification) == .skip)
+  }
+
+  @Test("a fuzzy match is handled as Skip-only even though v1 never produces one")
+  func fuzzyClassificationOffersOnlySkipEvenThoughV1NeverProducesIt() {
+    // Exhaustiveness freeze: v1 disables fuzzy matching, but the row type must
+    // still handle the case rather than trap, so a future caller that arms the
+    // policy cannot produce an unhandled row.
+    let classification = CustomWordsImportClassification.fuzzy(
+      existing: CustomWord(canonical: "Anand"), distance: 1)
+    #expect(Row.allowedDecisions(for: classification) == [.skip])
+    #expect(Row.defaultDecision(for: classification) == .skip)
+  }
+
+  @Test("a decision persistence would refuse is never accepted onto a row")
+  func setDecisionRejectsADisallowedDecision() async {
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    compare.results = [
+      [Self.comparison("GitHub", .exact(existing: CustomWord(canonical: "GitHub")))]
+    ]
+    let model = Self.makeModel(compare: compare, commit: commit)
+    await Self.runToReview(model, candidates: [Self.candidate("GitHub")])
+
+    let rowID = try! #require(model.rows.first).id
+    model.setDecision(.add, forRow: rowID)
+
+    #expect(model.rows[0].decision == .skip)
+    #expect(model.approvedRows.isEmpty)
+  }
+
+  // MARK: - Fuzzy is off
+
+  @Test("the flow always compares with the fuzzy policy disabled")
+  func flowPassesDisabledFuzzyPolicyToTheCompareEngine() async {
+    // Founder decision 2026-07-18, frozen here against silent re-arming: with
+    // Replace gone a similarity match can only withhold Add, so a false
+    // positive would refuse a legitimately different word with no recourse.
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    compare.results = [[Self.comparison("Ananda", .new)]]
+    let model = Self.makeModel(
+      existing: [CustomWord(canonical: "Anand")], compare: compare, commit: commit)
+
+    await Self.runToReview(model, candidates: [Self.candidate("Ananda")])
+
+    #expect(compare.policies == [.disabled])
+  }
+
+  // MARK: - Commit shape
+
+  @Test("confirm builds an additions-only plan with no replacements")
+  func confirmBuildsAdditionsOnlyPlanWithNoReplacements() async {
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    let existingWord = CustomWord(canonical: "GitHub")
+    compare.results = [
+      [
+        Self.comparison("Kubernetes", .new),
+        Self.comparison("GitHub", .exact(existing: existingWord)),
+      ]
+    ]
+    commit.outcomes = [
+      .committed(
+        CustomWordsImportCommitReceipt(
+          addedIDs: [UUID()], replacedIDs: [], droppedAliasCollisions: []))
+    ]
+    let model = Self.makeModel(existing: [existingWord], compare: compare, commit: commit)
+    await Self.runToReview(
+      model, candidates: [Self.candidate("Kubernetes"), Self.candidate("GitHub")])
+
+    model.confirm()
+
+    let plan = try! #require(commit.plans.first)
+    #expect(plan.replacements.isEmpty)
+    #expect(plan.additions.map(\.canonical) == ["Kubernetes"])
+    #expect(model.step == .result(.completed(added: 1, replaced: 0)))
+  }
+
+  @Test("confirm with everything skipped writes nothing")
+  func confirmWithAllSkippedWritesNothing() async {
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    compare.results = [
+      [Self.comparison("GitHub", .exact(existing: CustomWord(canonical: "GitHub")))]
+    ]
+    let model = Self.makeModel(compare: compare, commit: commit)
+    await Self.runToReview(model, candidates: [Self.candidate("GitHub")])
+
+    model.confirm()
+
+    #expect(commit.plans.isEmpty)
+    #expect(model.step == .result(.nothingApproved))
+  }
+
+  @Test("a second confirm while committing is ignored")
+  func secondConfirmWhileCommittingIsIgnored() async {
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    compare.results = [[Self.comparison("Kubernetes", .new)]]
+    commit.outcomes = [
+      .committed(
+        CustomWordsImportCommitReceipt(
+          addedIDs: [UUID()], replacedIDs: [], droppedAliasCollisions: []))
+    ]
+    let model = Self.makeModel(compare: compare, commit: commit)
+    await Self.runToReview(model, candidates: [Self.candidate("Kubernetes")])
+
+    model.confirm()
+    model.confirm()
+
+    #expect(commit.plans.count == 1)
+  }
+
+  // MARK: - Staleness
+
+  @Test("a stale commit re-compares against the current list and resets decisions")
+  func staleCommitRecomparesAndResetsDecisions() async {
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    let nowExisting = CustomWord(canonical: "Kubernetes")
+    // First run: the word is new. After the stale rejection the library has
+    // gained it, so the rebuild must classify it as an existing match.
+    compare.results = [
+      [Self.comparison("Kubernetes", .new)],
+      [Self.comparison("Kubernetes", .exact(existing: nowExisting))],
+    ]
+    commit.outcomes = [.stale]
+    let model = Self.makeModel(
+      existing: [nowExisting], compare: compare, commit: commit)
+    await Self.runToReview(model, candidates: [Self.candidate("Kubernetes")])
+    #expect(model.rows[0].decision == .add)
+
+    model.confirm()
+    await Self.settle(model) { $0.step == .review }
+
+    #expect(model.rows.count == 1)
+    #expect(model.rows[0].decision == .skip, "the rebuilt row must not inherit the old Add")
+    #expect(model.approvedRows.isEmpty)
+    #expect(model.staleNotice != nil)
+    #expect(compare.callCount == 2)
+  }
+
+  // MARK: - Cancellation
+
+  @Test("dismissing during comparison discards the late completion")
+  func dismissDuringComparisonIgnoresLateCompletion() async {
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    let (stream, continuation) = AsyncStream<Void>.makeStream()
+    compare.gateStream = stream
+    compare.gate = continuation
+    compare.results = [[Self.comparison("Kubernetes", .new)]]
+    let model = Self.makeModel(compare: compare, commit: commit)
+
+    model.select(.paste)
+    model.begin(with: StubSource(candidates: [Self.candidate("Kubernetes")]))
+    // Wait for the flow to actually reach the gated compare call, so the
+    // cancellation lands mid-flight rather than before the work started.
+    await Self.settle(model) { _ in compare.policies.isEmpty == false }
+
+    model.cancel()
+    continuation.yield()
+    continuation.finish()
+    // Wait for the gated call to actually finish. Without this the assertions
+    // below could pass because the work never ran, which is indistinguishable
+    // from working cancellation and would make this test worthless.
+    await Self.settle(model) { _ in compare.completedCalls == 1 }
+    // Then give the completed task every chance to publish; it must not.
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(compare.completedCalls == 1, "the late completion must really have happened")
+    #expect(model.rows.isEmpty, "a cancelled run must never publish review rows")
+    #expect(model.step != .review)
+  }
+
+  // MARK: - Disclosure
+
+  @Test("a row whose aliases collide shows the note naming the owner")
+  func rowWithCollidingAliasesShowsNote() {
+    let owner = CustomWord(canonical: "Anika", aliases: ["annie"])
+    let rows = Row.rows(
+      from: [
+        Self.comparison(
+          "Zed", .new,
+          collisions: [CustomWordsImportAliasCollision(alias: "Annie", heldBy: owner.id)])
+      ],
+      existingWords: [owner]
+    )
+
+    let note = try! #require(rows[0].collisionNote)
+    #expect(note.contains("Annie"))
+    #expect(note.contains("Anika"))
+    // Informational only: it must not change what the user may do.
+    #expect(rows[0].allowedDecisions == [.add, .skip])
+    #expect(rows[0].decision == .add)
+  }
+
+  @Test("a row with no collision has no note")
+  func rowWithoutCollisionHasNoNote() {
+    let rows = Row.rows(from: [Self.comparison("Zed", .new)], existingWords: [])
+    #expect(rows[0].collisionNote == nil)
+  }
+
+  @Test("the result screen surfaces the dropped-collision count")
+  func resultScreenSurfacesDroppedAliasCollisionCount() async {
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    compare.results = [[Self.comparison("Kubernetes", .new)]]
+    commit.outcomes = [
+      .committed(
+        CustomWordsImportCommitReceipt(
+          addedIDs: [UUID()],
+          replacedIDs: [],
+          droppedAliasCollisions: [
+            CustomWordsImportAliasCollision(alias: "k8s", heldBy: UUID())
+          ]))
+    ]
+    let model = Self.makeModel(compare: compare, commit: commit)
+    await Self.runToReview(model, candidates: [Self.candidate("Kubernetes")])
+
+    model.confirm()
+
+    #expect(model.droppedAliasCollisionCount == 1)
+    #expect(
+      CustomWordsImportResultCopy.droppedCollisionMessage(count: 1).contains("1 alternate"))
+  }
+
+  @Test("the result copy omits the replaced count when nothing was replaced")
+  func resultScreenOmitsReplacedCountWhenZero() {
+    let v1 = CustomWordsImportResultCopy.message(for: .completed(added: 3, replaced: 0))
+    #expect(v1 == "Added 3 words. Your words are ready to use.")
+    #expect(!v1.contains("Replaced"))
+
+    // A later flow (backup restore) can replace, and then it is reported.
+    let later = CustomWordsImportResultCopy.message(for: .completed(added: 1, replaced: 2))
+    #expect(later.contains("Replaced 2"))
+  }
+
+  @Test("finding no candidates and approving none are different outcomes")
+  func nothingFoundAndNothingApprovedAreDistinct() async {
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    let model = Self.makeModel(compare: compare, commit: commit)
+
+    model.select(.paste)
+    model.begin(with: StubSource(candidates: []))
+    await Self.settle(model) { $0.step.isResult }
+
+    #expect(model.step == .result(.nothingFound))
+    #expect(compare.callCount == 0, "an empty batch must not reach the compare engine")
+  }
+}
+
+extension CustomWordsImportFlowModel.Step {
+  fileprivate var isResult: Bool {
+    if case .result = self { return true }
+    return false
+  }
+}

--- a/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
@@ -353,6 +353,10 @@ struct CustomWordsImportReviewFlowTests {
     let note = try! #require(rows[0].collisionNote)
     #expect(note.contains("Annie"))
     #expect(note.contains("Anika"))
+    // Conditional by design: whether the alias actually lands depends on which
+    // rows are approved, and the commit receipt reports what was really
+    // dropped. Asserting the wording freezes that honesty (code review r1).
+    #expect(note.contains("may not be added"))
     // Informational only: it must not change what the user may do.
     #expect(rows[0].allowedDecisions == [.add, .skip])
     #expect(rows[0].decision == .add)

--- a/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
@@ -117,16 +117,33 @@ struct CustomWordsImportReviewFlowTests {
   ) async {
     model.select(.paste)
     model.begin(with: StubSource(candidates: candidates))
-    await Self.settle(model) { $0.step == .review || $0.step.isResult }
+    await Self.settle(model, waitingFor: "the review or result screen") {
+      $0.step == .review || $0.step.isResult
+    }
   }
 
   /// Signal-based settle: yield until the model reaches the state the caller
   /// is waiting for. No clock is involved, so a slow CI host cannot flake it.
-  static func settle(_ model: Model, until condition: (Model) -> Bool) async {
+  ///
+  /// Giving up is a FAILURE, never a quiet return (code review r2). A helper
+  /// that times out silently turns "the flow never got there" into a pass —
+  /// the cancellation test in particular would then cancel before the compare
+  /// call started and still go green without ever exercising mid-flight
+  /// cancellation.
+  static func settle(
+    _ model: Model,
+    waitingFor label: String,
+    until condition: (Model) -> Bool,
+    sourceLocation: SourceLocation = #_sourceLocation
+  ) async {
     for _ in 0..<1000 {
       if condition(model) { return }
       await Task.yield()
     }
+    Issue.record(
+      "Timed out waiting for \(label); the model never reached that state.",
+      sourceLocation: sourceLocation
+    )
   }
 
   // MARK: - Decision gating
@@ -294,7 +311,7 @@ struct CustomWordsImportReviewFlowTests {
     #expect(model.rows[0].decision == .add)
 
     model.confirm()
-    await Self.settle(model) { $0.step == .review }
+    await Self.settle(model, waitingFor: "the rebuilt review screen") { $0.step == .review }
 
     #expect(model.rows.count == 1)
     #expect(model.rows[0].decision == .skip, "the rebuilt row must not inherit the old Add")
@@ -319,7 +336,9 @@ struct CustomWordsImportReviewFlowTests {
     model.begin(with: StubSource(candidates: [Self.candidate("Kubernetes")]))
     // Wait for the flow to actually reach the gated compare call, so the
     // cancellation lands mid-flight rather than before the work started.
-    await Self.settle(model) { _ in compare.policies.isEmpty == false }
+    await Self.settle(model, waitingFor: "the compare call to start") { _ in
+      compare.policies.isEmpty == false
+    }
 
     model.cancel()
     continuation.yield()
@@ -327,7 +346,9 @@ struct CustomWordsImportReviewFlowTests {
     // Wait for the gated call to actually finish. Without this the assertions
     // below could pass because the work never ran, which is indistinguishable
     // from working cancellation and would make this test worthless.
-    await Self.settle(model) { _ in compare.completedCalls == 1 }
+    await Self.settle(model, waitingFor: "the gated compare call to finish") { _ in
+      compare.completedCalls == 1
+    }
     // Then give the completed task every chance to publish; it must not.
     for _ in 0..<50 { await Task.yield() }
 
@@ -411,7 +432,7 @@ struct CustomWordsImportReviewFlowTests {
 
     model.select(.paste)
     model.begin(with: StubSource(candidates: []))
-    await Self.settle(model) { $0.step.isResult }
+    await Self.settle(model, waitingFor: "a terminal result") { $0.step.isResult }
 
     #expect(model.step == .result(.nothingFound))
     #expect(compare.callCount == 0, "an empty batch must not reach the compare engine")

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
@@ -429,8 +429,8 @@ struct CustomWordsImportCompareEngineTests {
     // `WordCorrector.buildLookups` assigns the alias map unconditionally
     // (WordCorrector.swift:180-214), so the LATER word claims the trigger at
     // runtime — its own collision log says "using <later canonical>". The
-    // reported owner has to match that, or F2c's Replace-target suppression
-    // compares against a word that is not really holding the alias.
+    // reported owner has to match that, or the Review screen names a word
+    // that is not really holding the alias.
     let earlier = CustomWord(canonical: "Anika", aliases: ["annie"])
     let later = CustomWord(canonical: "Annabelle", aliases: ["annie"])
     let results = try await compare(
@@ -478,18 +478,17 @@ struct CustomWordsImportCompareEngineTests {
     #expect(results[0].collidingAliases.isEmpty)
   }
 
-  @Test("an alias owned by the candidate's own exact match IS still flagged here, by design")
-  func aliasOwnedByTheCandidatesOwnExactMatchIsFlaggedForF2cToSuppress() async throws {
+  @Test("an alias owned by the candidate's own exact match remains disclosed")
+  func aliasOwnedByTheCandidatesOwnExactMatchRemainsDisclosed() async throws {
     // DELIBERATE, per the adopted plan (PR-F2a §alias-collision detection):
-    // F2a is decision-agnostic — it runs before any Review decision exists,
-    // so it cannot know the user will pick Replace and make this harmless.
-    // It records the collision naming the matched word; **F2c** suppresses
-    // the inline note when the row's Decision is Replace and `heldBy` is the
-    // word being replaced, and F2b's enforcement evaluates the applied
-    // result (where the word owns its own alias and nothing is dropped).
-    // This test exists so the behavior reads as a design assignment rather
-    // than an oversight — a reviewer flagged it as a false positive, which
-    // it is at the DISPLAY layer, and the display layer is F2c's.
+    // this engine is decision-agnostic — it runs before any Review decision
+    // exists — so it records the collision naming the matched word and the
+    // Review screen owns display policy. Under the two-decision v1 scope
+    // (Add/Skip; founder 2026-07-18) every non-empty collision is displayed:
+    // the Replace-target suppression an earlier plan draft assigned to the
+    // Review screen is unreachable, because Replace is not a v1 decision.
+    // The commit step remains the persistence guarantee regardless, since it
+    // evaluates the fully-applied result.
     let existing = CustomWord(canonical: "Parvati", aliases: ["Pavarthi"])
     let results = try await compare(
       [candidate("Parvati", aliases: .supplied(["Pavarthi"]))], against: [existing])

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
@@ -445,4 +445,73 @@ struct CustomWordsCoordinatorLaunchFailureTests {
       [.posixPermissions: 0o600], ofItemAtPath: url.path)
     #expect(try Data(contentsOf: url) == bytesBefore)
   }
+
+  // MARK: - Stale import commit refreshes the in-memory list (#1679 cloud review)
+
+  @Test("a stale import commit refreshes the coordinator's list from disk")
+  func staleImportCommitRefreshesTheCoordinatorsListFromDisk() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let mgr = CustomWordsManager(fileURL: url)
+    var seeded = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Qualtrics"), to: &seeded)
+
+    let coordinator = CustomWordsCoordinator(manager: mgr)
+    let baseline = coordinator.customWords
+    #expect(baseline.contains { $0.canonical == "Qualtrics" })
+
+    // Something outside this coordinator changes the file after Review was
+    // built — another window, a restored backup, a second process.
+    let outside = CustomWordsManager(fileURL: url)
+    var outsideWords = try #require(outside.load())
+    try outside.add(word: CustomWord(canonical: "Interloper"), to: &outsideWords)
+    #expect(coordinator.customWords.contains { $0.canonical == "Interloper" } == false)
+
+    let outcome = coordinator.commitImport(
+      CustomWordsImportCommitPlan(
+        baseline: CustomWordsImportLibrarySnapshot(words: baseline),
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")],
+        replacements: []))
+
+    #expect(outcome == .stale)
+    // The whole point: the in-memory list must now match disk, so a rebuilt
+    // review compares against reality instead of looping on the same stale copy.
+    #expect(coordinator.customWords.contains { $0.canonical == "Interloper" })
+    #expect(coordinator.customWords.contains { $0.canonical == "Kubernetes" } == false)
+  }
+
+  @Test("a stale commit against an unreadable file keeps the current list")
+  func staleCommitAgainstAnUnreadableFileKeepsTheCurrentList() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let mgr = CustomWordsManager(fileURL: url)
+    var seeded = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Qualtrics"), to: &seeded)
+
+    let coordinator = CustomWordsCoordinator(manager: mgr)
+    let before = coordinator.customWords
+    #expect(before.isEmpty == false)
+
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: url.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    let outcome = coordinator.commitImport(
+      CustomWordsImportCommitPlan(
+        baseline: CustomWordsImportLibrarySnapshot(words: []),
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")],
+        replacements: []))
+
+    // Fails closed: an unreadable file must never clobber the live list with
+    // an empty one on the way out of a failed commit.
+    #expect(
+      outcome
+        != .committed(
+          CustomWordsImportCommitReceipt(
+            addedIDs: [], replacedIDs: [], droppedAliasCollisions: [])))
+    #expect(coordinator.customWords == before)
+  }
 }


### PR DESCRIPTION
Part of #1619. Closes #1669.

## What this is

The Review & Merge screen — the piece that wires the import sheet shell (#1657) to the compare engine (#1661) and the atomic commit (#1665). First point where the import flow is walkable end to end.

## v1 scope: two decisions, not four

Per the founder scope revision on #1669 (2026-07-18):

| Situation | Offered | Default |
|---|---|---|
| Word is new | Add, Skip | Add |
| Word already exists (any match) | Skip only — "you already have this one" | Skip |

Replace and Keep Both are absent. No import source ships yet, so a v1 candidate carries only its main word; a Replace would rewrite a hand-tuned entry's spelling on the authority of nothing. Importing *with your own aliases* arrives later as an alias **merge** built on F2b's replacement machinery.

**Fuzzy matching is OFF in v1** (founder, 2026-07-18): the flow passes `.disabled`. With Replace gone, a similarity match can only withhold Add, so a false positive would silently refuse a legitimately different word with no recourse. Frozen by test against silent re-arming.

## Release safety

Compiled out of release builds. The single `#if DEBUG` doorway in Your Words remains the only entry point; this PR adds no second one. A DEBUG fixture source makes the real load → compare → review → commit path exercisable before any production source exists.

## Review record

- Grounded review on the revised plan: r1 PROCEED-WITH-REVISIONS (2 findings), r2 PROCEED-WITH-REVISIONS (1), r3 **PROCEED-AS-PLANNED, zero findings**.
- Code-diff review: r1 (2 findings), r2 (1), r3 (1), r4 **clean, no actionable issues**.

Every finding was in the verification layer, not the feature: a factually wrong justification for dropping Replace, a warning that could state something untrue, a test helper that timed out silently, and a data race in test spies masked by `@unchecked Sendable`.

## Validation

- 3,320 tests green (Debug lane).
- Live UAT on the running app against the founder's real 30-word list:
  - 4 sample words → "2 new words found. 2 you already have." Kubernetes/Anthropic addable; EnviousWispr/Saurabh Skip-only with no control.
  - Confirm → "Added 2 words. Your words are ready to use." (no "replaced 0"); disk 30 → 32.
  - Cancel → word count and file mtime unchanged.
  - Quit + relaunch + re-import → all 4 classify as existing, confirm reads "Add nothing" — proves reload from disk.
  - "Add nothing" → "You skipped everything, so nothing was changed."; file byte-identical by hash.
  - Vocabulary restored byte-identical to the pre-UAT backup afterwards.

## Follow-ups unblocked by this PR

The alias-collision note is unreachable in v1 (the engine records a collision only for `.supplied` aliases, and no v1 source supplies any). It goes live with backup restore (PR-E1/U1), which must revisit its copy against real data — documented at the call site.
