### PR TITLE
fix(worker): drop daily-report onboard_activate's redundant dev-exclusion subquery

### DIFF
--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -137,20 +137,33 @@ const PROD = `properties.environment = 'production'
     SELECT distinct_id FROM events
     WHERE properties.app_version LIKE '%-dev%' )`;
 
+// Environment only, no whole-history dev-ID exclusion. Safe ONLY where the
+// caller separately applies full PROD to whichever set is being COUNTED -
+// see each call site's local comment for why (the #1655 doubled-subquery
+// class; never copy this constant in without re-deriving the argument).
+const ENV_ONLY = "properties.environment = 'production'";
+
 function windowClause(startUTC, endUTC) {
   return `timestamp >= '${sqlTimestamp(startUTC)}' AND timestamp < '${sqlTimestamp(endUTC)}'`;
 }
 
-/** The day's active-user population (successful dictators) as a reusable
- * subquery fragment - used once, for the onboarded->activated intersection
- * (a single subquery evaluation, cheap). NOT reused for polish tier-a: an
- * earlier version nested this same subquery twice inside a UNION, which
- * measurably timed out against production PostHog - see the comment above
- * `tierASqlFor` below for why tier-a instead takes a literal id list. */
+/** The day's active-user population (successful dictators), used once as an
+ * IN-membership test inside onboardActivateSql's `activated` column - see
+ * that query below. Deliberately ${ENV_ONLY}, not full PROD: every row this
+ * set is tested against already came from onboardActivateSql's own outer
+ * `WHERE ... AND ${PROD}` on onboarding.completed, so a dev-tainted id can
+ * never appear on the outer side to begin with - whether this inner set is
+ * ALSO dev-filtered cannot change which outer ids match it. Full PROD here
+ * would evaluate the same whole-history dev-exclusion subquery a second time
+ * for no change in result, which is exactly the doubled-subquery shape that
+ * measurably timed out production PostHog for polish tier-a (#1655) - fixed
+ * here the same way, after #1655's fix didn't cover this sibling query and
+ * it 504'd for real on 2026-07-20. This argument is local to this one call
+ * site; a new caller must re-derive it, not assume it. */
 function activeUsersSubquery(win) {
   return `SELECT DISTINCT distinct_id FROM events
     WHERE event = 'dictation.completed' AND properties.result = 'success'
-      AND ${PROD} AND ${win}`;
+      AND ${ENV_ONLY} AND ${win}`;
 }
 
 /** Escapes a distinct_id for a HogQL string literal (single-quote doubling,
@@ -164,27 +177,28 @@ function sqlIdList(ids) {
  * settings.changed, restricted to a literal list of already-known active-user
  * ids (rather than a re-evaluated subquery, which timed out).
  *
- * Deliberately uses the production-environment predicate rather than full PROD.
- * Every active id came from engineAndTierBSql, which already applied full PROD,
- * including the whole-history dev-ID exclusion. Repeating that exclusion twice
- * inside this UNION adds substantial work without changing results. Live A/B
+ * Deliberately uses ${ENV_ONLY} rather than full PROD. Every active id came
+ * from engineAndTierBSql, which already applied full PROD, including the
+ * whole-history dev-ID exclusion. Repeating that exclusion twice inside this
+ * UNION adds substantial work without changing results. Live A/B
  * verification found identical provider attribution for all active users.
- * This argument is local to tier-a; every other query keeps full PROD. */
+ * This argument is local to tier-a and to activeUsersSubquery's own,
+ * separately-derived use of ${ENV_ONLY} below; every other query keeps full
+ * PROD. */
 function tierASqlFor(activeIds, endTs) {
   const ids = sqlIdList(activeIds);
-  const envOnly = "properties.environment = 'production'";
   return `
     SELECT distinct_id, argMax(value, ts) AS provider
     FROM (
       SELECT distinct_id, properties.llm_provider AS value, timestamp AS ts
       FROM events
-      WHERE event = 'settings.snapshot' AND ${envOnly}
+      WHERE event = 'settings.snapshot' AND ${ENV_ONLY}
         AND distinct_id IN (${ids})
         AND timestamp < '${endTs}'
       UNION ALL
       SELECT distinct_id, properties.to AS value, timestamp AS ts
       FROM events
-      WHERE event = 'settings.changed' AND properties.setting = 'llm_provider' AND ${envOnly}
+      WHERE event = 'settings.changed' AND properties.setting = 'llm_provider' AND ${ENV_ONLY}
         AND distinct_id IN (${ids})
         AND timestamp < '${endTs}'
     )

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -502,11 +502,37 @@ test("source guardrail: tier-a may omit dev exclusion only while active ids come
 
   const tierAFunction = src.match(/function tierASqlFor\([\s\S]*?\n}\n/)?.[0];
   assert.ok(tierAFunction, "expected tierASqlFor");
-  assert.match(tierAFunction, /properties\.environment = 'production'/);
+  assert.match(tierAFunction, /\$\{ENV_ONLY\}/);
   assert.doesNotMatch(tierAFunction, /\$\{PROD\}/);
   assert.equal(
     (tierAFunction.match(/distinct_id IN \(\$\{ids\}\)/g) || []).length,
     2,
     "both tier-a UNION branches must remain restricted to the pre-filtered active-id list"
+  );
+});
+
+// ---- load-bearing coupling guard (#1716, sibling of #1655's tier-a guard) ----
+//
+// activeUsersSubquery may omit PROD's dev-ID exclusion ONLY because every id
+// it is tested against inside onboardActivateSql already came from that
+// query's own full-PROD outer WHERE. If a future edit drops onboardActivateSql's
+// outer ${PROD}, or reuses activeUsersSubquery from a caller that doesn't
+// pre-filter the same way, the omission silently becomes a correctness bug.
+
+test("source guardrail: onboard-activate's active-user lookup may omit dev exclusion only while its own outer WHERE keeps full PROD", async () => {
+  const fs = await import("node:fs");
+  const src = fs.readFileSync(new URL("../src/index.js", import.meta.url), "utf8");
+
+  const activeUsersFunction = src.match(/function activeUsersSubquery\([\s\S]*?\n}\n/)?.[0];
+  assert.ok(activeUsersFunction, "expected activeUsersSubquery");
+  assert.match(activeUsersFunction, /\$\{ENV_ONLY\}/);
+  assert.doesNotMatch(activeUsersFunction, /\$\{PROD\}/);
+
+  const onboardActivateQuery = src.match(/const onboardActivateSql = `([\s\S]*?)`;/)?.[1];
+  assert.ok(onboardActivateQuery, "expected onboardActivateSql");
+  assert.match(
+    onboardActivateQuery,
+    /WHERE event = 'onboarding\.completed' AND \$\{PROD\} AND \$\{win\}/,
+    "the outer onboarding.completed filter must keep full PROD - activeUsersSubquery's env-only shortcut depends on it"
   );
 });


### PR DESCRIPTION
Fixes #1716.

`onboard_activate` 504'd for real on 2026-07-20, the day after #1655 shipped
the same fix for a sibling query (`tier_a`). `PROD`'s whole-history dev-ID
exclusion subquery was being evaluated twice in this one query: once in its
own outer WHERE, once via `activeUsersSubquery` (used inside the
`activated`-count membership test). Every row `activeUsersSubquery` is
tested against already came through the outer full-`PROD` filter, so a
dev-tainted id can never reach that membership test to begin with -
dropping the inner exclusion to environment-only removes the duplication
for no change in result (same argument #1655 already established for
`tier_a`, applied to the sibling query it didn't cover).

Verified identical `onboarded`/`activated` counts live, before and after,
against the same production day. Added a source guardrail test locking the
coupling, mirroring #1655's tier-a guard - if a future edit ever drops the
outer full-`PROD` filter, the test catches it rather than a silent
correctness regression.

Measured live (interleaved A/B, force_blocking to bypass cache, 6 rounds):
8.18s → 6.91s median, 1/6 → 1/6 504s. Weaker signal than #1655's tier_a
result - a big share of this project's query latency looks like general
PostHog-side contention, not just this duplication. Full context in #1716.

Local Codex review: clean, no findings.

## Test plan
- [x] `node --test` in `workers/daily-report/` - 33/33 pass
- [x] `live-query-smoke.mjs 2026-07-19` against real production PostHog - identical numbers to the pre-fix recovered report
- [x] Local Codex diff review - clean
- [ ] Deploy + live verify (`?date=` trigger) after merge, per README