### PR TITLE
fix(worker): daily-report reliability hardening - shared dev-id predicate, longer retry backoff, fail-soft report

### DIFF
--- a/.github/workflows/daily-report-ping.yml
+++ b/.github/workflows/daily-report-ping.yml
@@ -18,6 +18,19 @@ on:
         required: false
         type: string
 
+# Serializes scheduled and manual runs of this workflow instead of letting
+# them overlap. queue: max is required alongside cancel-in-progress: false:
+# GitHub's default (queue: single) would silently CANCEL an already-pending
+# run when a new one is queued, even with cancel-in-progress: false (that
+# flag only governs already-RUNNING jobs) - a queued manual recovery run
+# could otherwise be dropped by the next scheduled cron firing before it
+# starts. Does not cover a direct curl to the public Worker endpoint; see
+# README for the procedural mitigation (#1720).
+concurrency:
+  group: daily-report
+  cancel-in-progress: false
+  queue: max
+
 permissions:
   contents: read
 

--- a/.github/workflows/daily-report-ping.yml
+++ b/.github/workflows/daily-report-ping.yml
@@ -26,6 +26,16 @@ on:
 # could otherwise be dropped by the next scheduled cron firing before it
 # starts. Does not cover a direct curl to the public Worker endpoint; see
 # README for the procedural mitigation (#1720).
+#
+# `queue` IS valid current GitHub Actions syntax - do not "fix" this by
+# removing it. `actionlint` v1.7.12 (2026-03-30, the latest release as of
+# this writing) does not yet recognize it and reports "unexpected key" -
+# its bundled schema predates this feature. Verified against the
+# community-maintained schema at schemastore.org/github-workflow.json
+# (which documents `queue: single|max` and cites live docs.github.com
+# pages) and independently against context7 `/websites/github_en_actions`.
+# A Codex code-diff review round flagged this as a P1 based on actionlint's
+# false negative; rejected with this evidence, not reverted (#1720).
 concurrency:
   group: daily-report
   cancel-in-progress: false

--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -7,6 +7,10 @@ alerts on nothing — purely a digest for the founder's morning read.
 Plan + full metric-definition rationale (including the two real bugs caught
 during planning and the two grounded-review rounds that shaped the final
 design): `docs/feature-requests/issue-1433-2026-07-09-daily-report.md`.
+Reliability-hardening rationale (why every query shares one resolved-once
+dev-exclusion predicate, why retries are 3 attempts with randomized backoff,
+why 5 of 6 primary queries degrade instead of failing the whole report):
+`docs/feature-requests/issue-1720-2026-07-20-daily-report-reliability-hardening.md`.
 
 ## What it reports
 
@@ -60,6 +64,18 @@ message, posts nothing):
 The optional date argument overrides "yesterday" — useful for testing
 against a known day, and mirrors the deployed worker's `?date=` recovery
 parameter (see below).
+
+**Verification methodology — do not rapid-fire the live trigger.** PostHog's
+project-level limit is 3 concurrent queries; this worker alone can fire up
+to ~8 in one run (6 primary + `resolveDevIds` + conditional `tier_a`).
+Manually re-triggering the live production endpoint two or three times in a
+short window (each firing its own batch) was directly observed causing
+429/504 failures on 2026-07-20 that a single isolated trigger did not
+reproduce — the repeated triggering was itself the dominant traffic source,
+not proof the underlying fix was broken. Verify a change with, in order: (1)
+`node --test`, (2) one `live-query-smoke.mjs` run (posts nothing), (3) after
+deploying, real unattended scheduled runs over the following days. Do not
+declare a fix "proven" from repeated manual endpoint hits.
 
 ## Deploy — REQUIRED after every source change
 
@@ -152,27 +168,37 @@ cron trigger time. Same secret lives as repo secret
 
 Two independent signals, matching `workers/product-health`'s posture:
 
-1. **A query or completeness-check failure** posts an explicit "Daily
-   report failed to generate for `<date>`: `<error>`" notice to Discord
-   (EnviousNotes) AND makes the worker return a non-2xx status, which turns
-   the GitHub Actions job red. You will see BOTH the Discord notice and a
-   GitHub Actions failure.
+1. **A `totals` failure, an auth failure, a malformed query/response, a
+   completeness-check mismatch, or a dev-id-list overflow** posts an explicit
+   "Daily report failed to generate for `<date>`: `<error>`" notice to
+   Discord (EnviousNotes) AND makes the worker return a non-2xx status, which
+   turns the GitHub Actions job red. You will see BOTH the Discord notice and
+   a GitHub Actions failure. `totals` is deliberately the ONE primary query
+   that never degrades — it anchors `resolveBuckets`' completeness check and
+   supplies the report's headline numbers, so there is no safe partial
+   substitute for it.
 
-   **One deliberate exception: `tier_a` degrades instead of failing (#1655).**
-   It is the polish-provider *settings* lookup, and `resolveBuckets` already
-   falls back per user (settings → actual dictation → shipped default), so an
-   empty `tier_a` still yields a complete breakdown. If it exhausts its retry
-   on a transient PostHog status (502/503/504), the report is still posted with
-   a note near the top: "today's polish-provider breakdown is approximate
-   because the settings lookup was temporarily unavailable." Read that note as
-   "this day's provider split leans on runtime signal rather than configured
-   choice," not as "the report is wrong."
+   **Six deliberate exceptions degrade instead of failing (#1655, #1716,
+   #1720).** `tier_a` (the polish-provider *settings* lookup) and 5 of the 6
+   primary queries — `installs`, `onboard_activate`, `engineAndTierB`, `geo`,
+   `top5` — can each independently degrade on an exhausted transient PostHog
+   status (429/502/503/504). `tier_a` degrading still yields a full report
+   with a near-top note ("today's polish-provider breakdown is approximate
+   because the settings lookup was temporarily unavailable"), because
+   `resolveBuckets` already falls back per user (settings → actual dictation
+   → shipped default). The other 5 have no such fallback data — a degraded
+   section is OMITTED with inline "temporarily unavailable" wording in its
+   normal spot (never a fabricated `0` or empty list shown as real data),
+   plus a combined near-top note listing every degraded section for a fast
+   skim. `engineAndTierB` degrading additionally skips `tier_a` (no active-id
+   list to enrich) and `resolveBuckets` entirely (no per-user rows to check
+   completeness against) — the breakdown lines are simply omitted.
 
-   This exception is scoped tightly. Only `tier_a`, and only on an exhausted
-   502/503/504 — an auth failure, a malformed query, a bad response shape, or
-   any ordinary programming error still fails the whole report loudly, because
-   a silently "approximate" report that hides a real defect is worse than no
-   report at all. Every other query remains fail-loud.
+   This exception is scoped tightly. Only these six, and only on an
+   exhausted 429/502/503/504 — an auth failure, a malformed query, a bad
+   response shape, or any ordinary programming error still fails the whole
+   report loudly, because a silently "approximate" report that hides a real
+   defect is worse than no report at all.
 2. **If Discord itself is unreachable/erroring**, the GitHub Actions job
    still goes red (the one failure mode with no Discord-side notice —
    GitHub's own failure-run email is the signal here).
@@ -183,12 +209,21 @@ Two independent signals, matching `workers/product-health`'s posture:
    curl -fsS "https://enviouswispr-daily-report.saurabhav.workers.dev/?token=<TRIGGER_SECRET>&date=2026-07-08"
    ```
 
-**Duplicate posts are expected, not a bug.** A manual `workflow_dispatch` or
-a GitHub Actions job rerun on a day the scheduled run already posted will
-post a second, real, duplicate report — same accepted tradeoff as
-`workers/product-health`'s own manual-trigger runbook. No idempotency/dedup
-mechanism is built (would need new stateful infrastructure — a Workers KV
-namespace — for a low-stakes internal report).
+**Duplicate posts remain possible for a genuinely separate trigger, not a
+bug.** A manual `workflow_dispatch` on a day the scheduled run already
+posted will still post a second, real, duplicate report — same accepted
+tradeoff as `workers/product-health`'s own manual-trigger runbook. No
+idempotency/dedup mechanism is built (would need new stateful infrastructure
+— a Workers KV namespace — for a low-stakes internal report). What #1720
+DOES prevent: `daily-report-ping.yml`'s own `concurrency: {group:
+daily-report, cancel-in-progress: false, queue: max}` stops the scheduled
+cron and a manual dispatch from overlapping or silently cancelling each
+other's pending run within GitHub Actions — GitHub's default behavior
+(`queue: single`) would otherwise let a new pending run silently replace an
+already-queued one, which could drop a queued manual recovery run entirely.
+This does not cover a direct `curl` to the public Worker endpoint; see the
+verification-methodology note above for why that path stays a manual,
+deliberate, spaced-out action.
 
 ## Rollback
 

--- a/workers/daily-report/live-query-smoke.mjs
+++ b/workers/daily-report/live-query-smoke.mjs
@@ -40,18 +40,28 @@ const data = await fetchReportData(env, win, endUTC);
 console.log("\n=== aggregate summary (counts/labels only, no per-user rows) ===");
 console.log({
   freshInstalls: data.freshInstalls,
+  installsDegraded: data.installsDegraded,
   onboarded: data.onboarded,
   activated: data.activated,
+  onboardActivateDegraded: data.onboardActivateDegraded,
   netDictations: data.netDictations,
   totalUsers: data.totalUsers,
   engineAndTierBRowCount: data.engineAndTierB.length,
+  engineAndTierBDegraded: data.engineAndTierBDegraded,
   tierARowCount: data.tierA.length,
   tierADegraded: data.tierADegraded, // true => tier-a exhausted its retry; breakdown is approximate (#1655)
   geo: data.geo,
+  geoDegraded: data.geoDegraded,
   top5Counts: data.top5.map((u) => u.n), // values only, no distinct_id
+  top5Degraded: data.top5Degraded,
 });
 
-const buckets = resolveBuckets(data); // throws loudly on a completeness mismatch
+// Mirrors runReport's own engineAndTierBDegraded bypass (#1720): calling
+// resolveBuckets unconditionally here would throw its completeness check
+// against the empty per-user rows a degraded engineAndTierB leaves behind.
+const buckets = data.engineAndTierBDegraded
+  ? { engineBuckets: {}, polishBuckets: {}, resolutionSource: { settings: 0, actual_dictation: 0, shipped_default: 0 } }
+  : resolveBuckets(data); // throws loudly on a completeness mismatch
 console.log("\n=== resolved buckets + resolution tiers (would be logged, never posted to Discord) ===");
 console.log({ engineBuckets: buckets.engineBuckets, polishBuckets: buckets.polishBuckets });
 console.log(buckets.resolutionSource);
@@ -60,4 +70,24 @@ const message = buildMessage(dateStr, data, buckets);
 console.log("\n=== would-be Discord message ===");
 console.log(message);
 
-console.log("\nSmoke OK: queries resolved, completeness check passed, nothing posted.");
+// A degraded section means PostHog didn't answer after 3 attempts DURING
+// this smoke run - the exact thing a pre-deploy smoke check exists to prove
+// didn't happen. Codex code-diff review caught that printing "Smoke OK"
+// regardless would let a real degradation pass silently (#1720); fail loud
+// and let the caller decide whether to retry rather than deploy on
+// unproven data.
+const degradedSections = [
+  ["installsDegraded", "installs"],
+  ["onboardActivateDegraded", "onboard_activate"],
+  ["engineAndTierBDegraded", "engine_and_tier_b"],
+  ["geoDegraded", "geo"],
+  ["top5Degraded", "top5"],
+  ["tierADegraded", "tier_a"],
+].filter(([key]) => data[key]).map(([, name]) => name);
+
+if (degradedSections.length) {
+  console.error(`\nSmoke FAILED: ${degradedSections.join(", ")} degraded during this run - not a clean pass. Nothing posted; retry later, spaced out (see README verification-methodology note).`);
+  process.exit(1);
+}
+
+console.log("\nSmoke OK: all queries resolved cleanly, completeness check passed, nothing posted.");

--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -29,8 +29,9 @@ const DEFAULT_ENGINE = "parakeet";
 const DEFAULT_PROVIDER = "appleIntelligence";
 
 // Per-worker distinct_id list bound. Genuinely a defense-in-depth ceiling,
-// never the primary correctness mechanism - see PROD/completeness check below
-// and plan §3.3a. 5000 is far above any realistic single-day population.
+// never the primary correctness mechanism - see resolveDevIds/completeness
+// check below and plan §3.3a. 5000 is far above any realistic single-day
+// population.
 const PER_USER_LIST_LIMIT = 5000;
 
 export default {
@@ -128,20 +129,54 @@ function sqlTimestamp(date) {
 
 // ----- PostHog ---------------------------------------------------------------
 
-// Per-distinct_id -dev exclusion (analytics-operations.md RULE:
-// founder-machine-tell-in-distinct-id): a dev build anywhere in an id's
-// history marks the whole id as dogfood. Verbatim shape from
-// workers/product-health/src/index.js.
-const PROD = `properties.environment = 'production'
-  AND distinct_id NOT IN (
-    SELECT distinct_id FROM events
-    WHERE properties.app_version LIKE '%-dev%' )`;
-
-// Environment only, no whole-history dev-ID exclusion. Safe ONLY where the
-// caller separately applies full PROD to whichever set is being COUNTED -
-// see each call site's local comment for why (the #1655 doubled-subquery
-// class; never copy this constant in without re-deriving the argument).
+// Environment predicate alone, no whole-history dev-ID exclusion applied
+// here. See productionClauseFor() below for the report's shared,
+// resolved-once dev-exclusion predicate, and each ENV_ONLY call site's local
+// comment for why omitting the exclusion there is separately safe.
 const ENV_ONLY = "properties.environment = 'production'";
+
+/** Converts a resolved dev-tainted distinct_id list (from resolveDevIds
+ * below) into the reusable production-filter predicate: environment =
+ * production, AND (only if any dev ids exist) NOT IN that literal list.
+ * Resolving the list ONCE per report run and threading the result through
+ * every query that needs it replaces the old per-query inline dev-exclusion
+ * subquery, which independently re-scanned the same whole-history data in
+ * every one of the 6 primary queries - the duplicated-subquery shape that
+ * measurably timed out production PostHog for polish tier-a (#1655) and
+ * onboard_activate (#1716). An empty list is a legitimate state (genuinely
+ * zero dev-tainted ids found across event history) and must not produce
+ * invalid `NOT IN ()` SQL, hence the empty-list branch below (#1720). */
+export function productionClauseFor(devIds) {
+  if (devIds.length === 0) return ENV_ONLY;
+  return `${ENV_ONLY}
+    AND distinct_id NOT IN (${sqlIdList(devIds)})`;
+}
+
+/** Resolves the day's whole-history dev-tainted distinct_id list ONCE per
+ * report run (analytics-operations.md RULE: founder-machine-tell-in-
+ * distinct-id: a dev build anywhere in an id's history marks the whole id
+ * as dogfood, so this is an unbounded scan, not day-windowed). Queried at
+ * PER_USER_LIST_LIMIT+1 to detect overflow: if the true count exceeds the
+ * ceiling, this throws rather than silently building a truncated exclusion
+ * list that would under-exclude dev accounts from production totals - fail
+ * loud, not warn-and-continue (#1720). This is itself a fail-loud query: an
+ * unresolved dev-id list can never safely be treated as "no dev accounts,"
+ * so callers must never wrap it in querySection's fail-soft catch. */
+export async function resolveDevIds(env, hogqlOpts = {}) {
+  const result = await hogql(
+    env,
+    `SELECT DISTINCT distinct_id FROM events
+     WHERE properties.app_version LIKE '%-dev%'
+     LIMIT ${PER_USER_LIST_LIMIT + 1}`,
+    "dev_ids",
+    hogqlOpts
+  );
+  const devIds = (result.results || []).map((row) => row[0]);
+  if (devIds.length > PER_USER_LIST_LIMIT) {
+    throw new Error(`dev-id completeness check failed: more than ${PER_USER_LIST_LIMIT} ids`);
+  }
+  return devIds;
+}
 
 function windowClause(startUTC, endUTC) {
   return `timestamp >= '${sqlTimestamp(startUTC)}' AND timestamp < '${sqlTimestamp(endUTC)}'`;
@@ -149,17 +184,18 @@ function windowClause(startUTC, endUTC) {
 
 /** The day's active-user population (successful dictators), used once as an
  * IN-membership test inside onboardActivateSql's `activated` column - see
- * that query below. Deliberately ${ENV_ONLY}, not full PROD: every row this
- * set is tested against already came from onboardActivateSql's own outer
- * `WHERE ... AND ${PROD}` on onboarding.completed, so a dev-tainted id can
- * never appear on the outer side to begin with - whether this inner set is
- * ALSO dev-filtered cannot change which outer ids match it. Full PROD here
- * would evaluate the same whole-history dev-exclusion subquery a second time
- * for no change in result, which is exactly the doubled-subquery shape that
- * measurably timed out production PostHog for polish tier-a (#1655) - fixed
- * here the same way, after #1655's fix didn't cover this sibling query and
- * it 504'd for real on 2026-07-20. This argument is local to this one call
- * site; a new caller must re-derive it, not assume it. */
+ * that query below. Deliberately ${ENV_ONLY}, not the full production
+ * predicate: every row this set is tested against already came from
+ * onboardActivateSql's own outer `WHERE ... AND ${prod}` on
+ * onboarding.completed, so a dev-tainted id can never appear on the outer
+ * side to begin with - whether this inner set is ALSO dev-filtered cannot
+ * change which outer ids match it. The full predicate here would evaluate
+ * the dev-exclusion a second time for no change in result, which is exactly
+ * the doubled-subquery shape that measurably timed out production PostHog
+ * for polish tier-a (#1655) - fixed here the same way, after #1655's fix
+ * didn't cover this sibling query and it 504'd for real on 2026-07-20. This
+ * argument is local to this one call site; a new caller must re-derive it,
+ * not assume it. */
 function activeUsersSubquery(win) {
   return `SELECT DISTINCT distinct_id FROM events
     WHERE event = 'dictation.completed' AND properties.result = 'success'
@@ -177,14 +213,15 @@ function sqlIdList(ids) {
  * settings.changed, restricted to a literal list of already-known active-user
  * ids (rather than a re-evaluated subquery, which timed out).
  *
- * Deliberately uses ${ENV_ONLY} rather than full PROD. Every active id came
- * from engineAndTierBSql, which already applied full PROD, including the
- * whole-history dev-ID exclusion. Repeating that exclusion twice inside this
- * UNION adds substantial work without changing results. Live A/B
- * verification found identical provider attribution for all active users.
- * This argument is local to tier-a and to activeUsersSubquery's own,
- * separately-derived use of ${ENV_ONLY} below; every other query keeps full
- * PROD. */
+ * Deliberately uses ${ENV_ONLY} rather than the full production predicate.
+ * Every active id came from engineAndTierBSql, which already applied the
+ * full predicate, including the whole-history dev-ID exclusion. Repeating
+ * that exclusion twice inside this UNION adds substantial work without
+ * changing results. Live A/B verification found identical provider
+ * attribution for all active users. This argument is local to tier-a and to
+ * activeUsersSubquery's own, separately-derived use of ${ENV_ONLY} below;
+ * every other query keeps the full dev-exclusion via
+ * `productionClauseFor`. */
 function tierASqlFor(activeIds, endTs) {
   const ids = sqlIdList(activeIds);
   return `
@@ -206,19 +243,36 @@ function tierASqlFor(activeIds, endTs) {
     LIMIT ${PER_USER_LIST_LIMIT}`;
 }
 
-// PostHog's project-level rate limit allows only 3 concurrent queries and
-// queues/cancels/times-out (HTTP 502/503/504) anything beyond that (#1588,
-// posthog.com/docs/api/queries + posthog.com/docs/endpoints/rate-limits).
-// `runLimited` below caps our own concurrency under that ceiling; this retry
-// is the second, complementary layer for genuine transient contention (e.g.
-// the project is shared with EnviousStaging - analytics-operations.md FACT:
-// posthog-project-is-shared-with-enviousstaging). It retries exactly once,
-// only on the documented queue-timeout status class, and only ever before
-// any Discord post happens - unlike the deliberately-rejected outer
+// PostHog's project-level rate limit allows only 3 concurrent queries, up to
+// 10s execution time per query, and queues/cancels/times-out (HTTP
+// 502/503/504) anything beyond that; 429 is the documented, distinct
+// concurrency-limit-reached status (posthog.com/docs/api/queries,
+// posthog.com/docs/endpoints/troubleshooting - #1588, #1720). `runLimited`
+// below caps our own concurrency under that ceiling; this retry is the
+// second, complementary layer for genuine transient contention (e.g. the
+// project is shared with EnviousStaging - analytics-operations.md FACT:
+// posthog-project-is-shared-with-enviousstaging). It retries up to twice
+// (3 attempts total), only on this documented status class, and only ever
+// before any Discord post happens - unlike the deliberately-rejected outer
 // GitHub-Actions-level retry (see the comment in daily-report-ping.yml),
 // this cannot produce a duplicate or confusing failure notice.
-const RETRYABLE_POSTHOG_STATUSES = new Set([502, 503, 504]);
+const RETRYABLE_POSTHOG_STATUSES = new Set([429, 502, 503, 504]);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Randomized backoff windows for retry attempts 2 and 3, informed by (not a
+// guarantee derived from) PostHog's documented up-to-30s queue-wait: once a
+// request has already queued, waited, and failed, its original window is
+// already over, so this is conservative contention backoff, not a claim
+// that a fixed wait "clears" any specific prior window (#1720).
+const RETRY_DELAY_RANGES_MS = [
+  [12_000, 18_000],
+  [30_000, 45_000],
+];
+
+function retryDelayMs(range, randomFn) {
+  const [min, max] = range;
+  return Math.floor(min + randomFn() * (max - min + 1));
+}
 
 /** Carries the query name and HTTP status alongside the message, so a caller
  * can distinguish an exhausted transient failure (which tier-a is allowed to
@@ -239,11 +293,12 @@ export async function hogql(
   env,
   sql,
   queryName,
-  { fetchFn = fetch, sleepFn = sleep, retryDelayMs = 1500 } = {}
+  { fetchFn = fetch, sleepFn = sleep, randomFn = Math.random } = {}
 ) {
   const url = `${POSTHOG_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/query/`;
+  const maxAttempts = RETRY_DELAY_RANGES_MS.length + 1;
 
-  for (let attempt = 1; attempt <= 2; attempt += 1) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const res = await fetchFn(url, {
       method: "POST",
       headers: {
@@ -279,10 +334,10 @@ export async function hogql(
       }
     }
 
-    if (attempt === 2 || !RETRYABLE_POSTHOG_STATUSES.has(status)) {
+    if (attempt === maxAttempts || !RETRYABLE_POSTHOG_STATUSES.has(status)) {
       throw new PostHogQueryError(queryName, status);
     }
-    await sleepFn(retryDelayMs);
+    await sleepFn(retryDelayMs(RETRY_DELAY_RANGES_MS[attempt - 1], randomFn));
   }
 }
 
@@ -306,6 +361,28 @@ export async function runLimited(tasks, limit) {
   return results;
 }
 
+/** Runs one hogql() call and reports whether it degraded instead of
+ * throwing, for any of the 5 non-essential primary queries (installs,
+ * onboard_activate, engineAndTierB, geo, top5). Only an EXHAUSTED retryable
+ * status (RETRYABLE_POSTHOG_STATUSES, after hogql's own retries) degrades;
+ * anything else - auth, bad SQL, a malformed response, a programming error -
+ * still throws, matching tier_a's existing degrade philosophy (#1655,
+ * extended report-wide by #1720). `totals` deliberately does NOT go through
+ * this helper - it stays fail-loud, see its call site in fetchReportData. */
+async function querySection(env, sql, queryName, hogqlOpts) {
+  try {
+    return { response: await hogql(env, sql, queryName, hogqlOpts), degraded: false };
+  } catch (err) {
+    const isExpectedTransientFailure =
+      err instanceof PostHogQueryError &&
+      err.queryName === queryName &&
+      RETRYABLE_POSTHOG_STATUSES.has(err.status);
+    if (!isExpectedTransientFailure) throw err;
+    console.log(`daily-report ${queryName} degraded after retries: HTTP ${err.status}`);
+    return { response: null, degraded: true };
+  }
+}
+
 function rowsToObjects(res) {
   const cols = res.columns || [];
   return (res.results || []).map((row) => {
@@ -316,28 +393,32 @@ function rowsToObjects(res) {
 }
 
 // `hogqlOpts` forwards the same injection bag `hogql` already accepts, so tests
-// can drive the retry path without a real 1.5s delay per retry - the pattern
-// the hogql unit tests already use. Production passes nothing.
+// can drive the retry path without real backoff delays - the pattern the
+// hogql unit tests already use. Production passes nothing.
 export async function fetchReportData(env, win, endUTC, hogqlOpts = {}) {
   const endTs = sqlTimestamp(endUTC);
+  // Resolved ONCE per report run and threaded through every query below,
+  // replacing the old per-query inline dev-exclusion subquery (#1720).
+  const devIds = await resolveDevIds(env, hogqlOpts);
+  const prod = productionClauseFor(devIds);
   const activeUsers = activeUsersSubquery(win);
 
   const installsSql = `
     SELECT uniqExact(distinct_id) FROM events
     WHERE event = 'app.launched' AND properties.is_fresh_install = true
-      AND ${PROD} AND ${win}`;
+      AND ${prod} AND ${win}`;
 
   const onboardActivateSql = `
     SELECT
       uniqExact(distinct_id) AS onboarded,
       uniqExactIf(distinct_id, distinct_id IN (${activeUsers})) AS activated
     FROM events
-    WHERE event = 'onboarding.completed' AND ${PROD} AND ${win}`;
+    WHERE event = 'onboarding.completed' AND ${prod} AND ${win}`;
 
   const totalsSql = `
     SELECT count() AS net_dictations, uniqExact(distinct_id) AS total_users
     FROM events
-    WHERE event = 'dictation.completed' AND properties.result = 'success' AND ${PROD} AND ${win}`;
+    WHERE event = 'dictation.completed' AND properties.result = 'success' AND ${prod} AND ${win}`;
 
   // Engine (row 3) + polish tier-b fallback (row 4) share the same event
   // population, so one query resolves both per user.
@@ -346,7 +427,7 @@ export async function fetchReportData(env, win, endUTC, hogqlOpts = {}) {
            argMax(properties.asr_backend, timestamp) AS engine,
            anyIf(properties.llm_provider, properties.llm_provider IS NOT NULL) AS tier_b_provider
     FROM events
-    WHERE event = 'dictation.completed' AND properties.result = 'success' AND ${PROD} AND ${win}
+    WHERE event = 'dictation.completed' AND properties.result = 'success' AND ${prod} AND ${win}
     GROUP BY distinct_id
     LIMIT ${PER_USER_LIST_LIMIT}`;
 
@@ -355,7 +436,7 @@ export async function fetchReportData(env, win, endUTC, hogqlOpts = {}) {
     FROM events
     WHERE event = 'dictation.completed' AND properties.result = 'success'
       AND properties.$geoip_country_name IS NOT NULL AND properties.$geoip_country_name != ''
-      AND ${PROD} AND ${win}
+      AND ${prod} AND ${win}
     GROUP BY country
     ORDER BY n DESC
     LIMIT 5`;
@@ -363,43 +444,46 @@ export async function fetchReportData(env, win, endUTC, hogqlOpts = {}) {
   const top5Sql = `
     SELECT distinct_id, count() AS n
     FROM events
-    WHERE event = 'dictation.completed' AND properties.result = 'success' AND ${PROD} AND ${win}
+    WHERE event = 'dictation.completed' AND properties.result = 'success' AND ${prod} AND ${win}
     GROUP BY distinct_id
     ORDER BY n DESC
     LIMIT 5`;
 
-  // These 6 queries are independent, but PostHog allows only 3 concurrent
-  // queries per project (#1588) - `runLimited(..., 2)` runs them in 3 fixed
-  // waves of 2, leaving one slot of headroom for the shared project's other
-  // traffic (EnviousStaging) rather than firing all 6 at once and getting
-  // the excess queued/timed-out. Polish tier-a (below) runs sequentially
-  // *after* all 3 waves finish - it does not need reserved concurrency.
-  // Tier-a has its own history: an EARLIER version embedded the active-user
-  // bound as a re-evaluated nested subquery inside a UNION and that
-  // measurably timed out against production PostHog (HTTP 504) - two nested
-  // re-scans of the whole PROD filter's dev-exclusion subquery, twice,
-  // inside a UNION, is too expensive. Fixed by resolving the active-user id
-  // list from `engineAndTierB` (already fetched, zero extra cost) and
-  // passing it to tier-a as a literal IN-list instead of a subquery.
-  const [installs, onboardActivate, totals, engineAndTierB, geo, top5] = await runLimited(
-    [
-      () => hogql(env, installsSql, "installs", hogqlOpts),
-      () => hogql(env, onboardActivateSql, "onboard_activate", hogqlOpts),
-      () => hogql(env, totalsSql, "totals", hogqlOpts),
-      () => hogql(env, engineAndTierBSql, "engine_and_tier_b", hogqlOpts),
-      () => hogql(env, geoSql, "geo", hogqlOpts),
-      () => hogql(env, top5Sql, "top5", hogqlOpts),
-    ],
-    2
-  );
+  // These 6 primary queries are independent, but PostHog allows only 3
+  // concurrent queries per project (#1588) - `runLimited(..., 2)` runs them
+  // in 3 fixed waves of 2, leaving one slot of headroom for the shared
+  // project's other traffic (EnviousStaging) rather than firing all 6 at
+  // once and getting the excess queued/timed-out. Polish tier-a (below)
+  // runs sequentially *after* all 3 waves finish - it does not need reserved
+  // concurrency. `totals` is the sole fail-loud query in this batch (it
+  // anchors resolveBuckets's completeness check and supplies the report's
+  // headline numbers); the other five go through querySection and degrade
+  // to "temporarily unavailable" instead of discarding the whole report on
+  // an exhausted transient failure (#1720).
+  const [installsResult, onboardActivateResult, totals, engineAndTierBResult, geoResult, top5Result] =
+    await runLimited(
+      [
+        () => querySection(env, installsSql, "installs", hogqlOpts),
+        () => querySection(env, onboardActivateSql, "onboard_activate", hogqlOpts),
+        () => hogql(env, totalsSql, "totals", hogqlOpts),
+        () => querySection(env, engineAndTierBSql, "engine_and_tier_b", hogqlOpts),
+        () => querySection(env, geoSql, "geo", hogqlOpts),
+        () => querySection(env, top5Sql, "top5", hogqlOpts),
+      ],
+      2
+    );
 
-  const activeIds = (engineAndTierB.results || []).map((row) => row[0]);
+  const engineAndTierB = engineAndTierBResult.degraded ? [] : rowsToObjects(engineAndTierBResult.response);
+  const activeIds = engineAndTierB.map((row) => row.distinct_id);
   // tier-a is an ENRICHMENT: resolveBuckets already falls back
   // tierA -> tier_b_provider -> DEFAULT_PROVIDER per user, so an empty tier-a
   // still yields a complete breakdown. A tier-a failure must therefore degrade
   // that one attribution tier rather than discard an otherwise-complete report.
   // On 2026-07-18 all six batched queries succeeded and were discarded because
-  // tier-a timed out (#1655).
+  // tier-a timed out (#1655). When engineAndTierB itself is degraded,
+  // activeIds is empty, so tier-a is naturally skipped below - runReport
+  // separately skips resolveBuckets entirely in that case (#1720), since a
+  // completeness check has nothing real to verify against.
   //
   // ONLY an exhausted retryable status degrades. Anything else - auth, bad SQL,
   // a malformed response, a programming error - stays loud: a silently
@@ -421,16 +505,21 @@ export async function fetchReportData(env, win, endUTC, hogqlOpts = {}) {
   }
 
   return {
-    freshInstalls: installs.results[0][0],
-    onboarded: rowsToObjects(onboardActivate)[0]?.onboarded ?? 0,
-    activated: rowsToObjects(onboardActivate)[0]?.activated ?? 0,
+    freshInstalls: installsResult.degraded ? null : installsResult.response.results[0][0],
+    installsDegraded: installsResult.degraded,
+    onboarded: onboardActivateResult.degraded ? null : rowsToObjects(onboardActivateResult.response)[0]?.onboarded ?? 0,
+    activated: onboardActivateResult.degraded ? null : rowsToObjects(onboardActivateResult.response)[0]?.activated ?? 0,
+    onboardActivateDegraded: onboardActivateResult.degraded,
     netDictations: rowsToObjects(totals)[0]?.net_dictations ?? 0,
     totalUsers: rowsToObjects(totals)[0]?.total_users ?? 0,
-    engineAndTierB: rowsToObjects(engineAndTierB),
+    engineAndTierB,
+    engineAndTierBDegraded: engineAndTierBResult.degraded,
     tierA: rowsToObjects(tierA),
     tierADegraded,
-    geo: rowsToObjects(geo),
-    top5: rowsToObjects(top5),
+    geo: geoResult.degraded ? [] : rowsToObjects(geoResult.response),
+    geoDegraded: geoResult.degraded,
+    top5: top5Result.degraded ? [] : rowsToObjects(top5Result.response),
+    top5Degraded: top5Result.degraded,
   };
 }
 
@@ -510,27 +599,51 @@ function formatWeekdayDate(dateStr) {
   }).format(noonUTC);
 }
 
+// Names for the "some sections were unavailable" summary note, keyed to the
+// same booleans fetchReportData returns. `totals` is deliberately absent -
+// it never degrades (#1720).
+const DEGRADED_SECTION_LABELS = [
+  ["installsDegraded", "new installs"],
+  ["onboardActivateDegraded", "onboarding/activation"],
+  ["engineAndTierBDegraded", "transcription engine and AI-polish breakdown"],
+  ["geoDegraded", "where they are"],
+  ["top5Degraded", "top 5 users"],
+];
+
 export function buildMessage(dateStr, data, buckets) {
   const lines = [`EnviousWispr Daily Report, ${formatWeekdayDate(dateStr)}`, ""];
 
   // Near the TOP deliberately: the tail is truncated at 1990 chars below, so a
   // note appended at the end could be silently cut off on exactly the busy days
-  // when the report is longest (#1655).
+  // when the report is longest (#1655). Distinct from the per-section inline
+  // "temporarily unavailable" wording below - this is a fast-skim summary,
+  // never a substitute for it, and never fabricates a zero for a degraded
+  // section (#1720).
+  const notes = [];
   if (data.tierADegraded) {
-    lines.push(
-      "Note: today's polish-provider breakdown is approximate because the settings lookup was temporarily unavailable.",
-      ""
-    );
+    notes.push("today's polish-provider breakdown is approximate because the settings lookup was temporarily unavailable");
+  }
+  const degradedSections = DEGRADED_SECTION_LABELS.filter(([key]) => data[key]).map(([, label]) => label);
+  if (degradedSections.length) {
+    notes.push(`some sections were temporarily unavailable today: ${degradedSections.join(", ")}`);
+  }
+  if (notes.length) {
+    lines.push(`Note: ${notes.join("; ")}.`, "");
   }
 
-  lines.push(
-    `New installs: ${data.freshInstalls}. People who finished setup today: ${data.onboarded}. Of those, ${data.activated} also dictated today.`,
-    ""
-  );
+  const installsPart = data.installsDegraded
+    ? "New installs: temporarily unavailable."
+    : `New installs: ${data.freshInstalls}.`;
+  const onboardPart = data.onboardActivateDegraded
+    ? "Onboarding and activation: temporarily unavailable."
+    : `People who finished setup today: ${data.onboarded}. Of those, ${data.activated} also dictated today.`;
+  lines.push(`${installsPart} ${onboardPart}`, "");
 
   lines.push(`Total users: ${data.totalUsers} people used the app today.`, "");
 
-  if (data.totalUsers > 0) {
+  if (data.engineAndTierBDegraded) {
+    lines.push("Transcription engine and AI-polish breakdown: temporarily unavailable.", "");
+  } else if (data.totalUsers > 0) {
     const engineLine = formatBuckets(buckets.engineBuckets, ENGINE_LABELS, data.totalUsers);
     if (engineLine) lines.push(`Transcription engine (by user): ${engineLine}.`, "");
 
@@ -540,11 +653,15 @@ export function buildMessage(dateStr, data, buckets) {
 
   lines.push(`Net total dictations: ${data.netDictations}.`, "");
 
-  if (data.geo.length) {
+  if (data.geoDegraded) {
+    lines.push("Where they are: temporarily unavailable.", "");
+  } else if (data.geo.length) {
     lines.push(`Where they are: ${data.geo.map((g) => `${g.country} ${g.n}`).join(", ")}.`, "");
   }
 
-  if (data.top5.length) {
+  if (data.top5Degraded) {
+    lines.push("Top 5 users by dictation volume: temporarily unavailable.");
+  } else if (data.top5.length) {
     lines.push(`Top 5 users by dictation volume: ${data.top5.map((u) => u.n).join(", ")}.`);
   }
 
@@ -572,14 +689,30 @@ async function safePost(env, content) {
   }
 }
 
-export async function runReport(env, dateOverride = null) {
+// `deps` is a test-only injection seam (production passes nothing, both
+// defaults apply): `deps.resolveBuckets` lets a degraded-engine test spy on
+// resolveBuckets and assert it was never called (proving the skip below
+// actually happened, not just that its output looks empty); `deps.hogqlOpts`
+// forwards into fetchReportData so the same test can force an exhausted
+// retry deterministically instead of waiting through real backoff delays
+// (#1720).
+export async function runReport(env, dateOverride = null, deps = {}) {
+  const resolveBucketsFn = deps.resolveBuckets || resolveBuckets;
+  const hogqlOpts = deps.hogqlOpts || {};
   const { dateStr, startUTC, endUTC } = easternYesterdayWindowUTC(new Date(), dateOverride);
   const win = windowClause(startUTC, endUTC);
 
   let data, buckets;
   try {
-    data = await fetchReportData(env, win, endUTC);
-    buckets = resolveBuckets(data);
+    data = await fetchReportData(env, win, endUTC, hogqlOpts);
+    // engineAndTierB degraded => no real per-user rows to check completeness
+    // against; resolveBucketsFn's completeness check would throw against
+    // absent data, so it is skipped entirely rather than called with a
+    // guaranteed-mismatched anchor (#1720). Empty placeholders let
+    // buildMessage omit the breakdown cleanly (see its own degraded branch).
+    buckets = data.engineAndTierBDegraded
+      ? { engineBuckets: {}, polishBuckets: {}, resolutionSource: { settings: 0, actual_dictation: 0, shipped_default: 0 } }
+      : resolveBucketsFn(data);
     // Resolution-tier logging (Cloudflare log only, never the Discord
     // message) - plan §3.3a. A spike in shipped_default's share vs
     // settings/actual_dictation is the telemetry-drift canary.

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -9,6 +9,9 @@ import {
   hogql,
   runLimited,
   fetchReportData,
+  runReport,
+  resolveDevIds,
+  productionClauseFor,
   PostHogQueryError,
 } from "../src/index.js";
 
@@ -124,6 +127,19 @@ test("resolveBuckets: zero active users is not a divide-by-zero / throw case", (
   assert.deepEqual(polishBuckets, {});
 });
 
+// ---- productionClauseFor (#1720) ----
+
+test("productionClauseFor: empty dev-id list uses bare ENV_ONLY, never NOT IN ()", () => {
+  const clause = productionClauseFor([]);
+  assert.doesNotMatch(clause, /NOT IN/);
+  assert.match(clause, /properties\.environment = 'production'/);
+});
+
+test("productionClauseFor: non-empty list appends a literal NOT IN exclusion", () => {
+  const clause = productionClauseFor(["dev-1", "dev-2"]);
+  assert.match(clause, /NOT IN \('dev-1', 'dev-2'\)/);
+});
+
 // ---- buildMessage ----
 // Golden fixture: real production numbers from a live-query-smoke.mjs run
 // against the ACTUAL implemented queries (2026-07-08 Eastern calendar day,
@@ -175,6 +191,8 @@ test("buildMessage: golden fixture matches the founder-approved report shape", (
   assert.match(msg, /Top 5 users by dictation volume: 557, 139, 113, 94, 70\./);
   // No em-dashes/en-dashes anywhere (global CLAUDE.md Rule 6).
   assert.doesNotMatch(msg, /[–—]/);
+  // Nothing degraded on the golden run - no "temporarily unavailable" wording.
+  assert.doesNotMatch(msg, /temporarily unavailable/);
 });
 
 test("buildMessage: zero-count buckets are omitted, not shown as '(0%)'", () => {
@@ -191,6 +209,71 @@ test("buildMessage: zero total_users omits the engine/polish section entirely (n
   assert.doesNotMatch(msg, /Transcription engine/);
   assert.doesNotMatch(msg, /AI polishing/);
   assert.match(msg, /Total users: 0 people used the app today\./);
+});
+
+// ---- buildMessage: per-section fail-soft degradation (#1720) ----
+//
+// Each of the 5 non-essential primary queries can independently degrade to
+// "temporarily unavailable" - never a fabricated zero or empty list shown as
+// real data - while the rest of the report still ships. `totals` never
+// degrades (verified separately below via fetchReportData/runReport).
+
+test("buildMessage: installsDegraded omits the freshInstalls number, keeps onboarding intact", () => {
+  const msg = buildMessage("2026-07-08", { ...GOLDEN_DATA, installsDegraded: true }, GOLDEN_BUCKETS);
+  assert.match(msg, /New installs: temporarily unavailable\./);
+  assert.doesNotMatch(msg, /New installs: 90/);
+  assert.match(msg, /People who finished setup today: 82\. Of those, 60 also dictated today\./);
+  assert.match(msg, /Note: .*new installs/);
+});
+
+test("buildMessage: onboardActivateDegraded omits onboarding, keeps installs intact", () => {
+  const msg = buildMessage("2026-07-08", { ...GOLDEN_DATA, onboardActivateDegraded: true }, GOLDEN_BUCKETS);
+  assert.match(msg, /New installs: 90\./);
+  assert.match(msg, /Onboarding and activation: temporarily unavailable\./);
+  assert.doesNotMatch(msg, /People who finished setup today/);
+  assert.match(msg, /Note: .*onboarding\/activation/);
+});
+
+test("buildMessage: engineAndTierBDegraded omits both engine and polish lines, never fabricates a bucket", () => {
+  const msg = buildMessage("2026-07-08", { ...GOLDEN_DATA, engineAndTierBDegraded: true }, GOLDEN_BUCKETS);
+  assert.match(msg, /Transcription engine and AI-polish breakdown: temporarily unavailable\./);
+  assert.doesNotMatch(msg, /Parakeet/);
+  assert.doesNotMatch(msg, /Apple Intelligence/);
+  assert.match(msg, /Note: .*transcription engine and AI-polish breakdown/);
+});
+
+test("buildMessage: geoDegraded omits the countries line, not an empty list shown as zero data", () => {
+  const msg = buildMessage("2026-07-08", { ...GOLDEN_DATA, geoDegraded: true }, GOLDEN_BUCKETS);
+  assert.match(msg, /Where they are: temporarily unavailable\./);
+  assert.doesNotMatch(msg, /Germany/);
+  assert.match(msg, /Note: .*where they are/);
+});
+
+test("buildMessage: top5Degraded omits the top-users line", () => {
+  const msg = buildMessage("2026-07-08", { ...GOLDEN_DATA, top5Degraded: true }, GOLDEN_BUCKETS);
+  assert.match(msg, /Top 5 users by dictation volume: temporarily unavailable\./);
+  assert.doesNotMatch(msg, /557, 139/);
+  assert.match(msg, /Note: .*top 5 users/);
+});
+
+test("buildMessage: multiple degraded sections all appear in one combined note", () => {
+  const msg = buildMessage(
+    "2026-07-08",
+    { ...GOLDEN_DATA, installsDegraded: true, geoDegraded: true },
+    GOLDEN_BUCKETS
+  );
+  const noteLine = msg.split("\n").find((l) => l.startsWith("Note:"));
+  assert.ok(noteLine, "expected one combined Note line");
+  assert.match(noteLine, /new installs/);
+  assert.match(noteLine, /where they are/);
+});
+
+test("buildMessage: totals never has a degrade flag - no such branch exists", () => {
+  // totals staying fail-loud means fetchReportData/runReport throw before
+  // buildMessage is ever called with degraded totals data - there is no
+  // totalsDegraded field to test here by design (see fetchReportData tests).
+  const msg = buildMessage("2026-07-08", GOLDEN_DATA, GOLDEN_BUCKETS);
+  assert.doesNotMatch(msg, /Total users: temporarily unavailable/);
 });
 
 // ---- Source-level guardrail: every list-returning query still carries an
@@ -263,7 +346,7 @@ test("runLimited: rejects a non-positive-integer limit", async () => {
   await assert.rejects(() => runLimited([() => Promise.resolve(1)], 0), TypeError);
 });
 
-// ---- hogql retry (#1588 - PostHog project concurrency limit / 504s) ----
+// ---- hogql retry (#1588/#1720 - PostHog project concurrency limit / 5xx / 429) ----
 
 function fakeResponse(status, body, { onCancel } = {}) {
   return {
@@ -274,7 +357,7 @@ function fakeResponse(status, body, { onCancel } = {}) {
   };
 }
 
-test("hogql: retries once on 504 then succeeds, without a real delay", async () => {
+test("hogql: retries on 504, waits within the attempt-2 backoff range, then succeeds", async () => {
   let calls = 0;
   const fetchFn = async () => {
     calls += 1;
@@ -285,10 +368,44 @@ test("hogql: retries once on 504 then succeeds, without a real delay", async () 
   const json = await hogql({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, "SELECT 1", "test_query", {
     fetchFn,
     sleepFn,
+    randomFn: () => 0, // pins the delay to the range floor for a deterministic assertion
   });
   assert.deepEqual(json.results, [[1]]);
   assert.equal(calls, 2);
-  assert.deepEqual(sleeps, [1500]);
+  assert.deepEqual(sleeps, [12_000], "attempt 2's backoff floor is 12s");
+});
+
+test("hogql: retries on 429 (previously threw immediately)", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return calls === 1 ? fakeResponse(429) : fakeResponse(200, { results: [[1]] });
+  };
+  const json = await hogql({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, "SELECT 1", "test_query", {
+    fetchFn,
+    sleepFn: async () => {},
+  });
+  assert.deepEqual(json.results, [[1]]);
+  assert.equal(calls, 2, "429 must be retried, not thrown immediately");
+});
+
+test("hogql: retry delay for attempt 3 falls within the documented 30-45s backoff range", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return calls < 3 ? fakeResponse(503) : fakeResponse(200, { results: [[1]] });
+  };
+  const sleeps = [];
+  const json = await hogql({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, "SELECT 1", "test_query", {
+    fetchFn,
+    sleepFn: async (ms) => sleeps.push(ms),
+    // Math.random() returns [0, 1), never exactly 1 - 0.5 is a realistic
+    // midpoint probe, not an out-of-domain edge value.
+    randomFn: () => 0.5,
+  });
+  assert.deepEqual(json.results, [[1]]);
+  assert.equal(calls, 3);
+  assert.deepEqual(sleeps, [15_000, 37_500], "attempt 2 midpoint is 15s, attempt 3 midpoint is 37.5s");
 });
 
 // Codex code-diff review, round 2 (#1588): an earlier draft of the retry
@@ -324,7 +441,7 @@ test("hogql: does not retry on a non-transient 4xx status", async () => {
   assert.equal(calls, 1, "must not retry a non-transient status");
 });
 
-test("hogql: throws with the query name after exhausting retries on repeated 504", async () => {
+test("hogql: throws with the query name after exhausting all 3 attempts on repeated 504", async () => {
   let calls = 0;
   const fetchFn = async () => {
     calls += 1;
@@ -338,10 +455,45 @@ test("hogql: throws with the query name after exhausting retries on repeated 504
       }),
     /PostHog query engine_and_tier_b HTTP 504/
   );
-  assert.equal(calls, 2, "expected exactly 2 attempts total");
+  assert.equal(calls, 3, "expected exactly 3 attempts total (#1720 raised this from 2)");
 });
 
-// ---- tier-a fail-soft boundary (#1655) ----
+// ---- resolveDevIds (#1720) ----
+
+test("resolveDevIds: accepts hogqlOpts so its own retry path is test-deterministic", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return calls === 1 ? fakeResponse(504) : fakeResponse(200, { results: [["dev-1"]] });
+  };
+  const devIds = await resolveDevIds({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, {
+    fetchFn,
+    sleepFn: async () => {},
+  });
+  assert.deepEqual(devIds, ["dev-1"]);
+  assert.equal(calls, 2, "resolveDevIds' own hogql call retries like any other query");
+});
+
+test("resolveDevIds: throws on overflow rather than silently building a truncated exclusion list", async () => {
+  // PER_USER_LIST_LIMIT is 5000; simulate a result over that ceiling via the
+  // LIMIT+1 query shape - the fetchFn doesn't need to know the real limit,
+  // it just needs to return more than 5000 rows.
+  const overflowRows = Array.from({ length: 5001 }, (_, i) => [`dev-${i}`]);
+  const fetchFn = async () => fakeResponse(200, { results: overflowRows });
+  await assert.rejects(
+    () => resolveDevIds({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, { fetchFn }),
+    /dev-id completeness check failed/,
+    "must fail loud on overflow, never silently truncate"
+  );
+});
+
+test("resolveDevIds: an empty result is a valid, non-throwing state", async () => {
+  const fetchFn = async () => fakeResponse(200, { results: [] });
+  const devIds = await resolveDevIds({ POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" }, { fetchFn });
+  assert.deepEqual(devIds, []);
+});
+
+// ---- fail-soft boundary: tier-a (#1655) and all 6 primary queries (#1720) ----
 //
 // These MUST drive fetchReportData, not hogql in isolation: the defect they
 // guard against (a blanket catch silently swallowing real errors) lives in
@@ -350,18 +502,38 @@ test("hogql: throws with the query name after exhausting retries on repeated 504
 // fetchFn, so the mock is installed on globalThis.fetch and dispatches on the
 // query name the worker puts in the request body.
 
-/** Installs a global fetch that lets every batch query succeed and lets the
- * caller decide what tier-a (or a named other query) does. Returns a restore fn. */
+/** Installs a global fetch that lets every batch query (including the new
+ * dev_ids preflight) succeed and lets the caller decide what one named query
+ * does. Also transparently succeeds any non-PostHog call (the Discord
+ * webhook POST runReport makes after a successful report - its body is
+ * `{content}`, with no `.name` field, unlike every hogql() request body) so
+ * tests can drive runReport end-to-end, not just fetchReportData. Returns a
+ * restore fn. */
 function mockPostHog({ failQuery, failWith }) {
   const realFetch = globalThis.fetch;
   const seen = [];
   globalThis.fetch = async (_url, init) => {
-    const name = JSON.parse(init.body).name; // "daily_report_<queryName>"
-    const queryName = name.replace(/^daily_report_/, "");
+    const body = init?.body ? JSON.parse(init.body) : {};
+    if (!body.name) {
+      return fakeResponse(204); // Discord webhook success shape, not a PostHog call
+    }
+    const queryName = body.name.replace(/^daily_report_/, "");
     seen.push(queryName);
     if (queryName === failQuery) {
       if (failWith instanceof Error) throw failWith;
       return fakeResponse(failWith);
+    }
+    // dev_ids: empty list is the common, valid case - keeps every downstream
+    // query's ${prod} predicate as plain ENV_ONLY in these tests.
+    if (queryName === "dev_ids") {
+      return fakeResponse(200, { results: [] });
+    }
+    // totals' total_users must match engine_and_tier_b's row count (1, "u1"),
+    // or resolveBuckets' completeness check throws on tests that chain all
+    // the way through runReport - the generic fallback below returns an
+    // unrelated {c: 0} shape that would falsely trip that check.
+    if (queryName === "totals") {
+      return fakeResponse(200, { results: [[42, 1]], columns: ["net_dictations", "total_users"] });
     }
     // engine_and_tier_b must return a non-empty id list, or tier-a is skipped
     // entirely and the degrade path is never reached.
@@ -439,31 +611,137 @@ test("tier-a: an ordinary Error still throws (no silent swallow)", async () => {
   }
 });
 
-test("a failure in a query OTHER than tier-a still fails the whole report", async () => {
+test("totals: an exhausted 504 still fails the whole report - the sole fail-loud primary query", async () => {
   const mock = mockPostHog({ failQuery: "totals", failWith: 504 });
   try {
     await assert.rejects(
       () => fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} }),
       /PostHog query totals HTTP 504/,
-      "fail-soft is scoped to tier-a only"
+      "totals must never degrade - it anchors resolveBuckets' completeness check"
     );
   } finally {
     mock.restore();
   }
 });
 
-test("a clean run leaves tierADegraded false", async () => {
-  const mock = mockPostHog({ failQuery: null });
+test("resolveDevIds: an exhausted 504 fails the whole report, never silently treated as 'no dev ids'", async () => {
+  const mock = mockPostHog({ failQuery: "dev_ids", failWith: 504 });
   try {
-    const data = await fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} });
-    assert.equal(data.tierADegraded, false);
-    assert.equal(data.tierA.length, 1);
+    await assert.rejects(
+      () => fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} }),
+      /PostHog query dev_ids HTTP 504/
+    );
   } finally {
     mock.restore();
   }
 });
 
-// ---- degraded note placement (#1655) ----
+test("a clean run leaves tierADegraded false and every other degraded flag false", async () => {
+  const mock = mockPostHog({ failQuery: null });
+  try {
+    const data = await fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} });
+    assert.equal(data.tierADegraded, false);
+    assert.equal(data.tierA.length, 1);
+    for (const key of ["installsDegraded", "onboardActivateDegraded", "engineAndTierBDegraded", "geoDegraded", "top5Degraded"]) {
+      assert.equal(data[key], false, `expected ${key} to be false on a clean run`);
+    }
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---- fail-soft: the 5 non-essential primary queries individually (#1720) ----
+
+for (const queryName of ["installs", "onboard_activate", "engine_and_tier_b", "geo", "top5"]) {
+  test(`${queryName}: an exhausted 504 degrades that section instead of failing the whole report`, async () => {
+    const mock = mockPostHog({ failQuery: queryName, failWith: 504 });
+    try {
+      const data = await fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} });
+      const degradedKey = {
+        installs: "installsDegraded",
+        onboard_activate: "onboardActivateDegraded",
+        engine_and_tier_b: "engineAndTierBDegraded",
+        geo: "geoDegraded",
+        top5: "top5Degraded",
+      }[queryName];
+      assert.equal(data[degradedKey], true, `expected ${degradedKey} to be true`);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  test(`${queryName}: a NON-retryable failure (401) still throws, no silent swallow`, async () => {
+    const mock = mockPostHog({ failQuery: queryName, failWith: 401 });
+    try {
+      await assert.rejects(
+        () => fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} }),
+        (err) => err instanceof PostHogQueryError && err.status === 401
+      );
+    } finally {
+      mock.restore();
+    }
+  });
+}
+
+test("engineAndTierBDegraded also empties activeIds, so tier_a is naturally skipped (not separately queried)", async () => {
+  const mock = mockPostHog({ failQuery: "engine_and_tier_b", failWith: 504 });
+  try {
+    const data = await fetchReportData(TEST_ENV, TEST_WIN, TEST_END, { sleepFn: async () => {} });
+    assert.equal(data.engineAndTierBDegraded, true);
+    assert.deepEqual(data.engineAndTierB, []);
+    assert.equal(data.tierADegraded, false, "tier_a was never attempted, so it is not itself degraded");
+    assert.ok(!mock.seen.includes("tier_a"), "tier_a must not be queried when there are no active ids to enrich");
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---- runReport: engineAndTierBDegraded skips resolveBuckets entirely (#1720) ----
+//
+// Proven via an injected/spied deps.resolveBuckets, not just output
+// inspection - a test asserting only on runReport's return value can't
+// distinguish "resolveBuckets ran and happened to produce empty buckets"
+// from "resolveBuckets was never called." deps.hogqlOpts is also injected so
+// the exhausted-retry path here doesn't sit through real backoff delays.
+
+test("runReport: engineAndTierBDegraded means resolveBuckets is never called, and the report still renders", async () => {
+  const mock = mockPostHog({ failQuery: "engine_and_tier_b", failWith: 504 });
+  let resolveBucketsCalls = 0;
+  const spyResolveBuckets = (data) => {
+    resolveBucketsCalls += 1;
+    return resolveBuckets(data);
+  };
+  try {
+    const message = await runReport(TEST_ENV, "2026-07-17", {
+      resolveBuckets: spyResolveBuckets,
+      hogqlOpts: { sleepFn: async () => {} },
+    });
+    assert.equal(resolveBucketsCalls, 0, "resolveBuckets must not be called when engineAndTierB degraded");
+    assert.match(message, /Transcription engine and AI-polish breakdown: temporarily unavailable\./);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("runReport: a clean run DOES call resolveBuckets (the spy is a real trigger, not always-skipped)", async () => {
+  const mock = mockPostHog({ failQuery: null });
+  let resolveBucketsCalls = 0;
+  const spyResolveBuckets = (data) => {
+    resolveBucketsCalls += 1;
+    return resolveBuckets(data);
+  };
+  try {
+    await runReport(TEST_ENV, "2026-07-17", {
+      resolveBuckets: spyResolveBuckets,
+      hogqlOpts: { sleepFn: async () => {} },
+    });
+    assert.equal(resolveBucketsCalls, 1, "expected resolveBuckets to run exactly once on a clean report");
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---- degraded note placement (#1655/#1720) ----
 
 test("degraded note appears near the top, above the truncation point", () => {
   // A long report: enough geo/top5 volume to push the tail past the 1990-char
@@ -484,26 +762,29 @@ test("degraded note appears near the top, above the truncation point", () => {
 test("no degraded note on a clean run", () => {
   const msg = buildMessage("2026-07-17", { ...GOLDEN_DATA, tierADegraded: false }, GOLDEN_BUCKETS);
   assert.doesNotMatch(msg, /approximate/);
+  assert.doesNotMatch(msg, /^Note:/m);
 });
 
-// ---- load-bearing coupling guard (#1655) ----
+// ---- load-bearing coupling guards ----
 //
-// tier-a may omit PROD's dev-ID exclusion ONLY because activeIds already came
-// from a full-PROD query. If a future edit breaks that coupling, the omission
-// silently becomes a correctness bug rather than a redundancy removal.
+// tier-a and activeUsersSubquery may each omit the whole-history dev-ID
+// exclusion ONLY because the population they're tested against was already
+// filtered by the report's shared `${prod}` predicate elsewhere. If a future
+// edit breaks that coupling, the omission silently becomes a correctness
+// bug rather than a redundancy removal.
 
-test("source guardrail: tier-a may omit dev exclusion only while active ids come from full PROD", async () => {
+test("source guardrail: tier-a may omit dev exclusion only while active ids come from the full production predicate", async () => {
   const fs = await import("node:fs");
   const src = fs.readFileSync(new URL("../src/index.js", import.meta.url), "utf8");
 
   const engineQuery = src.match(/const engineAndTierBSql = `([\s\S]*?)`;/)?.[1];
   assert.ok(engineQuery, "expected engineAndTierBSql");
-  assert.match(engineQuery, /\$\{PROD\}/);
+  assert.match(engineQuery, /\$\{prod\}/);
 
   const tierAFunction = src.match(/function tierASqlFor\([\s\S]*?\n}\n/)?.[0];
   assert.ok(tierAFunction, "expected tierASqlFor");
   assert.match(tierAFunction, /\$\{ENV_ONLY\}/);
-  assert.doesNotMatch(tierAFunction, /\$\{PROD\}/);
+  assert.doesNotMatch(tierAFunction, /\$\{prod\}/);
   assert.equal(
     (tierAFunction.match(/distinct_id IN \(\$\{ids\}\)/g) || []).length,
     2,
@@ -511,28 +792,57 @@ test("source guardrail: tier-a may omit dev exclusion only while active ids come
   );
 });
 
-// ---- load-bearing coupling guard (#1716, sibling of #1655's tier-a guard) ----
-//
-// activeUsersSubquery may omit PROD's dev-ID exclusion ONLY because every id
-// it is tested against inside onboardActivateSql already came from that
-// query's own full-PROD outer WHERE. If a future edit drops onboardActivateSql's
-// outer ${PROD}, or reuses activeUsersSubquery from a caller that doesn't
-// pre-filter the same way, the omission silently becomes a correctness bug.
-
-test("source guardrail: onboard-activate's active-user lookup may omit dev exclusion only while its own outer WHERE keeps full PROD", async () => {
+test("source guardrail: onboard-activate's active-user lookup may omit dev exclusion only while its own outer WHERE keeps the full predicate", async () => {
   const fs = await import("node:fs");
   const src = fs.readFileSync(new URL("../src/index.js", import.meta.url), "utf8");
 
   const activeUsersFunction = src.match(/function activeUsersSubquery\([\s\S]*?\n}\n/)?.[0];
   assert.ok(activeUsersFunction, "expected activeUsersSubquery");
   assert.match(activeUsersFunction, /\$\{ENV_ONLY\}/);
-  assert.doesNotMatch(activeUsersFunction, /\$\{PROD\}/);
+  assert.doesNotMatch(activeUsersFunction, /\$\{prod\}/);
 
   const onboardActivateQuery = src.match(/const onboardActivateSql = `([\s\S]*?)`;/)?.[1];
   assert.ok(onboardActivateQuery, "expected onboardActivateSql");
   assert.match(
     onboardActivateQuery,
-    /WHERE event = 'onboarding\.completed' AND \$\{PROD\} AND \$\{win\}/,
-    "the outer onboarding.completed filter must keep full PROD - activeUsersSubquery's env-only shortcut depends on it"
+    /WHERE event = 'onboarding\.completed' AND \$\{prod\} AND \$\{win\}/,
+    "the outer onboarding.completed filter must keep the full production predicate - activeUsersSubquery's env-only shortcut depends on it"
   );
+});
+
+test("source guardrail: all 6 primary *Sql builders reference the shared ${prod} predicate, none re-embeds a raw dev-exclusion subquery", async () => {
+  const fs = await import("node:fs");
+  const src = fs.readFileSync(new URL("../src/index.js", import.meta.url), "utf8");
+
+  for (const name of ["installsSql", "onboardActivateSql", "totalsSql", "engineAndTierBSql", "geoSql", "top5Sql"]) {
+    const query = src.match(new RegExp(`const ${name} = \`([\\s\\S]*?)\`;`))?.[1];
+    assert.ok(query, `expected ${name}`);
+    assert.match(query, /\$\{prod\}/, `${name} must reference the shared \${prod} predicate`);
+    assert.doesNotMatch(
+      query,
+      /app_version LIKE/,
+      `${name} must not re-embed the raw dev-exclusion subquery inline`
+    );
+  }
+});
+
+// ---- worst-case fetch-count bound (#1720, R1/R4 corrections) ----
+//
+// This worker is invoked via an incoming HTTP fetch (no Cloudflare hard
+// wall-time limit for that invocation type); the real caps are total
+// subrequests (50) and concurrent subrequests (6) per incoming request.
+// This test locks the arithmetic, not a wall-clock duration.
+
+test("worst-case explicit fetch count stays under Cloudflare's 50-subrequest cap", () => {
+  const PRIMARY_QUERIES = 6; // installs, onboard_activate, totals, engine_and_tier_b, geo, top5
+  const PREFLIGHT_QUERIES = 1; // resolveDevIds
+  const CONDITIONAL_QUERIES = 1; // tier_a, only when activeIds is non-empty
+  const MAX_ATTEMPTS_PER_QUERY = 3; // #1720 raised this from 2
+  const DISCORD_POSTS = 1;
+
+  const worstCase =
+    (PRIMARY_QUERIES + PREFLIGHT_QUERIES + CONDITIONAL_QUERIES) * MAX_ATTEMPTS_PER_QUERY + DISCORD_POSTS;
+
+  assert.equal(worstCase, 25);
+  assert.ok(worstCase < 50, "worst-case fetch count must stay under Cloudflare's 50-subrequest-per-request cap");
 });


### PR DESCRIPTION
Fixes #1720.

Three failures in four days (#1588, #1655, #1716) were each fixed as an isolated query-shape bug. This treats the underlying architecture problem instead of finding one more instance.

## Root cause

PostHog's documented limits (verified against PostHog's own docs via context7, not assumed): 3 concurrent queries, 10-second max execution time, 30-second max queue wait, 429 = concurrency-limit-reached (distinct from 502/503/504). Every one of this worker's 6 primary queries independently re-scanned the same whole-history "is this a dev account" filter, pushing several right up against the 10-second execution ceiling - which is why a *different* query failed each time, not the same one.

## Fix

1. **Resolve the dev-account exclusion list once per report run** (`resolveDevIds` + `productionClauseFor`), threaded through all 6 primary queries, replacing the per-query inline subquery.
2. **Retry policy**: 3 attempts (was 2), randomized 12-18s / 30-45s backoff (was a fixed 1.5s), and 429 added to the retryable set (was not retried at all).
3. **5 of 6 primary queries degrade instead of failing the whole report** on an exhausted transient failure - `totals` stays the sole fail-loud query since it anchors `resolveBuckets`' completeness check. `engineAndTierB` degrading skips `tier_a` and `resolveBuckets` entirely rather than crashing on an empty-data completeness mismatch.
4. **GitHub Actions concurrency guard** (`cancel-in-progress: false` + `queue: max`) on `daily-report-ping.yml`, so a queued manual recovery run can't be silently dropped by the next scheduled cron.

## Process

Plan went through 6 rounds of Codex grounded review before any code was written (declining findings: 3, 3, 2, 2, 1, 0 - clean PROCEED-AS-PLANNED). Real bugs it caught: an invalid empty-list SQL case, a "fail loud" promise that would have silently continued past its own overflow ceiling, a fail-soft path that would have still crashed the report it was meant to save, and the concurrency guard's own silent-drop bug. Full plan + all 6 audit transcripts: `docs/feature-requests/issue-1720-2026-07-20-daily-report-reliability-hardening.md` (gitignored, local only).

Local Codex code-diff review, round 1, found two real issues (both fixed): the pre-deploy live smoke check would have printed "Smoke OK" even if a section quietly degraded during the check itself; and flagged `queue: max` as invalid YAML. The second was investigated and rejected with evidence, not reverted - `actionlint` v1.7.12 (latest release, already installed) simply predates this GitHub Actions feature. Verified independently against the community-maintained `schemastore.org/github-workflow.json` schema (documents `queue: single|max`, cites live docs.github.com) and against context7's GitHub Actions docs. Round 2: clean, no findings.

## Test plan
- [x] `node --test` in `workers/daily-report/` - 63/63 pass
- [x] `live-query-smoke.mjs` against real production PostHog - identical numbers to every prior manual run of the same day's data; one run hit a real transient PostHog 504 (likely self-inflicted from this session's own heavy testing) and the new fail-loud behavior caught it cleanly and correctly - a second, spaced-out run succeeded
- [x] `actionlint` clean except the one documented, evidenced false positive
- [x] Local Codex code-diff review - clean (2 rounds)
- [ ] Deploy + live verify after merge, per README - founder deploy permission already granted this session for this worker