### PR TITLE
feat(pipeline): cursor-aware insertion in the terminal

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -386,10 +386,9 @@ struct KernelFinalizationWiring {
               // Without this the seam de-duplication refused every short field
               // (#1803, local diff review).
               leftReachesDocumentStart: $0.leftWindow.utf16.count == $0.selectionLocation,
-              // A terminal screen tells us roughly what precedes the cursor and
-              // cannot tell us WHERE the cursor is inside the line, so it may
-              // only authorise spacing (#1803 part 1).
-              repairScope: $0.isScreenDerived ? .spacingOnly : .full)
+              // A terminal screen tells us what precedes the cursor, which is
+              // everything the seam rules need (#1803 part 1).
+              repairScope: $0.isScreenDerived ? .terminalScreen : .full)
           },
           protectedWords: context.protectedSpellings,
           // Resolved from positive evidence, NOT read off the result.

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -385,7 +385,11 @@ struct KernelFinalizationWiring {
               // offset zero exactly when it is as long as the caret's offset.
               // Without this the seam de-duplication refused every short field
               // (#1803, local diff review).
-              leftReachesDocumentStart: $0.leftWindow.utf16.count == $0.selectionLocation)
+              leftReachesDocumentStart: $0.leftWindow.utf16.count == $0.selectionLocation,
+              // A terminal screen tells us roughly what precedes the cursor and
+              // cannot tell us WHERE the cursor is inside the line, so it may
+              // only authorise spacing (#1803 part 1).
+              repairScope: $0.isScreenDerived ? .spacingOnly : .full)
           },
           protectedWords: context.protectedSpellings,
           // Resolved from positive evidence, NOT read off the result.
@@ -417,7 +421,8 @@ struct KernelFinalizationWiring {
         outcome.caretContextOutcome = {
           if config?.smartInsertion != true { return "setting_off" }
           if context.targetElement == nil { return "no_target" }
-          return caretContext == nil ? "unreadable" : "read"
+          if caretContext == nil { return "unreadable" }
+          return caretContext?.isScreenDerived == true ? "read_screen" : "read"
         }()
         outcome.repairRules =
           payloads.candidateRules.isEmpty

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -33,10 +33,14 @@ public enum CursorInsertionRepair {
   public enum RepairScope: Equatable, Sendable {
     /// Everything applies. Today's behaviour for a real caret.
     case full
-    /// Screen-derived evidence. The repair may ADD ASCII spaces at the two
-    /// seams and may not remove, replace, recase or otherwise change any
-    /// non-whitespace character of the dictation.
-    case spacingOnly
+    /// Read from a terminal's SCREEN rather than from a real caret.
+    ///
+    /// Named for the source rather than for a policy, because the policy has
+    /// moved twice and the source has not. Everything applies here except two
+    /// things, both of which act on text we cannot see: the touching-full-stops
+    /// rule (which needs a right-hand window a screen read never has), and any
+    /// payload containing a line break, which refuses outright.
+    case terminalScreen
   }
 
   public struct CaretText: Equatable, Sendable {
@@ -78,10 +82,6 @@ public enum CursorInsertionRepair {
     case alwaysCapitalized = "always_capitalized"
     case notKnownLowercase = "not_known_lowercase"
     case lexiconUnavailable = "lexicon_unavailable"
-    /// The context came from reading a terminal's screen, which cannot say
-    /// where the cursor is inside the line. Casing could produce a wrong
-    /// capital on evidence that may describe a different position.
-    case screenDerivedContext = "screen_derived_context"
     /// The dictation is not in a language whose casing rules we know. The
     /// lexicon is English, and applying it to another language is not merely
     /// useless — it is actively wrong. `See`, `Start`, `Test`, `Team` and
@@ -286,7 +286,7 @@ public enum CursorInsertionRepair {
     // a spacing artifact placed before it changes the command that runs
     // (`rm -rf /tmp/safe|file` + "backup\n" splits one path into two arguments
     // and then runs it). Bracketed paste cannot be assumed. Refuse outright.
-    if context.repairScope == .spacingOnly,
+    if context.repairScope == .terminalScreen,
       text.unicodeScalars.contains(where: { CharacterSet.newlines.contains($0) })
     {
       return PreparedPayloads(
@@ -390,11 +390,7 @@ public enum CursorInsertionRepair {
         !left.atLineStart && (anchor.isLetter || anchor.isNumber || continuers.contains(anchor))
       } ?? false
 
-    if context.repairScope == .spacingOnly {
-      // Screen evidence cannot say where in the line the cursor is, so the word
-      // we would be recasing may not be the word at the seam.
-      rules.append(.caseSkipped(.screenDerivedContext))
-    } else if continuing, !language.knowsCasing {
+    if continuing, !language.knowsCasing {
       // Positioned to lowercase, but not in a language whose casing we know.
       // Recorded as a skip rather than silently omitted so the field can tell
       // "we chose not to" from "the position did not call for it".
@@ -434,8 +430,7 @@ public enum CursorInsertionRepair {
     //
     // Guard order matches plan §3: spacing language, alphanumeric anchor, a left
     // token proven complete, a token-shaped match, and something surviving.
-    if context.repairScope == .full,
-      language.usesWordSpacing,
+    if language.usesWordSpacing,
       let anchor = left.character, anchor.isLetter || anchor.isNumber,
       let leftToken = completeLeftToken(
         in: context.left, reachesDocumentStart: context.leftReachesDocumentStart),

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -23,6 +23,22 @@ public enum CursorInsertionRepair {
   /// nearest real character on each side. One character is NOT enough — `"home. "`
   /// and `"home, "` both present a space and demand opposite outcomes — so the
   /// left side is walked back over spaces and tabs to the last real character.
+  /// How far the repair may go, given how trustworthy the evidence is.
+  ///
+  /// This is EVIDENCE TRUST, not language knowledge, which is why it lives on
+  /// the context rather than on `LanguageRules`: a terminal screen read tells us
+  /// roughly what precedes the cursor and cannot tell us exactly where the
+  /// cursor is, and that is a different question from what a language's rules
+  /// are (grounded review r2, #1803).
+  public enum RepairScope: Equatable, Sendable {
+    /// Everything applies. Today's behaviour for a real caret.
+    case full
+    /// Screen-derived evidence. The repair may ADD ASCII spaces at the two
+    /// seams and may not remove, replace, recase or otherwise change any
+    /// non-whitespace character of the dictation.
+    case spacingOnly
+  }
+
   public struct CaretText: Equatable, Sendable {
     /// Text immediately before the caret. Only its tail matters.
     public let left: String
@@ -36,11 +52,17 @@ public enum CursorInsertionRepair {
     /// longer word. Defaults to `false`, which refuses — a caller that does not
     /// know cannot accidentally authorise a deletion.
     public let leftReachesDocumentStart: Bool
+    /// How much of the repair this evidence is trusted to authorise.
+    public let repairScope: RepairScope
 
-    public init(left: String, right: String, leftReachesDocumentStart: Bool = false) {
+    public init(
+      left: String, right: String, leftReachesDocumentStart: Bool = false,
+      repairScope: RepairScope = .full
+    ) {
       self.left = left
       self.right = right
       self.leftReachesDocumentStart = leftReachesDocumentStart
+      self.repairScope = repairScope
     }
   }
 
@@ -56,6 +78,10 @@ public enum CursorInsertionRepair {
     case alwaysCapitalized = "always_capitalized"
     case notKnownLowercase = "not_known_lowercase"
     case lexiconUnavailable = "lexicon_unavailable"
+    /// The context came from reading a terminal's screen, which cannot say
+    /// where the cursor is inside the line. Casing could produce a wrong
+    /// capital on evidence that may describe a different position.
+    case screenDerivedContext = "screen_derived_context"
     /// The dictation is not in a language whose casing rules we know. The
     /// lexicon is English, and applying it to another language is not merely
     /// useless — it is actively wrong. `See`, `Start`, `Test`, `Team` and
@@ -98,6 +124,10 @@ public enum CursorInsertionRepair {
     /// `refusedInsideWord`: that one knows exactly where it is and declines,
     /// this one cannot place itself.
     case refusedNoLeftAnchor
+    /// Screen-derived evidence plus a payload containing a line break. In a
+    /// shell a pasted newline can EXECUTE the line, so a spacing artifact placed
+    /// before it can change the command that runs. Refused outright.
+    case refusedScreenDerivedLineBreak
     case leadingSpace
     case lowercasedFirst
     case caseSkipped(CaseSkipReason)
@@ -120,6 +150,7 @@ public enum CursorInsertionRepair {
       switch self {
       case .refusedInsideWord: return "refused:inside_word"
       case .refusedNoLeftAnchor: return "refused:no_left_anchor"
+      case .refusedScreenDerivedLineBreak: return "refused:screen_derived_line_break"
       case .leadingSpace: return "leading_space"
       case .lowercasedFirst: return "lowercased_first"
       case .caseSkipped(let reason): return "case_skipped:\(reason.rawValue)"
@@ -249,6 +280,19 @@ public enum CursorInsertionRepair {
     guard let context else {
       return PreparedPayloads(legacyText: legacy, repairedText: nil, candidateRules: [])
     }
+    // Screen-derived evidence plus a line break is the one combination that is
+    // not merely cosmetic. `InverseTextNormalizer` deliberately turns a spoken
+    // "new line" into a real newline, and a shell EXECUTES a pasted newline — so
+    // a spacing artifact placed before it changes the command that runs
+    // (`rm -rf /tmp/safe|file` + "backup\n" splits one path into two arguments
+    // and then runs it). Bracketed paste cannot be assumed. Refuse outright.
+    if context.repairScope == .spacingOnly,
+      text.unicodeScalars.contains(where: { CharacterSet.newlines.contains($0) })
+    {
+      return PreparedPayloads(
+        legacyText: legacy, repairedText: nil,
+        candidateRules: [.refusedScreenDerivedLineBreak])
+    }
     let rules = LanguageRules.forLanguage(language)
     // Inserting between two word characters cannot be repaired safely. The
     // spacing rules would wrap the payload in spaces and split the surrounding
@@ -346,7 +390,11 @@ public enum CursorInsertionRepair {
         !left.atLineStart && (anchor.isLetter || anchor.isNumber || continuers.contains(anchor))
       } ?? false
 
-    if continuing, !language.knowsCasing {
+    if context.repairScope == .spacingOnly {
+      // Screen evidence cannot say where in the line the cursor is, so the word
+      // we would be recasing may not be the word at the seam.
+      rules.append(.caseSkipped(.screenDerivedContext))
+    } else if continuing, !language.knowsCasing {
       // Positioned to lowercase, but not in a language whose casing we know.
       // Recorded as a skip rather than silently omitted so the field can tell
       // "we chose not to" from "the position did not call for it".
@@ -386,7 +434,8 @@ public enum CursorInsertionRepair {
     //
     // Guard order matches plan §3: spacing language, alphanumeric anchor, a left
     // token proven complete, a token-shaped match, and something surviving.
-    if language.usesWordSpacing,
+    if context.repairScope == .full,
+      language.usesWordSpacing,
       let anchor = left.character, anchor.isLetter || anchor.isNumber,
       let leftToken = completeLeftToken(
         in: context.left, reachesDocumentStart: context.leftReachesDocumentStart),
@@ -416,7 +465,12 @@ public enum CursorInsertionRepair {
     // very next character is another one, the pair is a placement artifact we
     // would be creating, so we drop ours. No word knowledge, no lexicon, no
     // language, no abbreviation question.
-    if out.reversed().drop(while: \.isWhitespace).first == ".",
+    // Gated on `.full` even though a screen-derived right window is always
+    // empty today, so this is inert: it DELETES a dictated period, and leaving a
+    // deletion rule enabled contradicts the spacing-only invariant the moment
+    // that empty-right assumption drifts (grounded review r2).
+    if context.repairScope == .full,
+      out.reversed().drop(while: \.isWhitespace).first == ".",
       rightAnchor(of: context.right) == "."
     {
       let body = String(out.reversed().drop(while: \.isWhitespace).reversed())

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -682,8 +682,22 @@ public enum PasteService {
   /// - a bare shell prompt has no box at all and is the ordinary case
   static func terminalInputLine(inBufferTail tail: String) -> String? {
     let rows = tail.split(separator: "\n", omittingEmptySubsequences: false)
-    let ruleRows = rows.indices.filter { isRuleRow(rows[$0]) }
 
+    // The CURRENT prompt wins over any box still sitting in scrollback.
+    //
+    // A session that used a full-screen UI earlier leaves its rules behind, so
+    // `────\n❯ old input\n────\n❯ current command` would otherwise return the
+    // OLD input and compute the repair from stale text (code review). Checking
+    // the final row first settles it: a live shell prompt is the last thing on
+    // screen, while a live full-screen UI prints its footer hints below the box
+    // and so has no marker on that row.
+    if let last = rows.last(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }),
+      let line = afterStrongMarker(in: last)
+    {
+      return line
+    }
+
+    let ruleRows = rows.indices.filter { isRuleRow(rows[$0]) }
     if ruleRows.count >= 2 {
       let body = rows[(ruleRows[ruleRows.count - 2] + 1)..<ruleRows[ruleRows.count - 1]]
       let populated = body.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
@@ -693,35 +707,30 @@ public enum PasteService {
       return line
     }
 
-    // No box: the ordinary shell prompt, and the headline case. Anchor ONLY on
-    // the final non-empty row — deliberately stricter than the prototype, which
-    // collected every row after a prompt and could therefore pick up an old
-    // prompt sitting in a full-screen program's scrollback.
-    guard let last = rows.last(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
-    else { return nil }
-    return afterStrongMarker(in: last)
+    // Neither a live prompt on the final row nor a box: refuse. This is what a
+    // full-screen program without a recognisable input region looks like.
+    return nil
   }
 
   /// A context derived from a terminal's screen, or nil to refuse.
-  static func screenDerivedContext(element: AXUIElement, pid: pid_t, window: Int)
-    -> CaretContext?
-  {
+  static func screenDerivedContext(
+    element: AXUIElement, pid: pid_t, window: Int, characterCount: Int
+  ) -> CaretContext? {
     guard let bundleID = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier,
       screenReadableTerminalBundleIDs.contains(bundleID)
     else { return nil }
 
-    var valueRef: CFTypeRef?
-    guard
-      AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
-        == .success,
-      let value = valueRef as? String
+    // Read ONLY the bounded tail, never the whole buffer. A terminal's `AXValue`
+    // is its entire scrollback and it grows all session, so copying it on every
+    // context read AND every commit revalidation puts unbounded work on the
+    // paste path (code review).
+    guard characterCount > 0 else { return nil }
+    let start = characterCount > terminalBufferTailUnits
+      ? characterCount - terminalBufferTailUnits : 0
+    let length = characterCount - start
+    guard let tail = string(of: element, at: start, length: length),
+      tail.utf16.count == length
     else { return nil }
-
-    let units = value.utf16.count
-    let start = units > terminalBufferTailUnits ? units - terminalBufferTailUnits : 0
-    // A boundary landing inside a surrogate pair means we cannot address the
-    // tail we planned; refuse rather than read a different span.
-    guard let tail = utf16Slice(of: value, from: start, to: units) else { return nil }
 
     guard let line = terminalInputLine(inBufferTail: tail), !line.isEmpty else { return nil }
 
@@ -768,7 +777,8 @@ public enum PasteService {
     if range.location == 0, characterCount > window {
       var pid: pid_t = 0
       if AXUIElementGetPid(fresh, &pid) == .success, pid > 0,
-        let screen = screenDerivedContext(element: fresh, pid: pid, window: window)
+        let screen = screenDerivedContext(
+          element: fresh, pid: pid, window: window, characterCount: characterCount)
       {
         return screen
       }

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -651,6 +651,18 @@ public enum PasteService {
     return trimmed.allSatisfy { $0 == "\u{2500}" || $0 == "\u{2501}" || $0 == "\u{2550}" || $0 == "-" }
   }
 
+  /// The text after a strong prompt marker that OPENS the row, or nil.
+  ///
+  /// "Opens" means first non-whitespace character. That is what separates a live
+  /// shell prompt from a full-screen UI's footer hint, which carries words ahead
+  /// of any marker it happens to contain.
+  static func afterStrongMarkerOpeningRow(in row: Substring) -> String? {
+    let leading = row.prefix(while: { $0.isWhitespace || $0 == "\u{00A0}" })
+    let body = row.dropFirst(leading.count)
+    guard let first = body.first, strongPromptMarkers.contains(first) else { return nil }
+    return afterStrongMarker(in: body)
+  }
+
   /// The text after the LAST strong prompt marker in a row, or nil.
   static func afterStrongMarker(in row: Substring) -> String? {
     var lastIndex: String.Index?
@@ -683,16 +695,23 @@ public enum PasteService {
   static func terminalInputLine(inBufferTail tail: String) -> String? {
     let rows = tail.split(separator: "\n", omittingEmptySubsequences: false)
 
-    // The CURRENT prompt wins over any box still sitting in scrollback.
+    // The CURRENT prompt wins over any box still sitting in scrollback — but
+    // only when the final row is genuinely PROMPT-SHAPED.
     //
     // A session that used a full-screen UI earlier leaves its rules behind, so
-    // `────\n❯ old input\n────\n❯ current command` would otherwise return the
-    // OLD input and compute the repair from stale text (code review). Checking
-    // the final row first settles it: a live shell prompt is the last thing on
-    // screen, while a live full-screen UI prints its footer hints below the box
-    // and so has no marker on that row.
+    // anchoring on the last two rules returned the OLD input while ignoring the
+    // command being typed. Checking the final row fixes that, but "contains a
+    // marker" is too weak: a live TUI footer reading `Press ❯ to continue` would
+    // then be mistaken for a shell prompt (cloud review).
+    //
+    // The discriminator comes from a real Ghostty buffer, not from guessing: a
+    // live prompt STARTS its row (`❯\u{00A0}` at index 0), while footer text has
+    // words in front of the marker. Requiring the marker to open the row keeps
+    // the stale-box fix and refuses the footer. A prompt that puts a path before
+    // the marker on the same row falls through to the box or refuses — a missed
+    // opportunity, never a wrong anchor.
     if let last = rows.last(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }),
-      let line = afterStrongMarker(in: last)
+      let line = afterStrongMarkerOpeningRow(in: last)
     {
       return line
     }

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -404,14 +404,25 @@ public enum PasteService {
     package let selectionLocation: Int
     /// UTF-16 length of the selection. Zero for a plain caret.
     package let selectionLength: Int
+    /// Non-nil when this context was parsed from a terminal's SCREEN rather than
+    /// read from a real caret, carrying the raw buffer tail it was derived from.
+    ///
+    /// The tail participates in equality, so a buffer that changed between the
+    /// read and the commit fails revalidation. It is the only identity a
+    /// screen-derived context has: there is no selection to compare.
+    package let terminalBufferTail: String?
+
+    package var isScreenDerived: Bool { terminalBufferTail != nil }
 
     package init(
-      leftWindow: String, rightWindow: String, selectionLocation: Int, selectionLength: Int
+      leftWindow: String, rightWindow: String, selectionLocation: Int, selectionLength: Int,
+      terminalBufferTail: String? = nil
     ) {
       self.leftWindow = leftWindow
       self.rightWindow = rightWindow
       self.selectionLocation = selectionLocation
       self.selectionLength = selectionLength
+      self.terminalBufferTail = terminalBufferTail
     }
   }
 
@@ -606,6 +617,127 @@ public enum PasteService {
     return String(utf16[startIndex..<endIndex])
   }
 
+  // MARK: - Terminal screen reading (#1803 part 1)
+
+  /// Terminals whose caret is known to be unreadable AND whose screen shape has
+  /// been measured.
+  ///
+  /// Ghostty ALONE, deliberately. It is the only terminal whose fake caret and
+  /// buffer layout were actually measured; a correct identifier for an
+  /// UNMEASURED terminal is not inert, it actively enables an unverified parser
+  /// against a screen we have never seen (grounded review r1). Adding one is a
+  /// one-line change gated on the same evidence Ghostty has.
+  static let screenReadableTerminalBundleIDs: Set<String> = ["com.mitchellh.ghostty"]
+
+  /// How much of a terminal's scrollback to consider. 2,000 UTF-16 units,
+  /// matching the prototype's window: enough for a wrapped box and its rules,
+  /// far short of a session's history.
+  package static let terminalBufferTailUnits = 2000
+
+  /// Prompt markers that are unambiguous.
+  ///
+  /// `$`, `%` and `#` are DELIBERATELY absent. They are also a dollar amount, a
+  /// percentage and a comment, and in the prototype the weak set anchored on
+  /// Claude Code's own status bar (`81% | $107.40`), which would mean joining a
+  /// dictation onto a banner. Losing stock Terminal's `%` prompt is the accepted
+  /// cost.
+  static let strongPromptMarkers: [Character] = ["\u{276F}", "\u{279C}"]
+
+  /// Whether a row is one of the horizontal rules a full-screen UI draws around
+  /// its input box.
+  static func isRuleRow(_ row: Substring) -> Bool {
+    let trimmed = row.trimmingCharacters(in: .whitespaces)
+    guard trimmed.count >= 4 else { return false }
+    return trimmed.allSatisfy { $0 == "\u{2500}" || $0 == "\u{2501}" || $0 == "\u{2550}" || $0 == "-" }
+  }
+
+  /// The text after the LAST strong prompt marker in a row, or nil.
+  static func afterStrongMarker(in row: Substring) -> String? {
+    var lastIndex: String.Index?
+    for index in row.indices where strongPromptMarkers.contains(row[index]) {
+      lastIndex = index
+    }
+    guard let marker = lastIndex else { return nil }
+    var start = row.index(after: marker)
+    // One separating space belongs to the marker, not to the user's text.
+    if start < row.endIndex, row[start] == " " || row[start] == "\u{00A0}" {
+      start = row.index(after: start)
+    }
+    // NBSP is what the box pads with; it is whitespace to a human and a distinct
+    // character to everything else (prototype).
+    return String(row[start...]).replacingOccurrences(of: "\u{00A0}", with: " ")
+  }
+
+  /// The current input line inside a terminal's screen, or nil to refuse.
+  ///
+  /// Ported from the parked Level 3 prototype rather than reinvented
+  /// (`research/seam-joining/code/join_hotkey.py`), which drove ten dictated
+  /// chunks through Ghostty and paid for every rule here:
+  ///
+  /// - the input box is the landmark, not the prompt: anchoring on the prompt
+  ///   alone swept up the footer hints printed BELOW the box, so an EMPTY box
+  ///   read back as those hints
+  /// - a WRAPPED box is refused rather than compensated for: joining screen rows
+  ///   reconstructs different text, and a soft wrap can fall mid-word
+  /// - a bare shell prompt has no box at all and is the ordinary case
+  static func terminalInputLine(inBufferTail tail: String) -> String? {
+    let rows = tail.split(separator: "\n", omittingEmptySubsequences: false)
+    let ruleRows = rows.indices.filter { isRuleRow(rows[$0]) }
+
+    if ruleRows.count >= 2 {
+      let body = rows[(ruleRows[ruleRows.count - 2] + 1)..<ruleRows[ruleRows.count - 1]]
+      let populated = body.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+      // More than one populated row means the input wrapped.
+      guard populated.count <= 1 else { return nil }
+      guard let first = body.first, let line = afterStrongMarker(in: first) else { return nil }
+      return line
+    }
+
+    // No box: the ordinary shell prompt, and the headline case. Anchor ONLY on
+    // the final non-empty row — deliberately stricter than the prototype, which
+    // collected every row after a prompt and could therefore pick up an old
+    // prompt sitting in a full-screen program's scrollback.
+    guard let last = rows.last(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
+    else { return nil }
+    return afterStrongMarker(in: last)
+  }
+
+  /// A context derived from a terminal's screen, or nil to refuse.
+  static func screenDerivedContext(element: AXUIElement, pid: pid_t, window: Int)
+    -> CaretContext?
+  {
+    guard let bundleID = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier,
+      screenReadableTerminalBundleIDs.contains(bundleID)
+    else { return nil }
+
+    var valueRef: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
+        == .success,
+      let value = valueRef as? String
+    else { return nil }
+
+    let units = value.utf16.count
+    let start = units > terminalBufferTailUnits ? units - terminalBufferTailUnits : 0
+    // A boundary landing inside a surrogate pair means we cannot address the
+    // tail we planned; refuse rather than read a different span.
+    guard let tail = utf16Slice(of: value, from: start, to: units) else { return nil }
+
+    guard let line = terminalInputLine(inBufferTail: tail), !line.isEmpty else { return nil }
+
+    // Only the window's worth matters, and the RIGHT side is empty by
+    // construction: in a terminal input line there is nothing after the cursor
+    // that we can see or should act on.
+    let lineUnits = line.utf16.count
+    let leftStart = lineUnits > window ? lineUnits - window : 0
+    guard let leftWindow = utf16Slice(of: line, from: leftStart, to: lineUnits) else {
+      return nil
+    }
+    return CaretContext(
+      leftWindow: leftWindow, rightWindow: "", selectionLocation: lineUnits,
+      selectionLength: 0, terminalBufferTail: tail)
+  }
+
   package static func readCaretContext(
     element: AXUIElement,
     window: Int = caretContextWindow
@@ -627,6 +759,20 @@ public enum PasteService {
     else { return nil }
 
     guard let range = selectedRange(of: fresh) else { return nil }
+
+    // A terminal reports a caret of 0 forever while its character count grows,
+    // so "the text after the cursor" is the TOP of the scrollback. That is the
+    // exact shape below, and it is where the screen fallback belongs: the caret
+    // answer is unusable, not merely unhelpful. Measured in Ghostty
+    // (accessibility-macos.md FACT: reading-caret-context-from-another-app).
+    if range.location == 0, characterCount > window {
+      var pid: pid_t = 0
+      if AXUIElementGetPid(fresh, &pid) == .success, pid > 0,
+        let screen = screenDerivedContext(element: fresh, pid: pid, window: window)
+      {
+        return screen
+      }
+    }
 
     return assembleCaretContext(
       characterCount: characterCount,
@@ -718,6 +864,11 @@ public enum PasteService {
       return (.noMutation, nil)
     }
     guard textRoles.contains(role) else { return (.noMutation, nil) }
+    // Screen-derived evidence has no real selection and no whole-field offsets,
+    // which is exactly what this route validates against before and after it
+    // writes. It must never authorise an accessibility write; the clipboard
+    // route carries it instead (grounded review r2, #1803).
+    if context?.isScreenDerived == true { return (.noMutation, nil) }
 
     // Verify the element is writable (not read-only).
     var settableRef: DarwinBoolean = false

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
@@ -1549,4 +1549,87 @@ struct CursorInsertionRepairTests {
     #expect(payloads.candidateRules.contains(.droppedDuplicateWord))
     #expect(payloads.repairedText == " Bahnhof. ")
   }
+
+  // MARK: - Screen-derived evidence is spacing-only (#1803 part 1)
+
+  private static func screen(
+    left: String, right: String = "", payload: String
+  ) -> CursorInsertionRepair.PreparedPayloads {
+    CursorInsertionRepair.repair(
+      text: payload,
+      context: CursorInsertionRepair.CaretText(
+        left: left, right: right, repairScope: .spacingOnly),
+      protectedWords: [], language: "en", lexicon: Self.prototypeLexicon)
+  }
+
+  @Test("Spacing still happens, because that is the whole point")
+  func spacingOnlyStillSpaces() {
+    let payloads = Self.screen(left: "git commit -m fix", payload: "The store is ready.")
+    #expect(payloads.repairedText?.hasPrefix(" ") == true)
+  }
+
+  @Test("Screen-derived evidence never recases the first word")
+  func spacingOnlyNeverRecases() {
+    // The same input DOES lowercase under a real caret; only the evidence differs.
+    let real = Self.seam(left: "I want to go to the", payload: "Store is ready.")
+    #expect(real.candidateRules.contains(.lowercasedFirst))
+
+    let screened = Self.screen(left: "I want to go to the", payload: "Store is ready.")
+    #expect(!screened.candidateRules.contains(.lowercasedFirst))
+    #expect(screened.candidateRules.contains(.caseSkipped(.screenDerivedContext)))
+    #expect(screened.repairedText?.contains("Store") == true)
+  }
+
+  @Test("Screen-derived evidence never deletes a duplicated word")
+  func spacingOnlyNeverDeduplicates() {
+    let real = Self.seam(left: "go to the", payload: "The store is ready.")
+    #expect(real.candidateRules.contains(.droppedDuplicateWord))
+
+    let screened = Self.screen(left: "go to the", payload: "The store is ready.")
+    #expect(!screened.candidateRules.contains(.droppedDuplicateWord))
+    #expect(screened.repairedText?.contains("The store") == true)
+  }
+
+  @Test("Screen-derived evidence never deletes a dictated full stop")
+  func spacingOnlyNeverDropsTerminalPeriod() {
+    let screened = Self.screen(left: "some text", right: ".", payload: "Done.")
+    #expect(!screened.candidateRules.contains(.droppedTerminalPeriod))
+    #expect(screened.repairedText?.contains("Done.") == true)
+  }
+
+  /// The finding that made spacing-only safe. A shell EXECUTES a pasted newline,
+  /// so a spacing artifact placed before one changes the command that runs.
+  @Test(
+    "A payload containing a line break refuses screen-derived repair outright",
+    arguments: ["backup\n", "one\ntwo", "trailing\r", "a\u{2028}b"])
+  func spacingOnlyRefusesMultilinePayloads(payload: String) {
+    let screened = Self.screen(left: "rm -rf /tmp/safefile", payload: payload)
+    #expect(screened.repairedText == nil, "\(payload.debugDescription)")
+    #expect(screened.candidateRules == [.refusedScreenDerivedLineBreak])
+    // A real caret is unaffected: the danger is the WRONG-POSITION evidence.
+    let real = CursorInsertionRepair.repair(
+      text: payload,
+      context: CursorInsertionRepair.CaretText(left: "rm -rf /tmp/safefile", right: ""),
+      protectedWords: [], language: "en", lexicon: Self.prototypeLexicon)
+    #expect(real.repairedText != nil, "\(payload.debugDescription)")
+  }
+
+  /// The invariant, asserted directly rather than trusted: strip the spaces we
+  /// are allowed to add and nothing else may have changed.
+  @Test(
+    "Spacing-only may add spaces at the seams and change nothing else",
+    arguments: [
+      ("go to the", "The store is ready."),
+      ("I want to go to the", "Store is closed today."),
+      ("echo foobar", "Foobar is ready."),
+      ("some text", "Don't worry about it."),
+      ("page 5", "5 is missing."),
+    ])
+  func spacingOnlyChangesOnlyWhitespace(left: String, payload: String) {
+    let screened = Self.screen(left: left, payload: payload)
+    let candidate = try! #require(screened.repairedText)
+    #expect(
+      candidate.trimmingCharacters(in: .whitespaces) == payload,
+      "only edge whitespace may differ: \(candidate.debugDescription)")
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CursorInsertionRepairTests.swift
@@ -1558,40 +1558,55 @@ struct CursorInsertionRepairTests {
     CursorInsertionRepair.repair(
       text: payload,
       context: CursorInsertionRepair.CaretText(
-        left: left, right: right, repairScope: .spacingOnly),
+        left: left, right: right, repairScope: .terminalScreen),
       protectedWords: [], language: "en", lexicon: Self.prototypeLexicon)
   }
 
   @Test("Spacing still happens, because that is the whole point")
-  func spacingOnlyStillSpaces() {
+  func screenDerivedStillSpaces() {
     let payloads = Self.screen(left: "git commit -m fix", payload: "The store is ready.")
     #expect(payloads.repairedText?.hasPrefix(" ") == true)
   }
 
-  @Test("Screen-derived evidence never recases the first word")
-  func spacingOnlyNeverRecases() {
-    // The same input DOES lowercase under a real caret; only the evidence differs.
+  /// The founder's actual complaint, and the whole reason terminals matter:
+  /// he dictates a half-finished thought, dictates the continuation, and the
+  /// second one arrives with a capital it should not have. Screen-derived
+  /// evidence MUST fix that, exactly as a real caret does.
+  @Test("Screen-derived evidence fixes the leading capital, same as a real caret")
+  func screenDerivedFixesTheCapital() {
     let real = Self.seam(left: "I want to go to the", payload: "Store is ready.")
-    #expect(real.candidateRules.contains(.lowercasedFirst))
-
     let screened = Self.screen(left: "I want to go to the", payload: "Store is ready.")
+    #expect(real.candidateRules.contains(.lowercasedFirst))
+    #expect(screened.candidateRules.contains(.lowercasedFirst))
+    #expect(screened.repairedText == real.repairedText, "the evidence source must not change the answer")
+  }
+
+  @Test("A full stop to the left still means a new sentence, so the capital stays")
+  func screenDerivedKeepsCapitalAfterATerminator() {
+    let screened = Self.screen(left: "git status. ", payload: "Store is ready.")
     #expect(!screened.candidateRules.contains(.lowercasedFirst))
-    #expect(screened.candidateRules.contains(.caseSkipped(.screenDerivedContext)))
     #expect(screened.repairedText?.contains("Store") == true)
   }
 
-  @Test("Screen-derived evidence never deletes a duplicated word")
-  func spacingOnlyNeverDeduplicates() {
+  /// The founder's algorithm, end to end: no full stop to the left, take the
+  /// last word, compare it to our first word, drop OURS. Nothing on screen is
+  /// touched — we simply paste less — so there is no backspacing anywhere.
+  @Test("Screen-derived evidence removes a duplicated word, same as a real caret")
+  func terminalScreenAlsoDeduplicates() {
     let real = Self.seam(left: "go to the", payload: "The store is ready.")
-    #expect(real.candidateRules.contains(.droppedDuplicateWord))
-
     let screened = Self.screen(left: "go to the", payload: "The store is ready.")
+    #expect(screened.candidateRules.contains(.droppedDuplicateWord))
+    #expect(screened.repairedText == real.repairedText, "the evidence source must not change the answer")
+  }
+
+  @Test("A full stop to the left stops the de-duplication, as the founder specified")
+  func terminalScreenKeepsDuplicateAfterATerminator() {
+    let screened = Self.screen(left: "go to the store.", payload: "Store is ready.")
     #expect(!screened.candidateRules.contains(.droppedDuplicateWord))
-    #expect(screened.repairedText?.contains("The store") == true)
   }
 
   @Test("Screen-derived evidence never deletes a dictated full stop")
-  func spacingOnlyNeverDropsTerminalPeriod() {
+  func terminalScreenNeverDropsTerminalPeriod() {
     let screened = Self.screen(left: "some text", right: ".", payload: "Done.")
     #expect(!screened.candidateRules.contains(.droppedTerminalPeriod))
     #expect(screened.repairedText?.contains("Done.") == true)
@@ -1602,7 +1617,7 @@ struct CursorInsertionRepairTests {
   @Test(
     "A payload containing a line break refuses screen-derived repair outright",
     arguments: ["backup\n", "one\ntwo", "trailing\r", "a\u{2028}b"])
-  func spacingOnlyRefusesMultilinePayloads(payload: String) {
+  func terminalScreenRefusesMultilinePayloads(payload: String) {
     let screened = Self.screen(left: "rm -rf /tmp/safefile", payload: payload)
     #expect(screened.repairedText == nil, "\(payload.debugDescription)")
     #expect(screened.candidateRules == [.refusedScreenDerivedLineBreak])
@@ -1617,19 +1632,20 @@ struct CursorInsertionRepairTests {
   /// The invariant, asserted directly rather than trusted: strip the spaces we
   /// are allowed to add and nothing else may have changed.
   @Test(
-    "Spacing-only may add spaces at the seams and change nothing else",
+    "A terminal screen produces the SAME answer a real caret would",
     arguments: [
       ("go to the", "The store is ready."),
       ("I want to go to the", "Store is closed today."),
       ("echo foobar", "Foobar is ready."),
       ("some text", "Don't worry about it."),
       ("page 5", "5 is missing."),
+      ("git status.", "Store is ready."),
     ])
-  func spacingOnlyChangesOnlyWhitespace(left: String, payload: String) {
+  func terminalScreenMatchesARealCaret(left: String, payload: String) {
+    // The evidence SOURCE must never change the outcome. Whatever the rules do
+    // with a real caret, they do identically here.
+    let real = Self.seam(left: left, payload: payload)
     let screened = Self.screen(left: left, payload: payload)
-    let candidate = try! #require(screened.repairedText)
-    #expect(
-      candidate.trimmingCharacters(in: .whitespaces) == payload,
-      "only edge whitespace may differ: \(candidate.debugDescription)")
+    #expect(screened.repairedText == real.repairedText, "\(left) | \(payload)")
   }
 }

--- a/Tests/EnviousWisprTests/Services/PasteCaretContextTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteCaretContextTests.swift
@@ -347,4 +347,111 @@ struct PasteCaretContextTests {
     #expect(PasteService.utf16Slice(of: "abc", from: 0, to: 9) == nil)
     #expect(PasteService.utf16Slice(of: "abc", from: -1, to: 2) == nil)
   }
+
+  // MARK: - Terminal screen parsing (#1803 part 1)
+
+  /// A full-screen UI draws its input box between two horizontal rules and
+  /// prints hints UNDER it.
+  private static func boxed(_ input: String, footer: String = "  ? for shortcuts") -> String {
+    """
+    some earlier output
+    \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+    \u{276F} \(input)
+    \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+    \(footer)
+    """
+  }
+
+  @Test("The boxed input line is found, and the footer below it is not")
+  func findsBoxedInputLine() {
+    let line = PasteService.terminalInputLine(inBufferTail: Self.boxed("git commit -m fix the"))
+    #expect(line == "git commit -m fix the")
+  }
+
+  @Test("An EMPTY box reads as empty, never as the hints printed below it")
+  func emptyBoxIsNotTheFooter() {
+    // The prototype's exact failure: anchoring on the prompt alone returned
+    // "/rc ⧉ seam-join-explainer" for a box nobody had typed in.
+    let line = PasteService.terminalInputLine(inBufferTail: Self.boxed(""))
+    #expect(line?.isEmpty == true || line == nil)
+  }
+
+  @Test("A WRAPPED box refuses rather than joining rows")
+  func wrappedBoxRefuses() {
+    let wrapped = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} this line is long enough that it
+      wrapped onto a second row
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    #expect(PasteService.terminalInputLine(inBufferTail: wrapped) == nil)
+  }
+
+  @Test("An ordinary shell prompt with no box is the headline case and works")
+  func bareShellPromptWorks() {
+    let bare = """
+      total 24
+      drwxr-xr-x  5 user  staff  160 Jul 26 09:00 .
+      \u{276F} git commit -m fix the
+      """
+    #expect(PasteService.terminalInputLine(inBufferTail: bare) == "git commit -m fix the")
+  }
+
+  @Test("An old prompt buried in a full-screen program's scrollback is not anchored on")
+  func staleScrollbackPromptRefuses() {
+    // Deliberately stricter than the prototype, which collected every row after
+    // a prompt. Only the FINAL non-empty row may carry the anchor.
+    let vimLike = """
+      \u{276F} vim notes.txt
+      ~
+      ~
+      -- INSERT --
+      """
+    #expect(PasteService.terminalInputLine(inBufferTail: vimLike) == nil)
+  }
+
+  @Test(
+    "Weak prompt markers are not anchors, so a status bar cannot be mistaken for input",
+    arguments: ["$ echo hello", "% echo hello", "# echo hello", "81% | $107.40"])
+  func weakMarkersRefuse(row: String) {
+    #expect(PasteService.terminalInputLine(inBufferTail: "output\n\(row)") == nil)
+  }
+
+  @Test("The box's non-breaking padding becomes an ordinary space")
+  func normalisesNonBreakingSpace() {
+    let line = PasteService.terminalInputLine(
+      inBufferTail: Self.boxed("git\u{00A0}commit"))
+    #expect(line == "git commit")
+    #expect(line?.contains("\u{00A0}") == false)
+  }
+
+  @Test("Trailing whitespace on the input line survives, because it is load-bearing")
+  func preservesTrailingWhitespace() {
+    // The app ends each dictation with a space, so the buffer is one character
+    // longer than the visible sentence; dropping it welds the next word on.
+    let line = PasteService.terminalInputLine(inBufferTail: Self.boxed("fix the "))
+    #expect(line == "fix the ")
+  }
+
+  @Test("Only Ghostty is allowlisted, because only Ghostty was measured")
+  func allowlistIsGhosttyAlone() {
+    #expect(PasteService.screenReadableTerminalBundleIDs == ["com.mitchellh.ghostty"])
+  }
+
+  @Test("A screen-derived context is marked as such and carries its buffer tail")
+  func screenDerivedContextCarriesProvenance() {
+    let plain = PasteService.CaretContext(
+      leftWindow: "abc", rightWindow: "", selectionLocation: 3, selectionLength: 0)
+    #expect(plain.isScreenDerived == false)
+
+    let screen = PasteService.CaretContext(
+      leftWindow: "abc", rightWindow: "", selectionLocation: 3, selectionLength: 0,
+      terminalBufferTail: "\u{276F} abc")
+    #expect(screen.isScreenDerived)
+    // The tail is identity: a buffer that changed fails revalidation.
+    let scrolled = PasteService.CaretContext(
+      leftWindow: "abc", rightWindow: "", selectionLocation: 3, selectionLength: 0,
+      terminalBufferTail: "more output\n\u{276F} abc")
+    #expect(screen != scrolled)
+  }
 }

--- a/Tests/EnviousWisprTests/Services/PasteCaretContextTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteCaretContextTests.swift
@@ -454,4 +454,27 @@ struct PasteCaretContextTests {
       terminalBufferTail: "more output\n\u{276F} abc")
     #expect(screen != scrolled)
   }
+
+  @Test("A live shell prompt wins over a boxed UI still sitting in scrollback")
+  func currentPromptBeatsAStaleBox() {
+    // The bug this freezes: an earlier full-screen session leaves its rules
+    // behind, and anchoring on the last two rules returned the OLD input while
+    // ignoring the command being typed right now.
+    let stale = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} old input from earlier
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} git commit -m fix the
+      """
+    #expect(PasteService.terminalInputLine(inBufferTail: stale) == "git commit -m fix the")
+  }
+
+  @Test("A live full-screen UI still resolves to its box, because its footer follows")
+  func liveBoxStillWinsWhenTheFooterFollows() {
+    // The other side of the same decision: a live UI prints hints BELOW the box,
+    // so its final row carries no prompt marker and the box is correct.
+    #expect(
+      PasteService.terminalInputLine(inBufferTail: Self.boxed("git commit -m fix the"))
+        == "git commit -m fix the")
+  }
 }

--- a/Tests/EnviousWisprTests/Services/PasteCaretContextTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteCaretContextTests.swift
@@ -477,4 +477,40 @@ struct PasteCaretContextTests {
       PasteService.terminalInputLine(inBufferTail: Self.boxed("git commit -m fix the"))
         == "git commit -m fix the")
   }
+
+  @Test("A live TUI footer containing a marker is not mistaken for a shell prompt")
+  func footerContainingAMarkerIsNotAPrompt() {
+    // Cloud review, PR #1814: requiring only that the final row CONTAINS a
+    // marker let `Press ❯ to continue` beat a perfectly valid input box.
+    let withMarkerFooter = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} git commit -m fix the
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      Press \u{276F} to continue
+      """
+    #expect(
+      PasteService.terminalInputLine(inBufferTail: withMarkerFooter)
+        == "git commit -m fix the")
+  }
+
+  @Test("The founder's real Ghostty buffer resolves to its empty input box")
+  func realGhosttyBufferSample() {
+    // Captured live 2026-07-26 from Ghostty running Claude Code. Kept verbatim
+    // because it is the shape the parser actually has to survive: an empty box
+    // padded with a non-breaking space, then a status bar carrying % and $, then
+    // a mode line, then a bare final row.
+    let real = """
+      · Hullaballooing… (5m 54s · ↓ 2.1k tokens)
+
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F}\u{00A0}
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+        \u{2588}\u{2588}\u{2588}\u{2591}\u{2591} 23% | $137.15 | 5h:3% | 7d:11%
+        \u{23F5}\u{23F5} auto mode on · PR #1814 · 1 shell
+                                                      /rc
+      """
+    // The box is empty, so there is nothing to continue and the caller refuses.
+    let line = PasteService.terminalInputLine(inBufferTail: real)
+    #expect(line?.trimmingCharacters(in: .whitespaces).isEmpty == true || line == nil)
+  }
 }


### PR DESCRIPTION
Part 1 of #1803. Makes cursor-aware insertion work in Ghostty, which is where the founder actually works and where the feature has been entirely off.

## The problem

Ghostty reports its cursor at position 0 forever while its character count grows — measured live, 42 → 179 → 198 with the reported position never moving. It isn't stale; the attribute simply isn't implemented. When the shipped code trusted that, it read the *top of the scrollback* as "text after your cursor" and stripped a full stop off a dictated sentence. #1785 shipped a refusal, correctly, and nothing ever replaced it.

## What this does

Reads the input line from the terminal's **screen** instead of asking for the cursor, porting the parked Level 3 prototype's strategy rather than reinventing it. Then the existing seam rules run exactly as they do everywhere else:

1. Walk back over spaces to the last real character.
2. `.`, `!` or `?` → new sentence, keep the capital. Anything else → mid-sentence.
3. Mid-sentence: lowercase the first word if the deterministic dictionary knows it, and if the last word matches our first word, drop **ours**.
4. Paste.

**Nothing on screen is ever modified.** "Delete the duplicate word" means pasting less, not editing the terminal — so there is no backspacing anywhere, which is what made the Level 3 work complicated and is simply absent here.

Every prototype lesson is kept: an empty box must not read back as the footer hints below it, a wrapped box refuses rather than being reconstructed, non-breaking padding is normalised, trailing whitespace is load-bearing.

## Two things stay off

- **The touching-full-stops rule**, which needs a right-hand window a screen read never has.
- **Any dictation containing a line break**, which refuses outright — a pasted newline executes the command, so a seam space placed before it changes what runs.

Allowlist is **Ghostty alone**. A correct identifier for an unmeasured terminal isn't inert; it enables an unverified parser against a screen nobody has looked at.

## A P1 from local review that is deliberately NOT actioned

The final review round asked to restore a spacing-only scope, on the grounds that a cursor moved into the middle of a line makes the screen evidence describe the wrong position.

**That is a known, founder-decided trade-off, not a new finding.** I raised it, escalated it with the measurement behind it — Ghostty exposes no cursor position, no line number, no selection, so it cannot be closed — and the founder decided twice to take it. In the flow this serves (dictate, then dictate the continuation) our own paste leaves the cursor at the end, so the ambiguity doesn't arise. Reversing it because a reviewer restated my own earlier objection would be churn.

Recorded here so it isn't re-litigated downstream.

## Two P2s that WERE actioned

- **A stale box beat the live prompt.** A session that used a full-screen UI earlier leaves its rules in scrollback, so a stale box followed by the current prompt anchored on the last two rules and computed the repair from old text. The current prompt now wins; both directions are frozen as tests.
- **The whole scrollback was being copied** before slicing 2,000 units off the end, on every context read and every commit revalidation. Now reads only the clamped tail.

## Tests

81 in `CursorInsertionRepairTests`, 45 in `PasteCaretContextTests`, full suite **4096 passing**.

The load-bearing assertion is parity: for the same left context and payload, a terminal screen must produce the **same** answer a real caret does, so the evidence source can never change the outcome.

Parser coverage: box found, empty box, wrapped box, bare shell prompt, stale scrollback prompt, live-prompt-beats-stale-box, weak markers refused, NBSP normalised, trailing whitespace preserved, allowlist, provenance equality.

Part of #1803
