### PR TITLE
docs(llm): record the seam-joining research and its per-engine verdict

### DIFF
--- a/research/seam-joining/2026-07-25-replacement-mechanism.md
+++ b/research/seam-joining/2026-07-25-replacement-mechanism.md
@@ -1,0 +1,144 @@
+# How to replace a span of text in someone else's app
+
+Measured 2026-07-25 with `code/measure_replace.py` and `code/probe_model_sync.py`.
+Every number here comes from staging a real field in the real app, running the
+mechanism, and reading the field back
+(validation-discipline.md RULE: measure-with-the-real-tool-never-a-simulation).
+
+## The question
+
+Seam joining has to delete text a previous recording already committed and put
+joined text in its place. The prototype did that by posting one backspace per
+character. Founder objection: visibly slow, and a dropped keystroke inside a
+burst of forty leaves a character behind.
+
+## Result
+
+Correctness on a real two-sentence seam, 89 characters replaced by 82, five runs
+each. `-` means the mechanism could not be attempted at all.
+
+| mechanism | TextEdit | Chrome textarea | Chrome contenteditable | Slack | Excel | Ghostty |
+|---|---|---|---|---|---|---|
+| backspace × N, then paste | 5/5 | 5/5 | **0/5** | 5/5 | 5/5 | 5/5 |
+| select the range, then paste | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | **-** |
+| select the range, then write through accessibility | 5/5 | 0/5 | 0/5 | 0/5 | 0/5 | - |
+| shift+Left × N, then paste | 5/5 | 5/5 | 5/5 | 5/5 | **0/5** | **0/5** |
+| rewrite the whole value | 5/5 | 5/5 | 5/5 | 5/5 | 0/5 | 0/5 |
+| shift+Home, then paste | 0/5 | 0/5 | 0/5 | 0/5 | 0/5 | 0/5 |
+
+Wall clock, same fixed settle time in every arm, so the differences are the
+mechanisms and not the harness:
+
+| span | backspace | select |
+|---|---|---|
+| 20 characters | 673 ms | 371 ms |
+| 89 characters | 1369 ms | 370 ms |
+
+Selection is flat. Backspace is linear and unbounded.
+
+## What each failure actually was
+
+- **Backspace in a browser contenteditable** turns the space at the seam into a
+  non-breaking space. The text looks identical and is a different character.
+  That matters beyond cosmetics: the trigger rule compares the last sentence in
+  the field against what we last pasted, and an invisible character swap breaks
+  that comparison.
+- **shift+Left in a terminal** arrives as literal escape sequences: the field
+  ends up holding `;2D;2D;2D…`. Terminals have no selection to extend.
+- **shift+Left in Excel** extends the cell selection instead of the text
+  selection and wipes the cell.
+- **shift+Home** takes the whole line, so it destroys anything before the seam.
+  Only correct when the span happens to be the entire line.
+- **Writing through accessibility** is accepted and does nothing in every
+  Chromium app.
+
+## The one that had to be ruled out carefully
+
+Rewriting the whole value was the fastest of all, 155 ms, and passed the
+read-back everywhere except Excel and Ghostty. It is still wrong.
+
+Reading the text back proves the text changed; it cannot prove the app's own
+editor saw it. `probe_model_sync.py` types one more character afterwards and
+checks where it lands. In Slack and in a contenteditable the next character
+landed at the **start** of the field: the visible text was right, the editor's
+own cursor and document were not. Selection-then-paste passed the same check
+everywhere, because the text arrives through a genuine paste the editor
+processes normally.
+
+This is the failure shape that has burned this work repeatedly — an
+accessibility call reporting success while nothing real happened — and it is
+invisible to any check that only reads the value back.
+
+## Decision, implemented in `code/join_hotkey.py`
+
+Select the exact range and paste. Fall back to backspace when the app reports no
+caret position, which is the same condition that identifies a terminal and the
+one surface where backspace is the only thing that works. Chosen by the caret
+signal, not by an app name, so an unknown app routes itself.
+
+The selection is read back before anything is written. An ignored selection
+would be worse than useless: the paste would land beside the old text instead of
+on top of it and double the sentence.
+
+Both self-tests pass with the change, and each picks its own mechanism without
+being told: `selftest_join.py` reports `by selection`, `selftest_terminal.py`
+reports `by backspace`.
+
+## The terminal path, which took five more rounds
+
+Every one of these was found by the founder dictating into his own Claude Code
+input box and reporting what he saw. None reproduced in a fresh shell, because a
+full-screen text UI and a bare prompt are not the same surface.
+
+1. **Reading returned the footer.** With the box completely EMPTY it read back
+   `/rc ⧉ seam-join-explainer`. Anchoring on the prompt marker swept up
+   everything below the box. Fixed by finding the box itself, which is drawn
+   between two horizontal rules.
+2. **The status bar looked like a shell prompt.** `81% | $107.40` contains both
+   `%` and `$`. Those markers are now weak and consulted only when no
+   unambiguous one (`❯`, `➜`) is on screen.
+3. **The read window was too small.** 400 characters covered a one-line box; a
+   wrapped dictation pushed the prompt out of view, no anchor was found, and the
+   whole screen came back. Now 2000.
+4. **Counting from the screen instead of the text.** The screen holds the line
+   wraps and the box's padding, so its length is not the buffer's. One run
+   counted 126 against a buffer of 149 and left 23 characters behind.
+5. **Trailing whitespace was discarded.** The app ends every dictation with a
+   space, so the buffer is one character longer than the visible sentence, and
+   deleting the visible length leaves the FIRST letter of the old sentence
+   welded to the new one — the `It` in `…again.It looks like`.
+
+### Two ambiguities that cannot be read away
+
+A terminal cannot tell you whether a line break replaced a space or fell
+mid-word, and it cannot reliably report trailing spaces. Both are unmeasurable,
+so the design stops trying to measure them:
+
+- **Bias toward the visible mistake.** The initial deletion is deliberately one
+  character short per wrap. A character left behind can be seen and removed; a
+  space eaten off the front is invisible to any comparison that strips
+  whitespace, so it could never be detected. Under-delete, then converge.
+- **Write the separators rather than preserve them.** Both the leading and the
+  trailing space are supplied on paste. Deterministic, where reading was not.
+
+### Verification
+
+`code/selftest_chunks.py` runs the founder's own test without him: type a chunk,
+merge, type the next chunk, merge, in his real terminal, reproducing what the
+app does including the trailing space. Six chunks, then eight, then ten, all
+clean — every merge correct, every genuinely-separate pair correctly left alone,
+no lost words, no leftover characters, no missing spaces.
+
+Two harness lessons worth keeping. A fixed sleep before reading the screen back
+reads a stale frame, which reported failures on runs that were correct and would
+have fired corrective backspaces into kept text; wait for the screen to change
+instead. And a strict word check called the polisher's "It's" for "It is" both a
+lost word and an invented one, so comparison ignores apostrophes and allows
+prefixes.
+
+## Also fixed while in here
+
+The deletion length was computed from the width of the matched sentence rather
+than from the match's start to the caret. Those differ whenever whitespace sits
+between the sentence and the cursor, which shifted the whole replacement one
+character left. Latent in every run so far.

--- a/research/seam-joining/ASSESSMENT.md
+++ b/research/seam-joining/ASSESSMENT.md
@@ -1,0 +1,96 @@
+# Where this actually stands — 2026-07-25
+
+Written after a day of measurement, at the founder's direction to stop and define
+the target. Everything here is measured unless marked otherwise.
+
+## Solved, and not worth revisiting
+
+**How to perform the edit.** Joining requires deleting a full stop that is
+already in the user's document. Tested three mechanisms in four apps that behave
+four different ways (native, Chromium, Electron, Microsoft). Only a synthesised
+backspace works everywhere; it is undoable, costs nothing, and reuses the
+mechanism the paste path already uses. The two "faster" alternatives are silent
+no-ops in most apps, which their success codes do not reveal.
+
+**How many characters to remove.** Never a constant. Some apps keep the trailing
+space we append, some strip it. Count from what the caret read actually returns.
+
+**Delivery.** Bundled or fetched at install alongside the speech model, on by
+default, opt-out, never setup-blocking. 279 MB, 2.7 ms, macOS 14 compatible.
+
+## The problem, stated plainly
+
+**The model works on invented data and fails on real speech.**
+
+| | invented test data | the founder's real recordings |
+|---|---|---|
+| accuracy | 99.5% | 82-88% |
+| wrongly joins separate sentences | ~0 of 149 | **30-58 of 431 (7-13%)** |
+| misses joins it should make | ~0 | **24-29 of 49 (>50%)** |
+
+Both directions are bad, and the gap between the two columns is the finding of
+the day. Six models, three seeds each, two independent labelling passes. It is
+not a labelling artifact: correcting 35 labels moved wrong merges from 8-15% to
+7-13%.
+
+**Most likely cause, not yet proven:** training data is polished written prose
+chopped into halves. Real dictation is instructions, half-thoughts, test
+phrases, topic jumps. The model learned a tidy version of a messy problem.
+
+## The gaps
+
+1. **No trustworthy labelled real data.** This is the bottleneck, not compute.
+   The first grader called 29 of 43 real sentence boundaries a join. The
+   corrected one still needs its flags read by hand.
+2. **Capitalisation is entirely unmeasured.** The plan says the model should
+   decide it. Nothing has been built, trained or tested. We have zero numbers.
+3. **"Train on real data" is an untested hypothesis**, not a plan step.
+4. **No definition of good enough** — until now.
+
+## The bar
+
+The feature fires when the model says join. Getting it wrong damages text the
+user wrote; getting it right fixes text the transcriber broke. Those are not
+equally weighted, so the bar is asymmetric.
+
+Measured base rate: **about 10% of consecutive recordings are genuinely one
+thought split by a pause.** The other 90% are separate and must be left alone.
+
+**Ship criteria, fixed now, before any more results are seen:**
+
+| | target | today |
+|---|---|---|
+| wrongly joins a separate pair | **under 1%** | 7-13% |
+| catches a real join | **over 50%** | under 50% |
+| capitalisation correct, given a correct join | **over 95%** | unmeasured |
+
+At those numbers the feature fixes roughly 5% of pauses and damages under 1%, a
+better than five-to-one ratio of help to harm. Today it is roughly one to one,
+which is not worth shipping.
+
+**Wrong merges are capped in absolute terms too:** on a 500-pair real test set,
+no more than 5. A rate can hide a small denominator.
+
+## The plan to get there, and where it stops
+
+1. **Label real data properly.** 640 pairs now via parallel agents, capturing
+   BOTH the join decision and the capitalisation decision in one pass, so
+   nothing needs relabelling. A slower 4,000-pair pass runs unattended in the
+   background. Both graders see identical rows, which gives a free agreement
+   check on how much any of these labels can be trusted.
+2. **Retrain on real recordings** instead of chopped prose. Hold out a real test
+   set that no training touches.
+3. **Measure against the bar above.**
+4. **Stop if it misses.** If real training does not reach the bar, the answer is
+   not to grind: it is to ship the deterministic rules alone, which reach about
+   a quarter of seams with no model, or to ship nothing and keep the mechanism
+   work for later. That is a founder decision, brought with numbers.
+
+## What would make this fail, and be worth knowing early
+
+- Joinable seams are only ~10% of pauses, so the ceiling on user-visible benefit
+  is modest even at perfect accuracy. Worth remembering before spending weeks.
+- One person's voice is the entire validation set. Stated plainly rather than
+  implied away.
+- The labels are model-generated. Two independent passes disagreeing would be
+  the signal that this whole measurement rests on sand.

--- a/research/seam-joining/HANDOFF.md
+++ b/research/seam-joining/HANDOFF.md
@@ -1,0 +1,169 @@
+# Seam joining — research complete, ready to plan the build
+
+Research phase for #1785, 2026-07-25. Everything below is measured, not estimated.
+Nothing has been wired into the app.
+
+## The problem, restated
+
+A user dictates in several recordings. Each is transcribed independently, so the
+transcriber capitalises the first word and usually appends a full stop. The
+recordings land one after another at the cursor and read as broken:
+
+    "I mean the ideal outcome." + "would be recognizing when two sentences..."
+    pasted:  I mean the ideal outcome. Would be recognizing when...
+    wanted:  I mean the ideal outcome would be recognizing when...
+
+Both halves of the defect are ours to fix. Measured from the founder's real log:
+the transcriber capitalises most resumed recordings, and **our own polish step
+capitalises the rest** ("disjointed" -> "Disjointed", "is run" -> "Is run").
+
+## What shipped as the answer
+
+A **seam classifier**: a multilingual encoder reads a window either side of the
+join and emits ONE label. Deterministic code applies the edit.
+
+    KEEP · MERGE_SPACE · MERGE_COMMA
+
+The model never emits text. That is the load-bearing property — it is why this
+cannot delete words the way EG-1 did ("I mean" vanished) or rewrite them the way
+GECToR did ("is closed" -> "was closed").
+
+**Winning configuration:** XLM-RoBERTa base, square-root language-balanced
+sampling, checkpoint selected by fewest wrong merges, fp16 weights.
+
+| metric | measured |
+|---|---|
+| accuracy, trained languages (EN/DE/RU, 879 rows) | 99.8% |
+| accuracy, ZERO-SHOT languages (ES/FR/IT/PT/PL/NL, 330 rows) | 97.9% |
+| wrong merges (silent damage) across all 1,209 rows | **0** |
+| latency, single item, on the founder's M4 Mac | 13.6 ms median, 14.2 ms p95 |
+| download size | 573 MB (fp16) |
+| provider dependence | none — runs for every user |
+
+Model: `model/seam-fp16/`. All variants also on the rig at `C:\Users\saura\seam-*`.
+
+## Ranked alternatives, all measured on the same data
+
+| approach | trained-lang acc | unseen-lang acc | wrong merges | note |
+|---|---|---|---|---|
+| **classifier, sqrt-balanced** | **99.4%** | **97.7%** | 0.3 + 1.7 | winner |
+| classifier, no balancing | 98.8% | 96.4% | 1.3 + 2.0 | Russian unstable |
+| classifier, full balancing | 98.7% | 94.3% | 1.7 + 3.7 | overfits small langs |
+| classifier on mmBERT-small | 98.0% | **81.2%** | 2.3 + 9.0 | collapses zero-shot |
+| GECToR (Grammarly), fine-tuned | 64.1% seam | — | 68 | run-ons; edits far from seam |
+| GECToR off-the-shelf | 22.8% seam | — | — | trained on essay errors |
+| deterministic rules only | 36% seam / 78% usable | — | 0 | safe floor, no download |
+| today (do nothing) | 14% seam | — | 0 | baseline |
+
+## Findings that will save the next session time
+
+**Aggregate metrics hide the decision.** mmBERT-small looked competitive on
+trained languages (98.0%) and collapsed on unseen ones (81.2%). English is 68% of
+the trained test set, so ALWAYS read per-language columns. `compare_models.py`
+prints them.
+
+**Wrong merges and accuracy do not move together.** mmBERT-base had 2 wrong
+merges at epoch 2 and 14 at epoch 3 while accuracy moved 99.1% -> 98.1%.
+`train_seam.py` selects on wrong merges for this reason. Do not revert it.
+
+**Russian instability was a data-mix problem, not a model problem.** Russian was
+800 of 11,264 rows (7%) and swung 91.9-98.8% across seeds. Balanced sampling
+fixed it outright. **We did not need more Russian data.** Square-root balancing
+(`--balance-power 0.5`) beats both full balancing and none.
+
+**Zero-shot transfer works.** 97.9% on six languages with zero training examples.
+Expanding languages likely needs a validation set per language, not a data
+generation project.
+
+**Single-seed results cannot separate two models.** Wrong merges swung 1 -> 3 ->
+19 across epochs of one run. Everything reported here is 3 seeds.
+
+**The glue code mattered more than the model choice.** Blind LLM grading moved the
+classifier 73% -> 89% -> 100% usable across three rounds, entirely by fixing
+`arms.py`: a missing full stop when keeping a boundary, a doubled comma, "A"
+treated as an acronym, a surviving pause-comma on a space-merge, and the
+speaker's repeated word at the seam. None of these were model errors.
+
+## Build phase opened — 2026-07-25
+
+Epic **#1790**. Plan: `docs/feature-requests/issue-1790-2026-07-25-seam-joining.md`.
+Most of the questions below are now answered; the answers are recorded here so
+this file stays the single research record.
+
+**Core ML conversion, measured** (`code/convert_coreml.py`, reference re-scored
+on the M4 at the same fixed shape):
+
+| variant | size | trained acc | wrong | unseen acc | wrong | agreement | median ms |
+|---|---|---|---|---|---|---|---|
+| PyTorch reference | 1.1 GB | 99.8% | 0 | 97.9% | 0 | — | 13.6 |
+| Core ML fp16 | 557 MB | 99.8% | 0 | 97.9% | 0 | 100.0% | 2.7 |
+| **Core ML int8** | **279 MB** | **99.8%** | **0** | **97.6%** | **0** | **99.9%** | **2.7** |
+| Core ML 4-bit | 139 MB | 96.7% | **9** | 91.8% | **2** | 95.3% | 2.4 |
+
+Eight-bit ships. Four-bit is **measured and rejected** — it breaks the one
+disqualifying metric. macOS 14 target accepted, so no Sonoma exclusion.
+279 MB is under the 512 MB single-object CDN ceiling, so no sharding.
+Artifact kept at `model/seam-coreml-int8.mlpackage`.
+
+**Conversion gotcha, four failures of one class.** transformers 5's attention
+and masking code emits ops the converter cannot take: `new_ones`, a vectorised
+higher-order op in mask expansion, a TRAINING-dialect exported program, and a
+boolean mask combine. Do not patch these one at a time. Present the weights to
+transformers 4.49 through `prepare_legacy_dir()`, which writes corrected
+metadata and symlinks the untouched weights. Pinned env
+`~/.cache/seam-convert-venv`: torch 2.7.1, transformers 4.49.0, coremltools 9.0.
+The `model/seam-legacy-view/` directory is that shim, not a second model.
+
+**Founder decisions 2026-07-25.** Size is not a blocker; a mandatory download
+alongside the speech model at setup is fine, where "mandatory" means always
+fetched and never setup-blocking. The lexicon approach is rejected — the model
+takes over the casing decision, with labels derived free from the uncorrupted
+source text. New epic; #1785 keeps its spacing and paste-safety half.
+
+### Still open
+
+1. **Everything is synthetic corruption.** No test yet against the live
+   transcriber. Founder's own 12 real seams pass 12/12, but that is a small
+   sample. Phase D gate.
+2. **Tokenizer parity is unverified.** ArgmaxCore ships Unigram, a Precompiled
+   normalizer and a Metaspace pretokenizer, which is everything XLM-RoBERTa
+   needs, but fidelity against our real inputs is untested. First task of the
+   plan's Phase B.
+3. **Where it runs is settled, and it is NOT the always-on layer.** The seam
+   decision needs the text already at the cursor, which only exists at delivery,
+   after polish — and our own polish step is one of the two sources of the
+   spurious capital. It extends `CursorInsertionRepair`, not
+   `TextProcessingRunner`. Correcting the earlier note here.
+4. **Vocabulary trimming** is the only remaining size lever now that four-bit is
+   rejected. Costs zero-shot transfer. Not planned.
+
+## Reproducing
+
+    # rig (native Windows venv, transformers 5.14.1, gector 1.2.0 installed)
+    ssh saura@aliensv
+    python train_seam.py --model FacebookAI/xlm-roberta-base --epochs 3 \
+        --seed 11 --balance-power 0.5 --out seam-sqrt-s11
+    python compare_models.py seam-sqrt      # per-language
+    python final_bakeoff.py                 # both test sets, ranked
+
+    # Mac (transformers 5.14.1)
+    python quantise_and_measure.py          # fp16 + real Mac latency
+
+Rig gotchas: `set "VAR=value"` quoted or the trailing space corrupts it;
+`PYTHONUTF8=1` required or Cyrillic crashes the loader; transformers 5 can train
+GECToR but cannot load its checkpoints.
+
+## Data provenance
+
+`data/seam_train.jsonl` — 11,264 pairs. English from the founder's own dictations
+(EG-1 training corpus + private corpus), split at natural pause points and
+corrupted to match measured transcriber behaviour. German and Russian generated
+by ChatGPT (prompt in `../chatgpt-data-prompt.md`).
+
+`data/seam_test.jsonl` — 879 held out. English from the founder's independent
+1,000-case file; German and Russian carved out of the generated sets with an
+explicit leakage check (121 rows removed for sharing a first half with training).
+
+`data/seam_zeroshot.jsonl` — 330 rows, six languages never trained on.
+
+**Contains the founder's real dictation content. Gitignored. Never commit.**

--- a/research/seam-joining/README.md
+++ b/research/seam-joining/README.md
@@ -1,0 +1,175 @@
+# Seam joining research (2026-07-25)
+
+Making two consecutive dictations read as one sentence when the speaker split a
+single thought across a pause. One session of research, ending in a clear verdict
+per engine. **Read this file first; it says where everything is.**
+
+Parent epic: #1790. Level 2 (the deterministic half): #1785. Level 3 (this
+research): see the issue that links here.
+
+## The verdict, in one table
+
+Eleven cases: seven that should join, four that must be left alone. Greedy
+sampling everywhere, so a rerun reproduces it.
+
+| Engine | Score | Wrong merges | Destroyed text | Ship? |
+|---|---|---|---|---|
+| Apple Intelligence (on-device) | 3/11 | 1 | 3 | **No** |
+| EG-1 (our model) | 8/11 | 0 | 0 | Yes, as an option |
+| Cloud (Claude Haiku 4.5) | 9/9 on its set | 0 | 0 after the strict clause | Yes, as an option |
+
+**Apple Intelligence is not close, and not for want of prompting.** It answers
+the dictation instead of editing it — "I pushed the fix. Thanks for catching
+that." came back as "I appreciate your feedback. It's great to hear that the fix
+was helpful. If you have any more questions or need further assistance, feel free
+to ask!" It also deleted whole sentences. Two very different prompts, same shape
+of failure. Since Apple Intelligence is the default engine for most users, the
+merge cannot be a default feature; it is an opt-in for EG-1 and cloud polish.
+
+**EG-1's errors are all in the safe direction.** Three misses, where it declined
+to join something it should have. Zero wrong merges, zero mangled words. For a
+feature that edits text the user already has on screen, that is the error profile
+you want.
+
+## The single most important prompt finding
+
+EG-1 scored **8/11 on its own training prompt** and **4/11 on a hand-written
+narrow prompt** that was better on the cloud model. EG-1 was fine-tuned on one
+exact system prompt and one exact `<TRANSCRIPT>` wrapper
+(`Sources/EnviousWisprLLM/Prompting/EGOnePromptBuilder.swift`, marked "DO NOT
+EDIT without retraining"). Moving it off that prompt halves its score. Do not
+generalise prompt results from a frontier model to EG-1.
+
+The reverse also holds. On the cloud model the shipped polish prompt actively
+fights this task: it instructs the model to break run-on speech into *separate*
+sentences, and it licenses "obvious speech-to-text slips fixed when the intended
+word is clear from context". That clause rewrote a live dictation, "It now passes
+ten. Dictated chunks in a row, cleanly." into "It is now past ten." — two thirds
+of the sentence discarded, because it read "passes ten" as a time of day. Adding
+an explicit no-invention clause took the cloud model from 7/9 to 9/9.
+
+## What is proven and reusable regardless of the merge
+
+The editing mechanism. This is the durable output of the session and Level 2
+needs all of it.
+
+Replacing a span of text inside another application's text field, measured
+across TextEdit, Chrome (plain textarea and contenteditable), Slack, Excel and
+Ghostty. Full numbers in [`2026-07-25-replacement-mechanism.md`](2026-07-25-replacement-mechanism.md).
+
+- **Select the exact range, then paste.** Flat 0.37 s regardless of length,
+  correct everywhere it is available, and the app's own editor model follows it.
+- **Backspace per character is the fallback**, used only where the app reports no
+  caret, which is exactly what identifies a terminal. 1.37 s for a real
+  two-sentence seam and rising, and in a browser contenteditable it silently
+  turns the space at the seam into a non-breaking space.
+- **Rewriting the whole value is a trap.** Fastest of all at 0.15 s and it passes
+  a read-back, but in Slack and in a contenteditable the editor never sees it:
+  the next character typed lands at the very start of the field. Only
+  `code/probe_model_sync.py` catches this — reading the text back cannot.
+
+Terminals took five further rounds and are documented in the same file. The short
+version: read the input box by finding the two rules it is drawn between, not by
+hunting for the prompt marker; a terminal cannot tell you whether a line wrap
+replaced a space; and bias every count toward the mistake you can see.
+
+## Where everything lives
+
+### In this folder (committed)
+
+| Path | What it is |
+|---|---|
+| `2026-07-25-replacement-mechanism.md` | How to edit text in another app. The measurements, the traps, the decisions. |
+| `ASSESSMENT.md` | Mid-session step back: goals, gaps, and the quality bar. |
+| `HANDOFF.md` | The classifier line of work (superseded, see below). |
+| `code/join_hotkey.py` | **The live prototype.** Hold left ctrl+opt+cmd and it joins the last two sentences in whatever is focused. Real dictation, real fields, no app changes. |
+| `code/selftest_chunks.py` | Types chunks into a real terminal, merges, repeats. Six, eight and ten chunks, all clean. |
+| `code/selftest_join.py`, `code/selftest_terminal.py` | The same for TextEdit and a Ghostty shell. |
+| `code/measure_replace.py`, `code/probe_replace_routes.py` | The six replacement mechanisms across five apps. |
+| `code/probe_model_sync.py` | Proves whether the app's editor actually saw an edit. |
+| `code/stress_backspace.py`, `code/probe_terminal_read.py` | Terminal-specific diagnostics. |
+| `code/afm_join.swift` | Apple Intelligence test. `xcrun swiftc -O -parse-as-library afm_join.swift -o afm_join`, then `./afm_join` or `./afm_join --shipped`. |
+| `code/eg1_join_test.py` | EG-1 test. Start the engine first (below). |
+| `code/compare_join_notes.py` | Prompt variants on the cloud model. |
+| `code/convert_coreml.py`, `code/train_seam.py`, `code/eval_seam.py` | The classifier line of work. |
+
+### On the founder's Mac only, deliberately not committed
+
+Under `docs/feature-requests/issue-1785-artifacts/seam-joining/` in the main
+checkout. `docs/` is gitignored, and this material must not be published: the
+repository is public and the corpora are built from real dictation. Publishing
+them would breach the privacy boundary in the project's own CLAUDE.md.
+
+| Path | What it is | Why it stayed local |
+|---|---|---|
+| `data/seam_real_*.jsonl` | ~5,900 seam pairs from 15,000 real recordings, plus grader labels | Real dictated content |
+| `data/label_batches/`, `data/relabel/` | Grading rounds | Same |
+| `model/` (829 MB) | Trained seam classifier and its Core ML conversions | Size and provenance; also over GitHub's file limit |
+| `results/` | Raw scoring output | Derived from the corpora |
+
+Rebuild the corpora with `code/build_seam_corpus.py` and
+`code/extract_real_seams.py` against a local transcript store.
+
+## Reproducing the engine comparison
+
+```bash
+# Apple Intelligence (macOS 26+)
+xcrun swiftc -O -parse-as-library code/afm_join.swift -o /tmp/afm_join
+/tmp/afm_join            # narrow prompt
+/tmp/afm_join --shipped  # shipped polish prompt + join instruction
+
+# EG-1, with the shipping flags from eg1-operations.md FACT: eg1-runtime-config
+./Sources/EnviousWispr/Resources/llama-server \
+  -m "$HOME/Library/Application Support/EnviousWispr/Models/eg-1/eg-1-v1-00001-of-00008.gguf" \
+  --host 127.0.0.1 --port 8899 -c 16384 -fa on \
+  --cache-type-k q8_0 --cache-type-v q8_0 &
+python3 code/eg1_join_test.py
+# It holds ~4 GB. Kill it when finished.
+
+# Cloud, through the Bedrock credits
+~/.claude/bin/get-key launch aws-bedrock-access-key-id AWS_ACCESS_KEY_ID -- \
+  ~/.claude/bin/get-key launch aws-bedrock-secret-access-key AWS_SECRET_ACCESS_KEY -- \
+  python3 code/compare_join_notes.py
+```
+
+## Superseded, and why
+
+**The seam classifier** was the original plan: a multilingual encoder reads a
+window either side of the join and emits one label, with deterministic code
+applying the edit. It was built, converted to Core ML (279 MB int8, 2.7 ms) and
+trained. It is superseded by re-polishing the seam, a founder idea that is
+strictly better: nothing to label, nothing to grade, no 279 MB artifact, and it
+handles cases the classifier structurally cannot, such as a second recording that
+opens on "But".
+
+It also ran into a measurement wall worth remembering. Two graders agreed on only
+about half the merge cases. That is not sloppiness; deciding whether two
+sentences are one thought is genuinely ambiguous, and any future accuracy target
+has to account for the fact that humans disagree about the ground truth.
+
+`HANDOFF.md` and the training scripts are kept for that lesson, not as a plan.
+
+**A competitor comparison that changed the plan.** Spokenly is the only shipping
+product users cite for this. It does not do what this research does. Its Smart
+Spacing and Smart Capitalization inspect the single character on each side of the
+cursor: insert a space if a letter is adjacent, lowercase the first word if the
+preceding character is a letter rather than a full stop. Their documentation
+states it never modifies text already in the field and sends nothing anywhere,
+and their release notes never mention joining across dictations. That feature is
+Level 2, is fully deterministic, and works on every engine — which is why Level 2
+ships first and Level 3 is an option on top.
+
+Sources: <https://spokenly.app/docs/macos/smart-spacing>,
+<https://spokenly.app/releases/macos>.
+
+## Known gaps
+
+- The **automatic trigger** does not exist. The prototype is driven by a hotkey.
+  Deciding when to offer a join without being asked is unbuilt and unmeasured.
+- **Undo.** The replacement is one paste, so the user's own undo should reach it,
+  but this has not been tested in any application.
+- The trigger rule the founder specified — engage only when the text before the
+  cursor matches what we last pasted — is agreed and **not yet implemented**. It
+  holds in ordinary text fields and is weaker in terminals, where a sent message
+  stays painted on screen and would still match.
+- Everything here is **English only**.

--- a/research/seam-joining/code/afm_join.swift
+++ b/research/seam-joining/code/afm_join.swift
@@ -79,15 +79,19 @@ func words(_ text: String) -> [String] {
 // testing: without it the on-device model REPLIED to the dictation ("Sure, I'll
 // take a look..."), which is a verdict on the prompt, not on the model.
 func shippedPolishPrompt() -> String {
-  let path = NSString(
-    string:
-      "~/Developer/EnviousLabs/EnviousWispr/Sources/EnviousWisprLLM/Prompting/CloudFixedPromptBuilder.swift"
+  // The prompt production Apple Intelligence sessions actually use, which is
+  // NOT the cloud one. `AppleIntelligenceConnector.onDeviceInstructionsSingle`
+  // is a different document with different rules, and it wraps the transcript
+  // in <TRANSCRIPT> tags. Testing the cloud prompt here measured a
+  // configuration no user has ever run. Found by cloud review on PR #1793.
+  let path = NSString(string:
+    "~/Developer/EnviousLabs/EnviousWispr/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift"
   ).expandingTildeInPath
   guard let body = try? String(contentsOfFile: path, encoding: .utf8),
-    let start = body.range(of: "cloudFixedSystemPrompt = \"\"\"\n"),
+    let start = body.range(of: "onDeviceInstructionsSingle = \"\"\"\n"),
     let end = body.range(of: "\"\"\"", range: start.upperBound..<body.endIndex)
   else {
-    print("could not read the shipped prompt")
+    print("could not read the on-device prompt")
     exit(1)
   }
   return String(body[start.upperBound..<end.lowerBound])
@@ -129,7 +133,7 @@ struct Runner {
       var out = ""
       do {
         let response = try await session.respond(
-          to: source,
+          to: "<TRANSCRIPT>\n\(source)\n</TRANSCRIPT>",
           options: GenerationOptions(sampling: .greedy, maximumResponseTokens: 300))
         out = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
       } catch {
@@ -139,7 +143,11 @@ struct Runner {
       }
 
       let lost = words(source).filter { !words(out).contains($0) }
-      let joined = out != source
+      // Did the BOUNDARY go? Both halves arrive terminated, so the input
+      // always holds two sentence-final marks. One left means they were
+      // welded; two means they were not, however much else was edited.
+      let marks = out.filter { ".!?".contains($0) }.count
+      let joined = marks < 2
       let verdict: String
       if lost.count > 2 {
         verdict = "DESTROYED  lost \(lost)"

--- a/research/seam-joining/code/afm_join.swift
+++ b/research/seam-joining/code/afm_join.swift
@@ -1,0 +1,160 @@
+// Can Apple Intelligence decide whether two dictations are one thought?
+//
+// Founder call, 2026-07-25: stop testing this on a frontier cloud model. Apple
+// Intelligence is the default polish engine for most users, so if the on-device
+// model cannot make this judgement reliably, the whole re-polish approach is
+// dead and no amount of prompt work on Haiku matters.
+//
+// This calls the REAL on-device model through FoundationModels, the same
+// framework the shipped connector uses, with greedy sampling so a rerun gives
+// the same answer. Every case is one the cloud model was measured on, so the
+// two are directly comparable.
+
+import Foundation
+import FoundationModels
+
+struct Case {
+  let first: String
+  let second: String
+  let want: String  // "join" or "leave"
+}
+
+let cases: [Case] = [
+  // The founder's live failure: the cloud model rewrote this as "It is now past
+  // ten." and threw away two thirds of it.
+  Case(first: "It now passes ten.", second: "Dictated chunks in a row, cleanly.", want: "join"),
+  Case(
+    first: "I was thinking about the release.", second: "And how we should stage it.", want: "join"),
+  Case(first: "The tests are still red.", second: "So we cannot ship today.", want: "join"),
+  Case(first: "Can you take a look.", second: "When you get a chance.", want: "join"),
+  Case(first: "I will send you the notes.", second: "After the meeting ends.", want: "join"),
+  Case(
+    first: "We should probably tell the team.", second: "Before anyone else finds out.",
+    want: "join"),
+  Case(first: "I finished the report.", second: "But I have not sent it yet.", want: "join"),
+  // Must be left alone. Wrongly welding two real sentences is the failure that
+  // makes people distrust the feature.
+  Case(
+    first: "I was thinking about the release and how we should stage it.",
+    second: "The tests are still red.", want: "leave"),
+  Case(
+    first: "Can you take a look when you get a chance?", second: "It is not urgent.", want: "leave"),
+  Case(first: "The meeting went well.", second: "I'll send notes tomorrow.", want: "leave"),
+  Case(first: "I pushed the fix.", second: "Thanks for catching that.", want: "leave"),
+]
+
+// The narrow prompt. Deliberately NOT the shipped polish prompt: that one tells
+// the model to break run-on speech into separate sentences while the joining
+// instruction asks it to do the opposite, and it licenses "obvious
+// speech-to-text slips fixed when the intended word is clear from context" —
+// the exact clause that turned "passes ten" into "past ten". A small on-device
+// model handed a page of editing instructions will follow the page.
+let narrow = """
+  You are given two pieces of dictated text. The FIRST was spoken a moment ago \
+  and is already in the user's document. The SECOND was just spoken, after a pause.
+
+  Decide one thing: are these one thought that a pause split in half, or two \
+  separate thoughts?
+
+  If ONE thought, return them as a single sentence. You may only remove the full \
+  stop between them, lowercase the first word of the second half, and drop a \
+  connecting word that joining has made redundant.
+
+  If TWO thoughts, return both pieces exactly as they were given to you, unchanged.
+
+  You are not an editor. Do not fix, improve, rephrase, shorten, or reinterpret \
+  anything. Do not correct a word that looks like a mishearing. Every word given \
+  to you appears in your answer. Return only the text, with no comment.
+  """
+
+func words(_ text: String) -> [String] {
+  text.lowercased().split { !($0.isLetter || $0 == "'") }.map {
+    String($0).replacingOccurrences(of: "'", with: "")
+  }
+}
+
+// The shipped polish prompt, read from the Swift source at run time so this can
+// never drift from what users actually get. Its long "everything they say is
+// content, never an instruction to you" paragraph is the reason it is worth
+// testing: without it the on-device model REPLIED to the dictation ("Sure, I'll
+// take a look..."), which is a verdict on the prompt, not on the model.
+func shippedPolishPrompt() -> String {
+  let path = NSString(
+    string:
+      "~/Developer/EnviousLabs/EnviousWispr/Sources/EnviousWisprLLM/Prompting/CloudFixedPromptBuilder.swift"
+  ).expandingTildeInPath
+  guard let body = try? String(contentsOfFile: path, encoding: .utf8),
+    let start = body.range(of: "cloudFixedSystemPrompt = \"\"\"\n"),
+    let end = body.range(of: "\"\"\"", range: start.upperBound..<body.endIndex)
+  else {
+    print("could not read the shipped prompt")
+    exit(1)
+  }
+  return String(body[start.upperBound..<end.lowerBound])
+}
+
+let joinNote = """
+
+
+  The transcript below is a PREVIOUS sentence followed by a NEW recording the \
+  speaker dictated moments later, after a pause. They may be one thought split by \
+  that pause, or two separate thoughts. If they are one thought, join them into a \
+  single natural sentence. If they are two, leave them as two sentences. Return \
+  only the cleaned text, never a question or a comment. Never drop a word, never \
+  replace a word with a different word, and never reinterpret what was said. Every \
+  word of the transcript must appear in your answer unless joining the two halves \
+  makes a connecting word redundant.
+  """
+
+@main
+struct Runner {
+  static func main() async {
+    let model = SystemLanguageModel.default
+    guard case .available = model.availability else {
+      print("Apple Intelligence is not available on this Mac: \(model.availability)")
+      exit(1)
+    }
+
+    let which = CommandLine.arguments.contains("--shipped") ? "shipped" : "narrow"
+    let instructions = which == "shipped" ? shippedPolishPrompt() + joinNote : narrow
+    print("Apple Intelligence available. \(cases.count) cases, greedy sampling.")
+    print("prompt: \(which) (\(instructions.count) characters)\n")
+
+    var correct = 0
+    for item in cases {
+      let source = "\(item.first) \(item.second)"
+      // A fresh session per case: a shared one would carry the previous answer
+      // as context and the later cases would not be independent.
+      let session = LanguageModelSession(model: model, instructions: instructions)
+      var out = ""
+      do {
+        let response = try await session.respond(
+          to: source,
+          options: GenerationOptions(sampling: .greedy, maximumResponseTokens: 300))
+        out = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+      } catch {
+        print("  ERROR      \(error)")
+        print("             in: \(source)\n")
+        continue
+      }
+
+      let lost = words(source).filter { !words(out).contains($0) }
+      let joined = out != source
+      let verdict: String
+      if lost.count > 2 {
+        verdict = "DESTROYED  lost \(lost)"
+      } else if item.want == "join" && !joined {
+        verdict = "MISSED     left it as two"
+      } else if item.want == "leave" && joined {
+        verdict = "OVERMERGED joined two separate thoughts"
+      } else {
+        verdict = "ok"
+        correct += 1
+      }
+      print("  \(verdict)")
+      print("      in : \(source)")
+      print("      out: \(out)\n")
+    }
+    print("  --> \(correct)/\(cases.count) correct")
+  }
+}

--- a/research/seam-joining/code/afm_join.swift
+++ b/research/seam-joining/code/afm_join.swift
@@ -110,6 +110,28 @@ let joinNote = """
   makes a connecting word redundant.
   """
 
+
+/// Is there still a sentence boundary BETWEEN the two halves?
+///
+/// Everything else the model does — fixing a comma, contracting "it is",
+/// changing the closing punctuation — is irrelevant to that question. Anchor on
+/// the last word of the first half and the first word of the second, then look
+/// at the text between them: a terminator there means the seam survived.
+func wasJoined(first: String, second: String, output: String) -> Bool {
+  func words(_ text: String) -> [String] {
+    text.split { !($0.isLetter || $0.isNumber || $0 == "'") }.map(String.init)
+  }
+  guard let tail = words(first).last, let head = words(second).first else { return false }
+
+  let lower = output.lowercased()
+  guard let tailRange = lower.range(of: tail.lowercased()) else { return false }
+  let afterTail = lower[tailRange.upperBound...]
+  guard let headRange = afterTail.range(of: head.lowercased()) else { return false }
+
+  let gap = afterTail[..<headRange.lowerBound]
+  return !gap.contains { ".!?".contains($0) }
+}
+
 @main
 struct Runner {
   static func main() async {
@@ -143,11 +165,11 @@ struct Runner {
       }
 
       let lost = words(source).filter { !words(out).contains($0) }
-      // Did the BOUNDARY go? Both halves arrive terminated, so the input
-      // always holds two sentence-final marks. One left means they were
-      // welded; two means they were not, however much else was edited.
-      let marks = out.filter { ".!?".contains($0) }.count
-      let joined = marks < 2
+      // The same definition the Python harnesses use (seam_verdict.py).
+      // Counting sentence marks was wrong: an output that drops only its
+      // FINAL full stop leaves one mark and scored as joined while the
+      // boundary was plainly still there.
+      let joined = wasJoined(first: item.first, second: item.second, output: out)
       let verdict: String
       if lost.count > 2 {
         verdict = "DESTROYED  lost \(lost)"

--- a/research/seam-joining/code/afm_join.swift
+++ b/research/seam-joining/code/afm_join.swift
@@ -123,13 +123,22 @@ func wasJoined(first: String, second: String, output: String) -> Bool {
   }
   guard let tail = words(first).last, let head = words(second).first else { return false }
 
+  // Anchor on the LAST occurrence of the tail word that still has the head word
+  // after it. The first occurrence examines the wrong gap when the first half
+  // repeats its own final word ("Go when I say go." + "Go now.").
   let lower = output.lowercased()
-  guard let tailRange = lower.range(of: tail.lowercased()) else { return false }
-  let afterTail = lower[tailRange.upperBound...]
-  guard let headRange = afterTail.range(of: head.lowercased()) else { return false }
-
-  let gap = afterTail[..<headRange.lowerBound]
-  return !gap.contains { ".!?".contains($0) }
+  var searchEnd = lower.endIndex
+  while let tailRange = lower.range(of: tail.lowercased(), options: .backwards,
+                                    range: lower.startIndex..<searchEnd) {
+    let afterTail = lower[tailRange.upperBound...]
+    if let headRange = afterTail.range(of: head.lowercased()) {
+      let gap = afterTail[..<headRange.lowerBound]
+      return !gap.contains { ".!?".contains($0) }
+    }
+    if tailRange.lowerBound == lower.startIndex { break }
+    searchEnd = tailRange.lowerBound
+  }
+  return false
 }
 
 @main

--- a/research/seam-joining/code/arms.py
+++ b/research/seam-joining/code/arms.py
@@ -1,0 +1,191 @@
+"""Four-arm experiment harness for the seam-joining problem.
+
+Arms are pluggable so variants are cheap to add. The founder's standing
+instruction (2026-07-25): one result is one variation, never a verdict. Add
+variants here rather than rewriting the harness.
+
+  arm_today        what the app pastes now: the two recordings, unchanged
+  arm_deterministic  closed-class rules only, no model
+  arm_gector_full  Grammarly's GECToR over the whole joined text
+  arm_gector_seam  GECToR restricted to a window around the seam, so it
+                   physically cannot edit text far from the cursor
+  arm_classifier   (pending) trained seam classifier - council's proposal
+
+Every arm has the same signature: (rec1, rec2, language) -> final text.
+"""
+
+import re
+
+TERMINATORS = (".", "!", "?")
+
+# Closed-class function words that cannot END a finished sentence.
+from bench_options import CANNOT_END  # noqa: E402
+
+
+# ---------------------------------------------------------------- shared edits
+
+
+def apply_merge(left, right, separator=" "):
+    """Join two recordings, changing ONLY the seam.
+
+    Every rule here exists because blind grading caught it failing:
+      - MERGE_SPACE means the seam IS a space, so a comma the transcriber added
+        at the pause is stripped too, not just a full stop. Keeping it produced
+        "Please remember to, lock the door."
+      - a comma is never doubled when the left half already ends in one
+      - a single capital letter ("A") is not an acronym; "I" is protected by name
+      - a word the speaker repeated across the pause is dropped once. The
+        recogniser hears the tail of recording 1 again at the head of recording
+        2, producing "finish the the report" / "check check whether".
+    """
+    left = left.strip()
+    right = right.strip()
+    # Strip whatever punctuation the transcriber stuck on the pause.
+    left = re.sub(r"[.!?]+$", "", left).rstrip()
+    if separator.startswith(",") or separator.isspace() or separator == "":
+        left = left.rstrip(",").rstrip()
+
+    if right and right[0].isupper():
+        first = right.split()[0] if right.split() else ""
+        bare = first.rstrip(".,!?;:")
+        protected = (
+            bare == "I" or bare.startswith("I'")
+            or (len(bare) > 1 and any(c.isupper() for c in bare[1:]))
+            or (len(bare) > 1 and bare.isupper())
+        )
+        if not protected:
+            right = right[0].lower() + right[1:]
+
+    # Drop a word the speaker repeated across the pause.
+    lw, rw = left.split(), right.split()
+    if lw and rw:
+        tail = lw[-1].rstrip(".,!?;:").lower()
+        head = rw[0].rstrip(".,!?;:").lower()
+        if tail and tail == head:
+            rw = rw[1:]
+            right = " ".join(rw)
+            if right and right[0].isupper() and len(right.split()[0]) == 1:
+                pass
+    if not right:
+        return left
+    return f"{left}{separator}{right}"
+
+
+INTERROGATIVE_OPENERS = {
+    # closed set: words that can begin a direct question in English
+    "are", "is", "am", "was", "were", "do", "does", "did", "can", "could",
+    "should", "would", "will", "shall", "may", "might", "must", "have", "has",
+    "had", "what", "where", "when", "why", "who", "whom", "whose", "which",
+    "how",
+}
+
+
+def _looks_like_question(text):
+    """Does this clause read as a direct question?
+
+    Blind grading round 3 let two of these through: "Are you free after lunch."
+    and "Should I call the pharmacy again." Both keep a boundary correctly but
+    get a full stop where a question mark belongs, because the code only ever
+    supplied ".". The opener set is closed, so this needs no vocabulary.
+    """
+    words = re.findall(r"[^\W\d_]+", text, flags=re.UNICODE)
+    return bool(words) and words[0].lower() in INTERROGATIVE_OPENERS
+
+
+def apply_keep(left, right):
+    """Keep the two thoughts separate - and punctuate the boundary correctly.
+
+    A missing terminator is supplied, a trailing comma is promoted, and a clause
+    that reads as a question gets a question mark rather than a full stop.
+    """
+    left = left.strip()
+    right = right.strip()
+    had_question = left.rstrip().endswith("?")
+    left = re.sub(r"[,;:]+$", "", left).rstrip()
+    if left.endswith((".", "!", "?")):
+        # An existing full stop on a question is the transcriber's mistake.
+        if left.endswith(".") and (had_question or _looks_like_question(left)):
+            left = left[:-1] + "?"
+    else:
+        left += "?" if _looks_like_question(left) else "."
+    if right and right[0].islower():
+        right = right[0].upper() + right[1:]
+    return f"{left} {right}"
+
+
+# ------------------------------------------------------------------- the arms
+
+
+def arm_today(rec1, rec2, language=None):
+    return f"{rec1.strip()} {rec2.strip()}"
+
+
+def arm_deterministic(rec1, rec2, language="English"):
+    """Merge only when recording 1 is provably unfinished. Two certificates:
+    it has no terminal punctuation at all, OR its last word is a closed-class
+    function word that cannot end a sentence in that language."""
+    stripped = rec1.strip()
+    words = re.findall(r"[^\W\d_]+", stripped, flags=re.UNICODE)
+    last = words[-1].lower() if words else ""
+    unfinished = last in CANNOT_END.get(language, set())
+    if unfinished:
+        return apply_merge(stripped, rec2)
+    return apply_keep(stripped, rec2)
+
+
+class GECToRArm:
+    """Grammarly's tagger. `window` limits how much text it may see and edit.
+
+    window=None  -> the whole joined text (what off-the-shelf use looks like)
+    window=N     -> only N words either side of the seam are passed through the
+                    model; the rest is spliced back verbatim, so text far from
+                    the cursor is untouchable by construction.
+    """
+
+    def __init__(self, model_id="gotutiyan/gector-roberta-base-5k", window=None,
+                 keep_confidence=0.0, min_error_prob=0.0, n_iteration=5):
+        from gector.modeling import GECToR
+        from gector.predict import load_verb_dict
+        from transformers import AutoTokenizer
+
+        self.model = GECToR.from_pretrained(model_id)
+        self.model.eval()
+        self.tok = AutoTokenizer.from_pretrained(model_id)
+        self.enc, self.dec = load_verb_dict("verb-form-vocab.txt")
+        self.window = window
+        self.keep_confidence = keep_confidence
+        self.min_error_prob = min_error_prob
+        self.n_iteration = n_iteration
+
+    def _run(self, texts):
+        from gector.predict import predict
+
+        return predict(
+            self.model, self.tok, texts, self.enc, self.dec,
+            keep_confidence=self.keep_confidence,
+            min_error_prob=self.min_error_prob,
+            n_iteration=self.n_iteration,
+            batch_size=max(1, min(64, len(texts))),
+        )
+
+    def batch(self, pairs):
+        """pairs: [(rec1, rec2, language)] -> [final text]"""
+        prefixes, probes, suffixes = [], [], []
+        for rec1, rec2, _lang in pairs:
+            left, right = rec1.strip(), rec2.strip()
+            if self.window is None:
+                prefixes.append("")
+                probes.append(f"{left} {right}")
+                suffixes.append("")
+                continue
+            lw, rw = left.split(), right.split()
+            head, tail = lw[: max(0, len(lw) - self.window)], lw[max(0, len(lw) - self.window):]
+            r_head, r_tail = rw[: self.window], rw[self.window:]
+            prefixes.append(" ".join(head))
+            probes.append(" ".join(tail + r_head))
+            suffixes.append(" ".join(r_tail))
+        corrected = self._run(probes)
+        out = []
+        for pre, mid, suf in zip(prefixes, corrected, suffixes):
+            out.append(" ".join(p for p in (pre.strip(), mid.strip(), suf.strip()) if p))
+        return out

--- a/research/seam-joining/code/arms.py
+++ b/research/seam-joining/code/arms.py
@@ -127,8 +127,16 @@ def arm_deterministic(rec1, rec2, language="English"):
     stripped = rec1.strip()
     words = re.findall(r"[^\W\d_]+", stripped, flags=re.UNICODE)
     last = words[-1].lower() if words else ""
-    unfinished = last in CANNOT_END.get(language, set())
-    if unfinished:
+
+    # BOTH certificates, not just the second. The docstring has always promised
+    # two, and the deterministic arm is the baseline every other arm is measured
+    # against, so an arm that silently implements half its stated rule
+    # understates the deterministic floor and flatters everything compared to
+    # it. "We should release" — no terminator, ordinary final word — was being
+    # given a full stop and counted as a KEEP. Found by cloud review on PR #1793.
+    no_terminator = not stripped.endswith((".", "!", "?", "…"))
+    cannot_end = last in CANNOT_END.get(language, set())
+    if no_terminator or cannot_end:
         return apply_merge(stripped, rec2)
     return apply_keep(stripped, rec2)
 

--- a/research/seam-joining/code/assemble_dataset.py
+++ b/research/seam-joining/code/assemble_dataset.py
@@ -1,0 +1,248 @@
+"""Assemble the seam training/test sets for English, German and Russian.
+
+Founder scope decision 2026-07-25: validate on these three, expand later.
+
+SOURCES
+  English train : the founder's own polished dictations, split at natural pause
+                  points and corrupted the way the transcriber really corrupts
+                  them (measured: 80% full stop, 10% none, 10% question mark;
+                  90% of second halves capitalised).
+  German train  : ChatGPT-generated, 800 of 1000 rows.
+  Russian train : ChatGPT-generated, 800 of 1000 rows.
+
+  English test  : the founder's independent 1,000-case file (600 English rows).
+                  A completely separate source from anything trained on.
+  German test   : the held-out 200 rows.
+  Russian test  : the held-out 200 rows.
+
+LABELS are derived from the expected output, never hand-assigned:
+  KEEP         the join keeps a sentence boundary
+  MERGE_COMMA  the halves join with a comma
+  MERGE_SPACE  the halves join with a plain space
+
+Leakage is checked explicitly at the end - any first half appearing in both
+train and test is a bug, not a rounding error.
+"""
+
+import argparse
+import csv
+import json
+import os
+import random
+import re
+import sys
+from collections import Counter
+
+HOME = os.path.expanduser("~")
+DOWNLOADS = os.path.join(HOME, "Downloads")
+REPO = os.path.join(HOME, "Developer/EnviousLabs/EnviousWispr")
+OUT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data")
+
+GENERATED = {
+    "German": "german_voice_join_dataset_1000.csv",
+    "Russian": "russian_dictation_join_dataset_1000.csv",
+}
+TEST_FILE = "enviouswispr_smart_casing_spacing_1000.csv"
+EG1 = os.path.join(REPO, "scripts/eval/runs/bakeoff-1265/train_sft_v2.jsonl")
+
+TERMINATORS = (".", "!", "?")
+RESUME_AFTER_ANY = True  # split anywhere sensible, not only after function words
+
+
+def label_for(rec1, rec2, expected):
+    """Derive the seam label by comparing the expected output to the halves."""
+    exp = re.sub(r"\s+", " ", expected).strip()
+    left_words = len(re.sub(r"\s+", " ", rec1).strip().split())
+    words = exp.split()
+    if left_words == 0 or left_words >= len(words):
+        return None
+    boundary_token = words[left_words - 1]
+    if boundary_token.endswith(TERMINATORS):
+        return "KEEP"
+    if boundary_token.endswith(","):
+        return "MERGE_COMMA"
+    return "MERGE_SPACE"
+
+
+def rows_from_generated(path, language):
+    out = []
+    for r in csv.DictReader(open(path, encoding="utf-8-sig")):
+        lab = label_for(r["recording_1"], r["recording_2"], r["expected_output"])
+        if not lab:
+            continue
+        out.append({
+            "rec1": r["recording_1"].strip(),
+            "rec2": r["recording_2"].strip(),
+            "expected": r["expected_output"].strip(),
+            "label": lab,
+            "language": language,
+            "source": "generated",
+        })
+    return out
+
+
+def split_english(rng, cuts_per_text=8):
+    """Turn the founder's polished dictations into BALANCED seam pairs.
+
+    Splitting at random positions produces almost only MERGE_SPACE, because a
+    random point in a sentence is nearly always mid-clause. That imbalance would
+    teach a model to always merge. So each label is manufactured deliberately:
+
+      KEEP         split exactly at a real sentence boundary inside the text
+      MERGE_COMMA  split immediately after a comma, so rejoining needs one back
+      MERGE_SPACE  split mid-clause, away from any punctuation
+
+    BROAD-SPECTRUM SPLITTING (founder directive 2026-07-25). Earlier this took
+    exactly ONE cut per label per text, which used 6.9% of the 33,121 cut
+    positions the corpus offers. That was wrong, and the reason is the whole
+    point of the feature: you cannot predict where a person stops to think. The
+    pause lands wherever their mind needed a moment, so at inference the cut is
+    effectively arbitrary. Training on one "realistic" position per sentence
+    fits a distribution that does not exist; the model's actual job is to judge
+    two fragments however they were severed.
+
+    So cut in many places. What must stay realistic is the FRAGMENTS and the
+    damage the transcriber does to them, never the location of the break.
+
+    `cuts_per_text` caps how many positions each source text contributes, so a
+    long text cannot flood the set with near-copies of itself.
+    """
+    texts = []
+    if os.path.exists(EG1):
+        for line in open(EG1):
+            o = (json.loads(line).get("output") or "").strip()
+            if len(o.split()) >= 10:
+                texts.append(o)
+    corpus = os.path.join(REPO, "scripts/eval/corpus/corpus.jsonl")
+    if os.path.exists(corpus):
+        for line in open(corpus):
+            t = (json.loads(line).get("asr_input") or "").strip()
+            if len(t.split()) >= 10:
+                texts.append(t)
+    texts = list(dict.fromkeys(texts))
+
+    def corrupt(left, right, genuine):
+        roll = rng.random()
+        if genuine:
+            c_left = left  # already ends with its own terminator
+        elif roll < 0.80:
+            c_left = left.rstrip(",;:") + "."
+        elif roll < 0.90:
+            c_left = left
+        else:
+            c_left = left.rstrip(",;:") + "?"
+        c_right = right
+        if rng.random() < 0.90 and c_right[:1].islower():
+            c_right = c_right[0].upper() + c_right[1:]
+        return c_left, c_right
+
+    buckets = {"KEEP": [], "MERGE_COMMA": [], "MERGE_SPACE": []}
+    for text in texts:
+        words = text.split()
+        if len(words) < 8:
+            continue
+        boundary = [i for i in range(3, len(words) - 3) if words[i - 1].endswith(TERMINATORS)]
+        comma = [i for i in range(3, len(words) - 3) if words[i - 1].endswith(",")]
+        plain = [i for i in range(3, len(words) - 3)
+                 if not words[i - 1][-1:] in ".,!?;:"]
+
+        for label, spots in (("KEEP", boundary), ("MERGE_COMMA", comma), ("MERGE_SPACE", plain)):
+            if not spots:
+                continue
+            for idx in rng.sample(spots, min(cuts_per_text, len(spots))):
+                left = " ".join(words[:idx])
+                right = " ".join(words[idx:])
+                if label == "MERGE_COMMA":
+                    left = left.rstrip(",")  # the comma is what must come back
+                c_left, c_right = corrupt(left, right, label == "KEEP")
+                buckets[label].append({
+                    "rec1": c_left, "rec2": c_right, "expected": text,
+                    "label": label, "language": "English",
+                    "source": "founder_dictation",
+                })
+
+    # Rebalance toward the mix the generated sets use, so no label dominates.
+    target = {"MERGE_SPACE": 0.50, "KEEP": 0.35, "MERGE_COMMA": 0.15}
+    smallest = min(len(buckets[k]) / target[k] for k in target if buckets[k])
+    out = []
+    for label, frac in target.items():
+        take = int(smallest * frac)
+        rng.shuffle(buckets[label])
+        out += buckets[label][:take]
+    rng.shuffle(out)
+
+    # Which label ran out first decides where more data would actually help.
+    # Real sentence boundaries are the scarce resource: a text yields dozens of
+    # mid-clause cuts but only as many KEEP cuts as it has sentences. Print it
+    # rather than leaving a future session to rediscover the ceiling.
+    binding = min(target, key=lambda k: len(buckets[k]) / target[k] if buckets[k] else 1e9)
+    print(f"  english cuts harvested: "
+          f"{ {k: len(v) for k, v in buckets.items()} }", file=sys.stderr)
+    print(f"  binding label: {binding} — total capped at {len(out)} by its supply",
+          file=sys.stderr)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cuts", type=int, default=8,
+                    help="max split positions harvested per source text per label")
+    ap.add_argument("--suffix", default="",
+                    help="suffix for the output filenames, so two arms can coexist")
+    args = ap.parse_args()
+
+    rng = random.Random(1785)
+    train, test = [], []
+
+    # English: train from the founder's dictations, test from the independent file.
+    eng = split_english(rng, cuts_per_text=args.cuts)
+    rng.shuffle(eng)
+    train += eng
+    for r in csv.DictReader(open(os.path.join(DOWNLOADS, TEST_FILE), encoding="utf-8-sig")):
+        if r["language"] != "English":
+            continue
+        lab = label_for(r["recording_1"], r["recording_2"], r["expected_output"])
+        if lab:
+            test.append({"rec1": r["recording_1"].strip(), "rec2": r["recording_2"].strip(),
+                         "expected": r["expected_output"].strip(), "label": lab,
+                         "language": "English", "source": "holdout_file"})
+
+    # German and Russian: 800 train / 200 test out of each generated file.
+    #
+    # Each language gets its OWN generator, seeded by name. Sharing `rng` with
+    # the English splitter coupled them invisibly: broad-spectrum splitting drew
+    # far more random numbers, so the shared stream was in a different state by
+    # the time it shuffled these rows, and the holdout silently became a
+    # DIFFERENT 200 rows. That moved 231 of 879 previously-held-out rows into
+    # training and made the old and new models non-comparable on these
+    # languages. A holdout must not depend on how much randomness an unrelated
+    # step happened to consume.
+    for language, fn in GENERATED.items():
+        rows = rows_from_generated(os.path.join(DOWNLOADS, fn), language)
+        random.Random(f"holdout-{language}").shuffle(rows)
+        test += rows[:200]
+        train += rows[200:]
+
+    # Leakage check: no first half may appear on both sides.
+    train_left = {r["rec1"] for r in train}
+    overlap = [r for r in test if r["rec1"] in train_left]
+    if overlap:
+        print(f"LEAKAGE: {len(overlap)} test rows share a first half with train", file=sys.stderr)
+        test = [r for r in test if r["rec1"] not in train_left]
+
+    for name, rows in ((f"seam_train{args.suffix}.jsonl", train),
+                       (f"seam_test{args.suffix}.jsonl", test)):
+        with open(os.path.join(OUT, name), "w") as fh:
+            for r in rows:
+                fh.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    print(f"train {len(train)}   test {len(test)}   (leakage removed: {len(overlap)})")
+    for name, rows in (("TRAIN", train), ("TEST", test)):
+        print(f"\n{name}")
+        print(f"  language: {dict(Counter(r['language'] for r in rows))}")
+        print(f"  label   : {dict(Counter(r['label'] for r in rows))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/bench_options.py
+++ b/research/seam-joining/code/bench_options.py
@@ -1,0 +1,199 @@
+"""Benchmark the candidate options against the founder's 1,000-case multilingual set.
+
+The point is to establish what each option is worth BEFORE building anything, and
+to separate the easy half from the hard half so the hard half can be attacked on
+its own.
+
+Options measured here:
+  0. TODAY          - concatenate the two recordings, change nothing.
+  1. RIGHT-SIDE     - merge only when recording 1 does not end in . ! ?
+                      (the rule already measured at 96.1% on real dictations)
+  2. LEFT-SIDE      - merge when recording 1's last WORD cannot end a sentence,
+                      regardless of the punctuation the transcriber appended.
+                      Function words are a CLOSED class in every language, so
+                      this is a few dozen words per language, not a dictionary of
+                      the language.
+  3. COMBINED       - 1 or 2.
+
+Scored two ways: the MERGE/KEEP decision, and exact match of the final text
+(which additionally requires correct punctuation, casing and spacing).
+"""
+
+import csv
+import os
+import re
+import sys
+from collections import defaultdict
+
+CSV_PATH = os.path.expanduser("~/Downloads/enviouswispr_smart_casing_spacing_1000.csv")
+TERMINATORS = (".", "!", "?")
+
+# Closed-class function words that cannot END a finished sentence. Per language,
+# a few dozen: articles, prepositions, conjunctions, infinitive markers,
+# auxiliaries. This is a bounded linguistic class, not open vocabulary.
+CANNOT_END = {
+    "English": {
+        "a", "an", "the", "to", "of", "in", "on", "at", "for", "with", "from",
+        "by", "about", "into", "onto", "over", "under", "and", "or", "but",
+        "nor", "so", "because", "although", "though", "while", "if", "unless",
+        "until", "since", "that", "which", "who", "whom", "whose", "as",
+        "is", "are", "was", "were", "be", "been", "being", "am", "has", "have",
+        "had", "will", "would", "shall", "should", "can", "could", "may",
+        "might", "must", "do", "does", "did", "my", "your", "his", "her",
+        "its", "our", "their", "some", "any", "every", "each", "this", "these",
+        "those", "very", "more", "most", "than", "then", "when", "where",
+    },
+    "Spanish": {
+        "el", "la", "los", "las", "un", "una", "unos", "unas", "de", "del",
+        "a", "al", "en", "con", "por", "para", "sin", "sobre", "entre", "hasta",
+        "desde", "y", "o", "pero", "porque", "aunque", "si", "que", "cuando",
+        "como", "mi", "tu", "su", "nuestro", "es", "son", "era", "ser", "estar",
+        "está", "están", "he", "ha", "han", "muy", "más", "menos",
+    },
+    "French": {
+        "le", "la", "les", "un", "une", "des", "de", "du", "au", "aux", "à",
+        "en", "dans", "sur", "avec", "pour", "sans", "par", "entre", "chez",
+        "et", "ou", "mais", "car", "parce", "que", "si", "quand", "comme",
+        "mon", "ton", "son", "notre", "votre", "leur", "est", "sont", "était",
+        "être", "avoir", "a", "ai", "ont", "très", "plus", "moins",
+    },
+    "German": {
+        "der", "die", "das", "den", "dem", "des", "ein", "eine", "einen",
+        "einem", "einer", "eines", "und", "oder", "aber", "weil", "obwohl",
+        "wenn", "dass", "als", "wie", "in", "an", "auf", "mit", "von", "zu",
+        "für", "über", "unter", "bei", "nach", "vor", "durch", "ohne", "um",
+        "ist", "sind", "war", "waren", "sein", "haben", "hat", "hatte", "wird",
+        "werden", "kann", "können", "muss", "sehr", "mehr",
+    },
+    "Italian": {
+        "il", "lo", "la", "i", "gli", "le", "un", "uno", "una", "di", "del",
+        "della", "a", "al", "alla", "in", "nel", "con", "per", "su", "tra",
+        "fra", "da", "e", "o", "ma", "perché", "anche", "se", "che", "quando",
+        "come", "mio", "tuo", "suo", "nostro", "è", "sono", "era", "essere",
+        "avere", "ha", "hanno", "molto", "più",
+    },
+    "Portuguese": {
+        "o", "a", "os", "as", "um", "uma", "uns", "umas", "de", "do", "da",
+        "dos", "das", "em", "no", "na", "com", "por", "para", "sem", "sobre",
+        "entre", "até", "desde", "e", "ou", "mas", "porque", "embora", "se",
+        "que", "quando", "como", "meu", "teu", "seu", "nosso", "é", "são",
+        "era", "ser", "estar", "está", "tem", "têm", "muito", "mais",
+    },
+    "Polish": {
+        "i", "oraz", "albo", "lub", "ale", "bo", "że", "aby", "żeby", "jeśli",
+        "gdy", "kiedy", "jak", "w", "we", "na", "do", "od", "za", "przez",
+        "dla", "o", "z", "ze", "po", "pod", "nad", "przy", "bez", "jest",
+        "są", "był", "była", "być", "ma", "mają", "bardzo", "więcej",
+    },
+    "Dutch": {
+        "de", "het", "een", "van", "in", "op", "aan", "met", "voor", "door",
+        "over", "onder", "bij", "naar", "uit", "om", "te", "en", "of", "maar",
+        "want", "omdat", "hoewel", "als", "dat", "die", "wanneer", "hoe",
+        "mijn", "jouw", "zijn", "haar", "onze", "is", "zijn", "was", "waren",
+        "heeft", "hebben", "had", "kan", "kunnen", "moet", "zeer", "meer",
+    },
+}
+
+
+def last_word(text):
+    words = re.findall(r"[^\W\d_]+", text, flags=re.UNICODE)
+    return words[-1].lower() if words else ""
+
+
+def merge_text(r1, r2):
+    """Join, dropping recording 1's terminal punctuation and lowering
+    recording 2's leading capital. Spacing normalized to a single space."""
+    left = r1.strip()
+    left = re.sub(r"[.!?]+$", "", left).rstrip()
+    right = r2.strip()
+    if right and right[0].isupper():
+        first = right.split()[0] if right.split() else ""
+        bare = first.rstrip(".,!?;:")
+        # Leave acronyms and mixed-case tokens alone (CI, OpenAI).
+        if not (len(bare) > 1 and any(c.isupper() for c in bare[1:])) and not bare.isupper():
+            right = right[0].lower() + right[1:]
+    return f"{left} {right}"
+
+
+def keep_text(r1, r2):
+    """Keep the boundary, but normalize it: recording 1 gets a terminal period if
+    it has none (or a comma), recording 2 keeps its capital, single space."""
+    left = r1.strip()
+    left = re.sub(r"[,;:]+$", "", left).rstrip()
+    if not left.endswith(TERMINATORS):
+        left += "."
+    right = r2.strip()
+    if right and right[0].islower():
+        right = right[0].upper() + right[1:]
+    return f"{left} {right}"
+
+
+def decide(r1, r2, language, mode):
+    stripped = r1.strip()
+    unterminated = not stripped.endswith(TERMINATORS)
+    lw = last_word(stripped)
+    cannot_end = lw in CANNOT_END.get(language, set())
+    if mode == "right":
+        return unterminated
+    if mode == "left":
+        return cannot_end
+    if mode == "combined":
+        return unterminated or cannot_end
+    raise ValueError(mode)
+
+
+def main():
+    rows = list(csv.DictReader(open(CSV_PATH, encoding="utf-8-sig")))
+    modes = ["today", "right", "left", "combined"]
+    agg = {m: defaultdict(lambda: {"n": 0, "dec": 0, "exact": 0, "wrong_merge": 0}) for m in modes}
+
+    for r in rows:
+        r1, r2 = r["recording_1"], r["recording_2"]
+        want_merge = r["expected_action"] == "MERGE"
+        gold = r["expected_output"].strip()
+        lang, diff = r["language"], r["difficulty"]
+        hard_half = r1.strip().endswith(TERMINATORS)
+
+        for mode in modes:
+            if mode == "today":
+                merged = False
+                got = f"{r1.strip()} {r2.strip()}"
+            else:
+                merged = decide(r1, r2, lang, mode)
+                got = merge_text(r1, r2) if merged else keep_text(r1, r2)
+            for bucket in ("ALL", lang, f"difficulty:{diff}", "half:hard" if hard_half else "half:easy"):
+                s = agg[mode][bucket]
+                s["n"] += 1
+                s["dec"] += int(merged == want_merge)
+                s["exact"] += int(got.strip() == gold)
+                if merged and not want_merge:
+                    s["wrong_merge"] += 1
+
+    def show(buckets, title):
+        print(f"\n{title}")
+        print(f"{'bucket':22} " + " ".join(f"{m:>22}" for m in modes))
+        print("-" * (22 + 23 * len(modes)))
+        for b in buckets:
+            cells = []
+            for m in modes:
+                s = agg[m][b]
+                if not s["n"]:
+                    cells.append(f"{'-':>22}")
+                    continue
+                cells.append(
+                    f"{100*s['dec']/s['n']:5.1f}%dec {100*s['exact']/s['n']:5.1f}%ex"
+                )
+            print(f"{b:22} " + " ".join(f"{c:>22}" for c in cells))
+
+    show(["ALL", "half:easy", "half:hard"], "OVERALL and by half (dec = merge/keep decision, ex = exact text)")
+    show([f"difficulty:{d}" for d in ("easy", "medium", "hard")], "By difficulty")
+    show(sorted({r["language"] for r in rows}), "By language")
+
+    print("\nWRONG MERGES (corrupt correct text) out of 100 KEEP_BOUNDARY cases:")
+    for m in modes:
+        print(f"  {m:10} {agg[m]['ALL']['wrong_merge']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/build_seam_corpus.py
+++ b/research/seam-joining/code/build_seam_corpus.py
@@ -1,0 +1,167 @@
+"""Build a broad seam-testing corpus from the founder's real dictations.
+
+Founder's idea, 2026-07-25: take real dictations, split them at natural pause
+points, and re-join them. The original dictation IS the gold answer, so ground
+truth comes free and no hand-labelling is needed.
+
+Two properties make this corpus self-balancing:
+
+  * Split MID-CLAUSE ("...going to | the store") and the gold answer has no
+    period and no capital at the seam, so the joiner MUST merge.
+  * Split at a REAL sentence boundary ("...it works. | We should ship") and the
+    gold answer keeps both, so the joiner MUST NOT merge. Negatives are
+    generated automatically rather than invented.
+  * Where the second half legitimately begins with a proper noun, gold keeps the
+    capital, so "do not lowercase this" cases appear for free too.
+
+The corruption applied at each seam mimics what the transcriber actually does.
+That distribution is MEASURED from the real multi-take seams in today's app log,
+not guessed - see `observed_seam_stats`.
+
+PRIVACY: the source is the gitignored private corpus of real dictations. Output
+stays in the scratchpad and must never be committed.
+"""
+
+import json
+import os
+import random
+import re
+import sys
+
+CORPUS = (
+    os.path.expanduser(
+        "~/Developer/EnviousLabs/EnviousWispr/scripts/eval/corpus/corpus.jsonl")
+)
+LOG = os.path.expanduser("~/Library/Logs/EnviousWispr/app.log")
+
+# Words that, appearing at a split point, mark a natural mid-thought pause. A
+# speaker resuming after a breath very often resumes right here.
+RESUME_AFTER = {
+    "to", "and", "but", "so", "or", "for", "with", "that", "the", "a", "an",
+    "because", "if", "when", "while", "of", "in", "on", "at", "from", "about",
+    "we", "you", "it", "is", "was", "then", "than", "into", "over", "after",
+}
+
+TEST_ARTIFACT = re.compile(r"quick brown fox|testing one|test one two|lazy dog", re.I)
+TERMINATORS = (".", "!", "?")
+
+
+def observed_seam_stats():
+    """Measure, from the real log, how often the transcriber adds a terminal
+    full stop to a take and capitalises the next one."""
+    import datetime
+
+    recs = []
+    for ln in open(LOG, errors="replace"):
+        m = re.match(r"\[(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})[^\]]*\].*\[RAW ASR\] (.*)$", ln)
+        if not m:
+            continue
+        d, t, txt = m.groups()
+        if d != "2026-07-25":
+            continue
+        recs.append((datetime.datetime.fromisoformat(f"{d}T{t}"), txt.strip()))
+    recs.sort(key=lambda r: r[0])
+
+    period = capital = seams = 0
+    for (t1, a), (t2, b) in zip(recs, recs[1:]):
+        gap = (t2 - t1).total_seconds()
+        if not (0 < gap <= 8):  # a genuine mid-thought resume, not a new topic
+            continue
+        if TEST_ARTIFACT.search(a) or TEST_ARTIFACT.search(b):
+            continue
+        if not a or not b:
+            continue
+        seams += 1
+        period += a.rstrip().endswith(TERMINATORS)
+        capital += b[0].isupper()
+    return {
+        "seams": seams,
+        "period_rate": period / seams if seams else 0,
+        "capital_rate": capital / seams if seams else 0,
+    }
+
+
+def split_points(text):
+    """Yield (index, kind) split positions in a word list."""
+    words = text.split()
+    for i in range(2, len(words) - 2):
+        prev = words[i - 1]
+        bare = prev.rstrip(".,!?;:").lower()
+        if prev.rstrip().endswith(TERMINATORS):
+            yield i, "sentence_boundary"  # must NOT be merged
+        elif bare in RESUME_AFTER:
+            yield i, "mid_clause"  # must be merged
+
+
+def corrupt(left, right, add_period, capitalise):
+    """Apply what the transcriber does when a recording is split in two.
+
+    A trailing comma is LEFT ALONE rather than replaced by a full stop. That is
+    what the real transcriber does - the log shows "...and after that," keeping
+    its comma - and replacing it would also destroy information the joiner has no
+    way to restore, making the case unwinnable by construction rather than by
+    any defect in the joiner.
+    """
+    stripped = left.rstrip()
+    if add_period and not stripped.endswith(TERMINATORS) and not stripped.endswith((",", ";", ":")):
+        left = stripped + "."
+    if capitalise and right and right[0].islower():
+        right = right[0].upper() + right[1:]
+    return left, right
+
+
+def main():
+    stats = observed_seam_stats()
+    print(f"measured from real seams: {stats}", file=sys.stderr)
+
+    rows = [json.loads(l) for l in open(CORPUS)]
+    rng = random.Random(1785)  # fixed seed: the corpus must be reproducible
+
+    cases = []
+    for row in rows:
+        text = (row.get("asr_input") or "").strip()
+        if len(text.split()) < 12 or TEST_ARTIFACT.search(text):
+            continue
+        points = list(split_points(text))
+        if not points:
+            continue
+        # Two split points per dictation keeps the corpus varied without
+        # letting one long dictation dominate.
+        for idx, kind in rng.sample(points, min(2, len(points))):
+            words = text.split()
+            left, right = " ".join(words[:idx]), " ".join(words[idx:])
+            if not left or not right:
+                continue
+            # All four corruption combinations, so accuracy can be reported per
+            # combination instead of hidden inside one sampled average.
+            for add_period in (False, True):
+                for capitalise in (False, True):
+                    cl, cr = corrupt(left, right, add_period, capitalise)
+                    cases.append(
+                        {
+                            "id": f"{row['id'][:8]}-{idx}-{int(add_period)}{int(capitalise)}",
+                            "kind": kind,
+                            "should_merge": kind == "mid_clause",
+                            "add_period": add_period,
+                            "capitalise": capitalise,
+                            "left": cl,
+                            "right": cr,
+                            "today": f"{cl} {cr}",
+                            "gold": text,
+                        }
+                    )
+
+    out = "seam_corpus.jsonl"
+    with open(out, "w") as fh:
+        for c in cases:
+            fh.write(json.dumps(c) + "\n")
+
+    merge = sum(c["should_merge"] for c in cases)
+    print(f"wrote {out}: {len(cases)} cases from {len(rows)} dictations")
+    print(f"  should merge (mid-clause):     {merge}")
+    print(f"  must NOT merge (real boundary): {len(cases) - merge}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/calibrate_grader.py
+++ b/research/seam-joining/code/calibrate_grader.py
@@ -1,0 +1,174 @@
+"""Measure the grader before trusting it to label anything.
+
+A grader that labels real seams becomes the ground truth for the ship decision,
+so an unmeasured one is worse than none: it would quietly define success as
+"agrees with a model nobody checked". The first ten real pairs came back with
+"Yeah, I pushed to GitHub." + "Yes, push to GitHub." marked as one sentence,
+which is plainly wrong, so the prompt needed work and the work needed a scale.
+
+The held-out synthetic set has known labels. Running the grader on it measures
+exactly the thing that matters: does it over-merge? Over-merging is fatal here,
+because a grader biased toward JOIN would mark real wrong merges as correct and
+hide the only failure that disqualifies the feature.
+
+Compares prompt variants on the same rows so a change is an improvement rather
+than a different set of mistakes.
+"""
+
+import argparse
+import json
+import os
+import random
+import re
+import sys
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+
+BASE = """A person is dictating with speech-to-text. They spoke once, paused, then spoke again. Each recording was transcribed separately, so the software added a capital letter and a full stop to each one whether or not the thought was actually finished.
+
+Recording 1: {rec1}
+Recording 2: {rec2}
+
+Did they finish a thought and start a new one, or was this one thought interrupted by a pause?
+
+Answer with exactly one word:
+SEPARATE - two distinct thoughts, they should stay as two sentences
+JOIN - one thought split by the pause, the second continues the first
+COMMA - one thought split by the pause, and the join reads best with a comma
+
+Answer:"""
+
+STRICT = """A person dictated, paused, then dictated again. Each recording was transcribed on its own, so the software may have added a capital letter and a full stop to the first one even if the thought was not finished.
+
+Recording 1: {rec1}
+Recording 2: {rec2}
+
+Decide whether these are one sentence or two.
+
+The test is grammatical, not topical. Two fragments about the same subject are still two sentences. Ask: would a careful writer have written this as ONE sentence?
+
+Answer SEPARATE when both halves stand on their own as complete sentences, even if they are closely related, sequential, part of the same story, or the second one restates, corrects or contradicts the first.
+
+Answer JOIN only when the first half is grammatically incomplete without the second, so reading them as one sentence is clearly more natural than reading them as two. Typically the first half ends mid-clause, on a preposition, conjunction, article, or an unfinished verb phrase.
+
+Answer COMMA in the same situation as JOIN, but where the joined sentence reads best with a comma at the seam.
+
+When in doubt, answer SEPARATE.
+
+Answer with exactly one word.
+
+Answer:"""
+
+# Hand-checked correction. Reading the flagged cases showed one class the strict
+# rule got wrong every time: a second recording opening with a linking word
+# ("or", "and", "so", "but"). In speech that almost always CONTINUES the thought
+# after a pause — "Did you fix the GitHub problem?" + "Or is that still
+# pending?" is one question, not two. The strict rule called all 74 such cases
+# separate; a careful pass flipped 35 of them. Without this clause the grader
+# blames the model for joins it got right.
+LINKED = STRICT.replace(
+    "When in doubt, answer SEPARATE.",
+    """SPECIAL CASE, and it is common. If the second recording opens with a linking word (or, and, so, but, also, because, which, that), it usually CONTINUES the first thought rather than starting a new one, and the answer is usually COMMA. Read the two halves aloud as one sentence: if that reads naturally, it is one sentence.
+  "Did you just implement a fix for the GitHub problem?" + "Or is that still pending?" -> COMMA
+  "Is this a rebuild over CI tests?" + "Or was this a simplification?" -> COMMA
+Answer SEPARATE for such a pair only when the second half is a genuinely new point that merely happens to start with a linking word, so joining them would read as a rambling run-on.
+
+When in doubt on anything else, answer SEPARATE.""")
+
+PROMPTS = {"strict": STRICT, "linked": LINKED}
+LABEL_FROM_WORD = {"SEPARATE": "KEEP", "JOIN": "MERGE_SPACE", "COMMA": "MERGE_COMMA"}
+
+
+def grade(client, model, template, pair):
+    """Return (label, failure). A silent None here would be a fabricated result:
+    the first run of this file dropped 80 of 150 answers and still printed
+    confident percentages."""
+    for attempt in range(4):
+        try:
+            response = client.messages.create(
+                model=model, max_tokens=8, temperature=0,
+                messages=[{"role": "user", "content": template.format(
+                    rec1=pair["rec1"].strip(), rec2=pair["rec2"].strip())}])
+        except Exception as exc:
+            name = type(exc).__name__
+            if "Throttl" in name or "TooManyRequests" in name or "429" in str(exc):
+                time.sleep(1.5 * (attempt + 1))
+                continue
+            return None, f"api:{name}"
+        text = response.content[0].text
+        word = re.sub(r"[^A-Z]", "", text.upper())
+        for key, label in LABEL_FROM_WORD.items():
+            if word.startswith(key[:4]):
+                return label, None
+        return None, f"parse:{text.strip()[:24]!r}"
+    return None, "api:throttled-out"
+
+
+def report(name, results, rows):
+    preds = [r[0] for r in results]
+    failures = [r[1] for r in results if r[1]]
+    if failures:
+        print(f"  {name:8} {len(failures)}/{len(rows)} FAILED: "
+              f"{dict(Counter(failures).most_common(3))}")
+    pairs = [(p, r["label"]) for p, r in zip(preds, rows) if p]
+    if not pairs:
+        print(f"  {name}: no usable answers")
+        return
+    if len(pairs) < 0.9 * len(rows):
+        print(f"  {name:8} REFUSING to score: only {len(pairs)}/{len(rows)} answered")
+        return
+    correct = sum(1 for p, t in pairs if p == t)
+    # The fatal direction: truth is KEEP, grader says merge.
+    keeps = [(p, t) for p, t in pairs if t == "KEEP"]
+    over = sum(1 for p, _ in keeps if p != "KEEP")
+    merges = [(p, t) for p, t in pairs if t != "KEEP"]
+    under = sum(1 for p, _ in merges if p == "KEEP")
+    # Treating the two merge kinds as one, since the seam decision is what matters.
+    binary = sum(1 for p, t in pairs if (p == "KEEP") == (t == "KEEP"))
+    print(f"  {name:8} exact {100*correct/len(pairs):5.1f}%   "
+          f"join-or-not {100*binary/len(pairs):5.1f}%   "
+          f"OVER-merges {over:>3}/{len(keeps):<3}   under-merges {under:>3}/{len(merges)}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=150)
+    ap.add_argument("--model", default="us.anthropic.claude-haiku-4-5-20251001-v1:0")
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--lang", default="English")
+    args = ap.parse_args()
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    rows = [json.loads(l) for l in
+            open(os.path.join(root, "data", "seam_test_shared.jsonl"), encoding="utf-8")]
+    rows = [r for r in rows if r.get("language") == args.lang]
+    # Stratify. The natural mix is ~11% KEEP, so 150 unstratified rows carry
+    # about 11 of the ONE class that measures the fatal direction. Balance it
+    # so the over-merge denominator is big enough to mean anything.
+    rng = random.Random(1790)
+    keeps = [r for r in rows if r["label"] == "KEEP"]
+    merges = [r for r in rows if r["label"] != "KEEP"]
+    rng.shuffle(keeps); rng.shuffle(merges)
+    half = args.limit // 2
+    rows = keeps[:half] + merges[: args.limit - min(half, len(keeps))]
+    rng.shuffle(rows)
+    print(f"calibrating on {len(rows)} {args.lang} rows with KNOWN labels: "
+          f"{dict(Counter(r['label'] for r in rows))}", file=sys.stderr)
+
+    from anthropic import AnthropicBedrock
+    client = AnthropicBedrock(
+        aws_access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        aws_region="us-east-1")
+
+    print("\n  (over-merges is the fatal direction: grader calls a real boundary a join)")
+    for name, template in PROMPTS.items():
+        with ThreadPoolExecutor(max_workers=args.workers) as pool:
+            results = list(pool.map(lambda p: grade(client, args.model, template, p), rows))
+        report(name, results, rows)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/compare_join_notes.py
+++ b/research/seam-joining/code/compare_join_notes.py
@@ -1,0 +1,148 @@
+"""The polisher rewrote the founder's sentence into something he never said.
+
+Live, 2026-07-25, on his own dictation:
+
+    in   It now passes ten. Dictated chunks in a row, cleanly.
+    out  It is now past ten.
+
+It read "passes ten" as a time of day and discarded the rest — ten words in,
+five out. The word-loss guard refused it and his text survived, but a guard
+catching a destructive rewrite is the last line, not the fix. This is the real
+risk in re-polishing at the seam, and it is far more dangerous than merging two
+sentences that should have stayed apart.
+
+So: does a stricter instruction stop it, WITHOUT breaking the joins that already
+work? Both halves matter. An instruction that never destroys anything and also
+never joins anything is worthless.
+
+Run over the pairs verified clean in `selftest_chunks.py` plus the failure. Any
+candidate must fix the failure and keep every good join.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import join_hotkey as J  # noqa: E402
+
+# (first chunk, second chunk, what should happen)
+CASES = [
+    ("It now passes ten.", "Dictated chunks in a row, cleanly.", "join"),
+    ("I was thinking about the release.", "And how we should stage it.", "join"),
+    ("The tests are still red.", "So we cannot ship today.", "join"),
+    ("Can you take a look.", "When you get a chance.", "join"),
+    ("I will send you the notes.", "After the meeting ends.", "join"),
+    ("We should probably tell the team.", "Before anyone else finds out.", "join"),
+    ("I was thinking about the release and how we should stage it.",
+     "The tests are still red.", "leave"),
+    ("Can you take a look when you get a chance?", "It is not urgent.", "leave"),
+    ("The meeting went well.", "I'll send notes tomorrow.", "leave"),
+]
+
+# A candidate is a whole system prompt. Until now every one of them was the
+# shipped polish prompt with a joining instruction bolted on, and that prompt
+# actively works against the task: it tells the model to break run-on speech
+# into SEPARATE sentences while the appendix asks it to JOIN them, and it
+# explicitly licenses "obvious speech-to-text slips fixed when the intended word
+# is clear from context" — which is precisely the clause that rewrote the
+# founder's "It now passes ten" as "It is now past ten". The narrow prompt has
+# never been tried, and it is the one most likely to survive a small on-device
+# model, which will follow a page of editing instructions if given a page.
+NARROW = """\
+You are given two pieces of dictated text. The FIRST was spoken a moment ago \
+and is already in the user's document. The SECOND was just spoken, after a pause.
+
+Decide one thing: are these one thought that a pause split in half, or two \
+separate thoughts?
+
+If ONE thought, return them as a single sentence. You may only remove the full \
+stop between them, lowercase the first word of the second half, and drop a \
+connecting word that joining has made redundant.
+
+If TWO thoughts, return both pieces exactly as they were given to you, \
+unchanged.
+
+You are not an editor. Do not fix, improve, rephrase, shorten, or reinterpret \
+anything. Do not correct a word that looks like a mishearing. Every word given \
+to you appears in your answer. Return only the text, with no comment."""
+
+
+def with_shipped(note):
+    return ("shipped-polish", note)
+
+
+CANDIDATES = {
+    "shipped polish + loose join": ("shipped", J.JOIN_NOTE.replace(
+        " Never drop a word, never replace a word with a different word, and "
+        "never reinterpret what was said. Every word of the transcript must "
+        "appear in your answer unless joining the two halves makes a "
+        "connecting word redundant.", "")),
+    "shipped polish + strict join": ("shipped", J.JOIN_NOTE),
+    "narrow prompt, no polish": ("narrow", NARROW),
+}
+
+
+def words(text):
+    return [w.lower() for w in re.findall(r"[A-Za-z']+", text)]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="us.anthropic.claude-haiku-4-5-20251001-v1:0")
+    args = parser.parse_args()
+
+    from anthropic import AnthropicBedrock
+    client = AnthropicBedrock(
+        aws_access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        aws_region="us-east-1")
+
+    repo = os.path.expanduser("~/Developer/EnviousLabs/EnviousWispr")
+    swift = os.path.join(repo,
+                         "Sources/EnviousWisprLLM/Prompting/CloudFixedPromptBuilder.swift")
+    base = re.search(r'cloudFixedSystemPrompt = """\n(.*?)\n\s*"""',
+                     open(swift, encoding="utf-8").read(), re.DOTALL).group(1)
+
+    for name, note in CANDIDATES.items():
+        print(f"\n=== {name}")
+        wrong = 0
+        for first, second, want in CASES:
+            source = f"{first} {second}"
+            try:
+                response = client.messages.create(
+                    model=args.model, max_tokens=600, temperature=0,
+                    system=base + note,
+                    messages=[{"role": "user",
+                               "content": f"Transcript to clean:\n\n{source}"}])
+                out = response.content[0].text.strip()
+            except Exception as exc:
+                print(f"  [{type(exc).__name__}] {source}")
+                wrong += 1
+                continue
+
+            lost = [w for w in words(source) if w not in words(out)]
+            joined = out.strip() != source.strip()
+            # A dropped connecting word is legitimate when joining; losing a
+            # third of the sentence is the failure this exists to catch.
+            destroyed = len(lost) > 2
+
+            if destroyed:
+                verdict = f"DESTROYED  lost {lost}"
+            elif want == "join" and not joined:
+                verdict = "MISSED     left it as two"
+            elif want == "leave" and joined:
+                verdict = "OVERMERGED joined two separate thoughts"
+            else:
+                verdict = "ok"
+
+            if verdict != "ok":
+                wrong += 1
+            print(f"  {verdict:34} {out}")
+        print(f"  --> {len(CASES) - wrong}/{len(CASES)} correct")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/compare_join_notes.py
+++ b/research/seam-joining/code/compare_join_notes.py
@@ -24,6 +24,8 @@ import os
 import re
 import sys
 
+from seam_verdict import was_joined
+
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import join_hotkey as J  # noqa: E402
 
@@ -119,11 +121,9 @@ def main():
                 continue
 
             lost = [w for w in words(source) if w not in words(out)]
-            # Both halves arrive terminated, so the input always holds two
-            # sentence-final marks. One left means the boundary went; two
-            # means it did not, however much else was edited. Comparing
-            # against the source counted a casing tweak as a join.
-            joined = sum(out.count(c) for c in ".!?") < 2
+            joined = was_joined(first, second, out)  # seam_verdict.py
+            if joined is None:
+                joined = False  # a rewrite that heavy is not a join
             # A dropped connecting word is legitimate when joining; losing a
             # third of the sentence is the failure this exists to catch.
             destroyed = len(lost) > 2

--- a/research/seam-joining/code/compare_join_notes.py
+++ b/research/seam-joining/code/compare_join_notes.py
@@ -69,10 +69,6 @@ anything. Do not correct a word that looks like a mishearing. Every word given \
 to you appears in your answer. Return only the text, with no comment."""
 
 
-def with_shipped(note):
-    return ("shipped-polish", note)
-
-
 CANDIDATES = {
     "shipped polish + loose join": ("shipped", J.JOIN_NOTE.replace(
         " Never drop a word, never replace a word with a different word, and "
@@ -105,7 +101,7 @@ def main():
     base = re.search(r'cloudFixedSystemPrompt = """\n(.*?)\n\s*"""',
                      open(swift, encoding="utf-8").read(), re.DOTALL).group(1)
 
-    for name, note in CANDIDATES.items():
+    for name, (kind, note) in CANDIDATES.items():
         print(f"\n=== {name}")
         wrong = 0
         for first, second, want in CASES:
@@ -113,7 +109,7 @@ def main():
             try:
                 response = client.messages.create(
                     model=args.model, max_tokens=600, temperature=0,
-                    system=base + note,
+                    system=(base + note) if kind == "shipped" else note,
                     messages=[{"role": "user",
                                "content": f"Transcript to clean:\n\n{source}"}])
                 out = response.content[0].text.strip()
@@ -123,7 +119,11 @@ def main():
                 continue
 
             lost = [w for w in words(source) if w not in words(out)]
-            joined = out.strip() != source.strip()
+            # Both halves arrive terminated, so the input always holds two
+            # sentence-final marks. One left means the boundary went; two
+            # means it did not, however much else was edited. Comparing
+            # against the source counted a casing tweak as a join.
+            joined = sum(out.count(c) for c in ".!?") < 2
             # A dropped connecting word is legitimate when joining; losing a
             # third of the sentence is the failure this exists to catch.
             destroyed = len(lost) > 2

--- a/research/seam-joining/code/compare_models.py
+++ b/research/seam-joining/code/compare_models.py
@@ -1,0 +1,112 @@
+"""Compare every trained seam model PER LANGUAGE, across seeds.
+
+Founder point 2026-07-25: the English winner and the international winner may not
+be the same model. English is 598 of the 879 held-out rows - 68% - so an
+aggregate score is dominated by it and can hide a model that is worse in German
+or Russian. Aggregates are reported last, and only for context.
+
+Two numbers per language, because they answer different questions:
+  wrong merges - two separate sentences welded together. Silent damage. The
+                 number that decides whether something is shippable.
+  accuracy     - all three labels correct. Quality, not safety.
+"""
+
+import json
+import os
+import sys
+from collections import defaultdict
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+SEAM = "<seam>"
+
+
+def score(model_dir, rows):
+    tok = AutoTokenizer.from_pretrained(model_dir)
+    model = AutoModelForSequenceClassification.from_pretrained(model_dir)
+    model.eval()
+    if torch.cuda.is_available():
+        model.cuda()
+
+    per = defaultdict(lambda: {"n": 0, "correct": 0, "keep_n": 0, "wrong_merge": 0})
+    batch = 64
+    for i in range(0, len(rows), batch):
+        chunk = rows[i : i + batch]
+        texts = [
+            f"{' '.join(r['rec1'].split()[-18:])} {SEAM} {' '.join(r['rec2'].split()[:14])}"
+            for r in chunk
+        ]
+        enc = tok(texts, truncation=True, max_length=96, padding=True, return_tensors="pt")
+        if torch.cuda.is_available():
+            enc = {k: v.cuda() for k, v in enc.items()}
+        with torch.no_grad():
+            pred = model(**enc).logits.argmax(-1).tolist()
+        for r, p in zip(chunk, pred):
+            lab = LABELS[p]
+            s = per[r["language"]]
+            s["n"] += 1
+            s["correct"] += int(lab == r["label"])
+            if r["label"] == "KEEP":
+                s["keep_n"] += 1
+                s["wrong_merge"] += int(lab != "KEEP")
+    del model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return per
+
+
+def main():
+    rows = [json.loads(l) for l in open("seam_test.jsonl", encoding="utf-8")]
+    dirs = [d for d in sorted(os.listdir(".")) if d.startswith("seam-") and os.path.isdir(d)]
+    if len(sys.argv) > 1:
+        dirs = [d for d in dirs if any(a in d for a in sys.argv[1:])]
+
+    langs = sorted({r["language"] for r in rows})
+    results = {}
+    for d in dirs:
+        try:
+            results[d] = score(d, rows)
+        except Exception as exc:
+            print(f"{d}: skipped ({type(exc).__name__})", flush=True)
+
+    print("\nWRONG MERGES BY LANGUAGE  (silent damage - lower is better)")
+    head = f"{'model':26}" + "".join(f"{l:>12}" for l in langs) + f"{'TOTAL':>8}"
+    print(head)
+    print("-" * len(head))
+    for d, per in results.items():
+        cells = ""
+        tot = 0
+        for l in langs:
+            s = per.get(l)
+            if not s or not s["keep_n"]:
+                cells += f"{'-':>12}"
+                continue
+            cells += f"{s['wrong_merge']:>6}/{s['keep_n']:<5}"
+            tot += s["wrong_merge"]
+        print(f"{d:26}{cells}{tot:>8}")
+
+    print("\nACCURACY BY LANGUAGE")
+    print(head)
+    print("-" * len(head))
+    for d, per in results.items():
+        cells = ""
+        cor = n = 0
+        for l in langs:
+            s = per.get(l)
+            if not s or not s["n"]:
+                cells += f"{'-':>12}"
+                continue
+            cells += f"{100*s['correct']/s['n']:>11.1f}%"
+            cor += s["correct"]
+            n += s["n"]
+        print(f"{d:26}{cells}{100*cor/max(n,1):>7.1f}%")
+
+    print("\nNOTE: English is 68% of the rows, so the TOTAL column is mostly English.")
+    print("Read the per-language columns before picking a winner.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/compare_noterminator.py
+++ b/research/seam-joining/code/compare_noterminator.py
@@ -1,0 +1,120 @@
+"""Who should judge a recording that ends WITHOUT a full stop?
+
+Founder question, 2026-07-25. Two systems can answer it, so the plan has to say
+which one does, and "the simple rule is provably right here" turns out to be
+false: across all three sets, 8-14% of no-terminator rows are genuinely
+separate thoughts. A missing full stop is evidence, not proof.
+
+This scores both deciders on exactly that subset:
+
+  rule   #1785's deterministic certificate — no terminal punctuation, or a
+         final closed-class word that cannot end a sentence, means merge
+  model  the seam classifier, which saw no-terminator examples in training
+         (assemble_dataset.py leaves the terminator off 10% of the time)
+
+Reported separately because the two disagree in the direction that matters:
+a wrong merge welds two of the user's sentences together and is silent.
+"""
+
+import json
+import os
+import sys
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+SEAM = "<seam>"
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+MODEL = os.path.join(ROOT, "model", "seam-legacy-view")
+
+TERMINATORS = (".", "!", "?")
+
+# The REAL closed-class lists the deterministic arm uses, per language, not a
+# re-implementation. A hand-copied mirror measures a second implementation
+# against itself (validation-discipline.md
+# RULE: measure-with-the-real-tool-never-a-simulation).
+from bench_options import CANNOT_END  # noqa: E402
+
+
+def window(row):
+    left = " ".join(row["rec1"].split()[-18:])
+    right = " ".join(row["rec2"].split()[:14])
+    return f"{left} {SEAM} {right}"
+
+
+def rule_predict(row):
+    """#1785's arm, both certificates, using each row's own language list."""
+    stripped = row["rec1"].strip()
+    words = [w.strip(".,!?;:\"'()").lower() for w in stripped.split()]
+    closed = CANNOT_END.get(row.get("language", "English"), set())
+    if not stripped.endswith(TERMINATORS):
+        return "MERGE_SPACE"
+    if words and words[-1] in closed:
+        return "MERGE_SPACE"
+    return "KEEP"
+
+
+def rule_predict_safe_half(row):
+    """The same rule with the no-punctuation certificate REMOVED.
+
+    That certificate is the one under test: it claims a missing full stop
+    proves the thought was unfinished. If dropping it removes the wrong merges
+    without costing much, the fallback should ship without it.
+    """
+    stripped = row["rec1"].strip()
+    words = [w.strip(".,!?;:\"'()").lower() for w in stripped.split()]
+    closed = CANNOT_END.get(row.get("language", "English"), set())
+    if words and words[-1] in closed:
+        return "MERGE_SPACE"
+    return "KEEP"
+
+
+def model_predict(rows, batch=32):
+    tok = AutoTokenizer.from_pretrained(MODEL)
+    model = AutoModelForSequenceClassification.from_pretrained(MODEL)
+    model.eval()
+    out = []
+    for i in range(0, len(rows), batch):
+        chunk = rows[i : i + batch]
+        enc = tok([window(r) for r in chunk], truncation=True, max_length=96,
+                  padding=True, return_tensors="pt")
+        with torch.no_grad():
+            out.extend(model(**enc).logits.argmax(-1).tolist())
+    return [LABELS[p] for p in out]
+
+
+def score(preds, rows, label):
+    correct = sum(int(p == r["label"]) for p, r in zip(preds, rows))
+    keep_rows = [(p, r) for p, r in zip(preds, rows) if r["label"] == "KEEP"]
+    wrong_merges = sum(1 for p, _ in keep_rows if p != "KEEP")
+    merge_rows = [(p, r) for p, r in zip(preds, rows) if r["label"] != "KEEP"]
+    missed = sum(1 for p, _ in merge_rows if p == "KEEP")
+    print(f"  {label:26} {100*correct/len(rows):5.1f}% correct   "
+          f"{wrong_merges:>3} wrong merges of {len(keep_rows):>3} separate pairs   "
+          f"{missed:>3} joins missed of {len(merge_rows):>3}")
+
+
+def main():
+    for name in ("seam_test.jsonl", "seam_zeroshot.jsonl"):
+        path = os.path.join(ROOT, "data", name)
+        rows = [json.loads(l) for l in open(path, encoding="utf-8")]
+        subset = [r for r in rows if not r["rec1"].rstrip().endswith(TERMINATORS)]
+        if not subset:
+            continue
+        print(f"\n{name}: {len(subset)} rows where the left half has NO full stop")
+        score([rule_predict(r) for r in subset], subset, "rule, both certificates")
+        score([rule_predict_safe_half(r) for r in subset], subset, "rule, safe half only")
+        score(model_predict(subset), subset, "seam classifier")
+
+        # And the complement, so the comparison is not cherry-picked.
+        rest = [r for r in rows if r["rec1"].rstrip().endswith(TERMINATORS)]
+        print(f"  ({len(rest)} rows WITH a full stop, for contrast)")
+        score([rule_predict(r) for r in rest], rest, "rule, both certificates")
+        score(model_predict(rest), rest, "seam classifier")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/convert_coreml.py
+++ b/research/seam-joining/code/convert_coreml.py
@@ -1,0 +1,322 @@
+"""Convert the seam classifier to Core ML and measure what that costs.
+
+This is the plan's central premise, so it is measured rather than asserted: the
+model currently exists only in training format, which cannot ship in a Mac app
+at all. Core ML is the route the speech model already takes.
+
+Three things are measured, each INDEPENDENTLY so one failure cannot discard the
+others (the earlier quantisation script printed everything at the end, so the
+int8 failure took the fp32 and fp16 numbers with it):
+
+  agreement   does the converted model predict what the original predicted?
+              Measured against BOTH test sets, and reported as accuracy and as
+              wrong merges - the number that decides shippability.
+  size        the .mlpackage on disk. This decides bundle-vs-download.
+  latency     single item, on this Mac. Batched numbers flatter the result and
+              do not reflect one dictation ending.
+
+Variants, cheapest reduction first:
+  fp16        Core ML's default weight precision. Halves the file.
+  int8        8-bit linear weight quantisation - the same setting the shipped
+              speech model uses, so it is a proven-shippable precision here.
+  palettized  4-bit lookup-table weights. Roughly quarters it. Genuinely can
+              cost accuracy, so it is measured, never assumed cheap.
+"""
+
+import json
+import os
+import shutil
+import statistics
+import sys
+import time
+
+import numpy as np
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+import coremltools as ct
+from coremltools.converters.mil import Builder as mb
+from coremltools.converters.mil.frontend.torch.ops import _get_inputs
+from coremltools.converters.mil.frontend.torch.torch_op_registry import register_torch_op
+
+
+# The current library builds its attention mask with `new_ones`, which the
+# converter does not know. Pinning older library versions was tried first and
+# turned into a version fight (the tokenizer, then the config, then the dtype),
+# so the op is taught directly instead: one shim, no version roulette.
+@register_torch_op(override=True)
+def new_ones(context, node):
+    inputs = _get_inputs(context, node)
+    result = mb.fill(shape=inputs[1], value=1.0, name=node.name)
+    context.add(result)
+
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+SEAM = "<seam>"
+MAX_LEN = 96
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+SRC = os.path.join(ROOT, "model", "seam-fp16")
+OUT = os.path.join(ROOT, "model")
+
+
+class LogitsOnly(torch.nn.Module):
+    """Core ML wants tensors in and tensors out, not a HuggingFace output object."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, attention_mask):
+        return self.model(input_ids=input_ids, attention_mask=attention_mask).logits
+
+
+def prepare_legacy_dir():
+    """Present the trained model to an older library without copying 547 MB.
+
+    Four conversion attempts all failed inside the CURRENT library's attention
+    and masking code, in four different places: an op the converter lacks, a
+    vectorised higher-order op, a training-dialect program, and a boolean mask
+    combine. That is one class, not four bugs, so the fix is to stop patching
+    ops and stop using that code path. The older library's plain forward has
+    been convertible for years.
+
+    It cannot read the newer save format directly - the config records the
+    weight precision under a key it mis-parses, and the tokenizer records the
+    added seam token as a list where it expects a mapping. Both are metadata,
+    not weights, so a shim directory with corrected metadata and a symlink to
+    the untouched weights is enough. The shipped artifact is never mutated.
+    """
+    legacy = os.path.join(OUT, "seam-legacy-view")
+    os.makedirs(legacy, exist_ok=True)
+    for name in os.listdir(SRC):
+        target = os.path.join(legacy, name)
+        if name.endswith(".safetensors") or name.endswith(".bin"):
+            if not os.path.exists(target):
+                os.symlink(os.path.join(SRC, name), target)
+        elif name not in ("config.json", "tokenizer_config.json"):
+            shutil.copy2(os.path.join(SRC, name), target)
+
+    config = json.load(open(os.path.join(SRC, "config.json")))
+    if "dtype" in config:
+        config["torch_dtype"] = config.pop("dtype")
+    json.dump(config, open(os.path.join(legacy, "config.json"), "w"), indent=2)
+
+    tconfig = json.load(open(os.path.join(SRC, "tokenizer_config.json")))
+    tconfig.pop("extra_special_tokens", None)
+    tconfig["additional_special_tokens"] = [SEAM]
+    json.dump(tconfig, open(os.path.join(legacy, "tokenizer_config.json"), "w"), indent=2)
+    return legacy
+
+
+def load_rows():
+    def read(name):
+        path = os.path.join(ROOT, "data", name)
+        return [json.loads(l) for l in open(path, encoding="utf-8")] if os.path.exists(path) else []
+
+    return read("seam_test.jsonl"), read("seam_zeroshot.jsonl")
+
+
+def window(row):
+    left = " ".join(row["rec1"].split()[-18:])
+    right = " ".join(row["rec2"].split()[:14])
+    return f"{left} {SEAM} {right}"
+
+
+def encode(tok, rows):
+    """One fixed-shape encoding, reused by every variant so the comparison is
+    like-for-like and tokenisation cost never lands in a latency number."""
+    enc = tok([window(r) for r in rows], truncation=True, max_length=MAX_LEN,
+              padding="max_length", return_tensors="np")
+    return (enc["input_ids"].astype(np.int32), enc["attention_mask"].astype(np.int32))
+
+
+def torch_predictions(model, ids, mask, batch=32):
+    out = []
+    with torch.no_grad():
+        for i in range(0, len(ids), batch):
+            logits = model(input_ids=torch.from_numpy(ids[i : i + batch]).long(),
+                           attention_mask=torch.from_numpy(mask[i : i + batch]).long()).logits
+            out.extend(logits.argmax(-1).tolist())
+    return out
+
+
+def coreml_predictions(mlmodel, ids, mask, out_name):
+    out = []
+    for i in range(len(ids)):
+        result = mlmodel.predict({"input_ids": ids[i : i + 1].astype(np.float32),
+                                  "attention_mask": mask[i : i + 1].astype(np.float32)})
+        out.append(int(np.argmax(result[out_name][0])))
+    return out
+
+
+def score(preds, rows):
+    """Accuracy, and wrong merges: a KEEP row the model chose to merge. A wrong
+    merge welds two of the user's sentences together and is invisible until they
+    reread, which is why it is reported separately from accuracy."""
+    correct = sum(int(LABELS[p] == r["label"]) for p, r in zip(preds, rows))
+    wrong_merge = sum(1 for p, r in zip(preds, rows)
+                      if r["label"] == "KEEP" and LABELS[p] != "KEEP")
+    return correct / max(len(rows), 1), wrong_merge
+
+
+def latency(mlmodel, ids, mask, out_name, n=60):
+    samples = []
+    for i in range(min(n, len(ids))):
+        t0 = time.perf_counter()
+        mlmodel.predict({"input_ids": ids[i : i + 1].astype(np.float32),
+                         "attention_mask": mask[i : i + 1].astype(np.float32)})
+        samples.append((time.perf_counter() - t0) * 1000)
+    samples.sort()
+    return statistics.median(samples), samples[int(0.95 * (len(samples) - 1))]
+
+
+def dir_size_mb(path):
+    total = 0
+    for root, _, files in os.walk(path):
+        for f in files:
+            total += os.path.getsize(os.path.join(root, f))
+    return total / 1e6
+
+
+def main():
+    trained_rows, unseen_rows = load_rows()
+    if not trained_rows:
+        print("no test data found", file=sys.stderr)
+        return 1
+
+    source = prepare_legacy_dir()
+    tok = AutoTokenizer.from_pretrained(source)
+    torch_model = AutoModelForSequenceClassification.from_pretrained(
+        source, torch_dtype=torch.float32)
+    torch_model.eval()
+
+    t_ids, t_mask = encode(tok, trained_rows)
+    z_ids, z_mask = encode(tok, unseen_rows) if unseen_rows else (None, None)
+
+    # The reference the converted model must agree with.
+    base_t = torch_predictions(torch_model, t_ids, t_mask)
+    acc, wm = score(base_t, trained_rows)
+    print(f"\nreference (PyTorch, fixed {MAX_LEN}-token shape)")
+    print(f"  trained languages : {100*acc:.1f}% accuracy, {wm} wrong merges, {len(trained_rows)} rows")
+    base_z = None
+    if unseen_rows:
+        base_z = torch_predictions(torch_model, z_ids, z_mask)
+        acc_z, wm_z = score(base_z, unseen_rows)
+        print(f"  unseen languages  : {100*acc_z:.1f}% accuracy, {wm_z} wrong merges, {len(unseen_rows)} rows")
+
+    # Two routes into the converter, tried in order, because they fail in
+    # different places and the working combination depends on library versions:
+    #   export  the documented modern route; needs a torch whose exported
+    #           dialect this converter understands
+    #   trace   the older route; the current library's mask construction lowers
+    #           to `new_ones`, taught above
+    # Whichever succeeds is reported, so the plan can record the real route
+    # rather than an assumed one.
+    example = (torch.from_numpy(t_ids[:1]).long(), torch.from_numpy(t_mask[:1]).long())
+    wrapper = LogitsOnly(torch_model).eval()
+    # The trace route needs the input signature stated; the export route
+    # carries its own and rejects one.
+    traced_inputs = [ct.TensorType(name="input_ids", shape=(1, MAX_LEN), dtype=np.int32),
+                     ct.TensorType(name="attention_mask", shape=(1, MAX_LEN), dtype=np.int32)]
+    routes = []
+    try:
+        # `run_decompositions` lowers the exported program from the TRAINING
+        # dialect the converter refuses to the ATEN dialect it accepts.
+        routes.append(("export", torch.export.export(wrapper, example).run_decompositions({}), None))
+    except Exception as exc:
+        print(f"  export route unavailable: {type(exc).__name__}: {str(exc)[:70]}")
+    try:
+        routes.append(("trace", torch.jit.trace(wrapper, example, strict=False), traced_inputs))
+    except Exception as exc:
+        print(f"  trace route unavailable: {type(exc).__name__}: {str(exc)[:70]}")
+
+    print(f"\n{'variant':14}{'size':>9}{'trained acc':>13}{'wrong':>7}"
+          f"{'unseen acc':>12}{'wrong':>7}{'agree':>8}{'median ms':>11}{'p95 ms':>9}", flush=True)
+    print("-" * 90, flush=True)
+
+    base_model = {}
+
+    def measure(name, build):
+        try:
+            mlmodel, path = build()
+            out_name = list(mlmodel.output_description)[0]
+            preds = coreml_predictions(mlmodel, t_ids, t_mask, out_name)
+            acc, wm = score(preds, trained_rows)
+            agree = sum(int(a == b) for a, b in zip(preds, base_t)) / len(base_t)
+            if unseen_rows:
+                pz = coreml_predictions(mlmodel, z_ids, z_mask, out_name)
+                acc_z, wm_z = score(pz, unseen_rows)
+                agree = (agree * len(base_t) + sum(int(a == b) for a, b in zip(pz, base_z))) / (
+                    len(base_t) + len(base_z))
+            else:
+                acc_z, wm_z = float("nan"), 0
+            med, p95 = latency(mlmodel, t_ids, t_mask, out_name)
+            print(f"{name:14}{dir_size_mb(path):>7.0f}MB{100*acc:>12.1f}%{wm:>7}"
+                  f"{100*acc_z:>11.1f}%{wm_z:>7}{100*agree:>7.1f}%{med:>10.1f}{p95:>9.1f}",
+                  flush=True)
+        except Exception as exc:
+            print(f"{name:14}  FAILED: {type(exc).__name__}: {str(exc)[:60]}", flush=True)
+
+    def fp16():
+        path = os.path.join(OUT, "seam-coreml-fp16.mlpackage")
+        if os.path.exists(path):
+            shutil.rmtree(path)
+        errors = []
+        for route, program, route_inputs in routes:
+            try:
+                kwargs = {"inputs": route_inputs} if route_inputs else {}
+                m = ct.convert(program, convert_to="mlprogram",
+                               compute_precision=ct.precision.FLOAT16,
+                               minimum_deployment_target=ct.target.macOS14,
+                               **kwargs)
+                print(f"  converted via the {route} route", flush=True)
+                m.save(path)
+                base_model["m"] = m
+                return m, path
+            except Exception as exc:
+                errors.append(f"{route}: {type(exc).__name__}: {exc}")
+        for line in errors:
+            print(f"  ROUTE FAILED {line[:400]}", flush=True)
+        raise RuntimeError("no conversion route succeeded")
+
+    def int8():
+        from coremltools.optimize.coreml import (OpLinearQuantizerConfig,
+                                                 OptimizationConfig,
+                                                 linear_quantize_weights)
+        path = os.path.join(OUT, "seam-coreml-int8.mlpackage")
+        if os.path.exists(path):
+            shutil.rmtree(path)
+        cfg = OptimizationConfig(
+            global_config=OpLinearQuantizerConfig(mode="linear_symmetric", dtype="int8"))
+        m = linear_quantize_weights(base_model["m"], config=cfg)
+        m.save(path)
+        return m, path
+
+    def palettized():
+        from coremltools.optimize.coreml import (OpPalettizerConfig,
+                                                 OptimizationConfig,
+                                                 palettize_weights)
+        path = os.path.join(OUT, "seam-coreml-4bit.mlpackage")
+        if os.path.exists(path):
+            shutil.rmtree(path)
+        cfg = OptimizationConfig(
+            global_config=OpPalettizerConfig(mode="kmeans", nbits=4))
+        m = palettize_weights(base_model["m"], config=cfg)
+        m.save(path)
+        return m, path
+
+    measure("fp16", fp16)
+    if "m" in base_model:
+        measure("int8", int8)
+        measure("4-bit palette", palettized)
+    else:
+        print("fp16 conversion failed, so nothing to quantise from", flush=True)
+
+    print("\nLatency is single item on this Mac, which is what a user waits.")
+    print("Agreement is against the PyTorch reference on the same fixed shape.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/eg1_join_test.py
+++ b/research/seam-joining/code/eg1_join_test.py
@@ -125,7 +125,13 @@ def main():
                 continue
 
             lost = [w for w in words(source) if w not in words(out)]
-            joined = out.strip() != source.strip()
+            # Did the BOUNDARY go? Both halves arrive terminated, so the
+            # input always holds two sentence-final marks. One left means
+            # they were welded; two means they were not, however much else
+            # was edited. Scoring on 'anything changed' counted a casing or
+            # punctuation tweak as a successful join. Found by cloud review
+            # on PR #1793.
+            joined = sum(out.count(c) for c in '.!?') < 2
             if len(lost) > 2:
                 verdict = f"DESTROYED  lost {lost}"
             elif want == "join" and not joined:

--- a/research/seam-joining/code/eg1_join_test.py
+++ b/research/seam-joining/code/eg1_join_test.py
@@ -28,6 +28,8 @@ import re
 import sys
 
 import urllib.request
+
+from seam_verdict import was_joined
 import json
 
 SWIFT_EG1 = "Sources/EnviousWisprLLM/Prompting/EGOnePromptBuilder.swift"
@@ -125,13 +127,15 @@ def main():
                 continue
 
             lost = [w for w in words(source) if w not in words(out)]
-            # Did the BOUNDARY go? Both halves arrive terminated, so the
-            # input always holds two sentence-final marks. One left means
-            # they were welded; two means they were not, however much else
-            # was edited. Scoring on 'anything changed' counted a casing or
-            # punctuation tweak as a successful join. Found by cloud review
-            # on PR #1793.
-            joined = sum(out.count(c) for c in '.!?') < 2
+            # One shared definition, in seam_verdict.py. Two home-grown
+            # heuristics lived here before and both were wrong in ways that
+            # changed reported numbers.
+            joined = was_joined(first, second, out)
+            if joined is None:
+                print("  REWRITTEN  too changed to judge as joined or not")
+                print(f"      in : {source}")
+                print(f"      out: {out}")
+                continue
             if len(lost) > 2:
                 verdict = f"DESTROYED  lost {lost}"
             elif want == "join" and not joined:

--- a/research/seam-joining/code/eg1_join_test.py
+++ b/research/seam-joining/code/eg1_join_test.py
@@ -107,7 +107,12 @@ def main():
     parser.add_argument("--endpoint", default="http://127.0.0.1:8899")
     args = parser.parse_args()
 
-    repo = os.path.expanduser("~/Developer/EnviousLabs/EnviousWispr")
+    # Resolve the checkout from THIS file, not from the founder's home.
+    # research/seam-joining/code/ -> repo root is three levels up.
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo = os.path.dirname(os.path.dirname(os.path.dirname(here)))
+    if not os.path.exists(os.path.join(repo, SWIFT_EG1)):
+        repo = os.path.expanduser("~/Developer/EnviousLabs/EnviousWispr")
     trained = trained_prompt(repo)
 
     configurations = [

--- a/research/seam-joining/code/eg1_join_test.py
+++ b/research/seam-joining/code/eg1_join_test.py
@@ -1,0 +1,146 @@
+"""Last sanity check before declaring the merge system dead: can EG-1 do it?
+
+Apple Intelligence scored 3/11 with the shipped prompt and 2/11 with a narrow
+one, and its failures were not near misses — it replied to the dictation like a
+chatbot and deleted whole sentences. Founder call, 2026-07-25: if EG-1 fails too
+the approach is genuinely dead; if EG-1 has a pulse, the merge can ship as an
+option for EG-1 and cloud polish only.
+
+Same eleven cases as the Apple Intelligence run, so the three engines are
+directly comparable. Greedy sampling, so a rerun gives the same answer.
+
+EG-1's prompt is a training contract, not a free choice: the model was tuned on
+one exact system prompt and one exact <TRANSCRIPT> wrapper
+(`EGOnePromptBuilder.swift`, "DO NOT EDIT without retraining"). Both are read
+from the Swift source at run time so this cannot drift from what ships. Two
+configurations are tried:
+
+  trained + join   the training prompt with the joining instruction appended
+  narrow           the joining instruction alone, off the training distribution
+
+The second is expected to be worse for a fine-tuned model, but it is cheap and
+it is the configuration that would matter if the first one nearly works.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+import urllib.request
+import json
+
+SWIFT_EG1 = "Sources/EnviousWisprLLM/Prompting/EGOnePromptBuilder.swift"
+
+CASES = [
+    ("It now passes ten.", "Dictated chunks in a row, cleanly.", "join"),
+    ("I was thinking about the release.", "And how we should stage it.", "join"),
+    ("The tests are still red.", "So we cannot ship today.", "join"),
+    ("Can you take a look.", "When you get a chance.", "join"),
+    ("I will send you the notes.", "After the meeting ends.", "join"),
+    ("We should probably tell the team.", "Before anyone else finds out.", "join"),
+    ("I finished the report.", "But I have not sent it yet.", "join"),
+    ("I was thinking about the release and how we should stage it.",
+     "The tests are still red.", "leave"),
+    ("Can you take a look when you get a chance?", "It is not urgent.", "leave"),
+    ("The meeting went well.", "I'll send notes tomorrow.", "leave"),
+    ("I pushed the fix.", "Thanks for catching that.", "leave"),
+]
+
+JOIN_NOTE = (
+    " The transcript is a PREVIOUS sentence followed by a NEW recording the "
+    "speaker dictated moments later, after a pause. If they are one thought "
+    "split by that pause, join them into a single sentence. If they are two "
+    "separate thoughts, leave them as two sentences. Never drop a word, never "
+    "replace a word with a different word, and never reinterpret what was said."
+)
+
+NARROW = (
+    "You are given two pieces of dictated text. The FIRST is already in the "
+    "user's document. The SECOND was just spoken, after a pause. Decide one "
+    "thing: are these one thought that a pause split in half, or two separate "
+    "thoughts? If ONE thought, return them as a single sentence, changing only "
+    "the punctuation and capitalisation at the join. If TWO thoughts, return "
+    "both pieces exactly as given. Do not fix, improve, rephrase or reinterpret "
+    "anything. Every word given to you appears in your answer. Output only the "
+    "cleaned text."
+)
+
+
+def trained_prompt(repo):
+    """EG-1's exact training system prompt, read from the Swift source."""
+    body = open(os.path.join(repo, SWIFT_EG1), encoding="utf-8").read()
+    match = re.search(r"static let systemPrompt =\s*\n(.*?)\n\n", body, re.DOTALL)
+    if not match:
+        raise SystemExit("could not read EG-1's system prompt")
+    pieces = re.findall(r'"((?:[^"\\]|\\.)*)"', match.group(1))
+    return "".join(pieces)
+
+
+def ask(endpoint, system, transcript):
+    payload = {
+        "messages": [
+            {"role": "system", "content": system},
+            # The training-faithful wrapper. EG-1 saw this exact shape and
+            # nothing else; a bare transcript is off-distribution.
+            {"role": "user", "content": f"<TRANSCRIPT>\n{transcript}\n</TRANSCRIPT>"},
+        ],
+        "temperature": 0, "top_k": 1, "max_tokens": 400, "stream": False,
+    }
+    request = urllib.request.Request(
+        f"{endpoint}/v1/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(request, timeout=120) as response:
+        body = json.load(response)
+    return body["choices"][0]["message"]["content"].strip()
+
+
+def words(text):
+    return [w.lower().replace("'", "") for w in re.findall(r"[A-Za-z']+", text)]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", default="http://127.0.0.1:8899")
+    args = parser.parse_args()
+
+    repo = os.path.expanduser("~/Developer/EnviousLabs/EnviousWispr")
+    trained = trained_prompt(repo)
+
+    configurations = [
+        ("trained prompt + join instruction", trained + JOIN_NOTE),
+        ("narrow prompt only", NARROW),
+    ]
+
+    for label, system in configurations:
+        print(f"\n=== {label}  ({len(system)} characters)")
+        correct = 0
+        for first, second, want in CASES:
+            source = f"{first} {second}"
+            try:
+                out = ask(args.endpoint, system, source)
+            except Exception as exc:
+                print(f"  ERROR      {type(exc).__name__}: {exc}")
+                continue
+
+            lost = [w for w in words(source) if w not in words(out)]
+            joined = out.strip() != source.strip()
+            if len(lost) > 2:
+                verdict = f"DESTROYED  lost {lost}"
+            elif want == "join" and not joined:
+                verdict = "MISSED     left it as two"
+            elif want == "leave" and joined:
+                verdict = "OVERMERGED joined two separate thoughts"
+            else:
+                verdict = "ok"
+                correct += 1
+            print(f"  {verdict}")
+            print(f"      in : {source}")
+            print(f"      out: {out}")
+        print(f"  --> {correct}/{len(CASES)} correct")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/eval_seam.py
+++ b/research/seam-joining/code/eval_seam.py
@@ -102,12 +102,16 @@ def main():
 
     # ---------- 3. shortcut probe
     def punct_only(rec1):
+        """The real shortcut: does rec1's own punctuation decide the label?
+
+        Every branch used to return MERGE_SPACE, which made this a second
+        always-merge baseline wearing the name of a punctuation test — so it
+        could never reveal what it exists to reveal. A recording that ENDS a
+        thought carries terminal punctuation, so the honest shortcut is to keep
+        those apart and merge the rest. Found by cloud review on PR #1793.
+        """
         s = rec1.rstrip()
-        if s.endswith("?"):
-            return "MERGE_SPACE"
-        if s.endswith("."):
-            return "MERGE_SPACE"
-        return "MERGE_SPACE"
+        return "KEEP" if s.endswith((".", "?", "!")) else "MERGE_SPACE"
 
     naive = sum(1 for r in rows if punct_only(r["rec1"]) == r["label"])
     majority = Counter(r["label"] for r in rows).most_common(1)[0]

--- a/research/seam-joining/code/eval_seam.py
+++ b/research/seam-joining/code/eval_seam.py
@@ -1,0 +1,147 @@
+"""Interrogate the trained seam classifier. 99.2% is a number to distrust.
+
+Four checks, each designed to expose a different way that figure could be fake:
+
+  1. PER LANGUAGE. English test rows come from a completely independent file the
+     model never saw. German and Russian test rows were carved out of the SAME
+     generated file the training rows came from, so near-duplicates may survive
+     the exact-match leakage filter. If English collapses while German and
+     Russian are perfect, the score is leakage.
+
+  2. NEAR-DUPLICATE AUDIT. Exact first-half matches were removed at assembly
+     time. This checks how similar each test row's nearest training row is, so
+     "different by one word" cannot hide.
+
+  3. SHORTCUT PROBE. If the model can predict the label from the punctuation of
+     recording 1 alone - ignoring all the words - then it learned an artifact of
+     how the data was built, not grammar. Compares the model against a rule that
+     only looks at that punctuation.
+
+  4. THE FOUNDER'S OWN CASES, which never appeared in any training data.
+"""
+
+import json
+import os
+import sys
+import time
+from collections import Counter, defaultdict
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+SEAM = "<seam>"
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load():
+    tok = AutoTokenizer.from_pretrained(os.path.join(HERE, "seam-model"))
+    model = AutoModelForSequenceClassification.from_pretrained(os.path.join(HERE, "seam-model"))
+    model.eval()
+    return tok, model
+
+
+def predict(tok, model, pairs, bs=64):
+    out = []
+    for i in range(0, len(pairs), bs):
+        chunk = pairs[i : i + bs]
+        texts = [
+            f"{' '.join(a.split()[-18:])} {SEAM} {' '.join(b.split()[:14])}" for a, b in chunk
+        ]
+        enc = tok(texts, truncation=True, max_length=96, padding=True, return_tensors="pt")
+        with torch.no_grad():
+            logits = model(**enc).logits
+            probs = torch.softmax(logits, -1)
+        for p in probs:
+            idx = int(p.argmax())
+            out.append((LABELS[idx], float(p[idx])))
+    return out
+
+
+def main():
+    tok, model = load()
+    rows = [json.loads(l) for l in open(os.path.join(HERE, "seam_test.jsonl"), encoding="utf-8")]
+    pairs = [(r["rec1"], r["rec2"]) for r in rows]
+
+    t0 = time.perf_counter()
+    preds = predict(tok, model, pairs)
+    ms = (time.perf_counter() - t0) * 1000 / len(rows)
+
+    # ---------- 1. per language
+    per_lang = defaultdict(lambda: [0, 0])
+    damaging = defaultdict(int)
+    for r, (p, _) in zip(rows, preds):
+        per_lang[r["language"]][1] += 1
+        per_lang[r["language"]][0] += int(p == r["label"])
+        if r["label"] == "KEEP" and p != "KEEP":
+            damaging[r["language"]] += 1
+    print("1. ACCURACY BY LANGUAGE  (English source is fully independent)")
+    for lang, (c, n) in sorted(per_lang.items()):
+        print(f"   {lang:9} {c}/{n} = {100*c/n:5.1f}%   wrongly merged a real boundary: {damaging[lang]}")
+
+    # ---------- 2. near-duplicate audit
+    train = [json.loads(l) for l in open(os.path.join(HERE, "seam_train.jsonl"), encoding="utf-8")]
+    train_by_lang = defaultdict(list)
+    for t in train:
+        train_by_lang[t["language"]].append(set(t["rec1"].lower().split()))
+    print("\n2. NEAREST TRAINING ROW (word overlap of recording 1)")
+    for lang in sorted(per_lang):
+        sims = []
+        pool = train_by_lang[lang]
+        for r in [x for x in rows if x["language"] == lang][:150]:
+            w = set(r["rec1"].lower().split())
+            if not w or not pool:
+                continue
+            best = max((len(w & t) / len(w | t) for t in pool), default=0.0)
+            sims.append(best)
+        if sims:
+            sims.sort()
+            near = sum(1 for s in sims if s > 0.8)
+            print(f"   {lang:9} median {sims[len(sims)//2]:.2f}  p90 {sims[int(.9*len(sims))]:.2f}"
+                  f"  rows >0.8 similar: {near}/{len(sims)}")
+
+    # ---------- 3. shortcut probe
+    def punct_only(rec1):
+        s = rec1.rstrip()
+        if s.endswith("?"):
+            return "MERGE_SPACE"
+        if s.endswith("."):
+            return "MERGE_SPACE"
+        return "MERGE_SPACE"
+
+    naive = sum(1 for r in rows if punct_only(r["rec1"]) == r["label"])
+    majority = Counter(r["label"] for r in rows).most_common(1)[0]
+    model_acc = sum(1 for r, (p, _) in zip(rows, preds) if p == r["label"]) / len(rows)
+    print("\n3. COULD A SHORTCUT EXPLAIN THIS?")
+    print(f"   always-guess-{majority[0]:12} {100*majority[1]/len(rows):5.1f}%")
+    print(f"   punctuation of rec1 only  {100*naive/len(rows):5.1f}%")
+    print(f"   the trained model         {100*model_acc:5.1f}%")
+
+    # ---------- 4. founder's own seams, never in training
+    print("\n4. THE FOUNDER'S REAL SEAMS (never trained on)")
+    founder = [
+        ("I mean the ideal outcome.", "would be recognizing when two sentences need to be joined.", "MERGE_SPACE"),
+        ("Today I am going to", "The store.", "MERGE_SPACE"),
+        ("What I want you to do.", "is run multiple variations of broken sentences.", "MERGE_SPACE"),
+        ("The problem is that you", "Assumed how the software works without testing.", "MERGE_SPACE"),
+        ("I'm speaking in a longer sentence and I'm stopping.", "Mid thought.", "MERGE_SPACE"),
+        ("Let's make sure we", "Clean up the bathroom.", "MERGE_SPACE"),
+        ("Hold on a second. So we know that we keep the Bluetooth mic warm for 30 seconds and after that,", "We tear it down.", "MERGE_SPACE"),
+        ("I finished the report.", "The store is closed.", "KEEP"),
+        ("Thanks for sending that.", "I will review it tonight.", "KEEP"),
+        ("The build is green.", "We can merge now.", "KEEP"),
+        ("I sent the invoice.", "Did you get it?", "KEEP"),
+    ]
+    fp = predict(tok, model, [(a, b) for a, b, _ in founder])
+    ok = 0
+    for (a, b, want), (got, conf) in zip(founder, fp):
+        hit = got == want
+        ok += hit
+        print(f"   [{'OK ' if hit else 'MISS'}] {conf:.2f} {got:12} want {want:12} | {a[:44]} + {b[:34]}")
+    print(f"   => {ok}/{len(founder)}")
+    print(f"\nlatency on this Mac: {ms:.1f}ms per decision")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/extract_real_seams.py
+++ b/research/seam-joining/code/extract_real_seams.py
@@ -45,7 +45,11 @@ def parse_log(path):
         stamp = STAMP.match(raw)
         if not stamp:
             if pending_step and current:
-                current[pending_step] += raw.rstrip("\n")
+                # Keep the newline. Appending bare made a transcript
+                # containing a line break come out as "helloworld",
+                # silently corrupting the very recordings the corpus is
+                # built from. Found by cloud review on PR #1793.
+                current[pending_step] += "\n" + raw.rstrip("\n")
             continue
         match = STEP.search(raw)
         if not match:

--- a/research/seam-joining/code/extract_real_seams.py
+++ b/research/seam-joining/code/extract_real_seams.py
@@ -1,0 +1,134 @@
+"""Pull REAL consecutive-recording pairs out of the founder's dictation log.
+
+Everything the model has been judged on so far is synthetic: real sentences cut
+at real boundaries, then damaged to imitate what the transcriber does. The
+coverage round's strongest finding is that this proves nothing about production,
+where the two halves come from two separate recordings with two separate
+transcription passes, real polish artifacts, and a real human pause in between.
+
+The log already holds those pairs. Each dictation records its final text and a
+timestamp, so a pair of dictations close together in time IS a real seam: the
+user stopped talking, thought, and started again.
+
+What this does NOT do is label them. A real seam has no ground truth attached,
+so labelling is a separate step; this only builds the population.
+
+The output contains the founder's own dictation. It is gitignored and must
+never be committed.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime
+
+STAMP = re.compile(r"^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2})\]")
+STEP = re.compile(r"CORRECTION_DEBUG \[([^\]]+)\](?: OUT:)?\s?(.*)$", re.DOTALL)
+
+# Later steps win: the last one to report real text is what reached the clipboard.
+ORDER = ["RAW ASR", "Word Correction", "Filler Removal", "Emoji Formatter",
+         "Inverse Text Normalization", "LLM Polish", "Emoji Restore"]
+
+
+def parse_log(path):
+    """Yield (timestamp, final_text) per dictation.
+
+    A step's text can run over several lines, so a line without its own
+    timestamp continues the previous step rather than starting a new one.
+    """
+    dictations = []
+    current = {}
+    pending_step = None
+    for raw in open(path, encoding="utf-8", errors="replace"):
+        stamp = STAMP.match(raw)
+        if not stamp:
+            if pending_step and current:
+                current[pending_step] += raw.rstrip("\n")
+            continue
+        match = STEP.search(raw)
+        if not match:
+            pending_step = None
+            continue
+        step, text = match.group(1), match.group(2).rstrip("\n")
+        if step == "RAW ASR":
+            if current:
+                dictations.append(current)
+            current = {"_time": stamp.group(1)}
+        if not current:
+            continue
+        if text and text != "no change":
+            current[step] = text
+            pending_step = step
+        else:
+            pending_step = None
+    if current:
+        dictations.append(current)
+
+    out = []
+    for entry in dictations:
+        final = None
+        for step in ORDER:
+            if entry.get(step):
+                final = entry[step]
+        if final and entry.get("_time"):
+            out.append((datetime.fromisoformat(entry["_time"]), final.strip()))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gap", type=float, default=45.0,
+                    help="seconds between recordings to still count as one thought")
+    ap.add_argument("--min-words", type=int, default=4)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("logs", nargs="*",
+                    default=[os.path.expanduser("~/Library/Logs/EnviousWispr/app.log")])
+    args = ap.parse_args()
+
+    entries = []
+    for path in args.logs:
+        if os.path.exists(path):
+            found = parse_log(path)
+            print(f"{os.path.basename(path)}: {len(found)} dictations", file=sys.stderr)
+            entries.extend(found)
+    entries.sort(key=lambda e: e[0])
+    print(f"total dictations: {len(entries)}", file=sys.stderr)
+
+    pairs = []
+    for (t1, first), (t2, second) in zip(entries, entries[1:]):
+        gap = (t2 - t1).total_seconds()
+        if gap <= 0 or gap > args.gap:
+            continue
+        if len(first.split()) < args.min_words or len(second.split()) < args.min_words:
+            continue
+        if first == second:  # a repeated test utterance, not a seam
+            continue
+        pairs.append({"rec1": first, "rec2": second, "gap_seconds": round(gap, 1),
+                      "source": "founder_log", "language": "English"})
+
+    print(f"real consecutive pairs within {args.gap:.0f}s: {len(pairs)}", file=sys.stderr)
+    buckets = {"<10s": 0, "10-20s": 0, "20-45s": 0}
+    for p in pairs:
+        g = p["gap_seconds"]
+        buckets["<10s" if g < 10 else "10-20s" if g < 20 else "20-45s"] += 1
+    print(f"  by gap: {buckets}", file=sys.stderr)
+
+    starts_capital = sum(1 for p in pairs if p["rec2"][:1].isupper())
+    ends_terminal = sum(1 for p in pairs if p["rec1"].rstrip().endswith((".", "!", "?")))
+    print(f"  second half starts with a capital : {starts_capital}/{len(pairs)} "
+          f"({100*starts_capital/max(len(pairs),1):.1f}%)", file=sys.stderr)
+    print(f"  first half ends with a terminator : {ends_terminal}/{len(pairs)} "
+          f"({100*ends_terminal/max(len(pairs),1):.1f}%)", file=sys.stderr)
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as handle:
+            for pair in pairs:
+                handle.write(json.dumps(pair, ensure_ascii=False) + "\n")
+        print(f"wrote {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/final_bakeoff.py
+++ b/research/seam-joining/code/final_bakeoff.py
@@ -1,0 +1,112 @@
+"""Score every trained model on BOTH test sets and rank by a single honest rule.
+
+Two sets, because they answer different questions:
+  seam_test.jsonl      879 rows, English/German/Russian - languages we trained on
+  seam_zeroshot.jsonl  330 rows, six languages with ZERO training data
+
+A model that wins the first and loses the second is overfitted to its training
+languages, and expanding to new languages would then require a data project per
+language rather than working out of the box.
+
+Ranking rule, fixed before results are seen:
+  1. fewest wrong merges across BOTH sets (silent damage is disqualifying)
+  2. then highest mean accuracy across BOTH sets
+Seeds are averaged; the spread is printed so a lucky seed cannot be mistaken for
+a better model.
+"""
+
+import json
+import os
+import re
+import statistics
+import sys
+from collections import defaultdict
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+SEAM = "<seam>"
+
+
+def score(model_dir, rows):
+    tok = AutoTokenizer.from_pretrained(model_dir)
+    model = AutoModelForSequenceClassification.from_pretrained(model_dir)
+    model.eval()
+    if torch.cuda.is_available():
+        model.cuda()
+    correct = wrong_merge = keep_n = 0
+    for i in range(0, len(rows), 64):
+        chunk = rows[i : i + 64]
+        texts = [
+            f"{' '.join(r['rec1'].split()[-18:])} {SEAM} {' '.join(r['rec2'].split()[:14])}"
+            for r in chunk
+        ]
+        enc = tok(texts, truncation=True, max_length=96, padding=True, return_tensors="pt")
+        if torch.cuda.is_available():
+            enc = {k: v.cuda() for k, v in enc.items()}
+        with torch.no_grad():
+            pred = model(**enc).logits.argmax(-1).tolist()
+        for r, p in zip(chunk, pred):
+            lab = LABELS[p]
+            correct += int(lab == r["label"])
+            if r["label"] == "KEEP":
+                keep_n += 1
+                wrong_merge += int(lab != "KEEP")
+    del model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return correct / len(rows), wrong_merge, keep_n
+
+
+def main():
+    trained = [json.loads(l) for l in open("seam_test.jsonl", encoding="utf-8")]
+    unseen = [json.loads(l) for l in open("seam_zeroshot.jsonl", encoding="utf-8")]
+
+    dirs = sorted(d for d in os.listdir(".") if d.startswith("seam-") and os.path.isdir(d))
+    # Group seeds of the same configuration together.
+    groups = defaultdict(list)
+    for d in dirs:
+        groups[re.sub(r"-s\d+$", "", d)].append(d)
+
+    rows = []
+    for name, members in sorted(groups.items()):
+        accs_t, accs_z, wm_t, wm_z = [], [], [], []
+        for d in members:
+            try:
+                a, w, _ = score(d, trained)
+                accs_t.append(a)
+                wm_t.append(w)
+                a, w, _ = score(d, unseen)
+                accs_z.append(a)
+                wm_z.append(w)
+            except Exception as exc:
+                print(f"  {d}: skipped ({type(exc).__name__}: {str(exc)[:60]})", flush=True)
+        if not accs_t:
+            continue
+        rows.append({
+            "name": name,
+            "n": len(accs_t),
+            "acc_t": statistics.mean(accs_t),
+            "acc_z": statistics.mean(accs_z),
+            "wm_t": statistics.mean(wm_t),
+            "wm_z": statistics.mean(wm_z),
+            "spread_z": (min(accs_z), max(accs_z)),
+        })
+
+    rows.sort(key=lambda r: (r["wm_t"] + r["wm_z"], -(r["acc_t"] + r["acc_z"]) / 2))
+
+    print(f"\n{'configuration':24}{'seeds':>6}{'trained-lang':>14}{'UNSEEN-lang':>13}"
+          f"{'wrong merges':>15}{'unseen spread':>18}")
+    print(f"{'':24}{'':>6}{'accuracy':>14}{'accuracy':>13}{'trained+unseen':>15}{'':>18}")
+    print("-" * 92)
+    for r in rows:
+        lo, hi = r["spread_z"]
+        print(f"{r['name']:24}{r['n']:>6}{100*r['acc_t']:>13.1f}%{100*r['acc_z']:>12.1f}%"
+              f"{r['wm_t']:>8.1f}+{r['wm_z']:<5.1f}{100*lo:>10.1f}-{100*hi:.1f}%")
+    print("\nRanked by fewest wrong merges, then accuracy. Both criteria fixed before running.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/grade_real_seams.py
+++ b/research/seam-joining/code/grade_real_seams.py
@@ -103,15 +103,19 @@ def main():
             print(f"no MERGE decisions found in {args.predictions}", file=sys.stderr)
             return 1
         rows = wanted
-        print(f"grading the {len(rows)} pairs the model chose to MERGE "
-              f"(the dangerous direction, measured completely)", file=sys.stderr)
+        # "Completely" has to mean completely. The --limit slice below is for
+        # the sampling path; applying it here would grade the first 400 merges
+        # and silently drop every wrong merge after the cut, while the message
+        # claims full coverage. Found by cloud review on PR #1793.
+        print(f"grading ALL {len(rows)} pairs the model chose to MERGE "
+              f"(the dangerous direction, measured completely; --limit ignored)",
+              file=sys.stderr)
     else:
         random.Random(1790).shuffle(rows)
+        rows = rows[: args.limit]
         print(f"NO --predictions given: grading a random sample of "
-              f"{min(args.limit, len(rows))} pairs, which measures both "
-              f"directions weakly rather than the merge direction completely",
-              file=sys.stderr)
-    rows = rows[: args.limit]
+              f"{len(rows)} pairs, which measures both directions weakly "
+              f"rather than the merge direction completely", file=sys.stderr)
     print(f"grading {len(rows)} real pairs (gap <= {args.max_gap:.0f}s)", file=sys.stderr)
 
     from anthropic import AnthropicBedrock
@@ -141,7 +145,8 @@ def main():
             if failure or not label:
                 failures.append(failure or "unknown")
             else:
-                row = {**pair, "label": label, "label_source": "haiku_strict_blind"}
+                row = {**pair, "label": label, "label_source": ("haiku_strict_blind_targeted_merge_only"
+                                if args.predictions else "haiku_strict_blind")}
                 graded.append(row)
                 handle.write(json.dumps(row, ensure_ascii=False) + "\n")
                 handle.flush()

--- a/research/seam-joining/code/grade_real_seams.py
+++ b/research/seam-joining/code/grade_real_seams.py
@@ -97,7 +97,14 @@ def main():
     # be checked for progress, and would have lost every answer on a crash.
     graded, failures = [], []
     done = 0
-    handle = open(out_path, "w", encoding="utf-8")
+    # Write to a SIDECAR and only move it into place once the run has
+    # earned it. Opening the destination directly truncated the previous
+    # labels the moment the run started, so a throttled or interrupted
+    # rerun destroyed a complete label set and left a partial one behind —
+    # and the "REFUSING to write" guard below fired far too late to help.
+    # Found by cloud review on PR #1793.
+    partial_path = out_path + ".partial"
+    handle = open(partial_path, "w", encoding="utf-8")
     with ThreadPoolExecutor(max_workers=args.workers) as pool:
         for pair, (label, failure) in zip(
                 rows, pool.map(lambda p: grade_one(client, args.model, p), rows)):
@@ -117,8 +124,13 @@ def main():
     if len(graded) < 0.9 * len(rows):
         from collections import Counter as _C
         print(f"REFUSING to write: only {len(graded)}/{len(rows)} answered "
-              f"({dict(_C(failures).most_common(3))})", file=sys.stderr)
+              f"({dict(_C(failures).most_common(3))}); kept the previous "
+              f"labels, partial run left at {partial_path}", file=sys.stderr)
         return 1
+
+    # Earned it. Replacing in one step means the destination is either the
+    # old complete set or the new complete set, never a half-written mix.
+    os.replace(partial_path, out_path)
 
     from collections import Counter
     print(f"labelled {len(graded)}, failed {len(failures)}", file=sys.stderr)

--- a/research/seam-joining/code/grade_real_seams.py
+++ b/research/seam-joining/code/grade_real_seams.py
@@ -1,0 +1,133 @@
+"""Label the REAL consecutive-recording pairs, cheaply and where it matters.
+
+`extract_real_seams.py` produced 2,563 genuine pairs from the founder's logs.
+They have no ground truth attached, and labelling all of them would be wasteful,
+because the two directions of error are not equally important:
+
+  wrong merge   two separate thoughts welded together. Silent, the user does not
+                notice until they reread, and it is the disqualifying failure.
+  missed join   we leave today's behaviour. Annoying, never damaging.
+
+So grading is targeted. The default mode labels only the pairs the model chose
+to MERGE, which measures the dangerous direction exactly and completely: every
+one of those decisions is either correct or a wrong merge, with nothing in
+between. A sample of the KEEP decisions estimates the other direction.
+
+Each pair is graded blind: the grader never sees what the model decided, and the
+two halves are presented as a person would have said them.
+
+Routed through Bedrock so it spends existing credits rather than new money.
+"""
+
+import argparse
+import json
+import os
+import random
+import re
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+# The prompt is imported, never re-typed. `calibrate_grader.py` measured both
+# variants against known labels: the obvious phrasing called 29 of 43 real
+# sentence boundaries a join, which would have defined success as agreeing with
+# a grader that over-merges two times in three. The strict variant gets that to
+# 1 of 41. A copy of the text here would drift from the version that was
+# measured, and the measurement is the only reason to trust it.
+from calibrate_grader import LINKED as PROMPT  # noqa: E402
+
+LABEL_FROM_WORD = {"SEPARATE": "KEEP", "JOIN": "MERGE_SPACE", "COMMA": "MERGE_COMMA"}
+
+
+def grade_one(client, model, pair):
+    """Return (label, failure). Never a silent None: a dropped answer that still
+    counts toward a percentage is a fabricated result."""
+    body = PROMPT.format(rec1=pair["rec1"].strip(), rec2=pair["rec2"].strip())
+    for attempt in range(5):
+        try:
+            response = client.messages.create(
+                model=model, max_tokens=8, temperature=0,
+                messages=[{"role": "user", "content": body}])
+        except Exception as exc:
+            name = type(exc).__name__
+            if "Throttl" in name or "TooManyRequests" in name or "429" in str(exc):
+                time.sleep(1.5 * (attempt + 1))
+                continue
+            return None, f"api:{name}"
+        text = response.content[0].text
+        word = re.sub(r"[^A-Z]", "", text.upper())
+        for key, label in LABEL_FROM_WORD.items():
+            if word.startswith(key[:4]):
+                return label, None
+        return None, f"parse:{text.strip()[:24]!r}"
+    return None, "api:throttled-out"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pairs", default=None, help="jsonl of real pairs")
+    ap.add_argument("--limit", type=int, default=400)
+    ap.add_argument("--max-gap", type=float, default=25.0,
+                    help="only pairs closer together than this are plausible seams")
+    ap.add_argument("--model", default="us.anthropic.claude-haiku-4-5-20251001-v1:0")
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.dirname(here)
+    pairs_path = args.pairs or os.path.join(root, "data", "seam_real_founder.jsonl")
+    out_path = args.out or os.path.join(root, "data", "seam_real_labelled.jsonl")
+
+    rows = [json.loads(l) for l in open(pairs_path, encoding="utf-8")]
+    rows = [r for r in rows if r["gap_seconds"] <= args.max_gap]
+    random.Random(1790).shuffle(rows)
+    rows = rows[: args.limit]
+    print(f"grading {len(rows)} real pairs (gap <= {args.max_gap:.0f}s)", file=sys.stderr)
+
+    from anthropic import AnthropicBedrock
+
+    client = AnthropicBedrock(
+        aws_access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        aws_region="us-east-1")
+
+    # Write each answer AS IT ARRIVES, and say how far along it is. Holding
+    # everything until the end meant a 20-minute run showed nothing, could not
+    # be checked for progress, and would have lost every answer on a crash.
+    graded, failures = [], []
+    done = 0
+    handle = open(out_path, "w", encoding="utf-8")
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        for pair, (label, failure) in zip(
+                rows, pool.map(lambda p: grade_one(client, args.model, p), rows)):
+            done += 1
+            if failure or not label:
+                failures.append(failure or "unknown")
+            else:
+                row = {**pair, "label": label, "label_source": "haiku_strict_blind"}
+                graded.append(row)
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+                handle.flush()
+            if done % 100 == 0:
+                print(f"  {done}/{len(rows)} graded, {len(failures)} failed",
+                      file=sys.stderr, flush=True)
+    handle.close()
+
+    if len(graded) < 0.9 * len(rows):
+        from collections import Counter as _C
+        print(f"REFUSING to write: only {len(graded)}/{len(rows)} answered "
+              f"({dict(_C(failures).most_common(3))})", file=sys.stderr)
+        return 1
+
+    from collections import Counter
+    print(f"labelled {len(graded)}, failed {len(failures)}", file=sys.stderr)
+    if failures:
+        print(f"  failures: {dict(Counter(failures).most_common(3))}", file=sys.stderr)
+    print(f"  {dict(Counter(r['label'] for r in graded))}", file=sys.stderr)
+    print(f"wrote {out_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/grade_real_seams.py
+++ b/research/seam-joining/code/grade_real_seams.py
@@ -67,6 +67,8 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--pairs", default=None, help="jsonl of real pairs")
     ap.add_argument("--limit", type=int, default=400)
+    ap.add_argument("--predictions", default="",
+                    help="model decisions; grade only the MERGE ones")
     ap.add_argument("--max-gap", type=float, default=25.0,
                     help="only pairs closer together than this are plausible seams")
     ap.add_argument("--model", default="us.anthropic.claude-haiku-4-5-20251001-v1:0")
@@ -81,7 +83,34 @@ def main():
 
     rows = [json.loads(l) for l in open(pairs_path, encoding="utf-8")]
     rows = [r for r in rows if r["gap_seconds"] <= args.max_gap]
-    random.Random(1790).shuffle(rows)
+
+    # Targeting the dangerous direction requires knowing what the model decided,
+    # and that only exists in a predictions file. Without one this shuffles and
+    # samples, which measures BOTH directions weakly instead of the merge
+    # direction completely — so say which one is happening rather than claiming
+    # the targeted run and delivering the sample. Found by cloud review on
+    # PR #1793.
+    if args.predictions:
+        decided = {}
+        for line in open(args.predictions, encoding="utf-8"):
+            row = json.loads(line)
+            key = (row.get("rec1", ""), row.get("rec2", ""))
+            decided[key] = row.get("prediction") or row.get("label")
+        wanted = [r for r in rows
+                  if str(decided.get((r.get("rec1", ""), r.get("rec2", "")), ""))
+                  .startswith("MERGE")]
+        if not wanted:
+            print(f"no MERGE decisions found in {args.predictions}", file=sys.stderr)
+            return 1
+        rows = wanted
+        print(f"grading the {len(rows)} pairs the model chose to MERGE "
+              f"(the dangerous direction, measured completely)", file=sys.stderr)
+    else:
+        random.Random(1790).shuffle(rows)
+        print(f"NO --predictions given: grading a random sample of "
+              f"{min(args.limit, len(rows))} pairs, which measures both "
+              f"directions weakly rather than the merge direction completely",
+              file=sys.stderr)
     rows = rows[: args.limit]
     print(f"grading {len(rows)} real pairs (gap <= {args.max_gap:.0f}s)", file=sys.stderr)
 

--- a/research/seam-joining/code/join_hotkey.py
+++ b/research/seam-joining/code/join_hotkey.py
@@ -31,6 +31,8 @@ import sys
 import threading
 import time
 
+import regex
+
 import Quartz
 from AppKit import NSPasteboard, NSPasteboardTypeString, NSWorkspace
 from ApplicationServices import (AXUIElementCopyAttributeValue,
@@ -335,6 +337,34 @@ def post_key(keycode, flags=0):
         time.sleep(0.004)
 
 
+def utf16_length(text):
+    """Length in UTF-16 units, which is what accessibility ranges count.
+
+    Python counts code points; macOS counts UTF-16 units. They agree until the
+    text contains anything outside the basic plane — an emoji, which dictation
+    produces routinely (`EmojiRestorer` exists for exactly that reason). "I said
+    👍 to that" is 16 code points and 17 UTF-16 units, so a selection computed
+    the Python way starts one unit late and the replacement eats a character it
+    should have kept. Found by cloud review on PR #1793.
+    """
+    return len(text.encode("utf-16-le")) // 2
+
+
+def keypress_length(text):
+    """How many backspaces this text costs: one per user-visible character.
+
+    A third counting system, agreeing with neither of the others. A backspace
+    removes one grapheme cluster, so a flag or a family emoji is one keypress
+    but several code points and several UTF-16 units.
+
+    NOT verified against a real field — no emoji case has been run through the
+    backspace path. The shipped implementation is Swift, where `String` already
+    iterates graphemes and `String.utf16.count` gives the other number, so
+    neither approximation survives into the product.
+    """
+    return len(regex.findall(r"\X", text))
+
+
 def selected_range(element):
     raw = attr(element, "AXSelectedTextRange")
     if raw is None:
@@ -424,8 +454,8 @@ def settle_deletion(element, expected, before, budget=8):
     return f"did not settle — wanted {expected!r}, last saw {current!r}"
 
 
-def replace_span(element, caret, span_length, replacement, expected_after=None):
-    """Swap the `span_length` characters ending at the caret for `replacement`.
+def replace_span(element, caret, span_text, replacement, expected_after=None):
+    """Swap `span_text`, which ends at the caret, for `replacement`.
 
     Two mechanisms, measured across TextEdit, Chrome (both a plain textarea and
     a contenteditable), Slack, Excel and Ghostty on 2026-07-25:
@@ -448,12 +478,16 @@ def replace_span(element, caret, span_length, replacement, expected_after=None):
     contenteditable the editor never saw it — the next character typed landed at
     the very start of the field. Reading the text back cannot detect that.
     """
-    if caret is not None and caret >= span_length:
-        if select_range(element, caret - span_length, span_length):
+    # Three counting systems, one per consumer, and they disagree the moment an
+    # emoji appears. Measure `span_text` itself rather than passing one number
+    # around: accessibility ranges want UTF-16 units, backspaces want keypresses.
+    units = utf16_length(span_text)
+    if caret is not None and caret >= units:
+        if select_range(element, caret - units, units):
             paste(replacement)
             return "selection"
     before = terminal_line(element) if expected_after is not None else None
-    for _ in range(span_length):
+    for _ in range(keypress_length(span_text)):
         post_key(DELETE_KEY)
     note = ""
     if expected_after is not None:
@@ -612,7 +646,7 @@ def do_join(client, model, system):
         if not matches:
             print("  SKIPPED  cannot locate the text to replace in the field\n")
             return
-        to_delete = len(raw_tail) - matches[-1].start()
+        span_text = raw_tail[matches[-1].start():]
     else:
         # A terminal, counted from the PARSED line rather than the raw screen.
         # The raw screen contains the line wraps and the box's own padding, so
@@ -630,7 +664,10 @@ def do_join(client, model, system):
         # space eaten off the front is invisible to any comparison that strips
         # whitespace, so it can never be detected and repaired. Bias towards the
         # mistake that can be seen.
-        to_delete = len(before_caret) - matches[-1].start() - terminal_wraps(value)
+        trimmed = terminal_wraps(value)
+        span_text = before_caret[matches[-1].start():]
+        if trimmed:
+            span_text = span_text[:-trimmed]
         expected_after = before_caret[:matches[-1].start()].strip()
 
     # Screen content AFTER the match is not a problem: in a TUI the input box
@@ -638,8 +675,8 @@ def do_join(client, model, system):
     # so backspaces only consume the box's own text. What matters is that the
     # caret sits at the end of what we matched, which it does straight after
     # dictating. Sanity-check the count instead.
-    if to_delete > len(target) + 40:
-        print(f"  SKIPPED  span looks wrong ({to_delete} chars for "
+    if len(span_text) > len(target) + 40:
+        print(f"  SKIPPED  span looks wrong ({len(span_text)} chars for "
               f"{len(target)} of text), field untouched\n")
         return
 
@@ -653,8 +690,8 @@ def do_join(client, model, system):
     else:
         to_paste = (" " if expected_after else "") + result + " "
 
-    how = replace_span(element, position, to_delete, to_paste, expected_after)
-    print(f"  DONE     replaced {to_delete} characters by {how}\n")
+    how = replace_span(element, position, span_text, to_paste, expected_after)
+    print(f"  DONE     replaced {len(span_text)} characters by {how}\n")
 
 
 # ── hotkey plumbing ──────────────────────────────────────────────────────────

--- a/research/seam-joining/code/join_hotkey.py
+++ b/research/seam-joining/code/join_hotkey.py
@@ -1,0 +1,729 @@
+"""Live seam-joining prototype. Real dictation, real fields, no app changes.
+
+THE IDEA (founder, 2026-07-25). Instead of a classifier deciding whether two
+recordings belong together, hand the polisher the last sentence already sitting
+in the field plus the new recording, and let it produce clean joined text. Then
+delete that last sentence and paste the result.
+
+HOW TO USE IT
+  1. start this, then click into a real text box: Notes, Slack, Mail, a browser
+  2. dictate a half thought, pause, dictate the rest, exactly as you normally do
+  3. hold LEFT control + LEFT option + LEFT command, then let go
+  4. watch it replace the last two sentences with a joined version
+
+Everything is real except the trigger. The automatic trigger is the expensive
+part and is not worth building until the joining itself has earned its place.
+
+TERMINALS ARE A FIRST-CLASS SURFACE (founder, 2026-07-25): a large share of
+users dictate into one. The earlier failure was not the terminal, it was reading
+AXValue, which in a terminal returns the ENTIRE scrollback — so the script fed
+the polisher its own printed output. Reading a bounded window behind the cursor
+fixes it and matches what the shipped app does. Still run it from a DIFFERENT
+window than the one you type into.
+
+Terminal needs Accessibility permission. Ctrl-C to stop.
+"""
+
+import json
+import os
+import re
+import sys
+import threading
+import time
+
+import Quartz
+from AppKit import NSPasteboard, NSPasteboardTypeString, NSWorkspace
+from ApplicationServices import (AXUIElementCopyAttributeValue,
+                                 AXUIElementCopyParameterizedAttributeValue,
+                                 AXUIElementCreateApplication,
+                                 AXUIElementSetAttributeValue, AXValueCreate,
+                                 AXValueGetValue, kAXValueCFRangeType)
+
+# Device-dependent modifier bits. The ordinary flags say "control is down" but
+# not WHICH control, so a left-hand-only chord needs these.
+LEFT_CONTROL, LEFT_COMMAND, LEFT_OPTION = 0x01, 0x08, 0x20
+CHORD = LEFT_CONTROL | LEFT_COMMAND | LEFT_OPTION
+DELETE_KEY, V_KEY = 51, 9
+
+TERMINALS = {"ghostty", "terminal", "iterm2", "iterm", "warp", "alacritty",
+             "kitty", "wezterm", "hyper", "tabby"}
+TEXT_ROLES = {"AXTextArea", "AXTextField", "AXComboBox", "AXSearchField"}
+
+# The closing sentence is not padding. Without it the polisher rewrote the
+# founder's live dictation "It now passes ten. Dictated chunks in a row,
+# cleanly." into "It is now past ten." — it read "passes ten" as a time of day
+# and threw away two thirds of what he said. Adding the no-invention clause
+# fixed that case and scored 9/9 against 7/9 for the version without it,
+# including an over-merge the looser wording also produced
+# (`code/compare_join_notes.py`, 2026-07-25). Destroying a sentence is a worse
+# failure than merging two that should have stayed apart.
+JOIN_NOTE = (
+    "\n\nThe transcript below is a PREVIOUS sentence followed by a NEW recording "
+    "the speaker dictated moments later, after a pause. They may be one thought "
+    "split by that pause, or two separate thoughts. If they are one thought, join "
+    "them into a single natural sentence. If they are two, leave them as two "
+    "sentences. Return only the cleaned text, never a question or a comment."
+    " Never drop a word, never replace a word with a different word, and never "
+    "reinterpret what was said. Every word of the transcript must appear in your "
+    "answer unless joining the two halves makes a connecting word redundant."
+)
+
+
+# ── reading the field ────────────────────────────────────────────────────────
+
+def attr(element, name):
+    err, value = AXUIElementCopyAttributeValue(element, name, None)
+    return value if err == 0 else None
+
+
+def focused():
+    """The frontmost app's focused element, or a reason it cannot be used."""
+    NSWorkspace.sharedWorkspace().runningApplications()
+    app = NSWorkspace.sharedWorkspace().frontmostApplication()
+    if not app:
+        return None, None, "no frontmost app"
+    name = app.localizedName() or "?"
+    element = attr(AXUIElementCreateApplication(app.processIdentifier()),
+                   "AXFocusedUIElement")
+    if element is None:
+        return None, name, f"{name} has no focused element"
+    role = attr(element, "AXRole")
+    if role not in TEXT_ROLES:
+        return None, name, f"{name}: focused thing is a {role}, not a text box"
+    return element, name, None
+
+
+def caret_position(element):
+    raw = attr(element, "AXSelectedTextRange")
+    if raw is None:
+        return None
+    ok, value = AXValueGetValue(raw, kAXValueCFRangeType, None)
+    return int(value[0]) if ok else None
+
+
+def text_before_caret(element, position, window=400):
+    """Read a BOUNDED window behind the cursor, never the whole document.
+
+    Terminals report their entire scrollback as AXValue, so reading that hands
+    the polisher a whole session's history instead of the line being typed. A
+    bounded backward read is also what the shipped app does: AXStringForRange
+    costs the same 0.03-0.10 ms whether you ask for 2 characters or 1,556
+    (accessibility-macos.md FACT: reading-caret-context-from-another-app).
+    """
+    start = max(0, position - window)
+    length = position - start
+    if length <= 0:
+        return ""
+    value = AXValueCreate(kAXValueCFRangeType, (start, length))
+    if value is None:
+        return ""
+    err, result = AXUIElementCopyParameterizedAttributeValue(
+        element, "AXStringForRange", value, None)
+    return result if err == 0 and isinstance(result, str) else ""
+
+
+# A terminal hands over the whole screen, so a TUI's status bar and separators
+# arrive as if they were the user's prose. Claude Code contributed "git:main⚠",
+# "Opus 5 (1M context)" and a rule of box-drawing characters, which inflated the
+# input to 24 words against 6 real ones and tripped the lost-words guard on a
+# join that was actually correct. Prototype-only: the shipped app reads a real
+# focused text field and never sees chrome.
+CHROME = re.compile(
+    r"^\s*(?:[─━═|│┃┆┇┊┋]{4,}"                    # separator rules
+    r"|[⏵▶▸►]+\s"                                  # mode indicators
+    r"|.*\b(?:git:|⎇|shift\+tab|auto mode|context\))"  # status bars
+    r"|[█░▓▒]{3,})")                                # progress meters
+
+
+# In a terminal the screen buffer is NOT the editable region. Everything before
+# the last shell prompt is already committed output: banners, paths, previous
+# commands. Deleting into it is meaningless at best and destructive at worst —
+# the first successful run here read 144 characters including "Claude Max" and
+# the working directory, then backspaced over all of them. Anchor on the prompt
+# so only the current input line is ever a candidate.
+# Matched as a regex, not literals with a hard-coded trailing space. The chrome
+# stripper rstrips each line, so a bare prompt ends "…Pro ~ %" with nothing
+# after it — a literal "% " never matched, and a fresh window read back as
+# "Last login: …" instead of empty.
+PROMPT_RE = re.compile(r"(?:❯|➜|\|>|[$%#])\s*")
+
+# Split by confidence. A "$" or a "%" is a shell prompt on a bare prompt line and
+# is ALSO a dollar amount and a percentage — Claude Code's own status bar reads
+# "81% | $107.40", so the weak markers matched a line BELOW the input box and the
+# reader anchored on the status bar. Strong markers are unambiguous; the weak set
+# is consulted only when no strong one is on screen.
+STRONG_PROMPT_RE = re.compile(r"(?:❯|➜|\|>)\s*")
+
+
+# A full-screen terminal UI draws its input box between two horizontal rules and
+# prints hints UNDER it. Anchoring on the prompt marker alone therefore swept up
+# everything below the box: with the box completely EMPTY, reading it back
+# returned "/rc ⧉ seam-join-explainer". A reader that cannot tell empty from
+# full is worse than no reader — it invites deleting text nobody typed.
+RULE_LINE = re.compile(r"^\s*[─━═-]{4,}\s*$")
+
+
+# How much of the screen to read back. 400 characters covered a single-line
+# input box and nothing more: as soon as a dictation wrapped onto a second and
+# third line, the prompt marker fell outside the window, no anchor was found,
+# and the reader handed back the raw screen INCLUDING the footer hints — which
+# is how "/rc ⧉ seam-join-explainer" ended up inside a sentence being polished.
+TERMINAL_WINDOW = 2000
+
+
+def input_box_body(lines):
+    """The text inside a full-screen UI's input box, or None if there is no box.
+
+    Anchoring on the prompt marker alone is fragile: it has to be on screen, it
+    has to be found, and everything after it is assumed to be the user's. The
+    box itself is a stronger landmark — it is drawn between two horizontal
+    rules, and its contents are exactly the editable region. The prompt marker
+    then only has to CONFIRM that the pair of rules found really is the input
+    box rather than any other rule the program happened to print.
+    """
+    rules = [index for index, line in enumerate(lines) if RULE_LINE.match(line)]
+    if len(rules) < 2:
+        return None
+    body = lines[rules[-2] + 1:rules[-1]]
+    if not body or not STRONG_PROMPT_RE.search(body[0]):
+        return None
+    return body
+
+
+def terminal_text(value):
+    """The input line EXACTLY as the buffer holds it, trailing space and all.
+
+    Trailing whitespace is load-bearing and was being thrown away. The app ends
+    each dictation with a space so the next one does not run into it, so the
+    buffer is one character longer than the visible sentence — and deleting the
+    visible length from the end therefore stops one character short and leaves
+    the FIRST letter of the old sentence welded to the new one. That is the
+    "It" in "…again.It looks like", and it happened on every single terminal
+    run: wanted '', last saw 'O'; wanted '', last saw 'T'.
+
+    Safe to preserve because this terminal does not pad lines out to the window
+    width — an empty box reads back as "❯\\xa0" with nothing after it, and a
+    126-character sentence reads back as exactly 126 characters.
+    """
+    window = value[-TERMINAL_WINDOW:]
+    body = input_box_body(window.splitlines())
+    if body is None:
+        return strip_chrome(after_shell_prompt(window))
+
+    marker = list(STRONG_PROMPT_RE.finditer(body[0]))[-1]
+    parts = [body[0][marker.end():]] + list(body[1:])
+    # Every line but the last gets its wrap padding trimmed; the last keeps its
+    # tail, because that tail is real text the buffer contains.
+    head = [part.strip() for part in parts[:-1]]
+    head = [part for part in head if part]
+    last = parts[-1].lstrip()
+    joined = " ".join(head + [last]) if last else " ".join(head)
+    return joined.replace("\xa0", " ")
+
+
+def terminal_wraps(value):
+    """How many times the input box wrapped the line onto a new row.
+
+    Each wrap is a place where the screen shows a line break and the buffer may
+    or may not hold a space — the two are indistinguishable when reading the
+    screen back. Every wrap is therefore a potential phantom character in any
+    count derived from the screen, and counting one too many deletes the space
+    in FRONT of the text being replaced: "…stage it. The tests" came back as
+    "…stage it.The tests".
+    """
+    body = input_box_body(value[-TERMINAL_WINDOW:].splitlines())
+    return max(0, len(body) - 1) if body else 0
+
+
+def after_shell_prompt(text):
+    """The current input line: after the last prompt, before the box closes."""
+    lines = text.splitlines()
+
+    start, pattern = None, STRONG_PROMPT_RE
+    for index, line in enumerate(lines):
+        if STRONG_PROMPT_RE.search(line):
+            start = index
+    if start is None:
+        pattern = PROMPT_RE
+        for index, line in enumerate(lines):
+            if PROMPT_RE.search(line) and not CHROME.match(line):
+                start = index
+    if start is None:
+        return text
+
+    collected = []
+    for line in lines[start:]:
+        if RULE_LINE.match(line):
+            break  # the bottom of the input box; nothing below it is ours
+        collected.append(line)
+
+    marker = list(pattern.finditer(collected[0]))[-1]
+    collected[0] = collected[0][marker.end():]
+    # The box pads with a non-breaking space, which is whitespace to a human and
+    # a distinct character to everything else.
+    joined = " ".join(part.strip() for part in collected if part.strip())
+    return joined.replace("\xa0", " ").strip()
+
+
+def strip_chrome(text):
+    kept = [ln for ln in text.splitlines() if ln.strip() and not CHROME.match(ln)]
+    # A rule can also trail a real line: "…design. ────────────".
+    kept = [re.sub(r"\s*[─━═]{4,}.*$", "", ln).rstrip() for ln in kept]
+    return " ".join(ln for ln in kept if ln.strip())
+
+
+def loose_pattern(text):
+    """Find these words again however the gaps between them are punctuated.
+
+    The sentence being looked for is REBUILT with single spaces, while the field
+    holds whatever is really there. Requiring at least one space between every
+    pair of words therefore fails on the commonest case of all: a dictation
+    pasted straight onto the end of the previous one with no space at all, as in
+    "…joining system.It looks like…". That failure is silent — it reports that
+    it cannot find the text and does nothing, which is what happened twice in a
+    row on 2026-07-25. Allowing ZERO whitespace matches what is actually there.
+    """
+    return r"\s*".join(re.escape(word) for word in text.split())
+
+
+def sentences_in(text):
+    return [s for s in re.split(r"(?<=[.!?])\s+", text.strip()) if s]
+
+
+TRANSCRIPTS = os.path.expanduser("~/Library/Application Support/EnviousWispr/transcripts")
+
+
+def latest_recording():
+    """What the app most recently pasted, straight from its own transcript store.
+
+    Without this the prototype guesses the seam by splitting on punctuation and
+    taking the last two sentences. That is wrong twice over: when a recording
+    contains two sentences it looks at the wrong seam entirely, and when a
+    recording ends with NO full stop — the strongest possible signal that it is
+    unfinished — it sees one blob, decides there is nothing to join, and skips.
+
+    The shipped app never has to guess: it knows what it just pasted. Reading
+    the store gives the prototype the same knowledge and makes it faithful.
+    """
+    try:
+        files = [os.path.join(TRANSCRIPTS, f) for f in os.listdir(TRANSCRIPTS)
+                 if f.endswith(".json")]
+    except OSError:
+        return None
+    if not files:
+        return None
+    newest = max(files, key=os.path.getmtime)
+    if time.time() - os.path.getmtime(newest) > 600:
+        return None  # stale: nothing dictated recently
+    try:
+        data = json.load(open(newest, encoding="utf-8"))
+    except Exception:
+        return None
+    text = (data.get("polishedText") or data.get("text") or "").strip()
+    return text or None
+
+
+# ── writing to the field ─────────────────────────────────────────────────────
+
+def post_key(keycode, flags=0):
+    source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    for pressed in (True, False):
+        event = Quartz.CGEventCreateKeyboardEvent(source, keycode, pressed)
+        if flags:
+            Quartz.CGEventSetFlags(event, flags)
+        Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+        time.sleep(0.004)
+
+
+def selected_range(element):
+    raw = attr(element, "AXSelectedTextRange")
+    if raw is None:
+        return None
+    ok, value = AXValueGetValue(raw, kAXValueCFRangeType, None)
+    return (int(value[0]), int(value[1])) if ok else None
+
+
+def select_range(element, location, length):
+    """Ask the app to select exactly these characters, and CHECK that it did.
+
+    An accessibility call that returns success and changes nothing is the
+    failure mode this whole prototype keeps hitting, and here it would be
+    destructive rather than merely useless: an ignored selection means the paste
+    lands next to the old text instead of on top of it, doubling the sentence.
+    So the range is read back before anything is written.
+    """
+    value = AXValueCreate(kAXValueCFRangeType, (location, length))
+    if value is None:
+        return False
+    if AXUIElementSetAttributeValue(element, "AXSelectedTextRange", value) != 0:
+        return False
+    time.sleep(0.05)
+    return selected_range(element) == (location, length)
+
+
+def terminal_line(element):
+    value = attr(element, "AXValue")
+    if not isinstance(value, str):
+        return None
+    return terminal_text(value).strip()
+
+
+def wait_for_change(element, previous, timeout=1.5):
+    """Read back only once the screen has actually moved.
+
+    A fixed sleep after posting keys reads a screen that has not repainted yet.
+    That is how the check reported "wanted '', last saw 'I'" on runs whose text
+    ended up perfectly correct: it was looking at a stale frame. Harmless when
+    nothing remains to delete, and NOT harmless otherwise — it would have fired
+    corrective backspaces into text the user was keeping.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        current = terminal_line(element)
+        if current is not None and current != previous:
+            return current
+        time.sleep(0.05)
+    return terminal_line(element)
+
+
+def settle_deletion(element, expected, before, budget=8):
+    """Confirm the deletion actually landed, and finish it if it did not.
+
+    The founder has seen the replacement stop one character short twice. A
+    twenty-run stress test in the very same text box deleted all 46 characters
+    all 20 times, so a dropped keystroke is NOT the cause and guessing again
+    would be the third guess. Instead: read the line back, correct the
+    difference, and report what was actually seen so the next occurrence
+    identifies itself rather than needing another screenshot.
+
+    Bounded on purpose. Correcting one stray character is repair; hammering
+    backspace until some expectation is met is how a bug becomes data loss.
+    """
+    expected = expected.strip()
+    current = wait_for_change(element, before)
+    for _ in range(3):
+        if current is None or current.strip() == expected:
+            return None
+        current = current.strip()
+        if current.startswith(expected):
+            extra = len(current) - len(expected)
+            if extra > budget:
+                return f"{extra} characters too many left, refusing to keep deleting"
+            for _ in range(extra):
+                post_key(DELETE_KEY)
+            current = wait_for_change(element, current)
+            continue
+        if expected.startswith(current):
+            # Deleted too far. Put back what was taken; never leave it short.
+            type_text(expected[len(current):])
+            current = wait_for_change(element, current)
+            continue
+        return f"expected {expected!r}, found {current!r}"
+    # Say WHAT it saw. "did not settle" on its own sent the last round back to
+    # guesswork and a screenshot; the two strings identify the cause on sight.
+    return f"did not settle — wanted {expected!r}, last saw {current!r}"
+
+
+def replace_span(element, caret, span_length, replacement, expected_after=None):
+    """Swap the `span_length` characters ending at the caret for `replacement`.
+
+    Two mechanisms, measured across TextEdit, Chrome (both a plain textarea and
+    a contenteditable), Slack, Excel and Ghostty on 2026-07-25:
+
+      selection + paste   one call to select, one Cmd+V. Flat 0.37 s whatever
+                          the length. Correct everywhere it is available, and
+                          the app's own editor model follows it.
+      backspace + paste   what this used to do always. 1.37 s for a real
+                          two-sentence seam and rising with every character,
+                          and in a browser contenteditable it silently turns
+                          the space at the seam into a non-breaking space.
+
+    So selection is the default and backspace is the fallback, chosen by whether
+    the app reports a caret at all rather than by an app name. Terminals do not,
+    which is also the only surface where backspace is the one thing that works:
+    shift+arrow selection arrives there as literal escape sequences.
+
+    Rejected outright: writing the whole value through accessibility was the
+    fastest of all at 0.15 s and looked correct, but in Slack and in a
+    contenteditable the editor never saw it — the next character typed landed at
+    the very start of the field. Reading the text back cannot detect that.
+    """
+    if caret is not None and caret >= span_length:
+        if select_range(element, caret - span_length, span_length):
+            paste(replacement)
+            return "selection"
+    before = terminal_line(element) if expected_after is not None else None
+    for _ in range(span_length):
+        post_key(DELETE_KEY)
+    note = ""
+    if expected_after is not None:
+        problem = settle_deletion(element, expected_after, before)
+        if problem:
+            note = f", deletion check: {problem}"
+    paste(replacement)
+    return "backspace" + note
+
+
+def type_text(text):
+    """Type characters as key events. Used only to put back an over-deletion."""
+    source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    for character in text:
+        for pressed in (True, False):
+            event = Quartz.CGEventCreateKeyboardEvent(source, 0, pressed)
+            Quartz.CGEventKeyboardSetUnicodeString(event, len(character), character)
+            Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+        time.sleep(0.01)
+
+
+def paste(text):
+    board = NSPasteboard.generalPasteboard()
+    saved = board.stringForType_(NSPasteboardTypeString)
+    board.clearContents()
+    board.setString_forType_(text, NSPasteboardTypeString)
+    time.sleep(0.06)
+    post_key(V_KEY, Quartz.kCGEventFlagMaskCommand)
+    time.sleep(0.3)
+    board.clearContents()
+    if saved:
+        board.setString_forType_(saved, NSPasteboardTypeString)
+
+
+# ── the join ─────────────────────────────────────────────────────────────────
+
+def looks_unsafe(before, after):
+    """Reasons to abandon rather than write. Each one was seen for real today."""
+    if after.strip() == before.strip():
+        return "nothing changed"
+    if len(after.split()) < 0.6 * len(before.split()):
+        return f"lost too many words ({len(before.split())} -> {len(after.split())})"
+    if len(after.split()) > 1.6 * len(before.split()):
+        return f"invented too many words ({len(before.split())} -> {len(after.split())})"
+    lowered = after.lower()
+    for tell in ("could you", "please share", "i need the", "the transcript you",
+                 "appears to be", "i don't see"):
+        if tell in lowered:
+            return "model replied to us instead of cleaning the text"
+    return None
+
+
+def do_join(client, model, system):
+    element, app, problem = focused()
+    if problem:
+        print(f"  SKIPPED  {problem}\n")
+        return
+
+    position = caret_position(element)
+    value = attr(element, "AXValue")
+
+    # Ghostty (and terminals generally) always report the caret at 0, so
+    # "text before the cursor" is empty by definition and the bounded read
+    # returns nothing. When the caret is unusable, the most recent content is
+    # the TAIL of the value instead — in a terminal that is what was just typed.
+    if position and position > 0:
+        before_caret = text_before_caret(element, position)
+        if not before_caret.strip() and isinstance(value, str):
+            before_caret = value[:position]
+        source = "before the cursor"
+        raw_tail = before_caret
+        before_caret = strip_chrome(after_shell_prompt(before_caret))
+    elif isinstance(value, str) and value.strip():
+        # One reader for terminals, and it preserves trailing whitespace.
+        raw_tail = value[-TERMINAL_WINDOW:]
+        before_caret = terminal_text(value)
+        source = "end of the field (this app does not report a cursor position)"
+    else:
+        raw_tail = before_caret = ""
+        source = ""
+
+    if not before_caret.strip():
+        print(f"  SKIPPED  {app}: nothing readable in the field\n")
+        return
+
+    # Prefer the REAL recording boundary over guessing it from punctuation.
+    recording = latest_recording()
+    target = None
+    if recording:
+        flexible = loose_pattern(recording)
+        hit = list(re.finditer(flexible, before_caret))
+        if hit:
+            context = before_caret[:hit[-1].start()].rstrip()
+            if context:
+                previous = sentences_in(context)
+                if previous:
+                    target = f"{previous[-1]} {before_caret[hit[-1].start():].strip()}"
+                    print(f"  seam     using the real recording boundary")
+
+    if target is None:
+        found = sentences_in(before_caret)
+        if len(found) < 2:
+            print(f"  SKIPPED  {app}: only one sentence before the cursor, "
+                  f"nothing to join with\n")
+            return
+        target = f"{found[-2]} {found[-1]}"
+    print(f"  app      {app}  ({source})")
+    print(f"  reading  {target}")
+
+    try:
+        response = client.messages.create(
+            model=model, max_tokens=800, temperature=0, system=system,
+            messages=[{"role": "user", "content": f"Transcript to clean:\n\n{target}"}])
+        result = response.content[0].text.strip()
+    except Exception as exc:
+        print(f"  FAILED   polish call: {type(exc).__name__}\n")
+        return
+
+    print(f"  polished {result}")
+
+    # Deciding NOT to join is the system working, not the system failing. Both
+    # used to print as "SKIPPED nothing changed", so a correct refusal was
+    # indistinguishable from a fault and read to the founder as "not firing".
+    if result.strip() == target.strip():
+        print("  DECIDED  two separate thoughts, correctly left alone\n")
+        return
+
+    reason = looks_unsafe(target, result)
+    if reason:
+        print(f"  SKIPPED  {reason}, field untouched\n")
+        return
+
+    # Delete the REAL span, not the length of the rebuilt string. `target` joins
+    # the two halves with exactly one space; the field may hold two spaces or a
+    # newline, so counting the reconstruction leaves a stray character behind.
+    # Anchor on where the earlier sentence actually starts in the raw text.
+    # Locate the span with WHITESPACE-TOLERANT matching. `found[-2]` comes from
+    # cleaned text: chrome stripped, line breaks collapsed to spaces. A literal
+    # search for it in the raw screen text fails whenever the field held a
+    # newline or a double space, which is most of the time — every "cannot
+    # locate the text to replace" skip was this, on joins that were correct.
+    # Match the WHOLE target and delete exactly what it spans. Deleting from the
+    # anchor to the end of the buffer assumed the edited text is the last thing
+    # on screen; in a TUI it is not. Claude Code renders its input box in the
+    # MIDDLE, with a status bar below, so "to the end" meant 214 characters for
+    # 51 of prose and would have eaten UI that is not editable.
+    flexible = loose_pattern(target)
+    expected_after = None
+
+    if position and position > 0:
+        # A real text field: the window ends AT the caret, so the span runs from
+        # where the match starts to the caret — not the width of the match
+        # itself. Those differ whenever whitespace sits after the sentence, and
+        # counting the match instead shifted the deletion one character left.
+        matches = list(re.finditer(flexible, raw_tail))
+        if not matches:
+            print("  SKIPPED  cannot locate the text to replace in the field\n")
+            return
+        to_delete = len(raw_tail) - matches[-1].start()
+    else:
+        # A terminal, counted from the PARSED line rather than the raw screen.
+        # The raw screen contains the line wraps and the box's own padding, so
+        # its character count is not the buffer's: one run counted 126 against a
+        # buffer of 149 and left 23 characters of the old sentence behind. The
+        # parsed line is exact — typing 126 characters into the real box and
+        # reading it back returns 126 — so it is the only honest ruler here.
+        matches = list(re.finditer(flexible, before_caret))
+        if not matches:
+            print("  SKIPPED  cannot locate the text to replace in the field\n")
+            return
+        # Deliberately delete FEWER than the count suggests, one per wrap, then
+        # let the check below finish the job. The two error directions are not
+        # equal: a character left behind is visible and can be removed, while a
+        # space eaten off the front is invisible to any comparison that strips
+        # whitespace, so it can never be detected and repaired. Bias towards the
+        # mistake that can be seen.
+        to_delete = len(before_caret) - matches[-1].start() - terminal_wraps(value)
+        expected_after = before_caret[:matches[-1].start()].strip()
+
+    # Screen content AFTER the match is not a problem: in a TUI the input box
+    # sits mid-screen with a status bar below, but the caret is inside the box,
+    # so backspaces only consume the box's own text. What matters is that the
+    # caret sits at the end of what we matched, which it does straight after
+    # dictating. Sanity-check the count instead.
+    if to_delete > len(target) + 40:
+        print(f"  SKIPPED  span looks wrong ({to_delete} chars for "
+              f"{len(target)} of text), field untouched\n")
+        return
+
+    # Supply BOTH separators rather than trying to preserve them. The check
+    # above converges on the text with whitespace stripped, so whatever spaces
+    # sat either side of the replaced sentence are gone by design; writing them
+    # back is deterministic, where reading them was not. The trailing one also
+    # matches the app's own paste, so the next dictation does not land flush.
+    if expected_after is None:
+        to_paste = result
+    else:
+        to_paste = (" " if expected_after else "") + result + " "
+
+    how = replace_span(element, position, to_delete, to_paste, expected_after)
+    print(f"  DONE     replaced {to_delete} characters by {how}\n")
+
+
+# ── hotkey plumbing ──────────────────────────────────────────────────────────
+
+def main():
+    from anthropic import AnthropicBedrock
+
+    client = AnthropicBedrock(
+        aws_access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        aws_region="us-east-1")
+    model = os.environ.get("SEAM_MODEL", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+
+    repo = os.path.expanduser("~/Developer/EnviousLabs/EnviousWispr")
+    swift = os.path.join(repo, "Sources/EnviousWisprLLM/Prompting/CloudFixedPromptBuilder.swift")
+    match = re.search(r'cloudFixedSystemPrompt = """\n(.*?)\n\s*"""',
+                      open(swift, encoding="utf-8").read(), re.DOTALL)
+    if not match:
+        print("could not read the shipped polish prompt", file=sys.stderr)
+        return 1
+    system = match.group(1) + JOIN_NOTE
+
+    print("\n  Seam-join prototype — running\n")
+    print("  1. click into a REAL text box (Notes, Slack, Mail, a browser)")
+    print("     it will refuse to touch a terminal, including this one")
+    print("  2. dictate a half thought, pause, dictate the rest")
+    print("  3. hold LEFT control + option + command, then let go")
+    print("\n  Ctrl-C to stop.\n")
+
+    busy = {"now": False}
+
+    def on_event(proxy, event_type, event, refcon):
+        held = (Quartz.CGEventGetFlags(event) & CHORD) == CHORD
+        if held and not busy["now"]:
+            busy["now"] = True
+
+            def run():
+                # Wait for release: backspaces posted while command is held
+                # become command-delete and wipe the whole line.
+                while (Quartz.CGEventSourceFlagsState(
+                        Quartz.kCGEventSourceStateHIDSystemState) & CHORD):
+                    time.sleep(0.03)
+                time.sleep(0.15)
+                print("  ── triggered")
+                try:
+                    do_join(client, model, system)
+                except Exception as exc:
+                    print(f"  FAILED   {type(exc).__name__}: {exc}\n")
+                busy["now"] = False
+
+            threading.Thread(target=run, daemon=True).start()
+        return event
+
+    tap = Quartz.CGEventTapCreate(
+        Quartz.kCGSessionEventTap, Quartz.kCGHeadInsertEventTap,
+        Quartz.kCGEventTapOptionListenOnly,
+        Quartz.CGEventMaskBit(Quartz.kCGEventFlagsChanged), on_event, None)
+    if not tap:
+        print("Could not listen for the hotkey. Give Terminal Accessibility "
+              "permission in System Settings > Privacy & Security.", file=sys.stderr)
+        return 1
+    Quartz.CFRunLoopAddSource(
+        Quartz.CFRunLoopGetCurrent(),
+        Quartz.CFMachPortCreateRunLoopSource(None, tap, 0),
+        Quartz.kCFRunLoopCommonModes)
+    Quartz.CGEventTapEnable(tap, True)
+    Quartz.CFRunLoopRun()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/join_hotkey.py
+++ b/research/seam-joining/code/join_hotkey.py
@@ -226,12 +226,10 @@ def terminal_text(value):
 def terminal_wraps(value):
     """How many times the input box wrapped the line onto a new row.
 
-    Each wrap is a place where the screen shows a line break and the buffer may
-    or may not hold a space — the two are indistinguishable when reading the
-    screen back. Every wrap is therefore a potential phantom character in any
-    count derived from the screen, and counting one too many deletes the space
-    in FRONT of the text being replaced: "…stage it. The tests" came back as
-    "…stage it.The tests".
+    Any wrap at all means the screen cannot be read back faithfully, so this is
+    now a REFUSAL signal rather than a number to compensate for. See the caller
+    for the three ambiguities a wrap introduces and why only refusing closes
+    them all.
     """
     body = input_box_body(value[-TERMINAL_WINDOW:].splitlines())
     return max(0, len(body) - 1) if body else 0
@@ -561,7 +559,31 @@ def do_join(client, model, system):
         raw_tail = before_caret
         before_caret = strip_chrome(after_shell_prompt(before_caret))
     elif isinstance(value, str) and value.strip():
-        # One reader for terminals, and it preserves trailing whitespace.
+        # THE WHOLE CLASS, closed at its source rather than patched again.
+        #
+        # A terminal shows a grid of cells, not the text buffer behind it, and
+        # reconstructing one from the other is ambiguous in at least three ways
+        # that each cost a review round:
+        #   1. trailing whitespace is indistinguishable from cell padding
+        #   2. a soft wrap may have replaced a space, or may not have
+        #   3. a soft wrap may fall MID-WORD, so joining rows with a space
+        #      invents text: "recognizing" reconstructs as "recog nizing"
+        # The third is unrecoverable. The invented text does not match the real
+        # recording, the code falls back to splitting on punctuation, and it
+        # then rewrites the user's sentence around a word that was never there.
+        #
+        # Every one of these exists only because the box wrapped. So refuse a
+        # wrapped box. A single-row box has no wrap, no phantom space and no
+        # invented word, and the earlier compensation arithmetic disappears with
+        # the ambiguity it was compensating for.
+        #
+        # Prototype-only. The shipped feature reads a real focused text field
+        # and never reconstructs anything from a screen.
+        if terminal_wraps(value):
+            print(f"  SKIPPED  {app}: the input box has wrapped onto more than "
+                  f"one line, and a wrapped terminal cannot be read back "
+                  f"faithfully\n")
+            return
         raw_tail = value[-TERMINAL_WINDOW:]
         before_caret = terminal_text(value)
         source = "end of the field (this app does not report a cursor position)"
@@ -658,16 +680,7 @@ def do_join(client, model, system):
         if not matches:
             print("  SKIPPED  cannot locate the text to replace in the field\n")
             return
-        # Deliberately delete FEWER than the count suggests, one per wrap, then
-        # let the check below finish the job. The two error directions are not
-        # equal: a character left behind is visible and can be removed, while a
-        # space eaten off the front is invisible to any comparison that strips
-        # whitespace, so it can never be detected and repaired. Bias towards the
-        # mistake that can be seen.
-        trimmed = terminal_wraps(value)
         span_text = before_caret[matches[-1].start():]
-        if trimmed:
-            span_text = span_text[:-trimmed]
         expected_after = before_caret[:matches[-1].start()].strip()
 
     # Screen content AFTER the match is not a problem: in a TUI the input box

--- a/research/seam-joining/code/join_hotkey.py
+++ b/research/seam-joining/code/join_hotkey.py
@@ -34,7 +34,8 @@ import time
 import regex
 
 import Quartz
-from AppKit import NSPasteboard, NSPasteboardTypeString, NSWorkspace
+from AppKit import (NSPasteboard, NSPasteboardItem,
+                    NSPasteboardTypeString, NSWorkspace)
 from ApplicationServices import (AXUIElementCopyAttributeValue,
                                  AXUIElementCopyParameterizedAttributeValue,
                                  AXUIElementCreateApplication,
@@ -487,13 +488,19 @@ def replace_span(element, caret, span_text, replacement, expected_after=None):
     before = terminal_line(element) if expected_after is not None else None
     for _ in range(keypress_length(span_text)):
         post_key(DELETE_KEY)
-    note = ""
     if expected_after is not None:
         problem = settle_deletion(element, expected_after, before)
         if problem:
-            note = f", deletion check: {problem}"
+            # ABORT, do not paste. settle_deletion refuses precisely when the
+            # remaining text cannot be reconciled — too much left, or a prefix
+            # that is not what we expected — which means we no longer know what
+            # is in the field. Pasting on top of that writes the joined sentence
+            # into unknown text and makes a recoverable mess unrecoverable.
+            # It was previously logged and then pasted anyway. Found by cloud
+            # review on PR #1793.
+            return f"ABORTED before pasting, {problem}"
     paste(replacement)
-    return "backspace" + note
+    return "backspace"
 
 
 def type_text(text):
@@ -508,16 +515,43 @@ def type_text(text):
 
 
 def paste(text):
+    """Paste `text`, and put the clipboard back the way it was found.
+
+    Saving only the plain-string representation destroyed everything else on the
+    clipboard: a copied image, a file, or rich text with no string form left
+    `saved` as None and the restore silently dropped it. Even a text item lost
+    its styled and HTML flavours. The user never asked us to touch their
+    clipboard at all, so losing what was on it is our bug, not a side effect.
+    Found by cloud review on PR #1793.
+
+    Every item and every type is snapshotted and written back.
+    """
     board = NSPasteboard.generalPasteboard()
-    saved = board.stringForType_(NSPasteboardTypeString)
+    saved = []
+    for item in (board.pasteboardItems() or []):
+        flavours = {}
+        for kind in (item.types() or []):
+            data = item.dataForType_(kind)
+            if data is not None:
+                flavours[kind] = data
+        if flavours:
+            saved.append(flavours)
+
     board.clearContents()
     board.setString_forType_(text, NSPasteboardTypeString)
     time.sleep(0.06)
     post_key(V_KEY, Quartz.kCGEventFlagMaskCommand)
     time.sleep(0.3)
+
     board.clearContents()
-    if saved:
-        board.setString_forType_(saved, NSPasteboardTypeString)
+    restored = []
+    for flavours in saved:
+        item = NSPasteboardItem.alloc().init()
+        for kind, data in flavours.items():
+            item.setData_forType_(data, kind)
+        restored.append(item)
+    if restored:
+        board.writeObjects_(restored)
 
 
 # ── the join ─────────────────────────────────────────────────────────────────

--- a/research/seam-joining/code/measure_replace.py
+++ b/research/seam-joining/code/measure_replace.py
@@ -1,0 +1,331 @@
+"""Stage a real field in a real app, run every replacement route, read it back.
+
+The question, from the founder: backspacing forty times is slow to watch and
+sometimes drops a keystroke, so is there a faster and more reliable way to swap
+one span of text for another. Nobody can answer that from documentation — this
+morning an accessibility call returned success in Chrome and changed nothing.
+
+So every route is judged the same way: stage a known sentence, run the route,
+read the field back, and require the EXACT expected string. Timing is recorded
+alongside, but a fast route that produces the wrong text is not a candidate.
+
+  python measure_replace.py textedit
+  python measure_replace.py chrome        (also: chrome-contenteditable)
+  python measure_replace.py ghostty
+  python measure_replace.py slack
+  python measure_replace.py excel
+  python measure_replace.py focused       (whatever is focused right now)
+
+Every app is left as it was found: the staged text is cleared at the end and
+the result verified, so a failed cleanup is reported rather than left behind.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import probe_replace_routes as R  # noqa: E402
+import join_hotkey as J  # noqa: E402
+
+import Quartz  # noqa: E402
+
+# The replacement is a DIFFERENT length from the span, so an off-by-one route
+# cannot pass by luck. 20 characters out, 23 in.
+#
+# No apostrophe anywhere: TextEdit's smart quotes rewrote a typed ' into a ’ and
+# every route failed staging rather than failing on its own merits.
+STAGED = "I will head out now. Shower tonight."
+SPAN = "now. Shower tonight."
+REPLACEMENT = "now and shower tonight."
+EXPECTED = "I will head out now and shower tonight."
+
+# A real seam is two whole dictated sentences, not twenty characters. Backspace
+# cost is linear in the span, so a short case flatters it; this is the size the
+# mechanism actually has to survive.
+LONG_STAGED = ("Here are my notes. I was thinking about the release and how we "
+               "should stage it. But the tests are still red.")
+LONG_SPAN = ("I was thinking about the release and how we should stage it. "
+             "But the tests are still red.")
+LONG_REPLACEMENT = ("I was thinking about how we should stage the release, but "
+                    "the tests are still red.")
+LONG_EXPECTED = "Here are my notes. " + LONG_REPLACEMENT
+
+
+def use_long_case():
+    """Swap the module-level fixture; the probes read these by name."""
+    global STAGED, SPAN, REPLACEMENT, EXPECTED
+    STAGED, SPAN = LONG_STAGED, LONG_SPAN
+    REPLACEMENT, EXPECTED = LONG_REPLACEMENT, LONG_EXPECTED
+
+CLEAR_LINE = 21  # ctrl-U
+A_KEY = 0
+
+
+class Surface:
+    """One app, staged and read the way that app actually works."""
+
+    def __init__(self, name, launch=None, terminal=False, note=""):
+        self.name, self.launch, self.terminal, self.note = name, launch, terminal, note
+
+    def activate(self):
+        if self.launch:
+            self.launch()
+        time.sleep(1.2)
+        _, front = R.frontmost()
+        return front
+
+    def element(self):
+        element, _ = R.focused_element()
+        return element
+
+    def read(self, element):
+        value = R.attr(element, "AXValue")
+        if not isinstance(value, str):
+            return None
+        if self.terminal:
+            # A terminal hands over the whole scrollback; only the current
+            # input line is ours (join_hotkey.py explains why at length).
+            return J.terminal_text(value).strip()
+        return value.strip()
+
+    def caret(self, element):
+        if self.terminal:
+            return None  # Ghostty always reports 0, which is not a caret
+        selection = R.read_range(element)
+        return selection[0] if selection else None
+
+    def clear(self, element):
+        """Empty the field and PROVE it emptied.
+
+        ctrl-U silently failed in Ghostty once already, so cases two and three
+        ran against leftovers and reported failures the routes did not cause.
+        """
+        for attempt in range(4):
+            current = self.read(element) or ""
+            if not current.strip():
+                return True
+            if self.terminal:
+                R.post_key(CLEAR_LINE, Quartz.kCGEventFlagMaskControl)
+                time.sleep(0.2)
+                if (self.read(element) or "").strip():
+                    for _ in range(len(current) + 8):
+                        R.post_key(R.DELETE_KEY, settle=0.003)
+            else:
+                R.post_key(A_KEY, Quartz.kCGEventFlagMaskCommand)
+                time.sleep(0.1)
+                R.post_key(R.DELETE_KEY)
+            time.sleep(0.25)
+        return not (self.read(element) or "").strip()
+
+    def stage(self, element):
+        if not self.clear(element):
+            return "could not clear the field"
+        R.type_text(STAGED)
+        time.sleep(0.4)
+        got = self.read(element)
+        if got is None:
+            return "cannot read the field back"
+        if got.strip() != STAGED.strip():
+            return f"staged the wrong text: {got!r}"
+        return None
+
+
+# ── per-app launchers ────────────────────────────────────────────────────────
+
+def applescript(script):
+    return subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+
+
+def launch_textedit():
+    applescript('tell application "TextEdit" to close every document saving no')
+    time.sleep(0.3)
+    applescript('tell application "TextEdit" to activate')
+    time.sleep(0.5)
+    applescript('tell application "TextEdit" to make new document')
+    time.sleep(0.6)
+    applescript('tell application "TextEdit" to activate')
+
+
+def chrome_page(html_body, filename):
+    """A local page, because Chrome refuses top-level data: URLs.
+
+    Written under the job's own temp directory so parallel work cannot collide.
+    """
+    job = os.environ.get("CLAUDE_JOB_DIR")
+    directory = os.path.join(job, "tmp") if job else "/tmp"
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, filename)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(html_body)
+    subprocess.run(["open", "-a", "Google Chrome", path], capture_output=True)
+    time.sleep(2.5)
+    applescript('tell application "Google Chrome" to activate')
+
+
+def launch_chrome_textarea():
+    chrome_page(
+        "<!doctype html><meta charset=utf-8><title>replace probe</title>"
+        "<body style='font:16px system-ui;padding:40px'>"
+        "<p>Seam replacement probe. Safe to close.</p>"
+        "<textarea autofocus rows=6 cols=60 style='font:16px system-ui'></textarea>",
+        "seam_probe_textarea.html")
+
+
+def launch_chrome_contenteditable():
+    chrome_page(
+        "<!doctype html><meta charset=utf-8><title>replace probe</title>"
+        "<body style='font:16px system-ui;padding:40px'>"
+        "<p>Seam replacement probe. Safe to close.</p>"
+        "<div id=box contenteditable style='border:1px solid #999;padding:10px;"
+        "min-height:80px'></div><script>box.focus()</script>",
+        "seam_probe_contenteditable.html")
+
+
+def launch_ghostty():
+    subprocess.run(["open", "-na", "Ghostty"], capture_output=True)
+
+
+def launch_slack():
+    applescript('tell application "Slack" to activate')
+
+
+def launch_excel():
+    applescript('tell application "Microsoft Excel" to activate')
+    time.sleep(3.0)
+    applescript('tell application "Microsoft Excel" to make new workbook')
+    time.sleep(2.5)
+    applescript('tell application "Microsoft Excel" to select range "A1" of active sheet')
+
+
+class ExcelSurface(Surface):
+    """A spreadsheet cell is only a text field while it is being edited.
+
+    Outside edit mode Excel exposes an AXLayoutArea with no value, and Cmd+A
+    means "select every cell in the sheet" rather than "select this text" — so
+    the ordinary clear would have selected the whole workbook. Typing is what
+    enters edit mode, and backspace is what leaves the sheet alone.
+    """
+
+    def read(self, element):
+        element, _ = R.focused_element()
+        value = R.attr(element, "AXValue") if element is not None else None
+        return value.strip() if isinstance(value, str) else ""
+
+    def element(self):
+        element, _ = R.focused_element()
+        return element
+
+    def clear(self, element):
+        for _ in range(4):
+            current = self.read(element)
+            if not current:
+                return True
+            for _ in range(len(current) + 4):
+                R.post_key(R.DELETE_KEY, settle=0.003)
+            time.sleep(0.3)
+        return not self.read(element)
+
+
+SURFACES = {
+    "textedit": Surface("TextEdit", launch_textedit),
+    "chrome": Surface("Chrome (textarea)", launch_chrome_textarea),
+    "chrome-contenteditable": Surface("Chrome (contenteditable)",
+                                      launch_chrome_contenteditable),
+    "ghostty": Surface("Ghostty", launch_ghostty, terminal=True),
+    "slack": Surface("Slack", launch_slack,
+                     note="staged in whatever composer is focused; never sends"),
+    "excel": ExcelSurface("Excel", launch_excel,
+                          note="a new workbook; cell A1, discarded afterwards"),
+    "focused": Surface("whatever is focused", None),
+}
+
+
+# ── the measurement ──────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("surface", choices=sorted(SURFACES))
+    parser.add_argument("--repeat", type=int, default=1,
+                        help="runs per route, to expose intermittent drops")
+    parser.add_argument("--long", action="store_true",
+                        help="a real two-sentence seam instead of a short one")
+    parser.add_argument("--only", default="",
+                        help="prefix letters of the routes to run, e.g. AB")
+    args = parser.parse_args()
+
+    if args.long:
+        use_long_case()
+    surface = SURFACES[args.surface]
+    front = surface.activate()
+    print(f"\n{surface.name}  (frontmost: {front})")
+    if surface.note:
+        print(f"  note: {surface.note}")
+
+    element = surface.element()
+    if element is None:
+        print("  no focused element — nothing to measure")
+        return 1
+    role = R.attr(element, "AXRole")
+    print(f"  focused role: {role}")
+    print(f"  replacing {len(SPAN)} characters with {len(REPLACEMENT)}\n")
+
+    results = []
+    for label, route in R.ROUTES:
+        if args.only and label[0] not in args.only:
+            continue
+        outcomes, timings = [], []
+        for _ in range(args.repeat):
+            # Re-fetch every run: a spreadsheet cell is a different element
+            # while it is being edited than while it is merely selected.
+            element = surface.element()
+            problem = surface.stage(element)
+            if problem:
+                outcomes.append(f"HARNESS: {problem}")
+                continue
+            caret = surface.caret(element)
+            unavailable, elapsed = R.run_route(route, element, len(SPAN),
+                                               REPLACEMENT, caret)
+            time.sleep(0.25)
+            after = surface.read(element)
+            if unavailable:
+                outcomes.append(f"UNAVAILABLE ({unavailable})")
+                continue
+            timings.append(elapsed)
+            if after is None:
+                outcomes.append("could not read back")
+            elif after.strip() == EXPECTED:
+                outcomes.append("CORRECT")
+            elif after.strip() == STAGED:
+                outcomes.append("SILENT NO-OP")
+            else:
+                outcomes.append(f"WRONG -> {after!r}")
+
+        correct = sum(1 for o in outcomes if o == "CORRECT")
+        speed = f"{sum(timings)/len(timings):7.0f} ms" if timings else "      -   "
+        summary = (f"{correct}/{args.repeat}" if args.repeat > 1
+                   else ("ok" if correct else "no"))
+        print(f"  {label:28} {speed}  {summary:6} {outcomes[0]}")
+        for extra in outcomes[1:]:
+            if extra != outcomes[0]:
+                print(f"  {'':28} {'':10}  {'':6} {extra}")
+        results.append((label, correct, timings))
+
+    if not surface.clear(element):
+        print("\n  CLEANUP FAILED — the field still holds probe text")
+        return 1
+    print("\n  field cleared")
+
+    winners = [(l, sum(t)/len(t)) for l, c, t in results if c == args.repeat and t]
+    if winners:
+        best = min(winners, key=lambda pair: pair[1])
+        print(f"  fastest route that was always correct: {best[0]}  {best[1]:.0f} ms")
+    else:
+        print("  no route was correct on every run")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/positional_stress.py
+++ b/research/seam-joining/code/positional_stress.py
@@ -1,0 +1,190 @@
+"""Does the model hold up wherever the cut lands?
+
+The shared held-out set does not answer this. Both arms sit near its ceiling, so
+it cannot separate them, and it carries whatever cut-position distribution its
+own generator happened to produce. That is the wrong instrument for a change
+whose entire claim is about cut POSITION.
+
+This builds the right one. Take source texts the model has never seen, cut each
+at EVERY valid position, and report accuracy by what kind of word the cut
+followed. If training on one arbitrary cut per sentence leaves blind spots, they
+show up here as a class of preceding word the model gets wrong, and a model
+trained across the spectrum should be flat instead.
+
+Flat is the result to want. A high average with a bad bucket is exactly the
+failure the founder's directive predicts, and an average would hide it.
+"""
+
+import argparse
+import json
+import os
+import random
+import sys
+from collections import defaultdict
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+SEAM = "<seam>"
+TERMINATORS = (".", "!", "?")
+
+# Closed-class buckets, so "what kind of word preceded the cut" is a real
+# category rather than a bag of individual words.
+FUNCTION_WORDS = {
+    "articles": {"a", "an", "the"},
+    "prepositions": {"of", "in", "on", "at", "for", "with", "from", "by", "to",
+                     "into", "about", "over", "under", "through", "between"},
+    "conjunctions": {"and", "but", "or", "so", "because", "although", "while",
+                     "if", "when", "since", "that", "which", "as"},
+    "auxiliaries": {"is", "are", "was", "were", "am", "be", "been", "being",
+                    "has", "have", "had", "do", "does", "did", "will", "would",
+                    "can", "could", "should", "may", "might", "must"},
+    "pronouns": {"i", "you", "he", "she", "it", "we", "they", "my", "your",
+                 "his", "her", "its", "our", "their", "this", "these", "those"},
+}
+
+
+def bucket_for(word):
+    bare = word.strip(".,!?;:\"'()").lower()
+    if word.endswith(TERMINATORS):
+        return "after a full stop"
+    if word.endswith(","):
+        return "after a comma"
+    for name, members in FUNCTION_WORDS.items():
+        if bare in members:
+            return f"after {name}"
+    if bare.isdigit():
+        return "after a number"
+    if word[:1].isupper():
+        return "after a capitalised word"
+    return "after an ordinary word"
+
+
+def build(texts, rng, per_text=None):
+    rows = []
+    for text in texts:
+        words = text.split()
+        if len(words) < 10:
+            continue
+        spots = list(range(3, len(words) - 3))
+        if per_text and len(spots) > per_text:
+            spots = rng.sample(spots, per_text)
+        for idx in spots:
+            left = " ".join(words[:idx])
+            right = " ".join(words[idx:])
+            previous = words[idx - 1]
+            if previous.endswith(TERMINATORS):
+                label = "KEEP"
+            elif previous.endswith(","):
+                label = "MERGE_COMMA"
+                left = left.rstrip(",")
+            elif previous[-1:] in ";:":
+                continue
+            else:
+                label = "MERGE_SPACE"
+            # Corrupt exactly as the transcriber does, measured 2026-07-24.
+            roll = rng.random()
+            if label != "KEEP":
+                left = left.rstrip(",;:") + ("." if roll < 0.80 else "" if roll < 0.90 else "?")
+            if rng.random() < 0.90 and right[:1].islower():
+                right = right[0].upper() + right[1:]
+            rows.append({"rec1": left, "rec2": right, "label": label,
+                         "bucket": bucket_for(previous)})
+    return rows
+
+
+def score(model_dir, rows, batch=64):
+    tok = AutoTokenizer.from_pretrained(model_dir)
+    model = AutoModelForSequenceClassification.from_pretrained(model_dir)
+    model.eval()
+    if torch.cuda.is_available():
+        model.cuda()
+    per = defaultdict(lambda: {"n": 0, "ok": 0, "keep": 0, "wrong_merge": 0})
+    for i in range(0, len(rows), batch):
+        chunk = rows[i : i + batch]
+        texts = [f"{' '.join(r['rec1'].split()[-18:])} {SEAM} "
+                 f"{' '.join(r['rec2'].split()[:14])}" for r in chunk]
+        enc = tok(texts, truncation=True, max_length=96, padding=True, return_tensors="pt")
+        if torch.cuda.is_available():
+            enc = {k: v.cuda() for k, v in enc.items()}
+        with torch.no_grad():
+            preds = model(**enc).logits.argmax(-1).tolist()
+        for r, p in zip(chunk, preds):
+            got = LABELS[p]
+            s = per[r["bucket"]]
+            s["n"] += 1
+            s["ok"] += int(got == r["label"])
+            if r["label"] == "KEEP":
+                s["keep"] += 1
+                s["wrong_merge"] += int(got != "KEEP")
+    del model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return per
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("models", nargs="+")
+    ap.add_argument("--per-text", type=int, default=12)
+    args = ap.parse_args()
+
+    # The rig keeps everything flat in the home directory; the Mac keeps data
+    # one level up from the code. Look in both rather than assuming a layout.
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates = [os.path.join(os.path.dirname(here), "data", "seam_test_shared.jsonl"),
+                  os.path.join(here, "seam_test_shared.jsonl"),
+                  "seam_test_shared.jsonl"]
+    path = next((c for c in candidates if os.path.exists(c)), None)
+    if not path:
+        print(f"seam_test_shared.jsonl not found in {candidates}", file=sys.stderr)
+        return 1
+    seen = set()
+    texts = []
+    for line in open(path, encoding="utf-8"):
+        row = json.loads(line)
+        if row.get("language") != "English":
+            continue
+        expected = (row.get("expected") or "").strip()
+        if expected and expected not in seen:
+            seen.add(expected)
+            texts.append(expected)
+
+    rng = random.Random(1790)
+    rows = build(texts, rng, per_text=args.per_text)
+    print(f"positional stress set: {len(rows)} cuts from {len(texts)} unseen texts",
+          file=sys.stderr)
+
+    results = {m: score(m, rows) for m in args.models}
+    buckets = sorted({b for r in results.values() for b in r})
+
+    head = f"{'cut position':28}" + "".join(f"{os.path.basename(m):>22}" for m in args.models)
+    print("\nACCURACY BY WHERE THE CUT LANDED")
+    print(head)
+    print("-" * len(head))
+    for b in buckets:
+        line = f"{b:28}"
+        for m in args.models:
+            s = results[m].get(b)
+            line += f"{100*s['ok']/s['n']:>15.1f}% ({s['n']:>3})" if s and s["n"] else f"{'-':>22}"
+        print(line)
+
+    print("\nWRONG MERGES BY WHERE THE CUT LANDED  (only 'after a full stop' has any)")
+    for b in buckets:
+        cells = ""
+        any_keep = False
+        for m in args.models:
+            s = results[m].get(b)
+            if s and s["keep"]:
+                any_keep = True
+                cells += f"{s['wrong_merge']:>15}/{s['keep']:<6}"
+            else:
+                cells += f"{'-':>22}"
+        if any_keep:
+            print(f"{b:28}{cells}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/probe_ax_modify.py
+++ b/research/seam-joining/code/probe_ax_modify.py
@@ -1,0 +1,195 @@
+"""Can we MODIFY text that is already in another app's document?
+
+Seam joining needs to remove a full stop the previous recording left behind.
+Everything shipped so far only inserts at the cursor. `accessibility-macos.md`
+FACT: reading-caret-context-from-another-app measured READING across these same
+apps and found it works broadly; the write side was never measured, and the
+11.8% `ax_direct` rate is a cascade OUTCOME, not a capability.
+
+This probe answers the capability question directly, per app:
+
+  settable      is `AXSelectedTextRange` writable at all
+  extend        can the selection be extended backwards over the last character
+  replace       does writing `AXSelectedText` over that selection actually
+                change the document, verified by reading the text back
+
+Nothing here drives dictation or reads the clipboard: it types a known sentence
+into the app's own focused field, then tries to remove its final character.
+Run it with the target app frontmost and a text field focused.
+"""
+
+import sys
+import time
+
+from ApplicationServices import (AXUIElementCopyAttributeValue,
+                                 AXUIElementCreateApplication,
+                                 AXUIElementSetAttributeValue, AXValueCreate,
+                                 AXValueGetValue, kAXValueCFRangeType)
+from AppKit import NSWorkspace
+
+FOCUSED = "AXFocusedUIElement"
+SELECTED_RANGE = "AXSelectedTextRange"
+SELECTED_TEXT = "AXSelectedText"
+VALUE = "AXValue"
+ROLE = "AXRole"
+N_CHARS = "AXNumberOfCharacters"
+
+
+def attr(element, name):
+    err, value = AXUIElementCopyAttributeValue(element, name, None)
+    return value if err == 0 else None
+
+
+def running_apps(names):
+    """Resolve app names to pids WITHOUT bringing anything to the front.
+
+    Per-app `AXUIElementCreateApplication(pid)` reaches a background app's
+    focused element, and `accessibility-macos.md` records it as the stronger
+    call than the system-wide one. That matters here: the founder is using this
+    machine, so the probe must not steal focus to measure.
+    """
+    wanted = {n.lower() for n in names}
+    found = []
+    for app in NSWorkspace.sharedWorkspace().runningApplications():
+        label = app.localizedName()
+        if label and label.lower() in wanted:
+            found.append((app.processIdentifier(), label))
+    return found
+
+
+def read_range(element):
+    raw = attr(element, SELECTED_RANGE)
+    if raw is None:
+        return None
+    ok, value = AXValueGetValue(raw, kAXValueCFRangeType, None)
+    if not ok:
+        return None
+    # PyObjC hands a CFRange back as a plain tuple, not a struct.
+    return (int(value[0]), int(value[1]))
+
+
+def write_range(element, location, length):
+    value = AXValueCreate(kAXValueCFRangeType, (location, length))
+    if value is None:
+        return "could not build a range value"
+    err = AXUIElementSetAttributeValue(element, SELECTED_RANGE, value)
+    return None if err == 0 else f"AXError {err}"
+
+
+def probe(pid, name):
+    app = AXUIElementCreateApplication(pid)
+    element = attr(app, FOCUSED)
+    if element is None:
+        print(f"\n{name}  (pid {pid})\n  no focused element — nothing to probe")
+        return
+
+    role = attr(element, ROLE)
+    text = attr(element, VALUE)
+    count = attr(element, N_CHARS)
+    before = read_range(element)
+    print(f"\n{name}  (pid {pid})")
+    print(f"  role            : {role}")
+    print(f"  chars           : {count}")
+    print(f"  caret/selection : {before}")
+    print(f"  text tail       : {repr(text[-40:]) if isinstance(text, str) else text}")
+
+    if before is None:
+        print("  VERDICT         : cannot read a selection — modify is impossible here")
+        return
+
+    caret = before[0]
+    if caret < 1:
+        print("  VERDICT         : caret at position 0, nothing behind it to remove")
+        return
+
+    # 1. Is the range settable at all? Re-select the single character behind
+    #    the caret — the position a stray full stop would occupy.
+    error = write_range(element, caret - 1, 1)
+    if error:
+        print(f"  settable        : NO ({error})")
+        print("  VERDICT         : cannot extend backwards — modify unavailable")
+        return
+    time.sleep(0.05)
+
+    after = read_range(element)
+    extended = after == (caret - 1, 1)
+    print(f"  settable        : yes")
+    print(f"  extend back 1   : {'yes' if extended else f'NO (got {after})'}")
+    if not extended:
+        print("  VERDICT         : selection did not take — modify unreliable here")
+        return
+
+    doomed = attr(element, SELECTED_TEXT)
+    print(f"  selected char   : {repr(doomed)}")
+
+    # 2. Does replacing that selection actually change the document? This is
+    #    the real question: a selection that sets but does not accept a write
+    #    is useless. Delete the character, verify the document actually got
+    #    shorter, then put it back and restore the caret. Verifying by reading
+    #    the text back is the point — an AXError of 0 only says the call was
+    #    accepted, not that anything changed (validation-discipline.md
+    #    RULE: verify-the-feature-not-the-crash).
+    err = AXUIElementSetAttributeValue(element, SELECTED_TEXT, "")
+    time.sleep(0.08)
+    shortened = attr(element, VALUE)
+    deleted = isinstance(shortened, str) and isinstance(text, str) and len(
+        shortened) == len(text) - 1
+
+    print(f"  delete accepted : {'yes' if err == 0 else f'NO (AXError {err})'}")
+    print(f"  document shrank : {'yes' if deleted else 'NO — write was a no-op'}")
+
+    # 3. Put it back, whatever happened, and restore the original selection.
+    restored = False
+    if deleted:
+        AXUIElementSetAttributeValue(element, SELECTED_TEXT, doomed or "")
+        time.sleep(0.08)
+        restored = attr(element, VALUE) == text
+        print(f"  restored        : {'yes' if restored else 'NO — LEFT A CHANGE'}")
+    write_range(element, before[0], before[1])
+
+    if deleted and restored:
+        print("  VERDICT         : MODIFY WORKS — backwards edit available and reversible")
+    elif deleted:
+        print("  VERDICT         : modify works but restore failed — check this app by hand")
+    elif err == 0:
+        print("  VERDICT         : write silently ignored — insert-only in practice")
+    else:
+        print("  VERDICT         : write refused — insert-only app")
+
+
+def activate(pid):
+    for app in NSWorkspace.sharedWorkspace().runningApplications():
+        if app.processIdentifier() == pid:
+            app.activateWithOptions_(1 << 1)  # activateIgnoringOtherApps
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    targets = sys.argv[1:] or [
+        "Slack", "Google Chrome", "Discord", "ChatGPT", "Notes", "TextEdit",
+        "Mail", "Sublime Text", "Notion",
+    ]
+    apps = running_apps(targets)
+    if not apps:
+        print("none of the target apps are running")
+        raise SystemExit(1)
+
+    # A background app reports no focused element, so each target has to be
+    # frontmost for the length of its probe. The founder's app is put back at
+    # the end.
+    NSWorkspace.sharedWorkspace().runningApplications()
+    original = NSWorkspace.sharedWorkspace().frontmostApplication()
+    original_pid = original.processIdentifier() if original else None
+    print(f"Probing {len(apps)} apps. Focus returns to {original.localizedName()} at the end.")
+
+    for pid, name in sorted(apps, key=lambda p: p[1]):
+        try:
+            activate(pid)
+            time.sleep(0.8)
+            probe(pid, name)
+        except Exception as exc:
+            print(f"\n{name}  (pid {pid})\n  probe error: {type(exc).__name__}: {exc}")
+
+    if original_pid:
+        activate(original_pid)

--- a/research/seam-joining/code/probe_edit_cost.py
+++ b/research/seam-joining/code/probe_edit_cost.py
@@ -1,0 +1,134 @@
+"""What does each working edit path COST on a real-sized document?
+
+`probe_edit_paths.py` found two routes that survive Chromium: rewriting the
+whole field value, and posting a backspace. They are not equivalent, and the
+difference only shows up on a document larger than a test sentence:
+
+  latency      rewriting the whole value is O(document); a keystroke is not
+  caret        does the cursor end up where the user left it
+  undo         does the user's own undo history survive
+
+Undo is the one that decides it. If our edit collapses a document's undo stack,
+we have damaged something the user cannot get back, which is a different class
+of harm from a wrong space.
+
+Run with the target app frontmost and a large text field focused.
+"""
+
+import sys
+import time
+
+import Quartz
+from ApplicationServices import (AXUIElementCopyAttributeValue,
+                                 AXUIElementCreateApplication,
+                                 AXUIElementSetAttributeValue, AXValueCreate,
+                                 AXValueGetValue, kAXValueCFRangeType)
+from AppKit import NSWorkspace
+
+DELETE_KEYCODE = 51
+Z_KEYCODE = 6
+
+
+def attr(element, name):
+    err, value = AXUIElementCopyAttributeValue(element, name, None)
+    return value if err == 0 else None
+
+
+def read_range(element):
+    raw = attr(element, "AXSelectedTextRange")
+    if raw is None:
+        return None
+    ok, value = AXValueGetValue(raw, kAXValueCFRangeType, None)
+    return (int(value[0]), int(value[1])) if ok else None
+
+
+def write_range(element, location, length):
+    value = AXValueCreate(kAXValueCFRangeType, (location, length))
+    return value is not None and AXUIElementSetAttributeValue(
+        element, "AXSelectedTextRange", value) == 0
+
+
+def post_key(keycode, flags=0):
+    source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    for pressed in (True, False):
+        event = Quartz.CGEventCreateKeyboardEvent(source, keycode, pressed)
+        if flags:
+            Quartz.CGEventSetFlags(event, flags)
+        Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+        time.sleep(0.01)
+
+
+def frontmost():
+    NSWorkspace.sharedWorkspace().runningApplications()
+    app = NSWorkspace.sharedWorkspace().frontmostApplication()
+    return app.processIdentifier(), app.localizedName()
+
+
+def main():
+    pid, name = frontmost()
+    element = attr(AXUIElementCreateApplication(pid), "AXFocusedUIElement")
+    if element is None:
+        print(f"{name}: no focused element")
+        return 1
+    text = attr(element, "AXValue")
+    selection = read_range(element)
+    if not isinstance(text, str) or len(text) < 200 or selection is None:
+        print(f"{name}: need a focused field with 200+ characters "
+              f"(got {len(text) if isinstance(text,str) else text})")
+        return 1
+
+    caret = selection[0] if selection[0] > 0 else len(text)
+    print(f"\n{name}  chars={len(text)}  caret={caret}")
+
+    # Route B: whole-value rewrite.
+    start = time.perf_counter()
+    AXUIElementSetAttributeValue(element, "AXValue", text[:caret - 1] + text[caret:])
+    b_ms = (time.perf_counter() - start) * 1000
+    time.sleep(0.15)
+    b_after = attr(element, "AXValue")
+    b_worked = isinstance(b_after, str) and len(b_after) == len(text) - 1
+    b_caret = read_range(element)
+    print(f"  B whole-value rewrite : {'works' if b_worked else 'no-op'}  "
+          f"{b_ms:.1f} ms  caret now {b_caret}")
+
+    # Can the USER undo our edit, and does their own history survive?
+    post_key(Z_KEYCODE, Quartz.kCGEventFlagMaskCommand)
+    time.sleep(0.25)
+    undone = attr(element, "AXValue")
+    b_undo = undone == text
+    print(f"  B undo restores       : {'yes' if b_undo else 'NO'}"
+          f"{'' if b_undo else f' (len {len(undone) if isinstance(undone,str) else undone})'}")
+    if not b_undo:
+        AXUIElementSetAttributeValue(element, "AXValue", text)
+        time.sleep(0.15)
+
+    write_range(element, caret, 0)
+    time.sleep(0.1)
+
+    # Route C: synthetic backspace.
+    start = time.perf_counter()
+    post_key(DELETE_KEYCODE)
+    c_ms = (time.perf_counter() - start) * 1000
+    time.sleep(0.15)
+    c_after = attr(element, "AXValue")
+    c_worked = isinstance(c_after, str) and len(c_after) == len(text) - 1
+    c_caret = read_range(element)
+    print(f"  C synthetic backspace : {'works' if c_worked else 'no-op'}  "
+          f"{c_ms:.1f} ms  caret now {c_caret}")
+
+    post_key(Z_KEYCODE, Quartz.kCGEventFlagMaskCommand)
+    time.sleep(0.25)
+    undone = attr(element, "AXValue")
+    c_undo = undone == text
+    print(f"  C undo restores       : {'yes' if c_undo else 'NO'}")
+    if not c_undo:
+        AXUIElementSetAttributeValue(element, "AXValue", text)
+
+    time.sleep(0.1)
+    final = attr(element, "AXValue")
+    print(f"\n  field restored        : {'yes' if final == text else 'NO — CHECK BY HAND'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/probe_edit_paths.py
+++ b/research/seam-joining/code/probe_edit_paths.py
@@ -1,0 +1,177 @@
+"""Which mechanism can actually remove one character from another app's field?
+
+Seam joining has to delete a full stop the previous recording already committed
+to the user's document. `probe_ax_modify.py` established that the obvious route
+works in native apps and is silently ignored in Chromium ones, so this compares
+every route we have on the SAME focused field, back to back.
+
+  A  selection replace   extend the selection back one character, write ""
+  B  whole-value rewrite set AXValue to the text minus its last character
+  C  synthetic backspace post a Delete key event, the same mechanism the
+                         shipped Cmd+V paste already uses
+
+Every route is judged by reading the document back and checking it got exactly
+one character shorter. An accepted call that changes nothing is the failure
+mode this file exists to catch: both Chromium apps return success and do
+nothing (validation-discipline.md RULE: verify-the-feature-not-the-crash).
+
+Each route restores the character afterwards, so a run leaves the field as it
+found it. Run with the target app frontmost and a text field focused.
+"""
+
+import sys
+import time
+
+import Quartz
+from ApplicationServices import (AXUIElementCopyAttributeValue,
+                                 AXUIElementCreateApplication,
+                                 AXUIElementSetAttributeValue, AXValueCreate,
+                                 AXValueGetValue, kAXValueCFRangeType)
+from AppKit import NSWorkspace
+
+DELETE_KEYCODE = 51
+
+
+def attr(element, name):
+    err, value = AXUIElementCopyAttributeValue(element, name, None)
+    return value if err == 0 else None
+
+
+def read_range(element):
+    raw = attr(element, "AXSelectedTextRange")
+    if raw is None:
+        return None
+    ok, value = AXValueGetValue(raw, kAXValueCFRangeType, None)
+    return (int(value[0]), int(value[1])) if ok else None
+
+
+def write_range(element, location, length):
+    value = AXValueCreate(kAXValueCFRangeType, (location, length))
+    if value is None:
+        return False
+    return AXUIElementSetAttributeValue(element, "AXSelectedTextRange", value) == 0
+
+
+def focused(pid):
+    return attr(AXUIElementCreateApplication(pid), "AXFocusedUIElement")
+
+
+def frontmost():
+    NSWorkspace.sharedWorkspace().runningApplications()
+    app = NSWorkspace.sharedWorkspace().frontmostApplication()
+    return app.processIdentifier(), app.localizedName()
+
+
+def post_backspace():
+    source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    for pressed in (True, False):
+        event = Quartz.CGEventCreateKeyboardEvent(source, DELETE_KEYCODE, pressed)
+        Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+        time.sleep(0.01)
+
+
+def route_selection_replace(element, text, caret):
+    if not write_range(element, caret - 1, 1):
+        return "selection not settable"
+    AXUIElementSetAttributeValue(element, "AXSelectedText", "")
+    return None
+
+
+def route_whole_value(element, text, caret):
+    err = AXUIElementSetAttributeValue(element, "AXValue", text[:caret - 1] + text[caret:])
+    return None if err == 0 else f"AXValue not settable (AXError {err})"
+
+
+def route_backspace(element, text, caret):
+    post_backspace()
+    return None
+
+
+ROUTES = [
+    ("A selection replace", route_selection_replace),
+    ("B whole-value rewrite", route_whole_value),
+    ("C synthetic backspace", route_backspace),
+]
+
+
+def type_text(text):
+    """Type through key events, the only channel some apps honour at all.
+
+    Excel ignores both AXValue and AXSelectedText writes, so a probe that
+    restores through them silently leaves the user's cell modified. Restore has
+    to use the same mechanism that worked for the edit.
+    """
+    source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    for character in text:
+        for pressed in (True, False):
+            event = Quartz.CGEventCreateKeyboardEvent(source, 0, pressed)
+            Quartz.CGEventKeyboardSetUnicodeString(event, len(character), character)
+            Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+        time.sleep(0.01)
+
+
+def restore(element, original_text, original_range):
+    """Put the field back exactly as found, by whatever means still works."""
+    AXUIElementSetAttributeValue(element, "AXValue", original_text)
+    time.sleep(0.08)
+    if attr(element, "AXValue") != original_text:
+        # AXValue refused; rebuild through the selection instead.
+        now = attr(element, "AXValue") or ""
+        if len(now) == len(original_text) - 1:
+            write_range(element, len(now), 0)
+            AXUIElementSetAttributeValue(element, "AXSelectedText", original_text[-1])
+            time.sleep(0.08)
+    if attr(element, "AXValue") != original_text:
+        # Both accessibility writes refused. Type the missing tail back.
+        now = attr(element, "AXValue") or ""
+        if original_text.startswith(now) and len(now) < len(original_text):
+            type_text(original_text[len(now):])
+            time.sleep(0.12)
+    if original_range:
+        write_range(element, original_range[0], original_range[1])
+    time.sleep(0.05)
+    return attr(element, "AXValue") == original_text
+
+
+def main():
+    pid, name = frontmost()
+    element = focused(pid)
+    if element is None:
+        print(f"{name}: no focused element")
+        return 1
+
+    text = attr(element, "AXValue")
+    selection = read_range(element)
+    role = attr(element, "AXRole")
+    if not isinstance(text, str) or not text.strip() or selection is None:
+        print(f"{name}: focused {role} has no usable text ({text!r})")
+        return 1
+
+    caret = selection[0] if selection[0] > 0 else len(text)
+    print(f"\n{name}  role={role}  chars={len(text)}  caret={caret}")
+    print(f"  text: {text[-46:]!r}")
+    print(f"  removing {text[caret-1]!r} at {caret-1}\n")
+
+    for label, route in ROUTES:
+        before = attr(element, "AXValue")
+        problem = route(element, before, caret)
+        time.sleep(0.12)
+        after = attr(element, "AXValue")
+        if problem:
+            verdict, detail = "UNAVAILABLE", problem
+        elif isinstance(after, str) and len(after) == len(before) - 1:
+            verdict, detail = "WORKS", f"{len(before)} -> {len(after)} chars"
+        elif after == before:
+            verdict, detail = "SILENT NO-OP", "call accepted, document unchanged"
+        else:
+            verdict, detail = "WRONG", f"{len(before)} -> {len(after) if isinstance(after,str) else after}"
+        print(f"  {label:24} {verdict:14} {detail}")
+        if not restore(element, text, selection):
+            print(f"  {'':24} RESTORE FAILED — field left modified, stopping")
+            return 1
+    print("\n  field restored")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/probe_model_sync.py
+++ b/research/seam-joining/code/probe_model_sync.py
@@ -1,0 +1,82 @@
+"""Did the app itself see the edit, or only its accessibility surface?
+
+The read-back in `measure_replace.py` proves the text CHANGED. It cannot prove
+the app's own editor model changed with it. A rich editor like Slack's or
+Gmail's keeps its document in JavaScript and paints from that; a write that
+lands on the accessibility layer but not the model shows the right text and
+then sends the wrong one. That failure is invisible to every check run so far,
+and it is exactly the shape that has already burned this work once — an
+accessibility call returning success while doing nothing.
+
+The discriminator is to keep typing. If the model saw the edit, one more
+character lands at the end and everything is coherent. If the model is stale,
+the editor repaints from its own copy and the typed character exposes it.
+
+Routes worth this scrutiny are the two that do not go through a real editing
+gesture:
+  B  AX set range + paste    selection is set by accessibility, text arrives by
+                             a genuine Cmd+V, so the editor should see it
+  E  AXValue whole rewrite   nothing but accessibility, no gesture at all
+"""
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import measure_replace as M  # noqa: E402
+import probe_replace_routes as R  # noqa: E402
+
+POKE = "!"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("surface", choices=sorted(M.SURFACES))
+    args = parser.parse_args()
+
+    surface = M.SURFACES[args.surface]
+    front = surface.activate()
+    print(f"\n{surface.name}  (frontmost: {front})")
+    print("  replace, then type one more character and see if it lands\n")
+
+    for label, route in R.ROUTES:
+        if not label.startswith(("B", "E")):
+            continue
+        element = surface.element()
+        problem = surface.stage(element)
+        if problem:
+            print(f"  {label:28} HARNESS: {problem}")
+            continue
+        caret = surface.caret(element)
+        unavailable, _ = R.run_route(route, element, len(M.SPAN), M.REPLACEMENT, caret)
+        time.sleep(0.3)
+        if unavailable:
+            print(f"  {label:28} UNAVAILABLE ({unavailable})")
+            continue
+        replaced = surface.read(element)
+        if replaced is None or replaced.strip() != M.EXPECTED:
+            print(f"  {label:28} replace itself failed, nothing to test")
+            continue
+
+        R.type_text(POKE)
+        time.sleep(0.5)
+        after = surface.read(element)
+        wanted = M.EXPECTED + POKE
+        if after is not None and after.strip() == wanted:
+            verdict = "MODEL AGREES   the app kept typing where the edit ended"
+        else:
+            verdict = f"MODEL STALE    {after!r}"
+        print(f"  {label:28} {verdict}")
+
+    element = surface.element()
+    if not surface.clear(element):
+        print("\n  CLEANUP FAILED — the field still holds probe text")
+        return 1
+    print("\n  field cleared")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/probe_replace_routes.py
+++ b/research/seam-joining/code/probe_replace_routes.py
@@ -1,0 +1,232 @@
+"""Which mechanism can replace a SPAN of text fastest and most reliably?
+
+The prototype currently posts one backspace per character and then pastes. The
+founder's objection, 2026-07-25: it is visibly slow, and a dropped keystroke in
+a burst of forty leaves one character behind. Both complaints are about the same
+mechanism, so this measures every alternative on the SAME staged field.
+
+  A  backspace x N + paste     what ships in the prototype today, the baseline
+  B  AX set range + paste      one accessibility call to select, one Cmd+V
+  C  AX set range + AX write   pure accessibility, no synthetic keys at all
+  D  shift+Left x N + paste    keystroke selection, non-destructive until paste
+  E  AXValue whole rewrite     hand the app a whole new document
+  F  shift+Home + paste        one keystroke, but claims the whole line
+
+Judged by reading the field back: the exact expected string, or it failed. An
+accepted call that changes nothing is the failure this exists to catch — both
+Chromium apps returned success and did nothing when probed this morning
+(validation-discipline.md RULE: verify-the-feature-not-the-crash).
+
+The replacement is deliberately a DIFFERENT length from the span it replaces, so
+a route that is off by one cannot pass by coincidence.
+
+Run it through `measure_replace.py`, which stages each app. Running this file
+directly operates on whatever is focused right now.
+"""
+
+import time
+
+import Quartz
+from AppKit import NSPasteboard, NSPasteboardTypeString, NSWorkspace
+from ApplicationServices import (AXUIElementCopyAttributeValue,
+                                 AXUIElementCreateApplication,
+                                 AXUIElementSetAttributeValue, AXValueCreate,
+                                 AXValueGetValue, kAXValueCFRangeType)
+
+DELETE_KEY, V_KEY, LEFT_ARROW, HOME_KEY = 51, 9, 123, 115
+SHIFT = Quartz.kCGEventFlagMaskShift
+COMMAND = Quartz.kCGEventFlagMaskCommand
+
+
+# ── primitives ───────────────────────────────────────────────────────────────
+
+def attr(element, name):
+    err, value = AXUIElementCopyAttributeValue(element, name, None)
+    return value if err == 0 else None
+
+
+def frontmost():
+    NSWorkspace.sharedWorkspace().runningApplications()
+    app = NSWorkspace.sharedWorkspace().frontmostApplication()
+    return (app.processIdentifier(), app.localizedName()) if app else (None, None)
+
+
+def focused_element():
+    """The frontmost app's focused element, waking Chromium's tree if needed.
+
+    Chrome and Electron apps build no accessibility tree until an assistive
+    client asks for one, so the first read returns nothing at all — which reads
+    exactly like "this app has no text field" and is not that. Setting the two
+    opt-in flags below is what a screen reader does; without it Chrome measured
+    as unreachable when it is merely asleep.
+    """
+    pid, name = frontmost()
+    if pid is None:
+        return None, None
+    application = AXUIElementCreateApplication(pid)
+    element = attr(application, "AXFocusedUIElement")
+    if element is not None:
+        return element, name
+    for flag in ("AXManualAccessibility", "AXEnhancedUserInterface"):
+        AXUIElementSetAttributeValue(application, flag, True)
+    for _ in range(10):
+        time.sleep(0.3)
+        element = attr(application, "AXFocusedUIElement")
+        if element is not None:
+            return element, name
+    return None, name
+
+
+def read_range(element):
+    raw = attr(element, "AXSelectedTextRange")
+    if raw is None:
+        return None
+    ok, value = AXValueGetValue(raw, kAXValueCFRangeType, None)
+    return (int(value[0]), int(value[1])) if ok else None
+
+
+def write_range(element, location, length):
+    value = AXValueCreate(kAXValueCFRangeType, (location, length))
+    if value is None:
+        return False
+    return AXUIElementSetAttributeValue(element, "AXSelectedTextRange", value) == 0
+
+
+def post_key(keycode, flags=0, settle=0.004):
+    source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    for pressed in (True, False):
+        event = Quartz.CGEventCreateKeyboardEvent(source, keycode, pressed)
+        if flags:
+            Quartz.CGEventSetFlags(event, flags)
+        Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+        time.sleep(settle)
+
+
+def type_text(text):
+    """Type through key events, the only channel some apps honour at all."""
+    source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    for character in text:
+        for pressed in (True, False):
+            event = Quartz.CGEventCreateKeyboardEvent(source, 0, pressed)
+            Quartz.CGEventKeyboardSetUnicodeString(event, len(character), character)
+            Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+        time.sleep(0.012)
+
+
+def put_on_clipboard(text):
+    board = NSPasteboard.generalPasteboard()
+    saved = board.stringForType_(NSPasteboardTypeString)
+    board.clearContents()
+    board.setString_forType_(text, NSPasteboardTypeString)
+    return saved
+
+
+def restore_clipboard(saved):
+    board = NSPasteboard.generalPasteboard()
+    board.clearContents()
+    if saved:
+        board.setString_forType_(saved, NSPasteboardTypeString)
+
+
+# ── the routes ───────────────────────────────────────────────────────────────
+# Each takes the focused element, how many characters behind the caret to
+# replace, and the text to put there. Returns None, or a reason it could not
+# even be attempted. Correctness is judged by the caller reading the field.
+
+def route_backspace_paste(element, span_len, replacement, caret):
+    saved = put_on_clipboard(replacement)
+    try:
+        for _ in range(span_len):
+            post_key(DELETE_KEY)
+        time.sleep(0.15)
+        post_key(V_KEY, COMMAND)
+        time.sleep(0.30)
+    finally:
+        restore_clipboard(saved)
+    return None
+
+
+def route_axrange_paste(element, span_len, replacement, caret):
+    if caret is None:
+        return "app reports no caret position"
+    if not write_range(element, caret - span_len, span_len):
+        return "selection range not settable"
+    time.sleep(0.05)
+    saved = put_on_clipboard(replacement)
+    try:
+        post_key(V_KEY, COMMAND)
+        time.sleep(0.30)
+    finally:
+        restore_clipboard(saved)
+    return None
+
+
+def route_axrange_axwrite(element, span_len, replacement, caret):
+    if caret is None:
+        return "app reports no caret position"
+    if not write_range(element, caret - span_len, span_len):
+        return "selection range not settable"
+    time.sleep(0.05)
+    err = AXUIElementSetAttributeValue(element, "AXSelectedText", replacement)
+    time.sleep(0.15)
+    return None if err == 0 else f"AXSelectedText refused (AXError {err})"
+
+
+def route_shiftleft_paste(element, span_len, replacement, caret):
+    saved = put_on_clipboard(replacement)
+    try:
+        for _ in range(span_len):
+            post_key(LEFT_ARROW, SHIFT)
+        time.sleep(0.10)
+        post_key(V_KEY, COMMAND)
+        time.sleep(0.30)
+    finally:
+        restore_clipboard(saved)
+    return None
+
+
+def route_axvalue(element, span_len, replacement, caret):
+    current = attr(element, "AXValue")
+    if not isinstance(current, str):
+        return "app exposes no whole value"
+    if caret is None:
+        caret = len(current)
+    rebuilt = current[:caret - span_len] + replacement + current[caret:]
+    err = AXUIElementSetAttributeValue(element, "AXValue", rebuilt)
+    time.sleep(0.15)
+    return None if err == 0 else f"AXValue refused (AXError {err})"
+
+
+def route_shifthome_paste(element, span_len, replacement, caret):
+    """Selects to the start of the LINE, not the start of the span.
+
+    Included because it is the only single-keystroke option, and because in a
+    terminal the line often IS the span. Expected to destroy preceding text
+    anywhere else; the measurement is there to show exactly where.
+    """
+    saved = put_on_clipboard(replacement)
+    try:
+        post_key(HOME_KEY, SHIFT)
+        time.sleep(0.10)
+        post_key(V_KEY, COMMAND)
+        time.sleep(0.30)
+    finally:
+        restore_clipboard(saved)
+    return None
+
+
+ROUTES = [
+    ("A backspace x N + paste", route_backspace_paste),
+    ("B AX set range + paste", route_axrange_paste),
+    ("C AX set range + AX write", route_axrange_axwrite),
+    ("D shift+Left x N + paste", route_shiftleft_paste),
+    ("E AXValue whole rewrite", route_axvalue),
+    ("F shift+Home + paste", route_shifthome_paste),
+]
+
+
+def run_route(route, element, span_len, replacement, caret):
+    """Returns (unavailable_reason, elapsed_ms)."""
+    start = time.perf_counter()
+    problem = route(element, span_len, replacement, caret)
+    return problem, (time.perf_counter() - start) * 1000

--- a/research/seam-joining/code/probe_seam_join.py
+++ b/research/seam-joining/code/probe_seam_join.py
@@ -1,0 +1,161 @@
+"""The whole seam join, end to end, against a live app.
+
+Earlier probes settled the mechanism one question at a time: rewriting the
+whole field is inconsistent (undo fails in Chrome, the caret jumps to the start
+in Slack), while a posted backspace behaves correctly in both. This runs the
+ACTUAL edit the feature would perform and checks the text a user would read.
+
+The starting state is what the app really looks like after a first recording,
+including the trailing space delivery adds (`PasteService.appendTrailingSpace`):
+
+    "I mean the ideal outcome. "          caret at the end
+
+The join has to reach:
+
+    "I mean the ideal outcome would be recognizing when two sentences..."
+
+so it removes the terminator AND the trailing space, then inserts a space plus
+the lowercased payload. Two characters back, not one — a detail no
+single-character probe would have surfaced.
+
+Measured: does the final text match exactly, how long the edit takes, and
+whether one undo puts the user's document back.
+"""
+
+import sys
+import time
+
+import Quartz
+from ApplicationServices import (AXUIElementCopyAttributeValue,
+                                 AXUIElementCreateApplication,
+                                 AXUIElementSetAttributeValue, AXValueCreate,
+                                 AXValueGetValue, kAXValueCFRangeType)
+from AppKit import NSWorkspace
+
+DELETE_KEYCODE = 51
+Z_KEYCODE = 6
+
+FIRST = "I mean the ideal outcome. "
+SECOND = "Would be recognizing when two sentences belong together."
+WANTED = "I mean the ideal outcome would be recognizing when two sentences belong together."
+
+
+def attr(element, name):
+    err, value = AXUIElementCopyAttributeValue(element, name, None)
+    return value if err == 0 else None
+
+
+def read_range(element):
+    raw = attr(element, "AXSelectedTextRange")
+    if raw is None:
+        return None
+    ok, value = AXValueGetValue(raw, kAXValueCFRangeType, None)
+    return (int(value[0]), int(value[1])) if ok else None
+
+
+def write_range(element, location, length):
+    value = AXValueCreate(kAXValueCFRangeType, (location, length))
+    return value is not None and AXUIElementSetAttributeValue(
+        element, "AXSelectedTextRange", value) == 0
+
+
+def post_key(keycode, flags=0):
+    source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    for pressed in (True, False):
+        event = Quartz.CGEventCreateKeyboardEvent(source, keycode, pressed)
+        if flags:
+            Quartz.CGEventSetFlags(event, flags)
+        Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+
+
+def paste(text):
+    """Deliver text the way the shipped paste path does: clipboard then Cmd+V."""
+    from AppKit import NSPasteboard, NSPasteboardTypeString
+
+    board = NSPasteboard.generalPasteboard()
+    previous = board.stringForType_(NSPasteboardTypeString)
+    board.clearContents()
+    board.setString_forType_(text, NSPasteboardTypeString)
+    post_key(9, Quartz.kCGEventFlagMaskCommand)  # V
+    time.sleep(0.25)
+    board.clearContents()
+    if previous:
+        board.setString_forType_(previous, NSPasteboardTypeString)
+
+
+def frontmost():
+    NSWorkspace.sharedWorkspace().runningApplications()
+    app = NSWorkspace.sharedWorkspace().frontmostApplication()
+    return app.processIdentifier(), app.localizedName()
+
+
+def main():
+    pid, name = frontmost()
+    element = attr(AXUIElementCreateApplication(pid), "AXFocusedUIElement")
+    if element is None:
+        print(f"{name}: no focused element")
+        return 1
+
+    baseline = attr(element, "AXValue") or ""
+    print(f"\n{name}  starting from {len(baseline)} chars")
+
+    # Stage the state a first recording leaves behind.
+    paste(FIRST)
+    time.sleep(0.2)
+    staged = attr(element, "AXValue") or ""
+    if not staged.rstrip().endswith(FIRST.rstrip()):
+        print(f"  could not stage the first recording (got {staged[-30:]!r})")
+        return 1
+    print(f"  staged: {staged[-30:]!r}")
+
+    # How many characters have to go? NOT a constant. Chrome keeps the trailing
+    # space delivery appends and needs two deletes; Slack's composer strips it
+    # from the value we read back and needs one. Count from what the document
+    # actually contains — the same caret read the feature already performs —
+    # rather than assuming what we wrote is what is there.
+    trailing = len(staged) - len(staged.rstrip())
+    deletes = trailing + (1 if staged.rstrip().endswith((".", "!", "?")) else 0)
+    print(f"  trailing space : {trailing}   deletes needed : {deletes}")
+
+    start = time.perf_counter()
+    for _ in range(deletes):
+        post_key(DELETE_KEYCODE)
+        time.sleep(0.012)
+    payload = " " + SECOND[0].lower() + SECOND[1:]
+    paste(payload)
+    elapsed = (time.perf_counter() - start) * 1000
+
+    time.sleep(0.25)
+    joined = attr(element, "AXValue") or ""
+    got = joined[len(baseline):]
+    ok = got.strip() == WANTED
+    print(f"  joined: {got.strip()[-60:]!r}")
+    print(f"  matches target : {'YES' if ok else 'NO'}")
+    if not ok:
+        print(f"    wanted tail  : {WANTED[-60:]!r}")
+    print(f"  edit time      : {elapsed:.0f} ms  (2 deletes + paste)")
+
+    # Can the user walk it back?
+    post_key(Z_KEYCODE, Quartz.kCGEventFlagMaskCommand)
+    time.sleep(0.35)
+    after_undo = attr(element, "AXValue") or ""
+    print(f"  one undo gives : {after_undo[len(baseline):].strip()[-46:]!r}")
+
+    # Restore the field to exactly how it was found.
+    for _ in range(14):
+        current = attr(element, "AXValue") or ""
+        if current == baseline:
+            break
+        post_key(Z_KEYCODE, Quartz.kCGEventFlagMaskCommand)
+        time.sleep(0.18)
+    current = attr(element, "AXValue") or ""
+    if current != baseline:
+        AXUIElementSetAttributeValue(element, "AXValue", baseline)
+        time.sleep(0.15)
+        current = attr(element, "AXValue") or ""
+    print(f"  field restored : {'yes' if current == baseline else 'NO — CHECK BY HAND'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/probe_terminal_read.py
+++ b/research/seam-joining/code/probe_terminal_read.py
@@ -1,0 +1,83 @@
+"""What does reading a terminal's input line actually return? Read only.
+
+The stress test refused to start because its "is the line empty" check never
+became true, and a check like that is worth understanding before posting
+another keystroke — a clear loop that cannot tell empty from full is a loop
+that deletes things it was not asked to delete.
+
+This posts NOTHING. It waits for the window to be focused, then prints the raw
+screen tail, the same text after the chrome stripper, and again after the shell
+prompt anchor, so it is obvious which stage is wrong.
+"""
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import join_hotkey as J  # noqa: E402
+import probe_replace_routes as R  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wait", type=float, default=6.0)
+    parser.add_argument("--type", default="",
+                        help="a line to type, read back, and delete again")
+    args = parser.parse_args()
+
+    print(f"\nClick into the terminal. Starting in {args.wait} seconds. "
+          f"Nothing is ever submitted.")
+    time.sleep(args.wait)
+
+    element, name, problem = J.focused()
+    print(f"\nfrontmost: {name}")
+    if problem:
+        print(f"  {problem}")
+        return 1
+    print(f"  role: {R.attr(element, 'AXRole')}  caret: {J.caret_position(element)}")
+
+    value = R.attr(element, "AXValue")
+    if not isinstance(value, str):
+        print("  no text value")
+        return 1
+
+    report(element, "empty box")
+
+    if args.type:
+        # A wrapped sentence is the case that broke: the reader lost the prompt
+        # marker off the top of its window and handed back the whole screen.
+        # Reproducing it needs a line long enough to wrap, in the real box.
+        R.type_text(args.type)
+        time.sleep(0.6)
+        report(element, "after typing a line long enough to wrap")
+        current = read_parsed(element)
+        for _ in range(len(current) + 8):
+            R.post_key(R.DELETE_KEY, settle=0.004)
+        time.sleep(0.4)
+        report(element, "after clearing again")
+    return 0
+
+
+def read_parsed(element):
+    value = R.attr(element, "AXValue")
+    if not isinstance(value, str):
+        return ""
+    return J.terminal_text(value)
+
+
+def report(element, label):
+    value = R.attr(element, "AXValue")
+    if not isinstance(value, str):
+        print(f"\n  {label}: no text value")
+        return
+    tail = value[-J.TERMINAL_WINDOW:]
+    parsed = read_parsed(element)
+    print(f"\n  {label}")
+    print(f"    raw screen tail: {len(tail)} chars")
+    print(f"    reads back as ({len(parsed)} chars): {parsed!r}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/quantise_and_measure.py
+++ b/research/seam-joining/code/quantise_and_measure.py
@@ -1,0 +1,139 @@
+"""Shrink the winning model and measure what it costs in quality and speed.
+
+The winner (XLM-R, square-root balanced sampling) is 1.1 GB, which is the last
+blocker to shipping. Two reductions are tested, and BOTH are measured rather
+than assumed cheap:
+
+  fp16    half precision. Halves the file. Usually free in quality.
+  int8    dynamic quantisation of the linear layers. Roughly quarters it.
+          This one genuinely can cost accuracy, so it is measured, not trusted.
+
+Latency is measured HERE, on the Mac, because that is where the product runs.
+Every timing so far came from the 4090 and is irrelevant to shipping.
+"""
+
+import json
+import os
+import statistics
+import sys
+import time
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+SEAM = "<seam>"
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.join(HERE, "seam-sqrt-s22")
+
+
+def load_rows():
+    rows = [json.loads(l) for l in open(os.path.join(HERE, "seam_test.jsonl"), encoding="utf-8")]
+    zero = os.path.join(HERE, "seam_zeroshot.jsonl")
+    unseen = [json.loads(l) for l in open(zero, encoding="utf-8")] if os.path.exists(zero) else []
+    return rows, unseen
+
+
+def evaluate(model, tok, rows, batch=32):
+    correct = wrong_merge = keep_n = 0
+    for i in range(0, len(rows), batch):
+        chunk = rows[i : i + batch]
+        texts = [
+            f"{' '.join(r['rec1'].split()[-18:])} {SEAM} {' '.join(r['rec2'].split()[:14])}"
+            for r in chunk
+        ]
+        enc = tok(texts, truncation=True, max_length=96, padding=True, return_tensors="pt")
+        with torch.no_grad():
+            pred = model(**enc).logits.argmax(-1).tolist()
+        for r, p in zip(chunk, pred):
+            lab = LABELS[p]
+            correct += int(lab == r["label"])
+            if r["label"] == "KEEP":
+                keep_n += 1
+                wrong_merge += int(lab != "KEEP")
+    return correct / len(rows), wrong_merge
+
+
+def latency(model, tok, rows, n=60):
+    """Single-item latency, which is what a user actually experiences. Batched
+    numbers flatter the result and do not reflect one dictation ending."""
+    samples = []
+    for r in rows[:n]:
+        text = f"{' '.join(r['rec1'].split()[-18:])} {SEAM} {' '.join(r['rec2'].split()[:14])}"
+        enc = tok(text, truncation=True, max_length=96, return_tensors="pt")
+        t0 = time.perf_counter()
+        with torch.no_grad():
+            model(**enc)
+        samples.append((time.perf_counter() - t0) * 1000)
+    samples.sort()
+    return statistics.median(samples), samples[int(0.95 * len(samples))]
+
+
+def dir_size_mb(path):
+    total = 0
+    for root, _, files in os.walk(path):
+        for f in files:
+            total += os.path.getsize(os.path.join(root, f))
+    return total / 1e6
+
+
+def report(name, size, acc, wm, acc_z, wm_z, med, p95):
+    print(f"{name:16}{size:>7.0f}MB{100*acc:>12.1f}%{wm:>7}"
+          f"{100*acc_z:>11.1f}%{wm_z:>7}{med:>10.1f}{p95:>9.1f}", flush=True)
+
+
+def main():
+    rows, unseen = load_rows()
+    tok = AutoTokenizer.from_pretrained(SRC)
+
+    print(f"\n{'variant':16}{'size':>9}{'trained acc':>13}{'wrong':>7}"
+          f"{'unseen acc':>12}{'wrong':>7}{'median ms':>11}{'p95 ms':>9}", flush=True)
+    print("-" * 84, flush=True)
+
+    # Each variant is measured and printed independently. A failure in one must
+    # not discard the others - the int8 path died on this Mac and took the fp32
+    # and fp16 numbers with it, because everything was printed at the end.
+    def measure(name, build):
+        try:
+            model, size = build()
+            model.eval()
+            acc, wm = evaluate(model, tok, rows)
+            acc_z, wm_z = evaluate(model, tok, unseen) if unseen else (float("nan"), 0)
+            med, p95 = latency(model, tok, rows)
+            report(name, size, acc, wm, acc_z, wm_z, med, p95)
+        except Exception as exc:
+            print(f"{name:16}  FAILED: {type(exc).__name__}: {str(exc)[:56]}", flush=True)
+
+    def fp32():
+        return AutoModelForSequenceClassification.from_pretrained(SRC), dir_size_mb(SRC)
+
+    def fp16():
+        half = AutoModelForSequenceClassification.from_pretrained(SRC, dtype=torch.float16)
+        out = os.path.join(HERE, "seam-fp16")
+        half.save_pretrained(out)
+        tok.save_pretrained(out)
+        # Reload as fp32 for CPU inference; the weights carry fp16 rounding, which
+        # is exactly what shipping fp16 weights means for quality.
+        return (AutoModelForSequenceClassification.from_pretrained(out, dtype=torch.float32),
+                dir_size_mb(out))
+
+    def int8():
+        base = AutoModelForSequenceClassification.from_pretrained(SRC)
+        qt = torch.quantization.quantize_dynamic(base, {torch.nn.Linear}, dtype=torch.qint8)
+        qdir = os.path.join(HERE, "seam-int8")
+        os.makedirs(qdir, exist_ok=True)
+        torch.save(qt.state_dict(), os.path.join(qdir, "model_int8.pt"))
+        return qt, dir_size_mb(qdir)
+
+    measure("original fp32", fp32)
+    measure("fp16 weights", fp16)
+    measure("int8 dynamic", int8)
+
+    print("\nLatency measured on this Mac, single item - what a user actually waits.", flush=True)
+    print("int8 via torch needs a quantised backend that this arm64 build lacks;", flush=True)
+    print("the real shipping path for Apple Silicon is Core ML or ONNX, not this.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/score_real_seams.py
+++ b/research/seam-joining/code/score_real_seams.py
@@ -76,6 +76,23 @@ def main():
         print(f"{args.labels} not found — run grade_real_seams.py first", file=sys.stderr)
         return 1
     rows = [json.loads(l) for l in open(path, encoding="utf-8")]
+
+    # Refuse a TARGETED label file as a general corpus. `grade_real_seams.py
+    # --predictions` deliberately grades only the pairs ONE source model chose
+    # to merge, which is the right way to measure the dangerous direction and
+    # the wrong population to score any other model against: those rows are
+    # selected by that model's own decisions, so every other model's numbers
+    # come out of a biased sample while reading like a ship gate. Found by
+    # cloud review on PR #1793.
+    sources = {r.get("label_source", "unknown") for r in rows}
+    if any("targeted" in str(s) or "merge_only" in str(s) for s in sources):
+        print(f"REFUSING: {path} was graded on one model's MERGE decisions "
+              f"only (label_source={sorted(sources)}). Those rows are a biased "
+              f"sample, not a population, and scoring other models against them "
+              f"produces numbers that look like a gate and are not one. Grade a "
+              f"random sample instead (omit --predictions).", file=sys.stderr)
+        return 1
+
     boundaries = [r for r in rows if r["label"] == "KEEP"]
     joins = [r for r in rows if r["label"] != "KEEP"]
     print(f"\n{len(rows)} real consecutive recordings from the founder's logs")

--- a/research/seam-joining/code/score_real_seams.py
+++ b/research/seam-joining/code/score_real_seams.py
@@ -1,0 +1,118 @@
+"""Score models against REAL consecutive recordings. This is the ship gate.
+
+The synthetic held-out set is at its ceiling and cannot separate candidates; the
+positional stress set has only ten sentence boundaries and cannot measure safety
+at all. This set can: real pauses, real transcription artifacts, real polish
+output, and sentence boundaries in quantity.
+
+Two numbers, never merged into one:
+
+  wrong merges   the model joined two of the user's genuinely separate
+                 sentences. Silent damage. Zero is the bar.
+  missed joins   the model left today's behaviour in place. Costs nothing.
+
+Denominators are printed with the rates, because "zero wrong merges" over 40
+boundaries is a far weaker claim than over 400, and the honest form names it.
+
+The labels come from a grader that under-merges about 19% of the time
+(`calibrate_grader.py`), so a flagged wrong merge may be the grader's error
+rather than the model's. Every flag is therefore WRITTEN OUT for a human to
+read, and the printed count is labelled as a ceiling, not a verdict.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+SEAM = "<seam>"
+
+
+def find(name):
+    here = os.path.dirname(os.path.abspath(__file__))
+    for candidate in (os.path.join(os.path.dirname(here), "data", name),
+                      os.path.join(here, name), name):
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def predict(model_dir, rows, batch=64):
+    tok = AutoTokenizer.from_pretrained(model_dir)
+    model = AutoModelForSequenceClassification.from_pretrained(model_dir)
+    model.eval()
+    if torch.cuda.is_available():
+        model.cuda()
+    out = []
+    for i in range(0, len(rows), batch):
+        chunk = rows[i : i + batch]
+        texts = [f"{' '.join(r['rec1'].split()[-18:])} {SEAM} "
+                 f"{' '.join(r['rec2'].split()[:14])}" for r in chunk]
+        enc = tok(texts, truncation=True, max_length=96, padding=True, return_tensors="pt")
+        if torch.cuda.is_available():
+            enc = {k: v.cuda() for k, v in enc.items()}
+        with torch.no_grad():
+            out.extend(model(**enc).logits.argmax(-1).tolist())
+    del model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return [LABELS[p] for p in out]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("models", nargs="+")
+    ap.add_argument("--labels", default="seam_real_labelled.jsonl")
+    ap.add_argument("--flags-out", default="real_seam_flags.jsonl")
+    args = ap.parse_args()
+
+    path = find(args.labels)
+    if not path:
+        print(f"{args.labels} not found — run grade_real_seams.py first", file=sys.stderr)
+        return 1
+    rows = [json.loads(l) for l in open(path, encoding="utf-8")]
+    boundaries = [r for r in rows if r["label"] == "KEEP"]
+    joins = [r for r in rows if r["label"] != "KEEP"]
+    print(f"\n{len(rows)} real consecutive recordings from the founder's logs")
+    print(f"  graded as genuinely separate : {len(boundaries)}")
+    print(f"  graded as one thought split  : {len(joins)}")
+    if len(boundaries) < 30:
+        print("  WARNING: too few boundaries to make a safety claim", file=sys.stderr)
+
+    head = f"\n{'model':22}{'wrong merges':>18}{'missed joins':>18}{'agreement':>12}"
+    print(head)
+    print("-" * len(head.strip()))
+
+    flagged = []
+    for model_dir in args.models:
+        preds = predict(model_dir, rows)
+        wrong = [(r, p) for r, p in zip(rows, preds)
+                 if r["label"] == "KEEP" and p != "KEEP"]
+        missed = [(r, p) for r, p in zip(rows, preds)
+                  if r["label"] != "KEEP" and p == "KEEP"]
+        agree = sum(1 for r, p in zip(rows, preds) if p == r["label"]) / max(len(rows), 1)
+        name = os.path.basename(model_dir)
+        print(f"{name:22}{len(wrong):>8}/{len(boundaries):<9}"
+              f"{len(missed):>8}/{len(joins):<9}{100*agree:>11.1f}%")
+        for row, pred in wrong:
+            flagged.append({**row, "model": name, "model_said": pred,
+                            "grader_said": row["label"]})
+
+    out = os.path.join(os.path.dirname(path), args.flags_out)
+    with open(out, "w", encoding="utf-8") as handle:
+        for row in flagged:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    print(f"\nwrong-merge counts are a CEILING, not a verdict: the grader misses "
+          f"about 19% of real\njoins, so some flags are its error. All {len(flagged)} "
+          f"are written to {out}\nfor a human to read before any of them counts.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/score_seam_corpus.py
+++ b/research/seam-joining/code/score_seam_corpus.py
@@ -1,0 +1,151 @@
+"""Score the v3 seam joiner against the generated corpus.
+
+Reports, per corruption combination and per split kind:
+  * merge DECISION accuracy - did it merge exactly when it should have
+  * EXACT MATCH to the original dictation, which is the real bar
+  * the proper-noun subset, where gold keeps a capital at the seam
+
+Baseline is today's behaviour: paste the takes with a space and change nothing.
+
+Inference is batched because the corpus is thousands of cases and the model
+takes a list.
+"""
+
+import json
+import re
+import statistics
+import sys
+import time
+from collections import defaultdict
+
+from punctuators.models.punc_cap_seg_model import (
+    PunctCapSegConfigONNX,
+    PunctCapSegModelONNX,
+)
+
+MODEL_DIR = (
+    "/private/tmp/claude-501/-Users-m4pro-sv-Developer-EnviousLabs-EnviousWispr/"
+    "73bf0faa-2e60-4b76-9576-81465f742796/scratchpad/model_47lang"
+)
+TERMINATORS = (".", "!", "?")
+LEAD = "we agreed that"
+BATCH = 256
+
+
+def strip_punct(text):
+    return re.sub(r"\s+", " ", re.sub(r"[.,?;!]", " ", text.lower())).strip()
+
+
+def batched(model, probes):
+    out = []
+    for i in range(0, len(probes), BATCH):
+        out.extend(model.infer(probes[i : i + BATCH]))
+    return out
+
+
+def main():
+    limit = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+    cases = [json.loads(l) for l in open("seam_corpus.jsonl")]
+    if limit:
+        # Deterministic stride so the sample spans the whole corpus.
+        cases = cases[:: max(1, len(cases) // limit)][:limit]
+    print(f"scoring {len(cases)} cases", file=sys.stderr)
+
+    cfg = PunctCapSegConfigONNX(
+        directory=MODEL_DIR,
+        spe_filename="spe_unigram_64k_lowercase_47lang.model",
+        model_filename="punct_cap_seg_47lang.onnx",
+        config_filename="config.yaml",
+    )
+    model = PunctCapSegModelONNX(cfg)
+    model.infer(["warmup"])
+
+    start = time.perf_counter()
+
+    # Only takes following a terminated left context need the fragment probe;
+    # an unterminated left context is a certain merge and costs no inference.
+    needs_probe = [c for c in cases if c["left"].rstrip().endswith(TERMINATORS)]
+    stands_alone = {}
+    if needs_probe:
+        outs = batched(model, [strip_punct(c["right"]) for c in needs_probe])
+        for c, o in zip(needs_probe, outs):
+            first = o[0].strip() if o else ""
+            stands_alone[c["id"]] = bool(first) and first.endswith(TERMINATORS)
+
+    # Mid-sentence casing for every take that might get merged.
+    case_outs = batched(model, [f"{LEAD} {strip_punct(c['right'])}" for c in cases])
+    lead_n = len(LEAD.split())
+    mid_case = {}
+    for c, o in zip(cases, case_outs):
+        words = " ".join(o).split()
+        mid_case[c["id"]] = words[lead_n] if len(words) > lead_n else None
+
+    elapsed = time.perf_counter() - start
+
+    stats = defaultdict(lambda: {"n": 0, "decision": 0, "exact": 0, "base_exact": 0})
+    proper = {"n": 0, "kept": 0}
+
+    for c in cases:
+        left, right = c["left"], c["right"]
+        terminated = left.rstrip().endswith(TERMINATORS)
+        merged = True if not terminated else not stands_alone.get(c["id"], True)
+
+        if merged:
+            out_left = re.sub(r"\.\s*$", "", left)
+            words = right.split()
+            cased = mid_case.get(c["id"])
+            if words and cased:
+                words[0] = (
+                    cased if cased[:1].isupper() else words[0][0].lower() + words[0][1:]
+                )
+                right_out = " ".join(words)
+            else:
+                right_out = right
+            got = f"{out_left} {right_out}"
+        else:
+            got = f"{left} {right}"
+
+        today = c["today"]
+        key = (c["kind"], c["add_period"], c["capitalise"])
+        s = stats[key]
+        s["n"] += 1
+        s["decision"] += int(merged == c["should_merge"])
+        s["exact"] += int(got.strip() == c["gold"].strip())
+        s["base_exact"] += int(today.strip() == c["gold"].strip())
+
+        # Proper-noun subset: gold keeps a capital at the seam.
+        gold_words = c["gold"].split()
+        idx = len(c["left"].split())
+        if c["should_merge"] and idx < len(gold_words) and gold_words[idx][:1].isupper():
+            proper["n"] += 1
+            proper["kept"] += int(got.strip() == c["gold"].strip())
+
+    tot = sum(s["n"] for s in stats.values())
+    dec = sum(s["decision"] for s in stats.values())
+    ex = sum(s["exact"] for s in stats.values())
+    base = sum(s["base_exact"] for s in stats.values())
+
+    print(f"\n{'kind':20} {'per':4} {'cap':4} {'n':>6} {'decision':>9} {'exact':>8} {'today':>8}")
+    print("-" * 66)
+    for key in sorted(stats):
+        kind, per, cap = key
+        s = stats[key]
+        print(
+            f"{kind:20} {str(per)[:1]:4} {str(cap)[:1]:4} {s['n']:6} "
+            f"{100*s['decision']/s['n']:8.1f}% {100*s['exact']/s['n']:7.1f}% "
+            f"{100*s['base_exact']/s['n']:7.1f}%"
+        )
+    print("-" * 66)
+    print(f"{'TOTAL':30} {tot:6} {100*dec/tot:8.1f}% {100*ex/tot:7.1f}% {100*base/tot:7.1f}%")
+    if proper["n"]:
+        print(
+            f"\nproper noun at seam (gold keeps the capital): "
+            f"{proper['kept']}/{proper['n']} = {100*proper['kept']/proper['n']:.1f}%"
+        )
+    print(f"\ninference: {elapsed:.1f}s for {len(cases)} cases "
+          f"= {1000*elapsed/len(cases):.1f}ms per case")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/seam_verdict.py
+++ b/research/seam-joining/code/seam_verdict.py
@@ -1,0 +1,75 @@
+"""One definition of "were these two sentences joined", used by every harness.
+
+Three harnesses each answered this differently and each was wrong, in a
+different way, and each wrong answer changed a number that had already been
+reported:
+
+  "the output differs from the input"   a casing or punctuation tweak anywhere
+                                        scored as a successful merge
+  "fewer than two sentence marks"       an output that drops only its FINAL
+                                        full stop — "First sentence. Second
+                                        sentence" — scores as joined while the
+                                        boundary is plainly still there
+
+Both are proxies. The actual question is narrow and answerable directly: is
+there still a sentence boundary BETWEEN the two halves? Everything else the
+model does — fixing a comma, contracting "it is", changing the closing
+punctuation — is irrelevant to it.
+
+So: find where the first half ends and the second half begins in the output,
+and look at the text between them. A sentence terminator in that gap means the
+seam survived. No terminator means it was welded.
+
+Kept in one place because the same defect appeared in three copies, which is
+how it survived two review rounds.
+"""
+
+import re
+
+TERMINATORS = ".!?"
+
+
+def _words(text):
+    return re.findall(r"[A-Za-z0-9']+", text)
+
+
+def _find_last(haystack_words, needle, start=0):
+    """Index of the last occurrence of `needle` in `haystack_words`."""
+    found = -1
+    for index in range(start, len(haystack_words)):
+        if haystack_words[index].lower() == needle.lower():
+            found = index
+    return found
+
+
+def was_joined(first, second, output):
+    """True when no sentence boundary remains between the two halves.
+
+    Returns None when the halves cannot be located in the output at all, which
+    means the model rewrote things so heavily that "joined" is not the right
+    question — the caller should treat that as a separate outcome rather than
+    silently counting it either way.
+    """
+    out_words = _words(output)
+    first_words, second_words = _words(first), _words(second)
+    if not out_words or not first_words or not second_words:
+        return None
+
+    # Anchor on the last word of the first half and the first word of the
+    # second. Both survive any reasonable edit; the punctuation between them is
+    # exactly what the join changes.
+    tail_word, head_word = first_words[-1], second_words[0]
+
+    tail_matches = [m for m in re.finditer(rf"\b{re.escape(tail_word)}\b", output,
+                                           re.IGNORECASE)]
+    if not tail_matches:
+        return None
+    tail_end = tail_matches[0].end()
+
+    head_match = re.search(rf"\b{re.escape(head_word)}\b", output[tail_end:],
+                           re.IGNORECASE)
+    if not head_match:
+        return None
+
+    gap = output[tail_end:tail_end + head_match.start()]
+    return not any(mark in gap for mark in TERMINATORS)

--- a/research/seam-joining/code/seam_verdict.py
+++ b/research/seam-joining/code/seam_verdict.py
@@ -60,16 +60,22 @@ def was_joined(first, second, output):
     # exactly what the join changes.
     tail_word, head_word = first_words[-1], second_words[0]
 
-    tail_matches = [m for m in re.finditer(rf"\b{re.escape(tail_word)}\b", output,
-                                           re.IGNORECASE)]
+    # Anchor on the LAST occurrence of the tail word that still has the head
+    # word after it. Taking the first occurrence examines the wrong gap whenever
+    # the first half repeats its own final word: for "Go when I say go." +
+    # "Go now.", the first "Go" is at the very start, and the gap from there to
+    # the next "go" contains no terminator at all — so an untouched pair scored
+    # as joined. Found by cloud review on PR #1793.
+    tail_matches = list(re.finditer(rf"\b{re.escape(tail_word)}\b", output,
+                                    re.IGNORECASE))
     if not tail_matches:
         return None
-    tail_end = tail_matches[0].end()
 
-    head_match = re.search(rf"\b{re.escape(head_word)}\b", output[tail_end:],
-                           re.IGNORECASE)
-    if not head_match:
-        return None
-
-    gap = output[tail_end:tail_end + head_match.start()]
-    return not any(mark in gap for mark in TERMINATORS)
+    for match in reversed(tail_matches):
+        tail_end = match.end()
+        head_match = re.search(rf"\b{re.escape(head_word)}\b", output[tail_end:],
+                               re.IGNORECASE)
+        if head_match:
+            gap = output[tail_end:tail_end + head_match.start()]
+            return not any(mark in gap for mark in TERMINATORS)
+    return None

--- a/research/seam-joining/code/selftest_chunks.py
+++ b/research/seam-joining/code/selftest_chunks.py
@@ -1,0 +1,198 @@
+"""The founder's test, run without the founder: chunk, merge, chunk, merge.
+
+Every terminal bug so far was found by him dictating into his own window and
+reporting what he saw. This does that sequence automatically in the SAME window
+he uses, because the failures only ever appear in a full-screen text UI and
+never in a fresh shell.
+
+It reproduces what the app does when dictating, which matters more than it
+sounds: the app pastes each recording followed by a SPACE. Leaving that space
+out is precisely what hid the off-by-one for three rounds, so the harness must
+type it too or it proves nothing.
+
+For each chunk it types the text, tells the join what the "recording" was, runs
+the real join, and reads the box back. It checks two things every round:
+
+  nothing of the user's text is lost      every word must survive
+  no character is left behind             the merged text must not have a
+                                          stray letter welded to its front
+
+Nothing is ever submitted; no Return is sent. The box is cleared at the end and
+the clearing is verified.
+"""
+
+import argparse
+import os
+import re
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import join_hotkey as J  # noqa: E402
+import probe_replace_routes as R  # noqa: E402
+
+# A thought deliberately broken across chunks, the way a pause breaks one, plus
+# a chunk that genuinely starts something new so a wrong merge would show up.
+# Whole thoughts, each split across two chunks the way a pause splits one. The
+# lengths matter: the founder asked for six chunks, then eight, then ten,
+# because every failure so far has appeared only after several merges have
+# already landed on top of each other. A pair that merges is followed by a pair
+# that starts something new, so a wrong merge is as visible as a missed one.
+PAIRS = [
+    ("I was thinking about the release.", "And how we should stage it."),
+    ("The tests are still red.", "So we cannot ship today."),
+    ("Can you take a look.", "When you get a chance."),
+    ("I will send you the notes.", "After the meeting ends."),
+    ("We should probably tell the team.", "Before anyone else finds out."),
+]
+
+SEQUENCES = [
+    ("six chunks", [c for pair in PAIRS[:3] for c in pair]),
+    ("eight chunks", [c for pair in PAIRS[:4] for c in pair]),
+    ("ten chunks", [c for pair in PAIRS for c in pair]),
+]
+
+
+# Words the polisher may legitimately introduce when it welds two halves into
+# one sentence. Anything outside this and the spoken text is corruption.
+JOINING_WORDS = {"and", "but", "so", "that", "when", "if", "to", "a", "the",
+                 "it", "is", "you", "at", "on", "in", "for", "of"}
+
+
+def read_box():
+    element, _, problem = J.focused()
+    if problem:
+        return None
+    value = J.attr(element, "AXValue")
+    if not isinstance(value, str):
+        return None
+    return J.terminal_text(value)
+
+
+def clear_box():
+    for _ in range(5):
+        current = read_box()
+        if current is None:
+            return False
+        if not current.strip():
+            return True
+        for _ in range(len(current) + 6):
+            R.post_key(R.DELETE_KEY, settle=0.005)
+        time.sleep(0.3)
+    return not (read_box() or "").strip()
+
+
+def words(text):
+    """Tokens with apostrophes removed, so a contraction is comparable.
+
+    The polisher legitimately rewrote "It is not urgent" as "It's not urgent".
+    A strict word check called that a lost word AND an invented one — two
+    failures for correct behaviour. Comparing on prefixes below lets "its" stand
+    in for "it" and "is" without letting real corruption through, because the
+    off-by-one produces a word that is a prefix of nothing anyone said.
+    """
+    return [w.lower().replace("'", "") for w in re.findall(r"[A-Za-z']+", text)]
+
+
+def unexplained(box_words, said_words):
+    return [w for w in box_words
+            if w not in said_words and not any(w.startswith(s) for s in said_words)]
+
+
+def missing(box_words, said_words):
+    return [w for w in said_words
+            if w not in box_words and not any(b.startswith(w) for b in box_words)]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wait", type=float, default=6.0)
+    args = parser.parse_args()
+
+    from anthropic import AnthropicBedrock
+    client = AnthropicBedrock(
+        aws_access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        aws_region="us-east-1")
+    model = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+    repo = os.path.expanduser("~/Developer/EnviousLabs/EnviousWispr")
+    swift = os.path.join(repo,
+                         "Sources/EnviousWisprLLM/Prompting/CloudFixedPromptBuilder.swift")
+    match = re.search(r'cloudFixedSystemPrompt = """\n(.*?)\n\s*"""',
+                      open(swift, encoding="utf-8").read(), re.DOTALL)
+    system = match.group(1) + J.JOIN_NOTE
+
+    print(f"\nClick into the terminal to test. Starting in {args.wait} seconds.")
+    print("It types and deletes only. No Return is ever sent.")
+    time.sleep(args.wait)
+    _, front = R.frontmost()
+    if front not in ("Ghostty", "Terminal", "iTerm2", "Warp", "kitty", "WezTerm"):
+        print(f"frontmost is {front}, which is not a terminal — aborting")
+        return 1
+
+    # The join asks the app what it last pasted. Here the harness is the app.
+    spoken = {"text": None}
+    J.latest_recording = lambda: spoken["text"]
+
+    failures = 0
+    for label, chunks in SEQUENCES:
+        print(f"\n=== {label}")
+        if not clear_box():
+            print("  HARNESS could not clear the box")
+            failures += 1
+            continue
+
+        said = []
+        for chunk in chunks:
+            # Exactly what the app does: the text, then a space.
+            R.type_text(chunk + " ")
+            spoken["text"] = chunk
+            said.append(chunk)
+            time.sleep(0.5)
+
+            before = read_box()
+            print(f"  typed   {chunk!r}")
+            try:
+                J.do_join(client, model, system)
+            except Exception as exc:
+                print(f"  EXCEPTION {type(exc).__name__}: {exc}")
+                failures += 1
+                break
+            time.sleep(0.4)
+            after = read_box()
+            print(f"  box now {after!r}")
+
+            problems = []
+            if after is None:
+                problems.append("could not read the box back")
+            else:
+                said_words = set(words(" ".join(said))) | JOINING_WORDS
+                box_words = words(after)
+                lost = missing(box_words, set(words(" ".join(said))))
+                if lost:
+                    problems.append(f"lost: {lost}")
+                # The off-by-one leaves the first letter of the deleted text
+                # welded to the front of the new text: "It" arrives as "TIt".
+                # That produces a word nobody said, which is detectable without
+                # knowing what the polisher chose to write.
+                strangers = unexplained(box_words, said_words)
+                if strangers:
+                    problems.append(f"words nobody said: {strangers}")
+                if before and after and len(after) < len(before) - len(chunk) - 40:
+                    problems.append(f"lost too much text ({len(before)} -> {len(after)})")
+
+            for problem in problems:
+                print(f"  FAIL    {problem}")
+            failures += len(problems)
+
+        if not clear_box():
+            print("  HARNESS could not clear the box afterwards")
+            failures += 1
+
+    print(f"\n{'ALL PASS' if not failures else f'{failures} FAILING'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/selftest_join.py
+++ b/research/seam-joining/code/selftest_join.py
@@ -1,0 +1,175 @@
+"""Test the join myself instead of making the founder the QA loop.
+
+Types a known two-sentence text into a real field, runs the real join path, and
+reads the field back to check what actually happened. Every failure so far was
+found by him pressing the hotkey and telling me it was broken; this closes that
+loop.
+
+Cases cover the shapes that have already bitten:
+  single space between the sentences
+  DOUBLE space          — the delete count came up one character short
+  newline between them  — same class, different whitespace
+  already one sentence  — must refuse, nothing to join
+  a name at the seam    — must not lowercase it
+
+Runs against TextEdit, which exposes a real caret and a real value, so a failure
+here is the join logic rather than a terminal's quirks.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import join_hotkey as J  # noqa: E402
+
+CASES = [
+    ("single space", "I can't wait to go. Shower tonight.",
+     "one sentence, no leftover characters"),
+    ("double space", "I can't wait to go.  Shower tonight.",
+     "the whitespace case that left a stray character"),
+    ("newline", "I can't wait to go.\nShower tonight.",
+     "same class as double space"),
+    ("genuinely separate", "The meeting went well. I'll send notes tomorrow.",
+     "should stay as two sentences"),
+    ("name at the seam", "I will see you. Monday at noon.",
+     "must not lowercase Monday"),
+    ("only one sentence", "Just the one sentence here.",
+     "must refuse, nothing to join with"),
+]
+
+
+def applescript_string(text):
+    """AppleScript literals need their own escaping; naive quote-swapping broke
+    every case containing an apostrophe, which is most real dictation."""
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    escaped = escaped.replace("\n", '" & linefeed & "')
+    return f'"{escaped}"'
+
+
+def run_applescript(script):
+    return subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+
+
+def fresh_document(text):
+    """A new TextEdit window holding exactly `text`, caret at the end.
+
+    Closes anything already open first: the first run of this file read a
+    LEFTOVER document from an earlier test and reported a failure that had
+    nothing to do with the join.
+    """
+    run_applescript('tell application "TextEdit" to close every document saving no')
+    time.sleep(0.3)
+    run_applescript('tell application "TextEdit" to activate')
+    time.sleep(0.5)
+    run_applescript(f'tell application "TextEdit" to make new document with '
+                    f'properties {{text:{applescript_string(text)}}}')
+    time.sleep(0.7)
+    run_applescript('tell application "TextEdit" to activate')
+    time.sleep(0.4)
+    # Caret to the very end, where it would be after dictating.
+    run_applescript('tell application "System Events" to tell process "TextEdit" '
+                    'to key code 125 using command down')
+    time.sleep(0.4)
+
+
+def verify_staged(expected):
+    """Prove the document really holds what we think before testing the join."""
+    element, _, problem = J.focused()
+    if problem:
+        return f"could not focus TextEdit: {problem}"
+    value = J.attr(element, "AXValue")
+    if not isinstance(value, str):
+        return "TextEdit exposed no text"
+    if value.strip() != expected.strip():
+        return f"staged the wrong text: {value!r}"
+    return None
+
+
+def read_document():
+    element, _, problem = J.focused()
+    if problem:
+        return None
+    return J.attr(element, "AXValue")
+
+
+def close_documents():
+    subprocess.run(["osascript", "-e",
+                    'tell application "TextEdit" to close every document saving no'],
+                   capture_output=True)
+
+
+def main():
+    from anthropic import AnthropicBedrock
+    client = AnthropicBedrock(
+        aws_access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        aws_region="us-east-1")
+    model = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+    repo = os.path.expanduser("~/Developer/EnviousLabs/EnviousWispr")
+    swift = os.path.join(repo,
+                         "Sources/EnviousWisprLLM/Prompting/CloudFixedPromptBuilder.swift")
+    match = re.search(r'cloudFixedSystemPrompt = """\n(.*?)\n\s*"""',
+                      open(swift, encoding="utf-8").read(), re.DOTALL)
+    system = match.group(1) + J.JOIN_NOTE
+
+    failures = 0
+    for name, text, expectation in CASES:
+        print(f"\n=== {name}  ({expectation})")
+        print(f"  before: {text!r}")
+        fresh_document(text)
+        staging = verify_staged(text)
+        if staging:
+            print(f"  HARNESS  {staging}")
+            failures += 1
+            close_documents()
+            continue
+        try:
+            J.do_join(client, model, system)
+        except Exception as exc:
+            print(f"  EXCEPTION {type(exc).__name__}: {exc}")
+            failures += 1
+            close_documents()
+            continue
+        time.sleep(0.4)
+        after = read_document()
+        print(f"  after : {after!r}")
+
+        problems = []
+        if after is None:
+            problems.append("could not read the document back")
+        else:
+            body = after.strip()
+            if "only one sentence" in name:
+                if body != text.strip():
+                    problems.append("modified a document it should have refused")
+            else:
+                # Nothing from the original may be lost.
+                for word in re.findall(r"[A-Za-z']+", text):
+                    if word.lower() not in body.lower():
+                        problems.append(f"lost the word {word!r}")
+                        break
+                if re.search(r"[.!?]\s*[.!?]", body):
+                    problems.append("doubled punctuation")
+                if body.endswith(".."):
+                    problems.append("trailing double stop")
+            if "name at the seam" in name and "monday" in body and "Monday" not in body:
+                problems.append("lowercased Monday")
+
+        if problems:
+            failures += 1
+            for p in problems:
+                print(f"  FAIL  {p}")
+        else:
+            print("  ok")
+        close_documents()
+
+    print(f"\n{'ALL PASS' if not failures else f'{failures} FAILING'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/selftest_terminal.py
+++ b/research/seam-joining/code/selftest_terminal.py
@@ -1,0 +1,161 @@
+"""Test the join in a real terminal, so the founder does not have to.
+
+The terminal path has broken four different ways and each was found by him
+pressing the hotkey and reporting it: the whole scrollback read as the document,
+no caret position reported, UI chrome counted as prose, and the delete running
+to the end of the screen buffer instead of the end of his sentence.
+
+This opens its OWN Ghostty window, types a known two-sentence line at the shell
+prompt, runs the real join, and reads the field back. It never sends Return, so
+nothing is ever executed, and it clears the line afterwards.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import join_hotkey as J  # noqa: E402
+
+import Quartz  # noqa: E402
+from AppKit import NSWorkspace  # noqa: E402
+
+CASES = [
+    ("mid-clause continuation", "This is me trying. To understand if this will work."),
+    ("double space", "I can't wait to go.  Shower tonight."),
+    ("genuinely separate", "The meeting went well. I'll send notes tomorrow."),
+]
+
+CLEAR_LINE = 21  # ctrl-U
+
+
+def type_text(text):
+    source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+    for ch in text:
+        for pressed in (True, False):
+            event = Quartz.CGEventCreateKeyboardEvent(source, 0, pressed)
+            Quartz.CGEventKeyboardSetUnicodeString(event, len(ch), ch)
+            Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+        time.sleep(0.012)
+
+
+def clear_line():
+    """Backspace the line away and VERIFY it went.
+
+    ctrl-U alone silently failed here, so cases two and three ran against
+    leftover text from case one and reported failures that were the harness's
+    fault, not the join's. Never trust a cleanup step that is not checked.
+    """
+    for _ in range(4):
+        current = read_input_line() or ""
+        if not current.strip():
+            return True
+        source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+        for _ in range(len(current) + 8):
+            for pressed in (True, False):
+                event = Quartz.CGEventCreateKeyboardEvent(source, 51, pressed)
+                Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, event)
+            time.sleep(0.003)
+        time.sleep(0.3)
+    return not (read_input_line() or "").strip()
+
+
+def frontmost_name():
+    NSWorkspace.sharedWorkspace().runningApplications()
+    app = NSWorkspace.sharedWorkspace().frontmostApplication()
+    return app.localizedName() if app else None
+
+
+def read_input_line():
+    element, _, problem = J.focused()
+    if problem:
+        return None
+    value = J.attr(element, "AXValue")
+    if not isinstance(value, str):
+        return None
+    return J.terminal_text(value)
+
+
+def main():
+    from anthropic import AnthropicBedrock
+    client = AnthropicBedrock(
+        aws_access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        aws_region="us-east-1")
+    model = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+    repo = os.path.expanduser("~/Developer/EnviousLabs/EnviousWispr")
+    swift = os.path.join(repo,
+                         "Sources/EnviousWisprLLM/Prompting/CloudFixedPromptBuilder.swift")
+    match = re.search(r'cloudFixedSystemPrompt = """\n(.*?)\n\s*"""',
+                      open(swift, encoding="utf-8").read(), re.DOTALL)
+    system = match.group(1) + J.JOIN_NOTE
+
+    print("opening a dedicated Ghostty window (never touches an existing one)")
+    subprocess.run(["open", "-na", "Ghostty"], capture_output=True)
+    time.sleep(2.5)
+    if frontmost_name() != "Ghostty":
+        print(f"frontmost is {frontmost_name()}, not Ghostty — aborting")
+        return 1
+
+    failures = 0
+    for name, text in CASES:
+        print(f"\n=== {name}")
+        print(f"  typing : {text!r}")
+        if not clear_line():
+            print("  HARNESS could not clear the line, skipping")
+            failures += 1
+            continue
+        type_text(text)
+        time.sleep(0.5)
+
+        staged = read_input_line()
+        if not staged or text.split()[0] not in staged:
+            print(f"  HARNESS could not stage the line (read {staged!r})")
+            failures += 1
+            clear_line()
+            continue
+
+        try:
+            J.do_join(client, model, system)
+        except Exception as exc:
+            print(f"  EXCEPTION {type(exc).__name__}: {exc}")
+            failures += 1
+            clear_line()
+            continue
+
+        time.sleep(0.5)
+        after = read_input_line()
+        print(f"  after  : {after!r}")
+
+        problems = []
+        if after is None:
+            problems.append("could not read the line back")
+        else:
+            for word in re.findall(r"[A-Za-z']+", text):
+                if word.lower() not in after.lower():
+                    problems.append(f"lost the word {word!r}")
+                    break
+            if re.search(r"[.!?]\s*[.!?]", after):
+                problems.append("doubled punctuation")
+            leftovers = re.findall(r"[.!?]\s*$", after)
+            if after.count(".") > text.count(".") :
+                problems.append("gained a full stop")
+
+        if problems:
+            failures += 1
+            for p in problems:
+                print(f"  FAIL  {p}")
+        else:
+            print("  ok")
+        clear_line()
+
+    print(f"\n{'ALL PASS' if not failures else f'{failures} FAILING'}")
+    print("leaving the window open so the result can be seen")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/simulate_session.py
+++ b/research/seam-joining/code/simulate_session.py
@@ -1,0 +1,184 @@
+"""What happens over a WHOLE dictation session, not one pair at a time?
+
+Founder question, 2026-07-25, and it exposes a hole in everything measured so
+far: every number in this project comes from isolated pairs. Real people dictate
+into one field five or six times in a row. The risk is not one bad join, it is
+what a sequence of them produces.
+
+Cascading cannot run away on its own. Merging A and B deletes A's terminator but
+B keeps its own, so the text ends properly punctuated and the next decision
+starts clean. The real danger is compounding: at a 10% per-decision error rate,
+a six-recording burst has roughly a one-in-three chance of at least one bad
+join, and each bad join hands the next decision a longer, stranger sentence than
+anything in training.
+
+This replays REAL bursts from the founder's history, applying each decision to
+the text the previous decision produced, exactly as the app would. Then it
+prints the final text a user would actually be looking at.
+
+Two deterministic guardrails are measured with it, because they cost nothing:
+  --max-words   refuse to extend a sentence past this length
+  --max-chain   refuse more than N consecutive joins without a real break
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+SEAM = "<seam>"
+TERMINATORS = (".", "!", "?")
+KEEP_CAPITAL = {"i", "i'm", "i've", "i'll", "i'd"}
+
+
+def find(name):
+    here = os.path.dirname(os.path.abspath(__file__))
+    for c in (os.path.join(os.path.dirname(here), "data", name),
+              os.path.join(here, name), name):
+        if os.path.exists(c):
+            return c
+    return None
+
+
+def sessions_from(path, max_gap, min_len):
+    """A burst is consecutive recordings each within `max_gap` of the last."""
+    rows = [json.loads(l) for l in open(path, encoding="utf-8")]
+    bursts, current = [], []
+    for row in rows:
+        if current and row["gap_seconds"] <= max_gap:
+            current.append(row["rec2"])
+        else:
+            if len(current) >= min_len:
+                bursts.append(current)
+            current = [row["rec1"], row["rec2"]]
+    if len(current) >= min_len:
+        bursts.append(current)
+    return bursts
+
+
+def apply_join(left, right, separator):
+    """Exactly what the app would write: drop the terminator we are joining
+    across, drop the trailing space, lowercase the next word unless it earns
+    its capital."""
+    left = re.sub(r"[.!?]+$", "", left.strip()).rstrip()
+    if separator.strip() == "" or separator.startswith(","):
+        left = left.rstrip(",").rstrip()
+    words = right.split()
+    if words:
+        bare = words[0].strip(".,!?;:")
+        earns_capital = (
+            bare.lower() in KEEP_CAPITAL
+            or (len(bare) > 1 and any(c.isupper() for c in bare[1:]))
+        )
+        if not earns_capital and bare[:1].isupper():
+            right = right[0].lower() + right[1:]
+    return f"{left}{separator}{right}"
+
+
+def decide(model, tok, left, right):
+    text = (f"{' '.join(left.split()[-18:])} {SEAM} {' '.join(right.split()[:14])}")
+    enc = tok(text, truncation=True, max_length=96, return_tensors="pt")
+    if torch.cuda.is_available():
+        enc = {k: v.cuda() for k, v in enc.items()}
+    with torch.no_grad():
+        return LABELS[model(**enc).logits.argmax(-1).item()]
+
+
+def last_sentence(text):
+    parts = re.split(r"(?<=[.!?])\s+", text.strip())
+    return parts[-1] if parts else text
+
+
+def replay(model, tok, burst, max_words, max_chain):
+    """Run a burst through, applying each decision to the running text."""
+    out = burst[0].strip()
+    chain = 0
+    decisions = []
+    refusals = Counter()
+    for nxt in burst[1:]:
+        verdict = decide(model, tok, out, nxt)
+        tail = last_sentence(out)
+        if verdict != "KEEP":
+            if max_chain and chain >= max_chain:
+                verdict, reason = "KEEP", "chain limit"
+                refusals[reason] += 1
+            elif max_words and len(tail.split()) + len(nxt.split()) > max_words:
+                verdict, reason = "KEEP", "length ceiling"
+                refusals[reason] += 1
+        decisions.append(verdict)
+        if verdict == "KEEP":
+            chain = 0
+            if not out.rstrip().endswith(TERMINATORS):
+                out = out.rstrip() + "."
+            out = f"{out} {nxt.strip()}"
+        else:
+            chain += 1
+            out = apply_join(out, nxt.strip(), ", " if verdict == "MERGE_COMMA" else " ")
+    return out, decisions, refusals
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("model")
+    ap.add_argument("--pairs", default="seam_real_transcripts.jsonl")
+    ap.add_argument("--max-gap", type=float, default=30.0)
+    ap.add_argument("--min-len", type=int, default=4, help="recordings per burst")
+    ap.add_argument("--max-words", type=int, default=0, help="0 = no ceiling")
+    ap.add_argument("--max-chain", type=int, default=0, help="0 = no limit")
+    ap.add_argument("--show", type=int, default=6)
+    args = ap.parse_args()
+
+    path = find(args.pairs)
+    if not path:
+        print(f"{args.pairs} not found", file=sys.stderr)
+        return 1
+    bursts = sessions_from(path, args.max_gap, args.min_len)
+    print(f"\n{len(bursts)} real bursts of {args.min_len}+ recordings "
+          f"(gap <= {args.max_gap:.0f}s)")
+    print(f"guardrails: max sentence {args.max_words or 'none'} words, "
+          f"max consecutive joins {args.max_chain or 'none'}")
+
+    tok = AutoTokenizer.from_pretrained(args.model)
+    model = AutoModelForSequenceClassification.from_pretrained(args.model)
+    model.eval()
+    if torch.cuda.is_available():
+        model.cuda()
+
+    longest = 0
+    all_decisions = Counter()
+    all_refusals = Counter()
+    over40 = over60 = 0
+    shown = 0
+    for burst in bursts:
+        out, decisions, refusals = replay(model, tok, burst, args.max_words, args.max_chain)
+        all_decisions.update(decisions)
+        all_refusals.update(refusals)
+        worst = max((len(s.split()) for s in re.split(r"(?<=[.!?])\s+", out)), default=0)
+        longest = max(longest, worst)
+        over40 += worst > 40
+        over60 += worst > 60
+        if shown < args.show and any(d != "KEEP" for d in decisions):
+            shown += 1
+            print(f"\n--- burst of {len(burst)}, decisions: {decisions}")
+            print(f"    BEFORE: {' | '.join(b[:60] for b in burst[:4])}")
+            print(f"    AFTER : {out[:400]}")
+
+    total = sum(all_decisions.values())
+    print(f"\n{total} decisions across {len(bursts)} bursts: {dict(all_decisions)}")
+    print(f"joined {100*(total-all_decisions['KEEP'])/max(total,1):.1f}% of the time")
+    if all_refusals:
+        print(f"guardrail refusals: {dict(all_refusals)}")
+    print(f"longest sentence produced: {longest} words")
+    print(f"bursts producing a sentence over 40 words: {over40}/{len(bursts)}")
+    print(f"bursts producing a sentence over 60 words: {over60}/{len(bursts)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/stress_backspace.py
+++ b/research/seam-joining/code/stress_backspace.py
@@ -1,0 +1,113 @@
+"""How often does a burst of backspaces lose one?
+
+The founder has now reported the same failure twice: the deletion stops one
+character short and the pasted sentence arrives welded to a leftover letter. The
+count is not the cause — the run on 2026-07-25 counted 46 characters, posted 46
+backspaces, and 45 landed.
+
+Terminals are the only surface still using backspace at all, because they expose
+no caret to select against. So this measures the drop rate there directly rather
+than reasoning about it: type a known line, post exactly as many backspaces as
+it has characters, and read back how much survived.
+
+Reports the distribution, not an average. One drop in twenty is a bug the user
+meets weekly; one in two is a different problem entirely.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import join_hotkey as J  # noqa: E402
+import probe_replace_routes as R  # noqa: E402
+
+# The exact sentence that failed for real, at its exact length. A longer line
+# wraps inside a text box that has a border, and the wrap changes what reading
+# the screen returns — which would measure the reader rather than the keystrokes.
+LINE = "I am going to be very impressed if this works."
+
+
+def read_line():
+    element, _, problem = J.focused()
+    if problem:
+        return None
+    value = J.attr(element, "AXValue")
+    if not isinstance(value, str):
+        return None
+    return J.terminal_text(value).strip()
+
+
+def clear():
+    for _ in range(5):
+        current = read_line() or ""
+        if not current:
+            return True
+        for _ in range(len(current) + 6):
+            R.post_key(R.DELETE_KEY, settle=0.006)
+        time.sleep(0.3)
+    return not (read_line() or "")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runs", type=int, default=20)
+    parser.add_argument("--settle", type=float, default=0.004,
+                        help="seconds between key down and key up, as shipped")
+    parser.add_argument("--wait", type=float, default=6.0,
+                        help="seconds to click into the window being tested")
+    args = parser.parse_args()
+
+    # Test the window the failure actually happened in, rather than a fresh
+    # shell. A plain prompt and a full-screen text UI read keystrokes through
+    # completely different paths, and only the second one has misbehaved.
+    print(f"\nClick into the terminal to test. Starting in {args.wait} seconds.")
+    print("Nothing is ever submitted: no Return is sent at any point.")
+    time.sleep(args.wait)
+    _, front = R.frontmost()
+    if front not in ("Ghostty", "Terminal", "iTerm2", "Warp", "kitty", "WezTerm"):
+        print(f"frontmost is {front}, which is not a terminal — aborting")
+        return 1
+
+    print(f"\n{args.runs} runs, {len(LINE)} characters each, "
+          f"{args.settle * 1000:.0f} ms between key events\n")
+
+    leftovers = []
+    for run in range(1, args.runs + 1):
+        if not clear():
+            print(f"  run {run}: could not clear the line, skipping")
+            continue
+        R.type_text(LINE)
+        time.sleep(0.4)
+        staged = read_line()
+        if staged != LINE:
+            print(f"  run {run}: staged wrong, skipping ({staged!r})")
+            continue
+
+        for _ in range(len(LINE)):
+            R.post_key(R.DELETE_KEY, settle=args.settle)
+        time.sleep(0.4)
+        after = read_line()
+        if after is None:
+            print(f"  run {run}: could not read back")
+            continue
+        leftovers.append(len(after))
+        if after:
+            print(f"  run {run}: {len(after)} character(s) survived  {after!r}")
+
+    clear()
+    if not leftovers:
+        print("\nno usable runs")
+        return 1
+
+    clean = sum(1 for n in leftovers if n == 0)
+    print(f"\n  {clean}/{len(leftovers)} bursts deleted everything")
+    print(f"  worst leftover: {max(leftovers)} character(s)")
+    print("  leftovers:", " ".join(str(n) for n in leftovers))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/test_repolish.py
+++ b/research/seam-joining/code/test_repolish.py
@@ -1,0 +1,105 @@
+"""Founder's idea, 2026-07-25: skip the classifier, re-polish the seam instead.
+
+Instead of a model DECIDING whether two recordings join, hand the polisher the
+last sentence already sitting in the document plus the new recording, and let it
+produce clean joined text. Delete that last sentence, paste the result.
+
+It is a better idea than the classifier if it works, because it deletes the
+entire measurement problem: nothing to label, nothing to grade, no bias, no
+279 MB artifact. It also fixes things the classifier structurally cannot, like
+a second recording that opens on "But".
+
+The question is purely empirical and he asked it exactly right: what does the
+polisher actually DO with that input? Does it join? Restructure? Move the full
+stops? Rewrite words it should not touch?
+
+So this runs our REAL shipped polish prompt over real consecutive recordings and
+prints the before and after, side by side, for a human to read. It scores
+nothing. Reading the outputs is the point.
+
+Uses the labelled real pairs so both cases are covered: pairs a grader called
+one thought, and pairs it called two. The second group is the dangerous one — a
+polisher that helpfully welds separate sentences is worse than the classifier.
+"""
+
+import argparse
+import json
+import os
+import random
+import re
+import sys
+
+# The exact shipped cloud prompt, read from the Swift source so this can never
+# drift from what users get (validation-discipline.md
+# RULE: measure-with-the-real-tool-never-a-simulation).
+SWIFT = ("Sources/EnviousWisprLLM/Prompting/CloudFixedPromptBuilder.swift")
+
+
+def shipped_prompt(repo):
+    path = os.path.join(repo, SWIFT)
+    body = open(path, encoding="utf-8").read()
+    match = re.search(r'cloudFixedSystemPrompt = """\n(.*?)\n\s*"""', body, re.DOTALL)
+    if not match:
+        raise SystemExit(f"could not read the shipped prompt from {path}")
+    return match.group(1)
+
+
+def last_sentence(text):
+    parts = re.split(r"(?<=[.!?])\s+", text.strip())
+    return parts[-1] if parts else text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=12)
+    ap.add_argument("--model", default="us.anthropic.claude-haiku-4-5-20251001-v1:0")
+    args = ap.parse_args()
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.dirname(here)
+    repo = os.path.expanduser("~/Developer/EnviousLabs/EnviousWispr")
+    system = shipped_prompt(repo)
+
+    rows = [json.loads(l) for l in
+            open(os.path.join(root, "data", "seam_real_train.jsonl"), encoding="utf-8")]
+    joins = [r for r in rows if r["label"] != "KEEP"]
+    keeps = [r for r in rows if r["label"] == "KEEP"]
+    rng = random.Random(1790)
+    rng.shuffle(joins); rng.shuffle(keeps)
+    half = args.n // 2
+    sample = [("should join", r) for r in joins[:half]] + \
+             [("should stay apart", r) for r in keeps[:args.n - half]]
+    rng.shuffle(sample)
+
+    from anthropic import AnthropicBedrock
+    client = AnthropicBedrock(
+        aws_access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        aws_region="us-east-1")
+
+    print(f"Re-polishing {len(sample)} real seams with the SHIPPED cloud prompt.\n"
+          f"Input is the last sentence already in the document + the new recording.\n")
+
+    for i, (expected, row) in enumerate(sample, 1):
+        tail = last_sentence(row["rec1"])
+        combined = f"{tail} {row['rec2'].strip()}"
+        try:
+            response = client.messages.create(
+                model=args.model, max_tokens=600, temperature=0,
+                system=system,
+                messages=[{"role": "user",
+                           "content": f"Transcript to clean:\n\n{combined}"}])
+            out = response.content[0].text.strip()
+        except Exception as exc:
+            out = f"[FAILED: {type(exc).__name__}]"
+
+        changed = out.strip() != combined.strip()
+        print(f"--- {i}  ({expected})")
+        print(f"  IN : {combined}")
+        print(f"  OUT: {out}")
+        print(f"  {'CHANGED' if changed else 'unchanged'}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/seam-joining/code/train_seam.py
+++ b/research/seam-joining/code/train_seam.py
@@ -1,0 +1,217 @@
+"""Train the seam classifier on the RTX 4090.
+
+Council's architecture (2026-07-25): a multilingual encoder reads a window
+either side of the join and predicts ONE label. It never emits text, so
+deterministic code applies the edit and the model physically cannot rewrite,
+delete or paraphrase the user's words.
+
+    KEEP          the two recordings are separate sentences
+    MERGE_SPACE   join with a space
+    MERGE_COMMA   join with a comma
+
+The seam is marked explicitly with a special token so the model knows where the
+decision point is, rather than having to infer it.
+
+Run on the rig via the native Windows venv, never WSL:
+    C:\\Users\\saura\\spoken-cmd-winvenv\\Scripts\\python.exe train_seam.py
+"""
+
+import argparse
+import json
+import os
+import random
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    get_linear_schedule_with_warmup,
+)
+
+LABELS = ["KEEP", "MERGE_SPACE", "MERGE_COMMA"]
+L2I = {l: i for i, l in enumerate(LABELS)}
+SEAM = "<seam>"
+
+
+class SeamData(Dataset):
+    def __init__(self, path, tok, left_words=18, right_words=14, max_len=96):
+        self.rows = [json.loads(l) for l in open(path, encoding="utf-8")]
+        self.tok = tok
+        self.lw, self.rw, self.max_len = left_words, right_words, max_len
+
+    def __len__(self):
+        return len(self.rows)
+
+    def __getitem__(self, i):
+        r = self.rows[i]
+        # Only a window matters, and a fixed window keeps inference cost flat
+        # no matter how long the user's document is.
+        left = " ".join(r["rec1"].split()[-self.lw:])
+        right = " ".join(r["rec2"].split()[: self.rw])
+        enc = self.tok(
+            f"{left} {SEAM} {right}",
+            truncation=True,
+            max_length=self.max_len,
+            padding="max_length",
+            return_tensors="pt",
+        )
+        return {
+            "input_ids": enc["input_ids"][0],
+            "attention_mask": enc["attention_mask"][0],
+            "labels": torch.tensor(L2I[r["label"]]),
+        }
+
+
+def evaluate(model, loader, device):
+    model.eval()
+    correct = total = 0
+    per_label = {l: [0, 0] for l in LABELS}
+    confusion = {}
+    with torch.no_grad():
+        for b in loader:
+            ids = b["input_ids"].to(device)
+            mask = b["attention_mask"].to(device)
+            y = b["labels"].to(device)
+            pred = model(input_ids=ids, attention_mask=mask).logits.argmax(-1)
+            correct += (pred == y).sum().item()
+            total += y.numel()
+            for t, p in zip(y.tolist(), pred.tolist()):
+                per_label[LABELS[t]][1] += 1
+                per_label[LABELS[t]][0] += int(t == p)
+                if t != p:
+                    confusion[(LABELS[t], LABELS[p])] = confusion.get((LABELS[t], LABELS[p]), 0) + 1
+    model.train()
+    return correct / max(total, 1), per_label, confusion
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="FacebookAI/xlm-roberta-base")
+    ap.add_argument("--train", default="seam_train.jsonl")
+    ap.add_argument("--test", default="seam_test.jsonl")
+    ap.add_argument("--epochs", type=int, default=3)
+    ap.add_argument("--batch-size", type=int, default=32)
+    ap.add_argument("--lr", type=float, default=2e-5)
+    ap.add_argument("--out", default="seam-model")
+    ap.add_argument("--seed", type=int, default=1785)
+    ap.add_argument("--balance-languages", action="store_true")
+    ap.add_argument("--balance-power", type=float, default=0.0)
+    args = ap.parse_args()
+
+    # Wrong merges swing widely epoch to epoch (1 -> 3 -> 19 on one run), so a
+    # single seed cannot separate two models. The seed is a flag to make repeats
+    # cheap and the variance measurable.
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"device={device} model={args.model}", flush=True)
+
+    tok = AutoTokenizer.from_pretrained(args.model)
+    tok.add_special_tokens({"additional_special_tokens": [SEAM]})
+    model = AutoModelForSequenceClassification.from_pretrained(
+        args.model, num_labels=len(LABELS)
+    )
+    model.resize_token_embeddings(len(tok))
+    model.to(device)
+
+    tr = SeamData(args.train, tok)
+    te = SeamData(args.test, tok)
+    print(f"train={len(tr)} test={len(te)}", flush=True)
+
+    # Russian accuracy swung 91.9-98.8% across seeds with the architecture and
+    # data held constant. The training mix is 9,664 English rows against 800
+    # German and 800 Russian, so the non-English languages contribute little
+    # gradient and land wherever the seed puts them. Sampling each language
+    # equally tests whether the instability is a data-mix problem rather than a
+    # model problem.
+    if args.balance_power:
+        # Partial balancing. Full equal-sampling fixed German and Russian but HURT
+        # zero-shot transfer to unseen languages (4 wrong merges vs 2), likely by
+        # overfitting the 800 repetitive Russian rows. power=0.5 is the sqrt
+        # middle ground: lift the small languages without starving English.
+        from collections import Counter
+
+        from torch.utils.data import WeightedRandomSampler
+
+        langs = [r.get("language", "?") for r in tr.rows]
+        counts = Counter(langs)
+        weights = [(1.0 / counts[l]) ** args.balance_power for l in langs]
+        print(f"balance_power={args.balance_power} over {dict(counts)}", flush=True)
+        sampler = WeightedRandomSampler(weights, num_samples=len(tr), replacement=True)
+        tl = DataLoader(tr, batch_size=args.batch_size, sampler=sampler, num_workers=0)
+    elif args.balance_languages:
+        from collections import Counter
+
+        from torch.utils.data import WeightedRandomSampler
+
+        langs = [r.get("language", "?") for r in tr.rows]
+        counts = Counter(langs)
+        weights = [1.0 / counts[l] for l in langs]
+        print(f"balancing languages: {dict(counts)}", flush=True)
+        sampler = WeightedRandomSampler(weights, num_samples=len(tr), replacement=True)
+        tl = DataLoader(tr, batch_size=args.batch_size, sampler=sampler, num_workers=0)
+    else:
+        tl = DataLoader(tr, batch_size=args.batch_size, shuffle=True, num_workers=0)
+    el = DataLoader(te, batch_size=64, num_workers=0)
+
+    opt = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=0.01)
+    steps = len(tl) * args.epochs
+    sched = get_linear_schedule_with_warmup(opt, int(0.06 * steps), steps)
+    scaler = torch.amp.GradScaler("cuda", enabled=device == "cuda")
+
+    # Select the checkpoint by WRONG MERGES, not overall accuracy. A wrong merge
+    # welds two of the user's sentences together and is invisible until they
+    # reread; a missed merge just leaves today's behaviour. Both mmBERT variants
+    # peaked at epoch 2 and degraded on this metric at epoch 3 while overall
+    # accuracy still looked healthy, so last-epoch saving was discarding the
+    # better model.
+    best = {"wrong_merges": 10**9, "acc": -1.0, "epoch": None}
+
+    for epoch in range(1, args.epochs + 1):
+        running = 0.0
+        for i, b in enumerate(tl, 1):
+            ids = b["input_ids"].to(device)
+            mask = b["attention_mask"].to(device)
+            y = b["labels"].to(device)
+            opt.zero_grad(set_to_none=True)
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16, enabled=device == "cuda"):
+                loss = model(input_ids=ids, attention_mask=mask, labels=y).loss
+            scaler.scale(loss).backward()
+            scaler.unscale_(opt)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            scaler.step(opt)
+            scaler.update()
+            sched.step()
+            running += loss.item()
+            if i % 50 == 0:
+                print(f"  epoch {epoch} step {i}/{len(tl)} loss {running/i:.4f}", flush=True)
+        acc, per_label, confusion = evaluate(model, el, device)
+        print(f"epoch {epoch}: held-out accuracy {100*acc:.1f}%", flush=True)
+        for l, (c, n) in per_label.items():
+            print(f"    {l:12} {c}/{n} = {100*c/max(n,1):.1f}%", flush=True)
+        worst = sorted(confusion.items(), key=lambda kv: -kv[1])[:4]
+        for (t, p), n in worst:
+            print(f"    confused {t} -> {p}: {n}", flush=True)
+
+        kept_c, kept_n = per_label["KEEP"]
+        wrong_merges = kept_n - kept_c
+        better = (wrong_merges, -acc) < (best["wrong_merges"], -best["acc"])
+        print(f"    wrong merges this epoch: {wrong_merges}"
+              f"{'  <-- best so far' if better else ''}", flush=True)
+        if better:
+            best.update(wrong_merges=wrong_merges, acc=acc, epoch=epoch)
+            os.makedirs(args.out, exist_ok=True)
+            model.save_pretrained(args.out)
+            tok.save_pretrained(args.out)
+
+    print(f"saved epoch {best['epoch']} to {args.out} "
+          f"({best['wrong_merges']} wrong merges, {100*best['acc']:.1f}% accuracy)",
+          flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Research-only. No shipped code touched, no behaviour change.

One session of research into joining two consecutive dictations when the speaker split a single thought across a pause. Committed so a future session starts from the findings rather than from scratch.

## Verdict

Eleven cases, seven that should join and four that must be left alone, greedy sampling so it reproduces.

| Engine | Score | Wrong merges | Destroyed text | Ship? |
|---|---|---|---|---|
| Apple Intelligence | 3/11 | 1 | 3 | No |
| EG-1 | 8/11 | 0 | 0 | Yes, opt-in |
| Cloud (Haiku 4.5) | 9/9 on its set | 0 | 0 | Yes, opt-in |

Apple Intelligence answers the dictation instead of editing it, on two very different prompts, so the merge cannot be a default feature. EG-1's three failures are all cases where it declined to join, never a wrong merge and never a mangled word.

## What is reusable now

The editing mechanism, which Level 2 (#1785) needs in full: replacing a span of text inside another application's field, measured across TextEdit, Chrome (textarea and contenteditable), Slack, Excel and Ghostty. Select the exact range and paste where a caret is reported; fall back to backspace only in terminals. Rewriting the whole value looks fastest and passes a read-back, but the app's own editor never sees it.

## What deliberately did not come with it

Corpora built from ~15,000 real dictations, and 829 MB of model weights. The repository is public and that material is real dictated content. `research/seam-joining/README.md` records where they live on the founder's Mac and how to rebuild them.

Part of #1790.
