### PR TITLE
fix(user): renaming a built-in through the edit path no longer leaves it duplicated (#1670)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -960,6 +960,24 @@ public final class CustomWordsManager {
 
     var file = try loadFileForMutation()
 
+    // An edit that MOVES a built-in's canonical away has to retire the
+    // built-in too (mirrors the commitImport tombstone rule, #1668) —
+    // otherwise the built-in still matches no user word, so `mergedWords`
+    // keeps showing it beside the rename and the user gets two words where
+    // they edited one (#1670). A same-canonical edit (alias-only change)
+    // must NOT tombstone: the override already hides the built-in on its
+    // own, and recording a tombstone would persist a deletion the user never
+    // performed.
+    let previousCanonical = words[index].canonical
+    if let builtin = Self.builtinDefaults.first(where: {
+      $0.word.canonical.lowercased() == previousCanonical.lowercased()
+    }),
+      builtin.word.canonical.lowercased() != sanitized.canonical.lowercased(),
+      !file.deletedBuiltinIds.contains(builtin.id)
+    {
+      file.deletedBuiltinIds.append(builtin.id)
+    }
+
     // Check if this is a built-in word being edited — store as user override
     if let existingIdx = file.words.firstIndex(where: { $0.id == word.id }) {
       file.words[existingIdx] = sanitized

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
@@ -756,25 +756,120 @@ struct CustomWordsImportCommitTests {
     #expect(matching.first?.aliases.contains("fresh alias") == true)
   }
 
-  @Test("an import survives a library where a renamed built-in duplicates its own ID")
-  func importSurvivesDuplicateIDsFromARenamedBuiltin() throws {
-    let (manager, _) = makeManager()
+  @Test(
+    "renaming a built-in through update leaves exactly one word, not the built-in plus an override (#1670)"
+  )
+  func renamingABuiltinThroughUpdateRetiresTheBuiltinInsteadOfDuplicatingIt() throws {
+    let (manager, url) = makeManager()
     var live = try #require(manager.load())
     let builtin = try #require(live.first)
+    let originalCount = live.count
 
-    // Renaming a built-in stores a user override carrying the built-in's OWN
-    // UUID, while `mergedWords` keeps showing the built-in (its canonical no
-    // longer matches any user word). Within this process the two therefore
-    // share an id. A later re-read is what surfaces the pair to a caller.
-    //
-    // That duplicate is itself the bug in #1670, so the `count == 2` guard
-    // below is a precondition, not a desired outcome: fixing #1670 will make
-    // it fail. When that lands, keep the commit assertions and build the
-    // duplicate directly instead — this test defends commitImport against a
-    // non-unique list, whatever produced it.
     var renamed = builtin
     renamed.canonical = "\(builtin.canonical) Renamed"
     try manager.update(word: renamed, in: &live)
+
+    #expect(live.count == originalCount)
+    #expect(live.contains { $0.canonical == "\(builtin.canonical) Renamed" })
+    #expect(live.contains { $0.canonical == builtin.canonical } == false)
+
+    // Same duplicate-ID hazard `replacingABuiltinRetiresTheBuiltinInsteadOfDuplicatingIt`
+    // guards for commitImport: a reload must not resurface the built-in either.
+    let reloaded = try #require(manager.load())
+    #expect(reloaded.filter { $0.id == builtin.id }.count == 1)
+
+    // `deletedBuiltinIds` stores `BuiltinWord.id` (a stable string like
+    // "enviouswispr"), not the `CustomWord.id` UUID shown above — look up the
+    // matching entry by canonical to get the right key to check.
+    let matchingBuiltin = try #require(
+      CustomWordsManager.builtinDefaults.first {
+        $0.word.canonical.lowercased() == builtin.canonical.lowercased()
+      })
+    let file = try #require(
+      try? JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+    let tombstones = file["deletedBuiltinIds"] as? [String] ?? []
+    #expect(tombstones.contains(matchingBuiltin.id))
+  }
+
+  @Test("renaming a built-in then renaming it back leaves exactly one word (#1670 DoD)")
+  func renamingABuiltinThenRestoringItsOriginalNameLeavesExactlyOneWord() throws {
+    let (manager, _) = makeManager()
+    var live = try #require(manager.load())
+    let builtin = try #require(live.first)
+    let originalCount = live.count
+    let originalCanonical = builtin.canonical
+
+    var renamed = builtin
+    renamed.canonical = "\(originalCanonical) Renamed"
+    try manager.update(word: renamed, in: &live)
+
+    // Rename back to the built-in's original text. The built-in stays
+    // tombstoned (the identity is now this user override, not a restored
+    // built-in) — the DoD asks only that this behave sanely, i.e. exactly
+    // one word, never the duplicate-ID hazard the forward rename used to hit.
+    var restored = renamed
+    restored.canonical = originalCanonical
+    try manager.update(word: restored, in: &live)
+
+    #expect(live.count == originalCount)
+    let matching = live.filter { $0.canonical == originalCanonical }
+    #expect(matching.count == 1)
+
+    let reloaded = try #require(manager.load())
+    #expect(reloaded.filter { $0.id == builtin.id }.count == 1)
+  }
+
+  @Test(
+    "renaming a built-in's aliases through update, without moving its canonical, does not tombstone it (#1670)"
+  )
+  func updateWithoutRenamingLeavesTheBuiltinRestorable() throws {
+    let (manager, url) = makeManager()
+    var live = try #require(manager.load())
+    let builtin = try #require(live.first)
+    let originalCount = live.count
+
+    // Same canonical, new aliases: the override keeps hiding the built-in on
+    // its own, so recording a tombstone would persist a deletion the user
+    // never performed (mirrors replacingABuiltinWithoutRenamingLeavesItRestorable).
+    var edited = builtin
+    edited.aliases = builtin.aliases + ["extra alias"]
+    try manager.update(word: edited, in: &live)
+
+    #expect(live.count == originalCount)
+
+    let file = try #require(
+      try? JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+    let tombstones = file["deletedBuiltinIds"] as? [String] ?? []
+    #expect(tombstones.isEmpty)
+
+    let matching = live.filter { $0.canonical == builtin.canonical }
+    #expect(matching.count == 1)
+    #expect(matching.first?.aliases.contains("extra alias") == true)
+  }
+
+  @Test("an import survives a library where a duplicate ID was constructed directly")
+  func importSurvivesADirectlyConstructedDuplicateID() throws {
+    let (manager, url) = makeManager()
+    let live = try #require(manager.load())
+    let builtin = try #require(live.first)
+
+    // #1670 (fixed): renaming a built-in through `update` used to leave a
+    // user override carrying the built-in's OWN UUID while `mergedWords`
+    // kept showing the (no-longer-tombstoned) built-in too, so the two
+    // shared an id. That path is fixed now — `update` tombstones the
+    // built-in when the canonical moves away, so it can no longer produce
+    // this duplicate. `commitImport`'s defensive handling of a non-unique
+    // list is still worth proving, so construct the duplicate directly by
+    // writing it to disk rather than relying on a (fixed) bug to produce it.
+    struct RawFile: Codable {
+      var version = 1
+      var builtinsVersion = 1
+      var deletedBuiltinIds: [String] = []
+      var words: [CustomWord] = []
+    }
+    var renamed = builtin
+    renamed.canonical = "\(builtin.canonical) Renamed"
+    try JSONEncoder().encode(RawFile(words: [renamed])).write(to: url, options: [.atomic])
 
     let reloaded = try #require(manager.load())
     #expect(reloaded.filter { $0.id == builtin.id }.count == 2)


### PR DESCRIPTION
## Summary

`update(word:in:)` had no tombstone logic at all, unlike `commitImport`'s Replace path (#1668/F2b): renaming a built-in's canonical away left the built-in unmatched by any user word, so `mergedWords` kept showing it beside the user's rename — two words where the user edited one, sharing the built-in's own UUID within the same process (confirmed by an existing test's own left-behind comment: "That duplicate is itself the bug in #1670").

Fixed by porting the F2b tombstone rule to `update()`: when an edit moves a built-in's canonical away, retire the built-in in the same write. A same-canonical edit (alias-only) must NOT tombstone — the override already hides the built-in on its own, and recording a tombstone would persist a deletion the user never performed.

## Test plan

- [x] Rewrote `CustomWordsImportCommitTests.importSurvivesDuplicateIDsFromARenamedBuiltin` per its own left-behind instructions: the fix makes its `update`-produced duplicate impossible, so the duplicate is now constructed directly (raw disk write matching the file format) to keep proving `commitImport`'s defensive handling of a non-unique list, independent of what produces one.
- [x] Three new tests added, covering the fix directly and the issue's own DoD items:
  - Renaming a built-in through `update` tombstones it and leaves exactly one word
  - An alias-only edit (same canonical) does NOT tombstone
  - Renaming then renaming back to the original name behaves sanely (exactly one word, no duplicate-ID resurfacing)
- [x] Every new/changed assertion proven genuinely RED against the pre-fix code (temporarily reverted just the tombstone block, re-ran, restored) before being accepted
- [x] Full debug suite green (3699 tests)
- [x] Local Codex diff review: clean — "The update path now mirrors the existing import behavior by tombstoning a built-in only when its canonical name changes, while preserving alias-only edits."

## Related

- #1670
- #1668 (the commitImport tombstone rule this mirrors)
