### PR TITLE
feat(user): paste words import (PR-P1, #1681)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -106,6 +106,14 @@ final class CustomWordsImportFlowModel {
   private(set) var staleNotice: String?
   /// Surfaced on the result screen when PR-F2b dropped colliding aliases.
   private(set) var droppedAliasCollisionCount = 0
+  /// What the user typed on the Paste screen (#1681).
+  ///
+  /// Lives here rather than in the screen's own `@State` because the sheet
+  /// rebuilds each screen on every step change: Back from Review would
+  /// otherwise recreate the editor empty and silently discard a list the user
+  /// may have spent real effort assembling. Back exists precisely so they can
+  /// edit it, so the text has to outlive the screen.
+  var pasteDraft = ""
 
   private let dependencies: Dependencies
   /// The library the open review was built against — PR-F2b re-validates it at
@@ -206,6 +214,7 @@ final class CustomWordsImportFlowModel {
     rows = []
     staleNotice = nil
     droppedAliasCollisionCount = 0
+    pasteDraft = ""
     selectedMethod = nil
     step = .methodPicker
   }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -36,11 +36,8 @@ struct CustomWordsImportSheet: View {
           ImportMethodPickerScreen(model: model)
             .transition(Self.screenTransition)
         case .paste:
-          ImportPlaceholderScreen(
-            notice: "Paste import arrives with a later update.",
-            model: model
-          )
-          .transition(Self.screenTransition)
+          ImportPasteScreen(model: model)
+            .transition(Self.screenTransition)
         case .upload:
           ImportPlaceholderScreen(
             notice: "File import arrives with a later update.",
@@ -310,6 +307,67 @@ private struct ImportReviewRowView: View {
     .overlay(
       RoundedRectangle(cornerRadius: 10).strokeBorder(Color.stDivider, lineWidth: 1)
     )
+  }
+}
+
+// MARK: - Paste words (PR-P1)
+
+private struct ImportPasteScreen: View {
+  let model: CustomWordsImportFlowModel
+  @State private var text = ""
+  @FocusState private var isEditorFocused: Bool
+
+  /// Parsed live so the button can name the real outcome instead of promising
+  /// something the parser might not agree with.
+  private var wordCount: Int { PasteWordsParser.parse(text).count }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Paste your words, one per line or separated by commas.")
+        .settingsReadingCopy()
+
+      TextEditor(text: $text)
+        .focused($isEditorFocused)
+        .font(.body)
+        .scrollContentBackground(.hidden)
+        .padding(8)
+        .frame(height: 200)
+        .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(
+          RoundedRectangle(cornerRadius: 10).strokeBorder(Color.stDivider, lineWidth: 1)
+        )
+        .accessibilityLabel("Words to import")
+
+      HStack {
+        // Says what will actually happen, including the two cases people trip
+        // on: nothing typed yet, and duplicates collapsing to fewer words.
+        Text(summary)
+          .font(.stHelper)
+          .foregroundStyle(.stTextSecondary)
+        Spacer(minLength: 0)
+        Button("Continue") {
+          model.begin(with: PasteWordsImportSource(text: text))
+        }
+        .keyboardShortcut(.defaultAction)
+        .buttonStyle(.borderedProminent)
+        .disabled(wordCount == 0)
+      }
+    }
+    .onAppear { isEditorFocused = true }
+  }
+
+  private var summary: String {
+    let count = wordCount
+    switch count {
+    case 0 where text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
+      return "Nothing pasted yet."
+    case 0:
+      return "No words found in that text."
+    case 1:
+      return "1 word ready to review."
+    default:
+      return "\(count) words ready to review."
+    }
   }
 }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -313,20 +313,22 @@ private struct ImportReviewRowView: View {
 // MARK: - Paste words (PR-P1)
 
 private struct ImportPasteScreen: View {
-  let model: CustomWordsImportFlowModel
-  @State private var text = ""
+  @Bindable var model: CustomWordsImportFlowModel
   @FocusState private var isEditorFocused: Bool
 
   /// Parsed live so the button can name the real outcome instead of promising
   /// something the parser might not agree with.
-  private var wordCount: Int { PasteWordsParser.parse(text).count }
+  private var wordCount: Int { PasteWordsParser.parse(model.pasteDraft).count }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       Text("Paste your words, one per line or separated by commas.")
         .settingsReadingCopy()
 
-      TextEditor(text: $text)
+      // Bound to the model, not to local state: the sheet rebuilds this screen
+      // on every step change, so Back from Review would otherwise hand the
+      // user an empty editor and lose their list (code review r1).
+      TextEditor(text: $model.pasteDraft)
         .focused($isEditorFocused)
         .font(.body)
         .scrollContentBackground(.hidden)
@@ -346,7 +348,7 @@ private struct ImportPasteScreen: View {
           .foregroundStyle(.stTextSecondary)
         Spacer(minLength: 0)
         Button("Continue") {
-          model.begin(with: PasteWordsImportSource(text: text))
+          model.begin(with: PasteWordsImportSource(text: model.pasteDraft))
         }
         .keyboardShortcut(.defaultAction)
         .buttonStyle(.borderedProminent)
@@ -359,7 +361,7 @@ private struct ImportPasteScreen: View {
   private var summary: String {
     let count = wordCount
     switch count {
-    case 0 where text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
+    case 0 where model.pasteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
       return "Nothing pasted yet."
     case 0:
       return "No words found in that text."

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -44,9 +44,21 @@ struct YourWordsView: View {
           Label("Add term", systemImage: "plus")
         }
         #if DEBUG
-          // Import shell fixture walk (#1657). DEBUG-only until a real import
-          // source ships — a release-visible entry whose screens only show
-          // fixtures would ship a broken promise.
+          // The ONLY doorway into Custom Words import, and deliberately
+          // DEBUG-only.
+          //
+          // This is founder policy, not an oversight or an unfinished edge
+          // (epic #1619, restated 2026-07-19): the whole import feature is
+          // compiled out of release builds until the founder decides it ships,
+          // and every import PR carries "adds no second entry point" in its
+          // definition of done. The mechanism is compile-time exclusion rather
+          // than a runtime toggle precisely because a runtime toggle ships in
+          // release and is user-discoverable — the exact bleed being avoided.
+          //
+          // Reviewers reasonably read a real, working, unreachable feature as
+          // a bug — it was raised as a P1 on #1681 — so the reason lives here,
+          // next to the gate, rather than only in the issue tracker. Removing
+          // this gate is a founder decision, not a code-review one.
           Button {
             sheetRoute = .importWords
           } label: {

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -1,0 +1,65 @@
+import EnviousWisprCore
+import Foundation
+
+/// Turns pasted text into import candidates (#1681, PR-P1).
+///
+/// Deterministic and total: no model call, no network, no availability check.
+/// Whatever the user pasted either becomes a word or is honestly reported as
+/// nothing to import.
+///
+/// **v1 ships no on-device variant suggestions.** The adopted plan pairs Paste
+/// with `WordSuggestionService`, and that stage remains the right design — a
+/// pipeline step between compare and review, filling the candidate's
+/// never-authoritative `suggestedAliases` channel. It is deliberately deferred
+/// so the plain path can be proven first; nothing here forecloses it.
+package enum PasteWordsParser {
+  /// Separators, and only these.
+  ///
+  /// Semicolon, slash, hyphen, and plain space are deliberately NOT separators:
+  /// "Envious Labs" is one word, "C++"/"C#"/".NET" must survive intact, and a
+  /// hyphenated surname is not two people. Being conservative here is why the
+  /// user can paste a messy list and still get what they meant — a wrong split
+  /// silently invents words nobody typed.
+  private static let separators = CharacterSet(charactersIn: ",\n\r")
+
+  package static func parse(_ text: String) -> [String] {
+    var seen = Set<String>()
+    var results: [String] = []
+
+    for piece in text.components(separatedBy: separators) {
+      let trimmed = piece.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else { continue }
+      // Deduplicate on the compare engine's own key, so "GitHub" and "github"
+      // in one paste collapse the same way they would against the library —
+      // and the FIRST spelling wins, because that is the one the user typed
+      // first and has no reason to see replaced by a later casing.
+      let key = CustomWordsImportCompareEngine.normalize(trimmed)
+      guard !key.isEmpty, seen.insert(key).inserted else { continue }
+      results.append(trimmed)
+    }
+    return results
+  }
+}
+
+/// The pasted-text import source.
+package struct PasteWordsImportSource: CustomWordsImportSource {
+  package static let sourceID = "paste"
+
+  private let text: String
+
+  package init(text: String) {
+    self.text = text
+  }
+
+  package func loadCandidates() async throws -> CustomWordsImportBatch {
+    let canonicals = PasteWordsParser.parse(text)
+    return CustomWordsImportBatch(
+      sourceID: Self.sourceID,
+      sourceDisplayName: "Pasted words",
+      // Every authority field stays `.unspecified`: pasted text carries no
+      // alias data and no opinion about category, priority, strictness, or
+      // case sensitivity, so a Replace built from it must never claim to.
+      candidates: canonicals.map { CustomWordsImportCandidate(canonical: $0) }
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
@@ -169,4 +169,34 @@ struct CustomWordsImportFlowModelTests {
     #expect(failed.step == .result(.failed(message: "could not read the file")))
     #expect(nothingFound.step != failed.step)
   }
+
+  // MARK: - Paste draft (#1681)
+
+  @Test("the pasted draft survives going back from review")
+  func pasteDraftSurvivesBackFromReview() {
+    // Back from Review exists so the user can EDIT what they pasted. Holding
+    // the draft in the screen's own state meant the sheet rebuilt an empty
+    // editor and silently discarded the list (code review r1).
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Kubernetes\nAnthropic"
+    model.beginWork(.comparing)
+    model.showReview()
+    #expect(model.step == .review)
+
+    model.goBack()
+
+    #expect(model.step == .paste)
+    #expect(model.pasteDraft == "Kubernetes\nAnthropic")
+  }
+
+  @Test("resetting the sheet clears the pasted draft")
+  func resetClearsThePasteDraft() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Kubernetes"
+    model.reset()
+    #expect(model.pasteDraft.isEmpty)
+    #expect(model.step == .methodPicker)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
@@ -1,0 +1,135 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1681 (PR-P1) — pasted-text parsing.
+///
+/// The parser's job is to be conservative. A missed split costs the user one
+/// edit; a wrong split silently invents words they never typed and quietly
+/// corrupts their dictionary, so the non-separator cases matter more than the
+/// separator ones.
+@Suite("PasteWordsParser")
+struct PasteWordsImportSourceTests {
+
+  // MARK: - Separators
+
+  @Test(
+    "each supported separator splits",
+    arguments: [
+      ("Kubernetes,Anthropic", ["Kubernetes", "Anthropic"]),
+      ("Kubernetes\nAnthropic", ["Kubernetes", "Anthropic"]),
+      ("Kubernetes\r\nAnthropic", ["Kubernetes", "Anthropic"]),
+      ("Kubernetes\rAnthropic", ["Kubernetes", "Anthropic"]),
+      ("Kubernetes, Anthropic,\n Qualtrics", ["Kubernetes", "Anthropic", "Qualtrics"]),
+    ])
+  func supportedSeparatorsSplit(input: String, expected: [String]) {
+    #expect(PasteWordsParser.parse(input) == expected)
+  }
+
+  @Test(
+    "nothing else splits",
+    arguments: [
+      // A space is not a separator: multi-word terms are the common case.
+      ("Envious Labs", ["Envious Labs"]),
+      ("Visual Studio Code", ["Visual Studio Code"]),
+      // Punctuation that lives INSIDE real terms.
+      ("C++", ["C++"]),
+      ("C#", ["C#"]),
+      (".NET", [".NET"]),
+      ("Anand-Vaish", ["Anand-Vaish"]),
+      ("and/or", ["and/or"]),
+      ("Smith; Jones", ["Smith; Jones"]),
+      ("node.js", ["node.js"]),
+    ])
+  func nonSeparatorsAreLeftIntact(input: String, expected: [String]) {
+    #expect(PasteWordsParser.parse(input) == expected)
+  }
+
+  // MARK: - Trimming and empties
+
+  @Test("surrounding whitespace is trimmed, inner spacing is kept")
+  func whitespaceIsTrimmedButNotCollapsed() {
+    #expect(PasteWordsParser.parse("  Envious Labs  ") == ["Envious Labs"])
+  }
+
+  @Test("empty and whitespace-only pieces are dropped")
+  func emptyPiecesAreDropped() {
+    #expect(PasteWordsParser.parse("Kubernetes,,  ,\n\n,Anthropic") == ["Kubernetes", "Anthropic"])
+  }
+
+  @Test(
+    "input with no words yields nothing rather than a blank row",
+    arguments: ["", "   ", "\n\n", ",,,", " , \n , "])
+  func inputWithoutWordsYieldsNothing(input: String) {
+    #expect(PasteWordsParser.parse(input).isEmpty)
+  }
+
+  // MARK: - Deduplication
+
+  @Test("a repeated word appears once, in its first spelling")
+  func withinPasteDedupPreservesFirstSpelling() {
+    #expect(PasteWordsParser.parse("GitHub\ngithub\nGITHUB") == ["GitHub"])
+  }
+
+  @Test("dedup uses the same normalization the compare engine uses")
+  func dedupMatchesCompareEngineNormalization() {
+    // Both collapse to one key in the engine, so they must collapse here too;
+    // otherwise the review screen would show two rows that persistence would
+    // then refuse as duplicates.
+    let parsed = PasteWordsParser.parse("Claude Code\nClaude  Code")
+    #expect(parsed == ["Claude Code"])
+  }
+
+  @Test("distinct words are all kept, in paste order")
+  func distinctWordsKeepPasteOrder() {
+    #expect(
+      PasteWordsParser.parse("Qualtrics\nKubernetes\nAnthropic")
+        == ["Qualtrics", "Kubernetes", "Anthropic"])
+  }
+
+  // MARK: - Source contract
+
+  @Test("the source produces candidates with no authority over any field")
+  func sourceLeavesEveryAuthorityFieldUnspecified() async throws {
+    let batch = try await PasteWordsImportSource(text: "Kubernetes").loadCandidates()
+    let candidate = try #require(batch.candidates.first)
+
+    // Pasted text carries no alias data and no opinions, so a Replace built
+    // from it must never claim authority over a hand-tuned value.
+    #expect(candidate.aliases == .unspecified)
+    #expect(candidate.category == .unspecified)
+    #expect(candidate.priority == .unspecified)
+    #expect(candidate.forceReplace == .unspecified)
+    #expect(candidate.caseSensitive == .unspecified)
+    #expect(candidate.minSimilarityOverride == .unspecified)
+    // v1 ships no on-device suggestions; the channel exists but stays empty.
+    #expect(candidate.suggestedAliases.isEmpty)
+  }
+
+  @Test("the source reports a stable id and carries no notices in v1")
+  func sourceReportsStableIdentityAndNoNotices() async throws {
+    let batch = try await PasteWordsImportSource(text: "Kubernetes, Anthropic")
+      .loadCandidates()
+    #expect(batch.sourceID == "paste")
+    #expect(batch.candidates.map(\.canonical) == ["Kubernetes", "Anthropic"])
+    // Notices exist for the suggestion stage; with no AI call there is nothing
+    // to report, and an empty list is the honest answer rather than a
+    // placeholder notice.
+    #expect(batch.notices.isEmpty)
+  }
+
+  @Test("empty pasted text produces an empty batch, not an error")
+  func emptyTextProducesAnEmptyBatch() async throws {
+    let batch = try await PasteWordsImportSource(text: "   \n  ").loadCandidates()
+    #expect(batch.candidates.isEmpty)
+  }
+
+  @Test("each candidate gets its own identity")
+  func candidatesHaveDistinctIdentities() async throws {
+    let batch = try await PasteWordsImportSource(text: "Kubernetes\nAnthropic\nQualtrics")
+      .loadCandidates()
+    #expect(Set(batch.candidates.map(\.id)).count == 3)
+  }
+}


### PR DESCRIPTION
Part of #1619. Closes #1681.

## What this is

The first import source a real person uses: paste a list, review, add.

## Parsing is deliberately conservative

Splits on **comma, LF, CR** only. It does **not** split on space, semicolon, slash, hyphen, or dot.

"Envious Labs" is one word. `C++`, `C#`, `.NET`, `node.js`, `and/or`, and hyphenated surnames survive intact. A missed split costs the user one edit; a wrong split silently invents words they never typed and corrupts their dictionary — so the non-separator cases carry more weight than the separator ones, and are tested as such.

Within-paste duplicates collapse on the compare engine's own normalization key, first spelling winning. Same key the library uses, so the review screen can never show two rows persistence would reject as one.

Every candidate leaves all six authority fields `.unspecified`: pasted text carries no alias data and no opinion about category, priority, strictness, or case sensitivity, so a Replace built from it could never claim to.

## v1 scope: no on-device suggestions

The adopted plan pairs Paste with `WordSuggestionService`. v1 ships the deterministic half only.

That stage carries a per-word model call with a 5s ceiling, a per-import budget, progress reporting, availability mapping, and cancellation — most of the complexity here, for an enhancement rather than the function. The candidate contract already has the never-authoritative `suggestedAliases` channel, so the fast-follow slots in without rework.

Consistent with the earlier call to drop similar-word matching: cut the richness, keep the thing that works.

## Review record

| Round | Finding |
|---|---|
| r1 | **The pasted draft was lost on Back from Review.** It lived in the screen's own state, and the sheet rebuilds every screen on each step change — so the one path that exists for editing your list silently discarded it. |
| r2 | **P1: "expose paste in release builds."** Rejected — see below. |

### The rejected finding

r2 flagged as P1 that paste works but no release user can reach it. Accurate observation, wrong conclusion: the import feature is compiled out of release builds by founder policy until it ships, and every import PR carries "adds no second entry point" in its DoD. The founder restated it this session — this is being vetted in dev.

The reviewer was reading the code, where that policy was written nowhere. A real, working, unreachable feature is a reasonable thing to flag, and it will be flagged every round until the reason sits next to the gate. It now does, including that removing the gate is a founder decision rather than a code-review one.

## Validation

3,336 tests green. Entry stays the single `#if DEBUG` doorway in Your Words.
