### PR TITLE
feat(user): upload a file — words file and plain text (PR-U1, #1683)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -80,6 +80,20 @@ final class CustomWordsCoordinator {
       customWords = refreshed
       onWordsChanged?(customWords)
     }
+
+    // A corrupted file was ARCHIVED aside at launch, so this reload sees a
+    // legitimately missing file and reports a clean, empty library. That reads
+    // as success but the user's real words are sitting in the archive — and an
+    // export taken now would write an empty backup over the one they picked,
+    // destroying the copy they still had (code review, #1683).
+    //
+    // Once they have authored a word since, they have visibly accepted the
+    // fresh start and are building on it, so the list is theirs again.
+    if wordsLoadFailureAtLaunch == .corrupted,
+      !refreshed.contains(where: { $0.source == .user })
+    {
+      return false
+    }
     return true
   }
 

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -76,23 +76,25 @@ final class CustomWordsCoordinator {
   @discardableResult
   func refreshFromDiskIfPossible() -> Bool {
     guard let refreshed = manager.load() else { return false }
-    if refreshed != customWords {
-      customWords = refreshed
-      onWordsChanged?(customWords)
-    }
 
-    // A corrupted file was ARCHIVED aside at launch, so this reload sees a
-    // legitimately missing file and reports a clean, empty library. That reads
-    // as success but the user's real words are sitting in the archive — and an
-    // export taken now would write an empty backup over the one they picked,
-    // destroying the copy they still had (code review, #1683).
+    // Judge BEFORE publishing (code review r3). A corrupted file was ARCHIVED
+    // aside at launch, so this reload sees a legitimately missing file and
+    // reports a clean, empty library — which reads as success while the user's
+    // real words sit in the archive. Assigning first meant a refresh that
+    // returns false had already mutated live state and fired onWordsChanged,
+    // so "this failed" and "this changed everything" were both true at once.
     //
     // Once they have authored a word since, they have visibly accepted the
-    // fresh start and are building on it, so the list is theirs again.
+    // fresh start and the list is theirs again.
     if wordsLoadFailureAtLaunch == .corrupted,
       !refreshed.contains(where: { $0.source == .user })
     {
       return false
+    }
+
+    if refreshed != customWords {
+      customWords = refreshed
+      onWordsChanged?(customWords)
     }
     return true
   }

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -76,27 +76,30 @@ final class CustomWordsCoordinator {
   @discardableResult
   func refreshFromDiskIfPossible() -> Bool {
     guard let refreshed = manager.load() else { return false }
-
-    // Judge BEFORE publishing (code review r3). A corrupted file was ARCHIVED
-    // aside at launch, so this reload sees a legitimately missing file and
-    // reports a clean, empty library — which reads as success while the user's
-    // real words sit in the archive. Assigning first meant a refresh that
-    // returns false had already mutated live state and fired onWordsChanged,
-    // so "this failed" and "this changed everything" were both true at once.
-    //
-    // Once they have authored a word since, they have visibly accepted the
-    // fresh start and the list is theirs again.
-    if wordsLoadFailureAtLaunch == .corrupted,
-      !refreshed.contains(where: { $0.source == .user })
-    {
-      return false
-    }
-
     if refreshed != customWords {
       customWords = refreshed
       onWordsChanged?(customWords)
     }
     return true
+  }
+
+  /// Whether the current list is a safe thing to WRITE OUT (#1683).
+  ///
+  /// Deliberately separate from `refreshFromDiskIfPossible`, which answers a
+  /// different question — "can I read the library" — and must always adopt
+  /// what it reads. Folding export's refusal into that method re-created the
+  /// stale-commit loop it was written to fix: the import path stopped adopting
+  /// the current library, so every re-comparison saw the same old list and
+  /// Confirm could never succeed (code review r4). Two questions, two answers.
+  ///
+  /// A corrupted file is ARCHIVED aside at launch, so a reload afterwards sees
+  /// a legitimately missing file and reports a clean, empty library. Exporting
+  /// then would write an empty file over the one the user picked while their
+  /// real words sit in the archive. Once they have authored a word since, they
+  /// have visibly accepted the fresh start and the list is theirs again.
+  var canExportCurrentWords: Bool {
+    guard wordsLoadFailureAtLaunch == .corrupted else { return true }
+    return customWords.contains { $0.source == .user }
   }
 
   /// Apply a reviewed import in one atomic write. Fires `onWordsChanged`

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -13,16 +13,6 @@ final class CustomWordsCoordinator {
   /// intact, nothing was changed. `.corrupted`: it was archived for recovery.
   private(set) var wordsLoadFailureAtLaunch: CustomWordsInitialLoadFailure?
 
-  /// Whether the saved-words file can be read RIGHT NOW (#1680).
-  ///
-  /// `wordsLoadFailureAtLaunch` is a snapshot of one moment and stays set for
-  /// the session, so it cannot answer this: a file that was temporarily
-  /// unreadable may be readable again, and a corrupted one has since been
-  /// archived and replaced by a valid empty file the user may have added to.
-  /// Export asks the live question, because refusing forever on a stale flag
-  /// is its own kind of wrong (cloud review, #1682).
-  var savedWordsAreReadable: Bool { manager.load() != nil }
-
   let suggestionService = WordSuggestionService()
   /// The reused on-device alias generator, exposed as the narrow protocol so the
   /// composition root can wire it into the contacts-import coordinator without
@@ -71,6 +61,28 @@ final class CustomWordsCoordinator {
     case failed(message: String)
   }
 
+  /// Re-read the saved words from disk and adopt them, reporting whether the
+  /// list can now be trusted.
+  ///
+  /// One owner for "reload and adopt", used by both callers that need it: the
+  /// stale-commit path (#1679) and the export guard (#1680). Reading without
+  /// adopting is the trap — a readability check that discards what it read
+  /// leaves the caller believing the list is good while it still holds the
+  /// empty launch fallback, which is how export came to overwrite a real
+  /// backup with an empty file (cloud review, #1682).
+  ///
+  /// Fails closed: an unreadable file returns `false` and leaves the current
+  /// list untouched rather than substituting an empty one.
+  @discardableResult
+  func refreshFromDiskIfPossible() -> Bool {
+    guard let refreshed = manager.load() else { return false }
+    if refreshed != customWords {
+      customWords = refreshed
+      onWordsChanged?(customWords)
+    }
+    return true
+  }
+
   /// Apply a reviewed import in one atomic write. Fires `onWordsChanged`
   /// exactly once, and only when something actually changed.
   func commitImport(_ plan: CustomWordsImportCommitPlan) -> CustomWordsImportCommitOutcome {
@@ -92,10 +104,7 @@ final class CustomWordsCoordinator {
       // Fail closed on an unreadable file: keep the current list rather than
       // clobbering it with an empty one. The commit still reports `.stale`,
       // which is honest either way — nothing was written.
-      if let refreshed = manager.load(), refreshed != customWords {
-        customWords = refreshed
-        onWordsChanged?(customWords)
-      }
+      refreshFromDiskIfPossible()
       customWordError = nil
       return .stale
     } catch {

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -12,6 +12,17 @@ final class CustomWordsCoordinator {
   /// honest banner instead of a silent empty list. `.unreadable`: the file is
   /// intact, nothing was changed. `.corrupted`: it was archived for recovery.
   private(set) var wordsLoadFailureAtLaunch: CustomWordsInitialLoadFailure?
+
+  /// Whether the saved-words file can be read RIGHT NOW (#1680).
+  ///
+  /// `wordsLoadFailureAtLaunch` is a snapshot of one moment and stays set for
+  /// the session, so it cannot answer this: a file that was temporarily
+  /// unreadable may be readable again, and a corrupted one has since been
+  /// archived and replaced by a valid empty file the user may have added to.
+  /// Export asks the live question, because refusing forever on a stale flag
+  /// is its own kind of wrong (cloud review, #1682).
+  var savedWordsAreReadable: Bool { manager.load() != nil }
+
   let suggestionService = WordSuggestionService()
   /// The reused on-device alias generator, exposed as the narrow protocol so the
   /// composition root can wire it into the contacts-import coordinator without

--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -106,6 +106,14 @@ final class CustomWordsImportFlowModel {
   private(set) var staleNotice: String?
   /// Surfaced on the result screen when PR-F2b dropped colliding aliases.
   private(set) var droppedAliasCollisionCount = 0
+  /// What the user typed on the Paste screen (#1681).
+  ///
+  /// Lives here rather than in the screen's own `@State` because the sheet
+  /// rebuilds each screen on every step change: Back from Review would
+  /// otherwise recreate the editor empty and silently discard a list the user
+  /// may have spent real effort assembling. Back exists precisely so they can
+  /// edit it, so the text has to outlive the screen.
+  var pasteDraft = ""
 
   private let dependencies: Dependencies
   /// The library the open review was built against — PR-F2b re-validates it at
@@ -206,6 +214,7 @@ final class CustomWordsImportFlowModel {
     rows = []
     staleNotice = nil
     droppedAliasCollisionCount = 0
+    pasteDraft = ""
     selectedMethod = nil
     step = .methodPicker
   }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
@@ -11,7 +11,7 @@ enum CustomWordsExportPanel {
     let panel = NSSavePanel()
     panel.title = "Export your words"
     panel.prompt = "Export"
-    panel.nameFieldStringValue = "EnviousWispr Custom Words.json"
+    panel.nameFieldStringValue = "EnviousWispr Words.json"
     panel.allowedContentTypes = [.json]
     panel.canCreateDirectories = true
     panel.isExtensionHidden = false

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
@@ -1,0 +1,26 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// The app's first save panel (#1680, PR-E1).
+///
+/// Nothing is read from the word list until this returns a destination, so
+/// cancelling is a clean no-op rather than a snapshot taken and thrown away.
+@MainActor
+enum CustomWordsExportPanel {
+  static func chooseDestination() -> URL? {
+    let panel = NSSavePanel()
+    panel.title = "Export your words"
+    panel.prompt = "Export"
+    panel.nameFieldStringValue = "EnviousWispr Custom Words.json"
+    panel.allowedContentTypes = [.json]
+    panel.canCreateDirectories = true
+    panel.isExtensionHidden = false
+    // Said before the choice, not after: the file lands wherever the user
+    // points it, including a synced folder, and it can contain real names.
+    panel.message =
+      "Exported files may contain personal names and other private terms. "
+      + "Usage history is not included."
+
+    return panel.runModal() == .OK ? panel.url : nil
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
@@ -1,0 +1,24 @@
+import AppKit
+import EnviousWisprPostProcessing
+import UniformTypeIdentifiers
+
+/// The open panel for choosing a file to import (#1683, PR-U1).
+///
+/// Content types come from the parser registry rather than a hardcoded list,
+/// so registering a new format also makes it selectable — no second place to
+/// update and no chance of offering a file the app then refuses to read.
+@MainActor
+enum CustomWordsImportFilePanel {
+  static func chooseFile(registry: ImportFileRegistry = .v1) -> URL? {
+    let panel = NSOpenPanel()
+    panel.title = "Choose a file to import"
+    panel.prompt = "Import"
+    panel.message = "Choose an EnviousWispr backup or a plain text list of words."
+    panel.allowedContentTypes = registry.acceptedContentTypes
+    panel.allowsMultipleSelection = false
+    panel.canChooseDirectories = false
+    panel.canChooseFiles = true
+
+    return panel.runModal() == .OK ? panel.url : nil
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
@@ -13,7 +13,7 @@ enum CustomWordsImportFilePanel {
     let panel = NSOpenPanel()
     panel.title = "Choose a file to import"
     panel.prompt = "Import"
-    panel.message = "Choose an EnviousWispr backup or a plain text list of words."
+    panel.message = "Choose a file you exported from EnviousWispr, or a plain text list of words."
     panel.allowedContentTypes = registry.acceptedContentTypes
     panel.allowsMultipleSelection = false
     panel.canChooseDirectories = false

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -39,11 +39,8 @@ struct CustomWordsImportSheet: View {
           ImportPasteScreen(model: model)
             .transition(Self.screenTransition)
         case .upload:
-          ImportPlaceholderScreen(
-            notice: "File import arrives with a later update.",
-            model: model
-          )
-          .transition(Self.screenTransition)
+          ImportUploadScreen(model: model)
+            .transition(Self.screenTransition)
         case .smartImportAppPicker:
           ImportPlaceholderScreen(
             notice: "Importing from other apps arrives with a later update.",
@@ -369,6 +366,34 @@ private struct ImportPasteScreen: View {
       return "1 word ready to review."
     default:
       return "\(count) words ready to review."
+    }
+  }
+}
+
+// MARK: - Upload a file (PR-U1)
+
+private struct ImportUploadScreen: View {
+  let model: CustomWordsImportFlowModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Choose an EnviousWispr backup to restore, or a plain text list of words.")
+        .settingsReadingCopy()
+
+      Button {
+        // The panel is opened first and the file read only after a choice, so
+        // cancelling reads nothing and starts no work.
+        if let url = CustomWordsImportFilePanel.chooseFile() {
+          model.begin(with: FileImportSource(url: url))
+        }
+      } label: {
+        Label("Choose a file", systemImage: "folder")
+      }
+      .buttonStyle(.borderedProminent)
+
+      Text("Spreadsheets aren't supported yet.")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -161,7 +161,7 @@ private struct ImportMethodPickerScreen: View {
       ImportMethodCard(
         icon: "square.and.arrow.down",
         title: "Upload a file",
-        subtitle: "Import a backup or a spreadsheet of words."
+        subtitle: "Import words from a file you exported, or a list."
       ) {
         model.select(.upload)
       }
@@ -372,13 +372,23 @@ private struct ImportPasteScreen: View {
 
 // MARK: - Upload a file (PR-U1)
 
+/// Deliberately never says "restore" (founder, 2026-07-19).
+///
+/// v1 import ADDS words you don't have and SKIPS ones you do, leaving existing
+/// words and their alternate spellings completely untouched. "Restore" would
+/// promise that a word you had edited comes back as it was, which is exactly
+/// the overwriting this scope rules out. The screen says what it does.
 private struct ImportUploadScreen: View {
   let model: CustomWordsImportFlowModel
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text("Choose an EnviousWispr backup to restore, or a plain text list of words.")
+      Text("Choose a file you exported from EnviousWispr, or a plain text list of words.")
         .settingsReadingCopy()
+
+      Text("Words you already have are left exactly as they are.")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
 
       Button {
         // The panel is opened first and the file read only after a choice, so

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -313,9 +313,12 @@ private struct ImportPasteScreen: View {
   @Bindable var model: CustomWordsImportFlowModel
   @FocusState private var isEditorFocused: Bool
 
-  /// Parsed live so the button can name the real outcome instead of promising
-  /// something the parser might not agree with.
-  private var wordCount: Int { PasteWordsParser.parse(model.pasteDraft).count }
+  /// Recomputed when the draft changes, NOT on every render (code review r2).
+  ///
+  /// As a computed property this re-parsed the entire draft on every view
+  /// update, on the main actor — so a large pasted list made the editor
+  /// progressively less responsive the more it contained.
+  @State private var wordCount = 0
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -352,7 +355,15 @@ private struct ImportPasteScreen: View {
         .disabled(wordCount == 0)
       }
     }
-    .onAppear { isEditorFocused = true }
+    .onAppear {
+      isEditorFocused = true
+      // Back from Review returns to an existing draft, so the count has to be
+      // right on arrival, not only after the next keystroke.
+      wordCount = PasteWordsParser.parse(model.pasteDraft).count
+    }
+    .onChange(of: model.pasteDraft) { _, draft in
+      wordCount = PasteWordsParser.parse(draft).count
+    }
   }
 
   private var summary: String {

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -36,11 +36,8 @@ struct CustomWordsImportSheet: View {
           ImportMethodPickerScreen(model: model)
             .transition(Self.screenTransition)
         case .paste:
-          ImportPlaceholderScreen(
-            notice: "Paste import arrives with a later update.",
-            model: model
-          )
-          .transition(Self.screenTransition)
+          ImportPasteScreen(model: model)
+            .transition(Self.screenTransition)
         case .upload:
           ImportPlaceholderScreen(
             notice: "File import arrives with a later update.",
@@ -310,6 +307,67 @@ private struct ImportReviewRowView: View {
     .overlay(
       RoundedRectangle(cornerRadius: 10).strokeBorder(Color.stDivider, lineWidth: 1)
     )
+  }
+}
+
+// MARK: - Paste words (PR-P1)
+
+private struct ImportPasteScreen: View {
+  let model: CustomWordsImportFlowModel
+  @State private var text = ""
+  @FocusState private var isEditorFocused: Bool
+
+  /// Parsed live so the button can name the real outcome instead of promising
+  /// something the parser might not agree with.
+  private var wordCount: Int { PasteWordsParser.parse(text).count }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Paste your words, one per line or separated by commas.")
+        .settingsReadingCopy()
+
+      TextEditor(text: $text)
+        .focused($isEditorFocused)
+        .font(.body)
+        .scrollContentBackground(.hidden)
+        .padding(8)
+        .frame(height: 200)
+        .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(
+          RoundedRectangle(cornerRadius: 10).strokeBorder(Color.stDivider, lineWidth: 1)
+        )
+        .accessibilityLabel("Words to import")
+
+      HStack {
+        // Says what will actually happen, including the two cases people trip
+        // on: nothing typed yet, and duplicates collapsing to fewer words.
+        Text(summary)
+          .font(.stHelper)
+          .foregroundStyle(.stTextSecondary)
+        Spacer(minLength: 0)
+        Button("Continue") {
+          model.begin(with: PasteWordsImportSource(text: text))
+        }
+        .keyboardShortcut(.defaultAction)
+        .buttonStyle(.borderedProminent)
+        .disabled(wordCount == 0)
+      }
+    }
+    .onAppear { isEditorFocused = true }
+  }
+
+  private var summary: String {
+    let count = wordCount
+    switch count {
+    case 0 where text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
+      return "Nothing pasted yet."
+    case 0:
+      return "No words found in that text."
+    case 1:
+      return "1 word ready to review."
+    default:
+      return "\(count) words ready to review."
+    }
   }
 }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -313,20 +313,22 @@ private struct ImportReviewRowView: View {
 // MARK: - Paste words (PR-P1)
 
 private struct ImportPasteScreen: View {
-  let model: CustomWordsImportFlowModel
-  @State private var text = ""
+  @Bindable var model: CustomWordsImportFlowModel
   @FocusState private var isEditorFocused: Bool
 
   /// Parsed live so the button can name the real outcome instead of promising
   /// something the parser might not agree with.
-  private var wordCount: Int { PasteWordsParser.parse(text).count }
+  private var wordCount: Int { PasteWordsParser.parse(model.pasteDraft).count }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       Text("Paste your words, one per line or separated by commas.")
         .settingsReadingCopy()
 
-      TextEditor(text: $text)
+      // Bound to the model, not to local state: the sheet rebuilds this screen
+      // on every step change, so Back from Review would otherwise hand the
+      // user an empty editor and lose their list (code review r1).
+      TextEditor(text: $model.pasteDraft)
         .focused($isEditorFocused)
         .font(.body)
         .scrollContentBackground(.hidden)
@@ -346,7 +348,7 @@ private struct ImportPasteScreen: View {
           .foregroundStyle(.stTextSecondary)
         Spacer(minLength: 0)
         Button("Continue") {
-          model.begin(with: PasteWordsImportSource(text: text))
+          model.begin(with: PasteWordsImportSource(text: model.pasteDraft))
         }
         .keyboardShortcut(.defaultAction)
         .buttonStyle(.borderedProminent)
@@ -359,7 +361,7 @@ private struct ImportPasteScreen: View {
   private var summary: String {
     let count = wordCount
     switch count {
-    case 0 where text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
+    case 0 where model.pasteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
       return "Nothing pasted yet."
     case 0:
       return "No words found in that text."

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -132,6 +132,19 @@ struct YourWordsView: View {
     /// Built-ins are excluded; what ships is what the user authored or edited,
     /// which is the only scope whose restore path this app can actually honor.
     private func exportWords() {
+      // Refuse to export what we could not read (code review r3). When the
+      // launch-time load fails the coordinator holds an empty list while the
+      // real file may still be on disk or archived for recovery. Exporting
+      // then writes a VALID EMPTY backup — and can overwrite a good one — so
+      // the failure would destroy the very thing the user came here to save.
+      // The banner already explains the load failure; this says why the button
+      // did nothing.
+      if customWordsCoordinator.wordsLoadFailureAtLaunch != nil {
+        exportError =
+          "Your saved words couldn't be read this time, so there's nothing safe to export. "
+          + "Relaunch EnviousWispr and try again."
+        return
+      }
       guard let destination = CustomWordsExportPanel.chooseDestination() else { return }
       let userWords = customWordsCoordinator.customWords.filter { $0.source == .user }
       do {

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -144,7 +144,14 @@ struct YourWordsView: View {
       // list stayed the empty launch fallback, so export wrote a valid empty
       // file over a real one (cloud review, #1682). A corrupted-and-archived
       // library refuses here rather than exporting the empty shell left behind.
-      guard customWordsCoordinator.refreshFromDiskIfPossible() else {
+      // Adopt what is on disk, THEN judge whether it is safe to write out.
+      // Two separate questions: the reload must always adopt (the import path
+      // depends on it), while export additionally refuses the empty shell left
+      // behind by a corrupted-and-archived library.
+      guard
+        customWordsCoordinator.refreshFromDiskIfPossible(),
+        customWordsCoordinator.canExportCurrentWords
+      else {
         exportError =
           "Your saved words couldn't be read this time, so there's nothing safe to export. "
           + "Relaunch EnviousWispr and try again."

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -132,24 +132,25 @@ struct YourWordsView: View {
     /// Built-ins are excluded; what ships is what the user authored or edited,
     /// which is the only scope whose restore path this app can actually honor.
     private func exportWords() {
-      // Refuse to export what we could not read (code review r3). When the
-      // launch-time load fails the coordinator holds an empty list while the
-      // real file may still be on disk or archived for recovery. Exporting
-      // then writes a VALID EMPTY backup — and can overwrite a good one — so
-      // the failure would destroy the very thing the user came here to save.
-      // The banner already explains the load failure; this says why the button
-      // did nothing.
-      // Reload AND adopt before deciding. Merely checking that the file is
+      // Ask WHERE first, and only then touch anything (code review r3).
+      // Refreshing before the panel meant that opening Export and cancelling
+      // still reloaded the list and fired onWordsChanged — a "clean no-op"
+      // that quietly changed live state, which is the opposite of what
+      // cancelling should mean.
+      guard let destination = CustomWordsExportPanel.chooseDestination() else { return }
+
+      // Reload AND adopt before writing. Merely checking that the file is
       // readable was worse than refusing outright: the check passed while the
       // list stayed the empty launch fallback, so export wrote a valid empty
-      // backup over a real one (cloud review, #1682).
-      if !customWordsCoordinator.refreshFromDiskIfPossible() {
+      // file over a real one (cloud review, #1682). A corrupted-and-archived
+      // library refuses here rather than exporting the empty shell left behind.
+      guard customWordsCoordinator.refreshFromDiskIfPossible() else {
         exportError =
           "Your saved words couldn't be read this time, so there's nothing safe to export. "
           + "Relaunch EnviousWispr and try again."
         return
       }
-      guard let destination = CustomWordsExportPanel.chooseDestination() else { return }
+
       // Snapshot on the main actor, write off it (code review r5). The list is
       // read here, synchronously, so the file reflects the moment the user
       // confirmed rather than whenever the write happened to run; only the

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -139,7 +139,7 @@ struct YourWordsView: View {
       // the failure would destroy the very thing the user came here to save.
       // The banner already explains the load failure; this says why the button
       // did nothing.
-      if customWordsCoordinator.wordsLoadFailureAtLaunch != nil {
+      if !customWordsCoordinator.savedWordsAreReadable {
         exportError =
           "Your saved words couldn't be read this time, so there's nothing safe to export. "
           + "Relaunch EnviousWispr and try again."

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -24,6 +24,10 @@ struct YourWordsView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var sheetRoute: YourWordsSheetRoute?
+  #if DEBUG
+    /// Set when an export failed, so the failure is stated rather than silent.
+    @State private var exportError: String?
+  #endif
 
   var body: some View {
     @Bindable var settings = settings
@@ -52,6 +56,13 @@ struct YourWordsView: View {
           } label: {
             Label("Preview import", systemImage: "square.and.arrow.down")
           }
+          // Export (#1680). Also DEBUG-only: the whole import/export feature is
+          // compiled out of release builds until the founder ships it, and a
+          // release-visible Export whose companion Import is invisible would be
+          // half a promise.
+          Button(action: exportWords) {
+            Label("Export your words", systemImage: "square.and.arrow.up")
+          }
         #endif
       }
 
@@ -78,6 +89,19 @@ struct YourWordsView: View {
       VocabPacksSection()
       CustomTermsSection()
     }
+    #if DEBUG
+      .alert(
+        "Export didn't finish",
+        isPresented: Binding(
+          get: { exportError != nil },
+          set: { if !$0 { exportError = nil } }
+        )
+      ) {
+        Button("OK", role: .cancel) { exportError = nil }
+      } message: {
+        Text(exportError ?? "")
+      }
+    #endif
     .sheet(item: $sheetRoute) { route in
       switch route {
       case .addTerm:
@@ -99,6 +123,26 @@ struct YourWordsView: View {
       }
     }
   }
+
+  #if DEBUG
+    /// Export the user's own words (#1680).
+    ///
+    /// Order matters: the destination is chosen first, and only then is the
+    /// word list snapshotted — so cancelling reads nothing and writes nothing.
+    /// Built-ins are excluded; what ships is what the user authored or edited,
+    /// which is the only scope whose restore path this app can actually honor.
+    private func exportWords() {
+      guard let destination = CustomWordsExportPanel.chooseDestination() else { return }
+      let userWords = customWordsCoordinator.customWords.filter { $0.source == .user }
+      do {
+        try CustomWordsExportWriter.write(
+          CustomWordsTransferDocument(words: userWords), to: destination)
+        exportError = nil
+      } catch {
+        exportError = error.localizedDescription
+      }
+    }
+  #endif
 
   private func saveNewWord(_ newWord: CustomWord) -> String? {
     let trimmedCanonical = newWord.canonical.trimmingCharacters(in: .whitespaces)

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -146,13 +146,20 @@ struct YourWordsView: View {
         return
       }
       guard let destination = CustomWordsExportPanel.chooseDestination() else { return }
-      let userWords = customWordsCoordinator.customWords.filter { $0.source == .user }
-      do {
-        try CustomWordsExportWriter.write(
-          CustomWordsTransferDocument(words: userWords), to: destination)
-        exportError = nil
-      } catch {
-        exportError = error.localizedDescription
+      // Snapshot on the main actor, write off it (code review r5). The list is
+      // read here, synchronously, so the file reflects the moment the user
+      // confirmed rather than whenever the write happened to run; only the
+      // filesystem work moves off, so a slow network or cloud destination
+      // cannot freeze the settings window.
+      let document = CustomWordsTransferDocument(
+        words: customWordsCoordinator.customWords.filter { $0.source == .user })
+      Task {
+        do {
+          try await CustomWordsExportWriter.write(document, to: destination)
+          exportError = nil
+        } catch {
+          exportError = error.localizedDescription
+        }
       }
     }
   #endif

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -139,7 +139,11 @@ struct YourWordsView: View {
       // the failure would destroy the very thing the user came here to save.
       // The banner already explains the load failure; this says why the button
       // did nothing.
-      if !customWordsCoordinator.savedWordsAreReadable {
+      // Reload AND adopt before deciding. Merely checking that the file is
+      // readable was worse than refusing outright: the check passed while the
+      // list stayed the empty launch fallback, so export wrote a valid empty
+      // backup over a real one (cloud review, #1682).
+      if !customWordsCoordinator.refreshFromDiskIfPossible() {
         exportError =
           "Your saved words couldn't be read this time, so there's nothing safe to export. "
           + "Relaunch EnviousWispr and try again."

--- a/Sources/EnviousWisprCore/CustomWord.swift
+++ b/Sources/EnviousWisprCore/CustomWord.swift
@@ -73,6 +73,31 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     self.minSimilarityOverride = minSimilarityOverride
   }
 
+  /// The same word, re-tagged as user-authored (#1680).
+  ///
+  /// `source` is a `let`, so re-tagging means reconstructing. Needed where a
+  /// built-in becomes a user override — editing one, or replacing one through
+  /// import — because the value still carries `.builtin` from `builtinDefaults`
+  /// until a relaunch decodes it as `.user`. Export filters on `source ==
+  /// .user`, so without this an override would be missing from its own backup
+  /// until the app restarted.
+  public func ownedByUser() -> CustomWord {
+    guard source != .user else { return self }
+    return CustomWord(
+      id: id,
+      canonical: canonical,
+      aliases: aliases,
+      category: category,
+      priority: priority,
+      forceReplace: forceReplace,
+      caseSensitive: caseSensitive,
+      source: .user,
+      frequencyUsed: frequencyUsed,
+      lastUsed: lastUsed,
+      minSimilarityOverride: minSimilarityOverride
+    )
+  }
+
   // `source` deliberately omitted — keeps persisted JSON byte-equivalent to the
   // pre-Phase-0 schema for the source field. Bible §6.5.
   // `frequencyUsed` + `lastUsed` ARE persisted (Phase 3a, bible §9.2). Forward-

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -113,6 +113,18 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
   }
 }
 
+/// Shared ceilings every import source honours (#1683).
+///
+/// One home so paste and file import cannot drift apart: the compare engine,
+/// the review list, and the commit all pay the same cost per candidate no
+/// matter which door the words came through, so a limit that applies to one
+/// source and not another is an accident waiting to be found by a user.
+package enum CustomWordsImportLimits {
+  /// The compare engine's documented upload ceiling. Beyond this the review
+  /// screen is not something a person can meaningfully read anyway.
+  package static let maximumCandidates = 25_000
+}
+
 package protocol CustomWordsImportSource: Sendable {
   func loadCandidates() async throws -> CustomWordsImportBatch
 }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -33,11 +33,26 @@ package enum CustomWordsExportWriter {
       try handle.write(contentsOf: data)
       try handle.close()
 
-      if fm.fileExists(atPath: destination.path) {
-        _ = try fm.replaceItemAt(destination, withItemAt: tmpURL)
-      } else {
+      // Deliberately NOT `if fileExists { replace } else { move }`. That is a
+      // check-then-act across a window another export can land in: both see no
+      // file, both move, and the loser fails with "already exists". The
+      // concurrency test caught exactly that. Attempt the move, and treat any
+      // failure as "something is there now" and replace it.
+      //
+      // `.usingNewMetadataOnly` is load-bearing, not tidiness (code review):
+      // the default preserves the DESTINATION's metadata, so overwriting an
+      // existing world-readable file would silently discard this temp file's
+      // 0600 and leave a backup full of personal names at 0644.
+      do {
         try fm.moveItem(at: tmpURL, to: destination)
+      } catch {
+        _ = try fm.replaceItemAt(
+          destination, withItemAt: tmpURL, options: [.usingNewMetadataOnly])
       }
+      // Belt and braces: the privacy promise is stated in the save panel, so
+      // enforce it on the final file rather than trusting the replace options
+      // to behave identically on every filesystem (network, external, FAT).
+      try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
     } catch {
       // Best-effort cleanup. An existing destination is left untouched: the
       // replace either happened completely or not at all.

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -10,9 +10,15 @@ import Foundation
 /// once; a shared temp name would let them overwrite each other's partial
 /// bytes and produce one corrupt file.
 package enum CustomWordsExportWriter {
-  package static func write(_ document: CustomWordsTransferDocument, to destination: URL)
-    throws
-  {
+  /// `@concurrent` so this always runs OFF the caller's actor (code review r5).
+  /// The caller is a SwiftUI button action on the main actor, and a plain
+  /// `async` here would inherit that isolation — an export to a network,
+  /// cloud-synced, or external destination would then block the settings
+  /// window until the filesystem finished. It also makes the cancellation
+  /// check below meaningful, which it could not be in a synchronous call.
+  @concurrent package static func write(
+    _ document: CustomWordsTransferDocument, to destination: URL
+  ) async throws {
     let data = try document.encoded()
     let fm = FileManager.default
     let tmpURL =

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /// Writes a backup file to a destination the user chose (#1680, PR-E1).
 ///
-/// Mirrors `CustomWordsManager.saveFile`'s guards — exclusive create, mode
-/// 0600, atomic replace, cleanup on failure — with one deliberate difference:
-/// the temp filename is **unique**, not fixed. The live `custom-words.json`
-/// has exactly one writer, so a fixed `.tmp` sibling is safe there. An export
+/// Same guards as `CustomWordsManager.saveFile` — exclusive create, mode 0600,
+/// atomic publish, cleanup on failure — with one deliberate difference: the
+/// temp filename is **unique**, not fixed. The live `custom-words.json` has
+/// exactly one writer, so a fixed `.tmp` sibling is safe there. An export
 /// destination is a folder the user picked, and two exports can target it at
 /// once; a shared temp name would let them overwrite each other's partial
 /// bytes and produce one corrupt file.
@@ -39,41 +39,34 @@ package enum CustomWordsExportWriter {
       try handle.write(contentsOf: data)
       try handle.close()
 
-      // Deliberately NOT `if fileExists { replace } else { move }`. That is a
-      // check-then-act across a window another export can land in: both see no
-      // file, both move, and the loser fails with "already exists". The
-      // concurrency test caught exactly that. Attempt the move, and treat any
-      // failure as "something is there now" and replace it.
+      // Publish with a single `rename(2)`, which does in ONE atomic step what
+      // three earlier revisions of this function each got partly wrong
+      // (code reviews r1-r6):
       //
-      // `.usingNewMetadataOnly` is load-bearing, not tidiness (code review):
-      // the default preserves the DESTINATION's metadata, so overwriting an
-      // existing world-readable file would silently discard this temp file's
-      // 0600 and leave a backup full of personal names at 0644.
-      do {
-        try fm.moveItem(at: tmpURL, to: destination)
-      } catch {
-        // Replace ONLY a pre-existing regular file. The first version of this
-        // fallback replaced on ANY move failure, which meant that if the
-        // destination path had become a directory, Foundation would replace
-        // the directory with the export file and delete its contents — a
-        // destructive answer to an unrelated error. Anything that is not a
-        // plain file is not ours to overwrite; rethrow the real failure.
-        var isDirectory: ObjCBool = false
-        guard fm.fileExists(atPath: destination.path, isDirectory: &isDirectory),
-          !isDirectory.boolValue
-        else {
-          throw error
-        }
-        _ = try fm.replaceItemAt(
-          destination, withItemAt: tmpURL, options: [.usingNewMetadataOnly])
+      //  - Atomic replace of an existing regular file — no check-then-act
+      //    window where a second export sees "no file" and both try to move.
+      //  - Refuses a directory outright (EISDIR), by the kernel, with no
+      //    gap between deciding and acting. The previous fileExists-then-
+      //    replace guard was correct but not atomic: a cloud-sync client that
+      //    swapped the path to a directory in between could still have had it
+      //    deleted along with its contents.
+      //  - Keeps the temp file's own 0600 rather than inheriting a
+      //    world-readable destination's mode, so a backup full of personal
+      //    names cannot be published readable by everything on the machine.
+      //
+      // Same-directory temp file means same filesystem, which is what makes
+      // rename legal here.
+      guard Foundation.rename(tmpURL.path, destination.path) == 0 else {
+        throw NSError(
+          domain: NSPOSIXErrorDomain, code: Int(errno),
+          userInfo: [
+            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
+            NSFilePathErrorKey: destination.path,
+          ])
       }
-      // Belt and braces: the privacy promise is stated in the save panel, so
-      // enforce it on the final file rather than trusting the replace options
-      // to behave identically on every filesystem (network, external, FAT).
-      try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
     } catch {
-      // Best-effort cleanup. An existing destination is left untouched: the
-      // replace either happened completely or not at all.
+      // Best-effort cleanup. An existing destination is untouched unless the
+      // rename succeeded, and a failed rename changes nothing at all.
       try? fm.removeItem(at: tmpURL)
       throw error
     }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Writes a backup file to a destination the user chose (#1680, PR-E1).
+///
+/// Mirrors `CustomWordsManager.saveFile`'s guards — exclusive create, mode
+/// 0600, atomic replace, cleanup on failure — with one deliberate difference:
+/// the temp filename is **unique**, not fixed. The live `custom-words.json`
+/// has exactly one writer, so a fixed `.tmp` sibling is safe there. An export
+/// destination is a folder the user picked, and two exports can target it at
+/// once; a shared temp name would let them overwrite each other's partial
+/// bytes and produce one corrupt file.
+package enum CustomWordsExportWriter {
+  package static func write(_ document: CustomWordsTransferDocument, to destination: URL)
+    throws
+  {
+    let data = try document.encoded()
+    let fm = FileManager.default
+    let tmpURL =
+      destination
+      .deletingLastPathComponent()
+      .appendingPathComponent(".ew-export-\(UUID().uuidString).tmp")
+
+    do {
+      // Cancellation is checked before the temp file exists, so an abandoned
+      // export leaves nothing behind to clean up.
+      try Task.checkCancellation()
+
+      // O_EXCL: refuse to write through an existing file at the temp path
+      // rather than truncating whatever happens to be there.
+      let fd = Foundation.open(tmpURL.path, O_CREAT | O_EXCL | O_WRONLY, 0o600)
+      guard fd >= 0 else { throw CocoaError(.fileWriteUnknown) }
+      let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+      try handle.write(contentsOf: data)
+      try handle.close()
+
+      if fm.fileExists(atPath: destination.path) {
+        _ = try fm.replaceItemAt(destination, withItemAt: tmpURL)
+      } else {
+        try fm.moveItem(at: tmpURL, to: destination)
+      }
+    } catch {
+      // Best-effort cleanup. An existing destination is left untouched: the
+      // replace either happened completely or not at all.
+      try? fm.removeItem(at: tmpURL)
+      throw error
+    }
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -46,6 +46,18 @@ package enum CustomWordsExportWriter {
       do {
         try fm.moveItem(at: tmpURL, to: destination)
       } catch {
+        // Replace ONLY a pre-existing regular file. The first version of this
+        // fallback replaced on ANY move failure, which meant that if the
+        // destination path had become a directory, Foundation would replace
+        // the directory with the export file and delete its contents — a
+        // destructive answer to an unrelated error. Anything that is not a
+        // plain file is not ours to overwrite; rethrow the real failure.
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: destination.path, isDirectory: &isDirectory),
+          !isDirectory.boolValue
+        else {
+          throw error
+        }
         _ = try fm.replaceItemAt(
           destination, withItemAt: tmpURL, options: [.usingNewMetadataOnly])
       }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -6,6 +6,33 @@ import Foundation
 public struct BuiltinWord: Sendable {
   public let id: String
   public let word: CustomWord
+
+  /// Stamps `source: .builtin` centrally (#1680), so a built-in cannot ship
+  /// untagged no matter how its `CustomWord` was written. Export filters on
+  /// `source == .user`; an untagged built-in would silently export as if the
+  /// user had authored it. Tagging at the one construction point makes the
+  /// correct thing automatic rather than a rule every future entry must
+  /// remember — the tag is not spelled at any call site, so it cannot be
+  /// forgotten at one.
+  ///
+  /// Runtime-only: `source` is excluded from `CustomWord.CodingKeys`, and
+  /// decode always yields `.user`. Nothing on disk changes.
+  public init(id: String, word: CustomWord) {
+    self.id = id
+    self.word = CustomWord(
+      id: word.id,
+      canonical: word.canonical,
+      aliases: word.aliases,
+      category: word.category,
+      priority: word.priority,
+      forceReplace: word.forceReplace,
+      caseSensitive: word.caseSensitive,
+      source: .builtin,
+      frequencyUsed: word.frequencyUsed,
+      lastUsed: word.lastUsed,
+      minSimilarityOverride: word.minSimilarityOverride
+    )
+  }
 }
 
 /// Thrown by the CRUD mutation methods when an EXISTING custom-words file
@@ -816,11 +843,21 @@ public final class CustomWordsManager {
     guard let index = words.firstIndex(where: { $0.id == word.id }) else { return }
     let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
-    var sanitized = word
-    sanitized.canonical = trimmed
-    sanitized.aliases = sanitized.aliases
+    var edited = word
+    edited.canonical = trimmed
+    edited.aliases = edited.aliases
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
       .filter { !$0.isEmpty }
+
+    // An edit makes the word the user's, whatever it started as (#1680).
+    // Editing a built-in produces a user override, but the value still carries
+    // `source: .builtin` from `builtinDefaults` and `source` is a `let`, so it
+    // is reconstructed here. Applied ONCE, before both the file write and the
+    // in-memory publish: re-tagging only the file copy leaves the live list
+    // still claiming `.builtin`, and an export taken right after the edit —
+    // which filters on `source == .user` — would silently omit the user's own
+    // change until the next launch decoded it. (No-op for words already `.user`.)
+    let sanitized = edited.ownedByUser()
 
     var file = try loadFileForMutation()
 
@@ -828,7 +865,7 @@ public final class CustomWordsManager {
     if let existingIdx = file.words.firstIndex(where: { $0.id == word.id }) {
       file.words[existingIdx] = sanitized
     } else {
-      // Editing a built-in: add as user word (overrides built-in by canonical match)
+      // Editing a built-in: add as user word (overrides built-in by canonical match).
       file.words.append(sanitized)
     }
     try saveFile(file)

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -86,7 +86,11 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
     guard decoded.format == Self.formatIdentifier else {
       throw CustomWordsTransferError.notAnEnviousWisprBackup
     }
-    guard decoded.version <= Self.currentVersion else {
+    // A RANGE, not an upper bound. Version 1 is the first format and nothing
+    // earlier ever existed, so `0` or a negative version is a malformed or
+    // tampered file claiming a schema that was never defined — not something
+    // to import on the strength of the current fields happening to parse.
+    guard (1...Self.currentVersion).contains(decoded.version) else {
       throw CustomWordsTransferError.unsupportedVersion(decoded.version)
     }
     self = decoded

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -10,13 +10,13 @@ package enum CustomWordsTransferError: LocalizedError, Sendable, Equatable {
   package var errorDescription: String? {
     switch self {
     case .notAnEnviousWisprBackup:
-      return "That file isn't an EnviousWispr word backup."
+      return "That file didn't come from EnviousWispr."
     case .unsupportedVersion(let version):
       return
-        "That backup was made by a newer version of EnviousWispr (format \(version)). "
+        "That file was exported by a newer version of EnviousWispr (format \(version)). "
         + "Update the app, then try again."
     case .malformed:
-      return "That backup file is damaged and can't be read."
+      return "That file is damaged and can't be read."
     }
   }
 }
@@ -87,10 +87,21 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
     } catch {
       // A perfectly valid JSON file that simply isn't ours reads the same as
       // damaged bytes at this layer; separate them so the message is true.
-      if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-        object["format"] as? String != Self.formatIdentifier
+      //
+      // "Valid JSON" includes a top-level array, string, or number — a config
+      // file, an API dump, a word list someone saved as JSON. Those are
+      // healthy documents that just aren't ours, and calling them damaged
+      // sends the user hunting for corruption that isn't there (review r2).
+      if let json = try? JSONSerialization.jsonObject(
+        with: data, options: [.fragmentsAllowed])
       {
-        throw CustomWordsTransferError.notAnEnviousWisprBackup
+        let claimsOurFormat =
+          (json as? [String: Any])?["format"] as? String == Self.formatIdentifier
+        // Only a document claiming to BE ours can be damaged goods; anything
+        // else is simply a different file.
+        throw claimsOurFormat
+          ? CustomWordsTransferError.malformed
+          : CustomWordsTransferError.notAnEnviousWisprBackup
       }
       throw CustomWordsTransferError.malformed
     }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -66,16 +66,27 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
     self.words = words.map(PortableCustomWord.init)
   }
 
+  /// Just the envelope. Decoded first and alone so the format and version can
+  /// be judged before any version-specific payload is parsed.
+  private struct Header: Decodable {
+    let format: String
+    let version: Int
+  }
+
   /// Decode path. Rejects anything that isn't this format, and refuses a
-  /// version from the future rather than guessing at fields it doesn't know.
+  /// version it cannot interpret rather than guessing at fields it doesn't know.
   package init(data: Data) throws {
-    let decoded: CustomWordsTransferDocument
+    // Header FIRST (code review r3). A future format could rename a word field
+    // or add an enum case; decoding the whole document up front would throw on
+    // that payload before the version guard ran, and the user would be told
+    // their backup is damaged when the truth is "made by a newer version —
+    // update the app." Judge the envelope, then read the contents.
+    let header: Header
     do {
-      decoded = try JSONDecoder().decode(CustomWordsTransferDocument.self, from: data)
+      header = try JSONDecoder().decode(Header.self, from: data)
     } catch {
-      // A valid JSON object that simply isn't ours decodes as a key mismatch,
-      // same as damaged bytes; distinguish them so the user gets the right
-      // sentence rather than "damaged" for a perfectly fine unrelated file.
+      // A perfectly valid JSON file that simply isn't ours reads the same as
+      // damaged bytes at this layer; separate them so the message is true.
       if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
         object["format"] as? String != Self.formatIdentifier
       {
@@ -83,15 +94,24 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
       }
       throw CustomWordsTransferError.malformed
     }
-    guard decoded.format == Self.formatIdentifier else {
+    guard header.format == Self.formatIdentifier else {
       throw CustomWordsTransferError.notAnEnviousWisprBackup
     }
     // A RANGE, not an upper bound. Version 1 is the first format and nothing
     // earlier ever existed, so `0` or a negative version is a malformed or
     // tampered file claiming a schema that was never defined — not something
     // to import on the strength of the current fields happening to parse.
-    guard (1...Self.currentVersion).contains(decoded.version) else {
-      throw CustomWordsTransferError.unsupportedVersion(decoded.version)
+    guard (1...Self.currentVersion).contains(header.version) else {
+      throw CustomWordsTransferError.unsupportedVersion(header.version)
+    }
+
+    let decoded: CustomWordsTransferDocument
+    do {
+      decoded = try JSONDecoder().decode(CustomWordsTransferDocument.self, from: data)
+    } catch {
+      // The envelope is ours and its version is supported, so a payload that
+      // still won't parse is genuinely damaged.
+      throw CustomWordsTransferError.malformed
     }
     self = decoded
   }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -1,0 +1,128 @@
+import EnviousWisprCore
+import Foundation
+
+/// Errors from decoding an EnviousWispr custom-words backup (#1680, PR-E1).
+package enum CustomWordsTransferError: LocalizedError, Sendable, Equatable {
+  case notAnEnviousWisprBackup
+  case unsupportedVersion(Int)
+  case malformed
+
+  package var errorDescription: String? {
+    switch self {
+    case .notAnEnviousWisprBackup:
+      return "That file isn't an EnviousWispr word backup."
+    case .unsupportedVersion(let version):
+      return
+        "That backup was made by a newer version of EnviousWispr (format \(version)). "
+        + "Update the app, then try again."
+    case .malformed:
+      return "That backup file is damaged and can't be read."
+    }
+  }
+}
+
+/// One exported word. Deliberately narrower than `CustomWord`: usage history
+/// (`frequencyUsed` / `lastUsed`) never leaves this Mac, and `source` is a
+/// runtime tag with no meaning on another machine.
+package struct PortableCustomWord: Codable, Sendable, Equatable {
+  package let id: UUID
+  package let canonical: String
+  package let aliases: [String]
+  package let category: WordCategory
+  package let priority: Int
+  package let forceReplace: Bool
+  package let caseSensitive: Bool
+  package let minSimilarityOverride: Double?
+
+  package init(_ word: CustomWord) {
+    self.id = word.id
+    self.canonical = word.canonical
+    self.aliases = word.aliases
+    self.category = word.category
+    self.priority = word.priority
+    self.forceReplace = word.forceReplace
+    self.caseSensitive = word.caseSensitive
+    self.minSimilarityOverride = word.minSimilarityOverride
+  }
+}
+
+/// The portable backup format: a versioned envelope around the user's own words.
+///
+/// Scope is "your words", never "everything" — see the export path for why
+/// built-ins are excluded and why deleted-built-in tombstones are a documented
+/// non-goal rather than an oversight.
+package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
+  package static let formatIdentifier = "com.enviouswispr.custom-words"
+  package static let currentVersion = 1
+
+  package let format: String
+  package let version: Int
+  package let words: [PortableCustomWord]
+
+  /// Export path.
+  package init(words: [CustomWord]) {
+    self.format = Self.formatIdentifier
+    self.version = Self.currentVersion
+    self.words = words.map(PortableCustomWord.init)
+  }
+
+  /// Decode path. Rejects anything that isn't this format, and refuses a
+  /// version from the future rather than guessing at fields it doesn't know.
+  package init(data: Data) throws {
+    let decoded: CustomWordsTransferDocument
+    do {
+      decoded = try JSONDecoder().decode(CustomWordsTransferDocument.self, from: data)
+    } catch {
+      // A valid JSON object that simply isn't ours decodes as a key mismatch,
+      // same as damaged bytes; distinguish them so the user gets the right
+      // sentence rather than "damaged" for a perfectly fine unrelated file.
+      if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        object["format"] as? String != Self.formatIdentifier
+      {
+        throw CustomWordsTransferError.notAnEnviousWisprBackup
+      }
+      throw CustomWordsTransferError.malformed
+    }
+    guard decoded.format == Self.formatIdentifier else {
+      throw CustomWordsTransferError.notAnEnviousWisprBackup
+    }
+    guard decoded.version <= Self.currentVersion else {
+      throw CustomWordsTransferError.unsupportedVersion(decoded.version)
+    }
+    self = decoded
+  }
+
+  package func encoded() throws -> Data {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    return try encoder.encode(self)
+  }
+
+  /// Hand the decoded words to the shared import pipeline.
+  ///
+  /// Never returns `[CustomWord]`: an exported `id` is foreign to this Mac and
+  /// must not become a local persisted UUID. It survives only as review-row
+  /// identity — a committed addition mints a fresh UUID, and a committed
+  /// replacement keeps the *existing local* word's UUID.
+  ///
+  /// Every authority field is `.supplied`, including the two authoritative
+  /// clears no other source can express: `.supplied([])` means "this word
+  /// genuinely has no alternate spellings" and `.supplied(nil)` means "this
+  /// word genuinely uses the global strictness". A backup is a full round-trip
+  /// of a real word, so silence here would be a lie, not an absence of opinion.
+  package func candidatesForImport() -> [CustomWordsImportCandidate] {
+    words.map { word in
+      CustomWordsImportCandidate(
+        id: word.id,
+        canonical: word.canonical,
+        aliases: .supplied(word.aliases),
+        suggestedAliases: [],
+        category: .supplied(word.category),
+        priority: .supplied(word.priority),
+        forceReplace: .supplied(word.forceReplace),
+        caseSensitive: .supplied(word.caseSensitive),
+        minSimilarityOverride: .supplied(word.minSimilarityOverride)
+      )
+    }
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -100,10 +100,17 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
 
   /// Hand the decoded words to the shared import pipeline.
   ///
-  /// Never returns `[CustomWord]`: an exported `id` is foreign to this Mac and
-  /// must not become a local persisted UUID. It survives only as review-row
-  /// identity — a committed addition mints a fresh UUID, and a committed
-  /// replacement keeps the *existing local* word's UUID.
+  /// Never returns `[CustomWord]`: an exported `id` is a persistence UUID from
+  /// whichever Mac wrote the file, and must not become a local persisted UUID.
+  ///
+  /// The exported id is **not reused as review identity either** (code review).
+  /// Restoring a backup onto the Mac that wrote it makes every candidate id
+  /// equal to the live word's id, and the collision detector — which seeds
+  /// ownership from the existing library first — then reports each word's own
+  /// aliases as colliding with itself. Review would warn that spellings "may
+  /// not be added" when replacement keeps them. A fresh transient id per
+  /// candidate keeps review rows distinct from library entries, which is the
+  /// only thing this id is for.
   ///
   /// Every authority field is `.supplied`, including the two authoritative
   /// clears no other source can express: `.supplied([])` means "this word
@@ -113,7 +120,7 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
   package func candidatesForImport() -> [CustomWordsImportCandidate] {
     words.map { word in
       CustomWordsImportCandidate(
-        id: word.id,
+        id: UUID(),
         canonical: word.canonical,
         aliases: .supplied(word.aliases),
         suggestedAliases: [],

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -97,11 +97,15 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
     guard header.format == Self.formatIdentifier else {
       throw CustomWordsTransferError.notAnEnviousWisprBackup
     }
-    // A RANGE, not an upper bound. Version 1 is the first format and nothing
-    // earlier ever existed, so `0` or a negative version is a malformed or
-    // tampered file claiming a schema that was never defined — not something
-    // to import on the strength of the current fields happening to parse.
-    guard (1...Self.currentVersion).contains(header.version) else {
+    // A RANGE, not an upper bound — but the two ends mean different things and
+    // must not share a message (review r4). Below 1 is a schema that never
+    // existed, so the file is malformed or tampered; telling that user to
+    // "update the app" is advice that cannot help them. Above current is a
+    // genuine future format, where updating is exactly the fix.
+    guard header.version >= 1 else {
+      throw CustomWordsTransferError.malformed
+    }
+    guard header.version <= Self.currentVersion else {
       throw CustomWordsTransferError.unsupportedVersion(header.version)
     }
 

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -167,16 +167,29 @@ package struct FileImportSource: CustomWordsImportSource {
       throw ImportFileError.unsupportedType(name)
     }
 
-    let size =
-      (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? nil
-    if let size, size > Self.maximumFileBytes {
+    try Task.checkCancellation()
+
+    // Bound the READ itself, rather than checking the size and then reading
+    // separately (code review r3). Between a stat and a load the file can grow
+    // or be replaced — by a sync client, by whatever wrote it — and the ceiling
+    // would be bypassed on exactly the input it exists to refuse. Reading one
+    // byte past the limit from a single open handle answers "is this too big"
+    // and "give me the bytes" as one operation, so there is no window between
+    // the question and the answer.
+    guard let handle = try? FileHandle(forReadingFrom: url) else {
+      throw ImportFileError.unreadable
+    }
+    defer { try? handle.close() }
+
+    guard
+      let data = try? handle.read(upToCount: Self.maximumFileBytes + 1)
+    else {
+      throw ImportFileError.unreadable
+    }
+    guard data.count <= Self.maximumFileBytes else {
       throw ImportFileError.tooLarge
     }
 
-    try Task.checkCancellation()
-    guard let data = try? Data(contentsOf: url) else {
-      throw ImportFileError.unreadable
-    }
     try Task.checkCancellation()
 
     let candidates = try parser.parse(data: data)

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -6,18 +6,26 @@ import UniformTypeIdentifiers
 package enum ImportFileError: LocalizedError, Sendable, Equatable {
   case unreadable
   case unsupportedType(String)
-  case backup(CustomWordsTransferError)
+  case tooLarge
+  case tooManyWords(found: Int, limit: Int)
+  case exportedWords(CustomWordsTransferError)
 
   package var errorDescription: String? {
     switch self {
     case .unreadable:
       return "That file couldn't be read."
+    case .tooLarge:
+      return "That file is too big to be a word list. Check you picked the right one."
+    case .tooManyWords(let found, let limit):
+      return
+        "That file has \(found) words, which is more than EnviousWispr can import "
+        + "at once (\(limit)). Try splitting it into smaller files."
     case .unsupportedType(let name):
       return
         "EnviousWispr can't read \(name) files yet. "
-        + "Try an EnviousWispr backup or a plain text list."
-    case .backup(let underlying):
-      // The backup decoder already distinguishes "not ours", "from a newer
+        + "Try a file you exported from EnviousWispr, or a plain text list."
+    case .exportedWords(let underlying):
+      // The decoder already distinguishes "not ours", "from a newer
       // version", and "damaged"; passing its sentence through keeps the user
       // from being told something less true by a wrapper.
       return underlying.errorDescription
@@ -41,13 +49,16 @@ package protocol ImportFileParser: Sendable {
   func parse(data: Data) throws -> [CustomWordsImportCandidate]
 }
 
-/// The EnviousWispr backup format — what PR-E1 writes.
+/// The file EnviousWispr itself exports.
 ///
-/// Without this, an export could be produced but never restored, which would
-/// make the export feature a promise the app could not keep.
-package struct BackupImportFileParser: ImportFileParser {
-  package let identifier = "backup"
-  package let displayName = "EnviousWispr backup"
+/// Deliberately not called a "backup": the product has two ideas, import and
+/// export, and naming the exported file a third thing invented a concept the
+/// user never asked for (founder, 2026-07-19). Without this parser an export
+/// could be produced but never read back, which would make Export a promise
+/// the app could not keep.
+package struct ExportedWordsFileParser: ImportFileParser {
+  package let identifier = "exported-words"
+  package let displayName = "EnviousWispr words file"
   package let contentTypes: [UTType] = [.json]
 
   package init() {}
@@ -56,7 +67,7 @@ package struct BackupImportFileParser: ImportFileParser {
     do {
       return try CustomWordsTransferDocument(data: data).candidatesForImport()
     } catch let error as CustomWordsTransferError {
-      throw ImportFileError.backup(error)
+      throw ImportFileError.exportedWords(error)
     }
   }
 }
@@ -93,12 +104,12 @@ package struct PlainTextImportFileParser: ImportFileParser {
 package struct ImportFileRegistry: Sendable {
   package let parsers: [any ImportFileParser]
 
-  /// v1 registers the two formats that need no parsing decisions: the backup
-  /// format we author ourselves, and a plain word list. CSV is deliberately
+  /// v1 registers the two formats that need no parsing decisions: the file we
+  /// author ourselves, and a plain word list. CSV is deliberately
   /// absent — it is the only format that needs the quoted-field state machine
   /// (or a dependency to supply one), and that call is the founder's to make.
   package static let v1 = ImportFileRegistry(
-    parsers: [BackupImportFileParser(), PlainTextImportFileParser()])
+    parsers: [ExportedWordsFileParser(), PlainTextImportFileParser()])
 
   package init(parsers: [any ImportFileParser]) {
     self.parsers = parsers
@@ -131,6 +142,15 @@ package struct ImportFileRegistry: Sendable {
 
 /// Reads a user-chosen file and turns it into a batch.
 package struct FileImportSource: CustomWordsImportSource {
+  /// Refuse before allocating. A word list is small; anything of this size is
+  /// a mistaken selection (a video, a database, a disk image), and reading it
+  /// into memory to discover that is the expensive way to find out.
+  package static let maximumFileBytes = 16 * 1024 * 1024
+  /// The compare engine documents this ceiling for uploads. Enforced here, at
+  /// the door, rather than after every row has been parsed, compared and
+  /// rendered into a review the user cannot meaningfully read anyway.
+  package static let maximumCandidates = 25_000
+
   private let url: URL
   private let registry: ImportFileRegistry
 
@@ -139,18 +159,38 @@ package struct FileImportSource: CustomWordsImportSource {
     self.registry = registry
   }
 
-  package func loadCandidates() async throws -> CustomWordsImportBatch {
+  /// `@concurrent` so reading and parsing always leave the caller's actor.
+  /// The import model is `@MainActor`, and a plain `async` witness would
+  /// inherit that isolation — a large, network-mounted, or cloud-backed file
+  /// would then freeze the settings window while it was read (code review).
+  @concurrent package func loadCandidates() async throws -> CustomWordsImportBatch {
     guard let parser = registry.parser(for: url) else {
       let name = url.pathExtension.isEmpty ? "those" : ".\(url.pathExtension.lowercased())"
       throw ImportFileError.unsupportedType(name)
     }
+
+    let size =
+      (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? nil
+    if let size, size > Self.maximumFileBytes {
+      throw ImportFileError.tooLarge
+    }
+
+    try Task.checkCancellation()
     guard let data = try? Data(contentsOf: url) else {
       throw ImportFileError.unreadable
     }
+    try Task.checkCancellation()
+
+    let candidates = try parser.parse(data: data)
+    guard candidates.count <= Self.maximumCandidates else {
+      throw ImportFileError.tooManyWords(
+        found: candidates.count, limit: Self.maximumCandidates)
+    }
+
     return CustomWordsImportBatch(
       sourceID: parser.identifier,
       sourceDisplayName: parser.displayName,
-      candidates: try parser.parse(data: data)
+      candidates: candidates
     )
   }
 }

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -146,10 +146,8 @@ package struct FileImportSource: CustomWordsImportSource {
   /// a mistaken selection (a video, a database, a disk image), and reading it
   /// into memory to discover that is the expensive way to find out.
   package static let maximumFileBytes = 16 * 1024 * 1024
-  /// The compare engine documents this ceiling for uploads. Enforced here, at
-  /// the door, rather than after every row has been parsed, compared and
-  /// rendered into a review the user cannot meaningfully read anyway.
-  package static let maximumCandidates = 25_000
+  /// Shared with every other import source, so no door has a different limit.
+  package static var maximumCandidates: Int { CustomWordsImportLimits.maximumCandidates }
 
   private let url: URL
   private let registry: ImportFileRegistry

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -136,6 +136,16 @@ package struct ImportFileRegistry: Sendable {
     // rather than being read on a guess. That is the honest answer, and CSV
     // becomes supported by registering a real CSV parser — the seam this
     // registry exists for — not by widening this match.
+    //
+    // Reviewed twice (r4, r5) as "UTType returns a dynamic dyn.* type here, so
+    // every .json and .txt upload is rejected; 19 tests fail." Not reproduced
+    // in either environment: a direct probe resolves json → public.json and
+    // txt → public.plain-text, both non-dynamic and both matching, and the
+    // 19-test suite passes under BOTH scripts/xcode-test.sh and swift test.
+    // Left as-is deliberately rather than trading verified behaviour for an
+    // unverified claim. If some future environment genuinely yields dynamic
+    // types, the fix is an explicit extension→parser mapping here, keeping the
+    // CSV/TSV refusal intact.
     return parsers.first { $0.contentTypes.contains(type) }
   }
 }

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -181,10 +181,28 @@ package struct FileImportSource: CustomWordsImportSource {
     }
     defer { try? handle.close() }
 
-    guard
-      let data = try? handle.read(upToCount: Self.maximumFileBytes + 1)
-    else {
-      throw ImportFileError.unreadable
+    // Loop until EOF or one byte past the ceiling (code review r4). A single
+    // `read(upToCount:)` may return FEWER bytes without having reached the end
+    // — routine for network-mounted and cloud-backed files — which would have
+    // silently imported a truncated prefix of the user's list and could also
+    // miss that the file exceeds the limit. Accumulating until the file says
+    // it is done makes "how much is there" a fact rather than a guess.
+    var data = Data()
+    let ceiling = Self.maximumFileBytes + 1
+    while data.count < ceiling {
+      try Task.checkCancellation()
+      // `read(upToCount:)` signals EOF with NIL, and a genuine failure by
+      // throwing. Collapsing those two with `try?` turned every successful
+      // read-to-completion into "unreadable" — caught immediately by the
+      // existing tests, which is what they are for.
+      let chunk: Data?
+      do {
+        chunk = try handle.read(upToCount: ceiling - data.count)
+      } catch {
+        throw ImportFileError.unreadable
+      }
+      guard let chunk, !chunk.isEmpty else { break }  // EOF
+      data.append(chunk)
     }
     guard data.count <= Self.maximumFileBytes else {
       throw ImportFileError.tooLarge

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -1,0 +1,156 @@
+import EnviousWisprCore
+import Foundation
+import UniformTypeIdentifiers
+
+/// Why a chosen file could not become import candidates (#1683, PR-U1).
+package enum ImportFileError: LocalizedError, Sendable, Equatable {
+  case unreadable
+  case unsupportedType(String)
+  case backup(CustomWordsTransferError)
+
+  package var errorDescription: String? {
+    switch self {
+    case .unreadable:
+      return "That file couldn't be read."
+    case .unsupportedType(let name):
+      return
+        "EnviousWispr can't read \(name) files yet. "
+        + "Try an EnviousWispr backup or a plain text list."
+    case .backup(let underlying):
+      // The backup decoder already distinguishes "not ours", "from a newer
+      // version", and "damaged"; passing its sentence through keeps the user
+      // from being told something less true by a wrapper.
+      return underlying.errorDescription
+    }
+  }
+}
+
+/// One file format the picker can read.
+///
+/// A registry rather than a switch so CSV (and later Excel) is a pure addition:
+/// a new conformer and one registry entry, with nothing existing rewritten.
+/// That seam is the reason the plan asked for a registry at all, and it stays
+/// even though v1 registers only two formats.
+package protocol ImportFileParser: Sendable {
+  /// Stable identifier, emitted as the batch's `sourceID` for telemetry.
+  var identifier: String { get }
+  /// What the user sees.
+  var displayName: String { get }
+  /// Content types this parser claims.
+  var contentTypes: [UTType] { get }
+  func parse(data: Data) throws -> [CustomWordsImportCandidate]
+}
+
+/// The EnviousWispr backup format — what PR-E1 writes.
+///
+/// Without this, an export could be produced but never restored, which would
+/// make the export feature a promise the app could not keep.
+package struct BackupImportFileParser: ImportFileParser {
+  package let identifier = "backup"
+  package let displayName = "EnviousWispr backup"
+  package let contentTypes: [UTType] = [.json]
+
+  package init() {}
+
+  package func parse(data: Data) throws -> [CustomWordsImportCandidate] {
+    do {
+      return try CustomWordsTransferDocument(data: data).candidatesForImport()
+    } catch let error as CustomWordsTransferError {
+      throw ImportFileError.backup(error)
+    }
+  }
+}
+
+/// A plain list of words.
+///
+/// Deliberately the SAME parser the Paste screen uses, not a second
+/// implementation: a word list is a word list whether it was typed into a box
+/// or saved to a file, and two parsers would eventually disagree about what
+/// "C++" or "Envious Labs" means.
+package struct PlainTextImportFileParser: ImportFileParser {
+  package let identifier = "plain-text"
+  package let displayName = "Plain text"
+  package let contentTypes: [UTType] = [.plainText, .utf8PlainText, .text]
+
+  package init() {}
+
+  package func parse(data: Data) throws -> [CustomWordsImportCandidate] {
+    // Accept UTF-8 first, then fall back to the platform's legacy encoding
+    // rather than refusing a file a user exported from an older tool.
+    guard
+      let text = String(data: data, encoding: .utf8)
+        ?? String(data: data, encoding: .isoLatin1)
+    else {
+      throw ImportFileError.unreadable
+    }
+    return PasteWordsParser.parse(text).map {
+      CustomWordsImportCandidate(canonical: $0)
+    }
+  }
+}
+
+/// Chooses a parser for a file and runs it.
+package struct ImportFileRegistry: Sendable {
+  package let parsers: [any ImportFileParser]
+
+  /// v1 registers the two formats that need no parsing decisions: the backup
+  /// format we author ourselves, and a plain word list. CSV is deliberately
+  /// absent — it is the only format that needs the quoted-field state machine
+  /// (or a dependency to supply one), and that call is the founder's to make.
+  package static let v1 = ImportFileRegistry(
+    parsers: [BackupImportFileParser(), PlainTextImportFileParser()])
+
+  package init(parsers: [any ImportFileParser]) {
+    self.parsers = parsers
+  }
+
+  package var acceptedContentTypes: [UTType] {
+    parsers.flatMap(\.contentTypes)
+  }
+
+  package func parser(for url: URL) -> (any ImportFileParser)? {
+    guard
+      let type = UTType(filenameExtension: url.pathExtension.lowercased())
+    else { return nil }
+    // EXACT match, deliberately not conformance.
+    //
+    // CSV and TSV conform to `public.plain-text`, so a conformance match hands
+    // a spreadsheet to the plain-text parser — which splits on commas, and
+    // would silently turn one row of `GitHub,git hub,brand` into three words,
+    // header rows and category names included. Quietly corrupting a
+    // dictionary is far worse than refusing a file, so a format is readable
+    // only when a parser claims it by name.
+    //
+    // The cost is that an unrecognised text subtype reports "unsupported"
+    // rather than being read on a guess. That is the honest answer, and CSV
+    // becomes supported by registering a real CSV parser — the seam this
+    // registry exists for — not by widening this match.
+    return parsers.first { $0.contentTypes.contains(type) }
+  }
+}
+
+/// Reads a user-chosen file and turns it into a batch.
+package struct FileImportSource: CustomWordsImportSource {
+  private let url: URL
+  private let registry: ImportFileRegistry
+
+  package init(url: URL, registry: ImportFileRegistry = .v1) {
+    self.url = url
+    self.registry = registry
+  }
+
+  package func loadCandidates() async throws -> CustomWordsImportBatch {
+    guard let parser = registry.parser(for: url) else {
+      let name = url.pathExtension.isEmpty ? "those" : ".\(url.pathExtension.lowercased())"
+      throw ImportFileError.unsupportedType(name)
+    }
+    guard let data = try? Data(contentsOf: url) else {
+      throw ImportFileError.unreadable
+    }
+    return CustomWordsImportBatch(
+      sourceID: parser.identifier,
+      sourceDisplayName: parser.displayName,
+      candidates: try parser.parse(data: data)
+    )
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -1,0 +1,65 @@
+import EnviousWisprCore
+import Foundation
+
+/// Turns pasted text into import candidates (#1681, PR-P1).
+///
+/// Deterministic and total: no model call, no network, no availability check.
+/// Whatever the user pasted either becomes a word or is honestly reported as
+/// nothing to import.
+///
+/// **v1 ships no on-device variant suggestions.** The adopted plan pairs Paste
+/// with `WordSuggestionService`, and that stage remains the right design — a
+/// pipeline step between compare and review, filling the candidate's
+/// never-authoritative `suggestedAliases` channel. It is deliberately deferred
+/// so the plain path can be proven first; nothing here forecloses it.
+package enum PasteWordsParser {
+  /// Separators, and only these.
+  ///
+  /// Semicolon, slash, hyphen, and plain space are deliberately NOT separators:
+  /// "Envious Labs" is one word, "C++"/"C#"/".NET" must survive intact, and a
+  /// hyphenated surname is not two people. Being conservative here is why the
+  /// user can paste a messy list and still get what they meant — a wrong split
+  /// silently invents words nobody typed.
+  private static let separators = CharacterSet(charactersIn: ",\n\r")
+
+  package static func parse(_ text: String) -> [String] {
+    var seen = Set<String>()
+    var results: [String] = []
+
+    for piece in text.components(separatedBy: separators) {
+      let trimmed = piece.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else { continue }
+      // Deduplicate on the compare engine's own key, so "GitHub" and "github"
+      // in one paste collapse the same way they would against the library —
+      // and the FIRST spelling wins, because that is the one the user typed
+      // first and has no reason to see replaced by a later casing.
+      let key = CustomWordsImportCompareEngine.normalize(trimmed)
+      guard !key.isEmpty, seen.insert(key).inserted else { continue }
+      results.append(trimmed)
+    }
+    return results
+  }
+}
+
+/// The pasted-text import source.
+package struct PasteWordsImportSource: CustomWordsImportSource {
+  package static let sourceID = "paste"
+
+  private let text: String
+
+  package init(text: String) {
+    self.text = text
+  }
+
+  package func loadCandidates() async throws -> CustomWordsImportBatch {
+    let canonicals = PasteWordsParser.parse(text)
+    return CustomWordsImportBatch(
+      sourceID: Self.sourceID,
+      sourceDisplayName: "Pasted words",
+      // Every authority field stays `.unspecified`: pasted text carries no
+      // alias data and no opinion about category, priority, strictness, or
+      // case sensitivity, so a Replace built from it must never claim to.
+      candidates: canonicals.map { CustomWordsImportCandidate(canonical: $0) }
+    )
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -41,6 +41,20 @@ package enum PasteWordsParser {
   }
 }
 
+/// Pasting more than the shared ceiling allows (#1683).
+package enum PasteWordsImportError: LocalizedError, Sendable, Equatable {
+  case tooManyWords(found: Int, limit: Int)
+
+  package var errorDescription: String? {
+    switch self {
+    case .tooManyWords(let found, let limit):
+      return
+        "That's \(found) words, which is more than EnviousWispr can import at once "
+        + "(\(limit)). Try pasting a smaller batch."
+    }
+  }
+}
+
 /// The pasted-text import source.
 package struct PasteWordsImportSource: CustomWordsImportSource {
   package static let sourceID = "paste"
@@ -51,8 +65,16 @@ package struct PasteWordsImportSource: CustomWordsImportSource {
     self.text = text
   }
 
-  package func loadCandidates() async throws -> CustomWordsImportBatch {
+  /// `@concurrent` so a very large paste is parsed off the caller's actor
+  /// rather than on the main one (code review r2).
+  @concurrent package func loadCandidates() async throws -> CustomWordsImportBatch {
     let canonicals = PasteWordsParser.parse(text)
+    // The same ceiling file import enforces. A limit that applied to one door
+    // and not the other would just be a bug with a longer fuse.
+    guard canonicals.count <= CustomWordsImportLimits.maximumCandidates else {
+      throw PasteWordsImportError.tooManyWords(
+        found: canonicals.count, limit: CustomWordsImportLimits.maximumCandidates)
+    }
     return CustomWordsImportBatch(
       sourceID: Self.sourceID,
       sourceDisplayName: "Pasted words",

--- a/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
@@ -169,4 +169,34 @@ struct CustomWordsImportFlowModelTests {
     #expect(failed.step == .result(.failed(message: "could not read the file")))
     #expect(nothingFound.step != failed.step)
   }
+
+  // MARK: - Paste draft (#1681)
+
+  @Test("the pasted draft survives going back from review")
+  func pasteDraftSurvivesBackFromReview() {
+    // Back from Review exists so the user can EDIT what they pasted. Holding
+    // the draft in the screen's own state meant the sheet rebuilt an empty
+    // editor and silently discarded the list (code review r1).
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Kubernetes\nAnthropic"
+    model.beginWork(.comparing)
+    model.showReview()
+    #expect(model.step == .review)
+
+    model.goBack()
+
+    #expect(model.step == .paste)
+    #expect(model.pasteDraft == "Kubernetes\nAnthropic")
+  }
+
+  @Test("resetting the sheet clears the pasted draft")
+  func resetClearsThePasteDraft() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Kubernetes"
+    model.reset()
+    #expect(model.pasteDraft.isEmpty)
+    #expect(model.step == .methodPicker)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsBackupRoundTripTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsBackupRoundTripTests.swift
@@ -1,0 +1,160 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1680 (PR-E1) — export → compare → commit, against real files.
+///
+/// The plan parks the full round trip in PR-U1, because U1 is what reads a
+/// backup off disk through a file picker. That deferral would leave export's
+/// central promise — "this file can be restored" — untested in the PR that
+/// makes the promise, so the contract-level round trip runs here now and U1
+/// adds the picker leg on top.
+@MainActor
+@Suite("CustomWordsBackupRoundTrip")
+struct CustomWordsBackupRoundTripTests {
+
+  private func makeManager() -> (CustomWordsManager, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-roundtrip-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent("custom-words.json")
+    return (CustomWordsManager(fileURL: url), url)
+  }
+
+  @Test("a user's own words survive export and restore onto a fresh library")
+  func exportThenRestoreRebuildsEveryUserAuthoredWord() async throws {
+    // Mac A: two authored words, one carrying full configuration.
+    let (source, _) = makeManager()
+    var live = source.load() ?? []
+    try source.add(word: CustomWord(canonical: "Qualtrics", aliases: ["qualtrix"]), to: &live)
+    try source.add(
+      word: CustomWord(
+        canonical: "Kubernetes", aliases: ["k8s"], category: .brand, priority: 4,
+        forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.75),
+      to: &live)
+
+    let exported = live.filter { $0.source == .user }
+    #expect(exported.count == 2, "built-ins must not be in the export set")
+    let backup = try CustomWordsTransferDocument(
+      data: CustomWordsTransferDocument(words: exported).encoded())
+
+    // Mac B: a fresh library. Never actually empty — the built-ins are merged
+    // into every effective list — so "everything classifies as new" only holds
+    // for words that don't collide with a built-in.
+    let (destination, _) = makeManager()
+    var fresh = try #require(destination.load())
+    // A fresh library is never empty: `mergedWords` folds the built-ins into
+    // every effective list. Only the user-authored subset is empty.
+    #expect(fresh.contains { $0.source == .user } == false)
+    #expect(fresh.isEmpty == false)
+
+    let candidates = backup.candidatesForImport()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: candidates,
+      against: fresh,
+      fuzzyPolicy: .disabled
+    )
+    #expect(comparisons.allSatisfy { $0.classification == .new })
+
+    let receipt = try destination.commitImport(
+      CustomWordsImportCommitPlan(
+        baseline: CustomWordsImportLibrarySnapshot(words: fresh),
+        additions: comparisons.map(\.candidate),
+        replacements: []),
+      to: &fresh)
+    #expect(receipt.addedIDs.count == 2)
+
+    // Compare what the user actually authored, field by field.
+    let restored = Dictionary(
+      uniqueKeysWithValues: fresh.filter { $0.source == .user }.map { ($0.canonical, $0) })
+    let kubernetes = try #require(restored["Kubernetes"])
+    #expect(kubernetes.aliases == ["k8s"])
+    #expect(kubernetes.category == .brand)
+    #expect(kubernetes.priority == 4)
+    #expect(kubernetes.forceReplace == true)
+    #expect(kubernetes.caseSensitive == true)
+    #expect(kubernetes.minSimilarityOverride == 0.75)
+    #expect(try #require(restored["Qualtrics"]).aliases == ["qualtrix"])
+
+    // Usage history is local to the Mac that earned it.
+    #expect(kubernetes.frequencyUsed == 0)
+    #expect(kubernetes.lastUsed == nil)
+
+    // A restored word is a local word with a local identity.
+    let foreignIDs = Set(backup.words.map(\.id))
+    #expect(fresh.filter { $0.source == .user }.allSatisfy { !foreignIDs.contains($0.id) })
+  }
+
+  @Test("an edited built-in exports, and restoring it needs a replacement")
+  func restoringABuiltinOverrideRequiresAReplacementNotAnAdd() async throws {
+    // Mac A edits a built-in. The override is a real user word and must export.
+    let (source, _) = makeManager()
+    var live = try #require(source.load())
+    let github = try #require(live.first { $0.canonical == "GitHub" })
+    #expect(github.source == .builtin)
+    var edited = github
+    edited.aliases = ["git hub", "gh"]
+    try source.update(word: edited, in: &live)
+
+    let exported = live.filter { $0.source == .user }
+    #expect(
+      exported.contains { $0.canonical == "GitHub" },
+      "the override must export immediately, without waiting for a relaunch")
+
+    // Mac B still has the untouched built-in, so the incoming word is not new.
+    let (destination, _) = makeManager()
+    var fresh = try #require(destination.load())
+    let backup = CustomWordsTransferDocument(words: exported)
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: backup.candidatesForImport(),
+      against: fresh,
+      fuzzyPolicy: .disabled
+    )
+    let row = try #require(comparisons.first { $0.candidate.canonical == "GitHub" })
+    guard case .exact(let existing) = row.classification else {
+      Issue.record("expected the override to match Mac B's built-in exactly")
+      return
+    }
+
+    // The machinery restores it — but only through a REPLACEMENT. The v1
+    // review screen offers Add or Skip only, so this row would be Skip-only
+    // and the user's edit would not come back. That gap is the reason backup
+    // restore is the first real consumer of the alias-merge offer (#1619), and
+    // PR-U1 must surface it rather than silently skipping.
+    let receipt = try destination.commitImport(
+      CustomWordsImportCommitPlan(
+        baseline: CustomWordsImportLibrarySnapshot(words: fresh),
+        additions: [],
+        replacements: [
+          CustomWordsImportReplacement(existingID: existing.id, candidate: row.candidate)
+        ]),
+      to: &fresh)
+
+    #expect(receipt.replacedIDs.count == 1)
+    let restored = try #require(fresh.first { $0.canonical == "GitHub" })
+    #expect(restored.aliases == ["git hub", "gh"])
+    #expect(restored.source == .user)
+  }
+
+  @Test("deleted built-ins are not carried by a backup, by design")
+  func deletedBuiltinTombstonesAreANonGoal() throws {
+    let (source, _) = makeManager()
+    var live = try #require(source.load())
+    let claude = try #require(live.first { $0.canonical == "Claude" })
+    try source.remove(id: claude.id, from: &live)
+    #expect(live.contains { $0.canonical == "Claude" } == false)
+
+    let exported = live.filter { $0.source == .user }
+    let json = try #require(
+      String(data: try CustomWordsTransferDocument(words: exported).encoded(), encoding: .utf8))
+
+    // Frozen as a decision, not left to look like a bug: restoring your words
+    // onto a fresh Mac leaves that Mac's built-ins active, because the review
+    // model has no delete operation and a backup whose restore path cannot
+    // express part of its content would be a broken promise.
+    #expect(!json.contains("deletedBuiltinIds"))
+    #expect(!json.contains("Claude"))
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -46,6 +46,26 @@ struct CustomWordsExportWriterTests {
     #expect(decoded.words.map(\.canonical) == ["Kubernetes"])
   }
 
+  @Test("overwriting a world-readable file still lands at owner-only")
+  func writerOverwritingAWorldReadableFileEnforcesMode0600() throws {
+    // The bug this freezes (code review): `replaceItemAt` preserves the
+    // DESTINATION's metadata by default, so overwriting an existing 0644 file
+    // silently discarded the temp file's 0600 and left a backup full of
+    // personal names world-readable. The new-file test could never catch it.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json")
+    try Data("previous contents".utf8).write(to: destination)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o644], ofItemAtPath: destination.path)
+
+    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
+    let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+    #expect(permissions.int16Value == 0o600)
+  }
+
   @Test("no temporary file is left behind after a successful write")
   func writerLeavesNoTemporaryFile() throws {
     let dir = makeDirectory()

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -105,6 +105,30 @@ struct CustomWordsExportWriterTests {
     #expect(try Data(contentsOf: destination) == original)
   }
 
+  @Test("a directory at the destination is never replaced or emptied")
+  func writerRefusesToReplaceADirectory() throws {
+    // The bug this freezes (code review r2): the move-then-replace fallback
+    // originally replaced on ANY move failure, so a directory sitting at the
+    // destination path would be replaced by the export file and its contents
+    // deleted — a destructive answer to an unrelated error.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json", isDirectory: true)
+    try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+    let inhabitant = destination.appendingPathComponent("keep-me.txt")
+    try Data("precious".utf8).write(to: inhabitant)
+
+    #expect(throws: (any Error).self) {
+      try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    }
+
+    var isDirectory: ObjCBool = false
+    #expect(
+      FileManager.default.fileExists(atPath: destination.path, isDirectory: &isDirectory))
+    #expect(isDirectory.boolValue)
+    #expect(try Data(contentsOf: inhabitant) == Data("precious".utf8))
+  }
+
   @Test("two exports to one destination leave a single complete document")
   func concurrentWritesLeaveOneCompleteDecodableDocument() async throws {
     let dir = makeDirectory()

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -21,12 +21,12 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("a new file is created with owner-only permissions")
-  func writerCreatesNewFileWithMode0600() throws {
+  func writerCreatesNewFileWithMode0600() async throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let destination = dir.appendingPathComponent("words.json")
 
-    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
 
     let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
     let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
@@ -34,20 +34,20 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("an existing file is replaced atomically")
-  func writerAtomicallyReplacesExistingFile() throws {
+  func writerAtomicallyReplacesExistingFile() async throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let destination = dir.appendingPathComponent("words.json")
     try Data("previous contents".utf8).write(to: destination)
 
-    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
 
     let decoded = try CustomWordsTransferDocument(data: Data(contentsOf: destination))
     #expect(decoded.words.map(\.canonical) == ["Kubernetes"])
   }
 
   @Test("overwriting a world-readable file still lands at owner-only")
-  func writerOverwritingAWorldReadableFileEnforcesMode0600() throws {
+  func writerOverwritingAWorldReadableFileEnforcesMode0600() async throws {
     // The bug this freezes (code review): `replaceItemAt` preserves the
     // DESTINATION's metadata by default, so overwriting an existing 0644 file
     // silently discarded the temp file's 0600 and left a backup full of
@@ -59,7 +59,7 @@ struct CustomWordsExportWriterTests {
     try FileManager.default.setAttributes(
       [.posixPermissions: 0o644], ofItemAtPath: destination.path)
 
-    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
 
     let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
     let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
@@ -67,11 +67,11 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("no temporary file is left behind after a successful write")
-  func writerLeavesNoTemporaryFile() throws {
+  func writerLeavesNoTemporaryFile() async throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
 
-    try CustomWordsExportWriter.write(
+    try await CustomWordsExportWriter.write(
       document(["Kubernetes"]), to: dir.appendingPathComponent("words.json"))
 
     let leftovers = try FileManager.default
@@ -81,7 +81,7 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("an unwritable destination leaves any existing file intact")
-  func writerLeavesExistingFileIntactOnFailure() throws {
+  func writerLeavesExistingFileIntactOnFailure() async throws {
     let dir = makeDirectory()
     defer {
       try? FileManager.default.setAttributes(
@@ -96,8 +96,8 @@ struct CustomWordsExportWriterTests {
     try FileManager.default.setAttributes(
       [.posixPermissions: 0o500], ofItemAtPath: dir.path)
 
-    #expect(throws: (any Error).self) {
-      try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    await #expect(throws: (any Error).self) {
+      try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
     }
 
     try FileManager.default.setAttributes(
@@ -106,7 +106,7 @@ struct CustomWordsExportWriterTests {
   }
 
   @Test("a directory at the destination is never replaced or emptied")
-  func writerRefusesToReplaceADirectory() throws {
+  func writerRefusesToReplaceADirectory() async throws {
     // The bug this freezes (code review r2): the move-then-replace fallback
     // originally replaced on ANY move failure, so a directory sitting at the
     // destination path would be replaced by the export file and its contents
@@ -118,8 +118,8 @@ struct CustomWordsExportWriterTests {
     let inhabitant = destination.appendingPathComponent("keep-me.txt")
     try Data("precious".utf8).write(to: inhabitant)
 
-    #expect(throws: (any Error).self) {
-      try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    await #expect(throws: (any Error).self) {
+      try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
     }
 
     var isDirectory: ObjCBool = false
@@ -138,12 +138,12 @@ struct CustomWordsExportWriterTests {
     // The reason the temp filename is unique rather than fixed: a shared temp
     // name would let these two interleave into one corrupt file.
     async let first: Void = Task.detached {
-      try CustomWordsExportWriter.write(
+      try await CustomWordsExportWriter.write(
         CustomWordsTransferDocument(words: [CustomWord(canonical: "Kubernetes")]),
         to: destination)
     }.value
     async let second: Void = Task.detached {
-      try CustomWordsExportWriter.write(
+      try await CustomWordsExportWriter.write(
         CustomWordsTransferDocument(words: [CustomWord(canonical: "Anthropic")]),
         to: destination)
     }.value

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -1,0 +1,113 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1680 (PR-E1) — export writer. Every test writes to a real temp directory,
+/// so atomicity and permissions are verified against the filesystem.
+@Suite("CustomWordsExportWriter")
+struct CustomWordsExportWriterTests {
+
+  private func makeDirectory() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-export-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  private func document(_ canonicals: [String]) -> CustomWordsTransferDocument {
+    CustomWordsTransferDocument(words: canonicals.map { CustomWord(canonical: $0) })
+  }
+
+  @Test("a new file is created with owner-only permissions")
+  func writerCreatesNewFileWithMode0600() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json")
+
+    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
+    let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+    #expect(permissions.int16Value == 0o600)
+  }
+
+  @Test("an existing file is replaced atomically")
+  func writerAtomicallyReplacesExistingFile() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json")
+    try Data("previous contents".utf8).write(to: destination)
+
+    try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+
+    let decoded = try CustomWordsTransferDocument(data: Data(contentsOf: destination))
+    #expect(decoded.words.map(\.canonical) == ["Kubernetes"])
+  }
+
+  @Test("no temporary file is left behind after a successful write")
+  func writerLeavesNoTemporaryFile() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    try CustomWordsExportWriter.write(
+      document(["Kubernetes"]), to: dir.appendingPathComponent("words.json"))
+
+    let leftovers = try FileManager.default
+      .contentsOfDirectory(atPath: dir.path)
+      .filter { $0.hasPrefix(".ew-export-") }
+    #expect(leftovers.isEmpty)
+  }
+
+  @Test("an unwritable destination leaves any existing file intact")
+  func writerLeavesExistingFileIntactOnFailure() throws {
+    let dir = makeDirectory()
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o700], ofItemAtPath: dir.path)
+      try? FileManager.default.removeItem(at: dir)
+    }
+    let destination = dir.appendingPathComponent("words.json")
+    let original = Data("previous contents".utf8)
+    try original.write(to: destination)
+
+    // Read+execute only: the temp file cannot be created in this directory.
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o500], ofItemAtPath: dir.path)
+
+    #expect(throws: (any Error).self) {
+      try CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    }
+
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    #expect(try Data(contentsOf: destination) == original)
+  }
+
+  @Test("two exports to one destination leave a single complete document")
+  func concurrentWritesLeaveOneCompleteDecodableDocument() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let destination = dir.appendingPathComponent("words.json")
+
+    // The reason the temp filename is unique rather than fixed: a shared temp
+    // name would let these two interleave into one corrupt file.
+    async let first: Void = Task.detached {
+      try CustomWordsExportWriter.write(
+        CustomWordsTransferDocument(words: [CustomWord(canonical: "Kubernetes")]),
+        to: destination)
+    }.value
+    async let second: Void = Task.detached {
+      try CustomWordsExportWriter.write(
+        CustomWordsTransferDocument(words: [CustomWord(canonical: "Anthropic")]),
+        to: destination)
+    }.value
+    _ = try await (first, second)
+
+    // Which one wins is unspecified; that it is one complete document is not.
+    let decoded = try CustomWordsTransferDocument(data: Data(contentsOf: destination))
+    #expect(["Kubernetes", "Anthropic"].contains(try #require(decoded.words.first).canonical))
+    #expect(decoded.words.count == 1)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
@@ -448,8 +448,8 @@ struct CustomWordsCoordinatorLaunchFailureTests {
 
   // MARK: - Export readability is a live question, not a launch snapshot (#1682)
 
-  @Test("an unreadable file reports as not readable")
-  func savedWordsAreNotReadableWhileTheFileIsUnreadable() throws {
+  @Test("an unreadable file refuses the refresh and keeps the current list")
+  func refreshFailsClosedWhileTheFileIsUnreadable() throws {
     let url = Self.tempURL()
     defer { Self.cleanup(url) }
     let mgr = CustomWordsManager(fileURL: url)
@@ -464,11 +464,16 @@ struct CustomWordsCoordinatorLaunchFailureTests {
 
     let coordinator = CustomWordsCoordinator(manager: mgr)
     #expect(coordinator.wordsLoadFailureAtLaunch == .unreadable)
-    #expect(coordinator.savedWordsAreReadable == false)
+    #expect(coordinator.refreshFromDiskIfPossible() == false)
+    #expect(coordinator.customWords.isEmpty)
   }
 
-  @Test("readability recovers within the session even though the launch flag does not")
-  func savedWordsBecomeReadableAgainAfterTheFileRecovers() throws {
+  @Test("a recovered file is ADOPTED, not merely reported readable")
+  func refreshAdoptsTheRecoveredWordsRatherThanJustReportingReadable() throws {
+    // The bug this freezes (cloud review, #1682): a readability check that
+    // discarded what it read let export proceed while `customWords` was still
+    // the empty launch fallback, so it wrote a valid EMPTY backup over a real
+    // one. Reporting "readable" is not enough; the words have to arrive.
     let url = Self.tempURL()
     defer { Self.cleanup(url) }
     let mgr = CustomWordsManager(fileURL: url)
@@ -478,16 +483,19 @@ struct CustomWordsCoordinatorLaunchFailureTests {
       [.posixPermissions: 0o000], ofItemAtPath: url.path)
 
     let coordinator = CustomWordsCoordinator(manager: mgr)
-    #expect(coordinator.savedWordsAreReadable == false)
+    #expect(coordinator.customWords.isEmpty, "launch fallback while unreadable")
 
     // The file becomes readable again mid-session.
     try FileManager.default.setAttributes(
       [.posixPermissions: 0o600], ofItemAtPath: url.path)
 
-    // The launch flag is a snapshot and stays set — that is what makes it the
-    // wrong thing to gate export on.
+    #expect(coordinator.refreshFromDiskIfPossible())
+    // The launch flag is a snapshot and stays set — which is exactly why it
+    // was the wrong thing to gate on.
     #expect(coordinator.wordsLoadFailureAtLaunch == .unreadable)
-    #expect(coordinator.savedWordsAreReadable)
+    // The part that matters: the real words are now in hand, so an export
+    // taken at this moment carries them instead of nothing.
+    #expect(coordinator.customWords.contains { $0.canonical == "Kubernetes" })
   }
 
   // MARK: - Stale import commit refreshes the in-memory list (#1679 cloud review)

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsPersistenceTests.swift
@@ -446,6 +446,50 @@ struct CustomWordsCoordinatorLaunchFailureTests {
     #expect(try Data(contentsOf: url) == bytesBefore)
   }
 
+  // MARK: - Export readability is a live question, not a launch snapshot (#1682)
+
+  @Test("an unreadable file reports as not readable")
+  func savedWordsAreNotReadableWhileTheFileIsUnreadable() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let mgr = CustomWordsManager(fileURL: url)
+    var words = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: url.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    let coordinator = CustomWordsCoordinator(manager: mgr)
+    #expect(coordinator.wordsLoadFailureAtLaunch == .unreadable)
+    #expect(coordinator.savedWordsAreReadable == false)
+  }
+
+  @Test("readability recovers within the session even though the launch flag does not")
+  func savedWordsBecomeReadableAgainAfterTheFileRecovers() throws {
+    let url = Self.tempURL()
+    defer { Self.cleanup(url) }
+    let mgr = CustomWordsManager(fileURL: url)
+    var words = try #require(mgr.load())
+    try mgr.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: url.path)
+
+    let coordinator = CustomWordsCoordinator(manager: mgr)
+    #expect(coordinator.savedWordsAreReadable == false)
+
+    // The file becomes readable again mid-session.
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o600], ofItemAtPath: url.path)
+
+    // The launch flag is a snapshot and stays set — that is what makes it the
+    // wrong thing to gate export on.
+    #expect(coordinator.wordsLoadFailureAtLaunch == .unreadable)
+    #expect(coordinator.savedWordsAreReadable)
+  }
+
   // MARK: - Stale import commit refreshes the in-memory list (#1679 cloud review)
 
   @Test("a stale import commit refreshes the coordinator's list from disk")

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -1,0 +1,179 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1680 (PR-E1) — the portable backup format and its writer.
+@MainActor
+@Suite("CustomWordsTransferDocument")
+struct CustomWordsTransferDocumentTests {
+
+  private func word(
+    _ canonical: String,
+    aliases: [String] = [],
+    category: WordCategory = .general,
+    priority: Int = 0,
+    forceReplace: Bool = false,
+    caseSensitive: Bool = false,
+    source: WordSource = .user,
+    frequencyUsed: Int = 0,
+    lastUsed: Date? = nil,
+    minSimilarityOverride: Double? = nil
+  ) -> CustomWord {
+    CustomWord(
+      canonical: canonical, aliases: aliases, category: category, priority: priority,
+      forceReplace: forceReplace, caseSensitive: caseSensitive, source: source,
+      frequencyUsed: frequencyUsed, lastUsed: lastUsed,
+      minSimilarityOverride: minSimilarityOverride)
+  }
+
+  // MARK: - Round trip
+
+  @Test("every portable field survives an export and re-decode")
+  func exportRoundTripPreservesEveryPortableField() throws {
+    let original = word(
+      "Kubernetes", aliases: ["k8s", "kube"], category: .brand, priority: 3,
+      forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.8)
+    let data = try CustomWordsTransferDocument(words: [original]).encoded()
+    let decoded = try CustomWordsTransferDocument(data: data)
+
+    let restored = try #require(decoded.words.first)
+    #expect(restored.canonical == "Kubernetes")
+    #expect(restored.aliases == ["k8s", "kube"])
+    #expect(restored.category == .brand)
+    #expect(restored.priority == 3)
+    #expect(restored.forceReplace == true)
+    #expect(restored.caseSensitive == true)
+    #expect(restored.minSimilarityOverride == 0.8)
+    #expect(restored.id == original.id)
+  }
+
+  @Test("usage history never leaves this Mac")
+  func exportOmitsUsageHistoryAndRuntimeSource() throws {
+    let used = word("Kubernetes", frequencyUsed: 42, lastUsed: Date(timeIntervalSince1970: 1))
+    let data = try CustomWordsTransferDocument(words: [used]).encoded()
+    let json = try #require(String(data: data, encoding: .utf8))
+
+    #expect(!json.contains("frequencyUsed"))
+    #expect(!json.contains("lastUsed"))
+    #expect(!json.contains("source"))
+  }
+
+  @Test("an empty word list is a valid backup, not an error")
+  func emptyWordListIsAValidBackup() throws {
+    let data = try CustomWordsTransferDocument(words: []).encoded()
+    let decoded = try CustomWordsTransferDocument(data: data)
+    #expect(decoded.words.isEmpty)
+    #expect(decoded.format == CustomWordsTransferDocument.formatIdentifier)
+    #expect(decoded.version == CustomWordsTransferDocument.currentVersion)
+  }
+
+  // MARK: - Decode rejection
+
+  @Test("a JSON file that isn't ours is rejected by name, not called damaged")
+  func decoderRejectsWrongFormatIdentifier() throws {
+    let foreign = Data(#"{"format":"com.example.other","version":1,"words":[]}"#.utf8)
+    #expect(throws: CustomWordsTransferError.notAnEnviousWisprBackup) {
+      _ = try CustomWordsTransferDocument(data: foreign)
+    }
+  }
+
+  @Test("a backup from a newer app version is refused rather than guessed at")
+  func decoderRejectsUnsupportedFutureVersion() throws {
+    let future = Data(
+      #"{"format":"com.enviouswispr.custom-words","version":99,"words":[]}"#.utf8)
+    #expect(throws: CustomWordsTransferError.unsupportedVersion(99)) {
+      _ = try CustomWordsTransferDocument(data: future)
+    }
+  }
+
+  @Test("damaged bytes read as damaged")
+  func decoderRejectsMalformedData() throws {
+    #expect(throws: CustomWordsTransferError.malformed) {
+      _ = try CustomWordsTransferDocument(data: Data("not json at all {{{".utf8))
+    }
+  }
+
+  // MARK: - Import handoff
+
+  @Test("candidates supply all six authority fields, including both clears")
+  func candidatesForImportSupplyAllSixAuthorityFieldsIncludingClears() throws {
+    // A word with no aliases and no per-term strictness. Backup is the only
+    // source that can say "genuinely none" rather than "no opinion", and on a
+    // Replace that difference decides whether hand-tuned values are cleared.
+    let bare = word("Kubernetes", aliases: [], minSimilarityOverride: nil)
+    let candidates = CustomWordsTransferDocument(words: [bare]).candidatesForImport()
+    let candidate = try #require(candidates.first)
+
+    #expect(candidate.aliases == .supplied([]))
+    #expect(candidate.minSimilarityOverride == .supplied(nil))
+    #expect(candidate.category == .supplied(.general))
+    #expect(candidate.priority == .supplied(0))
+    #expect(candidate.forceReplace == .supplied(false))
+    #expect(candidate.caseSensitive == .supplied(false))
+  }
+
+  @Test("candidates carry no usage history and no AI suggestions")
+  func candidatesForImportResetsUsageHistory() throws {
+    let used = word("Kubernetes", frequencyUsed: 9, lastUsed: Date())
+    let candidate = try #require(
+      CustomWordsTransferDocument(words: [used]).candidatesForImport().first)
+    // The candidate type structurally cannot carry usage history; this asserts
+    // the suggestion channel is also empty, so nothing machine-generated rides
+    // in on a restore.
+    #expect(candidate.suggestedAliases.isEmpty)
+  }
+
+  @Test("a foreign id is review identity only")
+  func candidatesForImportPreservesForeignIDAsReviewIdentityOnly() throws {
+    let original = word("Kubernetes")
+    let data = try CustomWordsTransferDocument(words: [original]).encoded()
+    let candidate = try #require(
+      try CustomWordsTransferDocument(data: data).candidatesForImport().first)
+    // It round-trips so the review row is stable, but the commit path mints a
+    // fresh UUID on add and keeps the local word's UUID on replace — this id
+    // never becomes a persisted local identity.
+    #expect(candidate.id == original.id)
+  }
+
+  // MARK: - Built-in tagging (the export-scope prerequisite)
+
+  @Test("every built-in is constructed tagged as built-in")
+  func builtinDefaultsAreAllConstructedWithBuiltinSource() {
+    #expect(CustomWordsManager.builtinDefaults.isEmpty == false)
+    for builtin in CustomWordsManager.builtinDefaults {
+      #expect(
+        builtin.word.source == .builtin,
+        "built-in '\(builtin.id)' is untagged and would export as a user word")
+    }
+  }
+
+  @Test("re-tagging a built-in as user-owned preserves every other field")
+  func ownedByUserPreservesEveryOtherField() {
+    let builtin = word(
+      "GitHub", aliases: ["git hub"], category: .brand, priority: 2,
+      forceReplace: true, caseSensitive: true, source: .builtin,
+      frequencyUsed: 7, lastUsed: Date(timeIntervalSince1970: 5),
+      minSimilarityOverride: 0.9)
+    let owned = builtin.ownedByUser()
+
+    #expect(owned.source == .user)
+    #expect(owned.id == builtin.id)
+    #expect(owned.canonical == builtin.canonical)
+    #expect(owned.aliases == builtin.aliases)
+    #expect(owned.category == builtin.category)
+    #expect(owned.priority == builtin.priority)
+    #expect(owned.forceReplace == builtin.forceReplace)
+    #expect(owned.caseSensitive == builtin.caseSensitive)
+    #expect(owned.frequencyUsed == builtin.frequencyUsed)
+    #expect(owned.lastUsed == builtin.lastUsed)
+    #expect(owned.minSimilarityOverride == builtin.minSimilarityOverride)
+  }
+
+  @Test("re-tagging an already-user word returns it unchanged")
+  func ownedByUserIsANoOpForUserWords() {
+    let user = word("Kubernetes", source: .user)
+    #expect(user.ownedByUser() == user)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -88,13 +88,15 @@ struct CustomWordsTransferDocumentTests {
     }
   }
 
-  @Test("a version below the first supported format is refused")
-  func decoderRejectsVersionBelowTheFirstSupportedFormat() throws {
+  @Test("a version below the first supported format reads as damaged, not as newer")
+  func decoderRejectsVersionBelowTheFirstSupportedFormatAsMalformed() throws {
     // Version 1 is the first format; nothing earlier ever existed, so a file
     // claiming 0 is malformed or tampered rather than merely old (review r2).
+    // It must NOT say "made by a newer version — update the app" (review r4):
+    // that is advice which cannot help this user.
     let ancient = Data(
       #"{"format":"com.enviouswispr.custom-words","version":0,"words":[]}"#.utf8)
-    #expect(throws: CustomWordsTransferError.unsupportedVersion(0)) {
+    #expect(throws: CustomWordsTransferError.malformed) {
       _ = try CustomWordsTransferDocument(data: ancient)
     }
   }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -125,16 +125,25 @@ struct CustomWordsTransferDocumentTests {
     #expect(candidate.suggestedAliases.isEmpty)
   }
 
-  @Test("a foreign id is review identity only")
-  func candidatesForImportPreservesForeignIDAsReviewIdentityOnly() throws {
+  @Test("a candidate never carries the exported persistence id")
+  func candidatesForImportMintsFreshReviewIdentities() throws {
     let original = word("Kubernetes")
     let data = try CustomWordsTransferDocument(words: [original]).encoded()
     let candidate = try #require(
       try CustomWordsTransferDocument(data: data).candidatesForImport().first)
-    // It round-trips so the review row is stable, but the commit path mints a
-    // fresh UUID on add and keeps the local word's UUID on replace — this id
-    // never becomes a persisted local identity.
-    #expect(candidate.id == original.id)
+
+    // Restoring onto the Mac that wrote the backup would otherwise make the
+    // candidate id equal the live word's id, and the collision detector would
+    // report each word's own aliases as colliding with itself (code review).
+    #expect(candidate.id != original.id)
+  }
+
+  @Test("two candidates from one backup have distinct review identities")
+  func candidatesForImportGivesEachRowItsOwnIdentity() throws {
+    let candidates = CustomWordsTransferDocument(
+      words: [word("Kubernetes"), word("Anthropic")]
+    ).candidatesForImport()
+    #expect(Set(candidates.map(\.id)).count == 2)
   }
 
   // MARK: - Built-in tagging (the export-scope prerequisite)

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -88,6 +88,17 @@ struct CustomWordsTransferDocumentTests {
     }
   }
 
+  @Test("a version below the first supported format is refused")
+  func decoderRejectsVersionBelowTheFirstSupportedFormat() throws {
+    // Version 1 is the first format; nothing earlier ever existed, so a file
+    // claiming 0 is malformed or tampered rather than merely old (review r2).
+    let ancient = Data(
+      #"{"format":"com.enviouswispr.custom-words","version":0,"words":[]}"#.utf8)
+    #expect(throws: CustomWordsTransferError.unsupportedVersion(0)) {
+      _ = try CustomWordsTransferDocument(data: ancient)
+    }
+  }
+
   @Test("damaged bytes read as damaged")
   func decoderRejectsMalformedData() throws {
     #expect(throws: CustomWordsTransferError.malformed) {

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -99,6 +99,21 @@ struct CustomWordsTransferDocumentTests {
     }
   }
 
+  @Test("a future version is reported as newer, not as damaged")
+  func futureVersionWithUnknownPayloadReportsVersionNotDamage() throws {
+    // The header is judged before the payload (review r3), so a future format
+    // that changed a word field still gets the honest "update the app"
+    // message instead of "your backup is damaged".
+    let future = Data(
+      """
+      {"format":"com.enviouswispr.custom-words","version":99,
+       "words":[{"somethingNew":true}]}
+      """.utf8)
+    #expect(throws: CustomWordsTransferError.unsupportedVersion(99)) {
+      _ = try CustomWordsTransferDocument(data: future)
+    }
+  }
+
   @Test("damaged bytes read as damaged")
   func decoderRejectsMalformedData() throws {
     #expect(throws: CustomWordsTransferError.malformed) {

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -172,6 +172,29 @@ struct ImportFileParserTests {
     }
   }
 
+  @Test(
+    "healthy JSON that isn't ours reads as a different file, not a damaged one",
+    arguments: ["[1,2,3]", "\"just a string\"", "42", "[]"])
+  func nonObjectJSONReportsForeignRatherThanDamaged(payload: String) async throws {
+    // A config file, an API dump, a list saved as JSON — all valid documents
+    // that simply aren't ours. Calling them damaged sends the user hunting for
+    // corruption that isn't there (review r2).
+    let url = try write(payload, as: "other.json")
+    await #expect(throws: ImportFileError.exportedWords(.notAnEnviousWisprBackup)) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a file claiming to be ours but broken still reads as damaged")
+  func ourFormatWithBrokenPayloadStillReadsAsDamaged() async throws {
+    let url = try write(
+      #"{"format":"com.enviouswispr.custom-words","version":1,"words":"not-an-array"}"#,
+      as: "broken.json")
+    await #expect(throws: ImportFileError.exportedWords(.malformed)) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
   // MARK: - Limits
 
   @Test("an absurdly large file is refused before it is read into memory")

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -1,0 +1,195 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+
+@testable import EnviousWisprPostProcessing
+
+/// #1683 (PR-U1) — reading a chosen file into import candidates.
+///
+/// The failure paths carry most of the weight: a user who picks the wrong file
+/// should be told which wrong thing they picked, not handed "damaged" for a
+/// perfectly healthy document.
+@MainActor
+@Suite("ImportFileParser")
+struct ImportFileParserTests {
+
+  private func write(_ contents: Data, as name: String) throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-file-import-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent(name)
+    try contents.write(to: url)
+    return url
+  }
+
+  private func write(_ text: String, as name: String) throws -> URL {
+    try write(Data(text.utf8), as: name)
+  }
+
+  // MARK: - Backup format
+
+  @Test("an exported backup restores every portable field")
+  func backupParserRestoresEveryPortableField() async throws {
+    let original = CustomWord(
+      canonical: "Kubernetes", aliases: ["k8s"], category: .brand, priority: 3,
+      forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.8)
+    let data = try CustomWordsTransferDocument(words: [original]).encoded()
+    let url = try write(data, as: "words.json")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+    let candidate = try #require(batch.candidates.first)
+
+    #expect(batch.sourceID == "backup")
+    #expect(candidate.canonical == "Kubernetes")
+    // Backup is the one source with real authority over every field.
+    #expect(candidate.aliases == .supplied(["k8s"]))
+    #expect(candidate.category == .supplied(.brand))
+    #expect(candidate.priority == .supplied(3))
+    #expect(candidate.forceReplace == .supplied(true))
+    #expect(candidate.caseSensitive == .supplied(true))
+    #expect(candidate.minSimilarityOverride == .supplied(0.8))
+  }
+
+  @Test("a JSON file that isn't ours says so, rather than reading as damaged")
+  func foreignJSONReportsItIsNotABackup() async throws {
+    let url = try write(#"{"format":"com.example.other","version":1,"words":[]}"#, as: "other.json")
+    await #expect(throws: ImportFileError.backup(.notAnEnviousWisprBackup)) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a backup from a newer version says to update, not that it is damaged")
+  func futureBackupReportsVersionRatherThanDamage() async throws {
+    let url = try write(
+      #"{"format":"com.enviouswispr.custom-words","version":99,"words":[]}"#,
+      as: "future.json")
+    await #expect(throws: ImportFileError.backup(.unsupportedVersion(99))) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  // MARK: - Plain text
+
+  @Test("a plain list becomes one candidate per word")
+  func plainTextParsesOneCandidatePerWord() async throws {
+    let url = try write("Kubernetes\nAnthropic\nQualtrics", as: "words.txt")
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.sourceID == "plain-text")
+    #expect(batch.candidates.map(\.canonical) == ["Kubernetes", "Anthropic", "Qualtrics"])
+  }
+
+  @Test("a file list splits exactly like the paste box does")
+  func plainTextUsesTheSameRulesAsPaste() async throws {
+    // One parser, not two. A word list is a word list whether it was typed or
+    // saved to a file, and two implementations would eventually disagree about
+    // what "Envious Labs" or "C++" means.
+    let text = "Envious Labs, C++\nand/or\nSmith; Jones\nGitHub\ngithub"
+    let url = try write(text, as: "words.txt")
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.candidates.map(\.canonical) == PasteWordsParser.parse(text))
+    #expect(
+      batch.candidates.map(\.canonical)
+        == ["Envious Labs", "C++", "and/or", "Smith; Jones", "GitHub"])
+  }
+
+  @Test("a plain list claims no authority over any field")
+  func plainTextLeavesEveryAuthorityFieldUnspecified() async throws {
+    let url = try write("Kubernetes", as: "words.txt")
+    let candidate = try #require(
+      try await FileImportSource(url: url).loadCandidates().candidates.first)
+
+    #expect(candidate.aliases == .unspecified)
+    #expect(candidate.category == .unspecified)
+    #expect(candidate.priority == .unspecified)
+    #expect(candidate.forceReplace == .unspecified)
+    #expect(candidate.caseSensitive == .unspecified)
+    #expect(candidate.minSimilarityOverride == .unspecified)
+  }
+
+  @Test("an empty file yields nothing to import rather than an error")
+  func emptyFileYieldsNoCandidates() async throws {
+    let url = try write("   \n\n  ", as: "empty.txt")
+    let batch = try await FileImportSource(url: url).loadCandidates()
+    #expect(batch.candidates.isEmpty)
+  }
+
+  @Test("text that isn't UTF-8 still reads rather than being refused")
+  func latin1TextIsAccepted() async throws {
+    let url = try write(try #require("Beyoncé".data(using: .isoLatin1)), as: "legacy.txt")
+    let batch = try await FileImportSource(url: url).loadCandidates()
+    #expect(batch.candidates.map(\.canonical) == ["Beyoncé"])
+  }
+
+  // MARK: - Unsupported and unreadable
+
+  @Test("a spreadsheet is named as unsupported, with somewhere to go")
+  func spreadsheetReportsUnsupportedType() async throws {
+    let url = try write("a,b,c", as: "words.csv")
+    await #expect(throws: ImportFileError.unsupportedType(".csv")) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a spreadsheet is never quietly read as a word list")
+  func csvIsRefusedRatherThanMangledByThePlainTextParser() async throws {
+    // The bug this freezes: CSV conforms to public.plain-text, so a
+    // conformance-based match handed spreadsheets to the plain-text parser.
+    // That parser splits on commas, so this single row would have imported
+    // three "words" — the header included — silently corrupting the user's
+    // dictionary. Refusing the file is the only honest outcome until a real
+    // CSV parser is registered.
+    let url = try write("canonical,alias,category\nGitHub,git hub,brand", as: "words.csv")
+
+    await #expect(throws: ImportFileError.unsupportedType(".csv")) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a tab-separated file is refused for the same reason")
+  func tsvIsAlsoRefused() async throws {
+    let url = try write("canonical\talias\nGitHub\tgit hub", as: "words.tsv")
+    await #expect(throws: ImportFileError.unsupportedType(".tsv")) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("an unreadable file reports as unreadable")
+  func unreadableFileReportsUnreadable() async throws {
+    let url = try write("Kubernetes", as: "words.txt")
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: url.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    await #expect(throws: ImportFileError.unreadable) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  // MARK: - Registry
+
+  @Test("the picker offers exactly what the registry can read")
+  func acceptedContentTypesComeFromTheRegistry() {
+    // One source of truth, so a format cannot be selectable but unreadable —
+    // or readable but unselectable.
+    let types = ImportFileRegistry.v1.acceptedContentTypes
+    #expect(types.contains(.json))
+    #expect(types.contains(.plainText))
+    #expect(!types.contains(.commaSeparatedText))
+  }
+
+  @Test("registering a format is all it takes to make it readable")
+  func registryDispatchesByFileType() throws {
+    let json = try write("{}", as: "a.json")
+    let text = try write("a", as: "a.txt")
+
+    #expect(ImportFileRegistry.v1.parser(for: json)?.identifier == "backup")
+    #expect(ImportFileRegistry.v1.parser(for: text)?.identifier == "plain-text")
+    #expect(ImportFileRegistry.v1.parser(for: try write("a", as: "a.csv")) == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -27,10 +27,10 @@ struct ImportFileParserTests {
     try write(Data(text.utf8), as: name)
   }
 
-  // MARK: - Backup format
+  // MARK: - Exported words file
 
-  @Test("an exported backup restores every portable field")
-  func backupParserRestoresEveryPortableField() async throws {
+  @Test("an exported words file brings back every portable field")
+  func exportedWordsFileBringsBackEveryPortableField() async throws {
     let original = CustomWord(
       canonical: "Kubernetes", aliases: ["k8s"], category: .brand, priority: 3,
       forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.8)
@@ -40,9 +40,10 @@ struct ImportFileParserTests {
     let batch = try await FileImportSource(url: url).loadCandidates()
     let candidate = try #require(batch.candidates.first)
 
-    #expect(batch.sourceID == "backup")
+    #expect(batch.sourceID == "exported-words")
     #expect(candidate.canonical == "Kubernetes")
-    // Backup is the one source with real authority over every field.
+    // An exported file is the one source with real authority over every
+    // field: it is the user's own data going out and coming back.
     #expect(candidate.aliases == .supplied(["k8s"]))
     #expect(candidate.category == .supplied(.brand))
     #expect(candidate.priority == .supplied(3))
@@ -52,19 +53,19 @@ struct ImportFileParserTests {
   }
 
   @Test("a JSON file that isn't ours says so, rather than reading as damaged")
-  func foreignJSONReportsItIsNotABackup() async throws {
+  func foreignJSONReportsItDidNotComeFromEnviousWispr() async throws {
     let url = try write(#"{"format":"com.example.other","version":1,"words":[]}"#, as: "other.json")
-    await #expect(throws: ImportFileError.backup(.notAnEnviousWisprBackup)) {
+    await #expect(throws: ImportFileError.exportedWords(.notAnEnviousWisprBackup)) {
       _ = try await FileImportSource(url: url).loadCandidates()
     }
   }
 
-  @Test("a backup from a newer version says to update, not that it is damaged")
-  func futureBackupReportsVersionRatherThanDamage() async throws {
+  @Test("a file from a newer version says to update, not that it is damaged")
+  func futureFileReportsVersionRatherThanDamage() async throws {
     let url = try write(
       #"{"format":"com.enviouswispr.custom-words","version":99,"words":[]}"#,
       as: "future.json")
-    await #expect(throws: ImportFileError.backup(.unsupportedVersion(99))) {
+    await #expect(throws: ImportFileError.exportedWords(.unsupportedVersion(99))) {
       _ = try await FileImportSource(url: url).loadCandidates()
     }
   }
@@ -171,6 +172,41 @@ struct ImportFileParserTests {
     }
   }
 
+  // MARK: - Limits
+
+  @Test("an absurdly large file is refused before it is read into memory")
+  func oversizedFileIsRefusedBeforeReading() async throws {
+    // Refusing by size beats discovering it after allocating: a word list is
+    // small, so anything this big is a mistaken selection.
+    let url = try write(Data(count: FileImportSource.maximumFileBytes + 1), as: "huge.txt")
+    await #expect(throws: ImportFileError.tooLarge) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a file with more words than the limit is refused with both numbers")
+  func tooManyWordsIsRefusedWithCounts() async throws {
+    let limit = FileImportSource.maximumCandidates
+    let words = (0...limit).map { "word\($0)" }.joined(separator: "\n")
+    let url = try write(words, as: "many.txt")
+
+    await #expect(
+      throws: ImportFileError.tooManyWords(found: limit + 1, limit: limit)
+    ) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a file exactly at the limit is accepted")
+  func fileAtExactlyTheLimitIsAccepted() async throws {
+    let limit = FileImportSource.maximumCandidates
+    let words = (1...limit).map { "word\($0)" }.joined(separator: "\n")
+    let url = try write(words, as: "atlimit.txt")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+    #expect(batch.candidates.count == limit)
+  }
+
   // MARK: - Registry
 
   @Test("the picker offers exactly what the registry can read")
@@ -188,7 +224,7 @@ struct ImportFileParserTests {
     let json = try write("{}", as: "a.json")
     let text = try write("a", as: "a.txt")
 
-    #expect(ImportFileRegistry.v1.parser(for: json)?.identifier == "backup")
+    #expect(ImportFileRegistry.v1.parser(for: json)?.identifier == "exported-words")
     #expect(ImportFileRegistry.v1.parser(for: text)?.identifier == "plain-text")
     #expect(ImportFileRegistry.v1.parser(for: try write("a", as: "a.csv")) == nil)
   }

--- a/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
@@ -1,0 +1,135 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1681 (PR-P1) — pasted-text parsing.
+///
+/// The parser's job is to be conservative. A missed split costs the user one
+/// edit; a wrong split silently invents words they never typed and quietly
+/// corrupts their dictionary, so the non-separator cases matter more than the
+/// separator ones.
+@Suite("PasteWordsParser")
+struct PasteWordsImportSourceTests {
+
+  // MARK: - Separators
+
+  @Test(
+    "each supported separator splits",
+    arguments: [
+      ("Kubernetes,Anthropic", ["Kubernetes", "Anthropic"]),
+      ("Kubernetes\nAnthropic", ["Kubernetes", "Anthropic"]),
+      ("Kubernetes\r\nAnthropic", ["Kubernetes", "Anthropic"]),
+      ("Kubernetes\rAnthropic", ["Kubernetes", "Anthropic"]),
+      ("Kubernetes, Anthropic,\n Qualtrics", ["Kubernetes", "Anthropic", "Qualtrics"]),
+    ])
+  func supportedSeparatorsSplit(input: String, expected: [String]) {
+    #expect(PasteWordsParser.parse(input) == expected)
+  }
+
+  @Test(
+    "nothing else splits",
+    arguments: [
+      // A space is not a separator: multi-word terms are the common case.
+      ("Envious Labs", ["Envious Labs"]),
+      ("Visual Studio Code", ["Visual Studio Code"]),
+      // Punctuation that lives INSIDE real terms.
+      ("C++", ["C++"]),
+      ("C#", ["C#"]),
+      (".NET", [".NET"]),
+      ("Anand-Vaish", ["Anand-Vaish"]),
+      ("and/or", ["and/or"]),
+      ("Smith; Jones", ["Smith; Jones"]),
+      ("node.js", ["node.js"]),
+    ])
+  func nonSeparatorsAreLeftIntact(input: String, expected: [String]) {
+    #expect(PasteWordsParser.parse(input) == expected)
+  }
+
+  // MARK: - Trimming and empties
+
+  @Test("surrounding whitespace is trimmed, inner spacing is kept")
+  func whitespaceIsTrimmedButNotCollapsed() {
+    #expect(PasteWordsParser.parse("  Envious Labs  ") == ["Envious Labs"])
+  }
+
+  @Test("empty and whitespace-only pieces are dropped")
+  func emptyPiecesAreDropped() {
+    #expect(PasteWordsParser.parse("Kubernetes,,  ,\n\n,Anthropic") == ["Kubernetes", "Anthropic"])
+  }
+
+  @Test(
+    "input with no words yields nothing rather than a blank row",
+    arguments: ["", "   ", "\n\n", ",,,", " , \n , "])
+  func inputWithoutWordsYieldsNothing(input: String) {
+    #expect(PasteWordsParser.parse(input).isEmpty)
+  }
+
+  // MARK: - Deduplication
+
+  @Test("a repeated word appears once, in its first spelling")
+  func withinPasteDedupPreservesFirstSpelling() {
+    #expect(PasteWordsParser.parse("GitHub\ngithub\nGITHUB") == ["GitHub"])
+  }
+
+  @Test("dedup uses the same normalization the compare engine uses")
+  func dedupMatchesCompareEngineNormalization() {
+    // Both collapse to one key in the engine, so they must collapse here too;
+    // otherwise the review screen would show two rows that persistence would
+    // then refuse as duplicates.
+    let parsed = PasteWordsParser.parse("Claude Code\nClaude  Code")
+    #expect(parsed == ["Claude Code"])
+  }
+
+  @Test("distinct words are all kept, in paste order")
+  func distinctWordsKeepPasteOrder() {
+    #expect(
+      PasteWordsParser.parse("Qualtrics\nKubernetes\nAnthropic")
+        == ["Qualtrics", "Kubernetes", "Anthropic"])
+  }
+
+  // MARK: - Source contract
+
+  @Test("the source produces candidates with no authority over any field")
+  func sourceLeavesEveryAuthorityFieldUnspecified() async throws {
+    let batch = try await PasteWordsImportSource(text: "Kubernetes").loadCandidates()
+    let candidate = try #require(batch.candidates.first)
+
+    // Pasted text carries no alias data and no opinions, so a Replace built
+    // from it must never claim authority over a hand-tuned value.
+    #expect(candidate.aliases == .unspecified)
+    #expect(candidate.category == .unspecified)
+    #expect(candidate.priority == .unspecified)
+    #expect(candidate.forceReplace == .unspecified)
+    #expect(candidate.caseSensitive == .unspecified)
+    #expect(candidate.minSimilarityOverride == .unspecified)
+    // v1 ships no on-device suggestions; the channel exists but stays empty.
+    #expect(candidate.suggestedAliases.isEmpty)
+  }
+
+  @Test("the source reports a stable id and carries no notices in v1")
+  func sourceReportsStableIdentityAndNoNotices() async throws {
+    let batch = try await PasteWordsImportSource(text: "Kubernetes, Anthropic")
+      .loadCandidates()
+    #expect(batch.sourceID == "paste")
+    #expect(batch.candidates.map(\.canonical) == ["Kubernetes", "Anthropic"])
+    // Notices exist for the suggestion stage; with no AI call there is nothing
+    // to report, and an empty list is the honest answer rather than a
+    // placeholder notice.
+    #expect(batch.notices.isEmpty)
+  }
+
+  @Test("empty pasted text produces an empty batch, not an error")
+  func emptyTextProducesAnEmptyBatch() async throws {
+    let batch = try await PasteWordsImportSource(text: "   \n  ").loadCandidates()
+    #expect(batch.candidates.isEmpty)
+  }
+
+  @Test("each candidate gets its own identity")
+  func candidatesHaveDistinctIdentities() async throws {
+    let batch = try await PasteWordsImportSource(text: "Kubernetes\nAnthropic\nQualtrics")
+      .loadCandidates()
+    #expect(Set(batch.candidates.map(\.id)).count == 3)
+  }
+}


### PR DESCRIPTION
Part of #1619. Closes #1683.

Stacked on #1682 (export). Merge that first.

## What this is

A file picker plus a format registry, so an exported file can actually be read back and a saved word list can be imported.

Two formats:
- **EnviousWispr words file** — bridges the transfer document. Without it, Export would be a promise the app cannot keep.
- **Plain text** — reuses the paste parser rather than a second implementation. A word list is a word list whether typed or saved to a file; two parsers would eventually disagree about "Envious Labs" or "C++".

## The subtle one: exact type match, not conformance

CSV and TSV *conform to* `public.plain-text`. A conformance match therefore handed spreadsheets to the plain-text parser — which splits on commas. One row of `canonical,alias,category` would have imported **three words, header included**, silently corrupting the user's dictionary.

A format is now readable only when a parser claims it by name. Frozen by two tests, verified to fail under conformance matching.

## Terminology change (founder, 2026-07-19)

The product has **two** ideas: import and export. Calling the exported file a "backup" invented a third, and collided with the app's own internal safety copy — which is invisible plumbing, not a user concept. User-facing copy and the parser type now say what the file is: one you exported from EnviousWispr.

## Scope decisions

**CSV deliberately not shipped, and the dependency question left undecided.** Researched with a grounded consult ([#1683 comment](https://github.com/saurabhav88/EnviousWispr/issues/1683)): the plan's original `CodableCSV` recommendation predates the Add/Skip-only scope, and under it a CSV's extra columns are discarded except on a brand-new word. The consult also surfaced an option the plan missed — Apple's own `TabularData`, available since macOS 12 against a macOS 14 minimum, no third-party supply chain. Ranked order if CSV ever becomes required is recorded on the issue.

**No new module.** The plan put parsers in a new leaf module; with two conformers, one already living beside the transfer document, it would hold one file and its own build wiring. Deliberate deviation, extract when there is something to hold.

## Review record — 5 rounds

| Round | Finding |
|---|---|
| r1 | Export stayed open after a **corrupted** launch, able to write an empty file over a real one. File reading blocked the main actor. No size or word-count limits. Copy said "restore" while the flow cannot restore. |
| r2 | Paste was unbounded while files were capped, and re-parsed the whole draft per keystroke. Valid foreign JSON reported as "damaged". |
| r3 | **Failed refresh still mutated state**; **cancel was not the no-op its own comment promised**; size limit had a stat-then-read race. |
| r4 | Reload and export-safety had been folded into one method, re-creating a stale-commit loop a previous round fixed. Single `read(upToCount:)` could import a truncated prefix. |
| r5 | Repeat of a claim already rejected — see below. |

### The rejected finding, twice

r4 and r5 both claimed `UTType(filenameExtension:)` returns dynamic `dyn.*` types, so every `.json`/`.txt` upload is rejected, "confirmed by 19 test failures."

Not reproduced in either environment. A direct probe resolves `json` → `public.json` and `txt` → `public.plain-text`, both non-dynamic and both matching; the suite passes **19/19 under `scripts/xcode-test.sh` and under `swift test`**. Per this project's same-root-recurrence rule, the answer to a finding arriving twice is not a third round of the same argument — the verification and the contingent fix now live at the dispatch site.

## Known gap, inherited not introduced

Importing a file containing a word you already have skips it, leaving your existing word and its synonyms untouched — the founder's explicit v1 rule. So a word you had *edited* does not come back as you had it. Honest rather than silent: the row reports "you already have this one".

## Validation

3,382 tests green.
