### PR TITLE
fix(llm): whitespace-only cloud polish responses no longer report false success (#1710)

### DIFF
--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -212,7 +212,10 @@ public struct GeminiConnector: TranscriptPolisher {
       throw error
     }
 
-    guard !fullText.isEmpty else {
+    // Trimmed, not raw (#1710): see extractBatchResponseText's doc comment
+    // for why a whitespace/newline-only accumulation must not pass as a
+    // successful result.
+    guard !fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       statusForLog = "error_after_\(httpResponse.statusCode):empty_response"
       throw LLMError.emptyResponse
     }
@@ -264,46 +267,59 @@ public struct GeminiConnector: TranscriptPolisher {
     // call. The responseText empty-check is inside this do block because
     // an all-thought response still throws LLMError.emptyResponse and would
     // otherwise leak through with status=200.
-    let firstCandidate: [String: Any]
-    let responseText: String
+    let extracted: (text: String, finishReason: String?)
     do {
       if httpResponse.statusCode != 200 {
         let body = String(data: data, encoding: .utf8) ?? ""
         try handleHTTPError(statusCode: httpResponse.statusCode, body: body)
       }
 
-      let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-      guard let candidates = json?["candidates"] as? [[String: Any]],
-        let candidate = candidates.first,
-        let content = candidate["content"] as? [String: Any],
-        let candidateParts = content["parts"] as? [[String: Any]]
-      else {
-        throw LLMError.emptyResponse
-      }
-      let text =
-        candidateParts
-        .filter { $0["thought"] as? Bool != true }
-        .compactMap { $0["text"] as? String }
-        .joined()
-      guard !text.isEmpty else {
-        throw LLMError.emptyResponse
-      }
-      firstCandidate = candidate
-      responseText = text
+      extracted = try Self.extractBatchResponseText(from: data)
     } catch {
       statusForLog = "error_after_\(httpResponse.statusCode):\(Self.shortError(error))"
       throw error
     }
 
-    logTruncationIfNeeded(
-      finishReason: firstCandidate["finishReason"] as? String,
-      config: config
-    )
+    logTruncationIfNeeded(finishReason: extracted.finishReason, config: config)
 
     return LLMResult(
-      polishedText: responseText.trimmingCharacters(in: .whitespacesAndNewlines)
+      polishedText: extracted.text.trimmingCharacters(in: .whitespacesAndNewlines)
         .strippingLLMPreamble(stripTranscriptTags: false)
     )
+  }
+
+  /// Pure success-body parser for the non-streaming path (#1710, mirroring
+  /// `ClaudeConnector.extractResponseText`). Extracted out of `polishBatch`
+  /// so the emptiness edge case is unit-testable directly against `Data`
+  /// literals without a transport seam (neither Gemini nor Claude has one —
+  /// see `ClaudeConnectorTests.swift`).
+  ///
+  /// Emptiness is checked on the TRIMMED text, not the raw joined text: a
+  /// whitespace/newline-only response has a non-empty raw string but is a
+  /// successful-looking empty result once `polishBatch` trims it into the
+  /// final `LLMResult` — checking the untrimmed value here would let that
+  /// case through as a false "success" and hide a real provider failure
+  /// from the pipeline's fallback logic.
+  static func extractBatchResponseText(
+    from data: Data
+  ) throws -> (text: String, finishReason: String?) {
+    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    guard let candidates = json?["candidates"] as? [[String: Any]],
+      let candidate = candidates.first,
+      let content = candidate["content"] as? [String: Any],
+      let candidateParts = content["parts"] as? [[String: Any]]
+    else {
+      throw LLMError.emptyResponse
+    }
+    let text =
+      candidateParts
+      .filter { $0["thought"] as? Bool != true }
+      .compactMap { $0["text"] as? String }
+      .joined()
+    guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw LLMError.emptyResponse
+    }
+    return (text, candidate["finishReason"] as? String)
   }
 
   // MARK: - Shared

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -353,6 +353,13 @@ public struct OpenAIConnector: TranscriptPolisher {
   /// Parse a successful OpenAI 200 response into an LLMResult.
   /// Throws `LLMError.emptyResponse` on missing/empty content so the retry
   /// caller can mark statusForLog as error_after_200.
+  ///
+  /// Emptiness is checked on the TRIMMED content, not the raw string (#1710):
+  /// a whitespace/newline-only response has a non-empty raw string but is a
+  /// successful-looking empty result once this function trims it into the
+  /// final `LLMResult` — checking the untrimmed value would let that case
+  /// through as a false "success" and hide a real provider failure from the
+  /// pipeline's fallback logic. Mirrors `ClaudeConnector.extractResponseText`.
   private static func parseSuccess(
     data: Data, config: LLMProviderConfig
   ) throws -> LLMResult {
@@ -360,7 +367,7 @@ public struct OpenAIConnector: TranscriptPolisher {
     guard let choices = json?["choices"] as? [[String: Any]],
       let message = choices.first?["message"] as? [String: Any],
       let content = message["content"] as? String,
-      !content.isEmpty
+      !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     else {
       throw LLMError.emptyResponse
     }

--- a/Tests/EnviousWisprTests/LLM/GeminiResponseParsingTests.swift
+++ b/Tests/EnviousWisprTests/LLM/GeminiResponseParsingTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #1710 Gap 2: `extractBatchResponseText` is a pure success-body parser
+/// (mirroring `ClaudeConnector.extractResponseText`, Codex r6), extracted
+/// out of `GeminiConnector.polishBatch` specifically so this edge case is
+/// unit-testable directly against `Data` literals — neither Gemini nor
+/// Claude has an injectable transport seam (only `OpenAIConnector` does; see
+/// `ClaudeConnectorTests.swift`).
+@Suite("Gemini batch response parsing")
+struct GeminiResponseParsingTests {
+
+  private func responseJSON(
+    text: String, finishReason: String? = nil, thought: Bool = false
+  ) -> Data {
+    var part: [String: Any] = ["text": text]
+    if thought { part["thought"] = true }
+    var candidate: [String: Any] = ["content": ["parts": [part]]]
+    if let finishReason { candidate["finishReason"] = finishReason }
+    let payload: [String: Any] = ["candidates": [candidate]]
+    return try! JSONSerialization.data(withJSONObject: payload)
+  }
+
+  @Test func extractBatchResponseTextReturnsCleanText() throws {
+    let data = responseJSON(text: "Cleaned up dictation.")
+    let result = try GeminiConnector.extractBatchResponseText(from: data)
+    #expect(result.text == "Cleaned up dictation.")
+    #expect(result.finishReason == nil)
+  }
+
+  @Test func extractBatchResponseTextFlagsMaxTokensTruncation() throws {
+    let data = responseJSON(text: "This got cut off mid", finishReason: "MAX_TOKENS")
+    let result = try GeminiConnector.extractBatchResponseText(from: data)
+    #expect(result.text == "This got cut off mid")
+    #expect(result.finishReason == "MAX_TOKENS")
+  }
+
+  @Test func extractBatchResponseTextThrowsOnWhitespaceOnlyContent() {
+    // The raw joined text is non-empty ("   \n  "), so a check against the
+    // UNTRIMMED string would incorrectly treat this as success (#1710 Gap 2
+    // — the same shape the Codex r6 Claude fix targeted).
+    let data = responseJSON(text: "   \n  ")
+    #expect(throws: LLMError.self) {
+      try GeminiConnector.extractBatchResponseText(from: data)
+    }
+  }
+
+  @Test func extractBatchResponseTextThrowsOnAllThoughtResponse() {
+    let data = responseJSON(text: "internal reasoning only", thought: true)
+    #expect(throws: LLMError.self) {
+      try GeminiConnector.extractBatchResponseText(from: data)
+    }
+  }
+
+  @Test func extractBatchResponseTextThrowsOnMissingCandidates() {
+    let data = try! JSONSerialization.data(withJSONObject: ["promptFeedback": [:]])
+    #expect(throws: LLMError.self) {
+      try GeminiConnector.extractBatchResponseText(from: data)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/OpenAIParamStripTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAIParamStripTests.swift
@@ -155,6 +155,11 @@ struct OpenAIParamStripTests {
   private static let successBody = Data(
     #"{"choices": [{"message": {"content": "Polished."}, "finish_reason": "stop"}]}"#.utf8)
 
+  // The raw content is non-empty ("   \n  "), so a check against the
+  // UNTRIMMED string would incorrectly treat this as success (#1710 Gap 2).
+  private static let whitespaceOnlyBody = Data(
+    #"{"choices": [{"message": {"content": "   \n  "}, "finish_reason": "stop"}]}"#.utf8)
+
   private static func rejection(param: String) -> Data {
     Data(
       """
@@ -310,5 +315,26 @@ struct OpenAIParamStripTests {
       Issue.record("unexpected error: \(error)")
     }
     #expect(transport.requestCount == 0)
+  }
+
+  // MARK: - Empty/whitespace response (#1710 Gap 2)
+
+  @Test func whitespaceOnlyContentThrowsEmptyResponse() async {
+    let model = "gpt-4o-whitespace-\(UUID().uuidString)"
+    defer { OpenAIConnector.resetOmissions(model: model) }
+    let transport = ScriptedTransport(script: [
+      (Self.whitespaceOnlyBody, Self.response(200))
+    ])
+
+    do {
+      _ = try await connector(transport).polish(
+        text: "hello", instructions: .default, config: config(model: model), onToken: nil)
+      Issue.record("expected LLMError.emptyResponse")
+    } catch LLMError.emptyResponse {
+      // expected
+    } catch {
+      Issue.record("unexpected error: \(error)")
+    }
+    #expect(transport.requestCount == 1)
   }
 }


### PR DESCRIPTION
## Summary

Scoped to Gap 2 of #1710 only.

`OpenAIConnector.parseSuccess` and `GeminiConnector`'s batch/streaming response parsers checked emptiness on the RAW response string before trimming. A whitespace/newline-only response (e.g. `"   \n  "`) is non-empty as a raw string, so it passed the guard and was reported as a **successful** polish with an empty `polishedText` — hiding a real provider failure from the pipeline's fallback logic instead of surfacing it as `LLMError.emptyResponse`.

`ClaudeConnector` already had this exact bug and it was fixed during #158 (Codex r6) by checking the TRIMMED value instead. This PR ports that same fix to OpenAI and Gemini, which were explicitly left unchanged at the time (out of scope for "add Claude as a third provider") and tracked here as #1710.

- `OpenAIConnector.parseSuccess`: check trimmed content, not raw.
- `GeminiConnector`: fixed both the streaming path's `guard !fullText.isEmpty` and the batch path's `guard !text.isEmpty`.
- Extracted Gemini's batch parsing into a new `extractBatchResponseText` pure function (mirroring `ClaudeConnector.extractResponseText`'s shape) so the edge case is unit-testable directly against `Data` literals — neither Gemini nor Claude has an injectable transport seam (only `OpenAIConnector` does).

**Gap 1 (the `max_tokens`-truncation question) is intentionally NOT addressed here.** The issue itself flags it as needing real product/design input on whether truncated responses should be rejected-and-fallback vs. accept-with-warning, across all three providers uniformly — not an engineering call to make unilaterally. Left as open, unchanged behavior.

## Test plan

- [x] New regression tests, each independently proven RED against the pre-fix condition then GREEN against the fix (temporarily reverted just the two trimmed-check conditions, re-ran, restored):
  - `GeminiResponseParsingTests.extractBatchResponseTextThrowsOnWhitespaceOnlyContent` (+ 4 sibling cases: clean text, truncation flag, all-thought response, missing candidates)
  - `OpenAIParamStripTests.whitespaceOnlyContentThrowsEmptyResponse` (via the existing scripted-transport seam, through the real `polish()` entry point)
- [x] Full debug suite green (3696 tests)
- [x] Local Codex diff review: clean — "The changes consistently reject whitespace-only responses across Gemini streaming, Gemini batch, and OpenAI paths while preserving existing parsing and error handling. The added tests cover the relevant edge cases."
- [x] Existing `ClaudeConnectorTests` unaffected (24 tests, unchanged, still green)

**Live UAT not run.** This is a deterministic JSON-parsing edge case (a provider returning whitespace-only text) that isn't practically triggerable live, and the happy-path (non-whitespace) behavior is unchanged and covered by the full existing suite (including `OpenAIParamStripTests`'s existing success-path scripted-transport tests, still green). This is limb (polish), not heart-path.

## Related

- #1710 (Gap 2 only; Gap 1 left open pending a product decision)
- #158 (original Claude fix this mirrors)
