### PR TITLE
fix(test): repo root resolves by marker walk + realpath, not a fixed-depth trim

### DIFF
--- a/Tests/EnviousWisprTests/Architecture/AdapterShapeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AdapterShapeTests.swift
@@ -35,7 +35,7 @@ import Testing
 
   @Test("the production ParakeetEngineAdapter carries no FSM tokens")
   func realAdapterIsClean() throws {
-    let url = repoRoot().appending(path: Self.adapterRelativePath)
+    let url = RepoRoot.url.appending(path: Self.adapterRelativePath)
     let source = try String(contentsOf: url, encoding: .utf8)
     let violations = Self.scan(source)
     #expect(
@@ -116,15 +116,5 @@ import Testing
       }
     }
     return violations
-  }
-
-  /// Repo root, anchored off `#filePath` — this file lives at
-  /// `Tests/EnviousWisprTests/Architecture/`, four levels below the root.
-  private func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
   }
 }

--- a/Tests/EnviousWisprTests/Architecture/AppStateFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppStateFreezeTests.swift
@@ -28,7 +28,7 @@ import Testing
 
   @Test func appStateFileDoesNotExist() {
     for relativePath in Self.appStateRelativePaths {
-      let url = repoRoot().appending(path: relativePath)
+      let url = RepoRoot.url.appending(path: relativePath)
       #expect(
         !FileManager.default.fileExists(atPath: url.path),
         """
@@ -63,24 +63,13 @@ import Testing
 
   // MARK: - Helpers
 
-  /// Repo root, anchored off `#filePath` (cwd-independent in CI).
-  /// This file lives at `Tests/EnviousWisprTests/Architecture/` — three levels
-  /// below the root.
-  private func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-  }
-
   /// Returns `"path:line: text"` for every line under `directory` that contains
   /// a whole-word `AppState`, skipping files whose name is in `allowing`.
   private func referencingFiles(
     under directory: String, allowing: Set<String>
   ) throws -> [String] {
     let regex = try NSRegularExpression(pattern: Self.tokenPattern)
-    let root = repoRoot().appending(path: directory)
+    let root = RepoRoot.url.appending(path: directory)
     guard
       let enumerator = FileManager.default.enumerator(
         at: root, includingPropertiesForKeys: nil)

--- a/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineIdentityFreezeTests.swift
@@ -276,7 +276,7 @@ import Testing
 
   @Test("WhisperKit factory branch has exactly one production caller")
   func makeForWhisperKitHasExactlyOneProductionCaller() throws {
-    let sourcesRoot = Self.repoRoot().appending(path: "Sources")
+    let sourcesRoot = RepoRoot.url.appending(path: "Sources")
     let enumerator = FileManager.default.enumerator(
       at: sourcesRoot, includingPropertiesForKeys: nil,
       options: [.skipsHiddenFiles, .skipsPackageDescendants])
@@ -285,7 +285,7 @@ import Testing
     while let url = enumerator?.nextObject() as? URL {
       guard url.pathExtension == "swift" else { continue }
       let relative = url.path.replacingOccurrences(
-        of: Self.repoRoot().path + "/", with: "")
+        of: RepoRoot.url.path + "/", with: "")
       // The factory's own definition site is not a caller.
       if relative == "Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift" {
         continue
@@ -524,7 +524,7 @@ import Testing
       acc, hook in
       acc[hook] = try NSRegularExpression(pattern: #"\badapter\."# + hook + #"\("#)
     }
-    let sourcesRoot = Self.repoRoot().appending(path: "Sources")
+    let sourcesRoot = RepoRoot.url.appending(path: "Sources")
     let enumerator = FileManager.default.enumerator(
       at: sourcesRoot, includingPropertiesForKeys: nil,
       options: [.skipsHiddenFiles, .skipsPackageDescendants])
@@ -536,7 +536,7 @@ import Testing
       let ns = source as NSString
       let range = NSRange(location: 0, length: ns.length)
       let relative = url.path.replacingOccurrences(
-        of: Self.repoRoot().path + "/", with: "")
+        of: RepoRoot.url.path + "/", with: "")
       visited.insert(relative)
       let allowedPerHook = allowed[relative] ?? [:]
       for hook in hooks {
@@ -663,7 +663,7 @@ import Testing
   // MARK: Helpers
 
   private static func readSource(_ relative: String) throws -> String {
-    let url = repoRoot().appending(path: relative)
+    let url = RepoRoot.url.appending(path: relative)
     return try String(contentsOf: url, encoding: .utf8)
   }
 
@@ -678,7 +678,7 @@ import Testing
   /// historical breadcrumbs and must not trip the freeze.
   private static func scanSources(pattern: String) throws -> [String] {
     let regex = try NSRegularExpression(pattern: pattern)
-    let sourcesRoot = repoRoot().appending(path: "Sources")
+    let sourcesRoot = RepoRoot.url.appending(path: "Sources")
     let enumerator = FileManager.default.enumerator(
       at: sourcesRoot, includingPropertiesForKeys: nil,
       options: [.skipsHiddenFiles, .skipsPackageDescendants])
@@ -687,7 +687,7 @@ import Testing
       guard url.pathExtension == "swift" else { continue }
       let source = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
       let relative = url.path.replacingOccurrences(
-        of: repoRoot().path + "/", with: "")
+        of: RepoRoot.url.path + "/", with: "")
       for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false)
         .enumerated()
       {
@@ -736,13 +736,4 @@ import Testing
     return false
   }
 
-  /// Repo root, anchored off `#filePath` — this file lives at
-  /// `Tests/EnviousWisprTests/Architecture/`, four levels below the root.
-  private static func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-  }
 }

--- a/Tests/EnviousWisprTests/Architecture/EngineSwitchOwnershipFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineSwitchOwnershipFreezeTests.swift
@@ -125,14 +125,14 @@ import Testing
 
   private static func scanSources(pattern: String, excludingDir: String?) throws -> [String] {
     let regex = try NSRegularExpression(pattern: pattern)
-    let rootURL = repoRoot().appending(path: "Sources")
+    let rootURL = RepoRoot.url.appending(path: "Sources")
     let enumerator = FileManager.default.enumerator(
       at: rootURL, includingPropertiesForKeys: nil,
       options: [.skipsHiddenFiles, .skipsPackageDescendants])
     var hits: [String] = []
     while let url = enumerator?.nextObject() as? URL {
       guard url.pathExtension == "swift" else { continue }
-      let relative = url.path.replacingOccurrences(of: repoRoot().path + "/", with: "")
+      let relative = url.path.replacingOccurrences(of: RepoRoot.url.path + "/", with: "")
       if let dir = excludingDir, relative.hasPrefix(dir) { continue }
       let source = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
       for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false)
@@ -168,15 +168,5 @@ import Testing
     guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
     let ns = source as NSString
     return regex.firstMatch(in: source, range: NSRange(location: 0, length: ns.length)) != nil
-  }
-
-  /// Repo root, anchored off `#filePath` — this file lives at
-  /// `Tests/EnviousWisprTests/Architecture/`, four levels below the root.
-  private static func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
   }
 }

--- a/Tests/EnviousWisprTests/Architecture/KernelOwnershipFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/KernelOwnershipFreezeTests.swift
@@ -202,7 +202,7 @@ import Testing
 
   private static func scan(root: String, pattern: String, allowing: [String]) throws -> [String] {
     let regex = try NSRegularExpression(pattern: pattern)
-    let rootURL = repoRoot().appending(path: root)
+    let rootURL = RepoRoot.url.appending(path: root)
     let enumerator = FileManager.default.enumerator(
       at: rootURL, includingPropertiesForKeys: nil,
       options: [.skipsHiddenFiles, .skipsPackageDescendants])
@@ -211,7 +211,7 @@ import Testing
       guard url.pathExtension == "swift" else { continue }
       if allowing.contains(url.lastPathComponent) { continue }
       let source = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
-      let relative = url.path.replacingOccurrences(of: repoRoot().path + "/", with: "")
+      let relative = url.path.replacingOccurrences(of: RepoRoot.url.path + "/", with: "")
       for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false)
         .enumerated()
       {
@@ -256,15 +256,5 @@ import Testing
       }
     }
     return false
-  }
-
-  /// Repo root, anchored off `#filePath` — this file lives at
-  /// `Tests/EnviousWisprTests/Architecture/`, four levels below the root.
-  private static func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
   }
 }

--- a/Tests/EnviousWisprTests/Architecture/RepoRoot.swift
+++ b/Tests/EnviousWisprTests/Architecture/RepoRoot.swift
@@ -10,13 +10,31 @@ import Foundation
 /// reads fail. Every source-reading test resolves its repo-relative path
 /// through here instead, making the reads CWD-independent.
 enum RepoRoot {
-  /// This file lives at `<root>/Tests/EnviousWisprTests/Architecture/RepoRoot.swift`,
-  /// so four parent hops reach `<root>`.
-  static let url: URL = URL(fileURLWithPath: #filePath)
-    .deletingLastPathComponent()  // Architecture/
-    .deletingLastPathComponent()  // EnviousWisprTests/
-    .deletingLastPathComponent()  // Tests/
-    .deletingLastPathComponent()  // <root>/
+  /// Walks up from this file's directory until it finds `Package.swift`,
+  /// instead of trimming a fixed number of path components. `/tmp` is a
+  /// symlink to `/private/tmp` on macOS, which perturbs a fixed-depth trim's
+  /// component count for a checkout there and produced 6 false freeze-test
+  /// failures (#1675).
+  static let url: URL = resolve()
+
+  private static func resolve() -> URL {
+    var candidate = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    for _ in 0..<32 {
+      if FileManager.default.fileExists(
+        atPath: candidate.appending(path: "Package.swift").path)
+      {
+        return candidate
+      }
+      let parent = candidate.deletingLastPathComponent()
+      precondition(
+        parent.path != candidate.path,
+        "RepoRoot: reached the filesystem root without finding Package.swift, starting from \(#filePath)"
+      )
+      candidate = parent
+    }
+    preconditionFailure(
+      "RepoRoot: no Package.swift found within 32 parent directories of \(#filePath)")
+  }
 
   /// Absolute URL for a repo-relative source path (e.g.
   /// `"Sources/EnviousWisprAppKit/App/AppDelegate.swift"`). An already-absolute path

--- a/Tests/EnviousWisprTests/Architecture/RepoRoot.swift
+++ b/Tests/EnviousWisprTests/Architecture/RepoRoot.swift
@@ -15,6 +15,18 @@ enum RepoRoot {
   /// symlink to `/private/tmp` on macOS, which perturbs a fixed-depth trim's
   /// component count for a checkout there and produced 6 false freeze-test
   /// failures (#1675).
+  ///
+  /// Canonicalized through POSIX `realpath(3)`, NOT `URL.resolvingSymlinksInPath()`
+  /// / `.standardized` — both deliberately leave `/tmp` unresolved (an Apple
+  /// Foundation special case), while `FileManager.enumerator(at:)` returns
+  /// fully OS-resolved paths (`/private/tmp/...`) for anything under it. Every
+  /// scan function below compares an enumerated URL's path against this root's
+  /// path to compute a repo-relative path; leaving this root unresolved made
+  /// that comparison silently fail under a `/tmp` checkout (confirmed
+  /// empirically: `resolvingSymlinksInPath()` and `.standardized` both left
+  /// `/tmp/<dir>` unchanged, while `realpath(3)` correctly returned
+  /// `/private/tmp/<dir>`), producing the mangled `/privateSources/...`
+  /// offender paths in the original bug report.
   static let url: URL = resolve()
 
   private static func resolve() -> URL {
@@ -23,7 +35,7 @@ enum RepoRoot {
       if FileManager.default.fileExists(
         atPath: candidate.appending(path: "Package.swift").path)
       {
-        return candidate
+        return canonicalize(candidate)
       }
       let parent = candidate.deletingLastPathComponent()
       precondition(
@@ -34,6 +46,12 @@ enum RepoRoot {
     }
     preconditionFailure(
       "RepoRoot: no Package.swift found within 32 parent directories of \(#filePath)")
+  }
+
+  private static func canonicalize(_ url: URL) -> URL {
+    var buffer = [Int8](repeating: 0, count: Int(PATH_MAX))
+    guard realpath(url.path, &buffer) != nil else { return url }
+    return URL(fileURLWithPath: String(cString: buffer))
   }
 
   /// Absolute URL for a repo-relative source path (e.g.

--- a/Tests/EnviousWisprTests/Architecture/WhisperKitStitchFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/WhisperKitStitchFreezeTests.swift
@@ -23,7 +23,7 @@ import Testing
   ]
 
   @Test func workerFileDoesNotExist() {
-    let url = repoRoot().appending(
+    let url = RepoRoot.url.appending(
       path: "Sources/EnviousWisprASR/WhisperKitIncrementalWorker.swift")
     #expect(
       !FileManager.default.fileExists(atPath: url.path),
@@ -68,7 +68,7 @@ import Testing
   private func filesReferencing(
     pattern: String, under directory: String, allowing allowlist: [String]
   ) throws -> [String] {
-    let root = repoRoot().appending(path: directory)
+    let root = RepoRoot.url.appending(path: directory)
     let regex = try NSRegularExpression(pattern: pattern)
     var offenders: [String] = []
     let enumerator = FileManager.default.enumerator(
@@ -83,14 +83,5 @@ import Testing
       }
     }
     return offenders.sorted()
-  }
-
-  private func repoRoot() -> URL {
-    // #file = .../Tests/EnviousWisprTests/Architecture/WhisperKitStitchFreezeTests.swift
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()  // Architecture
-      .deletingLastPathComponent()  // EnviousWisprTests
-      .deletingLastPathComponent()  // Tests
-      .deletingLastPathComponent()  // repo root
   }
 }

--- a/Tests/EnviousWisprTests/Architecture/XcodeBuildTopologyFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/XcodeBuildTopologyFreezeTests.swift
@@ -157,17 +157,17 @@ import Testing
   }
 
   private static func requiredFile(_ path: String) -> String? {
-    FileManager.default.fileExists(atPath: repoRoot().appendingPathComponent(path).path)
+    FileManager.default.fileExists(atPath: RepoRoot.url.appendingPathComponent(path).path)
       ? nil : "Missing required file: \(path)"
   }
 
   private static func forbiddenFile(_ path: String) -> String? {
-    FileManager.default.fileExists(atPath: repoRoot().appendingPathComponent(path).path)
+    FileManager.default.fileExists(atPath: RepoRoot.url.appendingPathComponent(path).path)
       ? "Legacy file must stay deleted: \(path)" : nil
   }
 
   private static func read(_ path: String) throws -> String {
-    try String(contentsOf: repoRoot().appendingPathComponent(path), encoding: .utf8)
+    try String(contentsOf: RepoRoot.url.appendingPathComponent(path), encoding: .utf8)
   }
 
   private static func requireContains(_ source: String, _ needle: String, _ message: String)
@@ -180,13 +180,5 @@ import Testing
     -> String?
   {
     source.contains(needle) ? message : nil
-  }
-
-  private static func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()  // Architecture/
-      .deletingLastPathComponent()  // EnviousWisprTests/
-      .deletingLastPathComponent()  // Tests/
-      .deletingLastPathComponent()  // repo root
   }
 }

--- a/Tests/EnviousWisprTests/LLM/OutputClassifierTestSupport.swift
+++ b/Tests/EnviousWisprTests/LLM/OutputClassifierTestSupport.swift
@@ -11,12 +11,11 @@ import Foundation
 /// `#filePath` is the compile-time absolute source path inside whatever checkout
 /// is being built, so this resolves correctly on the dev machine and CI alike.
 enum OutputClassifierTestPaths {
-  /// `<repo>` — four parents up from this file (LLM → EnviousWisprTests → Tests → repo).
-  static let repoRoot: URL = URL(filePath: #filePath)
-    .deletingLastPathComponent()  // LLM
-    .deletingLastPathComponent()  // EnviousWisprTests
-    .deletingLastPathComponent()  // Tests
-    .deletingLastPathComponent()  // repo root
+  /// `<repo>`, resolved by the shared marker-walk helper (`RepoRoot.swift`,
+  /// `Tests/EnviousWisprTests/Architecture/`) rather than a fixed-depth trim.
+  /// A fixed 4-hop trim from this file broke under a `/tmp` checkout (`/tmp`
+  /// is a symlink to `/private/tmp` on macOS) — see #1675.
+  static let repoRoot: URL = RepoRoot.url
 
   static let tokenizerFolder = repoRoot.appending(
     path: "Sources/EnviousWisprLLM/Resources/OutputClassifierTokenizer")

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -1359,7 +1359,7 @@ import Testing
   @Test("WhisperKitEngineAdapter exists at Sources/EnviousWisprPipeline/")
   func productionFileExists() throws {
     let path = "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift"
-    let url = repoRoot().appending(path: path)
+    let url = RepoRoot.url.appending(path: path)
     #expect(FileManager.default.fileExists(atPath: url.path))
   }
 
@@ -1398,13 +1398,6 @@ import Testing
     (0..<count).map { _ in 0.1 }
   }
 
-  private func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-  }
 }
 
 // MARK: - Test-only inspectors on the adapter

--- a/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
@@ -143,7 +143,7 @@ struct RecoveryTextProcessorTests {
       "a second telemetry seam must not be left live in crash recovery")
   )
   func recoveryWiresTheSilentSeams() throws {
-    let path = repoRoot().appending(
+    let path = RepoRoot.url.appending(
       path: "Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift")
     let source = try String(contentsOf: path, encoding: .utf8)
     let code = source.split(separator: "\n")
@@ -179,7 +179,7 @@ struct RecoveryTextProcessorTests {
       "LLMPolishStep's own emitters must not leak into crash recovery")
   )
   func recoveryWiresLLMPolishStepSilent() throws {
-    let path = repoRoot().appending(
+    let path = RepoRoot.url.appending(
       path: "Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift")
     let source = try String(contentsOf: path, encoding: .utf8)
     let code = source.split(separator: "\n")
@@ -196,15 +196,5 @@ struct RecoveryTextProcessorTests {
 
     #expect(buildsStepFromSilent)
     #expect(handRolledSeams.isEmpty, "recovery must name .silent, not per-seam closures")
-  }
-
-  /// Repo root, anchored off `#filePath` — this file lives at
-  /// `Tests/EnviousWisprTests/Recovery/`, four levels below the root.
-  private func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
   }
 }


### PR DESCRIPTION
Closes #1675

## Bug
6 architecture freeze tests fail with false positives when run from a `/tmp` checkout (which the release checklist explicitly directs: `/tmp/ew-release-v<version>`). `/tmp` is a symlink to `/private/tmp` on macOS, which perturbed a fixed-4-hop `.deletingLastPathComponent()` trim used to locate the repo root, producing offender paths like `/privateSources/EnviousWisprASR/WhisperKitBackend.swift:398`.

## Root cause (two layers, both found via empirical A/B against a real `/tmp` worktree)
1. **Repo-root resolution**: `RepoRoot.swift` (the intended canonical helper, already used by 20+ test files) trimmed a fixed number of path components instead of walking to a marker. 9 files bypassed it entirely with their own private `repoRoot()` duplicating the same fixed-depth bug: the 7 named in the issue (`AdapterShapeTests`, `AppStateFreezeTests`, `EngineIdentityFreezeTests`, `EngineSwitchOwnershipFreezeTests`, `KernelOwnershipFreezeTests`, `WhisperKitStitchFreezeTests`, `XcodeBuildTopologyFreezeTests`), plus two more found by auditing the whole class of the defect rather than stopping at the reported instances (`WhisperKitEngineAdapterTests`, `RecoveryTextProcessorTests`). `OutputClassifierTestSupport.swift`'s separate `repoRoot` constant (also named in the issue) now aliases the same helper.
2. **A marker-walk fix alone was insufficient** (caught by re-running the A/B against `/tmp` before calling this done): `FileManager.enumerator(at:)` returns OS-resolved paths (`/private/tmp/...`), but `URL.resolvingSymlinksInPath()` / `.standardized` both deliberately leave `/tmp` unresolved — confirmed empirically with debug prints, not assumed. `RepoRoot.url` now canonicalizes through POSIX `realpath(3)` directly, which does follow the symlink.

## Validation
- Reproduced the original failure against unfixed code from a real `/tmp` worktree (`/tmp/ew-1675-baseline`, red-test-during-a-fix-runs-against-baseline-first)
- Confirmed the fix resolves it from an equivalent `/tmp` worktree at this branch's HEAD
- Full suite from the normal checkout path: 3663 tests, 0 failures
- Dev build succeeded
