### PR TITLE
feat(custom-words): bulk select and delete with an export-first offer (#1703)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/BulkDeleteConfirmSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/BulkDeleteConfirmSheet.swift
@@ -1,0 +1,119 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import SwiftUI
+
+/// Confirmation surface shown before any bulk word deletion commits (#1703).
+/// Shows an honest count and offers to export a backup first, framed as the
+/// easy path rather than a warning to click past. Mirrors
+/// `ContactsImportConfirm`'s shape.
+struct BulkDeleteConfirmSheet: View {
+  @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
+
+  let ids: Set<UUID>
+  let onDeleted: () -> Void
+  let onCancel: () -> Void
+
+  @State private var exportTask: Task<Void, Never>?
+  @State private var exportNotice: CustomWordsExportNotice?
+  @State private var deleteFailureMessage: String?
+
+  private var isExporting: Bool { exportTask != nil }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text("Delete \(ids.count) \(ids.count == 1 ? "word" : "words")?")
+        .font(.title3)
+        .bold()
+
+      Text("This can't be undone.")
+        .font(.body)
+
+      if let exportNotice {
+        Text(exportNotice.message)
+          .font(.stHelper)
+          .foregroundStyle(
+            exportNotice.title == "Export didn't finish" ? .stError : .stTextSecondary)
+      }
+
+      if let deleteFailureMessage {
+        Text(deleteFailureMessage)
+          .font(.stHelper)
+          .foregroundStyle(.stError)
+      }
+
+      HStack {
+        Button("Cancel", action: onCancel)
+          .keyboardShortcut(.cancelAction)
+          .disabled(isExporting)
+
+        Spacer()
+
+        Button {
+          exportCopy()
+        } label: {
+          if isExporting {
+            ProgressView().controlSize(.small)
+          } else {
+            Text("Export a copy first")
+          }
+        }
+        .disabled(isExporting)
+
+        Button("Delete \(ids.count) \(ids.count == 1 ? "word" : "words")", role: .destructive) {
+          deleteSelection()
+        }
+        .disabled(isExporting)
+      }
+    }
+    .padding(24)
+    .frame(width: 420)
+    .interactiveDismissDisabled(isExporting)
+    .onDisappear {
+      exportTask?.cancel()
+    }
+  }
+
+  /// Export the user's own words as a backup before the destructive delete
+  /// (#1703). Full library, not scoped to only the selected words — this is
+  /// meant as a genuine backup, matching the founder's framing.
+  ///
+  /// The stored task both guards against a duplicate export attempt AND owns
+  /// the task's lifecycle: it clears itself via `defer`, checks
+  /// cancellation before opening the save panel and again before publishing
+  /// a notice, so a torn-down sheet can never publish stale state. A
+  /// cancelled-late export may still have written its file; cancellation
+  /// only prevents surfacing a stale notice into a gone sheet, it does not
+  /// and cannot reverse a write already reached by the writer.
+  private func exportCopy() {
+    guard exportTask == nil else { return }
+
+    let proposed = CustomWordsExportAction.exportableWords(
+      from: customWordsCoordinator.customWords)
+
+    exportTask = Task {
+      defer { exportTask = nil }
+
+      guard !Task.isCancelled else { return }
+      let outcome = await CustomWordsExportAction.run(
+        coordinator: customWordsCoordinator,
+        proposedExportWords: proposed,
+        chooseDestination: {
+          CustomWordsExportPanel.chooseDestination(exportableCount: proposed.count)
+        },
+        write: { document, destination in
+          try await CustomWordsExportWriter.write(document, to: destination)
+        }
+      )
+      guard !Task.isCancelled else { return }
+      exportNotice = CustomWordsExportNotice.forOutcome(outcome)
+    }
+  }
+
+  private func deleteSelection() {
+    if let error = customWordsCoordinator.removeBatch(ids: Array(ids)) {
+      deleteFailureMessage = error
+      return
+    }
+    onDeleted()
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermListPolicy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermListPolicy.swift
@@ -51,6 +51,20 @@ enum CustomTermListPolicy {
     guard start < filtered.count else { return [] }
     return Array(filtered[start..<end])
   }
+
+  /// IDs eligible for bulk selection (#1703) = exactly the IDs
+  /// `CustomWordsExportAction.exportableWords` would back up. One authority
+  /// for "the user's own," not a second one.
+  static func selectableIDs(in words: [CustomWord]) -> Set<UUID> {
+    Set(CustomWordsExportAction.exportableWords(from: words).map(\.id))
+  }
+
+  /// Select-All/Deselect-All toggle over the CURRENT FILTERED target — not
+  /// the whole library, and not just the current page. If `target` is
+  /// already fully selected, deselect exactly it; otherwise union it in.
+  static func toggledSelection(current: Set<UUID>, target: Set<UUID>) -> Set<UUID> {
+    target.isSubset(of: current) ? current.subtracting(target) : current.union(target)
+  }
 }
 
 /// Phase 4 (#634) — Match Strictness picker mapping for `CustomWord.minSimilarityOverride`.

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -1,14 +1,28 @@
 import EnviousWisprCore
 import SwiftUI
 
+/// A pending bulk-delete confirmation, keyed by request rather than a bare
+/// boolean (#1703) — the confirmation's content depends on which IDs were
+/// selected, so `.sheet(item:)` is the correct presentation, matching the
+/// data-dependent sheet pattern this repo already uses (`YourWordsView`).
+private struct BulkDeleteRequest: Identifiable {
+  let id = UUID()
+  let ids: Set<UUID>
+}
+
 /// Phase 4 (#634) — Custom Terms section. Search + pagination + per-term Edit.
 /// Reads `frequencyUsed` from Phase 3a/b for "used N times" subtitle (omitted
 /// when frequency is 0 to avoid the "0 times" looks-like-a-bug case). Bible §10.2.
+/// Bulk select/delete (#1703): a "Select" mode lets several of the user's own
+/// words be checked off and removed in one action.
 struct CustomTermsSection: View {
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var searchQuery: String = ""
   @State private var currentPage: Int = 0
   @State private var editingWord: CustomWord?
+  @State private var isSelecting = false
+  @State private var selectedIDs: Set<UUID> = []
+  @State private var pendingBulkDelete: BulkDeleteRequest?
 
   private var allWords: [CustomWord] {
     customWordsCoordinator.customWords
@@ -16,6 +30,13 @@ struct CustomTermsSection: View {
 
   private var filteredWords: [CustomWord] {
     CustomTermListPolicy.filtered(allWords, query: searchQuery)
+  }
+
+  /// IDs eligible for bulk selection within the current search/filter — never
+  /// the whole library, and never a built-in or vocabulary-pack term. One
+  /// projection reused by both the Select-All control and row rendering.
+  private var filteredSelectableIDs: Set<UUID> {
+    CustomTermListPolicy.selectableIDs(in: filteredWords)
   }
 
   private var pageCount: Int {
@@ -29,7 +50,7 @@ struct CustomTermsSection: View {
 
   var body: some View {
     BrandedSection(header: "Custom terms · \(filteredWords.count)") {
-      // Search
+      // Search + selection controls
       BrandedRow(showDivider: true) {
         HStack(spacing: 6) {
           Image(systemName: "magnifyingglass")
@@ -52,6 +73,8 @@ struct CustomTermsSection: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Clear search")
           }
+          Spacer()
+          selectionControls
         }
       }
 
@@ -69,20 +92,23 @@ struct CustomTermsSection: View {
       } else {
         ForEach(Array(pagedWords.enumerated()), id: \.element.id) { idx, word in
           BrandedRow(showDivider: idx < pagedWords.count - 1 || pageCount > 1) {
-            HStack {
-              VStack(alignment: .leading, spacing: 2) {
-                Text(word.canonical)
-                  .font(.body)
-                Text(usageSubtitle(for: word))
-                  .font(.stHelper)
-                  .foregroundStyle(.stTextSecondary)
-              }
-              Spacer()
-              Button("Edit") {
-                editingWord = word
-              }
-              .controlSize(.small)
+            termRow(for: word)
+          }
+        }
+      }
+
+      // Bulk-delete action row, shown only once something is selected.
+      if isSelecting, !selectedIDs.isEmpty {
+        BrandedRow(showDivider: false) {
+          HStack {
+            Text("\(selectedIDs.count) selected")
+              .font(.stHelper)
+              .foregroundStyle(.stTextSecondary)
+            Spacer()
+            Button("Delete…", role: .destructive) {
+              pendingBulkDelete = BulkDeleteRequest(ids: selectedIDs)
             }
+            .controlSize(.small)
           }
         }
       }
@@ -116,6 +142,12 @@ struct CustomTermsSection: View {
         }
       }
     }
+    .onChange(of: allWords) { _, newWords in
+      // Prune against current ELIGIBILITY, not merely current ID existence:
+      // if a live refresh replaces an already-selected ID with a word that
+      // still exists but is no longer the user's own, drop it too (#1703).
+      selectedIDs.formIntersection(CustomTermListPolicy.selectableIDs(in: newWords))
+    }
     .sheet(item: $editingWord) { word in
       CustomWordEditSheet(
         word: word,
@@ -127,6 +159,90 @@ struct CustomTermsSection: View {
           customWordsCoordinator.remove(id: word.id)
         }
       )
+    }
+    .sheet(item: $pendingBulkDelete) { request in
+      BulkDeleteConfirmSheet(
+        ids: request.ids,
+        onDeleted: {
+          selectedIDs.subtract(request.ids)
+          isSelecting = false
+          pendingBulkDelete = nil
+        },
+        onCancel: { pendingBulkDelete = nil }
+      )
+    }
+  }
+
+  @ViewBuilder
+  private func termRow(for word: CustomWord) -> some View {
+    if isSelecting, filteredSelectableIDs.contains(word.id) {
+      Toggle(
+        isOn: Binding(
+          get: { selectedIDs.contains(word.id) },
+          set: { selected in
+            if selected {
+              selectedIDs.insert(word.id)
+            } else {
+              selectedIDs.remove(word.id)
+            }
+          }
+        )
+      ) {
+        termLabel(for: word)
+      }
+      .toggleStyle(.checkbox)
+    } else {
+      HStack {
+        termLabel(for: word)
+        Spacer()
+        // Edit is unavailable while selecting — structurally, not merely by
+        // convention, so the two sheets this section presents never both
+        // apply to the same row at once.
+        if !isSelecting {
+          Button("Edit") {
+            editingWord = word
+          }
+          .controlSize(.small)
+        }
+      }
+    }
+  }
+
+  private func termLabel(for word: CustomWord) -> some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(word.canonical)
+        .font(.body)
+      Text(usageSubtitle(for: word))
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+    }
+  }
+
+  /// Trailing controls in the search row: "Select" when idle (only offered
+  /// if there is anything selectable in the current filtered set), or
+  /// "Select All"/"Deselect All" + "Cancel" while selecting.
+  @ViewBuilder
+  private var selectionControls: some View {
+    if isSelecting {
+      let allSelected =
+        !filteredSelectableIDs.isEmpty && filteredSelectableIDs.isSubset(of: selectedIDs)
+      Button(allSelected ? "Deselect All" : "Select All") {
+        selectedIDs = CustomTermListPolicy.toggledSelection(
+          current: selectedIDs, target: filteredSelectableIDs)
+      }
+      .controlSize(.small)
+      .disabled(filteredSelectableIDs.isEmpty)
+
+      Button("Cancel") {
+        selectedIDs = []
+        isSelecting = false
+      }
+      .controlSize(.small)
+    } else if !filteredSelectableIDs.isEmpty {
+      Button("Select") {
+        isSelecting = true
+      }
+      .controlSize(.small)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportNotice.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportNotice.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Export-outcome-to-message mapping (#1703), extracted from the previously
+/// private, DEBUG-only `YourWordsView.ExportNotice` so a release-visible
+/// caller (`BulkDeleteConfirmSheet`) can present the identical copy. Two
+/// kinds, deliberately: a real failure, and an honest outcome that is not a
+/// failure. Sharing one "Export didn't finish" title for both would tell a
+/// pack-only user their export broke when it worked exactly as designed
+/// (#1697).
+enum CustomWordsExportNotice: Equatable {
+  case failure(String)
+  case info(String)
+
+  var title: String {
+    switch self {
+    case .failure: return "Export didn't finish"
+    case .info: return "Nothing was exported"
+    }
+  }
+
+  var message: String {
+    switch self {
+    case .failure(let text), .info(let text): return text
+    }
+  }
+
+  /// Maps a `CustomWordsExportAction.Outcome` to a notice, or `nil` when
+  /// there is nothing to say (`.cancelled` or `.exported`).
+  static func forOutcome(_ outcome: CustomWordsExportAction.Outcome) -> CustomWordsExportNotice? {
+    switch outcome {
+    case .cancelled, .exported:
+      return nil
+    case .refusedUnsafeLibrary:
+      return .failure(
+        "Your saved words couldn't be read this time, so there's nothing safe to export. "
+          + "Relaunch EnviousWispr and try again.")
+    // Neither of the next two is a failure, so neither wears the failure
+    // title. A pack-only user pressing Export has done nothing wrong; they
+    // need the reason their long word list produced no file (#1697).
+    case .nothingToExport:
+      return .info(
+        "There are no words of your own to export yet. "
+          + "Vocabulary packs are not included.")
+    case .libraryChanged:
+      return .info(
+        // Says nothing about WHEN or WHERE the list moved, because two
+        // different paths land here: the drift check after a folder was
+        // chosen, and a stale empty count that never opened a dialog at
+        // all (cloud review, #1715).
+        "Your word list changed, so nothing was exported. "
+          + "Try Export again.")
+    case .failed(let message):
+      return .failure(message)
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -25,29 +25,11 @@ struct YourWordsView: View {
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var sheetRoute: YourWordsSheetRoute?
   #if DEBUG
-    /// What to say after an export attempt. Two kinds, deliberately: a real
-    /// failure, and an honest outcome that is not a failure. Sharing one
-    /// "Export didn't finish" title for both would tell a pack-only user their
-    /// export broke when it worked exactly as designed (#1697).
-    enum ExportNotice: Equatable {
-      case failure(String)
-      case info(String)
-
-      var title: String {
-        switch self {
-        case .failure: return "Export didn't finish"
-        case .info: return "Nothing was exported"
-        }
-      }
-
-      var message: String {
-        switch self {
-        case .failure(let text), .info(let text): return text
-        }
-      }
-    }
-
-    @State private var exportNotice: ExportNotice?
+    // Outcome-to-message mapping moved to shared `CustomWordsExportNotice`
+    // (#1703) so `BulkDeleteConfirmSheet`'s release-visible export offer can
+    // present the identical copy. This button stays DEBUG-only; only the
+    // mapping it reads from is now shared, not private.
+    @State private var exportNotice: CustomWordsExportNotice?
   #endif
 
   var body: some View {
@@ -188,33 +170,7 @@ struct YourWordsView: View {
             try await CustomWordsExportWriter.write(document, to: destination)
           }
         )
-        switch outcome {
-        case .cancelled, .exported:
-          exportNotice = nil
-        case .refusedUnsafeLibrary:
-          exportNotice = .failure(
-            "Your saved words couldn't be read this time, so there's nothing safe to export. "
-              + "Relaunch EnviousWispr and try again.")
-        // Neither of the next two is a failure, so neither wears the failure
-        // title. A pack-only user pressing Export has done nothing wrong; they
-        // need the reason their long word list produced no file (#1697).
-        case .nothingToExport:
-          exportNotice = .info(
-            "There are no words of your own to export yet. "
-              + "Vocabulary packs are not included.")
-        case .libraryChanged:
-          exportNotice = .info(
-            // Says nothing about WHEN or WHERE the list moved, because two
-            // different paths land here: the drift check after a folder was
-            // chosen, and a stale empty count that never opened a dialog at
-            // all. Naming folder selection would describe a step the second
-            // user never took (cloud review, #1715). It also can't say "review
-            // the updated count" any more — there is no count on this screen.
-            "Your word list changed, so nothing was exported. "
-              + "Try Export again.")
-        case .failed(let message):
-          exportNotice = .failure(message)
-        }
+        exportNotice = CustomWordsExportNotice.forOutcome(outcome)
       }
     }
 

--- a/Tests/EnviousWisprTests/Settings/CustomTermListPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/CustomTermListPolicyTests.swift
@@ -118,6 +118,66 @@ struct CustomTermListPolicyTests {
     #expect(CustomTermListPolicy.paged(words, page: 5).isEmpty)
   }
 
+  // MARK: - selectableIDs (#1703)
+
+  @Test(
+    "selectableIDs matches source == .user for every WordSource case",
+    arguments: WordSource.allCases
+  )
+  func selectableIDsMatchesUserSource(source: WordSource) {
+    let word = CustomWord(canonical: "Test", source: source)
+    let ids = CustomTermListPolicy.selectableIDs(in: [word])
+    #expect(ids.contains(word.id) == (source == .user))
+  }
+
+  @Test("selectableIDs on empty input returns empty set")
+  func selectableIDsEmptyInput() {
+    #expect(CustomTermListPolicy.selectableIDs(in: []).isEmpty)
+  }
+
+  @Test("selectableIDs excludes built-in and pack words in a mixed list")
+  func selectableIDsMixedSources() {
+    let userWord = CustomWord(canonical: "UserWord", source: .user)
+    let builtinWord = CustomWord(canonical: "BuiltinWord", source: .builtin)
+    let packWord = CustomWord(canonical: "PackWord", source: .pack)
+    let ids = CustomTermListPolicy.selectableIDs(in: [userWord, builtinWord, packWord])
+    #expect(ids == [userWord.id])
+  }
+
+  // MARK: - toggledSelection (#1703)
+
+  @Test("toggledSelection: target fully selected already → deselects exactly the target")
+  func toggledSelectionDeselectsFullySelectedTarget() {
+    let hidden = UUID()
+    let visible = UUID()
+    let result = CustomTermListPolicy.toggledSelection(
+      current: [hidden, visible], target: [visible])
+    #expect(result == [hidden])
+  }
+
+  @Test("toggledSelection: target not fully selected → unions it in")
+  func toggledSelectionUnionsPartialTarget() {
+    let already = UUID()
+    let a = UUID()
+    let b = UUID()
+    let result = CustomTermListPolicy.toggledSelection(current: [already], target: [a, b])
+    #expect(result == [already, a, b])
+  }
+
+  @Test("toggledSelection: empty target → no change")
+  func toggledSelectionEmptyTargetNoChange() {
+    let existing = UUID()
+    let result = CustomTermListPolicy.toggledSelection(current: [existing], target: [])
+    #expect(result == [existing])
+  }
+
+  @Test("toggledSelection: empty current, non-empty target → selects the target")
+  func toggledSelectionEmptyCurrentSelectsTarget() {
+    let a = UUID()
+    let result = CustomTermListPolicy.toggledSelection(current: [], target: [a])
+    #expect(result == [a])
+  }
+
   // MARK: - MatchStrictness
 
   @Test("MatchStrictness override mapping")

--- a/Tests/EnviousWisprTests/Settings/CustomWordsExportNoticeTests.swift
+++ b/Tests/EnviousWisprTests/Settings/CustomWordsExportNoticeTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1703 — pins the outcome-to-message mapping extracted from
+/// `YourWordsView`'s previously private `ExportNotice`, shared with
+/// `BulkDeleteConfirmSheet`.
+@Suite("CustomWordsExportNotice")
+struct CustomWordsExportNoticeTests {
+
+  @Test("cancelled and exported map to nil — nothing to say")
+  func noOpOutcomesMapToNil() {
+    #expect(CustomWordsExportNotice.forOutcome(.cancelled) == nil)
+    #expect(CustomWordsExportNotice.forOutcome(.exported) == nil)
+  }
+
+  @Test("refusedUnsafeLibrary maps to a failure notice")
+  func refusedUnsafeLibraryIsFailure() throws {
+    let notice = try #require(CustomWordsExportNotice.forOutcome(.refusedUnsafeLibrary))
+    guard case .failure = notice else {
+      Issue.record("expected .failure, got \(notice)")
+      return
+    }
+  }
+
+  @Test("nothingToExport maps to an info notice, not a failure")
+  func nothingToExportIsInfo() throws {
+    let notice = try #require(CustomWordsExportNotice.forOutcome(.nothingToExport))
+    guard case .info = notice else {
+      Issue.record("expected .info, got \(notice)")
+      return
+    }
+  }
+
+  @Test("libraryChanged maps to an info notice, not a failure")
+  func libraryChangedIsInfo() throws {
+    let notice = try #require(CustomWordsExportNotice.forOutcome(.libraryChanged))
+    guard case .info = notice else {
+      Issue.record("expected .info, got \(notice)")
+      return
+    }
+  }
+
+  @Test("failed(message:) maps to a failure notice carrying that exact message")
+  func failedCarriesMessage() throws {
+    let notice = try #require(CustomWordsExportNotice.forOutcome(.failed(message: "disk full")))
+    #expect(notice == .failure("disk full"))
+  }
+
+  @Test("failure and info notices have distinct titles")
+  func titlesDistinguishFailureFromInfo() {
+    #expect(CustomWordsExportNotice.failure("x").title == "Export didn't finish")
+    #expect(CustomWordsExportNotice.info("x").title == "Nothing was exported")
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a Select mode to the Custom Terms list: checkboxes on the user's own words only (built-ins and vocabulary packs are never selectable), a Select-All scoped to the current search/filter, and a bottom action bar showing the live selection count.
- Bulk delete confirms with an exact count and offers to export a full backup first, framed as the easy path. Export is serialized (single in-flight task, buttons + dismissal disabled while it runs) and its outcome uses a shared, production-compiled notice type extracted from the existing debug-only Export button's mapping.
- Reuses `CustomWordsManager.removeBatch`/`CustomWordsCoordinator.removeBatch` and `CustomWordsExportAction` unmodified — no new persistence, no changed signatures.

Plan: `docs/feature-requests/issue-1703-2026-07-21-bulk-select-delete.md` (3 rounds of Codex grounded review to PROCEED-AS-PLANNED before Gate 2 sign-off).

## Test plan
- [x] `scripts/xcode-test.sh` — full suite green (3663 tests), including new `CustomTermListPolicyTests` selection cases and new `CustomWordsExportNoticeTests`.
- [x] Local Codex code-diff review — clean, no actionable findings.
- [x] Live UAT on a rebuilt dev app: created 3 disposable uniquely-named test words, entered Select mode, confirmed built-in words (API, ChatGPT, CLI, VS Code) show no checkbox while every user word does, selected the 3 test words, used the export-first offer (verified the real file on disk contains them), then deleted — confirmed gone from the live list and from `custom-words.json`, founder's real 33 words untouched.
- [x] Quick heart-path sanity dictation post-change — pipeline healthy (1.057s total), transcript correct.

Closes #1703