### PR TITLE
fix(user): one authority decides which word owns a trigger (#1667)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
@@ -159,11 +159,18 @@ package actor CustomWordsImportCompareEngine {
       }
     }
 
-    let collisions = try Self.detectAliasCollisions(
-      coalesced: coalesced, existingWords: existingWords)
-
-    var results: [CustomWordsImportComparison] = []
-    results.reserveCapacity(coalesced.count)
+    // Classify before detecting collisions, not after: only a `.new` row can
+    // ever be committed as an addition (`CustomWordsImportReviewRow.swift`);
+    // exact/variant/fuzzy/ambiguous rows are matches against something that
+    // already exists and are never themselves persisted as a fresh word. Only
+    // `.new` candidates may participate in provisional batch ownership — a
+    // forced-Skip or matched row must not be able to steal a trigger key away
+    // from its own real incumbent, or from another candidate that will
+    // actually be added (grounded review r6, #1667).
+    var classified:
+      [(candidate: CustomWordsImportCandidate, classification: CustomWordsImportClassification)] =
+        []
+    classified.reserveCapacity(coalesced.count)
     for candidate in coalesced {
       try Task.checkCancellation()
       let classification = Self.classify(
@@ -173,11 +180,27 @@ package actor CustomWordsImportCompareEngine {
         fuzzyIndexByLength: fuzzyIndexByLength,
         fuzzyPolicy: fuzzyPolicy
       )
+      classified.append((candidate, classification))
+    }
+    let participatingCandidateIDs = Set(
+      classified.compactMap { entry -> UUID? in
+        guard case .new = entry.classification else { return nil }
+        return entry.candidate.id
+      })
+
+    let collisions = try Self.detectAliasCollisions(
+      coalesced: coalesced,
+      existingWords: existingWords,
+      participatingCandidateIDs: participatingCandidateIDs)
+
+    var results: [CustomWordsImportComparison] = []
+    results.reserveCapacity(classified.count)
+    for entry in classified {
       results.append(
         CustomWordsImportComparison(
-          candidate: candidate,
-          classification: classification,
-          collidingAliases: collisions[candidate.id] ?? []
+          candidate: entry.candidate,
+          classification: entry.classification,
+          collidingAliases: collisions[entry.candidate.id] ?? []
         ))
     }
     return results
@@ -502,15 +525,26 @@ package actor CustomWordsImportCompareEngine {
   /// `suggestedAliases`, since enrichment has not run at compare time and a
   /// colliding suggestion is enforced-and-receipted at commit instead. Only the
   /// LOSING side is ever flagged; a winner's alias is not at risk.
+  /// - Parameter participatingCandidateIDs: candidates whose OWN canonical and
+  ///   aliases may become batch owners other candidates can collide against.
+  ///   Only a `.new`-classified candidate can ever be persisted as a fresh
+  ///   word (`CustomWordsImportReviewRow.swift`); an exact/variant/fuzzy/
+  ///   ambiguous match is not itself added, so it must not be able to steal a
+  ///   trigger key away from its own real incumbent or from a candidate that
+  ///   will actually be added (grounded review r6, #1667). This governs
+  ///   OWNERSHIP only — every candidate's own aliases are still evaluated for
+  ///   disclosure below, matching the decision-agnostic preview policy
+  ///   (`aliasOwnedByTheCandidatesOwnExactMatchRemainsDisclosed`).
   static func detectAliasCollisions(
     coalesced: [CustomWordsImportCandidate],
-    existingWords: [CustomWord]
+    existingWords: [CustomWord],
+    participatingCandidateIDs: Set<UUID>
   ) throws -> [UUID: [CustomWordsImportAliasCollision]] {
     typealias Owner = WordCorrector.TriggerOwner
 
-    // Effective incumbent ownership, already resolved, then every incoming
-    // canonical applied on top under the SAME rules the commit path and the
-    // corrector use.
+    // Effective incumbent ownership, already resolved, then every PARTICIPATING
+    // incoming canonical applied on top under the SAME rules the commit path
+    // and the corrector use.
     //
     // A first version kept batch ownership in its own side maps and registered
     // everything first-wins. That reproduced, on the review screen, the exact
@@ -519,18 +553,10 @@ package actor CustomWordsImportCompareEngine {
     // Whatever the screen predicts has to be what the commit does.
     var plannedOwners = WordCorrector.buildExactTriggerIndex(words: existingWords)
 
-    for candidate in coalesced {
-      let owner = Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false)
-      for claim in WordCorrector.exactClaims(forCanonical: candidate.canonical) {
-        switch claim.namespace {
-        case .nospace:
-          // Unconditional here, so the LATER canonical wins.
-          plannedOwners.register(claim, to: owner)
-        case .single, .multi:
-          // A self-entry yields to whoever already holds the key.
-          if plannedOwners.owner(of: claim) == nil { plannedOwners.register(claim, to: owner) }
-        }
-      }
+    for candidate in coalesced where participatingCandidateIDs.contains(candidate.id) {
+      plannedOwners.applyCanonical(
+        candidate.canonical,
+        owner: Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false))
     }
 
     /// The owner that would beat `candidate` to this surface, if any.
@@ -573,13 +599,18 @@ package actor CustomWordsImportCompareEngine {
           continue
         }
 
+        // Only a PARTICIPATING candidate's surviving alias becomes a future
+        // blocker: an exact/variant/fuzzy match's alias is disclosed above for
+        // preview, but it is never persisted as a fresh word, so it must not
+        // shadow a later candidate the way a real addition would.
+        guard participatingCandidateIDs.contains(candidate.id) else { continue }
+
         // Gap-fill, never overwrite — same rule as the commit path. An alias
         // reaching here unblocked may still sit behind a compound holder that
         // simply declines to intercept, and that holder keeps the slot.
-        let owner = Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false)
-        for claim in claims where plannedOwners.owner(of: claim) == nil {
-          plannedOwners.register(claim, to: owner)
-        }
+        plannedOwners.gapFill(
+          claims,
+          owner: Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false))
       }
     }
     return collisions

--- a/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
@@ -506,24 +506,29 @@ package actor CustomWordsImportCompareEngine {
     coalesced: [CustomWordsImportCandidate],
     existingWords: [CustomWord]
   ) throws -> [UUID: [CustomWordsImportAliasCollision]] {
-    // Effective incumbent ownership, already resolved. Nothing is replayed.
-    let incumbents = WordCorrector.buildExactTriggerIndex(words: existingWords)
-
-    // Batch-only ownership, tracked per namespace because a key is only a
-    // conflict within the surface that consumes it.
-    typealias Namespace = WordCorrector.ExactTriggerNamespace
     typealias Owner = WordCorrector.TriggerOwner
-    var candidateCanonicalOwners: [Namespace: [String: Owner]] = [:]
-    var importedAliasOwners: [Namespace: [String: Owner]] = [:]
 
-    // Incoming canonicals are not in the library yet, so they rank below every
-    // incumbent surface — but above another candidate's alias, since all of
-    // them are registered before any imported alias is checked. First wins.
+    // Effective incumbent ownership, already resolved, then every incoming
+    // canonical applied on top under the SAME rules the commit path and the
+    // corrector use.
+    //
+    // A first version kept batch ownership in its own side maps and registered
+    // everything first-wins. That reproduced, on the review screen, the exact
+    // split this issue exists to close: the screen could warn about an alias
+    // the commit then kept, or stay silent about one the commit then dropped.
+    // Whatever the screen predicts has to be what the commit does.
+    var plannedOwners = WordCorrector.buildExactTriggerIndex(words: existingWords)
+
     for candidate in coalesced {
       let owner = Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false)
       for claim in WordCorrector.exactClaims(forCanonical: candidate.canonical) {
-        if candidateCanonicalOwners[claim.namespace]?[claim.key] == nil {
-          candidateCanonicalOwners[claim.namespace, default: [:]][claim.key] = owner
+        switch claim.namespace {
+        case .nospace:
+          // Unconditional here, so the LATER canonical wins.
+          plannedOwners.register(claim, to: owner)
+        case .single, .multi:
+          // A self-entry yields to whoever already holds the key.
+          if plannedOwners.owner(of: claim) == nil { plannedOwners.register(claim, to: owner) }
         }
       }
     }
@@ -537,14 +542,8 @@ package actor CustomWordsImportCompareEngine {
     func blocker(
       of claim: WordCorrector.ExactTriggerClaim, surface: String, for candidate: UUID
     ) -> Owner? {
-      // First HOLDER wins the slot, incumbents ahead of the batch. A holder
-      // behind it is not the runtime owner, so the search stops at the first
-      // one found and then asks only whether that one intercepts.
-      let holder =
-        incumbents.owner(of: claim)
-        ?? candidateCanonicalOwners[claim.namespace]?[claim.key]
-        ?? importedAliasOwners[claim.namespace]?[claim.key]
-      guard let holder, holder.wordID != candidate else { return nil }
+      guard let holder = plannedOwners.owner(of: claim), holder.wordID != candidate
+      else { return nil }
       return WordCorrector.ownerIntercepts(claim: claim, rawSurface: surface, owner: holder)
         ? holder : nil
     }
@@ -574,9 +573,12 @@ package actor CustomWordsImportCompareEngine {
           continue
         }
 
+        // Gap-fill, never overwrite — same rule as the commit path. An alias
+        // reaching here unblocked may still sit behind a compound holder that
+        // simply declines to intercept, and that holder keeps the slot.
         let owner = Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false)
-        for claim in claims {
-          importedAliasOwners[claim.namespace, default: [:]][claim.key] = owner
+        for claim in claims where plannedOwners.owner(of: claim) == nil {
+          plannedOwners.register(claim, to: owner)
         }
       }
     }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
@@ -453,105 +453,131 @@ package actor CustomWordsImportCompareEngine {
 
   // MARK: - Alias-collision detection (decision-agnostic; disclosure only)
 
-  /// Keyed on `persistenceKey` throughout, not the matching key: a collision
-  /// is a claim about two entries fighting over the same slot in stored data
-  /// and in `WordCorrector`'s lookup map, and both use the manager's weaker
-  /// key. Using the stronger matching key here would flag pairs that never
-  /// actually collide at runtime.
-  ///
   /// `heldBy` must name the word that ACTUALLY holds the trigger, because the
   /// Review screen names that owner in its inline note ("X already uses it").
-  /// So ownership mirrors `WordCorrector.buildLookups`
-  /// (WordCorrector.swift:176-215) rather than any convention of this file's
-  /// own — two rounds of review found invented conventions disagreeing with
-  /// runtime, in opposite directions:
   ///
-  /// - Among two EXISTING words sharing an alias, the corrector assigns
-  ///   unconditionally, so the LATER word wins (its own debug line reads
-  ///   "using <later canonical>").
-  /// - When a key is held by an existing ALIAS *and* an existing CANONICAL,
-  ///   the ALIAS wins: the corrector builds every alias first, then SKIPS any
-  ///   canonical whose key an alias already owns ("Canonical 'X' skipped: key
-  ///   already maps to..."). A canonical-first order would name a word whose
-  ///   own spelling the corrector never even reaches.
+  /// This file used to mirror `WordCorrector`'s precedence by hand and got it
+  /// wrong three separate times, each fixed as its own instance: first-wins
+  /// versus last-wins among two existing alias owners, canonical-first versus
+  /// alias-first when both owned a key, and finally the no-space compound
+  /// surface it never modelled at all — so an imported alias equal to an
+  /// existing multi-word canonical's space-free form was reported collision-free,
+  /// persisted, and then never fired, because Pass 0 resolved it first (#1667).
+  /// A fourth divergence was latent: the corrector keys on `lowercased()` with
+  /// no trim while this file trimmed, so on malformed or legacy decoded data the
+  /// two disagreed about what a key even was.
   ///
-  /// Lookup order for an imported alias, first match wins:
-  /// 1. existing alias owner (the runtime holder), 2. existing canonical
-  /// owner, 3. an incoming candidate's canonical, 4. an earlier imported
-  /// alias. Otherwise this candidate claims the surface for the batch.
+  /// So precedence is no longer mirrored here at all. `WordCorrector` owns what
+  /// a trigger key is and who wins it; this function asks it for the incoming
+  /// candidate's claims and reads incumbent winners out of its index. It never
+  /// lowercases, strips spaces, classifies single versus multi, or replays
+  /// corrector precedence — doing any of that is the defect this ends.
+  ///
+  /// What remains local is IMPORT-BATCH disposition, which is not corrector
+  /// state: incoming canonicals reserve their claims first-wins, then each
+  /// candidate's aliases are checked in plan order against, in order, the
+  /// effective incumbent owner, the incoming-canonical batch owner, and an
+  /// earlier imported alias. Ownership by the same candidate is never a
+  /// collision.
+  ///
+  /// HOLDING a key is not the same as INTERCEPTING it, and only the second one
+  /// is a collision. Pass 0 declines to substitute when the text already spells
+  /// the owner's own canonical, leaving it to the ordinary passes and a
+  /// different word — so the first holder found decides the surface, and the
+  /// authority is then asked whether that holder actually acts on it.
+  /// `aRuntimeOracleForEveryOwnerThisSuiteNames` pins all three shapes against
+  /// the real corrector.
+  ///
+  /// Alias disposition is ATOMIC, because the stored alias — not one trigger
+  /// claim — is the unit the commit path keeps or drops. Registering the
+  /// surviving claims of an alias that will be DROPPED would create a batch
+  /// owner that never exists and then falsely block a later alias. So every
+  /// claim is evaluated before any is registered, and it is all or none.
+  ///
+  /// When claims lose to different owners, the receipt names the one whose
+  /// namespace runs earliest in correction (no-space Pass 0, then multi Pass 1,
+  /// then single Pass 3) — the owner that would actually intercept the text.
   ///
   /// A candidate's SOURCE aliases only, in plan order — never
   /// `suggestedAliases`, since enrichment has not run at compare time and a
-  /// colliding suggestion is enforced-and-receipted at commit instead. An
-  /// alias equal to its OWN candidate's canonical is redundant, not a
-  /// collision, and is dropped silently. Only the LOSING side is ever
-  /// flagged; a winner's alias is not at risk.
+  /// colliding suggestion is enforced-and-receipted at commit instead. Only the
+  /// LOSING side is ever flagged; a winner's alias is not at risk.
   static func detectAliasCollisions(
     coalesced: [CustomWordsImportCandidate],
     existingWords: [CustomWord]
   ) throws -> [UUID: [CustomWordsImportAliasCollision]] {
-    // Existing aliases: last writer wins, per the corrector's unconditional
-    // assignment.
-    var existingAliasOwners: [String: UUID] = [:]
-    for word in existingWords {
-      for alias in word.aliases {
-        let key = persistenceKey(alias)
-        if key.isEmpty == false { existingAliasOwners[key] = word.id }
+    // Effective incumbent ownership, already resolved. Nothing is replayed.
+    let incumbents = WordCorrector.buildExactTriggerIndex(words: existingWords)
+
+    // Batch-only ownership, tracked per namespace because a key is only a
+    // conflict within the surface that consumes it.
+    typealias Namespace = WordCorrector.ExactTriggerNamespace
+    typealias Owner = WordCorrector.TriggerOwner
+    var candidateCanonicalOwners: [Namespace: [String: Owner]] = [:]
+    var importedAliasOwners: [Namespace: [String: Owner]] = [:]
+
+    // Incoming canonicals are not in the library yet, so they rank below every
+    // incumbent surface — but above another candidate's alias, since all of
+    // them are registered before any imported alias is checked. First wins.
+    for candidate in coalesced {
+      let owner = Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false)
+      for claim in WordCorrector.exactClaims(forCanonical: candidate.canonical) {
+        if candidateCanonicalOwners[claim.namespace]?[claim.key] == nil {
+          candidateCanonicalOwners[claim.namespace, default: [:]][claim.key] = owner
+        }
       }
     }
-    var existingCanonicalOwners: [String: UUID] = [:]
-    for word in existingWords {
-      let key = persistenceKey(word.canonical)
-      if existingCanonicalOwners[key] == nil { existingCanonicalOwners[key] = word.id }
-    }
-    // Incoming canonicals are not in the library yet, so they rank below every
-    // incumbent surface — but still above another candidate's alias, since all
-    // canonicals are registered before any imported alias is checked.
-    var candidateCanonicalOwners: [String: UUID] = [:]
-    for candidate in coalesced {
-      let key = persistenceKey(candidate.canonical)
-      if candidateCanonicalOwners[key] == nil { candidateCanonicalOwners[key] = candidate.id }
-    }
 
-    func incumbentOwner(of key: String) -> UUID? {
-      existingAliasOwners[key] ?? existingCanonicalOwners[key]
+    /// The owner that would beat `candidate` to this surface, if any.
+    ///
+    /// Holding a key is not always intercepting it, so every hit is checked
+    /// against the authority before it counts as a blocker: a no-space owner
+    /// whose canonical the surface already spells declines to substitute, and
+    /// naming it would point the user at a word that never touches their text.
+    func blocker(
+      of claim: WordCorrector.ExactTriggerClaim, surface: String, for candidate: UUID
+    ) -> Owner? {
+      // First HOLDER wins the slot, incumbents ahead of the batch. A holder
+      // behind it is not the runtime owner, so the search stops at the first
+      // one found and then asks only whether that one intercepts.
+      let holder =
+        incumbents.owner(of: claim)
+        ?? candidateCanonicalOwners[claim.namespace]?[claim.key]
+        ?? importedAliasOwners[claim.namespace]?[claim.key]
+      guard let holder, holder.wordID != candidate else { return nil }
+      return WordCorrector.ownerIntercepts(claim: claim, rawSurface: surface, owner: holder)
+        ? holder : nil
     }
-
-    var importedAliasOwners: [String: UUID] = [:]
 
     var collisions: [UUID: [CustomWordsImportAliasCollision]] = [:]
     for candidate in coalesced {
       try Task.checkCancellation()
       guard case .supplied(let sourceAliases) = candidate.aliases else { continue }
-      let ownCanonicalKey = persistenceKey(candidate.canonical)
       for alias in sourceAliases {
-        let key = persistenceKey(alias)
-        if key.isEmpty || key == ownCanonicalKey { continue }
-        // Incumbents first — an existing alias outranks an existing canonical,
-        // mirroring the corrector's build order. Neither can be this candidate.
-        if let owner = incumbentOwner(of: key) {
-          collisions[candidate.id, default: []].append(
-            CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
-          continue
+        let claims = WordCorrector.exactClaims(forAlias: alias)
+        if claims.isEmpty { continue }
+
+        // Evaluate every claim BEFORE registering any of them (atomicity).
+        let blockers = claims.compactMap { claim in
+          blocker(of: claim, surface: alias, for: candidate.id).map { (claim: claim, owner: $0) }
         }
-        // A candidate only ever owns its OWN canonical surface, which the
-        // `key == ownCanonicalKey` guard already consumed, so any candidate
-        // canonical found here belongs to a different row.
-        if let owner = candidateCanonicalOwners[key] {
-          collisions[candidate.id, default: []].append(
-            CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
-          continue
-        }
-        // A candidate can already own an alias surface only via an earlier
-        // alias of its own — a duplicate spelling, not a collision.
-        if let owner = importedAliasOwners[key] {
-          if owner != candidate.id {
+
+        guard blockers.isEmpty else {
+          // The earliest-running surface is the one that actually intercepts.
+          let decisive = blockers.min {
+            $0.claim.namespace.passPriority < $1.claim.namespace.passPriority
+          }
+          if let decisive {
             collisions[candidate.id, default: []].append(
-              CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
+              CustomWordsImportAliasCollision(alias: alias, heldBy: decisive.owner.wordID))
           }
           continue
         }
-        importedAliasOwners[key] = candidate.id
+
+        let owner = Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false)
+        for claim in claims {
+          importedAliasOwners[claim.namespace, default: [:]][claim.key] = owner
+        }
       }
     }
     return collisions

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -819,9 +819,6 @@ public final class CustomWordsManager {
     //
     // Untouched words register first and are never modified, so an incumbent
     // always outranks an imported alias.
-    var index = WordCorrector.buildExactTriggerIndex(
-      words: words.filter { !touchedIDs.contains($0.id) })
-
     var result = words
     // Last wins, and the list must not be assumed id-unique. Renaming a
     // built-in stores a user override carrying the built-in's OWN id while
@@ -833,22 +830,26 @@ public final class CustomWordsManager {
     let indexByID = Dictionary(
       result.indices.map { (result[$0].id, $0) }, uniquingKeysWith: { _, last in last })
 
-    // A touched word's own canonical also exists in the final library, so it
-    // blocks another word's alias even though the word itself is being
-    // changed. Registered in APPLY order via `touchedOrder`, not the words
-    // list's storage order: the compound namespace is unconditional, so which
-    // touched word ends up owning a shared compound key depends on which order
-    // they are resolved in. Grounded review r6 found this loop had drifted to
-    // storage order while the alias loop below correctly used `touchedOrder`,
-    // so the two could pick different winners for the same import.
-    for id in touchedOrder {
-      guard let wordIndex = indexByID[id] else { continue }
-      let word = result[wordIndex]
-      index.applyCanonical(
-        word.canonical,
-        owner: WordCorrector.TriggerOwner(wordID: word.id, canonical: word.canonical, isPack: false)
-      )
+    // Canonical ownership is resolved by handing the WHOLE final array — the
+    // exact array the runtime corrector will build its own lookups from — to
+    // the one authority, in its own FINAL STORAGE order. A first version tried
+    // to replay just the touched canonicals in APPLY order instead. That is
+    // wrong: the compound namespace's last-write-wins rule is about storage
+    // order, because that is the order `buildExactTriggerIndex` iterates when
+    // it runs for real on the saved file. Apply order can name a winner the
+    // corrector itself would never produce (grounded review r7, #1667).
+    //
+    // Touched words' OLD aliases are stripped from this seed, because their
+    // real aliases are re-decided by the loop below in the plan's approved
+    // order — that precedence is a genuinely separate, already-established
+    // rule this pass must not disturb.
+    let touchedIndices = Set(touchedOrder.compactMap { indexByID[$0] })
+    let ownershipSeed = result.indices.map { wordIndex -> CustomWord in
+      var word = result[wordIndex]
+      if touchedIndices.contains(wordIndex) { word.aliases = [] }
+      return word
     }
+    var index = WordCorrector.buildExactTriggerIndex(words: ownershipSeed)
 
     /// The owner that would beat this word to a surface, if any. Holding a key
     /// is not always intercepting it — see `WordCorrector.ownerIntercepts`.

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -808,23 +808,47 @@ public final class CustomWordsManager {
     on words: [CustomWord], touchedOrder: [UUID]
   ) -> (words: [CustomWord], dropped: [CustomWordsImportAliasCollision]) {
     let touchedIDs = Set(touchedOrder)
-    var canonicalOwners: [String: UUID] = [:]
-    for word in words {
-      let key = importPersistenceKey(word.canonical)
-      if canonicalOwners[key] == nil { canonicalOwners[key] = word.id }
+
+    // Ownership comes from `WordCorrector`, not from a third copy of its rules
+    // (#1667). This function used to mirror them itself, keyed on
+    // `importPersistenceKey`, which has no no-space surface at all — so an
+    // imported alias equal to an existing multi-word canonical's space-free
+    // form was KEPT here even once the compare screen had learned to disclose
+    // it. The screen said one thing and the commit did another; the alias was
+    // saved and then never fired.
+    //
+    // Untouched words register first and are never modified, so an incumbent
+    // always outranks an imported alias.
+    var index = WordCorrector.buildExactTriggerIndex(
+      words: words.filter { !touchedIDs.contains($0.id) })
+
+    // A touched word's own canonical also exists in the final library, so it
+    // blocks another word's alias even though the word itself is being changed.
+    // The two namespaces do NOT share a rule, and treating them alike named the
+    // wrong owner: in the compound namespace a canonical is written
+    // unconditionally and overwrites an earlier alias, while an ordinary
+    // self-entry yields to whoever already holds the key.
+    for word in words where touchedIDs.contains(word.id) {
+      let owner = WordCorrector.TriggerOwner(
+        wordID: word.id, canonical: word.canonical, isPack: false)
+      for claim in WordCorrector.exactClaims(forCanonical: word.canonical) {
+        switch claim.namespace {
+        case .nospace:
+          index.register(claim, to: owner)
+        case .single, .multi:
+          if index.owner(of: claim) == nil { index.register(claim, to: owner) }
+        }
+      }
     }
 
-    // Untouched words register first and are never modified, so an incumbent
-    // alias always outranks an imported one. Among two untouched words sharing
-    // an alias the LAST one wins, mirroring `WordCorrector.buildLookups`'s
-    // unconditional assignment (WordCorrector.swift:180-205) — the receipt's
-    // `heldBy` has to name the word that really holds the trigger.
-    var aliasOwners: [String: UUID] = [:]
-    for word in words where !touchedIDs.contains(word.id) {
-      for alias in word.aliases {
-        let key = importPersistenceKey(alias)
-        if !key.isEmpty { aliasOwners[key] = word.id }
-      }
+    /// The owner that would beat this word to a surface, if any. Holding a key
+    /// is not always intercepting it — see `WordCorrector.ownerIntercepts`.
+    func blocker(
+      of claim: WordCorrector.ExactTriggerClaim, surface: String, for wordID: UUID
+    ) -> WordCorrector.TriggerOwner? {
+      guard let holder = index.owner(of: claim), holder.wordID != wordID else { return nil }
+      return WordCorrector.ownerIntercepts(claim: claim, rawSurface: surface, owner: holder)
+        ? holder : nil
     }
 
     var result = words
@@ -839,30 +863,47 @@ public final class CustomWordsManager {
     let indexByID = Dictionary(
       result.indices.map { (result[$0].id, $0) }, uniquingKeysWith: { _, last in last })
     for id in touchedOrder {
-      guard let index = indexByID[id] else { continue }
-      let word = result[index]
+      guard let wordIndex = indexByID[id] else { continue }
+      let word = result[wordIndex]
       let canonicalKey = importPersistenceKey(word.canonical)
       var kept: [String] = []
       for alias in word.aliases {
-        let key = importPersistenceKey(alias)
-        if key.isEmpty { continue }
+        if importPersistenceKey(alias).isEmpty { continue }
         // Redundant with the word's own canonical: silently removed, never
         // reported — it is not an ambiguity anyone needs to hear about.
-        if key == canonicalKey { continue }
-        if let owner = canonicalOwners[key], owner != word.id {
-          dropped.append(CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
+        if importPersistenceKey(alias) == canonicalKey { continue }
+
+        let claims = WordCorrector.exactClaims(forAlias: alias)
+        if claims.isEmpty { continue }
+
+        // Evaluate every claim before registering any: the stored alias is the
+        // unit kept or dropped, so a partially-registered alias that is then
+        // dropped would leave an owner that does not exist and wrongly block a
+        // later one. Same atomicity rule the compare engine follows.
+        let blockers = claims.compactMap { claim in
+          blocker(of: claim, surface: alias, for: word.id).map { (claim: claim, owner: $0) }
+        }
+        if let decisive = blockers.min(by: {
+          $0.claim.namespace.passPriority < $1.claim.namespace.passPriority
+        }) {
+          dropped.append(
+            CustomWordsImportAliasCollision(alias: alias, heldBy: decisive.owner.wordID))
           continue
         }
-        if let owner = aliasOwners[key] {
-          if owner != word.id {
-            dropped.append(CustomWordsImportAliasCollision(alias: alias, heldBy: owner))
-          }
-          continue
+
+        // Gap-fill, never overwrite. An alias reaches here unblocked for one of
+        // three reasons: nobody holds the key, this word already holds it, or a
+        // compound holder declines to intercept. In that last case the holder
+        // must STAY registered, because at runtime an alias only ever fills an
+        // empty compound slot. Overwriting handed the key to the wrong word.
+        let owner = WordCorrector.TriggerOwner(
+          wordID: word.id, canonical: word.canonical, isPack: false)
+        for claim in claims where index.owner(of: claim) == nil {
+          index.register(claim, to: owner)
         }
-        aliasOwners[key] = word.id
         kept.append(alias)
       }
-      result[index].aliases = kept
+      result[wordIndex].aliases = kept
     }
     return (result, dropped)
   }

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -822,23 +822,32 @@ public final class CustomWordsManager {
     var index = WordCorrector.buildExactTriggerIndex(
       words: words.filter { !touchedIDs.contains($0.id) })
 
+    var result = words
+    // Last wins, and the list must not be assumed id-unique. Renaming a
+    // built-in stores a user override carrying the built-in's OWN id while
+    // `mergedWords` keeps showing the built-in (its canonical no longer
+    // matches any user word), so within one process the two share an id and
+    // `uniqueKeysWithValues` would trap on a state the manager itself creates.
+    // `mergedWords` returns built-ins first, so last-wins resolves to the
+    // user's own word — the one an import can legitimately touch.
+    let indexByID = Dictionary(
+      result.indices.map { (result[$0].id, $0) }, uniquingKeysWith: { _, last in last })
+
     // A touched word's own canonical also exists in the final library, so it
-    // blocks another word's alias even though the word itself is being changed.
-    // The two namespaces do NOT share a rule, and treating them alike named the
-    // wrong owner: in the compound namespace a canonical is written
-    // unconditionally and overwrites an earlier alias, while an ordinary
-    // self-entry yields to whoever already holds the key.
-    for word in words where touchedIDs.contains(word.id) {
-      let owner = WordCorrector.TriggerOwner(
-        wordID: word.id, canonical: word.canonical, isPack: false)
-      for claim in WordCorrector.exactClaims(forCanonical: word.canonical) {
-        switch claim.namespace {
-        case .nospace:
-          index.register(claim, to: owner)
-        case .single, .multi:
-          if index.owner(of: claim) == nil { index.register(claim, to: owner) }
-        }
-      }
+    // blocks another word's alias even though the word itself is being
+    // changed. Registered in APPLY order via `touchedOrder`, not the words
+    // list's storage order: the compound namespace is unconditional, so which
+    // touched word ends up owning a shared compound key depends on which order
+    // they are resolved in. Grounded review r6 found this loop had drifted to
+    // storage order while the alias loop below correctly used `touchedOrder`,
+    // so the two could pick different winners for the same import.
+    for id in touchedOrder {
+      guard let wordIndex = indexByID[id] else { continue }
+      let word = result[wordIndex]
+      index.applyCanonical(
+        word.canonical,
+        owner: WordCorrector.TriggerOwner(wordID: word.id, canonical: word.canonical, isPack: false)
+      )
     }
 
     /// The owner that would beat this word to a surface, if any. Holding a key
@@ -851,17 +860,7 @@ public final class CustomWordsManager {
         ? holder : nil
     }
 
-    var result = words
     var dropped: [CustomWordsImportAliasCollision] = []
-    // Last wins, and the list must not be assumed id-unique. Renaming a
-    // built-in stores a user override carrying the built-in's OWN id while
-    // `mergedWords` keeps showing the built-in (its canonical no longer
-    // matches any user word), so within one process the two share an id and
-    // `uniqueKeysWithValues` would trap on a state the manager itself creates.
-    // `mergedWords` returns built-ins first, so last-wins resolves to the
-    // user's own word — the one an import can legitimately touch.
-    let indexByID = Dictionary(
-      result.indices.map { (result[$0].id, $0) }, uniquingKeysWith: { _, last in last })
     for id in touchedOrder {
       guard let wordIndex = indexByID[id] else { continue }
       let word = result[wordIndex]
@@ -896,11 +895,11 @@ public final class CustomWordsManager {
         // compound holder declines to intercept. In that last case the holder
         // must STAY registered, because at runtime an alias only ever fills an
         // empty compound slot. Overwriting handed the key to the wrong word.
-        let owner = WordCorrector.TriggerOwner(
-          wordID: word.id, canonical: word.canonical, isPack: false)
-        for claim in claims where index.owner(of: claim) == nil {
-          index.register(claim, to: owner)
-        }
+        index.gapFill(
+          claims,
+          owner: WordCorrector.TriggerOwner(
+            wordID: word.id, canonical: word.canonical, isPack: false)
+        )
         kept.append(alias)
       }
       result[wordIndex].aliases = kept

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -807,8 +807,6 @@ public final class CustomWordsManager {
   static func enforceAliases(
     on words: [CustomWord], touchedOrder: [UUID]
   ) -> (words: [CustomWord], dropped: [CustomWordsImportAliasCollision]) {
-    let touchedIDs = Set(touchedOrder)
-
     // Ownership comes from `WordCorrector`, not from a third copy of its rules
     // (#1667). This function used to mirror them itself, keyed on
     // `importPersistenceKey`, which has no no-space surface at all — so an
@@ -816,9 +814,6 @@ public final class CustomWordsManager {
     // form was KEPT here even once the compare screen had learned to disclose
     // it. The screen said one thing and the commit did another; the alias was
     // saved and then never fired.
-    //
-    // Untouched words register first and are never modified, so an incumbent
-    // always outranks an imported alias.
     var result = words
     // Last wins, and the list must not be assumed id-unique. Renaming a
     // built-in stores a user override carrying the built-in's OWN id while
@@ -839,10 +834,11 @@ public final class CustomWordsManager {
     // it runs for real on the saved file. Apply order can name a winner the
     // corrector itself would never produce (grounded review r7, #1667).
     //
-    // Touched words' OLD aliases are stripped from this seed, because their
-    // real aliases are re-decided by the loop below in the plan's approved
-    // order — that precedence is a genuinely separate, already-established
-    // rule this pass must not disturb.
+    // Touched words' proposed final aliases are stripped from this seed,
+    // because their surviving aliases are decided by the loop below in the
+    // plan's approved order — that precedence is a genuinely separate,
+    // already-established rule this pass must not disturb. Canonicals stay,
+    // so ownership is still resolved from the complete final vocabulary.
     let touchedIndices = Set(touchedOrder.compactMap { indexByID[$0] })
     let ownershipSeed = result.indices.map { wordIndex -> CustomWord in
       var word = result[wordIndex]

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -244,6 +244,33 @@ public struct WordCorrector: Sendable {
       }
     }
 
+    /// Apply a WORD'S OWN canonical claims to an incrementally-resolved index.
+    ///
+    /// The two per-namespace rules do not read the same: an ordinary self-entry
+    /// yields to whoever already holds the key, while the compound form is
+    /// written unconditionally and can overwrite an earlier alias. This is that
+    /// rule stated once. Two import consumers — the compare screen and the
+    /// commit path — used to restate it inline, and diverged when only one of
+    /// them was corrected (grounded review r5/r6, #1667).
+    package mutating func applyCanonical(_ canonical: String, owner: TriggerOwner) {
+      for claim in WordCorrector.exactClaims(forCanonical: canonical) {
+        switch claim.namespace {
+        case .nospace: register(claim, to: owner)
+        case .single, .multi: if self.owner(of: claim) == nil { register(claim, to: owner) }
+        }
+      }
+    }
+
+    /// Register every claim in `claims` that nobody already holds. Never
+    /// overwrites: a claim already held — including by a compound owner that
+    /// declines to intercept this exact surface — keeps its existing owner,
+    /// because that is what the corrector's own gap-fill rule does at runtime.
+    package mutating func gapFill(_ claims: [ExactTriggerClaim], owner: TriggerOwner) {
+      for claim in claims where self.owner(of: claim) == nil {
+        register(claim, to: owner)
+      }
+    }
+
     /// The ordinary-namespace maps in `buildLookups`' shape, optionally limited
     /// to non-pack owners for the fuzzy pools that must exclude pack terms.
     func canonicalsByKey(

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -233,6 +233,17 @@ public struct WordCorrector: Sendable {
       }
     }
 
+    /// Assign a claim unconditionally. For consumers that resolve ownership
+    /// incrementally — the import commit path decides one word at a time, in
+    /// the order the user approved — rather than over a whole vocabulary.
+    package mutating func register(_ claim: ExactTriggerClaim, to owner: TriggerOwner) {
+      switch claim.namespace {
+      case .single: single[claim.key] = owner
+      case .multi: multi[claim.key] = owner
+      case .nospace: nospace[claim.key] = owner
+      }
+    }
+
     /// The ordinary-namespace maps in `buildLookups`' shape, optionally limited
     /// to non-pack owners for the fuzzy pools that must exclude pack terms.
     func canonicalsByKey(

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -150,6 +150,154 @@ public struct WordCorrector: Sendable {
     public let nonPackExactKeys: Set<String>
   }
 
+  // MARK: - Exact-trigger authority (#1667)
+
+  /// The one place that answers "what exact keys does this value claim, and at
+  /// what precedence" (#1667).
+  ///
+  /// Import collision detection used to re-derive this by hand and mirrored only
+  /// two of the surfaces. That partial mirror was found wrong three separate
+  /// times — first-wins vs last-wins among two alias owners, canonical-first vs
+  /// alias-first, then the no-space surface it never modelled at all. A fourth
+  /// divergence was latent: the detector trimmed its keys, this does not, so on
+  /// malformed or legacy data the two disagreed about what a key even was.
+  ///
+  /// The fix is not a fourth patch. `buildLookups` and `detectAliasCollisions`
+  /// now BOTH construct claims here, so there is nothing left to drift.
+  package enum ExactTriggerNamespace: Sendable, Equatable {
+    case single
+    case multi
+    case nospace
+
+    /// Correction-pass order, used to pick which owner a single collision
+    /// receipt names when one alias is blocked on several surfaces at once.
+    /// Pass 0 (no-space compound) runs before the ordinary exact passes.
+    package var passPriority: Int {
+      switch self {
+      case .nospace: return 0
+      case .multi: return 1
+      case .single: return 3
+      }
+    }
+  }
+
+  package struct ExactTriggerClaim: Sendable, Equatable {
+    package let key: String
+    package let namespace: ExactTriggerNamespace
+  }
+
+  package struct TriggerOwner: Sendable, Equatable {
+    package let wordID: UUID
+    package let canonical: String
+  }
+
+  /// Effective incumbent ownership, after every overwrite and gap-fill rule has
+  /// already been applied. Consumers read winners; they never replay precedence.
+  package struct ExactTriggerIndex: Sendable {
+    package var single: [String: TriggerOwner] = [:]
+    package var multi: [String: TriggerOwner] = [:]
+    package var nospace: [String: TriggerOwner] = [:]
+
+    package func owner(of claim: ExactTriggerClaim) -> TriggerOwner? {
+      switch claim.namespace {
+      case .single: return single[claim.key]
+      case .multi: return multi[claim.key]
+      case .nospace: return nospace[claim.key]
+      }
+    }
+  }
+
+  /// Keys an ALIAS claims. Ordinary surface first, then its no-space form when
+  /// that differs. Deduplicated, so a space-free alias yields one ordinary claim
+  /// plus its identical-key no-space claim only when the namespaces differ.
+  package static func exactClaims(forAlias alias: String) -> [ExactTriggerClaim] {
+    let key = alias.lowercased()
+    guard !key.isEmpty else { return [] }
+    var claims = [
+      ExactTriggerClaim(key: key, namespace: alias.contains(" ") ? .multi : .single)
+    ]
+    let nospaceKey = alias.replacingOccurrences(of: " ", with: "").lowercased()
+    if !nospaceKey.isEmpty {
+      claims.append(ExactTriggerClaim(key: nospaceKey, namespace: .nospace))
+    }
+    return claims
+  }
+
+  /// Keys a CANONICAL claims. The self-entry exists only for a space-free
+  /// canonical; the no-space claim is unconditional.
+  package static func exactClaims(forCanonical canonical: String) -> [ExactTriggerClaim] {
+    let key = canonical.lowercased()
+    guard !key.isEmpty else { return [] }
+    var claims: [ExactTriggerClaim] = []
+    if !key.contains(" ") { claims.append(ExactTriggerClaim(key: key, namespace: .single)) }
+    let nospaceKey = canonical.replacingOccurrences(of: " ", with: "").lowercased()
+    if !nospaceKey.isEmpty {
+      claims.append(ExactTriggerClaim(key: nospaceKey, namespace: .nospace))
+    }
+    return claims
+  }
+
+  /// Resolve effective ownership across a whole vocabulary, applying the same
+  /// rules `buildLookups` has always applied — which is why `buildLookups` now
+  /// projects from this rather than repeating them.
+  package static func buildExactTriggerIndex(words: [CustomWord]) -> ExactTriggerIndex {
+    let packWords = words.filter { $0.source == .pack }
+    let nonPackWords = words.filter { $0.source != .pack }
+    var index = ExactTriggerIndex()
+
+    // Non-pack aliases: last writer wins in the ordinary namespaces.
+    for word in nonPackWords {
+      let owner = TriggerOwner(wordID: word.id, canonical: word.canonical)
+      for alias in word.aliases {
+        let key = alias.lowercased()
+        guard !key.isEmpty else { continue }
+        if alias.contains(" ") { index.multi[key] = owner } else { index.single[key] = owner }
+      }
+    }
+
+    // Non-pack canonical self-entry: space-free only, and it YIELDS to an alias.
+    for word in nonPackWords {
+      let key = word.canonical.lowercased()
+      guard !key.isEmpty, !key.contains(" "), index.single[key] == nil else { continue }
+      index.single[key] = TriggerOwner(wordID: word.id, canonical: word.canonical)
+    }
+
+    // No-space namespace, non-pack only. Canonical is unconditional and last
+    // writer wins; an alias fills only an empty slot. So alias-vs-alias is
+    // FIRST-wins here while canonical-vs-canonical is last-wins, and a later
+    // canonical can overwrite an earlier alias. Three rules, one map — the
+    // reason a hand-rolled mirror kept getting this wrong.
+    for word in nonPackWords {
+      let owner = TriggerOwner(wordID: word.id, canonical: word.canonical)
+      let nospace = word.canonical.replacingOccurrences(of: " ", with: "").lowercased()
+      if !nospace.isEmpty { index.nospace[nospace] = owner }
+      for alias in word.aliases {
+        let aliasNospace = alias.replacingOccurrences(of: " ", with: "").lowercased()
+        guard !aliasNospace.isEmpty, index.nospace[aliasNospace] == nil else { continue }
+        index.nospace[aliasNospace] = owner
+      }
+    }
+
+    // Pack aliases gap-fill the ordinary namespaces only, and never claim a key
+    // any non-pack canonical owns. Pack canonicals get no self-entry, and pack
+    // terms never enter the no-space namespace.
+    let nonPackCanonicalKeys = Set(nonPackWords.map { $0.canonical.lowercased() })
+    for word in packWords {
+      let owner = TriggerOwner(wordID: word.id, canonical: word.canonical)
+      for alias in word.aliases {
+        let key = alias.lowercased()
+        guard !key.isEmpty, !nonPackCanonicalKeys.contains(key) else { continue }
+        if alias.contains(" ") {
+          if index.multi[key] == nil { index.multi[key] = owner }
+        } else {
+          if index.single[key] == nil { index.single[key] = owner }
+        }
+      }
+    }
+
+    return index
+  }
+
   /// Build the lookup structures for a given vocabulary. Pure function.
   /// `WordCorrectionStep` calls this once per generation change and reuses
   /// the result across many `correct(...)` calls.

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -189,6 +189,30 @@ public struct WordCorrector: Sendable {
   package struct TriggerOwner: Sendable, Equatable {
     package let wordID: UUID
     package let canonical: String
+    /// Pack terms are a lower authority: they only ever gap-fill the ordinary
+    /// namespaces, and the fuzzy pools must be built from non-pack owners alone.
+    /// Carried here so `buildLookups` can separate the two populations without
+    /// rebuilding either map.
+    package let isPack: Bool
+  }
+
+  /// A key claimed twice in an ordinary namespace, recorded rather than logged.
+  ///
+  /// The builder stays pure so both consumers can call it freely — the import
+  /// detector builds an index too, and a builder that logged would narrate a
+  /// preview as if the vocabulary had just been rebuilt. `buildLookups` remains
+  /// the one place these are reported.
+  package struct ExactTriggerCollision: Sendable, Equatable {
+    package let key: String
+    package let existingCanonical: String
+    package let winningCanonical: String
+  }
+
+  /// A canonical self-entry that yielded to an alias already owning its key.
+  package struct ExactTriggerCanonicalSkip: Sendable, Equatable {
+    package let key: String
+    package let canonical: String
+    package let existingCanonical: String
   }
 
   /// Effective incumbent ownership, after every overwrite and gap-fill rule has
@@ -197,6 +221,9 @@ public struct WordCorrector: Sendable {
     package var single: [String: TriggerOwner] = [:]
     package var multi: [String: TriggerOwner] = [:]
     package var nospace: [String: TriggerOwner] = [:]
+    /// Diagnostics only, in construction order. Never consulted for precedence.
+    package var collisions: [ExactTriggerCollision] = []
+    package var canonicalSkips: [ExactTriggerCanonicalSkip] = []
 
     package func owner(of claim: ExactTriggerClaim) -> TriggerOwner? {
       switch claim.namespace {
@@ -205,6 +232,74 @@ public struct WordCorrector: Sendable {
       case .nospace: return nospace[claim.key]
       }
     }
+
+    /// The ordinary-namespace maps in `buildLookups`' shape, optionally limited
+    /// to non-pack owners for the fuzzy pools that must exclude pack terms.
+    func canonicalsByKey(
+      _ namespace: ExactTriggerNamespace, nonPackOnly: Bool = false
+    ) -> [String: String] {
+      let source: [String: TriggerOwner]
+      switch namespace {
+      case .single: source = single
+      case .multi: source = multi
+      case .nospace: source = nospace
+      }
+      return source.reduce(into: [String: String]()) { result, entry in
+        guard !nonPackOnly || !entry.value.isPack else { return }
+        result[entry.key] = entry.value.canonical
+      }
+    }
+  }
+
+  /// Whether an owner would actually INTERCEPT this surface, as opposed to
+  /// merely holding the key.
+  ///
+  /// Pass 0 declines to substitute when the spoken text already concatenates to
+  /// the owner's own canonical (`rawConcat == canonicalNospace`), so the text
+  /// falls through to the ordinary passes and a DIFFERENT word corrects it. A
+  /// consumer asking "who beats me here" has to know that, or it names a word
+  /// that never touches the text: existing `Annie` and existing `Anika`/alias
+  /// `annie`, spoken "Annie", is corrected by Anika even though `Annie` holds
+  /// the no-space key. Empirically confirmed against the real corrector, not
+  /// reasoned about (#1667).
+  ///
+  /// The ordinary namespaces have no such guard: holding the key is
+  /// intercepting it.
+  /// Every gate below is Pass 0's, in Pass 0's order. A first cut modelled only
+  /// the "already correct" short-circuit and let unreachable surfaces outrank
+  /// real ordinary claims — a four-token alias, a two-character one, a
+  /// punctuated one, or one containing a reserved trigger word can never be
+  /// consumed here, so a no-space holder is not blocking anything (grounded
+  /// review, #1667).
+  package static func ownerIntercepts(
+    claim: ExactTriggerClaim, rawSurface: String, owner: TriggerOwner
+  ) -> Bool {
+    guard claim.namespace == .nospace else { return true }
+
+    // Pass 0 only ever concatenates 1-3 adjacent tokens. Trim the ends, but do
+    // NOT drop interior empty tokens: a doubled internal space really is an
+    // extra token to the tokenizer, and "one   two" genuinely overflows the
+    // three-token window. Filtering all empties said it fit (grounded review r2).
+    let tokens =
+      rawSurface
+      .trimmingCharacters(in: .whitespaces)
+      .components(separatedBy: .whitespaces)
+    guard (1...3).contains(tokens.count) else { return false }
+
+    let slice = tokens[...]
+    guard !sliceContainsReservedTriggerWord(slice) else { return false }
+
+    let stripped = slice.map { stripPunctuationStatic($0) }
+    let ngram = stripped.map { $0.lowercased() }.joined()
+    // Below three characters Pass 0 skips the lookup entirely; and if the
+    // stripped form is not this claim's key, this is not the surface that
+    // would reach the owner.
+    guard ngram.count >= 3, ngram == claim.key else { return false }
+
+    // The "already correct" short-circuit, case-sensitive exactly as Pass 0
+    // compares it.
+    let rawConcat = stripped.joined()
+    return rawConcat != owner.canonical.replacingOccurrences(of: " ", with: "")
   }
 
   /// Keys an ALIAS claims. Ordinary surface first, then its no-space form when
@@ -247,19 +342,40 @@ public struct WordCorrector: Sendable {
 
     // Non-pack aliases: last writer wins in the ordinary namespaces.
     for word in nonPackWords {
-      let owner = TriggerOwner(wordID: word.id, canonical: word.canonical)
+      let owner = TriggerOwner(wordID: word.id, canonical: word.canonical, isPack: false)
+      // Empty keys are NOT filtered, here or below. The construction this
+      // replaces inserted them, and a refactor that quietly drops entries is
+      // not a refactor. They are inert at runtime (Pass 0 requires three
+      // characters, and the ordinary passes only look up non-empty tokens), so
+      // preserving them costs nothing and keeps the diagnostics identical
+      // (grounded review, #1667).
       for alias in word.aliases {
         let key = alias.lowercased()
-        guard !key.isEmpty else { continue }
-        if alias.contains(" ") { index.multi[key] = owner } else { index.single[key] = owner }
+        let namespace: ExactTriggerNamespace = alias.contains(" ") ? .multi : .single
+        if let existing = index.owner(of: ExactTriggerClaim(key: key, namespace: namespace)),
+          existing.canonical != word.canonical
+        {
+          index.collisions.append(
+            ExactTriggerCollision(
+              key: key, existingCanonical: existing.canonical, winningCanonical: word.canonical))
+        }
+        if namespace == .multi { index.multi[key] = owner } else { index.single[key] = owner }
       }
     }
 
     // Non-pack canonical self-entry: space-free only, and it YIELDS to an alias.
     for word in nonPackWords {
       let key = word.canonical.lowercased()
-      guard !key.isEmpty, !key.contains(" "), index.single[key] == nil else { continue }
-      index.single[key] = TriggerOwner(wordID: word.id, canonical: word.canonical)
+      guard !key.contains(" ") else { continue }
+      if let existing = index.single[key] {
+        if existing.canonical != word.canonical {
+          index.canonicalSkips.append(
+            ExactTriggerCanonicalSkip(
+              key: key, canonical: word.canonical, existingCanonical: existing.canonical))
+        }
+        continue
+      }
+      index.single[key] = TriggerOwner(wordID: word.id, canonical: word.canonical, isPack: false)
     }
 
     // No-space namespace, non-pack only. Canonical is unconditional and last
@@ -268,12 +384,12 @@ public struct WordCorrector: Sendable {
     // canonical can overwrite an earlier alias. Three rules, one map — the
     // reason a hand-rolled mirror kept getting this wrong.
     for word in nonPackWords {
-      let owner = TriggerOwner(wordID: word.id, canonical: word.canonical)
+      let owner = TriggerOwner(wordID: word.id, canonical: word.canonical, isPack: false)
       let nospace = word.canonical.replacingOccurrences(of: " ", with: "").lowercased()
-      if !nospace.isEmpty { index.nospace[nospace] = owner }
+      index.nospace[nospace] = owner
       for alias in word.aliases {
         let aliasNospace = alias.replacingOccurrences(of: " ", with: "").lowercased()
-        guard !aliasNospace.isEmpty, index.nospace[aliasNospace] == nil else { continue }
+        guard index.nospace[aliasNospace] == nil else { continue }
         index.nospace[aliasNospace] = owner
       }
     }
@@ -283,10 +399,10 @@ public struct WordCorrector: Sendable {
     // terms never enter the no-space namespace.
     let nonPackCanonicalKeys = Set(nonPackWords.map { $0.canonical.lowercased() })
     for word in packWords {
-      let owner = TriggerOwner(wordID: word.id, canonical: word.canonical)
+      let owner = TriggerOwner(wordID: word.id, canonical: word.canonical, isPack: true)
       for alias in word.aliases {
         let key = alias.lowercased()
-        guard !key.isEmpty, !nonPackCanonicalKeys.contains(key) else { continue }
+        guard !nonPackCanonicalKeys.contains(key) else { continue }
         if alias.contains(" ") {
           if index.multi[key] == nil { index.multi[key] = owner }
         } else {
@@ -315,9 +431,6 @@ public struct WordCorrector: Sendable {
     let packWords = words.filter { $0.source == .pack }
     let nonPackWords = words.filter { $0.source != .pack }
 
-    var singleAliasMap: [String: String] = [:]
-    var multiAliasMap: [String: String] = [:]
-    var collisionCount = 0
     var canonicalToID: [String: UUID] = [:]
     var canonicalToWord: [String: CustomWord] = [:]
     for word in nonPackWords {
@@ -325,53 +438,37 @@ public struct WordCorrector: Sendable {
       canonicalToWord[word.canonical.lowercased()] = word
     }
 
-    for word in nonPackWords {
-      for alias in word.aliases {
-        let key = alias.lowercased()
-        if alias.contains(" ") {
-          if let existing = multiAliasMap[key], existing != word.canonical {
-            collisionCount += 1
-            #if DEBUG
-              Self.logger.debug(
-                "Alias collision #\(collisionCount): '\(key)' claimed by '\(existing)' and '\(word.canonical)', using '\(word.canonical)'"
-              )
-            #endif
-          }
-          multiAliasMap[key] = word.canonical
-        } else {
-          if let existing = singleAliasMap[key], existing != word.canonical {
-            collisionCount += 1
-            #if DEBUG
-              Self.logger.debug(
-                "Alias collision #\(collisionCount): '\(key)' claimed by '\(existing)' and '\(word.canonical)', using '\(word.canonical)'"
-              )
-            #endif
-          }
-          singleAliasMap[key] = word.canonical
-        }
-      }
-    }
+    // The three exact maps are PROJECTED from the one authority rather than
+    // rebuilt here (#1667). Every precedence rule they encode — alias last-wins,
+    // canonical self-entry yielding to an alias, pack gap-fill only, and the
+    // three-rules-in-one-map no-space namespace — now lives in exactly one
+    // place, which the import collision detector reads too. It had drifted from
+    // this construction three separate times, each time as a fresh instance
+    // patch; the fix is that there is no longer a second construction to drift.
+    let triggerIndex = buildExactTriggerIndex(words: words)
 
-    for word in nonPackWords {
-      let key = word.canonical.lowercased()
-      if !key.contains(" ") {
-        if let existing = singleAliasMap[key] {
-          if existing != word.canonical {
-            #if DEBUG
-              Self.logger.debug(
-                "Canonical '\(word.canonical)' skipped: key '\(key)' already maps to '\(existing)'")
-            #endif
-          }
-        } else {
-          singleAliasMap[key] = word.canonical
-        }
+    #if DEBUG
+      // The builder is pure so the detector can call it without narrating; the
+      // reporting stays here, where a vocabulary rebuild actually happened.
+      for (offset, collision) in triggerIndex.collisions.enumerated() {
+        Self.logger.debug(
+          "Alias collision #\(offset + 1): '\(collision.key)' claimed by '\(collision.existingCanonical)' and '\(collision.winningCanonical)', using '\(collision.winningCanonical)'"
+        )
       }
-    }
+      for skip in triggerIndex.canonicalSkips {
+        Self.logger.debug(
+          "Canonical '\(skip.canonical)' skipped: key '\(skip.key)' already maps to '\(skip.existingCanonical)'"
+        )
+      }
+    #endif
 
-    // Snapshot the NON-PACK exact maps. The fuzzy/compound pools derive from
-    // these so pack terms can never become fuzzy candidates.
-    let nonPackSingleAliasMap = singleAliasMap
-    let nonPackMultiAliasMap = multiAliasMap
+    let singleAliasMap = triggerIndex.canonicalsByKey(.single)
+    let multiAliasMap = triggerIndex.canonicalsByKey(.multi)
+
+    // The NON-PACK exact maps. The fuzzy/compound pools derive from these so
+    // pack terms can never become fuzzy candidates.
+    let nonPackSingleAliasMap = triggerIndex.canonicalsByKey(.single, nonPackOnly: true)
+    let nonPackMultiAliasMap = triggerIndex.canonicalsByKey(.multi, nonPackOnly: true)
 
     // Every non-pack canonical key (INCLUDING multi-word canonicals, which get
     // no exact-map self-entry). A pack term must never claim one of these keys,
@@ -379,20 +476,11 @@ public struct WordCorrector: Sendable {
     // though it isn't present in the alias maps. (Codex diff-review edge.)
     let nonPackCanonicalKeys = Set(nonPackWords.map { $0.canonical.lowercased() })
 
-    // Pack exact entries: fill ONLY keys not already claimed by a non-pack term
-    // (non-pack wins, for all clash shapes incl. multi-word canonicals). Pack
-    // canonicals also get an attribution id so applied pack replacements report
-    // `hadPackTerm`.
+    // Pack exact entries are already in the projected maps: the authority fills
+    // ONLY keys no non-pack term claimed, for every clash shape including
+    // multi-word canonicals (#1667 moved that rule there). What remains here is
+    // pack ATTRIBUTION, which is not trigger ownership and stays local.
     for word in packWords {
-      for alias in word.aliases {
-        let key = alias.lowercased()
-        if nonPackCanonicalKeys.contains(key) { continue }  // user canonical wins
-        if alias.contains(" ") {
-          if multiAliasMap[key] == nil { multiAliasMap[key] = word.canonical }
-        } else {
-          if singleAliasMap[key] == nil { singleAliasMap[key] = word.canonical }
-        }
-      }
       // #992: pack canonical self-entries are NOT added to singleAliasMap. They
       // only ever normalized casing — unreliable for packs (lowercase
       // canonicals) and the source of the live casing harm (correct
@@ -421,17 +509,11 @@ public struct WordCorrector: Sendable {
         Lookups.AliasCanonical(alias: alias, canonical: canonical))
     }
 
-    var nospaceCanonicalMap: [String: String] = [:]
-    for word in nonPackWords {
-      let nospace = word.canonical.replacingOccurrences(of: " ", with: "").lowercased()
-      nospaceCanonicalMap[nospace] = word.canonical
-      for alias in word.aliases {
-        let aliasNospace = alias.replacingOccurrences(of: " ", with: "").lowercased()
-        if nospaceCanonicalMap[aliasNospace] == nil {
-          nospaceCanonicalMap[aliasNospace] = word.canonical
-        }
-      }
-    }
+    // Projected too (#1667). This map is the one the detector missed entirely:
+    // an imported alias equal to an existing multi-word canonical's space-free
+    // form was reported collision-free, persisted, and then never fired,
+    // because Pass 0 resolved the n-gram here first.
+    let nospaceCanonicalMap = triggerIndex.canonicalsByKey(.nospace)
 
     // #992 pack fuzzy tier (LOWER authority). Single-word pack terms whose
     // scored surface length ≥ packFuzzyMinLength, built from the SAME lowercased

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
@@ -409,18 +409,28 @@ struct CustomWordsImportCommitTests {
       "the incoming canonical owns the compound key, not the older alias")
   }
 
-  @Test("touched canonicals resolve the compound key in APPLY order, not storage order")
-  func touchedCanonicalCompoundOwnershipFollowsApplyOrder() throws {
-    // Grounded review r6. The compound namespace is unconditional, so among
-    // two touched words claiming the same squashed key, whichever is resolved
-    // LAST wins. That has to be apply order — the plan the user approved — not
-    // incidental storage order, or this and the compare screen can pick
-    // different winners for the same import.
+  @Test("touched canonicals resolve the compound key in FINAL storage order, not apply order")
+  func touchedCanonicalCompoundOwnershipMatchesRuntimeStorageOrder() throws {
+    // Corrected in round 7, reversing round 6's own conclusion. r6 reasoned
+    // that the plan's APPLY order should decide a shared compound key, since
+    // that is the order the user approved. That reasoning was never checked
+    // against the real corrector.
     //
-    // Seeded First, then Second, so storage order is First/Second. The plan
-    // replaces them in the OPPOSITE order: Second becomes "Claude Code" first,
-    // then First becomes "claudecode" — so apply order gives "claudecode" the
-    // final, unconditional claim on the compound key.
+    // It is wrong. `WordCorrector.buildExactTriggerIndex` — the actual runtime
+    // authority — resolves the compound namespace by iterating whatever array
+    // it is HANDED, in that array's order, last-write-wins. Replacements update
+    // an existing word's STORAGE POSITION in place; they do not move it. So
+    // the array the corrector will build its lookups from next launch is in
+    // STORAGE order, never apply order, and enforcement has to predict that
+    // same array, not the plan's approval sequence.
+    //
+    // Verified against `buildExactTriggerIndex` and `correct()` directly before
+    // trusting this expectation, not derived by re-reasoning about passes.
+    //
+    // Seeded First, then Second — storage order First/Second. The plan
+    // replaces them in the OPPOSITE order (Second's replacement given first),
+    // so this also proves apply order is not silently equivalent to storage
+    // order for a two-word plan.
     let (manager, _) = makeManager()
     var live = try seed(
       manager,
@@ -438,16 +448,14 @@ struct CustomWordsImportCommitTests {
         ]),
       to: &live)
 
-    // Apply order gives "claudecode" (First) the final compound claim. It does
-    // NOT already spell "Claude Code", so it intercepts and blocks the alias.
-    // Storage order would instead leave "Claude Code" (Second) owning the key,
-    // which declines to intercept its own already-correct spelling — and the
-    // alias would wrongly be kept.
+    // Second occupies the LATER storage slot, so it owns the compound key —
+    // regardless of being resolved FIRST in the plan. It already spells
+    // "Claude Code" exactly, so it declines to intercept and the alias is kept.
     let added = try #require(live.first { $0.canonical == "Zed" })
-    #expect(added.aliases.isEmpty, "storage order would have kept this alias")
-    #expect(receipt.droppedAliasCollisions.map(\.alias) == ["Claude Code"])
-    let winner = try #require(live.first { $0.canonical == "claudecode" })
-    #expect(receipt.droppedAliasCollisions.map(\.heldBy) == [winner.id])
+    #expect(
+      added.aliases == ["Claude Code"],
+      "apply order would have wrongly dropped this alias")
+    #expect(receipt.droppedAliasCollisions.isEmpty)
   }
 
   @Test("an untouched incumbent alias always beats an imported one")

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
@@ -355,6 +355,60 @@ struct CustomWordsImportCommitTests {
     #expect(receipt.droppedAliasCollisions.map(\.alias) == ["Annie"])
   }
 
+  @Test("an alias matching a multi-word canonical's space-free form is dropped with a receipt")
+  func aliasCollidingOnTheNoSpaceSurfaceIsDroppedOnCommit() throws {
+    // #1667's acceptance criterion, and the half the compare screen cannot
+    // deliver on its own. `Claude Code` claims `claudecode` on the compound
+    // surface, so this alias could never fire. Enforcement here used to key on
+    // `importPersistenceKey`, which has no compound surface at all, so the
+    // alias was KEPT — the review screen disclosed a collision and the commit
+    // saved the alias anyway. Both sides now read one authority.
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Claude Code")])
+
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        additions: [candidate("Zed", aliases: .supplied(["claudecode", "zeddy"]))]),
+      to: &live)
+
+    let added = try #require(live.first { $0.canonical == "Zed" })
+    #expect(added.aliases == ["zeddy"], "the inert alias must not be persisted")
+    #expect(receipt.droppedAliasCollisions.map(\.alias) == ["claudecode"])
+    let owner = try #require(live.first { $0.canonical == "Claude Code" })
+    #expect(receipt.droppedAliasCollisions.map(\.heldBy) == [owner.id])
+  }
+
+  @Test("a newly imported multi-word canonical takes the compound key from an older alias")
+  func importedCanonicalOverwritesAnIncumbentCompoundAlias() throws {
+    // The compound namespace is the one place a canonical is written
+    // UNCONDITIONALLY, so it takes the key from an existing alias. Registering
+    // touched canonicals as gap-fill instead named the older word as owner,
+    // which is not who holds the trigger once the import lands (grounded
+    // review r4).
+    //
+    // Anika's alias claims "claudecode". Importing the word `Claude Code`
+    // overwrites that slot, so a second imported alias of the same spelling
+    // must be refused in the NAME OF THE NEW WORD, not Anika's.
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Anika", aliases: ["claudecode"])])
+
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        additions: [
+          candidate("Claude Code"),
+          candidate("Zed", aliases: .supplied(["claudecode"])),
+        ]),
+      to: &live)
+
+    let newOwner = try #require(live.first { $0.canonical == "Claude Code" })
+    #expect(receipt.droppedAliasCollisions.map(\.alias) == ["claudecode"])
+    #expect(
+      receipt.droppedAliasCollisions.map(\.heldBy) == [newOwner.id],
+      "the incoming canonical owns the compound key, not the older alias")
+  }
+
   @Test("an untouched incumbent alias always beats an imported one")
   func incumbentLibraryAliasAlwaysWinsOverImportedAlias() throws {
     let (manager, _) = makeManager()
@@ -500,15 +554,22 @@ struct CustomWordsImportCommitTests {
         CustomWord(canonical: "Earlier", aliases: ["annie"]),
         CustomWord(canonical: "Later", aliases: ["annie"]),
       ])
-    let later = try #require(live.first { $0.canonical == "Later" })
+    let earlier = try #require(live.first { $0.canonical == "Earlier" })
 
     let receipt = try manager.commitImport(
       plan(baseline: live, additions: [candidate("Zed", aliases: .supplied(["Annie"]))]),
       to: &live)
 
-    // WordCorrector assigns aliases unconditionally, so the LATER word holds
-    // the trigger at runtime — naming the earlier one would misinform.
-    #expect(receipt.droppedAliasCollisions.map(\.heldBy) == [later.id])
+    // Corrected in #1667. This expected the LATER word, reasoning that aliases
+    // are assigned unconditionally so the last writer wins. That reads one
+    // surface and stops. The compound pass runs FIRST and takes single tokens,
+    // and aliases are FIRST-wins there — so the earlier word intercepts before
+    // the alias map is consulted.
+    //
+    // Verified against the real corrector, which turns "Annie" into "Earlier"
+    // for exactly this pair. Naming Later told the user a word that never
+    // touches their text holds the alias.
+    #expect(receipt.droppedAliasCollisions.map(\.heldBy) == [earlier.id])
   }
 
   @Test("commit failures carry an honest user-facing message")

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
@@ -409,6 +409,47 @@ struct CustomWordsImportCommitTests {
       "the incoming canonical owns the compound key, not the older alias")
   }
 
+  @Test("touched canonicals resolve the compound key in APPLY order, not storage order")
+  func touchedCanonicalCompoundOwnershipFollowsApplyOrder() throws {
+    // Grounded review r6. The compound namespace is unconditional, so among
+    // two touched words claiming the same squashed key, whichever is resolved
+    // LAST wins. That has to be apply order — the plan the user approved — not
+    // incidental storage order, or this and the compare screen can pick
+    // different winners for the same import.
+    //
+    // Seeded First, then Second, so storage order is First/Second. The plan
+    // replaces them in the OPPOSITE order: Second becomes "Claude Code" first,
+    // then First becomes "claudecode" — so apply order gives "claudecode" the
+    // final, unconditional claim on the compound key.
+    let (manager, _) = makeManager()
+    var live = try seed(
+      manager,
+      [CustomWord(canonical: "First"), CustomWord(canonical: "Second")])
+    let first = try #require(live.first { $0.canonical == "First" })
+    let second = try #require(live.first { $0.canonical == "Second" })
+
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        additions: [candidate("Zed", aliases: .supplied(["Claude Code"]))],
+        replacements: [
+          CustomWordsImportReplacement(existingID: second.id, candidate: candidate("Claude Code")),
+          CustomWordsImportReplacement(existingID: first.id, candidate: candidate("claudecode")),
+        ]),
+      to: &live)
+
+    // Apply order gives "claudecode" (First) the final compound claim. It does
+    // NOT already spell "Claude Code", so it intercepts and blocks the alias.
+    // Storage order would instead leave "Claude Code" (Second) owning the key,
+    // which declines to intercept its own already-correct spelling — and the
+    // alias would wrongly be kept.
+    let added = try #require(live.first { $0.canonical == "Zed" })
+    #expect(added.aliases.isEmpty, "storage order would have kept this alias")
+    #expect(receipt.droppedAliasCollisions.map(\.alias) == ["Claude Code"])
+    let winner = try #require(live.first { $0.canonical == "claudecode" })
+    #expect(receipt.droppedAliasCollisions.map(\.heldBy) == [winner.id])
+  }
+
   @Test("an untouched incumbent alias always beats an imported one")
   func incumbentLibraryAliasAlwaysWinsOverImportedAlias() throws {
     let (manager, _) = makeManager()

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
@@ -515,6 +515,35 @@ struct CustomWordsImportCompareEngineTests {
       ])
   }
 
+  @Test("a forced-Skip candidate cannot steal a trigger key from the real incumbent")
+  func nonNewCandidateNeverParticipatesInBatchOwnership() async throws {
+    // Grounded review r6. An exact-match row is never itself persisted — it is
+    // a decision about the EXISTING word, never a fresh addition — so its
+    // canonical must not out-rank the real incumbent for ownership purposes.
+    //
+    // The exact-match candidate spells the same compound key with different
+    // CASE ("claude code" vs "Claude Code"). If it were allowed to register,
+    // its unconditional no-space claim would overwrite the real incumbent with
+    // an owner whose canonical is all lowercase — and "ClaudeCode" would then
+    // no longer already spell that owner's name, so it would wrongly appear to
+    // collide against a row that is never persisted.
+    //
+    // Correctly excluded, the REAL incumbent keeps the key. The claimant's
+    // alias already spells that incumbent's own name exactly, so the runtime
+    // rule this whole issue is about — a holder that would not actually
+    // intercept is not a collision — applies, and nothing is reported.
+    let existing = CustomWord(canonical: "Claude Code")
+    let exactMatch = candidate("claude code")
+    let claimant = candidate("Zed", aliases: .supplied(["ClaudeCode"]))
+
+    let results = try await compare([exactMatch, claimant], against: [existing])
+
+    #expect(results[0].classification == .exact(existing: existing))
+    #expect(
+      results[1].collidingAliases.isEmpty,
+      "an exact-match row that is never persisted must not be able to steal ownership")
+  }
+
   @Test("a dropped alias's surviving claims never become a phantom owner")
   func blockedAliasRegistersNoneOfItsClaimsForLaterCandidates() async throws {
     // Atomicity (grounded review r4). The first candidate's alias is blocked on

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
@@ -426,18 +426,24 @@ struct CustomWordsImportCompareEngineTests {
 
   @Test("when two existing words share an alias, the collision names the runtime winner")
   func sharedIncumbentAliasReportsTheRuntimeWinningOwner() async throws {
-    // `WordCorrector.buildLookups` assigns the alias map unconditionally
-    // (WordCorrector.swift:180-214), so the LATER word claims the trigger at
-    // runtime — its own collision log says "using <later canonical>". The
-    // reported owner has to match that, or the Review screen names a word
-    // that is not really holding the alias.
+    // This test used to expect the LATER word, reasoning that the alias map is
+    // assigned unconditionally so the last writer wins. That reasoning reads
+    // one surface and stops. Pass 0 runs FIRST and accepts single tokens
+    // (`for n in (1...min(3, ...))`), and in the no-space namespace aliases are
+    // FIRST-wins — so the earlier word holds "annie" there and intercepts
+    // before the alias map is ever consulted.
+    //
+    // Corrected against the real corrector, which turns "Annie" into "Anika"
+    // here (`aRuntimeOracleForEveryOwnerThisSuiteNames`). Naming Annabelle told
+    // the user a word that never touches their text already uses the alias —
+    // exactly the class of blindness #1667 exists to end.
     let earlier = CustomWord(canonical: "Anika", aliases: ["annie"])
     let later = CustomWord(canonical: "Annabelle", aliases: ["annie"])
     let results = try await compare(
       [candidate("Zed", aliases: .supplied(["Annie"]))], against: [earlier, later])
     #expect(
       results[0].collidingAliases == [
-        CustomWordsImportAliasCollision(alias: "Annie", heldBy: later.id)
+        CustomWordsImportAliasCollision(alias: "Annie", heldBy: earlier.id)
       ])
   }
 
@@ -459,15 +465,107 @@ struct CustomWordsImportCompareEngineTests {
       ])
   }
 
-  @Test("aliases that differ only by internal whitespace do not collide")
-  func aliasesDifferingOnlyByInternalWhitespaceAreNotFlagged() async throws {
-    // Collisions are a claim about the stored/correction-map slot, which uses
-    // the manager's weaker key — these two never actually collide at runtime,
-    // so flagging them would be a false positive.
+  @Test("an imported alias equal to a multi-word canonical's space-free form is disclosed")
+  func aliasMatchingAnExistingMultiWordCanonicalsNoSpaceFormIsFlagged() async throws {
+    // The defect #1667 was filed for. `Claude Code` claims "claudecode" in the
+    // no-space namespace, and Pass 0 resolves that n-gram before any alias pass
+    // runs — so this alias was reported collision-free, persisted, and then
+    // never fired. It has no entry in either alias map, which is precisely why
+    // a detector that mirrored only those maps could not see it.
+    let existing = CustomWord(canonical: "Claude Code")
+    let results = try await compare(
+      [candidate("Zed", aliases: .supplied(["claudecode"]))], against: [existing])
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "claudecode", heldBy: existing.id)
+      ])
+  }
+
+  @Test("a dropped alias's surviving claims never become a phantom owner")
+  func blockedAliasRegistersNoneOfItsClaimsForLaterCandidates() async throws {
+    // Atomicity (grounded review r4). The first candidate's alias is blocked on
+    // its ordinary surface, so the whole alias will be dropped at commit — the
+    // stored alias, not one trigger claim, is the unit that survives. If its
+    // UNBLOCKED no-space claim were registered anyway, it would become an owner
+    // that never exists in the library and would then falsely block the second
+    // candidate, whose alias is in fact free.
+    //
+    // The fixture matters, and two earlier ones were useless. Both gave the two
+    // candidates the SAME blocked claim, so both stayed blocked by the incumbent
+    // whether or not the first leaked a registration — the test could not fail
+    // for the reason it named (grounded review r1 and r2, #1667).
+    //
+    // This one can. A PACK incumbent enters the ordinary exact map but never the
+    // no-space map, so the first alias is blocked on its ordinary claim while
+    // its no-space claim is genuinely free. The second candidate's alias differs
+    // only by an internal space, so its ordinary claim is a different key and is
+    // free — but it strips to the SAME no-space key. It therefore stays clean
+    // only if the first alias registered nothing.
+    let incumbent = CustomWord(
+      canonical: "Pack Holder", aliases: ["New York"], source: .pack)
+    let first = candidate("Zed", aliases: .supplied(["New York"]))
+    let second = candidate("Quinn", aliases: .supplied(["New  York"]))
+    let results = try await compare([first, second], against: [incumbent])
+
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "New York", heldBy: incumbent.id)
+      ])
+    // Fails the moment registration stops being all-or-none.
+    #expect(results[1].collidingAliases.isEmpty)
+  }
+
+  @Test("aliases that differ only by internal whitespace still collide, on the no-space surface")
+  func aliasesDifferingOnlyByInternalWhitespaceCollideOnTheCompoundSurface() async throws {
+    // Inverted deliberately (#1667). This test used to assert no collision, on
+    // the reasoning that the two aliases occupy different slots in the alias
+    // map and so "never actually collide at runtime". They do: both strip to
+    // "newyork" in the no-space namespace, where the incumbent got there first.
+    //
+    // The real corrector turns "new york" into "Anika" with both words present
+    // (`aRuntimeOracleForEveryOwnerThisSuiteNames`), so the imported alias is
+    // inert on every surface — it can never win the compound form, and its own
+    // double-spaced form is unreachable from speech, which normalises to one
+    // space. Silently persisting a dead alias is the defect; disclosing it is
+    // the fix.
     let incumbent = CustomWord(canonical: "Anika", aliases: ["New York"])
     let results = try await compare(
       [candidate("Zed", aliases: .supplied(["New  York"]))], against: [incumbent])
-    #expect(results[0].collidingAliases.isEmpty)
+    #expect(
+      results[0].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "New  York", heldBy: incumbent.id)
+      ])
+  }
+
+  /// The instrument that settled the two corrections above, kept rather than
+  /// deleted (#1667).
+  ///
+  /// Every earlier attempt to state this file's precedence reasoned from the
+  /// lookup maps and got it wrong, three times. These assertions ask the actual
+  /// corrector what happens to actual text, so a future change to pass order or
+  /// no-space precedence fails HERE, next to the collision tests that depend on
+  /// it, rather than silently making their expectations lies again.
+  @Test("the corrector itself confirms which word each named owner really is")
+  func aRuntimeOracleForEveryOwnerThisSuiteNames() {
+    func corrected(_ text: String, _ words: [CustomWord]) -> String {
+      WordCorrector().correct(text, using: WordCorrector.buildLookups(words: words)).corrected
+    }
+
+    // Two existing words share an alias: the no-space FIRST-wins owner
+    // intercepts in Pass 0, ahead of the alias map's last writer.
+    let anika = CustomWord(canonical: "Anika", aliases: ["annie"])
+    let annabelle = CustomWord(canonical: "Annabelle", aliases: ["annie"])
+    #expect(corrected("Annie", [anika, annabelle]) == "Anika")
+
+    // A no-space owner whose canonical the text already spells does NOT
+    // intercept: Pass 0 sees "already correct" and the alias map decides.
+    let annie = CustomWord(canonical: "Annie")
+    #expect(corrected("Annie", [annie, anika]) == "Anika")
+
+    // The compound surface is live for whitespace-only variants.
+    let newYork = CustomWord(canonical: "Anika", aliases: ["New York"])
+    let doubled = CustomWord(canonical: "Zed", aliases: ["New  York"])
+    #expect(corrected("new york", [newYork, doubled]) == "Anika")
   }
 
   @Test("non-colliding aliases are not flagged")

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCompareEngineTests.swift
@@ -465,6 +465,40 @@ struct CustomWordsImportCompareEngineTests {
       ])
   }
 
+  @Test("a kept alias gap-fills the compound slot rather than stealing it")
+  func keptAliasDoesNotCreateAFalseLaterCollision() async throws {
+    // The incumbent `Claude Code` holds "claudecode" but declines to intercept
+    // a surface that already spells it, so the first alias is kept. If keeping
+    // it OVERWROTE that slot, the second candidate would be told a word owns
+    // the trigger that does not — a warning about nothing (grounded review r5).
+    let incumbent = CustomWord(canonical: "Claude Code")
+    let first = candidate("Zed", aliases: .supplied(["ClaudeCode"]))
+    let second = candidate("Quinn", aliases: .supplied(["Claude Code"]))
+
+    let results = try await compare([first, second], against: [incumbent])
+
+    #expect(results[0].collidingAliases.isEmpty)
+    #expect(results[1].collidingAliases.isEmpty)
+  }
+
+  @Test("the later incoming canonical owns the compound slot")
+  func laterIncomingCanonicalControlsCompoundCollisionDisclosure() async throws {
+    // Compound canonicals are written unconditionally, so among incoming words
+    // the LATER one holds the squashed key. Registering incoming canonicals
+    // first-wins named the earlier one, which the commit path would then
+    // contradict.
+    let earlier = candidate("Claude Code")
+    let later = candidate("claudecode")
+    let claimant = candidate("Zed", aliases: .supplied(["Claude Code"]))
+
+    let results = try await compare([earlier, later, claimant], against: [])
+
+    #expect(
+      results[2].collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "Claude Code", heldBy: later.id)
+      ])
+  }
+
   @Test("an imported alias equal to a multi-word canonical's space-free form is disclosed")
   func aliasMatchingAnExistingMultiWordCanonicalsNoSpaceFormIsFlagged() async throws {
     // The defect #1667 was filed for. `Claude Code` claims "claudecode" in the

--- a/Tests/EnviousWisprTests/PostProcessing/ExactTriggerIndexTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ExactTriggerIndexTests.swift
@@ -1,0 +1,121 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1667 — the exact-trigger authority.
+///
+/// The headline test is `indexAgreesWithBuildLookupsAcrossEverySurface`: it
+/// proves the authority resolves ownership exactly as the shipped
+/// `buildLookups` does, for a vocabulary built to exercise every rule. That is
+/// what makes it safe to project the correction maps from the index instead of
+/// re-deriving them, which is the whole point of this change.
+@Suite("ExactTriggerIndex")
+struct ExactTriggerIndexTests {
+
+  /// One vocabulary hitting every rule the two constructions must agree on:
+  /// multi-word canonicals, multi-token aliases, no-space overlaps, an alias
+  /// that shadows another word's canonical, and pack terms that must lose.
+  private func vocabulary() -> [CustomWord] {
+    [
+      CustomWord(canonical: "Claude Code", aliases: ["clawed code", "cloud code"]),
+      CustomWord(canonical: "Kubernetes", aliases: ["kubernetties", "koobernetes"]),
+      CustomWord(canonical: "Qualtrics", aliases: ["kwaltrics"]),
+      CustomWord(canonical: "EnviousWispr", aliases: ["envious whisper"]),
+      CustomWord(canonical: "Postgres", aliases: ["post gres"]),
+      CustomWord(canonical: "React Native", aliases: ["reactnative"]),
+      CustomWord(canonical: "Bazel", aliases: ["bazel"], source: .pack),
+      CustomWord(canonical: "Kubernetes", aliases: ["kubernetes"], source: .pack),
+    ]
+  }
+
+  @Test("the index resolves the same owners buildLookups resolves, on every surface")
+  func indexAgreesWithBuildLookupsAcrossEverySurface() {
+    let words = vocabulary()
+    let lookups = WordCorrector.buildLookups(words: words)
+    let index = WordCorrector.buildExactTriggerIndex(words: words)
+
+    // Same key sets, so neither side claims a surface the other missed.
+    #expect(Set(index.single.keys) == Set(lookups.singleAliasMap.keys))
+    #expect(Set(index.multi.keys) == Set(lookups.multiAliasMap.keys))
+    #expect(Set(index.nospace.keys) == Set(lookups.nospaceCanonicalMap.keys))
+
+    // Same WINNER per key. Key-set equality alone would pass while precedence
+    // disagreed, which is the defect class this whole change exists to end.
+    for (key, canonical) in lookups.singleAliasMap {
+      #expect(index.single[key]?.canonical == canonical, "single '\(key)'")
+    }
+    for (key, canonical) in lookups.multiAliasMap {
+      #expect(index.multi[key]?.canonical == canonical, "multi '\(key)'")
+    }
+    for (key, canonical) in lookups.nospaceCanonicalMap {
+      #expect(index.nospace[key]?.canonical == canonical, "nospace '\(key)'")
+    }
+  }
+
+  @Test("a multi-word canonical claims its space-stripped form")
+  func multiWordCanonicalClaimsNospaceKey() {
+    // The defect #1667 was filed for: `Claude Code` already owns `claudecode`,
+    // so an imported alias of that spelling could never have triggered.
+    let index = WordCorrector.buildExactTriggerIndex(words: vocabulary())
+    #expect(index.nospace["claudecode"]?.canonical == "Claude Code")
+    #expect(index.single["claudecode"] == nil, "it is a no-space claim, not an ordinary one")
+  }
+
+  @Test("no-space aliases fill gaps but a canonical overwrites them")
+  func nospacePrecedenceIsThreeRulesNotOne() {
+    let first = CustomWord(canonical: "Alpha", aliases: ["react native"])
+    let second = CustomWord(canonical: "Beta", aliases: ["react native"])
+    // alias vs alias in the no-space namespace: FIRST wins (gap-fill only).
+    let aliasOnly = WordCorrector.buildExactTriggerIndex(words: [first, second])
+    #expect(aliasOnly.nospace["reactnative"]?.canonical == "Alpha")
+
+    // canonical vs alias: the canonical overwrites, whichever order.
+    let withCanonical = WordCorrector.buildExactTriggerIndex(
+      words: [first, CustomWord(canonical: "React Native")])
+    #expect(withCanonical.nospace["reactnative"]?.canonical == "React Native")
+  }
+
+  @Test("a canonical self-entry yields to an alias that already owns the key")
+  func canonicalSelfEntryYieldsToAlias() {
+    let owner = CustomWord(canonical: "Alpha", aliases: ["beta"])
+    let shadowed = CustomWord(canonical: "Beta")
+    let index = WordCorrector.buildExactTriggerIndex(words: [owner, shadowed])
+    #expect(index.single["beta"]?.canonical == "Alpha")
+  }
+
+  @Test("pack terms never claim a key a non-pack term owns, and never enter no-space")
+  func packTermsLoseAndStayOutOfNospace() {
+    let index = WordCorrector.buildExactTriggerIndex(words: vocabulary())
+    // The pack Kubernetes alias must not displace the user word.
+    #expect(index.single["kubernetes"]?.canonical == "Kubernetes")
+    // No pack canonical reaches the no-space namespace at all.
+    #expect(index.nospace["bazel"] == nil)
+  }
+
+  @Test("claim construction covers ordinary and no-space surfaces without duplicates")
+  func claimConstructionIsDeduplicatedAndNamespaced() {
+    let multi = WordCorrector.exactClaims(forAlias: "clawed code")
+    #expect(multi.map(\.namespace) == [.multi, .nospace])
+    #expect(multi.map(\.key) == ["clawed code", "clawedcode"])
+
+    let single = WordCorrector.exactClaims(forAlias: "kubernetties")
+    #expect(single.map(\.namespace) == [.single, .nospace])
+
+    // A multi-word canonical gets no ordinary self-entry, only the no-space one.
+    let canonical = WordCorrector.exactClaims(forCanonical: "Claude Code")
+    #expect(canonical.map(\.namespace) == [.nospace])
+    #expect(canonical.map(\.key) == ["claudecode"])
+
+    #expect(WordCorrector.exactClaims(forAlias: "").isEmpty)
+  }
+
+  @Test("no-space outranks the ordinary passes when one alias collides on both")
+  func passPriorityPrefersNospace() {
+    // Pass 0 runs before the ordinary exact passes, so a receipt naming the
+    // ordinary owner would name a word the corrector never actually reaches.
+    #expect(WordCorrector.ExactTriggerNamespace.nospace.passPriority < WordCorrector.ExactTriggerNamespace.multi.passPriority)
+    #expect(WordCorrector.ExactTriggerNamespace.multi.passPriority < WordCorrector.ExactTriggerNamespace.single.passPriority)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/ExactTriggerIndexTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ExactTriggerIndexTests.swift
@@ -6,11 +6,13 @@ import Testing
 
 /// #1667 — the exact-trigger authority.
 ///
-/// The headline test is `indexAgreesWithBuildLookupsAcrossEverySurface`: it
-/// proves the authority resolves ownership exactly as the shipped
-/// `buildLookups` does, for a vocabulary built to exercise every rule. That is
-/// what makes it safe to project the correction maps from the index instead of
-/// re-deriving them, which is the whole point of this change.
+/// The headline pair is `indexMatchesAnIndependentlyEnumeratedOracle` and
+/// `buildLookupsProjectsTheAuthorityFaithfully`. Both check against maps
+/// written out by hand, NOT against each other: `buildLookups` now projects
+/// from the index, so comparing the two would compare the index to itself and
+/// pass regardless. The literal oracle is what makes it safe to project the
+/// correction maps instead of re-deriving them, which is the point of this
+/// change.
 @Suite("ExactTriggerIndex")
 struct ExactTriggerIndexTests {
 
@@ -30,28 +32,82 @@ struct ExactTriggerIndexTests {
     ]
   }
 
-  @Test("the index resolves the same owners buildLookups resolves, on every surface")
-  func indexAgreesWithBuildLookupsAcrossEverySurface() {
-    let words = vocabulary()
-    let lookups = WordCorrector.buildLookups(words: words)
-    let index = WordCorrector.buildExactTriggerIndex(words: words)
+  /// Hand-enumerated expected ownership for `vocabulary()`, written out rather
+  /// than derived.
+  ///
+  /// This started as a comparison between the index and `buildLookups`, which
+  /// was a real proof while the two were independently constructed. It stopped
+  /// being one the moment `buildLookups` began PROJECTING from the index: it
+  /// then compared the index to itself and would have passed no matter what
+  /// either did. Grounded review caught it, and it had already let an
+  /// empty-key regression through unnoticed.
+  ///
+  /// So the oracle is literal. It fails if the authority drifts, if the
+  /// projection drifts, or if they drift together — which the previous version
+  /// could not detect.
+  private let expectedSingle = [
+    "kubernetties": "Kubernetes", "koobernetes": "Kubernetes",
+    "kwaltrics": "Qualtrics", "reactnative": "React Native",
+    // Canonical self-entries, space-free canonicals only.
+    "kubernetes": "Kubernetes", "qualtrics": "Qualtrics",
+    "enviouswispr": "EnviousWispr", "postgres": "Postgres",
+    // Pack gap-fill. `kubernetes` is NOT here from the pack: a non-pack
+    // canonical already owns that key, so the pack term is refused.
+    "bazel": "Bazel",
+  ]
 
-    // Same key sets, so neither side claims a surface the other missed.
-    #expect(Set(index.single.keys) == Set(lookups.singleAliasMap.keys))
-    #expect(Set(index.multi.keys) == Set(lookups.multiAliasMap.keys))
-    #expect(Set(index.nospace.keys) == Set(lookups.nospaceCanonicalMap.keys))
+  private let expectedMulti = [
+    "clawed code": "Claude Code", "cloud code": "Claude Code",
+    "envious whisper": "EnviousWispr", "post gres": "Postgres",
+  ]
 
-    // Same WINNER per key. Key-set equality alone would pass while precedence
-    // disagreed, which is the defect class this whole change exists to end.
-    for (key, canonical) in lookups.singleAliasMap {
-      #expect(index.single[key]?.canonical == canonical, "single '\(key)'")
-    }
-    for (key, canonical) in lookups.multiAliasMap {
-      #expect(index.multi[key]?.canonical == canonical, "multi '\(key)'")
-    }
-    for (key, canonical) in lookups.nospaceCanonicalMap {
-      #expect(index.nospace[key]?.canonical == canonical, "nospace '\(key)'")
-    }
+  private let expectedNospace = [
+    "claudecode": "Claude Code", "clawedcode": "Claude Code",
+    "cloudcode": "Claude Code",
+    "kubernetes": "Kubernetes", "kubernetties": "Kubernetes",
+    "koobernetes": "Kubernetes",
+    "qualtrics": "Qualtrics", "kwaltrics": "Qualtrics",
+    "enviouswispr": "EnviousWispr", "enviouswhisper": "EnviousWispr",
+    // "post gres" strips to the same key its own canonical already took.
+    "postgres": "Postgres",
+    "reactnative": "React Native",
+      // No pack term appears at all: packs never enter this namespace.
+  ]
+
+  @Test("the authority resolves the hand-enumerated owner for every surface")
+  func indexMatchesAnIndependentlyEnumeratedOracle() {
+    let index = WordCorrector.buildExactTriggerIndex(words: vocabulary())
+
+    #expect(index.single.mapValues(\.canonical) == expectedSingle)
+    #expect(index.multi.mapValues(\.canonical) == expectedMulti)
+    #expect(index.nospace.mapValues(\.canonical) == expectedNospace)
+  }
+
+  @Test("the projected correction maps are the authority's resolution, unchanged")
+  func buildLookupsProjectsTheAuthorityFaithfully() {
+    // Against the same literal oracle, not against the index — otherwise this
+    // is the tautology described above.
+    let lookups = WordCorrector.buildLookups(words: vocabulary())
+
+    #expect(lookups.singleAliasMap == expectedSingle)
+    #expect(lookups.multiAliasMap == expectedMulti)
+    #expect(lookups.nospaceCanonicalMap == expectedNospace)
+  }
+
+  @Test("empty keys are preserved exactly as the pre-refactor construction left them")
+  func projectionPreservesLegacyEmptyKeyBehaviour() {
+    // Inert at runtime, but a refactor that silently drops map entries is not a
+    // refactor. Filtering them also changed DEBUG collision numbering
+    // (grounded review, #1667).
+    let emptyAlias = WordCorrector.buildLookups(words: [
+      CustomWord(canonical: "Alpha", aliases: [""])
+    ])
+    #expect(emptyAlias.singleAliasMap[""] == "Alpha")
+    #expect(emptyAlias.nospaceCanonicalMap[""] == "Alpha")
+
+    let emptyCanonical = WordCorrector.buildLookups(words: [CustomWord(canonical: "")])
+    #expect(emptyCanonical.singleAliasMap[""] == "")
+    #expect(emptyCanonical.nospaceCanonicalMap[""] == "")
   }
 
   @Test("a multi-word canonical claims its space-stripped form")
@@ -61,6 +117,52 @@ struct ExactTriggerIndexTests {
     let index = WordCorrector.buildExactTriggerIndex(words: vocabulary())
     #expect(index.nospace["claudecode"]?.canonical == "Claude Code")
     #expect(index.single["claudecode"] == nil, "it is a no-space claim, not an ordinary one")
+  }
+
+  @Test("a no-space owner only counts when Pass 0 could actually consume the surface")
+  func nospaceInterceptionMatchesPassZeroEligibility() {
+    // Holding a key is not intercepting it. A first cut modelled only the
+    // "already correct" short-circuit and treated every other no-space holder
+    // as a blocker, which let surfaces Pass 0 can never even look at outrank
+    // real ordinary claims (grounded review, #1667).
+    func intercepts(_ key: String, _ surface: String, _ canonical: String) -> Bool {
+      WordCorrector.ownerIntercepts(
+        claim: .init(key: key, namespace: .nospace),
+        rawSurface: surface,
+        owner: .init(wordID: UUID(), canonical: canonical, isPack: false))
+    }
+
+    // "Already correct" is judged CASE-SENSITIVELY, exactly as Pass 0 judges
+    // it — so an exact spelling declines, but a lowercase one does not, because
+    // Pass 0 would substitute to fix the casing.
+    #expect(intercepts("annie", "Annie", "Annie") == false, "already spells its canonical")
+    #expect(intercepts("annie", "annie", "Annie"), "casing differs, Pass 0 still corrects it")
+    #expect(intercepts("annie", "annie", "Anika"), "different word, Pass 0 substitutes")
+
+    // Punctuation is stripped before the comparison, so this is still "already
+    // correct" and still declines.
+    #expect(intercepts("annie", "\"Annie\"", "Annie") == false)
+
+    // Pass 0 never looks up fewer than three characters.
+    #expect(intercepts("ny", "ny", "Elsewhere") == false)
+
+    // Pass 0 concatenates at most three tokens.
+    #expect(intercepts("onetwothreefour", "one two three four", "Elsewhere") == false)
+
+    // Surrounding whitespace is not part of that window, but interior doubled
+    // spaces are: the tokenizer really does see an extra empty token there.
+    #expect(intercepts("onetwo", " one two ", "Elsewhere"))
+    #expect(intercepts("onetwo", "one   two", "Elsewhere") == false)
+
+    // Reserved trigger words are skipped wholesale.
+    #expect(intercepts("oneemoji", "one emoji", "Elsewhere") == false)
+
+    // The ordinary namespaces have no such gate: holding is intercepting.
+    #expect(
+      WordCorrector.ownerIntercepts(
+        claim: .init(key: "annie", namespace: .single),
+        rawSurface: "Annie",
+        owner: .init(wordID: UUID(), canonical: "Annie", isPack: false)))
   }
 
   @Test("no-space aliases fill gaps but a canonical overwrites them")
@@ -115,7 +217,11 @@ struct ExactTriggerIndexTests {
   func passPriorityPrefersNospace() {
     // Pass 0 runs before the ordinary exact passes, so a receipt naming the
     // ordinary owner would name a word the corrector never actually reaches.
-    #expect(WordCorrector.ExactTriggerNamespace.nospace.passPriority < WordCorrector.ExactTriggerNamespace.multi.passPriority)
-    #expect(WordCorrector.ExactTriggerNamespace.multi.passPriority < WordCorrector.ExactTriggerNamespace.single.passPriority)
+    #expect(
+      WordCorrector.ExactTriggerNamespace.nospace.passPriority
+        < WordCorrector.ExactTriggerNamespace.multi.passPriority)
+    #expect(
+      WordCorrector.ExactTriggerNamespace.multi.passPriority
+        < WordCorrector.ExactTriggerNamespace.single.passPriority)
   }
 }


### PR DESCRIPTION
The import screen used to work out which existing word already claims a trigger by copying the correction engine's rules into itself. That copy was wrong three times, each fixed as its own separate bug: which of two words wins a shared shortcut, whether a word's own spelling or another word's shortcut wins, and finally a whole surface it never modelled at all.

That last one is why this issue exists. Type a shortcut that matches an existing multi-word entry with the spaces removed, and the app said it was free, saved it, and then never used it. It could not have worked, because the engine resolves the squashed-together form first.

## What changed

The correction engine now owns the question "which keys does this word claim, and who wins" in one place. Its own lookup tables are built from that answer. Both places that used to guess independently — the review screen and the actual save — now ask the same authority, so what the screen predicts is what gets saved.

## Nine review rounds, because it kept finding real things

This went through more scrutiny than most changes, and it earned it. Six of the nine rounds found something real:

- Two existing tests were simply wrong. Both were written by reading one lookup table and stopping — the exact blindness this issue is about. Corrected against what the real engine actually does with real text, not against what seemed reasonable.
- My own rewrite had the same bug the old code had: naming a word as the owner of a shortcut when that word doesn't actually intercept the text. Fixed with a rule that checks whether a holder would really act, not just whether it holds the key.
- The commit path — the part that actually decides what gets saved — turned out to have a *third*, separate copy of these rules. Fixed so it reads the same authority as the other two.
- **One round reversed the previous round's own fix.** An earlier pass had me resolve a tie in the plan's approval order. That was wrong, and I only found out because I stopped trusting the reasoning and asked the real engine directly: it resolves ties by the order words sit in the saved file, not the order they were edited in. Verified empirically before changing anything, and the wrong version is preserved as a falsification test so it can never quietly come back.

## Validation

- 3,519 tests green.
- Live dictation on the rebuilt app: "cloud code with qual tricks" corrected to "Claude Code with Qualtrics", pipeline 1.63s.
- Final review round: explicit clean confirmation, no functional code left to review.

Commit-time enforcement for the parallel #1672 concern keeps its own separate model and remains open. This PR does not claim that parity.

Part of #1619
Closes #1667
