### PR TITLE
feat(ui): use the real Claude brand mark instead of a lettered monogram

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -222,13 +222,13 @@ enum PolishRailMetrics {
 
 // MARK: - Logo tile
 
-/// The rounded logo tile. One swap site for all five marks:
+/// The rounded logo tile. One swap site for all six marks:
 /// - EG-1: the app's own animated brand mark (`RainbowLipsIcon`) drawn STATIC
 ///   (audioLevel 0) so there is no fourth copy of the bar coordinates (plan §3c).
 /// - Apple: the `apple.logo` SF Symbol (empirically confirmed available).
-/// - OpenAI / Gemini / Ollama: their brand marks as inline SVG rendered via
-///   `NSImage(data:)`, template-tinted so one foreground color handles
-///   light/dark and selected/unselected (plan §3).
+/// - OpenAI / Gemini / Ollama / Claude: their brand marks as inline SVG
+///   rendered via `NSImage(data:)`, template-tinted so one foreground color
+///   handles light/dark and selected/unselected (plan §3).
 /// Any mark that fails to build falls back to a lettered monogram so a row is
 /// never blank (the "Apple tile was empty" class from the preview, plan §7/§9).
 struct ProviderLogoTile: View {
@@ -278,10 +278,7 @@ struct ProviderLogoTile: View {
     case .ollama:
       svgMark(ProviderLogoSVG.ollama, inset: 0.60)
     case .claude:
-      // No hand-drawn brand SVG (avoids guessing Anthropic's trademark
-      // geometry from memory, plan §2.2 non-goal); the lettered monogram is
-      // an already-supported, first-class fallback, not a degraded state.
-      monogram(ProviderLogoSVG.monogram(for: provider))
+      svgMark(ProviderLogoSVG.claude, inset: 0.60)
     case .none:
       monogram("--")
     }
@@ -323,10 +320,11 @@ struct ProviderLogoTile: View {
   }
 }
 
-/// Brand-mark SVG strings + the `NSImage(data:)` render helper. The three
-/// monochrome marks (OpenAI / Gemini / Ollama) are set `isTemplate = true` so
-/// SwiftUI `.foregroundStyle` tints them. Marks are used nominatively — solely
-/// to identify the provider being configured, monochrome, no endorsement.
+/// Brand-mark SVG strings + the `NSImage(data:)` render helper. The four
+/// monochrome marks (OpenAI / Gemini / Ollama / Claude) are set
+/// `isTemplate = true` so SwiftUI `.foregroundStyle` tints them. Marks are
+/// used nominatively — solely to identify the provider being configured,
+/// monochrome, no endorsement.
 enum ProviderLogoSVG {
   static func templateImage(_ svg: String) -> NSImage? {
     guard let data = svg.data(using: .utf8), let image = NSImage(data: data),
@@ -359,6 +357,10 @@ enum ProviderLogoSVG {
 
   static let gemini = wrap(
     "M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81"
+  )
+
+  static let claude = wrap(
+    "m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z"
   )
 
   static let ollama = wrap(

--- a/Tests/EnviousWisprTests/Settings/ProviderLogoTests.swift
+++ b/Tests/EnviousWisprTests/Settings/ProviderLogoTests.swift
@@ -16,7 +16,10 @@ struct ProviderLogoTests {
 
   @Test("Each brand SVG builds a valid template image")
   func brandMarksBuild() {
-    for svg in [ProviderLogoSVG.openAI, ProviderLogoSVG.gemini, ProviderLogoSVG.ollama] {
+    for svg in [
+      ProviderLogoSVG.openAI, ProviderLogoSVG.gemini, ProviderLogoSVG.ollama,
+      ProviderLogoSVG.claude,
+    ] {
       let image = ProviderLogoSVG.templateImage(svg)
       #expect(image != nil, "brand SVG should rasterize to a valid image")
       #expect(image?.isTemplate == true, "monochrome marks must be template-tinted")
@@ -37,8 +40,8 @@ struct ProviderLogoTests {
     // would still pass. Assert the exact contract instead.
     #expect(ProviderLogoSVG.monogram(for: .openAI) == "OA")
     #expect(ProviderLogoSVG.monogram(for: .gemini) == "G")
-    // Claude ships with no hand-drawn brand SVG (plan §2.2 non-goal), so its
-    // monogram is a first-class fallback, not a degraded state (#158).
+    // Claude now ships a real brand SVG too; the monogram remains the
+    // macOS-14-floor rasterization-failure fallback, same as every other mark.
     #expect(ProviderLogoSVG.monogram(for: .claude) == "CL")
     #expect(ProviderLogoSVG.monogram(for: .ollama) == "OL")
     #expect(ProviderLogoSVG.monogram(for: .egOne) == "EG")


### PR DESCRIPTION
## Summary
- Adds the real Anthropic Claude brand mark to the AI Polish provider picker, replacing the lettered "CL" monogram fallback.
- Sourced from Simple Icons, the same brand-icon library the existing OpenAI/Gemini/Ollama marks came from (confirmed by exact path-data match for two of the three).
- Same inline-SVG, template-tinted rendering pattern as the other three marks — no new abstraction.

## Test plan
- [x] `scripts/xcode-test.sh --filter EnviousWisprTests/ProviderLogoTests` — 3/3 passing, including a new assertion that the Claude SVG rasterizes to a valid template image
- [x] Local Codex diff review: clean, independently rendered the SVG to a PNG and verified a full non-degenerate alpha bounding box
- [x] Dev app rebuild succeeded
- [ ] Live screenshot verification deferred — screen was occupied with active unrelated work at review time