### PR TITLE
fix(user): confirm before discarding a pasted import draft (#1700)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -220,9 +220,50 @@ final class CustomWordsImportFlowModel {
   }
 
   /// Sheet dismissal. Nothing is written on the way out; any in-flight stage
-  /// is cancelled and can no longer publish.
+  /// is cancelled and can no longer publish. Clears the draft so a confirmed
+  /// discard is final and idempotent, whether this runs from an explicit
+  /// discard action or from `.onDisappear`'s unconditional cleanup.
   func cancel() {
     abandonWork()
+    pasteDraft = ""
+  }
+
+  /// True iff closing the sheet right now, by any path, would silently throw
+  /// away words the user already typed (#1700). Excludes `.working(.committing)`
+  /// — an active write in flight is not "a draft" — and the two `.result`
+  /// cases where nothing is left to protect; includes `.result(.nothingFound)`
+  /// and `.result(.failed)`, since neither committed anything and the pasted
+  /// text is still sitting, uncommitted, in `pasteDraft`.
+  var hasDiscardableDraft: Bool {
+    switch step {
+    case .working(.committing), .result(.completed), .result(.nothingApproved):
+      return false
+    case .methodPicker, .paste, .upload, .smartImportAppPicker, .review,
+      .working(.loadingCandidates), .working(.comparing),
+      .result(.nothingFound), .result(.failed):
+      return !pasteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+  }
+
+  /// "Keep editing" from a confirmation dialog (#1700). On `.result(.nothingFound)`
+  /// / `.result(.failed)` there is no Back button to return the user to their
+  /// draft, so this actively returns to Paste with the draft intact; everywhere
+  /// else there is nothing to do — the user is already looking at their
+  /// editable draft, or there was nothing to protect in the first place.
+  func keepEditingDiscardableDraft() {
+    guard hasDiscardableDraft else { return }
+    switch step {
+    case .result(.nothingFound), .result(.failed):
+      abandonWork()
+      rows = []
+      staleNotice = nil
+      droppedAliasCollisionCount = 0
+      selectedMethod = .paste
+      step = .paste
+    case .methodPicker, .paste, .upload, .smartImportAppPicker, .review,
+      .working, .result(.completed), .result(.nothingApproved):
+      break
+    }
   }
 
   // MARK: - Workflow (PR-F2c)

--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -246,12 +246,22 @@ final class CustomWordsImportFlowModel {
       return false
     case .result(.completed), .result(.nothingApproved):
       guard selectedMethod != .paste else { return false }
-      return !pasteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      return hasNonWhitespacePasteDraft
     case .methodPicker, .paste, .upload, .smartImportAppPicker, .review,
       .working(.loadingCandidates), .working(.comparing),
       .result(.nothingFound), .result(.failed):
-      return !pasteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      return hasNonWhitespacePasteDraft
     }
+  }
+
+  /// `hasDiscardableDraft` is read from `body` on every keystroke, on macOS
+  /// 15+ via `dismissalConfirmationDialog(shouldPresent:)` (Codex code-diff
+  /// review). `contains(where:)` short-circuits at the first non-whitespace
+  /// character — real pasted text has one almost immediately — rather than
+  /// `trimmingCharacters(in:)`, which allocates a new trimmed `String` on
+  /// every call.
+  private var hasNonWhitespacePasteDraft: Bool {
+    pasteDraft.contains { !$0.isWhitespace }
   }
 
   /// "Keep editing" from a confirmation dialog (#1700). No `.result` case has

--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -254,23 +254,25 @@ final class CustomWordsImportFlowModel {
     }
   }
 
-  /// "Keep editing" from a confirmation dialog (#1700). On `.result(.nothingFound)`
-  /// / `.result(.failed)` there is no Back button to return the user to their
-  /// draft, so this actively returns to Paste with the draft intact; everywhere
-  /// else there is nothing to do — the user is already looking at their
-  /// editable draft, or there was nothing to protect in the first place.
+  /// "Keep editing" from a confirmation dialog (#1700). No `.result` case has
+  /// a Back button, so any terminal result `hasDiscardableDraft` judged worth
+  /// protecting — `.nothingFound`/`.failed` always, or `.completed`/
+  /// `.nothingApproved` when they're guarding an abandoned draft from a
+  /// different, already-finished method (Codex code-diff review) — actively
+  /// returns to Paste with the draft intact. Everywhere else there is nothing
+  /// to do: the user is already looking at their editable draft, or the guard
+  /// above already ruled out there being anything to protect.
   func keepEditingDiscardableDraft() {
     guard hasDiscardableDraft else { return }
     switch step {
-    case .result(.nothingFound), .result(.failed):
+    case .result:
       abandonWork()
       rows = []
       staleNotice = nil
       droppedAliasCollisionCount = 0
       selectedMethod = .paste
       step = .paste
-    case .methodPicker, .paste, .upload, .smartImportAppPicker, .review,
-      .working, .result(.completed), .result(.nothingApproved):
+    case .methodPicker, .paste, .upload, .smartImportAppPicker, .review, .working:
       break
     }
   }

--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -230,14 +230,23 @@ final class CustomWordsImportFlowModel {
 
   /// True iff closing the sheet right now, by any path, would silently throw
   /// away words the user already typed (#1700). Excludes `.working(.committing)`
-  /// — an active write in flight is not "a draft" — and the two `.result`
-  /// cases where nothing is left to protect; includes `.result(.nothingFound)`
+  /// — an active write in flight is not "a draft." Includes `.result(.nothingFound)`
   /// and `.result(.failed)`, since neither committed anything and the pasted
   /// text is still sitting, uncommitted, in `pasteDraft`.
+  ///
+  /// `.result(.completed)`/`.result(.nothingApproved)` are only genuinely
+  /// nothing-to-lose when THIS result's own method was paste — that's the
+  /// only case where `pasteDraft`'s content is guaranteed to be exactly what
+  /// was just committed. If the user typed a paste draft, went Back, and
+  /// completed a DIFFERENT method's import instead, `pasteDraft` still holds
+  /// that abandoned, never-committed text (Codex code-diff review, #1700).
   var hasDiscardableDraft: Bool {
     switch step {
-    case .working(.committing), .result(.completed), .result(.nothingApproved):
+    case .working(.committing):
       return false
+    case .result(.completed), .result(.nothingApproved):
+      guard selectedMethod != .paste else { return false }
+      return !pasteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     case .methodPicker, .paste, .upload, .smartImportAppPicker, .review,
       .working(.loadingCandidates), .working(.comparing),
       .result(.nothingFound), .result(.failed):

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -144,10 +144,18 @@ struct CustomWordsImportSheet: View {
         // Routed through requestCancel() (#1700): a `.nothingFound`/`.failed`
         // result still holds an uncommitted draft, so Done confirms first in
         // that case; `.completed`/`.nothingApproved` proceed silently, same
-        // as before.
+        // as before. The second, hidden button gives Escape the same route:
+        // without it, this screen has no `.cancelAction` button at all, so
+        // Escape would dismiss the system sheet directly and reach
+        // `.onDisappear`'s unconfirmed cleanup — the exact bug this issue is
+        // about, left open on the one screen this change touches (Codex
+        // code-diff review).
         Button("Done") { requestCancel() }
           .keyboardShortcut(.defaultAction)
           .buttonStyle(.borderedProminent)
+        Button("Done") { requestCancel() }
+          .keyboardShortcut(.cancelAction)
+          .hidden()
       case .review:
         Button("Cancel") { requestCancel() }
           .keyboardShortcut(.cancelAction)

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -144,18 +144,22 @@ struct CustomWordsImportSheet: View {
         // Routed through requestCancel() (#1700): a `.nothingFound`/`.failed`
         // result still holds an uncommitted draft, so Done confirms first in
         // that case; `.completed`/`.nothingApproved` proceed silently, same
-        // as before. The second, hidden button gives Escape the same route:
+        // as before. The overlaid hidden button gives Escape the same route:
         // without it, this screen has no `.cancelAction` button at all, so
         // Escape would dismiss the system sheet directly and reach
         // `.onDisappear`'s unconfirmed cleanup — the exact bug this issue is
         // about, left open on the one screen this change touches (Codex
-        // code-diff review).
+        // code-diff review). `.overlay` rather than a second sibling button:
+        // `.hidden()` on a sibling still reserves its layout footprint,
+        // visibly shifting Done off the trailing edge (Codex, round 3).
         Button("Done") { requestCancel() }
           .keyboardShortcut(.defaultAction)
           .buttonStyle(.borderedProminent)
-        Button("Done") { requestCancel() }
-          .keyboardShortcut(.cancelAction)
-          .hidden()
+          .overlay {
+            Button("Done") { requestCancel() }
+              .keyboardShortcut(.cancelAction)
+              .hidden()
+          }
       case .review:
         Button("Cancel") { requestCancel() }
           .keyboardShortcut(.cancelAction)

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -144,21 +144,26 @@ struct CustomWordsImportSheet: View {
         // Routed through requestCancel() (#1700): a `.nothingFound`/`.failed`
         // result still holds an uncommitted draft, so Done confirms first in
         // that case; `.completed`/`.nothingApproved` proceed silently, same
-        // as before. The overlaid hidden button gives Escape the same route:
-        // without it, this screen has no `.cancelAction` button at all, so
-        // Escape would dismiss the system sheet directly and reach
+        // as before. The overlaid, zero-opacity button gives Escape the same
+        // route: without it, this screen has no `.cancelAction` button at
+        // all, so Escape would dismiss the system sheet directly and reach
         // `.onDisappear`'s unconfirmed cleanup — the exact bug this issue is
         // about, left open on the one screen this change touches (Codex
         // code-diff review). `.overlay` rather than a second sibling button:
-        // `.hidden()` on a sibling still reserves its layout footprint,
-        // visibly shifting Done off the trailing edge (Codex, round 3).
+        // a sibling would reserve its own layout footprint, visibly shifting
+        // Done off the trailing edge (Codex, round 3). `.opacity(0)` rather
+        // than `.hidden()`: `.hidden()` views cannot receive or respond to
+        // interactions at all per Apple's own documentation, which would
+        // silently reintroduce the exact Escape bug this button exists to
+        // fix (Codex, round 4) — `.opacity` only affects rendering, not hit
+        // testing or shortcut dispatch.
         Button("Done") { requestCancel() }
           .keyboardShortcut(.defaultAction)
           .buttonStyle(.borderedProminent)
           .overlay {
             Button("Done") { requestCancel() }
               .keyboardShortcut(.cancelAction)
-              .hidden()
+              .opacity(0)
           }
       case .review:
         Button("Cancel") { requestCancel() }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -156,7 +156,10 @@ struct CustomWordsImportSheet: View {
         // interactions at all per Apple's own documentation, which would
         // silently reintroduce the exact Escape bug this button exists to
         // fix (Codex, round 4) — `.opacity` only affects rendering, not hit
-        // testing or shortcut dispatch.
+        // testing or shortcut dispatch. `.accessibilityHidden(true)` keeps
+        // VoiceOver/Full Keyboard Access from exposing two overlapping
+        // "Done" controls at the same location (Codex, round 6) — it only
+        // affects the accessibility tree, not keyboard shortcut dispatch.
         Button("Done") { requestCancel() }
           .keyboardShortcut(.defaultAction)
           .buttonStyle(.borderedProminent)
@@ -164,6 +167,7 @@ struct CustomWordsImportSheet: View {
             Button("Done") { requestCancel() }
               .keyboardShortcut(.cancelAction)
               .opacity(0)
+              .accessibilityHidden(true)
           }
       case .review:
         Button("Cancel") { requestCancel() }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -20,6 +20,7 @@ struct CustomWordsImportSheet: View {
   )
 
   @State private var model: CustomWordsImportFlowModel
+  @State private var showDiscardConfirm = false
   @Environment(\.dismiss) private var dismiss
 
   init(dependencies: CustomWordsImportFlowModel.Dependencies) {
@@ -27,6 +28,29 @@ struct CustomWordsImportSheet: View {
   }
 
   var body: some View {
+    // The macOS-15+ native window-close protection (#1700) is a second,
+    // deliberately separate, best-effort layer for the OS-level window-close
+    // trigger only — it is NOT proven reliable for this app's real nested
+    // sheet-inside-window topology (see the plan's empirical findings), so it
+    // is never relied on for Cancel/Escape/Done, which always use the local
+    // dialog below on every macOS version.
+    if #available(macOS 15.0, *) {
+      sheetContent
+        .dismissalConfirmationDialog(
+          "You've entered words. This will discard them.",
+          shouldPresent: model.hasDiscardableDraft
+        ) {
+          Button("Discard", role: .destructive) { model.cancel() }
+          Button("Keep editing", role: .cancel) {
+            model.keepEditingDiscardableDraft()
+          }
+        }
+    } else {
+      sheetContent
+    }
+  }
+
+  private var sheetContent: some View {
     VStack(alignment: .leading, spacing: 16) {
       header
 
@@ -68,6 +92,35 @@ struct CustomWordsImportSheet: View {
     // or clearing the sheet route dismisses without it, and an in-flight load
     // or comparison would otherwise keep running against a sheet that is gone.
     .onDisappear { model.cancel() }
+    // Single mechanism for Cancel, Escape, and Done, on every macOS version
+    // (#1700) — see `requestCancel()`.
+    .confirmationDialog(
+      "You've entered words. This will discard them.",
+      isPresented: $showDiscardConfirm,
+      titleVisibility: .visible
+    ) {
+      Button("Discard", role: .destructive) {
+        model.cancel()
+        dismiss()
+      }
+      Button("Keep editing", role: .cancel) {
+        model.keepEditingDiscardableDraft()
+      }
+    }
+  }
+
+  /// Single authority for every explicit discard action (Cancel, Escape via
+  /// the same `.keyboardShortcut(.cancelAction)`, and Done) (#1700). Calls
+  /// `model.cancel()` explicitly on the no-draft path rather than relying
+  /// solely on `.onDisappear`, so cleanup is part of the action's own
+  /// contract, not a lifecycle side effect.
+  private func requestCancel() {
+    if model.hasDiscardableDraft {
+      showDiscardConfirm = true
+    } else {
+      model.cancel()
+      dismiss()
+    }
   }
 
   private var header: some View {
@@ -88,24 +141,22 @@ struct CustomWordsImportSheet: View {
       Spacer()
       switch model.step {
       case .result:
-        Button("Done") { dismiss() }
+        // Routed through requestCancel() (#1700): a `.nothingFound`/`.failed`
+        // result still holds an uncommitted draft, so Done confirms first in
+        // that case; `.completed`/`.nothingApproved` proceed silently, same
+        // as before.
+        Button("Done") { requestCancel() }
           .keyboardShortcut(.defaultAction)
           .buttonStyle(.borderedProminent)
       case .review:
-        Button("Cancel") {
-          model.cancel()
-          dismiss()
-        }
-        .keyboardShortcut(.cancelAction)
+        Button("Cancel") { requestCancel() }
+          .keyboardShortcut(.cancelAction)
         Button(confirmTitle) { model.confirm() }
           .keyboardShortcut(.defaultAction)
           .buttonStyle(.borderedProminent)
       case .methodPicker, .paste, .upload, .smartImportAppPicker, .working:
-        Button("Cancel") {
-          model.cancel()
-          dismiss()
-        }
-        .keyboardShortcut(.cancelAction)
+        Button("Cancel") { requestCancel() }
+          .keyboardShortcut(.cancelAction)
       }
     }
   }

--- a/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
@@ -236,6 +236,46 @@ struct CustomWordsImportFlowModelTests {
     #expect(model.hasDiscardableDraft == true)
   }
 
+  @Test(
+    "an abandoned paste draft is still discardable after completing a DIFFERENT method's import"
+  )
+  func hasDiscardableDraftIsTrueForAbandonedDraftAfterOtherMethodCompletes() {
+    // Codex code-diff review: pasting a draft, backing out to try a different
+    // method, and completing THAT method's import must not let the earlier,
+    // never-committed paste draft be silently wiped by "nothing to lose"
+    // reasoning that only actually applies to the flow that just finished.
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.goBack()
+    #expect(model.step == .methodPicker)
+    #expect(model.pasteDraft == "Threadripper")
+
+    model.select(.upload)
+    model.beginWork(.committing)
+    model.showResult(.completed(added: 1, replaced: 0))
+
+    #expect(model.selectedMethod == .upload)
+    #expect(model.hasDiscardableDraft == true)
+  }
+
+  @Test(
+    "an abandoned paste draft is still discardable after a DIFFERENT method's import approves nothing"
+  )
+  func hasDiscardableDraftIsTrueForAbandonedDraftAfterOtherMethodApprovesNothing() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.goBack()
+
+    model.select(.smartImport)
+    model.beginWork(.committing)
+    model.showResult(.nothingApproved)
+
+    #expect(model.selectedMethod == .smartImport)
+    #expect(model.hasDiscardableDraft == true)
+  }
+
   @Test("a completed result has nothing left to discard")
   func hasDiscardableDraftIsFalseWhenCompleted() {
     let model = Self.makeModel()

--- a/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
@@ -379,4 +379,29 @@ struct CustomWordsImportFlowModelTests {
     #expect(model.selectedMethod == .paste)
     #expect(model.pasteDraft == "Threadripper")
   }
+
+  @Test(
+    "keeping an abandoned draft protected behind a DIFFERENT method's terminal result also reopens it"
+  )
+  func keepingAbandonedDraftAfterOtherMethodTerminalReopensPasteDraft() {
+    // Codex code-diff review, round 2: hasDiscardableDraft can now be true on
+    // .completed/.nothingApproved too, when they're guarding an abandoned
+    // draft from a method the user backed away from — Keep editing must
+    // reach that draft, not leave the user stuck on a screen with no Back.
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.goBack()
+
+    model.select(.upload)
+    model.beginWork(.committing)
+    model.showResult(.completed(added: 1, replaced: 0))
+    #expect(model.hasDiscardableDraft == true)
+
+    model.keepEditingDiscardableDraft()
+
+    #expect(model.step == .paste)
+    #expect(model.selectedMethod == .paste)
+    #expect(model.pasteDraft == "Threadripper")
+  }
 }

--- a/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportFlowModelTests.swift
@@ -199,4 +199,144 @@ struct CustomWordsImportFlowModelTests {
     #expect(model.pasteDraft.isEmpty)
     #expect(model.step == .methodPicker)
   }
+
+  // MARK: - Discardable draft confirmation (#1700)
+
+  @Test("an empty draft has nothing discardable")
+  func hasDiscardableDraftIsFalseForEmptyDraft() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    #expect(model.hasDiscardableDraft == false)
+  }
+
+  @Test("a whitespace-only draft has nothing discardable")
+  func hasDiscardableDraftIsFalseForWhitespaceOnlyDraft() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "   \n\t "
+    #expect(model.hasDiscardableDraft == false)
+  }
+
+  @Test("a non-empty draft on the paste screen is discardable")
+  func hasDiscardableDraftIsTrueOnPasteStep() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    #expect(model.hasDiscardableDraft == true)
+  }
+
+  @Test("a non-empty draft carried into review is still discardable")
+  func hasDiscardableDraftIsTrueOnReviewStep() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.beginWork(.comparing)
+    model.showReview()
+    #expect(model.step == .review)
+    #expect(model.hasDiscardableDraft == true)
+  }
+
+  @Test("a completed result has nothing left to discard")
+  func hasDiscardableDraftIsFalseWhenCompleted() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.beginWork(.committing)
+    model.showResult(.completed(added: 1, replaced: 0))
+    #expect(model.hasDiscardableDraft == false)
+  }
+
+  @Test("a nothing-approved result has nothing left to discard")
+  func hasDiscardableDraftIsFalseWhenNothingApproved() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.beginWork(.committing)
+    model.showResult(.nothingApproved)
+    #expect(model.hasDiscardableDraft == false)
+  }
+
+  @Test("a failed result still holds an uncommitted draft")
+  func failedResultKeepsDraftDiscardable() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.beginWork(.committing)
+    model.showResult(.failed(message: "Couldn't save"))
+    #expect(model.hasDiscardableDraft == true)
+  }
+
+  @Test("a nothing-found result still holds an uncommitted draft")
+  func nothingFoundResultKeepsDraftDiscardable() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.beginWork(.loadingCandidates)
+    model.showResult(.nothingFound)
+    #expect(model.hasDiscardableDraft == true)
+  }
+
+  @Test("an active commit has nothing framed as a discardable draft")
+  func hasDiscardableDraftIsFalseDuringCommit() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.beginWork(.committing)
+    #expect(model.hasDiscardableDraft == false)
+  }
+
+  @Test(
+    "loading or comparing candidates still counts as a discardable draft",
+    arguments: [
+      Model.Work.loadingCandidates, .comparing,
+    ])
+  func hasDiscardableDraftIsTrueDuringLoadOrCompare(work: Model.Work) {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.beginWork(work)
+    #expect(model.hasDiscardableDraft == true)
+  }
+
+  @Test("cancel clears the draft and its own predicate")
+  func cancelClearsDraftAndItsOwnPredicate() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.cancel()
+    #expect(model.pasteDraft.isEmpty)
+    #expect(model.hasDiscardableDraft == false)
+  }
+
+  @Test("going back still preserves a non-empty draft after the cancel() change")
+  func goBackStillPreservesDraftAfterCancelChange() {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.beginWork(.comparing)
+    model.showReview()
+    model.goBack()
+    #expect(model.step == .paste)
+    #expect(model.pasteDraft == "Threadripper")
+  }
+
+  @Test(
+    "keeping a discardable result reopens the pasted draft",
+    arguments: [
+      Model.Result.nothingFound,
+      .failed(message: "Couldn't import"),
+    ])
+  func keepingDiscardableResultReopensPasteDraft(result: Model.Result) {
+    let model = Self.makeModel()
+    model.select(.paste)
+    model.pasteDraft = "Threadripper"
+    model.beginWork(.loadingCandidates)
+    model.showResult(result)
+
+    model.keepEditingDiscardableDraft()
+
+    #expect(model.step == .paste)
+    #expect(model.selectedMethod == .paste)
+    #expect(model.pasteDraft == "Threadripper")
+  }
 }


### PR DESCRIPTION
## Summary
- Guards every path that can silently discard a pasted Custom Words import draft (Cancel, Escape, the Done button on a residual result screen, and macOS 15+ window-close best-effort) behind a single `hasDiscardableDraft` predicate and one explicit-action confirmation gate.
- `hasDiscardableDraft` correctly distinguishes a truly-committed result (nothing left to lose) from an abandoned draft left over after switching to a different, already-finished import method.
- `keepEditingDiscardableDraft()` reopens the paste screen with the draft intact for any discardable `.result` state, not just `.nothingFound`/`.failed`.

## Test plan
- [x] `scripts/xcode-test.sh --release` — 3614 Debug / 3342 Release tests, zero failures (includes 13+ new tests for `hasDiscardableDraft` / `keepEditingDiscardableDraft` / `cancel()`)
- [x] Local Codex code-diff review — 7 rounds to clean (P1 Escape bypass, P2 abandoned-draft exclusion, keep-editing widening, layout shift, opacity interactivity, perf, VoiceOver double-exposure)
- [x] Live UAT via `wispr_eyes.py` against the rebuilt dev app:
  - Cancel with a non-empty draft → confirmation dialog → Discard clears it
  - Escape with a non-empty draft → same confirmation gate fires
  - Empty/whitespace-only draft → silent dismiss, no dialog (as designed)
  - macOS 15+ window-close while the sheet is showing → AppKit disables the parent window's close button while the modal sheet is attached, so the close attempt is a no-op: window stays open, draft stays intact. No draft loss is possible via this path.
  - Done-on-residual-result path covered by unit tests; not forced live (native file-picker sheet is AX-unreachable for an unrelated check, same underlying confirmation mechanism already proven live above)

Closes #1700