### PR TITLE
feat(recovery): crash-safety-net readiness gating (#1707 Phase 3)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -115,6 +115,9 @@ let package = Package(
         "EnviousWisprCore",
         "EnviousWisprAudio",
         "EnviousWisprFluidAudioBridge",
+        // #1707 Phase 3: TelemetryService (recoveryEngineActionDeferred) for
+        // the EngineRecoveryGate mutation-claim guards on the idle-unload path.
+        "EnviousWisprServices",
         .product(name: "WhisperKit", package: "argmax-oss-swift"),
         "FluidAudio",
       ],

--- a/Project.swift
+++ b/Project.swift
@@ -258,6 +258,9 @@ let project = Project(
         .target(name: "EnviousWisprCore"),
         .target(name: "EnviousWisprAudio"),
         .target(name: "EnviousWisprFluidAudioBridge"),
+        // #1707 Phase 3: TelemetryService (recoveryEngineActionDeferred) for
+        // the EngineRecoveryGate mutation-claim guards on the idle-unload path.
+        .target(name: "EnviousWisprServices"),
         .package(product: "WhisperKit"),
         .package(product: "FluidAudio"),
       ]),

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -259,6 +259,23 @@ public final class ASRManager: ASRManagerInterface {
       }
       return
     }
+    // #1707 Phase 3 (§3.2, row 7): hold a mutation claim BEFORE touching
+    // anything below — including the load-generation bump and in-flight-load
+    // cancel, which would otherwise cancel a load RECOVERY is currently
+    // running under its own recovery claim (Codex code-diff round 1 P1: the
+    // original ordering let an idle-unload fire mid-recovery-load, invalidate
+    // its generation, and have recovery treat the resulting throw as an
+    // unrecoverable failure — deleting a recoverable spool). A denied claim
+    // (recovery holds the engine) skips this attempt entirely, touching
+    // NOTHING; the next genuine idle-unload trigger re-attempts — no bespoke
+    // retry machinery for a background convenience unload.
+    guard tryBeginEngineMutation() else {
+      TelemetryService.shared.recoveryEngineActionDeferred(site: "asrManagerUnload")
+      return
+    }
+    defer {
+      if endEngineMutation() { wakeRecoveryIfOwed() }
+    }
     // Bump before the loaded-guard so an in-flight load (flag still false) is
     // superseded too, not just a resident model.
     invalidateCurrentLoadGeneration(cause: "unload")
@@ -271,20 +288,6 @@ public final class ASRManager: ASRManagerInterface {
     inFlightLoadTask?.cancel()
     inFlightLoadTask = nil
     guard isModelLoaded, let activeBackend else { return }
-    // #1707 Phase 3 (§3.2, row 7): hold a mutation claim for the FULL awaited
-    // unload — this is the idle-unload choke point BOTH `noteTranscription
-    // Complete(.immediately)` and the idle timer route through, unrelated to
-    // any active session, so recovery must never race it. A denied claim
-    // (recovery holds the engine) skips this attempt; the next genuine
-    // idle-unload trigger re-attempts — no bespoke retry machinery for a
-    // background convenience unload.
-    guard tryBeginEngineMutation() else {
-      TelemetryService.shared.recoveryEngineActionDeferred(site: "asrManagerUnload")
-      return
-    }
-    defer {
-      if endEngineMutation() { wakeRecoveryIfOwed() }
-    }
     await activeBackend.unload()
     isModelLoaded = false
   }

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -1,5 +1,6 @@
 @preconcurrency import AVFoundation
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 
 /// Manages ASR backend selection and delegates transcription calls.
@@ -15,6 +16,19 @@ public final class ASRManager: ASRManagerInterface {
   public private(set) var downloadPhase: String = ""
   public private(set) var downloadDetail: String = ""
   public var onServiceInterrupted: (() -> Void)?  // No-op for in-process — no XPC crash path
+  /// #1707 Phase 3 (§3.2, row 7) — `EngineRecoveryGate.tryBeginMutation()`/
+  /// `endMutation()`, injected exactly like `onServiceInterrupted` above (this
+  /// type never references `EngineRecoveryGate` by concrete type). Guards
+  /// `unloadModel()`'s idle-timer unload — a background actor unrelated to
+  /// any active session, so recovery must never race it. Defaults keep every
+  /// existing test/legacy construction unchanged (always able to proceed).
+  public var tryBeginEngineMutation: @MainActor () -> Bool = { true }
+  /// Returns whether recovery was denied while this mutation was in flight
+  /// and is now owed a wake-up.
+  public var endEngineMutation: @MainActor () -> Bool = { false }
+  /// Called when `endEngineMutation()` returns true — wakes a stranded
+  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+  public var wakeRecoveryIfOwed: @MainActor () -> Void = {}
   /// Issue #445: in-process variant. Tests do not drive a progress-file stream,
   /// so this stays unset at runtime; the protocol requires it.
   public var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
@@ -257,6 +271,20 @@ public final class ASRManager: ASRManagerInterface {
     inFlightLoadTask?.cancel()
     inFlightLoadTask = nil
     guard isModelLoaded, let activeBackend else { return }
+    // #1707 Phase 3 (§3.2, row 7): hold a mutation claim for the FULL awaited
+    // unload — this is the idle-unload choke point BOTH `noteTranscription
+    // Complete(.immediately)` and the idle timer route through, unrelated to
+    // any active session, so recovery must never race it. A denied claim
+    // (recovery holds the engine) skips this attempt; the next genuine
+    // idle-unload trigger re-attempts — no bespoke retry machinery for a
+    // background convenience unload.
+    guard tryBeginEngineMutation() else {
+      TelemetryService.shared.recoveryEngineActionDeferred(site: "asrManagerUnload")
+      return
+    }
+    defer {
+      if endEngineMutation() { wakeRecoveryIfOwed() }
+    }
     await activeBackend.unload()
     isModelLoaded = false
   }

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -345,6 +345,23 @@ public final class ASRManagerProxy: ASRManagerInterface {
   }
 
   public func unloadModel() async {
+    // #1707 Phase 3 (§3.2, row 7): hold a mutation claim BEFORE touching
+    // anything below — including the load-generation bump and in-flight-load
+    // cancel, which would otherwise cancel a load RECOVERY is currently
+    // running under its own recovery claim (Codex code-diff round 1 P1: the
+    // original ordering let an idle-unload fire mid-recovery-load, invalidate
+    // its generation, and have recovery treat the resulting throw as an
+    // unrecoverable failure — deleting a recoverable spool). A denied claim
+    // (recovery holds the engine) skips this attempt entirely, touching
+    // NOTHING; the next genuine idle-unload trigger re-attempts — no bespoke
+    // retry machinery for a background convenience unload.
+    guard tryBeginEngineMutation() else {
+      TelemetryService.shared.recoveryEngineActionDeferred(site: "asrManagerProxyUnload")
+      return
+    }
+    defer {
+      if endEngineMutation() { wakeRecoveryIfOwed() }
+    }
     // #959: bump BEFORE the loaded-guard so an in-flight load (whose
     // `isModelLoaded` is still false) is superseded too, not just a resident model.
     invalidateCurrentLoadGeneration(cause: "unload")
@@ -357,17 +374,6 @@ public final class ASRManagerProxy: ASRManagerInterface {
     inFlightLoadTask?.cancel()
     inFlightLoadTask = nil
     guard isModelLoaded else { return }
-    // #1707 Phase 3 (§3.2, row 7): hold a mutation claim for the FULL awaited
-    // unload. A denied claim (recovery holds the engine) skips this attempt;
-    // the next genuine idle-unload trigger re-attempts — no bespoke retry
-    // machinery for a background convenience unload.
-    guard tryBeginEngineMutation() else {
-      TelemetryService.shared.recoveryEngineActionDeferred(site: "asrManagerProxyUnload")
-      return
-    }
-    defer {
-      if endEngineMutation() { wakeRecoveryIfOwed() }
-    }
     await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
       serviceProxy { proxy in
         proxy.unloadModel {

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -1,5 +1,6 @@
 @preconcurrency import AVFoundation
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 
 /// XPC-backed implementation of `ASRManagerInterface`.
@@ -33,6 +34,24 @@ public final class ASRManagerProxy: ASRManagerInterface {
 
   /// Fires when the ASR XPC service crashes during an active session (streaming or batch in-flight).
   public var onServiceInterrupted: (() -> Void)?
+
+  /// #1707 Phase 3 (§3.2, row 7) — `EngineRecoveryGate.tryBeginMutation()`/
+  /// `endMutation()`, injected exactly like `onServiceInterrupted` above (this
+  /// type never references `EngineRecoveryGate` by concrete type). Guards
+  /// `unloadModel()`'s idle-timer unload — a background actor unrelated to
+  /// any active session, so recovery must never race it. (A call arriving
+  /// via `switchBackend()` is already covered by `EngineCoordinator
+  /// .isSwitching`'s full-duration claim; recovery's own atomic handshake
+  /// checks `isEngineSwitching()` before claiming, so this claim can never
+  /// be denied during a genuine switch.) Defaults keep every existing
+  /// test/legacy construction unchanged (always able to proceed).
+  public var tryBeginEngineMutation: @MainActor () -> Bool = { true }
+  /// Returns whether recovery was denied while this mutation was in flight
+  /// and is now owed a wake-up.
+  public var endEngineMutation: @MainActor () -> Bool = { false }
+  /// Called when `endEngineMutation()` returns true — wakes a stranded
+  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+  public var wakeRecoveryIfOwed: @MainActor () -> Void = {}
 
   /// Issue #445: per-tick callback wired by the dictation kernel to feed
   /// its `LoadProgressWatcher` from the existing 8Hz polling timer.
@@ -338,6 +357,17 @@ public final class ASRManagerProxy: ASRManagerInterface {
     inFlightLoadTask?.cancel()
     inFlightLoadTask = nil
     guard isModelLoaded else { return }
+    // #1707 Phase 3 (§3.2, row 7): hold a mutation claim for the FULL awaited
+    // unload. A denied claim (recovery holds the engine) skips this attempt;
+    // the next genuine idle-unload trigger re-attempts — no bespoke retry
+    // machinery for a background convenience unload.
+    guard tryBeginEngineMutation() else {
+      TelemetryService.shared.recoveryEngineActionDeferred(site: "asrManagerProxyUnload")
+      return
+    }
+    defer {
+      if endEngineMutation() { wakeRecoveryIfOwed() }
+    }
     await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
       serviceProxy { proxy in
         proxy.unloadModel {

--- a/Sources/EnviousWisprASR/WhisperKitSetupService.swift
+++ b/Sources/EnviousWisprASR/WhisperKitSetupService.swift
@@ -1,3 +1,4 @@
+import EnviousWisprServices
 import Foundation
 
 /// States in the WhisperKit model setup flow.
@@ -62,6 +63,21 @@ public final class WhisperKitSetupService {
   /// 2c: the explicit Remove action. nil notice = removed; a notice = refused
   /// or failed, rendered inline.
   private let removeModelAction: @MainActor () async -> WhisperKitRemoveNotice?
+
+  /// #1707 Phase 3 (§3.2, rows 9/10) — `EngineRecoveryGate.tryBeginMutation()`/
+  /// `endMutation()`, injected by the composition root exactly like the
+  /// action closures above (this type never references `EngineRecoveryGate`
+  /// by concrete type). Guards Download/Cancel/Remove's engine-touching
+  /// work — none of these route through `ensureEngineWarm()`. Defaults keep
+  /// every existing test/legacy construction unchanged (always able to
+  /// proceed).
+  public var tryBeginEngineMutation: @MainActor () -> Bool = { true }
+  /// Returns whether recovery was denied while this mutation was in flight
+  /// and is now owed a wake-up.
+  public var endEngineMutation: @MainActor () -> Bool = { false }
+  /// Called when `endEngineMutation()` returns true — wakes a stranded
+  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+  public var wakeRecoveryIfOwed: @MainActor () -> Void = {}
 
   /// The default wiring reports "not downloaded" and does nothing: a build with
   /// no delivery wiring must offer no fetch at all rather than quietly resurrect
@@ -136,6 +152,17 @@ public final class WhisperKitSetupService {
         await self?.forceDetectState()
         return
       }
+      // #1707 Phase 3 (§3.2, row 9): hold a mutation claim for the FULL
+      // download — a Settings-initiated fetch must never race crash
+      // recovery on the shared engine.
+      guard self.tryBeginEngineMutation() else {
+        TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitDownload")
+        await self.forceDetectState()
+        return
+      }
+      defer {
+        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+      }
       if await startDownload() == false {
         await self.forceDetectState()
       }
@@ -150,7 +177,18 @@ public final class WhisperKitSetupService {
     // Invalidate any download intent whose task has not run yet — cancelling
     // downstream cannot reach a request that has not been made.
     downloadIntentEpoch += 1
-    Task { [cancelActiveDownload] in
+    Task { [cancelActiveDownload, weak self] in
+      // #1707 Phase 3 (§3.2, row 10): hold a mutation claim for the FULL
+      // cancel-drain — same reasoning as Download above. A denied claim
+      // (recovery holds the engine) skips this attempt; the fetch keeps
+      // running and the user can press Cancel again.
+      guard let self, self.tryBeginEngineMutation() else {
+        TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitCancelDownload")
+        return
+      }
+      defer {
+        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+      }
       // No re-detect on an accepted cancel: the delivery-state projection
       // publishes the terminal (paused/cancelled) state, and detection would
       // wipe it back to not-downloaded (Codex 2c-r7 P2). A REFUSED cancel
@@ -198,8 +236,18 @@ public final class WhisperKitSetupService {
     guard !isRemoving else { return }
     isRemoving = true
     Task { [removeModelAction, weak self] in
+      // #1707 Phase 3 (§3.2, row 10): hold a mutation claim for the FULL
+      // removal drain — same reasoning as Download/Cancel above.
+      guard let self, self.tryBeginEngineMutation() else {
+        TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitRemove")
+        self?.isRemoving = false
+        self?.removeNotice = .failed
+        return
+      }
+      defer {
+        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+      }
       let notice = await removeModelAction()
-      guard let self else { return }
       self.isRemoving = false
       self.removeNotice = notice
       if notice == nil {

--- a/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
+++ b/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
@@ -2,6 +2,7 @@
 import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 
 /// Measures ASR transcription performance across different audio durations.
@@ -29,6 +30,20 @@ final class BenchmarkSuite {
   private(set) var isRunning = false
   private(set) var progress: String = ""
 
+  /// #1707 Phase 3 (§3.2, rows 23/27) — `EngineRecoveryGate.tryBeginMutation()`/
+  /// `endMutation()`, injected by the composition root (this type never
+  /// references `EngineRecoveryGate` by concrete type). A Diagnostics-
+  /// triggered benchmark must never race crash recovery on the shared
+  /// engine. Defaults keep every existing test/legacy construction unchanged
+  /// (always able to proceed).
+  var tryBeginEngineMutation: @MainActor () -> Bool = { true }
+  /// Returns whether recovery was denied while this mutation was in flight
+  /// and is now owed a wake-up.
+  var endEngineMutation: @MainActor () -> Bool = { false }
+  /// Called when `endEngineMutation()` returns true — wakes a stranded
+  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+  var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+
   /// Ensure model is loaded, returning false (and updating progress) if loading fails.
   private func ensureModelLoaded(using activeEngine: ActiveEngineOperation) async -> Bool {
     guard !(await activeEngine.isLoaded()) else { return true }
@@ -47,6 +62,18 @@ final class BenchmarkSuite {
     guard !isRunning else { return }
     isRunning = true
     results = []
+
+    // #1707 Phase 3 (§3.2, row 23): hold a mutation claim for the FULL
+    // load+transcribe duration — a Diagnostics-triggered benchmark must
+    // never race crash recovery on the shared engine.
+    guard tryBeginEngineMutation() else {
+      TelemetryService.shared.recoveryEngineActionDeferred(site: "benchmarkSuiteBatch")
+      isRunning = false
+      return
+    }
+    defer {
+      if endEngineMutation() { wakeRecoveryIfOwed() }
+    }
 
     guard await ensureModelLoaded(using: activeEngine) else {
       isRunning = false
@@ -82,6 +109,23 @@ final class BenchmarkSuite {
     guard !isRunning else { return }
     isRunning = true
     pipelineResult = nil
+
+    // #1707 Phase 3 (§3.2, row 23): hold a mutation claim for the FULL
+    // load+batch-transcribe duration below — released before the separate
+    // streaming portion (row 27) claims its own, since they are genuinely
+    // distinct engine-touching surfaces, not one operation.
+    guard tryBeginEngineMutation() else {
+      TelemetryService.shared.recoveryEngineActionDeferred(site: "benchmarkSuiteBatch")
+      isRunning = false
+      return
+    }
+    var batchClaimReleased = false
+    let releaseBatchClaim = {
+      guard !batchClaimReleased else { return }
+      batchClaimReleased = true
+      if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+    }
+    defer { releaseBatchClaim() }
 
     guard await ensureModelLoaded(using: activeEngine) else {
       isRunning = false
@@ -123,6 +167,9 @@ final class BenchmarkSuite {
     let batchResult = try? await activeEngine.transcribe(testSamples, .default)
     let batchTime = CFAbsoluteTimeGetCurrent() - batchStart
     let batchTranscript = batchResult?.text ?? ""
+    // Row 23's claim covers only the batch work above — release it now,
+    // before row 27's genuinely separate streaming surface claims its own.
+    releaseBatchClaim()
 
     // Step 2: Streaming ASR (if supported)
     var streamingFinalizeTime: TimeInterval?
@@ -132,8 +179,34 @@ final class BenchmarkSuite {
     let supportsStreaming = await asrManager.activeBackendSupportsStreaming
     if supportsStreaming {
       progress = "Running streaming ASR..."
+      // #1707 Phase 3 (§3.2, row 27): hold a mutation claim for the whole
+      // start/feed/finalize sequence below. Round 3 correction: releasing
+      // the claim is NOT simply "on completion or abort" — `finalizeStreaming()`
+      // only clears streaming state after a SUCCESSFUL awaited finalize, so
+      // any throw below must first `await asrManager.cancelStreaming()`
+      // WHILE the claim is still held, and release only after that
+      // cancellation completes (or after a successful finalize) — never on
+      // the bare throw alone, or the claim would say "safe" while the
+      // backend's streaming session is still actually active underneath.
+      guard tryBeginEngineMutation() else {
+        TelemetryService.shared.recoveryEngineActionDeferred(site: "benchmarkSuiteStreaming")
+        progress = "Pipeline benchmark complete"
+        isRunning = false
+        pipelineResult = PipelineBenchmarkResult(
+          batchASRTime: batchTime, streamingFinalizeTime: nil, werDelta: nil,
+          audioDuration: testAudioDuration)
+        return
+      }
+      var streamingClaimReleased = false
+      let releaseStreamingClaim = {
+        guard !streamingClaimReleased else { return }
+        streamingClaimReleased = true
+        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+      }
+      var startedStreaming = false
       do {
         try await asrManager.startStreaming(options: .default)
+        startedStreaming = true
 
         // Chunk the samples into AVAudioPCMBuffers and feed them
         let chunkSize = AudioConstants.captureBufferSize
@@ -169,7 +242,20 @@ final class BenchmarkSuite {
           let werResult = WERCalculator.calculate(reference: batchTranscript, hypothesis: streaming)
           werDelta = werResult.wer
         }
+        // Successful finalize — the backend's streaming session has
+        // genuinely ended; safe to release now.
+        releaseStreamingClaim()
       } catch {
+        // #1707 Phase 3 (§3.2, row 27 fix): `feed`/`finalize` throwing means
+        // the streaming session may still be genuinely active underneath —
+        // await the real cancellation WHILE the claim is still held, so
+        // recovery cannot acquire until the backend has actually stopped,
+        // not merely until this throw is caught. `startStreaming()` itself
+        // throwing means there is no active session to cancel.
+        if startedStreaming {
+          await asrManager.cancelStreaming()
+        }
+        releaseStreamingClaim()
         Task {
           await AppLogger.shared.log(
             "Pipeline benchmark: streaming ASR failed: \(error.localizedDescription)",

--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -4,6 +4,7 @@
   import EnviousWisprAudio
   import EnviousWisprCore
   import EnviousWisprPipeline
+  import EnviousWisprServices
   import Foundation
   import Network
 
@@ -32,7 +33,10 @@
   ///   `query_batch_decode_fault(backend,trialID)`, `query_batch_decode_attempts(backend)`
   ///   (#1707 Phase 2 — the shared-backend overlap Live UAT oracle, §3.2a-i,
   ///   plus the content-free attempt-identity check, Codex r4; all seven
-  ///   route to the ONE `BatchDecodeFaultController`).
+  ///   route to the ONE `BatchDecodeFaultController`); `force_recovery_key_fault(status)`
+  ///   (#1707 Phase 3 — arms the NEXT crash-recovery Keychain read to fail
+  ///   with the given OSStatus, simulating a locked-keychain-state read
+  ///   without a real signed-release Data-Protection-Keychain).
   /// - Each command dispatches to `@MainActor` via `Task { @MainActor in ... }`
   ///   so command handling matches the actor isolation of the seams it drives.
   ///
@@ -328,6 +332,15 @@
           guard let batchDecodeFaultController else { return "ERR no_dependency" }
           let counts = batchDecodeFaultController.attemptSampleCounts(backend: backend)
           return "OK " + counts.map { (n: Int) in String(n) }.joined(separator: ",")
+        }
+        // #1707 Phase 3 (§11.1): arm the NEXT crash-recovery Keychain read to
+        // fail with the given OSStatus (may be negative — every documented
+        // Security-framework status is).
+        if let raw = parseStringArgCommand(cmd, prefix: "force_recovery_key_fault("),
+          let status = Int32(raw)
+        {
+          DebugRecoveryKeyFaultController.shared.arm(status: status)
+          return "OK"
         }
         return "ERR unknown_command"
       }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -108,6 +108,18 @@ final class DictationLifecycleCoordinator {
   /// behavior. (PR1's published-state cleanup branch is replaced by this signal.)
   var onRecordingEndedWithoutDurableSave: (String?, RecordingRecoveryEnding) -> Void = { _, _ in }
 
+  /// #1707 Phase 3 (GitHub cloud review, PR #1732 round 6) — fires when a
+  /// recording reaches `.complete` but its History save FAILED. Distinct from
+  /// `onRecordingEndedWithoutDurableSave` (which never fires for `.complete`)
+  /// and from `onDurableSave` (which only fires on a SUCCESSFUL save).
+  /// `DictationRuntime` sets it to
+  /// `RecoveryCoordinator.suppressUntilNextLaunch(recoverySessionID:)` so this
+  /// session's spool is protected from THIS SAME terminal transition's own
+  /// `onDictationEndedForRecovery` wake-up before that wake-up fires (both
+  /// calls happen synchronously, in this order, from the kernel's single
+  /// `fireStateChangeIfNeeded()` turn). Off-cap `var` closure, default no-op.
+  var onDurableSaveFailed: (String?) -> Void = { _ in }
+
   /// #1171 — fired on every pipeline state change (both drivers). The composition
   /// root binds it to `EngineCoordinator.poke(.driverStateChanged)` so the
   /// coordinator refreshes engine status on non-terminal transitions AND applies
@@ -285,6 +297,16 @@ final class DictationLifecycleCoordinator {
         ? .otherInterruption
         : CompletionInterruptionDisclosure(cause: kernelDriver.lastAudioInterruptionCause)
     )
+    // #1707 Phase 3 (GitHub cloud review, PR #1732 round 6): a `.complete`
+    // whose History save failed retains its spool, but `onSessionEndedWithoutSave`
+    // never fires for `.complete` — protect it from THIS SAME transition's own
+    // `onDictationEndedForRecovery` wake-up (fired moments later by the kernel's
+    // single `fireStateChangeIfNeeded()` turn) before that wake-up runs.
+    if case .complete = newState, !kernelDriver.lastHistorySaved,
+      let sid = kernelDriver.currentTranscript?.recoverySessionID
+    {
+      onDurableSaveFailed(sid)
+    }
     // PR7 of #763 — push polish error to the post-recording result home so
     // views can read `lastRecordingResult.polishError` without reaching
     // through the former root state. Sunset PR11.
@@ -346,6 +368,13 @@ final class DictationLifecycleCoordinator {
         ? .otherInterruption
         : CompletionInterruptionDisclosure(cause: whisperKitKernelDriver.lastAudioInterruptionCause)
     )
+    // #1707 Phase 3 (GitHub cloud review, PR #1732 round 6) — see the Parakeet
+    // handler above for why this must run before the kernel's own wake-up.
+    if case .complete = newState, !whisperKitKernelDriver.lastHistorySaved,
+      let sid = whisperKitKernelDriver.currentTranscript?.recoverySessionID
+    {
+      onDurableSaveFailed(sid)
+    }
     lastRecordingResult.polishError = whisperKitKernelDriver.lastPolishError
     dispatchChipLifecycle(
       newState: newState,

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -170,6 +170,12 @@ final class DictationRuntime {
       recoveryCoordinator.handleRecordingEndedWithoutDurableSave(
         recoverySessionID: id, ending: ending)
     }
+    // #1707 Phase 3 (GitHub cloud review, PR #1732 round 6): a `.complete`
+    // whose History save failed retains its spool but fires no delete
+    // callback — protect it from this same transition's own recovery wake-up.
+    dictationLifecycleCoordinator.onDurableSaveFailed = { id in
+      recoveryCoordinator.suppressUntilNextLaunch(recoverySessionID: id)
+    }
     let hotkeyController = HotkeyController(
       hotkeyService: hotkeyService,
       starter: starter,

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -145,6 +145,9 @@ final class DictationRuntime {
       // #1063 PR2: the recording gate — a press while recovery holds the shared
       // engine mints no session (shows the "recovering" pill).
       isRecovering: { recoveryCoordinator.isRecovering },
+      // #1707 Phase 3 (§3.1): a refused press yields the engine BETWEEN a
+      // multi-item recovery scan's items, not only after the whole scan.
+      signalPendingLiveStart: { recoveryCoordinator.pendingLiveStartSignal = true },
       // #1171: drive the selected engine to ready before recording, gate a press
       // during an in-flight switch, and hold the start-window state-gate so the
       // coordinator can't switch the engine out mid-startup.

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -127,21 +127,35 @@ final class RecordingStarter {
     asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
   }
 
-  /// #1707 Phase 3 — the backend + timestamp of the most recent recovery
-  /// refusal. Consumed (and cleared) ONLY by a LATER press that actually
-  /// mints an active kernel session — a failed or unrelated press never
-  /// consumes it, so it can't misattribute one recording's wait to a
-  /// different one's timing.
+  /// #1707 Phase 3 — the backend + timestamp of the FIRST recovery refusal in
+  /// an unbroken run of refusals ("blocked episode"). Consumed (and cleared)
+  /// ONLY by a LATER press that actually mints an active kernel session — a
+  /// failed or unrelated press never consumes it, so it can't misattribute
+  /// one recording's wait to a different one's timing.
+  ///
+  /// Deliberately NOT overwritten by a later refusal within the same episode
+  /// (GitHub cloud review, PR #1732): an impatient user pressing repeatedly
+  /// while still refused must not make `waitSeconds` shrink toward zero each
+  /// time — that would understate the real wait and could mask a genuine
+  /// regression in the bounded-wait fix this telemetry exists to validate.
+  /// This does not fully solve the inverse case (a user who presses once,
+  /// then waits well past recovery's actual release before retrying, still
+  /// inflates `waitSeconds` with real idle time) — that would need a release-
+  /// side timestamp from the recovery gate itself, out of scope for this
+  /// phase; disclosed in the plan as a known characteristic of this signal,
+  /// not corrected here.
   private var pendingBlockedPressInfo: (backend: String, blockedAt: ContinuousClock.Instant)?
 
   /// Every recovery-refusal read site funnels through here: shows the pill,
-  /// signals the scan to yield the engine (§3.1), records the blocked-press
-  /// timestamp for the pairing `recovery.press_unblocked` telemetry below, and
-  /// emits the existing `recovery.press_blocked` event.
+  /// signals the scan to yield the engine (§3.1), records the FIRST blocked-
+  /// press timestamp of this episode for the pairing `recovery.press_unblocked`
+  /// telemetry below, and emits the existing `recovery.press_blocked` event.
   private func handleRecoveryPressRefused(backend: ASRBackendType) {
     recordingOverlay.show(intent: .recoveringLastRecording)
     signalPendingLiveStart()
-    pendingBlockedPressInfo = (backend.rawValue, ContinuousClock.now)
+    if pendingBlockedPressInfo == nil {
+      pendingBlockedPressInfo = (backend.rawValue, ContinuousClock.now)
+    }
     TelemetryService.shared.recoveryPressBlocked(asrBackend: backend.rawValue)
   }
 

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -406,7 +406,6 @@ final class RecordingStarter {
       // #1171 — no engine-changed re-check here: the `beginMinting()` state-gate
       // (held since before preWarm) guarantees the coordinator did NOT switch the
       // active engine across these awaits, so `active` is still the user's choice.
-      consumePendingBlockedPressIfAny()
       try await active.handle(event: .toggleRecording(config))
     } catch {
       heartControlRecovery.recover(
@@ -453,6 +452,13 @@ final class RecordingStarter {
       recordingLockedAccess.set(false)
       return
     }
+    // GitHub cloud review, PR #1732: consume the pending blocked-press info
+    // (and emit `recovery.press_unblocked`) only NOW, after both post-
+    // condition early-returns above have been survived — a genuine session
+    // (active or a real pipeline error, not a silent wedge or a user-stop-
+    // during-arm no-op) actually started. Firing this before `handle(event:)`
+    // let a throw or an unactivated session get counted as "unblocked".
+    consumePendingBlockedPressIfAny()
     Task {
       await AppLogger.shared.log(
         "COLD-START [RecordingStarter] PTT-to-recording: total=\(totalMs)ms preWarm=\(preWarmMs)ms startRecording=\(totalMs - preWarmMs)ms backend=\(backend.rawValue) engineReadinessAtPTT=\(readinessAtEntry.coldStartCohortToken)",
@@ -556,9 +562,17 @@ final class RecordingStarter {
         // #1171 — no engine-changed re-check here: the `beginMinting()` state-gate
         // (held since before the recovery-arm await) guarantees the coordinator did
         // NOT switch the active engine, so `active` is still the user's choice.
-        consumePendingBlockedPressIfAny()
       }
       try await active.handle(event: .toggleRecording(config))
+      // GitHub cloud review, PR #1732: consume the pending blocked-press info
+      // (and emit `recovery.press_unblocked`) only after `handle(event:)`
+      // returned WITHOUT throwing AND the pipeline is genuinely active — a
+      // throw, or a dispatch that silently didn't activate anything, must not
+      // be counted as "unblocked". Toggle has no separate post-condition
+      // check the way `start()` does, so read `active.state.isActive` here.
+      if isStartingFromIdle && active.state.isActive {
+        consumePendingBlockedPressIfAny()
+      }
     } catch {
       heartControlRecovery.recover(
         error: error, op: "toggle",

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -62,6 +62,13 @@ final class RecordingStarter {
   /// legacy/test construction unchanged.
   let isRecovering: @MainActor () -> Bool
 
+  /// #1707 Phase 3 (§3.1) — set on every recovery-refusal read site so a
+  /// multi-item recovery scan yields the engine BETWEEN items instead of only
+  /// after the whole scan. Bare closure (off the collaborator cap); bound to
+  /// `RecoveryCoordinator.pendingLiveStartSignal = true`. Default no-op keeps
+  /// recovery-off and legacy/test construction unchanged.
+  let signalPendingLiveStart: @MainActor () -> Void
+
   /// #1171 — drives the SELECTED engine to ready (the coordinator owns the
   /// single-flight switch + warm) and returns the outcome (ready / notInstalled /
   /// notReady). Bound to `EngineCoordinator.ensureSelectedReadyForPress`; default
@@ -120,6 +127,40 @@ final class RecordingStarter {
     asrManager.activeBackendType == .whisperKit ? whisperKitKernelDriver : kernelDriver
   }
 
+  /// #1707 Phase 3 — the backend + timestamp of the most recent recovery
+  /// refusal. Consumed (and cleared) ONLY by a LATER press that actually
+  /// mints an active kernel session — a failed or unrelated press never
+  /// consumes it, so it can't misattribute one recording's wait to a
+  /// different one's timing.
+  private var pendingBlockedPressInfo: (backend: String, blockedAt: ContinuousClock.Instant)?
+
+  /// Every recovery-refusal read site funnels through here: shows the pill,
+  /// signals the scan to yield the engine (§3.1), records the blocked-press
+  /// timestamp for the pairing `recovery.press_unblocked` telemetry below, and
+  /// emits the existing `recovery.press_blocked` event.
+  private func handleRecoveryPressRefused(backend: ASRBackendType) {
+    recordingOverlay.show(intent: .recoveringLastRecording)
+    signalPendingLiveStart()
+    pendingBlockedPressInfo = (backend.rawValue, ContinuousClock.now)
+    TelemetryService.shared.recoveryPressBlocked(asrBackend: backend.rawValue)
+  }
+
+  /// Called immediately before a press commits to minting an active kernel
+  /// session (every gate, including the recovery one, has already passed).
+  /// Consumes any pending blocked-press info and emits the pairing
+  /// `recovery.press_unblocked` event so production telemetry can measure
+  /// whether the bounded-wait fix actually shrank real wait times. Reports
+  /// the BLOCKED press's backend (not the current one — an engine switch
+  /// could occur in between), so a backend's own wait times stay attributable
+  /// to it.
+  private func consumePendingBlockedPressIfAny() {
+    guard let info = pendingBlockedPressInfo else { return }
+    pendingBlockedPressInfo = nil
+    let waitSeconds = Int((ContinuousClock.now - info.blockedAt).components.seconds)
+    TelemetryService.shared.recoveryPressUnblocked(
+      asrBackend: info.backend, waitSeconds: waitSeconds)
+  }
+
   init(
     audioCapture: any AudioCaptureInterface,
     asrManager: any ASRManagerInterface,
@@ -139,6 +180,7 @@ final class RecordingStarter {
     )? = { _, _, _ in nil },
     cleanupRecoveryArm: @escaping @MainActor (String?) -> Void = { _ in },
     isRecovering: @escaping @MainActor () -> Bool = { false },
+    signalPendingLiveStart: @escaping @MainActor () -> Void = {},
     ensureSelectedReadyForPress: @escaping @MainActor () async -> EngineCoordinator.PressReadiness =
       {
         .notReady
@@ -150,6 +192,7 @@ final class RecordingStarter {
     self.makeRecoveryDirective = makeRecoveryDirective
     self.cleanupRecoveryArm = cleanupRecoveryArm
     self.isRecovering = isRecovering
+    self.signalPendingLiveStart = signalPendingLiveStart
     self.ensureSelectedReadyForPress = ensureSelectedReadyForPress
     self.isEngineSwitching = isEngineSwitching
     self.beginMinting = beginMinting
@@ -196,8 +239,7 @@ final class RecordingStarter {
     // pill (with Discard) and bail, before warming the engine the recovery is
     // using. Takes precedence over the cold-engine gate below (same shape).
     if isRecovering() {
-      recordingOverlay.show(intent: .recoveringLastRecording)
-      TelemetryService.shared.recoveryPressBlocked(asrBackend: backend.rawValue)
+      handleRecoveryPressRefused(backend: backend)
       return
     }
     // #1171 — start-of-recording safety: never record on an engine other than the
@@ -343,13 +385,14 @@ final class RecordingStarter {
       if isRecovering() {
         audioCapture.abortPreWarm()
         cleanupRecoveryArm(config.recoverySessionID)
-        recordingOverlay.show(intent: .recoveringLastRecording)
+        handleRecoveryPressRefused(backend: backend)
         recordingLockedAccess.set(false)
         return
       }
       // #1171 — no engine-changed re-check here: the `beginMinting()` state-gate
       // (held since before preWarm) guarantees the coordinator did NOT switch the
       // active engine across these awaits, so `active` is still the user's choice.
+      consumePendingBlockedPressIfAny()
       try await active.handle(event: .toggleRecording(config))
     } catch {
       heartControlRecovery.recover(
@@ -422,8 +465,7 @@ final class RecordingStarter {
       // A toggle that STOPS an active session is unaffected (guarded by
       // `isStartingFromIdle`).
       if isRecovering() {
-        recordingOverlay.show(intent: .recoveringLastRecording)
-        TelemetryService.shared.recoveryPressBlocked(asrBackend: backend.rawValue)
+        handleRecoveryPressRefused(backend: backend)
         return
       }
       // #1171 — start-of-recording safety, same as the PTT path: never record on
@@ -494,12 +536,13 @@ final class RecordingStarter {
         // armed id.
         if isRecovering() {
           cleanupRecoveryArm(config.recoverySessionID)
-          recordingOverlay.show(intent: .recoveringLastRecording)
+          handleRecoveryPressRefused(backend: backend)
           return
         }
         // #1171 — no engine-changed re-check here: the `beginMinting()` state-gate
         // (held since before the recovery-arm await) guarantees the coordinator did
         // NOT switch the active engine, so `active` is still the user's choice.
+        consumePendingBlockedPressIfAny()
       }
       try await active.handle(event: .toggleRecording(config))
     } catch {

--- a/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
@@ -194,6 +194,18 @@ final class EngineCoordinator {
   /// multilingual model.
   var isMintingWhisperKitSession: Bool { isMinting && status.active == .whisperKit }
 
+  /// GitHub cloud review, PR #1732: backend-agnostic twin of
+  /// `isMintingWhisperKitSession`, for `RecoveryCoordinator`'s
+  /// `isDictationActive` check. A record-press that has called
+  /// `beginMinting()` but not yet reached an active kernel session (still
+  /// suspended in `preWarm`/the recovery-arm await) does not yet make
+  /// `LiveRecordingState.isDictationActive` true — without this, recovery's
+  /// per-item scan could reclaim the engine for the next orphan during
+  /// exactly that window, and the in-flight press would abort when its own
+  /// stale-gate re-check catches up, defeating the "yield between items"
+  /// promise for this narrow start-window race.
+  var isMintingAnySession: Bool { isMinting }
+
   /// Called when the record-start path finishes (via `defer`, so it runs on every
   /// exit). Re-pokes so an engine switch deferred during the start window applies
   /// now (or stays deferred behind the live recording, which gate 5 still covers).

--- a/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
@@ -73,6 +73,18 @@ final class EngineCoordinator {
     /// Background warm of the given engine (the matching driver's
     /// `ensureEngineWarm`). The ONLY place a load failure surfaces.
     let warm: @MainActor (ASRBackendType) async -> EngineWarmupOutcome
+    /// #1707 Phase 3 (§3.2, row 4) — `EngineRecoveryGate.tryBeginMutation()`,
+    /// injected exactly like `isRecovering` above (this type never references
+    /// `EngineRecoveryGate` by concrete type). Bound by the composition root;
+    /// default keeps every existing test that doesn't wire a gate behaving as
+    /// before (always able to proceed).
+    var tryBeginEngineMutation: @MainActor () -> Bool = { true }
+    /// `EngineRecoveryGate.endMutation()` — returns whether recovery was
+    /// denied while this mutation was in flight and is now owed a wake-up.
+    var endEngineMutation: @MainActor () -> Bool = { false }
+    /// Called when `endEngineMutation()` returns true — wakes a stranded
+    /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+    var wakeRecoveryIfOwed: @MainActor () -> Void = {}
   }
 
   // MARK: - Published snapshot + gate
@@ -85,6 +97,13 @@ final class EngineCoordinator {
   /// before the `await`, cleared synchronously after). Recovery-start and
   /// record-start read it to mutually exclude with a switch (§3.4).
   private(set) var isSwitching = false
+
+  /// #1707 Phase 3 (§3.4 wake-up table) — fired when a warm completes, a
+  /// setup/migration state change lands, or an engine switch completes: any
+  /// of these may unblock a recovery pass that previously yielded. The
+  /// composition root binds this to
+  /// `RecoveryCoordinator.requestRecoveryRecheck`.
+  var onEngineStateChangedForRecovery: (() -> Void)?
 
   // MARK: - Wiring
 
@@ -229,6 +248,13 @@ final class EngineCoordinator {
     // Every exit resumes any record-start waiter whose condition is now met.
     defer { resumePressWaitersIfReady() }
 
+    // #1707 Phase 3 (§3.4 wake-up table): either of these may unblock a
+    // recovery pass that previously yielded because the engine wasn't ready
+    // or a migration was in flight.
+    if reason == .warmCompleted || reason == .setupStateChanged {
+      onEngineStateChangedForRecovery?()
+    }
+
     let want = deps.selectedBackend()
     let actual = deps.activeBackend()
 
@@ -307,6 +333,9 @@ final class EngineCoordinator {
     currentSwitchPhase = .idle
     clearEpoch()
     publishStatus()
+    // #1707 Phase 3 (§3.4 wake-up table): a completed switch may unblock a
+    // recovery pass that previously yielded because a switch was in flight.
+    onEngineStateChangedForRecovery?()
 
     // 8. Warm the now-active engine in the background (never awaited here).
     startWarm(for: want)
@@ -326,6 +355,20 @@ final class EngineCoordinator {
     warmingBackend = backend
     warmTask = Task(priority: .utility) { [weak self] in
       guard let self else { return }
+      // #1707 Phase 3 (§3.2, row 4): hold a mutation claim for the FULL
+      // awaited warm — recovery must never race a background warm. A denied
+      // claim (recovery holds the engine) skips this attempt; the next
+      // natural trigger (a future switch landing here, or a press's own
+      // cold-press warm) re-attempts — no bespoke retry machinery for a
+      // background convenience warm.
+      guard self.deps.tryBeginEngineMutation() else {
+        TelemetryService.shared.recoveryEngineActionDeferred(site: "startWarm")
+        self.warmingBackend = nil
+        return
+      }
+      defer {
+        if self.deps.endEngineMutation() { self.deps.wakeRecoveryIfOwed() }
+      }
       let start = ContinuousClock.now
       let outcome = await self.deps.warm(backend)
       self.warmingBackend = nil

--- a/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
@@ -266,6 +266,13 @@ final class EngineCoordinator {
       }
       clearEpoch()
       publishStatus()
+      // GitHub cloud review, PR #1732: a recovery pass that deferred because
+      // `isEngineSwitching()` was true can reach a genuinely converged engine
+      // through a `reason` this function doesn't otherwise wake recovery for
+      // (e.g. `.settingsChanged` looping back here after a superseded switch
+      // re-settled to the id it started from) — without this, such a pass
+      // stays stranded until an unrelated wake-up or the next launch.
+      onEngineStateChangedForRecovery?()
       return
     }
 
@@ -323,6 +330,14 @@ final class EngineCoordinator {
       TelemetryService.shared.engineSwitchSuperseded(from: want.rawValue, to: wantNow.rawValue)
       currentSwitchPhase = .idle
       publishStatus()
+      // GitHub cloud review, PR #1732: `isSwitching` just cleared (line 325)
+      // — a recovery pass that deferred behind THIS switch may now be able to
+      // proceed even though this particular switch was superseded rather than
+      // cleanly completed. The queued `.settingsChanged` poke below re-drives
+      // the engine toward the new target but is not itself a recovery-wake
+      // reason (line ~254), so without this call a pass deferred here has no
+      // guaranteed wake-up.
+      onEngineStateChangedForRecovery?()
       poke(.settingsChanged)  // loop to the latest target
       return
     }

--- a/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
@@ -261,18 +261,33 @@ final class EngineCoordinator {
     // 3. Converged — nothing owed.
     if want == actual {
       currentBlockedReason = nil
+      var justLeftSwitchingPhase = false
       if deps.readiness(actual) == .ready, case .switching = currentSwitchPhase {
         currentSwitchPhase = .idle
+        justLeftSwitchingPhase = true
       }
       clearEpoch()
       publishStatus()
-      // GitHub cloud review, PR #1732: a recovery pass that deferred because
+      // GitHub cloud review, PR #1732 (round 2 — the round-1 fix here was
+      // itself a real self-inflicted regression, caught by a later review
+      // round rather than shipped): a recovery pass that deferred because
       // `isEngineSwitching()` was true can reach a genuinely converged engine
       // through a `reason` this function doesn't otherwise wake recovery for
       // (e.g. `.settingsChanged` looping back here after a superseded switch
-      // re-settled to the id it started from) — without this, such a pass
-      // stays stranded until an unrelated wake-up or the next launch.
-      onEngineStateChangedForRecovery?()
+      // re-settled to the id it started from) — without a wake here, such a
+      // pass stays stranded until an unrelated wake-up or the next launch.
+      // MUST be gated on `justLeftSwitchingPhase`, not unconditional: this
+      // fast path is ALSO reached via `.recoveryComplete` itself (fired after
+      // EVERY replayed item, retained or not) — an unconditional wake here
+      // creates a closed loop for any RETAINED outcome (e.g. persistent
+      // marker-write or History-save failure): replay → onRecoveryComplete →
+      // poke(.recoveryComplete) → this fast path → wake → requestRecheck →
+      // re-discover the SAME still-retained spool → replay again, forever.
+      // Gating on the phase transition breaks the cycle: `currentSwitchPhase`
+      // is already `.idle` by the second iteration, so the condition is false.
+      if justLeftSwitchingPhase {
+        onEngineStateChangedForRecovery?()
+      }
       return
     }
 

--- a/Sources/EnviousWisprAppKit/App/EngineRecoveryGate.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineRecoveryGate.swift
@@ -1,0 +1,74 @@
+/// Atomic mutual-exclusion primitive between crash-recovery replay and every
+/// OTHER engine-mutating operation (#1707 Phase 3).
+///
+/// The pre-existing `EngineCoordinator.isSwitching`/`RecoveryCoordinator`
+/// contention guard already gives full-duration mutual exclusion between
+/// recovery and an engine SWITCH specifically (`isSwitching` is held across
+/// the entire awaited switch). Nothing gave that same full-duration guarantee
+/// to every OTHER engine-mutating actor — warm-ups, unloads, downloads,
+/// migrations, benchmarks — until now. A point-in-time boolean recheck
+/// immediately before an `await` is a check-then-act race, not a true
+/// exclusion (governing Bible `RULE: engine-readiness-is-an-atomic-claim-not-a-predicate`);
+/// this type is the corrected shape: a claim held for the FULL duration of the
+/// operation, checked and acquired in a single non-suspending MainActor turn.
+///
+/// `mutationCount` intentionally allows multiple non-recovery mutations to
+/// overlap exactly as they can today — its sole contract is that recovery
+/// cannot begin until every held mutation claim has released, and no mutation
+/// can begin while recovery holds the engine.
+///
+/// This is NOT a scheduler or wake registry: it has exactly two operation
+/// pairs and no scheduling logic of its own. `RecoveryCoordinator` still
+/// decides WHEN to scan and WHAT to retry; this only answers "is it safe to
+/// touch the engine right now."
+///
+/// Owned as a `let` by `WisprBootstrapper` (the composition root) and
+/// injected downward as narrow closures — `EnviousWisprPipeline` and
+/// `EnviousWisprASR` cannot import this `AppKit`-level type upward.
+@MainActor
+final class EngineRecoveryGate {
+  private(set) var isRecoveryClaimed = false
+  private var mutationCount = 0
+  private var recoveryRetryOwed = false
+
+  /// Attempts to claim the engine for a crash-recovery replay item. Fails
+  /// while ANY mutation claim is held or recovery already holds the claim.
+  /// On failure while a mutation is in flight, records that recovery is owed
+  /// a wake-up so it is never stranded once the last mutation releases.
+  func tryBeginRecovery() -> Bool {
+    guard !isRecoveryClaimed, mutationCount == 0 else {
+      if mutationCount > 0 { recoveryRetryOwed = true }
+      return false
+    }
+    isRecoveryClaimed = true
+    return true
+  }
+
+  func endRecovery() {
+    precondition(isRecoveryClaimed)
+    isRecoveryClaimed = false
+  }
+
+  /// Attempts to claim the engine for a non-switch engine mutation (warm-up,
+  /// unload, download, migration, benchmark). Fails while recovery holds the
+  /// claim; every caller must handle `false` by deferring/aborting its
+  /// mutation, never by proceeding anyway.
+  func tryBeginMutation() -> Bool {
+    guard !isRecoveryClaimed else { return false }
+    mutationCount += 1
+    return true
+  }
+
+  /// Returns true exactly when this was the LAST held mutation claim AND a
+  /// recovery attempt was refused while mutations were in flight — the
+  /// caller must invoke its recovery-recheck wake-up when this returns true,
+  /// so a denied recovery claim is never stranded without a guaranteed
+  /// wake-up.
+  func endMutation() -> Bool {
+    precondition(mutationCount > 0)
+    mutationCount -= 1
+    guard mutationCount == 0, recoveryRetryOwed else { return false }
+    recoveryRetryOwed = false
+    return true
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -45,6 +45,21 @@ public final class ModelDeliveryHome {
   /// model whose baseline was never recorded is treated as not-first-run).
   private var firstRunByIdentity: [ModelIdentity: Bool] = [:]
 
+  /// #1707 Phase 3 (§3.2, row 17) — `EngineRecoveryGate.tryBeginMutation()`/
+  /// `endMutation()`, injected by the composition root (this type never
+  /// references `EngineRecoveryGate` by concrete type). Guards Parakeet's
+  /// Settings Download/Cancel — a separate guarded site from `ensureEngineWarm()`,
+  /// since Parakeet delivery admission does not always route through it.
+  /// Defaults keep every existing test/legacy construction unchanged (always
+  /// able to proceed).
+  var tryBeginEngineMutation: @MainActor () -> Bool = { true }
+  /// Returns whether recovery was denied while this mutation was in flight
+  /// and is now owed a wake-up.
+  var endEngineMutation: @MainActor () -> Bool = { false }
+  /// Called when `endEngineMutation()` returns true — wakes a stranded
+  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+  var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+
   public init() {
     do {
       let manifest = try DeliveryManifest.loadBundled(resource: "parakeet-delivery-manifest")
@@ -153,14 +168,36 @@ public final class ModelDeliveryHome {
   /// the controller's cancel resolves only after the drain).
   public func cancelParakeetDownload() {
     guard let identity = parakeetIdentity else { return }
-    Task { _ = await controller.cancel(identity) }
+    Task { [weak self] in
+      // #1707 Phase 3 (§3.2, row 17): hold a mutation claim for the FULL
+      // cancel-drain.
+      guard let self, self.tryBeginEngineMutation() else {
+        TelemetryService.shared.recoveryEngineActionDeferred(site: "parakeetCancelDownload")
+        return
+      }
+      defer {
+        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+      }
+      _ = await self.controller.cancel(identity)
+    }
   }
 
   /// Settings-row Resume / Try Again: re-enters the single door (resume-aware
   /// by construction — staged partials survive a cancel).
   public func resumeParakeetDownload() {
     guard let handle = parakeetHandle else { return }
-    Task { _ = await handle.ensureAvailable() }
+    Task { [weak self] in
+      // #1707 Phase 3 (§3.2, row 17): hold a mutation claim for the FULL
+      // download.
+      guard let self, self.tryBeginEngineMutation() else {
+        TelemetryService.shared.recoveryEngineActionDeferred(site: "parakeetResumeDownload")
+        return
+      }
+      defer {
+        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+      }
+      _ = await handle.ensureAvailable()
+    }
   }
 }
 

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -523,6 +523,18 @@ final class RecoveryCoordinator {
     pendingLiveStartSignal = false
 
     for id in attemptable {
+      // GitHub cloud review, PR #1732: between the PRIOR item's `defer`
+      // (which flips `isRecovering` back to `false`) and this item's own
+      // claim below, nothing suspends — so a record-press whose Task is
+      // queued exactly in that window never actually gets a scheduling turn
+      // to observe `isRecovering == false` and proceed; Swift's MainActor
+      // only switches tasks at a genuine suspension point. `await
+      // Task.yield()` here gives such a press its turn BEFORE this item's
+      // check-and-claim sequence begins, so it can mint its own session
+      // normally instead of waiting through this item too. Placed before the
+      // atomic handshake below, not inside it — the handshake itself still
+      // has no `await` between its own check and claim.
+      await Task.yield()
       // Atomic per-item handshake (§3.1/§3.2) — ONE non-suspending MainActor
       // turn: checked and claimed here with no `await` between any step, so
       // there is no window between "checked" and "acted." Preserves the

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -127,15 +127,21 @@ final class RecoveryCoordinator {
   /// arriving mid-pass causes exactly one later pass, never zero and never two.
   private var pendingRescan = false
 
-  /// #1707 Phase 3 (§3.3) — ids whose attempt-marker clear FAILED after a
-  /// deferred outcome (Keychain-transient or a History-save failure). A
-  /// surviving marker would be misread by a SAME-launch rescan as a crashed
-  /// attempt (the crash-loop guard's "marker present ⇒ abandoned" reasoning
-  /// only holds for a genuinely NEW launch) — every same-launch pass skips
-  /// these ids, leaving them untouched on disk for a future launch's fresh
-  /// `RecoveryCoordinator` instance (which always starts empty). NEVER cleared
-  /// during one instance's lifetime; tests model "a new launch" by constructing
-  /// a new coordinator, never by clearing this set on an existing one.
+  /// #1707 Phase 3 (§3.3) — ids that must wait for a genuinely NEW launch
+  /// rather than any same-launch rescan. Two populations: (1) an attempt-
+  /// marker clear that FAILED after a deferred outcome (Keychain-transient or
+  /// a History-save failure) — a surviving marker would be misread by a
+  /// same-launch rescan as a crashed attempt (the crash-loop guard's "marker
+  /// present ⇒ abandoned" reasoning only holds for a genuinely new launch);
+  /// (2) a live recording's own RETAINED failure ending (GitHub cloud review,
+  /// PR #1732) — the engine may still be in the exact broken state that
+  /// produced the failure, so this same session's own wake-up must not
+  /// immediately re-attempt (and potentially delete) the spool it just
+  /// retained. Every same-launch pass skips these ids, leaving them untouched
+  /// on disk for a future launch's fresh `RecoveryCoordinator` instance
+  /// (which always starts empty). NEVER cleared during one instance's
+  /// lifetime; tests model "a new launch" by constructing a new coordinator,
+  /// never by clearing this set on an existing one.
   private var nextLaunchOnlyRecoveryIDs: Set<String> = []
 
   /// Monotonic token bumped by `discardActiveRecovery()`. The replayer captures
@@ -328,13 +334,27 @@ final class RecoveryCoordinator {
   /// Idempotent + best-effort; a no-op when `id` is nil. Always clears the live-
   /// recording protection (the recording is over). Returns the detached delete
   /// work (delete endings only) so tests can await it.
+  ///
+  /// A retain ending ALSO defers this id to `nextLaunchOnlyRecoveryIDs`
+  /// (GitHub cloud review, PR #1732): this same session's own
+  /// `onDictationEndedForRecovery` wake-up fires right after this call and
+  /// requests a same-launch rescan — without this, that rescan could pick up
+  /// the spool just retained here while the engine is still in the exact
+  /// state that produced the failure, replay it, classify it
+  /// `.failed(.unrecoverable)`, and delete the very audio this branch meant
+  /// to keep for a healthier future launch. Runs before that rescan Task is
+  /// even scheduled (both synchronous MainActor calls from the same driver
+  /// callback), so the exclusion is always in place before the pass runs.
   @discardableResult
   func handleRecordingEndedWithoutDurableSave(
     recoverySessionID id: String?, ending: RecordingRecoveryEnding
   ) -> Task<Void, Never>? {
     guard let id else { return nil }
     if armedSessionID == id { armedSessionID = nil }
-    guard Self.shouldDeleteOnLiveEnding(ending) else { return nil }
+    guard Self.shouldDeleteOnLiveEnding(ending) else {
+      nextLaunchOnlyRecoveryIDs.insert(id)
+      return nil
+    }
     return destroySpoolAndKey(id: id)
   }
 

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -562,6 +562,18 @@ final class RecoveryCoordinator {
       // launch/rescan. Every other outcome continues to the next orphan.
       if outcome == .aborted { break }
     }
+    // GitHub cloud review, PR #1732: a live-start signal that arrived during
+    // the LAST item's replay (or the discard `break` above) has no further
+    // loop iteration left to catch it at the top-of-loop guard — check once
+    // more here. Confirmed by reproduction (not just reasoning): without this
+    // check, a `pendingRescan` that ALSO gets set during that same window (an
+    // unrelated wake-up cause, coalesced since a scan is already in progress)
+    // makes `drainPendingRescan()` immediately run another pass; if the
+    // retained item's own rediscovery keeps re-triggering the same wake-up
+    // cause, this is not just a stranded signal but a genuine infinite loop
+    // (reproduced via `pendingLiveStartYieldsAfterFinalItem`, which hangs
+    // without this line).
+    if pendingLiveStartSignal { return true }
     return false
   }
 

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -128,20 +128,23 @@ final class RecoveryCoordinator {
   private var pendingRescan = false
 
   /// #1707 Phase 3 (§3.3) — ids that must wait for a genuinely NEW launch
-  /// rather than any same-launch rescan. Two populations: (1) an attempt-
+  /// rather than any same-launch rescan. Three populations: (1) an attempt-
   /// marker clear that FAILED after a deferred outcome (Keychain-transient or
-  /// a History-save failure) — a surviving marker would be misread by a
-  /// same-launch rescan as a crashed attempt (the crash-loop guard's "marker
-  /// present ⇒ abandoned" reasoning only holds for a genuinely new launch);
-  /// (2) a live recording's own RETAINED failure ending (GitHub cloud review,
-  /// PR #1732) — the engine may still be in the exact broken state that
-  /// produced the failure, so this same session's own wake-up must not
-  /// immediately re-attempt (and potentially delete) the spool it just
-  /// retained. Every same-launch pass skips these ids, leaving them untouched
-  /// on disk for a future launch's fresh `RecoveryCoordinator` instance
-  /// (which always starts empty). NEVER cleared during one instance's
-  /// lifetime; tests model "a new launch" by constructing a new coordinator,
-  /// never by clearing this set on an existing one.
+  /// a History-save failure DURING REPLAY) — a surviving marker would be
+  /// misread by a same-launch rescan as a crashed attempt (the crash-loop
+  /// guard's "marker present ⇒ abandoned" reasoning only holds for a
+  /// genuinely new launch); (2) a LIVE recording's own RETAINED failure
+  /// ending (GitHub cloud review, PR #1732 round 1) — the engine may still be
+  /// in the exact broken state that produced the failure; (3) a LIVE
+  /// recording that reached `.complete` but whose History save failed (PR
+  /// #1732 round 6) — `onDurableSave` never fires for this case (nothing to
+  /// delete), but the same terminal transition's own wake-up must not
+  /// immediately re-attempt (and potentially delete) the spool this failure
+  /// just retained. Every same-launch pass skips these ids, leaving them
+  /// untouched on disk for a future launch's fresh `RecoveryCoordinator`
+  /// instance (which always starts empty). NEVER cleared during one
+  /// instance's lifetime; tests model "a new launch" by constructing a new
+  /// coordinator, never by clearing this set on an existing one.
   private var nextLaunchOnlyRecoveryIDs: Set<String> = []
 
   /// Monotonic token bumped by `discardActiveRecovery()`. The replayer captures
@@ -324,6 +327,22 @@ final class RecoveryCoordinator {
   func handleDurableSave(recoverySessionID id: String) -> Task<Void, Never> {
     if armedSessionID == id { armedSessionID = nil }
     return destroySpoolAndKey(id: id)
+  }
+
+  /// A `.complete` dictation whose History save FAILED (GitHub cloud review,
+  /// PR #1732 round 6): `onDurableSave` never fires for this case (correctly
+  /// — nothing to delete, the spool must be retained), but this session's own
+  /// terminal transition ALSO fires `onDictationEndedForRecovery` moments
+  /// later via the SAME synchronous `fireStateChangeIfNeeded()` call that
+  /// dispatches to the caller of this method first — without this
+  /// suppression, that same-launch wake-up could immediately rescan and
+  /// destructively replay the spool this failure meant to retain for a
+  /// healthier future launch, exactly like the live-failure-ending case this
+  /// mirrors. No-op when `id` is nil (armed only when recovery was on for
+  /// this take).
+  func suppressUntilNextLaunch(recoverySessionID id: String?) {
+    guard let id else { return }
+    nextLaunchOnlyRecoveryIDs.insert(id)
   }
 
   /// A recording ended at a terminal state WITHOUT a durable transcript save

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -58,18 +58,29 @@ final class RecoveryCoordinator {
   /// concurrent-arm race. MainActor-confined.
   private var armedSessionID: String?
 
-  /// True while the launch scan is replaying orphans behind the blocking pill.
+  /// True while an orphan is being actively replayed on the shared engine.
   /// DRIVES the recording gate: a record-press while true mints no session (shows
   /// the "recovering" pill). `private(set)` — only the scan/discard own it, and a
-  /// `defer` guarantees it clears on EVERY scan exit (a stuck `true` would brick
-  /// recording). Read by the gate via an injected closure.
+  /// per-item `defer` guarantees it clears on EVERY item exit (a stuck `true`
+  /// would brick recording). Read by the gate via an injected closure.
+  ///
+  /// #1707 Phase 3 (§3.1): PER-ITEM, not scan-wide — a multi-item scan sets/
+  /// clears this once per orphan (immediately before/after that orphan's
+  /// replay), not once for the whole scan. This is what lets a live record-press
+  /// preempt recovery between items instead of waiting for an entire multi-item
+  /// scan (RULE: live-dictation-preempts-recovery-between-items). Any new
+  /// engine-mutating call site must observe the SAME two claims this phase
+  /// closes — `isEngineSwitching()` (unchanged, full-duration) and
+  /// `EngineRecoveryGate`'s begin/end mutation pair (§3.2) — not merely read
+  /// this flag; copy an EXISTING guarded call site (e.g. `EngineCoordinator
+  /// .startWarm()`) rather than inventing a new pattern.
   private(set) var isRecovering = false
 
-  /// #1171 — fired after a recovery scan finishes AND `isRecovering` has cleared
-  /// (registered as a `defer` AFTER the `isRecovering = false` defer, so LIFO runs
-  /// it second). Lets the composition root poke `EngineCoordinator` so an engine
-  /// switch deferred because it arrived while recovery held the shared engine
-  /// applies now. Set by the root.
+  /// #1171 — fired after EACH item's per-item claim releases (§3.1 moved
+  /// `isRecovering` from scan-wide to per-item, so a switch deferred while ONE
+  /// item held the engine can now retry as soon as THAT item releases, not only
+  /// after the whole multi-item scan). Lets the composition root poke
+  /// `EngineCoordinator` so a deferred switch applies now. Set by the root.
   var onRecoveryComplete: (() -> Void)?
 
   /// #1464 — fired after each `.recovered` replay result (a leftover recording
@@ -86,6 +97,47 @@ final class RecoveryCoordinator {
   /// switch while recovery is active). Default no-switch keeps tests unchanged.
   var isEngineSwitching: () -> Bool = { false }
 
+  /// #1707 Phase 3 (§3.2) — `EngineRecoveryGate.tryBeginRecovery()`/
+  /// `endRecovery()`, injected by the composition root exactly like
+  /// `isEngineSwitching` above (this type never references `EngineRecoveryGate`
+  /// by concrete type, matching the existing closure-injection convention).
+  /// `RecoveryCoordinator` is the SOLE owner of these calls — `RecoverySpool
+  /// Replayer` runs entirely underneath the already-held claim and never calls
+  /// them itself. Defaults keep every existing test that doesn't wire a gate
+  /// behaving as before (always able to claim).
+  var tryBeginRecoveryClaim: () -> Bool = { true }
+  var endRecoveryClaim: () -> Void = {}
+
+  /// #1707 Phase 3 (§3.1) — set by `RecordingStarter`'s refusal path when a
+  /// live record-press was refused because recovery held the engine. Checked
+  /// before each item's handshake so a multi-item scan yields the engine
+  /// BETWEEN items, not only at the very end. Cleared at the top of every fresh
+  /// scan pass (a stale signal from a prior pass must not spuriously yield a new
+  /// one that has nothing to do with it).
+  var pendingLiveStartSignal = false
+
+  /// #1707 Phase 3 (§3.4) — single-flight scan-in-progress guard, now shared by
+  /// both the launch-time `scanAndRecover()` entry point and every later
+  /// `requestRecoveryRecheck()` wake-up, coalesced through one owning drain
+  /// loop (`drainPendingRescan()`) rather than a recursive re-invocation.
+  private var scanInProgress = false
+  /// Set by any wake-up trigger arriving while a pass is already running (or by
+  /// a rejected concurrent `scanAndRecover()`/`requestRecoveryRecheck()` call);
+  /// the owning drain loop clears it immediately before each pass, so a trigger
+  /// arriving mid-pass causes exactly one later pass, never zero and never two.
+  private var pendingRescan = false
+
+  /// #1707 Phase 3 (§3.3) — ids whose attempt-marker clear FAILED after a
+  /// deferred outcome (Keychain-transient or a History-save failure). A
+  /// surviving marker would be misread by a SAME-launch rescan as a crashed
+  /// attempt (the crash-loop guard's "marker present ⇒ abandoned" reasoning
+  /// only holds for a genuinely NEW launch) — every same-launch pass skips
+  /// these ids, leaving them untouched on disk for a future launch's fresh
+  /// `RecoveryCoordinator` instance (which always starts empty). NEVER cleared
+  /// during one instance's lifetime; tests model "a new launch" by constructing
+  /// a new coordinator, never by clearing this set on an existing one.
+  private var nextLaunchOnlyRecoveryIDs: Set<String> = []
+
   /// Monotonic token bumped by `discardActiveRecovery()`. The replayer captures
   /// it per orphan and re-checks after every `await`: a mismatch means "discarded
   /// while my uncancellable batch transcribe was in flight" → drop the result,
@@ -96,9 +148,6 @@ final class RecoveryCoordinator {
   /// The orphan id currently being replayed, so Discard can delete exactly the
   /// recording the user is waiting on. nil when the scan is between orphans.
   private var activeRecoveryID: String?
-
-  /// Single-flight guard so a re-trigger of `scanAndRecover()` can't double-run.
-  private var scanInProgress = false
 
   /// Hard-reset the shared engine (the #445 service-kill: kills any in-flight
   /// load/transcribe and marks the engine for reinit). Lets Discard return the
@@ -244,9 +293,11 @@ final class RecoveryCoordinator {
   /// Delete-versus-retain after a launch replay attempt (#1464). Delete a recovered
   /// (saved) or unrecoverable orphan and a crash-loop `.abandoned` one; RETAIN a
   /// History-save failure (the audio is still good, §3.3). `.aborted` (the user
-  /// discarded — already deleted by `discardActiveRecovery`) and `.deferred` (the
-  /// marker was never written — keep for a future launch) delete nothing here.
-  /// Static + internal for direct adversarial testing.
+  /// discarded — already deleted by `discardActiveRecovery`), `.deferred` (the
+  /// marker was never written — keep for a future launch), and #1707 Phase 3's
+  /// `.deferredMarkerClearFailed` (Keychain-transient, marker survives — keep for
+  /// a future launch) delete nothing here. Static + internal for direct
+  /// adversarial testing.
   static func shouldDeleteAfterReplay(_ outcome: RecoveryReplayOutcome) -> Bool {
     switch outcome {
     case .recovered, .abandoned:
@@ -255,7 +306,7 @@ final class RecoveryCoordinator {
       return true
     case .failed(.save), .failed(.saveMarkerClearFailed):
       return false
-    case .aborted, .deferred:
+    case .aborted, .deferred, .deferredMarkerClearFailed:
       return false
     }
   }
@@ -300,14 +351,57 @@ final class RecoveryCoordinator {
     return destroySpoolAndKey(id: id)
   }
 
-  /// On launch, scan for orphan spools and recover them behind the blocking pill
-  /// (#1063 PR2 — replaces PR1's purge). Single-flight. Sequential. One attempt
-  /// per orphan. Strict limb: fails open at every step.
+  /// On launch, scan for orphan spools and recover them (#1063 PR2 — replaces
+  /// PR1's purge). Single-flight via the same owning drain loop
+  /// `requestRecoveryRecheck()` uses (#1707 Phase 3, §3.4) — a concurrent call
+  /// coalesces into a follow-up pass rather than running twice.
   func scanAndRecover() async {
+    pendingRescan = true
     guard !scanInProgress else { return }
     scanInProgress = true
-    defer { scanInProgress = false }
+    await drainPendingRescan()
+  }
 
+  /// #1707 Phase 3 (§3.4) — the sole synchronous, MainActor, no-`await` entry
+  /// point every wake-up cause calls to request a fresh recovery pass: a live
+  /// dictation ending, an engine switch/warm/setup-migration completing, or
+  /// `EngineRecoveryGate.endMutation()` returning true (a denied recovery claim
+  /// is now owed a retry, §3.2). Safe to call from a bare `defer`. Coalesces
+  /// with any in-progress pass through the SAME owning drain loop
+  /// `scanAndRecover()` uses — never a parallel path.
+  func requestRecoveryRecheck() {
+    pendingRescan = true
+    guard !scanInProgress else { return }
+    scanInProgress = true
+    Task { await drainPendingRescan() }
+  }
+
+  /// The single owning loop behind both public entry points above (§3.4 —
+  /// replaces an earlier recursive re-invocation design that had a lost-trigger
+  /// race and a live-yield/pending-rescan interaction). Clears `pendingRescan`
+  /// immediately before each pass, so a trigger arriving mid-pass causes
+  /// exactly one later pass, never zero and never two. A pass that yielded
+  /// specifically because of a pending live-start signal discards any pending
+  /// rescan rather than honoring it immediately — reclaiming the engine right
+  /// after yielding it would defeat the entire point of the yield; the live
+  /// dictation's own later end becomes the next legitimate wake-up instead.
+  private func drainPendingRescan() async {
+    defer { scanInProgress = false }
+    while pendingRescan {
+      pendingRescan = false
+      let yieldedToLiveStart = await runOneScanPass()
+      if yieldedToLiveStart {
+        pendingRescan = false
+        return
+      }
+    }
+  }
+
+  /// One full discovery + per-item-replay pass. Returns `true` exactly when
+  /// the pass stopped because a live record-press was refused mid-scan (§3.1)
+  /// — the signal `drainPendingRescan()` uses to stop draining outright rather
+  /// than immediately re-claiming the engine for a stale pending rescan.
+  private func runOneScanPass() async -> Bool {
     let store = makeSpoolStore()
     // Fail CLOSED on a scan error (Codex code-diff r3 P2): a directory IO /
     // permission failure must NOT be read as "no spools" — the key-only sweep
@@ -318,7 +412,7 @@ final class RecoveryCoordinator {
     do {
       spoolIDs = try store.listSpoolSessionIDs()
     } catch {
-      return
+      return false
     }
     let armed = armedSessionID
 
@@ -356,7 +450,7 @@ final class RecoveryCoordinator {
       }
     }
 
-    guard !spoolIDs.isEmpty else { return }
+    guard !spoolIDs.isEmpty else { return false }
 
     // Snapshot the History dedup set. A recording that arms during the dedup
     // `await` mints a fresh UUID not in `spoolIDs` (listed above) — already
@@ -375,35 +469,69 @@ final class RecoveryCoordinator {
         recoverable.append(id)
       }
     }
-    guard !recoverable.isEmpty else { return }
+    guard !recoverable.isEmpty else { return false }
 
-    // Contention guard: never run the shared engine while a live dictation is in
-    // flight (a recording can start in the launch window, including with recovery
-    // OFF) OR while an engine switch is in flight (#1171 — a switch unloads/sets
-    // the active engine; starting recovery on top would race the shared engine).
-    // Defer the orphans to a future launch — they stay on disk.
-    guard !isDictationActive(), !isEngineSwitching() else { return }
+    // #1707 Phase 3 (§3.3): skip ids whose marker-clear failure means only a
+    // genuinely NEW launch may safely re-check them — they stay on disk,
+    // untouched, waiting for a future launch's fresh coordinator instance.
+    let attemptable = recoverable.filter { !nextLaunchOnlyRecoveryIDs.contains($0) }
+    guard !attemptable.isEmpty else { return false }
 
-    TelemetryService.shared.recoveryFound(count: recoverable.count)
-    isRecovering = true
-    // #1171 — registered BEFORE the `isRecovering = false` defer so LIFO runs this
-    // SECOND (after the flag clears): the deferred-switch retry it triggers sees
-    // `isRecovering == false` and can apply. Only fires when recovery actually ran.
-    defer { onRecoveryComplete?() }
-    // R1 (Codex REV-2, BLOCKER): clear the gate on EVERY exit — normal completion,
-    // a thrown error, or an early return. A stuck `isRecovering = true` would
-    // refuse every record-start and brick the heart path.
-    defer { isRecovering = false }
+    TelemetryService.shared.recoveryFound(count: attemptable.count)
+    // #1707 Phase 3 (§3.1): cleared once per fresh pass — a live-start refusal
+    // observed DURING this pass (between items, below) still yields the
+    // engine; a refusal from a PRIOR pass must not spuriously yield this one.
+    pendingLiveStartSignal = false
 
-    for id in recoverable {
+    for id in attemptable {
+      // Atomic per-item handshake (§3.1/§3.2) — ONE non-suspending MainActor
+      // turn: checked and claimed here with no `await` between any step, so
+      // there is no window between "checked" and "acted." Preserves the
+      // existing switch symmetry exactly: a switch already in progress makes
+      // recovery defer here; once `isRecovering` is set below, a NEW switch
+      // cannot begin (`EngineCoordinator` already checks it).
+      guard !pendingLiveStartSignal else { return true }
+      // Contention guard: never run the shared engine while a live dictation is
+      // in flight (a recording can start in the launch window, including with
+      // recovery OFF) OR while an engine switch is in flight (#1171 — a switch
+      // unloads/sets the active engine; starting recovery on top would race the
+      // shared engine). Defer the remaining orphans — they stay on disk.
+      guard !isDictationActive(), !isEngineSwitching() else { return false }
+      guard tryBeginRecoveryClaim() else {
+        // The gate is held by an in-flight mutation; its `endMutation()`
+        // wake-up (§3.2's `recoveryRetryOwed`) calls `requestRecoveryRecheck()`
+        // when it releases, so stopping here is never a stranded deferral.
+        return false
+      }
+      isRecovering = true
+
       activeRecoveryID = id
       let generationAtStart = recoveryGeneration
+      // Per-item — not per-scan (§3.1) — so a switch deferred behind THIS item
+      // can retry as soon as THIS item's claim releases, not only after the
+      // whole multi-item scan. R1 (Codex REV-2, BLOCKER) still holds: this
+      // fires on EVERY exit from this iteration — normal completion, a thrown
+      // error, or `break` — so a stuck `isRecovering = true` can never brick
+      // recording.
+      defer {
+        activeRecoveryID = nil
+        isRecovering = false
+        endRecoveryClaim()
+        onRecoveryComplete?()
+      }
       let outcome = await replayer.replay(recoverySessionID: id) { [weak self] in
         // Discard bumps `recoveryGeneration`; a mismatch ⇒ abandon this in-flight
         // replay. Coordinator gone ⇒ treat as aborted (safe).
         self?.recoveryGeneration != generationAtStart
       }
-      activeRecoveryID = nil
+      // #1707 Phase 3 (§3.3): a marker-clear failure under either deferred
+      // outcome means only a genuinely new launch may safely re-check this id.
+      switch outcome {
+      case .deferredMarkerClearFailed, .failed(.saveMarkerClearFailed):
+        nextLaunchOnlyRecoveryIDs.insert(id)
+      default:
+        break
+      }
       // #1464: the coordinator is the sole destructor — the replayer no longer
       // deletes, so apply the replay predicate now that `replay()` has returned.
       // (`.aborted` deletes nothing here: `discardActiveRecovery` already did.)
@@ -411,9 +539,10 @@ final class RecoveryCoordinator {
       // Post the standalone success notice for a recording that landed in History.
       if case .recovered = outcome { onRecoverySucceeded?() }
       // A Discard ends the whole hold; remaining orphans (rare) wait for the next
-      // launch. Every other outcome continues to the next orphan.
+      // launch/rescan. Every other outcome continues to the next orphan.
       if outcome == .aborted { break }
     }
+    return false
   }
 
   /// The user pressed Discard on the recovering pill. No-op when nothing is

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -99,6 +99,15 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   private let currentVocabulary:
     @MainActor () -> (corrector: CorrectorVocabulary, polish: PolishVocabulary)
 
+  /// Test-only observation seam (GitHub cloud review, PR #1732): fires right
+  /// after the attempt marker write succeeds, before the Keychain retrieve
+  /// begins. Nil in production — exists so a test can deterministically
+  /// revoke spool-directory write access between the marker WRITE and its
+  /// later CLEAR (simulating a marker-clear failure) instead of polling
+  /// `hasAttemptMarker`, which can miss the narrow true→false window
+  /// entirely if the detached Keychain-read task races ahead of the poll.
+  var onAttemptMarkerWritten: (() -> Void)?
+
   init(
     activeEngine: ActiveEngineOperation,
     keyStore: RecoveryKeyStore,
@@ -160,6 +169,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       TelemetryService.shared.recoveryCompleted(outcome: "deferred", reason: .markerWriteFailed)
       return .deferred
     }
+    onAttemptMarkerWritten?()
 
     // Retrieve the per-session key off the MainActor (`keychain-not-mainactor`).
     // #1464: split a MISSING key (`key_missing`) from a store READ failure

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -5,6 +5,7 @@ import EnviousWisprPipeline
 import EnviousWisprServices
 import EnviousWisprStorage
 import Foundation
+import Security
 
 /// The terminal outcome of one orphan's recovery attempt (#1063 PR2). The
 /// `discarded` outcome is owned by `RecoveryCoordinator` (it deletes + emits on
@@ -24,6 +25,13 @@ enum RecoveryReplayOutcome: Equatable {
   /// The attempt marker could not be written, so recovery was deferred WITHOUT
   /// risking an un-guarded attempt — the spool stays for a future launch.
   case deferred
+  /// #1707 Phase 3 (§3.3): a Keychain read failed with a TRANSIENT status
+  /// (device locked / keychain daemon not yet unlocked) and the attempt
+  /// marker's clear ALSO failed — distinct from bare `.deferred` because the
+  /// surviving marker means only a genuine NEW launch (never a same-launch
+  /// rescan) may safely re-check this spool; `RecoveryCoordinator` routes
+  /// this into `nextLaunchOnlyRecoveryIDs`.
+  case deferredMarkerClearFailed
 }
 
 /// Why a replay `.failed`, carried to `RecoveryCoordinator` so it can apply the
@@ -166,6 +174,16 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     case .success(let data):
       keyData = data
     case .failure(let error):
+      // #1707 Phase 3 (§3.3, #1360): a TRANSIENT Keychain status (device
+      // locked / keychain daemon not yet unlocked) is a genuinely different
+      // condition from a permanent read failure — defer this attempt rather
+      // than treating it as unrecoverable and deleting a recoverable spool.
+      if let keyStoreError = error as? RecoveryKeyStoreError,
+        case .retrieveFailed(let status) = keyStoreError,
+        Self.isTransientKeychainStatus(status)
+      {
+        return deferForTransientKeychainFailure(spoolStore: spoolStore, id: id)
+      }
       let reason: RecoveryTelemetryReason =
         (error as? RecoveryKeyStoreError) == .notFound ? .keyMissing : .keyReadFailed
       return failUnrecoverable(reason: reason, category: .recoveryDecryptFailed)
@@ -345,6 +363,48 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
       campBCandidate: reconstructedSampleCount != nil ? true : nil,
       spoolSeconds: spoolSeconds)
     return .failed(.unrecoverable)
+  }
+
+  /// #1707 Phase 3 (§3.3): a Keychain read failed with a status expected to
+  /// clear on its own — defer this attempt WITHOUT treating it as
+  /// unrecoverable. Clears the attempt marker written above (mirrors the
+  /// existing `.save`/`.saveMarkerClearFailed` retention path, RULE:
+  /// port-proven-patterns-wholesale) so a same-launch or next-launch retry
+  /// sees a clean spool, not a crashed one. If the clear itself throws, the
+  /// marker survives and `RecoveryCoordinator` must treat this id as
+  /// next-launch-only — a same-launch rescan would otherwise misread the
+  /// surviving marker as a crashed attempt and abandon (delete) it.
+  private func deferForTransientKeychainFailure(
+    spoolStore: RecoverySpoolStore, id: String
+  ) -> RecoveryReplayOutcome {
+    do {
+      try spoolStore.deleteAttemptMarker(for: id)
+      TelemetryService.shared.recoveryCompleted(outcome: "deferred", reason: .keychainTransient)
+      return .deferred
+    } catch {
+      TelemetryService.shared.recoveryCompleted(outcome: "deferred", reason: .markerClearFailed)
+      return .deferredMarkerClearFailed
+    }
+  }
+
+  /// #1707 Phase 3 (§3.3): OSStatus values expected to clear on their own —
+  /// documented Apple meanings, not app-evidenced (the raw status is
+  /// discarded before Sentry/PostHog ever see it, so no production history
+  /// exists to confirm against). A false-transient (retrying a truly-terminal
+  /// code) costs one extra deferred cycle before the next wake-up re-attempts
+  /// and still eventually fails clean; a false-terminal (deleting a
+  /// recoverable spool) costs the recording permanently — the asymmetry
+  /// favors inclusion. `errSecAuthFailed`/`errSecUserCanceled` stay terminal:
+  /// a later retry CAN succeed after user action, but nothing in this flow (a
+  /// background replay, no user present to act) can clear them.
+  private static func isTransientKeychainStatus(_ status: OSStatus) -> Bool {
+    switch status {
+    case errSecInteractionNotAllowed, errSecInteractionRequired, errSecInDarkWake,
+      errSecNotAvailable, errSecServiceNotAvailable, errSecDatabaseLocked:
+      return true
+    default:
+      return false
+    }
   }
 
   /// Map a caught ASR/storage error to the narrow telemetry failure class (#1464).

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -603,6 +603,17 @@ public final class WisprBootstrapper {
           customWordsCoordinator.customWords,
           generation: UInt64(customWordsCoordinator.customWords.count) &+ 1)
       })
+    // GitHub cloud review, PR #1732: captured by `isDictationActive` below,
+    // assigned once `engineCoordinator` exists a few lines down. A record
+    // press that has called `beginMinting()` but not yet reached an active
+    // kernel session (still suspended in `preWarm`/the recovery-arm await)
+    // does not make `liveRecordingState.isDictationActive` true — without
+    // this, recovery's per-item scan could reclaim the engine for the next
+    // orphan during exactly that window, and the in-flight press would
+    // abort when its own stale-gate re-check catches up.
+    // `weak`, matching every other cross-reference between these two
+    // coordinators in this file — avoids a retain cycle.
+    weak var engineCoordinatorForRecoveryGate: EngineCoordinator?
     let recoveryCoordinator = RecoveryCoordinator(
       keyStore: recoveryKeyStore,
       makeSpoolStore: makeRecoverySpoolStore,
@@ -611,7 +622,10 @@ public final class WisprBootstrapper {
         let all = (try? await transcriptStore.loadAll()) ?? []
         return Set(all.compactMap(\.recoverySessionID))
       },
-      isDictationActive: { [liveRecordingState] in liveRecordingState.isDictationActive },
+      isDictationActive: { [liveRecordingState] in
+        liveRecordingState.isDictationActive
+          || (engineCoordinatorForRecoveryGate?.isMintingAnySession ?? false)
+      },
       // Discard hard-resets the ACTIVE engine (#445 service-kill) so an in-flight,
       // otherwise-uncancellable recovery load/transcribe aborts and the next
       // recording gets a clean engine. Routed through the active-engine door
@@ -665,6 +679,9 @@ public final class WisprBootstrapper {
         wakeRecoveryIfOwed: { [weak recoveryCoordinator] in
           recoveryCoordinator?.requestRecoveryRecheck()
         }))
+    // GitHub cloud review, PR #1732: now that `engineCoordinator` exists,
+    // `isDictationActive` (wired above) can read its minting state.
+    engineCoordinatorForRecoveryGate = engineCoordinator
     // The picker change notifies the coordinator (it reads the live selection).
     settingsSync.onSelectedBackendChanged = { [weak engineCoordinator] in
       engineCoordinator?.poke(.settingsChanged)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -138,6 +138,15 @@ public final class WisprBootstrapper {
     let asrManager: any ASRManagerInterface =
       useXPCASR ? ASRManagerProxy() : ASRManager()
 
+    // #1707 Phase 3 (§3.2): the atomic mutual-exclusion primitive between
+    // crash-recovery replay and every OTHER engine-mutating operation. One
+    // instance per app session, injected downward as closures into every
+    // guarded call site below — never referenced by concrete type outside
+    // `EnviousWisprAppKit` (the composition root is the only place both
+    // this AppKit-level type and the lower-module call sites are in scope
+    // together).
+    let engineRecoveryGate = EngineRecoveryGate()
+
     let llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
 
     let transcriptStore = TranscriptStore()
@@ -648,6 +657,13 @@ public final class WisprBootstrapper {
         warm: { [kernelDriver, whisperKitKernelDriver] backend in
           await (backend == .whisperKit ? whisperKitKernelDriver : kernelDriver)
             .ensureEngineWarm(reason: .engineSwap)
+        },
+        // #1707 Phase 3 (§3.2, row 4): `startWarm()`'s background convenience
+        // warm must never race recovery on the shared engine.
+        tryBeginEngineMutation: { [engineRecoveryGate] in engineRecoveryGate.tryBeginMutation() },
+        endEngineMutation: { [engineRecoveryGate] in engineRecoveryGate.endMutation() },
+        wakeRecoveryIfOwed: { [weak recoveryCoordinator] in
+          recoveryCoordinator?.requestRecoveryRecheck()
         }))
     // The picker change notifies the coordinator (it reads the live selection).
     settingsSync.onSelectedBackendChanged = { [weak engineCoordinator] in
@@ -662,6 +678,99 @@ public final class WisprBootstrapper {
     recoveryCoordinator.onRecoveryComplete = { [weak engineCoordinator] in
       engineCoordinator?.poke(.recoveryComplete)
     }
+
+    // #1707 Phase 3 (§3.1/§3.2/§3.4) — the `EngineRecoveryGate` wiring pass.
+    // `RecoveryCoordinator` is the SOLE owner of the recovery claim itself.
+    recoveryCoordinator.tryBeginRecoveryClaim = { [engineRecoveryGate] in
+      engineRecoveryGate.tryBeginRecovery()
+    }
+    recoveryCoordinator.endRecoveryClaim = { [engineRecoveryGate] in
+      engineRecoveryGate.endRecovery()
+    }
+    // §3.4 wake-up table: a completed switch/warm/setup-change may unblock a
+    // recovery pass that previously yielded.
+    engineCoordinator.onEngineStateChangedForRecovery = { [weak recoveryCoordinator] in
+      recoveryCoordinator?.requestRecoveryRecheck()
+    }
+    // Rows 4/12/13/15/16/18 (via `ensureEngineWarm()`'s shared choke point) +
+    // row 6 (propagated onto the WhisperKit adapter by `KernelDictationDriver`'s
+    // own `didSet`, since the adapter's concrete type is not visible here) +
+    // §3.4's "active dictation ended" wake-up cause.
+    for driver in [kernelDriver, whisperKitKernelDriver] {
+      driver.tryBeginEngineMutation = { [engineRecoveryGate] in
+        engineRecoveryGate.tryBeginMutation()
+      }
+      driver.endEngineMutation = { [engineRecoveryGate] in engineRecoveryGate.endMutation() }
+      driver.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
+        recoveryCoordinator?.requestRecoveryRecheck()
+      }
+      driver.onDictationEndedForRecovery = { [weak recoveryCoordinator] in
+        recoveryCoordinator?.requestRecoveryRecheck()
+      }
+    }
+    // Row 7: Parakeet's idle-unload choke point. Concrete-type downcast — these
+    // closures are not part of `ASRManagerInterface` (only the composition root
+    // needs them, so widening the protocol for every conformer is unwarranted).
+    if let asrManager = asrManager as? ASRManager {
+      asrManager.tryBeginEngineMutation = { [engineRecoveryGate] in
+        engineRecoveryGate.tryBeginMutation()
+      }
+      asrManager.endEngineMutation = { [engineRecoveryGate] in engineRecoveryGate.endMutation() }
+      asrManager.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
+        recoveryCoordinator?.requestRecoveryRecheck()
+      }
+    }
+    if let asrManagerProxy = asrManager as? ASRManagerProxy {
+      asrManagerProxy.tryBeginEngineMutation = { [engineRecoveryGate] in
+        engineRecoveryGate.tryBeginMutation()
+      }
+      asrManagerProxy.endEngineMutation = { [engineRecoveryGate] in
+        engineRecoveryGate.endMutation()
+      }
+      asrManagerProxy.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
+        recoveryCoordinator?.requestRecoveryRecheck()
+      }
+    }
+    // Rows 9/10: WhisperKit Settings Remove/Download/Cancel.
+    let whisperKitSetupForGate = whisperKit.setupService
+    whisperKitSetupForGate.tryBeginEngineMutation = { [engineRecoveryGate] in
+      engineRecoveryGate.tryBeginMutation()
+    }
+    whisperKitSetupForGate.endEngineMutation = { [engineRecoveryGate] in
+      engineRecoveryGate.endMutation()
+    }
+    whisperKitSetupForGate.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
+      recoveryCoordinator?.requestRecoveryRecheck()
+    }
+    // Row 14: the WhisperKit legacy-migration delete+refetch window.
+    whisperKitRetirement?.tryBeginEngineMutation = { [engineRecoveryGate] in
+      engineRecoveryGate.tryBeginMutation()
+    }
+    whisperKitRetirement?.endEngineMutation = { [engineRecoveryGate] in
+      engineRecoveryGate.endMutation()
+    }
+    whisperKitRetirement?.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
+      recoveryCoordinator?.requestRecoveryRecheck()
+    }
+    // Row 17: Parakeet Settings Download/Cancel.
+    modelDelivery.tryBeginEngineMutation = { [engineRecoveryGate] in
+      engineRecoveryGate.tryBeginMutation()
+    }
+    modelDelivery.endEngineMutation = { [engineRecoveryGate] in engineRecoveryGate.endMutation() }
+    modelDelivery.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
+      recoveryCoordinator?.requestRecoveryRecheck()
+    }
+    // Rows 23/27: the Diagnostics benchmark suite (DEBUG-only surface).
+    let benchmarkForGate = diagnosticsCoordinator.benchmark
+    benchmarkForGate.tryBeginEngineMutation = { [engineRecoveryGate] in
+      engineRecoveryGate.tryBeginMutation()
+    }
+    benchmarkForGate.endEngineMutation = { [engineRecoveryGate] in engineRecoveryGate.endMutation()
+    }
+    benchmarkForGate.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
+      recoveryCoordinator?.requestRecoveryRecheck()
+    }
+
     let lastRecordingResult = LastRecordingResult()
     let backendMetadata = BackendMetadata(
       settings: settings,

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -353,28 +353,36 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// `endMutation()`, injected exactly like `onStateChange` above. Bound by
   /// the composition root; defaults keep every existing test/legacy
   /// construction unchanged (always able to proceed). `didSet` also forwards
-  /// the SAME closure onto a `WhisperKitEngineAdapter` (row 6's idle-unload
-  /// guard, `WhisperKitEngineAdapter.swift`) when this driver's adapter is
-  /// one — `WisprBootstrapper` sets these once here, never on the adapter
-  /// directly, since the adapter's concrete type is not visible outside
+  /// the SAME closure onto (a) a `WhisperKitEngineAdapter` (row 6's
+  /// idle-unload guard, `WhisperKitEngineAdapter.swift`) when this driver's
+  /// adapter is one, and (b) the owned `RecordingSessionKernel` (row 21's
+  /// `preWarm()` guard) — `WisprBootstrapper` sets these once here, never on
+  /// either directly, since neither concrete type is visible outside
   /// `EnviousWisprPipeline`.
   @ObservationIgnored
   public var tryBeginEngineMutation: @MainActor () -> Bool = { true } {
     didSet {
       (adapter as? WhisperKitEngineAdapter)?.tryBeginEngineMutation = tryBeginEngineMutation
+      kernel.tryBeginEngineMutation = tryBeginEngineMutation
     }
   }
   /// Returns whether recovery was denied while this mutation was in flight
   /// and is now owed a wake-up.
   @ObservationIgnored
   public var endEngineMutation: @MainActor () -> Bool = { false } {
-    didSet { (adapter as? WhisperKitEngineAdapter)?.endEngineMutation = endEngineMutation }
+    didSet {
+      (adapter as? WhisperKitEngineAdapter)?.endEngineMutation = endEngineMutation
+      kernel.endEngineMutation = endEngineMutation
+    }
   }
   /// Called when `endEngineMutation()` returns true — wakes a stranded
   /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
   @ObservationIgnored
   public var wakeRecoveryIfOwed: @MainActor () -> Void = {} {
-    didSet { (adapter as? WhisperKitEngineAdapter)?.wakeRecoveryIfOwed = wakeRecoveryIfOwed }
+    didSet {
+      (adapter as? WhisperKitEngineAdapter)?.wakeRecoveryIfOwed = wakeRecoveryIfOwed
+      kernel.wakeRecoveryIfOwed = wakeRecoveryIfOwed
+    }
   }
 
   /// Fire-once latch for `onSessionEndedWithoutSave` (#1548 D1). Tracks the

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -338,6 +338,45 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   @ObservationIgnored
   public var onSessionEndedWithoutSave: (@MainActor (String?, RecordingRecoveryEnding) -> Void)?
 
+  /// #1707 Phase 3 (§3.4 wake-up table) — fired whenever this driver's
+  /// dictation ends (from BOTH `fireStateChangeIfNeeded()`'s transition out
+  /// of an active phase and `fireSessionEndedWithoutSaveIfNeeded()`): may
+  /// unblock a recovery pass that previously yielded because a live
+  /// dictation was active. Bound by the composition root to
+  /// `RecoveryCoordinator.requestRecoveryRecheck` — never referenced by name
+  /// here (`EnviousWisprPipeline` cannot import the AppKit-level type).
+  /// Firing from both sites is harmless: the underlying recheck coalesces.
+  @ObservationIgnored
+  public var onDictationEndedForRecovery: (@MainActor () -> Void)?
+
+  /// #1707 Phase 3 (§3.2) — `EngineRecoveryGate.tryBeginMutation()`/
+  /// `endMutation()`, injected exactly like `onStateChange` above. Bound by
+  /// the composition root; defaults keep every existing test/legacy
+  /// construction unchanged (always able to proceed). `didSet` also forwards
+  /// the SAME closure onto a `WhisperKitEngineAdapter` (row 6's idle-unload
+  /// guard, `WhisperKitEngineAdapter.swift`) when this driver's adapter is
+  /// one — `WisprBootstrapper` sets these once here, never on the adapter
+  /// directly, since the adapter's concrete type is not visible outside
+  /// `EnviousWisprPipeline`.
+  @ObservationIgnored
+  public var tryBeginEngineMutation: @MainActor () -> Bool = { true } {
+    didSet {
+      (adapter as? WhisperKitEngineAdapter)?.tryBeginEngineMutation = tryBeginEngineMutation
+    }
+  }
+  /// Returns whether recovery was denied while this mutation was in flight
+  /// and is now owed a wake-up.
+  @ObservationIgnored
+  public var endEngineMutation: @MainActor () -> Bool = { false } {
+    didSet { (adapter as? WhisperKitEngineAdapter)?.endEngineMutation = endEngineMutation }
+  }
+  /// Called when `endEngineMutation()` returns true — wakes a stranded
+  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+  @ObservationIgnored
+  public var wakeRecoveryIfOwed: @MainActor () -> Void = {} {
+    didSet { (adapter as? WhisperKitEngineAdapter)?.wakeRecoveryIfOwed = wakeRecoveryIfOwed }
+  }
+
   /// Fire-once latch for `onSessionEndedWithoutSave` (#1548 D1). Tracks the
   /// `currentSessionID` the ended-without-save check last fired for, so a
   /// re-armed observation can't double-fire for one concluded session while two
@@ -489,6 +528,21 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         wedgeGuard.disarm()
         sessionlessWedgeGuard = nil
       }
+    }
+    // #1707 Phase 3 (§3.2) — the SINGLE shared choke point every warm-up site
+    // routes through (per this method's own doc comment above), so gating
+    // here closes rows 2/9/10/12/13/15/16/18 at once rather than at each
+    // caller separately. Hold the claim for the FULL awaited `warmUp()`, not
+    // a point-in-time check. A denied claim (recovery holds the engine) is
+    // reported as `.cancelled` — a deliberate system choice, not a failure —
+    // so callers never surface the error UI for it; the next genuine
+    // poke/press re-attempts.
+    guard tryBeginEngineMutation() else {
+      TelemetryService.shared.recoveryEngineActionDeferred(site: "ensureEngineWarm")
+      return .cancelled
+    }
+    defer {
+      if endEngineMutation() { wakeRecoveryIfOwed() }
     }
     do {
       try await adapter.warmUp()
@@ -1249,6 +1303,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     guard mapped != lastFiredState else { return }
     lastFiredState = mapped
     onStateChange?(mapped)
+    // #1707 Phase 3 (§3.4): a transition OUT of an active phase means this
+    // dictation just ended (including the normal saved-completion case,
+    // which `onSessionEndedWithoutSave` never fires for) — the engine may be
+    // free for a recovery pass that previously yielded.
+    if !mapped.isActive { onDictationEndedForRecovery?() }
   }
 
   /// #1063 PR2 — fire `onSessionEndedWithoutSave` when the kernel enters a fresh
@@ -1282,6 +1341,8 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     }
     guard let ending else { return }
     onSessionEndedWithoutSave?(context.config?.recoverySessionID, ending)
+    // #1707 Phase 3 (§3.4) — see `fireStateChangeIfNeeded()`'s twin call.
+    onDictationEndedForRecovery?()
   }
 
   /// Project the non-`.completed` terminal `RecordingOutcome` into the narrow

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -535,6 +535,23 @@ final class RecordingSessionKernel {
   /// user-facing copy lives here — copy stays in the App layer.
   var onApproachingMaxDuration: (@MainActor (TimeInterval) -> Void)?
 
+  /// #1707 Phase 3 (§3.2, row 21) — `EngineRecoveryGate.tryBeginMutation()`/
+  /// `endMutation()`, injected exactly like `onApproachingMaxDuration` above
+  /// (this type never references `EngineRecoveryGate` by concrete type).
+  /// Guards `preWarm()`'s spawned adapter warm-up — the single most
+  /// surprising gap this phase closes: that warm-up runs BEFORE the session
+  /// reaches `.arming` (`state == .idle` still holds), so a recovery replay
+  /// could otherwise be racing an unsupervised warm-up here. Defaults keep
+  /// every existing test/legacy construction unchanged (always able to
+  /// proceed).
+  var tryBeginEngineMutation: @MainActor () -> Bool = { true }
+  /// Returns whether recovery was denied while this mutation was in flight
+  /// and is now owed a wake-up.
+  var endEngineMutation: @MainActor () -> Bool = { false }
+  /// Called when `endEngineMutation()` returns true — wakes a stranded
+  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+  var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+
   /// Low-cardinality reason the most recent recording stopped, set when the
   /// recording-exit latches and cleared at session start (#1060). Read by the
   /// driver to label the transcribing pill ("Recording ended, transcribing now"
@@ -928,7 +945,24 @@ final class RecordingSessionKernel {
     }
     // Adapter warm-up is spawned (can be a slow cold model load; the session's
     // own warmUp re-checks readiness and reruns cold if needed).
+    //
+    // #1707 Phase 3 (§3.2, row 21): hold a mutation claim for the FULL
+    // awaited warm-up — this runs while `state == .idle`, BEFORE the session
+    // is confirmed active, so recovery must never race it. A denied claim
+    // (recovery holds the engine) skips this attempt; the session's own
+    // in-session `warmUp(_:)` (row 22, already structurally safe) re-checks
+    // readiness and reruns cold if needed, so no bespoke retry machinery is
+    // needed for this best-effort pre-warm.
     spawn(sid) { [adapter, weak self] in
+      // `self` gone ⇒ proceed anyway (matches this task's existing tolerance
+      // for a deallocated kernel — `self?.log(...)` below already no-ops).
+      guard self?.tryBeginEngineMutation() ?? true else {
+        TelemetryService.shared.recoveryEngineActionDeferred(site: "preWarm")
+        return
+      }
+      defer {
+        if let self, self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+      }
       do {
         try await adapter.warmUp()
         self?.log("preWarm adapter.warmUp succeeded sid=\(sid.raw)")
@@ -2494,6 +2528,13 @@ final class RecordingSessionKernel {
 
   private enum WarmUpResult { case ready, wedged, loadFailed, cancelled, stopped }
 
+  /// #1707 Phase 3 (§3.2, row 22 — confirmed already safe, no code change):
+  /// no `EngineRecoveryGate` mutation claim here. This warm-up runs ONLY from
+  /// within an active recording session (the kernel reaches `.arming` — and
+  /// therefore this call — before any spawn, and a live session already
+  /// structurally precludes a recovery claim from existing, since recovery's
+  /// atomic handshake requires `!isDictationActive()`). Documented, not
+  /// gated (RULE: close-the-window-never-handle-it).
   private func warmUp(_ sid: SessionID) async -> WarmUpResult {
     loadWedgeDetected = false
     loadTickCount = 0

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1101,10 +1101,20 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         }
         guard claimed else { return }
         await backend.unload()
-        guard !Task.isCancelled else { return }
+        // #1707 Phase 3 (§3.2, row 6 — Codex code-diff round 1 P2): release
+        // the claim UNCONDITIONALLY right after the awaited unload returns,
+        // BEFORE the cancellation check below. Gating the release behind
+        // `!Task.isCancelled` left the claim permanently stranded whenever
+        // `cancelPendingUnload()` cancelled this Task while `backend.unload()`
+        // was in flight — `mutationCount` would never drain, refusing every
+        // later recovery attempt for the rest of the app session.
         await MainActor.run { [weak self] in
           guard let self else { return }
           if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+        }
+        guard !Task.isCancelled else { return }
+        await MainActor.run { [weak self] in
+          guard let self else { return }
           self.cachedReadiness = .notReady
         }
       }
@@ -1134,10 +1144,17 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         }
         guard claimed else { return }
         await backend.unload()
-        guard !Task.isCancelled else { return }
+        // #1707 Phase 3 (§3.2, row 6 — Codex code-diff round 1 P2): release
+        // UNCONDITIONALLY before the cancellation check; see the `.immediately`
+        // branch above for why gating this behind `!Task.isCancelled` leaks
+        // the claim forever.
         await MainActor.run { [weak self] in
           guard let self else { return }
           if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+        }
+        guard !Task.isCancelled else { return }
+        await MainActor.run { [weak self] in
+          guard let self else { return }
           self.cachedReadiness = .notReady
         }
       }

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -251,6 +251,21 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// this remains settable but unused inside the adapter.
   var onEngineInterrupted: (@MainActor () -> Void)?
 
+  /// #1707 Phase 3 (§3.2, row 6) — `EngineRecoveryGate.tryBeginMutation()`/
+  /// `endMutation()`, injected exactly like `onEngineInterrupted` above (this
+  /// type never references `EngineRecoveryGate` by concrete type). Guards
+  /// `applyUnloadPolicy()`'s idle-timer unload — a background actor
+  /// unrelated to any active session, so recovery must never race it.
+  /// Defaults keep every existing test/legacy construction unchanged
+  /// (always able to proceed).
+  var tryBeginEngineMutation: @MainActor () -> Bool = { true }
+  /// Returns whether recovery was denied while this mutation was in flight
+  /// and is now owed a wake-up.
+  var endEngineMutation: @MainActor () -> Bool = { false }
+  /// Called when `endEngineMutation()` returns true — wakes a stranded
+  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+  var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+
   /// #1707: WhisperKit is never the SOURCE of an ASR-interruption signal (no
   /// out-of-process connection to lose), but the shared `ASREventRouter` can
   /// still forward a stale Parakeet-origin signal to this adapter's kernel if
@@ -989,6 +1004,14 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// tests can drive a fast deadline; production uses the 2.0s default.
   private let wedgeRecoveryUnloadDeadlineSec: Double
 
+  /// #1707 Phase 3 (§3.2, structurally-safe row): no `EngineRecoveryGate`
+  /// mutation claim here — this is called ONLY by the kernel's wedge
+  /// detectors, which fire only from within an active recording session
+  /// (see the doc comment below). A live session already structurally
+  /// precludes a recovery claim from existing (recovery's atomic handshake
+  /// requires `!isDictationActive()`), so this call site cannot race
+  /// recovery by construction, not merely in practice. Documented, not
+  /// gated (RULE: close-the-window-never-handle-it).
   /// #959 HEAVY wedge recovery. The cheap discard (`cancel()`) PLUS a forced
   /// in-process backend unload so the next press reloads fresh. WhisperKit
   /// decodes IN-PROCESS, so a genuinely wedged CoreML decode could block
@@ -1063,10 +1086,26 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         // task. Without the recheck, the cancelled task can still fire
         // `backend.unload()` under session B (Codex code-diff r8).
         guard !Task.isCancelled else { return }
+        // #1707 Phase 3 (§3.2, row 6): hold a mutation claim for the FULL
+        // awaited unload — a background idle-timer actor unrelated to any
+        // active session, so recovery must never race it. `self` gone ⇒
+        // proceed anyway (matches this task's existing tolerance for a
+        // deallocated adapter, e.g. the `cachedReadiness` no-op below).
+        let claimed = await MainActor.run { () -> Bool in
+          guard let self else { return true }
+          guard self.tryBeginEngineMutation() else {
+            TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitIdleUnload")
+            return false
+          }
+          return true
+        }
+        guard claimed else { return }
         await backend.unload()
         guard !Task.isCancelled else { return }
         await MainActor.run { [weak self] in
-          self?.cachedReadiness = .notReady
+          guard let self else { return }
+          if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+          self.cachedReadiness = .notReady
         }
       }
     case .twoMinutes, .fiveMinutes, .tenMinutes, .fifteenMinutes, .sixtyMinutes:
@@ -1083,10 +1122,23 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         // task. Without the recheck, the cancelled task can still fire
         // `backend.unload()` under session B (Codex code-diff r8).
         guard !Task.isCancelled else { return }
+        // #1707 Phase 3 (§3.2, row 6): same atomic claim as the `.immediately`
+        // branch above.
+        let claimed = await MainActor.run { () -> Bool in
+          guard let self else { return true }
+          guard self.tryBeginEngineMutation() else {
+            TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitIdleUnload")
+            return false
+          }
+          return true
+        }
+        guard claimed else { return }
         await backend.unload()
         guard !Task.isCancelled else { return }
         await MainActor.run { [weak self] in
-          self?.cachedReadiness = .notReady
+          guard let self else { return }
+          if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+          self.cachedReadiness = .notReady
         }
       }
     }

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -1100,6 +1100,20 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
           return true
         }
         guard claimed else { return }
+        // GitHub cloud review, PR #1732 round 10: the mutation-claim hop
+        // above is ITSELF a suspension point between the line-1088 final
+        // cancellation check and `backend.unload()` — a `beginSession(B)`
+        // landing in exactly this window would cancel this task the SAME
+        // way the line-1088 check exists to catch, but nothing re-checked
+        // it before the unload call. Re-check here, releasing the just-
+        // acquired claim (never leak it) before bailing.
+        guard !Task.isCancelled else {
+          await MainActor.run { [weak self] in
+            guard let self else { return }
+            if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+          }
+          return
+        }
         await backend.unload()
         // #1707 Phase 3 (§3.2, row 6 — Codex code-diff round 1 P2): release
         // the claim UNCONDITIONALLY right after the awaited unload returns,
@@ -1143,6 +1157,17 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
           return true
         }
         guard claimed else { return }
+        // GitHub cloud review, PR #1732 round 10: see the `.immediately`
+        // branch above — the claim hop is itself a suspension point a
+        // `beginSession(B)` can cancel through, so re-check before unloading,
+        // releasing the just-acquired claim rather than leaking it.
+        guard !Task.isCancelled else {
+          await MainActor.run { [weak self] in
+            guard let self else { return }
+            if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
+          }
+          return
+        }
         await backend.unload()
         // #1707 Phase 3 (§3.2, row 6 — Codex code-diff round 1 P2): release
         // UNCONDITIONALLY before the cancellation check; see the `.immediately`

--- a/Sources/EnviousWisprPipeline/WhisperKitLegacyUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitLegacyUpgradeCoordinator.swift
@@ -1,4 +1,5 @@
 import EnviousWisprModelDelivery
+import EnviousWisprServices
 import Foundation
 
 /// Retires the multilingual engine's foreign copy and refetches a verified one.
@@ -39,6 +40,24 @@ public final class WhisperKitLegacyUpgradeCoordinator {
   }
 
   public var onEvent: (@MainActor @Sendable (Event) -> Void)?
+
+  /// #1707 Phase 3 (§3.2, row 14) — `EngineRecoveryGate.tryBeginMutation()`/
+  /// `endMutation()`, injected exactly like `onEvent` above (this type never
+  /// references `EngineRecoveryGate` by concrete type). This coordinator
+  /// never moves the engine itself, but its delete+refetch window (steps 6-7
+  /// of `retireAndRefetchIfNeeded()`) mutates the SAME on-disk model files a
+  /// concurrent crash-recovery replay's `activeEngine.load()` reads from — a
+  /// genuine hazard the launch grounding brief found (this Task and
+  /// `RecoveryCoordinator.scanAndRecover()`'s Task fire one line apart with
+  /// zero ordering). Defaults keep every existing test/legacy construction
+  /// unchanged (always able to proceed).
+  public var tryBeginEngineMutation: @MainActor () -> Bool = { true }
+  /// Returns whether recovery was denied while this mutation was in flight
+  /// and is now owed a wake-up.
+  public var endEngineMutation: @MainActor () -> Bool = { false }
+  /// Called when `endEngineMutation()` returns true — wakes a stranded
+  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
+  public var wakeRecoveryIfOwed: @MainActor () -> Void = {}
 
   /// L5: at most one command is current, and its KIND is load-bearing — a later ensure-intent
   /// must know whether it is joining a fetch or waiting out a Cancel.
@@ -351,6 +370,21 @@ public final class WhisperKitLegacyUpgradeCoordinator {
         emit(.legacyRetirementFailed(reason: .markerWrite))
         return
       }
+    }
+
+    // #1707 Phase 3 (§3.2, row 14): hold a mutation claim across the
+    // delete+refetch window below — a concurrent crash-recovery replay's
+    // `activeEngine.load()` must never read these files mid-flux. A denied
+    // claim (recovery holds the engine) defers this launch's migration
+    // attempt entirely; it is safe to retry on a future launch since the
+    // owed marker (freshly written above at step 5, or already owed from a
+    // prior launch) already exists and nothing has been deleted yet.
+    guard tryBeginEngineMutation() else {
+      TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitLegacyMigration")
+      return
+    }
+    defer {
+      if endEngineMutation() { wakeRecoveryIfOwed() }
     }
 
     // 6. Delete only what still matches the identity we captured (L3).

--- a/Sources/EnviousWisprServices/DebugRecoveryKeyFaultController.swift
+++ b/Sources/EnviousWisprServices/DebugRecoveryKeyFaultController.swift
@@ -26,27 +26,42 @@
     public static let shared = DebugRecoveryKeyFaultController()
 
     private let lock = NSLock()
-    private var armedStatus: OSStatus?
+    private var armed: (sessionID: String?, status: OSStatus)?
 
     private init() {}
 
     /// Arm the NEXT `retrieve()` call to fail with `status`. One-shot —
     /// consumed by the first read that observes it, so a Live UAT scenario
     /// staging a single deferred attempt cannot leak into a later real read.
-    public func arm(status: OSStatus) {
+    ///
+    /// `sessionID`, when provided, scopes the fault to that EXACT recovery
+    /// session — a `retrieve()` for any other id passes through untouched
+    /// (GitHub cloud review, PR #1732): the full Swift Testing suite runs
+    /// suites in parallel, and this controller is a process-wide singleton,
+    /// so an un-scoped one-shot fault could be consumed by an unrelated
+    /// concurrent `RecoveryKeyStore.retrieve()` call in a different test
+    /// suite (`RecoveryKeyStoreTests`, `RecoveryCoordinatorTests`) instead of
+    /// the specific replay this test armed it for. `nil` preserves the
+    /// original "fire on whichever call comes next" behavior the Live UAT
+    /// fault-injection endpoint uses, where there is no concurrent-suite
+    /// contention to worry about.
+    public func arm(status: OSStatus, forSessionID sessionID: String? = nil) {
       lock.lock()
       defer { lock.unlock() }
-      armedStatus = status
+      armed = (sessionID, status)
     }
 
-    /// Consume the armed status (if any), clearing it. Called by
+    /// Consume the armed status for `recoverySessionID` (if any and if it
+    /// matches — a `nil`-scoped arm matches any id), clearing it. Called by
     /// `RecoveryKeyStore.retrieve()` before every real read.
-    func consumeArmedStatus() -> OSStatus? {
+    func consumeArmedStatus(forSessionID recoverySessionID: String) -> OSStatus? {
       lock.lock()
       defer { lock.unlock() }
-      let status = armedStatus
-      armedStatus = nil
-      return status
+      guard let armed, armed.sessionID == nil || armed.sessionID == recoverySessionID else {
+        return nil
+      }
+      self.armed = nil
+      return armed.status
     }
   }
 

--- a/Sources/EnviousWisprServices/DebugRecoveryKeyFaultController.swift
+++ b/Sources/EnviousWisprServices/DebugRecoveryKeyFaultController.swift
@@ -1,0 +1,53 @@
+#if DEBUG
+
+  import Foundation
+  import Security
+
+  /// #1707 Phase 3 (§11.1): DEBUG-only, environment-gated fault-injection seam
+  /// for the Keychain transient-vs-terminal fix's Live UAT leg — arms the NEXT
+  /// `RecoveryKeyStore.retrieve()` call to throw a named
+  /// `RecoveryKeyStoreError.retrieveFailed(status)`, simulating a locked-
+  /// keychain-state read failure without a real signed-release Data-
+  /// Protection-Keychain (architecturally a different backend,
+  /// `RecoveryKeyStore.swift:17-20`, out of scope for this automated
+  /// harness). Whole-file `#if DEBUG`: the release build has no runtime
+  /// environment check, no optional dependency, no protocol conformance
+  /// slot, and no command-string literal referencing this feature at all —
+  /// it is not merely disabled at runtime, the code does not exist in a
+  /// release compilation. Release validation: `nm`/`strings` absence checks.
+  ///
+  /// A singleton (not injected through `RecoveryKeyStore`'s init) because
+  /// `RecoveryKeyStore` is a value type constructed fresh at many call
+  /// sites; every instance must observe the SAME armed fault regardless of
+  /// which one a given code path happened to construct. `RecoveryKeyStore`
+  /// itself is off-MainActor by design (`keychain-not-mainactor`), so this
+  /// type is lock-protected, not actor-isolated.
+  public final class DebugRecoveryKeyFaultController: @unchecked Sendable {
+    public static let shared = DebugRecoveryKeyFaultController()
+
+    private let lock = NSLock()
+    private var armedStatus: OSStatus?
+
+    private init() {}
+
+    /// Arm the NEXT `retrieve()` call to fail with `status`. One-shot —
+    /// consumed by the first read that observes it, so a Live UAT scenario
+    /// staging a single deferred attempt cannot leak into a later real read.
+    public func arm(status: OSStatus) {
+      lock.lock()
+      defer { lock.unlock() }
+      armedStatus = status
+    }
+
+    /// Consume the armed status (if any), clearing it. Called by
+    /// `RecoveryKeyStore.retrieve()` before every real read.
+    func consumeArmedStatus() -> OSStatus? {
+      lock.lock()
+      defer { lock.unlock() }
+      let status = armedStatus
+      armedStatus = nil
+      return status
+    }
+  }
+
+#endif

--- a/Sources/EnviousWisprServices/RecoveryKeyStore.swift
+++ b/Sources/EnviousWisprServices/RecoveryKeyStore.swift
@@ -67,7 +67,9 @@ public struct RecoveryKeyStore: Sendable {
 
   public func retrieve(for recoverySessionID: String) throws -> Data {
     #if DEBUG
-      if let status = DebugRecoveryKeyFaultController.shared.consumeArmedStatus() {
+      if let status = DebugRecoveryKeyFaultController.shared.consumeArmedStatus(
+        forSessionID: recoverySessionID)
+      {
         throw RecoveryKeyStoreError.retrieveFailed(status)
       }
     #endif

--- a/Sources/EnviousWisprServices/RecoveryKeyStore.swift
+++ b/Sources/EnviousWisprServices/RecoveryKeyStore.swift
@@ -66,6 +66,11 @@ public struct RecoveryKeyStore: Sendable {
   }
 
   public func retrieve(for recoverySessionID: String) throws -> Data {
+    #if DEBUG
+      if let status = DebugRecoveryKeyFaultController.shared.consumeArmedStatus() {
+        throw RecoveryKeyStoreError.retrieveFailed(status)
+      }
+    #endif
     switch backend {
     case .file:
       return try fileRetrieve(account: recoverySessionID)

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -66,6 +66,10 @@ public enum RecoveryTelemetryReason: String, Sendable {
   case markerWriteFailed = "marker_write_failed"
   case markerClearFailed = "marker_clear_failed"
   case crashLoop = "crash_loop"
+  /// #1707 Phase 3 — a Keychain read returned a transient OSStatus (device
+  /// locked / keychain daemon not yet unlocked); the spool is retained and
+  /// retried, not deleted. Bypass, not Failure.
+  case keychainTransient = "keychain_transient"
 }
 
 /// #1464 — the narrow failure CLASS behind a transcription-stage recovery failure,
@@ -1028,6 +1032,34 @@ public final class TelemetryService {
   public func recoveryPressBlocked(asrBackend: String) {
     PostHogSDK.shared.capture(
       "recovery.press_blocked", properties: ["asr_backend": asrBackend])
+  }
+
+  /// #1707 Phase 3 — pairs with `recoveryPressBlocked`: a press that was
+  /// previously blocked went on to mint an active session. `waitSeconds` is
+  /// the measured gap between the block and this later successful start,
+  /// bucketed the same as every other recovery duration. Lets production
+  /// telemetry measure whether the bounded-wait fix actually shrank real wait
+  /// times, not just whether presses get blocked at all.
+  public func recoveryPressUnblocked(asrBackend: String, waitSeconds: Int) {
+    PostHogSDK.shared.capture(
+      "recovery.press_unblocked",
+      properties: [
+        "asr_backend": asrBackend,
+        "wait_seconds_bucket": Self.recoverySecondsBucket(waitSeconds),
+      ])
+  }
+
+  /// #1707 Phase 3 — an engine-mutating call site deferred its own mutation
+  /// because `EngineRecoveryGate.tryBeginMutation()` returned `false` (recovery
+  /// held the engine). Observability only, no behavior change: today these
+  /// deferrals emit nothing, so a future regression reopening one of these
+  /// races has no telemetry signal to catch it by. One shared event with a
+  /// `site` property (e.g. `"startWarm"` / `"whisperKitUnload"` /
+  /// `"parakeetUnload"` / `"pttPrewarm"` / `"benchmarkSuite"`), not five
+  /// separate events.
+  public func recoveryEngineActionDeferred(site: String) {
+    PostHogSDK.shared.capture(
+      "recovery.engine_action_deferred", properties: ["site": site])
   }
 
   /// Coarse duration bucket (seconds) for recovery telemetry — keeps exact

--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
@@ -230,6 +230,23 @@ struct EngineCoordinatorTests {
     #expect(applied, "the deferred switch applies once minting ends")
   }
 
+  @Test(
+    "isMintingAnySession tracks beginMinting/endMinting for BOTH backends (GitHub cloud review, PR #1732)"
+  )
+  func isMintingAnySessionTracksBothBackends() async {
+    // `isMintingWhisperKitSession` is scoped to WhisperKit; `RecoveryCoordinator`'s
+    // isDictationActive check needs a backend-agnostic signal so a record-press
+    // still mid-start (beginMinting called, not yet an active kernel session)
+    // is never mistaken for "engine free" regardless of which backend it targets.
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    let c = fake.makeStartedCoordinator()
+    #expect(!c.isMintingAnySession, "not minting before any press")
+    c.beginMinting()
+    #expect(c.isMintingAnySession, "true while a record-start is minting (Parakeet active)")
+    c.endMinting()
+    #expect(!c.isMintingAnySession, "false again once minting ends")
+  }
+
   // MARK: - Failure model
 
   @Test("warm-after-switch failure honors the choice and never reverts")

--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTests.swift
@@ -126,6 +126,51 @@ struct EngineCoordinatorTests {
     #expect(applied, "the deferred switch must apply once recovery completes")
   }
 
+  @Test(
+    "a deferred switch applying on recovery-complete still wakes recovery (round-2 fix, PR #1732)"
+  )
+  func deferredSwitchAppliedOnRecoveryCompleteWakesRecovery() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    fake.recovering = true
+    let c = fake.makeStartedCoordinator()
+    var wakeCount = 0
+    c.onEngineStateChangedForRecovery = { wakeCount += 1 }
+    fake.selected = .whisperKit
+    c.poke(.settingsChanged)
+    _ = await enginePoll(.milliseconds(150)) { fake.active == .whisperKit }
+    fake.recovering = false
+    c.poke(.recoveryComplete)
+    let applied = await enginePoll { fake.active == .whisperKit }
+    #expect(applied, "the deferred switch must still apply once recovery completes")
+    // >=1, not an exact count: the switch-completion path (pre-existing,
+    // unconditional) AND the subsequent warm-completion path (pre-existing,
+    // `.warmCompleted`-gated) both legitimately fire here — this test's point
+    // is that the ROUND-2 gating change (only wake on a genuine
+    // switching->idle transition) does not accidentally suppress the real
+    // wake this scenario depends on, not to pin an incidental trigger count.
+    #expect(wakeCount >= 1, "a genuine switching->idle transition must wake recovery")
+  }
+
+  @Test(
+    "an already-converged recovery-complete poke never wakes recovery — GitHub cloud review round 1's fix, self-caught before shipping, was a closed loop for any RETAINED recovery outcome (PR #1732)"
+  )
+  func alreadyConvergedRecoveryCompletePokeNeverWakesRecovery() async {
+    let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)
+    let c = fake.makeStartedCoordinator()
+    var wakeCount = 0
+    c.onEngineStateChangedForRecovery = { wakeCount += 1 }
+    // Mirrors `RecoveryCoordinator.onRecoveryComplete` firing after EVERY
+    // replayed item, retained or not — repeated to prove this never becomes
+    // a self-perpetuating loop when nothing was ever switching.
+    for _ in 0..<5 {
+      c.poke(.recoveryComplete)
+      _ = await enginePoll(.milliseconds(50)) { false }  // let the mailbox drain
+    }
+    #expect(
+      wakeCount == 0,
+      "an ordinary already-converged poke must never wake recovery — no switch ever deferred")
+  }
+
   @Test("not-installed selection never loads, applies once the model downloads")
   func notInstalledDefersUntilDownloaded() async {
     let fake = FakeEngineDeps(selected: .parakeet, active: .parakeet)

--- a/Tests/EnviousWisprTests/App/EngineRecoveryGateTests.swift
+++ b/Tests/EnviousWisprTests/App/EngineRecoveryGateTests.swift
@@ -1,0 +1,109 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1707 Phase 3 (§3.2) — the atomic mutual-exclusion primitive between
+/// crash-recovery replay and every OTHER engine-mutating operation. Exclusion,
+/// not preemption: once a mutation has ALREADY acquired its claim, a recovery
+/// attempt starting after that must be REFUSED, never must it preempt the
+/// already-running mutation.
+@MainActor
+@Suite("EngineRecoveryGate (#1707 Phase 3)")
+struct EngineRecoveryGateTests {
+
+  @Test("recovery claims freely when nothing is mutating")
+  func recoveryClaimsWhenIdle() {
+    let gate = EngineRecoveryGate()
+    #expect(gate.tryBeginRecovery())
+    #expect(gate.isRecoveryClaimed)
+    gate.endRecovery()
+    #expect(!gate.isRecoveryClaimed)
+  }
+
+  @Test("mutation claims freely when nothing is recovering")
+  func mutationClaimsWhenIdle() {
+    let gate = EngineRecoveryGate()
+    #expect(gate.tryBeginMutation())
+    #expect(gate.endMutation() == false, "no recovery was ever denied — no wake-up owed")
+  }
+
+  @Test("a held mutation refuses recovery for its FULL duration, then recovery wakes and acquires")
+  func mutationExcludesRecoveryForFullDuration() {
+    let gate = EngineRecoveryGate()
+    #expect(gate.tryBeginMutation())
+    // Recovery's attempt FAILS while the mutation remains active — exclusion,
+    // not preemption of the already-running mutation.
+    #expect(!gate.tryBeginRecovery())
+    #expect(!gate.tryBeginRecovery(), "still refused — the mutation is still held")
+    // The mutation releases; it was the last held claim AND recovery was
+    // denied while it was in flight, so the caller is told to wake recovery.
+    #expect(gate.endMutation() == true)
+    // Recovery now acquires successfully.
+    #expect(gate.tryBeginRecovery())
+    gate.endRecovery()
+  }
+
+  @Test("a held recovery claim refuses every mutation for its FULL duration")
+  func recoveryExcludesMutationForFullDuration() {
+    let gate = EngineRecoveryGate()
+    #expect(gate.tryBeginRecovery())
+    #expect(!gate.tryBeginMutation())
+    #expect(!gate.tryBeginMutation(), "still refused — recovery is still held")
+    gate.endRecovery()
+    #expect(gate.tryBeginMutation())
+  }
+
+  @Test(
+    "two simultaneous mutation claims: recovery stays refused until BOTH release, wakes exactly once"
+  )
+  func twoOverlappingMutationsBothMustReleaseBeforeRecoveryWakes() {
+    let gate = EngineRecoveryGate()
+    #expect(gate.tryBeginMutation(), "first mutation claim")
+    #expect(gate.tryBeginMutation(), "second, overlapping mutation claim")
+    #expect(!gate.tryBeginRecovery(), "denied while EITHER mutation is held")
+    // The first release does NOT drain mutationCount to zero — no wake-up yet.
+    #expect(gate.endMutation() == false, "one claim remains — not yet owed")
+    #expect(!gate.tryBeginRecovery(), "still refused — the second claim is still held")
+    // The second (and last) release drains mutationCount to zero — wake-up owed.
+    #expect(gate.endMutation() == true)
+    #expect(gate.tryBeginRecovery())
+    gate.endRecovery()
+  }
+
+  @Test("two separate recovery-claim attempts denied by one mutation both set the SAME wake-up")
+  func twoSimultaneousDenialsCoalesceIntoOneWakeUp() {
+    let gate = EngineRecoveryGate()
+    #expect(gate.tryBeginMutation())
+    #expect(!gate.tryBeginRecovery(), "first denial")
+    #expect(!gate.tryBeginRecovery(), "second denial — recoveryRetryOwed must not be lost")
+    // Exactly one wake-up fires on the single mutation's release — a rescan
+    // re-discovers every spool from disk, so coalescing to one is correct,
+    // not a lost second denial.
+    #expect(gate.endMutation() == true)
+    #expect(gate.tryBeginRecovery())
+    gate.endRecovery()
+  }
+
+  @Test("a mutation denied while recovery is claimed grants no wake-up on recovery's own release")
+  func recoveryReleaseNeverOwesAMutationWakeUp() {
+    let gate = EngineRecoveryGate()
+    #expect(gate.tryBeginRecovery())
+    #expect(!gate.tryBeginMutation(), "denied while recovery holds the claim")
+    gate.endRecovery()
+    // `endRecovery()` returns Void by design — mutation call sites rely on
+    // their OWN natural retry trigger (a future press, a future timer), not a
+    // gate-driven wake-up, per §3.2's documented design choice.
+    #expect(gate.tryBeginMutation())
+  }
+
+  @Test("mutationCount allows unrelated mutations to overlap exactly as they can today")
+  func mutationsOverlapFreely() {
+    let gate = EngineRecoveryGate()
+    #expect(gate.tryBeginMutation())
+    #expect(gate.tryBeginMutation())
+    #expect(gate.tryBeginMutation())
+    #expect(gate.endMutation() == false)
+    #expect(gate.endMutation() == false)
+    #expect(gate.endMutation() == false, "no recovery was ever denied across any of these")
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
@@ -123,10 +123,21 @@ import Testing
     // instead. No new collaborator: both driver properties are already-owned
     // collaborators (collaboratorCount stays ≤ 11); no new method (nonPrivateMethodCount
     // unchanged). Deterministic rule: actual 446 + 10 → round up to nearest 5 = 460.
+    // #1732 (GitHub cloud review round 6): 460 → 500. Both `handleParakeet`/
+    // `handleWhisperKit` gained a 6-line block reading `kernelDriver`/
+    // `whisperKitKernelDriver.lastHistorySaved` + `.currentTranscript?
+    // .recoverySessionID` and calling the new `onDurableSaveFailed` closure on
+    // a `.complete`-with-failed-save transition — protects a spool this same
+    // transition's own recovery wake-up would otherwise immediately rescan.
+    // No new collaborator (both driver properties already owned); one new
+    // off-cap `var` closure (`onDurableSaveFailed`, same pattern as
+    // `onDurableSave`/`onRecordingEndedWithoutDurableSave`, already excluded
+    // from `nonPrivateMethodCount`). Deterministic rule: actual 488 + 10 →
+    // round up to nearest 5 = 500.
     #expect(
-      count <= 460,
+      count <= 500,
       """
-      DictationLifecycleCoordinator line count exceeded: \(count) > 460. \
+      DictationLifecycleCoordinator line count exceeded: \(count) > 500. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationRuntimeCeilingsTests.swift
@@ -100,9 +100,9 @@ import Testing
       contentsOf: RepoRoot.sourceURL(Self.sourcePath), encoding: .utf8)
     let count = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      count <= 217,
+      count <= 235,
       """
-      DictationRuntime line count exceeded: \(count) > 217. \
+      DictationRuntime line count exceeded: \(count) > 235. \
       Raise via Bible §30 only. PR10 ratcheted 100 → 200 to absorb the \
       7-collab field block + 6 façade methods + DR.init body building the \
       recording subsystem (HeartControlRecovery + Finalizer + Starter + \
@@ -113,7 +113,12 @@ import Testing
       #1388 ratcheted 215 → 216 for cancelActiveEngineWarmupForOnboarding \
       (#879's cancel twin — thin forward, no new state). #1224 ratcheted \
       216 → 217 for one new `recordingOverlay:` argument threaded into the \
-      existing AudioEventRouter(...) construction call.
+      existing AudioEventRouter(...) construction call. #1732 (GitHub cloud \
+      review round 6) ratcheted 217 → 235 for one new `onDurableSaveFailed` \
+      closure wiring block (mirrors the existing `onDurableSave`/ \
+      `onRecordingEndedWithoutDurableSave` wiring pattern) — no new \
+      collaborator or method, deterministic rule: actual 223 + 10 → round \
+      up to nearest 5 = 235.
       """)
   }
 

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -398,14 +398,28 @@ import Testing
   /// Codex r6 required gating the controller's own construction behind
   /// `#if DEBUG` (a Release build must not wire real fault-injection
   /// machinery into its object graph): actual 1200 + ~2, rounded to 1205.
+  /// #1707 Phase 3 (crash-safety-net readiness gating): 1205 → 1315 for the
+  /// `EngineRecoveryGate` construction + the composition-root wiring pass
+  /// that injects its closures downward into every guarded engine-mutating
+  /// call site (`kernelDriver`/`whisperKitKernelDriver`, `asrManager`'s
+  /// concrete type, `whisperKitSetup`, `whisperKitRetirement`,
+  /// `modelDelivery`, `diagnosticsCoordinator.benchmark`) plus
+  /// `EngineCoordinator`'s three new `Dependencies` fields and
+  /// `RecoveryCoordinator`'s claim closures. This is the irreducible cost of
+  /// naming a new cross-cutting subsystem, the same class of residue
+  /// `activeEngine`/`whisperKitRetirement` already justify above — only the
+  /// composition root has every guarded object in scope simultaneously to
+  /// wire them together; no domain logic moved here (the gate itself and
+  /// every guard's behavior live on their own types). Cap by deterministic
+  /// rule (actual 1309 + ~2, rounded up to nearest 5 = 1315).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1205,
+      lineCount <= 1315,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1205. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1315. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -412,14 +412,22 @@ import Testing
   /// wire them together; no domain logic moved here (the gate itself and
   /// every guard's behavior live on their own types). Cap by deterministic
   /// rule (actual 1309 + ~2, rounded up to nearest 5 = 1315).
+  /// #1732 (GitHub cloud review round 9): 1315 → 1330 for the
+  /// `engineCoordinatorForRecoveryGate` weak local var + its wiring into
+  /// `isDictationActive`, closing a narrow race where a record-press still
+  /// mid-`beginMinting()` (not yet an active kernel session) could have its
+  /// engine reclaimed by the next recovery item. Same class of irreducible
+  /// composition-root residue as the entries above; no domain logic moved
+  /// here. Cap by deterministic rule (actual 1326 + ~2, rounded up to
+  /// nearest 5 = 1330).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1315,
+      lineCount <= 1330,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1315. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1330. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -133,10 +133,19 @@ import Testing
     // #1386 PR-2c: 550 → 565 for the founder's removal gate — the honest
     // not-installed pill on BOTH press paths before any readiness logic (a
     // removal's first instants can still read ready). Actual 560 + ~2 → 565.
+    // #1707 Phase 3 (crash-safety-net readiness gating): 565 → 615 for the
+    // `signalPendingLiveStart` bare closure (also excluded — a non-`async`
+    // `() -> Void` closure is not a collaborator, collaboratorCount still
+    // ≤ 7) at all four existing recovery-refusal sites, plus the blocked-
+    // press timestamp state and the `handleRecoveryPressRefused`/
+    // `consumePendingBlockedPressIfAny` private helpers feeding the new
+    // `recovery.press_unblocked` telemetry. The recovery owner stays OFF
+    // this type; only the paper-line ceiling moves (deterministic rule:
+    // actual 603 + 10 → round up to nearest 5 = 615).
     #expect(
-      count <= 565,
+      count <= 615,
       """
-      RecordingStarter line count exceeded: \(count) > 565. \
+      RecordingStarter line count exceeded: \(count) > 615. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -142,16 +142,24 @@ import Testing
     // `recovery.press_unblocked` telemetry. The recovery owner stays OFF
     // this type; only the paper-line ceiling moves (deterministic rule:
     // actual 603 + 10 → round up to nearest 5 = 615).
-    // #1732 (GitHub cloud review fix): 615 → 630 — doc-comment additions
-    // only, explaining why `pendingBlockedPressInfo` is deliberately NOT
-    // overwritten by a later refusal within the same blocked episode. No new
-    // collaborator, method, or stored property; only the paper-line ceiling
-    // moves (deterministic rule: actual 617 + 10 → round up to nearest 5 =
-    // 630).
+    // #1732 (GitHub cloud review fix, round 1): 615 → 630 — doc-comment
+    // additions only, explaining why `pendingBlockedPressInfo` is
+    // deliberately NOT overwritten by a later refusal within the same
+    // blocked episode. No new collaborator, method, or stored property; only
+    // the paper-line ceiling moves (deterministic rule: actual 617 + 10 →
+    // round up to nearest 5 = 630).
+    // #1732 (GitHub cloud review fix, round 2): 630 → 645 — moved
+    // `consumePendingBlockedPressIfAny()` in BOTH `start()` and `toggle()` to
+    // fire only after a real session is confirmed active (not before
+    // `handle(event:)`, which could throw or silently not activate), each
+    // with an explanatory comment. No new collaborator or stored property;
+    // `toggle()`'s new `active.state.isActive` read is a property access, not
+    // a method. Only the paper-line ceiling moves (deterministic rule: actual
+    // 631 + 10 → round up to nearest 5 = 645).
     #expect(
-      count <= 630,
+      count <= 645,
       """
-      RecordingStarter line count exceeded: \(count) > 630. \
+      RecordingStarter line count exceeded: \(count) > 645. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -142,10 +142,16 @@ import Testing
     // `recovery.press_unblocked` telemetry. The recovery owner stays OFF
     // this type; only the paper-line ceiling moves (deterministic rule:
     // actual 603 + 10 → round up to nearest 5 = 615).
+    // #1732 (GitHub cloud review fix): 615 → 630 — doc-comment additions
+    // only, explaining why `pendingBlockedPressInfo` is deliberately NOT
+    // overwritten by a later refusal within the same blocked episode. No new
+    // collaborator, method, or stored property; only the paper-line ceiling
+    // moves (deterministic rule: actual 617 + 10 → round up to nearest 5 =
+    // 630).
     #expect(
-      count <= 615,
+      count <= 630,
       """
-      RecordingStarter line count exceeded: \(count) > 615. \
+      RecordingStarter line count exceeded: \(count) > 630. \
       Raise via Bible §30 only.
       """)
   }

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -103,6 +103,40 @@ import Testing
     #expect(unloadCount == 1)
   }
 
+  @Test(
+    "applyUnloadPolicy(.immediately): a cancellation landing exactly during the mutation-claim hop must NOT let the unload proceed (GitHub cloud review, PR #1732 round 10)"
+  )
+  func unloadCancelledDuringClaimHopNeverUnloads() async throws {
+    // The mutation-claim acquisition is ITSELF a suspension point between the
+    // pre-existing final-cancellation check and `backend.unload()` — a
+    // `beginSession(B)` landing exactly there cancels this task the same way
+    // that earlier check exists to catch, but nothing re-checked it before
+    // the unload call. Modeled by having `tryBeginEngineMutation` itself
+    // cancel the running unload task (standing in for `beginSession`
+    // cancelling it), then asserting the unload never executes and the
+    // just-acquired claim is still released, not leaked.
+    let backend = StubWhisperKitBackend()
+    let adapter = WhisperKitEngineAdapter(backend: backend)
+    try await adapter.warmUp()
+    #expect(adapter.readiness == .ready)
+    var mutationEndedCount = 0
+    adapter.tryBeginEngineMutation = { [weak adapter] in
+      adapter?.modelUnloadTaskForUnitTests?.cancel()
+      return true
+    }
+    adapter.endEngineMutation = {
+      mutationEndedCount += 1
+      return false
+    }
+    adapter.applyUnloadPolicy(.immediately)
+    await adapter.modelUnloadTaskForUnitTests?.value
+    let unloadCount = await backend.unloadCount
+    #expect(
+      unloadCount == 0, "a cancellation during the claim hop must prevent the unload from executing"
+    )
+    #expect(mutationEndedCount == 1, "the just-acquired claim must still be released, not leaked")
+  }
+
   @Test("readiness goes notReady when warmUp throws (failed prepare)")
   func cachedReadinessAfterFailedPrepare() async {
     let backend = StubWhisperKitBackend()

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -506,6 +506,43 @@ struct RecoveryCoordinatorTests {
       "the un-attempted second orphan stays on disk for the next trigger")
   }
 
+  @Test(
+    "a live-start signal observed during the LAST item's replay still yields — a concurrent wake-up does not immediately reclaim the engine"
+  )
+  func pendingLiveStartYieldsAfterFinalItem() async throws {
+    // GitHub cloud review, PR #1732: the top-of-loop guard only catches a
+    // live-start signal if there is a NEXT item to check it before. A signal
+    // arriving during the LAST item's replay had no such checkpoint, so if an
+    // UNRELATED wake-up cause also fires during that same window (setting
+    // `pendingRescan`, coalesced since a scan is already in progress),
+    // `drainPendingRescan()` would immediately run another pass — whose own
+    // per-pass reset clears the signal and reclaims the engine right after
+    // refusing the user's press, before their retry gets a chance.
+    let h = Self.makeHarness()
+    let first = "first-\(UUID().uuidString)"
+    let second = "second-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, first)
+    try Self.writeSpool(h.spoolStore, second)
+    // `second` is RETAINED (not deleted) so it would still be on disk for an
+    // improper immediate re-pass to (incorrectly) rediscover and re-attempt.
+    h.replayer.outcomeByID[second] = .failed(.save(.other))
+    h.replayer.onReplay = { [coordinator = h.coordinator] id in
+      if id == second {
+        coordinator.pendingLiveStartSignal = true
+        // Simulate an unrelated wake-up cause firing in the same window.
+        coordinator.requestRecoveryRecheck()
+      }
+    }
+    await h.coordinator.scanAndRecover()
+    #expect(
+      h.replayer.replayedIDs == [first, second],
+      "each real orphan attempted exactly once — no improper immediate re-pass")
+    #expect(!h.coordinator.isRecovering, "the gate is clear after yielding")
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: second).path),
+      "the retained second orphan stays on disk for the next real trigger")
+  }
+
   @Test("pendingLiveStartSignal is cleared entering the next fresh scan pass")
   func pendingLiveStartClearedOnNextPass() async throws {
     let h = Self.makeHarness()

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -432,6 +432,39 @@ struct RecoveryCoordinatorTests {
     }
   }
 
+  @Test(
+    "a live recording's own retained failure is excluded from THIS SAME session's wake-up rescan"
+  )
+  func retainedLiveFailureExcludedFromSameSessionRescan() async throws {
+    // GitHub cloud review, PR #1732: `onDictationEndedForRecovery` fires right
+    // after a live recording ends. For a RETAIN ending, the engine may still be
+    // in the exact broken state that produced the failure — a same-launch
+    // rescan must not immediately re-attempt (and potentially delete) the very
+    // spool this ending just retained.
+    let h = Self.makeHarness()
+    let id = "live-fail-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    // `.failed` is a RETAIN-kind ending (`shouldDeleteOnLiveEnding` returns
+    // false) — mirrors the live driver calling this on a genuine failure.
+    h.coordinator.handleRecordingEndedWithoutDurableSave(recoverySessionID: id, ending: .failed)
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "a retain ending never deletes")
+    // If the engine were still broken, a replay attempt here would fail again.
+    h.replayer.outcomeByID[id] = .failed(.unrecoverable)
+    // The SAME session's own wake-up call — must not touch `id` this pass.
+    h.coordinator.requestRecoveryRecheck()
+    for _ in 0..<20 {
+      try? await Task.sleep(for: .milliseconds(5))  // settle: bounded drain to let any spurious replay run
+    }
+    #expect(
+      h.replayer.replayedIDs.isEmpty,
+      "the just-retained id must not be re-attempted by this same session's own rescan")
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "still on disk — not destroyed by a same-launch replay of the just-retained spool")
+  }
+
   @Test("a FRESH coordinator instance (a genuine new launch) starts with an empty suppression set")
   func freshInstanceStartsEmpty() async throws {
     let h = Self.makeHarness()

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -80,6 +80,10 @@ struct RecoveryCoordinatorTests {
     let spoolStore: RecoverySpoolStore
     let replayer: FakeReplayer
     let resetEngineCount: Box<Int>
+    /// Exposed so a test can flip live-dictation-active state AFTER
+    /// construction (e.g. from a concurrently-spawned Task simulating a live
+    /// press that mints its own session mid-scan).
+    let dictationActiveBox: Box<Bool>
   }
 
   /// `existing` and `dictationActive` are boxed so a test can mutate them after
@@ -112,7 +116,7 @@ struct RecoveryCoordinatorTests {
     return Harness(
       coordinator: coordinator, keyStore: keyStore,
       spoolStore: RecoverySpoolStore(directory: spoolDir), replayer: replayer,
-      resetEngineCount: resetEngineCount)
+      resetEngineCount: resetEngineCount, dictationActiveBox: activeBox)
   }
 
   private static func writeSpool(_ store: RecoverySpoolStore, _ id: String) throws {
@@ -541,6 +545,43 @@ struct RecoveryCoordinatorTests {
     #expect(
       FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: second).path),
       "the retained second orphan stays on disk for the next real trigger")
+  }
+
+  @Test(
+    "a fresh record-press queued exactly at the item boundary gets a genuine scheduling turn before the next item re-claims the engine (GitHub cloud review, PR #1732)"
+  )
+  func freshPressAtItemBoundaryGetsScheduledBeforeNextClaim() async throws {
+    // Between one item's `defer` (isRecovering -> false) and the next item's
+    // own claim, nothing suspended in the OLD code — so a record-press Task
+    // queued exactly then never got an actual scheduling turn to observe
+    // `isRecovering == false` (Swift's MainActor only switches tasks at a
+    // real suspension point). The fix adds `await Task.yield()` at the top
+    // of each iteration so such a press gets its turn first. Modeled here as
+    // a Task spawned during item 1's replay that flips `isDictationActive`
+    // — simulating a live press that mints its own session — with NO
+    // internal yield of its own, so it is immediately ready to run the
+    // moment the coordinator's own Task next suspends.
+    let h = Self.makeHarness()
+    let first = "first-\(UUID().uuidString)"
+    let second = "second-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, first)
+    try Self.writeSpool(h.spoolStore, second)
+    h.replayer.onReplay = { [dictationActiveBox = h.dictationActiveBox] id in
+      if id == first {
+        Task { @MainActor in
+          dictationActiveBox.value = true
+        }
+      }
+    }
+    await h.coordinator.scanAndRecover()
+    #expect(
+      h.replayer.replayedIDs == [first],
+      "item 2 must never be attempted — the queued press's Task got a real turn at the yield and minted its own session before item 2's claim"
+    )
+    #expect(!h.coordinator.isRecovering, "the gate is clear after deferring")
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: second).path),
+      "the un-attempted second orphan stays on disk for the next trigger")
   }
 
   @Test("pendingLiveStartSignal is cleared entering the next fresh scan pass")

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -43,6 +43,10 @@ struct RecoveryCoordinatorTests {
     var isRecoveringDuringReplay: [Bool] = []
     var abortedSeen: [Bool] = []
     var outcomeByDefault: RecoveryReplayOutcome = .recovered
+    /// #1707 Phase 3 — per-id scripted outcome, taking precedence over
+    /// `outcomeByDefault` when present (for multi-item scans where different
+    /// orphans need different outcomes).
+    var outcomeByID: [String: RecoveryReplayOutcome] = [:]
     var onReplay: ((String) -> Void)?
     /// When true, the FIRST replay suspends on a continuation until the test
     /// resumes it — so the test can run a second scan while one is genuinely
@@ -66,7 +70,7 @@ struct RecoveryCoordinatorTests {
       onReplay?(id)
       let aborted = isAborted()
       abortedSeen.append(aborted)
-      return aborted ? .aborted : outcomeByDefault
+      return aborted ? .aborted : (outcomeByID[id] ?? outcomeByDefault)
     }
   }
 
@@ -385,6 +389,153 @@ struct RecoveryCoordinatorTests {
     try Self.writeSpool(h.spoolStore, "orphan-\(UUID().uuidString)")
     await h.coordinator.scanAndRecover()
     #expect(!h.coordinator.isRecovering)
+  }
+
+  // MARK: - #1707 Phase 3: nextLaunchOnlyRecoveryIDs
+
+  @Test(
+    ".deferredMarkerClearFailed and .failed(.saveMarkerClearFailed) both suppress same-launch rescan"
+  )
+  func markerClearFailureOutcomesSuppressSameLaunchRescan() async throws {
+    let h = Self.makeHarness()
+    let deferredID = "deferred-markerfail-\(UUID().uuidString)"
+    let saveID = "save-markerfail-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, deferredID)
+    try Self.writeSpool(h.spoolStore, saveID)
+    h.replayer.outcomeByID[deferredID] = .deferredMarkerClearFailed
+    h.replayer.outcomeByID[saveID] = .failed(.saveMarkerClearFailed(.other))
+    await h.coordinator.scanAndRecover()
+    #expect(Set(h.replayer.replayedIDs) == Set([deferredID, saveID]))
+    // Both outcomes RETAIN — neither spool is deleted.
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: deferredID).path))
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: saveID).path))
+    // A same-launch rescan (the SAME coordinator instance) must not re-attempt
+    // either id — they are next-launch-only.
+    h.replayer.replayedIDs = []
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs.isEmpty, "both ids suppressed on this instance's rescan")
+  }
+
+  @Test("nextLaunchOnlyRecoveryIDs is never cleared within one coordinator instance's lifetime")
+  func nextLaunchOnlyIDsNeverClearedOnSameInstance() async throws {
+    let h = Self.makeHarness()
+    let id = "persist-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    h.replayer.outcomeByID[id] = .deferredMarkerClearFailed
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs == [id])
+    // Repeated rescans on the SAME instance never re-attempt it.
+    for _ in 0..<3 {
+      h.replayer.replayedIDs = []
+      await h.coordinator.scanAndRecover()
+      #expect(h.replayer.replayedIDs.isEmpty)
+    }
+  }
+
+  @Test("a FRESH coordinator instance (a genuine new launch) starts with an empty suppression set")
+  func freshInstanceStartsEmpty() async throws {
+    let h = Self.makeHarness()
+    let id = "newlaunch-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    h.replayer.outcomeByID[id] = .deferredMarkerClearFailed
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs == [id])
+    // A genuinely NEW launch constructs a fresh coordinator (and fresh
+    // replayer) — the suppression set is per-instance, not persisted.
+    let h2 = Self.makeHarness()
+    try Self.writeSpool(h2.spoolStore, id)
+    h2.replayer.outcomeByDefault = .recovered
+    await h2.coordinator.scanAndRecover()
+    #expect(
+      h2.replayer.replayedIDs == [id], "a fresh instance re-attempts a previously-suppressed id")
+  }
+
+  // MARK: - #1707 Phase 3 §3.1: live-dictation-preempts-recovery-between-items
+
+  @Test(
+    "a pending live-start signal observed mid-scan yields the engine BETWEEN items — item 2 is never attempted"
+  )
+  func pendingLiveStartYieldsBetweenItems() async throws {
+    let h = Self.makeHarness()
+    let first = "first-\(UUID().uuidString)"
+    let second = "second-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, first)
+    try Self.writeSpool(h.spoolStore, second)
+    // Simulate `RecordingStarter`'s refusal path firing WHILE item 1 replays.
+    h.replayer.onReplay = { [coordinator = h.coordinator] id in
+      if id == first { coordinator.pendingLiveStartSignal = true }
+    }
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs == [first], "item 2 never attempted — the scan yielded first")
+    #expect(!h.coordinator.isRecovering, "the gate is clear after yielding")
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: second).path),
+      "the un-attempted second orphan stays on disk for the next trigger")
+  }
+
+  @Test("pendingLiveStartSignal is cleared entering the next fresh scan pass")
+  func pendingLiveStartClearedOnNextPass() async throws {
+    let h = Self.makeHarness()
+    let first = "first-\(UUID().uuidString)"
+    let second = "second-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, first)
+    try Self.writeSpool(h.spoolStore, second)
+    // A RETAINED (not deleted) outcome for `first`, so it is still on disk
+    // for pass 2 — isolating the assertion to the signal-clearing behavior,
+    // not to whether a successfully-recovered item gets deleted.
+    h.replayer.outcomeByID[first] = .failed(.save(.other))
+    h.replayer.onReplay = { [coordinator = h.coordinator] id in
+      if id == first { coordinator.pendingLiveStartSignal = true }
+    }
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs == [first])
+    // A later wake-up (e.g. the live dictation ending) triggers a fresh pass.
+    // The stale signal from the PRIOR pass must not spuriously yield this one.
+    h.replayer.onReplay = nil
+    h.replayer.replayedIDs = []
+    await h.coordinator.scanAndRecover()
+    #expect(
+      Set(h.replayer.replayedIDs) == Set([first, second]),
+      "a fresh pass re-attempts both remaining orphans — the prior signal is cleared, not stale")
+  }
+
+  // MARK: - #1707 Phase 3 §3.2: EngineRecoveryGate integration
+
+  @Test("a mutation claim held on the gate defers the ENTIRE scan — no item is attempted")
+  func gateDeniedRecoveryDefersWholeScan() async throws {
+    let h = Self.makeHarness()
+    let gate = EngineRecoveryGate()
+    h.coordinator.tryBeginRecoveryClaim = { gate.tryBeginRecovery() }
+    h.coordinator.endRecoveryClaim = { gate.endRecovery() }
+    #expect(gate.tryBeginMutation(), "an unrelated engine mutation holds the gate")
+    try Self.writeSpool(h.spoolStore, "orphan-\(UUID().uuidString)")
+    await h.coordinator.scanAndRecover()
+    #expect(
+      h.replayer.replayedIDs.isEmpty, "the gate denied the claim before any item was attempted")
+    #expect(!h.coordinator.isRecovering)
+  }
+
+  @Test("once the held mutation releases, requestRecoveryRecheck() lets the deferred scan succeed")
+  func gateReleaseThenRequestRecheckSucceeds() async throws {
+    let h = Self.makeHarness()
+    let gate = EngineRecoveryGate()
+    h.coordinator.tryBeginRecoveryClaim = { gate.tryBeginRecovery() }
+    h.coordinator.endRecoveryClaim = { gate.endRecovery() }
+    #expect(gate.tryBeginMutation())
+    let id = "orphan-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs.isEmpty, "denied while the mutation is held")
+    // The mutation releases — recovery was owed a retry (§3.2's `recoveryRetryOwed`).
+    #expect(gate.endMutation() == true)
+    h.coordinator.requestRecoveryRecheck()
+    // `requestRecoveryRecheck()` spawns its drain asynchronously — poll the
+    // real signal (`replayedIDs` becoming non-empty), backing off between
+    // checks rather than waiting a fixed duration.
+    for _ in 0..<200 where h.replayer.replayedIDs.isEmpty {
+      try? await Task.sleep(for: .milliseconds(5))  // settle: bounded poll backoff, not a fixed wait
+    }
+    #expect(h.replayer.replayedIDs == [id], "the deferred scan succeeded once the gate opened")
   }
 
   @Test("single-flight: a scan started while another is in-flight is rejected")

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -258,7 +258,8 @@ struct RecoverySpoolReplayerTests {
       let h = Self.makeHarness()
       let id = "transient-\(UUID().uuidString)"
       try await Self.seedSpool(h, id: id, samples: [0.6])
-      DebugRecoveryKeyFaultController.shared.arm(status: errSecInteractionNotAllowed)
+      DebugRecoveryKeyFaultController.shared.arm(
+        status: errSecInteractionNotAllowed, forSessionID: id)
       let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
       #expect(outcome == .deferred)
       #expect(h.asr.transcribeCallCount == 0, "never reaches transcribe on a deferred key read")
@@ -279,7 +280,8 @@ struct RecoverySpoolReplayerTests {
       let h = Self.makeHarness()
       let id = "transient-retry-\(UUID().uuidString)"
       try await Self.seedSpool(h, id: id, samples: [0.6])
-      DebugRecoveryKeyFaultController.shared.arm(status: errSecInteractionNotAllowed)
+      DebugRecoveryKeyFaultController.shared.arm(
+        status: errSecInteractionNotAllowed, forSessionID: id)
       let first = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
       #expect(first == .deferred)
       // No fault armed this time — the retry reads the REAL stored key.
@@ -296,7 +298,7 @@ struct RecoverySpoolReplayerTests {
       let h = Self.makeHarness()
       let id = "terminal-\(UUID().uuidString)"
       try await Self.seedSpool(h, id: id, samples: [0.6])
-      DebugRecoveryKeyFaultController.shared.arm(status: status)
+      DebugRecoveryKeyFaultController.shared.arm(status: status, forSessionID: id)
       let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
       #expect(
         outcome == .failed(.unrecoverable),
@@ -312,14 +314,21 @@ struct RecoverySpoolReplayerTests {
       let id = "transient-markerfail-\(UUID().uuidString)"
       try await Self.seedSpool(h, id: id, samples: [0.3])
       defer { _ = chmod(h.spoolDir.path, 0o700) }  // restore so temp cleanup/GC can proceed
-      DebugRecoveryKeyFaultController.shared.arm(status: errSecInteractionNotAllowed)
-      let replayTask = Task { await h.replayer.replay(recoverySessionID: id, isAborted: { false }) }
-      // Let the marker WRITE (needs a writable spool dir) land first, then
-      // revoke write access so the marker CLEAR the transient path triggers
-      // throws — deterministic ordering via a real signal, not a sleep.
-      while !h.spoolStore.hasAttemptMarker(for: id) { await Task.yield() }
-      _ = chmod(h.spoolDir.path, 0o500)
-      let outcome = await replayTask.value
+      DebugRecoveryKeyFaultController.shared.arm(
+        status: errSecInteractionNotAllowed, forSessionID: id)
+      // Deterministic ordering via a real signal, not a poll (GitHub cloud
+      // review, PR #1732): a poll on `hasAttemptMarker` raced the replayer's
+      // own detached Keychain-read task and could miss the narrow true→false
+      // window entirely (empirically ~2/3 runs, not a rare edge case).
+      // `onAttemptMarkerWritten` fires SYNCHRONOUSLY on the replayer's own
+      // MainActor turn, right after the marker write and before the
+      // `Task.detached` retrieve is even created — revoking write access from
+      // inside it is guaranteed to land before any clear attempt, no race
+      // window to catch.
+      h.replayer.onAttemptMarkerWritten = { [spoolDir = h.spoolDir] in
+        _ = chmod(spoolDir.path, 0o500)
+      }
+      let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
       #expect(outcome == .deferredMarkerClearFailed)
       #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
       #expect((try? h.keyStore.retrieve(for: id)) != nil)

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -3,6 +3,7 @@ import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import Foundation
+import Security
 import Testing
 
 @testable import EnviousWisprAppKit
@@ -246,6 +247,84 @@ struct RecoverySpoolReplayerTests {
     #expect(h.transcriptCoordinator.transcripts.isEmpty)
     #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
   }
+
+  // MARK: - #1707 Phase 3 §3.3: Keychain transient-vs-terminal
+
+  #if DEBUG
+    @Test(
+      "a transient Keychain read status defers WITHOUT treating it as unrecoverable — spool retained, marker cleared"
+    )
+    func transientKeyReadDefers() async throws {
+      let h = Self.makeHarness()
+      let id = "transient-\(UUID().uuidString)"
+      try await Self.seedSpool(h, id: id, samples: [0.6])
+      DebugRecoveryKeyFaultController.shared.arm(status: errSecInteractionNotAllowed)
+      let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+      #expect(outcome == .deferred)
+      #expect(h.asr.transcribeCallCount == 0, "never reaches transcribe on a deferred key read")
+      #expect(h.transcriptCoordinator.transcripts.isEmpty)
+      // Bypass, not failure: the spool + key are retained for a retry, and the
+      // marker is cleared so a later attempt does not misread this as a
+      // crashed attempt (the exact regression this fix prevents).
+      #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+      #expect(
+        (try? h.keyStore.retrieve(for: id)) != nil, "the ARMED fault is one-shot and consumed")
+      #expect(!h.spoolStore.hasAttemptMarker(for: id), "marker cleared so a retry does not abandon")
+    }
+
+    @Test(
+      "a SECOND replay after a transient-deferred first attempt does NOT see a surviving marker (the exact regression this fix prevents)"
+    )
+    func secondReplayAfterTransientDeferralDoesNotAbandon() async throws {
+      let h = Self.makeHarness()
+      let id = "transient-retry-\(UUID().uuidString)"
+      try await Self.seedSpool(h, id: id, samples: [0.6])
+      DebugRecoveryKeyFaultController.shared.arm(status: errSecInteractionNotAllowed)
+      let first = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+      #expect(first == .deferred)
+      // No fault armed this time — the retry reads the REAL stored key.
+      let second = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+      #expect(
+        second == .recovered, "a clean retry succeeds — the marker never survived to abandon it")
+    }
+
+    @Test(
+      "errSecAuthFailed / errSecUserCanceled stay terminal — not treated as transient (§3.3's explicit exclusion)",
+      arguments: [errSecAuthFailed, errSecUserCanceled]
+    )
+    func excludedStatusesStayTerminal(status: OSStatus) async throws {
+      let h = Self.makeHarness()
+      let id = "terminal-\(UUID().uuidString)"
+      try await Self.seedSpool(h, id: id, samples: [0.6])
+      DebugRecoveryKeyFaultController.shared.arm(status: status)
+      let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+      #expect(
+        outcome == .failed(.unrecoverable),
+        "excluded statuses fall through to the existing terminal path")
+      #expect(h.asr.transcribeCallCount == 0)
+    }
+
+    @Test(
+      "a Keychain-transient marker-clear FAILURE returns .deferredMarkerClearFailed, distinct from plain .deferred"
+    )
+    func transientKeyReadWithMarkerClearFailure() async throws {
+      let h = Self.makeHarness()
+      let id = "transient-markerfail-\(UUID().uuidString)"
+      try await Self.seedSpool(h, id: id, samples: [0.3])
+      defer { _ = chmod(h.spoolDir.path, 0o700) }  // restore so temp cleanup/GC can proceed
+      DebugRecoveryKeyFaultController.shared.arm(status: errSecInteractionNotAllowed)
+      let replayTask = Task { await h.replayer.replay(recoverySessionID: id, isAborted: { false }) }
+      // Let the marker WRITE (needs a writable spool dir) land first, then
+      // revoke write access so the marker CLEAR the transient path triggers
+      // throws — deterministic ordering via a real signal, not a sleep.
+      while !h.spoolStore.hasAttemptMarker(for: id) { await Task.yield() }
+      _ = chmod(h.spoolDir.path, 0o500)
+      let outcome = await replayTask.value
+      #expect(outcome == .deferredMarkerClearFailed)
+      #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+      #expect((try? h.keyStore.retrieve(for: id)) != nil)
+    }
+  #endif
 
   @Test("Discard during transcribe drops the result — nothing saved (generation guard, R2)")
   func discardDuringTranscribeDropsResult() async throws {

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -1541,6 +1541,30 @@ def test_hands_free(audio=None, sentence=None, hold=4.0, expect=None, timeout=30
 def test_ptt(key=None, audio=None, sentence=None, expect=None, timeout=10.0):
     """End-to-end PTT (push-to-talk) recording test via key hold.
 
+    #1707 Phase 3 crash-safety-net Live UAT recipe (bounded-wait + refuse-
+    then-retry): no new helper is warranted here — compose the existing
+    low-level calls directly, per RULE: wispr-eyes-fallback-to-direct-python.
+    1. Stage 2+ crashed spools: start a recording, wait for recovery arming
+       (the recovery key/spool are written before the risky work), then
+       kill the app with `SIGKILL` from the shell (`pgrep -f "EnviousWispr
+       Local.app/Contents/MacOS/EnviousWispr"` -> `kill -9`); repeat once
+       more for a second spool.
+    2. Relaunch the app fresh (the measured THIRD launch is the actual test
+       run — the app must not already be running before this launch).
+    3. Immediately call `test_ptt()` (or `tap()`), before the scan can
+       finish item 1's decode.
+    4. Assert refusal: read the "recovering" pill via `see()`/`read()`, and
+       grep `~/Library/Logs/EnviousWispr/app.log` for `recoveryPressBlocked`.
+    5. Wait roughly one item's expected decode time (measured empirically
+       per backend), bounded — this is what the harness itself times to
+       prove the bounded-wait claim (press-to-engine-release, not
+       `Pipeline timing TOTAL`).
+    6. Call `test_ptt()` again; assert success and the expected token in
+       `observed_transcript`.
+    Direct fault injection (`EW_FAULT_INJECTION=1`, `force_recovery_key_fault
+    (status)`) stages the Keychain-transient-lock scenario, since it is not
+    reachable through normal TTS-driven dictation alone.
+
     Precisely times key hold to match audio duration:
     1. Press key down (recording starts)
     2. Wait for recording to engage


### PR DESCRIPTION
## Summary

Phase 3 of 3 for the Recovery V2 epic (#1707) — crash-safety-net readiness gating. Closes the epic.

- Recovery no longer blocks live dictation for a whole multi-item scan: a `EngineRecoveryGate` primitive gives recovery and every engine-mutating actor (unload, warm-up, switch, download, benchmark, legacy migration) a genuine atomic mutual-exclusion claim, and a live press now yields the engine between scan items instead of waiting for the entire scan.
- Fixes a real shipping bug (#1360): a transient Keychain read failure (e.g. device still locked at boot) used to be treated identically to a permanent one and the recoverable audio was deleted. It's now deferred and retried instead.
- Every actor that can load/unload/switch the ASR engine (27-row inventory, Codex-verified across the plan's grounded-review rounds) is now classified against recovery and either gated or documented as a proven-safe no-op.

## Accepted residual risks (documented, not silently dropped)

1. Engine-switch-vs-other-mutation exclusion remains open — a pre-existing gap this phase doesn't introduce or worsen (`isSwitching` had the same 3 consumers before and after). Tracked as a separate follow-up.
2. The Diagnostics Benchmark Suite's streaming-cancel-before-release fix is proven on the in-process path only, not the real production XPC path — confined to a `#if DEBUG`-gated tool absent from release builds.

Both are recorded in the plan doc with founder sign-off after four consecutive Grounded Review rounds found new defects in the same cluster (round 4's own instruction was to stop and consolidate rather than iterate a fifth time).

## Test plan

- [x] `scripts/xcode-test.sh` — full debug suite green (3492 tests)
- [x] Xcode release build (`EnviousWispr-Release`) — exit 0
- [x] `scripts/xcode-test.sh --release` — green (3214 tests)
- [x] Local Codex code-diff review — round 1 found 4 real defects (all fixed and independently verified against the live code), round 2 came back clean ("No actionable correctness issues were found in the diff")
- [x] Release-binary DEBUG-exclusion verified empirically via `nm`/`strings` on the compiled Release binary — the new fault-injection controller and its command literal are completely absent, not just unreachable at runtime
- [x] Live UAT on the rebuilt dev app:
  - Multi-launch SIGKILL spool staging (2-3 genuinely orphaned crash-recovery spools coexisting), confirming the scan handles a real multi-item backlog
  - A live recording pressed immediately after a staged crash-recovery backlog completes successfully with the correct transcript, both via recovery's own replay and via a fresh live press — heart path intact
  - Keychain-transient fault injection (`force_recovery_key_fault`, new DEBUG-only seam) directly observed causing the spool to be RETAINED (not deleted) on the faulted attempt, then correctly replayed on the next trigger once the fault clears
  - p99 single-item replay latency baseline captured (Parakeet, N=32 real samples, this same Live UAT session) — see production-health baseline below
  - **Honest gap:** in this dev environment (warm OS-level model caches from many repeated launches this session), a single-item replay consistently completes in ~1-2s — fast enough that an external CGEvent-driven press could not reliably be timed to land inside the refusal window and observe a genuine "recoveryPressBlocked" live. The exact denial-then-wake-then-retry sequence IS proven deterministically by the unit suite against a real `EngineRecoveryGate` instance (`gateDeniedRecoveryDefersWholeScan`, `gateReleaseThenRequestRecheckSucceeds`, the two-denial test); the Live UAT run instead directly proved the three claims that unit tests structurally cannot: real multi-item scan correctness, real Keychain-fault retention, and real heart-path correctness under live audio.

## Cloud review fix history

The GitHub cloud Codex review found 7 real, distinct issues on this PR, all fixed in follow-up commits (all independently verified against the live code before fixing, never blind-accepted):

1. A live recording's own retained failure (`.failed`, `.audioInterrupted`, etc.) could be immediately re-scanned and destructively replayed by that same session's own recovery wake-up.
2. `recovery.press_unblocked` telemetry understated real wait time — an impatient repeated refused press overwrote the wait-start timestamp toward zero each time.
3. The same telemetry could also count a press as "unblocked" before confirming the retry actually activated a session (a throw or a silent non-activation still emitted the event).
4. `DebugRecoveryKeyFaultController`'s one-shot fault had no session-ID scoping, so parallel Swift Testing suites could steal it from each other; a companion test used an unbounded poll that could hang (reproduced: ~2/3 of repeated runs failed before the fix, replaced with a deterministic synchronization hook).
5. My own fix for finding 1's sibling case (waking recovery when an engine switch settles) was itself a real regression: the "already converged" fast path it hooked into is ALSO reached via `.recoveryComplete`, fired after every replayed item — an unconditional wake there closed a loop for any retained outcome. **Reproduced as a genuine infinite loop** before fixing it (confirmed via a stuck, spinning test process), then fixed by gating the wake on an actual switching→idle phase transition.
6. `RecoveryCoordinator`'s per-item scan loop only checked a live-start yield signal between items, not after the final one — **also reproduced as a genuine infinite loop** (a live press refused during the last item's replay, combined with an unrelated wake-up cause, could spin forever). Fixed with a check after the loop.
7. A `.complete` dictation whose History save failed had no suppression path into the same-launch-rescan exclusion set, since the existing "ended without a save" signal only fires for non-`.complete` terminals. Fixed with a new, narrower suppression entry point. Confirmed as the last remaining gap of this SHAPE via a dedicated, independent Codex consult that enumerated all ~20 wake-up-triggering call sites and every retention-outcome case (`docs/audits/2026-07-21-phase3-wakeup-matrix-consult.txt`, not committed — gitignored per this repo's `docs/` convention). This one fix lacks a dedicated automated regression test (would need new kernel + TranscriptStore-failure integration harness); disclosed per `RULE: test-obligations` rather than silently claimed as covered.
8. Even with all of the above fixed, a record-press whose Task got QUEUED exactly at a scan's item boundary never got an actual scheduling turn to observe `isRecovering == false` — Swift's MainActor only switches tasks at a genuine suspension point, and the per-item loop had none between items. **Reproduced as a third genuine correctness gap** (item 2 was attempted despite the queued press "wanting" the engine); fixed with `await Task.yield()` at the top of each iteration, placed before the atomic check-and-claim handshake (not inside it, preserving that handshake's own no-suspension invariant).
9. The yield from finding 8 still wasn't sufficient: a real record-press's own start sequence (`beginMinting` → `preWarm` → recovery-arm) has its OWN internal suspension points before it reaches an active kernel session, and `isDictationActive` only reflects the latter — so recovery could still reclaim the engine for the next item during that narrower window, aborting the in-flight press when its own stale-gate re-check caught up. Fixed by adding a backend-agnostic `isMintingAnySession` signal to `EngineCoordinator` and OR'ing it into the `isDictationActive` check.
10. Unrelated to the wake-up-mechanism cluster above — a pre-existing gap in the ORIGINAL Phase 3 build (not introduced by fixes 1-9): `WhisperKitEngineAdapter`'s idle-unload claim-acquisition itself hops through `MainActor.run`, which is a suspension point between the pre-existing "final cancellation check" (added in an earlier Codex round for exactly this class of race) and the actual unload call — a `beginSession(B)` landing in that narrow window could still let a cancelled unload task fire against the new session. Fixed with a re-check immediately after acquiring the claim in both the immediate and timed-policy branches, releasing the claim (not leaking it) on the cancelled path. Reproduced directly (the unload fired without the fix) before fixing.

Findings 5, 6, and 8 were each independently reproduced as genuine hangs/incorrect-attempts (not just reasoned about) before being fixed — the fix-and-verify loop caught 3 separate regressions the review process itself introduced while closing the ORIGINAL findings, which is exactly what the review gate exists to catch.

Final local Codex code-diff review round (10th of this fix cycle): **"No actionable regressions were found... all 156 focused Swift tests passed."** Full suite green throughout (3499 tests after all fixes, up from 3492 at the PR's initial commit).

## Production-health baseline (§11.3)

Recorded before merge per the plan's own ship criteria (not before Gate 2, since it needs a real build to measure against).

**Parakeet single-item replay latency, N=32 real crash-staged samples:** min=1.0s, max=2.0s, mean=1.16s. **p99 baseline (smallest whole-second bucket containing ≥99% of samples): 2 seconds** — 27/32 samples (84%) completed in ≤1s, all 32/32 (100%) completed in ≤2s. This 2-second bucket is the ship bound for the post-release production-health check: post-release, ≥95% of `recovery.press_unblocked` events should fall within 2s to pass; <30 production samples in a review window is "insufficient data," not pass/fail.

WhisperKit backend baseline not captured this session (Parakeet is the default/active backend on this machine; capturing WhisperKit would require a backend switch plus its own warm-up cycle). Flagged here rather than silently omitted — a fast-follow if the founder wants WhisperKit's own number before relying on this baseline for that backend specifically.

## Related

- Epic: #1707
- Predecessor phases: #1711 (Phase 1), #1725 (Phase 2)
- Reopen candidate this phase resolves: #1360
- Governing plan: `docs/feature-requests/issue-1707-2026-07-20-recovery-v2-phase3-crash-safety-net.md` and `docs/feature-requests/plan-2026-07-19-recovery-v2-bible.md` (both local-only per this repo's `docs/` convention; mirrored into #1707 as content-hashed comments per the docs-durability ship criterion)


