### PR TITLE
fix(ui): Apple Intelligence tile falls back to a letter, not blank

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -293,7 +293,7 @@ struct ProviderLogoTile: View {
         .frame(width: size * 0.52, height: size * 0.52)
         .foregroundStyle(markTint)
     } else {
-      monogram("")  // Apple glyph unavailable on the macOS-14 floor → letter fallback
+      monogram("A")  // Apple glyph unavailable on the macOS-14 floor → letter fallback
     }
   }
 


### PR DESCRIPTION
Closes #1613

## What
`ProviderLogoTile.appleMark`'s else-branch hardcoded `monogram("")` when the `apple.logo` SF Symbol is unavailable (macOS-14 floor), rendering a blank tile instead of a fallback letter. Every other provider's fallback already renders a real letter; this makes Apple Intelligence consistent.

## Fix
One-line change: `monogram("")` → `monogram("A")`.

`ProviderLogoSVG.monogram(for: .appleIntelligence)` (a separate static function, unreached by this code path today per the existing test comment) is intentionally untouched — same scope the issue calls out.

## Validation
- `council-skip: zero-blast-radius (single-value literal, 1 file, 1 line, no new symbols)`
- Self-audit-grep / Self-audit-owner in the commit body
- Local `codex review --base origin/main`: no blocking issues
- `scripts/xcode-test.sh --filter EnviousWisprTests/ProviderLogoTests`: 3/3 passed
- Dev build succeeded (`scripts/build-dev-app.sh`)
