### PR TITLE
feat(user): bulk-import enrichment for Custom Words (#1701)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BulkImportEnrichmentCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/BulkImportEnrichmentCoordinator.swift
@@ -2,28 +2,28 @@ import EnviousWisprCore
 import EnviousWisprPostProcessing
 import Foundation
 
-/// Background bulk-import-enrichment producer (#1701 Chunk 2), sibling of
+/// Background bulk-import-enrichment producer (#1701), sibling of
 /// `ContactsImportCoordinator`. Shares `WordSuggestionService`'s permit lane
 /// via the injected `AliasSuggesting` seam. Limb, not heart: depends only on
 /// `CustomWordsCoordinator` and an injected `any AliasSuggesting`. The
 /// durable queue is always a fresh scan of `enrichmentPending`, never an
-/// in-memory job list — a fresh instance, or a second app instance (#1747),
-/// finds the same work by re-scanning.
+/// in-memory list — a fresh or second app instance (#1747) re-scans it.
 @MainActor
 final class BulkImportEnrichmentCoordinator {
   private let customWords: CustomWordsCoordinator
   private let aliasSuggester: any AliasSuggesting
   /// Narrow closure into the transient-pill mechanism (`di-narrow-homes`).
   private let presentStatus: (String) -> Void
+  /// Cancellable timing seam for bounded `.libraryBusy` recovery (#1701).
+  /// Tests substitute a signal-recording stub, never wall-clock time.
+  private let retrySleep: @Sendable (Duration) async throws -> Void
 
   private var drainTask: Task<Void, Never>?
   /// A superseded task whose generation no longer matches must not act.
   private var generation = 0
-  /// Single-flight wake: consumed by the loop so a mid-drain request is
-  /// never lost, never a second concurrent walker.
+  /// Single-flight wake: never a lost mid-drain request, never a second walker.
   private var drainRequestedAgain = false
-  /// Checked only BEFORE starting the next word's call; in-flight always
-  /// finishes and checkpoints normally.
+  /// Checked only BEFORE the next word; in-flight always finishes and checkpoints.
   private var cancelRequested = false
   /// Whether the "started" pill has fired for the CURRENT session.
   private var didAnnounceStart = false
@@ -37,26 +37,31 @@ final class BulkImportEnrichmentCoordinator {
   private static let startMessage =
     "Importing your words now. Check progress in the Your Words menu."
   private static let finishMessage = "Finished importing your words."
+  /// Same shipped 1/2/4s schedule as `ManifestFetchTask`, not a new timing invention.
+  private static let busyRetryDelays: [Duration] = [.seconds(1), .seconds(2), .seconds(4)]
 
-  /// `.failed` hard-stops the loop regardless of `drainRequestedAgain` —
-  /// never retry a broken repair/read/write in a tight loop.
-  private enum DrainPassOutcome { case completedNormally, failed }
+  /// `.retryable` (transient `.libraryBusy`) retries silently until
+  /// exhausted. `.failed` hard-stops regardless of `drainRequestedAgain`.
+  private enum DrainPassOutcome { case completedNormally, retryable, failed }
   private enum DrainStatus: String { case checkpoint, completed, cancelled, failed }
 
   init(
     customWords: CustomWordsCoordinator,
     aliasSuggester: any AliasSuggesting,
-    presentStatus: @escaping (String) -> Void
+    presentStatus: @escaping (String) -> Void,
+    retrySleep: @escaping @Sendable (Duration) async throws -> Void = {
+      try await Task.sleep(for: $0)
+    }
   ) {
     self.customWords = customWords
     self.aliasSuggester = aliasSuggester
     self.presentStatus = presentStatus
+    self.retrySleep = retrySleep
   }
 
   /// Wake the drain — called at launch and after every nonempty import
   /// commit. Single-flight. Never gated on `isAvailable`: `suggestAliases`
-  /// resolves to `nil` safely when unavailable, an honest "tried, got
-  /// nothing" (D16 fail-open).
+  /// resolves to `nil` safely when unavailable, an honest "tried, got nothing".
   func requestDrain() {
     guard drainTask == nil else {
       drainRequestedAgain = true
@@ -77,8 +82,7 @@ final class BulkImportEnrichmentCoordinator {
     await drainTask?.value
   }
 
-  /// Never hard-cancels an in-flight call; the sweep runs only once the loop
-  /// observes this and exits.
+  /// Never hard-cancels an in-flight call; the sweep runs once the loop exits.
   func cancel() {
     guard drainTask != nil else {
       performCancelSweep()
@@ -88,9 +92,27 @@ final class BulkImportEnrichmentCoordinator {
   }
 
   private func runDrainLoop(generation gen: Int) async {
-    repeat {
+    // Attempt index is local to this pass, never stored session state — a
+    // fresh `requestDrain()` gets a fresh retry budget; success resets it.
+    outer: repeat {
       drainRequestedAgain = false
-      if case .failed = await drainOnce(generation: gen) { break }
+      for attempt in 0...Self.busyRetryDelays.count {
+        switch await drainOnce(generation: gen) {
+        case .completedNormally: break
+        case .failed: break outer
+        case .retryable:
+          guard attempt < Self.busyRetryDelays.count else {
+            // Exhausted: same one `.failed` log a permanent failure gets,
+            // then hard-stop — pending flags and the total stay intact for a
+            // later explicit wake to resume this same lingering session.
+            logCheckpoint(status: .failed)
+            break outer
+          }
+          try? await retrySleep(Self.busyRetryDelays[attempt])
+          continue
+        }
+        break
+      }
     } while drainRequestedAgain && gen == generation && !cancelRequested
     guard gen == generation else { return }  // superseded — a newer generation owns cleanup
     drainTask = nil
@@ -100,19 +122,27 @@ final class BulkImportEnrichmentCoordinator {
     }
   }
 
+  /// Transient `.libraryBusy` retries the same pass; everything else
+  /// (unreadable/corrupted files, coordination, ordinary write failures) is
+  /// an immediate hard stop, logged once here.
+  private func drainFailure(_ error: Error) -> DrainPassOutcome {
+    if error as? CustomWordsPersistenceError == .libraryBusy { return .retryable }
+    logCheckpoint(status: .failed)
+    return .failed
+  }
+
   private func drainOnce(generation gen: Int) async -> DrainPassOutcome {
-    customWords.repairPendingEnrichmentTotalIfNeeded()
-    if customWords.customWordError != nil {
-      logCheckpoint(status: .failed)
-      return .failed
+    do {
+      try customWords.repairPendingEnrichmentTotalIfNeeded()
+    } catch {
+      return drainFailure(error)
     }
     guard let pending = customWords.pendingEnrichmentWords() else {
       logCheckpoint(status: .failed)
       return .failed
     }
     guard !pending.isEmpty else {
-      // An unfinalized prior pass (its final scan failed after checkpointing
-      // everything) must finalize now, or it blocks the next session's pill.
+      // An unfinalized prior pass must finalize now, or it blocks the pill.
       finalizeLingeringSessionIfNeeded()
       return .completedNormally
     }
@@ -124,25 +154,30 @@ final class BulkImportEnrichmentCoordinator {
 
     var buffer: [CustomWordEnrichmentResult] = []
 
-    @discardableResult
-    func flush() -> Bool {
-      guard !buffer.isEmpty else { return true }
-      let error = customWords.applyEnrichmentResults(buffer)
-      buffer.removeAll(keepingCapacity: true)
-      return error == nil
+    // Never retains a stale buffer across a retry: a busy checkpoint
+    // propagates out of `drainOnce`; the next attempt starts fresh.
+    func flush() throws {
+      guard !buffer.isEmpty else { return }
+      defer { buffer.removeAll(keepingCapacity: true) }
+      try customWords.applyEnrichmentResults(buffer)
     }
 
     for word in pending {
       guard gen == generation, !cancelRequested else { break }
-      // `word` from this pass's ONE initial scan, never a per-word re-read
-      // (an O(n²) main-thread path) — the checkpoint's own pending-gate
-      // already makes a stale word a safe no-op.
-      let raw = await aliasSuggester.suggestAliases(
-        for: word.canonical, category: word.category, priority: .background)
+      // `word` from this pass's ONE initial scan, never a per-word re-read —
+      // the checkpoint's own pending-gate makes a stale word a safe no-op.
+      let raw: [String]?
+      if word.category == .general {
+        // Never a confirmed classification, only the type default — classify
+        // first rather than force-feeding the general-word prompt.
+        raw = await aliasSuggester.suggestAliases(for: word.canonical, priority: .background)
+      } else {
+        raw = await aliasSuggester.suggestAliases(
+          for: word.canonical, category: word.category, priority: .background)
+      }
 
-      // Always recorded, even if `cancelRequested` flipped true mid-call —
-      // "allow it to finish and checkpoint normally." Only the loop guard
-      // above, checked before STARTING the next call, stops further work.
+      // Always recorded, even if `cancelRequested` flipped mid-call — only
+      // the loop guard above, checked before the NEXT call, stops work.
       processedThisSession += 1
       if let raw, !raw.isEmpty {
         succeededWithAliases += 1
@@ -154,21 +189,22 @@ final class BulkImportEnrichmentCoordinator {
       buffer.append(CustomWordEnrichmentResult(id: word.id, generatedAliases: raw ?? []))
 
       if buffer.count >= Self.checkpointChunkSize {
-        guard flush() else {
-          logCheckpoint(status: .failed)
-          return .failed
+        do {
+          try flush()
+        } catch {
+          return drainFailure(error)
         }
         logCheckpoint(status: .checkpoint)
       }
     }
 
-    guard flush() else {
-      logCheckpoint(status: .failed)
-      return .failed
+    do {
+      try flush()
+    } catch {
+      return drainFailure(error)
     }
 
-    // A FAILED final read is its own terminal outcome, never folded into
-    // "read fine, still not empty."
+    // A FAILED final read is its own terminal outcome, not "still not empty".
     guard let stillPendingAfter = customWords.pendingEnrichmentWords() else {
       logCheckpoint(status: .failed)
       return .failed
@@ -190,8 +226,7 @@ final class BulkImportEnrichmentCoordinator {
   }
 
   private func performCancelSweep() {
-    // Report .cancelled and reset state ONLY once the sweep succeeds — a
-    // failed write is never logged as a clean cancel.
+    // A failed write is never logged as a clean cancel.
     guard customWords.cancelEnrichment() == nil else {
       logCheckpoint(status: .failed)
       return

--- a/Sources/EnviousWisprAppKit/App/BulkImportEnrichmentCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/BulkImportEnrichmentCoordinator.swift
@@ -1,0 +1,224 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import Foundation
+
+/// Background bulk-import-enrichment producer (#1701 Chunk 2), sibling of
+/// `ContactsImportCoordinator`. Shares `WordSuggestionService`'s permit lane
+/// via the injected `AliasSuggesting` seam. Limb, not heart: depends only on
+/// `CustomWordsCoordinator` and an injected `any AliasSuggesting`. The
+/// durable queue is always a fresh scan of `enrichmentPending`, never an
+/// in-memory job list — a fresh instance, or a second app instance (#1747),
+/// finds the same work by re-scanning.
+@MainActor
+final class BulkImportEnrichmentCoordinator {
+  private let customWords: CustomWordsCoordinator
+  private let aliasSuggester: any AliasSuggesting
+  /// Narrow closure into the transient-pill mechanism (`di-narrow-homes`).
+  private let presentStatus: (String) -> Void
+
+  private var drainTask: Task<Void, Never>?
+  /// A superseded task whose generation no longer matches must not act.
+  private var generation = 0
+  /// Single-flight wake: consumed by the loop so a mid-drain request is
+  /// never lost, never a second concurrent walker.
+  private var drainRequestedAgain = false
+  /// Checked only BEFORE starting the next word's call; in-flight always
+  /// finishes and checkpoints normally.
+  private var cancelRequested = false
+  /// Whether the "started" pill has fired for the CURRENT session.
+  private var didAnnounceStart = false
+  /// Local `AppLogger` diagnostics only; reset at every terminal boundary.
+  private var succeededWithAliases = 0
+  private var attemptedWithNothingUseful = 0
+  private var timedOutOrUnavailable = 0
+  private var processedThisSession = 0
+
+  private static let checkpointChunkSize = 25
+  private static let startMessage =
+    "Importing your words now. Check progress in the Your Words menu."
+  private static let finishMessage = "Finished importing your words."
+
+  /// `.failed` hard-stops the loop regardless of `drainRequestedAgain` —
+  /// never retry a broken repair/read/write in a tight loop.
+  private enum DrainPassOutcome { case completedNormally, failed }
+  private enum DrainStatus: String { case checkpoint, completed, cancelled, failed }
+
+  init(
+    customWords: CustomWordsCoordinator,
+    aliasSuggester: any AliasSuggesting,
+    presentStatus: @escaping (String) -> Void
+  ) {
+    self.customWords = customWords
+    self.aliasSuggester = aliasSuggester
+    self.presentStatus = presentStatus
+  }
+
+  /// Wake the drain — called at launch and after every nonempty import
+  /// commit. Single-flight. Never gated on `isAvailable`: `suggestAliases`
+  /// resolves to `nil` safely when unavailable, an honest "tried, got
+  /// nothing" (D16 fail-open).
+  func requestDrain() {
+    guard drainTask == nil else {
+      drainRequestedAgain = true
+      return
+    }
+    generation += 1
+    let gen = generation
+    cancelRequested = false
+    drainTask = Task { [weak self] in
+      await self?.runDrainLoop(generation: gen)
+    }
+  }
+
+  // periphery:ignore - test seam
+  /// Deterministically waits for the whole loop, called right after
+  /// `requestDrain()` assigns `drainTask` synchronously.
+  func awaitDrainForTesting() async {
+    await drainTask?.value
+  }
+
+  /// Never hard-cancels an in-flight call; the sweep runs only once the loop
+  /// observes this and exits.
+  func cancel() {
+    guard drainTask != nil else {
+      performCancelSweep()
+      return
+    }
+    cancelRequested = true
+  }
+
+  private func runDrainLoop(generation gen: Int) async {
+    repeat {
+      drainRequestedAgain = false
+      if case .failed = await drainOnce(generation: gen) { break }
+    } while drainRequestedAgain && gen == generation && !cancelRequested
+    guard gen == generation else { return }  // superseded — a newer generation owns cleanup
+    drainTask = nil
+    if cancelRequested {
+      performCancelSweep()
+      cancelRequested = false
+    }
+  }
+
+  private func drainOnce(generation gen: Int) async -> DrainPassOutcome {
+    customWords.repairPendingEnrichmentTotalIfNeeded()
+    if customWords.customWordError != nil {
+      logCheckpoint(status: .failed)
+      return .failed
+    }
+    guard let pending = customWords.pendingEnrichmentWords() else {
+      logCheckpoint(status: .failed)
+      return .failed
+    }
+    guard !pending.isEmpty else {
+      // An unfinalized prior pass (its final scan failed after checkpointing
+      // everything) must finalize now, or it blocks the next session's pill.
+      finalizeLingeringSessionIfNeeded()
+      return .completedNormally
+    }
+    guard !cancelRequested else { return .completedNormally }  // no pill on a pre-start cancel
+    if !didAnnounceStart {
+      presentStatus(Self.startMessage)
+      didAnnounceStart = true
+    }
+
+    var buffer: [CustomWordEnrichmentResult] = []
+
+    @discardableResult
+    func flush() -> Bool {
+      guard !buffer.isEmpty else { return true }
+      let error = customWords.applyEnrichmentResults(buffer)
+      buffer.removeAll(keepingCapacity: true)
+      return error == nil
+    }
+
+    for word in pending {
+      guard gen == generation, !cancelRequested else { break }
+      // `word` from this pass's ONE initial scan, never a per-word re-read
+      // (an O(n²) main-thread path) — the checkpoint's own pending-gate
+      // already makes a stale word a safe no-op.
+      let raw = await aliasSuggester.suggestAliases(
+        for: word.canonical, category: word.category, priority: .background)
+
+      // Always recorded, even if `cancelRequested` flipped true mid-call —
+      // "allow it to finish and checkpoint normally." Only the loop guard
+      // above, checked before STARTING the next call, stops further work.
+      processedThisSession += 1
+      if let raw, !raw.isEmpty {
+        succeededWithAliases += 1
+      } else if raw == nil {
+        timedOutOrUnavailable += 1
+      } else {
+        attemptedWithNothingUseful += 1
+      }
+      buffer.append(CustomWordEnrichmentResult(id: word.id, generatedAliases: raw ?? []))
+
+      if buffer.count >= Self.checkpointChunkSize {
+        guard flush() else {
+          logCheckpoint(status: .failed)
+          return .failed
+        }
+        logCheckpoint(status: .checkpoint)
+      }
+    }
+
+    guard flush() else {
+      logCheckpoint(status: .failed)
+      return .failed
+    }
+
+    // A FAILED final read is its own terminal outcome, never folded into
+    // "read fine, still not empty."
+    guard let stillPendingAfter = customWords.pendingEnrichmentWords() else {
+      logCheckpoint(status: .failed)
+      return .failed
+    }
+    if gen == generation, !cancelRequested, stillPendingAfter.isEmpty {
+      finalizeLingeringSessionIfNeeded()
+    } else {
+      logCheckpoint(status: .checkpoint)
+    }
+    return .completedNormally
+  }
+
+  private func finalizeLingeringSessionIfNeeded() {
+    guard didAnnounceStart || processedThisSession > 0 else { return }
+    logCheckpoint(status: .completed)
+    presentStatus(Self.finishMessage)
+    didAnnounceStart = false
+    resetSessionCounters()
+  }
+
+  private func performCancelSweep() {
+    // Report .cancelled and reset state ONLY once the sweep succeeds — a
+    // failed write is never logged as a clean cancel.
+    guard customWords.cancelEnrichment() == nil else {
+      logCheckpoint(status: .failed)
+      return
+    }
+    didAnnounceStart = false
+    logCheckpoint(status: .cancelled)
+    resetSessionCounters()
+  }
+
+  private func resetSessionCounters() {
+    succeededWithAliases = 0
+    attemptedWithNothingUseful = 0
+    timedOutOrUnavailable = 0
+    processedThisSession = 0
+  }
+
+  private func logCheckpoint(status: DrainStatus) {
+    let succeeded = succeededWithAliases
+    let nothingUseful = attemptedWithNothingUseful
+    let timedOut = timedOutOrUnavailable
+    let processed = processedThisSession
+    Task {
+      await AppLogger.shared.log(
+        "\(status.rawValue): succeeded=\(succeeded) nothingUseful=\(nothingUseful) "
+          + "timedOutOrUnavailable=\(timedOut) processedThisSession=\(processed)",
+        level: .info, category: "CustomWordsEnrichment"
+      )
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/ContactsImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/ContactsImportCoordinator.swift
@@ -338,7 +338,8 @@ final class ContactsImportCoordinator {
         enrichmentProgress?.done = attempted
         continue
       }
-      let raw = await suggester.suggestAliases(for: current.canonical, category: .person)
+      let raw = await suggester.suggestAliases(
+        for: current.canonical, category: .person, priority: .background)
       if Task.isCancelled { return }  // post-await: never write for a cancelled job
       attempted += 1
       enrichmentProgress?.done = attempted

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -367,9 +367,12 @@ final class CustomWordsCoordinator {
   /// One-time self-heal: repairs a `nil` durable total to the current live
   /// pending count when pending words exist but no total does. Adopts the
   /// (possibly just-repaired) total either way. Called by the background
-  /// coordinator before it begins draining.
+  /// coordinator before it begins draining. Throws (Phase 3 review finding
+  /// B, #1701) rather than silently falling back to the stale total, so a
+  /// caller can distinguish a transient `.libraryBusy` from a permanent
+  /// failure and retry accordingly.
   @discardableResult
-  func repairPendingEnrichmentTotalIfNeeded() -> Int? {
+  func repairPendingEnrichmentTotalIfNeeded() throws -> Int? {
     do {
       let total = try manager.repairPendingEnrichmentTotalIfNeeded()
       pendingEnrichmentBatchTotal = total
@@ -377,7 +380,7 @@ final class CustomWordsCoordinator {
       return total
     } catch {
       _ = note(error)
-      return pendingEnrichmentBatchTotal
+      throw error
     }
   }
 
@@ -386,8 +389,9 @@ final class CustomWordsCoordinator {
   /// one without the other. Fires `onWordsChanged` only when something in
   /// this batch actually still needed applying (first-terminal-action-wins:
   /// a checkpoint that only contains already-resolved IDs is a no-op).
-  @discardableResult
-  func applyEnrichmentResults(_ results: [CustomWordEnrichmentResult]) -> String? {
+  /// Throws (Phase 3 review finding B, #1701) so a caller can distinguish a
+  /// transient `.libraryBusy` from a permanent failure and retry accordingly.
+  func applyEnrichmentResults(_ results: [CustomWordEnrichmentResult]) throws {
     do {
       let outcome = try manager.applyEnrichmentResults(results)
       let snapshot = outcome.snapshot
@@ -407,9 +411,9 @@ final class CustomWordsCoordinator {
       }
       customWordError = nil
       if changed { onWordsChanged?(customWords) }
-      return nil
     } catch {
-      return note(error)
+      _ = note(error)
+      throw error
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsCoordinator.swift
@@ -3,6 +3,17 @@ import EnviousWisprPostProcessing
 import Foundation
 import Observation
 
+/// The progress card's word-transform display (#1701 Chunk 2): the most
+/// recently checkpointed word plus its freshly generated aliases. The
+/// checkpoint batch itself never carries canonical text (only id +
+/// generatedAliases, keeping persistence minimal) — `CustomWordsCoordinator`
+/// synthesizes this by matching the batch's last result against the
+/// just-reloaded snapshot, which does have it.
+struct CustomWordEnrichmentDisplay: Sendable, Equatable {
+  let canonical: String
+  let generatedAliases: [String]
+}
+
 /// Manages custom word state, CRUD operations, and persistence.
 @MainActor @Observable
 final class CustomWordsCoordinator {
@@ -16,6 +27,32 @@ final class CustomWordsCoordinator {
   /// aside. Separate from the launch flag because corruption does not only
   /// happen at startup, and the archive makes the next read look clean.
   private(set) var didDiscoverCorruptionThisSession = false
+  /// Durable bulk-import-enrichment total (#1701 Chunk 2) — the progress
+  /// card's denominator. `nil` = no run in progress. Initialized alongside
+  /// `customWords` from ONE `loadSnapshot()` call, never loaded separately,
+  /// so the two can never disagree; every checkpoint/Cancel wrapper below
+  /// atomically adopts both together too.
+  private(set) var pendingEnrichmentBatchTotal: Int?
+  /// Progress card's word-transform display (#1701 Chunk 2). Best-effort:
+  /// set from the last APPLIED result in each checkpoint batch (never the
+  /// caller's raw input, which can include results that were skipped,
+  /// sanitized away, or lost first-terminal-action-wins — Codex Chunk 2
+  /// review finding 6), cleared on Cancel and at the start of a genuinely new
+  /// run. Purely a delight/progress cue, never load-bearing for correctness.
+  private(set) var mostRecentEnrichment: CustomWordEnrichmentDisplay?
+
+  /// Live in-memory pending count (#1701 Chunk 2, Codex Chunk 2 review
+  /// finding 5) — the load-bearing signal for "is a background enrichment
+  /// run in progress," derived from the already-observable `customWords`.
+  /// NEVER touches disk: safe to read from a SwiftUI `body` on every render,
+  /// unlike `pendingEnrichmentWords()` (a real locked file read). Progress
+  /// card / sidebar badge visibility and the progress numerator both read
+  /// this, never `pendingEnrichmentBatchTotal`'s mere presence — the total
+  /// can theoretically lag behind live state during the brief self-heal
+  /// window `repairPendingEnrichmentTotalIfNeeded` exists for.
+  var pendingEnrichmentCount: Int {
+    customWords.reduce(into: 0) { if $1.enrichmentPending { $0 += 1 } }
+  }
 
   let suggestionService = WordSuggestionService()
   /// The reused on-device alias generator, exposed as the narrow protocol so the
@@ -25,12 +62,26 @@ final class CustomWordsCoordinator {
 
   /// Called after any mutation so the former root state can sync words to pipelines.
   var onWordsChanged: (([CustomWord]) -> Void)?
+  /// Fires after a successful, NONEMPTY import commit (#1701 Chunk 2) —
+  /// additive alongside `onWordsChanged`, never instead of it; never fires
+  /// for an empty/all-Skip, stale, or failed commit. `WisprBootstrapper`
+  /// wires this to `BulkImportEnrichmentCoordinator.requestDrain()` so a
+  /// commit that lands while the coordinator is idle wakes it, and one that
+  /// lands mid-drain still reaches it (no lost wakeup).
+  var onImportCommitted: (@MainActor () -> Void)?
+  /// Routes Your Words' progress-card Cancel action to
+  /// `BulkImportEnrichmentCoordinator.cancel()` (#1701 Chunk 2) — a narrow
+  /// closure rather than injecting that coordinator into the SwiftUI
+  /// environment, since this is the only interaction the view needs with it.
+  var cancelBulkImportEnrichment: (@MainActor () -> Void)?
 
   private let manager: CustomWordsManager
 
   init() {
     self.manager = CustomWordsManager()
-    customWords = manager.load() ?? []
+    let snapshot = manager.loadSnapshot()
+    customWords = snapshot?.words ?? []
+    pendingEnrichmentBatchTotal = snapshot?.pendingEnrichmentBatchTotal
     wordsLoadFailureAtLaunch = manager.lastLoadFailure
   }
 
@@ -39,7 +90,9 @@ final class CustomWordsCoordinator {
   // periphery:ignore - test seam
   package init(manager: CustomWordsManager) {
     self.manager = manager
-    customWords = manager.load() ?? []
+    let snapshot = manager.loadSnapshot()
+    customWords = snapshot?.words ?? []
+    pendingEnrichmentBatchTotal = snapshot?.pendingEnrichmentBatchTotal
     wordsLoadFailureAtLaunch = manager.lastLoadFailure
   }
 
@@ -97,7 +150,13 @@ final class CustomWordsCoordinator {
 
   @discardableResult
   func refreshFromDiskIfPossible() -> Bool {
-    guard let refreshed = manager.load() else {
+    // `loadSnapshot()`, never `load()` alone (Codex Chunk 2 review round 2
+    // finding 4): words and `pendingEnrichmentBatchTotal` must adopt together
+    // here too, the same atomic-pair guarantee every other read/write path
+    // already honors — otherwise a stale-commit refresh after another app
+    // instance wrote can leave the total pointing at a run that no longer
+    // matches the just-refreshed words.
+    guard let snapshot = manager.loadSnapshot() else {
       // Corruption found DURING the session, not at launch, is still
       // corruption — and it must be remembered (code review r3). The load
       // archives the damaged file aside, so the NEXT attempt sees a
@@ -109,9 +168,20 @@ final class CustomWordsCoordinator {
       }
       return false
     }
-    if refreshed != customWords {
-      customWords = refreshed
-      onWordsChanged?(customWords)
+    // Codex Chunk 2 review round 3 finding 3: words and total adopt
+    // together, but `onWordsChanged` fires ONLY when words actually
+    // changed — a total-only change (another instance's run starting or
+    // ending) must not republish unchanged words to pipelines. The same
+    // nil -> non-nil new-run detection `commitImport` uses clears a stale
+    // display here too, since another instance's fresh run is exactly as
+    // "new" as a local one.
+    let wordsChanged = snapshot.words != customWords
+    let isNewRun = pendingEnrichmentBatchTotal == nil && snapshot.pendingEnrichmentBatchTotal != nil
+    if wordsChanged || snapshot.pendingEnrichmentBatchTotal != pendingEnrichmentBatchTotal {
+      customWords = snapshot.words
+      pendingEnrichmentBatchTotal = snapshot.pendingEnrichmentBatchTotal
+      if isNewRun { mostRecentEnrichment = nil }
+      if wordsChanged { onWordsChanged?(customWords) }
     }
 
     // NOTE: the corrupted-library refusal deliberately does NOT live here.
@@ -150,12 +220,26 @@ final class CustomWordsCoordinator {
   }
 
   /// Apply a reviewed import in one atomic write. Fires `onWordsChanged`
-  /// exactly once, and only when something actually changed.
+  /// exactly once, and only when something actually changed; `onImportCommitted`
+  /// fires alongside it, under the identical `!plan.isEmpty` gate (#1701
+  /// Chunk 2) — an all-Skip commit touches neither `customWords` nor
+  /// `pendingEnrichmentBatchTotal`, matching `manager.commitImport`'s own
+  /// "writes nothing, changes no total" contract for that case.
   func commitImport(_ plan: CustomWordsImportCommitPlan) -> CustomWordsImportCommitOutcome {
     do {
       let receipt = try manager.commitImport(plan, to: &customWords)
       if !plan.isEmpty {
+        // A genuinely NEW run starting (nil -> non-nil) clears any stale
+        // display left over from a previous, already-completed run — an
+        // EXTENDING commit (a run already active) must not reset it, since
+        // that would flicker away a display mid-drain (Codex Chunk 2 review
+        // finding 6).
+        let isNewRun =
+          pendingEnrichmentBatchTotal == nil && receipt.pendingEnrichmentBatchTotal != nil
+        pendingEnrichmentBatchTotal = receipt.pendingEnrichmentBatchTotal
+        if isNewRun { mostRecentEnrichment = nil }
         onWordsChanged?(customWords)
+        onImportCommitted?()
       }
       customWordError = nil
       return .committed(receipt)
@@ -238,6 +322,113 @@ final class CustomWordsCoordinator {
       try manager.updateBatch(words, to: &customWords)
       onWordsChanged?(customWords)
       customWordError = nil
+      return nil
+    } catch {
+      return note(error)
+    }
+  }
+
+  // MARK: - Bulk-import enrichment (#1701 Chunk 2)
+  //
+  // `BulkImportEnrichmentCoordinator` never reaches through to
+  // `CustomWordsManager` directly — this is the sole AppKit adapter, exactly
+  // as it already is for every other Custom Words mutation.
+
+  #if DEBUG
+    // periphery:ignore - test seam
+    /// Forces the Nth call to `pendingEnrichmentWords()` this session to
+    /// return `nil` (a read failure), letting a test deterministically target
+    /// ONE specific call — e.g. the drain loop's final re-scan specifically,
+    /// distinct from its earlier, successful initial scan — without racing
+    /// real file-system timing. Both calls in one drain pass are fully
+    /// synchronous with no suspension point between them, so no external task
+    /// could otherwise intervene between "checkpoint succeeded" and "the
+    /// following scan failed."
+    var forcePendingEnrichmentWordsFailureOnCallForTesting: Int?
+    private var pendingEnrichmentWordsCallCountForTesting = 0
+  #endif
+
+  /// Word list filtered to `enrichmentPending == true` — the durable queue
+  /// itself is this scan over live state, never an in-memory job list. `nil`
+  /// only on the same unrecoverable read failure `customWords` itself would
+  /// report via `customWordError`.
+  func pendingEnrichmentWords() -> [CustomWord]? {
+    #if DEBUG
+      pendingEnrichmentWordsCallCountForTesting += 1
+      if forcePendingEnrichmentWordsFailureOnCallForTesting
+        == pendingEnrichmentWordsCallCountForTesting
+      {
+        return nil
+      }
+    #endif
+    return manager.loadPendingEnrichmentWords()
+  }
+
+  /// One-time self-heal: repairs a `nil` durable total to the current live
+  /// pending count when pending words exist but no total does. Adopts the
+  /// (possibly just-repaired) total either way. Called by the background
+  /// coordinator before it begins draining.
+  @discardableResult
+  func repairPendingEnrichmentTotalIfNeeded() -> Int? {
+    do {
+      let total = try manager.repairPendingEnrichmentTotalIfNeeded()
+      pendingEnrichmentBatchTotal = total
+      customWordError = nil
+      return total
+    } catch {
+      _ = note(error)
+      return pendingEnrichmentBatchTotal
+    }
+  }
+
+  /// Merge-safe, pending-gated checkpoint. Atomically adopts both the
+  /// returned words and the returned total before notifying observers — never
+  /// one without the other. Fires `onWordsChanged` only when something in
+  /// this batch actually still needed applying (first-terminal-action-wins:
+  /// a checkpoint that only contains already-resolved IDs is a no-op).
+  @discardableResult
+  func applyEnrichmentResults(_ results: [CustomWordEnrichmentResult]) -> String? {
+    do {
+      let outcome = try manager.applyEnrichmentResults(results)
+      let snapshot = outcome.snapshot
+      let changed =
+        snapshot.words != customWords
+        || snapshot.pendingEnrichmentBatchTotal != pendingEnrichmentBatchTotal
+      customWords = snapshot.words
+      pendingEnrichmentBatchTotal = snapshot.pendingEnrichmentBatchTotal
+      // Only a result that actually applied non-empty aliases — never the
+      // caller's raw input, which can include skipped/sanitized/collided
+      // results (Codex Chunk 2 review finding 6).
+      if let lastApplied = outcome.applied.last(where: { !$0.generatedAliases.isEmpty }),
+        let word = snapshot.words.first(where: { $0.id == lastApplied.id })
+      {
+        mostRecentEnrichment = CustomWordEnrichmentDisplay(
+          canonical: word.canonical, generatedAliases: lastApplied.generatedAliases)
+      }
+      customWordError = nil
+      if changed { onWordsChanged?(customWords) }
+      return nil
+    } catch {
+      return note(error)
+    }
+  }
+
+  /// Durable Cancel: one locked reload-and-sweep, under the manager's own
+  /// lock, clearing every word CURRENTLY pending — never this coordinator's
+  /// potentially-stale in-memory idea of what was pending — and the durable
+  /// total. Atomically adopts both before notifying observers.
+  @discardableResult
+  func cancelEnrichment() -> String? {
+    do {
+      let snapshot = try manager.cancelEnrichment()
+      let changed =
+        snapshot.words != customWords
+        || snapshot.pendingEnrichmentBatchTotal != pendingEnrichmentBatchTotal
+      customWords = snapshot.words
+      pendingEnrichmentBatchTotal = snapshot.pendingEnrichmentBatchTotal
+      mostRecentEnrichment = nil
+      customWordError = nil
+      if changed { onWordsChanged?(customWords) }
       return nil
     } catch {
       return note(error)

--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -120,6 +120,15 @@ final class CustomWordsImportFlowModel {
   /// commit time and refuses the write if it no longer matches.
   private var baseline = CustomWordsImportLibrarySnapshot(words: [])
   private var candidates: [CustomWordsImportCandidate] = []
+  /// Retained from the loaded batch's `enrichmentEligible` (#1701 Chunk 2) —
+  /// nothing about the originating batch otherwise survives to `confirm()`.
+  /// Reset to the safe default alongside every `abandonWork()` (a fresh
+  /// `begin()`, an explicit `cancel()`, or leaving Review via `goBack()`),
+  /// mirroring `candidates`' own lifecycle: `recompareAfterStaleCommit()`
+  /// deliberately does not call `abandonWork()`, so a stale-triggered
+  /// recompare correctly keeps the ORIGINAL load's eligibility, exactly as it
+  /// keeps `candidates` itself.
+  private var batchEnrichmentEligible = true
   private var generation = 0
   private var activeTask: Task<Void, Never>?
 
@@ -320,7 +329,8 @@ final class CustomWordsImportFlowModel {
     staleNotice = nil
     beginWork(.committing)
     let plan = CustomWordsImportCommitPlan(
-      baseline: baseline, additions: additions, replacements: [])
+      baseline: baseline, additions: additions, replacements: [],
+      enrichmentEligible: batchEnrichmentEligible)
 
     switch dependencies.commit(plan) {
     case .committed(let receipt):
@@ -353,6 +363,7 @@ final class CustomWordsImportFlowModel {
         return
       }
       candidates = batch.candidates
+      batchEnrichmentEligible = batch.enrichmentEligible
       beginWork(.comparing)
       await compare(candidates: batch.candidates, generation: generation)
     } catch is CancellationError {
@@ -409,6 +420,7 @@ final class CustomWordsImportFlowModel {
   private func abandonWork() -> Int {
     activeTask?.cancel()
     activeTask = nil
+    batchEnrichmentEligible = true
     return advanceGeneration()
   }
 

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -720,13 +720,13 @@ final class RecordingOverlayPanel {
   /// receives only a closure into this method, never the concrete panel type.
   func showImportStatus(message: String) {
     let dismissSeconds = Self.importStatusAutoDismissSeconds
-    guard panel == nil else {
-      transitionToImportStatus(message: message)
-      scheduleAutoDismiss(seconds: dismissSeconds)
-      return
-    }
-    pendingCreateWork?.cancel()
-    pendingCreateWork = nil
+    // Heart & Limbs: bulk-import enrichment is a limb and must never
+    // interrupt the live dictation overlay. If anything is showing, about to
+    // show, or queued to show — recording, processing, another notice — this
+    // pill is silently skipped rather than replacing it (Phase 3 review
+    // finding: the prior transition-in-place branch could close a live
+    // recording panel and cancel a queued one).
+    guard currentIntent == .hidden, panel == nil, pendingCreateWork == nil else { return }
     generation &+= 1
     let token = generation
 
@@ -742,33 +742,6 @@ final class RecordingOverlayPanel {
   }
 
   private static let importStatusAutoDismissSeconds = 3.0
-
-  /// Transition an existing panel to an import-status display.
-  private func transitionToImportStatus(message: String) {
-    guard let existingPanel = panel else { return }
-    let inheritedFrame = existingPanel.frame
-
-    panel = nil
-    autoDismissTask?.cancel()
-    autoDismissTask = nil
-    pendingCreateWork?.cancel()
-    pendingCreateWork = nil
-    CATransaction.flush()
-    existingPanel.close()
-
-    generation &+= 1
-    let token = generation
-
-    let work = DispatchWorkItem { [weak self] in
-      guard let self, self.generation == token else { return }
-      self.pendingCreateWork = nil
-      self.showPanel(
-        content: ImportStatusOverlayView(message: message), width: 320,
-        inheritedFrame: inheritedFrame, fitToContent: true)
-    }
-    pendingCreateWork = work
-    DispatchQueue.main.async(execute: work)
-  }
 
   /// Show a transient warning notice that auto-dismisses after 2.5s.
   func showWarning(message: String) {

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -62,6 +62,21 @@ final class RecordingOverlayPanel {
   /// shows only when `currentIntent == .hidden`).
   private(set) var currentIntent: OverlayIntent = .hidden
 
+  /// Local, generation-stamped ownership record for the bulk-import-status
+  /// pill (#1701 Phase 3 review finding B). Deliberately NOT an `OverlayIntent`
+  /// case — that enum is the dictation/processing pipeline's own intent set;
+  /// import-status UI ownership is local to this panel. The generation match
+  /// is the ownership proof: a stale import record can never authorize
+  /// closing a panel a newer recording or processing transition created.
+  private struct ImportStatusPresentation {
+    let generation: UInt64
+    let message: String
+  }
+  private var importStatusPresentation: ImportStatusPresentation?
+  private var importStatusOwnsCurrentSlot: Bool {
+    currentIntent == .hidden && importStatusPresentation?.generation == generation
+  }
+
   /// Tracks lock state for flicker guard comparison.
   private var isRecordingLocked: Bool = false
 
@@ -721,24 +736,68 @@ final class RecordingOverlayPanel {
   func showImportStatus(message: String) {
     let dismissSeconds = Self.importStatusAutoDismissSeconds
     // Heart & Limbs: bulk-import enrichment is a limb and must never
-    // interrupt the live dictation overlay. If anything is showing, about to
-    // show, or queued to show — recording, processing, another notice — this
-    // pill is silently skipped rather than replacing it (Phase 3 review
-    // finding: the prior transition-in-place branch could close a live
-    // recording panel and cancel a queued one).
-    guard currentIntent == .hidden, panel == nil, pendingCreateWork == nil else { return }
+    // interrupt the live dictation overlay. Accepted only when idle, or when
+    // replacing THIS feature's own prior import-status pill (#1701 Phase 3
+    // review finding B) — never a genuine recording/processing panel.
+    let replacingOwnStatus = importStatusOwnsCurrentSlot
+    guard
+      replacingOwnStatus
+        || (currentIntent == .hidden && panel == nil && pendingCreateWork == nil)
+    else { return }
+
+    let inheritedFrame = replacingOwnStatus ? tearDownOwnedImportStatus() : nil
+
     generation &+= 1
     let token = generation
+    importStatusPresentation = ImportStatusPresentation(generation: token, message: message)
 
     let work = DispatchWorkItem { [weak self] in
-      guard let self, self.generation == token else { return }
+      guard let self, self.generation == token,
+        self.importStatusPresentation?.generation == token
+      else { return }
       self.pendingCreateWork = nil
       self.showPanel(
-        content: ImportStatusOverlayView(message: message), width: 320, fitToContent: true)
+        content: ImportStatusOverlayView(message: message), width: 320,
+        inheritedFrame: inheritedFrame, fitToContent: true)
+      guard self.panel != nil else {
+        // `showPanel` can no-op (no screen available) — never claim false
+        // ownership of a slot with no actual panel.
+        self.importStatusPresentation = nil
+        return
+      }
       self.scheduleAutoDismiss(seconds: dismissSeconds)
     }
     pendingCreateWork = work
     DispatchQueue.main.async(execute: work)
+  }
+
+  /// Tears down THIS feature's own currently-owned import-status
+  /// pending/visible pill, returning its frame if one was visible so a
+  /// replacement can appear in the same place. Never operates on an
+  /// unowned panel (#1701 Phase 3 review finding B) — the previous,
+  /// unrestricted `transitionToImportStatus` (deleted in the round-1 fix)
+  /// is exactly what let this feature close a live recording panel.
+  private func tearDownOwnedImportStatus() -> NSRect? {
+    guard importStatusOwnsCurrentSlot else { return nil }
+    pendingCreateWork?.cancel()
+    pendingCreateWork = nil
+    guard let existingPanel = panel else { return nil }
+    let frame = existingPanel.frame
+    panel = nil
+    autoDismissTask?.cancel()
+    autoDismissTask = nil
+    CATransaction.flush()
+    existingPanel.close()
+    return frame
+  }
+
+  // periphery:ignore - test seam
+  /// Projects the currently-owned import-status message without exposing
+  /// panel/NSPanel internals (#1701 Phase 3 review finding B) — lets a
+  /// headless test assert the state-machine outcome without rendering.
+  var importStatusMessageForTesting: String? {
+    guard importStatusOwnsCurrentSlot else { return nil }
+    return importStatusPresentation?.message
   }
 
   private static let importStatusAutoDismissSeconds = 3.0
@@ -1245,6 +1304,7 @@ final class RecordingOverlayPanel {
     autoDismissTask?.cancel()
     autoDismissTask = nil
     generation &+= 1
+    importStatusPresentation = nil
     // Cancel any pending deferred panel creation so it never fires.
     // This handles the rapid-ESC race: if hide() is called before the
     // DispatchQueue.main.async closure from show() has had a chance to run,

--- a/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
+++ b/Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift
@@ -709,6 +709,67 @@ final class RecordingOverlayPanel {
     }
   }
 
+  /// One narrow informational-status entry point for the bulk-import-
+  /// enrichment start/finish pills (#1701 Chunk 2). Reuses this same
+  /// non-activating, positioned, auto-dismissing panel shell
+  /// `showWarning`/`showError`/`showNotification` already use, but is
+  /// deliberately NOT routed through `NotificationStyle` — that enum is the
+  /// recording domain's error/warning/interruption intent set, and this
+  /// message is neither; adding a case there would widen an intent enum this
+  /// feature has no business touching. `BulkImportEnrichmentCoordinator`
+  /// receives only a closure into this method, never the concrete panel type.
+  func showImportStatus(message: String) {
+    let dismissSeconds = Self.importStatusAutoDismissSeconds
+    guard panel == nil else {
+      transitionToImportStatus(message: message)
+      scheduleAutoDismiss(seconds: dismissSeconds)
+      return
+    }
+    pendingCreateWork?.cancel()
+    pendingCreateWork = nil
+    generation &+= 1
+    let token = generation
+
+    let work = DispatchWorkItem { [weak self] in
+      guard let self, self.generation == token else { return }
+      self.pendingCreateWork = nil
+      self.showPanel(
+        content: ImportStatusOverlayView(message: message), width: 320, fitToContent: true)
+      self.scheduleAutoDismiss(seconds: dismissSeconds)
+    }
+    pendingCreateWork = work
+    DispatchQueue.main.async(execute: work)
+  }
+
+  private static let importStatusAutoDismissSeconds = 3.0
+
+  /// Transition an existing panel to an import-status display.
+  private func transitionToImportStatus(message: String) {
+    guard let existingPanel = panel else { return }
+    let inheritedFrame = existingPanel.frame
+
+    panel = nil
+    autoDismissTask?.cancel()
+    autoDismissTask = nil
+    pendingCreateWork?.cancel()
+    pendingCreateWork = nil
+    CATransaction.flush()
+    existingPanel.close()
+
+    generation &+= 1
+    let token = generation
+
+    let work = DispatchWorkItem { [weak self] in
+      guard let self, self.generation == token else { return }
+      self.pendingCreateWork = nil
+      self.showPanel(
+        content: ImportStatusOverlayView(message: message), width: 320,
+        inheritedFrame: inheritedFrame, fitToContent: true)
+    }
+    pendingCreateWork = work
+    DispatchQueue.main.async(execute: work)
+  }
+
   /// Show a transient warning notice that auto-dismisses after 2.5s.
   func showWarning(message: String) {
     showNotification(message: message, style: .warning)
@@ -1727,6 +1788,30 @@ struct NotificationOverlayView: View {
     .background(
       style.usesDistressLips
         ? AnyView(DistressCapsuleBackground()) : AnyView(OverlayCapsuleBackground()))
+  }
+}
+
+/// Bulk-import-enrichment start/finish pill (#1701 Chunk 2). Mirrors
+/// `NotificationOverlayView`'s shell with a neutral status icon — this is
+/// neither an error nor a warning, so it does not borrow `NotificationStyle`.
+struct ImportStatusOverlayView: View {
+  let message: String
+
+  var body: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "arrow.triangle.2.circlepath")
+        .foregroundStyle(.white)
+        .font(.system(size: 16))
+      Text(message)
+        .font(.system(size: 13, weight: .medium))
+        .foregroundStyle(.white)
+        .lineLimit(2)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: 280, alignment: .leading)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+    .background(OverlayCapsuleBackground())
   }
 }
 

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -57,6 +57,8 @@ public final class WisprBootstrapper {
   let activeEngine: ActiveEngineOperation
   let customWordsCoordinator: CustomWordsCoordinator
   let contactsImportCoordinator: ContactsImportCoordinator
+  /// #1701 Chunk 2 — UI Cancel routes through `customWordsCoordinator.cancelBulkImportEnrichment`.
+  let bulkImportEnrichmentCoordinator: BulkImportEnrichmentCoordinator
   let setup: SetupCoordinator
   /// #1271 — EG-1 native runtime home (model store + inference server).
   let egOneRuntime: EGOneRuntime
@@ -121,6 +123,25 @@ public final class WisprBootstrapper {
     let contactsImportCoordinator = ContactsImportCoordinator(
       customWords: customWordsCoordinator,
       aliasSuggester: customWordsCoordinator.aliasSuggester)
+    // #1701 Chunk 2: bulk-import-enrichment producer, a sibling of
+    // `contactsImportCoordinator` on the same alias-suggester permit lane.
+    // Construction is unconditional; the DEBUG gate below controls scanning.
+    let bulkImportEnrichmentCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: customWordsCoordinator,
+      aliasSuggester: customWordsCoordinator.aliasSuggester,
+      presentStatus: { [weak recordingOverlay] message in
+        recordingOverlay?.showImportStatus(message: message)
+      })
+    #if DEBUG
+      customWordsCoordinator.onImportCommitted = { [weak bulkImportEnrichmentCoordinator] in
+        bulkImportEnrichmentCoordinator?.requestDrain()
+      }
+      customWordsCoordinator.cancelBulkImportEnrichment = {
+        [weak bulkImportEnrichmentCoordinator] in
+        bulkImportEnrichmentCoordinator?.cancel()
+      }
+      bulkImportEnrichmentCoordinator.requestDrain()
+    #endif
     let customWordsPropagator = CustomWordsPropagator()
     // #633 Phase 9: owns enabled vocabulary-pack state; merges pack terms into
     // the corrector lane (default OFF). Wired into `wireCustomWords` below.
@@ -954,6 +975,7 @@ public final class WisprBootstrapper {
     self.activeEngine = activeEngine
     self.customWordsCoordinator = customWordsCoordinator
     self.contactsImportCoordinator = contactsImportCoordinator
+    self.bulkImportEnrichmentCoordinator = bulkImportEnrichmentCoordinator
     self.setup = setup
     self.whisperKitRetirement = whisperKitRetirement
     self.egOneRuntime = egOneRuntime

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -218,22 +218,23 @@ struct CustomWordEditSheet: View {
       guard !snapshotCanonical.isEmpty, snapshotCanonical == trimmed else { return }
       isLoadingSuggestions = true
       noSuggestionsAvailable = false
-      let suggestions = await service.suggest(for: trimmed)
-      guard !Task.isCancelled else {
+      let fetchResult = await CustomWordSuggestionFlow.fetch(
+        canonical: trimmed,
+        suggest: { await service.suggest(for: $0, priority: .interactive) })
+      guard case .completed(let suggestions) = fetchResult else {
         isLoadingSuggestions = false
         return
       }
-      if let suggestions {
-        if word.aliases.isEmpty {
-          word.aliases = suggestions.suggestedAliases
-        }
-        if word.category == .general {
-          word.category = suggestions.category
-        }
-        suggestionsApplied = true
-      } else {
-        noSuggestionsAvailable = true
-      }
+      // Read word.aliases/word.category LIVE, here, after the await — never a
+      // value captured before it — so a manual edit made while the fetch was
+      // in flight is never silently overwritten (#1701 Grounded Review
+      // Chunk 1 round 2 finding).
+      let outcome = CustomWordSuggestionFlow.apply(
+        suggestions: suggestions, currentAliases: word.aliases, currentCategory: word.category)
+      word.aliases = outcome.aliases
+      word.category = outcome.category
+      suggestionsApplied = outcome.suggestionsApplied
+      noSuggestionsAvailable = outcome.noSuggestionsAvailable
       isLoadingSuggestions = false
     }
   }
@@ -264,4 +265,87 @@ struct CustomWordEditSheet: View {
     }
   }
 
+}
+
+/// The suggestion-fetch-and-apply step of `CustomWordEditSheet`'s
+/// `.task(id:)` body, extracted so it can be driven and characterized by a
+/// unit test without a live view hierarchy (#1701 Grounded Review Chunk 1 —
+/// the founder authorized this extraction after the reviewer stopped the
+/// build for skipping the plan's required Add-term characterization test).
+/// Covers exactly the piece this PR's migration touches: applying the
+/// service's result. The surrounding debounce, empty/already-applied guards,
+/// and loading-indicator choreography stay in the view body, unchanged.
+/// `suggest` is a closure, not a concrete `WordSuggestionService`, so a test
+/// can drive this deterministically without live FoundationModels — the
+/// production call site (above) is what pins the actual `.interactive`
+/// priority argument.
+@MainActor
+enum CustomWordSuggestionFlow {
+  /// `.cancelled` when the calling task was cancelled before `suggest`
+  /// returned (checked AFTER the await, matching the original's post-await
+  /// `!Task.isCancelled` guard) — the caller must discard this entirely and
+  /// leave every `@State` field as it was, never calling `apply`.
+  enum FetchResult {
+    case cancelled
+    case completed(WordSuggestions?)
+  }
+
+  /// The async half: call `suggest` and report whether the calling task
+  /// survived. Deliberately does NOT touch aliases/category at all — see
+  /// `apply` below for why applying the result must happen synchronously,
+  /// after this returns, using live state read at that exact moment.
+  /// `suggest` is `@MainActor`-isolated, matching the view's own isolation —
+  /// it's invoked in place, never sent across actors.
+  static func fetch(
+    canonical: String,
+    suggest: @MainActor (String) async -> WordSuggestions?
+  ) async -> FetchResult {
+    let suggestions = await suggest(canonical)
+    guard !Task.isCancelled else { return .cancelled }
+    return .completed(suggestions)
+  }
+
+  struct Outcome: Equatable {
+    var aliases: [String]
+    var category: WordCategory
+    var suggestionsApplied: Bool
+    var noSuggestionsAvailable: Bool
+  }
+
+  /// Synchronous — mirrors the original inline body's `if let suggestions
+  /// { ... } else { ... }` exactly: aliases/category are only ever set once
+  /// (`if aliases.isEmpty` / `if category == .general`, never overwriting
+  /// what's already there). Being synchronous is the point (#1701 Grounded
+  /// Review Chunk 1 round 2 finding): `currentAliases`/`currentCategory`
+  /// must be the view's LIVE `@State` read by the caller at the moment this
+  /// is called, never a value captured before `fetch`'s await — a manual
+  /// edit made while the suggestion request was in flight must never be
+  /// silently overwritten by a stale pre-await snapshot.
+  static func apply(
+    suggestions: WordSuggestions?,
+    currentAliases: [String],
+    currentCategory: WordCategory
+  ) -> Outcome {
+    var aliases = currentAliases
+    var category = currentCategory
+    var suggestionsApplied = false
+    var noSuggestionsAvailable = false
+    if let suggestions {
+      if aliases.isEmpty {
+        aliases = suggestions.suggestedAliases
+      }
+      if category == .general {
+        category = suggestions.category
+      }
+      suggestionsApplied = true
+    } else {
+      noSuggestionsAvailable = true
+    }
+    return Outcome(
+      aliases: aliases,
+      category: category,
+      suggestionsApplied: suggestionsApplied,
+      noSuggestionsAvailable: noSuggestionsAvailable
+    )
+  }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -7,6 +7,7 @@ struct UnifiedWindowView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(NavigationCoordinator.self) private var navigationCoordinator
   @Environment(UpdateCoordinatorHolder.self) private var updateCoordinatorHolder
+  @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var selectedSection: SettingsSection = .history
 
   var body: some View {
@@ -223,7 +224,10 @@ struct UnifiedWindowView: View {
       }
     } else {
       let selected = selectedSection == section
-      SidebarNavRow(label: section.label, isSelected: selected) {
+      SidebarNavRow(
+        label: section.label, isSelected: selected,
+        showsBadge: yourWordsEnrichmentBadgeVisible(for: section)
+      ) {
         Image(systemName: section.icon)
           .font(.system(size: 15, weight: .medium))
           .foregroundStyle(selected ? .white : .stAccent)
@@ -231,6 +235,22 @@ struct UnifiedWindowView: View {
         selectedSection = section
       }
     }
+  }
+
+  /// The load-bearing notification surface for a background bulk-import
+  /// enrichment run (#1701 Chunk 2, plan §3.1 point 6): independent of
+  /// whether either transient pill was ever seen, this badge tells the
+  /// founder something is in progress just by opening Settings at all.
+  /// DEBUG-only because the whole import feature is (§316). Reads
+  /// `pendingEnrichmentCount` (observable in-memory), never the total's mere
+  /// presence — same reasoning as the progress card (Codex Chunk 2 review
+  /// finding 5).
+  private func yourWordsEnrichmentBadgeVisible(for section: SettingsSection) -> Bool {
+    #if DEBUG
+      section == .wordCorrection && customWordsCoordinator.pendingEnrichmentCount > 0
+    #else
+      false
+    #endif
   }
 
   /// The centered top-bar identity: the brand mark plus the app wordmark. Held
@@ -266,6 +286,9 @@ struct UnifiedWindowView: View {
 private struct SidebarNavRow<Icon: View>: View {
   let label: String
   let isSelected: Bool
+  /// Small in-progress dot (#1701 Chunk 2). Paired with an accessibility
+  /// value rather than color/shape alone, per accessibility-noncolor-motion.
+  var showsBadge: Bool = false
   @ViewBuilder var icon: () -> Icon
   let action: () -> Void
 
@@ -280,6 +303,12 @@ private struct SidebarNavRow<Icon: View>: View {
           .lineLimit(1)
           .minimumScaleFactor(0.85)
         Spacer(minLength: 2)
+        if showsBadge {
+          Circle()
+            .fill(isSelected ? Color.white : Color.stAccentSolid)
+            .frame(width: 7, height: 7)
+            .accessibilityHidden(true)
+        }
       }
       .padding(.horizontal, 9)
       .padding(.vertical, 8)
@@ -307,6 +336,8 @@ private struct SidebarNavRow<Icon: View>: View {
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
+    .accessibilityLabel(label)
+    .accessibilityValue(showsBadge ? "Importing in progress" : "")
     .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -110,6 +110,31 @@ struct YourWordsView: View {
         }
       }
 
+      #if DEBUG
+        // Same DEBUG-only doorway as the rest of the import feature (#1619):
+        // this card can only ever appear if the DEBUG-only "Preview import"
+        // button above committed a batch, so it stays behind the same gate
+        // rather than a redundant runtime check.
+        //
+        // Visibility and the progress numerator both read `pendingEnrichmentCount`
+        // — the observable in-memory count, never `pendingEnrichmentWords()`
+        // (a real locked file read) and never the total's mere presence
+        // (Codex Chunk 2 review finding 5: neither belongs in a SwiftUI
+        // `body`, and the durable total can theoretically lag live state
+        // during the brief self-heal window). The durable total remains the
+        // denominator when available, falling back to the live count itself
+        // as an honest floor if the total is momentarily nil.
+        let pendingCount = customWordsCoordinator.pendingEnrichmentCount
+        if pendingCount > 0 {
+          BulkImportEnrichmentProgressCard(
+            total: customWordsCoordinator.pendingEnrichmentBatchTotal ?? pendingCount,
+            pendingCount: pendingCount,
+            recent: customWordsCoordinator.mostRecentEnrichment,
+            onCancel: { customWordsCoordinator.cancelBulkImportEnrichment?() }
+          )
+        }
+      #endif
+
       LearningSection()
       VocabPacksSection()
       CustomTermsSection()
@@ -223,6 +248,76 @@ private struct WordsLoadFailureBanner: View {
     .overlay(
       RoundedRectangle(cornerRadius: 10)
         .strokeBorder(Color.stWarning.opacity(0.25), lineWidth: 1)
+    )
+  }
+}
+
+/// Bulk-import-enrichment progress card (#1701 Chunk 2). Visible whenever a
+/// background enrichment run is in progress. Real progress against the
+/// durable total (never a timed animation standing in for it); once at least
+/// one word has actually completed, the word-transform display shows the
+/// actual word and its actual freshly generated aliases (mockup:
+/// docs/feature-requests/issue-1701-mockup-flow.html). A word that completed
+/// with no useful aliases shows no transform row for that moment — nothing
+/// honest to display.
+private struct BulkImportEnrichmentProgressCard: View {
+  let total: Int
+  let pendingCount: Int
+  let recent: CustomWordEnrichmentDisplay?
+  let onCancel: () -> Void
+
+  private var processedCount: Int { max(0, total - pendingCount) }
+  private var fraction: Double {
+    guard total > 0 else { return 0 }
+    return Double(processedCount) / Double(total)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack {
+        Text("Importing your words").settingsRowLabel()
+        Spacer()
+        Button("Cancel", action: onCancel)
+          .buttonStyle(.plain)
+          .font(.stHelper)
+          .foregroundStyle(.stAccent)
+      }
+
+      ProgressView(value: fraction)
+        .tint(.stAccentSolid)
+
+      HStack(alignment: .firstTextBaseline) {
+        Text("\(processedCount) of \(total) processed")
+          .font(.stHelper)
+          .foregroundStyle(.stTextSecondary)
+        Spacer(minLength: 8)
+        if let recent, !recent.generatedAliases.isEmpty {
+          HStack(spacing: 4) {
+            Text(recent.canonical)
+              .foregroundStyle(.stTextBody)
+            Image(systemName: "arrow.right")
+              .font(.system(size: 10, weight: .semibold))
+              .foregroundStyle(.stTextTertiary)
+              .accessibilityHidden(true)
+            Text(recent.generatedAliases.joined(separator: ", "))
+              .foregroundStyle(.stAccent)
+          }
+          .font(.stHelper)
+          .lineLimit(1)
+          .truncationMode(.tail)
+          .accessibilityElement(children: .ignore)
+          .accessibilityLabel(
+            "\(recent.canonical) now recognizes \(recent.generatedAliases.joined(separator: ", "))"
+          )
+        }
+      }
+    }
+    .padding(14)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))
+    .overlay(
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
+        .strokeBorder(Color.stDivider, lineWidth: 1)
     )
   }
 }

--- a/Sources/EnviousWisprCore/CustomWord.swift
+++ b/Sources/EnviousWisprCore/CustomWord.swift
@@ -46,6 +46,13 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
   /// "Match strictness: Loose / Default / Strict" radio. Pre-Phase-2 entries
   /// decode as nil (use global threshold).
   public var minSimilarityOverride: Double?
+  /// Durable bulk-import-enrichment queue flag (#1701 Chunk 2). `true` means
+  /// "eligible and not yet durably checkpointed" — the entire durable work
+  /// queue is a scan over this field, never a separate job list. Set only by
+  /// `CustomWordsManager.commitImport`; cleared only by
+  /// `CustomWordsManager.applyEnrichmentResults` or its Cancel sweep.
+  /// Pre-#1701 entries decode as `false` (`decodeIfPresent(...) ?? false`).
+  public var enrichmentPending: Bool
 
   public init(
     id: UUID = UUID(),
@@ -58,7 +65,8 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     source: WordSource = .user,
     frequencyUsed: Int = 0,
     lastUsed: Date? = nil,
-    minSimilarityOverride: Double? = nil
+    minSimilarityOverride: Double? = nil,
+    enrichmentPending: Bool = false
   ) {
     self.id = id
     self.canonical = canonical
@@ -71,6 +79,7 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     self.frequencyUsed = frequencyUsed
     self.lastUsed = lastUsed
     self.minSimilarityOverride = minSimilarityOverride
+    self.enrichmentPending = enrichmentPending
   }
 
   /// The same word, re-tagged as user-authored (#1680).
@@ -94,7 +103,8 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
       source: .user,
       frequencyUsed: frequencyUsed,
       lastUsed: lastUsed,
-      minSimilarityOverride: minSimilarityOverride
+      minSimilarityOverride: minSimilarityOverride,
+      enrichmentPending: enrichmentPending
     )
   }
 
@@ -107,7 +117,7 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
   // additive forward/backward-compat semantics.
   private enum CodingKeys: String, CodingKey {
     case id, canonical, aliases, category, priority, forceReplace, caseSensitive
-    case frequencyUsed, lastUsed, minSimilarityOverride
+    case frequencyUsed, lastUsed, minSimilarityOverride, enrichmentPending
   }
 
   public init(from decoder: Decoder) throws {
@@ -122,6 +132,7 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     self.frequencyUsed = try c.decodeIfPresent(Int.self, forKey: .frequencyUsed) ?? 0
     self.lastUsed = try c.decodeIfPresent(Date.self, forKey: .lastUsed)
     self.minSimilarityOverride = try c.decodeIfPresent(Double.self, forKey: .minSimilarityOverride)
+    self.enrichmentPending = try c.decodeIfPresent(Bool.self, forKey: .enrichmentPending) ?? false
     self.source = .user
   }
 
@@ -137,6 +148,7 @@ public struct CustomWord: Codable, Identifiable, Sendable, Hashable {
     try c.encode(frequencyUsed, forKey: .frequencyUsed)
     try c.encodeIfPresent(lastUsed, forKey: .lastUsed)
     try c.encodeIfPresent(minSimilarityOverride, forKey: .minSimilarityOverride)
+    try c.encode(enrichmentPending, forKey: .enrichmentPending)
     // source intentionally NOT encoded.
   }
 }

--- a/Sources/EnviousWisprCore/CustomWordsImportContract.swift
+++ b/Sources/EnviousWisprCore/CustomWordsImportContract.swift
@@ -131,17 +131,29 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
   package let sourceDisplayName: String
   package let candidates: [CustomWordsImportCandidate]
   package let notices: [CustomWordsImportNotice]
+  /// Per-BATCH (not per-candidate — one import session is uniformly eligible
+  /// or not), whether newly-added words from this batch should enter the
+  /// bulk-import-enrichment queue (#1701 Chunk 2). Defaults `true` so Paste
+  /// and Smart Import, which never construct this explicitly, stay eligible
+  /// for free. Only `ExportedWordsFileParser` sets this `false`, via
+  /// `FileImportSource.loadRawCandidates()` copying the matched parser's
+  /// `enrichmentEligible` — the user's own backup restore is already as
+  /// complete as it will get, so re-enriching it would waste a model call on
+  /// data that was never eligible in the first place.
+  package let enrichmentEligible: Bool
 
   package init(
     sourceID: String,
     sourceDisplayName: String,
     candidates: [CustomWordsImportCandidate],
-    notices: [CustomWordsImportNotice] = []
+    notices: [CustomWordsImportNotice] = [],
+    enrichmentEligible: Bool = true
   ) {
     self.sourceID = sourceID
     self.sourceDisplayName = sourceDisplayName
     self.candidates = candidates
     self.notices = notices
+    self.enrichmentEligible = enrichmentEligible
   }
 
   /// Refuses the WHOLE batch if any candidate is unstorable.
@@ -200,7 +212,8 @@ package struct CustomWordsImportBatch: Sendable, Equatable {
       sourceID: sourceID,
       sourceDisplayName: sourceDisplayName,
       candidates: candidates.map { $0.trimmed() },
-      notices: notices)
+      notices: notices,
+      enrichmentEligible: enrichmentEligible)
   }
 }
 

--- a/Sources/EnviousWisprPostProcessing/AliasSuggesting.swift
+++ b/Sources/EnviousWisprPostProcessing/AliasSuggesting.swift
@@ -1,5 +1,17 @@
 import EnviousWisprCore
 
+/// Scheduling hint for `WordSuggestionService`'s shared permit queue (#1701).
+/// Does not change what a call returns, only when it runs relative to other
+/// queued calls: an `.interactive` waiter is granted the next permit ahead of
+/// any already-queued `.background` waiter; two waiters of equal priority are
+/// served FIFO. `public` because `WordSuggestionService.suggest(for:priority:)`
+/// is a public API and Swift requires its parameter types be at least as
+/// visible as the function itself.
+public enum AliasSuggestionPriority: Sendable, Equatable {
+  case interactive
+  case background
+}
+
 /// Narrow, on-device alias generator seam. Declared `package` (same-package
 /// consumers only — EnviousWisprAppKit's contacts-import enrichment), mirroring
 /// Core's package narrow protocols. The sole production conformer is
@@ -12,5 +24,9 @@ package protocol AliasSuggesting: Sendable {
   /// Generate spoken-variant aliases for `word`, with the category already known
   /// so no classification call is made. Returns nil when unavailable, timed out,
   /// or the model degenerated to self-echoes (mirrors `suggest(for:)`).
-  func suggestAliases(for word: String, category: WordCategory) async -> [String]?
+  /// `priority` has no default: every caller must state its own scheduling
+  /// intent explicitly rather than silently inheriting `.interactive` (#1701).
+  func suggestAliases(
+    for word: String, category: WordCategory, priority: AliasSuggestionPriority
+  ) async -> [String]?
 }

--- a/Sources/EnviousWisprPostProcessing/AliasSuggesting.swift
+++ b/Sources/EnviousWisprPostProcessing/AliasSuggesting.swift
@@ -34,4 +34,16 @@ package protocol AliasSuggesting: Sendable {
   func suggestAliases(
     for word: String, category: WordCategory, priority: AliasSuggestionPriority
   ) async -> [String]?
+
+  /// Generate aliases for `word` whose category is NOT genuinely known —
+  /// classifies first, then generates from that classification (Phase 3
+  /// review finding A, #1701). A word stored as `.general` because it was
+  /// never explicitly categorized (the type default) must not be force-fed
+  /// the general-word prompt as though `.general` were confirmed; this
+  /// overload gets it a real classification pass first, matching what
+  /// Add-term's `suggest(for:priority:)` already does. Returns nil under the
+  /// same conditions as the known-category overload.
+  func suggestAliases(
+    for word: String, priority: AliasSuggestionPriority
+  ) async -> [String]?
 }

--- a/Sources/EnviousWisprPostProcessing/AliasSuggesting.swift
+++ b/Sources/EnviousWisprPostProcessing/AliasSuggesting.swift
@@ -18,7 +18,12 @@ public enum AliasSuggestionPriority: Sendable, Equatable {
 /// `WordSuggestionService`; tests use a fake. (#636 follow-up.)
 package protocol AliasSuggesting: Sendable {
   /// Whether on-device generation is available right now (Apple Intelligence on
-  /// macOS 26+). When false, callers skip enrichment entirely.
+  /// macOS 26+). `ContactsImportCoordinator` checks this and skips enrichment
+  /// entirely when false. `BulkImportEnrichmentCoordinator` does NOT check
+  /// this (#1701 D16 fail-open): it always calls `suggestAliases`, which
+  /// resolves to `nil` when unavailable the same way it does on a timeout,
+  /// and checkpoints that as an honest "tried, got nothing" so durable
+  /// pending state is never stranded waiting for availability to change.
   var isAvailable: Bool { get }
 
   /// Generate spoken-variant aliases for `word`, with the category already known

--- a/Sources/EnviousWisprPostProcessing/CustomWordsImportCommit.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsImportCommit.swift
@@ -72,20 +72,88 @@ package struct CustomWordsImportCommitPlan: Sendable, Equatable {
   package let baseline: CustomWordsImportLibrarySnapshot
   package let additions: [CustomWordsImportCandidate]
   package let replacements: [CustomWordsImportReplacement]
+  /// Carried from the originating `CustomWordsImportBatch.enrichmentEligible`
+  /// (#1701 Chunk 2), retained by `CustomWordsImportFlowModel` from
+  /// `loadCandidates()` through `confirm()` — nothing about the originating
+  /// batch otherwise survives to commit time. `commitImport` reads this once,
+  /// inside its own locked transaction, to decide whether freshly-added words
+  /// enter the bulk-import-enrichment queue. Never applies to Replace: a
+  /// machine guess must not overwrite hand-tuned aliases either way.
+  package let enrichmentEligible: Bool
 
   package init(
     baseline: CustomWordsImportLibrarySnapshot,
     additions: [CustomWordsImportCandidate],
-    replacements: [CustomWordsImportReplacement]
+    replacements: [CustomWordsImportReplacement],
+    enrichmentEligible: Bool = true
   ) {
     self.baseline = baseline
     self.additions = additions
     self.replacements = replacements
+    self.enrichmentEligible = enrichmentEligible
   }
 
   /// True when the commit would change nothing — an all-Skip confirm. Such a
   /// commit writes no file and takes no backup.
   package var isEmpty: Bool { additions.isEmpty && replacements.isEmpty }
+}
+
+/// One manager-level read of the persisted library plus its durable
+/// bulk-import-enrichment total, returned together so a caller can never see
+/// one without the other (#1701 Chunk 2). Deliberately NOT
+/// `CustomWordsImportLibrarySnapshot` above — that type is Review's baseline
+/// (excludes usage history, compares by value for staleness); this one is the
+/// AppKit-layer read path for `CustomWordsCoordinator.loadSnapshot()`, always
+/// initialized together so the total can never be read stale relative to the
+/// words it describes.
+package struct CustomWordsLibrarySnapshot: Sendable, Equatable {
+  package let words: [CustomWord]
+  /// `nil` = no bulk-import-enrichment run in progress. A number is the
+  /// honest original size of the current run, only ever extended (never
+  /// reset smaller) by a later import committing mid-drain.
+  package let pendingEnrichmentBatchTotal: Int?
+
+  package init(words: [CustomWord], pendingEnrichmentBatchTotal: Int?) {
+    self.words = words
+    self.pendingEnrichmentBatchTotal = pendingEnrichmentBatchTotal
+  }
+}
+
+/// One bulk-import-enrichment checkpoint outcome: stable word identity plus
+/// generated aliases ONLY — deliberately never a full `CustomWord` snapshot,
+/// which could go stale across the `await` between the background
+/// coordinator reading a word and checkpointing its result (#1701 Chunk 2).
+/// `CustomWordsManager.applyEnrichmentResults` reloads the live word by this
+/// `id`, under the same lock it writes with, and appends only these aliases
+/// to whatever is there right now.
+package struct CustomWordEnrichmentResult: Sendable, Equatable {
+  package let id: UUID
+  package let generatedAliases: [String]
+
+  package init(id: UUID, generatedAliases: [String]) {
+    self.id = id
+    self.generatedAliases = generatedAliases
+  }
+}
+
+/// The full outcome of one `CustomWordsManager.applyEnrichmentResults` call
+/// (Codex Chunk 2 review finding 6): the resulting snapshot, AND — separately
+/// from the caller's raw input — exactly which results actually applied and
+/// exactly which aliases actually landed for each, after in-word dedup AND
+/// cross-word alias-ownership enforcement (finding 3). A TOUCHED word (found
+/// and still pending) always appears here, with fewer aliases than it sent —
+/// possibly zero, if every one collided or was redundant with its own
+/// canonical — never more. A word is ABSENT only when its result was skipped
+/// entirely (not found, or no longer pending) — the input alone is never
+/// proof of what was actually persisted.
+package struct CustomWordsEnrichmentCheckpointOutcome: Sendable, Equatable {
+  package let snapshot: CustomWordsLibrarySnapshot
+  package let applied: [CustomWordEnrichmentResult]
+
+  package init(snapshot: CustomWordsLibrarySnapshot, applied: [CustomWordEnrichmentResult]) {
+    self.snapshot = snapshot
+    self.applied = applied
+  }
 }
 
 package struct CustomWordsImportCommitReceipt: Sendable, Equatable {
@@ -95,15 +163,22 @@ package struct CustomWordsImportCommitReceipt: Sendable, Equatable {
   /// `suggestedAliases`. The AI channel gets no compare-time disclosure, so
   /// this receipt is its only reporting path.
   package let droppedAliasCollisions: [CustomWordsImportAliasCollision]
+  /// The durable bulk-import-enrichment total immediately after this commit
+  /// (#1701 Chunk 2) — `nil` when no run is in progress. Lets
+  /// `CustomWordsCoordinator` adopt the fresh total from the SAME commit that
+  /// just wrote it, without a separate follow-up read.
+  package let pendingEnrichmentBatchTotal: Int?
 
   package init(
     addedIDs: [UUID],
     replacedIDs: [UUID],
-    droppedAliasCollisions: [CustomWordsImportAliasCollision]
+    droppedAliasCollisions: [CustomWordsImportAliasCollision],
+    pendingEnrichmentBatchTotal: Int? = nil
   ) {
     self.addedIDs = addedIDs
     self.replacedIDs = replacedIDs
     self.droppedAliasCollisions = droppedAliasCollisions
+    self.pendingEnrichmentBatchTotal = pendingEnrichmentBatchTotal
   }
 }
 

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -255,6 +255,14 @@ public final class CustomWordsManager {
     var builtinsVersion: Int = 1
     var deletedBuiltinIds: [String] = []
     var words: [CustomWord] = []
+    /// Durable bulk-import-enrichment total (#1701 Chunk 2) — the progress
+    /// card's denominator. `nil` = no run in progress. A missing key on a
+    /// pre-#1701 file decodes as `nil` automatically: this is a stored
+    /// `Optional` property with no explicit `CodingKeys` on this type, so
+    /// synthesized `Decodable` already treats an absent key as `nil`, exactly
+    /// the correct legacy behavior (no run can possibly be "in progress" in a
+    /// library persisted before this feature existed).
+    var pendingEnrichmentBatchTotal: Int?
   }
 
   /// `loadFileWhileLocked()`'s result (#1646) — distinguishes the three
@@ -327,17 +335,18 @@ public final class CustomWordsManager {
     return .needsRepair
   }
 
-  /// Load the effective word list: built-in defaults (minus tombstones) + user words.
-  /// Returns nil only on unrecoverable I/O failure or a corrupted (archived)
-  /// file — `lastLoadFailure` says which (#1646).
-  public func load() -> [CustomWord]? {
+  /// Shared resolution behind `load()` and `loadSnapshot()` (#1701 Chunk 2) —
+  /// one cascade, so the two callers can never disagree about what "the
+  /// current file" is. Sets `lastLoadFailure` exactly as the pre-#1701
+  /// `load()` body did; returns nil on the same unrecoverable conditions.
+  private func resolveCurrentFile() -> CustomWordsFile? {
     switch loadFileReadOnly() {
     case .missing:
       lastLoadFailure = nil
-      return mergedWords(file: CustomWordsFile())
+      return CustomWordsFile()
     case .loaded(let file):
       lastLoadFailure = nil
-      return mergedWords(file: file)
+      return file
     case .unreadable:
       lastLoadFailure = .unreadable
       return nil
@@ -354,7 +363,7 @@ public final class CustomWordsManager {
         let result = try withExclusiveFileLock(blocking: true) { loadFileWhileLocked() }
         switch result {
         case .missing:
-          // This same load() call already observed readable, non-current-format
+          // This same call already observed readable, non-current-format
           // bytes moments ago (that is why we are in the `.needsRepair` branch
           // at all). The app never deletes the canonical file except during
           // quarantine, so a fresh `.missing` result here, under the lock,
@@ -364,7 +373,7 @@ public final class CustomWordsManager {
           return nil
         case .loaded(let file):
           lastLoadFailure = nil
-          return mergedWords(file: file)
+          return file
         case .unreadable:
           lastLoadFailure = .unreadable
           return nil
@@ -382,6 +391,63 @@ public final class CustomWordsManager {
         lastLoadFailure = .unreadable
         return nil
       }
+    }
+  }
+
+  /// Load the effective word list: built-in defaults (minus tombstones) + user words.
+  /// Returns nil only on unrecoverable I/O failure or a corrupted (archived)
+  /// file — `lastLoadFailure` says which (#1646).
+  public func load() -> [CustomWord]? {
+    guard let file = resolveCurrentFile() else { return nil }
+    return mergedWords(file: file)
+  }
+
+  /// One read of the persisted library AND its durable bulk-import-enrichment
+  /// total together (#1701 Chunk 2), so a caller — `CustomWordsCoordinator`,
+  /// the sole AppKit adapter — can never see one without the other. Existing
+  /// `load()` stays a words-only convenience for every untouched consumer;
+  /// this is additive, sharing the identical resolution cascade.
+  package func loadSnapshot() -> CustomWordsLibrarySnapshot? {
+    guard let file = resolveCurrentFile() else { return nil }
+    return CustomWordsLibrarySnapshot(
+      words: mergedWords(file: file),
+      pendingEnrichmentBatchTotal: file.pendingEnrichmentBatchTotal)
+  }
+
+  /// Word list filtered to `enrichmentPending == true` (#1701 Chunk 2) — the
+  /// durable bulk-import-enrichment queue IS this scan over live state, never
+  /// a separately-tracked in-memory job list. Returns nil only on the same
+  /// unrecoverable read failure `load()`/`loadSnapshot()` report.
+  package func loadPendingEnrichmentWords() -> [CustomWord]? {
+    guard let file = resolveCurrentFile() else { return nil }
+    return mergedWords(file: file).filter(\.enrichmentPending)
+  }
+
+  /// Two-way self-heal (#1701 Chunk 2, Codex Chunk 2 review finding 2b) — a
+  /// state normal operation should never produce, but tolerated defensively
+  /// rather than treated as fatal:
+  /// - Pending words exist but no durable total: repairs the total to the
+  ///   current live pending count.
+  /// - No pending words exist but a total is stuck non-nil (e.g. the last
+  ///   pending word was deleted, whose checkpoint result then found nothing
+  ///   to apply and so never reached the total-clearing check): clears it.
+  /// No-op write when nothing needs repairing. Returns the resulting
+  /// (possibly just-repaired) total either way, so the caller always learns
+  /// the true current denominator. Called by the background coordinator
+  /// before it begins draining.
+  package func repairPendingEnrichmentTotalIfNeeded() throws -> Int? {
+    try performLockedTransaction { file -> (value: Int?, shouldSave: Bool) in
+      let livePendingCount = file.words.filter(\.enrichmentPending).count
+      if livePendingCount == 0 {
+        guard file.pendingEnrichmentBatchTotal != nil else { return (nil, false) }
+        file.pendingEnrichmentBatchTotal = nil
+        return (nil, true)
+      }
+      guard file.pendingEnrichmentBatchTotal == nil else {
+        return (file.pendingEnrichmentBatchTotal, false)
+      }
+      file.pendingEnrichmentBatchTotal = livePendingCount
+      return (livePendingCount, true)
     }
   }
 
@@ -850,12 +916,43 @@ public final class CustomWordsManager {
 
         // (3) Additions — fresh UUID each; unspecified fields take type defaults,
         // since there is no existing word to preserve from.
+        //
+        // Eligible additions enter the bulk-import-enrichment queue here
+        // (#1701 Chunk 2) — `plan.enrichmentEligible` is per-BATCH, so it
+        // applies uniformly to every addition in this plan, never to a
+        // Replace (a machine guess must not overwrite hand-tuned aliases
+        // either way, matching D15's existing rule for suggestedAliases).
         var addedIDs: [UUID] = []
+        var newlyPendingCount = 0
         for candidate in plan.additions {
-          let word = Self.makeAddition(from: candidate)
+          var word = Self.makeAddition(from: candidate)
           guard !word.canonical.isEmpty else { throw CustomWordsImportCommitError.invalidPlan }
+          if plan.enrichmentEligible {
+            word.enrichmentPending = true
+            newlyPendingCount += 1
+          }
           file.words.append(word)
           addedIDs.append(word.id)
+        }
+        // Atomically, in this SAME transaction as the flags just set above
+        // (never left "untouched" while flags change underneath it): extend
+        // an already-active total, or start one. Never reset smaller — a
+        // second import committing mid-drain must not lose the first run's
+        // remaining count. When the stored total is nil, it is NOT safe to
+        // assume nothing was pending before this commit (Codex Chunk 2 review
+        // finding 2a) — that is the same defensive "should never happen"
+        // state `repairPendingEnrichmentTotalIfNeeded` exists to heal, and if
+        // this commit wrote a total covering only its OWN new additions, the
+        // total would go non-nil and the repair path would never fire again,
+        // permanently undercounting. Base a fresh total on every word
+        // currently pending (already includes this commit's own additions,
+        // appended above), never just this commit's delta.
+        if newlyPendingCount > 0 {
+          if let existingTotal = file.pendingEnrichmentBatchTotal {
+            file.pendingEnrichmentBatchTotal = existingTotal + newlyPendingCount
+          } else {
+            file.pendingEnrichmentBatchTotal = file.words.filter(\.enrichmentPending).count
+          }
         }
 
         let touchedIDs = Set(addedIDs + replacedIDs)
@@ -908,7 +1005,8 @@ public final class CustomWordsManager {
         // saves `file` right after this closure returns, so this IS what will be on disk.
         resulting = mergedWords(file: file)
         let receipt = CustomWordsImportCommitReceipt(
-          addedIDs: addedIDs, replacedIDs: replacedIDs, droppedAliasCollisions: dropped)
+          addedIDs: addedIDs, replacedIDs: replacedIDs, droppedAliasCollisions: dropped,
+          pendingEnrichmentBatchTotal: file.pendingEnrichmentBatchTotal)
         return ((receipt, resulting), true)
       }
     } catch let persistenceError as CustomWordsPersistenceError {
@@ -938,6 +1036,151 @@ public final class CustomWordsManager {
       words = merged
     }
     return outcome.0
+  }
+
+  // MARK: - Bulk-import enrichment checkpoint (#1701 Chunk 2)
+
+  /// Merge-safe, pending-gated checkpoint. For each result: reload the live
+  /// word by ID under the SAME lock this saves with, apply only if it still
+  /// has `enrichmentPending == true` — first durable terminal action wins, so
+  /// a late result for a word another writer already checkpointed or
+  /// Cancel already cleared is silently skipped, never resurrecting the flag
+  /// and never applying a second time — append sanitized, nonduplicate
+  /// generated aliases to whatever aliases are there RIGHT NOW (never a
+  /// caller-supplied snapshot that could have gone stale across the await
+  /// before this call), clear the flag, leave every other field untouched. A
+  /// missing/deleted ID is skipped, never resurrected. Reapplying the
+  /// identical result is idempotent: a second pass finds
+  /// `enrichmentPending == false` already and no-ops.
+  ///
+  /// A generated alias clears the SAME `WordCorrector` ownership index the
+  /// import commit path's `enforceAliases` is built on, but ONLY the newly
+  /// generated alias is validated against it — never a touched word's
+  /// pre-existing aliases, which `enforceAliases`'s own touched-order replay
+  /// would otherwise re-evaluate and could silently drop even though this
+  /// checkpoint never intended to touch them (Codex Chunk 2 review round 2
+  /// finding 1: reusing `enforceAliases` wholesale let one touched word's
+  /// PRE-EXISTING alias lose to another touched word's PRE-EXISTING alias in
+  /// the same batch — neither was generated content). So a generated guess
+  /// can never collide with another word's canonical or ANY existing alias,
+  /// human-authored or otherwise (D17), while every already-persisted alias
+  /// on every word — touched or not — is left completely untouched. `applied`
+  /// reports exactly which generated aliases actually landed per touched
+  /// word (finding 6).
+  ///
+  /// The durable total is cleared whenever the freshly-computed live pending
+  /// count is zero, unconditionally — never gated behind whether THIS batch
+  /// itself changed anything (Codex Chunk 2 review finding 2b: a checkpoint
+  /// whose only result referenced an already-deleted word changes nothing
+  /// itself, but the delete may have been what brought the live count to
+  /// zero, and that must still clear the total).
+  package func applyEnrichmentResults(
+    _ results: [CustomWordEnrichmentResult]
+  ) throws -> CustomWordsEnrichmentCheckpointOutcome {
+    try performLockedTransaction {
+      file -> (value: CustomWordsEnrichmentCheckpointOutcome, shouldSave: Bool) in
+      var touchedIDs: [UUID] = []
+      var candidatesByID: [UUID: [String]] = [:]
+
+      for result in results {
+        guard let idx = file.words.firstIndex(where: { $0.id == result.id }) else { continue }
+        guard file.words[idx].enrichmentPending else { continue }
+        let existingKeys = Set(file.words[idx].aliases.map(Self.importPersistenceKey))
+        var seenThisWord = existingKeys
+        var candidates: [String] = []
+        for alias in Self.sanitizeAliases(result.generatedAliases) {
+          let key = Self.importPersistenceKey(alias)
+          guard !key.isEmpty, !seenThisWord.contains(key) else { continue }
+          candidates.append(alias)
+          seenThisWord.insert(key)
+        }
+        file.words[idx].enrichmentPending = false
+        touchedIDs.append(result.id)
+        candidatesByID[result.id] = candidates
+      }
+
+      // Ownership seeded from the CURRENT, untouched library — every alias
+      // any word holds right now, whether or not that word is touched, is a
+      // real existing claim a new guess must respect. Never stripped and
+      // never replayed: only the newly generated candidates below are ever
+      // validated or gap-filled.
+      var index = WordCorrector.buildExactTriggerIndex(words: mergedWords(file: file))
+      var applied: [CustomWordEnrichmentResult] = []
+      for id in touchedIDs {
+        guard let idx = file.words.firstIndex(where: { $0.id == id }) else {
+          applied.append(CustomWordEnrichmentResult(id: id, generatedAliases: []))
+          continue
+        }
+        let canonical = file.words[idx].canonical
+        let canonicalKey = Self.importPersistenceKey(canonical)
+        var accepted: [String] = []
+        for alias in candidatesByID[id] ?? [] {
+          // Redundant with the word's OWN canonical: silently dropped, same
+          // as `enforceAliases` (Codex Chunk 2 review round 3 finding 1 — the
+          // per-word ownership check excludes the word's own existing
+          // claims, so without this a generated "Kubernetes" could land on
+          // canonical "Kubernetes" itself).
+          if Self.importPersistenceKey(alias) == canonicalKey { continue }
+          // Mirrors `enforceAliases`'s own three-way branch exactly — a
+          // generated guess earns no different treatment than an imported
+          // one. `.noClaims` (the alias produces no real trigger claim at
+          // all) is dropped, same as there.
+          switch index.resolveAliasOwnership(for: alias, excludingOwnerID: id) {
+          case .noClaims, .blocked:
+            continue
+          case .available(let claims):
+            index.gapFill(
+              claims,
+              owner: WordCorrector.TriggerOwner(wordID: id, canonical: canonical, isPack: false))
+            accepted.append(alias)
+          }
+        }
+        file.words[idx].aliases.append(contentsOf: accepted)
+        applied.append(CustomWordEnrichmentResult(id: id, generatedAliases: accepted))
+      }
+
+      let changed = !touchedIDs.isEmpty
+      let stillPending = file.words.contains(where: \.enrichmentPending)
+      var totalChanged = false
+      if file.pendingEnrichmentBatchTotal != nil, !stillPending {
+        file.pendingEnrichmentBatchTotal = nil
+        totalChanged = true
+      }
+
+      return (
+        CustomWordsEnrichmentCheckpointOutcome(
+          snapshot: CustomWordsLibrarySnapshot(
+            words: mergedWords(file: file),
+            pendingEnrichmentBatchTotal: file.pendingEnrichmentBatchTotal),
+          applied: applied),
+        changed || totalChanged
+      )
+    }
+  }
+
+  /// Durable Cancel: one locked reload-and-sweep that clears
+  /// `enrichmentPending` on every word CURRENTLY found `true` in the freshly
+  /// reloaded file — never a caller's potentially-stale in-memory target
+  /// list — and clears the durable total to nil in the same transaction.
+  /// Returns the resulting snapshot so the caller can atomically adopt both.
+  package func cancelEnrichment() throws -> CustomWordsLibrarySnapshot {
+    try performLockedTransaction { file -> (value: CustomWordsLibrarySnapshot, shouldSave: Bool) in
+      var changed = false
+      for idx in file.words.indices where file.words[idx].enrichmentPending {
+        file.words[idx].enrichmentPending = false
+        changed = true
+      }
+      if file.pendingEnrichmentBatchTotal != nil {
+        file.pendingEnrichmentBatchTotal = nil
+        changed = true
+      }
+      return (
+        CustomWordsLibrarySnapshot(
+          words: mergedWords(file: file),
+          pendingEnrichmentBatchTotal: file.pendingEnrichmentBatchTotal),
+        changed
+      )
+    }
   }
 
   /// This type's own dedup rule, named so the import path cannot accidentally

--- a/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
+++ b/Sources/EnviousWisprPostProcessing/ImportFileParser.swift
@@ -82,6 +82,14 @@ package protocol ImportFileParser: Sendable {
   /// the words but not the bytes left the identical round-trip hole one layer
   /// down, since the byte check runs BEFORE the parser is consulted.
   var maximumBytes: Int { get }
+  /// Whether words newly added from this format should enter the bulk-import
+  /// enrichment queue (#1701 Chunk 2). Defaults `true` — every format opts
+  /// out deliberately, with a stated reason. Read off the matched parser by
+  /// `FileImportSource.loadRawCandidates()` and carried as a batch-level flag
+  /// (never per-candidate — `CustomWordsImportCandidate` deliberately cannot
+  /// carry provenance, and one Upload conformer serves multiple parsers, so
+  /// this is the correct, and only, seam for the decision).
+  var enrichmentEligible: Bool { get }
   func parse(data: Data) throws -> [CustomWordsImportCandidate]
 }
 
@@ -89,6 +97,7 @@ extension ImportFileParser {
   /// Formats default to the shared ceilings; a format opts out deliberately.
   package var maximumCandidates: Int? { CustomWordsImportLimits.maximumCandidates }
   package var maximumBytes: Int { CustomWordsImportLimits.maximumImportFileBytes }
+  package var enrichmentEligible: Bool { true }
 }
 
 /// The file EnviousWispr itself exports.
@@ -126,6 +135,14 @@ package struct ExportedWordsFileParser: ImportFileParser {
   /// case.
   package let maximumCandidates: Int? = CustomWordsImportLimits.maximumExportedCandidates
   package let maximumBytes = CustomWordsImportLimits.maximumExportedFileBytes
+
+  /// The user's own backup restore is already as complete as it will ever
+  /// get — whatever aliases it carries are what a prior enrichment run (or
+  /// hand-tuning) already produced. Re-enriching it would spend a model call
+  /// improving data this parser's own doc comment above says needs no
+  /// improving (#1701 Chunk 2). The sole override in this protocol; every
+  /// other parser inherits `true` unless it states an equally explicit reason.
+  package let enrichmentEligible = false
 
   package init() {}
 
@@ -302,7 +319,8 @@ package struct ImportFileRegistry: Sendable {
   /// this is the panel's view of the same set.
   package var acceptedContentTypes: [UTType] {
     let declared = parsers.flatMap(\.contentTypes)
-    let fromExtensions = parsers
+    let fromExtensions =
+      parsers
       .flatMap(\.fileExtensions)
       .compactMap { UTType(filenameExtension: $0) }
     var seen = Set<UTType>()
@@ -395,7 +413,8 @@ package struct FileImportSource: CustomWordsImportSource {
     return CustomWordsImportBatch(
       sourceID: parser.identifier,
       sourceDisplayName: parser.displayName,
-      candidates: candidates
+      candidates: candidates,
+      enrichmentEligible: parser.enrichmentEligible
     )
   }
 }

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -171,6 +171,13 @@ actor AliasSuggestionPermitQueue {
   }
 #endif
 
+/// Wraps `withPermit`'s operation result so a `nil` FROM the operation itself
+/// (a normal "no suggestion" outcome) is never confused with `withDeadline`
+/// abandoning the operation (Phase 3 review finding A, #1701).
+private struct PermitOperationResult<Value: Sendable>: Sendable {
+  let value: Value
+}
+
 public final class WordSuggestionService: Sendable {
   /// Serializes every production alias-suggestion call — `suggest(for:)` and
   /// `suggestAliases(for:category:)` — through one in-flight permit at a time,
@@ -216,11 +223,21 @@ public final class WordSuggestionService: Sendable {
   /// executor; this hook lets a test park the call at exactly that point,
   /// cancel it, then resume, proving the check fires correctly without
   /// relying on scheduler timing.
+  /// `deadlineSeconds` has no default (Phase 3 review finding A, #1701):
+  /// `withDeadline`, never `withThrowingTimeout`, bounds `operation` — a
+  /// FoundationModels call that ignores cancellation cannot make
+  /// `withThrowingTimeout`'s task-group scope return, which would strand
+  /// this permit forever and block every later interactive and background
+  /// caller. `withDeadline` returns at the true deadline WITHOUT awaiting an
+  /// abandoned operation; the abandoned physical task may keep running in
+  /// the background while a later logical request starts — an accepted
+  /// tradeoff over permanently blocking every suggestion request.
   func withPermit<T: Sendable>(
     priority: AliasSuggestionPriority,
     whenNotGranted: T,
+    deadlineSeconds: Double,
     afterGrantForTesting: (@Sendable () async -> Void)? = nil,
-    operation: @Sendable () async -> T
+    operation: @escaping @Sendable () async -> T
   ) async -> T {
     let id = UUID()
     let granted = await permitQueue.acquire(id: id, priority: priority)
@@ -230,10 +247,16 @@ public final class WordSuggestionService: Sendable {
       await permitQueue.release()
       return whenNotGranted
     }
-    let result = await operation()
+    let result = await withDeadline(seconds: deadlineSeconds) {
+      PermitOperationResult(value: await operation())
+    }
     await permitQueue.release()
-    return result
+    return result?.value ?? whenNotGranted
   }
+
+  /// Preserves the existing five-second policy — not a new timing invention
+  /// (Phase 3 review finding A, #1701).
+  private static let suggestionDeadlineSeconds = 5.0
 
   public func suggest(
     for word: String,
@@ -244,15 +267,10 @@ public final class WordSuggestionService: Sendable {
         case .available = SystemLanguageModel.default.availability
       else { return nil }
 
-      return await withPermit(priority: priority, whenNotGranted: nil) {
-        // Hard 5s timeout — FM can hang on some inputs
-        do {
-          return try await withThrowingTimeout(seconds: 5) {
-            await self.runSuggestion(for: word)
-          }
-        } catch {
-          return nil
-        }
+      return await withPermit(
+        priority: priority, whenNotGranted: nil, deadlineSeconds: Self.suggestionDeadlineSeconds
+      ) {
+        await self.runSuggestion(for: word)
       }
     #else
       return nil
@@ -891,13 +909,13 @@ extension WordSuggestionService: AliasSuggesting {
       guard #available(macOS 26, *),
         case .available = SystemLanguageModel.default.availability
       else { return nil }
-      return await withPermit(priority: priority, whenNotGranted: nil) {
+      return await withPermit(
+        priority: priority, whenNotGranted: nil, deadlineSeconds: Self.suggestionDeadlineSeconds
+      ) {
         do {
-          return try await withThrowingTimeout(seconds: 5) {
-            let raw = try await self.runRawSuggestion(for: word, knownCategory: category)
-            let filtered = Self.filterDegeneratedAliases(raw.aliases, canonical: word)
-            return filtered.isEmpty ? nil : filtered
-          }
+          let raw = try await self.runRawSuggestion(for: word, knownCategory: category)
+          let filtered = Self.filterDegeneratedAliases(raw.aliases, canonical: word)
+          return filtered.isEmpty ? nil : filtered
         } catch {
           return nil
         }

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -906,6 +906,18 @@ extension WordSuggestionService: AliasSuggesting {
       return nil
     #endif
   }
+
+  /// Delegates to `suggest(for:priority:)` directly, which already owns
+  /// availability, timeout, classification, filtering, and permit handling
+  /// — never a second `withPermit` wrapper here, or one logical request
+  /// would attempt to acquire the shared permit twice (Phase 3 review
+  /// finding A, #1701).
+  package func suggestAliases(
+    for word: String, priority: AliasSuggestionPriority
+  ) async -> [String]? {
+    let suggestions = await suggest(for: word, priority: priority)
+    return suggestions?.suggestedAliases
+  }
 }
 
 public struct WordSuggestions: Sendable {

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -1,11 +1,193 @@
 import EnviousWisprCore
 import Foundation
+import os
 
 #if canImport(FoundationModels)
   import FoundationModels
 #endif
 
+/// Explicit, priority-aware permit queue backing `WordSuggestionService`'s
+/// shared production door (#1701). Not "await inside an actor" — actors are
+/// reentrant across a suspension point, so a method that merely awaits model
+/// work inside an actor would still let a second call interleave. This type
+/// grants an explicit permit token instead: exactly one holder at a time,
+/// `.interactive` waiters served ahead of already-queued `.background`
+/// waiters, FIFO within a priority, and the current holder is never
+/// pre-empted — priority affects only queue ordering, not interruption.
+///
+/// `internal` (default) visibility: invisible to consumers outside this
+/// module (AppKit imports the module without `@testable`); reachable from
+/// `WordSuggestionServiceTests` only via `@testable import`, which is the
+/// narrow seam those tests use to drive queue ordering and cancellation
+/// deterministically without touching FoundationModels.
+actor AliasSuggestionPermitQueue {
+  private struct Waiter {
+    let id: UUID
+    let priority: AliasSuggestionPriority
+    let latch: CancellationLatch
+    let continuation: CheckedContinuation<Bool, Never>
+  }
+
+  /// Per-`acquire` cancellation signal, set synchronously and thread-safely
+  /// (via `OSAllocatedUnfairLock`) from `withTaskCancellationHandler`'s
+  /// `onCancel` closure, which is NOT
+  /// actor-isolated and may fire before, during, or after `register` runs.
+  /// Deliberately NOT actor state: an actor-owned `Set<UUID>` needs a
+  /// tombstone entry for every id whose `onCancel` races ahead of or past
+  /// `register`, and once `register` has already run for that id, nothing
+  /// could ever remove the tombstone (Grounded Review Chunk 1 finding —
+  /// reachable via Add-term's frequent debounced task cancellation, not a
+  /// rare edge: real unbounded growth, not the "bounded/inert" residue the
+  /// prior revision claimed). A latch scoped to the call stack is freed by
+  /// ARC when `acquire`'s frame unwinds — nothing persists in the actor
+  /// regardless of cancellation timing.
+  private final class CancellationLatch: Sendable {
+    private let lock = OSAllocatedUnfairLock(initialState: false)
+    var isCancelled: Bool { lock.withLock { $0 } }
+    func cancel() { lock.withLock { $0 = true } }
+  }
+
+  private var waiters: [Waiter] = []
+  private var permitHeld = false
+
+  /// Waits for the permit. Returns `true` once granted; returns `false`,
+  /// without ever granting a permit, when the caller's task was cancelled
+  /// before its turn arrived. A `false` result means zero model work should
+  /// run and the caller must not call `release()`.
+  func acquire(id: UUID, priority: AliasSuggestionPriority) async -> Bool {
+    let latch = CancellationLatch()
+    return await withTaskCancellationHandler {
+      await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+        register(id: id, priority: priority, latch: latch, continuation: continuation)
+      }
+    } onCancel: {
+      latch.cancel()
+      Task { await self.cancelWaiting(id: id) }
+    }
+  }
+
+  /// Test seam: current queue depth. Lets a test deterministically poll
+  /// (`await Task.yield()` in a loop, never `Task.sleep`/wall-clock) until a
+  /// concurrently-started waiter has actually registered, instead of guessing
+  /// at timing. `internal`: reachable only via `@testable import`.
+  var waiterCountForTesting: Int { waiters.count }
+
+  /// Releases the held permit, granting it directly to the next LIVE queued
+  /// waiter (priority, then FIFO) if one exists. Must be called exactly once
+  /// for every `acquire` that returned `true` — including when the caller
+  /// itself discovers a post-grant cancellation and never runs its operation.
+  ///
+  /// Walks (never just peeks) the front of the queue: `onCancel` sets a
+  /// waiter's latch synchronously but removes it from `waiters` via a
+  /// separately-scheduled actor message (`cancelWaiting`, below) — this
+  /// method can run BEFORE that removal message arrives (Grounded Review
+  /// Chunk 1 round 3 finding), so a queued-but-not-yet-removed cancelled
+  /// waiter must never be handed the permit even briefly. Each cancelled
+  /// waiter encountered is resumed `false` and dropped; the loop keeps going
+  /// until it finds a live waiter to grant, or the queue is exhausted.
+  func release() {
+    while !waiters.isEmpty {
+      let next = waiters.removeFirst()
+      if next.latch.isCancelled {
+        next.continuation.resume(returning: false)
+        continue
+      }
+      next.continuation.resume(returning: true)
+      // permitHeld stays true: ownership transfers directly to `next`, never
+      // a window where the permit is unheld while a waiter is queued.
+      return
+    }
+    permitHeld = false
+  }
+
+  private func register(
+    id: UUID,
+    priority: AliasSuggestionPriority,
+    latch: CancellationLatch,
+    continuation: CheckedContinuation<Bool, Never>
+  ) {
+    if latch.isCancelled {
+      continuation.resume(returning: false)
+      return
+    }
+    if !permitHeld {
+      permitHeld = true
+      continuation.resume(returning: true)
+      return
+    }
+    let insertIndex =
+      priority == .interactive
+      ? (waiters.firstIndex(where: { $0.priority == .background }) ?? waiters.count)
+      : waiters.count
+    waiters.insert(
+      Waiter(id: id, priority: priority, latch: latch, continuation: continuation),
+      at: insertIndex)
+  }
+
+  /// Test seam: marks a currently-queued waiter's cancellation latch as
+  /// cancelled WITHOUT removing it from the queue — simulates the exact
+  /// interleaving `release()`'s doc comment above describes, where
+  /// `onCancel` has set the latch but the asynchronous `cancelWaiting`
+  /// removal message has not yet reached the actor (Grounded Review Chunk 1
+  /// round 3 finding). No-op if `id` is not currently queued. `internal`:
+  /// reachable only via `@testable import`.
+  func cancelLatchWithoutRemovingForTesting(id: UUID) {
+    guard let waiter = waiters.first(where: { $0.id == id }) else { return }
+    waiter.latch.cancel()
+  }
+
+  /// No-op when `id` is neither currently queued nor still pending
+  /// registration — covers both "already granted" (nothing to remove) and
+  /// "already resolved via the latch" (the latch, not this method, was the
+  /// signal that mattered).
+  private func cancelWaiting(id: UUID) {
+    guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+    let waiter = waiters.remove(at: index)
+    waiter.continuation.resume(returning: false)
+  }
+}
+
+#if DEBUG
+  /// Test-only storage for `benchmarkSuggest`'s deterministic override
+  /// (#1701 Grounded Review Chunk 1 finding). An actor, not a plain `var` on
+  /// `WordSuggestionService`, so storage stays Sendable-safe without
+  /// `nonisolated(unsafe)`/`@unchecked` — `WordSuggestionService` otherwise
+  /// has only immutable stored properties. Always empty (`value == nil`) in
+  /// production; nothing production-facing ever writes to it. `#if DEBUG`-
+  /// gated end to end (Grounded Review Chunk 1 round 2 finding): the Release
+  /// alias-eval harness calls `benchmarkSuggest` directly to measure real
+  /// latency and concurrency (`scripts/eval/alias_runner`) — this box, its
+  /// property, and the check inside `benchmarkSuggest` must not add an actor
+  /// hop to that measured path.
+  actor RawSuggestionOverrideBox {
+    private(set) var value:
+      (@Sendable (String) async throws -> (category: WordCategory, aliases: [String]))?
+
+    func set(
+      _ newValue: (@Sendable (String) async throws -> (category: WordCategory, aliases: [String]))?
+    ) {
+      value = newValue
+    }
+  }
+#endif
+
 public final class WordSuggestionService: Sendable {
+  /// Serializes every production alias-suggestion call — `suggest(for:)` and
+  /// `suggestAliases(for:category:)` — through one in-flight permit at a time,
+  /// interactive before background (#1701). `internal` (narrowest visibility
+  /// that compiles): invisible to consumers outside this module; reachable
+  /// from `WordSuggestionServiceTests` only via `@testable import`. This is
+  /// the sole production door — there is no second, unserialized path to the
+  /// model left for a future caller to reach by accident.
+  let permitQueue = AliasSuggestionPermitQueue()
+
+  #if DEBUG
+    /// Test-only override for `benchmarkSuggest`'s on-device path (#1701).
+    /// See `RawSuggestionOverrideBox`. `internal`: reachable only via
+    /// `@testable import`. `#if DEBUG`-gated: absent from Release builds.
+    let rawSuggestionOverrideForTesting = RawSuggestionOverrideBox()
+  #endif
+
   public var isAvailable: Bool {
     #if canImport(FoundationModels)
       guard #available(macOS 26, *) else { return false }
@@ -17,19 +199,60 @@ public final class WordSuggestionService: Sendable {
 
   public init() {}
 
-  public func suggest(for word: String) async -> WordSuggestions? {
+  /// Runs `operation` while holding the shared permit, in priority order.
+  /// Returns `whenNotGranted` — never invoking `operation` — when the calling
+  /// task is cancelled either while queued or in the gap between permit grant
+  /// and this check (both are zero-model-call cancellation points; #1701).
+  /// `internal`: this is the test seam `WordSuggestionServiceTests` drives
+  /// directly to exercise the exact queue/permit mechanics both production
+  /// entry points use, without touching FoundationModels (unavailable/
+  /// unreliable in a test environment).
+  ///
+  /// `afterGrantForTesting` is a test-only hook, always `nil` in production
+  /// (`suggest`/`suggestAliases` never pass it, so `await nil?()` is an
+  /// instant no-op — zero behavior change on the real path). It exists
+  /// because the real cancelled-after-grant race is impossible to hit
+  /// deterministically through actual `Task` scheduling on a multi-threaded
+  /// executor; this hook lets a test park the call at exactly that point,
+  /// cancel it, then resume, proving the check fires correctly without
+  /// relying on scheduler timing.
+  func withPermit<T: Sendable>(
+    priority: AliasSuggestionPriority,
+    whenNotGranted: T,
+    afterGrantForTesting: (@Sendable () async -> Void)? = nil,
+    operation: @Sendable () async -> T
+  ) async -> T {
+    let id = UUID()
+    let granted = await permitQueue.acquire(id: id, priority: priority)
+    guard granted else { return whenNotGranted }
+    await afterGrantForTesting?()
+    if Task.isCancelled {
+      await permitQueue.release()
+      return whenNotGranted
+    }
+    let result = await operation()
+    await permitQueue.release()
+    return result
+  }
+
+  public func suggest(
+    for word: String,
+    priority: AliasSuggestionPriority = .interactive
+  ) async -> WordSuggestions? {
     #if canImport(FoundationModels)
       guard #available(macOS 26, *),
         case .available = SystemLanguageModel.default.availability
       else { return nil }
 
-      // Hard 5s timeout — FM can hang on some inputs
-      do {
-        return try await withThrowingTimeout(seconds: 5) {
-          await self.runSuggestion(for: word)
+      return await withPermit(priority: priority, whenNotGranted: nil) {
+        // Hard 5s timeout — FM can hang on some inputs
+        do {
+          return try await withThrowingTimeout(seconds: 5) {
+            await self.runSuggestion(for: word)
+          }
+        } catch {
+          return nil
         }
-      } catch {
-        return nil
       }
     #else
       return nil
@@ -52,6 +275,41 @@ public final class WordSuggestionService: Sendable {
     disableTimeout: Bool = false
   ) async -> WordSuggestionBenchmarkRecord {
     let startTime = Date()
+    #if DEBUG
+      // Test-only path (#1701 Grounded Review Chunk 1 finding), absent from
+      // Release entirely — the Release alias-eval harness calls this method
+      // directly to measure real latency and concurrency, so Release must
+      // never add an actor hop here even when the override is unset.
+      // Bypasses the live-availability gate below too, not just the
+      // raw-suggestion call — real Apple Intelligence eligibility is
+      // environment-dependent (this suite's own dev machine has it enabled,
+      // so a test asserting the unavailable branch would be flaky/wrong on a
+      // machine where it isn't), so a deterministic test needs the whole
+      // on-device decision replaced, not just the model call inside it.
+      if let override = await rawSuggestionOverrideForTesting.value {
+        do {
+          let resolved = try await override(word)
+          let filtered = Self.filterDegeneratedAliases(resolved.aliases, canonical: word)
+          return WordSuggestionBenchmarkRecord(
+            category: resolved.category,
+            rawAliases: resolved.aliases,
+            filteredAliases: filtered,
+            timedOut: false,
+            errorDescription: nil,
+            latencyMs: Self.elapsedMs(since: startTime)
+          )
+        } catch {
+          return WordSuggestionBenchmarkRecord(
+            category: .general,
+            rawAliases: [],
+            filteredAliases: [],
+            timedOut: false,
+            errorDescription: "\(error)",
+            latencyMs: Self.elapsedMs(since: startTime)
+          )
+        }
+      }
+    #endif
     #if canImport(FoundationModels)
       guard #available(macOS 26, *),
         case .available = SystemLanguageModel.default.availability
@@ -624,20 +882,25 @@ extension WordSuggestionService: AliasSuggesting {
   /// `suggest(for:)`'s availability gate, 5-second timeout, and degeneration
   /// filter, but skips classification (the caller pins the category) and returns
   /// the bare alias list. nil when unavailable, timed out, or the model
-  /// degenerated to self-echoes.
-  package func suggestAliases(for word: String, category: WordCategory) async -> [String]? {
+  /// degenerated to self-echoes. `priority` has no default (#1701) — every
+  /// caller states its own scheduling intent explicitly.
+  package func suggestAliases(
+    for word: String, category: WordCategory, priority: AliasSuggestionPriority
+  ) async -> [String]? {
     #if canImport(FoundationModels)
       guard #available(macOS 26, *),
         case .available = SystemLanguageModel.default.availability
       else { return nil }
-      do {
-        return try await withThrowingTimeout(seconds: 5) {
-          let raw = try await self.runRawSuggestion(for: word, knownCategory: category)
-          let filtered = Self.filterDegeneratedAliases(raw.aliases, canonical: word)
-          return filtered.isEmpty ? nil : filtered
+      return await withPermit(priority: priority, whenNotGranted: nil) {
+        do {
+          return try await withThrowingTimeout(seconds: 5) {
+            let raw = try await self.runRawSuggestion(for: word, knownCategory: category)
+            let filtered = Self.filterDegeneratedAliases(raw.aliases, canonical: word)
+            return filtered.isEmpty ? nil : filtered
+          }
+        } catch {
+          return nil
         }
-      } catch {
-        return nil
       }
     #else
       return nil

--- a/Tests/EnviousWisprTests/App/BulkImportEnrichmentCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/BulkImportEnrichmentCoordinatorTests.swift
@@ -14,7 +14,12 @@ import Testing
 private final class FakeAliasSuggester: AliasSuggesting, @unchecked Sendable {
   private let aliasesByWord: [String: [String]]
   private let gate: CallGate?
+  /// Known-category-overload calls (`suggestAliases(for:category:priority:)`).
   private(set) var calls: [String] = []
+  /// Classification-overload calls (`suggestAliases(for:priority:)`,
+  /// #1701 Phase 3 review finding A) — recorded SEPARATELY so tests can
+  /// assert which path a word actually took.
+  private(set) var classificationCalls: [String] = []
   var available = true
   var isAvailable: Bool { available }
 
@@ -32,6 +37,19 @@ private final class FakeAliasSuggester: AliasSuggesting, @unchecked Sendable {
     priorities.append(priority)
     // Mirrors `WordSuggestionService.suggestAliases`'s own real behavior:
     // unavailable always resolves to nil, never a call that hangs or throws.
+    guard available else { return nil }
+    if let gate {
+      await gate.markCallStarted()
+      try? await gate.waitUntilOpen()
+    }
+    return aliasesByWord[word]
+  }
+
+  func suggestAliases(
+    for word: String, priority: AliasSuggestionPriority
+  ) async -> [String]? {
+    classificationCalls.append(word)
+    priorities.append(priority)
     guard available else { return nil }
     if let gate {
       await gate.markCallStarted()
@@ -72,6 +90,14 @@ private actor CallGate {
       }
     }
   }
+}
+
+/// Records `retrySleep` calls without ever actually sleeping — the bounded
+/// `.libraryBusy` retry tests (#1701 Phase 3 review finding B) assert the
+/// exact delay schedule and count without depending on wall-clock time.
+private actor DelayRecorder {
+  private(set) var delays: [Duration] = []
+  func record(_ delay: Duration) { delays.append(delay) }
 }
 
 @MainActor
@@ -222,6 +248,8 @@ struct BulkImportEnrichmentCoordinatorTests {
     await bulkCoordinator.awaitDrainForTesting()
 
     #expect(suggester.calls.isEmpty, "a pre-start cancel must trigger zero model calls")
+    #expect(
+      suggester.classificationCalls.isEmpty, "a pre-start cancel must trigger zero model calls")
     #expect(presented.isEmpty, "a pre-start cancel must never announce a start pill")
     #expect(
       coordinator.pendingEnrichmentBatchTotal == nil, "the sweep must durably clear the total")
@@ -264,7 +292,9 @@ struct BulkImportEnrichmentCoordinatorTests {
 
     // The coalesced extra pass must have picked up "Qualtrics" too, not just
     // stopped after the original word.
-    #expect(suggester.calls.contains("Qualtrics"), "the newly added word must be drained too")
+    #expect(
+      suggester.classificationCalls.contains("Qualtrics"),
+      "the newly added word must be drained too")
     let qualtrics = try #require(coordinator.customWords.first { $0.canonical == "Qualtrics" })
     #expect(qualtrics.aliases == ["qualtrix"])
     #expect(coordinator.pendingEnrichmentBatchTotal == nil)
@@ -289,10 +319,12 @@ struct BulkImportEnrichmentCoordinatorTests {
     }
 
     var presented: [String] = []
+    let delayRecorder = DelayRecorder()
     let bulkCoordinator = BulkImportEnrichmentCoordinator(
       customWords: coordinator,
       aliasSuggester: FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]]),
-      presentStatus: { presented.append($0) })
+      presentStatus: { presented.append($0) },
+      retrySleep: { await delayRecorder.record($0) })
 
     bulkCoordinator.requestDrain()
     await bulkCoordinator.awaitDrainForTesting()
@@ -301,6 +333,9 @@ struct BulkImportEnrichmentCoordinatorTests {
     #expect(
       !presented.contains("Finished importing your words."),
       "a failed checkpoint write must never announce completion")
+    #expect(
+      await delayRecorder.delays.isEmpty,
+      "a permanent (non-.libraryBusy) failure must never retry — Phase 3 review finding B")
 
     // Restore permissions before reading back, so the read-side of this
     // assertion isn't itself blocked by the fixture's own lockdown.
@@ -310,6 +345,140 @@ struct BulkImportEnrichmentCoordinatorTests {
     #expect(
       word.enrichmentPending == true,
       "an unresolved word must keep its pending flag when the checkpoint failed to write")
+  }
+
+  // MARK: - Bounded .libraryBusy recovery (Phase 3 review finding B)
+
+  /// Unlike `makeCoordinator()`, keeps the manager reference so its
+  /// `lockSyscall` seam can be rigged after seeding (#1701 finding B).
+  private func makeCoordinatorRetainingManager() -> (CustomWordsCoordinator, CustomWordsManager) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-bulk-coordinator-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let mgr = CustomWordsManager(fileURL: dir.appendingPathComponent("custom-words.json"))
+    return (CustomWordsCoordinator(manager: mgr), mgr)
+  }
+
+  @Test("busy on the initial repair, then success: one retry, clean completion")
+  func busyOnRepairThenSucceeds() async throws {
+    let (coordinator, mgr) = makeCoordinatorRetainingManager()
+    // Seed through the coordinator's own commit path — real `lockSyscall`,
+    // exactly as production writes — before rigging contention.
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")])
+    )
+    var lockCalls = 0
+    mgr.lockSyscall = { fd, flags in
+      lockCalls += 1
+      guard lockCalls == 1 else { return flock(fd, flags) }
+      errno = EWOULDBLOCK
+      return -1
+    }
+
+    let delayRecorder = DelayRecorder()
+    var presented: [String] = []
+    let suggester = FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]])
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator,
+      aliasSuggester: suggester,
+      presentStatus: { presented.append($0) },
+      retrySleep: { await delayRecorder.record($0) })
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(await delayRecorder.delays == [.seconds(1)])
+    #expect(
+      suggester.classificationCalls == ["Kubernetes"],
+      "the busy repair failed before the word loop ever ran — exactly one model call, on retry")
+    #expect(coordinator.pendingEnrichmentCount == 0, "eventually persisted despite the busy repair")
+    #expect(
+      presented == [
+        "Importing your words now. Check progress in the Your Words menu.",
+        "Finished importing your words.",
+      ], "no duplicate pills across the retry")
+  }
+
+  @Test("busy on the checkpoint, then success: eventually persisted, pills not duplicated")
+  func busyOnCheckpointThenSucceeds() async throws {
+    let (coordinator, mgr) = makeCoordinatorRetainingManager()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")])
+    )
+    // Call 1 = the repair (must succeed); call 2 = the checkpoint (busy
+    // once); every later call succeeds — this puts the busy failure past the
+    // word loop, unlike `busyOnRepairThenSucceeds` above.
+    var lockCalls = 0
+    mgr.lockSyscall = { fd, flags in
+      lockCalls += 1
+      guard lockCalls == 2 else { return flock(fd, flags) }
+      errno = EWOULDBLOCK
+      return -1
+    }
+
+    let delayRecorder = DelayRecorder()
+    var presented: [String] = []
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator,
+      aliasSuggester: FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]]),
+      presentStatus: { presented.append($0) },
+      retrySleep: { await delayRecorder.record($0) })
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(await delayRecorder.delays == [.seconds(1)])
+    let word = try #require(coordinator.customWords.first { $0.canonical == "Kubernetes" })
+    #expect(word.aliases == ["k8s"], "the word is eventually persisted despite the busy checkpoint")
+    #expect(
+      presented == [
+        "Importing your words now. Check progress in the Your Words menu.",
+        "Finished importing your words.",
+      ], "the pills are not duplicated by the retry")
+  }
+
+  @Test("exhausting all retries hard-stops once, keeps the queue pending, never loops tightly")
+  func exhaustedRetriesHardStops() async throws {
+    let (coordinator, mgr) = makeCoordinatorRetainingManager()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")])
+    )
+    // Every acquisition is busy, with no escape — proves genuine exhaustion,
+    // not a lucky later success.
+    mgr.lockSyscall = { _, _ in
+      errno = EWOULDBLOCK
+      return -1
+    }
+
+    let delayRecorder = DelayRecorder()
+    var presented: [String] = []
+    let suggester = FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]])
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator,
+      aliasSuggester: suggester,
+      presentStatus: { presented.append($0) },
+      retrySleep: { await delayRecorder.record($0) })
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(
+      await delayRecorder.delays == [.seconds(1), .seconds(2), .seconds(4)],
+      "four total attempts (one initial + three retries), then genuine exhaustion")
+    #expect(
+      suggester.classificationCalls.isEmpty,
+      "every attempt failed at the repair, before the word loop could ever run")
+    #expect(
+      coordinator.pendingEnrichmentCount == 1, "the queue stays pending — nothing was abandoned")
+    #expect(
+      !presented.contains("Finished importing your words."),
+      "exhaustion is a hard stop, never a false completion")
   }
 
   // MARK: - Fail-open (Codex Chunk 2 review finding 1)
@@ -385,7 +554,9 @@ struct BulkImportEnrichmentCoordinatorTests {
     await gate.open_()
     await bulkCoordinator.awaitDrainForTesting()
 
-    #expect(suggester.calls.contains("Qualtrics"), "the model IS called again — no per-word skip")
+    #expect(
+      suggester.classificationCalls.contains("Qualtrics"),
+      "the model IS called again — no per-word skip")
     let qualtrics = try #require(coordinator.customWords.first { $0.id == qualtricsID })
     #expect(
       qualtrics.aliases == ["other-instance-alias"],
@@ -428,7 +599,7 @@ struct BulkImportEnrichmentCoordinatorTests {
 
     // Exactly one call: the failure must hard-stop the loop before the
     // queued wake gets a chance to retry the same broken write again.
-    #expect(suggester.calls == ["Kubernetes"])
+    #expect(suggester.classificationCalls == ["Kubernetes"])
   }
 
   #if DEBUG
@@ -537,6 +708,46 @@ struct BulkImportEnrichmentCoordinatorTests {
       "a failed sweep write must never be reported as a successful cancel")
   }
 
+  // MARK: - Classification-aware routing (Phase 3 review finding A)
+
+  @Test(
+    "a never-classified .general word is routed through classification; an explicitly categorized word is not"
+  )
+  func generalWordsClassifyExplicitlyCategorizedWordsDoNot() async throws {
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [
+          CustomWordsImportCandidate(canonical: "Kubernetes"),
+          CustomWordsImportCandidate(
+            canonical: "Qualtrics", category: .supplied(.brand)),
+        ]))
+    let suggester = FakeAliasSuggester(
+      aliasesByWord: ["Kubernetes": ["k8s"], "Qualtrics": ["qualtrix"]])
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester, presentStatus: { _ in })
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(
+      suggester.classificationCalls == ["Kubernetes"],
+      "the never-classified word must take the classification path, not the known-category one")
+    #expect(
+      suggester.calls == ["Qualtrics"],
+      "the explicitly categorized word must take the known-category path, not classification")
+    #expect(suggester.priorities == [.background, .background])
+
+    let kubernetes = try #require(coordinator.customWords.first { $0.canonical == "Kubernetes" })
+    #expect(kubernetes.aliases == ["k8s"], "classified aliases still persist")
+    #expect(
+      kubernetes.category == .general,
+      "the classifier's category is prompt-routing input only — the stored word stays .general")
+    let qualtrics = try #require(coordinator.customWords.first { $0.canonical == "Qualtrics" })
+    #expect(qualtrics.aliases == ["qualtrix"])
+  }
+
   // MARK: - Required coverage: priority, single-flight, pill counts, chunking
 
   @Test("every suggestion call uses .background priority")
@@ -582,7 +793,10 @@ struct BulkImportEnrichmentCoordinatorTests {
     await gate.open_()
     await bulkCoordinator.awaitDrainForTesting()
 
-    #expect(suggester.calls == ["Kubernetes"], "one word, called exactly once, by one walker")
+    #expect(
+      suggester.classificationCalls == ["Kubernetes"],
+      "one word, called exactly once, by one walker"
+    )
   }
 
   @Test("the start and finish pills each fire exactly once per continuous session")

--- a/Tests/EnviousWisprTests/App/BulkImportEnrichmentCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/BulkImportEnrichmentCoordinatorTests.swift
@@ -1,0 +1,635 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPostProcessing
+
+/// Test double for the on-device alias generator. `@unchecked Sendable`
+/// mirrors `ContactsImportCoordinatorTests`'s `FakeAliasSuggester`: the
+/// coordinator's drain loop calls it sequentially behind `await`, so mutable
+/// state here never races against the drain itself. `gate` lets a test hold
+/// every call open until it has set up the "mid-flight" state it needs, then
+/// release all of them at once.
+private final class FakeAliasSuggester: AliasSuggesting, @unchecked Sendable {
+  private let aliasesByWord: [String: [String]]
+  private let gate: CallGate?
+  private(set) var calls: [String] = []
+  var available = true
+  var isAvailable: Bool { available }
+
+  init(aliasesByWord: [String: [String]] = [:], gate: CallGate? = nil) {
+    self.aliasesByWord = aliasesByWord
+    self.gate = gate
+  }
+
+  private(set) var priorities: [AliasSuggestionPriority] = []
+
+  func suggestAliases(
+    for word: String, category: WordCategory, priority: AliasSuggestionPriority
+  ) async -> [String]? {
+    calls.append(word)
+    priorities.append(priority)
+    // Mirrors `WordSuggestionService.suggestAliases`'s own real behavior:
+    // unavailable always resolves to nil, never a call that hangs or throws.
+    guard available else { return nil }
+    if let gate {
+      await gate.markCallStarted()
+      try? await gate.waitUntilOpen()
+    }
+    return aliasesByWord[word]
+  }
+}
+
+/// Test-only rendezvous: closed by default, `open()` releases every call
+/// currently waiting AND every future one immediately. `waitUntilCallCount`
+/// gives a happens-before point to act from once a call has genuinely
+/// started, never racing real Swift Concurrency scheduling. Deadline-bounded
+/// (`withThrowingTimeout`), matching `WordSuggestionServiceTests`'s
+/// `ResumeGate` shape (`swift-patterns.md` RULE:
+/// tests-no-unconditional-continuation-await).
+private actor CallGate {
+  private var open = false
+  private(set) var callsStarted = 0
+
+  func markCallStarted() { callsStarted += 1 }
+  func open_() { open = true }
+
+  func waitUntilOpen(timeoutSeconds: Double = 5) async throws {
+    try await withThrowingTimeout(seconds: timeoutSeconds) {
+      while await self.open == false {
+        try Task.checkCancellation()
+        await Task.yield()
+      }
+    }
+  }
+
+  func waitUntilCallCount(_ expected: Int, timeoutSeconds: Double = 5) async throws {
+    try await withThrowingTimeout(seconds: timeoutSeconds) {
+      while await self.callsStarted != expected {
+        try Task.checkCancellation()
+        await Task.yield()
+      }
+    }
+  }
+}
+
+@MainActor
+@Suite("BulkImportEnrichmentCoordinator (#1701 Chunk 2)")
+struct BulkImportEnrichmentCoordinatorTests {
+
+  private func makeCoordinator() -> (CustomWordsCoordinator, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-bulk-coordinator-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent("custom-words.json")
+    return (CustomWordsCoordinator(manager: CustomWordsManager(fileURL: url)), url)
+  }
+
+  private func plan(
+    baseline: [CustomWord], additions: [CustomWordsImportCandidate]
+  ) -> CustomWordsImportCommitPlan {
+    CustomWordsImportCommitPlan(
+      baseline: CustomWordsImportLibrarySnapshot(words: baseline), additions: additions,
+      replacements: [])
+  }
+
+  // MARK: - Resume after relaunch
+
+  @Test("a fresh instance against pre-set pending state reads real progress, not a reset to zero")
+  func freshInstanceReadsRealProgressOnFirstObservation() async throws {
+    let (seedCoordinator, url) = makeCoordinator()
+    _ = seedCoordinator.commitImport(
+      plan(
+        baseline: seedCoordinator.customWords,
+        additions: [
+          CustomWordsImportCandidate(canonical: "Kubernetes"),
+          CustomWordsImportCandidate(canonical: "Qualtrics"),
+        ]))
+
+    // A fresh coordinator instance, as a relaunched process would construct —
+    // never the seeding instance held onto in memory.
+    let relaunchedCoordinator = CustomWordsCoordinator(manager: CustomWordsManager(fileURL: url))
+    var presented: [String] = []
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: relaunchedCoordinator, aliasSuggester: FakeAliasSuggester(),
+      presentStatus: { presented.append($0) })
+
+    // The FIRST observation, before requestDrain() has run at all: real
+    // durable state, not an in-memory counter reset to zero.
+    #expect(relaunchedCoordinator.pendingEnrichmentBatchTotal == 2)
+    #expect(relaunchedCoordinator.pendingEnrichmentWords()?.count == 2)
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(relaunchedCoordinator.pendingEnrichmentBatchTotal == nil)
+    #expect(presented.contains("Finished importing your words."))
+  }
+
+  // MARK: - Cancel
+
+  @Test(
+    "Cancel lets an in-flight checkpoint land, then sweeps a word added after the drain started"
+  )
+  func cancelLetsInFlightLandThenSweepsLiveStateNotAStaleCallerList() async throws {
+    let (coordinator, url) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+    let kubernetesID = try #require(
+      coordinator.customWords.first { $0.canonical == "Kubernetes" }
+    ).id
+
+    let gate = CallGate()
+    let suggester = FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]], gate: gate)
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester, presentStatus: { _ in })
+
+    bulkCoordinator.requestDrain()
+    try await gate.waitUntilCallCount(1)  // "Kubernetes"'s call has genuinely started
+
+    // A second import lands on the SAME FILE while the drain is mid-flight,
+    // through a raw manager the drain's own in-memory `pending` snapshot
+    // never saw — this coordinator's idea of the target list is now stale
+    // relative to the file.
+    let rawManager = CustomWordsManager(fileURL: url)
+    var rawWords = try #require(rawManager.load())
+    _ = try rawManager.commitImport(
+      plan(baseline: rawWords, additions: [CustomWordsImportCandidate(canonical: "Qualtrics")]),
+      to: &rawWords)
+
+    bulkCoordinator.cancel()
+    await gate.open_()  // let the in-flight "Kubernetes" call finish
+    await bulkCoordinator.awaitDrainForTesting()
+
+    let final = try #require(coordinator.customWords.first { $0.id == kubernetesID })
+    #expect(final.aliases == ["k8s"], "the in-flight call must finish and checkpoint normally")
+    #expect(final.enrichmentPending == false)
+
+    let qualtrics = try #require(coordinator.customWords.first { $0.canonical == "Qualtrics" })
+    #expect(
+      qualtrics.enrichmentPending == false,
+      "Cancel's reload-and-sweep must clear a word the drain's stale in-memory list never saw")
+    #expect(coordinator.pendingEnrichmentBatchTotal == nil)
+  }
+
+  @Test("cancel() with no active drain is a safe no-op sweep")
+  func cancelWithNoActiveDrainIsSafeNoOpSweep() {
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: FakeAliasSuggester(), presentStatus: { _ in })
+
+    bulkCoordinator.cancel()
+
+    #expect(coordinator.pendingEnrichmentBatchTotal == nil)
+    #expect(coordinator.customWords.allSatisfy { $0.enrichmentPending == false })
+  }
+
+  @Test(
+    "a cancel requested before the drain task even starts fires no pill and no model call, but still durably sweeps"
+  )
+  func cancelBeforeDrainStartsFiresNoPillAndSweeps() async throws {
+    // Plan-completion audit finding 1: `requestDrain()` immediately followed
+    // by `cancel()` — both synchronous MainActor calls with no `await`
+    // between them — sets `cancelRequested` before the spawned Task can run
+    // at all (the same synchronous-stretch guarantee this suite already
+    // relies on elsewhere). The old code only checked `cancelRequested`
+    // inside the per-word loop, so `drainOnce` still announced the start
+    // pill before that loop's own guard caught the cancellation and broke
+    // before any model call — zero calls even pre-fix, but a pill fired
+    // that should never have fired.
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+
+    let suggester = FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]])
+    var presented: [String] = []
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester,
+      presentStatus: { presented.append($0) })
+
+    bulkCoordinator.requestDrain()
+    bulkCoordinator.cancel()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(suggester.calls.isEmpty, "a pre-start cancel must trigger zero model calls")
+    #expect(presented.isEmpty, "a pre-start cancel must never announce a start pill")
+    #expect(
+      coordinator.pendingEnrichmentBatchTotal == nil, "the sweep must durably clear the total")
+    #expect(
+      coordinator.customWords.allSatisfy { $0.enrichmentPending == false },
+      "the sweep must durably clear every pending word")
+  }
+
+  // MARK: - Second import mid-drain
+
+  @Test("a second import mid-drain is picked up by the SAME drain, not dropped")
+  func secondImportMidDrainIsPickedUpNotDropped() async throws {
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+
+    let gate = CallGate()
+    let suggester = FakeAliasSuggester(
+      aliasesByWord: ["Kubernetes": ["k8s"], "Qualtrics": ["qualtrix"]], gate: gate)
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester, presentStatus: { _ in })
+
+    bulkCoordinator.requestDrain()
+    try await gate.waitUntilCallCount(1)  // "Kubernetes"'s call has genuinely started
+
+    // A second import lands mid-drain, through the coordinator itself —
+    // mirrors production: `CustomWordsCoordinator.onImportCommitted` would
+    // call `requestDrain()` again here.
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Qualtrics")]))
+    #expect(coordinator.pendingEnrichmentBatchTotal == 2, "extended, never reset")
+    bulkCoordinator.requestDrain()  // coalesces: marks "one more pass" since a drain is active
+
+    await gate.open_()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    // The coalesced extra pass must have picked up "Qualtrics" too, not just
+    // stopped after the original word.
+    #expect(suggester.calls.contains("Qualtrics"), "the newly added word must be drained too")
+    let qualtrics = try #require(coordinator.customWords.first { $0.canonical == "Qualtrics" })
+    #expect(qualtrics.aliases == ["qualtrix"])
+    #expect(coordinator.pendingEnrichmentBatchTotal == nil)
+  }
+
+  // MARK: - Write failure
+
+  @Test("a locked-transaction write failure stops the drain without a completion pill")
+  func writeFailureStopsTheDrainWithoutCompletionPill() async throws {
+    let (coordinator, url) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+    let dir = url.deletingLastPathComponent()
+
+    // Lock the containing directory down AFTER the seeding commit succeeded,
+    // so only the CHECKPOINT write fails.
+    try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dir.path)
+    defer {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    }
+
+    var presented: [String] = []
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator,
+      aliasSuggester: FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]]),
+      presentStatus: { presented.append($0) })
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(presented.contains("Importing your words now. Check progress in the Your Words menu."))
+    #expect(
+      !presented.contains("Finished importing your words."),
+      "a failed checkpoint write must never announce completion")
+
+    // Restore permissions before reading back, so the read-side of this
+    // assertion isn't itself blocked by the fixture's own lockdown.
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    let onDisk = try #require(CustomWordsManager(fileURL: url).load())
+    let word = try #require(onDisk.first { $0.canonical == "Kubernetes" })
+    #expect(
+      word.enrichmentPending == true,
+      "an unresolved word must keep its pending flag when the checkpoint failed to write")
+  }
+
+  // MARK: - Fail-open (Codex Chunk 2 review finding 1)
+
+  @Test("an unavailable model still resolves the whole queue, never stranding it")
+  func unavailableModelStillResolvesTheQueue() async throws {
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [
+          CustomWordsImportCandidate(canonical: "Kubernetes"),
+          CustomWordsImportCandidate(canonical: "Qualtrics"),
+        ]))
+
+    let suggester = FakeAliasSuggester()
+    suggester.available = false
+    var presented: [String] = []
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester, presentStatus: { presented.append($0) })
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(
+      coordinator.customWords.allSatisfy { $0.enrichmentPending == false },
+      "every word must still resolve — a stranded flag is what the old isAvailable guard caused")
+    #expect(coordinator.pendingEnrichmentBatchTotal == nil)
+    #expect(presented.contains("Finished importing your words."))
+  }
+
+  @Test(
+    "a duplicate late result for a word another instance already checkpointed cannot overwrite it"
+  )
+  func duplicateLateResultCannotOverwriteAnotherInstancesFirstCheckpoint() async throws {
+    // Codex Chunk 2 review round 2 finding 2: the per-word fresh re-read this
+    // test used to prove was itself an O(n²) main-thread cost at the
+    // 25,000-word ceiling. Correctness does not depend on skipping the
+    // duplicate call — `applyEnrichmentResults`'s own pending-gate is what
+    // actually protects the other instance's already-checkpointed result,
+    // proven here at the coordinator level: the drain WILL call the model
+    // again for "Qualtrics" (no per-word skip anymore), but its late result
+    // must still lose to the other instance's first checkpoint.
+    let (coordinator, url) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [
+          CustomWordsImportCandidate(canonical: "Kubernetes"),
+          CustomWordsImportCandidate(canonical: "Qualtrics"),
+        ]))
+    let qualtricsID = try #require(
+      coordinator.customWords.first { $0.canonical == "Qualtrics" }
+    ).id
+
+    let gate = CallGate()
+    let suggester = FakeAliasSuggester(
+      aliasesByWord: ["Kubernetes": ["k8s"], "Qualtrics": ["late-duplicate"]], gate: gate)
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester, presentStatus: { _ in })
+
+    bulkCoordinator.requestDrain()
+    try await gate.waitUntilCallCount(1)  // "Kubernetes"'s call has genuinely started
+
+    // A SEPARATE manager instance (simulating a second running app copy,
+    // #1747) checkpoints "Qualtrics" FIRST, directly, bypassing this
+    // coordinator entirely.
+    let rawManager = CustomWordsManager(fileURL: url)
+    _ = try rawManager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: qualtricsID, generatedAliases: ["other-instance-alias"])
+    ])
+
+    await gate.open_()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(suggester.calls.contains("Qualtrics"), "the model IS called again — no per-word skip")
+    let qualtrics = try #require(coordinator.customWords.first { $0.id == qualtricsID })
+    #expect(
+      qualtrics.aliases == ["other-instance-alias"],
+      "the late duplicate must never overwrite the other instance's first checkpoint")
+    #expect(!qualtrics.aliases.contains("late-duplicate"))
+  }
+
+  // MARK: - Worker failure terminality (Codex Chunk 2 review finding 4)
+
+  @Test("a checkpoint failure with a wake already queued still hard-stops, never retries")
+  func checkpointFailureWithQueuedWakeStillHardStops() async throws {
+    let (coordinator, url) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+    let dir = url.deletingLastPathComponent()
+
+    let gate = CallGate()
+    let suggester = FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]], gate: gate)
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester, presentStatus: { _ in })
+
+    bulkCoordinator.requestDrain()
+    try await gate.waitUntilCallCount(1)
+
+    // A wake arrives WHILE this pass is in flight, mirroring
+    // `onImportCommitted` firing mid-drain — queues "run one more pass."
+    bulkCoordinator.requestDrain()
+
+    // Lock the directory down so the tail checkpoint this pass is about to
+    // attempt fails to write.
+    try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dir.path)
+    defer {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    }
+
+    await gate.open_()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    // Exactly one call: the failure must hard-stop the loop before the
+    // queued wake gets a chance to retry the same broken write again.
+    #expect(suggester.calls == ["Kubernetes"])
+  }
+
+  #if DEBUG
+    // `forcePendingEnrichmentWordsFailureOnCallForTesting` is `#if
+    // DEBUG`-gated end to end (matches `rawSuggestionOverrideForTesting`'s
+    // own precedent), so this test is gated the same way since it
+    // references that symbol.
+    @Test(
+      "a failed final scan never fires a false completion pill, even after the checkpoint succeeded"
+    )
+    func failedFinalScanNeverFiresAFalseCompletionPill() async throws {
+      // Codex Chunk 2 review round 2 finding 3: the drain's tail checkpoint
+      // write and its immediately-following final re-scan read are both
+      // synchronous with no suspension point between them — no external task
+      // can time a real file-permission change to land strictly between
+      // them. `forcePendingEnrichmentWordsFailureOnCallForTesting` targets
+      // the SECOND call deterministically (call 1 = drainOnce's initial
+      // scan, which must succeed; call 2 = the final re-scan, forced to
+      // fail) with no file-system race at all — permissions stay open
+      // throughout, so the checkpoint write genuinely succeeds first.
+      let (coordinator, _) = makeCoordinator()
+      _ = coordinator.commitImport(
+        plan(
+          baseline: coordinator.customWords,
+          additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+      coordinator.forcePendingEnrichmentWordsFailureOnCallForTesting = 2
+
+      let suggester = FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]])
+      var presented: [String] = []
+      let bulkCoordinator = BulkImportEnrichmentCoordinator(
+        customWords: coordinator, aliasSuggester: suggester,
+        presentStatus: { presented.append($0) })
+
+      bulkCoordinator.requestDrain()
+      await bulkCoordinator.awaitDrainForTesting()
+
+      let onDisk = try #require(coordinator.customWords.first { $0.canonical == "Kubernetes" })
+      #expect(onDisk.aliases == ["k8s"], "the checkpoint itself must have genuinely succeeded")
+      #expect(
+        !presented.contains("Finished importing your words."),
+        "a failed final read must never be treated as an empty, completed queue")
+
+      // Codex Chunk 2 review round 3 finding 2: a failed final scan used to
+      // leave `didAnnounceStart` (and the diagnostic counters) stuck forever,
+      // so the NEXT session's genuine completion, and even its start pill,
+      // could be silently suppressed. Retry now that the injected failure has
+      // stopped firing (it targets call 2 only, already consumed above).
+      coordinator.forcePendingEnrichmentWordsFailureOnCallForTesting = nil
+      bulkCoordinator.requestDrain()
+      await bulkCoordinator.awaitDrainForTesting()
+
+      #expect(
+        presented == [
+          "Importing your words now. Check progress in the Your Words menu.",
+          "Finished importing your words.",
+        ],
+        "the lingering session must finalize exactly once, with no duplicate start pill")
+
+      // A genuinely NEW import must announce its own start pill normally —
+      // proving `didAnnounceStart` was reset, not left stuck true forever.
+      _ = coordinator.commitImport(
+        plan(
+          baseline: coordinator.customWords,
+          additions: [CustomWordsImportCandidate(canonical: "Qualtrics")]))
+      bulkCoordinator.requestDrain()
+      await bulkCoordinator.awaitDrainForTesting()
+
+      #expect(
+        presented == [
+          "Importing your words now. Check progress in the Your Words menu.",
+          "Finished importing your words.",
+          "Importing your words now. Check progress in the Your Words menu.",
+          "Finished importing your words.",
+        ],
+        "the new session's start pill must fire, and its own completion must land, not be suppressed"
+      )
+    }
+  #endif
+
+  @Test("a Cancel whose durable sweep fails to write is never reported as a clean cancel")
+  func cancelWriteFailureIsNeverReportedAsCleanCancel() throws {
+    let (coordinator, url) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+    let dir = url.deletingLastPathComponent()
+
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: FakeAliasSuggester(), presentStatus: { _ in })
+
+    try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dir.path)
+    defer {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    }
+
+    bulkCoordinator.cancel()  // no active drain — direct performCancelSweep() path
+
+    // Restore permissions before reading back, so the assertion's own read
+    // isn't blocked by the fixture's lockdown.
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    let onDisk = try #require(CustomWordsManager(fileURL: url).load())
+    let word = try #require(onDisk.first { $0.canonical == "Kubernetes" })
+    #expect(
+      word.enrichmentPending == true,
+      "a failed sweep write must never be reported as a successful cancel")
+  }
+
+  // MARK: - Required coverage: priority, single-flight, pill counts, chunking
+
+  @Test("every suggestion call uses .background priority")
+  func everyCallUsesBackgroundPriority() async throws {
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [
+          CustomWordsImportCandidate(canonical: "Kubernetes"),
+          CustomWordsImportCandidate(canonical: "Qualtrics"),
+        ]))
+    let suggester = FakeAliasSuggester()
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester, presentStatus: { _ in })
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(suggester.priorities == [.background, .background])
+  }
+
+  @Test("two overlapping requestDrain() calls run exactly one walker, never two")
+  func overlappingRequestDrainCallsAreSingleFlight() async throws {
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+    let gate = CallGate()
+    let suggester = FakeAliasSuggester(aliasesByWord: ["Kubernetes": ["k8s"]], gate: gate)
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester, presentStatus: { _ in })
+
+    bulkCoordinator.requestDrain()
+    try await gate.waitUntilCallCount(1)
+    // Fired repeatedly while the first pass is in flight — must coalesce,
+    // never start a second concurrent walker calling the model again.
+    bulkCoordinator.requestDrain()
+    bulkCoordinator.requestDrain()
+    bulkCoordinator.requestDrain()
+
+    await gate.open_()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(suggester.calls == ["Kubernetes"], "one word, called exactly once, by one walker")
+  }
+
+  @Test("the start and finish pills each fire exactly once per continuous session")
+  func startAndFinishPillsFireExactlyOncePerSession() async throws {
+    let (coordinator, _) = makeCoordinator()
+    let manyWords = (0..<30).map { CustomWordsImportCandidate(canonical: "Word\($0)") }
+    _ = coordinator.commitImport(plan(baseline: coordinator.customWords, additions: manyWords))
+
+    let suggester = FakeAliasSuggester()
+    var presented: [String] = []
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester,
+      presentStatus: { presented.append($0) })
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    #expect(
+      presented.filter { $0 == "Importing your words now. Check progress in the Your Words menu." }
+        .count == 1)
+    #expect(presented.filter { $0 == "Finished importing your words." }.count == 1)
+  }
+
+  @Test("more than 25 pending words checkpoint in chunks, not one call at the end")
+  func checkpointsInChunksOf25() async throws {
+    let (coordinator, _) = makeCoordinator()
+    let manyWords = (0..<30).map { CustomWordsImportCandidate(canonical: "Word\($0)") }
+    _ = coordinator.commitImport(plan(baseline: coordinator.customWords, additions: manyWords))
+
+    var checkpointSizes: [Int] = []
+    coordinator.onWordsChanged = { _ in
+      // Each `onWordsChanged` firing corresponds to one
+      // `applyEnrichmentResults` write; record the live pending count at that
+      // moment as a proxy for "a checkpoint just landed mid-drain."
+      checkpointSizes.append(coordinator.pendingEnrichmentCount)
+    }
+    let suggester = FakeAliasSuggester()
+    let bulkCoordinator = BulkImportEnrichmentCoordinator(
+      customWords: coordinator, aliasSuggester: suggester, presentStatus: { _ in })
+
+    bulkCoordinator.requestDrain()
+    await bulkCoordinator.awaitDrainForTesting()
+
+    // 30 words, chunked at 25: one checkpoint at 5 remaining, one at 0 —
+    // never a single checkpoint carrying all 30 at once.
+    #expect(checkpointSizes.count >= 2, "expected at least two separate checkpoint writes")
+    #expect(checkpointSizes.contains(5), "the first chunk boundary must land at 25 processed")
+    #expect(coordinator.pendingEnrichmentBatchTotal == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/App/CustomWordsCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsCoordinatorTests.swift
@@ -180,7 +180,7 @@ struct CustomWordsCoordinatorTests {
         baseline: coordinator.customWords,
         additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
     let target = try #require(coordinator.customWords.first { $0.canonical == "Kubernetes" })
-    _ = coordinator.applyEnrichmentResults([
+    try coordinator.applyEnrichmentResults([
       CustomWordEnrichmentResult(id: target.id, generatedAliases: ["k8s"])
     ])
     #expect(coordinator.mostRecentEnrichment != nil, "the completed run left a display behind")
@@ -225,7 +225,7 @@ struct CustomWordsCoordinatorTests {
   }
 
   @Test("pendingEnrichmentCount drops as checkpoints land and reaches 0 on completion")
-  func pendingEnrichmentCountDropsAsCheckpointsLand() {
+  func pendingEnrichmentCountDropsAsCheckpointsLand() throws {
     let (coordinator, _) = makeCoordinator()
     _ = coordinator.commitImport(
       plan(
@@ -238,12 +238,12 @@ struct CustomWordsCoordinatorTests {
       $0.canonical == "Kubernetes" || $0.canonical == "Qualtrics"
     }
 
-    _ = coordinator.applyEnrichmentResults([
+    try coordinator.applyEnrichmentResults([
       CustomWordEnrichmentResult(id: words[0].id, generatedAliases: [])
     ])
     #expect(coordinator.pendingEnrichmentCount == 1)
 
-    _ = coordinator.applyEnrichmentResults([
+    try coordinator.applyEnrichmentResults([
       CustomWordEnrichmentResult(id: words[1].id, generatedAliases: [])
     ])
     #expect(coordinator.pendingEnrichmentCount == 0)

--- a/Tests/EnviousWisprTests/App/CustomWordsCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsCoordinatorTests.swift
@@ -1,0 +1,264 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPostProcessing
+
+/// #1701 Chunk 2 — the AppKit adapter's own observability contract for
+/// bulk-import enrichment: `pendingEnrichmentBatchTotal` round-tripping and
+/// `onImportCommitted`'s firing rule. Persistence correctness itself is owned
+/// by `CustomWordsBulkEnrichmentTests` (manager-level); this suite is about
+/// what the coordinator surfaces to its observers.
+@MainActor
+@Suite("CustomWordsCoordinator — bulk-import enrichment observability")
+struct CustomWordsCoordinatorTests {
+
+  private func makeCoordinator() -> (CustomWordsCoordinator, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-coordinator-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent("custom-words.json")
+    return (CustomWordsCoordinator(manager: CustomWordsManager(fileURL: url)), url)
+  }
+
+  private func plan(
+    baseline: [CustomWord], additions: [CustomWordsImportCandidate] = []
+  ) -> CustomWordsImportCommitPlan {
+    CustomWordsImportCommitPlan(
+      baseline: CustomWordsImportLibrarySnapshot(words: baseline), additions: additions,
+      replacements: [])
+  }
+
+  @Test("pendingEnrichmentBatchTotal round-trips through loadSnapshot()")
+  func pendingTotalRoundTripsThroughLoadSnapshot() {
+    let (first, url) = makeCoordinator()
+    #expect(first.pendingEnrichmentBatchTotal == nil, "a fresh library has no run in progress")
+
+    _ = first.commitImport(
+      plan(
+        baseline: first.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+    #expect(first.pendingEnrichmentBatchTotal == 1)
+
+    // A SECOND coordinator instance backed by the SAME file (a fresh
+    // `loadSnapshot()` call, not the same in-memory object) must observe the
+    // same total — proving the value round-trips through disk, not just a
+    // held reference.
+    let second = CustomWordsCoordinator(manager: CustomWordsManager(fileURL: url))
+    #expect(second.pendingEnrichmentBatchTotal == 1)
+  }
+
+  @Test("onImportCommitted fires on a nonempty commit")
+  func onImportCommittedFiresOnNonemptyCommit() {
+    let (coordinator, _) = makeCoordinator()
+    var fired = 0
+    coordinator.onImportCommitted = { fired += 1 }
+
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+
+    #expect(fired == 1)
+  }
+
+  @Test("onImportCommitted does not fire on an all-Skip commit")
+  func onImportCommittedDoesNotFireOnEmptyCommit() {
+    let (coordinator, _) = makeCoordinator()
+    var fired = 0
+    coordinator.onImportCommitted = { fired += 1 }
+
+    _ = coordinator.commitImport(plan(baseline: coordinator.customWords))
+
+    #expect(fired == 0)
+  }
+
+  @Test("onImportCommitted does not fire on a stale or failed commit")
+  func onImportCommittedDoesNotFireOnStaleCommit() {
+    let (coordinator, _) = makeCoordinator()
+    let staleBaseline = coordinator.customWords
+    // Change the library after the (stale) baseline was captured.
+    _ = coordinator.add(CustomWord(canonical: "Interloper"))
+
+    var fired = 0
+    coordinator.onImportCommitted = { fired += 1 }
+
+    let outcome = coordinator.commitImport(
+      plan(
+        baseline: staleBaseline, additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+
+    guard case .stale = outcome else {
+      Issue.record("expected a stale outcome")
+      return
+    }
+    #expect(fired == 0)
+  }
+
+  @Test("a stale-commit refresh adopts words AND the durable total together, from one snapshot")
+  func staleCommitRefreshAdoptsWordsAndTotalTogether() {
+    // Codex Chunk 2 review round 2 finding 4: `refreshFromDiskIfPossible`
+    // used to call `manager.load()` (words only), so a stale-commit refresh
+    // after another app instance wrote could adopt fresh words paired with a
+    // now-stale (or missing) total — breaking the atomic-pair guarantee
+    // every other read/write path in this coordinator already honors.
+    let (coordinator, url) = makeCoordinator()
+    let staleBaseline = coordinator.customWords
+
+    // A SEPARATE manager instance (a second running app copy, #1747) commits
+    // an eligible import directly to the same file, bypassing this
+    // coordinator entirely — both new words AND a fresh durable total.
+    let rawManager = CustomWordsManager(fileURL: url)
+    var rawWords = rawManager.load() ?? []
+    _ = try! rawManager.commitImport(
+      plan(
+        baseline: rawWords,
+        additions: [
+          CustomWordsImportCandidate(canonical: "Kubernetes"),
+          CustomWordsImportCandidate(canonical: "Qualtrics"),
+        ]),
+      to: &rawWords)
+
+    // This coordinator's own commit, built against the now-stale baseline,
+    // triggers the internal refresh.
+    let outcome = coordinator.commitImport(
+      plan(baseline: staleBaseline, additions: [CustomWordsImportCandidate(canonical: "Anthropic")])
+    )
+    guard case .stale = outcome else {
+      Issue.record("expected a stale outcome")
+      return
+    }
+
+    #expect(coordinator.customWords.contains { $0.canonical == "Kubernetes" })
+    #expect(coordinator.customWords.contains { $0.canonical == "Qualtrics" })
+    #expect(
+      coordinator.pendingEnrichmentBatchTotal == 2,
+      "the total must reflect the SAME snapshot the refreshed words came from, never left stale")
+  }
+
+  @Test("a total-only refresh never republishes unchanged words to pipelines")
+  func totalOnlyRefreshDoesNotFireOnWordsChanged() throws {
+    // Codex Chunk 2 review round 3 finding 3a: the old unconditional
+    // `onWordsChanged?(customWords)` fired even when only the total changed,
+    // needlessly republishing byte-identical words to every pipeline
+    // consumer.
+    let (coordinator, url) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+    let wordsBefore = coordinator.customWords
+
+    // Directly edit the total on disk, leaving `words` byte-identical — a
+    // scenario real commits/checkpoints don't produce on their own, but
+    // isolates this specific invariant precisely.
+    let raw = try Data(contentsOf: url)
+    var json = try #require(try JSONSerialization.jsonObject(with: raw) as? [String: Any])
+    json["pendingEnrichmentBatchTotal"] = 5
+    try JSONSerialization.data(withJSONObject: json).write(to: url, options: [.atomic])
+
+    var changedFired = 0
+    coordinator.onWordsChanged = { _ in changedFired += 1 }
+
+    #expect(coordinator.refreshFromDiskIfPossible() == true)
+
+    #expect(coordinator.pendingEnrichmentBatchTotal == 5)
+    #expect(coordinator.customWords == wordsBefore)
+    #expect(changedFired == 0, "words never changed, so onWordsChanged must never fire")
+  }
+
+  @Test("a cross-process transition to a new run clears a stale display from a previous one")
+  func crossProcessNewRunClearsStaleDisplay() throws {
+    // Codex Chunk 2 review round 3 finding 3b: the local `commitImport` path
+    // already clears `mostRecentEnrichment` on a nil -> non-nil transition;
+    // `refreshFromDiskIfPossible` must apply the same rule, or a stale
+    // display from THIS coordinator's own already-completed run can flash
+    // before another instance's freshly-started run produces its own result.
+    let (coordinator, url) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+    let target = try #require(coordinator.customWords.first { $0.canonical == "Kubernetes" })
+    _ = coordinator.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: ["k8s"])
+    ])
+    #expect(coordinator.mostRecentEnrichment != nil, "the completed run left a display behind")
+    #expect(coordinator.pendingEnrichmentBatchTotal == nil)
+
+    // A SEPARATE manager instance starts a genuinely NEW run on the same file.
+    let rawManager = CustomWordsManager(fileURL: url)
+    var rawWords = rawManager.load() ?? []
+    _ = try rawManager.commitImport(
+      plan(baseline: rawWords, additions: [CustomWordsImportCandidate(canonical: "Qualtrics")]),
+      to: &rawWords)
+
+    #expect(coordinator.refreshFromDiskIfPossible() == true)
+
+    #expect(coordinator.pendingEnrichmentBatchTotal == 1)
+    #expect(
+      coordinator.mostRecentEnrichment == nil,
+      "the previous run's display must not survive into the new one")
+  }
+
+  // MARK: - pendingEnrichmentCount (Codex Chunk 2 review finding 5 — the UI
+  // progress projection: observable, in-memory, safe to read from a SwiftUI
+  // `body`, never a proxy for the durable total's mere presence)
+
+  @Test("pendingEnrichmentCount is 0 for a fresh library")
+  func pendingEnrichmentCountIsZeroForFreshLibrary() {
+    let (coordinator, _) = makeCoordinator()
+    #expect(coordinator.pendingEnrichmentCount == 0)
+  }
+
+  @Test("pendingEnrichmentCount reflects a commit immediately, in memory")
+  func pendingEnrichmentCountReflectsCommit() {
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [
+          CustomWordsImportCandidate(canonical: "Kubernetes"),
+          CustomWordsImportCandidate(canonical: "Qualtrics"),
+        ]))
+    #expect(coordinator.pendingEnrichmentCount == 2)
+  }
+
+  @Test("pendingEnrichmentCount drops as checkpoints land and reaches 0 on completion")
+  func pendingEnrichmentCountDropsAsCheckpointsLand() {
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [
+          CustomWordsImportCandidate(canonical: "Kubernetes"),
+          CustomWordsImportCandidate(canonical: "Qualtrics"),
+        ]))
+    let words = coordinator.customWords.filter {
+      $0.canonical == "Kubernetes" || $0.canonical == "Qualtrics"
+    }
+
+    _ = coordinator.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: words[0].id, generatedAliases: [])
+    ])
+    #expect(coordinator.pendingEnrichmentCount == 1)
+
+    _ = coordinator.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: words[1].id, generatedAliases: [])
+    ])
+    #expect(coordinator.pendingEnrichmentCount == 0)
+  }
+
+  @Test("pendingEnrichmentCount drops to 0 on Cancel")
+  func pendingEnrichmentCountDropsToZeroOnCancel() {
+    let (coordinator, _) = makeCoordinator()
+    _ = coordinator.commitImport(
+      plan(
+        baseline: coordinator.customWords,
+        additions: [CustomWordsImportCandidate(canonical: "Kubernetes")]))
+    #expect(coordinator.pendingEnrichmentCount == 1)
+
+    _ = coordinator.cancelEnrichment()
+    #expect(coordinator.pendingEnrichmentCount == 0)
+  }
+}

--- a/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
+++ b/Tests/EnviousWisprTests/App/CustomWordsImportReviewFlowTests.swift
@@ -53,9 +53,11 @@ struct CustomWordsImportReviewFlowTests {
 
   struct StubSource: CustomWordsImportSource {
     let candidates: [CustomWordsImportCandidate]
+    var enrichmentEligible = true
     func loadRawCandidates() async throws -> CustomWordsImportBatch {
       CustomWordsImportBatch(
-        sourceID: "test", sourceDisplayName: "Test", candidates: candidates)
+        sourceID: "test", sourceDisplayName: "Test", candidates: candidates,
+        enrichmentEligible: enrichmentEligible)
     }
   }
 
@@ -131,10 +133,11 @@ struct CustomWordsImportReviewFlowTests {
 
   /// Drive a source to the review screen. Returns once the flow settles.
   static func runToReview(
-    _ model: Model, candidates: [CustomWordsImportCandidate]
+    _ model: Model, candidates: [CustomWordsImportCandidate], enrichmentEligible: Bool = true
   ) async {
     model.select(.paste)
-    model.begin(with: StubSource(candidates: candidates))
+    model.begin(
+      with: StubSource(candidates: candidates, enrichmentEligible: enrichmentEligible))
     await Self.settle(model, waitingFor: "the review or result screen") {
       $0.step == .review || $0.step.isResult
     }
@@ -272,6 +275,48 @@ struct CustomWordsImportReviewFlowTests {
     #expect(plan.replacements.isEmpty)
     #expect(plan.additions.map(\.canonical) == ["Kubernetes"])
     #expect(model.step == .result(.completed(added: 1, replaced: 0)))
+  }
+
+  @Test("confirm's plan carries the loaded batch's enrichmentEligible (#1701 Chunk 2)")
+  func confirmPlanCarriesBatchEnrichmentEligible() async {
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    compare.results = [[Self.comparison("Kubernetes", .new)]]
+    commit.outcomes = [
+      .committed(
+        CustomWordsImportCommitReceipt(
+          addedIDs: [UUID()], replacedIDs: [], droppedAliasCollisions: []))
+    ]
+    let model = Self.makeModel(compare: compare, commit: commit)
+    await Self.runToReview(
+      model, candidates: [Self.candidate("Kubernetes")], enrichmentEligible: false)
+
+    model.confirm()
+
+    #expect(try! #require(commit.plans.first).enrichmentEligible == false)
+  }
+
+  @Test("a second, unrelated load never inherits an earlier batch's eligibility")
+  func secondLoadReflectsOnlyItsOwnBatchEligibility() async {
+    // #1701 Chunk 2: an ineligible batch's flag must never leak into a
+    // SUBSEQUENT, unrelated load in the same still-open sheet.
+    let compare = CompareSpy()
+    let commit = CommitSpy()
+    compare.results = [[Self.comparison("Kubernetes", .new)], [Self.comparison("Qualtrics", .new)]]
+    commit.outcomes = [
+      .committed(
+        CustomWordsImportCommitReceipt(
+          addedIDs: [UUID()], replacedIDs: [], droppedAliasCollisions: []))
+    ]
+    let model = Self.makeModel(compare: compare, commit: commit)
+    await Self.runToReview(
+      model, candidates: [Self.candidate("Kubernetes")], enrichmentEligible: false)
+
+    // Second, unrelated load — the eligible default this time.
+    await Self.runToReview(model, candidates: [Self.candidate("Qualtrics")])
+    model.confirm()
+
+    #expect(try! #require(commit.plans.first).enrichmentEligible == true)
   }
 
   @Test("confirm with everything skipped writes nothing")

--- a/Tests/EnviousWisprTests/App/RecordingOverlayPanelImportStatusTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingOverlayPanelImportStatusTests.swift
@@ -1,0 +1,61 @@
+import EnviousWisprPipeline
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Pins the bulk-import-status pill's Heart & Limbs state machine (#1701
+/// Phase 3 review findings, round 1 and round 3): a fast enrichment run must
+/// let "Finished" replace this feature's own still-pending "Importing", but
+/// neither call may ever interrupt a genuine recording or processing panel.
+/// `RecordingOverlayPanel` is otherwise real-NSPanel/window-server UI code
+/// with no existing test file (the established runtime-only exemption); this
+/// narrow state-machine logic — ownership, generation-stamping, guard
+/// branching — is deterministically testable without rendering.
+@MainActor
+@Suite("RecordingOverlayPanel — bulk-import status pill (#1701 Phase 3)")
+struct RecordingOverlayPanelImportStatusTests {
+
+  @Test("a still-pending Importing pill is replaced by Finished, not dropped")
+  func pendingImportingReplacedByFinished() {
+    let overlay = RecordingOverlayPanel()
+    defer { overlay.hide() }
+
+    // No `await`/suspension between these two calls — the first main-queue
+    // work item cannot run during this synchronous MainActor stretch, so
+    // this reproduces the exact race a fast (or unavailable-model) drain
+    // hits: "Finished" arriving before "Importing" has ever been rendered.
+    overlay.showImportStatus(message: "Importing your words now.")
+    overlay.showImportStatus(message: "Finished importing your words.")
+
+    #expect(overlay.importStatusMessageForTesting == "Finished importing your words.")
+  }
+
+  @Test("a pending recording panel refuses import status entirely")
+  func pendingRecordingRefusesImportStatus() {
+    let overlay = RecordingOverlayPanel()
+    defer { overlay.hide() }
+
+    overlay.show(intent: .recording(audioLevel: 0))
+    overlay.showImportStatus(message: "Finished importing your words.")
+
+    #expect(overlay.currentIntent == .recording(audioLevel: 0))
+    #expect(
+      overlay.importStatusMessageForTesting == nil,
+      "a limb must never claim ownership of a slot a genuine recording panel holds")
+  }
+
+  @Test("recording superseding a pending import status leaves no stale ownership")
+  func recordingSupersedesPendingImportStatus() {
+    let overlay = RecordingOverlayPanel()
+    defer { overlay.hide() }
+
+    overlay.showImportStatus(message: "Importing your words now.")
+    overlay.show(intent: .recording(audioLevel: 0))
+    overlay.showImportStatus(message: "Finished importing your words.")
+
+    #expect(overlay.currentIntent == .recording(audioLevel: 0))
+    #expect(
+      overlay.importStatusMessageForTesting == nil,
+      "the stale import token must lose all ownership once recording superseded it")
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/BulkImportEnrichmentCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/BulkImportEnrichmentCoordinatorCeilingsTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+/// Architecture ceiling for `BulkImportEnrichmentCoordinator` (#1701 Chunk 2).
+///
+/// First measurement, not a ratchet: caps are set to the shape that shipped,
+/// not padded ahead of need. Raising any of these requires a Bible §30
+/// changelog entry, same discipline as every other per-home ceiling.
+///
+/// Caps:
+/// - 3 stored collaborators (`customWords`, `aliasSuggester`, `presentStatus`)
+/// - 3 non-private methods (`requestDrain`, `cancel`, `awaitDrainForTesting`)
+/// - ≤225 lines
+/// - imports ⊆ {EnviousWisprCore, EnviousWisprPostProcessing, Foundation}
+@Suite struct BulkImportEnrichmentCoordinatorCeilingsTests {
+  private static let sourcePath =
+    "Sources/EnviousWisprAppKit/App/BulkImportEnrichmentCoordinator.swift"
+
+  @Test func storedCollaboratorCeiling() throws {
+    let source = try CeilingsTestSupport.source(at: Self.sourcePath)
+    let bodies = try CeilingsTestSupport.typeBodies(
+      named: "BulkImportEnrichmentCoordinator", in: source)
+    let total = bodies.reduce(0) { $0 + CeilingsTestSupport.countTopLevelLetCollaborators(in: $1) }
+    #expect(
+      total <= 3,
+      """
+      BulkImportEnrichmentCoordinator stored-collaborator ceiling exceeded: \(total) > 3. \
+      Expected only `customWords`, `aliasSuggester`, `presentStatus`. Raising this cap \
+      requires a Bible §30 changelog entry.
+      """)
+  }
+
+  @Test func nonPrivateMethodCeiling() throws {
+    let source = try CeilingsTestSupport.source(at: Self.sourcePath)
+    let bodies = try CeilingsTestSupport.typeBodies(
+      named: "BulkImportEnrichmentCoordinator", in: source)
+    let total = bodies.reduce(0) { $0 + CeilingsTestSupport.countNonPrivateMethods(in: $1) }
+    #expect(
+      total <= 3,
+      """
+      BulkImportEnrichmentCoordinator non-private method ceiling exceeded: \(total) > 3. \
+      Expected only `requestDrain`, `cancel`, `awaitDrainForTesting`. New domain methods \
+      require a Bible §30 changelog entry.
+      """)
+  }
+
+  @Test func lineCountCeiling() throws {
+    let source = try CeilingsTestSupport.source(at: Self.sourcePath)
+    let count = CeilingsTestSupport.lineCount(in: source)
+    #expect(
+      count <= 225,
+      """
+      BulkImportEnrichmentCoordinator line count exceeded: \(count) > 225. Ratchet down \
+      if shipping smaller; raise only via Bible §30.
+      """)
+  }
+
+  @Test func allowedImports() throws {
+    let source = try CeilingsTestSupport.source(at: Self.sourcePath)
+    let actual = CeilingsTestSupport.imports(in: source)
+    let allowed: Set<String> = ["EnviousWisprCore", "EnviousWisprPostProcessing", "Foundation"]
+    let extras = actual.subtracting(allowed)
+    #expect(
+      extras.isEmpty,
+      """
+      BulkImportEnrichmentCoordinator imports outside allowed set: \(extras.sorted()). \
+      Allowed: \(allowed.sorted()). New imports require a Bible §30 entry — this coordinator \
+      should not couple to additional modules without justification (it never reaches \
+      through to CustomWordsManager directly; see the file's own header comment).
+      """)
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/BulkImportEnrichmentCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/BulkImportEnrichmentCoordinatorCeilingsTests.swift
@@ -3,14 +3,21 @@ import Testing
 
 /// Architecture ceiling for `BulkImportEnrichmentCoordinator` (#1701 Chunk 2).
 ///
-/// First measurement, not a ratchet: caps are set to the shape that shipped,
-/// not padded ahead of need. Raising any of these requires a Bible §30
-/// changelog entry, same discipline as every other per-home ceiling.
+/// Ratchet history:
+/// - Stored collaborators 3 -> 4 in #1701 (2026-07-23): injected
+///   `retrySleep`, the cancellable timing seam for bounded `.libraryBusy`
+///   recovery. Production uses the shipped 1/2/4-second retry schedule;
+///   tests replace the wait with a signal and never depend on wall-clock time.
+/// - Lines 225 -> 260 in #1701 (2026-07-23): Phase 3 full-diff review required
+///   typed `.libraryBusy` handling, a bounded delayed-retry state machine,
+///   and classification-aware routing for `.general` imported words. This is
+///   coordinator sequencing, not a new domain responsibility.
 ///
 /// Caps:
-/// - 3 stored collaborators (`customWords`, `aliasSuggester`, `presentStatus`)
+/// - 4 stored collaborators
+///   (`customWords`, `aliasSuggester`, `presentStatus`, `retrySleep`)
 /// - 3 non-private methods (`requestDrain`, `cancel`, `awaitDrainForTesting`)
-/// - ≤225 lines
+/// - <=260 lines
 /// - imports ⊆ {EnviousWisprCore, EnviousWisprPostProcessing, Foundation}
 @Suite struct BulkImportEnrichmentCoordinatorCeilingsTests {
   private static let sourcePath =
@@ -22,11 +29,11 @@ import Testing
       named: "BulkImportEnrichmentCoordinator", in: source)
     let total = bodies.reduce(0) { $0 + CeilingsTestSupport.countTopLevelLetCollaborators(in: $1) }
     #expect(
-      total <= 3,
+      total <= 4,
       """
-      BulkImportEnrichmentCoordinator stored-collaborator ceiling exceeded: \(total) > 3. \
-      Expected only `customWords`, `aliasSuggester`, `presentStatus`. Raising this cap \
-      requires a Bible §30 changelog entry.
+      BulkImportEnrichmentCoordinator stored-collaborator ceiling exceeded: \(total) > 4. \
+      Expected only `customWords`, `aliasSuggester`, `presentStatus`, `retrySleep`. Raising \
+      this cap requires a Bible §30 changelog entry.
       """)
   }
 
@@ -48,9 +55,9 @@ import Testing
     let source = try CeilingsTestSupport.source(at: Self.sourcePath)
     let count = CeilingsTestSupport.lineCount(in: source)
     #expect(
-      count <= 225,
+      count <= 260,
       """
-      BulkImportEnrichmentCoordinator line count exceeded: \(count) > 225. Ratchet down \
+      BulkImportEnrichmentCoordinator line count exceeded: \(count) > 260. Ratchet down \
       if shipping smaller; raise only via Bible §30.
       """)
   }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -168,13 +168,17 @@ import Testing
   ///   phase ran and the retirement silently no-op'd (caught by Live UAT, not
   ///   by any static review). Storing it here IS the fix: nothing narrower owns
   ///   its lifetime, the same rule that placed `egOneRuntime` above.
+  /// - 38 → 39 in #1701 (2026-07-23): App-owned
+  ///   `bulkImportEnrichmentCoordinator`, the app-lifetime owner of the durable
+  ///   pending-word drain and Cancel/checkpoint sequencing. The approved #1701
+  ///   plan §3b/§10 places this sibling of `contactsImportCoordinator` here.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 38,
+      count <= 39,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 38. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 39. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.

--- a/Tests/EnviousWisprTests/Contacts/ContactsImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Contacts/ContactsImportCoordinatorTests.swift
@@ -60,6 +60,15 @@ private final class FakeAliasSuggester: AliasSuggesting, @unchecked Sendable {
     priorities.append(priority)
     return aliasesByWord[word]
   }
+
+  /// Contacts import always pins `.person` and never takes this path; a
+  /// minimal stub satisfies protocol conformance (#1701 Phase 3 review
+  /// finding A).
+  func suggestAliases(
+    for word: String, priority: AliasSuggestionPriority
+  ) async -> [String]? {
+    aliasesByWord[word]
+  }
 }
 
 @MainActor

--- a/Tests/EnviousWisprTests/Contacts/ContactsImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Contacts/ContactsImportCoordinatorTests.swift
@@ -42,6 +42,9 @@ private final class FakeAliasSuggester: AliasSuggesting, @unchecked Sendable {
   let available: Bool
   let aliasesByWord: [String: [String]]
   private(set) var calls: [String] = []
+  /// Priority received on each call, in order — #1701 characterization: the
+  /// coordinator must pass `.background` on every call, never the default.
+  private(set) var priorities: [AliasSuggestionPriority] = []
 
   init(available: Bool, aliasesByWord: [String: [String]] = [:]) {
     self.available = available
@@ -50,8 +53,11 @@ private final class FakeAliasSuggester: AliasSuggesting, @unchecked Sendable {
 
   var isAvailable: Bool { available }
 
-  func suggestAliases(for word: String, category: WordCategory) async -> [String]? {
+  func suggestAliases(
+    for word: String, category: WordCategory, priority: AliasSuggestionPriority
+  ) async -> [String]? {
     calls.append(word)
+    priorities.append(priority)
     return aliasesByWord[word]
   }
 }
@@ -231,6 +237,21 @@ struct ContactsImportCoordinatorTests {
     await coord.awaitEnrichmentForTesting()
     #expect(cw.customWords.first { $0.canonical == "Rajesh" }?.aliases == ["rah jesh", "raj esh"])
     #expect(cw.customWords.first { $0.canonical == "Vasquez" }?.aliases == ["vaskez", "vah skez"])
+  }
+
+  @Test("Enrichment calls the shared suggester with background priority, never the default (#1701)")
+  func enrichmentUsesBackgroundPriority() async {
+    let provider = FakeContactProvider(
+      status: .authorized, candidates: [contact("Rajesh", "Vasquez", id: "c1")])
+    let fake = FakeAliasSuggester(
+      available: true, aliasesByWord: ["Rajesh": ["r"], "Vasquez": ["v"]])
+    let (coord, _, _, dir) = make(provider: provider, suggester: fake)
+    defer { cleanup(dir) }
+    await coord.prepareImport()
+    coord.confirmImport()
+    await coord.awaitEnrichmentForTesting()
+    #expect(fake.calls.count == 2)
+    #expect(fake.priorities == [.background, .background])
   }
 
   @Test("Enrichment clears its progress line on completion")

--- a/Tests/EnviousWisprTests/Core/CustomWordSchemaTests.swift
+++ b/Tests/EnviousWisprTests/Core/CustomWordSchemaTests.swift
@@ -87,4 +87,31 @@ struct CustomWordSchemaTests {
     #expect(word.frequencyUsed == 0)
     #expect(word.lastUsed == nil)
   }
+
+  @Test("Decode pre-#1701 JSON (no enrichmentPending) defaults to false")
+  func decodePreEnrichmentJSONDefaultsToFalse() throws {
+    let json = """
+      {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "canonical": "EnviousWispr",
+        "aliases": ["envious wispr"],
+        "category": "brand",
+        "priority": 0,
+        "forceReplace": false,
+        "caseSensitive": false
+      }
+      """.data(using: .utf8)!
+
+    let word = try JSONDecoder().decode(CustomWord.self, from: json)
+    #expect(word.enrichmentPending == false, "Missing enrichmentPending defaults to false")
+  }
+
+  @Test("Round-trip preserves enrichmentPending")
+  func roundTripPreservesEnrichmentPending() throws {
+    var original = CustomWord(canonical: "Qualtrics")
+    original.enrichmentPending = true
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(CustomWord.self, from: data)
+    #expect(decoded.enrichmentPending == true)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsBulkEnrichmentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsBulkEnrichmentTests.swift
@@ -1,0 +1,540 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1701 Chunk 2 — bulk-import-enrichment persistence: `commitImport`'s
+/// pending-flag/total bookkeeping, the repair self-heal, and the two
+/// checkpoint transactions (`applyEnrichmentResults` / `cancelEnrichment`).
+/// Every test drives a real manager against a temp file, matching
+/// `CustomWordsImportCommitTests`'s harness shape.
+@MainActor
+@Suite("CustomWordsManager — bulk-import enrichment")
+struct CustomWordsBulkEnrichmentTests {
+
+  // MARK: - Harness
+
+  private func makeManager() -> (CustomWordsManager, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-bulk-enrichment-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appendingPathComponent("custom-words.json")
+    return (CustomWordsManager(fileURL: url), url)
+  }
+
+  private func candidate(_ canonical: String) -> CustomWordsImportCandidate {
+    CustomWordsImportCandidate(canonical: canonical)
+  }
+
+  /// Seeds words directly (never through the import pipeline), matching
+  /// `CustomWordsImportCommitTests`'s harness shape.
+  private func seed(
+    _ manager: CustomWordsManager, _ words: [CustomWord]
+  ) throws -> [CustomWord] {
+    var live = manager.load() ?? []
+    _ = try manager.addBatch(words, to: &live)
+    return live
+  }
+
+  private func plan(
+    baseline: [CustomWord],
+    additions: [CustomWordsImportCandidate] = [],
+    replacements: [CustomWordsImportReplacement] = [],
+    enrichmentEligible: Bool = true
+  ) -> CustomWordsImportCommitPlan {
+    CustomWordsImportCommitPlan(
+      baseline: CustomWordsImportLibrarySnapshot(words: baseline),
+      additions: additions, replacements: replacements,
+      enrichmentEligible: enrichmentEligible)
+  }
+
+  // MARK: - commitImport: pending flags + total
+
+  @Test("an eligible addition is marked pending and sets the total")
+  func eligibleAdditionSetsFlagAndTotal() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    let receipt = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes"), candidate("Qualtrics")]),
+      to: &live)
+
+    let added = live.filter { $0.canonical == "Kubernetes" || $0.canonical == "Qualtrics" }
+    #expect(added.allSatisfy { $0.enrichmentPending })
+    #expect(receipt.pendingEnrichmentBatchTotal == 2)
+  }
+
+  @Test("an ineligible-batch addition is never marked pending and sets no total")
+  func ineligibleAdditionNeverSetsFlagOrTotal() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    let receipt = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")], enrichmentEligible: false),
+      to: &live)
+
+    let added = try #require(live.first { $0.canonical == "Kubernetes" })
+    #expect(added.enrichmentPending == false)
+    #expect(receipt.pendingEnrichmentBatchTotal == nil)
+  }
+
+  @Test("a Replace never enters the enrichment queue, even in an eligible batch")
+  func replaceNeverEntersQueue() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Qualtrics")]), to: &live)
+    var afterFirstCommit = live
+    // Clear the flag as if a drain had already run, isolating this test to
+    // the Replace path alone.
+    let target = try #require(afterFirstCommit.first { $0.canonical == "Qualtrics" })
+    _ = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: [])
+    ])
+    afterFirstCommit = try #require(manager.load())
+    live = afterFirstCommit
+
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        replacements: [
+          CustomWordsImportReplacement(existingID: target.id, candidate: candidate("Qualtrics XM"))
+        ]),
+      to: &live)
+
+    let replaced = try #require(live.first { $0.id == target.id })
+    #expect(replaced.enrichmentPending == false)
+    #expect(receipt.pendingEnrichmentBatchTotal == nil)
+  }
+
+  @Test("a second import mid-run extends the total, never resets it")
+  func secondImportMidRunExtendsTotal() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    let first = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    #expect(first.pendingEnrichmentBatchTotal == 1)
+
+    let second = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Qualtrics"), candidate("Anthropic")]),
+      to: &live)
+
+    // 1 (still pending from the first commit) + 2 (this commit) = 3, never
+    // reset to just this commit's own count.
+    #expect(second.pendingEnrichmentBatchTotal == 3)
+  }
+
+  @Test("a library with pending words but a nil total repairs once, to the live count")
+  func repairHealsANilTotalToTheLivePendingCount() throws {
+    let (manager, url) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes"), candidate("Qualtrics")]),
+      to: &live)
+
+    // Simulate a library that somehow lost its total (legacy file / partial
+    // rollback) while the pending flags themselves survived.
+    let raw = try Data(contentsOf: url)
+    var json = try #require(try JSONSerialization.jsonObject(with: raw) as? [String: Any])
+    json.removeValue(forKey: "pendingEnrichmentBatchTotal")
+    try JSONSerialization.data(withJSONObject: json).write(to: url, options: [.atomic])
+
+    let snapshot = try #require(manager.loadSnapshot())
+    #expect(snapshot.pendingEnrichmentBatchTotal == nil)
+
+    let repaired = try manager.repairPendingEnrichmentTotalIfNeeded()
+    #expect(repaired == 2)
+
+    // Idempotent: repairing again is a no-op that returns the same value.
+    let repairedAgain = try manager.repairPendingEnrichmentTotalIfNeeded()
+    #expect(repairedAgain == 2)
+  }
+
+  @Test("repair heals a total stuck non-nil when nothing is actually pending")
+  func repairHealsAStuckNonNilTotalToNil() throws {
+    // Codex Chunk 2 review finding 2b's other direction: before the fix,
+    // `repairPendingEnrichmentTotalIfNeeded`'s guard only ever fired when
+    // `livePendingCount > 0`, so a total stuck non-nil with zero actually
+    // pending (e.g. the last pending word was deleted) was never healed.
+    let (manager, url) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Kubernetes" })
+    try manager.remove(id: target.id, from: &live)
+
+    // Simulate the total surviving the delete stuck at its pre-delete value
+    // (as the pre-fix `applyEnrichmentResults` could leave it).
+    let raw = try Data(contentsOf: url)
+    var json = try #require(try JSONSerialization.jsonObject(with: raw) as? [String: Any])
+    json["pendingEnrichmentBatchTotal"] = 1
+    try JSONSerialization.data(withJSONObject: json).write(to: url, options: [.atomic])
+    #expect(try #require(manager.loadSnapshot()).pendingEnrichmentBatchTotal == 1)
+
+    let repaired = try manager.repairPendingEnrichmentTotalIfNeeded()
+    #expect(repaired == nil)
+    #expect(try #require(manager.loadSnapshot()).pendingEnrichmentBatchTotal == nil)
+  }
+
+  @Test(
+    "committing into an existing-pending-but-nil-total state bases the new total on the live count")
+  func commitIntoExistingPendingNilTotalStateBasesTotalOnLiveCount() throws {
+    // Codex Chunk 2 review finding 2a: before the fix, committing into this
+    // defensive nil-total state wrote a total covering only THIS commit's own
+    // new additions — which goes non-nil, so the repair path (only fires when
+    // the total IS nil) would never again correct the permanent undercount.
+    let (manager, url) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes"), candidate("Qualtrics")]),
+      to: &live)
+
+    let raw = try Data(contentsOf: url)
+    var json = try #require(try JSONSerialization.jsonObject(with: raw) as? [String: Any])
+    json.removeValue(forKey: "pendingEnrichmentBatchTotal")
+    try JSONSerialization.data(withJSONObject: json).write(to: url, options: [.atomic])
+    live = try #require(manager.load())
+
+    let receipt = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Anthropic")]), to: &live)
+
+    // 2 (already pending, total was nil) + 1 (this commit's own addition) = 3,
+    // never just 1 (this commit's own delta alone).
+    #expect(receipt.pendingEnrichmentBatchTotal == 3)
+  }
+
+  @Test("repair is a no-op when there is nothing pending")
+  func repairIsNoOpWithNothingPending() throws {
+    let (manager, _) = makeManager()
+    let repaired = try manager.repairPendingEnrichmentTotalIfNeeded()
+    #expect(repaired == nil)
+  }
+
+  // MARK: - applyEnrichmentResults
+
+  @Test("a checkpoint appends to the word's CURRENT aliases, not a stale caller snapshot")
+  func checkpointAppendsToCurrentAliasesNotCallerSnapshot() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Kubernetes" })
+
+    // A concurrent edit lands BETWEEN the model call finishing and the
+    // checkpoint arriving — simulated by mutating the word on disk directly,
+    // bypassing the caller's in-memory copy entirely.
+    var concurrentlyEdited = try #require(manager.load())
+    let idx = try #require(concurrentlyEdited.firstIndex { $0.id == target.id })
+    concurrentlyEdited[idx].aliases = ["hand-typed-alias"]
+    try manager.update(word: concurrentlyEdited[idx], in: &concurrentlyEdited)
+
+    // The checkpoint call still carries the ORIGINAL (now stale) view of the
+    // word implicitly — it only ever sends id + generatedAliases, never a
+    // snapshot — proving the manager reloads under lock rather than trusting
+    // anything the caller might have held.
+    let outcome = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: ["k8s"])
+    ])
+
+    let result = try #require(outcome.snapshot.words.first { $0.id == target.id })
+    #expect(result.aliases.contains("hand-typed-alias"), "the concurrent edit must survive")
+    #expect(result.aliases.contains("k8s"), "the checkpoint's own alias must also land")
+    #expect(result.enrichmentPending == false)
+    #expect(outcome.applied.first?.generatedAliases == ["k8s"])
+  }
+
+  @Test("applying the same result twice is a no-op the second time")
+  func reapplyingTheSameResultIsIdempotent() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Kubernetes" })
+
+    let result = CustomWordEnrichmentResult(id: target.id, generatedAliases: ["k8s"])
+    let first = try manager.applyEnrichmentResults([result])
+    #expect(try #require(first.snapshot.words.first { $0.id == target.id }).aliases == ["k8s"])
+    #expect(first.applied.first?.generatedAliases == ["k8s"])
+
+    let second = try manager.applyEnrichmentResults([result])
+    let word = try #require(second.snapshot.words.first { $0.id == target.id })
+    #expect(word.aliases == ["k8s"], "no duplicate alias from reapplying")
+    #expect(word.enrichmentPending == false)
+    #expect(second.applied.isEmpty, "the second pass applied nothing — already resolved")
+  }
+
+  @Test("a deleted word's ID is skipped, never resurrected")
+  func deletedIDIsSkippedNotResurrected() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Kubernetes" })
+
+    try manager.remove(id: target.id, from: &live)
+    let countBefore = try #require(manager.load()).count
+
+    let outcome = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: ["k8s"])
+    ])
+
+    #expect(outcome.snapshot.words.contains { $0.id == target.id } == false)
+    #expect(outcome.snapshot.words.count == countBefore)
+    #expect(outcome.applied.isEmpty)
+  }
+
+  @Test("two processes' results for the same word: first checkpoint wins, the late one no-ops")
+  func firstCheckpointWinsOverALateDuplicate() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Kubernetes" })
+
+    // Two independent "processes" both computed a result for the same word
+    // before either checkpointed.
+    let processA = CustomWordEnrichmentResult(id: target.id, generatedAliases: ["k8s"])
+    let processB = CustomWordEnrichmentResult(id: target.id, generatedAliases: ["kube"])
+
+    _ = try manager.applyEnrichmentResults([processA])
+    let afterLate = try manager.applyEnrichmentResults([processB])
+
+    let word = try #require(afterLate.snapshot.words.first { $0.id == target.id })
+    #expect(word.aliases == ["k8s"], "the first checkpoint's alias wins")
+    #expect(!word.aliases.contains("kube"), "the late duplicate must not also apply")
+    #expect(afterLate.applied.isEmpty, "the late duplicate applied nothing")
+  }
+
+  @Test("a late checkpoint arriving after Cancel is a no-op, never re-enriching")
+  func lateCheckpointAfterCancelIsNoOp() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Kubernetes" })
+
+    _ = try manager.cancelEnrichment()
+
+    let afterLateCheckpoint = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: ["k8s"])
+    ])
+
+    let word = try #require(afterLateCheckpoint.snapshot.words.first { $0.id == target.id })
+    #expect(word.enrichmentPending == false)
+    #expect(word.aliases.isEmpty, "a cancelled word must not be re-enriched by a late result")
+    #expect(afterLateCheckpoint.applied.isEmpty)
+  }
+
+  @Test("the total clears to nil once the live pending count reaches zero")
+  func totalClearsWhenPendingCountReachesZero() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes"), candidate("Qualtrics")]),
+      to: &live)
+    let words = live.filter { $0.canonical == "Kubernetes" || $0.canonical == "Qualtrics" }
+
+    let afterFirst = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: words[0].id, generatedAliases: [])
+    ])
+    #expect(afterFirst.snapshot.pendingEnrichmentBatchTotal == 2, "one word still pending")
+
+    let afterSecond = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: words[1].id, generatedAliases: [])
+    ])
+    #expect(afterSecond.snapshot.pendingEnrichmentBatchTotal == nil, "nothing left pending")
+  }
+
+  @Test("the total clears even when the batch's only result was a deleted word")
+  func totalClearsWhenTheOnlyResultReferencesADeletedWord() throws {
+    // Codex Chunk 2 review finding 2b: clearing used to be gated behind
+    // `changed`, so a checkpoint whose only result referenced an
+    // already-deleted word (contributing nothing itself) never reached the
+    // total-clearing check, even though the delete had already brought the
+    // live pending count to zero.
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Kubernetes" })
+
+    try manager.remove(id: target.id, from: &live)
+
+    let outcome = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: ["k8s"])
+    ])
+    #expect(outcome.snapshot.pendingEnrichmentBatchTotal == nil)
+  }
+
+  // MARK: - applyEnrichmentResults: alias-ownership authority (Codex Chunk 2
+  // review finding 3 — generated aliases must clear the SAME authority the
+  // import commit path already uses, never a second, weaker in-word-only check)
+
+  @Test("a generated alias colliding with another word's canonical is dropped, never persisted")
+  func generatedAliasCollidingWithAnotherCanonicalIsDropped() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Kubernetes")])
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Qualtrics")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Qualtrics" })
+
+    let outcome = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: ["kubernetes", "qualtrix"])
+    ])
+
+    let word = try #require(outcome.snapshot.words.first { $0.id == target.id })
+    #expect(word.aliases == ["qualtrix"], "the colliding generated alias must not persist")
+    #expect(outcome.applied.first?.generatedAliases == ["qualtrix"])
+  }
+
+  @Test("a generated alias colliding with an incumbent's human-authored alias is dropped (D17)")
+  func generatedAliasCollidingWithHumanAuthoredAliasIsDropped() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(manager, [CustomWord(canonical: "Anika", aliases: ["annie"])])
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Annabelle")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Annabelle" })
+
+    let outcome = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: ["Annie", "belle"])
+    ])
+
+    let word = try #require(outcome.snapshot.words.first { $0.id == target.id })
+    #expect(word.aliases == ["belle"], "the human-authored incumbent alias must win")
+    let incumbent = try #require(outcome.snapshot.words.first { $0.canonical == "Anika" })
+    #expect(incumbent.aliases == ["annie"], "the incumbent's own alias is untouched")
+  }
+
+  @Test(
+    "in the SAME checkpoint, one touched word's PRE-EXISTING alias never loses to another touched word's generated duplicate"
+  )
+  func sameCheckpointPreExistingAliasNeverLostToASiblingTouchedWordsGeneratedDuplicate() throws {
+    // Codex Chunk 2 review round 2 finding 1: reusing `enforceAliases`
+    // wholesale re-evaluated EVERY touched word's full alias list — including
+    // aliases that were already persisted before this checkpoint and were
+    // never part of its generated content — so word B's own pre-existing
+    // alias could lose to word A's newly generated duplicate purely because
+    // both happened to receive a checkpoint in the same batch. A comes FIRST
+    // in this batch specifically to reproduce the touched-order dependency
+    // the bug had.
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    // B is pending (enrichment-eligible) AND already carries a supplied
+    // alias — a real shape per D17's supersession: an eligible row can
+    // already carry a source alias and still be enrichment-eligible.
+    let receipt = try manager.commitImport(
+      plan(
+        baseline: live,
+        additions: [
+          candidate("Anthropic"),
+          CustomWordsImportCandidate(canonical: "Betty", aliases: .supplied(["shared"])),
+        ]),
+      to: &live)
+    #expect(receipt.pendingEnrichmentBatchTotal == 2)
+    let wordA = try #require(live.first { $0.canonical == "Anthropic" })
+    let wordB = try #require(live.first { $0.canonical == "Betty" })
+    #expect(wordB.aliases == ["shared"])
+
+    let outcome = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: wordA.id, generatedAliases: ["shared"]),
+      CustomWordEnrichmentResult(id: wordB.id, generatedAliases: ["betty-alt"]),
+    ])
+
+    let resultA = try #require(outcome.snapshot.words.first { $0.id == wordA.id })
+    let resultB = try #require(outcome.snapshot.words.first { $0.id == wordB.id })
+    #expect(resultA.aliases.isEmpty, "A's duplicate must be blocked — B already holds it")
+    #expect(
+      resultB.aliases == ["shared", "betty-alt"],
+      "B's pre-existing alias must survive, AND its own new generated alias must land")
+  }
+
+  @Test(
+    "a checkpoint with no generated aliases leaves every existing alias byte-for-byte unchanged")
+  func emptyResultsLeaveEveryExistingAliasUnchanged() throws {
+    let (manager, _) = makeManager()
+    var live = try seed(
+      manager,
+      [
+        CustomWord(canonical: "Anika", aliases: ["annie", "annika"]),
+        CustomWord(canonical: "Betty", aliases: ["bett", "elizabeth"]),
+      ])
+    _ = try manager.commitImport(plan(baseline: live, additions: [candidate("Charlie")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Charlie" })
+    let before = try #require(manager.load())
+
+    let outcome = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: [])
+    ])
+
+    for word in before {
+      let after = try #require(outcome.snapshot.words.first { $0.id == word.id })
+      #expect(
+        after.aliases == word.aliases, "\(word.canonical)'s aliases must be byte-for-byte unchanged"
+      )
+    }
+  }
+
+  @Test("a generated alias equal to the word's own canonical is silently dropped, not persisted")
+  func generatedAliasEqualToOwnCanonicalIsDropped() throws {
+    // Codex Chunk 2 review round 3 finding 1: `resolveAliasOwnership`
+    // excludes the target word itself from blocking, so without an explicit
+    // own-canonical check (mirroring `enforceAliases`'s own), a generated
+    // "Kubernetes" could land as a redundant alias on canonical "Kubernetes".
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Kubernetes" })
+
+    let outcome = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: ["kubernetes", "k8s"])
+    ])
+
+    let word = try #require(outcome.snapshot.words.first { $0.id == target.id })
+    #expect(word.aliases == ["k8s"], "the self-redundant alias must never persist")
+    #expect(outcome.applied.first?.generatedAliases == ["k8s"])
+  }
+
+  @Test("a clean generated alias with no collision still lands normally")
+  func nonCollidingGeneratedAliasStillLands() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+    let target = try #require(live.first { $0.canonical == "Kubernetes" })
+
+    let outcome = try manager.applyEnrichmentResults([
+      CustomWordEnrichmentResult(id: target.id, generatedAliases: ["k8s"])
+    ])
+
+    #expect(try #require(outcome.snapshot.words.first { $0.id == target.id }).aliases == ["k8s"])
+    #expect(outcome.applied.first?.generatedAliases == ["k8s"])
+  }
+
+  // MARK: - cancelEnrichment
+
+  @Test("Cancel sweeps every currently-pending word, not a caller's stale target list")
+  func cancelSweepsLiveStateNotAStaleCallerList() throws {
+    let (manager, _) = makeManager()
+    var live = manager.load() ?? []
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Kubernetes")]), to: &live)
+
+    // A caller whose in-memory idea of the target list is deliberately stale
+    // relative to the file: a SECOND import lands, extending the durable
+    // queue, without this caller ever observing it.
+    _ = try manager.commitImport(
+      plan(baseline: live, additions: [candidate("Qualtrics")]), to: &live)
+
+    let snapshot = try manager.cancelEnrichment()
+
+    #expect(snapshot.words.allSatisfy { $0.enrichmentPending == false })
+    #expect(snapshot.pendingEnrichmentBatchTotal == nil)
+  }
+
+  @Test("Cancel is a safe no-op when nothing is pending")
+  func cancelIsNoOpWithNothingPending() throws {
+    let (manager, _) = makeManager()
+    let snapshot = try manager.cancelEnrichment()
+    #expect(snapshot.pendingEnrichmentBatchTotal == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsManagerLockingTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsManagerLockingTests.swift
@@ -901,6 +901,13 @@ struct CustomWordsManagerLockingTests {
 
     let loadSlice = try functionBody(
       in: source, declaring: "public func load() -> [CustomWord]?")
+    // #1701 Chunk 2: the missing/loaded/unreadable/needsRepair cascade —
+    // including load()'s blocking repair path — moved out of load() into
+    // this shared helper, verbatim, so loadSnapshot() and
+    // loadPendingEnrichmentWords() can reuse the identical resolution
+    // without duplicating it. load() itself is now a thin two-line wrapper.
+    let resolveCurrentFileSlice = try functionBody(
+      in: source, declaring: "private func resolveCurrentFile() -> CustomWordsFile?")
     let transactionSlice = try functionBody(
       in: source, declaring: "private func performLockedTransaction<T>(")
     let loadFileWhileLockedSlice = try functionBody(
@@ -922,16 +929,20 @@ struct CustomWordsManagerLockingTests {
       source.components(separatedBy: "try withExclusiveFileLock").count - 1 == 2,
       "Expected exactly two `try withExclusiveFileLock` call sites in the whole file.")
     #expect(
-      loadSlice.contains("try withExclusiveFileLock"),
-      "load()'s repair path must call withExclusiveFileLock.")
+      resolveCurrentFileSlice.contains("try withExclusiveFileLock"),
+      "resolveCurrentFile()'s repair path must call withExclusiveFileLock.")
     #expect(
       transactionSlice.contains("try withExclusiveFileLock"),
       "performLockedTransaction must call withExclusiveFileLock.")
 
-    // 3. load()'s slice shape.
-    #expect(loadSlice.contains("loadFileReadOnly()"))
-    #expect(loadSlice.contains("withExclusiveFileLock(blocking: true)"))
-    #expect(loadSlice.contains("loadFileWhileLocked()"))
+    // 3. resolveCurrentFile()'s slice shape — load()'s own slice is now just
+    // a two-line wrapper delegating to it (#1701 Chunk 2).
+    #expect(resolveCurrentFileSlice.contains("loadFileReadOnly()"))
+    #expect(resolveCurrentFileSlice.contains("withExclusiveFileLock(blocking: true)"))
+    #expect(resolveCurrentFileSlice.contains("loadFileWhileLocked()"))
+    #expect(
+      loadSlice.contains("resolveCurrentFile()"),
+      "load() must delegate to resolveCurrentFile(), not inline the cascade.")
 
     // 4. performLockedTransaction's slice shape — the mutation loader and
     // its sole save call (already proven non-blocking by check 2 above).

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -60,6 +60,22 @@ struct CustomWordsTransferDocumentTests {
     #expect(!json.contains("source"))
   }
 
+  @Test("bulk-import-enrichment state never leaves this Mac (#1701 Chunk 2)")
+  func exportOmitsEnrichmentPersistenceFields() throws {
+    // A restored backup is not enrichment-eligible in the first place
+    // (`ExportedWordsFileParser.enrichmentEligible == false`), so this
+    // in-progress state would be meaningless on another Mac even if it did
+    // travel — `PortableCustomWord`'s explicit field whitelist keeps it out
+    // structurally, this freezes that so a future widening can't reopen it.
+    var pending = word("Kubernetes")
+    pending.enrichmentPending = true
+    let data = try CustomWordsTransferDocument(words: [pending]).encoded()
+    let json = try #require(String(data: data, encoding: .utf8))
+
+    #expect(!json.contains("enrichmentPending"))
+    #expect(!json.contains("pendingEnrichmentBatchTotal"))
+  }
+
   @Test("an empty word list is a valid backup, not an error")
   func emptyWordListIsAValidBackup() throws {
     let data = try CustomWordsTransferDocument(words: []).encoded()
@@ -188,11 +204,15 @@ struct CustomWordsTransferDocumentTests {
 
   @Test("re-tagging a built-in as user-owned preserves every other field")
   func ownedByUserPreservesEveryOtherField() {
-    let builtin = word(
+    var builtin = word(
       "GitHub", aliases: ["git hub"], category: .brand, priority: 2,
       forceReplace: true, caseSensitive: true, source: .builtin,
       frequencyUsed: 7, lastUsed: Date(timeIntervalSince1970: 5),
       minSimilarityOverride: 0.9)
+    // #1701 Chunk 2: a field added to `CustomWord` after this reconstruction
+    // method existed must be threaded through it explicitly, or a built-in
+    // override edited mid-enrichment would silently lose its pending flag.
+    builtin.enrichmentPending = true
     let owned = builtin.ownedByUser()
 
     #expect(owned.source == .user)
@@ -206,6 +226,7 @@ struct CustomWordsTransferDocumentTests {
     #expect(owned.frequencyUsed == builtin.frequencyUsed)
     #expect(owned.lastUsed == builtin.lastUsed)
     #expect(owned.minSimilarityOverride == builtin.minSimilarityOverride)
+    #expect(owned.enrichmentPending == true)
   }
 
   @Test("re-tagging an already-user word returns it unchanged")

--- a/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ImportFileParserTests.swift
@@ -52,6 +52,29 @@ struct ImportFileParserTests {
     #expect(candidate.minSimilarityOverride == .supplied(0.8))
   }
 
+  @Test("an exported words file is not eligible for background enrichment")
+  func exportedWordsFileIsNotEnrichmentEligible() async throws {
+    // #1701 Chunk 2: a backup restore is already as complete as it will get —
+    // re-enriching it would waste a model call on data that was never
+    // eligible in the first place.
+    let original = CustomWord(canonical: "Kubernetes", aliases: ["k8s"], category: .brand)
+    let data = try CustomWordsTransferDocument(words: [original]).encoded()
+    let url = try write(data, as: "words.json")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.enrichmentEligible == false)
+  }
+
+  @Test("a plain-text file IS eligible for background enrichment")
+  func plainTextFileIsEnrichmentEligible() async throws {
+    let url = try write("Kubernetes", as: "words.txt")
+
+    let batch = try await FileImportSource(url: url).loadCandidates()
+
+    #expect(batch.enrichmentEligible == true)
+  }
+
   @Test("a JSON file that isn't ours says so, rather than reading as damaged")
   func foreignJSONReportsItDidNotComeFromEnviousWispr() async throws {
     let url = try write(#"{"format":"com.example.other","version":1,"words":[]}"#, as: "other.json")
@@ -1127,6 +1150,23 @@ struct ImportFileParserTests {
     await #expect(throws: CustomWordsImportValidationError.self) {
       try await FileImportSource(url: url).loadCandidates()
     }
+  }
+
+  @Test("validated() preserves enrichmentEligible through reconstruction")
+  func validatedPreservesEnrichmentEligible() throws {
+    // #1701 Chunk 2 (Grounded Review round 2 — the actual bug the plan's
+    // first revision missed): validated() rebuilds the batch from scratch, so
+    // a field not explicitly threaded through silently reverts to its default.
+    let candidates = [CustomWordsImportCandidate(canonical: "Kubernetes")]
+    let ineligible = CustomWordsImportBatch(
+      sourceID: "exported-words", sourceDisplayName: "test", candidates: candidates,
+      enrichmentEligible: false)
+    #expect(try ineligible.validated().enrichmentEligible == false)
+
+    let eligible = CustomWordsImportBatch(
+      sourceID: "plain-text", sourceDisplayName: "test", candidates: candidates,
+      enrichmentEligible: true)
+    #expect(try eligible.validated().enrichmentEligible == true)
   }
 
 }

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -341,3 +341,362 @@ struct WordSuggestionServiceHeuristicClassifierTests {
     #expect(WordSuggestionService.classifyByHeuristic("   ") == nil)
   }
 }
+
+// MARK: - Permit queue test helpers (#1701)
+
+/// Deterministically waits for a waiter to actually register on the queue —
+/// polls real actor state via `Task.yield()`, bounded by a deadline-fallback
+/// `withThrowingTimeout` (`swift-patterns.md` RULE:
+/// tests-no-unconditional-continuation-await — an unbounded wait hangs CI on
+/// a genuine regression instead of failing; mirrors
+/// `LLMTelemetrySinkLiveTests`'s deadline-fallback shape, Grounded Review
+/// Chunk 1 finding).
+private func waitForWaiterCount(
+  _ queue: AliasSuggestionPermitQueue, toEqual expected: Int, timeoutSeconds: Double = 5
+) async throws {
+  try await withThrowingTimeout(seconds: timeoutSeconds) {
+    while await queue.waiterCountForTesting != expected {
+      try Task.checkCancellation()
+      await Task.yield()
+    }
+  }
+}
+
+/// Test-only rendezvous: `wait()` parks until `resume()` is called elsewhere.
+/// `waitUntilParked()` blocks until a concurrently-running `wait()` call has
+/// genuinely parked, giving tests a happens-before point to act from — e.g.
+/// cancelling a task only once it is provably suspended inside the hook
+/// under test, never racing real Swift Concurrency scheduling. Both are
+/// deadline-bounded (`withThrowingTimeout`, never an unconditional wait —
+/// same rule and finding as `waitForWaiterCount` above).
+private actor ResumeGate {
+  private(set) var parked = false
+  private var released = false
+
+  func markParked() { parked = true }
+  func resume() { released = true }
+
+  func wait(timeoutSeconds: Double = 5) async throws {
+    markParked()
+    try await withThrowingTimeout(seconds: timeoutSeconds) {
+      while await self.released == false {
+        try Task.checkCancellation()
+        await Task.yield()
+      }
+    }
+  }
+
+  func waitUntilParked(timeoutSeconds: Double = 5) async throws {
+    try await withThrowingTimeout(seconds: timeoutSeconds) {
+      while await self.parked == false {
+        try Task.checkCancellation()
+        await Task.yield()
+      }
+    }
+  }
+}
+
+/// Records call order from concurrent tasks without a data race.
+private actor OrderLog {
+  private(set) var entries: [String] = []
+  func record(_ entry: String) { entries.append(entry) }
+}
+
+/// Counts operation invocations without a data race.
+private actor CallCounter {
+  private(set) var count = 0
+  func increment() { count += 1 }
+}
+
+/// Pins the explicit permit queue behind `WordSuggestionService.suggest(for:)`
+/// and `.suggestAliases(for:category:)` (#1701). Swift actors are reentrant
+/// across a suspension point, so a naive "await inside an actor" would not
+/// actually serialize two concurrent callers — these tests exercise the
+/// actual continuation-based queue, not a simulation of it. Every test drives
+/// `AliasSuggestionPermitQueue` / `WordSuggestionService.withPermit` directly
+/// via `@testable import`: the public `suggest`/`suggestAliases` entry points
+/// gate on live FoundationModels/macOS 26 runtime availability, which is
+/// unavailable-or-unreliable in a test environment (this file has never
+/// exercised those two methods end-to-end, for the same reason — see the
+/// suites above, which only ever test the pure static helpers). The queue
+/// mechanics under test here are identical regardless of which entry point
+/// calls them.
+@Suite("WordSuggestionService — permit queue (#1701)")
+struct WordSuggestionServicePermitQueueTests {
+
+  @Test(
+    "An interactive arrival is granted the next permit ahead of already-queued background waiters")
+  func interactiveJumpsBackgroundQueue() async throws {
+    let queue = AliasSuggestionPermitQueue()
+    let holderGranted = await queue.acquire(id: UUID(), priority: .interactive)
+    #expect(holderGranted)
+
+    let bg1: Task<Bool, Never> = Task { await queue.acquire(id: UUID(), priority: .background) }
+    try await waitForWaiterCount(queue, toEqual: 1)
+    let bg2: Task<Bool, Never> = Task { await queue.acquire(id: UUID(), priority: .background) }
+    try await waitForWaiterCount(queue, toEqual: 2)
+    let interactive: Task<Bool, Never> = Task {
+      await queue.acquire(id: UUID(), priority: .interactive)
+    }
+    try await waitForWaiterCount(queue, toEqual: 3)
+
+    await queue.release()  // holder done — interactive must jump ahead of bg1/bg2
+    #expect(await interactive.value)
+    #expect(await queue.waiterCountForTesting == 2)  // bg1, bg2 still waiting
+
+    await queue.release()  // interactive done — bg1 (FIFO-first) granted next
+    #expect(await bg1.value)
+    #expect(await queue.waiterCountForTesting == 1)
+
+    await queue.release()  // bg1 done — bg2 granted last
+    #expect(await bg2.value)
+    #expect(await queue.waiterCountForTesting == 0)
+
+    await queue.release()  // bg2 done — no waiters remain
+  }
+
+  @Test("Two background requests are served FIFO")
+  func backgroundRequestsAreFIFO() async throws {
+    let queue = AliasSuggestionPermitQueue()
+    let holderGranted = await queue.acquire(id: UUID(), priority: .interactive)
+    #expect(holderGranted)
+
+    let first: Task<Bool, Never> = Task { await queue.acquire(id: UUID(), priority: .background) }
+    try await waitForWaiterCount(queue, toEqual: 1)
+    let second: Task<Bool, Never> = Task { await queue.acquire(id: UUID(), priority: .background) }
+    try await waitForWaiterCount(queue, toEqual: 2)
+
+    await queue.release()
+    #expect(await first.value)
+    #expect(await queue.waiterCountForTesting == 1)  // second must still be waiting
+
+    await queue.release()
+    #expect(await second.value)
+  }
+
+  @Test("A request cancelled while queued performs zero model operations")
+  func cancelledWhileQueuedNeverRunsOperation() async throws {
+    let queue = AliasSuggestionPermitQueue()
+    let holderGranted = await queue.acquire(id: UUID(), priority: .interactive)
+    #expect(holderGranted)
+
+    let waiting: Task<Bool, Never> = Task { await queue.acquire(id: UUID(), priority: .background) }
+    try await waitForWaiterCount(queue, toEqual: 1)
+
+    waiting.cancel()
+    #expect(await waiting.value == false)
+    #expect(await queue.waiterCountForTesting == 0)  // removed, not left dangling
+
+    await queue.release()  // holder done — nobody left to grant
+    #expect(await queue.waiterCountForTesting == 0)
+  }
+
+  @Test(
+    "release() skips a queued waiter whose latch is cancelled but not yet removed, granting the next live waiter directly — exactly-one continuation resumption throughout (Grounded Review Chunk 1 round 3 finding)"
+  )
+  func releaseSkipsLatchCancelledWaiterBeforeRemovalArrives() async throws {
+    let queue = AliasSuggestionPermitQueue()
+    let holderGranted = await queue.acquire(id: UUID(), priority: .interactive)
+    #expect(holderGranted)
+
+    let firstID = UUID()
+    let first: Task<Bool, Never> = Task { await queue.acquire(id: firstID, priority: .background) }
+    try await waitForWaiterCount(queue, toEqual: 1)
+    let second: Task<Bool, Never> = Task { await queue.acquire(id: UUID(), priority: .background) }
+    try await waitForWaiterCount(queue, toEqual: 2)
+
+    // Simulate the exact race release()'s doc comment describes: the latch
+    // is cancelled, but the async `cancelWaiting` removal message has NOT
+    // yet reached the actor — `first` is still physically present in
+    // `waiters` when release() runs below.
+    await queue.cancelLatchWithoutRemovingForTesting(id: firstID)
+
+    await queue.release()  // holder done — must skip the cancelled `first` and grant `second` directly
+    #expect(await second.value)
+    #expect(await first.value == false)
+    // release()'s skip-loop physically removed `first` too — nothing left
+    // for the (now redundant, since it already ran here) real cancellation
+    // path to find later; no double-resume, no leaked entry.
+    #expect(await queue.waiterCountForTesting == 0)
+  }
+
+  @Test(
+    "A request cancelled after grant but before inference starts performs zero model operations")
+  func cancelledInGapBetweenGrantAndInferencePerformsZeroModelCalls() async throws {
+    let service = WordSuggestionService()
+    let counter = CallCounter()
+    let gate = ResumeGate()
+
+    // Permit is free, so acquire() grants immediately; the operation is held
+    // at the gate right after grant, before it can run — the exact window
+    // this test proves is cancellation-safe.
+    let waiting: Task<Bool, Never> = Task {
+      await service.withPermit(
+        priority: .interactive,
+        whenNotGranted: false,
+        afterGrantForTesting: { try? await gate.wait() }
+      ) {
+        await counter.increment()
+        return true
+      }
+    }
+    try await gate.waitUntilParked()  // provably suspended right after grant, before the isCancelled check
+
+    waiting.cancel()
+    await gate.resume()
+
+    #expect(await waiting.value == false)
+    #expect(await counter.count == 0)
+  }
+
+  @Test("A higher-priority arrival never preempts the in-flight permit holder")
+  func inFlightHolderNeverPreempted() async throws {
+    let queue = AliasSuggestionPermitQueue()
+    let holderGranted = await queue.acquire(id: UUID(), priority: .background)
+    #expect(holderGranted)
+
+    let interactive: Task<Bool, Never> = Task {
+      await queue.acquire(id: UUID(), priority: .interactive)
+    }
+    try await waitForWaiterCount(queue, toEqual: 1)
+    // Nothing in the design can force the background holder to give up the
+    // permit early — the interactive arrival can only queue.
+    #expect(await queue.waiterCountForTesting == 1)
+
+    await queue.release()  // only the holder's own explicit release grants it
+    #expect(await interactive.value)
+  }
+
+  @Test("Both production entry points serialize through one shared permit")
+  func sharedPermitAcrossEntryPoints() async throws {
+    let service = WordSuggestionService()
+    let order = OrderLog()
+    let holdGate = ResumeGate()
+
+    let first: Task<Bool, Never> = Task {
+      await service.withPermit(priority: .interactive, whenNotGranted: false) {
+        try? await holdGate.wait()
+        await order.record("first")
+        return true
+      }
+    }
+    try await holdGate.waitUntilParked()  // `first` now holds the one permit
+
+    let second: Task<Bool, Never> = Task {
+      await service.withPermit(priority: .background, whenNotGranted: false) {
+        await order.record("second")
+        return true
+      }
+    }
+    // `second` genuinely had to queue behind `first` on `service.permitQueue`
+    // — proof they share the exact same instance, not independent permits.
+    try await waitForWaiterCount(service.permitQueue, toEqual: 1)
+
+    await holdGate.resume()
+    #expect(await first.value)
+    #expect(await second.value)
+    #expect(await order.entries == ["first", "second"])
+  }
+
+  #if DEBUG
+    // `rawSuggestionOverrideForTesting` is `#if DEBUG`-gated end to end
+    // (Grounded Review Chunk 1 round 2 finding) so the Release alias-eval
+    // harness's `benchmarkSuggest` measurements never gain an added actor
+    // hop; this test is gated the same way since it references that symbol.
+    @Test(
+      "benchmarkSuggest never touches the production permit queue, driven with a deterministic fake — no live model inference"
+    )
+    func benchmarkSuggestStaysOutsideQueue() async throws {
+      let service = WordSuggestionService()
+      // Deterministic fake, no live FoundationModels call — real Apple
+      // Intelligence eligibility is environment-dependent (Grounded Review
+      // Chunk 1 finding: the prior revision's assertion on the real model's
+      // output was flaky by construction — it happened to pass on this
+      // machine only because this machine has it enabled).
+      await service.rawSuggestionOverrideForTesting.set { word in
+        (category: .general, aliases: ["\(word)-alt-one", "\(word)-alt-two"])
+      }
+      let holdGate = ResumeGate()
+
+      let holder: Task<Bool, Never> = Task {
+        await service.withPermit(priority: .interactive, whenNotGranted: false) {
+          try? await holdGate.wait()
+          return true
+        }
+      }
+      try await holdGate.waitUntilParked()  // production permit held and stays held
+
+      // If `benchmarkSuggest` called `withPermit`/`permitQueue.acquire` like
+      // a production entry point would, this call would deadlock until
+      // `holdGate.resume()` below, which cannot run before this line does.
+      let record = await service.benchmarkSuggest(for: "gemini")
+      #expect(record.rawAliases == ["gemini-alt-one", "gemini-alt-two"])
+      #expect(record.errorDescription == nil)
+      #expect(record.timedOut == false)
+
+      await holdGate.resume()
+      #expect(await holder.value)
+    }
+  #endif
+
+  @Test(
+    "A request already cancelled before entering acquire() is granted no permit and leaves no queue state"
+  )
+  func cancelledBeforeRegistrationLeavesNoState() async throws {
+    // Creating a Task and immediately calling .cancel() does NOT prove the
+    // child hasn't started — it can run concurrently on another executor
+    // thread (Grounded Review Chunk 1 round 2 finding). A gate makes this
+    // deterministic instead: park BEFORE ever calling acquire(), cancel
+    // while provably parked, then resume — acquire() is entered already
+    // cancelled, which `withTaskCancellationHandler` guarantees invokes
+    // `onCancel` before `operation` ever runs.
+    let queue = AliasSuggestionPermitQueue()
+    let gate = ResumeGate()
+    let task: Task<Bool, Never> = Task {
+      try? await gate.wait()
+      return await queue.acquire(id: UUID(), priority: .interactive)
+    }
+    try await gate.waitUntilParked()
+    task.cancel()
+    await gate.resume()
+    #expect(await task.value == false)
+    #expect(await queue.waiterCountForTesting == 0)
+  }
+
+  @Test(
+    "Repeated grant-then-cancel-while-parked-after-grant leaves no residual actor state (Grounded Review Chunk 1 finding)"
+  )
+  func repeatedGrantThenCancelInGapLeavesNoResidue() async throws {
+    // Reproduces the exact shape of the leak Grounded Review found: a
+    // request is granted immediately (permit free) and is THEN cancelled
+    // while still parked in the post-grant hook, before its operation ever
+    // runs — a real, repeatedly reachable path via Add-term's debounced
+    // `.task(id:)` restarting on every keystroke. Cancelling only after the
+    // task has already completed (the round-1 version of this test) proves
+    // nothing: a completed task's cancellation handler is no longer active.
+    // The `CancellationLatch` redesign scopes the cancellation signal to the
+    // call stack instead of an actor-owned Set, so nothing should
+    // accumulate across repeated cycles of this real shape.
+    let service = WordSuggestionService()
+    for _ in 0..<50 {
+      let counter = CallCounter()
+      let gate = ResumeGate()
+      let waiting: Task<Bool, Never> = Task {
+        await service.withPermit(
+          priority: .interactive,
+          whenNotGranted: false,
+          afterGrantForTesting: { try? await gate.wait() }
+        ) {
+          await counter.increment()
+          return true
+        }
+      }
+      try await gate.waitUntilParked()  // permit granted; parked before the isCancelled check
+      waiting.cancel()
+      await gate.resume()
+      #expect(await waiting.value == false)
+      #expect(await counter.count == 0)
+      #expect(await service.permitQueue.waiterCountForTesting == 0)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -567,6 +567,42 @@ struct WordSuggestionServicePermitQueueTests {
     #expect(await interactive.value)
   }
 
+  @Test(
+    "A bulk-import (.background) arrival cannot preempt an in-flight Add-term (.interactive) request"
+  )
+  func bulkImportNeverPreemptsAddTerm() async throws {
+    // The exact cross-producer acceptance test named in the plan (issue-1701
+    // §6, `BulkImportEnrichmentCoordinator` row): `.background` stands in for
+    // bulk import's real priority, `.interactive` for `CustomWordEditSheet`'s
+    // real Add-term priority, driven through the SAME shared
+    // `WordSuggestionService` instance both production callers actually use
+    // — composing `inFlightHolderNeverPreempted` and
+    // `sharedPermitAcrossEntryPoints` with the real producer framing, which
+    // neither proves alone.
+    let service = WordSuggestionService()
+    let holdGate = ResumeGate()
+
+    let addTerm: Task<Bool, Never> = Task {
+      await service.withPermit(priority: .interactive, whenNotGranted: false) {
+        try? await holdGate.wait()
+        return true
+      }
+    }
+    try await holdGate.waitUntilParked()  // Add-term now holds the one permit
+
+    let bulk: Task<Bool, Never> = Task {
+      await service.withPermit(priority: .background, whenNotGranted: false) { true }
+    }
+    try await waitForWaiterCount(service.permitQueue, toEqual: 1)
+    // Nothing can force the in-flight Add-term holder to give up the permit
+    // early — a bulk arrival can only queue, never interrupt.
+    #expect(await service.permitQueue.waiterCountForTesting == 1)
+
+    await holdGate.resume()
+    #expect(await addTerm.value)  // Add-term finished normally, never interrupted
+    #expect(await bulk.value)  // bulk granted only after Add-term released
+  }
+
   @Test("Both production entry points serialize through one shared permit")
   func sharedPermitAcrossEntryPoints() async throws {
     let service = WordSuggestionService()

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -408,6 +408,35 @@ private actor CallCounter {
   func increment() { count += 1 }
 }
 
+/// Simulates a FoundationModels call that ignores cancellation entirely
+/// (Phase 3 review finding A, #1701): `waitIgnoringCancellation()` never
+/// calls `Task.checkCancellation()`, unlike every other gate in this file —
+/// that is the whole point, since a genuinely cooperating wait would not
+/// reproduce the hang `withDeadline` exists to survive.
+private actor NonCooperativeGate {
+  private(set) var parked = false
+  private var released = false
+
+  func markParked() { parked = true }
+  func release() { released = true }
+
+  func waitIgnoringCancellation() async {
+    markParked()
+    while !released {
+      await Task.yield()
+    }
+  }
+
+  func waitUntilParked(timeoutSeconds: Double = 5) async throws {
+    try await withThrowingTimeout(seconds: timeoutSeconds) {
+      while await self.parked == false {
+        try Task.checkCancellation()
+        await Task.yield()
+      }
+    }
+  }
+}
+
 /// Pins the explicit permit queue behind `WordSuggestionService.suggest(for:)`
 /// and `.suggestAliases(for:category:)` (#1701). Swift actors are reentrant
 /// across a suspension point, so a naive "await inside an actor" would not
@@ -534,6 +563,7 @@ struct WordSuggestionServicePermitQueueTests {
       await service.withPermit(
         priority: .interactive,
         whenNotGranted: false,
+        deadlineSeconds: 30,
         afterGrantForTesting: { try? await gate.wait() }
       ) {
         await counter.increment()
@@ -583,7 +613,7 @@ struct WordSuggestionServicePermitQueueTests {
     let holdGate = ResumeGate()
 
     let addTerm: Task<Bool, Never> = Task {
-      await service.withPermit(priority: .interactive, whenNotGranted: false) {
+      await service.withPermit(priority: .interactive, whenNotGranted: false, deadlineSeconds: 30) {
         try? await holdGate.wait()
         return true
       }
@@ -591,7 +621,9 @@ struct WordSuggestionServicePermitQueueTests {
     try await holdGate.waitUntilParked()  // Add-term now holds the one permit
 
     let bulk: Task<Bool, Never> = Task {
-      await service.withPermit(priority: .background, whenNotGranted: false) { true }
+      await service.withPermit(priority: .background, whenNotGranted: false, deadlineSeconds: 30) {
+        true
+      }
     }
     try await waitForWaiterCount(service.permitQueue, toEqual: 1)
     // Nothing can force the in-flight Add-term holder to give up the permit
@@ -610,7 +642,7 @@ struct WordSuggestionServicePermitQueueTests {
     let holdGate = ResumeGate()
 
     let first: Task<Bool, Never> = Task {
-      await service.withPermit(priority: .interactive, whenNotGranted: false) {
+      await service.withPermit(priority: .interactive, whenNotGranted: false, deadlineSeconds: 30) {
         try? await holdGate.wait()
         await order.record("first")
         return true
@@ -619,7 +651,7 @@ struct WordSuggestionServicePermitQueueTests {
     try await holdGate.waitUntilParked()  // `first` now holds the one permit
 
     let second: Task<Bool, Never> = Task {
-      await service.withPermit(priority: .background, whenNotGranted: false) {
+      await service.withPermit(priority: .background, whenNotGranted: false, deadlineSeconds: 30) {
         await order.record("second")
         return true
       }
@@ -655,7 +687,8 @@ struct WordSuggestionServicePermitQueueTests {
       let holdGate = ResumeGate()
 
       let holder: Task<Bool, Never> = Task {
-        await service.withPermit(priority: .interactive, whenNotGranted: false) {
+        await service.withPermit(priority: .interactive, whenNotGranted: false, deadlineSeconds: 30)
+        {
           try? await holdGate.wait()
           return true
         }
@@ -721,6 +754,7 @@ struct WordSuggestionServicePermitQueueTests {
         await service.withPermit(
           priority: .interactive,
           whenNotGranted: false,
+          deadlineSeconds: 30,
           afterGrantForTesting: { try? await gate.wait() }
         ) {
           await counter.increment()
@@ -734,5 +768,43 @@ struct WordSuggestionServicePermitQueueTests {
       #expect(await counter.count == 0)
       #expect(await service.permitQueue.waiterCountForTesting == 0)
     }
+  }
+
+  @Test(
+    "a model call that ignores cancellation cannot strand the permit past its deadline (Phase 3 review finding A)"
+  )
+  func nonCooperatingOperationDoesNotStrandThePermit() async throws {
+    let service = WordSuggestionService()
+    let gate = NonCooperativeGate()
+
+    let first: Task<Bool, Never> = Task {
+      await service.withPermit(
+        priority: .interactive, whenNotGranted: false, deadlineSeconds: 0.05
+      ) {
+        await gate.waitIgnoringCancellation()
+        return true
+      }
+    }
+    try await gate.waitUntilParked()  // first operation genuinely started, ignoring cancellation
+
+    let second: Task<Bool, Never> = Task {
+      await service.withPermit(priority: .interactive, whenNotGranted: false, deadlineSeconds: 30) {
+        true
+      }
+    }
+    try await waitForWaiterCount(service.permitQueue, toEqual: 1)  // genuinely queued behind first
+
+    // The key assertion is not elapsed-time precision — it is that the
+    // second operation is granted and completes while the first is STILL
+    // physically running (its gate is still closed here), proving the
+    // logical permit was released at the deadline despite the
+    // non-cooperating first caller.
+    let secondResult = try await withThrowingTimeout(seconds: 5) { await second.value }
+    #expect(secondResult, "the second request must be granted despite the first still running")
+
+    let firstResult = await first.value
+    #expect(firstResult == false, "the abandoned first caller receives whenNotGranted")
+
+    await gate.release()  // clean teardown of the still-running abandoned operation
   }
 }

--- a/Tests/EnviousWisprTests/Views/CustomWordEditSheetTests.swift
+++ b/Tests/EnviousWisprTests/Views/CustomWordEditSheetTests.swift
@@ -1,0 +1,151 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPostProcessing
+
+/// Characterizes `CustomWordSuggestionFlow` — the piece of
+/// `CustomWordEditSheet`'s Add-term/Edit-word suggestion flow this PR's
+/// migration actually touches (#1701 Grounded Review Chunk 1). The founder
+/// authorized extracting this piece into a directly testable unit after the
+/// reviewer stopped the build for skipping the plan's required Add-term
+/// characterization test; the surrounding debounce and loading-indicator
+/// choreography stays inline in the view, unchanged, and is covered by
+/// Live UAT instead (not unit-testable — no established pattern in this
+/// codebase for driving a SwiftUI `.task(id:)` body directly).
+///
+/// `fetch`'s `suggest` is injected as a plain closure — deterministic, no
+/// live FoundationModels call — while the production call site in
+/// `CustomWordEditSheet.swift` is what pins the actual `priority: .interactive`
+/// argument (grep-verified in the Chunk 1 receipt); the dedicated permit-queue
+/// suite (`WordSuggestionServiceTests.swift`) separately proves `.interactive`
+/// is served ahead of `.background`.
+///
+/// `@testable import EnviousWisprPostProcessing` (not a widened public API,
+/// Grounded Review Chunk 1 round 2 finding) is what makes `WordSuggestions`'s
+/// existing internal memberwise initializer reachable here, matching the
+/// established pattern in `ContactsImportCoordinatorTests.swift`.
+@MainActor
+@Suite("CustomWordSuggestionFlow — Add-term suggestion fetch/apply (#1701 characterization)")
+struct CustomWordSuggestionFlowTests {
+
+  @Test("apply: fills suggested aliases and category when both are still empty/general")
+  func applyFillsWhenEmpty() {
+    let outcome = CustomWordSuggestionFlow.apply(
+      suggestions: WordSuggestions(category: .person, suggestedAliases: ["Sourabh", "Sorab"]),
+      currentAliases: [],
+      currentCategory: .general)
+    #expect(outcome.aliases == ["Sourabh", "Sorab"])
+    #expect(outcome.category == .person)
+    #expect(outcome.suggestionsApplied == true)
+    #expect(outcome.noSuggestionsAvailable == false)
+  }
+
+  @Test("apply: never overwrites aliases or a category the word already carries")
+  func applyNeverOverwritesExisting() {
+    let outcome = CustomWordSuggestionFlow.apply(
+      suggestions: WordSuggestions(category: .person, suggestedAliases: ["would-overwrite"]),
+      currentAliases: ["already-here"],
+      currentCategory: .brand)
+    // suggestionsApplied still flips true (a suggestion WAS returned and
+    // consulted) even though nothing was actually overwritten — matches the
+    // original body's unconditional `suggestionsApplied = true` inside the
+    // `if let suggestions` branch.
+    #expect(outcome.aliases == ["already-here"])
+    #expect(outcome.category == .brand)
+    #expect(outcome.suggestionsApplied == true)
+  }
+
+  @Test("apply: nil suggestions sets noSuggestionsAvailable, leaves aliases/category untouched")
+  func applyNilSuggestionsSetsFlag() {
+    let outcome = CustomWordSuggestionFlow.apply(
+      suggestions: nil, currentAliases: [], currentCategory: .general)
+    #expect(outcome.aliases == [])
+    #expect(outcome.category == .general)
+    #expect(outcome.suggestionsApplied == false)
+    #expect(outcome.noSuggestionsAvailable == true)
+  }
+
+  @Test(
+    "A newer edit made while suggestion fetching is in flight wins — apply is called with live state, never a pre-fetch snapshot (#1701 Grounded Review Chunk 1 round 2 finding)"
+  )
+  func liveEditDuringFetchWinsOverFetchedSuggestion() async throws {
+    let gate = FlowTestGate()
+    let fetchTask: Task<CustomWordSuggestionFlow.FetchResult, Never> = Task {
+      await CustomWordSuggestionFlow.fetch(
+        canonical: "Saurabh",
+        suggest: { _ in
+          try? await gate.wait()
+          return WordSuggestions(category: .person, suggestedAliases: ["Sourabh"])
+        })
+    }
+    try await gate.waitUntilParked()  // provably mid-fetch, suggestion not yet returned
+    // Simulate the user manually typing an alias WHILE the fetch is parked —
+    // `fetch` never captured `word.aliases`, so there is nothing stale for it
+    // to hand back; the view reads this live value itself, after the await.
+    let liveAliasesAfterUserEdit = ["hand-typed"]
+    await gate.resume()
+
+    guard case .completed(let suggestions) = await fetchTask.value else {
+      Issue.record("expected .completed")
+      return
+    }
+    let outcome = CustomWordSuggestionFlow.apply(
+      suggestions: suggestions,
+      currentAliases: liveAliasesAfterUserEdit,
+      currentCategory: .general)
+    #expect(outcome.aliases == ["hand-typed"])
+    #expect(outcome.suggestionsApplied == true)
+  }
+
+  @Test(
+    "fetch: a cancelled calling task reports .cancelled, matching the original's post-await guard")
+  func fetchReportsCancelledOnCancellation() async throws {
+    let gate = FlowTestGate()
+    let task: Task<CustomWordSuggestionFlow.FetchResult, Never> = Task {
+      await CustomWordSuggestionFlow.fetch(
+        canonical: "x",
+        suggest: { _ in
+          try? await gate.wait()
+          return WordSuggestions(category: .person, suggestedAliases: ["y"])
+        })
+    }
+    try await gate.waitUntilParked()
+    task.cancel()
+    await gate.resume()
+    if case .cancelled = await task.value {
+    } else {
+      Issue.record("expected .cancelled")
+    }
+  }
+}
+
+/// Minimal deadline-bounded rendezvous, local to this file (mirrors
+/// `WordSuggestionServiceTests.ResumeGate`; not shared cross-file since both
+/// are small, private test-only helpers — `swift-patterns.md` RULE:
+/// tests-no-unconditional-continuation-await).
+private actor FlowTestGate {
+  private(set) var parked = false
+  private var released = false
+
+  func wait(timeoutSeconds: Double = 5) async throws {
+    parked = true
+    try await withThrowingTimeout(seconds: timeoutSeconds) {
+      while await self.released == false {
+        try Task.checkCancellation()
+        await Task.yield()
+      }
+    }
+  }
+
+  func waitUntilParked(timeoutSeconds: Double = 5) async throws {
+    try await withThrowingTimeout(seconds: timeoutSeconds) {
+      while await self.parked == false {
+        try Task.checkCancellation()
+        await Task.yield()
+      }
+    }
+  }
+
+  func resume() { released = true }
+}


### PR DESCRIPTION
## Summary
- Bulk-imported and uncategorized Custom Words now get background AI-suggested aliases (sound-alike spellings), the same enrichment Contacts import already gets, so dictation recognizes them without a separate manual pass per word.
- A shared priority queue serializes alias-suggestion calls across Add Term, Contacts import, and bulk import so a burst of bulk-imported words never starves the interactive Add Term flow.
- Uncategorized bulk-imported words are classified before suggestion instead of force-fed a mismatched prompt; transient lock contention retries with the same backoff schedule the model-manifest fetcher already uses.
- A hung model call can no longer strand the shared permit queue forever; a fast-finishing enrichment pass correctly replaces a still-pending "Importing..." pill with "Finished" instead of silently dropping it.

## Test plan
- [x] Full logic test suite (Debug), including new coordinator/permit-queue/overlay-panel tests
- [x] Codex Grounded Review → PROCEED-AS-PLANNED; chunk build-orchestration → CHUNK-CLEAN; plan-completion/integration audit → PLAN-CLEAN
- [x] Phase 3 fresh independent full-diff Codex review → clean (4 rounds, no actionable defects on the final pass)
- [x] Live UAT on rebuilt dev app: navigated Settings → Your Words → Preview import → pasted words → confirmed import; observed the "Importing your words now" pill; log-confirmed `completed: succeeded=2 nothingUseful=0 timedOutOrUnavailable=1 processedThisSession=3`; verified aliases persisted correctly for imported words

## Note
Live UAT also surfaced a pre-existing bug (predates this PR, in the shared alias-response parser, not specific to bulk import) where a model response wrapped in markdown code-fence lines can leak literal fence text into a saved alias list. Founder decision: ship this PR as-is, tracked separately as a fast-follow: #1763.
