### PR TITLE
feat(user): import competitors' misspellings as aliases (#1706)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -612,9 +612,9 @@ private struct ImportSmartAppPickerScreen: View {
       }
 
       // Says the honest shape of the migration before they commit to it: this
-      // brings words across, not the corrections that map onto them.
+      // brings words across WITH the alternate spellings that correct them.
       Text(
-        "Words come across on their own. Alternate spellings you set up in the other app stay there."
+        "Words come across with the alternate spellings you set up in the other app."
       )
       .font(.stHelper)
       .foregroundStyle(.stTextSecondary)

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -612,9 +612,12 @@ private struct ImportSmartAppPickerScreen: View {
       }
 
       // Says the honest shape of the migration before they commit to it: this
-      // brings words across WITH the alternate spellings that correct them.
+      // brings NEW words across WITH the alternate spellings that correct
+      // them. Every match against a word already in the library is Skip-only
+      // (CustomWordsImportReviewRow.allowedDecisions) — this sentence must
+      // not read as a promise to enrich those (GitHub cloud review, PR #1748).
       Text(
-        "Words come across with the alternate spellings you set up in the other app."
+        "New words come across with the alternate spellings you set up in the other app."
       )
       .font(.stHelper)
       .foregroundStyle(.stTextSecondary)

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -412,13 +412,26 @@ package struct SmartImportSource: CustomWordsImportSource {
         found: words.count, limit: CustomWordsImportLimits.maximumCandidates)
     }
 
+    // Trim aliases up front so both the ceiling below and candidate
+    // construction judge the same values that would actually get stored —
+    // matching CustomWordsImportCandidate.storedValues's own rule (judge the
+    // trimmed value, since that is what gets saved). Counting raw,
+    // pre-trim aliases let a FluidVoice term padded with blank/whitespace-only
+    // alias slots trip this ceiling on values that were always going to be
+    // dropped and never stored (GitHub cloud review, PR #1748).
+    let trimmedAliasesByIndex = words.map { word in
+      word.aliases
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+    }
+
     // A second, new ceiling: total stored surface (canonical + every alias),
     // not just row count. FluidVoice's real schema can attach an unbounded
     // alias array to one term, which the row-count check above cannot see.
     // Same all-or-nothing shape as the sibling ceiling above, reusing the
     // error family the Upload path already established for this concern.
-    let storedValueCount = words.reduce(into: 0) { count, word in
-      count += 1 + word.aliases.count
+    let storedValueCount = trimmedAliasesByIndex.reduce(into: 0) { count, aliases in
+      count += 1 + aliases.count
     }
     guard storedValueCount <= CustomWordsImportLimits.maximumExportedStoredValues else {
       throw ImportFileError.tooManyStoredValues(
@@ -430,12 +443,9 @@ package struct SmartImportSource: CustomWordsImportSource {
     // downstream — the existing, already-tested owner of "should these merge"
     // (§3c) — rather than re-deciding it locally with a different key.
     var canonicals: [CustomWordsImportCandidate] = []
-    for word in words {
+    for (word, aliases) in zip(words, trimmedAliasesByIndex) {
       let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
       guard !CustomWordsImportCompareEngine.normalize(trimmed).isEmpty else { continue }
-      let aliases = word.aliases
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
       canonicals.append(
         CustomWordsImportCandidate(
           canonical: trimmed,

--- a/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
+++ b/Sources/EnviousWisprPostProcessing/SmartImportSource.swift
@@ -34,10 +34,22 @@ package protocol SmartImportAdapter: Sendable {
   var displayName: String { get }
   /// Where this app keeps vocabulary, in probe order.
   var candidatePaths: [URL] { get }
-  /// Read the canonical words. Aliases are deliberately NOT returned: v1
-  /// import carries the main word only (founder rule), so an adapter that
-  /// harvested synonyms would be supplying data the pipeline must discard.
-  func loadWords(at url: URL) throws -> [String]
+  /// Read the canonical words, alongside any misspelling the source app
+  /// itself records as correcting to that word.
+  func loadWords(at url: URL) throws -> [SmartImportWord]
+}
+
+/// One word an adapter found, with the human-typed misspelling it corrects
+/// FROM, if the source app records one. `aliases` is always an array — plural
+/// because FluidVoice supplies a real list; Superwhisper and Wispr Flow only
+/// ever produce at most one.
+package struct SmartImportWord: Sendable, Equatable {
+  package let canonical: String
+  package let aliases: [String]
+  package init(canonical: String, aliases: [String] = []) {
+    self.canonical = canonical
+    self.aliases = aliases
+  }
 }
 
 extension SmartImportAdapter {
@@ -86,7 +98,10 @@ package struct FluidVoiceAdapter: SmartImportAdapter {
   package let displayName = "FluidVoice"
 
   private struct Vocabulary: Decodable {
-    struct Term: Decodable { let text: String }
+    struct Term: Decodable {
+      let text: String
+      let aliases: [String]?
+    }
     let terms: [Term]?
   }
 
@@ -100,13 +115,15 @@ package struct FluidVoiceAdapter: SmartImportAdapter {
 
   package init() {}
 
-  package func loadWords(at url: URL) throws -> [String] {
+  package func loadWords(at url: URL) throws -> [SmartImportWord] {
     let data = try boundedData(at: url, appName: displayName)
     guard let vocabulary = try? JSONDecoder().decode(Vocabulary.self, from: data) else {
       throw SmartImportError.unreadable(displayName)
     }
     // `terms` absent entirely is a legitimate fresh install, not a failure.
-    return (vocabulary.terms ?? []).map(\.text)
+    return (vocabulary.terms ?? []).map {
+      SmartImportWord(canonical: $0.text, aliases: $0.aliases ?? [])
+    }
   }
 }
 
@@ -119,7 +136,10 @@ package struct SuperwhisperAdapter: SmartImportAdapter {
   package let displayName = "Superwhisper"
 
   private struct Settings: Decodable {
-    struct Replacement: Decodable { let with: String? }
+    struct Replacement: Decodable {
+      let with: String?
+      let original: String?
+    }
     let vocabulary: [String]?
     let replacements: [Replacement]?
   }
@@ -140,16 +160,23 @@ package struct SuperwhisperAdapter: SmartImportAdapter {
 
   package init() {}
 
-  package func loadWords(at url: URL) throws -> [String] {
+  package func loadWords(at url: URL) throws -> [SmartImportWord] {
     let data = try boundedData(at: url, appName: displayName)
     guard let settings = try? JSONDecoder().decode(Settings.self, from: data) else {
       throw SmartImportError.unreadable(displayName)
     }
     // A replacement is a find/replace pair; its `with` side is the spelling
-    // the user actually wants, which is the word worth bringing across. The
-    // `original` side is the alias, and v1 does not import aliases.
-    let corrected = (settings.replacements ?? []).compactMap(\.with)
-    return (settings.vocabulary ?? []) + corrected
+    // the user actually wants, which is the word worth bringing across; its
+    // `original` side, when present, is the misspelling that prompted it.
+    let plain = (settings.vocabulary ?? []).map { SmartImportWord(canonical: $0) }
+    let corrected = (settings.replacements ?? []).compactMap { replacement -> SmartImportWord? in
+      guard let with = replacement.with?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !with.isEmpty
+      else { return nil }
+      let alias = replacement.original?.trimmingCharacters(in: .whitespacesAndNewlines)
+      return SmartImportWord(canonical: with, aliases: (alias?.isEmpty == false) ? [alias!] : [])
+    }
+    return plain + corrected
   }
 }
 
@@ -169,17 +196,25 @@ package struct WisprFlowAdapter: SmartImportAdapter {
 
   package init() {}
 
-  package func loadWords(at url: URL) throws -> [String] {
+  package func loadWords(at url: URL) throws -> [SmartImportWord] {
     // isDeleted: a soft-delete flag. Importing unfiltered would resurrect
     // words the user deliberately removed — the single worst thing this
     // adapter could do.
     // isSnippet: text expansions are a different feature, not vocabulary.
     // `replacement` is the corrected spelling when present; `phrase` is the
-    // alias in that case, and v1 does not import aliases.
+    // misspelling that prompted it, carried across as an alias.
+    //
+    // `ORDER BY id` is new: a bare `LIMIT` with no order leaves SQLite's row
+    // order unspecified, and "the same word claimed as an alias by two
+    // different corrected spellings" needs a real, stable "earlier" for that
+    // to mean anything. `id` (VARCHAR(36) PRIMARY KEY) is ordered, not
+    // `rowid` — this table's PK does not alias `rowid`, and an unaliased
+    // `rowid` is not guaranteed persistent across a `VACUUM`.
     let sql = """
-      SELECT COALESCE(NULLIF(TRIM(replacement), ''), phrase)
+      SELECT phrase, replacement
       FROM Dictionary
       WHERE isDeleted = 0 AND isSnippet = 0
+      ORDER BY id COLLATE BINARY ASC
       LIMIT \(CustomWordsImportLimits.maximumCandidates + 1)
       """
 
@@ -280,13 +315,25 @@ package struct WisprFlowAdapter: SmartImportAdapter {
     return words
   }
 
-  private func readWords(from statement: OpaquePointer?) throws -> [String] {
+  private func readWords(from statement: OpaquePointer?) throws -> [SmartImportWord] {
 
-    var words: [String] = []
+    var words: [SmartImportWord] = []
     var result = sqlite3_step(statement)
     while result == SQLITE_ROW {
-      if let text = sqlite3_column_text(statement, 0) {
-        words.append(String(cString: text))
+      guard let phraseText = sqlite3_column_text(statement, 0) else {
+        result = sqlite3_step(statement)
+        continue
+      }
+      let phrase = String(cString: phraseText)
+      let replacement = sqlite3_column_text(statement, 1).map { String(cString: $0) }
+      // `.whitespacesAndNewlines` also strips tabs/newlines, unlike the
+      // ASCII-space-only `TRIM()` this replaced — matching the trim already
+      // used everywhere else in this file.
+      let trimmedReplacement = replacement?.trimmingCharacters(in: .whitespacesAndNewlines)
+      if let trimmedReplacement, !trimmedReplacement.isEmpty {
+        words.append(SmartImportWord(canonical: trimmedReplacement, aliases: [phrase]))
+      } else {
+        words.append(SmartImportWord(canonical: phrase))
       }
       result = sqlite3_step(statement)
     }
@@ -365,25 +412,38 @@ package struct SmartImportSource: CustomWordsImportSource {
         found: words.count, limit: CustomWordsImportLimits.maximumCandidates)
     }
 
-    // Reuse the shared splitter's normalization so a competitor's list dedups
-    // exactly the way a pasted one does, and trim/blank handling is identical.
-    var seen = Set<String>()
-    var canonicals: [String] = []
+    // A second, new ceiling: total stored surface (canonical + every alias),
+    // not just row count. FluidVoice's real schema can attach an unbounded
+    // alias array to one term, which the row-count check above cannot see.
+    // Same all-or-nothing shape as the sibling ceiling above, reusing the
+    // error family the Upload path already established for this concern.
+    let storedValueCount = words.reduce(into: 0) { count, word in
+      count += 1 + word.aliases.count
+    }
+    guard storedValueCount <= CustomWordsImportLimits.maximumExportedStoredValues else {
+      throw ImportFileError.tooManyStoredValues(
+        found: storedValueCount, limit: CustomWordsImportLimits.maximumExportedStoredValues)
+    }
+
+    // Trim and drop blanks only; no merge here. Two rows resolving to the
+    // same word are left for `CustomWordsImportCompareEngine.coalesceDuplicates`
+    // downstream — the existing, already-tested owner of "should these merge"
+    // (§3c) — rather than re-deciding it locally with a different key.
+    var canonicals: [CustomWordsImportCandidate] = []
     for word in words {
-      let trimmed = word.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else { continue }
-      let key = CustomWordsImportCompareEngine.normalize(trimmed)
-      guard !key.isEmpty, seen.insert(key).inserted else { continue }
-      canonicals.append(trimmed)
+      let trimmed = word.canonical.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !CustomWordsImportCompareEngine.normalize(trimmed).isEmpty else { continue }
+      let aliases = word.aliases
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+      canonicals.append(
+        CustomWordsImportCandidate(
+          canonical: trimmed,
+          aliases: aliases.isEmpty ? .unspecified : .supplied(aliases)))
     }
 
     return CustomWordsImportBatch(
-      sourceID: adapter.identifier,
-      sourceDisplayName: adapter.displayName,
-      // Main word only, every authority field unspecified — the same contract
-      // paste and plain text honour. A competitor's synonyms are not imported
-      // in v1, so an existing word is skipped rather than modified.
-      candidates: canonicals.map { CustomWordsImportCandidate(canonical: $0) }
-    )
+      sourceID: adapter.identifier, sourceDisplayName: adapter.displayName,
+      candidates: canonicals)
   }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -29,8 +29,8 @@ struct SmartImportSourceTests {
 
   // MARK: - FluidVoice
 
-  @Test("FluidVoice terms are read and its tuning parameters ignored")
-  func fluidVoiceReadsOnlyTerms() throws {
+  @Test("FluidVoice terms carry their own aliases array across as the word's aliases")
+  func fluidVoiceReadsTermsWithAliases() throws {
     // Real shape: the keys beside `terms` are that app's ASR tuning knobs.
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
@@ -38,10 +38,17 @@ struct SmartImportSourceTests {
       """
       { "alpha": 2.8, "minCtcScore": -2.2, "minSimilarity": 0.72, "minTermLength": 3,
         "terms": [ { "text": "FluidVoice", "aliases": ["fluid voice"], "weight": 10.0 },
-                   { "text": "Kubernetes", "aliases": [], "weight": 1.0 } ] }
+                   { "text": "Kubernetes", "aliases": [], "weight": 1.0 },
+                   { "text": "NoAliasKey", "weight": 1.0 } ] }
       """, to: dir, as: "v.json")
 
-    #expect(try FluidVoiceAdapter().loadWords(at: url) == ["FluidVoice", "Kubernetes"])
+    #expect(
+      try FluidVoiceAdapter().loadWords(at: url)
+        == [
+          SmartImportWord(canonical: "FluidVoice", aliases: ["fluid voice"]),
+          SmartImportWord(canonical: "Kubernetes", aliases: []),
+          SmartImportWord(canonical: "NoAliasKey", aliases: []),
+        ])
   }
 
   @Test("a FluidVoice file with no terms key is a fresh install, not a failure")
@@ -52,24 +59,141 @@ struct SmartImportSourceTests {
     #expect(try FluidVoiceAdapter().loadWords(at: url).isEmpty)
   }
 
+  @Test("FluidVoice aliases present as a non-array refuses the whole import")
+  func fluidVoiceAliasesAsNonArrayRefusesTheWholeImport() throws {
+    // Newly-recognized field, newly validated: before this plan, an unknown
+    // shape here was silently ignored. Now a malformed value is treated the
+    // same as any other unreadable file, not a partial/best-effort read.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "Kubernetes", "aliases": "k8s" } ] }"#, to: dir, as: "v.json")
+
+    #expect(throws: SmartImportError.unreadable("FluidVoice")) {
+      _ = try FluidVoiceAdapter().loadWords(at: url)
+    }
+  }
+
+  @Test("a non-string element inside FluidVoice aliases refuses the whole import")
+  func fluidVoiceNonStringAliasElementRefusesTheWholeImport() throws {
+    // A distinct malformed shape from "aliases is not an array" — the array
+    // itself decodes, but one of its elements does not.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "Kubernetes", "aliases": ["k8s", 8] } ] }"#, to: dir, as: "v.json")
+
+    #expect(throws: SmartImportError.unreadable("FluidVoice")) {
+      _ = try FluidVoiceAdapter().loadWords(at: url)
+    }
+  }
+
+  @Test("a term with no aliases key maps to .unspecified downstream, not .supplied([])")
+  func fluidVoiceTermWithNoAliasesKeyMapsToUnspecifiedDownstream() async throws {
+    // Strengthens the adapter-level `aliases == []` assertion above (§8's
+    // three-way distinction: no opinion vs. authoritative-empty vs. found).
+    // "This source found no misspelling" must never become "this source
+    // asserts zero aliases" once it reaches the shared candidate type.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "NoAliasKey", "weight": 1.0 } ] }"#, to: dir, as: "v.json")
+
+    struct Fixed: SmartImportAdapter {
+      let identifier = "fluidvoice"
+      let displayName = "FluidVoice"
+      let url: URL
+      var candidatePaths: [URL] { [url] }
+      func loadWords(at url: URL) throws -> [SmartImportWord] {
+        try FluidVoiceAdapter().loadWords(at: url)
+      }
+    }
+
+    let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
+    let candidate = try #require(batch.candidates.first)
+    #expect(candidate.canonical == "NoAliasKey")
+    #expect(candidate.aliases == .unspecified)
+  }
+
   // MARK: - Superwhisper
 
-  @Test("Superwhisper reads plain vocabulary and the corrected side of replacements")
-  func superwhisperReadsVocabularyAndReplacementTargets() throws {
+  @Test("Superwhisper vocabulary entries import with no alias")
+  func superwhisperPlainVocabularyHasNoAlias() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "favoriteModelIDs": ["vad-v2"], "vocabulary": ["Saurabh"] }"#, to: dir,
+      as: "settings.json"
+    )
+
+    #expect(try SuperwhisperAdapter().loadWords(at: url) == [SmartImportWord(canonical: "Saurabh")])
+  }
+
+  @Test("a Superwhisper replacement carries its original as the alias")
+  func superwhisperReplacementCarriesOriginalAsAlias() throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try write(
       """
-      { "favoriteModelIDs": ["vad-v2"],
-        "replacements": [ { "id": "A", "original": "super whisper", "with": "Superwhisper" } ],
-        "vocabulary": ["Superwhisper", "Saurabh"] }
+      { "replacements": [ { "id": "A", "original": "super whisper", "with": "Superwhisper" } ] }
       """, to: dir, as: "settings.json")
 
-    // The `with` side is the spelling the user actually wants. `original` is
-    // the alias, and v1 does not import aliases.
     #expect(
       try SuperwhisperAdapter().loadWords(at: url)
-        == ["Superwhisper", "Saurabh", "Superwhisper"])
+        == [SmartImportWord(canonical: "Superwhisper", aliases: ["super whisper"])])
+  }
+
+  @Test("a Superwhisper replacement missing original has no alias")
+  func superwhisperReplacementMissingOriginalHasNoAlias() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "replacements": [ { "id": "A", "with": "Superwhisper" } ] }"#, to: dir,
+      as: "settings.json")
+
+    #expect(
+      try SuperwhisperAdapter().loadWords(at: url) == [SmartImportWord(canonical: "Superwhisper")])
+  }
+
+  @Test("a Superwhisper replacement missing with is dropped, as today")
+  func superwhisperReplacementMissingWithIsDropped() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "replacements": [ { "id": "A", "original": "super whisper" } ] }"#, to: dir,
+      as: "settings.json")
+
+    #expect(try SuperwhisperAdapter().loadWords(at: url).isEmpty)
+  }
+
+  @Test(
+    "a Superwhisper replacement with an empty or whitespace-only with is dropped at the adapter")
+  func superwhisperReplacementBlankWithIsDroppedAtTheAdapter() throws {
+    // Previously this row was still emitted by the adapter and dropped one
+    // hop later by SmartImportSource's own trim/blank filter; the outcome is
+    // unchanged, but the filtering now happens here (§3, Grounded Review r3/r4).
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      """
+      { "replacements": [ { "id": "A", "original": "x", "with": "" },
+                           { "id": "B", "original": "y", "with": "   " } ] }
+      """, to: dir, as: "settings.json")
+
+    #expect(try SuperwhisperAdapter().loadWords(at: url).isEmpty)
+  }
+
+  @Test("Superwhisper original present as a non-string value refuses the whole import")
+  func superwhisperMalformedOriginalRefusesTheWholeImport() throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "replacements": [ { "id": "A", "original": 8, "with": "Superwhisper" } ] }"#, to: dir,
+      as: "settings.json")
+
+    #expect(throws: SmartImportError.unreadable("Superwhisper")) {
+      _ = try SuperwhisperAdapter().loadWords(at: url)
+    }
   }
 
   @Test("a Superwhisper file missing both keys reads as empty")
@@ -138,7 +262,7 @@ struct SmartImportSourceTests {
     let url = try makeWisprFlowDatabase(in: dir)
 
     let words = try WisprFlowAdapter().loadWords(at: url)
-    #expect(!words.contains("deleted word"))
+    #expect(!words.map(\.canonical).contains("deleted word"))
   }
 
   @Test("Wispr Flow skips text-expansion snippets")
@@ -148,33 +272,163 @@ struct SmartImportSourceTests {
     let url = try makeWisprFlowDatabase(in: dir)
 
     // Snippets are a different feature, not vocabulary.
-    let words = try WisprFlowAdapter().loadWords(at: url)
+    let words = try WisprFlowAdapter().loadWords(at: url).map(\.canonical)
     #expect(!words.contains("my long signature"))
     #expect(!words.contains("sig"))
   }
 
-  @Test("Wispr Flow takes the corrected spelling when there is one")
-  func wisprFlowPrefersReplacementOverPhrase() throws {
+  @Test("Wispr Flow takes the corrected spelling as canonical and the phrase as its alias")
+  func wisprFlowPrefersReplacementOverPhraseAndCarriesPhraseAsAlias() throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try makeWisprFlowDatabase(in: dir)
 
     let words = try WisprFlowAdapter().loadWords(at: url)
-    // `btw → by the way`: the corrected side is the word worth having.
-    #expect(words.contains("by the way"))
-    #expect(!words.contains("btw"))
-    // No replacement at all: the phrase itself is the word.
-    #expect(words.contains("Wispr Flow"))
+    // `btw → by the way`: the corrected side is the word worth having, and
+    // the misspelling that prompted it comes across as the alias.
+    #expect(words.contains(SmartImportWord(canonical: "by the way", aliases: ["btw"])))
+    // No replacement at all: the phrase itself is the word, with no alias.
+    #expect(words.contains(SmartImportWord(canonical: "Wispr Flow")))
   }
 
-  @Test("a whitespace-only replacement falls back to the phrase")
+  @Test("a whitespace-only replacement falls back to the phrase with no alias")
   func wisprFlowTreatsBlankReplacementAsAbsent() throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try makeWisprFlowDatabase(in: dir)
 
     // An empty-but-present replacement would otherwise import a blank word.
-    #expect(try WisprFlowAdapter().loadWords(at: url).contains("blank replacement"))
+    let words = try WisprFlowAdapter().loadWords(at: url)
+    #expect(words.contains(SmartImportWord(canonical: "blank replacement")))
+  }
+
+  @Test("a tab-only replacement falls back to the phrase, unlike the old SQL TRIM")
+  func wisprFlowTabOnlyReplacementFallsBackToPhrase() throws {
+    // SQLite's TRIM() (the old single-column query) strips ASCII spaces only,
+    // so a tab-only replacement would have stayed as a non-empty (whitespace)
+    // canonical under the exact old semantics. `.whitespacesAndNewlines` also
+    // strips tabs, matching every other trim call in this file — a
+    // deliberate, disclosed broadening (§3).
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("flow.sqlite")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    defer { sqlite3_close(db) }
+    let schema = """
+      CREATE TABLE Dictionary (id VARCHAR(36) PRIMARY KEY, phrase VARCHAR(255) NOT NULL,
+        replacement VARCHAR(255), isDeleted TINYINT DEFAULT 0, isSnippet TINYINT DEFAULT 0);
+      INSERT INTO Dictionary VALUES ('1','tab word','	',0,0);
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+
+    let words = try WisprFlowAdapter().loadWords(at: url)
+    #expect(words == [SmartImportWord(canonical: "tab word")])
+  }
+
+  @Test("a self-referential Wispr Flow row still emits the alias at this layer")
+  func wisprFlowSelfReferentialRowStillEmitsTheAliasHere() throws {
+    // Not filtered at the adapter layer — the existing downstream
+    // `enforceAliases` rule absorbs a self-referential alias at commit time
+    // (§2.5.4, §7). Filtering it here would duplicate that authority.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("flow.sqlite")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    defer { sqlite3_close(db) }
+    let schema = """
+      CREATE TABLE Dictionary (id VARCHAR(36) PRIMARY KEY, phrase VARCHAR(255) NOT NULL,
+        replacement VARCHAR(255), isDeleted TINYINT DEFAULT 0, isSnippet TINYINT DEFAULT 0);
+      INSERT INTO Dictionary VALUES ('1','Superwhisper','Superwhisper',0,0);
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+
+    let words = try WisprFlowAdapter().loadWords(at: url)
+    #expect(words == [SmartImportWord(canonical: "Superwhisper", aliases: ["Superwhisper"])])
+  }
+
+  @Test("Wispr Flow orders by the row's own stored id, not insertion order")
+  func wisprFlowOrdersByStoredIdNotInsertionOrder() throws {
+    // A bare LIMIT with no ORDER BY leaves row order unspecified, and the
+    // alias-collision case (§7) needs a real, stable "earlier" for that to
+    // mean anything. Inserted in the OPPOSITE order from `id` on purpose, to
+    // prove the output follows the stored id rather than insertion sequence.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("flow.sqlite")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    defer { sqlite3_close(db) }
+    let schema = """
+      CREATE TABLE Dictionary (id VARCHAR(36) PRIMARY KEY, phrase VARCHAR(255) NOT NULL,
+        replacement VARCHAR(255), isDeleted TINYINT DEFAULT 0, isSnippet TINYINT DEFAULT 0);
+      INSERT INTO Dictionary VALUES ('z','zebra word',NULL,0,0);
+      INSERT INTO Dictionary VALUES ('a','alpha word',NULL,0,0);
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+
+    let canonicals = try WisprFlowAdapter().loadWords(at: url).map(\.canonical)
+    let alphaIndex = try #require(canonicals.firstIndex(of: "alpha word"))
+    let zebraIndex = try #require(canonicals.firstIndex(of: "zebra word"))
+    #expect(alphaIndex < zebraIndex)
+  }
+
+  @Test("phrase NOT NULL guarantees a value exists, not that it is non-blank")
+  func wisprFlowBlankPhraseIsPassedThroughAtThisLayer() throws {
+    // NOT NULL does not forbid an empty string. Downstream blank-filtering in
+    // `SmartImportSource.loadRawCandidates()` produces no candidate for a row
+    // like this, same as any other blank canonical — that is a separate,
+    // already-covered guarantee (§9), not this adapter's job.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("flow.sqlite")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    defer { sqlite3_close(db) }
+    let schema = """
+      CREATE TABLE Dictionary (id VARCHAR(36) PRIMARY KEY, phrase VARCHAR(255) NOT NULL,
+        replacement VARCHAR(255), isDeleted TINYINT DEFAULT 0, isSnippet TINYINT DEFAULT 0);
+      INSERT INTO Dictionary VALUES ('1','',NULL,0,0);
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+
+    let words = try WisprFlowAdapter().loadWords(at: url)
+    #expect(words == [SmartImportWord(canonical: "")])
+  }
+
+  @Test("a blank or whitespace-only phrase produces no candidate downstream")
+  func wisprFlowBlankOrWhitespacePhraseProducesNoDownstreamCandidate() async throws {
+    // Proves the §9 guarantee end to end, not just that the adapter passes
+    // the row through unfiltered: `SmartImportSource.loadRawCandidates()`'s
+    // own blank-filter is what actually absorbs this, same as any other
+    // blank canonical.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("flow.sqlite")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    defer { sqlite3_close(db) }
+    let schema = """
+      CREATE TABLE Dictionary (id VARCHAR(36) PRIMARY KEY, phrase VARCHAR(255) NOT NULL,
+        replacement VARCHAR(255), isDeleted TINYINT DEFAULT 0, isSnippet TINYINT DEFAULT 0);
+      INSERT INTO Dictionary VALUES ('1','',NULL,0,0);
+      INSERT INTO Dictionary VALUES ('2','   ',NULL,0,0);
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+
+    struct Fixed: SmartImportAdapter {
+      let identifier = "wispr-flow"
+      let displayName = "Wispr Flow"
+      let url: URL
+      var candidatePaths: [URL] { [url] }
+      func loadWords(at url: URL) throws -> [SmartImportWord] {
+        try WisprFlowAdapter().loadWords(at: url)
+      }
+    }
+
+    let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
+    #expect(batch.candidates.isEmpty)
   }
 
   @Test("a half-recovered database is refused rather than written into")
@@ -254,15 +508,15 @@ struct SmartImportSourceTests {
       let identifier = "missing"
       let displayName = "Nothing"
       var candidatePaths: [URL] { [URL(fileURLWithPath: "/nonexistent/nope.json")] }
-      func loadWords(at url: URL) throws -> [String] { [] }
+      func loadWords(at url: URL) throws -> [SmartImportWord] { [] }
     }
     await #expect(throws: SmartImportError.appNotFound("Nothing")) {
       _ = try await SmartImportSource(adapter: Missing()).loadCandidates()
     }
   }
 
-  @Test("imported words carry no authority over any field")
-  func candidatesClaimNoAuthority() async throws {
+  @Test("an imported word carries its source alias as authoritative")
+  func importedWordsCarryTheirSourceAliasAsAuthoritative() async throws {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try write(
@@ -273,7 +527,7 @@ struct SmartImportSourceTests {
       let displayName = "FluidVoice"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [String] {
+      func loadWords(at url: URL) throws -> [SmartImportWord] {
         try FluidVoiceAdapter().loadWords(at: url)
       }
     }
@@ -281,18 +535,70 @@ struct SmartImportSourceTests {
     let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
     let candidate = try #require(batch.candidates.first)
 
-    // v1 imports the main word only. Even though FluidVoice HAS aliases for
-    // this term, they are not brought across — so an existing word is skipped
-    // rather than modified.
+    // This is the whole point of this phase: a source-provided alias is now
+    // carried across as `.supplied`, not discarded.
     #expect(candidate.canonical == "Kubernetes")
-    #expect(candidate.aliases == .unspecified)
-    #expect(candidate.category == .unspecified)
-    #expect(candidate.suggestedAliases.isEmpty)
+    #expect(candidate.aliases == .supplied(["k8s"]))
     #expect(batch.sourceID == "fluidvoice")
   }
 
-  @Test("duplicates across an app's own lists collapse once")
-  func duplicatesCollapseUsingTheSharedKey() async throws {
+  @Test("an imported word claims no authority over any other field")
+  func importedWordsClaimNoAuthorityOverAnyOtherField() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "Kubernetes", "aliases": ["k8s"] } ] }"#, to: dir, as: "v.json")
+
+    struct Fixed: SmartImportAdapter {
+      let identifier = "fluidvoice"
+      let displayName = "FluidVoice"
+      let url: URL
+      var candidatePaths: [URL] { [url] }
+      func loadWords(at url: URL) throws -> [SmartImportWord] {
+        try FluidVoiceAdapter().loadWords(at: url)
+      }
+    }
+
+    let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
+    let candidate = try #require(batch.candidates.first)
+
+    // Only aliases changed by this plan (§2.2). Every other authority field
+    // stays exactly as unopinionated as it was before this phase.
+    #expect(candidate.category == .unspecified)
+    #expect(candidate.priority == .unspecified)
+    #expect(candidate.forceReplace == .unspecified)
+    #expect(candidate.caseSensitive == .unspecified)
+    #expect(candidate.minSimilarityOverride == .unspecified)
+    #expect(candidate.suggestedAliases.isEmpty)
+  }
+
+  @Test("an alias that is whitespace-only is dropped, never carried as .supplied([\"\"])")
+  func whitespaceOnlyAliasIsDroppedNotSuppliedEmpty() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "Kubernetes", "aliases": ["   "] } ] }"#, to: dir, as: "v.json")
+
+    struct Fixed: SmartImportAdapter {
+      let identifier = "fluidvoice"
+      let displayName = "FluidVoice"
+      let url: URL
+      var candidatePaths: [URL] { [url] }
+      func loadWords(at url: URL) throws -> [SmartImportWord] {
+        try FluidVoiceAdapter().loadWords(at: url)
+      }
+    }
+
+    let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
+    let candidate = try #require(batch.candidates.first)
+    #expect(candidate.aliases == .unspecified)
+  }
+
+  @Test("duplicate rows are no longer merged at this layer")
+  func duplicateRowsAreNotMergedAtThisLayer() async throws {
+    // Merging same-canonical rows within one batch is now entirely
+    // `CustomWordsImportCompareEngine.coalesceDuplicates`'s job, downstream
+    // of this source (§3c). This layer emits every trimmed row as-is.
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try write(
@@ -306,15 +612,73 @@ struct SmartImportSourceTests {
       let displayName = "Superwhisper"
       let url: URL
       var candidatePaths: [URL] { [url] }
-      func loadWords(at url: URL) throws -> [String] {
+      func loadWords(at url: URL) throws -> [SmartImportWord] {
         try SuperwhisperAdapter().loadWords(at: url)
       }
     }
 
     let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
-    // Same normalization the paste and file paths use, so a competitor list
-    // dedups exactly the way a typed one does.
-    #expect(batch.candidates.map(\.canonical) == ["Superwhisper"])
+    #expect(batch.candidates.map(\.canonical) == ["Superwhisper", "superwhisper", "Superwhisper"])
+    #expect(
+      batch.candidates.map(\.aliases) == [.unspecified, .unspecified, .supplied(["super whisper"])])
+  }
+
+  @Test("raw candidates differing only by internal whitespace stay separate at this layer")
+  func rawCandidatesKeepInternalWhitespaceVariantsSeparate() async throws {
+    // `SmartImportSource`'s own former local dedup used the STRONGER
+    // `normalize` key, which collapsed this pair; the weaker `persistenceKey`
+    // this plan delegates to downstream treats them as distinct (§3c, §4).
+    // This layer must not pre-merge them either way — proving that requires
+    // both to still be present here.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "Claude Code" }, { "text": "Claude  Code" } ] }"#, to: dir,
+      as: "v.json")
+
+    struct Fixed: SmartImportAdapter {
+      let identifier = "fluidvoice"
+      let displayName = "FluidVoice"
+      let url: URL
+      var candidatePaths: [URL] { [url] }
+      func loadWords(at url: URL) throws -> [SmartImportWord] {
+        try FluidVoiceAdapter().loadWords(at: url)
+      }
+    }
+
+    let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
+    #expect(batch.candidates.map(\.canonical) == ["Claude Code", "Claude  Code"])
+  }
+
+  @Test("raw candidates differing only by Unicode composition stay separate at this layer")
+  func rawCandidatesKeepUnicodeCompositionVariantsSeparate() async throws {
+    // A distinct axis from internal whitespace — tested as its own case so an
+    // implementation cannot satisfy an "or" description by covering only one
+    // (Grounded Review r2).
+    let nfc = "caf\u{e9}"
+    let nfd = "cafe\u{301}"
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "\#(nfc)" }, { "text": "\#(nfd)" } ] }"#, to: dir, as: "v.json")
+
+    struct Fixed: SmartImportAdapter {
+      let identifier = "fluidvoice"
+      let displayName = "FluidVoice"
+      let url: URL
+      var candidatePaths: [URL] { [url] }
+      func loadWords(at url: URL) throws -> [SmartImportWord] {
+        try FluidVoiceAdapter().loadWords(at: url)
+      }
+    }
+
+    let batch = try await SmartImportSource(adapter: Fixed(url: url)).loadCandidates()
+    // Swift `String ==` is canonically equivalent — nfc == nfd is TRUE, so
+    // comparing `[String]` here would pass even if composition were silently
+    // normalized away. Unicode scalars distinguish what canonical-equivalent
+    // String comparison cannot (Codex chunk review r1).
+    let actualScalars = batch.candidates.map { Array($0.canonical.unicodeScalars) }
+    #expect(actualScalars == [Array(nfc.unicodeScalars), Array(nfd.unicodeScalars)])
   }
 
   @Test("the registry ships the three verified apps and not the unverified one")
@@ -347,26 +711,27 @@ struct SmartImportSourceTests {
     let dir = makeDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let url = try write(#"{ "terms": [ { "text": "Kubernetes" } ] }"#, to: dir, as: "v.json")
-    #expect(try FluidVoiceAdapter().loadWords(at: url) == ["Kubernetes"])
+    #expect(
+      try FluidVoiceAdapter().loadWords(at: url) == [SmartImportWord(canonical: "Kubernetes")])
   }
 
-  @Test("a truncated read is refused even when duplicates hide it")
-  func truncatedReadIsRefusedEvenWhenDedupHidesIt() async throws {
-    // The trap (code review r10): the adapter reads one past the ceiling so
-    // "too many" is knowable, but deduplication SHRINKS the list — so a source
-    // whose overflowing rows are duplicates would fall back under the limit
-    // and report a successful import that had silently dropped the rest.
-    // Every ceiling needs a signal for having been reached, and counting after
-    // the shrink loses it.
+  @Test("a truncated read is refused even though nothing shrinks it anymore")
+  func truncatedReadIsRefusedBeforeConstruction() async throws {
+    // The raw row-count ceiling still applies before candidate construction.
+    // Unlike before this plan, nothing at this layer shrinks the list anymore
+    // (the local dedup was deleted, §3c) — so this now proves the ceiling
+    // check's POSITION (before any merging could ever hide an overflow)
+    // rather than proving it survives a shrink that no longer happens.
     struct Flood: SmartImportAdapter {
       let identifier = "flood"
       let displayName = "Flood"
       var candidatePaths: [URL] { [URL(fileURLWithPath: "/dev/null")] }
-      func loadWords(at url: URL) throws -> [String] {
-        // One past the ceiling, and all identical: dedup collapses this to a
-        // single word, which would look like a tiny successful import.
+      func loadWords(at url: URL) throws -> [SmartImportWord] {
+        // One past the ceiling, and all identical — would look like a tiny
+        // successful import if this layer merged duplicates, which it no
+        // longer does.
         Array(
-          repeating: "duplicate",
+          repeating: SmartImportWord(canonical: "duplicate"),
           count: CustomWordsImportLimits.maximumCandidates + 1)
       }
     }
@@ -378,5 +743,398 @@ struct SmartImportSourceTests {
     ) {
       _ = try await SmartImportSource(adapter: Flood()).loadCandidates()
     }
+  }
+
+  /// FluidVoice is the real amplification vector this ceiling exists for: its
+  /// schema can attach an unbounded alias array to one term (§3 rationale).
+  /// Routes the actual decoded JSON through the real adapter, not a synthetic
+  /// double, so the ceiling is proven against the shape it was built for.
+  private func writeFluidVoiceFixture(aliasCount: Int, to dir: URL) throws -> URL {
+    let aliasesJSON = (0..<aliasCount).map { "\"a\($0)\"" }.joined(separator: ",")
+    return try write(
+      #"{ "terms": [ { "text": "Word", "aliases": [\#(aliasesJSON)] } ] }"#, to: dir, as: "v.json")
+  }
+
+  private struct FixedFluidVoice: SmartImportAdapter {
+    let identifier = "fluidvoice"
+    let displayName = "FluidVoice"
+    let url: URL
+    var candidatePaths: [URL] { [url] }
+    func loadWords(at url: URL) throws -> [SmartImportWord] {
+      try FluidVoiceAdapter().loadWords(at: url)
+    }
+  }
+
+  @Test("the stored-value ceiling accepts a batch exactly at the limit")
+  func storedValueCeilingAcceptsExactLimit() async throws {
+    let limit = CustomWordsImportLimits.maximumExportedStoredValues
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    // canonical (1) + aliasCount == limit exactly.
+    let url = try writeFluidVoiceFixture(aliasCount: limit - 1, to: dir)
+
+    let batch = try await SmartImportSource(adapter: FixedFluidVoice(url: url)).loadCandidates()
+    #expect(batch.candidates.count == 1)
+  }
+
+  @Test("the stored-value ceiling refuses a batch one past the limit")
+  func storedValueCeilingRefusesLimitPlusOne() async throws {
+    let limit = CustomWordsImportLimits.maximumExportedStoredValues
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    // canonical (1) + aliasCount == limit + 1.
+    let url = try writeFluidVoiceFixture(aliasCount: limit, to: dir)
+
+    await #expect(
+      throws: ImportFileError.tooManyStoredValues(found: limit + 1, limit: limit)
+    ) {
+      _ = try await SmartImportSource(adapter: FixedFluidVoice(url: url)).loadCandidates()
+    }
+  }
+
+  // MARK: - Pipeline: real adapter output through the real compare/commit boundary
+  //
+  // Proves the boundary this source relies on (§2.5.1 Hop 4, Hop 6), not just
+  // the isolated unit tests that already cover `CustomWordsImportCompareEngine`
+  // and `CustomWordsManager` generically. Every fixture here is real adapter
+  // output run through `SmartImportSource.loadRawCandidates()`, then the real
+  // `CustomWordsImportCompareEngine`/`CustomWordsManager` — never a
+  // reimplementation of coalescing, collision detection, sanitization, or
+  // persistence rules.
+
+  /// Path substitution only: delegates decoding entirely to the real adapter.
+  private struct PathSubstituteAdapter<Base: SmartImportAdapter>: SmartImportAdapter {
+    let base: Base
+    let url: URL
+    var identifier: String { base.identifier }
+    var displayName: String { base.displayName }
+    var candidatePaths: [URL] { [url] }
+    func loadWords(at url: URL) throws -> [SmartImportWord] {
+      try base.loadWords(at: url)
+    }
+  }
+
+  private func makeWisprFlowDatabase(in dir: URL, rows: String) throws -> URL {
+    let url = dir.appendingPathComponent("flow.sqlite")
+    var db: OpaquePointer?
+    #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+    defer { sqlite3_close(db) }
+    let schema = """
+      CREATE TABLE Dictionary (id VARCHAR(36) PRIMARY KEY, phrase VARCHAR(255) NOT NULL,
+        replacement VARCHAR(255), isDeleted TINYINT DEFAULT 0, isSnippet TINYINT DEFAULT 0);
+      \(rows)
+      """
+    #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+    return url
+  }
+
+  // MARK: 1. Superwhisper dual representation, preview
+
+  @Test("Superwhisper's dual representation resolves to one .new comparison carrying the alias")
+  func superwhisperDualRepresentationResolvesToOneNewComparisonWithAlias() async throws {
+    // The founder-data-shaped end-to-end preview proof: a bare `vocabulary`
+    // entry and a `replacements` entry resolving to the same canonical.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      """
+      { "vocabulary": ["Superwhisper"],
+        "replacements": [ { "original": "super whisper", "with": "Superwhisper" } ] }
+      """, to: dir, as: "settings.json")
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: SuperwhisperAdapter(), url: url))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+
+    #expect(comparisons.count == 1)
+    let comparison = try #require(comparisons.first)
+    #expect(comparison.classification == .new)
+    #expect(comparison.candidate.canonical == "Superwhisper")
+    #expect(comparison.candidate.aliases == .supplied(["super whisper"]))
+  }
+
+  // MARK: 2-3. Canonicals differing only by one axis, preview
+
+  @Test("canonicals differing only by internal whitespace stay two separate .new rows")
+  func internalWhitespaceCanonicalsStayTwoSeparateNewRows() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "Claude Code" }, { "text": "Claude  Code" } ] }"#, to: dir,
+      as: "v.json")
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: FluidVoiceAdapter(), url: url))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+
+    #expect(comparisons.count == 2)
+    #expect(comparisons.allSatisfy { $0.classification == .new })
+    #expect(comparisons.map { $0.candidate.canonical } == ["Claude Code", "Claude  Code"])
+  }
+
+  @Test("canonicals differing only by Unicode composition coalesce to one .new row")
+  func unicodeCompositionCanonicalsCoalesceToOneNewRow() async throws {
+    // Corrected, Build Chunk 2 (2026-07-22): the approved plan originally
+    // claimed this axis "stays separate" like internal whitespace. It does
+    // not — Swift's own `String` equality is Unicode-canonical-equivalence-
+    // aware regardless of `persistenceKey`'s trim+lowercase transform, so
+    // these coalesce under both the old and new matching key. Verified
+    // against the real `coalesceDuplicates`, escalated, and the plan
+    // corrected (docs/audits/2026-07-22-issue1706-chunk2-nfc-nfd-escalation.txt).
+    let nfc = "caf\u{e9}"
+    let nfd = "cafe\u{301}"
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      #"{ "terms": [ { "text": "\#(nfc)" }, { "text": "\#(nfd)" } ] }"#, to: dir, as: "v.json")
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: FluidVoiceAdapter(), url: url))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+
+    #expect(comparisons.count == 1)
+    let comparison = try #require(comparisons.first)
+    #expect(comparison.classification == .new)
+    // First row's spelling wins. Unicode scalars, not `String ==`, because
+    // canonical-equivalent strings compare equal regardless of composition.
+    #expect(Array(comparison.candidate.canonical.unicodeScalars) == Array(nfc.unicodeScalars))
+  }
+
+  // MARK: 4-6. Duplicate canonicals with aliases differing by one axis, preview
+
+  @Test("duplicate canonicals with aliases differing only by case coalesce to one alias")
+  func duplicateCanonicalsWithCaseOnlyAliasesCoalesce() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      """
+      { "terms": [ { "text": "Kubernetes", "aliases": ["k8s"] },
+                    { "text": "Kubernetes", "aliases": ["K8S"] } ] }
+      """, to: dir, as: "v.json")
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: FluidVoiceAdapter(), url: url))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+
+    #expect(comparisons.count == 1)
+    let comparison = try #require(comparisons.first)
+    // First spelling wins on the union.
+    #expect(comparison.candidate.aliases == .supplied(["k8s"]))
+  }
+
+  @Test("duplicate canonicals with aliases differing only by internal whitespace both survive")
+  func duplicateCanonicalsWithWhitespaceOnlyAliasesBothSurvive() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      """
+      { "terms": [ { "text": "Kubernetes", "aliases": ["Claude Code"] },
+                    { "text": "Kubernetes", "aliases": ["Claude  Code"] } ] }
+      """, to: dir, as: "v.json")
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: FluidVoiceAdapter(), url: url))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+
+    #expect(comparisons.count == 1)
+    let comparison = try #require(comparisons.first)
+    #expect(comparison.candidate.aliases == .supplied(["Claude Code", "Claude  Code"]))
+  }
+
+  @Test("duplicate canonicals with aliases differing only by Unicode composition coalesce")
+  func duplicateCanonicalsWithUnicodeCompositionAliasesCoalesce() async throws {
+    // Corrected, Build Chunk 2 (2026-07-22) — same root cause as the canonical
+    // case above: Swift's `String` equality merges NFC/NFD regardless of
+    // `persistenceKey`'s transform, so these coalesce to ONE alias, not two.
+    let nfc = "caf\u{e9}"
+    let nfd = "cafe\u{301}"
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      """
+      { "terms": [ { "text": "Kubernetes", "aliases": ["\(nfc)"] },
+                    { "text": "Kubernetes", "aliases": ["\(nfd)"] } ] }
+      """, to: dir, as: "v.json")
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: FluidVoiceAdapter(), url: url))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+
+    #expect(comparisons.count == 1)
+    let comparison = try #require(comparisons.first)
+    guard case .supplied(let aliases) = comparison.candidate.aliases else {
+      Issue.record("expected .supplied aliases, got \(comparison.candidate.aliases)")
+      return
+    }
+    #expect(aliases.count == 1)
+    if let firstAlias = aliases.first {
+      #expect(Array(firstAlias.unicodeScalars) == Array(nfc.unicodeScalars))
+    }
+  }
+
+  // MARK: 7-8. Self-referential alias: preview carries it, commit removes it
+
+  @Test("a self-referential alias survives preview unremoved and uncollided")
+  func selfReferentialAliasSurvivesPreview() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(
+      in: dir, rows: "INSERT INTO Dictionary VALUES ('1','Superwhisper','Superwhisper',0,0);")
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: WisprFlowAdapter(), url: url))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+
+    let comparison = try #require(comparisons.first)
+    #expect(comparison.classification == .new)
+    #expect(comparison.candidate.aliases == .supplied(["Superwhisper"]))
+    #expect(comparison.collidingAliases.isEmpty)
+  }
+
+  @Test("the self-referential candidate commits with no alias and no reported drop")
+  @MainActor
+  func selfReferentialAliasCommitsWithoutAliasAndWithoutReportedDrop() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let dbURL = try makeWisprFlowDatabase(
+      in: dir, rows: "INSERT INTO Dictionary VALUES ('1','Superwhisper','Superwhisper',0,0);")
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: WisprFlowAdapter(), url: dbURL))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+    let additions = comparisons.map(\.candidate)
+
+    let manager = CustomWordsManager(fileURL: dir.appendingPathComponent("custom-words.json"))
+    var live = manager.load() ?? []
+    let receipt = try manager.commitImport(
+      CustomWordsImportCommitPlan(
+        baseline: CustomWordsImportLibrarySnapshot(words: live),
+        additions: additions, replacements: []),
+      to: &live)
+
+    let persisted = try #require(live.first { $0.canonical == "Superwhisper" })
+    #expect(persisted.aliases.isEmpty)
+    #expect(receipt.droppedAliasCollisions.isEmpty)
+  }
+
+  // MARK: 9. D15: an existing-library match never receives the imported alias
+
+  @Test("an existing-library match classifies exact and receives no imported alias")
+  func existingLibraryMatchClassifiesExactAndReceivesNoAlias() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try write(
+      """
+      { "vocabulary": ["Superwhisper"],
+        "replacements": [ { "original": "super whisper", "with": "Superwhisper" } ] }
+      """, to: dir, as: "settings.json")
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: SuperwhisperAdapter(), url: url))
+    let batch = try await source.loadRawCandidates()
+
+    let existing = CustomWord(canonical: "Superwhisper")
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [existing], fuzzyPolicy: .disabled)
+
+    #expect(comparisons.count == 1)
+    let comparison = try #require(comparisons.first)
+    #expect(comparison.classification == .exact(existing: existing))
+    // D15: an .exact match is Skip-only. The existing word is a local value
+    // untouched by comparison, and this row is never eligible for a commit
+    // plan's additions/replacements (§2.2) — nothing here can persist it.
+    #expect(existing.aliases.isEmpty)
+    // The incoming alias is still CARRIED on the comparison, not discarded —
+    // D15 is enforced by never committing this row, not by stripping data.
+    #expect(comparison.candidate.aliases == .supplied(["super whisper"]))
+  }
+
+  // MARK: 10-11. Two canonicals sharing one alias: deterministic first owner
+
+  @Test(
+    "two different canonicals sharing one alias: the ID-sorted earlier candidate has no collisions"
+  )
+  func twoCanonicalsShareOneAliasEarlierWinsByStoredID() async throws {
+    // IDs inserted in the OPPOSITE order from `id` on purpose, so `ORDER BY id
+    // COLLATE BINARY ASC` — not insertion order — determines who claims the
+    // shared alias first.
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = try makeWisprFlowDatabase(
+      in: dir,
+      rows: """
+        INSERT INTO Dictionary VALUES ('z','annie','Annabelle',0,0);
+        INSERT INTO Dictionary VALUES ('a','annie','Anika',0,0);
+        """)
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: WisprFlowAdapter(), url: url))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+
+    #expect(comparisons.count == 2)
+    let earlier = try #require(comparisons.first { $0.candidate.canonical == "Anika" })
+    let later = try #require(comparisons.first { $0.candidate.canonical == "Annabelle" })
+    #expect(earlier.collidingAliases.isEmpty)
+    #expect(
+      later.collidingAliases == [
+        CustomWordsImportAliasCollision(alias: "annie", heldBy: earlier.candidate.id)
+      ])
+  }
+
+  @Test("committing the shared-alias batch keeps the earlier canonical's alias, drops the later")
+  @MainActor
+  func sharedAliasBatchCommitKeepsEarlierDropsLaterWithReceipt() async throws {
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let dbURL = try makeWisprFlowDatabase(
+      in: dir,
+      rows: """
+        INSERT INTO Dictionary VALUES ('z','annie','Annabelle',0,0);
+        INSERT INTO Dictionary VALUES ('a','annie','Anika',0,0);
+        """)
+
+    let source = SmartImportSource(
+      adapter: PathSubstituteAdapter(base: WisprFlowAdapter(), url: dbURL))
+    let batch = try await source.loadRawCandidates()
+    let comparisons = try await CustomWordsImportCompareEngine().compare(
+      candidates: batch.candidates, against: [], fuzzyPolicy: .disabled)
+    // Plan order preserved: both are `.new`, so both become additions in the
+    // same order the comparison produced them.
+    let additions = comparisons.map(\.candidate)
+
+    let manager = CustomWordsManager(fileURL: dir.appendingPathComponent("custom-words.json"))
+    var live = manager.load() ?? []
+    let receipt = try manager.commitImport(
+      CustomWordsImportCommitPlan(
+        baseline: CustomWordsImportLibrarySnapshot(words: live),
+        additions: additions, replacements: []),
+      to: &live)
+
+    let anika = try #require(live.first { $0.canonical == "Anika" })
+    let annabelle = try #require(live.first { $0.canonical == "Annabelle" })
+    #expect(anika.aliases == ["annie"])
+    #expect(annabelle.aliases.isEmpty)
+    #expect(
+      receipt.droppedAliasCollisions == [
+        CustomWordsImportAliasCollision(alias: "annie", heldBy: anika.id)
+      ])
   }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SmartImportSourceTests.swift
@@ -792,6 +792,27 @@ struct SmartImportSourceTests {
     }
   }
 
+  @Test("blank/whitespace-only alias padding does not count against the stored-value ceiling")
+  func blankAliasPaddingDoesNotCountAgainstStoredValueCeiling() async throws {
+    // Fixed, GitHub cloud review (PR #1748): the ceiling used to count raw,
+    // pre-trim aliases, so a term padded with blank slots that were always
+    // going to be dropped could trip the ceiling and refuse an import that
+    // never actually approached the real stored-surface limit.
+    let limit = CustomWordsImportLimits.maximumExportedStoredValues
+    let dir = makeDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    // Far more raw aliases than the limit, every one blank — the trimmed
+    // surface is just the one canonical.
+    let aliasesJSON = (0..<(limit + 100)).map { _ in "\"   \"" }.joined(separator: ",")
+    let url = try write(
+      #"{ "terms": [ { "text": "Word", "aliases": [\#(aliasesJSON)] } ] }"#, to: dir, as: "v.json")
+
+    let batch = try await SmartImportSource(adapter: FixedFluidVoice(url: url)).loadCandidates()
+    let candidate = try #require(batch.candidates.first)
+    #expect(candidate.canonical == "Word")
+    #expect(candidate.aliases == .unspecified)
+  }
+
   // MARK: - Pipeline: real adapter output through the real compare/commit boundary
   //
   // Proves the boundary this source relies on (§2.5.1 Hop 4, Hop 6), not just


### PR DESCRIPTION
## Summary
- Smart Import from Wispr Flow, Superwhisper, and FluidVoice now carries the misspelling side of a competitor's find/replace pair across as an alias on the imported word, instead of discarding it. Two of the three adapters previously never even decoded that data.
- Merging within one import batch is delegated entirely to the existing, already-tested `CustomWordsImportCompareEngine.coalesceDuplicates` rather than a second, weaker local dedup — a disclosed behavior change for internal-whitespace duplicates (see plan §3c/§4).
- New resource ceiling on total stored surface (canonical + every alias) per batch, reusing the existing `tooManyStoredValues` error family.
- The Smart Import picker's helper text is corrected to match: it no longer claims alternate spellings stay behind in the other app.
- Mid-build correction (founder-approved): the plan's original claim that Unicode-composition (NFC/NFD) duplicate spellings "stay separate" after this change was factually wrong about existing, unmodified code — Swift's `String` equality is itself Unicode-canonical-equivalence-aware, so they coalesce under both the old and new matching key. Plan document corrected; tests assert the verified real behavior.

Plan: `docs/feature-requests/issue-1706-2026-07-22-competitor-alias-import.md`. Six rounds of Grounded Review reached PROCEED-AS-PLANNED before build; three build chunks each reached CHUNK-CLEAN with Codex.

## Test plan
- [x] `SmartImportSourceTests` — 51 tests, all passing (adapter-level + pipeline-level preview/commit proofs against the real compare/commit engines)
- [x] `CustomWordsImportCompareEngineTests` — 52 tests, unchanged, all passing
- [x] `CustomWordsImportCommitTests` — 36 tests, unchanged, all passing
- [x] Full unfiltered suite — 3,755 tests, all passing
- [x] Fresh independent whole-diff `codex review` — no actionable defects found
- [x] Live UAT against real founder data: Superwhisper import (`super whisper → Superwhisper`) verified in the persisted file; dictation of the misspelling verified correcting on both ASR backends via the app's own processing log; Wispr Flow's real-time write-safety refusal verified working correctly when the app was actively writing to its database
- [x] Release/dev build green; founder's Custom Words file and ASR backend setting restored to their pre-test state afterward