### PR TITLE
fix(user): one shared decision answers alias-collision ownership for both import screens (#1672)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsImportCompareEngine.swift
@@ -490,11 +490,16 @@ package actor CustomWordsImportCompareEngine {
   /// no trim while this file trimmed, so on malformed or legacy decoded data the
   /// two disagreed about what a key even was.
   ///
-  /// So precedence is no longer mirrored here at all. `WordCorrector` owns what
-  /// a trigger key is and who wins it; this function asks it for the incoming
-  /// candidate's claims and reads incumbent winners out of its index. It never
-  /// lowercases, strips spaces, classifies single versus multi, or replays
-  /// corrector precedence — doing any of that is the defect this ends.
+  /// So precedence is no longer mirrored here at all. `WordCorrector` owns both
+  /// what a trigger key is (`ExactTriggerIndex`) AND the decision of whether a
+  /// given alias collides and who wins (`resolveAliasOwnership`, #1672). This
+  /// function builds the planned index, applies participating candidates' own
+  /// canonicals to it, and asks that one shared function for each alias's
+  /// answer — it never lowercases, strips spaces, classifies single versus
+  /// multi, replays corrector precedence, or re-derives blocker/decisive-owner
+  /// selection itself. `CustomWordsManager.enforceAliases` calls the identical
+  /// function; doing either of those things here again is the defect this
+  /// ends.
   ///
   /// What remains local is IMPORT-BATCH disposition, which is not corrector
   /// state: incoming canonicals reserve their claims first-wins, then each
@@ -540,8 +545,6 @@ package actor CustomWordsImportCompareEngine {
     existingWords: [CustomWord],
     participatingCandidateIDs: Set<UUID>
   ) throws -> [UUID: [CustomWordsImportAliasCollision]] {
-    typealias Owner = WordCorrector.TriggerOwner
-
     // Effective incumbent ownership, already resolved, then every PARTICIPATING
     // incoming canonical applied on top under the SAME rules the commit path
     // and the corrector use.
@@ -556,22 +559,8 @@ package actor CustomWordsImportCompareEngine {
     for candidate in coalesced where participatingCandidateIDs.contains(candidate.id) {
       plannedOwners.applyCanonical(
         candidate.canonical,
-        owner: Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false))
-    }
-
-    /// The owner that would beat `candidate` to this surface, if any.
-    ///
-    /// Holding a key is not always intercepting it, so every hit is checked
-    /// against the authority before it counts as a blocker: a no-space owner
-    /// whose canonical the surface already spells declines to substitute, and
-    /// naming it would point the user at a word that never touches their text.
-    func blocker(
-      of claim: WordCorrector.ExactTriggerClaim, surface: String, for candidate: UUID
-    ) -> Owner? {
-      guard let holder = plannedOwners.owner(of: claim), holder.wordID != candidate
-      else { return nil }
-      return WordCorrector.ownerIntercepts(claim: claim, rawSurface: surface, owner: holder)
-        ? holder : nil
+        owner: WordCorrector.TriggerOwner(
+          wordID: candidate.id, canonical: candidate.canonical, isPack: false))
     }
 
     var collisions: [UUID: [CustomWordsImportAliasCollision]] = [:]
@@ -579,38 +568,33 @@ package actor CustomWordsImportCompareEngine {
       try Task.checkCancellation()
       guard case .supplied(let sourceAliases) = candidate.aliases else { continue }
       for alias in sourceAliases {
-        let claims = WordCorrector.exactClaims(forAlias: alias)
-        if claims.isEmpty { continue }
-
-        // Evaluate every claim BEFORE registering any of them (atomicity).
-        let blockers = claims.compactMap { claim in
-          blocker(of: claim, surface: alias, for: candidate.id).map { (claim: claim, owner: $0) }
-        }
-
-        guard blockers.isEmpty else {
-          // The earliest-running surface is the one that actually intercepts.
-          let decisive = blockers.min {
-            $0.claim.namespace.passPriority < $1.claim.namespace.passPriority
-          }
-          if let decisive {
-            collisions[candidate.id, default: []].append(
-              CustomWordsImportAliasCollision(alias: alias, heldBy: decisive.owner.wordID))
-          }
+        // Blocker detection, decisive-owner selection, and the "holding a key
+        // isn't always intercepting it" gate are no longer restated here —
+        // `resolveAliasOwnership` is the one shared answer both this preview
+        // and the commit path (`CustomWordsManager.enforceAliases`) call, so
+        // there is nothing left in either file to drift apart again (#1672).
+        switch plannedOwners.resolveAliasOwnership(for: alias, excludingOwnerID: candidate.id) {
+        case .noClaims:
           continue
+        case .blocked(let owner):
+          collisions[candidate.id, default: []].append(
+            CustomWordsImportAliasCollision(alias: alias, heldBy: owner.wordID))
+        case .available(let claims):
+          // Only a PARTICIPATING candidate's surviving alias becomes a future
+          // blocker: an exact/variant/fuzzy match's alias is disclosed above
+          // for preview, but it is never persisted as a fresh word, so it
+          // must not shadow a later candidate the way a real addition would.
+          guard participatingCandidateIDs.contains(candidate.id) else { continue }
+
+          // Gap-fill, never overwrite — same rule as the commit path. An
+          // alias reaching here unblocked may still sit behind a compound
+          // holder that simply declines to intercept, and that holder keeps
+          // the slot.
+          plannedOwners.gapFill(
+            claims,
+            owner: WordCorrector.TriggerOwner(
+              wordID: candidate.id, canonical: candidate.canonical, isPack: false))
         }
-
-        // Only a PARTICIPATING candidate's surviving alias becomes a future
-        // blocker: an exact/variant/fuzzy match's alias is disclosed above for
-        // preview, but it is never persisted as a fresh word, so it must not
-        // shadow a later candidate the way a real addition would.
-        guard participatingCandidateIDs.contains(candidate.id) else { continue }
-
-        // Gap-fill, never overwrite — same rule as the commit path. An alias
-        // reaching here unblocked may still sit behind a compound holder that
-        // simply declines to intercept, and that holder keeps the slot.
-        plannedOwners.gapFill(
-          claims,
-          owner: Owner(wordID: candidate.id, canonical: candidate.canonical, isPack: false))
       }
     }
     return collisions

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -807,13 +807,16 @@ public final class CustomWordsManager {
   static func enforceAliases(
     on words: [CustomWord], touchedOrder: [UUID]
   ) -> (words: [CustomWord], dropped: [CustomWordsImportAliasCollision]) {
-    // Ownership comes from `WordCorrector`, not from a third copy of its rules
-    // (#1667). This function used to mirror them itself, keyed on
-    // `importPersistenceKey`, which has no no-space surface at all — so an
-    // imported alias equal to an existing multi-word canonical's space-free
-    // form was KEPT here even once the compare screen had learned to disclose
-    // it. The screen said one thing and the commit did another; the alias was
-    // saved and then never fired.
+    // Ownership DATA comes from `WordCorrector` (#1667), and the collision
+    // DECISION comes from its `resolveAliasOwnership` (#1672) — the same
+    // function `CustomWordsImportCompareEngine.detectAliasCollisions` calls.
+    // This function used to mirror both itself, keyed on `importPersistenceKey`
+    // (no no-space surface at all, so an imported alias equal to an existing
+    // multi-word canonical's space-free form was KEPT here even once the
+    // compare screen had learned to disclose it), then later restated the
+    // shared blocker/decisive-owner logic as its own local copy. Doing either
+    // again is the defect this ends: the screen said one thing and the commit
+    // did another, twice, before this.
     var result = words
     // Last wins, and the list must not be assumed id-unique. Renaming a
     // built-in stores a user override carrying the built-in's OWN id while
@@ -847,16 +850,6 @@ public final class CustomWordsManager {
     }
     var index = WordCorrector.buildExactTriggerIndex(words: ownershipSeed)
 
-    /// The owner that would beat this word to a surface, if any. Holding a key
-    /// is not always intercepting it — see `WordCorrector.ownerIntercepts`.
-    func blocker(
-      of claim: WordCorrector.ExactTriggerClaim, surface: String, for wordID: UUID
-    ) -> WordCorrector.TriggerOwner? {
-      guard let holder = index.owner(of: claim), holder.wordID != wordID else { return nil }
-      return WordCorrector.ownerIntercepts(claim: claim, rawSurface: surface, owner: holder)
-        ? holder : nil
-    }
-
     var dropped: [CustomWordsImportAliasCollision] = []
     for id in touchedOrder {
       guard let wordIndex = indexByID[id] else { continue }
@@ -869,35 +862,30 @@ public final class CustomWordsManager {
         // reported — it is not an ambiguity anyone needs to hear about.
         if importPersistenceKey(alias) == canonicalKey { continue }
 
-        let claims = WordCorrector.exactClaims(forAlias: alias)
-        if claims.isEmpty { continue }
-
-        // Evaluate every claim before registering any: the stored alias is the
-        // unit kept or dropped, so a partially-registered alias that is then
-        // dropped would leave an owner that does not exist and wrongly block a
-        // later one. Same atomicity rule the compare engine follows.
-        let blockers = claims.compactMap { claim in
-          blocker(of: claim, surface: alias, for: word.id).map { (claim: claim, owner: $0) }
-        }
-        if let decisive = blockers.min(by: {
-          $0.claim.namespace.passPriority < $1.claim.namespace.passPriority
-        }) {
-          dropped.append(
-            CustomWordsImportAliasCollision(alias: alias, heldBy: decisive.owner.wordID))
+        // Blocker detection, decisive-owner selection, and the "holding a key
+        // isn't always intercepting it" gate are no longer restated here —
+        // `resolveAliasOwnership` is the one shared answer both this commit
+        // path and the preview (`CustomWordsImportCompareEngine`) call, so
+        // there is nothing left in either file to drift apart again (#1672).
+        switch index.resolveAliasOwnership(for: alias, excludingOwnerID: word.id) {
+        case .noClaims:
           continue
+        case .blocked(let owner):
+          dropped.append(CustomWordsImportAliasCollision(alias: alias, heldBy: owner.wordID))
+        case .available(let claims):
+          // Gap-fill, never overwrite. An alias reaches here unblocked for one
+          // of three reasons: nobody holds the key, this word already holds
+          // it, or a compound holder declines to intercept. In that last case
+          // the holder must STAY registered, because at runtime an alias only
+          // ever fills an empty compound slot. Overwriting handed the key to
+          // the wrong word.
+          index.gapFill(
+            claims,
+            owner: WordCorrector.TriggerOwner(
+              wordID: word.id, canonical: word.canonical, isPack: false)
+          )
+          kept.append(alias)
         }
-
-        // Gap-fill, never overwrite. An alias reaches here unblocked for one of
-        // three reasons: nobody holds the key, this word already holds it, or a
-        // compound holder declines to intercept. In that last case the holder
-        // must STAY registered, because at runtime an alias only ever fills an
-        // empty compound slot. Overwriting handed the key to the wrong word.
-        index.gapFill(
-          claims,
-          owner: WordCorrector.TriggerOwner(
-            wordID: word.id, canonical: word.canonical, isPack: false)
-        )
-        kept.append(alias)
       }
       result[wordIndex].aliases = kept
     }

--- a/Sources/EnviousWisprPostProcessing/WordCorrector.swift
+++ b/Sources/EnviousWisprPostProcessing/WordCorrector.swift
@@ -215,6 +215,21 @@ public struct WordCorrector: Sendable {
     package let existingCanonical: String
   }
 
+  /// The three possible answers to "does this alias collide against a planned
+  /// ownership index, and who wins" (#1672). Not persisted, not Codable — a
+  /// pure in-memory decision value scoped to one compare/commit pass.
+  package enum ExactAliasOwnershipResolution: Sendable, Equatable {
+    /// The alias normalizes to no exact-trigger claims at all (e.g. empty).
+    case noClaims
+    /// Nothing intercepts this alias — every claim is either unheld, held
+    /// only by the excluded owner, or held by a compound owner that
+    /// declines to intercept. Carries the claims so the caller can gap-fill
+    /// them under its own ownership if it decides to keep this alias.
+    case available(claims: [ExactTriggerClaim])
+    /// The earliest-intercepting held claim blocks this alias.
+    case blocked(by: TriggerOwner)
+  }
+
   /// Effective incumbent ownership, after every overwrite and gap-fill rule has
   /// already been applied. Consumers read winners; they never replay precedence.
   package struct ExactTriggerIndex: Sendable {
@@ -269,6 +284,43 @@ public struct WordCorrector: Sendable {
       for claim in claims where self.owner(of: claim) == nil {
         register(claim, to: owner)
       }
+    }
+
+    /// The single shared answer to "does this alias collide, and who wins" —
+    /// called by BOTH the import preview
+    /// (`CustomWordsImportCompareEngine.detectAliasCollisions`) and the import
+    /// commit (`CustomWordsManager.enforceAliases`). Neither consumer may
+    /// re-derive blocker detection or decisive-owner selection locally; both
+    /// call this and branch only on the returned case (#1672).
+    ///
+    /// Read-only: does not mutate `self`. Registration (`gapFill`) remains the
+    /// caller's explicit, separate responsibility in the `.available` branch —
+    /// preserving the existing atomicity rule that a partially-registered
+    /// alias must never be created (evaluate fully, THEN register).
+    ///
+    /// `excludingOwnerID` is the word/candidate whose own claim on a key must
+    /// never count as blocking itself — an existing `CustomWord.id` for the
+    /// commit path, a not-yet-saved `CustomWordsImportCandidate.id` for the
+    /// preview path. Both are `UUID`; the exclusion semantics are identical
+    /// either way ("this owner's own claim cannot block its own alias").
+    package func resolveAliasOwnership(
+      for alias: String, excludingOwnerID: UUID
+    ) -> ExactAliasOwnershipResolution {
+      let claims = WordCorrector.exactClaims(forAlias: alias)
+      guard !claims.isEmpty else { return .noClaims }
+
+      let blockers = claims.compactMap {
+        claim -> (claim: ExactTriggerClaim, owner: TriggerOwner)? in
+        guard let holder = owner(of: claim), holder.wordID != excludingOwnerID else { return nil }
+        return WordCorrector.ownerIntercepts(claim: claim, rawSurface: alias, owner: holder)
+          ? (claim, holder) : nil
+      }
+      if let decisive = blockers.min(by: {
+        $0.claim.namespace.passPriority < $1.claim.namespace.passPriority
+      }) {
+        return .blocked(by: decisive.owner)
+      }
+      return .available(claims: claims)
     }
 
     /// The ordinary-namespace maps in `buildLookups`' shape, optionally limited

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsImportCommitTests.swift
@@ -504,6 +504,37 @@ struct CustomWordsImportCommitTests {
     #expect(receipt.droppedAliasCollisions.count == 1)
   }
 
+  @Test(
+    "a key held by both an existing alias and an existing canonical names the alias owner on commit"
+  )
+  func keyHeldByBothAnExistingAliasAndCanonicalReportsTheAliasOwnerOnCommit() throws {
+    // #1672's originally-requested proof, mirroring the existing preview-side
+    // test `CustomWordsImportCompareEngineTests.keyHeldByBothAnExistingAliasAndCanonicalReportsTheAliasOwner`.
+    // The corrector builds every alias into the lookup FIRST, then skips any
+    // canonical whose key an alias already owns — so when both kinds of owner
+    // exist, the alias owner is the real holder. Before #1672, the commit path
+    // and the preview screen answered this differently.
+    let (manager, _) = makeManager()
+    var live = try seed(
+      manager,
+      [
+        CustomWord(canonical: "Annie"),
+        CustomWord(canonical: "Anika", aliases: ["annie"]),
+      ])
+    let aliasHolder = try #require(live.first { $0.canonical == "Anika" })
+
+    let receipt = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Zed", aliases: .supplied(["Annie"]))]),
+      to: &live)
+
+    #expect(
+      receipt.droppedAliasCollisions == [
+        CustomWordsImportAliasCollision(alias: "Annie", heldBy: aliasHolder.id)
+      ])
+    #expect(try #require(live.first { $0.canonical == "Zed" }).aliases.isEmpty)
+    #expect(try #require(live.first { $0.canonical == "Anika" }).aliases == ["annie"])
+  }
+
   @Test("an alias equal to its own canonical is removed silently, not reported")
   func aliasEqualToItsOwnCanonicalIsSilentlyRemovedNotReportedAsADrop() throws {
     let (manager, _) = makeManager()

--- a/Tests/EnviousWisprTests/PostProcessing/ExactTriggerIndexTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ExactTriggerIndexTests.swift
@@ -224,4 +224,92 @@ struct ExactTriggerIndexTests {
       WordCorrector.ExactTriggerNamespace.multi.passPriority
         < WordCorrector.ExactTriggerNamespace.single.passPriority)
   }
+
+  // MARK: - resolveAliasOwnership (#1672)
+  //
+  // The shared decision both `CustomWordsImportCompareEngine` and
+  // `CustomWordsManager` call instead of each hand-rolling their own blocker
+  // detection and decisive-owner selection.
+
+  @Test("resolveAliasOwnership returns blocked when a single alias-holder intercepts")
+  func resolveAliasOwnershipBlockedBySingleHolder() {
+    let owner = CustomWord(canonical: "Anika", aliases: ["annie"])
+    let index = WordCorrector.buildExactTriggerIndex(words: [owner])
+    let ownerID = try! #require(index.single["annie"]?.wordID)
+
+    let resolution = index.resolveAliasOwnership(for: "Annie", excludingOwnerID: UUID())
+    #expect(resolution == .blocked(by: .init(wordID: ownerID, canonical: "Anika", isPack: false)))
+  }
+
+  @Test("resolveAliasOwnership returns available when nobody holds the key")
+  func resolveAliasOwnershipAvailableWhenUnclaimed() {
+    let index = WordCorrector.buildExactTriggerIndex(words: [CustomWord(canonical: "Anika")])
+    let resolution = index.resolveAliasOwnership(for: "Zed", excludingOwnerID: UUID())
+    guard case .available(let claims) = resolution else {
+      Issue.record("expected .available, got \(resolution)")
+      return
+    }
+    #expect(!claims.isEmpty)
+  }
+
+  @Test("resolveAliasOwnership excludes the given owner id from counting as a blocker")
+  func resolveAliasOwnershipExcludesOwnOwner() {
+    let owner = CustomWord(canonical: "Anika", aliases: ["annie"])
+    let index = WordCorrector.buildExactTriggerIndex(words: [owner])
+    let ownerID = try! #require(index.single["annie"]?.wordID)
+
+    let resolution = index.resolveAliasOwnership(for: "Annie", excludingOwnerID: ownerID)
+    guard case .available = resolution else {
+      Issue.record("expected .available when excluding the key's own holder, got \(resolution)")
+      return
+    }
+  }
+
+  @Test("resolveAliasOwnership returns noClaims for an empty alias")
+  func resolveAliasOwnershipNoClaimsForEmptyAlias() {
+    // `exactClaims(forAlias:)` lowercases but does NOT trim whitespace — a
+    // whitespace-only alias like "   " is NOT empty after lowercasing and
+    // yields a real `.multi` claim, not `.noClaims`. Only the literal empty
+    // string produces zero claims.
+    let index = WordCorrector.ExactTriggerIndex()
+    #expect(index.resolveAliasOwnership(for: "", excludingOwnerID: UUID()) == .noClaims)
+  }
+
+  @Test("resolveAliasOwnership names the earliest-intercepting namespace's owner")
+  func resolveAliasOwnershipPrefersEarliestNamespace() {
+    // "New York" claims both the .multi surface ("new york") and the .nospace
+    // surface ("newyork"). Register two DIFFERENT owners on those two keys, so
+    // whichever one the resolution names proves which namespace actually wins.
+    let multiOwner = WordCorrector.TriggerOwner(
+      wordID: UUID(), canonical: "Multi Owner", isPack: false)
+    let nospaceOwner = WordCorrector.TriggerOwner(
+      wordID: UUID(), canonical: "Nospace Owner", isPack: false)
+
+    var index = WordCorrector.ExactTriggerIndex()
+    index.register(.init(key: "new york", namespace: .multi), to: multiOwner)
+    index.register(.init(key: "newyork", namespace: .nospace), to: nospaceOwner)
+
+    let resolution = index.resolveAliasOwnership(for: "New York", excludingOwnerID: UUID())
+    #expect(resolution == .blocked(by: nospaceOwner), "nospace runs Pass 0, before multi's Pass 1")
+  }
+
+  @Test("resolveAliasOwnership skips a non-intercepting holder and finds the real blocker")
+  func resolveAliasOwnershipSkipsNonInterceptingHolder() {
+    // The no-space owner's OWN canonical already spells the surface, so Pass 0
+    // declines to substitute (`ownerIntercepts`) — the real blocker is the
+    // .multi owner, which DOES intercept.
+    let nospaceOwner = WordCorrector.TriggerOwner(
+      wordID: UUID(), canonical: "New York", isPack: false)
+    let multiOwner = WordCorrector.TriggerOwner(
+      wordID: UUID(), canonical: "Other Word", isPack: false)
+
+    var index = WordCorrector.ExactTriggerIndex()
+    index.register(.init(key: "newyork", namespace: .nospace), to: nospaceOwner)
+    index.register(.init(key: "new york", namespace: .multi), to: multiOwner)
+
+    let resolution = index.resolveAliasOwnership(for: "New York", excludingOwnerID: UUID())
+    #expect(
+      resolution == .blocked(by: multiOwner),
+      "the declining no-space holder must not shadow the real, intercepting blocker")
+  }
 }


### PR DESCRIPTION
## Summary
- Preview (`CustomWordsImportCompareEngine.detectAliasCollisions`) and commit (`CustomWordsManager.enforceAliases`) each hand-wrote their own blocker-detection and decisive-owner-selection logic around the shared `WordCorrector.ExactTriggerIndex` data #1667 already unified. Third recorded divergence of this exact class in the epic.
- Extracts one shared function, `WordCorrector.ExactTriggerIndex.resolveAliasOwnership(for:excludingOwnerID:)`, that both consumers call instead of re-deriving the decision. Both old hand-rolled copies are deleted outright, not left beside the new function.
- Closes the coverage gap #1672 originally asked for: adds the commit-path proof (alias-over-canonical precedence) mirroring the existing preview-side test.

## Plan
`docs/feature-requests/issue-1672-2026-07-21-collision-ownership-front-desk.md` — 5 review rounds (4 grounded, 1 holistic zoom-out; Codex standing in for council per founder instruction), final verdict AGREE.

## Test plan
- [x] Full test suite: 3706 tests, zero failures
- [x] All 87 pre-existing collision tests (`CustomWordsImportCompareEngineTests`, `CustomWordsImportCommitTests`) pass unchanged
- [x] 7 new tests added (6 direct `resolveAliasOwnership` cases + 1 commit-path DoD test), all passing
- [x] Local Codex code-diff review: clean, no findings
- [x] Live UAT: passed against the rebuilt dev app — import review screen correctly names the real alias-holding word, not the canonical-match row or any other word
- [x] Ship-criteria greps confirm zero decision-copy remnants and exactly one `resolveAliasOwnership` call site per consumer

Closes #1672