### PR TITLE
Recovery engine-mutation gate: required-at-construction capabilities + a bounded freeze-test guardrail

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dfed2cdc877cc40115f0f7416fde8d7670121ce89284fee489b4769566811387",
+  "originHash" : "9925f51a1e59246437b26429727b479f3162e5a8d630d61a4d9e527057dcc0ac",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -52,6 +52,15 @@
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,15 @@ let package = Package(
     .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
     .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),
+    // Test-only (#1741 Chunk 10): real Swift lexical/syntactic awareness for
+    // EngineMutationInventoryFreezeTests's comment/string handling, replacing
+    // a hand-rolled character scanner that hit diminishing returns across 5
+    // Codex review rounds. 603.0.2 matches this project's Swift 6.3.3
+    // toolchain (swift-syntax's own versioning: major version 60X aligns
+    // with Swift 6.X). Depended on ONLY by the EnviousWisprTests test
+    // target below — SwiftPM links a dependency only into targets that
+    // import it, so this never reaches the shipped app or the XPC helper.
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.2"),
   ],
   targets: [
     .target(
@@ -219,6 +228,15 @@ let package = Package(
         // so `swift test` / `xcodebuild test` never launch the app.
         "EnviousWisprAppKit",
         "EnviousWisprContacts",
+        // #1741 Chunk 10: EngineMutationInventoryFreezeTests's real Swift
+        // parser (replaces its hand-rolled comment/string scanner). This is
+        // the ONLY place swift-syntax is depended on in this package.
+        // `SwiftOperators` (operator-sequence folding) was added in round 2
+        // and removed in the council-approved contract pivot — it existed
+        // only to resolve a call's callee, which the current
+        // reference-inventory design no longer attempts.
+        .product(name: "SwiftParser", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
       ],
       path: "Tests/EnviousWisprTests"
     ),

--- a/Project.swift
+++ b/Project.swift
@@ -442,6 +442,13 @@ let project = Project(
         .target(name: "EnviousWisprFluidAudioBridge"),
         .package(product: "FluidAudio"),
         .package(product: "Sparkle"),
+        // #1741 Chunk 10: EngineMutationInventoryFreezeTests's real Swift
+        // parser. Test-target-only — never reaches the app or XPC targets
+        // above (see Package.swift for the matching SPM dependency).
+        // `SwiftOperators` was removed in the council-approved contract
+        // pivot (no longer resolving callees, so no folding needed).
+        .package(product: "SwiftParser"),
+        .package(product: "SwiftSyntax"),
       ],
       settings: projectSettings
     ),

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -1,6 +1,5 @@
 @preconcurrency import AVFoundation
 import EnviousWisprCore
-import EnviousWisprServices
 import Foundation
 
 /// Manages ASR backend selection and delegates transcription calls.
@@ -16,19 +15,15 @@ public final class ASRManager: ASRManagerInterface {
   public private(set) var downloadPhase: String = ""
   public private(set) var downloadDetail: String = ""
   public var onServiceInterrupted: (() -> Void)?  // No-op for in-process — no XPC crash path
-  /// #1707 Phase 3 (§3.2, row 7) — `EngineRecoveryGate.tryBeginMutation()`/
-  /// `endMutation()`, injected exactly like `onServiceInterrupted` above (this
-  /// type never references `EngineRecoveryGate` by concrete type). Guards
-  /// `unloadModel()`'s idle-timer unload — a background actor unrelated to
-  /// any active session, so recovery must never race it. Defaults keep every
-  /// existing test/legacy construction unchanged (always able to proceed).
-  public var tryBeginEngineMutation: @MainActor () -> Bool = { true }
-  /// Returns whether recovery was denied while this mutation was in flight
-  /// and is now owed a wake-up.
-  public var endEngineMutation: @MainActor () -> Bool = { false }
-  /// Called when `endEngineMutation()` returns true — wakes a stranded
-  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-  public var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+  /// #1707 Phase 3 (§3.2, row 7) / #1741 Chunk 3 — the mutation-side capability
+  /// guarding `unloadModel()`'s idle-timer unload, a background actor unrelated
+  /// to any active session, so recovery must never race it. Required at
+  /// construction (no default) — replaces the old defaulted
+  /// `tryBeginEngineMutation`/`endEngineMutation`/`wakeRecoveryIfOwed` closure
+  /// triplet. `package`, not `public`: `EnviousWisprASR` is an exported
+  /// library product and `EngineMutationScope` is itself only
+  /// `package`-visible, so a wider property could not hold it.
+  package let engineMutationScope: EngineMutationScope
   /// Issue #445: in-process variant. Tests do not drive a progress-file stream,
   /// so this stays unset at runtime; the protocol requires it.
   public var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)?
@@ -68,7 +63,8 @@ public final class ASRManager: ASRManagerInterface {
   // reset-branch coverage in `setInitialBackendType` and `switchBackend`.
   private var parakeetBackend: any ASRBackend
 
-  public init(parakeetBackend: (any ASRBackend)? = nil) {
+  package init(engineMutationScope: EngineMutationScope, parakeetBackend: (any ASRBackend)? = nil) {
+    self.engineMutationScope = engineMutationScope
     self.parakeetBackend = parakeetBackend ?? ParakeetBackend()
   }
 
@@ -259,37 +255,32 @@ public final class ASRManager: ASRManagerInterface {
       }
       return
     }
-    // #1707 Phase 3 (§3.2, row 7): hold a mutation claim BEFORE touching
-    // anything below — including the load-generation bump and in-flight-load
-    // cancel, which would otherwise cancel a load RECOVERY is currently
-    // running under its own recovery claim (Codex code-diff round 1 P1: the
-    // original ordering let an idle-unload fire mid-recovery-load, invalidate
-    // its generation, and have recovery treat the resulting throw as an
-    // unrecoverable failure — deleting a recoverable spool). A denied claim
-    // (recovery holds the engine) skips this attempt entirely, touching
+    // #1707 Phase 3 (§3.2, row 7) / #1741 Chunk 3: hold a mutation claim BEFORE
+    // touching anything below — including the load-generation bump and
+    // in-flight-load cancel, which would otherwise cancel a load RECOVERY is
+    // currently running under its own recovery claim (Codex code-diff round 1
+    // P1: the original ordering let an idle-unload fire mid-recovery-load,
+    // invalidate its generation, and have recovery treat the resulting throw
+    // as an unrecoverable failure — deleting a recoverable spool). A denied
+    // claim (recovery holds the engine) skips this attempt entirely, touching
     // NOTHING; the next genuine idle-unload trigger re-attempts — no bespoke
     // retry machinery for a background convenience unload.
-    guard tryBeginEngineMutation() else {
-      TelemetryService.shared.recoveryEngineActionDeferred(site: "asrManagerUnload")
-      return
+    _ = await engineMutationScope.withClaim(site: "asrManagerUnload") {
+      // Bump before the loaded-guard so an in-flight load (flag still false) is
+      // superseded too, not just a resident model.
+      self.invalidateCurrentLoadGeneration(cause: "unload")
+      // #959 (Codex re-review P2): retire the superseded in-flight load task the
+      // same way `switchBackend()` / `cancelInFlightLoad()` do — otherwise a retry
+      // that joins via single-flight before the doomed task finishes propagates
+      // `ASRLoadSupersededError` instead of starting a fresh load. Must run BEFORE
+      // the loaded-guard, because the in-flight case is exactly when `isModelLoaded`
+      // is still false and the guard would early-return with the stale handle live.
+      self.inFlightLoadTask?.cancel()
+      self.inFlightLoadTask = nil
+      guard self.isModelLoaded, let activeBackend = self.activeBackend else { return }
+      await activeBackend.unload()
+      self.isModelLoaded = false
     }
-    defer {
-      if endEngineMutation() { wakeRecoveryIfOwed() }
-    }
-    // Bump before the loaded-guard so an in-flight load (flag still false) is
-    // superseded too, not just a resident model.
-    invalidateCurrentLoadGeneration(cause: "unload")
-    // #959 (Codex re-review P2): retire the superseded in-flight load task the
-    // same way `switchBackend()` / `cancelInFlightLoad()` do — otherwise a retry
-    // that joins via single-flight before the doomed task finishes propagates
-    // `ASRLoadSupersededError` instead of starting a fresh load. Must run BEFORE
-    // the loaded-guard, because the in-flight case is exactly when `isModelLoaded`
-    // is still false and the guard would early-return with the stale handle live.
-    inFlightLoadTask?.cancel()
-    inFlightLoadTask = nil
-    guard isModelLoaded, let activeBackend else { return }
-    await activeBackend.unload()
-    isModelLoaded = false
   }
 
   /// Issue #445: in-process variant of the watchdog recovery. No XPC connection

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -1,6 +1,5 @@
 @preconcurrency import AVFoundation
 import EnviousWisprCore
-import EnviousWisprServices
 import Foundation
 
 /// XPC-backed implementation of `ASRManagerInterface`.
@@ -35,23 +34,17 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// Fires when the ASR XPC service crashes during an active session (streaming or batch in-flight).
   public var onServiceInterrupted: (() -> Void)?
 
-  /// #1707 Phase 3 (§3.2, row 7) — `EngineRecoveryGate.tryBeginMutation()`/
-  /// `endMutation()`, injected exactly like `onServiceInterrupted` above (this
-  /// type never references `EngineRecoveryGate` by concrete type). Guards
-  /// `unloadModel()`'s idle-timer unload — a background actor unrelated to
-  /// any active session, so recovery must never race it. (A call arriving
+  /// #1707 Phase 3 (§3.2, row 7) / #1741 Chunk 3 — the mutation-side capability
+  /// guarding `unloadModel()`'s idle-timer unload, a background actor unrelated
+  /// to any active session, so recovery must never race it. (A call arriving
   /// via `switchBackend()` is already covered by `EngineCoordinator
   /// .isSwitching`'s full-duration claim; recovery's own atomic handshake
   /// checks `isEngineSwitching()` before claiming, so this claim can never
-  /// be denied during a genuine switch.) Defaults keep every existing
-  /// test/legacy construction unchanged (always able to proceed).
-  public var tryBeginEngineMutation: @MainActor () -> Bool = { true }
-  /// Returns whether recovery was denied while this mutation was in flight
-  /// and is now owed a wake-up.
-  public var endEngineMutation: @MainActor () -> Bool = { false }
-  /// Called when `endEngineMutation()` returns true — wakes a stranded
-  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-  public var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+  /// be denied during a genuine switch.) Required at construction (no
+  /// default) — replaces the old defaulted `tryBeginEngineMutation`/
+  /// `endEngineMutation`/`wakeRecoveryIfOwed` closure triplet. `package`, not
+  /// `public`, matching `ASRManager`'s identical narrowing.
+  package let engineMutationScope: EngineMutationScope
 
   /// Issue #445: per-tick callback wired by the dictation kernel to feed
   /// its `LoadProgressWatcher` from the existing 8Hz polling timer.
@@ -105,7 +98,11 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// private `ensureConnection()`.
   private let connectionPreflight: @MainActor (ASRManagerProxy) -> Void
 
-  public init(connectionPreflight: (@MainActor (ASRManagerProxy) -> Void)? = nil) {
+  package init(
+    engineMutationScope: EngineMutationScope,
+    connectionPreflight: (@MainActor (ASRManagerProxy) -> Void)? = nil
+  ) {
+    self.engineMutationScope = engineMutationScope
     self.connectionPreflight = connectionPreflight ?? { $0.ensureConnection() }
   }
 
@@ -345,45 +342,40 @@ public final class ASRManagerProxy: ASRManagerInterface {
   }
 
   public func unloadModel() async {
-    // #1707 Phase 3 (§3.2, row 7): hold a mutation claim BEFORE touching
-    // anything below — including the load-generation bump and in-flight-load
-    // cancel, which would otherwise cancel a load RECOVERY is currently
-    // running under its own recovery claim (Codex code-diff round 1 P1: the
-    // original ordering let an idle-unload fire mid-recovery-load, invalidate
-    // its generation, and have recovery treat the resulting throw as an
-    // unrecoverable failure — deleting a recoverable spool). A denied claim
-    // (recovery holds the engine) skips this attempt entirely, touching
+    // #1707 Phase 3 (§3.2, row 7) / #1741 Chunk 3: hold a mutation claim BEFORE
+    // touching anything below — including the load-generation bump and
+    // in-flight-load cancel, which would otherwise cancel a load RECOVERY is
+    // currently running under its own recovery claim (Codex code-diff round 1
+    // P1: the original ordering let an idle-unload fire mid-recovery-load,
+    // invalidate its generation, and have recovery treat the resulting throw
+    // as an unrecoverable failure — deleting a recoverable spool). A denied
+    // claim (recovery holds the engine) skips this attempt entirely, touching
     // NOTHING; the next genuine idle-unload trigger re-attempts — no bespoke
     // retry machinery for a background convenience unload.
-    guard tryBeginEngineMutation() else {
-      TelemetryService.shared.recoveryEngineActionDeferred(site: "asrManagerProxyUnload")
-      return
-    }
-    defer {
-      if endEngineMutation() { wakeRecoveryIfOwed() }
-    }
-    // #959: bump BEFORE the loaded-guard so an in-flight load (whose
-    // `isModelLoaded` is still false) is superseded too, not just a resident model.
-    invalidateCurrentLoadGeneration(cause: "unload")
-    // #959 (Codex re-review P2): retire the superseded in-flight load task the
-    // same way `switchBackend()` / `cancelInFlightLoad()` do — otherwise a retry
-    // that joins via single-flight before the doomed task finishes propagates
-    // `ASRLoadSupersededError` instead of starting a fresh load. Must run BEFORE
-    // the loaded-guard, because the in-flight case is exactly when `isModelLoaded`
-    // is still false and the guard would early-return with the stale handle live.
-    inFlightLoadTask?.cancel()
-    inFlightLoadTask = nil
-    guard isModelLoaded else { return }
-    await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-      serviceProxy { proxy in
-        proxy.unloadModel {
+    _ = await engineMutationScope.withClaim(site: "asrManagerProxyUnload") {
+      // #959: bump BEFORE the loaded-guard so an in-flight load (whose
+      // `isModelLoaded` is still false) is superseded too, not just a resident model.
+      self.invalidateCurrentLoadGeneration(cause: "unload")
+      // #959 (Codex re-review P2): retire the superseded in-flight load task the
+      // same way `switchBackend()` / `cancelInFlightLoad()` do — otherwise a retry
+      // that joins via single-flight before the doomed task finishes propagates
+      // `ASRLoadSupersededError` instead of starting a fresh load. Must run BEFORE
+      // the loaded-guard, because the in-flight case is exactly when `isModelLoaded`
+      // is still false and the guard would early-return with the stale handle live.
+      self.inFlightLoadTask?.cancel()
+      self.inFlightLoadTask = nil
+      guard self.isModelLoaded else { return }
+      await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+        self.serviceProxy { proxy in
+          proxy.unloadModel {
+            cont.resume()
+          }
+        } onProxyError: {
           cont.resume()
         }
-      } onProxyError: {
-        cont.resume()
       }
+      self.isModelLoaded = false
     }
-    isModelLoaded = false
   }
 
   /// Set the backend type synchronously at app startup. No unload (nothing loaded yet).

--- a/Sources/EnviousWisprASR/EngineMutationScope.swift
+++ b/Sources/EnviousWisprASR/EngineMutationScope.swift
@@ -1,0 +1,63 @@
+package enum EngineMutationOutcome<T: Sendable>: Sendable {
+  case refused
+  case completed(T)
+}
+
+@MainActor
+package struct EngineMutationScope {
+  private let tryBegin: @MainActor () -> Bool
+  private let end: @MainActor () -> Bool
+  private let wake: @MainActor () -> Void
+  private let onRefused: @MainActor (String) -> Void
+
+  package static func live(
+    tryBegin: @escaping @MainActor () -> Bool,
+    end: @escaping @MainActor () -> Bool,
+    wake: @escaping @MainActor () -> Void,
+    onRefused: @escaping @MainActor (String) -> Void
+  ) -> Self {
+    Self(tryBegin: tryBegin, end: end, wake: wake, onRefused: onRefused)
+  }
+
+  /// Test-only, and INTENTIONALLY not a substitute for `.live(...)` anywhere
+  /// production constructs a consumer. `internal`, not `package` or `public`
+  /// (Grounded Review finding — `EnviousWisprASR` is an exported library
+  /// product; a wider-than-`internal` always-allowed value is itself a
+  /// silent-bypass risk if a real call site ever reaches for it by name, the
+  /// same disease this plan exists to cure, one level down). Tests reach it
+  /// via `@testable import EnviousWisprASR`. Mitigated structurally, not by
+  /// naming alone: `EngineMutationInventoryFreezeTests` asserts ZERO
+  /// references to `alwaysAllowedForTesting` under `Sources/`.
+  internal static let alwaysAllowedForTesting = Self(
+    tryBegin: { true }, end: { false }, wake: {}, onRefused: { _ in })
+
+  /// Owns ONLY the claim/release/wake/refusal-telemetry ceremony — acquire
+  /// once, run `operation`, always release and forward a wake if one is
+  /// owed on every actual scope exit (return or throw, including a thrown
+  /// `CancellationError`); emit refusal telemetry exactly once if the claim
+  /// itself is refused.
+  ///
+  /// Task cancellation is cooperative and does not itself exit this scope.
+  /// `Task.cancel()` only sets a flag; it does not force a running
+  /// `operation` that ignores cancellation to return or throw. `defer`
+  /// still guarantees release/wake on every exit that DOES happen, but it
+  /// cannot make an uncooperative operation finish sooner.
+  ///
+  /// Deliberately does NOT interpret `Task` cancellation. Every site's own
+  /// domain-specific cancellation and identity checks (e.g.
+  /// `WhisperKitEngineAdapter`'s `sessionID`-keying re-check) stay inside
+  /// that site's own `operation` closure, unchanged from today.
+  package func withClaim<T: Sendable>(
+    site: String,
+    _ operation: @MainActor () async throws -> T
+  ) async rethrows -> EngineMutationOutcome<T> {
+    guard tryBegin() else {
+      onRefused(site)
+      return .refused
+    }
+    defer {
+      if end() { wake() }
+    }
+    return .completed(try await operation())
+  }
+}

--- a/Sources/EnviousWisprASR/WhisperKitSetupService.swift
+++ b/Sources/EnviousWisprASR/WhisperKitSetupService.swift
@@ -1,4 +1,3 @@
-import EnviousWisprServices
 import Foundation
 
 /// States in the WhisperKit model setup flow.
@@ -64,30 +63,27 @@ public final class WhisperKitSetupService {
   /// or failed, rendered inline.
   private let removeModelAction: @MainActor () async -> WhisperKitRemoveNotice?
 
-  /// #1707 Phase 3 (§3.2, rows 9/10) — `EngineRecoveryGate.tryBeginMutation()`/
-  /// `endMutation()`, injected by the composition root exactly like the
-  /// action closures above (this type never references `EngineRecoveryGate`
-  /// by concrete type). Guards Download/Cancel/Remove's engine-touching
-  /// work — none of these route through `ensureEngineWarm()`. Defaults keep
-  /// every existing test/legacy construction unchanged (always able to
-  /// proceed).
-  public var tryBeginEngineMutation: @MainActor () -> Bool = { true }
-  /// Returns whether recovery was denied while this mutation was in flight
-  /// and is now owed a wake-up.
-  public var endEngineMutation: @MainActor () -> Bool = { false }
-  /// Called when `endEngineMutation()` returns true — wakes a stranded
-  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-  public var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+  /// #1707 Phase 3 (§3.2, rows 9/10) / #1741 Chunk 4 — the mutation-side
+  /// capability guarding Download/Cancel/Remove's engine-touching work, none
+  /// of which routes through `ensureEngineWarm()`. Required at construction
+  /// (no default) — replaces the old defaulted `tryBeginEngineMutation`/
+  /// `endEngineMutation`/`wakeRecoveryIfOwed` closure triplet. `package`, not
+  /// `public`: `EnviousWisprASR` is an exported library product and
+  /// `EngineMutationScope` is itself only `package`-visible, so a wider
+  /// property could not hold it.
+  package let engineMutationScope: EngineMutationScope
 
   /// The default wiring reports "not downloaded" and does nothing: a build with
   /// no delivery wiring must offer no fetch at all rather than quietly resurrect
   /// an unverified one.
-  public init(
+  package init(
+    engineMutationScope: EngineMutationScope,
     readAvailability: @escaping @MainActor () async -> WhisperKitSetupState = { .notDownloaded },
     startDownload: @escaping @MainActor () async -> Bool = { false },
     cancelActiveDownload: @escaping @MainActor () async -> Bool = { false },
     removeModelAction: @escaping @MainActor () async -> WhisperKitRemoveNotice? = { .failed }
   ) {
+    self.engineMutationScope = engineMutationScope
     self.readAvailability = readAvailability
     self.startDownload = startDownload
     self.cancelActiveDownload = cancelActiveDownload
@@ -152,18 +148,15 @@ public final class WhisperKitSetupService {
         await self?.forceDetectState()
         return
       }
-      // #1707 Phase 3 (§3.2, row 9): hold a mutation claim for the FULL
-      // download — a Settings-initiated fetch must never race crash
+      // #1707 Phase 3 (§3.2, row 9) / #1741 Chunk 4: hold a mutation claim for
+      // the FULL download — a Settings-initiated fetch must never race crash
       // recovery on the shared engine.
-      guard self.tryBeginEngineMutation() else {
-        TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitDownload")
-        await self.forceDetectState()
-        return
+      let outcome = await self.engineMutationScope.withClaim(site: "whisperKitDownload") {
+        if await startDownload() == false {
+          await self.forceDetectState()
+        }
       }
-      defer {
-        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-      }
-      if await startDownload() == false {
+      if case .refused = outcome {
         await self.forceDetectState()
       }
     }
@@ -178,22 +171,19 @@ public final class WhisperKitSetupService {
     // downstream cannot reach a request that has not been made.
     downloadIntentEpoch += 1
     Task { [cancelActiveDownload, weak self] in
-      // #1707 Phase 3 (§3.2, row 10): hold a mutation claim for the FULL
-      // cancel-drain — same reasoning as Download above. A denied claim
-      // (recovery holds the engine) skips this attempt; the fetch keeps
-      // running and the user can press Cancel again.
-      guard let self, self.tryBeginEngineMutation() else {
-        TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitCancelDownload")
-        return
-      }
-      defer {
-        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-      }
+      guard let self else { return }
+      // #1707 Phase 3 (§3.2, row 10) / #1741 Chunk 4: hold a mutation claim
+      // for the FULL cancel-drain — same reasoning as Download above. A
+      // denied claim (recovery holds the engine) skips this attempt; the
+      // fetch keeps running and the user can press Cancel again.
+      //
       // No re-detect on an accepted cancel: the delivery-state projection
       // publishes the terminal (paused/cancelled) state, and detection would
       // wipe it back to not-downloaded (Codex 2c-r7 P2). A REFUSED cancel
-      // changes nothing either way.
-      _ = await cancelActiveDownload()
+      // (gate or coordinator) changes nothing either way.
+      _ = await self.engineMutationScope.withClaim(site: "whisperKitCancelDownload") {
+        _ = await cancelActiveDownload()
+      }
     }
   }
 
@@ -236,35 +226,33 @@ public final class WhisperKitSetupService {
     guard !isRemoving else { return }
     isRemoving = true
     Task { [removeModelAction, weak self] in
-      // #1707 Phase 3 (§3.2, row 10): hold a mutation claim for the FULL
-      // removal drain — same reasoning as Download/Cancel above.
-      guard let self, self.tryBeginEngineMutation() else {
-        TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitRemove")
-        self?.isRemoving = false
-        self?.removeNotice = .failed
-        return
+      guard let self else { return }
+      // #1707 Phase 3 (§3.2, row 10) / #1741 Chunk 4: hold a mutation claim
+      // for the FULL removal drain — same reasoning as Download/Cancel above.
+      let outcome = await self.engineMutationScope.withClaim(site: "whisperKitRemove") {
+        let notice = await removeModelAction()
+        self.isRemoving = false
+        self.removeNotice = notice
+        if notice == nil {
+          // Successful removal is authoritative terminal delivery truth on its
+          // own — probing the controller again would call adoptIfPresent(),
+          // which republishes .notReady and re-enters this exact removal
+          // completion through the delivery observer (the live infinite-loop
+          // bug: Remove -> .notReady -> forceDetectState -> adoptIfPresent ->
+          // .notReady -> repeat forever, pinning the main actor). Apply the
+          // known terminal state directly instead.
+          self.applyDeliveryState(.notDownloaded)
+        } else {
+          // A failure may have partially deleted (marker gone, bytes
+          // remaining), and the row must show disk truth while the notice
+          // above it explains the failure (Codex 2c-r1 P2 — the notice now
+          // survives state flips by rendering outside the state switch).
+          await self.forceDetectState()
+        }
       }
-      defer {
-        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-      }
-      let notice = await removeModelAction()
-      self.isRemoving = false
-      self.removeNotice = notice
-      if notice == nil {
-        // Successful removal is authoritative terminal delivery truth on its
-        // own — probing the controller again would call adoptIfPresent(),
-        // which republishes .notReady and re-enters this exact removal
-        // completion through the delivery observer (the live infinite-loop
-        // bug: Remove -> .notReady -> forceDetectState -> adoptIfPresent ->
-        // .notReady -> repeat forever, pinning the main actor). Apply the
-        // known terminal state directly instead.
-        self.applyDeliveryState(.notDownloaded)
-      } else {
-        // A failure may have partially deleted (marker gone, bytes
-        // remaining), and the row must show disk truth while the notice
-        // above it explains the failure (Codex 2c-r1 P2 — the notice now
-        // survives state flips by rendering outside the state switch).
-        await self.forceDetectState()
+      if case .refused = outcome {
+        self.isRemoving = false
+        self.removeNotice = .failed
       }
     }
   }

--- a/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
+++ b/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
@@ -2,7 +2,6 @@
 import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
-import EnviousWisprServices
 import Foundation
 
 /// Measures ASR transcription performance across different audio durations.
@@ -30,19 +29,18 @@ final class BenchmarkSuite {
   private(set) var isRunning = false
   private(set) var progress: String = ""
 
-  /// #1707 Phase 3 (§3.2, rows 23/27) — `EngineRecoveryGate.tryBeginMutation()`/
-  /// `endMutation()`, injected by the composition root (this type never
+  /// #1707 Phase 3 (§3.2, rows 23/27) / #1741 Chunk 5 — the mutation-side
+  /// capability guarding both benchmark methods below (this type never
   /// references `EngineRecoveryGate` by concrete type). A Diagnostics-
   /// triggered benchmark must never race crash recovery on the shared
-  /// engine. Defaults keep every existing test/legacy construction unchanged
-  /// (always able to proceed).
-  var tryBeginEngineMutation: @MainActor () -> Bool = { true }
-  /// Returns whether recovery was denied while this mutation was in flight
-  /// and is now owed a wake-up.
-  var endEngineMutation: @MainActor () -> Bool = { false }
-  /// Called when `endEngineMutation()` returns true — wakes a stranded
-  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-  var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+  /// engine. Required at construction (no default) — replaces the old
+  /// defaulted `tryBeginEngineMutation`/`endEngineMutation`/`wakeRecoveryIfOwed`
+  /// closure triplet.
+  let engineMutationScope: EngineMutationScope
+
+  init(engineMutationScope: EngineMutationScope) {
+    self.engineMutationScope = engineMutationScope
+  }
 
   /// Ensure model is loaded, returning false (and updating progress) if loading fails.
   private func ensureModelLoaded(using activeEngine: ActiveEngineOperation) async -> Bool {
@@ -63,42 +61,32 @@ final class BenchmarkSuite {
     isRunning = true
     results = []
 
-    // #1707 Phase 3 (§3.2, row 23): hold a mutation claim for the FULL
-    // load+transcribe duration — a Diagnostics-triggered benchmark must
-    // never race crash recovery on the shared engine.
-    guard tryBeginEngineMutation() else {
-      TelemetryService.shared.recoveryEngineActionDeferred(site: "benchmarkSuiteBatch")
-      isRunning = false
-      return
+    // #1707 Phase 3 (§3.2, row 23) / #1741 Chunk 5: hold a mutation claim for
+    // the FULL load+transcribe duration — a Diagnostics-triggered benchmark
+    // must never race crash recovery on the shared engine.
+    _ = await engineMutationScope.withClaim(site: "benchmarkSuiteBatch") {
+      guard await ensureModelLoaded(using: activeEngine) else { return }
+
+      let durations: [TimeInterval] = [5, 15, 30]
+
+      for duration in durations {
+        progress = "Testing \(Int(duration))s audio..."
+        let samples = generateTestAudio(duration: duration)
+
+        let start = CFAbsoluteTimeGetCurrent()
+        _ = try? await activeEngine.transcribe(samples, .default)
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+
+        results.append(
+          Result(
+            label: "\(Int(duration))s",
+            processingTime: elapsed,
+            rtf: duration / elapsed
+          ))
+      }
+
+      progress = "Complete"
     }
-    defer {
-      if endEngineMutation() { wakeRecoveryIfOwed() }
-    }
-
-    guard await ensureModelLoaded(using: activeEngine) else {
-      isRunning = false
-      return
-    }
-
-    let durations: [TimeInterval] = [5, 15, 30]
-
-    for duration in durations {
-      progress = "Testing \(Int(duration))s audio..."
-      let samples = generateTestAudio(duration: duration)
-
-      let start = CFAbsoluteTimeGetCurrent()
-      _ = try? await activeEngine.transcribe(samples, .default)
-      let elapsed = CFAbsoluteTimeGetCurrent() - start
-
-      results.append(
-        Result(
-          label: "\(Int(duration))s",
-          processingTime: elapsed,
-          rtf: duration / elapsed
-        ))
-    }
-
-    progress = "Complete"
     isRunning = false
   }
 
@@ -110,66 +98,70 @@ final class BenchmarkSuite {
     isRunning = true
     pipelineResult = nil
 
-    // #1707 Phase 3 (§3.2, row 23): hold a mutation claim for the FULL
-    // load+batch-transcribe duration below — released before the separate
-    // streaming portion (row 27) claims its own, since they are genuinely
-    // distinct engine-touching surfaces, not one operation.
-    guard tryBeginEngineMutation() else {
-      TelemetryService.shared.recoveryEngineActionDeferred(site: "benchmarkSuiteBatch")
-      isRunning = false
-      return
-    }
-    var batchClaimReleased = false
-    let releaseBatchClaim = {
-      guard !batchClaimReleased else { return }
-      batchClaimReleased = true
-      if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-    }
-    defer { releaseBatchClaim() }
+    // #1707 Phase 3 (§3.2, row 23) / #1741 Chunk 5: hold a mutation claim for
+    // the FULL load+batch-transcribe duration below — released before the
+    // separate streaming portion (row 27) claims its own, since they are
+    // genuinely distinct engine-touching surfaces, not one operation. The two
+    // claims map onto two separate `withClaim` calls, in sequence, never
+    // nested or overlapping — this closure's own natural return is what
+    // releases the batch claim, before the streaming `withClaim` below ever
+    // starts.
+    var testAudioDuration: TimeInterval = 0
+    var testSamples: [Float] = []
+    var batchTime: TimeInterval = 0
+    var batchTranscript = ""
+    var loadFailed = false
 
-    guard await ensureModelLoaded(using: activeEngine) else {
-      isRunning = false
-      return
-    }
-
-    // Load test audio — try jfk.wav from WhisperKit test resources, fall back to synthetic
-    let testAudioDuration: TimeInterval
-    let testSamples: [Float]
-
-    // Resolve jfk.wav relative to the bundle: .app is inside the project's build/ dir,
-    // so go up two levels (Contents/MacOS → .app → build/) then ../Tests/Resources/
-    let executableURL = Bundle.main.executableURL ?? URL(fileURLWithPath: "/")
-    let projectRoot =
-      executableURL
-      .deletingLastPathComponent()  // MacOS/
-      .deletingLastPathComponent()  // Contents/
-      .deletingLastPathComponent()  // EnviousWispr.app/
-      .deletingLastPathComponent()  // build/
-    let jfkURL = projectRoot.appendingPathComponent("Tests/Resources/jfk.wav")
-    if FileManager.default.fileExists(atPath: jfkURL.path) {
-      progress = "Loading test audio..."
-      do {
-        testSamples = try loadAudioFile(url: jfkURL)
-        testAudioDuration = Double(testSamples.count) / AudioConstants.sampleRate
-      } catch {
-        progress = "Failed to load test audio: \(error.localizedDescription)"
-        isRunning = false
+    let batchOutcome = await engineMutationScope.withClaim(site: "benchmarkSuiteBatch") {
+      guard await ensureModelLoaded(using: activeEngine) else {
+        loadFailed = true
         return
       }
-    } else {
-      testAudioDuration = 15.0
-      testSamples = generateTestAudio(duration: testAudioDuration)
-    }
 
-    // Step 1: Batch ASR
-    progress = "Running batch ASR..."
-    let batchStart = CFAbsoluteTimeGetCurrent()
-    let batchResult = try? await activeEngine.transcribe(testSamples, .default)
-    let batchTime = CFAbsoluteTimeGetCurrent() - batchStart
-    let batchTranscript = batchResult?.text ?? ""
-    // Row 23's claim covers only the batch work above — release it now,
-    // before row 27's genuinely separate streaming surface claims its own.
-    releaseBatchClaim()
+      // Load test audio — try jfk.wav from WhisperKit test resources, fall back to synthetic
+      // Resolve jfk.wav relative to the bundle: .app is inside the project's build/ dir,
+      // so go up two levels (Contents/MacOS → .app → build/) then ../Tests/Resources/
+      let executableURL = Bundle.main.executableURL ?? URL(fileURLWithPath: "/")
+      let projectRoot =
+        executableURL
+        .deletingLastPathComponent()  // MacOS/
+        .deletingLastPathComponent()  // Contents/
+        .deletingLastPathComponent()  // EnviousWispr.app/
+        .deletingLastPathComponent()  // build/
+      let jfkURL = projectRoot.appendingPathComponent("Tests/Resources/jfk.wav")
+      if FileManager.default.fileExists(atPath: jfkURL.path) {
+        progress = "Loading test audio..."
+        do {
+          testSamples = try loadAudioFile(url: jfkURL)
+          testAudioDuration = Double(testSamples.count) / AudioConstants.sampleRate
+        } catch {
+          progress = "Failed to load test audio: \(error.localizedDescription)"
+          loadFailed = true
+          return
+        }
+      } else {
+        testAudioDuration = 15.0
+        testSamples = generateTestAudio(duration: testAudioDuration)
+      }
+
+      // Step 1: Batch ASR
+      progress = "Running batch ASR..."
+      let batchStart = CFAbsoluteTimeGetCurrent()
+      let batchResult = try? await activeEngine.transcribe(testSamples, .default)
+      batchTime = CFAbsoluteTimeGetCurrent() - batchStart
+      batchTranscript = batchResult?.text ?? ""
+      // This closure's own return below is what releases row 23's claim
+      // (via `withClaim`'s `defer`) — before row 27's genuinely separate
+      // streaming surface claims its own, further down.
+    }
+    if case .refused = batchOutcome {
+      isRunning = false
+      return
+    }
+    if loadFailed {
+      isRunning = false
+      return
+    }
 
     // Step 2: Streaming ASR (if supported)
     var streamingFinalizeTime: TimeInterval?
@@ -179,89 +171,91 @@ final class BenchmarkSuite {
     let supportsStreaming = await asrManager.activeBackendSupportsStreaming
     if supportsStreaming {
       progress = "Running streaming ASR..."
-      // #1707 Phase 3 (§3.2, row 27): hold a mutation claim for the whole
-      // start/feed/finalize sequence below. Round 3 correction: releasing
-      // the claim is NOT simply "on completion or abort" — `finalizeStreaming()`
+      // #1707 Phase 3 (§3.2, row 27) / #1741 Chunk 5: hold a mutation claim
+      // for the whole start/feed/finalize sequence below. Releasing the
+      // claim is NOT simply "on completion or abort" — `finalizeStreaming()`
       // only clears streaming state after a SUCCESSFUL awaited finalize, so
       // any throw below must first `await asrManager.cancelStreaming()`
       // WHILE the claim is still held, and release only after that
       // cancellation completes (or after a successful finalize) — never on
       // the bare throw alone, or the claim would say "safe" while the
       // backend's streaming session is still actually active underneath.
-      guard tryBeginEngineMutation() else {
-        TelemetryService.shared.recoveryEngineActionDeferred(site: "benchmarkSuiteStreaming")
+      // The `do`/`catch` below absorbs every error INSIDE this closure so
+      // none of it ever escapes `withClaim`'s operation parameter: letting
+      // an error propagate out would run `withClaim`'s release/wake `defer`
+      // immediately, before the cancellation below has had a chance to run.
+      let streamingOutcome = await engineMutationScope.withClaim(site: "benchmarkSuiteStreaming") {
+        var startedStreaming = false
+        do {
+          try await asrManager.startStreaming(options: .default)
+          startedStreaming = true
+
+          // Chunk the samples into AVAudioPCMBuffers and feed them
+          let chunkSize = AudioConstants.captureBufferSize
+          let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: AudioConstants.sampleRate,
+            channels: AVAudioChannelCount(AudioConstants.channels),
+            interleaved: false
+          )!
+
+          var offset = 0
+          while offset < testSamples.count {
+            let remaining = testSamples.count - offset
+            let count = min(chunkSize, remaining)
+            let buffer = AVAudioPCMBuffer(
+              pcmFormat: format, frameCapacity: AVAudioFrameCount(count))!
+            buffer.frameLength = AVAudioFrameCount(count)
+            if let channelData = buffer.floatChannelData {
+              testSamples.withUnsafeBufferPointer { ptr in
+                channelData[0].update(from: ptr.baseAddress! + offset, count: count)
+              }
+            }
+            try await asrManager.feedAudio(buffer)
+            offset += count
+          }
+
+          let finalizeStart = CFAbsoluteTimeGetCurrent()
+          let streamResult = try await asrManager.finalizeStreaming()
+          streamingFinalizeTime = CFAbsoluteTimeGetCurrent() - finalizeStart
+          streamingTranscript = streamResult.text
+
+          // WER comparison (if both transcripts have content)
+          if !batchTranscript.isEmpty, let streaming = streamingTranscript, !streaming.isEmpty {
+            let werResult = WERCalculator.calculate(
+              reference: batchTranscript, hypothesis: streaming)
+            werDelta = werResult.wer
+          }
+          // Successful finalize — the backend's streaming session has
+          // genuinely ended; safe to let this closure return now, which
+          // releases the claim via `withClaim`'s own `defer`.
+        } catch {
+          // #1707 Phase 3 (§3.2, row 27 fix): `feed`/`finalize` throwing means
+          // the streaming session may still be genuinely active underneath —
+          // await the real cancellation WHILE the claim is still held (this
+          // closure has not returned yet, so `withClaim`'s release/wake
+          // `defer` has not fired), so recovery cannot acquire until the
+          // backend has actually stopped, not merely until this throw is
+          // caught. `startStreaming()` itself throwing means there is no
+          // active session to cancel.
+          if startedStreaming {
+            await asrManager.cancelStreaming()
+          }
+          Task {
+            await AppLogger.shared.log(
+              "Pipeline benchmark: streaming ASR failed: \(error.localizedDescription)",
+              level: .info, category: "Benchmark"
+            )
+          }
+        }
+      }
+      if case .refused = streamingOutcome {
         progress = "Pipeline benchmark complete"
         isRunning = false
         pipelineResult = PipelineBenchmarkResult(
           batchASRTime: batchTime, streamingFinalizeTime: nil, werDelta: nil,
           audioDuration: testAudioDuration)
         return
-      }
-      var streamingClaimReleased = false
-      let releaseStreamingClaim = {
-        guard !streamingClaimReleased else { return }
-        streamingClaimReleased = true
-        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-      }
-      var startedStreaming = false
-      do {
-        try await asrManager.startStreaming(options: .default)
-        startedStreaming = true
-
-        // Chunk the samples into AVAudioPCMBuffers and feed them
-        let chunkSize = AudioConstants.captureBufferSize
-        let format = AVAudioFormat(
-          commonFormat: .pcmFormatFloat32,
-          sampleRate: AudioConstants.sampleRate,
-          channels: AVAudioChannelCount(AudioConstants.channels),
-          interleaved: false
-        )!
-
-        var offset = 0
-        while offset < testSamples.count {
-          let remaining = testSamples.count - offset
-          let count = min(chunkSize, remaining)
-          let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(count))!
-          buffer.frameLength = AVAudioFrameCount(count)
-          if let channelData = buffer.floatChannelData {
-            testSamples.withUnsafeBufferPointer { ptr in
-              channelData[0].update(from: ptr.baseAddress! + offset, count: count)
-            }
-          }
-          try await asrManager.feedAudio(buffer)
-          offset += count
-        }
-
-        let finalizeStart = CFAbsoluteTimeGetCurrent()
-        let streamResult = try await asrManager.finalizeStreaming()
-        streamingFinalizeTime = CFAbsoluteTimeGetCurrent() - finalizeStart
-        streamingTranscript = streamResult.text
-
-        // WER comparison (if both transcripts have content)
-        if !batchTranscript.isEmpty, let streaming = streamingTranscript, !streaming.isEmpty {
-          let werResult = WERCalculator.calculate(reference: batchTranscript, hypothesis: streaming)
-          werDelta = werResult.wer
-        }
-        // Successful finalize — the backend's streaming session has
-        // genuinely ended; safe to release now.
-        releaseStreamingClaim()
-      } catch {
-        // #1707 Phase 3 (§3.2, row 27 fix): `feed`/`finalize` throwing means
-        // the streaming session may still be genuinely active underneath —
-        // await the real cancellation WHILE the claim is still held, so
-        // recovery cannot acquire until the backend has actually stopped,
-        // not merely until this throw is caught. `startStreaming()` itself
-        // throwing means there is no active session to cancel.
-        if startedStreaming {
-          await asrManager.cancelStreaming()
-        }
-        releaseStreamingClaim()
-        Task {
-          await AppLogger.shared.log(
-            "Pipeline benchmark: streaming ASR failed: \(error.localizedDescription)",
-            level: .info, category: "Benchmark"
-          )
-        }
       }
     }
 

--- a/Sources/EnviousWisprAppKit/App/DiagnosticsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DiagnosticsCoordinator.swift
@@ -1,3 +1,4 @@
+import EnviousWisprASR
 import Observation
 
 /// Owns the diagnostics-tab benchmark surface that the Settings →
@@ -8,5 +9,13 @@ import Observation
 @MainActor
 @Observable
 final class DiagnosticsCoordinator {
-  let benchmark = BenchmarkSuite()
+  let benchmark: BenchmarkSuite
+
+  /// #1741 Chunk 5 — threads the one shared `EngineMutationScope`
+  /// `WisprBootstrapper` constructs straight into `BenchmarkSuite`; not
+  /// stored here, since nothing else in this home needs it after
+  /// construction.
+  init(engineMutationScope: EngineMutationScope) {
+    benchmark = BenchmarkSuite(engineMutationScope: engineMutationScope)
+  }
 }

--- a/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
@@ -73,18 +73,15 @@ final class EngineCoordinator {
     /// Background warm of the given engine (the matching driver's
     /// `ensureEngineWarm`). The ONLY place a load failure surfaces.
     let warm: @MainActor (ASRBackendType) async -> EngineWarmupOutcome
-    /// #1707 Phase 3 (§3.2, row 4) — `EngineRecoveryGate.tryBeginMutation()`,
-    /// injected exactly like `isRecovering` above (this type never references
-    /// `EngineRecoveryGate` by concrete type). Bound by the composition root;
-    /// default keeps every existing test that doesn't wire a gate behaving as
-    /// before (always able to proceed).
-    var tryBeginEngineMutation: @MainActor () -> Bool = { true }
-    /// `EngineRecoveryGate.endMutation()` — returns whether recovery was
-    /// denied while this mutation was in flight and is now owed a wake-up.
-    var endEngineMutation: @MainActor () -> Bool = { false }
-    /// Called when `endEngineMutation()` returns true — wakes a stranded
-    /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-    var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+    /// #1707 Phase 3 (§3.2, row 4) / #1741 Chunk 7 — the shared
+    /// `EngineMutationScope` constructed once by the composition root (this
+    /// type never references `EngineRecoveryGate` by concrete type). Guards
+    /// `startWarm()`'s background convenience warm — recovery must never race
+    /// it. Required at construction (no default) — replaces the old defaulted
+    /// `tryBeginEngineMutation`/`endEngineMutation`/`wakeRecoveryIfOwed`
+    /// closure triplet; the scope's own `onRefused` closure now owns refusal
+    /// telemetry.
+    let engineMutationScope: EngineMutationScope
   }
 
   // MARK: - Published snapshot + gate
@@ -403,45 +400,43 @@ final class EngineCoordinator {
       // natural trigger (a future switch landing here, or a press's own
       // cold-press warm) re-attempts — no bespoke retry machinery for a
       // background convenience warm.
-      guard self.deps.tryBeginEngineMutation() else {
-        TelemetryService.shared.recoveryEngineActionDeferred(site: "startWarm")
+      let claimOutcome = await self.deps.engineMutationScope.withClaim(site: "startWarm") {
+        let start = ContinuousClock.now
+        let outcome = await self.deps.warm(backend)
         self.warmingBackend = nil
-        return
+        if Task.isCancelled { return }
+        let ms = Self.elapsedMs(since: start)
+        switch outcome {
+        case .ready:
+          TelemetryService.shared.engineWarm(
+            engine: backend.rawValue, durationMs: ms, outcome: "ready")
+          if case .failed = self.currentSwitchPhase { self.currentSwitchPhase = .idle }
+        case .failed:
+          // switchBackend itself cannot fail; a load failure is a WARM outcome.
+          // Honor the user's choice (active stays the newly-selected engine) and
+          // surface honestly — the next press takes the cold-press path. No tight
+          // retry; the next genuine poke/press re-attempts.
+          self.currentSwitchPhase = .failed(reason: "warm_failed")
+          TelemetryService.shared.engineWarm(
+            engine: backend.rawValue, durationMs: ms, outcome: "failed")
+          TelemetryService.shared.engineSwitchFailed(
+            engine: backend.rawValue, reason: "warm_failed")
+        case .cancelled:
+          // #1388: a deliberate cancel (user Cancel during the onboarding
+          // install, which shares the single-flighted load this warm joined) is
+          // a choice, not a failure — no failed switch phase, no
+          // engine_switch_failed. The next genuine poke/press re-attempts.
+          TelemetryService.shared.engineWarm(
+            engine: backend.rawValue, durationMs: ms, outcome: "cancelled")
+        }
+        // Readiness changed with NO kernel state transition, so `onStateChange`
+        // would miss it — self-poke so the published status reflects it AND any
+        // gate-4b-deferred switch re-arms (REV-4).
+        self.poke(.warmCompleted)
       }
-      defer {
-        if self.deps.endEngineMutation() { self.deps.wakeRecoveryIfOwed() }
+      if case .refused = claimOutcome {
+        self.warmingBackend = nil
       }
-      let start = ContinuousClock.now
-      let outcome = await self.deps.warm(backend)
-      self.warmingBackend = nil
-      if Task.isCancelled { return }
-      let ms = Self.elapsedMs(since: start)
-      switch outcome {
-      case .ready:
-        TelemetryService.shared.engineWarm(
-          engine: backend.rawValue, durationMs: ms, outcome: "ready")
-        if case .failed = self.currentSwitchPhase { self.currentSwitchPhase = .idle }
-      case .failed:
-        // switchBackend itself cannot fail; a load failure is a WARM outcome.
-        // Honor the user's choice (active stays the newly-selected engine) and
-        // surface honestly — the next press takes the cold-press path. No tight
-        // retry; the next genuine poke/press re-attempts.
-        self.currentSwitchPhase = .failed(reason: "warm_failed")
-        TelemetryService.shared.engineWarm(
-          engine: backend.rawValue, durationMs: ms, outcome: "failed")
-        TelemetryService.shared.engineSwitchFailed(engine: backend.rawValue, reason: "warm_failed")
-      case .cancelled:
-        // #1388: a deliberate cancel (user Cancel during the onboarding
-        // install, which shares the single-flighted load this warm joined) is
-        // a choice, not a failure — no failed switch phase, no
-        // engine_switch_failed. The next genuine poke/press re-attempts.
-        TelemetryService.shared.engineWarm(
-          engine: backend.rawValue, durationMs: ms, outcome: "cancelled")
-      }
-      // Readiness changed with NO kernel state transition, so `onStateChange`
-      // would miss it — self-poke so the published status reflects it AND any
-      // gate-4b-deferred switch re-arms (REV-4).
-      self.poke(.warmCompleted)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -1,3 +1,4 @@
+import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprModelDelivery
 import EnviousWisprPipeline
@@ -45,24 +46,31 @@ public final class ModelDeliveryHome {
   /// model whose baseline was never recorded is treated as not-first-run).
   private var firstRunByIdentity: [ModelIdentity: Bool] = [:]
 
-  /// #1707 Phase 3 (§3.2, row 17) — `EngineRecoveryGate.tryBeginMutation()`/
-  /// `endMutation()`, injected by the composition root (this type never
-  /// references `EngineRecoveryGate` by concrete type). Guards Parakeet's
-  /// Settings Download/Cancel — a separate guarded site from `ensureEngineWarm()`,
-  /// since Parakeet delivery admission does not always route through it.
-  /// Defaults keep every existing test/legacy construction unchanged (always
-  /// able to proceed).
-  var tryBeginEngineMutation: @MainActor () -> Bool = { true }
-  /// Returns whether recovery was denied while this mutation was in flight
-  /// and is now owed a wake-up.
-  var endEngineMutation: @MainActor () -> Bool = { false }
-  /// Called when `endEngineMutation()` returns true — wakes a stranded
-  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-  var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+  /// #1707 Phase 3 (§3.2, row 17) / #1741 Chunk 6 — the shared
+  /// `EngineMutationScope` constructed once by the composition root (this
+  /// type never references `EngineRecoveryGate` by concrete type). Guards
+  /// Parakeet's Settings Download/Cancel — a separate guarded site from
+  /// `ensureEngineWarm()`, since Parakeet delivery admission does not always
+  /// route through it. Required at construction (no default) — replaces the
+  /// old defaulted `tryBeginEngineMutation`/`endEngineMutation`/
+  /// `wakeRecoveryIfOwed` closure triplet; the scope's own `onRefused`
+  /// closure now owns refusal telemetry, so this home no longer emits it.
+  let engineMutationScope: EngineMutationScope
 
-  public init() {
+  /// #1741 Chunk 6 — the ONLY seam this type exposes for the two bundled
+  /// manifest loads below. Production ALWAYS passes `.main` (the signed
+  /// app's own bundle stays the trust root, contract §4a — unchanged);
+  /// `WisprBootstrapper` is the sole production construction site and does
+  /// so explicitly. A unit-test process's own `Bundle.main` cannot see these
+  /// resources (they ride the app target, not any framework/test bundle),
+  /// so tests pass a bundle pointed at the SAME committed manifest files
+  /// instead of a divergent fixture. Internal, not public — no other
+  /// consumer needs it.
+  init(engineMutationScope: EngineMutationScope, manifestBundle: Bundle) {
+    self.engineMutationScope = engineMutationScope
     do {
-      let manifest = try DeliveryManifest.loadBundled(resource: "parakeet-delivery-manifest")
+      let manifest = try DeliveryManifest.loadBundled(
+        resource: "parakeet-delivery-manifest", bundle: manifestBundle)
       let identity = manifest.identity
       let registration = DeliveryRegistration(
         manifest: manifest,
@@ -87,7 +95,8 @@ public final class ModelDeliveryHome {
     // observers wired above are per-identity for Parakeet's mirror only, and the
     // event bridge below them is already generic across every identity.
     do {
-      let manifest = try DeliveryManifest.loadBundled(resource: "whisperkit-delivery-manifest")
+      let manifest = try DeliveryManifest.loadBundled(
+        resource: "whisperkit-delivery-manifest", bundle: manifestBundle)
       let appSupport = FileManager.default.urls(
         for: .applicationSupportDirectory, in: .userDomainMask)[0]
       let registration = DeliveryRegistration(
@@ -169,16 +178,12 @@ public final class ModelDeliveryHome {
   public func cancelParakeetDownload() {
     guard let identity = parakeetIdentity else { return }
     Task { [weak self] in
+      guard let self else { return }
       // #1707 Phase 3 (§3.2, row 17): hold a mutation claim for the FULL
       // cancel-drain.
-      guard let self, self.tryBeginEngineMutation() else {
-        TelemetryService.shared.recoveryEngineActionDeferred(site: "parakeetCancelDownload")
-        return
+      _ = await self.engineMutationScope.withClaim(site: "parakeetCancelDownload") {
+        _ = await self.controller.cancel(identity)
       }
-      defer {
-        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-      }
-      _ = await self.controller.cancel(identity)
     }
   }
 
@@ -187,16 +192,12 @@ public final class ModelDeliveryHome {
   public func resumeParakeetDownload() {
     guard let handle = parakeetHandle else { return }
     Task { [weak self] in
+      guard let self else { return }
       // #1707 Phase 3 (§3.2, row 17): hold a mutation claim for the FULL
       // download.
-      guard let self, self.tryBeginEngineMutation() else {
-        TelemetryService.shared.recoveryEngineActionDeferred(site: "parakeetResumeDownload")
-        return
+      _ = await self.engineMutationScope.withClaim(site: "parakeetResumeDownload") {
+        _ = await handle.ensureAvailable()
       }
-      defer {
-        if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-      }
-      _ = await handle.ensureAvailable()
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -97,16 +97,16 @@ final class RecoveryCoordinator {
   /// switch while recovery is active). Default no-switch keeps tests unchanged.
   var isEngineSwitching: () -> Bool = { false }
 
-  /// #1707 Phase 3 (§3.2) — `EngineRecoveryGate.tryBeginRecovery()`/
-  /// `endRecovery()`, injected by the composition root exactly like
-  /// `isEngineSwitching` above (this type never references `EngineRecoveryGate`
-  /// by concrete type, matching the existing closure-injection convention).
-  /// `RecoveryCoordinator` is the SOLE owner of these calls — `RecoverySpool
-  /// Replayer` runs entirely underneath the already-held claim and never calls
-  /// them itself. Defaults keep every existing test that doesn't wire a gate
-  /// behaving as before (always able to claim).
-  var tryBeginRecoveryClaim: () -> Bool = { true }
-  var endRecoveryClaim: () -> Void = {}
+  /// #1707 Phase 3 (§3.2), required capability (#1741) — wraps
+  /// `EngineRecoveryGate.tryBeginRecovery()`/`endRecovery()`, constructed by
+  /// the composition root exactly like before (this type never references
+  /// `EngineRecoveryGate` by concrete type, matching the existing
+  /// closure-injection convention). `RecoveryCoordinator` is the SOLE owner
+  /// of these calls — `RecoverySpoolReplayer` runs entirely underneath the
+  /// already-held claim and never calls them itself. Required at
+  /// construction, no default — a test that wants always-able-to-claim opts
+  /// in explicitly via `.alwaysAllowedForTesting`.
+  private let recoveryEngineClaim: RecoveryEngineClaim
 
   /// #1707 Phase 3 (§3.1) — set by `RecordingStarter`'s refusal path when a
   /// live record-press was refused because recovery held the engine. Checked
@@ -171,6 +171,7 @@ final class RecoveryCoordinator {
     replayer: any RecoverySpoolReplaying,
     existingRecoveryIDs: @escaping @MainActor () async -> Set<String>,
     isDictationActive: @escaping @MainActor () -> Bool,
+    recoveryEngineClaim: RecoveryEngineClaim,
     resetEngine: @escaping @MainActor () -> Void = {}
   ) {
     self.keyStore = keyStore
@@ -178,6 +179,7 @@ final class RecoveryCoordinator {
     self.replayer = replayer
     self.existingRecoveryIDs = existingRecoveryIDs
     self.isDictationActive = isDictationActive
+    self.recoveryEngineClaim = recoveryEngineClaim
     self.resetEngine = resetEngine
   }
 
@@ -548,7 +550,7 @@ final class RecoveryCoordinator {
       // unloads/sets the active engine; starting recovery on top would race the
       // shared engine). Defer the remaining orphans — they stay on disk.
       guard !isDictationActive(), !isEngineSwitching() else { return false }
-      guard tryBeginRecoveryClaim() else {
+      guard recoveryEngineClaim.tryBegin() else {
         // The gate is held by an in-flight mutation; its `endMutation()`
         // wake-up (§3.2's `recoveryRetryOwed`) calls `requestRecoveryRecheck()`
         // when it releases, so stopping here is never a stranded deferral.
@@ -567,7 +569,7 @@ final class RecoveryCoordinator {
       defer {
         activeRecoveryID = nil
         isRecovering = false
-        endRecoveryClaim()
+        recoveryEngineClaim.end()
         onRecoveryComplete?()
       }
       let outcome = await replayer.replay(recoverySessionID: id) { [weak self] in

--- a/Sources/EnviousWisprAppKit/App/RecoveryEngineClaim.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryEngineClaim.swift
@@ -1,0 +1,24 @@
+// AppKit-local (not EnviousWisprASR) — its sole producer (WisprBootstrapper)
+// and sole consumer (RecoveryCoordinator) are both already here, so this
+// needs no cross-module visibility at all.
+
+@MainActor
+struct RecoveryEngineClaim {
+  private let tryBeginAction: @MainActor () -> Bool
+  private let endAction: @MainActor () -> Void
+
+  static func live(
+    tryBegin: @escaping @MainActor () -> Bool,
+    end: @escaping @MainActor () -> Void
+  ) -> Self {
+    Self(tryBeginAction: tryBegin, endAction: end)
+  }
+
+  /// Same structural mitigation as `EngineMutationScope.alwaysAllowedForTesting`
+  /// — zero production references, enforced by the same freeze test.
+  internal static let alwaysAllowedForTesting = Self(
+    tryBeginAction: { true }, endAction: {})
+
+  func tryBegin() -> Bool { tryBeginAction() }
+  func end() { endAction() }
+}

--- a/Sources/EnviousWisprAppKit/App/SetupCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/SetupCoordinator.swift
@@ -37,7 +37,7 @@ final class SetupCoordinator {
 
   init(
     asrManager: any ASRManagerInterface,
-    whisperKitSetup: WhisperKitSetupService = WhisperKitSetupService(),
+    whisperKitSetup: WhisperKitSetupService,
     setupStateReader: (@MainActor () -> WhisperKitSetupState)? = nil,
     runDocumentsMigration: @escaping @MainActor () async -> Void = {},
     preloadAction: @escaping @MainActor () async -> Void

--- a/Sources/EnviousWisprAppKit/App/WhisperKitDeliveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/WhisperKitDeliveryWiring.swift
@@ -22,7 +22,9 @@ enum WhisperKitDeliveryWiring {
     let setupService: WhisperKitSetupService
   }
 
-  static func make(modelDelivery: ModelDeliveryHome) -> Wired {
+  static func make(modelDelivery: ModelDeliveryHome, engineMutationScope: EngineMutationScope)
+    -> Wired
+  {
     let handle = modelDelivery.whisperKitHandle
     let installDirectory = modelDelivery.whisperKitRegistration?.installDirectory
     let trustedFiles = modelDelivery.whisperKitRegistration?.manifest.files.map {
@@ -76,7 +78,8 @@ enum WhisperKitDeliveryWiring {
         cancelActiveFetch: { [weak handle] in await handle?.cancelActiveFetch() },
         // Read again at the TOP of every run: retiring bytes while the switch is
         // off would strand a rollback user with neither model (Codex 2b-r1 P1).
-        isDeliveryEnabled: { [weak handle] in handle?.isEnabled() == true })
+        isDeliveryEnabled: { [weak handle] in handle?.isEnabled() == true },
+        engineMutationScope: engineMutationScope)
     }
     // The migration must not ship blind: retirement outcomes ride the shared
     // delivery funnel, same wiring shape as EG-1's bridge (#1386 PR-2b).
@@ -93,6 +96,7 @@ enum WhisperKitDeliveryWiring {
     // and never loaded, and the shipped `.notDownloaded` + Download button is the
     // honest answer for an engine whose model is not installed.
     let setupService = WhisperKitSetupService(
+      engineMutationScope: engineMutationScope,
       readAvailability: { [weak handle] in
         guard let handle else { return .notDownloaded }
         if await handle.isAdmitted() { return .ready }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -131,13 +131,6 @@ public final class WisprBootstrapper {
     // helper was collapsed away). The ASR helper below stays isolated.
     let audioCapture: any AudioCaptureInterface = AudioCaptureManager()
 
-    // XPC ASR service — default ON. ASR inference runs in a separate XPC
-    // service process for memory isolation. Escape hatch:
-    // `defaults write ... useXPCASRService -bool false`.
-    let useXPCASR = UserDefaults.standard.object(forKey: "useXPCASRService") as? Bool ?? true
-    let asrManager: any ASRManagerInterface =
-      useXPCASR ? ASRManagerProxy() : ASRManager()
-
     // #1707 Phase 3 (§3.2): the atomic mutual-exclusion primitive between
     // crash-recovery replay and every OTHER engine-mutating operation. One
     // instance per app session, injected downward as closures into every
@@ -145,7 +138,36 @@ public final class WisprBootstrapper {
     // `EnviousWisprAppKit` (the composition root is the only place both
     // this AppKit-level type and the lower-module call sites are in scope
     // together).
+    // #1741 Chunk 3 — moved before `asrManager` (was constructed 10 lines
+    // below it): `asrManager`'s new required `engineMutationScope` argument
+    // needs the gate, and the one shared capability value below, to already
+    // exist.
     let engineRecoveryGate = EngineRecoveryGate()
+    // #1741 Chunk 3 — forward reference for the shared scope's wake closure;
+    // `recoveryCoordinator` isn't constructed until much later in this
+    // function. Matches the existing `engineCoordinatorForRecoveryGate`
+    // forward-declared-then-assigned-after-construction pattern below.
+    weak var recoveryCoordinatorForEngineMutationScope: RecoveryCoordinator?
+    // #1741 — the ONE shared mutation-side capability (§3 construction-
+    // topology correction: one value, not one per consumer), threaded through
+    // each consumer's required initializer argument as this plan migrates it
+    // off the old defaulted-closure-triplet shape, one type at a time across
+    // several chunks. A consumer not yet migrated stays on its existing
+    // per-consumer closure wiring below until its own chunk lands.
+    let engineMutationScope = EngineMutationScope.live(
+      tryBegin: { [engineRecoveryGate] in engineRecoveryGate.tryBeginMutation() },
+      end: { [engineRecoveryGate] in engineRecoveryGate.endMutation() },
+      wake: { recoveryCoordinatorForEngineMutationScope?.requestRecoveryRecheck() },
+      onRefused: { site in TelemetryService.shared.recoveryEngineActionDeferred(site: site) })
+
+    // XPC ASR service — default ON. ASR inference runs in a separate XPC
+    // service process for memory isolation. Escape hatch:
+    // `defaults write ... useXPCASRService -bool false`.
+    let useXPCASR = UserDefaults.standard.object(forKey: "useXPCASRService") as? Bool ?? true
+    let asrManager: any ASRManagerInterface =
+      useXPCASR
+      ? ASRManagerProxy(engineMutationScope: engineMutationScope)
+      : ASRManager(engineMutationScope: engineMutationScope)
 
     let llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
 
@@ -170,7 +192,10 @@ public final class WisprBootstrapper {
     // §Decision A construction-order fix: the adapter must exist before launch
     // activation calls it). A failed bundled-manifest load leaves the Parakeet
     // handle nil (legacy path), unit-tested can't-happen.
-    let modelDelivery = ModelDeliveryHome()
+    // #1741 Chunk 6 — `.main` is the ONLY production value: the signed app's
+    // own bundle stays the manifest trust root (contract §4a), unchanged.
+    let modelDelivery = ModelDeliveryHome(
+      engineMutationScope: engineMutationScope, manifestBundle: .main)
 
     // #1707 Phase 2: `whisperKitBackend` is hoisted here (only these two
     // lines — NOT the full `whisperKitKernelDriver`, which still needs
@@ -181,7 +206,8 @@ public final class WisprBootstrapper {
     // is extracted from the SAME `whisperKit` value at its original site
     // further down — `whisperKit` is a plain `let` that survives the
     // intervening code.
-    let whisperKit = WhisperKitDeliveryWiring.make(modelDelivery: modelDelivery)
+    let whisperKit = WhisperKitDeliveryWiring.make(
+      modelDelivery: modelDelivery, engineMutationScope: engineMutationScope)
     let whisperKitBackend = whisperKit.backend
 
     // #1707 Phase 2: DEBUG fault-injection oracle (§11.1/§3.2a-i) — the SOLE
@@ -300,6 +326,7 @@ public final class WisprBootstrapper {
         keychainManager: keychainManager,
         captureTelemetry: captureTelemetry,
         pasteCompletionRegistry: pasteCompletionRegistry,
+        engineMutationScope: engineMutationScope,
         outputClassifierHolder: outputClassifierHolder,
         dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled },
         egOneRuntime: egOneRuntime,
@@ -350,6 +377,7 @@ public final class WisprBootstrapper {
         keychainManager: keychainManager,
         captureTelemetry: captureTelemetry,
         pasteCompletionRegistry: pasteCompletionRegistry,
+        engineMutationScope: engineMutationScope,
         outputClassifierHolder: outputClassifierHolder,
         dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled },
         egOneRuntime: egOneRuntime,
@@ -501,7 +529,7 @@ public final class WisprBootstrapper {
     if settings.selectedBackend == .parakeet {
       Task { [weak kernelDriver] in
         // Discard the outcome so the Task's Success type stays Void
-        // (`EngineWarmupOutcome` is @MainActor-only, not Sendable).
+        // (`EngineWarmupOutcome` does not declare Sendable conformance).
         _ = await kernelDriver?.ensureEngineWarm(reason: .launch)
       }
     }
@@ -512,7 +540,7 @@ public final class WisprBootstrapper {
     let activeEngine = ActiveEngineOperation.live(
       asrManager: asrManager, whisperKitBackend: whisperKitBackend)
 
-    let diagnosticsCoordinator = DiagnosticsCoordinator()
+    let diagnosticsCoordinator = DiagnosticsCoordinator(engineMutationScope: engineMutationScope)
 
     // PR4 of #763 construction-order constraint preserved: LanguageSuggestionPresenter
     // captures `recordingOverlay` through narrow closures.
@@ -614,6 +642,12 @@ public final class WisprBootstrapper {
     // `weak`, matching every other cross-reference between these two
     // coordinators in this file — avoids a retain cycle.
     weak var engineCoordinatorForRecoveryGate: EngineCoordinator?
+    // #1741 Chunk 2 — the recovery-side capability, required at construction
+    // (replacing the post-init `tryBeginRecoveryClaim`/`endRecoveryClaim`
+    // closure assignments this plan removes below).
+    let recoveryEngineClaim = RecoveryEngineClaim.live(
+      tryBegin: { [engineRecoveryGate] in engineRecoveryGate.tryBeginRecovery() },
+      end: { [engineRecoveryGate] in engineRecoveryGate.endRecovery() })
     let recoveryCoordinator = RecoveryCoordinator(
       keyStore: recoveryKeyStore,
       makeSpoolStore: makeRecoverySpoolStore,
@@ -626,12 +660,17 @@ public final class WisprBootstrapper {
         liveRecordingState.isDictationActive
           || (engineCoordinatorForRecoveryGate?.isMintingAnySession ?? false)
       },
+      recoveryEngineClaim: recoveryEngineClaim,
       // Discard hard-resets the ACTIVE engine (#445 service-kill) so an in-flight,
       // otherwise-uncancellable recovery load/transcribe aborts and the next
       // recording gets a clean engine. Routed through the active-engine door
       // because recovery itself runs there: resetting only the Parakeet manager
       // would leave a WhisperKit recovery uncancellable (Codex 2b-r2 P1).
       resetEngine: { [activeEngine] in Task { await activeEngine.hardCancel() } })
+    // #1741 Chunk 3 — now that `recoveryCoordinator` exists, the shared
+    // `engineMutationScope`'s wake closure (constructed before `asrManager`,
+    // above) can reach it.
+    recoveryCoordinatorForEngineMutationScope = recoveryCoordinator
     // #1063 PR2: the "recovering" pill's Discard action.
     recordingOverlay.setDiscardRecoveryHandler { [weak recoveryCoordinator] in
       recoveryCoordinator?.discardActiveRecovery()
@@ -672,13 +711,10 @@ public final class WisprBootstrapper {
           await (backend == .whisperKit ? whisperKitKernelDriver : kernelDriver)
             .ensureEngineWarm(reason: .engineSwap)
         },
-        // #1707 Phase 3 (§3.2, row 4): `startWarm()`'s background convenience
-        // warm must never race recovery on the shared engine.
-        tryBeginEngineMutation: { [engineRecoveryGate] in engineRecoveryGate.tryBeginMutation() },
-        endEngineMutation: { [engineRecoveryGate] in engineRecoveryGate.endMutation() },
-        wakeRecoveryIfOwed: { [weak recoveryCoordinator] in
-          recoveryCoordinator?.requestRecoveryRecheck()
-        }))
+        // #1707 Phase 3 (§3.2, row 4) / #1741 Chunk 7: `startWarm()`'s
+        // background convenience warm must never race recovery on the shared
+        // engine — guarded by the one shared `engineMutationScope`.
+        engineMutationScope: engineMutationScope))
     // GitHub cloud review, PR #1732: now that `engineCoordinator` exists,
     // `isDictationActive` (wired above) can read its minting state.
     engineCoordinatorForRecoveryGate = engineCoordinator
@@ -696,97 +732,43 @@ public final class WisprBootstrapper {
       engineCoordinator?.poke(.recoveryComplete)
     }
 
-    // #1707 Phase 3 (§3.1/§3.2/§3.4) — the `EngineRecoveryGate` wiring pass.
-    // `RecoveryCoordinator` is the SOLE owner of the recovery claim itself.
-    recoveryCoordinator.tryBeginRecoveryClaim = { [engineRecoveryGate] in
-      engineRecoveryGate.tryBeginRecovery()
-    }
-    recoveryCoordinator.endRecoveryClaim = { [engineRecoveryGate] in
-      engineRecoveryGate.endRecovery()
-    }
     // §3.4 wake-up table: a completed switch/warm/setup-change may unblock a
     // recovery pass that previously yielded.
     engineCoordinator.onEngineStateChangedForRecovery = { [weak recoveryCoordinator] in
       recoveryCoordinator?.requestRecoveryRecheck()
     }
     // Rows 4/12/13/15/16/18 (via `ensureEngineWarm()`'s shared choke point) +
-    // row 6 (propagated onto the WhisperKit adapter by `KernelDictationDriver`'s
-    // own `didSet`, since the adapter's concrete type is not visible here) +
-    // §3.4's "active dictation ended" wake-up cause.
+    // row 6 (the WhisperKit adapter) + row 21 (the owned
+    // `RecordingSessionKernel`'s `preWarm()`) — #1741 Chunk 9: `kernelDriver`
+    // and `whisperKitKernelDriver`, their owned kernels, and the WhisperKit
+    // adapter all received the shared `engineMutationScope` directly at
+    // THEIR OWN construction, via the factories above; no post-init
+    // forwarding needed here anymore. §3.4's "active dictation ended" wake-up
+    // cause still needs per-driver wiring.
     for driver in [kernelDriver, whisperKitKernelDriver] {
-      driver.tryBeginEngineMutation = { [engineRecoveryGate] in
-        engineRecoveryGate.tryBeginMutation()
-      }
-      driver.endEngineMutation = { [engineRecoveryGate] in engineRecoveryGate.endMutation() }
-      driver.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
-        recoveryCoordinator?.requestRecoveryRecheck()
-      }
       driver.onDictationEndedForRecovery = { [weak recoveryCoordinator] in
         recoveryCoordinator?.requestRecoveryRecheck()
       }
     }
-    // Row 7: Parakeet's idle-unload choke point. Concrete-type downcast — these
-    // closures are not part of `ASRManagerInterface` (only the composition root
-    // needs them, so widening the protocol for every conformer is unwarranted).
-    if let asrManager = asrManager as? ASRManager {
-      asrManager.tryBeginEngineMutation = { [engineRecoveryGate] in
-        engineRecoveryGate.tryBeginMutation()
-      }
-      asrManager.endEngineMutation = { [engineRecoveryGate] in engineRecoveryGate.endMutation() }
-      asrManager.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
-        recoveryCoordinator?.requestRecoveryRecheck()
-      }
-    }
-    if let asrManagerProxy = asrManager as? ASRManagerProxy {
-      asrManagerProxy.tryBeginEngineMutation = { [engineRecoveryGate] in
-        engineRecoveryGate.tryBeginMutation()
-      }
-      asrManagerProxy.endEngineMutation = { [engineRecoveryGate] in
-        engineRecoveryGate.endMutation()
-      }
-      asrManagerProxy.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
-        recoveryCoordinator?.requestRecoveryRecheck()
-      }
-    }
-    // Rows 9/10: WhisperKit Settings Remove/Download/Cancel.
-    let whisperKitSetupForGate = whisperKit.setupService
-    whisperKitSetupForGate.tryBeginEngineMutation = { [engineRecoveryGate] in
-      engineRecoveryGate.tryBeginMutation()
-    }
-    whisperKitSetupForGate.endEngineMutation = { [engineRecoveryGate] in
-      engineRecoveryGate.endMutation()
-    }
-    whisperKitSetupForGate.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
-      recoveryCoordinator?.requestRecoveryRecheck()
-    }
-    // Row 14: the WhisperKit legacy-migration delete+refetch window.
-    whisperKitRetirement?.tryBeginEngineMutation = { [engineRecoveryGate] in
-      engineRecoveryGate.tryBeginMutation()
-    }
-    whisperKitRetirement?.endEngineMutation = { [engineRecoveryGate] in
-      engineRecoveryGate.endMutation()
-    }
-    whisperKitRetirement?.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
-      recoveryCoordinator?.requestRecoveryRecheck()
-    }
-    // Row 17: Parakeet Settings Download/Cancel.
-    modelDelivery.tryBeginEngineMutation = { [engineRecoveryGate] in
-      engineRecoveryGate.tryBeginMutation()
-    }
-    modelDelivery.endEngineMutation = { [engineRecoveryGate] in engineRecoveryGate.endMutation() }
-    modelDelivery.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
-      recoveryCoordinator?.requestRecoveryRecheck()
-    }
+    // Row 7: Parakeet's idle-unload choke point. #1741 Chunk 3 — `asrManager`
+    // (whichever concrete type) already received the shared `engineMutationScope`
+    // at construction, above; no post-init wiring needed here anymore.
+    // Rows 9/10: WhisperKit Settings Remove/Download/Cancel. #1741 Chunk 4 —
+    // `whisperKit.setupService` already received the shared `engineMutationScope`
+    // at construction, via `WhisperKitDeliveryWiring.make(...)` above; no
+    // post-init wiring needed here anymore.
+    // Row 14: the WhisperKit legacy-migration delete+refetch window. #1741
+    // Chunk 8 — `whisperKitRetirement` already received the shared
+    // `engineMutationScope` at construction, via
+    // `WhisperKitDeliveryWiring.make(...)` above; no post-init wiring needed
+    // here anymore.
+    // Row 17: Parakeet Settings Download/Cancel. #1741 Chunk 6 —
+    // `modelDelivery` already received the shared `engineMutationScope` at
+    // construction, above; no post-init wiring needed here anymore.
     // Rows 23/27: the Diagnostics benchmark suite (DEBUG-only surface).
-    let benchmarkForGate = diagnosticsCoordinator.benchmark
-    benchmarkForGate.tryBeginEngineMutation = { [engineRecoveryGate] in
-      engineRecoveryGate.tryBeginMutation()
-    }
-    benchmarkForGate.endEngineMutation = { [engineRecoveryGate] in engineRecoveryGate.endMutation()
-    }
-    benchmarkForGate.wakeRecoveryIfOwed = { [weak recoveryCoordinator] in
-      recoveryCoordinator?.requestRecoveryRecheck()
-    }
+    // #1741 Chunk 5 — `diagnosticsCoordinator.benchmark` already received the
+    // shared `engineMutationScope` at construction, above; no post-init
+    // wiring needed here anymore.
 
     let lastRecordingResult = LastRecordingResult()
     let backendMetadata = BackendMetadata(

--- a/Sources/EnviousWisprPipeline/KernelAdapterFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelAdapterFactory.swift
@@ -49,10 +49,12 @@ package enum KernelAdapterFactory {
     backend: any WhisperKitBackendDriving,
     languageDetector: LanguageDetector,
     audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64,
+    engineMutationScope: EngineMutationScope,
     batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) -> any ASREngineAdapter {
     WhisperKitEngineAdapter(
       backend: backend,
+      engineMutationScope: engineMutationScope,
       languageDetector: languageDetector,
       audioCaptureSessionIDSource: audioCaptureSessionIDSource,
       batchDecodeFaultController: batchDecodeFaultController)

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1,4 +1,5 @@
 import AppKit
+import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprServices
@@ -47,8 +48,8 @@ public enum EngineWarmupReason: Sendable {
 /// callers (a warm-up failure must not crash the heart-path press), so it
 /// reports the result as a value. Most callers discard it (they re-read live
 /// readiness); onboarding consumes `.failed` to drive its "download failed →
-/// Retry" UX, which needs the underlying error. Not `Sendable` — produced and
-/// consumed on the `@MainActor`.
+/// Retry" UX, which needs the underlying error. Does not declare `Sendable`
+/// conformance; produced and consumed on the `@MainActor`.
 ///
 /// #1388: `.cancelled` is a user-chosen terminal, NOT a failure. A user's
 /// Cancel during the onboarding install (or a task cancellation of the
@@ -349,41 +350,17 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   @ObservationIgnored
   public var onDictationEndedForRecovery: (@MainActor () -> Void)?
 
-  /// #1707 Phase 3 (§3.2) — `EngineRecoveryGate.tryBeginMutation()`/
-  /// `endMutation()`, injected exactly like `onStateChange` above. Bound by
-  /// the composition root; defaults keep every existing test/legacy
-  /// construction unchanged (always able to proceed). `didSet` also forwards
-  /// the SAME closure onto (a) a `WhisperKitEngineAdapter` (row 6's
-  /// idle-unload guard, `WhisperKitEngineAdapter.swift`) when this driver's
-  /// adapter is one, and (b) the owned `RecordingSessionKernel` (row 21's
-  /// `preWarm()` guard) — `WisprBootstrapper` sets these once here, never on
-  /// either directly, since neither concrete type is visible outside
-  /// `EnviousWisprPipeline`.
+  /// #1707 Phase 3 (§3.2) / #1741 Chunk 9 — the shared `EngineMutationScope`
+  /// constructed once by the composition root, injected exactly like
+  /// `onStateChange` above. Guards this driver's own `ensureEngineWarm(_:)`
+  /// claim (row 4/12/13/15/16/18's single shared choke point). The owned
+  /// `RecordingSessionKernel` (row 21's `preWarm()` guard) and, when this
+  /// driver's adapter is a `WhisperKitEngineAdapter` (row 6's idle-unload
+  /// guard), the adapter itself now each receive the SAME shared value
+  /// directly at THEIR OWN construction, via the factories — no more
+  /// post-construction forwarding through this property.
   @ObservationIgnored
-  public var tryBeginEngineMutation: @MainActor () -> Bool = { true } {
-    didSet {
-      (adapter as? WhisperKitEngineAdapter)?.tryBeginEngineMutation = tryBeginEngineMutation
-      kernel.tryBeginEngineMutation = tryBeginEngineMutation
-    }
-  }
-  /// Returns whether recovery was denied while this mutation was in flight
-  /// and is now owed a wake-up.
-  @ObservationIgnored
-  public var endEngineMutation: @MainActor () -> Bool = { false } {
-    didSet {
-      (adapter as? WhisperKitEngineAdapter)?.endEngineMutation = endEngineMutation
-      kernel.endEngineMutation = endEngineMutation
-    }
-  }
-  /// Called when `endEngineMutation()` returns true — wakes a stranded
-  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-  @ObservationIgnored
-  public var wakeRecoveryIfOwed: @MainActor () -> Void = {} {
-    didSet {
-      (adapter as? WhisperKitEngineAdapter)?.wakeRecoveryIfOwed = wakeRecoveryIfOwed
-      kernel.wakeRecoveryIfOwed = wakeRecoveryIfOwed
-    }
-  }
+  package let engineMutationScope: EngineMutationScope
 
   /// Fire-once latch for `onSessionEndedWithoutSave` (#1548 D1). Tracks the
   /// `currentSessionID` the ended-without-save check last fired for, so a
@@ -449,6 +426,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     context: KernelSessionContext,
     steps: LimbSteps,
     adapter: any ASREngineAdapter,
+    engineMutationScope: EngineMutationScope,
     captureErrorSink: @escaping KernelDictationDriverFactory.HeartPathCaptureErrorSink =
       KernelDictationDriverFactory.defaultCaptureErrorSink
   ) {
@@ -458,6 +436,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     self.context = context
     self.steps = steps
     self.adapter = adapter
+    self.engineMutationScope = engineMutationScope
     self.captureErrorSink = captureErrorSink
     self.lastFiredState = Self.pipelineState(
       for: kernel.state, outcome: kernel.recordingOutcome, externalReason: nil)
@@ -537,84 +516,88 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         sessionlessWedgeGuard = nil
       }
     }
-    // #1707 Phase 3 (§3.2) — the SINGLE shared choke point every warm-up site
-    // routes through (per this method's own doc comment above), so gating
-    // here closes rows 2/9/10/12/13/15/16/18 at once rather than at each
-    // caller separately. Hold the claim for the FULL awaited `warmUp()`, not
-    // a point-in-time check. A denied claim (recovery holds the engine) is
-    // reported as `.cancelled` — a deliberate system choice, not a failure —
-    // so callers never surface the error UI for it; the next genuine
-    // poke/press re-attempts.
-    guard tryBeginEngineMutation() else {
-      TelemetryService.shared.recoveryEngineActionDeferred(site: "ensureEngineWarm")
-      return .cancelled
-    }
-    defer {
-      if endEngineMutation() { wakeRecoveryIfOwed() }
-    }
-    do {
-      try await adapter.warmUp()
-      residentModelLostWhileIdle = false  // #959: load succeeded — drop stale marker.
-      let ms = Self.elapsedMs(since: start)
-      // #1388: un-truncated install-phase observation. With gate (B) removed
-      // there is no auto-abort at 15s, so the success event finally records
-      // what real installs look like (duration + longest internal silence).
-      // Nil when no guard covered this warm-up (WhisperKit, in-process debug).
-      let install = observedGuard?.installObservation
-      TelemetryService.shared.coldStartWarmupCompleted(
-        engine: engine, reason: reason.telemetryToken, durationMs: ms,
-        inferenceWarmupMs: adapter.lastWarmupInferenceMs,
-        installDurationMs: install?.durationMs,
-        installSilenceMaxMs: install?.silenceMaxMs)
-      if reason == .launch {
-        TelemetryService.shared.launchModelPreloadCompleted(
-          backend: engine, result: warmupInFlight ? "joined_in_flight" : "success",
-          durationMs: ms)
+    // #1707 Phase 3 (§3.2) / #1741 Chunk 9 — the SINGLE shared choke point
+    // every warm-up site routes through (per this method's own doc comment
+    // above), so gating here closes rows 2/9/10/12/13/15/16/18 at once rather
+    // than at each caller separately. Hold the claim for the FULL awaited
+    // `warmUp()`, not a point-in-time check. A denied claim (recovery holds
+    // the engine) is reported as `.cancelled` — a deliberate system choice,
+    // not a failure — so callers never surface the error UI for it; the next
+    // genuine poke/press re-attempts.
+    //
+    // `EngineWarmupOutcome` does not declare `Sendable` conformance, so it
+    // cannot be `withClaim`'s generic `T` directly — the operation closure
+    // mutates this local instead of returning through T, then the claim's
+    // own outcome (never the local's stale initial value) decides the final
+    // return.
+    var warmResult: EngineWarmupOutcome = .cancelled
+    let claimOutcome = await engineMutationScope.withClaim(site: "ensureEngineWarm") {
+      do {
+        try await adapter.warmUp()
+        residentModelLostWhileIdle = false  // #959: load succeeded — drop stale marker.
+        let ms = Self.elapsedMs(since: start)
+        // #1388: un-truncated install-phase observation. With gate (B) removed
+        // there is no auto-abort at 15s, so the success event finally records
+        // what real installs look like (duration + longest internal silence).
+        // Nil when no guard covered this warm-up (WhisperKit, in-process debug).
+        let install = observedGuard?.installObservation
+        TelemetryService.shared.coldStartWarmupCompleted(
+          engine: engine, reason: reason.telemetryToken, durationMs: ms,
+          inferenceWarmupMs: adapter.lastWarmupInferenceMs,
+          installDurationMs: install?.durationMs,
+          installSilenceMaxMs: install?.silenceMaxMs)
+        if reason == .launch {
+          TelemetryService.shared.launchModelPreloadCompleted(
+            backend: engine, result: warmupInFlight ? "joined_in_flight" : "success",
+            durationMs: ms)
+        }
+        warmResult = .ready
+      } catch {
+        let ms = Self.elapsedMs(since: start)
+        switch Self.classifyWarmupThrow(error, guardFired: observedGuard?.didFire == true) {
+        case .wedge:
+          // A guard fire is a detector VERDICT — with gate (B) removed this can
+          // only be gate (A): the service reported nothing whatsoever inside
+          // the deadline. Classified as the wedge it actually is so onboarding
+          // shows the setup-failure copy + Retry, not a raw transport string.
+          let classified: any Error = ModelLoadWatchdog.WedgeError()
+          TelemetryService.shared.coldStartWarmupFailed(
+            engine: engine, reason: reason.telemetryToken,
+            error: String(describing: classified))
+          if reason == .launch {
+            TelemetryService.shared.launchModelPreloadCompleted(
+              backend: engine, result: "failed", durationMs: ms)
+          }
+          warmResult = .failed(classified)
+        case .cancelled:
+          // A deliberate cancel (user Cancel via `cancelInFlightLoad`, or a
+          // cancelled surrounding task / delivery download cancel) is a CHOICE:
+          // never `warmup_failed`, never the error UI. `install_cancelled` is
+          // the population signal for how often users bail out of the wait.
+          TelemetryService.shared.installCancelled(
+            engine: engine, reason: reason.telemetryToken, durationMs: ms)
+          if reason == .launch {
+            TelemetryService.shared.launchModelPreloadCompleted(
+              backend: engine, result: "cancelled", durationMs: ms)
+          }
+          warmResult = .cancelled
+        case .failure:
+          // Everything else is a genuine failure with the true underlying
+          // error (typed transport error on service death — step 1 made that
+          // path actually resume; before #1388 it hung with no outcome).
+          TelemetryService.shared.coldStartWarmupFailed(
+            engine: engine, reason: reason.telemetryToken,
+            error: String(describing: error))
+          if reason == .launch {
+            TelemetryService.shared.launchModelPreloadCompleted(
+              backend: engine, result: "failed", durationMs: ms)
+          }
+          warmResult = .failed(error)
+        }
       }
-      return .ready
-    } catch {
-      let ms = Self.elapsedMs(since: start)
-      switch Self.classifyWarmupThrow(error, guardFired: observedGuard?.didFire == true) {
-      case .wedge:
-        // A guard fire is a detector VERDICT — with gate (B) removed this can
-        // only be gate (A): the service reported nothing whatsoever inside
-        // the deadline. Classified as the wedge it actually is so onboarding
-        // shows the setup-failure copy + Retry, not a raw transport string.
-        let classified: any Error = ModelLoadWatchdog.WedgeError()
-        TelemetryService.shared.coldStartWarmupFailed(
-          engine: engine, reason: reason.telemetryToken,
-          error: String(describing: classified))
-        if reason == .launch {
-          TelemetryService.shared.launchModelPreloadCompleted(
-            backend: engine, result: "failed", durationMs: ms)
-        }
-        return .failed(classified)
-      case .cancelled:
-        // A deliberate cancel (user Cancel via `cancelInFlightLoad`, or a
-        // cancelled surrounding task / delivery download cancel) is a CHOICE:
-        // never `warmup_failed`, never the error UI. `install_cancelled` is
-        // the population signal for how often users bail out of the wait.
-        TelemetryService.shared.installCancelled(
-          engine: engine, reason: reason.telemetryToken, durationMs: ms)
-        if reason == .launch {
-          TelemetryService.shared.launchModelPreloadCompleted(
-            backend: engine, result: "cancelled", durationMs: ms)
-        }
-        return .cancelled
-      case .failure:
-        // Everything else is a genuine failure with the true underlying
-        // error (typed transport error on service death — step 1 made that
-        // path actually resume; before #1388 it hung with no outcome).
-        TelemetryService.shared.coldStartWarmupFailed(
-          engine: engine, reason: reason.telemetryToken,
-          error: String(describing: error))
-        if reason == .launch {
-          TelemetryService.shared.launchModelPreloadCompleted(
-            backend: engine, result: "failed", durationMs: ms)
-        }
-        return .failed(error)
-      }
     }
+    if case .refused = claimOutcome { return .cancelled }
+    return warmResult
   }
 
   /// #1388: how a warm-up throw maps to a terminal outcome.

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -103,6 +103,10 @@ public enum KernelDictationDriverFactory {
     /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1/§3.2a-i) — nil in
     /// every existing test call site.
     package let batchDecodeFaultController: BatchDecodeFaultController?
+    /// #1741 Chunk 9 — the shared `EngineMutationScope` constructed once by
+    /// the composition root, threaded into the driver and kernel this
+    /// factory builds. Required — no default.
+    package let engineMutationScope: EngineMutationScope
 
     /// Explicit package init: Swift's synthesized memberwise init is `internal`
     /// and would prevent App callers from constructing this struct. `@MainActor`
@@ -118,6 +122,7 @@ public enum KernelDictationDriverFactory {
       keychainManager: KeychainManager,
       captureTelemetry: CaptureTelemetryState,
       pasteCompletionRegistry: PasteCompletionRegistry,
+      engineMutationScope: EngineMutationScope,
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
       dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
@@ -132,6 +137,7 @@ public enum KernelDictationDriverFactory {
       self.keychainManager = keychainManager
       self.captureTelemetry = captureTelemetry
       self.pasteCompletionRegistry = pasteCompletionRegistry
+      self.engineMutationScope = engineMutationScope
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
       self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
@@ -168,6 +174,10 @@ public enum KernelDictationDriverFactory {
     /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1/§3.2a-i) — nil in
     /// every existing test call site.
     package let batchDecodeFaultController: BatchDecodeFaultController?
+    /// #1741 Chunk 9 — the shared `EngineMutationScope` constructed once by
+    /// the composition root, threaded into the driver, kernel, and
+    /// `WhisperKitEngineAdapter` this factory builds. Required — no default.
+    package let engineMutationScope: EngineMutationScope
 
     /// Explicit package init — same reasoning as `ParakeetInputs.init`.
     /// `languageDetector` is intentionally non-optional (no default) so the
@@ -186,6 +196,7 @@ public enum KernelDictationDriverFactory {
       keychainManager: KeychainManager,
       captureTelemetry: CaptureTelemetryState,
       pasteCompletionRegistry: PasteCompletionRegistry,
+      engineMutationScope: EngineMutationScope,
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
       dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
@@ -200,6 +211,7 @@ public enum KernelDictationDriverFactory {
       self.keychainManager = keychainManager
       self.captureTelemetry = captureTelemetry
       self.pasteCompletionRegistry = pasteCompletionRegistry
+      self.engineMutationScope = engineMutationScope
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
       self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
@@ -258,6 +270,7 @@ public enum KernelDictationDriverFactory {
       keychainManager: inputs.keychainManager,
       captureTelemetry: inputs.captureTelemetry,
       pasteCompletionRegistry: inputs.pasteCompletionRegistry,
+      engineMutationScope: inputs.engineMutationScope,
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
       dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider,
@@ -281,6 +294,7 @@ public enum KernelDictationDriverFactory {
       backend: inputs.whisperKitBackend,
       languageDetector: inputs.languageDetector,
       audioCaptureSessionIDSource: { captureSource.currentCaptureSessionID },
+      engineMutationScope: inputs.engineMutationScope,
       batchDecodeFaultController: inputs.batchDecodeFaultController)
     return assembleDriver(
       adapter: adapter,
@@ -290,6 +304,7 @@ public enum KernelDictationDriverFactory {
       keychainManager: inputs.keychainManager,
       captureTelemetry: inputs.captureTelemetry,
       pasteCompletionRegistry: inputs.pasteCompletionRegistry,
+      engineMutationScope: inputs.engineMutationScope,
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
       dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider,
@@ -310,6 +325,7 @@ public enum KernelDictationDriverFactory {
     keychainManager: KeychainManager,
     captureTelemetry: CaptureTelemetryState,
     pasteCompletionRegistry: PasteCompletionRegistry,
+    engineMutationScope: EngineMutationScope,
     captureErrorSink: @escaping HeartPathCaptureErrorSink,
     outputClassifierHolder: OutputClassifierHolder? = nil,
     dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
@@ -413,6 +429,7 @@ public enum KernelDictationDriverFactory {
       processText: wiring.processText,
       store: wiring.store,
       deliver: wiring.deliver,
+      engineMutationScope: engineMutationScope,
       // Production wedge-stall window — `RecordingSessionKernel` defaults
       // to 2 ticks (test-only value); with the wiring's 100ms tick clock
       // that would cancel cold model loads after ~200ms instead of the
@@ -515,6 +532,7 @@ public enum KernelDictationDriverFactory {
       context: context,
       steps: limbSteps,
       adapter: adapter,
+      engineMutationScope: engineMutationScope,
       captureErrorSink: captureErrorSink
     )
     driver.start()  // arms driver-side state observation (PR-4a)

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprServices
@@ -535,22 +536,17 @@ final class RecordingSessionKernel {
   /// user-facing copy lives here — copy stays in the App layer.
   var onApproachingMaxDuration: (@MainActor (TimeInterval) -> Void)?
 
-  /// #1707 Phase 3 (§3.2, row 21) — `EngineRecoveryGate.tryBeginMutation()`/
-  /// `endMutation()`, injected exactly like `onApproachingMaxDuration` above
-  /// (this type never references `EngineRecoveryGate` by concrete type).
-  /// Guards `preWarm()`'s spawned adapter warm-up — the single most
-  /// surprising gap this phase closes: that warm-up runs BEFORE the session
-  /// reaches `.arming` (`state == .idle` still holds), so a recovery replay
-  /// could otherwise be racing an unsupervised warm-up here. Defaults keep
-  /// every existing test/legacy construction unchanged (always able to
-  /// proceed).
-  var tryBeginEngineMutation: @MainActor () -> Bool = { true }
-  /// Returns whether recovery was denied while this mutation was in flight
-  /// and is now owed a wake-up.
-  var endEngineMutation: @MainActor () -> Bool = { false }
-  /// Called when `endEngineMutation()` returns true — wakes a stranded
-  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-  var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+  /// #1707 Phase 3 (§3.2, row 21) / #1741 Chunk 9 — the shared
+  /// `EngineMutationScope` constructed once by the composition root, injected
+  /// exactly like `onApproachingMaxDuration` above (this type never
+  /// references `EngineRecoveryGate` by concrete type). Guards `preWarm()`'s
+  /// spawned adapter warm-up — the single most surprising gap this phase
+  /// closes: that warm-up runs BEFORE the session reaches `.arming`
+  /// (`state == .idle` still holds), so a recovery replay could otherwise be
+  /// racing an unsupervised warm-up here. Required at construction (no
+  /// default) — replaces the old defaulted `tryBeginEngineMutation`/
+  /// `endEngineMutation`/`wakeRecoveryIfOwed` closure triplet.
+  let engineMutationScope: EngineMutationScope
 
   /// Low-cardinality reason the most recent recording stopped, set when the
   /// recording-exit latches and cleared at session start (#1060). Read by the
@@ -698,6 +694,7 @@ final class RecordingSessionKernel {
     ) async throws -> String,
     store: @escaping @MainActor (_ text: String, _ transcriptID: UUID) async throws -> Void,
     deliver: @escaping @MainActor (_ text: String) async -> KernelDeliveryOutcome,
+    engineMutationScope: EngineMutationScope,
     wedgeStallTicks: Int = 2,
     minimumRecordingTicks: Int = 5,
     zombieZeroPeakTelemetry: @escaping @MainActor (ZeroPeakContext) -> Void = { _ in },
@@ -736,6 +733,7 @@ final class RecordingSessionKernel {
     self.processText = processText
     self.store = store
     self.deliver = deliver
+    self.engineMutationScope = engineMutationScope
     self.wedgeStallTicks = wedgeStallTicks
     self.minimumRecordingTicks = minimumRecordingTicks
     self.zombieZeroPeakTelemetry = zombieZeroPeakTelemetry
@@ -946,28 +944,25 @@ final class RecordingSessionKernel {
     // Adapter warm-up is spawned (can be a slow cold model load; the session's
     // own warmUp re-checks readiness and reruns cold if needed).
     //
-    // #1707 Phase 3 (§3.2, row 21): hold a mutation claim for the FULL
-    // awaited warm-up — this runs while `state == .idle`, BEFORE the session
-    // is confirmed active, so recovery must never race it. A denied claim
-    // (recovery holds the engine) skips this attempt; the session's own
+    // #1707 Phase 3 (§3.2, row 21) / #1741 Chunk 9: hold a mutation claim for
+    // the FULL awaited warm-up — this runs while `state == .idle`, BEFORE the
+    // session is confirmed active, so recovery must never race it. A denied
+    // claim (recovery holds the engine) skips this attempt; the session's own
     // in-session `warmUp(_:)` (row 22, already structurally safe) re-checks
     // readiness and reruns cold if needed, so no bespoke retry machinery is
-    // needed for this best-effort pre-warm.
-    spawn(sid) { [adapter, weak self] in
-      // `self` gone ⇒ proceed anyway (matches this task's existing tolerance
-      // for a deallocated kernel — `self?.log(...)` below already no-ops).
-      guard self?.tryBeginEngineMutation() ?? true else {
-        TelemetryService.shared.recoveryEngineActionDeferred(site: "preWarm")
-        return
-      }
-      defer {
-        if let self, self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-      }
-      do {
-        try await adapter.warmUp()
-        self?.log("preWarm adapter.warmUp succeeded sid=\(sid.raw)")
-      } catch {
-        self?.log("preWarm adapter.warmUp failed sid=\(sid.raw) error=\(error)")
+    // needed for this best-effort pre-warm. `engineMutationScope` is
+    // captured directly (like `adapter`), not read through `self` — the SAME
+    // "self gone ⇒ proceed anyway" tolerance the old `?? true` fallback gave
+    // this task now holds structurally: the claim check no longer depends on
+    // the kernel surviving at all.
+    spawn(sid) { [adapter, engineMutationScope, weak self] in
+      _ = await engineMutationScope.withClaim(site: "preWarm") {
+        do {
+          try await adapter.warmUp()
+          self?.log("preWarm adapter.warmUp succeeded sid=\(sid.raw)")
+        } catch {
+          self?.log("preWarm adapter.warmUp failed sid=\(sid.raw) error=\(error)")
+        }
       }
     }
     // Capture pre-warm is awaited end-to-end (Codex r4): the BT codec

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -251,20 +251,15 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// this remains settable but unused inside the adapter.
   var onEngineInterrupted: (@MainActor () -> Void)?
 
-  /// #1707 Phase 3 (§3.2, row 6) — `EngineRecoveryGate.tryBeginMutation()`/
-  /// `endMutation()`, injected exactly like `onEngineInterrupted` above (this
-  /// type never references `EngineRecoveryGate` by concrete type). Guards
-  /// `applyUnloadPolicy()`'s idle-timer unload — a background actor
-  /// unrelated to any active session, so recovery must never race it.
-  /// Defaults keep every existing test/legacy construction unchanged
-  /// (always able to proceed).
-  var tryBeginEngineMutation: @MainActor () -> Bool = { true }
-  /// Returns whether recovery was denied while this mutation was in flight
-  /// and is now owed a wake-up.
-  var endEngineMutation: @MainActor () -> Bool = { false }
-  /// Called when `endEngineMutation()` returns true — wakes a stranded
-  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-  var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+  /// #1707 Phase 3 (§3.2, row 6) / #1741 Chunk 9 — the shared
+  /// `EngineMutationScope` constructed once by the composition root, injected
+  /// exactly like `onEngineInterrupted` above (this type never references
+  /// `EngineRecoveryGate` by concrete type). Guards `applyUnloadPolicy()`'s
+  /// idle-timer unload — a background actor unrelated to any active session,
+  /// so recovery must never race it. Required at construction (no default) —
+  /// replaces the old defaulted `tryBeginEngineMutation`/`endEngineMutation`/
+  /// `wakeRecoveryIfOwed` closure triplet.
+  let engineMutationScope: EngineMutationScope
 
   /// #1707: WhisperKit is never the SOURCE of an ASR-interruption signal (no
   /// out-of-process connection to lose), but the shared `ASREventRouter` can
@@ -285,6 +280,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
 
   init(
     backend: any WhisperKitBackendDriving,
+    engineMutationScope: EngineMutationScope,
     languageDetector: LanguageDetector = LanguageDetector(),
     audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64 = { 0 },
     wedgeRecoveryUnloadDeadlineSec: Double = 2.0,
@@ -293,6 +289,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) {
     self.backend = backend
+    self.engineMutationScope = engineMutationScope
     self.languageDetector = languageDetector
     self.audioCaptureSessionIDSource = audioCaptureSessionIDSource
     self.wedgeRecoveryUnloadDeadlineSec = wedgeRecoveryUnloadDeadlineSec
@@ -1072,7 +1069,7 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     case .never:
       return
     case .immediately:
-      modelUnloadTask = Task { [backend, weak self] in
+      modelUnloadTask = Task { [backend, engineMutationScope, weak self] in
         guard !Task.isCancelled else { return }
         // Re-check session keying right before the unload call — a
         // `beginSession(B)` between arm and execute must NOT see A's
@@ -1086,55 +1083,34 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         // task. Without the recheck, the cancelled task can still fire
         // `backend.unload()` under session B (Codex code-diff r8).
         guard !Task.isCancelled else { return }
-        // #1707 Phase 3 (§3.2, row 6): hold a mutation claim for the FULL
-        // awaited unload — a background idle-timer actor unrelated to any
-        // active session, so recovery must never race it. `self` gone ⇒
-        // proceed anyway (matches this task's existing tolerance for a
-        // deallocated adapter, e.g. the `cachedReadiness` no-op below).
-        let claimed = await MainActor.run { () -> Bool in
-          guard let self else { return true }
-          guard self.tryBeginEngineMutation() else {
-            TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitIdleUnload")
-            return false
-          }
-          return true
-        }
-        guard claimed else { return }
-        // GitHub cloud review, PR #1732 round 10: the mutation-claim hop
-        // above is ITSELF a suspension point between the line-1088 final
-        // cancellation check and `backend.unload()` — a `beginSession(B)`
-        // landing in exactly this window would cancel this task the SAME
-        // way the line-1088 check exists to catch, but nothing re-checked
-        // it before the unload call. Re-check here, releasing the just-
-        // acquired claim (never leak it) before bailing.
-        guard !Task.isCancelled else {
-          await MainActor.run { [weak self] in
-            guard let self else { return }
-            if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-          }
-          return
-        }
-        await backend.unload()
-        // #1707 Phase 3 (§3.2, row 6 — Codex code-diff round 1 P2): release
-        // the claim UNCONDITIONALLY right after the awaited unload returns,
-        // BEFORE the cancellation check below. Gating the release behind
-        // `!Task.isCancelled` left the claim permanently stranded whenever
-        // `cancelPendingUnload()` cancelled this Task while `backend.unload()`
-        // was in flight — `mutationCount` would never drain, refusing every
-        // later recovery attempt for the rest of the app session.
-        await MainActor.run { [weak self] in
-          guard let self else { return }
-          if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-        }
-        guard !Task.isCancelled else { return }
-        await MainActor.run { [weak self] in
-          guard let self else { return }
-          self.cachedReadiness = .notReady
+        // #1707 Phase 3 (§3.2, row 6) / #1741 Chunk 9: hold a mutation claim
+        // for the FULL awaited unload — a background idle-timer actor
+        // unrelated to any active session, so recovery must never race it.
+        // `engineMutationScope` is captured directly (like `backend`), not
+        // read through `self` — the SAME "self gone ⇒ proceed anyway"
+        // tolerance the old claim check gave this task now holds
+        // structurally, since the claim no longer depends on the adapter
+        // surviving at all. The scope's own `defer` releases and wakes
+        // UNCONDITIONALLY on every exit from the operation below — the old
+        // manual "release even when cancelled, never gate it behind
+        // !Task.isCancelled" fix (Codex code-diff round 1 P2) is now
+        // structurally guaranteed rather than hand-maintained.
+        _ = await engineMutationScope.withClaim(site: "whisperKitIdleUnload") { [weak self] in
+          // GitHub cloud review, PR #1732 round 10: reaching this closure
+          // required an actor hop onto MainActor to acquire the claim — a
+          // `beginSession(B)` landing in exactly that window would cancel
+          // this task the SAME way the checks above exist to catch, but
+          // nothing would re-check it before the unload call otherwise.
+          // Re-check here, on entry, before ever calling `backend.unload()`.
+          guard !Task.isCancelled else { return }
+          await backend.unload()
+          guard !Task.isCancelled else { return }
+          self?.cachedReadiness = .notReady
         }
       }
     case .twoMinutes, .fiveMinutes, .tenMinutes, .fifteenMinutes, .sixtyMinutes:
       guard let interval = policy.interval else { return }
-      modelUnloadTask = Task { [backend, weak self] in
+      modelUnloadTask = Task { [backend, engineMutationScope, weak self] in
         try? await Task.sleep(for: .seconds(interval))
         guard !Task.isCancelled else { return }
         let shouldUnload = await MainActor.run { [weak self] () -> Bool in
@@ -1146,41 +1122,17 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         // task. Without the recheck, the cancelled task can still fire
         // `backend.unload()` under session B (Codex code-diff r8).
         guard !Task.isCancelled else { return }
-        // #1707 Phase 3 (§3.2, row 6): same atomic claim as the `.immediately`
-        // branch above.
-        let claimed = await MainActor.run { () -> Bool in
-          guard let self else { return true }
-          guard self.tryBeginEngineMutation() else {
-            TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitIdleUnload")
-            return false
-          }
-          return true
-        }
-        guard claimed else { return }
-        // GitHub cloud review, PR #1732 round 10: see the `.immediately`
-        // branch above — the claim hop is itself a suspension point a
-        // `beginSession(B)` can cancel through, so re-check before unloading,
-        // releasing the just-acquired claim rather than leaking it.
-        guard !Task.isCancelled else {
-          await MainActor.run { [weak self] in
-            guard let self else { return }
-            if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-          }
-          return
-        }
-        await backend.unload()
-        // #1707 Phase 3 (§3.2, row 6 — Codex code-diff round 1 P2): release
-        // UNCONDITIONALLY before the cancellation check; see the `.immediately`
-        // branch above for why gating this behind `!Task.isCancelled` leaks
-        // the claim forever.
-        await MainActor.run { [weak self] in
-          guard let self else { return }
-          if self.endEngineMutation() { self.wakeRecoveryIfOwed() }
-        }
-        guard !Task.isCancelled else { return }
-        await MainActor.run { [weak self] in
-          guard let self else { return }
-          self.cachedReadiness = .notReady
+        // #1707 Phase 3 (§3.2, row 6) / #1741 Chunk 9: same atomic claim as
+        // the `.immediately` branch above.
+        _ = await engineMutationScope.withClaim(site: "whisperKitIdleUnload") { [weak self] in
+          // GitHub cloud review, PR #1732 round 10: see the `.immediately`
+          // branch above — reaching this closure required an actor hop onto
+          // MainActor to acquire the claim, so re-check cancellation here,
+          // on entry, before ever calling `backend.unload()`.
+          guard !Task.isCancelled else { return }
+          await backend.unload()
+          guard !Task.isCancelled else { return }
+          self?.cachedReadiness = .notReady
         }
       }
     }

--- a/Sources/EnviousWisprPipeline/WhisperKitLegacyUpgradeCoordinator.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitLegacyUpgradeCoordinator.swift
@@ -1,5 +1,5 @@
+import EnviousWisprASR
 import EnviousWisprModelDelivery
-import EnviousWisprServices
 import Foundation
 
 /// Retires the multilingual engine's foreign copy and refetches a verified one.
@@ -41,23 +41,19 @@ public final class WhisperKitLegacyUpgradeCoordinator {
 
   public var onEvent: (@MainActor @Sendable (Event) -> Void)?
 
-  /// #1707 Phase 3 (§3.2, row 14) — `EngineRecoveryGate.tryBeginMutation()`/
-  /// `endMutation()`, injected exactly like `onEvent` above (this type never
-  /// references `EngineRecoveryGate` by concrete type). This coordinator
-  /// never moves the engine itself, but its delete+refetch window (steps 6-7
-  /// of `retireAndRefetchIfNeeded()`) mutates the SAME on-disk model files a
-  /// concurrent crash-recovery replay's `activeEngine.load()` reads from — a
-  /// genuine hazard the launch grounding brief found (this Task and
-  /// `RecoveryCoordinator.scanAndRecover()`'s Task fire one line apart with
-  /// zero ordering). Defaults keep every existing test/legacy construction
-  /// unchanged (always able to proceed).
-  public var tryBeginEngineMutation: @MainActor () -> Bool = { true }
-  /// Returns whether recovery was denied while this mutation was in flight
-  /// and is now owed a wake-up.
-  public var endEngineMutation: @MainActor () -> Bool = { false }
-  /// Called when `endEngineMutation()` returns true — wakes a stranded
-  /// recovery attempt. Bound to `RecoveryCoordinator.requestRecoveryRecheck`.
-  public var wakeRecoveryIfOwed: @MainActor () -> Void = {}
+  /// #1707 Phase 3 (§3.2, row 14) / #1741 Chunk 8 — the shared
+  /// `EngineMutationScope` constructed once by the composition root (this
+  /// type never references `EngineRecoveryGate` by concrete type). This
+  /// coordinator never moves the engine itself, but its delete+refetch window
+  /// (steps 6-8 of `retireAndRefetchIfNeeded()`) mutates the SAME on-disk
+  /// model files a concurrent crash-recovery replay's `activeEngine.load()`
+  /// reads from — a genuine hazard the launch grounding brief found (this
+  /// Task and `RecoveryCoordinator.scanAndRecover()`'s Task fire one line
+  /// apart with zero ordering). Required at construction (no default) —
+  /// replaces the old defaulted `tryBeginEngineMutation`/`endEngineMutation`/
+  /// `wakeRecoveryIfOwed` closure triplet; the scope's own `onRefused`
+  /// closure now owns refusal telemetry.
+  package let engineMutationScope: EngineMutationScope
 
   /// L5: at most one command is current, and its KIND is load-bearing — a later ensure-intent
   /// must know whether it is joining a fetch or waiting out a Cancel.
@@ -110,7 +106,7 @@ public final class WhisperKitLegacyUpgradeCoordinator {
   private var commandTicket = 0
   private var commandGeneration = 0
 
-  public init(
+  package init(
     documentsDirectory: URL = FileManager.default.urls(
       for: .documentDirectory, in: .userDomainMask)[0],
     appSupportDirectory: URL = FileManager.default.urls(
@@ -121,6 +117,7 @@ public final class WhisperKitLegacyUpgradeCoordinator {
     ensureAvailable: @escaping @MainActor @Sendable () async -> Bool,
     cancelActiveFetch: @escaping @MainActor @Sendable () async -> Void,
     isDeliveryEnabled: @escaping @MainActor @Sendable () -> Bool,
+    engineMutationScope: EngineMutationScope,
     hashFile: (@Sendable (URL) async throws -> String)? = nil,
     removeItem: ((URL) throws -> Void)? = nil
   ) {
@@ -132,6 +129,7 @@ public final class WhisperKitLegacyUpgradeCoordinator {
     self.ensureAvailable = ensureAvailable
     self.cancelActiveFetch = cancelActiveFetch
     self.isDeliveryEnabled = isDeliveryEnabled
+    self.engineMutationScope = engineMutationScope
     self.hashFile = hashFile
     self.removeItem = removeItem
   }
@@ -379,36 +377,30 @@ public final class WhisperKitLegacyUpgradeCoordinator {
     // attempt entirely; it is safe to retry on a future launch since the
     // owed marker (freshly written above at step 5, or already owed from a
     // prior launch) already exists and nothing has been deleted yet.
-    guard tryBeginEngineMutation() else {
-      TelemetryService.shared.recoveryEngineActionDeferred(site: "whisperKitLegacyMigration")
-      return
-    }
-    defer {
-      if endEngineMutation() { wakeRecoveryIfOwed() }
-    }
+    _ = await engineMutationScope.withClaim(site: "whisperKitLegacyMigration") {
+      // 6. Delete only what still matches the identity we captured (L3).
+      let result = LegacyRetirement.unlinkUnchanged(
+        root: foreignVariantDirectory, verdicts: verdicts, removeItem: removeItem)
+      if result.preserved.isEmpty {
+        removeEmptyManifestDirectories()
+        emit(.legacyRetired)
+      } else {
+        // Keep the marker and fetch anyway: we owe them a model either way, and the stale bytes
+        // are a disk cost, not a correctness one.
+        emit(.legacyRetirementFailed(reason: .delete))
+      }
 
-    // 6. Delete only what still matches the identity we captured (L3).
-    let result = LegacyRetirement.unlinkUnchanged(
-      root: foreignVariantDirectory, verdicts: verdicts, removeItem: removeItem)
-    if result.preserved.isEmpty {
-      removeEmptyManifestDirectories()
-      emit(.legacyRetired)
-    } else {
-      // Keep the marker and fetch anyway: we owe them a model either way, and the stale bytes
-      // are a disk cost, not a correctness one.
-      emit(.legacyRetirementFailed(reason: .delete))
-    }
+      guard generation == commandGeneration else { return }
 
-    guard generation == commandGeneration else { return }
+      // 7. Refetch through the verified path.
+      let admitted = await ensureAvailable()
+      guard generation == commandGeneration else { return }
 
-    // 7. Refetch through the verified path.
-    let admitted = await ensureAvailable()
-    guard generation == commandGeneration else { return }
-
-    // 8. Clear the marker on admission. Nothing else — no engine was ever moved.
-    if admitted {
-      try? LegacyRetirement.clearMarker(owedMarkerURL)
-      emit(.replacementCompleted)
+      // 8. Clear the marker on admission. Nothing else — no engine was ever moved.
+      if admitted {
+        try? LegacyRetirement.clearMarker(owedMarkerURL)
+        emit(.replacementCompleted)
+      }
     }
   }
 

--- a/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
@@ -23,7 +23,8 @@ struct ASRManagerBackendInjectionTests {
   @Test("switchBackend from a loaded state resets isModelLoaded to false")
   func switchBackendFromLoadedResetsIsModelLoaded() async throws {
     let parakeet = FakeASRBackend(initiallyReady: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
 
     // Drive the manager to "loaded" via the public loadModel path. Because
     // FakeASRBackend reports ready, loadModel completes synchronously after
@@ -39,7 +40,8 @@ struct ASRManagerBackendInjectionTests {
   @Test("switchBackend unloads the previous backend exactly once")
   func switchBackendUnloadsPreviousBackend() async throws {
     let parakeet = FakeASRBackend(initiallyReady: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
     try await manager.loadModel()
 
     await manager.switchBackend(to: .whisperKit)
@@ -51,7 +53,8 @@ struct ASRManagerBackendInjectionTests {
   @Test("switchBackend to the same type is a no-op (no unload, flags preserved)")
   func switchBackendSameTypeIsNoOp() async throws {
     let parakeet = FakeASRBackend(initiallyReady: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
     try await manager.loadModel()
 
     await manager.switchBackend(to: .parakeet)
@@ -67,7 +70,8 @@ struct ASRManagerBackendInjectionTests {
   @Test("setInitialBackendType after a load resets isModelLoaded and isStreaming")
   func setInitialBackendTypeAfterLoadResetsFlags() async throws {
     let parakeet = FakeASRBackend(initiallyReady: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
     try await manager.loadModel()
     #expect(manager.isModelLoaded == true)
 
@@ -95,7 +99,8 @@ struct ASRManagerLoadGenerationTests {
   @Test("a load superseded by cancelInFlightLoad mid-flight throws and stays unloaded")
   func cancelInFlightLoadSupersedes() async throws {
     let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
 
     let loadTask = Task { @MainActor in
       await #expect(throws: ASRLoadSupersededError.self) { try await manager.loadModel() }
@@ -110,7 +115,8 @@ struct ASRManagerLoadGenerationTests {
   @Test("unloadModel during an in-flight load supersedes it (bump-before-guard, Codex r2)")
   func unloadDuringInFlightLoadSupersedes() async throws {
     let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
 
     let loadTask = Task { @MainActor in
       await #expect(throws: ASRLoadSupersededError.self) { try await manager.loadModel() }
@@ -127,7 +133,8 @@ struct ASRManagerLoadGenerationTests {
   @Test("same-backend switch during an in-flight load does NOT supersede it (Codex r3)")
   func sameBackendSwitchDoesNotSupersede() async throws {
     let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
 
     let loadTask = Task { @MainActor in try await manager.loadModel() }
     await waitForPrepareEntered(parakeet)
@@ -145,7 +152,8 @@ struct ASRManagerLoadGenerationTests {
   )
   func realSwitchDuringInFlightLoadStartsFresh() async throws {
     let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
 
     let loadTask = Task { @MainActor in
       await #expect(throws: ASRLoadSupersededError.self) { try await manager.loadModel() }
@@ -177,7 +185,8 @@ struct ASRManagerLoadGenerationTests {
   @Test("loadModel refuses an engine the manager does not own, loudly")
   func loadModelRefusesNonOwnedBackend() async throws {
     let parakeet = FakeASRBackend(initiallyReady: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
     manager.setInitialBackendType(.whisperKit)
 
     // WhisperKit loads in-process behind its relocation gate, never here. A
@@ -194,7 +203,8 @@ struct ASRManagerLoadGenerationTests {
   @Test("transcribe refuses an engine the manager does not own")
   func transcribeRefusesNonOwnedBackend() async throws {
     let parakeet = FakeASRBackend(initiallyReady: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
     manager.setInitialBackendType(.whisperKit)
 
     await #expect(throws: ASRManagerNotOwnedError(backend: .whisperKit)) {
@@ -204,7 +214,9 @@ struct ASRManagerLoadGenerationTests {
 
   @Test("the manager reports no streaming support for an engine it does not own")
   func noStreamingSupportForNonOwnedBackend() async throws {
-    let manager = ASRManager(parakeetBackend: FakeASRBackend(initiallyReady: true))
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting,
+      parakeetBackend: FakeASRBackend(initiallyReady: true))
     manager.setInitialBackendType(.whisperKit)
     #expect(await manager.activeBackendSupportsStreaming == false)
   }
@@ -214,7 +226,8 @@ struct ASRManagerLoadGenerationTests {
   )
   func unloadDuringInFlightLoadRetiresTaskSoRetryStartsFresh() async throws {
     let parakeet = FakeASRBackend(initiallyReady: false, gated: true)
-    let manager = ASRManager(parakeetBackend: parakeet)
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackend: parakeet)
 
     // Load A parks in prepare() holding generation G.
     let loadTask = Task { @MainActor in

--- a/Tests/EnviousWisprASRTests/ASRManagerColdStateContractTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerColdStateContractTests.swift
@@ -9,7 +9,7 @@ struct ASRManagerColdStateContractTests {
 
   @Test("default manager starts on Parakeet, unloaded, not streaming")
   func defaultState() async {
-    let sut = ASRManager()
+    let sut = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
 
     #expect(sut.activeBackendType == .parakeet)
     #expect(sut.isModelLoaded == false)
@@ -26,7 +26,7 @@ struct ASRManagerColdStateContractTests {
     // and capability bit on a fresh manager. Proving the reset branch requires
     // a seam to put flags into a non-default state first (see #398 for the
     // proposed refactor).
-    let sut = ASRManager()
+    let sut = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
 
     sut.setInitialBackendType(.whisperKit)
 
@@ -38,7 +38,7 @@ struct ASRManagerColdStateContractTests {
 
   @Test("sequential switchBackend calls leave the last requested backend active")
   func sequentialSwitchesTrackLastRequest() async {
-    let sut = ASRManager()
+    let sut = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
 
     await sut.switchBackend(to: .whisperKit)
     #expect(sut.activeBackendType == .whisperKit)
@@ -58,7 +58,7 @@ struct ASRManagerColdStateContractTests {
 
   @Test("transcribe before load throws notReady and preserves manager flags")
   func transcribeBeforeLoadThrowsNotReady() async {
-    let sut = ASRManager()
+    let sut = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
 
     do {
       _ = try await sut.transcribe(audioSamples: [], options: .default)
@@ -81,7 +81,7 @@ struct ASRManagerColdStateContractTests {
 
   @Test("startStreaming before prepare on Parakeet throws notReady and leaves isStreaming false")
   func startStreamingBeforePrepareOnParakeet() async {
-    let sut = ASRManager()
+    let sut = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
 
     do {
       try await sut.startStreaming(options: .default)
@@ -104,7 +104,7 @@ struct ASRManagerColdStateContractTests {
 
   @Test("startStreaming on WhisperKit is a no-op because streaming is unsupported")
   func startStreamingOnWhisperKitDoesNothing() async throws {
-    let sut = ASRManager()
+    let sut = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
     sut.setInitialBackendType(.whisperKit)
 
     try await sut.startStreaming(options: .default)
@@ -118,7 +118,7 @@ struct ASRManagerColdStateContractTests {
   @Test(
     "finalizeStreaming without an active stream throws streamingNotSupported and preserves flags")
   func finalizeWithoutActiveStreamThrows() async {
-    let sut = ASRManager()
+    let sut = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
 
     do {
       _ = try await sut.finalizeStreaming()

--- a/Tests/EnviousWisprASRTests/ASRManagerProxyLoadCompletionTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerProxyLoadCompletionTests.swift
@@ -24,7 +24,8 @@ struct ASRManagerProxyLoadCompletionTests {
 
   @Test("cancelInFlightLoad with no load in flight is a safe no-op")
   func cancelWithNoLoadIsNoOp() {
-    let proxy = ASRManagerProxy(connectionPreflight: { _ in })
+    let proxy = ASRManagerProxy(
+      engineMutationScope: .alwaysAllowedForTesting, connectionPreflight: { _ in })
     #expect(proxy.hasPendingLoadCompletionForTesting == false)
     proxy.cancelInFlightLoad()
     #expect(proxy.hasPendingLoadCompletionForTesting == false)
@@ -39,7 +40,8 @@ struct ASRManagerProxyLoadCompletionTests {
     // stale non-nil guard here would let a LATER cancel/invalidation resume a
     // continuation that already completed (the one-shot drops it, but the
     // registration leak would still mask real pending state).
-    let proxy = ASRManagerProxy(connectionPreflight: { _ in })
+    let proxy = ASRManagerProxy(
+      engineMutationScope: .alwaysAllowedForTesting, connectionPreflight: { _ in })
     await #expect(throws: XPCASRTransportError.self) {
       try await proxy.loadModel()
     }

--- a/Tests/EnviousWisprASRTests/ASRManagerProxyProgressPollingTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerProxyProgressPollingTests.swift
@@ -27,7 +27,7 @@ struct ASRManagerProxyProgressPollingTests {
 
   @Test("startProgressPolling schedules a live timer on the main run loop")
   func startActivates() throws {
-    let proxy = ASRManagerProxy()
+    let proxy = ASRManagerProxy(engineMutationScope: .alwaysAllowedForTesting)
     #expect(proxy.progressPollTimerForTesting == nil)
 
     proxy.startProgressPolling()
@@ -51,7 +51,7 @@ struct ASRManagerProxyProgressPollingTests {
 
   @Test("stopProgressPolling clears the timer (the defer-cleanup invariant)")
   func stopClears() {
-    let proxy = ASRManagerProxy()
+    let proxy = ASRManagerProxy(engineMutationScope: .alwaysAllowedForTesting)
     proxy.startProgressPolling()
     #expect(proxy.isProgressPollingActiveForTesting == true)
 
@@ -61,7 +61,7 @@ struct ASRManagerProxyProgressPollingTests {
 
   @Test("re-arming via startProgressPolling invalidates the prior timer (no leak)")
   func reArmingDoesNotLeak() {
-    let proxy = ASRManagerProxy()
+    let proxy = ASRManagerProxy(engineMutationScope: .alwaysAllowedForTesting)
     proxy.startProgressPolling()
     let firstTimer = proxy.progressPollTimerForTesting
     #expect(firstTimer?.isValid == true)
@@ -84,7 +84,7 @@ struct ASRManagerProxyProgressPollingTests {
 
   @Test("stopProgressPolling is idempotent — calling twice is safe")
   func stopIsIdempotent() {
-    let proxy = ASRManagerProxy()
+    let proxy = ASRManagerProxy(engineMutationScope: .alwaysAllowedForTesting)
     proxy.startProgressPolling()
     proxy.stopProgressPolling()
     proxy.stopProgressPolling()
@@ -93,7 +93,7 @@ struct ASRManagerProxyProgressPollingTests {
 
   @Test("stopProgressPolling on a never-started proxy is a no-op")
   func stopOnNeverStartedProxy() {
-    let proxy = ASRManagerProxy()
+    let proxy = ASRManagerProxy(engineMutationScope: .alwaysAllowedForTesting)
     proxy.stopProgressPolling()
     #expect(proxy.isProgressPollingActiveForTesting == false)
   }
@@ -112,7 +112,8 @@ struct ASRManagerProxyProgressPollingTests {
     // `defer { self.stopProgressPolling() }` inside `loadModel()` — the #586
     // leak guard. Deleting that defer leaves the timer alive after the awaited
     // throw, so this test goes red.
-    let proxy = ASRManagerProxy(connectionPreflight: { _ in })
+    let proxy = ASRManagerProxy(
+      engineMutationScope: .alwaysAllowedForTesting, connectionPreflight: { _ in })
 
     await #expect(throws: XPCASRTransportError.self) {
       try await proxy.loadModel()

--- a/Tests/EnviousWisprASRTests/EngineMutationScopeTests.swift
+++ b/Tests/EnviousWisprASRTests/EngineMutationScopeTests.swift
@@ -1,0 +1,136 @@
+import Testing
+
+@testable import EnviousWisprASR
+
+@Suite("EngineMutationScope claim/release/wake/telemetry ceremony")
+@MainActor
+struct EngineMutationScopeTests {
+
+  @Test("a granted claim runs the operation and returns .completed")
+  func grantedClaimRunsOperation() async {
+    let scope = EngineMutationScope.live(
+      tryBegin: { true }, end: { false }, wake: {}, onRefused: { _ in })
+
+    let outcome = await scope.withClaim(site: "test") { 42 }
+
+    guard case .completed(let value) = outcome else {
+      Issue.record("expected .completed")
+      return
+    }
+    #expect(value == 42)
+  }
+
+  @Test("a refused claim never runs the operation, returns .refused, and reports the site")
+  func refusedClaimSkipsOperationAndReportsSite() async {
+    var reportedSite: String?
+    var operationRan = false
+    let scope = EngineMutationScope.live(
+      tryBegin: { false }, end: { false }, wake: {},
+      onRefused: { site in reportedSite = site })
+
+    let outcome = await scope.withClaim(site: "myOperation") {
+      operationRan = true
+      return 1
+    }
+
+    guard case .refused = outcome else {
+      Issue.record("expected .refused")
+      return
+    }
+    #expect(operationRan == false)
+    #expect(reportedSite == "myOperation")
+  }
+
+  @Test("refusal telemetry fires exactly once per refused claim, not on a granted claim")
+  func refusalTelemetryFiresExactlyOnceAndOnlyOnRefusal() async {
+    var refusalCount = 0
+    let refusing = EngineMutationScope.live(
+      tryBegin: { false }, end: { false }, wake: {},
+      onRefused: { _ in refusalCount += 1 })
+    _ = await refusing.withClaim(site: "site") { 1 }
+    #expect(refusalCount == 1)
+
+    var grantedRefusalCount = 0
+    let granting = EngineMutationScope.live(
+      tryBegin: { true }, end: { false }, wake: {},
+      onRefused: { _ in grantedRefusalCount += 1 })
+    _ = await granting.withClaim(site: "site") { 1 }
+    #expect(grantedRefusalCount == 0)
+  }
+
+  @Test("a granted claim releases and forwards a wake on normal completion")
+  func releaseAndWakeOnNormalCompletion() async {
+    var released = false
+    var woke = false
+    let scope = EngineMutationScope.live(
+      tryBegin: { true },
+      end: {
+        released = true
+        return true
+      },
+      wake: { woke = true },
+      onRefused: { _ in })
+
+    _ = await scope.withClaim(site: "site") { 1 }
+
+    #expect(released)
+    #expect(woke)
+  }
+
+  @Test("a granted claim releases and forwards a wake even when the operation throws")
+  func releaseAndWakeOnThrownError() async {
+    struct ProbeError: Error {}
+    var released = false
+    var woke = false
+    let scope = EngineMutationScope.live(
+      tryBegin: { true },
+      end: {
+        released = true
+        return true
+      },
+      wake: { woke = true },
+      onRefused: { _ in })
+
+    await #expect(throws: ProbeError.self) {
+      _ = try await scope.withClaim(site: "site") {
+        throw ProbeError()
+      }
+    }
+
+    #expect(released)
+    #expect(woke)
+  }
+
+  @Test("end() returning false (no wake owed) does not forward a wake")
+  func noWakeWhenNotOwed() async {
+    var woke = false
+    let scope = EngineMutationScope.live(
+      tryBegin: { true },
+      end: { false },
+      wake: { woke = true },
+      onRefused: { _ in })
+
+    _ = await scope.withClaim(site: "site") { 1 }
+
+    #expect(woke == false)
+  }
+
+  @Test("release and wake fire exactly once per claim, never twice, when a wake is owed")
+  func coalescedWakeNotDoubleFired() async {
+    var endCallCount = 0
+    var wakeCount = 0
+    let scope = EngineMutationScope.live(
+      tryBegin: { true },
+      end: {
+        endCallCount += 1
+        return true
+      },
+      wake: { wakeCount += 1 },
+      onRefused: { _ in })
+
+    _ = await scope.withClaim(site: "site") { 1 }
+
+    #expect(endCallCount == 1)
+    #expect(wakeCount == 1)
+  }
+}

--- a/Tests/EnviousWisprASRTests/ParakeetDeliveryModeTests.swift
+++ b/Tests/EnviousWisprASRTests/ParakeetDeliveryModeTests.swift
@@ -29,7 +29,8 @@ import Testing
   /// remoteObjectProxyWithErrorHandler callback is integration-covered by
   /// the drill matrix's teardown rows.
   @Test func proxyErrorRecyclesConnection() {
-    let proxy = ASRManagerProxy(connectionPreflight: { _ in })  // no real XPC
+    let proxy = ASRManagerProxy(
+      engineMutationScope: .alwaysAllowedForTesting, connectionPreflight: { _ in })  // no real XPC
     #expect(!proxy.hasConnectionForTesting)
     proxy.recycleConnectionAfterProxyError()
     #expect(!proxy.hasConnectionForTesting)
@@ -39,7 +40,8 @@ import Testing
   /// The XPC call carries cacheOnly ONLY for Parakeet — a WhisperKit-typed
   /// proxy never flips the service's offline switch.
   @Test func cacheOnlyIsParakeetScoped() {
-    let proxy = ASRManagerProxy(connectionPreflight: { _ in })
+    let proxy = ASRManagerProxy(
+      engineMutationScope: .alwaysAllowedForTesting, connectionPreflight: { _ in })
     proxy.parakeetCacheOnly = true
     proxy.setInitialBackendType(.whisperKit)
     #expect(proxy.activeBackendType == .whisperKit)

--- a/Tests/EnviousWisprTests/ASR/WhisperKitSetupServiceTests.swift
+++ b/Tests/EnviousWisprTests/ASR/WhisperKitSetupServiceTests.swift
@@ -11,6 +11,7 @@ import Testing
   /// The refusal must re-detect back to honest truth.
   @Test func aRefusedDownloadReturnsTheRowToHonestStateInsteadOfStickingForever() async throws {
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .notDownloaded },
       startDownload: { false })
 
@@ -31,13 +32,22 @@ import Testing
   /// An ACCEPTED download keeps the optimistic state — progress arrives via the
   /// delivery-state projection, not via detection.
   @Test func anAcceptedDownloadKeepsTheOptimisticStateForTheProjection() async throws {
+    final class Box: @unchecked Sendable { var startCalls = 0 }
+    let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .notDownloaded },
-      startDownload: { true })
+      startDownload: {
+        box.startCalls += 1
+        return true
+      })
 
     service.downloadModel()
-    for _ in 0..<50 { await Task.yield() }
+    // Signal, not clock: wait for startDownload to actually run before
+    // asserting the state it leaves behind.
+    for _ in 0..<200 where box.startCalls == 0 { await Task.yield() }
 
+    #expect(box.startCalls == 1)
     if case .downloading = service.setupState {
     } else {
       Issue.record("accepted download must not re-detect away: \(service.setupState)")
@@ -48,14 +58,23 @@ import Testing
   /// marker) means the fetch is still running — re-detecting to "not downloaded"
   /// would lie. The row must keep showing the live download.
   @Test func aRefusedCancelKeepsShowingTheRunningFetch() async throws {
+    final class Box: @unchecked Sendable { var cancelCalls = 0 }
+    let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .notDownloaded },
-      cancelActiveDownload: { false })
+      cancelActiveDownload: {
+        box.cancelCalls += 1
+        return false
+      })
     service.applyDeliveryState(.downloading(progress: 0.5, status: "Downloading model files..."))
 
     service.cancelDownload()
-    for _ in 0..<50 { await Task.yield() }
+    // Signal, not clock: wait for cancelActiveDownload to actually run before
+    // asserting the state it leaves behind.
+    for _ in 0..<200 where box.cancelCalls == 0 { await Task.yield() }
 
+    #expect(box.cancelCalls == 1)
     if case .downloading = service.setupState {
     } else {
       Issue.record("refused cancel must not re-detect away: \(service.setupState)")
@@ -69,6 +88,7 @@ import Testing
     final class Box: @unchecked Sendable { var started = 0 }
     let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .notDownloaded },
       startDownload: {
         box.started += 1
@@ -91,13 +111,23 @@ import Testing
   /// 2026-07-17; Codex 2c-r7 P2). The projection then publishes paused and it
   /// STICKS.
   @Test func anAcceptedCancelLeavesTheRowToTheProjection() async throws {
+    final class Box: @unchecked Sendable { var cancelCalls = 0 }
+    let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .notDownloaded },
-      cancelActiveDownload: { true })
+      cancelActiveDownload: {
+        box.cancelCalls += 1
+        return true
+      })
     service.applyDeliveryState(.downloading(progress: 0.5, status: "Downloading model files..."))
 
     service.cancelDownload()
-    for _ in 0..<100 { await Task.yield() }
+    // Signal, not clock: wait for cancelActiveDownload to actually run before
+    // asserting the state it leaves behind.
+    for _ in 0..<200 where box.cancelCalls == 0 { await Task.yield() }
+
+    #expect(box.cancelCalls == 1)
     if case .downloading = service.setupState {
     } else {
       Issue.record("cancel itself must not rewrite the row: \(service.setupState)")
@@ -113,6 +143,7 @@ import Testing
     final class Box: @unchecked Sendable { var actionCalls = 0 }
     let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .ready },
       removeModelAction: {
         box.actionCalls += 1
@@ -131,6 +162,7 @@ import Testing
     final class Box: @unchecked Sendable { var actionCalls = 0 }
     let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .ready },
       removeModelAction: {
         box.actionCalls += 1
@@ -160,6 +192,7 @@ import Testing
     final class Box: @unchecked Sendable { var actionCalls = 0 }
     let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .ready },
       removeModelAction: {
         box.actionCalls += 1
@@ -179,6 +212,7 @@ import Testing
     final class Box: @unchecked Sendable { var actionCalls = 0 }
     let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .ready },
       removeModelAction: {
         box.actionCalls += 1
@@ -195,6 +229,7 @@ import Testing
 
   @Test func aFailedRemovalShowsTheFailureNoticeAndReDetectsDiskTruth() async throws {
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .notDownloaded },  // partial deletion: marker gone
       removeModelAction: { .failed })
     service.isDictationInFlight = { false }
@@ -223,6 +258,7 @@ import Testing
     final class Box: @unchecked Sendable { var readAvailabilityCalls = 0 }
     let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: {
         box.readAvailabilityCalls += 1
         return .ready  // if this fires again, the row would flicker back
@@ -253,6 +289,7 @@ import Testing
     }
     let box = Box()
     let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting,
       readAvailability: { .notDownloaded },
       removeModelAction: {
         box.calls += 1
@@ -278,8 +315,88 @@ import Testing
   }
 
   @Test func aResumableCancelPresentsPausedNotNotDownloaded() async throws {
-    let service = WhisperKitSetupService(readAvailability: { .notDownloaded })
+    let service = WhisperKitSetupService(
+      engineMutationScope: .alwaysAllowedForTesting, readAvailability: { .notDownloaded })
     service.applyDeliveryState(.paused)
     #expect(service.setupState == .paused, "paused survives as its own presentation")
+  }
+
+  // MARK: - #1741 Chunk 4: EngineMutationScope gate refusal (distinct from the
+  // action-closure refusals above — these deny at the shared gate itself,
+  // proving the gate-refusal outcome each of the three call sites maps to).
+
+  @Test func aGateRefusedDownloadNeverStartsAndReDetects() async throws {
+    final class Box: @unchecked Sendable { var started = 0 }
+    let box = Box()
+    let service = WhisperKitSetupService(
+      engineMutationScope: .live(
+        tryBegin: { false }, end: { false }, wake: {}, onRefused: { _ in }),
+      readAvailability: { .notDownloaded },
+      startDownload: {
+        box.started += 1
+        return true
+      })
+
+    service.downloadModel()
+    for _ in 0..<200 where service.setupState != .notDownloaded {
+      await Task.yield()
+    }
+    #expect(box.started == 0, "a gate-refused download must never call startDownload")
+    #expect(
+      service.setupState == .notDownloaded, "a gate-refused download re-detects to honest state")
+  }
+
+  @Test func aGateRefusedCancelNeverCancelsAndLeavesTheFetchRunning() async throws {
+    final class Box: @unchecked Sendable {
+      var cancelCalls = 0
+      var refusedSites: [String] = []
+    }
+    let box = Box()
+    let service = WhisperKitSetupService(
+      engineMutationScope: .live(
+        tryBegin: { false }, end: { false }, wake: {},
+        onRefused: { box.refusedSites.append($0) }),
+      readAvailability: { .notDownloaded },
+      cancelActiveDownload: {
+        box.cancelCalls += 1
+        return true
+      })
+    service.applyDeliveryState(.downloading(progress: 0.5, status: "Downloading model files..."))
+
+    service.cancelDownload()
+    // Signal, not clock: wait for the gate's own refusal telemetry, proving
+    // the Task actually reached and was refused by the claim, before asserting
+    // the negative (no cancel, state unchanged) that refusal implies.
+    for _ in 0..<200 where box.refusedSites.isEmpty { await Task.yield() }
+
+    #expect(box.refusedSites == ["whisperKitCancelDownload"])
+    #expect(box.cancelCalls == 0, "a gate-refused cancel must never call cancelActiveDownload")
+    if case .downloading = service.setupState {
+    } else {
+      Issue.record("a gate-refused cancel must leave the fetch running: \(service.setupState)")
+    }
+  }
+
+  @Test func aGateRefusedRemoveClearsIsRemovingAndSurfacesFailed() async throws {
+    final class Box: @unchecked Sendable { var actionCalls = 0 }
+    let box = Box()
+    let service = WhisperKitSetupService(
+      engineMutationScope: .live(
+        tryBegin: { false }, end: { false }, wake: {}, onRefused: { _ in }),
+      readAvailability: { .ready },
+      removeModelAction: {
+        box.actionCalls += 1
+        return nil
+      })
+    service.isDictationInFlight = { false }
+
+    service.removeModel()
+    for _ in 0..<200 where service.removeNotice == nil {
+      await Task.yield()
+    }
+
+    #expect(box.actionCalls == 0, "a gate-refused remove must never call removeModelAction")
+    #expect(service.removeNotice == .failed)
+    #expect(service.isRemoving == false)
   }
 }

--- a/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/AudioEventRouterTests.swift
@@ -94,7 +94,8 @@ struct AudioEventRouterTests {
       transcriptStore: TranscriptStore(),
       keychainManager: KeychainManager(),
       captureTelemetry: CaptureTelemetryState(),
-      pasteCompletionRegistry: PasteCompletionRegistry())
+      pasteCompletionRegistry: PasteCompletionRegistry(),
+      engineMutationScope: .alwaysAllowedForTesting)
     let driver = KernelDictationDriverFactory.makeForParakeet(inputs: inputs)
 
     // Signal-based state-change waiter. Resumes the instant the driver

--- a/Tests/EnviousWisprTests/App/BackendMetadataTests.swift
+++ b/Tests/EnviousWisprTests/App/BackendMetadataTests.swift
@@ -199,7 +199,7 @@ struct BackendMetadataTests {
 
   private func makeBackendMetadata() -> BackendMetadata {
     let settings = SettingsManager()
-    let asrManager = ASRManager()
+    let asrManager = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
     let llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: KeychainManager())
     return BackendMetadata(
       settings: settings,

--- a/Tests/EnviousWisprTests/App/DiagnosticsCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/DiagnosticsCoordinatorTests.swift
@@ -1,5 +1,6 @@
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprAppKit
 
 /// Issue #768 (PR3 of epic #763) — pins the `DiagnosticsCoordinator` contract
@@ -10,7 +11,7 @@ struct DiagnosticsCoordinatorTests {
 
   @Test("coordinator owns a fresh BenchmarkSuite")
   func ownsBenchmarkSuite() {
-    let coordinator = DiagnosticsCoordinator()
+    let coordinator = DiagnosticsCoordinator(engineMutationScope: .alwaysAllowedForTesting)
     #expect(coordinator.benchmark.isRunning == false)
     #expect(coordinator.benchmark.results.isEmpty)
     #expect(coordinator.benchmark.pipelineResult == nil)
@@ -19,8 +20,8 @@ struct DiagnosticsCoordinatorTests {
 
   @Test("two coordinators own independent BenchmarkSuite instances")
   func independentInstances() {
-    let a = DiagnosticsCoordinator()
-    let b = DiagnosticsCoordinator()
+    let a = DiagnosticsCoordinator(engineMutationScope: .alwaysAllowedForTesting)
+    let b = DiagnosticsCoordinator(engineMutationScope: .alwaysAllowedForTesting)
     #expect(a.benchmark !== b.benchmark)
   }
 }

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -127,7 +127,8 @@ enum DictationRuntimeFixtures {
         transcriptStore: store,
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry()
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting
       ))
   }
 
@@ -163,7 +164,8 @@ enum DictationRuntimeFixtures {
         transcriptStore: store,
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry()
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting
       ))
   }
 

--- a/Tests/EnviousWisprTests/App/EngineCoordinatorTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/EngineCoordinatorTestSupport.swift
@@ -2,6 +2,7 @@ import EnviousWisprCore
 import EnviousWisprPipeline
 import Foundation
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprAppKit
 
 /// #1171 — a fully programmable fake for `EngineCoordinator.Dependencies`, so
@@ -87,7 +88,8 @@ final class FakeEngineDeps {
         let outcome = self.warmOutcome[backend] ?? .ready
         if case .ready = outcome { self.setReadiness(backend, .ready) }
         return outcome
-      })
+      },
+      engineMutationScope: .alwaysAllowedForTesting)
   }
 
   /// Build a started coordinator over this fake. `start()` fires the initial

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -123,7 +123,7 @@ struct LiveRecordingStateTests {
 
   private func makeState(
     audioCapture: any AudioCaptureInterface = SettableAudioCapture(),
-    asrManager: any ASRManagerInterface = ASRManager()
+    asrManager: any ASRManagerInterface = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
   ) -> LiveRecordingState {
     // Codex code-diff revision: use the internal `init(directory:)` overload
     // with a temp directory so the test does not write into the user's

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -354,7 +354,7 @@ struct MenuBarControllerTests {
   }
 
   private func makeController(spy: ActionSpy = ActionSpy()) -> MenuBarController {
-    let asrManager = ASRManager()
+    let asrManager = ASRManager(engineMutationScope: .alwaysAllowedForTesting)
     // Shared lightweight audio fake from DictationRuntimeTestSupport (same
     // test target). MenuBarController never reads `audioLevel` in these tests
     // (the icon animator's level closure is only wired by `installStatusItem`,

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
+
+/// #1741 Chunk 6 — pins the gate-refusal contract for `ModelDeliveryHome`'s
+/// two Settings-row mutation sites (Parakeet Cancel/Resume).
+@MainActor
+@Suite("ModelDeliveryHome — engine mutation gate refusal")
+struct ModelDeliveryHomeTests {
+
+  /// Production's trust root is the signed app's own `Bundle.main` (contract
+  /// §4a), which a unit-test process cannot see — these resources ride the
+  /// `EnviousWispr` app target, not any framework or test bundle. Rather than
+  /// author a divergent fixture, point at a `Bundle` over the SAME committed
+  /// manifest files `ModelDeliveryHome` loads in production. Same repo-root
+  /// discovery as `ParakeetShippedManifestTests.repoRoot`
+  /// (`Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift`).
+  private static func manifestBundle() throws -> Bundle {
+    let repoRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // (file)
+      .deletingLastPathComponent()  // App
+      .deletingLastPathComponent()  // EnviousWisprTests
+      .deletingLastPathComponent()  // Tests
+    let resourcesDir = repoRoot.appendingPathComponent("Sources/EnviousWispr/Resources")
+    return try #require(Bundle(url: resourcesDir))
+  }
+
+  @Test("a gate-refused cancel reports the site and never releases or wakes")
+  func aGateRefusedCancelReportsTheSiteAndNeverReleasesOrWakes() async throws {
+    final class Box: @unchecked Sendable {
+      var endCalls = 0
+      var wakeCalls = 0
+      var refusedSites: [String] = []
+    }
+    let box = Box()
+    let home = ModelDeliveryHome(
+      engineMutationScope: .live(
+        tryBegin: { false },
+        end: {
+          box.endCalls += 1
+          return false
+        },
+        wake: { box.wakeCalls += 1 },
+        onRefused: { box.refusedSites.append($0) }),
+      manifestBundle: try Self.manifestBundle())
+
+    home.cancelParakeetDownload()
+    // Signal, not clock: wait for the gate's own refusal telemetry, proving
+    // the Task actually reached and was refused by the claim, before
+    // asserting the negatives that a refusal implies.
+    for _ in 0..<200 where box.refusedSites.isEmpty { await Task.yield() }
+
+    #expect(box.refusedSites == ["parakeetCancelDownload"])
+    #expect(box.endCalls == 0, "a refused claim is never released")
+    #expect(box.wakeCalls == 0, "a refused claim never owes a wake")
+  }
+
+  @Test("a gate-refused resume reports the site and never releases or wakes")
+  func aGateRefusedResumeReportsTheSiteAndNeverReleasesOrWakes() async throws {
+    final class Box: @unchecked Sendable {
+      var endCalls = 0
+      var wakeCalls = 0
+      var refusedSites: [String] = []
+    }
+    let box = Box()
+    let home = ModelDeliveryHome(
+      engineMutationScope: .live(
+        tryBegin: { false },
+        end: {
+          box.endCalls += 1
+          return false
+        },
+        wake: { box.wakeCalls += 1 },
+        onRefused: { box.refusedSites.append($0) }),
+      manifestBundle: try Self.manifestBundle())
+
+    home.resumeParakeetDownload()
+    // Signal, not clock: wait for the gate's own refusal telemetry, proving
+    // the Task actually reached and was refused by the claim, before
+    // asserting the negatives that a refusal implies.
+    for _ in 0..<200 where box.refusedSites.isEmpty { await Task.yield() }
+
+    #expect(box.refusedSites == ["parakeetResumeDownload"])
+    #expect(box.endCalls == 0, "a refused claim is never released")
+    #expect(box.wakeCalls == 0, "a refused claim never owes a wake")
+  }
+}

--- a/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
@@ -6,6 +6,7 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprAppKit
 @testable import EnviousWisprPipeline
 
@@ -47,6 +48,7 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
       currentTick: { 0 }, sleepTicks: { _ in },
       processText: { raw, _ in raw },
       store: { _, _ in }, deliver: { _ in .pasted },
+      engineMutationScope: .alwaysAllowedForTesting,
       minimumRecordingTicks: 0)
     let observer = KernelHeartPathTelemetryObserver(
       kernel: kernel, audioCapture: FakeAudioCapture(),
@@ -55,7 +57,8 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
       emitLifecycleEvent: { _ in })
     let driver = KernelDictationDriver(
       kernel: kernel, observer: observer, outcome: outcome,
-      context: context, steps: steps, adapter: adapter)
+      context: context, steps: steps, adapter: adapter,
+      engineMutationScope: .alwaysAllowedForTesting)
     let deps = PipelineStateChangeHandlerFactory.Deps(
       showOverlay: { _ in },
       cancelPendingWarning: {},

--- a/Tests/EnviousWisprTests/Architecture/DiagnosticsCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DiagnosticsCoordinatorCeilingsTests.swift
@@ -6,11 +6,22 @@ import Testing
 /// PR3 (#768/#769) shipped before per-home ceiling discipline existed. PR5
 /// backfills the cap to lock the current shape.
 ///
+/// Bible §30 changelog: #1741 Chunk 5 (2026-07-21) — `BenchmarkSuite` now
+/// requires an `EngineMutationScope` at construction (the #1707 Phase 3
+/// engine-mutation-gate refactor), so this home gained a required explicit
+/// `init(engineMutationScope:)` that constructs `benchmark` in its body
+/// instead of a bare property initializer, plus the `EnviousWisprASR` import
+/// that type lives in. Stored-collaborator and non-private-method counts are
+/// unchanged (the initializer is not a stored collaborator, and `init` is not
+/// a `func`); only the line count and allowed-imports caps move, by exactly
+/// the amount the real file needs — 14 → 22, {Observation} → {EnviousWisprASR,
+/// Observation}.
+///
 /// Caps:
-/// - 1 stored collaborator (`let benchmark = BenchmarkSuite()`)
+/// - 1 stored collaborator (`let benchmark`, constructed in `init`)
 /// - 0 non-private methods (read-only collaborator)
-/// - ≤14 lines
-/// - imports ⊆ {Observation}
+/// - ≤22 lines
+/// - imports ⊆ {EnviousWisprASR, Observation}
 @Suite struct DiagnosticsCoordinatorCeilingsTests {
   private static let sourcePath = "Sources/EnviousWisprAppKit/App/DiagnosticsCoordinator.swift"
 
@@ -23,7 +34,7 @@ import Testing
       total <= 1,
       """
       DiagnosticsCoordinator stored-collaborator ceiling exceeded: \(total) > 1. \
-      Expected only `let benchmark = BenchmarkSuite()`. Raising this cap \
+      Expected only `let benchmark`. Raising this cap \
       requires a Bible §30 changelog entry.
       """)
   }
@@ -46,9 +57,9 @@ import Testing
     let source = try CeilingsTestSupport.source(at: Self.sourcePath)
     let count = CeilingsTestSupport.lineCount(in: source)
     #expect(
-      count <= 14,
+      count <= 22,
       """
-      DiagnosticsCoordinator line count exceeded: \(count) > 14. Ratchet down \
+      DiagnosticsCoordinator line count exceeded: \(count) > 22. Ratchet down \
       if shipping smaller; raise only via Bible §30.
       """)
   }
@@ -56,7 +67,7 @@ import Testing
   @Test func allowedImports() throws {
     let source = try CeilingsTestSupport.source(at: Self.sourcePath)
     let actual = CeilingsTestSupport.imports(in: source)
-    let allowed: Set<String> = ["Observation"]
+    let allowed: Set<String> = ["EnviousWisprASR", "Observation"]
     let extras = actual.subtracting(allowed)
     #expect(
       extras.isEmpty,

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -86,6 +86,53 @@ import Testing
 // must match this frozen table. A site that appears, disappears, or is
 // duplicated fails immediately; the classification labels are then verified
 // by self-review and Codex against live source (never trusted as-is).
+//
+// Chunk 11 (2026-07-23): what this suite covers, and an honest statement of
+// what it cannot. A grounded review of Chunk 10's original 13-name
+// vocabulary found it omitted real engine-mutating methods. Grounding
+// expanded the deliberately bounded surface from three protocols to ten:
+// seven additional known protocols this file had not previously enumerated
+// (`ASREngineLanguageIdentifying`, `ASREngineWarmupCancelling`,
+// `WhisperKitBackendDriving`, `WhisperKitIncrementalSession`,
+// `WhisperKitTranscribing`, `ASRServiceProtocol`,
+// `ASREngineTelemetryProviding` — some read-only, frozen for drift even
+// though they are not vocabulary candidates themselves; see
+// `EngineProtocolSurfaceFreezeTests` for all ten's frozen signatures) plus
+// two concrete-only method surfaces not declared by any of the ten frozen
+// protocols (`WhisperKitEngineAdapter.unloadForRemoval()`, reached via a
+// type-cast at one call site; `ParakeetBackend.prepare(cacheOnly:progressCallback:)`,
+// reached via a type-cast at one call site AND via direct, uncast
+// construction/ownership at another — `ASRServiceHandler.swift` builds and
+// holds a concrete `ParakeetBackend` natively, so "reached only via a cast"
+// would be false for this one). Two consecutive grounded
+// Codex reviews each found "one more engine-facing surface" the prior pass
+// had missed — including, on the second pass, a structural hole in a
+// proposed general downcast scanner (a real production call site takes a
+// concrete engine type directly as a typed parameter, no cast at all). That
+// pattern — repeated discovery with no sign of converging to zero — is this
+// project's own signal that hand-enumerating "every possible way into the
+// engine" cannot be proven exhaustive, and that trying to build a
+// general-purpose detector for it was the wrong goal.
+//
+// So Chunk 11 does NOT claim, and no comment in this file should ever claim
+// again, that this suite "detects all future engine-touching code," proves
+// the vocabulary is complete, or makes an unsafe engine access structurally
+// impossible. What it DOES do, concretely: freezes the reference inventory
+// for every method name in `vocabulary` below (this file) and the exact
+// signatures of the ten protocols named above plus the two known concrete
+// escape hatches (`EngineProtocolSurfaceFreezeTests`) — so a NEW reference to
+// an ALREADY-tracked name, or a change to an ALREADY-tracked protocol's
+// signature, fails the build and demands classification. It does NOT, and
+// structurally cannot, discover a brand-new protocol nobody has told it
+// about, a brand-new concrete type, a new XPC route, a macro-generated call,
+// or a concrete engine type accessed with no protocol and no cast at all —
+// those require a human doing the same kind of grounding pass that found the
+// ten protocols and two escape hatches here, not a bigger test. Real,
+// already-known production races found along the way are tracked as
+// `knownGap` entries pointing at their own issues (#1745, #1749) — this
+// suite documents them; it does not fix them, and a test cannot substitute
+// for the documentation, code review, and engineering judgment an actual
+// fix or a future architecture change would need.
 @Suite struct EngineMutationInventoryFreezeTests {
 
   // MARK: Classification
@@ -188,26 +235,100 @@ import Testing
 
   // MARK: Vocabulary — sessionless/maintenance mutation calls only
 
-  /// Exact vocabulary from the approved Chunk 10 scope. Deliberately excludes
-  /// `applyUnloadPolicy(` — a container that arms a policy-scoped Task, not a
-  /// raw mutation call itself (its OWN body's `backend.unload()` is what the
-  /// `unload` matcher below catches).
+  /// Vocabulary as of the #1741 Chunk 11 bounded known-surface freeze
+  /// (2026-07-23), superseding Chunk 10's original 13 names. Two grounded
+  /// Codex plan reviews traced the full engine-facing surface across TEN
+  /// protocols (`ASRBackend`, `ASRManagerInterface`, `ASREngineAdapter`,
+  /// `ASREngineLanguageIdentifying`, `ASREngineWarmupCancelling`,
+  /// `WhisperKitBackendDriving`, `WhisperKitIncrementalSession`,
+  /// `WhisperKitTranscribing`, `ASRServiceProtocol`,
+  /// `ASREngineTelemetryProviding` — see `EngineProtocolSurfaceFreezeTests`
+  /// for their frozen signatures) plus two concrete-only method surfaces not
+  /// declared by any of the ten frozen protocols
+  /// (`WhisperKitEngineAdapter.unloadForRemoval()`, reached via a type-cast;
+  /// `ParakeetBackend.prepare(cacheOnly:progressCallback:)`, reached via a
+  /// type-cast at one call site and via direct, uncast construction/ownership
+  /// in `ASRServiceHandler`; both are already caught here because their names
+  /// match an existing/added entry below. Only their EXISTENCE and signature
+  /// were invisible to the old name-only protocol check, which
+  /// `EngineProtocolSurfaceFreezeTests` now pins explicitly).
   ///
-  /// #1741 Chunk 10, council-approved contract pivot: a "hit" is any real
-  /// code reference (bare `DeclReferenceExprSyntax`, or the `.declName` of a
-  /// `MemberAccessExprSyntax` — see `CallSiteVisitor` below) whose terminal
-  /// identifier is one of these 13 names — not a proof that the reference is
-  /// ultimately called. `switchBackend` is matched uniformly like every
-  /// other name; the founder's prior `.switchBackend(to:` argument-label
-  /// distinction was deliberately dropped (Codex plan review: keeping any
-  /// argument-shape special case reintroduces the exact "does this shape
-  /// count" question the pivot exists to retire — the one production
-  /// reference already carries `to:` in its recorded source text
-  /// descriptively, so no information is lost).
+  /// New in Chunk 11: `transcribe`, `feedAudio`, `finalizeStreaming`,
+  /// `cancelStreaming` (Codex's original finding — real across ALL of
+  /// `ASRBackend`/`ASRManagerInterface`/`ASRServiceProtocol`, matched once
+  /// per name since bare-identifier matching does not distinguish layers),
+  /// `beginSession`, `acceptAudio`, `finalize` (`ASREngineAdapter` /
+  /// `WhisperKitIncrementalSession` — `finalize` also matches
+  /// `WhisperKitStreamingSession.finalize(finalSamples:speechSegments:)`,
+  /// a different type sharing the bare name; classified like every other
+  /// entry, not specially unified), `observeLID`, `makeStreamingSession`
+  /// (`WhisperKitBackendDriving`), `cancelSessionlessWarmup`
+  /// (`ASREngineWarmupCancelling`), `unloadForRemoval` (concrete-only,
+  /// reached via `adapter as? WhisperKitEngineAdapter`), `transcribeSamples`,
+  /// `feedAudioBuffer` (`ASRServiceProtocol` — its own `loadModel`/
+  /// `unloadModel`/`startStreaming`/`finalizeStreaming`/`cancelStreaming`
+  /// requirements share bare names already tracked, so only these two
+  /// XPC-specific names are new).
+  ///
+  /// Deliberately excludes `applyUnloadPolicy(` — a container that arms a
+  /// policy-scoped Task, not a raw mutation call itself (its own body's
+  /// `backend.unload()` is what the `unload` matcher below catches) — and,
+  /// for the same reason, `noteTranscriptionComplete`: both route to an
+  /// already-tracked `unload`/`unloadModel` reference; the CORRECT reason to
+  /// exclude them is that their target is independently caught, NOT (an
+  /// earlier draft's wrong claim) that they "don't gate engine mutation" —
+  /// `applyUnloadPolicy`'s `.immediately` case directly arms a real
+  /// deferred `backend.unload()` call (`WhisperKitEngineAdapter.swift:1072`).
+  ///
+  /// Two names are deliberately excluded despite being real engine
+  /// operations, for the SAME bare-name-collision reason, each documented
+  /// with its real production call sites so the exclusion is never mistaken
+  /// for an oversight:
+  /// - `cancel` (`ASREngineAdapter`/`WhisperKitIncrementalSession`): ~134
+  ///   raw text matches across the four scanned roots, almost all
+  ///   `Task.cancel()`/`<x>Task?.cancel()` and other types' own unrelated
+  ///   `cancel()` methods. The real engine-touching sites are
+  ///   `KernelDictationDriver.swift:641`, `RecordingSessionKernel.swift:3852`
+  ///   (`adapter.cancel()`), and `WhisperKitEngineAdapter.swift:988`
+  ///   (`live.cancel()`, forwarding to `WhisperKitStreamingSession.cancel()`).
+  ///   NOT claimed safe merely because their owners hold
+  ///   `EngineMutationScope` — `RecordingSessionKernel.swift:3852`'s call
+  ///   specifically sits inside the #1749 race window (see the doc comment
+  ///   above `expected` for how that race surfaces in this table instead,
+  ///   through `transcribe`).
+  /// - `start` (`WhisperKitIncrementalSession`): 25 raw text matches, almost
+  ///   all `Timer`/`NWListener`/`NWConnection`/hotkey-service/watcher
+  ///   `.start()` calls with no relation to the ASR engine. The real sites
+  ///   are `TailBenchmarkHarness.swift:163`, `TailBenchmarkHarness.swift:288`,
+  ///   and `WhisperKitEngineAdapter.swift:526` (`session.start(audioSamplesProvider:)`).
+  ///
+  /// Both exclusions are permanent under THIS design, not temporary
+  /// oversights — a future rename of either protocol requirement (e.g.
+  /// `cancelEngine()`, `startIncrementalDecoding()`) would remove the
+  /// bare-name collision and let either be tracked; that rename is out of
+  /// scope for this chunk (no separate architecture issue tracks it — a
+  /// test suite is a guardrail, not a substitute for the documentation,
+  /// review, and engineering judgment an actual rename decision needs).
+  ///
+  /// #1741 Chunk 10, council-approved contract pivot, unchanged by Chunk 11:
+  /// a "hit" is any real code reference (bare `DeclReferenceExprSyntax`, or
+  /// the `.declName` of a `MemberAccessExprSyntax` — see `CallSiteVisitor`
+  /// below) whose terminal identifier is one of these names — not a proof
+  /// that the reference is ultimately called. `switchBackend` is matched
+  /// uniformly like every other name; the founder's prior
+  /// `.switchBackend(to:` argument-label distinction was deliberately
+  /// dropped (Codex plan review: keeping any argument-shape special case
+  /// reintroduces the exact "does this shape count" question the pivot
+  /// exists to retire — the one production reference already carries `to:`
+  /// in its recorded source text descriptively, so no information is lost).
   private static let vocabulary: Set<String> = [
     "warmUp", "warmUpFromCache", "unload", "unloadModel", "prepare", "loadModel", "loadModels",
     "switchBackend", "startStreaming", "cancelInFlightLoad", "recoverFromWedge",
     "recoverFromASRInterruption", "retryDecode",
+    // Chunk 11 additions:
+    "transcribe", "feedAudio", "finalizeStreaming", "cancelStreaming", "beginSession",
+    "acceptAudio", "finalize", "observeLID", "makeStreamingSession", "cancelSessionlessWarmup",
+    "unloadForRemoval", "transcribeSamples", "feedAudioBuffer",
   ]
 
   /// A member-access reference (`adapter.warmUp`) or bare reference
@@ -259,12 +380,58 @@ import Testing
     // `BenchmarkSuite.ensureModelLoaded` (under its own
     // `engineMutationScope.withClaim`) — always reached with a claim already
     // held, so `transitivelyCoveredByCaller` rather than `recoveryOwned`.
+    // #1749 (found during the Chunk 11 grounding pass): this `load` closure is
+    // reached from BOTH `BenchmarkSuite` (safe, its own separate claim) and
+    // `RecoverySpoolReplayer` (recovery) — but recovery's claim does not wait
+    // for a just-ended ordinary session's unawaited termination cleanup to
+    // finish before this call proceeds, so this single physical site carries
+    // the less-safe caller's classification rather than a caller-averaged one.
     CallSite(
       file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "prepare",
-      text: "try await whisperKitBackend.prepare()", classification: .transitivelyCoveredByCaller),
+      text: "try await whisperKitBackend.prepare()",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "recovery's claim does not wait for a just-ended ordinary session's unawaited termination cleanup to finish before this call proceeds"
+      )),
     CallSite(
       file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "loadModel",
-      text: "try await asrManager.loadModel()", classification: .transitivelyCoveredByCaller),
+      text: "try await asrManager.loadModel()",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "recovery's claim does not wait for a just-ended ordinary session's unawaited termination cleanup to finish before this call proceeds"
+      )),
+    // #1749: recovery's two concrete transcribe routes, reached only after
+    // the `load` calls directly above.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "transcribe",
+      text:
+        "return try await whisperKitBackend.transcribe(audioSamples: samples, options: options)",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "recovery's claim does not wait for a just-ended ordinary session's unawaited termination cleanup to finish before this call proceeds"
+      )),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "transcribe",
+      text: "return try await asrManager.transcribe(audioSamples: samples, options: options)",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "recovery's claim does not wait for a just-ended ordinary session's unawaited termination cleanup to finish before this call proceeds"
+      )),
+    // #1749 — the original site this whole gap was found at: `RecoverySpoolReplayer`'s
+    // own call into `activeEngine.transcribe`, one caller of the two
+    // `ActiveEngineOperation` transcribe routes directly above.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift", matcher: "transcribe",
+      text: "result = try await activeEngine.transcribe(recovered.samples, options)",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "recovery's claim does not wait for a just-ended ordinary session's unawaited termination cleanup to finish before this call proceeds"
+      )),
     // `hardCancel` is DIFFERENT: its sole production caller
     // (`RecoveryCoordinator.discardActiveRecovery()` -> `resetEngine` closure,
     // `WisprBootstrapper.swift:669`) fires it inside an unawaited, unstructured
@@ -641,6 +808,348 @@ import Testing
     CallSite(
       file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "prepare",
       text: "let task = Task<Void, Error> { try await captured.prepare() }",
+      classification: .transitivelyCoveredByCaller),
+    // `startStreamingSession`'s vend — reached only at a session's own start
+    // (same window `ParakeetEngineAdapter.beginSession`'s streaming-start
+    // entry above covers), a `WhisperKitBackendDriving` requirement.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift",
+      matcher: "makeStreamingSession",
+      text: "guard let session = await backend.makeStreamingSession(options: options) else {",
+      classification: .structurallySafe),
+    // Language-ID observation inside the adapter's own finalize/decode flow —
+    // session-scoped, an `ASREngineLanguageIdentifying`-adjacent read that
+    // runs a real inference but never mutates persistent engine state.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "observeLID",
+      text: "await backendForObserver.observeLID(", classification: .structurallySafe),
+    // The adapter's own flush into its incremental streaming session's
+    // `WhisperKitIncrementalSession.finalize` — session-scoped (`streamingSession`
+    // is non-nil only during an active streaming session).
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "finalize",
+      text: "let result = await live.finalize(finalSamples: [], speechSegments: [])",
+      classification: .structurallySafe),
+    // #1749 — the WhisperKit batch transcribe inside `finalize()`, one of the
+    // "ordinary-session operations that can remain in flight" Codex's
+    // grounded review traced: not guaranteed to stop when the session's own
+    // unawaited cancellation races recovery's gate opening.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "transcribe",
+      text: "let result = try await backend.transcribe(",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "an in-flight batch transcribe is not guaranteed to stop before recovery's gate opens"
+      )),
+
+    // MARK: ASRManager — new Chunk 11 XPC-mirrored operations. Same inherited-
+    // safety reasoning as the file's existing `prepare`/`startStreaming`
+    // entries: these are `ASRManager`'s own forwarding implementations,
+    // reached by both safe (gated/session-scoped) and, transitively, the
+    // #1749-affected recovery path — the #1749 tag lives at the specific
+    // `ActiveEngineOperation`/adapter-level call sites Codex's grounded
+    // review named, not cascaded through every deeper forwarding layer.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "transcribe",
+      text:
+        "return try await activeBackend.transcribe(audioSamples: audioSamples, options: options)",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "feedAudio",
+      text: "try await activeBackend.feedAudio(buffer)",
+      classification: .transitivelyCoveredByCaller),
+    // `startStreaming`'s pre-start drain, and `finalizeStreaming`'s own
+    // post-finalize path — both reached via the same mixed caller set.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "cancelStreaming",
+      text: "await activeBackend.cancelStreaming()", classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "cancelStreaming",
+      text: "await activeBackend.cancelStreaming()", classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "finalizeStreaming",
+      text: "let result = try await activeBackend.finalizeStreaming()",
+      classification: .transitivelyCoveredByCaller),
+
+    // MARK: ASRManagerProxy — new Chunk 11 XPC-client forwarding, same
+    // reasoning as the file's existing `loadModel`/`startStreaming` entries.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "transcribeSamples",
+      text: "proxy.transcribeSamples(", classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "feedAudioBuffer",
+      text: "proxy.feedAudioBuffer(data, frameCount: count)",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "finalizeStreaming",
+      text: "proxy.finalizeStreaming { resultData, nsError in",
+      classification: .transitivelyCoveredByCaller),
+    // #1749 — this XPC-client `cancelStreaming` forward is part of the same
+    // fire-and-forget chain `detachedAdapterCancel()` triggers on Parakeet;
+    // no reply is awaited, so it can still be in flight when recovery's gate
+    // opens.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "cancelStreaming",
+      text: "serviceProxy { proxy in proxy.cancelStreaming() }",
+      classification: .knownGap(
+        issue: 1749,
+        reason: "fire-and-forget XPC cancel forward, no reply awaited, part of the #1749 chain"
+      )),
+
+    // MARK: ASRServiceHandler — new Chunk 11 XPC-service forwarding, same
+    // reasoning as the file's existing `startStreaming`/`prepare` entries.
+    CallSite(
+      file: "Sources/EnviousWisprASRService/ASRServiceHandler.swift", matcher: "transcribe",
+      text: "let result = try await parakeet.transcribe(audioSamples: samples, options: options)",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASRService/ASRServiceHandler.swift", matcher: "feedAudio",
+      text: "Task { try? await parakeet.feedAudio(unsafeBuffer) }",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASRService/ASRServiceHandler.swift", matcher: "finalizeStreaming",
+      text: "let result = try await parakeet.finalizeStreaming()",
+      classification: .transitivelyCoveredByCaller),
+    // #1749 — the service-side twin of the XPC-client cancel forward above;
+    // spawns its own untracked `Task`, never awaited by the client.
+    CallSite(
+      file: "Sources/EnviousWisprASRService/ASRServiceHandler.swift", matcher: "cancelStreaming",
+      text: "Task { await parakeet.cancelStreaming() }",
+      classification: .knownGap(
+        issue: 1749,
+        reason: "fire-and-forget XPC cancel forward, no reply awaited, part of the #1749 chain"
+      )),
+
+    // MARK: ParakeetBackend — new Chunk 11 entry, same inherited coverage as
+    // the file's existing `prepare`/`loadModels`/`startStreaming` entries:
+    // the concrete `ASRBackend.transcribe` implementation, forwarding to
+    // FluidAudio's own manager.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "transcribe",
+      text:
+        "let fluidResult = try await manager.transcribe(audioSamples, decoderState: &decoderState)",
+      classification: .transitivelyCoveredByCaller),
+
+    // MARK: WhisperKitBackend — new Chunk 11 entries.
+    // `performWarmup`'s silent probe decode — part of `warmUp()`'s own
+    // already-tracked chain (gated/structurallySafe depending on caller),
+    // unrelated to the #1749 race.
+    CallSite(
+      file: "Sources/EnviousWisprASR/WhisperKitBackend.swift", matcher: "transcribe",
+      text: "_ = try await wk.transcribe(audioArray: silence, decodeOptions: opts)",
+      classification: .transitivelyCoveredByCaller),
+    // The concrete `ASRBackend.transcribe` implementation, forwarding to the
+    // real WhisperKit SDK decode. #1749 — every currently-known external
+    // caller of this specific method (`ActiveEngineOperation.swift`'s direct
+    // `whisperKitBackend.transcribe` and `WhisperKitEngineAdapter.swift`'s
+    // `backend.transcribe`) is already tagged `knownGap(1749)` above; marking
+    // this deeper layer `transitivelyCoveredByCaller` would overstate safety
+    // this method does not currently have from any known caller.
+    CallSite(
+      file: "Sources/EnviousWisprASR/WhisperKitBackend.swift", matcher: "transcribe",
+      text:
+        "results = try await kit.transcribe(audioArray: paddedSamples, decodeOptions: decodeOptions)",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "every currently-known caller of this method is itself part of the #1749 race window"
+      )),
+
+    // MARK: WhisperKitIncrementalSession — `WhisperKitTranscribing`'s
+    // forwarding wrapper around WhisperKit's own real decode entry point (a
+    // THIRD-PARTY method sharing this vocabulary's bare name coincidentally);
+    // safety is inherited from whichever caller reached this layer, same as
+    // `ASRProtocol.swift`'s existing `prepare()` forward.
+    CallSite(
+      file: "Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift", matcher: "transcribe",
+      text: "try await self.transcribe(", classification: .transitivelyCoveredByCaller),
+
+    // MARK: WhisperKitStreamingSession — the concrete incremental-decode
+    // session vended by `WhisperKitBackend.makeStreamingSession()`. All three
+    // `transcribe` calls below are internal decode-loop steps; #1749 —
+    // "ordinary-session operations that can remain in flight" per Codex's
+    // grounded review: not guaranteed to stop before recovery's gate opens.
+    CallSite(
+      file: "Sources/EnviousWisprASR/WhisperKitStreamingSession.swift", matcher: "transcribe",
+      text: "let results = try await whisperKit.transcribe(",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "an in-flight incremental decode is not guaranteed to stop before recovery's gate opens"
+      )),
+    CallSite(
+      file: "Sources/EnviousWisprASR/WhisperKitStreamingSession.swift", matcher: "transcribe",
+      text:
+        "let results = try await whisperKit.transcribe(audioArray: paddedSamples, decodeOptions: opts)",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "an in-flight incremental decode is not guaranteed to stop before recovery's gate opens"
+      )),
+    CallSite(
+      file: "Sources/EnviousWisprASR/WhisperKitStreamingSession.swift", matcher: "transcribe",
+      text:
+        "let results = try await whisperKit.transcribe(audioArray: samples, decodeOptions: opts)",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "an in-flight incremental decode is not guaranteed to stop before recovery's gate opens"
+      )),
+
+    // MARK: RecordingSessionKernel — Chunk 11 additions, same session-scoped
+    // reasoning as this file's existing entries for this type.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "acceptAudio",
+      text: "self.adapter.acceptAudio(handoff)", classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "beginSession",
+      text: "try await adapter.beginSession(", classification: .structurallySafe),
+    // The real adapter-facing finalize call.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "finalize",
+      text: "let outcome = await adapter.finalize(batchSamples: batchSamples)",
+      classification: .structurallySafe),
+    // The kernel's own private `finalize(sid:batchSamples:)` called
+    // recursively during ASR-interruption salvage and the empty-result retry
+    // ladder — bare, implicit-`self` calls to an already-counted deeper
+    // engine touch, same pattern as the file's existing `warmUp(sid)` entry.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "finalize",
+      text: "let outcome = await finalize(sid, batchSamples: asrSamples)",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "finalize",
+      text: "let retry = await finalize(sid, batchSamples: Array(samples[trim...]))",
+      classification: .transitivelyCoveredByCaller),
+
+    // MARK: ParakeetEngineAdapter — Chunk 11 additions.
+    // Streaming-feed dispatch, guarded by session/terminal checks on the
+    // `@MainActor` hop — session-scoped, same as this file's existing
+    // `beginSession`/`startStreaming` entries for this type.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "feedAudio",
+      text: "try await self.asrManager.feedAudio(pcmBuffer)", classification: .structurallySafe),
+    // #1749 — the batch-rescue transcribe inside `finalize`/`retryDecode`,
+    // reached during normal decode; one of the "ordinary-session operations
+    // that can remain in flight" per Codex's grounded review.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "transcribe",
+      text: "let result = try await asrManager.transcribe(",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "an in-flight batch transcribe is not guaranteed to stop before recovery's gate opens"
+      )),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "transcribe",
+      text: "let result = try await asrManager.transcribe(",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "an in-flight batch transcribe is not guaranteed to stop before recovery's gate opens"
+      )),
+    // #1749 — `discardSession()`'s `cancelStreaming` forward, the same
+    // fire-and-forget chain `detachedAdapterCancel()` triggers.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "cancelStreaming",
+      text: "await asrManager.cancelStreaming()",
+      classification: .knownGap(
+        issue: 1749,
+        reason: "fire-and-forget cancel forward, part of the #1749 chain"
+      )),
+    // #1749 — `finalizeStreaming` reached when cancellation lands mid-finalize
+    // (the `catch` path's own await, still able to overlap recovery).
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift",
+      matcher: "finalizeStreaming",
+      text: "let result = try await asrManager.finalizeStreaming()",
+      classification: .knownGap(
+        issue: 1749,
+        reason:
+          "finalizeStreaming reached when cancellation lands mid-finalize is not guaranteed to stop before recovery's gate opens"
+      )),
+
+    // MARK: BenchmarkSuite — Chunk 11 additions, all directly inside this
+    // file's own "benchmarkSuiteBatch"/"benchmarkSuiteStreaming" claims
+    // (same claims the file's existing `startStreaming` entry already uses).
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift", matcher: "transcribe",
+      text: "_ = try? await activeEngine.transcribe(samples, .default)", classification: .gated),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift", matcher: "transcribe",
+      text: "let batchResult = try? await activeEngine.transcribe(testSamples, .default)",
+      classification: .gated),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift", matcher: "feedAudio",
+      text: "try await asrManager.feedAudio(buffer)", classification: .gated),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift", matcher: "finalizeStreaming",
+      text: "let streamResult = try await asrManager.finalizeStreaming()", classification: .gated),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift", matcher: "cancelStreaming",
+      text: "await asrManager.cancelStreaming()", classification: .gated),
+
+    // MARK: TailBenchmarkHarness — an external eval-harness support type
+    // (`scripts/eval/tail_runner`), never constructed anywhere in production
+    // `Sources/` (grep-verified). Reachable in theory, never exercised by the
+    // shipping app's own configuration — the same `dormant` bucket as
+    // `WhisperKitBackend`'s existing test-seam entry.
+    CallSite(
+      file: "Sources/EnviousWisprASR/TailBenchmarkHarness.swift", matcher: "transcribe",
+      text:
+        "let results = try await model.kit.transcribe(audioArray: decodeInput, decodeOptions: opts)",
+      classification: .dormant),
+    CallSite(
+      file: "Sources/EnviousWisprASR/TailBenchmarkHarness.swift", matcher: "transcribe",
+      text: "let results = try await model.kit.transcribe(audioArray: padded, decodeOptions: opts)",
+      classification: .dormant),
+    CallSite(
+      file: "Sources/EnviousWisprASR/TailBenchmarkHarness.swift", matcher: "transcribe",
+      text: "let results = try await model.kit.transcribe(audioArray: padded, decodeOptions: opts)",
+      classification: .dormant),
+    CallSite(
+      file: "Sources/EnviousWisprASR/TailBenchmarkHarness.swift", matcher: "finalize",
+      text: "let result = await session.finalize(finalSamples: [], speechSegments: [])",
+      classification: .dormant),
+
+    // MARK: DictationRuntime / KernelDictationDriver — the onboarding
+    // install Cancel button's seam (#1388 step 3). Race-safe by
+    // construction, not by claim: "the adapter's in-flight gate and the
+    // delivery controller's completion-wins-the-race handling both make it a
+    // no-op" against a just-completed load — `structurallySafe` category (c).
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift",
+      matcher: "cancelSessionlessWarmup",
+      text: "await starter.activeDriver.cancelSessionlessWarmup()",
+      classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/KernelDictationDriver.swift",
+      matcher: "cancelSessionlessWarmup", text: "await cancelling.cancelSessionlessWarmup()",
+      classification: .transitivelyCoveredByCaller),
+
+    // MARK: WhisperKitLegacyUpgradeCoordinator / KernelDictationDriver /
+    // WisprBootstrapper — the three remaining links in the ALREADY-verified
+    // "whisperKitRemove" claim chain this file's existing
+    // `WhisperKitEngineAdapter.swift` `unloadForRemoval` entry documents
+    // end-to-end (`WhisperKitSetupService.removeModel()` ->
+    // `WhisperKitLegacyUpgradeCoordinator.remove()` -> `unloadForRemoval`
+    // closure -> `KernelDictationDriver.unloadEngineForRemoval()` -> the
+    // already-counted adapter entry). Each is one more layer of that same
+    // verified chain, not a new one.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitLegacyUpgradeCoordinator.swift",
+      matcher: "unloadForRemoval", text: "await unloadForRemoval()",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/KernelDictationDriver.swift", matcher: "unloadForRemoval",
+      text: "await (adapter as? WhisperKitEngineAdapter)?.unloadForRemoval()",
+      classification: .transitivelyCoveredByCaller),
+    // The closure WIRING itself — a property assignment, not a call; safety
+    // inherited from wherever it is actually invoked (the same chain above).
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift", matcher: "unloadForRemoval",
+      text: "whisperKitRetirement?.unloadForRemoval = { [weak whisperKitKernelDriver] in",
       classification: .transitivelyCoveredByCaller),
   ]
 
@@ -1304,6 +1813,14 @@ import Testing
   // MARK: 9 — every knownGap entry is fully tracked, and only the confirmed
   // sites carry it
 
+  /// Every issue a `knownGap` entry may currently point at. #1745 (recovery
+  /// Discard's fire-and-forget engine reset) and #1749 (recovery's claim not
+  /// waiting for an ordinary session's own fire-and-forget termination
+  /// cleanup) — both a real, tracked, out-of-#1741-scope production gap, not
+  /// a placeholder. A future third gap needs its own issue added here
+  /// deliberately, never silently.
+  private static let knownGapIssues: Set<Int> = [1745, 1749]
+
   @Test("every knownGap classification names a positive, concrete issue and reason")
   func knownGapEntriesAreFullyTracked() {
     let gaps: [(issue: Int, reason: String)] = Self.expected.compactMap { site in
@@ -1311,32 +1828,94 @@ import Testing
       return (issue, reason)
     }
     #expect(
-      gaps.count == 2,
-      "expected exactly the two ActiveEngineOperation hardCancel entries to carry `knownGap`, found \(gaps.count)"
+      gaps.count == 18,
+      "expected exactly 18 `knownGap` entries (2 for #1745, 16 for #1749), found \(gaps.count)"
     )
     for gap in gaps {
       #expect(
         gap.issue > 0,
         "a `knownGap` entry must name a real, positive GitHub issue number — never a placeholder")
       #expect(
-        gap.issue == 1745,
-        "expected every current `knownGap` entry to point at #1745; found #\(gap.issue) instead")
+        Self.knownGapIssues.contains(gap.issue),
+        "expected every current `knownGap` entry to point at #1745 or #1749; found #\(gap.issue) instead"
+      )
       #expect(
         !gap.reason.trimmingCharacters(in: .whitespaces).isEmpty,
         "a `knownGap` entry must carry a concrete reason, not a blank string")
     }
   }
 
-  @Test(
-    "knownGap applies to exactly the two confirmed-unsafe ActiveEngineOperation sites, no others")
+  @Test("knownGap applies to exactly the confirmed-unsafe sites tracked at #1745/#1749, no others")
   func knownGapAppliesOnlyToTheConfirmedUnsafeSites() {
+    // Ground truth extracted directly from a failing run of this test with an
+    // empty expectation (measure-with-the-real-tool, not hand-transcription) —
+    // 17 distinct sites; 18 total `knownGap` entries above because
+    // `ParakeetEngineAdapter.swift`'s two identical-text `transcribe(` sites
+    // collapse to one `SiteKey`, preserving multiplicity only in Test 1's own
+    // multiset check, not in this Set-based one.
     let expectedGapKeys: Set<SiteKey> = [
+      // #1745
       SiteKey(
         file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "unload",
         text: "await whisperKitBackend.unload()"),
       SiteKey(
         file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift",
         matcher: "cancelInFlightLoad", text: "asrManager.cancelInFlightLoad()"),
+      // #1749
+      SiteKey(
+        file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "prepare",
+        text: "try await whisperKitBackend.prepare()"),
+      SiteKey(
+        file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "loadModel",
+        text: "try await asrManager.loadModel()"),
+      SiteKey(
+        file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "transcribe",
+        text:
+          "return try await whisperKitBackend.transcribe(audioSamples: samples, options: options)"
+      ),
+      SiteKey(
+        file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "transcribe",
+        text: "return try await asrManager.transcribe(audioSamples: samples, options: options)"),
+      SiteKey(
+        file: "Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift", matcher: "transcribe",
+        text: "result = try await activeEngine.transcribe(recovered.samples, options)"),
+      SiteKey(
+        file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "cancelStreaming",
+        text: "serviceProxy { proxy in proxy.cancelStreaming() }"),
+      SiteKey(
+        file: "Sources/EnviousWisprASRService/ASRServiceHandler.swift", matcher: "cancelStreaming",
+        text: "Task { await parakeet.cancelStreaming() }"),
+      SiteKey(
+        file: "Sources/EnviousWisprASR/WhisperKitBackend.swift", matcher: "transcribe",
+        text:
+          "results = try await kit.transcribe(audioArray: paddedSamples, decodeOptions: decodeOptions)"
+      ),
+      SiteKey(
+        file: "Sources/EnviousWisprASR/WhisperKitStreamingSession.swift", matcher: "transcribe",
+        text: "let results = try await whisperKit.transcribe("),
+      SiteKey(
+        file: "Sources/EnviousWisprASR/WhisperKitStreamingSession.swift", matcher: "transcribe",
+        text:
+          "let results = try await whisperKit.transcribe(audioArray: paddedSamples, decodeOptions: opts)"
+      ),
+      SiteKey(
+        file: "Sources/EnviousWisprASR/WhisperKitStreamingSession.swift", matcher: "transcribe",
+        text:
+          "let results = try await whisperKit.transcribe(audioArray: samples, decodeOptions: opts)"
+      ),
+      SiteKey(
+        file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "transcribe",
+        text: "let result = try await backend.transcribe("),
+      SiteKey(
+        file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "transcribe",
+        text: "let result = try await asrManager.transcribe("),
+      SiteKey(
+        file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift",
+        matcher: "cancelStreaming",
+        text: "await asrManager.cancelStreaming()"),
+      SiteKey(
+        file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift",
+        matcher: "finalizeStreaming", text: "let result = try await asrManager.finalizeStreaming()"),
     ]
     let actualGapKeys = Set(
       Self.expected.compactMap { site -> SiteKey? in
@@ -1346,8 +1925,7 @@ import Testing
     #expect(
       actualGapKeys == expectedGapKeys,
       """
-      `knownGap` must apply to exactly the two confirmed-unsafe
-      `ActiveEngineOperation.hardCancel` sites tracked at #1745 — found:
+      `knownGap` must apply to exactly the confirmed-unsafe sites tracked at #1745/#1749 — found:
       \(actualGapKeys)
       A different entry carrying `knownGap` means either a real new gap was found (open its own
       issue and add it here deliberately) or an already-safe entry was quietly weakened to dodge

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -1,0 +1,1357 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+// MARK: - EngineMutationInventoryFreezeTests (#1741 Chunk 10)
+//
+// The permanent safety net promised by `EngineMutationScope.swift`'s own doc
+// comment (Chunk 1): every sessionless/maintenance call that touches the ASR
+// engine must be accounted for — either it acquires the shared
+// `EngineMutationScope` (or is reached only from a call chain that already
+// holds one), or it is reached only from a context recovery structurally
+// cannot race (a live dictation session, or the older `isSwitching`/
+// `isRecovering` mutual exclusion), or it is a test-only/dead/unrelated-domain
+// call, OR it is a real, confirmed gap tracked by its own open GitHub issue
+// (`knownGap` — never a bare comment asserting "fine for now"). A future
+// engineer adding a new raw mutation call anywhere in the four scanned
+// modules — without classifying it here — fails this build instead of
+// silently reintroducing the exact "enforced by convention and reviewer
+// memory" gap issue #1741 exists to close.
+//
+// This is a STRUCTURAL freeze, not a behavior test: it parses source, so it
+// catches a new/moved call site no runtime test happens to exercise. Shares
+// its fail-closed-count and call-vs-declaration philosophy with
+// `EngineSwitchOwnershipFreezeTests` / `WhisperKitGatedLoadFreezeTests` /
+// `EngineIdentityFreezeTests`, but those three use a hand-rolled
+// comment-skipping text scanner; this one does not.
+//
+// History (kept because it explains the design, not as a tracker): the first
+// version of this suite DID use a hand-rolled character scanner, matching
+// its siblings. Hardening its comment/string handling took 5 consecutive
+// Codex review rounds (block comments, ordinary strings, raw strings,
+// same-line interpolation, multi-line interpolation) with no convergence in
+// sight. A web-grounded council consult (GPT-5.6-sol + Gemini-3.1-pro,
+// 2026-07-22) confirmed this is a known, named class of problem — SwiftLint's
+// own multi-year regex-to-SwiftSyntax migration is the closest real-world
+// precedent — and that a real parser is the right fix once a scanner needs
+// this level of lexical precision. This suite now parses every scanned file
+// with `SwiftParser` (the same front-end the Swift compiler itself uses) and
+// walks the resulting syntax tree with a `SyntaxVisitor`, so comments and
+// every string form are structurally excluded rather than pattern-matched
+// around. `swift-syntax` is a test-target-only SPM dependency (`Package.swift`)
+// — it never reaches the shipped app.
+//
+// A real parser fixed the comment/string axis completely, but a second,
+// narrower axis then surfaced and cost THREE more redesigns before it was
+// recognized as a CONTRACT problem, not an implementation gap: trying to
+// prove, from syntax alone, that a `FunctionCallExprSyntax`'s callee is
+// DEFINITELY one of the 13 vocabulary methods. Round 1 unwrapped 3 wrapper
+// kinds (parens, force-unwrap, optional-chaining) one at a time; round 2's
+// Codex review found a 4th (`as`-casts) and warned more existed, so the
+// design was generalized (fold every operator sequence with `SwiftOperators`,
+// unwrap a closed, exhaustively-enumerated set of ~12 identity-preserving
+// node kinds); the NEXT review round then found a missed value-selecting
+// construct (postfix `#if`) AND a condition-vs-value precision bug in the
+// new "ambiguous branching value" detector that redesign had added. Three
+// consecutive rounds finding "one more shape in the same area" is exactly
+// this repo's own signal to stop patching and name the class — so the
+// founder called it what it was: the test was asking an unnecessarily hard
+// question ("is this DEFINITELY the function being called?") when a safety
+// NET only needs a much simpler, provably complete one: "does this source
+// contain any real code reference to a protected name at all?"
+//
+// A web-grounded council review (GPT-5.6-sol + Gemini-3.1-pro, 2026-07-22,
+// unanimous, no disagreement) confirmed this reframing — real precedent:
+// SwiftLint's own banned-API rules, Semgrep, and Android Lint all catch a
+// forbidden name conservatively rather than trying to prove invocation, and
+// let an explicit baseline/allowlist absorb the harmless matches. This suite
+// now does the same: it inventories every real code reference (bare or
+// member-access) whose terminal name matches the vocabulary, makes NO
+// attempt to determine whether that reference is ultimately called, stored,
+// passed, or merely mentioned, and classifies every match in the same
+// inventory table this file has always used. This closes the wrapper axis,
+// the operator-folding axis, and the branching-ambiguity axis all at once —
+// none of them matter when the question is "is the name referenced" rather
+// than "is this specifically a call." It also closes a boundary the PRIOR
+// design had to accept: a stored method reference (`let f = adapter.warmUp`)
+// is now caught at the point of reference, not lost to an untraceable alias.
+// `SwiftOperators` (operator-sequence folding) was removed entirely — it
+// existed only to resolve a call's callee, which this design no longer does.
+//
+// Classification is a REVIEW aid, not something a parser can derive alone —
+// "is this call protected" requires reading control flow. The mechanical
+// guarantee this suite enforces is narrower and load-bearing on its own: the
+// exact MULTISET of live call sites (by file + matcher + normalized text)
+// must match this frozen table. A site that appears, disappears, or is
+// duplicated fails immediately; the classification labels are then verified
+// by self-review and Codex against live source (never trusted as-is).
+@Suite struct EngineMutationInventoryFreezeTests {
+
+  // MARK: Classification
+
+  enum Classification: Sendable {
+    /// The call sits directly inside one of the 16 established
+    /// `engineMutationScope.withClaim(site:)` closures (or, for the
+    /// sessionless load-wedge guard, is armed/disarmed across exactly that
+    /// claim's own lifetime — `KernelDictationDriver.ensureEngineWarm`'s
+    /// `SessionlessLoadWedgeGuard`).
+    case gated
+    /// Reached only from within crash-recovery's own `recoveryEngineClaim`
+    /// hold — currently unpopulated. `ActiveEngineOperation`'s `load` calls
+    /// are reached by both `RecoverySpoolReplayer` (recovery) AND
+    /// `BenchmarkSuite` (Diagnostics, under its own `engineMutationScope`
+    /// claim), so they are NOT recovery-exclusive and are
+    /// `transitivelyCoveredByCaller` instead. `ActiveEngineOperation`'s
+    /// `hardCancel` calls ARE recovery-exclusive (Diagnostics never calls
+    /// `hardCancel`) but are NOT reliably covered by the claim for their full
+    /// duration (see `knownGap`, tracked at #1745) — recovery-exclusive is
+    /// necessary but not sufficient for this case; the claim must also
+    /// actually stay held throughout. Kept in the enum for the shape the
+    /// founder's classification scheme specifies; a future recovery-only raw
+    /// call that IS fully covered for its whole duration would take this case.
+    case recoveryOwned
+    /// Not itself gated, and not tied to one specific structural fact — its
+    /// safety is entirely inherited from whichever caller reached it (a
+    /// shared adapter/backend/XPC internal called via a chain rooted in a
+    /// `gated` or `structurallySafe` entry point).
+    case transitivelyCoveredByCaller
+    /// Protected by a DIFFERENT, pre-#1741 mechanism, not by
+    /// `EngineMutationScope`: either (a) reached only from within an active
+    /// recording session, which structurally precludes a recovery claim from
+    /// existing (recovery's atomic handshake requires `!isDictationActive()`
+    /// — RULE: close-the-window-never-handle-it, documented not gated), (b)
+    /// the older `EngineCoordinator.isSwitching` / `RecoveryCoordinator`
+    /// bidirectional check that already gives full-duration mutual exclusion
+    /// for an engine SWITCH specifically, or (c) a call that cannot conflict
+    /// with recovery regardless of timing because the callee re-acquires its
+    /// own claim internally on every invocation, or performs no actual engine
+    /// mutation (a pure readiness read).
+    case structurallySafe
+    /// Present in source, reachable in theory, but never exercised by current
+    /// production configuration (a test-seam override that is always nil in
+    /// production).
+    case dormant
+    /// Touches a different subsystem entirely (VAD, not the ASR engine) —
+    /// matched only because the method name coincides with the vocabulary.
+    case unrelatedDomain
+    /// A REAL, CONFIRMED protection gap — not safe, not covered by any of the
+    /// six categories above, and not being papered over as one. Codex's
+    /// Chunk 10 round-1 review found and confirmed this itself: the recovery
+    /// Discard path's engine reset is fire-and-forget (an unawaited,
+    /// unstructured `Task { ... }` — NOT `Task.detached`, but the same
+    /// unawaited-completion hazard in effect here), so the recovery claim can
+    /// release before that reset actually finishes, letting another mutation
+    /// start touching the same engine while the abandoned reset is still
+    /// running underneath it. #1741 does NOT fix this — it is out of this
+    /// issue's scope (a pre-existing bug, unrelated to the ten-consumer
+    /// capability migration) and requires a production code change this
+    /// test-only chunk is not authorized to make. Every use of this case
+    /// names an issue number and reason (structurally required by this
+    /// case's associated values) — Test 9 checks that structure and that no
+    /// other entry is quietly relabeled into this case to dodge Test 1; it
+    /// cannot itself verify the issue is real or still open on GitHub, which
+    /// is a matter for self-review and Codex, not this suite.
+    case knownGap(issue: Int, reason: String)
+  }
+
+  /// Stable identity: file + matcher + normalized (trimmed) source text +
+  /// classification. Deliberately NOT line number — a reformat that keeps the
+  /// same call unchanged must not spuriously fail. Two physically distinct
+  /// call sites with identical trimmed text (e.g. `WhisperKitEngineAdapter`'s
+  /// two `await backend.unload()` claim closures) are represented as two
+  /// array entries, preserving multiplicity as its own signal.
+  struct CallSite {
+    let file: String
+    let matcher: String
+    let text: String
+    let classification: Classification
+  }
+
+  /// The comparison key — classification excluded, since the live scanner
+  /// (plain text matching) cannot derive it. Test 1 compares raw-key
+  /// multisets; the classification riding on each `CallSite` is what a human
+  /// or Codex reviews against live source, never what the scanner checks.
+  struct SiteKey: Hashable {
+    let file: String
+    let matcher: String
+    let text: String
+  }
+
+  struct RawHit {
+    let file: String
+    let matcher: String
+    let text: String
+    let line: Int
+    var key: SiteKey { SiteKey(file: file, matcher: matcher, text: text) }
+  }
+
+  // MARK: Vocabulary — sessionless/maintenance mutation calls only
+
+  /// Exact vocabulary from the approved Chunk 10 scope. Deliberately excludes
+  /// `applyUnloadPolicy(` — a container that arms a policy-scoped Task, not a
+  /// raw mutation call itself (its OWN body's `backend.unload()` is what the
+  /// `unload` matcher below catches).
+  ///
+  /// #1741 Chunk 10, council-approved contract pivot: a "hit" is any real
+  /// code reference (bare `DeclReferenceExprSyntax`, or the `.declName` of a
+  /// `MemberAccessExprSyntax` — see `CallSiteVisitor` below) whose terminal
+  /// identifier is one of these 13 names — not a proof that the reference is
+  /// ultimately called. `switchBackend` is matched uniformly like every
+  /// other name; the founder's prior `.switchBackend(to:` argument-label
+  /// distinction was deliberately dropped (Codex plan review: keeping any
+  /// argument-shape special case reintroduces the exact "does this shape
+  /// count" question the pivot exists to retire — the one production
+  /// reference already carries `to:` in its recorded source text
+  /// descriptively, so no information is lost).
+  private static let vocabulary: Set<String> = [
+    "warmUp", "warmUpFromCache", "unload", "unloadModel", "prepare", "loadModel", "loadModels",
+    "switchBackend", "startStreaming", "cancelInFlightLoad", "recoverFromWedge",
+    "recoverFromASRInterruption", "retryDecode",
+  ]
+
+  /// A member-access reference (`adapter.warmUp`) or bare reference
+  /// (`warmUp`) is a real `DeclReferenceExprSyntax` node; the matching
+  /// DECLARATION (`func warmUp(`) is a completely different node kind
+  /// (`FunctionDeclSyntax`, whose name is a plain `TokenSyntax`, never
+  /// wrapped in an expression node) that this visitor never visits as a
+  /// reference at all — the same call-vs-declaration precision
+  /// `EngineSwitchOwnershipFreezeTests` / `EngineIdentityFreezeTests` rely on,
+  /// guaranteed by the parser's own grammar.
+  ///
+  /// The prior design's one accepted, irreducible boundary — a method
+  /// reference assigned to a variable and called later
+  /// (`let f = adapter.warmUp; await f()`) — is CLOSED by this contract
+  /// pivot, not merely documented: the assignment line itself contains a
+  /// real reference to `warmUp` and is caught and classified there. Only a
+  /// reference with NO source-level spelling of the name at all (macro-
+  /// generated code, or a call constructed via string-based reflection, e.g.
+  /// `NSSelectorFromString("warmUp")`) is outside this test's reach — grep-
+  /// verified zero occurrences of either shape across the four scanned
+  /// directories today. If EnviousWispr ever adopts one of those mechanisms
+  /// for ASR mutation, it needs its own explicit policy, not a bigger
+  /// version of this inventory.
+  private static let scannedRoots = [
+    "Sources/EnviousWisprASR",
+    "Sources/EnviousWisprPipeline",
+    "Sources/EnviousWisprAppKit",
+    "Sources/EnviousWisprASRService",
+  ]
+
+  // MARK: Frozen classified inventory, re-derived from source and cross-
+  // checked against every `#1707 Phase 3 (§3.2, row N)` breadcrumb comment
+  // still in the codebase; the underlying 27-row plan document is external
+  // to this repo per the issue #1741 GitHub comment.
+  //
+  // Entry count history: 45 (round 6, the switch to a real parser found a
+  // trailing-closure `unloadModel` call the old regex could never match) →
+  // 54 (a bare-call widening found 9 more genuine call sites) → council-
+  // approved contract pivot (this state): every real reference, not just
+  // call sites, now requires classification — see the file-level doc
+  // comment above for the full history. `switchBackendTo` was renamed to
+  // `switchBackend` (the argument-label distinction was dropped, see the
+  // vocabulary doc comment above).
+
+  private static let expected: [CallSite] = [
+    // MARK: ActiveEngineOperation — the one door for crash-recovery + the
+    // Diagnostics benchmark. Not itself gated. `load` is called from BOTH
+    // `RecoverySpoolReplayer` (under `recoveryEngineClaim`) and
+    // `BenchmarkSuite.ensureModelLoaded` (under its own
+    // `engineMutationScope.withClaim`) — always reached with a claim already
+    // held, so `transitivelyCoveredByCaller` rather than `recoveryOwned`.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "prepare",
+      text: "try await whisperKitBackend.prepare()", classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "loadModel",
+      text: "try await asrManager.loadModel()", classification: .transitivelyCoveredByCaller),
+    // `hardCancel` is DIFFERENT: its sole production caller
+    // (`RecoveryCoordinator.discardActiveRecovery()` -> `resetEngine` closure,
+    // `WisprBootstrapper.swift:669`) fires it inside an unawaited, unstructured
+    // `Task { ... }` (NOT `Task.detached` — a plain `Task` closure, but the
+    // same unawaited-completion hazard applies here). The recovery claim
+    // releases via the scan loop's own `defer` as soon as
+    // `replayer.replay(...)` returns, with no synchronization against that
+    // Task actually finishing — so a WhisperKit `unload()` here can still be
+    // running after the claim (and thus this exact protection) has already
+    // been given up. Confirmed real by Codex (Chunk 10 round 1); tracked at
+    // #1745, which #1741 does NOT fix (production change, out of this
+    // test-only chunk's scope).
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "unload",
+      text: "await whisperKitBackend.unload()",
+      classification: .knownGap(
+        issue: 1745,
+        reason:
+          "hardCancel fires in an unawaited Task the recovery claim's release does not wait for"
+      )),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift",
+      matcher: "cancelInFlightLoad", text: "asrManager.cancelInFlightLoad()",
+      classification: .knownGap(
+        issue: 1745,
+        reason:
+          "hardCancel fires in an unawaited Task the recovery claim's release does not wait for"
+      )),
+
+    // MARK: BenchmarkSuite — direct call inside its own "benchmarkSuiteStreaming" claim.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift", matcher: "startStreaming",
+      text: "try await asrManager.startStreaming(options: .default)", classification: .gated),
+
+    // MARK: WisprBootstrapper — the sole `.switchBackend(to:)` call site
+    // (frozen separately by `EngineSwitchOwnershipFreezeTests`). Protected by
+    // the older, pre-#1741 `EngineCoordinator.isSwitching` /
+    // `RecoveryCoordinator.isEngineSwitching()` bidirectional MainActor
+    // check — a genuinely different, already-adequate mutual-exclusion
+    // mechanism, never migrated onto `EngineMutationScope`.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift", matcher: "switchBackend",
+      text: "await asrManager.switchBackend(to: backend)", classification: .structurallySafe),
+
+    // MARK: ASRManager
+    // `switchBackend(to:)`'s internal unload — same structural protection as
+    // the call site above (its one and only caller).
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "unload",
+      text: "await activeBackend?.unload()", classification: .structurallySafe),
+    // `loadModel()`'s Parakeet-prepare calls — reached via `adapter.warmUp()`,
+    // itself reached via gated (`ensureEngineWarm`/`preWarm`) AND
+    // structurally-safe (session-scoped `recoverFromASRInterruption`/
+    // `retryDecode`/row-22 warmUp) callers alike.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "prepare",
+      text: "try await parakeet.prepare(cacheOnly: true, progressCallback: progress)",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "prepare",
+      text: "try await self.parakeetBackend.prepare(progressCallback: progress)",
+      classification: .transitivelyCoveredByCaller),
+    // `startStreaming(options:)` — reached via BenchmarkSuite's gated claim
+    // AND `ParakeetEngineAdapter.beginSession`'s structurally-safe
+    // (session-start / minting-window) call; its own protection is inherited.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "startStreaming",
+      text: "try await activeBackend.startStreaming(options: options)",
+      classification: .transitivelyCoveredByCaller),
+    // The real unload, directly inside "asrManagerUnload"'s claim closure.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "unload",
+      text: "await activeBackend.unload()", classification: .gated),
+    // Idle-timer firing `unloadModel()` on itself. Safe regardless of when it
+    // fires: `unloadModel()`'s OWN body re-acquires "asrManagerUnload"
+    // internally on every call, by construction — not because of anything
+    // about this call site or its caller.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "unloadModel",
+      text: "_ = Task<Void, Never> { await self?.unloadModel() }",
+      classification: .structurallySafe),
+    // `noteTranscriptionComplete`'s immediate-unload branch — a bare, implicit-
+    // `self` call the visitor could not see before Codex r1 (SwiftSyntax-pivot
+    // round) required `DeclReferenceExprSyntax` callee matching too. Same
+    // reasoning as the `self?.unloadModel()` idle-timer entry directly above:
+    // `unloadModel()`'s own body re-acquires its claim internally regardless
+    // of how it is reached.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "unloadModel",
+      text: "Task { await unloadModel() }", classification: .structurallySafe),
+
+    // MARK: ASRManagerProxy — the XPC-fronted mirror of ASRManager.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "loadModel",
+      text: "proxy.loadModel(backendType: self.activeBackendType.rawValue, cacheOnly: cacheOnly) {",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "startStreaming",
+      text: "proxy.startStreaming(", classification: .transitivelyCoveredByCaller),
+    // Same reasoning as ASRManager's idle-timer trigger above.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "unloadModel",
+      text: "_ = Task<Void, Never> { await self?.unloadModel() }",
+      classification: .structurallySafe),
+    // `switchBackend`'s pre-switch drain — bare, implicit `self`. Same
+    // self-re-acquiring-claim reasoning as every other bare/optional
+    // `unloadModel()` call in this file.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "unloadModel",
+      text: "if isModelLoaded { await unloadModel() }", classification: .structurallySafe),
+    // `noteTranscriptionComplete`'s immediate-unload branch — the proxy-side
+    // twin of ASRManager's identical bare call above.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "unloadModel",
+      text: "Task { await unloadModel() }", classification: .structurallySafe),
+    // The real XPC forwarding call, a trailing-closure call
+    // (`proxy.unloadModel { cont.resume() }` — no parentheses), which the
+    // OLD regex-based scanner's `\.unloadModel\(` pattern could never match
+    // (it required a literal `(` immediately after the name) — a real gap in
+    // the retired scanner's coverage that the semantic, parser-based visitor
+    // now correctly closes (#1741 Chunk 10 round 6, found on first real run).
+    // Directly inside `unloadModel()`'s own "asrManagerProxyUnload" claim
+    // closure — nested inside `withCheckedContinuation`/`serviceProxy`'s
+    // synchronous callback setup, never crossing a new claim boundary.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "unloadModel",
+      text: "proxy.unloadModel {", classification: .gated),
+
+    // MARK: ASRProtocol — the shared `ASRBackend` protocol extension's
+    // default `prepare(progressCallback:)`, used by any conformer that does
+    // not override it (ParakeetBackend does; WhisperKitBackend does not).
+    // Its bare, implicit-`self` forward to `prepare()` dispatches
+    // polymorphically to whichever concrete backend is live — already
+    // covered by that backend's own already-classified `prepare()` entry
+    // (e.g. `whisperKitBackend.prepare()` at `ActiveEngineOperation.swift`,
+    // `transitivelyCoveredByCaller`). This forward crosses no new claim
+    // boundary of its own.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ASRProtocol.swift", matcher: "prepare",
+      text: "try await prepare()", classification: .transitivelyCoveredByCaller),
+
+    // MARK: ParakeetBackend — FluidAudio's own manager, one layer below
+    // ASRManager's `.prepare()`/`.startStreaming()`. Same inherited coverage.
+    // The two bare `prepare()` overloads below both forward, implicit-`self`,
+    // to this file's own `prepare(cacheOnly:progressCallback:)` — the same
+    // instance already reached (for the no-callback overload) via
+    // `whisperKitBackend.prepare()`-shaped external calls, or (for the
+    // callback overload) via `ASRManager`'s `self.parakeetBackend.prepare(
+    // progressCallback:)`, both already counted, `transitivelyCoveredByCaller`.
+    CallSite(
+      file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "prepare",
+      text: "try await prepare(cacheOnly: false, progressCallback: nil)",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "prepare",
+      text: "try await prepare(cacheOnly: false, progressCallback: progressCallback)",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "loadModels",
+      text: "try await manager.loadModels(loadedModels)",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "loadModels",
+      text: "try await manager.loadModels(models)", classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "startStreaming",
+      text: "try await manager.startStreaming(source: .microphone)",
+      classification: .transitivelyCoveredByCaller),
+
+    // MARK: WhisperKitBackend — test-seam override, always nil in production.
+    CallSite(
+      file: "Sources/EnviousWisprASR/WhisperKitBackend.swift", matcher: "loadModel",
+      text: "if let seams = testSeams { return try await seams.loadModel(modelPath) }",
+      classification: .dormant),
+
+    // MARK: ASRServiceHandler — the XPC helper process's two forwarding
+    // sites. No gate of its own is possible (a separate process); both are
+    // covered only because the client (ASRManagerProxy) never sends the
+    // message unless ITS OWN call chain already holds adequate protection.
+    CallSite(
+      file: "Sources/EnviousWisprASRService/ASRServiceHandler.swift", matcher: "startStreaming",
+      text: "try await parakeet.startStreaming(options: options)",
+      classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprASRService/ASRServiceHandler.swift", matcher: "prepare",
+      text: "try await backend.prepare(cacheOnly: cacheOnly) { fraction, phase, detail in",
+      classification: .transitivelyCoveredByCaller),
+
+    // MARK: CaptureVADSignalSource — a different subsystem (voice-activity
+    // detection), not the ASR engine. Matched only by method-name coincidence.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift", matcher: "prepare",
+      text: "try await detector.prepare()", classification: .unrelatedDomain),
+
+    // MARK: KernelDictationDriver
+    // The SESSIONLESS load-wedge guard's fire path. `SessionlessLoadWedgeGuard`
+    // is armed immediately before, and disarmed immediately after,
+    // `ensureEngineWarm`'s own "ensureEngineWarm" claim — both transitions
+    // are synchronous MainActor steps with no intervening `await`, so the
+    // guard's live window never outlives the claim in any observable way.
+    // (The Phase-3-era "row 2" breadcrumb at this claim's own comment block
+    // confirms this exact site was accounted for in the original plan, not
+    // an oversight.)
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/KernelDictationDriver.swift", matcher: "recoverFromWedge",
+      text: "await self.adapter.recoverFromWedge()", classification: .gated),
+    // Direct call inside "ensureEngineWarm"'s own claim closure.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/KernelDictationDriver.swift", matcher: "warmUp",
+      text: "try await adapter.warmUp()", classification: .gated),
+
+    // MARK: ParakeetEngineAdapter
+    // `recoverFromASRInterruption()`'s own recursive warm-up — that function
+    // has exactly one caller (`RecordingSessionKernel`'s mid-`.delivering`
+    // ASR-interruption salvage), itself session-scoped.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "warmUp",
+      text: "try await self.warmUp()", classification: .structurallySafe),
+    // `retryDecode()`'s own repair-before-retry re-warm — a bare, implicit-
+    // `self` call inside the SAME session-scoped `retryDecode` whose external
+    // call site is already `structurallySafe` below (`RecordingSessionKernel`
+    // reaches it only mid-`.delivering`). Inherits that same guarantee.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "warmUp",
+      text: "try await warmUp()", classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift",
+      matcher: "cancelInFlightLoad", text: "self.asrManager.cancelInFlightLoad()",
+      classification: .structurallySafe),
+    // `loadModelWithTransportRecovery()`'s primary + one-shot-retry loads —
+    // reached only via `warmUp()`, itself both gated- and
+    // structurally-safe-reachable.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "loadModel",
+      text: "try await asrManager.loadModel()", classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "loadModel",
+      text: "try await asrManager.loadModel()", classification: .transitivelyCoveredByCaller),
+    // `beginSession()`'s streaming start — reached only at a session's own
+    // start, inside the minting window `isMintingAnySession` covers.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "startStreaming",
+      text: "try await asrManager.startStreaming(options: options)",
+      classification: .structurallySafe),
+    // `cancel()`'s in-flight-load release — its dominant caller is genuine
+    // session termination (structurally safe); its one sessionless caller
+    // (`cancelSessionlessWarmup()`, the onboarding-install Cancel) performs a
+    // synchronous, generation-scoped flag reset that touches no state
+    // recovery's OWN load/session generation reads, and `EngineRecoveryGate`
+    // explicitly tolerates non-recovery mutations overlapping each other.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift",
+      matcher: "cancelInFlightLoad", text: "asrManager.cancelInFlightLoad()",
+      classification: .structurallySafe),
+    // `recoverFromWedge()`'s release — called only by the kernel's
+    // SESSION-scoped load-wedge detector.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift",
+      matcher: "cancelInFlightLoad", text: "asrManager.cancelInFlightLoad()",
+      classification: .structurallySafe),
+    // `retryDecode()`'s repair-before-retry release — `retryDecode` itself is
+    // session-scoped (called only from `RecordingSessionKernel`'s ASR-failure
+    // handling mid-`.delivering`).
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift",
+      matcher: "cancelInFlightLoad", text: "asrManager.cancelInFlightLoad()",
+      classification: .structurallySafe),
+
+    // MARK: RecordingSessionKernel — every site below fires only from within
+    // an active recording session (`.arming`/`.delivering`), which
+    // structurally precludes a recovery claim from existing.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift",
+      matcher: "recoverFromASRInterruption",
+      text: "let recovery = await adapter.recoverFromASRInterruption()",
+      classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "retryDecode",
+      text: "operation: { [adapter] in await adapter.retryDecode(inputSamples: retryInput) },",
+      classification: .structurallySafe),
+    // Row 22 — "confirmed already safe, no code change" per this file's own
+    // doc comment at the site.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "warmUp",
+      text: "try await adapter.warmUp()", classification: .structurallySafe),
+    // The kernel's own session-entry dispatch to its PRIVATE `warmUp(_ sid:)`
+    // (row 22 above) — a bare, implicit-`self` call to a same-instance
+    // method, not a new engine touch of its own. The real engine mutation
+    // happens one level deeper, inside that private method's body, via the
+    // `adapter.warmUp()` member-access call already counted (both entries
+    // immediately above and below this one).
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "warmUp",
+      text: "let warmResult = await warmUp(sid)", classification: .transitivelyCoveredByCaller),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift",
+      matcher: "recoverFromWedge",
+      text: "await adapter.recoverFromWedge()", classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift",
+      matcher: "recoverFromWedge",
+      text: "await adapter.recoverFromWedge()", classification: .structurallySafe),
+    // `preWarm()`'s best-effort cache-only pre-load, BEFORE the "preWarm"
+    // claim starts. Performs no actual engine mutation for either engine
+    // today (WhisperKit: a pure readiness read; Parakeet: the protocol's
+    // no-op default) — cannot conflict with recovery regardless of timing.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift",
+      matcher: "warmUpFromCache", text: "try? await adapter.warmUpFromCache()",
+      classification: .structurallySafe),
+    // Direct call inside "preWarm"'s own claim closure.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "warmUp",
+      text: "try await adapter.warmUp()", classification: .gated),
+
+    // MARK: OnboardingV2View — `startSetup(warmUp:settings:)`'s bare
+    // `await warmUp()` invokes a LOCAL PARAMETER (`warmUp: @MainActor ()
+    // async -> EngineWarmupOutcome`), not `ASRBackend.warmUp() async throws`
+    // directly — the visitor cannot distinguish a bare call to a local
+    // closure parameter from a bare call to a same-type instance method,
+    // both being `DeclReferenceExprSyntax`. Codex round 2 correction: its one
+    // real caller (`OnboardingV2View.swift:546`) supplies
+    // `DictationRuntime.ensureActiveEngineWarmForOnboarding()`, which routes
+    // through `KernelDictationDriver.ensureEngineWarm(reason:)` to the
+    // already-counted, `gated` `adapter.warmUp()` call above — so this DOES
+    // touch the ASR subsystem, via the callee re-acquiring (transitively)
+    // the same claim regardless of how the closure got here.
+    // `structurallySafe` category (c): reached only through a chain whose
+    // real engine touch re-acquires its own claim internally.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift",
+      matcher: "warmUp", text: "let outcome = await warmUp()",
+      classification: .structurallySafe),
+    // The one newly measured reference under the council-approved contract
+    // pivot (Codex plan-review r1 predicted this exact site): one step
+    // EARLIER in the same forwarding chain as the entry directly above —
+    // `kickSetupIfNeeded`'s own `warmUp` parameter (same local-parameter
+    // coincidental-name reasoning) is passed along to `startSetup`, whose
+    // body is the sibling entry immediately above. Same sole real wiring,
+    // same classification.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift",
+      matcher: "warmUp", text: "await self.startSetup(warmUp: warmUp, settings: settings)",
+      classification: .structurallySafe),
+
+    // MARK: WhisperKitEngineAdapter
+    // `recoverFromWedge()`'s deadline-bounded unload — this file's own doc
+    // comment marks it "§3.2, structurally-safe row": called only by the
+    // kernel's wedge detectors, which fire only within an active session.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "unload",
+      text: "await captured.unload()", classification: .structurallySafe),
+    // `unloadForRemoval()`'s unload — reached ONLY via the user-facing Remove
+    // command (`WhisperKitSetupService.removeModel()` -> `removeModelAction`
+    // -> `WhisperKitLegacyUpgradeCoordinator.remove()` -> `unloadForRemoval`
+    // closure -> `KernelDictationDriver.unloadEngineForRemoval()` -> here),
+    // which is entirely inside `removeModel()`'s own "whisperKitRemove"
+    // claim closure (verified end-to-end; this is NOT the same as the two
+    // `whisperKitIdleUnload` sites below, which are direct claim-closure
+    // calls rather than several layers of indirection into one).
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "unload",
+      text: "await backend.unload()", classification: .transitivelyCoveredByCaller),
+    // Direct calls inside the two "whisperKitIdleUnload" claim closures
+    // (`.immediately` and the timed-interval branch).
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "unload",
+      text: "await backend.unload()", classification: .gated),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "unload",
+      text: "await backend.unload()", classification: .gated),
+    // `warmUp()`'s own prepare call — reached via the same gated- and
+    // structurally-safe-mixed callers as `ParakeetEngineAdapter.warmUp()`.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "prepare",
+      text: "let task = Task<Void, Error> { try await captured.prepare() }",
+      classification: .transitivelyCoveredByCaller),
+  ]
+
+  // MARK: Live scan
+
+  /// Council-approved contract pivot (#1741 Chunk 10): a "hit" is any real
+  /// code reference to a vocabulary name, not a proof that the reference is
+  /// ultimately called. `MemberAccessExprSyntax.declName` IS ITSELF a child
+  /// `DeclReferenceExprSyntax` node in the tree (Codex plan-review r1
+  /// correction) — so a single hook on `DeclReferenceExprSyntax` catches
+  /// both a bare reference (`warmUp`) and a member reference
+  /// (`adapter.warmUp`, where `warmUp` is `declName`) with no double
+  /// counting and no separate `MemberAccessExprSyntax` hook needed. This
+  /// deletes the entire prior callee-resolution machinery (wrapper unwrap,
+  /// operator folding, ambiguous-branch detection) — none of it matters when
+  /// the question is "is the name referenced" rather than "is this
+  /// specifically a call."
+  ///
+  /// Comments are trivia the parser already excludes from the syntax tree —
+  /// this visitor never sees them at all, in any form (line, block, nested).
+  /// String literal CONTENT is never parsed as an expression, so vocabulary
+  /// text quoted inside a log message is never mistaken for a reference, in
+  /// any string form (plain, multi-line, raw, any hash count). A real
+  /// reference hidden inside string interpolation — even split across
+  /// multiple physical lines — is correctly found too, because SwiftParser
+  /// parses an interpolation segment as a REAL, complete expression subtree.
+  /// This guarantee is parser-structural and untouched by the contract
+  /// pivot.
+  private final class CallSiteVisitor: SyntaxVisitor {
+    private(set) var hits: [(matcher: String, line: Int, text: String)] = []
+    private let converter: SourceLocationConverter
+    private let sourceLines: [Substring]
+
+    init(source: String, tree: some SyntaxProtocol) {
+      self.converter = SourceLocationConverter(fileName: "", tree: tree)
+      self.sourceLines = source.split(separator: "\n", omittingEmptySubsequences: false)
+      super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+      // Codex round 1 correction: `.text` preserves backticks, so an escaped
+      // reference (`` adapter.`warmUp`() ``) would silently bypass the
+      // vocabulary check. `.identifier?.name` is SwiftSyntax's own canonical,
+      // backtick-stripped identifier — the general fix, not a backtick
+      // special case.
+      guard let name = node.baseName.identifier?.name, vocabulary.contains(name) else {
+        return .visitChildren
+      }
+      let line = converter.location(for: node.positionAfterSkippingLeadingTrivia).line
+      let text =
+        (line - 1) < sourceLines.count
+        ? sourceLines[line - 1].trimmingCharacters(in: .whitespaces) : ""
+      hits.append((matcher: name, line: line, text: text))
+      return .visitChildren
+    }
+  }
+
+  /// A source file that could not be discovered (directory enumeration
+  /// failed), read, or parsed cleanly. Codex plan-review r1 correction: an
+  /// unreadable or unparseable file must fail the whole scan, never be
+  /// silently treated as clean (the prior `(try? ... ) ?? ""` pattern turned
+  /// an unreadable file into a successfully-parsed EMPTY file — invisible to
+  /// the inventory, not merely skipped).
+  private struct ScanFailedError: Error, CustomStringConvertible {
+    let file: String
+    let reason: String
+    var description: String {
+      "Scan failed for \(file): \(reason). Never silently treated as clean."
+    }
+  }
+
+  /// Shared by the live file scanner and the fixture-based tests below, so a
+  /// test proving comment/string handling actually exercises the SAME parser
+  /// + visitor path the live scan uses (Codex round 1 P3, still honored:
+  /// never a parallel, simpler stand-in).
+  ///
+  /// `Parser.parse` never throws — it is resilient by design and always
+  /// returns SOME tree, using error-recovery nodes for malformed input.
+  /// `tree.hasError` is checked explicitly and throws `ScanFailedError`
+  /// rather than silently scanning a best-effort recovered tree that could
+  /// hide or misplace a reference.
+  private static func hits(inSource source: String, file: String) throws -> [RawHit] {
+    let tree = Parser.parse(source: source)
+    guard !tree.hasError else {
+      throw ScanFailedError(file: file, reason: "source did not parse cleanly (tree.hasError)")
+    }
+    let visitor = CallSiteVisitor(source: source, tree: tree)
+    visitor.walk(tree)
+    return visitor.hits.map {
+      RawHit(file: file, matcher: $0.matcher, text: $0.text, line: $0.line)
+    }
+  }
+
+  /// Count of vocabulary-name references matching `matcher` in `source` —
+  /// used by the fixture tests below.
+  private static func hitCount(in source: String, matcher: String) throws -> Int {
+    try Self.hits(inSource: source, file: "<fixture>").filter { $0.matcher == matcher }.count
+  }
+
+  /// Scans a single directory. Extracted from `scanLiveCallSites()` so a
+  /// fixture test can point it at a throwaway temp directory to exercise the
+  /// REAL discovery/read/parse failure paths, not a parallel simpler
+  /// stand-in.
+  private static func scanRoot(at rootURL: URL) throws -> [RawHit] {
+    var hits: [RawHit] = []
+    var enumerationError: Error?
+    // A trailing closure directly in a `guard`/`if` condition is a known
+    // Swift parser ambiguity (it can be read as the statement's own body) —
+    // passed as an explicit `errorHandler:` argument instead.
+    guard
+      let enumerator = FileManager.default.enumerator(
+        at: rootURL, includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles, .skipsPackageDescendants],
+        errorHandler: { _, error in
+          enumerationError = error
+          return false
+        })
+    else {
+      // Codex round 1 correction: `FileManager.enumerator` returns an
+      // Optional; relying solely on the error-handler closure firing left a
+      // theoretical path where a nil enumerator (no callback invoked) would
+      // fall through the `while let` below as zero hits — a silent, wrongly
+      // "clean" scan rather than a failure. Guarded explicitly here.
+      throw ScanFailedError(file: rootURL.path, reason: "could not create a directory enumerator")
+    }
+    while let url = enumerator.nextObject() as? URL {
+      guard url.pathExtension == "swift" else { continue }
+      let source: String
+      do {
+        source = try String(contentsOf: url, encoding: .utf8)
+      } catch {
+        throw ScanFailedError(file: url.path, reason: "could not be read: \(error)")
+      }
+      hits.append(contentsOf: try Self.hits(inSource: source, file: url.path))
+    }
+    if let enumerationError {
+      throw ScanFailedError(
+        file: rootURL.path, reason: "directory enumeration failed: \(enumerationError)")
+    }
+    return hits
+  }
+
+  private static func scanLiveCallSites() throws -> [RawHit] {
+    var hits: [RawHit] = []
+    let relativePrefix = RepoRoot.url.path + "/"
+    for root in scannedRoots {
+      let rootURL = RepoRoot.sourceURL(root)
+      let rootHits = try scanRoot(at: rootURL)
+      hits.append(
+        contentsOf: rootHits.map {
+          RawHit(
+            file: $0.file.replacingOccurrences(of: relativePrefix, with: ""), matcher: $0.matcher,
+            text: $0.text, line: $0.line)
+        })
+    }
+    return hits
+  }
+
+  /// Generic recursive scan under an arbitrary repo-relative root, used by the
+  /// whole-repo single-authority tests (5/6/7/8) that are not scoped to the
+  /// four mutation-vocabulary directories.
+  private static func scanSources(pattern: String, under root: String) throws -> [String] {
+    let regex = try NSRegularExpression(pattern: pattern)
+    let rootURL = RepoRoot.sourceURL(root)
+    let enumerator = FileManager.default.enumerator(
+      at: rootURL, includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles, .skipsPackageDescendants])
+    var hits: [String] = []
+    while let url = enumerator?.nextObject() as? URL {
+      guard url.pathExtension == "swift" else { continue }
+      let relative = url.path.replacingOccurrences(of: RepoRoot.url.path + "/", with: "")
+      let source = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+      for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false)
+        .enumerated()
+      {
+        let text = String(line)
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("//") { continue }
+        let ns = text as NSString
+        if regex.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)) != nil {
+          hits.append("\(relative):\(idx + 1): \(trimmed)")
+        }
+      }
+    }
+    return hits
+  }
+
+  // MARK: 1 — the live scan's raw multiset exactly matches the frozen table
+
+  @Test("live scanner output exactly matches the frozen classified inventory, as a multiset")
+  func liveInventoryMatchesFrozenClassification() throws {
+    let live = try Self.scanLiveCallSites()
+    var liveCounts: [SiteKey: Int] = [:]
+    for hit in live { liveCounts[hit.key, default: 0] += 1 }
+
+    var expectedCounts: [SiteKey: Int] = [:]
+    for site in Self.expected {
+      expectedCounts[
+        SiteKey(file: site.file, matcher: site.matcher, text: site.text), default: 0] += 1
+    }
+
+    let newOrDuplicated = liveCounts.filter { expectedCounts[$0.key, default: 0] < $0.value }
+    let goneOrUndersized = expectedCounts.filter { liveCounts[$0.key, default: 0] < $0.value }
+
+    func describe(_ key: SiteKey, liveHits: [RawHit]) -> String {
+      let lines = liveHits.filter { $0.key == key }.map { "\($0.file):\($0.line)" }
+      return "  [\(key.file)] matcher=\(key.matcher) text=`\(key.text)` (live at: \(lines))"
+    }
+
+    #expect(
+      newOrDuplicated.isEmpty,
+      """
+      Found \(newOrDuplicated.count) live call site(s) not fully accounted for in the frozen
+      table (a new call, a moved call, or a duplicate this table under-counts):
+      \(newOrDuplicated.keys.map { describe($0, liveHits: live) }.joined(separator: "\n"))
+      Classify the new/duplicated site and add it to `expected` in this file.
+      """)
+    #expect(
+      goneOrUndersized.isEmpty,
+      """
+      Found \(goneOrUndersized.count) frozen entry/entries no longer present in live source
+      (a call was deleted, renamed, or this table over-counts):
+      \(goneOrUndersized.keys.map { "  [\($0.file)] matcher=\($0.matcher) text=`\($0.text)`" }
+        .joined(separator: "\n"))
+      Remove the stale entry/entries from `expected` in this file.
+      """)
+  }
+
+  // MARK: 2 — a call expression is detected while a declaration is not
+
+  @Test("a call expression is detected while a method declaration with the same name is not")
+  func adversarialCallSiteVsDeclaration() throws {
+    let call = "adapter.warmUp()"
+    let decl = "func warmUp() async throws {}"
+    #expect(try Self.hitCount(in: call, matcher: "warmUp") == 1)
+    #expect(try Self.hitCount(in: decl, matcher: "warmUp") == 0)
+  }
+
+  // MARK: 2b — direct/chained calls and stored references (council-approved
+  // contract pivot: a reference is a hit regardless of whether, how, or
+  // whether-at-all it is ultimately called — see the file-level doc comment
+  // above for why this replaces the entire prior callee-resolution axis).
+
+  @Test("a direct call is detected")
+  func positiveControlDirectCallIsDetected() throws {
+    #expect(try Self.hitCount(in: "adapter.warmUp()", matcher: "warmUp") == 1)
+  }
+
+  @Test(
+    "a chained call (base is itself a call result) is detected — the base's own kind never matters")
+  func positiveControlChainedCallIsDetected() throws {
+    #expect(try Self.hitCount(in: "getAdapter().warmUp()", matcher: "warmUp") == 1)
+  }
+
+  @Test("a bare call with implicit `self` (no member-access receiver at all) is detected")
+  func positiveControlBareImplicitSelfCallIsDetected() throws {
+    #expect(try Self.hitCount(in: "Task { await unloadModel() }", matcher: "unloadModel") == 1)
+  }
+
+  @Test("a trailing-closure call with no parentheses at all is detected")
+  func positiveControlTrailingClosureNoParensIsDetected() throws {
+    // The real entry in the frozen table (`ASRManagerProxy.swift`) proves
+    // this against live source; this fixture proves it in isolation.
+    #expect(
+      try Self.hitCount(in: "proxy.unloadModel { cont.resume() }", matcher: "unloadModel") == 1)
+  }
+
+  @Test(
+    "a method reference stored in a variable and NEVER called is now caught at the point of reference — the prior design's one accepted, irreducible boundary is closed, not merely documented"
+  )
+  func positiveControlStoredUninvokedReferenceIsDetected() throws {
+    #expect(try Self.hitCount(in: "let f = adapter.warmUp", matcher: "warmUp") == 1)
+  }
+
+  @Test(
+    "a vocabulary name passed as a plain argument, never itself called, is still a real reference and is detected"
+  )
+  func positiveControlArgumentPositionReferenceIsDetected() throws {
+    #expect(try Self.hitCount(in: "foo(adapter.warmUp)", matcher: "warmUp") == 1)
+  }
+
+  @Test(
+    "switchBackend is matched uniformly regardless of argument label — the prior `to:`-only special case is retired"
+  )
+  func positiveControlSwitchBackendMatchedUniformly() throws {
+    #expect(try Self.hitCount(in: "switchBackend(to: .whisperKit)", matcher: "switchBackend") == 1)
+    #expect(
+      try Self.hitCount(in: "switchBackend(from: .whisperKit)", matcher: "switchBackend") == 1)
+  }
+
+  @Test(
+    "a member access is counted exactly once — `MemberAccessExprSyntax.declName` IS the same `DeclReferenceExprSyntax` node the generic visitor hook sees, not a second occurrence (Codex plan-review r1 double-count correction)"
+  )
+  func adversarialMemberAccessCountedOnce() throws {
+    #expect(try Self.hitCount(in: "adapter.warmUp()", matcher: "warmUp") == 1)
+    #expect(try Self.hitCount(in: "let f = adapter.warmUp", matcher: "warmUp") == 1)
+  }
+
+  @Test(
+    "a backtick-escaped member reference is still detected — `.text` would preserve the backticks and silently miss this (Codex round 1 correction)"
+  )
+  func adversarialEscapedMemberReferenceIsDetected() throws {
+    #expect(try Self.hitCount(in: "adapter.`warmUp`()", matcher: "warmUp") == 1)
+  }
+
+  @Test("a backtick-escaped bare reference is still detected")
+  func adversarialEscapedBareReferenceIsDetected() throws {
+    #expect(try Self.hitCount(in: "let f = `warmUp`", matcher: "warmUp") == 1)
+  }
+
+  // MARK: 2c — conditional compilation: every syntactically represented
+  // branch is scanned in one pass, regardless of which flags this test
+  // process itself was built with.
+
+  @Test(
+    "both branches of an #if/#else are scanned, regardless of which flag is active for this test process"
+  )
+  func positiveControlConditionalCompilationBothBranchesScanned() throws {
+    let source = """
+      #if USE_WARMUP
+      adapter.warmUp()
+      #else
+      adapter.prepare()
+      #endif
+      """
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+    #expect(try Self.hitCount(in: source, matcher: "prepare") == 1)
+  }
+
+  @Test("a postfix #if/#else directly in a member-access chain is scanned on both sides")
+  func positiveControlPostfixIfConfigBothSidesScanned() throws {
+    // Codex's exact counterexample from the abandoned callee-folding design
+    // — a real, intentional, SwiftParser-tested form. Under the reference-
+    // only contract this needs no special handling at all: both `.warmUp`
+    // and `.prepare` are ordinary member references, found independently.
+    let source = """
+      adapter
+        #if USE_WARMUP
+          .warmUp
+        #else
+          .prepare
+        #endif
+        ()
+      """
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+    #expect(try Self.hitCount(in: source, matcher: "prepare") == 1)
+  }
+
+  // MARK: 2d — conditional and operator expressions: no ambiguity detection
+  // needed anymore. Each branch is an independent reference, found and
+  // counted on its own; there is nothing left to disambiguate.
+
+  @Test(
+    "a ternary naming a vocabulary method on either branch counts BOTH references — no ambiguity to detect"
+  )
+  func positiveControlTernaryBothBranchesCounted() throws {
+    let source = "(useFirst ? adapter.warmUp : other.prepare)()"
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+    #expect(try Self.hitCount(in: source, matcher: "prepare") == 1)
+  }
+
+  @Test(
+    "a nil-coalescing expression naming a vocabulary method on either side counts BOTH references")
+  func positiveControlNilCoalescingBothSidesCounted() throws {
+    let source = "(adapter.warmUp ?? other.prepare)()"
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+    #expect(try Self.hitCount(in: source, matcher: "prepare") == 1)
+  }
+
+  @Test("an `if`-used-as-expression selecting between vocabulary references counts BOTH branches")
+  func positiveControlIfExpressionBothBranchesCounted() throws {
+    let source = #"""
+      (if useFirst {
+        adapter.warmUp
+      } else {
+        other.prepare
+      })()
+      """#
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+    #expect(try Self.hitCount(in: source, matcher: "prepare") == 1)
+  }
+
+  @Test(
+    "an `as`-cast-wrapped reference is detected — Codex round 2's exact counterexample from the abandoned design, trivial under the new contract"
+  )
+  func positiveControlAsCastWrappedReferenceIsDetected() throws {
+    let source = "try await (adapter.warmUp as () async throws -> Void)()"
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+  }
+
+  @Test(
+    "an `is`-check testing a vocabulary reference is a real reference and IS counted — the contract no longer tries to judge whether the surrounding expression is 'identity-preserving'"
+  )
+  func positiveControlIsCheckReferenceIsCounted() throws {
+    #expect(try Self.hitCount(in: "(adapter.warmUp is AnyObject)()", matcher: "warmUp") == 1)
+  }
+
+  @Test("calling the RESULT of a call is not conflated with the vocabulary name that produced it")
+  func adversarialDoubleCallAsCalleeIsNotFabricated() throws {
+    // `adapter.warmUp()` (the INNER call) is one real reference; the OUTER
+    // call's callee is that inner call's RESULT, containing no name of its
+    // own — so the total is exactly 1, proving the inner reference is found
+    // once and the outer call adds no phantom second reference.
+    #expect(try Self.hitCount(in: "adapter.warmUp()()", matcher: "warmUp") == 1)
+  }
+
+  @Test("two distinct vocabulary references on the same line are both counted, independently")
+  func positiveControlTwoDistinctReferencesOnOneLineAreBothCounted() throws {
+    let source = "adapter.warmUp(); await other.unloadModel()"
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+    #expect(try Self.hitCount(in: source, matcher: "unloadModel") == 1)
+  }
+
+  // MARK: 2e — ownership-related forms (Swift 5.9+ `consume`/`copy`/`borrow`,
+  // supported by this project's Swift 6.3.3 toolchain). Plain references
+  // under the new contract; no special unwrap logic required.
+
+  @Test("a `consume`-wrapped reference is detected")
+  func positiveControlConsumeReferenceIsDetected() throws {
+    #expect(try Self.hitCount(in: "(consume adapter.warmUp)()", matcher: "warmUp") == 1)
+  }
+
+  @Test("a `copy`-wrapped reference is detected")
+  func positiveControlCopyReferenceIsDetected() throws {
+    #expect(try Self.hitCount(in: "(copy adapter.warmUp)()", matcher: "warmUp") == 1)
+  }
+
+  @Test("a `borrow`-wrapped reference is detected")
+  func positiveControlBorrowReferenceIsDetected() throws {
+    #expect(try Self.hitCount(in: "(borrow adapter.warmUp)()", matcher: "warmUp") == 1)
+  }
+
+  // MARK: 2f — fail-closed on discovery/read/parse failure (Codex plan-
+  // review r1 correction: the prior `(try? ...) ?? ""` pattern silently
+  // turned an unreadable file into a successfully-parsed empty file).
+
+  @Test(
+    "malformed source that cannot parse cleanly fails the scan closed, rather than being silently treated as clean"
+  )
+  func adversarialMalformedSourceFailsClosed() throws {
+    let source = "func warmUp( { this is not valid Swift at all !!! ###"
+    #expect(throws: ScanFailedError.self) {
+      try Self.hits(inSource: source, file: "<fixture>")
+    }
+  }
+
+  @Test(
+    "a directory containing a file that cannot be read fails the scan closed, rather than silently skipping it"
+  )
+  func adversarialUnreadableFileFailsClosed() throws {
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let fileURL = tempDir.appendingPathComponent("Unreadable.swift")
+    try "adapter.warmUp()".write(to: fileURL, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: fileURL.path)
+    defer {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: fileURL.path)
+    }
+    #expect(throws: ScanFailedError.self) {
+      try Self.scanRoot(at: tempDir)
+    }
+  }
+
+  @Test(
+    "a directory that does not exist fails the scan closed, rather than silently returning zero hits"
+  )
+  func adversarialNonexistentDirectoryFailsClosed() throws {
+    let missingDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "does-not-exist-\(UUID().uuidString)")
+    #expect(throws: ScanFailedError.self) {
+      try Self.scanRoot(at: missingDir)
+    }
+  }
+
+  // MARK: 3 — comments and string content are never mistaken for a real call
+
+  @Test("a comment-only mention of a vocabulary call is ignored — line comment")
+  func negativeControlLineCommentSkipped() throws {
+    let source = """
+      // adapter.recoverFromWedge() used to run unconditionally here
+      let x = 1
+      """
+    #expect(try Self.hitCount(in: source, matcher: "recoverFromWedge") == 0)
+  }
+
+  @Test("a comment-only mention of a vocabulary call is ignored — block comment")
+  func negativeControlBlockCommentSkipped() throws {
+    let source = """
+      /* adapter.warmUp() was removed from this path */
+      let x = 1
+      """
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 0)
+  }
+
+  @Test("a comment-only mention of a vocabulary call is ignored — multi-line block comment")
+  func negativeControlMultiLineBlockCommentSkipped() throws {
+    let source = """
+      /*
+      adapter.warmUp() used to run here
+      */
+      let x = 1
+      """
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 0)
+  }
+
+  @Test("vocabulary text quoted inside a string literal is not counted as a real call")
+  func negativeControlVocabularyInsideStringLiteralNotCounted() throws {
+    let source = #"log.info("adapter.warmUp() was skipped this run")"#
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 0)
+  }
+
+  @Test("vocabulary text quoted inside a RAW string literal is not counted as a real call")
+  func negativeControlVocabularyInsideRawStringLiteralNotCounted() throws {
+    let source = ##"log.info(#"adapter.warmUp() was skipped this run"#)"##
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 0)
+  }
+
+  @Test("a comment-delimiter-shaped substring inside a string literal does not confuse the parser")
+  func negativeControlURLStringDoesNotConfuseTheParser() throws {
+    let source = #"let url = "https://example.com"; await adapter.warmUp()"#
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+  }
+
+  @Test("a bare `/*`-shaped substring inside a string literal does not confuse the parser")
+  func negativeControlBlockCommentOpenerStringDoesNotConfuseTheParser() throws {
+    let source = #"""
+      let marker = "/*"; await adapter.warmUp()
+      await adapter.recoverFromWedge()
+      """#
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+    #expect(try Self.hitCount(in: source, matcher: "recoverFromWedge") == 1)
+  }
+
+  @Test(
+    "a comment-delimiter-shaped substring inside a RAW string literal does not confuse the parser"
+  )
+  func negativeControlRawStringDoesNotConfuseTheParser() throws {
+    let source = ##"let pattern = #"http://example.com"#; await adapter.warmUp()"##
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 1)
+  }
+
+  @Test(
+    "a genuine call hidden inside string interpolation IS correctly detected (Codex round 4's first counterexample, previously a fail-closed case in the hand-rolled scanner)"
+  )
+  func positiveControlInterpolatedCallIsDetected() throws {
+    let source = #"let result = "\(await adapter.retryDecode(inputSamples: samples))""#
+    #expect(try Self.hitCount(in: source, matcher: "retryDecode") == 1)
+  }
+
+  @Test(
+    "a nested quote inside an interpolation neither hides nor fabricates a hit (Codex round 4's second counterexample)"
+  )
+  func positiveControlNestedQuoteInInterpolationIsHandledCorrectly() throws {
+    // The real call here is `format(...)`, whose argument is a plain string —
+    // not a member-access call — so a real parser correctly finds zero
+    // `.warmUp(` calls, exactly what a human reading this code would
+    // conclude. Under the old hand-rolled scanner, this exact shape could
+    // make naive quote-tracking exit the outer string early and misread the
+    // inner quoted text as a real `.warmUp(` call.
+    let source = ##"let text = "\(format("adapter.warmUp()"))""##
+    #expect(try Self.hitCount(in: source, matcher: "warmUp") == 0)
+  }
+
+  @Test(
+    "multi-line interpolation spanning multiple physical lines is correctly detected (Codex round 5)"
+  )
+  func positiveControlMultiLineInterpolationIsDetected() throws {
+    let source = #"""
+      let result = """
+      \(
+        await adapter.retryDecode(inputSamples: samples)
+      )
+      """
+      """#
+    #expect(try Self.hitCount(in: source, matcher: "retryDecode") == 1)
+  }
+
+  // MARK: 4 — duplicate identical calls preserve multiplicity
+
+  @Test("duplicate identical calls on separate lines preserve multiplicity")
+  func duplicateCallsOnSeparateLinesPreserveMultiplicity() throws {
+    let source = """
+      await adapter.warmUp()
+      await adapter.warmUp()
+      """
+    #expect(
+      try Self.hitCount(in: source, matcher: "warmUp") == 2,
+      "two identical calls must both be counted, never deduplicated to one")
+  }
+
+  @Test("duplicate identical calls on the SAME line preserve multiplicity")
+  func duplicateCallsOnTheSameLinePreserveMultiplicity() throws {
+    let source = "await first.warmUp(); await second.warmUp()"
+    #expect(
+      try Self.hitCount(in: source, matcher: "warmUp") == 2,
+      "two calls sharing one physical line must both be counted")
+  }
+
+  // MARK: 5 — no production consumer uses .alwaysAllowedForTesting
+
+  @Test(
+    "no production consumer references .alwaysAllowedForTesting outside its two declaring files")
+  func alwaysAllowedForTestingHasNoProductionConsumer() throws {
+    let declaringFiles: Set<String> = [
+      "Sources/EnviousWisprASR/EngineMutationScope.swift",
+      "Sources/EnviousWisprAppKit/App/RecoveryEngineClaim.swift",
+    ]
+    let hits = try Self.scanSources(pattern: #"alwaysAllowedForTesting"#, under: "Sources")
+    let offenders = hits.filter { hit in
+      !declaringFiles.contains { hit.hasPrefix($0 + ":") }
+    }
+    #expect(
+      offenders.isEmpty,
+      """
+      `.alwaysAllowedForTesting` is referenced in production outside its two declaring files:
+      \(offenders.joined(separator: "\n"))
+      It is `internal`, test-only, and reachable only via `@testable import`; a real production
+      site using it by name would be exactly the silent-bypass risk #1741 exists to prevent.
+      """)
+  }
+
+  // MARK: 6 — exactly one production EngineMutationScope.live(...) call
+
+  @Test("exactly one production EngineMutationScope.live(...) construction")
+  func engineMutationScopeLiveConstructedOnce() throws {
+    let hits = try Self.scanSources(pattern: #"EngineMutationScope\.live\("#, under: "Sources")
+    #expect(
+      hits.count == 1,
+      "expected exactly one `EngineMutationScope.live(...)` construction, found \(hits.count): \(hits)"
+    )
+    #expect(hits.first?.contains("WisprBootstrapper.swift") == true, "found: \(hits)")
+  }
+
+  // MARK: 7 — exactly one production RecoveryEngineClaim.live(...) call
+
+  @Test("exactly one production RecoveryEngineClaim.live(...) construction")
+  func recoveryEngineClaimLiveConstructedOnce() throws {
+    let hits = try Self.scanSources(pattern: #"RecoveryEngineClaim\.live\("#, under: "Sources")
+    #expect(
+      hits.count == 1,
+      "expected exactly one `RecoveryEngineClaim.live(...)` construction, found \(hits.count): \(hits)"
+    )
+    #expect(hits.first?.contains("WisprBootstrapper.swift") == true, "found: \(hits)")
+  }
+
+  // MARK: 8 — both .live(...) calls live in WisprBootstrapper.swift
+
+  @Test("both .live(...) capability constructions live in WisprBootstrapper.swift")
+  func bothLiveConstructionsShareOneCompositionRoot() throws {
+    let scopeHits = try Self.scanSources(pattern: #"EngineMutationScope\.live\("#, under: "Sources")
+    let claimHits = try Self.scanSources(pattern: #"RecoveryEngineClaim\.live\("#, under: "Sources")
+    let allInBootstrapper =
+      (scopeHits + claimHits).allSatisfy { $0.contains("App/WisprBootstrapper.swift") }
+    let allHits = scopeHits + claimHits
+    #expect(
+      allInBootstrapper,
+      "both capability `.live(...)` constructions must live in the composition root: \(allHits)")
+  }
+
+  // MARK: 9 — every knownGap entry is fully tracked, and only the confirmed
+  // sites carry it
+
+  @Test("every knownGap classification names a positive, concrete issue and reason")
+  func knownGapEntriesAreFullyTracked() {
+    let gaps: [(issue: Int, reason: String)] = Self.expected.compactMap { site in
+      guard case .knownGap(let issue, let reason) = site.classification else { return nil }
+      return (issue, reason)
+    }
+    #expect(
+      gaps.count == 2,
+      "expected exactly the two ActiveEngineOperation hardCancel entries to carry `knownGap`, found \(gaps.count)"
+    )
+    for gap in gaps {
+      #expect(
+        gap.issue > 0,
+        "a `knownGap` entry must name a real, positive GitHub issue number — never a placeholder")
+      #expect(
+        gap.issue == 1745,
+        "expected every current `knownGap` entry to point at #1745; found #\(gap.issue) instead")
+      #expect(
+        !gap.reason.trimmingCharacters(in: .whitespaces).isEmpty,
+        "a `knownGap` entry must carry a concrete reason, not a blank string")
+    }
+  }
+
+  @Test(
+    "knownGap applies to exactly the two confirmed-unsafe ActiveEngineOperation sites, no others")
+  func knownGapAppliesOnlyToTheConfirmedUnsafeSites() {
+    let expectedGapKeys: Set<SiteKey> = [
+      SiteKey(
+        file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift", matcher: "unload",
+        text: "await whisperKitBackend.unload()"),
+      SiteKey(
+        file: "Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift",
+        matcher: "cancelInFlightLoad", text: "asrManager.cancelInFlightLoad()"),
+    ]
+    let actualGapKeys = Set(
+      Self.expected.compactMap { site -> SiteKey? in
+        guard case .knownGap = site.classification else { return nil }
+        return SiteKey(file: site.file, matcher: site.matcher, text: site.text)
+      })
+    #expect(
+      actualGapKeys == expectedGapKeys,
+      """
+      `knownGap` must apply to exactly the two confirmed-unsafe
+      `ActiveEngineOperation.hardCancel` sites tracked at #1745 — found:
+      \(actualGapKeys)
+      A different entry carrying `knownGap` means either a real new gap was found (open its own
+      issue and add it here deliberately) or an already-safe entry was quietly weakened to dodge
+      Test 1 — neither may happen silently.
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -1308,33 +1308,109 @@ import Testing
     return hits
   }
 
-  /// Generic recursive scan under an arbitrary repo-relative root, used by the
-  /// whole-repo single-authority tests (5/6/7/8) that are not scoped to the
-  /// four mutation-vocabulary directories.
-  private static func scanSources(pattern: String, under root: String) throws -> [String] {
-    let regex = try NSRegularExpression(pattern: pattern)
-    let rootURL = RepoRoot.sourceURL(root)
-    let enumerator = FileManager.default.enumerator(
-      at: rootURL, includingPropertiesForKeys: nil,
-      options: [.skipsHiddenFiles, .skipsPackageDescendants])
-    var hits: [String] = []
-    while let url = enumerator?.nextObject() as? URL {
+  /// The narrow source shapes used by the whole-repo single-authority tests
+  /// (5/6/7/8), structurally recognized from Swift tokens rather than text.
+  private enum SourceNeedle: Hashable, Sendable {
+    case identifier(String)
+    case staticMember(type: String, member: String)
+  }
+
+  private static func scanSources(_ needle: SourceNeedle, at rootURL: URL) throws -> [String] {
+    try scanSources([needle], at: rootURL)[needle, default: []]
+  }
+
+  /// URL-taking overload so the live single-authority checks and their
+  /// adversarial fixtures exercise the same discovery/read/parse/match path.
+  private static func scanSources(
+    _ needles: Set<SourceNeedle>, at rootURL: URL
+  ) throws -> [SourceNeedle: [String]] {
+    var enumerationError: Error?
+    guard
+      let enumerator = FileManager.default.enumerator(
+        at: rootURL, includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles, .skipsPackageDescendants],
+        errorHandler: { _, error in
+          enumerationError = error
+          return false
+        })
+    else {
+      throw ScanFailedError(file: rootURL.path, reason: "could not create a directory enumerator")
+    }
+    var hits = Dictionary(uniqueKeysWithValues: needles.map { ($0, [String]()) })
+    while let url = enumerator.nextObject() as? URL {
       guard url.pathExtension == "swift" else { continue }
       let relative = url.path.replacingOccurrences(of: RepoRoot.url.path + "/", with: "")
-      let source = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
-      for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false)
-        .enumerated()
-      {
-        let text = String(line)
-        let trimmed = text.trimmingCharacters(in: .whitespaces)
-        if trimmed.hasPrefix("//") { continue }
-        let ns = text as NSString
-        if regex.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)) != nil {
-          hits.append("\(relative):\(idx + 1): \(trimmed)")
+      let source: String
+      do {
+        source = try String(contentsOf: url, encoding: .utf8)
+      } catch {
+        throw ScanFailedError(file: url.path, reason: "could not be read: \(error)")
+      }
+      let tree = Parser.parse(source: source)
+      guard !tree.hasError else {
+        throw ScanFailedError(
+          file: url.path, reason: "source did not parse cleanly (tree.hasError)")
+      }
+      let converter = SourceLocationConverter(fileName: url.path, tree: tree)
+      let tokens = Array(tree.tokens(viewMode: .sourceAccurate))
+
+      func appendHit(for needle: SourceNeedle, at token: TokenSyntax) {
+        let line = converter.location(for: token.positionAfterSkippingLeadingTrivia).line
+        hits[needle, default: []].append("\(relative):\(line)")
+      }
+
+      for needle in needles {
+        switch needle {
+        case .identifier(let expected):
+          for token in tokens {
+            if case .identifier(let name) = token.tokenKind, name == expected {
+              appendHit(for: needle, at: token)
+            }
+          }
+        case .staticMember(let expectedType, let expectedMember):
+          guard tokens.count >= 3 else { continue }
+          for index in 0...(tokens.count - 3) {
+            guard
+              case .identifier(let typeName) = tokens[index].tokenKind,
+              typeName == expectedType,
+              tokens[index + 1].tokenKind == .period,
+              case .identifier(let memberName) = tokens[index + 2].tokenKind,
+              memberName == expectedMember
+            else {
+              continue
+            }
+            appendHit(for: needle, at: tokens[index])
+          }
         }
       }
     }
+    if let enumerationError {
+      throw ScanFailedError(
+        file: rootURL.path, reason: "directory enumeration failed: \(enumerationError)")
+    }
     return hits
+  }
+
+  private struct SourceAuthoritySnapshot: Sendable {
+    let alwaysAllowedForTesting: [String]
+    let engineMutationScopeLive: [String]
+    let recoveryEngineClaimLive: [String]
+  }
+
+  /// One fail-closed parse of `Sources/`, shared by tests 5/6/7/8. Without
+  /// this snapshot those four assertions would independently parse the same
+  /// production tree five times.
+  private static let sourceAuthoritySnapshot: Result<SourceAuthoritySnapshot, any Error> = Result {
+    let alwaysAllowed = SourceNeedle.identifier("alwaysAllowedForTesting")
+    let mutationScope = SourceNeedle.staticMember(type: "EngineMutationScope", member: "live")
+    let recoveryClaim = SourceNeedle.staticMember(type: "RecoveryEngineClaim", member: "live")
+    let hits = try scanSources(
+      [alwaysAllowed, mutationScope, recoveryClaim],
+      at: RepoRoot.sourceURL("Sources"))
+    return SourceAuthoritySnapshot(
+      alwaysAllowedForTesting: hits[alwaysAllowed, default: []],
+      engineMutationScopeLive: hits[mutationScope, default: []],
+      recoveryEngineClaimLive: hits[recoveryClaim, default: []])
   }
 
   // MARK: 1 — the live scan's raw multiset exactly matches the frozen table
@@ -1612,6 +1688,10 @@ import Testing
     #expect(throws: ScanFailedError.self) {
       try Self.scanRoot(at: tempDir)
     }
+    #expect(throws: ScanFailedError.self) {
+      try Self.scanSources(
+        .staticMember(type: "EngineMutationScope", member: "live"), at: tempDir)
+    }
   }
 
   @Test(
@@ -1622,6 +1702,10 @@ import Testing
       "does-not-exist-\(UUID().uuidString)")
     #expect(throws: ScanFailedError.self) {
       try Self.scanRoot(at: missingDir)
+    }
+    #expect(throws: ScanFailedError.self) {
+      try Self.scanSources(
+        .staticMember(type: "EngineMutationScope", member: "live"), at: missingDir)
     }
   }
 
@@ -1758,7 +1842,7 @@ import Testing
       "Sources/EnviousWisprASR/EngineMutationScope.swift",
       "Sources/EnviousWisprAppKit/App/RecoveryEngineClaim.swift",
     ]
-    let hits = try Self.scanSources(pattern: #"alwaysAllowedForTesting"#, under: "Sources")
+    let hits = try Self.sourceAuthoritySnapshot.get().alwaysAllowedForTesting
     let offenders = hits.filter { hit in
       !declaringFiles.contains { hit.hasPrefix($0 + ":") }
     }
@@ -1774,9 +1858,29 @@ import Testing
 
   // MARK: 6 — exactly one production EngineMutationScope.live(...) call
 
+  @Test("a capability construction split across physical lines is still detected")
+  func multilineCapabilityConstructionIsDetected() throws {
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let fileURL = tempDir.appendingPathComponent("MultilineConstruction.swift")
+    try """
+    let scope = EngineMutationScope
+      .live(
+        tryBegin: { true },
+        end: { false },
+        wake: {},
+        onRefused: { _ in })
+    """.write(to: fileURL, atomically: true, encoding: .utf8)
+
+    let hits = try Self.scanSources(
+      .staticMember(type: "EngineMutationScope", member: "live"), at: tempDir)
+    #expect(hits.count == 1, "multiline construction must count as one hit: \(hits)")
+  }
+
   @Test("exactly one production EngineMutationScope.live(...) construction")
   func engineMutationScopeLiveConstructedOnce() throws {
-    let hits = try Self.scanSources(pattern: #"EngineMutationScope\.live\("#, under: "Sources")
+    let hits = try Self.sourceAuthoritySnapshot.get().engineMutationScopeLive
     #expect(
       hits.count == 1,
       "expected exactly one `EngineMutationScope.live(...)` construction, found \(hits.count): \(hits)"
@@ -1788,7 +1892,7 @@ import Testing
 
   @Test("exactly one production RecoveryEngineClaim.live(...) construction")
   func recoveryEngineClaimLiveConstructedOnce() throws {
-    let hits = try Self.scanSources(pattern: #"RecoveryEngineClaim\.live\("#, under: "Sources")
+    let hits = try Self.sourceAuthoritySnapshot.get().recoveryEngineClaimLive
     #expect(
       hits.count == 1,
       "expected exactly one `RecoveryEngineClaim.live(...)` construction, found \(hits.count): \(hits)"
@@ -1800,8 +1904,9 @@ import Testing
 
   @Test("both .live(...) capability constructions live in WisprBootstrapper.swift")
   func bothLiveConstructionsShareOneCompositionRoot() throws {
-    let scopeHits = try Self.scanSources(pattern: #"EngineMutationScope\.live\("#, under: "Sources")
-    let claimHits = try Self.scanSources(pattern: #"RecoveryEngineClaim\.live\("#, under: "Sources")
+    let snapshot = try Self.sourceAuthoritySnapshot.get()
+    let scopeHits = snapshot.engineMutationScopeLive
+    let claimHits = snapshot.recoveryEngineClaimLive
     let allInBootstrapper =
       (scopeHits + claimHits).allSatisfy { $0.contains("App/WisprBootstrapper.swift") }
     let allHits = scopeHits + claimHits

--- a/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
@@ -29,9 +29,14 @@ import Testing
 // the ten protocols (including a changed parameter label, type, return
 // type, `async`/`throws`, property accessor kind, or an added overload); a
 // changed inheritance clause; a member added only via a protocol extension
-// with no matching requirement; and a signature change to either pinned
-// concrete method. It will NOT, and cannot, catch: a brand-new protocol
-// nobody has told it about, a brand-new concrete type, a new XPC route, a
+// declared in the SAME FILE as the protocol, with no matching requirement;
+// and a signature change to either pinned concrete method. It will NOT, and
+// cannot, catch: a brand-new protocol nobody has told it about, a
+// brand-new concrete type, a new XPC route, an extension of one of these
+// ten protocols declared in a DIFFERENT file (grounded 2026-07-23: none of
+// the ten currently has one — Codex final-integration r1 flagged this as a
+// theoretical future gap, not a present one — but the scanner does not look
+// beyond each protocol's own declaration file), a
 // macro-generated call, or a concrete engine type accessed with no
 // protocol and no cast at all (the exact structural hole a proposed
 // general downcast scanner had — Codex's second grounded review round
@@ -125,8 +130,19 @@ import Testing
               context: "#if clause inside a protocol/extension member block",
               reason: "clause does not contain a declaration list — fail closed rather than skip")
           }
-          let clauseCondition = clause.condition?.trimmedDescription
-          try collectMembers(nested, condition: clauseCondition, into: &members)
+          // `#else` has no condition expression of its own (Codex final-
+          // integration r1: recording it as `nil` made it indistinguishable
+          // from a genuinely unconditional top-level member — moving a
+          // requirement from `#else` to unconditional code would then leave
+          // the frozen signature unchanged). Labeled "else" instead, which
+          // can never collide with a real condition's trimmed text.
+          let clauseCondition = clause.condition?.trimmedDescription ?? "else"
+          // A NESTED `#if` combines with its outer condition rather than
+          // replacing it (same review round: replacing silently dropped the
+          // outer guard, under-reporting the true compiled condition).
+          let combinedCondition = [condition, clauseCondition].compactMap { $0 }.joined(
+            separator: " && ")
+          try collectMembers(nested, condition: combinedCondition, into: &members)
         }
         continue
       }
@@ -858,6 +874,47 @@ import Testing
         }
         """, protocolName: "P")
     #expect(members.contains { $0.condition == "DEBUG" && $0.signature.contains("armHold") })
+  }
+
+  @Test(
+    "an #else member is labeled distinctly from a genuinely unconditional member, so moving a requirement from #else to unconditional code is a real detected change (Codex final-integration r1)"
+  )
+  func adversarialElseMemberIsDistinguishedFromUnconditional() throws {
+    let members = try Self.members(
+      of: """
+        protocol P {
+          #if DEBUG
+            func armHold() async
+          #else
+            func releaseHold() async
+          #endif
+        }
+        """, protocolName: "P")
+    let releaseHold = members.first { $0.signature.contains("releaseHold") }
+    #expect(releaseHold?.condition != nil, "an #else member must not be recorded as unconditional")
+    // Moving it to genuinely unconditional code must be a real, detected change.
+    let unconditional = try Self.members(
+      of: "protocol P { func releaseHold() async }", protocolName: "P")
+    #expect(members != unconditional)
+  }
+
+  @Test(
+    "a nested #if combines with its outer condition rather than replacing it (Codex final-integration r1)"
+  )
+  func adversarialNestedConditionCombinesWithOuter() throws {
+    let members = try Self.members(
+      of: """
+        protocol P {
+          #if DEBUG
+            #if os(macOS)
+              func armHold() async
+            #endif
+          #endif
+        }
+        """, protocolName: "P")
+    let armHold = members.first { $0.signature.contains("armHold") }
+    #expect(armHold?.condition?.contains("DEBUG") == true)
+    #expect(armHold?.condition?.contains("os(macOS)") == true)
   }
 
   @Test(

--- a/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
@@ -254,36 +254,63 @@ import Testing
       let typeName: String
       let methodName: String
       var foundType = false
-      var matches: [String] = []
+      var matches: [MemberSignature] = []
+      var thrown: Error?
       init(typeName: String, methodName: String) {
         self.typeName = typeName
         self.methodName = methodName
         super.init(viewMode: .sourceAccurate)
       }
-      private func scanMembers(_ list: MemberBlockItemListSyntax) {
+      // Recurses into `#if` blocks and preserves (combined, nested) conditions
+      // exactly like the protocol-member collector above (Codex final-
+      // integration r2: a bare `item.decl.as(FunctionDeclSyntax.self)` check
+      // silently skipped a conditionally-compiled overload entirely — an
+      // `#if DEBUG` variant of a pinned concrete method could change or
+      // disappear with the surface-freeze test passing unchanged).
+      private func scanMembers(_ list: MemberBlockItemListSyntax, condition: String?) {
         for item in list {
+          if let ifConfig = item.decl.as(IfConfigDeclSyntax.self) {
+            for clause in ifConfig.clauses {
+              guard case .decls(let nested) = clause.elements else {
+                thrown = ScanFailedError(
+                  context: "#if clause inside a concrete type's member block",
+                  reason:
+                    "clause does not contain a declaration list — fail closed rather than skip"
+                )
+                continue
+              }
+              let clauseCondition = clause.condition?.trimmedDescription ?? "else"
+              let combinedCondition = [condition, clauseCondition].compactMap { $0 }.joined(
+                separator: " && ")
+              scanMembers(nested, condition: combinedCondition)
+            }
+            continue
+          }
           guard let fn = item.decl.as(FunctionDeclSyntax.self), fn.name.text == methodName else {
             continue
           }
-          matches.append(EngineProtocolSurfaceFreezeTests.truncatedAtBody(fn.trimmedDescription))
+          matches.append(
+            MemberSignature(
+              condition: condition,
+              signature: EngineProtocolSurfaceFreezeTests.truncatedAtBody(fn.trimmedDescription)))
         }
       }
       override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
         guard node.name.text == typeName else { return .visitChildren }
         foundType = true
-        scanMembers(node.memberBlock.members)
+        scanMembers(node.memberBlock.members, condition: nil)
         return .skipChildren
       }
       override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         guard node.name.text == typeName else { return .visitChildren }
         foundType = true
-        scanMembers(node.memberBlock.members)
+        scanMembers(node.memberBlock.members, condition: nil)
         return .skipChildren
       }
       override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         guard node.name.text == typeName else { return .visitChildren }
         foundType = true
-        scanMembers(node.memberBlock.members)
+        scanMembers(node.memberBlock.members, condition: nil)
         return .skipChildren
       }
       override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -291,12 +318,13 @@ import Testing
           ident.name.text == typeName
         else { return .visitChildren }
         foundType = true
-        scanMembers(node.memberBlock.members)
+        scanMembers(node.memberBlock.members, condition: nil)
         return .skipChildren
       }
     }
     let collector = Collector(typeName: typeName, methodName: methodName)
     collector.walk(tree)
+    if let thrown = collector.thrown { throw thrown }
     guard collector.foundType else {
       throw ScanFailedError(
         context: context, reason: "type `\(typeName)` not found — fail closed rather than guess")
@@ -308,7 +336,7 @@ import Testing
           "type `\(typeName)` has no `\(methodName)` declaration — fail closed rather than report an empty surface"
       )
     }
-    return collector.matches.map { MemberSignature(condition: nil, signature: $0) }
+    return collector.matches
   }
 
   /// Reads `file` and pins ONE concrete method's own signature(s) by name —
@@ -987,5 +1015,25 @@ import Testing
         struct Other { func prepare() async throws {} }
         """, typeName: "Target", methodName: "prepare", context: "<fixture>")
     #expect(members.count == 1, "expected exactly Target's own prepare, found: \(members)")
+  }
+
+  @Test(
+    "a conditionally-compiled overload of a pinned concrete method is still collected, not silently skipped (Codex final-integration r2)"
+  )
+  func adversarialConditionalConcreteMethodOverloadIsDetected() throws {
+    let members = try Self.concreteMethodMembers(
+      inParsedSource: """
+        struct Target {
+          func prepare() async throws {}
+          #if DEBUG
+            func prepare(fake: Bool) async throws {}
+          #endif
+        }
+        """, typeName: "Target", methodName: "prepare", context: "<fixture>")
+    #expect(
+      members.count == 2,
+      "expected both the unconditional and #if DEBUG overloads, found: \(members)")
+    let conditional = members.first { $0.signature.contains("fake") }
+    #expect(conditional?.condition == "DEBUG")
   }
 }

--- a/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
@@ -1,0 +1,934 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+// MARK: - EngineProtocolSurfaceFreezeTests (#1741 Chunk 11)
+//
+// Companion to `EngineMutationInventoryFreezeTests`, kept in a separate file
+// because the two ask different questions with different mechanics and
+// different failure modes: that file asks "is every REFERENCE to a known
+// engine-mutating name classified" (open-world — arbitrary call sites);
+// this file asks "has the DECLARED SURFACE of a known, bounded list of
+// protocols and concrete methods changed" (closed-world — a protocol's own
+// requirement list, or one method's own signature, is a real, enumerable
+// authority once the file it lives in is fixed).
+//
+// SCOPE, STATED HONESTLY (do not remove or soften this without a fresh
+// grounding pass — see `EngineMutationInventoryFreezeTests`'s own Chunk 11
+// doc comment for the two-consecutive-Codex-round history that makes this
+// necessary): this suite freezes the exact signatures of TEN engine-facing
+// protocols and TWO known concrete-only method surfaces not declared by any
+// of the ten protocols (one, `WhisperKitEngineAdapter.unloadForRemoval()`,
+// is reached only via a type-cast; the other,
+// `ParakeetBackend.prepare(cacheOnly:progressCallback:)`, is reached via a
+// type-cast at one call site AND via direct, uncast construction/ownership
+// at another — `ASRServiceHandler.swift` builds and holds a concrete
+// `ParakeetBackend` natively), all grounded as of 2026-07-23. It
+// WILL catch: a member added to, removed from, or resignatured on any of
+// the ten protocols (including a changed parameter label, type, return
+// type, `async`/`throws`, property accessor kind, or an added overload); a
+// changed inheritance clause; a member added only via a protocol extension
+// with no matching requirement; and a signature change to either pinned
+// concrete method. It will NOT, and cannot, catch: a brand-new protocol
+// nobody has told it about, a brand-new concrete type, a new XPC route, a
+// macro-generated call, or a concrete engine type accessed with no
+// protocol and no cast at all (the exact structural hole a proposed
+// general downcast scanner had — Codex's second grounded review round
+// found `ActiveEngineOperation.live(asrManager:whisperKitBackend:)` takes
+// `WhisperKitBackend` as a plain typed parameter, no cast in sight). Those
+// require the same kind of human grounding pass that found the ten
+// protocols and two escape hatches here — this suite is a guardrail on top
+// of that judgment, not a replacement for it.
+@Suite struct EngineProtocolSurfaceFreezeTests {
+
+  private struct ScanFailedError: Error, CustomStringConvertible {
+    let context: String
+    let reason: String
+    var description: String {
+      "Scan failed for \(context): \(reason). Never silently treated as clean."
+    }
+  }
+
+  /// One frozen member/requirement signature. `condition` names the `#if`
+  /// clause it lives under (e.g. `"DEBUG"`), or `nil` for an unconditional
+  /// member — so a member moving in or out of a conditional block is a real
+  /// change, not invisible.
+  private struct MemberSignature: Hashable, CustomStringConvertible {
+    let condition: String?
+    let signature: String
+    var description: String {
+      condition.map { "[#if \($0)] \(signature)" } ?? signature
+    }
+  }
+
+  /// One frozen surface: either a protocol's own requirement list (plus any
+  /// same-file extension defaults) or one concrete type's method-by-name
+  /// group (one or more overloads).
+  private struct Surface {
+    let name: String
+    let file: String
+    /// The `protocol Name: Inheritance` header, trimmed — `nil` for a
+    /// concrete-method surface, which has no protocol header of its own.
+    let header: String?
+    let members: [MemberSignature]
+  }
+
+  // MARK: Parsing
+
+  /// A function's declaration text truncated at its first `{` — a protocol
+  /// requirement never has a body at all, so this is a no-op for those; an
+  /// extension's default implementation DOES have a real statement body,
+  /// which is free to change without tripping this freeze (only what the
+  /// function PROMISES is frozen, not how a default fulfills it).
+  private static func truncatedAtBody(_ text: String) -> String {
+    guard let braceIndex = text.firstIndex(of: "{") else { return text }
+    return String(text[text.startIndex..<braceIndex]).trimmingCharacters(
+      in: .whitespacesAndNewlines)
+  }
+
+  /// Recognized protocol-member declaration kinds. Anything else (an
+  /// `associatedtype`, `init`, `subscript`, macro expansion, or any future
+  /// syntax this visitor does not recognize) fails the scan closed rather
+  /// than being silently skipped — Codex's grounded review flagged exactly
+  /// this as a real risk for a member-kind-unaware collector.
+  ///
+  /// A property is NEVER truncated at its first `{`, unlike a function: a
+  /// protocol requirement's `{ get }` / `{ get set }` accessor spec is part
+  /// of the SIGNATURE itself (it declares whether the property must be
+  /// settable), not a body to strip. An extension's real computed-property
+  /// body is kept whole too, for the same reason a function's is stripped —
+  /// property bodies in this codebase's ten protocols are short, single-
+  /// expression defaults where the distinction rarely matters, and keeping
+  /// the whole text is simpler and cannot under-report a change.
+  private static func normalizedSignature(of decl: DeclSyntax) throws -> String? {
+    if let fn = decl.as(FunctionDeclSyntax.self) {
+      return Self.truncatedAtBody(fn.trimmedDescription)
+    }
+    if let v = decl.as(VariableDeclSyntax.self) {
+      return v.trimmedDescription
+    }
+    if decl.is(MissingDeclSyntax.self) { return nil }  // a bare `;` between members
+    throw ScanFailedError(
+      context: "protocol/extension member",
+      reason: "unrecognized member declaration kind \(decl.kind) — fail closed rather than skip")
+  }
+
+  private static func collectMembers(
+    _ list: MemberBlockItemListSyntax, condition: String?, into members: inout [MemberSignature]
+  ) throws {
+    for item in list {
+      if let ifConfig = item.decl.as(IfConfigDeclSyntax.self) {
+        for clause in ifConfig.clauses {
+          guard case .decls(let nested) = clause.elements else {
+            throw ScanFailedError(
+              context: "#if clause inside a protocol/extension member block",
+              reason: "clause does not contain a declaration list — fail closed rather than skip")
+          }
+          let clauseCondition = clause.condition?.trimmedDescription
+          try collectMembers(nested, condition: clauseCondition, into: &members)
+        }
+        continue
+      }
+      guard let signature = try Self.normalizedSignature(of: item.decl) else { continue }
+      members.append(MemberSignature(condition: condition, signature: signature))
+    }
+  }
+
+  /// Parses `source` and collects `protocolName`'s own requirements plus any
+  /// same-file `extension protocolName { ... }` default-implementation
+  /// signatures — both are part of what the protocol actually promises.
+  /// Shared by the live file-based scan AND the fixture tests below, so a
+  /// fixture exercises the exact same collection path the live scan uses,
+  /// never a parallel, simpler stand-in.
+  private static func surfaceMembers(
+    inParsedSource source: String, protocolName: String, context: String
+  ) throws -> (header: String?, members: [MemberSignature]) {
+    let tree = Parser.parse(source: source)
+    guard !tree.hasError else {
+      throw ScanFailedError(
+        context: context, reason: "source did not parse cleanly (tree.hasError)")
+    }
+
+    final class Collector: SyntaxVisitor {
+      let targetName: String
+      var header: String?
+      var members: [MemberSignature] = []
+      var thrown: Error?
+      init(targetName: String) {
+        self.targetName = targetName
+        super.init(viewMode: .sourceAccurate)
+      }
+      override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard node.name.text == targetName else { return .skipChildren }
+        let inheritance = node.inheritanceClause?.trimmedDescription ?? ""
+        header = "protocol \(targetName) \(inheritance)".trimmingCharacters(in: .whitespaces)
+        do {
+          try EngineProtocolSurfaceFreezeTests.collectMembers(
+            node.memberBlock.members, condition: nil, into: &members)
+        } catch {
+          thrown = error
+        }
+        return .skipChildren
+      }
+      override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let ident = node.extendedType.as(IdentifierTypeSyntax.self),
+          ident.name.text == targetName
+        else { return .visitChildren }
+        do {
+          try EngineProtocolSurfaceFreezeTests.collectMembers(
+            node.memberBlock.members, condition: nil, into: &members)
+        } catch {
+          thrown = error
+        }
+        return .skipChildren
+      }
+    }
+
+    let collector = Collector(targetName: protocolName)
+    collector.walk(tree)
+    if let thrown = collector.thrown { throw thrown }
+    return (collector.header, collector.members)
+  }
+
+  /// Reads `file` and collects `protocolName`'s frozen surface from it.
+  private static func protocolSurface(named protocolName: String, in file: String) throws -> Surface
+  {
+    let url = RepoRoot.sourceURL(file)
+    let source: String
+    do {
+      source = try String(contentsOf: url, encoding: .utf8)
+    } catch {
+      throw ScanFailedError(context: file, reason: "could not be read: \(error)")
+    }
+    let (header, members) = try surfaceMembers(
+      inParsedSource: source, protocolName: protocolName, context: file)
+    guard let header else {
+      throw ScanFailedError(
+        context: file,
+        reason: "protocol \(protocolName) not found — fail closed, never report empty")
+    }
+    return Surface(name: protocolName, file: file, header: header, members: members)
+  }
+
+  /// Collects `typeName`'s own `methodName` declaration(s) from already-parsed
+  /// `source` — scoped to `typeName`'s own actor/class/struct declaration and
+  /// its same-file extensions ONLY. An unrelated type in the same file
+  /// sharing `methodName` is never collected (Codex implementation-review
+  /// r1: the prior version matched `methodName` anywhere in the file, a real
+  /// fail-open — if the target method were removed while another type kept a
+  /// same-named method, the "missing" check would be silently masked by the
+  /// unrelated match). A type may legitimately overload a method (e.g.
+  /// `ParakeetBackend.prepare` has three overloads); every matching
+  /// declaration from the RIGHT type is collected as its own member,
+  /// mirroring how a protocol's own overloaded requirements are handled.
+  /// Shared by the live file-based scan AND the fixture tests below, so a
+  /// fixture exercises the exact same type-scoping path, never a parallel,
+  /// simpler stand-in.
+  private static func concreteMethodMembers(
+    inParsedSource source: String, typeName: String, methodName: String, context: String
+  ) throws -> [MemberSignature] {
+    let tree = Parser.parse(source: source)
+    guard !tree.hasError else {
+      throw ScanFailedError(
+        context: context, reason: "source did not parse cleanly (tree.hasError)")
+    }
+
+    final class Collector: SyntaxVisitor {
+      let typeName: String
+      let methodName: String
+      var foundType = false
+      var matches: [String] = []
+      init(typeName: String, methodName: String) {
+        self.typeName = typeName
+        self.methodName = methodName
+        super.init(viewMode: .sourceAccurate)
+      }
+      private func scanMembers(_ list: MemberBlockItemListSyntax) {
+        for item in list {
+          guard let fn = item.decl.as(FunctionDeclSyntax.self), fn.name.text == methodName else {
+            continue
+          }
+          matches.append(EngineProtocolSurfaceFreezeTests.truncatedAtBody(fn.trimmedDescription))
+        }
+      }
+      override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard node.name.text == typeName else { return .visitChildren }
+        foundType = true
+        scanMembers(node.memberBlock.members)
+        return .skipChildren
+      }
+      override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard node.name.text == typeName else { return .visitChildren }
+        foundType = true
+        scanMembers(node.memberBlock.members)
+        return .skipChildren
+      }
+      override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard node.name.text == typeName else { return .visitChildren }
+        foundType = true
+        scanMembers(node.memberBlock.members)
+        return .skipChildren
+      }
+      override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let ident = node.extendedType.as(IdentifierTypeSyntax.self),
+          ident.name.text == typeName
+        else { return .visitChildren }
+        foundType = true
+        scanMembers(node.memberBlock.members)
+        return .skipChildren
+      }
+    }
+    let collector = Collector(typeName: typeName, methodName: methodName)
+    collector.walk(tree)
+    guard collector.foundType else {
+      throw ScanFailedError(
+        context: context, reason: "type `\(typeName)` not found — fail closed rather than guess")
+    }
+    guard !collector.matches.isEmpty else {
+      throw ScanFailedError(
+        context: context,
+        reason:
+          "type `\(typeName)` has no `\(methodName)` declaration — fail closed rather than report an empty surface"
+      )
+    }
+    return collector.matches.map { MemberSignature(condition: nil, signature: $0) }
+  }
+
+  /// Reads `file` and pins ONE concrete method's own signature(s) by name —
+  /// used for the two known concrete escape hatches.
+  private static func concreteMethodSurface(
+    typeName: String, methodName: String, in file: String
+  ) throws -> Surface {
+    let url = RepoRoot.sourceURL(file)
+    let source: String
+    do {
+      source = try String(contentsOf: url, encoding: .utf8)
+    } catch {
+      throw ScanFailedError(context: file, reason: "could not be read: \(error)")
+    }
+    let members = try concreteMethodMembers(
+      inParsedSource: source, typeName: typeName, methodName: methodName, context: file)
+    return Surface(name: "\(typeName).\(methodName)", file: file, header: nil, members: members)
+  }
+
+  // MARK: Frozen surfaces — the ten protocols + two concrete escape hatches
+  // grounded as of 2026-07-23 (#1741 Chunk 11). Adding an eleventh protocol
+  // or a third escape hatch to this list is a deliberate grounding decision,
+  // not something this suite can discover on its own — see the file-level
+  // doc comment above.
+
+  private static let targets: [(kind: String, name: String, file: String, method: String?)] = [
+    ("protocol", "ASRBackend", "Sources/EnviousWisprASR/ASRProtocol.swift", nil),
+    ("protocol", "ASRManagerInterface", "Sources/EnviousWisprASR/ASRManagerInterface.swift", nil),
+    ("protocol", "ASREngineAdapter", "Sources/EnviousWisprPipeline/ASREngineAdapter.swift", nil),
+    (
+      "protocol", "ASREngineLanguageIdentifying",
+      "Sources/EnviousWisprPipeline/ASREngineOptionalCapabilities.swift", nil
+    ),
+    (
+      "protocol", "ASREngineWarmupCancelling",
+      "Sources/EnviousWisprPipeline/ASREngineOptionalCapabilities.swift", nil
+    ),
+    (
+      "protocol", "WhisperKitBackendDriving",
+      "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", nil
+    ),
+    (
+      "protocol", "WhisperKitIncrementalSession",
+      "Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift", nil
+    ),
+    (
+      "protocol", "WhisperKitTranscribing",
+      "Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift", nil
+    ),
+    ("protocol", "ASRServiceProtocol", "Sources/EnviousWisprCore/ASRServiceProtocol.swift", nil),
+    (
+      "protocol", "ASREngineTelemetryProviding",
+      "Sources/EnviousWisprPipeline/KernelTelemetryState.swift", nil
+    ),
+    (
+      "concrete", "WhisperKitEngineAdapter",
+      "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", "unloadForRemoval"
+    ),
+    ("concrete", "ParakeetBackend", "Sources/EnviousWisprASR/ParakeetBackend.swift", "prepare"),
+  ]
+
+  private static func liveSurfaces() throws -> [Surface] {
+    try targets.map { target in
+      if target.kind == "protocol" {
+        return try protocolSurface(named: target.name, in: target.file)
+      }
+      return try concreteMethodSurface(
+        typeName: target.name, methodName: target.method!, in: target.file)
+    }
+  }
+
+  // MARK: Frozen signatures, re-derived from the real parser (measure with
+  // the real tool, never hand-transcribed) as of 2026-07-23.
+
+  private static let frozen: [String: Surface] = [
+    "ASRBackend": Surface(
+      name: "ASRBackend", file: "Sources/EnviousWisprASR/ASRProtocol.swift",
+      header: "protocol ASRBackend : Actor",
+      members: [
+        MemberSignature(condition: nil, signature: "var isReady: Bool { get }"),
+        MemberSignature(condition: nil, signature: "func prepare() async throws"),
+        MemberSignature(
+          condition: nil,
+          signature: "func prepare(progressCallback: ProgressCallback?) async throws"
+        ),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult"
+        ),
+        MemberSignature(condition: nil, signature: "func unload() async"),
+        MemberSignature(condition: nil, signature: "var supportsStreaming: Bool { get }"),
+        MemberSignature(
+          condition: nil,
+          signature: "func startStreaming(options: TranscriptionOptions) async throws"
+        ),
+        MemberSignature(
+          condition: nil, signature: "func feedAudio(_ buffer: AVAudioPCMBuffer) async throws"),
+        MemberSignature(
+          condition: nil, signature: "func finalizeStreaming() async throws -> ASRResult"),
+        MemberSignature(condition: nil, signature: "func cancelStreaming() async"),
+        // Extension defaults (`extension ASRBackend { ... }`) — part of what
+        // the protocol actually promises to a non-overriding conformer.
+        MemberSignature(condition: nil, signature: "public var supportsStreaming: Bool { false }"),
+        MemberSignature(
+          condition: nil,
+          signature: "public func startStreaming(options _: TranscriptionOptions) async throws"),
+        MemberSignature(
+          condition: nil,
+          signature: "public func feedAudio(_ buffer: AVAudioPCMBuffer) async throws"
+        ),
+        MemberSignature(
+          condition: nil, signature: "public func finalizeStreaming() async throws -> ASRResult"),
+        MemberSignature(condition: nil, signature: "public func cancelStreaming() async"),
+        MemberSignature(
+          condition: nil,
+          signature: "public func prepare(progressCallback: ProgressCallback?) async throws"),
+      ]),
+    "ASRManagerInterface": Surface(
+      name: "ASRManagerInterface", file: "Sources/EnviousWisprASR/ASRManagerInterface.swift",
+      header: "protocol ASRManagerInterface : AnyObject",
+      members: [
+        MemberSignature(condition: nil, signature: "var activeBackendType: ASRBackendType { get }"),
+        MemberSignature(condition: nil, signature: "var isModelLoaded: Bool { get }"),
+        MemberSignature(condition: nil, signature: "var isStreaming: Bool { get }"),
+        MemberSignature(condition: nil, signature: "var downloadProgress: Double { get }"),
+        MemberSignature(condition: nil, signature: "var downloadPhase: String { get }"),
+        MemberSignature(condition: nil, signature: "var downloadDetail: String { get }"),
+        MemberSignature(condition: nil, signature: "var parakeetCacheOnly: Bool { get set }"),
+        MemberSignature(condition: nil, signature: "func loadModel() async throws"),
+        MemberSignature(condition: nil, signature: "func unloadModel() async"),
+        MemberSignature(
+          condition: nil, signature: "func setInitialBackendType(_ type: ASRBackendType)"),
+        MemberSignature(
+          condition: nil, signature: "func switchBackend(to type: ASRBackendType) async"),
+        MemberSignature(
+          condition: nil, signature: "var activeBackendSupportsStreaming: Bool { get async }"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult"
+        ),
+        MemberSignature(
+          condition: nil,
+          signature: "func startStreaming(options: TranscriptionOptions) async throws"),
+        MemberSignature(
+          condition: nil, signature: "func feedAudio(_ buffer: AVAudioPCMBuffer) async throws"),
+        MemberSignature(
+          condition: nil, signature: "func finalizeStreaming() async throws -> ASRResult"),
+        MemberSignature(condition: nil, signature: "func cancelStreaming() async"),
+        MemberSignature(
+          condition: nil, signature: "func noteTranscriptionComplete(policy: ModelUnloadPolicy)"),
+        MemberSignature(condition: nil, signature: "func cancelIdleTimer()"),
+        MemberSignature(condition: nil, signature: "func cancelInFlightLoad()"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "var loadProgressTickReporter: (@MainActor @Sendable (Date?, String) -> Void)? { get set }"
+        ),
+        MemberSignature(condition: nil, signature: "var feedsSharedProgressFile: Bool { get }"),
+        MemberSignature(
+          condition: nil, signature: "var onServiceInterrupted: (() -> Void)? { get set }"),
+        // Extension defaults.
+        MemberSignature(
+          condition: nil,
+          signature: "public var feedsSharedProgressFile: Bool { false }"),
+        MemberSignature(
+          condition: nil,
+          signature: "public var parakeetCacheOnly: Bool {\n    get { false }\n    set {}\n  }"),
+      ]),
+    "ASREngineAdapter": Surface(
+      name: "ASREngineAdapter", file: "Sources/EnviousWisprPipeline/ASREngineAdapter.swift",
+      header: "protocol ASREngineAdapter : AnyObject, Sendable",
+      members: [
+        MemberSignature(condition: nil, signature: "var engineIdentity: ASREngineIdentity { get }"),
+        MemberSignature(
+          condition: nil, signature: "var capabilities: ASREngineCapabilities { get }"),
+        MemberSignature(condition: nil, signature: "var readiness: ASREngineReadiness { get }"),
+        MemberSignature(condition: nil, signature: "var lastWarmupInferenceMs: Int? { get }"),
+        MemberSignature(condition: nil, signature: "func warmUp() async throws"),
+        MemberSignature(
+          condition: nil, signature: "var loadProgress: AsyncStream<ASRLoadProgressTick>? { get }"),
+        MemberSignature(condition: nil, signature: "var lastObservedPhase: String { get }"),
+        MemberSignature(condition: nil, signature: "var warmupStallGuardEligible: Bool { get }"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func beginSession(_ id: SessionID, options: TranscriptionOptions, streaming: Bool) async throws"
+        ),
+        MemberSignature(
+          condition: nil, signature: "func acceptAudio(_ buffer: AudioBufferHandoff)"),
+        MemberSignature(
+          condition: nil,
+          signature: "func finalize(batchSamples: [Float]?) async -> ASREngineOutcome"),
+        MemberSignature(
+          condition: nil,
+          signature: "var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { get }"),
+        MemberSignature(
+          condition: nil,
+          signature: "func retryDecode(inputSamples: [Float]) async -> ASREngineOutcome"),
+        MemberSignature(
+          condition: nil,
+          signature: "func retryDecodeTimeoutSeconds(forSampleCount sampleCount: Int) -> Double"),
+        MemberSignature(condition: nil, signature: "func bumpRetryGeneration()"),
+        MemberSignature(condition: nil, signature: "func cancel() async"),
+        MemberSignature(condition: nil, signature: "func recoverFromWedge() async"),
+        MemberSignature(
+          condition: nil,
+          signature: "var onEngineInterrupted: (@MainActor () -> Void)? { get set }"),
+        MemberSignature(
+          condition: nil,
+          signature: "func recoverFromASRInterruption() async -> ASRInterruptionRecoveryOutcome"),
+        MemberSignature(
+          condition: nil, signature: "func applyUnloadPolicy(_ policy: ModelUnloadPolicy)"),
+        MemberSignature(condition: nil, signature: "var lastResult: ASRResult? { get }"),
+        MemberSignature(condition: nil, signature: "func warmUpFromCache() async throws"),
+        MemberSignature(condition: nil, signature: "func cancelPendingUnload()"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func observeSpeechSegments(_ segments: [SpeechSegment], rawCaptureSamples: [Float])"),
+        // Extension defaults (two separate `extension ASREngineAdapter { ... }` blocks).
+        MemberSignature(
+          condition: nil, signature: "public var lastObservedPhase: String { \"warmup\" }"),
+        MemberSignature(
+          condition: nil, signature: "public var lastWarmupInferenceMs: Int? { nil }"),
+        MemberSignature(condition: nil, signature: "public func warmUpFromCache() async throws"),
+        MemberSignature(condition: nil, signature: "public func cancelPendingUnload()"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "public func observeSpeechSegments(\n    _ segments: [SpeechSegment], rawCaptureSamples: [Float]\n  )"
+        ),
+        MemberSignature(
+          condition: nil, signature: "public var warmupStallGuardEligible: Bool { false }"),
+      ]),
+    "ASREngineLanguageIdentifying": Surface(
+      name: "ASREngineLanguageIdentifying",
+      file: "Sources/EnviousWisprPipeline/ASREngineOptionalCapabilities.swift",
+      header: "protocol ASREngineLanguageIdentifying : AnyObject",
+      members: [
+        MemberSignature(
+          condition: nil, signature: "var lastLanguageDetection: LanguageDetectionResult? { get }")
+      ]),
+    "ASREngineWarmupCancelling": Surface(
+      name: "ASREngineWarmupCancelling",
+      file: "Sources/EnviousWisprPipeline/ASREngineOptionalCapabilities.swift",
+      header: "protocol ASREngineWarmupCancelling : AnyObject",
+      members: [
+        MemberSignature(condition: nil, signature: "func cancelSessionlessWarmup() async")
+      ]),
+    "WhisperKitBackendDriving": Surface(
+      name: "WhisperKitBackendDriving",
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift",
+      header: "protocol WhisperKitBackendDriving : Actor",
+      members: [
+        MemberSignature(condition: nil, signature: "var isReady: Bool { get }"),
+        MemberSignature(condition: nil, signature: "var modelVariantName: String { get }"),
+        MemberSignature(condition: nil, signature: "var lastWarmupInferenceMs: Int? { get }"),
+        MemberSignature(condition: nil, signature: "func prepare() async throws"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult"
+        ),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func observeLID(samples: [Float], maxWindows: Int) async -> LIDObservationBatch"
+        ),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func makeStreamingSession(options: TranscriptionOptions) async\n    -> (any WhisperKitIncrementalSession)?"
+        ),
+        MemberSignature(condition: nil, signature: "func unload() async"),
+      ]),
+    "WhisperKitIncrementalSession": Surface(
+      name: "WhisperKitIncrementalSession",
+      file: "Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift",
+      header: "protocol WhisperKitIncrementalSession : Sendable",
+      members: [
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func start(\n    audioSamplesProvider: @Sendable @escaping () async -> (samples: [Float], count: Int)\n  ) async"
+        ),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func finalize(\n    finalSamples: [Float],\n    speechSegments: [SpeechSegment]\n  ) async -> IncrementalResult"
+        ),
+        MemberSignature(condition: nil, signature: "func cancel() async"),
+        MemberSignature(condition: nil, signature: "func noteStopRequested() async"),
+      ]),
+    "WhisperKitTranscribing": Surface(
+      name: "WhisperKitTranscribing",
+      file: "Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift",
+      header: "protocol WhisperKitTranscribing : Sendable",
+      members: [
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func transcribe(audioArray: [Float], decodeOptions: DecodingOptions?) async throws\n    -> [TranscriptionResult]"
+        ),
+        MemberSignature(condition: nil, signature: "func encodeText(_ text: String) -> [Int]"),
+      ]),
+    "ASRServiceProtocol": Surface(
+      name: "ASRServiceProtocol", file: "Sources/EnviousWisprCore/ASRServiceProtocol.swift",
+      header: "protocol ASRServiceProtocol",
+      members: [
+        MemberSignature(condition: nil, signature: "func ping(reply: @escaping (String) -> Void)"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func loadModel(backendType: String, cacheOnly: Bool, reply: @escaping (NSError?) -> Void)"
+        ),
+        MemberSignature(condition: nil, signature: "func unloadModel(reply: @escaping () -> Void)"),
+        MemberSignature(
+          condition: nil, signature: "func getModelState(reply: @escaping (Bool, Bool) -> Void)"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func transcribeSamples(\n    _ data: Data, sampleCount: Int, language: String, enableTimestamps: Bool,\n    speechSegmentsData: Data?,\n    reply: @escaping (Data?, NSError?) -> Void)"
+        ),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func startStreaming(\n    operationID: String, language: String, enableTimestamps: Bool,\n    reply: @escaping (NSError?) -> Void)"
+        ),
+        MemberSignature(
+          condition: nil, signature: "func feedAudioBuffer(_ data: Data, frameCount: Int)"),
+        MemberSignature(
+          condition: nil,
+          signature: "func finalizeStreaming(reply: @escaping (Data?, NSError?) -> Void)"
+        ),
+        MemberSignature(condition: nil, signature: "func cancelStreaming()"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "func checkStreamingSupport(backendType: String, reply: @escaping (Bool) -> Void)"),
+        MemberSignature(
+          condition: "DEBUG",
+          signature: "func armBatchDecodeHold(trialID: String, reply: @escaping () -> Void)"),
+        MemberSignature(
+          condition: "DEBUG",
+          signature: "func releaseBatchDecode(trialID: String, reply: @escaping () -> Void)"),
+        MemberSignature(
+          condition: "DEBUG", signature: "func clearBatchDecodeFault(reply: @escaping () -> Void)"),
+      ]),
+    "ASREngineTelemetryProviding": Surface(
+      name: "ASREngineTelemetryProviding",
+      file: "Sources/EnviousWisprPipeline/KernelTelemetryState.swift",
+      header: "protocol ASREngineTelemetryProviding : AnyObject",
+      members: [
+        MemberSignature(
+          condition: nil,
+          signature: "var lastASRDiagnostics: KernelASRAdapterDiagnostics? { get }"),
+        MemberSignature(condition: nil, signature: "var lastFailureError: (any Error)? { get }"),
+      ]),
+    "WhisperKitEngineAdapter.unloadForRemoval": Surface(
+      name: "WhisperKitEngineAdapter.unloadForRemoval",
+      file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", header: nil,
+      members: [
+        MemberSignature(condition: nil, signature: "package func unloadForRemoval() async")
+      ]),
+    "ParakeetBackend.prepare": Surface(
+      name: "ParakeetBackend.prepare", file: "Sources/EnviousWisprASR/ParakeetBackend.swift",
+      header: nil,
+      members: [
+        MemberSignature(condition: nil, signature: "public func prepare() async throws"),
+        MemberSignature(
+          condition: nil,
+          signature: "public func prepare(progressCallback: ProgressCallback?) async throws"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "public func prepare(cacheOnly: Bool, progressCallback: ProgressCallback?) async throws"
+        ),
+      ]),
+  ]
+
+  // MARK: 1 — every target's live surface exactly matches the frozen one
+
+  @Test("live protocol/concrete-method signatures exactly match the frozen surfaces")
+  func liveSurfacesMatchFrozenSignatures() throws {
+    let live = try Self.liveSurfaces()
+    var failures: [String] = []
+    for surface in live {
+      guard let expected = Self.frozen[surface.name] else {
+        failures.append("Surface `\(surface.name)` has no frozen entry at all.")
+        continue
+      }
+      if surface.header != expected.header {
+        failures.append(
+          "Surface `\(surface.name)` header changed:\n  was: \(expected.header ?? "<none>")\n  now: \(surface.header ?? "<none>")"
+        )
+      }
+      let liveSet = Set(surface.members)
+      let expectedSet = Set(expected.members)
+      let added = liveSet.subtracting(expectedSet)
+      let removed = expectedSet.subtracting(liveSet)
+      if !added.isEmpty {
+        failures.append(
+          "Surface `\(surface.name)` gained member(s):\n"
+            + added.map { "  + \($0)" }.joined(separator: "\n"))
+      }
+      if !removed.isEmpty {
+        failures.append(
+          "Surface `\(surface.name)` lost member(s):\n"
+            + removed.map { "  - \($0)" }.joined(separator: "\n"))
+      }
+    }
+    #expect(
+      failures.isEmpty,
+      """
+      \(failures.count) protocol/concrete-method surface change(s) detected:
+      \(failures.joined(separator: "\n"))
+      A new/removed/resignatured member means: if it is engine-mutating, add it to
+      `EngineMutationInventoryFreezeTests.vocabulary` and classify its references; if it is a
+      read-only query or policy/wiring member, update the frozen surface here deliberately.
+      """)
+  }
+
+  // MARK: 2 — fixture proofs that the mechanism itself detects each named
+  // change shape, not just that today's ten protocols happen to match.
+
+  private static func members(of source: String, protocolName: String) throws -> Set<
+    MemberSignature
+  > {
+    let (_, members) = try surfaceMembers(
+      inParsedSource: source, protocolName: protocolName, context: "<fixture>")
+    return Set(members)
+  }
+
+  @Test("adding a requirement changes the collected member set")
+  func adversarialAddedRequirementIsDetected() throws {
+    let before = try Self.members(
+      of: "protocol P { func warmUp() async throws }", protocolName: "P")
+    let after = try Self.members(
+      of: "protocol P { func warmUp() async throws\n func cancel() async }", protocolName: "P")
+    #expect(before != after)
+    #expect(after.count == before.count + 1)
+  }
+
+  @Test("removing a requirement changes the collected member set")
+  func adversarialRemovedRequirementIsDetected() throws {
+    let before = try Self.members(
+      of: "protocol P { func warmUp() async throws\n func cancel() async }", protocolName: "P")
+    let after = try Self.members(
+      of: "protocol P { func warmUp() async throws }", protocolName: "P")
+    #expect(before != after)
+  }
+
+  @Test("renaming a requirement changes the collected member set")
+  func adversarialRenamedRequirementIsDetected() throws {
+    let before = try Self.members(
+      of: "protocol P { func warmUp() async throws }", protocolName: "P")
+    let after = try Self.members(
+      of: "protocol P { func warmUpEngine() async throws }", protocolName: "P")
+    #expect(before != after)
+  }
+
+  @Test("a changed parameter label changes the collected member set")
+  func adversarialChangedParameterLabelIsDetected() throws {
+    let before = try Self.members(
+      of: "protocol P { func prepare(cacheOnly: Bool) async throws }", protocolName: "P")
+    let after = try Self.members(
+      of: "protocol P { func prepare(fromCache: Bool) async throws }", protocolName: "P")
+    #expect(before != after)
+  }
+
+  @Test("a changed parameter type changes the collected member set")
+  func adversarialChangedParameterTypeIsDetected() throws {
+    let before = try Self.members(
+      of: "protocol P { func retryDecode(inputSamples: [Float]) async }", protocolName: "P")
+    let after = try Self.members(
+      of: "protocol P { func retryDecode(inputSamples: [Double]) async }", protocolName: "P")
+    #expect(before != after)
+  }
+
+  @Test("adding `throws` to a requirement changes the collected member set")
+  func adversarialAddedThrowsIsDetected() throws {
+    let before = try Self.members(of: "protocol P { func warmUp() async }", protocolName: "P")
+    let after = try Self.members(of: "protocol P { func warmUp() async throws }", protocolName: "P")
+    #expect(before != after)
+  }
+
+  @Test("a property changing from get-only to get/set changes the collected member set")
+  func adversarialChangedPropertyAccessorIsDetected() throws {
+    let before = try Self.members(of: "protocol P { var isReady: Bool { get } }", protocolName: "P")
+    let after = try Self.members(
+      of: "protocol P { var isReady: Bool { get set } }", protocolName: "P")
+    #expect(before != after)
+  }
+
+  @Test("an added overload sharing an existing base name changes the collected member set")
+  func adversarialAddedOverloadIsDetected() throws {
+    let before = try Self.members(
+      of: "protocol P { func prepare() async throws }", protocolName: "P")
+    let after = try Self.members(
+      of:
+        "protocol P { func prepare() async throws\n func prepare(cacheOnly: Bool) async throws }",
+      protocolName: "P")
+    #expect(before != after)
+    #expect(after.count == before.count + 1)
+  }
+
+  @Test("a default-implementation BODY change alone does not change the frozen signature")
+  func positiveControlBodyOnlyChangeIsIgnored() throws {
+    let before = try Self.members(
+      of:
+        "protocol P { func cancelPendingUnload() }\nextension P { func cancelPendingUnload() {} }",
+      protocolName: "P")
+    let after = try Self.members(
+      of:
+        "protocol P { func cancelPendingUnload() }\nextension P { func cancelPendingUnload() { print(1) } }",
+      protocolName: "P")
+    #expect(before == after)
+  }
+
+  @Test(
+    "a capability added only via an extension default, with no matching requirement, is still caught"
+  )
+  func adversarialExtensionOnlyMemberIsDetected() throws {
+    let before = try Self.members(
+      of: "protocol P { func warmUp() async throws }", protocolName: "P")
+    let after = try Self.members(
+      of: "protocol P { func warmUp() async throws }\nextension P { func cancel() async {} }",
+      protocolName: "P")
+    #expect(before != after)
+  }
+
+  @Test("a member moving into a #if DEBUG block is a real change, not invisible")
+  func adversarialConditionalMemberChangeIsDetected() throws {
+    let before = try Self.members(
+      of: """
+        protocol P {
+          func warmUp() async throws
+          func armHold() async
+        }
+        """, protocolName: "P")
+    let after = try Self.members(
+      of: """
+        protocol P {
+          func warmUp() async throws
+          #if DEBUG
+            func armHold() async
+          #endif
+        }
+        """, protocolName: "P")
+    #expect(before != after)
+  }
+
+  @Test("both branches of a differently-conditioned member are tracked with their own condition")
+  func positiveControlConditionalMemberConditionIsCaptured() throws {
+    let members = try Self.members(
+      of: """
+        protocol P {
+          #if DEBUG
+            func armHold() async
+          #endif
+        }
+        """, protocolName: "P")
+    #expect(members.contains { $0.condition == "DEBUG" && $0.signature.contains("armHold") })
+  }
+
+  @Test(
+    "an unsupported protocol member kind fails the scan closed rather than being silently skipped")
+  func adversarialUnsupportedMemberKindFailsClosed() throws {
+    #expect(throws: ScanFailedError.self) {
+      _ = try Self.members(of: "protocol P { associatedtype Foo }", protocolName: "P")
+    }
+  }
+
+  @Test("malformed source fails the scan closed rather than being silently treated as clean")
+  func adversarialMalformedSourceFailsClosed() throws {
+    #expect(throws: ScanFailedError.self) {
+      _ = try Self.members(of: "protocol P { func warmUp( {{{ !!! ###", protocolName: "P")
+    }
+  }
+
+  @Test(
+    "a missing protocol declaration fails the scan closed rather than reporting an empty surface")
+  func adversarialMissingProtocolFailsClosed() throws {
+    #expect(throws: ScanFailedError.self) {
+      _ = try Self.protocolSurface(
+        named: "DoesNotExist", in: "Sources/EnviousWisprASR/ASRProtocol.swift")
+    }
+  }
+
+  @Test(
+    "a missing concrete-method name fails the scan closed rather than reporting an empty surface")
+  func adversarialMissingConcreteMethodFailsClosed() throws {
+    #expect(throws: ScanFailedError.self) {
+      _ = try Self.concreteMethodSurface(
+        typeName: "ParakeetBackend", methodName: "thisMethodDoesNotExist",
+        in: "Sources/EnviousWisprASR/ParakeetBackend.swift")
+    }
+  }
+
+  @Test("a legitimately overloaded concrete method collects every overload as its own member")
+  func positiveControlOverloadedConcreteMethodCollectsAll() throws {
+    let surface = try Self.concreteMethodSurface(
+      typeName: "ParakeetBackend", methodName: "prepare",
+      in: "Sources/EnviousWisprASR/ParakeetBackend.swift")
+    #expect(
+      surface.members.count == 3,
+      "expected all three `prepare` overloads, found: \(surface.members)")
+  }
+
+  @Test(
+    "the target method missing from the NAMED type fails closed even when an unrelated type in the same file has a same-named method (Codex implementation-review r1)"
+  )
+  func adversarialMethodPresentOnWrongTypeFailsClosed() throws {
+    // `Target` exists but has no `prepare`; only unrelated `Other` does —
+    // scanning `Target.prepare` must fail closed, never silently match
+    // `Other`'s method (the exact fail-open the prior version had).
+    #expect(throws: ScanFailedError.self) {
+      _ = try Self.concreteMethodMembers(
+        inParsedSource: """
+          struct Target {}
+          struct Other { func prepare() async throws {} }
+          """, typeName: "Target", methodName: "prepare", context: "<fixture>")
+    }
+  }
+
+  @Test(
+    "an unrelated same-named method on a DIFFERENT type is never collected — only the named type's own method counts"
+  )
+  func positiveControlUnrelatedSameNamedMethodIsIgnored() throws {
+    let members = try Self.concreteMethodMembers(
+      inParsedSource: """
+        struct Target { func prepare() async throws {} }
+        struct Other { func prepare() async throws {} }
+        """, typeName: "Target", methodName: "prepare", context: "<fixture>")
+    #expect(members.count == 1, "expected exactly Target's own prepare, found: \(members)")
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/KernelDictationDriverPublicSurfaceTests.swift
@@ -40,7 +40,14 @@ import Testing
       transcriptStore: TranscriptStore(),
       keychainManager: KeychainManager(),
       captureTelemetry: CaptureTelemetryState(),
-      pasteCompletionRegistry: PasteCompletionRegistry())
+      pasteCompletionRegistry: PasteCompletionRegistry(),
+      // #1741 Chunk 9 — `EngineMutationScope` and `.live(...)` are both
+      // `package`-level (not `internal`), so this stays reachable without
+      // `@testable`, preserving this file's whole point: proving the public/
+      // package surface compiles from outside the module. `.alwaysAllowedForTesting`
+      // is deliberately `internal`-only and would defeat that.
+      engineMutationScope: .live(
+        tryBegin: { true }, end: { false }, wake: {}, onRefused: { _ in }))
     let driver = KernelDictationDriverFactory.makeForParakeet(inputs: inputs)
 
     // Read every member named in PR-4b.2 §3.2's table. The point is that

--- a/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
@@ -1,8 +1,8 @@
 @preconcurrency import AVFoundation
-import EnviousWisprASR
 import EnviousWisprCore
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprAppKit
 
 /// Unit tests for SetupCoordinator's preload observation behavior.
@@ -32,13 +32,20 @@ struct SetupCoordinatorTests {
     let counter = InvocationCounter()
     let coord = SetupCoordinator(
       asrManager: fakeASR,
+      whisperKitSetup: WhisperKitSetupService(engineMutationScope: .alwaysAllowedForTesting),
       setupStateReader: { .ready },
       preloadAction: { @MainActor in counter.increment() }
     )
 
     coord.startPreloadObservation()
+    // Signal, not clock: wait for the observation Task to actually reach and
+    // read the backend guard before asserting the negative it implies.
+    for _ in 0..<200 where fakeASR.activeBackendTypeAccessCount == 0 {
+      await Task.yield()
+    }
     await drainMainActorTasks()
 
+    #expect(fakeASR.activeBackendTypeAccessCount > 0, "the backend guard must have been reached")
     #expect(
       counter.count == 0,
       "preloadAction must not fire for a parakeet backend even when setup is .ready"
@@ -59,6 +66,7 @@ struct SetupCoordinatorTests {
     let counter = InvocationCounter()
     let coord = SetupCoordinator(
       asrManager: fakeASR,
+      whisperKitSetup: WhisperKitSetupService(engineMutationScope: .alwaysAllowedForTesting),
       setupStateReader: { .ready },
       preloadAction: { @MainActor in counter.increment() }
     )
@@ -93,8 +101,17 @@ private final class InvocationCounter {
 /// `activeBackendType`; everything else traps to make accidental use loud.
 @MainActor
 private final class FakeASRManager: ASRManagerInterface {
-  let activeBackendType: ASRBackendType
-  init(backend: ASRBackendType) { self.activeBackendType = backend }
+  private let backendType: ASRBackendType
+  /// Signal, not clock: `startPreloadObservation()`'s guard reads this exactly
+  /// once per loop entry before deciding whether to proceed — a test polls
+  /// this count to prove the observation Task actually reached the guard,
+  /// rather than waiting a fixed number of yields and hoping.
+  private(set) var activeBackendTypeAccessCount = 0
+  var activeBackendType: ASRBackendType {
+    activeBackendTypeAccessCount += 1
+    return backendType
+  }
+  init(backend: ASRBackendType) { self.backendType = backend }
 
   var isModelLoaded: Bool { false }
   var isStreaming: Bool { false }

--- a/Tests/EnviousWisprTests/Pipeline/EngineIdentityPropagationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EngineIdentityPropagationTests.swift
@@ -2,6 +2,7 @@ import EnviousWisprCore
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - EngineIdentityPropagationTests (epic #827, PR-5 Rung 1)
@@ -33,6 +34,7 @@ import Testing
       processText: { raw, _ in raw },
       store: { _, _ in },
       deliver: { _ in .pasted },
+      engineMutationScope: .alwaysAllowedForTesting,
       minimumRecordingTicks: 0,
       telemetryState: telemetryState)
 
@@ -62,6 +64,7 @@ import Testing
       processText: { raw, _ in raw },
       store: { _, _ in },
       deliver: { _ in .pasted },
+      engineMutationScope: .alwaysAllowedForTesting,
       minimumRecordingTicks: 0,
       telemetryState: telemetryState)
 

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -1,6 +1,5 @@
 @preconcurrency import AVFoundation
 import AppKit
-import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
@@ -9,6 +8,7 @@ import EnviousWisprStorage
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 @MainActor
@@ -99,7 +99,8 @@ struct HeartPathIntegrationTests {
         transcriptStore: TranscriptStore(),
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry()
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting
       ))
     let stateWaiter = PipelineStateWaiter(pipeline)
     #expect(pipeline.currentSessionConfig == nil)

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -1,5 +1,4 @@
 @preconcurrency import AVFoundation
-import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
@@ -8,6 +7,7 @@ import EnviousWisprStorage
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 /// Pipeline-level tests for the `HeartPathTelemetryEmitter` wiring.
@@ -111,6 +111,7 @@ struct HeartPathTelemetryWiringTests {
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
         pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting,
         captureErrorSink: captureErrorSink
       ))
   }
@@ -224,6 +225,7 @@ struct HeartPathTelemetryWiringTests {
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
         pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting,
         // Asserts on STATE, not Sentry — no-op sink keeps the stall captureError
         // off the process-global delegate (#875).
         captureErrorSink: { _, _, _, _, _ in }

--- a/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
@@ -1,9 +1,9 @@
 import AVFoundation
-import EnviousWisprASR
 import EnviousWisprCore
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - KernelAdapterFactoryTests (epic #827, PR-6)
@@ -36,7 +36,8 @@ import Testing
     let adapter = KernelAdapterFactory.makeWhisperKitAdapter(
       backend: WhisperKitBackend(admittedModelFolder: { nil }),
       languageDetector: LanguageDetector(),
-      audioCaptureSessionIDSource: { 0 })
+      audioCaptureSessionIDSource: { 0 },
+      engineMutationScope: .alwaysAllowedForTesting)
     #expect(adapter.engineIdentity.backendType == .whisperKit)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
@@ -6,6 +6,7 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - KernelDictationDriverBridgeMatrixTests (epic #827, PR-4b.2 bridge matrix)
@@ -56,6 +57,7 @@ import Testing
         currentTick: { 0 }, sleepTicks: { _ in },
         processText: { raw, _ in raw },
         store: { _, _ in }, deliver: { _ in .pasted },
+        engineMutationScope: .alwaysAllowedForTesting,
         minimumRecordingTicks: 0)
       let observer = KernelHeartPathTelemetryObserver(
         kernel: kernel, audioCapture: FakeAudioCapture(),
@@ -64,7 +66,8 @@ import Testing
         emitLifecycleEvent: { _ in })
       let driver = KernelDictationDriver(
         kernel: kernel, observer: observer, outcome: outcome,
-        context: context, steps: steps, adapter: adapter)
+        context: context, steps: steps, adapter: adapter,
+        engineMutationScope: .alwaysAllowedForTesting)
       driver.start()
       return Fixture(driver: driver, kernel: kernel)
     }

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverConfigBindingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverConfigBindingTests.swift
@@ -5,6 +5,7 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - KernelDictationDriverConfigBindingTests (epic #827, PR-4b.2 §11)
@@ -51,6 +52,7 @@ import Testing
         currentTick: { 0 }, sleepTicks: { _ in },
         processText: { raw, _ in raw },
         store: { _, _ in }, deliver: { _ in .pasted },
+        engineMutationScope: .alwaysAllowedForTesting,
         minimumRecordingTicks: 0)
       let observer = KernelHeartPathTelemetryObserver(
         kernel: kernel, audioCapture: FakeAudioCapture(),
@@ -59,7 +61,8 @@ import Testing
         emitLifecycleEvent: { _ in })
       let driver = KernelDictationDriver(
         kernel: kernel, observer: observer, outcome: outcome,
-        context: context, steps: steps, adapter: adapter)
+        context: context, steps: steps, adapter: adapter,
+        engineMutationScope: .alwaysAllowedForTesting)
       driver.start()
       return Fixture(driver: driver, kernel: kernel, context: context, steps: steps)
     }

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverFactoryWhisperKitTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverFactoryWhisperKitTests.swift
@@ -1,4 +1,3 @@
-import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
@@ -7,6 +6,7 @@ import EnviousWisprStorage
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - KernelDictationDriverFactoryWhisperKitTests (epic #827, PR-5 Rung 4)
@@ -60,7 +60,8 @@ import Testing
         transcriptStore: TranscriptStore(),
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry())
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting)
       return KernelDictationDriverFactory.makeForWhisperKit(inputs: inputs)
     }
 
@@ -93,7 +94,8 @@ import Testing
         transcriptStore: TranscriptStore(),
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry())
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting)
       _ = KernelDictationDriverFactory.makeForWhisperKit(inputs: inputs)
       // Factory construction is synchronous and pure — no warm-up dispatch.
       // Backend's `isReady` flips to true only after `prepare()` completes.

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverSurfaceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverSurfaceTests.swift
@@ -1,4 +1,3 @@
-import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
@@ -7,6 +6,7 @@ import EnviousWisprStorage
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - KernelDictationDriverSurfaceTests (epic #827, PR-4b.2 §11)
@@ -54,7 +54,8 @@ import Testing
         transcriptStore: TranscriptStore(),
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
-        pasteCompletionRegistry: PasteCompletionRegistry())
+        pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting)
       return KernelDictationDriverFactory.makeForParakeet(inputs: inputs)
     }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -1,11 +1,11 @@
 import AppKit
-import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprServices
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - KernelDictationDriverTests (epic #827, PR-4 §11.4)
@@ -712,6 +712,7 @@ import Testing
       processText: { raw, _ in raw },
       store: { _, _ in },
       deliver: { _ in .pasted },
+      engineMutationScope: .alwaysAllowedForTesting,
       minimumRecordingTicks: 0)  // PR-4.5 #4: clock never advances; opt out of the gate
     let observer = KernelHeartPathTelemetryObserver(
       kernel: kernel, audioCapture: FakeAudioCapture(),
@@ -728,7 +729,8 @@ import Testing
       emojiRestore: EmojiRestoreStep())
     let driver = KernelDictationDriver(
       kernel: kernel, observer: observer, outcome: outcome,
-      context: KernelSessionContext(), steps: steps, adapter: adapter)
+      context: KernelSessionContext(), steps: steps, adapter: adapter,
+      engineMutationScope: .alwaysAllowedForTesting)
     driver.start()
     return Harness(
       driver: driver, kernel: kernel, outcome: outcome, adapter: adapter, clock: clock,

--- a/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelHeartPathTelemetryObserverTests.swift
@@ -4,6 +4,7 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - KernelHeartPathTelemetryObserverTests (epic #827, PR-4 §11.4)
@@ -310,6 +311,7 @@ import Testing
         processText: { raw, _ in raw },
         store: { _, _ in },
         deliver: { _ in .pasted },
+        engineMutationScope: .alwaysAllowedForTesting,
         minimumRecordingTicks: 0)  // PR-4.5 #4: clock never advances; opt out of the gate
     }
 

--- a/Tests/EnviousWisprTests/Pipeline/LIDPerfSignpostSessionIDTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LIDPerfSignpostSessionIDTests.swift
@@ -1,9 +1,9 @@
 @preconcurrency import AVFoundation
-import EnviousWisprASR
 import EnviousWisprCore
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - LIDPerfSignpostSessionIDTests (epic #827, PR-5 Rung 4.5)
@@ -39,6 +39,7 @@ import Testing
     var readCount = 0
     let adapter = WhisperKitEngineAdapter(
       backend: StubWhisperKitBackend(),
+      engineMutationScope: .alwaysAllowedForTesting,
       audioCaptureSessionIDSource: {
         readCount += 1
         return 42
@@ -61,6 +62,7 @@ import Testing
     var readCount = 0
     let adapter = WhisperKitEngineAdapter(
       backend: backend,
+      engineMutationScope: .alwaysAllowedForTesting,
       audioCaptureSessionIDSource: {
         readCount += 1
         return 555
@@ -98,6 +100,7 @@ import Testing
     let capturedID: UInt64 = 7777
     let adapter = WhisperKitEngineAdapter(
       backend: backend,
+      engineMutationScope: .alwaysAllowedForTesting,
       audioCaptureSessionIDSource: { capturedID })
 
     try await adapter.beginSession(

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -3,6 +3,7 @@ import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - SUT seam (epic #827, PR-2 plan §3.0, §3b)
@@ -233,6 +234,7 @@ final class KernelRecordingSession: RecordingSessionDriving {
       // advance the FakeClock between start and stop, so a positive
       // minimum-recording threshold would discard most scenarios. The
       // dedicated #4 coverage lives in `ConductorParitySeamTests`.
+      engineMutationScope: .alwaysAllowedForTesting,
       minimumRecordingTicks: minimumRecordingTicks,
       captureTelemetry: captureTelemetry,
       deadMicRetireAttemptTelemetry: { [deadMicLog] ctx in

--- a/Tests/EnviousWisprTests/Pipeline/V2/CancellationSilentUnwindTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/CancellationSilentUnwindTests.swift
@@ -1,5 +1,4 @@
 @preconcurrency import AVFoundation
-import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
@@ -8,6 +7,7 @@ import EnviousWisprStorage
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 /// V2 fault-injection — Lane C invariant C2 (issue #291).
@@ -87,6 +87,7 @@ struct CancellationSilentUnwindTests {
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
         pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting,
         captureErrorSink: { _, category, stage, _, _ in
           spy.record(.init(category: category, stage: stage))
         }

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -1,5 +1,4 @@
 @preconcurrency import AVFoundation
-import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprLLM
@@ -8,6 +7,7 @@ import EnviousWisprStorage
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 /// V2 fault-injection — Lane C invariant C1 (issue #291).
@@ -44,6 +44,7 @@ struct DedupSurvivesStallTests {
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
         pasteCompletionRegistry: PasteCompletionRegistry(),
+        engineMutationScope: .alwaysAllowedForTesting,
         // No-op sink: this test asserts on STATE flips, not on Sentry. Inject a
         // no-op so the pipeline's stall captureError never reaches the
         // process-global delegate, where it could pollute a concurrent test's

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterLastResultLifecycleTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterLastResultLifecycleTests.swift
@@ -1,9 +1,9 @@
 @preconcurrency import AVFoundation
-import EnviousWisprASR
 import EnviousWisprCore
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - WhisperKitEngineAdapterLastResultLifecycleTests (epic #827, PR-5 Rung 3 §11.2)
@@ -24,7 +24,8 @@ import Testing
       ASRResult(
         text: "first", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -42,7 +43,8 @@ import Testing
       ASRResult(
         text: "polished", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -63,7 +65,8 @@ import Testing
       ASRResult(
         text: "done", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -81,7 +84,8 @@ import Testing
       ASRResult(
         text: "", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -100,7 +104,8 @@ import Testing
   func lastResultNotSetOnFailedFinalize() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setTranscribeThrows(StubBackendError.decodeFailed)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -116,7 +121,8 @@ import Testing
   @Test("lastResult is NOT set on .cancelled finalize outcomes")
   func lastResultNotSetOnCancelledFinalize() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.beginSession(SessionID(), options: .default, streaming: false)
     await adapter.cancel()
     _ = await adapter.finalize(batchSamples: nil)

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitEngineAdapterTests.swift
@@ -1,9 +1,9 @@
 @preconcurrency import AVFoundation
-import EnviousWisprASR
 import EnviousWisprCore
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 // MARK: - WhisperKitEngineAdapterTests (epic #827, PR-5 Rung 3 §11.2)
@@ -22,14 +22,16 @@ import Testing
 
   @Test("engineIdentity: WhisperKit declares .whisperKit backend")
   func engineIdentityBackend() {
-    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    let adapter = WhisperKitEngineAdapter(
+      backend: StubWhisperKitBackend(), engineMutationScope: .alwaysAllowedForTesting)
     #expect(adapter.engineIdentity.backendType == .whisperKit)
     #expect(adapter.engineIdentity.rawValue == "whisperKit")
   }
 
   @Test("engineIdentity: WhisperKit displayName == WhisperKit")
   func engineIdentityDisplayName() {
-    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    let adapter = WhisperKitEngineAdapter(
+      backend: StubWhisperKitBackend(), engineMutationScope: .alwaysAllowedForTesting)
     #expect(adapter.engineIdentity.displayName == "WhisperKit")
   }
 
@@ -37,7 +39,8 @@ import Testing
 
   @Test("capabilities: WhisperKit streams (PR-2), detects language, ignores conditioned batch")
   func capabilities() {
-    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    let adapter = WhisperKitEngineAdapter(
+      backend: StubWhisperKitBackend(), engineMutationScope: .alwaysAllowedForTesting)
     // #1308 (Step 2, PR-2): WhisperKit now advertises streaming so the kernel's
     // `useStreamingASR && supportsStreaming` gate can route the Live-transcription
     // toggle through it (the adapter still degrades to batch for auto language).
@@ -51,7 +54,8 @@ import Testing
   @Test("readiness transitions: init → notReady; warmUp → ready; cancel keeps notReady")
   func cachedReadinessTransitions() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     #expect(adapter.readiness == .notReady)
     try await adapter.warmUp()
     #expect(adapter.readiness == .ready)
@@ -67,7 +71,8 @@ import Testing
   @Test("#959 recoverFromWedge() tears the engine down to .notReady for a fresh reload")
   func recoverFromWedgeForcesNotReady() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUp()
     #expect(adapter.readiness == .ready)
     await adapter.recoverFromWedge()
@@ -81,7 +86,9 @@ import Testing
     await backend.setHangUnload(true)
     // Inject a fast fail-open deadline; a wedged in-process unload must NOT hang
     // the kernel's recovery path.
-    let adapter = WhisperKitEngineAdapter(backend: backend, wedgeRecoveryUnloadDeadlineSec: 0.05)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting,
+      wedgeRecoveryUnloadDeadlineSec: 0.05)
     try await adapter.warmUp()
     #expect(adapter.readiness == .ready)
     await adapter.recoverFromWedge()  // must return despite the hung unload
@@ -91,7 +98,8 @@ import Testing
   @Test("readiness goes notReady after applyUnloadPolicy(.immediately) executes")
   func cachedReadinessAfterImmediateUnload() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUp()
     #expect(adapter.readiness == .ready)
     adapter.applyUnloadPolicy(.immediately)
@@ -111,37 +119,52 @@ import Testing
     // pre-existing final-cancellation check and `backend.unload()` — a
     // `beginSession(B)` landing exactly there cancels this task the same way
     // that earlier check exists to catch, but nothing re-checked it before
-    // the unload call. Modeled by having `tryBeginEngineMutation` itself
-    // cancel the running unload task (standing in for `beginSession`
-    // cancelling it), then asserting the unload never executes and the
-    // just-acquired claim is still released, not leaked.
+    // the unload call. Modeled by having the scope's `tryBegin` itself cancel
+    // the running unload task (standing in for `beginSession` cancelling it),
+    // then asserting the unload never executes and the just-acquired claim is
+    // still released exactly once, not leaked. #1741 Chunk 9: the gate is now
+    // fixed at construction (no post-init property assignment), so the
+    // cancelling `tryBegin` is built into a custom `.live(...)` scope handed
+    // to the adapter's initializer; `Box` breaks the construction-order
+    // chicken-and-egg (the scope must exist before the adapter does) with a
+    // weak back-reference, mirroring the original test's own `[weak adapter]`.
+    final class Box: @unchecked Sendable {
+      weak var adapter: WhisperKitEngineAdapter?
+      var mutationEndedCount = 0
+    }
+    let box = Box()
+    let scope = EngineMutationScope.live(
+      tryBegin: {
+        box.adapter?.modelUnloadTaskForUnitTests?.cancel()
+        return true
+      },
+      end: {
+        box.mutationEndedCount += 1
+        return false
+      },
+      wake: {},
+      onRefused: { _ in })
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(backend: backend, engineMutationScope: scope)
+    box.adapter = adapter
     try await adapter.warmUp()
     #expect(adapter.readiness == .ready)
-    var mutationEndedCount = 0
-    adapter.tryBeginEngineMutation = { [weak adapter] in
-      adapter?.modelUnloadTaskForUnitTests?.cancel()
-      return true
-    }
-    adapter.endEngineMutation = {
-      mutationEndedCount += 1
-      return false
-    }
     adapter.applyUnloadPolicy(.immediately)
     await adapter.modelUnloadTaskForUnitTests?.value
     let unloadCount = await backend.unloadCount
     #expect(
       unloadCount == 0, "a cancellation during the claim hop must prevent the unload from executing"
     )
-    #expect(mutationEndedCount == 1, "the just-acquired claim must still be released, not leaked")
+    #expect(
+      box.mutationEndedCount == 1, "the just-acquired claim must still be released, not leaked")
   }
 
   @Test("readiness goes notReady when warmUp throws (failed prepare)")
   func cachedReadinessAfterFailedPrepare() async {
     let backend = StubWhisperKitBackend()
     await backend.setPrepareThrows(StubBackendError.prepareFailed)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     do {
       try await adapter.warmUp()
       Issue.record("expected throw")
@@ -156,7 +179,8 @@ import Testing
   @Test("warmUp() loads when the backend is not ready")
   func warmUpLoads() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUp()
     let count = await backend.prepareCount
     #expect(count == 1)
@@ -166,7 +190,8 @@ import Testing
   func warmUpIdempotent() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setIsReady(true)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUp()
     let count = await backend.prepareCount
     #expect(count == 0)
@@ -182,7 +207,8 @@ import Testing
     // an unconditional stub.
     let backend = StubWhisperKitBackend()
     await backend.setIsReady(true)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let outcome = await adapter.recoverFromASRInterruption()
     #expect(outcome == .readyForBatchDecode)
   }
@@ -191,7 +217,8 @@ import Testing
   func recoverFromASRInterruptionFailsWhenNotReady() async {
     let backend = StubWhisperKitBackend()
     await backend.setIsReady(false)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let outcome = await adapter.recoverFromASRInterruption()
     #expect(outcome == .failed)
   }
@@ -202,7 +229,8 @@ import Testing
     // re-await the real backend, not read the cache alone.
     let backend = StubWhisperKitBackend()
     await backend.setIsReady(true)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUp()  // populates cachedReadiness == .ready
     await backend.setIsReady(false)  // the backend itself became not-ready
     let outcome = await adapter.recoverFromASRInterruption()
@@ -213,7 +241,8 @@ import Testing
   @Test("warmUpFromCache() reads readiness and never triggers a load")
   func warmUpFromCacheDoesNotTriggerLoad() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUpFromCache()
     // warmUpFromCache awaits its own work and spawns no background load task, so
     // the count is final the instant it returns — assert synchronously instead
@@ -227,7 +256,8 @@ import Testing
   @Test("warmUpFromCache() refreshes cachedReadiness from the backend state")
   func warmUpFromCacheRefreshesCachedReadiness() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     // Backend is not ready → cachedReadiness stays .notReady.
     try await adapter.warmUpFromCache()
     #expect(adapter.readiness == .notReady)
@@ -241,19 +271,22 @@ import Testing
   @Test("warmUpFromCache() never throws (limb-style)")
   func warmUpFromCacheNeverThrows() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUpFromCache()  // must not throw
   }
 
   @Test("loadProgress returns nil (WhisperKit has no model-load signal)")
   func loadProgressIsNil() {
-    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    let adapter = WhisperKitEngineAdapter(
+      backend: StubWhisperKitBackend(), engineMutationScope: .alwaysAllowedForTesting)
     #expect(adapter.loadProgress == nil)
   }
 
   @Test("lastObservedPhase falls back to protocol default \"warmup\"")
   func lastObservedPhaseDefault() {
-    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    let adapter = WhisperKitEngineAdapter(
+      backend: StubWhisperKitBackend(), engineMutationScope: .alwaysAllowedForTesting)
     #expect(adapter.lastObservedPhase == "warmup")
   }
 
@@ -267,7 +300,8 @@ import Testing
   )
   func beginSessionClearsState() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: [0.1, 0.2], session: sid)
@@ -286,7 +320,8 @@ import Testing
   func acceptAudioAfterTerminalIsNoOp() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setObserveLIDResult(.unavailable)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: [0.1], session: sid)
@@ -302,7 +337,8 @@ import Testing
   )
   func acceptAudioDropsStaleSessionBuffers() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sidA = SessionID()
     try await adapter.beginSession(sidA, options: .default, streaming: false)
     feed(adapter, samples: [0.1, 0.1], session: sidA)
@@ -322,7 +358,8 @@ import Testing
   @Test("acceptAudio is bounded by retainedPCMCap")
   func acceptAudioCappedAtMaxRecording() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     let cap = Int(TimingConstants.maxRecordingDuration * AudioConstants.sampleRate)
@@ -338,7 +375,8 @@ import Testing
   @Test("observeSpeechSegments stores segments; cleared on beginSession and cancel")
   func observeSpeechSegmentsLifecycle() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     let segments = [SpeechSegment(startSample: 0, endSample: 16_000)]
@@ -359,7 +397,8 @@ import Testing
       ASRResult(
         text: "recovered", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -388,7 +427,8 @@ import Testing
       ASRResult(
         text: "recovered", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -409,7 +449,8 @@ import Testing
       ASRResult(
         text: "hello world", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -430,7 +471,8 @@ import Testing
       ASRResult(
         text: "  ", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -452,7 +494,8 @@ import Testing
       ASRResult(
         text: "", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     let samples = speechSamples(count: 16_000)
@@ -470,7 +513,8 @@ import Testing
   @Test("finalize after cancel() returns .cancelled (never partial text)")
   func finalizeAfterCancelReturnsCancelled() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.beginSession(SessionID(), options: .default, streaming: false)
     await adapter.cancel()
     let outcome = await adapter.finalize(batchSamples: nil)
@@ -484,7 +528,8 @@ import Testing
   func finalizeBackendCancellationReturnsCancelled() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setTranscribeThrows(CancellationError())
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -502,7 +547,8 @@ import Testing
   func finalizeBackendErrorReturnsFailed() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setTranscribeThrows(StubBackendError.decodeFailed)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -525,7 +571,8 @@ import Testing
         RawLIDObservation(argmaxLang: "es", logProb: -0.05),
         RawLIDObservation(argmaxLang: "es", logProb: -0.05),
       ]))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000 * 3), session: sid)
@@ -547,7 +594,8 @@ import Testing
   func lidAbstainedKeepsNilLanguage() async throws {
     let backend = StubWhisperKitBackend()
     await backend.setObserveLIDResult(.error(reason: "all_windows_failed"))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -562,7 +610,8 @@ import Testing
   )
   func lastLanguageDetectionLifecycle() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     #expect(adapter.lastLanguageDetection == nil)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
@@ -584,7 +633,8 @@ import Testing
       ASRResult(
         text: "batch-text", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     let options = TranscriptionOptions(language: "en")
     try await adapter.beginSession(sid, options: options, streaming: false)
@@ -607,7 +657,8 @@ import Testing
       ASRResult(
         text: "auto-batch", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -628,7 +679,8 @@ import Testing
     let backend = StubWhisperKitBackend()
     let stubSession = StubIncrementalSession(result: .accepted(text: "streamed-text"))
     await backend.setStreamingSessionFactory({ stubSession })
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(
       sid, options: TranscriptionOptions(language: "en"), streaming: true)
@@ -671,7 +723,8 @@ import Testing
       ASRResult(
         text: "auto-batch", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: true)
     let mss = await backend.makeStreamingSessionCount
@@ -702,7 +755,8 @@ import Testing
       ASRResult(
         text: "fallback-batch", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(
       sid, options: TranscriptionOptions(language: "en"), streaming: true)
@@ -733,7 +787,8 @@ import Testing
       ASRResult(
         text: "rescue-batch", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(
       sid, options: TranscriptionOptions(language: "en"), streaming: true)
@@ -772,7 +827,8 @@ import Testing
       ASRResult(
         text: "off-batch", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(
       sid, options: TranscriptionOptions(language: "en"), streaming: false)
@@ -804,7 +860,8 @@ import Testing
       ASRResult(
         text: "decoded", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     let retained: [Float] = (0..<16_000).map { _ in 0.1 }
@@ -834,7 +891,8 @@ import Testing
       ASRResult(
         text: "ok", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -864,7 +922,8 @@ import Testing
     // first (mirroring cancelPendingUnloadCancelsArmed below) so repeated
     // cancellation has something real to cancel.
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUp()
     adapter.applyUnloadPolicy(.twoMinutes)
     // Codex review (#1595): an optional `armed?.value` lets this test pass
@@ -888,7 +947,8 @@ import Testing
   )
   func staleFeedDropped() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sidA = SessionID()
     try await adapter.beginSession(sidA, options: .default, streaming: false)
     feed(adapter, samples: [0.1, 0.1], session: sidA)
@@ -908,7 +968,8 @@ import Testing
       ASRResult(
         text: "stale-text", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sidA = SessionID()
     try await adapter.beginSession(sidA, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sidA)
@@ -937,7 +998,8 @@ import Testing
       ASRResult(
         text: "stale-text", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sidA = SessionID()
     try await adapter.beginSession(sidA, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sidA)
@@ -970,7 +1032,8 @@ import Testing
   @Test("applyUnloadPolicy(.never) schedules no unload task")
   func applyUnloadPolicyNever() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUp()
     adapter.applyUnloadPolicy(.never)
     // `.never` arms no task — the inspector is nil synchronously after the
@@ -984,7 +1047,8 @@ import Testing
   @Test("applyUnloadPolicy(.immediately) calls backend.unload()")
   func applyUnloadPolicyImmediately() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUp()
     adapter.applyUnloadPolicy(.immediately)
     // Await the armed unload task deterministically (release-config CI does
@@ -997,7 +1061,8 @@ import Testing
   @Test("cancelPendingUnload cancels the in-flight modelUnloadTask")
   func cancelPendingUnloadCancelsArmed() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     try await adapter.warmUp()
     adapter.applyUnloadPolicy(.twoMinutes)
     // Capture the armed task, cancel it, then await the captured handle: its
@@ -1021,7 +1086,8 @@ import Testing
 
   @Test("WhisperKit leaves onEngineInterrupted to the App router (settable but not auto-fired)")
   func engineInterruptedCallbackOwnership() async throws {
-    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    let adapter = WhisperKitEngineAdapter(
+      backend: StubWhisperKitBackend(), engineMutationScope: .alwaysAllowedForTesting)
     var fired = false
     adapter.onEngineInterrupted = { fired = true }
     #expect(fired == false)
@@ -1036,7 +1102,8 @@ import Testing
   )
   func finalizeWithoutSessionShortCircuits() async {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let outcome = await adapter.finalize(batchSamples: nil)
     guard case .empty(let hadSpeechEvidence) = outcome, hadSpeechEvidence == false else {
       Issue.record("expected .empty(false), got \(outcome)")
@@ -1057,7 +1124,8 @@ import Testing
       ASRResult(
         text: "first", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -1085,7 +1153,8 @@ import Testing
       ASRResult(
         text: "done", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     feed(adapter, samples: speechSamples(count: 16_000), session: sid)
@@ -1103,7 +1172,8 @@ import Testing
   )
   func observeSpeechSegmentsDroppedAfterCancel() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     await adapter.cancel()
@@ -1117,7 +1187,8 @@ import Testing
     "observeSpeechSegments without a live session is dropped (Codex r7 S0)"
   )
   func observeSpeechSegmentsWithoutSessionIsDropped() {
-    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    let adapter = WhisperKitEngineAdapter(
+      backend: StubWhisperKitBackend(), engineMutationScope: .alwaysAllowedForTesting)
     adapter.observeSpeechSegments([SpeechSegment(startSample: 0, endSample: 16_000)])
     #expect(
       adapter.observedSpeechSegmentsForTests.isEmpty,
@@ -1131,7 +1202,8 @@ import Testing
   )
   func observeSpeechSegmentsStoresUnshifted() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     // Segments index into `rawCaptureSamples` (the kernel's captureResult.samples),
@@ -1160,7 +1232,8 @@ import Testing
       ASRResult(
         text: "decoded", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     // Shadow buffer (retainedPCM): 16_000 samples of 0.1, fed async.
@@ -1188,7 +1261,8 @@ import Testing
   )
   func applyUnloadPolicyRefusedDuringActiveSession() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(sid, options: .default, streaming: false)
     adapter.applyUnloadPolicy(.immediately)
@@ -1207,7 +1281,8 @@ import Testing
   )
   func applyUnloadPolicyArmedUnderADoesNotFireUnderB() async throws {
     let backend = StubWhisperKitBackend()
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     // Drive A through to terminal (so applyUnloadPolicy may arm).
     let sidA = SessionID()
     try await adapter.beginSession(sidA, options: .default, streaming: false)
@@ -1243,7 +1318,8 @@ import Testing
       ASRResult(
         text: "retried text", language: "en", duration: 1, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(
       sid, options: TranscriptionOptions(language: "en"), streaming: false)
@@ -1272,7 +1348,8 @@ import Testing
       ASRResult(
         text: "retried text", language: "en", duration: 0, processingTime: 0.1,
         backendType: .whisperKit))
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(
       sid, options: TranscriptionOptions(language: "en"), streaming: false)
@@ -1304,7 +1381,8 @@ import Testing
     // fails for real — exactly the condition that makes the KERNEL spend its
     // one Phase-2 retry.
     await backend.setTranscribeThrows(StubBackendError.decodeFailed)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     try await adapter.beginSession(
       sid, options: TranscriptionOptions(language: "en"), streaming: true)
@@ -1354,7 +1432,8 @@ import Testing
     // The first attempt's own batch decode fails for real, triggering the
     // kernel's Phase-2 retry.
     await backend.setTranscribeThrows(StubBackendError.decodeFailed)
-    let adapter = WhisperKitEngineAdapter(backend: backend)
+    let adapter = WhisperKitEngineAdapter(
+      backend: backend, engineMutationScope: .alwaysAllowedForTesting)
     let sid = SessionID()
     // Auto-language (nil) — LID must run on this first attempt.
     try await adapter.beginSession(
@@ -1401,7 +1480,8 @@ import Testing
     "#1707 Codex r8/r9: retryDecodeTimeoutSeconds(forSampleCount:) scales with audio length, not a flat constant"
   )
   func retryDecodeTimeoutScalesWithSampleCount() {
-    let adapter = WhisperKitEngineAdapter(backend: StubWhisperKitBackend())
+    let adapter = WhisperKitEngineAdapter(
+      backend: StubWhisperKitBackend(), engineMutationScope: .alwaysAllowedForTesting)
     let zero = adapter.retryDecodeTimeoutSeconds(forSampleCount: 0)
     let oneMinute = adapter.retryDecodeTimeoutSeconds(forSampleCount: 16_000 * 60)
     let oneHour = adapter.retryDecodeTimeoutSeconds(forSampleCount: 16_000 * 3600)

--- a/Tests/EnviousWisprTests/Pipeline/WhisperKitLegacyUpgradeCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/WhisperKitLegacyUpgradeCoordinatorTests.swift
@@ -3,6 +3,7 @@ import EnviousWisprModelDelivery
 import Foundation
 import Testing
 
+@testable import EnviousWisprASR
 @testable import EnviousWisprPipeline
 
 /// #1386 PR-2b. The retire-and-refetch coordinator: L1–L7 of the plan's §1.
@@ -112,7 +113,8 @@ import Testing
         world.fetchRelease?.resume()
         world.fetchRelease = nil
       },
-      isDeliveryEnabled: { world.deliveryEnabled })
+      isDeliveryEnabled: { world.deliveryEnabled },
+      engineMutationScope: .alwaysAllowedForTesting)
     coordinator.onEvent = { world.events.append($0) }
     coordinator.unloadForRemoval = {
       world.unloadCalls += 1
@@ -207,7 +209,8 @@ import Testing
         world.fetches += 1
         return false
       },
-      cancelActiveFetch: {}, isDeliveryEnabled: { true }, hashFile: countingHash)
+      cancelActiveFetch: {}, isDeliveryEnabled: { true },
+      engineMutationScope: .alwaysAllowedForTesting, hashFile: countingHash)
     await first.runLaunch()
     let afterFirst = hashes
     #expect(afterFirst > 0, "the first pass must actually hash")
@@ -221,7 +224,8 @@ import Testing
         world.fetches += 1
         return false
       },
-      cancelActiveFetch: {}, isDeliveryEnabled: { true }, hashFile: countingHash)
+      cancelActiveFetch: {}, isDeliveryEnabled: { true },
+      engineMutationScope: .alwaysAllowedForTesting, hashFile: countingHash)
     await second.runLaunch()
 
     // This is the forever-cost guard: §2.1 makes this run on every launch for the life of the
@@ -474,7 +478,8 @@ import Testing
     // re-check after the cancelled join and immediately starts fetch #2 —
     // restarting the multi-GB download the user just cancelled.
     #expect(world.fetches == 1, "the cancelled Download must not fall through to a second fetch")
-    #expect(!FileManager.default.fileExists(atPath: world.markerURL.path), "cancel cleared the debt")
+    #expect(
+      !FileManager.default.fileExists(atPath: world.markerURL.path), "cancel cleared the debt")
   }
 
   @Test func aDownloadDuringTheCancelDrainWaitsItOutThenFetchesFresh() async throws {
@@ -531,7 +536,8 @@ import Testing
     #expect(outcome == .removed)
     #expect(!FileManager.default.fileExists(atPath: world.markerURL.path), "marker cleared FIRST")
     // L1: controller drain precedes unload precedes deletion.
-    #expect(world.callOrder == ["cancelFetch", "unload", "remove"],
+    #expect(
+      world.callOrder == ["cancelFetch", "unload", "remove"],
       "L1 order violated: \(world.callOrder)")
   }
 

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -95,7 +95,8 @@ struct RecoveryCoordinatorTests {
 
   private static func makeHarness(
     existing: Set<String> = [],
-    dictationActive: Bool = false
+    dictationActive: Bool = false,
+    recoveryEngineClaim: RecoveryEngineClaim = .alwaysAllowedForTesting
   ) -> Harness {
     let keyStore = RecoveryKeyStore(backend: .file, fileDirectory: tempDir())
     let spoolDir = tempDir()
@@ -111,6 +112,7 @@ struct RecoveryCoordinatorTests {
       replayer: replayer,
       existingRecoveryIDs: { existingBox.value },
       isDictationActive: { activeBox.value },
+      recoveryEngineClaim: recoveryEngineClaim,
       resetEngine: { resetEngineCount.value += 1 })
     coordinatorRef = coordinator
     return Harness(
@@ -614,10 +616,10 @@ struct RecoveryCoordinatorTests {
 
   @Test("a mutation claim held on the gate defers the ENTIRE scan — no item is attempted")
   func gateDeniedRecoveryDefersWholeScan() async throws {
-    let h = Self.makeHarness()
     let gate = EngineRecoveryGate()
-    h.coordinator.tryBeginRecoveryClaim = { gate.tryBeginRecovery() }
-    h.coordinator.endRecoveryClaim = { gate.endRecovery() }
+    let h = Self.makeHarness(
+      recoveryEngineClaim: .live(
+        tryBegin: { gate.tryBeginRecovery() }, end: { gate.endRecovery() }))
     #expect(gate.tryBeginMutation(), "an unrelated engine mutation holds the gate")
     try Self.writeSpool(h.spoolStore, "orphan-\(UUID().uuidString)")
     await h.coordinator.scanAndRecover()
@@ -628,10 +630,10 @@ struct RecoveryCoordinatorTests {
 
   @Test("once the held mutation releases, requestRecoveryRecheck() lets the deferred scan succeed")
   func gateReleaseThenRequestRecheckSucceeds() async throws {
-    let h = Self.makeHarness()
     let gate = EngineRecoveryGate()
-    h.coordinator.tryBeginRecoveryClaim = { gate.tryBeginRecovery() }
-    h.coordinator.endRecoveryClaim = { gate.endRecovery() }
+    let h = Self.makeHarness(
+      recoveryEngineClaim: .live(
+        tryBegin: { gate.tryBeginRecovery() }, end: { gate.endRecovery() }))
     #expect(gate.tryBeginMutation())
     let id = "orphan-\(UUID().uuidString)"
     try Self.writeSpool(h.spoolStore, id)
@@ -801,7 +803,8 @@ struct RecoveryCoordinatorTests {
       makeSpoolStore: { RecoverySpoolStore(directory: spoolDir) },
       replayer: replayer,
       existingRecoveryIDs: { [] },
-      isDictationActive: { false })
+      isDictationActive: { false },
+      recoveryEngineClaim: .alwaysAllowedForTesting)
     let result = await coordinator.makeDirective(
       settings: Self.freshSettings(crashRecoveryEnabled: true),
       backendType: .parakeet, supportsLanguageDetection: false)

--- a/Tests/EnviousWisprTests/Recovery/RecoveryEngineClaimTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryEngineClaimTests.swift
@@ -1,0 +1,32 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+@Suite("RecoveryEngineClaim claim/release ceremony")
+@MainActor
+struct RecoveryEngineClaimTests {
+
+  @Test("tryBegin() forwards the live closure's result when granted")
+  func tryBeginForwardsGrantedResult() {
+    let claim = RecoveryEngineClaim.live(tryBegin: { true }, end: {})
+
+    #expect(claim.tryBegin() == true)
+  }
+
+  @Test("tryBegin() forwards the live closure's result when refused")
+  func tryBeginForwardsRefusedResult() {
+    let claim = RecoveryEngineClaim.live(tryBegin: { false }, end: {})
+
+    #expect(claim.tryBegin() == false)
+  }
+
+  @Test("end() forwards to the live closure exactly once per call")
+  func endForwardsToLiveClosure() {
+    var endCallCount = 0
+    let claim = RecoveryEngineClaim.live(tryBegin: { true }, end: { endCallCount += 1 })
+
+    claim.end()
+
+    #expect(endCallCount == 1)
+  }
+}


### PR DESCRIPTION
## Summary

Replaces convention-enforced ASR engine-mutation gating with two required-at-construction capability types (`EngineMutationScope`, `RecoveryEngineClaim`), migrated across all 11 consumers that touch the shared ASR engine, plus a permanent architecture-freeze test suite that keeps the gate honest going forward.

## What changed

**Chunks 1–9**: `EngineMutationScope` (EnviousWisprASR) and `RecoveryEngineClaim` (EnviousWisprAppKit) are now required at construction — a consumer cannot compile without explicitly wiring one in, replacing the prior optional-closure-defaulted-to-always-allowed pattern. Migrated: `RecoveryCoordinator`, `ASRManager`, `ASRManagerProxy`, `WhisperKitSetupService`, `BenchmarkSuite`, `ModelDeliveryHome`, `EngineCoordinator`, `WhisperKitLegacyUpgradeCoordinator`, `KernelDictationDriver`, `RecordingSessionKernel`, `WhisperKitEngineAdapter`. No behavior change — spot-checked line-by-line against pre-refactor logic on every high-risk transform.

**Chunks 10–11**: a permanent freeze-test pair that inventories every real source reference to the engine-mutating surface and fails the build on an unclassified one:
- `EngineMutationInventoryFreezeTests` — reference inventory. 26 tracked method names, 106 classified call sites.
- `EngineProtocolSurfaceFreezeTests` (new) — a companion signature-level freeze for the ten protocols and two concrete-only method surfaces that make up the engine-facing API, so a changed/added/removed member fails the build too.

## These are bounded guardrails, not universal detection

Two consecutive grounded Codex plan reviews each found "one more engine-facing surface" the prior pass had missed, including a structural hole in a proposed general downcast scanner (a real call site takes a concrete engine type as a plain typed parameter, no cast at all). That pattern — repeated discovery with no sign of converging to zero — is why this ships as an **honestly bounded** freeze rather than a claim of completeness: tests and architecture changes are guardrails, not a replacement for documentation, review, and engineering judgment.

Concretely, both test suites now state in their own doc comments what they catch (a new/changed reference to an already-tracked name; a changed signature on an already-tracked protocol or concrete method) and what they cannot (a brand-new protocol nobody has told them about, a brand-new concrete type, a new XPC route, a macro-generated call, or a concrete type accessed with no protocol and no cast at all). Closing that gap for good would need a different kind of tool — evaluated and set aside as its own question, not folded into this refactor.

## Known production gaps (not fixed here)

Grounding this surface surfaced real, pre-existing production races. Both are explicitly disclosed, tracked in the freeze test as `knownGap` entries pointing at their own issues, and deliberately **not fixed** in this PR (production behavior change, out of this refactor's scope):

- **#1745** — Recovery Discard's engine reset is fire-and-forget; the recovery claim can release before it finishes.
- **#1749** — Recovery can act on the ASR engine before an ordinary session's own termination cleanup finishes cancelling it (a sibling race to #1745, different trigger and code path). Filed during this work.

18 classified call sites carry `knownGap`: 2 for #1745, 16 for #1749.

## Validation

- Focused architecture suite: 47/47 passing.
- Full suite: 3841/3841 passing (debug lane, post-rebase onto `origin/main`).
- Whole-diff self-review + canonical final integration Codex review ran 2 rounds. A later final audit corrected the one previously deferred single-authority scanner finding and a second fail-open source-read/discovery gap. A focused Codex confirmation of those fixes found no actionable defects.
- No production code changed in Chunks 10–11 or the final audit correction — test/tooling only.

## Deviations from earlier plan drafts

- Chunk 10's original 13-name vocabulary grew to 26 names after grounding found real gaps; `EngineProtocolSurfaceFreezeTests` is new, not in the original Chunk 10 scope.
- A proposed "general downcast escape-hatch scanner" and a follow-up "compiler-enforced engine boundary" research issue (#1751) were both proposed mid-effort and then explicitly rejected by the founder — closed with that rationale recorded on #1751 itself.

Closes #1741.
