### PR TITLE
feat(user): upload a file — words file and plain text (PR-U1, #1683)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -111,19 +111,16 @@ final class CustomWordsCoordinator {
       onWordsChanged?(customWords)
     }
 
-    // A corrupted file was ARCHIVED aside at launch, so this reload sees a
-    // legitimately missing file and reports a clean, empty library. That reads
-    // as success but the user's real words are sitting in the archive — and an
-    // export taken now would write an empty backup over the one they picked,
-    // destroying the copy they still had (code review, #1683).
+    // NOTE: the corrupted-library refusal deliberately does NOT live here.
+    // An earlier version put it inside this reload and that re-created the
+    // stale-import loop it was meant to prevent: the import path stopped
+    // adopting the current library, so every re-comparison saw the same old
+    // list and Confirm could never succeed. This method answers "can I read
+    // it", and must always adopt what it reads; `canExportCurrentWords`
+    // answers "is it safe to write out". Two questions, two answers.
     //
-    // Once they have authored a word since, they have visibly accepted the
-    // fresh start and are building on it, so the list is theirs again.
-    if wordsLoadFailureAtLaunch == .corrupted,
-      !refreshed.contains(where: { $0.source == .user })
-    {
-      return false
-    }
+    // A rebase reintroduced the old inline refusal alongside the new one, and
+    // the export test caught the contradiction immediately.
     return true
   }
 

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -110,6 +110,20 @@ final class CustomWordsCoordinator {
       customWords = refreshed
       onWordsChanged?(customWords)
     }
+
+    // A corrupted file was ARCHIVED aside at launch, so this reload sees a
+    // legitimately missing file and reports a clean, empty library. That reads
+    // as success but the user's real words are sitting in the archive — and an
+    // export taken now would write an empty backup over the one they picked,
+    // destroying the copy they still had (code review, #1683).
+    //
+    // Once they have authored a word since, they have visibly accepted the
+    // fresh start and are building on it, so the list is theirs again.
+    if wordsLoadFailureAtLaunch == .corrupted,
+      !refreshed.contains(where: { $0.source == .user })
+    {
+      return false
+    }
     return true
   }
 

--- a/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
@@ -49,11 +49,44 @@ enum CustomWordsExportAction {
     let document = CustomWordsTransferDocument(
       words: coordinator.customWords.filter { $0.source == .user })
 
+    // 5. Refuse to write a file our own importer would reject. The exporter
+    //    and importer are one round trip, so a limit enforced on only one side
+    //    is a promise the pair cannot keep: raising the IMPORT ceilings while
+    //    export kept no preflight left the same "writes a file it then
+    //    refuses" hole open, just from the other direction (Codex import
+    //    taxonomy audit, #1683 — class C08).
+    //
+    //    Checked against the encoded bytes, not an estimate, because the byte
+    //    ceiling is enforced on encoded bytes at read time.
     do {
+      let encoded = try document.encoded()
+      if let refusal = Self.refusalIfUnimportable(document: document, encoded: encoded) {
+        return .failed(message: refusal)
+      }
       try await write(document, destination)
       return .exported
     } catch {
       return .failed(message: error.localizedDescription)
     }
+  }
+
+  /// The one place export and import agree on what fits.
+  static func refusalIfUnimportable(
+    document: CustomWordsTransferDocument, encoded: Data
+  ) -> String? {
+    let words = document.words.count
+    let wordCeiling = CustomWordsImportLimits.maximumExportedCandidates
+    if words > wordCeiling {
+      return
+        "You have \(words) words, which is more than EnviousWispr can read back "
+        + "in one file (\(wordCeiling)). Nothing was exported."
+    }
+    let byteCeiling = CustomWordsImportLimits.maximumExportedFileBytes
+    if encoded.count > byteCeiling {
+      return
+        "Your words are too large to fit in one file EnviousWispr could read "
+        + "back. Nothing was exported."
+    }
+    return nil
   }
 }

--- a/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
@@ -58,10 +58,12 @@ enum CustomWordsExportAction {
     //    document a second time. One encode, off-main, and the same bytes are
     //    both measured and written.
     do {
-      let encoded = try await Self.encoded(document)
-      if let refusal = Self.refusalIfUnimportable(document: document, encoded: encoded) {
-        return .failed(message: refusal)
-      }
+      // The WHOLE preflight runs off-main, not just the encode. Moving only
+      // the encode left a pass that mints a candidate per word and validates
+      // every word and alias running on the main actor — at the ceiling that
+      // is still enough to freeze the settings window (Codex review, #1683).
+      let (encoded, refusal) = try await Self.encodedAndChecked(document)
+      if let refusal { return .failed(message: refusal) }
       try await write(encoded, destination)
       return .exported
     } catch {
@@ -69,10 +71,11 @@ enum CustomWordsExportAction {
     }
   }
 
-  @concurrent private static func encoded(
+  @concurrent private static func encodedAndChecked(
     _ document: CustomWordsTransferDocument
-  ) async throws -> Data {
-    try document.encoded()
+  ) async throws -> (Data, String?) {
+    let encoded = try document.encoded()
+    return (encoded, refusalIfUnimportable(document: document, encoded: encoded))
   }
 
   /// The one place export and import agree on what fits — and on what is
@@ -84,7 +87,7 @@ enum CustomWordsExportAction {
   /// wholesale (Codex review, #1683). It therefore runs the importer's OWN
   /// validation rather than a second description of it, which is what stops
   /// the two from drifting apart again.
-  static func refusalIfUnimportable(
+  nonisolated static func refusalIfUnimportable(
     document: CustomWordsTransferDocument, encoded: Data
   ) -> String? {
     let words = document.words.count

--- a/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
@@ -78,42 +78,36 @@ enum CustomWordsExportAction {
     return (encoded, refusalIfUnimportable(document: document, encoded: encoded))
   }
 
-  /// The one place export and import agree on what fits — and on what is
-  /// storable at all.
+  /// Asks the IMPORTER whether it can read these bytes, rather than keeping a
+  /// second list of what "importable" means.
   ///
-  /// Size was not the only way to write an unimportable file: a word or alias
-  /// authored in the editor can hold a scalar the import policy refuses, so a
-  /// count-and-bytes preflight still produced a file that import rejected
-  /// wholesale (Codex review, #1683). It therefore runs the importer's OWN
-  /// validation rather than a second description of it, which is what stops
-  /// the two from drifting apart again.
+  /// Five separate review rounds found the same defect here: a constraint
+  /// added to import and not to export (word ceiling, then byte ceiling, then
+  /// character policy, then stored-surface ceiling). Every fix was a promise
+  /// to remember the other side next time, and every next time forgot. So the
+  /// preflight no longer describes importability at all — it runs the actual
+  /// import path over the actual bytes. A ceiling added to the parser from now
+  /// on is enforced here the moment it exists, with nothing to keep in sync.
   nonisolated static func refusalIfUnimportable(
     document: CustomWordsTransferDocument, encoded: Data
   ) -> String? {
-    let words = document.words.count
-    let wordCeiling = CustomWordsImportLimits.maximumExportedCandidates
-    if words > wordCeiling {
-      return
-        "You have \(words) words, which is more than EnviousWispr can read back "
-        + "in one file (\(wordCeiling)). Nothing was exported."
-    }
-    let byteCeiling = CustomWordsImportLimits.maximumExportedFileBytes
-    if encoded.count > byteCeiling {
+    // The byte ceiling belongs to the READER, not the parser, so it is the one
+    // check that has to be stated here. It mirrors FileImportSource.
+    if encoded.count > CustomWordsImportLimits.maximumExportedFileBytes {
       return
         "Your words are too large to fit in one file EnviousWispr could read "
         + "back. Nothing was exported."
     }
     do {
+      let candidates = try ExportedWordsFileParser().parse(data: encoded)
       _ = try CustomWordsImportBatch(
         sourceID: "exported-words",
         sourceDisplayName: "EnviousWispr words file",
-        candidates: try document.candidatesForImport()
+        candidates: candidates
       ).validated()
+      return nil
     } catch {
-      return
-        "One of your words can't be written to a file EnviousWispr could read "
-        + "back (\(error.localizedDescription)) Nothing was exported."
+      return "\(error.localizedDescription) Nothing was exported."
     }
-    return nil
   }
 }

--- a/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
@@ -33,7 +33,7 @@ enum CustomWordsExportAction {
   static func run(
     coordinator: CustomWordsCoordinator,
     chooseDestination: () -> URL?,
-    write: @escaping @Sendable (CustomWordsTransferDocument, URL) async throws -> Void
+    write: @escaping @Sendable (Data, URL) async throws -> Void
   ) async -> Outcome {
     // 1. Ask first. Refreshing before this made cancelling mutate state.
     guard let destination = chooseDestination() else { return .cancelled }
@@ -51,26 +51,39 @@ enum CustomWordsExportAction {
 
     // 5. Refuse to write a file our own importer would reject. The exporter
     //    and importer are one round trip, so a limit enforced on only one side
-    //    is a promise the pair cannot keep: raising the IMPORT ceilings while
-    //    export kept no preflight left the same "writes a file it then
-    //    refuses" hole open, just from the other direction (Codex import
-    //    taxonomy audit, #1683 — class C08).
+    //    is a promise the pair cannot keep.
     //
-    //    Checked against the encoded bytes, not an estimate, because the byte
-    //    ceiling is enforced on encoded bytes at read time.
+    //    Encoding happens OFF the main actor: at the 64 MB ceiling doing it
+    //    here froze the settings window, and the writer then encoded the same
+    //    document a second time. One encode, off-main, and the same bytes are
+    //    both measured and written.
     do {
-      let encoded = try document.encoded()
+      let encoded = try await Self.encoded(document)
       if let refusal = Self.refusalIfUnimportable(document: document, encoded: encoded) {
         return .failed(message: refusal)
       }
-      try await write(document, destination)
+      try await write(encoded, destination)
       return .exported
     } catch {
       return .failed(message: error.localizedDescription)
     }
   }
 
-  /// The one place export and import agree on what fits.
+  @concurrent private static func encoded(
+    _ document: CustomWordsTransferDocument
+  ) async throws -> Data {
+    try document.encoded()
+  }
+
+  /// The one place export and import agree on what fits — and on what is
+  /// storable at all.
+  ///
+  /// Size was not the only way to write an unimportable file: a word or alias
+  /// authored in the editor can hold a scalar the import policy refuses, so a
+  /// count-and-bytes preflight still produced a file that import rejected
+  /// wholesale (Codex review, #1683). It therefore runs the importer's OWN
+  /// validation rather than a second description of it, which is what stops
+  /// the two from drifting apart again.
   static func refusalIfUnimportable(
     document: CustomWordsTransferDocument, encoded: Data
   ) -> String? {
@@ -86,6 +99,17 @@ enum CustomWordsExportAction {
       return
         "Your words are too large to fit in one file EnviousWispr could read "
         + "back. Nothing was exported."
+    }
+    do {
+      _ = try CustomWordsImportBatch(
+        sourceID: "exported-words",
+        sourceDisplayName: "EnviousWispr words file",
+        candidates: try document.candidatesForImport()
+      ).validated()
+    } catch {
+      return
+        "One of your words can't be written to a file EnviousWispr could read "
+        + "back (\(error.localizedDescription)) Nothing was exported."
     }
     return nil
   }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
@@ -11,7 +11,7 @@ enum CustomWordsExportPanel {
     let panel = NSSavePanel()
     panel.title = "Export your words"
     panel.prompt = "Export"
-    panel.nameFieldStringValue = "EnviousWispr Custom Words.json"
+    panel.nameFieldStringValue = "EnviousWispr Words.json"
     panel.allowedContentTypes = [.json]
     panel.canCreateDirectories = true
     panel.isExtensionHidden = false

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
@@ -1,0 +1,24 @@
+import AppKit
+import EnviousWisprPostProcessing
+import UniformTypeIdentifiers
+
+/// The open panel for choosing a file to import (#1683, PR-U1).
+///
+/// Content types come from the parser registry rather than a hardcoded list,
+/// so registering a new format also makes it selectable — no second place to
+/// update and no chance of offering a file the app then refuses to read.
+@MainActor
+enum CustomWordsImportFilePanel {
+  static func chooseFile(registry: ImportFileRegistry = .v1) -> URL? {
+    let panel = NSOpenPanel()
+    panel.title = "Choose a file to import"
+    panel.prompt = "Import"
+    panel.message = "Choose an EnviousWispr backup or a plain text list of words."
+    panel.allowedContentTypes = registry.acceptedContentTypes
+    panel.allowsMultipleSelection = false
+    panel.canChooseDirectories = false
+    panel.canChooseFiles = true
+
+    return panel.runModal() == .OK ? panel.url : nil
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
@@ -13,7 +13,7 @@ enum CustomWordsImportFilePanel {
     let panel = NSOpenPanel()
     panel.title = "Choose a file to import"
     panel.prompt = "Import"
-    panel.message = "Choose an EnviousWispr backup or a plain text list of words."
+    panel.message = "Choose a file you exported from EnviousWispr, or a plain text list of words."
     panel.allowedContentTypes = registry.acceptedContentTypes
     panel.allowsMultipleSelection = false
     panel.canChooseDirectories = false

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportFilePanel.swift
@@ -19,6 +19,39 @@ enum CustomWordsImportFilePanel {
     panel.canChooseDirectories = false
     panel.canChooseFiles = true
 
-    return panel.runModal() == .OK ? panel.url : nil
+    // `allowedContentTypes` filters by CONFORMANCE, but the registry parses by
+    // EXACT extension — so on its own the panel would offer a `.csv` (which
+    // conforms to plain text) and the import would then refuse it. The user
+    // would have picked a file the app had just told them was acceptable
+    // (cloud review, #1683).
+    //
+    // The delegate closes that gap by asking the registry the SAME question
+    // the import will ask. Selectability is therefore defined in one place: a
+    // format is offered exactly when a parser claims it, so the two can never
+    // drift apart as formats are added.
+    let delegate = RegistryFilter(registry: registry)
+    panel.delegate = delegate
+
+    let choice = panel.runModal() == .OK ? panel.url : nil
+    // The panel holds its delegate weakly; keep it alive until the modal ends.
+    withExtendedLifetime(delegate) {}
+    return choice
+  }
+
+  /// Enables only the files the import can actually read.
+  private final class RegistryFilter: NSObject, NSOpenSavePanelDelegate {
+    private let registry: ImportFileRegistry
+
+    init(registry: ImportFileRegistry) {
+      self.registry = registry
+    }
+
+    func panel(_ sender: Any, shouldEnable url: URL) -> Bool {
+      // Directories stay enabled or the user cannot navigate to their file.
+      let isDirectory =
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+      if isDirectory { return true }
+      return registry.parser(for: url) != nil
+    }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -319,6 +319,7 @@ private struct ImportPasteScreen: View {
   /// update, on the main actor — so a large pasted list made the editor
   /// progressively less responsive the more it contained.
   @State private var wordCount = 0
+  @State private var parseProblem: String?
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -359,18 +360,34 @@ private struct ImportPasteScreen: View {
       isEditorFocused = true
       // Back from Review returns to an existing draft, so the count has to be
       // right on arrival, not only after the next keystroke.
-      wordCount =
-        (try? PasteWordsParser.parse(
-          model.pasteDraft, limit: CustomWordsImportLimits.maximumCandidates))?.count ?? 0
+      recount(model.pasteDraft)
     }
     .onChange(of: model.pasteDraft) { _, draft in
-      wordCount =
-        (try? PasteWordsParser.parse(
-          draft, limit: CustomWordsImportLimits.maximumCandidates))?.count ?? 0
+      recount(draft)
+    }
+  }
+
+  /// Keeps the parse failure rather than collapsing it to a zero count.
+  ///
+  /// `try?` here turned a real, actionable error — an entry longer than the
+  /// limit — into "No words found", which is false and left the user stuck
+  /// with Continue disabled and nothing to act on (Codex review, #1683). A
+  /// counter must not surface a crash, but it must not invent an answer
+  /// either.
+  private func recount(_ draft: String) {
+    do {
+      wordCount = try PasteWordsParser.parse(
+        draft, limit: CustomWordsImportLimits.maximumCandidates
+      ).count
+      parseProblem = nil
+    } catch {
+      wordCount = 0
+      parseProblem = error.localizedDescription
     }
   }
 
   private var summary: String {
+    if let parseProblem { return parseProblem }
     let count = wordCount
     switch count {
     case 0 where model.pasteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -39,11 +39,8 @@ struct CustomWordsImportSheet: View {
           ImportPasteScreen(model: model)
             .transition(Self.screenTransition)
         case .upload:
-          ImportPlaceholderScreen(
-            notice: "File import arrives with a later update.",
-            model: model
-          )
-          .transition(Self.screenTransition)
+          ImportUploadScreen(model: model)
+            .transition(Self.screenTransition)
         case .smartImportAppPicker:
           ImportPlaceholderScreen(
             notice: "Importing from other apps arrives with a later update.",
@@ -369,6 +366,34 @@ private struct ImportPasteScreen: View {
       return "1 word ready to review."
     default:
       return "\(count) words ready to review."
+    }
+  }
+}
+
+// MARK: - Upload a file (PR-U1)
+
+private struct ImportUploadScreen: View {
+  let model: CustomWordsImportFlowModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Choose an EnviousWispr backup to restore, or a plain text list of words.")
+        .settingsReadingCopy()
+
+      Button {
+        // The panel is opened first and the file read only after a choice, so
+        // cancelling reads nothing and starts no work.
+        if let url = CustomWordsImportFilePanel.chooseFile() {
+          model.begin(with: FileImportSource(url: url))
+        }
+      } label: {
+        Label("Choose a file", systemImage: "folder")
+      }
+      .buttonStyle(.borderedProminent)
+
+      Text("Spreadsheets aren't supported yet.")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -359,10 +359,12 @@ private struct ImportPasteScreen: View {
       isEditorFocused = true
       // Back from Review returns to an existing draft, so the count has to be
       // right on arrival, not only after the next keystroke.
-      wordCount = PasteWordsParser.parse(model.pasteDraft).count
+      wordCount = (try? PasteWordsParser.parse(
+        model.pasteDraft, limit: CustomWordsImportLimits.maximumCandidates))?.count ?? 0
     }
     .onChange(of: model.pasteDraft) { _, draft in
-      wordCount = PasteWordsParser.parse(draft).count
+      wordCount = (try? PasteWordsParser.parse(
+        draft, limit: CustomWordsImportLimits.maximumCandidates))?.count ?? 0
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -161,7 +161,7 @@ private struct ImportMethodPickerScreen: View {
       ImportMethodCard(
         icon: "square.and.arrow.down",
         title: "Upload a file",
-        subtitle: "Import a backup or a spreadsheet of words."
+        subtitle: "Import words from a file you exported, or a list."
       ) {
         model.select(.upload)
       }
@@ -372,13 +372,23 @@ private struct ImportPasteScreen: View {
 
 // MARK: - Upload a file (PR-U1)
 
+/// Deliberately never says "restore" (founder, 2026-07-19).
+///
+/// v1 import ADDS words you don't have and SKIPS ones you do, leaving existing
+/// words and their alternate spellings completely untouched. "Restore" would
+/// promise that a word you had edited comes back as it was, which is exactly
+/// the overwriting this scope rules out. The screen says what it does.
 private struct ImportUploadScreen: View {
   let model: CustomWordsImportFlowModel
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text("Choose an EnviousWispr backup to restore, or a plain text list of words.")
+      Text("Choose a file you exported from EnviousWispr, or a plain text list of words.")
         .settingsReadingCopy()
+
+      Text("Words you already have are left exactly as they are.")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
 
       Button {
         // The panel is opened first and the file read only after a choice, so

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -313,9 +313,12 @@ private struct ImportPasteScreen: View {
   @Bindable var model: CustomWordsImportFlowModel
   @FocusState private var isEditorFocused: Bool
 
-  /// Parsed live so the button can name the real outcome instead of promising
-  /// something the parser might not agree with.
-  private var wordCount: Int { PasteWordsParser.parse(model.pasteDraft).count }
+  /// Recomputed when the draft changes, NOT on every render (code review r2).
+  ///
+  /// As a computed property this re-parsed the entire draft on every view
+  /// update, on the main actor — so a large pasted list made the editor
+  /// progressively less responsive the more it contained.
+  @State private var wordCount = 0
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -352,7 +355,15 @@ private struct ImportPasteScreen: View {
         .disabled(wordCount == 0)
       }
     }
-    .onAppear { isEditorFocused = true }
+    .onAppear {
+      isEditorFocused = true
+      // Back from Review returns to an existing draft, so the count has to be
+      // right on arrival, not only after the next keystroke.
+      wordCount = PasteWordsParser.parse(model.pasteDraft).count
+    }
+    .onChange(of: model.pasteDraft) { _, draft in
+      wordCount = PasteWordsParser.parse(draft).count
+    }
   }
 
   private var summary: String {

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -359,12 +359,14 @@ private struct ImportPasteScreen: View {
       isEditorFocused = true
       // Back from Review returns to an existing draft, so the count has to be
       // right on arrival, not only after the next keystroke.
-      wordCount = (try? PasteWordsParser.parse(
-        model.pasteDraft, limit: CustomWordsImportLimits.maximumCandidates))?.count ?? 0
+      wordCount =
+        (try? PasteWordsParser.parse(
+          model.pasteDraft, limit: CustomWordsImportLimits.maximumCandidates))?.count ?? 0
     }
     .onChange(of: model.pasteDraft) { _, draft in
-      wordCount = (try? PasteWordsParser.parse(
-        draft, limit: CustomWordsImportLimits.maximumCandidates))?.count ?? 0
+      wordCount =
+        (try? PasteWordsParser.parse(
+          draft, limit: CustomWordsImportLimits.maximumCandidates))?.count ?? 0
     }
   }
 
@@ -377,6 +379,14 @@ private struct ImportPasteScreen: View {
       return "No words found in that text."
     case 1:
       return "1 word ready to review."
+    case let n where n > CustomWordsImportLimits.maximumCandidates:
+      // The scan stops one past the limit, so this count is a sentinel rather
+      // than a total — and none of these words are "ready to review", because
+      // Confirm will refuse the batch. Saying so here beats letting the user
+      // find out at the end (Codex review, #1683).
+      return
+        "That's more than \(CustomWordsImportLimits.maximumCandidates) words. "
+        + "Paste a smaller batch."
     default:
       return "\(count) words ready to review."
     }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -353,7 +353,11 @@ private struct ImportPasteScreen: View {
         }
         .keyboardShortcut(.defaultAction)
         .buttonStyle(.borderedProminent)
-        .disabled(wordCount == 0)
+        // Over-limit is a refusal, not a warning: Confirm would throw and land
+        // the user on the terminal failure screen, which has no Back, so the
+        // draft they could have split is gone. Block it where they can still
+        // edit it (cloud review, #1683).
+        .disabled(wordCount == 0 || wordCount > CustomWordsImportLimits.maximumCandidates)
       }
     }
     .onAppear {

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -531,7 +531,7 @@ private struct ImportResultScreen: View {
   /// field stays `.unspecified`, so this fixture cannot smuggle in behavior a
   /// real v1 source would not have.
   struct CustomWordsImportFixtureSource: CustomWordsImportSource {
-    func loadCandidates() async throws -> CustomWordsImportBatch {
+    func loadRawCandidates() async throws -> CustomWordsImportBatch {
       CustomWordsImportBatch(
         sourceID: "debug-fixture",
         sourceDisplayName: "Sample words",

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -151,8 +151,14 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
         scanned += 1
         if scanned.isMultiple(of: 1_000) { try Task.checkCancellation() }
 
-        guard value.unicodeScalars.count
-          <= CustomWordsImportLimits.maximumStoredValueScalars
+        // Judged on the TRIMMED value, because trimmed is what gets stored —
+        // the same rule the paste scanner and the manager's write boundary
+        // apply. Counting padding here refused a short word in a structured
+        // file for whitespace that would never have been saved (cloud review,
+        // #1683).
+        guard
+          value.trimmingCharacters(in: .whitespacesAndNewlines).unicodeScalars.count
+            <= CustomWordsImportLimits.maximumStoredValueScalars
         else {
           throw CustomWordsImportValidationError.wordTooLong(
             limit: CustomWordsImportLimits.maximumStoredValueScalars)

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -131,6 +131,12 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
     for candidate in candidates {
       scanned += 1
       if scanned.isMultiple(of: 1_000) { try Task.checkCancellation() }
+      guard candidate.canonical.unicodeScalars.count
+        <= CustomWordsImportLimits.maximumStoredValueScalars
+      else {
+        throw CustomWordsImportValidationError.wordTooLong(
+          limit: CustomWordsImportLimits.maximumStoredValueScalars)
+      }
       guard CustomWordsImportTextPolicy.isAcceptableStoredValue(candidate.canonical) else {
         throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
       }
@@ -138,6 +144,12 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
         for alias in aliases {
           scanned += 1
           if scanned.isMultiple(of: 1_000) { try Task.checkCancellation() }
+          guard alias.unicodeScalars.count
+            <= CustomWordsImportLimits.maximumStoredValueScalars
+          else {
+            throw CustomWordsImportValidationError.wordTooLong(
+              limit: CustomWordsImportLimits.maximumStoredValueScalars)
+          }
           guard CustomWordsImportTextPolicy.isAcceptableStoredValue(alias) else {
             throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
           }
@@ -188,6 +200,16 @@ package enum CustomWordsImportLimits {
   /// and index (Codex review, #1683). The cost of an import tracks the stored
   /// SURFACE, so that is what has a ceiling.
   package static let maximumExportedStoredValues = 400_000
+
+  /// Longest a single canonical or alias may be, in Unicode scalars.
+  ///
+  /// A custom word is a word or short phrase. Without this, one enormous line
+  /// — a minified file or a log picked by mistake — passes the candidate
+  /// ceiling as a SINGLE entry and becomes a multi-megabyte "word" that is
+  /// copied through normalisation and comparison, rendered in Review, and
+  /// persisted (Codex review, #1683). Generous enough for any real term,
+  /// including long compounds in scripts that do not space-separate.
+  package static let maximumStoredValueScalars = 512
 }
 
 package protocol CustomWordsImportSource: Sendable {
@@ -213,6 +235,7 @@ extension CustomWordsImportSource {
 /// A candidate that cannot be stored, and why (#1683).
 package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatable {
   case unusableWord(canonical: String)
+  case wordTooLong(limit: Int)
 
   /// Replaces anything the policy refuses with a visible `U+XXXX` label, so a
   /// deceptive scalar cannot act on the UI that reports it.
@@ -227,6 +250,10 @@ package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatab
 
   package var errorDescription: String? {
     switch self {
+    case .wordTooLong(let limit):
+      return
+        "That contains an entry longer than \(limit) characters, which is too "
+        + "long to be a word. Nothing was imported."
     case .unusableWord(let canonical):
       // Source-neutral: this validator now runs for pasted text and files
       // alike, so naming a file was wrong half the time (Codex review, #1683).

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -151,7 +151,8 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
               limit: CustomWordsImportLimits.maximumStoredValueScalars)
           }
           guard CustomWordsImportTextPolicy.isAcceptableStoredValue(alias) else {
-            throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
+            throw CustomWordsImportValidationError.unusableAlias(
+              alias: alias, canonical: candidate.canonical)
           }
         }
       }
@@ -235,6 +236,7 @@ extension CustomWordsImportSource {
 /// A candidate that cannot be stored, and why (#1683).
 package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatable {
   case unusableWord(canonical: String)
+  case unusableAlias(alias: String, canonical: String)
   case wordTooLong(limit: Int)
 
   /// Replaces anything the policy refuses with a visible `U+XXXX` label, so a
@@ -254,6 +256,14 @@ package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatab
       return
         "That contains an entry longer than \(limit) characters, which is too "
         + "long to be a word. Nothing was imported."
+    case .unusableAlias(let alias, let canonical):
+      // Names the ALIAS, not the word that owns it. Reporting the canonical
+      // quoted an innocent value and hid the one that has to be fixed (Codex
+      // review, #1683).
+      return
+        "That contains an alternate spelling EnviousWispr can't store "
+        + "(\"\(Self.displayable(alias))\", for \"\(Self.displayable(canonical))\"). "
+        + "Nothing was imported."
     case .unusableWord(let canonical):
       // Source-neutral: this validator now runs for pasted text and files
       // alike, so naming a file was wrong half the time (Codex review, #1683).

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -287,10 +287,31 @@ package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatab
   static func displayable(_ value: String) -> String {
     String(
       value.unicodeScalars.map { scalar -> String in
-        CustomWordsImportTextPolicy.isAcceptableInStoredValue(scalar)
-          ? String(scalar)
-          : "<U+" + String(format: "%04X", scalar.value) + ">"
+        // Escapes the INVISIBLE as well as the disallowed. A value refused for
+        // having no visible content — an exported word made only of a joiner
+        // or a variation selector — is built from scalars that are individually
+        // acceptable, so echoing them raw rendered the error as empty quotes
+        // and left the user hunting for an entry the message could not name
+        // (cloud review, #1683).
+        let mustEscape =
+          !CustomWordsImportTextPolicy.isAcceptableInStoredValue(scalar)
+          || scalar.properties.isDefaultIgnorableCodePoint
+        return mustEscape
+          ? "<U+" + String(format: "%04X", scalar.value) + ">"
+          : String(scalar)
       }.joined())
+  }
+
+  /// How to refer to a rejected value in a sentence.
+  ///
+  /// Quotes escape into something identifiable when there is anything to name,
+  /// and steps aside when there is not: a whitespace-only entry has no scalar
+  /// worth printing, and `"   "` is the same dead end as `""` was.
+  static func describe(_ value: String) -> String {
+    let hasSomethingToName = value.unicodeScalars.contains {
+      !CharacterSet.whitespacesAndNewlines.contains($0)
+    }
+    return hasSomethingToName ? "\"\(displayable(value))\"" : "a blank entry"
   }
 
   package var errorDescription: String? {
@@ -305,7 +326,7 @@ package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatab
       // review, #1683).
       return
         "That contains an alternate spelling EnviousWispr can't store "
-        + "(\"\(Self.displayable(alias))\", for \"\(Self.displayable(canonical))\"). "
+        + "(\(Self.describe(alias)), for \(Self.describe(canonical))). "
         + "Nothing was imported."
     case .unusableWord(let canonical):
       // Source-neutral: this validator now runs for pasted text and files
@@ -316,8 +337,7 @@ package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatab
       // separator — got rendered into the message explaining its rejection,
       // where it can reorder or break the error text itself. Naming the
       // offending scalar is more useful to the user than showing it.
-      let shown =
-        canonical.isEmpty ? "a blank entry" : "\"\(Self.displayable(canonical))\""
+      let shown = Self.describe(canonical)
       return
         "That contains a word EnviousWispr can't store (\(shown)). "
         + "Nothing was imported."

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -113,6 +113,18 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
   }
 }
 
+/// Shared ceilings every import source honours (#1683).
+///
+/// One home so paste and file import cannot drift apart: the compare engine,
+/// the review list, and the commit all pay the same cost per candidate no
+/// matter which door the words came through, so a limit that applies to one
+/// source and not another is an accident waiting to be found by a user.
+package enum CustomWordsImportLimits {
+  /// The compare engine's documented upload ceiling. Beyond this the review
+  /// screen is not something a person can meaningfully read anyway.
+  package static let maximumCandidates = 25_000
+}
+
 package protocol CustomWordsImportSource: Sendable {
   func loadCandidates() async throws -> CustomWordsImportBatch
 }

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -123,17 +123,24 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
   /// every source, which is the gap that let exported JSON skip the character
   /// rules the text path enforced.
   package func validated() throws -> CustomWordsImportBatch {
-    for (index, candidate) in candidates.enumerated() {
-      // The ceiling allows 400,000 stored values, so this loop is long enough
-      // to outlive a dismissed sheet (Codex review, #1683).
-      if index.isMultiple(of: 1_000) { try Task.checkCancellation() }
+    // Counted across BOTH loops, because the work is proportional to total
+    // stored values and one candidate may carry hundreds of thousands of
+    // aliases — checking only the outer loop left the inner one uninterruptible
+    // (Codex review, #1683).
+    var scanned = 0
+    for candidate in candidates {
+      scanned += 1
+      if scanned.isMultiple(of: 1_000) { try Task.checkCancellation() }
       guard CustomWordsImportTextPolicy.isAcceptableStoredValue(candidate.canonical) else {
         throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
       }
       if case .supplied(let aliases) = candidate.aliases {
-        for alias in aliases
-        where !CustomWordsImportTextPolicy.isAcceptableStoredValue(alias) {
-          throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
+        for alias in aliases {
+          scanned += 1
+          if scanned.isMultiple(of: 1_000) { try Task.checkCancellation() }
+          guard CustomWordsImportTextPolicy.isAcceptableStoredValue(alias) else {
+            throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
+          }
         }
       }
     }
@@ -212,7 +219,7 @@ package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatab
   static func displayable(_ value: String) -> String {
     String(
       value.unicodeScalars.map { scalar -> String in
-        CustomWordsImportTextPolicy.isAcceptableStoredValue(String(scalar))
+        CustomWordsImportTextPolicy.isAcceptableInStoredValue(scalar)
           ? String(scalar)
           : "<U+" + String(format: "%04X", scalar.value) + ">"
       }.joined())

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -207,10 +207,12 @@ package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatab
   package var errorDescription: String? {
     switch self {
     case .unusableWord(let canonical):
+      // Source-neutral: this validator now runs for pasted text and files
+      // alike, so naming a file was wrong half the time (Codex review, #1683).
       let shown = canonical.isEmpty ? "a blank entry" : "\"\(canonical)\""
       return
-        "That file contains a word EnviousWispr can't store (\(shown)). "
-        + "Nothing was imported. Check the file and try again."
+        "That contains a word EnviousWispr can't store (\(shown)). "
+        + "Nothing was imported."
     }
   }
 }

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -123,7 +123,10 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
   /// every source, which is the gap that let exported JSON skip the character
   /// rules the text path enforced.
   package func validated() throws -> CustomWordsImportBatch {
-    for candidate in candidates {
+    for (index, candidate) in candidates.enumerated() {
+      // The ceiling allows 400,000 stored values, so this loop is long enough
+      // to outlive a dismissed sheet (Codex review, #1683).
+      if index.isMultiple(of: 1_000) { try Task.checkCancellation() }
       guard CustomWordsImportTextPolicy.isAcceptableStoredValue(candidate.canonical) else {
         throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
       }
@@ -204,12 +207,30 @@ extension CustomWordsImportSource {
 package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatable {
   case unusableWord(canonical: String)
 
+  /// Replaces anything the policy refuses with a visible `U+XXXX` label, so a
+  /// deceptive scalar cannot act on the UI that reports it.
+  static func displayable(_ value: String) -> String {
+    String(
+      value.unicodeScalars.map { scalar -> String in
+        CustomWordsImportTextPolicy.isAcceptableStoredValue(String(scalar))
+          ? String(scalar)
+          : "<U+" + String(format: "%04X", scalar.value) + ">"
+      }.joined())
+  }
+
   package var errorDescription: String? {
     switch self {
     case .unusableWord(let canonical):
       // Source-neutral: this validator now runs for pasted text and files
       // alike, so naming a file was wrong half the time (Codex review, #1683).
-      let shown = canonical.isEmpty ? "a blank entry" : "\"\(canonical)\""
+      //
+      // The value is SANITISED before display. Echoing it raw meant the very
+      // character rejected for rendering deceptively — a bidi override, a line
+      // separator — got rendered into the message explaining its rejection,
+      // where it can reorder or break the error text itself. Naming the
+      // offending scalar is more useful to the user than showing it.
+      let shown =
+        canonical.isEmpty ? "a blank entry" : "\"\(Self.displayable(canonical))\""
       return
         "That contains a word EnviousWispr can't store (\(shown)). "
         + "Nothing was imported."

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -123,6 +123,16 @@ package enum CustomWordsImportLimits {
   /// The compare engine's documented upload ceiling. Beyond this the review
   /// screen is not something a person can meaningfully read anyway.
   package static let maximumCandidates = 25_000
+
+  /// Untrusted files: a word list is small, so anything larger is a mistaken
+  /// selection (a video, a database, a disk image) and reading it into memory
+  /// to find that out is the expensive way to learn it.
+  package static let maximumImportFileBytes = 16 * 1024 * 1024
+
+  /// Our OWN exported file, which must always be readable back — an export you
+  /// cannot import is not an export. Far above any real library (over a
+  /// million terms), while still refusing a mistakenly chosen disk image.
+  package static let maximumExportedFileBytes = 256 * 1024 * 1024
 }
 
 package protocol CustomWordsImportSource: Sendable {

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -67,6 +67,24 @@ package struct CustomWordsImportCandidate: Identifiable, Sendable, Hashable {
     return values
   }
 
+  /// The candidate as it would be STORED: every stored value trimmed.
+  ///
+  /// Pairs with `storedValues` — that property says which fields reach the
+  /// library, this one puts them in the form the library keeps. A field added
+  /// to one must be added to the other, or validation measures a value nobody
+  /// stores while the real one goes downstream untouched.
+  package func trimmed() -> CustomWordsImportCandidate {
+    var copy = self
+    copy.canonical = canonical.trimmingCharacters(in: .whitespacesAndNewlines)
+    if case .supplied(let values) = aliases {
+      copy.aliases = .supplied(values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+    }
+    copy.suggestedAliases = suggestedAliases.map {
+      $0.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    return copy
+  }
+
   package init(
     id: UUID = UUID(),
     canonical: String,
@@ -156,14 +174,13 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
         // apply. Counting padding here refused a short word in a structured
         // file for whitespace that would never have been saved (cloud review,
         // #1683).
-        guard
-          value.trimmingCharacters(in: .whitespacesAndNewlines).unicodeScalars.count
-            <= CustomWordsImportLimits.maximumStoredValueScalars
+        let stored = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard stored.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
         else {
           throw CustomWordsImportValidationError.wordTooLong(
             limit: CustomWordsImportLimits.maximumStoredValueScalars)
         }
-        guard CustomWordsImportTextPolicy.isAcceptableStoredValue(value) else {
+        guard CustomWordsImportTextPolicy.isAcceptableStoredValue(stored) else {
           throw value == candidate.canonical
             ? CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
             : CustomWordsImportValidationError.unusableAlias(
@@ -171,7 +188,19 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
         }
       }
     }
-    return self
+    // Returns what it validated, not what it was handed.
+    //
+    // Measuring the trimmed value while passing the raw one downstream would
+    // enforce the ceiling and then hand the compare engine and the review
+    // screen a value the ceiling never applied to — tens of megabytes of
+    // padding around a short word, normalized and rendered, with trimming
+    // deferred to commit (Codex review, #1683). One boundary decides what a
+    // stored value is, and everything after it sees only that.
+    return CustomWordsImportBatch(
+      sourceID: sourceID,
+      sourceDisplayName: sourceDisplayName,
+      candidates: candidates.map { $0.trimmed() },
+      notices: notices)
   }
 }
 

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -111,6 +111,31 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
     self.candidates = candidates
     self.notices = notices
   }
+
+  /// Refuses the WHOLE batch if any candidate is unstorable.
+  ///
+  /// All-or-nothing on purpose: silently dropping bad rows would show the user
+  /// a review screen that quietly disagrees with their file, and importing
+  /// them would put invisible characters inside stored words. A refusal names
+  /// the offending entry so the file can be fixed.
+  ///
+  /// Checks the values that actually get STORED — canonical and aliases — for
+  /// every source, which is the gap that let exported JSON skip the character
+  /// rules the text path enforced.
+  package func validated() throws -> CustomWordsImportBatch {
+    for candidate in candidates {
+      guard CustomWordsImportTextPolicy.isAcceptableStoredValue(candidate.canonical) else {
+        throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
+      }
+      if case .supplied(let aliases) = candidate.aliases {
+        for alias in aliases
+        where !CustomWordsImportTextPolicy.isAcceptableStoredValue(alias) {
+          throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
+        }
+      }
+    }
+    return self
+  }
 }
 
 /// Shared ceilings every import source honours (#1683).
@@ -146,5 +171,36 @@ package enum CustomWordsImportLimits {
 }
 
 package protocol CustomWordsImportSource: Sendable {
-  func loadCandidates() async throws -> CustomWordsImportBatch
+  /// Produce candidates. Callers do NOT call this — they call
+  /// `loadCandidates()`, which validates what this returns.
+  func loadRawCandidates() async throws -> CustomWordsImportBatch
+}
+
+extension CustomWordsImportSource {
+  /// The only entry point callers use, so domain validation cannot be
+  /// forgotten by a new source (#1683).
+  ///
+  /// Validation used to live inside one parser, which meant it protected the
+  /// door it was written for and no other: words from an exported file
+  /// bypassed every character rule the pasted-text path enforced. Putting it
+  /// HERE makes it a property of importing rather than of one importer — a new
+  /// source gets it by existing, and cannot opt out by forgetting.
+  package func loadCandidates() async throws -> CustomWordsImportBatch {
+    try await loadRawCandidates().validated()
+  }
+}
+
+/// A candidate that cannot be stored, and why (#1683).
+package enum CustomWordsImportValidationError: LocalizedError, Sendable, Equatable {
+  case unusableWord(canonical: String)
+
+  package var errorDescription: String? {
+    switch self {
+    case .unusableWord(let canonical):
+      let shown = canonical.isEmpty ? "a blank entry" : "\"\(canonical)\""
+      return
+        "That file contains a word EnviousWispr can't store (\(shown)). "
+        + "Nothing was imported. Check the file and try again."
+    }
+  }
 }

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -168,6 +168,16 @@ package enum CustomWordsImportLimits {
   /// larger than most complete English dictionaries — while keeping the
   /// compare engine and review list inside a worst case we have reasoned about.
   package static let maximumExportedCandidates = 100_000
+
+  /// Total stored strings — every canonical PLUS every alias — an exported
+  /// file may carry.
+  ///
+  /// Bounding words alone bounded one dimension of the wrong thing: 100,000
+  /// words each carrying hundreds of aliases fits inside both the word and
+  /// byte ceilings while producing millions of strings to validate, compare,
+  /// and index (Codex review, #1683). The cost of an import tracks the stored
+  /// SURFACE, so that is what has a ceiling.
+  package static let maximumExportedStoredValues = 400_000
 }
 
 package protocol CustomWordsImportSource: Sendable {

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -130,9 +130,19 @@ package enum CustomWordsImportLimits {
   package static let maximumImportFileBytes = 16 * 1024 * 1024
 
   /// Our OWN exported file, which must always be readable back — an export you
-  /// cannot import is not an export. Far above any real library (over a
-  /// million terms), while still refusing a mistakenly chosen disk image.
-  package static let maximumExportedFileBytes = 256 * 1024 * 1024
+  /// cannot import is not an export.
+  ///
+  /// Higher than the untrusted cap, but still FINITE, because the
+  /// "this is an EnviousWispr export" marker is self-declared and unsigned:
+  /// any JSON claiming it would otherwise get an unbounded budget (Codex
+  /// review, #1683). Bounded means a crafted or damaged file has a known worst
+  /// case instead of hanging the review screen.
+  package static let maximumExportedFileBytes = 64 * 1024 * 1024
+
+  /// Words an exported file may carry. Comfortably past any real library —
+  /// larger than most complete English dictionaries — while keeping the
+  /// compare engine and review list inside a worst case we have reasoned about.
+  package static let maximumExportedCandidates = 100_000
 }
 
 package protocol CustomWordsImportSource: Sendable {

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -53,6 +53,20 @@ package struct CustomWordsImportCandidate: Identifiable, Sendable, Hashable {
   /// round-trip); `.unspecified` = the source knows nothing about strictness.
   package var minSimilarityOverride: CustomWordsImportField<Double?>
 
+  /// Every string this candidate could put into the library.
+  ///
+  /// Enumerated in ONE place so validation cannot check some of them: it
+  /// covered canonical and aliases while `suggestedAliases` — which the commit
+  /// path also persists — went unchecked (cloud review, #1683). A field added
+  /// here is validated automatically; a field added anywhere else is not, so
+  /// this is the list to extend.
+  package var storedValues: [String] {
+    var values = [canonical]
+    if case .supplied(let aliases) = aliases { values.append(contentsOf: aliases) }
+    values.append(contentsOf: suggestedAliases)
+    return values
+  }
+
   package init(
     id: UUID = UUID(),
     canonical: String,
@@ -123,37 +137,31 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
   /// every source, which is the gap that let exported JSON skip the character
   /// rules the text path enforced.
   package func validated() throws -> CustomWordsImportBatch {
-    // Counted across BOTH loops, because the work is proportional to total
-    // stored values and one candidate may carry hundreds of thousands of
-    // aliases — checking only the outer loop left the inner one uninterruptible
-    // (Codex review, #1683).
+    // Walks `storedValues` rather than naming fields here, so a field added to
+    // the candidate is validated by existing. Naming them individually is what
+    // let `suggestedAliases` — which the commit path persists — go unchecked
+    // while canonical and aliases were covered (cloud review, #1683).
+    //
+    // Counted across the whole walk, because the work is proportional to total
+    // stored values: one candidate may carry hundreds of thousands of aliases,
+    // so a per-candidate check leaves that uninterruptible.
     var scanned = 0
     for candidate in candidates {
-      scanned += 1
-      if scanned.isMultiple(of: 1_000) { try Task.checkCancellation() }
-      guard candidate.canonical.unicodeScalars.count
-        <= CustomWordsImportLimits.maximumStoredValueScalars
-      else {
-        throw CustomWordsImportValidationError.wordTooLong(
-          limit: CustomWordsImportLimits.maximumStoredValueScalars)
-      }
-      guard CustomWordsImportTextPolicy.isAcceptableStoredValue(candidate.canonical) else {
-        throw CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
-      }
-      if case .supplied(let aliases) = candidate.aliases {
-        for alias in aliases {
-          scanned += 1
-          if scanned.isMultiple(of: 1_000) { try Task.checkCancellation() }
-          guard alias.unicodeScalars.count
-            <= CustomWordsImportLimits.maximumStoredValueScalars
-          else {
-            throw CustomWordsImportValidationError.wordTooLong(
-              limit: CustomWordsImportLimits.maximumStoredValueScalars)
-          }
-          guard CustomWordsImportTextPolicy.isAcceptableStoredValue(alias) else {
-            throw CustomWordsImportValidationError.unusableAlias(
-              alias: alias, canonical: candidate.canonical)
-          }
+      for value in candidate.storedValues {
+        scanned += 1
+        if scanned.isMultiple(of: 1_000) { try Task.checkCancellation() }
+
+        guard value.unicodeScalars.count
+          <= CustomWordsImportLimits.maximumStoredValueScalars
+        else {
+          throw CustomWordsImportValidationError.wordTooLong(
+            limit: CustomWordsImportLimits.maximumStoredValueScalars)
+        }
+        guard CustomWordsImportTextPolicy.isAcceptableStoredValue(value) else {
+          throw value == candidate.canonical
+            ? CustomWordsImportValidationError.unusableWord(canonical: candidate.canonical)
+            : CustomWordsImportValidationError.unusableAlias(
+              alias: value, canonical: candidate.canonical)
         }
       }
     }

--- a/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
@@ -57,14 +57,23 @@ package enum CustomWordsImportTextPolicy {
   /// Line breaks and tabs are separators BETWEEN words, never content within
   /// one, so they are refused here even though `isPlausiblyText` allows them
   /// while scanning a whole file.
+  /// Scalar-level form of `isAcceptableStoredValue`, for callers inspecting
+  /// one character at a time.
+  ///
+  /// Needed because the whole-value check also rejects blank values, so
+  /// testing a single space through it reports the space as rejected — which
+  /// made the error sanitiser label ordinary spaces as bad characters (Codex
+  /// review, #1683).
+  package static func isAcceptableInStoredValue(_ scalar: Unicode.Scalar) -> Bool {
+    guard scalar != "\n", scalar != "\r", scalar != "\t" else { return false }
+    return isAcceptable(scalar)
+  }
+
   package static func isAcceptableStoredValue(_ value: String) -> Bool {
     guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       return false
     }
-    return value.unicodeScalars.allSatisfy { scalar in
-      guard scalar != "\n", scalar != "\r", scalar != "\t" else { return false }
-      return isAcceptable(scalar)
-    }
+    return value.unicodeScalars.allSatisfy(isAcceptableInStoredValue)
   }
 
   private static func isAcceptable(_ scalar: Unicode.Scalar) -> Bool {

--- a/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// What characters may appear in imported text, for EVERY source (#1683).
+///
+/// This lives in Core, not in the plain-text parser that first needed it,
+/// because the policy is about the STORE and not about one door into it. While
+/// it lived beside the text parser, words arriving from an exported file
+/// skipped it entirely: the same hardening that refused an invisible control
+/// character from a pasted list happily accepted one from JSON (Codex import
+/// taxonomy audit, #1683 — class C04/C09).
+///
+/// Every rule here therefore applies to plain text, exported files, and any
+/// future source, or it does not belong here.
+package enum CustomWordsImportTextPolicy {
+  /// The two format scalars that are word-forming.
+  ///
+  /// Load-bearing in Hindi, Persian, and emoji sequences, so they survive.
+  /// The rest of the format category must not: a mid-file byte-order mark is
+  /// invisible, and a bidi override makes a word render as something other
+  /// than what it is. Both would be stored INSIDE a word, where nothing
+  /// downstream strips them.
+  private static let wordFormingInvisibles: Set<UInt32> = [0x200C, 0x200D]
+
+  /// Whether text is plausibly text at all — no controls, surrogates,
+  /// private-use, unassigned, or non-word-forming format scalars.
+  ///
+  /// Asks Unicode rather than hand-rolling ranges: a numeric approximation
+  /// (`< 0x20 || == 0x7F`) missed the entire C1 block, so `C2 85` imported an
+  /// invisible character inside a word.
+  package static func isPlausiblyText(_ text: String) -> Bool {
+    text.unicodeScalars.allSatisfy(isAcceptable)
+  }
+
+  /// Whether text looks like WORDS rather than merely printable characters.
+  ///
+  /// Stricter than `isPlausiblyText`: non-ASCII must be a letter, mark, or
+  /// digit. Symbols are the tell that an encoding was misread — `qg¬N` rather
+  /// than `Beyoncé` — and no one puts a maths symbol in a vocabulary entry.
+  /// ASCII passes freely so `C++` and `.NET` are unaffected.
+  package static func looksLikeWords(_ text: String) -> Bool {
+    guard !text.isEmpty, isPlausiblyText(text) else { return false }
+    return text.unicodeScalars.allSatisfy { scalar in
+      if scalar.isASCII { return true }
+      if wordFormingInvisibles.contains(scalar.value) { return true }
+      switch scalar.properties.generalCategory {
+      case .uppercaseLetter, .lowercaseLetter, .titlecaseLetter, .modifierLetter,
+        .otherLetter, .nonspacingMark, .spacingMark, .decimalNumber, .otherNumber:
+        return true
+      default:
+        return false
+      }
+    }
+  }
+
+  /// Whether a single stored value — a canonical or an alias — is acceptable.
+  ///
+  /// Line breaks and tabs are separators BETWEEN words, never content within
+  /// one, so they are refused here even though `isPlausiblyText` allows them
+  /// while scanning a whole file.
+  package static func isAcceptableStoredValue(_ value: String) -> Bool {
+    guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return false
+    }
+    return value.unicodeScalars.allSatisfy { scalar in
+      guard scalar != "\n", scalar != "\r", scalar != "\t" else { return false }
+      return isAcceptable(scalar)
+    }
+  }
+
+  private static func isAcceptable(_ scalar: Unicode.Scalar) -> Bool {
+    if scalar == "\n" || scalar == "\r" || scalar == "\t" { return true }
+    if wordFormingInvisibles.contains(scalar.value) { return true }
+    switch scalar.properties.generalCategory {
+    case .control, .surrogate, .privateUse, .unassigned, .format:
+      return false
+    default:
+      return true
+    }
+  }
+}

--- a/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
@@ -71,7 +71,12 @@ package enum CustomWordsImportTextPolicy {
     if scalar == "\n" || scalar == "\r" || scalar == "\t" { return true }
     if wordFormingInvisibles.contains(scalar.value) { return true }
     switch scalar.properties.generalCategory {
-    case .control, .surrogate, .privateUse, .unassigned, .format:
+    case .control, .surrogate, .privateUse, .unassigned, .format,
+      // U+2028 and U+2029 are line and paragraph breaks with their OWN
+      // categories, so a control-only check let them through — invisible,
+      // inside a stored word, despite the separator policy saying otherwise
+      // (Codex review, #1683).
+      .lineSeparator, .paragraphSeparator:
       return false
     default:
       return true

--- a/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
@@ -94,8 +94,14 @@ package enum CustomWordsImportTextPolicy {
   /// but disallowed: those have to reach the validator so the user is told
   /// (cloud review, #1683).
   package static func hasVisibleContent(_ value: String) -> Bool {
+    // Asks Unicode which scalars are invisible instead of listing them.
+    // A hand-rolled list of "the invisible ones" named the two joiners and
+    // missed variation selectors and every other default-ignorable scalar, so
+    // a word made only of U+FE0F still counted as visible (cloud review,
+    // #1683) — the same hand-rolled-range mistake as the C1 controls, one
+    // property over.
     value.unicodeScalars.contains {
-      !wordFormingInvisibles.contains($0.value)
+      !$0.properties.isDefaultIgnorableCodePoint
         && !CharacterSet.whitespacesAndNewlines.contains($0)
     }
   }

--- a/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
@@ -73,6 +73,16 @@ package enum CustomWordsImportTextPolicy {
     guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       return false
     }
+    // "Not empty" is not the same as "visible". A value made only of joiners
+    // — which are legitimately allowed INSIDE words — passed the emptiness
+    // check and every scalar check, so a blank-looking word could be stored
+    // and shown in Review as nothing at all (cloud review, #1683).
+    guard
+      value.unicodeScalars.contains(where: {
+        !wordFormingInvisibles.contains($0.value)
+          && !CharacterSet.whitespacesAndNewlines.contains($0)
+      })
+    else { return false }
     return value.unicodeScalars.allSatisfy(isAcceptableInStoredValue)
   }
 

--- a/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportTextPolicy.swift
@@ -27,8 +27,25 @@ package enum CustomWordsImportTextPolicy {
   /// Asks Unicode rather than hand-rolling ranges: a numeric approximation
   /// (`< 0x20 || == 0x7F`) missed the entire C1 block, so `C2 85` imported an
   /// invisible character inside a word.
+  /// Decode-level check: does this look like text at all, or like bytes read
+  /// in the wrong encoding?
+  ///
+  /// Deliberately NARROWER than the content policy. Mojibake announces itself
+  /// as controls, surrogates, private-use, and unassigned scalars, so those
+  /// are the tell. A bidi override or a stray byte-order mark in otherwise
+  /// valid UTF-8 is not a decoding failure — it is a CONTENT problem, and
+  /// treating it as one lets the validator name the offending word instead of
+  /// the whole file being reported as unreadable (cloud review, #1683).
   package static func isPlausiblyText(_ text: String) -> Bool {
-    text.unicodeScalars.allSatisfy(isAcceptable)
+    text.unicodeScalars.allSatisfy { scalar in
+      if scalar == "\n" || scalar == "\r" || scalar == "\t" { return true }
+      switch scalar.properties.generalCategory {
+      case .control, .surrogate, .privateUse, .unassigned:
+        return false
+      default:
+        return true
+      }
+    }
   }
 
   /// Whether text looks like WORDS rather than merely printable characters.
@@ -69,20 +86,28 @@ package enum CustomWordsImportTextPolicy {
     return isAcceptable(scalar)
   }
 
+  /// Whether a value contains anything the user could SEE.
+  ///
+  /// Separate from acceptability on purpose. A scan uses this to skip blank
+  /// pieces — an empty line, or one made only of joiners — the way it always
+  /// skipped whitespace. It must NOT be used to skip values that are visible
+  /// but disallowed: those have to reach the validator so the user is told
+  /// (cloud review, #1683).
+  package static func hasVisibleContent(_ value: String) -> Bool {
+    value.unicodeScalars.contains {
+      !wordFormingInvisibles.contains($0.value)
+        && !CharacterSet.whitespacesAndNewlines.contains($0)
+    }
+  }
+
   package static func isAcceptableStoredValue(_ value: String) -> Bool {
     guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       return false
     }
-    // "Not empty" is not the same as "visible". A value made only of joiners
-    // — which are legitimately allowed INSIDE words — passed the emptiness
-    // check and every scalar check, so a blank-looking word could be stored
-    // and shown in Review as nothing at all (cloud review, #1683).
-    guard
-      value.unicodeScalars.contains(where: {
-        !wordFormingInvisibles.contains($0.value)
-          && !CharacterSet.whitespacesAndNewlines.contains($0)
-      })
-    else { return false }
+    // "Not empty" is not the same as "visible": a value made only of joiners
+    // — legitimately allowed INSIDE words — passed the emptiness check and
+    // every scalar check, so a blank-looking word could be stored.
+    guard hasVisibleContent(value) else { return false }
     return value.unicodeScalars.allSatisfy(isAcceptableInStoredValue)
   }
 

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -17,9 +17,8 @@ package enum CustomWordsExportWriter {
   /// window until the filesystem finished. It also makes the cancellation
   /// check below meaningful, which it could not be in a synchronous call.
   @concurrent package static func write(
-    _ document: CustomWordsTransferDocument, to destination: URL
+    _ data: Data, to destination: URL
   ) async throws {
-    let data = try document.encoded()
     let fm = FileManager.default
     let tmpURL =
       destination

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -398,6 +398,15 @@ public final class CustomWordsManager {
   public func add(word: CustomWord, to words: inout [CustomWord]) throws {
     let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
+    // The same ceiling importing enforces, applied where words are AUTHORED.
+    // Without it the app could create a library it then refused to export:
+    // import capped stored values, the editor did not, so a hand-typed entry
+    // over the ceiling made the user's own words unexportable (cloud review,
+    // #1683). Real entries are nowhere near this — the founder's longest word
+    // is 14 characters — so it only ever catches something pasted by mistake.
+    guard trimmed.unicodeScalars.count
+      <= CustomWordsImportLimits.maximumStoredValueScalars
+    else { return }
     guard
       !words.contains(where: {
         $0.canonical.caseInsensitiveCompare(trimmed) == .orderedSame
@@ -418,9 +427,7 @@ public final class CustomWordsManager {
 
     var sanitized = word
     sanitized.canonical = trimmed
-    sanitized.aliases = sanitized.aliases
-      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-      .filter { !$0.isEmpty }
+    sanitized.aliases = Self.sanitizeAliases(sanitized.aliases)
     file.words.append(sanitized)
     try saveFile(file)
     words = mergedWords(file: file)
@@ -450,7 +457,9 @@ public final class CustomWordsManager {
 
     for word in incoming {
       let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else { continue }
+      guard !trimmed.isEmpty,
+        trimmed.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
+      else { continue }
       let key = trimmed.lowercased()
       guard !seen.contains(key) else { continue }
 
@@ -468,9 +477,7 @@ public final class CustomWordsManager {
 
       var sanitized = word
       sanitized.canonical = trimmed
-      sanitized.aliases = sanitized.aliases
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
+      sanitized.aliases = Self.sanitizeAliases(sanitized.aliases)
       file.words.append(sanitized)
       createdIDs.append(sanitized.id)
       seen.insert(key)
@@ -734,6 +741,11 @@ public final class CustomWordsManager {
     aliases
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
       .filter { !$0.isEmpty }
+      // Same ceiling as canonicals, for the same reason: an alias the app
+      // stores but cannot export breaks the round trip just as thoroughly.
+      .filter {
+        $0.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
+      }
   }
 
   /// Guarantees no alias this import touched is left ambiguous, whatever
@@ -842,12 +854,12 @@ public final class CustomWordsManager {
   public func update(word: CustomWord, in words: inout [CustomWord]) throws {
     guard let index = words.firstIndex(where: { $0.id == word.id }) else { return }
     let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return }
+    guard !trimmed.isEmpty,
+      trimmed.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
+    else { return }
     var edited = word
     edited.canonical = trimmed
-    edited.aliases = edited.aliases
-      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-      .filter { !$0.isEmpty }
+    edited.aliases = Self.sanitizeAliases(edited.aliases)
 
     // An edit makes the word the user's, whatever it started as (#1680).
     // Editing a built-in produces a user override, but the value still carries
@@ -892,13 +904,13 @@ public final class CustomWordsManager {
     var changed = false
     for word in updates {
       let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else { continue }
+      guard !trimmed.isEmpty,
+        trimmed.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
+      else { continue }
       guard let idx = file.words.firstIndex(where: { $0.id == word.id }) else { continue }
       var sanitized = word
       sanitized.canonical = trimmed
-      sanitized.aliases = sanitized.aliases
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
+      sanitized.aliases = Self.sanitizeAliases(sanitized.aliases)
       file.words[idx] = sanitized
       changed = true
     }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -42,6 +42,7 @@ public struct BuiltinWord: Sendable {
 package enum CustomWordsPersistenceError: LocalizedError, Sendable, Equatable {
   case unreadableExistingFile
   case corruptedExistingFile
+  case unusableValue
 
   package var errorDescription: String? {
     switch self {
@@ -50,6 +51,9 @@ package enum CustomWordsPersistenceError: LocalizedError, Sendable, Equatable {
     case .corruptedExistingFile:
       return
         "Your saved words file was damaged and moved aside for recovery. No edit or import was applied."
+    case .unusableValue:
+      return
+        "That word or spelling can't be saved. It may be too long, or contain characters that aren't part of a word."
     }
   }
 }
@@ -400,7 +404,15 @@ public final class CustomWordsManager {
     guard !trimmed.isEmpty else { return }
     // The same rule importing enforces, applied where words are AUTHORED, so
     // the library can never hold what export refuses (cloud review, #1683).
-    guard Self.isStorable(trimmed) else { return }
+    //
+    // THROWS rather than returning, unlike the batch doors below. A user typed
+    // this one value and is watching for the result: a silent return dismisses
+    // the sheet on a nil error, so the app reports a save it did not make. The
+    // batch doors keep skipping because per-item skip IS their contract.
+    guard Self.isStorable(trimmed) else { throw CustomWordsPersistenceError.unusableValue }
+    guard Self.everyAliasIsStorable(word.aliases) else {
+      throw CustomWordsPersistenceError.unusableValue
+    }
     guard
       !words.contains(where: {
         $0.canonical.caseInsensitiveCompare(trimmed) == .orderedSame
@@ -744,6 +756,19 @@ public final class CustomWordsManager {
     return CustomWordsImportTextPolicy.isAcceptableStoredValue(trimmed)
   }
 
+  /// True when every alias the user actually authored can be stored.
+  ///
+  /// Blank aliases are not a refusal — the editor leaves empty rows behind and
+  /// dropping those is ordinary trimming, not a lost edit. A NON-blank alias
+  /// that the policy refuses is the lie this catches: `sanitizeAliases` would
+  /// filter it out and the save would report success without it.
+  private static func everyAliasIsStorable(_ aliases: [String]) -> Bool {
+    aliases
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+      .allSatisfy { isStorable($0) }
+  }
+
   private static func sanitizeAliases(_ aliases: [String]) -> [String] {
     aliases
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -858,7 +883,11 @@ public final class CustomWordsManager {
   public func update(word: CustomWord, in words: inout [CustomWord]) throws {
     guard let index = words.firstIndex(where: { $0.id == word.id }) else { return }
     let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard Self.isStorable(trimmed) else { return }
+    // Same authoring door as `add`, same reason it throws: see there.
+    guard Self.isStorable(trimmed) else { throw CustomWordsPersistenceError.unusableValue }
+    guard Self.everyAliasIsStorable(word.aliases) else {
+      throw CustomWordsPersistenceError.unusableValue
+    }
     var edited = word
     edited.canonical = trimmed
     edited.aliases = Self.sanitizeAliases(edited.aliases)

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -398,15 +398,9 @@ public final class CustomWordsManager {
   public func add(word: CustomWord, to words: inout [CustomWord]) throws {
     let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
-    // The same ceiling importing enforces, applied where words are AUTHORED.
-    // Without it the app could create a library it then refused to export:
-    // import capped stored values, the editor did not, so a hand-typed entry
-    // over the ceiling made the user's own words unexportable (cloud review,
-    // #1683). Real entries are nowhere near this — the founder's longest word
-    // is 14 characters — so it only ever catches something pasted by mistake.
-    guard trimmed.unicodeScalars.count
-      <= CustomWordsImportLimits.maximumStoredValueScalars
-    else { return }
+    // The same rule importing enforces, applied where words are AUTHORED, so
+    // the library can never hold what export refuses (cloud review, #1683).
+    guard Self.isStorable(trimmed) else { return }
     guard
       !words.contains(where: {
         $0.canonical.caseInsensitiveCompare(trimmed) == .orderedSame
@@ -457,9 +451,7 @@ public final class CustomWordsManager {
 
     for word in incoming {
       let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty,
-        trimmed.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
-      else { continue }
+      guard Self.isStorable(trimmed) else { continue }
       let key = trimmed.lowercased()
       guard !seen.contains(key) else { continue }
 
@@ -737,15 +729,27 @@ public final class CustomWordsManager {
     )
   }
 
+  /// Whether a value may enter the library AT ALL, from any authoring path.
+  ///
+  /// The same question importing asks, asked here — because "what may be
+  /// stored" is one rule and the library is what it protects. Applying only
+  /// PART of it here (length, but not the character policy) let the editor
+  /// author a word that export then refused, which is the round-trip
+  /// asymmetry again with authoring as the door (cloud review, #1683).
+  static func isStorable(_ value: String) -> Bool {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty,
+      trimmed.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
+    else { return false }
+    return CustomWordsImportTextPolicy.isAcceptableStoredValue(trimmed)
+  }
+
   private static func sanitizeAliases(_ aliases: [String]) -> [String] {
     aliases
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-      .filter { !$0.isEmpty }
-      // Same ceiling as canonicals, for the same reason: an alias the app
-      // stores but cannot export breaks the round trip just as thoroughly.
-      .filter {
-        $0.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
-      }
+      // The whole rule, not a piece of it: an alias the app stores but cannot
+      // export breaks the round trip just as thoroughly as a canonical does.
+      .filter { isStorable($0) }
   }
 
   /// Guarantees no alias this import touched is left ambiguous, whatever
@@ -854,9 +858,7 @@ public final class CustomWordsManager {
   public func update(word: CustomWord, in words: inout [CustomWord]) throws {
     guard let index = words.firstIndex(where: { $0.id == word.id }) else { return }
     let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty,
-      trimmed.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
-    else { return }
+    guard Self.isStorable(trimmed) else { return }
     var edited = word
     edited.canonical = trimmed
     edited.aliases = Self.sanitizeAliases(edited.aliases)
@@ -904,9 +906,7 @@ public final class CustomWordsManager {
     var changed = false
     for word in updates {
       let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty,
-        trimmed.unicodeScalars.count <= CustomWordsImportLimits.maximumStoredValueScalars
-      else { continue }
+      guard Self.isStorable(trimmed) else { continue }
       guard let idx = file.words.firstIndex(where: { $0.id == word.id }) else { continue }
       var sanitized = word
       sanitized.canonical = trimmed

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -10,13 +10,13 @@ package enum CustomWordsTransferError: LocalizedError, Sendable, Equatable {
   package var errorDescription: String? {
     switch self {
     case .notAnEnviousWisprBackup:
-      return "That file isn't an EnviousWispr word backup."
+      return "That file didn't come from EnviousWispr."
     case .unsupportedVersion(let version):
       return
-        "That backup was made by a newer version of EnviousWispr (format \(version)). "
+        "That file was exported by a newer version of EnviousWispr (format \(version)). "
         + "Update the app, then try again."
     case .malformed:
-      return "That backup file is damaged and can't be read."
+      return "That file is damaged and can't be read."
     }
   }
 }
@@ -87,10 +87,21 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
     } catch {
       // A perfectly valid JSON file that simply isn't ours reads the same as
       // damaged bytes at this layer; separate them so the message is true.
-      if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-        object["format"] as? String != Self.formatIdentifier
+      //
+      // "Valid JSON" includes a top-level array, string, or number — a config
+      // file, an API dump, a word list someone saved as JSON. Those are
+      // healthy documents that just aren't ours, and calling them damaged
+      // sends the user hunting for corruption that isn't there (review r2).
+      if let json = try? JSONSerialization.jsonObject(
+        with: data, options: [.fragmentsAllowed])
       {
-        throw CustomWordsTransferError.notAnEnviousWisprBackup
+        let claimsOurFormat =
+          (json as? [String: Any])?["format"] as? String == Self.formatIdentifier
+        // Only a document claiming to BE ours can be damaged goods; anything
+        // else is simply a different file.
+        throw claimsOurFormat
+          ? CustomWordsTransferError.malformed
+          : CustomWordsTransferError.notAnEnviousWisprBackup
       }
       throw CustomWordsTransferError.malformed
     }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsTransferDocument.swift
@@ -156,8 +156,16 @@ package struct CustomWordsTransferDocument: Codable, Sendable, Equatable {
   /// genuinely has no alternate spellings" and `.supplied(nil)` means "this
   /// word genuinely uses the global strictness". A backup is a full round-trip
   /// of a real word, so silence here would be a lie, not an absence of opinion.
-  package func candidatesForImport() -> [CustomWordsImportCandidate] {
-    words.map { word in
+  /// Throws on cancellation, because this is the expensive half of reading a
+  /// large export and the sheet can be dismissed mid-flight. Without a check
+  /// here the work carried on burning CPU and memory after the UI was gone
+  /// (Codex review, #1683).
+  package func candidatesForImport() throws -> [CustomWordsImportCandidate] {
+    try words.enumerated().map { index, word in
+      // Cancellation is cheap to observe but not free, so check per batch
+      // rather than per word.
+      if index.isMultiple(of: 1_000) { try Task.checkCancellation() }
+      return
       CustomWordsImportCandidate(
         id: UUID(),
         canonical: word.canonical,

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -219,15 +219,33 @@ package struct PlainTextImportFileParser: ImportFileParser {
     text.hasPrefix("\u{FEFF}") ? String(text.dropFirst()) : text
   }
 
+  /// Whether decoded text is plausibly text at all.
+  ///
+  /// Asks Unicode rather than hand-rolling ranges, which is what the previous
+  /// version did wrong: it checked below U+0020 plus DEL and so let the C1
+  /// block through, meaning `C2 85` imported an invisible control character as
+  /// part of a word (cloud review, #1683). The general category knows about
+  /// every control, in every block, without a range to keep in sync.
+  ///
+  /// Deliberately NOT rejected: the format category (zero-width joiners and
+  /// non-joiners). Those are load-bearing in Hindi, Persian, and emoji
+  /// sequences, so refusing them would break exactly the international word
+  /// lists this feature is meant to support.
+  ///
   /// Real word lists do not contain NULs or stray control characters. This is
   /// what stops ANY decode step from laundering binary — or text in an
   /// encoding we guessed wrong — into candidates. It is the single check that
   /// makes trying several encodings safe: a wrong guess fails it and the next
   /// encoding gets its turn, rather than the first lucky decode winning.
   private static func isPlausiblyText(_ text: String) -> Bool {
-    !text.unicodeScalars.contains { scalar in
-      guard scalar.value < 0x20 || scalar.value == 0x7F else { return false }
-      return scalar != "\n" && scalar != "\r" && scalar != "\t"
+    text.unicodeScalars.allSatisfy { scalar in
+      if scalar == "\n" || scalar == "\r" || scalar == "\t" { return true }
+      switch scalar.properties.generalCategory {
+      case .control, .surrogate, .privateUse, .unassigned:
+        return false
+      default:
+        return true
+      }
     }
   }
 }

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -175,10 +175,10 @@ package struct PlainTextImportFileParser: ImportFileParser {
   private static func decodeUsingByteOrderMark(_ data: Data) -> String? {
     let bom = Array(data.prefix(3))
     if bom.starts(with: [0xFF, 0xFE]) {
-      return String(data: data, encoding: .utf16LittleEndian).map(strippingBOM)
+      return decodeUTF16(data, as: .utf16LittleEndian)
     }
     if bom.starts(with: [0xFE, 0xFF]) {
-      return String(data: data, encoding: .utf16BigEndian).map(strippingBOM)
+      return decodeUTF16(data, as: .utf16BigEndian)
     }
     if bom.starts(with: [0xEF, 0xBB, 0xBF]) {
       return String(data: data, encoding: .utf8).map(strippingBOM)
@@ -214,6 +214,16 @@ package struct PlainTextImportFileParser: ImportFileParser {
         return false
       }
     }
+  }
+
+  /// UTF-16 needs an even byte count, and Foundation does NOT enforce it: a
+  /// partially written file with a dangling byte decodes silently to its
+  /// prefix, so a truncated list imported as if complete (Codex review,
+  /// #1683). Same principle as reading to EOF rather than trusting one read —
+  /// a partial answer must be recognisable as partial.
+  private static func decodeUTF16(_ data: Data, as encoding: String.Encoding) -> String? {
+    guard data.count.isMultiple(of: 2) else { return nil }
+    return String(data: data, encoding: encoding).map(strippingBOM)
   }
 
   /// The mark itself is metadata, not a character the user typed. Left in, it

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -287,8 +287,21 @@ package struct ImportFileRegistry: Sendable {
     self.parsers = parsers
   }
 
+  /// Content types for the open panel, built from the registered EXTENSIONS
+  /// as well as the declared types.
+  ///
+  /// Declared types alone could hide a file the registry actually accepts: on
+  /// a system where `.list` resolves to an unregistered dynamic type it
+  /// conforms to no generic text type, so the panel greyed out a file the
+  /// parser claims (Codex review, #1683). Routing still reads extensions only;
+  /// this is the panel's view of the same set.
   package var acceptedContentTypes: [UTType] {
-    parsers.flatMap(\.contentTypes)
+    let declared = parsers.flatMap(\.contentTypes)
+    let fromExtensions = parsers
+      .flatMap(\.fileExtensions)
+      .compactMap { UTType(filenameExtension: $0) }
+    var seen = Set<UTType>()
+    return (declared + fromExtensions).filter { seen.insert($0).inserted }
   }
 
   package func parser(for url: URL) -> (any ImportFileParser)? {

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -223,15 +223,20 @@ package struct PlainTextImportFileParser: ImportFileParser {
     // through on failure re-created the bug the alignment check was added to
     // fix — `[FF FE E9]` is a truncated UTF-16 file, and Latin-1 turned it
     // into the plausible-looking word `ÿþé` (Codex review, #1683).
+    // Decoders strip the mark themselves, so what comes back here is already
+    // clean. Stripping again at this level read as if it were the only place
+    // it happened — a reviewer took the redundant call for the real one and
+    // reported valid UTF-16 as broken. One stripping site, no ambiguity.
     if hasByteOrderMark(data) {
-      guard let marked = decodeUsingByteOrderMark(data), CustomWordsImportTextPolicy.isPlausiblyText(marked)
+      guard let marked = decodeUsingByteOrderMark(data),
+        CustomWordsImportTextPolicy.isPlausiblyText(marked)
       else { return nil }
-      return strippingBOM(marked)
+      return marked
     }
     guard let utf8 = String(data: data, encoding: .utf8),
       CustomWordsImportTextPolicy.isPlausiblyText(utf8)
     else { return nil }
-    return strippingBOM(utf8)
+    return utf8
   }
 
   private static func hasByteOrderMark(_ data: Data) -> Bool {

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -167,16 +167,29 @@ package struct FileImportSource: CustomWordsImportSource {
       throw ImportFileError.unsupportedType(name)
     }
 
-    let size =
-      (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? nil
-    if let size, size > Self.maximumFileBytes {
+    try Task.checkCancellation()
+
+    // Bound the READ itself, rather than checking the size and then reading
+    // separately (code review r3). Between a stat and a load the file can grow
+    // or be replaced — by a sync client, by whatever wrote it — and the ceiling
+    // would be bypassed on exactly the input it exists to refuse. Reading one
+    // byte past the limit from a single open handle answers "is this too big"
+    // and "give me the bytes" as one operation, so there is no window between
+    // the question and the answer.
+    guard let handle = try? FileHandle(forReadingFrom: url) else {
+      throw ImportFileError.unreadable
+    }
+    defer { try? handle.close() }
+
+    guard
+      let data = try? handle.read(upToCount: Self.maximumFileBytes + 1)
+    else {
+      throw ImportFileError.unreadable
+    }
+    guard data.count <= Self.maximumFileBytes else {
       throw ImportFileError.tooLarge
     }
 
-    try Task.checkCancellation()
-    guard let data = try? Data(contentsOf: url) else {
-      throw ImportFileError.unreadable
-    }
     try Task.checkCancellation()
 
     let candidates = try parser.parse(data: data)

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -6,18 +6,26 @@ import UniformTypeIdentifiers
 package enum ImportFileError: LocalizedError, Sendable, Equatable {
   case unreadable
   case unsupportedType(String)
-  case backup(CustomWordsTransferError)
+  case tooLarge
+  case tooManyWords(found: Int, limit: Int)
+  case exportedWords(CustomWordsTransferError)
 
   package var errorDescription: String? {
     switch self {
     case .unreadable:
       return "That file couldn't be read."
+    case .tooLarge:
+      return "That file is too big to be a word list. Check you picked the right one."
+    case .tooManyWords(let found, let limit):
+      return
+        "That file has \(found) words, which is more than EnviousWispr can import "
+        + "at once (\(limit)). Try splitting it into smaller files."
     case .unsupportedType(let name):
       return
         "EnviousWispr can't read \(name) files yet. "
-        + "Try an EnviousWispr backup or a plain text list."
-    case .backup(let underlying):
-      // The backup decoder already distinguishes "not ours", "from a newer
+        + "Try a file you exported from EnviousWispr, or a plain text list."
+    case .exportedWords(let underlying):
+      // The decoder already distinguishes "not ours", "from a newer
       // version", and "damaged"; passing its sentence through keeps the user
       // from being told something less true by a wrapper.
       return underlying.errorDescription
@@ -41,13 +49,16 @@ package protocol ImportFileParser: Sendable {
   func parse(data: Data) throws -> [CustomWordsImportCandidate]
 }
 
-/// The EnviousWispr backup format — what PR-E1 writes.
+/// The file EnviousWispr itself exports.
 ///
-/// Without this, an export could be produced but never restored, which would
-/// make the export feature a promise the app could not keep.
-package struct BackupImportFileParser: ImportFileParser {
-  package let identifier = "backup"
-  package let displayName = "EnviousWispr backup"
+/// Deliberately not called a "backup": the product has two ideas, import and
+/// export, and naming the exported file a third thing invented a concept the
+/// user never asked for (founder, 2026-07-19). Without this parser an export
+/// could be produced but never read back, which would make Export a promise
+/// the app could not keep.
+package struct ExportedWordsFileParser: ImportFileParser {
+  package let identifier = "exported-words"
+  package let displayName = "EnviousWispr words file"
   package let contentTypes: [UTType] = [.json]
 
   package init() {}
@@ -56,7 +67,7 @@ package struct BackupImportFileParser: ImportFileParser {
     do {
       return try CustomWordsTransferDocument(data: data).candidatesForImport()
     } catch let error as CustomWordsTransferError {
-      throw ImportFileError.backup(error)
+      throw ImportFileError.exportedWords(error)
     }
   }
 }
@@ -93,12 +104,12 @@ package struct PlainTextImportFileParser: ImportFileParser {
 package struct ImportFileRegistry: Sendable {
   package let parsers: [any ImportFileParser]
 
-  /// v1 registers the two formats that need no parsing decisions: the backup
-  /// format we author ourselves, and a plain word list. CSV is deliberately
+  /// v1 registers the two formats that need no parsing decisions: the file we
+  /// author ourselves, and a plain word list. CSV is deliberately
   /// absent — it is the only format that needs the quoted-field state machine
   /// (or a dependency to supply one), and that call is the founder's to make.
   package static let v1 = ImportFileRegistry(
-    parsers: [BackupImportFileParser(), PlainTextImportFileParser()])
+    parsers: [ExportedWordsFileParser(), PlainTextImportFileParser()])
 
   package init(parsers: [any ImportFileParser]) {
     self.parsers = parsers
@@ -131,6 +142,15 @@ package struct ImportFileRegistry: Sendable {
 
 /// Reads a user-chosen file and turns it into a batch.
 package struct FileImportSource: CustomWordsImportSource {
+  /// Refuse before allocating. A word list is small; anything of this size is
+  /// a mistaken selection (a video, a database, a disk image), and reading it
+  /// into memory to discover that is the expensive way to find out.
+  package static let maximumFileBytes = 16 * 1024 * 1024
+  /// The compare engine documents this ceiling for uploads. Enforced here, at
+  /// the door, rather than after every row has been parsed, compared and
+  /// rendered into a review the user cannot meaningfully read anyway.
+  package static let maximumCandidates = 25_000
+
   private let url: URL
   private let registry: ImportFileRegistry
 
@@ -139,18 +159,38 @@ package struct FileImportSource: CustomWordsImportSource {
     self.registry = registry
   }
 
-  package func loadCandidates() async throws -> CustomWordsImportBatch {
+  /// `@concurrent` so reading and parsing always leave the caller's actor.
+  /// The import model is `@MainActor`, and a plain `async` witness would
+  /// inherit that isolation — a large, network-mounted, or cloud-backed file
+  /// would then freeze the settings window while it was read (code review).
+  @concurrent package func loadCandidates() async throws -> CustomWordsImportBatch {
     guard let parser = registry.parser(for: url) else {
       let name = url.pathExtension.isEmpty ? "those" : ".\(url.pathExtension.lowercased())"
       throw ImportFileError.unsupportedType(name)
     }
+
+    let size =
+      (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? nil
+    if let size, size > Self.maximumFileBytes {
+      throw ImportFileError.tooLarge
+    }
+
+    try Task.checkCancellation()
     guard let data = try? Data(contentsOf: url) else {
       throw ImportFileError.unreadable
     }
+    try Task.checkCancellation()
+
+    let candidates = try parser.parse(data: data)
+    guard candidates.count <= Self.maximumCandidates else {
+      throw ImportFileError.tooManyWords(
+        found: candidates.count, limit: Self.maximumCandidates)
+    }
+
     return CustomWordsImportBatch(
       sourceID: parser.identifier,
       sourceDisplayName: parser.displayName,
-      candidates: try parser.parse(data: data)
+      candidates: candidates
     )
   }
 }

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -53,12 +53,19 @@ package protocol ImportFileParser: Sendable {
   /// of unknown provenance. It is a property of the format, not of importing
   /// in general, which is why it lives here rather than at the one call site.
   var maximumCandidates: Int? { get }
+  /// How many BYTES a file of this format may be.
+  ///
+  /// Same reasoning as the word ceiling, and it has to move with it: capping
+  /// the words but not the bytes left the identical round-trip hole one layer
+  /// down, since the byte check runs BEFORE the parser is consulted.
+  var maximumBytes: Int { get }
   func parse(data: Data) throws -> [CustomWordsImportCandidate]
 }
 
 extension ImportFileParser {
-  /// Formats default to the shared ceiling; a format opts OUT deliberately.
+  /// Formats default to the shared ceilings; a format opts out deliberately.
   package var maximumCandidates: Int? { CustomWordsImportLimits.maximumCandidates }
+  package var maximumBytes: Int { CustomWordsImportLimits.maximumImportFileBytes }
 }
 
 /// The file EnviousWispr itself exports.
@@ -81,9 +88,16 @@ package struct ExportedWordsFileParser: ImportFileParser {
   /// to split a JSON file by hand (cloud review, #1683). An export you cannot
   /// import is not an export.
   ///
-  /// Still bounded, just by the honest limit: `maximumFileBytes`, which is
-  /// checked before parsing.
+  /// The byte ceiling moves with it, for the same reason: capping the words
+  /// but not the bytes left the identical hole one layer down, since the size
+  /// check runs BEFORE the parser is consulted (cloud review, #1683). Fixing
+  /// the word count alone was a fix to the instance, not to the rule.
+  ///
+  /// Still bounded, just far above any real library: a words file this large
+  /// would hold over a million terms, so a mistakenly chosen disk image is
+  /// still refused rather than read into memory.
   package let maximumCandidates: Int? = nil
+  package let maximumBytes = CustomWordsImportLimits.maximumExportedFileBytes
 
   package init() {}
 
@@ -273,7 +287,7 @@ package struct FileImportSource: CustomWordsImportSource {
   /// Refuse before allocating. A word list is small; anything of this size is
   /// a mistaken selection (a video, a database, a disk image), and reading it
   /// into memory to discover that is the expensive way to find out.
-  package static let maximumFileBytes = 16 * 1024 * 1024
+  package static var maximumFileBytes: Int { CustomWordsImportLimits.maximumImportFileBytes }
   /// Shared with every other import source, so no door has a different limit.
   package static var maximumCandidates: Int { CustomWordsImportLimits.maximumCandidates }
 
@@ -316,7 +330,7 @@ package struct FileImportSource: CustomWordsImportSource {
     // miss that the file exceeds the limit. Accumulating until the file says
     // it is done makes "how much is there" a fact rather than a guess.
     var data = Data()
-    let ceiling = Self.maximumFileBytes + 1
+    let ceiling = parser.maximumBytes + 1
     while data.count < ceiling {
       try Task.checkCancellation()
       // `read(upToCount:)` signals EOF with NIL, and a genuine failure by
@@ -332,7 +346,7 @@ package struct FileImportSource: CustomWordsImportSource {
       guard let chunk, !chunk.isEmpty else { break }  // EOF
       data.append(chunk)
     }
-    guard data.count <= Self.maximumFileBytes else {
+    guard data.count <= parser.maximumBytes else {
       throw ImportFileError.tooLarge
     }
 

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -187,9 +187,18 @@ package struct PlainTextImportFileParser: ImportFileParser {
   /// rather than guessed at. Real UTF-16 writers emit a mark — that is what it
   /// is for — and refusing a file beats silently importing the wrong word.
   ///
-  /// Latin-1 survives as the last resort for genuinely legacy lists, but must
-  /// look like WORDS rather than merely printable characters, which is what
-  /// stops un-recognised encodings from landing there as `qg¬N`.
+  /// There is deliberately NO legacy fallback. Latin-1 cannot fail — every
+  /// byte is a valid Latin-1 character — so as a last resort it is not a
+  /// fallback at all but a catch-all that renames "I could not read this" to
+  /// a confident wrong answer. It let `qg¬N` through as a word, and a
+  /// "does it look like words" guard only narrowed which wrong answers
+  /// survived: a Windows-1252 or mixed-encoding file still lands as plausible
+  /// mojibake (Codex import taxonomy audit, #1683 — class C01).
+  ///
+  /// So the supported set is exactly what can be known: UTF-8, and UTF-16 or
+  /// UTF-8 carrying a byte-order mark. Anything else is refused. If a real
+  /// legacy list ever needs importing, the answer is an explicit user choice
+  /// of encoding — evidence from the person who has it — not a guess.
   static func decode(_ data: Data) -> String? {
     // A recognised mark is AUTHORITATIVE: if it says UTF-16 and the bytes then
     // fail to decode, the file is broken, not secretly something else. Falling
@@ -197,17 +206,14 @@ package struct PlainTextImportFileParser: ImportFileParser {
     // fix — `[FF FE E9]` is a truncated UTF-16 file, and Latin-1 turned it
     // into the plausible-looking word `ÿþé` (Codex review, #1683).
     if hasByteOrderMark(data) {
-      guard let marked = decodeUsingByteOrderMark(data), isPlausiblyText(marked)
+      guard let marked = decodeUsingByteOrderMark(data), CustomWordsImportTextPolicy.isPlausiblyText(marked)
       else { return nil }
       return strippingBOM(marked)
     }
-    if let utf8 = String(data: data, encoding: .utf8), isPlausiblyText(utf8) {
-      return strippingBOM(utf8)
-    }
-    guard let latin1 = String(data: data, encoding: .isoLatin1),
-      looksLikeWords(latin1)
+    guard let utf8 = String(data: data, encoding: .utf8),
+      CustomWordsImportTextPolicy.isPlausiblyText(utf8)
     else { return nil }
-    return strippingBOM(latin1)
+    return strippingBOM(utf8)
   }
 
   private static func hasByteOrderMark(_ data: Data) -> Bool {
@@ -230,36 +236,6 @@ package struct PlainTextImportFileParser: ImportFileParser {
     return nil
   }
 
-  /// Whether text read through the catch-all encoding is plausibly a WORD
-  /// LIST, rather than some other encoding misread as Latin-1.
-  ///
-  /// Non-ASCII characters must be letters, marks, or digits — the things words
-  /// are made of. Symbols are the tell: UTF-16 misread as Latin-1 produces
-  /// runs like `qg¬N`, where `¬` is a maths symbol no one puts in a
-  /// vocabulary entry, while a real Latin-1 list (`Beyoncé`, `Jalapeño`)
-  /// contains only accented letters. ASCII passes freely so `C++` and `.NET`
-  /// are unaffected.
-  ///
-  /// This is a REFUSAL, not a repair: a single CJK word saved as UTF-16 with
-  /// no byte-order mark and no line break is genuinely ambiguous — the same
-  /// bytes are a valid Latin-1 list — and the wrong guess would corrupt real
-  /// data either way. Refusing says so honestly instead of importing nonsense.
-  /// (Multi-word CJK lists are unaffected: the line breaks supply the NUL
-  /// bytes the detector above reads.)
-  private static func looksLikeWords(_ text: String) -> Bool {
-    guard !text.isEmpty, isPlausiblyText(text) else { return false }
-    return text.unicodeScalars.allSatisfy { scalar in
-      if scalar.isASCII { return true }
-      switch scalar.properties.generalCategory {
-      case .uppercaseLetter, .lowercaseLetter, .titlecaseLetter, .modifierLetter,
-        .otherLetter, .nonspacingMark, .spacingMark, .decimalNumber, .otherNumber:
-        return true
-      default:
-        return false
-      }
-    }
-  }
-
   /// UTF-16 needs an even byte count, and Foundation does NOT enforce it: a
   /// partially written file with a dangling byte decodes silently to its
   /// prefix, so a truncated list imported as if complete (Codex review,
@@ -275,45 +251,6 @@ package struct PlainTextImportFileParser: ImportFileParser {
   /// same word further down the file.
   private static func strippingBOM(_ text: String) -> String {
     text.hasPrefix("\u{FEFF}") ? String(text.dropFirst()) : text
-  }
-
-  /// Whether decoded text is plausibly text at all.
-  ///
-  /// Asks Unicode rather than hand-rolling ranges, which is what the previous
-  /// version did wrong: it checked below U+0020 plus DEL and so let the C1
-  /// block through, meaning `C2 85` imported an invisible control character as
-  /// part of a word (cloud review, #1683). The general category knows about
-  /// every control, in every block, without a range to keep in sync.
-  ///
-  /// Deliberately allowed: the zero-width joiner and non-joiner, and ONLY
-  /// those. They are load-bearing in Hindi, Persian, and emoji sequences, so
-  /// refusing them would break exactly the international word lists this
-  /// feature exists to support. Naming the two beats accepting the whole
-  /// format category, which also admits invisible and deceptive scalars —
-  /// a mid-file byte-order mark, or a bidi override that makes a word render
-  /// as something other than what it is.
-  ///
-  /// Real word lists do not contain NULs or stray control characters. This is
-  /// what stops ANY decode step from laundering binary — or text in an
-  /// encoding we guessed wrong — into candidates. It is the single check that
-  /// makes trying several encodings safe: a wrong guess fails it and the next
-  /// encoding gets its turn, rather than the first lucky decode winning.
-  private static func isPlausiblyText(_ text: String) -> Bool {
-    text.unicodeScalars.allSatisfy { scalar in
-      if scalar == "\n" || scalar == "\r" || scalar == "\t" { return true }
-      // Two format scalars are word-forming and must survive; the rest of the
-      // category must not. Allowing all of `.format` to protect these also
-      // admitted a mid-file byte-order mark and bidi overrides like U+202E,
-      // which nothing downstream strips — so they would have been saved INSIDE
-      // a custom word, invisibly (cloud review, #1683).
-      if scalar.value == 0x200C || scalar.value == 0x200D { return true }
-      switch scalar.properties.generalCategory {
-      case .control, .surrogate, .privateUse, .unassigned, .format:
-        return false
-      default:
-        return true
-      }
-    }
   }
 }
 
@@ -365,7 +302,7 @@ package struct FileImportSource: CustomWordsImportSource {
   /// The import model is `@MainActor`, and a plain `async` witness would
   /// inherit that isolation — a large, network-mounted, or cloud-backed file
   /// would then freeze the settings window while it was read (code review).
-  @concurrent package func loadCandidates() async throws -> CustomWordsImportBatch {
+  @concurrent package func loadRawCandidates() async throws -> CustomWordsImportBatch {
     guard let parser = registry.parser(for: url) else {
       let name = url.pathExtension.isEmpty ? "those" : ".\(url.pathExtension.lowercased())"
       throw ImportFileError.unsupportedType(name)

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -146,10 +146,8 @@ package struct FileImportSource: CustomWordsImportSource {
   /// a mistaken selection (a video, a database, a disk image), and reading it
   /// into memory to discover that is the expensive way to find out.
   package static let maximumFileBytes = 16 * 1024 * 1024
-  /// The compare engine documents this ceiling for uploads. Enforced here, at
-  /// the door, rather than after every row has been parsed, compared and
-  /// rendered into a review the user cannot meaningfully read anyway.
-  package static let maximumCandidates = 25_000
+  /// Shared with every other import source, so no door has a different limit.
+  package static var maximumCandidates: Int { CustomWordsImportLimits.maximumCandidates }
 
   private let url: URL
   private let registry: ImportFileRegistry

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -131,9 +131,12 @@ package struct PlainTextImportFileParser: ImportFileParser {
       return strippingBOM(utf8)
     }
     // Latin-1 last, because it accepts every byte: anything arriving here has
-    // already failed every encoding capable of refusing it honestly.
+    // already failed every encoding capable of refusing it honestly. It must
+    // therefore look like WORDS, not merely like printable characters —
+    // otherwise it is where un-recognised UTF-16 lands and becomes `qg¬N`
+    // (cloud review, #1683).
     guard let latin1 = String(data: data, encoding: .isoLatin1),
-      isPlausiblyText(latin1)
+      looksLikeWords(latin1)
     else { return nil }
     return strippingBOM(latin1)
   }
@@ -150,6 +153,36 @@ package struct PlainTextImportFileParser: ImportFileParser {
       return String(data: data, encoding: .utf8).map(strippingBOM)
     }
     return nil
+  }
+
+  /// Whether text read through the catch-all encoding is plausibly a WORD
+  /// LIST, rather than some other encoding misread as Latin-1.
+  ///
+  /// Non-ASCII characters must be letters, marks, or digits — the things words
+  /// are made of. Symbols are the tell: UTF-16 misread as Latin-1 produces
+  /// runs like `qg¬N`, where `¬` is a maths symbol no one puts in a
+  /// vocabulary entry, while a real Latin-1 list (`Beyoncé`, `Jalapeño`)
+  /// contains only accented letters. ASCII passes freely so `C++` and `.NET`
+  /// are unaffected.
+  ///
+  /// This is a REFUSAL, not a repair: a single CJK word saved as UTF-16 with
+  /// no byte-order mark and no line break is genuinely ambiguous — the same
+  /// bytes are a valid Latin-1 list — and the wrong guess would corrupt real
+  /// data either way. Refusing says so honestly instead of importing nonsense.
+  /// (Multi-word CJK lists are unaffected: the line breaks supply the NUL
+  /// bytes the detector above reads.)
+  private static func looksLikeWords(_ text: String) -> Bool {
+    guard !text.isEmpty, isPlausiblyText(text) else { return false }
+    return text.unicodeScalars.allSatisfy { scalar in
+      if scalar.isASCII { return true }
+      switch scalar.properties.generalCategory {
+      case .uppercaseLetter, .lowercaseLetter, .titlecaseLetter, .modifierLetter,
+        .otherLetter, .nonspacingMark, .spacingMark, .decimalNumber, .otherNumber:
+        return true
+      default:
+        return false
+      }
+    }
   }
 
   /// Reads the NUL layout to tell UTF-16 apart from UTF-8, and one byte order

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -132,6 +132,15 @@ package struct ExportedWordsFileParser: ImportFileParser {
       guard document.words.count <= ceiling else {
         throw ImportFileError.tooManyWords(found: document.words.count, limit: ceiling)
       }
+      // Words are one dimension; the work is proportional to the total stored
+      // SURFACE. Few words carrying millions of aliases fits under both the
+      // word and byte ceilings and still floods validation, comparison, and
+      // the collision index (Codex review, #1683).
+      let surface = document.words.reduce(0) { $0 + 1 + $1.aliases.count }
+      let surfaceCeiling = CustomWordsImportLimits.maximumExportedStoredValues
+      guard surface <= surfaceCeiling else {
+        throw ImportFileError.tooManyWords(found: surface, limit: surfaceCeiling)
+      }
       return try document.candidatesForImport()
     } catch let error as CustomWordsTransferError {
       throw ImportFileError.exportedWords(error)

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -8,6 +8,7 @@ package enum ImportFileError: LocalizedError, Sendable, Equatable {
   case unsupportedType(String)
   case tooLarge
   case tooManyWords(found: Int, limit: Int)
+  case tooManyStoredValues(found: Int, limit: Int)
   case exportedWords(CustomWordsTransferError)
 
   package var errorDescription: String? {
@@ -25,6 +26,14 @@ package enum ImportFileError: LocalizedError, Sendable, Equatable {
       return
         "That file has more than \(limit) words, which is more than EnviousWispr "
         + "can import at once. Try splitting it into smaller files."
+    case .tooManyStoredValues(_, let limit):
+      // Distinct from tooManyWords on purpose: this file trips the ceiling on
+      // total words PLUS alternate spellings, so reporting it as a word count
+      // would state a number the user cannot see anywhere and advise splitting
+      // a file whose word count is fine (Codex review, #1683).
+      return
+        "That file has more than \(limit) words and alternate spellings "
+        + "combined, which is more than EnviousWispr can import at once."
     case .unsupportedType(let name):
       return
         "EnviousWispr can't read \(name) files yet. "
@@ -139,7 +148,7 @@ package struct ExportedWordsFileParser: ImportFileParser {
       let surface = document.words.reduce(0) { $0 + 1 + $1.aliases.count }
       let surfaceCeiling = CustomWordsImportLimits.maximumExportedStoredValues
       guard surface <= surfaceCeiling else {
-        throw ImportFileError.tooManyWords(found: surface, limit: surfaceCeiling)
+        throw ImportFileError.tooManyStoredValues(found: surface, limit: surfaceCeiling)
       }
       return try document.candidatesForImport()
     } catch let error as CustomWordsTransferError {

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -16,10 +16,15 @@ package enum ImportFileError: LocalizedError, Sendable, Equatable {
       return "That file couldn't be read."
     case .tooLarge:
       return "That file is too big to be a word list. Check you picked the right one."
-    case .tooManyWords(let found, let limit):
+    case .tooManyWords(_, let limit):
+      // Says "more than", never an exact figure. On the text path the count is
+      // a stop-sentinel — scanning halts one past the limit rather than
+      // counting a file it is going to refuse — so printing it would state a
+      // number nobody measured (Codex review, #1683). The associated value is
+      // kept for tests and telemetry, which can tell the two cases apart.
       return
-        "That file has \(found) words, which is more than EnviousWispr can import "
-        + "at once (\(limit)). Try splitting it into smaller files."
+        "That file has more than \(limit) words, which is more than EnviousWispr "
+        + "can import at once. Try splitting it into smaller files."
     case .unsupportedType(let name):
       return
         "EnviousWispr can't read \(name) files yet. "
@@ -186,7 +191,14 @@ package struct PlainTextImportFileParser: ImportFileParser {
   /// look like WORDS rather than merely printable characters, which is what
   /// stops un-recognised encodings from landing there as `qg¬N`.
   static func decode(_ data: Data) -> String? {
-    if let marked = decodeUsingByteOrderMark(data), isPlausiblyText(marked) {
+    // A recognised mark is AUTHORITATIVE: if it says UTF-16 and the bytes then
+    // fail to decode, the file is broken, not secretly something else. Falling
+    // through on failure re-created the bug the alignment check was added to
+    // fix — `[FF FE E9]` is a truncated UTF-16 file, and Latin-1 turned it
+    // into the plausible-looking word `ÿþé` (Codex review, #1683).
+    if hasByteOrderMark(data) {
+      guard let marked = decodeUsingByteOrderMark(data), isPlausiblyText(marked)
+      else { return nil }
       return strippingBOM(marked)
     }
     if let utf8 = String(data: data, encoding: .utf8), isPlausiblyText(utf8) {
@@ -196,6 +208,12 @@ package struct PlainTextImportFileParser: ImportFileParser {
       looksLikeWords(latin1)
     else { return nil }
     return strippingBOM(latin1)
+  }
+
+  private static func hasByteOrderMark(_ data: Data) -> Bool {
+    let bom = Array(data.prefix(3))
+    return bom.starts(with: [0xFF, 0xFE]) || bom.starts(with: [0xFE, 0xFF])
+      || bom.starts(with: [0xEF, 0xBB, 0xBF])
   }
 
   private static func decodeUsingByteOrderMark(_ data: Data) -> String? {

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -129,9 +129,11 @@ package struct PlainTextImportFileParser: ImportFileParser {
 
   package func parse(data: Data) throws -> [CustomWordsImportCandidate] {
     guard let text = Self.decode(data) else { throw ImportFileError.unreadable }
-    return PasteWordsParser.parse(text).map {
-      CustomWordsImportCandidate(canonical: $0)
-    }
+    // Bounded at the parse itself, so a huge list is refused without first
+    // building every entry (Codex review, #1683).
+    return try PasteWordsParser.parse(
+      text, limit: CustomWordsImportLimits.maximumCandidates
+    ).map { CustomWordsImportCandidate(canonical: $0) }
   }
 
   /// Turns file bytes into text, or refuses.

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -44,8 +44,17 @@ package protocol ImportFileParser: Sendable {
   var identifier: String { get }
   /// What the user sees.
   var displayName: String { get }
-  /// Content types this parser claims.
+  /// Content types this parser claims. Used ONLY to populate the open panel.
   var contentTypes: [UTType] { get }
+  /// Filename extensions this parser claims, lowercased and without the dot.
+  ///
+  /// Dispatch reads THIS, not `contentTypes`, so routing never depends on
+  /// Launch Services resolving an extension to the same static `UTType`. In a
+  /// restricted environment it resolves to `dyn.*` instead and every supported
+  /// upload was rejected before the file was read (Codex review, #1683).
+  /// A literal map is also simply less machinery than round-tripping a
+  /// filename through system services to get back a fact we already know.
+  var fileExtensions: [String] { get }
   /// How many words this format may carry, or nil for "as many as the file
   /// size allows".
   ///
@@ -79,6 +88,7 @@ package struct ExportedWordsFileParser: ImportFileParser {
   package let identifier = "exported-words"
   package let displayName = "EnviousWispr words file"
   package let contentTypes: [UTType] = [.json]
+  package let fileExtensions = ["json"]
 
   /// No word ceiling, because this file is the user's OWN library coming home.
   ///
@@ -124,6 +134,10 @@ package struct PlainTextImportFileParser: ImportFileParser {
   package let identifier = "plain-text"
   package let displayName = "Plain text"
   package let contentTypes: [UTType] = [.plainText, .utf8PlainText, .text]
+  /// Deliberately NOT csv/tsv: those conform to plain text but a comma is a
+  /// COLUMN separator there, so the plain-text parser would read one row as
+  /// several words, header included.
+  package let fileExtensions = ["txt", "text", "md", "list"]
 
   package init() {}
 
@@ -295,33 +309,14 @@ package struct ImportFileRegistry: Sendable {
   }
 
   package func parser(for url: URL) -> (any ImportFileParser)? {
-    guard
-      let type = UTType(filenameExtension: url.pathExtension.lowercased())
-    else { return nil }
-    // EXACT match, deliberately not conformance.
-    //
-    // CSV and TSV conform to `public.plain-text`, so a conformance match hands
-    // a spreadsheet to the plain-text parser — which splits on commas, and
-    // would silently turn one row of `GitHub,git hub,brand` into three words,
-    // header rows and category names included. Quietly corrupting a
-    // dictionary is far worse than refusing a file, so a format is readable
-    // only when a parser claims it by name.
-    //
-    // The cost is that an unrecognised text subtype reports "unsupported"
-    // rather than being read on a guess. That is the honest answer, and CSV
-    // becomes supported by registering a real CSV parser — the seam this
-    // registry exists for — not by widening this match.
-    //
-    // Reviewed twice (r4, r5) as "UTType returns a dynamic dyn.* type here, so
-    // every .json and .txt upload is rejected; 19 tests fail." Not reproduced
-    // in either environment: a direct probe resolves json → public.json and
-    // txt → public.plain-text, both non-dynamic and both matching, and the
-    // 19-test suite passes under BOTH scripts/xcode-test.sh and swift test.
-    // Left as-is deliberately rather than trading verified behaviour for an
-    // unverified claim. If some future environment genuinely yields dynamic
-    // types, the fix is an explicit extension→parser mapping here, keeping the
-    // CSV/TSV refusal intact.
-    return parsers.first { $0.contentTypes.contains(type) }
+    // Matched on the extension itself. EXACT membership, deliberately not
+    // UTType conformance: csv and tsv conform to plain text, so a conformance
+    // match handed a spreadsheet to the plain-text parser and one row of
+    // `canonical,alias,category` imported as THREE words, header included.
+    // Unclaimed extensions are refused, which is what keeps that structural.
+    let ext = url.pathExtension.lowercased()
+    guard !ext.isEmpty else { return nil }
+    return parsers.first { $0.fileExtensions.contains(ext) }
   }
 }
 

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -117,7 +117,17 @@ package struct ExportedWordsFileParser: ImportFileParser {
 
   package func parse(data: Data) throws -> [CustomWordsImportCandidate] {
     do {
-      return try CustomWordsTransferDocument(data: data).candidatesForImport()
+      let document = try CustomWordsTransferDocument(data: data)
+      // Checked on the DECODED count, before expanding into candidates and
+      // minting a UUID for each. Checking afterwards spends the CPU and memory
+      // the ceiling exists to save — the same parse-then-check shape already
+      // fixed on the plain-text side, which is why both parsers now bound
+      // their own output (Codex review, #1683).
+      let ceiling = CustomWordsImportLimits.maximumExportedCandidates
+      guard document.words.count <= ceiling else {
+        throw ImportFileError.tooManyWords(found: document.words.count, limit: ceiling)
+      }
+      return try document.candidatesForImport()
     } catch let error as CustomWordsTransferError {
       throw ImportFileError.exportedWords(error)
     }

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -118,47 +118,36 @@ package struct PlainTextImportFileParser: ImportFileParser {
 
   /// Turns file bytes into text, or refuses.
   ///
-  /// Order matters, because Latin-1 **cannot fail**: every byte is a valid
-  /// Latin-1 character, so it accepts anything handed to it. Reached too
-  /// early it is not a fallback but a catch-all that turns text it does not
-  /// understand into convincing garbage. A UTF-16 file decoded that way
-  /// becomes `ÿþK\0u\0b\0…` — which then imports as WORDS, so the user's
-  /// dictionary silently fills with mojibake (cloud review, #1683).
+  /// Only two things are trusted: a byte-order mark, which NAMES its encoding,
+  /// and UTF-8, which fails loudly when the bytes are not UTF-8. Everything
+  /// else is a guess, and four review rounds were spent learning that guesses
+  /// here corrupt data quietly (cloud reviews, #1683):
   ///
-  /// So: a byte-order mark names its own encoding and is trusted first, then
-  /// each remaining encoding is TRIED — and every one of them, including the
-  /// mark-named path, must prove the result is plausibly text before it
-  /// counts.
+  ///  - Latin-1 cannot fail, so as a fallback it is a catch-all that turned
+  ///    UTF-16 into `ÿþK\0u\0…` and imported it as words.
+  ///  - Trying each encoding and keeping what "looks like text" picks the
+  ///    WRONG one confidently: `Beyoncé\nJalapeño` read as UTF-16 decodes to
+  ///    敂潹据૩慊慬数濱 — real letters, no symbols.
+  ///  - Inferring byte order from where the NUL bytes fall is not proof
+  ///    either: UTF-16LE `一` is `00 4E`, indistinguishable from big-endian
+  ///    `N`.
   ///
-  /// Applying that proof to Latin-1 alone was not enough, and the gap is worth
-  /// naming: UTF-16 **without** a mark is valid UTF-8, because NUL is a legal
-  /// UTF-8 byte. So the UTF-8 branch succeeded and returned `K\0u\0b\0…`
-  /// without the check ever running (cloud review, #1683 — the same defect a
-  /// second time, in the one path the first fix left ungated). A decode step
-  /// that can succeed on garbage needs the check; that is every step here, so
-  /// the check belongs in the loop rather than at any single call site.
+  /// That last one is not a bug to fix, it is the shape of the problem: with
+  /// no mark, BOTH byte orders decode to something for ANY even-length input,
+  /// so no evidence in the bytes can settle it. So unmarked UTF-16 is refused
+  /// rather than guessed at. Real UTF-16 writers emit a mark — that is what it
+  /// is for — and refusing a file beats silently importing the wrong word.
+  ///
+  /// Latin-1 survives as the last resort for genuinely legacy lists, but must
+  /// look like WORDS rather than merely printable characters, which is what
+  /// stops un-recognised encodings from landing there as `qg¬N`.
   static func decode(_ data: Data) -> String? {
     if let marked = decodeUsingByteOrderMark(data), isPlausiblyText(marked) {
-      return marked
-    }
-    // Detect UTF-16 STRUCTURALLY rather than by trying it and seeing whether
-    // the result looks like text. Trying encodings in turn is not safe here:
-    // big-endian bytes read as little-endian produce `䬀甀戀攀爀渀攀琀攀猀`
-    // — real characters, no control characters — so a "does it look like
-    // text?" test accepts it confidently and the correct encoding never gets
-    // its turn. Guessing cannot be rescued by a stronger-looking check; the
-    // byte layout has to be read directly.
-    if let utf16 = decodeUTF16WithoutByteOrderMark(data), isPlausiblyText(utf16) {
-      return strippingBOM(utf16)
+      return strippingBOM(marked)
     }
     if let utf8 = String(data: data, encoding: .utf8), isPlausiblyText(utf8) {
       return strippingBOM(utf8)
     }
-    // Latin-1 last, because it accepts every byte: anything arriving here has
-    // already failed every encoding capable of refusing it honestly. It must
-    // therefore look like WORDS, not merely like printable characters —
-    // otherwise it is where un-recognised UTF-16 lands and becomes `qg¬N`
-    // (cloud review, #1683).
     guard let latin1 = String(data: data, encoding: .isoLatin1),
       looksLikeWords(latin1)
     else { return nil }
@@ -207,36 +196,6 @@ package struct PlainTextImportFileParser: ImportFileParser {
         return false
       }
     }
-  }
-
-  /// Reads the NUL layout to tell UTF-16 apart from UTF-8, and one byte order
-  /// from the other.
-  ///
-  /// A word list is overwhelmingly ASCII, and ASCII in UTF-16 pairs every
-  /// character with a NUL: little-endian puts it at ODD offsets (`K\0u\0`),
-  /// big-endian at EVEN ones (`\0K\0u`). That layout is a fact about the
-  /// bytes, so it decides the encoding instead of leaving it to whichever
-  /// guess happens to produce printable characters first.
-  ///
-  /// Returns nil when the NULs fit neither pattern — which is what binary
-  /// looks like, and refusing it is the honest answer.
-  private static func decodeUTF16WithoutByteOrderMark(_ data: Data) -> String? {
-    let bytes = Array(data)
-    guard bytes.count >= 2, bytes.count.isMultiple(of: 2), bytes.contains(0) else {
-      return nil
-    }
-    var nulsAtOddOffsets = 0
-    var nulsAtEvenOffsets = 0
-    for (offset, byte) in bytes.enumerated() where byte == 0 {
-      if offset.isMultiple(of: 2) { nulsAtEvenOffsets += 1 } else { nulsAtOddOffsets += 1 }
-    }
-    if nulsAtOddOffsets > 0, nulsAtEvenOffsets == 0 {
-      return String(data: data, encoding: .utf16LittleEndian)
-    }
-    if nulsAtEvenOffsets > 0, nulsAtOddOffsets == 0 {
-      return String(data: data, encoding: .utf16BigEndian)
-    }
-    return nil
   }
 
   /// The mark itself is metadata, not a character the user typed. Left in, it

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -136,6 +136,16 @@ package struct ImportFileRegistry: Sendable {
     // rather than being read on a guess. That is the honest answer, and CSV
     // becomes supported by registering a real CSV parser — the seam this
     // registry exists for — not by widening this match.
+    //
+    // Reviewed twice (r4, r5) as "UTType returns a dynamic dyn.* type here, so
+    // every .json and .txt upload is rejected; 19 tests fail." Not reproduced
+    // in either environment: a direct probe resolves json → public.json and
+    // txt → public.plain-text, both non-dynamic and both matching, and the
+    // 19-test suite passes under BOTH scripts/xcode-test.sh and swift test.
+    // Left as-is deliberately rather than trading verified behaviour for an
+    // unverified claim. If some future environment genuinely yields dynamic
+    // types, the fix is an explicit extension→parser mapping here, keeping the
+    // CSV/TSV refusal intact.
     return parsers.first { $0.contentTypes.contains(type) }
   }
 }

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -86,16 +86,61 @@ package struct PlainTextImportFileParser: ImportFileParser {
   package init() {}
 
   package func parse(data: Data) throws -> [CustomWordsImportCandidate] {
-    // Accept UTF-8 first, then fall back to the platform's legacy encoding
-    // rather than refusing a file a user exported from an older tool.
-    guard
-      let text = String(data: data, encoding: .utf8)
-        ?? String(data: data, encoding: .isoLatin1)
-    else {
-      throw ImportFileError.unreadable
-    }
+    guard let text = Self.decode(data) else { throw ImportFileError.unreadable }
     return PasteWordsParser.parse(text).map {
       CustomWordsImportCandidate(canonical: $0)
+    }
+  }
+
+  /// Turns file bytes into text, or refuses.
+  ///
+  /// Order matters, because Latin-1 **cannot fail**: every byte is a valid
+  /// Latin-1 character, so it accepts anything handed to it. Reached too
+  /// early it is not a fallback but a catch-all that turns text it does not
+  /// understand into convincing garbage. A UTF-16 file decoded that way
+  /// becomes `ÿþK\0u\0b\0…` — which then imports as WORDS, so the user's
+  /// dictionary silently fills with mojibake (cloud review, #1683).
+  ///
+  /// So: a byte-order mark names its own encoding and is trusted first; UTF-8
+  /// is tried next because it is what everything modern writes; Latin-1 stays
+  /// last and now has to prove the result is plausibly text before it counts.
+  static func decode(_ data: Data) -> String? {
+    if let marked = decodeUsingByteOrderMark(data) { return marked }
+    if let utf8 = String(data: data, encoding: .utf8) { return utf8 }
+    guard let latin1 = String(data: data, encoding: .isoLatin1),
+      isPlausiblyText(latin1)
+    else { return nil }
+    return latin1
+  }
+
+  private static func decodeUsingByteOrderMark(_ data: Data) -> String? {
+    let bom = Array(data.prefix(3))
+    if bom.starts(with: [0xFF, 0xFE]) {
+      return String(data: data, encoding: .utf16LittleEndian).map(strippingBOM)
+    }
+    if bom.starts(with: [0xFE, 0xFF]) {
+      return String(data: data, encoding: .utf16BigEndian).map(strippingBOM)
+    }
+    if bom.starts(with: [0xEF, 0xBB, 0xBF]) {
+      return String(data: data, encoding: .utf8).map(strippingBOM)
+    }
+    return nil
+  }
+
+  /// The mark itself is metadata, not a character the user typed. Left in, it
+  /// rides along on the first word and imports as a different term than the
+  /// same word further down the file.
+  private static func strippingBOM(_ text: String) -> String {
+    text.hasPrefix("\u{FEFF}") ? String(text.dropFirst()) : text
+  }
+
+  /// Real word lists do not contain NULs or stray control characters. This is
+  /// what stops Latin-1 from laundering binary — or any encoding we failed to
+  /// recognise — into candidates.
+  private static func isPlausiblyText(_ text: String) -> Bool {
+    !text.unicodeScalars.contains { scalar in
+      guard scalar.value < 0x20 || scalar.value == 0x7F else { return false }
+      return scalar != "\n" && scalar != "\r" && scalar != "\t"
     }
   }
 }

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -93,10 +93,14 @@ package struct ExportedWordsFileParser: ImportFileParser {
   /// check runs BEFORE the parser is consulted (cloud review, #1683). Fixing
   /// the word count alone was a fix to the instance, not to the rule.
   ///
-  /// Still bounded, just far above any real library: a words file this large
-  /// would hold over a million terms, so a mistakenly chosen disk image is
-  /// still refused rather than read into memory.
-  package let maximumCandidates: Int? = nil
+  /// Raised, NOT removed. The "this is an EnviousWispr export" marker is
+  /// self-declared and unsigned, so treating it as a licence for an unbounded
+  /// candidate set trusts a claim anyone can make: a crafted 64 MB file could
+  /// otherwise produce hundreds of thousands of rows and hang the review
+  /// screen (Codex review, #1683). A ceiling far above any real library still
+  /// keeps the round trip whole while giving a hostile file a known worst
+  /// case.
+  package let maximumCandidates: Int? = CustomWordsImportLimits.maximumExportedCandidates
   package let maximumBytes = CustomWordsImportLimits.maximumExportedFileBytes
 
   package init() {}

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -101,16 +101,41 @@ package struct PlainTextImportFileParser: ImportFileParser {
   /// becomes `ÿþK\0u\0b\0…` — which then imports as WORDS, so the user's
   /// dictionary silently fills with mojibake (cloud review, #1683).
   ///
-  /// So: a byte-order mark names its own encoding and is trusted first; UTF-8
-  /// is tried next because it is what everything modern writes; Latin-1 stays
-  /// last and now has to prove the result is plausibly text before it counts.
+  /// So: a byte-order mark names its own encoding and is trusted first, then
+  /// each remaining encoding is TRIED — and every one of them, including the
+  /// mark-named path, must prove the result is plausibly text before it
+  /// counts.
+  ///
+  /// Applying that proof to Latin-1 alone was not enough, and the gap is worth
+  /// naming: UTF-16 **without** a mark is valid UTF-8, because NUL is a legal
+  /// UTF-8 byte. So the UTF-8 branch succeeded and returned `K\0u\0b\0…`
+  /// without the check ever running (cloud review, #1683 — the same defect a
+  /// second time, in the one path the first fix left ungated). A decode step
+  /// that can succeed on garbage needs the check; that is every step here, so
+  /// the check belongs in the loop rather than at any single call site.
   static func decode(_ data: Data) -> String? {
-    if let marked = decodeUsingByteOrderMark(data) { return marked }
-    if let utf8 = String(data: data, encoding: .utf8) { return utf8 }
+    if let marked = decodeUsingByteOrderMark(data), isPlausiblyText(marked) {
+      return marked
+    }
+    // Detect UTF-16 STRUCTURALLY rather than by trying it and seeing whether
+    // the result looks like text. Trying encodings in turn is not safe here:
+    // big-endian bytes read as little-endian produce `䬀甀戀攀爀渀攀琀攀猀`
+    // — real characters, no control characters — so a "does it look like
+    // text?" test accepts it confidently and the correct encoding never gets
+    // its turn. Guessing cannot be rescued by a stronger-looking check; the
+    // byte layout has to be read directly.
+    if let utf16 = decodeUTF16WithoutByteOrderMark(data), isPlausiblyText(utf16) {
+      return strippingBOM(utf16)
+    }
+    if let utf8 = String(data: data, encoding: .utf8), isPlausiblyText(utf8) {
+      return strippingBOM(utf8)
+    }
+    // Latin-1 last, because it accepts every byte: anything arriving here has
+    // already failed every encoding capable of refusing it honestly.
     guard let latin1 = String(data: data, encoding: .isoLatin1),
       isPlausiblyText(latin1)
     else { return nil }
-    return latin1
+    return strippingBOM(latin1)
   }
 
   private static func decodeUsingByteOrderMark(_ data: Data) -> String? {
@@ -127,6 +152,36 @@ package struct PlainTextImportFileParser: ImportFileParser {
     return nil
   }
 
+  /// Reads the NUL layout to tell UTF-16 apart from UTF-8, and one byte order
+  /// from the other.
+  ///
+  /// A word list is overwhelmingly ASCII, and ASCII in UTF-16 pairs every
+  /// character with a NUL: little-endian puts it at ODD offsets (`K\0u\0`),
+  /// big-endian at EVEN ones (`\0K\0u`). That layout is a fact about the
+  /// bytes, so it decides the encoding instead of leaving it to whichever
+  /// guess happens to produce printable characters first.
+  ///
+  /// Returns nil when the NULs fit neither pattern — which is what binary
+  /// looks like, and refusing it is the honest answer.
+  private static func decodeUTF16WithoutByteOrderMark(_ data: Data) -> String? {
+    let bytes = Array(data)
+    guard bytes.count >= 2, bytes.count.isMultiple(of: 2), bytes.contains(0) else {
+      return nil
+    }
+    var nulsAtOddOffsets = 0
+    var nulsAtEvenOffsets = 0
+    for (offset, byte) in bytes.enumerated() where byte == 0 {
+      if offset.isMultiple(of: 2) { nulsAtEvenOffsets += 1 } else { nulsAtOddOffsets += 1 }
+    }
+    if nulsAtOddOffsets > 0, nulsAtEvenOffsets == 0 {
+      return String(data: data, encoding: .utf16LittleEndian)
+    }
+    if nulsAtEvenOffsets > 0, nulsAtOddOffsets == 0 {
+      return String(data: data, encoding: .utf16BigEndian)
+    }
+    return nil
+  }
+
   /// The mark itself is metadata, not a character the user typed. Left in, it
   /// rides along on the first word and imports as a different term than the
   /// same word further down the file.
@@ -135,8 +190,10 @@ package struct PlainTextImportFileParser: ImportFileParser {
   }
 
   /// Real word lists do not contain NULs or stray control characters. This is
-  /// what stops Latin-1 from laundering binary — or any encoding we failed to
-  /// recognise — into candidates.
+  /// what stops ANY decode step from laundering binary — or text in an
+  /// encoding we guessed wrong — into candidates. It is the single check that
+  /// makes trying several encodings safe: a wrong guess fails it and the next
+  /// encoding gets its turn, rather than the first lucky decode winning.
   private static func isPlausiblyText(_ text: String) -> Bool {
     !text.unicodeScalars.contains { scalar in
       guard scalar.value < 0x20 || scalar.value == 0x7F else { return false }

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -227,10 +227,13 @@ package struct PlainTextImportFileParser: ImportFileParser {
   /// part of a word (cloud review, #1683). The general category knows about
   /// every control, in every block, without a range to keep in sync.
   ///
-  /// Deliberately NOT rejected: the format category (zero-width joiners and
-  /// non-joiners). Those are load-bearing in Hindi, Persian, and emoji
-  /// sequences, so refusing them would break exactly the international word
-  /// lists this feature is meant to support.
+  /// Deliberately allowed: the zero-width joiner and non-joiner, and ONLY
+  /// those. They are load-bearing in Hindi, Persian, and emoji sequences, so
+  /// refusing them would break exactly the international word lists this
+  /// feature exists to support. Naming the two beats accepting the whole
+  /// format category, which also admits invisible and deceptive scalars —
+  /// a mid-file byte-order mark, or a bidi override that makes a word render
+  /// as something other than what it is.
   ///
   /// Real word lists do not contain NULs or stray control characters. This is
   /// what stops ANY decode step from laundering binary — or text in an
@@ -240,8 +243,14 @@ package struct PlainTextImportFileParser: ImportFileParser {
   private static func isPlausiblyText(_ text: String) -> Bool {
     text.unicodeScalars.allSatisfy { scalar in
       if scalar == "\n" || scalar == "\r" || scalar == "\t" { return true }
+      // Two format scalars are word-forming and must survive; the rest of the
+      // category must not. Allowing all of `.format` to protect these also
+      // admitted a mid-file byte-order mark and bidi overrides like U+202E,
+      // which nothing downstream strips — so they would have been saved INSIDE
+      // a custom word, invisibly (cloud review, #1683).
+      if scalar.value == 0x200C || scalar.value == 0x200D { return true }
       switch scalar.properties.generalCategory {
-      case .control, .surrogate, .privateUse, .unassigned:
+      case .control, .surrogate, .privateUse, .unassigned, .format:
         return false
       default:
         return true
@@ -302,10 +311,6 @@ package struct ImportFileRegistry: Sendable {
 
 /// Reads a user-chosen file and turns it into a batch.
 package struct FileImportSource: CustomWordsImportSource {
-  /// Refuse before allocating. A word list is small; anything of this size is
-  /// a mistaken selection (a video, a database, a disk image), and reading it
-  /// into memory to discover that is the expensive way to find out.
-  package static var maximumFileBytes: Int { CustomWordsImportLimits.maximumImportFileBytes }
   /// Shared with every other import source, so no door has a different limit.
   package static var maximumCandidates: Int { CustomWordsImportLimits.maximumCandidates }
 

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -181,10 +181,28 @@ package struct FileImportSource: CustomWordsImportSource {
     }
     defer { try? handle.close() }
 
-    guard
-      let data = try? handle.read(upToCount: Self.maximumFileBytes + 1)
-    else {
-      throw ImportFileError.unreadable
+    // Loop until EOF or one byte past the ceiling (code review r4). A single
+    // `read(upToCount:)` may return FEWER bytes without having reached the end
+    // — routine for network-mounted and cloud-backed files — which would have
+    // silently imported a truncated prefix of the user's list and could also
+    // miss that the file exceeds the limit. Accumulating until the file says
+    // it is done makes "how much is there" a fact rather than a guess.
+    var data = Data()
+    let ceiling = Self.maximumFileBytes + 1
+    while data.count < ceiling {
+      try Task.checkCancellation()
+      // `read(upToCount:)` signals EOF with NIL, and a genuine failure by
+      // throwing. Collapsing those two with `try?` turned every successful
+      // read-to-completion into "unreadable" — caught immediately by the
+      // existing tests, which is what they are for.
+      let chunk: Data?
+      do {
+        chunk = try handle.read(upToCount: ceiling - data.count)
+      } catch {
+        throw ImportFileError.unreadable
+      }
+      guard let chunk, !chunk.isEmpty else { break }  // EOF
+      data.append(chunk)
     }
     guard data.count <= Self.maximumFileBytes else {
       throw ImportFileError.tooLarge

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -1,0 +1,156 @@
+import EnviousWisprCore
+import Foundation
+import UniformTypeIdentifiers
+
+/// Why a chosen file could not become import candidates (#1683, PR-U1).
+package enum ImportFileError: LocalizedError, Sendable, Equatable {
+  case unreadable
+  case unsupportedType(String)
+  case backup(CustomWordsTransferError)
+
+  package var errorDescription: String? {
+    switch self {
+    case .unreadable:
+      return "That file couldn't be read."
+    case .unsupportedType(let name):
+      return
+        "EnviousWispr can't read \(name) files yet. "
+        + "Try an EnviousWispr backup or a plain text list."
+    case .backup(let underlying):
+      // The backup decoder already distinguishes "not ours", "from a newer
+      // version", and "damaged"; passing its sentence through keeps the user
+      // from being told something less true by a wrapper.
+      return underlying.errorDescription
+    }
+  }
+}
+
+/// One file format the picker can read.
+///
+/// A registry rather than a switch so CSV (and later Excel) is a pure addition:
+/// a new conformer and one registry entry, with nothing existing rewritten.
+/// That seam is the reason the plan asked for a registry at all, and it stays
+/// even though v1 registers only two formats.
+package protocol ImportFileParser: Sendable {
+  /// Stable identifier, emitted as the batch's `sourceID` for telemetry.
+  var identifier: String { get }
+  /// What the user sees.
+  var displayName: String { get }
+  /// Content types this parser claims.
+  var contentTypes: [UTType] { get }
+  func parse(data: Data) throws -> [CustomWordsImportCandidate]
+}
+
+/// The EnviousWispr backup format — what PR-E1 writes.
+///
+/// Without this, an export could be produced but never restored, which would
+/// make the export feature a promise the app could not keep.
+package struct BackupImportFileParser: ImportFileParser {
+  package let identifier = "backup"
+  package let displayName = "EnviousWispr backup"
+  package let contentTypes: [UTType] = [.json]
+
+  package init() {}
+
+  package func parse(data: Data) throws -> [CustomWordsImportCandidate] {
+    do {
+      return try CustomWordsTransferDocument(data: data).candidatesForImport()
+    } catch let error as CustomWordsTransferError {
+      throw ImportFileError.backup(error)
+    }
+  }
+}
+
+/// A plain list of words.
+///
+/// Deliberately the SAME parser the Paste screen uses, not a second
+/// implementation: a word list is a word list whether it was typed into a box
+/// or saved to a file, and two parsers would eventually disagree about what
+/// "C++" or "Envious Labs" means.
+package struct PlainTextImportFileParser: ImportFileParser {
+  package let identifier = "plain-text"
+  package let displayName = "Plain text"
+  package let contentTypes: [UTType] = [.plainText, .utf8PlainText, .text]
+
+  package init() {}
+
+  package func parse(data: Data) throws -> [CustomWordsImportCandidate] {
+    // Accept UTF-8 first, then fall back to the platform's legacy encoding
+    // rather than refusing a file a user exported from an older tool.
+    guard
+      let text = String(data: data, encoding: .utf8)
+        ?? String(data: data, encoding: .isoLatin1)
+    else {
+      throw ImportFileError.unreadable
+    }
+    return PasteWordsParser.parse(text).map {
+      CustomWordsImportCandidate(canonical: $0)
+    }
+  }
+}
+
+/// Chooses a parser for a file and runs it.
+package struct ImportFileRegistry: Sendable {
+  package let parsers: [any ImportFileParser]
+
+  /// v1 registers the two formats that need no parsing decisions: the backup
+  /// format we author ourselves, and a plain word list. CSV is deliberately
+  /// absent — it is the only format that needs the quoted-field state machine
+  /// (or a dependency to supply one), and that call is the founder's to make.
+  package static let v1 = ImportFileRegistry(
+    parsers: [BackupImportFileParser(), PlainTextImportFileParser()])
+
+  package init(parsers: [any ImportFileParser]) {
+    self.parsers = parsers
+  }
+
+  package var acceptedContentTypes: [UTType] {
+    parsers.flatMap(\.contentTypes)
+  }
+
+  package func parser(for url: URL) -> (any ImportFileParser)? {
+    guard
+      let type = UTType(filenameExtension: url.pathExtension.lowercased())
+    else { return nil }
+    // EXACT match, deliberately not conformance.
+    //
+    // CSV and TSV conform to `public.plain-text`, so a conformance match hands
+    // a spreadsheet to the plain-text parser — which splits on commas, and
+    // would silently turn one row of `GitHub,git hub,brand` into three words,
+    // header rows and category names included. Quietly corrupting a
+    // dictionary is far worse than refusing a file, so a format is readable
+    // only when a parser claims it by name.
+    //
+    // The cost is that an unrecognised text subtype reports "unsupported"
+    // rather than being read on a guess. That is the honest answer, and CSV
+    // becomes supported by registering a real CSV parser — the seam this
+    // registry exists for — not by widening this match.
+    return parsers.first { $0.contentTypes.contains(type) }
+  }
+}
+
+/// Reads a user-chosen file and turns it into a batch.
+package struct FileImportSource: CustomWordsImportSource {
+  private let url: URL
+  private let registry: ImportFileRegistry
+
+  package init(url: URL, registry: ImportFileRegistry = .v1) {
+    self.url = url
+    self.registry = registry
+  }
+
+  package func loadCandidates() async throws -> CustomWordsImportBatch {
+    guard let parser = registry.parser(for: url) else {
+      let name = url.pathExtension.isEmpty ? "those" : ".\(url.pathExtension.lowercased())"
+      throw ImportFileError.unsupportedType(name)
+    }
+    guard let data = try? Data(contentsOf: url) else {
+      throw ImportFileError.unreadable
+    }
+    return CustomWordsImportBatch(
+      sourceID: parser.identifier,
+      sourceDisplayName: parser.displayName,
+      candidates: try parser.parse(data: data)
+    )
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -46,7 +46,19 @@ package protocol ImportFileParser: Sendable {
   var displayName: String { get }
   /// Content types this parser claims.
   var contentTypes: [UTType] { get }
+  /// How many words this format may carry, or nil for "as many as the file
+  /// size allows".
+  ///
+  /// The ceiling exists to bound UNTRUSTED input — a pasted or hand-made list
+  /// of unknown provenance. It is a property of the format, not of importing
+  /// in general, which is why it lives here rather than at the one call site.
+  var maximumCandidates: Int? { get }
   func parse(data: Data) throws -> [CustomWordsImportCandidate]
+}
+
+extension ImportFileParser {
+  /// Formats default to the shared ceiling; a format opts OUT deliberately.
+  package var maximumCandidates: Int? { CustomWordsImportLimits.maximumCandidates }
 }
 
 /// The file EnviousWispr itself exports.
@@ -60,6 +72,18 @@ package struct ExportedWordsFileParser: ImportFileParser {
   package let identifier = "exported-words"
   package let displayName = "EnviousWispr words file"
   package let contentTypes: [UTType] = [.json]
+
+  /// No word ceiling, because this file is the user's OWN library coming home.
+  ///
+  /// Nothing caps how many words a library may accumulate — contacts import
+  /// and hand-added terms both grow it freely — so the shared ceiling made the
+  /// app able to WRITE a file it would then refuse to read, advising the user
+  /// to split a JSON file by hand (cloud review, #1683). An export you cannot
+  /// import is not an export.
+  ///
+  /// Still bounded, just by the honest limit: `maximumFileBytes`, which is
+  /// checked before parsing.
+  package let maximumCandidates: Int? = nil
 
   package init() {}
 
@@ -356,9 +380,8 @@ package struct FileImportSource: CustomWordsImportSource {
     try Task.checkCancellation()
 
     let candidates = try parser.parse(data: data)
-    guard candidates.count <= Self.maximumCandidates else {
-      throw ImportFileError.tooManyWords(
-        found: candidates.count, limit: Self.maximumCandidates)
+    if let ceiling = parser.maximumCandidates, candidates.count > ceiling {
+      throw ImportFileError.tooManyWords(found: candidates.count, limit: ceiling)
     }
 
     return CustomWordsImportBatch(

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -48,6 +48,9 @@ package enum PasteWordsParser {
     var buffer = ""
     let ceiling = limit.map { $0 + 1 }
     var scanned = 0
+    // flush() reports "stop" for both success-with-ceiling-reached and a real
+    // failure, so the failure is carried out rather than inferred.
+    var lengthFailure: CustomWordsImportValidationError?
 
     func flush() -> Bool {
       defer { buffer.removeAll(keepingCapacity: true) }
@@ -66,6 +69,16 @@ package enum PasteWordsParser {
       guard !trimmed.isEmpty,
         CustomWordsImportTextPolicy.hasVisibleContent(trimmed)
       else { return true }
+      // Length is judged on the TRIMMED value, matching the validator. Judging
+      // the raw buffer counted padding as part of the word, so 513 spaces or a
+      // heavily padded short entry failed as "too long" (cloud review, #1683).
+      guard trimmed.unicodeScalars.count
+        <= CustomWordsImportLimits.maximumStoredValueScalars
+      else {
+        lengthFailure = CustomWordsImportValidationError.wordTooLong(
+          limit: CustomWordsImportLimits.maximumStoredValueScalars)
+        return false
+      }
       // Deduplicate on the compare engine's own key, so "GitHub" and "github"
       // in one paste collapse the same way they would against the library —
       // and the FIRST spelling wins, because that is the one the user typed
@@ -80,14 +93,18 @@ package enum PasteWordsParser {
       scanned += 1
       if scanned.isMultiple(of: 100_000) { try Task.checkCancellation() }
       if separators.contains(scalar) {
-        guard flush() else { return results }
+        guard flush() else {
+          if let lengthFailure { throw lengthFailure }
+          return results
+        }
         continue
       }
-      // Stop BUILDING an over-long entry rather than assembling megabytes and
-      // rejecting it afterwards — the same reason the candidate ceiling stops
-      // the scan rather than trimming the result (Codex review, #1683).
+      // A MEMORY bound, not the word-length rule: it exists so one enormous
+      // line cannot grow the buffer to the whole file. The rule itself is
+      // applied to the trimmed value in flush(), because padding is not part
+      // of the word. Generous multiple so trimming always gets its say first.
       guard buffer.unicodeScalars.count
-        < CustomWordsImportLimits.maximumStoredValueScalars
+        < CustomWordsImportLimits.maximumStoredValueScalars * 4
       else {
         throw CustomWordsImportValidationError.wordTooLong(
           limit: CustomWordsImportLimits.maximumStoredValueScalars)
@@ -95,6 +112,7 @@ package enum PasteWordsParser {
       buffer.unicodeScalars.append(scalar)
     }
     _ = flush()
+    if let lengthFailure { throw lengthFailure }
     return results
   }
 }

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -15,12 +15,18 @@ import Foundation
 package enum PasteWordsParser {
   /// Separators, and only these.
   ///
+  /// Tab IS a separator, by the same reasoning that excludes the others: it
+  /// never appears inside a word. Treating it as ordinary whitespace instead
+  /// stored it INSIDE a canonical term, where it is invisible — and comparison
+  /// normalises it to a space, so the saved word could never match a
+  /// transcript (Codex review, #1683).
+  ///
   /// Semicolon, slash, hyphen, and plain space are deliberately NOT separators:
   /// "Envious Labs" is one word, "C++"/"C#"/".NET" must survive intact, and a
   /// hyphenated surname is not two people. Being conservative here is why the
   /// user can paste a messy list and still get what they meant — a wrong split
   /// silently invents words nobody typed.
-  private static let separators = CharacterSet(charactersIn: ",\n\r")
+  private static let separators = CharacterSet(charactersIn: ",\n\r\t")
 
   /// Scans the text ONCE, emitting words as it goes, and stops at `limit` + 1.
   ///

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -41,6 +41,20 @@ package enum PasteWordsParser {
   }
 }
 
+/// Pasting more than the shared ceiling allows (#1683).
+package enum PasteWordsImportError: LocalizedError, Sendable, Equatable {
+  case tooManyWords(found: Int, limit: Int)
+
+  package var errorDescription: String? {
+    switch self {
+    case .tooManyWords(let found, let limit):
+      return
+        "That's \(found) words, which is more than EnviousWispr can import at once "
+        + "(\(limit)). Try pasting a smaller batch."
+    }
+  }
+}
+
 /// The pasted-text import source.
 package struct PasteWordsImportSource: CustomWordsImportSource {
   package static let sourceID = "paste"
@@ -51,8 +65,16 @@ package struct PasteWordsImportSource: CustomWordsImportSource {
     self.text = text
   }
 
-  package func loadCandidates() async throws -> CustomWordsImportBatch {
+  /// `@concurrent` so a very large paste is parsed off the caller's actor
+  /// rather than on the main one (code review r2).
+  @concurrent package func loadCandidates() async throws -> CustomWordsImportBatch {
     let canonicals = PasteWordsParser.parse(text)
+    // The same ceiling file import enforces. A limit that applied to one door
+    // and not the other would just be a bug with a longer fuse.
+    guard canonicals.count <= CustomWordsImportLimits.maximumCandidates else {
+      throw PasteWordsImportError.tooManyWords(
+        found: canonicals.count, limit: CustomWordsImportLimits.maximumCandidates)
+    }
     return CustomWordsImportBatch(
       sourceID: Self.sourceID,
       sourceDisplayName: "Pasted words",

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -52,7 +52,15 @@ package enum PasteWordsParser {
     func flush() -> Bool {
       defer { buffer.removeAll(keepingCapacity: true) }
       let trimmed = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else { return true }
+      // Skipped like any other blank line. A piece made only of invisible
+      // joiners is noise in a pasted list, not a word the user meant — and
+      // refusing the whole paste over one would be a strange way to treat
+      // what is effectively an empty line (cloud review, #1683). A structured
+      // file is different: there a blank word is a defect, and the validator
+      // refuses it.
+      guard !trimmed.isEmpty,
+        CustomWordsImportTextPolicy.isAcceptableStoredValue(trimmed)
+      else { return true }
       // Deduplicate on the compare engine's own key, so "GitHub" and "github"
       // in one paste collapse the same way they would against the library —
       // and the FIRST spelling wins, because that is the one the user typed

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -58,8 +58,13 @@ package enum PasteWordsParser {
       // what is effectively an empty line (cloud review, #1683). A structured
       // file is different: there a blank word is a defect, and the validator
       // refuses it.
+      // Skips only what is BLANK — an empty line, or a piece made of nothing
+      // but joiners — the way this has always skipped whitespace. Deliberately
+      // NOT the full acceptability check: a visible entry carrying a
+      // disallowed character must reach the validator and be REPORTED, not
+      // vanish from a list the user pasted (cloud review, #1683).
       guard !trimmed.isEmpty,
-        CustomWordsImportTextPolicy.isAcceptableStoredValue(trimmed)
+        CustomWordsImportTextPolicy.hasVisibleContent(trimmed)
       else { return true }
       // Deduplicate on the compare engine's own key, so "GitHub" and "github"
       // in one paste collapse the same way they would against the library —

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -105,7 +105,7 @@ package struct PasteWordsImportSource: CustomWordsImportSource {
 
   /// `@concurrent` so a very large paste is parsed off the caller's actor
   /// rather than on the main one (code review r2).
-  @concurrent package func loadCandidates() async throws -> CustomWordsImportBatch {
+  @concurrent package func loadRawCandidates() async throws -> CustomWordsImportBatch {
     let canonicals = try PasteWordsParser.parse(
       text, limit: CustomWordsImportLimits.maximumCandidates)
     // The same ceiling file import enforces. A limit that applied to one door

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -22,21 +22,51 @@ package enum PasteWordsParser {
   /// silently invents words nobody typed.
   private static let separators = CharacterSet(charactersIn: ",\n\r")
 
-  package static func parse(_ text: String) -> [String] {
+  /// Scans the text ONCE, emitting words as it goes, and stops at `limit` + 1.
+  ///
+  /// The previous shape built every component first and checked the ceiling
+  /// afterwards, so a 16 MB list of separators materialised millions of
+  /// entries to then reject the file — spending exactly the memory the ceiling
+  /// exists to save, with cancellation unobserved until it finished (Codex
+  /// review, #1683).
+  ///
+  /// `split`/`components(separatedBy:)` cannot fix that: both build the whole
+  /// array before any early exit can run. Only a character-by-character scan
+  /// with its own buffer is genuinely incremental.
+  ///
+  /// One entry past the limit is enough for the caller to tell "at the limit"
+  /// from "over" it.
+  package static func parse(_ text: String, limit: Int? = nil) throws -> [String] {
     var seen = Set<String>()
     var results: [String] = []
+    var buffer = ""
+    let ceiling = limit.map { $0 + 1 }
+    var scanned = 0
 
-    for piece in text.components(separatedBy: separators) {
-      let trimmed = piece.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else { continue }
+    func flush() -> Bool {
+      defer { buffer.removeAll(keepingCapacity: true) }
+      let trimmed = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else { return true }
       // Deduplicate on the compare engine's own key, so "GitHub" and "github"
       // in one paste collapse the same way they would against the library —
       // and the FIRST spelling wins, because that is the one the user typed
       // first and has no reason to see replaced by a later casing.
       let key = CustomWordsImportCompareEngine.normalize(trimmed)
-      guard !key.isEmpty, seen.insert(key).inserted else { continue }
+      guard !key.isEmpty, seen.insert(key).inserted else { return true }
       results.append(trimmed)
+      return ceiling.map { results.count < $0 } ?? true
     }
+
+    for scalar in text.unicodeScalars {
+      scanned += 1
+      if scanned.isMultiple(of: 100_000) { try Task.checkCancellation() }
+      if separators.contains(scalar) {
+        guard flush() else { return results }
+        continue
+      }
+      buffer.unicodeScalars.append(scalar)
+    }
+    _ = flush()
     return results
   }
 }
@@ -68,7 +98,8 @@ package struct PasteWordsImportSource: CustomWordsImportSource {
   /// `@concurrent` so a very large paste is parsed off the caller's actor
   /// rather than on the main one (code review r2).
   @concurrent package func loadCandidates() async throws -> CustomWordsImportBatch {
-    let canonicals = PasteWordsParser.parse(text)
+    let canonicals = try PasteWordsParser.parse(
+      text, limit: CustomWordsImportLimits.maximumCandidates)
     // The same ceiling file import enforces. A limit that applied to one door
     // and not the other would just be a bug with a longer fuse.
     guard canonicals.count <= CustomWordsImportLimits.maximumCandidates else {

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -49,6 +49,10 @@ package enum PasteWordsParser {
     // Whitespace seen since the last real character, held rather than buffered
     // so padding never counts toward a length. See the scan loop below.
     var pendingWhitespace: [Unicode.Scalar] = []
+    var pendingWhitespaceOverflowed = false
+    // One bound for both the buffer and the held whitespace: neither may grow
+    // toward the size of the file.
+    let memoryBound = CustomWordsImportLimits.maximumStoredValueScalars * 4
     let ceiling = limit.map { $0 + 1 }
     var scanned = 0
     // flush() reports "stop" for both success-with-ceiling-reached and a real
@@ -61,6 +65,7 @@ package enum PasteWordsParser {
       defer {
         buffer.removeAll(keepingCapacity: true)
         pendingWhitespace.removeAll(keepingCapacity: true)
+        pendingWhitespaceOverflowed = false
       }
       let trimmed = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
       // Skipped like any other blank line. A piece made only of invisible
@@ -115,9 +120,29 @@ package enum PasteWordsParser {
       // ("Claude Code"). Without this, a file of 3000 spaces — which should
       // import nothing — tripped the buffer bound below and failed the whole
       // paste as "too long" (cloud review, #1683).
+      //
+      // The hold is BOUNDED, or excluding padding from the length would just
+      // move the unbounded growth somewhere the limit no longer watches: `x`
+      // followed by millions of spaces would retain every one of them (Codex
+      // review, #1683). Past the bound the run stops being kept and is only
+      // remembered as overflowed — enough, because interior spacing that long
+      // can only produce an entry the ceiling refuses anyway, and if no real
+      // character follows, it was trailing padding and is discarded.
       if scalar.properties.isWhitespace {
-        if !buffer.isEmpty { pendingWhitespace.append(scalar) }
+        guard !buffer.isEmpty else { continue }
+        if pendingWhitespace.count < memoryBound {
+          pendingWhitespace.append(scalar)
+        } else {
+          pendingWhitespaceOverflowed = true
+        }
         continue
+      }
+      // A real character after an overflowed run: the entry now contains that
+      // whole run, so it is over-length by construction. Refuse it here rather
+      // than materialising it to measure it.
+      if pendingWhitespaceOverflowed {
+        throw CustomWordsImportValidationError.wordTooLong(
+          limit: CustomWordsImportLimits.maximumStoredValueScalars)
       }
       buffer.unicodeScalars.append(contentsOf: pendingWhitespace)
       pendingWhitespace.removeAll(keepingCapacity: true)

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -85,8 +85,10 @@ package enum PasteWordsImportError: LocalizedError, Sendable, Equatable {
     switch self {
     case .tooManyWords(let found, let limit):
       return
-        "That's \(found) words, which is more than EnviousWispr can import at once "
-        + "(\(limit)). Try pasting a smaller batch."
+        // See ImportFileError.tooManyWords: `found` is a stop-sentinel, not a
+        // total.
+        "That's more than \(limit) words, which is more than EnviousWispr can "
+        + "import at once. Try pasting a smaller batch."
     }
   }
 }

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -70,6 +70,15 @@ package enum PasteWordsParser {
         guard flush() else { return results }
         continue
       }
+      // Stop BUILDING an over-long entry rather than assembling megabytes and
+      // rejecting it afterwards — the same reason the candidate ceiling stops
+      // the scan rather than trimming the result (Codex review, #1683).
+      guard buffer.unicodeScalars.count
+        < CustomWordsImportLimits.maximumStoredValueScalars
+      else {
+        throw CustomWordsImportValidationError.wordTooLong(
+          limit: CustomWordsImportLimits.maximumStoredValueScalars)
+      }
       buffer.unicodeScalars.append(scalar)
     }
     _ = flush()

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -46,6 +46,9 @@ package enum PasteWordsParser {
     var seen = Set<String>()
     var results: [String] = []
     var buffer = ""
+    // Whitespace seen since the last real character, held rather than buffered
+    // so padding never counts toward a length. See the scan loop below.
+    var pendingWhitespace: [Unicode.Scalar] = []
     let ceiling = limit.map { $0 + 1 }
     var scanned = 0
     // flush() reports "stop" for both success-with-ceiling-reached and a real
@@ -53,7 +56,12 @@ package enum PasteWordsParser {
     var lengthFailure: CustomWordsImportValidationError?
 
     func flush() -> Bool {
-      defer { buffer.removeAll(keepingCapacity: true) }
+      // Whatever whitespace was being held is trailing padding at a boundary,
+      // and trailing padding is not part of the entry.
+      defer {
+        buffer.removeAll(keepingCapacity: true)
+        pendingWhitespace.removeAll(keepingCapacity: true)
+      }
       let trimmed = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
       // Skipped like any other blank line. A piece made only of invisible
       // joiners is noise in a pasted list, not a word the user meant — and
@@ -72,8 +80,9 @@ package enum PasteWordsParser {
       // Length is judged on the TRIMMED value, matching the validator. Judging
       // the raw buffer counted padding as part of the word, so 513 spaces or a
       // heavily padded short entry failed as "too long" (cloud review, #1683).
-      guard trimmed.unicodeScalars.count
-        <= CustomWordsImportLimits.maximumStoredValueScalars
+      guard
+        trimmed.unicodeScalars.count
+          <= CustomWordsImportLimits.maximumStoredValueScalars
       else {
         lengthFailure = CustomWordsImportValidationError.wordTooLong(
           limit: CustomWordsImportLimits.maximumStoredValueScalars)
@@ -99,12 +108,26 @@ package enum PasteWordsParser {
         }
         continue
       }
-      // A MEMORY bound, not the word-length rule: it exists so one enormous
-      // line cannot grow the buffer to the whole file. The rule itself is
-      // applied to the trimmed value in flush(), because padding is not part
-      // of the word. Generous multiple so trimming always gets its say first.
-      guard buffer.unicodeScalars.count
-        < CustomWordsImportLimits.maximumStoredValueScalars * 4
+      // Padding never reaches the buffer, so it can never count toward a
+      // length. Whitespace is HELD until a real character follows it: leading
+      // padding is then dropped, trailing padding is discarded at flush, and
+      // interior spacing survives because a term may legitimately contain it
+      // ("Claude Code"). Without this, a file of 3000 spaces — which should
+      // import nothing — tripped the buffer bound below and failed the whole
+      // paste as "too long" (cloud review, #1683).
+      if scalar.properties.isWhitespace {
+        if !buffer.isEmpty { pendingWhitespace.append(scalar) }
+        continue
+      }
+      buffer.unicodeScalars.append(contentsOf: pendingWhitespace)
+      pendingWhitespace.removeAll(keepingCapacity: true)
+      // A MEMORY bound so one enormous line cannot grow the buffer to the
+      // whole file. Now that padding is excluded, anything reaching it really
+      // is an over-length entry, so wordTooLong is the honest error. The rule
+      // itself still lives in flush(), applied to the trimmed value.
+      guard
+        buffer.unicodeScalars.count
+          < CustomWordsImportLimits.maximumStoredValueScalars * 4
       else {
         throw CustomWordsImportValidationError.wordTooLong(
           limit: CustomWordsImportLimits.maximumStoredValueScalars)

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -279,29 +279,36 @@ struct CustomWordsExportActionTests {
 
   @Test("the app cannot author a word it would then refuse to export")
   func authoringCannotCreateAnUnexportableLibrary() throws {
-    // Import capped stored values; the editor did not. A hand-typed entry over
-    // the ceiling therefore made the user's own words unexportable — the
-    // round-trip asymmetry again, with authoring as the third door.
+    // "What may be stored" is ONE rule, and the library is what it protects.
+    // Applying part of it here — length but not the character policy — let the
+    // editor author a word export then refused. Both halves now come from the
+    // same predicate every authoring path shares.
     let url = FileManager.default.temporaryDirectory
       .appendingPathComponent("ew-author-\(UUID().uuidString).json")
     let manager = CustomWordsManager(fileURL: url)
     var live = manager.load() ?? []
 
-    let tooLong = String(repeating: "x", count: CustomWordsImportLimits.maximumStoredValueScalars + 1)
-    try manager.add(word: CustomWord(canonical: tooLong), to: &live)
-    try manager.add(
-      word: CustomWord(canonical: "Kubernetes", aliases: [tooLong, "k8s"]), to: &live)
+    let tooLong = String(
+      repeating: "x", count: CustomWordsImportLimits.maximumStoredValueScalars + 1)
+    let deceptive = "Kub\u{202E}ernetes"
+    let invisible = "\u{200D}"
 
-    // Neither the over-long word nor the over-long alias was stored...
-    #expect(!live.contains { $0.canonical == tooLong })
-    #expect(!live.contains { $0.aliases.contains(tooLong) })
+    for bad in [tooLong, deceptive, invisible] {
+      try manager.add(word: CustomWord(canonical: bad), to: &live)
+      #expect(!live.contains { $0.canonical == bad }, "authored an unstorable word: \(bad.debugDescription)")
+    }
+    try manager.add(
+      word: CustomWord(canonical: "Kubernetes", aliases: [deceptive, tooLong, "k8s"]),
+      to: &live)
+
     #expect(live.contains { $0.canonical == "Kubernetes" && $0.aliases == ["k8s"] })
 
-    // ...so whatever the library holds, export accepts it.
+    // Whatever the library holds after all that, export accepts it.
     let document = CustomWordsTransferDocument(words: live.filter { $0.source == .user })
     #expect(
       CustomWordsExportAction.refusalIfUnimportable(
         document: document, encoded: try document.encoded()) == nil)
   }
+
 
 }

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -150,4 +150,34 @@ struct CustomWordsExportActionTests {
     #expect(outcome == .refusedUnsafeLibrary)
     #expect(spy.document == nil, "an empty export must never reach the writer")
   }
+
+  @Test("export refuses to write a file the importer would reject")
+  func exportRefusesUnimportableFile() throws {
+    // The exporter and importer are one round trip. Raising the IMPORT
+    // ceilings while export kept no preflight left the same "writes a file it
+    // then refuses" hole open from the other direction.
+    let over = (0...CustomWordsImportLimits.maximumExportedCandidates).map {
+      CustomWord(canonical: "Term\($0)", aliases: [], category: .general)
+    }
+    let document = CustomWordsTransferDocument(words: over)
+
+    let refusal = CustomWordsExportAction.refusalIfUnimportable(
+      document: document, encoded: try document.encoded())
+
+    #expect(refusal != nil)
+    #expect(refusal?.contains("Nothing was exported") == true)
+  }
+
+  @Test("an export at the limit is allowed through")
+  func exportAtLimitAllowed() throws {
+    let atLimit = (0..<CustomWordsImportLimits.maximumExportedCandidates).map {
+      CustomWord(canonical: "T\($0)", aliases: [], category: .general)
+    }
+    let document = CustomWordsTransferDocument(words: atLimit)
+
+    #expect(
+      CustomWordsExportAction.refusalIfUnimportable(
+        document: document, encoded: try document.encoded()) == nil)
+  }
+
 }

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -276,4 +276,32 @@ struct CustomWordsExportActionTests {
     }
   }
 
+
+  @Test("the app cannot author a word it would then refuse to export")
+  func authoringCannotCreateAnUnexportableLibrary() throws {
+    // Import capped stored values; the editor did not. A hand-typed entry over
+    // the ceiling therefore made the user's own words unexportable — the
+    // round-trip asymmetry again, with authoring as the third door.
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-author-\(UUID().uuidString).json")
+    let manager = CustomWordsManager(fileURL: url)
+    var live = manager.load() ?? []
+
+    let tooLong = String(repeating: "x", count: CustomWordsImportLimits.maximumStoredValueScalars + 1)
+    try manager.add(word: CustomWord(canonical: tooLong), to: &live)
+    try manager.add(
+      word: CustomWord(canonical: "Kubernetes", aliases: [tooLong, "k8s"]), to: &live)
+
+    // Neither the over-long word nor the over-long alias was stored...
+    #expect(!live.contains { $0.canonical == tooLong })
+    #expect(!live.contains { $0.aliases.contains(tooLong) })
+    #expect(live.contains { $0.canonical == "Kubernetes" && $0.aliases == ["k8s"] })
+
+    // ...so whatever the library holds, export accepts it.
+    let document = CustomWordsTransferDocument(words: live.filter { $0.source == .user })
+    #expect(
+      CustomWordsExportAction.refusalIfUnimportable(
+        document: document, encoded: try document.encoded()) == nil)
+  }
+
 }

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -183,7 +183,6 @@ struct CustomWordsExportActionTests {
         document: document, encoded: try document.encoded()) == nil)
   }
 
-
   @Test("a word the importer would refuse blocks the export")
   func unstorableWordBlocksExport() throws {
     // Size was not the only way to write an unimportable file. A word authored
@@ -215,7 +214,6 @@ struct CustomWordsExportActionTests {
       CustomWordsExportAction.refusalIfUnimportable(
         document: document, encoded: try document.encoded()) == nil)
   }
-
 
   @Test("export refuses a library that trips the stored-surface ceiling")
   func exportRefusesOnStoredSurface() throws {
@@ -269,13 +267,13 @@ struct CustomWordsExportActionTests {
       } catch {
         importerRefuses = true
       }
-      let exportRefuses = CustomWordsExportAction.refusalIfUnimportable(
-        document: document, encoded: encoded) != nil
+      let exportRefuses =
+        CustomWordsExportAction.refusalIfUnimportable(
+          document: document, encoded: encoded) != nil
 
       #expect(importerRefuses == exportRefuses)
     }
   }
-
 
   @Test("the app cannot author a word it would then refuse to export")
   func authoringCannotCreateAnUnexportableLibrary() throws {
@@ -293,14 +291,31 @@ struct CustomWordsExportActionTests {
     let deceptive = "Kub\u{202E}ernetes"
     let invisible = "\u{200D}"
 
+    // Refused LOUDLY, not silently. A silent return dismissed the edit sheet
+    // on a nil error, so the user was shown a save that never happened
+    // (cloud review, #1683).
     for bad in [tooLong, deceptive, invisible] {
-      try manager.add(word: CustomWord(canonical: bad), to: &live)
-      #expect(!live.contains { $0.canonical == bad }, "authored an unstorable word: \(bad.debugDescription)")
+      #expect(throws: CustomWordsPersistenceError.unusableValue) {
+        try manager.add(word: CustomWord(canonical: bad), to: &live)
+      }
+      #expect(
+        !live.contains { $0.canonical == bad },
+        "authored an unstorable word: \(bad.debugDescription)")
     }
-    try manager.add(
-      word: CustomWord(canonical: "Kubernetes", aliases: [deceptive, tooLong, "k8s"]),
-      to: &live)
 
+    // An unstorable ALIAS is the same lie one layer down: dropping it quietly
+    // reports a save that lost part of what the user typed.
+    #expect(throws: CustomWordsPersistenceError.unusableValue) {
+      try manager.add(
+        word: CustomWord(canonical: "Kubernetes", aliases: [deceptive, tooLong, "k8s"]),
+        to: &live)
+    }
+    #expect(!live.contains { $0.canonical == "Kubernetes" })
+
+    // Blank alias rows are not a refusal — the editor leaves them behind and
+    // trimming them away loses nothing the user meant.
+    try manager.add(
+      word: CustomWord(canonical: "Kubernetes", aliases: ["k8s", "  ", ""]), to: &live)
     #expect(live.contains { $0.canonical == "Kubernetes" && $0.aliases == ["k8s"] })
 
     // Whatever the library holds after all that, export accepts it.
@@ -309,6 +324,5 @@ struct CustomWordsExportActionTests {
       CustomWordsExportAction.refusalIfUnimportable(
         document: document, encoded: try document.encoded()) == nil)
   }
-
 
 }

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -216,4 +216,64 @@ struct CustomWordsExportActionTests {
         document: document, encoded: try document.encoded()) == nil)
   }
 
+
+  @Test("export refuses a library that trips the stored-surface ceiling")
+  func exportRefusesOnStoredSurface() throws {
+    // The fifth instance of one defect: a ceiling added to import and not to
+    // export. This library has an acceptable WORD count and byte size, and
+    // trips only the surface ceiling — which the previous preflight, holding
+    // its own list of checks, did not know about.
+    let perWord = 5_000
+    let count = (CustomWordsImportLimits.maximumExportedStoredValues / perWord) + 2
+    let words = (0..<count).map { index in
+      CustomWord(
+        canonical: "Term\(index)",
+        aliases: (0..<perWord).map { "a\(index)_\($0)" },
+        category: .general)
+    }
+    let document = CustomWordsTransferDocument(words: words)
+    #expect(document.words.count < CustomWordsImportLimits.maximumExportedCandidates)
+
+    let refusal = CustomWordsExportAction.refusalIfUnimportable(
+      document: document, encoded: try document.encoded())
+
+    #expect(refusal?.contains("Nothing was exported") == true)
+    // Reported as words AND alternate spellings, not as a word count the user
+    // cannot see anywhere.
+    #expect(refusal?.contains("alternate spellings") == true)
+  }
+
+  @Test("whatever the importer refuses, export refuses — by construction")
+  func exportRefusalTracksTheImporter() throws {
+    // The property that matters is not that today's ceilings are checked, but
+    // that a ceiling added to the parser LATER is enforced here with no change
+    // to this file. Proven by driving the real parser: anything it rejects,
+    // the preflight rejects, because the preflight IS the parser.
+    let unstorable = CustomWordsTransferDocument(words: [
+      CustomWord(canonical: "Kub\u{202E}ernetes", aliases: [], category: .general)
+    ])
+    let overWordCeiling = CustomWordsTransferDocument(
+      words: (0...CustomWordsImportLimits.maximumExportedCandidates).map {
+        CustomWord(canonical: "T\($0)", aliases: [], category: .general)
+      })
+
+    for document in [unstorable, overWordCeiling] {
+      let encoded = try document.encoded()
+      let importerRefuses: Bool
+      do {
+        let candidates = try ExportedWordsFileParser().parse(data: encoded)
+        _ = try CustomWordsImportBatch(
+          sourceID: "exported-words", sourceDisplayName: "x", candidates: candidates
+        ).validated()
+        importerRefuses = false
+      } catch {
+        importerRefuses = true
+      }
+      let exportRefuses = CustomWordsExportAction.refusalIfUnimportable(
+        document: document, encoded: encoded) != nil
+
+      #expect(importerRefuses == exportRefuses)
+    }
+  }
+
 }

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -20,7 +20,10 @@ struct CustomWordsExportActionTests {
   /// is the thing this codebase already learned not to do.
   @MainActor
   final class WriteSpy {
-    var document: CustomWordsTransferDocument?
+    /// Captures the BYTES now, which is what actually reaches disk — so
+    /// assertions decode what would have been written rather than trusting an
+    /// object that was never serialised.
+    var written: Data?
     var writeCount = 0
   }
 
@@ -74,11 +77,11 @@ struct CustomWordsExportActionTests {
     let outcome = await CustomWordsExportAction.run(
       coordinator: coordinator,
       chooseDestination: { self.tempURL() },
-      write: { document, _ in await MainActor.run { spy.document = document } }
+      write: { data, _ in await MainActor.run { spy.written = data } }
     )
 
     #expect(outcome == .refusedUnsafeLibrary)
-    #expect(spy.document == nil, "an empty export must never reach the writer")
+    #expect(spy.written == nil, "an empty export must never reach the writer")
   }
 
   @Test("a healthy library exports exactly the user's own words")
@@ -91,11 +94,11 @@ struct CustomWordsExportActionTests {
     let outcome = await CustomWordsExportAction.run(
       coordinator: coordinator,
       chooseDestination: { self.tempURL() },
-      write: { document, _ in await MainActor.run { spy.document = document } }
+      write: { data, _ in await MainActor.run { spy.written = data } }
     )
 
     #expect(outcome == .exported)
-    let document = try #require(spy.document)
+    let document = try CustomWordsTransferDocument(data: try #require(spy.written))
     #expect(document.words.map(\.canonical).sorted() == ["Kubernetes", "Qualtrics"])
     // Built-ins are excluded: this is "your words", not "everything".
     #expect(!document.words.contains { $0.canonical == "GitHub" })
@@ -144,11 +147,11 @@ struct CustomWordsExportActionTests {
     let outcome = await CustomWordsExportAction.run(
       coordinator: coordinator,
       chooseDestination: { self.tempURL() },
-      write: { document, _ in await MainActor.run { spy.document = document } }
+      write: { data, _ in await MainActor.run { spy.written = data } }
     )
 
     #expect(outcome == .refusedUnsafeLibrary)
-    #expect(spy.document == nil, "an empty export must never reach the writer")
+    #expect(spy.written == nil, "an empty export must never reach the writer")
   }
 
   @Test("export refuses to write a file the importer would reject")
@@ -174,6 +177,39 @@ struct CustomWordsExportActionTests {
       CustomWord(canonical: "T\($0)", aliases: [], category: .general)
     }
     let document = CustomWordsTransferDocument(words: atLimit)
+
+    #expect(
+      CustomWordsExportAction.refusalIfUnimportable(
+        document: document, encoded: try document.encoded()) == nil)
+  }
+
+
+  @Test("a word the importer would refuse blocks the export")
+  func unstorableWordBlocksExport() throws {
+    // Size was not the only way to write an unimportable file. A word authored
+    // in the editor can hold a scalar the import policy refuses, so a
+    // count-and-bytes preflight still produced a file that import rejected
+    // wholesale. The preflight runs the importer's OWN validation now, so the
+    // two cannot describe "storable" differently.
+    let document = CustomWordsTransferDocument(words: [
+      CustomWord(canonical: "Kub\u{202E}ernetes", aliases: [], category: .general)
+    ])
+
+    let refusal = CustomWordsExportAction.refusalIfUnimportable(
+      document: document, encoded: try document.encoded())
+
+    #expect(refusal?.contains("Nothing was exported") == true)
+  }
+
+  @Test("a normal library is not blocked by the storability check")
+  func normalLibraryPassesStorabilityCheck() throws {
+    // The check must not become a wall: real words, including non-Latin ones
+    // and joiners, export fine.
+    let document = CustomWordsTransferDocument(words: [
+      CustomWord(canonical: "Kubernetes", aliases: ["k8s"], category: .brand),
+      CustomWord(canonical: "東京", aliases: [], category: .general),
+      CustomWord(canonical: "क्\u{200D}ष", aliases: [], category: .general),
+    ])
 
     #expect(
       CustomWordsExportAction.refusalIfUnimportable(

--- a/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
@@ -53,7 +53,7 @@ struct CustomWordsImportReviewFlowTests {
 
   struct StubSource: CustomWordsImportSource {
     let candidates: [CustomWordsImportCandidate]
-    func loadCandidates() async throws -> CustomWordsImportBatch {
+    func loadRawCandidates() async throws -> CustomWordsImportBatch {
       CustomWordsImportBatch(
         sourceID: "test", sourceDisplayName: "Test", candidates: candidates)
     }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsBackupRoundTripTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsBackupRoundTripTests.swift
@@ -50,7 +50,7 @@ struct CustomWordsBackupRoundTripTests {
     #expect(fresh.contains { $0.source == .user } == false)
     #expect(fresh.isEmpty == false)
 
-    let candidates = backup.candidatesForImport()
+    let candidates = try backup.candidatesForImport()
     let comparisons = try await CustomWordsImportCompareEngine().compare(
       candidates: candidates,
       against: fresh,

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -20,13 +20,19 @@ struct CustomWordsExportWriterTests {
     CustomWordsTransferDocument(words: canonicals.map { CustomWord(canonical: $0) })
   }
 
+  /// The writer takes bytes now, so encoding happens once, off the main actor,
+  /// and the same bytes are measured and written.
+  private func encoded(_ canonicals: [String]) throws -> Data {
+    try document(canonicals).encoded()
+  }
+
   @Test("a new file is created with owner-only permissions")
   func writerCreatesNewFileWithMode0600() async throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let destination = dir.appendingPathComponent("words.json")
 
-    try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    try await CustomWordsExportWriter.write(try encoded(["Kubernetes"]), to: destination)
 
     let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
     let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
@@ -40,7 +46,7 @@ struct CustomWordsExportWriterTests {
     let destination = dir.appendingPathComponent("words.json")
     try Data("previous contents".utf8).write(to: destination)
 
-    try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    try await CustomWordsExportWriter.write(try encoded(["Kubernetes"]), to: destination)
 
     let decoded = try CustomWordsTransferDocument(data: Data(contentsOf: destination))
     #expect(decoded.words.map(\.canonical) == ["Kubernetes"])
@@ -59,7 +65,7 @@ struct CustomWordsExportWriterTests {
     try FileManager.default.setAttributes(
       [.posixPermissions: 0o644], ofItemAtPath: destination.path)
 
-    try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+    try await CustomWordsExportWriter.write(try encoded(["Kubernetes"]), to: destination)
 
     let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)
     let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
@@ -71,8 +77,7 @@ struct CustomWordsExportWriterTests {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
 
-    try await CustomWordsExportWriter.write(
-      document(["Kubernetes"]), to: dir.appendingPathComponent("words.json"))
+    try await CustomWordsExportWriter.write(try encoded(["Kubernetes"]), to: dir.appendingPathComponent("words.json"))
 
     let leftovers = try FileManager.default
       .contentsOfDirectory(atPath: dir.path)
@@ -97,7 +102,7 @@ struct CustomWordsExportWriterTests {
       [.posixPermissions: 0o500], ofItemAtPath: dir.path)
 
     await #expect(throws: (any Error).self) {
-      try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+      try await CustomWordsExportWriter.write(try encoded(["Kubernetes"]), to: destination)
     }
 
     try FileManager.default.setAttributes(
@@ -119,7 +124,7 @@ struct CustomWordsExportWriterTests {
     try Data("precious".utf8).write(to: inhabitant)
 
     await #expect(throws: (any Error).self) {
-      try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: destination)
+      try await CustomWordsExportWriter.write(try encoded(["Kubernetes"]), to: destination)
     }
 
     var isDirectory: ObjCBool = false
@@ -139,12 +144,14 @@ struct CustomWordsExportWriterTests {
     // name would let these two interleave into one corrupt file.
     async let first: Void = Task.detached {
       try await CustomWordsExportWriter.write(
-        CustomWordsTransferDocument(words: [CustomWord(canonical: "Kubernetes")]),
+        try CustomWordsTransferDocument(words: [CustomWord(canonical: "Kubernetes")])
+          .encoded(),
         to: destination)
     }.value
     async let second: Void = Task.detached {
       try await CustomWordsExportWriter.write(
-        CustomWordsTransferDocument(words: [CustomWord(canonical: "Anthropic")]),
+        try CustomWordsTransferDocument(words: [CustomWord(canonical: "Anthropic")])
+          .encoded(),
         to: destination)
     }.value
     _ = try await (first, second)

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
@@ -606,4 +606,54 @@ struct CustomWordsImportCompareEngineTests {
       _ = try await task.value
     }
   }
+
+  // MARK: - Skip never rewrites an existing word
+
+  @Test("re-importing a word you already have cannot touch its aliases")
+  func skippingAnExistingWordPreservesItsAliases() async throws {
+    // Founder's exact scenario (2026-07-19): GitHub ships with 3 aliases, the
+    // user adds 3 more, exports, then re-imports the SAME file on the SAME
+    // Mac. "Skip" has to mean nothing is written for that word — NOT that it
+    // is rewritten with the importing file's shorter alias list. Their words
+    // stay their words.
+    let mine = word("GitHub", aliases: ["git hub", "get hub", "gh", "git-hub", "githib", "guthub"])
+    let engine = CustomWordsImportCompareEngine()
+
+    // A plain list carries no alias opinion at all — the strongest case,
+    // because there is nothing for a Replace to even be built from.
+    let comparisons = try await engine.compare(
+      candidates: [candidate("GitHub")], against: [mine], fuzzyPolicy: .disabled)
+
+    let row = try #require(comparisons.first)
+    guard case .exact(let matched) = row.classification else {
+      Issue.record("expected an exact match, got \(row.classification)")
+      return
+    }
+    // The matched word is the user's, with all six alternates intact...
+    #expect(matched.aliases.count == 6)
+    #expect(matched.aliases.contains("gh"))
+    // ...and the candidate carries no authority to overwrite them with.
+    #expect(row.candidate.aliases == .unspecified)
+  }
+
+  @Test("even an exported file's aliases cannot overwrite the word you have")
+  func exportedFileAliasesCannotOverwriteExistingWord() async throws {
+    // An exported file DOES carry aliases, so this is the case where a Replace
+    // would be constructible. It must still classify as already-present: v1
+    // never modifies an existing word or its alternates.
+    let mine = word("GitHub", aliases: ["git hub", "get hub", "gh"])
+    let engine = CustomWordsImportCompareEngine()
+
+    let fromExport = candidate("GitHub", aliases: .supplied(["totally", "different"]))
+    let comparisons = try await engine.compare(
+      candidates: [fromExport], against: [mine], fuzzyPolicy: .disabled)
+
+    let row = try #require(comparisons.first)
+    guard case .exact(let matched) = row.classification else {
+      Issue.record("expected an exact match, got \(row.classification)")
+      return
+    }
+    #expect(matched.aliases == ["git hub", "get hub", "gh"])
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -131,7 +131,7 @@ struct CustomWordsTransferDocumentTests {
     // source that can say "genuinely none" rather than "no opinion", and on a
     // Replace that difference decides whether hand-tuned values are cleared.
     let bare = word("Kubernetes", aliases: [], minSimilarityOverride: nil)
-    let candidates = CustomWordsTransferDocument(words: [bare]).candidatesForImport()
+    let candidates = try CustomWordsTransferDocument(words: [bare]).candidatesForImport()
     let candidate = try #require(candidates.first)
 
     #expect(candidate.aliases == .supplied([]))
@@ -146,7 +146,7 @@ struct CustomWordsTransferDocumentTests {
   func candidatesForImportResetsUsageHistory() throws {
     let used = word("Kubernetes", frequencyUsed: 9, lastUsed: Date())
     let candidate = try #require(
-      CustomWordsTransferDocument(words: [used]).candidatesForImport().first)
+      try CustomWordsTransferDocument(words: [used]).candidatesForImport().first)
     // The candidate type structurally cannot carry usage history; this asserts
     // the suggestion channel is also empty, so nothing machine-generated rides
     // in on a restore.
@@ -168,7 +168,7 @@ struct CustomWordsTransferDocumentTests {
 
   @Test("two candidates from one backup have distinct review identities")
   func candidatesForImportGivesEachRowItsOwnIdentity() throws {
-    let candidates = CustomWordsTransferDocument(
+    let candidates = try CustomWordsTransferDocument(
       words: [word("Kubernetes"), word("Anthropic")]
     ).candidatesForImport()
     #expect(Set(candidates.map(\.id)).count == 2)

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -614,4 +614,22 @@ struct ImportFileParserTests {
     #expect(batch.candidates.count == limit)
   }
 
+
+  @Test("routing does not depend on the system resolving extensions")
+  func routingUsesExtensionsNotSystemTypes() async throws {
+    // Dispatch previously round-tripped the filename through Launch Services;
+    // in a restricted environment that returns dyn.* and EVERY supported
+    // upload was rejected before the file was read.
+    let registry = ImportFileRegistry.v1
+    #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/a.json"))?.identifier == "exported-words")
+    #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/a.txt"))?.identifier == "plain-text")
+    // Case and path shape are irrelevant to the decision.
+    #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/A.JSON"))?.identifier == "exported-words")
+    // Spreadsheets stay refused: the CSV split bug was the reason dispatch is
+    // exact-match in the first place, and that must survive the mechanism change.
+    #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/a.csv")) == nil)
+    #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/a.tsv")) == nil)
+    #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/noextension")) == nil)
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -457,4 +457,6 @@ struct ImportFileParserTests {
     }
   }
 
+
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -332,4 +332,97 @@ struct ImportFileParserTests {
     #expect(candidates.map { $0.canonical } == ["Kubernetes"])
   }
 
+
+  @Test("word lists in other scripts import intact")
+  func internationalWordListsImportIntact() async throws {
+    // Japanese, Hindi, Arabic, Korean, Russian, Greek, accented Latin, and a
+    // word with a combining mark. If any script silently dropped or mangled,
+    // custom words would be an English-only feature (founder question).
+    let words = [
+      "東京", "こんにちは", "नमस्ते", "مرحبا", "서울",
+      "Москва", "Αθήνα", "Beyoncé", "Ångström", "Jalapeño",
+    ]
+    let url = try write(words.joined(separator: "\n"), as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == words)
+  }
+
+  @Test("words in other scripts are matched, not duplicated, on re-import")
+  func internationalWordsCompareAgainstExistingLibrary() async throws {
+    // Import equality runs through the compare engine's normalize(). If that
+    // were ASCII-only, a re-import would add a SECOND "東京" every time.
+    let normalized = CustomWordsImportCompareEngine.normalize("東京")
+    #expect(normalized == CustomWordsImportCompareEngine.normalize("東京"))
+    #expect(!normalized.isEmpty)
+
+    // Case folding must still work for scripts that HAVE case...
+    #expect(
+      CustomWordsImportCompareEngine.normalize("Москва")
+        == CustomWordsImportCompareEngine.normalize("МОСКВА"))
+    // ...and accents must stay meaningful: "resume" is not "résumé".
+    #expect(
+      CustomWordsImportCompareEngine.normalize("résumé")
+        != CustomWordsImportCompareEngine.normalize("resume"))
+  }
+
+
+  @Test("a non-English custom word actually corrects a transcript")
+  func nonEnglishCustomWordCorrectsTranscript() async throws {
+    // Import is only half the promise. If correction is ASCII-only, an
+    // imported Japanese or Russian term would sit in the list and never fire
+    // (founder question: does this work internationally?).
+    let corrector = WordCorrector()
+    let words = [
+      CustomWord(canonical: "東京", aliases: ["とうきょう"], category: .general),
+      CustomWord(canonical: "Москва", aliases: ["москва"], category: .general),
+      CustomWord(canonical: "Jalapeño", aliases: ["jalapeno"], category: .general),
+    ]
+
+    let (japanese, _) = corrector.correct("とうきょう に行きます", against: words)
+    let (russian, _) = corrector.correct("я живу в москва", against: words)
+    let (accented, _) = corrector.correct("I ate a jalapeno", against: words)
+
+    #expect(japanese.contains("東京"))
+    #expect(russian.contains("Москва"))
+    #expect(accented.contains("Jalapeño"))
+  }
+
+
+  @Test("a multi-word CJK list in UTF-16 imports correctly")
+  func multiWordCJKUTF16Imports() async throws {
+    // The realistic shape: line breaks supply the NUL bytes the detector
+    // reads, so a Japanese word list saved as UTF-16 works.
+    let url = try write("東京\n大阪\n京都".data(using: .utf16LittleEndian)!, as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["東京", "大阪", "京都"])
+  }
+
+  @Test("a single CJK word in UTF-16 with no mark is refused, not corrupted")
+  func singleCJKWordWithoutMarkIsRefused() async throws {
+    // Genuinely ambiguous: these four bytes are a valid Latin-1 word list AND
+    // valid UTF-16. Guessing UTF-16 here would corrupt real Latin-1 files
+    // (Beyoncé/Jalapeño decodes to plausible-looking CJK), so refusing is the
+    // honest answer. Refused beats "qg¬N" imported as a word.
+    let url = try write("東京".data(using: .utf16LittleEndian)!, as: "words.txt")
+
+    await #expect(throws: ImportFileError.unreadable) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a single CJK word WITH a byte-order mark imports fine")
+  func singleCJKWordWithMarkImports() async throws {
+    // Which is why the mark matters, and why real UTF-16 writers emit one.
+    let data = Data([0xFF, 0xFE]) + "東京".data(using: .utf16LittleEndian)!
+    let url = try write(data, as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["東京"])
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -1074,4 +1074,38 @@ struct ImportFileParserTests {
     #expect(candidate.storedValues == ["Kubernetes", "k8s", "kube"])
   }
 
+
+  @Test("padding is not part of the word")
+  func paddingDoesNotCountTowardWordLength() async throws {
+    // Judging the raw buffer counted whitespace as part of the word, so a
+    // heavily padded short entry — a fixed-width list — failed as "too long".
+    let padded = String(repeating: " ", count: 600) + "Kubernetes"
+      + String(repeating: " ", count: 600)
+    let url = try write(padded, as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Kubernetes"])
+  }
+
+  @Test("a file of nothing but spaces imports nothing, rather than erroring")
+  func whitespaceOnlyFileIsEmptyNotAnError() async throws {
+    let url = try write(String(repeating: " ", count: 600), as: "words.txt")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.candidates.isEmpty)
+  }
+
+  @Test("a genuinely over-long word is still refused")
+  func genuinelyLongWordStillRefused() async throws {
+    // The rule still bites on real content, just not on padding.
+    let url = try write(
+      "  " + String(repeating: "x", count: 600) + "  ", as: "words.txt")
+
+    await #expect(throws: CustomWordsImportValidationError.self) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -810,4 +810,36 @@ struct ImportFileParserTests {
     #expect(batch.candidates.count == 500)
   }
 
+
+  @Test("the picker offers every extension the registry claims")
+  func pickerCoversEveryRegisteredExtension() throws {
+    // Declared types alone could hide a file the registry accepts: on a system
+    // where an extension resolves to an unregistered dynamic type it conforms
+    // to no generic text type, so the panel greyed out a file the parser
+    // claims and the delegate never got the chance to enable it.
+    let registry = ImportFileRegistry.v1
+    let offered = Set(registry.acceptedContentTypes)
+
+    for parser in registry.parsers {
+      for ext in parser.fileExtensions {
+        guard let type = UTType(filenameExtension: ext) else { continue }
+        #expect(
+          offered.contains(type) || offered.contains { type.conforms(to: $0) },
+          "the picker hides .\(ext), which \(parser.identifier) claims")
+      }
+    }
+  }
+
+  @Test("a rejected pasted word does not blame a file")
+  func validationCopyIsSourceNeutral() throws {
+    // The validator runs for pasted text and files alike now, so naming a file
+    // was wrong half the time.
+    let message = try #require(
+      CustomWordsImportValidationError.unusableWord(canonical: "Kub\u{202E}ernetes")
+        .errorDescription)
+
+    #expect(!message.lowercased().contains("file"))
+    #expect(message.contains("Nothing was imported"))
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -842,4 +842,35 @@ struct ImportFileParserTests {
     #expect(message.contains("Nothing was imported"))
   }
 
+
+  @Test("a rejected character is named, never rendered, in the error")
+  func rejectedCharacterIsNotEchoedIntoTheError() throws {
+    // Echoing the raw value meant the very character rejected for rendering
+    // deceptively got rendered into the message explaining its rejection,
+    // where it can reorder the error text itself.
+    let message = try #require(
+      CustomWordsImportValidationError.unusableWord(canonical: "Kub\u{202E}ernetes")
+        .errorDescription)
+
+    #expect(!message.unicodeScalars.contains { $0.value == 0x202E })
+    #expect(message.contains("<U+202E>"))
+    // The readable part still survives, so the user can find the entry.
+    #expect(message.contains("Kub"))
+  }
+
+  @Test("validation stops when the sheet is dismissed")
+  func validationHonoursCancellation() async throws {
+    // 400,000 stored values is long enough to outlive a dismissed sheet.
+    let candidates = (0..<5_000).map {
+      CustomWordsImportCandidate(canonical: "Term\($0)")
+    }
+    let batch = CustomWordsImportBatch(
+      sourceID: "test", sourceDisplayName: "test", candidates: candidates)
+
+    let task = Task { try batch.validated() }
+    task.cancel()
+
+    await #expect(throws: CancellationError.self) { try await task.value }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -664,4 +664,31 @@ struct ImportFileParserTests {
     #expect(candidates.allSatisfy { !$0.canonical.contains("\t") })
   }
 
+
+  @Test("a truncated UTF-16 file is refused, not read as Latin-1")
+  func markedButBrokenFileDoesNotFallThrough() async throws {
+    // A recognised mark is authoritative: if it says UTF-16 and the bytes fail
+    // to decode, the file is broken, not secretly something else. Falling
+    // through re-created the very bug the alignment check was added to fix —
+    // [FF FE E9] became the plausible-looking word "ÿþé".
+    let url = try write(Data([0xFF, 0xFE, 0xE9]), as: "words.txt")
+
+    await #expect(throws: ImportFileError.unreadable) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("an over-limit file never states an exact word count")
+  func overLimitMessageDoesNotInventACount() async throws {
+    // The scan stops one past the limit rather than counting a file it is
+    // going to refuse, so printing that figure would state a number nobody
+    // measured.
+    let limit = CustomWordsImportLimits.maximumCandidates
+    let message = try #require(
+      ImportFileError.tooManyWords(found: limit + 1, limit: limit).errorDescription)
+
+    #expect(message.contains("more than \(limit)"))
+    #expect(!message.contains("\(limit + 1)"))
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -90,7 +90,8 @@ struct ImportFileParserTests {
     let url = try write(text, as: "words.txt")
     let batch = try await FileImportSource(url: url).loadCandidates()
 
-    #expect(batch.candidates.map { $0.canonical } == PasteWordsParser.parse(text))
+    let viaPaste = try PasteWordsParser.parse(text)
+    #expect(batch.candidates.map { $0.canonical } == viaPaste)
     #expect(
       batch.candidates.map { $0.canonical }
         == ["Envious Labs", "C++", "and/or", "Smith; Jones", "GitHub"])
@@ -578,6 +579,39 @@ struct ImportFileParserTests {
     await #expect(throws: ImportFileError.unreadable) {
       try await FileImportSource(url: url).loadCandidates()
     }
+  }
+
+
+  @Test("a huge word list is refused without building every entry")
+  func hugeListStopsAtTheCeiling() async throws {
+    // Parsing everything and checking afterwards spent exactly the memory the
+    // ceiling exists to save, and ignored cancellation until it finished.
+    let limit = CustomWordsImportLimits.maximumCandidates
+    let words = (0...(limit + 10)).map { "Term\($0)" }.joined(separator: "\n")
+
+    let parsed = try PasteWordsParser.parse(words, limit: limit)
+
+    // Stops one past the limit: enough to tell "at the limit" from "over".
+    #expect(parsed.count == limit + 1)
+
+    let url = try write(words, as: "words.txt")
+    await #expect(
+      throws: ImportFileError.tooManyWords(found: limit + 1, limit: limit)
+    ) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("an exactly-at-the-limit list still imports")
+  func exactlyAtLimitImports() async throws {
+    // The off-by-one that a "+1" sentinel invites.
+    let limit = CustomWordsImportLimits.maximumCandidates
+    let words = (0..<limit).map { "Term\($0)" }.joined(separator: "\n")
+    let url = try write(words, as: "words.txt")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.candidates.count == limit)
   }
 
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -847,6 +847,34 @@ struct ImportFileParserTests {
     #expect(message.contains("Kub"))
   }
 
+  /// A refusal must name the entry it is asking the user to fix. An entry made
+  /// only of invisible characters is built from scalars that are individually
+  /// acceptable, so the message rendered as empty quotes and named nothing
+  /// (cloud review, #1683) — and whitespace-only is the same dead end.
+  @Test(
+    "an entry with nothing visible is still identifiable in the error",
+    arguments: [
+      ("\u{200D}", "<U+200D>"),
+      ("\u{FE0F}", "<U+FE0F>"),
+      ("Kub\u{200D}ernetes", "<U+200D>"),
+    ])
+  func invisibleOnlyEntriesAreNamed(value: String, expectedCodePoint: String) throws {
+    let message = try #require(
+      CustomWordsImportValidationError.unusableWord(canonical: value).errorDescription)
+
+    #expect(message.contains(expectedCodePoint))
+    #expect(!message.contains("(\"\")"))
+  }
+
+  @Test("a whitespace-only entry is described rather than quoted as blank")
+  func whitespaceOnlyEntryIsDescribed() throws {
+    let message = try #require(
+      CustomWordsImportValidationError.unusableWord(canonical: "   ").errorDescription)
+
+    #expect(message.contains("a blank entry"))
+    #expect(!message.contains("\"   \""))
+  }
+
   @Test("validation stops when the sheet is dismissed")
   func validationHonoursCancellation() async throws {
     // 400,000 stored values is long enough to outlive a dismissed sheet.

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -549,7 +549,10 @@ struct ImportFileParserTests {
       "Kub\u{00AD}ernetes",  // soft hyphen
     ] {
       let url = try write(text, as: "words.txt")
-      await #expect(throws: ImportFileError.unreadable) {
+      // Refused as CONTENT, naming the word, rather than as "that file
+      // couldn't be read" — these decode perfectly well, they just cannot be
+      // stored.
+      await #expect(throws: CustomWordsImportValidationError.self) {
         try await FileImportSource(url: url).loadCandidates()
       }
     }
@@ -992,6 +995,30 @@ struct ImportFileParserTests {
 
     #expect(candidates.count == 1)
     #expect(candidates[0].canonical.unicodeScalars.contains { $0.value == 0x200D })
+  }
+
+
+  @Test("a pasted word with a bad character is reported, not silently dropped")
+  func badPastedEntryIsReportedNotDropped() async throws {
+    // Skipping everything the policy rejects was too broad: a visible entry
+    // carrying a bidi override vanished from the list, and the user saw a
+    // successful import of the OTHER words with no hint one was missing.
+    let url = try write("Good\nKub\u{202E}ernetes\nAlsoGood", as: "words.txt")
+
+    await #expect(throws: CustomWordsImportValidationError.self) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("blank pieces are still skipped quietly")
+  func blankPiecesStillSkipped() async throws {
+    // The narrow case that SHOULD be skipped: empty lines and joiner-only
+    // noise, exactly as whitespace has always been skipped.
+    let url = try write("Good\n\n\u{200D}\n   \nAlsoGood", as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Good", "AlsoGood"])
   }
 
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -535,4 +535,36 @@ struct ImportFileParserTests {
     }
   }
 
+
+  @Test("an exported file's word ceiling is raised, not removed")
+  func exportedFileCeilingIsFiniteNotAbsent() async throws {
+    // The "this is an EnviousWispr export" marker is self-declared and
+    // unsigned, so any JSON can claim it. Removing the ceiling outright would
+    // hand a crafted file an unbounded budget and hang the review screen; the
+    // round trip only needs the ceiling RAISED above any real library.
+    let ceiling = try #require(ExportedWordsFileParser().maximumCandidates)
+    #expect(ceiling > CustomWordsImportLimits.maximumCandidates)
+    #expect(ceiling == CustomWordsImportLimits.maximumExportedCandidates)
+    // And the bytes are bounded too, so the two cannot drift apart again.
+    #expect(
+      ExportedWordsFileParser().maximumBytes
+        == CustomWordsImportLimits.maximumExportedFileBytes)
+  }
+
+  @Test("reading a large export stops when the sheet is dismissed")
+  func candidateConversionHonoursCancellation() async throws {
+    // Decoding and converting is the expensive half of reading a big export.
+    // Without a check inside it, the work carried on burning CPU and memory
+    // after the user had closed the sheet.
+    let words = (0..<5_000).map {
+      CustomWord(canonical: "Term\($0)", aliases: [], category: .general)
+    }
+    let document = CustomWordsTransferDocument(words: words)
+
+    let task = Task { try document.candidatesForImport() }
+    task.cancel()
+
+    await #expect(throws: CancellationError.self) { try await task.value }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -632,4 +632,36 @@ struct ImportFileParserTests {
     #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/noextension")) == nil)
   }
 
+
+  @Test("an oversized export is refused before candidates are built")
+  func oversizedExportRefusedBeforeExpanding() async throws {
+    // Same parse-then-check shape as the plain-text side: converting every
+    // word and minting a UUID each, THEN checking, spends what the ceiling
+    // exists to save. Both parsers now bound their own output.
+    let ceiling = CustomWordsImportLimits.maximumExportedCandidates
+    let words = (0...ceiling).map {
+      CustomWord(canonical: "Term\($0)", aliases: [], category: .general)
+    }
+    let url = try write(try CustomWordsTransferDocument(words: words).encoded(), as: "words.json")
+
+    await #expect(
+      throws: ImportFileError.tooManyWords(found: ceiling + 1, limit: ceiling)
+    ) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a tab separates words instead of hiding inside one")
+  func tabSeparatesWords() async throws {
+    // Accepted as whitespace but never split on, a tab was stored INSIDE a
+    // canonical term where it is invisible — and comparison normalises it to a
+    // space, so the saved word could never match a transcript.
+    let url = try write("Kubernetes\tPostgreSQL\nGitHub", as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Kubernetes", "PostgreSQL", "GitHub"])
+    #expect(candidates.allSatisfy { !$0.canonical.contains("\t") })
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -1088,7 +1088,13 @@ struct ImportFileParserTests {
     let batch = CustomWordsImportBatch(
       sourceID: "test", sourceDisplayName: "test", candidates: [candidate])
 
-    #expect(throws: Never.self) { try batch.validated() }
+    // Validation returns what it VALIDATED. Measuring the trimmed value and
+    // then handing the raw one to the compare engine and the review screen
+    // would enforce the ceiling on a value nobody downstream ever sees
+    // (Codex review, #1683).
+    let validated = try batch.validated()
+    #expect(validated.candidates.map(\.canonical) == ["Kubernetes"])
+    #expect(validated.candidates.first?.aliases == .supplied(["k8s"]))
 
     // And still refused when the CONTENT is what exceeds the ceiling.
     let genuinelyLong = CustomWordsImportBatch(

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -309,4 +309,27 @@ struct ImportFileParserTests {
     }
   }
 
+
+  @Test("UTF-16 without a byte-order mark still imports real words")
+  func utf16WithoutByteOrderMarkDecodes() async throws {
+    // NUL is a legal UTF-8 byte, so these bytes decode "successfully" as UTF-8
+    // to "K\0u\0b\0…". Gating only the Latin-1 path let that straight
+    // through — the plausibility check has to guard EVERY decode step.
+    let url = try write(
+      "Kubernetes\nPostgreSQL".data(using: .utf16LittleEndian)!, as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Kubernetes", "PostgreSQL"])
+  }
+
+  @Test("big-endian UTF-16 without a byte-order mark decodes too")
+  func utf16BigEndianWithoutByteOrderMarkDecodes() async throws {
+    let url = try write("Kubernetes".data(using: .utf16BigEndian)!, as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Kubernetes"])
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -207,7 +207,8 @@ struct ImportFileParserTests {
   func oversizedFileIsRefusedBeforeReading() async throws {
     // Refusing by size beats discovering it after allocating: a word list is
     // small, so anything this big is a mistaken selection.
-    let url = try write(Data(count: CustomWordsImportLimits.maximumImportFileBytes + 1), as: "huge.txt")
+    let url = try write(
+      Data(count: CustomWordsImportLimits.maximumImportFileBytes + 1), as: "huge.txt")
     await #expect(throws: ImportFileError.tooLarge) {
       _ = try await FileImportSource(url: url).loadCandidates()
     }
@@ -329,7 +330,6 @@ struct ImportFileParserTests {
     }
   }
 
-
   @Test("word lists in other scripts import intact")
   func internationalWordListsImportIntact() async throws {
     // Japanese, Hindi, Arabic, Korean, Russian, Greek, accented Latin, and a
@@ -364,7 +364,6 @@ struct ImportFileParserTests {
         != CustomWordsImportCompareEngine.normalize("resume"))
   }
 
-
   @Test("a non-English custom word actually corrects a transcript")
   func nonEnglishCustomWordCorrectsTranscript() async throws {
     // Import is only half the promise. If correction is ASCII-only, an
@@ -386,7 +385,6 @@ struct ImportFileParserTests {
     #expect(accented.contains("Jalapeño"))
   }
 
-
   @Test("a single CJK word WITH a byte-order mark imports fine")
   func singleCJKWordWithMarkImports() async throws {
     // Which is why the mark matters, and why real UTF-16 writers emit one.
@@ -397,7 +395,6 @@ struct ImportFileParserTests {
 
     #expect(candidates.map { $0.canonical } == ["東京"])
   }
-
 
   @Test("a library larger than the paste ceiling still exports and imports back")
   func oversizedLibraryRoundTrips() async throws {
@@ -430,9 +427,6 @@ struct ImportFileParserTests {
     }
   }
 
-
-
-
   @Test("UTF-16 without a byte-order mark is refused, never guessed at")
   func unmarkedUTF16IsRefused() async throws {
     // With no mark, BOTH byte orders decode to something for any even-length
@@ -457,8 +451,10 @@ struct ImportFileParserTests {
     // Which is the whole point of the mark, and why real UTF-16 writers emit
     // one. The supported path stays supported.
     let cases: [(Data, [String])] = [
-      (Data([0xFF, 0xFE]) + "Kubernetes\nPostgreSQL".data(using: .utf16LittleEndian)!,
-        ["Kubernetes", "PostgreSQL"]),
+      (
+        Data([0xFF, 0xFE]) + "Kubernetes\nPostgreSQL".data(using: .utf16LittleEndian)!,
+        ["Kubernetes", "PostgreSQL"]
+      ),
       (Data([0xFE, 0xFF]) + "Kubernetes".data(using: .utf16BigEndian)!, ["Kubernetes"]),
       (Data([0xFF, 0xFE]) + "東京\n大阪".data(using: .utf16LittleEndian)!, ["東京", "大阪"]),
       (Data([0xFF, 0xFE]) + "一".data(using: .utf16LittleEndian)!, ["一"]),
@@ -469,7 +465,6 @@ struct ImportFileParserTests {
       #expect(candidates.map { $0.canonical } == expected)
     }
   }
-
 
   @Test("an exported words file larger than the untrusted byte cap still imports")
   func oversizedExportedFileStillImports() async throws {
@@ -501,7 +496,6 @@ struct ImportFileParserTests {
       try await FileImportSource(url: url).loadCandidates()
     }
   }
-
 
   @Test("invisible control characters never become part of a word")
   func controlCharactersAreRefused() async throws {
@@ -536,7 +530,6 @@ struct ImportFileParserTests {
     #expect(candidates[1].canonical.unicodeScalars.contains { $0.value == 0x200C })
   }
 
-
   @Test("invisible and deceptive format characters are refused")
   func deceptiveFormatCharactersAreRefused() async throws {
     // Allowing the whole format category to protect joiners also admitted
@@ -557,7 +550,6 @@ struct ImportFileParserTests {
       }
     }
   }
-
 
   @Test("an exported file's word ceiling is raised, not removed")
   func exportedFileCeilingIsFiniteNotAbsent() async throws {
@@ -590,7 +582,6 @@ struct ImportFileParserTests {
     await #expect(throws: CancellationError.self) { try await task.value }
   }
 
-
   @Test("a truncated UTF-16 file is refused, not imported as its prefix")
   func truncatedUTF16IsRefused() async throws {
     // Foundation ignores a dangling byte, so a partial write decoded to its
@@ -602,7 +593,6 @@ struct ImportFileParserTests {
       try await FileImportSource(url: url).loadCandidates()
     }
   }
-
 
   @Test("a huge word list is refused without building every entry")
   func hugeListStopsAtTheCeiling() async throws {
@@ -636,24 +626,24 @@ struct ImportFileParserTests {
     #expect(batch.candidates.count == limit)
   }
 
-
   @Test("routing does not depend on the system resolving extensions")
   func routingUsesExtensionsNotSystemTypes() async throws {
     // Dispatch previously round-tripped the filename through Launch Services;
     // in a restricted environment that returns dyn.* and EVERY supported
     // upload was rejected before the file was read.
     let registry = ImportFileRegistry.v1
-    #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/a.json"))?.identifier == "exported-words")
+    #expect(
+      registry.parser(for: URL(fileURLWithPath: "/tmp/a.json"))?.identifier == "exported-words")
     #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/a.txt"))?.identifier == "plain-text")
     // Case and path shape are irrelevant to the decision.
-    #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/A.JSON"))?.identifier == "exported-words")
+    #expect(
+      registry.parser(for: URL(fileURLWithPath: "/tmp/A.JSON"))?.identifier == "exported-words")
     // Spreadsheets stay refused: the CSV split bug was the reason dispatch is
     // exact-match in the first place, and that must survive the mechanism change.
     #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/a.csv")) == nil)
     #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/a.tsv")) == nil)
     #expect(registry.parser(for: URL(fileURLWithPath: "/tmp/noextension")) == nil)
   }
-
 
   @Test("an oversized export is refused before candidates are built")
   func oversizedExportRefusedBeforeExpanding() async throws {
@@ -686,7 +676,6 @@ struct ImportFileParserTests {
     #expect(candidates.allSatisfy { !$0.canonical.contains("\t") })
   }
 
-
   @Test("a truncated UTF-16 file is refused, not read as Latin-1")
   func markedButBrokenFileDoesNotFallThrough() async throws {
     // A recognised mark is authoritative: if it says UTF-16 and the bytes fail
@@ -713,7 +702,6 @@ struct ImportFileParserTests {
     #expect(!message.contains("\(limit + 1)"))
   }
 
-
   // MARK: - One policy for every door (#1683 taxonomy P0s)
 
   @Test("an exported file cannot smuggle invisible characters into a word")
@@ -724,7 +712,8 @@ struct ImportFileParserTests {
     // property of the STORE, so it now runs for every source.
     for hostile in ["Kub\u{202E}ernetes", "Kub\u{0000}ernetes", "Kub\u{FEFF}ernetes", "   "] {
       let word = CustomWord(canonical: hostile, aliases: [], category: .general)
-      let url = try write(try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
+      let url = try write(
+        try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
 
       await #expect(throws: CustomWordsImportValidationError.self) {
         try await FileImportSource(url: url).loadCandidates()
@@ -760,7 +749,6 @@ struct ImportFileParserTests {
     #expect(candidates[0].aliases == .supplied(["k8s"]))
   }
 
-
   @Test("line and paragraph separators cannot hide inside a stored word")
   func lineSeparatorsAreRefused() async throws {
     // U+2028 and U+2029 have their OWN Unicode categories, so a control-only
@@ -768,14 +756,14 @@ struct ImportFileParserTests {
     // separator policy saying otherwise.
     for hidden in ["Kub\u{2028}ernetes", "Kub\u{2029}ernetes"] {
       let word = CustomWord(canonical: hidden, aliases: [], category: .general)
-      let url = try write(try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
+      let url = try write(
+        try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
 
       await #expect(throws: CustomWordsImportValidationError.self) {
         try await FileImportSource(url: url).loadCandidates()
       }
     }
   }
-
 
   @Test("few words with millions of aliases is refused")
   func aliasSurfaceIsBounded() async throws {
@@ -813,7 +801,6 @@ struct ImportFileParserTests {
     #expect(batch.candidates.count == 500)
   }
 
-
   @Test("the picker offers every extension the registry claims")
   func pickerCoversEveryRegisteredExtension() throws {
     // Declared types alone could hide a file the registry accepts: on a system
@@ -845,7 +832,6 @@ struct ImportFileParserTests {
     #expect(message.contains("Nothing was imported"))
   }
 
-
   @Test("a rejected character is named, never rendered, in the error")
   func rejectedCharacterIsNotEchoedIntoTheError() throws {
     // Echoing the raw value meant the very character rejected for rendering
@@ -876,7 +862,6 @@ struct ImportFileParserTests {
     await #expect(throws: CancellationError.self) { try await task.value }
   }
 
-
   @Test("sanitising an error keeps ordinary spaces intact")
   func sanitisedErrorKeepsSpaces() throws {
     // Testing each scalar through the whole-VALUE check treated a standalone
@@ -906,7 +891,6 @@ struct ImportFileParserTests {
 
     await #expect(throws: CancellationError.self) { try await task.value }
   }
-
 
   @Test("one enormous line is refused, not stored as a single word")
   func oneEnormousLineIsRefused() async throws {
@@ -947,7 +931,6 @@ struct ImportFileParserTests {
     #expect(candidates.map { $0.canonical } == [long])
   }
 
-
   @Test("a bad alias is named, not the innocent word that owns it")
   func aliasErrorNamesTheAlias() async throws {
     // Reporting the canonical quoted a value that was fine and hid the one
@@ -966,7 +949,6 @@ struct ImportFileParserTests {
       #expect(message.contains("Kubernetes"))
     }
   }
-
 
   @Test("a word made only of invisible joiners is refused")
   func joinerOnlyValueIsRefused() async throws {
@@ -997,7 +979,6 @@ struct ImportFileParserTests {
     #expect(candidates[0].canonical.unicodeScalars.contains { $0.value == 0x200D })
   }
 
-
   @Test("a pasted word with a bad character is reported, not silently dropped")
   func badPastedEntryIsReportedNotDropped() async throws {
     // Skipping everything the policy rejects was too broad: a visible entry
@@ -1020,7 +1001,6 @@ struct ImportFileParserTests {
 
     #expect(candidates.map { $0.canonical } == ["Good", "AlsoGood"])
   }
-
 
   @Test("a word of only invisible marks is refused, whichever mark it is")
   func invisibleOnlyValuesAreRefused() async throws {
@@ -1048,7 +1028,6 @@ struct ImportFileParserTests {
     #expect(candidates[0].canonical.unicodeScalars.contains { $0.value == 0xFE0F })
   }
 
-
   @Test("a suggested alias is validated like every other stored value")
   func suggestedAliasesAreValidated() throws {
     // The commit path persists suggestedAliases as aliases, but validation
@@ -1074,12 +1053,12 @@ struct ImportFileParserTests {
     #expect(candidate.storedValues == ["Kubernetes", "k8s", "kube"])
   }
 
-
   @Test("padding is not part of the word")
   func paddingDoesNotCountTowardWordLength() async throws {
     // Judging the raw buffer counted whitespace as part of the word, so a
     // heavily padded short entry — a fixed-width list — failed as "too long".
-    let padded = String(repeating: " ", count: 600) + "Kubernetes"
+    let padded =
+      String(repeating: " ", count: 600) + "Kubernetes"
       + String(repeating: " ", count: 600)
     let url = try write(padded, as: "words.txt")
 
@@ -1095,6 +1074,27 @@ struct ImportFileParserTests {
     let batch = try await FileImportSource(url: url).loadCandidates()
 
     #expect(batch.candidates.isEmpty)
+  }
+
+  @Test("padding does not count toward length in a structured file either")
+  func validatorJudgesLengthOnTheTrimmedValue() throws {
+    // Same rule, second door. The validator measured the value as written,
+    // but the manager stores it TRIMMED — so a short word padded inside a
+    // JSON file was refused for whitespace that would never have been saved.
+    let pad = String(repeating: " ", count: 600)
+    let candidate = CustomWordsImportCandidate(
+      canonical: pad + "Kubernetes" + pad,
+      aliases: .supplied([pad + "k8s" + pad]))
+    let batch = CustomWordsImportBatch(
+      sourceID: "test", sourceDisplayName: "test", candidates: [candidate])
+
+    #expect(throws: Never.self) { try batch.validated() }
+
+    // And still refused when the CONTENT is what exceeds the ceiling.
+    let genuinelyLong = CustomWordsImportBatch(
+      sourceID: "test", sourceDisplayName: "test",
+      candidates: [CustomWordsImportCandidate(canonical: pad + String(repeating: "x", count: 600))])
+    #expect(throws: CustomWordsImportValidationError.self) { try genuinelyLong.validated() }
   }
 
   @Test("a genuinely over-long word is still refused")

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -773,4 +773,41 @@ struct ImportFileParserTests {
     }
   }
 
+
+  @Test("few words with millions of aliases is refused")
+  func aliasSurfaceIsBounded() async throws {
+    // Bounding words alone bounded one dimension of the wrong thing: the work
+    // tracks total stored strings, so a handful of words each carrying a huge
+    // alias list fits under both the word and byte ceilings while flooding
+    // validation, comparison, and the collision index.
+    let perWord = 5_000
+    let wordCount =
+      (CustomWordsImportLimits.maximumExportedStoredValues / perWord) + 2
+    let words = (0..<wordCount).map { index in
+      CustomWord(
+        canonical: "Term\(index)",
+        aliases: (0..<perWord).map { "a\(index)_\($0)" },
+        category: .general)
+    }
+    let document = CustomWordsTransferDocument(words: words)
+    #expect(document.words.count < CustomWordsImportLimits.maximumExportedCandidates)
+    let url = try write(try document.encoded(), as: "words.json")
+
+    await #expect(throws: ImportFileError.self) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a normal library with aliases is unaffected by the surface ceiling")
+  func normalAliasSurfacePasses() async throws {
+    let words = (0..<500).map {
+      CustomWord(canonical: "Term\($0)", aliases: ["a\($0)", "b\($0)"], category: .general)
+    }
+    let url = try write(try CustomWordsTransferDocument(words: words).encoded(), as: "words.json")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.candidates.count == 500)
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -425,4 +425,36 @@ struct ImportFileParserTests {
     #expect(candidates.map { $0.canonical } == ["東京"])
   }
 
+
+  @Test("a library larger than the paste ceiling still exports and imports back")
+  func oversizedLibraryRoundTrips() async throws {
+    // Nothing caps how many words a library accumulates, so the app could
+    // WRITE a file it then refused to read — telling the user to split a JSON
+    // file by hand. An export you cannot import is not an export.
+    let words = (0..<(CustomWordsImportLimits.maximumCandidates + 500)).map {
+      CustomWord(canonical: "Term\($0)", aliases: [], category: .general)
+    }
+    let url = try write(try CustomWordsTransferDocument(words: words).encoded(), as: "words.json")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.candidates.count == words.count)
+  }
+
+  @Test("a pasted-style text list is still held to the ceiling")
+  func plainTextListStillCapped() async throws {
+    // The ceiling is not gone, it is scoped: untrusted input still has one.
+    let many = (0..<(CustomWordsImportLimits.maximumCandidates + 1))
+      .map { "Term\($0)" }.joined(separator: "\n")
+    let url = try write(many, as: "words.txt")
+
+    await #expect(
+      throws: ImportFileError.tooManyWords(
+        found: CustomWordsImportLimits.maximumCandidates + 1,
+        limit: CustomWordsImportLimits.maximumCandidates)
+    ) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -1048,4 +1048,30 @@ struct ImportFileParserTests {
     #expect(candidates[0].canonical.unicodeScalars.contains { $0.value == 0xFE0F })
   }
 
+
+  @Test("a suggested alias is validated like every other stored value")
+  func suggestedAliasesAreValidated() throws {
+    // The commit path persists suggestedAliases as aliases, but validation
+    // named canonical and .aliases only — so this third stored field went
+    // unchecked. Validation now walks storedValues, so a field is covered by
+    // being in that list.
+    var candidate = CustomWordsImportCandidate(canonical: "Kubernetes")
+    candidate.suggestedAliases = ["k8s", "kube\u{202E}rnetes"]
+    let batch = CustomWordsImportBatch(
+      sourceID: "test", sourceDisplayName: "test", candidates: [candidate])
+
+    #expect(throws: CustomWordsImportValidationError.self) { try batch.validated() }
+  }
+
+  @Test("every stored field is reachable from storedValues")
+  func storedValuesCoversEveryStoredField() throws {
+    // The property that keeps this fixed: if a field can be persisted, it must
+    // appear here, or validation silently stops covering it.
+    var candidate = CustomWordsImportCandidate(
+      canonical: "Kubernetes", aliases: .supplied(["k8s"]))
+    candidate.suggestedAliases = ["kube"]
+
+    #expect(candidate.storedValues == ["Kubernetes", "k8s", "kube"])
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -450,4 +450,36 @@ struct ImportFileParserTests {
     }
   }
 
+
+  @Test("an exported words file larger than the untrusted byte cap still imports")
+  func oversizedExportedFileStillImports() async throws {
+    // Capping the WORDS but not the BYTES left the same round-trip hole one
+    // layer down: the size check runs before the parser is consulted, so the
+    // app could still write a words file it then refused as .tooLarge.
+    // Padded via alias text so the file genuinely exceeds the untrusted cap.
+    let filler = String(repeating: "x", count: 512)
+    let words = (0..<40_000).map {
+      CustomWord(canonical: "Term\($0)", aliases: ["\(filler)\($0)"], category: .general)
+    }
+    let data = try CustomWordsTransferDocument(words: words).encoded()
+    #expect(data.count > CustomWordsImportLimits.maximumImportFileBytes)
+    let url = try write(data, as: "words.json")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.candidates.count == words.count)
+  }
+
+  @Test("an untrusted text file is still held to the smaller byte cap")
+  func oversizedTextFileStillRefused() async throws {
+    // The cap is scoped, not removed.
+    let big = String(
+      repeating: "Term\n", count: CustomWordsImportLimits.maximumImportFileBytes / 4)
+    let url = try write(big, as: "words.txt")
+
+    await #expect(throws: ImportFileError.tooLarge) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -172,6 +172,29 @@ struct ImportFileParserTests {
     }
   }
 
+  @Test(
+    "healthy JSON that isn't ours reads as a different file, not a damaged one",
+    arguments: ["[1,2,3]", "\"just a string\"", "42", "[]"])
+  func nonObjectJSONReportsForeignRatherThanDamaged(payload: String) async throws {
+    // A config file, an API dump, a list saved as JSON — all valid documents
+    // that simply aren't ours. Calling them damaged sends the user hunting for
+    // corruption that isn't there (review r2).
+    let url = try write(payload, as: "other.json")
+    await #expect(throws: ImportFileError.exportedWords(.notAnEnviousWisprBackup)) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a file claiming to be ours but broken still reads as damaged")
+  func ourFormatWithBrokenPayloadStillReadsAsDamaged() async throws {
+    let url = try write(
+      #"{"format":"com.enviouswispr.custom-words","version":1,"words":"not-an-array"}"#,
+      as: "broken.json")
+    await #expect(throws: ImportFileError.exportedWords(.malformed)) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
   // MARK: - Limits
 
   @Test("an absurdly large file is refused before it is read into memory")

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -201,7 +201,7 @@ struct ImportFileParserTests {
   func oversizedFileIsRefusedBeforeReading() async throws {
     // Refusing by size beats discovering it after allocating: a word list is
     // small, so anything this big is a mistaken selection.
-    let url = try write(Data(count: FileImportSource.maximumFileBytes + 1), as: "huge.txt")
+    let url = try write(Data(count: CustomWordsImportLimits.maximumImportFileBytes + 1), as: "huge.txt")
     await #expect(throws: ImportFileError.tooLarge) {
       _ = try await FileImportSource(url: url).loadCandidates()
     }
@@ -514,6 +514,25 @@ struct ImportFileParserTests {
     #expect(candidates.count == 2)
     #expect(candidates[0].canonical.unicodeScalars.contains { $0.value == 0x200D })
     #expect(candidates[1].canonical.unicodeScalars.contains { $0.value == 0x200C })
+  }
+
+
+  @Test("invisible and deceptive format characters are refused")
+  func deceptiveFormatCharactersAreRefused() async throws {
+    // Allowing the whole format category to protect joiners also admitted
+    // these. Nothing downstream strips them, so they would be saved INSIDE a
+    // word: a mid-file byte-order mark is invisible, and a bidi override makes
+    // a word render as something other than what it is.
+    for text in [
+      "Kub\u{FEFF}ernetes",  // mid-file byte-order mark
+      "Kub\u{202E}ernetes",  // right-to-left override
+      "Kub\u{00AD}ernetes",  // soft hyphen
+    ] {
+      let url = try write(text, as: "words.txt")
+      await #expect(throws: ImportFileError.unreadable) {
+        try await FileImportSource(url: url).loadCandidates()
+      }
+    }
   }
 
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -964,4 +964,34 @@ struct ImportFileParserTests {
     }
   }
 
+
+  @Test("a word made only of invisible joiners is refused")
+  func joinerOnlyValueIsRefused() async throws {
+    // Joiners are legitimate INSIDE a word, so "not empty" and "every scalar
+    // allowed" both passed — and a visually blank word could be stored and
+    // shown in Review as nothing at all.
+    for blank in ["\u{200D}", "\u{200C}\u{200D}", " \u{200D} "] {
+      let url = try write(blank, as: "words.txt")
+      let batch = try await FileImportSource(url: url).loadCandidates()
+      #expect(batch.candidates.isEmpty, "a joiner-only entry must not become a word")
+    }
+
+    // And the same value cannot arrive through an exported file either.
+    let word = CustomWord(canonical: "\u{200D}", aliases: [], category: .general)
+    let url = try write(try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
+    await #expect(throws: CustomWordsImportValidationError.self) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a real word containing a joiner still imports")
+  func joinerInsideRealWordSurvives() async throws {
+    let url = try write("क्\u{200D}ष", as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.count == 1)
+    #expect(candidates[0].canonical.unicodeScalars.contains { $0.value == 0x200D })
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -567,4 +567,17 @@ struct ImportFileParserTests {
     await #expect(throws: CancellationError.self) { try await task.value }
   }
 
+
+  @Test("a truncated UTF-16 file is refused, not imported as its prefix")
+  func truncatedUTF16IsRefused() async throws {
+    // Foundation ignores a dangling byte, so a partial write decoded to its
+    // prefix and imported as if complete.
+    let full = Data([0xFF, 0xFE]) + "Kubernetes\nPostgreSQL".data(using: .utf16LittleEndian)!
+    let url = try write(full.dropLast(), as: "words.txt")
+
+    await #expect(throws: ImportFileError.unreadable) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -757,4 +757,20 @@ struct ImportFileParserTests {
     #expect(candidates[0].aliases == .supplied(["k8s"]))
   }
 
+
+  @Test("line and paragraph separators cannot hide inside a stored word")
+  func lineSeparatorsAreRefused() async throws {
+    // U+2028 and U+2029 have their OWN Unicode categories, so a control-only
+    // check let them through — invisible, inside a stored word, despite the
+    // separator policy saying otherwise.
+    for hidden in ["Kub\u{2028}ernetes", "Kub\u{2029}ernetes"] {
+      let word = CustomWord(canonical: hidden, aliases: [], category: .general)
+      let url = try write(try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
+
+      await #expect(throws: CustomWordsImportValidationError.self) {
+        try await FileImportSource(url: url).loadCandidates()
+      }
+    }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -477,7 +477,7 @@ struct ImportFileParserTests {
     // layer down: the size check runs before the parser is consulted, so the
     // app could still write a words file it then refused as .tooLarge.
     // Padded via alias text so the file genuinely exceeds the untrusted cap.
-    let filler = String(repeating: "x", count: 512)
+    let filler = String(repeating: "x", count: 400)
     let words = (0..<40_000).map {
       CustomWord(canonical: "Term\($0)", aliases: ["\(filler)\($0)"], category: .general)
     }
@@ -902,6 +902,46 @@ struct ImportFileParserTests {
     task.cancel()
 
     await #expect(throws: CancellationError.self) { try await task.value }
+  }
+
+
+  @Test("one enormous line is refused, not stored as a single word")
+  func oneEnormousLineIsRefused() async throws {
+    // A minified file or log picked by mistake passes the candidate ceiling as
+    // ONE entry, so without a length cap it became a multi-megabyte "word":
+    // copied through normalisation and comparison, rendered in Review, and
+    // persisted.
+    let huge = String(repeating: "x", count: 2_000_000)
+    let url = try write(huge, as: "words.txt")
+
+    await #expect(throws: CustomWordsImportValidationError.self) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("an exported file cannot smuggle an enormous word past the text cap")
+  func exportedFileLengthIsCappedToo() async throws {
+    // Both doors: the cap on the text scan means nothing if JSON can carry the
+    // same value straight through.
+    let word = CustomWord(
+      canonical: String(repeating: "x", count: 5_000), aliases: [], category: .general)
+    let url = try write(try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
+
+    await #expect(throws: CustomWordsImportValidationError.self) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a long but realistic word still imports")
+  func longRealisticWordImports() async throws {
+    // The cap must clear real terms, including long compounds in scripts that
+    // do not space-separate.
+    let long = String(repeating: "り", count: 200)
+    let url = try write(long, as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == [long])
   }
 
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -944,4 +944,24 @@ struct ImportFileParserTests {
     #expect(candidates.map { $0.canonical } == [long])
   }
 
+
+  @Test("a bad alias is named, not the innocent word that owns it")
+  func aliasErrorNamesTheAlias() async throws {
+    // Reporting the canonical quoted a value that was fine and hid the one
+    // that has to be fixed.
+    let word = CustomWord(
+      canonical: "Kubernetes", aliases: ["k8s", "kube\u{202E}rnetes"], category: .general)
+    let url = try write(try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
+
+    do {
+      _ = try await FileImportSource(url: url).loadCandidates()
+      Issue.record("expected the alias to be refused")
+    } catch let error as CustomWordsImportValidationError {
+      let message = try #require(error.errorDescription)
+      #expect(message.contains("alternate spelling"))
+      #expect(message.contains("<U+202E>"))
+      #expect(message.contains("Kubernetes"))
+    }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -310,29 +310,6 @@ struct ImportFileParserTests {
   }
 
 
-  @Test("UTF-16 without a byte-order mark still imports real words")
-  func utf16WithoutByteOrderMarkDecodes() async throws {
-    // NUL is a legal UTF-8 byte, so these bytes decode "successfully" as UTF-8
-    // to "K\0u\0b\0…". Gating only the Latin-1 path let that straight
-    // through — the plausibility check has to guard EVERY decode step.
-    let url = try write(
-      "Kubernetes\nPostgreSQL".data(using: .utf16LittleEndian)!, as: "words.txt")
-
-    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
-
-    #expect(candidates.map { $0.canonical } == ["Kubernetes", "PostgreSQL"])
-  }
-
-  @Test("big-endian UTF-16 without a byte-order mark decodes too")
-  func utf16BigEndianWithoutByteOrderMarkDecodes() async throws {
-    let url = try write("Kubernetes".data(using: .utf16BigEndian)!, as: "words.txt")
-
-    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
-
-    #expect(candidates.map { $0.canonical } == ["Kubernetes"])
-  }
-
-
   @Test("word lists in other scripts import intact")
   func internationalWordListsImportIntact() async throws {
     // Japanese, Hindi, Arabic, Korean, Russian, Greek, accented Latin, and a
@@ -390,30 +367,6 @@ struct ImportFileParserTests {
   }
 
 
-  @Test("a multi-word CJK list in UTF-16 imports correctly")
-  func multiWordCJKUTF16Imports() async throws {
-    // The realistic shape: line breaks supply the NUL bytes the detector
-    // reads, so a Japanese word list saved as UTF-16 works.
-    let url = try write("東京\n大阪\n京都".data(using: .utf16LittleEndian)!, as: "words.txt")
-
-    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
-
-    #expect(candidates.map { $0.canonical } == ["東京", "大阪", "京都"])
-  }
-
-  @Test("a single CJK word in UTF-16 with no mark is refused, not corrupted")
-  func singleCJKWordWithoutMarkIsRefused() async throws {
-    // Genuinely ambiguous: these four bytes are a valid Latin-1 word list AND
-    // valid UTF-16. Guessing UTF-16 here would corrupt real Latin-1 files
-    // (Beyoncé/Jalapeño decodes to plausible-looking CJK), so refusing is the
-    // honest answer. Refused beats "qg¬N" imported as a word.
-    let url = try write("東京".data(using: .utf16LittleEndian)!, as: "words.txt")
-
-    await #expect(throws: ImportFileError.unreadable) {
-      try await FileImportSource(url: url).loadCandidates()
-    }
-  }
-
   @Test("a single CJK word WITH a byte-order mark imports fine")
   func singleCJKWordWithMarkImports() async throws {
     // Which is why the mark matters, and why real UTF-16 writers emit one.
@@ -458,5 +411,43 @@ struct ImportFileParserTests {
   }
 
 
+
+
+  @Test("UTF-16 without a byte-order mark is refused, never guessed at")
+  func unmarkedUTF16IsRefused() async throws {
+    // With no mark, BOTH byte orders decode to something for any even-length
+    // input, so nothing in the bytes can settle which was meant: UTF-16LE 一
+    // is 00 4E, identical to big-endian N. Guessing here corrupted data in
+    // four separate review rounds. Refusing is the honest answer.
+    for data in [
+      "Kubernetes\nPostgreSQL".data(using: .utf16LittleEndian)!,
+      "Kubernetes".data(using: .utf16BigEndian)!,
+      "東京\n大阪".data(using: .utf16LittleEndian)!,
+      Data([0x00, 0x4E]),
+    ] {
+      let url = try write(data, as: "words.txt")
+      await #expect(throws: ImportFileError.unreadable) {
+        try await FileImportSource(url: url).loadCandidates()
+      }
+    }
+  }
+
+  @Test("UTF-16 WITH a byte-order mark imports, including CJK")
+  func markedUTF16Imports() async throws {
+    // Which is the whole point of the mark, and why real UTF-16 writers emit
+    // one. The supported path stays supported.
+    let cases: [(Data, [String])] = [
+      (Data([0xFF, 0xFE]) + "Kubernetes\nPostgreSQL".data(using: .utf16LittleEndian)!,
+        ["Kubernetes", "PostgreSQL"]),
+      (Data([0xFE, 0xFF]) + "Kubernetes".data(using: .utf16BigEndian)!, ["Kubernetes"]),
+      (Data([0xFF, 0xFE]) + "東京\n大阪".data(using: .utf16LittleEndian)!, ["東京", "大阪"]),
+      (Data([0xFF, 0xFE]) + "一".data(using: .utf16LittleEndian)!, ["一"]),
+    ]
+    for (data, expected) in cases {
+      let url = try write(data, as: "words.txt")
+      let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+      #expect(candidates.map { $0.canonical } == expected)
+    }
+  }
 
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -482,4 +482,38 @@ struct ImportFileParserTests {
     }
   }
 
+
+  @Test("invisible control characters never become part of a word")
+  func controlCharactersAreRefused() async throws {
+    // The old check hand-rolled a range (below U+0020 plus DEL) and so missed
+    // the C1 block: bytes C2 85 are valid UTF-8 for U+0085, which nothing
+    // downstream splits or strips, so it imported as an invisible character
+    // inside a custom word. Asking Unicode's category covers every control in
+    // every block without a range to keep in sync.
+    for bytes in [
+      Data([0x4B, 0xC2, 0x85, 0x75]),  // C1 NEL inside a word
+      Data([0x4B, 0xC2, 0x9B, 0x75]),  // C1 CSI
+      Data([0x4B, 0x00, 0x75]),  // C0 NUL
+    ] {
+      let url = try write(bytes, as: "words.txt")
+      await #expect(throws: ImportFileError.unreadable) {
+        try await FileImportSource(url: url).loadCandidates()
+      }
+    }
+  }
+
+  @Test("zero-width joiners survive, because real scripts need them")
+  func zeroWidthJoinersSurvive() async throws {
+    // Rejecting the whole format category would have been the easy fix and
+    // would have broken Hindi, Persian, and emoji sequences — the exact
+    // international lists this is meant to support.
+    let url = try write("क्‍ष\nحرف‌ها", as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.count == 2)
+    #expect(candidates[0].canonical.unicodeScalars.contains { $0.value == 0x200D })
+    #expect(candidates[1].canonical.unicodeScalars.contains { $0.value == 0x200C })
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -1,0 +1,195 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+
+@testable import EnviousWisprPostProcessing
+
+/// #1683 (PR-U1) — reading a chosen file into import candidates.
+///
+/// The failure paths carry most of the weight: a user who picks the wrong file
+/// should be told which wrong thing they picked, not handed "damaged" for a
+/// perfectly healthy document.
+@MainActor
+@Suite("ImportFileParser")
+struct ImportFileParserTests {
+
+  private func write(_ contents: Data, as name: String) throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-file-import-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent(name)
+    try contents.write(to: url)
+    return url
+  }
+
+  private func write(_ text: String, as name: String) throws -> URL {
+    try write(Data(text.utf8), as: name)
+  }
+
+  // MARK: - Backup format
+
+  @Test("an exported backup restores every portable field")
+  func backupParserRestoresEveryPortableField() async throws {
+    let original = CustomWord(
+      canonical: "Kubernetes", aliases: ["k8s"], category: .brand, priority: 3,
+      forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.8)
+    let data = try CustomWordsTransferDocument(words: [original]).encoded()
+    let url = try write(data, as: "words.json")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+    let candidate = try #require(batch.candidates.first)
+
+    #expect(batch.sourceID == "backup")
+    #expect(candidate.canonical == "Kubernetes")
+    // Backup is the one source with real authority over every field.
+    #expect(candidate.aliases == .supplied(["k8s"]))
+    #expect(candidate.category == .supplied(.brand))
+    #expect(candidate.priority == .supplied(3))
+    #expect(candidate.forceReplace == .supplied(true))
+    #expect(candidate.caseSensitive == .supplied(true))
+    #expect(candidate.minSimilarityOverride == .supplied(0.8))
+  }
+
+  @Test("a JSON file that isn't ours says so, rather than reading as damaged")
+  func foreignJSONReportsItIsNotABackup() async throws {
+    let url = try write(#"{"format":"com.example.other","version":1,"words":[]}"#, as: "other.json")
+    await #expect(throws: ImportFileError.backup(.notAnEnviousWisprBackup)) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a backup from a newer version says to update, not that it is damaged")
+  func futureBackupReportsVersionRatherThanDamage() async throws {
+    let url = try write(
+      #"{"format":"com.enviouswispr.custom-words","version":99,"words":[]}"#,
+      as: "future.json")
+    await #expect(throws: ImportFileError.backup(.unsupportedVersion(99))) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  // MARK: - Plain text
+
+  @Test("a plain list becomes one candidate per word")
+  func plainTextParsesOneCandidatePerWord() async throws {
+    let url = try write("Kubernetes\nAnthropic\nQualtrics", as: "words.txt")
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.sourceID == "plain-text")
+    #expect(batch.candidates.map(\.canonical) == ["Kubernetes", "Anthropic", "Qualtrics"])
+  }
+
+  @Test("a file list splits exactly like the paste box does")
+  func plainTextUsesTheSameRulesAsPaste() async throws {
+    // One parser, not two. A word list is a word list whether it was typed or
+    // saved to a file, and two implementations would eventually disagree about
+    // what "Envious Labs" or "C++" means.
+    let text = "Envious Labs, C++\nand/or\nSmith; Jones\nGitHub\ngithub"
+    let url = try write(text, as: "words.txt")
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.candidates.map(\.canonical) == PasteWordsParser.parse(text))
+    #expect(
+      batch.candidates.map(\.canonical)
+        == ["Envious Labs", "C++", "and/or", "Smith; Jones", "GitHub"])
+  }
+
+  @Test("a plain list claims no authority over any field")
+  func plainTextLeavesEveryAuthorityFieldUnspecified() async throws {
+    let url = try write("Kubernetes", as: "words.txt")
+    let candidate = try #require(
+      try await FileImportSource(url: url).loadCandidates().candidates.first)
+
+    #expect(candidate.aliases == .unspecified)
+    #expect(candidate.category == .unspecified)
+    #expect(candidate.priority == .unspecified)
+    #expect(candidate.forceReplace == .unspecified)
+    #expect(candidate.caseSensitive == .unspecified)
+    #expect(candidate.minSimilarityOverride == .unspecified)
+  }
+
+  @Test("an empty file yields nothing to import rather than an error")
+  func emptyFileYieldsNoCandidates() async throws {
+    let url = try write("   \n\n  ", as: "empty.txt")
+    let batch = try await FileImportSource(url: url).loadCandidates()
+    #expect(batch.candidates.isEmpty)
+  }
+
+  @Test("text that isn't UTF-8 still reads rather than being refused")
+  func latin1TextIsAccepted() async throws {
+    let url = try write(try #require("Beyoncé".data(using: .isoLatin1)), as: "legacy.txt")
+    let batch = try await FileImportSource(url: url).loadCandidates()
+    #expect(batch.candidates.map(\.canonical) == ["Beyoncé"])
+  }
+
+  // MARK: - Unsupported and unreadable
+
+  @Test("a spreadsheet is named as unsupported, with somewhere to go")
+  func spreadsheetReportsUnsupportedType() async throws {
+    let url = try write("a,b,c", as: "words.csv")
+    await #expect(throws: ImportFileError.unsupportedType(".csv")) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a spreadsheet is never quietly read as a word list")
+  func csvIsRefusedRatherThanMangledByThePlainTextParser() async throws {
+    // The bug this freezes: CSV conforms to public.plain-text, so a
+    // conformance-based match handed spreadsheets to the plain-text parser.
+    // That parser splits on commas, so this single row would have imported
+    // three "words" — the header included — silently corrupting the user's
+    // dictionary. Refusing the file is the only honest outcome until a real
+    // CSV parser is registered.
+    let url = try write("canonical,alias,category\nGitHub,git hub,brand", as: "words.csv")
+
+    await #expect(throws: ImportFileError.unsupportedType(".csv")) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a tab-separated file is refused for the same reason")
+  func tsvIsAlsoRefused() async throws {
+    let url = try write("canonical\talias\nGitHub\tgit hub", as: "words.tsv")
+    await #expect(throws: ImportFileError.unsupportedType(".tsv")) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("an unreadable file reports as unreadable")
+  func unreadableFileReportsUnreadable() async throws {
+    let url = try write("Kubernetes", as: "words.txt")
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: url.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    await #expect(throws: ImportFileError.unreadable) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  // MARK: - Registry
+
+  @Test("the picker offers exactly what the registry can read")
+  func acceptedContentTypesComeFromTheRegistry() {
+    // One source of truth, so a format cannot be selectable but unreadable —
+    // or readable but unselectable.
+    let types = ImportFileRegistry.v1.acceptedContentTypes
+    #expect(types.contains(.json))
+    #expect(types.contains(.plainText))
+    #expect(!types.contains(.commaSeparatedText))
+  }
+
+  @Test("registering a format is all it takes to make it readable")
+  func registryDispatchesByFileType() throws {
+    let json = try write("{}", as: "a.json")
+    let text = try write("a", as: "a.txt")
+
+    #expect(ImportFileRegistry.v1.parser(for: json)?.identifier == "backup")
+    #expect(ImportFileRegistry.v1.parser(for: text)?.identifier == "plain-text")
+    #expect(ImportFileRegistry.v1.parser(for: try write("a", as: "a.csv")) == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -1021,4 +1021,31 @@ struct ImportFileParserTests {
     #expect(candidates.map { $0.canonical } == ["Good", "AlsoGood"])
   }
 
+
+  @Test("a word of only invisible marks is refused, whichever mark it is")
+  func invisibleOnlyValuesAreRefused() async throws {
+    // Listing "the invisible ones" by hand named the two joiners and missed
+    // variation selectors and every other default-ignorable scalar, so a word
+    // made only of U+FE0F counted as visible and could be stored blank.
+    for blank in ["\u{FE0F}", "\u{200D}\u{FE0F}", "\u{2060}", "\u{FE00}\u{200C}"] {
+      let word = CustomWord(canonical: blank, aliases: [], category: .general)
+      let url = try write(try CustomWordsTransferDocument(words: [word]).encoded(), as: "w.json")
+      await #expect(throws: CustomWordsImportValidationError.self) {
+        try await FileImportSource(url: url).loadCandidates()
+      }
+    }
+  }
+
+  @Test("an emoji with a variation selector is still a real word")
+  func emojiWithVariationSelectorSurvives() async throws {
+    // The check must reject values that are ONLY invisible, never strip
+    // invisibles from words that have visible content.
+    let url = try write("\u{2764}\u{FE0F}\nKubernetes", as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.count == 2)
+    #expect(candidates[0].canonical.unicodeScalars.contains { $0.value == 0xFE0F })
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -873,4 +873,35 @@ struct ImportFileParserTests {
     await #expect(throws: CancellationError.self) { try await task.value }
   }
 
+
+  @Test("sanitising an error keeps ordinary spaces intact")
+  func sanitisedErrorKeepsSpaces() throws {
+    // Testing each scalar through the whole-VALUE check treated a standalone
+    // space as blank, so a multi-word entry rendered as Foo<U+0020>Bar and
+    // told the user their spaces were bad characters.
+    let message = try #require(
+      CustomWordsImportValidationError.unusableWord(canonical: "Foo Bar\u{202E}")
+        .errorDescription)
+
+    #expect(message.contains("Foo Bar"))
+    #expect(!message.contains("<U+0020>"))
+    #expect(message.contains("<U+202E>"))
+  }
+
+  @Test("validation stops mid-aliases when the sheet is dismissed")
+  func aliasValidationHonoursCancellation() async throws {
+    // One candidate can carry hundreds of thousands of aliases, so checking
+    // only the outer loop left the inner one uninterruptible.
+    let candidate = CustomWordsImportCandidate(
+      canonical: "Kubernetes",
+      aliases: .supplied((0..<20_000).map { "alias\($0)" }))
+    let batch = CustomWordsImportBatch(
+      sourceID: "test", sourceDisplayName: "test", candidates: [candidate])
+
+    let task = Task { try batch.validated() }
+    task.cancel()
+
+    await #expect(throws: CancellationError.self) { try await task.value }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -27,10 +27,10 @@ struct ImportFileParserTests {
     try write(Data(text.utf8), as: name)
   }
 
-  // MARK: - Backup format
+  // MARK: - Exported words file
 
-  @Test("an exported backup restores every portable field")
-  func backupParserRestoresEveryPortableField() async throws {
+  @Test("an exported words file brings back every portable field")
+  func exportedWordsFileBringsBackEveryPortableField() async throws {
     let original = CustomWord(
       canonical: "Kubernetes", aliases: ["k8s"], category: .brand, priority: 3,
       forceReplace: true, caseSensitive: true, minSimilarityOverride: 0.8)
@@ -40,9 +40,10 @@ struct ImportFileParserTests {
     let batch = try await FileImportSource(url: url).loadCandidates()
     let candidate = try #require(batch.candidates.first)
 
-    #expect(batch.sourceID == "backup")
+    #expect(batch.sourceID == "exported-words")
     #expect(candidate.canonical == "Kubernetes")
-    // Backup is the one source with real authority over every field.
+    // An exported file is the one source with real authority over every
+    // field: it is the user's own data going out and coming back.
     #expect(candidate.aliases == .supplied(["k8s"]))
     #expect(candidate.category == .supplied(.brand))
     #expect(candidate.priority == .supplied(3))
@@ -52,19 +53,19 @@ struct ImportFileParserTests {
   }
 
   @Test("a JSON file that isn't ours says so, rather than reading as damaged")
-  func foreignJSONReportsItIsNotABackup() async throws {
+  func foreignJSONReportsItDidNotComeFromEnviousWispr() async throws {
     let url = try write(#"{"format":"com.example.other","version":1,"words":[]}"#, as: "other.json")
-    await #expect(throws: ImportFileError.backup(.notAnEnviousWisprBackup)) {
+    await #expect(throws: ImportFileError.exportedWords(.notAnEnviousWisprBackup)) {
       _ = try await FileImportSource(url: url).loadCandidates()
     }
   }
 
-  @Test("a backup from a newer version says to update, not that it is damaged")
-  func futureBackupReportsVersionRatherThanDamage() async throws {
+  @Test("a file from a newer version says to update, not that it is damaged")
+  func futureFileReportsVersionRatherThanDamage() async throws {
     let url = try write(
       #"{"format":"com.enviouswispr.custom-words","version":99,"words":[]}"#,
       as: "future.json")
-    await #expect(throws: ImportFileError.backup(.unsupportedVersion(99))) {
+    await #expect(throws: ImportFileError.exportedWords(.unsupportedVersion(99))) {
       _ = try await FileImportSource(url: url).loadCandidates()
     }
   }
@@ -171,6 +172,41 @@ struct ImportFileParserTests {
     }
   }
 
+  // MARK: - Limits
+
+  @Test("an absurdly large file is refused before it is read into memory")
+  func oversizedFileIsRefusedBeforeReading() async throws {
+    // Refusing by size beats discovering it after allocating: a word list is
+    // small, so anything this big is a mistaken selection.
+    let url = try write(Data(count: FileImportSource.maximumFileBytes + 1), as: "huge.txt")
+    await #expect(throws: ImportFileError.tooLarge) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a file with more words than the limit is refused with both numbers")
+  func tooManyWordsIsRefusedWithCounts() async throws {
+    let limit = FileImportSource.maximumCandidates
+    let words = (0...limit).map { "word\($0)" }.joined(separator: "\n")
+    let url = try write(words, as: "many.txt")
+
+    await #expect(
+      throws: ImportFileError.tooManyWords(found: limit + 1, limit: limit)
+    ) {
+      _ = try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a file exactly at the limit is accepted")
+  func fileAtExactlyTheLimitIsAccepted() async throws {
+    let limit = FileImportSource.maximumCandidates
+    let words = (1...limit).map { "word\($0)" }.joined(separator: "\n")
+    let url = try write(words, as: "atlimit.txt")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+    #expect(batch.candidates.count == limit)
+  }
+
   // MARK: - Registry
 
   @Test("the picker offers exactly what the registry can read")
@@ -188,7 +224,7 @@ struct ImportFileParserTests {
     let json = try write("{}", as: "a.json")
     let text = try write("a", as: "a.txt")
 
-    #expect(ImportFileRegistry.v1.parser(for: json)?.identifier == "backup")
+    #expect(ImportFileRegistry.v1.parser(for: json)?.identifier == "exported-words")
     #expect(ImportFileRegistry.v1.parser(for: text)?.identifier == "plain-text")
     #expect(ImportFileRegistry.v1.parser(for: try write("a", as: "a.csv")) == nil)
   }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -118,11 +118,16 @@ struct ImportFileParserTests {
     #expect(batch.candidates.isEmpty)
   }
 
-  @Test("text that isn't UTF-8 still reads rather than being refused")
-  func latin1TextIsAccepted() async throws {
+  @Test("text in an unknowable encoding is refused rather than guessed at")
+  func latin1TextIsRefused() async throws {
+    // Superseded contract (#1683). This previously asserted that Latin-1 text
+    // "still reads" — which sounds generous and was in fact the catch-all that
+    // imported mojibake as words, since Latin-1 accepts every byte and can
+    // never report failure. Refusing beats storing a wrong word.
     let url = try write(try #require("Beyoncé".data(using: .isoLatin1)), as: "legacy.txt")
-    let batch = try await FileImportSource(url: url).loadCandidates()
-    #expect(batch.candidates.map { $0.canonical } == ["Beyoncé"])
+    await #expect(throws: ImportFileError.unreadable) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
   }
 
   // MARK: - Unsupported and unreadable
@@ -290,17 +295,31 @@ struct ImportFileParserTests {
     #expect(candidates.map { $0.canonical } == ["Kubernetes"])
   }
 
-  @Test("a legacy Latin-1 file still imports")
-  func latin1FileStillImports() async throws {
-    // The fallback must keep working for its real case; the fix narrows WHEN
-    // it is reached, it does not remove it.
+  @Test("a legacy Latin-1 file is refused rather than guessed at")
+  func latin1FileIsRefused() async throws {
+    // Latin-1 CANNOT fail — every byte is valid — so as a fallback it is a
+    // catch-all that renames "I could not read this" to a confident wrong
+    // answer. A "looks like words" guard only narrowed which wrong answers
+    // survived; Windows-1252 and mixed-encoding files still landed as
+    // plausible mojibake. Supported set is now exactly UTF-8 and marked
+    // UTF-16, and anything else is refused.
     let url = try write("Beyoncé\nJalapeño".data(using: .isoLatin1)!, as: "words.txt")
+
+    await #expect(throws: ImportFileError.unreadable) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("the same words as UTF-8 import fine")
+  func sameWordsAsUTF8Import() async throws {
+    // The accented words themselves were never the problem — the ENCODING
+    // was. Saved as UTF-8, which is what everything modern writes, they import.
+    let url = try write("Beyoncé\nJalapeño", as: "words.txt")
 
     let candidates = try await FileImportSource(url: url).loadCandidates().candidates
 
     #expect(candidates.map { $0.canonical } == ["Beyoncé", "Jalapeño"])
   }
-
   @Test("binary content is refused rather than laundered into words")
   func binaryContentIsRefused() async throws {
     let url = try write(Data([0x00, 0x01, 0x02, 0xFF, 0x00, 0x7F]), as: "words.txt")
@@ -689,6 +708,53 @@ struct ImportFileParserTests {
 
     #expect(message.contains("more than \(limit)"))
     #expect(!message.contains("\(limit + 1)"))
+  }
+
+
+  // MARK: - One policy for every door (#1683 taxonomy P0s)
+
+  @Test("an exported file cannot smuggle invisible characters into a word")
+  func exportedFileIsHeldToTheSameCharacterPolicy() async throws {
+    // The character rules lived inside the plain-text parser, so words
+    // arriving from JSON skipped every one of them: the same bidi override
+    // refused from a pasted list was accepted from a file. The policy is a
+    // property of the STORE, so it now runs for every source.
+    for hostile in ["Kub\u{202E}ernetes", "Kub\u{0000}ernetes", "Kub\u{FEFF}ernetes", "   "] {
+      let word = CustomWord(canonical: hostile, aliases: [], category: .general)
+      let url = try write(try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
+
+      await #expect(throws: CustomWordsImportValidationError.self) {
+        try await FileImportSource(url: url).loadCandidates()
+      }
+    }
+  }
+
+  @Test("an exported alias is held to the policy too, not just the word")
+  func exportedAliasesAreValidated() async throws {
+    let word = CustomWord(
+      canonical: "Kubernetes", aliases: ["k8s", "kube\u{202E}rnetes"], category: .general)
+    let url = try write(try CustomWordsTransferDocument(words: [word]).encoded(), as: "words.json")
+
+    await #expect(throws: CustomWordsImportValidationError.self) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
+  @Test("a clean exported file still imports, aliases intact")
+  func cleanExportedFileStillImports() async throws {
+    // The validator must not become a wall: real exports keep working, and
+    // international words are not collateral damage.
+    let words = [
+      CustomWord(canonical: "Kubernetes", aliases: ["k8s"], category: .brand),
+      CustomWord(canonical: "東京", aliases: ["とうきょう"], category: .general),
+      CustomWord(canonical: "क्‍ष", aliases: [], category: .general),
+    ]
+    let url = try write(try CustomWordsTransferDocument(words: words).encoded(), as: "words.json")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Kubernetes", "東京", "क्‍ष"])
+    #expect(candidates[0].aliases == .supplied(["k8s"]))
   }
 
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -78,7 +78,7 @@ struct ImportFileParserTests {
     let batch = try await FileImportSource(url: url).loadCandidates()
 
     #expect(batch.sourceID == "plain-text")
-    #expect(batch.candidates.map(\.canonical) == ["Kubernetes", "Anthropic", "Qualtrics"])
+    #expect(batch.candidates.map { $0.canonical } == ["Kubernetes", "Anthropic", "Qualtrics"])
   }
 
   @Test("a file list splits exactly like the paste box does")
@@ -90,9 +90,9 @@ struct ImportFileParserTests {
     let url = try write(text, as: "words.txt")
     let batch = try await FileImportSource(url: url).loadCandidates()
 
-    #expect(batch.candidates.map(\.canonical) == PasteWordsParser.parse(text))
+    #expect(batch.candidates.map { $0.canonical } == PasteWordsParser.parse(text))
     #expect(
-      batch.candidates.map(\.canonical)
+      batch.candidates.map { $0.canonical }
         == ["Envious Labs", "C++", "and/or", "Smith; Jones", "GitHub"])
   }
 
@@ -121,7 +121,7 @@ struct ImportFileParserTests {
   func latin1TextIsAccepted() async throws {
     let url = try write(try #require("Beyoncé".data(using: .isoLatin1)), as: "legacy.txt")
     let batch = try await FileImportSource(url: url).loadCandidates()
-    #expect(batch.candidates.map(\.canonical) == ["Beyoncé"])
+    #expect(batch.candidates.map { $0.canonical } == ["Beyoncé"])
   }
 
   // MARK: - Unsupported and unreadable
@@ -251,4 +251,62 @@ struct ImportFileParserTests {
     #expect(ImportFileRegistry.v1.parser(for: text)?.identifier == "plain-text")
     #expect(ImportFileRegistry.v1.parser(for: try write("a", as: "a.csv")) == nil)
   }
+
+  // MARK: - Text encodings
+
+  @Test("a UTF-16 file imports its real words, not mojibake")
+  func utf16FileDecodesToRealWords() async throws {
+    // Latin-1 accepts every byte, so before the BOM check this decoded to
+    // "ÿþK\0u\0b\0…" and imported NUL-laden garbage as words.
+    let data = "Kubernetes\nPostgreSQL".data(using: .utf16LittleEndian)!
+    let withBOM = Data([0xFF, 0xFE]) + data
+    let url = try write(withBOM, as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Kubernetes", "PostgreSQL"])
+  }
+
+  @Test("a big-endian UTF-16 file decodes too")
+  func utf16BigEndianDecodes() async throws {
+    let data = "Kubernetes".data(using: .utf16BigEndian)!
+    let url = try write(Data([0xFE, 0xFF]) + data, as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Kubernetes"])
+  }
+
+  @Test("a UTF-8 byte-order mark is not imported as part of the first word")
+  func utf8ByteOrderMarkIsStripped() async throws {
+    // Left in, the mark rides along invisibly and "Kubernetes" imports as a
+    // DIFFERENT term than the same word typed anywhere else.
+    let url = try write(
+      Data([0xEF, 0xBB, 0xBF]) + Data("Kubernetes".utf8), as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Kubernetes"])
+  }
+
+  @Test("a legacy Latin-1 file still imports")
+  func latin1FileStillImports() async throws {
+    // The fallback must keep working for its real case; the fix narrows WHEN
+    // it is reached, it does not remove it.
+    let url = try write("Beyoncé\nJalapeño".data(using: .isoLatin1)!, as: "words.txt")
+
+    let candidates = try await FileImportSource(url: url).loadCandidates().candidates
+
+    #expect(candidates.map { $0.canonical } == ["Beyoncé", "Jalapeño"])
+  }
+
+  @Test("binary content is refused rather than laundered into words")
+  func binaryContentIsRefused() async throws {
+    let url = try write(Data([0x00, 0x01, 0x02, 0xFF, 0x00, 0x7F]), as: "words.txt")
+
+    await #expect(throws: ImportFileError.unreadable) {
+      try await FileImportSource(url: url).loadCandidates()
+    }
+  }
+
 }

--- a/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
@@ -24,8 +24,8 @@ struct PasteWordsImportSourceTests {
       ("Kubernetes\rAnthropic", ["Kubernetes", "Anthropic"]),
       ("Kubernetes, Anthropic,\n Qualtrics", ["Kubernetes", "Anthropic", "Qualtrics"]),
     ])
-  func supportedSeparatorsSplit(input: String, expected: [String]) {
-    #expect(PasteWordsParser.parse(input) == expected)
+  func supportedSeparatorsSplit(input: String, expected: [String]) throws {
+    #expect(try PasteWordsParser.parse(input) == expected)
   }
 
   @Test(
@@ -43,49 +43,49 @@ struct PasteWordsImportSourceTests {
       ("Smith; Jones", ["Smith; Jones"]),
       ("node.js", ["node.js"]),
     ])
-  func nonSeparatorsAreLeftIntact(input: String, expected: [String]) {
-    #expect(PasteWordsParser.parse(input) == expected)
+  func nonSeparatorsAreLeftIntact(input: String, expected: [String]) throws {
+    #expect(try PasteWordsParser.parse(input) == expected)
   }
 
   // MARK: - Trimming and empties
 
   @Test("surrounding whitespace is trimmed, inner spacing is kept")
-  func whitespaceIsTrimmedButNotCollapsed() {
-    #expect(PasteWordsParser.parse("  Envious Labs  ") == ["Envious Labs"])
+  func whitespaceIsTrimmedButNotCollapsed() throws {
+    #expect(try PasteWordsParser.parse("  Envious Labs  ") == ["Envious Labs"])
   }
 
   @Test("empty and whitespace-only pieces are dropped")
-  func emptyPiecesAreDropped() {
-    #expect(PasteWordsParser.parse("Kubernetes,,  ,\n\n,Anthropic") == ["Kubernetes", "Anthropic"])
+  func emptyPiecesAreDropped() throws {
+    #expect(try PasteWordsParser.parse("Kubernetes,,  ,\n\n,Anthropic") == ["Kubernetes", "Anthropic"])
   }
 
   @Test(
     "input with no words yields nothing rather than a blank row",
     arguments: ["", "   ", "\n\n", ",,,", " , \n , "])
-  func inputWithoutWordsYieldsNothing(input: String) {
-    #expect(PasteWordsParser.parse(input).isEmpty)
+  func inputWithoutWordsYieldsNothing(input: String) throws {
+    #expect(try PasteWordsParser.parse(input).isEmpty)
   }
 
   // MARK: - Deduplication
 
   @Test("a repeated word appears once, in its first spelling")
-  func withinPasteDedupPreservesFirstSpelling() {
-    #expect(PasteWordsParser.parse("GitHub\ngithub\nGITHUB") == ["GitHub"])
+  func withinPasteDedupPreservesFirstSpelling() throws {
+    #expect(try PasteWordsParser.parse("GitHub\ngithub\nGITHUB") == ["GitHub"])
   }
 
   @Test("dedup uses the same normalization the compare engine uses")
-  func dedupMatchesCompareEngineNormalization() {
+  func dedupMatchesCompareEngineNormalization() throws {
     // Both collapse to one key in the engine, so they must collapse here too;
     // otherwise the review screen would show two rows that persistence would
     // then refuse as duplicates.
-    let parsed = PasteWordsParser.parse("Claude Code\nClaude  Code")
+    let parsed = try PasteWordsParser.parse("Claude Code\nClaude  Code")
     #expect(parsed == ["Claude Code"])
   }
 
   @Test("distinct words are all kept, in paste order")
-  func distinctWordsKeepPasteOrder() {
+  func distinctWordsKeepPasteOrder() throws {
     #expect(
-      PasteWordsParser.parse("Qualtrics\nKubernetes\nAnthropic")
+      try PasteWordsParser.parse("Qualtrics\nKubernetes\nAnthropic")
         == ["Qualtrics", "Kubernetes", "Anthropic"])
   }
 

--- a/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
@@ -56,7 +56,8 @@ struct PasteWordsImportSourceTests {
 
   @Test("empty and whitespace-only pieces are dropped")
   func emptyPiecesAreDropped() throws {
-    #expect(try PasteWordsParser.parse("Kubernetes,,  ,\n\n,Anthropic") == ["Kubernetes", "Anthropic"])
+    #expect(
+      try PasteWordsParser.parse("Kubernetes,,  ,\n\n,Anthropic") == ["Kubernetes", "Anthropic"])
   }
 
   @Test(
@@ -64,6 +65,43 @@ struct PasteWordsImportSourceTests {
     arguments: ["", "   ", "\n\n", ",,,", " , \n , "])
   func inputWithoutWordsYieldsNothing(input: String) throws {
     #expect(try PasteWordsParser.parse(input).isEmpty)
+  }
+
+  /// The bug this freezes (cloud review, #1683): padding is not part of the
+  /// word, but the scan buffer counted it, so whitespace alone could exceed a
+  /// LENGTH ceiling and fail the whole paste as "too long". Spaces are not
+  /// separators — they have to survive inside a term like "Claude Code" — so
+  /// they accumulated. Every case here is padding a trim would erase.
+  @Test("padding is never mistaken for word length")
+  func paddingIsNotCountedTowardWordLength() throws {
+    let farPastTheCeiling = CustomWordsImportLimits.maximumStoredValueScalars * 6
+
+    // Whitespace alone imports nothing; it must not throw.
+    #expect(try PasteWordsParser.parse(String(repeating: " ", count: farPastTheCeiling)).isEmpty)
+
+    // A short word keeps its meaning however it is padded.
+    let pad = String(repeating: " ", count: farPastTheCeiling)
+    #expect(try PasteWordsParser.parse(pad + "Kubernetes") == ["Kubernetes"])
+    #expect(try PasteWordsParser.parse("Kubernetes" + pad) == ["Kubernetes"])
+    #expect(try PasteWordsParser.parse(pad + "Kubernetes" + pad) == ["Kubernetes"])
+    #expect(
+      try PasteWordsParser.parse(pad + "Claude Code" + pad + ",\n" + pad + "Anthropic")
+        == ["Claude Code", "Anthropic"])
+  }
+
+  /// The ceiling still applies to real content, so relaxing the padding rule
+  /// cannot become "no limit at all" — including when interior spacing is what
+  /// carries the entry past it.
+  @Test("a genuinely over-long entry is still refused")
+  func overLongEntryStillThrows() throws {
+    let tooLong = String(
+      repeating: "x", count: CustomWordsImportLimits.maximumStoredValueScalars + 1)
+    #expect(throws: (any Error).self) { try PasteWordsParser.parse(tooLong) }
+
+    let spacedOut = (0...CustomWordsImportLimits.maximumStoredValueScalars)
+      .map { _ in "x" }
+      .joined(separator: " ")
+    #expect(throws: (any Error).self) { try PasteWordsParser.parse(spacedOut) }
   }
 
   // MARK: - Deduplication

--- a/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
@@ -89,6 +89,20 @@ struct PasteWordsImportSourceTests {
         == ["Claude Code", "Anthropic"])
   }
 
+  /// Excluding padding from the LENGTH must not move the unbounded growth into
+  /// the hold: a term followed by an enormous whitespace run would otherwise
+  /// retain every scalar (Codex review, #1683). Refused when real content
+  /// follows the run, ignored as trailing padding when none does.
+  @Test("an enormous interior whitespace run is bounded, not retained")
+  func interiorWhitespaceRunIsBounded() throws {
+    let hugeRun = String(repeating: " ", count: 40_000)
+
+    #expect(throws: (any Error).self) { try PasteWordsParser.parse("x" + hugeRun + "y") }
+    // Nothing follows it, so it was trailing padding all along.
+    #expect(try PasteWordsParser.parse("x" + hugeRun) == ["x"])
+    #expect(try PasteWordsParser.parse("x" + hugeRun + ",y") == ["x", "y"])
+  }
+
   /// The ceiling still applies to real content, so relaxing the padding rule
   /// cannot become "no limit at all" — including when interior spacing is what
   /// carries the entry past it.


### PR DESCRIPTION
Part of #1619. Closes #1683.

Replaces #1685, which was branched off export and conflicted once export merged. Same content, same review history — replayed cleanly onto main.

## What this is

A file picker plus a format registry, so an exported file can be read back and a saved word list can be imported.

- **EnviousWispr words file** — bridges the transfer document. Without it, Export would be a promise the app cannot keep.
- **Plain text** — reuses the paste parser rather than a second implementation. A word list is a word list whether typed or saved to a file.

## The subtle one: exact type match

CSV and TSV *conform to* plain text. A conformance match handed spreadsheets to the plain-text parser — which splits on commas — so one row of `canonical,alias,category` would have imported **three words, header included**, silently corrupting the dictionary. Dispatch now matches the filename extension directly, so the refusal is structural: those extensions are claimed by no parser.

## Review record — 5 local rounds

| Round | Finding |
|---|---|
| r1 | Export stayed open after a corrupted launch; file reading blocked the main actor; no size or word-count limits; copy said "restore" while the flow cannot restore. |
| r2 | Paste was unbounded while files were capped, and re-parsed per keystroke. Valid foreign JSON reported as "damaged". |
| r3 | Failed refresh mutated state; cancel was not the no-op its own comment promised; the size limit had a stat-then-read race. |
| r4 | Reload and export-safety folded into one method, re-creating a stale-import loop. A single read could import a truncated prefix. |
| r5 | A repeat of a claim already rejected — verified unreproducible in both test environments. |

Plus a rebase fix: replaying onto main reintroduced an older corruption refusal inside the reload, which the export test caught on the first run.

## Terminology (founder, 2026-07-19)

The product has two ideas — import and export. Calling the exported file a "backup" invented a third and collided with the app's own invisible safety copy. User-facing copy says what the file is.

## Scope

CSV deliberately not shipped, dependency question left open — researched on #1683, including an option the plan missed (Apple's own `TabularData`). No new module for two parsers.

3,389 tests green.
