### PR TITLE
feat(settings): spoken punctuation becomes a user toggle, default off (#1794)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -71,6 +71,8 @@ final class PipelineSettingsSync {
     whisperKitKernelDriver.wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
     whisperKitKernelDriver.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
     whisperKitKernelDriver.emojiFormatter.emojiFormatterEnabled = settings.emojiFormatterEnabled
+    kernelDriver.spokenPunctuationEnabled = settings.spokenPunctuationEnabled
+    whisperKitKernelDriver.spokenPunctuationEnabled = settings.spokenPunctuationEnabled
 
     audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
     audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
@@ -166,6 +168,12 @@ final class PipelineSettingsSync {
     case .fillerRemovalEnabled:
       kernelDriver.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
       whisperKitKernelDriver.fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+    case .spokenPunctuationEnabled:
+      // Live-mutable, matching its three Cleanup siblings above. A take already in
+      // text processing keeps the value it started with (the step snapshots before
+      // its actor hop); the next take uses the new value.
+      kernelDriver.spokenPunctuationEnabled = settings.spokenPunctuationEnabled
+      whisperKitKernelDriver.spokenPunctuationEnabled = settings.spokenPunctuationEnabled
     case .isDebugModeEnabled:
       Task { await AppLogger.shared.setDebugMode(settings.isDebugModeEnabled) }
     case .debugLogLevel:

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -208,6 +208,7 @@ final class RecoveryCoordinator {
       wordCorrectionEnabled: settings.wordCorrectionEnabled,
       fillerRemovalEnabled: settings.fillerRemovalEnabled,
       emojiFormatterEnabled: settings.emojiFormatterEnabled,
+      spokenPunctuationEnabled: settings.spokenPunctuationEnabled,
       llmProvider: settings.llmProvider.rawValue,
       llmModel: resolvedModel,
       useExtendedThinking: settings.useExtendedThinking)

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -30,6 +30,7 @@ enum SettingsProjection {
     case fillerRemoval = "filler_removal"
     case contactsSync = "contacts_sync"
     case emojiFormatter = "emoji_formatter"
+    case spokenPunctuation = "spoken_punctuation"
     case crashRecovery = "crash_recovery"
     case useExtendedThinking = "use_extended_thinking"
     case languageMode = "language_mode"
@@ -74,6 +75,7 @@ enum SettingsProjection {
     case .fillerRemovalEnabled: return .fillerRemoval
     case .contactsSyncOnLaunchEnabled: return .contactsSync
     case .emojiFormatterEnabled: return .emojiFormatter
+    case .spokenPunctuationEnabled: return .spokenPunctuation
     case .crashRecoveryEnabled: return .crashRecovery
     case .useExtendedThinking: return .useExtendedThinking
     case .languageMode: return .languageMode
@@ -117,6 +119,7 @@ enum SettingsProjection {
     case .fillerRemoval: return onOff(settings.fillerRemovalEnabled)
     case .contactsSync: return onOff(settings.contactsSyncOnLaunchEnabled)
     case .emojiFormatter: return onOff(settings.emojiFormatterEnabled)
+    case .spokenPunctuation: return onOff(settings.spokenPunctuationEnabled)
     case .crashRecovery: return onOff(settings.crashRecoveryEnabled)
     case .useExtendedThinking: return onOff(settings.useExtendedThinking)
     case .languageMode: return languageModeLabel(settings.languageMode)

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -17,6 +17,7 @@ struct SpeechEngineSettingsView: View {
   @Environment(ModelDeliveryHome.self) private var modelDelivery: ModelDeliveryHome?
 
   @State private var showLanguageLockSheet: Bool = false
+  @State private var showSpokenPunctuationHelp: Bool = false
 
   /// #1171 — shown ONLY when the user's selected engine differs from the active
   /// one because a switch is deferred while a dictation/recovery is in flight.
@@ -317,7 +318,7 @@ struct SpeechEngineSettingsView: View {
             }
           }
         }
-        BrandedRow(showDivider: false) {
+        BrandedRow(showDivider: true) {
           HStack(alignment: .top, spacing: 11) {
             SettingsRowIcon(systemName: "face.smiling")
             VStack(alignment: .leading, spacing: 4) {
@@ -326,6 +327,22 @@ struct SpeechEngineSettingsView: View {
               }
               .toggleStyle(BrandedToggleStyle())
               Text("Say \"<phrase> emoji\" to get the glyph. Bare words never convert.")
+                .settingsReadingCopy()
+            }
+          }
+        }
+        BrandedRow(showDivider: false) {
+          HStack(alignment: .top, spacing: 11) {
+            SettingsRowIcon(systemName: "text.quote")
+            VStack(alignment: .leading, spacing: 4) {
+              HStack(spacing: 6) {
+                Toggle(isOn: $settings.spokenPunctuationEnabled) {
+                  Text(SpokenPunctuationCopy.toggleLabel).settingsRowLabel()
+                }
+                .toggleStyle(BrandedToggleStyle())
+                spokenPunctuationHelpButton
+              }
+              Text(SpokenPunctuationCopy.toggleDescription)
                 .settingsReadingCopy()
             }
           }
@@ -575,6 +592,55 @@ struct SpeechEngineSettingsView: View {
     .buttonStyle(.borderless)
     .help("Re-check model status")
     .accessibilityLabel("Re-check model status")
+  }
+
+  // MARK: - Spoken punctuation help (#1794)
+
+  /// A real `Button`, never a hover-only reveal. Hover cannot be reached by keyboard and
+  /// does not exist for VoiceOver, and the personas who most need this vocabulary are the
+  /// ones least able to reach a hover target. `.help()` gives the mouse-hover tooltip on
+  /// top; the button is what makes it reachable at all.
+  private var spokenPunctuationHelpButton: some View {
+    Button {
+      showSpokenPunctuationHelp = true
+    } label: {
+      Image(systemName: "questionmark.circle")
+        .foregroundStyle(Color.stTextSecondary)
+        .font(.stHelper)
+    }
+    .buttonStyle(.borderless)
+    .help(SpokenPunctuationCopy.helpButtonAccessibilityLabel)
+    .accessibilityLabel(SpokenPunctuationCopy.helpButtonAccessibilityLabel)
+    .popover(isPresented: $showSpokenPunctuationHelp, arrowEdge: .bottom) {
+      spokenPunctuationHelpPanel
+    }
+  }
+
+  private var spokenPunctuationHelpPanel: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text(SpokenPunctuationCopy.helpTitle)
+        .font(.stSectionHeader)
+      Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 6) {
+        GridRow {
+          Text(SpokenPunctuationCopy.helpSayColumn)
+            .foregroundStyle(Color.stTextSecondary)
+          Text(SpokenPunctuationCopy.helpGetColumn)
+            .foregroundStyle(Color.stTextSecondary)
+        }
+        .font(.stHelper)
+        ForEach(SpokenPunctuationCopy.phrases) { phrase in
+          GridRow {
+            Text("\"\(phrase.spoken)\"")
+            Text(phrase.result)
+          }
+        }
+      }
+      .font(.stBody)
+      Text(SpokenPunctuationCopy.helpFootnote)
+        .settingsReadingCopy()
+        .frame(maxWidth: 280, alignment: .leading)
+    }
+    .padding(16)
   }
 }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpokenPunctuationCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpokenPunctuationCopy.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// #1794: canonical copy for the spoken-punctuation setting and its in-app help panel.
+///
+/// `phrases` is a HAND-MAINTAINED mirror of `InverseTextNormalizer.punct` (nine rule
+/// tuples, ten spoken phrases — `exclamation (mark|point)` yields two). The regex table
+/// is `private` and deliberately stays that way: deriving this list from it at runtime
+/// would mean widening the engine's internals across a module boundary to render a
+/// static help panel. The cost of the mirror is drift; the guard is
+/// `SpokenPunctuationCopyTests`, which pins every pair verbatim, plus a comment on the
+/// `punct` table pointing back here. Change the rules, change this list.
+///
+/// No em-dashes or en-dashes (brand rule).
+enum SpokenPunctuationCopy {
+  static let toggleLabel = "Convert spoken punctuation"
+  static let toggleDescription =
+    "Say punctuation out loud to insert it. EnviousWispr already adds punctuation for "
+    + "you, so this can compete with it."
+
+  static let helpButtonAccessibilityLabel = "What can I say?"
+  static let helpTitle = "Words you can say"
+  static let helpSayColumn = "Say this"
+  static let helpGetColumn = "You get"
+  /// Closing note in the panel: names the failure mode a user will otherwise discover
+  /// by having a sentence quietly broken.
+  static let helpFootnote =
+    "These words become marks even when you meant the word itself, like \"the grace "
+    + "period expires\"."
+
+  /// Spoken phrase paired with what the user sees. Order is the order shown.
+  /// `result` is display copy, not the literal replacement: "new line" inserts a real
+  /// line break, which cannot be rendered meaningfully in a table cell.
+  struct Phrase: Identifiable, Equatable {
+    let spoken: String
+    let result: String
+    var id: String { spoken }
+  }
+
+  static let phrases: [Phrase] = [
+    Phrase(spoken: "comma", result: ","),
+    Phrase(spoken: "period", result: "."),
+    Phrase(spoken: "full stop", result: "."),
+    Phrase(spoken: "question mark", result: "?"),
+    Phrase(spoken: "exclamation mark", result: "!"),
+    Phrase(spoken: "exclamation point", result: "!"),
+    Phrase(spoken: "colon", result: ":"),
+    Phrase(spoken: "semicolon", result: ";"),
+    Phrase(spoken: "new line", result: "a line break"),
+    Phrase(spoken: "new paragraph", result: "a blank line"),
+  ]
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -13,6 +13,17 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.4.2
+
+    Entry(
+      id: "spoken-punctuation-is-now-a-choice",
+      icon: "text.quote",
+      title: "Saying \"comma\" and \"period\" is now yours to switch on",
+      description:
+        "Until now, saying words like \"comma\", \"period\" or \"colon\" always turned them into punctuation marks, even when you meant the word. Dictating \"the grace period expires\" could quietly break your sentence. EnviousWispr already adds punctuation for you, so this is off from now on. If you like dictating punctuation out loud, turn it back on under Speech Engine, in the Cleanup section, where a help button lists every word you can say and what you get.",
+      version: "2.4.2"
+    ),
+
     // MARK: - v2.4.1
 
     Entry(

--- a/Sources/EnviousWisprCore/DictationSessionConfig.swift
+++ b/Sources/EnviousWisprCore/DictationSessionConfig.swift
@@ -32,8 +32,15 @@ public enum TriggerSource: String, Sendable, CaseIterable {
 /// duration of the recording. Settings mutated mid-recording apply to the NEXT recording.
 ///
 /// Contains only values that must be frozen per recording. Live-mutable settings
-/// (hotkey registration, `wordCorrectionEnabled`, `fillerRemovalEnabled`, custom-words
-/// dictionary, Ollama RAM eviction side-effects) stay in `PipelineSettingsSync`.
+/// (hotkey registration, `wordCorrectionEnabled`, `fillerRemovalEnabled`,
+/// `spokenPunctuationEnabled`, custom-words dictionary, Ollama RAM eviction
+/// side-effects) stay in `PipelineSettingsSync`.
+///
+/// #1794 note: the live-mutable Cleanup toggles are ALSO frozen into
+/// `RecordingSettingsSnapshot` at capture start, so flipping one mid-recording can make
+/// the live take and a later recovered replay of that same take disagree. That is
+/// pre-existing and shared by all four Cleanup toggles, deliberately not fixed for one
+/// of them alone; fixing it means moving all four here, as one change.
 public struct DictationSessionConfig: Sendable {
   // MARK: Paste / clipboard
 

--- a/Sources/EnviousWisprCore/RecoverySpool.swift
+++ b/Sources/EnviousWisprCore/RecoverySpool.swift
@@ -70,6 +70,18 @@ public struct RecordingSettingsSnapshot: Codable, Sendable, Equatable {
   public let wordCorrectionEnabled: Bool
   public let fillerRemovalEnabled: Bool
   public let emojiFormatterEnabled: Bool
+  /// Spoken-punctuation switch at record time (#1794). OPTIONAL: spools written before
+  /// #1794 have no key, and this type uses synthesized `Codable` with no custom decoder,
+  /// so a non-optional field would fail the WHOLE settings decode. `RecoverySpoolStore`
+  /// swallows that with `try?`, which would silently drop engine, language and polish
+  /// replay fidelity too. `nil` means no preference was recorded because the setting did
+  /// not exist yet; recovery resolves that to the founder-directed default, OFF. Do not
+  /// infer delivery state from spool existence — spools are armed for EVERY recording.
+  ///
+  /// The initializer parameter below is deliberately NOT defaulted: it is the only
+  /// compile-time force on `RecoveryCoordinator` to pass the record-time value. Giving
+  /// it a default would let a new spool silently carry `nil` forever.
+  public let spokenPunctuationEnabled: Bool?
   /// Version/hash of the custom-words vocabulary at record time, so recovery
   /// can note when the vocabulary has since changed. Nil when unknown.
   public let customWordsVersion: String?
@@ -90,6 +102,7 @@ public struct RecordingSettingsSnapshot: Codable, Sendable, Equatable {
     wordCorrectionEnabled: Bool,
     fillerRemovalEnabled: Bool,
     emojiFormatterEnabled: Bool,
+    spokenPunctuationEnabled: Bool?,
     customWordsVersion: String? = nil,
     llmProvider: String,
     llmModel: String,
@@ -102,6 +115,7 @@ public struct RecordingSettingsSnapshot: Codable, Sendable, Equatable {
     self.wordCorrectionEnabled = wordCorrectionEnabled
     self.fillerRemovalEnabled = fillerRemovalEnabled
     self.emojiFormatterEnabled = emojiFormatterEnabled
+    self.spokenPunctuationEnabled = spokenPunctuationEnabled
     self.customWordsVersion = customWordsVersion
     self.llmProvider = llmProvider
     self.llmModel = llmModel

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.4.1"
+  public static let currentContentVersion = "2.4.2"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"

--- a/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
+++ b/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
@@ -32,6 +32,16 @@ final class InverseTextNormalizationStep: TextProcessingStep {
   /// own deadline (which also owns the anomaly breadcrumb).
   var maxDuration: Duration { .seconds(2) }
 
+  /// Spoken-punctuation sub-feature gate (#1794). Distinct from `isEnabled`, which
+  /// stays `true`: the ITN limb keeps running either way, because numbers, currency,
+  /// dates, times, phone, email, URL and ordinal formatting are unaffected by this
+  /// setting. Only the nine bare command rewrites are gated.
+  ///
+  /// Default `false` — the safe state for a step built in isolation (tests, and
+  /// recovery before `applySettings` runs), and it matches the shipped product
+  /// default. Seeded and live-updated through `KernelDictationDriver`'s façade.
+  var spokenPunctuationEnabled: Bool = false
+
   /// Per-session capability hint wired by `KernelFinalizationWiring` from
   /// `adapter.capabilities.supportsLanguageDetection` — NOT an engine-identity
   /// literal (`EngineIdentityFreezeTests` bans identity reads at non-factory sites).
@@ -85,10 +95,14 @@ final class InverseTextNormalizationStep: TextProcessingStep {
     // cap. Snapshot the Sendable engine into a LOCAL first so the `@Sendable`
     // closure does not capture `self` across the actor boundary (Codex r2;
     // `swift-concurrency-patterns` snapshot rule; `withDeadline` precedent #832/#913 PR8).
+    // Snapshot the flag alongside the normalizer BEFORE the actor hop: a toggle
+    // landing mid-run must not tear this take, which completes under the value it
+    // started with (`swift-concurrency-patterns` telemetry-snapshot-not-shared-property).
     let normalizer = self.normalizer
+    let spokenPunctuation = self.spokenPunctuationEnabled
     let start = CFAbsoluteTimeGetCurrent()
     let maybeConverted = await withDeadline(seconds: 0.5) {
-      normalizer.normalize(input)
+      normalizer.normalize(input, spokenPunctuation: spokenPunctuation)
     }
     let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
     guard let converted = maybeConverted else {

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -664,6 +664,17 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   public var emojiFormatter: EmojiFormatterStep { steps.emojiFormatter }
   public var llmPolish: LLMPolishStep { steps.llmPolish }
 
+  /// Spoken-punctuation gate (#1794). A narrow `Bool` rather than an
+  /// `InverseTextNormalizationStep` accessor like its siblings above: those work only
+  /// because their step types are `public`, and `InverseTextNormalizationStep` is
+  /// internal. Widening the whole type across a module boundary to pass one flag would
+  /// violate `architecture-rules.md` RULE: minimize-visibility, so AppKit gets the
+  /// Boolean and nothing else. `package` because only first-party targets consume it.
+  package var spokenPunctuationEnabled: Bool {
+    get { steps.inverseTextNormalization.spokenPunctuationEnabled }
+    set { steps.inverseTextNormalization.spokenPunctuationEnabled = newValue }
+  }
+
   // MARK: Caller-visible signals
 
   /// The kernel's `RecordingSessionState` mapped to the legacy `PipelineState`.

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -84,6 +84,11 @@ public final class RecoveryTextProcessor {
     steps.wordCorrection.wordCorrectionEnabled = snapshot.wordCorrectionEnabled
     steps.fillerRemoval.fillerRemovalEnabled = snapshot.fillerRemovalEnabled
     steps.emojiFormatter.emojiFormatterEnabled = snapshot.emojiFormatterEnabled
+    // #1794: a legacy spool records no preference for this setting, absence is not an
+    // affirmative opt-in, and the founder-directed default is OFF. Does NOT depend on
+    // whether the take was ever delivered.
+    steps.inverseTextNormalization.spokenPunctuationEnabled =
+      snapshot.spokenPunctuationEnabled ?? false
     // Match the live ITN language gate: a LID engine with unknown language skips
     // ITN rather than rewriting possibly-non-English text. Sourced from the
     // record-time capability, never an engine-identity literal (Codex PR0 P2).

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -155,7 +155,12 @@ public struct InverseTextNormalizer: Sendable {
 
   // MARK: - Public entry point
 
-  public func normalize(_ text: String) -> String {
+  /// - Parameter spokenPunctuation: gates ONLY the nine bare spoken-punctuation
+  ///   commands (see `punct`). Every other conversion — numbers, currency, dates,
+  ///   times, phone, email, URL, ordinals, ranges — and the sentence-capitalization
+  ///   pass run regardless. Defaults to `false`, matching the shipped product default
+  ///   (#1794) so a caller that forgets it gets the non-rewriting behaviour.
+  public func normalize(_ text: String, spokenPunctuation: Bool = false) -> String {
     var t = " " + text.trimmingCharacters(in: .whitespacesAndNewlines) + " "
 
     // "shout" = the whole utterance is upper-case (typed in caps). In shout text a capitalized
@@ -497,7 +502,7 @@ public struct InverseTextNormalizer: Sendable {
     t = reSub(#"\b(\d[\d,]*\.\d+)\s+(?:percent|per\s+cent)\b"#, t) { m in "\(m.g(1) ?? "")% " }
 
     t = keepMagnitude(t)  // '$80,000,000'->'$80 million' (founder house style), keep the word
-    t = applyPunct(t)
+    t = applyPunct(t, spokenPunctuation: spokenPunctuation)
 
     // restore register-preserved spans verbatim
     for (i, p) in protected.enumerated() {
@@ -837,7 +842,9 @@ public struct InverseTextNormalizer: Sendable {
     // number is never followed by ",digit" (greedy match would have consumed it), so this only
     // fires where \b failed on the full figure — ordinal suffixes ('1,000,000,000th' #1201),
     // decimals past the (?!\.\d) block ('$5,000,000,000.00'), plurals ('1,000,000,000s').
-    return reSub(#"(?<cur>\$)?(?<n>\d{1,3}(?:,\d{3})+)\b(?!\.\d)(?!,\d)"#, t, caseInsensitive: false) {
+    return reSub(
+      #"(?<cur>\$)?(?<n>\d{1,3}(?:,\d{3})+)\b(?!\.\d)(?!,\d)"#, t, caseInsensitive: false
+    ) {
       m in
       let cur = m.g("cur") ?? ""
       guard let n = Int((m.g("n") ?? "").replacingOccurrences(of: ",", with: "")) else {
@@ -865,6 +872,18 @@ public struct InverseTextNormalizer: Sendable {
 
   // MARK: - Punctuation
 
+  /// The nine bare spoken-punctuation commands, gated by the user setting (#1794).
+  /// Nine tuples, TEN phrases: `exclamation (mark|point)` yields two.
+  ///
+  /// Matching is case-INSENSITIVE (`reSub` defaults `caseInsensitive: true` and the
+  /// loop below does not override it), so "Period" at a sentence start converts too.
+  ///
+  /// User-facing copy mirrors this table BY HAND in `SpokenPunctuationCopy`
+  /// (EnviousWisprAppKit). Change one, change the other, or the in-app help panel
+  /// starts lying about what the app does. A freeze test pins that copy.
+  ///
+  /// Spoken symbol words in CONTEXTUAL conversions (email at/dot, URL dot/slash,
+  /// numeric slash, percent, decimal dot) are NOT here and are never gated.
   private static let punct: [(String, String)] = [
     (#"\bnew paragraph\b"#, "\n\n"), (#"\bnew line\b"#, "\n"),
     (#"\s+comma\b"#, ","), (#"\s+period\b"#, "."), (#"\s+full stop\b"#, "."),
@@ -872,10 +891,17 @@ public struct InverseTextNormalizer: Sendable {
     (#"\s+colon\b"#, ":"), (#"\s+semicolon\b"#, ";"),
   ]
 
-  private func applyPunct(_ t0: String) -> String {
+  /// - Parameter spokenPunctuation: when false, the nine command rewrites are skipped
+  ///   and their trigger words survive as ordinary text. Sentence capitalization below
+  ///   runs REGARDLESS: it keys off `.!?` whoever produced them, including the marks
+  ///   the speech recognizer adds on its own, so it is general formatting rather than
+  ///   part of the spoken-command feature.
+  private func applyPunct(_ t0: String, spokenPunctuation: Bool) -> String {
     var t = t0
-    for (pat, rep) in Self.punct {
-      t = reSub(pat, t) { _ in rep }
+    if spokenPunctuation {
+      for (pat, rep) in Self.punct {
+        t = reSub(pat, t) { _ in rep }
+      }
     }
     // capitalize sentence starts crudely (no case-insensitivity: targets lowercase only)
     t = reSub(#"(^|[.!?]\s+)([a-z])"#, t, caseInsensitive: false) { m in

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -59,6 +59,12 @@ enum SettingsDefaultValues {
   // sentiment (personas.md emoji-control-current), so uncustomized users see no
   // surprise emoji, just gain the explicit-trigger capability.
   static let emojiFormatterEnabled = true
+  // #1794: spoken-punctuation commands ("comma" -> ",") OFF by default — the only
+  // Text-cleanup toggle that ships off. These rules shipped always-on as a rider on
+  // #145 and #1367 measured them: they fight the punctuation both recognizers already
+  // add, and they fire on content words ("the grace period expires"). Founder
+  // direction 2026-07-25: off for everyone, opt in from Settings.
+  static let spokenPunctuationEnabled = false
 
   // #1063: crash-recovery audio safety copy. Default ON — every recording is
   // protected by an encrypted, auto-deleted-on-success spool. Off means never

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -29,6 +29,7 @@ public final class SettingsManager {
     case wordCorrectionEnabled
     case fillerRemovalEnabled
     case emojiFormatterEnabled
+    case spokenPunctuationEnabled
     case crashRecoveryEnabled
     case contactsSyncOnLaunchEnabled
     case isDebugModeEnabled
@@ -76,7 +77,8 @@ public final class SettingsManager {
     "cancelKeyCode", "cancelModifiersRaw", "toggleKeyCode", "toggleModifiersRaw",
     "pushToTalkKeyCode", "pushToTalkModifiersRaw", "modelUnloadPolicy",
     "restoreClipboardAfterPaste", "wordCorrectionEnabled", "fillerRemovalEnabled",
-    "emojiFormatterEnabled", "crashRecoveryEnabled", "contactsSyncOnLaunchEnabled",
+    "emojiFormatterEnabled", "spokenPunctuationEnabled", "crashRecoveryEnabled",
+    "contactsSyncOnLaunchEnabled",
     "isDebugModeEnabled", "isDictationAudioArchiveEnabled", "debugLogLevel",
     "useExtendedThinking", "whisperKitLanguage", "languageMode",
     "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
@@ -345,6 +347,17 @@ public final class SettingsManager {
     didSet {
       defaults.set(emojiFormatterEnabled, forKey: "emojiFormatterEnabled")
       onChange?(.emojiFormatterEnabled)
+    }
+  }
+
+  /// Spoken-punctuation commands (#1794). Default OFF — the only Text-cleanup toggle
+  /// that ships off, because these rules compete with the punctuation both recognizers
+  /// already add and fire on content words. Canonical default in
+  /// `SettingsDefaultValues.spokenPunctuationEnabled`.
+  public var spokenPunctuationEnabled: Bool {
+    didSet {
+      defaults.set(spokenPunctuationEnabled, forKey: "spokenPunctuationEnabled")
+      onChange?(.spokenPunctuationEnabled)
     }
   }
 
@@ -667,6 +680,9 @@ public final class SettingsManager {
     emojiFormatterEnabled =
       defaults.object(forKey: "emojiFormatterEnabled") as? Bool
       ?? SettingsDefaultValues.emojiFormatterEnabled
+    spokenPunctuationEnabled =
+      defaults.object(forKey: "spokenPunctuationEnabled") as? Bool
+      ?? SettingsDefaultValues.spokenPunctuationEnabled
     crashRecoveryEnabled =
       defaults.object(forKey: "crashRecoveryEnabled") as? Bool
       ?? SettingsDefaultValues.crashRecoveryEnabled

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
@@ -50,7 +50,7 @@ struct InverseTextNormalizerParityTests {
     var perCategoryFail: [String: Int] = [:]
     for row in rows {
       perCategoryTotal[row.category, default: 0] += 1
-      let got = itn.normalize(row.input)
+      let got = itn.normalize(row.input, spokenPunctuation: true)
       if got != row.expected {
         perCategoryFail[row.category, default: 0] += 1
         if mismatches.count < 40 { mismatches.append((row, got)) }
@@ -112,8 +112,8 @@ struct InverseTextNormalizerParityTests {
     #expect(rows.isEmpty == false)
     let itn = InverseTextNormalizer()
     var corrupted: [(String, String)] = []
-    for row in rows where itn.normalize(row.input) != row.expected {
-      corrupted.append((row.input, itn.normalize(row.input)))
+    for row in rows where itn.normalize(row.input, spokenPunctuation: true) != row.expected {
+      corrupted.append((row.input, itn.normalize(row.input, spokenPunctuation: true)))
     }
     // Parity already pins these to the oracle; this is a focused readout of the safety floor.
     #expect(corrupted.isEmpty, "negatives diverged from oracle: \(corrupted.prefix(10))")
@@ -127,8 +127,8 @@ struct InverseTextNormalizerParityTests {
     let itn = InverseTextNormalizer()
     var unstable: [(String, String, String)] = []
     for row in rows where Self.knownNonIdempotentInputs.contains(row.input) == false {
-      let once = itn.normalize(row.input)
-      let twice = itn.normalize(once)
+      let once = itn.normalize(row.input, spokenPunctuation: true)
+      let twice = itn.normalize(once, spokenPunctuation: true)
       if twice != once {
         unstable.append((row.input, once, twice))
       }
@@ -176,7 +176,7 @@ struct InverseTextNormalizerParityTests {
       ("One Million Moms", "One Million Moms"),
     ])
   func categoryFixes(input: String, expected: String) {
-    #expect(InverseTextNormalizer().normalize(input) == expected)
+    #expect(InverseTextNormalizer().normalize(input, spokenPunctuation: true) == expected)
   }
 
   // AP-style number formatting (#1187). Spell one-nine; digits for 10+; always-digit exceptions
@@ -207,7 +207,7 @@ struct InverseTextNormalizerParityTests {
       ("we ate at Five Guys", "we ate at Five Guys"),
     ])
   func apNumberPolicy(input: String, expected: String) {
-    #expect(InverseTextNormalizer().normalize(input) == expected)
+    #expect(InverseTextNormalizer().normalize(input, spokenPunctuation: true) == expected)
   }
 
   // Codex-finding regressions from PR #1191's review. Fix 1: keep-magnitude must never rewrite
@@ -246,6 +246,6 @@ struct InverseTextNormalizerParityTests {
       ("she came 3rd - not bad", "she came 3rd - not bad"),
     ])
   func codexFindingRegressions(input: String, expected: String) {
-    #expect(InverseTextNormalizer().normalize(input) == expected)
+    #expect(InverseTextNormalizer().normalize(input, spokenPunctuation: true) == expected)
   }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/SpokenPunctuationToggleTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SpokenPunctuationToggleTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #1794: the spoken-punctuation toggle gates the nine bare command rewrites and NOTHING
+/// else in the inverse-text normalizer.
+///
+/// These tests deliberately do NOT characterise how badly the nine rules misfire on
+/// content words ("the grace period expires", "in a coma"). `matcher-set-adversarial-tests`
+/// would normally demand that for a routing matcher, but that rule protects a matcher we
+/// rely on. We do not rely on this one: it is known-bad (#1367), now ships OFF, and the
+/// long-term answer is the model handling it natively (#1364). What must be proven is
+/// narrower — the switch works, and nothing else moved.
+struct SpokenPunctuationToggleTests {
+
+  private static let itn = InverseTextNormalizer()
+
+  /// The ten spoken phrases the nine `punct` tuples produce. Mirrors
+  /// `SpokenPunctuationCopy.phrases`; the copy-freeze test in the AppKit suite pins the
+  /// user-facing side.
+  static let triggers: [(spoken: String, mark: String)] = [
+    ("comma", ","), ("period", "."), ("full stop", "."),
+    ("question mark", "?"), ("exclamation mark", "!"), ("exclamation point", "!"),
+    ("colon", ":"), ("semicolon", ";"),
+  ]
+
+  // MARK: - The switch works
+
+  @Test("OFF leaves every trigger phrase as ordinary words", arguments: triggers)
+  func offLeavesTriggersLiteral(trigger: (spoken: String, mark: String)) {
+    let input = "alpha \(trigger.spoken) beta"
+    let out = Self.itn.normalize(input, spokenPunctuation: false)
+    #expect(
+      out.contains(trigger.spoken),
+      "\(trigger.spoken.debugDescription) should survive as text with the toggle OFF, got \(out.debugDescription)"
+    )
+    #expect(out.contains(trigger.mark) == false, "no mark expected, got \(out.debugDescription)")
+  }
+
+  @Test("ON converts every trigger phrase", arguments: triggers)
+  func onConvertsTriggers(trigger: (spoken: String, mark: String)) {
+    let input = "alpha \(trigger.spoken) beta"
+    let out = Self.itn.normalize(input, spokenPunctuation: true)
+    #expect(
+      out.contains("alpha\(trigger.mark)"),
+      "expected alpha\(trigger.mark), got \(out.debugDescription)")
+    #expect(
+      out.contains(trigger.spoken) == false,
+      "trigger word should be consumed, got \(out.debugDescription)")
+  }
+
+  @Test("Line-break triggers convert only when ON")
+  func lineBreakTriggers() {
+    #expect(Self.itn.normalize("alpha new line beta", spokenPunctuation: true).contains("\n"))
+    #expect(
+      Self.itn.normalize("alpha new paragraph beta", spokenPunctuation: true).contains("\n\n"))
+    #expect(
+      Self.itn.normalize("alpha new line beta", spokenPunctuation: false).contains("\n") == false)
+    #expect(
+      Self.itn.normalize("alpha new paragraph beta", spokenPunctuation: false).contains("\n")
+        == false)
+  }
+
+  /// Matching is case-insensitive today (`reSub` defaults `caseInsensitive: true`). Frozen
+  /// so nobody "tidies" it into case-sensitivity without noticing it is a behaviour change.
+  @Test("Case variants follow the switch, not the case")
+  func caseInsensitivity() {
+    #expect(Self.itn.normalize("alpha Period beta", spokenPunctuation: true).contains("alpha."))
+    #expect(Self.itn.normalize("alpha Period beta", spokenPunctuation: false).contains("Period"))
+  }
+
+  // MARK: - Nothing else moved
+
+  /// Capitalization lives inside `applyPunct` beside the gated loop but must NOT be gated:
+  /// it keys off `.!?` whoever produced them, including the recognizer's own marks.
+  ///
+  /// The leading `h` stays lowercase in BOTH arms because `normalize` pads its working
+  /// string with a leading space, so the `^` branch never matches the real first character.
+  @Test("Sentence capitalization runs with the toggle OFF")
+  func capitalizationSurvivesOff() {
+    #expect(Self.itn.normalize("hello. world", spokenPunctuation: false) == "hello. World")
+    #expect(Self.itn.normalize("hello period world", spokenPunctuation: true) == "hello. World")
+  }
+
+  @Test(
+    "Non-punctuation conversions are identical in both switch positions",
+    arguments: [
+      "we counted twenty three",
+      "the invoice is eighty five dollars",
+      "we raised eighty million dollars last year",
+      "i was born in nineteen eighty seven",
+      "call me at 203 nine five four eight eight seven nine",
+      "email casey at proton dot me",
+      "visit stackoverflow dot io slash blog",
+      "the twentieth century",
+      "five point five percent",
+    ])
+  func otherCategoriesUnaffected(input: String) {
+    let off = Self.itn.normalize(input, spokenPunctuation: false)
+    let on = Self.itn.normalize(input, spokenPunctuation: true)
+    #expect(
+      off == on,
+      "toggle leaked into a non-punctuation category: \(off.debugDescription) vs \(on.debugDescription)"
+    )
+  }
+
+  /// The strongest isolation proof: run the ENTIRE 2,064-row parity corpus both ways and
+  /// pin exactly which rows the toggle changes. Any row outside the pinned set means the
+  /// gate leaked; an empty set means the test went vacuous.
+  ///
+  /// The pinned set is derived from a real run, never predicted. It contains the
+  /// punctuation-category rows that actually carry a trigger, plus three `url` rows whose
+  /// degenerate spelled-out input ("h t t p colon slash slash ...") happens to hit the
+  /// `colon` rule. Those three are NOT real URL handling — the URL rule matches
+  /// `host dot tld` and is untouched by this change.
+  @Test("Toggle changes exactly the pinned corpus rows and no others")
+  func corpusIsolation() throws {
+    let rows = try InverseTextNormalizerParityTests.loadRows()
+    #expect(rows.count > 1500, "parity fixture looks truncated: \(rows.count) rows")
+
+    let divergent = rows.filter {
+      Self.itn.normalize($0.input, spokenPunctuation: false)
+        != Self.itn.normalize($0.input, spokenPunctuation: true)
+    }
+    #expect(divergent.isEmpty == false, "vacuous: the toggle changed nothing across the corpus")
+
+    let unexpected = divergent.filter { $0.category != "punctuation" && $0.category != "url" }
+    let leaked = unexpected.prefix(10)
+      .map { "[\($0.category)] \($0.input.debugDescription)" }
+      .joined(separator: ", ")
+    #expect(unexpected.isEmpty, "toggle leaked outside punctuation/url: \(leaked)")
+
+    let urlDivergent = divergent.filter { $0.category == "url" }
+    let urlSample = urlDivergent.prefix(5).map { $0.input.debugDescription }.joined(separator: ", ")
+    #expect(
+      urlDivergent.count == 3,
+      "expected exactly the 3 degenerate spelled-out url rows, got \(urlDivergent.count): \(urlSample)"
+    )
+    for row in urlDivergent {
+      #expect(
+        row.input.contains("colon"),
+        "a url row diverged for a reason other than the colon rule: \(row.input.debugDescription)")
+    }
+  }
+
+  @Test("Idempotence holds in both switch positions")
+  func idempotenceBothWays() throws {
+    let rows = try InverseTextNormalizerParityTests.loadRows()
+    for flag in [false, true] {
+      var unstable: [(String, String, String)] = []
+      for row in rows
+      where InverseTextNormalizerParityTests.knownNonIdempotentInputs.contains(row.input) == false {
+        let once = Self.itn.normalize(row.input, spokenPunctuation: flag)
+        let twice = Self.itn.normalize(once, spokenPunctuation: flag)
+        if twice != once { unstable.append((row.input, once, twice)) }
+      }
+      #expect(
+        unstable.isEmpty, "non-idempotent with spokenPunctuation=\(flag): \(unstable.prefix(5))")
+    }
+  }
+
+  /// The parameter defaults to `false` so a caller that forgets it gets the non-rewriting
+  /// behaviour, which is what keeps the gitignored local ASR benchmark source-compatible.
+  @Test("The default argument is OFF")
+  func defaultArgumentIsOff() {
+    #expect(
+      Self.itn.normalize("alpha comma beta")
+        == Self.itn.normalize("alpha comma beta", spokenPunctuation: false))
+    #expect(Self.itn.normalize("alpha comma beta").contains("comma"))
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolCodecTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolCodecTests.swift
@@ -23,6 +23,7 @@ struct RecoverySpoolCodecTests {
       wordCorrectionEnabled: true,
       fillerRemovalEnabled: true,
       emojiFormatterEnabled: false,
+      spokenPunctuationEnabled: false,
       customWordsVersion: "v3",
       llmProvider: "appleIntelligence",
       llmModel: "apple-intelligence",

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -116,6 +116,7 @@ struct RecoverySpoolReplayerTests {
       wordCorrectionEnabled: false,
       fillerRemovalEnabled: false,
       emojiFormatterEnabled: false,
+      spokenPunctuationEnabled: false,
       customWordsVersion: nil,
       llmProvider: "none",
       llmModel: "",

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
@@ -28,6 +28,7 @@ struct RecoverySpoolStoreTests {
       wordCorrectionEnabled: false,
       fillerRemovalEnabled: true,
       emojiFormatterEnabled: false,
+      spokenPunctuationEnabled: false,
       customWordsVersion: nil,
       llmProvider: "openAI",
       llmModel: "gpt-4o-mini",

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolWriterTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolWriterTests.swift
@@ -18,7 +18,8 @@ struct RecoverySpoolWriterTests {
     RecordingSettingsSnapshot(
       backendType: .parakeet, backendSupportsLanguageDetection: false, languageMode: .auto,
       wordCorrectionEnabled: false, fillerRemovalEnabled: false,
-      emojiFormatterEnabled: false, customWordsVersion: nil,
+      emojiFormatterEnabled: false, spokenPunctuationEnabled: false,
+      customWordsVersion: nil,
       llmProvider: "none", llmModel: "none", polishPromptVersion: nil)
   }
 

--- a/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
@@ -25,6 +25,7 @@ struct RecoveryTextProcessorTests {
       wordCorrectionEnabled: false,
       fillerRemovalEnabled: fillerRemoval,
       emojiFormatterEnabled: false,
+      spokenPunctuationEnabled: false,
       customWordsVersion: nil,
       llmProvider: provider,
       llmModel: "none",

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -27,6 +27,8 @@ struct SettingsDefaultsRoutingTests {
     let settings = SettingsManager(defaults: Self.freshSuite())
     // The two #923 corrections:
     #expect(settings.emojiFormatterEnabled == true)
+    // #1794: the ONE Text-cleanup toggle that ships OFF.
+    #expect(settings.spokenPunctuationEnabled == false)
     #expect(settings.llmProvider == .appleIntelligence)
     // Unchanged canonical values (lock them so an accidental flip fails here):
     #expect(settings.recordingMode == .pushToTalk)
@@ -52,12 +54,15 @@ struct SettingsDefaultsRoutingTests {
     let settings = SettingsManager(defaults: suite)
     settings.toggleKeyCode = 99
     settings.emojiFormatterEnabled = false
+    settings.spokenPunctuationEnabled = true
     #expect(suite.object(forKey: "toggleKeyCode") as? Int == 99)
     #expect(suite.object(forKey: "emojiFormatterEnabled") as? Bool == false)
+    #expect(suite.object(forKey: "spokenPunctuationEnabled") as? Bool == true)
     // Reconstructing from the same suite round-trips the explicit values.
     let reloaded = SettingsManager(defaults: suite)
     #expect(reloaded.toggleKeyCode == 99)
     #expect(reloaded.emojiFormatterEnabled == false)
+    #expect(reloaded.spokenPunctuationEnabled == true)
   }
 
   // MARK: - Exclusions (adversarial — these MUST stay per-build)

--- a/Tests/EnviousWisprTests/Settings/SpokenPunctuationCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/SpokenPunctuationCopyTests.swift
@@ -1,0 +1,60 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #1794: the in-app help panel's word list is a HAND-MAINTAINED mirror of
+/// `InverseTextNormalizer.punct`. Nothing derives one from the other at runtime, so this
+/// freeze test is the guard: if someone edits the copy, it must be a conscious act, and if
+/// someone edits the nine rules the mismatch shows up here rather than in a panel that
+/// quietly lies to users about what the app does.
+struct SpokenPunctuationCopyTests {
+
+  /// Nine rule tuples, TEN phrases: `exclamation (mark|point)` yields two.
+  @Test("The help panel lists exactly the ten spoken phrases, verbatim and in order")
+  func phrasesAreFrozen() {
+    let expected: [(String, String)] = [
+      ("comma", ","),
+      ("period", "."),
+      ("full stop", "."),
+      ("question mark", "?"),
+      ("exclamation mark", "!"),
+      ("exclamation point", "!"),
+      ("colon", ":"),
+      ("semicolon", ";"),
+      ("new line", "a line break"),
+      ("new paragraph", "a blank line"),
+    ]
+    #expect(SpokenPunctuationCopy.phrases.count == expected.count)
+    for (actual, want) in zip(SpokenPunctuationCopy.phrases, expected) {
+      #expect(actual.spoken == want.0, "spoken phrase drifted: \(actual.spoken) vs \(want.0)")
+      #expect(actual.result == want.1, "result copy drifted for \(actual.spoken)")
+    }
+  }
+
+  /// The panel is keyed by `spoken` through `Identifiable`, so a duplicate would silently
+  /// collapse a row in the `ForEach` and hide a phrase from users.
+  @Test("Spoken phrases are unique so no row is dropped from the panel")
+  func spokenPhrasesAreUnique() {
+    let spoken = SpokenPunctuationCopy.phrases.map(\.spoken)
+    #expect(Set(spoken).count == spoken.count, "duplicate spoken phrase would collapse a panel row")
+  }
+
+  /// Brand rule: no em-dashes or en-dashes in user-facing copy.
+  @Test("User-facing strings carry no em-dash or en-dash")
+  func noDashes() {
+    let strings =
+      [
+        SpokenPunctuationCopy.toggleLabel,
+        SpokenPunctuationCopy.toggleDescription,
+        SpokenPunctuationCopy.helpButtonAccessibilityLabel,
+        SpokenPunctuationCopy.helpTitle,
+        SpokenPunctuationCopy.helpSayColumn,
+        SpokenPunctuationCopy.helpGetColumn,
+        SpokenPunctuationCopy.helpFootnote,
+      ] + SpokenPunctuationCopy.phrases.flatMap { [$0.spoken, $0.result] }
+    for s in strings {
+      #expect(s.contains("\u{2014}") == false, "em-dash in user-facing copy: \(s)")
+      #expect(s.contains("\u{2013}") == false, "en-dash in user-facing copy: \(s)")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -59,7 +59,7 @@ struct WhatsNewContentTests {
     // untouched by #1493; asserting the real sequence is the falsifiable version.
     #expect(
       WhatsNewContent.versions == [
-        "2.4.1", "2.4.0",
+        "2.4.2", "2.4.1", "2.4.0",
         "2.3.2", "2.3.1", "2.3.0",
         "2.2.1", "2.2.0",
         "2.1.4", "2.1.3", "2.1.2", "2.1.1", "2.1.0",


### PR DESCRIPTION
Closes #1794

## What and why

Nine spoken-punctuation rewrites ("comma" becomes ",") have been live and always-on for every English user since 2026-06-02, shipped as a rider inside the always-on ITN formatter (#145 / PR #951). #1367 measured them, shelved its replacement, and deliberately left these rules in place. Founder direction 2026-07-25: make them a toggle, off for everyone, with copy warning that they compete with punctuation the app already adds.

## The evidence, reproduced live on this build

Same sentence, same audio, both switch positions. Per-step trace from `app.log`:

**OFF (the shipped default)**

```
Transcription: "The grace period expires in 30 days, and the invoice is $85."
```

"period" survives as a word; `30` and `$85` still convert. One sentence proving the gate suppressed the punctuation rule and did not touch number or currency formatting.

**ON**

```
[Inverse Text Normalization] IN:  The grace period expires in thirty days and the invoice is $85.
[Inverse Text Normalization] OUT: The grace. Expires in 30 days and the invoice is $85.
[LLM Polish]                 OUT: The grace expires in 30 days, and the invoice is $85.
```

The user said "the grace period expires" and gets "the grace expires". The formatter turns the word into a full stop, capitalization then fires on the mark it just inserted, and polish tidies the stray full stop away, which hides the damage rather than fixing it. Nothing in the output hints anything went wrong. This is #1367's finding end to end, and it is the argument for the default.

## Scope

Gates ONLY the nine bare command rewrites. Untouched and still always-on: numbers, currency, dates, times, phone, email, URL, ordinals, ranges, and the sentence-capitalization pass that lives inside the same function (it keys off `.!?` whoever produced them, including the recognizer's own marks).

Wired exactly like its three Cleanup siblings: setting, both engine drivers, settings-change telemetry (which carries it into the launch snapshot for free via `Logical.allCases`), and the crash-recovery snapshot.

Deliberately NOT in scope, per founder ruling: upgrade notice, new per-dictation telemetry, help article, and any characterization of how the nine rules misfire. Those rules are known-bad and headed for #1364; this change puts a switch on them, it does not improve them.

## Three decisions worth review

**Recovery snapshot field is `Bool?` with a NON-defaulted init parameter.** Optional so spools written by shipped versions still decode (synthesized `Codable`, no custom decoder; a non-optional field would fail the whole settings decode and `RecoverySpoolStore` swallows that with `try?`, silently dropping engine/language/polish replay fidelity too). Non-defaulted parameter because it is the only compile-time force on the one caller. `nil` resolves to `false`: a legacy spool records no preference, absence is not an opt-in, and the founder-directed default governs. It does NOT rest on any claim about whether the take was delivered.

**A package-visible `Bool` façade on `KernelDictationDriver`, not a step accessor.** Its three siblings expose their step objects, which works only because those step types are public. `InverseTextNormalizationStep` is internal, and widening it across a module boundary to pass one flag would violate minimize-visibility.

**Mid-recording toggling is live-mutable, matching its siblings.** Grounded review proposed freezing it into `DictationSessionConfig`. Rejected: `wordCorrectionEnabled`, `fillerRemovalEnabled` and `emojiFormatterEnabled` are all live-mutable AND all frozen into the recovery snapshot today, so the live-vs-recovery mismatch is pre-existing and shared. Fixing it for one toggle alone would make punctuation the odd one out. Documented on `DictationSessionConfig` as a four-toggle class to fix together or not at all.

## Testing

- Full suite green: **3,873 tests in 385 suites**, plus 179 in 18 suites.
- New `SpokenPunctuationToggleTests` (9 tests, 30 cases). The load-bearing one runs the entire 2,064-row parity corpus in both positions and pins exactly which rows the toggle changes: punctuation rows plus three `url` rows whose degenerate spelled-out input (`h t t p colon slash slash ...`) hits the `colon` rule. Anything else diverging means the gate leaked. Also asserts non-vacuity.
- New `SpokenPunctuationCopyTests` freezes all ten help-panel pairs verbatim; the panel mirrors the regex table by hand, so this is the drift guard.
- All eight parity call sites now pass `spokenPunctuation: true` to keep pinning the Python oracle.
- Xcode Release build clean. Codex diff review: no actionable defects.

## Note for whoever cuts the release

What's New content, `currentContentVersion`, and the frozen version list in `WhatsNewContentTests` all say **2.4.2**. If the release lands on a different number, all three change together; the tests fail loudly if they disagree.
