### PR TITLE
fix(release): unblock v2.4.1 — sync third-party notices, ship Custom Words import/export

### DIFF
--- a/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
+++ b/Sources/EnviousWisprAppKit/App/CustomWordsImportFlowModel.swift
@@ -7,9 +7,7 @@ import Foundation
 ///
 /// Owns which screen the sheet shows, which method the user picked, the review
 /// rows and their decisions, and the load → compare → review → commit
-/// sequence. Real input sources arrive later (P1 paste, U1 upload, 4a smart
-/// import); PR-P1 also inserts its enrichment stage between compare and
-/// review by editing this model directly — no seam is pre-built for it here.
+/// sequence shared by Paste, Open a file, and From another app.
 ///
 /// Invariant: `selectedMethod` is non-nil exactly while a method's flow is
 /// active; returning to `.methodPicker` (via `goBack()` or `reset()`) clears it.

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -125,23 +125,22 @@ public final class WisprBootstrapper {
       aliasSuggester: customWordsCoordinator.aliasSuggester)
     // #1701 Chunk 2: bulk-import-enrichment producer, a sibling of
     // `contactsImportCoordinator` on the same alias-suggester permit lane.
-    // Construction is unconditional; the DEBUG gate below controls scanning.
+    // Construction and scanning are both unconditional: without this wiring
+    // `onImportCommitted` stays nil and a committed import never enriches.
     let bulkImportEnrichmentCoordinator = BulkImportEnrichmentCoordinator(
       customWords: customWordsCoordinator,
       aliasSuggester: customWordsCoordinator.aliasSuggester,
       presentStatus: { [weak recordingOverlay] message in
         recordingOverlay?.showImportStatus(message: message)
       })
-    #if DEBUG
-      customWordsCoordinator.onImportCommitted = { [weak bulkImportEnrichmentCoordinator] in
-        bulkImportEnrichmentCoordinator?.requestDrain()
-      }
-      customWordsCoordinator.cancelBulkImportEnrichment = {
-        [weak bulkImportEnrichmentCoordinator] in
-        bulkImportEnrichmentCoordinator?.cancel()
-      }
-      bulkImportEnrichmentCoordinator.requestDrain()
-    #endif
+    customWordsCoordinator.onImportCommitted = { [weak bulkImportEnrichmentCoordinator] in
+      bulkImportEnrichmentCoordinator?.requestDrain()
+    }
+    customWordsCoordinator.cancelBulkImportEnrichment = {
+      [weak bulkImportEnrichmentCoordinator] in
+      bulkImportEnrichmentCoordinator?.cancel()
+    }
+    bulkImportEnrichmentCoordinator.requestDrain()
     let customWordsPropagator = CustomWordsPropagator()
     // #633 Phase 9: owns enabled vocabulary-pack state; merges pack terms into
     // the corrector lane (default OFF). Wired into `wireCustomWords` below.

--- a/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
+++ b/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
@@ -554,7 +554,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Sparkle
-  Version: 2.9.3
+  Version: 2.9.4
   License: MIT (with bundled BSD/MIT components)
   Source:  https://github.com/sparkle-project/Sparkle
 --------------------------------------------------------------------------------
@@ -700,6 +700,226 @@ swift-argument-parser
   Version: 1.7.1
   License: Apache-2.0
   Source:  https://github.com/apple/swift-argument-parser
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+
+    As an exception, if you use this Software to compile your source code and
+    portions of this Software are embedded into the binary product as a result,
+    you may redistribute such product without providing attribution as would
+    otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+
+--------------------------------------------------------------------------------
+swift-syntax
+  Version: 603.0.2
+  License: Apache-2.0
+  Source:  https://github.com/swiftlang/swift-syntax
 --------------------------------------------------------------------------------
 
                                  Apache License

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportNotice.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportNotice.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Export-outcome-to-message mapping (#1703), extracted from the previously
-/// private, DEBUG-only `YourWordsView.ExportNotice` so a release-visible
-/// caller (`BulkDeleteConfirmSheet`) can present the identical copy. Two
+/// private `YourWordsView.ExportNotice` so both export entry points
+/// (`YourWordsView` and `BulkDeleteConfirmSheet`) present identical copy. Two
 /// kinds, deliberately: a real failure, and an honest outcome that is not a
 /// failure. Sharing one "Export didn't finish" title for both would tell a
 /// pack-only user their export broke when it worked exactly as designed

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -6,12 +6,11 @@ import SwiftUI
 ///
 /// One observable model, one root `switch`, one container-level `.animation()`
 /// — the `OnboardingV2View` root-switch pattern without its timers or
-/// permissions logic. The three input screens are still placeholders until
-/// their real sources land (P1 paste, U1 upload, 4a smart import); Review and
-/// the commit path are real from F2c on.
+/// permissions logic. Paste, file, and supported-app sources all feed the same
+/// review and commit path.
 ///
-/// The sheet is reachable only through the DEBUG-only "Import" button
-/// in Your Words, so no release user can see the remaining placeholders.
+/// The sheet is reachable through the "Import" button in Your Words, shipped to
+/// release users from v2.4.1.
 /// Dismissing at any point cancels in-flight work and writes nothing.
 struct CustomWordsImportSheet: View {
   private static let screenTransition: AnyTransition = .asymmetric(
@@ -636,11 +635,12 @@ private struct ImportSmartAppPickerScreen: View {
   }
 }
 
-// MARK: - Input placeholders (replaced wholesale by the real source PRs)
+// MARK: - DEBUG fixture preview
 
-/// Shared placeholder for the three input screens. In DEBUG it walks the real
-/// pipeline using a fixture source, so the whole flow is exercisable before
-/// any real source exists; in a release build there is no way to reach it.
+/// Test-only fixture launcher retained for focused DEBUG walkthroughs. The
+/// production Paste, Open a file, and From another app sources are wired above;
+/// the fixture button inside this screen is DEBUG-only and unreachable in a
+/// release build.
 private struct ImportPlaceholderScreen: View {
   let notice: String
   let model: CustomWordsImportFlowModel

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -240,17 +240,12 @@ struct UnifiedWindowView: View {
   /// The load-bearing notification surface for a background bulk-import
   /// enrichment run (#1701 Chunk 2, plan §3.1 point 6): independent of
   /// whether either transient pill was ever seen, this badge tells the
-  /// founder something is in progress just by opening Settings at all.
-  /// DEBUG-only because the whole import feature is (§316). Reads
+  /// user something is in progress just by opening Settings at all. Reads
   /// `pendingEnrichmentCount` (observable in-memory), never the total's mere
   /// presence — same reasoning as the progress card (Codex Chunk 2 review
   /// finding 5).
   private func yourWordsEnrichmentBadgeVisible(for section: SettingsSection) -> Bool {
-    #if DEBUG
-      section == .wordCorrection && customWordsCoordinator.pendingEnrichmentCount > 0
-    #else
-      false
-    #endif
+    section == .wordCorrection && customWordsCoordinator.pendingEnrichmentCount > 0
   }
 
   /// The centered top-bar identity: the brand mark plus the app wordmark. Held

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -20,7 +20,7 @@ enum WhatsNewContent {
       icon: "arrow.down.doc",
       title: "Bring your words over from another dictation app",
       description:
-        "Switching no longer means retyping your vocabulary. Pick the app you used before and your words come across, including the misspellings you had it watch for. FluidVoice, Superwhisper and Wispr Flow are supported today, with more on the way, and only apps actually installed on your Mac are offered. Nothing on your disk is touched until you choose one, and nothing is added to your words until you review and approve it. Once they are in, EnviousWispr suggests sound-alike spellings for them automatically, so dictation picks them up without a second pass by hand.",
+        "Switching no longer means retyping your vocabulary. Pick the app you used before and your words come across, including the misspellings you had it watch for. FluidVoice, Superwhisper and Wispr Flow are supported today, with more on the way, and only apps actually installed on your Mac are offered. Nothing on your disk is touched until you choose one, and nothing is added to your words until you review and approve it. On Macs where Apple Intelligence is available, EnviousWispr also suggests sound-alike spellings for your new words automatically, so dictation picks them up without a second pass by hand.",
       version: "2.4.1"
     ),
     Entry(
@@ -28,7 +28,7 @@ enum WhatsNewContent {
       icon: "square.and.arrow.down",
       title: "Import words from a file, or just paste a list",
       description:
-        "Upload a words file or a plain text file, or paste a list straight in. Every route lands on the same review screen, so you see exactly what will be added, what is already yours, and what clashes, before anything changes. Imported words get their sound-alike spellings suggested automatically too.",
+        "Upload a words file or a plain text file, or paste a list straight in. Every route lands on the same review screen, so you see exactly what will be added, what is already yours, and what clashes, before anything changes. On Macs where Apple Intelligence is available, new words can also get automatic sound-alike suggestions.",
       version: "2.4.1"
     ),
     Entry(

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -24,13 +24,9 @@ struct YourWordsView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var sheetRoute: YourWordsSheetRoute?
-  #if DEBUG
-    // Outcome-to-message mapping moved to shared `CustomWordsExportNotice`
-    // (#1703) so `BulkDeleteConfirmSheet`'s release-visible export offer can
-    // present the identical copy. This button stays DEBUG-only; only the
-    // mapping it reads from is now shared, not private.
-    @State private var exportNotice: CustomWordsExportNotice?
-  #endif
+  // Outcome-to-message mapping is shared with `BulkDeleteConfirmSheet` so both
+  // export entry points present the identical copy (#1703).
+  @State private var exportNotice: CustomWordsExportNotice?
 
   var body: some View {
     @Bindable var settings = settings
@@ -50,45 +46,28 @@ struct YourWordsView: View {
         } label: {
           Label("Add term", systemImage: "plus")
         }
-        #if DEBUG
-          // The ONLY doorway into Custom Words import, and deliberately
-          // DEBUG-only.
-          //
-          // This is founder policy, not an oversight or an unfinished edge
-          // (epic #1619, restated 2026-07-19): the whole import feature is
-          // compiled out of release builds until the founder decides it ships,
-          // and every import PR carries "adds no second entry point" in its
-          // definition of done. The mechanism is compile-time exclusion rather
-          // than a runtime toggle precisely because a runtime toggle ships in
-          // release and is user-discoverable — the exact bleed being avoided.
-          //
-          // Reviewers reasonably read a real, working, unreachable feature as
-          // a bug — it was raised as a P1 on #1681 — so the reason lives here,
-          // next to the gate, rather than only in the issue tracker. Removing
-          // this gate is a founder decision, not a code-review one.
-          Button {
-            sheetRoute = .importWords
-          } label: {
-            Label("Import", systemImage: "square.and.arrow.down")
-          }
-          // Export (#1680). Also DEBUG-only: the whole import/export feature is
-          // compiled out of release builds until the founder ships it, and a
-          // release-visible Export whose companion Import is invisible would be
-          // half a promise.
-          // ONE body-render snapshot drives both the count shown in the save
-          // dialog and the array handed to the action, so the number the user
-          // reads and the bytes written cannot come from different moments
-          // (#1697). The sentence itself lives in the dialog, not on this
-          // screen: a paragraph wedged between two buttons competes with them
-          // (#1715).
-          let proposed = CustomWordsExportAction.exportableWords(
-            from: customWordsCoordinator.customWords)
-          Button {
-            exportWords(proposed: proposed)
-          } label: {
-            Label("Export your words", systemImage: "square.and.arrow.up")
-          }
-        #endif
+        // The ONLY doorway into Custom Words import (epic #1619). Shipped to
+        // release users from v2.4.1 by founder decision, 2026-07-24; every
+        // import PR still carries "adds no second entry point" in its
+        // definition of done, so this stays the single doorway.
+        Button {
+          sheetRoute = .importWords
+        } label: {
+          Label("Import", systemImage: "square.and.arrow.down")
+        }
+        // Export (#1680). ONE body-render snapshot drives both the count shown
+        // in the save dialog and the array handed to the action, so the number
+        // the user reads and the bytes written cannot come from different
+        // moments (#1697). The sentence itself lives in the dialog, not on this
+        // screen: a paragraph wedged between two buttons competes with them
+        // (#1715).
+        let proposed = CustomWordsExportAction.exportableWords(
+          from: customWordsCoordinator.customWords)
+        Button {
+          exportWords(proposed: proposed)
+        } label: {
+          Label("Export your words", systemImage: "square.and.arrow.up")
+        }
       }
 
       // Master toggle (preserves the Enable custom words switch from the old view)
@@ -110,48 +89,39 @@ struct YourWordsView: View {
         }
       }
 
-      #if DEBUG
-        // Same DEBUG-only doorway as the rest of the import feature (#1619):
-        // this card can only ever appear if the DEBUG-only "Import"
-        // button above committed a batch, so it stays behind the same gate
-        // rather than a redundant runtime check.
-        //
-        // Visibility and the progress numerator both read `pendingEnrichmentCount`
-        // — the observable in-memory count, never `pendingEnrichmentWords()`
-        // (a real locked file read) and never the total's mere presence
-        // (Codex Chunk 2 review finding 5: neither belongs in a SwiftUI
-        // `body`, and the durable total can theoretically lag live state
-        // during the brief self-heal window). The durable total remains the
-        // denominator when available, falling back to the live count itself
-        // as an honest floor if the total is momentarily nil.
-        let pendingCount = customWordsCoordinator.pendingEnrichmentCount
-        if pendingCount > 0 {
-          BulkImportEnrichmentProgressCard(
-            total: customWordsCoordinator.pendingEnrichmentBatchTotal ?? pendingCount,
-            pendingCount: pendingCount,
-            recent: customWordsCoordinator.mostRecentEnrichment,
-            onCancel: { customWordsCoordinator.cancelBulkImportEnrichment?() }
-          )
-        }
-      #endif
+      // Visibility and the progress numerator both read `pendingEnrichmentCount`
+      // — the observable in-memory count, never `pendingEnrichmentWords()`
+      // (a real locked file read) and never the total's mere presence
+      // (Codex Chunk 2 review finding 5: neither belongs in a SwiftUI
+      // `body`, and the durable total can theoretically lag live state
+      // during the brief self-heal window). The durable total remains the
+      // denominator when available, falling back to the live count itself
+      // as an honest floor if the total is momentarily nil.
+      let pendingCount = customWordsCoordinator.pendingEnrichmentCount
+      if pendingCount > 0 {
+        BulkImportEnrichmentProgressCard(
+          total: customWordsCoordinator.pendingEnrichmentBatchTotal ?? pendingCount,
+          pendingCount: pendingCount,
+          recent: customWordsCoordinator.mostRecentEnrichment,
+          onCancel: { customWordsCoordinator.cancelBulkImportEnrichment?() }
+        )
+      }
 
       LearningSection()
       VocabPacksSection()
       CustomTermsSection()
     }
-    #if DEBUG
-      .alert(
-        exportNotice?.title ?? "",
-        isPresented: Binding(
-          get: { exportNotice != nil },
-          set: { if !$0 { exportNotice = nil } }
-        )
-      ) {
-        Button("OK", role: .cancel) { exportNotice = nil }
-      } message: {
-        Text(exportNotice?.message ?? "")
-      }
-    #endif
+    .alert(
+      exportNotice?.title ?? "",
+      isPresented: Binding(
+        get: { exportNotice != nil },
+        set: { if !$0 { exportNotice = nil } }
+      )
+    ) {
+      Button("OK", role: .cancel) { exportNotice = nil }
+    } message: {
+      Text(exportNotice?.message ?? "")
+    }
     .sheet(item: $sheetRoute) { route in
       switch route {
       case .addTerm:
@@ -174,32 +144,29 @@ struct YourWordsView: View {
     }
   }
 
-  #if DEBUG
-    /// Export the user's own words (#1680).
-    ///
-    /// Order matters: the destination is chosen first, and only then is the
-    /// word list snapshotted — so cancelling reads nothing and writes nothing.
-    /// Built-ins are excluded; what ships is what the user authored or edited,
-    /// which is the only scope whose restore path this app can actually honor.
-    private func exportWords(proposed: [CustomWord]) {
-      // The decision lives in CustomWordsExportAction so the ORDER of its
-      // steps is testable; this is just the wiring (#1680).
-      Task {
-        let outcome = await CustomWordsExportAction.run(
-          coordinator: customWordsCoordinator,
-          proposedExportWords: proposed,
-          chooseDestination: {
-            CustomWordsExportPanel.chooseDestination(exportableCount: proposed.count)
-          },
-          write: { document, destination in
-            try await CustomWordsExportWriter.write(document, to: destination)
-          }
-        )
-        exportNotice = CustomWordsExportNotice.forOutcome(outcome)
-      }
+  /// Export the user's own words (#1680).
+  ///
+  /// Order matters: the destination is chosen first, and only then is the
+  /// word list snapshotted — so cancelling reads nothing and writes nothing.
+  /// Built-ins are excluded; what ships is what the user authored or edited,
+  /// which is the only scope whose restore path this app can actually honor.
+  private func exportWords(proposed: [CustomWord]) {
+    // The decision lives in CustomWordsExportAction so the ORDER of its
+    // steps is testable; this is just the wiring (#1680).
+    Task {
+      let outcome = await CustomWordsExportAction.run(
+        coordinator: customWordsCoordinator,
+        proposedExportWords: proposed,
+        chooseDestination: {
+          CustomWordsExportPanel.chooseDestination(exportableCount: proposed.count)
+        },
+        write: { document, destination in
+          try await CustomWordsExportWriter.write(document, to: destination)
+        }
+      )
+      exportNotice = CustomWordsExportNotice.forOutcome(outcome)
     }
-
-  #endif
+  }
 
   private func saveNewWord(_ newWord: CustomWord) -> String? {
     let trimmedCanonical = newWord.canonical.trimmingCharacters(in: .whitespaces)

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -554,7 +554,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Sparkle
-  Version: 2.9.3
+  Version: 2.9.4
   License: MIT (with bundled BSD/MIT components)
   Source:  https://github.com/sparkle-project/Sparkle
 --------------------------------------------------------------------------------
@@ -700,6 +700,226 @@ swift-argument-parser
   Version: 1.7.1
   License: Apache-2.0
   Source:  https://github.com/apple/swift-argument-parser
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+
+    As an exception, if you use this Software to compile your source code and
+    portions of this Software are embedded into the binary product as a result,
+    you may redistribute such product without providing attribution as would
+    otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+
+--------------------------------------------------------------------------------
+swift-syntax
+  Version: 603.0.2
+  License: Apache-2.0
+  Source:  https://github.com/swiftlang/swift-syntax
 --------------------------------------------------------------------------------
 
                                  Apache License

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -40,8 +40,14 @@ COMPONENTS=(
   "FluidAudio|e7948e1a (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
   "PostHog iOS|3.62.4|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
   "Sentry Cocoa|9.19.0|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
-  "Sparkle|2.9.3|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"
+  "Sparkle|2.9.4|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"
   "swift-argument-parser|1.7.1|Apache-2.0|swift-argument-parser/LICENSE.txt|https://github.com/apple/swift-argument-parser|swift-argument-parser"
+  # #1741: test-only — the freeze test's Swift parser. Never linked into the
+  # shipped app (Package.swift depends on it solely from the EnviousWisprTests
+  # test target). Credited anyway: the coverage cross-check keys off
+  # Package.resolved, which cannot distinguish a test-only pin, and
+  # over-attributing costs nothing while under-attributing is the real risk.
+  "swift-syntax|603.0.2|Apache-2.0|swift-syntax/LICENSE.txt|https://github.com/swiftlang/swift-syntax|swift-syntax"
   "fastcluster (bundled in FluidAudio)|n/a|BSD-2-Clause|FluidAudio/ThirdPartyLicenses/fastcluster-LICENSE.md|https://github.com/dmuellner/fastcluster|"
   "VBx (bundled in FluidAudio)|n/a|Apache-2.0|FluidAudio/ThirdPartyLicenses/vbx-LICENSE.md|https://github.com/BUTSpeechFIT/VBx|"
   "PLCrashReporter + protobuf-c (bundled in PostHog)|n/a|MIT / Apache-2.0 / BSD-2-Clause|posthog-ios/vendor/PHPLCrashReporter/LICENSE|https://github.com/microsoft/plcrashreporter|"


### PR DESCRIPTION
Unblocks the v2.4.1 release. Two independent blockers, one commit each.

## 1. Third-party notices out of sync (blocks ALL releases)

The release packaging gate hard-failed on `main`, so no release could ship:

- `sparkle` drifted to 2.9.4 in `Package.resolved` (#1733) without updating the notice generator.
- `swift-syntax` arrived as a new pin (#1741) with no entry at all.

Neither was caught by PR CI, because `gen-third-party-notices.sh` only runs during release packaging. Worth closing that gap separately.

`swift-syntax` is test-only (`Package.swift` depends on it solely from the test target). Credited anyway, with a comment explaining why: the coverage cross-check keys off `Package.resolved`, which cannot distinguish a test-only pin, and over-attributing is the safe direction. Founder decision.

## 2. Custom Words import/export was compiled out of release builds

The feature (epic #1619) is complete and merged, but every user-facing entry point sat behind `#if DEBUG`. The comment at the gate stated that removing it is a founder decision. **The founder made that decision on 2026-07-24.**

Seven gates removed, enumerated via a Codex grounding pass rather than one at a time:

| Location | What was dark in release |
|---|---|
| `YourWordsView` | Import button, Export button, export state, export alert, `exportWords` implementation |
| `WisprBootstrapper` | **The bulk-import enrichment wiring.** Silent failure: `onImportCommitted` stayed nil, so a release import saved successfully and then never enriched, Cancel did nothing, and pending work never resumed at launch. No error surfaced. |
| `SettingsView` | Sidebar enrichment badge hard-returned `false`, losing the progress signal outside Your Words |

The bootstrapper and sidebar gates were **not** in my initial sweep; Codex found them.

Stale comments asserting the feature is DEBUG-only, unreachable in release, or "still placeholders" are corrected. They would otherwise ship as false documentation.

What's New entries 1 and 2 now condition the automatic alias suggestions on Apple Intelligence availability. Enrichment runs on the on-device model (macOS 26+); imports complete cleanly without it, so the previous unconditional promise was wrong for older Macs.

## Validation

- [x] **Release configuration compiles clean** (0 errors) — the receipt a DEBUG build cannot give
- [x] **Verified in a running Release build**: Import and Export buttons present; Import sheet opens with all three real sources (Paste words, Open a file, From another app). Screenshot confirmed.
- [x] Full suite green: 3839 + 179 tests
- [x] First run tripped the `WisprBootstrapper` 1330-line ceiling at 1331; comment trimmed to 1329 rather than raising the cap
- [x] `gen-third-party-notices.sh --check` passes: 15 components, both notices copies in sync
- [x] Local `codex review --base origin/main`: "No actionable defects found"
- [ ] build-check CI
- [ ] Cloud Codex review

## After merge

`v2.4.1` currently points at a commit containing none of this, and both prior release runs failed before publishing anything, so no user ever received that tag. It will be deleted and re-pointed at the merge commit.

Part of #1619.