### PR TITLE
feat(user): export your words to a portable backup (PR-E1, #1680)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -12,6 +12,10 @@ final class CustomWordsCoordinator {
   /// honest banner instead of a silent empty list. `.unreadable`: the file is
   /// intact, nothing was changed. `.corrupted`: it was archived for recovery.
   private(set) var wordsLoadFailureAtLaunch: CustomWordsInitialLoadFailure?
+  /// Set when a load DURING the session found the file corrupt and archived it
+  /// aside. Separate from the launch flag because corruption does not only
+  /// happen at startup, and the archive makes the next read look clean.
+  private(set) var didDiscoverCorruptionThisSession = false
 
   let suggestionService = WordSuggestionService()
   /// The reused on-device alias generator, exposed as the narrow protocol so the
@@ -75,12 +79,38 @@ final class CustomWordsCoordinator {
   /// list untouched rather than substituting an empty one.
   @discardableResult
   func refreshFromDiskIfPossible() -> Bool {
-    guard let refreshed = manager.load() else { return false }
+    guard let refreshed = manager.load() else {
+      // Corruption found DURING the session is still corruption, and it must
+      // be remembered: the load archives the damaged file aside, so the NEXT
+      // attempt sees a legitimately missing file and reports success.
+      if manager.lastLoadFailure == .corrupted {
+        didDiscoverCorruptionThisSession = true
+      }
+      return false
+    }
     if refreshed != customWords {
       customWords = refreshed
       onWordsChanged?(customWords)
     }
     return true
+  }
+
+  /// Whether the current list is a safe thing to WRITE OUT (cloud review, #1682).
+  ///
+  /// A corrupted file is ARCHIVED aside, so a reload afterwards sees a
+  /// legitimately missing file and reports a clean, empty library. Exporting
+  /// then would write an empty file over the one the user picked while their
+  /// real words sit in the archive — destroying the copy they still had.
+  ///
+  /// Deliberately separate from `refreshFromDiskIfPossible`, which answers
+  /// "can I read the library" and must always adopt what it reads. Once the
+  /// user has authored a word since, they have visibly accepted the fresh
+  /// start and the list is theirs again.
+  var canExportCurrentWords: Bool {
+    let sawCorruption =
+      wordsLoadFailureAtLaunch == .corrupted || didDiscoverCorruptionThisSession
+    guard sawCorruption else { return true }
+    return customWords.contains { $0.source == .user }
   }
 
   /// Apply a reviewed import in one atomic write. Fires `onWordsChanged`

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -13,16 +13,6 @@ final class CustomWordsCoordinator {
   /// intact, nothing was changed. `.corrupted`: it was archived for recovery.
   private(set) var wordsLoadFailureAtLaunch: CustomWordsInitialLoadFailure?
 
-  /// Whether the saved-words file can be read RIGHT NOW (#1680).
-  ///
-  /// `wordsLoadFailureAtLaunch` is a snapshot of one moment and stays set for
-  /// the session, so it cannot answer this: a file that was temporarily
-  /// unreadable may be readable again, and a corrupted one has since been
-  /// archived and replaced by a valid empty file the user may have added to.
-  /// Export asks the live question, because refusing forever on a stale flag
-  /// is its own kind of wrong (cloud review, #1682).
-  var savedWordsAreReadable: Bool { manager.load() != nil }
-
   let suggestionService = WordSuggestionService()
   /// The reused on-device alias generator, exposed as the narrow protocol so the
   /// composition root can wire it into the contacts-import coordinator without
@@ -71,6 +61,28 @@ final class CustomWordsCoordinator {
     case failed(message: String)
   }
 
+  /// Re-read the saved words from disk and adopt them, reporting whether the
+  /// list can now be trusted.
+  ///
+  /// One owner for "reload and adopt", used by both callers that need it: the
+  /// stale-commit path (#1679) and the export guard (#1680). Reading without
+  /// adopting is the trap — a readability check that discards what it read
+  /// leaves the caller believing the list is good while it still holds the
+  /// empty launch fallback, which is how export came to overwrite a real
+  /// backup with an empty file (cloud review, #1682).
+  ///
+  /// Fails closed: an unreadable file returns `false` and leaves the current
+  /// list untouched rather than substituting an empty one.
+  @discardableResult
+  func refreshFromDiskIfPossible() -> Bool {
+    guard let refreshed = manager.load() else { return false }
+    if refreshed != customWords {
+      customWords = refreshed
+      onWordsChanged?(customWords)
+    }
+    return true
+  }
+
   /// Apply a reviewed import in one atomic write. Fires `onWordsChanged`
   /// exactly once, and only when something actually changed.
   func commitImport(_ plan: CustomWordsImportCommitPlan) -> CustomWordsImportCommitOutcome {
@@ -92,10 +104,7 @@ final class CustomWordsCoordinator {
       // Fail closed on an unreadable file: keep the current list rather than
       // clobbering it with an empty one. The commit still reports `.stale`,
       // which is honest either way — nothing was written.
-      if let refreshed = manager.load(), refreshed != customWords {
-        customWords = refreshed
-        onWordsChanged?(customWords)
-      }
+      refreshFromDiskIfPossible()
       customWordError = nil
       return .stale
     } catch {

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -51,8 +51,7 @@ final class CustomWordsCoordinator {
       customWordError = nil
       return nil
     } catch {
-      customWordError = error.localizedDescription
-      return customWordError
+      return note(error)
     }
   }
 
@@ -77,6 +76,25 @@ final class CustomWordsCoordinator {
   ///
   /// Fails closed: an unreadable file returns `false` and leaves the current
   /// list untouched rather than substituting an empty one.
+  /// Record a failure, latching corruption whichever operation discovered it.
+  ///
+  /// Corruption has SEVERAL discoverers, not one (cloud review): any mutation
+  /// can hit it first, and `loadFileForMutation` archives the damaged file and
+  /// throws without touching the launch flag. The next read then sees a
+  /// legitimately missing file and looks perfectly healthy — so export would
+  /// write an empty file over the user's real one while their words sat in
+  /// the archive. Routing every failure through one place means a future
+  /// mutation cannot forget to say so.
+  private func note(_ error: Error) -> String {
+    if let persistence = error as? CustomWordsPersistenceError,
+      persistence == .corruptedExistingFile
+    {
+      didDiscoverCorruptionThisSession = true
+    }
+    customWordError = error.localizedDescription
+    return error.localizedDescription
+  }
+
   @discardableResult
   func refreshFromDiskIfPossible() -> Bool {
     guard let refreshed = manager.load() else {
@@ -138,8 +156,7 @@ final class CustomWordsCoordinator {
       customWordError = nil
       return .stale
     } catch {
-      customWordError = error.localizedDescription
-      return .failed(message: error.localizedDescription)
+      return .failed(message: note(error))
     }
   }
 
@@ -152,7 +169,7 @@ final class CustomWordsCoordinator {
       customWordError = nil
       return created
     } catch {
-      customWordError = error.localizedDescription
+      _ = note(error)
       return nil
     }
   }
@@ -165,8 +182,7 @@ final class CustomWordsCoordinator {
       customWordError = nil
       return nil
     } catch {
-      customWordError = error.localizedDescription
-      return customWordError
+      return note(error)
     }
   }
 
@@ -179,8 +195,7 @@ final class CustomWordsCoordinator {
       customWordError = nil
       return nil
     } catch {
-      customWordError = error.localizedDescription
-      return customWordError
+      return note(error)
     }
   }
 
@@ -192,8 +207,7 @@ final class CustomWordsCoordinator {
       customWordError = nil
       return nil
     } catch {
-      customWordError = error.localizedDescription
-      return customWordError
+      return note(error)
     }
   }
 
@@ -208,8 +222,7 @@ final class CustomWordsCoordinator {
       customWordError = nil
       return nil
     } catch {
-      customWordError = error.localizedDescription
-      return customWordError
+      return note(error)
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -12,6 +12,17 @@ final class CustomWordsCoordinator {
   /// honest banner instead of a silent empty list. `.unreadable`: the file is
   /// intact, nothing was changed. `.corrupted`: it was archived for recovery.
   private(set) var wordsLoadFailureAtLaunch: CustomWordsInitialLoadFailure?
+
+  /// Whether the saved-words file can be read RIGHT NOW (#1680).
+  ///
+  /// `wordsLoadFailureAtLaunch` is a snapshot of one moment and stays set for
+  /// the session, so it cannot answer this: a file that was temporarily
+  /// unreadable may be readable again, and a corrupted one has since been
+  /// archived and replaced by a valid empty file the user may have added to.
+  /// Export asks the live question, because refusing forever on a stale flag
+  /// is its own kind of wrong (cloud review, #1682).
+  var savedWordsAreReadable: Bool { manager.load() != nil }
+
   let suggestionService = WordSuggestionService()
   /// The reused on-device alias generator, exposed as the narrow protocol so the
   /// composition root can wire it into the contacts-import coordinator without

--- a/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
@@ -1,0 +1,59 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import Foundation
+
+/// The export decision, lifted out of the view so it can be tested (#1680).
+///
+/// This exists because of a real miss: the safety guard was written as a
+/// property on the coordinator and then never wired into the button, and the
+/// tests could not see the difference — they exercised the property directly,
+/// so they passed with the guard disconnected. Cloud review caught it.
+///
+/// Testing the ingredients is not testing the dish. The ORDER of these steps
+/// is the whole safety property:
+///   1. ask where — so cancelling touches nothing;
+///   2. reload and adopt — so the snapshot is the real list, not a stale one;
+///   3. refuse if the library is not safe to write out — so a corrupted-and-
+///      archived library cannot export an empty file over a real one;
+///   4. snapshot on the main actor, write off it.
+/// Every one of those was a separately-found bug. Keeping them in a testable
+/// unit means the sequence itself is covered, not just its parts.
+@MainActor
+enum CustomWordsExportAction {
+  enum Outcome: Equatable {
+    case cancelled
+    case exported
+    case refusedUnsafeLibrary
+    case failed(message: String)
+  }
+
+  /// - Parameters:
+  ///   - chooseDestination: returns nil when the user cancels.
+  ///   - write: performs the actual file write.
+  static func run(
+    coordinator: CustomWordsCoordinator,
+    chooseDestination: () -> URL?,
+    write: @escaping @Sendable (CustomWordsTransferDocument, URL) async throws -> Void
+  ) async -> Outcome {
+    // 1. Ask first. Refreshing before this made cancelling mutate state.
+    guard let destination = chooseDestination() else { return .cancelled }
+
+    // 2 + 3. Adopt what is on disk, then judge whether it may be written out.
+    guard coordinator.refreshFromDiskIfPossible(), coordinator.canExportCurrentWords
+    else {
+      return .refusedUnsafeLibrary
+    }
+
+    // 4. Snapshot here, synchronously, so the file reflects the moment the
+    // user confirmed rather than whenever the write happened to run.
+    let document = CustomWordsTransferDocument(
+      words: coordinator.customWords.filter { $0.source == .user })
+
+    do {
+      try await write(document, destination)
+      return .exported
+    } catch {
+      return .failed(message: error.localizedDescription)
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
@@ -1,0 +1,26 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// The app's first save panel (#1680, PR-E1).
+///
+/// Nothing is read from the word list until this returns a destination, so
+/// cancelling is a clean no-op rather than a snapshot taken and thrown away.
+@MainActor
+enum CustomWordsExportPanel {
+  static func chooseDestination() -> URL? {
+    let panel = NSSavePanel()
+    panel.title = "Export your words"
+    panel.prompt = "Export"
+    panel.nameFieldStringValue = "EnviousWispr Custom Words.json"
+    panel.allowedContentTypes = [.json]
+    panel.canCreateDirectories = true
+    panel.isExtensionHidden = false
+    // Said before the choice, not after: the file lands wherever the user
+    // points it, including a synced folder, and it can contain real names.
+    panel.message =
+      "Exported files may contain personal names and other private terms. "
+      + "Usage history is not included."
+
+    return panel.runModal() == .OK ? panel.url : nil
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -132,6 +132,19 @@ struct YourWordsView: View {
     /// Built-ins are excluded; what ships is what the user authored or edited,
     /// which is the only scope whose restore path this app can actually honor.
     private func exportWords() {
+      // Refuse to export what we could not read (code review r3). When the
+      // launch-time load fails the coordinator holds an empty list while the
+      // real file may still be on disk or archived for recovery. Exporting
+      // then writes a VALID EMPTY backup — and can overwrite a good one — so
+      // the failure would destroy the very thing the user came here to save.
+      // The banner already explains the load failure; this says why the button
+      // did nothing.
+      if customWordsCoordinator.wordsLoadFailureAtLaunch != nil {
+        exportError =
+          "Your saved words couldn't be read this time, so there's nothing safe to export. "
+          + "Relaunch EnviousWispr and try again."
+        return
+      }
       guard let destination = CustomWordsExportPanel.chooseDestination() else { return }
       let userWords = customWordsCoordinator.customWords.filter { $0.source == .user }
       do {

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -139,7 +139,7 @@ struct YourWordsView: View {
       // the failure would destroy the very thing the user came here to save.
       // The banner already explains the load failure; this says why the button
       // did nothing.
-      if customWordsCoordinator.wordsLoadFailureAtLaunch != nil {
+      if !customWordsCoordinator.savedWordsAreReadable {
         exportError =
           "Your saved words couldn't be read this time, so there's nothing safe to export. "
           + "Relaunch EnviousWispr and try again."

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -24,6 +24,10 @@ struct YourWordsView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var sheetRoute: YourWordsSheetRoute?
+  #if DEBUG
+    /// Set when an export failed, so the failure is stated rather than silent.
+    @State private var exportError: String?
+  #endif
 
   var body: some View {
     @Bindable var settings = settings
@@ -52,6 +56,13 @@ struct YourWordsView: View {
           } label: {
             Label("Preview import", systemImage: "square.and.arrow.down")
           }
+          // Export (#1680). Also DEBUG-only: the whole import/export feature is
+          // compiled out of release builds until the founder ships it, and a
+          // release-visible Export whose companion Import is invisible would be
+          // half a promise.
+          Button(action: exportWords) {
+            Label("Export your words", systemImage: "square.and.arrow.up")
+          }
         #endif
       }
 
@@ -78,6 +89,19 @@ struct YourWordsView: View {
       VocabPacksSection()
       CustomTermsSection()
     }
+    #if DEBUG
+      .alert(
+        "Export didn't finish",
+        isPresented: Binding(
+          get: { exportError != nil },
+          set: { if !$0 { exportError = nil } }
+        )
+      ) {
+        Button("OK", role: .cancel) { exportError = nil }
+      } message: {
+        Text(exportError ?? "")
+      }
+    #endif
     .sheet(item: $sheetRoute) { route in
       switch route {
       case .addTerm:
@@ -99,6 +123,26 @@ struct YourWordsView: View {
       }
     }
   }
+
+  #if DEBUG
+    /// Export the user's own words (#1680).
+    ///
+    /// Order matters: the destination is chosen first, and only then is the
+    /// word list snapshotted — so cancelling reads nothing and writes nothing.
+    /// Built-ins are excluded; what ships is what the user authored or edited,
+    /// which is the only scope whose restore path this app can actually honor.
+    private func exportWords() {
+      guard let destination = CustomWordsExportPanel.chooseDestination() else { return }
+      let userWords = customWordsCoordinator.customWords.filter { $0.source == .user }
+      do {
+        try CustomWordsExportWriter.write(
+          CustomWordsTransferDocument(words: userWords), to: destination)
+        exportError = nil
+      } catch {
+        exportError = error.localizedDescription
+      }
+    }
+  #endif
 
   private func saveNewWord(_ newWord: CustomWord) -> String? {
     let trimmedCanonical = newWord.canonical.trimmingCharacters(in: .whitespaces)

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -146,13 +146,20 @@ struct YourWordsView: View {
         return
       }
       guard let destination = CustomWordsExportPanel.chooseDestination() else { return }
-      let userWords = customWordsCoordinator.customWords.filter { $0.source == .user }
-      do {
-        try CustomWordsExportWriter.write(
-          CustomWordsTransferDocument(words: userWords), to: destination)
-        exportError = nil
-      } catch {
-        exportError = error.localizedDescription
+      // Snapshot on the main actor, write off it (code review r5). The list is
+      // read here, synchronously, so the file reflects the moment the user
+      // confirmed rather than whenever the write happened to run; only the
+      // filesystem work moves off, so a slow network or cloud destination
+      // cannot freeze the settings window.
+      let document = CustomWordsTransferDocument(
+        words: customWordsCoordinator.customWords.filter { $0.source == .user })
+      Task {
+        do {
+          try await CustomWordsExportWriter.write(document, to: destination)
+          exportError = nil
+        } catch {
+          exportError = error.localizedDescription
+        }
       }
     }
   #endif

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -132,37 +132,25 @@ struct YourWordsView: View {
     /// Built-ins are excluded; what ships is what the user authored or edited,
     /// which is the only scope whose restore path this app can actually honor.
     private func exportWords() {
-      // Refuse to export what we could not read (code review r3). When the
-      // launch-time load fails the coordinator holds an empty list while the
-      // real file may still be on disk or archived for recovery. Exporting
-      // then writes a VALID EMPTY backup — and can overwrite a good one — so
-      // the failure would destroy the very thing the user came here to save.
-      // The banner already explains the load failure; this says why the button
-      // did nothing.
-      // Reload AND adopt before deciding. Merely checking that the file is
-      // readable was worse than refusing outright: the check passed while the
-      // list stayed the empty launch fallback, so export wrote a valid empty
-      // backup over a real one (cloud review, #1682).
-      if !customWordsCoordinator.refreshFromDiskIfPossible() {
-        exportError =
-          "Your saved words couldn't be read this time, so there's nothing safe to export. "
-          + "Relaunch EnviousWispr and try again."
-        return
-      }
-      guard let destination = CustomWordsExportPanel.chooseDestination() else { return }
-      // Snapshot on the main actor, write off it (code review r5). The list is
-      // read here, synchronously, so the file reflects the moment the user
-      // confirmed rather than whenever the write happened to run; only the
-      // filesystem work moves off, so a slow network or cloud destination
-      // cannot freeze the settings window.
-      let document = CustomWordsTransferDocument(
-        words: customWordsCoordinator.customWords.filter { $0.source == .user })
+      // The decision lives in CustomWordsExportAction so the ORDER of its
+      // steps is testable; this is just the wiring (#1680).
       Task {
-        do {
-          try await CustomWordsExportWriter.write(document, to: destination)
+        let outcome = await CustomWordsExportAction.run(
+          coordinator: customWordsCoordinator,
+          chooseDestination: { CustomWordsExportPanel.chooseDestination() },
+          write: { document, destination in
+            try await CustomWordsExportWriter.write(document, to: destination)
+          }
+        )
+        switch outcome {
+        case .cancelled, .exported:
           exportError = nil
-        } catch {
-          exportError = error.localizedDescription
+        case .refusedUnsafeLibrary:
+          exportError =
+            "Your saved words couldn't be read this time, so there's nothing safe to export. "
+            + "Relaunch EnviousWispr and try again."
+        case .failed(let message):
+          exportError = message
         }
       }
     }

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -139,7 +139,11 @@ struct YourWordsView: View {
       // the failure would destroy the very thing the user came here to save.
       // The banner already explains the load failure; this says why the button
       // did nothing.
-      if !customWordsCoordinator.savedWordsAreReadable {
+      // Reload AND adopt before deciding. Merely checking that the file is
+      // readable was worse than refusing outright: the check passed while the
+      // list stayed the empty launch fallback, so export wrote a valid empty
+      // backup over a real one (cloud review, #1682).
+      if !customWordsCoordinator.refreshFromDiskIfPossible() {
         exportError =
           "Your saved words couldn't be read this time, so there's nothing safe to export. "
           + "Relaunch EnviousWispr and try again."

--- a/Sources/EnviousWisprCore/CustomWord.swift
+++ b/Sources/EnviousWisprCore/CustomWord.swift
@@ -73,6 +73,31 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     self.minSimilarityOverride = minSimilarityOverride
   }
 
+  /// The same word, re-tagged as user-authored (#1680).
+  ///
+  /// `source` is a `let`, so re-tagging means reconstructing. Needed where a
+  /// built-in becomes a user override — editing one, or replacing one through
+  /// import — because the value still carries `.builtin` from `builtinDefaults`
+  /// until a relaunch decodes it as `.user`. Export filters on `source ==
+  /// .user`, so without this an override would be missing from its own backup
+  /// until the app restarted.
+  public func ownedByUser() -> CustomWord {
+    guard source != .user else { return self }
+    return CustomWord(
+      id: id,
+      canonical: canonical,
+      aliases: aliases,
+      category: category,
+      priority: priority,
+      forceReplace: forceReplace,
+      caseSensitive: caseSensitive,
+      source: .user,
+      frequencyUsed: frequencyUsed,
+      lastUsed: lastUsed,
+      minSimilarityOverride: minSimilarityOverride
+    )
+  }
+
   // `source` deliberately omitted — keeps persisted JSON byte-equivalent to the
   // pre-Phase-0 schema for the source field. Bible §6.5.
   // `frequencyUsed` + `lastUsed` ARE persisted (Phase 3a, bible §9.2). Forward-

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -33,11 +33,26 @@ package enum CustomWordsExportWriter {
       try handle.write(contentsOf: data)
       try handle.close()
 
-      if fm.fileExists(atPath: destination.path) {
-        _ = try fm.replaceItemAt(destination, withItemAt: tmpURL)
-      } else {
+      // Deliberately NOT `if fileExists { replace } else { move }`. That is a
+      // check-then-act across a window another export can land in: both see no
+      // file, both move, and the loser fails with "already exists". The
+      // concurrency test caught exactly that. Attempt the move, and treat any
+      // failure as "something is there now" and replace it.
+      //
+      // `.usingNewMetadataOnly` is load-bearing, not tidiness (code review):
+      // the default preserves the DESTINATION's metadata, so overwriting an
+      // existing world-readable file would silently discard this temp file's
+      // 0600 and leave a backup full of personal names at 0644.
+      do {
         try fm.moveItem(at: tmpURL, to: destination)
+      } catch {
+        _ = try fm.replaceItemAt(
+          destination, withItemAt: tmpURL, options: [.usingNewMetadataOnly])
       }
+      // Belt and braces: the privacy promise is stated in the save panel, so
+      // enforce it on the final file rather than trusting the replace options
+      // to behave identically on every filesystem (network, external, FAT).
+      try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
     } catch {
       // Best-effort cleanup. An existing destination is left untouched: the
       // replace either happened completely or not at all.

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -10,9 +10,15 @@ import Foundation
 /// once; a shared temp name would let them overwrite each other's partial
 /// bytes and produce one corrupt file.
 package enum CustomWordsExportWriter {
-  package static func write(_ document: CustomWordsTransferDocument, to destination: URL)
-    throws
-  {
+  /// `@concurrent` so this always runs OFF the caller's actor (code review r5).
+  /// The caller is a SwiftUI button action on the main actor, and a plain
+  /// `async` here would inherit that isolation — an export to a network,
+  /// cloud-synced, or external destination would then block the settings
+  /// window until the filesystem finished. It also makes the cancellation
+  /// check below meaningful, which it could not be in a synchronous call.
+  @concurrent package static func write(
+    _ document: CustomWordsTransferDocument, to destination: URL
+  ) async throws {
     let data = try document.encoded()
     let fm = FileManager.default
     let tmpURL =

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /// Writes a backup file to a destination the user chose (#1680, PR-E1).
 ///
-/// Mirrors `CustomWordsManager.saveFile`'s guards — exclusive create, mode
-/// 0600, atomic replace, cleanup on failure — with one deliberate difference:
-/// the temp filename is **unique**, not fixed. The live `custom-words.json`
-/// has exactly one writer, so a fixed `.tmp` sibling is safe there. An export
+/// Same guards as `CustomWordsManager.saveFile` — exclusive create, mode 0600,
+/// atomic publish, cleanup on failure — with one deliberate difference: the
+/// temp filename is **unique**, not fixed. The live `custom-words.json` has
+/// exactly one writer, so a fixed `.tmp` sibling is safe there. An export
 /// destination is a folder the user picked, and two exports can target it at
 /// once; a shared temp name would let them overwrite each other's partial
 /// bytes and produce one corrupt file.
@@ -39,41 +39,34 @@ package enum CustomWordsExportWriter {
       try handle.write(contentsOf: data)
       try handle.close()
 
-      // Deliberately NOT `if fileExists { replace } else { move }`. That is a
-      // check-then-act across a window another export can land in: both see no
-      // file, both move, and the loser fails with "already exists". The
-      // concurrency test caught exactly that. Attempt the move, and treat any
-      // failure as "something is there now" and replace it.
+      // Publish with a single `rename(2)`, which does in ONE atomic step what
+      // three earlier revisions of this function each got partly wrong
+      // (code reviews r1-r6):
       //
-      // `.usingNewMetadataOnly` is load-bearing, not tidiness (code review):
-      // the default preserves the DESTINATION's metadata, so overwriting an
-      // existing world-readable file would silently discard this temp file's
-      // 0600 and leave a backup full of personal names at 0644.
-      do {
-        try fm.moveItem(at: tmpURL, to: destination)
-      } catch {
-        // Replace ONLY a pre-existing regular file. The first version of this
-        // fallback replaced on ANY move failure, which meant that if the
-        // destination path had become a directory, Foundation would replace
-        // the directory with the export file and delete its contents — a
-        // destructive answer to an unrelated error. Anything that is not a
-        // plain file is not ours to overwrite; rethrow the real failure.
-        var isDirectory: ObjCBool = false
-        guard fm.fileExists(atPath: destination.path, isDirectory: &isDirectory),
-          !isDirectory.boolValue
-        else {
-          throw error
-        }
-        _ = try fm.replaceItemAt(
-          destination, withItemAt: tmpURL, options: [.usingNewMetadataOnly])
+      //  - Atomic replace of an existing regular file — no check-then-act
+      //    window where a second export sees "no file" and both try to move.
+      //  - Refuses a directory outright (EISDIR), by the kernel, with no
+      //    gap between deciding and acting. The previous fileExists-then-
+      //    replace guard was correct but not atomic: a cloud-sync client that
+      //    swapped the path to a directory in between could still have had it
+      //    deleted along with its contents.
+      //  - Keeps the temp file's own 0600 rather than inheriting a
+      //    world-readable destination's mode, so a backup full of personal
+      //    names cannot be published readable by everything on the machine.
+      //
+      // Same-directory temp file means same filesystem, which is what makes
+      // rename legal here.
+      guard Foundation.rename(tmpURL.path, destination.path) == 0 else {
+        throw NSError(
+          domain: NSPOSIXErrorDomain, code: Int(errno),
+          userInfo: [
+            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
+            NSFilePathErrorKey: destination.path,
+          ])
       }
-      // Belt and braces: the privacy promise is stated in the save panel, so
-      // enforce it on the final file rather than trusting the replace options
-      // to behave identically on every filesystem (network, external, FAT).
-      try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
     } catch {
-      // Best-effort cleanup. An existing destination is left untouched: the
-      // replace either happened completely or not at all.
+      // Best-effort cleanup. An existing destination is untouched unless the
+      // rename succeeded, and a failed rename changes nothing at all.
       try? fm.removeItem(at: tmpURL)
       throw error
     }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Writes a backup file to a destination the user chose (#1680, PR-E1).
+///
+/// Mirrors `CustomWordsManager.saveFile`'s guards — exclusive create, mode
+/// 0600, atomic replace, cleanup on failure — with one deliberate difference:
+/// the temp filename is **unique**, not fixed. The live `custom-words.json`
+/// has exactly one writer, so a fixed `.tmp` sibling is safe there. An export
+/// destination is a folder the user picked, and two exports can target it at
+/// once; a shared temp name would let them overwrite each other's partial
+/// bytes and produce one corrupt file.
+package enum CustomWordsExportWriter {
+  package static func write(_ document: CustomWordsTransferDocument, to destination: URL)
+    throws
+  {
+    let data = try document.encoded()
+    let fm = FileManager.default
+    let tmpURL =
+      destination
+      .deletingLastPathComponent()
+      .appendingPathComponent(".ew-export-\(UUID().uuidString).tmp")
+
+    do {
+      // Cancellation is checked before the temp file exists, so an abandoned
+      // export leaves nothing behind to clean up.
+      try Task.checkCancellation()
+
+      // O_EXCL: refuse to write through an existing file at the temp path
+      // rather than truncating whatever happens to be there.
+      let fd = Foundation.open(tmpURL.path, O_CREAT | O_EXCL | O_WRONLY, 0o600)
+      guard fd >= 0 else { throw CocoaError(.fileWriteUnknown) }
+      let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+      try handle.write(contentsOf: data)
+      try handle.close()
+
+      if fm.fileExists(atPath: destination.path) {
+        _ = try fm.replaceItemAt(destination, withItemAt: tmpURL)
+      } else {
+        try fm.moveItem(at: tmpURL, to: destination)
+      }
+    } catch {
+      // Best-effort cleanup. An existing destination is left untouched: the
+      // replace either happened completely or not at all.
+      try? fm.removeItem(at: tmpURL)
+      throw error
+    }
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -46,6 +46,18 @@ package enum CustomWordsExportWriter {
       do {
         try fm.moveItem(at: tmpURL, to: destination)
       } catch {
+        // Replace ONLY a pre-existing regular file. The first version of this
+        // fallback replaced on ANY move failure, which meant that if the
+        // destination path had become a directory, Foundation would replace
+        // the directory with the export file and delete its contents — a
+        // destructive answer to an unrelated error. Anything that is not a
+        // plain file is not ours to overwrite; rethrow the real failure.
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: destination.path, isDirectory: &isDirectory),
+          !isDirectory.boolValue
+        else {
+          throw error
+        }
         _ = try fm.replaceItemAt(
           destination, withItemAt: tmpURL, options: [.usingNewMetadataOnly])
       }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -6,6 +6,33 @@ import Foundation
 public struct BuiltinWord: Sendable {
   public let id: String
   public let word: CustomWord
+
+  /// Stamps `source: .builtin` centrally (#1680), so a built-in cannot ship
+  /// untagged no matter how its `CustomWord` was written. Export filters on
+  /// `source == .user`; an untagged built-in would silently export as if the
+  /// user had authored it. Tagging at the one construction point makes the
+  /// correct thing automatic rather than a rule every future entry must
+  /// remember — the tag is not spelled at any call site, so it cannot be
+  /// forgotten at one.
+  ///
+  /// Runtime-only: `source` is excluded from `CustomWord.CodingKeys`, and
+  /// decode always yields `.user`. Nothing on disk changes.
+  public init(id: String, word: CustomWord) {
+    self.id = id
+    self.word = CustomWord(
+      id: word.id,
+      canonical: word.canonical,
+      aliases: word.aliases,
+      category: word.category,
+      priority: word.priority,
+      forceReplace: word.forceReplace,
+      caseSensitive: word.caseSensitive,
+      source: .builtin,
+      frequencyUsed: word.frequencyUsed,
+      lastUsed: word.lastUsed,
+      minSimilarityOverride: word.minSimilarityOverride
+    )
+  }
 }
 
 /// Thrown by the CRUD mutation methods when an EXISTING custom-words file
@@ -816,11 +843,21 @@ public final class CustomWordsManager {
     guard let index = words.firstIndex(where: { $0.id == word.id }) else { return }
     let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
-    var sanitized = word
-    sanitized.canonical = trimmed
-    sanitized.aliases = sanitized.aliases
+    var edited = word
+    edited.canonical = trimmed
+    edited.aliases = edited.aliases
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
       .filter { !$0.isEmpty }
+
+    // An edit makes the word the user's, whatever it started as (#1680).
+    // Editing a built-in produces a user override, but the value still carries
+    // `source: .builtin` from `builtinDefaults` and `source` is a `let`, so it
+    // is reconstructed here. Applied ONCE, before both the file write and the
+    // in-memory publish: re-tagging only the file copy leaves the live list
+    // still claiming `.builtin`, and an export taken right after the edit —
+    // which filters on `source == .user` — would silently omit the user's own
+    // change until the next launch decoded it. (No-op for words already `.user`.)
+    let sanitized = edited.ownedByUser()
 
     var file = try loadFileForMutation()
 
@@ -828,7 +865,7 @@ public final class CustomWordsManager {
     if let existingIdx = file.words.firstIndex(where: { $0.id == word.id }) {
       file.words[existingIdx] = sanitized
     } else {
-      // Editing a built-in: add as user word (overrides built-in by canonical match)
+      // Editing a built-in: add as user word (overrides built-in by canonical match).
       file.words.append(sanitized)
     }
     try saveFile(file)

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -86,7 +86,11 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
     guard decoded.format == Self.formatIdentifier else {
       throw CustomWordsTransferError.notAnEnviousWisprBackup
     }
-    guard decoded.version <= Self.currentVersion else {
+    // A RANGE, not an upper bound. Version 1 is the first format and nothing
+    // earlier ever existed, so `0` or a negative version is a malformed or
+    // tampered file claiming a schema that was never defined — not something
+    // to import on the strength of the current fields happening to parse.
+    guard (1...Self.currentVersion).contains(decoded.version) else {
       throw CustomWordsTransferError.unsupportedVersion(decoded.version)
     }
     self = decoded

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -66,16 +66,27 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
     self.words = words.map(PortableCustomWord.init)
   }
 
+  /// Just the envelope. Decoded first and alone so the format and version can
+  /// be judged before any version-specific payload is parsed.
+  private struct Header: Decodable {
+    let format: String
+    let version: Int
+  }
+
   /// Decode path. Rejects anything that isn't this format, and refuses a
-  /// version from the future rather than guessing at fields it doesn't know.
+  /// version it cannot interpret rather than guessing at fields it doesn't know.
   package init(data: Data) throws {
-    let decoded: CustomWordsTransferDocument
+    // Header FIRST (code review r3). A future format could rename a word field
+    // or add an enum case; decoding the whole document up front would throw on
+    // that payload before the version guard ran, and the user would be told
+    // their backup is damaged when the truth is "made by a newer version —
+    // update the app." Judge the envelope, then read the contents.
+    let header: Header
     do {
-      decoded = try JSONDecoder().decode(CustomWordsTransferDocument.self, from: data)
+      header = try JSONDecoder().decode(Header.self, from: data)
     } catch {
-      // A valid JSON object that simply isn't ours decodes as a key mismatch,
-      // same as damaged bytes; distinguish them so the user gets the right
-      // sentence rather than "damaged" for a perfectly fine unrelated file.
+      // A perfectly valid JSON file that simply isn't ours reads the same as
+      // damaged bytes at this layer; separate them so the message is true.
       if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
         object["format"] as? String != Self.formatIdentifier
       {
@@ -83,15 +94,24 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
       }
       throw CustomWordsTransferError.malformed
     }
-    guard decoded.format == Self.formatIdentifier else {
+    guard header.format == Self.formatIdentifier else {
       throw CustomWordsTransferError.notAnEnviousWisprBackup
     }
     // A RANGE, not an upper bound. Version 1 is the first format and nothing
     // earlier ever existed, so `0` or a negative version is a malformed or
     // tampered file claiming a schema that was never defined — not something
     // to import on the strength of the current fields happening to parse.
-    guard (1...Self.currentVersion).contains(decoded.version) else {
-      throw CustomWordsTransferError.unsupportedVersion(decoded.version)
+    guard (1...Self.currentVersion).contains(header.version) else {
+      throw CustomWordsTransferError.unsupportedVersion(header.version)
+    }
+
+    let decoded: CustomWordsTransferDocument
+    do {
+      decoded = try JSONDecoder().decode(CustomWordsTransferDocument.self, from: data)
+    } catch {
+      // The envelope is ours and its version is supported, so a payload that
+      // still won't parse is genuinely damaged.
+      throw CustomWordsTransferError.malformed
     }
     self = decoded
   }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -1,0 +1,128 @@
+import EnviousWisprCore
+import Foundation
+
+/// Errors from decoding an EnviousWispr custom-words backup (#1680, PR-E1).
+package enum CustomWordsTransferError: LocalizedError, Sendable, Equatable {
+  case notAnEnviousWisprBackup
+  case unsupportedVersion(Int)
+  case malformed
+
+  package var errorDescription: String? {
+    switch self {
+    case .notAnEnviousWisprBackup:
+      return "That file isn't an EnviousWispr word backup."
+    case .unsupportedVersion(let version):
+      return
+        "That backup was made by a newer version of EnviousWispr (format \(version)). "
+        + "Update the app, then try again."
+    case .malformed:
+      return "That backup file is damaged and can't be read."
+    }
+  }
+}
+
+/// One exported word. Deliberately narrower than `CustomWord`: usage history
+/// (`frequencyUsed` / `lastUsed`) never leaves this Mac, and `source` is a
+/// runtime tag with no meaning on another machine.
+package struct PortableCustomWord: Codable, Sendable, Equatable {
+  package let id: UUID
+  package let canonical: String
+  package let aliases: [String]
+  package let category: WordCategory
+  package let priority: Int
+  package let forceReplace: Bool
+  package let caseSensitive: Bool
+  package let minSimilarityOverride: Double?
+
+  package init(_ word: CustomWord) {
+    self.id = word.id
+    self.canonical = word.canonical
+    self.aliases = word.aliases
+    self.category = word.category
+    self.priority = word.priority
+    self.forceReplace = word.forceReplace
+    self.caseSensitive = word.caseSensitive
+    self.minSimilarityOverride = word.minSimilarityOverride
+  }
+}
+
+/// The portable backup format: a versioned envelope around the user's own words.
+///
+/// Scope is "your words", never "everything" — see the export path for why
+/// built-ins are excluded and why deleted-built-in tombstones are a documented
+/// non-goal rather than an oversight.
+package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
+  package static let formatIdentifier = "com.enviouswispr.custom-words"
+  package static let currentVersion = 1
+
+  package let format: String
+  package let version: Int
+  package let words: [PortableCustomWord]
+
+  /// Export path.
+  package init(words: [CustomWord]) {
+    self.format = Self.formatIdentifier
+    self.version = Self.currentVersion
+    self.words = words.map(PortableCustomWord.init)
+  }
+
+  /// Decode path. Rejects anything that isn't this format, and refuses a
+  /// version from the future rather than guessing at fields it doesn't know.
+  package init(data: Data) throws {
+    let decoded: CustomWordsTransferDocument
+    do {
+      decoded = try JSONDecoder().decode(CustomWordsTransferDocument.self, from: data)
+    } catch {
+      // A valid JSON object that simply isn't ours decodes as a key mismatch,
+      // same as damaged bytes; distinguish them so the user gets the right
+      // sentence rather than "damaged" for a perfectly fine unrelated file.
+      if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        object["format"] as? String != Self.formatIdentifier
+      {
+        throw CustomWordsTransferError.notAnEnviousWisprBackup
+      }
+      throw CustomWordsTransferError.malformed
+    }
+    guard decoded.format == Self.formatIdentifier else {
+      throw CustomWordsTransferError.notAnEnviousWisprBackup
+    }
+    guard decoded.version <= Self.currentVersion else {
+      throw CustomWordsTransferError.unsupportedVersion(decoded.version)
+    }
+    self = decoded
+  }
+
+  package func encoded() throws -> Data {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    return try encoder.encode(self)
+  }
+
+  /// Hand the decoded words to the shared import pipeline.
+  ///
+  /// Never returns `[CustomWord]`: an exported `id` is foreign to this Mac and
+  /// must not become a local persisted UUID. It survives only as review-row
+  /// identity — a committed addition mints a fresh UUID, and a committed
+  /// replacement keeps the *existing local* word's UUID.
+  ///
+  /// Every authority field is `.supplied`, including the two authoritative
+  /// clears no other source can express: `.supplied([])` means "this word
+  /// genuinely has no alternate spellings" and `.supplied(nil)` means "this
+  /// word genuinely uses the global strictness". A backup is a full round-trip
+  /// of a real word, so silence here would be a lie, not an absence of opinion.
+  package func candidatesForImport() -> [CustomWordsImportCandidate] {
+    words.map { word in
+      CustomWordsImportCandidate(
+        id: word.id,
+        canonical: word.canonical,
+        aliases: .supplied(word.aliases),
+        suggestedAliases: [],
+        category: .supplied(word.category),
+        priority: .supplied(word.priority),
+        forceReplace: .supplied(word.forceReplace),
+        caseSensitive: .supplied(word.caseSensitive),
+        minSimilarityOverride: .supplied(word.minSimilarityOverride)
+      )
+    }
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -100,10 +100,17 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
 
   /// Hand the decoded words to the shared import pipeline.
   ///
-  /// Never returns `[CustomWord]`: an exported `id` is foreign to this Mac and
-  /// must not become a local persisted UUID. It survives only as review-row
-  /// identity — a committed addition mints a fresh UUID, and a committed
-  /// replacement keeps the *existing local* word's UUID.
+  /// Never returns `[CustomWord]`: an exported `id` is a persistence UUID from
+  /// whichever Mac wrote the file, and must not become a local persisted UUID.
+  ///
+  /// The exported id is **not reused as review identity either** (code review).
+  /// Restoring a backup onto the Mac that wrote it makes every candidate id
+  /// equal to the live word's id, and the collision detector — which seeds
+  /// ownership from the existing library first — then reports each word's own
+  /// aliases as colliding with itself. Review would warn that spellings "may
+  /// not be added" when replacement keeps them. A fresh transient id per
+  /// candidate keeps review rows distinct from library entries, which is the
+  /// only thing this id is for.
   ///
   /// Every authority field is `.supplied`, including the two authoritative
   /// clears no other source can express: `.supplied([])` means "this word
@@ -113,7 +120,7 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
   package func candidatesForImport() -> [CustomWordsImportCandidate] {
     words.map { word in
       CustomWordsImportCandidate(
-        id: word.id,
+        id: UUID(),
         canonical: word.canonical,
         aliases: .supplied(word.aliases),
         suggestedAliases: [],

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -97,11 +97,15 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
     guard header.format == Self.formatIdentifier else {
       throw CustomWordsTransferError.notAnEnviousWisprBackup
     }
-    // A RANGE, not an upper bound. Version 1 is the first format and nothing
-    // earlier ever existed, so `0` or a negative version is a malformed or
-    // tampered file claiming a schema that was never defined — not something
-    // to import on the strength of the current fields happening to parse.
-    guard (1...Self.currentVersion).contains(header.version) else {
+    // A RANGE, not an upper bound — but the two ends mean different things and
+    // must not share a message (review r4). Below 1 is a schema that never
+    // existed, so the file is malformed or tampered; telling that user to
+    // "update the app" is advice that cannot help them. Above current is a
+    // genuine future format, where updating is exactly the fix.
+    guard header.version >= 1 else {
+      throw CustomWordsTransferError.malformed
+    }
+    guard header.version <= Self.currentVersion else {
       throw CustomWordsTransferError.unsupportedVersion(header.version)
     }
 

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -117,4 +117,37 @@ struct CustomWordsExportActionTests {
       return
     }
   }
+
+  @Test("corruption discovered by an EDIT still blocks a later export")
+  func corruptionFoundByAMutationBlocksExport() async throws {
+    // A fourth door into the same data loss (cloud review): when a mutation is
+    // what first hits the damaged file, the manager archives it and throws
+    // WITHOUT touching the launch flag. The next read then sees a legitimately
+    // missing file and looks perfectly healthy — so export would write an
+    // empty file over the user's real one while their words sat in the
+    // archive. Corruption has several discoverers, not one.
+    let url = tempURL()
+    let manager = CustomWordsManager(fileURL: url)
+    var live = manager.load() ?? []
+    try manager.add(word: CustomWord(canonical: "Kubernetes"), to: &live)
+
+    // The app is running with a healthy library — launch flag clean.
+    let coordinator = CustomWordsCoordinator(manager: manager)
+    #expect(coordinator.wordsLoadFailureAtLaunch == nil)
+    #expect(coordinator.customWords.contains { $0.canonical == "Kubernetes" })
+
+    // The file goes bad underneath it, and an EDIT is what finds out.
+    try Data("not valid json at all {{{".utf8).write(to: url)
+    #expect(coordinator.add(CustomWord(canonical: "Qualtrics")) != nil, "the edit must fail")
+
+    let spy = WriteSpy()
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      chooseDestination: { self.tempURL() },
+      write: { document, _ in await MainActor.run { spy.document = document } }
+    )
+
+    #expect(outcome == .refusedUnsafeLibrary)
+    #expect(spy.document == nil, "an empty export must never reach the writer")
+  }
 }

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -1,0 +1,120 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPostProcessing
+
+/// #1680 — the export action, including the ORDER of its steps.
+///
+/// These exist because the safety guard was once written as a property and
+/// never wired into the button, and the tests could not tell: they exercised
+/// the property directly, so they passed with it disconnected. Testing the
+/// ingredients is not testing the dish.
+@MainActor
+@Suite("CustomWordsExportAction")
+struct CustomWordsExportActionTests {
+
+  /// `@MainActor`-isolated recorder rather than a captured var: the write
+  /// closure is `@Sendable`, and hiding a race behind an unchecked conformance
+  /// is the thing this codebase already learned not to do.
+  @MainActor
+  final class WriteSpy {
+    var document: CustomWordsTransferDocument?
+    var writeCount = 0
+  }
+
+  private func tempURL() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-export-action-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent("custom-words.json")
+  }
+
+  private func coordinator(seedWords: [CustomWord] = []) throws -> CustomWordsCoordinator {
+    let url = tempURL()
+    let manager = CustomWordsManager(fileURL: url)
+    var live = manager.load() ?? []
+    for word in seedWords { try manager.add(word: word, to: &live) }
+    return CustomWordsCoordinator(manager: manager)
+  }
+
+  private func corruptedCoordinator() throws -> CustomWordsCoordinator {
+    let url = tempURL()
+    try Data("not valid json at all {{{".utf8).write(to: url)
+    return CustomWordsCoordinator(manager: CustomWordsManager(fileURL: url))
+  }
+
+  @Test("cancelling touches nothing at all")
+  func cancellingWritesNothingAndChangesNothing() async throws {
+    let coordinator = try coordinator(seedWords: [CustomWord(canonical: "Kubernetes")])
+    let before = coordinator.customWords
+    let spy = WriteSpy()
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      chooseDestination: { nil },
+      write: { _, _ in await MainActor.run { spy.writeCount += 1 } }
+    )
+
+    #expect(outcome == .cancelled)
+    #expect(spy.writeCount == 0)
+    // Refreshing before asking where would have mutated state on cancel.
+    #expect(coordinator.customWords == before)
+  }
+
+  @Test("a corrupted library refuses to export instead of writing an empty file")
+  func corruptedLibraryRefusesRatherThanWritingEmpty() async throws {
+    // The guard being PRESENT is not enough — it has to be reached. This test
+    // fails if the export path stops consulting it, which is the exact bug
+    // that shipped and was caught in cloud review.
+    let coordinator = try corruptedCoordinator()
+    let spy = WriteSpy()
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      chooseDestination: { self.tempURL() },
+      write: { document, _ in await MainActor.run { spy.document = document } }
+    )
+
+    #expect(outcome == .refusedUnsafeLibrary)
+    #expect(spy.document == nil, "an empty export must never reach the writer")
+  }
+
+  @Test("a healthy library exports exactly the user's own words")
+  func healthyLibraryExportsUserWordsOnly() async throws {
+    let coordinator = try coordinator(seedWords: [
+      CustomWord(canonical: "Kubernetes"), CustomWord(canonical: "Qualtrics"),
+    ])
+    let spy = WriteSpy()
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      chooseDestination: { self.tempURL() },
+      write: { document, _ in await MainActor.run { spy.document = document } }
+    )
+
+    #expect(outcome == .exported)
+    let document = try #require(spy.document)
+    #expect(document.words.map(\.canonical).sorted() == ["Kubernetes", "Qualtrics"])
+    // Built-ins are excluded: this is "your words", not "everything".
+    #expect(!document.words.contains { $0.canonical == "GitHub" })
+  }
+
+  @Test("a write failure is reported rather than reading as success")
+  func writeFailureIsReported() async throws {
+    struct Boom: Error {}
+    let coordinator = try coordinator(seedWords: [CustomWord(canonical: "Kubernetes")])
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      chooseDestination: { self.tempURL() },
+      write: { _, _ in throw Boom() }
+    )
+
+    guard case .failed = outcome else {
+      Issue.record("expected a failure outcome, got \(outcome)")
+      return
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsBackupRoundTripTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsBackupRoundTripTests.swift
@@ -1,0 +1,160 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1680 (PR-E1) — export → compare → commit, against real files.
+///
+/// The plan parks the full round trip in PR-U1, because U1 is what reads a
+/// backup off disk through a file picker. That deferral would leave export's
+/// central promise — "this file can be restored" — untested in the PR that
+/// makes the promise, so the contract-level round trip runs here now and U1
+/// adds the picker leg on top.
+@MainActor
+@Suite("CustomWordsBackupRoundTrip")
+struct CustomWordsBackupRoundTripTests {
+
+  private func makeManager() -> (CustomWordsManager, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-roundtrip-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent("custom-words.json")
+    return (CustomWordsManager(fileURL: url), url)
+  }
+
+  @Test("a user's own words survive export and restore onto a fresh library")
+  func exportThenRestoreRebuildsEveryUserAuthoredWord() async throws {
+    // Mac A: two authored words, one carrying full configuration.
+    let (source, _) = makeManager()
+    var live = source.load() ?? []
+    try source.add(word: CustomWord(canonical: "Qualtrics", aliases: ["qualtrix"]), to: &live)
+    try source.add(
+      word: CustomWord(
+        canonical: "Kubernetes", aliases: ["k8s"], category: .brand, priority: 4,
+        forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.75),
+      to: &live)
+
+    let exported = live.filter { $0.source == .user }
+    #expect(exported.count == 2, "built-ins must not be in the export set")
+    let backup = try CustomWordsTransferDocument(
+      data: CustomWordsTransferDocument(words: exported).encoded())
+
+    // Mac B: a fresh library. Never actually empty — the built-ins are merged
+    // into every effective list — so "everything classifies as new" only holds
+    // for words that don't collide with a built-in.
+    let (destination, _) = makeManager()
+    var fresh = try #require(destination.load())
+    // A fresh library is never empty: `mergedWords` folds the built-ins into
+    // every effective list. Only the user-authored subset is empty.
+    #expect(fresh.contains { $0.source == .user } == false)
+    #expect(fresh.isEmpty == false)
+
+    let candidates = backup.candidatesForImport()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: candidates,
+      against: fresh,
+      fuzzyPolicy: .disabled
+    )
+    #expect(comparisons.allSatisfy { $0.classification == .new })
+
+    let receipt = try destination.commitImport(
+      CustomWordsImportCommitPlan(
+        baseline: CustomWordsImportLibrarySnapshot(words: fresh),
+        additions: comparisons.map(\.candidate),
+        replacements: []),
+      to: &fresh)
+    #expect(receipt.addedIDs.count == 2)
+
+    // Compare what the user actually authored, field by field.
+    let restored = Dictionary(
+      uniqueKeysWithValues: fresh.filter { $0.source == .user }.map { ($0.canonical, $0) })
+    let kubernetes = try #require(restored["Kubernetes"])
+    #expect(kubernetes.aliases == ["k8s"])
+    #expect(kubernetes.category == .brand)
+    #expect(kubernetes.priority == 4)
+    #expect(kubernetes.forceReplace == true)
+    #expect(kubernetes.caseSensitive == true)
+    #expect(kubernetes.minSimilarityOverride == 0.75)
+    #expect(try #require(restored["Qualtrics"]).aliases == ["qualtrix"])
+
+    // Usage history is local to the Mac that earned it.
+    #expect(kubernetes.frequencyUsed == 0)
+    #expect(kubernetes.lastUsed == nil)
+
+    // A restored word is a local word with a local identity.
+    let foreignIDs = Set(backup.words.map(\.id))
+    #expect(fresh.filter { $0.source == .user }.allSatisfy { !foreignIDs.contains($0.id) })
+  }
+
+  @Test("an edited built-in exports, and restoring it needs a replacement")
+  func restoringABuiltinOverrideRequiresAReplacementNotAnAdd() async throws {
+    // Mac A edits a built-in. The override is a real user word and must export.
+    let (source, _) = makeManager()
+    var live = try #require(source.load())
+    let github = try #require(live.first { $0.canonical == "GitHub" })
+    #expect(github.source == .builtin)
+    var edited = github
+    edited.aliases = ["git hub", "gh"]
+    try source.update(word: edited, in: &live)
+
+    let exported = live.filter { $0.source == .user }
+    #expect(
+      exported.contains { $0.canonical == "GitHub" },
+      "the override must export immediately, without waiting for a relaunch")
+
+    // Mac B still has the untouched built-in, so the incoming word is not new.
+    let (destination, _) = makeManager()
+    var fresh = try #require(destination.load())
+    let backup = CustomWordsTransferDocument(words: exported)
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: backup.candidatesForImport(),
+      against: fresh,
+      fuzzyPolicy: .disabled
+    )
+    let row = try #require(comparisons.first { $0.candidate.canonical == "GitHub" })
+    guard case .exact(let existing) = row.classification else {
+      Issue.record("expected the override to match Mac B's built-in exactly")
+      return
+    }
+
+    // The machinery restores it — but only through a REPLACEMENT. The v1
+    // review screen offers Add or Skip only, so this row would be Skip-only
+    // and the user's edit would not come back. That gap is the reason backup
+    // restore is the first real consumer of the alias-merge offer (#1619), and
+    // PR-U1 must surface it rather than silently skipping.
+    let receipt = try destination.commitImport(
+      CustomWordsImportCommitPlan(
+        baseline: CustomWordsImportLibrarySnapshot(words: fresh),
+        additions: [],
+        replacements: [
+          CustomWordsImportReplacement(existingID: existing.id, candidate: row.candidate)
+        ]),
+      to: &fresh)
+
+    #expect(receipt.replacedIDs.count == 1)
+    let restored = try #require(fresh.first { $0.canonical == "GitHub" })
+    #expect(restored.aliases == ["git hub", "gh"])
+    #expect(restored.source == .user)
+  }
+
+  @Test("deleted built-ins are not carried by a backup, by design")
+  func deletedBuiltinTombstonesAreANonGoal() throws {
+    let (source, _) = makeManager()
+    var live = try #require(source.load())
+    let claude = try #require(live.first { $0.canonical == "Claude" })
+    try source.remove(id: claude.id, from: &live)
+    #expect(live.contains { $0.canonical == "Claude" } == false)
+
+    let exported = live.filter { $0.source == .user }
+    let json = try #require(
+      String(data: try CustomWordsTransferDocument(words: exported).encoded(), encoding: .utf8))
+
+    // Frozen as a decision, not left to look like a bug: restoring your words
+    // onto a fresh Mac leaves that Mac's built-ins active, because the review
+    // model has no delete operation and a backup whose restore path cannot
+    // express part of its content would be a broken promise.
+    #expect(!json.contains("deletedBuiltinIds"))
+    #expect(!json.contains("Claude"))
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -46,6 +46,26 @@ struct CustomWordsExportWriterTests {
     #expect(decoded.words.map(\.canonical) == ["Kubernetes"])
   }
 
+  @Test("overwriting a world-readable file still lands at owner-only")
+  func writerOverwritingAWorldReadableFileEnforcesMode0600() throws {
+    // The bug this freezes (code review): `replaceItemAt` preserves the
+    // DESTINATION's metadata by default, so overwriting an existing 0644 file
+    // silently discarded the temp file's 0600 and left a backup full of
+    // personal names world-readable. The new-file test could never catch it.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json")
+    try Data("previous contents".utf8).write(to: destination)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o644], ofItemAtPath: destination.path)
+
+    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
+    let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+    #expect(permissions.int16Value == 0o600)
+  }
+
   @Test("no temporary file is left behind after a successful write")
   func writerLeavesNoTemporaryFile() throws {
     let dir = makeDirectory()

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -105,6 +105,30 @@ struct CustomWordsExportWriterTests {
     #expect(try Data(contentsOf: destination) == original)
   }
 
+  @Test("a directory at the destination is never replaced or emptied")
+  func writerRefusesToReplaceADirectory() throws {
+    // The bug this freezes (code review r2): the move-then-replace fallback
+    // originally replaced on ANY move failure, so a directory sitting at the
+    // destination path would be replaced by the export file and its contents
+    // deleted — a destructive answer to an unrelated error.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json", isDirectory: true)
+    try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+    let inhabitant = destination.appendingPathComponent("keep-me.txt")
+    try Data("precious".utf8).write(to: inhabitant)
+
+    #expect(throws: (any Error).self) {
+      try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    }
+
+    var isDirectory: ObjCBool = false
+    #expect(
+      FileManager.default.fileExists(atPath: destination.path, isDirectory: &isDirectory))
+    #expect(isDirectory.boolValue)
+    #expect(try Data(contentsOf: inhabitant) == Data("precious".utf8))
+  }
+
   @Test("two exports to one destination leave a single complete document")
   func concurrentWritesLeaveOneCompleteDecodableDocument() async throws {
     let dir = makeDirectory()

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -21,12 +21,12 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("a new file is created with owner-only permissions")
-  func writerCreatesNewFileWithMode0600() throws {
+  func writerCreatesNewFileWithMode0600() async throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let destination = dir.appendingPathComponent("words.json")
 
-    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
 
     let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
     let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
@@ -34,20 +34,20 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("an existing file is replaced atomically")
-  func writerAtomicallyReplacesExistingFile() throws {
+  func writerAtomicallyReplacesExistingFile() async throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let destination = dir.appendingPathComponent("words.json")
     try Data("previous contents".utf8).write(to: destination)
 
-    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
 
     let decoded = try CustomWordsTransferDocument(data: Data(contentsOf: destination))
     #expect(decoded.words.map(\.canonical) == ["Kubernetes"])
   }
 
   @Test("overwriting a world-readable file still lands at owner-only")
-  func writerOverwritingAWorldReadableFileEnforcesMode0600() throws {
+  func writerOverwritingAWorldReadableFileEnforcesMode0600() async throws {
     // The bug this freezes (code review): `replaceItemAt` preserves the
     // DESTINATION's metadata by default, so overwriting an existing 0644 file
     // silently discarded the temp file's 0600 and left a backup full of
@@ -59,7 +59,7 @@ struct CustomWordsExportWriterTests {
     try FileManager.default.setAttributes(
       [.posixPermissions: 0o644], ofItemAtPath: destination.path)
 
-    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
 
     let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
     let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
@@ -67,11 +67,11 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("no temporary file is left behind after a successful write")
-  func writerLeavesNoTemporaryFile() throws {
+  func writerLeavesNoTemporaryFile() async throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
 
-    try CustomWordsExportWriter.write(
+    try await CustomWordsExportWriter.write(
       document(["Kubernetes"]), to: dir.appendingPathComponent("words.json"))
 
     let leftovers = try FileManager.default
@@ -81,7 +81,7 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("an unwritable destination leaves any existing file intact")
-  func writerLeavesExistingFileIntactOnFailure() throws {
+  func writerLeavesExistingFileIntactOnFailure() async throws {
     let dir = makeDirectory()
     defer {
       try? FileManager.default.setAttributes(
@@ -96,8 +96,8 @@ struct CustomWordsExportWriterTests {
     try FileManager.default.setAttributes(
       [.posixPermissions: 0o500], ofItemAtPath: dir.path)
 
-    #expect(throws: (any Error).self) {
-      try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    await #expect(throws: (any Error).self) {
+      try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
     }
 
     try FileManager.default.setAttributes(
@@ -106,7 +106,7 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("a directory at the destination is never replaced or emptied")
-  func writerRefusesToReplaceADirectory() throws {
+  func writerRefusesToReplaceADirectory() async throws {
     // The bug this freezes (code review r2): the move-then-replace fallback
     // originally replaced on ANY move failure, so a directory sitting at the
     // destination path would be replaced by the export file and its contents
@@ -118,8 +118,8 @@ struct CustomWordsExportWriterTests {
     let inhabitant = destination.appendingPathComponent("keep-me.txt")
     try Data("precious".utf8).write(to: inhabitant)
 
-    #expect(throws: (any Error).self) {
-      try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    await #expect(throws: (any Error).self) {
+      try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
     }
 
     var isDirectory: ObjCBool = false
@@ -138,12 +138,12 @@ struct CustomWordsExportWriterTests {
     // The reason the temp filename is unique rather than fixed: a shared temp
     // name would let these two interleave into one corrupt file.
     async let first: Void = Task.detached {
-      try CustomWordsExportWriter.write(
+      try await CustomWordsExportWriter.write(
         CustomWordsTransferDocument(words: [CustomWord(canonical: "Kubernetes")]),
         to: destination)
     }.value
     async let second: Void = Task.detached {
-      try CustomWordsExportWriter.write(
+      try await CustomWordsExportWriter.write(
         CustomWordsTransferDocument(words: [CustomWord(canonical: "Anthropic")]),
         to: destination)
     }.value

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -1,0 +1,113 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1680 (PR-E1) — export writer. Every test writes to a real temp directory,
+/// so atomicity and permissions are verified against the filesystem.
+@Suite("CustomWordsExportWriter")
+struct CustomWordsExportWriterTests {
+
+  private func makeDirectory() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-export-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  private func document(_ canonicals: [String]) -> CustomWordsTransferDocument {
+    CustomWordsTransferDocument(words: canonicals.map { CustomWord(canonical: $0) })
+  }
+
+  @Test("a new file is created with owner-only permissions")
+  func writerCreatesNewFileWithMode0600() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json")
+
+    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
+    let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+    #expect(permissions.int16Value == 0o600)
+  }
+
+  @Test("an existing file is replaced atomically")
+  func writerAtomicallyReplacesExistingFile() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json")
+    try Data("previous contents".utf8).write(to: destination)
+
+    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+
+    let decoded = try CustomWordsTransferDocument(data: Data(contentsOf: destination))
+    #expect(decoded.words.map(\.canonical) == ["Kubernetes"])
+  }
+
+  @Test("no temporary file is left behind after a successful write")
+  func writerLeavesNoTemporaryFile() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    try CustomWordsExportWriter.write(
+      document(["Kubernetes"]), to: dir.appendingPathComponent("words.json"))
+
+    let leftovers = try FileManager.default
+      .contentsOfDirectory(atPath: dir.path)
+      .filter { $0.hasPrefix(".ew-export-") }
+    #expect(leftovers.isEmpty)
+  }
+
+  @Test("an unwritable destination leaves any existing file intact")
+  func writerLeavesExistingFileIntactOnFailure() throws {
+    let dir = makeDirectory()
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o700], ofItemAtPath: dir.path)
+      try? FileManager.default.removeItem(at: dir)
+    }
+    let destination = dir.appendingPathComponent("words.json")
+    let original = Data("previous contents".utf8)
+    try original.write(to: destination)
+
+    // Read+execute only: the temp file cannot be created in this directory.
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o500], ofItemAtPath: dir.path)
+
+    #expect(throws: (any Error).self) {
+      try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    }
+
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    #expect(try Data(contentsOf: destination) == original)
+  }
+
+  @Test("two exports to one destination leave a single complete document")
+  func concurrentWritesLeaveOneCompleteDecodableDocument() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json")
+
+    // The reason the temp filename is unique rather than fixed: a shared temp
+    // name would let these two interleave into one corrupt file.
+    async let first: Void = Task.detached {
+      try CustomWordsExportWriter.write(
+        CustomWordsTransferDocument(words: [CustomWord(canonical: "Kubernetes")]),
+        to: destination)
+    }.value
+    async let second: Void = Task.detached {
+      try CustomWordsExportWriter.write(
+        CustomWordsTransferDocument(words: [CustomWord(canonical: "Anthropic")]),
+        to: destination)
+    }.value
+    _ = try await (first, second)
+
+    // Which one wins is unspecified; that it is one complete document is not.
+    let decoded = try CustomWordsTransferDocument(data: Data(contentsOf: destination))
+    #expect(["Kubernetes", "Anthropic"].contains(try #require(decoded.words.first).canonical))
+    #expect(decoded.words.count == 1)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
@@ -566,4 +566,40 @@ struct CustomWordsCoordinatorLaunchFailureTests {
             addedIDs: [], replacedIDs: [], droppedAliasCollisions: [])))
     #expect(coordinator.customWords == before)
   }
+
+  @Test("a corrupted-and-archived library is not safe to export")
+  func corruptedLibraryIsNotExportable() throws {
+    // The scenario: the file is damaged at launch, so the manager archives it
+    // aside. A later reload then sees a legitimately MISSING file and reports
+    // a clean, empty library — which reads as success while the user's real
+    // words sit in the archive. Exporting there writes an empty file over
+    // whatever the user picked (cloud review, #1682).
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    try Data("not valid json at all {{{".utf8).write(to: url)
+
+    let coordinator = CustomWordsCoordinator(manager: CustomWordsManager(fileURL: url))
+    #expect(coordinator.wordsLoadFailureAtLaunch == .corrupted)
+
+    // The reload succeeds — the damaged file is gone — and that is exactly why
+    // readability alone cannot be the gate.
+    #expect(coordinator.refreshFromDiskIfPossible())
+    #expect(coordinator.canExportCurrentWords == false)
+  }
+
+  @Test("authoring a word after corruption makes the list exportable again")
+  func authoringAWordAfterCorruptionRestoresExportability() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    try Data("not valid json at all {{{".utf8).write(to: url)
+
+    let coordinator = CustomWordsCoordinator(manager: CustomWordsManager(fileURL: url))
+    #expect(coordinator.canExportCurrentWords == false)
+
+    // Once they have written something since, they have visibly accepted the
+    // fresh start and the list is theirs again — blocking forever would be its
+    // own kind of wrong.
+    #expect(coordinator.add(CustomWord(canonical: "Kubernetes")) == nil)
+    #expect(coordinator.canExportCurrentWords)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
@@ -448,8 +448,8 @@ struct CustomWordsCoordinatorLaunchFailureTests {
 
   // MARK: - Export readability is a live question, not a launch snapshot (#1682)
 
-  @Test("an unreadable file reports as not readable")
-  func savedWordsAreNotReadableWhileTheFileIsUnreadable() throws {
+  @Test("an unreadable file refuses the refresh and keeps the current list")
+  func refreshFailsClosedWhileTheFileIsUnreadable() throws {
     let url = Self.tempURL()
     defer { Self.cleanup(url) }
     let mgr = CustomWordsManager(fileURL: url)
@@ -464,11 +464,16 @@ struct CustomWordsCoordinatorLaunchFailureTests {
 
     let coordinator = CustomWordsCoordinator(manager: mgr)
     #expect(coordinator.wordsLoadFailureAtLaunch == .unreadable)
-    #expect(coordinator.savedWordsAreReadable == false)
+    #expect(coordinator.refreshFromDiskIfPossible() == false)
+    #expect(coordinator.customWords.isEmpty)
   }
 
-  @Test("readability recovers within the session even though the launch flag does not")
-  func savedWordsBecomeReadableAgainAfterTheFileRecovers() throws {
+  @Test("a recovered file is ADOPTED, not merely reported readable")
+  func refreshAdoptsTheRecoveredWordsRatherThanJustReportingReadable() throws {
+    // The bug this freezes (cloud review, #1682): a readability check that
+    // discarded what it read let export proceed while `customWords` was still
+    // the empty launch fallback, so it wrote a valid EMPTY backup over a real
+    // one. Reporting "readable" is not enough; the words have to arrive.
     let url = Self.tempURL()
     defer { Self.cleanup(url) }
     let mgr = CustomWordsManager(fileURL: url)
@@ -478,16 +483,19 @@ struct CustomWordsCoordinatorLaunchFailureTests {
       [.posixPermissions: 0o000], ofItemAtPath: url.path)
 
     let coordinator = CustomWordsCoordinator(manager: mgr)
-    #expect(coordinator.savedWordsAreReadable == false)
+    #expect(coordinator.customWords.isEmpty, "launch fallback while unreadable")
 
     // The file becomes readable again mid-session.
     try FileManager.default.setAttributes(
       [.posixPermissions: 0o600], ofItemAtPath: url.path)
 
-    // The launch flag is a snapshot and stays set — that is what makes it the
-    // wrong thing to gate export on.
+    #expect(coordinator.refreshFromDiskIfPossible())
+    // The launch flag is a snapshot and stays set — which is exactly why it
+    // was the wrong thing to gate on.
     #expect(coordinator.wordsLoadFailureAtLaunch == .unreadable)
-    #expect(coordinator.savedWordsAreReadable)
+    // The part that matters: the real words are now in hand, so an export
+    // taken at this moment carries them instead of nothing.
+    #expect(coordinator.customWords.contains { $0.canonical == "Kubernetes" })
   }
 
   // MARK: - Stale import commit refreshes the in-memory list (#1679 cloud review)

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
@@ -446,6 +446,50 @@ struct CustomWordsCoordinatorLaunchFailureTests {
     #expect(try Data(contentsOf: url) == bytesBefore)
   }
 
+  // MARK: - Export readability is a live question, not a launch snapshot (#1682)
+
+  @Test("an unreadable file reports as not readable")
+  func savedWordsAreNotReadableWhileTheFileIsUnreadable() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let mgr = CustomWordsManager(fileURL: url)
+    var words = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: url.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    let coordinator = CustomWordsCoordinator(manager: mgr)
+    #expect(coordinator.wordsLoadFailureAtLaunch == .unreadable)
+    #expect(coordinator.savedWordsAreReadable == false)
+  }
+
+  @Test("readability recovers within the session even though the launch flag does not")
+  func savedWordsBecomeReadableAgainAfterTheFileRecovers() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let mgr = CustomWordsManager(fileURL: url)
+    var words = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: url.path)
+
+    let coordinator = CustomWordsCoordinator(manager: mgr)
+    #expect(coordinator.savedWordsAreReadable == false)
+
+    // The file becomes readable again mid-session.
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o600], ofItemAtPath: url.path)
+
+    // The launch flag is a snapshot and stays set — that is what makes it the
+    // wrong thing to gate export on.
+    #expect(coordinator.wordsLoadFailureAtLaunch == .unreadable)
+    #expect(coordinator.savedWordsAreReadable)
+  }
+
   // MARK: - Stale import commit refreshes the in-memory list (#1679 cloud review)
 
   @Test("a stale import commit refreshes the coordinator's list from disk")

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -1,0 +1,179 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1680 (PR-E1) — the portable backup format and its writer.
+@MainActor
+@Suite("CustomWordsTransferDocument")
+struct CustomWordsTransferDocumentTests {
+
+  private func word(
+    _ canonical: String,
+    aliases: [String] = [],
+    category: WordCategory = .general,
+    priority: Int = 0,
+    forceReplace: Bool = false,
+    caseSensitive: Bool = false,
+    source: WordSource = .user,
+    frequencyUsed: Int = 0,
+    lastUsed: Date? = nil,
+    minSimilarityOverride: Double? = nil
+  ) -> CustomWord {
+    CustomWord(
+      canonical: canonical, aliases: aliases, category: category, priority: priority,
+      forceReplace: forceReplace, caseSensitive: caseSensitive, source: source,
+      frequencyUsed: frequencyUsed, lastUsed: lastUsed,
+      minSimilarityOverride: minSimilarityOverride)
+  }
+
+  // MARK: - Round trip
+
+  @Test("every portable field survives an export and re-decode")
+  func exportRoundTripPreservesEveryPortableField() throws {
+    let original = word(
+      "Kubernetes", aliases: ["k8s", "kube"], category: .brand, priority: 3,
+      forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.8)
+    let data = try CustomWordsTransferDocument(words: [original]).encoded()
+    let decoded = try CustomWordsTransferDocument(data: data)
+
+    let restored = try #require(decoded.words.first)
+    #expect(restored.canonical == "Kubernetes")
+    #expect(restored.aliases == ["k8s", "kube"])
+    #expect(restored.category == .brand)
+    #expect(restored.priority == 3)
+    #expect(restored.forceReplace == true)
+    #expect(restored.caseSensitive == true)
+    #expect(restored.minSimilarityOverride == 0.8)
+    #expect(restored.id == original.id)
+  }
+
+  @Test("usage history never leaves this Mac")
+  func exportOmitsUsageHistoryAndRuntimeSource() throws {
+    let used = word("Kubernetes", frequencyUsed: 42, lastUsed: Date(timeIntervalSince1970: 1))
+    let data = try CustomWordsTransferDocument(words: [used]).encoded()
+    let json = try #require(String(data: data, encoding: .utf8))
+
+    #expect(!json.contains("frequencyUsed"))
+    #expect(!json.contains("lastUsed"))
+    #expect(!json.contains("source"))
+  }
+
+  @Test("an empty word list is a valid backup, not an error")
+  func emptyWordListIsAValidBackup() throws {
+    let data = try CustomWordsTransferDocument(words: []).encoded()
+    let decoded = try CustomWordsTransferDocument(data: data)
+    #expect(decoded.words.isEmpty)
+    #expect(decoded.format == CustomWordsTransferDocument.formatIdentifier)
+    #expect(decoded.version == CustomWordsTransferDocument.currentVersion)
+  }
+
+  // MARK: - Decode rejection
+
+  @Test("a JSON file that isn't ours is rejected by name, not called damaged")
+  func decoderRejectsWrongFormatIdentifier() throws {
+    let foreign = Data(#"{"format":"com.example.other","version":1,"words":[]}"#.utf8)
+    #expect(throws: CustomWordsTransferError.notAnEnviousWisprBackup) {
+      _ = try CustomWordsTransferDocument(data: foreign)
+    }
+  }
+
+  @Test("a backup from a newer app version is refused rather than guessed at")
+  func decoderRejectsUnsupportedFutureVersion() throws {
+    let future = Data(
+      #"{"format":"com.enviouswispr.custom-words","version":99,"words":[]}"#.utf8)
+    #expect(throws: CustomWordsTransferError.unsupportedVersion(99)) {
+      _ = try CustomWordsTransferDocument(data: future)
+    }
+  }
+
+  @Test("damaged bytes read as damaged")
+  func decoderRejectsMalformedData() throws {
+    #expect(throws: CustomWordsTransferError.malformed) {
+      _ = try CustomWordsTransferDocument(data: Data("not json at all {{{".utf8))
+    }
+  }
+
+  // MARK: - Import handoff
+
+  @Test("candidates supply all six authority fields, including both clears")
+  func candidatesForImportSupplyAllSixAuthorityFieldsIncludingClears() throws {
+    // A word with no aliases and no per-term strictness. Backup is the only
+    // source that can say "genuinely none" rather than "no opinion", and on a
+    // Replace that difference decides whether hand-tuned values are cleared.
+    let bare = word("Kubernetes", aliases: [], minSimilarityOverride: nil)
+    let candidates = CustomWordsTransferDocument(words: [bare]).candidatesForImport()
+    let candidate = try #require(candidates.first)
+
+    #expect(candidate.aliases == .supplied([]))
+    #expect(candidate.minSimilarityOverride == .supplied(nil))
+    #expect(candidate.category == .supplied(.general))
+    #expect(candidate.priority == .supplied(0))
+    #expect(candidate.forceReplace == .supplied(false))
+    #expect(candidate.caseSensitive == .supplied(false))
+  }
+
+  @Test("candidates carry no usage history and no AI suggestions")
+  func candidatesForImportResetsUsageHistory() throws {
+    let used = word("Kubernetes", frequencyUsed: 9, lastUsed: Date())
+    let candidate = try #require(
+      CustomWordsTransferDocument(words: [used]).candidatesForImport().first)
+    // The candidate type structurally cannot carry usage history; this asserts
+    // the suggestion channel is also empty, so nothing machine-generated rides
+    // in on a restore.
+    #expect(candidate.suggestedAliases.isEmpty)
+  }
+
+  @Test("a foreign id is review identity only")
+  func candidatesForImportPreservesForeignIDAsReviewIdentityOnly() throws {
+    let original = word("Kubernetes")
+    let data = try CustomWordsTransferDocument(words: [original]).encoded()
+    let candidate = try #require(
+      try CustomWordsTransferDocument(data: data).candidatesForImport().first)
+    // It round-trips so the review row is stable, but the commit path mints a
+    // fresh UUID on add and keeps the local word's UUID on replace — this id
+    // never becomes a persisted local identity.
+    #expect(candidate.id == original.id)
+  }
+
+  // MARK: - Built-in tagging (the export-scope prerequisite)
+
+  @Test("every built-in is constructed tagged as built-in")
+  func builtinDefaultsAreAllConstructedWithBuiltinSource() {
+    #expect(CustomWordsManager.builtinDefaults.isEmpty == false)
+    for builtin in CustomWordsManager.builtinDefaults {
+      #expect(
+        builtin.word.source == .builtin,
+        "built-in '\(builtin.id)' is untagged and would export as a user word")
+    }
+  }
+
+  @Test("re-tagging a built-in as user-owned preserves every other field")
+  func ownedByUserPreservesEveryOtherField() {
+    let builtin = word(
+      "GitHub", aliases: ["git hub"], category: .brand, priority: 2,
+      forceReplace: true, caseSensitive: true, source: .builtin,
+      frequencyUsed: 7, lastUsed: Date(timeIntervalSince1970: 5),
+      minSimilarityOverride: 0.9)
+    let owned = builtin.ownedByUser()
+
+    #expect(owned.source == .user)
+    #expect(owned.id == builtin.id)
+    #expect(owned.canonical == builtin.canonical)
+    #expect(owned.aliases == builtin.aliases)
+    #expect(owned.category == builtin.category)
+    #expect(owned.priority == builtin.priority)
+    #expect(owned.forceReplace == builtin.forceReplace)
+    #expect(owned.caseSensitive == builtin.caseSensitive)
+    #expect(owned.frequencyUsed == builtin.frequencyUsed)
+    #expect(owned.lastUsed == builtin.lastUsed)
+    #expect(owned.minSimilarityOverride == builtin.minSimilarityOverride)
+  }
+
+  @Test("re-tagging an already-user word returns it unchanged")
+  func ownedByUserIsANoOpForUserWords() {
+    let user = word("Kubernetes", source: .user)
+    #expect(user.ownedByUser() == user)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -88,13 +88,15 @@ struct CustomWordsTransferDocumentTests {
     }
   }
 
-  @Test("a version below the first supported format is refused")
-  func decoderRejectsVersionBelowTheFirstSupportedFormat() throws {
+  @Test("a version below the first supported format reads as damaged, not as newer")
+  func decoderRejectsVersionBelowTheFirstSupportedFormatAsMalformed() throws {
     // Version 1 is the first format; nothing earlier ever existed, so a file
     // claiming 0 is malformed or tampered rather than merely old (review r2).
+    // It must NOT say "made by a newer version — update the app" (review r4):
+    // that is advice which cannot help this user.
     let ancient = Data(
       #"{"format":"com.enviouswispr.custom-words","version":0,"words":[]}"#.utf8)
-    #expect(throws: CustomWordsTransferError.unsupportedVersion(0)) {
+    #expect(throws: CustomWordsTransferError.malformed) {
       _ = try CustomWordsTransferDocument(data: ancient)
     }
   }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -125,16 +125,25 @@ struct CustomWordsTransferDocumentTests {
     #expect(candidate.suggestedAliases.isEmpty)
   }
 
-  @Test("a foreign id is review identity only")
-  func candidatesForImportPreservesForeignIDAsReviewIdentityOnly() throws {
+  @Test("a candidate never carries the exported persistence id")
+  func candidatesForImportMintsFreshReviewIdentities() throws {
     let original = word("Kubernetes")
     let data = try CustomWordsTransferDocument(words: [original]).encoded()
     let candidate = try #require(
       try CustomWordsTransferDocument(data: data).candidatesForImport().first)
-    // It round-trips so the review row is stable, but the commit path mints a
-    // fresh UUID on add and keeps the local word's UUID on replace — this id
-    // never becomes a persisted local identity.
-    #expect(candidate.id == original.id)
+
+    // Restoring onto the Mac that wrote the backup would otherwise make the
+    // candidate id equal the live word's id, and the collision detector would
+    // report each word's own aliases as colliding with itself (code review).
+    #expect(candidate.id != original.id)
+  }
+
+  @Test("two candidates from one backup have distinct review identities")
+  func candidatesForImportGivesEachRowItsOwnIdentity() throws {
+    let candidates = CustomWordsTransferDocument(
+      words: [word("Kubernetes"), word("Anthropic")]
+    ).candidatesForImport()
+    #expect(Set(candidates.map(\.id)).count == 2)
   }
 
   // MARK: - Built-in tagging (the export-scope prerequisite)

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -88,6 +88,17 @@ struct CustomWordsTransferDocumentTests {
     }
   }
 
+  @Test("a version below the first supported format is refused")
+  func decoderRejectsVersionBelowTheFirstSupportedFormat() throws {
+    // Version 1 is the first format; nothing earlier ever existed, so a file
+    // claiming 0 is malformed or tampered rather than merely old (review r2).
+    let ancient = Data(
+      #"{"format":"com.enviouswispr.custom-words","version":0,"words":[]}"#.utf8)
+    #expect(throws: CustomWordsTransferError.unsupportedVersion(0)) {
+      _ = try CustomWordsTransferDocument(data: ancient)
+    }
+  }
+
   @Test("damaged bytes read as damaged")
   func decoderRejectsMalformedData() throws {
     #expect(throws: CustomWordsTransferError.malformed) {

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -99,6 +99,21 @@ struct CustomWordsTransferDocumentTests {
     }
   }
 
+  @Test("a future version is reported as newer, not as damaged")
+  func futureVersionWithUnknownPayloadReportsVersionNotDamage() throws {
+    // The header is judged before the payload (review r3), so a future format
+    // that changed a word field still gets the honest "update the app"
+    // message instead of "your backup is damaged".
+    let future = Data(
+      """
+      {"format":"com.enviouswispr.custom-words","version":99,
+       "words":[{"somethingNew":true}]}
+      """.utf8)
+    #expect(throws: CustomWordsTransferError.unsupportedVersion(99)) {
+      _ = try CustomWordsTransferDocument(data: future)
+    }
+  }
+
   @Test("damaged bytes read as damaged")
   func decoderRejectsMalformedData() throws {
     #expect(throws: CustomWordsTransferError.malformed) {


### PR DESCRIPTION
Part of #1619. Closes #1680.

## What this is

A versioned JSON backup of the words you authored, re-importable by PR-U1. Export button on Your Words, DEBUG-gated like the import doorway.

## Scope: your words only

Exports `source == .user`. A "full backup" including built-ins would need import to *delete* built-ins on restore, and the review model deliberately has no delete operation — a backup whose restore path cannot express part of its own content is a broken promise. Deleted-built-in tombstones are a named non-goal, frozen by test.

## Two prerequisite fixes carried here

Both runtime-only; `source` stays out of `CodingKeys` and decode always yields `.user`, so nothing on disk changes.

1. **Built-ins were untagged**, so an export filter could not tell them from user words. Now stamped at the single `BuiltinWord` construction point rather than at 11 call sites — a future built-in cannot ship untagged.
2. **Editing a built-in kept the `.builtin` tag until relaunch**, so an export taken right after the edit silently omitted the user's own change. Re-tagged once, before both the file write and the in-memory publish. The first version of this fix covered only the file copy; the round-trip test caught it.

## Review record — 7 rounds, every one found something real

| Round | Finding |
|---|---|
| r1 | **Privacy:** overwriting an existing export inherited its permissions, leaving a backup of personal names world-readable. Same-Mac restore reported each word's aliases as colliding with itself. |
| r1→r2 | Fixing the move race left a catch-all fallback that would **replace a directory and delete its contents**. |
| r2 | Version check was upper-bound only; a file claiming version 0 imported under an undefined schema. |
| r3 | **Export after a failed load wrote a valid EMPTY backup**, able to overwrite a good one while the banner said nothing was deleted. Future-version backups reported as "damaged" instead of "update the app". |
| r4 | Pre-v1 files got the future-version message — advice that cannot help that user. |
| r5 | Export I/O ran on the main actor; a slow or network destination froze the settings window. |
| r6 | Directory refusal was correct but **not atomic**. |
| r7 | **Clean.** |

Round 6's fix removed code rather than adding it: a single `rename(2)` publishes the file atomically, refuses a directory by kernel guarantee, and keeps the temp file's `0600` instead of inheriting the destination's mode — replacing the entire move/replace/check/chmod sequence and closing r1, r2, and r6 by construction.

## Validation

3,347 tests green. Round-trip tested here rather than deferred to U1, because otherwise the PR making the "you can restore this" promise would not test it.

## Known gap, recorded in a test

Restoring an edited built-in requires a **replacement**, and the v1 review screen offers Add/Skip only — so that row is Skip-only and the user's edit does not come back. The machinery exists; the offer does not. PR-U1 must surface an alias-merge rather than silently skipping. Frozen in `CustomWordsBackupRoundTripTests` so it reads as a known gap, not a surprise.
