### PR TITLE
fix: tombstone built-in words when renaming to prevent duplicate display

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -861,6 +861,18 @@ public final class CustomWordsManager {
 
     var file = try loadFileForMutation()
 
+    // If editing a built-in word and changing its canonical form, tombstone the built-in
+    // to prevent it from appearing alongside the user override.
+    let originalWord = words[index]
+    if let builtin = Self.builtinDefaults.first(where: {
+      $0.word.canonical.caseInsensitiveCompare(originalWord.canonical) == .orderedSame
+    }),
+       builtin.word.canonical.caseInsensitiveCompare(word.canonical) != .orderedSame,
+       !file.deletedBuiltinIds.contains(builtin.id)
+    {
+      file.deletedBuiltinIds.append(builtin.id)
+    }
+
     // Check if this is a built-in word being edited — store as user override
     if let existingIdx = file.words.firstIndex(where: { $0.id == word.id }) {
       file.words[existingIdx] = sanitized


### PR DESCRIPTION
# fix: tombstone built-in words when renaming to prevent duplicate display

## Summary

Fixed a bug where renaming a built-in word would leave the original visible alongside the renamed version. When editing a built-in word and changing its canonical form, the update function was storing a user override but failing to tombstone the original built-in, causing both to appear in the UI.

Added tombstone logic to the `update(word:in:)` function that mirrors the pattern used in `commitImport`: when editing a built-in word and changing its canonical form, the built-in's ID is added to `deletedBuiltinIds` to hide it from the merged word list.

Fixes #1670

## Changes

- Added tombstone logic to `CustomWordsManager.update(word:in:)` to prevent built-in words from appearing alongside user overrides when their canonical form changes
- The logic checks if the original word matches a built-in, if the canonical form is changing, and if the built-in isn't already tombstoned before adding it to `deletedBuiltinIds`

## Testing

- Verified the fix addresses the exact issue described in #1670: renaming a built-in word now shows only the renamed version
- Confirmed alias-only edits (same canonical) still work correctly without tombstoning
- Verified the implementation mirrors the existing pattern in `commitImport` function
- Code compiles successfully with no syntax errors

### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.