### PR TITLE
fix(user): the export count reads in the save dialog, not on the page (#1715)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsExportAction.swift
@@ -19,19 +19,20 @@ import Foundation
 /// Every one of those was a separately-found bug. Keeping them in a testable
 /// unit means the sequence itself is covered, not just its parts.
 ///
-/// #1697 added a count on screen and nearly broke step 1 doing it. A save
-/// panel's message must exist BEFORE the panel opens, so putting the count
-/// there would have forced the refresh ahead of the ask. Grounded review r2
-/// established what that actually costs: `refreshFromDiskIfPossible` is not an
-/// in-memory read. It can rewrite a legacy file during migration, move a
-/// corrupt file into an archive, latch session corruption state, and publish a
-/// replaced library to runtime consumers. Opening Export and CANCELLING would
-/// have done all of that — the exact bug step 1 exists to prevent.
+/// Step 1 is why the count is passed IN rather than computed here. Grounded
+/// review r2 established what a refresh actually costs: `refreshFromDiskIfPossible`
+/// is not an in-memory read. It can rewrite a legacy file during migration, move
+/// a corrupt file into an archive, latch session corruption state, and publish a
+/// replaced library to runtime consumers. Opening Export and CANCELLING must not
+/// do any of that.
 ///
-/// So the count is derived on screen, passed in as `proposedExportWords`, and
-/// verified after the destination is chosen. One filtering authority, two
-/// time-separated snapshots: the proposed array owns both the number the user
-/// saw and the bytes written; the refreshed array only proves nothing moved.
+/// #1697 read that constraint as also forbidding the count from appearing in the
+/// save dialog, and put a sentence on the Your Words screen instead; #1715 moved
+/// it back. The number never needed a refresh — it is derived on screen from the
+/// in-memory coordinator, handed in as `proposedExportWords`, and shown in the
+/// dialog the file comes out of. One filtering authority, two time-separated
+/// snapshots: the proposed array owns both the number the user saw and the bytes
+/// written; the refreshed array only proves nothing moved.
 @MainActor
 enum CustomWordsExportAction {
   enum Outcome: Equatable {

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
@@ -26,7 +26,31 @@ enum CustomWordsExportPanel {
     searchResults.first
   }
 
-  static func chooseDestination() -> URL? {
+  /// Says what Export will actually produce, read in the dialog that produces it
+  /// (#1715).
+  ///
+  /// #1697 put this sentence on the Your Words screen instead, on the reasoning
+  /// that a panel message must exist before the panel opens and the count could
+  /// only come from a refresh the panel is not allowed to trigger. Half of that
+  /// is true: the refresh must stay after the ask. But the count never needed
+  /// one — it is read from the in-memory coordinator and handed in. Knowing the
+  /// number and refreshing the library are independent, and conflating them put
+  /// a paragraph on a screen of controls.
+  ///
+  /// There is no zero case: `CustomWordsExportAction.run` returns before opening
+  /// a panel when the proposal is empty, so an empty export cannot be described
+  /// here. That is enforced by the action, not defended by a branch here.
+  static func exportSummary(exportableCount: Int) -> String {
+    exportableCount == 1
+      ? "Exporting 1 word of your own. Vocabulary packs aren't included."
+      : "Exporting \(exportableCount) words of your own. Vocabulary packs aren't included."
+  }
+
+  /// - Parameter exportableCount: the size of the proposed snapshot the file
+  ///   will be built from. The action re-derives and compares the whole payload
+  ///   after a destination is chosen, so this number is what gets written or
+  ///   nothing is.
+  static func chooseDestination(exportableCount: Int) -> URL? {
     let panel = NSSavePanel()
     panel.title = "Export your words"
     panel.prompt = "Export"
@@ -42,13 +66,9 @@ enum CustomWordsExportPanel {
       searchResults: FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask))
     // Said before the choice, not after: the file lands wherever the user
     // points it, including a synced folder, and it can contain real names.
-    //
-    // The word COUNT deliberately does not live here. It is shown on the Your
-    // Words screen before Export is pressed, because the count must come from
-    // the same snapshot the file is built from, and building that snapshot here
-    // would need a refresh this panel is not allowed to trigger (#1697).
     panel.message =
-      "Exported files may contain personal names and other private terms. "
+      exportSummary(exportableCount: exportableCount) + "\n\n"
+      + "Exported files may contain personal names and other private terms. "
       + "Usage history is not included."
 
     return panel.runModal() == .OK ? panel.url : nil

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -93,14 +93,14 @@ struct YourWordsView: View {
           // compiled out of release builds until the founder ships it, and a
           // release-visible Export whose companion Import is invisible would be
           // half a promise.
-          // ONE body-render snapshot drives both the visible count and the
-          // array handed to the action, so the number the user reads and the
-          // bytes written cannot come from different moments (#1697).
+          // ONE body-render snapshot drives both the count shown in the save
+          // dialog and the array handed to the action, so the number the user
+          // reads and the bytes written cannot come from different moments
+          // (#1697). The sentence itself lives in the dialog, not on this
+          // screen: a paragraph wedged between two buttons competes with them
+          // (#1715).
           let proposed = CustomWordsExportAction.exportableWords(
             from: customWordsCoordinator.customWords)
-          Text(exportCountSummary(proposed.count))
-            .font(.stHelper)
-            .foregroundStyle(.stTextSecondary)
           Button {
             exportWords(proposed: proposed)
           } label: {
@@ -181,7 +181,9 @@ struct YourWordsView: View {
         let outcome = await CustomWordsExportAction.run(
           coordinator: customWordsCoordinator,
           proposedExportWords: proposed,
-          chooseDestination: { CustomWordsExportPanel.chooseDestination() },
+          chooseDestination: {
+            CustomWordsExportPanel.chooseDestination(exportableCount: proposed.count)
+          },
           write: { document, destination in
             try await CustomWordsExportWriter.write(document, to: destination)
           }
@@ -202,22 +204,17 @@ struct YourWordsView: View {
               + "Vocabulary packs are not included.")
         case .libraryChanged:
           exportNotice = .info(
-            "Your word list changed. Nothing was exported. "
-              + "Review the updated count and try Export again.")
+            // Not "review the updated count": there is no count on this screen
+            // to review any more (#1715). Export again and the dialog shows the
+            // new number.
+            "Your word list changed while you were choosing a folder. "
+              + "Nothing was exported. Try Export again.")
         case .failed(let message):
           exportNotice = .failure(message)
         }
       }
     }
 
-    /// Says what Export will actually produce, before it is pressed.
-    private func exportCountSummary(_ count: Int) -> String {
-      switch count {
-      case 0: return "No words of your own yet. Packs aren't included."
-      case 1: return "Exporting 1 word of your own. Packs aren't included."
-      default: return "Exporting \(count) of your own words. Packs aren't included."
-      }
-    }
   #endif
 
   private func saveNewWord(_ newWord: CustomWord) -> String? {

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -204,11 +204,14 @@ struct YourWordsView: View {
               + "Vocabulary packs are not included.")
         case .libraryChanged:
           exportNotice = .info(
-            // Not "review the updated count": there is no count on this screen
-            // to review any more (#1715). Export again and the dialog shows the
-            // new number.
-            "Your word list changed while you were choosing a folder. "
-              + "Nothing was exported. Try Export again.")
+            // Says nothing about WHEN or WHERE the list moved, because two
+            // different paths land here: the drift check after a folder was
+            // chosen, and a stale empty count that never opened a dialog at
+            // all. Naming folder selection would describe a step the second
+            // user never took (cloud review, #1715). It also can't say "review
+            // the updated count" any more — there is no count on this screen.
+            "Your word list changed, so nothing was exported. "
+              + "Try Export again.")
         case .failed(let message):
           exportNotice = .failure(message)
         }

--- a/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsExportActionTests.swift
@@ -335,8 +335,7 @@ struct CustomWordsExportActionTests {
         document: document, encoded: try document.encoded()) == nil)
   }
 
-
-  // MARK: - #1697: the count on screen and the bytes on disk are one fact
+  // MARK: - #1697: the count the user is shown and the bytes on disk are one fact
 
   /// The oracle here is an INDEPENDENTLY enumerated set, not `exportableWords`.
   ///
@@ -544,5 +543,21 @@ struct CustomWordsExportActionTests {
     // Two literals would let the exporter rename the file and leave the import
     // copy describing one that no longer exists.
     #expect(CustomWordsExportPanel.defaultFilename == "EnviousWispr Words.json")
+  }
+
+  // MARK: - #1715: the count reads in the dialog that produces the file
+
+  @Test("the dialog counts one word in the singular and the rest in the plural")
+  func exportSummaryAgreesWithItsNumber() {
+    #expect(
+      CustomWordsExportPanel.exportSummary(exportableCount: 1)
+        == "Exporting 1 word of your own. Vocabulary packs aren't included.")
+    #expect(
+      CustomWordsExportPanel.exportSummary(exportableCount: 33)
+        == "Exporting 33 words of your own. Vocabulary packs aren't included.")
+    // No zero case is asserted because none exists: `run` returns before opening
+    // a panel when the proposal is empty. That impossibility is proven by
+    // `emptyLibraryReportsNothingToExportAndNeverAsksForAFolder`, not by a
+    // branch in the summary.
   }
 }


### PR DESCRIPTION
Founder call on shipped PR #1708: "it has to show in this pop up or not show at all."

The count was a full sentence wedged between two buttons on the Your Words screen, competing with the controls it described.

## Why it was there, and why that was wrong

A save panel's message must exist before the panel opens, and refreshing the library before the user picks a destination is genuinely forbidden: a cancelled export would then migrate, archive, or publish state, which is the bug the ask-first ordering exists to prevent.

But the count never needed a refresh. It is read from the in-memory coordinator and handed in. Knowing the number and refreshing the library are independent concerns, and conflating them moved the sentence off the dialog it belonged to.

## What changed

- The panel takes the proposed count and states it above the existing privacy line.
- The on-page sentence is gone.
- The "your list changed" copy no longer tells the user to review a count that no longer appears anywhere.
- Three doc comments carrying the old rationale are corrected.

The guarantee is unchanged: the number shown is the proposed snapshot, and after a destination is chosen the action re-derives and compares the whole payload, writing nothing if the list moved. The dialog states exactly what lands on disk, or nothing does.

## Validation

- 23 tests in the export suite green, including new singular and plural coverage.
- No zero case is asserted or handled, because the action returns before opening a panel on an empty proposal. That impossibility is proven by an existing test, not defended by a branch.
- Local Codex diff review: clean, no actional defects, round 1.
- Dev app built and launched.

council-skip: zero-blast-radius (user-facing copy)

Part of #1619
Closes #1715
