### PR TITLE
Replace brittle live-query Discord download counter with owned Durable Object (#1691)

### DIFF
--- a/workers/download-counter/README.md
+++ b/workers/download-counter/README.md
@@ -1,0 +1,99 @@
+# Download-Notification Counter (issue #1691)
+
+Replaces a brittle PostHog Hog script that ran a live `SELECT count()` query
+against PostHog's own Query API on every download click — a query that shared
+PostHog's project-wide 3-concurrent-query ceiling with every other consumer in
+the account, and intermittently rendered `Download #?!` in Discord under load
+(confirmed via live Hog-function logs, 2026-07-19: 3x-retried 504s/timeouts).
+
+This Worker owns the count instead. PostHog's "Discord: Download Notification"
+CDP destination becomes a thin relay: it POSTs the event's fields here, and
+this Worker decides whether it qualifies, de-duplicates rage-clicks by IP,
+increments its own counter (a single Durable Object, `DownloadCounter`), and
+posts to Discord itself — with retry-safe delivery so a PostHog-side retry of
+the same event resumes instead of double-counting or silently dropping.
+
+Plan (design rationale, five grounded-review rounds, every finding and fix):
+`docs/feature-requests/issue-1691-2026-07-19-download-counter-worker.md`.
+
+## Why a Durable Object, not Workers KV
+
+Workers KV enforces a 60-second minimum write expiration and at most one
+write per second per key — both of which the counter's read-increment-write
+pattern would violate under the exact bursty retry traffic (PostHog's own 3x
+automatic fetch retry) this fix exists to survive. A Durable Object gives
+transactional, single-threaded-between-awaits storage instead.
+
+## Develop / test
+
+```bash
+cd workers/download-counter
+node --test
+```
+
+Pure-logic tests only (mocked Durable Object storage, mocked `fetch` for
+Discord) — no network calls, no PostHog, no real Discord posts.
+
+## Deploy (one-time)
+
+```bash
+cd workers/download-counter
+npx wrangler deploy
+
+# secrets (never committed):
+security find-generic-password -w -a m4pro_sv -s enviouswispr.discord-webhook-downloads | npx wrangler secret put DISCORD_WEBHOOK_URL
+openssl rand -hex 32 | npx wrangler secret put TRIGGER_SECRET
+openssl rand -hex 32 | npx wrangler secret put IP_HASH_SECRET
+
+# smoke environment (separate deployment, separate Durable Object namespace by
+# construction — see wrangler.toml comment):
+npx wrangler deploy --env smoke
+security find-generic-password -w -a m4pro_sv -s enviouswispr.discord-webhook-downloads | npx wrangler secret put DISCORD_WEBHOOK_URL --env smoke
+openssl rand -hex 32 | npx wrangler secret put TRIGGER_SECRET --env smoke
+openssl rand -hex 32 | npx wrangler secret put IP_HASH_SECRET --env smoke
+```
+
+## Pre-cutover smoke test
+
+Run against the isolated `smoke` deployment ONLY — never the production
+Worker, and never before the real production seed (§3/§9 of the plan explain
+why touching production before seeding would corrupt the real tally and lock
+out the real `/seed` call):
+
+```bash
+DOWNLOAD_COUNTER_SMOKE_URL="https://enviouswispr-download-counter-smoke.saurabhav.workers.dev" \
+DOWNLOAD_COUNTER_SMOKE_SECRET="<the smoke env's TRIGGER_SECRET>" \
+node workers/download-counter/live-endpoint-smoke.mjs
+```
+
+Confirms: a real Discord post lands (prefixed `🧪 SMOKE TEST — ignore`), a
+retry of the same event resumes without re-incrementing, a duplicate same-IP
+event is suppressed, and two genuinely concurrent same-event requests never
+both post (the one check an in-memory mock can't reproduce).
+
+## Production seed + cutover (one time, in this exact order)
+
+1. Measure the live true count (the exact query the old Hog script ran):
+   ```bash
+   ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- python3 -c "
+   import os, json, urllib.request
+   req = urllib.request.Request(
+       'https://us.posthog.com/api/projects/354235/query/',
+       data=json.dumps({'query': {'kind': 'HogQLQuery', 'query':
+           \"SELECT count() FROM events WHERE event='download_clicked' OR (event='download_redirect' AND coalesce(properties.excluded_reason,'')='')\"
+       }}).encode(),
+       headers={'Authorization': f'Bearer {os.environ[\"POSTHOG_KEY\"]}', 'Content-Type': 'application/json'},
+       method='POST',
+   )
+   print(json.loads(urllib.request.urlopen(req).read())['results'])
+   "
+   ```
+2. `POST /seed` on the PRODUCTION deployment with that number (secret-gated, refuses any call once the counter is initialized):
+   ```bash
+   curl -X POST https://enviouswispr-download-counter.saurabhav.workers.dev/seed \
+     -H "x-trigger-secret: <production TRIGGER_SECRET>" -H "Content-Type: application/json" \
+     -d '{"total": <N>}'
+   ```
+3. Verify the persisted value in the response.
+4. PATCH the PostHog Hog relay script (see plan §3/§10) to the new thin relay, saving a rollback backup first.
+5. Send one real PostHog destination test event; confirm the Discord post carries `<N>+1`.

--- a/workers/download-counter/README.md
+++ b/workers/download-counter/README.md
@@ -87,7 +87,15 @@ retry of the same event resumes without re-incrementing, a duplicate same-IP
 event is suppressed, and two genuinely concurrent same-event requests never
 both post (the one check an in-memory mock can't reproduce).
 
-## Production seed + cutover (one time, in this exact order)
+## Production seed + cutover
+
+**Prep first (any time before cutover — these don't touch the live counter and don't need to happen close to the cutover moment):**
+
+- In the PostHog CDP destination editor for "Discord: Download Notification" (`019d35b0-c128-0000-30a8-5fc2570a8a88`), send a test event through the CURRENT (old) script and confirm `event.uuid` is populated in the payload — the relay's retry-safety depends on it being a stable per-event id, not assumed. If it is ever absent, use `event.properties.$insert_id` instead and update `hog-relay.hog` accordingly before proceeding. This is safe pre-cutover: the old script doesn't touch the new Worker at all.
+- Save a rollback backup of the CURRENT live `hog`/`inputs`/`inputs_schema` fields: `GET /api/projects/354235/hog_functions/019d35b0-c128-0000-30a8-5fc2570a8a88/`.
+- Have the exact `POST /seed` and PATCH commands ready to paste (below), so the live sequence runs with no thinking time in between.
+
+**Then, in immediate succession — measuring and cutting over are two ends of the SAME race window** (a real download landing between "measure" and "PATCH" would be counted by the old script but never reach the new counter's seed, permanently undercounting by one). Minimizing the gap between these three steps is the actual mitigation; do not do anything else between them:
 
 1. Measure the live true count (the exact query the old Hog script ran):
    ```bash
@@ -111,8 +119,7 @@ both post (the one check an in-memory mock can't reproduce).
      -H "Content-Type: application/json" \
      -d '{"total": <N>}'
    ```
-3. Verify the persisted value in the response.
-4. In the PostHog CDP destination editor for "Discord: Download Notification" (`019d35b0-c128-0000-30a8-5fc2570a8a88`), send a real test event and confirm `event.uuid` is populated in the test payload — the relay's retry-safety depends on it being a stable per-event id, not assumed. If it is ever absent, use `event.properties.$insert_id` instead and update `hog-relay.hog` accordingly before proceeding.
-5. Save a rollback backup of the CURRENT live `hog`/`inputs`/`inputs_schema` fields (`GET /api/projects/354235/hog_functions/019d35b0-c128-0000-30a8-5fc2570a8a88/`) before mutating anything.
-6. PATCH the destination's `hog` field to the contents of `hog-relay.hog` (this file, committed) and `inputs_schema` to `[workerUrl (string, required), workerSecret (string, secret, required)]` — dropping `webhookUrl`/`phApiKey`. Set `workerUrl` to the production Worker's URL and `workerSecret` to the value in `enviouswispr.download-counter-trigger-secret`.
-7. Send one more real PostHog destination test event; confirm the Discord post carries `<N>+1`.
+   Verify the persisted value in the response.
+3. Immediately PATCH the destination's `hog` field to the contents of `hog-relay.hog` (this file, committed) and `inputs_schema` to `[workerUrl (string, required), workerSecret (string, secret, required)]` — dropping `webhookUrl`/`phApiKey`. Set `workerUrl` to the production Worker's URL and `workerSecret` to the value in `enviouswispr.download-counter-trigger-secret`.
+
+**Verify with a REAL download, never a synthetic PostHog test event.** Once the destination is PATCHed, PostHog's "send test event" feature would invoke the actual live relay against the production Worker — it is not a sandbox — permanently incrementing the real counter and posting an unmarked, indistinguishable-from-real message claiming someone downloaded EnviousWispr when nobody did. Instead, trigger (or wait for) one genuine download and confirm the Discord post carries `<N>+1`. This also verifies the full real pipeline end to end, not just the Worker in isolation.

--- a/workers/download-counter/README.md
+++ b/workers/download-counter/README.md
@@ -36,21 +36,37 @@ Discord) — no network calls, no PostHog, no real Discord posts.
 
 ## Deploy (one-time)
 
+Cloudflare secrets are write-only — `wrangler secret put` accepts a value but
+there is no way to read it back later. `TRIGGER_SECRET` is needed again by
+the smoke script and the PostHog Hog relay's `workerSecret` input, so it must
+be generated into Keychain FIRST (same pattern as the existing
+`enviouswispr.discord-webhook-*` items — see
+`~/.claude/knowledge/secrets-management.md` RULE: webhooks-read-from-keychain),
+then read from Keychain into `wrangler secret put`, never generated and
+piped away in one step:
+
 ```bash
 cd workers/download-counter
 npx wrangler deploy
 
-# secrets (never committed):
+# secrets (never committed; generate into Keychain first, THEN set on Cloudflare):
+security add-generic-password -U -A -a m4pro_sv -s enviouswispr.download-counter-trigger-secret -w "$(openssl rand -hex 32)"
+security add-generic-password -U -A -a m4pro_sv -s enviouswispr.download-counter-ip-hash-secret -w "$(openssl rand -hex 32)"
+
 security find-generic-password -w -a m4pro_sv -s enviouswispr.discord-webhook-downloads | npx wrangler secret put DISCORD_WEBHOOK_URL
-openssl rand -hex 32 | npx wrangler secret put TRIGGER_SECRET
-openssl rand -hex 32 | npx wrangler secret put IP_HASH_SECRET
+security find-generic-password -w -a m4pro_sv -s enviouswispr.download-counter-trigger-secret | npx wrangler secret put TRIGGER_SECRET
+security find-generic-password -w -a m4pro_sv -s enviouswispr.download-counter-ip-hash-secret | npx wrangler secret put IP_HASH_SECRET
 
 # smoke environment (separate deployment, separate Durable Object namespace by
-# construction — see wrangler.toml comment):
+# construction — see wrangler.toml comment). Distinct secrets from
+# production, so a leaked smoke secret can't authenticate against it:
 npx wrangler deploy --env smoke
+security add-generic-password -U -A -a m4pro_sv -s enviouswispr.download-counter-smoke-trigger-secret -w "$(openssl rand -hex 32)"
+security add-generic-password -U -A -a m4pro_sv -s enviouswispr.download-counter-smoke-ip-hash-secret -w "$(openssl rand -hex 32)"
+
 security find-generic-password -w -a m4pro_sv -s enviouswispr.discord-webhook-downloads | npx wrangler secret put DISCORD_WEBHOOK_URL --env smoke
-openssl rand -hex 32 | npx wrangler secret put TRIGGER_SECRET --env smoke
-openssl rand -hex 32 | npx wrangler secret put IP_HASH_SECRET --env smoke
+security find-generic-password -w -a m4pro_sv -s enviouswispr.download-counter-smoke-trigger-secret | npx wrangler secret put TRIGGER_SECRET --env smoke
+security find-generic-password -w -a m4pro_sv -s enviouswispr.download-counter-smoke-ip-hash-secret | npx wrangler secret put IP_HASH_SECRET --env smoke
 ```
 
 ## Pre-cutover smoke test
@@ -62,7 +78,7 @@ out the real `/seed` call):
 
 ```bash
 DOWNLOAD_COUNTER_SMOKE_URL="https://enviouswispr-download-counter-smoke.saurabhav.workers.dev" \
-DOWNLOAD_COUNTER_SMOKE_SECRET="<the smoke env's TRIGGER_SECRET>" \
+DOWNLOAD_COUNTER_SMOKE_SECRET="$(security find-generic-password -w -a m4pro_sv -s enviouswispr.download-counter-smoke-trigger-secret)" \
 node workers/download-counter/live-endpoint-smoke.mjs
 ```
 
@@ -91,9 +107,12 @@ both post (the one check an in-memory mock can't reproduce).
 2. `POST /seed` on the PRODUCTION deployment with that number (secret-gated, refuses any call once the counter is initialized):
    ```bash
    curl -X POST https://enviouswispr-download-counter.saurabhav.workers.dev/seed \
-     -H "x-trigger-secret: <production TRIGGER_SECRET>" -H "Content-Type: application/json" \
+     -H "x-trigger-secret: $(security find-generic-password -w -a m4pro_sv -s enviouswispr.download-counter-trigger-secret)" \
+     -H "Content-Type: application/json" \
      -d '{"total": <N>}'
    ```
 3. Verify the persisted value in the response.
-4. PATCH the PostHog Hog relay script (see plan §3/§10) to the new thin relay, saving a rollback backup first.
-5. Send one real PostHog destination test event; confirm the Discord post carries `<N>+1`.
+4. In the PostHog CDP destination editor for "Discord: Download Notification" (`019d35b0-c128-0000-30a8-5fc2570a8a88`), send a real test event and confirm `event.uuid` is populated in the test payload — the relay's retry-safety depends on it being a stable per-event id, not assumed. If it is ever absent, use `event.properties.$insert_id` instead and update `hog-relay.hog` accordingly before proceeding.
+5. Save a rollback backup of the CURRENT live `hog`/`inputs`/`inputs_schema` fields (`GET /api/projects/354235/hog_functions/019d35b0-c128-0000-30a8-5fc2570a8a88/`) before mutating anything.
+6. PATCH the destination's `hog` field to the contents of `hog-relay.hog` (this file, committed) and `inputs_schema` to `[workerUrl (string, required), workerSecret (string, secret, required)]` — dropping `webhookUrl`/`phApiKey`. Set `workerUrl` to the production Worker's URL and `workerSecret` to the value in `enviouswispr.download-counter-trigger-secret`.
+7. Send one more real PostHog destination test event; confirm the Discord post carries `<N>+1`.

--- a/workers/download-counter/hog-relay.hog
+++ b/workers/download-counter/hog-relay.hog
@@ -16,7 +16,11 @@ if (not match(inputs.workerUrl, '^https://.*')) {
     throw Error('Invalid worker URL. Must start with https://')
 }
 
-let res := fetch(inputs.workerUrl, {
+// inputs.workerUrl is the Worker's base URL (as documented in the README's
+// deploy/cutover steps); the actual route is appended here, not left to the
+// operator to remember — a bare POST to the base URL 404s, since the Worker
+// only serves /count and /seed.
+let res := fetch(f'{inputs.workerUrl}/count', {
     'method': 'POST',
     'headers': {
         'Content-Type': 'application/json',

--- a/workers/download-counter/hog-relay.hog
+++ b/workers/download-counter/hog-relay.hog
@@ -1,0 +1,44 @@
+// PostHog Hog script for the "Discord: Download Notification" CDP
+// destination (id 019d35b0-c128-0000-30a8-5fc2570a8a88). PATCH this in via
+// the PostHog API to replace the old live-query script, alongside
+// inputs_schema: [workerUrl (string, required), workerSecret (string,
+// secret, required)] — drops webhookUrl/phApiKey entirely, since the Worker
+// now owns the real Discord webhook and never queries PostHog itself.
+//
+// Trigger filter stays unchanged: fires on download_clicked and
+// download_redirect (see analytics-operations.md FACT:
+// download-notification-cdp for the live filters.events bytecode).
+//
+// Field mapping matches workers/download-counter/src/index.js's expected
+// /count body exactly (see REQUIRED_EVENT_TYPES / handleCount destructure).
+
+if (not match(inputs.workerUrl, '^https://.*')) {
+    throw Error('Invalid worker URL. Must start with https://')
+}
+
+let res := fetch(inputs.workerUrl, {
+    'method': 'POST',
+    'headers': {
+        'Content-Type': 'application/json',
+        'x-trigger-secret': inputs.workerSecret
+    },
+    'body': {
+        'eventId': event.uuid,
+        'event': event.event,
+        'ip': event.properties.$ip ?? '',
+        'city': event.properties.$geoip_city_name ?? '',
+        'country': event.properties.$geoip_country_name ?? '',
+        'countryCode': event.properties.$geoip_country_code ?? '',
+        'referrer': event.properties.$referrer ?? '',
+        'page': event.properties.page ?? '',
+        'browser': event.properties.$browser ?? '',
+        'os': event.properties.$os ?? '',
+        'lang': event.properties.$browser_language ?? '',
+        'excludedReason': event.properties.excluded_reason ?? '',
+        'sourceBucket': event.properties.source_bucket ?? ''
+    }
+})
+
+if (res.status >= 400) {
+    throw Error(f'Download counter Worker call failed: {res.status}')
+}

--- a/workers/download-counter/hog-relay.hog
+++ b/workers/download-counter/hog-relay.hog
@@ -15,6 +15,12 @@
 if (not match(inputs.workerUrl, '^https://.*')) {
     throw Error('Invalid worker URL. Must start with https://')
 }
+if (match(inputs.workerUrl, '/$')) {
+    // A trailing slash here would make the /count append below build "//count",
+    // which the Worker does not serve — reject explicitly rather than
+    // silently constructing a URL that 404s every real download.
+    throw Error('Invalid worker URL. Must not end with a trailing slash')
+}
 
 // inputs.workerUrl is the Worker's base URL (as documented in the README's
 // deploy/cutover steps); the actual route is appended here, not left to the

--- a/workers/download-counter/live-endpoint-smoke.mjs
+++ b/workers/download-counter/live-endpoint-smoke.mjs
@@ -1,0 +1,122 @@
+/**
+ * Live-endpoint smoke test for workers/download-counter (#1691).
+ *
+ * Targets the ISOLATED `smoke` Wrangler environment deployment ONLY — never
+ * the production Worker, and never before the real production seed step
+ * (plan §3/§9: touching production before seeding would corrupt the real
+ * tally and permanently lock out the real /seed call).
+ *
+ * Usage:
+ *   DOWNLOAD_COUNTER_SMOKE_URL="https://enviouswispr-download-counter-smoke.saurabhav.workers.dev" \
+ *   DOWNLOAD_COUNTER_SMOKE_SECRET="<smoke env TRIGGER_SECRET>" \
+ *   node workers/download-counter/live-endpoint-smoke.mjs
+ */
+
+const BASE_URL = process.env.DOWNLOAD_COUNTER_SMOKE_URL;
+const SECRET = process.env.DOWNLOAD_COUNTER_SMOKE_SECRET;
+
+if (!BASE_URL || !SECRET) {
+  console.error("Set DOWNLOAD_COUNTER_SMOKE_URL and DOWNLOAD_COUNTER_SMOKE_SECRET first.");
+  process.exit(1);
+}
+if (BASE_URL.includes("download-counter.") && !BASE_URL.includes("download-counter-smoke")) {
+  console.error(`Refusing to run against a non-smoke-looking URL: ${BASE_URL}`);
+  process.exit(1);
+}
+
+let failures = 0;
+
+function check(label, condition) {
+  if (condition) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    console.log(`  FAIL  ${label}`);
+    failures += 1;
+  }
+}
+
+function uniqueId(label) {
+  return `smoke-${label}-${process.pid}-${Math.floor(performance.now() * 1000)}`;
+}
+
+async function postCount(body) {
+  const res = await fetch(`${BASE_URL}/count`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-trigger-secret": SECRET },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json = null;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    // 502/503 responses have no body
+  }
+  return { status: res.status, json };
+}
+
+function smokeEvent(overrides = {}) {
+  return {
+    eventId: uniqueId("evt"),
+    event: "download_clicked",
+    ip: "203.0.113.1",
+    city: "Nowhere",
+    country: "Testland",
+    countryCode: "US",
+    referrer: "$direct",
+    page: "/",
+    browser: "SmokeTest",
+    os: "SmokeOS",
+    lang: "",
+    ...overrides,
+  };
+}
+
+async function main() {
+  console.log(`Smoke-testing ${BASE_URL}\n`);
+
+  console.log("1. A real new event posts to Discord and returns a total");
+  const first = await postCount(smokeEvent());
+  check("status 200", first.status === 200);
+  check("counted true", first.json?.counted === true);
+  check("total is a number", typeof first.json?.total === "number");
+
+  console.log("\n2. Retrying the SAME event resumes instead of re-incrementing");
+  const eventId = uniqueId("retry");
+  const original = smokeEvent({ eventId });
+  const attempt1 = await postCount(original);
+  const attempt2 = await postCount(original);
+  check("first attempt counted", attempt1.json?.counted === true);
+  check("retry reuses the same total", attempt2.json?.total === attempt1.json?.total);
+  check("retry reason is already-delivered", attempt2.json?.reason === "already-delivered");
+
+  console.log("\n3. A second distinct event from the same IP within the dedup window is suppressed");
+  const sharedIp = "203.0.113.55";
+  const dupA = await postCount(smokeEvent({ eventId: uniqueId("dup-a"), ip: sharedIp }));
+  const dupB = await postCount(smokeEvent({ eventId: uniqueId("dup-b"), ip: sharedIp }));
+  check("first counts", dupA.json?.counted === true);
+  check("second is suppressed as a duplicate", dupB.json?.counted === false && dupB.json?.reason === "duplicate");
+
+  console.log("\n4. Two genuinely concurrent requests for the SAME event never both post");
+  const concurrentId = uniqueId("concurrent");
+  const [concA, concB] = await Promise.all([
+    postCount(smokeEvent({ eventId: concurrentId, ip: "203.0.113.77" })),
+    postCount(smokeEvent({ eventId: concurrentId, ip: "203.0.113.77" })),
+  ]);
+  const statuses = [concA.status, concB.status].sort();
+  check(
+    "exactly one of the two succeeded (200) and the other was told to back off (503)",
+    (statuses[0] === 200 && statuses[1] === 503) || (statuses[0] === 200 && statuses[1] === 200),
+  );
+  if (statuses[0] === 200 && statuses[1] === 200) {
+    check("if both eventually succeeded, they report the SAME total (no double count)", concA.json?.total === concB.json?.total);
+  }
+
+  console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("Smoke test crashed:", err);
+  process.exit(1);
+});

--- a/workers/download-counter/live-endpoint-smoke.mjs
+++ b/workers/download-counter/live-endpoint-smoke.mjs
@@ -39,6 +39,18 @@ function uniqueId(label) {
   return `smoke-${label}-${process.pid}-${Math.floor(performance.now() * 1000)}`;
 }
 
+// Fresh octet per run (not a fixed literal): if this script is re-run within
+// the 30s dedup window, reusing the same hardcoded IPs would make the FIRST
+// request of several sections look like a duplicate of the PRIOR run's
+// event on that same IP, failing the smoke test on a healthy deployment.
+// Each call returns a distinct octet for one run, so cross-run collisions
+// require the exact same octet to be drawn twice inside the same window —
+// negligible, and irrelevant to correctness (a false, rare re-run collision
+// is a flaky smoke run, not a production defect).
+function freshOctet() {
+  return 1 + Math.floor(Math.random() * 254);
+}
+
 async function postCount(body) {
   const res = await fetch(`${BASE_URL}/count`, {
     method: "POST",
@@ -59,7 +71,6 @@ function smokeEvent(overrides = {}) {
   return {
     eventId: uniqueId("evt"),
     event: "download_clicked",
-    ip: "203.0.113.1",
     city: "Nowhere",
     country: "Testland",
     countryCode: "US",
@@ -76,17 +87,14 @@ async function main() {
   console.log(`Smoke-testing ${BASE_URL}\n`);
 
   console.log("1. A real new event posts to Discord and returns a total");
-  const first = await postCount(smokeEvent());
+  const first = await postCount(smokeEvent({ ip: `203.0.113.${freshOctet()}` }));
   check("status 200", first.status === 200);
   check("counted true", first.json?.counted === true);
   check("total is a number", typeof first.json?.total === "number");
 
   console.log("\n2. Retrying the SAME event resumes instead of re-incrementing");
   const eventId = uniqueId("retry");
-  // Distinct IP from section 1's default (203.0.113.1): sections run within the
-  // same 30s dedup window, so sharing an IP here would suppress attempt1 as a
-  // duplicate of section 1's event and break this test deterministically.
-  const original = smokeEvent({ eventId, ip: "203.0.113.2" });
+  const original = smokeEvent({ eventId, ip: `203.0.114.${freshOctet()}` });
   const attempt1 = await postCount(original);
   const attempt2 = await postCount(original);
   check("first attempt counted", attempt1.json?.counted === true);
@@ -94,7 +102,7 @@ async function main() {
   check("retry reason is already-delivered", attempt2.json?.reason === "already-delivered");
 
   console.log("\n3. A second distinct event from the same IP within the dedup window is suppressed");
-  const sharedIp = "203.0.113.55";
+  const sharedIp = `203.0.115.${freshOctet()}`;
   const dupA = await postCount(smokeEvent({ eventId: uniqueId("dup-a"), ip: sharedIp }));
   const dupB = await postCount(smokeEvent({ eventId: uniqueId("dup-b"), ip: sharedIp }));
   check("first counts", dupA.json?.counted === true);
@@ -102,9 +110,10 @@ async function main() {
 
   console.log("\n4. Two genuinely concurrent requests for the SAME event never both post");
   const concurrentId = uniqueId("concurrent");
+  const concurrentIp = `203.0.116.${freshOctet()}`;
   const [concA, concB] = await Promise.all([
-    postCount(smokeEvent({ eventId: concurrentId, ip: "203.0.113.77" })),
-    postCount(smokeEvent({ eventId: concurrentId, ip: "203.0.113.77" })),
+    postCount(smokeEvent({ eventId: concurrentId, ip: concurrentIp })),
+    postCount(smokeEvent({ eventId: concurrentId, ip: concurrentIp })),
   ]);
   const statuses = [concA.status, concB.status].sort();
   check(

--- a/workers/download-counter/live-endpoint-smoke.mjs
+++ b/workers/download-counter/live-endpoint-smoke.mjs
@@ -83,7 +83,10 @@ async function main() {
 
   console.log("\n2. Retrying the SAME event resumes instead of re-incrementing");
   const eventId = uniqueId("retry");
-  const original = smokeEvent({ eventId });
+  // Distinct IP from section 1's default (203.0.113.1): sections run within the
+  // same 30s dedup window, so sharing an IP here would suppress attempt1 as a
+  // duplicate of section 1's event and break this test deterministically.
+  const original = smokeEvent({ eventId, ip: "203.0.113.2" });
   const attempt1 = await postCount(original);
   const attempt2 = await postCount(original);
   check("first attempt counted", attempt1.json?.counted === true);
@@ -109,7 +112,11 @@ async function main() {
     (statuses[0] === 200 && statuses[1] === 503) || (statuses[0] === 200 && statuses[1] === 200),
   );
   if (statuses[0] === 200 && statuses[1] === 200) {
-    check("if both eventually succeeded, they report the SAME total (no double count)", concA.json?.total === concB.json?.total);
+    const reasons = [concA.json?.reason, concB.json?.reason].sort();
+    check(
+      "if both returned 200, exactly one is the original delivery and the other reused it (never two independent posts)",
+      concA.json?.total === concB.json?.total && reasons[0] === "already-delivered" && reasons[1] === undefined,
+    );
   }
 
   console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);

--- a/workers/download-counter/package.json
+++ b/workers/download-counter/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "enviouswispr-download-counter",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/workers/download-counter/src/index.js
+++ b/workers/download-counter/src/index.js
@@ -44,6 +44,34 @@ const DISCORD_CONTENT_MAX_LEN = 2000;
 // retry). See postToDiscord's classification.
 const WEBHOOK_CONFIG_ERROR_STATUSES = new Set([401, 403, 404]);
 
+// Delivery records are retained (not pruned after minutes) specifically to
+// preserve retry-safety — see the design note at their write site. But
+// "retained" must not mean "forever, unbounded": 90 days is far longer than
+// any realistic PostHog retry/replay window (observed retries resolve in
+// seconds), so pruning past it is pure storage hygiene, not a replay-safety
+// change. A small opportunistic, bounded sweep (not a scheduled job — none
+// is needed at real volume, ~1-5 downloads/day) keeps the singleton
+// Durable Object's storage from growing without bound over years.
+const DELIVERY_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+const PRUNE_SAMPLE_SIZE = 50;
+const PRUNE_PROBABILITY = 0.02;
+
+// Exported for direct unit testing — the real call site is probability-gated
+// (PRUNE_PROBABILITY), so a behavioral test through handleCount would be
+// flaky without this.
+export async function pruneOldDeliveryRecords(storage, now) {
+  const entries = await storage.list({ prefix: "delivery:", limit: PRUNE_SAMPLE_SIZE });
+  const staleKeys = [];
+  for (const [key, value] of entries) {
+    if (value && typeof value.createdAt === "number" && now - value.createdAt > DELIVERY_RETENTION_MS) {
+      staleKeys.push(key);
+    }
+  }
+  if (staleKeys.length > 0) {
+    await storage.delete(staleKeys);
+  }
+}
+
 // Off-site source_bucket -> human label, ported verbatim from the live Hog
 // script (pulled via the PostHog API, 2026-07-19) so the Discord message text
 // is byte-identical after the cutover.
@@ -248,6 +276,9 @@ export class DownloadCounter {
       // not at all — the counter is never persisted separately from its
       // reservation.
       await storage.put(batch);
+      if (Math.random() < PRUNE_PROBABILITY) {
+        await pruneOldDeliveryRecords(storage, now);
+      }
       return { record: newRecord };
     });
 

--- a/workers/download-counter/src/index.js
+++ b/workers/download-counter/src/index.js
@@ -205,7 +205,7 @@ export class DownloadCounter {
       await storage.put(batch);
     }
 
-    const content = formatMessage({
+    let content = formatMessage({
       total: record.total,
       isOffsite: event === "download_redirect",
       city,
@@ -218,6 +218,12 @@ export class DownloadCounter {
       lang,
       sourceBucket,
     });
+    // The smoke environment shares the production Discord webhook (README) so
+    // it can prove a real post lands; every post it makes must be visually
+    // unmistakable from a real download in the shared channel.
+    if (this.env.SMOKE === "true") {
+      content = `🧪 SMOKE TEST — ignore\n${content}`;
+    }
 
     const result = await postToDiscord(this.env.DISCORD_WEBHOOK_URL, content, {
       timeoutMs: DISCORD_ATTEMPT_TIMEOUT_MS,

--- a/workers/download-counter/src/index.js
+++ b/workers/download-counter/src/index.js
@@ -1,0 +1,335 @@
+/**
+ * EnviousWispr Download-Notification Counter (#1691)
+ *
+ * Replaces a brittle Hog-script live PostHog query (which shared PostHog's
+ * project-wide 3-concurrent-query ceiling and intermittently rendered
+ * "Download #?!" in Discord) with an owned, always-fast counter. PostHog's
+ * CDP destination becomes a thin relay: it POSTs the event's fields here,
+ * and this Worker owns counting, IP-based rage-click dedup, retry-safe
+ * Discord delivery, and message formatting.
+ *
+ * Plan (design rationale, five grounded-review rounds, all findings):
+ * docs/feature-requests/issue-1691-2026-07-19-download-counter-worker.md
+ *
+ * The counter, IP-dedup markers, and per-event Discord-delivery state all
+ * live in one singleton Durable Object (`DownloadCounter`, instance name
+ * always "global" for production traffic — never taken from the request).
+ * A Durable Object was required, not Workers KV: KV enforces a 60s minimum
+ * write TTL and 1 write/sec/key, both of which the counter's
+ * read-increment-write pattern would violate under PostHog's own retry
+ * bursts (grounded review round 1).
+ */
+
+const REQUIRED_EVENT_TYPES = ["download_clicked", "download_redirect"];
+const MAX_EVENT_ID_LEN = 200;
+
+const LEASE_MS = 15_000;
+const DISCORD_ATTEMPT_TIMEOUT_MS = 4_000;
+const MAX_RETRY_DELAY_MS = 2_000;
+const DEDUP_WINDOW_MS = 30_000;
+
+// Off-site source_bucket -> human label, ported verbatim from the live Hog
+// script (pulled via the PostHog API, 2026-07-19) so the Discord message text
+// is byte-identical after the cutover.
+const SOURCE_LABELS = {
+  github_readme: "the GitHub README",
+  github_release: "GitHub",
+  blog: "the blog",
+  directory_alternativeto: "AlternativeTo",
+  directory_macupdate: "MacUpdate",
+  directory_other: "a directory listing",
+  linkedin: "LinkedIn",
+  reddit: "Reddit",
+  x: "X",
+  youtube: "YouTube",
+  medium: "Medium",
+  facebook: "Facebook",
+  hackernews: "Hacker News",
+  producthunt: "Product Hunt",
+  discord: "Discord",
+  ai_assistant: "an AI assistant (ChatGPT/Claude/etc.)",
+  newsletter: "a newsletter",
+  direct_or_dark: "a direct or untracked link",
+  unknown_referrer: "an unrecognized site",
+};
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (url.pathname !== "/count" && url.pathname !== "/seed") {
+      return new Response("not found\n", { status: 404 });
+    }
+    if (request.method !== "POST") {
+      return new Response("method not allowed\n", { status: 405, headers: { Allow: "POST" } });
+    }
+
+    const provided = request.headers.get("x-trigger-secret");
+    if (!env.TRIGGER_SECRET || provided !== env.TRIGGER_SECRET) {
+      return new Response("unauthorized\n", { status: 401 });
+    }
+
+    let payload;
+    try {
+      payload = await request.json();
+    } catch {
+      return Response.json({ error: "invalid_json" }, { status: 400 });
+    }
+
+    if (url.pathname === "/seed") {
+      if (!Number.isInteger(payload.total) || payload.total < 0) {
+        return Response.json({ error: "invalid_total" }, { status: 400 });
+      }
+    } else {
+      if (!REQUIRED_EVENT_TYPES.includes(payload.event)) {
+        return Response.json({ error: "invalid_event" }, { status: 400 });
+      }
+      if (
+        typeof payload.eventId !== "string" ||
+        payload.eventId.length === 0 ||
+        payload.eventId.length > MAX_EVENT_ID_LEN
+      ) {
+        return Response.json({ error: "invalid_event_id" }, { status: 400 });
+      }
+    }
+
+    // Durable Object instance is always "global" — never taken from the
+    // request. Isolation for the smoke-test script comes from a separate
+    // Wrangler environment (its own Worker deployment + DO namespace), not
+    // from a caller-supplied instance name (grounded review round 4 rejected
+    // an earlier design that accepted one here as a production trust-boundary
+    // risk).
+    const id = env.DOWNLOAD_COUNTER.idFromName("global");
+    const stub = env.DOWNLOAD_COUNTER.get(id);
+    return stub.fetch(`https://download-counter${url.pathname}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  },
+};
+
+export class DownloadCounter {
+  constructor(ctx, env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    const payload = await request.json();
+
+    if (url.pathname === "/seed") {
+      return this.handleSeed(payload);
+    }
+    return this.handleCount(payload);
+  }
+
+  async handleSeed(payload) {
+    const storage = this.ctx.storage;
+    const existingCounter = await storage.get("counter");
+    const existingDeliveries = await storage.list({ prefix: "delivery:", limit: 1 });
+    if (existingCounter !== undefined || existingDeliveries.size > 0) {
+      return Response.json({ error: "already_seeded" }, { status: 409 });
+    }
+    await storage.put("counter", payload.total);
+    return Response.json({ total: payload.total });
+  }
+
+  async handleCount(payload) {
+    const {
+      eventId,
+      event,
+      ip,
+      excludedReason,
+      city,
+      country,
+      countryCode,
+      referrer,
+      page,
+      browser,
+      os,
+      lang,
+      sourceBucket,
+    } = payload;
+
+    // Qualification (#1243's definition, preserved exactly): on-site always
+    // qualifies; off-site qualifies only when not bot-excluded. excludedReason
+    // is never applied to download_clicked.
+    const qualifies =
+      event === "download_clicked" ||
+      (event === "download_redirect" && (excludedReason == null || excludedReason === ""));
+    if (!qualifies) {
+      return Response.json({ counted: false, reason: "excluded" });
+    }
+
+    const storage = this.ctx.storage;
+    const now = Date.now();
+    const deliveryKey = `delivery:${eventId}`;
+    let record = await storage.get(deliveryKey);
+
+    if (record) {
+      if (record.status === "delivered") {
+        return Response.json({ counted: true, total: record.total, reason: "already-delivered" });
+      }
+      if (record.status === "failed") {
+        return Response.json({ counted: true, total: record.total, reason: "discord-rejected" });
+      }
+      // status === "pending": either a legitimate retry to resume, or a
+      // genuinely concurrent overlapping request for the same event (a
+      // Durable Object yields control on `await fetch()`, so two requests
+      // for the same eventId can interleave around the Discord call).
+      if (record.leaseUntil > now) {
+        return new Response(null, { status: 503, headers: { "Retry-After": "2" } });
+      }
+      record = { ...record, leaseUntil: now + LEASE_MS };
+      await storage.put(deliveryKey, record);
+    } else {
+      // Genuinely new event.
+      let ipHmac = null;
+      if (ip) {
+        ipHmac = await hmacIp(ip, this.env.IP_HASH_SECRET);
+        const seenAt = await storage.get(`seen:${ipHmac}`);
+        if (seenAt !== undefined && now - seenAt < DEDUP_WINDOW_MS) {
+          return Response.json({ counted: false, reason: "duplicate" });
+        }
+      }
+      const storedCounter = (await storage.get("counter")) ?? 0;
+      const total = storedCounter + 1;
+      record = { status: "pending", total, leaseUntil: now + LEASE_MS, createdAt: now };
+      const batch = { counter: total, [deliveryKey]: record };
+      if (ipHmac) batch[`seen:${ipHmac}`] = now;
+      // Atomic: counter, seen marker, and delivery record commit together or
+      // not at all — the counter is never persisted separately from its
+      // reservation.
+      await storage.put(batch);
+    }
+
+    const content = formatMessage({
+      total: record.total,
+      isOffsite: event === "download_redirect",
+      city,
+      country,
+      countryCode,
+      referrer,
+      page,
+      browser,
+      os,
+      lang,
+      sourceBucket,
+    });
+
+    const result = await postToDiscord(this.env.DISCORD_WEBHOOK_URL, content, {
+      timeoutMs: DISCORD_ATTEMPT_TIMEOUT_MS,
+      maxRetryDelayMs: MAX_RETRY_DELAY_MS,
+    });
+
+    if (result.outcome === "delivered") {
+      await storage.put(deliveryKey, { ...record, status: "delivered" });
+      return Response.json({ counted: true, total: record.total });
+    }
+
+    if (result.outcome === "rejected") {
+      await storage.put(deliveryKey, { ...record, status: "failed", failedStatus: result.status });
+      console.error(
+        `download-counter: Discord permanently rejected post (status ${result.status}) for eventId=${eventId}, total=${record.total}`,
+      );
+      return Response.json({ counted: true, total: record.total, reason: "discord-rejected" });
+    }
+
+    // Exhausted network/429/5xx retries. Clear the lease immediately (rather
+    // than leaving it to expire naturally) so PostHog's own next retry can
+    // reacquire it right away instead of waiting out the rest of LEASE_MS.
+    await storage.put(deliveryKey, { ...record, leaseUntil: 0 });
+    return new Response(null, { status: 502 });
+  }
+}
+
+async function hmacIp(ip, secret) {
+  if (!secret) {
+    throw new Error("IP_HASH_SECRET is not configured");
+  }
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(ip));
+  return Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function formatMessage({ total, isOffsite, city, country, countryCode, referrer, page, browser, os, lang, sourceBucket }) {
+  const resolvedCountry = country || "Unknown location";
+  const location = city ? `${city}, ${resolvedCountry}` : resolvedCountry;
+  const flag = countryCode ? `:flag_${countryCode.toLowerCase()}: ` : "";
+  const referrerValue = referrer && referrer !== "$direct" ? referrer : "Direct visit";
+
+  if (isOffsite) {
+    const sourceLabel = SOURCE_LABELS[sourceBucket] ?? "an off-site link";
+    return (
+      `:tada: **Download #${total}!** Someone just grabbed EnviousWispr\n` +
+      `> ${flag}**Location:** ${location}\n` +
+      `> **Source:** ${sourceLabel}\n` +
+      `> **Referred by:** ${referrerValue}`
+    );
+  }
+
+  const resolvedOs = os || "Unknown";
+  const resolvedBrowser = browser || "Unknown";
+  const resolvedPage = page || "/";
+  let content =
+    `:tada: **Download #${total}!** Someone just grabbed EnviousWispr\n` +
+    `> ${flag}**Location:** ${location}\n` +
+    `> **Platform:** ${resolvedOs} / ${resolvedBrowser}\n` +
+    `> **Referred by:** ${referrerValue}\n` +
+    `> **Page:** ${resolvedPage}`;
+  if (lang) {
+    content += `\n> **Language:** ${lang}`;
+  }
+  return content;
+}
+
+async function postToDiscord(webhookUrl, content, { timeoutMs, maxRetryDelayMs }) {
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content }),
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+
+      if (res.status === 200 || res.status === 204) {
+        return { outcome: "delivered" };
+      }
+      if (res.status !== 429 && res.status < 500) {
+        return { outcome: "rejected", status: res.status };
+      }
+      if (attempt === 2) {
+        return { outcome: "exhausted" };
+      }
+      const retryAfterHeader = res.headers.get("Retry-After");
+      const retryAfterMs = retryAfterHeader ? Number(retryAfterHeader) * 1000 : maxRetryDelayMs;
+      await sleep(Math.min(Math.max(retryAfterMs, 0), maxRetryDelayMs));
+    } catch {
+      clearTimeout(timer);
+      if (attempt === 2) {
+        return { outcome: "exhausted" };
+      }
+      await sleep(maxRetryDelayMs);
+    }
+  }
+  return { outcome: "exhausted" };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/workers/download-counter/src/index.js
+++ b/workers/download-counter/src/index.js
@@ -38,6 +38,12 @@ const DEDUP_WINDOW_MS = 30_000;
 // crafted "@everyone" in a referrer would actually ping the channel.
 const DISCORD_CONTENT_MAX_LEN = 2000;
 
+// Discord responses indicating the webhook URL/token itself is wrong, stale,
+// or revoked (a config problem, recoverable by fixing the secret) rather than
+// a defect in this specific event's content (which would never resolve on
+// retry). See postToDiscord's classification.
+const WEBHOOK_CONFIG_ERROR_STATUSES = new Set([401, 403, 404]);
+
 // Off-site source_bucket -> human label, ported verbatim from the live Hog
 // script (pulled via the PostHog API, 2026-07-19) so the Discord message text
 // is byte-identical after the cutover.
@@ -137,13 +143,19 @@ export class DownloadCounter {
 
   async handleSeed(payload) {
     const storage = this.ctx.storage;
-    const existingCounter = await storage.get("counter");
-    const existingDeliveries = await storage.list({ prefix: "delivery:", limit: 1 });
-    if (existingCounter !== undefined || existingDeliveries.size > 0) {
-      return Response.json({ error: "already_seeded" }, { status: 409 });
-    }
-    await storage.put("counter", payload.total);
-    return Response.json({ total: payload.total });
+    // Same reasoning as handleCount: the check-then-write must be one
+    // indivisible step, or two overlapping /seed calls (or a /seed racing
+    // the very first real /count) could both observe "uninitialized" and
+    // both write, silently corrupting the one-time bootstrap contract.
+    return this.ctx.blockConcurrencyWhile(async () => {
+      const existingCounter = await storage.get("counter");
+      const existingDeliveries = await storage.list({ prefix: "delivery:", limit: 1 });
+      if (existingCounter !== undefined || existingDeliveries.size > 0) {
+        return Response.json({ error: "already_seeded" }, { status: 409 });
+      }
+      await storage.put("counter", payload.total);
+      return Response.json({ total: payload.total });
+    });
   }
 
   async handleCount(payload) {
@@ -363,6 +375,16 @@ async function postToDiscord(webhookUrl, content, { timeoutMs, maxRetryDelayMs }
 
       if (res.status === 200 || res.status === 204) {
         return { outcome: "delivered" };
+      }
+      // 401/403/404 mean the webhook URL/token itself is wrong, stale, or
+      // revoked — a config problem, not a defect in THIS event's content.
+      // Retrying the same request won't help immediately, but the config can
+      // be fixed later, and a permanently-"failed" delivery record would
+      // never resume even after that fix. Treat these as retryable (same
+      // outcome as an exhausted network/5xx attempt) rather than a permanent
+      // per-event rejection.
+      if (WEBHOOK_CONFIG_ERROR_STATUSES.has(res.status)) {
+        return { outcome: "exhausted" };
       }
       if (res.status !== 429 && res.status < 500) {
         return { outcome: "rejected", status: res.status };

--- a/workers/download-counter/src/index.js
+++ b/workers/download-counter/src/index.js
@@ -28,6 +28,16 @@ const DISCORD_ATTEMPT_TIMEOUT_MS = 4_000;
 const MAX_RETRY_DELAY_MS = 2_000;
 const DEDUP_WINDOW_MS = 30_000;
 
+// Discord webhook `content` hard-fails with 400 above 2000 characters
+// (discord-webhooks.md FACT: posting-contract). Every field folded into the
+// message is forwarded, attacker-influenceable request data (referrer, page,
+// source), so both a length cap and disabling mention parsing are required —
+// not just a formatting nicety. Without a cap, an oversized field would
+// permanently mark a real download's delivery "failed" (never retried) even
+// though the counter had already advanced; without allowed_mentions, a
+// crafted "@everyone" in a referrer would actually ping the channel.
+const DISCORD_CONTENT_MAX_LEN = 2000;
+
 // Off-site source_bucket -> human label, ported verbatim from the live Hog
 // script (pulled via the PostHog API, 2026-07-19) so the Discord message text
 // is byte-identical after the cutover.
@@ -164,46 +174,75 @@ export class DownloadCounter {
     }
 
     const storage = this.ctx.storage;
-    const now = Date.now();
     const deliveryKey = `delivery:${eventId}`;
-    let record = await storage.get(deliveryKey);
 
-    if (record) {
-      if (record.status === "delivered") {
-        return Response.json({ counted: true, total: record.total, reason: "already-delivered" });
+    // The read (does this event/IP already have state?), the decision (is it
+    // excluded/duplicate/already-resolved?), and the reservation write must
+    // all happen as one indivisible step. A Durable Object's storage.put is
+    // atomic, but storage.get + a decision + a later storage.put is NOT —
+    // Durable Objects are single-threaded but can still interleave two
+    // DIFFERENT requests across `await` points (confirmed: Cloudflare's own
+    // docs state "multiple request events may still be processed
+    // out-of-order"). Without blockConcurrencyWhile, two genuinely different
+    // new events overlapping here could both read the same stale counter and
+    // both reserve the same total, and two events sharing an IP could both
+    // pass the dedup check before either had written its `seen:` marker.
+    // blockConcurrencyWhile defers every OTHER request to this Durable Object
+    // instance until this callback resolves; the (potentially slow) Discord
+    // POST below stays outside it on purpose, since overlapping requests
+    // there are expected and already handled by the posting lease.
+    const decision = await this.ctx.blockConcurrencyWhile(async () => {
+      const now = Date.now();
+      let record = await storage.get(deliveryKey);
+
+      if (record) {
+        if (record.status === "delivered") {
+          return {
+            respond: Response.json({ counted: true, total: record.total, reason: "already-delivered" }),
+          };
+        }
+        if (record.status === "failed") {
+          return {
+            respond: Response.json({ counted: true, total: record.total, reason: "discord-rejected" }),
+          };
+        }
+        // status === "pending": either a legitimate retry to resume, or a
+        // genuinely concurrent overlapping request for the same event (a
+        // Durable Object yields control on `await fetch()`, so two requests
+        // for the same eventId can interleave around the Discord call).
+        if (record.leaseUntil > now) {
+          return { respond: new Response(null, { status: 503, headers: { "Retry-After": "2" } }) };
+        }
+        record = { ...record, leaseUntil: now + LEASE_MS };
+        await storage.put(deliveryKey, record);
+        return { record };
       }
-      if (record.status === "failed") {
-        return Response.json({ counted: true, total: record.total, reason: "discord-rejected" });
-      }
-      // status === "pending": either a legitimate retry to resume, or a
-      // genuinely concurrent overlapping request for the same event (a
-      // Durable Object yields control on `await fetch()`, so two requests
-      // for the same eventId can interleave around the Discord call).
-      if (record.leaseUntil > now) {
-        return new Response(null, { status: 503, headers: { "Retry-After": "2" } });
-      }
-      record = { ...record, leaseUntil: now + LEASE_MS };
-      await storage.put(deliveryKey, record);
-    } else {
+
       // Genuinely new event.
       let ipHmac = null;
       if (ip) {
         ipHmac = await hmacIp(ip, this.env.IP_HASH_SECRET);
         const seenAt = await storage.get(`seen:${ipHmac}`);
         if (seenAt !== undefined && now - seenAt < DEDUP_WINDOW_MS) {
-          return Response.json({ counted: false, reason: "duplicate" });
+          return { respond: Response.json({ counted: false, reason: "duplicate" }) };
         }
       }
       const storedCounter = (await storage.get("counter")) ?? 0;
       const total = storedCounter + 1;
-      record = { status: "pending", total, leaseUntil: now + LEASE_MS, createdAt: now };
-      const batch = { counter: total, [deliveryKey]: record };
+      const newRecord = { status: "pending", total, leaseUntil: now + LEASE_MS, createdAt: now };
+      const batch = { counter: total, [deliveryKey]: newRecord };
       if (ipHmac) batch[`seen:${ipHmac}`] = now;
       // Atomic: counter, seen marker, and delivery record commit together or
       // not at all — the counter is never persisted separately from its
       // reservation.
       await storage.put(batch);
+      return { record: newRecord };
+    });
+
+    if (decision.respond) {
+      return decision.respond;
     }
+    const record = decision.record;
 
     let content = formatMessage({
       total: record.total,
@@ -300,7 +339,16 @@ function formatMessage({ total, isOffsite, city, country, countryCode, referrer,
   return content;
 }
 
+function truncateForDiscord(content) {
+  if (content.length <= DISCORD_CONTENT_MAX_LEN) {
+    return content;
+  }
+  const suffix = "\n> …(truncated)";
+  return content.slice(0, DISCORD_CONTENT_MAX_LEN - suffix.length) + suffix;
+}
+
 async function postToDiscord(webhookUrl, content, { timeoutMs, maxRetryDelayMs }) {
+  const safeContent = truncateForDiscord(content);
   for (let attempt = 1; attempt <= 2; attempt += 1) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -308,7 +356,7 @@ async function postToDiscord(webhookUrl, content, { timeoutMs, maxRetryDelayMs }
       const res = await fetch(webhookUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ content }),
+        body: JSON.stringify({ content: safeContent, allowed_mentions: { parse: [] } }),
         signal: controller.signal,
       });
       clearTimeout(timer);

--- a/workers/download-counter/src/index.js
+++ b/workers/download-counter/src/index.js
@@ -56,6 +56,14 @@ const DELIVERY_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const PRUNE_SAMPLE_SIZE = 50;
 const PRUNE_PROBABILITY = 0.02;
 
+// seen:<hmac> markers are functionally useless after DEDUP_WINDOW_MS (30s) —
+// the dedup check already ignores an expired one via the timestamp compare —
+// but nothing previously deleted the key itself, so it persisted forever.
+// 5 minutes gives generous headroom past the functional window before actual
+// deletion (deleting exactly at 30s would work too; the margin is just
+// slack, not a correctness requirement).
+const IP_MARKER_RETENTION_MS = 5 * 60 * 1000;
+
 // Exported for direct unit testing — the real call site is probability-gated
 // (PRUNE_PROBABILITY), so a behavioral test through handleCount would be
 // flaky without this.
@@ -64,6 +72,20 @@ export async function pruneOldDeliveryRecords(storage, now) {
   const staleKeys = [];
   for (const [key, value] of entries) {
     if (value && typeof value.createdAt === "number" && now - value.createdAt > DELIVERY_RETENTION_MS) {
+      staleKeys.push(key);
+    }
+  }
+  if (staleKeys.length > 0) {
+    await storage.delete(staleKeys);
+  }
+}
+
+// Exported for direct unit testing, same reasoning as pruneOldDeliveryRecords.
+export async function pruneStaleIpMarkers(storage, now) {
+  const entries = await storage.list({ prefix: "seen:", limit: PRUNE_SAMPLE_SIZE });
+  const staleKeys = [];
+  for (const [key, value] of entries) {
+    if (typeof value === "number" && now - value > IP_MARKER_RETENTION_MS) {
       staleKeys.push(key);
     }
   }
@@ -278,6 +300,7 @@ export class DownloadCounter {
       await storage.put(batch);
       if (Math.random() < PRUNE_PROBABILITY) {
         await pruneOldDeliveryRecords(storage, now);
+        await pruneStaleIpMarkers(storage, now);
       }
       return { record: newRecord };
     });

--- a/workers/download-counter/test/counter.test.js
+++ b/workers/download-counter/test/counter.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import worker, { DownloadCounter, pruneOldDeliveryRecords } from "../src/index.js";
+import worker, { DownloadCounter, pruneOldDeliveryRecords, pruneStaleIpMarkers } from "../src/index.js";
 
 class FakeStorage {
   constructor() {
@@ -551,6 +551,24 @@ test("pruneOldDeliveryRecords never touches counter or seen: keys", async () => 
   assert.equal(storage.map.get("counter"), 42);
   assert.equal(storage.map.get("seen:abc"), now - 999_999_999);
   assert.equal(storage.map.get("delivery:ancient"), undefined);
+});
+
+test("pruneStaleIpMarkers deletes seen: markers past their retention window, never delivery: or counter", async () => {
+  const storage = new FakeStorage();
+  const now = Date.now();
+  const SIX_MINUTES_MS = 6 * 60 * 1000;
+  const ONE_MINUTE_MS = 60 * 1000;
+  await storage.put("counter", 7);
+  await storage.put("seen:old", now - SIX_MINUTES_MS);
+  await storage.put("seen:recent", now - ONE_MINUTE_MS);
+  await storage.put("delivery:keep-forever", { status: "delivered", total: 1, createdAt: now });
+
+  await pruneStaleIpMarkers(storage, now);
+
+  assert.equal(storage.map.get("seen:old"), undefined, "a seen: marker past its retention window must be pruned");
+  assert.equal(storage.map.get("seen:recent"), now - ONE_MINUTE_MS, "a recent marker must survive pruning");
+  assert.equal(storage.map.get("counter"), 7);
+  assert.ok(storage.map.get("delivery:keep-forever"), "pruneStaleIpMarkers must never touch delivery: records");
 });
 
 test("/seed succeeds once on a cold counter, then refuses with 409", async () => {

--- a/workers/download-counter/test/counter.test.js
+++ b/workers/download-counter/test/counter.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import worker, { DownloadCounter } from "../src/index.js";
+import worker, { DownloadCounter, pruneOldDeliveryRecords } from "../src/index.js";
 
 class FakeStorage {
   constructor() {
@@ -26,6 +26,12 @@ class FakeStorage {
       if (limit && result.size >= limit) break;
     }
     return result;
+  }
+  async delete(keyOrKeys) {
+    const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+    for (const k of keys) {
+      this.map.delete(k);
+    }
   }
 }
 
@@ -517,6 +523,34 @@ test("without SMOKE set, the message carries no test marker", async () => {
   } finally {
     mock.restore();
   }
+});
+
+test("pruneOldDeliveryRecords deletes only records past the retention window", async () => {
+  const storage = new FakeStorage();
+  const now = Date.now();
+  const NINETY_ONE_DAYS_MS = 91 * 24 * 60 * 60 * 1000;
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+  await storage.put("delivery:old", { status: "delivered", total: 1, createdAt: now - NINETY_ONE_DAYS_MS });
+  await storage.put("delivery:recent", { status: "delivered", total: 2, createdAt: now - ONE_DAY_MS });
+
+  await pruneOldDeliveryRecords(storage, now);
+
+  assert.equal(storage.map.get("delivery:old"), undefined, "a record past the 90-day retention window must be pruned");
+  assert.ok(storage.map.get("delivery:recent"), "a recent record must survive pruning");
+});
+
+test("pruneOldDeliveryRecords never touches counter or seen: keys", async () => {
+  const storage = new FakeStorage();
+  const now = Date.now();
+  await storage.put("counter", 42);
+  await storage.put("seen:abc", now - 999_999_999);
+  await storage.put("delivery:ancient", { status: "delivered", total: 1, createdAt: 0 });
+
+  await pruneOldDeliveryRecords(storage, now);
+
+  assert.equal(storage.map.get("counter"), 42);
+  assert.equal(storage.map.get("seen:abc"), now - 999_999_999);
+  assert.equal(storage.map.get("delivery:ancient"), undefined);
 });
 
 test("/seed succeeds once on a cold counter, then refuses with 409", async () => {

--- a/workers/download-counter/test/counter.test.js
+++ b/workers/download-counter/test/counter.test.js
@@ -31,7 +31,33 @@ class FakeStorage {
 
 function makeCounter(env = {}) {
   const storage = new FakeStorage();
-  const ctx = { storage };
+  // Sufficient for sequential tests: no other request is ever actually
+  // in flight, so a pass-through is equivalent to the real serialized
+  // behavior. The dedicated concurrency test below uses a genuinely
+  // serializing implementation instead.
+  const ctx = { storage, blockConcurrencyWhile: (fn) => fn() };
+  const counter = new DownloadCounter(ctx, {
+    DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test",
+    IP_HASH_SECRET: "test-secret",
+    ...env,
+  });
+  return { counter, storage };
+}
+
+function makeSerializingCounter(env = {}) {
+  const storage = new FakeStorage();
+  let chain = Promise.resolve();
+  const ctx = {
+    storage,
+    blockConcurrencyWhile(fn) {
+      const result = chain.then(() => fn());
+      chain = result.then(
+        () => {},
+        () => {},
+      );
+      return result;
+    },
+  };
   const counter = new DownloadCounter(ctx, {
     DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test",
     IP_HASH_SECRET: "test-secret",
@@ -367,6 +393,67 @@ test("an unrecognized sourceBucket falls back to a generic off-site label", asyn
     );
     const sent = JSON.parse(mock.calls[0].init.body).content;
     assert.ok(sent.includes("an off-site link"));
+  } finally {
+    mock.restore();
+  }
+});
+
+test("two genuinely concurrent DIFFERENT new events never reserve the same total", async () => {
+  const { counter } = makeSerializingCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    const [resA, resB] = await Promise.all([
+      counter.fetch(countRequest(onSiteEvent({ eventId: "evt-race-a", ip: "10.0.0.1" }))),
+      counter.fetch(countRequest(onSiteEvent({ eventId: "evt-race-b", ip: "10.0.0.2" }))),
+    ]);
+    const totalA = (await resA.json()).total;
+    const totalB = (await resB.json()).total;
+    assert.notEqual(totalA, totalB, "two different concurrent events must never reserve the same total");
+    assert.deepEqual([totalA, totalB].sort(), [1, 2]);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("two genuinely concurrent events sharing an IP: exactly one is counted, never both", async () => {
+  const { counter } = makeSerializingCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    const [resA, resB] = await Promise.all([
+      counter.fetch(countRequest(onSiteEvent({ eventId: "evt-race-c", ip: "10.0.0.9" }))),
+      counter.fetch(countRequest(onSiteEvent({ eventId: "evt-race-d", ip: "10.0.0.9" }))),
+    ]);
+    const bodies = [await resA.json(), await resB.json()];
+    const countedTrue = bodies.filter((b) => b.counted === true);
+    const duplicates = bodies.filter((b) => b.reason === "duplicate");
+    assert.equal(countedTrue.length, 1, "exactly one of the two concurrent same-IP events must count");
+    assert.equal(duplicates.length, 1, "the other must be suppressed as a duplicate, not silently double-counted");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("an oversized Discord message is truncated to Discord's 2000-char limit, not rejected", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    const res = await counter.fetch(countRequest(onSiteEvent({ referrer: "https://example.com/?x=" + "a".repeat(3000) })));
+    const body = await res.json();
+    assert.equal(body.counted, true);
+    const sent = JSON.parse(mock.calls[0].init.body).content;
+    assert.ok(sent.length <= 2000, `expected <=2000 chars, got ${sent.length}`);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("Discord posts disable mention parsing so attacker-controlled fields can never ping the channel", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent({ referrer: "https://evil.example/?x=@everyone" })));
+    const sentBody = JSON.parse(mock.calls[0].init.body);
+    assert.deepEqual(sentBody.allowed_mentions, { parse: [] });
   } finally {
     mock.restore();
   }

--- a/workers/download-counter/test/counter.test.js
+++ b/workers/download-counter/test/counter.test.js
@@ -1,0 +1,465 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import worker, { DownloadCounter } from "../src/index.js";
+
+class FakeStorage {
+  constructor() {
+    this.map = new Map();
+  }
+  async get(key) {
+    return this.map.get(key);
+  }
+  async put(keyOrEntries, maybeValue) {
+    if (typeof keyOrEntries === "string") {
+      this.map.set(keyOrEntries, maybeValue);
+      return;
+    }
+    for (const [k, v] of Object.entries(keyOrEntries)) {
+      this.map.set(k, v);
+    }
+  }
+  async list({ prefix, limit } = {}) {
+    const result = new Map();
+    for (const [k, v] of this.map.entries()) {
+      if (prefix && !k.startsWith(prefix)) continue;
+      result.set(k, v);
+      if (limit && result.size >= limit) break;
+    }
+    return result;
+  }
+}
+
+function makeCounter(env = {}) {
+  const storage = new FakeStorage();
+  const ctx = { storage };
+  const counter = new DownloadCounter(ctx, {
+    DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test",
+    IP_HASH_SECRET: "test-secret",
+    ...env,
+  });
+  return { counter, storage };
+}
+
+function countRequest(body) {
+  return new Request("https://do/count", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function seedRequest(total) {
+  return new Request("https://do/seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ total }),
+  });
+}
+
+function mockFetch(responder) {
+  const original = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return responder(calls.length);
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function onSiteEvent(overrides = {}) {
+  return {
+    eventId: "evt-1",
+    event: "download_clicked",
+    ip: "1.2.3.4",
+    city: "Springfield",
+    country: "United States",
+    countryCode: "US",
+    referrer: "https://google.com",
+    page: "/",
+    browser: "Chrome",
+    os: "Mac OS X",
+    lang: "en-US",
+    ...overrides,
+  };
+}
+
+test("on-site download_clicked always qualifies, even with excludedReason set", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    const res = await counter.fetch(countRequest(onSiteEvent({ excludedReason: "bot" })));
+    const body = await res.json();
+    assert.equal(body.counted, true);
+    assert.equal(body.total, 1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("off-site download_redirect with non-empty excludedReason is excluded", async () => {
+  const { counter, storage } = makeCounter();
+  const res = await counter.fetch(
+    countRequest({ eventId: "evt-2", event: "download_redirect", excludedReason: "bot", ip: "5.6.7.8" }),
+  );
+  const body = await res.json();
+  assert.deepEqual(body, { counted: false, reason: "excluded" });
+  assert.equal(storage.map.get("counter"), undefined);
+});
+
+test("off-site download_redirect with empty excludedReason qualifies", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 200 }));
+  try {
+    const res = await counter.fetch(
+      countRequest({
+        eventId: "evt-3",
+        event: "download_redirect",
+        excludedReason: "",
+        ip: "5.6.7.8",
+        sourceBucket: "reddit",
+        country: "Canada",
+        referrer: "https://reddit.com/r/foo",
+      }),
+    );
+    const body = await res.json();
+    assert.equal(body.counted, true);
+    assert.equal(body.total, 1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("new event increments counter atomically and posts to Discord", async () => {
+  const { counter, storage } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    const res = await counter.fetch(countRequest(onSiteEvent()));
+    const body = await res.json();
+    assert.equal(body.total, 1);
+    assert.equal(storage.map.get("counter"), 1);
+    assert.equal(storage.map.get("delivery:evt-1").status, "delivered");
+    assert.equal(mock.calls.length, 1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("retry of a delivered eventId returns the stored total without re-posting", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent()));
+    const res = await counter.fetch(countRequest(onSiteEvent()));
+    const body = await res.json();
+    assert.deepEqual(body, { counted: true, total: 1, reason: "already-delivered" });
+    assert.equal(mock.calls.length, 1, "must not re-post a delivered event");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("retry of a failed (permanent 4xx) eventId returns discord-rejected without re-posting", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 400 }));
+  try {
+    const first = await counter.fetch(countRequest(onSiteEvent()));
+    assert.equal((await first.json()).reason, "discord-rejected");
+    const second = await counter.fetch(countRequest(onSiteEvent()));
+    const body = await second.json();
+    assert.deepEqual(body, { counted: true, total: 1, reason: "discord-rejected" });
+    assert.equal(mock.calls.length, 1, "a permanent rejection must never be retried");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("a genuinely concurrent request for the same eventId gets 503 while the lease is held", async () => {
+  const { counter, storage } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent()));
+    // Force the record back into "pending" with a live lease, simulating an
+    // in-flight overlapping request.
+    await storage.put("delivery:evt-1", { status: "pending", total: 1, leaseUntil: Date.now() + 10_000 });
+    const res = await counter.fetch(countRequest(onSiteEvent()));
+    assert.equal(res.status, 503);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("an expired lease on a pending record resumes using the stored total, not a new increment", async () => {
+  const { counter, storage } = makeCounter();
+  await storage.put("counter", 5);
+  await storage.put("delivery:evt-1", { status: "pending", total: 6, leaseUntil: Date.now() - 1_000, createdAt: Date.now() });
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    const res = await counter.fetch(countRequest(onSiteEvent()));
+    const body = await res.json();
+    assert.equal(body.total, 6, "must reuse the reserved total, not increment again");
+    assert.equal(storage.map.get("counter"), 5, "counter must not be touched on a resumed retry");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("exhausted retries clear the lease to 0 and return 502", async () => {
+  const { counter, storage } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 500 }));
+  try {
+    const res = await counter.fetch(countRequest(onSiteEvent()));
+    assert.equal(res.status, 502);
+    const record = storage.map.get("delivery:evt-1");
+    assert.equal(record.status, "pending");
+    assert.equal(record.leaseUntil, 0);
+    assert.equal(mock.calls.length, 2, "must attempt exactly 2 Discord posts on repeated 5xx");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("a cleared lease lets the very next retry take over immediately", async () => {
+  const { counter, storage } = makeCounter();
+  let attempt = 0;
+  const mock = mockFetch(() => {
+    attempt += 1;
+    return new Response(null, { status: attempt <= 2 ? 500 : 204 });
+  });
+  try {
+    const first = await counter.fetch(countRequest(onSiteEvent()));
+    assert.equal(first.status, 502);
+    assert.equal(storage.map.get("delivery:evt-1").leaseUntil, 0);
+
+    const second = await counter.fetch(countRequest(onSiteEvent()));
+    const body = await second.json();
+    assert.equal(body.counted, true);
+    assert.equal(body.total, 1, "resumed retry must reuse the original reserved total");
+    assert.equal(storage.map.get("counter"), 1, "counter must never be incremented twice for one event");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("same IP within the dedup window suppresses a second distinct event, does not reserve a total", async () => {
+  const { counter, storage } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent({ eventId: "evt-a", ip: "9.9.9.9" })));
+    const res = await counter.fetch(countRequest(onSiteEvent({ eventId: "evt-b", ip: "9.9.9.9" })));
+    const body = await res.json();
+    assert.deepEqual(body, { counted: false, reason: "duplicate" });
+    assert.equal(storage.map.get("counter"), 1, "the duplicate must not reserve a second total");
+    assert.equal(storage.map.get("delivery:evt-b"), undefined);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("a different IP is never suppressed by another visitor's dedup marker", async () => {
+  const { counter, storage } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent({ eventId: "evt-a", ip: "1.1.1.1" })));
+    const res = await counter.fetch(countRequest(onSiteEvent({ eventId: "evt-b", ip: "2.2.2.2" })));
+    const body = await res.json();
+    assert.equal(body.counted, true);
+    assert.equal(storage.map.get("counter"), 2);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("a missing IP skips dedup entirely and never collides with another missing-IP event", async () => {
+  const { counter, storage } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent({ eventId: "evt-a", ip: "" })));
+    const res = await counter.fetch(countRequest(onSiteEvent({ eventId: "evt-b", ip: "" })));
+    const body = await res.json();
+    assert.equal(body.counted, true, "a second missing-IP event must count normally, not collide");
+    assert.equal(storage.map.get("counter"), 2);
+    for (const key of storage.map.keys()) {
+      assert.ok(!key.startsWith("seen:"), "no seen:* key may be written for a missing IP");
+    }
+  } finally {
+    mock.restore();
+  }
+});
+
+test("on-site message format matches the live Hog script's template", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent()));
+    const sent = JSON.parse(mock.calls[0].init.body).content;
+    assert.equal(
+      sent,
+      ":tada: **Download #1!** Someone just grabbed EnviousWispr\n" +
+        "> :flag_us: **Location:** Springfield, United States\n" +
+        "> **Platform:** Mac OS X / Chrome\n" +
+        "> **Referred by:** https://google.com\n" +
+        "> **Page:** /\n" +
+        "> **Language:** en-US",
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test("on-site message omits the Language line when lang is absent", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent({ lang: "" })));
+    const sent = JSON.parse(mock.calls[0].init.body).content;
+    assert.ok(!sent.includes("Language"));
+  } finally {
+    mock.restore();
+  }
+});
+
+test("off-site message uses the Source label and omits Platform/Page/Language", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(
+      countRequest({
+        eventId: "evt-off",
+        event: "download_redirect",
+        excludedReason: "",
+        ip: "8.8.8.8",
+        country: "Germany",
+        sourceBucket: "reddit",
+        referrer: "$direct",
+      }),
+    );
+    const sent = JSON.parse(mock.calls[0].init.body).content;
+    assert.equal(
+      sent,
+      ":tada: **Download #1!** Someone just grabbed EnviousWispr\n" +
+        "> **Location:** Germany\n" +
+        "> **Source:** Reddit\n" +
+        "> **Referred by:** Direct visit",
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test("an unrecognized sourceBucket falls back to a generic off-site label", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(
+      countRequest({
+        eventId: "evt-unk",
+        event: "download_redirect",
+        excludedReason: "",
+        ip: "8.8.8.9",
+        country: "France",
+        sourceBucket: "totally_unknown",
+      }),
+    );
+    const sent = JSON.parse(mock.calls[0].init.body).content;
+    assert.ok(sent.includes("an off-site link"));
+  } finally {
+    mock.restore();
+  }
+});
+
+test("/seed succeeds once on a cold counter, then refuses with 409", async () => {
+  const { counter, storage } = makeCounter();
+  const first = await counter.fetch(seedRequest(756));
+  assert.equal(first.status, 200);
+  assert.equal(storage.map.get("counter"), 756);
+
+  const second = await counter.fetch(seedRequest(1));
+  assert.equal(second.status, 409);
+  assert.equal(storage.map.get("counter"), 756, "a rejected reseed must never overwrite the real counter");
+});
+
+test("/seed refuses once real traffic has already created delivery records", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent()));
+    const seeded = await counter.fetch(seedRequest(999));
+    assert.equal(seeded.status, 409);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("a seeded counter's next new event increments from the seeded value", async () => {
+  const { counter, storage } = makeCounter();
+  await counter.fetch(seedRequest(756));
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    const res = await counter.fetch(countRequest(onSiteEvent()));
+    const body = await res.json();
+    assert.equal(body.total, 757);
+    assert.equal(storage.map.get("counter"), 757);
+  } finally {
+    mock.restore();
+  }
+});
+
+function fakeDoNamespace(counter) {
+  return {
+    idFromName: () => "global",
+    get: () => ({ fetch: (url, init) => counter.fetch(new Request(url, init)) }),
+  };
+}
+
+test("Worker: missing/wrong x-trigger-secret is rejected before the Durable Object is touched", async () => {
+  const { counter } = makeCounter();
+  const env = { TRIGGER_SECRET: "correct-secret", DOWNLOAD_COUNTER: fakeDoNamespace(counter) };
+  const req = new Request("https://worker/count", {
+    method: "POST",
+    headers: { "x-trigger-secret": "wrong", "Content-Type": "application/json" },
+    body: JSON.stringify(onSiteEvent()),
+  });
+  const res = await worker.fetch(req, env);
+  assert.equal(res.status, 401);
+});
+
+test("Worker: an event outside the known two types is rejected with 400", async () => {
+  const { counter } = makeCounter();
+  const env = { TRIGGER_SECRET: "s", DOWNLOAD_COUNTER: fakeDoNamespace(counter) };
+  const req = new Request("https://worker/count", {
+    method: "POST",
+    headers: { "x-trigger-secret": "s", "Content-Type": "application/json" },
+    body: JSON.stringify(onSiteEvent({ event: "something_else" })),
+  });
+  const res = await worker.fetch(req, env);
+  assert.equal(res.status, 400);
+});
+
+test("Worker: a missing, empty, or oversized eventId is rejected with 400 before storage is touched", async () => {
+  const { counter, storage } = makeCounter();
+  const env = { TRIGGER_SECRET: "s", DOWNLOAD_COUNTER: fakeDoNamespace(counter) };
+  for (const badId of [undefined, "", "x".repeat(201)]) {
+    const req = new Request("https://worker/count", {
+      method: "POST",
+      headers: { "x-trigger-secret": "s", "Content-Type": "application/json" },
+      body: JSON.stringify(onSiteEvent({ eventId: badId })),
+    });
+    const res = await worker.fetch(req, env);
+    assert.equal(res.status, 400, `expected 400 for eventId=${JSON.stringify(badId)}`);
+  }
+  assert.equal(storage.map.size, 0, "no storage write may happen for a rejected request");
+});
+
+test("Worker: an unknown route is 404, a non-POST method is 405", async () => {
+  const { counter } = makeCounter();
+  const env = { TRIGGER_SECRET: "s", DOWNLOAD_COUNTER: fakeDoNamespace(counter) };
+  const notFound = await worker.fetch(new Request("https://worker/unknown", { method: "POST" }), env);
+  assert.equal(notFound.status, 404);
+  const wrongMethod = await worker.fetch(new Request("https://worker/count", { method: "GET" }), env);
+  assert.equal(wrongMethod.status, 405);
+});

--- a/workers/download-counter/test/counter.test.js
+++ b/workers/download-counter/test/counter.test.js
@@ -204,6 +204,42 @@ test("retry of a failed (permanent 4xx) eventId returns discord-rejected without
   }
 });
 
+test("a webhook config error (401/403/404) is treated as retryable, never marked permanently failed", async () => {
+  for (const status of [401, 403, 404]) {
+    const { counter, storage } = makeCounter();
+    const mock = mockFetch(() => new Response(null, { status }));
+    try {
+      const res = await counter.fetch(countRequest(onSiteEvent()));
+      assert.equal(res.status, 502, `status ${status} should return 502 (retryable), not a terminal 200`);
+      const record = storage.map.get("delivery:evt-1");
+      assert.equal(record.status, "pending", `status ${status} must stay pending, not become "failed"`);
+      assert.equal(record.leaseUntil, 0);
+    } finally {
+      mock.restore();
+    }
+  }
+});
+
+test("once a webhook config error clears (e.g. secret fixed), a resumed retry can still deliver", async () => {
+  const { counter, storage } = makeCounter();
+  let attempt = 0;
+  const mock = mockFetch(() => {
+    attempt += 1;
+    return new Response(null, { status: attempt === 1 ? 401 : 204 });
+  });
+  try {
+    const first = await counter.fetch(countRequest(onSiteEvent()));
+    assert.equal(first.status, 502);
+    const second = await counter.fetch(countRequest(onSiteEvent()));
+    const body = await second.json();
+    assert.equal(body.counted, true);
+    assert.equal(body.total, 1, "must resume with the original total, not re-increment");
+    assert.equal(storage.map.get("delivery:evt-1").status, "delivered");
+  } finally {
+    mock.restore();
+  }
+});
+
 test("a genuinely concurrent request for the same eventId gets 503 while the lease is held", async () => {
   const { counter, storage } = makeCounter();
   const mock = mockFetch(() => new Response(null, { status: 204 }));

--- a/workers/download-counter/test/counter.test.js
+++ b/workers/download-counter/test/counter.test.js
@@ -372,6 +372,30 @@ test("an unrecognized sourceBucket falls back to a generic off-site label", asyn
   }
 });
 
+test("SMOKE env prefixes the Discord message so a test post is never mistaken for a real download", async () => {
+  const { counter } = makeCounter({ SMOKE: "true" });
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent()));
+    const sent = JSON.parse(mock.calls[0].init.body).content;
+    assert.ok(sent.startsWith("🧪 SMOKE TEST — ignore\n"));
+  } finally {
+    mock.restore();
+  }
+});
+
+test("without SMOKE set, the message carries no test marker", async () => {
+  const { counter } = makeCounter();
+  const mock = mockFetch(() => new Response(null, { status: 204 }));
+  try {
+    await counter.fetch(countRequest(onSiteEvent()));
+    const sent = JSON.parse(mock.calls[0].init.body).content;
+    assert.ok(!sent.includes("SMOKE TEST"));
+  } finally {
+    mock.restore();
+  }
+});
+
 test("/seed succeeds once on a cold counter, then refuses with 409", async () => {
   const { counter, storage } = makeCounter();
   const first = await counter.fetch(seedRequest(756));

--- a/workers/download-counter/wrangler.toml
+++ b/workers/download-counter/wrangler.toml
@@ -1,0 +1,53 @@
+# Download-notification counter (#1691): replaces the brittle Hog-script live
+# PostHog query with an owned, always-fast counter. PostHog's "Discord: Download
+# Notification" CDP destination becomes a thin relay that POSTs event fields
+# here; this Worker owns counting, IP-based rage-click dedup, retry-safe
+# Discord delivery, and formatting. Plan: docs/feature-requests/issue-1691-2026-07-19-download-counter-worker.md
+#
+# Durable Object `DownloadCounter` (instance name always "global" for real
+# traffic, hardcoded in src/index.js — never taken from the request) owns the
+# counter, IP-dedup markers, and per-event Discord-delivery state.
+#
+# No [triggers] cron here: this worker is a pure request/response relay, no
+# scheduled trigger needed (and the account is already at its 5-cron
+# free-plan limit, #1092).
+
+name = "enviouswispr-download-counter"
+main = "src/index.js"
+compatibility_date = "2026-07-19"
+
+[[durable_objects.bindings]]
+name = "DOWNLOAD_COUNTER"
+class_name = "DownloadCounter"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["DownloadCounter"]
+
+# Secrets (set via `npx wrangler secret put <NAME>`, never in this file):
+#   DISCORD_WEBHOOK_URL  - Keychain `enviouswispr.discord-webhook-downloads`
+#   TRIGGER_SECRET       - gates /count and /seed; sent by the PostHog Hog
+#                          relay as the `x-trigger-secret` header
+#   IP_HASH_SECRET       - keyed HMAC secret for IP dedup; new random value,
+#                          not reused from any other secret
+
+# Isolated smoke-test deployment (`wrangler deploy --env smoke`). Cloudflare
+# environments get independently namespaced Durable Object storage even with
+# an identical binding name and idFromName() string, so this environment's
+# "global" DownloadCounter instance is a structurally separate object from
+# production's — the smoke script can never touch real counter state, no
+# matter what it sends. Shares the production DISCORD_WEBHOOK_URL (so the
+# smoke script can prove a real Discord post lands; its message is always
+# prefixed "🧪 SMOKE TEST — ignore") but uses its OWN TRIGGER_SECRET and
+# IP_HASH_SECRET, so a leaked smoke secret can't authenticate against
+# production.
+[env.smoke]
+name = "enviouswispr-download-counter-smoke"
+
+[[env.smoke.durable_objects.bindings]]
+name = "DOWNLOAD_COUNTER"
+class_name = "DownloadCounter"
+
+[[env.smoke.migrations]]
+tag = "v1"
+new_sqlite_classes = ["DownloadCounter"]

--- a/workers/download-counter/wrangler.toml
+++ b/workers/download-counter/wrangler.toml
@@ -44,6 +44,9 @@ new_sqlite_classes = ["DownloadCounter"]
 [env.smoke]
 name = "enviouswispr-download-counter-smoke"
 
+[env.smoke.vars]
+SMOKE = "true"
+
 [[env.smoke.durable_objects.bindings]]
 name = "DOWNLOAD_COUNTER"
 class_name = "DownloadCounter"


### PR DESCRIPTION
## Summary

The Discord "someone downloaded EnviousWispr" bot ran a live PostHog HogQL `SELECT count()` query on every download click. That query shared PostHog's project-wide 3-concurrent-query ceiling with every other consumer in the account and intermittently rendered `Download #?!` under load — confirmed live via Hog function logs showing 3x-retried 504s/timeouts (2 of 3 posts failed on 2026-07-19).

Replaces it with a small Cloudflare Worker (`workers/download-counter/`) backed by one Durable Object that owns the counter, IP-based rage-click dedup, and retry-safe Discord delivery. PostHog's CDP destination becomes a thin relay (`hog-relay.hog`, committed) that forwards the event to the Worker; the Worker decides whether it qualifies, dedups, increments, and posts to Discord itself.

- Durable Object required, not Workers KV: KV's 60s minimum write TTL and 1-write/sec/key limit would violate the counter's read-increment-write pattern under PostHog's own retry bursts.
- A 4-state delivery record per `event.uuid` (`absent → pending → delivered/failed`) with a posting lease means a PostHog retry resumes the same reserved total instead of double-counting or being silently dropped.
- The read-decide-reserve section runs inside `ctx.blockConcurrencyWhile` — Durable Objects can interleave two *different* requests across `await` points, which the atomic write alone doesn't prevent.
- Keyed HMAC-SHA256 IP dedup (30s window), Discord content truncated to 2000 chars, `allowed_mentions` disabled (forwarded fields are attacker-influenceable), bounded retention (90 days delivery records / 5 min IP markers), and an isolated `[env.smoke]` Wrangler deployment for testing without touching production.
- Design went through 5 rounds of grounded plan review + 8 rounds of local Codex code-diff review (each found real, progressively narrower issues — a genuine cross-event reservation race, a config-vs-content error misclassification, a relay bug that would have 404'd every real download, etc.) before shipping.

**Already deployed and cut over live** (both production and an isolated smoke environment): counter seeded from the live true count, PostHog's destination PATCHed to the new relay, verified against a real production download — new relay completed in 420ms with zero retries, vs. the old script's 9100ms with 3 failed attempts.

## Test plan

- [x] `node --test` — 35 tests, all passing (qualification, dedup, retry/lease/concurrency, Discord hardening, retention, seed one-shot behavior)
- [x] `wrangler deploy --dry-run` clean for both production and smoke environments
- [x] Live-endpoint smoke test passed against the real deployed smoke Worker, including a genuine concurrent-request check no mock could reproduce
- [x] Production cutover verified against a real download through `enviouswispr.com/download`
- [x] 8 rounds of local Codex code-diff review, final round clean ("No actionable correctness issues remain")

This PR ships an already-live production change; see `.claude/knowledge/analytics-operations.md` FACT: download-counter-worker for the full operational reference.
