### PR TITLE
fix(build): dependency-direction allowlist missed ASR's Services edge from #1707 Phase 3

### DIFF
--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -9,7 +9,7 @@
 #   EnviousWisprAppKit     -> Core, Storage, PostProcessing, Audio, Services, ASR, LLM, Pipeline, Contacts (app-shell library; #919, top of stack)
 #   EnviousWisprASRService -> Core, ASR, Audio, ObservabilityCore (XPC executable; the audio capture XPC service was removed at #1543)
 #   EnviousWisprPipeline   -> Core, ASR, Audio, LLM, PostProcessing, Services, Storage
-#   EnviousWisprASR        -> Core, Audio, FluidAudioBridge
+#   EnviousWisprASR        -> Core, Audio, FluidAudioBridge, Services (idle-unload mutation guards emit via TelemetryService; #1707 Phase 3)
 #   EnviousWisprFluidAudioBridge -> (no app deps; internal FluidAudio vendor-error classifier leaf; #1525 PR I-B)
 #   EnviousWisprServices   -> Core, ObservabilityCore
 #   EnviousWisprLLM        -> Core, ModelDelivery
@@ -32,7 +32,7 @@ permitted_imports_for() {
     EnviousWisprObservabilityCore) echo "" ;;
     EnviousWisprAudio)             echo "EnviousWisprCore" ;;
     EnviousWisprFluidAudioBridge)  echo "" ;;
-    EnviousWisprASR)               echo "EnviousWisprCore EnviousWisprAudio EnviousWisprFluidAudioBridge" ;;
+    EnviousWisprASR)               echo "EnviousWisprCore EnviousWisprAudio EnviousWisprFluidAudioBridge EnviousWisprServices" ;;
     EnviousWisprPostProcessing)    echo "EnviousWisprCore" ;;
     EnviousWisprContacts)          echo "EnviousWisprCore" ;;
     EnviousWisprStorage)           echo "EnviousWisprCore" ;;


### PR DESCRIPTION
## Summary

`scripts/check-dependency-direction.sh`'s `EnviousWisprASR` allowlist was never updated when `Package.swift`/`Project.swift` added a legitimate, Codex-reviewed `EnviousWisprASR -> EnviousWisprServices` dependency (idle-unload mutation guards emitting via `TelemetryService.recoveryEngineActionDeferred`, shipped in PR #1732 / #1707 Phase 3). The script currently fails on `origin/main` itself — 3 violations — which blocks every local push project-wide via `check-push-discipline.sh`, regardless of what a given branch actually changes. Not run in CI (`.github/workflows/` has no reference to it), so this hasn't broken any GitHub check, only local pushes.

Fix: add `EnviousWisprServices` to the `EnviousWisprASR` allowlist, matching the already-declared and already-reviewed dependency in `Package.swift`.

## Test plan

- [x] Ran the real script directly (not simulated): 3 violations against unmodified `origin/main`, 0 after this fix
- [x] Full debug suite green (3690 tests)
- [x] Local Codex diff review: clean — "The allowlist now matches the existing dependency declarations in Package.swift and Project.swift. The dependency-direction check passes under macOS Bash 3.2."
- [x] Dev build succeeds

`council-skip: zero-blast-radius` (config-allowlist-sync — one value added to an existing allowlist string, syncing an already-reviewed and shipped architecture decision, no new logic or symbols).

## Related

Discovered while pushing an unrelated fix (#1710) and hitting this pre-existing, main-wide violation.
