### PR TITLE
fix(worker): product-health reliability + plain-English rewrite

### DIFF
--- a/.github/workflows/daily-report-ping.yml
+++ b/.github/workflows/daily-report-ping.yml
@@ -57,7 +57,8 @@ jobs:
           if [ -n "$DATE_OVERRIDE" ]; then
             URL="${URL}?date=${DATE_OVERRIDE}"
           fi
-          # No --retry here (unlike product-health-ping.yml's --retry 3): this
+          # No --retry here (product-health-ping.yml's own --retry 3 was
+          # removed for the identical reason, issue #1589): this
           # worker posts a Discord failure notice as a SIDE EFFECT before
           # returning a non-2xx (src/index.js runReport's catch block), so a
           # blind curl retry on a transient 500/504 could post a duplicate or

--- a/.github/workflows/product-health-ping.yml
+++ b/.github/workflows/product-health-ping.yml
@@ -13,6 +13,27 @@ on:
     - cron: "17 14 * * *"  # ~10:17am ET daily. Offset minute (not :00): GitHub flags top-of-hour as a high-load window where scheduled runs are delayed/dropped (#1131). Minute drift is harmless - the worker evaluates the prior COMPLETED UTC day. The :14 hour is the ingestion-lag buffer for offline laptops.
   workflow_dispatch: {}
 
+# Serializes scheduled and manual runs of this workflow instead of letting
+# them overlap (issue #1589): the worker's own runLimited(..., 2) caps ONE
+# invocation to 2 concurrent PostHog queries, staying under the project's
+# 3-concurrent-query ceiling - but two overlapping invocations would each
+# independently run that cap and jointly exceed it. queue: max is required
+# alongside cancel-in-progress: false: GitHub's default (queue: single) would
+# silently CANCEL an already-pending run when a new one is queued, even with
+# cancel-in-progress: false (that flag only governs already-RUNNING jobs).
+# Does not cover a direct curl to the public Worker endpoint; that remains a
+# deliberate runbook action that must not overlap another run.
+#
+# `queue` IS valid current GitHub Actions syntax - do not "fix" this by
+# removing it. `actionlint` v1.7.12 does not yet recognize it and reports
+# "unexpected key" - its bundled schema predates this feature (verified
+# locally against the installed actionlint 1.7.12, same gap daily-report-
+# ping.yml already documents and works around).
+concurrency:
+  group: product-health
+  cancel-in-progress: false
+  queue: max
+
 permissions:
   contents: read
 
@@ -24,7 +45,17 @@ jobs:
         env:
           TRIGGER_SECRET: ${{ secrets.PRODUCT_HEALTH_TRIGGER_SECRET }}
         run: |
-          curl -fsS --retry 3 --retry-delay 10 \
+          # No --retry here (issue #1589, matching daily-report-ping.yml's
+          # already-shipped fix): the worker posts a Discord failure notice
+          # as a SIDE EFFECT before returning a non-2xx (src/index.js
+          # runHealth's catch block), so a blind curl retry on a transient
+          # 500/502/503/504 could rerun all 9 queries and post a duplicate or
+          # confusing failure notice, or a false failure notice immediately
+          # followed by a real heartbeat if the retry recovers. A single
+          # failed attempt already turns this job red (GitHub's own
+          # failure-email signal); manual recovery is a direct curl to the
+          # endpoint, not an automatic retry.
+          curl -fsS \
             -H "x-trigger-secret: ${TRIGGER_SECRET}" \
             "https://enviouswispr-product-health.saurabhav.workers.dev/" \
             -o /dev/null -w "worker responded HTTP %{http_code}\n"

--- a/workers/product-health/README.md
+++ b/workers/product-health/README.md
@@ -4,12 +4,20 @@ A daily Cloudflare Worker that watches product-health metrics and posts an
 advisory line to Discord. Read-only: it consumes events that already emit to
 PostHog. It gates nothing.
 
-It posts a **one-line heartbeat every run** (so a silent worker death or a
+It posts **a heartbeat block every run** (so a silent worker death or a
 telemetry blackout is itself visible) and a **louder alert block** only when a
-metric crosses a baseline-calibrated threshold.
+metric crosses a baseline-calibrated threshold. Every message is plain
+English: no internal field names or abbreviations.
+
+Reliability: queries run in capped waves (PostHog allows only 3 concurrent
+per project) with retry on 429/502/503/504; the dev-id exclusion is resolved
+once per run, not once per query; a non-essential query's exhausted retry
+degrades only the metrics it feeds instead of discarding the whole run.
 
 Plan + threshold rationale + baselines:
 `docs/feature-requests/issue-1092-2026-06-20-daily-product-health-check.md`.
+Reliability + plain-English rewrite:
+`docs/feature-requests/issue-1589-2026-07-24-product-health-reliability-and-plain-english.md`.
 
 ## Metrics + thresholds (v1)
 
@@ -25,27 +33,41 @@ anywhere in its history excluded (founder-machine-tell).
 | transcription | `pipeline.failed` stage=transcription family share (incl. legit no-speech) | prev 7 days | >=200 dictations | share >5% | ~0.9% |
 | volume / integrity | T-1 dictation count + co-firing check | T-1 vs trailing 7 days | trailing avg >=20/day | T-1=0 on active baseline, OR a co-firing event=0 (schema drift) | ~200/day |
 
-AFM discard reads `dark-awaiting-release` until `fallback_reason` ships in a
-release and users update (it is null on 100% of production events as of
-2026-06-20; merged in #1067 but not yet in a release).
+`fallback_reason` shipped in v2.3.1. The internal state name
+`dark-awaiting-release` is historical; today it means the query returned zero
+eligible fallback-reason rows.
 
 ## Develop / test
 
 ```bash
 cd workers/product-health
-node --test                     # pure threshold/state logic, no network
+node --test                     # pure threshold/state logic + reliability machinery, no network
+```
+
+Before touching `.github/workflows/product-health-ping.yml`, verify it still has no outer `curl --retry` and its `concurrency:` block is intact (the worker's own retry/degrade machinery assumes both):
+
+```bash
+workflow=../../.github/workflows/product-health-ping.yml
+if grep -nE '^[[:space:]]*curl .*--retry|^[[:space:]]*--retry([[:space:]]|$)' "$workflow"; then
+  echo "outer workflow retry must be removed"; exit 1
+fi
+sed '/^[[:space:]]*queue: max[[:space:]]*$/d' "$workflow" | actionlint -   # actionlint v1.7.12 predates the valid `queue` key
 ```
 
 Pre-deploy live-query smoke (runs the real HogQL against production PostHog,
-asserts the queries resolve + denominators are non-zero, prints the heartbeat,
-posts nothing):
+asserts the queries resolve + denominators are non-zero + no query degraded,
+prints the heartbeat, posts nothing):
 
 ```bash
 ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
   node workers/product-health/live-query-smoke.mjs
 ```
 
-## Deploy (one-time)
+## Deploy (required after every source change)
+
+There is no automatic deploy workflow: merging a PR to `main` does NOT ship
+the code to the running worker. Run this manually after every merge that
+touches `workers/product-health/`.
 
 ```bash
 cd workers/product-health

--- a/workers/product-health/live-query-smoke.mjs
+++ b/workers/product-health/live-query-smoke.mjs
@@ -1,23 +1,17 @@
-// Pre-deploy live-query smoke (issue #1092 plan, section 11).
+// Pre-deploy live-query smoke (issue #1092 plan, section 11; reliability +
+// evaluateHealthData wiring per issue #1589).
 // Runs the REAL worker HogQL against production PostHog, asserts the queries
-// resolve + known-live events have non-zero denominators, then prints the
-// heartbeat WITHOUT posting to Discord. Never posts anywhere.
+// resolve + known-live events have non-zero denominators + no query degraded,
+// then prints the heartbeat WITHOUT posting to Discord. Never posts anywhere.
+//
+// Calls the same evaluateHealthData() production uses (issue #1589) instead
+// of duplicating the evaluate-and-degrade wiring, closing a real drift: this
+// script used to omit the backendAttributionBlackout computation entirely.
 //
 // Run (bridges the key, no stdout leak):
 //   ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \
 //     node workers/product-health/live-query-smoke.mjs
-import {
-  fetchHealth,
-  evaluateLatency,
-  evaluatePaste,
-  evaluateAFM,
-  evaluateTranscription,
-  evaluateVolume,
-  evaluateOnboardingAbandon,
-  evaluateBackendTranscription,
-  evaluateOnboardingBlackout,
-  buildMessage,
-} from "./src/index.js";
+import { fetchHealth, evaluateHealthData, buildMessage } from "./src/index.js";
 
 const env = {
   POSTHOG_PROJECT_ID: "354235",
@@ -30,7 +24,10 @@ if (!env.POSTHOG_PERSONAL_API_KEY) {
 
 const data = await fetchHealth(env);
 
-// Assertions: queries resolved with rows, known-live denominators non-zero.
+// Assertions: queries resolved with rows, known-live denominators non-zero,
+// and no query degraded. A clean-looking response shape is not proof the
+// query actually succeeded end to end - it may have degraded to an empty
+// fallback after exhausting retries, which a shape-only check would miss.
 const fail = (m) => {
   console.error("SMOKE FAIL:", m);
   process.exit(1);
@@ -41,29 +38,38 @@ if (!(Number(data.seven.dictations_7d) > 0)) fail("7d dictations is zero - filte
 if (!(Number(data.seven.paste_total) > 0)) fail("7d paste_total is zero - filter or window bug");
 if (!data.onboardingDays.length) fail("onboarding query returned no days");
 if (!Object.keys(data.backendTranscriptionDays).length) fail("backend transcription query returned no backends");
-// fallback_reason is expected all-null pre-release: afm_fr_rows may be 0.
-console.log("columns OK; denominators non-zero.");
+
+const degradedQueries = [
+  ["latency", data.latencyDegraded],
+  ["seven-day aggregate", data.sevenDayDegraded],
+  ["versions", data.versionsDegraded],
+  ["onboarding", data.onboardingDegraded],
+  ["backend transcription", data.backendTranscriptionDegraded],
+  ["onboarding versions", data.onboardingVersionsDegraded],
+  ["backend versions", data.backendVersionsDegraded],
+]
+  .filter(([, degraded]) => degraded)
+  .map(([name]) => name);
+if (degradedQueries.length) fail(`queries degraded after retries: ${degradedQueries.join(", ")}`);
+
+// fallback_reason shipped in v2.3.1; afm_fr_rows may still be 0 on a
+// genuinely quiet week for eligible fallback-reason rows.
+console.log("columns OK; denominators non-zero; no query degraded.");
 console.log("7d:", JSON.stringify(data.seven));
 console.log("latency days:", data.latencyDays.length, "volume days:", data.volumeDays.length);
 console.log("onboarding days:", data.onboardingDays.length, "backends:", Object.keys(data.backendTranscriptionDays));
-console.log("afm_fr_rows (expect 0 pre-release):", data.seven.afm_fr_rows);
-
-const results = {
-  latency: evaluateLatency(data.latencyDays),
-  paste: evaluatePaste(data.seven),
-  afm: evaluateAFM(data.seven),
-  transcription: evaluateTranscription(data.seven),
-  volume: evaluateVolume(data.volumeDays, data.t1ref),
-  onboardingAbandon: evaluateOnboardingAbandon(data.onboardingDays, data.t1ref),
-  backendTranscription: evaluateBackendTranscription(data.backendTranscriptionDays, data.t1ref),
-  onboardingBlackout: evaluateOnboardingBlackout(data.onboardingDays, data.t1ref),
-};
+console.log("afm_fr_rows:", data.seven.afm_fr_rows);
 console.log("t1ref (PostHog clock):", data.t1ref);
+
+const results = evaluateHealthData(data);
+const STATE_KEYS = ["latency", "paste", "afm", "transcription", "volume", "onboardingAbandon", "onboardingBlackout"];
 console.log(
   "\nstates:",
-  Object.fromEntries(
-    Object.entries(results).map(([k, v]) => [k, Array.isArray(v) ? v.map((row) => `${row.backend}:${row.state}`) : v.state])
-  )
+  Object.fromEntries(STATE_KEYS.map((k) => [k, results[k].state])),
+  "| backendTranscription:",
+  results.backendTranscription.map((row) => `${row.backend}:${row.state}`),
+  "| backendAttributionBlackout:",
+  results.backendAttributionBlackout
 );
 console.log("\n--- heartbeat preview (NOT posted) ---");
-console.log(buildMessage(results, data.versions, data.onboardingVersions, data.backendVersions));
+console.log(buildMessage(results));

--- a/workers/product-health/src/index.js
+++ b/workers/product-health/src/index.js
@@ -4,13 +4,25 @@
  * Runs once a day (cron) plus a manual HTTP trigger. Reads existing product
  * events from PostHog over COMPLETED time windows, compares each metric to a
  * baseline-calibrated threshold with low-volume guards, and posts to Discord:
- *   - a one-line heartbeat EVERY run (carries the day's dictation volume +
- *     which metrics evaluated / were skipped / are dark / failed), so a silent
- *     worker death or a telemetry blackout is itself visible;
+ *   - a heartbeat block EVERY run (carries the day's dictation volume +
+ *     which metrics evaluated / were skipped / are dark / temporarily
+ *     unavailable), so a silent worker death or a telemetry blackout is
+ *     itself visible;
  *   - a louder alert block when a metric crosses.
+ *
+ * Message text is plain English (issue #1589) - no internal field names or
+ * abbreviations in anything posted to Discord.
+ *
+ * Reliability (issue #1589, porting workers/daily-report's already-shipped
+ * #1588/#1655/#1716/#1720 fixes): PostHog allows only 3 concurrent queries
+ * per project, so queries run in capped waves with retry on 429/502/503/504;
+ * the dev-id exclusion is resolved ONCE per run, not once per query; a
+ * non-essential query's exhausted retry degrades only the metrics it feeds
+ * (see evaluateHealthData) instead of discarding the whole run.
  *
  * Advisory only. Gates nothing. Plan + thresholds:
  *   docs/feature-requests/issue-1092-2026-06-20-daily-product-health-check.md
+ *   docs/feature-requests/issue-1589-2026-07-24-product-health-reliability-and-plain-english.md
  *
  * Privacy: output and logs are counts / rates / version-tags only. Never an
  * error_code string, never a raw PostHog row, never a per-user id.
@@ -60,51 +72,225 @@ export default {
 
 // ----- PostHog -------------------------------------------------------------
 
-// Per-distinct_id -dev exclusion implements analytics-operations.md
-// RULE: founder-machine-tell-in-distinct-id (a dev build anywhere in an id's
-// history marks the whole id as dogfood). Bare field names do not resolve in
-// HogQL, so every property reference is prefixed `properties.`.
-const PROD = `properties.environment = 'production'
-  AND distinct_id NOT IN (
-    SELECT distinct_id FROM events
-    WHERE properties.app_version LIKE '%-dev%' )`;
+// Environment predicate alone; combined with the resolved dev-id exclusion by
+// productionClauseFor() below. Bare field names do not resolve in HogQL, so
+// every property reference is prefixed `properties.`.
+const ENV_ONLY = "properties.environment = 'production'";
 
-async function hogql(env, sql) {
-  const res = await fetch(`${POSTHOG_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/query/`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${env.POSTHOG_PERSONAL_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ query: { kind: "HogQLQuery", query: sql }, refresh: "blocking" }),
-  });
-  if (!res.ok) {
-    // Loud: do not let a query failure look like healthy silence.
-    throw new Error(`PostHog query HTTP ${res.status}`);
+/** Converts a resolved dev-tainted distinct_id list (from resolveDevIds
+ * below) into the reusable production-filter predicate: environment =
+ * production, AND (only if any dev ids exist) NOT IN that literal list.
+ * Resolving the list ONCE per run and threading the result through every
+ * query that needs it replaces the old per-query live dev-exclusion
+ * subquery, which independently re-scanned the same whole-history data in
+ * 8 separate top-level queries (issue #1589, porting workers/daily-report's
+ * #1720 fix - RULE: founder-machine-tell-in-distinct-id: a dev build
+ * anywhere in an id's history marks the whole id as dogfood). An empty list
+ * is a legitimate state and must not produce invalid `NOT IN ()` SQL. */
+export function productionClauseFor(devIds) {
+  if (devIds.length === 0) return ENV_ONLY;
+  return `${ENV_ONLY}
+    AND distinct_id NOT IN (${sqlIdList(devIds)})`;
+}
+
+/** Escapes a distinct_id for a HogQL string literal (single-quote doubling -
+ * distinct_ids are opaque PostHog-generated ids, never user-authored text). */
+function sqlIdList(ids) {
+  return ids.map((id) => `'${String(id).replace(/'/g, "''")}'`).join(", ");
+}
+
+// Per-worker distinct_id list bound - defense-in-depth ceiling, never the
+// primary correctness mechanism (see resolveDevIds below). 5000 is far above
+// any realistic single-day population.
+const PER_USER_LIST_LIMIT = 5000;
+
+/** Resolves the whole-history dev-tainted distinct_id list ONCE per run.
+ * Queried at PER_USER_LIST_LIMIT+1 to detect overflow: if the true count
+ * exceeds the ceiling, this throws rather than silently building a
+ * truncated exclusion list that would under-exclude dev accounts from
+ * production totals - fail loud, not warn-and-continue. This is itself a
+ * fail-loud query: an unresolved dev-id list can never safely be treated as
+ * "no dev accounts," so callers must never wrap it in querySection's fail-
+ * soft catch. */
+export async function resolveDevIds(env, hogqlOpts = {}) {
+  const result = await hogql(
+    env,
+    `SELECT DISTINCT distinct_id FROM events
+     WHERE properties.app_version LIKE '%-dev%'
+     LIMIT ${PER_USER_LIST_LIMIT + 1}`,
+    "dev_ids",
+    hogqlOpts
+  );
+  const devIds = (result.results || []).map((row) => row[0]);
+  if (devIds.length > PER_USER_LIST_LIMIT) {
+    throw new Error(`dev-id completeness check failed: more than ${PER_USER_LIST_LIMIT} ids`);
   }
-  const json = await res.json();
-  if (!json.results) throw new Error("PostHog query returned no results array");
-  return json; // { results: [...rows], columns: [...] }
+  return devIds;
+}
+
+// PostHog's project-level rate limit allows only 3 concurrent queries, up to
+// 10s execution time per query, and queues/cancels/times out (HTTP
+// 502/503/504) anything beyond that; 429 is the documented, distinct
+// concurrency-limit-reached status (posthog.com/docs/api/queries,
+// posthog.com/docs/endpoints/troubleshooting). `runLimited` below caps this
+// worker's own concurrency under that ceiling; this retry is the second,
+// complementary layer for genuine transient contention (e.g. the project is
+// shared with EnviousStaging - analytics-operations.md FACT:
+// posthog-project-is-shared-with-enviousstaging). Retries up to twice (3
+// attempts total), only on this status class, only ever before any Discord
+// post happens.
+const RETRYABLE_POSTHOG_STATUSES = new Set([429, 502, 503, 504]);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Randomized backoff windows for retry attempts 2 and 3 (ported from
+// workers/daily-report's #1588/#1720 shipped precedent).
+const RETRY_DELAY_RANGES_MS = [
+  [12_000, 18_000],
+  [30_000, 45_000],
+];
+
+function retryDelayMs(range, randomFn) {
+  const [min, max] = range;
+  return Math.floor(min + randomFn() * (max - min + 1));
+}
+
+/** Carries the query name and HTTP status alongside the message, so a caller
+ * can distinguish an exhausted transient failure (which a degradable query
+ * is allowed to degrade on) from an auth failure, a malformed query, or a
+ * bad response shape (which must stay loud). */
+export class PostHogQueryError extends Error {
+  constructor(queryName, status) {
+    super(`PostHog query ${queryName} HTTP ${status}`);
+    this.name = "PostHogQueryError";
+    this.queryName = queryName;
+    this.status = status;
+  }
+}
+
+export async function hogql(
+  env,
+  sql,
+  queryName,
+  { fetchFn = fetch, sleepFn = sleep, randomFn = Math.random } = {}
+) {
+  const url = `${POSTHOG_HOST}/api/projects/${env.POSTHOG_PROJECT_ID}/query/`;
+  const maxAttempts = RETRY_DELAY_RANGES_MS.length + 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const res = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.POSTHOG_PERSONAL_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: { kind: "HogQLQuery", query: sql },
+        refresh: "blocking",
+        name: `product_health_${queryName}`,
+      }),
+    });
+
+    if (res.ok) {
+      const json = await res.json();
+      if (!json.results) throw new Error(`PostHog query ${queryName} returned no results array`);
+      return json; // { results: [...rows], columns: [...] }
+    }
+
+    const status = res.status;
+    if (res.body) {
+      try {
+        await res.body.cancel();
+      } catch (_) {
+        // Best effort: the status remains the authoritative failure, and a
+        // failed cancel must not mask it. Draining the failed body matters
+        // because a retry immediately opens a new outbound request on the
+        // same wave - an uncancelled body can hold its Cloudflare
+        // subrequest connection open.
+      }
+    }
+
+    if (attempt === maxAttempts || !RETRYABLE_POSTHOG_STATUSES.has(status)) {
+      throw new PostHogQueryError(queryName, status);
+    }
+    await sleepFn(retryDelayMs(RETRY_DELAY_RANGES_MS[attempt - 1], randomFn));
+  }
+}
+
+// Runs `tasks` (zero-arg async thunks) in fixed waves of at most `limit`
+// concurrently, preserving input order in the returned results. A failed
+// wave stops later waves from starting, matching `Promise.all`'s existing
+// all-or-nothing contract for the whole batch.
+export async function runLimited(tasks, limit) {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new TypeError("limit must be a positive integer");
+  }
+  const results = [];
+  for (let start = 0; start < tasks.length; start += limit) {
+    const wave = tasks.slice(start, start + limit);
+    results.push(...(await Promise.all(wave.map((task) => task()))));
+  }
+  return results;
+}
+
+/** Runs one hogql() call and reports whether it degraded instead of
+ * throwing. Only an EXHAUSTED retryable status (RETRYABLE_POSTHOG_STATUSES,
+ * after hogql's own retries) degrades; anything else - auth, bad SQL, a
+ * malformed response, a programming error - still throws. A silently
+ * "approximate" report that hides a real defect is worse than no report. */
+async function querySection(env, sql, queryName, hogqlOpts) {
+  try {
+    return { response: await hogql(env, sql, queryName, hogqlOpts), degraded: false };
+  } catch (err) {
+    const isExpectedTransientFailure =
+      err instanceof PostHogQueryError &&
+      err.queryName === queryName &&
+      RETRYABLE_POSTHOG_STATUSES.has(err.status);
+    if (!isExpectedTransientFailure) throw err;
+    console.log(`product-health ${queryName} degraded after retries: HTTP ${err.status}`);
+    return { response: null, degraded: true };
+  }
 }
 
 // Completed-window helpers: every window ends at the start of today (UTC), so
 // the partial current day (and late-flushing offline laptops) is excluded.
 const DAY = "toStartOfDay(now())"; // ClickHouse/PostHog default timezone is UTC
 
-export async function fetchHealth(env) {
+// `hogqlOpts` forwards the injection bag `hogql` already accepts, so tests can
+// drive the retry path without real backoff delays. Production passes nothing.
+export async function fetchHealth(env, hogqlOpts = {}) {
+  // The expected T-1 date per PostHog's own clock. Used to detect a zero-event
+  // T-1: the GROUP BY day query emits NO row for a day with zero events, so we
+  // must look T-1 up by date rather than trust the newest row.
+  const refSql = `SELECT toString(toDate(toStartOfDay(now()) - INTERVAL 1 DAY)) AS t1`;
+
+  // refSql and the dev-id resolution both stay fail-loud and run first: every
+  // other query below depends on the T-1 date or the production filter (or
+  // both), so there is nothing left to meaningfully degrade around if either
+  // of these fails (issue #1589 §2.5 point 4).
+  const [ref, devIds] = await Promise.all([
+    hogql(env, refSql, "ref", hogqlOpts),
+    resolveDevIds(env, hogqlOpts),
+  ]);
+  const prod = productionClauseFor(devIds);
+
   // 1) Per-day latency for the last 14 complete days (covers the 2-qualifying-day
-  //    sustained check AND the 14d drift median).
+  //    sustained check AND the 14d drift median). Degradable: feeds only the
+  //    latency alert and the heartbeat's response-speed line.
   const latencySql = `
     SELECT toDate(timestamp) AS day, count() AS n,
            round(quantile(0.5)(toFloat(properties.e2e_seconds)), 3) AS p50,
            round(quantile(0.95)(toFloat(properties.e2e_seconds)), 3) AS p95
     FROM events
-    WHERE event = 'dictation.completed' AND ${PROD}
+    WHERE event = 'dictation.completed' AND ${prod}
       AND properties.e2e_seconds IS NOT NULL
       AND timestamp >= ${DAY} - INTERVAL 14 DAY AND timestamp < ${DAY}
     GROUP BY day ORDER BY day DESC`;
 
   // 2) The four 7d rate metrics in one pass (previous 7 complete days).
+  //    Degradable, but degrades paste + AFM + transcription TOGETHER (they
+  //    share this one query), and also disables the backend-attribution-
+  //    blackout check, which needs dictations_7d as its own volume proof
+  //    (issue #1589 §2.5 point 4 - this query is NOT "one query, one metric").
   const sevenDaySql = `
     SELECT
       countIf(event = 'paste.completed') AS paste_total,
@@ -117,23 +303,28 @@ export async function fetchHealth(env) {
       countIf(event = 'pipeline.failed' AND properties.stage = 'transcription') AS trans_fails,
       countIf(event = 'dictation.completed') AS dictations_7d
     FROM events
-    WHERE ${PROD}
+    WHERE ${prod}
       AND event IN ('paste.completed', 'llm.polish_completed', 'pipeline.failed', 'dictation.completed')
       AND timestamp >= ${DAY} - INTERVAL 7 DAY AND timestamp < ${DAY}`;
 
   // 3) Per-day volume + co-firing counts for the last 8 complete days
   //    (T-1 vs the 7 days before it; co-firing blackout = schema drift).
+  //    Fail-loud: this owns the heartbeat's headline dictation count and the
+  //    zero/drift integrity alerts - a heartbeat with no volume number is not
+  //    a heartbeat.
   const volumeSql = `
     SELECT toDate(timestamp) AS day,
            countIf(event = 'dictation.completed') AS dictations,
            countIf(event = 'paste.completed') AS pastes,
            countIf(event = 'asr.completed') AS asr
     FROM events
-    WHERE ${PROD} AND event IN ('dictation.completed', 'paste.completed', 'asr.completed')
+    WHERE ${prod} AND event IN ('dictation.completed', 'paste.completed', 'asr.completed')
       AND timestamp >= ${DAY} - INTERVAL 8 DAY AND timestamp < ${DAY}
     GROUP BY day ORDER BY day DESC`;
 
   // 4) Top app-versions for the crossing-prone metrics (one pass, 7d).
+  //    Degradable, enrichment-only: never suppresses the paste/AFM/
+  //    transcription alerts themselves, only their "top versions" detail.
   const versionSql = `
     SELECT properties.app_version AS ver,
            countIf(event = 'paste.completed' AND properties.tier LIKE 'clipboard_only%') AS paste_fb,
@@ -141,15 +332,10 @@ export async function fetchHealth(env) {
            countIf(event = 'llm.polish_completed'
                    AND properties.fallback_reason IN ('guard_discard', 'validator_discard')) AS afm_disc
     FROM events
-    WHERE ${PROD}
+    WHERE ${prod}
       AND event IN ('paste.completed', 'pipeline.failed', 'llm.polish_completed')
       AND timestamp >= ${DAY} - INTERVAL 7 DAY AND timestamp < ${DAY}
     GROUP BY ver ORDER BY (paste_fb + trans_fail + afm_disc) DESC LIMIT 5`;
-
-  // The expected T-1 date per PostHog's own clock. Used to detect a zero-event
-  // T-1: the GROUP BY day query emits NO row for a day with zero events, so we
-  // must look T-1 up by date rather than trust the newest row.
-  const refSql = `SELECT toString(toDate(toStartOfDay(now()) - INTERVAL 1 DAY)) AS t1`;
 
   // 5) Phase 10 (#1179): per-day onboarding funnel, 21 complete days (covers
   //    the rolling baseline AND the fast path AND the blackout's 9-day need).
@@ -186,6 +372,8 @@ export async function fetchHealth(env) {
   // with `abandoned === 0`, which is healthy, correctly-tagged data, not
   // drift, and the old raw-vs-filtered inference could not tell the two
   // apart.
+  // 5) Degradable, but degrades BOTH onboarding evaluators together - they
+  //    share this one query's rows (issue #1589 §2.5 point 4).
   const onboardingSql = `
     SELECT toDate(timestamp) AS day,
            countIf(event = 'onboarding.started') AS started,
@@ -194,7 +382,7 @@ export async function fetchHealth(env) {
            countIf(event = 'onboarding.abandoned') AS abandonedRaw,
            countIf(event = 'onboarding.abandoned' AND (properties.screen IS NULL OR properties.screen = '')) AS abandonedMissingScreen
     FROM events
-    WHERE ${PROD}
+    WHERE ${prod}
       AND event IN ('onboarding.started', 'onboarding.completed', 'onboarding.abandoned')
       AND timestamp >= ${DAY} - INTERVAL 21 DAY AND timestamp < ${DAY}
     GROUP BY day ORDER BY day DESC`;
@@ -203,26 +391,31 @@ export async function fetchHealth(env) {
   //    complete days. Backend enumeration comes from EITHER event's backend
   //    tag (dictation.completed's asr_backend, pipeline.failed's backend) —
   //    canonical contract B2: an active backend with zero matching failures
-  //    still gets a row (fails: 0), never silently drops.
+  //    still gets a row (fails: 0), never silently drops. Degradable, but
+  //    degrades the per-backend evaluation AND backend-attribution-blackout
+  //    together - a degraded query must read as "we couldn't check this,"
+  //    never get reinterpreted as "zero backends found = blackout" (issue
+  //    #1589 §2.5 point 4).
   const backendTranscriptionSql = `
     SELECT toDate(timestamp) AS day,
            coalesce(properties.asr_backend, properties.backend) AS backend,
            countIf(event = 'dictation.completed') AS dictations,
            countIf(event = 'pipeline.failed' AND properties.stage = 'transcription') AS fails
     FROM events
-    WHERE ${PROD}
+    WHERE ${prod}
       AND ((event = 'dictation.completed')
         OR (event = 'pipeline.failed' AND properties.stage = 'transcription'))
       AND timestamp >= ${DAY} - INTERVAL 14 DAY AND timestamp < ${DAY}
     GROUP BY day, backend ORDER BY day DESC`;
 
   // 7) Phase 10 (#1179) per-release segmentation, matching each metric's own
-  //    window (§3 Design "Per-release segmentation").
+  //    window (§3 Design "Per-release segmentation"). Degradable, enrichment-
+  //    only: never suppresses the onboarding-abandon rolling alert itself.
   const onboardingVersionSql = `
     SELECT properties.app_version AS ver,
            countIf(event = 'onboarding.abandoned' AND properties.screen != 'welcome') AS onboarding_abandon
     FROM events
-    WHERE ${PROD} AND event = 'onboarding.abandoned'
+    WHERE ${prod} AND event = 'onboarding.abandoned'
       AND timestamp >= ${DAY} - INTERVAL 21 DAY AND timestamp < ${DAY}
     GROUP BY ver ORDER BY onboarding_abandon DESC LIMIT 5`;
 
@@ -232,39 +425,58 @@ export async function fetchHealth(env) {
   // only after this query returns (Codex review finding). Two backends today
   // (Parakeet, WhisperKit) with `limit: 3` displayed each means 40 comfortably
   // covers both without a per-backend-ranked subquery this codebase has no
-  // other precedent for.
+  // other precedent for. Degradable, enrichment-only.
   const backendVersionSql = `
     SELECT properties.app_version AS ver,
            properties.backend AS backend,
            countIf(event = 'pipeline.failed' AND properties.stage = 'transcription') AS backend_trans_fail
     FROM events
-    WHERE ${PROD} AND event = 'pipeline.failed' AND properties.stage = 'transcription'
+    WHERE ${prod} AND event = 'pipeline.failed' AND properties.stage = 'transcription'
       AND timestamp >= ${DAY} - INTERVAL 14 DAY AND timestamp < ${DAY}
     GROUP BY ver, backend ORDER BY backend_trans_fail DESC LIMIT 40`;
 
-  const [latency, seven, volume, versions, ref, onboarding, backendTranscription, onboardingVersions, backendVersions] =
-    await Promise.all([
-      hogql(env, latencySql),
-      hogql(env, sevenDaySql),
-      hogql(env, volumeSql),
-      hogql(env, versionSql),
-      hogql(env, refSql),
-      hogql(env, onboardingSql),
-      hogql(env, backendTranscriptionSql),
-      hogql(env, onboardingVersionSql),
-      hogql(env, backendVersionSql),
-    ]);
+  // PostHog allows only 3 concurrent queries per project (posthog-project-
+  // concurrency-limit); `runLimited(..., 2)` runs these 8 in 4 fixed waves of
+  // 2, leaving one slot of headroom for the shared project's other traffic
+  // (EnviousStaging) rather than firing all 8 at once. `volumeSql` is the
+  // sole fail-loud member of this batch (mirrors daily-report's `totals`);
+  // the other 7 go through `querySection` and degrade to "temporarily
+  // unavailable" instead of discarding the whole run on an exhausted
+  // transient failure.
+  const [latencyResult, sevenDayResult, volume, versionsResult, onboardingResult, backendTranscriptionResult, onboardingVersionsResult, backendVersionsResult] =
+    await runLimited(
+      [
+        () => querySection(env, latencySql, "latency", hogqlOpts),
+        () => querySection(env, sevenDaySql, "seven_day", hogqlOpts),
+        () => hogql(env, volumeSql, "volume", hogqlOpts),
+        () => querySection(env, versionSql, "versions", hogqlOpts),
+        () => querySection(env, onboardingSql, "onboarding", hogqlOpts),
+        () => querySection(env, backendTranscriptionSql, "backend_transcription", hogqlOpts),
+        () => querySection(env, onboardingVersionSql, "onboarding_versions", hogqlOpts),
+        () => querySection(env, backendVersionSql, "backend_versions", hogqlOpts),
+      ],
+      2
+    );
 
   return {
-    latencyDays: rowsToObjects(latency),
-    seven: rowsToObjects(seven)[0] || {},
+    latencyDays: latencyResult.degraded ? [] : rowsToObjects(latencyResult.response),
+    latencyDegraded: latencyResult.degraded,
+    seven: sevenDayResult.degraded ? {} : rowsToObjects(sevenDayResult.response)[0] || {},
+    sevenDayDegraded: sevenDayResult.degraded,
     volumeDays: rowsToObjects(volume),
-    versions: rowsToObjects(versions),
+    versions: versionsResult.degraded ? [] : rowsToObjects(versionsResult.response),
+    versionsDegraded: versionsResult.degraded,
     t1ref: (rowsToObjects(ref)[0] || {}).t1,
-    onboardingDays: rowsToObjects(onboarding),
-    backendTranscriptionDays: groupByBackend(rowsToObjects(backendTranscription)),
-    onboardingVersions: rowsToObjects(onboardingVersions),
-    backendVersions: rowsToObjects(backendVersions),
+    onboardingDays: onboardingResult.degraded ? [] : rowsToObjects(onboardingResult.response),
+    onboardingDegraded: onboardingResult.degraded,
+    backendTranscriptionDays: backendTranscriptionResult.degraded
+      ? {}
+      : groupByBackend(rowsToObjects(backendTranscriptionResult.response)),
+    backendTranscriptionDegraded: backendTranscriptionResult.degraded,
+    onboardingVersions: onboardingVersionsResult.degraded ? [] : rowsToObjects(onboardingVersionsResult.response),
+    onboardingVersionsDegraded: onboardingVersionsResult.degraded,
+    backendVersions: backendVersionsResult.degraded ? [] : rowsToObjects(backendVersionsResult.response),
+    backendVersionsDegraded: backendVersionsResult.degraded,
   };
 }
 
@@ -503,6 +715,56 @@ export function evaluateOnboardingBlackout(rows, expectedT1, TH = THRESHOLDS.onb
     entryPointDown, terminalDrift, recentStarted, recentTerminals, baselineAvg };
 }
 
+/** Issue #1589: the SOLE owner of turning `fetchHealth()`'s output (real
+ * rows + per-query degrade flags) into the per-metric `evaluate*()` results
+ * `buildMessage()` consumes. Calls each `evaluate*()` only when its backing
+ * query did NOT degrade; on a degraded query, substitutes
+ * `{ state: "temporarily-unavailable" }` for every metric that query feeds,
+ * per the dependency table in the plan (§2.5 point 4) - `sevenDayDegraded`
+ * alone yields THREE unavailable metrics (paste, afm, transcription) plus an
+ * uncheckable `backendAttributionBlackout`; `onboardingDegraded` yields two
+ * (onboardingAbandon, onboardingBlackout). Both `runHealth()` (production)
+ * and `live-query-smoke.mjs` call this ONE function, so they cannot drift
+ * apart the way they previously did (the smoke script used to omit the
+ * `backendAttributionBlackout` computation entirely). */
+export function evaluateHealthData(data) {
+  const unavailable = () => ({ state: "temporarily-unavailable" });
+
+  const backendTranscription = data.backendTranscriptionDegraded
+    ? []
+    : evaluateBackendTranscription(data.backendTranscriptionDays, data.t1ref);
+
+  const backendAttributionBlackoutUnavailable =
+    data.backendTranscriptionDegraded || data.sevenDayDegraded;
+
+  return {
+    latency: data.latencyDegraded ? unavailable() : evaluateLatency(data.latencyDays),
+    paste: data.sevenDayDegraded ? unavailable() : evaluatePaste(data.seven),
+    afm: data.sevenDayDegraded ? unavailable() : evaluateAFM(data.seven),
+    transcription: data.sevenDayDegraded ? unavailable() : evaluateTranscription(data.seven),
+    volume: evaluateVolume(data.volumeDays, data.t1ref),
+    onboardingAbandon: data.onboardingDegraded
+      ? unavailable()
+      : evaluateOnboardingAbandon(data.onboardingDays, data.t1ref),
+    onboardingBlackout: data.onboardingDegraded
+      ? unavailable()
+      : evaluateOnboardingBlackout(data.onboardingDays, data.t1ref),
+    backendTranscription,
+    backendTranscriptionUnavailable: data.backendTranscriptionDegraded,
+    backendAttributionBlackout:
+      !backendAttributionBlackoutUnavailable &&
+      backendTranscription.length === 0 &&
+      num(data.seven.dictations_7d) >= THRESHOLDS.transcription.minDictations,
+    backendAttributionBlackoutUnavailable,
+    versions: data.versions,
+    onboardingVersions: data.onboardingVersions,
+    backendVersions: data.backendVersions,
+    versionsDegraded: data.versionsDegraded,
+    onboardingVersionsDegraded: data.onboardingVersionsDegraded,
+    backendVersionsDegraded: data.backendVersionsDegraded,
+  };
+}
+
 function num(v) {
   const n = typeof v === "string" ? parseFloat(v) : v;
   return Number.isFinite(n) ? n : 0;
@@ -518,69 +780,88 @@ function topVersionsFor(versions, key, { backend = null, limit = 3 } = {}) {
     .filter((row) => num(row[key]) > 0)
     .sort((a, b) => num(b[key]) - num(a[key]))
     .slice(0, limit)
-    .map((row) => `${row.ver || "unknown"}: ${num(row[key])}`)
+    .map((row) => `${row.ver || "unknown"} (${num(row[key])})`)
     .join(", ");
+}
+
+// Issue #1589: naive title-casing turns `whisperKit` into "Whisperkit."
+// `ASRBackendType`'s Swift rawValue is `whisperKit` camelCase
+// (Sources/EnviousWisprCore/ASRResult.swift) - the lowercase alias is
+// defensive in case an older/renamed tag ever reaches this worker.
+const BACKEND_LABELS = { parakeet: "Parakeet", whisperKit: "WhisperKit", whisperkit: "WhisperKit" };
+function backendLabel(backend) {
+  return BACKEND_LABELS[backend] || (backend ? backend.charAt(0).toUpperCase() + backend.slice(1) : "unknown");
+}
+
+// Issue #1589: the `{ topVersions }` clause. Enrichment-only degrades must
+// stay visible rather than silently vanish, so a degraded backing version
+// query renders a plain "couldn't break this down" sentence instead of
+// omitting the clause. `fastCrossing` alerts never get version attribution
+// at all (a 2-day window can't be honestly attributed to a 21/14-day version
+// query), so callers pass `degraded = false` and `entries = []` for those.
+function topVersionsClause(versions, key, degraded, opts) {
+  if (degraded) return " We couldn't break this down by app version today.";
+  const tv = topVersionsFor(versions, key, opts);
+  return tv ? ` App versions with the most affected events: ${tv}.` : "";
 }
 
 // ----- Message ------------------------------------------------------------
 
-export function buildMessage(r, versions = [], onboardingVersions = [], backendVersions = []) {
+// Issue #1589: plain-English rewrite. `r` is evaluateHealthData()'s return
+// object - one argument, carrying every evaluate*() result plus the version
+// row arrays and every degrade flag `buildMessage` needs.
+export function buildMessage(r) {
   const alerts = [];
   const evaluated = [];
   const skipped = [];
   const dark = [];
+  const unavailable = [];
 
-  const note = (name, ev) => {
+  const note = (label, ev) => {
     if (ev.state === "alerting") return; // handled as an alert
-    if (ev.state === "evaluated-ok") evaluated.push(name);
-    else if (ev.state === "dark-awaiting-release") dark.push(name);
-    else skipped.push(name);
+    if (ev.state === "evaluated-ok") evaluated.push(label);
+    else if (ev.state === "dark-awaiting-release") dark.push(label);
+    else if (ev.state === "temporarily-unavailable") unavailable.push(label);
+    else skipped.push(label);
   };
 
-  // Latency
+  // Response speed (latency)
   if (r.latency.state === "alerting") {
     const d = r.latency.latest;
     alerts.push(
-      `latency high: p50 ${d.p50}s / p95 ${d.p95}s, ${r.latency.last2.length} qualifying days, ` +
-      `thresholds p50>${THRESHOLDS.latency.p50}s or p95>${THRESHOLDS.latency.p95}s (baseline p50 ~1.5s).`
+      `Dictation is taking longer than usual to finish. On the latest day with enough data, the typical time was ${d.p50}s and the slowest 5% took at least ${d.p95}s. This crossed the alert line on each of the latest ${r.latency.last2.length} days with enough data. We alert above ${THRESHOLDS.latency.p50}s typical or ${THRESHOLDS.latency.p95}s for the slowest 5%; normal typical time is about 1.5s.`
     );
   }
-  note("latency", r.latency);
+  note("response speed", r.latency);
 
-  // Paste
+  // Auto-paste reliability
   if (r.paste.state === "alerting") {
-    const tv = topVersionsFor(versions, "paste_fb");
+    const tv = topVersionsClause(r.versions, "paste_fb", r.versionsDegraded);
     alerts.push(
-      `paste fallback ${pct(r.paste.share)} (${r.paste.fb}/${r.paste.total}, prev 7d), ` +
-      `threshold >${pct(THRESHOLDS.paste.share)}, baseline ~1.2%. ` +
-      `Split: ax_denied ${r.paste.ax}, direct-paste-failed ${r.paste.cb}.` +
-      (tv ? ` Top versions ${tv}.` : "")
+      `Auto-paste is failing more than usual: ${pct(r.paste.share)} of pastes over the last week fell back to copying to the clipboard instead of pasting directly (${r.paste.fb} of ${r.paste.total} pastes). ${r.paste.ax} were caused by a missing permission; ${r.paste.cb} failed another way. Normal is about 1.2%; we alert above ${pct(THRESHOLDS.paste.share)}.${tv}`
     );
   }
-  note("paste", r.paste);
+  note("auto-paste reliability", r.paste);
 
-  // AFM discard
+  // Apple on-device polishing quality (AFM)
   if (r.afm.state === "alerting") {
-    const tv = topVersionsFor(versions, "afm_disc");
+    const tv = topVersionsClause(r.versions, "afm_disc", r.versionsDegraded);
     alerts.push(
-      `AFM genuine discard ${pct(r.afm.share)} (${r.afm.disc}/${r.afm.frRows} fr-rows, prev 7d), ` +
-      `threshold >${pct(THRESHOLDS.afm.share)}, baseline ~10%.` + (tv ? ` Top versions ${tv}.` : "")
+      `Among the times Apple's on-device polishing used the raw transcript, it did so because it rejected its own rewritten text more often than usual: ${pct(r.afm.share)} over the last week (${r.afm.disc} of ${r.afm.frRows} raw-text fallbacks). Normal is about 10%; we alert above ${pct(THRESHOLDS.afm.share)}.${tv}`
     );
   }
-  note("AFM-discard", r.afm);
+  note("Apple on-device polishing quality", r.afm);
 
-  // Transcription
+  // Speech-to-text reliability (aggregate)
   if (r.transcription.state === "alerting") {
-    const tv = topVersionsFor(versions, "trans_fail");
+    const tv = topVersionsClause(r.versions, "trans_fail", r.versionsDegraded);
     alerts.push(
-      `transcription failure family ${pct(r.transcription.share)} ` +
-      `(${r.transcription.fails}/${r.transcription.denom}, prev 7d, includes legitimate no-speech), ` +
-      `threshold >${pct(THRESHOLDS.transcription.share)}, baseline ~0.9%.` + (tv ? ` Top versions ${tv}.` : "")
+      `Speech-to-text failed to produce any text more than usual: ${pct(r.transcription.share)} of attempts over the last week (${r.transcription.fails} of ${r.transcription.denom}; this includes attempts where the person genuinely said nothing). Normal is about 0.9%; we alert above ${pct(THRESHOLDS.transcription.share)}.${tv}`
     );
   }
-  note("transcription", r.transcription);
+  note("speech-to-text reliability", r.transcription);
 
-  // Onboarding abandon (Phase 10, #1179)
+  // Onboarding completion (Phase 10, #1179)
   if (r.onboardingAbandon) {
     const ev = r.onboardingAbandon;
     if (ev.state === "alerting" && ev.attributionDrift) {
@@ -589,184 +870,188 @@ export function buildMessage(r, versions = [], onboardingVersions = [], backendV
       // count directly (Codex r4 review finding), not the raw total, so the
       // alert cannot fire on a legitimate all-welcome concentration.
       alerts.push(
-        `onboarding abandon attribution lost: ${ev.totalAbandonedMissingScreen} of ` +
-        `${ev.totalAbandonedRaw} onboarding.abandoned events over the prev 21d had no usable ` +
-        `properties.screen (properties.screen may have stopped emitting or been renamed).`
+        `We lost the ability to tell where setup was abandoned: ${ev.totalAbandonedMissingScreen} of ${ev.totalAbandonedRaw} abandon events over the last three weeks are missing the tag for which screen they were on. Onboarding tracking may be broken.`
+      );
+    } else if (ev.state === "alerting" && ev.fastCrossing) {
+      // Report the fast window's own rate, never the healthy rolling total
+      // (Codex review finding), and never attribute a 2-day crossing to the
+      // metric's own 21-day version query (window mismatch).
+      alerts.push(
+        `In just the last 2 days, ${pct(ev.fastShare)} of setup attempts ended before setup was finished (${ev.fastAbandoned} of ${ev.fastStarted}). This is a sudden change worth a look even though the 3-week average still looks fine.`
       );
     } else if (ev.state === "alerting") {
-      // Report the window that actually crossed (Codex review finding: a
-      // fast-only crossing must not display the healthy rolling total).
-      const windowText = ev.fastCrossing
-        ? `${pct(ev.fastShare)} (${ev.fastAbandoned}/${ev.fastStarted}, fast 2-day crossing)`
-        : `${pct(ev.rollingShare)} (${ev.totalAbandoned}/${ev.totalStarted}, prev 21d, rolling crossing)`;
-      // Version attribution only matches the metric's own 21-day window —
-      // a fast (2-day) crossing must not misattribute to it (Codex review
-      // finding: an older high-volume release can otherwise be blamed for a
-      // regression confined to the last 2 days).
-      const tv = ev.fastCrossing ? "" : topVersionsFor(onboardingVersions, "onboarding_abandon");
+      const tv = topVersionsClause(r.onboardingVersions, "onboarding_abandon", r.onboardingVersionsDegraded);
       alerts.push(
-        `onboarding abandon ${windowText}, threshold >${pct(THRESHOLDS.onboardingAbandon.share)}, ` +
-        `baseline ~37%.` + (tv ? ` Top versions ${tv}.` : "")
+        `Of the setup attempts started over the last three weeks, ${pct(ev.rollingShare)} ended before setup was finished (${ev.totalAbandoned} of ${ev.totalStarted}). Normal is about 37%; we alert above ${pct(THRESHOLDS.onboardingAbandon.share)}.${tv}`
       );
     }
-    note("onboarding-abandon", ev);
+    note("onboarding completion", ev);
   }
 
-  // Per-backend transcription (Phase 10, #1179)
-  if (r.backendTranscription) {
+  // Speech-to-text reliability by engine (Phase 10, #1179)
+  if (r.backendTranscriptionUnavailable) {
+    note("speech-to-text reliability by engine", { state: "temporarily-unavailable" });
+  } else if (r.backendTranscription) {
     for (const row of r.backendTranscription) {
+      const label = backendLabel(row.backend);
       if (row.state === "alerting" && row.attributionDrift) {
         // Backend-attribution drift (Codex review finding): distinct wording,
         // no version attribution.
         alerts.push(
-          `transcription backend attribution lost: ${row.attempts} dictation/failure events ` +
-          `over the prev 14d carried no usable asr_backend or backend tag ` +
-          `(the per-backend split has degraded to an aggregate).`
+          `We lost track of which speech engine, Parakeet or WhisperKit, was used for ${row.attempts} dictation or failure events over the last two weeks. That tracking tag may have stopped working.`
+        );
+      } else if (row.state === "alerting" && row.fastCrossing) {
+        alerts.push(
+          `In just the last 2 days, ${label} speech-to-text failed on ${pct(row.fastShare)} of attempts (${row.fastFails} of ${row.fastAttempts}). This crossed the alert line on both days, a sudden change worth a look even if the 2-week average still looks fine.`
         );
       } else if (row.state === "alerting") {
-        // Same fix as onboarding-abandon: name the window that actually
-        // crossed, and only attribute versions to a matching window.
-        const windowText = row.fastCrossing
-          ? `${pct(row.fastShare)} (${row.fastFails}/${row.fastAttempts}, fast 2-day crossing)`
-          : `${pct(row.rollingShare)} (${row.fails}/${row.attempts}, prev 14d, rolling crossing)`;
-        const tv = row.fastCrossing
-          ? ""
-          : topVersionsFor(backendVersions, "backend_trans_fail", { backend: row.backend });
+        const tv = topVersionsClause(r.backendVersions, "backend_trans_fail", r.backendVersionsDegraded, { backend: row.backend });
         alerts.push(
-          `${row.backend} transcription failure ${windowText}, ` +
-          `threshold >${pct(THRESHOLDS.backendTranscription.share)}.` + (tv ? ` Top versions ${tv}.` : "")
+          `${label} speech-to-text is failing more than usual: ${pct(row.rollingShare)} of attempts over the last two weeks (${row.fails} of ${row.attempts}). We alert above ${pct(THRESHOLDS.backendTranscription.share)}.${tv}`
         );
       }
-      note(`transcription-${row.backend}`, row);
+      note(`${label} speech-to-text`, row);
     }
-    if (r.backendTranscription.length === 0 && !r.backendAttributionBlackout) {
+    if (r.backendTranscription.length === 0 && !r.backendAttributionBlackout && !r.backendAttributionBlackoutUnavailable) {
       // Codex r5 review finding: an empty result during a genuinely
       // low-volume period (not blackout, since aggregate volume is also
       // low) never reaches the loop above, so the metric silently vanished
       // from evaluated/skipped/alerts instead of reading as skipped.
-      note("transcription-backend", { state: "skipped-low-volume" });
-    }
-    if (r.backendAttributionBlackout) {
-      // Total backend-attribution blackout (Codex review finding): the query
-      // matched zero (day, backend) groups despite healthy overall dictation
-      // volume — the per-backend split vanished entirely rather than reading
-      // as merely quiet.
-      alerts.push(
-        `transcription backend attribution blackout: 0 backend rows over the prev 14d despite ` +
-        `healthy aggregate 7d dictation volume (asr_backend/backend may have stopped emitting entirely).`
-      );
+      note("speech-to-text reliability by engine", { state: "skipped-low-volume" });
     }
   }
 
-  // Onboarding blackout (Phase 10, #1179) — evaluated-ok/alerting only, no
-  // low-volume/dark states, so it participates in `note()`'s evaluated bucket
-  // like the rate metrics, but can never land in skipped/dark.
+  // Speech-engine tracking (backend-attribution blackout)
+  if (r.backendAttributionBlackoutUnavailable) {
+    note("speech-engine tracking", { state: "temporarily-unavailable" });
+  } else if (r.backendAttributionBlackout) {
+    // Total backend-attribution blackout (Codex review finding): the query
+    // matched zero (day, backend) groups despite healthy overall dictation
+    // volume - the per-backend split vanished entirely rather than reading
+    // as merely quiet.
+    alerts.push(
+      `We can no longer tell which speech engine people are using at all, even though overall dictation volume looks normal. That tracking may have broken entirely.`
+    );
+  }
+
+  // Onboarding tracking (Phase 10, #1179) - evaluated-ok/alerting only, no
+  // low-volume/dark states normally, but CAN now be temporarily-unavailable.
   if (r.onboardingBlackout) {
     if (r.onboardingBlackout.state === "alerting") {
       if (r.onboardingBlackout.entryPointDown) {
         alerts.push(
-          `onboarding entry point down: 0 starts over the trailing 48h while the 7-day ` +
-          `baseline average is ${r.onboardingBlackout.baselineAvg.toFixed(1)}/day ` +
-          `(possible onboarding-screen crash or telemetry blackout).`
+          `There were no setup starts in the last 2 days, even though a typical day sees about ${r.onboardingBlackout.baselineAvg.toFixed(1)}. Either the setup screen is broken, or our own tracking is.`
         );
       }
       if (r.onboardingBlackout.terminalDrift) {
         alerts.push(
-          `onboarding terminal drift: ${r.onboardingBlackout.recentStarted} starts over the trailing 48h ` +
-          `but neither onboarding.completed nor onboarding.abandoned fired ` +
-          `(a terminal event may have stopped emitting).`
+          `There were ${r.onboardingBlackout.recentStarted} setup starts in the last 2 days, but none registered as either finishing or giving up. That tracking may be broken.`
         );
       }
     }
-    note("onboarding-blackout", r.onboardingBlackout);
+    note("onboarding tracking", r.onboardingBlackout);
   }
 
   // Volume / integrity
   if (r.volume.state === "alerting") {
     if (r.volume.zeroAlert) {
       alerts.push(
-        `ZERO dictations on T-1 while trailing-7d average is ${r.volume.avg.toFixed(0)}/day ` +
-        `(possible crash-on-launch or telemetry blackout).`
+        `No dictations were completed yesterday, even though a typical day sees about ${r.volume.avg.toFixed(0)}. This usually means either the app is crashing for everyone, or our own tracking is broken.`
       );
     }
     if (r.volume.driftAlert) {
       alerts.push(
-        `telemetry drift: T-1 had ${r.volume.t1d} dictations but asr.completed was 0 ` +
-        `(it co-fires on every successful dictation) - a success event may have stopped emitting.`
+        `Something looks broken in our own tracking: ${r.volume.t1d} dictations finished successfully yesterday, but a signal that should fire every time did not fire once. Today's numbers may not be trustworthy until this is fixed.`
       );
     }
   }
 
-  // Heartbeat line (always)
+  // Heartbeat block (always)
   const t1d = r.volume.t1d != null ? r.volume.t1d : "?";
-  const ratioStr =
-    r.volume.ratio != null ? ` (${r.volume.ratio.toFixed(2)}x trailing avg)` : "";
-  const driftStr =
-    r.latency.driftMedian != null && r.latency.latest
-      ? ` p50 drift: ${r.latency.latest.p50}s vs 14d ${r.latency.driftMedian.toFixed(2)}s`
+  const ratioClause =
+    r.volume.ratio == null
+      ? ""
+      : r.volume.ratio < 0.7
+        ? ", well below the usual amount"
+        : r.volume.ratio > 1.3
+          ? ", well above the usual amount"
+          : ", about the usual amount";
+  const responseSpeedLine =
+    r.latency.latest && r.latency.driftMedian != null
+      ? `\nResponse speed on the latest day with enough data: ${r.latency.latest.p50}s, compared with a 14-day median of ${r.latency.driftMedian.toFixed(2)}s.`
       : "";
-  const coverage =
-    `Evaluated: ${evaluated.join(", ") || "none"}.` +
-    (dark.length ? ` Dark: ${dark.join(", ")}.` : "") +
-    (skipped.length ? ` Skipped (low volume): ${skipped.join(", ")}.` : "");
-  const head = alerts.length ? "EnviousWispr health - ALERT" : "EnviousWispr health - OK";
-  // H1 (canonical contract H1): a static pointer, every run — this worker does
-  // NOT deliver crash-free-session-rate or per-version crash regression.
-  const h1Line = " Crash/error-rate monitoring lives in Sentry's own alert rules (see Error Spike >5/hr), not in this report.";
-  const heartbeat = `${head}. T-1: ${t1d} dictations${ratioStr}. ${coverage}${driftStr}${h1Line}`;
+  const coverageLine =
+    `Checked and normal: ${evaluated.join(", ") || "none"}.` +
+    (dark.length ? ` Waiting for enough eligible data: ${dark.join(", ")}.` : "") +
+    (skipped.length ? ` Not enough activity to judge: ${skipped.join(", ")}.` : "") +
+    (unavailable.length ? ` Temporarily unavailable: ${unavailable.join(", ")}.` : "");
+  // Codex diff review finding: a degraded-but-not-alerting run must NOT claim
+  // "everything looks normal" - that is exactly the partial-failure scenario
+  // this reliability fix introduces, and it would falsely reassure a founder
+  // skimming only the headline while checks silently couldn't run.
+  const headline = alerts.length
+    ? `found ${alerts.length} thing${alerts.length === 1 ? "" : "s"} worth a look`
+    : unavailable.length
+      ? `no problems found, but ${unavailable.length} check${unavailable.length === 1 ? "" : "s"} couldn't run today`
+      : "everything looks normal";
+  // `heartbeatHead` deliberately excludes the dashboard line: it is appended
+  // exactly once, as the final line, by each of the three return paths below
+  // - never duplicated, and never at risk of being truncated away (Codex
+  // review finding: a blind character slice can cut mid-alert and silently
+  // drop the dashboard link, hiding the very alerts most worth seeing - drop
+  // whole alerts from the end instead, always keeping the dashboard link).
+  const heartbeatHead =
+    `EnviousWispr health check for yesterday: ${headline}.\n` +
+    `${t1d} dictations were completed yesterday${ratioClause}.\n` +
+    `${coverageLine}${responseSpeedLine}\n` +
+    `Crashes and app errors are tracked separately and alert on their own. This check is only about product usage patterns.`;
 
-  if (!alerts.length) return heartbeat;
+  if (!alerts.length) return `${heartbeatHead}\nFull data: ${DASHBOARD}`;
 
-  // Discord content cap is 2000 chars. A blind character slice can cut mid-
-  // alert and silently drop the dashboard link, hiding the very alerts most
-  // worth seeing (Codex review finding) — drop whole alerts from the end
-  // instead, always keeping the heartbeat and the dashboard link.
   for (let keep = alerts.length; keep > 0; keep--) {
     const omitted = alerts.length - keep;
-    const trailer = omitted > 0 ? `\n(${omitted} more alert(s) omitted; see dashboard)` : "";
+    const trailer = omitted > 0 ? `\n(${omitted} more alert(s) omitted; see full data below.)` : "";
     const trial =
-      heartbeat + "\n\n" + alerts.slice(0, keep).map((a) => "* " + a).join("\n") + trailer + `\n${DASHBOARD}`;
+      heartbeatHead +
+      "\n\n" +
+      alerts.slice(0, keep).map((a) => "* " + a).join("\n") +
+      trailer +
+      `\nFull data: ${DASHBOARD}`;
     if (trial.length <= 1990) return trial;
   }
-  return `${heartbeat}\n\n${alerts.length} alert(s) triggered; see ${DASHBOARD}`.slice(0, 1990);
+  return `${heartbeatHead}\n\n${alerts.length} alert(s) triggered.\nFull data: ${DASHBOARD}`.slice(0, 1990);
 }
 
 // ----- Run ----------------------------------------------------------------
 
-async function runHealth(env) {
+// `deps` is a test-only injection seam (production passes nothing, both
+// defaults apply): `deps.evaluateHealthData` lets a test spy on it; `deps.
+// hogqlOpts` forwards into fetchHealth so a test can force an exhausted
+// retry deterministically instead of waiting through real backoff delays.
+export async function runHealth(env, deps = {}) {
+  const evaluateHealthDataFn = deps.evaluateHealthData || evaluateHealthData;
+  const hogqlOpts = deps.hogqlOpts || {};
+
   let data;
   try {
-    data = await fetchHealth(env);
+    data = await fetchHealth(env, hogqlOpts);
   } catch (err) {
-    // Loud failure: post a notice if Discord is reachable, then rethrow so
-    // Cloudflare logs it. A failed run must never read as "all green".
-    await safePost(env, `EnviousWispr health - CHECK FAILED TO RUN: ${err.message}`);
+    // Loud failure: post a plain-English notice if Discord is reachable, then
+    // rethrow so Cloudflare logs it. A failed run must never read as "all
+    // green". No claimed cause in the plain sentence (issue #1589): this path
+    // also carries auth failures, malformed SQL, malformed responses, and
+    // dev-id-list overflow, none of which are a timeout. Codex diff review
+    // finding: `err.message` (e.g. "PostHog query ref HTTP 503") must stay in
+    // the Cloudflare log for my own debugging, never in the Discord post -
+    // exposing raw HTTP/query-name jargon to the founder is exactly the
+    // unreadable-error-text problem this rewrite exists to remove.
+    console.log(`product-health check failed to run: ${err.message}`);
+    await safePost(env, "EnviousWispr health check didn't run today.");
     throw err;
   }
 
-  const backendTranscription = evaluateBackendTranscription(data.backendTranscriptionDays, data.t1ref);
-  // Backend-attribution blackout (Codex review finding): an empty result here
-  // means the query matched zero (day, backend) groups at all — every row's
-  // backend tag AND every dictation/failure vanished together. The existing
-  // aggregate transcription metric's own 7-day dictation count is proof this
-  // worker already has of real activity; if it's healthy while this metric's
-  // per-backend split came back with nothing, that split has silently gone
-  // dark rather than merely being quiet, so it must alert, not disappear.
-  const backendAttributionBlackout =
-    backendTranscription.length === 0 && num(data.seven.dictations_7d) >= THRESHOLDS.transcription.minDictations;
-
-  const results = {
-    latency: evaluateLatency(data.latencyDays),
-    paste: evaluatePaste(data.seven),
-    afm: evaluateAFM(data.seven),
-    transcription: evaluateTranscription(data.seven),
-    volume: evaluateVolume(data.volumeDays, data.t1ref),
-    onboardingAbandon: evaluateOnboardingAbandon(data.onboardingDays, data.t1ref),
-    backendTranscription,
-    backendAttributionBlackout,
-    onboardingBlackout: evaluateOnboardingBlackout(data.onboardingDays, data.t1ref),
-  };
-  const message = buildMessage(results, data.versions, data.onboardingVersions, data.backendVersions);
+  const results = evaluateHealthDataFn(data);
+  const message = buildMessage(results);
 
   const ok = await postToDiscord(env.DISCORD_WEBHOOK_URL, message);
   if (!ok) throw new Error("Discord post failed");

--- a/workers/product-health/test/health.test.js
+++ b/workers/product-health/test/health.test.js
@@ -1,4 +1,6 @@
-// Unit tests for the pure threshold/state logic (no network).
+// Unit tests for the pure threshold/state logic (no network) plus the
+// reliability machinery (issue #1589: concurrency cap, retry, resolve-once
+// dev exclusion, fail-soft degrade, evaluateHealthData, plain-English copy).
 // Run: node --test  (from workers/product-health/)
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -12,7 +14,15 @@ import {
   evaluateOnboardingAbandon,
   evaluateBackendTranscription,
   evaluateOnboardingBlackout,
+  evaluateHealthData,
   buildMessage,
+  hogql,
+  runLimited,
+  fetchHealth,
+  runHealth,
+  resolveDevIds,
+  productionClauseFor,
+  PostHogQueryError,
 } from "../src/index.js";
 
 // ---- latency ----
@@ -75,13 +85,13 @@ test("paste: below 50 total -> skipped", () => {
   assert.equal(evaluatePaste({ paste_total: 40, paste_cb: 30, paste_ax: 0 }).state, "skipped-low-volume");
 });
 
-// ---- AFM (dark / forward-looking) ----
-test("AFM: zero fr-bearing rows (pre-release) -> dark", () => {
+// ---- AFM data availability ----
+test("AFM: zero eligible fallback-reason rows -> dark", () => {
   const row = { afm_fr_rows: 0, afm_disc: 0 };
   assert.equal(evaluateAFM(row).state, "dark-awaiting-release");
 });
 
-test("AFM: release seen but too few rows -> skipped (not 0%)", () => {
+test("AFM: too few eligible fallback-reason rows -> skipped (not 0%)", () => {
   assert.equal(evaluateAFM({ afm_fr_rows: 20, afm_disc: 2 }).state, "skipped-low-volume");
 });
 
@@ -217,6 +227,14 @@ function results(over = {}) {
       afm: { state: "dark-awaiting-release" },
       transcription: { state: "evaluated-ok" },
       volume: { state: "evaluated-ok", t1d: 312, avg: 280, ratio: 1.11 },
+      versions: [],
+      onboardingVersions: [],
+      backendVersions: [],
+      versionsDegraded: false,
+      onboardingVersionsDegraded: false,
+      backendVersionsDegraded: false,
+      backendTranscriptionUnavailable: false,
+      backendAttributionBlackoutUnavailable: false,
     },
     over
   );
@@ -224,33 +242,38 @@ function results(over = {}) {
 
 test("message: clean day posts a heartbeat only, no alert block", () => {
   const msg = buildMessage(results());
-  assert.match(msg, /health - OK/);
-  assert.match(msg, /312 dictations/);
-  assert.match(msg, /Dark: AFM-discard/);
+  assert.match(msg, /everything looks normal/);
+  assert.match(msg, /312 dictations were completed yesterday/);
+  assert.match(msg, /Waiting for enough eligible data: Apple on-device polishing quality/);
   assert.ok(!msg.includes("\n\n*"), "no alert block on a clean day");
 });
 
-test("message: a crossing produces an ALERT header + block + dashboard link", () => {
+test("message: a crossing produces a found-N-things header + alert block + dashboard link", () => {
   const msg = buildMessage(
-    results({ paste: { state: "alerting", share: 0.065, fb: 17, cb: 7, ax: 10, total: 260 } }),
-    [{ ver: "v2.1.4", paste_fb: 12, trans_fail: 0, afm_disc: 0 }]
+    results({
+      paste: { state: "alerting", share: 0.065, fb: 17, cb: 7, ax: 10, total: 260 },
+      versions: [{ ver: "v2.1.4", paste_fb: 12, trans_fail: 0, afm_disc: 0 }],
+    })
   );
-  assert.match(msg, /health - ALERT/);
-  assert.match(msg, /paste fallback 6\.5%/);
-  assert.match(msg, /ax_denied 10, direct-paste-failed 7/);
-  assert.match(msg, /v2\.1\.4: 12/);
-  assert.match(msg, /dashboard/);
+  assert.match(msg, /found 1 thing worth a look/);
+  assert.match(msg, /Auto-paste is failing more than usual: 6\.5%/);
+  assert.match(msg, /10 were caused by a missing permission; 7 failed another way/);
+  assert.match(msg, /v2\.1\.4 \(12\)/);
+  assert.match(msg, /Full data: https:\/\/us\.posthog\.com/);
 });
 
-test("message: drift alert names asr.completed, not paste/asr (#1130)", () => {
+test("message: drift alert renders the tracking-broken wording, not the zero-dictations wording (#1130)", () => {
   const msg = buildMessage(
     results({
       volume: { state: "alerting", t1d: 200, avg: 200, ratio: 1.0, zeroAlert: false, driftAlert: true, asrDrift: true },
     })
   );
-  assert.match(msg, /health - ALERT/);
-  assert.match(msg, /asr\.completed was 0/);
-  assert.ok(!msg.includes("paste/asr"), "drift wording must not reference the dropped paste leg");
+  assert.match(msg, /found 1 thing worth a look/);
+  assert.match(msg, /a signal that should fire every time did not fire once/);
+  assert.ok(
+    !msg.includes("even though a typical day sees about"),
+    "drift wording must not also render the zero-dictations wording"
+  );
 });
 
 test("message: stays within Discord 2000-char cap", () => {
@@ -475,13 +498,12 @@ test("backend transcription: unknown backend with trivial volume does NOT trip d
 });
 
 // ---- message: Phase 10 additions ----
-test("message: H1 static pointer appears every run", () => {
+test("message: crash-tracking disclaimer appears every run", () => {
   const msg = buildMessage(results());
-  assert.match(msg, /Sentry's own alert rules/);
-  assert.match(msg, /Error Spike >5\/hr/);
+  assert.match(msg, /Crashes and app errors are tracked separately and alert on their own/);
 });
 
-test("message: onboarding-abandon alert renders and is not double-counted as evaluated", () => {
+test("message: onboarding-abandon alert renders and is not double-counted as checked-and-normal", () => {
   const msg = buildMessage(
     results({
       onboardingAbandon: {
@@ -490,8 +512,8 @@ test("message: onboarding-abandon alert renders and is not double-counted as eva
       },
     })
   );
-  assert.match(msg, /onboarding abandon 60\.0%/);
-  assert.ok(!msg.includes("Evaluated: onboarding-abandon"));
+  assert.match(msg, /60\.0% of setup attempts ended before setup was finished \(6 of 10\)/);
+  assert.ok(!/Checked and normal:[^\n]*onboarding completion/.test(msg));
 });
 
 test("message: onboarding-abandon fast crossing does not report the healthy rolling rate", () => {
@@ -503,7 +525,8 @@ test("message: onboarding-abandon fast crossing does not report the healthy roll
       },
     })
   );
-  assert.match(msg, /fast 2-day crossing/);
+  assert.match(msg, /In just the last 2 days/);
+  assert.match(msg, /sudden change worth a look/);
   assert.ok(!msg.includes("14.5%"), "must not display the healthy rolling share when the fast path fired");
 });
 
@@ -513,7 +536,7 @@ test("message: onboarding-abandon rolling crossing reports the rolling window", 
       onboardingAbandon: { state: "alerting", fastCrossing: false, rollingShare: 0.6, totalStarted: 40, totalAbandoned: 24 },
     })
   );
-  assert.match(msg, /rolling crossing/);
+  assert.match(msg, /Of the setup attempts started over the last three weeks/);
   assert.match(msg, /60\.0%/);
 });
 
@@ -526,30 +549,48 @@ test("message: per-backend transcription alerts name the backend and skip clean 
       ],
     })
   );
-  assert.match(msg, /whisperkit transcription failure 30\.0%/);
-  assert.ok(!msg.includes("parakeet transcription failure"));
-  assert.match(msg, /Evaluated:.*transcription-parakeet/);
+  assert.match(msg, /WhisperKit speech-to-text is failing more than usual: 30\.0%/);
+  assert.ok(!msg.includes("Parakeet speech-to-text is failing"));
+  assert.match(msg, /Checked and normal:[^\n]*Parakeet speech-to-text/);
 });
 
 test("message: empty per-backend result during genuine low volume reports skipped, not silence (Codex r5 fix)", () => {
   const msg = buildMessage(
     results({ backendTranscription: [], backendAttributionBlackout: false })
   );
-  assert.match(msg, /Skipped \(low volume\):.*transcription-backend/);
-  assert.ok(!msg.includes("attribution blackout"));
+  assert.match(msg, /Not enough activity to judge:[^\n]*speech-to-text reliability by engine/);
+  assert.ok(!msg.includes("We can no longer tell which speech engine"));
+});
+
+test("message: backend-transcription and blackout unavailable together render as unavailable, not alerts", () => {
+  const msg = buildMessage(
+    results({ backendTranscriptionUnavailable: true, backendAttributionBlackoutUnavailable: true })
+  );
+  assert.match(msg, /Temporarily unavailable:[^\n]*speech-to-text reliability by engine/);
+  assert.match(msg, /Temporarily unavailable:[^\n]*speech-engine tracking/);
+  // Codex diff review finding: a degraded-but-not-alerting run must NOT claim
+  // "everything looks normal" - that would falsely reassure a founder
+  // skimming only the headline while two checks silently couldn't run.
+  assert.match(msg, /no problems found, but 2 checks couldn't run today/);
+  assert.ok(!msg.includes("everything looks normal"));
+});
+
+test("message: a single unavailable check uses singular grammar in the headline", () => {
+  const msg = buildMessage(results({ afm: { state: "temporarily-unavailable" } }));
+  assert.match(msg, /no problems found, but 1 check couldn't run today/);
 });
 
 test("message: onboarding-blackout entry-point-down and terminal-drift render distinct wording", () => {
   const entryDown = buildMessage(
     results({ onboardingBlackout: { state: "alerting", entryPointDown: true, terminalDrift: false, recentStarted: 0, recentTerminals: 0, baselineAvg: 12 } })
   );
-  assert.match(entryDown, /onboarding entry point down/);
+  assert.match(entryDown, /There were no setup starts in the last 2 days/);
 
   const terminalDrift = buildMessage(
     results({ onboardingBlackout: { state: "alerting", entryPointDown: false, terminalDrift: true, recentStarted: 10, recentTerminals: 0, baselineAvg: 12 } })
   );
-  assert.match(terminalDrift, /onboarding terminal drift/);
-  assert.ok(!terminalDrift.includes("entry point down"));
+  assert.match(terminalDrift, /but none registered as either finishing or giving up/);
+  assert.ok(!terminalDrift.includes("no setup starts"));
 });
 
 test("message: many simultaneous alerts drop whole alerts from the end, never the dashboard link", () => {
@@ -570,7 +611,7 @@ test("message: many simultaneous alerts drop whole alerts from the end, never th
   assert.ok(msg.length <= 2000, `message must respect the Discord cap, got ${msg.length}`);
   assert.match(msg, /https:\/\/us\.posthog\.com\/project\/\d+\/dashboard\/\d+/, "dashboard link must always survive truncation");
   if (msg.includes("more alert(s) omitted")) {
-    assert.match(msg, /\d+ more alert\(s\) omitted; see dashboard/);
+    assert.match(msg, /\d+ more alert\(s\) omitted; see full data below\./);
   }
 });
 
@@ -578,11 +619,11 @@ test("message: onboarding screen-attribution drift renders distinct wording, no 
   const msg = buildMessage(
     results({
       onboardingAbandon: { state: "alerting", attributionDrift: true, fastCrossing: false, totalStarted: 100, totalAbandoned: 0, totalAbandonedRaw: 40, totalAbandonedMissingScreen: 40 },
-    }),
-    [], [{ ver: "v2.1.4", onboarding_abandon: 40 }]
+      onboardingVersions: [{ ver: "v2.1.4", onboarding_abandon: 40 }],
+    })
   );
-  assert.match(msg, /onboarding abandon attribution lost/);
-  assert.match(msg, /40 of 40 onboarding\.abandoned events/);
+  assert.match(msg, /We lost the ability to tell where setup was abandoned/);
+  assert.match(msg, /40 of 40 abandon events/);
   assert.ok(!msg.includes("v2.1.4"), "attribution-drift alert must not attach version data to a broken denominator");
 });
 
@@ -594,19 +635,21 @@ test("message: backend attribution drift (unknown backend) renders distinct word
       ],
     })
   );
-  assert.match(msg, /transcription backend attribution lost/);
+  assert.match(msg, /We lost track of which speech engine, Parakeet or WhisperKit, was used for 270/);
 });
 
 test("message: backend attribution blackout (empty result set) renders and alerts", () => {
   const msg = buildMessage(results({ backendTranscription: [], backendAttributionBlackout: true }));
-  assert.match(msg, /transcription backend attribution blackout/);
-  assert.match(msg, /health - ALERT/);
+  assert.match(msg, /We can no longer tell which speech engine people are using at all/);
+  assert.match(msg, /found 1 thing worth a look/);
 });
 
 test("message: fast-crossing alerts omit version attribution (window mismatch, Codex review finding)", () => {
   const onboardingMsg = buildMessage(
-    results({ onboardingAbandon: { state: "alerting", fastCrossing: true, fastStarted: 10, fastAbandoned: 6, fastShare: 0.6, rollingShare: 0.1, totalStarted: 300, totalAbandoned: 30 } }),
-    [], [{ ver: "v2.1.4", onboarding_abandon: 40 }]
+    results({
+      onboardingAbandon: { state: "alerting", fastCrossing: true, fastStarted: 10, fastAbandoned: 6, fastShare: 0.6, rollingShare: 0.1, totalStarted: 300, totalAbandoned: 30 },
+      onboardingVersions: [{ ver: "v2.1.4", onboarding_abandon: 40 }],
+    })
   );
   assert.ok(!onboardingMsg.includes("v2.1.4"), "a fast (2-day) crossing must not attribute to a 21-day version query");
 
@@ -615,8 +658,416 @@ test("message: fast-crossing alerts omit version attribution (window mismatch, C
       backendTranscription: [
         { backend: "parakeet", state: "alerting", fastCrossing: true, fastFails: 20, fastDictations: 10, fastAttempts: 30, fastShare: 0.67, rollingShare: 0.05, fails: 50, dictations: 950, attempts: 1000 },
       ],
-    }),
-    [], [], [{ ver: "v2.1.4", backend: "parakeet", backend_trans_fail: 40 }]
+      backendVersions: [{ ver: "v2.1.4", backend: "parakeet", backend_trans_fail: 40 }],
+    })
   );
   assert.ok(!backendMsg.includes("v2.1.4"), "a fast (2-day) crossing must not attribute to a 14-day version query");
+});
+
+test("message: a degraded version query preserves the core alert, only its top-versions clause changes", () => {
+  const msg = buildMessage(
+    results({
+      paste: { state: "alerting", share: 0.065, fb: 17, cb: 7, ax: 10, total: 260 },
+      versionsDegraded: true,
+    })
+  );
+  assert.match(msg, /Auto-paste is failing more than usual: 6\.5%/, "the core alert must still fire normally");
+  assert.match(msg, /We couldn't break this down by app version today\./);
+});
+
+// ---- runLimited (issue #1589 - PostHog's 3-concurrent-query project limit) ----
+test("runLimited: never exceeds the given concurrency and preserves input order", async () => {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const tasks = [1, 2, 3, 4, 5].map(
+    (n) => () =>
+      new Promise((resolve) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        // settle: fixed synthetic duration observed via the maxInFlight counter, not a wall-clock race
+        setTimeout(() => {
+          inFlight -= 1;
+          resolve(n);
+        }, 5);
+      })
+  );
+  const out = await runLimited(tasks, 2);
+  assert.deepEqual(out, [1, 2, 3, 4, 5]);
+  assert.ok(maxInFlight <= 2, `expected at most 2 concurrent tasks, saw ${maxInFlight}`);
+});
+
+test("runLimited: a failed wave rejects and never starts a later wave", async () => {
+  let laterWaveStarted = false;
+  const tasks = [
+    () => Promise.resolve("ok"),
+    () => Promise.reject(new Error("boom")),
+    () => {
+      laterWaveStarted = true;
+      return Promise.resolve("should not run");
+    },
+  ];
+  await assert.rejects(() => runLimited(tasks, 2), /boom/);
+  assert.equal(laterWaveStarted, false);
+});
+
+test("runLimited: rejects a non-positive-integer limit", async () => {
+  await assert.rejects(() => runLimited([() => Promise.resolve(1)], 0), TypeError);
+});
+
+// ---- hogql retry (issue #1589, ported from workers/daily-report #1588/#1720) ----
+function fakeResponse(status, body, { onCancel } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    body: onCancel ? { cancel: async () => onCancel() } : undefined,
+  };
+}
+
+const TEST_ENV = { POSTHOG_PROJECT_ID: "x", POSTHOG_PERSONAL_API_KEY: "k" };
+
+test("hogql: retries on 504, waits within the attempt-2 backoff range, then succeeds", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return calls === 1 ? fakeResponse(504) : fakeResponse(200, { results: [[1]] });
+  };
+  const sleeps = [];
+  const sleepFn = async (ms) => sleeps.push(ms);
+  const json = await hogql(TEST_ENV, "SELECT 1", "test_query", {
+    fetchFn,
+    sleepFn,
+    randomFn: () => 0, // pins the delay to the range floor for a deterministic assertion
+  });
+  assert.deepEqual(json.results, [[1]]);
+  assert.equal(calls, 2);
+  assert.deepEqual(sleeps, [12_000], "attempt 2's backoff floor is 12s");
+});
+
+test("hogql: retries on 429 (previously threw immediately)", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return calls === 1 ? fakeResponse(429) : fakeResponse(200, { results: [[1]] });
+  };
+  const json = await hogql(TEST_ENV, "SELECT 1", "test_query", { fetchFn, sleepFn: async () => {}, randomFn: () => 0 });
+  assert.deepEqual(json.results, [[1]]);
+  assert.equal(calls, 2);
+});
+
+test("hogql: cancels the failed response body before retrying", async () => {
+  let cancelled = false;
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    if (calls === 1) return fakeResponse(504, undefined, { onCancel: () => (cancelled = true) });
+    return fakeResponse(200, { results: [[1]] });
+  };
+  await hogql(TEST_ENV, "SELECT 1", "test_query", { fetchFn, sleepFn: async () => {}, randomFn: () => 0 });
+  assert.equal(cancelled, true);
+});
+
+test("hogql: does not retry on a non-transient 4xx status", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return fakeResponse(401);
+  };
+  await assert.rejects(
+    () => hogql(TEST_ENV, "SELECT 1", "test_query", { fetchFn, sleepFn: async () => {}, randomFn: () => 0 }),
+    (err) => err instanceof PostHogQueryError && err.status === 401
+  );
+  assert.equal(calls, 1, "a non-retryable status must not be retried");
+});
+
+test("hogql: throws with the query name after exhausting all 3 attempts on repeated 504", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return fakeResponse(504);
+  };
+  await assert.rejects(
+    () => hogql(TEST_ENV, "SELECT 1", "test_query", { fetchFn, sleepFn: async () => {}, randomFn: () => 0 }),
+    (err) => {
+      assert.ok(err instanceof PostHogQueryError);
+      assert.equal(err.queryName, "test_query");
+      assert.equal(err.status, 504);
+      return true;
+    }
+  );
+  assert.equal(calls, 3);
+});
+
+// ---- resolveDevIds / productionClauseFor (issue #1589, ported from daily-report #1720) ----
+test("resolveDevIds: accepts hogqlOpts so its own retry path is test-deterministic", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return calls === 1 ? fakeResponse(504) : fakeResponse(200, { results: [["dev-1"]] });
+  };
+  const ids = await resolveDevIds(TEST_ENV, { fetchFn, sleepFn: async () => {}, randomFn: () => 0 });
+  assert.deepEqual(ids, ["dev-1"]);
+  assert.equal(calls, 2);
+});
+
+test("resolveDevIds: throws on overflow rather than silently building a truncated exclusion list", async () => {
+  const manyIds = Array.from({ length: 5001 }, (_, i) => [`dev-${i}`]);
+  const fetchFn = async () => fakeResponse(200, { results: manyIds });
+  await assert.rejects(() => resolveDevIds(TEST_ENV, { fetchFn }), /dev-id completeness check failed/);
+});
+
+test("resolveDevIds: an empty result is a valid, non-throwing state", async () => {
+  const fetchFn = async () => fakeResponse(200, { results: [] });
+  const ids = await resolveDevIds(TEST_ENV, { fetchFn });
+  assert.deepEqual(ids, []);
+});
+
+test("productionClauseFor: empty dev-id list uses the bare environment filter, never NOT IN ()", () => {
+  const clause = productionClauseFor([]);
+  assert.doesNotMatch(clause, /NOT IN/);
+  assert.match(clause, /properties\.environment = 'production'/);
+});
+
+test("productionClauseFor: non-empty list appends a literal NOT IN exclusion", () => {
+  const clause = productionClauseFor(["dev-1", "dev-2"]);
+  assert.match(clause, /NOT IN \('dev-1', 'dev-2'\)/);
+});
+
+// ---- fetchHealth: fail-loud vs degradable queries (issue #1589) ----
+//
+// These MUST drive fetchHealth, not hogql in isolation - the dependency-
+// graph-aware degrade wiring these guard lives in fetchHealth's own
+// construction of the return object. fetchHealth calls hogql without an
+// injectable fetchFn of its own, so the mock installs on globalThis.fetch
+// and dispatches on the query name the worker puts in the request body.
+
+const DEFAULT_QUERY_RESPONSES = {
+  ref: { results: [["2026-07-17"]], columns: ["t1"] },
+  dev_ids: { results: [], columns: ["distinct_id"] },
+  latency: { results: [], columns: ["day", "n", "p50", "p95"] },
+  seven_day: {
+    results: [[0, 0, 0, 0, 0, 0, 0]],
+    columns: ["paste_total", "paste_cb", "paste_ax", "afm_fr_rows", "afm_disc", "trans_fails", "dictations_7d"],
+  },
+  volume: { results: [], columns: ["day", "dictations", "pastes", "asr"] },
+  versions: { results: [], columns: ["ver", "paste_fb", "trans_fail", "afm_disc"] },
+  onboarding: { results: [], columns: ["day", "started", "completed", "abandoned", "abandonedRaw", "abandonedMissingScreen"] },
+  backend_transcription: { results: [], columns: ["day", "backend", "dictations", "fails"] },
+  onboarding_versions: { results: [], columns: ["ver", "onboarding_abandon"] },
+  backend_versions: { results: [], columns: ["ver", "backend", "backend_trans_fail"] },
+};
+
+/** Installs a global fetch that lets every query succeed with a minimal
+ * valid shape and lets the caller decide what one named query does. Also
+ * transparently succeeds any non-PostHog call (the Discord webhook POST
+ * runHealth makes - its body is `{content}`, with no `.name` field, unlike
+ * every hogql() request body) so tests can drive runHealth end-to-end, not
+ * just fetchHealth. Returns a restore fn and any Discord post bodies
+ * captured. */
+function mockPostHog({ failQuery, failWith }) {
+  const realFetch = globalThis.fetch;
+  const discordPosts = [];
+  globalThis.fetch = async (_url, init) => {
+    const body = init?.body ? JSON.parse(init.body) : {};
+    if (!body.name) {
+      if (typeof body.content === "string") discordPosts.push(body.content);
+      return fakeResponse(204); // Discord webhook success shape, not a PostHog call
+    }
+    const queryName = body.name.replace(/^product_health_/, "");
+    if (queryName === failQuery) {
+      if (failWith instanceof Error) throw failWith;
+      return fakeResponse(failWith);
+    }
+    const shape = DEFAULT_QUERY_RESPONSES[queryName] || { results: [], columns: [] };
+    return fakeResponse(200, shape);
+  };
+  return { restore: () => (globalThis.fetch = realFetch), discordPosts };
+}
+
+for (const queryName of ["ref", "dev_ids", "volume"]) {
+  test(`fetchHealth: ${queryName} exhausting retries fails the whole run (fail-loud)`, async () => {
+    const mock = mockPostHog({ failQuery: queryName, failWith: 504 });
+    try {
+      await assert.rejects(
+        () => fetchHealth(TEST_ENV, { sleepFn: async () => {} }),
+        new RegExp(`PostHog query ${queryName} HTTP 504`)
+      );
+    } finally {
+      mock.restore();
+    }
+  });
+}
+
+const DEGRADABLE_QUERY_FLAGS = {
+  latency: "latencyDegraded",
+  seven_day: "sevenDayDegraded",
+  versions: "versionsDegraded",
+  onboarding: "onboardingDegraded",
+  backend_transcription: "backendTranscriptionDegraded",
+  onboarding_versions: "onboardingVersionsDegraded",
+  backend_versions: "backendVersionsDegraded",
+};
+
+for (const [queryName, flag] of Object.entries(DEGRADABLE_QUERY_FLAGS)) {
+  test(`fetchHealth: ${queryName} exhausting retries degrades only its own flag (${flag})`, async () => {
+    const mock = mockPostHog({ failQuery: queryName, failWith: 504 });
+    try {
+      const data = await fetchHealth(TEST_ENV, { sleepFn: async () => {} });
+      assert.equal(data[flag], true, `expected ${flag} to be true`);
+      for (const otherFlag of Object.values(DEGRADABLE_QUERY_FLAGS)) {
+        if (otherFlag !== flag) assert.equal(data[otherFlag], false, `expected ${otherFlag} to stay false`);
+      }
+    } finally {
+      mock.restore();
+    }
+  });
+
+  test(`fetchHealth: ${queryName} a NON-retryable failure (401) still throws, no silent swallow`, async () => {
+    const mock = mockPostHog({ failQuery: queryName, failWith: 401 });
+    try {
+      await assert.rejects(
+        () => fetchHealth(TEST_ENV, { sleepFn: async () => {} }),
+        (err) => err instanceof PostHogQueryError && err.status === 401
+      );
+    } finally {
+      mock.restore();
+    }
+  });
+}
+
+test("fetchHealth: a clean run leaves every degrade flag false", async () => {
+  const mock = mockPostHog({ failQuery: null });
+  try {
+    const data = await fetchHealth(TEST_ENV, { sleepFn: async () => {} });
+    for (const flag of Object.values(DEGRADABLE_QUERY_FLAGS)) {
+      assert.equal(data[flag], false, `expected ${flag} to be false on a clean run`);
+    }
+  } finally {
+    mock.restore();
+  }
+});
+
+// ---- evaluateHealthData (issue #1589): single owner of degrade-then-evaluate wiring ----
+function healthData(over = {}) {
+  return Object.assign(
+    {
+      latencyDays: [{ day: "2026-07-15", n: 200, p50: 1.5, p95: 4.9 }],
+      latencyDegraded: false,
+      seven: { paste_total: 1000, paste_cb: 9, paste_ax: 3, afm_fr_rows: 100, afm_disc: 10, trans_fails: 14, dictations_7d: 1500 },
+      sevenDayDegraded: false,
+      volumeDays: [{ day: "2026-07-15", dictations: 300, pastes: 300, asr: 300 }],
+      versions: [],
+      versionsDegraded: false,
+      t1ref: "2026-07-15",
+      onboardingDays: [{ day: "2026-07-15", started: 50, completed: 40, abandoned: 5, abandonedRaw: 5, abandonedMissingScreen: 0 }],
+      onboardingDegraded: false,
+      backendTranscriptionDays: { parakeet: [{ day: "2026-07-15", dictations: 300, fails: 5 }] },
+      backendTranscriptionDegraded: false,
+      onboardingVersions: [],
+      onboardingVersionsDegraded: false,
+      backendVersions: [],
+      backendVersionsDegraded: false,
+    },
+    over
+  );
+}
+
+test("evaluateHealthData: sevenDayDegraded disables paste+afm+transcription together and makes the blackout check uncheckable", () => {
+  const r = evaluateHealthData(healthData({ sevenDayDegraded: true }));
+  assert.equal(r.paste.state, "temporarily-unavailable");
+  assert.equal(r.afm.state, "temporarily-unavailable");
+  assert.equal(r.transcription.state, "temporarily-unavailable");
+  assert.equal(r.backendAttributionBlackoutUnavailable, true);
+  assert.equal(r.backendAttributionBlackout, false, "must never fabricate a blackout when it can't be checked");
+  // Unrelated metrics stay real.
+  assert.equal(r.latency.state, "evaluated-ok");
+});
+
+test("evaluateHealthData: onboardingDegraded disables both onboarding checks together", () => {
+  const r = evaluateHealthData(healthData({ onboardingDegraded: true }));
+  assert.equal(r.onboardingAbandon.state, "temporarily-unavailable");
+  assert.equal(r.onboardingBlackout.state, "temporarily-unavailable");
+});
+
+test("evaluateHealthData: backendTranscriptionDegraded can never fabricate a blackout reading", () => {
+  const r = evaluateHealthData(healthData({ backendTranscriptionDegraded: true }));
+  assert.deepEqual(r.backendTranscription, []);
+  assert.equal(r.backendTranscriptionUnavailable, true);
+  assert.equal(r.backendAttributionBlackoutUnavailable, true);
+  assert.equal(r.backendAttributionBlackout, false);
+});
+
+test("evaluateHealthData: latencyDegraded is independent of every other metric", () => {
+  const r = evaluateHealthData(healthData({ latencyDegraded: true }));
+  assert.equal(r.latency.state, "temporarily-unavailable");
+  assert.equal(r.paste.state, "evaluated-ok");
+  assert.equal(r.onboardingAbandon.state, "evaluated-ok");
+});
+
+test("evaluateHealthData: a clean run carries the version arrays through untouched", () => {
+  const data = healthData({
+    versions: [{ ver: "v2.1.4", paste_fb: 5 }],
+    onboardingVersions: [{ ver: "v2.1.4", onboarding_abandon: 3 }],
+    backendVersions: [{ ver: "v2.1.4", backend: "parakeet", backend_trans_fail: 1 }],
+  });
+  const r = evaluateHealthData(data);
+  assert.deepEqual(r.versions, data.versions);
+  assert.deepEqual(r.onboardingVersions, data.onboardingVersions);
+  assert.deepEqual(r.backendVersions, data.backendVersions);
+});
+
+// ---- runHealth (issue #1589): plain failure notice, no claimed cause, no raw error text on Discord ----
+test("runHealth: an exhausted retryable failure posts a plain notice with no technical detail, logs the detail instead, and rethrows", async () => {
+  const mock = mockPostHog({ failQuery: "volume", failWith: 504 });
+  const realConsoleLog = console.log;
+  const logged = [];
+  console.log = (...args) => logged.push(args.join(" "));
+  try {
+    await assert.rejects(
+      () =>
+        runHealth(
+          { ...TEST_ENV, DISCORD_WEBHOOK_URL: "https://discord.example/webhook" },
+          { hogqlOpts: { sleepFn: async () => {} } }
+        ),
+      /PostHog query volume HTTP 504/
+    );
+    assert.equal(mock.discordPosts.length, 1);
+    assert.equal(mock.discordPosts[0], "EnviousWispr health check didn't run today.");
+    assert.ok(
+      !mock.discordPosts[0].includes("didn't respond in time"),
+      "must not claim a specific cause for a failure class that also covers auth/malformed-response/overflow errors"
+    );
+    // Codex diff review finding: raw HTTP/query-name jargon must never reach
+    // the founder-facing Discord post - it belongs only in the Cloudflare log.
+    assert.ok(
+      !/PostHog|HTTP \d/.test(mock.discordPosts[0]),
+      "must not expose raw PostHog error text on Discord"
+    );
+    assert.ok(
+      logged.some((line) => line.includes("PostHog query volume HTTP 504")),
+      "the technical detail must still be logged for debugging, just not posted to Discord"
+    );
+  } finally {
+    console.log = realConsoleLog;
+    mock.restore();
+  }
+});
+
+test("runHealth: a clean run calls evaluateHealthData exactly once and posts a real heartbeat", async () => {
+  const mock = mockPostHog({ failQuery: null });
+  let calls = 0;
+  const spy = (data) => {
+    calls += 1;
+    return evaluateHealthData(data);
+  };
+  try {
+    const message = await runHealth(
+      { ...TEST_ENV, DISCORD_WEBHOOK_URL: "https://discord.example/webhook" },
+      { evaluateHealthData: spy, hogqlOpts: { sleepFn: async () => {} } }
+    );
+    assert.equal(calls, 1);
+    assert.match(message, /EnviousWispr health check for yesterday/);
+  } finally {
+    mock.restore();
+  }
 });


### PR DESCRIPTION
## Summary
- Ports `workers/daily-report`'s already-shipped concurrency cap, retry, resolve-once dev-id exclusion, and fail-soft degrade (#1588/#1655/#1716/#1720) into `workers/product-health`, which fired 9 PostHog queries in one uncapped `Promise.all` and discarded the whole run on a single transient failure.
- Adds `evaluateHealthData()` as the single owner of dependency-aware degrade-then-evaluate wiring, shared by production and `live-query-smoke.mjs` (closes a drift where the smoke script silently omitted the backend-attribution-blackout check).
- Rewrites `buildMessage()`'s Discord output from technical jargon into plain English (founder-reported: "the output is far too technical and I don't understand what it's telling me").
- Removes `product-health-ping.yml`'s outer `curl --retry`, which could rerun the whole invocation and post duplicate/contradictory Discord notices, and adds a workflow concurrency group, matching `daily-report-ping.yml`'s own precedent.

Plan (5 grounded-review rounds to PROCEED-AS-PLANNED): `docs/feature-requests/issue-1589-2026-07-24-product-health-reliability-and-plain-english.md`. Closes #1589.

## Test plan
- [x] `node --test` from `workers/product-health/`: 102/102 passing (61 pre-existing + 41 new, including retry/concurrency/degrade coverage)
- [x] Filtered `actionlint` clean on both workflow files (works around `actionlint` 1.7.12's `queue` key schema lag)
- [x] Local Codex whole-diff review: 2 rounds, round 2 clean (round 1 caught a misleading "everything looks normal" headline on a degraded-but-not-alerting run, and raw PostHog error text leaking into the Discord failure notice — both fixed)
- [x] Live smoke run against real production PostHog from this branch: all 9 queries succeeded, zero degradation, heartbeat renders as plain English (verified against the exact AFM-discard alert from the founder's original screenshot)
- [ ] GitHub cloud Codex review
- [ ] Manual `npx wrangler deploy` after merge (this worker has no auto-deploy workflow) + one real triggered run verified in Discord