### PR TITLE
chore(build): bump Sparkle 2.9.3 to 2.9.4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1e64e701c44afeabab312276102681de62de30bab71cbbfc9f54ba886bce8155",
+  "originHash" : "dfed2cdc877cc40115f0f7416fde8d7670121ce89284fee489b4769566811387",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
-        "version" : "2.9.3"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     },
     {


### PR DESCRIPTION
## What
Dependency version bump only: `Sparkle` 2.9.3 → 2.9.4. Found during an overnight dependency audit (WhisperKit is already current; the pinned FluidAudio fork is deliberately deferred — see the audit notes below).

## Why
Sparkle 2.9.4's single change is a fix for backgrounded/dockless apps not bringing windows to the front on a user-initiated update action ([sparkle-project/Sparkle#2890](https://github.com/sparkle-project/Sparkle/issues/2890)). EnviousWispr is a menu-bar/dockless app, exactly the class this fixes. No API surface change; `Package.swift`'s constraint (`from: "2.6.0"`) already permits this version.

## Validation
- `council-skip: zero-blast-radius (version bump, single dependency pin, no code change)`
- Self-audit-grep / Self-audit-owner in the commit body
- Full test suite: 3663 tests, 0 failures
- Dev build succeeded
