### PR TITLE
fix(user): drop markdown code-fence lines from AI word-alias suggestions (#1763)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -608,26 +608,42 @@ public final class WordSuggestionService: Sendable {
     let fenceRegex = try? NSRegularExpression(
       pattern: #"^(?:`{3,}|~{3,}).*$"#
     )
+    // List/blockquote container markers: all three CommonMark bullet
+    // characters (-, *, +), ordered markers, and blockquote '>'. Compiled
+    // once per call, applied repeatedly below (they nest arbitrarily, e.g.
+    // "- > text" or "\"- text\"", so a single fixed-order pass of
+    // bracket/list/quote stripping can leave an inner wrapper behind —
+    // GitHub cloud review, PR #1765 r2/r3). Ordered/bullet markers require
+    // trailing whitespace or end-of-line so the fixed-point loop below
+    // cannot repeatedly eat real content like "+44" or "--alias" one
+    // character at a time (Codex final sweep, PR #1765 r4) — blockquote
+    // '>' keeps optional whitespace since CommonMark permits ">text".
+    let listPrefixRegex = try? NSRegularExpression(
+      pattern: #"^(?:\d+[.)](?:\s+|$)|[-*•+](?:\s+|$)|>\s*)"#
+    )
     for line in raw.components(separatedBy: .newlines) {
       var s = line.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
-      s = s.trimmingCharacters(in: CharacterSet(charactersIn: "[]()"))
-      s = s.trimmingCharacters(in: .whitespacesAndNewlines)
-      if s.isEmpty { continue }
-      if let regex = try? NSRegularExpression(
-        pattern: #"^(?:\d+[.)]\s*|[-*•]\s*)"#
-      ) {
-        let range = NSRange(s.startIndex..., in: s)
-        s = regex.stringByReplacingMatches(in: s, range: range, withTemplate: "")
+      // Strip brackets, quotes, and list/blockquote markers to a fixed
+      // point — any interleaving or nesting of these wrapper types (a
+      // quoted bullet, a bulleted blockquote, brackets around a numbered
+      // line) converges to the real inner content, not just one layer of it.
+      var previous = ""
+      while previous != s {
+        previous = s
+        s = s.trimmingCharacters(in: CharacterSet(charactersIn: "[]()"))
+        s = s.trimmingCharacters(
+          in: CharacterSet(charactersIn: "\"'\u{201C}\u{201D}\u{2018}\u{2019},."))
+        if let listPrefixRegex {
+          let range = NSRange(s.startIndex..., in: s)
+          s = listPrefixRegex.stringByReplacingMatches(in: s, range: range, withTemplate: "")
+        }
+        s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       }
-      s = s.trimmingCharacters(
-        in: CharacterSet(charactersIn: "\"'\u{201C}\u{201D}\u{2018}\u{2019},."))
-      s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
-      // Re-check for a fence AFTER list-marker/quote/bracket stripping —
-      // a numbered/bulleted/quoted fence line (e.g. "1. ```plaintext") does
-      // not match the bare-fence pattern until its wrapper is removed
-      // (GitHub cloud review, PR #1765).
+      // Fence check runs AFTER wrapper convergence — a wrapped fence line
+      // (numbered, bulleted, quoted, blockquoted, or any nesting of those)
+      // does not match the bare-fence pattern until every wrapper is gone.
       if let fenceRegex,
         fenceRegex.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) != nil
       {

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -617,35 +617,47 @@ public final class WordSuggestionService: Sendable {
     // whitespace or end-of-line so the fixed-point loop below cannot
     // repeatedly eat real content like "+44" or "--alias" one character at
     // a time (Codex final sweep, PR #1765 r4). Ordered markers instead
-    // require the following char be NOT a digit (rather than requiring
-    // whitespace outright) — AFM sometimes emits a compact numbered item
-    // with no space ("1.kuber netties"), which must still strip, while a
-    // decimal/version-shaped alias ("1.2") must not have its leading
-    // "1." mistaken for a marker (GitHub cloud review, PR #1765 r5).
-    // Blockquote '>' keeps optional whitespace since CommonMark permits
-    // ">text".
+    // require the following char be NOT a digit — AFM sometimes emits a
+    // compact numbered item with no space ("1.kuber netties"), which must
+    // still strip, while a decimal/version-shaped alias ("1.2") must not
+    // have its leading "1." mistaken for a marker; `(?!\d)` also succeeds
+    // at end-of-line, covering a marker-only line ("1.") with no separate
+    // alternative needed (GitHub cloud review, PR #1765 r5/r6). Blockquote
+    // '>' keeps optional whitespace since CommonMark permits ">text".
     let listPrefixRegex = try? NSRegularExpression(
-      pattern: #"^(?:\d+[.)](?:\s+|$|(?![0-9]))|[-*•+](?:\s+|$)|>\s*)"#
+      pattern: #"^(?:\d+[.)](?!\d)|[-*•+](?:\s+|$)|>\s*)"#
     )
     for line in raw.components(separatedBy: .newlines) {
       var s = line.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
-      // Strip brackets, quotes, and list/blockquote markers to a fixed
+      // Strip list/blockquote markers, brackets, and quotes to a fixed
       // point — any interleaving or nesting of these wrapper types (a
       // quoted bullet, a bulleted blockquote, brackets around a numbered
-      // line) converges to the real inner content, not just one layer of it.
+      // line) converges to the real inner content, not just one layer of
+      // it. List-marker stripping runs FIRST in each pass, before comma/
+      // period trimming ever gets a chance to eat a marker's own "."/")"
+      // out from under it and leave an orphaned digit behind (GitHub cloud
+      // review, PR #1765 r6) — comma/period trimming is deliberately
+      // deferred to a single pass after the loop converges, below.
       var previous = ""
       while previous != s {
         previous = s
-        s = s.trimmingCharacters(in: CharacterSet(charactersIn: "[]()"))
-        s = s.trimmingCharacters(
-          in: CharacterSet(charactersIn: "\"'\u{201C}\u{201D}\u{2018}\u{2019},."))
         if let listPrefixRegex {
           let range = NSRange(s.startIndex..., in: s)
           s = listPrefixRegex.stringByReplacingMatches(in: s, range: range, withTemplate: "")
         }
+        s = s.trimmingCharacters(in: CharacterSet(charactersIn: "[]()"))
+        s = s.trimmingCharacters(
+          in: CharacterSet(charactersIn: "\"'\u{201C}\u{201D}\u{2018}\u{2019}"))
         s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       }
+      if s.isEmpty { continue }
+      // Comma/period trimming runs ONCE, after convergence, not inside the
+      // loop — combining it with quote trimming let it strip a marker's own
+      // "." out from under the list-marker regex before that regex ever saw
+      // the whole marker (GitHub cloud review, PR #1765 r6).
+      s = s.trimmingCharacters(in: CharacterSet(charactersIn: ",."))
+      s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
       // Fence check runs AFTER wrapper convergence — a wrapped fence line
       // (numbered, bulleted, quoted, blockquoted, or any nesting of those)

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -701,18 +701,22 @@ public final class WordSuggestionService: Sendable {
     return aliases
   }
 
-  /// Removes at most one matching character from the front and one from
-  /// the back — deliberately NOT `trimmingCharacters(in:)`, which removes
-  /// an entire consecutive run and can consume a wrapper character together
-  /// with an unrelated adjacent delimiter (e.g. a list marker's own "."/")")
-  /// in a single call. Used by `parsePlainStringAliases`'s convergence loop
-  /// so every removal gets re-evaluated by the marker regex on the next
-  /// pass, rather than several edge characters vanishing at once (#1763).
+  /// Removes AT MOST ONE matching character total — from the front if it
+  /// matches, else from the back if it matches, never both in one call.
+  /// Deliberately NOT `trimmingCharacters(in:)`, which removes an entire
+  /// consecutive run, and deliberately not "one from each edge" either —
+  /// either of those can consume a wrapper character on one edge together
+  /// with an unrelated list marker's own delimiter sitting on the OTHER
+  /// edge in a single call (e.g. ",1." or "[1)"), before the marker regex
+  /// gets another look. Used by `parsePlainStringAliases`'s convergence
+  /// loop, which already stops and restarts from the marker check after
+  /// ANY single-character change (#1763).
   private static func peelOneEdgeCharacter(_ s: String, in set: CharacterSet) -> String {
     guard !s.isEmpty else { return s }
     var s = s
     if let first = s.unicodeScalars.first, set.contains(first) {
       s.removeFirst()
+      return s
     }
     if let last = s.unicodeScalars.last, set.contains(last) {
       s.removeLast()

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -601,10 +601,12 @@ public final class WordSuggestionService: Sendable {
       "asr", "i have ", "i did not", "no mistranscript", "no aliases",
       "return empty", "explanation",
     ]
-    // A line that is purely a fence delimiter (optional language tag), not
-    // real content that merely contains backticks. Compiled once per call.
+    // A line that starts with 3+ of the same fence character (backtick or
+    // tilde, the two CommonMark fence delimiters) — a real alias never
+    // starts this way, so the rest of the line (any info string, or none)
+    // is accepted rather than allowlisted. Compiled once per call.
     let fenceRegex = try? NSRegularExpression(
-      pattern: #"^`{3,}[ \t]*[A-Za-z0-9_+./#-]*[ \t]*$"#
+      pattern: #"^(?:`{3,}|~{3,}).*$"#
     )
     for line in raw.components(separatedBy: .newlines) {
       var s = line.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -630,15 +630,19 @@ public final class WordSuggestionService: Sendable {
     for line in raw.components(separatedBy: .newlines) {
       var s = line.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
-      // Strip list/blockquote markers, brackets, and quotes to a fixed
-      // point — any interleaving or nesting of these wrapper types (a
-      // quoted bullet, a bulleted blockquote, brackets around a numbered
-      // line) converges to the real inner content, not just one layer of
-      // it. List-marker stripping runs FIRST in each pass, before comma/
-      // period trimming ever gets a chance to eat a marker's own "."/")"
-      // out from under it and leave an orphaned digit behind (GitHub cloud
-      // review, PR #1765 r6) — comma/period trimming is deliberately
-      // deferred to a single pass after the loop converges, below.
+      // Strip list/blockquote markers, brackets, quotes, and trailing
+      // comma/period to a fixed point — any interleaving or nesting of
+      // these wrapper types converges to the real inner content, not just
+      // one layer of it. A comma sitting outside a closing quote (AFM's
+      // JSON-array-style output, `"word",`) blocks that quote from the
+      // string's true edge until the comma is removed — removing
+      // comma/period only ONCE, outside the loop, left that exposed quote
+      // permanently stuck on the end (GitHub cloud review, PR #1765 r7).
+      // List-marker stripping still runs FIRST in each pass, before
+      // comma/period trimming gets a chance to eat a marker's own "."/")"
+      // out from under it and leave an orphaned digit behind (r6) — moving
+      // comma/period back into the loop does not reopen that: the marker
+      // regex always sees the untouched line at the start of every pass.
       var previous = ""
       while previous != s {
         previous = s
@@ -649,15 +653,9 @@ public final class WordSuggestionService: Sendable {
         s = s.trimmingCharacters(in: CharacterSet(charactersIn: "[]()"))
         s = s.trimmingCharacters(
           in: CharacterSet(charactersIn: "\"'\u{201C}\u{201D}\u{2018}\u{2019}"))
+        s = s.trimmingCharacters(in: CharacterSet(charactersIn: ",."))
         s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       }
-      if s.isEmpty { continue }
-      // Comma/period trimming runs ONCE, after convergence, not inside the
-      // loop — combining it with quote trimming let it strip a marker's own
-      // "." out from under the list-marker regex before that regex ever saw
-      // the whole marker (GitHub cloud review, PR #1765 r6).
-      s = s.trimmingCharacters(in: CharacterSet(charactersIn: ",."))
-      s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
       // Fence check runs AFTER wrapper convergence — a wrapped fence line
       // (numbered, bulleted, quoted, blockquoted, or any nesting of those)

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -636,24 +636,42 @@ public final class WordSuggestionService: Sendable {
       // Strip list/blockquote markers, brackets, quotes, and trailing
       // comma/period to a fixed point — any interleaving or nesting of
       // these wrapper types converges to the real inner content, not just
-      // one layer of it. Brackets/quotes/comma-period are peeled ONE
-      // character per edge per pass (never `trimmingCharacters`'s
-      // whole-run removal): a run-trim can eat an outer wrapper AND a
-      // marker's own delimiter together in one call before the marker
-      // regex — which always runs first each pass — gets another look,
-      // e.g. "(1))" wrongly collapsing straight to "1" instead of exposing
-      // "1)" for the marker regex to strip on the next pass (GitHub cloud
-      // review structured pair-matrix check, PR #1765 r8).
+      // one layer of it. At most ONE of these operations may change `s`
+      // per pass; the moment any one does, the pass ends immediately and
+      // the marker check re-runs on the result — never two operations
+      // applied back-to-back in the same pass. Batching them (even with
+      // single-character peeling) let a marker's own delimiter be exposed
+      // and then immediately consumed by the NEXT operation in the same
+      // pass before the marker regex saw it, e.g. "\"1.\"" or "(1.)"
+      // wrongly collapsing to "1" (GitHub cloud review structured
+      // pair-matrix re-check, PR #1765 r9).
       var previous = ""
       while previous != s {
         previous = s
         if let listPrefixRegex {
           let range = NSRange(s.startIndex..., in: s)
-          s = listPrefixRegex.stringByReplacingMatches(in: s, range: range, withTemplate: "")
+          let stripped = listPrefixRegex.stringByReplacingMatches(
+            in: s, range: range, withTemplate: "")
+          if stripped != s {
+            s = stripped
+            continue
+          }
         }
-        s = Self.peelOneEdgeCharacter(s, in: bracketSet)
-        s = Self.peelOneEdgeCharacter(s, in: quoteSet)
-        s = Self.peelOneEdgeCharacter(s, in: commaPeriodSet)
+        let withoutBracket = Self.peelOneEdgeCharacter(s, in: bracketSet)
+        if withoutBracket != s {
+          s = withoutBracket
+          continue
+        }
+        let withoutQuote = Self.peelOneEdgeCharacter(s, in: quoteSet)
+        if withoutQuote != s {
+          s = withoutQuote
+          continue
+        }
+        let withoutCommaPeriod = Self.peelOneEdgeCharacter(s, in: commaPeriodSet)
+        if withoutCommaPeriod != s {
+          s = withoutCommaPeriod
+          continue
+        }
         s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       }
       if s.isEmpty { continue }

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -588,7 +588,9 @@ public final class WordSuggestionService: Sendable {
   /// Accepts numbered, dashed, or newline-separated outputs. Strips leading
   /// numbering, surrounding quotes (straight or curly), bracket artifacts,
   /// and whitespace. Drops obvious meta-commentary lines (model often
-  /// produces "Note:", "Example for X:", "If you cannot..." etc.).
+  /// produces "Note:", "Example for X:", "If you cannot..." etc.) and
+  /// markdown code-fence delimiter lines (the model sometimes wraps its
+  /// list in ```plaintext ... ```, #1763).
   /// Used by the plain-string alias-generation path (mirroring the polish
   /// path's plain-string + post-filter pattern).
   static func parsePlainStringAliases(_ raw: String) -> [String] {
@@ -599,9 +601,19 @@ public final class WordSuggestionService: Sendable {
       "asr", "i have ", "i did not", "no mistranscript", "no aliases",
       "return empty", "explanation",
     ]
+    // A line that is purely a fence delimiter (optional language tag), not
+    // real content that merely contains backticks. Compiled once per call.
+    let fenceRegex = try? NSRegularExpression(
+      pattern: #"^`{3,}[ \t]*[A-Za-z0-9_+./#-]*[ \t]*$"#
+    )
     for line in raw.components(separatedBy: .newlines) {
       var s = line.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
+      if let fenceRegex,
+        fenceRegex.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) != nil
+      {
+        continue
+      }
       s = s.trimmingCharacters(in: CharacterSet(charactersIn: "[]()"))
       s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -627,22 +627,23 @@ public final class WordSuggestionService: Sendable {
     let listPrefixRegex = try? NSRegularExpression(
       pattern: #"^(?:\d+[.)](?!\d)|[-*•+](?:\s+|$)|>\s*)"#
     )
+    let bracketSet = CharacterSet(charactersIn: "[]()")
+    let quoteSet = CharacterSet(charactersIn: "\"'\u{201C}\u{201D}\u{2018}\u{2019}")
+    let commaPeriodSet = CharacterSet(charactersIn: ",.")
     for line in raw.components(separatedBy: .newlines) {
       var s = line.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
       // Strip list/blockquote markers, brackets, quotes, and trailing
       // comma/period to a fixed point — any interleaving or nesting of
       // these wrapper types converges to the real inner content, not just
-      // one layer of it. A comma sitting outside a closing quote (AFM's
-      // JSON-array-style output, `"word",`) blocks that quote from the
-      // string's true edge until the comma is removed — removing
-      // comma/period only ONCE, outside the loop, left that exposed quote
-      // permanently stuck on the end (GitHub cloud review, PR #1765 r7).
-      // List-marker stripping still runs FIRST in each pass, before
-      // comma/period trimming gets a chance to eat a marker's own "."/")"
-      // out from under it and leave an orphaned digit behind (r6) — moving
-      // comma/period back into the loop does not reopen that: the marker
-      // regex always sees the untouched line at the start of every pass.
+      // one layer of it. Brackets/quotes/comma-period are peeled ONE
+      // character per edge per pass (never `trimmingCharacters`'s
+      // whole-run removal): a run-trim can eat an outer wrapper AND a
+      // marker's own delimiter together in one call before the marker
+      // regex — which always runs first each pass — gets another look,
+      // e.g. "(1))" wrongly collapsing straight to "1" instead of exposing
+      // "1)" for the marker regex to strip on the next pass (GitHub cloud
+      // review structured pair-matrix check, PR #1765 r8).
       var previous = ""
       while previous != s {
         previous = s
@@ -650,10 +651,9 @@ public final class WordSuggestionService: Sendable {
           let range = NSRange(s.startIndex..., in: s)
           s = listPrefixRegex.stringByReplacingMatches(in: s, range: range, withTemplate: "")
         }
-        s = s.trimmingCharacters(in: CharacterSet(charactersIn: "[]()"))
-        s = s.trimmingCharacters(
-          in: CharacterSet(charactersIn: "\"'\u{201C}\u{201D}\u{2018}\u{2019}"))
-        s = s.trimmingCharacters(in: CharacterSet(charactersIn: ",."))
+        s = Self.peelOneEdgeCharacter(s, in: bracketSet)
+        s = Self.peelOneEdgeCharacter(s, in: quoteSet)
+        s = Self.peelOneEdgeCharacter(s, in: commaPeriodSet)
         s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       }
       if s.isEmpty { continue }
@@ -681,6 +681,25 @@ public final class WordSuggestionService: Sendable {
       aliases.append(s)
     }
     return aliases
+  }
+
+  /// Removes at most one matching character from the front and one from
+  /// the back — deliberately NOT `trimmingCharacters(in:)`, which removes
+  /// an entire consecutive run and can consume a wrapper character together
+  /// with an unrelated adjacent delimiter (e.g. a list marker's own "."/")")
+  /// in a single call. Used by `parsePlainStringAliases`'s convergence loop
+  /// so every removal gets re-evaluated by the marker regex on the next
+  /// pass, rather than several edge characters vanishing at once (#1763).
+  private static func peelOneEdgeCharacter(_ s: String, in set: CharacterSet) -> String {
+    guard !s.isEmpty else { return s }
+    var s = s
+    if let first = s.unicodeScalars.first, set.contains(first) {
+      s.removeFirst()
+    }
+    if let last = s.unicodeScalars.last, set.contains(last) {
+      s.removeLast()
+    }
+    return s
   }
 
   /// Deterministic classification by syntax. Returns nil when AFM should

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -613,13 +613,19 @@ public final class WordSuggestionService: Sendable {
     // once per call, applied repeatedly below (they nest arbitrarily, e.g.
     // "- > text" or "\"- text\"", so a single fixed-order pass of
     // bracket/list/quote stripping can leave an inner wrapper behind —
-    // GitHub cloud review, PR #1765 r2/r3). Ordered/bullet markers require
-    // trailing whitespace or end-of-line so the fixed-point loop below
-    // cannot repeatedly eat real content like "+44" or "--alias" one
-    // character at a time (Codex final sweep, PR #1765 r4) — blockquote
-    // '>' keeps optional whitespace since CommonMark permits ">text".
+    // GitHub cloud review, PR #1765 r2/r3). Bullet markers require trailing
+    // whitespace or end-of-line so the fixed-point loop below cannot
+    // repeatedly eat real content like "+44" or "--alias" one character at
+    // a time (Codex final sweep, PR #1765 r4). Ordered markers instead
+    // require the following char be NOT a digit (rather than requiring
+    // whitespace outright) — AFM sometimes emits a compact numbered item
+    // with no space ("1.kuber netties"), which must still strip, while a
+    // decimal/version-shaped alias ("1.2") must not have its leading
+    // "1." mistaken for a marker (GitHub cloud review, PR #1765 r5).
+    // Blockquote '>' keeps optional whitespace since CommonMark permits
+    // ">text".
     let listPrefixRegex = try? NSRegularExpression(
-      pattern: #"^(?:\d+[.)](?:\s+|$)|[-*•+](?:\s+|$)|>\s*)"#
+      pattern: #"^(?:\d+[.)](?:\s+|$|(?![0-9]))|[-*•+](?:\s+|$)|>\s*)"#
     )
     for line in raw.components(separatedBy: .newlines) {
       var s = line.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
+++ b/Sources/EnviousWisprPostProcessing/WordSuggestionService.swift
@@ -609,11 +609,6 @@ public final class WordSuggestionService: Sendable {
     for line in raw.components(separatedBy: .newlines) {
       var s = line.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
-      if let fenceRegex,
-        fenceRegex.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) != nil
-      {
-        continue
-      }
       s = s.trimmingCharacters(in: CharacterSet(charactersIn: "[]()"))
       s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
@@ -627,6 +622,15 @@ public final class WordSuggestionService: Sendable {
         in: CharacterSet(charactersIn: "\"'\u{201C}\u{201D}\u{2018}\u{2019},."))
       s = s.trimmingCharacters(in: .whitespacesAndNewlines)
       if s.isEmpty { continue }
+      // Re-check for a fence AFTER list-marker/quote/bracket stripping —
+      // a numbered/bulleted/quoted fence line (e.g. "1. ```plaintext") does
+      // not match the bare-fence pattern until its wrapper is removed
+      // (GitHub cloud review, PR #1765).
+      if let fenceRegex,
+        fenceRegex.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) != nil
+      {
+        continue
+      }
       // Drop meta-commentary by token match.
       let lower = s.lowercased()
       var isMeta = false

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -320,6 +320,15 @@ struct WordSuggestionServiceParserTests {
 
     #expect(parsed == ["word", "word", "1.2", "12.34", "cube"])
   }
+
+  @Test("Quoted line with a trailing comma fully unwraps (JSON-array-style output)")
+  func quotedLineWithTrailingCommaFullyUnwraps() {
+    let raw = "\"kuber netties\",\n\"cube ernetes\",\ncooper nettys"
+
+    let parsed = WordSuggestionService.parsePlainStringAliases(raw)
+
+    #expect(parsed == ["kuber netties", "cube ernetes", "cooper nettys"])
+  }
 }
 
 /// Pins the multi-call dedupe pool helper.

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -335,6 +335,12 @@ struct WordSuggestionServiceParserTests {
     #expect(WordSuggestionService.parsePlainStringAliases("(1))").isEmpty)
     #expect(WordSuggestionService.parsePlainStringAliases(",1.,").isEmpty)
   }
+
+  @Test("A marker's own delimiter is not consumed by a DIFFERENT operation later in the same pass")
+  func markerDelimiterNotConsumedWithinSameBatchedPass() {
+    #expect(WordSuggestionService.parsePlainStringAliases("\"1.\"").isEmpty)
+    #expect(WordSuggestionService.parsePlainStringAliases("(1.)").isEmpty)
+  }
 }
 
 /// Pins the multi-call dedupe pool helper.

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -303,6 +303,23 @@ struct WordSuggestionServiceParserTests {
 
     #expect(parsed == ["kuber netties", "cube ernetes"])
   }
+
+  @Test("Marker-only lines vanish; decimals survive; compact markers still strip")
+  func markerOnlyLinesAndDecimalsHandledCorrectly() {
+    let raw = [
+      "1. word",
+      "1.word",
+      "1.",
+      "1.2",
+      "12.34",
+      "2)cube",
+      "2)",
+    ].joined(separator: "\n")
+
+    let parsed = WordSuggestionService.parsePlainStringAliases(raw)
+
+    #expect(parsed == ["word", "word", "1.2", "12.34", "cube"])
+  }
 }
 
 /// Pins the multi-call dedupe pool helper.

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -294,6 +294,15 @@ struct WordSuggestionServiceParserTests {
 
     #expect(parsed == ["+44", "++alias", "--alias", "***alias", "1.2"])
   }
+
+  @Test("Compact numbered list markers with no separating space still strip")
+  func compactNumberedMarkersStripped() {
+    let raw = "1.kuber netties\n2)cube ernetes"
+
+    let parsed = WordSuggestionService.parsePlainStringAliases(raw)
+
+    #expect(parsed == ["kuber netties", "cube ernetes"])
+  }
 }
 
 /// Pins the multi-call dedupe pool helper.

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -254,6 +254,46 @@ struct WordSuggestionServiceParserTests {
 
     #expect(parsed == ["kuber netties", "cube ernetes", "cooper nettys"])
   }
+
+  @Test("Nested and blockquote container markers around a fence are stripped repeatedly")
+  func nestedContainerMarkersAroundFenceDropped() {
+    let raw = [
+      "kuber netties",
+      "> ```plaintext",
+      "- - ```",
+      "+ ```swift",
+      "- > ```",
+      "cube ernetes",
+    ].joined(separator: "\n")
+
+    let parsed = WordSuggestionService.parsePlainStringAliases(raw)
+
+    #expect(parsed == ["kuber netties", "cube ernetes"])
+  }
+
+  @Test("Interleaved wrapper types around a fence converge to nothing, not one layer")
+  func interleavedWrapperTypesAroundFenceDropped() {
+    let raw = [
+      "kuber netties",
+      "\"- ```plaintext\"",
+      "[- > ```]",
+      "- \"```\"",
+      "cube ernetes",
+    ].joined(separator: "\n")
+
+    let parsed = WordSuggestionService.parsePlainStringAliases(raw)
+
+    #expect(parsed == ["kuber netties", "cube ernetes"])
+  }
+
+  @Test("Punctuation-prefixed content is preserved, not eaten as a repeated list marker")
+  func punctuationPrefixedContentPreserved() {
+    let raw = "+44\n++alias\n--alias\n***alias\n1.2"
+
+    let parsed = WordSuggestionService.parsePlainStringAliases(raw)
+
+    #expect(parsed == ["+44", "++alias", "--alias", "***alias", "1.2"])
+  }
 }
 
 /// Pins the multi-call dedupe pool helper.

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -341,6 +341,12 @@ struct WordSuggestionServiceParserTests {
     #expect(WordSuggestionService.parsePlainStringAliases("\"1.\"").isEmpty)
     #expect(WordSuggestionService.parsePlainStringAliases("(1.)").isEmpty)
   }
+
+  @Test("A wrapper on one edge is never peeled together with a marker delimiter on the other edge")
+  func wrapperOnOneEdgeNotPeeledWithMarkerOnOtherEdge() {
+    #expect(WordSuggestionService.parsePlainStringAliases(",1.").isEmpty)
+    #expect(WordSuggestionService.parsePlainStringAliases("[1)").isEmpty)
+  }
 }
 
 /// Pins the multi-call dedupe pool helper.

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -192,6 +192,46 @@ struct WordSuggestionServiceParserTests {
     #expect(WordSuggestionService.parsePlainStringAliases("   ").isEmpty)
     #expect(WordSuggestionService.parsePlainStringAliases("\n\n\n").isEmpty)
   }
+
+  @Test("Fence-only lines are dropped without stripping legitimate backticks")
+  func fenceOnlyLinesDropped() {
+    let raw = [
+      "```plaintext",
+      "```PlainText",
+      "``` c#",
+      "```text/plain",
+      "```",
+      "````",
+      "`````swift",
+      "kuber ``` netties",
+      "`inline alias`",
+      "``double inline alias``",
+    ].joined(separator: "\n")
+
+    let parsed = WordSuggestionService.parsePlainStringAliases(raw)
+
+    #expect(
+      parsed == [
+        "kuber ``` netties",
+        "`inline alias`",
+        "``double inline alias``",
+      ])
+  }
+
+  @Test("Kubernetes response strips Markdown fences (#1763 regression)")
+  func kubernetesResponseStripsMarkdownFences() {
+    let raw = [
+      "kuber netties",
+      "cube ernetes",
+      "cooper nettys",
+      "```plaintext",
+      "```",
+    ].joined(separator: "\n")
+
+    let parsed = WordSuggestionService.parsePlainStringAliases(raw)
+
+    #expect(parsed == ["kuber netties", "cube ernetes", "cooper nettys"])
+  }
 }
 
 /// Pins the multi-call dedupe pool helper.

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -329,6 +329,12 @@ struct WordSuggestionServiceParserTests {
 
     #expect(parsed == ["kuber netties", "cube ernetes", "cooper nettys"])
   }
+
+  @Test("A marker's own delimiter is never consumed alongside an unrelated outer wrapper")
+  func markerDelimiterNotConsumedByOuterWrapperRun() {
+    #expect(WordSuggestionService.parsePlainStringAliases("(1))").isEmpty)
+    #expect(WordSuggestionService.parsePlainStringAliases(",1.,").isEmpty)
+  }
 }
 
 /// Pins the multi-call dedupe pool helper.

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -193,19 +193,24 @@ struct WordSuggestionServiceParserTests {
     #expect(WordSuggestionService.parsePlainStringAliases("\n\n\n").isEmpty)
   }
 
-  @Test("Fence-only lines are dropped without stripping legitimate backticks")
+  @Test("Fence-only lines are dropped without stripping legitimate backticks or tildes")
   func fenceOnlyLinesDropped() {
     let raw = [
       "```plaintext",
       "```PlainText",
       "``` c#",
       "```text/plain",
+      "```plain text",
       "```",
       "````",
       "`````swift",
+      "~~~plaintext",
+      "~~~ plain text",
+      "~~~",
       "kuber ``` netties",
       "`inline alias`",
       "``double inline alias``",
+      "~ish sound",
     ].joined(separator: "\n")
 
     let parsed = WordSuggestionService.parsePlainStringAliases(raw)
@@ -215,6 +220,7 @@ struct WordSuggestionServiceParserTests {
         "kuber ``` netties",
         "`inline alias`",
         "``double inline alias``",
+        "~ish sound",
       ])
   }
 

--- a/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/WordSuggestionServiceTests.swift
@@ -232,6 +232,22 @@ struct WordSuggestionServiceParserTests {
 
     #expect(parsed == ["kuber netties", "cube ernetes", "cooper nettys"])
   }
+
+  @Test("Fence lines wrapped in a numbered, bulleted, or quoted marker are still dropped")
+  func fenceLinesWithListMarkersOrQuotesDropped() {
+    let raw = [
+      "1. kuber netties",
+      "2. cube ernetes",
+      "3. cooper nettys",
+      "4. ```plaintext",
+      "- ```",
+      "\"```\"",
+    ].joined(separator: "\n")
+
+    let parsed = WordSuggestionService.parsePlainStringAliases(raw)
+
+    #expect(parsed == ["kuber netties", "cube ernetes", "cooper nettys"])
+  }
 }
 
 /// Pins the multi-call dedupe pool helper.


### PR DESCRIPTION
## Summary
- When the app asks the on-device AI for alternate spellings of a word, the response can come back wrapped in a markdown code fence. The parser had no defense against a fence-delimiter-only line, so it survived straight into the saved alias list as junk (e.g. "```plaintext", "```").
- Fixes the shared parser used by every alias-suggestion caller: Add Term's interactive suggestion, Contacts import, and bulk import (#1701).
- Reproduces and fixes the exact real-world response observed during #1701 Live UAT.

## Review history (10 rounds, each a genuinely distinct finding, ending in a proven invariant)
1-3. Regex too narrow (language tag, tilde fences), fence-check ordering vs list-marker stripping.
4-6. Convergence-loop over-consumption of real punctuation-prefixed content, ordered-marker vs decimal disambiguation, comma/period trimming pulled outside the loop breaking quote+comma interaction.
7-10. The actual root cause: `trimmingCharacters(in:)`-style whole-run/multi-character removal could consume an outer wrapper together with a list marker's own delimiter before the marker regex got another look — closed in three steps: single-character-per-edge peeling, then at-most-one-operation-per-pass with immediate restart, then at-most-one-character-total (never front+back together) per peel call.

**Final round: asked Codex to verify a stated invariant, not search for another example.** Invariant: every state-change in one loop pass is either (a) a complete marker-token removal, (b) exactly one wrapper character removed by exactly one operation, or (c) a whitespace run-trim (provably safe since whitespace is disjoint from every other character set involved) — meaning no two unrelated character removals can ever happen without the marker regex getting a fresh look between them. Codex verified this clause-by-clause against the actual code: **PROCEED-AS-PLANNED** — "The invariant is true in the actual code... This is done."

## Test plan
- [x] 12 new `@Test` cases covering the full enumerated axis space plus every adversarial batching/ordering case found across all 10 rounds (each hand-traced before implementation, then verified against the real compiled function)
- [x] Full Debug suite: 3977 tests pass (0 regressions)
- [x] 10 rounds of Codex review (local + cloud, alternating) ending in a proven structural invariant, not just repeated spot-checks

Closes #1763.
