### PR TITLE
fix(build): UAT switch_backend labels and Settings-reopen fallback

### DIFF
--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -1423,10 +1423,10 @@ def A9_backend_switch_mid_record(**_) -> dict:
         _stop_recording_locked(settle_s=2.0)
     pre_backend = _read_setting("selectedBackend") or "parakeet"
     target_button_for_switch_attempt = (
-        "Multi-Language" if pre_backend.lower() == "parakeet" else "Fast (English)"
+        "All Languages" if pre_backend.lower() == "parakeet" else "Fast"
     )
     target_button_for_restore = (
-        "Fast (English)" if pre_backend.lower() == "parakeet" else "Multi-Language"
+        "Fast" if pre_backend.lower() == "parakeet" else "All Languages"
     )
 
     if not _start_recording_locked():

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -1193,8 +1193,8 @@ def _extract_transcript_text(signal, log_state_before, clip_seen=None, lines_acc
 # Settings UI labels for the two ASR engines. Source of truth for switch_backend.
 # Updated when the buttons in Settings -> Transcription change copy.
 _BACKEND_LABELS = {
-    "parakeet": "Fast (English)",
-    "whisperkit": "Multi-Language",
+    "parakeet": "Fast",
+    "whisperkit": "All Languages",
 }
 
 
@@ -1206,8 +1206,8 @@ def switch_backend(name, wait=3.0):
         wait: seconds to let the model load after switching.
 
     Settings -> Transcription has two buttons:
-        Fast (English)   -> Parakeet (PR #720-era label)
-        Multi-Language   -> WhisperKit
+        Fast            -> Parakeet
+        All Languages   -> WhisperKit
 
     Usage:
         switch_backend("whisperkit")
@@ -1216,7 +1216,9 @@ def switch_backend(name, wait=3.0):
     if name not in _BACKEND_LABELS:
         raise ValueError(f"Unknown backend '{name}'. Use one of: {list(_BACKEND_LABELS)}")
     connect()
-    nav("Transcription")
+    # nav("Transcription") requires AXOutline and silently no-ops against the
+    # button sidebar (#1296); tap() on the sidebar button itself is reliable.
+    tap("Transcription")
     time.sleep(0.3)
     label = _BACKEND_LABELS[name]
     if not tap(label):

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -1217,8 +1217,17 @@ def switch_backend(name, wait=3.0):
         raise ValueError(f"Unknown backend '{name}'. Use one of: {list(_BACKEND_LABELS)}")
     connect()
     # nav("Transcription") requires AXOutline and silently no-ops against the
-    # button sidebar (#1296); tap() on the sidebar button itself is reliable.
-    tap("Transcription")
+    # button sidebar (#1296); tap() on the sidebar button itself is reliable
+    # once Settings is open. But nav()'s own auto-open-Settings fallback still
+    # ran before it gave up on the sidebar search, so a caller relying on that
+    # side effect (e.g. after Settings closed between two switch_backend calls)
+    # needs the same explicit open here (Codex code-diff review, 2026-07-22).
+    if not tap("Transcription"):
+        if not tap("Settings..."):
+            raise RuntimeError("Could not open Settings to reach Transcription")
+        time.sleep(0.8)  # settle: mirrors nav()'s own post-auto-open wait for the window to animate in
+        if not tap("Transcription"):
+            raise RuntimeError("Could not tap 'Transcription' in the Settings sidebar")
     time.sleep(0.3)
     label = _BACKEND_LABELS[name]
     if not tap(label):

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -390,7 +390,7 @@ def read(label):
 
 
 _CARD_GROUPS = {
-    "engine": ["Fast (English)", "Multi-Language"],
+    "engine": ["Fast", "All Languages"],
     "style": ["Formal", "Standard", "Friendly"],
 }
 


### PR DESCRIPTION
## Summary
- Session drift found while testing #1706: `switch_backend()`'s hardcoded Settings labels (`Fast (English)` / `Multi-Language`) were stale; the real UI now reads `Fast` / `All Languages`.
- Replaced the broken `nav("Transcription")` call (requires `AXOutline`, silently no-ops against the button sidebar since #1296) with a direct `tap()`, then restored the auto-open-Settings fallback that `nav()` used to provide as a side effect before it gave up — a local Codex review round caught that the first pass dropped this, breaking callers after Settings had already closed.
- Both directions and both window states (open, closed) validated live against the running app, not just read.

## Test plan
- [x] Validated live: `switch_backend("whisperkit")` then `switch_backend("parakeet")` against the running dev app, Settings open
- [x] Validated live: same, with Settings deliberately closed first (`close_window()`), confirming the reopen fallback fires
- [x] Local `codex review` — two rounds, one real finding (missing Settings-reopen fallback) fixed, round 2 clean
- [x] `python3 -m py_compile Tests/RuntimeUAT/wispr_eyes.py` succeeds (part of Codex round 2)

No Swift changed; test-tooling only (`Tests/RuntimeUAT/wispr_eyes.py`).