### PR TITLE
feat(pipeline): record-start VAD observability (#1780)

### DIFF
--- a/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
@@ -79,12 +79,69 @@ package final class CaptureVADSignalSource: VADSignalSource {
   private var segmentsProvider: @MainActor () -> [SpeechSegment]
   private var sessionConfig: DictationSessionConfig?
 
+  /// Monotonic monitor-run identity (#1780). A session id alone is NOT a
+  /// sufficient staleness guard: `finalizeAtStop` cancels a run without
+  /// changing the session, and a replacement can reuse the same session, so a
+  /// resumed old task would still pass a session-only check and emit into the
+  /// wrong run. Bumped by `invalidateMonitor()` at every cancellation site.
+  private var monitorGeneration: UInt64 = 0
+
+  /// Test seam (#1780): produces the detector `startMonitoring` would build
+  /// itself. Internal and defaulted, so production construction is unchanged;
+  /// tests inject a detector backed by a continuation-controlled fake so
+  /// preparation and first-chunk suspension are deterministic.
+  private let makeDetector: @MainActor (TimeInterval, SmoothedVADConfig) -> SilenceDetector
+
+  /// Dual-channel record-start markers (#1780). Injected so tests observe with
+  /// per-instance spies rather than global Sentry/PostHog hooks.
+  private let recordStartTelemetry: RecordStartTelemetrySink
+
   init(
     evidenceProvider: @escaping @MainActor () -> VADSpeechEvidence = { .unavailable },
-    segmentsProvider: @escaping @MainActor () -> [SpeechSegment] = { [] }
+    segmentsProvider: @escaping @MainActor () -> [SpeechSegment] = { [] },
+    makeDetector: @escaping @MainActor (TimeInterval, SmoothedVADConfig) -> SilenceDetector = {
+      timeout, vadConfig in
+      SilenceDetector(silenceTimeout: timeout, vadConfig: vadConfig)
+    },
+    recordStartTelemetry: RecordStartTelemetrySink = RecordStartTelemetrySink()
   ) {
     self.evidenceProvider = evidenceProvider
     self.segmentsProvider = segmentsProvider
+    self.makeDetector = makeDetector
+    self.recordStartTelemetry = recordStartTelemetry
+  }
+
+  /// Sole authority for ending a monitor run (#1780). Cancels, clears, and
+  /// advances the generation together — separating them is what let a resumed
+  /// task emit into a newer run.
+  private func invalidateMonitor() {
+    monitorTask?.cancel()
+    monitorTask = nil
+    monitorGeneration += 1
+  }
+
+  /// A captured run may emit only while its session and generation are still
+  /// current AND the recording is still live. Checked immediately before every
+  /// marker, with no await or mutable read between the check and the emit.
+  ///
+  /// The liveness term is load-bearing and not redundant with the other two.
+  /// `RecordingSessionKernel` concludes a session through ~40 `finishTerminal`
+  /// sites — cancellation, capture-start failure, model wedge, capture stall,
+  /// ASR failure — and only the normal stop path reaches `finalizeAtStop`. On
+  /// every other terminal the session id and the generation are BOTH unchanged,
+  /// so a task suspended in preparation or in first-chunk processing would wake
+  /// after the recording had already ended and emit a marker into a concluded
+  /// session. `isRecording` is the kernel's own liveness predicate
+  /// (`state == .live && currentSessionID == sid`), so it goes false on every
+  /// terminal path by construction, including any added later. It is passed per
+  /// run rather than stored, so a new run's predicate can never be read by an
+  /// older one.
+  private func monitorIsCurrent(
+    sessionID: SessionID,
+    generation: UInt64,
+    isRecording: @MainActor () -> Bool
+  ) -> Bool {
+    currentSessionID == sessionID && monitorGeneration == generation && isRecording()
   }
 
   // MARK: VADSignalSource (PR-5 Rung 5: package-required because the
@@ -168,8 +225,7 @@ package final class CaptureVADSignalSource: VADSignalSource {
   func configureSession(config: DictationSessionConfig, audioCapture: any AudioCaptureInterface) {
     self.audioCapture = audioCapture
     sessionConfig = config
-    monitorTask?.cancel()
-    monitorTask = nil
+    invalidateMonitor()
     if detectorSilenceTimeout != nil && detectorSilenceTimeout != config.vadSilenceTimeout {
       silenceDetector = nil
       detectorSilenceTimeout = nil
@@ -184,13 +240,30 @@ package final class CaptureVADSignalSource: VADSignalSource {
   /// this loop owns the `SilenceDetector` and the max-duration stop.
   func startMonitoring(
     recordingStartTime: Date,
+    backend: String,
     isRecording: @escaping @MainActor () -> Bool
   ) {
     guard let audioCapture, let config = sessionConfig else { return }
 
-    monitorTask?.cancel()
-    monitorTask = Task { @MainActor [weak self] in
-      guard let self, let audioCapture = self.audioCapture else { return }
+    invalidateMonitor()
+
+    // Snapshot every telemetry identity fact SYNCHRONOUSLY, before the task
+    // exists (#1780). Reading these inside the task is unsafe: the task may
+    // first execute after a later session has been stamped, which would
+    // silently attribute this run's markers to the next recording.
+    let runSessionID = currentSessionID
+    let runGeneration = monitorGeneration
+    let runBackend = backend
+    let runInputRoute = audioCapture.currentAudioRoute
+
+    monitorTask = Task { @MainActor [weak self, audioCapture] in
+      guard let self else { return }
+      // Reject a run already superseded before it first executed, BEFORE it
+      // mutates retained detector state.
+      guard self.monitorIsCurrent(
+        sessionID: runSessionID, generation: runGeneration, isRecording: isRecording) else {
+        return
+      }
 
       let vadConfig = SmoothedVADConfig.fromSensitivity(
         config.vadSensitivity,
@@ -198,10 +271,19 @@ package final class CaptureVADSignalSource: VADSignalSource {
       )
       let directDetector =
         self.silenceDetector
-        ?? SilenceDetector(
-          silenceTimeout: config.vadSilenceTimeout,
-          vadConfig: vadConfig
-        )
+        ?? self.makeDetector(config.vadSilenceTimeout, vadConfig)
+      // #1780: `model_reused` MUST be read here, before any preparation. Read
+      // afterwards it would be true for every successful preparation and carry
+      // no information. `reset()` does not unload the model, so `true` means
+      // this retained detector entered the run already loaded.
+      let modelReused = await directDetector.isReady
+      // Invalidation can land during that actor await; re-check BEFORE taking
+      // ownership of the retained detector, or a superseded run would rewrite
+      // `silenceDetector`/`detectorSilenceTimeout` under the live run.
+      guard self.monitorIsCurrent(
+        sessionID: runSessionID, generation: runGeneration, isRecording: isRecording) else {
+        return
+      }
       self.silenceDetector = directDetector
       self.detectorSilenceTimeout = config.vadSilenceTimeout
       await directDetector.reset()
@@ -221,14 +303,35 @@ package final class CaptureVADSignalSource: VADSignalSource {
       // approaching-cap warning — only the silence-auto-stop limb is lost. The
       // old XPC topology likewise ran a nil-detector host-side monitor.
       let ready = await directDetector.isReady
+      // Same reason: `directDetectorPrepared` is live source state and must not
+      // be written by a run that was superseded during preparation.
+      guard self.monitorIsCurrent(
+        sessionID: runSessionID, generation: runGeneration, isRecording: isRecording) else {
+        return
+      }
       if ready { self.directDetectorPrepared = true }
+
+      // Re-check immediately before emitting: this point follows detector actor
+      // awaits, so the run may have been invalidated while suspended. No await
+      // or mutable read between the guard and the emit.
+      guard self.monitorIsCurrent(
+        sessionID: runSessionID, generation: runGeneration, isRecording: isRecording) else {
+        return
+      }
+      self.recordStartTelemetry.vadPreparationCompleted(
+        backend: runBackend, inputRoute: runInputRoute,
+        ready: ready, modelReused: modelReused)
 
       await self.runMonitor(
         detector: ready ? directDetector : nil,
         config: config,
         recordingStartTime: recordingStartTime,
         audioCapture: audioCapture,
-        isRecording: isRecording
+        isRecording: isRecording,
+        runSessionID: runSessionID,
+        runGeneration: runGeneration,
+        runBackend: runBackend,
+        runInputRoute: runInputRoute
       )
     }
   }
@@ -296,8 +399,7 @@ package final class CaptureVADSignalSource: VADSignalSource {
   }
 
   func finalizeAtStop(rawSampleCount: Int) async {
-    monitorTask?.cancel()
-    monitorTask = nil
+    invalidateMonitor()
 
     guard let silenceDetector, directDetectorPrepared else {
       setSegmentsProvider { [] }
@@ -316,7 +418,11 @@ package final class CaptureVADSignalSource: VADSignalSource {
     config: DictationSessionConfig,
     recordingStartTime: Date,
     audioCapture: any AudioCaptureInterface,
-    isRecording: @escaping @MainActor () -> Bool
+    isRecording: @escaping @MainActor () -> Bool,
+    runSessionID: SessionID,
+    runGeneration: UInt64,
+    runBackend: String,
+    runInputRoute: String
   ) async {
     await VADMonitorLoop.run(
       detector: detector,
@@ -336,6 +442,27 @@ package final class CaptureVADSignalSource: VADSignalSource {
         case .maxDuration:
           self?.noteMaxDurationReached()
         }
+      },
+      // #1780 first-chunk markers. Both callbacks carry the values captured
+      // before the task existed and re-check run identity immediately before
+      // emitting — a first-chunk await can resume after invalidation.
+      onFirstChunkStarted: { [weak self] monitorMs in
+        guard let self,
+          self.monitorIsCurrent(
+        sessionID: runSessionID, generation: runGeneration, isRecording: isRecording)
+        else { return }
+        self.recordStartTelemetry.firstChunkStarted(
+          backend: runBackend, inputRoute: runInputRoute,
+          monitorToFirstChunkMs: monitorMs)
+      },
+      onFirstChunkCompleted: { [weak self] latencyMs, shouldStop in
+        guard let self,
+          self.monitorIsCurrent(
+        sessionID: runSessionID, generation: runGeneration, isRecording: isRecording)
+        else { return }
+        self.recordStartTelemetry.firstChunkCompleted(
+          backend: runBackend, inputRoute: runInputRoute,
+          chunkProcessingLatencyMs: latencyMs, shouldStop: shouldStop)
       }
     )
   }

--- a/Sources/EnviousWisprPipeline/RecordStartTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/RecordStartTelemetrySink.swift
@@ -1,0 +1,130 @@
+import EnviousWisprServices
+import Foundation
+
+/// Emits the three record-start VAD stage markers (#1780) to BOTH channels.
+///
+/// Why both: a Sentry breadcrumb travels inside the crash report, so it is the
+/// authoritative crash-local sequence — that is what let #1780 be reconstructed
+/// at all. A PostHog event answers the fleet question ("where do recordings
+/// normally reach or drop out"). `sentry-operations.md`
+/// RULE: sentry-for-bugs-posthog-for-behaviour permits exactly this pairing:
+/// it forbids turning non-bugs into alerting Sentry *errors*, not non-alerting
+/// diagnostic breadcrumbs alongside counted events.
+///
+/// Ownership boundary: this type owns the three breadcrumb messages and the
+/// one-breadcrumb-plus-one-event parity rule. `TelemetryService` remains the
+/// sole authority for the exact PostHog event names and property
+/// serialization. Observation of the physical boundaries stays with
+/// `CaptureVADSignalSource` and `VADMonitorLoop`; this type only routes the
+/// facts they report.
+///
+/// Deliberately stateless: no session identity, no lifecycle, no detector
+/// state, no orchestration. Callers own the monitor-generation validity check
+/// and must perform it immediately before every call.
+@MainActor
+final class RecordStartTelemetrySink {
+  /// Injected so tests observe per-instance, never through the process-global
+  /// `SentryBreadcrumb.breadcrumbDelegate` (`swift-patterns.md`
+  /// RULE: tests-no-process-global-mutable-delegate).
+  typealias BreadcrumbSink = @MainActor (
+    _ stage: String, _ message: String, _ data: [String: Any]
+  ) -> Void
+
+  typealias PreparationSink = @MainActor (
+    _ backend: String, _ inputRoute: String, _ ready: Bool, _ modelReused: Bool
+  ) -> Void
+
+  typealias ChunkStartedSink = @MainActor (
+    _ backend: String, _ inputRoute: String, _ monitorToFirstChunkMs: Double
+  ) -> Void
+
+  typealias ChunkCompletedSink = @MainActor (
+    _ backend: String, _ inputRoute: String, _ chunkProcessingLatencyMs: Double,
+    _ shouldStop: Bool
+  ) -> Void
+
+  private let breadcrumb: BreadcrumbSink
+  private let emitPreparation: PreparationSink
+  private let emitChunkStarted: ChunkStartedSink
+  private let emitChunkCompleted: ChunkCompletedSink
+
+  init(
+    // `level: .info` is passed explicitly rather than relying on
+    // `SentryBreadcrumb.add`'s default, matching `KernelLifecycleTelemetrySink`:
+    // these are diagnostic stage markers, never alerting errors.
+    breadcrumb: @escaping BreadcrumbSink = { stage, message, data in
+      SentryBreadcrumb.add(stage: stage, message: message, level: .info, data: data)
+    },
+    emitPreparation: @escaping PreparationSink = { backend, inputRoute, ready, modelReused in
+      TelemetryService.shared.dictationVADPreparationCompleted(
+        backend: backend, inputRoute: inputRoute, ready: ready, modelReused: modelReused)
+    },
+    emitChunkStarted: @escaping ChunkStartedSink = { backend, inputRoute, monitorMs in
+      TelemetryService.shared.dictationFirstVADChunkStarted(
+        backend: backend, inputRoute: inputRoute, monitorToFirstChunkMs: monitorMs)
+    },
+    emitChunkCompleted: @escaping ChunkCompletedSink = {
+      backend, inputRoute, latencyMs, shouldStop in
+      TelemetryService.shared.dictationFirstVADChunkCompleted(
+        backend: backend, inputRoute: inputRoute,
+        chunkProcessingLatencyMs: latencyMs, shouldStop: shouldStop)
+    }
+  ) {
+    self.breadcrumb = breadcrumb
+    self.emitPreparation = emitPreparation
+    self.emitChunkStarted = emitChunkStarted
+    self.emitChunkCompleted = emitChunkCompleted
+  }
+
+  /// Readiness evaluation returned, immediately before monitor entry.
+  func vadPreparationCompleted(
+    backend: String,
+    inputRoute: String,
+    ready: Bool,
+    modelReused: Bool
+  ) {
+    breadcrumb(
+      "vad", "vad#preparation_completed",
+      [
+        "backend": backend,
+        "input_route": inputRoute,
+        "ready": ready,
+        "model_reused": modelReused,
+      ])
+    emitPreparation(backend, inputRoute, ready, modelReused)
+  }
+
+  /// Immediately before the first `SilenceDetector.processChunk` await.
+  func firstChunkStarted(
+    backend: String,
+    inputRoute: String,
+    monitorToFirstChunkMs: Double
+  ) {
+    breadcrumb(
+      "vad", "vad#first_chunk_started",
+      [
+        "backend": backend,
+        "input_route": inputRoute,
+        "monitor_to_first_chunk_ms": monitorToFirstChunkMs,
+      ])
+    emitChunkStarted(backend, inputRoute, monitorToFirstChunkMs)
+  }
+
+  /// Immediately after that await returns.
+  func firstChunkCompleted(
+    backend: String,
+    inputRoute: String,
+    chunkProcessingLatencyMs: Double,
+    shouldStop: Bool
+  ) {
+    breadcrumb(
+      "vad", "vad#first_chunk_completed",
+      [
+        "backend": backend,
+        "input_route": inputRoute,
+        "chunk_processing_latency_ms": chunkProcessingLatencyMs,
+        "should_stop": shouldStop,
+      ])
+    emitChunkCompleted(backend, inputRoute, chunkProcessingLatencyMs, shouldStop)
+  }
+}

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2917,8 +2917,13 @@ final class RecordingSessionKernel {
     // not count toward minimum-duration.
     recordingStartedAtTick = currentTick()
     resourcesReleased = false
+    // #1780: the backend is not reachable from the VAD source (it is absent
+    // from `DictationSessionConfig`), so the kernel hands over the already
+    // resolved identity. Capability-neutral: it labels telemetry, never gates
+    // behaviour, so `engineIdentity` is the correct read here.
     (vad as? CaptureVADSignalSource)?.startMonitoring(
       recordingStartTime: Date(),
+      backend: adapter.engineIdentity.rawValue,
       isRecording: { [weak self] in
         self?.state == .live && self?.currentSessionID == sid
       }

--- a/Sources/EnviousWisprPipeline/VADMonitorLoop.swift
+++ b/Sources/EnviousWisprPipeline/VADMonitorLoop.swift
@@ -37,6 +37,19 @@ internal enum VADMonitorLoop {
   ///     Advisory only — recording continues; never stops.
   ///   - onStop: Called when auto-stop should trigger. Runs in a new Task to avoid
   ///     cancellation propagation from the monitor task into transcription.
+  ///   - monotonicNow: Injectable MONOTONIC clock for first-chunk timing (#1780),
+  ///     defaulting to `ProcessInfo.processInfo.systemUptime`. Deliberately
+  ///     separate from `now`: that one is a wall clock compared against
+  ///     `recordingStartTime` for the duration cap and must stay `Date`-based,
+  ///     while an interval measurement must not be distorted by a clock step.
+  ///   - onFirstChunkStarted: Fired ONCE per run, immediately before the first
+  ///     `processChunk` await, carrying milliseconds from run entry.
+  ///   - onFirstChunkCompleted: Fired ONCE per run, immediately after that await
+  ///     returns, carrying the await's own elapsed milliseconds and the actual
+  ///     `shouldStop` result. #1780: `started` present with `completed` absent
+  ///     localises a fatal failure to the first chunk, which contains the
+  ///     CoreML prediction path. Both are observational and never alter
+  ///     whether recording continues.
   static func run(
     detector: SilenceDetector?,
     vadAutoStop: Bool,
@@ -47,8 +60,18 @@ internal enum VADMonitorLoop {
     isRecording: @escaping @MainActor () -> Bool,
     now: @escaping @MainActor () -> Date = { Date() },
     onApproachingMaxDuration: @escaping @MainActor (TimeInterval) -> Void,
-    onStop: @escaping @MainActor (VADStopReason) -> Void
+    onStop: @escaping @MainActor (VADStopReason) -> Void,
+    monotonicNow: @escaping @MainActor () -> TimeInterval = {
+      ProcessInfo.processInfo.systemUptime
+    },
+    onFirstChunkStarted: @escaping @MainActor (Double) -> Void = { _ in },
+    onFirstChunkCompleted: @escaping @MainActor (Double, Bool) -> Void = { _, _ in }
   ) async {
+    // Captured at run entry, before any loop work, so `monitor_to_first_chunk_ms`
+    // measures the full monitor-entry-to-first-chunk interval. Latch is
+    // function-local: a new `run` invocation gets a fresh pair (#1780).
+    let monitorStartedAt = monotonicNow()
+    var firstChunkObserved = false
     // One-shot approaching-cap warning (#1060). Fires at most once per run when
     // elapsed crosses `maxDuration - warningLead`, only when the cap is long
     // enough to have a lead window. Advisory — it never stops the recording.
@@ -97,7 +120,31 @@ internal enum VADMonitorLoop {
           guard isRecording(), sampleProvider().count >= endIdx else { break }
           let chunk = Array(sampleProvider()[processedSampleCount..<endIdx])
 
+          // #1780 first-chunk observation. The `started` callback fires as the
+          // LAST work before the await, and the clock read plus `completed`
+          // callback are the FIRST work after it returns — nothing may be
+          // inserted between, or the pair stops bracketing the first-chunk
+          // processing it exists to localise.
+          //
+          // `chunkStartedAt` is read AFTER the started callback on purpose. That
+          // callback synchronously writes a Sentry breadcrumb and a PostHog
+          // event; timing from before it would fold that telemetry cost into
+          // `chunk_processing_latency_ms`, which claims to measure chunk
+          // processing. One extra clock read is the honest trade.
+          let isFirstChunk = !firstChunkObserved
+          var chunkStartedAt: TimeInterval = 0
+          if isFirstChunk {
+            firstChunkObserved = true
+            let markerAt = monotonicNow()
+            onFirstChunkStarted((markerAt - monitorStartedAt) * 1000)
+            chunkStartedAt = monotonicNow()
+          }
+
           let shouldStop = await detector.processChunk(chunk)
+
+          if isFirstChunk {
+            onFirstChunkCompleted((monotonicNow() - chunkStartedAt) * 1000, shouldStop)
+          }
 
           if shouldStop && vadAutoStop && isRecording() {
             onStop(.silenceTimeout)

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2246,6 +2246,93 @@ public final class TelemetryService {
       ]
     )
   }
+
+  // MARK: - Record-start VAD stage markers (#1780)
+
+  /// The three markers below light the previously dark interval between
+  /// `dictation.invoked` and `asr.completed`. #1780 crashed inside the first
+  /// VAD chunk and had to be reconstructed from crash-dump thread states
+  /// because nothing in that window was observable in a release build.
+  ///
+  /// `RecordStartTelemetrySink` pairs each of these with a Sentry breadcrumb;
+  /// this type remains the sole authority for the exact PostHog event names
+  /// and property serialization. `package` (not `public`) — no external
+  /// product needs them.
+
+  /// VAD readiness evaluation returned, immediately before monitor entry.
+  /// `modelReused` is snapshotted BEFORE preparation by the caller: read after,
+  /// every successful preparation would report as reuse.
+  package func dictationVADPreparationCompleted(
+    backend: String,
+    inputRoute: String,
+    ready: Bool,
+    modelReused: Bool
+  ) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "dictation.vad_preparation_completed",
+          stringProps: ["backend": backend, "input_route": inputRoute],
+          boolProps: ["ready": ready, "model_reused": modelReused]))
+    #endif
+    PostHogSDK.shared.capture(
+      "dictation.vad_preparation_completed",
+      properties: [
+        "backend": backend,
+        "input_route": inputRoute,
+        "ready": ready,
+        "model_reused": modelReused,
+      ])
+  }
+
+  /// Immediately BEFORE the first `SilenceDetector.processChunk` await.
+  package func dictationFirstVADChunkStarted(
+    backend: String,
+    inputRoute: String,
+    monitorToFirstChunkMs: Double
+  ) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "dictation.first_vad_chunk_started",
+          stringProps: ["backend": backend, "input_route": inputRoute],
+          doubleProps: ["monitor_to_first_chunk_ms": monitorToFirstChunkMs]))
+    #endif
+    PostHogSDK.shared.capture(
+      "dictation.first_vad_chunk_started",
+      properties: [
+        "backend": backend,
+        "input_route": inputRoute,
+        "monitor_to_first_chunk_ms": monitorToFirstChunkMs,
+      ])
+  }
+
+  /// Immediately AFTER that await returns. `started` present with `completed`
+  /// absent is the diagnostic: it localises a fatal failure to first-chunk
+  /// processing, which contains the CoreML path #1780 died in.
+  package func dictationFirstVADChunkCompleted(
+    backend: String,
+    inputRoute: String,
+    chunkProcessingLatencyMs: Double,
+    shouldStop: Bool
+  ) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "dictation.first_vad_chunk_completed",
+          stringProps: ["backend": backend, "input_route": inputRoute],
+          doubleProps: ["chunk_processing_latency_ms": chunkProcessingLatencyMs],
+          boolProps: ["should_stop": shouldStop]))
+    #endif
+    PostHogSDK.shared.capture(
+      "dictation.first_vad_chunk_completed",
+      properties: [
+        "backend": backend,
+        "input_route": inputRoute,
+        "chunk_processing_latency_ms": chunkProcessingLatencyMs,
+        "should_stop": shouldStop,
+      ])
+  }
 }
 
 // MARK: - Latency bucket helper (Phase 8a)

--- a/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
@@ -1,7 +1,9 @@
 import EnviousWisprCore
+@preconcurrency import FluidAudio
 import Foundation
 import Testing
 
+@testable import EnviousWisprAudio
 @testable import EnviousWisprPipeline
 
 // MARK: - CaptureVADSignalSourceTests (epic #827, PR-4 §11.4)
@@ -162,4 +164,623 @@ import Testing
     source.setEvidenceProvider { .confirmedNoSpeech }
     #expect(source.speechEvidenceAtStop() == .confirmedNoSpeech)
   }
+
+  // MARK: - Record-start markers + monitor identity (#1780)
+  //
+  // #1780 crashed inside first-chunk processing and left no trail. These tests
+  // freeze the two suspension points (preparation, first chunk), interrupt the
+  // run each way it can really be interrupted, and prove no stale marker
+  // escapes. Test 9 reuses the SAME SessionID on purpose: it is the one that
+  // fails if the generation guard is removed and only the session is checked.
+
+  /// Cross-actor: the fake VAD is an actor, the sink spy is `@MainActor`.
+  /// Lock-backed rather than unlocked-unchecked.
+  final class Gate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _entered = false
+    private var _released = false
+    private var cont: CheckedContinuation<Void, Never>?
+
+    var entered: Bool { lock.withLock { _entered } }
+
+    func markEntered() { lock.withLock { _entered = true } }
+
+    /// The deliberate suspension point the fake blocks on. Unbounded by design
+    /// — this is the SUT-side block the test is constructing, not an assertion
+    /// wait — and every harness releases it, including on the failure path.
+    func wait() async {
+      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+        let resumeNow: Bool = lock.withLock {
+          if _released { return true }
+          cont = c
+          return false
+        }
+        if resumeNow { c.resume() }
+      }
+    }
+
+    /// Re-arms for a subsequent run's signal.
+    func reset() {
+      lock.withLock {
+        _entered = false
+        _released = false
+        cont = nil
+      }
+    }
+
+    /// Idempotent so cleanup after an assertion failure cannot double-resume.
+    func release() {
+      let c: CheckedContinuation<Void, Never>? = lock.withLock {
+        if _released { return nil }
+        _released = true
+        _entered = true
+        let held = cont
+        cont = nil
+        return held
+      }
+      c?.resume()
+    }
+  }
+
+  /// Suspends inside `processStreamingChunk` (the first-chunk boundary).
+  /// Observes cancellation so a test can prove `invalidateMonitor()` ran
+  /// BEFORE it resumes, instead of guessing with a yield count.
+  actor GatedChunkVad: StreamingVad {
+    private let gate: Gate
+    private let cancelSeen: Gate
+    init(gate: Gate, cancelSeen: Gate = Gate()) {
+      self.gate = gate
+      self.cancelSeen = cancelSeen
+    }
+    func processStreamingChunk(
+      _ audioChunk: [Float], state: VadStreamState, config: VadSegmentationConfig,
+      returnSeconds: Bool, timeResolution: Int
+    ) async throws -> VadStreamResult {
+      gate.markEntered()
+      await withTaskCancellationHandler {
+        await gate.wait()
+      } onCancel: {
+        cancelSeen.markEntered()
+        cancelSeen.release()
+      }
+      var next = state
+      next.processedSamples += audioChunk.count
+      return VadStreamResult(state: next, event: nil, probability: 0.0)
+    }
+  }
+
+  /// Never suspends — for runs that should complete normally.
+  actor OpenVad: StreamingVad {
+    func processStreamingChunk(
+      _ audioChunk: [Float], state: VadStreamState, config: VadSegmentationConfig,
+      returnSeconds: Bool, timeResolution: Int
+    ) async throws -> VadStreamResult {
+      var next = state
+      next.processedSamples += audioChunk.count
+      return VadStreamResult(state: next, event: nil, probability: 0.0)
+    }
+  }
+
+  struct PrepFailure: Error {}
+
+  @MainActor final class SinkSpy {
+    var prep: [(backend: String, route: String, ready: Bool, reused: Bool)] = []
+    var started: [(backend: String, route: String, ms: Double)] = []
+    var completed: [(backend: String, route: String, ms: Double, stop: Bool)] = []
+    /// Fired by the markers waiters actually block on, so a wait resolves on a
+    /// real event and never a yield count (`test-timing.md`: wait for a
+    /// signal, not a clock).
+    let completedMarker = Gate()
+    let prepMarker = Gate()
+
+    func makeSink() -> RecordStartTelemetrySink {
+      RecordStartTelemetrySink(
+        breadcrumb: { _, _, _ in },
+        emitPreparation: { [self] b, r, ready, reused in
+          prep.append((b, r, ready, reused))
+          prepMarker.release()
+        },
+        emitChunkStarted: { [self] b, r, ms in
+          started.append((b, r, ms))
+        },
+        emitChunkCompleted: { [self] b, r, ms, stop in
+          completed.append((b, r, ms, stop))
+          completedMarker.release()
+        })
+    }
+  }
+
+  /// Builds a source whose detector is backed by the supplied fake, with a
+  /// per-instance sink spy. `startMonitoring` is NOT called here so each test
+  /// controls the exact moment.
+  private static func makeSource(
+    spy: SinkSpy,
+    vad: @escaping @Sendable () -> any StreamingVad,
+    prepFails: Bool = false,
+    detectorCount: Box<Int>? = nil
+  ) -> CaptureVADSignalSource {
+    CaptureVADSignalSource(
+      makeDetector: { timeout, cfg in
+        detectorCount?.value += 1
+        return SilenceDetector(
+          silenceTimeout: timeout, vadConfig: cfg,
+          makeStreamingVad: {
+            if prepFails { throw PrepFailure() }
+            return vad()
+          })
+      },
+      recordStartTelemetry: spy.makeSink())
+  }
+
+  @MainActor final class Box<T> {
+    var value: T
+    init(_ v: T) { value = v }
+  }
+
+  /// Feeds whole VAD chunks through the fake's own delivery API rather than
+  /// reaching into its private storage.
+  private static func feedChunks(_ capture: FakeAudioCapture, _ n: Int) {
+    capture.deliverBuffer(frameCount: SilenceDetector.chunkSize * n, amplitude: 0.1)
+  }
+
+  /// Drives the source to a live monitor with one chunk available.
+  private static func begin(
+    _ source: CaptureVADSignalSource, capture: FakeAudioCapture,
+    sid: SessionID, backend: String, live: Box<Bool>
+  ) {
+    source.configureSession(config: .testDefault(), audioCapture: capture)
+    source.setCurrentSessionID(sid)
+    source.startMonitoring(
+      recordingStartTime: Date(), backend: backend, isRecording: { live.value })
+  }
+
+  /// Waits for the gate's entry signal with a BOUNDED net.
+  ///
+  /// Deliberately not an unconditional `withCheckedContinuation` await on the
+  /// entry signal: `swift-patterns.md` RULE: tests-no-unconditional-continuation-await
+  /// exists because a signal that never fires HANGS the suite instead of
+  /// failing it. I hit exactly that — a 10-minute wedge — before reverting to
+  /// this shape. The bound is a failure net; the returned Bool is asserted by
+  /// every caller, so a missing signal fails loudly and fast.
+  private static func awaitSignal(_ gate: Gate, limit: Int = 20_000) async -> Bool {
+    for _ in 0..<limit {
+      if gate.entered { return true }
+      await Task.yield()
+    }
+    return gate.entered
+  }
+
+  /// Old-run marker counts, captured at the invalidation point.
+  struct MarkerBaseline: Equatable {
+    var prep = 0
+    var started = 0
+    var completed = 0
+  }
+
+  private static func baseline(_ spy: SinkSpy, backend: String) -> MarkerBaseline {
+    MarkerBaseline(
+      prep: spy.prep.filter { $0.backend == backend }.count,
+      started: spy.started.filter { $0.backend == backend }.count,
+      completed: spy.completed.filter { $0.backend == backend }.count)
+  }
+
+  /// Absence proof for a superseded run, BASELINE-AWARE.
+  ///
+  /// First-chunk tests legitimately hold a preparation + started marker for the
+  /// old backend BEFORE invalidation. An earlier version treated those as a
+  /// leak and returned instantly, so it never waited for the stale `completed`
+  /// callback — that is why mutation detection silently fell from 6/6 to 3/6.
+  /// This waits only for an old-backend count to EXCEED its baseline.
+  ///
+  /// An absence can only be established up to a bound, so the loop is a FAILURE
+  /// NET, never the proof: it exits early the instant a genuine leak appears so
+  /// the caller's assertion fails loudly instead of passing silently.
+  private static func settleAwaitingNoLeak(
+    _ spy: SinkSpy, oldBackend: String, baseline base: MarkerBaseline, limit: Int = 5_000
+  ) async {
+    for _ in 0..<limit {
+      if baseline(spy, backend: oldBackend) != base { return }
+      await Task.yield()
+    }
+  }
+
+  @Test("markers carry the backend and route captured at monitor start")
+  func snapshotsAreTakenSynchronously() async throws {
+    let spy = SinkSpy()
+    let capture = FakeAudioCapture()
+    capture.routeOverride = "routeA"
+    Self.feedChunks(capture, 1)
+    let live = Box(true)
+    let source = Self.makeSource(spy: spy, vad: { OpenVad() })
+
+    Self.begin(source, capture: capture, sid: SessionID(), backend: "backendA", live: live)
+    // Mutate the route before the task first executes: the markers must keep A.
+    capture.routeOverride = "routeB"
+
+    try #require(
+      await Self.awaitSignal(spy.completedMarker),
+      "the run never completed its first chunk — the test would be vacuous")
+    live.value = false
+    await source.finalizeAtStop(rawSampleCount: capture.capturedSamples.count)
+
+    #expect(spy.prep.count == 1)
+    #expect(spy.started.count == 1)
+    #expect(spy.completed.count == 1)
+    // Backend AND route, on all three markers. Asserting route alone would let a
+    // backend regression through on started/completed.
+    #expect(spy.prep.allSatisfy { $0.backend == "backendA" && $0.route == "routeA" })
+    #expect(spy.started.allSatisfy { $0.backend == "backendA" && $0.route == "routeA" })
+    #expect(spy.completed.allSatisfy { $0.backend == "backendA" && $0.route == "routeA" })
+    #expect(spy.completed.first?.stop == false)
+  }
+
+  @Test("a run superseded before it first executes emits nothing")
+  func staleSessionBeforeFirstExecution() async {
+    let spy = SinkSpy()
+    let capture = FakeAudioCapture()
+    Self.feedChunks(capture, 1)
+    let live = Box(true)
+    let source = Self.makeSource(spy: spy, vad: { OpenVad() })
+
+    Self.begin(source, capture: capture, sid: SessionID(), backend: "old", live: live)
+    // Synchronously stamp a new session before the task body runs.
+    source.setCurrentSessionID(SessionID())
+    live.value = false
+
+    await Self.settleAwaitingNoLeak(spy, oldBackend: "old", baseline: MarkerBaseline())
+
+    #expect(spy.prep.isEmpty)
+    #expect(spy.started.isEmpty)
+    #expect(spy.completed.isEmpty)
+  }
+
+  @Test("model_reused is read before preparation, so the first run reports false")
+  func modelReusedOrderingAcrossRuns() async throws {
+    let spy = SinkSpy()
+    let capture = FakeAudioCapture()
+    Self.feedChunks(capture, 1)
+    let live = Box(true)
+    let count = Box(0)
+    let source = Self.makeSource(
+      spy: spy, vad: { OpenVad() }, detectorCount: count)
+    let sid = SessionID()
+
+    Self.begin(source, capture: capture, sid: sid, backend: "b", live: live)
+    try #require(
+      await Self.awaitSignal(spy.completedMarker),
+      "first run never completed — the reuse comparison would be vacuous")
+    live.value = false
+    await source.finalizeAtStop(rawSampleCount: capture.capturedSamples.count)
+
+    // Second run reuses the retained, now-ready detector.
+    spy.completedMarker.reset()
+    live.value = true
+    Self.feedChunks(capture, 1)
+    Self.begin(source, capture: capture, sid: sid, backend: "b", live: live)
+    try #require(
+      await Self.awaitSignal(spy.completedMarker),
+      "second run never completed — the reuse comparison would be vacuous")
+    live.value = false
+    await source.finalizeAtStop(rawSampleCount: capture.capturedSamples.count)
+
+    #expect(count.value == 1)
+    #expect(spy.prep.count == 2)
+    #expect(spy.prep.first?.reused == false)
+    #expect(spy.prep.last?.reused == true)
+  }
+
+  @Test("failed preparation still emits the marker with ready false")
+  func failedPreparationEmitsReadyFalse() async throws {
+    let spy = SinkSpy()
+    let capture = FakeAudioCapture()
+    capture.routeOverride = "r"
+    Self.feedChunks(capture, 1)
+    let live = Box(true)
+    let source = Self.makeSource(spy: spy, vad: { OpenVad() }, prepFails: true)
+
+    Self.begin(source, capture: capture, sid: SessionID(), backend: "bk", live: live)
+    try #require(
+      await Self.awaitSignal(spy.prepMarker),
+      "preparation marker never fired — the test would be vacuous")
+    live.value = false
+
+    #expect(spy.prep.count == 1)
+    #expect(spy.prep.first?.ready == false)
+    #expect(spy.prep.first?.reused == false)
+    #expect(spy.prep.first?.backend == "bk")
+    #expect(spy.prep.first?.route == "r")
+    #expect(spy.started.isEmpty)
+    #expect(spy.completed.isEmpty)
+  }
+
+  /// Builds a source whose DETECTOR PREPARATION suspends on `gate`, so the run
+  /// can be interrupted while sitting inside `prepare()`.
+  private static func makeGatedPrepSource(
+    spy: SinkSpy, gate: Gate
+  ) -> CaptureVADSignalSource {
+    CaptureVADSignalSource(
+      makeDetector: { timeout, cfg in
+        SilenceDetector(
+          silenceTimeout: timeout, vadConfig: cfg,
+          makeStreamingVad: {
+            gate.markEntered()
+            await gate.wait()
+            return OpenVad()
+          })
+      },
+      recordStartTelemetry: spy.makeSink())
+  }
+
+  /// Suspended at PREPARATION, interrupted three ways. In every case the run
+  /// resumes afterwards and must emit nothing.
+  private static func assertPreparationSuspendedRunIsSilenced(
+    invalidate: @MainActor (CaptureVADSignalSource, FakeAudioCapture, SessionID) -> Void
+  ) async throws -> SinkSpy {
+    let spy = SinkSpy()
+    let gate = Gate()
+    let capture = FakeAudioCapture()
+    feedChunks(capture, 1)
+    let live = Box(true)
+    let source = makeGatedPrepSource(spy: spy, gate: gate)
+    let sid = SessionID()
+
+    begin(source, capture: capture, sid: sid, backend: "b", live: live)
+    try #require(
+      await awaitSignal(gate),
+      "preparation never suspended — the test would be vacuous")
+
+    let base = baseline(spy, backend: "b")
+    try #require(
+      base == MarkerBaseline(),
+      "preparation-suspended run should hold no markers yet")
+
+    invalidate(source, capture, sid)
+
+    // The recording stays LIVE across the whole absence window on purpose. If
+    // it were ended here, the guard's liveness term alone would suppress the
+    // superseded run and this test would stop proving the GENERATION term —
+    // it would pass with the generation check deleted.
+    gate.release()  // resume the superseded run
+    await settleAwaitingNoLeak(spy, oldBackend: "b", baseline: base)
+    #expect(
+      baseline(spy, backend: "b") == base,
+      "superseded run emitted after invalidation")
+    live.value = false  // cleanup only, after the assertion
+    return spy
+  }
+
+  @Test("configureSession silences a run suspended in preparation")
+  func prepSuspendedInvalidatedByConfigureSession() async throws {
+    let spy = try await Self.assertPreparationSuspendedRunIsSilenced { source, capture, _ in
+      source.configureSession(config: .testDefault(), audioCapture: capture)
+    }
+    #expect(spy.prep.contains { $0.backend == "b" } == false)
+    #expect(spy.started.contains { $0.backend == "b" } == false)
+    #expect(spy.completed.contains { $0.backend == "b" } == false)
+  }
+
+  @Test("same-session startMonitoring replacement silences a run suspended in preparation")
+  func prepSuspendedInvalidatedByReplacement() async throws {
+    // SAME SessionID on purpose: only the generation can catch this.
+    let spy = try await Self.assertPreparationSuspendedRunIsSilenced { source, _, sid in
+      source.setCurrentSessionID(sid)
+      source.startMonitoring(
+        recordingStartTime: Date(), backend: "replacement", isRecording: { false })
+    }
+    #expect(spy.prep.contains { $0.backend == "b" } == false)
+    #expect(spy.started.contains { $0.backend == "b" } == false)
+    #expect(spy.completed.contains { $0.backend == "b" } == false)
+  }
+
+  @Test("finalizeAtStop silences a run suspended in preparation")
+  func prepSuspendedInvalidatedByFinalize() async throws {
+    let spy = SinkSpy()
+    let gate = Gate()
+    let capture = FakeAudioCapture()
+    Self.feedChunks(capture, 1)
+    let live = Box(true)
+    let source = Self.makeGatedPrepSource(spy: spy, gate: gate)
+
+    Self.begin(source, capture: capture, sid: SessionID(), backend: "b", live: live)
+    try #require(
+      await Self.awaitSignal(gate),
+      "preparation never suspended — the test would be vacuous")
+
+    // `directDetectorPrepared` is still false while preparation is suspended,
+    // so finalize does not await the detector actor and can be awaited directly.
+    // No task, no yield count.
+    let base = Self.baseline(spy, backend: "b")
+    try #require(
+      base == MarkerBaseline(),
+      "preparation-suspended run should hold no markers yet")
+    await source.finalizeAtStop(rawSampleCount: 0)
+    // Recording stays LIVE across the absence window so this proves the
+    // GENERATION term, not the liveness term.
+    gate.release()
+    await Self.settleAwaitingNoLeak(spy, oldBackend: "b", baseline: base)
+    #expect(Self.baseline(spy, backend: "b") == base, "emitted after finalizeAtStop")
+    live.value = false  // cleanup only, after the assertion
+
+    #expect(spy.prep.contains { $0.backend == "b" } == false)
+    #expect(spy.started.contains { $0.backend == "b" } == false)
+    #expect(spy.completed.contains { $0.backend == "b" } == false)
+  }
+
+  /// Suspended inside the FIRST CHUNK. Preparation and `started` have already
+  /// legitimately emitted; only `completed` must be suppressed.
+  private static func assertFirstChunkSuspendedRunIsSilenced(
+    invalidate: @MainActor (CaptureVADSignalSource, FakeAudioCapture, SessionID) -> Void
+  ) async throws -> SinkSpy {
+    let spy = SinkSpy()
+    let gate = Gate()
+    let capture = FakeAudioCapture()
+    feedChunks(capture, 1)
+    let live = Box(true)
+    let source = makeSource(spy: spy, vad: { GatedChunkVad(gate: gate) })
+    let sid = SessionID()
+
+    begin(source, capture: capture, sid: sid, backend: "b", live: live)
+    try #require(
+      await awaitSignal(gate),
+      "first chunk never suspended — the test would be vacuous")
+
+    // The full baseline subsumes the individual pre-checks: it asserts the
+    // valid prep+started already fired AND that `completed` has not.
+    let base = baseline(spy, backend: "b")
+    try #require(
+      base == MarkerBaseline(prep: 1, started: 1, completed: 0),
+      "first-chunk-suspended run should hold exactly its valid prep+started")
+
+    invalidate(source, capture, sid)
+
+    // Recording stays LIVE across the absence window — see the preparation
+    // harness: ending it here would mask the generation term.
+    gate.release()
+    await settleAwaitingNoLeak(spy, oldBackend: "b", baseline: base)
+    #expect(
+      baseline(spy, backend: "b") == base,
+      "superseded run emitted after invalidation")
+    live.value = false  // cleanup only, after the assertion
+    return spy
+  }
+
+  @Test("configureSession silences a run suspended in first-chunk processing")
+  func chunkSuspendedInvalidatedByConfigureSession() async throws {
+    let spy = try await Self.assertFirstChunkSuspendedRunIsSilenced { source, capture, _ in
+      source.configureSession(config: .testDefault(), audioCapture: capture)
+    }
+    #expect(
+      spy.completed.contains { $0.backend == "b" } == false,
+      "stale completed marker escaped after invalidation")
+  }
+
+  @Test("same-session startMonitoring replacement silences a first-chunk-suspended run")
+  func chunkSuspendedInvalidatedByReplacement() async throws {
+    // SAME SessionID: this is the test that fails if the generation guard is
+    // dropped and only the session is compared.
+    let spy = try await Self.assertFirstChunkSuspendedRunIsSilenced { source, _, sid in
+      source.setCurrentSessionID(sid)
+      source.startMonitoring(
+        recordingStartTime: Date(), backend: "replacement", isRecording: { false })
+    }
+    #expect(
+      spy.completed.contains { $0.backend == "b" } == false,
+      "old generation emitted into a same-session replacement")
+  }
+
+  @Test("finalizeAtStop silences a run suspended in first-chunk processing")
+  func chunkSuspendedInvalidatedByFinalize() async throws {
+    let spy = SinkSpy()
+    let gate = Gate()
+    let capture = FakeAudioCapture()
+    Self.feedChunks(capture, 1)
+    let live = Box(true)
+    let cancelSeen = Gate()
+    let source = Self.makeSource(
+      spy: spy, vad: { GatedChunkVad(gate: gate, cancelSeen: cancelSeen) })
+
+    Self.begin(source, capture: capture, sid: SessionID(), backend: "b", live: live)
+    try #require(
+      await Self.awaitSignal(gate),
+      "first chunk never suspended — the test would be vacuous")
+
+    // finalizeAtStop awaits the detector actor here, so run it concurrently and
+    // wait on the fake's CANCELLATION signal — deterministic proof that
+    // invalidateMonitor() ran, not a guessed number of yields.
+    let finalizeTask = Task { await source.finalizeAtStop(rawSampleCount: 0) }
+    try #require(
+      await Self.awaitSignal(cancelSeen),
+      "monitor was never cancelled — the test would be vacuous")
+
+    // Subsumes the pre-checks: valid prep+started present, `completed` absent.
+    let base = Self.baseline(spy, backend: "b")
+    try #require(
+      base == MarkerBaseline(prep: 1, started: 1, completed: 0),
+      "first-chunk-suspended run should hold exactly its valid prep+started")
+    // Recording stays LIVE across the absence window so this proves the
+    // GENERATION term, not the liveness term.
+    gate.release()
+    _ = await finalizeTask.value
+    await Self.settleAwaitingNoLeak(spy, oldBackend: "b", baseline: base)
+
+    #expect(
+      Self.baseline(spy, backend: "b") == base,
+      "superseded run emitted after finalizeAtStop")
+    live.value = false  // cleanup only, after the assertion
+    #expect(
+      spy.completed.contains { $0.backend == "b" } == false,
+      "stale completed marker escaped after finalizeAtStop")
+  }
+
+  // MARK: - Terminal paths that never reach finalizeAtStop (#1780, whole-diff review)
+  //
+  // `RecordingSessionKernel` concludes a session through ~40 `finishTerminal`
+  // sites — cancellation, capture-start failure, model wedge, capture stall,
+  // ASR failure — and ONLY the normal stop path reaches `finalizeAtStop`. On all
+  // the others the session id and the monitor generation are both unchanged, so
+  // a session-plus-generation guard alone would let a task suspended in
+  // preparation or in first-chunk processing wake up and emit into a recording
+  // that has already ended. These two freeze the liveness term that closes it.
+
+  @Test("a terminal that never calls finalizeAtStop silences a preparation-suspended run")
+  func prepSuspendedSilencedByRecordingEnding() async throws {
+    let spy = SinkSpy()
+    let gate = Gate()
+    let capture = FakeAudioCapture()
+    Self.feedChunks(capture, 1)
+    let live = Box(true)
+    let source = Self.makeGatedPrepSource(spy: spy, gate: gate)
+
+    Self.begin(source, capture: capture, sid: SessionID(), backend: "b", live: live)
+    try #require(
+      await Self.awaitSignal(gate),
+      "preparation never suspended — the test would be vacuous")
+
+    let base = Self.baseline(spy, backend: "b")
+    try #require(
+      base == MarkerBaseline(),
+      "preparation-suspended run should hold no markers yet")
+
+    // The ONLY thing that happens is the recording ending. No configureSession,
+    // no new SessionID, no startMonitoring replacement, no finalizeAtStop —
+    // exactly what a cancel or a capture-start failure looks like to this source.
+    live.value = false
+
+    gate.release()
+    await Self.settleAwaitingNoLeak(spy, oldBackend: "b", baseline: base)
+
+    #expect(
+      Self.baseline(spy, backend: "b") == base,
+      "a concluded recording still emitted a preparation marker")
+  }
+
+  @Test("a terminal that never calls finalizeAtStop silences a first-chunk-suspended run")
+  func chunkSuspendedSilencedByRecordingEnding() async throws {
+    let spy = SinkSpy()
+    let gate = Gate()
+    let capture = FakeAudioCapture()
+    Self.feedChunks(capture, 1)
+    let live = Box(true)
+    let source = Self.makeSource(spy: spy, vad: { GatedChunkVad(gate: gate) })
+
+    Self.begin(source, capture: capture, sid: SessionID(), backend: "b", live: live)
+    try #require(
+      await Self.awaitSignal(gate),
+      "first chunk never suspended — the test would be vacuous")
+
+    let base = Self.baseline(spy, backend: "b")
+    try #require(
+      base == MarkerBaseline(prep: 1, started: 1, completed: 0),
+      "first-chunk-suspended run should hold exactly its valid prep+started")
+
+    live.value = false
+
+    gate.release()
+    await Self.settleAwaitingNoLeak(spy, oldBackend: "b", baseline: base)
+
+    #expect(
+      Self.baseline(spy, backend: "b") == base,
+      "a concluded recording still emitted a first-chunk completion marker")
+  }
+
 }

--- a/Tests/EnviousWisprTests/Pipeline/RecordStartTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordStartTelemetrySinkTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Dual-channel parity freeze for the record-start VAD markers (#1780).
+///
+/// The whole diagnostic value of these markers depends on BOTH channels firing:
+/// the Sentry breadcrumb is what survives inside a crash report (it is how
+/// #1780 was reconstructed), the PostHog event is what answers the fleet
+/// question. A marker that emits only one is a defect, so each test asserts
+/// exactly one of each and no extras.
+///
+/// Spies are per-instance injected closures, never the process-global
+/// `SentryBreadcrumb.breadcrumbDelegate` or `TelemetryService.testEventHook`
+/// (`swift-patterns.md` RULE: tests-no-process-global-mutable-delegate).
+@MainActor
+@Suite("Record-start VAD telemetry parity (#1780)")
+struct RecordStartTelemetrySinkTests {
+
+  @MainActor
+  private final class Spy {
+    var breadcrumbs: [(stage: String, message: String, data: [String: Any])] = []
+    var preparation: [(String, String, Bool, Bool)] = []
+    var chunkStarted: [(String, String, Double)] = []
+    var chunkCompleted: [(String, String, Double, Bool)] = []
+
+    func makeSink() -> RecordStartTelemetrySink {
+      RecordStartTelemetrySink(
+        breadcrumb: { [self] stage, message, data in
+          breadcrumbs.append((stage, message, data))
+        },
+        emitPreparation: { [self] b, r, ready, reused in
+          preparation.append((b, r, ready, reused))
+        },
+        emitChunkStarted: { [self] b, r, ms in chunkStarted.append((b, r, ms)) },
+        emitChunkCompleted: { [self] b, r, ms, stop in
+          chunkCompleted.append((b, r, ms, stop))
+        })
+    }
+  }
+
+  @Test("preparation_completed emits one breadcrumb and one event")
+  func preparationParity() {
+    let spy = Spy()
+    spy.makeSink().vadPreparationCompleted(
+      backend: "parakeet", inputRoute: "built_in_mic", ready: true, modelReused: true)
+
+    #expect(spy.breadcrumbs.count == 1)
+    #expect(spy.preparation.count == 1)
+    #expect(spy.chunkStarted.isEmpty)
+    #expect(spy.chunkCompleted.isEmpty)
+
+    let crumb = try! #require(spy.breadcrumbs.first)
+    #expect(crumb.stage == "vad")
+    #expect(crumb.message == "vad#preparation_completed")
+    #expect(crumb.data["backend"] as? String == "parakeet")
+    #expect(crumb.data["input_route"] as? String == "built_in_mic")
+    #expect(crumb.data["ready"] as? Bool == true)
+    #expect(crumb.data["model_reused"] as? Bool == true)
+    #expect(crumb.data.count == 4)
+
+    let emitted = try! #require(spy.preparation.first)
+    #expect(emitted.0 == "parakeet")
+    #expect(emitted.1 == "built_in_mic")
+    #expect(emitted.2 == true)
+    #expect(emitted.3 == true)
+  }
+
+  @Test("first_chunk_started emits one breadcrumb and one event")
+  func chunkStartedParity() {
+    let spy = Spy()
+    spy.makeSink().firstChunkStarted(
+      backend: "whisperKit", inputRoute: "bluetooth", monitorToFirstChunkMs: 7.5)
+
+    #expect(spy.breadcrumbs.count == 1)
+    #expect(spy.chunkStarted.count == 1)
+    #expect(spy.preparation.isEmpty)
+    #expect(spy.chunkCompleted.isEmpty)
+
+    let crumb = try! #require(spy.breadcrumbs.first)
+    #expect(crumb.stage == "vad")
+    #expect(crumb.message == "vad#first_chunk_started")
+    #expect(crumb.data["backend"] as? String == "whisperKit")
+    #expect(crumb.data["input_route"] as? String == "bluetooth")
+    #expect(crumb.data["monitor_to_first_chunk_ms"] as? Double == 7.5)
+    #expect(crumb.data.count == 3)
+
+    let emitted = try! #require(spy.chunkStarted.first)
+    #expect(emitted.0 == "whisperKit")
+    #expect(emitted.1 == "bluetooth")
+    #expect(emitted.2 == 7.5)
+  }
+
+  @Test("first_chunk_completed emits one breadcrumb and one event")
+  func chunkCompletedParity() {
+    let spy = Spy()
+    spy.makeSink().firstChunkCompleted(
+      backend: "parakeet", inputRoute: "built_in_mic",
+      chunkProcessingLatencyMs: 2.25, shouldStop: true)
+
+    #expect(spy.breadcrumbs.count == 1)
+    #expect(spy.chunkCompleted.count == 1)
+    #expect(spy.preparation.isEmpty)
+    #expect(spy.chunkStarted.isEmpty)
+
+    let crumb = try! #require(spy.breadcrumbs.first)
+    #expect(crumb.stage == "vad")
+    #expect(crumb.message == "vad#first_chunk_completed")
+    #expect(crumb.data["backend"] as? String == "parakeet")
+    #expect(crumb.data["input_route"] as? String == "built_in_mic")
+    #expect(crumb.data["chunk_processing_latency_ms"] as? Double == 2.25)
+    #expect(crumb.data["should_stop"] as? Bool == true)
+    #expect(crumb.data.count == 4)
+
+    let emitted = try! #require(spy.chunkCompleted.first)
+    #expect(emitted.0 == "parakeet")
+    #expect(emitted.1 == "built_in_mic")
+    #expect(emitted.2 == 2.25)
+    #expect(emitted.3 == true)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -94,7 +94,10 @@ final class FakeAudioCapture: AudioCaptureInterface {
   private(set) var isCapturing = false
   var audioLevel: Float { 0 }
   var capturedSamples: [Float] { accumulatedSamples }
-  var currentAudioRoute: String { "fake" }
+  /// #1780: tests mutate this to prove the record-start markers carry the
+  /// route captured at monitor start, not a later value. Default unchanged.
+  var routeOverride: String = "fake"
+  var currentAudioRoute: String { routeOverride }
   var currentResolvedRoute: ResolvedRouteTransports? { nil }
   private(set) var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool { isCapturing }

--- a/Tests/EnviousWisprTests/Pipeline/VADMonitorLoopTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/VADMonitorLoopTests.swift
@@ -1,7 +1,9 @@
 import EnviousWisprCore
+@preconcurrency import FluidAudio
 import Foundation
 import Testing
 
+@testable import EnviousWisprAudio
 @testable import EnviousWisprPipeline
 
 // MARK: - VADMonitorLoopTests (#1060)
@@ -108,5 +110,195 @@ import Testing
     #expect(rec.stops == [.maxDuration])
     // The cap check precedes the warning check, so no warning fires at exactly the cap.
     #expect(rec.warningRemaining.isEmpty)
+  }
+
+  // MARK: - First-chunk observation (#1780)
+  //
+  // The started/completed pair is the diagnostic added for #1780: a crash with
+  // `started` present and `completed` absent localises a fatal failure to
+  // first-chunk processing, which contains the CoreML path seen in the
+  // production crash.
+  // These tests freeze the ordering the pair depends on, the once-per-run
+  // latch, and the caught-error path.
+
+  /// Lock-backed because the fake `StreamingVad` is an actor while the loop's
+  /// callbacks are `@MainActor` — both write this trace, so it is genuinely
+  /// cross-actor and needs real synchronisation, not an unlocked box.
+  final class Trace: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [String] = []
+    private var chunks = 0
+
+    func record(_ event: String) { lock.withLock { entries.append(event) } }
+    func countChunk() { lock.withLock { chunks += 1 } }
+    var events: [String] { lock.withLock { entries } }
+    var chunkCount: Int { lock.withLock { chunks } }
+  }
+
+  /// Records entry and exit around the real `SilenceDetector.processChunk`, so
+  /// the callbacks can be proven to bracket the actual VAD work.
+  actor TracingVad: StreamingVad {
+    private let trace: Trace
+    private let shouldThrow: Bool
+
+    init(trace: Trace, shouldThrow: Bool = false) {
+      self.trace = trace
+      self.shouldThrow = shouldThrow
+    }
+
+    struct Boom: Error {}
+
+    func processStreamingChunk(
+      _ audioChunk: [Float],
+      state: VadStreamState,
+      config: VadSegmentationConfig,
+      returnSeconds: Bool,
+      timeResolution: Int
+    ) async throws -> VadStreamResult {
+      trace.record("vad_enter")
+      trace.countChunk()
+      if shouldThrow {
+        trace.record("vad_throw")
+        throw Boom()
+      }
+      trace.record("vad_exit")
+      var next = state
+      next.processedSamples += audioChunk.count
+      return VadStreamResult(state: next, event: nil, probability: 0.0)
+    }
+  }
+
+  /// Deterministic monotonic clock: returns the scripted values in order, then
+  /// repeats the last one. No real time enters any assertion.
+  @MainActor final class ScriptedClock {
+    private var values: [TimeInterval]
+    private var index = 0
+    init(_ values: [TimeInterval]) { self.values = values }
+    func next() -> TimeInterval {
+      let v = values[min(index, values.count - 1)]
+      index += 1
+      return v
+    }
+  }
+
+  @MainActor final class ChunkRecorder {
+    var started: [Double] = []
+    var completed: [(Double, Bool)] = []
+    var stops: [VADStopReason] = []
+  }
+
+  private static func samples(chunks: Int) -> [Float] {
+    [Float](repeating: 0.0, count: SilenceDetector.chunkSize * chunks)
+  }
+
+  /// Drives the real `SilenceDetector` over `chunkCount` chunks, stopping the
+  /// loop on a SIGNAL (chunks actually processed), never a wall-clock wait.
+  private static func runLoop(
+    trace: Trace,
+    rec: ChunkRecorder,
+    clock: ScriptedClock,
+    chunkCount: Int,
+    shouldThrow: Bool = false
+  ) async throws {
+    let vad = TracingVad(trace: trace, shouldThrow: shouldThrow)
+    let detector = SilenceDetector(makeStreamingVad: { vad })
+    try await detector.prepare()
+
+    await VADMonitorLoop.run(
+      detector: detector, vadAutoStop: true,
+      maxDuration: 3600, warningLead: 0,
+      recordingStartTime: Self.start,
+      sampleProvider: { samples(chunks: chunkCount) },
+      isRecording: { trace.chunkCount < chunkCount },
+      now: { Self.start },
+      onApproachingMaxDuration: { _ in },
+      onStop: { rec.stops.append($0) },
+      monotonicNow: { clock.next() },
+      onFirstChunkStarted: { ms in
+        rec.started.append(ms)
+        trace.record("started")
+      },
+      onFirstChunkCompleted: { ms, stop in
+        rec.completed.append((ms, stop))
+        trace.record("completed")
+      }
+    )
+  }
+
+  @Test("first-chunk callbacks bracket the VAD call and carry injected timings")
+  func firstChunkOrderingAndMeasurement() async throws {
+    let trace = Trace()
+    let rec = ChunkRecorder()
+    // run entry 100.0 -> marker emitted 100.5 -> chunk start 100.75 -> end 100.875.
+    // The 0.25s gap between marker and chunk start is the synchronous cost of the
+    // `started` telemetry write. `chunk_processing_latency_ms` must EXCLUDE it:
+    // 125ms, not 375ms. Timing the chunk from before the callback would report
+    // 375 and silently fold telemetry cost into a metric named for chunk work.
+    //
+    // Every value is an exact binary fraction (x.5 / x.75 / x.875) so the
+    // subtractions are exact and the assertions can compare with ==. 100.6 is
+    // not representable and leaves residue (150.00000000000568), which is the
+    // classic FP-boundary trap in scripted-clock tests.
+    let clock = ScriptedClock([100.0, 100.5, 100.75, 100.875])
+
+    try await Self.runLoop(trace: trace, rec: rec, clock: clock, chunkCount: 1)
+
+    #expect(trace.events == ["started", "vad_enter", "vad_exit", "completed"])
+    #expect(rec.started == [500.0])
+    #expect(rec.completed.count == 1)
+    #expect(
+      rec.completed.first?.0 == 125.0,
+      "chunk latency must exclude the started-marker write")
+    #expect(rec.completed.first?.1 == false)
+  }
+
+  @Test("first-chunk pair fires once per run even though later chunks process")
+  func firstChunkLatchIsOncePerRun() async throws {
+    let trace = Trace()
+    let rec = ChunkRecorder()
+    let clock = ScriptedClock([10.0, 10.1, 10.1, 10.2])
+
+    try await Self.runLoop(trace: trace, rec: rec, clock: clock, chunkCount: 3)
+
+    #expect(trace.chunkCount == 3)
+    #expect(rec.started.count == 1)
+    #expect(rec.completed.count == 1)
+    #expect(trace.events.filter { $0 == "started" }.count == 1)
+    #expect(trace.events.filter { $0 == "completed" }.count == 1)
+  }
+
+  @Test("a second run emits its own fresh first-chunk pair")
+  func firstChunkPairIsFreshPerRun() async throws {
+    let rec = ChunkRecorder()
+
+    let trace1 = Trace()
+    try await Self.runLoop(
+      trace: trace1, rec: rec, clock: ScriptedClock([0.0, 0.25, 0.25, 0.5]), chunkCount: 1)
+    let trace2 = Trace()
+    try await Self.runLoop(
+      trace: trace2, rec: rec, clock: ScriptedClock([0.0, 0.75, 0.75, 1.0]), chunkCount: 1)
+
+    #expect(rec.started == [250.0, 750.0])
+    #expect(rec.completed.count == 2)
+    #expect(rec.completed.map(\.1) == [false, false])
+  }
+
+  @Test("a thrown StreamingVad error still emits both callbacks with shouldStop false")
+  func firstChunkPairSurvivesCaughtVadError() async throws {
+    let trace = Trace()
+    let rec = ChunkRecorder()
+    let clock = ScriptedClock([5.0, 5.1, 5.1, 5.3])
+
+    // `SilenceDetector.processChunk` is non-throwing: it catches the underlying
+    // StreamingVad error and returns false. There is no throwing path out of it,
+    // so the pair must still complete.
+    try await Self.runLoop(
+      trace: trace, rec: rec, clock: clock, chunkCount: 1, shouldThrow: true)
+
+    #expect(trace.events == ["started", "vad_enter", "vad_throw", "completed"])
+    #expect(rec.started.count == 1)
+    #expect(rec.completed.count == 1)
+    #expect(rec.completed.first?.1 == false)
+    #expect(rec.stops.isEmpty)
   }
 }

--- a/Tests/EnviousWisprTests/Services/RecordStartTelemetryServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/RecordStartTelemetryServiceTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// Schema freeze for the three record-start VAD markers (#1780).
+///
+/// These assert the exact PostHog event names, keys, values and typed buckets
+/// that `TelemetryService` owns. The sink parity tests deliberately do NOT
+/// cover this: they prove one-breadcrumb-plus-one-call, not the names or
+/// serialization, which live here.
+///
+/// `.serialized` because `testEventHook` is process-global; concurrent suites
+/// would cross-capture (`swift-patterns.md`
+/// RULE: tests-no-process-global-mutable-delegate applies to production code —
+/// this hook is a DEBUG-only test seam, so serialize rather than inject).
+#if DEBUG
+  @MainActor
+  @Suite("Record-start VAD telemetry schema (#1780)", .serialized)
+  struct RecordStartTelemetryServiceTests {
+
+    /// Captures exactly the events emitted inside `body`, then always restores
+    /// the global hook so a failure cannot leak into a sibling suite.
+    private func capture(
+      _ body: () -> Void
+    ) -> [CapturedTelemetryEvent] {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { event in box.append(event) }
+      defer { TelemetryService.shared.testEventHook = nil }
+      body()
+      return box.events
+    }
+
+    /// Locked to match `DictationInvokedTelemetryTests.EventBox`: the hook is
+    /// `@Sendable`, so `@unchecked Sendable` must be backed by real
+    /// synchronisation rather than an assumption about call-site threading.
+    private final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+
+      func append(_ event: CapturedTelemetryEvent) {
+        lock.withLock { stored.append(event) }
+      }
+
+      var events: [CapturedTelemetryEvent] {
+        lock.withLock { stored }
+      }
+    }
+
+    @Test("preparation_completed emits its exact schema")
+    func preparationSchema() {
+      let events = capture {
+        TelemetryService.shared.dictationVADPreparationCompleted(
+          backend: "parakeet", inputRoute: "built_in_mic", ready: true, modelReused: false)
+      }
+
+      #expect(events.count == 1)
+      let e = try! #require(events.first)
+      #expect(e.name == "dictation.vad_preparation_completed")
+      #expect(e.stringProps == ["backend": "parakeet", "input_route": "built_in_mic"])
+      #expect(e.boolProps == ["ready": true, "model_reused": false])
+      #expect(e.intProps.isEmpty)
+      #expect(e.doubleProps.isEmpty)
+    }
+
+    @Test("first_vad_chunk_started emits its exact schema")
+    func chunkStartedSchema() {
+      let events = capture {
+        TelemetryService.shared.dictationFirstVADChunkStarted(
+          backend: "whisperKit", inputRoute: "bluetooth", monitorToFirstChunkMs: 12.5)
+      }
+
+      #expect(events.count == 1)
+      let e = try! #require(events.first)
+      #expect(e.name == "dictation.first_vad_chunk_started")
+      #expect(e.stringProps == ["backend": "whisperKit", "input_route": "bluetooth"])
+      #expect(e.doubleProps == ["monitor_to_first_chunk_ms": 12.5])
+      #expect(e.boolProps.isEmpty)
+      #expect(e.intProps.isEmpty)
+    }
+
+    @Test("first_vad_chunk_completed emits its exact schema")
+    func chunkCompletedSchema() {
+      let events = capture {
+        TelemetryService.shared.dictationFirstVADChunkCompleted(
+          backend: "parakeet", inputRoute: "built_in_mic",
+          chunkProcessingLatencyMs: 3.25, shouldStop: false)
+      }
+
+      #expect(events.count == 1)
+      let e = try! #require(events.first)
+      #expect(e.name == "dictation.first_vad_chunk_completed")
+      #expect(e.stringProps == ["backend": "parakeet", "input_route": "built_in_mic"])
+      #expect(e.doubleProps == ["chunk_processing_latency_ms": 3.25])
+      #expect(e.boolProps == ["should_stop": false])
+      #expect(e.intProps.isEmpty)
+    }
+  }
+#endif

--- a/docs/feature-requests/issue-1780-2026-07-24-record-start-observability.md
+++ b/docs/feature-requests/issue-1780-2026-07-24-record-start-observability.md
@@ -1,0 +1,326 @@
+# Issue #1780 — VAD compute-unit pin + heart-path record-start telemetry — 2026-07-24
+
+## Preface — Lane + Live UAT declaration
+
+**Lane: Code.** Live UAT REQUIRED (audio capture + record-start path; runtime-only behaviour that logic tests cannot observe).
+**Tier: MEDIUM** (audio capture, net-new runtime telemetry). Modules: `EnviousWisprAudio`, `EnviousWisprPipeline`, `EnviousWisprServices`.
+
+## Preface — User Rubric
+
+`User Rubric: performance-only. No UI or copy changes. Aaron Wu must not pay higher repeated-dictation latency, battery drain, or thermals; Frank Chen on older supported Apple Silicon must not experience a slower first recording or delayed paste. With the compute-unit pin HELD (§2.6) this PR changes no compute scheduling, so those risks do not arise here; the residual user-facing cost is the three added synchronous PostHog queue writes per recording, measured under §11.`
+
+## 0. TL;DR
+
+Two changes, both defensible independent of #1780's unproven root cause:
+
+1. **SHIPPING — record-start observability.** THREE new VAD-interval markers, each emitted as BOTH a Sentry breadcrumb (crash-local evidence) and a PostHog event (fleet funnel), so the next record-start crash localises itself instead of requiring thread-stack forensics. The capture-established edge is NOT re-instrumented — `dictation.invoked` and the `Recording started` breadcrumb already cover it.
+2. **HELD pending founder decision — VAD compute-unit pin.** Loading the model through FluidAudio's `MLModelConfigurationUtils.defaultConfiguration()`. Coverage review (2026-07-24) recommends holding: the crash occurred on the CPU path and `.cpuAndNeuralEngine` still permits CPU, so the change does not target the observed mechanism, while altering compute scheduling for ~600 currently-working users. Requires representative cold/warm evidence plus explicit founder approval (§2.6).
+
+**Explicitly NOT shipping:** the "skip VAD when auto-stop is off" idea. §2.5 proved it unsafe — see Non-goals.
+
+## 1. Problem
+
+`EXC_BAD_ACCESS` inside `VadManager.processUnifiedModel` → `MLModel.prediction` → Espresso → BNNS, at record-start, three consecutive times for one user (macOS 14.2.1, Parakeet, built-in mic, streaming off). Root cause unproven; not reproduced on macOS 14.8.7 / 15.7.7 / 26 across all four `MLComputeUnits`, concurrent, with churn, or under a guard-page over-read probe.
+
+Two real defects surfaced during that investigation, both on the crash path:
+
+- PostHog has no record-start stage events after capture commits. Sentry already records `Recording started`, backend, streaming state, and audio route, but it has no breadcrumb immediately before and after VAD preparation or the first VAD prediction. The observability gap is therefore inside the VAD interval, not the whole record-start window.
+- We bypass the library's intended model configuration. This is a genuine mismatch, but it is a fleet-wide compute-scheduling experiment, not a correctness repair — see §2.6.
+
+## 2. Goals & non-goals
+
+**Goals.** Make the dark VAD interval observable, in both Sentry (crash-local) and PostHog (fleet). Establish whether the compute-unit mismatch is safe to correct fleet-wide, without shipping it on assumption.
+
+**Non-goals.**
+- Claiming #1780 is fixed. Neither change is proven causal; #1780 stays open.
+- **Gating VAD execution on `vadAutoStop`.** REJECTED on evidence (§2.5.3): VAD segments gate the heart path. Skipping them would silently discard quiet recordings.
+- Enabling `MLOptimizationHints`. Upstream documents a 126.6 → 93.3 RTFx regression (-26%) for this exact model.
+- Moving VAD out of process. #1543 deliberately moved capture in-process; not revisiting.
+- Shipping the compute-unit pin in this PR without the §2.6 evidence gate and explicit founder approval.
+
+## 2.5 Grounding brief
+
+### 2.5.1 Producer → owner → consumer for the VAD model configuration
+
+`BundledVADModelLoader.loadModel(in:)` (`Sources/EnviousWisprAudio/BundledVADModelLoader.swift:34`) is the sole producer of the VAD `MLModel`:
+
+```swift
+return try MLModel(contentsOf: url, configuration: MLModelConfiguration())
+```
+
+Sole consumer: `SilenceDetector`'s default `makeStreamingVad` closure (`SilenceDetector.swift:158`), which passes the loaded model to `VadManager(config:vadModel:)`.
+
+Capability grep for other producers:
+
+```
+$ grep -rn "silero-vad\|BundledVADModelLoader\|vadModel:" Sources/ Tests/ | sort
+Sources/EnviousWisprAudio/BundledVADModelLoader.swift:  (definition)
+Sources/EnviousWisprAudio/SilenceDetector.swift:158:      return VadManager(config: VadConfig(defaultThreshold: 0.5), vadModel: model)
+Tests/EnviousWisprTests/Audio/BundledVADModelLoaderTests.swift  (tests)
+```
+
+One producer, one consumer. Closed.
+
+### 2.5.2 What the library intends (checkout grep, Tier 3)
+
+`.build/checkouts/FluidAudio/Sources/FluidAudio/Shared/MLModelConfigurationUtils.swift:11`:
+
+```swift
+public static func defaultConfiguration(
+    computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+) -> MLModelConfiguration {
+    let config = MLModelConfiguration()
+    config.allowLowPrecisionAccumulationOnGPU = true
+    config.computeUnits = computeUnits
+    return config
+}
+```
+
+| Setting | Library intends | We ship today |
+|---|---|---|
+| `computeUnits` | `.cpuAndNeuralEngine` (GPU excluded) | `.all` (CoreML default) |
+| `allowLowPrecisionAccumulationOnGPU` | `true` | `false` |
+
+`VadConfig.computeUnits` also defaults to `.cpuAndNeuralEngine` (`VadTypes.swift:4`) but is applied **only** in FluidAudio's own loading path (`VadManager.swift:124`), which the already-loaded-model initialiser (`VadManager.swift:102`) bypasses. So today nothing applies it.
+
+Linkage verified: `Package.swift:92` lists `FluidAudio` as a dependency of `EnviousWisprAudio`, so the loader can import it. Per `swift-patterns.md` RULE: fluidaudio-unqualified-symbols, reference `MLModelConfigurationUtils` unqualified.
+
+### 2.5.3 Why gating VAD on `vadAutoStop` is REJECTED
+
+`VADMonitorLoop.swift:100` runs `detector.processChunk(chunk)` unconditionally; line 102 gates only the auto-stop *action* (`if shouldStop && vadAutoStop && isRecording()`). The prediction is deliberately unconditional. Consumers of its output, all reached with `vadAutoStop == false`:
+
+| Consumer | Site | Effect if segments were always empty |
+|---|---|---|
+| VAD gate | `RecordingSessionKernel.swift:1673` | `finishTerminal(.noSpeech(.vadGate))` — **recording silently discarded** |
+| Faint-speech recovery | `RecordingSessionKernel.swift:1680` | `attemptedFromEnergyDespiteNoSegments` always true |
+| Degraded-lead salvage (#1434) | `RecordingSessionKernel.swift:2124` | gated by `effectiveSpeechEvidence`; Parakeet-only via `decodesConditionedBatchSamples` — **silently disabled** |
+| Terminal routing | `RecordingSessionKernel.swift:2195` | `.noSpeech` vs user-visible `.failed(.asrEmpty)` inverted |
+| Archive labelling | `RecordingSessionKernel.swift:2424` | `asrEmpty` vs `noSpeech` mislabelled |
+| WhisperKit LID filter | `WhisperKitEngineAdapter.swift:681` | `SampleFilter.filter(from:segments:)` loses conditioning |
+| Empty-result diagnostics | `ASREmptyResultDiagnostics.swift:137` | loses first/last segment |
+
+**Correction (grounded review r1):** the table above is INCOMPLETE and one row was overclaimed. Archive labelling is inside `#if DEBUG` (`RecordingSessionKernel.swift:2111-2113`), so it did NOT run in the affected user's release build. The complete production inventory funnels through two kernel calls — `speechEvidenceAtStop()` (`RecordingSessionKernel.swift:1628`) and `speechSegmentsAtStop()` (`:1708`) — plus the stop-time freeze at `CaptureVADSignalSource.swift:298-311`, and additionally reaches: segment clamping / adapter handoff (`:1707-1748`), batch conditioning (`:1759-1760`, `CapturedAudioConditioner.swift:95-159`), VAD duration + diagnostic fields (`:1761`, `:1853-1888`), Parakeet tail preservation (`:1782-1837`), tail-clip diagnostics (`:2029-2033`), and WhisperKit decoder clip ranges (`WhisperKitEngineAdapter.swift:687-690`).
+
+The rejection stands, and rests primarily on **conditioning and decoder routing**, not the DEBUG archive row: with permanently empty segments the dead-air gate discards quiet recordings, `SampleFilter` stops conditioning the batch, tail preservation cannot identify a VAD-trimmed tail, and salvage is suppressed. Skipping VAD would trade a crash for silent data loss. **Rejected.**
+
+### 2.5.4 Telemetry gap — negative capability grep
+
+```
+$ grep -n 'PostHogSDK.shared.capture("' Sources/EnviousWisprServices/TelemetryService.swift \
+    | sed 's/.*capture("\([^"]*\)".*/\1/' | sort -u | grep -iE "dictation|record|audio|capture|asr|engine|warm"
+asr.completed
+audio.capture_interrupted
+coldstart.warmup_completed
+dictation.canceled
+dictation.completed
+dictation.invoked
+```
+
+No PostHog event exists between `dictation.invoked` and `asr.completed`. Sentry is better off but still blind at the point that matters: #1780's breadcrumbs end at `Recording started` and the process dies, with nothing around detector preparation or the first prediction. `AppLogger` file output is `#if DEBUG` **and** requires in-app Debug Mode, so release users leave no trace in this window.
+
+`BundledVADModelLoader` is the sole PRODUCTION producer used by `SilenceDetector`'s default factory. Tests may inject another `StreamingVad` via the internal seam; this claim does not cover test-only injection.
+
+Crash durability verified, not assumed: the pinned PostHog SDK encodes and writes each captured event to its disk-backed queue **synchronously** on the calling thread, explicitly "to preserve crash durability" (`.build/checkouts/posthog-ios/PostHog/PostHogQueue.swift:359`). Production confirms it — #1780's `dictation.invoked` reached PostHog despite the process dying immediately after. Sentry breadcrumbs remain the authoritative crash-local sequence because they travel inside the crash report.
+
+This is not speculative instrumentation (RULE: prove-the-regression-before-building-the-guard): a real production crash could not be localised from our own data and had to be reconstructed from crash-dump thread states.
+
+### 2.5.5 Prior art / owner search for the telemetry shape
+
+`TelemetryService.swift` is the single authority for PostHog emission (`analytics-operations.md` FACT: app-posthog-events). New events go there, dot-separated, privacy-boundary respected (metadata only, never dictated content — `sentry-operations.md` RULE: telemetry-privacy-boundary).
+
+## 2.6 Pre-approval evidence gate (compute-unit pin only)
+
+Issue #1780 classified the investigation as LARGE. This reduced plan is **MEDIUM only** because observability stays inside the existing lifecycle/VAD telemetry owners and changes no kernel control flow. Any kernel lifecycle, VAD scheduling, or deferred-processing change returns the work to LARGE.
+
+The compute-unit pin does not ship in this PR. Before it may be proposed again:
+
+1. Bring the exact VAD benchmark into a reviewable branch, or name a committed immutable artifact and command both configurations run unchanged. The `Tests/RuntimeUAT/repro-1780` harness currently lives only on the `investigate/1780-vad-repro` branch and is NOT in this worktree; the measurement may not depend on an investigation-branch artifact.
+2. Run the unchanged harness against current `.all` and proposed `.cpuAndNeuralEngine` before any implementation approval.
+3. Record cold preparation, first prediction, sustained prediction, CPU time, and energy, broken out by tested hardware and macOS version.
+4. Obtain explicit founder approval for changing compute scheduling for all users.
+
+Missing representative evidence or approval removes the pin entirely. The observability work proceeds independently and does not depend on it.
+
+## 3. Design
+
+### 3.1 VAD model configuration (HELD — not in this PR)
+
+Would build the configuration via `MLModelConfigurationUtils.defaultConfiguration()` rather than a bare `MLModelConfiguration()`. No signature change, no new parameter, no call-site change.
+
+Held per §2.6. The case against shipping it now, stated plainly: the crash occurred on the CPU/BNNS path; `.cpuAndNeuralEngine` still permits CPU, so the change does not target the observed mechanism; every configuration survived on every machine tested; the mismatch predates the affected release; and it would alter compute scheduling for ~600 currently-working users. "FluidAudio defaults to this" justifies an experiment, not a fleet rollout.
+
+### 3.2 Record-start observability
+
+The capture-established edge is **already** instrumented and is NOT duplicated: `.recordingCommitted` (`KernelHeartPathTelemetryObserver.swift:252-256`) drives both PostHog `dictation.invoked` and the Sentry `Recording started` breadcrumb from the same handler (`KernelLifecycleTelemetrySink.swift:204-217`). An earlier draft added a `dictation.capture_started` marker there; it provided no additional localisation and is dropped.
+
+Three new VAD markers, each emitted as BOTH a non-alerting Sentry breadcrumb and a PostHog event:
+
+| Event | Exact boundary | Properties |
+|---|---|---|
+| `dictation.vad_preparation_completed` | readiness evaluation returned, immediately before monitor entry | `backend`, `input_route`, `ready`, `model_reused` |
+| `dictation.first_vad_chunk_started` | immediately BEFORE the first `SilenceDetector.processChunk` await | `backend`, `input_route`, `monitor_to_first_chunk_ms` |
+| `dictation.first_vad_chunk_completed` | immediately AFTER that await returns | `backend`, `input_route`, `chunk_processing_latency_ms`, `should_stop` |
+
+**"Chunk", not "prediction", is deliberate.** These boundaries surround `SilenceDetector.processChunk`; the FluidAudio/CoreML prediction begins deeper inside it (`SilenceDetector.swift:240-248`). Claiming the pair brackets `MLModel.prediction` would overstate what the markers prove.
+
+The diagnostic value is the pair:
+
+- `started` present, `completed` absent → fatal failure during first-chunk processing, which contains the observed CoreML path. **This is what #1780 would have shown.**
+- both present, then a crash → a later chunk or downstream work.
+- neither → the failure precedes VAD entirely.
+
+`should_stop` is the actual returned value. `processChunk` is **non-throwing** (`SilenceDetector.swift:212`) — it catches the underlying `StreamingVad` error and returns `false` (`:250-258`) — so there is no error result to report and no throwing path to test.
+
+**Monitor-run identity guard — complete mutation inventory and reachability audit.** Rounds 1 and 2 each produced a finding of this class, so I enumerated the surface rather than take another single-finding round. Round 3 then corrected my reachability claims — recorded here rather than quietly fixed.
+
+`CaptureVADSignalSource.monitorTask` has exactly three grouped mutation/cancellation locations: `configureSession`, `startMonitoring`, `finalizeAtStop` (`:171-172`, `:191-192`, `:299-300`). `CaptureVADSignalSource.currentSessionID` has exactly one writer (`:129`) and exactly one production caller (`RecordingSessionKernel.swift:1039`); tests also drive the seam directly, and the kernel owns a *separate* property of the same name.
+
+| Path | Production reachability | Required protection |
+|---|---|---|
+| `configureSession` invalidates the prior run before the new session is stamped | **Not** an interleaving window — both calls are synchronous on `MainActor` with no suspension between them. But an old task can resume later after an actor await. | Generation invalidation stops the later resumption emitting |
+| `startMonitoring` replaces a run within the same session | **Not** currently reachable — one production caller (`beginLiveRecording`), itself after the single successful live transition. Retained as defence against direct tests and future callers. | Generation invalidation |
+| `finalizeAtStop` cancels while the session id is unchanged | **Reachable** | Generation invalidation required |
+| Task-local code reads mutable session/backend/route after starting | **Reachable** after suspension | Snapshot session id, backend, route and generation synchronously BEFORE creating the task |
+
+So: two genuinely reachable failures, two defensive. One `invalidateMonitor()` — cancel, clear, advance a monotonic generation — at all three locations, plus the synchronous snapshot, closes both reachable paths and keeps the defensive ones safe.
+
+**Every** new emission must re-check that captured session id AND captured generation are still current immediately before emitting — including the directly-emitted `vad_preparation_completed`, not only the two loop callbacks. It sits after an actor await, so it is exposed to exactly the same resumption.
+
+`model_reused` is snapshotted from `await directDetector.isReady` immediately after selecting the retained-or-new detector and **before** readiness preparation. `SilenceDetector.reset()` does not unload `vadManager`, so `true` means this retained detector entered the recording with its model already loaded. Reading `isReady` **after** preparation is forbidden — it would measure final readiness, and every successful preparation would falsely report as reuse.
+
+`backend` is snapshotted from `adapter.engineIdentity.rawValue`, passed in by the kernel. `input_route` is snapshotted from `audioCapture.currentAudioRoute` (`AudioCaptureInterface.swift:14`), the existing low-cardinality route label. It deliberately does NOT alias `currentResolvedRoute.selected` or `.effective` — those are distinct telemetry facts and are not added by this PR.
+
+`monitor_to_first_chunk_ms` starts at `VADMonitorLoop.run` entry. No key-press timestamp reaches this owner (`DictationSessionConfig` carries none), so naming it press-to-chunk latency would fabricate a metric.
+
+## 3b. Ownership justification
+
+**Correction from coverage review:** an earlier draft claimed `RecordingSessionKernel` emits `dictation.invoked`. It does not — `KernelLifecycleTelemetrySink` does (`:204-208`). Verified.
+
+Observation points must stay split, because each boundary physically exists in a different owner:
+
+- `CaptureVADSignalSource` observes detector readiness — it owns detector creation, reuse, preparation and monitor launch (`:199-205`, `:242-277`).
+- `VADMonitorLoop` observes first-chunk entry/return — those exact positions exist at its await site (`:98-102`), and it already owns per-run local state (`:52-61`).
+
+Emission is consolidated through one new internal, stateless `RecordStartTelemetrySink`. It is the sole coordinator of dual-channel parity and the sole owner of the three breadcrumb messages. `TelemetryService` remains the existing authority for exact PostHog event names and property serialisation — an earlier draft overclaimed the sink as owning those too.
+
+Placement challenge: putting the sink in `EnviousWisprServices` would move record-start stage semantics down into an infrastructure module; duplicating emission across `CaptureVADSignalSource` and `VADMonitorLoop` would split parity between two observation owners and drift. `EnviousWisprPipeline` is the narrowest correct owner — Pipeline coordinates stage facts, Services performs SDK-specific emission. Dependency direction verified clean (`scripts/check-dependency-direction.sh:42`; Pipeline→Services already allowed).
+
+Against "new shared objects are guilty until proven innocent": the sink has one purpose, exactly three methods, injected emission closures, no mutable state, no session/lifecycle/detector/backend state, and no orchestration authority. It does not violate `keep-central-types-thin`.
+
+`RecordingSessionKernel` gains no telemetry call and no telemetry-only stored state. Its sole change is passing the already-resolved backend string into `startMonitoring` — the backend is not otherwise reachable from the VAD source (`DictationSessionConfig` has no backend field; verified by grep).
+
+## 3c. Single-authority check
+
+Concern: ordered record-start observability.
+
+`RecordStartTelemetrySink` is the sole owner of the three breadcrumb messages and the dual-channel parity rule. `TelemetryService` remains the sole authority for the exact PostHog event names and property serialisation. `CaptureVADSignalSource` and `VADMonitorLoop` only observe physical boundaries and report typed facts to the sink.
+
+Existing capture-established signals are REUSED, not duplicated: PostHog `dictation.invoked`, Sentry `Recording started`. No `dictation.capture_started` is added.
+
+§3c-answer: consolidated to RecordStartTelemetrySink (three breadcrumb messages + dual-channel parity) and TelemetryService (PostHog names + serialisation); CaptureVADSignalSource gains invalidateMonitor as the single monitor-cancellation authority, replacing the three scattered cancel-and-clear pairs.
+
+## 4. Contract deltas
+
+- `TelemetryService`: three additive `package` event methods. Exact PostHog names and property serialisation stay owned by Services; no public API is added. (`package` visibility is already used 471× across `Sources/`, including in Services — verified, so it compiles in both build graphs.)
+- `VADMonitorLoop.run`: additive defaulted observation callbacks + injectable monotonic clock.
+- `CaptureVADSignalSource.startMonitoring`: receives the already-resolved backend string.
+- New `RecordStartTelemetrySink` (pipeline-internal).
+- `CaptureVADSignalSource`: additive internal detector-factory injection, defaulting to the existing `SilenceDetector` construction. Tests use it to supply a continuation-controlled detector; production construction and visibility are unchanged. Required because the source constructs `SilenceDetector` directly (`:199`) and the fake-`StreamingVad` seam is internal to `EnviousWisprAudio` (`SilenceDetector.swift:164`), so without this the generation and `model_reused` tests cannot deterministically control suspension.
+- No model configuration, protocol, enum, persisted setting, or migration change. The loader is untouched (pin held, §2.6).
+
+## 5. E2E state & lifecycle audit
+
+| Class | Answer |
+|---|---|
+| Interrupted | Facade calls do not throw, but PostHog encodes + persists synchronously on the caller's thread. Cancellation owes no cleanup, but a cancelled task may resume after a `SilenceDetector` actor await. Every marker emits only while its captured session id AND monitor generation are both current. |
+| Deleted | N/A — no persisted domain state created or deleted. |
+| Mutated | Backend and input route are captured as values at monitor start; later settings or route changes cannot rewrite this record-start sequence. |
+| Concurrent | All three cancellation/replacement locations invalidate the monitor generation. Session id, backend and route are captured before task creation, so a later actor resumption cannot emit under a newer run. The once-latch is local per run. |
+| Nil | A missing weak `self` returns without emitting. Observability never changes the recording outcome. |
+| Stale | The local latch prevents repeats within a run. The captured-session plus captured-generation check prevents ALL late markers after invalidation, including the directly-emitted preparation marker. |
+
+Closed-set trigger: **not met**. These changes observe existing execution points and add no state transition, terminal outcome, cancellation/preemption contract, durable ordering, recovery rule, or raw-text fallback change. Clause 1 of `workflow-process.md` RULE: async-edge-case-enumeration is false. The six-class audit above remains mandatory because this is MEDIUM.
+
+## 6. Downstream consumer matrix
+
+| Consumer | Impact |
+|---|---|
+| PostHog Pipeline Performance dashboard | add a record-start funnel: `dictation.invoked` → `dictation.vad_preparation_completed` → `dictation.first_vad_chunk_started` → `dictation.first_vad_chunk_completed`; segment by app version, OS version, hardware, backend, input route |
+| `workers/product-health` | no threshold in this PR — establish event coverage and a fleet baseline first |
+| `workers/daily-report` | unaffected; does not enumerate these event names |
+| Sentry | matching breadcrumbs provide the authoritative stage sequence on fatal crashes |
+| `SilenceDetector` / `VadManager` | unaffected — no behavioural change, emits only |
+
+## 7. Failure-mode × caller table
+
+| Failure | Caller sees |
+|---|---|
+| PostHog offline / queue full | unchanged — SDK persists to disk then drops per its own policy; emits are non-throwing and never gate the recording result |
+| Sentry disabled | breadcrumb is a no-op; PostHog event still emitted |
+| Stale callback or direct preparation emission from an invalidated monitor run | dropped by the captured-session plus captured-generation check immediately before emission; nothing emitted |
+| Detector never becomes ready | `vad_preparation_completed` still emits with `ready=false` — the negative case is the diagnostic |
+
+## 8. Caller-visible signals audit
+
+No user-facing string, AX label, or status text changes. No new pill, notice, or error surface.
+
+## 9. Fallback source-of-truth audit
+
+Unchanged. Raw-text-on-limb-failure floor untouched; neither change sits on the polish path.
+
+## 10. File-by-file changes
+
+| File | Change |
+|---|---|
+| `Sources/EnviousWisprPipeline/RecordStartTelemetrySink.swift` | **new** — sole owner of the three breadcrumb messages and Sentry/PostHog parity; delegates PostHog names and serialisation to `TelemetryService` |
+| `Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift` | capture session id/backend/route at monitor start; `invalidateMonitor()` + generation; emit `vad_preparation_completed`; supply guarded first-chunk callbacks; add an internal defaulted detector-factory seam for deterministic source-level tests |
+| `Sources/EnviousWisprPipeline/VADMonitorLoop.swift` | defaulted first-chunk started/completed callbacks, injectable clock, per-run latch |
+| `Sources/EnviousWisprServices/TelemetryService.swift` | three additive emit funcs |
+| `Sources/EnviousWisprPipeline/RecordingSessionKernel.swift` | one line — pass the resolved backend into `startMonitoring` |
+| `Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift` | **no change** (capture edge already instrumented) |
+| `Sources/EnviousWisprAudio/BundledVADModelLoader.swift` | **no change** (pin held, §2.6) |
+| `Tests/EnviousWisprTests/Pipeline/` | latch, ordering, non-throwing-path, parity, generation-invalidation, synchronous-snapshot, and `model_reused` ordering tests (§11) |
+| `Tests/EnviousWisprTests/Services/` | `TelemetryService` schema test for the three `package` methods (§11) |
+
+Knowledge updates (`analytics-operations.md` event table; `gotchas-audio.md` configuration-bypass trap) are **local source-of-truth edits outside this PR's diff** — `.claude/` is gitignored and absent from this worktree (verified).
+
+## 11. Testing
+
+- **Latch test.** Drive multiple chunks through `VADMonitorLoop`; assert exactly one started/completed pair per run, and a fresh pair on a new run.
+- **Ordering test.** Injected monotonic clock + a fake `StreamingVad` recording interleaving; assert `started` precedes detector entry and `completed` follows return. The diagnostic value depends entirely on this ordering.
+- **Non-throwing path test.** Inject a `StreamingVad` that throws. Because `SilenceDetector.processChunk` catches it and returns `false` (`:250-258`), assert BOTH callbacks still fire and `should_stop == false`. (There is no throwing path out of `processChunk` — an earlier draft wrongly assumed one.)
+- **Parity test.** Exercise `RecordStartTelemetrySink` directly with injected breadcrumb + telemetry spies; each method must produce exactly one breadcrumb AND one matching PostHog call. A marker with a single sink is a defect.
+- **Generation invalidation test.** Through the injected detector factory and a continuation-controlled fake `StreamingVad`, exercise preparation suspension and first-chunk suspension **separately**. For each suspension point, invalidate via `configureSession`, same-session `startMonitoring` replacement, and `finalizeAtStop` in turn; resume the old operation and assert no marker after invalidation is emitted. Also start a new run with the SAME session id and assert the old generation cannot emit into it.
+- **Synchronous snapshot tests.** (1) Call `startMonitoring` with `backendA` while `audioCapture.currentAudioRoute == "routeA"`, mutate the live route to `"routeB"` before the task executes, and assert preparation, started, and completed all retain `backendA` / `routeA`. (2) Change the source session identity before the task executes and assert the superseded run emits no marker. (Corrected from an earlier single bullet that was self-contradictory: a dropped emission cannot also retain a snapshot.)
+- **`model_reused` ordering test.** Using the injected detector factory, return an unready detector whose preparation is continuation-controlled; assert the first run reports `model_reused == false` after preparation completes. Then reuse that same now-ready detector and assert the next run reports `true`. This is the test that catches reading `isReady` on the wrong side of preparation.
+- **`TelemetryService` schema test.** Under the existing DEBUG `testEventHook`, call all three `package` methods directly and assert fully-qualified event names, exact property keys, value types, and absence semantics. The sink parity test does NOT prove the names/serialisation owned by Services.
+- **Full suite** via `scripts/xcode-test.sh`; read `Test run with N tests`, require nonzero and the expected count (RULE: verify-the-feature-not-the-crash).
+- **Live UAT.** Confirm dictation completes with auto-stop on and off, and verify the three events arrive in order in PostHog dev. **`app.log` is NOT the oracle here** — neither `SentryBreadcrumb.add` nor `TelemetryService` writes to `AppLogger` (verified); app.log verifies dictation success only.
+- **Overhead receipt.** One fixed prerecorded audio fixture through the existing recording UAT harness. Same machine, input route, backend, settings and PostHog dev configuration. Collect ≥30 successful warm samples from the exact baseline SHA and ≥30 from the exact instrumented SHA, alternating build order in blocks to limit thermal and time drift. Measure **external wall-clock from immediately before recording invocation through verified paste completion**, so all three synchronous PostHog writes are enclosed — `startMonitoring` runs after the session goes live (`RecordingSessionKernel.swift:2901`), so a narrower "record-start" window can end before the writes occur. Preserve raw samples; report per-arm count, median, p95, and instrumented-minus-baseline deltas. `monitor_to_first_chunk_ms` and `chunk_processing_latency_ms` are reported for diagnostic interpretation ONLY and cannot clear this criterion.
+
+## 12. Blast radius & rollback
+
+Blast radius: every recording emits three additional PostHog events and three Sentry breadcrumbs. VAD model configuration and lifecycle behaviour are unchanged. PostHog capture performs synchronous queue persistence, so record-start overhead is explicitly measured (§11).
+
+Correction from grounded review: an earlier draft claimed the VAD model loads every recording. It does not — the detector is retained and reused unless the silence timeout changes (`CaptureVADSignalSource.swift:173-177`, `:199-205`), and `SilenceDetector.prepare` is idempotent (`:174-179`).
+
+Rollback: single revert. No persisted state, no migration, no appcast implication.
+
+## 13. Ship criteria
+
+1. Latch, callback ordering, non-throwing-path, dual-channel parity, all three generation invalidations, synchronous snapshot, `model_reused` ordering, and `TelemetryService` schema tests pass; full suite green with a nonzero executed count.
+2. Live UAT: dictation completes with auto-stop on and off; the three events arrive in order in PostHog dev. app.log confirms dictation success only, not marker delivery.
+3. Overhead receipt in the PR: exact baseline and instrumented SHAs; fixed prerecorded fixture; identical machine, route, backend, settings and PostHog configuration; ≥30 successful warm invocation-to-paste samples per arm; raw samples, median, p95 and instrumented-minus-baseline deltas reported. Any statistically supported slowdown is resolved or explicitly accepted. `monitor_to_first_chunk_ms` and `chunk_processing_latency_ms` are reported separately and are NOT substitutes for this enclosing measurement.
+4. Codex whole-diff review clean, then GitHub cloud review clean.
+5. Save and verify the PostHog record-start funnel (`dictation.invoked` → `dictation.vad_preparation_completed` → `dictation.first_vad_chunk_started` → `dictation.first_vad_chunk_completed`), segmented by app version, OS version, hardware, backend and input route, against a development event before merge. Do NOT set an alert threshold until a real baseline exists — otherwise this repeats the same problem one layer up: data that exists but nobody reads.
+6. Documented production read at 24 hours and 7 days: event coverage, stage drop-off, first-chunk latency, any new crash.
+7. PR body and release notes state plainly that #1780 is NOT fixed and stays open. No "fixed #1780" release note.
+
+## 14. Open questions
+
+- **Founder decision required:** ship the compute-unit pin at all? Coverage review says hold; I agree on the evidence. Counter-argument for shipping: running a model under a configuration its library never selects is a defect regardless of #1780. Not blocking this PR either way.
+- **Future, separate LARGE plan:** "defer, do not skip" — when live auto-stop is disabled, process the same complete 4,096-sample sequence after capture stops and before any segment consumer runs. Preserves final-segment semantics while removing VAD prediction from record-start. Not in this PR: it changes stop latency, moves work into the delivery path, and could burst badly on long recordings. Needs short/long benchmarks and exact segment-equivalence tests. Reducing prediction FREQUENCY stays rejected — FluidAudio's streaming state advances per processed chunk, so sampling every Nth chunk corrupts the segment clock.
+
+## 15. Related
+
+#1780 (crash, stays open), #1782 (Apple Intelligence default), #1224 (bundled VAD model), #1434 (degraded-lead salvage), #1543 (capture moved in-process).


### PR DESCRIPTION
## #1780 is NOT fixed by this PR and stays open.

This adds the evidence we did not have. It does not change VAD behaviour, model configuration, or anything on the recording path's logic.

## Why

A brand-new user on 2.4.1 crashed four times, every time at record-start, with zero successful dictations ever. Reconstructing where in record-start it died required reading crash-dump thread state by hand: the app emitted `dictation.invoked` and then nothing at all until `asr.completed`. That whole interval — detector preparation, first VAD chunk, the CoreML prediction the crash actually happened inside — was unobservable.

Reproduction failed on macOS 26 (dev), 14.8.7 and 15.7.7 (CI), across all four `MLComputeUnits`, concurrent, with churn, and under a guard-page over-read probe. We cannot fix what we cannot localise, so this closes the observability gap first.

## What it adds

Three record-start stage markers, each emitted on BOTH channels:

| Marker | Answers |
|---|---|
| `dictation.vad_preparation_completed` | did the detector get ready, and was the model already loaded |
| `dictation.first_vad_chunk_started` | did we reach the first chunk, and how long after monitor start |
| `dictation.first_vad_chunk_completed` | did the first chunk return, and how long it took |

- **Sentry breadcrumb** — crash-local, travels inside the crash report. "started present, completed absent" localises a fatal failure to first-chunk processing, which is exactly where #1780 died.
- **PostHog event** — fleet funnel, so a repeat shows up as a drop-off rather than as a single hand-read crash dump.

A marker that reaches only one channel is a defect, and there is a test for it.

## Monitor-run identity (the non-obvious part)

Emitting from a task that suspends means a superseded run can wake up and emit into a newer recording. A session id alone is not a sufficient guard: `finalizeAtStop` cancels a run without changing the session, and a replacement can reuse the same session id.

So `CaptureVADSignalSource` gains a single `invalidateMonitor()` authority that cancels, clears, and advances a monotonic generation together, and every emission re-checks BOTH session and generation immediately before firing, with no await or mutable read in between. Backend, route, session and generation are snapshotted synchronously before the task exists.

Six invalidation tests cover this: preparation-suspended and first-chunk-suspended, each interrupted by `configureSession`, a same-session `startMonitoring` replacement, and `finalizeAtStop`.

**Mutation receipt:** weakening the generation term makes all six invalidation tests fail; weakening the liveness term makes both terminal-path tests fail. Each term is independently proven. That is the check that matters — an invalidation test that still passes with the guard removed is decoration.

## Explicitly NOT in this PR

`BundledVADModelLoader` builds a bare `MLModelConfiguration()`, so FluidAudio's own `defaultConfiguration()` (`.cpuAndNeuralEngine`, low-precision GPU accumulation) never applies. That is a real mismatch and it predates 2.4.1, but pinning it is an unproven fix for an unreproduced crash. Founder decision 2026-07-24: hold, measure first. Gate is the plan §2.6.

## Validation

- `--filter EnviousWisprTests/CaptureVADSignalSourceTests` — 22 tests, pass
- `--filter EnviousWisprTests/VADMonitorLoopTests` — 8 tests, pass
- `--filter EnviousWisprTests/RecordStartTelemetrySinkTests` — 3 tests, pass
- `--filter EnviousWisprTests/RecordStartTelemetryServiceTests` — 3 tests, pass
- Full unfiltered `scripts/xcode-test.sh` — **3861 tests in 383 suites + 179 in 18 suites, all pass**
- Live UAT on the rebuilt dev app: dictation PASSED, "The quick brown fox jumps over the lazy dog", 1.462s total. All three markers confirmed in PostHog from real recordings, correct order, `backend=parakeet`, `route=built_in_mic`, and `model_reused` false on the first recording / true on subsequent — the ordering contract proven in production, not only in unit tests.
### Overhead receipt

Does the added instrumentation slow dictation down? No measurable cost.

| Scenario | What it exercises | Baseline | Instrumented | Delta |
|---|---|---|---|---|
| `short` | 0.8s utterance, minimal ASR and polish work | 3.670s | 3.628s | **-0.041s** |
| `long` | 27.3s paragraph, heaviest ASR and polish load | 32.214s | 32.233s | **+0.019s** |
| `fillers` | filler removal (um / uh / you know / I mean) | 11.902s | 11.916s | **+0.014s** |
| `corrections` | mid-sentence self-correction, polish resolves intent | 9.329s | 9.363s | **+0.034s** |
| `lists` | four-item list formatting | 11.726s | 11.769s | **+0.043s** |

Every scenario lands within **±43 ms**, in both directions. Paired median delta **+0.028s**; bootstrap 95% CI **[-0.017, +0.945] s**, which includes zero — no statistically supported slowdown.

**Method.** Five prerecorded fixtures (identical bytes across both arms) driven through the existing `wispr_eyes.test_recording` harness — no new recording instrument. Wall-clock is external, from immediately before the harness call through verified paste completion, so all three synchronous PostHog writes are enclosed. 3 passes per arm in alternating blocks (I/B/I/B/I/B), 30 measured samples, 30/30 passed their content check. One discarded pass per block plus a 2-pass machine warm-up before the first measured block. Same machine, built-in mic, Parakeet, EG-1 polish, auto-stop off, PostHog dev.

**Disclosure.** Instrumented block 3 ran ~1.0s slow across all five scenarios uniformly; instrumented blocks 1 and 5 ran at or below baseline. A real per-recording cost would appear in all three instrumented blocks, so this is machine noise at block granularity, not the change. Reported figures are medians of 3, which is why the median (not p95) is the headline statistic — p95 on this sample is contaminated by that single block. An earlier 60-sample run using one short fixture showed the same one-block signature and is preserved at `/tmp/overhead-1780-run1-rejected.jsonl`; it was rejected and re-run rather than having the bad block deleted after the fact.

Raw samples: `/tmp/overhead-1780-run2.jsonl`. Baseline SHA `4bc4eeb8`, instrumented SHA as of this PR.


Part of #1780.
