### PR TITLE
feat(pipeline): Lane 2 discard cutover — failed dictations never resurrect at launch (#1755)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -168,6 +168,10 @@ public final class ASRManagerProxy: ASRManagerInterface {
   // periphery:ignore - test seam
   func setConnectionForTesting(_ conn: NSXPCConnection?) { connection = conn }
 
+  // periphery:ignore - test seam (PR #1761 cloud P2: lets the streaming-finalize
+  // registration test pass the isStreaming guard without a real session)
+  func setStreamingForTesting(_ streaming: Bool) { isStreaming = streaming }
+
   /// #1755: the registry lifecycle around ONE suspended transcribe reply —
   /// register the resume-once guard under a fresh operation UUID, hand it to
   /// `start` (production wires the XPC call; tests wire a scripted
@@ -596,15 +600,17 @@ public final class ASRManagerProxy: ASRManagerInterface {
   public func finalizeStreaming() async throws -> ASRResult {
     guard isStreaming else { throw ASRError.streamingNotSupported }
 
-    let (resultData, error): (Data?, NSError?) = try await withCheckedThrowingContinuation {
-      (cont: CheckedContinuation<(Data?, NSError?), any Error>) in
-      let guard_ = OneShotContinuationASR(cont)
+    // PR #1761 cloud P2: route the STREAMING finalize through the same
+    // pending-transcribe registry as the batch path — a helper death during a
+    // streaming session's finalize must fail this suspended await (and enter
+    // the Phase-2 retry) instead of hanging it forever.
+    let (resultData, error): (Data?, NSError?) = try await awaitTranscribeReply { completion in
       serviceProxy { proxy in
         proxy.finalizeStreaming { resultData, nsError in
-          guard_.resume(returning: (resultData, nsError))
+          completion.resume(returning: (resultData, nsError))
         }
       } onProxyError: {
-        guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
+        completion.resume(throwing: XPCASRTransportError.serviceUnreachable)
       }
     }
 

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -69,6 +69,19 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// from clobbering a retry's freshly registered guard.
   private var pendingLoadCompletion: OneShotContinuationASR<Void>?
 
+  /// #1755 §3.4 prerequisite: the pending batch-transcribe continuations'
+  /// resume-once guards, keyed by per-call operation UUID, reachable by EVERY
+  /// completion source — the XPC reply, the per-call proxy error, and the
+  /// interruption/invalidation handlers. Same production defect class as
+  /// `pendingLoadCompletion` (#1388: the per-call error handler is NOT
+  /// guaranteed to fire for a pending reply on invalidate/death): before this
+  /// registry, a helper death mid-decode left `transcribe(audioSamples:)`'s
+  /// await suspended forever, so the kernel's finalize could never fail into
+  /// its Phase-2 retry. `OneShotContinuationASR` guarantees exactly one
+  /// resume; `awaitTranscribeReply`'s `defer` removes exactly its own key on every exit,
+  /// so a superseded call can never clobber a later call's registration.
+  private var pendingTranscribeCompletions: [UUID: OneShotContinuationASR<(Data?, NSError?)>] = [:]
+
   /// #959 readiness-integrity token. Monotonic; `loadModel()` captures it at the
   /// start of its load and refuses to write `isModelLoaded = true` if it changed
   /// before the load completes (throws `ASRLoadSupersededError`). Bumped by
@@ -145,6 +158,48 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// The contract test asserts it is cleared on every `loadModel` exit.
   // periphery:ignore - test seam
   var hasPendingLoadCompletionForTesting: Bool { pendingLoadCompletion != nil }
+
+  /// #1755 test seams (minimal, mirroring the recycle/load seams above): the
+  /// registry count and a connection-era setter, so the real handler factories'
+  /// era guard is testable without spawning a helper.
+  // periphery:ignore - test seam
+  var pendingTranscribeCountForTesting: Int { pendingTranscribeCompletions.count }
+
+  // periphery:ignore - test seam
+  func setConnectionForTesting(_ conn: NSXPCConnection?) { connection = conn }
+
+  /// #1755: the registry lifecycle around ONE suspended transcribe reply —
+  /// register the resume-once guard under a fresh operation UUID, hand it to
+  /// `start` (production wires the XPC call; tests wire a scripted
+  /// completion), and remove exactly this call's key on every exit. This is
+  /// the SINGLE implementation `transcribe(audioSamples:)` runs, so tests of
+  /// this helper test production's real registration/cleanup, not a copy.
+  func awaitTranscribeReply(
+    _ start: (OneShotContinuationASR<(Data?, NSError?)>) -> Void
+  ) async throws -> (Data?, NSError?) {
+    let operationID = UUID()
+    defer { pendingTranscribeCompletions.removeValue(forKey: operationID) }
+    return try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<(Data?, NSError?), any Error>) in
+      let completion = OneShotContinuationASR(continuation)
+      pendingTranscribeCompletions[operationID] = completion
+      start(completion)
+    }
+  }
+
+  /// #1755: fail every pending batch-transcribe completion with the typed
+  /// transport error. Called ONLY from the current-era region of the
+  /// interruption/invalidation handlers (the callers hold the era guard, so a
+  /// retired connection's late handler can never drain a successor's
+  /// operations). Snapshot-then-clear before resuming so a re-entrant
+  /// registration during resume cannot be swallowed.
+  private func failAllPendingTranscribes() {
+    let pending = Array(pendingTranscribeCompletions.values)
+    pendingTranscribeCompletions.removeAll()
+    for completion in pending {
+      completion.resume(throwing: XPCASRTransportError.serviceUnreachable)
+    }
+  }
 
   /// Invalidate whatever load is current: bump the generation so an in-flight
   /// `loadModel()` completion (even one whose `isModelLoaded` is still `false`)
@@ -445,19 +500,20 @@ public final class ASRManagerProxy: ASRManagerInterface {
       }
     }
 
-    let (resultData, error): (Data?, NSError?) = try await withCheckedThrowingContinuation {
-      (cont: CheckedContinuation<(Data?, NSError?), any Error>) in
-      let guard_ = OneShotContinuationASR(cont)
+    // #1755 §3.4 prerequisite: run the reply through the registry helper so
+    // the connection death handlers can fail a suspended decode (see
+    // `pendingTranscribeCompletions` / `awaitTranscribeReply`).
+    let (resultData, error): (Data?, NSError?) = try await awaitTranscribeReply { completion in
       serviceProxy { proxy in
         proxy.transcribeSamples(
           data, sampleCount: audioSamples.count,
           language: language, enableTimestamps: options.enableTimestamps,
           speechSegmentsData: speechSegmentsData
         ) { resultData, nsError in
-          guard_.resume(returning: (resultData, nsError))
+          completion.resume(returning: (resultData, nsError))
         }
       } onProxyError: {
-        guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
+        completion.resume(throwing: XPCASRTransportError.serviceUnreachable)
       }
     }
 
@@ -858,8 +914,9 @@ public final class ASRManagerProxy: ASRManagerInterface {
     }
   }
 
-  nonisolated private static func makeInterruptionHandler(
-    proxy: ASRManagerProxy, connection: NSXPCConnection
+  nonisolated static func makeInterruptionHandler(  // internal: #1755 era-guard tests
+    proxy: ASRManagerProxy, connection: NSXPCConnection,
+    didFinishForTesting: (@MainActor @Sendable () -> Void)? = nil
   ) -> @Sendable () ->
     Void
   {
@@ -868,6 +925,7 @@ public final class ASRManagerProxy: ASRManagerInterface {
     let eraID = ObjectIdentifier(connection)
     return { [weak proxy] in
       Task { @MainActor [weak proxy] in
+        defer { didFinishForTesting?() }
         guard let proxy else { return }
         let wasStreaming = proxy.isStreaming
         let wasLoaded = proxy.isModelLoaded
@@ -892,6 +950,10 @@ public final class ASRManagerProxy: ASRManagerInterface {
         guard currentEraID == nil || currentEraID == eraID else { return }
         proxy.pendingLoadCompletion?.resume(throwing: XPCASRTransportError.serviceUnreachable)
         proxy.pendingLoadCompletion = nil
+        // #1755 §3.4 prerequisite: a helper death must also fail every
+        // suspended batch decode, or the kernel's finalize hangs and the one
+        // live rescue can never begin (same #1388 defect class as the load).
+        proxy.failAllPendingTranscribes()
         // #959: supersede the current/in-flight load (and log the ready→notReady
         // cause) BEFORE clearing `isModelLoaded`, so the cause log fires and a
         // load completing after this teardown cannot resurrect a false `.ready`.
@@ -919,14 +981,16 @@ public final class ASRManagerProxy: ASRManagerInterface {
     }
   }
 
-  nonisolated private static func makeInvalidationHandler(
-    proxy: ASRManagerProxy, connection: NSXPCConnection
+  nonisolated static func makeInvalidationHandler(  // internal: #1755 era-guard tests
+    proxy: ASRManagerProxy, connection: NSXPCConnection,
+    didFinishForTesting: (@MainActor @Sendable () -> Void)? = nil
   ) -> @Sendable () ->
     Void
   {
     let eraID = ObjectIdentifier(connection)
     return { [weak proxy] in
       Task { @MainActor [weak proxy] in
+        defer { didFinishForTesting?() }
         guard let proxy else { return }
         let wasActive = proxy.isStreaming || proxy.isModelLoaded
         let wasInFlight = proxy.inFlightLoadTask != nil
@@ -941,6 +1005,9 @@ public final class ASRManagerProxy: ASRManagerInterface {
         guard currentEraID == nil || currentEraID == eraID else { return }
         proxy.pendingLoadCompletion?.resume(throwing: XPCASRTransportError.serviceUnreachable)
         proxy.pendingLoadCompletion = nil
+        // #1755 §3.4 prerequisite: same as the interruption handler — fail
+        // every suspended batch decode under the same era guard.
+        proxy.failAllPendingTranscribes()
         // #959: same as the interruption handler — supersede current/in-flight
         // load + log cause BEFORE clearing `isModelLoaded`.
         if wasActive || wasInFlight {

--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -268,6 +268,37 @@
             + "source_incarnation=\(status.sourceIncarnation) "
             + "capture_source=\(status.captureSourceType)"
         }
+        // #1755 chunk 6: crash-boundary commands — the three narrow verbs
+        // over the ONE shared CrashBoundaryFaultController. `arm` replies OK
+        // only after the acknowledged arm (in-process state + artifact);
+        // `query` is a pre-hold diagnostic (the authoritative post-hold read
+        // is the external file read, off this MainActor). Boundary strings
+        // are validated against the closed five-value enum; anything else is
+        // ERR.
+        if cmd == "clear_crash_boundary" {
+          CrashBoundaryFaultController.shared.clear()
+          return "OK"
+        }
+        if let (boundaryRaw, trialID) = parseTwoStringArgCommand(
+          cmd, prefix: "arm_crash_boundary(")
+        {
+          guard let boundary = CrashBoundary(rawValue: boundaryRaw) else {
+            return "ERR unknown_boundary"
+          }
+          guard CrashBoundaryFaultController.shared.arm(trialID: trialID, boundary: boundary)
+          else { return "ERR arm_failed" }
+          return "OK"
+        }
+        if let (boundaryRaw, trialID) = parseTwoStringArgCommand(
+          cmd, prefix: "query_crash_boundary(")
+        {
+          guard let boundary = CrashBoundary(rawValue: boundaryRaw) else {
+            return "ERR unknown_boundary"
+          }
+          let reached = CrashBoundaryFaultController.shared.isReached(
+            trialID: trialID, boundary: boundary)
+          return "OK reached=\(reached)"
+        }
         // #1707 Phase 2 (§11.1/§3.2a-i): the seven batch-decode fault
         // commands, all routing to the ONE `BatchDecodeFaultController` —
         // adapter-boundary forced failures (`fail_batch_decode`/
@@ -370,6 +401,18 @@
       guard cmd.hasPrefix(prefix), cmd.hasSuffix(")") else { return nil }
       let inner = String(cmd.dropFirst(prefix.count).dropLast())
       return inner.isEmpty ? nil : inner
+    }
+
+    /// #1755 chunk 6: parse `<prefix><first>,<second>)` — two non-empty
+    /// comma-separated strings, no nesting, no configurability.
+    private func parseTwoStringArgCommand(
+      _ cmd: String, prefix: String
+    ) -> (String, String)? {
+      guard cmd.hasPrefix(prefix), cmd.hasSuffix(")") else { return nil }
+      let inner = cmd.dropFirst(prefix.count).dropLast()
+      let parts = inner.split(separator: ",", maxSplits: 1, omittingEmptySubsequences: false)
+      guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+      return (String(parts[0]), String(parts[1]))
     }
 
     /// #1707 Phase 2: parse `<prefix><backend>)` — `<backend>` is

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -175,9 +175,10 @@ final class DictationLifecycleCoordinator {
       guard let self else { return }
       self.handleWhisperKit(newState: newState)
     }
-    // #1063 PR2: the kernel's RAW non-`.completed` terminal signal, carrying the
-    // recovery id + terminal KIND. Routed to the recovery cleanup (discard deletes,
-    // failure retains). Distinct from `onStateChange` (the pinnable published
+    // #1063 PR2 / #1755: the kernel's RAW non-`.completed` terminal signal,
+    // carrying the recovery id + terminal KIND. Routed to the recovery cleanup
+    // (every represented ending requests best-effort deletion under the
+    // discard doctrine). Distinct from `onStateChange` (the pinnable published
     // state) — keyed off the kernel terminal so it never fires during `.finalizing`.
     kernelDriver.onSessionEndedWithoutSave = { [weak self] id, ending in
       self?.onRecordingEndedWithoutDurableSave(id, ending)

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -163,9 +163,9 @@ final class DictationRuntime {
     dictationLifecycleCoordinator.onDurableSave = { id in
       recoveryCoordinator.handleDurableSave(recoverySessionID: id)
     }
-    // #1063 PR2 / #1464: a recording that ends at a non-saved terminal routes to
-    // recovery cleanup — the coordinator's predicate deletes a discard/no-speech/
-    // user-cancel ending now and RETAINS a fault ending for next-launch recovery.
+    // #1063 PR2 / #1464 / #1755: a recording that ends at a non-saved terminal
+    // routes to recovery cleanup — under the discard doctrine the coordinator's
+    // predicate requests best-effort deletion for EVERY represented ending.
     dictationLifecycleCoordinator.onRecordingEndedWithoutDurableSave = { id, ending in
       recoveryCoordinator.handleRecordingEndedWithoutDurableSave(
         recoverySessionID: id, ending: ending)

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -169,6 +169,13 @@ final class DictationRuntime {
     dictationLifecycleCoordinator.onRecordingEndedWithoutDurableSave = { id, ending in
       recoveryCoordinator.handleRecordingEndedWithoutDurableSave(
         recoverySessionID: id, ending: ending)
+      #if DEBUG
+        // #1755 chunk 6: crash-boundary hold — the live-ending API has
+        // ACTUALLY returned (never faked inside the coordinator). While this
+        // boundary is armed, the detached key deletion is gated at its
+        // pre-point, in either schedule. Unarmed: no-op.
+        CrashBoundaryFaultController.shared.boundaryReached(.destructionAPIReturn)
+      #endif
     }
     // #1707 Phase 3 (GitHub cloud review, PR #1732 round 6): a `.complete`
     // whose History save failed retains its spool but fires no delete

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
@@ -42,9 +42,9 @@ final class RecordingFinalizer {
     try await $0.handle(event: .requestStop)
   }
   var cancelRecordingDispatch: @MainActor (KernelDictationDriver) async -> Void = {
-    // #1063 PR2 / #1464: this is the genuine USER cancel path (the cancel button →
-    // `RecordingFinalizer.cancel()`), so a recovery spool is DELETED, not retained.
-    // The settings-rebuild system cancel uses `cancelRecording()`'s retain default.
+    // #1063 PR2 / #1464 / #1755: the genuine USER cancel path (the cancel
+    // button → `RecordingFinalizer.cancel()`) — attributed `.user` for
+    // provenance; every cancel origin deletes under the discard doctrine.
     await $0.cancelRecording(disposition: .user)
   }
 

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -266,6 +266,40 @@ final class RecoveryCoordinator {
     return (recoverySessionID, payload)
   }
 
+  /// #1755 chunk 4 — fixed, low-cardinality labels for WHY a destruction ran.
+  /// Closed enum: no caller-supplied strings, no configurability.
+  private enum DestructionSource: String {
+    case durableSave = "durable_save"
+    case liveEnding = "live_ending"
+    case preStartAbort = "pre_start_abort"
+    case historyDedup = "history_dedup"
+    case replayOutcome = "replay_outcome"
+    case userDiscard = "user_discard"
+  }
+
+  /// #1755 chunk 4 test seams (internal; nil in production — the real spool
+  /// store, key store, and `SentryBreadcrumb.add` run when unset). Narrow,
+  /// policy-free, instance-scoped (no process-global spy, parallel-test safe).
+  // periphery:ignore - test seam
+  var destructionSpoolDeleteForTesting: ((String) throws -> Void)?
+  // periphery:ignore - test seam
+  var destructionKeyDeleteForTesting: (@Sendable (String) throws -> Void)?
+  // periphery:ignore - test seam
+  var deletionFailureBreadcrumbForTesting:
+    (@MainActor @Sendable (_ stage: String, _ message: String, _ data: [String: String]) -> Void)?
+
+  /// #1755 chunk 4: one failure-only breadcrumb per failed component per
+  /// destruction call. Never includes the recovery ID, path, or raw error —
+  /// deletion stays best-effort and swallowed; this is diagnosis only.
+  private func emitDeletionFailed(component: String, source: DestructionSource) {
+    let data = ["component": component, "source": source.rawValue]
+    if let sink = deletionFailureBreadcrumbForTesting {
+      sink("recovery", "deletion_failed", data)
+    } else {
+      SentryBreadcrumb.add(stage: "recovery", message: "deletion_failed", data: data)
+    }
+  }
+
   /// The SOLE spool+key destructor (#1464). Deletes the spool file (which also
   /// clears its attempt marker) SYNCHRONOUSLY — it is cheap local FS, and a
   /// follow-up scan / the dedup + discard callers must see it gone at once — then
@@ -274,11 +308,35 @@ final class RecoveryCoordinator {
   /// double-delete or a concurrently-removed spool is a harmless no-op. Returns the
   /// detached key-delete work so tests can await completion; callers may discard it.
   @discardableResult
-  private func destroySpoolAndKey(id: String) -> Task<Void, Never> {
-    try? makeSpoolStore().delete(recoverySessionID: id)
+  private func destroySpoolAndKey(id: String, source: DestructionSource) -> Task<Void, Never> {
+    do {
+      if let override = destructionSpoolDeleteForTesting {
+        try override(id)
+      } else {
+        try makeSpoolStore().delete(recoverySessionID: id)
+      }
+    } catch {
+      emitDeletionFailed(component: "spool", source: source)
+    }
+    // Key deletion ALWAYS runs, detached, even after a spool failure.
     let keyStore = self.keyStore
+    let keyOverride = destructionKeyDeleteForTesting
+    // Capture self STRONGLY: the failure breadcrumb must survive coordinator
+    // deallocation racing the detached delete (a weak capture silently
+    // dropped it). The task is short-lived; the temporary strong retention
+    // ends when the task completes.
     return Task.detached(priority: .utility) {
-      try? keyStore.delete(for: id)
+      do {
+        if let keyOverride {
+          try keyOverride(id)
+        } else {
+          try keyStore.delete(for: id)
+        }
+      } catch {
+        await MainActor.run {
+          self.emitDeletionFailed(component: "key", source: source)
+        }
+      }
     }
   }
 
@@ -328,7 +386,7 @@ final class RecoveryCoordinator {
   @discardableResult
   func handleDurableSave(recoverySessionID id: String) -> Task<Void, Never> {
     if armedSessionID == id { armedSessionID = nil }
-    return destroySpoolAndKey(id: id)
+    return destroySpoolAndKey(id: id, source: .durableSave)
   }
 
   /// A `.complete` dictation whose History save FAILED (GitHub cloud review,
@@ -376,7 +434,7 @@ final class RecoveryCoordinator {
       nextLaunchOnlyRecoveryIDs.insert(id)
       return nil
     }
-    return destroySpoolAndKey(id: id)
+    return destroySpoolAndKey(id: id, source: .liveEnding)
   }
 
   /// A record-press aborted BEFORE a kernel session was minted (a PTT release or
@@ -389,7 +447,7 @@ final class RecoveryCoordinator {
   func handlePreStartAbort(recoverySessionID id: String?) -> Task<Void, Never>? {
     guard let id else { return nil }
     if armedSessionID == id { armedSessionID = nil }
-    return destroySpoolAndKey(id: id)
+    return destroySpoolAndKey(id: id, source: .preStartAbort)
   }
 
   /// On launch, scan for orphan spools and recover them (#1063 PR2 — replaces
@@ -505,7 +563,7 @@ final class RecoveryCoordinator {
         // re-transcribing (the dedup MUST precede any append — History forbids a
         // duplicate id). Routed through the sole destructor (#1464); these ids are
         // never appended to `recoverable`, so the async delete never races a replay.
-        destroySpoolAndKey(id: id)
+        destroySpoolAndKey(id: id, source: .historyDedup)
       } else {
         recoverable.append(id)
       }
@@ -588,7 +646,7 @@ final class RecoveryCoordinator {
       // #1464: the coordinator is the sole destructor — the replayer no longer
       // deletes, so apply the replay predicate now that `replay()` has returned.
       // (`.aborted` deletes nothing here: `discardActiveRecovery` already did.)
-      if Self.shouldDeleteAfterReplay(outcome) { destroySpoolAndKey(id: id) }
+      if Self.shouldDeleteAfterReplay(outcome) { destroySpoolAndKey(id: id, source: .replayOutcome) }
       // Post the standalone success notice for a recording that landed in History.
       if case .recovered = outcome { onRecoverySucceeded?() }
       // A Discard ends the whole hold; remaining orphans (rare) wait for the next
@@ -634,7 +692,7 @@ final class RecoveryCoordinator {
     resetEngine()
     // Route through the sole destructor (#1464). The post-replay predicate sees
     // `.aborted` for this id and does NO second delete.
-    destroySpoolAndKey(id: id)
+    destroySpoolAndKey(id: id, source: .userDiscard)
     activeRecoveryID = nil
     TelemetryService.shared.recoveryCompleted(outcome: "discarded")
   }

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -447,6 +447,15 @@ final class RecoveryCoordinator {
       nextLaunchOnlyRecoveryIDs.insert(id)
       return nil
     }
+    // GitHub cloud review PR #1761: suppress BEFORE the best-effort delete.
+    // If the spool deletion fails (transient FS/permission error), the same
+    // callback fires `onDictationEndedForRecovery` moments later — without
+    // this, that same-launch rescan could rediscover and REPLAY the
+    // undeleted spool, resurrecting a take whose live terminal the user
+    // already saw. A successful delete makes the suppression harmless; a
+    // failed one leaves the survivor as a next-launch item, consistent with
+    // the best-effort crash-atomicity contract (§3.5).
+    nextLaunchOnlyRecoveryIDs.insert(id)
     return destroySpoolAndKey(id: id, source: .liveEnding)
   }
 

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -18,9 +18,10 @@ import Foundation
 /// - **Clean up on success:** once a recording's transcript is durably saved,
 ///   delete that session's spool file + key.
 /// - **Clean up on a non-saved ending:** apply `shouldDeleteOnLiveEnding` to the
-///   narrow `RecordingRecoveryEnding` — discard / no-speech / user-cancel delete
-///   now; a fault ending (pipeline / audio / engine / system-cancel) RETAINS the
-///   spool so the audio is recovered on the next launch.
+///   narrow `RecordingRecoveryEnding` — under the #1755 discard doctrine EVERY
+///   concluded live ending requests best-effort deletion (the user witnessed
+///   the failure and re-dictates). Launch replay serves only the no-ending
+///   app-gone orphan and the History-save self-heal case.
 /// - **Scan + recover on launch (PR2):** find orphan spools, dedup any already
 ///   in History, then — behind a blocking "recovering your last recording" pill
 ///   that holds new recordings off the one shared engine — replay each orphan
@@ -127,24 +128,13 @@ final class RecoveryCoordinator {
   /// arriving mid-pass causes exactly one later pass, never zero and never two.
   private var pendingRescan = false
 
-  /// #1707 Phase 3 (§3.3) — ids that must wait for a genuinely NEW launch
-  /// rather than any same-launch rescan. Three populations: (1) an attempt-
-  /// marker clear that FAILED after a deferred outcome (Keychain-transient or
-  /// a History-save failure DURING REPLAY) — a surviving marker would be
-  /// misread by a same-launch rescan as a crashed attempt (the crash-loop
-  /// guard's "marker present ⇒ abandoned" reasoning only holds for a
-  /// genuinely new launch); (2) a LIVE recording's own RETAINED failure
-  /// ending (GitHub cloud review, PR #1732 round 1) — the engine may still be
-  /// in the exact broken state that produced the failure; (3) a LIVE
-  /// recording that reached `.complete` but whose History save failed (PR
-  /// #1732 round 6) — `onDurableSave` never fires for this case (nothing to
-  /// delete), but the same terminal transition's own wake-up must not
-  /// immediately re-attempt (and potentially delete) the spool this failure
-  /// just retained. Every same-launch pass skips these ids, leaving them
-  /// untouched on disk for a future launch's fresh `RecoveryCoordinator`
-  /// instance (which always starts empty). NEVER cleared during one
-  /// instance's lifetime; tests model "a new launch" by constructing a new
-  /// coordinator, never by clearing this set on an existing one.
+  /// IDs excluded from SAME-LAUNCH rescans, cleared only by a genuine new
+  /// launch (a fresh coordinator). Two populations remain (#1755 narrowed it
+  /// from three — concluded live endings now delete instead of retaining):
+  /// 1. Replay continuation cases — `.failed(.save)` / marker-clear failures /
+  ///    `.deferredMarkerClearFailed` — retained for a FUTURE launch, never
+  ///    re-attempted by this one.
+  /// 2. A live `.completed` whose History save failed (self-heal next launch).
   private var nextLaunchOnlyRecoveryIDs: Set<String> = []
 
   /// Monotonic token bumped by `discardActiveRecovery()`. The replayer captures
@@ -340,22 +330,30 @@ final class RecoveryCoordinator {
     }
   }
 
-  /// Delete-versus-retain for a live recording that ended without a durable save
-  /// (#1464). Reproduces the former driver `endedWithoutSaveKind` mapping EXACTLY:
-  /// delete when there is nothing worth keeping (discard / no-speech) or the user
-  /// asked to drop it; RETAIN when the captured audio is the user's words a fault
-  /// cut short. Static + internal so the split is unit-tested directly
-  /// (`matcher-set-adversarial-tests`).
+  /// Delete-versus-retain for a live recording that ended without a durable
+  /// save (#1464; policy cutover #1755, founder Gate 2 2026-07-23). An ending
+  /// fired ⇒ the app was ALIVE ⇒ the user witnessed the outcome, got the one
+  /// in-session rescue, and re-dictates — so EVERY represented ending requests
+  /// best-effort deletion (`discard-not-differentiate`). Launch replay is
+  /// reserved for the no-ending app-gone orphan, which never reaches this
+  /// predicate. The switch stays exhaustive with no `default` so a future
+  /// ending case forces an explicit decision here. Static + internal so the
+  /// cells are unit-tested directly (`matcher-set-adversarial-tests`).
   static func shouldDeleteOnLiveEnding(_ ending: RecordingRecoveryEnding) -> Bool {
     switch ending {
     case .discarded, .noSpeech, .asrRetryExhausted:
       return true
     case .failed, .audioInterrupted, .asrInterrupted, .noTransport:
-      return false
+      // #1755: flipped from retain — the in-session salvage/retry was the
+      // user's one rescue; a surprise replay at a later launch is a bug in
+      // the user's eyes, not a favor.
+      return true
     case .cancelled(.user):
       return true
     case .cancelled(.systemOrFault):
-      return false
+      // #1755: flipped — every producer is app-alive by construction (an
+      // app-gone event cannot publish any ending; it leaves an orphan).
+      return true
     }
   }
 
@@ -397,31 +395,26 @@ final class RecoveryCoordinator {
   /// dispatches to the caller of this method first — without this
   /// suppression, that same-launch wake-up could immediately rescan and
   /// destructively replay the spool this failure meant to retain for a
-  /// healthier future launch, exactly like the live-failure-ending case this
-  /// mirrors. No-op when `id` is nil (armed only when recovery was on for
-  /// this take).
+  /// healthier future launch. (#1755: this History-save self-heal case is now
+  /// the ONLY live path that retains.) No-op when `id` is nil (armed only
+  /// when recovery was on for this take).
   func suppressUntilNextLaunch(recoverySessionID id: String?) {
     guard let id else { return }
     nextLaunchOnlyRecoveryIDs.insert(id)
   }
 
   /// A recording ended at a terminal state WITHOUT a durable transcript save
-  /// (#1063 PR2 / #1464). Applies `shouldDeleteOnLiveEnding` to the narrow
-  /// `RecordingRecoveryEnding` the driver projected: a delete ending (discard /
-  /// no-speech / user-cancel) destroys the spool + key now; a retain ending
-  /// (pipeline / audio / engine / system-cancel) keeps it for the next launch.
-  /// Idempotent + best-effort; a no-op when `id` is nil. Always clears the live-
-  /// recording protection (the recording is over). Returns the detached delete
-  /// work (delete endings only) so tests can await it.
+  /// (#1063 PR2 / #1464; #1755 cutover). Applies `shouldDeleteOnLiveEnding`
+  /// to the narrow `RecordingRecoveryEnding` the driver projected — under the
+  /// discard doctrine EVERY represented ending destroys the spool + key now.
+  /// Idempotent + best-effort; a no-op when `id` is nil. Always clears the
+  /// live-recording protection (the recording is over). Returns the detached
+  /// delete work so tests can await it.
   ///
-  /// A retain ending ALSO defers this id to `nextLaunchOnlyRecoveryIDs`
-  /// (GitHub cloud review, PR #1732): this same session's own
-  /// `onDictationEndedForRecovery` wake-up fires right after this call and
-  /// requests a same-launch rescan — without this, that rescan could pick up
-  /// the spool just retained here while the engine is still in the exact
-  /// state that produced the failure, replay it, classify it
-  /// `.failed(.unrecoverable)`, and delete the very audio this branch meant
-  /// to keep for a healthier future launch. Runs before that rescan Task is
+  /// The retain branch below is the future-proof expression of the sole
+  /// policy authority: currently unreachable (no ending returns false), it
+  /// keeps the deferral wiring honest should a future ending case ever
+  /// decide to retain. Runs before the same-launch rescan Task is
   /// even scheduled (both synchronous MainActor calls from the same driver
   /// callback), so the exclusion is always in place before the pass runs.
   @discardableResult

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -270,6 +270,11 @@ final class RecoveryCoordinator {
   /// #1755 chunk 4 test seams (internal; nil in production — the real spool
   /// store, key store, and `SentryBreadcrumb.add` run when unset). Narrow,
   /// policy-free, instance-scoped (no process-global spy, parallel-test safe).
+  #if DEBUG
+    /// #1755 chunk 6: crash-boundary hold seam (see the kernel's twin).
+    var crashBoundaryController: CrashBoundaryFaultController = .shared
+  #endif
+
   // periphery:ignore - test seam
   var destructionSpoolDeleteForTesting: ((String) throws -> Void)?
   // periphery:ignore - test seam
@@ -299,6 +304,11 @@ final class RecoveryCoordinator {
   /// detached key-delete work so tests can await completion; callers may discard it.
   @discardableResult
   private func destroySpoolAndKey(id: String, source: DestructionSource) -> Task<Void, Never> {
+    #if DEBUG
+      // #1755 chunk 6: crash-boundary hold — immediately before the spool
+      // attempt (seam or real store). Unarmed: no-op.
+      crashBoundaryController.boundaryReached(.beforeSpoolDelete)
+    #endif
     do {
       if let override = destructionSpoolDeleteForTesting {
         try override(id)
@@ -315,7 +325,17 @@ final class RecoveryCoordinator {
     // deallocation racing the detached delete (a weak capture silently
     // dropped it). The task is short-lived; the temporary strong retention
     // ends when the task completes.
+    #if DEBUG
+      let crashBoundaryController = self.crashBoundaryController
+    #endif
     return Task.detached(priority: .utility) {
+      #if DEBUG
+        // #1755 chunk 6: crash-boundary hold — immediately before the key
+        // attempt. While destruction_api_return is armed this call GATES
+        // (parks without publishing) so the caller-side hook can prove the
+        // live-ending API returned first.
+        crashBoundaryController.boundaryReached(.beforeKeyDelete)
+      #endif
       do {
         if let keyOverride {
           try keyOverride(id)

--- a/Sources/EnviousWisprCore/CrashBoundaryFaultController.swift
+++ b/Sources/EnviousWisprCore/CrashBoundaryFaultController.swift
@@ -1,0 +1,230 @@
+#if DEBUG
+  import Foundation
+
+  /// #1755 chunk 6 — the closed crash-boundary vocabulary for the Bible Open
+  /// decision #5 Live UAT matrix (plan §11.1 leg 5). Exactly these five; a new
+  /// boundary is a plan change, not a string.
+  public enum CrashBoundary: String, CaseIterable, Sendable {
+    case retryExhaustionDecided = "retry_exhaustion_decided"
+    case liveTerminalPublished = "live_terminal_published"
+    case beforeSpoolDelete = "before_spool_delete"
+    case beforeKeyDelete = "before_key_delete"
+    case destructionAPIReturn = "destruction_api_return"
+  }
+
+  /// The exact on-disk record for both the arm and the reached artifacts —
+  /// trial identity + boundary only. Never a recovery ID, path, transcript,
+  /// or error text.
+  public struct CrashBoundarySignalRecord: Codable, Sendable, Equatable {
+    public let trialID: String
+    public let boundary: String
+    public init(trialID: String, boundary: String) {
+      self.trialID = trialID
+      self.boundary = boundary
+    }
+  }
+
+  /// #1755 chunk 6 — DEBUG-only crash-boundary holds (plan §10). Mirrors the
+  /// `BatchDecodeFaultSnapshotFile` atomic-plist signal pattern with one
+  /// controller owning arm/consume/publish/hold under a single lock:
+  ///
+  /// - **Arm** is IN-PROCESS state established only by the acknowledged arm
+  ///   command; the arm artifact is external evidence/cleanup material. A
+  ///   fresh process never activates a stale on-disk arm.
+  /// - **One-shot consumption:** the first matching hit claims the live arm,
+  ///   removes the arm artifact, and only then publishes the reached
+  ///   artifact — all under the lock. A wrong-boundary hit leaves the arm
+  ///   intact; a second matching hit finds no arm and passes through. If the
+  ///   reached publication fails, the hit fails CLOSED: no reached claim, no
+  ///   hold.
+  /// - **Real holds:** after publishing, the execution path parks on a
+  ///   semaphore until the app is killed or a test release fires. No clocks.
+  /// - **`destruction_api_return` gate:** while that boundary is armed, the
+  ///   key-delete pre-point is GATED (parked without consuming or
+  ///   publishing) in BOTH schedules; only the caller-side hook that runs
+  ///   after `handleRecordingEndedWithoutDurableSave(...)` returned may
+  ///   consume and publish.
+  /// - **External query:** the reached artifact is a plain plist read —
+  ///   usable from another process while a hold deliberately stops the
+  ///   MainActor. Missing, malformed, wrong-trial, or wrong-boundary records
+  ///   all read as "not reached."
+  ///
+  /// Comments describe practical limits: the lock serializes THIS
+  /// controller's state; it does not make unrelated concurrent writers to the
+  /// shared `/tmp` paths impossible.
+  public final class CrashBoundaryFaultController: @unchecked Sendable {
+    public static let shared = CrashBoundaryFaultController(
+      armFilePath: "/tmp/com.enviouswispr.crash-boundary-arm",
+      reachedFilePath: "/tmp/com.enviouswispr.crash-boundary-reached")
+
+    private let armFilePath: String
+    private let reachedFilePath: String
+    private let lock = NSLock()
+    private var liveArm: (trialID: String, boundary: CrashBoundary)?
+    private var released = false
+    private var parkedHolds: [DispatchSemaphore] = []
+    /// Persistent E-gate: once `destruction_api_return` publishes (consuming
+    /// the arm), the key-delete pre-point must STILL gate until release/clear
+    /// — the process is meant to be frozen for the kill.
+    private var destructionAPIReturnGateActive = false
+
+    /// Test-only publication observer: invoked synchronously AFTER the
+    /// reached artifact is written and BEFORE the path parks — the
+    /// deterministic signal tests release on. Production never sets it.
+    public var onPublishForTesting: (@Sendable (CrashBoundary) -> Void)?
+
+    /// Test-only gate-decision observer for the `.beforeKeyDelete` pre-point:
+    /// `true` when the hit was gated, `false` when it passed. Fires before
+    /// the park. Production never sets it.
+    public var onKeyDeleteGateDecisionForTesting: (@Sendable (Bool) -> Void)?
+
+    /// Isolated instances (tests) take their own file paths; production uses
+    /// `.shared`. A new controller NEVER reads the on-disk artifacts to
+    /// activate an arm.
+    public init(armFilePath: String, reachedFilePath: String) {
+      self.armFilePath = armFilePath
+      self.reachedFilePath = reachedFilePath
+    }
+
+    // MARK: - Commands
+
+    /// Arm exactly one `(trialID, boundary)`. Returns true ONLY after the
+    /// in-process arm is live AND the arm artifact is durably written — the
+    /// acknowledgement the endpoint replies OK on. An empty trial ID fails.
+    public func arm(trialID: String, boundary: CrashBoundary) -> Bool {
+      guard !trialID.isEmpty else { return false }
+      let record = CrashBoundarySignalRecord(trialID: trialID, boundary: boundary.rawValue)
+      guard let data = try? PropertyListEncoder().encode(record) else { return false }
+      lock.lock()
+      defer { lock.unlock() }
+      do {
+        try data.write(to: URL(fileURLWithPath: armFilePath), options: .atomic)
+      } catch {
+        return false
+      }
+      liveArm = (trialID, boundary)
+      released = false
+      destructionAPIReturnGateActive = false
+      return true
+    }
+
+    /// Remove both artifacts, drop the live arm, and release every parked
+    /// hold/gate (the external harness also clears before each arm and after
+    /// each relaunch, because `kill -9` prevents in-process cleanup).
+    public func clear() {
+      let parked: [DispatchSemaphore] = lock.withLock {
+        liveArm = nil
+        released = true
+        destructionAPIReturnGateActive = false
+        let p = parkedHolds
+        parkedHolds = []
+        return p
+      }
+      for hold in parked { hold.signal() }
+      try? FileManager.default.removeItem(atPath: armFilePath)
+      try? FileManager.default.removeItem(atPath: reachedFilePath)
+    }
+
+    /// Test-only release: unblock every parked hold/gate WITHOUT touching the
+    /// artifacts (the test still wants to read the reached record). Never a
+    /// production escape hatch — nothing in production calls this.
+    public func releaseHeldForTesting() {
+      let parked: [DispatchSemaphore] = lock.withLock {
+        released = true
+        destructionAPIReturnGateActive = false
+        let p = parkedHolds
+        parkedHolds = []
+        return p
+      }
+      for hold in parked { hold.signal() }
+    }
+
+    // MARK: - Queries
+
+    /// The authoritative post-hold query: a direct file read of the reached
+    /// artifact requiring the EXACT pair. Static + file-based so an external
+    /// process can use it while a hold stops the MainActor.
+    public static func readReached(
+      trialID: String, boundary: CrashBoundary, reachedFilePath: String
+    ) -> Bool {
+      guard !trialID.isEmpty,
+        let data = try? Data(contentsOf: URL(fileURLWithPath: reachedFilePath)),
+        let record = try? PropertyListDecoder().decode(CrashBoundarySignalRecord.self, from: data)
+      else { return false }
+      return record.trialID == trialID && record.boundary == boundary.rawValue
+    }
+
+    /// Instance convenience over this controller's own reached path.
+    public func isReached(trialID: String, boundary: CrashBoundary) -> Bool {
+      Self.readReached(trialID: trialID, boundary: boundary, reachedFilePath: reachedFilePath)
+    }
+
+    /// Whether an arm is live in THIS process (diagnostics; never evidence of
+    /// "reached").
+    public var hasLiveArmForTesting: Bool { lock.withLock { liveArm != nil } }
+
+    // MARK: - The hook
+
+    /// Called from the five production hook sites. Unarmed or wrong-boundary
+    /// calls return immediately (pre-chunk behavior). A matching hit consumes
+    /// the arm, publishes the reached record, and PARKS the calling path until
+    /// kill/clear/test-release. While `destruction_api_return` is armed, a
+    /// `.beforeKeyDelete` hit is gated (parked, NOT consumed/published) so the
+    /// caller-side hook can prove the API returned first — in either schedule.
+    public func boundaryReached(_ boundary: CrashBoundary) {
+      enum Role { case none, consumed, gated(DispatchSemaphore) }
+      var role = Role.none
+      lock.lock()
+      if !released {
+        let mustGateKey =
+          boundary == .beforeKeyDelete
+          && (liveArm?.boundary == .destructionAPIReturn || destructionAPIReturnGateActive)
+        if mustGateKey {
+          // The E-gate: park the key path without consuming or publishing —
+          // in BOTH schedules (armed-not-yet-published, and already
+          // published via the persistent gate flag).
+          let gate = DispatchSemaphore(value: 0)
+          parkedHolds.append(gate)
+          role = .gated(gate)
+        } else if let arm = liveArm, arm.boundary == boundary {
+          // One-shot: claim the arm, consume its artifact, then publish.
+          liveArm = nil
+          try? FileManager.default.removeItem(atPath: armFilePath)
+          let record = CrashBoundarySignalRecord(
+            trialID: arm.trialID, boundary: boundary.rawValue)
+          if let data = try? PropertyListEncoder().encode(record),
+            (try? data.write(to: URL(fileURLWithPath: reachedFilePath), options: .atomic)) != nil
+          {
+            if boundary == .destructionAPIReturn {
+              destructionAPIReturnGateActive = true
+            }
+            role = .consumed
+          }
+          // Publication failure falls through with no reached claim and no
+          // hold — fail closed, never a permanent unobservable park.
+        }
+      }
+      lock.unlock()
+      switch role {
+      case .none:
+        if boundary == .beforeKeyDelete { onKeyDeleteGateDecisionForTesting?(false) }
+        return
+      case .gated(let gate):
+        onKeyDeleteGateDecisionForTesting?(true)
+        gate.wait()
+      case .consumed:
+        // Publication signal fires BEFORE the park so a test can release
+        // deterministically (and a released/cleared controller skips the
+        // park entirely — no lost-wakeup window).
+        onPublishForTesting?(boundary)
+        let hold: DispatchSemaphore? = lock.withLock {
+          if released { return nil }
+          let h = DispatchSemaphore(value: 0)
+          parkedHolds.append(h)
+          return h
+        }
+        hold?.wait()
+      }
+    }
+  }
+#endif

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -328,8 +328,8 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// carrying this session's `recoverySessionID` (captured from `context.config`
   /// BEFORE the terminal cleanup nulls it) and the terminal KIND (discard vs
   /// failure). The App's `DictationLifecycleCoordinator` routes it to
-  /// `RecoveryCoordinator` so a discarded recording's spool is deleted and a
-  /// failed recording's spool is RETAINED for next-launch recovery. Distinct
+  /// `RecoveryCoordinator`, which under the #1755 discard doctrine requests
+  /// best-effort deletion for every represented live ending. Distinct
   /// from `onStateChange` (which fires the externalError-pinnable public
   /// `PipelineState`): this keys off the RAW kernel terminal, so it never fires
   /// for `.completed` (a durable save already ran) and the error pin can't
@@ -374,14 +374,14 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// #1063 PR2 / #1464 — the origin attributed to the CURRENT session's
   /// `.cancelled` terminal. `.cancelled` is reached by BOTH a genuine user cancel
   /// (`RecordingFinalizer.cancel()` → `cancelRecording(disposition: .user)`) AND
-  /// fault/system cancels that route through `kernel.cancel()` (active `reset()`,
-  /// `setTerminalReason()`, the settings-rebuild cancel). A user cancel should
-  /// DELETE the spool; a fault cancel should RETAIN recoverable audio. Defaults to
-  /// `.systemOrFault` (RETAIN) so any cancel NOT explicitly attributed as a user
-  /// discard conservatively keeps the audio. Set at the `cancelRecording` call
-  /// site, consumed + reset at the `.cancelled` signal fire, and reset on each new
-  /// session start. Projected into `RecordingRecoveryEnding.cancelled(_)` for the
-  /// coordinator's delete-versus-retain predicate.
+  /// fault/system cancels that route through `kernel.cancel()` (active
+  /// `reset()`, `setTerminalReason()`). PROVENANCE only (#1755): both origins
+  /// delete at the coordinator; the distinction feeds diagnostics and copy.
+  /// Defaults to `.systemOrFault` so a cancel NOT explicitly attributed as a
+  /// user discard never masquerades as one. Set at the `cancelRecording` call
+  /// site, consumed + reset at the `.cancelled` signal fire, and reset on
+  /// each new session start. Projected into
+  /// `RecordingRecoveryEnding.cancelled(_)` for the coordinator's predicate.
   @ObservationIgnored
   private var pendingCancelOrigin: RecordingCancelOrigin = .systemOrFault
 
@@ -733,10 +733,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// on its own is fire-and-latch: it triggers the recording-exit path or sets
   /// `cancelRequested`, but the actual transition to `.cancelled` /
   /// `.discarded` happens on the forward path's next yield.
-  /// `disposition` (#1063 PR2 / #1464) attributes a `.cancelled` terminal for
-  /// crash recovery: `.user` (genuine USER cancel — delete the spool) vs the
-  /// default `.systemOrFault` (a system cancel — RETAIN recoverable audio). The
-  /// user-cancel path passes `.user`; system cancels use the retain default.
+  /// `disposition` (#1063 PR2 / #1464 / #1755) attributes a `.cancelled`
+  /// terminal's PROVENANCE for crash recovery: `.user` (genuine USER cancel)
+  /// vs the default `.systemOrFault` (a system/fault cancel). Both delete
+  /// under the #1755 discard doctrine — the origin is diagnostics/copy, not a
+  /// retain/delete fork. The user-cancel path passes `.user` explicitly.
   public func cancelRecording(disposition: RecordingCancelOrigin = .systemOrFault) async {
     pendingCancelOrigin = disposition
     kernel.cancel()
@@ -1070,10 +1071,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
         // closures to read at finalize time (the wiring's optional-chained
         // reads were always-nil in production until this PR — finding #6).
         lastTerminalReason = nil
-        // #1063 PR2: a fresh session starts with the conservative cancel origin
-        // (RETAIN) — only a genuine user cancel during this session flips it to
-        // `.user`. Prevents a stale user-discard from a prior session leaking onto
-        // this session's fault-cancel.
+        // #1063 PR2 / #1755: a fresh session starts at the `.systemOrFault`
+        // provenance default — only a genuine user cancel during this session
+        // flips it to `.user`, so a stale user attribution from a prior
+        // session can never leak onto this session's fault-cancel.
         pendingCancelOrigin = .systemOrFault
         outcome.transcript = nil
         outcome.polishError = nil
@@ -1318,13 +1319,12 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     lastEndedWithoutSaveSessionID = kernel.currentSessionID
     let ending: RecordingRecoveryEnding?
     if case .cancelled = outcome {
-      // `.cancelled` is ambiguous (Codex terminal-kind matrix): a genuine user
-      // cancel DELETES, but a fault/system cancel (active reset, external-error,
-      // settings rebuild) RETAINS recoverable audio. Resolve via the per-cancel
-      // origin attributed at the `kernel.cancel()` call site; consume + reset to
-      // the conservative default so a stale user-discard can't leak to a later
-      // fault cancel. The delete-versus-retain decision itself lives in the
-      // coordinator's predicate (#1464) — the driver only projects the origin.
+      // `.cancelled` carries per-cancel PROVENANCE (user vs system/fault),
+      // attributed at the `kernel.cancel()` call site; consume + reset to the
+      // default so a stale user attribution can't leak to a later fault
+      // cancel. Both origins delete under #1755 — the disposition decision
+      // lives solely in the coordinator's predicate; the driver only
+      // projects the origin.
       ending = .cancelled(pendingCancelOrigin)
       pendingCancelOrigin = .systemOrFault
     } else {
@@ -1357,7 +1357,7 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// whose retry was exhausted projects to the distinct `.asrRetryExhausted`
   /// ending (§4) so `RecoveryCoordinator` can delete that spool specifically
   /// — a pre-capture `.failed` (retry never consulted, `retryOutcome == nil`)
-  /// still projects to plain `.failed` and retains exactly as today. Codex r7:
+  /// still projects to plain `.failed` (#1755: which now deletes). Codex r7:
   /// `.asrInterrupted` honors the same exhausted-retry distinction, since the
   /// kernel's `interruptedTerminalFloor` can raise an exhausted-retry `.failed`
   /// into `.asrInterrupted` when an ASR-interruption salvage attempt preceded it.

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1355,9 +1355,9 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// all continue to get plain `.failed`. Only the ONE production call site
   /// above passes `kernel.asrRetryOutcome` explicitly. A `.failed` outcome
   /// whose retry was exhausted projects to the distinct `.asrRetryExhausted`
-  /// ending (§4) so `RecoveryCoordinator` can delete that spool specifically
-  /// — a pre-capture `.failed` (retry never consulted, `retryOutcome == nil`)
-  /// still projects to plain `.failed` (#1755: which now deletes). Codex r7:
+  /// ending (§4) as a typed diagnostic — under #1755 it AGREES with plain
+  /// `.failed` on deletion (a pre-capture or never-retried `.failed`,
+  /// `retryOutcome == nil`, projects to plain `.failed` and deletes too). Codex r7:
   /// `.asrInterrupted` honors the same exhausted-retry distinction, since the
   /// kernel's `interruptedTerminalFloor` can raise an exhausted-retry `.failed`
   /// into `.asrInterrupted` when an ASR-interruption salvage attempt preceded it.

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -144,11 +144,10 @@ public enum OverlayIntent: Equatable, Sendable {
   case bluetoothAwareness
 }
 
-/// The user-versus-fault attribution of a `.cancelled` recording terminal — the
-/// only outcome whose recovery disposition is ambiguous (#1464). A genuine user
-/// cancel DELETES the spool; a fault/system cancel RETAINS the recoverable audio.
-/// Kept narrow and public so the driver can project it across the Pipeline →
-/// AppKit boundary without leaking the internal `RecordingOutcome`.
+/// Typed cancellation PROVENANCE for a `.cancelled` terminal: who asked —
+/// the user, or the system/a fault. Under the #1755 discard doctrine both
+/// origins delete the recovery spool; the distinction survives for
+/// diagnostics and copy, not as a retain/delete fork.
 public enum RecordingCancelOrigin: Equatable, Sendable {
   case user
   case systemOrFault
@@ -159,15 +158,14 @@ public enum RecordingCancelOrigin: Equatable, Sendable {
 /// (and its `DiscardReason` / `NoSpeechSource` payloads) stays inside Pipeline;
 /// `KernelDictationDriver` maps the already-floored outcome into this before it
 /// crosses into AppKit, where `RecoveryCoordinator` applies the SOLE
-/// delete-versus-retain predicate:
+/// delete-versus-retain predicate.
 ///
-/// - delete: `.discarded`, `.noSpeech`, `.cancelled(.user)`, `.asrRetryExhausted`
-///   — nothing worth recovering, the user asked to drop it, or (#1707 Phase 2)
-///   this session spent and exhausted its one live retry over the exact same
-///   audio, so there is nothing left to recover on the next launch either.
-/// - retain: `.failed`, `.audioInterrupted`, `.asrInterrupted`, `.noTransport`,
-///   `.cancelled(.systemOrFault)` — the captured audio is the user's words; keep
-///   the spool so the next launch recovers it.
+/// #1755 (founder Gate 2 2026-07-23): EVERY represented non-saved live ending
+/// requests best-effort deletion — an ending fired means the app was alive, the
+/// user witnessed the outcome, and the one in-session rescue already ran.
+/// `.asrRetryExhausted` stays a distinct case for typed projection/diagnostic
+/// clarity even though it now agrees with `.failed` on deletion. Launch replay
+/// serves only the no-ending app-gone orphan (which never projects here).
 ///
 /// `.completed` is not representable here — a durable save has its own cleanup
 /// callback (`handleDurableSave`).
@@ -177,8 +175,7 @@ public enum RecordingRecoveryEnding: Equatable, Sendable {
   case failed
   /// #1707 Phase 2: a `.failed` session that spent and exhausted its one
   /// Phase-2 retry over the exact same already-captured audio. Distinct from
-  /// plain `.failed` (a pre-capture failure, or a `.failed` that never
-  /// consulted Phase 2) — only this case deletes the spool.
+  /// plain `.failed` for diagnostics; both delete under #1755.
   case asrRetryExhausted
   case audioInterrupted
   case asrInterrupted

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -3029,9 +3029,10 @@ final class RecordingSessionKernel {
   /// Routing differs by state because the recording-exit continuation is
   /// consumed once: in `.recording` we send through the channel so the
   /// forward-path coroutine sees the exit and runs unified cleanup; in
-  /// `.transcribing` the continuation is gone, so we go DIRECTLY to terminal.
-  /// Other states (.stopping, .finalizing, terminal) are unchanged from the
-  /// prior drop — out of scope for #7.
+  /// `.transcribing` (#1755 chunk 3) we freeze diagnostics and let the
+  /// suspended `finalize` fail into the existing Phase-2 retry — no direct
+  /// terminal. Other states (.stopping, .finalizing, terminal) are unchanged
+  /// from the prior drop — out of scope for #7.
   private func routeASRInterruption(sid: SessionID) {
     guard isCurrent(sid) else { return }
     // PR-4.5 §8: record the FSM state at callback time. The OLD pipeline's
@@ -3051,11 +3052,19 @@ final class RecordingSessionKernel {
       freezeRecordingSnapshot()
       deliverRecordingExit(.asrInterruption)
     case .delivering where deliveringPhase == .transcribing:
-      // Pre-transcript delivering — the continuation is gone, so conclude
-      // directly. `wasRecording: false` (not `.live`) folds in the observer's
-      // old `priorState == .recording` distinction (§3.7).
+      // #1755 chunk 3 (§3.4 Option B): do NOT conclude here. The forward
+      // coroutine is suspended on `await finalize(...)` and still owns the
+      // captured samples; the helper's death resolves that call as a failure
+      // (the #1755 chunk-1 drained continuation), which lands in the ordinary
+      // `.failed(let error)` switch and spends the ONE existing Phase-2
+      // retry. Publishing `.asrInterrupted(wasRecording: false)` first would
+      // preempt that rescue and race the losing signal (#1713, settled by not
+      // racing at all). Freeze the diagnostics snapshot and return — the
+      // session stays in `.delivering(.transcribing)` until its own decode
+      // resolves. Deliberately NOT stamping `interruptedSalvageSource = .asr`:
+      // that field means an interruption won while capture was still `.live`
+      // and would invoke the live-interruption terminal floor.
       freezeRecordingSnapshot()
-      finishTerminal(.asrInterrupted(wasRecording: false), sid: sid)
     default:
       // `.arming` / `.stopping` / `delivering(.finalizing(_))` (safe point) —
       // unchanged prior drop (out of scope for #7 / #1548).
@@ -3173,9 +3182,10 @@ final class RecordingSessionKernel {
     case .delivering:
       switch phase {
       case .transcribing:
-        // Old transcribing terminal edges. `.asrInterrupted(false)` is the
-        // pre-existing direct producer (routed from `delivering(.transcribing)`
-        // by a genuinely NEW interruption at that phase); `.asrInterrupted(true)`
+        // Old transcribing terminal edges. `.asrInterrupted(false)` is
+        // legacy/defensive legality only — #1755 chunk 3 removed its direct
+        // producer (a transcribe-phase interruption now lets the suspended
+        // finalize fail into the Phase-2 retry); `.asrInterrupted(true)`
         // is #1707's salvage-recovery-failure floor target, typed-gated below.
         switch outcome {
         case .failed, .noSpeech, .cancelled, .audioInterrupted:

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2243,20 +2243,14 @@ final class RecordingSessionKernel {
       // and eliminates the cross-session write for the stale one.
       guard isCurrent(sid), recordingOutcome == nil else { return }
       markASRTimingEnd()
-      // Codex r5: a TIMEOUT (`nil`) is NOT a confirmed second failure — the
-      // real decode call is still running in the background (no genuine
-      // in-flight cancellation exists on either backend, per the comment
-      // above) and could still succeed after our still-unmeasured placeholder
-      // deadline (§11.1) gave up waiting, especially for a long recording.
-      // Conflating "we stopped waiting" with "the decode genuinely produced
-      // nothing" would delete recoverable user audio. Leave
-      // `asrRetryOutcome` at `.attempted` (never promote to
-      // `.retryExhausted`) so `recoveryEnding`/`shouldDeleteOnLiveEnding`
-      // retain the spool exactly as a plain `.failed`. GitHub cloud review
-      // (PR #1725): `.cancelled` gets the SAME non-exhausted treatment
-      // below — only `.empty`/`.failed` are a confirmed decode conclusion
-      // with nothing useful; `.cancelled` means we have no conclusion at
-      // all, same as the timeout case here.
+      // A TIMEOUT (`nil`) is not a confirmed second failure — `.attempted`
+      // remains the honest diagnostic that no decode conclusion was accepted
+      // (never promoted to `.retryExhausted`), and the late-result fencing
+      // above stays unchanged. #1755 (founder Gate 2 2026-07-23): the
+      // DISPOSITION no longer follows that nuance — the user watched the
+      // live rescue visibly fail, so plain `.failed` now deletes at the
+      // coordinator like every concluded live ending. `.cancelled` gets the
+      // same treatment below.
       guard let retryOutcome else {
         finishTerminal(.failed(.asrFailed), sid: sid)
         return
@@ -2306,14 +2300,10 @@ final class RecordingSessionKernel {
         telemetryState.asrRetryOutcome = .retryExhausted
         finishTerminal(.failed(.asrFailed), sid: sid)
       case .cancelled:
-        // GitHub cloud review (PR #1725): `.cancelled` is NOT a confirmed
-        // second failure the way `.empty`/`.failed` are — both adapters can
-        // return it from a genuine backend `CancellationError` (a real
-        // Task/XPC cancellation mid-decode) with THIS session still
-        // current, not only from the staleness guard's own supersede path.
-        // Either way we have no confirmed decode conclusion, exactly the
-        // nil-timeout case above — leave `asrRetryOutcome` at `.attempted`
-        // so the spool is retained, never promoted to `.retryExhausted`.
+        // `.cancelled` is not a confirmed second failure — `.attempted`
+        // remains the honest no-conclusion diagnostic (same as the timeout
+        // case above, never promoted to `.retryExhausted`). #1755: the
+        // disposition deletes anyway; the visible live rescue failed.
         finishTerminal(.failed(.asrFailed), sid: sid)
       }
     }
@@ -2495,8 +2485,8 @@ final class RecordingSessionKernel {
     // so an empty result here is genuinely non-lexical (a bare filler / non-
     // speech artifact). End quietly as no-speech — never a heart-path failure
     // (mirrors the #979 asr-empty downgrade). If the capture was interrupted,
-    // `interruptedTerminalFloor` floors this to `.audioInterrupted` to retain
-    // the #1408 crash-recovery spool.
+    // `interruptedTerminalFloor` floors this to `.audioInterrupted` so the
+    // notice tells the truth (#1755: disposition is best-effort deletion).
     if processed.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
       finishTerminal(.noSpeech(.emptyAfterProcessing), sid: sid)
       return
@@ -2802,7 +2792,7 @@ final class RecordingSessionKernel {
   ///
   /// #1317 §3.2 / #1548 D2: routes by `ctx.failureMode` AND lifecycle state.
   /// - `.noBuffers` + no buffer ever (`bufferCountThisSession == 0`) → dead mic:
-  ///   `finishTerminal(.noTransport)` ("No audio captured", spool retained).
+  ///   `finishTerminal(.noTransport)` ("No audio captured"; #1755 disposition: best-effort deletion).
   /// - `.noBuffers` after a buffer arrived → `.captureStall` (routed via the
   ///   pending slot from `.arming`, `deliverRecordingExitIfCurrent` from `.live`).
   /// - `.allZeroFromStart` / `.becameZeroMidCapture` → the dedicated `.zeroSignal`
@@ -2818,7 +2808,7 @@ final class RecordingSessionKernel {
       // would override a latched stop. Honor the earlier winner.
       guard !stopLatched, !cancelRequested, !recordingExitLatched else { return }
       if bufferCountThisSession == 0 {
-        // Dead mic — no audio ever arrived. "No audio captured", spool retained.
+        // Dead mic — no audio ever arrived. "No audio captured" (#1755: deletes).
         finishTerminal(.noTransport, sid: currentSessionID)
       } else {
         // A buffer arrived, then the stream stalled. `.captureStall` must survive
@@ -3220,11 +3210,12 @@ final class RecordingSessionKernel {
     }
   }
 
-  /// #1408. On a session whose capture was interrupted, any terminal that would
-  /// DELETE the crash-recovery spool must instead land on `.audioInterrupted` — a
-  /// `.failure` terminal that RETAINS it, and precisely the terminal this session
-  /// reached before salvage existed. Salvage may only ever ADD a transcript; it
-  /// must never convert "recoverable on the next launch" into "gone."
+  /// #1408 / #1755. On a session whose capture was interrupted, the three
+  /// no-transcript terminals land on `.audioInterrupted` — the honest notice
+  /// ("the mic died"), precisely the terminal this session reached before
+  /// salvage existed. Salvage may only ever ADD a transcript. Since #1755
+  /// the floor decides the terminal/notice ONLY; disk disposition is
+  /// best-effort deletion for every concluded live ending.
   ///
   /// Applied ONCE, inside `finishTerminal`, never at the call sites: one of the
   /// terminals is computed from a ternary (`effectiveSpeechEvidence ?
@@ -3236,14 +3227,12 @@ final class RecordingSessionKernel {
   /// **One rule: an interrupted recording that ends with no transcript lands on
   /// `.audioInterrupted`, whatever interrupted it.**
   ///
-  /// `.discarded` / `.noSpeech` DELETE the spool (they project to a delete ending;
-  /// #1464). Letting an interrupted session reach either would destroy the
-  /// crash-recovery copy of audio the user can still get back on next launch —
-  /// converting "recoverable" into "gone." Safety does not get to depend on which
-  /// interruption fired, so this holds for every cause including the duration cap.
-  /// `.failed(.noAudioCaptured)` already retains the spool; it is folded in so all
-  /// three no-transcript endings agree, rather than one of them keeping a
-  /// different overlay for no reason a user could name.
+  /// #1755: the floor is about TERMINAL/NOTICE honesty, not disk retention —
+  /// every concluded live ending now requests best-effort deletion at the
+  /// coordinator. `.discarded` / `.noSpeech` would tell an interrupted user
+  /// "you said nothing" when their mic died mid-sentence; the floor lands all
+  /// three no-transcript endings on `.audioInterrupted` so the notice tells
+  /// the truth, whatever interruption fired (including the duration cap).
   ///
   /// This used to be TWO rules, the second gated on `cause.isDeviceLoss`, because
   /// `.audioInterrupted` rendered "Microphone disconnected" unconditionally and
@@ -3251,18 +3240,19 @@ final class RecordingSessionKernel {
   /// lives at its own single authority (#1558: the driver stamps a typed
   /// `TerminalNoticeReason` and `DictationNarrator` authors the copy), so
   /// the floor no longer has to encode a copy decision. What the terminal MEANS
-  /// (the spool survives) and what the user READS are separate questions with
-  /// separate owners — which is the same split `hasRecoverableAudio` and
-  /// `isDeviceLoss` draw one layer up.
+  /// and what the user READS are separate questions with separate owners —
+  /// the same split `hasRecoverableAudio` and `isDeviceLoss` draw one layer
+  /// up. (Since #1755 neither question decides retention.)
   ///
-  /// `.cancelled` is NEVER floored: an explicit user cancel is honored, and its
-  /// retain/delete disposition belongs to the driver's `pendingCancelOrigin`. Every other
-  /// `.failed(reason)` (`.asrEmpty`, `.asrFailed`, `.captureStartFailed`,
-  /// `.modelLoadFailed`) keeps its own honest reason and is already spool-retaining.
+  /// `.cancelled` is NEVER floored: an explicit user cancel is honored, and
+  /// its provenance belongs to the driver's `pendingCancelOrigin` (both
+  /// origins delete under #1755). Every other `.failed(reason)` (`.asrEmpty`,
+  /// `.asrFailed`, `.captureStartFailed`, `.modelLoadFailed`) keeps its own
+  /// honest reason.
   /// #1707: extended for the ASR-interruption salvage source. `.engine`
-  /// keeps the original, narrower protection (deletion-class outcomes only —
-  /// every other `.failed(reason)` already retains the spool on its own
-  /// honest terminal). `.asr` is WIDER by design: the salvage promises the
+  /// keeps the original, narrower honesty set (the three no-transcript
+  /// endings only — every other `.failed(reason)` keeps its own honest
+  /// terminal). `.asr` is WIDER by design: the salvage promises the
   /// SAME terminal every failure mode already produced before salvage
   /// existed, not just the deletion-class subset — restoring
   /// `.asrInterrupted(wasRecording: true)` for any outcome that isn't a
@@ -3985,12 +3975,12 @@ final class RecordingSessionKernel {
       lastStopReason = reason
     }
 
-    /// #1408: surface the terminal floor as a pure function so a test can prove it
-    /// covers EVERY outcome that would delete the spool. The floor's mapped set and
-    /// the coordinator's spool-deleting endings (`KernelDictationDriver.recovery
-    /// Ending` → `RecoveryCoordinator.shouldDeleteOnLiveEnding`, #1464) are two lists
-    /// of the same fact; without this seam they can drift, and a new spool-deleting
-    /// outcome would silently escape the floor.
+    /// #1408 / #1755: surface the terminal floor as a pure function so tests
+    /// can prove its terminal-honesty mapping (the exact three no-transcript
+    /// endings floor to `.audioInterrupted`; everything else passes through)
+    /// and that every non-completed projected ending requests deletion at the
+    /// coordinator. Stale interruption state would mislabel the next
+    /// terminal/notice — it can no longer retain a spool.
     func testInterruptedTerminalFloor(_ outcome: RecordingOutcome)
       -> RecordingOutcome
     {

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -3302,6 +3302,14 @@ final class RecordingSessionKernel {
         // just this one. Extending it would mean revisiting that cross-cutting
         // policy, out of scope here.
         telemetryState.asrSalvageOutcome = .cancelled
+        // #1709 (folded into #1755 chunk 4): a context-only breadcrumb for the
+        // formerly-invisible cancelled-during-ASR-salvage cell — no event, no
+        // captured error, no new telemetry owner. Fires ONLY here (the typed
+        // `.asr` source + `.cancelled` floor cell), never for ordinary or
+        // engine-interruption cancellation.
+        SentryBreadcrumb.add(
+          stage: "recovery", message: "asr_salvage_cancelled",
+          data: ["asr_salvage_outcome": "cancelled"])
         return outcome
       case .discarded, .noSpeech, .failed, .audioInterrupted, .asrInterrupted, .noTransport:
         // #1707 Codex code-diff r2: only UPGRADE the telemetry signal — a

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2472,10 +2472,20 @@ final class RecordingSessionKernel {
         self?.bump()
       }
     } catch {
+      // #1755 §3.2b: a THROWING text-processing step must not lose a
+      // transcript the app already has (heart rule
+      // preserve-raw-dictation-on-polish-error). Route the raw ASR through
+      // the sole recovery-floor authority: lexical raw text falls through to
+      // the ordinary store → deliver → `.completed` path below; filler-only/
+      // non-lexical raw text yields "" and lands on the quiet
+      // `.noSpeech(.emptyAfterProcessing)` branch. The error stays on the
+      // diagnostics side-channel either way.
       guard isCurrent(sid) else { return }
       telemetryState.transcriptionFailureError = error
-      finishTerminal(.failed(.emptyAfterProcessing), sid: sid)
-      return
+      processed = KernelFinalizationWiring.emptyOutputRecoveryFloor(
+        deterministicText: "",
+        rawASR: asrText
+      )
     }
     guard isCurrent(sid) else { return }
 

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -203,6 +203,13 @@ final class RecordingSessionKernel {
   /// no-op in production.
   private let batchDecodeFaultController: BatchDecodeFaultController?
 
+  #if DEBUG
+    /// #1755 chunk 6: crash-boundary hold seam. Defaults to the shared
+    /// controller (unarmed = every hook is a no-op); tests inject an isolated
+    /// instance. Compiled out of release entirely.
+    var crashBoundaryController: CrashBoundaryFaultController = .shared
+  #endif
+
   /// Logical-time seam (PR-3 plan §14a). Production wiring of a real clock is
   /// PR-4/PR-7; the simulator wires `FakeClock`.
   private let currentTick: @MainActor () -> UInt64
@@ -2295,9 +2302,18 @@ final class RecordingSessionKernel {
         telemetryState.transcriptionFailureError =
           (adapter as? ASREngineTelemetryProviding)?.lastFailureError ?? retryError
         telemetryState.asrRetryOutcome = .retryExhausted
+        #if DEBUG
+          // #1755 chunk 6: crash-boundary hold — after the diagnostic stamp,
+          // before terminal publication. Unarmed: no-op.
+          crashBoundaryController.boundaryReached(.retryExhaustionDecided)
+        #endif
         finishTerminal(.failed(.asrFailed), sid: sid)
       case .empty:  // genuinely resolved with nothing useful; exhausted
         telemetryState.asrRetryOutcome = .retryExhausted
+        #if DEBUG
+          // #1755 chunk 6: same crash boundary as the confirmed-failure branch.
+          crashBoundaryController.boundaryReached(.retryExhaustionDecided)
+        #endif
         finishTerminal(.failed(.asrFailed), sid: sid)
       case .cancelled:
         // `.cancelled` is not a confirmed second failure — `.attempted`
@@ -3337,6 +3353,11 @@ final class RecordingSessionKernel {
     }
     let terminal = outcome  // local alias for the existing telemetry logs below
     recordingOutcome = outcome
+    #if DEBUG
+      // #1755 chunk 6: crash-boundary hold — immediately after the set-once
+      // outcome write, before the idle transition and downstream cleanup.
+      crashBoundaryController.boundaryReached(.liveTerminalPublished)
+    #endif
     // #1548 D2: wake a forward path parked in `awaitRecordingExit()` when the
     // session is concluded DIRECTLY — the dead-mic `.noTransport` branch of
     // `externalCaptureStalled` calls `finishTerminal` while the forward path sits

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -48,8 +48,10 @@ public enum ApiKeyValidationSource: String, Sendable {
 }
 
 /// #1464 — the root cause behind one crash-recovery attempt's `recovery.completed`
-/// event. Closed + typed so the retain-vs-delete-on-failure policy (deferred to
-/// Phase 3) can be chosen from real field data instead of a coarse stage. Privacy:
+/// event. Closed + typed root-cause diagnostics. (#1755 settled the
+/// retain-vs-delete policy at Gate 2 — every concluded live ending discards —
+/// dissolving #1464's data-gated Phase 3; the typed causes remain for field
+/// diagnosis of the crash-only replay population.) Privacy:
 /// a category only — the underlying `NSError` domain/code/description is classifier
 /// INPUT and is NEVER emitted (`sentry-operations.md` telemetry-privacy boundary).
 public enum RecoveryTelemetryReason: String, Sendable {

--- a/Tests/EnviousWisprASRTests/ASRManagerProxyTranscribeCompletionTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerProxyTranscribeCompletionTests.swift
@@ -1,0 +1,295 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+
+/// #1755 §3.4 prerequisite — the pending batch-transcribe completion contract.
+///
+/// Same production defect class as #1388's load contract: a helper death
+/// mid-decode left `transcribe(audioSamples:)`'s continuation suspended
+/// forever, because the per-call XPC error handler is not guaranteed to fire
+/// for a pending reply and the death handlers could reach only
+/// `pendingLoadCompletion`. These tests pin the registry lifecycle — register
+/// → (reply | proxy error | current-era death) → exactly one resume →
+/// exact-key removal — through `awaitTranscribeReply`, the SINGLE
+/// implementation production's `transcribe(audioSamples:)` runs, so the tests
+/// exercise production's real registration/cleanup, not a copy. Death-handler
+/// waits use the factories' explicit `didFinishForTesting` completion signal
+/// (no clocks, no scheduling assumptions). The full integration (kill the
+/// real helper during a real decode) is runtime-only and lives in the #1755
+/// Live UAT Fork-2 legs.
+@MainActor
+@Suite("ASRManagerProxy — #1755 transcribe completion contract")
+struct ASRManagerProxyTranscribeCompletionTests {
+
+  private static func makeProxy() -> ASRManagerProxy {
+    ASRManagerProxy(engineMutationScope: .alwaysAllowedForTesting, connectionPreflight: { _ in })
+  }
+
+  /// A dummy connection used ONLY as an era-identity token; never resumed.
+  private static func dummyConnection() -> NSXPCConnection {
+    NSXPCConnection(serviceName: "com.enviouswispr.test.nonexistent")
+  }
+
+  /// Starts a REAL pending reply through the production helper: the returned
+  /// task is suspended inside `awaitTranscribeReply`, and this function
+  /// returns only after the registration is VISIBLE on the proxy (the helper
+  /// hands its guard to `start` synchronously after registering — that
+  /// hand-off is the signal).
+  private static func startPendingReply(
+    on proxy: ASRManagerProxy
+  ) async -> (
+    task: Task<Result<(Data?, NSError?), any Error>, Never>,
+    guard_: OneShotContinuationASR<(Data?, NSError?)>
+  ) {
+    var handed: CheckedContinuation<OneShotContinuationASR<(Data?, NSError?)>, Never>?
+    let task = Task { @MainActor in
+      do {
+        let value = try await proxy.awaitTranscribeReply { completion in
+          handed?.resume(returning: completion)
+        }
+        return Result<(Data?, NSError?), any Error>.success(value)
+      } catch {
+        return Result<(Data?, NSError?), any Error>.failure(error)
+      }
+    }
+    // MainActor FIFO: the spawned task cannot run until this body suspends
+    // below, and the suspension body installs `handed` first.
+    let guard_ = await withCheckedContinuation {
+      (c: CheckedContinuation<OneShotContinuationASR<(Data?, NSError?)>, Never>) in
+      handed = c
+    }
+    return (task, guard_)
+  }
+
+  /// Fires a death handler built with the explicit completion signal and
+  /// suspends until its `@MainActor` task has fully finished.
+  private static func fireAndAwait(
+    _ make: (ASRManagerProxy, NSXPCConnection, (@MainActor @Sendable () -> Void)?)
+      -> @Sendable () -> Void,
+    proxy: ASRManagerProxy, connection: NSXPCConnection
+  ) async {
+    await withCheckedContinuation { (done: CheckedContinuation<Void, Never>) in
+      nonisolated(unsafe) let doneBox = done
+      make(proxy, connection) { doneBox.resume() }()
+    }
+  }
+
+  // MARK: - Registration lifecycle through the production helper
+
+  @Test("normal reply completes exactly once and clears its registration")
+  func normalReplyClearsRegistration() async throws {
+    let proxy = Self.makeProxy()
+    let expected = Data([1, 2, 3])
+    let result = try await proxy.awaitTranscribeReply { completion in
+      completion.resume(returning: (expected, nil))
+    }
+    #expect(result.0 == expected)
+    #expect(result.1 == nil)
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+
+  @Test("per-call proxy error completes exactly once and clears its registration")
+  func proxyErrorExitClearsRegistration() async {
+    // No-op preflight → nil connection → the real `serviceProxy` nil branch
+    // fires `onProxyError` → serviceUnreachable, through the REAL
+    // `transcribe(audioSamples:)` entry point.
+    let proxy = Self.makeProxy()
+    do {
+      _ = try await proxy.transcribe(audioSamples: [0.1, 0.2], options: TranscriptionOptions())
+      Issue.record("transcribe must throw with no connection")
+    } catch {
+      #expect(error as? XPCASRTransportError == .serviceUnreachable)
+    }
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+
+  @Test("exact-key removal spares a concurrent pending operation")
+  func exactKeyRemovalSparesBystander() async throws {
+    let proxy = Self.makeProxy()
+    let bystander = await Self.startPendingReply(on: proxy)
+    #expect(proxy.pendingTranscribeCountForTesting == 1)
+    // A second operation completes normally; only ITS key is removed.
+    _ = try await proxy.awaitTranscribeReply { completion in
+      completion.resume(returning: (nil, nil))
+    }
+    #expect(proxy.pendingTranscribeCountForTesting == 1, "bystander registration must survive")
+    bystander.guard_.resume(throwing: XPCASRTransportError.serviceUnreachable)
+    let outcome = await bystander.task.value
+    guard case .failure(let error) = outcome else {
+      Issue.record("bystander should conclude with the thrown error")
+      return
+    }
+    #expect(error as? XPCASRTransportError == .serviceUnreachable)
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+
+  // MARK: - Current-era death drains
+
+  @Test("current-era interruption fails ALL registered transcriptions with serviceUnreachable")
+  func interruptionDrainsAllPending() async {
+    let proxy = Self.makeProxy()
+    let a = await Self.startPendingReply(on: proxy)
+    let b = await Self.startPendingReply(on: proxy)
+    let c = await Self.startPendingReply(on: proxy)
+    #expect(proxy.pendingTranscribeCountForTesting == 3)
+    // proxy.connection is nil → currentEraID == nil → the guard admits the
+    // handler (the "cleared with no successor" era case).
+    await Self.fireAndAwait(
+      {
+        ASRManagerProxy.makeInterruptionHandler(proxy: $0, connection: $1, didFinishForTesting: $2)
+      },
+      proxy: proxy, connection: Self.dummyConnection())
+    for pending in [a, b, c] {
+      let outcome = await pending.task.value
+      guard case .failure(let error) = outcome else {
+        Issue.record("expected serviceUnreachable, got a value")
+        continue
+      }
+      #expect(error as? XPCASRTransportError == .serviceUnreachable)
+    }
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+
+  @Test("current-era invalidation fails ALL registered transcriptions with serviceUnreachable")
+  func invalidationDrainsAllPending() async {
+    let proxy = Self.makeProxy()
+    let a = await Self.startPendingReply(on: proxy)
+    let b = await Self.startPendingReply(on: proxy)
+    #expect(proxy.pendingTranscribeCountForTesting == 2)
+    await Self.fireAndAwait(
+      {
+        ASRManagerProxy.makeInvalidationHandler(proxy: $0, connection: $1, didFinishForTesting: $2)
+      },
+      proxy: proxy, connection: Self.dummyConnection())
+    for pending in [a, b] {
+      let outcome = await pending.task.value
+      guard case .failure(let error) = outcome else {
+        Issue.record("expected serviceUnreachable, got a value")
+        continue
+      }
+      #expect(error as? XPCASRTransportError == .serviceUnreachable)
+    }
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+
+  // MARK: - Late replies after a death resume
+
+  @Test("late reply after interruption drain is dropped by the one-shot guard")
+  func lateReplyAfterInterruptionIgnored() async {
+    let proxy = Self.makeProxy()
+    let pending = await Self.startPendingReply(on: proxy)
+    await Self.fireAndAwait(
+      {
+        ASRManagerProxy.makeInterruptionHandler(proxy: $0, connection: $1, didFinishForTesting: $2)
+      },
+      proxy: proxy, connection: Self.dummyConnection())
+    let outcome = await pending.task.value
+    // The helper's reply arrives late; the one-shot guard must drop it.
+    pending.guard_.resume(returning: (Data(), nil))
+    guard case .failure(let error) = outcome else {
+      Issue.record("the death cause must win; the late reply must be dropped")
+      return
+    }
+    #expect(error as? XPCASRTransportError == .serviceUnreachable)
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+
+  @Test("late error after invalidation drain is dropped by the one-shot guard")
+  func lateReplyAfterInvalidationIgnored() async {
+    let proxy = Self.makeProxy()
+    let pending = await Self.startPendingReply(on: proxy)
+    await Self.fireAndAwait(
+      {
+        ASRManagerProxy.makeInvalidationHandler(proxy: $0, connection: $1, didFinishForTesting: $2)
+      },
+      proxy: proxy, connection: Self.dummyConnection())
+    let outcome = await pending.task.value
+    pending.guard_.resume(throwing: CancellationError())
+    guard case .failure(let error) = outcome else {
+      Issue.record("the death cause must win; the late error must be dropped")
+      return
+    }
+    #expect(error as? XPCASRTransportError == .serviceUnreachable)
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+
+  // MARK: - Era guard: retired handlers cannot touch a successor
+
+  @Test("a retired connection's interruption handler does not drain successor operations")
+  func retiredInterruptionCannotDrainSuccessor() async {
+    let proxy = Self.makeProxy()
+    let retired = Self.dummyConnection()
+    let successor = Self.dummyConnection()
+    proxy.setConnectionForTesting(successor)
+    defer { proxy.setConnectionForTesting(nil) }
+    let survivor = await Self.startPendingReply(on: proxy)
+    // Fire the RETIRED era's handler and wait for its task to fully finish;
+    // the era guard must reject the whole body.
+    await Self.fireAndAwait(
+      {
+        ASRManagerProxy.makeInterruptionHandler(proxy: $0, connection: $1, didFinishForTesting: $2)
+      },
+      proxy: proxy, connection: retired)
+    #expect(proxy.pendingTranscribeCountForTesting == 1, "successor operation must survive")
+    // Now the CURRENT era dies: the successor's own handler drains it.
+    await Self.fireAndAwait(
+      {
+        ASRManagerProxy.makeInvalidationHandler(proxy: $0, connection: $1, didFinishForTesting: $2)
+      },
+      proxy: proxy, connection: successor)
+    let outcome = await survivor.task.value
+    guard case .failure(let error) = outcome else {
+      Issue.record("expected serviceUnreachable after the current era died")
+      return
+    }
+    #expect(error as? XPCASRTransportError == .serviceUnreachable)
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+
+  @Test("a retired connection's invalidation handler does not drain successor operations")
+  func retiredInvalidationCannotDrainSuccessor() async {
+    let proxy = Self.makeProxy()
+    let retired = Self.dummyConnection()
+    let successor = Self.dummyConnection()
+    proxy.setConnectionForTesting(successor)
+    defer { proxy.setConnectionForTesting(nil) }
+    let survivor = await Self.startPendingReply(on: proxy)
+    await Self.fireAndAwait(
+      {
+        ASRManagerProxy.makeInvalidationHandler(proxy: $0, connection: $1, didFinishForTesting: $2)
+      },
+      proxy: proxy, connection: retired)
+    #expect(proxy.pendingTranscribeCountForTesting == 1, "successor operation must survive")
+    await Self.fireAndAwait(
+      {
+        ASRManagerProxy.makeInterruptionHandler(proxy: $0, connection: $1, didFinishForTesting: $2)
+      },
+      proxy: proxy, connection: successor)
+    let outcome = await survivor.task.value
+    guard case .failure(let error) = outcome else {
+      Issue.record("expected serviceUnreachable after the current era died")
+      return
+    }
+    #expect(error as? XPCASRTransportError == .serviceUnreachable)
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+
+  // MARK: - Load contract untouched
+
+  @Test("a death drain leaves the pending-load contract state untouched when no load is pending")
+  func drainWithNoPendingLoadIsSafe() async {
+    let proxy = Self.makeProxy()
+    let pending = await Self.startPendingReply(on: proxy)
+    #expect(proxy.hasPendingLoadCompletionForTesting == false)
+    await Self.fireAndAwait(
+      {
+        ASRManagerProxy.makeInterruptionHandler(proxy: $0, connection: $1, didFinishForTesting: $2)
+      },
+      proxy: proxy, connection: Self.dummyConnection())
+    _ = await pending.task.value
+    #expect(proxy.hasPendingLoadCompletionForTesting == false)
+    #expect(proxy.pendingTranscribeCountForTesting == 0)
+  }
+}

--- a/Tests/EnviousWisprASRTests/ASRManagerProxyTranscribeCompletionTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerProxyTranscribeCompletionTests.swift
@@ -292,4 +292,23 @@ struct ASRManagerProxyTranscribeCompletionTests {
     #expect(proxy.hasPendingLoadCompletionForTesting == false)
     #expect(proxy.pendingTranscribeCountForTesting == 0)
   }
+  // MARK: - Streaming finalize shares the registry (PR #1761 cloud P2)
+
+  @Test("a suspended streaming finalize is drained by a current-era interruption")
+  func streamingFinalizeDrainedOnInterruption() async {
+    let proxy = Self.makeProxy()
+    proxy.setStreamingForTesting(true)
+    // No connection → the registration happens, then serviceProxy fires
+    // onProxyError synchronously → serviceUnreachable through the SAME
+    // registry defer. The real drain path is proven by the shared-registry
+    // drain tests above; this pins that finalizeStreaming REGISTERS.
+    do {
+      _ = try await proxy.finalizeStreaming()
+      Issue.record("finalizeStreaming must throw with no connection")
+    } catch {
+      #expect(error as? XPCASRTransportError == .serviceUnreachable)
+    }
+    #expect(proxy.pendingTranscribeCountForTesting == 0, "registration cleared on exit")
+  }
+
 }

--- a/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
@@ -246,11 +246,11 @@ private final class SavedBox {
     }
 
     @Test(
-      "an interrupted empty finalize floors .noSpeech → .audioInterrupted (retain spool), else unchanged"
+      "an interrupted empty finalize floors .noSpeech → .audioInterrupted (honest terminal), else unchanged"
     )
     func interruptedEmptyFloorsToAudioInterrupted() {
       // With an interruption cause, the empty no-speech is floored UP so the
-      // #1408 crash-recovery spool is retained.
+      // #1408 honest interruption terminal; disk disposition is #1755 best-effort deletion.
       let interrupted = freshKernelAtFinalizing()
       interrupted.testSetInterruptionCause(.engineLost)
       #expect(

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
@@ -179,18 +179,19 @@ import Testing
       // `.live → .asrInterrupted` depends on the live recording-exit
       // continuation that the real forward path creates — the forced-state
       // fixture has no continuation, so this matrix freeze covers only
-      // `delivering(.transcribing)`, which concludes through `finishTerminal`
-      // directly. Recording-positive coverage lives in the kernel's
-      // external-entry scenario tests (`RecordingSessionKernelExternalInterruptionTests`).
+      // `delivering(.transcribing)`. #1755 chunk 3: that state ROUTES into the
+      // kernel and stays pending (the suspended decode's own failure enters
+      // the Phase-2 retry) — no early terminal, and no driver fallback error
+      // for a routable state. Retry behavior: `KernelPhase2RetryTests`.
       let fx = makeFixture()
       await place(fx.kernel, in: .deliveringTranscribing)
       fx.driver.handleASRServiceInterruption()
       await drain()
-      if case .asrInterrupted = fx.kernel.recordingOutcome {
-      } else {
-        Issue.record(
-          "asrInterruption from delivering(.transcribing) must conclude .asrInterrupted; got outcome \(String(describing: fx.kernel.recordingOutcome))"
-        )
+      #expect(fx.kernel.recordingOutcome == nil, "no early terminal from a routable state")
+      #expect(fx.kernel.state == .delivering)
+      #expect(fx.kernel.deliveringPhase == .transcribing)
+      if case .error = fx.driver.state {
+        Issue.record("the driver must not manufacture its fallback error for a routable state")
       }
     }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -55,6 +55,104 @@ struct KernelPhase2RetryTests {
     await ctx.wrapper.drainReadyWork()
   }
 
+  /// #1755 chunk 3 helper: stop with the held finalize suspended, await the
+  /// fake's registration signal (never scheduler timing), and return once the
+  /// kernel is genuinely parked in `.delivering(.transcribing)`.
+  private func stopIntoHeldFinalize(_ ctx: Context) async {
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    deliverVoicedCapture(ctx)
+    await ctx.wrapper.drainReadyWork()
+    var pendingSignal: CheckedContinuation<Void, Never>?
+    ctx.engine.onHeldFinalizePending = { pendingSignal?.resume() }
+    await ctx.wrapper.apply(.stop)
+    if !ctx.engine.heldFinalizePending {
+      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+        pendingSignal = c
+        if ctx.engine.heldFinalizePending { c.resume() }
+      }
+    }
+    ctx.engine.onHeldFinalizePending = nil
+  }
+
+  // MARK: #1755 chunk 3 — transcribe-phase helper death enters the SAME retry
+
+  @Test("helper death mid-decode routes into the one Phase-2 retry, and a successful retry delivers")
+  func helperDeathMidDecodeRetriesAndDelivers() async {
+    let ctx = makeContext(behavior: .heldFinalize)
+    ctx.engine.retryDecodeResult = .transcript(
+      ASRResult(
+        text: "rescued after death", language: nil, duration: 0, processingTime: 0,
+        backendType: .parakeet))
+    await stopIntoHeldFinalize(ctx)
+    let kernel = ctx.wrapper.testKernel
+    #expect(ctx.engine.heldFinalizePending, "the initial finalize must be genuinely suspended")
+    #expect(ctx.engine.finalizeCallCount == 1)
+
+    // Helper death arrives while the decode is suspended.
+    kernel.externalASRInterrupted()
+    await ctx.wrapper.drainReadyWork()
+
+    // No early terminal: the session keeps waiting for its own decode to fail.
+    #expect(kernel.recordingOutcome == nil, "no terminal may be published before finalize resolves")
+    #expect(kernel.state == .delivering)
+    #expect(kernel.deliveringPhase == .transcribing)
+    #expect(ctx.engine.retryDecodeCallCount == 0, "the retry must not start early")
+
+    // Chunk 1's drained continuation: the suspended decode now fails.
+    ctx.engine.resolveHeldFinalizeAsHelperDeath()
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.engine.finalizeCallCount == 1, "the initial decode ran exactly once")
+    #expect(
+      ctx.engine.recoverFromASRInterruptionCallCount == 0,
+      "this is NOT the .live Phase-1 rewarm path")
+    #expect(ctx.engine.retryDecodeCallCount == 1, "exactly one Phase-2 retry")
+    #expect(
+      !(ctx.engine.lastRetryDecodeInputSamples?.isEmpty ?? true),
+      "the retry decodes the captured audio, not an empty buffer")
+    #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .retrySucceeded)
+    #expect(kernel.recordingOutcome == .completed)
+    #expect(kernel.deliveredTranscript == "rescued after death")
+    #expect(ctx.wrapper.storedTexts == ["rescued after death"])
+    #expect(ctx.paste.pasteAttempts == ["rescued after death"])
+    #expect(ctx.paste.pasteCount == 1)
+    #expect(kernel.recordingOutcome != .asrInterrupted(wasRecording: false))
+  }
+
+  @Test("helper death mid-decode with an exhausted retry ends .asrFailed and projects .asrRetryExhausted")
+  func helperDeathMidDecodeExhaustsOnce() async {
+    let ctx = makeContext(behavior: .heldFinalize)
+    ctx.engine.retryDecodeResult = .failed(.decodeFailed)
+    await stopIntoHeldFinalize(ctx)
+    let kernel = ctx.wrapper.testKernel
+    #expect(ctx.engine.heldFinalizePending, "the initial finalize must be genuinely suspended")
+
+    kernel.externalASRInterrupted()
+    await ctx.wrapper.drainReadyWork()
+    #expect(kernel.recordingOutcome == nil, "no terminal may be published before finalize resolves")
+    #expect(kernel.state == .delivering)
+    #expect(kernel.deliveringPhase == .transcribing)
+    #expect(ctx.engine.retryDecodeCallCount == 0)
+
+    ctx.engine.resolveHeldFinalizeAsHelperDeath()
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(ctx.engine.finalizeCallCount == 1)
+    #expect(ctx.engine.recoverFromASRInterruptionCallCount == 0)
+    #expect(ctx.engine.retryDecodeCallCount == 1, "one retry, no second budget")
+    #expect(!(ctx.engine.lastRetryDecodeInputSamples?.isEmpty ?? true))
+    #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .retryExhausted)
+    #expect(kernel.recordingOutcome == .failed(.asrFailed))
+    #expect(
+      KernelDictationDriver.recoveryEnding(for: .failed(.asrFailed), retryOutcome: .retryExhausted)
+        == .asrRetryExhausted)
+    #expect(ctx.wrapper.storedTexts.isEmpty, "storage receives zero calls")
+    #expect(ctx.paste.pasteAttempts.isEmpty, "the delivery seam is never called")
+    #expect(kernel.deliveredTranscript == nil)
+    #expect(kernel.pasteCount == 0)
+  }
+
   @Test("a decode failure spends exactly one retry, and a successful retry delivers its own text")
   func decodeFailureRetriesOnceAndDelivers() async {
     let ctx = makeContext(behavior: .crashOnFinalize)

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -2,6 +2,7 @@ import EnviousWisprCore
 import Foundation
 import Testing
 
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprPipeline
 
 // MARK: - #1707 Phase 2 — one live post-capture decode retry (kernel routing)
@@ -185,9 +186,9 @@ struct KernelPhase2RetryTests {
   }
 
   @Test(
-    "GitHub cloud review (PR #1725): a retry that resolves .cancelled (a genuine backend CancellationError, not a confirmed decode conclusion) still terminates as .asrFailed but retains the spool, same as a timeout"
+    "#1755 founder override: a retry that resolves .cancelled still terminates .asrFailed, stays diagnostically .attempted, and now DELETES"
   )
-  func cancelledRetryTerminatesButRetainsSpool() async {
+  func cancelledRetryTerminatesAndDeletes() async {
     let ctx = makeContext(behavior: .crashOnFinalize)
     ctx.engine.retryDecodeResult = .cancelled
     await runToTerminal(ctx)
@@ -195,18 +196,26 @@ struct KernelPhase2RetryTests {
 
     #expect(kernel.recordingOutcome == .failed(.asrFailed))
     #expect(kernel.deliveredTranscript == nil)
-    #expect(ctx.engine.retryDecodeCallCount == 1)
-    // The distinguishing assertion: NOT .retryExhausted — `.cancelled` is
-    // not a confirmed "the decode produced nothing," so the spool must be
-    // retained exactly like the timeout case above, not deleted like a
-    // genuine `.empty`/`.failed` exhaustion.
+    #expect(ctx.wrapper.storedTexts.isEmpty)
+    #expect(ctx.paste.pasteAttempts.isEmpty)
+    #expect(ctx.engine.retryDecodeCallCount == 1, "retry budget unchanged: exactly one")
+    // `.attempted` remains the honest diagnostic that no decode conclusion
+    // was accepted (late-result fencing unchanged); the founder's Gate 2
+    // decision makes the DISPOSITION delete anyway — the user watched the
+    // retry fail and re-dictates.
     #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .attempted)
+    let ending = KernelDictationDriver.recoveryEnding(
+      for: .failed(.asrFailed), retryOutcome: .attempted)
+    #expect(ending == .failed, "projects to plain .failed")
+    #expect(
+      RecoveryCoordinator.shouldDeleteOnLiveEnding(.failed),
+      "#1755: the composed authorities delete")
   }
 
   @Test(
-    "#1707 Codex r5: a retry that times out (never resolves) still terminates as .asrFailed but retains the spool, distinct from a genuinely exhausted retry"
+    "#1755 founder override: a retry that times out still terminates .asrFailed, stays diagnostically .attempted, and now DELETES"
   )
-  func timedOutRetryTerminatesButRetainsSpool() async {
+  func timedOutRetryTerminatesAndDeletes() async {
     let ctx = makeContext(behavior: .crashOnFinalize)
     // A real, tiny wall-clock deadline — the retry never resolves within it
     // (the fake-clock delay is never advanced during this test), so
@@ -226,13 +235,22 @@ struct KernelPhase2RetryTests {
     }
 
     #expect(kernel.recordingOutcome == .failed(.asrFailed))
-    #expect(ctx.engine.bumpRetryGenerationCallCount == 1)
-    // The distinguishing assertion (Codex r5): NOT .retryExhausted. A mere
-    // timeout must never be conflated with a confirmed second failure — the
-    // underlying decode call is still running with no genuine cancellation,
-    // and deleting the spool now could discard audio a slower-but-healthy
-    // retry would have recovered.
+    #expect(kernel.deliveredTranscript == nil)
+    #expect(ctx.wrapper.storedTexts.isEmpty, "zero storage")
+    #expect(ctx.paste.pasteAttempts.isEmpty, "zero delivery")
+    #expect(kernel.pasteCount == 0, "zero paste")
+    #expect(ctx.engine.retryDecodeCallCount == 1, "exactly one retry, no second budget")
+    #expect(ctx.engine.bumpRetryGenerationCallCount == 1, "late-result fencing unchanged")
+    // `.attempted` (not .retryExhausted) remains the honest diagnostic: we
+    // stopped waiting, no conclusion was accepted. The founder's Gate 2
+    // decision deletes anyway — the visible live rescue failed.
     #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .attempted)
+    let ending = KernelDictationDriver.recoveryEnding(
+      for: .failed(.asrFailed), retryOutcome: .attempted)
+    #expect(ending == .failed, "projects to plain .failed")
+    #expect(
+      RecoveryCoordinator.shouldDeleteOnLiveEnding(.failed),
+      "#1755: the composed authorities delete")
   }
 
   @Test(

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -155,6 +155,7 @@ struct KernelPhase2RetryTests {
   }
 
 
+#if DEBUG
   // MARK: - #1755 chunk 6 — crash-boundary hook lockstep (kernel side)
 
   private static func makeIsolatedBoundaryController() -> CrashBoundaryFaultController {
@@ -246,6 +247,8 @@ struct KernelPhase2RetryTests {
     #expect(ctx.wrapper.testKernel.recordingOutcome == .completed)
     #expect(ctx.paste.pasteCount == 1)
   }
+
+#endif
 
   @Test("a decode failure spends exactly one retry, and a successful retry delivers its own text")
   func decodeFailureRetriesOnceAndDelivers() async {

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -154,6 +154,99 @@ struct KernelPhase2RetryTests {
     #expect(kernel.pasteCount == 0)
   }
 
+
+  // MARK: - #1755 chunk 6 — crash-boundary hook lockstep (kernel side)
+
+  private static func makeIsolatedBoundaryController() -> CrashBoundaryFaultController {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-cb-kernel-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return CrashBoundaryFaultController(
+      armFilePath: dir.appendingPathComponent("arm").path,
+      reachedFilePath: dir.appendingPathComponent("reached").path)
+  }
+
+  /// Snapshot box the publication callback (fires on the hook's own thread,
+  /// before the park) writes into; the callback releases the hold immediately
+  /// so the flow completes — deterministic, no polling.
+  private final class BoundarySnapshot: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _fired = 0
+    private var _outcomeWasNil: Bool?
+    var fired: Int { lock.withLock { _fired } }
+    var outcomeWasNil: Bool? { lock.withLock { _outcomeWasNil } }
+    func record(outcomeWasNil: Bool) {
+      lock.withLock {
+        _fired += 1
+        if _outcomeWasNil == nil { _outcomeWasNil = outcomeWasNil }
+      }
+    }
+  }
+
+  @Test("retry_exhaustion_decided fires after the diagnostic stamp, before terminal publication")
+  func retryExhaustionBoundaryHook() async {
+    let ctx = makeContext(behavior: .crashOnFinalize)
+    ctx.engine.retryDecodeResult = .failed(.decodeFailed)
+    let controller = Self.makeIsolatedBoundaryController()
+    ctx.wrapper.testKernel.crashBoundaryController = controller
+    defer { controller.clear() }
+    let snapshot = BoundarySnapshot()
+    let kernel = ctx.wrapper.testKernel
+    controller.onPublishForTesting = { _ in
+      // The hook fires on the kernel's MainActor context, synchronously.
+      MainActor.assumeIsolated {
+        snapshot.record(outcomeWasNil: kernel.recordingOutcome == nil)
+      }
+      controller.releaseHeldForTesting()
+    }
+    #expect(controller.arm(trialID: "kb1", boundary: .retryExhaustionDecided))
+
+    await runToTerminal(ctx)
+
+    #expect(snapshot.fired == 1, "the boundary published exactly once")
+    #expect(
+      snapshot.outcomeWasNil == true,
+      "at the boundary the terminal was NOT yet published (hook sits before finishTerminal)")
+    #expect(controller.isReached(trialID: "kb1", boundary: .retryExhaustionDecided))
+    #expect(ctx.wrapper.telemetryState.asrRetryOutcome == .retryExhausted, "after the stamp")
+    #expect(kernel.recordingOutcome == .failed(.asrFailed))
+  }
+
+  @Test("live_terminal_published fires exactly once, after the set-once outcome write")
+  func liveTerminalBoundaryHook() async {
+    let ctx = makeContext(behavior: .batchSuccess(text: "hello"))
+    let controller = Self.makeIsolatedBoundaryController()
+    ctx.wrapper.testKernel.crashBoundaryController = controller
+    defer { controller.clear() }
+    let snapshot = BoundarySnapshot()
+    let kernel = ctx.wrapper.testKernel
+    controller.onPublishForTesting = { _ in
+      MainActor.assumeIsolated {
+        snapshot.record(outcomeWasNil: kernel.recordingOutcome == nil)
+      }
+      controller.releaseHeldForTesting()
+    }
+    #expect(controller.arm(trialID: "kb2", boundary: .liveTerminalPublished))
+
+    await runToTerminal(ctx)
+
+    #expect(snapshot.fired == 1, "one-shot: fired exactly once")
+    #expect(
+      snapshot.outcomeWasNil == false,
+      "at the boundary recordingOutcome was ALREADY set (hook sits after the set-once write)")
+    #expect(controller.isReached(trialID: "kb2", boundary: .liveTerminalPublished))
+    #expect(!controller.hasLiveArmForTesting, "consumed exactly once")
+  }
+
+  @Test("unarmed sessions retain the exact pre-chunk behavior and never block")
+  func unarmedBoundaryControllerIsInert() async {
+    let ctx = makeContext(behavior: .batchSuccess(text: "hello"))
+    ctx.wrapper.testKernel.crashBoundaryController = Self.makeIsolatedBoundaryController()
+    await runToTerminal(ctx)
+    #expect(ctx.wrapper.testKernel.recordingOutcome == .completed)
+    #expect(ctx.paste.pasteCount == 1)
+  }
+
   @Test("a decode failure spends exactly one retry, and a successful retry delivers its own text")
   func decodeFailureRetriesOnceAndDelivers() async {
     let ctx = makeContext(behavior: .crashOnFinalize)

--- a/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelTerminalKindTests.swift
@@ -2,6 +2,7 @@ import EnviousWisprCore
 import Foundation
 import Testing
 
+@testable import EnviousWisprAppKit
 @testable import EnviousWisprPipeline
 
 /// #1063 PR2 / #1548 D1 / #1464 — the driver projects each concluded session's
@@ -122,5 +123,52 @@ struct KernelTerminalKindTests {
   @Test(".completed never fires the signal (durable save ran)")
   func completedIsNil() {
     #expect(KernelDictationDriver.recoveryEnding(for: .completed) == nil)
+  }
+}
+
+// MARK: - #1755 chunk 5 — ending × retry-outcome composed through both real authorities
+
+/// Proves the existing projection collapse is CORRECT under the discard
+/// doctrine: every retry-outcome cell of `.failed(.asrFailed)` and both
+/// `.asrInterrupted` payloads project to an ending the coordinator deletes.
+@MainActor
+@Suite("Ending × retry-outcome composed matrix (#1755)")
+struct EndingRetryOutcomeComposedMatrixTests {
+  private func composedDelete(
+    _ outcome: RecordingOutcome, _ retry: ASRRetryOutcome?
+  ) -> (ending: RecordingRecoveryEnding?, deletes: Bool) {
+    let ending = KernelDictationDriver.recoveryEnding(for: outcome, retryOutcome: retry)
+    guard let ending else { return (nil, false) }
+    return (ending, RecoveryCoordinator.shouldDeleteOnLiveEnding(ending))
+  }
+
+  @Test(".failed(.asrFailed): all four retry-outcome cells project and delete")
+  func failedAllRetryCellsDelete() {
+    #expect(composedDelete(.failed(.asrFailed), nil) == (.failed, true))
+    #expect(composedDelete(.failed(.asrFailed), .attempted) == (.failed, true))
+    #expect(composedDelete(.failed(.asrFailed), .retrySucceeded) == (.failed, true))
+    #expect(composedDelete(.failed(.asrFailed), .retryExhausted) == (.asrRetryExhausted, true))
+  }
+
+  @Test(".asrInterrupted (both payloads): all four retry-outcome cells project and delete")
+  func asrInterruptedAllRetryCellsDelete() {
+    for wasRecording in [true, false] {
+      let outcome = RecordingOutcome.asrInterrupted(wasRecording: wasRecording)
+      #expect(composedDelete(outcome, nil) == (.asrInterrupted, true))
+      #expect(composedDelete(outcome, .attempted) == (.asrInterrupted, true))
+      #expect(composedDelete(outcome, .retrySucceeded) == (.asrInterrupted, true))
+      #expect(composedDelete(outcome, .retryExhausted) == (.asrRetryExhausted, true))
+    }
+  }
+
+  @Test("characterization: .completed and static .cancelled stay outside the predicate")
+  func completedAndStaticCancelledProjectNil() {
+    #expect(KernelDictationDriver.recoveryEnding(for: .completed) == nil)
+    #expect(KernelDictationDriver.recoveryEnding(for: .cancelled) == nil)
+    // Both DYNAMIC cancel origins delete when presented to the coordinator.
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.cancelled(.user)))
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.cancelled(.systemOrFault)))
+    // No-ending/app-gone has no predicate invocation by construction — there
+    // is no synthetic ending to test, which is the point.
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelExternalInterruptionTests.swift
@@ -127,20 +127,30 @@ import Testing
       #expect(kernel.lastASRSalvageOutcome == .rewarmSucceeded)
     }
 
-    @Test("externalASRInterrupted while delivering(.transcribing) records wasRecording false")
-    func asrInterruptedWhileTranscribingCarriesFalse() {
+    @Test("externalASRInterrupted while delivering(.transcribing) publishes NO early terminal")
+    func asrInterruptedWhileTranscribingStaysPending() {
+      // #1755 chunk 3: a helper death during the transcribe phase no longer
+      // concludes the session directly — the suspended decode's own failure
+      // (Chunk 1's drained continuation) enters the Phase-2 retry instead.
+      // This forced-state routing test pins ONLY the routing: no terminal, no
+      // synthesized success, session parked exactly where it was. The real
+      // retry behavior lives in `KernelPhase2RetryTests`.
       let (_, wrapper) = makeWrapper()
       let kernel = wrapper.testKernel
 
-      // The ASR-service crash arriving during the transcribe phase (not `.live`)
-      // must stamp `wasRecording: false`, the distinction `isLegalConclusion`
-      // enforces per state.
       kernel.testForceState(.delivering)
       kernel.testSetDeliveringPhase(.transcribing)
+      #expect(kernel.testGetRecordingSnapshot() == nil, "no snapshot before the interruption")
 
       kernel.externalASRInterrupted()
 
-      #expect(kernel.recordingOutcome == .asrInterrupted(wasRecording: false))
+      #expect(
+        kernel.testGetRecordingSnapshot() != nil,
+        "the diagnostics snapshot must be frozen at routing time")
+      #expect(kernel.recordingOutcome == nil, "no early terminal")
+      #expect(kernel.state == .delivering)
+      #expect(kernel.deliveringPhase == .transcribing)
+      #expect(kernel.deliveredTranscript == nil, "nothing may be synthesized")
     }
 
     @Test(

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
@@ -152,6 +152,68 @@ struct ExhaustedRetrySpoolDeletionTests {
     // always holds the samples, so no interruption cause is unsalvageable. The
     // salvage-succeeds path is covered by the salvage tests below.
 
+    // MARK: 1b. #1755 chunk 2 — a text-processing throw must not lose usable raw ASR
+
+    /// North Star point 3: a transcript the app already has is never thrown
+    /// away when raw text can be delivered. A throwing `processText` used to
+    /// publish `.failed(.emptyAfterProcessing)` BEFORE storage or delivery;
+    /// it now routes the raw ASR through the sole recovery-floor authority
+    /// (`KernelFinalizationWiring.emptyOutputRecoveryFloor`) and, when
+    /// lexical, follows the ordinary store → deliver → `.completed` path.
+    @Test("a processText throw with lexical raw ASR stores and delivers the raw text once")
+    func processTextThrowLexicalRawDelivers() async {
+      let (context, wrapper) = makeWrapper(behavior: .batchSuccess(text: "raw text"))
+      wrapper.testProcessTextThrows()
+      let kernel = wrapper.testKernel
+
+      await startRecording(context)
+      await context.sut.apply(.stop)
+      await wrapper.drainReadyWork()
+
+      #expect(
+        wrapper.telemetryState.transcriptionFailureError as? KernelLimbError
+          == .emptyAfterProcessing,
+        "the exact processing error must remain on the diagnostics side-channel")
+      #expect(wrapper.storedTexts == ["raw text"], "storage receives exactly the raw ASR")
+      #expect(
+        context.paste.pasteAttempts == ["raw text"],
+        "the delivery seam is called exactly once with the raw ASR")
+      #expect(context.paste.pasteCount == 1, "delivery happens exactly once")
+      #expect(kernel.deliveredTranscript == "raw text")
+      #expect(kernel.recordingOutcome == .completed)
+      #expect(
+        KernelDictationDriver.recoveryEnding(for: .completed) == nil,
+        "a completed dictation requests no ended-without-save recovery ending")
+      #expect(kernel.recordingOutcome != .failed(.emptyAfterProcessing))
+    }
+
+    /// The quiet twin: filler-only raw ASR has nothing worth saving — the
+    /// floor returns empty and the session ends `.noSpeech(.emptyAfterProcessing)`
+    /// with zero storage and zero delivery (never `.completed`, never `.failed`).
+    @Test("a processText throw with filler-only raw ASR ends quietly as no-speech")
+    func processTextThrowFillerOnlyEndsNoSpeech() async {
+      let (context, wrapper) = makeWrapper(behavior: .batchSuccess(text: "uh"))
+      wrapper.testProcessTextThrows()
+      let kernel = wrapper.testKernel
+
+      await startRecording(context)
+      await context.sut.apply(.stop)
+      await wrapper.drainReadyWork()
+
+      #expect(
+        wrapper.telemetryState.transcriptionFailureError as? KernelLimbError
+          == .emptyAfterProcessing,
+        "the exact processing error must remain on the diagnostics side-channel")
+      #expect(kernel.recordingOutcome == .noSpeech(.emptyAfterProcessing))
+      #expect(wrapper.storedTexts.isEmpty, "storage receives zero calls")
+      #expect(context.paste.pasteAttempts.isEmpty, "the delivery seam is never called")
+      #expect(kernel.deliveredTranscript == nil)
+      #expect(kernel.recordingOutcome != .completed)
+      if case .failed = kernel.recordingOutcome {
+        Issue.record("a filler-only processing throw must never be a .failed terminal")
+      }
+    }
+
     // MARK: 2. The floor — salvage never deletes a spool today's code would keep
 
     /// The pair that proves the floor. Same early terminal (`bufferCount == 0`

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
@@ -1,5 +1,6 @@
 import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 import Testing
 
@@ -212,6 +213,53 @@ struct ExhaustedRetrySpoolDeletionTests {
       if case .failed = kernel.recordingOutcome {
         Issue.record("a filler-only processing throw must never be a .failed terminal")
       }
+    }
+
+    // MARK: 1c. #1755 chunk 4 — #1709 salvage-cancelled breadcrumb (exact cell only)
+
+    /// ONE synchronous MainActor test with no suspension points: the
+    /// process-global SentryBreadcrumb delegate is swapped in, every cell is
+    /// driven synchronously, and the PRIOR delegate is preserved, forwarded
+    /// unrelated breadcrumbs, and restored. The no-suspension window is the
+    /// real protection — a previously installed delegate survives; a truly
+    /// concurrent writer to the same global could still race it, which this
+    /// test cannot prevent.
+    @Test("the .asr + .cancelled floor cell emits exactly one asr_salvage_cancelled breadcrumb; siblings stay silent")
+    func asrSalvageCancelledBreadcrumbExactCellOnly() {
+      nonisolated(unsafe) var matches: [[String: String]] = []
+      let prior = SentryBreadcrumb.breadcrumbDelegate
+      SentryBreadcrumb.breadcrumbDelegate = { stage, message, level, data in
+        guard message == "asr_salvage_cancelled" else {
+          prior?(stage, message, level, data)  // forward unrelated crumbs
+          return
+        }
+        matches.append(
+          ["stage": stage]
+            .merging((data ?? [:]).compactMapValues { $0 as? String }) { a, _ in a })
+      }
+      defer { SentryBreadcrumb.breadcrumbDelegate = prior }
+
+      // Eligible cell: .asr source + .cancelled.
+      let (_, eligible) = makeWrapper()
+      eligible.telemetryState.interruptedSalvageSource = .asr
+      let floored = eligible.testKernel.testInterruptedTerminalFloor(.cancelled)
+      #expect(floored == .cancelled, "the terminal itself is unchanged")
+      #expect(eligible.telemetryState.asrSalvageOutcome == .cancelled)
+      #expect(matches.count == 1, "exactly one breadcrumb for the eligible cell")
+      #expect(
+        matches.first == ["stage": "recovery", "asr_salvage_outcome": "cancelled"],
+        "exact shape: stage recovery + the single data field")
+
+      // Adversarial siblings, same delegate, still synchronous.
+      let (_, sibling1) = makeWrapper()
+      sibling1.telemetryState.interruptedSalvageSource = .asr
+      _ = sibling1.testKernel.testInterruptedTerminalFloor(.failed(.asrFailed))
+      let (_, sibling2) = makeWrapper()
+      sibling2.telemetryState.interruptedSalvageSource = .engine(.deviceRemoved)
+      _ = sibling2.testKernel.testInterruptedTerminalFloor(.cancelled)
+      let (_, sibling3) = makeWrapper()
+      _ = sibling3.testKernel.testInterruptedTerminalFloor(.cancelled)
+      #expect(matches.count == 1, "no sibling cell may emit the salvage-cancelled breadcrumb")
     }
 
     // MARK: 2. The floor — salvage never deletes a spool today's code would keep

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelSalvageTests.swift
@@ -30,53 +30,56 @@ private func deletesRecoverySpool(_ outcome: RecordingOutcome, retryOutcome: ASR
   return RecoveryCoordinator.shouldDeleteOnLiveEnding(ending)
 }
 
-/// #1707 Phase 2: an exhausted Phase-2 retry deletes its spool — the decode
-/// genuinely never produced anything, so there is nothing worth recovering
-/// (§4/§6). The negative (RULE: matcher-set-adversarial-tests): a pre-capture
-/// or never-retried `.asrFailed` — `retryOutcome == nil`, exactly the default
-/// every existing call site above already exercises — still retains.
+/// #1755 discard doctrine: EVERY `.failed` deletes, whatever the retry
+/// outcome — an ending fired while the app was alive, the user witnessed the
+/// failure and re-dictates. `.asrRetryExhausted` stays a distinct typed
+/// projection for diagnostics; it now AGREES with `.failed` on deletion.
 @MainActor
-@Suite("Exhausted-retry spool deletion (#1707 Phase 2)")
+@Suite("Failed-session spool deletion (#1707 Phase 2 → #1755 cutover)")
 struct ExhaustedRetrySpoolDeletionTests {
-  @Test("an exhausted retry's failed session deletes its spool")
+  @Test("an exhausted retry's failed session deletes its spool (unchanged)")
   func exhaustedRetryDeletes() {
     #expect(deletesRecoverySpool(.failed(.asrFailed), retryOutcome: .retryExhausted))
   }
 
-  @Test("a pre-capture or never-retried failed session still retains its spool")
-  func neverRetriedFailureRetains() {
-    #expect(!deletesRecoverySpool(.failed(.asrFailed), retryOutcome: nil))
-    #expect(!deletesRecoverySpool(.failed(.asrFailed)))
+  @Test("a pre-capture or never-retried failed session deletes too (#1755 flipped)")
+  func neverRetriedFailureDeletes() {
+    #expect(deletesRecoverySpool(.failed(.asrFailed), retryOutcome: nil))
+    #expect(deletesRecoverySpool(.failed(.asrFailed)))
   }
 
-  @Test("a retry left at .attempted by a preempting interruption does not delete as .failed")
-  func attemptedOnlyRetryDoesNotDeleteAsFailed() {
-    #expect(!deletesRecoverySpool(.failed(.asrFailed), retryOutcome: .attempted))
+  @Test("a retry left at .attempted (timeout/cancel) deletes as plain .failed (#1755 founder override)")
+  func attemptedOnlyRetryDeletesAsFailed() {
+    // `.attempted` remains the honest diagnostic that no decode conclusion
+    // was accepted; the founder's Gate 2 decision makes it delete anyway —
+    // a visible retry failure is a failure to the user.
+    #expect(deletesRecoverySpool(.failed(.asrFailed), retryOutcome: .attempted))
   }
 }
 
 // MARK: - #1408 — salvage a dictation whose capture was interrupted mid-recording
 //
-// Before this change, a microphone that died mid-sentence sent the recording
+// Before #1408, a microphone that died mid-sentence sent the recording
 // straight to `.audioInterrupted` and the audio the capture manager was still
 // holding was never transcribed. Now a salvageable interruption falls through
 // into the normal stop tail.
 //
-// Two properties are under test, and the second is the one that matters:
+// Two properties are under test:
 //
 //   1. Salvage happens for the causes that leave audio in memory, and does NOT
 //      happen for the one cause whose sample owner is gone.
-//   2. THE FLOOR. Salvage may only ever ADD a transcript. It must never turn a
-//      terminal that RETAINS the crash-recovery spool into one that DELETES it.
-//      Falling through means an interrupted recording now meets the same early
+//   2. THE FLOOR (#1755 reframe: terminal/notice HONESTY, not retention).
+//      Falling through means an interrupted recording meets the same early
 //      terminals a normal stop does (`.discarded`, `.noSpeech`,
-//      `.failed(.noAudioCaptured)`) — and two of those delete the spool. The
-//      floor maps them back to `.audioInterrupted`, precisely the terminal this
-//      session reached before salvage existed.
+//      `.failed(.noAudioCaptured)`) — which would tell an interrupted user
+//      "you said nothing." The floor maps them back to `.audioInterrupted`,
+//      the honest notice. Disk disposition is uniform best-effort deletion
+//      for every concluded live ending; stale interruption state can only
+//      mislabel a terminal/notice, never retain a spool.
 //
-// The floor's proof is a PAIR: identical early-terminal trigger, different exit.
-// A too-short user stop must still `.discarded` (spool deleted, unchanged); a
-// too-short interrupted recording must land `.audioInterrupted` (spool retained).
+// The floor's proof is a PAIR: identical early-terminal trigger, different
+// exit. A too-short user stop still reads `.discarded`; a too-short
+// interrupted recording reads `.audioInterrupted` (the honest notice).
 
 #if DEBUG
 
@@ -271,12 +274,12 @@ struct ExhaustedRetrySpoolDeletionTests {
     /// A too-short INTERRUPTED recording must NOT discard: without the floor it
     /// would reach `.discarded`, whose terminal kind is `.discard` — "delete the
     /// spool now" — destroying the only surviving copy of a recording the user
-    /// never chose to throw away.
+    /// never chose to be told they "said nothing" about.
     // The PAIR that proves the floor (#1548 D1): identical sub-minimum setup —
     // one real buffer (so the session reaches `.live` under the transport gate)
     // but below the tick-based minimum-recording gate (the clock never advances)
     // — different exit. A too-short USER stop still discards; a too-short
-    // INTERRUPTED recording floors to `.audioInterrupted` (spool retained). The
+    // INTERRUPTED recording floors to `.audioInterrupted` (honest notice). The
     // old zero-buffer arm is unreachable now: with no buffer the session never
     // reaches `.live`, so it cannot be interrupted mid-recording at all.
     @Test("a sub-minimum USER stop still discards (the floor is inert outside salvage)")
@@ -304,9 +307,10 @@ struct ExhaustedRetrySpoolDeletionTests {
       await wrapper.drainReadyWork()
 
       #expect(wrapper.testKernel.recordingOutcome == .audioInterrupted(.engineLost))
-      #expect(
-        !deletesRecoverySpool(.audioInterrupted(.engineLost)),
-        "the floor must convert the spool-deleting terminal into a spool-retaining one")
+      // #1755: the floor now preserves honest TERMINAL/notice semantics only —
+      // `.audioInterrupted` tells the user what happened; the disk disposition
+      // is best-effort deletion like every concluded live ending.
+      #expect(deletesRecoverySpool(.audioInterrupted(.engineLost)))
     }
 
     /// The tick-driven arm of the same gate, with the minimum-recording
@@ -400,9 +404,10 @@ struct ExhaustedRetrySpoolDeletionTests {
       #expect(wrapper.testKernel.recordingOutcome != nil, "\(site.name): wedged")
     }
 
-    /// THE INVARIANT. Absent an explicit user cancel, a session whose exit was a
-    /// salvageable interruption terminates in exactly one of two states. There is
-    /// no third outcome, and neither outcome deletes a spool today's code retains.
+    /// THE INVARIANT. Absent an explicit user cancel, a session whose exit was
+    /// a salvageable interruption terminates in exactly one of two states —
+    /// `.completed` or `.audioInterrupted` (#1755: both request best-effort
+    /// deletion; the invariant is about terminal honesty, not disk state).
     @Test(
       "invariant: a live salvageable interruption ends .completed or .audioInterrupted, never a third state",
       // #1548 D1: a genuine interruption is only reachable from `.live`, which
@@ -423,15 +428,16 @@ struct ExhaustedRetrySpoolDeletionTests {
         terminal.kind == .completed || terminal.kind == .audioInterrupted,
         "salvage produced a third terminal: \(String(describing: terminal))")
       if terminal.kind != .completed, let outcome = terminal {
-        #expect(!deletesRecoverySpool(outcome))
+        // #1755: every non-completed live ending now requests deletion.
+        #expect(deletesRecoverySpool(outcome))
       }
     }
 
     /// The one sanctioned third outcome. A user who sees the disconnect notice
-    /// and cancels has asked us to throw the take away; flooring `.cancelled`
-    /// would override an explicit instruction to protect data the user just told
-    /// us to discard. Its retain/delete disposition belongs to the driver's
-    /// `pendingCancelOrigin`, not to the floor.
+    /// and cancels has asked us to stop; flooring `.cancelled` would override
+    /// that explicit instruction with an interruption notice. Its provenance
+    /// belongs to the driver's `pendingCancelOrigin` (#1755: both origins
+    /// delete), not to the floor.
     @Test("an explicit cancel during a salvage is honored, never floored")
     func explicitCancelDuringSalvageIsNotFloored() async {
       // `slowFinalize` dwells inside `.transcribing`, which is how the inventory
@@ -473,35 +479,43 @@ struct ExhaustedRetrySpoolDeletionTests {
       .failed(.modelLoadFailed), .failed(.captureStartFailed), .failed(.noAudioCaptured),
       .failed(.asrEmpty), .failed(.asrFailed), .failed(.asrWedged),
       .failed(.emptyAfterProcessing), .failed(.captureStalled),
+      // #1755 chunk 5: the two cases the "every terminal" claim omitted.
+      .failed(.noMicrophoneFound), .failed(.zeroSignal),
     ]
 
-    /// The floor's mapped set and the coordinator's spool-deleting endings are two
-    /// lists of one fact: "this terminal deletes the crash-recovery spool." They
-    /// live in different types (Pipeline floor + AppKit predicate) and can drift.
-    /// This test couples them through the two real authorities, so adding a new
-    /// spool-deleting terminal without flooring it reddens here rather than
-    /// silently destroying a user's only surviving copy of a dictation.
-    @Test("the floor covers EVERY terminal that would delete the spool")
-    func floorCoversEverySpoolDeletingTerminal() async {
+    /// #1755 rewrite: under the discard doctrine EVERY concluded live ending
+    /// deletes, so "the floor protects the spool" is obsolete. The floor's
+    /// remaining job is TERMINAL/NOTICE honesty: exactly its original mapped
+    /// set (`.discarded` / `.noSpeech` / `.failed(.noAudioCaptured)`) floors
+    /// to `.audioInterrupted` so the user is told the mic died rather than
+    /// "you said nothing"; every other terminal passes through, and every
+    /// non-completed terminal now requests deletion at the coordinator.
+    @Test("the floor keeps its exact terminal-honesty set; every non-completed terminal deletes")
+    func floorKeepsTerminalHonestySetAndEverythingDeletes() async {
       let (_, wrapper) = makeWrapper()
       wrapper.telemetryState.interruptionCause = .engineLost
       let kernel = wrapper.testKernel
 
       for terminal in Self.allTerminals {
-        let deletesSpool = deletesRecoverySpool(terminal)
         let floored = kernel.testInterruptedTerminalFloor(terminal)
-        if deletesSpool {
+        switch terminal {
+        case .discarded, .noSpeech, .failed(.noAudioCaptured):
           #expect(
             floored.kind == .audioInterrupted,
-            "\(terminal) deletes the spool but the floor let it through")
+            "\(terminal) is in the floor's honesty set and must floor")
+        default:
+          #expect(floored == terminal, "\(terminal) must pass through unchanged")
+        }
+        if floored.kind != .completed, floored.kind != .cancelled {
+          #expect(deletesRecoverySpool(floored), "\(floored) must request deletion (#1755)")
         }
       }
     }
 
-    /// The floor must not over-reach. A user who cancels has asked us to discard;
-    /// a completion delivered a transcript; every other `.failed` reason is
-    /// already spool-retaining and keeps its own honest cause.
-    @Test("the floor leaves every non-spool-deleting terminal alone, except noAudioCaptured")
+    /// The floor must not over-reach. A user who cancels has asked us to stop;
+    /// a completion delivered a transcript; every other `.failed` reason keeps
+    /// its own honest cause (#1755: all of them delete at the coordinator).
+    @Test("the floor leaves every terminal outside its honesty set alone")
     func floorLeavesOtherTerminalsAlone() async {
       let (_, wrapper) = makeWrapper()
       wrapper.telemetryState.interruptionCause = .deviceRemoved
@@ -516,19 +530,20 @@ struct ExhaustedRetrySpoolDeletionTests {
           == .asrInterrupted(wasRecording: false))
       #expect(kernel.testInterruptedTerminalFloor(.failed(.asrEmpty)) == .failed(.asrEmpty))
       #expect(kernel.testInterruptedTerminalFloor(.failed(.asrFailed)) == .failed(.asrFailed))
-      // Folded in with the spool-deleting pair: already retaining, but all three
-      // no-transcript endings land on one terminal so none of them keeps a
-      // different overlay for a reason no user could name.
+      // Folded in with the other two no-transcript endings: all three land on
+      // one honest terminal so none keeps a different overlay for a reason no
+      // user could name.
       #expect(
         kernel.testInterruptedTerminalFloor(.failed(.noAudioCaptured)).kind == .audioInterrupted)
     }
 
     // MARK: 2b. The floor is unconditional — the SENTENCE is what varies
 
-    /// SAFETY, for every cause. A spool-deleting terminal is rewritten no matter
-    /// which interruption fired. Letting the cap fall through to `.discarded`
-    /// because "no microphone disconnected" would be a NEW data loss dressed up
-    /// as honesty. The honesty belongs in the message, not the terminal.
+    /// HONESTY, for every cause. A no-transcript terminal is rewritten no
+    /// matter which interruption fired: letting the cap fall through to
+    /// `.discarded` because "no microphone disconnected" would tell the user
+    /// "you said nothing" when the take was cut short. The cause-specific
+    /// sentence belongs to the message; the honest CATEGORY to the terminal.
     @Test(
       "every no-transcript terminal is floored for EVERY recoverable cause",
       arguments: EngineInterruptionCause.allCases.filter(\.hasRecoverableAudio))
@@ -592,7 +607,9 @@ struct ExhaustedRetrySpoolDeletionTests {
         kernel.recordingOutcome == .asrInterrupted(wasRecording: true),
         "reached \(String(describing: kernel.recordingOutcome)) — a wedge would leave no outcome")
       #expect(kernel.recordingOutcome != nil, "the session must not wedge")
-      #expect(!deletesRecoverySpool(.asrInterrupted(wasRecording: true)))
+      #expect(
+        deletesRecoverySpool(.asrInterrupted(wasRecording: true)),
+        "#1755: the interruption terminal keeps its honest copy but now deletes")
       #expect(context.paste.pasteCount == 0)
       #expect(
         kernel.lastASRSalvageOutcome == .decodeFailed,
@@ -639,8 +656,8 @@ struct ExhaustedRetrySpoolDeletionTests {
       #expect(EngineInterruptionCause(rawValue: "xpc_connection_lost") == nil)
     }
 
-    /// Outside an interruption the floor is a no-op on every terminal. If it were
-    /// not, an ordinary too-short tap would retain a spool forever.
+    /// Outside an interruption the floor is a no-op on every terminal. If it
+    /// were not, an ordinary too-short tap would read as a mic interruption.
     @Test("with no interruption stamped, the floor is the identity function")
     func floorIsInertWithoutACause() async {
       let (_, wrapper) = makeWrapper()
@@ -656,10 +673,11 @@ struct ExhaustedRetrySpoolDeletionTests {
 
     // MARK: 3. The single home — one writer, one clearer
 
-    /// The cause now lives on the shared `KernelTelemetryState`, cleared ONLY by
-    /// `resetForNewSession()`. Two clearers would let a stale cause leak into the
-    /// next session, and the floor would then convert an ordinary too-short tap
-    /// into `.audioInterrupted` with a retained spool. This test is the guard.
+    /// The cause now lives on the shared `KernelTelemetryState`, cleared ONLY
+    /// by `resetForNewSession()`. Two clearers would let a stale cause leak
+    /// into the next session, and the floor would then mislabel an ordinary
+    /// too-short tap as `.audioInterrupted` — a wrong notice (#1755: never a
+    /// retention change). This test is the guard.
     @Test("a fresh session starts with no cause, even after an interrupted one")
     func causeDoesNotLeakAcrossSessions() async {
       let (context, wrapper) = makeWrapper()
@@ -674,7 +692,7 @@ struct ExhaustedRetrySpoolDeletionTests {
 
       #expect(
         wrapper.testKernel.lastAudioInterruptionCause == nil,
-        "a stale cause would make the next ordinary too-short tap retain a spool")
+        "a stale cause would mislabel the next ordinary too-short tap as an interruption")
 
       // And the floor is genuinely inert again: an ordinary stop discards.
       await wrapper.apply(.stop)

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -61,6 +61,15 @@ enum FakeEngineBehavior: Sendable {
   /// genuine finalize cadence stall (PR-3 plan §3.7). Resolved only by
   /// `cancel()`.
   case wedgeOnFinalize
+  /// #1755 chunk 3: `finalize()` SUSPENDS on a continuation (a genuine
+  /// in-flight decode) until the test resolves it via
+  /// `resolveHeldFinalizeAsHelperDeath()`, then returns `.failed(.engineCrashed)`
+  /// — the deterministic stand-in for a helper death failing a suspended
+  /// decode (Chunk 1's drained continuation). `heldFinalizePending` /
+  /// `onHeldFinalizePending` are the registration signals; `cancel()` releases
+  /// the continuation so a test cannot leak it. No routing or retry policy
+  /// lives here.
+  case heldFinalize
   /// `finalize()` surfaces an engine crash as `.failed(.engineCrashed)` —
   /// never a throw, never a hang.
   case crashOnFinalize
@@ -133,6 +142,18 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
   var asrInterruptionRecoveryResult: ASRInterruptionRecoveryOutcome = .readyForBatchDecode
   var asrInterruptionRecoveryDelayTicks = 0
   private(set) var recoverFromASRInterruptionCallCount = 0
+
+  /// #1755 chunk 3 — held-finalize signals (see `.heldFinalize`).
+  private(set) var heldFinalizePending = false
+  var onHeldFinalizePending: (@MainActor () -> Void)?
+  private var heldFinalizeContinuation: CheckedContinuation<Void, Never>?
+
+  /// Resolve the suspended `.heldFinalize` decode as a helper death. Safe to
+  /// call when nothing is pending (no-op).
+  func resolveHeldFinalizeAsHelperDeath() {
+    heldFinalizeContinuation?.resume()
+    heldFinalizeContinuation = nil
+  }
 
   func recoverFromASRInterruption() async -> ASRInterruptionRecoveryOutcome {
     recoverFromASRInterruptionCallCount += 1
@@ -416,6 +437,23 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
     case .crashOnFinalize:
       // An engine crash surfaces as a VALUE, never a throw, never a hang.
       outcome = .failed(.engineCrashed)
+    case .heldFinalize:
+      // #1755 chunk 3: a genuine suspended decode. Signal registration, park
+      // on the continuation, and — once the test resolves it — surface the
+      // helper death exactly as Chunk 1's drained continuation does.
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        // Store FIRST, then signal — the signal structurally proves the
+        // continuation is registered and resolvable.
+        heldFinalizeContinuation = continuation
+        heldFinalizePending = true
+        onHeldFinalizePending?()
+      }
+      heldFinalizePending = false
+      if isCancelled {
+        isTerminal = true
+        return .cancelled
+      }
+      outcome = .failed(.engineCrashed)
     case .wedgeOnFinalize:
       // The finalize emits a few finalize-progress ticks (arming the kernel's
       // wedge watcher) then goes silent — a genuine cadence stall (PR-3 plan
@@ -489,6 +527,11 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
     // #959: cheap discard — it does NOT release a wedged `warmUp()`/`finalize()`.
     // The kernel only routes ordinary terminals here; releasing a wedge is the
     // job of `recoverFromWedge()` below.
+    // #1755 chunk 3: the HELD finalize is the exception — release it on cancel
+    // so a cancelling test cannot leak the continuation (it then returns
+    // `.cancelled` per the post-cancel MUST clause above).
+    heldFinalizeContinuation?.resume()
+    heldFinalizeContinuation = nil
   }
 
   /// #959 HEAVY wedge recovery. Does the same teardown as `cancel()` PLUS

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -129,6 +129,18 @@ final class LimbInjectionBox {
   /// without depending on this harness's identity `processText` running real
   /// text-processing logic (it does not — PR-3's fake polish is identity).
   var forceEmptyAfterProcessing = false
+  /// #1755 chunk 2: forces the harness `processText` to THROW (the
+  /// `KernelLimbError.emptyAfterProcessing` seam) — the deterministic stand-in
+  /// for a text-processing step failing outright while valid raw ASR exists,
+  /// driving `runFinalizing`'s catch.
+  var processTextThrows = false
+}
+
+/// #1755 chunk 2: records every text the kernel's `store` seam receives, in
+/// order. Reference type for the same pre-`self` capture constraint as
+/// `StopTimeZeroSignalTelemetryLog` — observation only, no policy.
+final class StoreLog {
+  var storedTexts: [String] = []
 }
 
 /// #1317: reference-type holder so `stopTimeZeroSignalTelemetry`'s closure
@@ -161,6 +173,10 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// instance across the kernel, the finalization wiring, and the lifecycle sink;
   /// this wrapper mirrors that by constructing it once and passing it in.
   let telemetryState = KernelTelemetryState()
+
+  private let storeLog = StoreLog()
+  /// #1755 chunk 2: every text the kernel handed the `store` seam, in order.
+  var storedTexts: [String] { storeLog.storedTexts }
 
   private let stopTimeTelemetryLog = StopTimeZeroSignalTelemetryLog()
   /// #1317: `CaptureStallContext`s the kernel's STOP-time classification
@@ -198,6 +214,7 @@ final class KernelRecordingSession: RecordingSessionDriving {
     let limb = self.limb
     let telemetryState = self.telemetryState
     let stopTimeTelemetryLog = self.stopTimeTelemetryLog
+    let storeLog = self.storeLog
     let captureTelemetry = self.captureTelemetry
     let deadMicLog = self.deadMicLog
     self.kernel = RecordingSessionKernel(
@@ -213,10 +230,12 @@ final class KernelRecordingSession: RecordingSessionDriving {
         // way so the kernel's polish-signal observation point is covered.
         onPolishStarted()
         _ = limb.degradeToRaw
+        if limb.processTextThrows { throw KernelLimbError.emptyAfterProcessing }
         if limb.forceEmptyAfterProcessing { return "" }
         return raw
       },
-      store: { _, _ in
+      store: { [storeLog] text, _ in
+        storeLog.storedTexts.append(text)
         // #1167: a throwing save models the best-effort store seam. The kernel
         // ABSORBS the throw (records it on the finalization outcome) and still
         // proceeds to deliver + `.completed` — it no longer routes a terminal
@@ -325,6 +344,12 @@ final class KernelRecordingSession: RecordingSessionDriving {
   /// `runFinalizing`-from-`.finalizing` empty path).
   func testForceEmptyAfterProcessing() {
     limb.forceEmptyAfterProcessing = true
+  }
+
+  /// #1755 chunk 2: direct test-only knob — makes the harness `processText`
+  /// throw, standing in for a real text-processing failure over valid raw ASR.
+  func testProcessTextThrows() {
+    limb.processTextThrows = true
   }
 
   /// Yield until the kernel's `workEpoch` stops advancing — the FSM has settled

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
@@ -402,12 +402,12 @@ enum ScenarioInventory {
     // `.live`, so a device that dies before the first buffer now routes through the
     // ONE `.live` interruption path (§3.7) — not the old Arming no-transport
     // fallback. It concludes `.audioInterrupted` (rendering `.interruption`); the
-    // crash-recovery spool is still retained via that failure terminal. This is the
+    // interruption terminal keeps its honest copy (#1755: disk disposition is best-effort deletion). This is the
     // deliberate unification: one interruption path, not two. The salvage FLOOR for
     // a device that dies mid-recording WITH audio is C5 + the salvage-suite floor
     // tests.
     Scenario(
-      id: "C8", name: "device dies before the first buffer (interruption, spool retained)",
+      id: "C8", name: "device dies before the first buffer (interruption terminal)",
       steps: [.trigger(.start), .capture(.interrupt), .capture(.stall)],
       expected: ExpectedOutcome(
         terminalState: .audioInterrupted, pasteCount: 0, pasteOutcome: .none,

--- a/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
@@ -102,7 +102,7 @@ struct ZeroSignalRecoveryTests {
   func reactiveNoBuffersWithNoAudioConcludesNoTransport() async {
     // #1548 D2: reaching `.live` no longer needs a buffer (sequential transition),
     // so a `.noBuffers` stall with `bufferCountThisSession == 0` is the dead-mic
-    // case → `.noTransport` ("No audio captured", spool retained), NOT the live
+    // case → `.noTransport` ("No audio captured"; #1755: best-effort deletion), NOT the live
     // `.captureStall` exit. (The `.captureStall` path — `.noBuffers` AFTER a buffer
     // arrived — is covered by `captureStalledRoutes` in the external-entry suite.)
     let ctx = makeContext()

--- a/Tests/EnviousWisprTests/Recovery/CrashBoundaryFaultControllerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/CrashBoundaryFaultControllerTests.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import EnviousWisprCore
 import Foundation
 import Testing
@@ -291,3 +292,4 @@ struct CrashBoundaryFaultControllerTests {
     #expect(!fresh.hasLiveArmForTesting)
   }
 }
+#endif

--- a/Tests/EnviousWisprTests/Recovery/CrashBoundaryFaultControllerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/CrashBoundaryFaultControllerTests.swift
@@ -1,0 +1,293 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+/// #1755 chunk 6 — the crash-boundary controller contract (plan §10/§11.1
+/// leg 5). Every test uses an ISOLATED controller with its own temp file
+/// paths — nothing here touches the shared `/tmp` production paths, so the
+/// suite needs no serialization.
+@Suite("CrashBoundaryFaultController (#1755 chunk 6)")
+struct CrashBoundaryFaultControllerTests {
+
+  private struct Fixture {
+    let controller: CrashBoundaryFaultController
+    let armPath: String
+    let reachedPath: String
+  }
+
+  private static func makeFixture() -> Fixture {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-crash-boundary-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let arm = dir.appendingPathComponent("arm").path
+    let reached = dir.appendingPathComponent("reached").path
+    return Fixture(
+      controller: CrashBoundaryFaultController(armFilePath: arm, reachedFilePath: reached),
+      armPath: arm, reachedPath: reached)
+  }
+
+  private static func write(_ record: CrashBoundarySignalRecord, to path: String) {
+    let data = try! PropertyListEncoder().encode(record)
+    try! data.write(to: URL(fileURLWithPath: path), options: .atomic)
+  }
+
+  /// Lock-protected fired-or-waiting one-shot (same shape as the recovery
+  /// coordinator tests' helper): whichever of signal()/wait() runs first, the
+  /// waiter resumes exactly once. Signals, never clocks.
+  private final class OneShot: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+    private var waiter: CheckedContinuation<Void, Never>?
+    func signal() {
+      let resumable: CheckedContinuation<Void, Never>? = lock.withLock {
+        if fired { return nil }
+        fired = true
+        let w = waiter
+        waiter = nil
+        return w
+      }
+      resumable?.resume()
+    }
+    func wait() async {
+      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+        let resumeNow: Bool = lock.withLock {
+          if fired { return true }
+          waiter = c
+          return false
+        }
+        if resumeNow { c.resume() }
+      }
+    }
+  }
+
+  private struct BackgroundHit {
+    let entered: OneShot
+    let finished: OneShot
+  }
+
+  /// Fires `boundaryReached` on a dedicated background thread and returns
+  /// (entered, finished) one-shot observation points.
+  private static func fireOnBackgroundTask(
+    _ controller: CrashBoundaryFaultController, _ boundary: CrashBoundary
+  ) -> BackgroundHit {
+    let entered = OneShot()
+    let finished = OneShot()
+    Thread.detachNewThread {
+      entered.signal()
+      controller.boundaryReached(boundary)
+      finished.signal()
+    }
+    return BackgroundHit(entered: entered, finished: finished)
+  }
+
+  @Test("the boundary vocabulary is exactly the five approved raw values")
+  func vocabularyIsClosed() {
+    #expect(
+      Set(CrashBoundary.allCases.map(\.rawValue)) == [
+        "retry_exhaustion_decided", "live_terminal_published", "before_spool_delete",
+        "before_key_delete", "destruction_api_return",
+      ])
+    #expect(CrashBoundary.allCases.count == 5)
+  }
+
+  @Test("arm acknowledgement records the exact pair; empty trial fails closed")
+  func armWritesExactPair() throws {
+    let fx = Self.makeFixture()
+    #expect(!fx.controller.arm(trialID: "", boundary: .beforeSpoolDelete), "empty trial refused")
+    #expect(fx.controller.arm(trialID: "t1", boundary: .beforeSpoolDelete))
+    let data = try Data(contentsOf: URL(fileURLWithPath: fx.armPath))
+    let record = try PropertyListDecoder().decode(CrashBoundarySignalRecord.self, from: data)
+    #expect(record == CrashBoundarySignalRecord(trialID: "t1", boundary: "before_spool_delete"))
+    fx.controller.clear()
+  }
+
+  @Test(
+    "missing, malformed, stale-trial, wrong-trial, and wrong-boundary reached files query false")
+  func reachedQueryFailsClosed() throws {
+    let fx = Self.makeFixture()
+    // Missing.
+    #expect(!fx.controller.isReached(trialID: "t1", boundary: .beforeSpoolDelete))
+    // Malformed.
+    try Data([0xDE, 0xAD]).write(to: URL(fileURLWithPath: fx.reachedPath))
+    #expect(!fx.controller.isReached(trialID: "t1", boundary: .beforeSpoolDelete))
+    // Stale/wrong trial and wrong boundary.
+    Self.write(
+      CrashBoundarySignalRecord(trialID: "old-trial", boundary: "before_spool_delete"),
+      to: fx.reachedPath)
+    #expect(!fx.controller.isReached(trialID: "t1", boundary: .beforeSpoolDelete), "wrong trial")
+    #expect(
+      !fx.controller.isReached(trialID: "old-trial", boundary: .beforeKeyDelete), "wrong boundary")
+    #expect(
+      fx.controller.isReached(trialID: "old-trial", boundary: .beforeSpoolDelete),
+      "the exact pair still reads true")
+    // Empty trial never matches.
+    #expect(
+      !CrashBoundaryFaultController.readReached(
+        trialID: "", boundary: .beforeSpoolDelete, reachedFilePath: fx.reachedPath))
+  }
+
+  @Test("a wrong-boundary hit leaves the live arm intact and does not block")
+  func wrongBoundaryHitLeavesArm() {
+    let fx = Self.makeFixture()
+    #expect(fx.controller.arm(trialID: "t1", boundary: .beforeSpoolDelete))
+    // Wrong boundary: returns synchronously (this call would hang the test if
+    // it parked — its prompt return IS the assertion), consumes nothing.
+    fx.controller.boundaryReached(.retryExhaustionDecided)
+    #expect(fx.controller.hasLiveArmForTesting, "the arm survives a wrong-boundary hit")
+    #expect(FileManager.default.fileExists(atPath: fx.armPath), "arm artifact survives")
+    #expect(!fx.controller.isReached(trialID: "t1", boundary: .retryExhaustionDecided))
+    fx.controller.clear()
+  }
+
+  @Test("a matching hit consumes the arm BEFORE publishing, holds until release, exact record")
+  func matchingHitConsumesPublishesAndHolds() async {
+    let fx = Self.makeFixture()
+    #expect(fx.controller.arm(trialID: "t2", boundary: .liveTerminalPublished))
+    let published = OneShot()
+    fx.controller.onPublishForTesting = { _ in published.signal() }
+    let run = Self.fireOnBackgroundTask(fx.controller, .liveTerminalPublished)
+    await published.wait()
+    fx.controller.releaseHeldForTesting()
+    await run.finished.wait()
+    #expect(
+      fx.controller.isReached(trialID: "t2", boundary: .liveTerminalPublished),
+      "the exact reached record was published before the park")
+    #expect(!FileManager.default.fileExists(atPath: fx.armPath), "arm consumed before publication")
+    #expect(!fx.controller.hasLiveArmForTesting)
+  }
+
+  @Test("a duplicate matching hit neither republishes nor holds")
+  func duplicateHitPassesThrough() async {
+    let fx = Self.makeFixture()
+    #expect(fx.controller.arm(trialID: "t3", boundary: .beforeSpoolDelete))
+    let published = OneShot()
+    fx.controller.onPublishForTesting = { _ in published.signal() }
+    let run = Self.fireOnBackgroundTask(fx.controller, .beforeSpoolDelete)
+    await published.wait()
+    fx.controller.releaseHeldForTesting()
+    await run.finished.wait()
+    // Second hit: arm is gone — synchronous pass-through (a park would hang).
+    fx.controller.boundaryReached(.beforeSpoolDelete)
+    #expect(fx.controller.isReached(trialID: "t3", boundary: .beforeSpoolDelete))
+  }
+
+  @Test("clear removes both artifacts and releases a held path")
+  func clearRemovesAndReleases() async {
+    let fx = Self.makeFixture()
+    #expect(fx.controller.arm(trialID: "t4", boundary: .beforeKeyDelete))
+    let published = OneShot()
+    fx.controller.onPublishForTesting = { _ in published.signal() }
+    let run = Self.fireOnBackgroundTask(fx.controller, .beforeKeyDelete)
+    await published.wait()
+    fx.controller.clear()
+    await run.finished.wait()
+    #expect(!FileManager.default.fileExists(atPath: fx.armPath))
+    #expect(!FileManager.default.fileExists(atPath: fx.reachedPath))
+  }
+
+  @Test("a new controller does not activate stale on-disk arm or reached files")
+  func freshControllerIgnoresStaleFiles() {
+    let fx = Self.makeFixture()
+    Self.write(
+      CrashBoundarySignalRecord(trialID: "ghost", boundary: "before_key_delete"), to: fx.armPath)
+    Self.write(
+      CrashBoundarySignalRecord(trialID: "ghost", boundary: "before_key_delete"),
+      to: fx.reachedPath)
+    let fresh = CrashBoundaryFaultController(
+      armFilePath: fx.armPath, reachedFilePath: fx.reachedPath)
+    #expect(!fresh.hasLiveArmForTesting, "files are evidence, never permission to re-arm")
+    // An unarmed hit passes straight through (a park would hang the test).
+    fresh.boundaryReached(.beforeKeyDelete)
+    // The stale reached file still reads for ITS pair (external cleanup is
+    // the harness's job) — but nothing new was armed, consumed, or held.
+    #expect(fresh.isReached(trialID: "ghost", boundary: .beforeKeyDelete))
+  }
+
+  // MARK: - destruction_api_return two-order matrix
+
+  @Test(
+    "key-delete first: gated without publication; caller hook then publishes; release frees both")
+  func destructionAPIReturnKeyFirst() async {
+    let fx = Self.makeFixture()
+    #expect(fx.controller.arm(trialID: "t5", boundary: .destructionAPIReturn))
+    // Schedule 1: the detached key path arrives BEFORE the API returns —
+    // observe the GATE DECISION itself.
+    let gateDecision = OneShot()
+    let gatedBox = NSLock()
+    nonisolated(unsafe) var gated: Bool?
+    fx.controller.onKeyDeleteGateDecisionForTesting = { decision in
+      gatedBox.withLock { if gated == nil { gated = decision } }
+      gateDecision.signal()
+    }
+    let keyPath = Self.fireOnBackgroundTask(fx.controller, .beforeKeyDelete)
+    await gateDecision.wait()
+    #expect(gatedBox.withLock { gated } == true, "key-first: the key path is gated")
+    #expect(
+      !fx.controller.isReached(trialID: "t5", boundary: .destructionAPIReturn),
+      "gating the key path must not publish destruction_api_return")
+    #expect(fx.controller.hasLiveArmForTesting, "the gate does not consume the arm")
+    // The caller hook (API returned) now publishes and holds.
+    let published = OneShot()
+    fx.controller.onPublishForTesting = { _ in published.signal() }
+    let caller = Self.fireOnBackgroundTask(fx.controller, .destructionAPIReturn)
+    await published.wait()
+    #expect(
+      fx.controller.isReached(trialID: "t5", boundary: .destructionAPIReturn),
+      "the caller-side hook published the exact record before parking")
+    fx.controller.releaseHeldForTesting()
+    await keyPath.finished.wait()
+    await caller.finished.wait()
+  }
+
+  @Test(
+    "API-return first: publishes and holds; a later key-delete path is still gated; release frees both"
+  )
+  func destructionAPIReturnCallerFirst() async {
+    let fx = Self.makeFixture()
+    #expect(fx.controller.arm(trialID: "t6", boundary: .destructionAPIReturn))
+    // Schedule 2: the caller hook fires first. NOTE the consumed arm: gating
+    // afterwards relies on `released` still being false.
+    let published = OneShot()
+    fx.controller.onPublishForTesting = { _ in published.signal() }
+    let caller = Self.fireOnBackgroundTask(fx.controller, .destructionAPIReturn)
+    await published.wait()
+    #expect(fx.controller.isReached(trialID: "t6", boundary: .destructionAPIReturn))
+    // The later key path must STILL be gated (persistent gate flag after the
+    // arm was consumed) — observe the GATE DECISION itself, not thread entry.
+    let gateDecision = OneShot()
+    let gatedBox = NSLock()
+    nonisolated(unsafe) var gated: Bool?
+    fx.controller.onKeyDeleteGateDecisionForTesting = { decision in
+      gatedBox.withLock { if gated == nil { gated = decision } }
+      gateDecision.signal()
+    }
+    let keyPath = Self.fireOnBackgroundTask(fx.controller, .beforeKeyDelete)
+    await gateDecision.wait()
+    #expect(gatedBox.withLock { gated } == true, "caller-first: the key path is still gated")
+    fx.controller.releaseHeldForTesting()
+    await caller.finished.wait()
+    await keyPath.finished.wait()
+  }
+
+  @Test("stale files with no live in-process arm do not gate key deletion")
+  func staleFilesDoNotGateKeyDeletion() {
+    let fx = Self.makeFixture()
+    Self.write(
+      CrashBoundarySignalRecord(trialID: "ghost", boundary: "destruction_api_return"),
+      to: fx.armPath)
+    Self.write(
+      CrashBoundarySignalRecord(trialID: "ghost", boundary: "destruction_api_return"),
+      to: fx.reachedPath)
+    let fresh = CrashBoundaryFaultController(
+      armFilePath: fx.armPath, reachedFilePath: fx.reachedPath)
+    let gatedBox = NSLock()
+    nonisolated(unsafe) var gated: Bool?
+    fresh.onKeyDeleteGateDecisionForTesting = { decision in
+      gatedBox.withLock { if gated == nil { gated = decision } }
+    }
+    // Synchronous return IS the assertion — a gate would hang the test.
+    fresh.boundaryReached(.beforeKeyDelete)
+    #expect(gatedBox.withLock { gated } == false, "no live arm ⇒ the key path passes ungated")
+    #expect(!fresh.hasLiveArmForTesting)
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -1091,4 +1091,26 @@ struct RecoveryCoordinatorTests {
     #expect(keyAttempted.value == 1, "the gated key deletion completed after release")
   }
 
+  @Test("a FAILED live-ending spool delete is suppressed from the same-launch rescan (PR #1761 cloud P2)")
+  func failedLiveDeleteSuppressedSameLaunch() async throws {
+    let h = Self.makeHarness()
+    struct InjectedDeleteFailure: Error {}
+    h.coordinator.destructionSpoolDeleteForTesting = { _ in throw InjectedDeleteFailure() }
+    h.coordinator.destructionKeyDeleteForTesting = { _ in }
+    let id = "suppress-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: id, ending: .failed)
+    let unwrapped = try #require(task)
+    await unwrapped.value
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "precondition: the spool survived the failed delete")
+    // The same-launch scan must NOT rediscover/replay the survivor.
+    await h.coordinator.scanAndRecover()
+    #expect(
+      h.replayer.replayedIDs.isEmpty,
+      "the failed-delete survivor is suppressed until a genuine new launch")
+  }
+
 }

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -813,4 +813,161 @@ struct RecoveryCoordinatorTests {
       coordinator.handleRecordingEndedWithoutDurableSave(
         recoverySessionID: nil, ending: .discarded) == nil)
   }
+  // MARK: - #1755 chunk 4 — deletion-failure breadcrumb matrix
+
+  /// The exact breadcrumb shape the deletion-failure seam records.
+  struct Crumb: Equatable {
+    let stage: String
+    let message: String
+    let data: [String: String]
+  }
+
+  private final class CrumbLog {
+    var crumbs: [Crumb] = []
+  }
+
+  /// Lock-protected fired-or-waiting one-shot: whichever of signal()/wait()
+  /// runs first, the waiter resumes exactly once. Race-safe by construction.
+  private final class OneShotSignal: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+    private var waiter: CheckedContinuation<Void, Never>?
+    func signal() {
+      let resumable: CheckedContinuation<Void, Never>? = lock.withLock {
+        if fired { return nil }
+        fired = true
+        let w = waiter
+        waiter = nil
+        return w
+      }
+      resumable?.resume()
+    }
+    func wait() async {
+      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+        let resumeNow: Bool = lock.withLock {
+          if fired { return true }
+          waiter = c
+          return false
+        }
+        if resumeNow { c.resume() }
+      }
+    }
+  }
+
+  /// Lock-safe counter for the key-delete seam, which runs OFF the MainActor
+  /// inside the detached destruction task. Awaiting that task proves the
+  /// increment completed — no scheduling hops.
+  private final class AtomicCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    func increment() { lock.withLock { count += 1 } }
+    var value: Int { lock.withLock { count } }
+  }
+
+  // Best-effort deletion stays best-effort (no retries, no escapes); the ONLY
+  // new behavior is one failure breadcrumb per failed component per
+  // destruction call, with exact shape and a fixed source label.
+  @Test(
+    "live-ending destruction: 2×2 spool/key failure matrix emits exactly one breadcrumb per failed component",
+    arguments: [false, true], [false, true])
+  func deletionFailureMatrix(spoolFails: Bool, keyFails: Bool) async throws {
+    let harness = Self.makeHarness()
+    let coordinator = harness.coordinator
+    let log = CrumbLog()
+    let spoolAttempts = Box(0)
+    let keyAttempts = AtomicCounter()
+    struct InjectedDeleteFailure: Error {}
+    coordinator.destructionSpoolDeleteForTesting = { _ in
+      spoolAttempts.value += 1
+      if spoolFails { throw InjectedDeleteFailure() }
+    }
+    coordinator.destructionKeyDeleteForTesting = { _ in
+      keyAttempts.increment()
+      if keyFails { throw InjectedDeleteFailure() }
+    }
+    coordinator.deletionFailureBreadcrumbForTesting = { stage, message, data in
+      log.crumbs.append(Crumb(stage: stage, message: message, data: data))
+    }
+
+    // Drive the REAL live-ending destruction route with a delete-class ending.
+    let task = coordinator.handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: "matrix-\(spoolFails)-\(keyFails)", ending: .discarded)
+    let unwrapped = try #require(task, "a delete-class ending must return the detached work")
+    // Awaiting the destruction task IS the completion proof: the key attempt
+    // increments inline and the key-failure breadcrumb's MainActor emission is
+    // awaited inside the task before it finishes.
+    await unwrapped.value
+
+    #expect(spoolAttempts.value == 1, "spool attempt exactly once")
+    #expect(keyAttempts.value == 1, "key attempt exactly once, even after spool failure")
+    let expectedCount = (spoolFails ? 1 : 0) + (keyFails ? 1 : 0)
+    #expect(log.crumbs.count == expectedCount, "exactly one breadcrumb per failed component")
+    if spoolFails {
+      #expect(
+        log.crumbs.contains(
+          Crumb(
+            stage: "recovery", message: "deletion_failed",
+            data: ["component": "spool", "source": "live_ending"])),
+        "exact spool failure breadcrumb")
+    }
+    if keyFails {
+      #expect(
+        log.crumbs.contains(
+          Crumb(
+            stage: "recovery", message: "deletion_failed",
+            data: ["component": "key", "source": "live_ending"])),
+        "exact key failure breadcrumb")
+    }
+    if spoolFails && keyFails {
+      #expect(
+        Set(log.crumbs.map { $0.data["component"] ?? "" }) == ["spool", "key"],
+        "both-fail cell: one spool + one key, no duplicate")
+    }
+  }
+
+  @Test("key-failure breadcrumb survives external coordinator ownership release")
+  func keyFailureBreadcrumbSurvivesOwnershipRelease() async throws {
+    // Finding r2-1/r3-1: prove the detached delete's STRONG capture delivers
+    // the breadcrumb after every external reference is gone. Deterministic
+    // protocol: gate the injected key delete AFTER it signals entry, await the
+    // entry signal, nil every external strong reference, assert the weak
+    // observer stays alive (the task owns the coordinator), release the gate
+    // so the delete throws, await the task, assert the exact crumb.
+    let log = CrumbLog()
+    struct InjectedDeleteFailure: Error {}
+    var harness: Harness? = Self.makeHarness()
+    var coordinator: RecoveryCoordinator? = harness?.coordinator
+    weak var observed = coordinator
+    // Race-safe one-shot entry signal, created BEFORE destruction starts —
+    // fired-or-waiting semantics make the ordering safe whichever thread wins
+    // (r4 ordering).
+    let entry = OneShotSignal()
+    let gate = DispatchSemaphore(value: 0)
+    coordinator?.destructionSpoolDeleteForTesting = { _ in }
+    coordinator?.destructionKeyDeleteForTesting = { _ in
+      entry.signal()
+      gate.wait()  // released by the test after ownership is dropped — a signal, not a clock
+      throw InjectedDeleteFailure()
+    }
+    coordinator?.deletionFailureBreadcrumbForTesting = { stage, message, data in
+      log.crumbs.append(Crumb(stage: stage, message: message, data: data))
+    }
+    let task = try #require(coordinator).handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: "lifetime", ending: .discarded)
+    let unwrapped = try #require(task)
+    await entry.wait()  // entry — resumes immediately if it already fired
+    harness = nil
+    coordinator = nil
+    #expect(observed != nil, "the detached task must own the coordinator while running")
+    gate.signal()
+    await unwrapped.value
+    #expect(
+      log.crumbs == [
+        Crumb(
+          stage: "recovery", message: "deletion_failed",
+          data: ["component": "key", "source": "live_ending"])
+      ],
+      "the strong capture must deliver the breadcrumb after ownership release")
+  }
+
 }

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -963,4 +963,132 @@ struct RecoveryCoordinatorTests {
       "the strong capture must deliver the breadcrumb after ownership release")
   }
 
+  // MARK: - #1755 chunk 6 — crash-boundary hook lockstep (coordinator side)
+
+  private static func makeBoundaryController() -> CrashBoundaryFaultController {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-cb-coord-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return CrashBoundaryFaultController(
+      armFilePath: dir.appendingPathComponent("arm").path,
+      reachedFilePath: dir.appendingPathComponent("reached").path)
+  }
+
+  @Test("before_spool_delete fires before the spool attempt; release lets deletion proceed")
+  func beforeSpoolDeleteHook() async throws {
+    let h = Self.makeHarness()
+    let controller = Self.makeBoundaryController()
+    h.coordinator.crashBoundaryController = controller
+    defer { controller.clear() }
+    let spoolAttempted = AtomicCounter()
+    let attemptsAtBoundary = AtomicCounter()
+    h.coordinator.destructionSpoolDeleteForTesting = { _ in spoolAttempted.increment() }
+    h.coordinator.destructionKeyDeleteForTesting = { _ in }
+    controller.onPublishForTesting = { _ in
+      // Publication callback fires synchronously at the hook, BEFORE the
+      // spool attempt; record and release immediately (no polling).
+      for _ in 0..<spoolAttempted.value { attemptsAtBoundary.increment() }
+      controller.releaseHeldForTesting()
+    }
+    #expect(controller.arm(trialID: "cb1", boundary: .beforeSpoolDelete))
+
+    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: "cb-spool", ending: .failed)
+    let unwrapped = try #require(task)
+    await unwrapped.value
+
+    #expect(controller.isReached(trialID: "cb1", boundary: .beforeSpoolDelete))
+    #expect(attemptsAtBoundary.value == 0, "the boundary sits BEFORE the spool attempt")
+    #expect(spoolAttempted.value == 1, "release lets the real attempt proceed")
+  }
+
+  @Test("before_key_delete fires inside the detached task before the key attempt")
+  func beforeKeyDeleteHook() async throws {
+    let h = Self.makeHarness()
+    let controller = Self.makeBoundaryController()
+    h.coordinator.crashBoundaryController = controller
+    defer { controller.clear() }
+    let keyAttempted = AtomicCounter()
+    let attemptsAtBoundary = AtomicCounter()
+    h.coordinator.destructionSpoolDeleteForTesting = { _ in }
+    h.coordinator.destructionKeyDeleteForTesting = { _ in keyAttempted.increment() }
+    controller.onPublishForTesting = { _ in
+      for _ in 0..<keyAttempted.value { attemptsAtBoundary.increment() }
+      controller.releaseHeldForTesting()
+    }
+    #expect(controller.arm(trialID: "cb2", boundary: .beforeKeyDelete))
+
+    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: "cb-key", ending: .failed)
+    let unwrapped = try #require(task)
+    await unwrapped.value
+
+    #expect(controller.isReached(trialID: "cb2", boundary: .beforeKeyDelete))
+    #expect(attemptsAtBoundary.value == 0, "the boundary sits BEFORE the key attempt")
+    #expect(keyAttempted.value == 1, "release lets the real attempt proceed")
+  }
+
+  @Test("destruction_api_return: key deletion gated across the API return; caller hook publishes after")
+  func destructionAPIReturnHookOrdering() async throws {
+    let h = Self.makeHarness()
+    let controller = Self.makeBoundaryController()
+    h.coordinator.crashBoundaryController = controller
+    defer { controller.clear() }
+    let keyAttempted = AtomicCounter()
+    h.coordinator.destructionSpoolDeleteForTesting = { _ in }
+    // The key-delete seam SIGNALS entry so the gated schedule is provable
+    // without any polling: the gate parks BEFORE the seam runs, so entry
+    // never fires while gated.
+    let keyEntered = OneShotSignal()
+    h.coordinator.destructionKeyDeleteForTesting = { _ in
+      keyAttempted.increment()
+      keyEntered.signal()
+    }
+    // Observe the real detached key path REACHING the gate — `keyAttempted ==
+    // 0` alone could mean the detached task simply has not started yet.
+    let gateDecision = OneShotSignal()
+    let gateDecisionLock = NSLock()
+    nonisolated(unsafe) var keyWasGated: Bool?
+    controller.onKeyDeleteGateDecisionForTesting = { decision in
+      gateDecisionLock.withLock {
+        if keyWasGated == nil { keyWasGated = decision }
+      }
+      gateDecision.signal()
+    }
+    #expect(controller.arm(trialID: "cb3", boundary: .destructionAPIReturn))
+
+    // The API must return while the key path is gated.
+    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: "cb-api", ending: .failed)
+    let unwrapped = try #require(task, "the API returned while the key path is gated")
+    await gateDecision.wait()
+    #expect(
+      gateDecisionLock.withLock { keyWasGated } == true,
+      "the real detached key path reached the API-return gate")
+    #expect(keyAttempted.value == 0, "key deletion has not passed its pre-point")
+    #expect(
+      !controller.isReached(trialID: "cb3", boundary: .destructionAPIReturn),
+      "gating alone must not publish")
+
+    // The caller-side hook (what DictationRuntime's closure runs after the
+    // API returns) publishes and parks on a background thread; its
+    // publication callback releases every hold, freeing the gated key path.
+    let published = OneShotSignal()
+    controller.onPublishForTesting = { _ in
+      controller.releaseHeldForTesting()
+      published.signal()
+    }
+    let callerDone = OneShotSignal()
+    Thread.detachNewThread {
+      controller.boundaryReached(.destructionAPIReturn)
+      callerDone.signal()
+    }
+    await published.wait()
+    await callerDone.wait()
+    await keyEntered.wait()
+    await unwrapped.value
+    #expect(controller.isReached(trialID: "cb3", boundary: .destructionAPIReturn))
+    #expect(keyAttempted.value == 1, "the gated key deletion completed after release")
+  }
+
 }

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -963,6 +963,7 @@ struct RecoveryCoordinatorTests {
       "the strong capture must deliver the breadcrumb after ownership release")
   }
 
+#if DEBUG
   // MARK: - #1755 chunk 6 — crash-boundary hook lockstep (coordinator side)
 
   private static func makeBoundaryController() -> CrashBoundaryFaultController {
@@ -1090,6 +1091,8 @@ struct RecoveryCoordinatorTests {
     #expect(controller.isReached(trialID: "cb3", boundary: .destructionAPIReturn))
     #expect(keyAttempted.value == 1, "the gated key deletion completed after release")
   }
+
+#endif
 
   @Test("a FAILED live-ending spool delete is suppressed from the same-launch rescan (PR #1761 cloud P2)")
   func failedLiveDeleteSuppressedSameLaunch() async throws {

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -164,37 +164,30 @@ struct RecoveryCoordinatorTests {
 
   // MARK: - Non-saved terminal routing (#1464 live-ending predicate)
 
-  @Test("a delete ending (discard/no-speech/user-cancel) deletes the spool + key")
-  func discardTerminalDeletes() async throws {
+  @Test("EVERY concluded live ending physically deletes the spool + key (#1755 discard doctrine)")
+  func everyLiveEndingDeletes() async throws {
+    // #1755: an ending fired ⇒ the app was alive ⇒ the user witnessed the
+    // outcome and re-dictates. All nine representable endings request
+    // best-effort deletion; only the no-ending app-gone orphan retains.
     let h = Self.makeHarness()
-    for ending in [RecordingRecoveryEnding.discarded, .noSpeech, .cancelled(.user)] {
-      let id = "del-\(UUID().uuidString)"
-      try Self.writeSpool(h.spoolStore, id)
-      try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
-      await h.coordinator.handleRecordingEndedWithoutDurableSave(
-        recoverySessionID: id, ending: ending)?.value
-      #expect(
-        !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
-        "\(ending) should delete the spool")
-      #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
-    }
-  }
-
-  @Test("a retain ending (fault / system-cancel) RETAINS the spool + key")
-  func failureTerminalRetains() async throws {
-    let h = Self.makeHarness()
-    let retainEndings: [RecordingRecoveryEnding] = [
-      .failed, .audioInterrupted, .asrInterrupted, .noTransport, .cancelled(.systemOrFault),
+    let allEndings: [RecordingRecoveryEnding] = [
+      .discarded, .noSpeech, .failed, .asrRetryExhausted, .audioInterrupted,
+      .asrInterrupted, .noTransport, .cancelled(.user), .cancelled(.systemOrFault),
     ]
-    for ending in retainEndings {
-      let id = "keep-\(UUID().uuidString)"
+    for ending in allEndings {
+      let id = "del-\(UUID().uuidString)"
       try Self.writeSpool(h.spoolStore, id)
       try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
       let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
         recoverySessionID: id, ending: ending)
-      #expect(task == nil, "\(ending) retains — no delete work")
-      #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
-      #expect((try? h.keyStore.retrieve(for: id)) != nil)
+      let unwrapped = try #require(task, "\(ending) must return the destruction work")
+      await unwrapped.value
+      #expect(
+        !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+        "\(ending) must delete the spool")
+      #expect(
+        throws: RecoveryKeyStoreError.notFound, "\(ending) must delete the key"
+      ) { try h.keyStore.retrieve(for: id) }
     }
   }
 
@@ -208,21 +201,31 @@ struct RecoveryCoordinatorTests {
 
   // MARK: - #1464 delete/retain predicates (adversarial: every case in both classes)
 
-  @Test("shouldDeleteOnLiveEnding: delete endings delete, retain endings retain")
+  @Test("shouldDeleteOnLiveEnding: all nine ending cells delete (#1755 founder discard doctrine)")
   func liveEndingPredicate() {
-    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.discarded))
-    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.noSpeech))
-    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.cancelled(.user)))
-    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.failed))
-    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.audioInterrupted))
-    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.asrInterrupted))
-    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.noTransport))
-    #expect(!RecoveryCoordinator.shouldDeleteOnLiveEnding(.cancelled(.systemOrFault)))
+    // Unchanged cells (already deleted before #1755):
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.discarded), "unchanged")
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.noSpeech), "unchanged")
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.cancelled(.user)), "unchanged")
+    // FLIPPED by the founder's discard doctrine (#1755, Gate 2 2026-07-23):
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.failed), "flipped: live failure discards")
+    #expect(
+      RecoveryCoordinator.shouldDeleteOnLiveEnding(.audioInterrupted),
+      "flipped: in-session salvage already ran; discard on failure")
+    #expect(
+      RecoveryCoordinator.shouldDeleteOnLiveEnding(.asrInterrupted),
+      "flipped: the live rescue is the Phase-2 retry; discard on failure")
+    #expect(
+      RecoveryCoordinator.shouldDeleteOnLiveEnding(.noTransport),
+      "flipped: nothing recoverable by construction")
+    #expect(
+      RecoveryCoordinator.shouldDeleteOnLiveEnding(.cancelled(.systemOrFault)),
+      "flipped: every producer is app-alive")
     // #1707 Phase 2: an exhausted Phase-2 retry deletes its spool (the
     // decode genuinely never produced anything); a pre-capture / never-
-    // retried `.failed` (plain, no retry consulted) still retains — the
+    // #1755: plain `.failed` (no retry consulted) ALSO deletes now — the
     // negative half of this same adversarial pair.
-    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.asrRetryExhausted))
+    #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.asrRetryExhausted), "unchanged")
   }
 
   @Test(
@@ -438,37 +441,27 @@ struct RecoveryCoordinatorTests {
     }
   }
 
-  @Test(
-    "a live recording's own retained failure is excluded from THIS SAME session's wake-up rescan"
-  )
-  func retainedLiveFailureExcludedFromSameSessionRescan() async throws {
-    // GitHub cloud review, PR #1732: `onDictationEndedForRecovery` fires right
-    // after a live recording ends. For a RETAIN ending, the engine may still be
-    // in the exact broken state that produced the failure — a same-launch
-    // rescan must not immediately re-attempt (and potentially delete) the very
-    // spool this ending just retained.
+  @Test("a live failure deletes its spool, so a same-launch scan finds nothing to replay (#1755)")
+  func liveFailureDeletedNothingForSameSessionRescan() async throws {
+    // #1755 rewrite of the PR #1732 retention test: `.failed` now DELETES —
+    // the launch/wake scan has nothing left to replay, which removes the
+    // same-launch race population at the source instead of suppressing it.
     let h = Self.makeHarness()
     let id = "live-fail-\(UUID().uuidString)"
     try Self.writeSpool(h.spoolStore, id)
-    // `.failed` is a RETAIN-kind ending (`shouldDeleteOnLiveEnding` returns
-    // false) — mirrors the live driver calling this on a genuine failure.
-    h.coordinator.handleRecordingEndedWithoutDurableSave(recoverySessionID: id, ending: .failed)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: id, ending: .failed)
+    let unwrapped = try #require(task, ".failed now returns destruction work")
+    await unwrapped.value
     #expect(
-      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
-      "a retain ending never deletes")
-    // If the engine were still broken, a replay attempt here would fail again.
-    h.replayer.outcomeByID[id] = .failed(.unrecoverable)
-    // The SAME session's own wake-up call — must not touch `id` this pass.
-    h.coordinator.requestRecoveryRecheck()
-    for _ in 0..<20 {
-      try? await Task.sleep(for: .milliseconds(5))  // settle: bounded drain to let any spurious replay run
-    }
+      !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "the live failure's spool is gone")
+    // A direct same-launch scan attempts nothing — the population is empty.
+    await h.coordinator.scanAndRecover()
     #expect(
       h.replayer.replayedIDs.isEmpty,
-      "the just-retained id must not be re-attempted by this same session's own rescan")
-    #expect(
-      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
-      "still on disk — not destroyed by a same-launch replay of the just-retained spool")
+      "nothing remains for the same-launch scan to replay")
   }
 
   @Test("a FRESH coordinator instance (a genuine new launch) starts with an empty suppression set")

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -1653,6 +1653,92 @@ def evaluate_trial(name: str, inner: dict) -> tuple[bool, str]:
     return True, "ok"
 
 
+# ---------------------------------------------------------------------------
+# #1755 chunk 6 — crash-boundary helpers (plan §11.1 leg 5 client support).
+# The five-leg scenario execution itself is NOT here; these are the narrow
+# building blocks: validate → clear → arm (acknowledged) → read the reached
+# artifact directly (cross-process, works while the app's main thread is
+# deliberately held) → clear after relaunch.
+
+CRASH_BOUNDARIES = (
+    "retry_exhaustion_decided",
+    "live_terminal_published",
+    "before_spool_delete",
+    "before_key_delete",
+    "destruction_api_return",
+)
+_CRASH_BOUNDARY_ARM_FILE = "/tmp/com.enviouswispr.crash-boundary-arm"
+_CRASH_BOUNDARY_REACHED_FILE = "/tmp/com.enviouswispr.crash-boundary-reached"
+
+
+def _validate_crash_boundary(boundary: str) -> None:
+    if boundary not in CRASH_BOUNDARIES:
+        raise ValueError(f"unknown crash boundary {boundary!r}; must be one of {CRASH_BOUNDARIES}")
+
+
+def clear_crash_boundary_artifacts() -> None:
+    """Remove both signal files. MUST run before every arm and after every
+    relaunch — kill -9 prevents in-process cleanup, and a stale reached file
+    must never authorize a kill."""
+    import os
+
+    for path in (_CRASH_BOUNDARY_ARM_FILE, _CRASH_BOUNDARY_REACHED_FILE):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+
+def arm_crash_boundary(boundary: str, trial_id: str) -> str:
+    """Clear stale artifacts, then arm the exact (boundary, trial) pair via the
+    endpoint. Returns only after the app acknowledged the arm (OK)."""
+    _validate_crash_boundary(boundary)
+    if not trial_id:
+        raise ValueError("trial_id must be non-empty")
+    clear_crash_boundary_artifacts()
+    reply = send(f"clear_crash_boundary")
+    if reply != "OK":
+        raise RuntimeError(f"clear_crash_boundary failed: {reply!r}")
+    reply = send(f"arm_crash_boundary({boundary},{trial_id})")
+    if reply != "OK":
+        raise RuntimeError(f"arm_crash_boundary failed: {reply!r}")
+    return reply
+
+
+def read_crash_boundary_reached(boundary: str, trial_id: str) -> bool:
+    """The authoritative post-hold query: a direct plist read of the reached
+    artifact requiring the EXACT pair. Missing, malformed, mismatched-trial,
+    and mismatched-boundary records all read False (fail closed). Never uses
+    the endpoint — a hold may deliberately stop the app's main thread."""
+    import plistlib
+
+    _validate_crash_boundary(boundary)
+    if not trial_id:
+        return False
+    try:
+        with open(_CRASH_BOUNDARY_REACHED_FILE, "rb") as fh:
+            record = plistlib.load(fh)
+    except (FileNotFoundError, plistlib.InvalidFileException, OSError, ValueError):
+        return False
+    if not isinstance(record, dict):
+        return False
+    return record.get("trialID") == trial_id and record.get("boundary") == boundary
+
+
+def wait_crash_boundary_reached(boundary: str, trial_id: str, deadline_sec: float = 30.0) -> bool:
+    """Bounded external poll of the reached artifact (short intervals; elapsed
+    time is never evidence — only the exact record authorizes kill -9)."""
+    import time
+
+    _validate_crash_boundary(boundary)
+    end = time.monotonic() + deadline_sec
+    while time.monotonic() < end:
+        if read_crash_boundary_reached(boundary, trial_id):
+            return True
+        time.sleep(0.05)
+    return False
+
+
 def main(argv: list[str]) -> int:
     if not argv or argv[0] in ("-h", "--help", "list", "list_scenarios"):
         print_scenarios()


### PR DESCRIPTION
Closes #1755.

## What this does (founder doctrine, Gate 2 2026-07-23)

A dictation that fails while the app is ALIVE gets its one in-session rescue; if that fails, the audio is discarded — every one of the nine live endings now requests best-effort deletion of the recovery spool + key. Next-launch replay is reserved for the genuine app-gone orphan (and the History-save self-heal case). Retry timeout/cancel keep their honest `.attempted` diagnostic but delete (founder override of the PR #1725 retention precedent): a visible retry failure is a failure to the user.

## The six chunks (each CHUNK-CLEAN in the persistent orchestrator session)

1. **ASR helper death resolves suspended decodes** — pending-transcribe continuation registry drained by both XPC death handlers (the #1388 defect class, now for transcribe).
2. **A text-processing throw delivers the raw transcript** instead of publishing `.failed(.emptyAfterProcessing)` over deliverable text (heart rule).
3. **Transcribe-phase helper death enters the existing Phase-2 retry** — no early `.asrInterrupted(false)` terminal; rescue delivers exactly once or exhausts into the discard.
4. **Deletion-failure + #1709 salvage-cancelled breadcrumbs** (failure-only, component+source, no identifying data); detached key delete retains the coordinator so a racing dealloc can't drop the crumb.
5. **The policy flip** — all nine `RecordingRecoveryEnding` cells delete; exhaustive switch, no default; full retention-language sweep across production comments and freeze tests.
6. **DEBUG crash-boundary holds** — five trialID-keyed one-shot boundaries with real holds, acknowledged arming, fail-closed external queries; Release binary scrubbed to zero symbols/strings.

## Validation

- Full suite green: 3,699 + 178 tests. Fresh whole-diff local Codex review: clean first pass. Plan reached PROCEED-AS-PLANNED across 7 grounded rounds; audits in docs/audits/2026-07-23-1755-*.
- **Live UAT (rebuilt debug app, real audio verified audible in-window):** retry exhaustion discards in-session (spool+key gone, relaunch replays nothing, no History row) · crash mid-recording recovers verbatim into History on relaunch (including an unplanned real-voice proof: the founder's own dictation was mid-flight during a drill kill and came back isRecovered=true) · kill -9 during the in-flight retry leaves the marker-free spool and recovers exactly once on relaunch · helper death mid-decode rescues invisibly (delivered once, 1.25s total) · all five crash-atomicity boundaries held, killed, and matched the predicted disk states.
- UAT harness lesson captured: two false findings (a "replay deletes without recovering" scare, filed and closed as #1760, and an "instant rescue failure") were both a silent-audio harness artifact — TTS playback was never verified inside the capture window.

## Notes

- `.asrRetryExhausted` remains a distinct typed diagnostic; it now agrees with `.failed` on deletion.
- Deletion stays a best-effort request (crash-atomicity decision: Bible Open decision #5 Option B, documented) — no tombstones or durability machinery.
- Cross-process relocation hazard split to #1756. Supersedes #1745/#1749 (their fuel — wrongly retained non-crash items — no longer exists).