### PR TITLE
chore(release): bump version to 2.4.1

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -13,6 +13,73 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.4.1
+
+    Entry(
+      id: "import-words-from-another-app",
+      icon: "arrow.down.doc",
+      title: "Bring your words over from another dictation app",
+      description:
+        "Switching no longer means retyping your vocabulary. Pick the app you used before and your words come across, including the misspellings you had it watch for. FluidVoice, Superwhisper and Wispr Flow are supported today, with more on the way, and only apps actually installed on your Mac are offered. Nothing on your disk is touched until you choose one, and nothing is added to your words until you review and approve it. Once they are in, EnviousWispr suggests sound-alike spellings for them automatically, so dictation picks them up without a second pass by hand.",
+      version: "2.4.1"
+    ),
+    Entry(
+      id: "import-words-from-file-or-paste",
+      icon: "square.and.arrow.down",
+      title: "Import words from a file, or just paste a list",
+      description:
+        "Upload a words file or a plain text file, or paste a list straight in. Every route lands on the same review screen, so you see exactly what will be added, what is already yours, and what clashes, before anything changes. Imported words get their sound-alike spellings suggested automatically too.",
+      version: "2.4.1"
+    ),
+    Entry(
+      id: "export-words-backup",
+      icon: "square.and.arrow.up",
+      title: "Export your words to a backup you own",
+      description:
+        "Save your whole vocabulary to a file. Useful for a backup, for moving to a new Mac, or for sharing a set of words with someone else.",
+      version: "2.4.1"
+    ),
+    Entry(
+      id: "claude-cloud-polish-provider",
+      icon: "sparkles",
+      title: "Claude joins OpenAI and Gemini for cloud polish",
+      description:
+        "Bring your own Anthropic key and let Claude clean up your dictation, with ten models to choose from. As always, it is your key and your account, and the app tells you exactly what gets sent.",
+      version: "2.4.1"
+    ),
+    Entry(
+      id: "bulk-select-delete-words",
+      icon: "checklist",
+      title: "Select and delete many words at once",
+      description:
+        "Tidy up your list without deleting one word at a time. If you are about to remove a lot, EnviousWispr offers to export them first so nothing disappears by accident.",
+      version: "2.4.1"
+    ),
+    Entry(
+      id: "revamped-crash-recovery",
+      icon: "lifepreserver",
+      title: "Revamped crash recovery",
+      description:
+        "Our crash recovery system is smarter now. It actively tries to rescue a failed dictation wherever it can while the app is still running, not only after a crash. If the speech engine stops responding while you are still talking, EnviousWispr keeps the audio it already captured and transcribes it rather than losing the dictation.",
+      version: "2.4.1"
+    ),
+    Entry(
+      id: "cloud-polish-longer-dictations",
+      icon: "text.alignleft",
+      title: "Better cloud polishing for long dictations",
+      description:
+        "We reworked the output limits across all three cloud AI providers, so even a very long dictation has the room it needs to be polished in full.",
+      version: "2.4.1"
+    ),
+    Entry(
+      id: "two-copies-share-words-safely",
+      icon: "square.on.square",
+      title: "Fixed: a rare issue when the app was running twice",
+      description:
+        "If you happened to have two copies of EnviousWispr running at the same time, your custom words could be affected. That is now handled properly.",
+      version: "2.4.1"
+    ),
+
     // MARK: - v2.4.0
 
     Entry(

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.4.0"
+  public static let currentContentVersion = "2.4.1"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -59,7 +59,7 @@ struct WhatsNewContentTests {
     // untouched by #1493; asserting the real sequence is the falsifiable version.
     #expect(
       WhatsNewContent.versions == [
-        "2.4.0",
+        "2.4.1", "2.4.0",
         "2.3.2", "2.3.1", "2.3.0",
         "2.2.1", "2.2.0",
         "2.1.4", "2.1.3", "2.1.2", "2.1.1", "2.1.0",


### PR DESCRIPTION
## Summary

Version bump to v2.4.1 with What's New entries for the user-visible changes shipped since v2.4.0.

Eight entries, founder-reviewed: word import from another dictation app, file/paste import, export, Claude as a third cloud polish provider, bulk select and delete, revamped crash recovery, better cloud polishing for long dictations, and the two-copies custom-words fix.

Also updates the hard-coded version list in `WhatsNewContentTests.versionsAreNewestFirst` to include 2.4.1, which would otherwise fail the suite.

## Test plan

- [x] `scripts/build-dev-app.sh` — BUILD SUCCEEDED, bundle reports 2.4.1
- [x] `scripts/xcode-test.sh` — 3839 + 179 tests passed, TEST SUCCEEDED
- [x] `render-release-notes.py --self-test` — 106 entries parsed, 8 render for 2.4.1
- [x] What's New screen reviewed by founder
- [ ] build-check CI passes on this PR
- [ ] Tag v2.4.1 after merge triggers release pipeline