### PR TITLE
fix(asr): stop Parakeet inventing words after you finish speaking (#1792)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9925f51a1e59246437b26429727b479f3162e5a8d630d61a4d9e527057dcc0ac",
+  "originHash" : "d730f41454297b3f35e35e261d1b24c358e501b92d2110c5ada9d7102a511281",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/saurabhav88/FluidAudio.git",
       "state" : {
-        "revision" : "e7948e1ac3e4eb0254201d19bb8496a4398c8476"
+        "revision" : "afb9aab1efdad979bca22ca887a936ff2c1cd8ea"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", from: "1.0.0"),
     .package(
       url: "https://github.com/saurabhav88/FluidAudio.git",
-      revision: "e7948e1ac3e4eb0254201d19bb8496a4398c8476"),
+      revision: "afb9aab1efdad979bca22ca887a936ff2c1cd8ea"),
     .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
     .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),

--- a/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
@@ -172,5 +172,5 @@
     "diskHeadroomFactor": "2.2",
     "evictPreviousRevisions": false
   },
-  "manifestDigest": "edbd8592cc8316b5aa3a82de81c0855af9d0463a7e2bf8a5a1fe8569af497676"
+  "manifestDigest": "db47ee6d8eb3bff63a46619ef626bd28618b165e1a48d56ae799871cd31f9232"
 }

--- a/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
@@ -5,7 +5,7 @@
     "name": "parakeet-tdt-0.6b-v3-coreml",
     "revision": "aed02740059203c4a87495924f685de3722ae9ce",
     "variant": "int8",
-    "runtimeABI": "fluidAudio-e7948e1a"
+    "runtimeABI": "fluidAudio-afb9aab1"
   },
   "runtimeCompatibility": {
     "minAppVersion": "2.4.0"

--- a/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
+++ b/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
@@ -257,7 +257,7 @@ The full text of the Apache License, Version 2.0 follows.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: e7948e1a (fork saurabhav88/FluidAudio)
+  Version: afb9aab1 (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -257,7 +257,7 @@ The full text of the Apache License, Version 2.0 follows.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: e7948e1a (fork saurabhav88/FluidAudio)
+  Version: afb9aab1 (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
@@ -247,7 +247,11 @@ enum ManifestFixture {
   /// runtime).
   // Updated 2026-07-07 (#1405 Phase 2): `our_copy` baseURL repointed to the
   // edge-cached `/parakeet/` path; digest recomputed via the same canonicalization.
-  static let goldenDigest = "edbd8592cc8316b5aa3a82de81c0855af9d0463a7e2bf8a5a1fe8569af497676"
+  // Updated 2026-07-25 (#1792): `identity.runtimeABI` bumped to the fork pin
+  // carrying the finalization fix. `runtimeABI` participates in the canonical
+  // JSON, so the digest moves with it — cloud review caught the stale value,
+  // which would have made `loadBundled` reject the manifest on every launch.
+  static let goldenDigest = "db47ee6d8eb3bff63a46619ef626bd28618b165e1a48d56ae799871cd31f9232"
 
   @Test func shippedManifestLoadsAndMatchesGoldenDigest() throws {
     let data = try Data(contentsOf: Self.shippedManifestURL)

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -37,7 +37,7 @@ COMPONENTS=(
   # text too, not just Argmax's MIT LICENSE (Codex audit 2026-07-10). Empty
   # identity — it is vendored inside argmax-oss-swift, not its own SwiftPM pin.
   "swift-transformers (incorporated into Argmax OSS)|n/a|Apache-2.0|argmax-oss-swift/NOTICES|https://github.com/huggingface/swift-transformers|"
-  "FluidAudio|e7948e1a (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
+  "FluidAudio|afb9aab1 (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
   "PostHog iOS|3.62.4|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
   "Sentry Cocoa|9.19.0|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
   "Sparkle|2.9.4|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"


### PR DESCRIPTION
Bumps the FluidAudio fork pin to `afb9aab1`, which carries one decoder change: the last-chunk finalization block may flush **punctuation only**, never lexical content.

Fork PR: saurabhav88/FluidAudio#1

## The bug

Founder said "I was able to" and got "I was able to **do that**." Reproduced deterministically offline from the archived audio, and confirmed with an independent whisper-1 decode that the tail was never spoken.

The decoder has a block that keeps decoding after the normal frame loop exhausts its time index. Its legitimate job is flushing a pending trailing punctuation mark. It was also free to emit words — and with no frames left to advance through, the prediction network's prior dominates and finishes the sentence for you.

Neither NeMo's transducer greedy decoding nor FluidAudio's own `UnifiedRnntDecoder` emits past frame exhaustion. This block is a local deviation.

## Not the diagnosis in the issue

#1792 blames a VAD override that transcribes when no speech segments are found. That is wrong: the override fired **0 times** in the reported session, and all three failing recordings had healthy VAD output (one segment, 72–100% voiced).

## Measurements

500 archived real dictations, decoded through the shipped backend with and without the change:

| | |
|---|---|
| changed | 16 / 500 |
| byte-identical | 484 / 500 |
| **spoken words removed** | **0** |
| adversarial clips changed | 0 / 40 |
| symbol-bait clips producing a stray symbol | 0 / 56 |

Every removal is reference-negative under an independent whisper-1 decode. An instrumented trace over those 556 clips admitted only `.` ×102, `?` ×14, `,` ×1 and blocked 37 lexical pieces.

Three alternatives were built and killed by measurement, not argument: silence padding (made one clip invent *more*, erased another), lowering `consecutiveBlankLimit` (stripped final punctuation from 99/500 and still didn't fix it), and removing the block entirely (stripped punctuation from 101/500).

## Scope — partial, deliberately

Covers post-exhaustion emission only. An invented word from the NORMAL decode loop carries a real frame index and is untouched — roughly half of the founder's live trail-off takes. Tracked as #1799, with four already-measured-and-rejected discriminators recorded so nobody repeats them.

Founder accepted the partial scope after live testing.

## Live UAT

Run on the rebuilt dev app; fix confirmed present in the shipped XPC binary.

| Said | Result |
|---|---|
| "What I want to" | "What I want to" ✅ |
| "Let us" ×3 | "Let us" ✅ |
| "I was able to" | "I was able to" ✅ (was "…do that.") |
| "Let us" (2.92s take) | "Let us know." ❌ normal-loop path, #1799 |
| Complete sentences, counting, questions | unchanged, no regression |

## Also in this PR

Every surface naming the fork revision, including `scripts/ci/gen-third-party-notices.sh` — patching only the generated notices file would have been silently reverted by the next CI run.

## Telemetry note

`lastTokenEndMs` now excludes suppressed tokens, so `TailClipDiagnostics` sees a truthful (smaller) decoder reach. At most 6/500 recordings shift classification — telemetry only, cannot affect delivered text. **Do not rebaseline the 250/500ms thresholds to absorb it**; the new value is the honest one, the old one was inflated by text we agree was invented.

Part of #1792