### PR TITLE
fix(vad): pin the bundled VAD model's requested CoreML load policy (#1784)

### DIFF
--- a/Sources/EnviousWisprAudio/BundledVADModelLoader.swift
+++ b/Sources/EnviousWisprAudio/BundledVADModelLoader.swift
@@ -31,7 +31,12 @@ enum BundledVADModelLoader {
       throw LoadError.resourceNotFound
     }
     do {
-      return try MLModel(contentsOf: url, configuration: MLModelConfiguration())
+      // Match the pinned FluidAudio VAD loader (`DownloadUtils.swift:301-303`).
+      // Keep this heart-path policy explicit across dependency updates (#1784).
+      let configuration = MLModelConfiguration()
+      configuration.computeUnits = .cpuAndNeuralEngine
+      configuration.allowLowPrecisionAccumulationOnGPU = true
+      return try MLModel(contentsOf: url, configuration: configuration)
     } catch {
       throw LoadError.loadFailed(error)
     }

--- a/Tests/EnviousWisprTests/Audio/BundledVADModelLoaderTests.swift
+++ b/Tests/EnviousWisprTests/Audio/BundledVADModelLoaderTests.swift
@@ -1,3 +1,4 @@
+import CoreML
 import Foundation
 import Testing
 
@@ -22,7 +23,7 @@ struct BundledVADModelLoaderTests {
         "Sources/EnviousWispr/Resources/VAD/silero-vad-unified-256ms-v6.0.0.mlmodelc")
   }
 
-  @Test("loads the model given a bundle containing the real resource")
+  @Test("loads the model with the pinned FluidAudio VAD compute policy")
   func loadsBundledModel() throws {
     let checkedIn = Self.checkedInModelURL
     #expect(FileManager.default.fileExists(atPath: checkedIn.path))
@@ -40,7 +41,13 @@ struct BundledVADModelLoaderTests {
       to: fixtureRoot.appendingPathComponent("silero-vad-unified-256ms-v6.0.0.mlmodelc"))
 
     let fixtureBundle = try #require(Bundle(path: fixtureRoot.path))
-    _ = try BundledVADModelLoader.loadModel(in: fixtureBundle)
+    let model = try BundledVADModelLoader.loadModel(in: fixtureBundle)
+
+    // #1784: freeze the REQUESTED load policy. `MLModel.configuration` reports what
+    // the caller asked for, not CoreML's resolved device — which is exactly the
+    // thing this change alters. A bare `MLModelConfiguration()` would report `.all`.
+    #expect(model.configuration.computeUnits == .cpuAndNeuralEngine)
+    #expect(model.configuration.allowLowPrecisionAccumulationOnGPU)
   }
 
   @Test("throws resourceNotFound given a bundle that does not carry the asset")

--- a/docs/audits/2026-07-24-1784-codex-diff-review-verdict.md
+++ b/docs/audits/2026-07-24-1784-codex-diff-review-verdict.md
@@ -1,0 +1,6 @@
+The VAD configuration and its test appear correct, but the patch also commits substantial unrelated generated dependency content in an audit log. That content should be removed before merging.
+
+Review comment:
+
+- [P2] Remove unrelated source maps from the audit log — /Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/audits/2026-07-24-1784-grounded-review-r2.txt:1498-1498
+  This captured command output embeds over 1 MB of unrelated Next.js source maps from temporary EnviousStaging and probe directories into two single lines. Every clone retains this permanent repository bloat, and the huge lines make the audit difficult to inspect without adding evidence for #1784; trim the unrelated grep output or commit only the final review result.

--- a/docs/audits/2026-07-24-1784-crash-containment-council-verdict.md
+++ b/docs/audits/2026-07-24-1784-crash-containment-council-verdict.md
@@ -1,0 +1,299 @@
+Short answer: the premise is false. A hard fault inside CoreML/Espresso/BNNS cannot be contained inside the same process. Without a process boundary, the only way to eliminate that crash class is to stop executing that CoreML path.
+
+My practical recommendation is: align the model configuration, then add a one-strike local quarantine that disables VAD after an incomplete first prediction and deliberately reports `.unavailable`. That prevents another four-crash loop, but it cannot save the first crash.
+
+## Q0 — Challenge the premise
+
+### Missing premise 1: Swift cannot contain this hard fault
+
+The current `do/catch` at `Sources/EnviousWisprAudio/SilenceDetector.swift:240-258` contains a thrown `MLModel`/FluidAudio error. It cannot contain `SIGSEGV`, `SIGBUS`, `SIGABRT`, or an `EXC_BAD_ACCESS`.
+
+The hard-fault boundary is deeper:
+
+- FluidAudio writes through raw `MLMultiArray` pointers at `.build/checkouts/FluidAudio/Sources/FluidAudio/VAD/VadManager.swift:208-258`.
+- It enters the synchronous CoreML prediction at `VadManager.swift:268`.
+- The enclosing Swift actor at `SilenceDetector.swift:107` serializes access; it does not provide another address space.
+
+Apple describes Swift errors as recoverable thrown values, while crash reports treat bad memory access as an unrecoverable process failure. Apple’s signal documentation also warns that almost everything beyond setting a flag in a signal handler is unsafe. [Swift error handling](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/errorhandling/), [Apple crash-report guidance](https://developer.apple.com/documentation/xcode/analyzing-a-crash-report), [Apple `sigaction` manual](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/sigaction.2.html).
+
+Exact design text:
+
+> This design does not claim in-process crash containment. A SIGSEGV, SIGBUS, SIGABRT, or EXC_BAD_ACCESS raised during CoreML/Espresso/BNNS execution terminates the application process. `do/catch`, `Result`, actors, tasks, queues, timeouts, Objective-C exception wrappers, signal handlers, and Mach exception handlers are not credited as containment. Under the no-new-process constraint, only not executing this implementation eliminates this hard-fault class.
+
+If “the silence detector must be unable to crash the app” is literal and covers every possible detector bug, a separate address space is required. A replacement written in Swift can remove this CoreML crash class, but even Swift can trap or call unsafe system libraries.
+
+### Missing premise 2: “no detector” and “detector found no speech” are already different states
+
+The rejected `vadAutoStop` gate remains correctly rejected. But deliberate health-based VAD unavailability is not equivalent to returning permanently empty segments from a prepared detector.
+
+The current contract says:
+
+- `.confirmedNoSpeech` may skip ASR: `Sources/EnviousWisprPipeline/VADSignalSource.swift:63-72` and `RecordingSessionKernel.swift:1628-1674`.
+- `.unavailable` explicitly lets ASR run.
+- When no prepared detector exists, finalization publishes `[]` plus `.unavailable`: `CaptureVADSignalSource.swift:401-407`.
+- Empty segments then make conditioning a raw-audio no-op: `CapturedAudioConditioner.swift:84-99`.
+- WhisperKit also runs raw ASR without clip timestamps: `WhisperKitEngineAdapter.swift:654-690`.
+
+Exact design text:
+
+> A deliberately disabled or quarantined VAD MUST represent “no detector ran,” not “the detector confirmed no speech.” It MUST leave `directDetectorPrepared == false`, publish `.unavailable`, return `[]` segments, and continue raw ASR. It MUST NOT publish `.confirmedNoSpeech`.
+
+That avoids the silent dead-air discard. It still loses auto-stop, VAD conditioning, tail information, degraded-lead gating and WhisperKit clip ranges. That is a real quality cost, but different from losing the raw transcript.
+
+## Q1 — Pathways
+
+### 1. Align the configuration and accept the remaining risk
+
+Mechanism: load the bundled model using FluidAudio’s actual default configuration.
+
+Exact Swift:
+
+```swift
+import CoreML
+@preconcurrency import FluidAudio
+import Foundation
+
+// Inside BundledVADModelLoader.loadModel(in:)
+let configuration = MLModelConfigurationUtils.defaultConfiguration()
+return try MLModel(contentsOf: url, configuration: configuration)
+```
+
+This belongs at the sole model-construction point, `Sources/EnviousWisprAudio/BundledVADModelLoader.swift:19-34`. Changing only `VadConfig.computeUnits` would do nothing: the preloaded-model initializer merely stores that configuration at `.build/checkouts/FluidAudio/Sources/FluidAudio/VAD/VadManager.swift:102-107`; only FluidAudio’s separate loading path reads it at `:124-145`.
+
+- Contains: recoverable model-loading errors, through the existing readiness handling.
+- May reduce: hard-fault probability if `.all` produced a different CoreML execution plan.
+- Does not contain: hard faults, hangs or wrong answers.
+- Cost: compute scheduling and possibly small numerical/segment differences.
+- Fair case for it: one unexplained installation, extensive negative reproduction, same in-process stack works elsewhere, and the divergence is real.
+- Fair limit: the crash was on CPU/BNNS and `.cpuAndNeuralEngine` still permits CPU.
+
+### 2. Add a one-strike crash-loop quarantine
+
+Mechanism: use a local marker around the first VAD prediction. A stale marker on next launch means the preceding process never completed that prediction, so VAD is quarantined and the recording uses `.unavailable`.
+
+Exact contract:
+
+> After successful model preparation and before making the detector eligible to run, atomically arm a local first-prediction marker. Clear it only after `SilenceDetector.processChunk` returns and `dictation.first_vad_chunk_completed` has been emitted. Clear it on a normal stop in which no first chunk ran. If the next launch finds the marker stale, or if arming it fails, do not make the detector prepared: run the max-duration monitor with `detector: nil` and publish `.unavailable`. Key quarantine by VAD model hash, FluidAudio revision, compute-unit configuration, OS build and Mac model. Retry only when that tuple changes or through an explicit canary.
+
+- Contains: repeat hard faults and repeat hangs in the guarded interval.
+- Does not contain: the first hard fault or wrong answers.
+- Cost: synchronous local metadata work, false quarantine if the app is killed during the short armed interval, and degraded VAD functionality thereafter.
+- Owner: `CaptureVADSignalSource`, which already owns detector preparation, monitor selection and fail-open evidence at `CaptureVADSignalSource.swift:225-335` and `:401-413`.
+
+### 3. Deliberately disable CoreML VAD
+
+This is the pure subtraction path: do not construct or invoke the CoreML detector for a quarantined tuple, affected OS/hardware combination, or emergency cached kill switch.
+
+Exact contract:
+
+> VAD disablement is a health policy, never an alias for the user’s `vadAutoStop` preference. The decision must be available locally before recording; network availability must not gate record-start. The disabled path passes `detector: nil`, retains max-duration protection, publishes `.unavailable`, and sends raw capture to ASR.
+
+- Contains: every CoreML VAD hard fault, hang and wrong answer while disabled, because no prediction occurs.
+- Does not contain: other app faults.
+- Cost: no silence auto-stop or segment-driven conditioning/routing.
+
+### 4. Replace the CoreML detector
+
+Replace Silero/CoreML with a non-CoreML detector, such as a carefully validated energy/spectral detector, while preserving the existing shared VAD signal contract.
+
+The existing seam is `StreamingVad` at `Sources/EnviousWisprAudio/SilenceDetector.swift:5-26`. Both engines must continue to receive the single shared source created at `KernelDictationDriverFactory.swift:237-253`.
+
+Exact contract:
+
+> The replacement MUST preserve one result for every 4,096-sample chunk, the monotonically advancing sample clock, speech-start/end boundaries, open-segment finalization and the `.voiced` / `.confirmedNoSpeech` / `.unavailable` distinction. It may replace the detector implementation in `EnviousWisprAudio`; it may not create separate Parakeet and WhisperKit VAD owners.
+
+- Contains: this CoreML/Espresso/BNNS failure class.
+- Does not contain: traps or hard faults in the replacement, or wrong segmentation.
+- Cost: substantial correctness validation across quiet speech, noise, soft onsets and tails.
+
+### 5. Simplify FluidAudio’s input-buffer path
+
+Remove pooled `MLMultiArray` reuse and create fresh correctly shaped input arrays per call. Validate counts and finite values before prediction.
+
+Exact experiment text:
+
+> Replace the three `memoryOptimizer.getPooledBuffer` calls at `VadManager.swift:216-229` with fresh `MLMultiArray` allocations of identical shape and type. Keep model, state progression and prediction API unchanged. Credit the experiment only if it changes the crash or produces a reproducible memory-safety signal; do not call it containment.
+
+- Contains: only a proven pooling, lifetime, shape or aliasing defect.
+- Does not contain: arbitrary CoreML hard faults or hangs.
+- Cost: allocations every 256 ms, possible latency/energy churn and a maintained FluidAudio fork.
+
+### 6. Reuse the existing ASR XPC process
+
+This is the only path that contains the hard fault without adding a second helper process. Move VAD execution into the existing ASR service.
+
+The target already imports Audio and FluidAudio at `Project.swift:323-344`, but the VAD resource currently exists only in the app target at `Project.swift:392-399`. The service is explicitly Parakeet-only today at `Sources/EnviousWisprASRService/ASRServiceHandler.swift:6-18`.
+
+Exact contract:
+
+> Move, do not duplicate, VAD model ownership into the existing ASR service. Extend `ASRServiceProtocol` with start, ordered-chunk and finalize operations. On service invalidation or deadline expiry, the host MUST publish `.unavailable` and continue from its retained raw capture. This pathway is accepted only after fault injection proves that killing the helper during VAD still yields a raw pasted transcript for both engines.
+
+- Contains: VAD hard faults; the app survives.
+- Can contain hangs only with a host deadline plus connection invalidation.
+- Does not contain: wrong answers.
+- Cost: chunk IPC, ordering/backpressure, resource packaging and new coupling between a limb and ASR.
+
+### 7. Defer VAD
+
+For auto-stop-off sessions, process the complete sequence after capture rather than live. This is already described at `docs/feature-requests/issue-1780-2026-07-24-record-start-observability.md:319-322`.
+
+- Before ASR/paste: removes the record-start exposure but still lets VAD kill the app before text delivery.
+- After paste: protects the delivered transcript, but VAD can no longer affect that dictation’s conditioning or decoder ranges.
+- Does not contain the hard fault.
+- Cost: burst work on long recordings, stop latency, or loss of current-dictation consumers.
+
+Exact disposition:
+
+> Deferred VAD is an exposure-reduction or transcript-first pathway. It MUST NOT be described as crash containment.
+
+### 8. Actor, task, thread, timeout, exception or signal wrappers
+
+- `do/catch`: contains only thrown errors.
+- Actor/serial queue: contains races through serialization, not process faults.
+- Detached worker plus timeout: may let the caller stop waiting, but cannot safely terminate a wedged CoreML thread.
+- Signal/Mach exception recovery: process state, Swift frames and CoreML locks may already be corrupt.
+
+Exact disposition:
+
+> Reject all same-address-space wrappers as a hard-fault containment claim. Keep the existing actor for serialization and the existing `do/catch` for recoverable errors only.
+
+### 9. Crash recovery and relaunch
+
+The existing spool is a best-effort recovery limb on a background queue: `Sources/EnviousWisprAudio/RecoverySpoolWriter.swift:5-14` and `AudioCaptureManager.swift:1078-1113`.
+
+- Contains: some post-crash audio loss when the spool was armed and sufficiently flushed.
+- Does not contain: the crash, immediate paste failure, the unsaved tail or recovery failures.
+- Cost: the brand-new user still sees an app crash and no immediate text.
+
+Exact disposition:
+
+> Crash recovery may remain defence in depth. It MUST NOT be credited as VAD containment, and the recovery owner MUST NOT also become the VAD health/quarantine owner.
+
+### 10. A dedicated VAD helper
+
+This is the clean containment baseline: XPC invalidation converts the helper crash into an unavailable VAD result. Apple explicitly states that XPC services run in another process and can be restarted after crashing. [Apple XPC](https://developer.apple.com/documentation/XPC).
+
+It violates the founder’s stated constraint and reintroduces the distributed lifecycle cost documented in `docs/heartpath-refactor/DECISIONS.md:55-91`. But it is the only honest way to retain this exact CoreML implementation while making its first hard fault nonfatal to both the app and ASR process.
+
+## Q2 — Strongest argument against every pathway
+
+1. **Configuration only:** it is not causal evidence. The proposed configuration still permits the observed CPU/BNNS path.  
+   Exact correction: describe it as “configuration alignment and risk reduction,” never “the #1780 fix.”
+
+2. **Crash-loop quarantine:** it cannot save the first crash and can falsely quarantine after a force-quit or unrelated crash. It also risks adding a second health owner beside `VADModelReadinessTracker` at `CaptureVADSignalSource.swift:53-58`.  
+   Exact correction:
+
+   > Do not add a parallel quarantine Boolean. Replace the current typed readiness state with one authority that can represent `unknown`, `ready`, `broken` and `quarantined`; keep storage mechanics injected and keep the execution decision in `CaptureVADSignalSource`.
+
+3. **Global/tuple disable:** it removes multiple useful consumers, not just auto-stop.  
+   Exact correction: limit it to health quarantine or an evidence-backed denylist; never bind it to the user’s auto-stop preference.
+
+4. **Replacement detector:** a mediocre VAD can silently damage far more dictations than this crash. ASR-native endpointing would also add Parakeet and WhisperKit owners for a concern currently owned once.  
+   Exact correction: keep one source and require downstream-equivalence evidence, including dead-air routing, conditioned samples, tail preservation and final text.
+
+5. **Fresh buffers:** it targets an unproven hypothesis. The crash occurred at first-use and the guard-page probe was negative. Repeated allocation can create a different performance problem.  
+   Exact correction: allow one bounded paired experiment; stop if it produces neither a crash signal nor measurable memory-safety evidence.
+
+6. **Existing ASR XPC:** the VAD limb could now kill the ASR helper. That may preserve the app window while losing the raw transcript—the wrong reliability trade. XPC replies are also serialized, as the protocol itself warns at `Sources/EnviousWisprCore/ASRServiceProtocol.swift:98-105`.  
+   Exact correction: reject until process-kill UAT proves raw paste for both engines and proves VAD calls cannot head-of-line block ASR.
+
+7. **Deferral:** it relocates the crash. Before paste, it still breaks the heart; after paste, its current consumers are too late.  
+   Exact correction: call it transcript-first only if paste completion is the hard boundary.
+
+8. **Same-process wrappers:** they create false confidence around corrupted process state.  
+   Exact correction: the Q0 hard-fault paragraph should be a plan-level acceptance criterion.
+
+9. **Recovery:** it changes “lost forever” into “possibly recoverable later,” not “heart never failed.”  
+   Exact correction: report recovery separately from immediate text delivery.
+
+10. **Dedicated helper:** it cleanly solves containment but pays exactly the process-boundary cost the founder rejected.  
+    Exact correction: reconsider it only if literal first-fault containment outranks D-028.
+
+## Q3 — Placement challenge
+
+I rank the crash-loop quarantine first among the no-new-process substitutes.
+
+The correct policy owner is `CaptureVADSignalSource` because it already owns:
+
+- detector creation and preparation: `CaptureVADSignalSource.swift:241-312`;
+- detector versus nil monitor selection: `:325-335`;
+- the final `.unavailable` versus `.confirmedNoSpeech` decision: `:401-413`.
+
+Exact ownership text:
+
+> `CaptureVADSignalSource` is the sole owner of whether VAD executes for a recording and which speech-evidence state is published. The persistent guard store reports only marker facts; it does not decide fallback.
+
+The strongest alternative owner is `SilenceDetector`, because it is closest to `MLModel.prediction`.
+
+The cost of choosing it is worse ownership: the Audio module would now need persistent product policy and would have to influence Pipeline’s `.unavailable` decision. It could stop making predictions, but it cannot by itself prevent Pipeline from interpreting a prepared detector with no segments as `.confirmedNoSpeech`. That splits execution health from fallback semantics.
+
+## Q4 — Evidence that would change my ranking
+
+1. **Affected-environment A/B:** reproduce on the original Mac/macOS 14.2.1 combination with `.all`, then show the same unchanged workload survives with `.cpuAndNeuralEngine`. That would move configuration-only to first.  
+   Obtainable only with the original machine or a matching environment. A VM is partial evidence because the observed stack was CPU, but it cannot reproduce all hardware scheduling.
+
+2. **Post-fix recurrence:** one configuration-aligned build producing `first_vad_chunk_started` without `first_vad_chunk_completed`, paired with a matching Sentry CoreML crash, would demote configuration-only immediately. A second distinct installation would move deliberate quarantine/disablement above observation.  
+   Obtainable with the merged Sentry/PostHog funnel.
+
+3. **Equivalent exposure with zero recurrence:** after the aligned build accumulates at least the same number of first-recording VAD starts as the affected release, with no matching incomplete pair or crash, configuration-only could move above quarantine. That is evidence of reduced risk, not proof of impossibility.
+
+4. **Quarantine overhead:** use the five-scenario paired harness to enclose marker arm/clear through verified paste. Any statistically supported median or p95 regression—or meaningful false quarantine during normal stop/cancel tests—moves quarantine down.  
+   Obtainable now.
+
+5. **Fault-injection receipt:** deliberately terminate the app during the guarded first-chunk interval, relaunch, and prove both engines paste raw text with VAD reported unavailable. This determines whether quarantine actually prevents the second crash loop.  
+   Obtainable with a separate UAT harness; a unit test cannot survive its own process death.
+
+6. **Replacement correctness:** compare segment boundaries, speech evidence, conditioner route, tail handling, WhisperKit clip ranges and final transcript—not merely latency—over quiet speech, noise, soft onset and long-tail fixtures. If a non-CoreML detector is equivalent, replacement moves near the top.  
+   Obtainable, but the current latency harness alone is insufficient.
+
+7. **Existing-XPC proof:** kill the ASR service during VAD preparation and prediction for both engines. If the app reliably reconstructs raw ASR and the five-scenario harness shows no meaningful paste delay or reply blocking, reusing that boundary moves above replacement.  
+   Obtainable, but it must test the heart result, not merely app survival.
+
+## Q5 — Industry precedent
+
+What is genuinely common:
+
+- Small first-party CoreML models run in the application process. FluidAudio’s documented streaming example constructs `VadManager` in a Swift `Task` and invokes it directly; its documented default is `.cpuAndNeuralEngine`. [FluidAudio VAD API](https://github.com/FluidInference/FluidAudio/blob/main/Documentation/API.md#voice-activity-detection)
+- Muesli publicly documents “in-process CoreML/ANE” and Silero VAD through FluidAudio. [Muesli](https://github.com/Muesli-HQ/muesli)
+- CoreML’s documented recoverable failures are ordinary thrown prediction errors. [Apple CoreML integration](https://developer.apple.com/documentation/coreml/integrating-a-core-ml-model-into-your-app)
+
+So the common small-model practice is: configure the model deliberately, serialize state, catch documented errors, measure performance and collect crash reports. It is not hard-fault containment.
+
+What is genuinely common when host survival is mandatory:
+
+- Another process. Apple’s Audio Unit design makes the trade explicit: out-of-process prevents a misbehaving plug-in from crashing the host; opting into in-process removes IPC overhead but gives up that stability boundary. [Apple Audio Unit guidance](https://developer.apple.com/documentation/audiotoolbox/incorporating-audio-effects-and-instruments)
+- XPC services are launched and restarted separately by `launchd`. [Apple XPC](https://developer.apple.com/documentation/XPC)
+
+What is merely possible, not responsible precedent:
+
+- catching fatal signals and continuing;
+- `setjmp`/`longjmp` across CoreML/Swift frames;
+- Mach exception tricks;
+- moving prediction to a thread and abandoning it after a timeout.
+
+Apple’s signal manual says most operations from a signal handler have undefined behaviour and handlers should do little more than set a flag.
+
+The competitor evidence is useful but limited. Spokenly, Vox and FluidVoice running the same library in-process without this observed crash supports “rare environment-specific failure,” not “our configuration is equivalent” or “the component cannot crash.”
+
+Exact precedent wording:
+
+> Public precedent supports in-process VAD as common practice and process isolation as the only real hard-fault boundary. Competitor non-reproduction is negative evidence about frequency only; it is not evidence of their compute units, model lifecycle or crash-containment design.
+
+## Unhedged ranking
+
+Under the no-new-process constraint:
+
+1. **Configuration alignment plus a one-strike local quarantine to `.unavailable`.**
+2. **Configuration alignment alone**, if the marker mechanism cannot clear the latency and false-quarantine gates.
+3. **Evidence-backed tuple disablement** using the existing raw-ASR fallback.
+4. **A validated non-CoreML replacement.**
+5. **Reuse the existing ASR XPC**, only after process-kill heart-path proof.
+6. **Fresh-buffer FluidAudio experiment.**
+7. **Deferral.**
+8. **Recovery, threads, timeouts, signals or exception wrappers—they are not containment.**
+
+The plan must not say “VAD is unable to crash the app.” The honest no-new-process promise is:
+
+> VAD remains in-process, so its first hard fault can still terminate the app. The model configuration is aligned with FluidAudio, the fault interval is observable, and an incomplete first prediction quarantines VAD on relaunch so subsequent dictations fail open to raw ASR.
+
+If literal first-fault nonfatality is non-negotiable, I would reject every no-new-process design. A process boundary is the answer.

--- a/docs/audits/2026-07-24-1784-grounded-review-r1-verdict.md
+++ b/docs/audits/2026-07-24-1784-grounded-review-r1-verdict.md
@@ -1,0 +1,175 @@
+# Verdict: PROCEED-WITH-REVISIONS
+
+The compute-unit change is correct and narrowly scoped. Do not use `MLModelConfigurationUtils.defaultConfiguration()`. Set the two properties explicitly in `BundledVADModelLoader`.
+
+The plan’s main errors are:
+
+- FluidAudio’s factory is not its VAD loading authority.
+- The proposed fallback test would not test the loader.
+- Live UAT alone is too weak for possible boundary movement.
+- This qualifies as SMALL, zero-blast-radius work.
+- The deferred classifier is not incapable of crashing an active dictation.
+
+## Q1 — Direction
+
+### Case for the FluidAudio factory
+
+- It is public and reachable.
+- It currently produces the desired configuration.
+- It avoids repeating two assignments.
+- It would inherit future FluidAudio defaults automatically.
+
+### Case for explicit local configuration
+
+- This is a pinned fork, and dependency updates are deliberate review points: [Package.resolved:14](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Package.resolved:14).
+- A future factory change could silently alter extra CoreML settings in the heart path.
+- Most importantly, the factory is not used by FluidAudio’s VAD loader. The real loader creates its configuration locally at [DownloadUtils.swift:301](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/DownloadUtils.swift:301).
+- Therefore adopting the factory does not actually “return to the VAD paved road.”
+
+Commitment: configure it locally. This pins the intended heart-path policy while matching the current FluidAudio VAD loader exactly.
+
+```swift
+do {
+  // Match the pinned FluidAudio VAD load policy explicitly. Keep this
+  // heart-path configuration reviewable across dependency updates.
+  let configuration = MLModelConfiguration()
+  configuration.computeUnits = .cpuAndNeuralEngine
+  configuration.allowLowPrecisionAccumulationOnGPU = true
+  return try MLModel(contentsOf: url, configuration: configuration)
+} catch {
+  throw LoadError.loadFailed(error)
+}
+```
+
+## Q2 — Fact-check
+
+| # | Verdict | Evidence |
+|---|---|---|
+| 1 | **TRUE** | The sole EnviousWispr VAD `MLModel` construction is [BundledVADModelLoader.swift:19](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprAudio/BundledVADModelLoader.swift:19), with the load at [line 34](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprAudio/BundledVADModelLoader.swift:34). Its only production caller is [SilenceDetector.swift:157](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprAudio/SilenceDetector.swift:157). |
+| 2 | **TRUE**, scoped to VAD | The preloaded initializer only stores `config` and `vadModel`: [VadManager.swift:102](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/VAD/VadManager.swift:102). VAD reads `config.computeUnits` only in `loadUnifiedModel`: [VadManager.swift:124](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/VAD/VadManager.swift:124), [line 135](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/VAD/VadManager.swift:135). |
+| 3 | **TRUE**, with an important qualification | The factory is public and sets those two properties: [MLModelConfigurationUtils.swift:5](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/Shared/MLModelConfigurationUtils.swift:5), [lines 11-16](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/Shared/MLModelConfigurationUtils.swift:11). The optimization hints and 126.6 → 93.3 result are comments only: [lines 17-28](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/Shared/MLModelConfigurationUtils.swift:17). But the VAD loader does not use this factory; it repeats the settings at [DownloadUtils.swift:301](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/DownloadUtils.swift:301). |
+| 4 | **TRUE** | `EnviousWisprAudio` directly depends on FluidAudio: [Project.swift:231](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Project.swift:231) and [Package.swift:89](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Package.swift:89). FluidAudio exports the collision-prone `FluidAudio` struct at [FluidAudioSwift.swift:29](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/FluidAudioSwift.swift:29), but no local `MLModelConfigurationUtils` or `FluidAudio` type exists in `Sources/`. |
+| 5 | **TRUE** | First-party modules are static frameworks: [Project.swift:151](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Project.swift:151). Audio reaches the app through Pipeline/AppKit at [Project.swift:278](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Project.swift:278) and reaches the ASR executable directly at [Project.swift:335](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Project.swift:335). The ASR service constructs only `ParakeetBackend`: [ASRServiceHandler.swift:48](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprASRService/ASRServiceHandler.swift:48). The detector construction is in the app pipeline: [CaptureVADSignalSource.swift:99](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift:99). |
+| 6 | **TRUE** for the production VAD feed | The size is 4096: [SilenceDetector.swift:132](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprAudio/SilenceDetector.swift:132). Processing begins only when a complete chunk exists, and the slice has that exact size: [VADMonitorLoop.swift:109](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprPipeline/VADMonitorLoop.swift:109), [lines 111-121](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprPipeline/VADMonitorLoop.swift:111). FluidAudio can pad arbitrary callers’ short arrays, but this production caller never supplies one. |
+| 7 | **JUDGMENT-CALL** | “Untouched” is factual; “correctly” is a policy judgment. Parakeet uses FluidAudio’s normal model loading and `.default`: [ParakeetBackend.swift:108](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprASR/ParakeetBackend.swift:108), [lines 115-123](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprASR/ParakeetBackend.swift:115). WhisperKit deliberately requests `.cpuAndGPU`: [WhisperKitBackend.swift:9](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprASR/WhisperKitBackend.swift:9), [lines 22-25](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprASR/WhisperKitBackend.swift:22). Neither file is in the planned diff. |
+| 8 | **TRUE** | The only `MLModelConfiguration()` constructions in `Sources/` are the VAD loader at [BundledVADModelLoader.swift:34](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprAudio/BundledVADModelLoader.swift:34) and the separate LLM classifier at [CoreMLOutputClassifier.swift:93](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprLLM/CoreMLOutputClassifier.swift:93). |
+
+### Coverage-round skip
+
+The skip is legitimate, but for a different reason than the prior council.
+
+The intended change is:
+
+- At most 20 lines and two files.
+- No new symbol, API, control flow, module edge, persistence, or migration.
+- A single configuration change with clean rollback.
+
+That exactly matches [workflow-process.md RULE: council-skip-zero-blast-radius:61](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.claude/rules/workflow-process.md:61). Config tweaks are SMALL at [line 141](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.claude/rules/workflow-process.md:141).
+
+The prior council did not cover the weak oracle, deterministic boundary comparison, or incorrect authority claim. Grounded review caught those. But the explicit zero-blast rule still makes the separate coverage round optional.
+
+If the eventual diff exceeds those limits, the exemption must be reconsidered.
+
+## Q3 — Consolidation and authority
+
+The dominant concern is:
+
+> Which requested CoreML load policy is used for the bundled VAD model?
+
+There is one EnviousWispr runtime owner: `BundledVADModelLoader.loadModel(in:)`.
+
+The plan’s claim that FluidAudio’s factory is the authority is false. FluidAudio has two equivalent implementations today:
+
+- Factory: [MLModelConfigurationUtils.swift:11](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/Shared/MLModelConfigurationUtils.swift:11)
+- Actual VAD model loading: [DownloadUtils.swift:301](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/DownloadUtils.swift:301)
+
+The correct local authority is therefore the sole model construction site, with a comment saying it intentionally matches the pinned dependency.
+
+Deferring `CoreMLOutputClassifier.swift:93` is acceptable. It is a different model and policy, and `EnviousWisprLLM` does not depend on FluidAudio: [Package.swift:135](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Package.swift:135). Folding it in would add an inappropriate module dependency or broaden the change.
+
+However, the reason written in the plan is false. Classifier inference happens in-process during polish before paste: [EnviousOutputFilter.swift:78](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprLLM/EnviousOutputFilter.swift:78), [AppleIntelligenceConnector.swift:453](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift:453). Throws and timeouts fail open, but a hard CoreML process fault cannot be caught and could terminate the active dictation.
+
+## Q4 — Mandatory plan edits
+
+### 1. Replace the implementation direction
+
+Replace §3’s factory adoption with:
+
+> `BundledVADModelLoader.loadModel(in:)` remains the sole EnviousWispr authority for the bundled VAD model’s requested CoreML load policy. Construct an `MLModelConfiguration` locally and explicitly set `computeUnits = .cpuAndNeuralEngine` and `allowLowPrecisionAccumulationOnGPU = true`. These values match the pinned FluidAudio VAD loader at `DownloadUtils.swift:301-303`. Keeping them explicit prevents a future dependency update from silently adding or changing heart-path CoreML policy through a shared factory.
+
+Replace §3c-answer with:
+
+> `§3c-answer: one EnviousWispr authority — BundledVADModelLoader.loadModel(in:) owns the requested CoreML configuration at the sole VAD MLModel construction site. It explicitly pins the two values matching the current pinned FluidAudio VAD loader. VadConfig.computeUnits remains library-owned metadata consumed only by FluidAudio’s bypassed loading path; EnviousWispr creates no second runtime configuration site.`
+
+Also remove:
+
+> “what every peer app on this library runs”
+
+That was not established by the measurements.
+
+Replace “No behaviour switch” with:
+
+> `No public API, control-flow, fallback, or lifecycle change. The observable runtime change is the requested CoreML hardware policy and any resulting numerical or latency difference.`
+
+### 2. Replace the test oracle
+
+`MLModel.configuration` represents the load-time configuration requested when the model was instantiated, not proof of the hardware CoreML ultimately selected. Apple describes `MLComputeUnits` as the compute devices the application permits, while CoreML chooses within that set. See [MLModel.configuration](https://developer.apple.com/documentation/coreml/mlmodel/configuration) and [MLComputeUnits](https://developer.apple.com/documentation/coreml/mlcomputeunits).
+
+That makes it a valid oracle for the feature being changed: the loader’s requested policy. It does not prove actual ANE placement.
+
+Use this test:
+
+```swift
+import CoreML
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// ...
+
+let fixtureBundle = try #require(Bundle(path: fixtureRoot.path))
+let model = try BundledVADModelLoader.loadModel(in: fixtureBundle)
+
+#expect(model.configuration.computeUnits == .cpuAndNeuralEngine)
+#expect(model.configuration.allowLowPrecisionAccumulationOnGPU)
+```
+
+Delete the fallback that tests `MLModelConfigurationUtils.defaultConfiguration()` directly. That fallback would pass even if `BundledVADModelLoader` still used the bare configuration, so it would be decoration.
+
+Keep the mutation receipt: restoring the bare configuration must fail this test.
+
+### 3. Add deterministic offline comparison
+
+Live UAT on both engines is necessary but insufficient. Both engines share the same VAD, so changing ASR engines does not provide independent VAD numerical coverage.
+
+Replace §14 question 2 with:
+
+> **Could segment boundaries shift?** Yes. Before Live UAT, run a deterministic offline A/B using identical frozen 16 kHz mono Float32 audio and the checked-in VAD model. Arm A uses the current bare configuration (`.all`, low-precision GPU accumulation disabled). Arm B uses `.cpuAndNeuralEngine` with low-precision GPU accumulation enabled. Feed only complete 4,096-sample chunks through fresh detector state using the production threshold, smoothing, minimum-speech, silence-timeout, and padding settings. Include silence-only, quiet onset, normal short speech, fillers/internal pauses, and long speech with trailing silence. Record per-chunk probabilities, event types and sample indexes, final SpeechSegment ranges, and the first auto-stop chunk. Run each arm three times to detect within-arm variation. Acceptance requires identical event sequences, segment boundaries, and auto-stop decisions for every fixture. Report maximum probability delta as supporting evidence. Any decision or boundary difference stops the change for founder review. Live UAT then confirms real capture, paste, and both ASR integrations.
+
+### 4. Correct the tier declaration
+
+Replace the preface with:
+
+> - **Lane:** Code  
+> - **Tier:** SMALL (single VAD model-load configuration change; no control flow, lifecycle, public API, module edge, persistence, or migration)  
+> - **Coverage round:** SKIPPED under RULE: council-skip-zero-blast-radius. The production/test diff remains ≤20 lines across two files and is a single-value configuration change with single-commit rollback. PR tag: `council-skip: zero-blast-radius (single-value config)`.  
+> - **Live UAT:** Y (RULE: runtime-uat-catches-static-misses; SMALL does not waive runtime validation for ML/audio changes)  
+> - **Modules:** EnviousWisprAudio  
+> - **Test:** required (EnviousWisprTests/Audio)
+
+The current MEDIUM declaration over-processes the change. Keeping Live UAT does not make it MEDIUM.
+
+### 5. Correct the classifier deferral
+
+Replace both classifier statements with:
+
+> `CoreMLOutputClassifier.swift:93` uses the same bare-constructor pattern for a different model and a separate placement policy. It is a limb, but its in-process prediction runs during Apple Intelligence polish before paste, so a hard CoreML fault could still terminate that dictation. Founder-approved as separate work at Gate 1; this VAD-only change does not alter it.
+
+### 6. Correct the failure-mode statement
+
+Replace “CoreML falls back internally” with:
+
+> `.cpuAndNeuralEngine` permits CPU and Neural Engine execution and excludes GPU execution. CoreML chooses within the permitted resources; this requested policy does not prove which permitted device executes each operation.
+
+Final position: keep the VAD-only scope, use explicit local settings, strengthen the real-loader test, add the offline A/B boundary receipt, and classify the work as SMALL zero-blast-radius.

--- a/docs/audits/2026-07-24-1784-grounded-review-r2-verdict.md
+++ b/docs/audits/2026-07-24-1784-grounded-review-r2-verdict.md
@@ -1,0 +1,189 @@
+# Verdict: PROCEED-WITH-REVISIONS
+
+The main design is now right. Four real issues remain:
+
+- The classifier deferral still uses a factory-era dependency argument.
+- Several untouched sections still mention the removed factory or give Live UAT the job now assigned to §11.3.
+- The A/B input normalization and executable harness route are underspecified.
+- The exact proposed diff likely exceeds the zero-blast 20-line limit because of the long production comment.
+
+## Q1 — Six revisions
+
+### 1. Explicit local configuration: correctly landed
+
+Correct in:
+
+- TL;DR: [plan:21](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:21)
+- Library comparison and revision note: [plan:98](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:98)
+- Design decision: [plan:192](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:192)
+- Proposed Swift: [plan:295](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:295)
+
+Two factory-era remnants remain in §2.5 and §5, covered below.
+
+### 2. Single authority: correctly landed
+
+The new answer at [plan:218-228](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:218) is correct.
+
+However, §3b still says “Keeping both inside the loader keeps one place to read” at [plan:212-216](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:212). `VadConfig` remains in `SilenceDetector`, so “both” are not inside the loader.
+
+Replace the final sentence of §3b with:
+
+> Keeping the `MLModel` load policy at the model-construction site prevents callers from trying to control it through the ignored `VadConfig.computeUnits` field. The separate segmentation configuration remains owned by `SilenceDetector`.
+
+### 3. Real-loader test: partially landed
+
+The assertions are correct at [plan:335-349](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:335).
+
+Two corrections remain:
+
+- The drop-in test omitted `import CoreML`.
+- The mutation instruction still says “revert the one line” at [plan:350](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:350), but the revised implementation uses two property assignments.
+
+Use:
+
+```swift
+import CoreML
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+```
+
+Replace the mutation receipt with:
+
+> **Mutation receipt:** remove both explicit property assignments so the loader passes a fresh bare `MLModelConfiguration()` to `MLModel`. Confirm that the configuration assertions FAIL. A freeze test that passes with the requested policy removed is decoration.
+
+Also change §10’s test-file row to:
+
+> `Tests/EnviousWisprTests/Audio/BundledVADModelLoaderTests.swift` | Add `import CoreML` and freeze the requested configuration through the real loader.
+
+### 4. Offline A/B: direction correctly landed, execution underspecified
+
+The ordering, fixtures, trace outputs, and stop gate landed at [plan:354-378](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:354). Ship criteria also correctly gate on it at [plan:394-403](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:394).
+
+But the named files are 24 kHz MP3s, not frozen 16 kHz Float32 buffers. The plan does not define decoding or resampling. It also calls the harness a scratchpad, but constructing two `SilenceDetector` instances with alternate preloaded models requires the module’s internal test seam at [SilenceDetector.swift:162](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprAudio/SilenceDetector.swift:162).
+
+Replace the beginning of §11.3 after the two arm definitions with:
+
+> Implement this as a temporary, uncommitted test-target harness using `@testable import EnviousWisprAudio`, so it can use `SilenceDetector`’s internal `makeStreamingVad` seam. Wrap each arm’s `VadManager` in a recording `StreamingVad` that delegates every call while capturing probability, event kind, and sample index.
+>
+> The named `ovh-*.mp3` fixtures are 24 kHz mono MP3 files, not detector-ready PCM. Decode and resample each fixture exactly once to one in-memory 16 kHz mono Float32 buffer before constructing either arm. Feed that same buffer object to both arms, in complete 4,096-sample chunks, and discard the same incomplete final remainder. Do not independently decode or resample per arm. Record the source-file SHA-256 values and decoded sample counts in the measurement receipt.
+>
+> Use `vadSensitivity = 0.5`, `vadEnergyGate = true`, and `vadSilenceTimeout = 1.5`, matching current production defaults. This produces the `SmoothedVADConfig` through `SmoothedVADConfig.fromSensitivity` rather than restating its derived thresholds in the harness.
+
+Replace §10’s scratchpad sentence with:
+
+> The §11.3 A/B runs from a temporary, uncommitted test-target file because it needs `@testable` access to the detector’s existing injection seam. Remove that file after recording the receipt. If the harness must remain in the repository, add it to the file list and re-evaluate the zero-blast exemption before push.
+
+### 5. SMALL retier: correctly landed, line-limit claim needs repair
+
+The classification at [plan:5-13](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:5) is directionally correct.
+
+However, the production comment proposed at [plan:298-308](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:298) is eleven lines. Combined with the configuration, test assertions, test import, and deleted lines, the planned diff is about 23 changed lines. That conflicts with the `≤20` assertion.
+
+Replace that production comment with:
+
+```swift
+// Match the pinned FluidAudio VAD loader (`DownloadUtils.swift:301-303`).
+// Keep this heart-path policy explicit across dependency updates.
+```
+
+The detailed rationale already lives in the plan. With that shortened comment, the shipped diff should fit the exemption. Verify the actual `git diff --stat` and changed-line count before using the PR tag.
+
+### 6. Classifier and failure wording: partially landed
+
+The compute-unit failure wording is correct at [plan:264-270](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:264).
+
+The classifier correction accurately admits the hard-fault risk at [plan:61-71](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:61), but its dependency rationale is now wrong. Explicit local configuration would not require `EnviousWisprLLM` to depend on FluidAudio.
+
+Replace the classifier non-goal with:
+
+> **`CoreMLOutputClassifier.swift:93`**, the second bare-config site. It uses the same constructor pattern for a different model whose correct placement policy has not been established. It is a limb, but its in-process prediction runs during Apple Intelligence polish before paste, so a hard CoreML fault could still terminate that dictation. Copying the VAD policy into this unrelated model would be unsupported scope expansion. Founder-approved as separate work at Gate 1; this VAD-only change does not alter it.
+
+## Q2 — Remaining contradictions and stale sections
+
+### §2.1 does not include the new behavioral gate
+
+The goals at [plan:46-51](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:46) still jump from configuration freeze to latency.
+
+Replace them with:
+
+> 1. The bundled model is constructed with the same requested configuration FluidAudio’s pinned VAD loader would produce.  
+> 2. A real-loader test freezes that policy so a future edit cannot silently restore CoreML’s default.  
+> 3. A deterministic offline A/B verifies that the policy change does not alter VAD events, segment boundaries, or auto-stop decisions on the frozen corpus.  
+> 4. A measured latency receipt on the real app proves no heart-path regression.
+
+### §2.5 still grounds the optimization-hints claim through the wrong implementation
+
+At [plan:187](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:187), “the library default” again points primarily to the factory.
+
+Replace that premise row with:
+
+> The pinned VAD load policy is CHEAP and does not carry the documented RTFx regression | `DownloadUtils.swift:301-303`, the actual VAD path, constructs a bare configuration and sets only `computeUnits` plus `allowLowPrecisionAccumulationOnGPU`. It sets no `MLOptimizationHints`. The separate shared factory’s comments at `MLModelConfigurationUtils.swift:17-29` document the 126.6 → 93.3 regression and leave those hints disabled. The local policy mirrored by this plan therefore does not adopt the regressing hints.
+
+### §4 claims actual hardware placement rather than requested policy
+
+At [plan:230-233](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:230), replace the final sentence with:
+
+> The only direct observable delta is the requested CoreML compute-unit policy. CoreML’s resolved placement is not directly asserted; numerical, boundary, and latency effects are measured in §11.
+
+### §5 still invokes the removed factory
+
+The concurrent row at [plan:244](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:244) is stale.
+
+Replace it with:
+
+> Concurrent | Two processes may each load their own model. Every call constructs a new local `MLModelConfiguration`; no configuration object or model state is shared between processes.
+
+### §6 contradicts the A/B design
+
+At [plan:256](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:256), “Silero is deterministic per chunk” is too broad when the plan explicitly tests compute-policy drift.
+
+Replace that row with:
+
+> `SilenceDetector.processChunk` | Same API. Raw probabilities may differ by compute policy; §11.3 verifies whether any difference reaches VAD events, segment boundaries, or auto-stop decisions.
+
+Replace [plan:262](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:262) with:
+
+> The deterministic offline A/B (§11.3) checks detector behavior. Live UAT (§11.1) then checks capture, ASR, auto-stop, and paste integration.
+
+### §11.3 acceptance is achievable
+
+The current criterion does not require bit-identical probabilities. It requires identical discrete behavior. That is the right bar.
+
+A different segment boundary is not harmless floating-point noise. Those boundaries feed dead-air handling, conditioning, Parakeet tail preservation, WhisperKit clipping, and auto-stop. Founder review is appropriate if one moves.
+
+Add this clarification after [plan:375-378](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:375):
+
+> Probability values are not required to be equal and have no arbitrary epsilon gate. A numerical delta is tolerable when all three runs within each arm are stable and both arms produce identical event kinds and indexes, final segments, speech-evidence outcome, and first auto-stop chunk. A difference in any of those discrete outputs is a real behavioral change, not a numerical false-fail.
+
+### §12 understates the shipped diff
+
+At [plan:389-392](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:389), replace:
+
+> The shipped change touches one production file and one test file. Production replaces the bare model configuration with one explicit requested policy; tests freeze that policy through the real loader. Rollback is a single commit with no downstream cleanup, persisted state, or migration. Blast radius is the requested compute policy for the bundled VAD model.
+
+### §14 contradicts the corrected classifier section
+
+At [plan:413-414](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:413), “same defect, off the heart path” repeats both rejected claims.
+
+Replace it with:
+
+> **`CoreMLOutputClassifier.swift:93`** uses the same constructor pattern for a different model with no established replacement placement policy. Its in-process execution can terminate an active dictation on a hard fault. Founder-approved as separate work; unchanged here.
+
+Sections §8, §9, and §15 remain consistent.
+
+## Q3 — SMALL and coverage skip
+
+**SMALL remains correct.** Validation effort does not raise the implementation tier. The shipped change remains a configuration tweak with no new control flow, API, lifecycle, persistence, or module edge.
+
+The scratch A/B harness also does not count toward shipped blast radius if it is genuinely uncommitted and removed after producing the receipt.
+
+The zero-blast skip is legitimate only after:
+
+1. Shortening the production comment.
+2. Adding the missing test import.
+3. Counting the actual final diff and confirming it is ≤20 changed lines across two files.
+4. Ensuring the A/B harness does not remain in the repository.
+
+If the harness becomes a committed script or the final diff exceeds 20 changed lines, the plan must withdraw the zero-blast tag and re-evaluate coverage before push.

--- a/docs/audits/2026-07-24-1784-grounded-review-r3-verdict.md
+++ b/docs/audits/2026-07-24-1784-grounded-review-r3-verdict.md
@@ -1,0 +1,195 @@
+# Verdict: PROCEED-WITH-REVISIONS
+
+The production design is clean. Three plan issues remain:
+
+1. The zero-blast declaration still contradicts its conditional gate.
+2. Two sentences still confuse requested policy with actual placement.
+3. The validation plan depends on temporary files and a scratch harness that are not available from the repo alone.
+
+## Q1 — Verification of the 17 revisions
+
+The following landed correctly:
+
+- §3b ownership correction: [plan:223-229](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:223)
+- Test imports and real-loader assertions: [plan:342-357](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:342)
+- Two-assignment mutation receipt: [plan:364-366](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:364)
+- Test-file description: [plan:304-307](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:304)
+- Temporary test-target harness wording: [plan:309](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:309)
+- Two-line production comment: [plan:314-315](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:314)
+- `@testable` seam and recording wrapper: [plan:379-382](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:379)
+- Decode-once/shared-buffer requirement: [plan:384-389](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:384)
+- Production VAD settings and factory method: [plan:391-394](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:391)
+- Probability-tolerance clarification: [plan:409-412](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:409)
+- Classifier non-goal: [plan:71-82](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:71)
+- Classifier open question: [plan:449-451](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:449)
+- Goals: [plan:54-61](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:54)
+- Corrected FluidAudio premise: [plan:193-201](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:193)
+- Contract and lifecycle wording: [plan:243-265](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:243)
+- Downstream ownership split: [plan:267-278](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:267)
+- Blast-radius wording: [plan:423-428](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:423)
+
+Two were applied correctly in their target sections but remain inconsistent with neighboring text:
+
+- The conditional zero-blast paragraph is correct, but the first bullet and revision note still assert that the exemption already holds.
+- The self-contained A/B mechanics are better specified, but their inputs are still external `/private/tmp` files.
+
+## Q2 — Exhaustive four-class sweep
+
+### A. Abandoned factory design
+
+Every remaining factory reference was enumerated:
+
+- [Lines 112-148](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:112): historical explanation of why the factory was rejected. Correct.
+- [Line 198](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:198): uses the factory comments only as evidence about disabled optimization hints. Correct.
+- [Lines 205-210](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:205): explains why local policy avoids future factory drift. Correct.
+- [Lines 235-238](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:235): authority comparison. Correct.
+- [Lines 359-363](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:359): rejects a factory-only test oracle. Correct.
+
+The `KernelDictationDriverFactory` reference at line 93 is an unrelated type name.
+
+**Factory-design sweep: clean.**
+
+### B. Live UAT doing §11.3’s job
+
+Every Live UAT reference was enumerated:
+
+- [Lines 3 and 8](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:3): declaration. Correct.
+- [Lines 18-20](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:18): tier explanation. Correct.
+- [Lines 277-278](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:277): §11.3 owns detector behavior; UAT owns integration. Correct.
+- [Lines 327-338](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:327): integration UAT. Correct.
+- [Lines 369-372](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:369): explicitly says UAT is insufficient for numerical drift. Correct.
+- [Line 437](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:437): ship gate. Correct.
+- [Lines 446-448](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:446): points boundary validation to §11.3. Correct.
+
+**Live-UAT ownership sweep: clean.**
+
+### C. “One line” and diff-size claims
+
+Complete list:
+
+- [Line 7](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:7): incorrectly asserts `SKIPPED`, `remains ≤20`, and the PR tag before verification.
+- [Lines 12-16](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:12): correctly makes the exemption conditional.
+- [Lines 18-21](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:18): incorrectly says the change already meets every condition.
+- [Line 34](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:34): “No new import” contradicts the test’s new CoreML import.
+- [Lines 223-224](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:223): “one line later” describes current source proximity, not diff size. Correct.
+- [Line 306](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:306): production-only `+3 lines` and no production import. Correct.
+- [Line 309](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:309): correctly re-evaluates the exemption if the harness ships.
+
+Three stale claims remain: lines 7, 18-21, and 34.
+
+### D. Actual placement versus requested policy
+
+Complete meaningful list:
+
+- [Lines 29-32](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:29): bare configuration takes the requested `.all` default. Correct.
+- [Lines 36-37](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:36): explicitly says requested policy. Correct.
+- [Line 44](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:44): incorrectly says the model “runs `.all`.”
+- [Lines 46-47](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:46): incorrectly describes actual execution in an excluded hardware configuration.
+- [Lines 119-136](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:119): code samples showing requested policy. Correct.
+- [Line 165](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:165): ASR configuration evidence. Correct.
+- [Lines 205-210](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:205): requested load policy. Correct.
+- [Lines 245-248](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:245): explicitly refuses to claim resolved placement. Correct.
+- [Line 284](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:284): permitted resources and CoreML choice. Correct.
+- [Lines 376-377](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:376): A/B requested policies. Correct.
+- [Line 419](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:419): “runs once per chunk” means invocation frequency, not placement. Correct.
+
+Two stale placement claims remain: lines 44 and 46-47.
+
+## Q3 — Buildability
+
+The production change and freeze test are buildable without guessing.
+
+The validation plan is not yet self-contained.
+
+### External fixture dependency
+
+Section 11.3 relies on `/private/tmp/ovh-*.mp3`: [plan:396-399](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:396). Those files are not in the repo and can disappear.
+
+The repo already contains five committed 16 kHz mono PCM fixtures:
+
+- `scripts/freeze-suite/clips/normal-speech.wav`
+- `scripts/freeze-suite/clips/mumbled-speech.wav`
+- `scripts/freeze-suite/clips/silence.wav`
+- `scripts/freeze-suite/clips/background-noise.wav`
+- `scripts/freeze-suite/clips/sudden-burst.wav`
+
+Those should replace the temporary MP3 corpus.
+
+### Replay lifecycle is not fully defined
+
+The plan does not say:
+
+- How each arm’s `MLModel` and `VadManager` are constructed.
+- Whether detector state is reset or reused across the three runs.
+- Whether feeding stops at the first auto-stop signal.
+- When `finalizeSegments` is called.
+- How “quiet onset” is synthesized.
+
+An implementer would have to choose.
+
+### Latency harness is not in the repo
+
+Section 11.4 says “Reuse the #1780 five-scenario harness”: [plan:414-421](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:414). That harness is a session scratch file, not a repository artifact. The number of passes and the meaning of “statistically supported” are also unspecified.
+
+## Q4 — Exact edits
+
+### 1. Replace the coverage bullet and revision note
+
+Replace line 7 with:
+
+> - **Coverage round:** CONDITIONALLY SKIPPED under RULE: council-skip-zero-blast-radius. Apply PR tag `council-skip: zero-blast-radius (single-value config)` only after the four-condition pre-push gate below passes. Otherwise withdraw the exemption and re-evaluate coverage before push.
+
+Replace the revision note at lines 18-21 with:
+
+> **Revision note (grounded review r1/r2).** This preface previously declared MEDIUM. Corrected to SMALL because the shipped change is a configuration tweak; retaining Live UAT does not raise the tier. The zero-blast exemption is expected, not pre-proven: r2 added the four-condition gate after the earlier proposed comment would have exceeded the 20-line limit.
+
+### 2. Replace the TL;DR size sentence
+
+Replace line 34 with:
+
+> Production replaces one bare load with an explicit policy at one site. The test adds `import CoreML` and two real-loader assertions. No new symbols, control flow, fallback, or production import.
+
+### 3. Replace the two actual-placement claims
+
+Replace lines 41-47 with:
+
+> We bundle the VAD model (#1224) and load it ourselves, so we use FluidAudio’s pre-loaded-model initializer. That initializer stores the `VadConfig` we pass but never reads its `computeUnits` field; that field is read only inside the loading path we bypass. The manager therefore reports `.cpuAndNeuralEngine` while the preloaded model was created with CoreML’s requested `.all` default.
+>
+> We therefore permit GPU execution for this heart-path model even though FluidAudio’s pinned VAD loader requests only CPU and Neural Engine. This describes the requested allowed set, not proof of CoreML’s resolved device placement.
+
+### 4. Make §11.3 repo-contained and executable
+
+Replace the fixture and construction material at lines 374-402 with:
+
+> Use the checked-in VAD model and the five committed fixtures under `scripts/freeze-suite/clips/`: `normal-speech.wav`, `mumbled-speech.wav`, `silence.wav`, `background-noise.wav`, and `sudden-burst.wav`. These files are committed 16 kHz mono Int16 PCM. Verify that format, record each SHA-256, and decode each file exactly once into one in-memory mono Float32 buffer. Feed the same decoded buffer to both arms; do not decode independently per arm.
+>
+> Create a deterministic quiet-onset fixture from the decoded `normal-speech.wav`: scale complete chunks 0-1 by `0.10`, chunks 2-3 by `0.25`, chunks 4-5 by `0.50`, and all remaining speech chunks by `1.0`. Append twelve zero chunks to `normal-speech`, `mumbled-speech`, and quiet-onset so speech-end and auto-stop behavior receive 3.072 seconds of identical trailing silence. Truncate every fixture to complete 4,096-sample chunks after constructing it.
+>
+> Implement the harness as a temporary, uncommitted `EnviousWisprTests` source with:
+>
+> ```swift
+> @preconcurrency import AVFoundation
+> import CoreML
+> @preconcurrency import FluidAudio
+> import Testing
+>
+> @testable import EnviousWisprAudio
+> ```
+>
+> Resolve the checked-in compiled model URL once. Load one model for Arm A using a bare `MLModelConfiguration()` and one model for Arm B using `.cpuAndNeuralEngine` plus `allowLowPrecisionAccumulationOnGPU = true`. For each repetition, construct a fresh `VadManager(config: VadConfig(defaultThreshold: 0.5), vadModel: model)`, a fresh recording `StreamingVad` wrapper, and a fresh `SilenceDetector` through its internal `makeStreamingVad` seam. Build the detector configuration with `SmoothedVADConfig.fromSensitivity(0.5, energyGate: true)` and use `silenceTimeout: 1.5`. Call `prepare()` before feeding audio. Never reuse detector or stream state between repetitions.
+>
+> Each repetition performs two replays. The full-feed replay records every chunk, ignores `shouldAutoStop` until the buffer ends, then calls `finalizeSegments(totalSampleCount:)`. The auto-stop replay stops at the first `true`, records that chunk index, and calls `finalizeSegments(totalSampleCount:)` with the number of samples actually processed. Capture probabilities, event kinds and indexes, final segments, speech-evidence outcome, and first auto-stop chunk for both replay modes. Run three repetitions per arm.
+
+Keep the existing acceptance text at lines 404-412.
+
+### 5. Replace §11.4 with a repo-contained latency receipt
+
+> ### 11.4 Latency receipt
+>
+> Use the committed `scripts/freeze-suite/clips/*.wav` fixtures and the repository’s `Tests/RuntimeUAT/wispr_eyes.py::test_recording`; do not depend on the removed #1780 session scratchpad or `/private/tmp/ovh-*`.
+>
+> Preserve two app artifacts: Arm A built from the pre-change commit and Arm B built from the final change. Use identical dev settings, engine state, fixtures, and expected transcripts. Quit one artifact fully before launching the other.
+>
+> Pre-warm each arm with one unmeasured pass over all five fixtures. Then run ten measured passes per arm and engine in alternating `A-B-B-A` blocks. For every recording, capture the #1783 first-chunk processing duration and `Pipeline timing TOTAL` from `app.log`, keyed by the recording’s session marker. Report per-fixture and aggregate medians plus paired fixed-minus-baseline deltas.
+>
+> A statistically supported regression means the fixed arm has a positive paired median delta whose 95% bootstrap confidence interval excludes zero. Any such regression stops for founder review. Otherwise report the observed median and maximum deltas without claiming exact parity.

--- a/docs/audits/2026-07-24-1784-grounded-review-r4-verdict.md
+++ b/docs/audits/2026-07-24-1784-grounded-review-r4-verdict.md
@@ -1,0 +1,125 @@
+# Verdict: PROCEED-WITH-REVISIONS
+
+The production change and freeze test are ready. Two substantive validation ambiguities remain:
+
+1. The two offline replay modes appear to share detector state.
+2. The latency receipt does not define the measured value, app artifacts, pairing unit, or bootstrap sample.
+
+Per the round-four rule, these require founder escalation rather than another routine review round.
+
+## Q1 — Round-three edits
+
+Correctly landed:
+
+- Conditional coverage exemption: [plan:7-21](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:7)
+- Accurate TL;DR/import statement: [plan:29-38](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:29)
+- Requested-policy wording: [plan:42-49](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:42)
+- Committed fixture selection and format: [plan:381-391](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:381)
+- Quiet-onset and trailing-silence construction: [plan:393-397](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:393)
+- Harness imports and model policies: [plan:399-419](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:399)
+- Full-feed and auto-stop modes: [plan:421-426](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:421)
+- Repository-based latency inputs and defined regression direction: [plan:441-455](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:441)
+
+Two are partial:
+
+### Offline state isolation
+
+The plan constructs one fresh detector “for each repetition” at [plan:410-419](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:410), then performs two replays during that repetition at [plan:421-426](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:421).
+
+If interpreted literally, auto-stop starts with state left by full-feed. `SilenceDetector` retains stream state, EMA, phase, segments, and counters across calls: [SilenceDetector.swift:181-193](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprAudio/SilenceDetector.swift:181). Each replay mode needs its own fresh detector.
+
+### Latency measurement
+
+The regression formula landed, but its inputs remain undefined. `test_recording` returns only a Boolean: [wispr_eyes.py:1240](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Tests/RuntimeUAT/wispr_eyes.py:1240), [line 1344](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Tests/RuntimeUAT/wispr_eyes.py:1344).
+
+The plan does not specify:
+
+- Whether the measured value is wall time, `Pipeline timing TOTAL`, or VAD chunk latency.
+- How Arm A and Arm B app artifacts are preserved and alternated.
+- What one paired observation is.
+- Whether the bootstrap operates over three passes, fixtures, engines, or all recording cells.
+- What “one discarded pass per block” means.
+
+Those choices materially change the verdict.
+
+## Q2 — Independent sweeps
+
+### A. Abandoned factory design: CLEAN
+
+Remaining references at lines 113-150, 200, 207-212, 237-240, and 361-365 are historical explanation, supporting evidence, or explicit rejection of the factory. None proposes using it.
+
+### B. Live UAT versus §11.3 ownership: CLEAN
+
+The plan consistently assigns:
+
+- Detector numerical/behavioral comparison to §11.3: [plan:273-280](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:273)
+- Capture, engine, auto-stop, and paste integration to Live UAT: [plan:329-340](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:329)
+- The limitation of Live UAT to §11.3: [plan:371-374](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:371)
+
+### C. One-line and diff-size claims: CLEAN
+
+All operative claims are conditional and internally consistent:
+
+- Conditional exemption: [plan:7-16](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:7)
+- Expected, not pre-proven: [plan:18-21](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:18)
+- Production-only `+3 lines` claim: [plan:306-309](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:306)
+
+“One line later” at line 225 describes source proximity, not diff size.
+
+### D. Requested policy versus actual placement: CLEAN
+
+The plan now consistently says:
+
+- Bare loading requests `.all`: [plan:42-45](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:42)
+- This permits GPU but does not prove resolved placement: [plan:47-49](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:47)
+- CoreML chooses within the permitted set: [plan:284-286](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:284)
+
+### Fixture-swap sweep: CLEAN
+
+No operative instruction still assumes MP3, resampling, the old five-scenario labels, or non-repository inputs.
+
+The only matches are:
+
+- Historical revision note: [plan:389-391](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:389)
+- Explicit prohibition in latency testing: [plan:443-445](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:443)
+
+The five committed files are confirmed as 16 kHz, mono, Int16 PCM.
+
+## Q3 — Final buildability
+
+- Production change: **buildable without guessing**
+- Freeze test: **buildable without guessing**
+- Offline A/B: **not buildable unambiguously until state isolation is corrected**
+- Latency receipt: **not buildable unambiguously until its measurement contract is specified**
+
+## Q4 — Required edits
+
+### 1. Make every replay independent
+
+Replace [plan:410-426](/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:410) with:
+
+> Resolve the checked-in compiled model URL once. Load one model for Arm A using a bare `MLModelConfiguration()` and one model for Arm B using `.cpuAndNeuralEngine` plus `allowLowPrecisionAccumulationOnGPU = true`. The loaded model may be reused within its arm.
+>
+> For every **arm × fixture × repetition × replay mode**, construct a fresh `VadManager(config: VadConfig(defaultThreshold: 0.5), vadModel: model)`, fresh recording `StreamingVad` wrapper, and fresh `SilenceDetector` through its internal `makeStreamingVad` seam (`SilenceDetector.swift:162-168`). Build the detector configuration with `SmoothedVADConfig.fromSensitivity(0.5, energyGate: true)` and use `silenceTimeout: 1.5`, matching `SettingsDefaultValues.swift:38-40` and production construction at `CaptureVADSignalSource.swift:268-271`. Call `prepare()` before feeding audio. Never reuse detector, wrapper, or stream state between full-feed and auto-stop, between fixtures, or between repetitions.
+>
+> Each repetition performs two independently initialized replays. The **full-feed** replay records every chunk, ignores `shouldAutoStop` until the buffer ends, then calls `finalizeSegments(totalSampleCount:)`. The **auto-stop** replay stops at the first `true`, records that chunk index, and calls `finalizeSegments(totalSampleCount:)` with the number of samples actually processed. Capture probabilities, event kinds and indexes, final segments, speech-evidence outcome, and first auto-stop chunk for both replay modes. Run three repetitions per arm.
+
+Delete the duplicated “Run each arm three times” sentence at lines 428-429.
+
+### 2. Define the latency measurement contract
+
+Replace §11.4 with:
+
+> ### 11.4 Latency receipt
+>
+> Use the same five committed `scripts/freeze-suite/clips/*.wav` fixtures and `Tests/RuntimeUAT/wispr_eyes.py::test_recording`. Do not depend on the #1780 scratchpad or `/private/tmp/ovh-*`.
+>
+> Arm A is a dev app built from baseline commit `d2f903c1`. Arm B is a dev app built from the final implementation. Preserve both `.app` artifacts at separate temporary paths. Run only one at a time, fully quitting it before launching the other. Use identical user settings and model-warm state in both arms.
+>
+> For each engine, run one unmeasured `normal-speech.wav` warm-up on each arm. Then run three measured passes per arm, where one pass processes all five fixtures in the order listed in §11.3. Use measured arm order `A1, B1, B2, A2, A3, B3`. Do not discard any additional measured pass.
+>
+> Before every `test_recording` call, record the current `app.log` byte offset. After completion, parse the first new `Pipeline timing TOTAL:` record for that recording and extract its leading total-seconds value. A failed or unverifiable recording fails the receipt; do not omit or impute it.
+>
+> One paired observation is identified by **engine × fixture × measured-pass index**. Compute `Arm B - Arm A` for all 30 pairs: two engines × five fixtures × three passes. Report per-engine, per-fixture, and aggregate medians.
+>
+> For the aggregate gate, bootstrap the 30 paired deltas with 10,000 resamples using fixed seed `1784`, calculating the median for each resample. A statistically supported regression means the observed aggregate paired median is positive and the percentile 95% bootstrap interval excludes zero. An interval containing zero is not a supported regression. Any supported regression stops for founder review.

--- a/docs/audits/2026-07-24-1784-grounded-review-r5-verdict.md
+++ b/docs/audits/2026-07-24-1784-grounded-review-r5-verdict.md
@@ -1,0 +1,32 @@
+## Verdict: PROCEED-AS-PLANNED
+
+### Q1 — Both edits landed correctly
+
+- Replay isolation is complete: fresh state is required for every arm × fixture × repetition × replay mode, with reuse explicitly prohibited. The lifecycle and three repetitions are unambiguous. [Plan §11.3](</Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:410>)
+- The cited retained state is supported by [`SilenceDetector.reset()`](</Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprAudio/SilenceDetector.swift:181>).
+- The latency contract fully specifies artifacts, launch isolation, warm-up, run ordering, log extraction, 30 pairings, bootstrap parameters, and the regression threshold. [Plan §11.4](</Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md:444>)
+- Its source premises are correct: `test_recording` returns `overall_pass` at [wispr_eyes.py:1344](</Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Tests/RuntimeUAT/wispr_eyes.py:1344>), while the timing record is emitted at [KernelFinalizationWiring.swift:538](</Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-1784vadconfig/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift:538>).
+
+### Q2 — No new defects
+
+Sections §11.1–§11.4 remain correctly numbered. Cross-references in the goals, validation table, implementation surface, ship criteria, and open questions still point to the right sections.
+
+Section §13 correctly requires:
+
+- Deterministic A/B equivalence from §11.3.
+- Live UAT as a separate check.
+- No statistically supported latency regression under §11.4.
+
+Nothing was broken or made ambiguous by these edits.
+
+### Q3 — Not escalating was correct
+
+Your reading of the rule is right. Escalation is for flat or rising unresolved root clusters after four rounds, or a genuine product/scope/safety decision. The findings declined, the repeated stale-reference classes were closed, and the final two items were mechanical specification gaps with no competing product choice.
+
+My prior recommendation to escalate merely because findings remained in round 4 was too broad.
+
+### Q4 — Remaining edits
+
+None. No substantive or presentational correction is needed before Gate 2.
+
+This approves the plan as written; it does not imply that its still-unwritten implementation has been validated.

--- a/docs/audits/2026-07-24-1784-offline-ab-receipt.md
+++ b/docs/audits/2026-07-24-1784-offline-ab-receipt.md
@@ -1,0 +1,48 @@
+# #1784 §11.3 offline A/B receipt — 2026-07-24
+
+Arm A = bare MLModelConfiguration() (current shipped). Arm B = .cpuAndNeuralEngine + allowLowPrecisionAccumulationOnGPU (this change).
+6 fixtures x 2 replay modes x 3 repetitions per arm = 72 replays. Fresh VadManager + recorder + SilenceDetector per replay; model loaded per replay.
+Fixtures: committed scripts/freeze-suite/clips/*.wav (16 kHz mono Int16, verified via afinfo) + quiet-onset synthesized from normal-speech.wav.
+
+RESULT: 12/12 comparisons — stableA=true stableB=true agree=true. Identical event sequences, segment boundaries, speech-evidence outcomes, and first auto-stop chunk indexes.
+
+normal-speech [full-feed] stableA=true stableB=true agree=true
+    A: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 94208, time: nil),-,-,-,-,-,- segments=0-94208 speech=true autoStop=30
+    B: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 94208, time: nil),-,-,-,-,-,- segments=0-94208 speech=true autoStop=30
+normal-speech [auto-stop] stableA=true stableB=true agree=true
+    A: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 94208, time: nil),- segments=0-94208 speech=true autoStop=30
+    B: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 94208, time: nil),- segments=0-94208 speech=true autoStop=30
+mumbled-speech [full-feed] stableA=true stableB=true agree=true
+    A: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 180224, time: nil),-,-,-,-,- segments=0-180224 speech=true autoStop=52
+    B: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 180224, time: nil),-,-,-,-,- segments=0-180224 speech=true autoStop=52
+mumbled-speech [auto-stop] stableA=true stableB=true agree=true
+    A: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 180224, time: nil),-,- segments=0-180224 speech=true autoStop=52
+    B: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 180224, time: nil),-,- segments=0-180224 speech=true autoStop=52
+quiet-onset [full-feed] stableA=true stableB=true agree=true
+    A: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 94208, time: nil),-,-,-,-,-,- segments=0-94208 speech=true autoStop=30
+    B: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 94208, time: nil),-,-,-,-,-,- segments=0-94208 speech=true autoStop=30
+quiet-onset [auto-stop] stableA=true stableB=true agree=true
+    A: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 94208, time: nil),- segments=0-94208 speech=true autoStop=30
+    B: events=VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechStart, sampleIndex: 0, time: nil),-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,VadStreamEvent(kind: FluidAudio.VadStreamEvent.Kind.speechEnd, sampleIndex: 94208, time: nil),- segments=0-94208 speech=true autoStop=30
+silence [full-feed] stableA=true stableB=true agree=true
+    A: events=-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,- segments= speech=false autoStop=none
+    B: events=-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,- segments= speech=false autoStop=none
+silence [auto-stop] stableA=true stableB=true agree=true
+    A: events=-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,- segments= speech=false autoStop=none
+    B: events=-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,- segments= speech=false autoStop=none
+background-noise [full-feed] stableA=true stableB=true agree=true
+    A: events=-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,- segments= speech=false autoStop=none
+    B: events=-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,- segments= speech=false autoStop=none
+background-noise [auto-stop] stableA=true stableB=true agree=true
+    A: events=-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,- segments= speech=false autoStop=none
+    B: events=-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,- segments= speech=false autoStop=none
+sudden-burst [full-feed] stableA=true stableB=true agree=true
+    A: events=-,-,-,-,-,-,- segments= speech=false autoStop=none
+    B: events=-,-,-,-,-,-,- segments= speech=false autoStop=none
+sudden-burst [auto-stop] stableA=true stableB=true agree=true
+    A: events=-,-,-,-,-,-,- segments= speech=false autoStop=none
+    B: events=-,-,-,-,-,-,- segments= speech=false autoStop=none
+## Honest limitation
+The synthesized quiet-onset fixture produced output identical to normal-speech (segments 0-94208, autoStop=30), i.e. the 0.10/0.25/0.50 attenuation of the first six chunks did NOT move the onset decision. That fixture therefore did not discriminate, and this receipt should not be read as covering a genuinely marginal onset. The recipe was executed exactly as specified in the approved plan; it was not retuned after seeing the result.
+
+Harness source preserved at scratchpad/ZZ1784OfflineABHarness.swift.kept; the file is NOT committed (plan Preface zero-blast condition 4).

--- a/docs/audits/2026-07-25-1784-latency-receipt.md
+++ b/docs/audits/2026-07-25-1784-latency-receipt.md
@@ -1,0 +1,51 @@
+# #1784 latency receipt — 2026-07-25
+
+## Headline: the detector-only measurement is the one that answers the question
+
+Direct replay of committed fixtures through SilenceDetector under both configurations,
+median of 5 runs each, no app / mic / polish / paste involved:
+
+| fixture | chunks | bare (.all) per-chunk | pinned (.cpuAndNeuralEngine) per-chunk | delta |
+|---|---|---|---|---|
+| normal-speech | 36 | 0.344 ms | 0.342 ms | **-0.002 ms** |
+| mumbled-speech | 56 | 0.349 ms | 0.347 ms | **-0.002 ms** |
+
+The detector is ~0.1% of pipeline time. **No measurable cost; if anything marginally faster.**
+
+## End-to-end paired run (retained for completeness, and as a lesson)
+
+Arm A = baseline d2f903c1 dev build. Arm B = this change. Alternating blocks A1 B1 B2 A2 A3 B3,
+five fixtures per pass, both engines, timing parsed from the first new `Pipeline timing TOTAL:` record
+after a recorded log offset. Stopped early at founder request: 55/60 recordings, all usable.
+
+- **parakeet**: n=15, median +0.0500s, bootstrap 95% CI [+0.0030, +0.0670], 12/15 positive
+- **whisperKit**: n=10, median +0.0055s, bootstrap 95% CI [-0.3315, +0.1570], 5/10 positive
+- **aggregate**: n=25, median +0.0410s, bootstrap 95% CI [-0.0140, +0.0670] — includes zero
+
+**Gate (paired median > 0 AND CI excludes zero): PASS** — no statistically supported regression.
+
+### Why this run was the wrong instrument
+
+Parakeet showed +0.050s with a CI excluding zero, which looked like a real cost on the default
+engine. Decomposing it by stage shows where it actually sat:
+
+| stage | parakeet delta | whisperKit delta |
+|---|---|---|
+| ASR | +0.001s | -0.002s |
+| polish | +0.013s | +0.012s |
+| paste | +0.030s | -0.003s |
+
+ASR is the only stage where detector contention could appear, and it is flat. The delta sits in
+paste and polish — stages that run after the detector has finished, with no causal path to it.
+Arm A paste spread 0.255-0.277s; arm B 0.256-0.359s: same floor, a few spikes.
+
+A hypothesis that the detector now contends with Parakeet on the Neural Engine (Parakeet runs
+`.cpuAndNeuralEngine`, WhisperKit is pinned `.cpuAndGPU`) was stated in advance and is REFUTED by
+the ASR row and by the detector-only measurement above.
+
+**Lesson, promoted to validation-discipline.md RULE: capture-polish-latency-per-bucket:** measure at
+the component when the component is a small fraction of the pipeline. 55 recordings over ~30 minutes
+produced a misleading number; the correct measurement took 0.7 seconds. Two suitable instruments
+already existed, including telemetry shipped the previous night.
+
+Raw samples: /tmp/1784-latency.jsonl (55 rows). Baseline SHA d2f903c1.

--- a/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md
+++ b/docs/feature-requests/issue-1784-2026-07-24-vad-compute-units.md
@@ -1,0 +1,510 @@
+# #1784 — Pin the bundled VAD model's requested CoreML load policy
+
+## Preface — Lane + Live UAT declaration
+
+- **Lane:** Code
+- **Tier:** SMALL (single VAD model-load configuration change; no control flow, lifecycle, public API, module edge, persistence, or migration)
+- **Coverage round:** CONDITIONALLY SKIPPED under RULE: council-skip-zero-blast-radius. Apply PR tag `council-skip: zero-blast-radius (single-value config)` only after the four-condition pre-push gate below passes. Otherwise withdraw the exemption and re-evaluate coverage before push.
+- **Live UAT:** Y (RULE: runtime-uat-catches-static-misses; SMALL does not waive runtime validation for ML/audio changes)
+- **Modules:** EnviousWisprAudio
+- **Test:** required (EnviousWisprTests/Audio)
+
+**The zero-blast tag is CONDITIONAL and must be verified before push, not asserted here.** It holds
+only after all four: (1) the production comment stays at the two shortened lines in §10;
+(2) the test file's `import CoreML` is added; (3) `git diff --stat` confirms ≤20 changed lines across
+exactly two files; (4) the §11.3 A/B harness is removed and not committed. If the harness ships or
+the diff exceeds 20 changed lines, WITHDRAW the tag and re-evaluate coverage before push.
+
+> **Revision note (grounded review r1/r2/r3).** This preface previously declared MEDIUM. Corrected to
+> SMALL because the shipped change is a configuration tweak; retaining Live UAT does not raise the
+> tier. The zero-blast exemption is EXPECTED, not pre-proven: r2 added the four-condition gate after
+> the earlier proposed comment would have exceeded the 20-line limit.
+
+## Preface — User Rubric
+
+`User Rubric: N/A — not one of epics #314 / #316 / #317 / #320 / #321.`
+
+## 0. TL;DR
+
+`BundledVADModelLoader` builds the Silero VAD model with a bare `MLModelConfiguration()`, taking
+CoreML's `.all` default. Set `computeUnits = .cpuAndNeuralEngine` and
+`allowLowPrecisionAccumulationOnGPU = true` explicitly, matching what the pinned FluidAudio VAD
+loader itself produces at `DownloadUtils.swift:301-303`.
+
+Production replaces one bare load with an explicit policy at one site. The test adds `import CoreML`
+and two real-loader assertions. No new symbols, control flow, fallback, or production import.
+
+No public API, control-flow, fallback, or lifecycle change. The observable runtime change is the
+requested CoreML hardware policy and any resulting numerical or latency difference.
+
+## 1. Problem
+
+We bundle the VAD model (#1224) and load it ourselves, so we use FluidAudio's pre-loaded-model
+initializer. That initializer **stores** the `VadConfig` we pass but never reads its `computeUnits`
+field; that field is read only inside the loading path we bypass. The manager therefore reports
+`.cpuAndNeuralEngine` while the preloaded model was created with CoreML's requested `.all` default.
+
+We therefore permit GPU execution for this heart-path model even though FluidAudio's pinned VAD
+loader requests only CPU and Neural Engine — on every dictation, in every engine, regardless of user
+settings. This describes the requested allowed set, not proof of CoreML's resolved device placement.
+
+Crash #1780 occurred inside this model's prediction. **This plan does not claim to fix #1784 → #1780
+causation** (see §14).
+
+## 2. Goals & non-goals
+
+### 2.1 Goals
+
+1. The bundled model is constructed with the same requested configuration FluidAudio's pinned VAD
+   loader would produce.
+2. A real-loader test freezes that policy so a future edit cannot silently restore CoreML's default.
+3. A deterministic offline A/B verifies that the policy change does not alter VAD events, segment
+   boundaries, or auto-stop decisions on the frozen corpus.
+4. A measured latency receipt on the real app proves no heart-path regression.
+
+### 2.2 Non-goals
+
+- **Fixing #1780.** It stays open. Unreproduced across macOS 26 / 14.8.7 / 15.7.7, all four
+  `MLComputeUnits`, concurrent, churn, guard-page probe.
+- **Any crash safety net** — quarantine, crash counters, one-strike disable, health state, kill
+  switch. Founder decision 2026-07-24, on evidence: no competitor ships one (§2.5.3).
+- **Any new process boundary.** D-028 collapsed the capture XPC deliberately.
+- **Reverting model bundling.** The network fetch stays dead.
+- **`CoreMLOutputClassifier.swift:93`**, the second bare-config site. It uses the same constructor
+  pattern for a different model whose correct placement policy has not been established. It is a
+  limb, but its in-process prediction runs during Apple Intelligence polish before paste
+  (`EnviousOutputFilter.swift:78`, `AppleIntelligenceConnector.swift:453`), so a hard CoreML fault
+  could still terminate that dictation. Copying the VAD policy into this unrelated model would be
+  unsupported scope expansion. Founder-approved as separate work at Gate 1; this VAD-only change does
+  not alter it.
+
+  > **Revision note (r1/r2).** This previously read "off the heart path, cannot crash a dictation" —
+  > false; a hard fault there can terminate an active dictation. A subsequent draft justified the
+  > deferral by a module dependency that explicit local configuration would not actually require.
+  > Both reasons were wrong. The deferral stands on scope: this model's correct policy is unestablished.
+
+## 2.5 Grounding brief
+
+### 1. Trace producer → owner → consumer end to end
+
+| Stage | Site | Note |
+|---|---|---|
+| Model construction | `Sources/EnviousWisprAudio/BundledVADModelLoader.swift:19-38` | **Sole** construction site of the VAD `MLModel`. |
+| Consumer | `Sources/EnviousWisprAudio/SilenceDetector.swift:157-158` | Only caller in `Sources/`. Wraps it: `VadManager(config: VadConfig(defaultThreshold: 0.5), vadModel: model)`. |
+| Detector construction | `Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift:104` | Sole `SilenceDetector(...)` site. |
+| Signal-source construction | `KernelDictationDriverFactory.swift:247-250` | Sole `CaptureVADSignalSource()` site; frozen by `architecture/vadSignalSourceHasSingleConstructionSite`. |
+| Both engines | `:257` `makeForParakeet`, `:286` `makeForWhisperKit` | Both receive the SAME instance via `inputs.vadSignalSource`. |
+| Execution | `VADMonitorLoop.swift:143` | `await detector.processChunk(chunk)` runs unconditionally; `:149` checks `vadAutoStop` only to decide whether to ACT. |
+
+Capability grep, complete and uncurated:
+
+```
+$ grep -rn "BundledVADModelLoader" Sources/ Tests/
+Sources/EnviousWisprAudio/SilenceDetector.swift:157
+Sources/EnviousWisprAudio/BundledVADModelLoader.swift:13
+Tests/EnviousWisprTests/Audio/BundledVADModelLoaderTests.swift:6,9,10,34,43,49,50
+```
+
+Closed-world: `BundledVADModelLoader` is a module-internal `enum` with one `static func`. One
+production caller, one test suite. Expected 1 production consumer, observed 1.
+
+### 2. Find the existing authority before proposing one
+
+Per RULE: grep-the-dependency-for-lifecycle-before-hand-rolling, the library was grepped BEFORE
+designing. **The first search found the wrong authority.** FluidAudio ships a shared factory:
+
+`.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/Shared/MLModelConfigurationUtils.swift:5-30`
+
+```swift
+public enum MLModelConfigurationUtils {
+    public static func defaultConfiguration(
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+    ) -> MLModelConfiguration {
+        let config = MLModelConfiguration()
+        config.allowLowPrecisionAccumulationOnGPU = true
+        config.computeUnits = computeUnits
+        return config
+    }
+}
+```
+
+**But the VAD loading path does not use that factory.** `loadUnifiedModel` calls
+`DownloadUtils.loadModels`, which builds its configuration locally
+(`.derivedData/Dev/SourcePackages/checkouts/FluidAudio/Sources/FluidAudio/DownloadUtils.swift:301-303`):
+
+```swift
+let config = MLModelConfiguration()
+config.computeUnits = computeUnits
+config.allowLowPrecisionAccumulationOnGPU = true
+```
+
+So FluidAudio has two equivalent implementations today, and the one the VAD actually loads through
+is the local one. Adopting the factory would NOT be "returning to the VAD paved road" — it would
+bind our heart path to a shared factory the VAD loader itself does not use, so a future library
+change to that factory could silently alter heart-path CoreML policy on a dependency bump.
+
+**Decision: set the two properties locally, matching `DownloadUtils.swift:301-303` exactly.**
+
+> **Revision note (r1).** This section previously concluded "adopt the factory; do not hand-roll."
+> That reversed on evidence: the grounded review found the VAD loader does not call the factory, and
+> the citation was verified directly before adopting the correction.
+
+Reachability verified: `Project.swift:232-236` gives `EnviousWisprAudio` a direct
+`.package(product: "FluidAudio")` dependency, and `SilenceDetector.swift:2` already does
+`@preconcurrency import FluidAudio` in this module.
+
+Our own configuration sites, complete:
+
+```
+$ grep -rn "MLModelConfiguration\|computeUnits\|MLComputeUnits" Sources/
+Sources/EnviousWisprAudio/BundledVADModelLoader.swift:34   <- this plan
+Sources/EnviousWisprASR/WhisperKitBackend.swift:19          (comment)
+Sources/EnviousWisprLLM/CoreMLOutputClassifier.swift:93     <- explicit non-goal
+```
+
+`ParakeetBackend.swift:115-121` uses `AsrModels.loadFromCache` / `downloadAndLoad` +
+`AsrManager(config: .default)` — already the library's own path. `WhisperKitBackend.swift:22-26`
+pins `ModelComputeOptions(.cpuAndGPU ×3)` with measured rationale (#879 Phase C). **The ASR paths
+are already correct and are not touched.**
+
+### 3. Read prior attempts and live direction
+
+- **#1224** bundled the model to kill a network fetch at record-start that silently broke auto-stop
+  for 171 users / 508 occurrences. Bundling stays.
+- **#1780 plan §2.5.3** REJECTED gating VAD on `vadAutoStop`: segments feed the dead-air gate,
+  `CapturedAudioConditioner.swift:95-159`, Parakeet tail preservation, degraded-lead salvage, and
+  `WhisperKitEngineAdapter.swift:687-690` clip ranges. Still rejected; unchanged by this plan.
+- **#1783** shipped the record-start funnel (merged). Three markers on Sentry + PostHog.
+- **Founder held this pin on 2026-07-24** pending measurement; released it 2026-07-24 after the
+  broad-spectrum analysis (issue comments) eliminated the alternatives.
+- **Codex council at xhigh** (`docs/audits/2026-07-24-1784-crash-containment-council.txt`) ranked
+  "configuration alignment" first-equal and supplied the exact Swift adopted in §10.
+
+### 4. Name the lifecycle, trust, and process boundaries a naive design would miss
+
+- `BundledVADModelLoader` takes the `Bundle` explicitly because `EnviousWisprAudio` is a **static
+  framework linked into more than one executable** (`BundledVADModelLoader.swift:8-12`): the app and
+  the ASR service each have their own `Bundle.main`. The change is inside the loader, so both
+  linkers inherit it identically. Verified today that only the app process constructs a detector —
+  `grep -rn "SilenceDetector\|StreamingVad\|VadManager" Sources/EnviousWisprASRService/` returns
+  nothing — so there is no second live construction path to keep in sync.
+- **No load-order or lifecycle change.** The configuration is constructed and consumed inside one
+  synchronous call; nothing is stored, shared, or reused across sessions.
+- **Not a settings change.** No `UserDefaults` key, no migration, no persisted state.
+
+### 5. Prove the high-risk premises
+
+| Premise | Proof |
+|---|---|
+| Only the loading path reads `config.computeUnits`, so changing `VadConfig` alone would be a no-op | `grep -rn "config.computeUnits" .../FluidAudio/Sources/FluidAudio/VAD/VadManager.swift` → exactly one hit, `:135`, inside `loadUnifiedModel`. The pre-loaded init (`:103-107`) assigns `self.config` and `self.vadModel` only. |
+| The pinned VAD load policy is CHEAP and does not carry the documented RTFx regression | `DownloadUtils.swift:301-303`, the actual VAD path, constructs a bare configuration and sets only `computeUnits` plus `allowLowPrecisionAccumulationOnGPU`. It sets no `MLOptimizationHints`. The separate shared factory's comments at `MLModelConfigurationUtils.swift:17-29` document the 126.6 → 93.3 regression and leave those hints disabled. The local policy mirrored by this plan therefore does not adopt the regressing hints. **This also corrects an over-stated caution in the #1784 issue body.** |
+| Our bundled model is not a different artifact from what the library delivers | `diff -r Sources/EnviousWispr/Resources/VAD/silero-vad-unified-256ms-v6.0.0.mlmodelc "$HOME/Library/Application Support/FluidAudio/Models/silero-vad-coreml/silero-vad-unified-256ms-v6.0.0.mlmodelc"` → **IDENTICAL** (all five files). Model bytes are eliminated as a variable. |
+| Chunk feeding is not malformed on the first chunk | `VADMonitorLoop.swift:111-121`: the `while` admits only `processedSampleCount + chunkSize <= currentCount`, so every chunk is exactly `chunkSize`; bounds are re-checked live before slicing. No short or partial first chunk exists. |
+| No competitor ships a crash safety net around VAD | Binary sweep of Spokenly / Vox / superwhisper / FluidVoice / TypeWhisper. All four apparent hits were false positives: superwhisper's = Firebase Crashlytics field names (`launchesSinceLastCrash`); TypeWhisper's matched inside `dictationRecoveryModel`; Vox's = `com.apple.quarantine`; FluidVoice's `DirectAudioCaptureConsecutiveFailures` is a capture-path counter beside `ExperimentalDirectAudioCaptureEnabled`, not a VAD guard. Open-source peer `moona3k/macparakeet` returns `nil` on load failure and runs without VAD — load-time fail-open, not crash quarantine. **Open-world claim: no implementation found in these five binaries or the open-source peers read.** |
+
+## 3. Design
+
+`BundledVADModelLoader.loadModel(in:)` remains the sole EnviousWispr authority for the bundled VAD
+model's requested CoreML load policy. Construct an `MLModelConfiguration` locally and explicitly set
+`computeUnits = .cpuAndNeuralEngine` and `allowLowPrecisionAccumulationOnGPU = true`. These values
+match the pinned FluidAudio VAD loader at `DownloadUtils.swift:301-303`. Keeping them explicit
+prevents a future dependency update from silently adding or changing heart-path CoreML policy
+through a shared factory.
+
+Extract nothing, add no type, add no parameter, add no import.
+
+The loader keeps its existing contract exactly: `resourceNotFound` when the asset is absent,
+`loadFailed(Error)` when CoreML rejects it.
+
+### 3b. Ownership justification
+
+**No ownership change.** `BundledVADModelLoader` is already the sole owner of VAD model
+construction; this changes what it constructs the model *with*. No coordinator, manager, or
+App-owned home gains responsibility.
+
+Alternative owner considered: `SilenceDetector`, which builds the `VadConfig` one line later at
+`:158`. Cost of choosing it: the configuration would then be split across two files — the CoreML
+configuration in one, the FluidAudio configuration in another — and the caller would have to know
+that the pre-loaded initializer ignores half of what it is handed. That is the exact confusion that
+produced this defect. Keeping the `MLModel` load policy at the model-construction site prevents
+callers from trying to control it through the ignored `VadConfig.computeUnits` field. The separate
+segmentation configuration remains owned by `SilenceDetector`.
+
+### 3c. Single-authority check
+
+Concern: "which CoreML load policy is REQUESTED for the bundled VAD model."
+
+- Handled in 2+ places? **No.** One site, `BundledVADModelLoader.swift:34`.
+- Existing owner? **In our code, yes — that same site.** In the library there are two equivalent
+  implementations (`MLModelConfigurationUtils.swift:11` and `DownloadUtils.swift:301`); the VAD path
+  uses the latter, so we mirror it rather than binding to the former.
+- Duplicates deleted? Nothing to delete; the bare `MLModelConfiguration()` is replaced in place.
+
+§3c-answer: one EnviousWispr authority — BundledVADModelLoader.loadModel(in:) owns the requested CoreML configuration at the sole VAD MLModel construction site. It explicitly pins the two values matching the current pinned FluidAudio VAD loader (DownloadUtils.swift:301-303). VadConfig.computeUnits remains library-owned metadata consumed only by FluidAudio's bypassed loading path; EnviousWispr creates no second runtime configuration site.
+
+## 4. Contract deltas
+
+**None.** `loadModel(in:)` keeps its signature, return type, and both error cases. No public or
+package surface changes. The only direct observable delta is the requested CoreML compute-unit
+policy. CoreML's resolved placement is not directly asserted; numerical, boundary, and latency
+effects are measured in §11.
+
+## 5. E2E state & lifecycle audit
+
+Six async classes against the change:
+
+| Class | Answer |
+|---|---|
+| Interrupted | `loadModel` is synchronous and non-suspending. No cancellation point inside it. |
+| Deleted | Asset deletion already yields `resourceNotFound`; unchanged. |
+| Mutated | No setting feeds this configuration. Nothing to change in flight. |
+| Concurrent | Two processes may each load their own model. Every call constructs a new local `MLModelConfiguration`; no configuration object or model state is shared between processes. |
+| Nil | No optional dependency. |
+| Stale | Nothing cached or snapshotted. |
+
+**Closed-set trigger: NOT met.** No lifecycle/outcome/durability contract changes; no terminal
+transition, cancellation, session identity, or durable save/cleanup ordering is touched. Full
+`state × event` matrix not required.
+
+## 6. Downstream consumer matrix
+
+| Consumer | Effect |
+|---|---|
+| `SilenceDetector.processChunk` | Same API. Raw probabilities may differ by compute policy; §11.3 verifies whether any difference reaches VAD events, segment boundaries, or auto-stop decisions. |
+| Dead-air gate / `speechEvidenceAtStop` | Unchanged unless segment boundaries shift. |
+| `CapturedAudioConditioner` | Unchanged unless segments shift. |
+| Parakeet tail preservation, WhisperKit clip ranges | Unchanged unless segments shift. |
+| Auto-stop | Unchanged unless segments shift. |
+
+The deterministic offline A/B (§11.3) checks detector behavior. Live UAT (§11.1) then checks
+capture, ASR, auto-stop, and paste integration.
+
+## 7. Failure-mode × caller table
+
+| Failure | Behaviour | Caller |
+|---|---|---|
+| Requested units not all usable on device | `.cpuAndNeuralEngine` permits CPU and Neural Engine execution and excludes GPU execution. CoreML chooses within the permitted resources; this requested policy does not prove which permitted device executes each operation. | None. |
+| Model fails to load | `LoadError.loadFailed` — the existing path. `CaptureVADSignalSource` publishes `.unavailable` and ASR runs on raw audio. | Unchanged. |
+| Asset missing | `LoadError.resourceNotFound` — unchanged. | Unchanged. |
+
+## 8. Caller-visible signals audit
+
+No new signal, telemetry event, log line, or user-facing string. The #1783 markers
+(`dictation.vad_preparation_completed`, `dictation.first_vad_chunk_started`,
+`dictation.first_vad_chunk_completed`) already cover this interval and are how a post-ship
+recurrence would be detected.
+
+## 9. Fallback source-of-truth audit
+
+Unchanged. `CaptureVADSignalSource.swift:401-413` remains the sole authority for
+`.unavailable` vs `.confirmedNoSpeech`.
+
+## 10. File-by-file changes
+
+### File list
+
+| File | Change |
+|---|---|
+| `Sources/EnviousWisprAudio/BundledVADModelLoader.swift` | Pin the requested CoreML policy explicitly (+3 lines, + comment). No new import. |
+| `Tests/EnviousWisprTests/Audio/BundledVADModelLoaderTests.swift` | Add `import CoreML` and freeze the requested configuration through the real loader. |
+
+The §11.3 A/B runs from a temporary, uncommitted test-target file because it needs `@testable` access to the detector's existing injection seam. Remove that file after recording the receipt. If the harness must remain in the repository, add it to the file list and re-evaluate the zero-blast exemption before push.
+
+```swift
+// BundledVADModelLoader.swift — inside loadModel(in:)
+    do {
+      // Match the pinned FluidAudio VAD loader (`DownloadUtils.swift:301-303`).
+      // Keep this heart-path policy explicit across dependency updates.
+      let configuration = MLModelConfiguration()
+      configuration.computeUnits = .cpuAndNeuralEngine
+      configuration.allowLowPrecisionAccumulationOnGPU = true
+      return try MLModel(contentsOf: url, configuration: configuration)
+    } catch {
+      throw LoadError.loadFailed(error)
+    }
+```
+
+## 11. Testing
+
+### 11.1 Live UAT spec
+
+Rebuild the dev app once, after Codex is clean (RULE: codex-clean-gates-runtime-uat), then:
+
+1. `test_recording()` with auto-stop **ON** — assert the transcript pastes and auto-stop fires on
+   trailing silence.
+2. `test_recording()` with auto-stop **OFF** — assert the transcript pastes and the recording runs
+   to manual stop.
+3. Both engines: Parakeet and WhisperKit.
+4. Read `~/Library/Logs/EnviousWispr/app.log` for `CORRECTION_DEBUG` + `Pipeline timing TOTAL`;
+   verdicts come from the log, never the clipboard (RULE: uat-verdicts-from-app-log).
+5. Confirm all three #1783 markers still fire in order.
+
+### 11.2 Other test obligations
+
+- **New freeze test** in `BundledVADModelLoaderTests`, exercising the REAL loader:
+
+  ```swift
+  import CoreML
+  import Foundation
+  import Testing
+
+  @testable import EnviousWisprAudio
+
+  // ...
+  let fixtureBundle = try #require(Bundle(path: fixtureRoot.path))
+  let model = try BundledVADModelLoader.loadModel(in: fixtureBundle)
+
+  #expect(model.configuration.computeUnits == .cpuAndNeuralEngine)
+  #expect(model.configuration.allowLowPrecisionAccumulationOnGPU)
+  ```
+
+  `MLModel.configuration` reports the load-time configuration that was REQUESTED, not proof of the
+  device CoreML ultimately selected. That is the correct oracle here, because the requested policy is
+  exactly what this change alters. **No fallback assertion on a library factory** — such a test would
+  pass even with the bare configuration still in the loader, which is decoration
+  (RULE: verify-the-feature-not-the-crash).
+- **Mutation receipt:** remove both explicit property assignments so the loader passes a fresh bare
+  `MLModelConfiguration()` to `MLModel`. Confirm that the configuration assertions FAIL. A freeze
+  test that passes with the requested policy removed is decoration.
+- Full `scripts/xcode-test.sh`, nonzero executed count read from `Test run with N tests`.
+
+### 11.3 Deterministic offline A/B — segment-boundary receipt (runs BEFORE Live UAT)
+
+Live UAT is necessary but insufficient for numerical drift: both engines consume the same VAD, so
+engine-swapping provides no independent detector coverage.
+
+Feed identical frozen 16 kHz mono Float32 audio through the checked-in VAD model twice:
+
+- **Arm A** — current bare configuration (`.all`, low-precision GPU accumulation disabled).
+- **Arm B** — `.cpuAndNeuralEngine` with low-precision GPU accumulation enabled.
+
+Use the checked-in VAD model and the **five committed fixtures** under `scripts/freeze-suite/clips/`:
+`normal-speech.wav`, `mumbled-speech.wav`, `silence.wav`, `background-noise.wav`, and
+`sudden-burst.wav`. Verified 2026-07-24 via `afinfo` as 16 kHz mono Int16 PCM — already
+detector-native, no resampling, and version-controlled so the measurement is reproducible from the
+repo alone. Re-verify that format, record each SHA-256, and decode each file exactly once into one
+in-memory mono Float32 buffer. Feed the same decoded buffer to both arms; do not decode independently
+per arm.
+
+> **Revision note (r3).** An earlier draft used `/private/tmp/ovh-*.mp3` from the #1780 session —
+> 24 kHz MP3s outside the repo that can disappear. That was a
+> RULE: use-existing-uat-harness-first miss: this committed corpus already existed.
+
+Create a deterministic quiet-onset fixture from the decoded `normal-speech.wav`: scale complete
+chunks 0-1 by `0.10`, chunks 2-3 by `0.25`, chunks 4-5 by `0.50`, and all remaining speech chunks by
+`1.0`. Append twelve zero chunks to `normal-speech`, `mumbled-speech`, and quiet-onset so speech-end
+and auto-stop behavior receive 3.072 seconds of identical trailing silence. Truncate every fixture to
+complete 4,096-sample chunks after constructing it.
+
+Implement the harness as a temporary, uncommitted `EnviousWisprTests` source with:
+
+```swift
+@preconcurrency import AVFoundation
+import CoreML
+@preconcurrency import FluidAudio
+import Testing
+
+@testable import EnviousWisprAudio
+```
+
+Resolve the checked-in compiled model URL once. Load one model for Arm A using a bare
+`MLModelConfiguration()` and one model for Arm B using `.cpuAndNeuralEngine` plus
+`allowLowPrecisionAccumulationOnGPU = true`. The loaded model may be reused within its arm.
+
+For every **arm × fixture × repetition × replay mode**, construct a fresh
+`VadManager(config: VadConfig(defaultThreshold: 0.5), vadModel: model)`, fresh recording
+`StreamingVad` wrapper, and fresh `SilenceDetector` through its internal `makeStreamingVad` seam
+(`SilenceDetector.swift:162-168`). Build the detector configuration with
+`SmoothedVADConfig.fromSensitivity(0.5, energyGate: true)` and use `silenceTimeout: 1.5` — verified
+as the shipped defaults at `SettingsDefaultValues.swift:38-40`, matching production's construction at
+`CaptureVADSignalSource.swift:268-271`. Call `prepare()` before feeding audio. **Never reuse
+detector, wrapper, or stream state between full-feed and auto-stop, between fixtures, or between
+repetitions.** `SilenceDetector` carries `streamState`, `phase`, `emaSmoothedProbability`,
+`speechSegments`, `processedSampleCount`, and the prebuffer across calls
+(`SilenceDetector.swift:182-194`), so a shared instance would let the first replay contaminate the
+second.
+
+Each repetition performs two **independently initialized** replays. The **full-feed** replay records
+every chunk, ignores `shouldAutoStop` until the buffer ends, then calls
+`finalizeSegments(totalSampleCount:)`. The **auto-stop** replay stops at the first `true`, records
+that chunk index, and calls `finalizeSegments(totalSampleCount:)` with the number of samples actually
+processed. Capture probabilities, event kinds and indexes, final segments, speech-evidence outcome,
+and first auto-stop chunk for both replay modes. Run three repetitions per arm.
+
+**Acceptance: identical event sequences, segment boundaries, and auto-stop decisions for every
+fixture.** Report maximum probability delta as supporting evidence. Any decision or boundary
+difference STOPS the change for founder review — it would mean the fix silently changes what the
+product hears, which is a different decision from the one approved at Gate 1.
+
+Probability values are not required to be equal and have no arbitrary epsilon gate. A numerical delta
+is tolerable when all three runs within each arm are stable and both arms produce identical event
+kinds and indexes, final segments, speech-evidence outcome, and first auto-stop chunk. A difference
+in any of those discrete outputs is a real behavioral change, not a numerical false-fail.
+
+### 11.4 Latency receipt
+
+Use the same five committed `scripts/freeze-suite/clips/*.wav` fixtures and
+`Tests/RuntimeUAT/wispr_eyes.py::test_recording`. Do NOT depend on the #1780 session scratchpad or
+`/private/tmp/ovh-*`, which are not repository artifacts.
+
+**Arms.** Arm A is a dev app built from baseline commit `d2f903c1`. Arm B is a dev app built from the
+final implementation. Preserve both `.app` artifacts at separate temporary paths. Run only one at a
+time, fully quitting it before launching the other (RULE: dev-bundle-id-collision-across-worktrees —
+all dev builds share one bundle id, so `open` can silently activate the wrong one; verify the running
+PID's path). Use identical user settings and model-warm state in both arms.
+
+**Passes.** For each engine, run one unmeasured `normal-speech.wav` warm-up on each arm. Then run
+three measured passes per arm, where one pass processes all five fixtures in the §11.3 order. Measured
+arm order `A1, B1, B2, A2, A3, B3`. Do not discard any additional measured pass.
+
+**Measured value.** `test_recording` returns only a Boolean (`wispr_eyes.py:1344`), so the timing
+must come from the log. Before every call, record the current `~/Library/Logs/EnviousWispr/app.log`
+byte offset. After completion, parse the first NEW `Pipeline timing TOTAL:` record for that recording
+(`KernelFinalizationWiring.swift:538`) and extract its leading total-seconds value. A failed or
+unverifiable recording FAILS the receipt; do not omit or impute it.
+
+**Pairing.** One paired observation is identified by **engine × fixture × measured-pass index**.
+Compute `Arm B − Arm A` for all 30 pairs: two engines × five fixtures × three passes. Report
+per-engine, per-fixture, and aggregate medians.
+
+**Gate.** Bootstrap the 30 paired deltas with 10,000 resamples using fixed seed `1784`, taking the
+median of each resample. A statistically supported regression means the observed aggregate paired
+median is positive AND the percentile 95% bootstrap interval excludes zero. An interval containing
+zero is not a supported regression. Any supported regression stops for founder review.
+
+## 12. Blast radius & rollback
+
+The shipped change touches one production file and one test file. Production replaces the bare model
+configuration with one explicit requested policy; tests freeze that policy through the real loader.
+Rollback is a single commit with no downstream cleanup, persisted state, or migration. Blast radius
+is the requested compute policy for the bundled VAD model.
+
+## 13. Ship criteria
+
+1. Full `scripts/xcode-test.sh` green with a nonzero executed count.
+2. New freeze test passes; mutation receipt shows it FAILS with the bare configuration restored.
+3. **§11.3 offline A/B: identical event sequences, segment boundaries, and auto-stop decisions on
+   every fixture, across three runs per arm.** Any difference stops the change for founder review.
+4. Local whole-diff `codex review` clean.
+5. Live UAT §11.1 passes on both engines, auto-stop on and off — run ONCE, after Codex is clean.
+6. Latency receipt shows no statistically supported regression.
+7. GitHub cloud review clean.
+
+## 14. Open questions
+
+1. **Causation is not claimed.** If #1780 recurs on a configuration-aligned build, the #1783 markers
+   will show `first_vad_chunk_started` without `first_vad_chunk_completed`, and the hypothesis space
+   changes. #1780 stays open either way.
+2. **Could segment boundaries shift? Yes — and Live UAT alone cannot answer it.** Both engines share
+   the same VAD instance, so swapping ASR engines gives no independent numerical coverage of the
+   detector. **Before Live UAT**, run a deterministic offline A/B (§11.3).
+3. **`CoreMLOutputClassifier.swift:93`** uses the same constructor pattern for a different model with
+   no established replacement placement policy. Its in-process execution can terminate an active
+   dictation on a hard fault. Founder-approved as separate work; unchanged here. Still open on #1784.
+
+## 15. Related
+
+#1784 (this), #1780 (crash, stays open), PR #1783 (record-start observability), #1224 (bundled VAD
+model), #879 (WhisperKit compute options), D-028 (`docs/heartpath-refactor/DECISIONS.md`),
+`docs/audits/2026-07-24-1784-crash-containment-council.txt`,
+`.claude/knowledge/gotchas-audio.md` FACT: bundled-vad-model-pins-its-own-compute-policy (renamed from `...-bypasses-fluidaudio-default-configuration` when this change inverted it).


### PR DESCRIPTION
## #1780 is NOT fixed by this PR and stays open.

This removes a real configuration divergence on the heart path. It is **not proven** to cause #1780, and this PR does not claim it does.

## What changed

`BundledVADModelLoader.loadModel(in:)` built the bundled Silero VAD model with a bare `MLModelConfiguration()` — CoreML's `.all` default, which permits GPU. FluidAudio's own VAD loading path requests `.cpuAndNeuralEngine` + `allowLowPrecisionAccumulationOnGPU` and deliberately excludes the GPU (`DownloadUtils.swift:301-303`).

Three lines set those two properties at the sole construction site.

**Why not `VadConfig.computeUnits`?** It is a silent no-op on our path. Bundling the model (#1224) moved us off `VadManager.init(config:modelDirectory:)`; the pre-loaded initializer we use *stores* the `VadConfig` and never reads `computeUnits` (`VadManager.swift:102-107`), which is read at exactly one site (`:135`) inside `loadUnifiedModel`. The manager was reporting `.cpuAndNeuralEngine` while the model had been built permitting GPU.

**Why not `MLModelConfigurationUtils.defaultConfiguration()`?** FluidAudio has two equivalent implementations and the VAD path does not use that factory. Binding to it would let a dependency bump silently change heart-path CoreML policy.

## Why this is the remaining difference

Broad-spectrum competitor analysis (#1784 comments): **no competitor bundles a CoreML model — 0 of 8.** Among open-source consumers of the same library, essentially nobody uses the pre-loaded-model initializer; the one project that does sets the compute units itself before handing the model over, exactly as this PR now does.

Our bundled model is **byte-identical** to what the library downloads (`diff -r` across all five files), and the VAD feed supplies only complete 4,096-sample chunks. Model bytes and audio feeding are therefore eliminated as variables. Configuration was the last one standing.

## Receipts

**Behaviour — `docs/audits/2026-07-24-1784-offline-ab-receipt.md`**
6 fixtures × 2 replay modes × 3 repetitions per arm = 72 replays, fresh detector and freshly loaded model per replay. **12/12 comparisons identical**: event sequences, segment boundaries, speech evidence, first auto-stop chunk. Both arms stable within themselves. Committed `scripts/freeze-suite/clips/*.wav`, decoded once and shared by both arms.
*Disclosed limitation:* the synthesized quiet-onset fixture produced output identical to `normal-speech`, so it did not discriminate. The recipe was run as specified and not retuned after seeing the result.

**Latency — `docs/audits/2026-07-25-1784-latency-receipt.md`**
Detector-only, the measurement that answers the question: **0.344 ms → 0.342 ms per chunk (−0.002 ms)**. The detector is ~0.1% of pipeline time.
An end-to-end paired run (55/60 recordings, alternating arms, both engines) showed aggregate median +0.041s with a bootstrap 95% CI of [−0.014, +0.067] — includes zero, gate passes. Parakeet's +0.050s decomposed into paste (+0.030s) and polish (+0.013s) with ASR flat at +0.001s, i.e. stages with no causal path to this change. A neural-engine contention hypothesis was stated in advance and is refuted by both the ASR row and the detector-only number.

**Tests**
- `--filter EnviousWisprTests/BundledVADModelLoaderTests` — 2 tests, pass
- Full `scripts/xcode-test.sh` — **4040 tests executed**, pass
- **Mutation receipt:** removing both property assignments makes the freeze test FAIL with `MLComputeUnits(rawValue: 2) == MLComputeUnits(rawValue: 3)`. The oracle observes the change.

**Live UAT** — 4/4 configurations (Parakeet and WhisperKit × auto-stop on and off), identical correct transcript each time, verdicts from `app.log`. Every recording asserted the running process was this worktree's build and that the binary carried the fix.

## Scope

`council-skip: zero-blast-radius (single-value config)` — ship-path diff is **18 changed lines across exactly 2 files**, measured not asserted; the A/B harness was run from an uncommitted test file and deleted.

Deliberately out of scope: `CoreMLOutputClassifier.swift:93` uses the same constructor pattern for a different model whose correct placement policy is unestablished. It is a limb, but runs in-process before paste, so a hard CoreML fault there could still terminate a dictation. Tracked on #1784.

Also out of scope by founder decision: any crash safety net (quarantine, counters, one-strike disable). Evidence: no competitor ships one — four apparent hits in a binary sweep were all false positives (Crashlytics field names, a model name, the macOS download attribute, and a capture-path counter).

Part of #1784.
