### PR TITLE
fix(user): Custom Words UI polish — Import label, bulk-delete row placement

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -78,6 +78,25 @@ struct CustomTermsSection: View {
         }
       }
 
+      // Bulk-delete action row, shown only once something is selected.
+      // Rendered directly under the search/selection row — above the term
+      // list and pagination — so it never requires scrolling past a full
+      // page of results to reach (founder feedback 2026-07-24).
+      if isSelecting, !selectedIDs.isEmpty {
+        BrandedRow(showDivider: true) {
+          HStack {
+            Text("\(selectedIDs.count) selected")
+              .font(.stHelper)
+              .foregroundStyle(.stTextSecondary)
+            Spacer()
+            Button("Delete…", role: .destructive) {
+              pendingBulkDelete = BulkDeleteRequest(ids: selectedIDs)
+            }
+            .controlSize(.small)
+          }
+        }
+      }
+
       // List or empty state
       if pagedWords.isEmpty {
         BrandedRow(showDivider: false) {
@@ -93,22 +112,6 @@ struct CustomTermsSection: View {
         ForEach(Array(pagedWords.enumerated()), id: \.element.id) { idx, word in
           BrandedRow(showDivider: idx < pagedWords.count - 1 || pageCount > 1) {
             termRow(for: word)
-          }
-        }
-      }
-
-      // Bulk-delete action row, shown only once something is selected.
-      if isSelecting, !selectedIDs.isEmpty {
-        BrandedRow(showDivider: false) {
-          HStack {
-            Text("\(selectedIDs.count) selected")
-              .font(.stHelper)
-              .foregroundStyle(.stTextSecondary)
-            Spacer()
-            Button("Delete…", role: .destructive) {
-              pendingBulkDelete = BulkDeleteRequest(ids: selectedIDs)
-            }
-            .controlSize(.small)
           }
         }
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// their real sources land (P1 paste, U1 upload, 4a smart import); Review and
 /// the commit path are real from F2c on.
 ///
-/// The sheet is reachable only through the DEBUG-only "Preview import" button
+/// The sheet is reachable only through the DEBUG-only "Import" button
 /// in Your Words, so no release user can see the remaining placeholders.
 /// Dismissing at any point cancels in-flight work and writes nothing.
 struct CustomWordsImportSheet: View {

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -69,7 +69,7 @@ struct YourWordsView: View {
           Button {
             sheetRoute = .importWords
           } label: {
-            Label("Preview import", systemImage: "square.and.arrow.down")
+            Label("Import", systemImage: "square.and.arrow.down")
           }
           // Export (#1680). Also DEBUG-only: the whole import/export feature is
           // compiled out of release builds until the founder ships it, and a
@@ -112,7 +112,7 @@ struct YourWordsView: View {
 
       #if DEBUG
         // Same DEBUG-only doorway as the rest of the import feature (#1619):
-        // this card can only ever appear if the DEBUG-only "Preview import"
+        // this card can only ever appear if the DEBUG-only "Import"
         // button above committed a batch, so it stays behind the same gate
         // rather than a redundant runtime check.
         //


### PR DESCRIPTION
## What this does

Two small UI fixes to the Custom Words screen, from founder live testing on a dev build ahead of tonight's release:

1. The DEBUG-only import entry point now reads "Import" instead of "Preview import."
2. The bulk-delete action row (shown once you select one or more of your own words) now renders directly under the search/select-all row, instead of after the full term list and pagination controls — no more scrolling to the bottom of the page to find it.

No behavior change: same button, same delete action, same eligibility rules for what can be bulk-selected. Purely a relabel + a render-order move.

council-skip: zero-blast-radius (UI layout/copy — no new symbols, no control-flow change, 3 files)

## Testing

- Local Codex diff review: clean, no actionable findings.
- Dev build rebuilt and relaunched; both changes verified live.