### PR TITLE
fix(ci): close three release gaps that reported green while broken

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -52,6 +52,15 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: scripts/ci/classify-changes.sh "$BASE_SHA" "$HEAD_SHA"
 
+      # #1778: the notices gate used to run ONLY during release packaging, so a
+      # dependency bump that forgot the generator sat green on main until someone
+      # tried to ship - v2.4.1 lost two release runs to exactly that (Sparkle
+      # 2.9.4 via #1733, swift-syntax via #1741). `--check` reads only committed
+      # files (no .build/checkouts), so it is seconds and runs unconditionally:
+      # a paths filter here would be one more thing that can drift out of sync.
+      - name: Verify third-party notices are in sync
+        run: scripts/ci/gen-third-party-notices.sh --check
+
       - name: Verify environment
         if: steps.changes.outputs.needs_build == 'true'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,8 +324,15 @@ jobs:
           MISE_URL="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-macos-arm64"
           MISE_TMP="$RUNNER_TEMP/mise"
           echo "==> Downloading pinned mise ${MISE_VERSION} from ${MISE_URL}"
+          # --retry-all-errors is load-bearing, not belt-and-braces: bare --retry
+          # only retries curl's "transient" set (timeouts, 408/429/5xx STATUS
+          # lines). v2.4.1's first release run died on `curl: (56) ... error: 504`
+          # — a gateway error delivered mid-transfer, which curl classifies as a
+          # RECV error, not a retryable status, so --retry 3 never fired once.
+          # --retry-all-errors covers that class. --max-time is per-attempt.
           curl --proto '=https' --tlsv1.2 --fail --location \
-            --retry 3 --retry-connrefused --connect-timeout 15 --max-time 120 \
+            --retry 5 --retry-all-errors --retry-delay 3 --retry-connrefused \
+            --connect-timeout 15 --max-time 120 \
             -sS -o "$MISE_TMP" "$MISE_URL"
           echo "${MISE_SHA256}  ${MISE_TMP}" | shasum -a 256 -c -
           mkdir -p "$HOME/.local/bin"
@@ -1097,7 +1104,12 @@ jobs:
         needs.publish-github-release.result == 'success'
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 15, not 5: the dispatch step now hashes the published DMG and waits for the
+    # cask to actually land (see "Dispatch cask bump and verify it landed"). The
+    # cap must EXCEED that step's worst case (~8.5 min) with room for the failure
+    # -reporting step, because a timeout cancels the job and !cancelled() would
+    # then suppress the very alert this verification exists to raise.
+    timeout-minutes: 15
     permissions:
       contents: read
       issues: write   # #1368: the failure-alert step files an issue via the repo GITHUB_TOKEN
@@ -1124,7 +1136,7 @@ jobs:
           echo "DRY RUN: would dispatch the Homebrew cask bump for v${VERSION}:"
           echo "  gh workflow run bump-cask.yml -R saurabhav88/homebrew-tap -f version=${VERSION}"
 
-      - name: Dispatch cask bump
+      - name: Dispatch cask bump and verify it landed
         id: dispatch-cask
         if: inputs.dry_run != true
         continue-on-error: true
@@ -1135,7 +1147,70 @@ jobs:
           set -euo pipefail
           echo "==> Dispatching bump-cask.yml on saurabhav88/homebrew-tap for v${VERSION}"
           gh workflow run bump-cask.yml -R saurabhav88/homebrew-tap -f version="${VERSION}"
-          echo "==> Dispatched (fire-and-forget). The tap workflow reconciles the cask; it is idempotent + self-healing."
+
+          # This step used to end here, fire-and-forget: it reported SUCCESS for
+          # having SENT the request, so a tap workflow that failed outright still
+          # showed a green "Homebrew cask" row in the release summary. Green meant
+          # "dispatched", never "users can brew install this version".
+          #
+          # Verify the END STATE rather than an intermediate job status — a tap
+          # run can conclude success without the cask landing on main.
+          #
+          # BOTH fields, not just version. `brew install` fails on a checksum
+          # mismatch exactly as hard as on a wrong version, and version alone is
+          # the weaker signal precisely when it matters: re-running a release for
+          # an existing version, or repairing a cask whose version is already
+          # right but whose sha256 is stale, would match on the FIRST poll and
+          # exit green before the tap reconciled the checksum.
+          # Every bound below is deliberate and must stay inside this job's
+          # timeout-minutes. A job that hits its timeout is CANCELLED, and the
+          # "Report cask bump failure" step is guarded by !cancelled() — so an
+          # over-long verifier would go SILENT under exactly the network failures
+          # it exists to detect. Worst case here: download 4 x 60s + 3 x 3s delay
+          # (~4.2 min) + poll deadline 4 min + one in-flight iteration (~20s)
+          # = ~8.5 min, against a 15 min cap. Re-do this arithmetic before
+          # loosening any retry count, --max-time, or the poll deadline.
+          DMG_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/download/v${VERSION}/EnviousWispr-${VERSION}.dmg"
+          echo "==> Hashing the published DMG to get the expected checksum"
+          curl -sS --fail --location --retry 3 --retry-all-errors --retry-delay 3 \
+            --connect-timeout 15 --max-time 60 -o "$RUNNER_TEMP/verify.dmg" "$DMG_URL"
+          EXPECTED_SHA="$(sha256sum "$RUNNER_TEMP/verify.dmg" | awk '{print $1}')"
+          rm -f "$RUNNER_TEMP/verify.dmg"
+          echo "    expected sha256: ${EXPECTED_SHA}"
+
+          # Cache-busted: the raw CDN serves a stale copy for minutes after a push.
+          # Bounded by WALL CLOCK, not an iteration count: a count times a curl
+          # timeout is not a duration, which is how the 12-min overrun above hid.
+          CASK_URL="https://raw.githubusercontent.com/saurabhav88/homebrew-tap/main/Casks/enviouswispr.rb"
+          POLL_DEADLINE=$(( $(date +%s) + 240 ))
+          attempt=0
+          echo "==> Waiting for the cask to report ${VERSION} + matching sha256 (up to 4 min)"
+          while [ "$(date +%s)" -lt "$POLL_DEADLINE" ]; do
+            attempt=$(( attempt + 1 ))
+            sleep 10
+            CASK_BODY="$(curl -sS --fail --max-time 10 "${CASK_URL}?cb=${GITHUB_RUN_ID}-${attempt}" || true)"
+            CASK_VERSION="$(printf '%s' "$CASK_BODY" | sed -n 's/^[[:space:]]*version "\([^"]*\)".*/\1/p' | head -1)"
+            CASK_SHA="$(printf '%s' "$CASK_BODY" | sed -n 's/^[[:space:]]*sha256 "\([^"]*\)".*/\1/p' | head -1)"
+            # Distinguish "not updated YET" from "cannot parse this file at all".
+            # Both look like an empty CASK_VERSION, but only the first is worth
+            # waiting out; the second would burn the whole deadline and then file
+            # a cask-did-not-land issue that names the wrong cause. Fail fast and
+            # accurately instead. Deliberately NOT solved by loosening the match:
+            # the `url` line also contains the word `version`, so a laxer pattern
+            # could return a WRONG value, which is worse than returning none.
+            if [ -n "$CASK_BODY" ] && [ -z "$CASK_VERSION" ] && [ -z "$CASK_SHA" ]; then
+              echo "::error::Fetched the cask but could not parse version/sha256 from it — the tap's file format likely changed, so this check can no longer verify anything. Update the parse in this step."
+              printf '%s\n' "$CASK_BODY" | head -5
+              exit 1
+            fi
+            if [ "$CASK_VERSION" = "$VERSION" ] && [ "$CASK_SHA" = "$EXPECTED_SHA" ]; then
+              echo "==> Cask is at ${VERSION} with the correct checksum after ${attempt} check(s)."
+              exit 0
+            fi
+            echo "    attempt ${attempt}: version='${CASK_VERSION:-<unreadable>}' sha256='${CASK_SHA:-<unreadable>}'"
+          done
+          echo "::error::Cask did not reach ${VERSION} with checksum ${EXPECTED_SHA} within the wait window (last saw version='${CASK_VERSION:-<unreadable>}' sha256='${CASK_SHA:-<unreadable>}'). brew install will fail or serve the OLD version until this is fixed."
+          exit 1
 
       # #1368: fire when EITHER the App-token mint failed (e.g. the App lacks tap
       # access/actions:write — cloud review P2) OR the dispatch failed. The mint
@@ -1144,7 +1219,10 @@ jobs:
       # this run after that failure. A continue-on-error dispatch failure needs
       # the explicit OUTCOME check (bare `failure()` never fires for it). Uses the
       # current-repo GITHUB_TOKEN (issues:write above), NOT the tap App token.
-      - name: Report cask trigger failure
+      # Fires for a failed token mint, a failed dispatch, OR (since #1778) a
+      # dispatch that was accepted but whose cask never actually reached this
+      # version — the case that used to pass silently as green.
+      - name: Report cask bump failure
         if: >
           !cancelled() && inputs.dry_run != true &&
           (steps.app-token.outcome == 'failure' || steps.dispatch-cask.outcome == 'failure')
@@ -1158,10 +1236,10 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          echo "::warning::Homebrew cask auto-bump could not be triggered for v${VERSION} — cask may be stale. Filing an issue."
+          echo "::warning::Homebrew cask did not reach v${VERSION} — brew install serves the OLD version. Filing an issue."
           gh issue create \
             --title "Homebrew cask auto-bump failed for v${VERSION}" \
-            --body "$(printf 'The release pipeline could not trigger the tap cask bump for v%s (App-token mint or workflow dispatch failed).\n\nRelease shipped fine (this is a non-blocking limb), but Homebrew may be stale.\n\nRun: %s\n\nManual fix: gh workflow run bump-cask.yml -R saurabhav88/homebrew-tap -f version=%s' "${VERSION}" "${RUN_URL}" "${VERSION}")" \
+            --body "$(printf 'The tap cask did not reach v%s: the App-token mint failed, the workflow dispatch failed, or the dispatch was accepted but the cask never landed.\n\nRelease shipped fine (this is a non-blocking limb), but `brew install --cask enviouswispr` serves the PREVIOUS version until this is fixed.\n\nRun: %s\n\nManual fix: gh workflow run bump-cask.yml -R saurabhav88/homebrew-tap -f version=%s\n\nThen confirm the cask really moved, not just that the run went green:\n  curl -s "https://raw.githubusercontent.com/saurabhav88/homebrew-tap/main/Casks/enviouswispr.rb?cb=$RANDOM" | head -3' "${VERSION}" "${RUN_URL}" "${VERSION}")" \
             --label "bug" || echo "::warning::Could not file the cask-failure issue (labels/perms?)."
           # #1368 (Codex P2): fail the job so needs.bump-homebrew-cask.result ==
           # 'failure' → release-summary surfaces the cask follow-up + Discord alert.


### PR DESCRIPTION
All three surfaced during the v2.4.1 release, which lost two runs to them. Each is the same shape: **a check that passes without proving the thing it exists to prove.**

## 1. Notices gate ran only at release packaging (closes #1778)

Sparkle 2.9.4 (#1733) and swift-syntax (#1741) both merged green and left `main` unreleasable. Nobody found out until a tag was already pushed.

Now runs on every PR via `--check`, which reads committed files only (no `.build/checkouts`), so it costs seconds. Deliberately unconditional rather than behind a paths filter: that filter would be one more thing that can drift out of sync with what it guards.

No deadlock risk: if `main` breaks, every PR goes red, but the PR that *fixes* it passes its own check.

## 2. Pinned mise download had retries and still killed a release run

`curl: (56) ... error: 504`. Bare `--retry` only covers curl's "transient" set (timeouts, 408/429/5xx **status lines**). This 504 arrived mid-transfer and was classified as a RECV error, so the retry never fired once. Added `--retry-all-errors`.

## 3. Homebrew cask job was fire-and-forget

It reported SUCCESS for having **sent** the dispatch, so a tap workflow that failed outright would still show a green "Homebrew cask" row while `brew install` served the old version.

Now verifies the **end state** — the cask file naming this version **and** carrying the checksum of the published DMG — rather than an intermediate job status, since a tap run can conclude success without the cask landing.

Two defects in my own verification, both caught by local Codex review, both the same class as the bug being fixed:
- **Version alone was insufficient.** `brew install` fails on a checksum mismatch as hard as on a wrong version, and version-only is weakest exactly when it matters: a re-run for an existing version would match on the first poll and exit green before the tap reconciled `sha256`. Now hashes the published DMG and requires both.
- **The verifier could outlive its own job.** Worst case was ~42 min against a 10 min cap. A job that hits its cap is CANCELLED, and the alert step is guarded by `!cancelled()` — so under exactly the network failures this detects, it would have gone **silent**. Both operations are now bounded inside the budget (~8.5 min worst case, 15 min cap), and the poll switched from an iteration count to a wall-clock deadline, since a count times a timeout is not a duration — which is how the overrun hid.

## Validation

Measured, not assumed:

- Notices check **proven live**: injected a fake Sparkle drift → exits 1 with the correct error; restored → exits 0. Not a vacuous guard.
- Cask version **and** sha256 extraction run against the **live tap file**; both matched, and sha256 matched the real 62 MB DMG byte-for-byte.
- Poll loop **run**: exits at exactly its wall-clock deadline and correctly refuses a wrong version.
- Verifier hashes the **same URL the cask points at** (confirmed against the live cask), so the comparison is meaningful.
- curl flag combination accepted (8.7.1; `--retry-all-errors` needs 7.71+).
- Both workflows parse (ruby YAML).
- Local `codex review`: 3 rounds, final clean.

## Not fixed here

The `.claude/` release-checklist skill warned future sessions to expect 6 known-false test failures in `/tmp` worktrees and wave them through. #1731 fixed that cause in v2.4.1, and the v2.4.1 release ran 3839 + 179 tests from `/tmp` worktrees with zero failures. That warning is corrected on disk (gitignored, so not in this diff) to say the opposite: treat any failure there as real.