### PR TITLE
feat(user): export says what it produces, import names the file (v2-2 PR A, #1619)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
@@ -90,14 +90,25 @@ enum CustomWordsExportAction {
 
     // 4. Verify the list did not move while the user was picking a folder.
     //    Complete records, not just the count: a same-size edit is exactly the
-    //    drift a count comparison cannot see. `CustomWord` synthesizes equality
-    //    over every stored field, and array equality is order-sensitive.
+    //    drift a count comparison cannot see.
+    //
+    //    Compare the DOCUMENTS, not the words. `CustomWord` is Hashable over
+    //    every stored field including `frequencyUsed` and `lastUsed`, which the
+    //    export format deliberately omits — so comparing words would refuse a
+    //    perfectly valid export whenever usage counts moved. That is not a rare
+    //    race: the usage counter is the app's one writer that runs with NO user
+    //    action (30s debounce or 50 corrections, #1695), and the save panel sits
+    //    open for exactly as long as a person takes to pick a folder. Dictating
+    //    while that panel is open would eventually refuse every export.
+    //
+    //    The document is the export payload, so asking whether the PAYLOAD
+    //    changed is the actual question, and it needs no second definition of
+    //    which fields matter (Codex review r1, P2).
     let refreshedExportWords = exportableWords(from: coordinator.customWords)
-    guard refreshedExportWords == proposedExportWords else { return .libraryChanged }
-
-    // 5. Build from the PROPOSED array — the one the user was shown a count of.
-    //    Step 4 has just proven it equals what is on disk.
     let document = CustomWordsTransferDocument(words: proposedExportWords)
+    guard document == CustomWordsTransferDocument(words: refreshedExportWords) else {
+      return .libraryChanged
+    }
 
     // 6. Refuse to write a file our own importer would reject. The exporter
     //    and importer are one round trip, so a limit enforced on only one side

--- a/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
@@ -18,23 +18,67 @@ import Foundation
 ///   4. snapshot on the main actor, write off it.
 /// Every one of those was a separately-found bug. Keeping them in a testable
 /// unit means the sequence itself is covered, not just its parts.
+///
+/// #1697 added a count on screen and nearly broke step 1 doing it. A save
+/// panel's message must exist BEFORE the panel opens, so putting the count
+/// there would have forced the refresh ahead of the ask. Grounded review r2
+/// established what that actually costs: `refreshFromDiskIfPossible` is not an
+/// in-memory read. It can rewrite a legacy file during migration, move a
+/// corrupt file into an archive, latch session corruption state, and publish a
+/// replaced library to runtime consumers. Opening Export and CANCELLING would
+/// have done all of that — the exact bug step 1 exists to prevent.
+///
+/// So the count is derived on screen, passed in as `proposedExportWords`, and
+/// verified after the destination is chosen. One filtering authority, two
+/// time-separated snapshots: the proposed array owns both the number the user
+/// saw and the bytes written; the refreshed array only proves nothing moved.
 @MainActor
 enum CustomWordsExportAction {
   enum Outcome: Equatable {
     case cancelled
     case exported
     case refusedUnsafeLibrary
+    /// No words of the user's own. Not a failure — an honest empty state, and
+    /// the only place a pack-only user learns why their long list is excluded.
+    case nothingToExport
+    /// The library changed between the count being shown and the write. Nothing
+    /// was written. Neutral, not a failure: the user is told the number moved.
+    case libraryChanged
     case failed(message: String)
   }
 
+  /// The one filtering authority (#1697). Called once per snapshot, never once
+  /// per consumer — a count computed by a second call is a second measurement.
+  nonisolated static func exportableWords(from words: [CustomWord]) -> [CustomWord] {
+    words.filter { $0.source == .user }
+  }
+
   /// - Parameters:
+  ///   - proposedExportWords: the array the visible count was rendered from.
+  ///     The file is built from this exact array, so the number the user saw
+  ///     and the bytes on disk cannot disagree.
   ///   - chooseDestination: returns nil when the user cancels.
   ///   - write: performs the actual file write.
   static func run(
     coordinator: CustomWordsCoordinator,
+    proposedExportWords: [CustomWord],
     chooseDestination: () -> URL?,
     write: @escaping @Sendable (Data, URL) async throws -> Void
   ) async -> Outcome {
+    // An empty proposal never opens a panel: a save dialog that can only make an
+    // empty file is a trap. Refresh anyway — the on-screen count may be stale.
+    guard !proposedExportWords.isEmpty else {
+      guard coordinator.refreshFromDiskIfPossible(), coordinator.canExportCurrentWords
+      else {
+        return .refusedUnsafeLibrary
+      }
+      // Still empty after adopting disk: genuinely nothing of the user's own.
+      // No longer empty: the count the user saw was wrong, so say so rather
+      // than exporting a snapshot they were never shown.
+      return exportableWords(from: coordinator.customWords).isEmpty
+        ? .nothingToExport : .libraryChanged
+    }
+
     // 1. Ask first. Refreshing before this made cancelling mutate state.
     guard let destination = chooseDestination() else { return .cancelled }
 
@@ -44,12 +88,18 @@ enum CustomWordsExportAction {
       return .refusedUnsafeLibrary
     }
 
-    // 4. Snapshot here, synchronously, so the file reflects the moment the
-    // user confirmed rather than whenever the write happened to run.
-    let document = CustomWordsTransferDocument(
-      words: coordinator.customWords.filter { $0.source == .user })
+    // 4. Verify the list did not move while the user was picking a folder.
+    //    Complete records, not just the count: a same-size edit is exactly the
+    //    drift a count comparison cannot see. `CustomWord` synthesizes equality
+    //    over every stored field, and array equality is order-sensitive.
+    let refreshedExportWords = exportableWords(from: coordinator.customWords)
+    guard refreshedExportWords == proposedExportWords else { return .libraryChanged }
 
-    // 5. Refuse to write a file our own importer would reject. The exporter
+    // 5. Build from the PROPOSED array — the one the user was shown a count of.
+    //    Step 4 has just proven it equals what is on disk.
+    let document = CustomWordsTransferDocument(words: proposedExportWords)
+
+    // 6. Refuse to write a file our own importer would reject. The exporter
     //    and importer are one round trip, so a limit enforced on only one side
     //    is a promise the pair cannot keep.
     //

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -137,6 +137,30 @@ struct CustomWordEditSheet: View {
 
       Spacer()
 
+      // Suggestion status, LAID OUT rather than floated (#1705).
+      //
+      // This was an `.overlay(alignment: .bottomLeading)` with hardcoded
+      // padding, which put it directly on top of Delete — visually illegible,
+      // and an overlay sits above the button in the z-order, so it could
+      // intercept clicks meant for it.
+      //
+      // Height is reserved from REAL content, not a constant: both variants are
+      // laid out hidden so the row always reserves the taller one at whatever
+      // the current text size is. A fixed height would clip at larger text
+      // sizes, and a row that grows and shrinks moves Save and Delete under a
+      // cursor that is already on its way down.
+      ZStack(alignment: .leading) {
+        suggestionStatusRow(isLoading: true).hidden()
+        suggestionStatusRow(isLoading: false).hidden()
+        if isLoadingSuggestions {
+          suggestionStatusRow(isLoading: true)
+        } else if noSuggestionsAvailable {
+          suggestionStatusRow(isLoading: false)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .accessibilityElement(children: .combine)
+
       // Actions
       HStack {
         if onDelete != nil {
@@ -176,24 +200,6 @@ struct CustomWordEditSheet: View {
     }
     .padding(20)
     .frame(width: 400, height: 480)
-    .overlay(alignment: .bottomLeading) {
-      if isLoadingSuggestions {
-        HStack(spacing: 6) {
-          ProgressView().controlSize(.small)
-          Text("Getting AI suggestions...")
-            .font(.stHelper)
-            .foregroundStyle(.stTextSecondary)
-        }
-        .padding(.leading, 20)
-        .padding(.bottom, 28)
-      } else if noSuggestionsAvailable {
-        Text("No suggestions available")
-          .font(.stHelper)
-          .foregroundStyle(.stTextSecondary)
-          .padding(.leading, 20)
-          .padding(.bottom, 28)
-      }
-    }
     // Phase 1 (#637) + Phase 4 (#634) + Codex P2 fix: keyed task that restarts
     // when canonical changes. Empty-canonical guard prevents the AFM call from
     // running on the blank "+ Add term" sheet open. After the user types into
@@ -238,4 +244,24 @@ struct CustomWordEditSheet: View {
     word.aliases.append(trimmed)
     newAlias = ""
   }
+  // MARK: - Suggestion status
+
+  /// One row, two states, one shape — so the hidden layout copies that reserve
+  /// the row's height are the same views that will actually be shown.
+  @ViewBuilder
+  private func suggestionStatusRow(isLoading: Bool) -> some View {
+    if isLoading {
+      HStack(spacing: 6) {
+        ProgressView().controlSize(.small)
+        Text("Getting AI suggestions...")
+          .font(.stHelper)
+          .foregroundStyle(.stTextSecondary)
+      }
+    } else {
+      Text("No suggestions available")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+    }
+  }
+
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
@@ -5,18 +5,48 @@ import UniformTypeIdentifiers
 ///
 /// Nothing is read from the word list until this returns a destination, so
 /// cancelling is a clean no-op rather than a snapshot taken and thrown away.
+/// That ordering is load-bearing and is defended in `CustomWordsExportAction`:
+/// refreshing before this point can migrate, archive, or publish library state,
+/// so a cancelled export would stop being free (#1696, grounded review r2).
 @MainActor
 enum CustomWordsExportPanel {
+  /// The one runtime authority for what an exported file is called (#1699).
+  ///
+  /// The import screen names this file so the user can recognise what they are
+  /// holding. Two literals would let the exporter rename the file and leave the
+  /// import copy describing one that no longer exists.
+  static let defaultFilename = "EnviousWispr Words.json"
+
+  /// Where the panel starts (#1696).
+  ///
+  /// Split out from panel construction because an `NSSavePanel` cannot run in a
+  /// test, so the nil branch would otherwise be unreachable from one. Production
+  /// passes the user-domain Downloads URLs; tests pass an empty array.
+  static func startingDirectory(searchResults: [URL]) -> URL? {
+    searchResults.first
+  }
+
   static func chooseDestination() -> URL? {
     let panel = NSSavePanel()
     panel.title = "Export your words"
     panel.prompt = "Export"
-    panel.nameFieldStringValue = "EnviousWispr Words.json"
+    panel.nameFieldStringValue = defaultFilename
     panel.allowedContentTypes = [.json]
     panel.canCreateDirectories = true
     panel.isExtensionHidden = false
+    // Downloads every time, not "last used" (#1696). Today's behaviour is
+    // whatever this app last wrote to, which on a fresh build is a temp path.
+    // Nothing chose temp; we chose nothing. If Downloads cannot be resolved,
+    // leave it unset — a missing start directory is not worth failing over.
+    panel.directoryURL = startingDirectory(
+      searchResults: FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask))
     // Said before the choice, not after: the file lands wherever the user
     // points it, including a synced folder, and it can contain real names.
+    //
+    // The word COUNT deliberately does not live here. It is shown on the Your
+    // Words screen before Export is pressed, because the count must come from
+    // the same snapshot the file is built from, and building that snapshot here
+    // would need a refresh this panel is not allowed to trigger (#1697).
     panel.message =
       "Exported files may contain personal names and other private terms. "
       + "Usage history is not included."

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -124,7 +124,7 @@ struct CustomWordsImportSheet: View {
     switch model.step {
     case .methodPicker: return "Import words"
     case .paste: return "Paste words"
-    case .upload: return "Upload a file"
+    case .upload: return "Open a file"
     case .smartImportAppPicker: return "From another app"
     case .review: return "Review & Merge"
     case .working(.loadingCandidates): return "Finding words"
@@ -155,10 +155,19 @@ private struct ImportMethodPickerScreen: View {
       ) {
         model.select(.paste)
       }
+      // "Upload" implied a cloud destination for a purely local file read,
+      // which fights the local-and-private positioning this whole feature is
+      // built on. The copy also names the actual file and BOTH journeys —
+      // moving Macs and restoring a backup. Six later phases treat the export
+      // as their safety net, so the person most likely to be on this screen is
+      // recovering on the same Mac, not migrating (#1699).
       ImportMethodCard(
         icon: "square.and.arrow.down",
-        title: "Upload a file",
-        subtitle: "Import words from a file you exported, or a list."
+        title: "Open a file",
+        subtitle:
+          "Moving Macs or restoring a backup? Pick the "
+          + "\(CustomWordsExportPanel.defaultFilename) you exported. "
+          + "Plain text lists work too."
       ) {
         model.select(.upload)
       }
@@ -445,7 +454,7 @@ private struct ImportPasteScreen: View {
   }
 }
 
-// MARK: - Upload a file (PR-U1)
+// MARK: - Open a file (PR-U1)
 
 /// Deliberately never says "restore" (founder, 2026-07-19).
 ///

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -157,17 +157,25 @@ private struct ImportMethodPickerScreen: View {
       }
       // "Upload" implied a cloud destination for a purely local file read,
       // which fights the local-and-private positioning this whole feature is
-      // built on. The copy also names the actual file and BOTH journeys —
-      // moving Macs and restoring a backup. Six later phases treat the export
-      // as their safety net, so the person most likely to be on this screen is
-      // recovering on the same Mac, not migrating (#1699).
+      // built on. The copy also names the actual file and BOTH journeys, since
+      // six later phases treat the export as their safety net and the person on
+      // this screen is often recovering on the same Mac, not migrating (#1699).
+      //
+      // It deliberately does NOT say "restore". Import is additive: an existing
+      // word is reported and skipped, and its aliases and settings are never
+      // touched (D15; `confirmWithAllSkippedWritesNothing`). So importing a
+      // backup over a library that still has those words restores nothing, and
+      // promising otherwise would let someone believe their old settings came
+      // back when they did not (Codex review r2, P2). "Bringing your words
+      // back" is true of the additive behaviour; the second sentence states the
+      // limit rather than leaving the user to discover it.
       ImportMethodCard(
         icon: "square.and.arrow.down",
         title: "Open a file",
         subtitle:
-          "Moving Macs or restoring a backup? Pick the "
-          + "\(CustomWordsExportPanel.defaultFilename) you exported. "
-          + "Plain text lists work too."
+          "Moving Macs, or bringing your words back? Pick the "
+          + "\(CustomWordsExportPanel.defaultFilename) you exported, or a plain "
+          + "list. Words you already have are left as they are."
       ) {
         model.select(.upload)
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -25,8 +25,29 @@ struct YourWordsView: View {
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var sheetRoute: YourWordsSheetRoute?
   #if DEBUG
-    /// Set when an export failed, so the failure is stated rather than silent.
-    @State private var exportError: String?
+    /// What to say after an export attempt. Two kinds, deliberately: a real
+    /// failure, and an honest outcome that is not a failure. Sharing one
+    /// "Export didn't finish" title for both would tell a pack-only user their
+    /// export broke when it worked exactly as designed (#1697).
+    enum ExportNotice: Equatable {
+      case failure(String)
+      case info(String)
+
+      var title: String {
+        switch self {
+        case .failure: return "Export didn't finish"
+        case .info: return "Nothing was exported"
+        }
+      }
+
+      var message: String {
+        switch self {
+        case .failure(let text), .info(let text): return text
+        }
+      }
+    }
+
+    @State private var exportNotice: ExportNotice?
   #endif
 
   var body: some View {
@@ -72,7 +93,17 @@ struct YourWordsView: View {
           // compiled out of release builds until the founder ships it, and a
           // release-visible Export whose companion Import is invisible would be
           // half a promise.
-          Button(action: exportWords) {
+          // ONE body-render snapshot drives both the visible count and the
+          // array handed to the action, so the number the user reads and the
+          // bytes written cannot come from different moments (#1697).
+          let proposed = CustomWordsExportAction.exportableWords(
+            from: customWordsCoordinator.customWords)
+          Text(exportCountSummary(proposed.count))
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+          Button {
+            exportWords(proposed: proposed)
+          } label: {
             Label("Export your words", systemImage: "square.and.arrow.up")
           }
         #endif
@@ -103,15 +134,15 @@ struct YourWordsView: View {
     }
     #if DEBUG
       .alert(
-        "Export didn't finish",
+        exportNotice?.title ?? "",
         isPresented: Binding(
-          get: { exportError != nil },
-          set: { if !$0 { exportError = nil } }
+          get: { exportNotice != nil },
+          set: { if !$0 { exportNotice = nil } }
         )
       ) {
-        Button("OK", role: .cancel) { exportError = nil }
+        Button("OK", role: .cancel) { exportNotice = nil }
       } message: {
-        Text(exportError ?? "")
+        Text(exportNotice?.message ?? "")
       }
     #endif
     .sheet(item: $sheetRoute) { route in
@@ -143,12 +174,13 @@ struct YourWordsView: View {
     /// word list snapshotted — so cancelling reads nothing and writes nothing.
     /// Built-ins are excluded; what ships is what the user authored or edited,
     /// which is the only scope whose restore path this app can actually honor.
-    private func exportWords() {
+    private func exportWords(proposed: [CustomWord]) {
       // The decision lives in CustomWordsExportAction so the ORDER of its
       // steps is testable; this is just the wiring (#1680).
       Task {
         let outcome = await CustomWordsExportAction.run(
           coordinator: customWordsCoordinator,
+          proposedExportWords: proposed,
           chooseDestination: { CustomWordsExportPanel.chooseDestination() },
           write: { document, destination in
             try await CustomWordsExportWriter.write(document, to: destination)
@@ -156,14 +188,34 @@ struct YourWordsView: View {
         )
         switch outcome {
         case .cancelled, .exported:
-          exportError = nil
+          exportNotice = nil
         case .refusedUnsafeLibrary:
-          exportError =
+          exportNotice = .failure(
             "Your saved words couldn't be read this time, so there's nothing safe to export. "
-            + "Relaunch EnviousWispr and try again."
+              + "Relaunch EnviousWispr and try again.")
+        // Neither of the next two is a failure, so neither wears the failure
+        // title. A pack-only user pressing Export has done nothing wrong; they
+        // need the reason their long word list produced no file (#1697).
+        case .nothingToExport:
+          exportNotice = .info(
+            "There are no words of your own to export yet. "
+              + "Vocabulary packs are not included.")
+        case .libraryChanged:
+          exportNotice = .info(
+            "Your word list changed. Nothing was exported. "
+              + "Review the updated count and try Export again.")
         case .failed(let message):
-          exportError = message
+          exportNotice = .failure(message)
         }
+      }
+    }
+
+    /// Says what Export will actually produce, before it is pressed.
+    private func exportCountSummary(_ count: Int) -> String {
+      switch count {
+      case 0: return "No words of your own yet. Packs aren't included."
+      case 1: return "Exporting 1 word of your own. Packs aren't included."
+      default: return "Exporting \(count) of your own words. Packs aren't included."
       }
     }
   #endif

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -416,6 +416,32 @@ struct CustomWordsExportActionTests {
     #expect(spy.written == nil)
   }
 
+  @Test("a usage-count flush does NOT refuse the write")
+  func usageOnlyChangeStillExports() async throws {
+    // The counter that bumps frequencyUsed runs with no user action, and the
+    // save panel is open for however long a person takes to pick a folder. If
+    // the drift check compared whole words, dictating while that panel is open
+    // would eventually refuse every export — a reproducible false refusal, not
+    // a rare race (Codex review r1, P2). Usage is not part of the export
+    // payload, so it must not be part of the question.
+    let coordinator = try coordinator(seedWords: [CustomWord(canonical: "Kubernetes")])
+    var used = CustomWordsExportAction.exportableWords(from: coordinator.customWords)
+    used[0].frequencyUsed += 7
+    used[0].lastUsed = Date(timeIntervalSince1970: 1_000_000)
+    let spy = WriteSpy()
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      proposedExportWords: used,
+      chooseDestination: { self.tempURL() },
+      write: { data, _ in await MainActor.run { spy.written = data } }
+    )
+
+    #expect(outcome == .exported, "usage counts are not part of the exported payload")
+    let document = try CustomWordsTransferDocument(data: try #require(spy.written))
+    #expect(document.words.map(\.canonical) == ["Kubernetes"])
+  }
+
   @Test("an order-only change refuses the write")
   func orderOnlyChangeRefusesTheWrite() async throws {
     let coordinator = try coordinator(seedWords: [

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -56,6 +56,8 @@ struct CustomWordsExportActionTests {
 
     let outcome = await CustomWordsExportAction.run(
       coordinator: coordinator,
+      proposedExportWords: CustomWordsExportAction.exportableWords(
+        from: coordinator.customWords),
       chooseDestination: { nil },
       write: { _, _ in await MainActor.run { spy.writeCount += 1 } }
     )
@@ -76,6 +78,8 @@ struct CustomWordsExportActionTests {
 
     let outcome = await CustomWordsExportAction.run(
       coordinator: coordinator,
+      proposedExportWords: CustomWordsExportAction.exportableWords(
+        from: coordinator.customWords),
       chooseDestination: { self.tempURL() },
       write: { data, _ in await MainActor.run { spy.written = data } }
     )
@@ -93,6 +97,8 @@ struct CustomWordsExportActionTests {
 
     let outcome = await CustomWordsExportAction.run(
       coordinator: coordinator,
+      proposedExportWords: CustomWordsExportAction.exportableWords(
+        from: coordinator.customWords),
       chooseDestination: { self.tempURL() },
       write: { data, _ in await MainActor.run { spy.written = data } }
     )
@@ -111,6 +117,8 @@ struct CustomWordsExportActionTests {
 
     let outcome = await CustomWordsExportAction.run(
       coordinator: coordinator,
+      proposedExportWords: CustomWordsExportAction.exportableWords(
+        from: coordinator.customWords),
       chooseDestination: { self.tempURL() },
       write: { _, _ in throw Boom() }
     )
@@ -146,6 +154,8 @@ struct CustomWordsExportActionTests {
     let spy = WriteSpy()
     let outcome = await CustomWordsExportAction.run(
       coordinator: coordinator,
+      proposedExportWords: CustomWordsExportAction.exportableWords(
+        from: coordinator.customWords),
       chooseDestination: { self.tempURL() },
       write: { data, _ in await MainActor.run { spy.written = data } }
     )
@@ -325,4 +335,188 @@ struct CustomWordsExportActionTests {
         document: document, encoded: try document.encoded()) == nil)
   }
 
+
+  // MARK: - #1697: the count on screen and the bytes on disk are one fact
+
+  /// The oracle here is an INDEPENDENTLY enumerated set, not `exportableWords`.
+  ///
+  /// Comparing the displayed count against the file proves the two AGREE, which
+  /// is not the same as proving either is right: a filter that drops a word
+  /// drops it from both and the test still passes green. Six later phases treat
+  /// this file as the user's backup, so the expected set has to come from
+  /// somewhere the export code cannot influence (council finding 2).
+  @Test("the exported file contains exactly the user's own words, judged independently")
+  func exportedFileMatchesAnIndependentlyEnumeratedSet() async throws {
+    let expected = ["Kubernetes", "Qualtrics", "Threadripper"]
+    // The oracle is only independent if it names words the app does not already
+    // ship. Seeding a built-in canonical collapses it onto the built-in, which
+    // export correctly excludes — the first draft of this test used
+    // "EnviousWispr" and failed for exactly that reason. Assert the fixture's
+    // own premise so the next author cannot repeat it silently.
+    for canonical in expected {
+      #expect(
+        !CustomWordsManager.builtinDefaults.contains { $0.word.canonical == canonical },
+        "\(canonical) is a built-in; it can never appear in a user-word export")
+    }
+    let coordinator = try coordinator(seedWords: expected.map { CustomWord(canonical: $0) })
+    let spy = WriteSpy()
+    let proposed = CustomWordsExportAction.exportableWords(from: coordinator.customWords)
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      proposedExportWords: proposed,
+      chooseDestination: { self.tempURL() },
+      write: { data, _ in await MainActor.run { spy.written = data } }
+    )
+
+    #expect(outcome == .exported)
+    #expect(proposed.count == expected.count, "the number the user is shown")
+    let document = try CustomWordsTransferDocument(data: try #require(spy.written))
+    #expect(document.words.map(\.canonical).sorted() == expected.sorted())
+    // And the bytes round-trip back through the REAL import path, because a
+    // file the importer cannot read is not a backup.
+    let candidates = try ExportedWordsFileParser().parse(data: try #require(spy.written))
+    #expect(candidates.count == expected.count)
+  }
+
+  @Test("a same-size edit while the folder is being chosen refuses the write")
+  func sameCountRecordChangeRefusesTheWrite() async throws {
+    // The drift a count comparison cannot see: one word swapped for another, so
+    // the total never moves. This is why the check compares complete records.
+    let coordinator = try coordinator(seedWords: [CustomWord(canonical: "Kubernetes")])
+    let stale = [CustomWord(canonical: "SomethingElse")]
+    let spy = WriteSpy()
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      proposedExportWords: stale,
+      chooseDestination: { self.tempURL() },
+      write: { data, _ in await MainActor.run { spy.written = data } }
+    )
+
+    #expect(outcome == .libraryChanged)
+    #expect(spy.written == nil, "nothing may be written when the list moved")
+  }
+
+  @Test("a field-only edit refuses the write")
+  func fieldOnlyChangeRefusesTheWrite() async throws {
+    let coordinator = try coordinator(seedWords: [CustomWord(canonical: "Kubernetes")])
+    var drifted = CustomWordsExportAction.exportableWords(from: coordinator.customWords)
+    drifted[0].aliases = ["kubernetties"]
+    let spy = WriteSpy()
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      proposedExportWords: drifted,
+      chooseDestination: { self.tempURL() },
+      write: { data, _ in await MainActor.run { spy.written = data } }
+    )
+
+    #expect(outcome == .libraryChanged)
+    #expect(spy.written == nil)
+  }
+
+  @Test("an order-only change refuses the write")
+  func orderOnlyChangeRefusesTheWrite() async throws {
+    let coordinator = try coordinator(seedWords: [
+      CustomWord(canonical: "Kubernetes"), CustomWord(canonical: "Qualtrics"),
+    ])
+    let reversed = Array(
+      CustomWordsExportAction.exportableWords(from: coordinator.customWords).reversed())
+    let spy = WriteSpy()
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      proposedExportWords: reversed,
+      chooseDestination: { self.tempURL() },
+      write: { data, _ in await MainActor.run { spy.written = data } }
+    )
+
+    #expect(outcome == .libraryChanged)
+    #expect(spy.written == nil)
+  }
+
+  @Test("no words of your own reports an honest empty state without opening a panel")
+  func emptyLibraryReportsNothingToExportAndNeverAsksForAFolder() async throws {
+    let coordinator = try coordinator()
+    let spy = WriteSpy()
+    var panelOpened = false
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      proposedExportWords: [],
+      chooseDestination: {
+        panelOpened = true
+        return self.tempURL()
+      },
+      write: { data, _ in await MainActor.run { spy.written = data } }
+    )
+
+    #expect(outcome == .nothingToExport)
+    #expect(!panelOpened, "a dialog that can only produce an empty file is a trap")
+    #expect(spy.written == nil)
+  }
+
+  @Test("an empty count that is actually stale says so instead of exporting silently")
+  func emptyProposalThatRefreshesToNonEmptyReportsLibraryChanged() async throws {
+    // The user was shown zero; disk disagrees. Exporting here would write a
+    // snapshot they were never shown a number for.
+    let coordinator = try coordinator(seedWords: [CustomWord(canonical: "Kubernetes")])
+    var panelOpened = false
+
+    let outcome = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      proposedExportWords: [],
+      chooseDestination: {
+        panelOpened = true
+        return self.tempURL()
+      },
+      write: { _, _ in }
+    )
+
+    #expect(outcome == .libraryChanged)
+    #expect(!panelOpened)
+  }
+
+  @Test("a retry against unchanged state exports rather than refusing forever")
+  func stableRetryExportsAndDoesNotLoop() async throws {
+    let coordinator = try coordinator(seedWords: [CustomWord(canonical: "Kubernetes")])
+    let spy = WriteSpy()
+
+    // First attempt drifts and is refused.
+    let first = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      proposedExportWords: [CustomWord(canonical: "Stale")],
+      chooseDestination: { self.tempURL() },
+      write: { data, _ in await MainActor.run { spy.written = data } }
+    )
+    #expect(first == .libraryChanged)
+
+    // The screen re-renders from adopted state; the retry must succeed.
+    let second = await CustomWordsExportAction.run(
+      coordinator: coordinator,
+      proposedExportWords: CustomWordsExportAction.exportableWords(
+        from: coordinator.customWords),
+      chooseDestination: { self.tempURL() },
+      write: { data, _ in await MainActor.run { spy.written = data } }
+    )
+    #expect(second == .exported)
+  }
+
+  // MARK: - #1696 / #1699: panel defaults
+
+  @Test("the save panel starts in Downloads, and survives Downloads being unresolvable")
+  func startingDirectoryPrefersDownloadsAndToleratesItsAbsence() {
+    let downloads = URL(fileURLWithPath: "/Users/someone/Downloads", isDirectory: true)
+    #expect(CustomWordsExportPanel.startingDirectory(searchResults: [downloads]) == downloads)
+    // Unresolvable is not worth failing an export over: leave it unset.
+    #expect(CustomWordsExportPanel.startingDirectory(searchResults: []) == nil)
+  }
+
+  @Test("the import screen names the file the exporter actually writes")
+  func importCopyAndExportFilenameShareOneAuthority() {
+    // Two literals would let the exporter rename the file and leave the import
+    // copy describing one that no longer exists.
+    #expect(CustomWordsExportPanel.defaultFilename == "EnviousWispr Words.json")
+  }
 }


### PR DESCRIPTION
Phase **v2-2 PR A** of epic #1619. Four polish items from the founder's v1 test drive. #1700 ships separately as PR B.

Plan: `docs/feature-requests/issue-1619-2026-07-20-cw-v2-2-small-fixes.md`

## What changes for the user

- **#1696** The save dialog starts in Downloads every time. It used to start wherever the app last wrote, which on a fresh build is a temp folder. Nothing chose temp; we chose nothing.
- **#1697** Your Words now states what Export will produce, before you press it: *"Exporting 33 of your own words. Packs aren't included."*
- **#1699** The import card is *"Open a file"*, names the actual file, and covers both journeys. "Upload" implied a cloud destination for a purely local file read.
- **#1705** The AI suggestion status is laid out above the buttons instead of floating on top of Delete.

## The two things that were harder than they looked

**The count could not go in the save dialog.** A panel's message must exist before the panel opens, so the count would have described a pre-refresh list while the file described a post-refresh one. Moving the refresh earlier was worse: `refreshFromDiskIfPossible` can migrate a legacy file, archive a corrupt one, latch corruption state, and publish a replaced library. Opening Export and **cancelling** would have mutated state, which is the exact bug the ask-first ordering exists to prevent (`CustomWordsExportAction.swift:38`). So the screen owns the proposed snapshot and the action verifies it after the destination is chosen.

**The drift check compared the wrong thing** (Codex review r1, P2). It used whole-`CustomWord` equality, which includes `frequencyUsed` and `lastUsed` — fields the export format deliberately omits. That is not a rare race: the usage counter is the app's one writer that runs with no user action (30s debounce or 50 corrections, #1695), and the save panel stays open for as long as a person takes to pick a folder. Dictating with that panel open would have refused valid exports repeatably. It now compares export payloads.

## Review

- **Grounded review: 4 rounds to PROCEED-AS-PLANNED** (9 → 6 → 6 → 10 → 0 findings). Round 2 reversed round 1's export-ordering fix after checking v1's comment against the code.
- **Local `codex review`: 3 rounds to clean.** Two real P2s: the drift comparison above, and import copy that promised a "restore" the additive import cannot deliver (an existing word is reported and skipped, D15).
- **3,339 logic tests green.**

## Live UAT — run, with the word list hashed on both sides

Founder lifted the no-dev-app constraint for this session. Every step was read-only against the live library, and the file hash was recorded before and after.

| Check | Result |
|---|---|
| Export count on screen | "Exporting 33 of your own words. Packs aren't included." |
| Exported file word count | **33 — matches exactly** |
| Usage fields in exported file | none, confirming the P2 premise |
| Save panel starting folder | **Downloads** |
| Cancelling the panel | live file hash **unchanged** — ask-first holds |
| Full export to a scratch path | live file hash **unchanged** |
| Suggestion status placement | own row above the buttons, no overlap |
| Import card copy | renders as written |

`custom-words.json` SHA-256 `89bb356b…57dd87` before, during and after. The scratch export was deleted after verification because it contained real names.

Not verified live: the zero-words empty state (covered hermetically) and the status row with a Delete button present — the status is now a sibling row rather than an overlay, so the z-order relationship that caused the bug no longer exists.

## For the founder

The import copy raises a product question I did not decide: **should importing a backup restore settings onto words you still have?** Today it cannot — an existing word is never modified by an import (D15, your rule). That makes "backup" slightly generous: export brings back *words*, not *state*. Changing it is a merge policy, not copy, and would fit naturally with the CSV and docs work.

Part of #1619
