### PR TITLE
fix(model-delivery): duplicate manifest source IDs degrade instead of crashing

### DIFF
--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -63,7 +63,11 @@ public struct DeliveryFlags: Sendable {
       let wanted = sourceOrder.split(separator: ",").map {
         $0.trimmingCharacters(in: .whitespaces)
       }
-      let byID = Dictionary(uniqueKeysWithValues: sources.map { ($0.id, $0) })
+      // First-wins: a manifest with a duplicate source id must degrade, not
+      // trap (#1671). Every other branch here is fail-soft on bad input; a
+      // publishing typo on remote manifest data must not be the one line that
+      // crashes the app.
+      let byID = Dictionary(sources.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
       let reordered = wanted.compactMap { byID[$0] }
       if !reordered.isEmpty { sources = reordered }
     }

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
@@ -348,6 +348,37 @@ enum ManifestFixture {
     #expect(flags.orderedSources(from: manifest).map(\.id) == ["our_copy", "backup"])
   }
 
+  /// #1671: `orderedSources` indexed sources with a trapping
+  /// `Dictionary(uniqueKeysWithValues:)`. A manifest with a duplicate source
+  /// id must degrade (first-wins), not crash the app.
+  @Test func duplicateSourceIDDoesNotCrashAndFirstWins() throws {
+    let manifest = try ManifestFixture.manifest(
+      files: ManifestFixture.smallFiles)
+    let duplicated = DeliveryManifest(
+      schemaVersion: manifest.schemaVersion,
+      identity: manifest.identity,
+      files: manifest.files,
+      optionalFiles: manifest.optionalFiles,
+      totalBytes: manifest.totalBytes,
+      sources: [
+        DeliveryManifest.Source(
+          id: "our_copy", baseURL: try #require(URL(string: "https://first.invalid.example/"))),
+        DeliveryManifest.Source(
+          id: "our_copy", baseURL: try #require(URL(string: "https://second.invalid.example/"))),
+        manifest.sources[1],
+      ],
+      admission: manifest.admission,
+      manifestDigest: manifest.manifestDigest)
+    let d = defaults()
+    d.set("our_copy,backup", forKey: "modelDelivery.parakeet.sourceOrder")
+    let flags = DeliveryFlags.snapshot(family: .parakeet, defaults: d)
+    let ordered = flags.orderedSources(from: duplicated)
+    #expect(ordered.map(\.id) == ["our_copy", "backup"])
+    #expect(
+      ordered.first(where: { $0.id == "our_copy" })?.baseURL.absoluteString
+        == "https://first.invalid.example/")
+  }
+
   @Test func mirrorAndBackupKillSwitches() throws {
     let manifest = try ManifestFixture.manifest(files: ManifestFixture.smallFiles)
     let d = defaults()


### PR DESCRIPTION
Closes #1671

## What
`DeliveryFlags.orderedSources(from:)` indexed a manifest's sources with a trapping `Dictionary(uniqueKeysWithValues:)`. Two sources sharing an `id` in a published manifest would crash the app rather than degrade — the one exception to this function's otherwise fail-soft posture (a support-flag override that would empty the source list already falls back to manifest order; this line didn't get that treatment).

We author the manifest, so this isn't known to have happened, but the failure mode (crash on remote/untrusted-at-this-boundary data) doesn't match the file's own stated posture.

## Fix
First-wins uniquing via `Dictionary(_:uniquingKeysWith:)`. Verified the original construct actually traps (not just theoretically) via an isolated `swift -e` repro before writing the fix.

## Validation
- Reproduced the crash in isolation, confirmed the fix prevents it
- New test: `duplicateSourceIDDoesNotCrashAndFirstWins` (asserts first-wins ordering, not just absence-of-crash)
- Self-audit-grep: 3 remaining `Dictionary(uniqueKeysWithValues:)` sites are all test fixtures on test-authored data, out of scope
- Full suite: 3503 tests, 0 failures
- Dev build succeeded
