### PR TITLE
feat(pipeline): Phase 2 recovery — one live post-capture ASR decode retry (#1707)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -691,6 +691,22 @@ public final class ASRManagerProxy: ASRManagerInterface {
         }
       }
     }
+
+    /// Clears all armed/held state (`ParakeetBackend.clearBatchDecodeFault`,
+    /// across XPC), so a forgotten trial from one Live UAT scenario cannot
+    /// leak into the next.
+    package func clearBatchDecodeFault() async {
+      try? await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+        let guard_ = OneShotContinuationASR(cont)
+        serviceProxy { proxy in
+          proxy.clearBatchDecodeFault {
+            guard_.resume(returning: ())
+          }
+        } onProxyError: {
+          guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
+        }
+      }
+    }
   #endif
 
   // MARK: - XPC Connection

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -649,6 +649,48 @@ public final class ASRManagerProxy: ASRManagerInterface {
     package func forceConnectionTerminationNow() {
       connection?.invalidate()
     }
+
+    // MARK: - #1707 Phase 2: batch-decode fault oracle (shared-backend
+    // overlap Live UAT, §3.2a-i). Copies `transcribe(audioSamples:options:)`'s
+    // FULL existing XPC pattern (`:420-434`) — the same `OneShotContinuationASR`
+    // resume-once guard and `onProxyError` handling, so arm/release cannot
+    // leave a continuation suspended when the connection is missing or dies.
+    // Best-effort: a missing connection silently no-ops (`try?`) rather than
+    // throwing — a Live UAT scenario observes whether the arm actually landed
+    // via the shared snapshot file / the held decode's own behavior, not via
+    // this call's return.
+
+    /// Arms a one-shot hold on the NEXT `transcribeSamples` call's real
+    /// decode (`ParakeetBackend.armBatchDecodeHold`, across XPC). Awaits the
+    /// FULL round trip before returning — the acknowledged-arm barrier
+    /// `BatchDecodeFaultController` depends on.
+    package func armBatchDecodeHold(trialID: String) async {
+      try? await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+        let guard_ = OneShotContinuationASR(cont)
+        serviceProxy { proxy in
+          proxy.armBatchDecodeHold(trialID: trialID) {
+            guard_.resume(returning: ())
+          }
+        } onProxyError: {
+          guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
+        }
+      }
+    }
+
+    /// Releases a previously-armed hold (`ParakeetBackend.releaseBatchDecode`,
+    /// across XPC), letting the held decode proceed.
+    package func releaseBatchDecode(trialID: String) async {
+      try? await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+        let guard_ = OneShotContinuationASR(cont)
+        serviceProxy { proxy in
+          proxy.releaseBatchDecode(trialID: trialID) {
+            guard_.resume(returning: ())
+          }
+        } onProxyError: {
+          guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
+        }
+      }
+    }
   #endif
 
   // MARK: - XPC Connection

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -147,6 +147,16 @@ public actor ParakeetBackend: ASRBackend {
     // `source:` parameter is gone. Language hint intentionally NOT passed in PR-2
     // (parity with the d5fcca4 behavior); G7 language propagation ships in PR-4.
     var decoderState = TdtDecoderState.make(decoderLayers: await manager.decoderLayerCount)
+    #if DEBUG
+      // #1707 Phase 2: the real shared-engine call boundary for the overlap
+      // Live UAT oracle (§3.2a-i) — `defer` closes the interval on every
+      // exit (success or either catch), and the entry suspension (if this
+      // call is the classified "held" one) happens BEFORE the real call, so
+      // a genuinely NEW session's decode can reach and enter this SAME
+      // boundary while the first is suspended here.
+      let batchDecodeFaultRole = await enterBatchDecodeFaultBoundary()
+      defer { exitBatchDecodeFaultBoundary(role: batchDecodeFaultRole) }
+    #endif
     do {
       let fluidResult = try await manager.transcribe(audioSamples, decoderState: &decoderState)
       let elapsed = CFAbsoluteTimeGetCurrent() - startTime
@@ -246,4 +256,109 @@ public actor ParakeetBackend: ASRBackend {
     fluidModels = nil
     isReady = false
   }
+
+  #if DEBUG
+    // MARK: #1707 Phase 2 — batch-decode fault oracle (shared-backend overlap
+    // Live UAT, §3.2a-i). One armed trial at a time by construction (a DEBUG
+    // test seam, never a concurrent-scenario primitive). The first real
+    // `transcribe(...)` call after arming is classified `held` (suspends
+    // until released); a SECOND call arriving while the trial is still
+    // active is classified `newSession` (records timestamps, does not
+    // suspend) — this is what lets a Live UAT test prove genuine overlap at
+    // the real shared-engine boundary.
+
+    private enum BatchDecodeFaultRole {
+      case none
+      case held(trialID: String)
+      case newSession(trialID: String)
+    }
+
+    private var armedBatchDecodeTrialID: String?
+    private var batchDecodeHeldClassified = false
+    private var batchDecodeHoldContinuation: CheckedContinuation<Void, Never>?
+
+    /// A forgotten release cannot wedge the ASR service process — bounded by
+    /// this safety unhold, well past any realistic Live UAT test duration.
+    private static let batchDecodeFaultSafetyUnholdSec: Double = 30.0
+
+    /// Arms a one-shot hold for the NEXT `manager.transcribe(...)` call this
+    /// actor issues. `package` access: callable from `ASRServiceHandler` in
+    /// the sibling `EnviousWisprASRService` target (same package,
+    /// `Package.swift`), mirroring `ASRManagerProxy`'s existing `package`
+    /// DEBUG methods.
+    package func armBatchDecodeHold(trialID: String) {
+      armedBatchDecodeTrialID = trialID
+      batchDecodeHeldClassified = false
+      BatchDecodeFaultSnapshotFile.shared.write(BatchDecodeFaultSnapshotState(trialID: trialID))
+    }
+
+    /// Releases a held decode, letting it proceed to the real
+    /// `manager.transcribe(...)` call. No-op if `trialID` does not match the
+    /// currently-armed trial or nothing is currently held.
+    package func releaseBatchDecode(trialID: String) {
+      guard armedBatchDecodeTrialID == trialID else { return }
+      batchDecodeHoldContinuation?.resume()
+      batchDecodeHoldContinuation = nil
+    }
+
+    /// Clears all armed/held state and the shared snapshot file, so a
+    /// forgotten trial from one Live UAT scenario cannot leak into the next.
+    package func clearBatchDecodeFault() {
+      batchDecodeHoldContinuation?.resume()
+      batchDecodeHoldContinuation = nil
+      armedBatchDecodeTrialID = nil
+      batchDecodeHeldClassified = false
+      BatchDecodeFaultSnapshotFile.shared.clear()
+    }
+
+    private func enterBatchDecodeFaultBoundary() async -> BatchDecodeFaultRole {
+      guard let trialID = armedBatchDecodeTrialID else { return .none }
+      let now = Date().timeIntervalSince1970
+      var snapshot =
+        BatchDecodeFaultSnapshotFile.shared.read().flatMap { $0.trialID == trialID ? $0 : nil }
+        ?? BatchDecodeFaultSnapshotState(trialID: trialID)
+      guard !batchDecodeHeldClassified else {
+        snapshot.newSessionEntryEpochSec = now
+        BatchDecodeFaultSnapshotFile.shared.write(snapshot)
+        return .newSession(trialID: trialID)
+      }
+      batchDecodeHeldClassified = true
+      snapshot.heldDecodeEntryEpochSec = now
+      BatchDecodeFaultSnapshotFile.shared.write(snapshot)
+      await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+        batchDecodeHoldContinuation = cont
+        Task { [weak self] in
+          try? await Task.sleep(for: .seconds(Self.batchDecodeFaultSafetyUnholdSec))
+          await self?.autoReleaseBatchDecodeHoldIfStillHeld(trialID: trialID)
+        }
+      }
+      return .held(trialID: trialID)
+    }
+
+    private func exitBatchDecodeFaultBoundary(role: BatchDecodeFaultRole) {
+      let now = Date().timeIntervalSince1970
+      switch role {
+      case .none:
+        return
+      case .held(let trialID):
+        guard var snapshot = BatchDecodeFaultSnapshotFile.shared.read(),
+          snapshot.trialID == trialID
+        else { return }
+        snapshot.heldDecodeCompletionEpochSec = now
+        BatchDecodeFaultSnapshotFile.shared.write(snapshot)
+      case .newSession(let trialID):
+        guard var snapshot = BatchDecodeFaultSnapshotFile.shared.read(),
+          snapshot.trialID == trialID
+        else { return }
+        snapshot.newSessionCompletionEpochSec = now
+        BatchDecodeFaultSnapshotFile.shared.write(snapshot)
+      }
+    }
+
+    private func autoReleaseBatchDecodeHoldIfStillHeld(trialID: String) {
+      guard armedBatchDecodeTrialID == trialID, batchDecodeHoldContinuation != nil else { return }
+      batchDecodeHoldContinuation?.resume()
+      batchDecodeHoldContinuation = nil
+    }
+  #endif
 }

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -490,6 +490,17 @@ public actor WhisperKitBackend: ASRBackend {
     let decodeOptions = makeDecodeOptions(from: options, sampleCount: paddedSamples.count)
     let startTime = CFAbsoluteTimeGetCurrent()
     let results: [TranscriptionResult]
+    #if DEBUG
+      // #1707 Phase 2: the real shared-engine call boundary for the overlap
+      // Live UAT oracle (§3.2a-i) — `defer` closes the interval on every
+      // exit. Because `WhisperKitBackend` is an actor, suspending at this
+      // exact point (BEFORE the real call) is what lets a SECOND
+      // `transcribe()` call reach this SAME point and proceed to ITS OWN
+      // real `kit.transcribe()` call while the first is held — the actual
+      // actor-reentrancy question this oracle exists to exercise.
+      let batchDecodeFaultRole = await enterBatchDecodeFaultBoundary()
+      defer { exitBatchDecodeFaultBoundary(role: batchDecodeFaultRole) }
+    #endif
     do {
       // TODO(#827): watchdog needs a decoder-step or token/segment progress
       // callback owned by WhisperKit; cancellation depends on this await
@@ -741,4 +752,102 @@ public actor WhisperKitBackend: ASRBackend {
       backendType: .whisperKit
     )
   }
+
+  #if DEBUG
+    // MARK: #1707 Phase 2 — batch-decode fault oracle (shared-backend overlap
+    // Live UAT, §3.2a-i). One armed trial at a time by construction (a DEBUG
+    // test seam, never a concurrent-scenario primitive). Mirrors
+    // `ParakeetBackend`'s identically-shaped seam; unlike Parakeet, this
+    // actor is in-process, so `queryBatchDecodeFault` returns state directly
+    // — no cross-process file needed (`BatchDecodeFaultController` holds a
+    // direct reference to this actor).
+
+    private enum BatchDecodeFaultRole {
+      case none
+      case held(trialID: String)
+      case newSession(trialID: String)
+    }
+
+    private var armedBatchDecodeTrialID: String?
+    private var batchDecodeHeldClassified = false
+    private var batchDecodeHoldContinuation: CheckedContinuation<Void, Never>?
+    private var batchDecodeSnapshot: BatchDecodeFaultSnapshotState?
+
+    /// A forgotten release cannot wedge this actor — bounded by this safety
+    /// unhold, well past any realistic Live UAT test duration.
+    private static let batchDecodeFaultSafetyUnholdSec: Double = 30.0
+
+    /// Arms a one-shot hold for the NEXT `transcribe(...)` call this actor
+    /// issues. `package` access: callable from `BatchDecodeFaultController`
+    /// in `EnviousWisprPipeline` (same package, `Package.swift`).
+    package func armBatchDecodeHold(trialID: String) {
+      armedBatchDecodeTrialID = trialID
+      batchDecodeHeldClassified = false
+      batchDecodeSnapshot = BatchDecodeFaultSnapshotState(trialID: trialID)
+    }
+
+    /// Releases a held decode, letting it proceed to the real
+    /// `kit.transcribe(...)` call. No-op if `trialID` does not match the
+    /// currently-armed trial or nothing is currently held.
+    package func releaseBatchDecode(trialID: String) {
+      guard armedBatchDecodeTrialID == trialID else { return }
+      batchDecodeHoldContinuation?.resume()
+      batchDecodeHoldContinuation = nil
+    }
+
+    /// Clears all armed/held state so a forgotten trial from one Live UAT
+    /// scenario cannot leak into the next.
+    package func clearBatchDecodeFault() {
+      batchDecodeHoldContinuation?.resume()
+      batchDecodeHoldContinuation = nil
+      armedBatchDecodeTrialID = nil
+      batchDecodeHeldClassified = false
+      batchDecodeSnapshot = nil
+    }
+
+    /// Returns the current backend-side snapshot for `trialID`, or `nil` if
+    /// it does not match the currently/most-recently armed trial.
+    package func queryBatchDecodeFault(trialID: String) -> BatchDecodeFaultSnapshotState? {
+      batchDecodeSnapshot.flatMap { $0.trialID == trialID ? $0 : nil }
+    }
+
+    private func enterBatchDecodeFaultBoundary() async -> BatchDecodeFaultRole {
+      guard let trialID = armedBatchDecodeTrialID else { return .none }
+      let now = Date().timeIntervalSince1970
+      guard !batchDecodeHeldClassified else {
+        batchDecodeSnapshot?.newSessionEntryEpochSec = now
+        return .newSession(trialID: trialID)
+      }
+      batchDecodeHeldClassified = true
+      batchDecodeSnapshot?.heldDecodeEntryEpochSec = now
+      await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+        batchDecodeHoldContinuation = cont
+        Task { [weak self] in
+          try? await Task.sleep(for: .seconds(Self.batchDecodeFaultSafetyUnholdSec))
+          await self?.autoReleaseBatchDecodeHoldIfStillHeld(trialID: trialID)
+        }
+      }
+      return .held(trialID: trialID)
+    }
+
+    private func exitBatchDecodeFaultBoundary(role: BatchDecodeFaultRole) {
+      let now = Date().timeIntervalSince1970
+      switch role {
+      case .none:
+        return
+      case .held(let trialID):
+        guard batchDecodeSnapshot?.trialID == trialID else { return }
+        batchDecodeSnapshot?.heldDecodeCompletionEpochSec = now
+      case .newSession(let trialID):
+        guard batchDecodeSnapshot?.trialID == trialID else { return }
+        batchDecodeSnapshot?.newSessionCompletionEpochSec = now
+      }
+    }
+
+    private func autoReleaseBatchDecodeHoldIfStillHeld(trialID: String) {
+      guard armedBatchDecodeTrialID == trialID, batchDecodeHoldContinuation != nil else { return }
+      batchDecodeHoldContinuation?.resume()
+      batchDecodeHoldContinuation = nil
+    }
+  #endif
 }

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -289,4 +289,30 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
   func checkStreamingSupport(backendType: String, reply: @escaping (Bool) -> Void) {
     reply(backendType == "parakeet")
   }
+
+  #if DEBUG
+    // MARK: - #1707 Phase 2: batch-decode fault oracle forwarding
+
+    /// Pure forwarder — holds no timing state itself. Awaits the FULL
+    /// forward into `ParakeetBackend` before replying, so `DebugFaultEndpoint`'s
+    /// reply (which itself already awaits this handler fully,
+    /// `DebugFaultEndpoint.swift:187-188`) is the acknowledged-arm barrier: a
+    /// caller that waits for that reply is guaranteed the arm has landed
+    /// service-side before triggering the next real transcription call.
+    func armBatchDecodeHold(trialID: String, reply: @escaping () -> Void) {
+      nonisolated(unsafe) let safeReply = reply
+      Task { @MainActor in
+        await self.parakeetBackend?.armBatchDecodeHold(trialID: trialID)
+        safeReply()
+      }
+    }
+
+    func releaseBatchDecode(trialID: String, reply: @escaping () -> Void) {
+      nonisolated(unsafe) let safeReply = reply
+      Task { @MainActor in
+        await self.parakeetBackend?.releaseBatchDecode(trialID: trialID)
+        safeReply()
+      }
+    }
+  #endif
 }

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -314,5 +314,13 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
         safeReply()
       }
     }
+
+    func clearBatchDecodeFault(reply: @escaping () -> Void) {
+      nonisolated(unsafe) let safeReply = reply
+      Task { @MainActor in
+        await self.parakeetBackend?.clearBatchDecodeFault()
+        safeReply()
+      }
+    }
   #endif
 }

--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -67,6 +67,13 @@ final class AppLifecycleCoordinator {
   // Bluetooth predicate, overlay branching, or once-per-launch state — it only
   // hands the presenter a `Trigger` fact.
   private let bluetoothAwarenessPresenter: BluetoothAwarenessPresenter
+  /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1/§3.2a-i), forwarded
+  /// into `DebugFaultEndpoint`'s construction below — a deliberate, explicit
+  /// stored-property allowlist addition (`AppLifecycleCoordinatorCeilingsTests.swift`),
+  /// not a workaround around it: the ceilings test exists to catch accidental
+  /// growth, and this is one genuinely new capability adding exactly one
+  /// dependency.
+  private let batchDecodeFaultController: BatchDecodeFaultController?
 
   init(
     settings: SettingsManager,
@@ -90,7 +97,8 @@ final class AppLifecycleCoordinator {
     bluetoothAwarenessPresenter: BluetoothAwarenessPresenter,
     // #1176: captured in the onboarding-dismiss closure below (NOT stored — keeps
     // this coordinator's stored-property ceiling clean).
-    onboardingProgress: OnboardingProgress
+    onboardingProgress: OnboardingProgress,
+    batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) {
     self.settings = settings
     self.permissions = permissions
@@ -111,6 +119,7 @@ final class AppLifecycleCoordinator {
     self.hotkeyService = hotkeyService
     self.applicationRelocationCoordinator = applicationRelocationCoordinator
     self.bluetoothAwarenessPresenter = bluetoothAwarenessPresenter
+    self.batchDecodeFaultController = batchDecodeFaultController
     // Icon-refresh seam: the window coordinator's two onboarding-dismiss
     // callsites route through this closure. Was wired in `AppDelegate.attach`
     // before PR-B.4.
@@ -297,7 +306,8 @@ final class AppLifecycleCoordinator {
           whisperKitKernelDriver: whisperKitKernelDriver,
           activeBackend: { [weak self] in
             self?.settings.selectedBackend ?? .parakeet
-          }
+          },
+          batchDecodeFaultController: batchDecodeFaultController
         )
         endpoint.start()
         debugFaultEndpoint = endpoint

--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -29,9 +29,10 @@
   ///   the in-process `AudioCaptureManager` — #1543); `fail_batch_decode(backend)`,
   ///   `fail_every_batch_decode(backend)`, `clear_batch_decode_fault(backend,trialID)`,
   ///   `hold_batch_decode(backend,trialID)`, `release_batch_decode(backend,trialID)`,
-  ///   `query_batch_decode_fault(backend,trialID)` (#1707 Phase 2 — the
-  ///   shared-backend overlap Live UAT oracle, §3.2a-i; all six route to the
-  ///   ONE `BatchDecodeFaultController`).
+  ///   `query_batch_decode_fault(backend,trialID)`, `query_batch_decode_attempts(backend)`
+  ///   (#1707 Phase 2 — the shared-backend overlap Live UAT oracle, §3.2a-i,
+  ///   plus the content-free attempt-identity check, Codex r4; all seven
+  ///   route to the ONE `BatchDecodeFaultController`).
   /// - Each command dispatches to `@MainActor` via `Task { @MainActor in ... }`
   ///   so command handling matches the actor isolation of the seams it drives.
   ///
@@ -263,10 +264,11 @@
             + "source_incarnation=\(status.sourceIncarnation) "
             + "capture_source=\(status.captureSourceType)"
         }
-        // #1707 Phase 2 (§11.1/§3.2a-i): the six batch-decode fault commands,
-        // all routing to the ONE `BatchDecodeFaultController` — adapter-
-        // boundary forced failures (`fail_batch_decode`/`fail_every_batch_decode`/
-        // `clear_batch_decode_fault`) and the real-engine-boundary overlap
+        // #1707 Phase 2 (§11.1/§3.2a-i): the seven batch-decode fault
+        // commands, all routing to the ONE `BatchDecodeFaultController` —
+        // adapter-boundary forced failures (`fail_batch_decode`/
+        // `fail_every_batch_decode`/`clear_batch_decode_fault`/
+        // `query_batch_decode_attempts`) and the real-engine-boundary overlap
         // oracle (`hold_batch_decode`/`release_batch_decode`/
         // `query_batch_decode_fault`).
         if let backend = parseBackendArgCommand(cmd, prefix: "fail_batch_decode(") {
@@ -316,6 +318,16 @@
           let r = await batchDecodeFaultController.queryBatchDecodeFault(
             backend: backend, trialID: trialID)
           return Self.formatBatchDecodeFaultQueryReply(r)
+        }
+        // #1707 Phase 2 (Codex r4): content-free sample counts for every real
+        // batch-decode attempt this backend has issued, oldest first — lets a
+        // Live UAT test confirm the retry decoded the SAME captured audio as
+        // the failed attempt (never a synthetic stand-in), without exposing
+        // any transcript text.
+        if let backend = parseBackendArgCommand(cmd, prefix: "query_batch_decode_attempts(") {
+          guard let batchDecodeFaultController else { return "ERR no_dependency" }
+          let counts = batchDecodeFaultController.attemptSampleCounts(backend: backend)
+          return "OK " + counts.map { (n: Int) in String(n) }.joined(separator: ",")
         }
         return "ERR unknown_command"
       }

--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -26,7 +26,12 @@
   ///   `force_cancel`, `force_xpc_kill` (ASR helper), `query_state`,
   ///   `force_zero_fill(mode,N,trialID)`, `query_fault_status(trialID)` (#1317
   ///   proof-bench; the last two drive the DEBUG all-zero injector directly on
-  ///   the in-process `AudioCaptureManager` — #1543).
+  ///   the in-process `AudioCaptureManager` — #1543); `fail_batch_decode(backend)`,
+  ///   `fail_every_batch_decode(backend)`, `clear_batch_decode_fault(backend,trialID)`,
+  ///   `hold_batch_decode(backend,trialID)`, `release_batch_decode(backend,trialID)`,
+  ///   `query_batch_decode_fault(backend,trialID)` (#1707 Phase 2 — the
+  ///   shared-backend overlap Live UAT oracle, §3.2a-i; all six route to the
+  ///   ONE `BatchDecodeFaultController`).
   /// - Each command dispatches to `@MainActor` via `Task { @MainActor in ... }`
   ///   so command handling matches the actor isolation of the seams it drives.
   ///
@@ -49,6 +54,9 @@
     private let kernelDriver: KernelDictationDriver
     private let whisperKitKernelDriver: KernelDictationDriver
     private let activeBackend: () -> ASRBackendType
+    /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1/§3.2a-i) — the SOLE
+    /// dispatch target for every `*_batch_decode*` command below.
+    private let batchDecodeFaultController: BatchDecodeFaultController?
 
     // MARK: - Listener state
 
@@ -68,7 +76,8 @@
       kernelDriver: KernelDictationDriver,
       whisperKitKernelDriver: KernelDictationDriver,
       activeBackend: @escaping () -> ASRBackendType,
-      port: UInt16 = 8765
+      port: UInt16 = 8765,
+      batchDecodeFaultController: BatchDecodeFaultController? = nil
     ) {
       self.audioCapture = audioCapture
       self.asrProxy = asrProxy
@@ -76,6 +85,7 @@
       self.whisperKitKernelDriver = whisperKitKernelDriver
       self.activeBackend = activeBackend
       self.port = port
+      self.batchDecodeFaultController = batchDecodeFaultController
       self.token = Self.generateToken()
       self.tokenPath = Self.tokenURL(pid: ProcessInfo.processInfo.processIdentifier)
     }
@@ -253,6 +263,60 @@
             + "source_incarnation=\(status.sourceIncarnation) "
             + "capture_source=\(status.captureSourceType)"
         }
+        // #1707 Phase 2 (§11.1/§3.2a-i): the six batch-decode fault commands,
+        // all routing to the ONE `BatchDecodeFaultController` — adapter-
+        // boundary forced failures (`fail_batch_decode`/`fail_every_batch_decode`/
+        // `clear_batch_decode_fault`) and the real-engine-boundary overlap
+        // oracle (`hold_batch_decode`/`release_batch_decode`/
+        // `query_batch_decode_fault`).
+        if let backend = parseBackendArgCommand(cmd, prefix: "fail_batch_decode(") {
+          guard let batchDecodeFaultController else { return "ERR no_dependency" }
+          batchDecodeFaultController.failNextBatchDecode(backend: backend)
+          return "OK"
+        }
+        if let backend = parseBackendArgCommand(cmd, prefix: "fail_every_batch_decode(") {
+          guard let batchDecodeFaultController else { return "ERR no_dependency" }
+          batchDecodeFaultController.failEveryBatchDecode(backend: backend)
+          return "OK"
+        }
+        // `clear_batch_decode_fault(<backend>,<trialID>)` clears BOTH the
+        // adapter-boundary pending-failure state for `backend` and the
+        // oracle/trial state for `trialID`, so a forgotten trial from one
+        // Live UAT scenario cannot leak into the next.
+        if let (backend, trialID) = parseBackendAndTrialArgCommand(
+          cmd, prefix: "clear_batch_decode_fault(")
+        {
+          guard let batchDecodeFaultController else { return "ERR no_dependency" }
+          batchDecodeFaultController.clearBatchDecodeFault(backend: backend)
+          await batchDecodeFaultController.clearBatchDecodeFault(trialID: trialID)
+          return "OK"
+        }
+        if let (backend, trialID) = parseBackendAndTrialArgCommand(
+          cmd, prefix: "hold_batch_decode(")
+        {
+          guard let batchDecodeFaultController else { return "ERR no_dependency" }
+          // Acknowledged-arm barrier: this reply fires only AFTER the arm has
+          // landed (across XPC for Parakeet), so a caller that waits for it
+          // is guaranteed the arm took effect before triggering the next real
+          // transcription call.
+          await batchDecodeFaultController.holdBatchDecode(backend: backend, trialID: trialID)
+          return "OK"
+        }
+        if let (backend, trialID) = parseBackendAndTrialArgCommand(
+          cmd, prefix: "release_batch_decode(")
+        {
+          guard let batchDecodeFaultController else { return "ERR no_dependency" }
+          await batchDecodeFaultController.releaseBatchDecode(backend: backend, trialID: trialID)
+          return "OK"
+        }
+        if let (backend, trialID) = parseBackendAndTrialArgCommand(
+          cmd, prefix: "query_batch_decode_fault(")
+        {
+          guard let batchDecodeFaultController else { return "ERR no_dependency" }
+          let r = await batchDecodeFaultController.queryBatchDecodeFault(
+            backend: backend, trialID: trialID)
+          return Self.formatBatchDecodeFaultQueryReply(r)
+        }
         return "ERR unknown_command"
       }
     }
@@ -281,6 +345,53 @@
       guard cmd.hasPrefix(prefix), cmd.hasSuffix(")") else { return nil }
       let inner = String(cmd.dropFirst(prefix.count).dropLast())
       return inner.isEmpty ? nil : inner
+    }
+
+    /// #1707 Phase 2: parse `<prefix><backend>)` — `<backend>` is
+    /// `ASRBackendType`'s raw value (`parakeet` or `whisperKit`).
+    private func parseBackendArgCommand(_ cmd: String, prefix: String) -> ASRBackendType? {
+      guard let raw = parseStringArgCommand(cmd, prefix: prefix) else { return nil }
+      return ASRBackendType(rawValue: raw)
+    }
+
+    /// #1707 Phase 2: parse `<prefix><backend>,<trialID>)`. Only the first
+    /// comma splits, so `trialID` is the final unsplit field and may itself
+    /// contain commas; it must be non-empty.
+    private func parseBackendAndTrialArgCommand(
+      _ cmd: String, prefix: String
+    ) -> (backend: ASRBackendType, trialID: String)? {
+      guard cmd.hasPrefix(prefix), cmd.hasSuffix(")") else { return nil }
+      let inner = cmd.dropFirst(prefix.count).dropLast()
+      let parts = inner.split(separator: ",", maxSplits: 1, omittingEmptySubsequences: false)
+      guard parts.count == 2, let backend = ASRBackendType(rawValue: String(parts[0])) else {
+        return nil
+      }
+      let trialID = String(parts[1])
+      guard !trialID.isEmpty else { return nil }
+      return (backend, trialID)
+    }
+
+    /// #1707 Phase 2: broken into intermediate statements — a single chained
+    /// string-interpolation expression here made the type checker time out.
+    private static func formatBatchDecodeFaultQueryReply(
+      _ r: BatchDecodeFaultQueryResult
+    ) -> String {
+      let kernelRetryStarted =
+        r.kernelRetryStartedAtEpochSec.map { (v: Double) in String(v) } ?? "nil"
+      let kernelTimeoutFired =
+        r.kernelRetryTimeoutFiredAtEpochSec.map { (v: Double) in String(v) } ?? "nil"
+      let heldEntry = r.heldDecodeEntryEpochSec.map { (v: Double) in String(v) } ?? "nil"
+      let heldCompletion = r.heldDecodeCompletionEpochSec.map { (v: Double) in String(v) } ?? "nil"
+      let newSessionEntry = r.newSessionEntryEpochSec.map { (v: Double) in String(v) } ?? "nil"
+      let newSessionCompletion =
+        r.newSessionCompletionEpochSec.map { (v: Double) in String(v) } ?? "nil"
+      var reply = "OK kernel_retry_started=\(kernelRetryStarted) "
+      reply += "kernel_timeout_fired=\(kernelTimeoutFired) "
+      reply += "held_entry=\(heldEntry) "
+      reply += "held_completion=\(heldCompletion) "
+      reply += "new_session_entry=\(newSessionEntry) "
+      reply += "new_session_completion=\(newSessionCompletion)"
+      return reply
     }
 
     // MARK: - Token file management

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
@@ -49,7 +49,12 @@ enum DictationCompletedReporting {
       interruptedBy: driver.lastAudioInterruptionCause?.rawValue,
       // #1707: which ASR/XPC-helper salvage outcome preceded this completion.
       // Absent unless a live ASR crash was salvaged during this session.
-      asrSalvageOutcome: driver.lastASRSalvageOutcome?.rawValue)
+      asrSalvageOutcome: driver.lastASRSalvageOutcome?.rawValue,
+      // #1707 Phase 2: without this, a retry-rescued dictation's completion
+      // is invisible — it never reaches either Sentry capture site (those
+      // only fire on `.asrFailed`/`.asrInterrupted`), so this read-through
+      // chain is a successful retry's ONLY visibility.
+      asrRetryOutcome: driver.asrRetryOutcome?.rawValue)
   }
 
   private static func positive(_ value: Int?) -> Int? {

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -230,7 +230,7 @@ final class RecoveryCoordinator {
   /// (`matcher-set-adversarial-tests`).
   static func shouldDeleteOnLiveEnding(_ ending: RecordingRecoveryEnding) -> Bool {
     switch ending {
-    case .discarded, .noSpeech:
+    case .discarded, .noSpeech, .asrRetryExhausted:
       return true
     case .failed, .audioInterrupted, .asrInterrupted, .noTransport:
       return false

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -181,9 +181,22 @@ public final class WisprBootstrapper {
     // ASRManagerProxy` is nil when the in-process `ASRManager` escape hatch
     // is active (`useXPCASRService=false`) — the Parakeet half of the oracle
     // simply no-ops then, exactly like every other DEBUG-only fault seam.
-    let batchDecodeFaultController = BatchDecodeFaultController(
-      whisperKitBackend: whisperKitBackend,
-      asrManagerProxy: asrManager as? ASRManagerProxy)
+    //
+    // Codex r6: the CONTROLLER TYPE is deliberately not `#if DEBUG`-gated
+    // (only its real-engine-boundary methods are, § the type's own header
+    // comment), but that does not mean it should exist in a Release build's
+    // OBJECT GRAPH — every real decode call consults its adapter-boundary
+    // `shouldForceFailBatchDecode`, which now also records an ever-growing,
+    // never-cleared attempt-identity list. Construct a real instance only in
+    // DEBUG; Release wires `nil`, exactly like production already does for
+    // every other DEBUG-only fault seam.
+    #if DEBUG
+      let batchDecodeFaultController: BatchDecodeFaultController? = BatchDecodeFaultController(
+        whisperKitBackend: whisperKitBackend,
+        asrManagerProxy: asrManager as? ASRManagerProxy)
+    #else
+      let batchDecodeFaultController: BatchDecodeFaultController? = nil
+    #endif
 
     // #1271/#1348 Phase 3 — EG-1 native runtime: the model bytes now move
     // through the shared delivery engine via `EGOneDeliveryAdapter` (a limb —

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -163,6 +163,28 @@ public final class WisprBootstrapper {
     // handle nil (legacy path), unit-tested can't-happen.
     let modelDelivery = ModelDeliveryHome()
 
+    // #1707 Phase 2: `whisperKitBackend` is hoisted here (only these two
+    // lines — NOT the full `whisperKitKernelDriver`, which still needs
+    // `vadSource`/`languageDetector` built later) so `BatchDecodeFaultController`
+    // can be constructed with BOTH backend references before the Parakeet
+    // driver below. No circular dependency: `WhisperKitDeliveryWiring.make`'s
+    // only input, `modelDelivery`, is already in scope. `whisperKitRetirement`
+    // is extracted from the SAME `whisperKit` value at its original site
+    // further down — `whisperKit` is a plain `let` that survives the
+    // intervening code.
+    let whisperKit = WhisperKitDeliveryWiring.make(modelDelivery: modelDelivery)
+    let whisperKitBackend = whisperKit.backend
+
+    // #1707 Phase 2: DEBUG fault-injection oracle (§11.1/§3.2a-i) — the SOLE
+    // owner of every batch-decode fault command, dispatching to whichever
+    // backend-specific mechanism it holds a reference to. `asrManager as?
+    // ASRManagerProxy` is nil when the in-process `ASRManager` escape hatch
+    // is active (`useXPCASRService=false`) — the Parakeet half of the oracle
+    // simply no-ops then, exactly like every other DEBUG-only fault seam.
+    let batchDecodeFaultController = BatchDecodeFaultController(
+      whisperKitBackend: whisperKitBackend,
+      asrManagerProxy: asrManager as? ASRManagerProxy)
+
     // #1271/#1348 Phase 3 — EG-1 native runtime: the model bytes now move
     // through the shared delivery engine via `EGOneDeliveryAdapter` (a limb —
     // a delivery failure degrades polish to raw text, never blocks dictation).
@@ -259,7 +281,8 @@ public final class WisprBootstrapper {
         outputClassifierHolder: outputClassifierHolder,
         dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled },
         egOneRuntime: egOneRuntime,
-        parakeetDelivery: modelDelivery.parakeetHandle
+        parakeetDelivery: modelDelivery.parakeetHandle,
+        batchDecodeFaultController: batchDecodeFaultController
       ))
 
     // W6: language-flip telemetry wired via a closure so `EnviousWisprASR`
@@ -289,8 +312,10 @@ public final class WisprBootstrapper {
     // #1386 PR-2: the multilingual engine's delivery wiring (owned folder,
     // relocation coordinator, one gated backend, setup surface). Detail lives in
     // `WhisperKitDeliveryWiring`; the root just names it.
-    let whisperKit = WhisperKitDeliveryWiring.make(modelDelivery: modelDelivery)
-    let whisperKitBackend = whisperKit.backend
+    // #1707 Phase 2: `whisperKit`/`whisperKitBackend` are now constructed
+    // earlier (hoisted above the Parakeet driver, see the #1707 comment near
+    // `modelDelivery`) — only `whisperKitRetirement` is extracted here, from
+    // that SAME already-constructed `whisperKit` value.
     let whisperKitRetirement = whisperKit.retirement
 
     let whisperKitKernelDriver = KernelDictationDriverFactory.makeForWhisperKit(
@@ -305,7 +330,8 @@ public final class WisprBootstrapper {
         pasteCompletionRegistry: pasteCompletionRegistry,
         outputClassifierHolder: outputClassifierHolder,
         dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled },
-        egOneRuntime: egOneRuntime
+        egOneRuntime: egOneRuntime,
+        batchDecodeFaultController: batchDecodeFaultController
       ))
 
     // Phase F (#501) — `SetupCoordinator` needs `asrManager` + the WhisperKit
@@ -778,7 +804,8 @@ public final class WisprBootstrapper {
       hotkeyService: hotkeyService,
       applicationRelocationCoordinator: applicationRelocationCoordinator,
       bluetoothAwarenessPresenter: bluetoothAwarenessPresenter,
-      onboardingProgress: onboardingProgress
+      onboardingProgress: onboardingProgress,
+      batchDecodeFaultController: batchDecodeFaultController
     )
 
     self.navigationCoordinator = navigationCoordinator

--- a/Sources/EnviousWisprCore/ASRResult.swift
+++ b/Sources/EnviousWisprCore/ASRResult.swift
@@ -11,6 +11,18 @@ public enum ASRBackendType: String, Codable, Sendable {
     case .whisperKit: return "WhisperKit"
     }
   }
+
+  /// #1707 Phase 2: per-backend budget for the one live post-capture retry
+  /// decode. PLACEHOLDER pending a real, stratified Live UAT latency
+  /// measurement (RULE: timeout-numbers-need-distribution-evidence) —
+  /// owned here, not at the kernel reader site, so `EngineIdentityFreezeTests`
+  /// keeps kernel code free of a bare `.parakeet`/`.whisperKit` literal.
+  public var defaultRetryDecodeTimeoutSeconds: Double {
+    switch self {
+    case .parakeet: return 8.0
+    case .whisperKit: return 15.0
+    }
+  }
 }
 
 /// Numbers-only summary of an ASR pass's token timings.

--- a/Sources/EnviousWisprCore/ASRResult.swift
+++ b/Sources/EnviousWisprCore/ASRResult.swift
@@ -11,18 +11,6 @@ public enum ASRBackendType: String, Codable, Sendable {
     case .whisperKit: return "WhisperKit"
     }
   }
-
-  /// #1707 Phase 2: per-backend budget for the one live post-capture retry
-  /// decode. PLACEHOLDER pending a real, stratified Live UAT latency
-  /// measurement (RULE: timeout-numbers-need-distribution-evidence) —
-  /// owned here, not at the kernel reader site, so `EngineIdentityFreezeTests`
-  /// keeps kernel code free of a bare `.parakeet`/`.whisperKit` literal.
-  public var defaultRetryDecodeTimeoutSeconds: Double {
-    switch self {
-    case .parakeet: return 8.0
-    case .whisperKit: return 15.0
-    }
-  }
 }
 
 /// Numbers-only summary of an ASR pass's token timings.

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -68,6 +68,27 @@ import Foundation
 
   /// Check whether the specified backend supports streaming transcription.
   func checkStreamingSupport(backendType: String, reply: @escaping (Bool) -> Void)
+
+  #if DEBUG
+    // MARK: - #1707 Phase 2: batch-decode fault oracle (shared-backend
+    // overlap Live UAT, §3.2a-i). Arm/release cross XPC; the pre-release
+    // query does NOT — XPC replies serialize behind a pending request (this
+    // is exactly why `XPCOperationSignalFile` exists for progress queries),
+    // so `BatchDecodeFaultController` reads `BatchDecodeFaultSnapshotFile`
+    // directly instead of asking the service while a `transcribeSamples`
+    // reply is held pending. Additive, absent from release builds.
+
+    /// Arms a one-shot hold for the NEXT `transcribeSamples` call's real
+    /// `manager.transcribe(...)` decode (`ParakeetBackend`). Reply fires
+    /// once the arm has landed service-side (the acknowledged-arm barrier)
+    /// — not once a call is actually held.
+    func armBatchDecodeHold(trialID: String, reply: @escaping () -> Void)
+
+    /// Releases a previously-armed hold, letting the held decode proceed.
+    /// No-op (still calls reply) if no call is currently held under
+    /// `trialID`.
+    func releaseBatchDecode(trialID: String, reply: @escaping () -> Void)
+  #endif
 }
 
 /// XPC protocol: callbacks from ASR service to host app.

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -88,6 +88,10 @@ import Foundation
     /// No-op (still calls reply) if no call is currently held under
     /// `trialID`.
     func releaseBatchDecode(trialID: String, reply: @escaping () -> Void)
+
+    /// Clears all armed/held state, so a forgotten trial from one Live UAT
+    /// scenario cannot leak into the next.
+    func clearBatchDecodeFault(reply: @escaping () -> Void)
   #endif
 }
 

--- a/Sources/EnviousWisprCore/BatchDecodeFaultSnapshotFile.swift
+++ b/Sources/EnviousWisprCore/BatchDecodeFaultSnapshotFile.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// #1707 Phase 2: cross-process snapshot for the Parakeet shared-backend
+/// overlap Live UAT oracle (§3.2a-i). Mirrors `XPCOperationSignalFile`'s own
+/// established pattern (atomic PropertyList write, shared `/tmp` path) for
+/// the identical reason its doc comment states: "XPC replies serialize
+/// behind the pending request, so a proxy cannot ask the service for
+/// progress while it is already waiting for that request's reply." A
+/// `query_batch_decode_fault` cannot ask the ASR service for backend
+/// timestamps over the same connection while a `transcribeSamples` reply is
+/// still pending (the held decode) — so `ParakeetBackend` (inside the ASR
+/// service process) writes ONLY its own four backend-side timestamps here,
+/// keyed by the externally-supplied trial ID; `BatchDecodeFaultController`
+/// (app process) reads them directly, off XPC, and merges them with its own
+/// locally-held two kernel-side timestamps.
+///
+/// DEBUG-only in practice: only `ParakeetBackend`'s `#if DEBUG` fault seam
+/// ever writes to this file, and only `BatchDecodeFaultController` (itself
+/// constructed only for a Live UAT run) ever reads it — but the type itself
+/// is not `#if DEBUG`-gated, matching `XPCOperationSignalFile`'s own shape,
+/// so no caller needs its own conditional-compilation seam just to hold a
+/// reference to it.
+public final class BatchDecodeFaultSnapshotFile: Sendable {
+  public static let shared = BatchDecodeFaultSnapshotFile(
+    filePath: "/tmp/com.enviouswispr.batch-decode-fault-snapshot")
+
+  private let filePath: String
+
+  private init(filePath: String) {
+    self.filePath = filePath
+  }
+
+  public func write(_ state: BatchDecodeFaultSnapshotState) {
+    guard let data = try? PropertyListEncoder().encode(state) else { return }
+    do {
+      try data.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+    } catch {
+      // Signal write failure is non-fatal — a Live UAT poll that never
+      // observes the expected field simply reports "not observed yet" and
+      // eventually times out (§11.2), it does not hang.
+    }
+  }
+
+  /// Returns the current snapshot, or `nil` if no snapshot has been written
+  /// yet, the file is unreadable, or the plist is malformed — every one of
+  /// these means "not observed yet," never a crash.
+  public func read() -> BatchDecodeFaultSnapshotState? {
+    guard let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)) else { return nil }
+    return try? PropertyListDecoder().decode(BatchDecodeFaultSnapshotState.self, from: data)
+  }
+
+  public func clear() {
+    try? FileManager.default.removeItem(atPath: filePath)
+  }
+}
+
+/// The four Parakeet backend-side timestamps (epoch seconds), keyed by the
+/// externally-supplied trial ID so a stale snapshot from a PRIOR trial can
+/// never be mistaken for the current one. All four are optional — absence
+/// means "not observed yet," not failure (Grounded Review r10).
+public struct BatchDecodeFaultSnapshotState: Codable, Sendable {
+  public let trialID: String
+  public var heldDecodeEntryEpochSec: Double?
+  public var heldDecodeCompletionEpochSec: Double?
+  public var newSessionEntryEpochSec: Double?
+  public var newSessionCompletionEpochSec: Double?
+
+  public init(trialID: String) {
+    self.trialID = trialID
+  }
+}

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -369,6 +369,17 @@ package protocol ASREngineAdapter: AnyObject, Sendable {
   /// in the sense `finalize(batchSamples:)`'s own parameter name implies.
   func retryDecode(inputSamples: [Float]) async -> ASREngineOutcome
 
+  /// #1707 Phase 2: this adapter's own budget for its one live retry decode.
+  /// PLACEHOLDER — §11.1 requires this tuned from a real, stratified Live
+  /// UAT latency measurement (≥30 samples per {backend}×{short/medium/long
+  /// audio} bucket, RULE: timeout-numbers-need-distribution-evidence), not
+  /// asserted from reasoning alone. Pipeline-owned retry POLICY, not a Core
+  /// model fact — each conformer returns its own constant directly (no
+  /// per-backend switch anywhere; `EngineIdentityFreezeTests` bans an
+  /// identity-case literal only at KERNEL reader sites, and this property
+  /// removes the need for one there entirely).
+  var retryDecodeTimeoutSeconds: Double { get }
+
   /// Best-effort, honest "stop waiting" signal for a retry that has timed out
   /// — NOT a claim of active cancellation. Neither adapter's decode call is
   /// genuinely interruptible mid-flight. Synchronous, so it can run directly

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -245,8 +245,19 @@ public struct AudioBufferHandoff: @unchecked Sendable {
 /// never touches capture, finalization, paste, UI, or kernel state. The
 /// MUST / MUST NOT clauses in PR-1 §B.2.2 define the behavior every conformer
 /// (`FakeEngine`, and the PR-4 / PR-5 real adapters) must implement.
+// #1707 Phase 2: `Sendable` added so `retryDecode(inputSamples:)` can be
+// captured by name (`[adapter]`) inside `withOrderedDeadline`'s `@Sendable`
+// `operation` closure — capturing the EXISTENTIAL `any ASREngineAdapter`
+// directly (unlike a concrete `@MainActor` class, e.g. Phase 1's own
+// `recoverFromASRInterruption()` capturing `[weak self]`) does not get the
+// same automatic Sendable-safety inference the compiler grants concrete
+// MainActor-isolated types. Every conformer is `@MainActor`-isolated, so
+// `@unchecked Sendable` on each concrete conformer is the correct, safe
+// annotation — MainActor isolation (not value semantics) is what actually
+// prevents the data race the compiler cannot otherwise verify through this
+// existential boundary.
 @MainActor
-package protocol ASREngineAdapter: AnyObject {
+package protocol ASREngineAdapter: AnyObject, Sendable {
   // MARK: Identity & capability
 
   /// Self-declared engine identity. The kernel and factory read identity from
@@ -345,6 +356,27 @@ package protocol ASREngineAdapter: AnyObject {
   /// OPTIONAL `finalize()`-wedge signal (PR-1 §B.1.7). Same `nil` semantics as
   /// `loadProgress`.
   var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { get }
+
+  /// #1707 Phase 2 — a second, bounded decode attempt over audio a PRIOR
+  /// `finalize()` call already failed to decode. Distinct from calling
+  /// `finalize()` again: both `ParakeetEngineAdapter` and
+  /// `WhisperKitEngineAdapter` self-latch a terminal flag on every exit from
+  /// `finalize()` (each adapter's own `isTerminal`), so a second literal
+  /// `finalize()` call does not crash — it silently misbehaves. `inputSamples`
+  /// is REQUIRED (non-optional) — never falls back to adapter-held state,
+  /// because that state is already gone. Named `inputSamples`, NOT
+  /// `batchSamples`: for WhisperKit this is raw capture, not a "batch" buffer
+  /// in the sense `finalize(batchSamples:)`'s own parameter name implies.
+  func retryDecode(inputSamples: [Float]) async -> ASREngineOutcome
+
+  /// Best-effort, honest "stop waiting" signal for a retry that has timed out
+  /// — NOT a claim of active cancellation. Neither adapter's decode call is
+  /// genuinely interruptible mid-flight. Synchronous, so it can run directly
+  /// inside `withOrderedDeadline`'s `onTimeout` closure. Bumps an
+  /// adapter-local generation token; combined with the attempt/commit split,
+  /// this is what actually prevents a late-arriving abandoned result from
+  /// mutating state belonging to a session that has since moved on.
+  func bumpRetryGeneration()
 
   /// Idempotent discard. Calling it 2+ times has the same effect as once
   /// (PR-1 §B.2.2).

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -369,16 +369,21 @@ package protocol ASREngineAdapter: AnyObject, Sendable {
   /// in the sense `finalize(batchSamples:)`'s own parameter name implies.
   func retryDecode(inputSamples: [Float]) async -> ASREngineOutcome
 
-  /// #1707 Phase 2: this adapter's own budget for its one live retry decode.
-  /// PLACEHOLDER — §11.1 requires this tuned from a real, stratified Live
-  /// UAT latency measurement (≥30 samples per {backend}×{short/medium/long
-  /// audio} bucket, RULE: timeout-numbers-need-distribution-evidence), not
-  /// asserted from reasoning alone. Pipeline-owned retry POLICY, not a Core
-  /// model fact — each conformer returns its own constant directly (no
-  /// per-backend switch anywhere; `EngineIdentityFreezeTests` bans an
-  /// identity-case literal only at KERNEL reader sites, and this property
+  /// #1707 Phase 2: this adapter's own budget for its one live retry decode,
+  /// given the sample count of the audio being retried. Length-aware
+  /// because decode time scales with recording length (Codex r8 P1: a
+  /// single fixed constant either rejects a healthy long decode too early
+  /// or wastes time waiting on a short one) — a flat placeholder was
+  /// measured 2026-07-20 against the live dev app across {Parakeet,
+  /// WhisperKit} x {~5s, ~20s, ~59s} real audio
+  /// (`docs/audits/2026-07-20-recovery-v2-phase2-retry-decode-latency.md`)
+  /// and replaced with a fixed-floor-plus-per-second-budget formula, each
+  /// conformer tuned from its own measured real-time factor. Pipeline-owned
+  /// retry POLICY, not a Core model fact — each conformer computes its own
+  /// value directly (no per-backend switch anywhere; `EngineIdentityFreezeTests`
+  /// bans an identity-case literal only at KERNEL reader sites, and this
   /// removes the need for one there entirely).
-  var retryDecodeTimeoutSeconds: Double { get }
+  func retryDecodeTimeoutSeconds(forSampleCount sampleCount: Int) -> Double
 
   /// Best-effort, honest "stop waiting" signal for a retry that has timed out
   /// — NOT a claim of active cancellation. Neither adapter's decode call is

--- a/Sources/EnviousWisprPipeline/BatchDecodeFaultController.swift
+++ b/Sources/EnviousWisprPipeline/BatchDecodeFaultController.swift
@@ -87,69 +87,82 @@ package final class BatchDecodeFaultController {
   }
 
   // MARK: Real-engine-boundary hold/release/query (§3.2a-i)
+  //
+  // DEBUG-only: `WhisperKitBackend`'s and `ASRManagerProxy`'s hold/release/
+  // clear methods are themselves declared inside `#if DEBUG` (they don't
+  // exist in Release), and this controller is deliberately NOT gated at the
+  // type level (§ file header) — so these four methods must be individually
+  // gated, or a Release build fails to compile calling symbols that aren't
+  // there. The only caller, `DebugFaultEndpoint`, is itself a `#if DEBUG`
+  // file, so nothing outside DEBUG ever needs these.
 
-  /// Arms a one-shot hold on the NEXT real decode call the given backend
-  /// issues (`WhisperKitBackend.armBatchDecodeHold` in-process;
-  /// `ParakeetBackend.armBatchDecodeHold` across XPC via `ASRManagerProxy`).
-  package func holdBatchDecode(backend: ASRBackendType, trialID: String) async {
-    switch backend {
-    case .whisperKit:
-      await whisperKitBackend?.armBatchDecodeHold(trialID: trialID)
-    case .parakeet:
-      await asrManagerProxy?.armBatchDecodeHold(trialID: trialID)
+  #if DEBUG
+    /// Arms a one-shot hold on the NEXT real decode call the given backend
+    /// issues (`WhisperKitBackend.armBatchDecodeHold` in-process;
+    /// `ParakeetBackend.armBatchDecodeHold` across XPC via `ASRManagerProxy`).
+    package func holdBatchDecode(backend: ASRBackendType, trialID: String) async {
+      switch backend {
+      case .whisperKit:
+        await whisperKitBackend?.armBatchDecodeHold(trialID: trialID)
+      case .parakeet:
+        await asrManagerProxy?.armBatchDecodeHold(trialID: trialID)
+      }
     }
-  }
 
-  /// Releases a previously-armed hold, letting the held decode proceed.
-  package func releaseBatchDecode(backend: ASRBackendType, trialID: String) async {
-    switch backend {
-    case .whisperKit:
-      await whisperKitBackend?.releaseBatchDecode(trialID: trialID)
-    case .parakeet:
-      await asrManagerProxy?.releaseBatchDecode(trialID: trialID)
+    /// Releases a previously-armed hold, letting the held decode proceed.
+    package func releaseBatchDecode(backend: ASRBackendType, trialID: String) async {
+      switch backend {
+      case .whisperKit:
+        await whisperKitBackend?.releaseBatchDecode(trialID: trialID)
+      case .parakeet:
+        await asrManagerProxy?.releaseBatchDecode(trialID: trialID)
+      }
     }
-  }
 
-  /// Merges this controller's own kernel-side timestamps with the
-  /// backend-side timestamps — read directly from `WhisperKitBackend`
-  /// in-process, or from the shared `BatchDecodeFaultSnapshotFile` for
-  /// Parakeet (never over XPC — XPC replies serialize behind a pending
-  /// request, so a query cannot ask the service for progress while a
-  /// `transcribeSamples` reply is held pending; this is the SAME reason
-  /// `XPCOperationSignalFile` exists for progress queries). A one-shot
-  /// atomic snapshot read, NOT an arrival barrier — the caller is
-  /// responsible for polling with a bounded deadline until the required
-  /// field predicate is satisfied (§11.2).
-  package func queryBatchDecodeFault(
-    backend: ASRBackendType, trialID: String
-  ) async -> BatchDecodeFaultQueryResult {
-    let kernel = kernelTimestamps
-    let backendSnapshot: BatchDecodeFaultSnapshotState?
-    switch backend {
-    case .whisperKit:
-      backendSnapshot = await whisperKitBackend?.queryBatchDecodeFault(trialID: trialID)
-    case .parakeet:
-      backendSnapshot = BatchDecodeFaultSnapshotFile.shared.read()
-        .flatMap { $0.trialID == trialID ? $0 : nil }
+    /// Merges this controller's own kernel-side timestamps with the
+    /// backend-side timestamps — read directly from `WhisperKitBackend`
+    /// in-process, or from the shared `BatchDecodeFaultSnapshotFile` for
+    /// Parakeet (never over XPC — XPC replies serialize behind a pending
+    /// request, so a query cannot ask the service for progress while a
+    /// `transcribeSamples` reply is held pending; this is the SAME reason
+    /// `XPCOperationSignalFile` exists for progress queries). A one-shot
+    /// atomic snapshot read, NOT an arrival barrier — the caller is
+    /// responsible for polling with a bounded deadline until the required
+    /// field predicate is satisfied (§11.2).
+    package func queryBatchDecodeFault(
+      backend: ASRBackendType, trialID: String
+    ) async -> BatchDecodeFaultQueryResult {
+      let kernel = kernelTimestamps
+      let backendSnapshot: BatchDecodeFaultSnapshotState?
+      switch backend {
+      case .whisperKit:
+        backendSnapshot = await whisperKitBackend?.queryBatchDecodeFault(trialID: trialID)
+      case .parakeet:
+        backendSnapshot = BatchDecodeFaultSnapshotFile.shared.read()
+          .flatMap { $0.trialID == trialID ? $0 : nil }
+      }
+      return BatchDecodeFaultQueryResult(
+        kernelRetryStartedAtEpochSec: kernel.retryStartedAtEpochSec,
+        kernelRetryTimeoutFiredAtEpochSec: kernel.retryTimeoutFiredAtEpochSec,
+        heldDecodeEntryEpochSec: backendSnapshot?.heldDecodeEntryEpochSec,
+        heldDecodeCompletionEpochSec: backendSnapshot?.heldDecodeCompletionEpochSec,
+        newSessionEntryEpochSec: backendSnapshot?.newSessionEntryEpochSec,
+        newSessionCompletionEpochSec: backendSnapshot?.newSessionCompletionEpochSec
+      )
     }
-    return BatchDecodeFaultQueryResult(
-      kernelRetryStartedAtEpochSec: kernel.retryStartedAtEpochSec,
-      kernelRetryTimeoutFiredAtEpochSec: kernel.retryTimeoutFiredAtEpochSec,
-      heldDecodeEntryEpochSec: backendSnapshot?.heldDecodeEntryEpochSec,
-      heldDecodeCompletionEpochSec: backendSnapshot?.heldDecodeCompletionEpochSec,
-      newSessionEntryEpochSec: backendSnapshot?.newSessionEntryEpochSec,
-      newSessionCompletionEpochSec: backendSnapshot?.newSessionCompletionEpochSec
-    )
-  }
 
-  /// Clears all armed/held state (both backends) and the kernel-side
-  /// timestamps, so a forgotten trial from one Live UAT scenario cannot
-  /// leak into the next.
-  package func clearBatchDecodeFault(trialID: String) async {
-    kernelTimestamps = KernelTimestamps()
-    await whisperKitBackend?.clearBatchDecodeFault()
-    BatchDecodeFaultSnapshotFile.shared.clear()
-  }
+    /// Clears all armed/held state (both backends) and the kernel-side
+    /// timestamps, so a forgotten trial from one Live UAT scenario cannot
+    /// leak into the next. Both backends: WhisperKit in-process, Parakeet
+    /// across XPC via `ASRManagerProxy` — a Parakeet-only trial that skipped
+    /// this call would stay held until the 30-second safety release.
+    package func clearBatchDecodeFault(trialID: String) async {
+      kernelTimestamps = KernelTimestamps()
+      await whisperKitBackend?.clearBatchDecodeFault()
+      await asrManagerProxy?.clearBatchDecodeFault()
+      BatchDecodeFaultSnapshotFile.shared.clear()
+    }
+  #endif
 
   // MARK: Kernel-side timestamps (§3.3)
 

--- a/Sources/EnviousWisprPipeline/BatchDecodeFaultController.swift
+++ b/Sources/EnviousWisprPipeline/BatchDecodeFaultController.swift
@@ -50,6 +50,7 @@ package final class BatchDecodeFaultController {
 
   package func clearBatchDecodeFault(backend: ASRBackendType) {
     setPendingFailure(.none, backend: backend)
+    clearAttemptSampleCounts(backend: backend)
   }
 
   private func setPendingFailure(_ value: PendingFailure, backend: ASRBackendType) {
@@ -65,7 +66,15 @@ package final class BatchDecodeFaultController {
   /// retry genuinely re-decodes real, already-captured audio. Returns `true`
   /// (and consumes a one-shot `.next`) if this attempt should force-fail;
   /// `.every` fires on every subsequent call until explicitly cleared.
-  package func shouldForceFailBatchDecode(backend: ASRBackendType) -> Bool {
+  ///
+  /// `sampleCount` is unconditionally recorded as this backend's most recent
+  /// attempt identity (Codex r4: a Live UAT test needs a content-free way to
+  /// confirm the retry actually re-decoded the SAME captured audio as the
+  /// failed attempt, not a synthetic stand-in — `lastAttemptSampleCount`
+  /// exposes exactly that, for both the failed attempt and the retry, in
+  /// call order).
+  package func shouldForceFailBatchDecode(backend: ASRBackendType, sampleCount: Int) -> Bool {
+    recordAttemptSampleCount(backend: backend, sampleCount: sampleCount)
     switch backend {
     case .parakeet:
       switch parakeetPendingFailure {
@@ -84,6 +93,28 @@ package final class BatchDecodeFaultController {
       case .every: return true
       }
     }
+  }
+
+  /// Every real batch-decode attempt this backend has issued, oldest first —
+  /// content-free (sample counts only, never transcript text). A Live UAT
+  /// test compares the failed attempt's entry against the retry's to confirm
+  /// they decoded the same audio.
+  private var attemptSampleCounts: [ASRBackendType: [Int]] = [:]
+
+  private func recordAttemptSampleCount(backend: ASRBackendType, sampleCount: Int) {
+    attemptSampleCounts[backend, default: []].append(sampleCount)
+  }
+
+  /// This backend's recorded attempt sample counts, oldest first. Empty if
+  /// `shouldForceFailBatchDecode` was never consulted for this backend.
+  package func attemptSampleCounts(backend: ASRBackendType) -> [Int] {
+    attemptSampleCounts[backend] ?? []
+  }
+
+  /// Clears the recorded attempt identity for a backend, so a forgotten
+  /// trial cannot leak sample counts into the next.
+  package func clearAttemptSampleCounts(backend: ASRBackendType) {
+    attemptSampleCounts[backend] = nil
   }
 
   // MARK: Real-engine-boundary hold/release/query (§3.2a-i)

--- a/Sources/EnviousWisprPipeline/BatchDecodeFaultController.swift
+++ b/Sources/EnviousWisprPipeline/BatchDecodeFaultController.swift
@@ -1,0 +1,194 @@
+import EnviousWisprASR
+import EnviousWisprCore
+import Foundation
+
+/// #1707 Phase 2: the SOLE owner of every batch-decode fault command — DEBUG
+/// test infrastructure for both the Live UAT fault-injection spec (§11.1:
+/// `fail_batch_decode`/`fail_every_batch_decode`, adapter-boundary forced
+/// failures, unchanged from round 3) and the shared-backend overlap oracle
+/// (§3.2a-i: `hold_batch_decode`/`release_batch_decode`/
+/// `query_batch_decode_fault`, real-engine-boundary). `DebugFaultEndpoint`
+/// (the existing TCP command dispatcher Phase 1's own fault-injection UAT
+/// already uses) routes every batch-decode command here; this controller
+/// dispatches to whichever backend-specific mechanism it holds a reference
+/// to — not two independently-wired seams.
+///
+/// Constructed once in `WisprBootstrapper`, threaded through both adapters'
+/// driver input structs (for the adapter-boundary faults, via
+/// `KernelAdapterFactory`) and into `RecordingSessionKernel` (for the
+/// kernel-side retry-start/timeout-fired timestamps) and into
+/// `AppLifecycleCoordinator`'s existing `DebugFaultEndpoint` construction
+/// (for the real-engine-boundary hold/release/query).
+@MainActor
+package final class BatchDecodeFaultController {
+  private let whisperKitBackend: WhisperKitBackend?
+  private let asrManagerProxy: ASRManagerProxy?
+
+  package init(whisperKitBackend: WhisperKitBackend?, asrManagerProxy: ASRManagerProxy?) {
+    self.whisperKitBackend = whisperKitBackend
+    self.asrManagerProxy = asrManagerProxy
+  }
+
+  // MARK: Adapter-boundary forced failures (§11.1)
+
+  private enum PendingFailure {
+    case none
+    case next
+    case every
+  }
+
+  private var parakeetPendingFailure: PendingFailure = .none
+  private var whisperKitPendingFailure: PendingFailure = .none
+
+  package func failNextBatchDecode(backend: ASRBackendType) {
+    setPendingFailure(.next, backend: backend)
+  }
+
+  package func failEveryBatchDecode(backend: ASRBackendType) {
+    setPendingFailure(.every, backend: backend)
+  }
+
+  package func clearBatchDecodeFault(backend: ASRBackendType) {
+    setPendingFailure(.none, backend: backend)
+  }
+
+  private func setPendingFailure(_ value: PendingFailure, backend: ASRBackendType) {
+    switch backend {
+    case .parakeet: parakeetPendingFailure = value
+    case .whisperKit: whisperKitPendingFailure = value
+    }
+  }
+
+  /// Consulted by each adapter's pure attempt helper immediately before
+  /// issuing its real decode call — fires only AFTER the real retry input
+  /// and decode-options snapshot have been prepared (§11.1), proving the
+  /// retry genuinely re-decodes real, already-captured audio. Returns `true`
+  /// (and consumes a one-shot `.next`) if this attempt should force-fail;
+  /// `.every` fires on every subsequent call until explicitly cleared.
+  package func shouldForceFailBatchDecode(backend: ASRBackendType) -> Bool {
+    switch backend {
+    case .parakeet:
+      switch parakeetPendingFailure {
+      case .none: return false
+      case .next:
+        parakeetPendingFailure = .none
+        return true
+      case .every: return true
+      }
+    case .whisperKit:
+      switch whisperKitPendingFailure {
+      case .none: return false
+      case .next:
+        whisperKitPendingFailure = .none
+        return true
+      case .every: return true
+      }
+    }
+  }
+
+  // MARK: Real-engine-boundary hold/release/query (§3.2a-i)
+
+  /// Arms a one-shot hold on the NEXT real decode call the given backend
+  /// issues (`WhisperKitBackend.armBatchDecodeHold` in-process;
+  /// `ParakeetBackend.armBatchDecodeHold` across XPC via `ASRManagerProxy`).
+  package func holdBatchDecode(backend: ASRBackendType, trialID: String) async {
+    switch backend {
+    case .whisperKit:
+      await whisperKitBackend?.armBatchDecodeHold(trialID: trialID)
+    case .parakeet:
+      await asrManagerProxy?.armBatchDecodeHold(trialID: trialID)
+    }
+  }
+
+  /// Releases a previously-armed hold, letting the held decode proceed.
+  package func releaseBatchDecode(backend: ASRBackendType, trialID: String) async {
+    switch backend {
+    case .whisperKit:
+      await whisperKitBackend?.releaseBatchDecode(trialID: trialID)
+    case .parakeet:
+      await asrManagerProxy?.releaseBatchDecode(trialID: trialID)
+    }
+  }
+
+  /// Merges this controller's own kernel-side timestamps with the
+  /// backend-side timestamps — read directly from `WhisperKitBackend`
+  /// in-process, or from the shared `BatchDecodeFaultSnapshotFile` for
+  /// Parakeet (never over XPC — XPC replies serialize behind a pending
+  /// request, so a query cannot ask the service for progress while a
+  /// `transcribeSamples` reply is held pending; this is the SAME reason
+  /// `XPCOperationSignalFile` exists for progress queries). A one-shot
+  /// atomic snapshot read, NOT an arrival barrier — the caller is
+  /// responsible for polling with a bounded deadline until the required
+  /// field predicate is satisfied (§11.2).
+  package func queryBatchDecodeFault(
+    backend: ASRBackendType, trialID: String
+  ) async -> BatchDecodeFaultQueryResult {
+    let kernel = kernelTimestamps
+    let backendSnapshot: BatchDecodeFaultSnapshotState?
+    switch backend {
+    case .whisperKit:
+      backendSnapshot = await whisperKitBackend?.queryBatchDecodeFault(trialID: trialID)
+    case .parakeet:
+      backendSnapshot = BatchDecodeFaultSnapshotFile.shared.read()
+        .flatMap { $0.trialID == trialID ? $0 : nil }
+    }
+    return BatchDecodeFaultQueryResult(
+      kernelRetryStartedAtEpochSec: kernel.retryStartedAtEpochSec,
+      kernelRetryTimeoutFiredAtEpochSec: kernel.retryTimeoutFiredAtEpochSec,
+      heldDecodeEntryEpochSec: backendSnapshot?.heldDecodeEntryEpochSec,
+      heldDecodeCompletionEpochSec: backendSnapshot?.heldDecodeCompletionEpochSec,
+      newSessionEntryEpochSec: backendSnapshot?.newSessionEntryEpochSec,
+      newSessionCompletionEpochSec: backendSnapshot?.newSessionCompletionEpochSec
+    )
+  }
+
+  /// Clears all armed/held state (both backends) and the kernel-side
+  /// timestamps, so a forgotten trial from one Live UAT scenario cannot
+  /// leak into the next.
+  package func clearBatchDecodeFault(trialID: String) async {
+    kernelTimestamps = KernelTimestamps()
+    await whisperKitBackend?.clearBatchDecodeFault()
+    BatchDecodeFaultSnapshotFile.shared.clear()
+  }
+
+  // MARK: Kernel-side timestamps (§3.3)
+
+  private struct KernelTimestamps {
+    var retryStartedAtEpochSec: Double?
+    var retryTimeoutFiredAtEpochSec: Double?
+  }
+
+  /// NOT keyed by `SessionID` — the kernel's internally-minted `SessionID`
+  /// and a Live UAT test's externally-chosen trial ID are minted by
+  /// different parties at different times and cannot be equated (an
+  /// earlier revision of this file keyed a dictionary by `sessionID` on
+  /// write and by `trialID` on read, so the lookup could never hit — this
+  /// controller's own doc comment already establishes "one armed trial at a
+  /// time by construction," so a single un-keyed slot is both correct and
+  /// simpler than threading a shared identity that does not exist).
+  private var kernelTimestamps = KernelTimestamps()
+
+  /// Called from `RecordingSessionKernel` immediately before
+  /// `withOrderedDeadline`.
+  package func recordRetryStarted() {
+    kernelTimestamps.retryStartedAtEpochSec = Date().timeIntervalSince1970
+  }
+
+  /// Called from `RecordingSessionKernel`'s `withOrderedDeadline` `onTimeout`
+  /// closure — the kernel genuinely gave up waiting on the retry.
+  package func recordRetryTimeoutFired() {
+    kernelTimestamps.retryTimeoutFiredAtEpochSec = Date().timeIntervalSince1970
+  }
+}
+
+/// The complete six-field oracle result `query_batch_decode_fault` returns —
+/// the first two honestly kernel-side, the remaining four honestly
+/// backend-side, never conflated (Grounded Review r7).
+package struct BatchDecodeFaultQueryResult: Sendable {
+  package let kernelRetryStartedAtEpochSec: Double?
+  package let kernelRetryTimeoutFiredAtEpochSec: Double?
+  package let heldDecodeEntryEpochSec: Double?
+  package let heldDecodeCompletionEpochSec: Double?
+  package let newSessionEntryEpochSec: Double?
+  package let newSessionCompletionEpochSec: Double?
+}

--- a/Sources/EnviousWisprPipeline/KernelAdapterFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelAdapterFactory.swift
@@ -27,25 +27,34 @@ package enum KernelAdapterFactory {
 
   /// The single Parakeet adapter construction site in `Sources/`.
   /// `delivery` (#1348 Phase 2): nil = legacy in-service download path.
+  /// `batchDecodeFaultController` (#1707 Phase 2): DEBUG fault-injection
+  /// oracle, defaulted `nil` so every existing test call site is unaffected.
   package static func makeParakeetAdapter(
     asrManager: any ASRManagerInterface,
-    delivery: ParakeetDeliveryHandle? = nil
+    delivery: ParakeetDeliveryHandle? = nil,
+    batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) -> any ASREngineAdapter {
-    ParakeetEngineAdapter(asrManager: asrManager, delivery: delivery)
+    ParakeetEngineAdapter(
+      asrManager: asrManager, delivery: delivery,
+      batchDecodeFaultController: batchDecodeFaultController)
   }
 
   /// The single WhisperKit adapter construction site in `Sources/`.
   /// `audioCaptureSessionIDSource` mirrors the adapter's own parameter (PR-5
   /// Rung 4.5) so the adapter can snapshot the capture session id at
   /// `beginSession` for race-safe delayed LID perf signposts.
+  /// `batchDecodeFaultController` (#1707 Phase 2): DEBUG fault-injection
+  /// oracle, defaulted `nil` so every existing test call site is unaffected.
   package static func makeWhisperKitAdapter(
     backend: any WhisperKitBackendDriving,
     languageDetector: LanguageDetector,
-    audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64
+    audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64,
+    batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) -> any ASREngineAdapter {
     WhisperKitEngineAdapter(
       backend: backend,
       languageDetector: languageDetector,
-      audioCaptureSessionIDSource: audioCaptureSessionIDSource)
+      audioCaptureSessionIDSource: audioCaptureSessionIDSource,
+      batchDecodeFaultController: batchDecodeFaultController)
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1305,7 +1305,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// whose retry was exhausted projects to the distinct `.asrRetryExhausted`
   /// ending (§4) so `RecoveryCoordinator` can delete that spool specifically
   /// — a pre-capture `.failed` (retry never consulted, `retryOutcome == nil`)
-  /// still projects to plain `.failed` and retains exactly as today.
+  /// still projects to plain `.failed` and retains exactly as today. Codex r7:
+  /// `.asrInterrupted` honors the same exhausted-retry distinction, since the
+  /// kernel's `interruptedTerminalFloor` can raise an exhausted-retry `.failed`
+  /// into `.asrInterrupted` when an ASR-interruption salvage attempt preceded it.
   static func recoveryEnding(
     for outcome: RecordingOutcome, retryOutcome: ASRRetryOutcome? = nil
   )
@@ -1321,7 +1324,13 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     case .audioInterrupted:
       return .audioInterrupted
     case .asrInterrupted:
-      return .asrInterrupted
+      // #1707 Codex r7: `interruptedTerminalFloor` can raise a `.failed`
+      // whose retry exhausted into `.asrInterrupted` (an ASR-interruption
+      // salvage attempt AND the Phase 2 retry both failed in the same
+      // session) — honor the same exhausted-retry distinction here so the
+      // coordinator still deletes rather than replaying audio the retry
+      // already definitively gave up on.
+      return retryOutcome == .retryExhausted ? .asrRetryExhausted : .asrInterrupted
     case .noTransport:
       return .noTransport
     case .cancelled, .completed:

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -894,6 +894,15 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   public var lastASRSalvageOutcome: ASRSalvageOutcome? {
     kernel.lastASRSalvageOutcome
   }
+  /// #1707 Phase 2: non-nil when this session started a post-capture-decode
+  /// retry — distinguishing an attempt left unresolved by a preempting
+  /// interruption from one this session actually accepted as succeeded or
+  /// exhausted. LIVE pass-through from the kernel; feeds the success-side
+  /// `dictation.completed` reporting chain (§3a) and the exhausted-retry
+  /// spool-deletion projection (`recoveryEnding(for:retryOutcome:)`).
+  public var asrRetryOutcome: ASRRetryOutcome? {
+    kernel.asrRetryOutcome
+  }
   /// #1317: non-nil when the most recent recording was classified as the
   /// mic-harness all-zero glitch (`allZeroFromStart` = the `.zeroSignal`
   /// pill; `becameZeroMidCapture` = a normal completion whose disclosure
@@ -1269,7 +1278,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       ending = .cancelled(pendingCancelOrigin)
       pendingCancelOrigin = .systemOrFault
     } else {
-      ending = Self.recoveryEnding(for: outcome)
+      ending = Self.recoveryEnding(for: outcome, retryOutcome: kernel.asrRetryOutcome)
     }
     guard let ending else { return }
     onSessionEndedWithoutSave?(context.config?.recoverySessionID, ending)
@@ -1287,7 +1296,19 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// Also nil for `.completed` (durable save ran). Exhaustive so a new
   /// `RecordingOutcome` forces a routing decision. Internal (not private) so the
   /// split is unit-tested directly (`matcher-set-adversarial-tests`).
-  static func recoveryEnding(for outcome: RecordingOutcome)
+  ///
+  /// #1707 Phase 2: `retryOutcome` defaults to `nil` so every existing call
+  /// site (16 across `KernelTerminalKindTests`/`RecordingSessionKernelSalvageTests`)
+  /// compiles and behaves unchanged — none of them pass a retry outcome, and
+  /// all continue to get plain `.failed`. Only the ONE production call site
+  /// above passes `kernel.asrRetryOutcome` explicitly. A `.failed` outcome
+  /// whose retry was exhausted projects to the distinct `.asrRetryExhausted`
+  /// ending (§4) so `RecoveryCoordinator` can delete that spool specifically
+  /// — a pre-capture `.failed` (retry never consulted, `retryOutcome == nil`)
+  /// still projects to plain `.failed` and retains exactly as today.
+  static func recoveryEnding(
+    for outcome: RecordingOutcome, retryOutcome: ASRRetryOutcome? = nil
+  )
     -> RecordingRecoveryEnding?
   {
     switch outcome {
@@ -1296,7 +1317,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     case .noSpeech:
       return .noSpeech
     case .failed:
-      return .failed
+      return retryOutcome == .retryExhausted ? .asrRetryExhausted : .failed
     case .audioInterrupted:
       return .audioInterrupted
     case .asrInterrupted:

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -100,6 +100,9 @@ public enum KernelDictationDriverFactory {
     /// bundled-manifest load, which a unit test makes can't-happen in
     /// release) means the legacy in-service download path.
     package let parakeetDelivery: ParakeetDeliveryHandle?
+    /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1/§3.2a-i) — nil in
+    /// every existing test call site.
+    package let batchDecodeFaultController: BatchDecodeFaultController?
 
     /// Explicit package init: Swift's synthesized memberwise init is `internal`
     /// and would prevent App callers from constructing this struct. `@MainActor`
@@ -119,7 +122,8 @@ public enum KernelDictationDriverFactory {
       outputClassifierHolder: OutputClassifierHolder? = nil,
       dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
       egOneRuntime: (any EGOneEndpointProviding)? = nil,
-      parakeetDelivery: ParakeetDeliveryHandle? = nil
+      parakeetDelivery: ParakeetDeliveryHandle? = nil,
+      batchDecodeFaultController: BatchDecodeFaultController? = nil
     ) {
       self.audioCapture = audioCapture
       self.asrManager = asrManager
@@ -133,6 +137,7 @@ public enum KernelDictationDriverFactory {
       self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
       self.egOneRuntime = egOneRuntime
       self.parakeetDelivery = parakeetDelivery
+      self.batchDecodeFaultController = batchDecodeFaultController
     }
   }
 
@@ -160,6 +165,9 @@ public enum KernelDictationDriverFactory {
     package let dictationAudioArchiveOptInProvider: @MainActor () -> Bool
     /// #1271: EG-1 runtime handle. See `ParakeetInputs.egOneRuntime`.
     package let egOneRuntime: (any EGOneEndpointProviding)?
+    /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1/§3.2a-i) — nil in
+    /// every existing test call site.
+    package let batchDecodeFaultController: BatchDecodeFaultController?
 
     /// Explicit package init — same reasoning as `ParakeetInputs.init`.
     /// `languageDetector` is intentionally non-optional (no default) so the
@@ -181,7 +189,8 @@ public enum KernelDictationDriverFactory {
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
       dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
-      egOneRuntime: (any EGOneEndpointProviding)? = nil
+      egOneRuntime: (any EGOneEndpointProviding)? = nil,
+      batchDecodeFaultController: BatchDecodeFaultController? = nil
     ) {
       self.audioCapture = audioCapture
       self.whisperKitBackend = whisperKitBackend
@@ -195,6 +204,7 @@ public enum KernelDictationDriverFactory {
       self.outputClassifierHolder = outputClassifierHolder
       self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
       self.egOneRuntime = egOneRuntime
+      self.batchDecodeFaultController = batchDecodeFaultController
     }
   }
 
@@ -238,7 +248,8 @@ public enum KernelDictationDriverFactory {
     // longer names a concrete adapter type in code (EngineIdentityFreezeTests
     // Test B); it assembles around the opaque `any ASREngineAdapter` returned.
     let adapter = KernelAdapterFactory.makeParakeetAdapter(
-      asrManager: inputs.asrManager, delivery: inputs.parakeetDelivery)
+      asrManager: inputs.asrManager, delivery: inputs.parakeetDelivery,
+      batchDecodeFaultController: inputs.batchDecodeFaultController)
     return assembleDriver(
       adapter: adapter,
       audioCapture: inputs.audioCapture,
@@ -250,7 +261,8 @@ public enum KernelDictationDriverFactory {
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
       dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider,
-      egOneRuntime: inputs.egOneRuntime)
+      egOneRuntime: inputs.egOneRuntime,
+      batchDecodeFaultController: inputs.batchDecodeFaultController)
   }
 
   /// Build the driver stack for the WhisperKit engine. PR-5 Rung 5 flips the
@@ -268,7 +280,8 @@ public enum KernelDictationDriverFactory {
     let adapter = KernelAdapterFactory.makeWhisperKitAdapter(
       backend: inputs.whisperKitBackend,
       languageDetector: inputs.languageDetector,
-      audioCaptureSessionIDSource: { captureSource.currentCaptureSessionID })
+      audioCaptureSessionIDSource: { captureSource.currentCaptureSessionID },
+      batchDecodeFaultController: inputs.batchDecodeFaultController)
     return assembleDriver(
       adapter: adapter,
       audioCapture: inputs.audioCapture,
@@ -280,7 +293,8 @@ public enum KernelDictationDriverFactory {
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
       dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider,
-      egOneRuntime: inputs.egOneRuntime)
+      egOneRuntime: inputs.egOneRuntime,
+      batchDecodeFaultController: inputs.batchDecodeFaultController)
   }
 
   /// Engine-agnostic assembler. The two package entry points construct their
@@ -299,7 +313,8 @@ public enum KernelDictationDriverFactory {
     captureErrorSink: @escaping HeartPathCaptureErrorSink,
     outputClassifierHolder: OutputClassifierHolder? = nil,
     dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
-    egOneRuntime: (any EGOneEndpointProviding)? = nil
+    egOneRuntime: (any EGOneEndpointProviding)? = nil,
+    batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) -> KernelDictationDriver {
     // 1. LimbSteps — same instances driver + wiring hold by reference.
     // #832/#913 PR8: the live-dictation LLMPolishStep receives the app-owned
@@ -439,7 +454,8 @@ public enum KernelDictationDriverFactory {
         outcome.asrEndedAtSeconds = CFAbsoluteTimeGetCurrent()
       },
       telemetryState: telemetryState,
-      dictationAudioArchiveOptInProvider: dictationAudioArchiveOptInProvider
+      dictationAudioArchiveOptInProvider: dictationAudioArchiveOptInProvider,
+      batchDecodeFaultController: batchDecodeFaultController
     )
     telemetryRelay.kernel = kernel
 

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -310,6 +310,13 @@ final class KernelLifecycleTelemetrySink {
       if let salvageOutcome = telemetryState.asrSalvageOutcome {
         extra["asr_salvage_outcome"] = salvageOutcome.rawValue
       }
+      // #1707 Phase 2: a retry preempted by a competing interruption before
+      // its own result was accepted leaves `.attempted` as the FINAL
+      // recorded value (§3a) — this is where that value actually surfaces,
+      // since that race publishes `.asrInterrupted`, not `.asrFailed`.
+      if let retryOutcome = telemetryState.asrRetryOutcome {
+        extra["asr_retry_outcome"] = retryOutcome.rawValue
+      }
       emitCaptureError(
         KernelFallbackSentryError.xpcServiceError(backendLabel: backendLabel),
         .xpcServiceError, "asr",
@@ -650,10 +657,18 @@ final class KernelLifecycleTelemetrySink {
       let error =
         telemetryState.transcriptionFailureError
         ?? KernelFallbackSentryError.transcriptionFailed
+      // #1707 Phase 2: a retry this session accepted as exhausted surfaces
+      // here (the retry-exhausted `default:` branch sets `.retryExhausted`
+      // immediately before this terminal fires) — absent when no Phase-2
+      // retry was ever consulted (the pre-capture producer).
+      var asrFailedExtra: [String: Any] = ["backend": backend.rawValue]
+      if let retryOutcome = telemetryState.asrRetryOutcome {
+        asrFailedExtra["asr_retry_outcome"] = retryOutcome.rawValue
+      }
       emitCaptureError(
         SentryCaptureBoundaryError.normalizingTranscriptionFailure(error),
         .asrFailed, "transcription",
-        ["backend": backend.rawValue],
+        asrFailedExtra,
         snapshot: recordingSnapshot())
     case .permissionDenied:
       let error =

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -29,6 +29,19 @@ public enum ASRSalvageOutcome: String, Sendable {
   case cancelled = "cancelled"
 }
 
+/// #1707 Phase 2 — this session's ASR post-capture-decode retry outcome.
+/// `.attempted` is set BEFORE the retry's own await begins and can be the
+/// FINAL recorded value (a retry preempted by a competing interruption/
+/// supersession before its own result is accepted never reaches `.retrySucceeded`/
+/// `.retryExhausted`) — this is not a bug, it is the honest terminal state for
+/// that race. `nil` means no Phase-2 retry ever started for this session
+/// (covers both the pre-capture producer and a first-attempt success).
+public enum ASRRetryOutcome: String, Sendable {
+  case attempted = "attempted"
+  case retrySucceeded = "retry_succeeded"
+  case retryExhausted = "retry_exhausted"
+}
+
 /// Per-session telemetry side-channel for details that do not belong in the
 /// kernel FSM state enum. The kernel writes this before terminal transitions;
 /// `KernelLifecycleTelemetrySink` reads it when rendering the lifecycle event.
@@ -91,6 +104,10 @@ final class KernelTelemetryState {
   /// salvage was attempted. See `ASRSalvageOutcome` for the value taxonomy.
   var asrSalvageOutcome: ASRSalvageOutcome?
 
+  /// #1707 Phase 2: this session's post-capture-decode retry outcome, or
+  /// `nil` if no Phase-2 retry ever started. See `ASRRetryOutcome`.
+  var asrRetryOutcome: ASRRetryOutcome?
+
   func resetForNewSession(polishEnabled: Bool) {
     self.polishEnabled = polishEnabled
     recordingSnapshot = nil
@@ -105,6 +122,7 @@ final class KernelTelemetryState {
     interruptedSalvageSource = nil
     zeroSignalFailureMode = nil
     asrSalvageOutcome = nil
+    asrRetryOutcome = nil
   }
 }
 

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -256,8 +256,21 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     ASREngineIdentity(backendType: .parakeet)
   }
 
-  /// #1707 Phase 2: PLACEHOLDER — see the protocol doc comment.
-  var retryDecodeTimeoutSeconds: Double { 8.0 }
+  /// #1707 Phase 2: measured 2026-07-20 against the live dev app — 10 real
+  /// batch decodes spanning 3.9-59.2s of audio, real-time factor (decode
+  /// seconds / audio seconds) observed 0.0056-0.0572, HIGHEST at the
+  /// shortest clips (fixed per-call overhead dominates) and settling near
+  /// 0.006-0.009 by 15-59s — i.e. Parakeet does not get slower per second of
+  /// audio as recordings grow. `3.0` fixed floor covers per-call/XPC
+  /// overhead with headroom over the worst short-clip observation; `0.15`
+  /// per second is ~2.6x the highest RTF seen at any length. At the 3600s
+  /// (60-minute) recording cap this budgets 543s — generous given the
+  /// measured trend, never the bottleneck for a genuinely succeeding decode.
+  /// Raw samples: `docs/audits/2026-07-20-recovery-v2-phase2-retry-decode-latency.md`.
+  func retryDecodeTimeoutSeconds(forSampleCount sampleCount: Int) -> Double {
+    let audioDurationSec = Double(sampleCount) / AudioConstants.sampleRate
+    return 3.0 + audioDurationSec * 0.15
+  }
 
   /// Parakeet decodes incrementally and detects no language (D2, D15). Static —
   /// the kernel branches on `capabilities`, never on engine identity.

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -688,6 +688,22 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     // outcome alone — an honest, non-atomic signal (§3.2's documented limit).
     let session = sessionID
     let generation = retryGeneration
+    // GitHub cloud review (PR #1725): a per-call XPC proxy error
+    // (`ASRManagerProxy.transcribe`'s `onProxyError` -> `.serviceUnreachable`)
+    // never clears `isModelLoaded`/`connection` — only the connection's OWN
+    // interruption/invalidation handler does that. So `readiness` can still
+    // read `.ready` even though the PRIMARY decode's own failure proves the
+    // connection is actually dead, and the check below would then skip
+    // repair entirely, re-attempting the same broken proxy and exhausting
+    // the one retry instead of reconnecting. `.serviceUnreachable`
+    // specifically (not the other `XPCASRTransportError` cases, which are
+    // encoding/decoding issues a reconnect would not fix — mirrors this same
+    // file's existing one-shot transport-retry classification) forces
+    // `cancelInFlightLoad()` to make the mirror honest before the existing
+    // gate below decides whether to repair.
+    if readiness == .ready, (lastFailureError as? XPCASRTransportError) == .serviceUnreachable {
+      asrManager.cancelInFlightLoad()
+    }
     if readiness != .ready {
       do {
         try await warmUp()

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -261,15 +261,25 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// seconds / audio seconds) observed 0.0056-0.0572, HIGHEST at the
   /// shortest clips (fixed per-call overhead dominates) and settling near
   /// 0.006-0.009 by 15-59s — i.e. Parakeet does not get slower per second of
-  /// audio as recordings grow. `3.0` fixed floor covers per-call/XPC
-  /// overhead with headroom over the worst short-clip observation; `0.15`
-  /// per second is ~2.6x the highest RTF seen at any length. At the 3600s
-  /// (60-minute) recording cap this budgets 543s — generous given the
-  /// measured trend, never the bottleneck for a genuinely succeeding decode.
-  /// Raw samples: `docs/audits/2026-07-20-recovery-v2-phase2-retry-decode-latency.md`.
+  /// audio as recordings grow. `0.15` per second is ~2.6x the highest RTF
+  /// seen at any length. Raw samples:
+  /// `docs/audits/2026-07-20-recovery-v2-phase2-retry-decode-latency.md`.
+  ///
+  /// GitHub cloud review (PR #1725): the fixed floor is
+  /// `asrInterruptionRecoveryDeadlineSec` (this SAME file's own measured,
+  /// headroom-inclusive helper-reload deadline, `8.0` — see its doc comment
+  /// above), NOT an ad-hoc `3.0`. `retryDecode`'s readiness-gated repair
+  /// calls `warmUp()` before it can even attempt the second decode when the
+  /// XPC helper died — the whole call, repair included, is bounded by this
+  /// ONE deadline (§3.2). An ad-hoc floor tuned only from measured DECODE
+  /// time (never exercising the repair path) would budget less than the
+  /// ~4.2s p99 real reload cost for any recording under ~8s, timing out
+  /// during warm-up itself before the retry could transcribe anything — the
+  /// opposite of what this mechanism exists to do. At the 3600s (60-minute)
+  /// recording cap this budgets 548s.
   func retryDecodeTimeoutSeconds(forSampleCount sampleCount: Int) -> Double {
     let audioDurationSec = Double(sampleCount) / AudioConstants.sampleRate
-    return 3.0 + audioDurationSec * 0.15
+    return asrInterruptionRecoveryDeadlineSec + audioDurationSec * 0.15
   }
 
   /// Parakeet decodes incrementally and detects no language (D2, D15). Static —

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -25,7 +25,7 @@ import Foundation
 
 /// Wraps Parakeet's `ASRManagerInterface` as a kernel-facing `ASREngineAdapter`.
 @MainActor
-final class ParakeetEngineAdapter: ASREngineAdapter {
+final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
 
   // MARK: Injected dependency
 
@@ -33,6 +33,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// #1348 Phase 2: the delivery stage that runs before any Parakeet load —
   /// nil means the legacy in-service download path (tests, or the flag off).
   private let delivery: ParakeetDeliveryHandle?
+  /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1) — `nil` in every
+  /// production/test path that doesn't explicitly construct one.
+  private let batchDecodeFaultController: BatchDecodeFaultController?
 
   // MARK: Engine-session bookkeeping (NOT FSM state — §3.11)
 
@@ -145,6 +148,18 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// cannot clear a newer call's shared tracking fields after it unwinds late.
   private var warmUpGeneration = 0
 
+  /// #1707 Phase 2: monotonic generation for the attempt/commit split shared
+  /// by `finalize()` and `retryDecode()`. Bumped by `beginSession`/
+  /// `discardSession` (a new session or a cancel/wedge-recovery must
+  /// invalidate any in-flight attempt, mirroring `recoveryGeneration`'s own
+  /// bump sites) AND by `bumpRetryGeneration()` specifically (a retry's own
+  /// honest "stop waiting" signal). A SEPARATE counter from
+  /// `recoveryGeneration`/`warmUpGeneration` — those are scoped entirely to
+  /// Phase 1's `recoverFromASRInterruption()`/`warmUp()` reentrancy, a
+  /// different mechanism at a different layer; not reused here, not
+  /// conflicting either.
+  private var retryGeneration = 0
+
   // MARK: ASREngineAdapter — engine interruption
 
   /// Optional adapter-local interruption hook. Parakeet leaves
@@ -219,11 +234,15 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
   init(
     asrManager: any ASRManagerInterface, delivery: ParakeetDeliveryHandle? = nil,
-    asrInterruptionRecoveryDeadlineSec: Double = 8.0
+    asrInterruptionRecoveryDeadlineSec: Double = 8.0,
+    // #1707 Phase 2: DEBUG fault-injection oracle (§11.1). Defaulted `nil`
+    // so every existing test construction site is unaffected.
+    batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) {
     self.asrManager = asrManager
     self.delivery = delivery
     self.asrInterruptionRecoveryDeadlineSec = asrInterruptionRecoveryDeadlineSec
+    self.batchDecodeFaultController = batchDecodeFaultController
     (loadStream, loadContinuation) = AsyncStream.makeStream(of: ASRLoadProgressTick.self)
     // ASR service interruption is single-owner at the App router. Installing
     // here races `ASREventRouter`'s handler and loses by last-writer-wins.
@@ -417,6 +436,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     // #1707: a new session invalidates any recovery attempt still pending
     // from a prior one — its post-await checks compare against this.
     recoveryGeneration &+= 1
+    retryGeneration &+= 1  // #1707 Phase 2: also invalidate any pending retry.
     sessionID = id
     decodeOptions = options
     isTerminal = false
@@ -514,22 +534,24 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
       return .cancelled
     }
     let session = sessionID
+    let generation = retryGeneration
     let outcome: ASREngineOutcome
     if streamingActive {
       await drainStreamingFeeds()
-      outcome = await finalizeStreamingWithRescue(batchSamples: batchSamples)
+      outcome = await finalizeStreamingWithRescue(
+        batchSamples: batchSamples, session: session, generation: generation)
     } else {
-      outcome = await finalizeBatch(batchSamples: batchSamples)
+      outcome = await finalizeBatch(
+        batchSamples: batchSamples, session: session, generation: generation)
     }
     // A `cancel()` + new `beginSession()` during the ASR await must not let
-    // this stale finalize clobber the fresh session's `lastResult` / retained
-    // PCM / terminal flag (Codex r2 — stale-finalize race). The kernel's own
-    // `finalize(_:)` wrapper drops the stale return value separately.
+    // this stale finalize clobber the fresh session's retained PCM / terminal
+    // flag (Codex r2 — stale-finalize race). `lastResult`/`lastASRDiagnostics`/
+    // `lastFailureError` are already gated on this SAME staleness check inside
+    // `commitAttempt`, called from `finalizeStreamingWithRescue`/`finalizeBatch`
+    // — not re-written here (single owner, #1707 Phase 2).
     guard sessionID == session, !isCancelled else {
       return isCancelled ? .cancelled : outcome
-    }
-    if case .transcript(let result) = outcome {
-      lastResult = result
     }
     isTerminal = true
     streamingActive = false
@@ -552,6 +574,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     // lifecycle op that can start replacement work invalidates any pending
     // recovery attempt in one place.
     recoveryGeneration &+= 1
+    retryGeneration &+= 1  // #1707 Phase 2: also invalidate any pending retry.
     isCancelled = true
     isTerminal = true
     lastResult = nil
@@ -613,6 +636,46 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
   func applyUnloadPolicy(_ policy: ModelUnloadPolicy) {
     asrManager.noteTranscriptionComplete(policy: policy)
+  }
+
+  // MARK: ASREngineAdapter — Phase 2 retry
+
+  /// Best-effort, honest "stop waiting" signal for a retry that has timed
+  /// out — NOT active cancellation (no genuine in-flight-decode cancel
+  /// exists on this backend, §3.2a). Bumping `retryGeneration` is what
+  /// actually prevents a late-arriving abandoned result from mutating state
+  /// belonging to a session/attempt that has since moved on — checked inside
+  /// `commitAttempt`.
+  func bumpRetryGeneration() {
+    retryGeneration &+= 1
+  }
+
+  /// #1707 Phase 2: a second, bounded batch decode attempt over audio a
+  /// PRIOR `finalize()` call already failed to decode. Always batch-only —
+  /// never re-attempts the streaming-then-rescue sequence, since a retry is
+  /// scoped to a single failed decode, not a fresh session.
+  func retryDecode(inputSamples: [Float]) async -> ASREngineOutcome {
+    // Readiness-gated repair-before-retry (§3.2): `.decodeFailed` conflates a
+    // benign decode error (helper alive, connection intact) with the XPC
+    // helper actually dying mid-transcribe (which independently clears
+    // `isModelLoaded`). Gate on the live readiness snapshot rather than the
+    // outcome alone — an honest, non-atomic signal (§3.2's documented limit).
+    let session = sessionID
+    let generation = retryGeneration
+    if readiness != .ready {
+      do {
+        try await warmUp()
+      } catch {
+        return .failed(.decodeFailed)
+      }
+      // The repair awaited — re-check staleness BEFORE spending the decode
+      // attempt on audio that may no longer belong to the current session.
+      guard sessionID == session, retryGeneration == generation else { return .cancelled }
+    }
+    // Retry is always batch-only — never re-attempt streaming-then-rescue.
+    streamingActive = false
+    let attempt = await attemptBatchDecode(samples: inputSamples)
+    return commitAttempt(attempt, session: session, generation: generation)
   }
 
   // MARK: ASREngineAdapter optional engine hooks (PR-5 Rung 2A)
@@ -678,7 +741,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
   /// saw samples), and the KERNEL re-maps it to `.noSpeech` because it knows the
   /// segments were empty. The rescue always attempts batch when streaming
   /// yields nothing.
-  private func finalizeStreamingWithRescue(batchSamples: [Float]?) async -> ASREngineOutcome {
+  private func finalizeStreamingWithRescue(
+    batchSamples: [Float]?, session: SessionID?, generation: Int
+  ) async -> ASREngineOutcome {
     var diagnostics = KernelASRAdapterDiagnostics(
       streamingBuffersDispatched: streamingBuffersDispatched,
       streamingBuffersFed: streamingBuffersFed
@@ -697,8 +762,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
         level: .info, category: "Pipeline"
       )
       if !trimmed.isEmpty {
-        lastASRDiagnostics = diagnostics
-        return .transcript(result)
+        let attempt = DecodeAttemptResult(
+          outcome: .transcript(result), diagnostics: diagnostics, failureError: nil)
+        return commitAttempt(attempt, session: session, generation: generation)
       }
       // Streaming returned empty — fall through to the batch rescue.
     } catch is CancellationError {
@@ -714,7 +780,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
     }
     // Codex r1: store the rescue outcome locally so the emit can read whether the
     // batch rescue recovered a transcript before returning it.
-    let outcome = await finalizeBatchRescue(batchSamples: batchSamples, diagnostics: diagnostics)
+    let outcome = await finalizeBatchRescue(
+      batchSamples: batchSamples, diagnostics: diagnostics, session: session, generation: generation
+    )
     // #1177 (Telemetry Bible Phase 8): observe the quiet streaming-finalize failure.
     // The heart was fine (batch rescue gave text, or raw fell through), but until now
     // we never knew streaming broke. Fire ONLY on the genuine-failure branch — a
@@ -736,7 +804,8 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
 
   private func finalizeBatchRescue(
     batchSamples: [Float]?,
-    diagnostics: KernelASRAdapterDiagnostics
+    diagnostics: KernelASRAdapterDiagnostics,
+    session: SessionID?, generation: Int
   ) async -> ASREngineOutcome {
     var diagnostics = diagnostics
     diagnostics.batchRescueAttempted = true
@@ -746,52 +815,89 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
       level: .info, category: "Pipeline"
     )
     guard !samples.isEmpty else {
-      lastASRDiagnostics = diagnostics
-      return .empty(hadSpeechEvidence: true)
+      let attempt = DecodeAttemptResult(
+        outcome: .empty(hadSpeechEvidence: true), diagnostics: diagnostics, failureError: nil)
+      return commitAttempt(attempt, session: session, generation: generation)
     }
     do {
       let result = try await asrManager.transcribe(
         audioSamples: samples, options: decodeOptions)
       let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
       diagnostics.batchRescueResultChars = trimmed.count
-      lastASRDiagnostics = diagnostics
       await AppLogger.shared.log(
         "Streaming rescue result: batch produced \(trimmed.count) chars",
         level: .info, category: "Pipeline"
       )
-      if trimmed.isEmpty {
-        return .empty(hadSpeechEvidence: true)
-      }
-      return .transcript(result)
+      let outcome: ASREngineOutcome =
+        trimmed.isEmpty ? .empty(hadSpeechEvidence: true) : .transcript(result)
+      let attempt = DecodeAttemptResult(
+        outcome: outcome, diagnostics: diagnostics, failureError: nil)
+      return commitAttempt(attempt, session: session, generation: generation)
     } catch is CancellationError {
       return .cancelled
     } catch {
-      lastFailureError = error
-      lastASRDiagnostics = diagnostics
       await AppLogger.shared.log(
         "Streaming rescue result: batch failed: \(error.localizedDescription)",
         level: .info, category: "Pipeline"
       )
-      return .failed(.decodeFailed)
+      let attempt = DecodeAttemptResult(
+        outcome: .failed(.decodeFailed), diagnostics: diagnostics, failureError: error)
+      return commitAttempt(attempt, session: session, generation: generation)
     }
   }
 
   /// Batch decode (§3.2a). Uses kernel-conditioned `batchSamples` when
   /// supplied (PR-4.5 #5 — VAD-filtered + raw-fallback + silence-padded);
   /// else falls back to the adapter's raw retained PCM.
-  private func finalizeBatch(batchSamples: [Float]?) async -> ASREngineOutcome {
+  private func finalizeBatch(
+    batchSamples: [Float]?, session: SessionID?, generation: Int
+  ) async -> ASREngineOutcome {
     let samples = batchSamples ?? retainedPCM
+    let attempt = await attemptBatchDecode(samples: samples)
+    return commitAttempt(attempt, session: session, generation: generation)
+  }
+
+  // MARK: #1707 Phase 2 — attempt/commit split
+
+  /// Pure decode-attempt result — no shared-state writes. Both `finalize()`
+  /// (via `finalizeBatch`/`finalizeStreamingWithRescue`/`finalizeBatchRescue`)
+  /// and `retryDecode()` produce one of these, then commit it through the
+  /// SAME gated step (`commitAttempt`) — the generation guard that actually
+  /// prevents a late-arriving abandoned result from mutating state belonging
+  /// to a session/attempt that has since moved on (Grounded Review r1
+  /// finding #5: a check performed only AFTER this write would be too late).
+  private struct DecodeAttemptResult {
+    let outcome: ASREngineOutcome
+    let diagnostics: KernelASRAdapterDiagnostics
+    let failureError: (any Error)?
+  }
+
+  /// Pure batch-decode attempt over already-resolved `samples` — reused by
+  /// `finalizeBatch` (existing decode, `batchSamples ?? retainedPCM`) and
+  /// `retryDecode` (always the retry's own `inputSamples`, no fallback: the
+  /// first attempt's `retainedPCM` is already cleared by the time a retry
+  /// runs). No shared-state writes; the caller commits via `commitAttempt`.
+  private func attemptBatchDecode(samples: [Float]) async -> DecodeAttemptResult {
     var diagnostics = KernelASRAdapterDiagnostics(batchRescueAttempted: false)
     guard !samples.isEmpty else {
-      lastASRDiagnostics = diagnostics
-      return .empty(hadSpeechEvidence: true)
+      return DecodeAttemptResult(
+        outcome: .empty(hadSpeechEvidence: true), diagnostics: diagnostics, failureError: nil)
+    }
+    // #1707 Phase 2 (§11.1): DEBUG-only forced-failure fault, consulted only
+    // AFTER the real retry input snapshot above is already prepared — proving
+    // the retry genuinely re-decodes real, already-captured audio. `nil`
+    // controller (production, and every test that doesn't opt in) never
+    // forces a failure.
+    if batchDecodeFaultController?.shouldForceFailBatchDecode(backend: .parakeet) == true {
+      let error = ASREngineError.decodeFailed
+      return DecodeAttemptResult(
+        outcome: .failed(error), diagnostics: diagnostics, failureError: error)
     }
     do {
       let result = try await asrManager.transcribe(
         audioSamples: samples, options: decodeOptions)
       let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
       diagnostics.batchRescueResultChars = trimmed.count
-      lastASRDiagnostics = diagnostics
       if trimmed.isEmpty {
         // The adapter saw samples, so it reports `hadSpeechEvidence: true`. Past
         // the kernel's VAD no-speech gate this normally routes to
@@ -800,16 +906,40 @@ final class ParakeetEngineAdapter: ASREngineAdapter {
         // recovery path (zero VAD segments but raw energy above the dead-air
         // floor) it re-maps this empty result to `.noSpeech`. The kernel owns
         // that decision; the adapter's report is unchanged.
-        return .empty(hadSpeechEvidence: true)
+        return DecodeAttemptResult(
+          outcome: .empty(hadSpeechEvidence: true), diagnostics: diagnostics, failureError: nil)
       }
-      return .transcript(result)
+      return DecodeAttemptResult(
+        outcome: .transcript(result), diagnostics: diagnostics, failureError: nil)
     } catch is CancellationError {
-      return .cancelled
+      return DecodeAttemptResult(outcome: .cancelled, diagnostics: diagnostics, failureError: nil)
     } catch {
-      lastFailureError = error
-      lastASRDiagnostics = diagnostics
-      return .failed(.decodeFailed)
+      return DecodeAttemptResult(
+        outcome: .failed(.decodeFailed), diagnostics: diagnostics, failureError: error)
     }
+  }
+
+  /// Commit step, shared by every batch-decode-shaped path
+  /// (`finalizeBatch`/`finalizeStreamingWithRescue`/`finalizeBatchRescue`/
+  /// `retryDecode`): writes `lastASRDiagnostics`/`lastFailureError`/
+  /// `lastResult` ONLY while the captured session and generation are still
+  /// current — the SOLE owner of these three fields (§3c single-authority).
+  /// Session-closing bookkeeping (`isTerminal`/`streamingActive`/
+  /// `retainedPCM`) is NOT this function's concern — `finalize()`'s own
+  /// wrapper owns that, since a retry does not re-terminate an
+  /// already-terminal session.
+  private func commitAttempt(
+    _ attempt: DecodeAttemptResult, session: SessionID?, generation: Int
+  ) -> ASREngineOutcome {
+    guard sessionID == session, retryGeneration == generation else { return .cancelled }
+    lastASRDiagnostics = attempt.diagnostics
+    if let failureError = attempt.failureError {
+      lastFailureError = failureError
+    }
+    if case .transcript(let result) = attempt.outcome {
+      lastResult = result
+    }
+    return attempt.outcome
   }
 
   // MARK: PCM retention

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -256,6 +256,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     ASREngineIdentity(backendType: .parakeet)
   }
 
+  /// #1707 Phase 2: PLACEHOLDER — see the protocol doc comment.
+  var retryDecodeTimeoutSeconds: Double { 8.0 }
+
   /// Parakeet decodes incrementally and detects no language (D2, D15). Static —
   /// the kernel branches on `capabilities`, never on engine identity.
   var capabilities: ASREngineCapabilities {

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -822,6 +822,20 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         outcome: .empty(hadSpeechEvidence: true), diagnostics: diagnostics, failureError: nil)
       return commitAttempt(attempt, session: session, generation: generation)
     }
+    // Codex r4: this real decode call bypassed the §11.1 fault check entirely
+    // — `fail_batch_decode(parakeet)`/`fail_every_batch_decode(parakeet)` must
+    // cover EVERY real batch-decode call this adapter issues, not just the
+    // one `attemptBatchDecode` makes, or a Live UAT test targeting a
+    // streaming session's rescue path would silently never exercise the
+    // Phase-2 retry it's trying to test.
+    if batchDecodeFaultController?.shouldForceFailBatchDecode(
+      backend: .parakeet, sampleCount: samples.count) == true
+    {
+      let error = ASREngineError.decodeFailed
+      let attempt = DecodeAttemptResult(
+        outcome: .failed(error), diagnostics: diagnostics, failureError: error)
+      return commitAttempt(attempt, session: session, generation: generation)
+    }
     do {
       let result = try await asrManager.transcribe(
         audioSamples: samples, options: decodeOptions)
@@ -891,7 +905,9 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     // the retry genuinely re-decodes real, already-captured audio. `nil`
     // controller (production, and every test that doesn't opt in) never
     // forces a failure.
-    if batchDecodeFaultController?.shouldForceFailBatchDecode(backend: .parakeet) == true {
+    if batchDecodeFaultController?.shouldForceFailBatchDecode(
+      backend: .parakeet, sampleCount: samples.count) == true
+    {
       let error = ASREngineError.decodeFailed
       return DecodeAttemptResult(
         outcome: .failed(error), diagnostics: diagnostics, failureError: error)

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -675,7 +675,13 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         // (`?? retryError`) never triggers because that stale value is
         // non-nil, so Sentry would attribute retry exhaustion to the wrong
         // (primary) failure instead of this actual warm-up/repair failure.
-        lastFailureError = error
+        // Codex r7: but this write must be staleness-gated exactly like
+        // `commitAttempt`'s — an abandoned retry's `warmUp()` throwing AFTER
+        // it was superseded (session changed, or `bumpRetryGeneration()` from
+        // a timeout) must not overwrite a NEWER session's own failure.
+        if sessionID == session, retryGeneration == generation {
+          lastFailureError = error
+        }
         return .failed(.decodeFailed)
       }
       // The repair awaited — re-check staleness BEFORE spending the decode

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -669,6 +669,13 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
       do {
         try await warmUp()
       } catch {
+        // Codex r6: without this, `lastFailureError` still holds the STALE
+        // error from the PRIMARY decode's own earlier failure (set by
+        // `commitAttempt` there) — the kernel's error-attribution fix
+        // (`?? retryError`) never triggers because that stale value is
+        // non-nil, so Sentry would attribute retry exhaustion to the wrong
+        // (primary) failure instead of this actual warm-up/repair failure.
+        lastFailureError = error
         return .failed(.decodeFailed)
       }
       // The repair awaited — re-check staleness BEFORE spending the decode

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -161,8 +161,10 @@ public enum RecordingCancelOrigin: Equatable, Sendable {
 /// crosses into AppKit, where `RecoveryCoordinator` applies the SOLE
 /// delete-versus-retain predicate:
 ///
-/// - delete: `.discarded`, `.noSpeech`, `.cancelled(.user)` — nothing worth
-///   recovering, or the user asked to drop it.
+/// - delete: `.discarded`, `.noSpeech`, `.cancelled(.user)`, `.asrRetryExhausted`
+///   — nothing worth recovering, the user asked to drop it, or (#1707 Phase 2)
+///   this session spent and exhausted its one live retry over the exact same
+///   audio, so there is nothing left to recover on the next launch either.
 /// - retain: `.failed`, `.audioInterrupted`, `.asrInterrupted`, `.noTransport`,
 ///   `.cancelled(.systemOrFault)` — the captured audio is the user's words; keep
 ///   the spool so the next launch recovers it.
@@ -173,6 +175,11 @@ public enum RecordingRecoveryEnding: Equatable, Sendable {
   case discarded
   case noSpeech
   case failed
+  /// #1707 Phase 2: a `.failed` session that spent and exhausted its one
+  /// Phase-2 retry over the exact same already-captured audio. Distinct from
+  /// plain `.failed` (a pre-capture failure, or a `.failed` that never
+  /// consulted Phase 2) — only this case deletes the spool.
+  case asrRetryExhausted
   case audioInterrupted
   case asrInterrupted
   case noTransport

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -409,16 +409,12 @@ final class RecordingSessionKernel {
   /// start.
   private var hasUsedPhase2Retry: Bool = false
 
-  /// #1707 Phase 2: per-backend retry-decode timeout budget. PLACEHOLDER —
-  /// §11.1 requires this to be tuned from a real, stratified Live UAT latency
-  /// measurement (≥30 samples per {backend}×{short/medium/long audio} bucket,
-  /// RULE: timeout-numbers-need-distribution-evidence), not asserted from
-  /// reasoning alone. These values are a conservative starting point only.
-  /// The per-backend split itself lives on `ASRBackendType` (mirrors
-  /// `displayName`), not here — a per-engine identity-case literal is
-  /// banned at this kernel reader site (`EngineIdentityFreezeTests`).
+  /// #1707 Phase 2: this adapter's own retry-decode timeout budget (Codex r3:
+  /// Pipeline-owned retry POLICY, read straight from the adapter seam — no
+  /// per-backend switch or identity-case literal at this kernel reader site
+  /// at all, closed-set or otherwise).
   private var asrRetryDeadlineSec: Double {
-    adapter.engineIdentity.backendType.defaultRetryDecodeTimeoutSeconds
+    adapter.retryDecodeTimeoutSeconds
   }
 
   /// How delivery happened, or `nil` if nothing was delivered.
@@ -2239,7 +2235,19 @@ final class RecordingSessionKernel {
           salvageArchiveFed = retryInput
         #endif
         await runFinalizing(sid, asrText: retryResult.text, transcriptID: transcriptID)
-      default:  // nil (timed out), .empty, .cancelled, .failed — all discard identically
+      case .failed(let retryError):
+        // Codex r3: the retry's OWN failure, not the stale primary-decode
+        // error `transcriptionFailureError` was set to before this retry
+        // started (`:2172`) — otherwise the Sentry `.asrFailed` capture
+        // attributes retry exhaustion to the wrong failure whenever the two
+        // attempts fail for different reasons. The terminal choice itself
+        // does not differentiate (RULE: discard-not-differentiate) — only
+        // this error-attribution field does.
+        telemetryState.transcriptionFailureError =
+          (adapter as? ASREngineTelemetryProviding)?.lastFailureError ?? retryError
+        telemetryState.asrRetryOutcome = .retryExhausted
+        finishTerminal(.failed(.asrFailed), sid: sid)
+      default:  // nil (timed out), .empty, .cancelled — discard identically, primary error stands
         telemetryState.asrRetryOutcome = .retryExhausted
         finishTerminal(.failed(.asrFailed), sid: sid)
       }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2210,6 +2210,15 @@ final class RecordingSessionKernel {
         // mislabel a batch retry as "streaming" whenever the ORIGINAL,
         // non-retry attempt happened to be a streaming session.
         stampAcceptedTranscriptTelemetry(result: retryResult, mode: "batch")
+        #if DEBUG
+          // The archive tail below still reads the ORIGINAL failed outcome
+          // unless rebound here — mirrors the salvage-ladder's identical
+          // rebind (Codex r1 finding): a successfully delivered, retry-
+          // rescued dictation must archive as its own success, not as the
+          // primary decode's failure.
+          archiveClassification = "phase2RetrySucceeded"
+          archiveEffectiveOutcome = .transcript(retryResult)
+        #endif
         await runFinalizing(sid, asrText: retryResult.text, transcriptID: transcriptID)
       default:  // nil (timed out), .empty, .cancelled, .failed — all discard identically
         telemetryState.asrRetryOutcome = .retryExhausted

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -196,6 +196,12 @@ final class RecordingSessionKernel {
   private let audioCapture: any AudioCaptureInterface
   private let vad: any VADSignalSource
 
+  /// #1707 Phase 2: oracle for the shared-backend overlap Live UAT
+  /// (§3.2a-i). Always compiled — a plain timestamp-recording class; release
+  /// builds never construct/wire a real instance, so this stays `nil` and a
+  /// no-op in production.
+  private let batchDecodeFaultController: BatchDecodeFaultController?
+
   /// Logical-time seam (PR-3 plan §14a). Production wiring of a real clock is
   /// PR-4/PR-7; the simulator wires `FakeClock`.
   private let currentTick: @MainActor () -> UInt64
@@ -350,6 +356,15 @@ final class RecordingSessionKernel {
     telemetryState.asrSalvageOutcome
   }
 
+  /// #1707 Phase 2: read-through to this session's post-capture-decode retry
+  /// outcome, or `nil` if no Phase-2 retry ever started. Feeds the
+  /// success-side `dictation.completed` reporting chain (driver read-through
+  /// → `DictationCompletedReporting` → `TelemetryService`) and the
+  /// `.asrFailed`/`.asrInterrupted` Sentry breadcrumbs.
+  var asrRetryOutcome: ASRRetryOutcome? {
+    telemetryState.asrRetryOutcome
+  }
+
   /// #1317: which zero-signal failure mode this session was classified as, or
   /// `nil` if it never was. Stamped once by the winning classification
   /// (reactive `.zeroSignal` exit OR STOP-time), cleared per session in
@@ -386,6 +401,25 @@ final class RecordingSessionKernel {
   /// would misreport every streaming session as batch). Reset on session
   /// start.
   private(set) var isStreamingSession: Bool = false
+
+  /// #1707 Phase 2: `true` once this session has spent its one live retry
+  /// over a post-capture decode failure. A defensive re-entry guard, not a
+  /// race condition to protect against for the ordinary case — `finalize()`
+  /// is called exactly once per session by construction. Reset on session
+  /// start.
+  private var hasUsedPhase2Retry: Bool = false
+
+  /// #1707 Phase 2: per-backend retry-decode timeout budget. PLACEHOLDER —
+  /// §11.1 requires this to be tuned from a real, stratified Live UAT latency
+  /// measurement (≥30 samples per {backend}×{short/medium/long audio} bucket,
+  /// RULE: timeout-numbers-need-distribution-evidence), not asserted from
+  /// reasoning alone. These values are a conservative starting point only.
+  /// The per-backend split itself lives on `ASRBackendType` (mirrors
+  /// `displayName`), not here — a per-engine identity-case literal is
+  /// banned at this kernel reader site (`EngineIdentityFreezeTests`).
+  private var asrRetryDeadlineSec: Double {
+    adapter.engineIdentity.backendType.defaultRetryDecodeTimeoutSeconds
+  }
 
   /// How delivery happened, or `nil` if nothing was delivered.
   private(set) var deliveryOutcome: KernelDeliveryOutcome?
@@ -670,7 +704,14 @@ final class RecordingSessionKernel {
     markASRTimingStart: @escaping @MainActor (_ streaming: Bool) -> Void = { _ in },
     markASRTimingEnd: @escaping @MainActor () -> Void = {},
     telemetryState: KernelTelemetryState = KernelTelemetryState(),
-    dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false }
+    dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
+    // #1707 Phase 2: oracle for the shared-backend overlap Live UAT
+    // (§3.2a-i). Defaulted `nil` so every existing test construction site is
+    // unaffected. `BatchDecodeFaultController` is always compiled (a plain
+    // timestamp-recording class) — only its actual fault-actuating methods
+    // are `#if DEBUG`-gated, and release builds never construct/wire a real
+    // instance, so this stays a no-op in production.
+    batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) {
     self.adapter = adapter
     self.audioCapture = audioCapture
@@ -711,6 +752,7 @@ final class RecordingSessionKernel {
     self.markASRTimingEnd = markASRTimingEnd
     self.telemetryState = telemetryState
     self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
+    self.batchDecodeFaultController = batchDecodeFaultController
   }
 
   // MARK: Driver entry points (PR-1 §A.2 trigger vocabulary)
@@ -1956,46 +1998,53 @@ final class RecordingSessionKernel {
         decodedInputSampleCount: decodedInputCount,
         lastTokenEndMs: result.tokenTimingSummary?.lastTokenEndMs)
       let adapterDiag = (adapter as? ASREngineTelemetryProviding)?.lastASRDiagnostics
-      telemetryState.asrCompletedTelemetry = KernelASRCompletedTelemetry(
-        durationSeconds: result.processingTime,
-        charCount: result.text.trimmingCharacters(in: .whitespacesAndNewlines).count,
-        mode: isStreamingSession ? "streaming" : "batch",
-        language: result.language,
-        // PR-5 Rung 5 Pass 2 r2 #B1: carry the incremental-vs-batch outcome into
-        // the ASR-completed Sentry breadcrumb (parity with OLD
-        // `WhisperKitPipeline.swift:1049-1052`). nil for Parakeet.
-        incrementalAccepted: adapterDiag?.incrementalAccepted,
-        // #950 tail-trim diagnostic (eligible Parakeet batch only; nil omitted).
-        droppedTailMs: tailDroppedMs,
-        tailHadEnergy: tailHadEnergy,
-        // #950 tail-preserve recovery + tuning signals.
-        usedTailPreservation: usedTailPreservation,
-        recoveredTailMs: recoveredTailMs,
-        tailVoicedFraction: tailVoicedFractionForTelemetry,
-        tailRefusedReason: tailRefusedReason,
-        tailClipClassification: tailClip.classification.rawValue,
-        captureTrailingSilenceMs: tailClip.trailingSilenceMs,
-        captureTail200Rms: Double(tailClip.tail200RMS),
-        captureTail200Peak: Double(tailClip.tail200Peak),
-        asrInputDurationMs: tailClip.asrInputDurationMs,
-        asrLastTokenEndMs: tailClip.asrLastTokenEndMs,
-        asrLastTokenGapMs: tailClip.asrLastTokenGapMs,
-        asrChunked: tailClip.asrChunked,
-        // #1309 effective-path streaming telemetry. Requested comes from the
-        // kernel's own capability gate; effective/degrade/path from the
-        // adapter's diagnostics. WhisperKit-only (nil for Parakeet → omitted).
-        streamingRequested: adapterDiag?.streamingEffective != nil ? isStreamingSession : nil,
-        streamingEffective: adapterDiag?.streamingEffective,
-        streamingDegradeReason: adapterDiag?.streamingDegradeReason,
-        streamingFinalPath: adapterDiag?.streamingFinalPath,
-        streamingDecodeCount: adapterDiag?.incrementalDecodeCount,
-        streamingCoveredSec: adapterDiag?.incrementalSamplesCovered.map {
-          Double($0) / AudioConstants.sampleRate
-        },
-        tailDecodeSec: adapterDiag?.incrementalTailDecodeMs.map { Double($0) / 1000.0 },
-        maxUnconfirmedWindowSec: adapterDiag?.streamingMaxUnconfirmedWindowSec,
-        stopWhileDecodeInFlight: adapterDiag?.stopWhileDecodeInFlight
-      )
+      // #1707 Phase 2: the core fields (duration/char-count/mode/language) are
+      // stamped via the shared helper both this ordinary success path and the
+      // retry-success path (§3.3) use, so a retry-rescued completion can never
+      // skip this telemetry the way a bare `runFinalizing` call would. This
+      // branch then layers its own tail-clip/streaming/salvage-specific fields
+      // on top — a retry has no separate tail-trim/streaming event of its own,
+      // so those stay nil there (never duplicated from a stale first attempt).
+      stampAcceptedTranscriptTelemetry(
+        result: result, mode: isStreamingSession ? "streaming" : "batch")
+      var completedTelemetry = telemetryState.asrCompletedTelemetry!
+      // PR-5 Rung 5 Pass 2 r2 #B1: carry the incremental-vs-batch outcome into
+      // the ASR-completed Sentry breadcrumb (parity with OLD
+      // `WhisperKitPipeline.swift:1049-1052`). nil for Parakeet.
+      completedTelemetry.incrementalAccepted = adapterDiag?.incrementalAccepted
+      // #950 tail-trim diagnostic (eligible Parakeet batch only; nil omitted).
+      completedTelemetry.droppedTailMs = tailDroppedMs
+      completedTelemetry.tailHadEnergy = tailHadEnergy
+      // #950 tail-preserve recovery + tuning signals.
+      completedTelemetry.usedTailPreservation = usedTailPreservation
+      completedTelemetry.recoveredTailMs = recoveredTailMs
+      completedTelemetry.tailVoicedFraction = tailVoicedFractionForTelemetry
+      completedTelemetry.tailRefusedReason = tailRefusedReason
+      completedTelemetry.tailClipClassification = tailClip.classification.rawValue
+      completedTelemetry.captureTrailingSilenceMs = tailClip.trailingSilenceMs
+      completedTelemetry.captureTail200Rms = Double(tailClip.tail200RMS)
+      completedTelemetry.captureTail200Peak = Double(tailClip.tail200Peak)
+      completedTelemetry.asrInputDurationMs = tailClip.asrInputDurationMs
+      completedTelemetry.asrLastTokenEndMs = tailClip.asrLastTokenEndMs
+      completedTelemetry.asrLastTokenGapMs = tailClip.asrLastTokenGapMs
+      completedTelemetry.asrChunked = tailClip.asrChunked
+      // #1309 effective-path streaming telemetry. Requested comes from the
+      // kernel's own capability gate; effective/degrade/path from the
+      // adapter's diagnostics. WhisperKit-only (nil for Parakeet → omitted).
+      completedTelemetry.streamingRequested =
+        adapterDiag?.streamingEffective != nil ? isStreamingSession : nil
+      completedTelemetry.streamingEffective = adapterDiag?.streamingEffective
+      completedTelemetry.streamingDegradeReason = adapterDiag?.streamingDegradeReason
+      completedTelemetry.streamingFinalPath = adapterDiag?.streamingFinalPath
+      completedTelemetry.streamingDecodeCount = adapterDiag?.incrementalDecodeCount
+      completedTelemetry.streamingCoveredSec = adapterDiag?.incrementalSamplesCovered.map {
+        Double($0) / AudioConstants.sampleRate
+      }
+      completedTelemetry.tailDecodeSec =
+        adapterDiag?.incrementalTailDecodeMs.map { Double($0) / 1000.0 }
+      completedTelemetry.maxUnconfirmedWindowSec = adapterDiag?.streamingMaxUnconfirmedWindowSec
+      completedTelemetry.stopWhileDecodeInFlight = adapterDiag?.stopWhileDecodeInFlight
+      telemetryState.asrCompletedTelemetry = completedTelemetry
       // #1232 debug-log line: the per-dictation tail-clip verdict + lead signals,
       // greppable in app.log next to the conditioner line for live triage.
       log(
@@ -2121,7 +2170,51 @@ final class RecordingSessionKernel {
     case .failed(let error):
       telemetryState.transcriptionFailureError =
         (adapter as? ASREngineTelemetryProviding)?.lastFailureError ?? error
-      finishTerminal(.failed(.asrFailed), sid: sid)
+      // #1707 Phase 2: give this ONE specific failure (a post-capture decode
+      // failure over already-captured audio) exactly one retry before
+      // discarding. A pre-capture `beginSession` failure never reaches this
+      // switch at all (it fires from a structurally separate catch block), so
+      // `hasUsedPhase2Retry` is never even consulted there — zero retries by
+      // construction, not by an explicit check.
+      guard !hasUsedPhase2Retry else {
+        finishTerminal(.failed(.asrFailed), sid: sid)
+        break  // fall through to the shared archive tail, matching every other case
+      }
+      hasUsedPhase2Retry = true
+      telemetryState.asrRetryOutcome = .attempted  // breadcrumb BEFORE the await
+      let retryInput =
+        adapter.capabilities.decodesConditionedBatchSamples
+        ? asrSamples : captureResult.samples
+      // Oracle timestamp — nil no-op unless a Live UAT test wired a real
+      // controller (never happens in release).
+      batchDecodeFaultController?.recordRetryStarted()
+      let retryOutcome = await withOrderedDeadline(
+        seconds: asrRetryDeadlineSec,  // measured per-backend — see §11.1
+        operation: { [adapter] in await adapter.retryDecode(inputSamples: retryInput) },
+        // No genuine in-flight-decode cancellation exists on either backend.
+        // `onTimeout` is honest about this: it bumps the adapter's own
+        // retry-generation token (checked INSIDE the adapter's commit step) so
+        // a late-arriving result cannot mutate whatever session/state exists
+        // by the time it finishes, without pretending to actively stop anything.
+        onTimeout: { [weak self, weak adapter] in
+          self?.batchDecodeFaultController?.recordRetryTimeoutFired()
+          adapter?.bumpRetryGeneration()
+        }
+      )
+      guard isCurrent(sid), recordingOutcome == nil else { return }
+      switch retryOutcome {
+      case .transcript(let retryResult):
+        telemetryState.asrRetryOutcome = .retrySucceeded
+        // Every Phase-2 retry is batch-only by construction (§3.1's
+        // `retryDecode` doc comment) — using `isStreamingSession` here would
+        // mislabel a batch retry as "streaming" whenever the ORIGINAL,
+        // non-retry attempt happened to be a streaming session.
+        stampAcceptedTranscriptTelemetry(result: retryResult, mode: "batch")
+        await runFinalizing(sid, asrText: retryResult.text, transcriptID: transcriptID)
+      default:  // nil (timed out), .empty, .cancelled, .failed — all discard identically
+        telemetryState.asrRetryOutcome = .retryExhausted
+        finishTerminal(.failed(.asrFailed), sid: sid)
+      }
     }
 
     // #1230 — the single dictation-audio archive call. Runs AFTER the outcome
@@ -3289,6 +3382,7 @@ final class RecordingSessionKernel {
     forbiddenTransitionRejected = false
     formatStabilizedThisSession = nil
     captureRebuiltForFormatThisSession = nil
+    hasUsedPhase2Retry = false  // #1707 Phase 2
   }
 
   /// Derive decode options from the frozen session config's language mode
@@ -3354,6 +3448,24 @@ final class RecordingSessionKernel {
         outputTransport: resolvedRoute?.outputTransport,
         routeResolutionSource: resolvedRoute?.routeResolutionSource
       )
+    )
+  }
+
+  /// #1707 Phase 2: shared "accepted transcript" telemetry-population step.
+  /// Used by BOTH the ordinary `.transcript` success branch (which layers its
+  /// own tail-clip/streaming/salvage-specific fields on top afterward) and the
+  /// retry-success branch (§3.3, which adds nothing further — a retry has no
+  /// separate tail-trim/streaming event of its own to report, and duplicating
+  /// the first attempt's now-stale diagnostic values would be misleading, not
+  /// merely incomplete). Without this shared step, a retry-rescued completion
+  /// calling `runFinalizing` directly would never populate this telemetry at
+  /// all, since `runFinalizing` itself only processes/stores/delivers/completes.
+  private func stampAcceptedTranscriptTelemetry(result: ASRResult, mode: String) {
+    telemetryState.asrCompletedTelemetry = KernelASRCompletedTelemetry(
+      durationSeconds: result.processingTime,
+      charCount: result.text.trimmingCharacters(in: .whitespacesAndNewlines).count,
+      mode: mode,
+      language: result.language
     )
   }
 

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2206,6 +2206,22 @@ final class RecordingSessionKernel {
       // Idempotent: a plain overwrite.
       markASRTimingEnd()
       guard isCurrent(sid), recordingOutcome == nil else { return }
+      // Codex r5: a TIMEOUT (`nil`) is NOT a confirmed second failure — the
+      // real decode call is still running in the background (no genuine
+      // in-flight cancellation exists on either backend, per the comment
+      // above) and could still succeed after our still-unmeasured placeholder
+      // deadline (§11.1) gave up waiting, especially for a long recording.
+      // Conflating "we stopped waiting" with "the decode genuinely produced
+      // nothing" would delete recoverable user audio. Leave
+      // `asrRetryOutcome` at `.attempted` (never promote to
+      // `.retryExhausted`) so `recoveryEnding`/`shouldDeleteOnLiveEnding`
+      // retain the spool exactly as a plain `.failed` — only a retry that
+      // ACTUALLY resolved (success, or a genuine `.empty`/`.cancelled`/
+      // `.failed`) is exhausted.
+      guard let retryOutcome else {
+        finishTerminal(.failed(.asrFailed), sid: sid)
+        return
+      }
       switch retryOutcome {
       case .transcript(let retryResult):
         telemetryState.asrRetryOutcome = .retrySucceeded
@@ -2247,7 +2263,7 @@ final class RecordingSessionKernel {
           (adapter as? ASREngineTelemetryProviding)?.lastFailureError ?? retryError
         telemetryState.asrRetryOutcome = .retryExhausted
         finishTerminal(.failed(.asrFailed), sid: sid)
-      default:  // nil (timed out), .empty, .cancelled — discard identically, primary error stands
+      default:  // .empty, .cancelled — genuinely resolved with nothing useful; exhausted
         telemetryState.asrRetryOutcome = .retryExhausted
         finishTerminal(.failed(.asrFailed), sid: sid)
       }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2199,15 +2199,21 @@ final class RecordingSessionKernel {
           adapter?.bumpRetryGeneration()
         }
       )
-      // Codex r2 finding: `markASRTimingEnd()` already froze the end
-      // timestamp for the FAILED primary decode before this retry started.
-      // Mirrors the salvage ladder's identical re-stamp (`:2101`) — called
-      // unconditionally (success or exhaustion) because real wall-clock time
-      // elapsed either way, and BEFORE the currency guard below since the
-      // elapsed time is real even if this session turns out to be stale.
-      // Idempotent: a plain overwrite.
-      markASRTimingEnd()
+      // GitHub cloud review (PR #1725): moved AFTER the currency guard —
+      // `markASRTimingEnd()` writes into the kernel's single shared
+      // `KernelFinalizationOutcome` instance (`outcome.asrEndedAtSeconds`),
+      // not a per-session value. The original pre-guard placement (Codex
+      // r2) meant an abandoned session A's retry, resolving after session B
+      // has already started and stamped its OWN `asrStartedAtSeconds`,
+      // would overwrite B's `asrEndedAtSeconds` with A's stale timestamp
+      // before this guard could reject A as stale — corrupting B's ASR
+      // latency telemetry even though B's own terminal state stays correct.
+      // Only the CURRENT session's telemetry ever reads this field (a
+      // stale session's own `finishTerminal` never runs), so stamping it
+      // only once currency is confirmed loses nothing for the live case
+      // and eliminates the cross-session write for the stale one.
       guard isCurrent(sid), recordingOutcome == nil else { return }
+      markASRTimingEnd()
       // Codex r5: a TIMEOUT (`nil`) is NOT a confirmed second failure — the
       // real decode call is still running in the background (no genuine
       // in-flight cancellation exists on either backend, per the comment

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -412,9 +412,11 @@ final class RecordingSessionKernel {
   /// #1707 Phase 2: this adapter's own retry-decode timeout budget (Codex r3:
   /// Pipeline-owned retry POLICY, read straight from the adapter seam — no
   /// per-backend switch or identity-case literal at this kernel reader site
-  /// at all, closed-set or otherwise).
-  private var asrRetryDeadlineSec: Double {
-    adapter.retryDecodeTimeoutSeconds
+  /// at all, closed-set or otherwise). Codex r8/r9: length-aware — the
+  /// budget scales with the audio being retried, so a genuinely long
+  /// recording is not rejected on a one-size-fits-all deadline.
+  private func asrRetryDeadlineSec(forSampleCount sampleCount: Int) -> Double {
+    adapter.retryDecodeTimeoutSeconds(forSampleCount: sampleCount)
   }
 
   /// How delivery happened, or `nil` if nothing was delivered.
@@ -2185,7 +2187,7 @@ final class RecordingSessionKernel {
       // controller (never happens in release).
       batchDecodeFaultController?.recordRetryStarted()
       let retryOutcome = await withOrderedDeadline(
-        seconds: asrRetryDeadlineSec,  // measured per-backend — see §11.1
+        seconds: asrRetryDeadlineSec(forSampleCount: retryInput.count),  // measured, length-aware — see §11.1
         operation: { [adapter] in await adapter.retryDecode(inputSamples: retryInput) },
         // No genuine in-flight-decode cancellation exists on either backend.
         // `onTimeout` is honest about this: it bumps the adapter's own

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2201,6 +2201,14 @@ final class RecordingSessionKernel {
           adapter?.bumpRetryGeneration()
         }
       )
+      // Codex r2 finding: `markASRTimingEnd()` already froze the end
+      // timestamp for the FAILED primary decode before this retry started.
+      // Mirrors the salvage ladder's identical re-stamp (`:2101`) — called
+      // unconditionally (success or exhaustion) because real wall-clock time
+      // elapsed either way, and BEFORE the currency guard below since the
+      // elapsed time is real even if this session turns out to be stale.
+      // Idempotent: a plain overwrite.
+      markASRTimingEnd()
       guard isCurrent(sid), recordingOutcome == nil else { return }
       switch retryOutcome {
       case .transcript(let retryResult):
@@ -2218,6 +2226,17 @@ final class RecordingSessionKernel {
           // primary decode's failure.
           archiveClassification = "phase2RetrySucceeded"
           archiveEffectiveOutcome = .transcript(retryResult)
+          // Codex r2 finding: for an originally-STREAMING Parakeet session,
+          // the retry's own diagnostics report `batchRescueAttempted ==
+          // false` (this is a Phase-2 retry, not the adapter's internal
+          // streaming-then-batch-rescue fallback), so the archive tail's
+          // heuristic would otherwise misclassify this as a streaming win
+          // and archive an empty fed buffer. Reuse the salvage ladder's own
+          // override slot — the same "what did this delivery actually
+          // decode" escape hatch, mutually exclusive with the salvage
+          // ladder's own use of it (that lives in the sibling `.empty` case
+          // of this same switch).
+          salvageArchiveFed = retryInput
         #endif
         await runFinalizing(sid, asrText: retryResult.text, transcriptID: transcriptID)
       default:  // nil (timed out), .empty, .cancelled, .failed — all discard identically

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2217,9 +2217,11 @@ final class RecordingSessionKernel {
       // nothing" would delete recoverable user audio. Leave
       // `asrRetryOutcome` at `.attempted` (never promote to
       // `.retryExhausted`) so `recoveryEnding`/`shouldDeleteOnLiveEnding`
-      // retain the spool exactly as a plain `.failed` — only a retry that
-      // ACTUALLY resolved (success, or a genuine `.empty`/`.cancelled`/
-      // `.failed`) is exhausted.
+      // retain the spool exactly as a plain `.failed`. GitHub cloud review
+      // (PR #1725): `.cancelled` gets the SAME non-exhausted treatment
+      // below — only `.empty`/`.failed` are a confirmed decode conclusion
+      // with nothing useful; `.cancelled` means we have no conclusion at
+      // all, same as the timeout case here.
       guard let retryOutcome else {
         finishTerminal(.failed(.asrFailed), sid: sid)
         return
@@ -2265,8 +2267,18 @@ final class RecordingSessionKernel {
           (adapter as? ASREngineTelemetryProviding)?.lastFailureError ?? retryError
         telemetryState.asrRetryOutcome = .retryExhausted
         finishTerminal(.failed(.asrFailed), sid: sid)
-      default:  // .empty, .cancelled — genuinely resolved with nothing useful; exhausted
+      case .empty:  // genuinely resolved with nothing useful; exhausted
         telemetryState.asrRetryOutcome = .retryExhausted
+        finishTerminal(.failed(.asrFailed), sid: sid)
+      case .cancelled:
+        // GitHub cloud review (PR #1725): `.cancelled` is NOT a confirmed
+        // second failure the way `.empty`/`.failed` are — both adapters can
+        // return it from a genuine backend `CancellationError` (a real
+        // Task/XPC cancellation mid-decode) with THIS session still
+        // current, not only from the staleness guard's own supersede path.
+        // Either way we have no confirmed decode conclusion, exactly the
+        // nil-timeout case above — leave `asrRetryOutcome` at `.attempted`
+        // so the spool is retained, never promoted to `.retryExhausted`.
         finishTerminal(.failed(.asrFailed), sid: sid)
       }
     }

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -234,8 +234,6 @@ internal final class TextProcessingRunner {
             )
           }
         }
-      } catch is CancellationError {
-        throw CancellationError()
       } catch {
         let stepMs = (CFAbsoluteTimeGetCurrent() - stepStart) * 1000
         let isTimeout = error is TimeoutError
@@ -320,10 +318,23 @@ internal final class TextProcessingRunner {
         }
         let isSilentPolishSkip = silentPolishSkipReason != nil
         // #945: a raw `URLError.cancelled` from a torn-down request is not a real
-        // failure — never surface a notice or fire a capture for it. Swift
-        // `CancellationError` is already short-circuited above
-        // (`catch is CancellationError`); this covers the URL-loading variant.
-        let isCancellationLike = (error as? URLError)?.code == .cancelled
+        // failure — never surface a notice or fire a capture for it.
+        // #1707 Phase 2 (Open Decision #9): a bare `CancellationError` reaching
+        // here is, by construction, ALWAYS an incidental Task-tree cancellation
+        // today — `RecordingFinalizer.cancel()` cannot fire once state has
+        // moved past recording/loading, so no producer carries deliberate
+        // user-cancel provenance. Reclassified from "abort the whole run,
+        // retain the spool" to the SAME silent skip the URLError variant
+        // already gets: if a limb is interrupted after valid deterministic
+        // text already exists, the user gets that text, not data loss. Simply
+        // deleting the old `catch is CancellationError { throw
+        // CancellationError() }` line would NOT have been sufficient — an
+        // unclassified `CancellationError` matches none of the OTHER silent-skip
+        // conditions below and would have been treated as a SURFACED failure,
+        // the opposite of the intended silent skip.
+        let isCancellationLike =
+          error is CancellationError
+          || (error as? URLError)?.code == .cancelled
         if step.errorSurfacePolicy == .surface, let skipReason = localPolishSkipReason {
           // #1305 surfaced skip: set the pinned skipped-tone notice, fire NO
           // Sentry capture (that is the point of the class). The composed

--- a/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptFinalizer.swift
@@ -105,9 +105,11 @@ internal final class TranscriptFinalizer {
 
   /// Finalize a transcription: process text, store transcript, paste to target.
   ///
-  /// Throws `FinalizationError` for typed failures. Throws `CancellationError` if cancelled.
-  /// Text processing step failures are handled internally (heart & limbs) and reported
-  /// via `polishError` in the result, NOT as thrown errors.
+  /// Throws `FinalizationError` for typed failures. Text processing step failures,
+  /// INCLUDING a `CancellationError` reaching a step (#1707 Phase 2, Open Decision
+  /// #9 — `TextProcessingRunner`'s widened `isCancellationLike` classification),
+  /// are handled internally (heart & limbs) and reported via `polishError` in the
+  /// result, NOT as thrown errors; the pre-step text ships instead.
   func finalize(_ request: FinalizationRequest) async throws -> FinalizationResult {
     // 1. Text processing (step failures handled internally by runner)
     let polishStart = CFAbsoluteTimeGetCurrent()

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1164,6 +1164,21 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         return .empty(hadSpeechEvidence: true)
       }
       lastResult = result
+      // #1707 Codex r9: mirror the normal finalize path's per-transcription
+      // latency telemetry (`:930` above) — without this, every Phase-2
+      // retry-rescued dictation silently drops out of the model/language
+      // latency metric, biasing production data toward first-attempt-only
+      // successes.
+      if result.duration > 0 {
+        let modelName = await backend.modelVariantName
+        let msPerAudioSec = (result.processingTime * 1000.0) / result.duration
+        TelemetryService.shared.trackTranscriptionLatency(
+          lang: result.language,
+          model: modelName,
+          durationSeconds: result.processingTime,
+          msPerAudioSecond: msPerAudioSec
+        )
+      }
       return .transcript(result)
     case .cancelled:
       return .cancelled

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1124,6 +1124,21 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     let session = sessionID
     let generation = retryGeneration
     batchCaptureSamples = inputSamples
+    // The primary `finalize()` already marked this session terminal, so the
+    // kernel's normal terminal cleanup never calls `cancel()` after a retry —
+    // release this retained audio ourselves on every exit (success, empty,
+    // cancelled, failed, or the stale-guard's early return below), matching
+    // what `clearSessionBuffers()` already did for the first attempt. Guarded
+    // on currency (re-checked at defer time, not the pre-await snapshot): a
+    // STALE retry must NOT clear `batchCaptureSamples` if a superseding
+    // session has since started and populated its OWN samples into the same
+    // field — that would clobber the new session's audio, not just release
+    // this retry's own.
+    defer {
+      if sessionID == session, retryGeneration == generation {
+        batchCaptureSamples.removeAll()
+      }
+    }
     let asrSamples = WhisperKitPipelineSpeechRouting.paddedASRSamples(
       rawSamples: inputSamples,
       minimumSamples: AudioConstants.minimumTranscriptionSamples

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -292,6 +292,9 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     ASREngineIdentity(backendType: .whisperKit)
   }
 
+  /// #1707 Phase 2: PLACEHOLDER — see the protocol doc comment.
+  var retryDecodeTimeoutSeconds: Double { 15.0 }
+
   /// WhisperKit runs engine-internal LID and, since #1276 Step 2 (PR-2),
   /// advertises streaming: the kernel's existing `useStreamingASR &&
   /// supportsStreaming` gate then routes the "Live transcription" toggle through
@@ -1110,11 +1113,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// `observedSpeechSegments` on the first `finalize()`'s exit, so this
   /// CANNOT re-derive `paddedLIDSamples`/`transcriptionOptions(from:
   /// speechSegments:)` the way the first attempt did — that derivation needs
-  /// segments that are gone. Instead: repopulate `batchCaptureSamples`
-  /// directly from `inputSamples` (bypassing the `observeSpeechSegments`
-  /// entry guard, which itself requires `!isTerminal`); re-derive ONLY
-  /// `paddedASRSamples` (a pure function of the raw bytes alone, no segments
-  /// needed); reuse the post-LID `decodeOptions` the first attempt already
+  /// segments that are gone. Instead: re-derive ONLY `paddedASRSamples` (a
+  /// pure function of the raw bytes alone, no segments needed) straight from
+  /// the `inputSamples` parameter — never touches `batchCaptureSamples`
+  /// (Codex r3: an earlier revision repopulated it needlessly, retaining the
+  /// full recording in memory for no reason since nothing reads it again
+  /// here); reuse the post-LID `decodeOptions` the first attempt already
   /// finalized and left in place UNCHANGED (`clearSessionBuffers()` does not
   /// touch it) — never re-run language detection. LID was not the failure
   /// point (the decode was), and re-running it would introduce fresh
@@ -1123,22 +1127,12 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   func retryDecode(inputSamples: [Float]) async -> ASREngineOutcome {
     let session = sessionID
     let generation = retryGeneration
-    batchCaptureSamples = inputSamples
-    // The primary `finalize()` already marked this session terminal, so the
-    // kernel's normal terminal cleanup never calls `cancel()` after a retry —
-    // release this retained audio ourselves on every exit (success, empty,
-    // cancelled, failed, or the stale-guard's early return below), matching
-    // what `clearSessionBuffers()` already did for the first attempt. Guarded
-    // on currency (re-checked at defer time, not the pre-await snapshot): a
-    // STALE retry must NOT clear `batchCaptureSamples` if a superseding
-    // session has since started and populated its OWN samples into the same
-    // field — that would clobber the new session's audio, not just release
-    // this retry's own.
-    defer {
-      if sessionID == session, retryGeneration == generation {
-        batchCaptureSamples.removeAll()
-      }
-    }
+    // Codex r3: `retryDecode` never reads `batchCaptureSamples` again after
+    // this point — it decodes solely from the local `inputSamples`/
+    // `asrSamples` — so writing it here served no purpose and, worse,
+    // retained the entire recording (potentially hundreds of MB) until some
+    // later session's `beginSession()`/`cancel()` happened to clear it. No
+    // assignment means nothing to release.
     let asrSamples = WhisperKitPipelineSpeechRouting.paddedASRSamples(
       rawSamples: inputSamples,
       minimumSamples: AudioConstants.minimumTranscriptionSamples

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1173,29 +1173,40 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
       if trimmed.isEmpty {
         return .empty(hadSpeechEvidence: true)
       }
-      lastResult = result
+      // GitHub cloud review: rebuild the result with the corrected duration
+      // BEFORE committing to `lastResult` — `KernelFinalizationWiring`
+      // reads `adapter.lastResult?.duration` straight into saved History
+      // metadata, so storing the backend's own `result.duration` as-is
+      // would persist a wrong/zero duration for a retry-rescued dictation
+      // whenever `WhisperKitBackend.mapResults` derived it from the LAST
+      // DECODED SEGMENT's end time (short on trailing silence, or zero
+      // when text exists without segment timestamps). Mirrors the normal
+      // finalize path's identical rebuild (`:914-921` above), which
+      // constructs its own `ASRResult` from `rawSamples.count` (`:882`)
+      // rather than trusting the backend's own duration field.
+      let audioDurationSec = Double(inputSamples.count) / AudioConstants.sampleRate
+      let correctedResult = ASRResult(
+        text: result.text,
+        language: result.language,
+        duration: audioDurationSec,
+        processingTime: result.processingTime,
+        backendType: result.backendType
+      )
+      lastResult = correctedResult
       // #1707 Codex r9/r10: mirror the normal finalize path's per-
       // transcription latency telemetry (`:930` above) — without this,
       // every Phase-2 retry-rescued dictation silently drops out of the
-      // model/language latency metric. Duration is derived from the
-      // retry's own INPUT sample count, matching the normal path's
-      // `rawSamples.count` (`:882`) — NOT `result.duration`:
-      // `WhisperKitBackend.mapResults` sets that to the LAST DECODED
-      // SEGMENT's end time, which can be shorter than the real capture
-      // (trailing silence) or even zero when text exists without segment
-      // timestamps, silently dropping exactly the retry telemetry this
-      // fix exists to restore.
-      let audioDurationSec = Double(inputSamples.count) / AudioConstants.sampleRate
+      // model/language latency metric.
       if audioDurationSec > 0, let modelName = modelNameForTelemetry {
-        let msPerAudioSec = (result.processingTime * 1000.0) / audioDurationSec
+        let msPerAudioSec = (correctedResult.processingTime * 1000.0) / audioDurationSec
         TelemetryService.shared.trackTranscriptionLatency(
-          lang: result.language,
+          lang: correctedResult.language,
           model: modelName,
-          durationSeconds: result.processingTime,
+          durationSeconds: correctedResult.processingTime,
           msPerAudioSecond: msPerAudioSec
         )
       }
-      return .transcript(result)
+      return .transcript(correctedResult)
     case .cancelled:
       return .cancelled
     case .failed(let error):

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1152,6 +1152,16 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
       minimumSamples: AudioConstants.minimumTranscriptionSamples
     )
     let batchOutcome = await runBatchDecode(samples: asrSamples)
+    // Codex r10: fetch the model name (the only remaining backend hop)
+    // BEFORE the staleness guard below, mirroring the normal finalize
+    // path's identical ordering (`:889`) — an await between the guard and
+    // the state mutation could let a cancel/interruption supersede this
+    // retry in the gap, so the code would still commit and emit success
+    // telemetry for an attempt the guard was meant to have already fenced.
+    var modelNameForTelemetry: String?
+    if case .success = batchOutcome {
+      modelNameForTelemetry = await backend.modelVariantName
+    }
     // Commit gate (§3.2a): write shared state ONLY while the captured
     // session and generation are still current — a late-arriving abandoned
     // retry must not mutate state belonging to a session/attempt that has
@@ -1164,14 +1174,20 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         return .empty(hadSpeechEvidence: true)
       }
       lastResult = result
-      // #1707 Codex r9: mirror the normal finalize path's per-transcription
-      // latency telemetry (`:930` above) — without this, every Phase-2
-      // retry-rescued dictation silently drops out of the model/language
-      // latency metric, biasing production data toward first-attempt-only
-      // successes.
-      if result.duration > 0 {
-        let modelName = await backend.modelVariantName
-        let msPerAudioSec = (result.processingTime * 1000.0) / result.duration
+      // #1707 Codex r9/r10: mirror the normal finalize path's per-
+      // transcription latency telemetry (`:930` above) — without this,
+      // every Phase-2 retry-rescued dictation silently drops out of the
+      // model/language latency metric. Duration is derived from the
+      // retry's own INPUT sample count, matching the normal path's
+      // `rawSamples.count` (`:882`) — NOT `result.duration`:
+      // `WhisperKitBackend.mapResults` sets that to the LAST DECODED
+      // SEGMENT's end time, which can be shorter than the real capture
+      // (trailing silence) or even zero when text exists without segment
+      // timestamps, silently dropping exactly the retry telemetry this
+      // fix exists to restore.
+      let audioDurationSec = Double(inputSamples.count) / AudioConstants.sampleRate
+      if audioDurationSec > 0, let modelName = modelNameForTelemetry {
+        let msPerAudioSec = (result.processingTime * 1000.0) / audioDurationSec
         TelemetryService.shared.trackTranscriptionLatency(
           lang: result.language,
           model: modelName,

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1310,7 +1310,9 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     // prepared by the caller — proving the retry genuinely re-decodes real,
     // already-captured audio, not a synthetic stand-in. `nil` controller
     // (production, and every test that doesn't opt in) never forces a failure.
-    if batchDecodeFaultController?.shouldForceFailBatchDecode(backend: .whisperKit) == true {
+    if batchDecodeFaultController?.shouldForceFailBatchDecode(
+      backend: .whisperKit, sampleCount: samples.count) == true
+    {
       return .failed(ASREngineError.decodeFailed)
     }
     do {

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -68,12 +68,15 @@ import Foundation
 /// (`WhisperKitBackendDriving` below) so tests can inject a stub without
 /// loading a real model.
 @MainActor
-final class WhisperKitEngineAdapter: ASREngineAdapter {
+final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
 
   // MARK: Injected dependencies
 
   private let backend: any WhisperKitBackendDriving
   private let languageDetector: LanguageDetector
+  /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1) — `nil` in every
+  /// production/test path that doesn't explicitly construct one.
+  private let batchDecodeFaultController: BatchDecodeFaultController?
 
   // MARK: Engine-session bookkeeping (NOT FSM state — §3.11 adapter-shape check)
 
@@ -88,6 +91,13 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   private var isTerminal = false
   /// `true` once `cancel()` ran — `finalize()` then returns `.cancelled`.
   private var isCancelled = false
+
+  /// #1707 Phase 2: monotonic generation for `retryDecode()`'s commit gate.
+  /// Bumped by `beginSession`/`cancel()` (a new session or discard must
+  /// invalidate any in-flight retry attempt) and by `bumpRetryGeneration()`
+  /// itself (a retry's own honest "stop waiting" signal). Mirrors
+  /// `ParakeetEngineAdapter`'s identically-named field.
+  private var retryGeneration = 0
 
   /// Synchronously-readable cached readiness. WhisperKit's `isReady` lives on
   /// an actor (`public private(set) var isReady`); the `ASREngineAdapter`
@@ -262,12 +272,16 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     backend: any WhisperKitBackendDriving,
     languageDetector: LanguageDetector = LanguageDetector(),
     audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64 = { 0 },
-    wedgeRecoveryUnloadDeadlineSec: Double = 2.0
+    wedgeRecoveryUnloadDeadlineSec: Double = 2.0,
+    // #1707 Phase 2: DEBUG fault-injection oracle (§11.1). Defaulted `nil`
+    // so every existing test construction site is unaffected.
+    batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) {
     self.backend = backend
     self.languageDetector = languageDetector
     self.audioCaptureSessionIDSource = audioCaptureSessionIDSource
     self.wedgeRecoveryUnloadDeadlineSec = wedgeRecoveryUnloadDeadlineSec
+    self.batchDecodeFaultController = batchDecodeFaultController
   }
 
   // MARK: ASREngineAdapter — identity & capability
@@ -387,6 +401,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
     decodeOptions = options
     isTerminal = false
     isCancelled = false
+    retryGeneration &+= 1  // #1707 Phase 2: invalidate any pending retry.
     lastResult = nil
     lastASRDiagnostics = nil
     lastFailureError = nil
@@ -929,6 +944,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   func cancel() async {
     isCancelled = true
     isTerminal = true
+    retryGeneration &+= 1  // #1707 Phase 2: invalidate any pending retry.
     lastResult = nil
     lastLanguageDetection = nil
     // Drop feed-task handles — a `finalize()` after `cancel()` short-circuits to
@@ -1069,6 +1085,69 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   func cancelPendingUnload() {
     modelUnloadTask?.cancel()
     modelUnloadTask = nil
+  }
+
+  // MARK: ASREngineAdapter — Phase 2 retry
+
+  /// Best-effort, honest "stop waiting" signal for a retry that has timed
+  /// out — NOT active cancellation (no genuine in-flight-decode cancel
+  /// exists on this backend, §3.2a: a single in-flight CoreML prediction
+  /// call is not itself interruptible). Bumping `retryGeneration` is what
+  /// actually prevents a late-arriving abandoned result from mutating state
+  /// belonging to a session/attempt that has since moved on.
+  func bumpRetryGeneration() {
+    retryGeneration &+= 1
+  }
+
+  /// #1707 Phase 2: a second, bounded batch decode attempt over the raw
+  /// capture audio a PRIOR `finalize()` call already failed to decode.
+  /// `finalize(batchSamples:)` ignores its own parameter and decodes
+  /// `batchCaptureSamples` (raw capture) instead — so `inputSamples` here is
+  /// the kernel's `captureResult.samples`, NOT the conditioned `asrSamples`
+  /// (§3.2's per-adapter kernel-side selection).
+  ///
+  /// `clearSessionBuffers()` already cleared `batchCaptureSamples` and
+  /// `observedSpeechSegments` on the first `finalize()`'s exit, so this
+  /// CANNOT re-derive `paddedLIDSamples`/`transcriptionOptions(from:
+  /// speechSegments:)` the way the first attempt did — that derivation needs
+  /// segments that are gone. Instead: repopulate `batchCaptureSamples`
+  /// directly from `inputSamples` (bypassing the `observeSpeechSegments`
+  /// entry guard, which itself requires `!isTerminal`); re-derive ONLY
+  /// `paddedASRSamples` (a pure function of the raw bytes alone, no segments
+  /// needed); reuse the post-LID `decodeOptions` the first attempt already
+  /// finalized and left in place UNCHANGED (`clearSessionBuffers()` does not
+  /// touch it) — never re-run language detection. LID was not the failure
+  /// point (the decode was), and re-running it would introduce fresh
+  /// nondeterminism and violate "same audio-coordinate and timestamp rules
+  /// as the original attempt."
+  func retryDecode(inputSamples: [Float]) async -> ASREngineOutcome {
+    let session = sessionID
+    let generation = retryGeneration
+    batchCaptureSamples = inputSamples
+    let asrSamples = WhisperKitPipelineSpeechRouting.paddedASRSamples(
+      rawSamples: inputSamples,
+      minimumSamples: AudioConstants.minimumTranscriptionSamples
+    )
+    let batchOutcome = await runBatchDecode(samples: asrSamples)
+    // Commit gate (§3.2a): write shared state ONLY while the captured
+    // session and generation are still current — a late-arriving abandoned
+    // retry must not mutate state belonging to a session/attempt that has
+    // since moved on. Mirrors `ParakeetEngineAdapter.commitAttempt`.
+    guard sessionID == session, retryGeneration == generation else { return .cancelled }
+    switch batchOutcome {
+    case .success(let result):
+      let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      if trimmed.isEmpty {
+        return .empty(hadSpeechEvidence: true)
+      }
+      lastResult = result
+      return .transcript(result)
+    case .cancelled:
+      return .cancelled
+    case .failed(let error):
+      lastFailureError = error
+      return .failed(.decodeFailed)
+    }
   }
 
   // MARK: PCM retention
@@ -1217,6 +1296,14 @@ final class WhisperKitEngineAdapter: ASREngineAdapter {
   }
 
   private func runBatchDecode(samples: [Float]) async -> BatchDecodeOutcome {
+    // #1707 Phase 2 (§11.1): DEBUG-only forced-failure fault, consulted only
+    // AFTER the real retry input and decode-options snapshot are already
+    // prepared by the caller — proving the retry genuinely re-decodes real,
+    // already-captured audio, not a synthetic stand-in. `nil` controller
+    // (production, and every test that doesn't opt in) never forces a failure.
+    if batchDecodeFaultController?.shouldForceFailBatchDecode(backend: .whisperKit) == true {
+      return .failed(ASREngineError.decodeFailed)
+    }
     do {
       let result = try await backend.transcribe(
         audioSamples: samples, options: decodeOptions)

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -292,8 +292,22 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     ASREngineIdentity(backendType: .whisperKit)
   }
 
-  /// #1707 Phase 2: PLACEHOLDER — see the protocol doc comment.
-  var retryDecodeTimeoutSeconds: Double { 15.0 }
+  /// #1707 Phase 2: measured 2026-07-20 against the live dev app — 7 real
+  /// batch decodes spanning 3.8-59.2s of audio, real-time factor (decode
+  /// seconds / audio seconds) observed 0.047-0.312, HIGHEST at the shortest
+  /// clips (fixed per-call overhead dominates) and settling near 0.09-0.10
+  /// by 20-59s. `5.0` fixed floor covers per-call overhead with headroom
+  /// over the worst short-clip observation; `0.30` per second is
+  /// comfortably above every observed RTF at any length, including the
+  /// short-clip outliers, not just the settled long-clip rate. At the 3600s
+  /// (60-minute) recording cap this budgets 1085s, generous given the
+  /// measured trend — WhisperKit is deliberately the slower, more-capable
+  /// "toughest audio" option, so its floor is the widest of the two.
+  /// Raw samples: `docs/audits/2026-07-20-recovery-v2-phase2-retry-decode-latency.md`.
+  func retryDecodeTimeoutSeconds(forSampleCount sampleCount: Int) -> Double {
+    let audioDurationSec = Double(sampleCount) / AudioConstants.sampleRate
+    return 5.0 + audioDurationSec * 0.30
+  }
 
   /// WhisperKit runs engine-internal LID and, since #1276 Step 2 (PR-2),
   /// advertises streaming: the kernel's existing `useStreamingASR &&

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -121,7 +121,12 @@ public final class TelemetryService {
     // never reaches a completed transcript (it floors to `.asrInterrupted` or
     // `.cancelled` instead, reported via the Sentry capture in
     // `KernelLifecycleTelemetrySink`, not this PostHog event).
-    asrSalvageOutcome: String? = nil
+    asrSalvageOutcome: String? = nil,
+    // #1707 Phase 2: present only for a dictation rescued by the one live
+    // retry over a post-capture decode failure — always `retry_succeeded`
+    // here, since a `.retryExhausted`/preempted retry never reaches a
+    // completed transcript.
+    asrRetryOutcome: String? = nil
   ) {
     #if DEBUG
       var hookStringProps: [String: String] = [
@@ -130,6 +135,7 @@ public final class TelemetryService {
       ]
       if let ib = interruptedBy { hookStringProps["interrupted_by"] = ib }
       if let aso = asrSalvageOutcome { hookStringProps["asr_salvage_outcome"] = aso }
+      if let aro = asrRetryOutcome { hookStringProps["asr_retry_outcome"] = aro }
       // #1376: mirror the emitted route keys' presence-only semantics so the
       // App → Telemetry threading is unit-testable.
       if let st = selectedTransport { hookStringProps["selected_transport"] = st }
@@ -194,7 +200,8 @@ public final class TelemetryService {
       captureNativeChannelCount: captureNativeChannelCount,
       salvagedLeadTrimMs: salvagedLeadTrimMs,
       interruptedBy: interruptedBy,
-      asrSalvageOutcome: asrSalvageOutcome
+      asrSalvageOutcome: asrSalvageOutcome,
+      asrRetryOutcome: asrRetryOutcome
     )
     if let asrLat = m?.asrLatencySeconds {
       asrCompleted(
@@ -666,7 +673,8 @@ public final class TelemetryService {
     captureRebuiltForFormat: Bool? = nil, captureNativeChannelCount: Int? = nil,
     salvagedLeadTrimMs: Int? = nil,
     interruptedBy: String? = nil,
-    asrSalvageOutcome: String? = nil
+    asrSalvageOutcome: String? = nil,
+    asrRetryOutcome: String? = nil
   ) {
     var props: [String: Any] = [
       "result": result,
@@ -686,6 +694,9 @@ public final class TelemetryService {
     // #1707: which ASR/XPC-helper salvage outcome preceded this completion.
     // Present only for a dictation that survived a live-recording ASR crash.
     if let aso = asrSalvageOutcome { props["asr_salvage_outcome"] = aso }
+    // #1707 Phase 2: present only for a dictation rescued by the one live
+    // retry over a post-capture decode failure.
+    if let aro = asrRetryOutcome { props["asr_retry_outcome"] = aro }
     // #1434: capture-health facts + salvage marker (fleet visibility across
     // Bluetooth device models; counters omitted when zero at the call site).
     if let rate = captureNativeRateHz { props["capture_native_rate_hz"] = Int(rate) }

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -42,7 +42,10 @@ import Testing
 /// coordinator carries NO Bluetooth predicate, overlay branching, or once-per-launch
 /// state — all decision logic lives on the presenter (§3b), so this is one narrow
 /// delegation, not accretion. Allowlist 21 → 22 (3 owned `var` + 19 injected `let`);
-/// non-private method count unchanged at 3.
+/// non-private method count unchanged at 3. #1707 Phase 2: 22 → 23 (3 owned
+/// `var` + 20 injected `let`) — `batchDecodeFaultController`, a deliberate,
+/// explicit addition for the new DEBUG fault-injection oracle (§11.1/§3.2a-i),
+/// forwarded into `DebugFaultEndpoint`'s construction; not accretion.
 @Suite struct AppLifecycleCoordinatorCeilingsTests {
   private static let sourcePath =
     "Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift"
@@ -70,6 +73,7 @@ import Testing
     "hotkeyService",
     "applicationRelocationCoordinator",
     "bluetoothAwarenessPresenter",
+    "batchDecodeFaultController",
   ]
 
   @Test func storedPropertyNamesMatchAllowlist() throws {

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -394,15 +394,18 @@ import Testing
   /// transcription-engine retry): hoisted the WhisperKit backend construction
   /// earlier so `BatchDecodeFaultController` can be built from both backends,
   /// and threaded that controller into both `ParakeetInputs`/`WhisperKitInputs`
-  /// and `AppLifecycleCoordinator`: actual 1187 + ~2, rounded to 1190.
+  /// and `AppLifecycleCoordinator`: actual 1187 + ~2, rounded to 1190. Then
+  /// Codex r6 required gating the controller's own construction behind
+  /// `#if DEBUG` (a Release build must not wire real fault-injection
+  /// machinery into its object graph): actual 1200 + ~2, rounded to 1205.
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1190,
+      lineCount <= 1205,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1190. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1205. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -390,15 +390,19 @@ import Testing
   /// wired the install read into the press path (isSelectedModelInstalled):
   /// actual 1151 + ~2, rounded to 1155. Then that read became removal-aware
   /// (founder: a model mid-removal accepts no dictations; Codex 2c-r7 P1):
-  /// actual 1160 + ~2, rounded to 1165.
+  /// actual 1160 + ~2, rounded to 1165. #1707 Phase 2 (recovery-v2
+  /// transcription-engine retry): hoisted the WhisperKit backend construction
+  /// earlier so `BatchDecodeFaultController` can be built from both backends,
+  /// and threaded that controller into both `ParakeetInputs`/`WhisperKitInputs`
+  /// and `AppLifecycleCoordinator`: actual 1187 + ~2, rounded to 1190.
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1165,
+      lineCount <= 1190,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1165. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1190. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -632,6 +632,31 @@ import Testing
     #expect(recorder.captureErrors.first?.extraKeys.contains("asr_salvage_outcome") == true)
   }
 
+  @Test(
+    "#1707 Phase 2: .asrInterrupted surfaces asr_retry_outcome when a preempting interruption left a retry at .attempted"
+  )
+  func asrInterruptedThreadsRetryOutcome() {
+    let telemetryState = KernelTelemetryState()
+    telemetryState.asrRetryOutcome = .attempted
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+    sink.emit(.asrInterrupted(wasRecording: true))
+    #expect(recorder.captureErrors.count == 1)
+    #expect(recorder.captureErrors.first?.extraKeys.contains("asr_retry_outcome") == true)
+  }
+
+  @Test(
+    "#1707 Phase 2: .asrInterrupted omits asr_retry_outcome when no Phase-2 retry was ever consulted"
+  )
+  func asrInterruptedOmitsRetryOutcomeWhenNil() {
+    let telemetryState = KernelTelemetryState()
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+    sink.emit(.asrInterrupted(wasRecording: true))
+    #expect(recorder.captureErrors.count == 1)
+    #expect(recorder.captureErrors.first?.extraKeys.contains("asr_retry_outcome") == false)
+  }
+
   @Test(".discarded carries the reason as a data field (PR-1 §B.7.4)")
   func discardedEmission() {
     let recorder = Recorder()
@@ -875,6 +900,30 @@ import Testing
     #expect(recorder.captureErrors.count == 1)
     #expect(recorder.captureErrors.first?.category == .asrFailed)
     #expect(recorder.captureErrors.first?.stage == "transcription")
+  }
+
+  @Test(
+    "#1707 Phase 2: .failed(.asrFailed) surfaces asr_retry_outcome when this session exhausted its retry"
+  )
+  func failedASRFailedThreadsRetryOutcome() {
+    let telemetryState = KernelTelemetryState()
+    telemetryState.asrRetryOutcome = .retryExhausted
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+    sink.emit(.failed(.asrFailed))
+    #expect(recorder.captureErrors.count == 1)
+    #expect(recorder.captureErrors.first?.extraKeys.contains("asr_retry_outcome") == true)
+  }
+
+  @Test(
+    "#1707 Phase 2: .failed(.asrFailed) omits asr_retry_outcome for a pre-capture failure (retry never consulted)"
+  )
+  func failedASRFailedOmitsRetryOutcomeWhenNil() {
+    let recorder = Recorder()
+    let sink = makeSink(recorder: recorder)
+    sink.emit(.failed(.asrFailed))
+    #expect(recorder.captureErrors.count == 1)
+    #expect(recorder.captureErrors.first?.extraKeys.contains("asr_retry_outcome") == false)
   }
 
   @Test(".failed(.asrWedged) routes through the same .asrFailed/transcription path")

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -1,0 +1,270 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - #1707 Phase 2 — one live post-capture decode retry (kernel routing)
+//
+// Drives the REAL `RecordingSessionKernel` through the simulator fakes.
+// `FakeEngine.crashOnFinalize` scripts the first decode attempt to fail
+// (`.failed(.engineCrashed)`); `retryDecodeResult`/`retryDecodeDelayTicks`
+// script the Phase-2 retry's own outcome and timing. Assertions cover the
+// retry gate, telemetry, the pre-capture exclusion, Phase-1 composition, and
+// the kernel-level staleness guard against a late-arriving abandoned retry.
+
+@MainActor
+@Suite("RecordingSessionKernel — Phase 2 post-capture decode retry (#1707)")
+struct KernelPhase2RetryTests {
+
+  private struct Context {
+    let wrapper: KernelRecordingSession
+    let engine: FakeEngine
+    let capture: FakeAudioCapture
+    let vad: FakeVADSignalSource
+    let paste: FakePasteTarget
+    let clock: FakeClock
+  }
+
+  private func makeContext(behavior: FakeEngineBehavior) -> Context {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: behavior, clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    return Context(
+      wrapper: wrapper, engine: engine, capture: capture, vad: vad, paste: paste, clock: clock)
+  }
+
+  private func deliverVoicedCapture(_ ctx: Context) {
+    ctx.capture.deliverBuffer(frameCount: 48000, amplitude: 0.25)
+    ctx.vad.evidence = .voiced
+    ctx.vad.segments = [SpeechSegment(startSample: 0, endSample: 48000)]
+  }
+
+  private func runToTerminal(_ ctx: Context) async {
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    deliverVoicedCapture(ctx)
+    // #1548 D1: the first converted buffer flips Arming -> Live via an async
+    // @MainActor hop — drain so the commit lands before stop.
+    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+  }
+
+  @Test("a decode failure spends exactly one retry, and a successful retry delivers its own text")
+  func decodeFailureRetriesOnceAndDelivers() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    ctx.engine.retryDecodeResult = .transcript(
+      ASRResult(
+        text: "rescued text", language: nil, duration: 0, processingTime: 0,
+        backendType: .parakeet))
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.recordingOutcome == .completed)
+    #expect(kernel.deliveredTranscript == "rescued text")
+    #expect(kernel.pasteCount == 1)
+    #expect(ctx.engine.retryDecodeCallCount == 1)
+    #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .retrySucceeded)
+  }
+
+  @Test("an exhausted retry still terminates as .asrFailed and spends exactly one retry")
+  func exhaustedRetryStillFailsOnce() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    ctx.engine.retryDecodeResult = .failed(.decodeFailed)
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.recordingOutcome == .failed(.asrFailed))
+    #expect(kernel.deliveredTranscript == nil)
+    #expect(kernel.pasteCount == 0)
+    #expect(ctx.engine.retryDecodeCallCount == 1)
+    #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .retryExhausted)
+  }
+
+  @Test(
+    "retry succeeds but polish then empties the result -> falls through to the noSpeech empty path")
+  func retrySucceedsThenPolishEmpties() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    ctx.engine.retryDecodeResult = .transcript(
+      ASRResult(
+        text: "rescued text", language: nil, duration: 0, processingTime: 0,
+        backendType: .parakeet))
+    ctx.wrapper.testForceEmptyAfterProcessing()
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.recordingOutcome.kind == .noSpeech)
+    #expect(kernel.deliveredTranscript == nil)
+    #expect(kernel.pasteCount == 0)
+    // The retry itself still ran and was accepted — polish is what collapsed
+    // the result, not the decode.
+    #expect(ctx.engine.retryDecodeCallCount == 1)
+    #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .retrySucceeded)
+  }
+
+  @Test("a pre-capture load failure never consults the Phase-2 retry at all")
+  func preCaptureFailureNeverConsultsRetry() async {
+    let ctx = makeContext(behavior: .failLoad(ASREngineError.loadFailed))
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.recordingOutcome == .failed(.modelLoadFailed))
+    #expect(ctx.engine.retryDecodeCallCount == 0)
+    #expect(ctx.wrapper.telemetryState.asrRetryOutcome == nil)
+  }
+
+  @Test(
+    "#1707 Phase 1 ∘ Phase 2 composition: an interruption-recovered decode that then fails gets exactly one Phase-2 retry, not a second budget"
+  )
+  func phase1RecoveredSessionGetsExactlyOnePhase2Retry() async {
+    // The session starts streaming (config default; the fake reports
+    // `supportsStreaming` for `.streamingSuccess`).
+    let ctx = makeContext(behavior: .streamingSuccess(partials: ["hel"], final: "hello"))
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    deliverVoicedCapture(ctx)
+    await ctx.wrapper.drainReadyWork()
+    let kernel = ctx.wrapper.testKernel
+    #expect(kernel.isStreamingSession, "precondition: this session must start streaming")
+
+    // The XPC helper crashes mid-recording. Recovery (FakeEngine's default
+    // `.readyForBatchDecode`) forces the decode down the batch path, scripted
+    // here to fail (an engine crash) — Phase 2's own retry must engage
+    // exactly once on top of this Phase-1 recovery, not stack a second
+    // parallel retry budget.
+    ctx.engine.behavior = .crashOnFinalize
+    ctx.engine.retryDecodeResult = .transcript(
+      ASRResult(
+        text: "rescued after recovery", language: nil, duration: 0, processingTime: 0,
+        backendType: .parakeet))
+    kernel.externalASRInterrupted()
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(kernel.recordingOutcome == .completed)
+    #expect(kernel.deliveredTranscript == "rescued after recovery")
+    // Exactly one finalize (the recovery-forced batch decode) and exactly one
+    // Phase-2 retry on top of it — never two retry budgets.
+    #expect(ctx.engine.finalizeCallCount == 1)
+    #expect(ctx.engine.retryDecodeCallCount == 1)
+  }
+
+  @Test(
+    "a retry that resolves after a NEW session has already started does not corrupt the new session"
+  )
+  func lateAbandonedRetryDoesNotCorruptNewSession() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    // Park the retry on the fake clock — it will not resolve until this test
+    // explicitly advances it, regardless of any real-wall-clock deadline or
+    // outer task cancellation (FakeClock.sleep never checks cancellation).
+    ctx.engine.retryDecodeDelayTicks = 3
+    ctx.engine.retryDecodeResult = .transcript(
+      ASRResult(
+        text: "stale retry text", language: nil, duration: 0, processingTime: 0,
+        backendType: .parakeet))
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    deliverVoicedCapture(ctx)
+    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+    let kernel = ctx.wrapper.testKernel
+
+    // Session A's retry is in flight (parked), so A has not concluded yet.
+    #expect(ctx.engine.retryDecodeCallCount == 1)
+    #expect(kernel.recordingOutcome == nil, "session A must still be in-flight (retry pending)")
+
+    // A superseding user action concludes session A while its retry is
+    // still parked — mirrors the kernel's own documented "Concurrent" class
+    // (§5): a cancel landing while the retry awaits.
+    kernel.cancel()
+    await ctx.wrapper.drainReadyWork()
+    #expect(kernel.recordingOutcome == .cancelled)
+
+    // Session B starts and completes normally before A's abandoned retry
+    // ever resolves.
+    ctx.engine.behavior = .batchSuccess(text: "session B text")
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    deliverVoicedCapture(ctx)
+    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+    #expect(kernel.recordingOutcome == .completed)
+    #expect(kernel.deliveredTranscript == "session B text")
+
+    // NOW let A's abandoned retry finally resolve. The kernel's own
+    // `isCurrent(sid)` guard must drop it without touching B's state.
+    ctx.clock.advance(by: 3)
+    await ctx.wrapper.drainReadyWork()
+    #expect(kernel.recordingOutcome == .completed)
+    #expect(kernel.deliveredTranscript == "session B text")
+    #expect(kernel.pasteCount == 1)
+  }
+
+  @Test(
+    "a retry-rescued completion stamps the SAME accepted-transcript telemetry as a first-attempt success"
+  )
+  func retrySuccessTelemetryUsesSharedHelper() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    ctx.engine.retryDecodeResult = .transcript(
+      ASRResult(
+        text: "rescued telemetry text", language: "en", duration: 1.5, processingTime: 0.4,
+        backendType: .parakeet))
+    await runToTerminal(ctx)
+
+    let completed = ctx.wrapper.telemetryState.asrCompletedTelemetry
+    #expect(completed?.mode == "batch")
+    #expect(completed?.language == "en")
+    #expect(completed?.charCount == "rescued telemetry text".count)
+    #expect(completed?.durationSeconds == 0.4)
+  }
+
+  // MARK: Completion-owner validation cases (§11.2)
+
+  @Test(
+    "a retry-rescued completion whose History save fails still completes exactly once and delivers")
+  func retryRescuedCompletionSurvivesStorageFailure() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    ctx.engine.retryDecodeResult = .transcript(
+      ASRResult(
+        text: "rescued text", language: nil, duration: 0, processingTime: 0,
+        backendType: .parakeet))
+    ctx.wrapper.inject(.storageWriteFails)
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    // #1167: the store failure is best-effort absorbed — the kernel still
+    // proceeds to deliver, exactly one terminal, exactly one delivery.
+    #expect(kernel.recordingOutcome == .completed)
+    #expect(kernel.deliveredTranscript == "rescued text")
+    #expect(kernel.pasteCount == 1)
+    #expect(ctx.engine.retryDecodeCallCount == 1)
+  }
+
+  @Test(
+    "a retry-rescued completion whose paste falls back to clipboard still completes exactly once")
+  func retryRescuedCompletionSurvivesClipboardFallback() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    ctx.engine.retryDecodeResult = .transcript(
+      ASRResult(
+        text: "rescued text", language: nil, duration: 0, processingTime: 0,
+        backendType: .parakeet))
+    ctx.paste.shouldFailPaste = true
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.recordingOutcome == .completed)
+    #expect(kernel.deliveredTranscript == "rescued text")
+    #expect(kernel.deliveryOutcome == .clipboardOnly)
+    // A clipboard-only delivery counts 0 real pastes (SessionEffects/kernel
+    // convention — a real paste is what pasteCount tracks).
+    #expect(kernel.pasteCount == 0)
+    #expect(ctx.engine.retryDecodeCallCount == 1)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -87,6 +87,38 @@ struct KernelPhase2RetryTests {
   }
 
   @Test(
+    "#1707 Codex r5: a retry that times out (never resolves) still terminates as .asrFailed but retains the spool, distinct from a genuinely exhausted retry"
+  )
+  func timedOutRetryTerminatesButRetainsSpool() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    // A real, tiny wall-clock deadline — the retry never resolves within it
+    // (the fake-clock delay is never advanced during this test), so
+    // `withOrderedDeadline`'s `onTimeout` fires for real.
+    ctx.engine.retryDecodeTimeoutSeconds = 0.05
+    ctx.engine.retryDecodeDelayTicks = 1
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    // `drainReadyWork()`'s epoch-stability heuristic settles immediately
+    // here since nothing in the kernel produces work while it awaits a REAL
+    // wall-clock sleep — poll the real signal (recordingOutcome actually
+    // publishing) instead, bounded well past the 50ms deadline configured
+    // above.
+    for _ in 0..<200 where kernel.recordingOutcome == nil {
+      try? await Task.sleep(for: .milliseconds(5))  // settle: poll recordingOutcome around the real 50ms deadline configured above
+    }
+
+    #expect(kernel.recordingOutcome == .failed(.asrFailed))
+    #expect(ctx.engine.bumpRetryGenerationCallCount == 1)
+    // The distinguishing assertion (Codex r5): NOT .retryExhausted. A mere
+    // timeout must never be conflated with a confirmed second failure — the
+    // underlying decode call is still running with no genuine cancellation,
+    // and deleting the spool now could discard audio a slower-but-healthy
+    // retry would have recovered.
+    #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .attempted)
+  }
+
+  @Test(
     "retry succeeds but polish then empties the result -> falls through to the noSpeech empty path")
   func retrySucceedsThenPolishEmpties() async {
     let ctx = makeContext(behavior: .crashOnFinalize)

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -87,6 +87,25 @@ struct KernelPhase2RetryTests {
   }
 
   @Test(
+    "GitHub cloud review (PR #1725): a retry that resolves .cancelled (a genuine backend CancellationError, not a confirmed decode conclusion) still terminates as .asrFailed but retains the spool, same as a timeout"
+  )
+  func cancelledRetryTerminatesButRetainsSpool() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    ctx.engine.retryDecodeResult = .cancelled
+    await runToTerminal(ctx)
+    let kernel = ctx.wrapper.testKernel
+
+    #expect(kernel.recordingOutcome == .failed(.asrFailed))
+    #expect(kernel.deliveredTranscript == nil)
+    #expect(ctx.engine.retryDecodeCallCount == 1)
+    // The distinguishing assertion: NOT .retryExhausted — `.cancelled` is
+    // not a confirmed "the decode produced nothing," so the spool must be
+    // retained exactly like the timeout case above, not deleted like a
+    // genuine `.empty`/`.failed` exhaustion.
+    #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .attempted)
+  }
+
+  @Test(
     "#1707 Codex r5: a retry that times out (never resolves) still terminates as .asrFailed but retains the spool, distinct from a genuinely exhausted retry"
   )
   func timedOutRetryTerminatesButRetainsSpool() async {

--- a/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
@@ -46,6 +46,39 @@ struct KernelTerminalKindTests {
     #expect(KernelDictationDriver.recoveryEnding(for: .noTransport) == .noTransport)
   }
 
+  @Test(
+    "#1707 Phase 2: a .failed outcome whose retry was exhausted projects to .asrRetryExhausted, distinct from plain .failed"
+  )
+  func exhaustedRetryProjectsToDistinctEnding() {
+    #expect(
+      KernelDictationDriver.recoveryEnding(for: .failed(.asrFailed), retryOutcome: .retryExhausted)
+        == .asrRetryExhausted)
+  }
+
+  @Test(
+    "#1707 Phase 2: a .failed outcome projects to plain .failed when the retry was never consulted, only attempted, or succeeded"
+  )
+  func nonExhaustedRetryOutcomesProjectToPlainFailed() {
+    // Pre-capture producer — retry never consulted at all (the default,
+    // matching every existing call site above).
+    #expect(
+      KernelDictationDriver.recoveryEnding(for: .failed(.asrFailed), retryOutcome: nil) == .failed)
+    // A retry preempted mid-flight by a competing interruption before its own
+    // result was ever accepted (§3a) — still plain .failed, never the
+    // exhausted-specific ending (this session's OWN retry never resolved to
+    // exhausted).
+    #expect(
+      KernelDictationDriver.recoveryEnding(for: .failed(.asrFailed), retryOutcome: .attempted)
+        == .failed)
+    // A retry that actually succeeded reaches `.completed`, not `.failed`, in
+    // production — but the projection itself is exhaustive over
+    // `ASRRetryOutcome?` and must not accidentally map this combination to
+    // the exhausted ending either.
+    #expect(
+      KernelDictationDriver.recoveryEnding(for: .failed(.asrFailed), retryOutcome: .retrySucceeded)
+        == .failed)
+  }
+
   @Test(".cancelled is excluded from the projection (resolved dynamically at the fire site)")
   func cancelledIsDynamic() {
     // `.cancelled` is reached by both a user cancel and a fault/system cancel, so

--- a/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
@@ -79,6 +79,38 @@ struct KernelTerminalKindTests {
         == .failed)
   }
 
+  @Test(
+    "#1707 Codex r7: an .asrInterrupted outcome whose retry was exhausted ALSO projects to .asrRetryExhausted, since interruptedTerminalFloor can raise an exhausted-retry .failed into .asrInterrupted"
+  )
+  func exhaustedRetryAfterInterruptionFloorProjectsToDistinctEnding() {
+    #expect(
+      KernelDictationDriver.recoveryEnding(
+        for: .asrInterrupted(wasRecording: true), retryOutcome: .retryExhausted)
+        == .asrRetryExhausted)
+    #expect(
+      KernelDictationDriver.recoveryEnding(
+        for: .asrInterrupted(wasRecording: false), retryOutcome: .retryExhausted)
+        == .asrRetryExhausted)
+  }
+
+  @Test(
+    "#1707 Codex r7: an .asrInterrupted outcome projects to plain .asrInterrupted when the retry was never consulted, only attempted, or succeeded"
+  )
+  func nonExhaustedRetryOutcomesProjectToPlainAsrInterrupted() {
+    #expect(
+      KernelDictationDriver.recoveryEnding(
+        for: .asrInterrupted(wasRecording: true), retryOutcome: nil)
+        == .asrInterrupted)
+    #expect(
+      KernelDictationDriver.recoveryEnding(
+        for: .asrInterrupted(wasRecording: true), retryOutcome: .attempted)
+        == .asrInterrupted)
+    #expect(
+      KernelDictationDriver.recoveryEnding(
+        for: .asrInterrupted(wasRecording: true), retryOutcome: .retrySucceeded)
+        == .asrInterrupted)
+  }
+
   @Test(".cancelled is excluded from the projection (resolved dynamically at the fire site)")
   func cancelledIsDynamic() {
     // `.cancelled` is reached by both a user cancel and a fault/system cancel, so

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -791,6 +791,47 @@ import Testing
   }
 
   @Test(
+    "GitHub cloud review (PR #1725): a stale-readiness proxy error (readiness still .ready but the primary failed via .serviceUnreachable) forces a real reconnect before the retry, not a no-op warmUp()"
+  )
+  func retryDecodeForcesReconnectAfterStaleReadinessTransportFailure() async throws {
+    let manager = StubParakeetASRManager()
+    manager.isModelLoaded = true
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+    feed(adapter, samples: [0.1, 0.2, 0.3], session: sid)
+
+    // Primary decode fails via a per-call XPC proxy error — the STUB, like
+    // the real onProxyError path, never clears isModelLoaded on this error.
+    manager.transcribeError = XPCASRTransportError.serviceUnreachable
+    let primaryOutcome = await adapter.finalize(batchSamples: nil)
+    guard case .failed = primaryOutcome else {
+      Issue.record("expected the primary decode to fail, got \(primaryOutcome)")
+      return
+    }
+    #expect(
+      manager.isModelLoaded,
+      "onProxyError never clears isModelLoaded — the stale mirror this bug depends on")
+    #expect((adapter.lastFailureError as? XPCASRTransportError) == .serviceUnreachable)
+
+    // Retry: the stale readiness mirror alone would skip repair entirely.
+    manager.transcribeError = nil
+    manager.transcribeResult = makeResult("reconnected retry text")
+    let retryOutcome = await adapter.retryDecode(inputSamples: [0.1, 0.2, 0.3])
+    guard case .transcript(let result) = retryOutcome else {
+      Issue.record("expected the retry to succeed after a forced reconnect, got \(retryOutcome)")
+      return
+    }
+    #expect(result.text == "reconnected retry text")
+    #expect(
+      manager.cancelInFlightLoadCount == 1,
+      "must force the stale readiness mirror to reflect the actually-dead connection")
+    #expect(
+      manager.loadModelCount == 1,
+      "warmUp() must perform a REAL reload, not a no-op on the stale isModelLoaded flag")
+  }
+
+  @Test(
     "#1707 Codex r8/r9: retryDecodeTimeoutSeconds(forSampleCount:) scales with audio length, not a flat constant"
   )
   func retryDecodeTimeoutScalesWithSampleCount() {
@@ -857,6 +898,10 @@ final class StubParakeetASRManager: ASRManagerInterface {
     text: "default-batch", language: "en", duration: 1, processingTime: 0,
     backendType: .parakeet)
   var transcribeThrows = false
+  /// Settable so a test can inject a SPECIFIC error (e.g.
+  /// `XPCASRTransportError.serviceUnreachable`) rather than the fixed
+  /// `FakeASRError.decode` `transcribeThrows` always throws. Checked first.
+  var transcribeError: (any Error)?
   /// When set, `feedAudio` throws — models a transient ASR/XPC feed failure that
   /// the per-buffer feed task swallows (#867).
   var feedAudioThrows = false
@@ -929,6 +974,7 @@ final class StubParakeetASRManager: ASRManagerInterface {
   func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult {
     transcribeCount += 1
     lastTranscribeSamples = audioSamples
+    if let transcribeError { throw transcribeError }
     if transcribeThrows { throw FakeASRError.decode }
     return transcribeResult
   }
@@ -982,7 +1028,14 @@ final class StubParakeetASRManager: ASRManagerInterface {
   }
   func noteTranscriptionComplete(policy: ModelUnloadPolicy) { lastUnloadPolicy = policy }
   func cancelIdleTimer() { cancelIdleTimerCount += 1 }
-  func cancelInFlightLoad() { cancelInFlightLoadCount += 1 }
+  func cancelInFlightLoad() {
+    cancelInFlightLoadCount += 1
+    // Mirrors the real ASRManagerProxy.cancelInFlightLoad(), which
+    // synchronously clears isModelLoaded (GitHub cloud review, PR #1725) —
+    // a stub that only counted the call without this side effect could not
+    // distinguish "readiness now reflects reality" from "still stale".
+    isModelLoaded = false
+  }
 
   enum FakeASRError: Error { case streamingSetup, decode, feed }
 }

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -790,6 +790,23 @@ import Testing
     )
   }
 
+  @Test(
+    "#1707 Codex r8/r9: retryDecodeTimeoutSeconds(forSampleCount:) scales with audio length, not a flat constant"
+  )
+  func retryDecodeTimeoutScalesWithSampleCount() {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    // 16kHz mono — 16_000 samples/sec (AudioConstants.sampleRate).
+    let zero = adapter.retryDecodeTimeoutSeconds(forSampleCount: 0)
+    let oneMinute = adapter.retryDecodeTimeoutSeconds(forSampleCount: 16_000 * 60)
+    let oneHour = adapter.retryDecodeTimeoutSeconds(forSampleCount: 16_000 * 3600)
+    #expect(zero == 3.0, "the fixed floor with zero audio")
+    #expect(oneMinute > zero, "a longer recording must get a longer budget")
+    #expect(oneHour > oneMinute, "budget keeps scaling for the longest supported recording")
+    #expect(abs(oneMinute - 12.0) < 0.01)
+    #expect(abs(oneHour - 543.0) < 0.01)
+  }
+
   // MARK: Helpers
 
   /// Feed one synthetic buffer stamped with `session` — the kernel always

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -755,6 +755,41 @@ import Testing
     #expect(adapter.lastResult == nil, "the discarded retry's result must never reach lastResult")
   }
 
+  @Test(
+    "#1707 Codex r7: a retry's warmUp() repair throwing AFTER it was superseded by a new session must not write its stale error into lastFailureError"
+  )
+  func supersededRetryWarmUpFailureDoesNotPolluteNewSessionError() async throws {
+    struct SimulatedRepairFailure: Error {}
+    let manager = StubParakeetASRManager()
+    manager.isModelLoaded = true
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+
+    // Readiness drops below .ready, so retryDecode's repair-before-retry gate
+    // engages warmUp() -> loadModel(). Park it, then queue a failure for
+    // when it's released.
+    manager.isModelLoaded = false
+    manager.gateLoadModel = true
+    manager.loadModelError = SimulatedRepairFailure()
+    async let outcome = adapter.retryDecode(inputSamples: [0.1, 0.2])
+    while manager.loadModelCount == 0 { await Task.yield() }
+
+    // A new session begins BEFORE the parked repair resolves — mirrors the
+    // kernel's onTimeout/new-session paths that make this retry stale.
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    manager.releaseLoadGate()
+
+    guard case .failed = await outcome else {
+      Issue.record("expected the stale repair failure to still report .failed")
+      return
+    }
+    #expect(
+      adapter.lastFailureError == nil,
+      "a stale, superseded retry's repair failure must never write lastFailureError — it would corrupt the NEW session's own error attribution"
+    )
+  }
+
   // MARK: Helpers
 
   /// Feed one synthetic buffer stamped with `session` — the kernel always
@@ -844,12 +879,14 @@ final class StubParakeetASRManager: ASRManagerInterface {
 
   func loadModel() async throws {
     loadModelCount += 1
+    if gateLoadModel {
+      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in loadGates.append(c) }
+    }
+    // Checked AFTER the gate parks/releases so a test can script a load that
+    // throws once resumed (#1707 Codex r7), not only an immediate throw.
     if let error = loadModelError {
       loadModelError = nil
       throw error
-    }
-    if gateLoadModel {
-      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in loadGates.append(c) }
     }
     isModelLoaded = true
   }

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -631,6 +631,130 @@ import Testing
     }
   }
 
+  // MARK: #1707 Phase 2 — post-capture decode retry
+
+  @Test("retryDecode() decodes the given samples and commits lastResult on success")
+  func retryDecodeSucceeds() async throws {
+    let manager = StubParakeetASRManager()
+    manager.transcribeResult = makeResult("retried text")
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+
+    let outcome = await adapter.retryDecode(inputSamples: [0.1, 0.2, 0.3])
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "retried text")
+    #expect(adapter.lastResult?.text == "retried text")
+    #expect(manager.transcribeCount == 1)
+    #expect(manager.lastTranscribeSamples == [0.1, 0.2, 0.3])
+  }
+
+  @Test(
+    "an adapter's own internal streaming-then-batch-rescue fallback and an explicit Phase-2 retryDecode are two distinct decode calls, never one shared budget"
+  )
+  func internalRescueAndPhase2RetryAreDistinctDecodeCalls() async throws {
+    let manager = StubParakeetASRManager()
+    // Streaming returns empty -> the internal batch-rescue fallback engages.
+    manager.finalizeStreamingResult = ASRResult(
+      text: "", language: "en", duration: 1, processingTime: 0, backendType: .parakeet)
+    // The internal rescue's own batch decode also fails for real, exactly the
+    // condition that makes the KERNEL spend its one Phase-2 retry.
+    manager.transcribeThrows = true
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: true)
+    feed(adapter, samples: [0.1], session: sid)
+
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .failed = outcome else {
+      Issue.record("expected the internal rescue to also fail, got \(outcome)")
+      return
+    }
+    #expect(
+      manager.transcribeCount == 1,
+      "the internal streaming-then-batch-rescue fallback is ONE decode call")
+
+    // The kernel now spends its one Phase-2 retry — a second, independent
+    // decode call, not a continuation of the internal rescue's own budget.
+    manager.transcribeThrows = false
+    manager.transcribeResult = makeResult("phase 2 retry text")
+    let retryOutcome = await adapter.retryDecode(inputSamples: [0.4, 0.5])
+    guard case .transcript(let retryResult) = retryOutcome else {
+      Issue.record("expected the Phase-2 retry to recover a transcript, got \(retryOutcome)")
+      return
+    }
+    #expect(retryResult.text == "phase 2 retry text")
+    #expect(
+      manager.transcribeCount == 2,
+      "the internal fallback and the explicit Phase-2 retry are two distinct decode calls")
+  }
+
+  @Test(
+    "retryDecode's readiness-gated repair re-checks staleness before spending the decode — a session change during the repair returns .cancelled and never decodes"
+  )
+  func retryDecodePostRepairStalenessRecheck() async throws {
+    let manager = StubParakeetASRManager()
+    manager.isModelLoaded = true
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sidA = SessionID()
+    try await adapter.beginSession(sidA, options: .default, streaming: false)
+
+    // Simulate the XPC helper dying mid-transcribe: readiness drops below
+    // .ready, so retryDecode's repair-before-retry gate engages warmUp().
+    manager.isModelLoaded = false
+    manager.gateLoadModel = true
+    async let outcome = adapter.retryDecode(inputSamples: [0.1, 0.2])
+    // Wait until the repair warmUp() has genuinely entered loadModel().
+    while manager.loadModelCount == 0 { await Task.yield() }
+
+    // A new session begins while the repair is still in flight.
+    try await adapter.beginSession(SessionID(), options: .default, streaming: false)
+    manager.releaseLoadGate()
+
+    guard case .cancelled = await outcome else {
+      Issue.record("expected .cancelled from the post-repair staleness recheck")
+      return
+    }
+    #expect(
+      manager.transcribeCount == 0,
+      "the decode attempt must never be spent once the repair discovers staleness")
+  }
+
+  @Test(
+    "bumpRetryGeneration() — mirroring the kernel's own onTimeout closure — supersedes an in-flight retry so its eventual late completion is discarded, idempotently"
+  )
+  func bumpRetryGenerationSupersedesInFlightRetry() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let sid = SessionID()
+    try await adapter.beginSession(sid, options: .default, streaming: false)
+
+    // Force retryDecode down its readiness-repair path so it parks on the
+    // gated loadModel() — a deterministic stand-in for "the kernel's
+    // withOrderedDeadline decided this retry took too long."
+    manager.isModelLoaded = false
+    manager.gateLoadModel = true
+    manager.transcribeResult = makeResult("should be discarded")
+    async let outcome = adapter.retryDecode(inputSamples: [0.1])
+    while manager.loadModelCount == 0 { await Task.yield() }
+
+    // Mirrors the kernel's onTimeout closure: bump the retry generation
+    // (called twice — idempotent, never throws) BEFORE the parked repair
+    // resolves.
+    adapter.bumpRetryGeneration()
+    adapter.bumpRetryGeneration()
+    manager.releaseLoadGate()
+
+    guard case .cancelled = await outcome else {
+      Issue.record("expected the superseded retry to resolve .cancelled, not commit its decode")
+      return
+    }
+    #expect(adapter.lastResult == nil, "the discarded retry's result must never reach lastResult")
+  }
+
   // MARK: Helpers
 
   /// Feed one synthetic buffer stamped with `session` — the kernel always

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -795,16 +795,21 @@ import Testing
   )
   func retryDecodeTimeoutScalesWithSampleCount() {
     let manager = StubParakeetASRManager()
+    // Default asrInterruptionRecoveryDeadlineSec (8.0) is the fixed floor —
+    // GitHub cloud review (PR #1725): reused directly since retryDecode's
+    // readiness-gated repair calls warmUp() before the second decode, and
+    // the whole call (repair included) is bounded by this ONE deadline.
     let adapter = ParakeetEngineAdapter(asrManager: manager)
     // 16kHz mono — 16_000 samples/sec (AudioConstants.sampleRate).
     let zero = adapter.retryDecodeTimeoutSeconds(forSampleCount: 0)
     let oneMinute = adapter.retryDecodeTimeoutSeconds(forSampleCount: 16_000 * 60)
     let oneHour = adapter.retryDecodeTimeoutSeconds(forSampleCount: 16_000 * 3600)
-    #expect(zero == 3.0, "the fixed floor with zero audio")
+    #expect(
+      zero == 8.0, "the fixed floor with zero audio matches asrInterruptionRecoveryDeadlineSec")
     #expect(oneMinute > zero, "a longer recording must get a longer budget")
     #expect(oneHour > oneMinute, "budget keeps scaling for the longest supported recording")
-    #expect(abs(oneMinute - 12.0) < 0.01)
-    #expect(abs(oneHour - 543.0) < 0.01)
+    #expect(abs(oneMinute - 17.0) < 0.01)
+    #expect(abs(oneHour - 548.0) < 0.01)
   }
 
   // MARK: Helpers

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
@@ -18,6 +18,42 @@ private func deletesRecoverySpool(_ outcome: RecordingOutcome) -> Bool {
   return RecoveryCoordinator.shouldDeleteOnLiveEnding(ending)
 }
 
+/// #1707 Phase 2 sibling of `deletesRecoverySpool(_:)`, threading the retry
+/// outcome through the SAME two real authorities.
+@MainActor
+private func deletesRecoverySpool(_ outcome: RecordingOutcome, retryOutcome: ASRRetryOutcome?)
+  -> Bool
+{
+  guard let ending = KernelDictationDriver.recoveryEnding(for: outcome, retryOutcome: retryOutcome)
+  else { return false }
+  return RecoveryCoordinator.shouldDeleteOnLiveEnding(ending)
+}
+
+/// #1707 Phase 2: an exhausted Phase-2 retry deletes its spool — the decode
+/// genuinely never produced anything, so there is nothing worth recovering
+/// (§4/§6). The negative (RULE: matcher-set-adversarial-tests): a pre-capture
+/// or never-retried `.asrFailed` — `retryOutcome == nil`, exactly the default
+/// every existing call site above already exercises — still retains.
+@MainActor
+@Suite("Exhausted-retry spool deletion (#1707 Phase 2)")
+struct ExhaustedRetrySpoolDeletionTests {
+  @Test("an exhausted retry's failed session deletes its spool")
+  func exhaustedRetryDeletes() {
+    #expect(deletesRecoverySpool(.failed(.asrFailed), retryOutcome: .retryExhausted))
+  }
+
+  @Test("a pre-capture or never-retried failed session still retains its spool")
+  func neverRetriedFailureRetains() {
+    #expect(!deletesRecoverySpool(.failed(.asrFailed), retryOutcome: nil))
+    #expect(!deletesRecoverySpool(.failed(.asrFailed)))
+  }
+
+  @Test("a retry left at .attempted by a preempting interruption does not delete as .failed")
+  func attemptedOnlyRetryDoesNotDeleteAsFailed() {
+    #expect(!deletesRecoverySpool(.failed(.asrFailed), retryOutcome: .attempted))
+  }
+}
+
 // MARK: - #1408 — salvage a dictation whose capture was interrupted mid-recording
 //
 // Before this change, a microphone that died mid-sentence sent the recording

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -28,6 +28,8 @@ enum FakeEngineEvent: Equatable, Sendable {
   case finalize
   case cancel
   case recoverFromWedge
+  case retryDecode
+  case bumpRetryGeneration
 }
 
 /// Synthetic error type for the cache-preload failure-bypass test
@@ -78,7 +80,7 @@ enum FakeEngineBehavior: Sendable {
 }
 
 @MainActor
-final class FakeEngine: ASREngineAdapter {
+final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
   /// `var` so a scenario's `EngineDirective.setBehavior` can reconfigure the
   /// fake before a session begins (e.g. the engine-switch scenarios).
   var behavior: FakeEngineBehavior
@@ -126,6 +128,41 @@ final class FakeEngine: ASREngineAdapter {
       await clock.sleep(ticks: asrInterruptionRecoveryDelayTicks)
     }
     return asrInterruptionRecoveryResult
+  }
+
+  // MARK: #1707 Phase 2 — retry scripting
+
+  /// Scriptable result for `retryDecode(inputSamples:)`. Defaults to a
+  /// deterministic success so a scenario that never explicitly configures a
+  /// retry still resolves without hanging. `retryDecodeDelayTicks` mirrors
+  /// `asrInterruptionRecoveryDelayTicks`'s place-on-the-fake-clock pattern,
+  /// so a scenario can deterministically race a retry against the kernel's
+  /// own `withOrderedDeadline` timeout or a superseding session/cancel.
+  var retryDecodeResult: ASREngineOutcome = .transcript(
+    ASRResult(
+      text: "retried transcript", language: nil, duration: 0, processingTime: 0,
+      backendType: .parakeet))
+  var retryDecodeDelayTicks = 0
+  private(set) var retryDecodeCallCount = 0
+  private(set) var lastRetryDecodeInputSamples: [Float]?
+  private(set) var bumpRetryGenerationCallCount = 0
+
+  func retryDecode(inputSamples: [Float]) async -> ASREngineOutcome {
+    retryDecodeCallCount += 1
+    lastRetryDecodeInputSamples = inputSamples
+    eventLog.append(.retryDecode)
+    if retryDecodeDelayTicks > 0 {
+      await clock.sleep(ticks: retryDecodeDelayTicks)
+    }
+    if case .transcript(let result) = retryDecodeResult {
+      lastResult = result
+    }
+    return retryDecodeResult
+  }
+
+  func bumpRetryGeneration() {
+    bumpRetryGenerationCallCount += 1
+    eventLog.append(.bumpRetryGeneration)
   }
 
   // MARK: Observed counters (for FakeEngineTests)

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -91,6 +91,12 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
   /// scenarios assert byte-identical strings.
   var engineIdentity: ASREngineIdentity = ASREngineIdentity(backendType: .parakeet)
 
+  /// #1707 Phase 2: settable so a test can drive `withOrderedDeadline`'s real
+  /// deadline race deliberately; the fake-clock-driven scenarios in this
+  /// simulator never wait anywhere near this long in real wall time, so the
+  /// exact default is inert for them.
+  var retryDecodeTimeoutSeconds: Double = 20.0
+
   /// Capabilities follow `behavior` — a `streamingSuccess` fake advertises
   /// `supportsStreaming`, so a kernel that branches on `capabilities` runs the
   /// A2 / A9 / A10 streaming scenarios through a genuinely streaming adapter.

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -94,8 +94,14 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
   /// #1707 Phase 2: settable so a test can drive `withOrderedDeadline`'s real
   /// deadline race deliberately; the fake-clock-driven scenarios in this
   /// simulator never wait anywhere near this long in real wall time, so the
-  /// exact default is inert for them.
+  /// exact default is inert for them. Codex r8/r9: production made this
+  /// length-aware, but the fake stays a fixed, directly-settable value —
+  /// no test in this simulator needs the formula itself, only control over
+  /// the deadline race.
   var retryDecodeTimeoutSeconds: Double = 20.0
+  func retryDecodeTimeoutSeconds(forSampleCount sampleCount: Int) -> Double {
+    retryDecodeTimeoutSeconds
+  }
 
   /// Capabilities follow `behavior` — a `streamingSuccess` fake advertises
   /// `supportsStreaming`, so a kernel that branches on `capabilities` runs the

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
@@ -39,6 +39,12 @@ enum EngineDirective: Sendable {
   /// session's lifetime, so the active session keeps its original engine
   /// (PR-3 plan §3.6).
   case requestMidSessionSwitch
+  /// #1707 Phase 2: reconfigure the fake's `retryDecode(inputSamples:)`
+  /// result before the next session step. `FakeEngine`'s default already
+  /// scripts a successful retry, so a scenario needs this ONLY to model an
+  /// exhausted retry (A14) — a scenario proving the rescue path (A23) relies
+  /// on the untouched default.
+  case setRetryDecodeResult(ASREngineOutcome)
 }
 
 /// A directive to the `FakePasteTarget` mid-scenario.

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
@@ -178,9 +178,15 @@ enum ScenarioInventory {
         terminalState: .failed(.asrWedged), pasteCount: 0, pasteOutcome: .none,
         transcript: .none, userVisibleError: .recoverableError)),
     Scenario(
-      id: "A14", name: "adapter fails after audio captured",
+      // #1707 Phase 2: a post-capture decode failure now spends one live
+      // retry before a terminal `.failed`. The FakeEngine's `retryDecode`
+      // default scripts a SUCCESSFUL retry (A23 covers that rescue path), so
+      // this scenario must explicitly exhaust the retry too to keep testing
+      // genuine, unrescuable engine failure.
+      id: "A14", name: "adapter fails after audio captured, retry also exhausted",
       steps: [
         .engine(.setBehavior(.crashOnFinalize)),
+        .engine(.setRetryDecodeResult(.failed(.decodeFailed))),
         .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
       ],
       expected: ExpectedOutcome(
@@ -284,6 +290,20 @@ enum ScenarioInventory {
       expected: ExpectedOutcome(
         terminalState: .noSpeech, pasteCount: 0, pasteOutcome: .none,
         transcript: .none)),
+    Scenario(
+      // #1707 Phase 2: the rescue counterpart to A14. A post-capture decode
+      // failure spends its one live retry; `FakeEngine.retryDecodeResult`'s
+      // default already scripts a successful "retried transcript" decode, so
+      // this scenario proves the session completes and delivers it instead
+      // of terminating on the first failure.
+      id: "A23", name: "adapter fails once, Phase 2 retry rescues it",
+      steps: [
+        .engine(.setBehavior(.crashOnFinalize)),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .exact("retried transcript"))),
   ]
 
   // MARK: §1.3 regression locks (R1, R2)
@@ -473,7 +493,7 @@ enum ScenarioInventory {
   static let canonicalIDs: Set<String> = [
     "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10",
     "A11", "A12", "A13", "A14", "A15", "A16", "A17", "A18", "A19",
-    "A20", "A21", "A22",
+    "A20", "A21", "A22", "A23",
     "R1", "R2",
     "C1", "C2", "C3", "C4", "C5", "C6", "C8",
     "L1", "L2", "L3", "L4", "L5", "L6",

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventoryTests.swift
@@ -8,11 +8,13 @@ import Testing
 @Suite("ScenarioInventory")
 struct ScenarioInventoryTests {
 
-  @Test("the inventory holds exactly the 37 canonical scenarios")
-  func inventoryHoldsThirtySeven() {
+  @Test("the inventory holds exactly the 38 canonical scenarios")
+  func inventoryHoldsThirtyEight() {
     // #1543 removed C7 (audio helper death — impossible with capture in-process).
-    #expect(ScenarioInventory.all.count == 37)
-    #expect(ScenarioInventory.canonicalIDs.count == 37)
+    // #1707 Phase 2 added A23 (post-capture decode failure rescued by the
+    // one live retry) alongside A14's exhausted-retry counterpart.
+    #expect(ScenarioInventory.all.count == 38)
+    #expect(ScenarioInventory.canonicalIDs.count == 38)
   }
 
   @Test("the inventory's ID set matches the canonical ID set exactly")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -97,6 +97,8 @@ struct ScenarioRunner {
         // A18 — a factory-preference change request (PR-6 owns the factory).
         // Inert against the running adapter; the active session is unaffected.
         context.engine.noteMidSessionSwitchRequest()
+      case .setRetryDecodeResult(let outcome):
+        context.engine.retryDecodeResult = outcome
       }
 
     case .capture(let directive):

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingChainRacesTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingChainRacesTests.swift
@@ -8,9 +8,9 @@ import Testing
 struct TextProcessingChainRacesTests {
 
   @Test(
-    "cancelling the outer task while a step is suspended rethrows CancellationError and stops the chain"
+    "#1707 Phase 2 (Open Decision #9): cancelling the outer task while a step is suspended is silently absorbed and the chain continues to completion"
   )
-  func cancellationMidStepRethrowsAndStopsLaterSteps() async {
+  func cancellationMidStepIsSilentlyAbsorbedAndChainContinues() async {
     let runner = TextProcessingRunner()
     let started = AsyncStream.makeStream(of: Void.self)
 
@@ -50,13 +50,18 @@ struct TextProcessingChainRacesTests {
     let outcome = await task.result
     switch outcome {
     case .success:
-      Issue.record("expected CancellationError, got success")
+      break
     case .failure(let error):
-      #expect(error is CancellationError, "expected CancellationError, got \(error)")
+      Issue.record("expected success (cancellation silently absorbed), got \(error)")
     }
 
     #expect(suspending.runCount == 1)
-    #expect(after.runCount == 0)
+    // "After" is entered (the loop advances past the cancelled step instead
+    // of aborting) — its OWN outcome, once entered, races the still-cancelled
+    // ambient task against its own `withThrowingTimeout` wrapper (Swift does
+    // not guarantee which finishes first when both are already-cancelled),
+    // so its exact text contribution is not asserted here.
+    #expect(after.runCount == 1)
   }
 
   @Test(

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerTests.swift
@@ -447,8 +447,10 @@ struct TextProcessingRunnerTests {
     #expect(fakeTimeout.capturedBudgets == [5.0, 0.05, 5.0])
   }
 
-  @Test("rethrows CancellationError and does not run later steps")
-  func rethrowsCancellationError() async {
+  @Test(
+    "#1707 Phase 2 (Open Decision #9): silently skips a CancellationError and continues the chain"
+  )
+  func silentlySkipsCancellationAndContinuesChain() async throws {
     let runner = deterministicRunner()
 
     let first = RecordingStep(name: "A") { context in
@@ -467,21 +469,18 @@ struct TextProcessingRunnerTests {
       return next
     }
 
-    do {
-      _ = try await runner.run(
-        rawText: "start",
-        language: "en",
-        targetAppName: nil,
-        steps: [first, cancelling, third]
-      )
-      Issue.record("Expected CancellationError to be thrown")
-    } catch is CancellationError {
-      #expect(first.runCount == 1)
-      #expect(cancelling.runCount == 1)
-      #expect(third.runCount == 0)
-    } catch {
-      Issue.record("Expected CancellationError, got \(error)")
-    }
+    let result = try await runner.run(
+      rawText: "start",
+      language: "en",
+      targetAppName: nil,
+      steps: [first, cancelling, third]
+    )
+
+    #expect(first.runCount == 1)
+    #expect(cancelling.runCount == 1)
+    #expect(third.runCount == 1)
+    #expect(result.context.text == "start-A-C")
+    #expect(result.polishError == nil)
   }
 
   // MARK: - Phase G1 — error-surface policy contract tests

--- a/Tests/EnviousWisprTests/Pipeline/TranscriptFinalizerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TranscriptFinalizerTests.swift
@@ -91,8 +91,10 @@ struct TranscriptFinalizerTests {
 
   // MARK: - 4. Cancellation during text processing (deterministic gate)
 
-  @Test("Cancellation mid-processing throws CancellationError without saving")
-  func cancellationMidProcessingThrowsWithoutSaving() async {
+  @Test(
+    "#1707 Phase 2 (Open Decision #9): cancellation mid-processing is silently absorbed, raw ASR text is saved and delivered"
+  )
+  func cancellationMidProcessingSavesAndDeliversRawText() async throws {
     let savedTranscripts = Box<[Transcript]>([])
     let pasteCount = Box(0)
     let started = AsyncStream.makeStream(of: Void.self)
@@ -104,8 +106,13 @@ struct TranscriptFinalizerTests {
       started.continuation.yield(())
       started.continuation.finish()
       // Cancellation-aware sleep. Throws CancellationError when the outer
-      // task is cancelled, which the runner's `catch is CancellationError`
-      // branch rethrows up through `finalize`.
+      // task is cancelled — the runner's widened `isCancellationLike`
+      // classification (#1707 Phase 2, Open Decision #9) now absorbs this
+      // silently instead of rethrowing, so `finalize` completes with the
+      // pre-step (raw ASR) text unchanged. `TranscriptFinalizer` itself is a
+      // test-only seam (production finalization is `KernelFinalizationWiring`);
+      // the KERNEL's own `isCurrent(sid)` guard is the real session-staleness
+      // safety net when this fires from a superseded session.
       try await Task.sleep(for: .seconds(60))
       return ctx
     }
@@ -127,14 +134,15 @@ struct TranscriptFinalizerTests {
 
     let outcome = await task.result
     switch outcome {
-    case .success:
-      Issue.record("expected cancellation, got success")
+    case .success(let result):
+      #expect(result.transcript.text == "hello")
     case .failure(let error):
-      #expect(error is CancellationError, "expected CancellationError, got \(error)")
+      Issue.record("expected success (cancellation silently absorbed), got \(error)")
     }
 
-    #expect(savedTranscripts.value.isEmpty)
-    #expect(pasteCount.value == 0)
+    #expect(savedTranscripts.value.count == 1)
+    #expect(savedTranscripts.value.first?.text == "hello")
+    #expect(pasteCount.value == 1)
   }
 
   // MARK: - 5. Paste clipboard-only is non-fatal

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -1200,6 +1200,126 @@ import Testing
     #expect(count == 0, "unload from A's armed task must NOT fire under B")
   }
 
+  // MARK: #1707 Phase 2 — post-capture decode retry
+
+  @Test("retryDecode() decodes the given samples and commits lastResult on success")
+  func retryDecodeSucceeds() async throws {
+    let backend = StubWhisperKitBackend()
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "retried text", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(
+      sid, options: TranscriptionOptions(language: "en"), streaming: false)
+
+    let outcome = await adapter.retryDecode(inputSamples: speechSamples(count: 16_000))
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(result.text == "retried text")
+    #expect(adapter.lastResult?.text == "retried text")
+    let txCount = await backend.transcribeCount
+    #expect(txCount == 1)
+  }
+
+  @Test(
+    "an adapter's own internal streaming-then-clean-batch-fallback and an explicit Phase-2 retryDecode are two distinct decode calls, never one shared budget"
+  )
+  func internalFallbackAndPhase2RetryAreDistinctDecodeCalls() async throws {
+    let backend = StubWhisperKitBackend()
+    let stubSession = StubIncrementalSession(result: .rejected(stopWhileDecodeInFlight: true))
+    await backend.setStreamingSessionFactory({ stubSession })
+    // The internal clean-batch fallback (triggered by the empty flush) also
+    // fails for real — exactly the condition that makes the KERNEL spend its
+    // one Phase-2 retry.
+    await backend.setTranscribeThrows(StubBackendError.decodeFailed)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(
+      sid, options: TranscriptionOptions(language: "en"), streaming: true)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+
+    let outcome = await adapter.finalize(batchSamples: nil)
+    guard case .failed = outcome else {
+      Issue.record("expected the internal clean-batch fallback to also fail, got \(outcome)")
+      return
+    }
+    let firstCount = await backend.transcribeCount
+    #expect(firstCount == 1, "the internal streaming-then-clean-batch fallback is ONE decode call")
+
+    // The kernel now spends its one Phase-2 retry — a second, independent
+    // decode call, not a continuation of the internal fallback's own budget.
+    await backend.setTranscribeThrows(nil)
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "phase 2 retry text", language: "en", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let retryOutcome = await adapter.retryDecode(inputSamples: speechSamples(count: 16_000))
+    guard case .transcript(let retryResult) = retryOutcome else {
+      Issue.record("expected the Phase-2 retry to recover a transcript, got \(retryOutcome)")
+      return
+    }
+    #expect(retryResult.text == "phase 2 retry text")
+    let secondCount = await backend.transcribeCount
+    #expect(
+      secondCount == 2,
+      "the internal fallback and the explicit Phase-2 retry are two distinct decode calls")
+  }
+
+  @Test(
+    "retryDecode reuses the first attempt's finalized decode options exactly and never re-runs LID"
+  )
+  func retryDecodePreservesDecodeOptionsAndSkipsLID() async throws {
+    let backend = StubWhisperKitBackend()
+    // Three unanimous, high-confidence votes for "es" — a clean, unambiguous
+    // LID resolution on the first (auto-language) attempt.
+    await backend.setObserveLIDResult(
+      .observations([
+        RawLIDObservation(argmaxLang: "es", logProb: -0.05),
+        RawLIDObservation(argmaxLang: "es", logProb: -0.05),
+        RawLIDObservation(argmaxLang: "es", logProb: -0.05),
+      ]))
+    // The first attempt's own batch decode fails for real, triggering the
+    // kernel's Phase-2 retry.
+    await backend.setTranscribeThrows(StubBackendError.decodeFailed)
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    // Auto-language (nil) — LID must run on this first attempt.
+    try await adapter.beginSession(
+      sid, options: TranscriptionOptions(language: nil), streaming: false)
+    feed(adapter, samples: speechSamples(count: 16_000), session: sid)
+    adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
+    _ = await adapter.finalize(batchSamples: nil)
+
+    let lidCountAfterFirstAttempt = await backend.observeLIDCount
+    #expect(lidCountAfterFirstAttempt > 0, "precondition: the auto-language first attempt ran LID")
+    let resolvedLanguage = await backend.lastTranscribeOptions.language
+    #expect(resolvedLanguage == "es", "precondition: the first attempt resolved to es")
+
+    // The Phase-2 retry must reuse that resolved language exactly, never
+    // re-running LID.
+    await backend.setTranscribeThrows(nil)
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "retried spanish text", language: "es", duration: 1, processingTime: 0.1,
+        backendType: .whisperKit))
+    let retryOutcome = await adapter.retryDecode(inputSamples: speechSamples(count: 16_000))
+    guard case .transcript = retryOutcome else {
+      Issue.record("expected the retry to recover a transcript, got \(retryOutcome)")
+      return
+    }
+    let lidCountAfterRetry = await backend.observeLIDCount
+    #expect(
+      lidCountAfterRetry == lidCountAfterFirstAttempt,
+      "the retry must never re-run LID")
+    let retryLanguage = await backend.lastTranscribeOptions.language
+    #expect(retryLanguage == "es", "the retry must reuse the first attempt's resolved language")
+  }
+
   // MARK: Production-unwired sanity
 
   @Test("WhisperKitEngineAdapter exists at Sources/EnviousWisprPipeline/")

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -1226,6 +1226,40 @@ import Testing
   }
 
   @Test(
+    "GitHub cloud review: a retry-rescued result whose backend duration is short (trailing silence) or zero (no segment timestamps) still commits the FULL capture duration to lastResult, since KernelFinalizationWiring saves History metadata straight from it"
+  )
+  func retryDecodeCorrectsBackendDurationBeforeCommitting() async throws {
+    let backend = StubWhisperKitBackend()
+    // Simulates WhisperKitBackend.mapResults deriving duration from the last
+    // decoded segment's end time — 0 here models "text exists without
+    // segment timestamps," the case that would otherwise silently skip
+    // telemetry AND persist a zero-duration History entry.
+    await backend.setTranscribeResult(
+      ASRResult(
+        text: "retried text", language: "en", duration: 0, processingTime: 0.1,
+        backendType: .whisperKit))
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let sid = SessionID()
+    try await adapter.beginSession(
+      sid, options: TranscriptionOptions(language: "en"), streaming: false)
+
+    // 4 seconds of real captured audio at 16kHz.
+    let outcome = await adapter.retryDecode(inputSamples: speechSamples(count: 16_000 * 4))
+    guard case .transcript(let result) = outcome else {
+      Issue.record("expected .transcript, got \(outcome)")
+      return
+    }
+    #expect(
+      abs(result.duration - 4.0) < 0.001,
+      "the returned result must carry the real capture duration, not the backend's own (short/zero) value"
+    )
+    #expect(
+      abs((adapter.lastResult?.duration ?? -1) - 4.0) < 0.001,
+      "lastResult is what KernelFinalizationWiring saves to History — it must never persist the backend's raw duration"
+    )
+  }
+
+  @Test(
     "an adapter's own internal streaming-then-clean-batch-fallback and an explicit Phase-2 retryDecode are two distinct decode calls, never one shared budget"
   )
   func internalFallbackAndPhase2RetryAreDistinctDecodeCalls() async throws {

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -1329,6 +1329,21 @@ import Testing
     #expect(FileManager.default.fileExists(atPath: url.path))
   }
 
+  @Test(
+    "#1707 Codex r8/r9: retryDecodeTimeoutSeconds(forSampleCount:) scales with audio length, not a flat constant"
+  )
+  func retryDecodeTimeoutScalesWithSampleCount() {
+    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    let zero = adapter.retryDecodeTimeoutSeconds(forSampleCount: 0)
+    let oneMinute = adapter.retryDecodeTimeoutSeconds(forSampleCount: 16_000 * 60)
+    let oneHour = adapter.retryDecodeTimeoutSeconds(forSampleCount: 16_000 * 3600)
+    #expect(zero == 5.0, "the fixed floor with zero audio")
+    #expect(oneMinute > zero, "a longer recording must get a longer budget")
+    #expect(oneHour > oneMinute, "budget keeps scaling for the longest supported recording")
+    #expect(abs(oneMinute - 23.0) < 0.01)
+    #expect(abs(oneHour - 1085.0) < 0.01)
+  }
+
   // MARK: Helpers
 
   /// Feed one synthetic buffer stamped with `session` — the kernel always

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -208,6 +208,11 @@ struct RecoveryCoordinatorTests {
     #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.asrInterrupted))
     #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.noTransport))
     #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.cancelled(.systemOrFault)))
+    // #1707 Phase 2: an exhausted Phase-2 retry deletes its spool (the
+    // decode genuinely never produced anything); a pre-capture / never-
+    // retried `.failed` (plain, no retry consulted) still retains — the
+    // negative half of this same adversarial pair.
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.asrRetryExhausted))
   }
 
   @Test(

--- a/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
@@ -122,5 +122,37 @@ struct DictationCompletedRouteFieldsTests {
 
       #expect(box.event?.stringProps["asr_salvage_outcome"] == nil)
     }
+
+    @Test(
+      "#1707 Phase 2: asrRetryOutcome threads into dictation.completed when a retry rescued the take"
+    )
+    func asrRetryOutcomeThreaded() {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt",
+        asrRetryOutcome: "retry_succeeded")
+
+      #expect(box.event?.stringProps["asr_retry_outcome"] == "retry_succeeded")
+    }
+
+    @Test(
+      "#1707 Phase 2: a first-attempt success (no Phase-2 retry) omits the asr_retry_outcome key")
+    func asrRetryOutcomeOmittedWhenNil() {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt")
+
+      #expect(box.event?.stringProps["asr_retry_outcome"] == nil)
+    }
   #endif
 }


### PR DESCRIPTION
## Summary

Part of #1707 (Recovery V2 epic, Phase 2 of 3). When a dictation's post-capture ASR decode fails after audio is already captured, the kernel now spends exactly one bounded retry decode over the same audio before giving up — rescuing dictations that would otherwise be silently discarded.

- One live Phase-2 retry per session, batch-only, over the exact audio the primary decode already failed on (never a fresh capture).
- Retry deadline is length-aware, derived from real measured decode latency per backend (`docs/audits/2026-07-20-recovery-v2-phase2-retry-decode-latency.md`, local-only): Parakeet `3.0s + 0.15s/audio-second`, WhisperKit `5.0s + 0.30s/audio-second`.
- A retry that times out (kernel gives up waiting) is distinct from one that genuinely exhausts (resolved with nothing useful) — only a confirmed exhaustion deletes the recovery spool; a timeout retains it, since the real decode may still be running in the background with no true cancellation on either backend.
- DEBUG-only fault-injection oracle (`BatchDecodeFaultController`, gated out of Release entirely) backs both the Live UAT fault-injection scenarios and the founder-mandated shared-backend-overlap proof.

## Live UAT (this session, both backends)

- Per-backend retry success (primary force-fails, retry rescues) and retry exhaustion (both attempts fail, spool correctly deleted) — verified via real dictations, `app.log`, and the recovery spool directory.
- **Shared-backend-overlap oracle**: proved a genuine, concurrent overlap between an abandoned (timed-out) retry's real decode call and a brand-new session's decode call on the same backend, for both the in-process WhisperKit actor and the cross-process Parakeet XPC path. Zero cross-session content contamination (verified via distinct sample counts and exact verbatim transcript text); the abandoned retry's spool was correctly retained (timeout ≠ exhausted).
- Final smoke re-confirmation on both backends after the length-aware timeout and telemetry fixes landed.

## Test plan

- [x] `scripts/xcode-test.sh` — 3631 tests passing (up from 3618 baseline; ~28 new tests for the retry mechanism, exhaustion projection, telemetry threading, and the length-aware timeout formula)
- [x] Release configuration compiles clean
- [x] 11 rounds of local `codex review` iterated to a clean pass ("No actionable correctness issues remain in the reviewed diff")
- [x] Live UAT: retry success/exhaustion both backends, shared-backend-overlap oracle both backends, final re-smoke after latency-formula changes
- [x] Dev app rebuilt from this branch, relaunched, and manually exercised throughout