### PR TITLE
feat(user): import words from another dictation app (PR-4a/b/c, #1686)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -98,9 +98,12 @@ final class CustomWordsCoordinator {
   @discardableResult
   func refreshFromDiskIfPossible() -> Bool {
     guard let refreshed = manager.load() else {
-      // Corruption found DURING the session is still corruption, and it must
-      // be remembered: the load archives the damaged file aside, so the NEXT
-      // attempt sees a legitimately missing file and reports success.
+      // Corruption found DURING the session, not at launch, is still
+      // corruption — and it must be remembered (code review r3). The load
+      // archives the damaged file aside, so the NEXT attempt sees a
+      // legitimately missing file, adopts the built-ins, and reports success.
+      // Without latching this, a retry would sail past the export guard, find
+      // zero user words, and write an empty file over the user's existing one.
       if manager.lastLoadFailure == .corrupted {
         didDiscoverCorruptionThisSession = true
       }
@@ -136,6 +139,10 @@ final class CustomWordsCoordinator {
   /// user has authored a word since, they have visibly accepted the fresh
   /// start and the list is theirs again.
   var canExportCurrentWords: Bool {
+    // Either origin of corruption counts: at launch, or discovered mid-session
+    // (code review r3). Checking only the launch flag meant a file that went
+    // bad while the app was open passed the guard on the second attempt and
+    // exported nothing over something.
     let sawCorruption =
       wordsLoadFailureAtLaunch == .corrupted || didDiscoverCorruptionThisSession
     guard sawCorruption else { return true }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -42,11 +42,8 @@ struct CustomWordsImportSheet: View {
           ImportUploadScreen(model: model)
             .transition(Self.screenTransition)
         case .smartImportAppPicker:
-          ImportPlaceholderScreen(
-            notice: "Importing from other apps arrives with a later update.",
-            model: model
-          )
-          .transition(Self.screenTransition)
+          ImportSmartAppPickerScreen(model: model)
+            .transition(Self.screenTransition)
         case .review:
           ImportReviewScreen(model: model)
             .transition(Self.screenTransition)
@@ -448,6 +445,67 @@ private struct ImportUploadScreen: View {
       Text("Spreadsheets aren't supported yet.")
         .font(.stHelper)
         .foregroundStyle(.stTextSecondary)
+    }
+  }
+}
+
+// MARK: - From another app (PR-4a/b/c)
+
+private struct ImportSmartAppPickerScreen: View {
+  let model: CustomWordsImportFlowModel
+  /// Detection runs when this screen appears, not at launch or when the sheet
+  /// opens: an installed competitor is never quietly inspected in the
+  /// background, only when the user has asked to see this list.
+  @State private var installed: [String] = []
+  @State private var didLookForApps = false
+
+  private var registry: SmartImportRegistry { .v1 }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("Bring the words across from another dictation app you use.")
+        .settingsReadingCopy()
+
+      if !didLookForApps {
+        HStack(spacing: 8) {
+          ProgressView().controlSize(.small)
+          Text("Looking for apps on this Mac.").settingsReadingCopy()
+        }
+      } else if installed.isEmpty {
+        InsetNotice(
+          text: "No supported dictation apps found on this Mac. "
+            + "EnviousWispr can read Wispr Flow, FluidVoice, and Superwhisper.")
+      } else {
+        ForEach(registry.adapters.filter { installed.contains($0.identifier) }, id: \.identifier) {
+          adapter in
+          ImportMethodCard(
+            icon: "app.badge",
+            title: adapter.displayName,
+            subtitle: "Read your words from \(adapter.displayName)."
+          ) {
+            model.begin(with: SmartImportSource(adapter: adapter))
+          }
+        }
+      }
+
+      // Says the honest shape of the migration before they commit to it: this
+      // brings words across, not the corrections that map onto them.
+      Text(
+        "Words come across on their own. Alternate spellings you set up in the other app stay there."
+      )
+      .font(.stHelper)
+      .foregroundStyle(.stTextSecondary)
+    }
+    .task {
+      // Off the main actor: this touches the filesystem.
+      let found = await Task.detached { () -> [String] in
+        // Detached rather than a plain Task: a plain Task inherits MainActor
+        // from this view, and these are disk existence checks across several
+        // locations. Nothing here needs actor context.
+        SmartImportRegistry.v1.adapters.filter(\.isInstalled).map(\.identifier)
+      }.value
+      installed = found
+      didLookForApps = true
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -319,6 +319,9 @@ private struct ImportPasteScreen: View {
   @State private var parseProblem: String?
   /// The in-flight count, so the next edit can cancel it.
   @State private var countingTask: Task<Void, Never>?
+  /// True while the on-screen count belongs to an older draft than the one in
+  /// the editor. Continue stays disabled until the current draft is counted.
+  @State private var isCounting = false
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -356,7 +359,9 @@ private struct ImportPasteScreen: View {
         // the user on the terminal failure screen, which has no Back, so the
         // draft they could have split is gone. Block it where they can still
         // edit it (cloud review, #1683).
-        .disabled(wordCount == 0 || wordCount > CustomWordsImportLimits.maximumCandidates)
+        .disabled(
+          isCounting || wordCount == 0
+            || wordCount > CustomWordsImportLimits.maximumCandidates)
       }
     }
     .onAppear {
@@ -387,6 +392,13 @@ private struct ImportPasteScreen: View {
   /// exists (code review r6, #1686).
   private func recount(_ draft: String) {
     countingTask?.cancel()
+    // The count belongs to the PREVIOUS draft until the new one is counted.
+    // Leaving it on screen kept Continue enabled across the gap, so clearing
+    // a valid paste — or replacing it with an over-limit one — could still be
+    // submitted, landing on a terminal screen with no Back (Codex review,
+    // #1686). Moving the count off the main actor is what opened that window;
+    // an answer that is merely late must not be treated as current.
+    isCounting = true
     countingTask = Task {
       do {
         let counted = try await PasteWordsParser.countWords(
@@ -394,17 +406,22 @@ private struct ImportPasteScreen: View {
         guard !Task.isCancelled, draft == model.pasteDraft else { return }
         wordCount = counted
         parseProblem = nil
+        isCounting = false
       } catch is CancellationError {
         return
       } catch {
         guard !Task.isCancelled, draft == model.pasteDraft else { return }
         wordCount = 0
         parseProblem = error.localizedDescription
+        isCounting = false
       }
     }
   }
 
   private var summary: String {
+    // Says it is still working rather than reporting a stale number as
+    // current, or flashing "no words found" at text nobody has counted yet.
+    if isCounting { return "Counting…" }
     if let parseProblem { return parseProblem }
     let count = wordCount
     switch count {

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -317,6 +317,8 @@ private struct ImportPasteScreen: View {
   /// progressively less responsive the more it contained.
   @State private var wordCount = 0
   @State private var parseProblem: String?
+  /// The in-flight count, so the next edit can cancel it.
+  @State private var countingTask: Task<Void, Never>?
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -368,22 +370,37 @@ private struct ImportPasteScreen: View {
     }
   }
 
-  /// Keeps the parse failure rather than collapsing it to a zero count.
+  /// Counts OFF the main actor, and keeps the parse failure rather than
+  /// collapsing it to a zero count.
   ///
-  /// `try?` here turned a real, actionable error — an entry longer than the
-  /// limit — into "No words found", which is false and left the user stuck
-  /// with Continue disabled and nothing to act on (Codex review, #1683). A
-  /// counter must not surface a crash, but it must not invent an answer
-  /// either.
+  /// Two separate lessons, one function. `try?` here turned a real, actionable
+  /// error — an entry longer than the limit — into "No words found", which is
+  /// false and left the user stuck with Continue disabled and nothing to act
+  /// on (Codex review, #1683). And counting on the main actor made typing feel
+  /// heavy: bounded work is still work, and at the ceiling it is 25,000 words
+  /// per keystroke (code review r5, #1686).
+  ///
+  /// Off-main means results can land out of order, so each edit cancels the
+  /// previous count and a result is applied only while its draft is still the
+  /// current one — otherwise a slow count of a long list could finish after
+  /// the user cleared the box and re-enable Continue for text that no longer
+  /// exists (code review r6, #1686).
   private func recount(_ draft: String) {
-    do {
-      wordCount = try PasteWordsParser.parse(
-        draft, limit: CustomWordsImportLimits.maximumCandidates
-      ).count
-      parseProblem = nil
-    } catch {
-      wordCount = 0
-      parseProblem = error.localizedDescription
+    countingTask?.cancel()
+    countingTask = Task {
+      do {
+        let counted = try await PasteWordsParser.countWords(
+          draft, limit: CustomWordsImportLimits.maximumCandidates)
+        guard !Task.isCancelled, draft == model.pasteDraft else { return }
+        wordCount = counted
+        parseProblem = nil
+      } catch is CancellationError {
+        return
+      } catch {
+        guard !Task.isCancelled, draft == model.pasteDraft else { return }
+        wordCount = 0
+        parseProblem = error.localizedDescription
+      }
     }
   }
 

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -10,6 +10,28 @@ import Foundation
 /// once; a shared temp name would let them overwrite each other's partial
 /// bytes and produce one corrupt file.
 package enum CustomWordsExportWriter {
+  /// Refusing to write onto EnviousWispr's own storage (#1686).
+  package enum ExportDestinationError: LocalizedError, Sendable, Equatable {
+    case wouldOverwriteLiveWords
+
+    package var errorDescription: String? {
+      "That's EnviousWispr's own words file. Choose a different name or folder, "
+        + "so your saved words aren't replaced by the export."
+    }
+  }
+
+  /// Whether this destination is the app's live word list.
+  ///
+  /// Selecting it would atomically replace the app's storage with the transfer
+  /// format; the next launch would find a file it cannot parse, archive it as
+  /// corrupt, and the user would have destroyed their dictionary by exporting
+  /// it. Compared on resolved paths so a symlink or `..` cannot walk around it.
+  package static func wouldOverwriteLiveWords(_ destination: URL) -> Bool {
+    guard let live = CustomWordsManager.liveFileURL else { return false }
+    return destination.resolvingSymlinksInPath().standardizedFileURL
+      == live.resolvingSymlinksInPath().standardizedFileURL
+  }
+
   /// `@concurrent` so this always runs OFF the caller's actor (code review r5).
   /// The caller is a SwiftUI button action on the main actor, and a plain
   /// `async` here would inherit that isolation — an export to a network,
@@ -19,6 +41,12 @@ package enum CustomWordsExportWriter {
   @concurrent package static func write(
     _ data: Data, to destination: URL
   ) async throws {
+    // Refuse before touching anything: exporting must never be the action that
+    // destroys the thing being exported (#1686).
+    guard !Self.wouldOverwriteLiveWords(destination) else {
+      throw ExportDestinationError.wouldOverwriteLiveWords
+    }
+
     let fm = FileManager.default
     let tmpURL =
       destination

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -28,8 +28,27 @@ package enum CustomWordsExportWriter {
   /// it. Compared on resolved paths so a symlink or `..` cannot walk around it.
   package static func wouldOverwriteLiveWords(_ destination: URL) -> Bool {
     guard let live = CustomWordsManager.liveFileURL else { return false }
-    return destination.resolvingSymlinksInPath().standardizedFileURL
-      == live.resolvingSymlinksInPath().standardizedFileURL
+    let target = destination.resolvingSymlinksInPath().standardizedFileURL
+    let liveURL = live.resolvingSymlinksInPath().standardizedFileURL
+
+    // Ask the FILESYSTEM whether these are the same file, not the strings
+    // (code review r6). macOS is case-insensitive by default, so
+    // `CUSTOM-WORDS.JSON` and `custom-words.json` are one file that string
+    // equality calls two — and picking the shouty spelling would walk straight
+    // past this guard into the data loss it exists to prevent.
+    if let targetID = try? target.resourceValues(forKeys: [.fileResourceIdentifierKey])
+      .fileResourceIdentifier,
+      let liveID = try? liveURL.resourceValues(forKeys: [.fileResourceIdentifierKey])
+        .fileResourceIdentifier
+    {
+      return targetID.isEqual(liveID)
+    }
+
+    // The destination may not exist yet, so there is no identity to compare.
+    // Fall back to a case-insensitive path match: on the default volume that
+    // is the truth, and on a case-sensitive one it is merely stricter than
+    // necessary — which is the safe direction to be wrong in.
+    return target.path.compare(liveURL.path, options: .caseInsensitive) == .orderedSame
   }
 
   /// `@concurrent` so this always runs OFF the caller's actor (code review r5).

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -77,6 +77,25 @@ package enum CustomWordsInitialLoadFailure: Sendable, Equatable {
 public final class CustomWordsManager {
   private let fileURL: URL
 
+  /// Where the live word list is kept.
+  ///
+  /// Exposed so the export path can refuse to write ONTO it (#1686). Choosing
+  /// it as an export destination would atomically replace the app's own
+  /// storage with the transfer-document schema; the next load would find a
+  /// file it cannot parse, archive it as corrupt, and the user would have
+  /// destroyed their dictionary by exporting it.
+  /// `nonisolated`: this is a path computation with no state, and the export
+  /// writer runs off the main actor.
+  nonisolated package static var liveFileURL: URL? {
+    FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+      .appendingPathComponent("EnviousWispr", isDirectory: true)
+      .appendingPathComponent("custom-words.json")
+  }
+
+  /// This instance's file, so a test-injected manager can be guarded too.
+  package var storageURL: URL { fileURL }
+
   public init() {
     guard
       let baseURL = FileManager.default.urls(

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -170,8 +170,12 @@ package enum PasteWordsParser {
   /// bounded but not free — at the ceiling it is still 25,000 words of work on
   /// whatever actor asked. `@concurrent` keeps that off the main one, so a
   /// large paste cannot make typing feel heavy.
-  @concurrent package static func countWords(_ text: String, limit: Int) async -> Int {
-    parse(text, limit: limit).count
+  /// Throws what `parse` throws rather than collapsing it to a count. A
+  /// counter must not surface a crash, but it must not invent an answer
+  /// either: swallowing an over-length entry as "0 words" told the user
+  /// nothing was found and left them with no way to act (#1683).
+  @concurrent package static func countWords(_ text: String, limit: Int) async throws -> Int {
+    try parse(text, limit: limit).count
   }
 }
 

--- a/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/PasteWordsImportSource.swift
@@ -163,6 +163,16 @@ package enum PasteWordsParser {
     if let lengthFailure { throw lengthFailure }
     return results
   }
+
+  /// Count words off the caller's actor (code review r5).
+  ///
+  /// The paste screen recomputes this on every change, and the parse is
+  /// bounded but not free — at the ceiling it is still 25,000 words of work on
+  /// whatever actor asked. `@concurrent` keeps that off the main one, so a
+  /// large paste cannot make typing feel heavy.
+  @concurrent package static func countWords(_ text: String, limit: Int) async -> Int {
+    parse(text, limit: limit).count
+  }
 }
 
 /// Pasting more than the shared ceiling allows (#1683).

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -1,0 +1,253 @@
+import EnviousWisprCore
+import Foundation
+import SQLite3
+
+/// Why reading another app's vocabulary didn't work (#1686).
+package enum SmartImportError: LocalizedError, Sendable, Equatable {
+  case appNotFound(String)
+  case unreadable(String)
+
+  package var errorDescription: String? {
+    switch self {
+    case .appNotFound(let app):
+      return "Couldn't find any \(app) words on this Mac."
+    case .unreadable(let app):
+      return
+        "Couldn't read your \(app) words. If \(app) is open, try quitting it and importing again."
+    }
+  }
+}
+
+/// One competitor app EnviousWispr can read vocabulary out of.
+///
+/// A registry, like the file parsers: adding an app is a new conformer and one
+/// list entry, with nothing existing rewritten.
+///
+/// **Nothing here runs until the user asks for it.** No adapter touches disk at
+/// launch or when the sheet opens — an installed competitor is never quietly
+/// inspected in the background. `isInstalled` is only consulted once the user
+/// is looking at the app picker, and `loadWords` only after they choose one.
+package protocol SmartImportAdapter: Sendable {
+  /// Stable identifier emitted as the batch's `sourceID` for telemetry.
+  var identifier: String { get }
+  /// What the user sees.
+  var displayName: String { get }
+  /// Where this app keeps vocabulary, in probe order.
+  var candidatePaths: [URL] { get }
+  /// Read the canonical words. Aliases are deliberately NOT returned: v1
+  /// import carries the main word only (founder rule), so an adapter that
+  /// harvested synonyms would be supplying data the pipeline must discard.
+  func loadWords(at url: URL) throws -> [String]
+}
+
+extension SmartImportAdapter {
+  /// The first location that actually exists, or nil.
+  package var installedPath: URL? {
+    candidatePaths.first { FileManager.default.fileExists(atPath: $0.path) }
+  }
+  package var isInstalled: Bool { installedPath != nil }
+}
+
+// MARK: - FluidVoice
+
+/// Single JSON file. The keys beside `terms` are FluidVoice's own ASR tuning
+/// parameters, not vocabulary, and are ignored.
+package struct FluidVoiceAdapter: SmartImportAdapter {
+  package let identifier = "fluidvoice"
+  package let displayName = "FluidVoice"
+
+  private struct Vocabulary: Decodable {
+    struct Term: Decodable { let text: String }
+    let terms: [Term]?
+  }
+
+  package var candidatePaths: [URL] {
+    [
+      FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(
+          "Library/Application Support/FluidVoice/parakeet_custom_vocabulary.json")
+    ]
+  }
+
+  package init() {}
+
+  package func loadWords(at url: URL) throws -> [String] {
+    guard let data = try? Data(contentsOf: url) else {
+      throw SmartImportError.unreadable(displayName)
+    }
+    guard let vocabulary = try? JSONDecoder().decode(Vocabulary.self, from: data) else {
+      throw SmartImportError.unreadable(displayName)
+    }
+    // `terms` absent entirely is a legitimate fresh install, not a failure.
+    return (vocabulary.terms ?? []).map(\.text)
+  }
+}
+
+// MARK: - Superwhisper
+
+/// JSON settings file in one of two locations. Both keys may be absent
+/// entirely on a fresh install rather than present-but-empty.
+package struct SuperwhisperAdapter: SmartImportAdapter {
+  package let identifier = "superwhisper"
+  package let displayName = "Superwhisper"
+
+  private struct Settings: Decodable {
+    struct Replacement: Decodable { let with: String? }
+    let vocabulary: [String]?
+    let replacements: [Replacement]?
+  }
+
+  package var candidatePaths: [URL] {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    // Probe BOTH: the app's current default is directly under home, while
+    // older installs keep it under Documents. Checking only one silently
+    // reports "not found" for half the installed base.
+    return [
+      home.appendingPathComponent("Documents/superwhisper/settings/settings.json"),
+      home.appendingPathComponent("superwhisper/settings/settings.json"),
+    ]
+  }
+
+  package init() {}
+
+  package func loadWords(at url: URL) throws -> [String] {
+    guard let data = try? Data(contentsOf: url) else {
+      throw SmartImportError.unreadable(displayName)
+    }
+    guard let settings = try? JSONDecoder().decode(Settings.self, from: data) else {
+      throw SmartImportError.unreadable(displayName)
+    }
+    // A replacement is a find/replace pair; its `with` side is the spelling
+    // the user actually wants, which is the word worth bringing across. The
+    // `original` side is the alias, and v1 does not import aliases.
+    let corrected = (settings.replacements ?? []).compactMap(\.with)
+    return (settings.vocabulary ?? []) + corrected
+  }
+}
+
+// MARK: - Wispr Flow
+
+/// SQLite, read strictly read-only against another app's live database.
+package struct WisprFlowAdapter: SmartImportAdapter {
+  package let identifier = "wispr-flow"
+  package let displayName = "Wispr Flow"
+
+  package var candidatePaths: [URL] {
+    [
+      FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/Wispr Flow/flow.sqlite")
+    ]
+  }
+
+  package init() {}
+
+  package func loadWords(at url: URL) throws -> [String] {
+    // `immutable=1` plus READONLY: this belongs to another running app. We
+    // promise never to write to it, and immutable avoids taking locks or
+    // touching its journal, so importing cannot disturb or corrupt a database
+    // the user still depends on.
+    var db: OpaquePointer?
+    let uri = "file:\(url.path)?immutable=1"
+    guard
+      sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK,
+      let db
+    else {
+      sqlite3_close(db)
+      throw SmartImportError.unreadable(displayName)
+    }
+    defer { sqlite3_close(db) }
+
+    // isDeleted: a soft-delete flag. Importing unfiltered would resurrect
+    // words the user deliberately removed — the single worst thing this
+    // adapter could do.
+    // isSnippet: text expansions are a different feature, not vocabulary.
+    // `replacement` is the corrected spelling when present; `phrase` is the
+    // alias in that case, and v1 does not import aliases.
+    let sql = """
+      SELECT COALESCE(NULLIF(TRIM(replacement), ''), phrase)
+      FROM Dictionary
+      WHERE isDeleted = 0 AND isSnippet = 0
+      """
+    var statement: OpaquePointer?
+    guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+      throw SmartImportError.unreadable(displayName)
+    }
+    defer { sqlite3_finalize(statement) }
+
+    var words: [String] = []
+    while sqlite3_step(statement) == SQLITE_ROW {
+      if let text = sqlite3_column_text(statement, 0) {
+        words.append(String(cString: text))
+      }
+    }
+    return words
+  }
+}
+
+// MARK: - Registry and source
+
+package struct SmartImportRegistry: Sendable {
+  package let adapters: [any SmartImportAdapter]
+
+  /// TypeWhisper is deliberately absent: its schema is confirmed but its table
+  /// is empty on the only machine available, so an adapter would be written
+  /// against a shape nobody has seen populated, and its WAL sidecar files add
+  /// a correctness question that cannot be tested without real content.
+  package static let v1 = SmartImportRegistry(
+    adapters: [WisprFlowAdapter(), FluidVoiceAdapter(), SuperwhisperAdapter()])
+
+  package init(adapters: [any SmartImportAdapter]) {
+    self.adapters = adapters
+  }
+
+  package func adapter(withID id: String) -> (any SmartImportAdapter)? {
+    adapters.first { $0.identifier == id }
+  }
+}
+
+/// Reads one competitor app's vocabulary into the shared pipeline.
+package struct SmartImportSource: CustomWordsImportSource {
+  private let adapter: any SmartImportAdapter
+
+  package init(adapter: any SmartImportAdapter) {
+    self.adapter = adapter
+  }
+
+  /// `@concurrent` so a SQLite read of another app's database never runs on
+  /// the main actor.
+  @concurrent package func loadCandidates() async throws -> CustomWordsImportBatch {
+    guard let path = adapter.installedPath else {
+      throw SmartImportError.appNotFound(adapter.displayName)
+    }
+    try Task.checkCancellation()
+
+    let words = try adapter.loadWords(at: path)
+    try Task.checkCancellation()
+
+    // Reuse the shared splitter's normalization so a competitor's list dedups
+    // exactly the way a pasted one does, and trim/blank handling is identical.
+    var seen = Set<String>()
+    var canonicals: [String] = []
+    for word in words {
+      let trimmed = word.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else { continue }
+      let key = CustomWordsImportCompareEngine.normalize(trimmed)
+      guard !key.isEmpty, seen.insert(key).inserted else { continue }
+      canonicals.append(trimmed)
+    }
+
+    guard canonicals.count <= CustomWordsImportLimits.maximumCandidates else {
+      throw ImportFileError.tooManyWords(
+        found: canonicals.count, limit: CustomWordsImportLimits.maximumCandidates)
+    }
+
+    return CustomWordsImportBatch(
+      sourceID: adapter.identifier,
+      sourceDisplayName: adapter.displayName,
+      // Main word only, every authority field unspecified — the same contract
+      // paste and plain text honour. A competitor's synonyms are not imported
+      // in v1, so an existing word is skipped rather than modified.
+      candidates: canonicals.map { CustomWordsImportCandidate(canonical: $0) }
+    )
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -157,46 +157,52 @@ package struct WisprFlowAdapter: SmartImportAdapter {
       WHERE isDeleted = 0 AND isSnippet = 0
       """
 
-    // Plain read-only FIRST, immutable only as a fallback — and the order is
-    // load-bearing in both directions (code review, then measured).
+    // Choose the connection mode from the WAL sidecar, rather than trying one
+    // and falling back (code reviews r1 + r2, both measured).
     //
-    // Review asked for plain read-only, because `immutable=1` promises SQLite
-    // the file cannot change and lets it skip WAL handling: with Wispr Flow
-    // open and writing, that can read stale or torn rows. Correct concern.
+    // r1 asked for plain read-only, because `immutable=1` lets SQLite skip WAL
+    // handling and can return stale or torn rows while Wispr Flow writes. Real
+    // concern. But measured on a real install with the app NOT running, plain
+    // read-only opens and then fails to prepare with SQLITE_CANTOPEN: the
+    // database is WAL and a read-only connection needs the `-shm` sidecar,
+    // which a cleanly closed app does not leave behind.
     //
-    // But plain read-only alone does not work here. This database uses WAL,
-    // and a read-only connection needs the `-shm` sidecar; when the app is
-    // closed cleanly that file does not exist and read-only mode may not
-    // create it. Measured on a real install with the app NOT running: plain
-    // read-only opens and then fails to prepare with SQLITE_CANTOPEN, while
-    // immutable succeeds.
+    // r2 then caught what try-and-fallback risks: `SQLITE_OPEN_READONLY`
+    // protects the main database only. A read-only connection CAN create
+    // `-wal`/`-shm` in a writable directory, so merely attempting it can
+    // leave files inside another app's data folder — which is not read-only
+    // in any sense the user would recognise. It did not happen here (the
+    // attempt failed first), but "it happens to fail safely" is not a
+    // guarantee worth shipping.
     //
-    // So: try the WAL-aware connection first, which is what succeeds while the
-    // other app is live and holds its sidecars. Fall back to immutable only
-    // when that fails — which is precisely the cleanly-closed case, where
-    // there is no uncommitted WAL content to miss and the committed file IS
-    // the whole truth.
-    for uri in ["file:\(url.path)", "file:\(url.path)?immutable=1"] {
-      var db: OpaquePointer?
-      guard
-        sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK,
-        let db
-      else {
-        sqlite3_close(db)
-        continue
-      }
-      defer { sqlite3_close(db) }
+    // So decide up front, from a fact already on disk:
+    //   WAL present  → the other app has uncommitted content, so read it
+    //                  WAL-aware. Its sidecars already exist; we create nothing.
+    //   WAL absent   → nothing uncommitted, the committed file IS the whole
+    //                  truth, and immutable reads it without ever creating a
+    //                  sidecar.
+    let walURL = URL(fileURLWithPath: url.path + "-wal")
+    let hasWAL = FileManager.default.fileExists(atPath: walURL.path)
+    let uri = hasWAL ? "file:\(url.path)" : "file:\(url.path)?immutable=1"
 
-      var statement: OpaquePointer?
-      guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
-        sqlite3_finalize(statement)
-        continue
-      }
-      defer { sqlite3_finalize(statement) }
-
-      return try readWords(from: statement)
+    var db: OpaquePointer?
+    guard
+      sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK,
+      let db
+    else {
+      sqlite3_close(db)
+      throw SmartImportError.unreadable(displayName)
     }
-    throw SmartImportError.unreadable(displayName)
+    defer { sqlite3_close(db) }
+
+    var statement: OpaquePointer?
+    guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+      sqlite3_finalize(statement)
+      throw SmartImportError.unreadable(displayName)
+    }
+    defer { sqlite3_finalize(statement) }
+
+    return try readWords(from: statement)
   }
 
   private func readWords(from statement: OpaquePointer?) throws -> [String] {
@@ -275,8 +281,7 @@ package struct SmartImportSource: CustomWordsImportSource {
     }
 
     guard canonicals.count <= CustomWordsImportLimits.maximumCandidates else {
-      throw ImportFileError.tooManyWords(
-        found: canonicals.count, limit: CustomWordsImportLimits.maximumCandidates)
+      throw ImportFileError.tooManyWords(limit: CustomWordsImportLimits.maximumCandidates)
     }
 
     return CustomWordsImportBatch(

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -200,6 +200,19 @@ package struct WisprFlowAdapter: SmartImportAdapter {
     }
     let uri = hasWAL ? "file:\(url.path)" : "file:\(url.path)?immutable=1"
 
+    // The check above and the open below are two moments, and Wispr Flow can
+    // start or stop writing in between (code review r4). Two ways that hurts:
+    // a WAL created after an immutable decision is ignored, silently importing
+    // stale words; a WAL that disappears makes the read-only path recreate
+    // sidecars in the competitor's directory.
+    //
+    // A snapshot copy would close the window completely, but the real database
+    // here is 151 MB — copying it to read a handful of words is a poor trade.
+    // Instead the state is re-checked after the read (see below): if it moved,
+    // the import is refused rather than reported. That turns an invisible
+    // wrong answer into a visible "try again", which is the honest failure.
+    let sidecarStateAtStart = hasWAL
+
     var db: OpaquePointer?
     guard
       sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK,
@@ -217,7 +230,17 @@ package struct WisprFlowAdapter: SmartImportAdapter {
     }
     defer { sqlite3_finalize(statement) }
 
-    return try readWords(from: statement)
+    let words = try readWords(from: statement)
+
+    // Re-check the sidecar state the mode was chosen from. If Wispr Flow began
+    // or finished writing while this read was in flight, the connection mode no
+    // longer matches the database and these words may be a stale view. Refuse
+    // rather than hand back something that looks complete — the error already
+    // tells the user to quit the other app and try again.
+    guard fm.fileExists(atPath: url.path + "-wal") == sidecarStateAtStart else {
+      throw SmartImportError.unreadable(displayName)
+    }
+    return words
   }
 
   private func readWords(from statement: OpaquePointer?) throws -> [String] {

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -41,6 +41,35 @@ package protocol SmartImportAdapter: Sendable {
 }
 
 extension SmartImportAdapter {
+  /// Refuse an implausibly large vocabulary file before decoding it.
+  ///
+  /// A word list is small. Reading an arbitrarily large or corrupted file into
+  /// memory to discover it is too big is the expensive way to find out, and
+  /// can end the app before the intended error is ever shown (code review r9).
+  static var maximumVocabularyBytes: Int { 8 * 1024 * 1024 }
+
+  /// Read a vocabulary file with that ceiling applied to the READ itself.
+  func boundedData(at url: URL, appName: String) throws -> Data {
+    guard let handle = try? FileHandle(forReadingFrom: url) else {
+      throw SmartImportError.unreadable(appName)
+    }
+    defer { try? handle.close() }
+    let ceiling = Self.maximumVocabularyBytes + 1
+    var data = Data()
+    while data.count < ceiling {
+      let chunk: Data?
+      do { chunk = try handle.read(upToCount: ceiling - data.count) } catch {
+        throw SmartImportError.unreadable(appName)
+      }
+      guard let chunk, !chunk.isEmpty else { break }
+      data.append(chunk)
+    }
+    guard data.count <= Self.maximumVocabularyBytes else {
+      throw SmartImportError.unreadable(appName)
+    }
+    return data
+  }
+
   /// The first location that actually exists, or nil.
   package var installedPath: URL? {
     candidatePaths.first { FileManager.default.fileExists(atPath: $0.path) }
@@ -72,9 +101,7 @@ package struct FluidVoiceAdapter: SmartImportAdapter {
   package init() {}
 
   package func loadWords(at url: URL) throws -> [String] {
-    guard let data = try? Data(contentsOf: url) else {
-      throw SmartImportError.unreadable(displayName)
-    }
+    let data = try boundedData(at: url, appName: displayName)
     guard let vocabulary = try? JSONDecoder().decode(Vocabulary.self, from: data) else {
       throw SmartImportError.unreadable(displayName)
     }
@@ -114,9 +141,7 @@ package struct SuperwhisperAdapter: SmartImportAdapter {
   package init() {}
 
   package func loadWords(at url: URL) throws -> [String] {
-    guard let data = try? Data(contentsOf: url) else {
-      throw SmartImportError.unreadable(displayName)
-    }
+    let data = try boundedData(at: url, appName: displayName)
     guard let settings = try? JSONDecoder().decode(Settings.self, from: data) else {
       throw SmartImportError.unreadable(displayName)
     }
@@ -155,6 +180,7 @@ package struct WisprFlowAdapter: SmartImportAdapter {
       SELECT COALESCE(NULLIF(TRIM(replacement), ''), phrase)
       FROM Dictionary
       WHERE isDeleted = 0 AND isSnippet = 0
+      LIMIT \(CustomWordsImportLimits.maximumCandidates + 1)
       """
 
     // Choose the connection mode from the WAL sidecar, rather than trying one

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -181,8 +181,23 @@ package struct WisprFlowAdapter: SmartImportAdapter {
     //   WAL absent   → nothing uncommitted, the committed file IS the whole
     //                  truth, and immutable reads it without ever creating a
     //                  sidecar.
-    let walURL = URL(fileURLWithPath: url.path + "-wal")
-    let hasWAL = FileManager.default.fileExists(atPath: walURL.path)
+    // BOTH sidecars, not just the WAL (code review r3). If `-wal` exists but
+    // `-shm` does not — a crashed or mid-recovery Wispr Flow — a plain
+    // read-only connection will CREATE the missing `-shm` in a writable
+    // directory, which is the exact thing the previous round removed. And
+    // immutable is not a safe substitute here either: with real uncommitted
+    // WAL content, skipping it would import a stale view and call it complete.
+    //
+    // Neither option is honest, so refuse and say what would fix it. Quitting
+    // the other app flushes its WAL and makes the next attempt both safe and
+    // complete — which is exactly what the error message already tells the
+    // user to do.
+    let fm = FileManager.default
+    let hasWAL = fm.fileExists(atPath: url.path + "-wal")
+    let hasSHM = fm.fileExists(atPath: url.path + "-shm")
+    if hasWAL && !hasSHM {
+      throw SmartImportError.unreadable(displayName)
+    }
     let uri = hasWAL ? "file:\(url.path)" : "file:\(url.path)?immutable=1"
 
     var db: OpaquePointer?

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -323,7 +323,12 @@ package struct SmartImportSource: CustomWordsImportSource {
 
   /// `@concurrent` so a SQLite read of another app's database never runs on
   /// the main actor.
-  @concurrent package func loadCandidates() async throws -> CustomWordsImportBatch {
+  ///
+  /// Returns RAW candidates: the protocol's `loadCandidates()` validates what
+  /// this produces, so a competitor's vocabulary goes through exactly the same
+  /// character and length rules as a pasted list or an uploaded file. A source
+  /// cannot opt out of that by forgetting to call it (#1683).
+  @concurrent package func loadRawCandidates() async throws -> CustomWordsImportBatch {
     guard let path = adapter.installedPath else {
       throw SmartImportError.appNotFound(adapter.displayName)
     }
@@ -341,7 +346,12 @@ package struct SmartImportSource: CustomWordsImportSource {
     // needs a signal for having been reached; counting after the shrink loses
     // that signal — the same mistake the pasted-text parser made.
     guard words.count <= CustomWordsImportLimits.maximumCandidates else {
-      throw ImportFileError.tooManyWords(limit: CustomWordsImportLimits.maximumCandidates)
+      // `found` is a real count here, not a stop-sentinel: the adapters read
+      // exactly one past the ceiling, so this is what was actually seen. The
+      // message says "more than" either way, so it never states a figure it
+      // cannot stand behind.
+      throw ImportFileError.tooManyWords(
+        found: words.count, limit: CustomWordsImportLimits.maximumCandidates)
     }
 
     // Reuse the shared splitter's normalization so a competitor's list dedups

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -332,6 +332,18 @@ package struct SmartImportSource: CustomWordsImportSource {
     let words = try adapter.loadWords(at: path)
     try Task.checkCancellation()
 
+    // Check the RAW row count, before deduplication (code review r10).
+    //
+    // The adapters read one past the ceiling so that "too many" is knowable.
+    // But dedup shrinks the list, so a source whose first 25,001 rows contain
+    // duplicates would fall back under the limit and report a successful
+    // import that had silently dropped everything beyond it. Every ceiling
+    // needs a signal for having been reached; counting after the shrink loses
+    // that signal — the same mistake the pasted-text parser made.
+    guard words.count <= CustomWordsImportLimits.maximumCandidates else {
+      throw ImportFileError.tooManyWords(limit: CustomWordsImportLimits.maximumCandidates)
+    }
+
     // Reuse the shared splitter's normalization so a competitor's list dedups
     // exactly the way a pasted one does, and trim/blank handling is identical.
     var seen = Set<String>()
@@ -342,10 +354,6 @@ package struct SmartImportSource: CustomWordsImportSource {
       let key = CustomWordsImportCompareEngine.normalize(trimmed)
       guard !key.isEmpty, seen.insert(key).inserted else { continue }
       canonicals.append(trimmed)
-    }
-
-    guard canonicals.count <= CustomWordsImportLimits.maximumCandidates else {
-      throw ImportFileError.tooManyWords(limit: CustomWordsImportLimits.maximumCandidates)
     }
 
     return CustomWordsImportBatch(

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -99,12 +99,15 @@ package struct SuperwhisperAdapter: SmartImportAdapter {
 
   package var candidatePaths: [URL] {
     let home = FileManager.default.homeDirectoryForCurrentUser
-    // Probe BOTH: the app's current default is directly under home, while
-    // older installs keep it under Documents. Checking only one silently
-    // reports "not found" for half the installed base.
+    // Probe BOTH, CURRENT FIRST. The app's current default is directly under
+    // home; older installs keep it under Documents. Checking only one silently
+    // reports "not found" for half the installed base — but order matters just
+    // as much: an upgraded install can retain BOTH files, and probing the
+    // legacy path first would read vocabulary the user stopped editing months
+    // ago while ignoring the file the app is actually using (code review).
     return [
-      home.appendingPathComponent("Documents/superwhisper/settings/settings.json"),
       home.appendingPathComponent("superwhisper/settings/settings.json"),
+      home.appendingPathComponent("Documents/superwhisper/settings/settings.json"),
     ]
   }
 
@@ -142,21 +145,6 @@ package struct WisprFlowAdapter: SmartImportAdapter {
   package init() {}
 
   package func loadWords(at url: URL) throws -> [String] {
-    // `immutable=1` plus READONLY: this belongs to another running app. We
-    // promise never to write to it, and immutable avoids taking locks or
-    // touching its journal, so importing cannot disturb or corrupt a database
-    // the user still depends on.
-    var db: OpaquePointer?
-    let uri = "file:\(url.path)?immutable=1"
-    guard
-      sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK,
-      let db
-    else {
-      sqlite3_close(db)
-      throw SmartImportError.unreadable(displayName)
-    }
-    defer { sqlite3_close(db) }
-
     // isDeleted: a soft-delete flag. Importing unfiltered would resurrect
     // words the user deliberately removed — the single worst thing this
     // adapter could do.
@@ -168,17 +156,67 @@ package struct WisprFlowAdapter: SmartImportAdapter {
       FROM Dictionary
       WHERE isDeleted = 0 AND isSnippet = 0
       """
-    var statement: OpaquePointer?
-    guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
-      throw SmartImportError.unreadable(displayName)
+
+    // Plain read-only FIRST, immutable only as a fallback — and the order is
+    // load-bearing in both directions (code review, then measured).
+    //
+    // Review asked for plain read-only, because `immutable=1` promises SQLite
+    // the file cannot change and lets it skip WAL handling: with Wispr Flow
+    // open and writing, that can read stale or torn rows. Correct concern.
+    //
+    // But plain read-only alone does not work here. This database uses WAL,
+    // and a read-only connection needs the `-shm` sidecar; when the app is
+    // closed cleanly that file does not exist and read-only mode may not
+    // create it. Measured on a real install with the app NOT running: plain
+    // read-only opens and then fails to prepare with SQLITE_CANTOPEN, while
+    // immutable succeeds.
+    //
+    // So: try the WAL-aware connection first, which is what succeeds while the
+    // other app is live and holds its sidecars. Fall back to immutable only
+    // when that fails — which is precisely the cleanly-closed case, where
+    // there is no uncommitted WAL content to miss and the committed file IS
+    // the whole truth.
+    for uri in ["file:\(url.path)", "file:\(url.path)?immutable=1"] {
+      var db: OpaquePointer?
+      guard
+        sqlite3_open_v2(uri, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil) == SQLITE_OK,
+        let db
+      else {
+        sqlite3_close(db)
+        continue
+      }
+      defer { sqlite3_close(db) }
+
+      var statement: OpaquePointer?
+      guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+        sqlite3_finalize(statement)
+        continue
+      }
+      defer { sqlite3_finalize(statement) }
+
+      return try readWords(from: statement)
     }
-    defer { sqlite3_finalize(statement) }
+    throw SmartImportError.unreadable(displayName)
+  }
+
+  private func readWords(from statement: OpaquePointer?) throws -> [String] {
 
     var words: [String] = []
-    while sqlite3_step(statement) == SQLITE_ROW {
+    var result = sqlite3_step(statement)
+    while result == SQLITE_ROW {
       if let text = sqlite3_column_text(statement, 0) {
         words.append(String(cString: text))
       }
+      result = sqlite3_step(statement)
+    }
+    // Only SQLITE_DONE means "that was all of them" (code review). The first
+    // version treated every non-ROW result as the end, so SQLITE_BUSY on a
+    // database Wispr Flow was writing — or IOERR, or CORRUPT — returned
+    // whatever prefix had been read so far, possibly nothing at all, and the
+    // import reported success. A partial read presented as a complete one is
+    // the same false-pass shape as a test that never runs.
+    guard result == SQLITE_DONE else {
+      throw SmartImportError.unreadable(displayName)
     }
     return words
   }

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -219,25 +219,36 @@ package struct WisprFlowAdapter: SmartImportAdapter {
     // complete — which is exactly what the error message already tells the
     // user to do.
     let fm = FileManager.default
-    let hasWAL = fm.fileExists(atPath: url.path + "-wal")
-    let hasSHM = fm.fileExists(atPath: url.path + "-shm")
-    if hasWAL && !hasSHM {
+    func sidecarsExist() -> Bool {
+      fm.fileExists(atPath: url.path + "-wal") || fm.fileExists(atPath: url.path + "-shm")
+    }
+    // ANY sidecar means refuse — and the connection is ALWAYS immutable.
+    //
+    // The earlier shape read WAL-aware when a WAL was present, which required
+    // a non-immutable connection, which is the only mode that can CREATE
+    // files. That left a race no re-check could close: if the other app quit
+    // between this decision and the open, both sidecars vanished, SQLite
+    // recreated empty ones inside their directory, and the after-read check
+    // then saw a WAL again and called the import good (Codex review, #1686).
+    //
+    // Refusing instead removes the mode that can write at all, so there is no
+    // window left to lose. It costs the user one step — quit the other app,
+    // which flushes its WAL — and that is exactly what the error already asks
+    // for. Reading a live database was never going to be both safe and
+    // complete; this picks the honest half.
+    guard !sidecarsExist() else {
       throw SmartImportError.unreadable(displayName)
     }
-    let uri = hasWAL ? "file:\(url.path)" : "file:\(url.path)?immutable=1"
+    let uri = "file:\(url.path)?immutable=1"
 
-    // The check above and the open below are two moments, and Wispr Flow can
-    // start or stop writing in between (code review r4). Two ways that hurts:
-    // a WAL created after an immutable decision is ignored, silently importing
-    // stale words; a WAL that disappears makes the read-only path recreate
-    // sidecars in the competitor's directory.
-    //
-    // A snapshot copy would close the window completely, but the real database
-    // here is 151 MB — copying it to read a handful of words is a poor trade.
-    // Instead the state is re-checked after the read (see below): if it moved,
-    // the import is refused rather than reported. That turns an invisible
-    // wrong answer into a visible "try again", which is the honest failure.
-    let sidecarStateAtStart = hasWAL
+    // The check above and the open below are still two moments: Wispr Flow can
+    // START writing in between, and immutable would then read a stale view
+    // that ignores its uncommitted WAL. A snapshot copy would close the window
+    // completely, but the real database is 151 MB — copying it to read a
+    // handful of words is a poor trade. The state is re-checked after the read
+    // instead: if a sidecar appeared, the words may be stale, so refuse rather
+    // than report. Immutable cannot create one, so a sidecar found afterwards
+    // is always the other app's doing, never ours.
 
     var db: OpaquePointer?
     guard
@@ -263,7 +274,7 @@ package struct WisprFlowAdapter: SmartImportAdapter {
     // longer matches the database and these words may be a stale view. Refuse
     // rather than hand back something that looks complete — the error already
     // tells the user to quit the other app and try again.
-    guard fm.fileExists(atPath: url.path + "-wal") == sidecarStateAtStart else {
+    guard !sidecarsExist() else {
       throw SmartImportError.unreadable(displayName)
     }
     return words

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -199,4 +199,30 @@ struct CustomWordsExportWriterTests {
       !CustomWordsExportWriter.wouldOverwriteLiveWords(
         dir.appendingPathComponent("EnviousWispr Words.json")))
   }
+
+  @Test("a shouty spelling of the live file is still refused")
+  func exportRefusalIsCaseInsensitive() throws {
+    // macOS is case-insensitive by default, so CUSTOM-WORDS.JSON and
+    // custom-words.json are ONE file that string equality calls two. Picking
+    // the loud spelling would otherwise walk straight past the guard into the
+    // data loss it exists to prevent (code review r6).
+    let live = try #require(CustomWordsManager.liveFileURL)
+    let shouty = live
+      .deletingLastPathComponent()
+      .appendingPathComponent(live.lastPathComponent.uppercased())
+
+    #expect(CustomWordsExportWriter.wouldOverwriteLiveWords(shouty))
+  }
+
+  @Test("a different file in the same folder is still allowed")
+  func exportAllowsASiblingOfTheLiveFile() throws {
+    // The guard must be narrow: refusing the whole folder would stop someone
+    // legitimately exporting next to it.
+    let live = try #require(CustomWordsManager.liveFileURL)
+    let sibling = live
+      .deletingLastPathComponent()
+      .appendingPathComponent("my-words-export.json")
+
+    #expect(!CustomWordsExportWriter.wouldOverwriteLiveWords(sibling))
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -161,4 +161,42 @@ struct CustomWordsExportWriterTests {
     #expect(["Kubernetes", "Anthropic"].contains(try #require(decoded.words.first).canonical))
     #expect(decoded.words.count == 1)
   }
+
+  @Test("exporting onto EnviousWispr's own words file is refused")
+  func exportRefusesToOverwriteTheLiveWordsFile() async throws {
+    // The worst possible outcome of an export: choosing the app's own storage
+    // as the destination would atomically replace the live dictionary with the
+    // transfer format, the next launch would find a file it cannot parse and
+    // archive it as corrupt, and the user would have destroyed their words BY
+    // EXPORTING THEM (code review r5).
+    let live = try #require(CustomWordsManager.liveFileURL)
+
+    await #expect(
+      throws: CustomWordsExportWriter.ExportDestinationError.wouldOverwriteLiveWords
+    ) {
+      try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: live)
+    }
+  }
+
+  @Test("the refusal cannot be walked around with a relative path")
+  func exportRefusalResolvesPathsBeforeComparing() async throws {
+    let live = try #require(CustomWordsManager.liveFileURL)
+    // Same file, spelled the long way round.
+    let indirect = live
+      .deletingLastPathComponent()
+      .appendingPathComponent("..")
+      .appendingPathComponent(live.deletingLastPathComponent().lastPathComponent)
+      .appendingPathComponent(live.lastPathComponent)
+
+    #expect(CustomWordsExportWriter.wouldOverwriteLiveWords(indirect))
+  }
+
+  @Test("an ordinary destination is still allowed")
+  func exportAllowsAnOrdinaryDestination() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    #expect(
+      !CustomWordsExportWriter.wouldOverwriteLiveWords(
+        dir.appendingPathComponent("EnviousWispr Words.json")))
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsExportWriterTests.swift
@@ -174,7 +174,7 @@ struct CustomWordsExportWriterTests {
     await #expect(
       throws: CustomWordsExportWriter.ExportDestinationError.wouldOverwriteLiveWords
     ) {
-      try await CustomWordsExportWriter.write(document(["Kubernetes"]), to: live)
+      try await CustomWordsExportWriter.write(try encoded(["Kubernetes"]), to: live)
     }
   }
 

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -214,17 +214,6 @@ struct ImportFileParserTests {
     }
   }
 
-  @Test("a file with more words than the limit is refused with both numbers")
-  func tooManyWordsIsRefusedWithCounts() async throws {
-    let limit = FileImportSource.maximumCandidates
-    let words = (0...limit).map { "word\($0)" }.joined(separator: "\n")
-    let url = try write(words, as: "many.txt")
-
-    await #expect(throws: ImportFileError.tooManyWords(limit: limit)) {
-      _ = try await FileImportSource(url: url).loadCandidates()
-    }
-  }
-
   @Test("a file exactly at the limit is accepted")
   func fileAtExactlyTheLimitIsAccepted() async throws {
     let limit = FileImportSource.maximumCandidates

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -220,9 +220,7 @@ struct ImportFileParserTests {
     let words = (0...limit).map { "word\($0)" }.joined(separator: "\n")
     let url = try write(words, as: "many.txt")
 
-    await #expect(
-      throws: ImportFileError.tooManyWords(found: limit + 1, limit: limit)
-    ) {
+    await #expect(throws: ImportFileError.tooManyWords(limit: limit)) {
       _ = try await FileImportSource(url: url).loadCandidates()
     }
   }

--- a/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
@@ -184,4 +184,21 @@ struct PasteWordsImportSourceTests {
       .loadCandidates()
     #expect(Set(batch.candidates.map(\.id)).count == 3)
   }
+
+  @Test("a huge duplicate-only paste stops scanning instead of grinding")
+  func duplicateHeavyInputIsBoundedByScanNotOnlyByDistinctWords() {
+    // "a,a,a,a…" never grows the distinct-word count, so a ceiling expressed
+    // only in results would keep tokenizing millions of duplicates before
+    // producing an answer (code review r7). Whichever ceiling comes first
+    // ends the work.
+    let duplicates = Array(repeating: "a", count: 200_000).joined(separator: ",")
+    let parsed = PasteWordsParser.parse(duplicates, limit: 10)
+    #expect(parsed == ["a"])
+  }
+
+  @Test("a bounded parse still returns everything under the limit")
+  func boundedParseIsExactUnderTheLimit() {
+    let words = (1...50).map { "word\($0)" }.joined(separator: "\n")
+    #expect(PasteWordsParser.parse(words, limit: 25_000).count == 50)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/PasteWordsImportSourceTests.swift
@@ -186,19 +186,19 @@ struct PasteWordsImportSourceTests {
   }
 
   @Test("a huge duplicate-only paste stops scanning instead of grinding")
-  func duplicateHeavyInputIsBoundedByScanNotOnlyByDistinctWords() {
+  func duplicateHeavyInputIsBoundedByScanNotOnlyByDistinctWords() throws {
     // "a,a,a,a…" never grows the distinct-word count, so a ceiling expressed
     // only in results would keep tokenizing millions of duplicates before
     // producing an answer (code review r7). Whichever ceiling comes first
     // ends the work.
     let duplicates = Array(repeating: "a", count: 200_000).joined(separator: ",")
-    let parsed = PasteWordsParser.parse(duplicates, limit: 10)
+    let parsed = try PasteWordsParser.parse(duplicates, limit: 10)
     #expect(parsed == ["a"])
   }
 
   @Test("a bounded parse still returns everything under the limit")
-  func boundedParseIsExactUnderTheLimit() {
+  func boundedParseIsExactUnderTheLimit() throws {
     let words = (1...50).map { "word\($0)" }.joined(separator: "\n")
-    #expect(PasteWordsParser.parse(words, limit: 25_000).count == 50)
+    #expect(try PasteWordsParser.parse(words, limit: 25_000).count == 50)
   }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -177,6 +177,39 @@ struct SmartImportSourceTests {
     #expect(try WisprFlowAdapter().loadWords(at: url).contains("blank replacement"))
   }
 
+  @Test("a half-recovered database is refused rather than written into")
+  func walWithoutShmIsRefused() throws {
+    // -wal present but -shm missing means a crashed or mid-recovery Wispr
+    // Flow. A plain read-only connection would CREATE the missing -shm inside
+    // that app's directory, and immutable would skip real uncommitted content
+    // and call a stale view complete. Neither is honest, so refuse and let the
+    // error tell them to quit the app — which flushes the WAL and makes the
+    // next attempt both safe and complete.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(in: dir)
+    try Data("pretend wal".utf8).write(to: URL(fileURLWithPath: url.path + "-wal"))
+
+    #expect(throws: SmartImportError.unreadable("Wispr Flow")) {
+      _ = try WisprFlowAdapter().loadWords(at: url)
+    }
+    // And nothing was created on the way out.
+    #expect(!FileManager.default.fileExists(atPath: url.path + "-shm"))
+  }
+
+  @Test("a cleanly closed database is read without creating sidecars")
+  func cleanDatabaseLeavesNoSidecarsBehind() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(in: dir)
+
+    _ = try WisprFlowAdapter().loadWords(at: url)
+
+    // Reading another app's data must never write into its folder.
+    #expect(!FileManager.default.fileExists(atPath: url.path + "-wal"))
+    #expect(!FileManager.default.fileExists(atPath: url.path + "-shm"))
+  }
+
   // MARK: - Source contract
 
   @Test("an app that isn't installed reports not found rather than failing oddly")

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -1,0 +1,240 @@
+import EnviousWisprCore
+import Foundation
+import SQLite3
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1686 — reading vocabulary out of other dictation apps.
+///
+/// Fixtures mirror each app's real on-disk shape, captured from live data on
+/// 2026-07-19. The filter tests carry the most weight: importing a word the
+/// user deliberately deleted in another app is the worst thing these adapters
+/// could do, and it would look like success.
+@Suite("SmartImport")
+struct SmartImportSourceTests {
+
+  private func makeDirectory() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-smart-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  private func write(_ text: String, to dir: URL, as name: String) throws -> URL {
+    let url = dir.appendingPathComponent(name)
+    try Data(text.utf8).write(to: url)
+    return url
+  }
+
+  // MARK: - FluidVoice
+
+  @Test("FluidVoice terms are read and its tuning parameters ignored")
+  func fluidVoiceReadsOnlyTerms() throws {
+    // Real shape: the keys beside `terms` are that app's ASR tuning knobs.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      """
+      { "alpha": 2.8, "minCtcScore": -2.2, "minSimilarity": 0.72, "minTermLength": 3,
+        "terms": [ { "text": "FluidVoice", "aliases": ["fluid voice"], "weight": 10.0 },
+                   { "text": "Kubernetes", "aliases": [], "weight": 1.0 } ] }
+      """, to: dir, as: "v.json")
+
+    #expect(try FluidVoiceAdapter().loadWords(at: url) == ["FluidVoice", "Kubernetes"])
+  }
+
+  @Test("a FluidVoice file with no terms key is a fresh install, not a failure")
+  func fluidVoiceMissingTermsIsEmptyNotAnError() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(#"{ "alpha": 2.8 }"#, to: dir, as: "v.json")
+    #expect(try FluidVoiceAdapter().loadWords(at: url).isEmpty)
+  }
+
+  // MARK: - Superwhisper
+
+  @Test("Superwhisper reads plain vocabulary and the corrected side of replacements")
+  func superwhisperReadsVocabularyAndReplacementTargets() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      """
+      { "favoriteModelIDs": ["vad-v2"],
+        "replacements": [ { "id": "A", "original": "super whisper", "with": "Superwhisper" } ],
+        "vocabulary": ["Superwhisper", "Saurabh"] }
+      """, to: dir, as: "settings.json")
+
+    // The `with` side is the spelling the user actually wants. `original` is
+    // the alias, and v1 does not import aliases.
+    #expect(
+      try SuperwhisperAdapter().loadWords(at: url)
+        == ["Superwhisper", "Saurabh", "Superwhisper"])
+  }
+
+  @Test("a Superwhisper file missing both keys reads as empty")
+  func superwhisperMissingKeysIsEmpty() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(#"{ "modeKeys": [] }"#, to: dir, as: "settings.json")
+    #expect(try SuperwhisperAdapter().loadWords(at: url).isEmpty)
+  }
+
+  @Test("Superwhisper probes both the current and legacy locations")
+  func superwhisperProbesBothLocations() {
+    let paths = SuperwhisperAdapter().candidatePaths.map(\.path)
+    // Checking only one silently reports "not found" for half the install base.
+    #expect(paths.contains { $0.contains("Documents/superwhisper") })
+    #expect(paths.contains { !$0.contains("Documents") && $0.contains("superwhisper") })
+  }
+
+  // MARK: - Wispr Flow
+
+  /// Builds a database with Wispr Flow's real column shape.
+  private func makeWisprFlowDatabase(in dir: URL) throws -> URL {
+    let url = dir.appendingPathComponent("flow.sqlite")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    defer { sqlite3_close(db) }
+    let schema = """
+      CREATE TABLE Dictionary (id VARCHAR(36) PRIMARY KEY, phrase VARCHAR(255) NOT NULL,
+        replacement VARCHAR(255), isDeleted TINYINT DEFAULT 0, isSnippet TINYINT DEFAULT 0);
+      INSERT INTO Dictionary VALUES ('1','Wispr Flow',NULL,0,0);
+      INSERT INTO Dictionary VALUES ('2','btw','by the way',0,0);
+      INSERT INTO Dictionary VALUES ('3','deleted word',NULL,1,0);
+      INSERT INTO Dictionary VALUES ('4','sig','my long signature',0,1);
+      INSERT INTO Dictionary VALUES ('5','blank replacement','   ',0,0);
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+    return url
+  }
+
+  @Test("Wispr Flow never imports a word the user deleted there")
+  func wisprFlowFiltersSoftDeletedEntries() throws {
+    // The worst thing this adapter could do is resurrect words someone
+    // deliberately removed — and it would look like a successful import.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(in: dir)
+
+    let words = try WisprFlowAdapter().loadWords(at: url)
+    #expect(!words.contains("deleted word"))
+  }
+
+  @Test("Wispr Flow skips text-expansion snippets")
+  func wisprFlowFiltersSnippets() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(in: dir)
+
+    // Snippets are a different feature, not vocabulary.
+    let words = try WisprFlowAdapter().loadWords(at: url)
+    #expect(!words.contains("my long signature"))
+    #expect(!words.contains("sig"))
+  }
+
+  @Test("Wispr Flow takes the corrected spelling when there is one")
+  func wisprFlowPrefersReplacementOverPhrase() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(in: dir)
+
+    let words = try WisprFlowAdapter().loadWords(at: url)
+    // `btw → by the way`: the corrected side is the word worth having.
+    #expect(words.contains("by the way"))
+    #expect(!words.contains("btw"))
+    // No replacement at all: the phrase itself is the word.
+    #expect(words.contains("Wispr Flow"))
+  }
+
+  @Test("a whitespace-only replacement falls back to the phrase")
+  func wisprFlowTreatsBlankReplacementAsAbsent() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(in: dir)
+
+    // An empty-but-present replacement would otherwise import a blank word.
+    #expect(try WisprFlowAdapter().loadWords(at: url).contains("blank replacement"))
+  }
+
+  // MARK: - Source contract
+
+  @Test("an app that isn't installed reports not found rather than failing oddly")
+  func missingAppReportsNotFound() async throws {
+    struct Missing: SmartImportAdapter {
+      let identifier = "missing"
+      let displayName = "Nothing"
+      var candidatePaths: [URL] { [URL(fileURLWithPath: "/nonexistent/nope.json")] }
+      func loadWords(at url: URL) throws -> [String] { [] }
+    }
+    await #expect(throws: SmartImportError.appNotFound("Nothing")) {
+      _ = try await SmartImportSource(adapter: Missing()).loadCandidates()
+    }
+  }
+
+  @Test("imported words carry no authority over any field")
+  func candidatesClaimNoAuthority() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "Kubernetes", "aliases": ["k8s"] } ] }"#, to: dir, as: "v.json")
+
+    struct Fixed: SmartImportAdapter {
+      let identifier = "fluidvoice"
+      let displayName = "FluidVoice"
+      let url: URL
+      var candidatePaths: [URL] { [url] }
+      func loadWords(at url: URL) throws -> [String] {
+        try FluidVoiceAdapter().loadWords(at: url)
+      }
+    }
+
+    let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
+    let candidate = try #require(batch.candidates.first)
+
+    // v1 imports the main word only. Even though FluidVoice HAS aliases for
+    // this term, they are not brought across — so an existing word is skipped
+    // rather than modified.
+    #expect(candidate.canonical == "Kubernetes")
+    #expect(candidate.aliases == .unspecified)
+    #expect(candidate.category == .unspecified)
+    #expect(candidate.suggestedAliases.isEmpty)
+    #expect(batch.sourceID == "fluidvoice")
+  }
+
+  @Test("duplicates across an app's own lists collapse once")
+  func duplicatesCollapseUsingTheSharedKey() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      """
+      { "vocabulary": ["Superwhisper", "superwhisper"],
+        "replacements": [ { "original": "super whisper", "with": "Superwhisper" } ] }
+      """, to: dir, as: "settings.json")
+
+    struct Fixed: SmartImportAdapter {
+      let identifier = "superwhisper"
+      let displayName = "Superwhisper"
+      let url: URL
+      var candidatePaths: [URL] { [url] }
+      func loadWords(at url: URL) throws -> [String] {
+        try SuperwhisperAdapter().loadWords(at: url)
+      }
+    }
+
+    let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
+    // Same normalization the paste and file paths use, so a competitor list
+    // dedups exactly the way a typed one does.
+    #expect(batch.candidates.map(\.canonical) == ["Superwhisper"])
+  }
+
+  @Test("the registry ships the three verified apps and not the unverified one")
+  func registryShipsOnlyVerifiedAdapters() {
+    let ids = SmartImportRegistry.v1.adapters.map(\.identifier)
+    #expect(ids.sorted() == ["fluidvoice", "superwhisper", "wispr-flow"])
+    // TypeWhisper is absent deliberately: its table is empty on the only
+    // machine available, so an adapter would be written against a shape nobody
+    // has seen populated.
+    #expect(!ids.contains("typewhisper"))
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -197,6 +197,42 @@ struct SmartImportSourceTests {
     #expect(!FileManager.default.fileExists(atPath: url.path + "-shm"))
   }
 
+  @Test("a live database with both sidecars is refused, not read WAL-aware")
+  func liveDatabaseWithSidecarsIsRefused() throws {
+    // Reading WAL-aware required a connection mode that can CREATE files, and
+    // that mode is the only way this can ever write into another app's folder.
+    // If the app quit between the check and the open, SQLite recreated empty
+    // sidecars there — and the after-read check then saw a WAL again and
+    // called the import good (Codex review, #1686).
+    //
+    // Refusing removes the writable mode entirely, so there is no window left
+    // to lose. The cost is one step the error already asks for: quit the app.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(in: dir)
+    try Data("pretend wal".utf8).write(to: URL(fileURLWithPath: url.path + "-wal"))
+    try Data("pretend shm".utf8).write(to: URL(fileURLWithPath: url.path + "-shm"))
+
+    #expect(throws: SmartImportError.unreadable("Wispr Flow")) {
+      _ = try WisprFlowAdapter().loadWords(at: url)
+    }
+  }
+
+  @Test("an -shm alone is refused too, whichever sidecar it is")
+  func shmWithoutWalIsRefused() throws {
+    // The rule is "any sidecar", not "the WAL": naming one of a pair is how
+    // the earlier version left a case uncovered.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(in: dir)
+    try Data("pretend shm".utf8).write(to: URL(fileURLWithPath: url.path + "-shm"))
+
+    #expect(throws: SmartImportError.unreadable("Wispr Flow")) {
+      _ = try WisprFlowAdapter().loadWords(at: url)
+    }
+    #expect(!FileManager.default.fileExists(atPath: url.path + "-wal"))
+  }
+
   @Test("a cleanly closed database is read without creating sidecars")
   func cleanDatabaseLeavesNoSidecarsBehind() throws {
     let dir = makeDirectory()

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -336,7 +336,9 @@ struct SmartImportSourceTests {
     }
 
     await #expect(
-      throws: ImportFileError.tooManyWords(limit: CustomWordsImportLimits.maximumCandidates)
+      throws: ImportFileError.tooManyWords(
+        found: CustomWordsImportLimits.maximumCandidates + 1,
+        limit: CustomWordsImportLimits.maximumCandidates)
     ) {
       _ = try await SmartImportSource(adapter: Flood()).loadCandidates()
     }

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -290,4 +290,27 @@ struct SmartImportSourceTests {
     // has seen populated.
     #expect(!ids.contains("typewhisper"))
   }
+
+  @Test("an implausibly large vocabulary file is refused before decoding")
+  func oversizedVocabularyFileIsRefusedBeforeDecoding() throws {
+    // Reading an arbitrary file into memory to discover it is too big can end
+    // the app before the intended error is ever shown (code review r9).
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("v.json")
+    let huge = Data(count: FluidVoiceAdapter.maximumVocabularyBytes + 1)
+    try huge.write(to: url)
+
+    #expect(throws: SmartImportError.unreadable("FluidVoice")) {
+      _ = try FluidVoiceAdapter().loadWords(at: url)
+    }
+  }
+
+  @Test("a normal-sized vocabulary file is still read")
+  func normalSizedVocabularyFileIsAccepted() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(#"{ "terms": [ { "text": "Kubernetes" } ] }"#, to: dir, as: "v.json")
+    #expect(try FluidVoiceAdapter().loadWords(at: url) == ["Kubernetes"])
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -313,4 +313,32 @@ struct SmartImportSourceTests {
     let url = try write(#"{ "terms": [ { "text": "Kubernetes" } ] }"#, to: dir, as: "v.json")
     #expect(try FluidVoiceAdapter().loadWords(at: url) == ["Kubernetes"])
   }
+
+  @Test("a truncated read is refused even when duplicates hide it")
+  func truncatedReadIsRefusedEvenWhenDedupHidesIt() async throws {
+    // The trap (code review r10): the adapter reads one past the ceiling so
+    // "too many" is knowable, but deduplication SHRINKS the list — so a source
+    // whose overflowing rows are duplicates would fall back under the limit
+    // and report a successful import that had silently dropped the rest.
+    // Every ceiling needs a signal for having been reached, and counting after
+    // the shrink loses it.
+    struct Flood: SmartImportAdapter {
+      let identifier = "flood"
+      let displayName = "Flood"
+      var candidatePaths: [URL] { [URL(fileURLWithPath: "/dev/null")] }
+      func loadWords(at url: URL) throws -> [String] {
+        // One past the ceiling, and all identical: dedup collapses this to a
+        // single word, which would look like a tiny successful import.
+        Array(
+          repeating: "duplicate",
+          count: CustomWordsImportLimits.maximumCandidates + 1)
+      }
+    }
+
+    await #expect(
+      throws: ImportFileError.tooManyWords(limit: CustomWordsImportLimits.maximumCandidates)
+    ) {
+      _ = try await SmartImportSource(adapter: Flood()).loadCandidates()
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -80,12 +80,32 @@ struct SmartImportSourceTests {
     #expect(try SuperwhisperAdapter().loadWords(at: url).isEmpty)
   }
 
-  @Test("Superwhisper probes both the current and legacy locations")
-  func superwhisperProbesBothLocations() {
+  @Test("Superwhisper probes the current location before the legacy one")
+  func superwhisperProbesCurrentLocationFirst() {
     let paths = SuperwhisperAdapter().candidatePaths.map(\.path)
-    // Checking only one silently reports "not found" for half the install base.
-    #expect(paths.contains { $0.contains("Documents/superwhisper") })
-    #expect(paths.contains { !$0.contains("Documents") && $0.contains("superwhisper") })
+    // Checking only one silently reports "not found" for half the install
+    // base — and ORDER matters just as much: an upgraded install can retain
+    // both files, and probing legacy first reads vocabulary the user stopped
+    // editing months ago while ignoring the file the app actually uses.
+    #expect(paths.count == 2)
+    #expect(!paths[0].contains("Documents"))
+    #expect(paths[1].contains("Documents/superwhisper"))
+  }
+
+  @Test("a corrupt database is refused rather than importing whatever was read")
+  func corruptDatabaseIsRefusedRatherThanPartiallyImported() throws {
+    // A partial read presented as a complete import is the same false-pass
+    // shape as a test that never runs: the user would see "imported 3 words"
+    // and never learn the other forty were unreachable.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("flow.sqlite")
+    // A file that opens as a database but whose table cannot be read.
+    try Data("SQLite format 3\u{0}garbage-not-a-real-database".utf8).write(to: url)
+
+    #expect(throws: SmartImportError.unreadable("Wispr Flow")) {
+      _ = try WisprFlowAdapter().loadWords(at: url)
+    }
   }
 
   // MARK: - Wispr Flow


### PR DESCRIPTION
Brings your words across from another dictation app. The last of the five import/export pieces (#1619).

## What a user gets

Pick "From another app", choose the one you used before, and your vocabulary comes over. Three apps are supported: FluidVoice, Superwhisper, and Wispr Flow. Only apps actually installed on the Mac are offered, and nothing on disk is touched until you choose one — an installed competitor is never quietly inspected in the background.

Everything lands on the same Review screen as every other import, so nothing is added until you approve it, and words you already have are left exactly as they are.

## Reading someone else's data

This is the part worth reviewing closely, because it reads files another app owns.

- **We never write into their folder.** The database is opened in a strictly non-writing mode, always. Reading it any other way requires a mode that can create files, and that mode is the only path by which this code could ever leave something behind in their directory.
- **If their app is running, we decline.** Any sidecar file present means refuse, with an error telling the user to quit that app and try again. Reading a live database was never going to be both safe and complete; this picks the honest half.
- **A partial read is never reported as success.** Only a clean end-of-results counts as "that was all of them" — a busy or corrupt database refuses rather than importing whatever prefix it managed.
- **Deleted words stay deleted.** Wispr Flow soft-deletes; importing unfiltered would resurrect words the user deliberately removed.
- **Ceilings are checked before deduplication**, so a source whose first 25,001 rows are duplicates cannot shrink under the limit and report a truncated import as complete.

## Rebase note

This branch predated the upload work that just merged. Both had independently fixed several of the same review findings; main's versions were consistently further along and won every shared file. One guard main lacked was carried across: **exporting onto EnviousWispr's own words file is refused**, since choosing it would replace the live dictionary with a different format and destroy the words by exporting them.

Two protections dropped as superseded were verified rather than assumed — a 200,000-duplicate paste completes in 0.26s on main's scanner, and main's own test proves the file path reports overflow honestly.

## Validation

3487 tests green. Local Codex clean over two rounds; both rounds' findings were real races, fixed by removing the window rather than guarding it, and each fix was confirmed by deleting it and watching the new tests fail.
