### PR TITLE
fix(user): two running copies no longer share one scratch file (#1690)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -2,13 +2,16 @@ import Foundation
 
 /// Writes a backup file to a destination the user chose (#1680, PR-E1).
 ///
-/// Same guards as `CustomWordsManager.saveFile` — exclusive create, mode 0600,
-/// atomic publish, cleanup on failure — with one deliberate difference: the
-/// temp filename is **unique**, not fixed. The live `custom-words.json` has
-/// exactly one writer, so a fixed `.tmp` sibling is safe there. An export
-/// destination is a folder the user picked, and two exports can target it at
-/// once; a shared temp name would let them overwrite each other's partial
-/// bytes and produce one corrupt file.
+/// Same guards as `CustomWordsManager.saveFile` — unique temp filename,
+/// exclusive create, mode 0600, atomic publish, cleanup on failure.
+///
+/// This file used to claim the live `custom-words.json` "has exactly one
+/// writer, so a fixed `.tmp` sibling is safe there," and that sentence is why
+/// the manager kept the weaker shape. It is not true: two running instances
+/// are two writers, and a shared temp name plus `O_TRUNC` let one silently
+/// overwrite the other's partial bytes, publishing whichever landed last as
+/// the user's whole library (#1690). Both writers now use the same guards,
+/// because the reason for them was never the destination.
 package enum CustomWordsExportWriter {
   /// `@concurrent` so this always runs OFF the caller's actor (code review r5).
   /// The caller is a SwiftUI button action on the main actor, and a plain

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -1039,25 +1039,53 @@ public final class CustomWordsManager {
   /// then renames into place. Mirrors `KeychainManager.store` to avoid the
   /// brief world-readable window that `Data.write(.atomic)` + post-write
   /// chmod creates. (V3 audit #561.)
+  ///
+  /// The guard set here is `CustomWordsExportWriter`'s, ported whole rather
+  /// than piecemeal (#1690). That writer had already paid for each one; this
+  /// one kept an older shape on the belief — written into that file's own
+  /// header — that "the live custom-words.json has exactly one writer, so a
+  /// fixed .tmp sibling is safe there." Two instances of the app break that,
+  /// and the cost is the user's entire vocabulary:
+  ///
+  ///  - **Unique temp name**, not a fixed `.custom-words.json.tmp`. With a
+  ///    shared name plus `O_TRUNC`, a second writer wipes the first's partial
+  ///    bytes and whichever publish lands last wins. That is not a torn file;
+  ///    it is one instance's library silently replacing another's, which is
+  ///    exactly what the artifact quarantined on 2026-07-19 looked like —
+  ///    valid JSON containing one word that did not belong there.
+  ///  - **`O_EXCL`**, so a colliding temp fails loudly instead of truncating
+  ///    somebody else's write in progress.
+  ///  - **One `rename(2)`** instead of `fileExists` then
+  ///    `replaceItemAt`/`moveItem`. That branch was check-then-act, and
+  ///    `replaceItemAt` also preserves the DESTINATION's metadata, so a live
+  ///    file that had become 0644 would stay world-readable through every
+  ///    subsequent save. `rename` is atomic, refuses a directory by the kernel
+  ///    (EISDIR), and keeps the temp file's own 0600.
   private func saveFile(_ file: CustomWordsFile) throws {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(file)
-    let tmpURL = fileURL.deletingLastPathComponent().appendingPathComponent(
-      ".custom-words.json.tmp")
+    let tmpURL = fileURL.deletingLastPathComponent()
+      .appendingPathComponent(".custom-words.json.\(UUID().uuidString).tmp")
     let fm = FileManager.default
     do {
-      let fd = Foundation.open(tmpURL.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
+      let fd = Foundation.open(tmpURL.path, O_CREAT | O_EXCL | O_WRONLY, 0o600)
       guard fd >= 0 else {
         throw CocoaError(.fileWriteUnknown)
       }
       let fh = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
       try fh.write(contentsOf: data)
       try fh.close()
-      if fm.fileExists(atPath: fileURL.path) {
-        _ = try fm.replaceItemAt(fileURL, withItemAt: tmpURL)
-      } else {
-        try fm.moveItem(at: tmpURL, to: fileURL)
+
+      // Same-directory temp file means same filesystem, which is what makes
+      // rename legal here.
+      guard Foundation.rename(tmpURL.path, fileURL.path) == 0 else {
+        throw NSError(
+          domain: NSPOSIXErrorDomain, code: Int(errno),
+          userInfo: [
+            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
+            NSFilePathErrorKey: fileURL.path,
+          ])
       }
     } catch {
       try? fm.removeItem(at: tmpURL)

--- a/Tests/EnviousWisprTests/Core/CustomWordsManagerDiskRoundTripTests.swift
+++ b/Tests/EnviousWisprTests/Core/CustomWordsManagerDiskRoundTripTests.swift
@@ -176,4 +176,86 @@ struct CustomWordsManagerDiskRoundTripTests {
     let after = try Self.readWords(at: path)
     #expect(after.first?.frequencyUsed == 4, "1 + 2 + 1 = 4 across three flushes")
   }
+
+  // MARK: - Concurrent writers (#1690)
+
+  /// The bug this freezes, made DETERMINISTIC.
+  ///
+  /// `saveFile` wrote through a FIXED temp filename with `O_TRUNC`, on the
+  /// belief — stated in `CustomWordsExportWriter`'s own header — that the live
+  /// file has exactly one writer. Two running instances are two writers: the
+  /// second truncated the first's partial bytes in the shared temp file, and
+  /// whichever publish landed last became the user's whole library.
+  ///
+  /// Racing two real saves does NOT prove this — both orderings usually
+  /// produce a readable file, so such a test passes on the broken writer too
+  /// (measured: it did). What discriminates is the shared path itself. A file
+  /// already sitting at the fixed temp name stands in for another instance's
+  /// write in progress: the old writer truncates it and renames it away, the
+  /// fixed name being the whole mechanism. A writer using a unique name plus
+  /// `O_EXCL` cannot touch it.
+  @Test("a save never writes through another instance's scratch file")
+  func saveDoesNotClobberAForeignTemporaryFile() throws {
+    let path = Self.tempFileURL()
+    defer { Self.cleanup(path) }
+    try Self.seed(path: path, words: [])
+
+    // What the OLD code used, byte for byte.
+    let sharedTemp = path.deletingLastPathComponent()
+      .appendingPathComponent(".custom-words.json.tmp")
+    let otherInstanceBytes = Data("another instance was writing here".utf8)
+    try otherInstanceBytes.write(to: sharedTemp)
+
+    let manager = CustomWordsManager(fileURL: path)
+    var words = manager.load() ?? []
+    try manager.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+
+    // Untouched: not truncated, not renamed away, not adopted as our publish.
+    #expect(
+      FileManager.default.fileExists(atPath: sharedTemp.path),
+      "the other writer's scratch file was renamed away")
+    #expect(
+      try Data(contentsOf: sharedTemp) == otherInstanceBytes,
+      "the other writer's bytes were overwritten")
+
+    // And our own save still landed correctly.
+    #expect(try Self.readWords(at: path).map(\.canonical) == ["Kubernetes"])
+  }
+
+  /// A save must never leave its scratch file behind, and never a shared one:
+  /// a fixed name is what let two writers collide in the first place.
+  @Test("a save leaves no temp file, and never a fixed shared name")
+  func saveLeavesNoTemporaryFile() throws {
+    let path = Self.tempFileURL()
+    defer { Self.cleanup(path) }
+    try Self.seed(path: path, words: [])
+
+    let manager = CustomWordsManager(fileURL: path)
+    var words = manager.load() ?? []
+    try manager.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+
+    let leftovers = try FileManager.default
+      .contentsOfDirectory(atPath: path.deletingLastPathComponent().path)
+      .filter { $0.hasPrefix(".custom-words.json") }
+    #expect(leftovers.isEmpty, "left behind: \(leftovers)")
+  }
+
+  /// `replaceItemAt` preserved the DESTINATION's metadata, so a live file that
+  /// had become world-readable stayed that way through every later save — a
+  /// file full of personal names. `rename` keeps the temp file's own 0600.
+  @Test("saving over a world-readable file restores owner-only permissions")
+  func saveEnforcesOwnerOnlyPermissions() throws {
+    let path = Self.tempFileURL()
+    defer { Self.cleanup(path) }
+    try Self.seed(path: path, words: [])
+    try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: path.path)
+
+    let manager = CustomWordsManager(fileURL: path)
+    var words = manager.load() ?? []
+    try manager.add(word: CustomWord(canonical: "Kubernetes"), to: &words)
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: path.path)
+    let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+    #expect(permissions.int16Value == 0o600)
+  }
 }


### PR DESCRIPTION
Part of #1690. Closes the scratch-file mechanism; the issue stays open for the lost-update one (see Limitation).

## The bug

Saving your word list wrote through a **fixed** temp filename with `O_TRUNC`. What made that look deliberate was a sentence in `CustomWordsExportWriter`'s own header:

> "The live custom-words.json has exactly one writer, so a fixed `.tmp` sibling is safe there."

Two running instances are two writers. The second truncated the first's partial bytes in the shared scratch file, and whichever publish landed last became the user's entire library.

This matches the artifact quarantined on 2026-07-19 during the founder's data loss: **valid** JSON holding a single word that did not belong there. Not damaged bytes — another instance's file winning a race.

## The fix

The export writer had already paid for every guard this needed, so they are ported whole rather than one at a time:

- **unique temp filename**, so two writers never share a path;
- **`O_EXCL`**, so a collision fails loudly instead of truncating someone else's write in progress;
- **one `rename(2)`** in place of `fileExists` → `replaceItemAt`/`moveItem`. That branch was check-then-act, and `replaceItemAt` also preserves the *destination's* metadata, so a live file that had become world-readable would stay that way through every later save.

The false comment is corrected too, since it is the reason the weaker shape survived.

## On the evidence

Racing two real saves does **not** prove this. I wrote that test first and it passed on the broken writer — both orderings usually produce a readable file.

The shipped test is deterministic: a file already sitting at the fixed temp path stands in for another instance mid-write. On the old code it is truncated and renamed away, failing with *"the other writer's scratch file was renamed away"*. The temp-cleanup and permissions tests pass on both writers; they are forward guards, not evidence for this change, and I have labelled them as such rather than counting them.

## Limitation — why this does not close the issue

Codex review raised a P1 that is arguably the more likely mechanism: each instance still does load → mutate → save over the **whole** library, so two copies adding different words can both succeed and the later rename silently discards the earlier change. Unique temp files cannot help — both writes are individually well-formed.

Not bolted on here because (1) `saveFile` is called from *inside* `loadFile` during legacy migration, so a naive "verify nothing moved before renaming" check needs the migration paths designed for rather than special-cased, and (2) it needs a product decision on what the user sees when two copies disagree: refuse, merge, or reload and retry. Written up with a suggested shape in #1690.

## Validation

3463 tests green. Local Codex clean apart from the P1 above, which is adjudicated as real and out of scope for this slice rather than dismissed.
