### PR TITLE
fix(worker): daily report says "that day" instead of "today"

### DIFF
--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -183,8 +183,9 @@ Two independent signals, matching `workers/product-health`'s posture:
    primary queries — `installs`, `onboard_activate`, `engineAndTierB`, `geo`,
    `top5` — can each independently degrade on an exhausted transient PostHog
    status (429/502/503/504). `tier_a` degrading still yields a full report
-   with a near-top note ("today's polish-provider breakdown is approximate
-   because the settings lookup was temporarily unavailable"), because
+   with a near-top note ("the polish-provider breakdown is approximate
+   because the settings lookup was temporarily unavailable when this report
+   ran"), because
    `resolveBuckets` already falls back per user (settings → actual dictation
    → shipped default). The other 5 have no such fallback data — a degraded
    section is OMITTED with inline "temporarily unavailable" wording in its

--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -621,11 +621,11 @@ export function buildMessage(dateStr, data, buckets) {
   // section (#1720).
   const notes = [];
   if (data.tierADegraded) {
-    notes.push("today's polish-provider breakdown is approximate because the settings lookup was temporarily unavailable");
+    notes.push("the polish-provider breakdown is approximate because the settings lookup was temporarily unavailable when this report ran");
   }
   const degradedSections = DEGRADED_SECTION_LABELS.filter(([key]) => data[key]).map(([, label]) => label);
   if (degradedSections.length) {
-    notes.push(`some sections were temporarily unavailable today: ${degradedSections.join(", ")}`);
+    notes.push(`some sections were temporarily unavailable when this report ran: ${degradedSections.join(", ")}`);
   }
   if (notes.length) {
     lines.push(`Note: ${notes.join("; ")}.`, "");
@@ -636,10 +636,10 @@ export function buildMessage(dateStr, data, buckets) {
     : `New installs: ${data.freshInstalls}.`;
   const onboardPart = data.onboardActivateDegraded
     ? "Onboarding and activation: temporarily unavailable."
-    : `People who finished setup today: ${data.onboarded}. Of those, ${data.activated} also dictated today.`;
+    : `People who finished setup that day: ${data.onboarded}. Of those, ${data.activated} also dictated that day.`;
   lines.push(`${installsPart} ${onboardPart}`, "");
 
-  lines.push(`Total users: ${data.totalUsers} people used the app today.`, "");
+  lines.push(`Total users: ${data.totalUsers} people used the app that day.`, "");
 
   if (data.engineAndTierBDegraded) {
     lines.push("Transcription engine and AI-polish breakdown: temporarily unavailable.", "");

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -177,10 +177,10 @@ test("buildMessage: golden fixture matches the founder-approved report shape", (
   const msg = buildMessage("2026-07-08", GOLDEN_DATA, GOLDEN_BUCKETS);
 
   assert.match(msg, /^EnviousWispr Daily Report, Wednesday, July 8, 2026/);
-  assert.match(msg, /New installs: 90\. People who finished setup today: 82\. Of those, 60 also dictated today\./);
+  assert.match(msg, /New installs: 90\. People who finished setup that day: 82\. Of those, 60 also dictated that day\./);
   assert.doesNotMatch(msg, /for the first time/);
   assert.doesNotMatch(msg, /out of 90/); // no funnel-bleed wording (r1 fix)
-  assert.match(msg, /Total users: 110 people used the app today\./);
+  assert.match(msg, /Total users: 110 people used the app that day\./);
   // Percentages are against total_users (110), not net_dictations (1868).
   assert.match(msg, /Parakeet 100 \(91%\)/);
   assert.match(msg, /WhisperKit 10 \(9%\)/);
@@ -208,7 +208,7 @@ test("buildMessage: zero total_users omits the engine/polish section entirely (n
   const msg = buildMessage("2026-07-08", { ...GOLDEN_DATA, totalUsers: 0 }, { engineBuckets: {}, polishBuckets: {} });
   assert.doesNotMatch(msg, /Transcription engine/);
   assert.doesNotMatch(msg, /AI polishing/);
-  assert.match(msg, /Total users: 0 people used the app today\./);
+  assert.match(msg, /Total users: 0 people used the app that day\./);
 });
 
 // ---- buildMessage: per-section fail-soft degradation (#1720) ----
@@ -222,7 +222,7 @@ test("buildMessage: installsDegraded omits the freshInstalls number, keeps onboa
   const msg = buildMessage("2026-07-08", { ...GOLDEN_DATA, installsDegraded: true }, GOLDEN_BUCKETS);
   assert.match(msg, /New installs: temporarily unavailable\./);
   assert.doesNotMatch(msg, /New installs: 90/);
-  assert.match(msg, /People who finished setup today: 82\. Of those, 60 also dictated today\./);
+  assert.match(msg, /People who finished setup that day: 82\. Of those, 60 also dictated that day\./);
   assert.match(msg, /Note: .*new installs/);
 });
 
@@ -230,7 +230,7 @@ test("buildMessage: onboardActivateDegraded omits onboarding, keeps installs int
   const msg = buildMessage("2026-07-08", { ...GOLDEN_DATA, onboardActivateDegraded: true }, GOLDEN_BUCKETS);
   assert.match(msg, /New installs: 90\./);
   assert.match(msg, /Onboarding and activation: temporarily unavailable\./);
-  assert.doesNotMatch(msg, /People who finished setup today/);
+  assert.doesNotMatch(msg, /People who finished setup that day/);
   assert.match(msg, /Note: .*onboarding\/activation/);
 });
 
@@ -755,7 +755,7 @@ test("degraded note appears near the top, above the truncation point", () => {
 
   assert.match(msg, /polish-provider breakdown is approximate/);
   assert.ok(msg.length <= 1990, "message must respect the Discord cap");
-  const noteIndex = msg.indexOf("Note: today's polish-provider breakdown");
+  const noteIndex = msg.indexOf("Note: the polish-provider breakdown is approximate");
   assert.ok(noteIndex >= 0 && noteIndex < 200, `note must be near the top, was at ${noteIndex}`);
 });
 


### PR DESCRIPTION
## What

The daily report body said "today" in five places, even though it always covers the PRIOR Eastern calendar day (or a past `?date=` recovery override). The message header already prints the correct real date, so a report landing the next morning read as same-day data when it was not.

Changed the five reporting-date references to "that day". Left the two outage-notice strings (tier-a settings-lookup degrade, combined degraded-sections note) with report-generation-time wording instead, since those describe a PostHog query failing while the report is running, not something about the historical date — caught by local Codex review round 1, fixed in round 2.

## Test plan

- [x] `node --test` — 63/63 pass
- [x] Local Codex code-diff review clean (round 2, after round 1 caught the outage-timing wording issue)
- [x] `grep -rn "today" workers/daily-report/` returns zero hits
