### PR TITLE
feat(pipeline): drop a word repeated across the insertion seam

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -376,7 +376,16 @@ struct KernelFinalizationWiring {
         let payloads = CursorInsertionRepair.repair(
           text: text,
           context: caretContext.map {
-            CursorInsertionRepair.CaretText(left: $0.leftWindow, right: $0.rightWindow)
+            CursorInsertionRepair.CaretText(
+              left: $0.leftWindow, right: $0.rightWindow,
+              // The left window is cut to `caretContextWindow` units, and the
+              // string cannot say whether it was cut or simply began at the
+              // document's start. `assembleCaretContext` reads from
+              // `max(0, selectionLocation - window)`, so the window reached
+              // offset zero exactly when it is as long as the caret's offset.
+              // Without this the seam de-duplication refused every short field
+              // (#1803, local diff review).
+              leftReachesDocumentStart: $0.leftWindow.utf16.count == $0.selectionLocation)
           },
           protectedWords: context.protectedSpellings,
           // Resolved from positive evidence, NOT read off the result.

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -626,6 +626,12 @@ public enum CursorInsertionRepair {
     while index < text.endIndex, isHorizontalWhitespace(text[index]) {
       index = text.index(after: index)
     }
+    // The ENTIRE separator must be horizontal, not just its first character.
+    // `The \nstore` passes the guard above on the space, and this loop then
+    // stops AT the newline — so without this the token would be deleted across
+    // a line break, which is precisely what the newline refusal exists to
+    // prevent (cloud review, PR #1804).
+    guard index < text.endIndex, !text[index].isNewline else { return nil }
 
     // Never empty the user's dictation. This is the guard the deleted
     // terminal-period rule never had.

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -28,10 +28,19 @@ public enum CursorInsertionRepair {
     public let left: String
     /// Text immediately after the caret. Only its head matters.
     public let right: String
+    /// Whether `left` begins at the very start of the document rather than at a
+    /// bounded-window cut.
+    ///
+    /// The difference is invisible in the string itself and decides whether a
+    /// token touching the window's start is COMPLETE or merely the tail of a
+    /// longer word. Defaults to `false`, which refuses — a caller that does not
+    /// know cannot accidentally authorise a deletion.
+    public let leftReachesDocumentStart: Bool
 
-    public init(left: String, right: String) {
+    public init(left: String, right: String, leftReachesDocumentStart: Bool = false) {
       self.left = left
       self.right = right
+      self.leftReachesDocumentStart = leftReachesDocumentStart
     }
   }
 
@@ -93,6 +102,9 @@ public enum CursorInsertionRepair {
     case lowercasedFirst
     case caseSkipped(CaseSkipReason)
     case caseKept(CaseKeptReason)
+    /// The payload's first word repeated the word immediately left of the caret,
+    /// so ours was dropped. Placement only — see `dropDuplicateSeamToken`.
+    case droppedDuplicateWord
     case droppedTerminalPeriod
     case trailingSpace
     case trailingSpaceSkipped(TrailingSkipReason)
@@ -112,6 +124,7 @@ public enum CursorInsertionRepair {
       case .lowercasedFirst: return "lowercased_first"
       case .caseSkipped(let reason): return "case_skipped:\(reason.rawValue)"
       case .caseKept(let reason): return "case_kept:\(reason.rawValue)"
+      case .droppedDuplicateWord: return "dropped_duplicate_word"
       case .droppedTerminalPeriod: return "dropped_terminal_period"
       case .trailingSpace: return "trailing_space"
       case .trailingSpaceSkipped(let reason): return "trailing_space_skipped:\(reason.rawValue)"
@@ -355,6 +368,35 @@ public enum CursorInsertionRepair {
       rules.append(.caseKept(.other))
     }
 
+    // Rule 2a: drop a word repeated across the left seam.
+    //
+    // Polish never sees the document (#1790 is parked), so it returns a
+    // well-formed sentence whose opening word the user has often already typed:
+    // caret after `I want to go to the`, polish returns `The store is closed
+    // today.`, and the result reads `…to the the store…`. This layer is the one
+    // that can see both sides, so it removes OUR copy. Founder framing, #1803:
+    // "is the word to the left of the cursor the same as the word to the right?
+    // If yes, delete that first word before you paste."
+    //
+    // Placement is seam-only: no lexicon, no part of speech, no judgement about
+    // the sentence. It runs AFTER `applyLeadingCase` deliberately — running it
+    // first would retarget the casing rule onto the SECOND word, so
+    // `the` + `The Review is ready.` would lowercase `Review` (it is in the
+    // lexicon) and ship `the review is ready.` (grounded review r1).
+    //
+    // Guard order matches plan §3: spacing language, alphanumeric anchor, a left
+    // token proven complete, a token-shaped match, and something surviving.
+    if language.usesWordSpacing,
+      let anchor = left.character, anchor.isLetter || anchor.isNumber,
+      let leftToken = completeLeftToken(
+        in: context.left, reachesDocumentStart: context.leftReachesDocumentStart),
+      let deduplicated = dropDuplicateSeamToken(
+        from: out, leftToken: leftToken, documentOwnsSeparator: left.crossedSpace)
+    {
+      out = deduplicated
+      rules.append(.droppedDuplicateWord)
+    }
+
     // Rule 2b: never leave TWO full stops touching.
     //
     // SCOPE CORRECTED by the founder, 2026-07-26: "polish takes care of the
@@ -453,6 +495,144 @@ public enum CursorInsertionRepair {
 
     let lowered = String(firstCharacter).lowercased()
     return (String(leadingWhitespace) + lowered + String(stripped.dropFirst()), .lowercasedFirst)
+  }
+
+  // MARK: - Seam de-duplication (#1803)
+
+  /// Whitespace that is NOT a line break.
+  ///
+  /// Swift counts `\n` as whitespace, and both the casing rule and the anchor
+  /// walk use the bare `isWhitespace`. An unqualified "whitespace" contract here
+  /// would let `the` + `The\nstore` delete the word AND the newline, welding two
+  /// lines together — so every whitespace decision in this rule is horizontal.
+  static func isHorizontalWhitespace(_ character: Character) -> Bool {
+    character.isWhitespace && !character.isNewline
+  }
+
+  /// A token with its edge connectors removed, or `nil` when nothing well-formed
+  /// survives.
+  ///
+  /// `wordConnectors` may only sit INSIDE a token: `can't` and
+  /// `state-of-the-art` are one token each, while the trailing apostrophe of
+  /// `the Joneses'` and the bullet in `- item` are not part of one.
+  static func normalizedToken(_ raw: String) -> String? {
+    var characters = Array(raw)
+    while let first = characters.first, wordConnectors.contains(first) {
+      characters.removeFirst()
+    }
+    while let last = characters.last, wordConnectors.contains(last) {
+      characters.removeLast()
+    }
+    guard let first = characters.first, let last = characters.last,
+      first.isLetter || first.isNumber, last.isLetter || last.isNumber
+    else { return nil }
+    return String(characters)
+  }
+
+  /// Two tokens are the same word, ignoring case and apostrophe shape.
+  ///
+  /// Case-insensitive because the duplicate IS a capitalisation mismatch, and
+  /// apostrophe-folded because cloud polish emits `U+2019` while a typed
+  /// document holds `U+0027`.
+  static func tokensMatch(_ lhs: String, _ rhs: String) -> Bool {
+    OrdinaryLowercaseLexicon.normalizeApostrophes(lhs).lowercased()
+      == OrdinaryLowercaseLexicon.normalizeApostrophes(rhs).lowercased()
+  }
+
+  /// The complete token immediately left of the caret, or `nil`.
+  ///
+  /// Returns `nil` when completeness cannot be PROVEN. The left window is
+  /// bounded (20 UTF-16 units), so a backward scan that consumes the whole
+  /// window may be holding the tail of a longer word — comparing that would
+  /// match a suffix and delete a word on the strength of it.
+  ///
+  /// `reachesDocumentStart` is the one piece of evidence the string itself
+  /// cannot carry: a window that starts at document offset 0 was never cut, so a
+  /// token touching its start IS complete. Everything else fails in the safe
+  /// direction — a missed duplicate, never an invented deletion.
+  static func completeLeftToken(in window: String, reachesDocumentStart: Bool) -> String? {
+    var cursor = window.endIndex
+    // Reach the anchor. A newline is a boundary, not a separator to cross.
+    while cursor > window.startIndex {
+      let previous = window.index(before: cursor)
+      let character = window[previous]
+      if character.isNewline { return nil }
+      guard isHorizontalWhitespace(character) else { break }
+      cursor = previous
+    }
+    let end = cursor
+    guard end > window.startIndex else { return nil }
+
+    var start = end
+    while start > window.startIndex {
+      let previous = window.index(before: start)
+      let character = window[previous]
+      guard character.isLetter || character.isNumber || wordConnectors.contains(character)
+      else { break }
+      start = previous
+    }
+    // The scan ran out of window instead of meeting a boundary. That is only
+    // ambiguous when the window was CUT: a window that begins at the document's
+    // own start has no hidden prefix, so the token is complete. Without this the
+    // rule refused every short field — document `the ` plus payload
+    // `The store...` is a common Slack or search-box case (local diff review).
+    guard start > window.startIndex || reachesDocumentStart else { return nil }
+    return normalizedToken(String(window[start..<end]))
+  }
+
+  /// Remove the payload's leading token when it duplicates `leftToken`.
+  ///
+  /// Returns `nil` — meaning refuse — unless the payload opens with exactly one
+  /// complete token followed by a non-empty run of horizontal whitespace. A
+  /// payload opening with a quote or bracket, or whose token is followed by
+  /// punctuation rather than a space, is left alone rather than deleted with
+  /// dangling punctuation left behind.
+  ///
+  /// `documentOwnsSeparator` settles which side supplies the seam space. Rule 1
+  /// declines to add one when the payload already begins with whitespace, so
+  /// with `crossedSpace` true AND a polish payload carrying its own leading
+  /// space, both sides supply one and keeping both emits a double space
+  /// (grounded review r2). Exactly one side wins, never both.
+  static func dropDuplicateSeamToken(
+    from text: String,
+    leftToken: String,
+    documentOwnsSeparator: Bool
+  ) -> String? {
+    var index = text.startIndex
+    while index < text.endIndex, isHorizontalWhitespace(text[index]) {
+      index = text.index(after: index)
+    }
+    let leadingWhitespace = text[text.startIndex..<index]
+    // A payload that starts on its own line is not continuing this one.
+    guard index < text.endIndex, !text[index].isNewline else { return nil }
+
+    let tokenStart = index
+    while index < text.endIndex,
+      text[index].isLetter || text[index].isNumber || wordConnectors.contains(text[index])
+    {
+      index = text.index(after: index)
+    }
+    let rawToken = String(text[tokenStart..<index])
+    guard let token = normalizedToken(rawToken), token.count == rawToken.count else {
+      // A trimmed edge connector means the payload opened with punctuation that
+      // deletion would strand. Refuse rather than guess.
+      return nil
+    }
+    guard tokensMatch(token, leftToken) else { return nil }
+
+    // The token must be followed by a real separator, so `The` alone and
+    // `The, store` both refuse.
+    guard index < text.endIndex, isHorizontalWhitespace(text[index]) else { return nil }
+    while index < text.endIndex, isHorizontalWhitespace(text[index]) {
+      index = text.index(after: index)
+    }
+
+    // Never empty the user's dictation. This is the guard the deleted
+    // terminal-period rule never had.
+    let remainder = text[index...]
+    guard remainder.contains(where: { $0.isLetter || $0.isNumber }) else { return nil }
+
+    return (documentOwnsSeparator ? "" : String(leadingWhitespace)) + String(remainder)
   }
 
   /// Whether the caret sits between two word characters.

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -796,7 +796,8 @@ import Testing
     // lowercase word AND a German noun — the collision the language gate exists
     // for.
     let processed = try await wiring.processText(
-      "Start ist heute Abend und danach gehen wir in die Stadt") {}
+      "Start ist heute Abend und danach gehen wir in die Stadt"
+    ) {}
     _ = await wiring.deliver(processed)
 
     let request = try #require(captured.requests.first)
@@ -804,6 +805,102 @@ import Testing
     #expect(
       delivered.hasPrefix("Start"),
       "a German noun must keep its capital even though the engine reported English")
+  }
+
+  // Seam de-duplication, checked through the REAL delivery composition (#1803).
+  //
+  // The unit table in `CursorInsertionRepairTests` proves the rule's logic with
+  // hand-built arguments. It cannot prove the rule is wired to the right INPUT,
+  // and that is exactly the class that escaped #1785's eight local rounds, four
+  // apps of live UAT and 4,000 tests: a language gate reading a hard-coded "en",
+  // caught only by cloud review. These drive the actual `deliver` closure.
+  @Test("a word repeated across the seam is delivered once")
+  func duplicateSeamWordIsDroppedThroughTheRealComposition() async throws {
+    let captured = DeliveryRequestBox()
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+    context.targetElement = Self.stubCaretElement()
+    let wiring = makeWiring(
+      context: context,
+      deliverPaste: { request in
+        captured.requests.append(request)
+        return Self.deliveredResult
+      },
+      readCaretContext: { _ in
+        PasteService.CaretContext(
+          leftWindow: "I want to go to the ", rightWindow: "", selectionLocation: 20,
+          selectionLength: 0)
+      },
+      adapter: Self.transcribedEngine(language: "en"))
+
+    let processed = try await wiring.processText(
+      "The store is closed today and I will go tomorrow instead"
+    ) {}
+    _ = await wiring.deliver(processed)
+
+    let request = try #require(captured.requests.first)
+    let repaired = try #require(request.repairedText)
+    #expect(
+      repaired.hasPrefix("store"),
+      "the duplicated determiner must be gone, leaving: \(repaired)")
+    #expect(!repaired.lowercased().hasPrefix("the "))
+  }
+
+  @Test("a locked unsegmented language refuses the drop even with a space in the text")
+  func lockedJapaneseRefusesTheDrop() async throws {
+    // Proves the rule reads the RESOLVED language rather than the presence of a
+    // space. An English reading of this text would find a word boundary and a
+    // matching leading token.
+    let captured = DeliveryRequestBox()
+    let context = KernelSessionContext()
+    context.config = .testDefault(
+      autoPasteToActiveApp: true, smartInsertion: true, languageMode: .locked("ja"))
+    context.targetElement = Self.stubCaretElement()
+    let wiring = makeWiring(
+      context: context,
+      deliverPaste: { request in
+        captured.requests.append(request)
+        return Self.deliveredResult
+      },
+      readCaretContext: { _ in
+        PasteService.CaretContext(
+          leftWindow: "\u{4ECA}\u{65E5}", rightWindow: "", selectionLocation: 2,
+          selectionLength: 0)
+      },
+      adapter: Self.transcribedEngine(language: "ja"))
+
+    let processed = try await wiring.processText("\u{4ECA}\u{65E5} \u{6674}\u{308C}") {}
+    _ = await wiring.deliver(processed)
+
+    let request = try #require(captured.requests.first)
+    let delivered = request.repairedText ?? request.legacyText
+    #expect(
+      delivered.hasPrefix("\u{4ECA}\u{65E5}"),
+      "an unsegmented script has no word to de-duplicate: \(delivered)")
+  }
+
+  @Test("an unreadable caret yields no candidate, so today's payload is delivered")
+  func unreadableCaretDeliversLegacyPayload() async throws {
+    let captured = DeliveryRequestBox()
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+    context.targetElement = Self.stubCaretElement()
+    let wiring = makeWiring(
+      context: context,
+      deliverPaste: { request in
+        captured.requests.append(request)
+        return Self.deliveredResult
+      },
+      readCaretContext: { _ in nil })
+
+    let processed = try await wiring.processText(
+      "The store is closed today and I will go tomorrow instead"
+    ) {}
+    _ = await wiring.deliver(processed)
+
+    let request = try #require(captured.requests.first)
+    #expect(request.repairedText == nil)
+    #expect(request.legacyText.hasPrefix("The store"))
   }
 
   @Test("English text on the same engine is still recased")
@@ -823,7 +920,8 @@ import Testing
       adapter: Self.transcribedEngine(language: "en"))
 
     let processed = try await wiring.processText(
-      "Review this before the meeting and then send it along") {}
+      "Review this before the meeting and then send it along"
+    ) {}
     _ = await wiring.deliver(processed)
 
     let request = try #require(captured.requests.first)

--- a/Tests/EnviousWisprTests/Pipeline/PasteExecutionMetricsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteExecutionMetricsTests.swift
@@ -65,7 +65,7 @@ struct PasteExecutionMetricsTests {
     // The whole set, so a rule added later without a name cannot slip through.
     let every: [CursorInsertionRepair.AppliedRule] = [
       .refusedInsideWord, .refusedNoLeftAnchor, .leadingSpace, .lowercasedFirst,
-      .droppedTerminalPeriod, .trailingSpace,
+      .droppedDuplicateWord, .droppedTerminalPeriod, .trailingSpace,
       .caseSkipped(.alreadyLower), .caseSkipped(.protectedWord),
       .caseSkipped(.mixedCaseOrAcronym), .caseSkipped(.containsDigit),
       .caseSkipped(.pronounI), .caseSkipped(.alwaysCapitalized),

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
@@ -1373,4 +1373,174 @@ struct CursorInsertionRepairTests {
       #expect(payloads.repairedText == nil, "\(language ?? "nil")")
     }
   }
+
+  // MARK: - Seam de-duplication (#1803)
+
+  /// One helper so every de-duplication case reads as document + dictation.
+  private static func seam(
+    left: String, right: String = "", payload: String, language: String? = "en",
+    protectedWords: Set<String> = []
+  ) -> CursorInsertionRepair.PreparedPayloads {
+    CursorInsertionRepair.repair(
+      text: payload,
+      context: CursorInsertionRepair.CaretText(left: left, right: right),
+      protectedWords: protectedWords, language: language, lexicon: Self.prototypeLexicon)
+  }
+
+  @Test("The founder's reported case emits one word, not two")
+  func founderCaseDropsTheDuplicate() {
+    let payloads = Self.seam(left: "I want to go to the", payload: "The store is closed today.")
+    #expect(payloads.candidateRules.contains(.droppedDuplicateWord))
+    #expect(
+      "I want to go to the" + (payloads.repairedText ?? "")
+        == "I want to go to the store is closed today. ")
+  }
+
+  @Test("Both the casing decision and the drop are reported, in order")
+  func recordsCasingAndDropTogether() {
+    let payloads = Self.seam(left: "I want to go to the", payload: "The store is closed today.")
+    let names = payloads.candidateRules.map(\.telemetryName)
+    #expect(names.contains("lowercased_first"))
+    #expect(names.contains("dropped_duplicate_word"))
+    // AppliedRule records decisions TAKEN, not only effects visible in the final
+    // payload, so the casing result is not suppressed by the later deletion.
+    #expect(
+      names.firstIndex(of: "lowercased_first")! < names.firstIndex(of: "dropped_duplicate_word")!)
+  }
+
+  /// The r1 defect, frozen. Dropping BEFORE the casing rule would retarget
+  /// casing onto the second word: `Store` is in the lexicon, so the payload
+  /// would have shipped as `store` and a title or name would be corrupted.
+  @Test("Dropping the duplicate does not retarget the casing rule onto the next word")
+  func dropDoesNotRetargetCasing() {
+    let payloads = Self.seam(left: "Send me the", payload: "The Store is ready.")
+    #expect(payloads.candidateRules.contains(.droppedDuplicateWord))
+    #expect(payloads.repairedText == " Store is ready. ")
+  }
+
+  /// The r2 defect, frozen. Exactly one side supplies the seam separator.
+  @Test(
+    "Separator ownership never yields a double or a missing space",
+    arguments: [
+      ("go to the", "The store.", " store. "),
+      ("go to the", " The store.", " store. "),
+      ("go to the ", "The store.", "store. "),
+      ("go to the ", " The store.", "store. "),
+    ])
+  func separatorOwnershipMatrix(left: String, payload: String, expected: String) {
+    let payloads = Self.seam(left: left, payload: payload)
+    #expect(payloads.candidateRules.contains(.droppedDuplicateWord), "\(left)|\(payload)")
+    #expect(payloads.repairedText == expected, "\(left)|\(payload)")
+  }
+
+  @Test("The whole whitespace run after the duplicate goes, not one character")
+  func removesTheWholeWhitespaceRun() {
+    let payloads = Self.seam(left: "go to the", payload: "The   store is ready.")
+    #expect(payloads.repairedText == " store is ready. ")
+  }
+
+  @Test(
+    "A newline on either side of the candidate refuses",
+    arguments: [
+      ("go to the", "\nThe store is ready."),
+      ("go to the", "The\nstore is ready."),
+      ("go to the\n   ", "The store is ready."),
+    ])
+  func newlineRefusesTheDrop(left: String, payload: String) {
+    let payloads = Self.seam(left: left, payload: payload)
+    #expect(!payloads.candidateRules.contains(.droppedDuplicateWord), "\(left)|\(payload)")
+  }
+
+  @Test(
+    "Refusals that protect the user's own text",
+    arguments: [
+      // Nothing may survive an empty payload — the guard the deleted
+      // terminal-period rule never had.
+      ("go to the", "The"),
+      ("go to the", "The."),
+      // Token shape: deleting here would strand punctuation.
+      ("go to the", "\"The store is ready."),
+      ("go to the", "(The store is ready."),
+      ("go to the", "The, store is ready."),
+      // A sentence boundary is not a seam; the repeat is deliberate.
+      ("I went home.", "Home is where it is."),
+      // A comma between the words means the user wrote something on purpose.
+      ("go to the,", "The store is ready."),
+      // Not a duplicate at all.
+      ("go to the", "Store is ready."),
+    ])
+  func refusesWhereIntentIsUnclear(left: String, payload: String) {
+    let payloads = Self.seam(left: left, payload: payload)
+    #expect(!payloads.candidateRules.contains(.droppedDuplicateWord), "\(left)|\(payload)")
+  }
+
+  @Test("A left token that fills a CUT window is unproven, so it refuses")
+  func truncatedLeftTokenRefuses() {
+    // No boundary inside the window and no document-start evidence: what we hold
+    // may be the tail of a longer word, and matching a suffix would delete a word
+    // on false evidence.
+    let payloads = Self.seam(left: "the", payload: "The store is ready.")
+    #expect(!payloads.candidateRules.contains(.droppedDuplicateWord))
+  }
+
+  @Test("The same token IS complete when the window began at the document start")
+  func documentStartMakesTheLeftTokenComplete() {
+    // Byte-identical left window to the test above; only the provenance differs.
+    // A short field — the user typed `the ` and dictates the rest — is a common
+    // Slack and search-box case that refusing here would never fix.
+    let payloads = CursorInsertionRepair.repair(
+      text: "The store is ready.",
+      context: CursorInsertionRepair.CaretText(
+        left: "the ", right: "", leftReachesDocumentStart: true),
+      protectedWords: [], language: "en", lexicon: Self.prototypeLexicon)
+    #expect(payloads.candidateRules.contains(.droppedDuplicateWord))
+    #expect(payloads.repairedText == "store is ready. ")
+  }
+
+  @Test("Document-start evidence defaults to absent, so an unaware caller refuses")
+  func documentStartDefaultsToRefusing() {
+    let payloads = CursorInsertionRepair.repair(
+      text: "The store is ready.",
+      context: CursorInsertionRepair.CaretText(left: "the ", right: ""),
+      protectedWords: [], language: "en", lexicon: Self.prototypeLexicon)
+    #expect(!payloads.candidateRules.contains(.droppedDuplicateWord))
+  }
+
+  @Test("Apostrophe shape does not hide a duplicate")
+  func foldsApostrophesBeforeComparing() {
+    let payloads = Self.seam(left: "I said don\u{2019}t", payload: "Don't worry about it.")
+    #expect(payloads.candidateRules.contains(.droppedDuplicateWord))
+  }
+
+  @Test("A repeated number is a duplicate like any other token")
+  func dropsRepeatedNumber() {
+    let payloads = Self.seam(left: "on page 5", payload: "5 is missing.")
+    #expect(payloads.candidateRules.contains(.droppedDuplicateWord))
+  }
+
+  @Test("A word character to the RIGHT of the caret does not block the rule")
+  func rightSideWordCharacterStillReachesTheRule() {
+    // Premise B, corrected: `isInsideWord` refuses only when BOTH immediate
+    // sides continue a word. Here the immediate left is whitespace, so the
+    // contextual rules run with a word character on the right.
+    let payloads = Self.seam(left: "go to the ", right: "store", payload: "The store is ready.")
+    #expect(payloads.candidateRules.contains(.droppedDuplicateWord))
+  }
+
+  @Test("An unsegmented script has no word to de-duplicate")
+  func unsegmentedScriptRefuses() {
+    let payloads = Self.seam(
+      left: "\u{4ECA}\u{65E5}\u{306F}", payload: "\u{4ECA}\u{65E5} \u{6674}\u{308C}",
+      language: "ja")
+    #expect(!payloads.candidateRules.contains(.droppedDuplicateWord))
+  }
+
+  @Test("Another spacing language de-duplicates the same way English does")
+  func spacingLanguageDropsDuplicate() {
+    // German: spacing is universal, casing is not. The drop is placement only,
+    // so it fires while the capital is left alone.
+    let payloads = Self.seam(left: "Ich gehe zum", payload: "Zum Bahnhof.", language: "de")
+    #expect(payloads.candidateRules.contains(.droppedDuplicateWord))
+    #expect(payloads.repairedText == " Bahnhof. ")
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
@@ -1445,6 +1445,12 @@ struct CursorInsertionRepairTests {
       ("go to the", "\nThe store is ready."),
       ("go to the", "The\nstore is ready."),
       ("go to the\n   ", "The store is ready."),
+      // Cloud review, PR #1804: the separator's FIRST character is horizontal
+      // and the run then ends at a newline. Checking only the first character
+      // deleted the token across a line break.
+      ("go to the", "The \nstore is ready."),
+      ("go to the", "The\t\nstore is ready."),
+      ("go to the", "The  \n  store is ready."),
     ])
   func newlineRefusesTheDrop(left: String, payload: String) {
     let payloads = Self.seam(left: left, payload: payload)


### PR DESCRIPTION
Part 3 of #1803. Parts 1 (terminal / app coverage) and 2 (German capitalisation) are separate PRs; their gating measurements are already posted on the issue.

## What you get

Cursor at the end of `I want to go to the`, you dictate "the store is closed today", and you get:

```
I want to go to the store is closed today.
```

instead of `I want to go to the the store is closed today.`

The duplicate comes from polish, which never sees your document, so it returns a well-formed sentence starting with a word you already typed. The existing repair made it *more* visible, not less: `the` is in the shipped lexicon, so the casing rule lowercased `The` and the two identical words ended up side by side.

## Verified live, both delivery routes

| App | Route | Destination field after dictating |
|---|---|---|
| TextEdit | `tier=ax_direct` | `I want to go to the store is closed today. ` |
| Chrome | `tier=cgevent` (clipboard) | `I want to go to the store is closed today. ` |

Each run carries three receipts: the pre-delivery text still began with the duplicate (raw ASR `The store is closed today.`, polish no change), a fresh accessibility read of the destination shows exactly one `the`, and the log names the route that actually committed. The clipboard is never the oracle.

## Four defects, each caught by a review layer rather than by me

1. **Ordering.** I placed the rule before the casing rule. That RETARGETS casing onto the second word: `the` + `The Review is ready.` would lowercase `Review` (it is in the lexicon) and ship `the review is ready.`, corrupting a title. Now runs after casing; frozen as a regression test.
2. **Separator ownership.** Rule 1 declines to add a space when the payload already begins with one, so a document ending in whitespace plus a polish payload carrying its own leading space would emit a double space. `crossedSpace` decides which side owns the seam; four-cell matrix frozen.
3. **Newlines.** Swift counts `\n` as whitespace, so an unqualified contract would let `the` + `The\nstore` delete the word AND the newline, welding two lines together. Horizontal whitespace only; a newline refuses.
4. **Short fields.** The completeness guard refused whenever the backward scan hit the window start — but a window beginning at document offset 0 was never cut, so the token IS complete. This silently skipped every short field (a Slack box or search field containing just `the `). `CaretText` now carries that provenance, defaulting to refuse.

Nothing can empty the payload, which is the guard the deleted terminal-period rule never had.

## Two decisions worth your eye, both recorded rather than taken quietly

Plan §14 has the full reasoning.

1. **Review argued deletion should require proof that polish INTRODUCED the word.** I rejected it as the sole gate: if you spoke "the store is closed today" and polish only capitalised it, that gate refuses and leaves the exact bug you filed. Cost of my choice: eight reproducible classes lose a word (`that that`, `had had`, `Bora Bora`, repeated codes, `March march`, Hindi reduplication). All are visible and instantly recoverable; the bug they replace is visible every time.
2. **Review argued this deserves its own control, default off.** I kept it inside Smart Insertion, which is **default ON**, so it ships enabled to everyone. This is the weaker of my two rejections and you may want to overrule it; a nested toggle is a small change.

## Tests

- 73 in `CursorInsertionRepairTests` (frozen tables: separator matrix, newline refusals, token-shape refusals, ordering regression, document-start provenance).
- 45 in `KernelFinalizationWiringTests` — caller-level composition, driving the real delivery closure. This is the class that escaped #1785's eight local rounds, four apps of live UAT and 4,000 tests, and was caught only by cloud review.
- Full suite 4074 tests. **One failure, pre-existing on main**: `ContactsImportCorrectorBenchmark` latency, 3132ms here against a 1500ms bar. Reproduced on unmodified main at 2836ms, so it is load-bound and not this change. Reported separately rather than fixed here.

Reviewed: 1 coverage round, 5 grounded rounds to PROCEED-AS-PLANNED, 2 local diff reviews to clean.

Part of #1803
