### PR TITLE
feat(pipeline): cursor-aware insertion in the terminal

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -169,8 +169,13 @@ struct KernelFinalizationWiring {
     // Caret reader seam. Production reads the live focused field; tests inject
     // deterministic context so the real composition path can be driven without
     // depending on whatever field happens to be focused on the machine.
-    readCaretContext: @escaping @MainActor (AXUIElement) -> PasteService.CaretContext? =
-      { PasteService.readCaretContext(element: $0) },
+    // Caret reader seam. Production reads the live focused field, and supplies
+    // the per-delivery terminal budget so a terminal read is bounded by the same
+    // cumulative allowance as its later revalidation.
+    readCaretContext: @escaping @MainActor (AXUIElement, TerminalResolutionBudget) ->
+      PasteService.CaretContext? = {
+        PasteService.readCaretContext(element: $0, terminalBudget: $1)
+      },
     // Word-oracle seam. Production takes the live runtime snapshot; tests inject
     // a fixed oracle so a case never depends on the machine's dictionaries — and
     // so no test has to MUTATE the process-global runtime, which would race the
@@ -367,6 +372,12 @@ struct KernelFinalizationWiring {
       var pasteResult: PasteDeliveryResult?
       let deliveryOutcome: KernelDeliveryOutcome
       if config?.autoPasteToActiveApp == true {
+        // ONE cumulative terminal-resolution budget for this whole delivery,
+        // created here and reused by every commit-boundary revalidation. A fresh
+        // budget per route would let the total the user waits for grow with the
+        // number of routes tried, which is the bound it exists to keep.
+        let terminalBudget = TerminalResolutionBudget()
+
         // Read the caret ONCE, only when the frozen setting allows it and we
         // actually have a target. `readCaretContext` fails open, so a nil result
         // simply means no candidate.
@@ -374,7 +385,7 @@ struct KernelFinalizationWiring {
           guard config?.smartInsertion == true, let element = context.targetElement else {
             return nil
           }
-          return readCaretContext(element)
+          return readCaretContext(element, terminalBudget)
         }()
 
         // ONE call to the repair, which is the sole owner of the trailing-space
@@ -399,7 +410,12 @@ struct KernelFinalizationWiring {
             // offset zero exactly when it is as long as the caret's offset.
             // Without this the seam de-duplication refused every short field
             // (#1803, local diff review).
-            leftReachesDocumentStart: $0.leftWindow.utf16.count == $0.selectionLocation)
+            leftReachesDocumentStart: $0.leftWindow.utf16.count == $0.selectionLocation,
+            // The narrow policy fact the repair needs. A screen-derived line is
+            // ONE rendered row, so a payload carrying a line break is refused
+            // rather than reasoned about — in a terminal a newline can submit
+            // the command.
+            isScreenDerived: $0.isScreenDerived)
         }
 
         // Resolved from positive evidence, NOT read off the result.
@@ -477,7 +493,8 @@ struct KernelFinalizationWiring {
             caretContext: caretContext,
             targetApp: context.targetApp,
             targetElement: context.targetElement,
-            restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false))
+            restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false,
+            terminalBudget: terminalBudget))
         pasteResult = result
         if case .delivered = result.outcome {
           // The text that actually LANDED, which is not always the one this

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -172,10 +172,11 @@ struct KernelFinalizationWiring {
     // Caret reader seam. Production reads the live focused field, and supplies
     // the per-delivery terminal budget so a terminal read is bounded by the same
     // cumulative allowance as its later revalidation.
-    readCaretContext: @escaping @MainActor (AXUIElement, TerminalResolutionBudget) ->
-      PasteService.CaretContext? = {
-        PasteService.readCaretContext(element: $0, terminalBudget: $1)
-      },
+    readCaretContext: @escaping @MainActor (
+      AXUIElement, TerminalResolutionBudget, ((TerminalContextRefusal) -> Void)?
+    ) -> PasteService.CaretContext? = {
+      PasteService.readCaretContext(element: $0, terminalBudget: $1, onTerminalRefusal: $2)
+    },
     // Word-oracle seam. Production takes the live runtime snapshot; tests inject
     // a fixed oracle so a case never depends on the machine's dictionaries — and
     // so no test has to MUTATE the process-global runtime, which would race the
@@ -381,11 +382,14 @@ struct KernelFinalizationWiring {
         // Read the caret ONCE, only when the frozen setting allows it and we
         // actually have a target. `readCaretContext` fails open, so a nil result
         // simply means no candidate.
+        // The specific terminal refusal, so a wrong-case report can be diagnosed
+        // from the log instead of guessed at. Names and shapes only.
+        var terminalRefusal: TerminalContextRefusal?
         let caretContext: PasteService.CaretContext? = {
           guard config?.smartInsertion == true, let element = context.targetElement else {
             return nil
           }
-          return readCaretContext(element, terminalBudget)
+          return readCaretContext(element, terminalBudget, { terminalRefusal = $0 })
         }()
 
         // ONE call to the repair, which is the sole owner of the trailing-space
@@ -465,7 +469,9 @@ struct KernelFinalizationWiring {
         outcome.caretContextOutcome = {
           if config?.smartInsertion != true { return "setting_off" }
           if context.targetElement == nil { return "no_target" }
-          return caretContext == nil ? "unreadable" : "read"
+          if let terminalRefusal { return terminalRefusal.rawValue }
+          if caretContext?.isScreenDerived == true { return "terminal_read" }
+          return caretContext == nil ? "unreadable" : "read_selected"
         }()
         outcome.repairRules =
           payloads.candidateRules.isEmpty

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -19,6 +19,12 @@ internal struct PasteDeliveryRequest {
   let targetApp: NSRunningApplication?
   let targetElement: AXUIElement?
   let restoreClipboardAfterPaste: Bool
+  /// The SAME cumulative terminal-resolution budget the caret read used.
+  ///
+  /// One per delivery, shared by the initial resolution and every commit
+  /// revalidation. A fresh budget per route would let the total wait grow with
+  /// the number of routes tried, which is the bound this exists to keep.
+  let terminalBudget: TerminalResolutionBudget?
 }
 
 /// Typed outcome of a paste delivery operation. Authoritative input for both
@@ -349,7 +355,8 @@ internal final class PasteCascadeExecutor {
           legacy: request.legacyText,
           repaired: request.repairedText,
           context: request.caretContext,
-          element: request.targetElement)
+          element: request.targetElement,
+          terminalBudget: request.terminalBudget)
         // Snapshot AFTER that revalidation, immediately before the write. The
         // re-check makes accessibility calls, and anything copied while they run
         // would otherwise be captured as "the user's old clipboard" and then
@@ -397,7 +404,8 @@ internal final class PasteCascadeExecutor {
           legacy: request.legacyText,
           repaired: request.repairedText,
           context: request.caretContext,
-          element: request.targetElement)
+          element: request.targetElement,
+          terminalBudget: request.terminalBudget)
         // Same ordering as Tier 2: snapshot after the re-check, before the write.
         let snapshot: ClipboardSnapshot? =
           request.restoreClipboardAfterPaste
@@ -447,7 +455,8 @@ internal final class PasteCascadeExecutor {
           legacy: request.legacyText,
           repaired: request.repairedText,
           context: request.caretContext,
-          element: request.targetElement)
+          element: request.targetElement,
+          terminalBudget: request.terminalBudget)
         submittedKind = payload.kind
         let changeCount = PasteService.copyToClipboardReturningChangeCount(payload.text)
         submittedClipboardChangeCount = changeCount

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -373,8 +373,24 @@ public enum CursorInsertionRepair {
 
     // Rule 1: a leading space, unless one side already supplies separation —
     // or the language does not separate words with spaces at all.
-    if language.usesWordSpacing, let anchor = left.character, !left.crossedSpace,
-      !left.isOpener,
+    //
+    // NEVER in a terminal (founder 2026-07-28, after live testing). A terminal
+    // truncates each rendered row at its last VISIBLE character — measured: an
+    // input row reported length 2 while the rules around it were 68 — because it
+    // draws a cursor where the trailing space would be. So `fix the` and
+    // `fix the ` are byte-identical on screen and this rule cannot tell them
+    // apart. Since every dictation already ends with a trailing space, it fired
+    // on every consecutive dictation and produced a double space every time.
+    //
+    // Dropping it rather than dropping the trailing space is the founder's call
+    // and the better one: the trailing space is a product promise users have
+    // already learned everywhere else, and removing it in terminals alone would
+    // make terminals the one inconsistent surface. The cost — typing a word,
+    // not typing a space, then dictating — is user-controlled and already how
+    // the app behaves next to a period, which users understand because they
+    // caused it.
+    if !context.isScreenDerived, language.usesWordSpacing, let anchor = left.character,
+      !left.crossedSpace, !left.isOpener,
       let firstCharacter = out.first, !firstCharacter.isWhitespace
     {
       out = " " + out

--- a/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
+++ b/Sources/EnviousWisprPostProcessing/CursorInsertionRepair.swift
@@ -37,10 +37,23 @@ public enum CursorInsertionRepair {
     /// know cannot accidentally authorise a deletion.
     public let leftReachesDocumentStart: Bool
 
-    public init(left: String, right: String, leftReachesDocumentStart: Bool = false) {
+    /// Whether this context was parsed from a terminal's rendered SCREEN rather
+    /// than read from a real caret.
+    ///
+    /// The narrow POLICY fact, and nothing more: process and accessibility
+    /// evidence stay in Services. A screen-derived line is one rendered row, so
+    /// a payload containing a line break cannot be reasoned about here — see
+    /// the refusal in `prepare`.
+    public let isScreenDerived: Bool
+
+    public init(
+      left: String, right: String, leftReachesDocumentStart: Bool = false,
+      isScreenDerived: Bool = false
+    ) {
       self.left = left
       self.right = right
       self.leftReachesDocumentStart = leftReachesDocumentStart
+      self.isScreenDerived = isScreenDerived
     }
   }
 
@@ -313,6 +326,15 @@ public enum CursorInsertionRepair {
     // character, so refusing there would add a refusal that changes no text.
     // Founder direction 2026-07-25 that this work in every tool.
     if leftAnchor(of: context.left).character == nil, !context.right.isEmpty {
+      return PreparedPayloads(
+        legacyText: legacy, repairedText: nil, candidateRules: [.refusedNoLeftAnchor])
+    }
+    // A screen-derived context describes ONE rendered row. A payload carrying a
+    // line break would submit a line the user never saw assembled, and in a
+    // terminal a newline can SUBMIT the command — so refuse rather than reason
+    // about it. Cheap, and it costs nothing real: dictation into a terminal
+    // prompt is a single line by construction.
+    if context.isScreenDerived, text.contains(where: \.isNewline) {
       return PreparedPayloads(
         legacyText: legacy, repairedText: nil, candidateRules: [.refusedNoLeftAnchor])
     }

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -461,6 +461,11 @@ public enum PasteService {
     }
   }
 
+  /// The accessibility messaging timeout applied to a destination before any
+  /// read. A failure bound, not a latency target — single owner, so the terminal
+  /// path can restore exactly this value after tightening it.
+  package static let axMessagingTimeoutSeconds: Double = 0.5
+
   /// How many UTF-16 units to read either side. One character is provably not
   /// enough — `"home. "` and `"home, "` both end in a space and need opposite
   /// decisions — so the reader takes a window and the rule walks back within it.
@@ -568,8 +573,8 @@ public enum PasteService {
 
     let application = AXUIElementCreateApplication(pid)
     // Bound every subsequent read. A wedged destination must not hang the
-    // dictation path; 0.5s is a failure bound, not a latency target.
-    AXUIElementSetMessagingTimeout(application, 0.5)
+    // dictation path; this is a failure bound, not a latency target.
+    AXUIElementSetMessagingTimeout(application, Float(axMessagingTimeoutSeconds))
 
     var focusedRef: CFTypeRef?
     guard
@@ -705,7 +710,23 @@ public enum PasteService {
     let dependencies = TerminalContextResolver.Dependencies(
       bundleIdentifier: { NSRunningApplication(processIdentifier: pid)?.bundleIdentifier },
       scanProcesses: { TerminalProcessScanner.liveSnapshot() },
-      readScreenTail: { terminalScreenTail(of: element) })
+      readScreenTail: {
+        // Bound the accessibility call ITSELF to what is left of the budget,
+        // rather than only noticing afterwards that it overran.
+        //
+        // The default messaging timeout is 0.5 s per call, so a wedged terminal
+        // would otherwise block delivery for five times the budget before
+        // anything could react. This is the one lever that shortens the call
+        // instead of just measuring it, and it needs no async ripple through a
+        // synchronous, main-actor read path.
+        //
+        // The breaker still matters: this bounds ONE call, while the breaker
+        // stops the next dictation paying the same cost again.
+        let application = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(application, Float(max(0.010, budget.remaining)))
+        defer { AXUIElementSetMessagingTimeout(application, Float(axMessagingTimeoutSeconds)) }
+        return terminalScreenTail(of: element)
+      })
 
     guard
       let evidence = TerminalContextResolver.resolve(

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -562,7 +562,10 @@ public enum PasteService {
   ///
   /// Returns nil for untrusted accessibility, a dead process, an unreadable
   /// focus, or a different element — every one of which means "do not repair".
-  static func freshFocusedElement(matching element: AXUIElement) -> AXUIElement? {
+  static func freshFocusedElement(
+    matching element: AXUIElement,
+    messagingTimeout: Double = axMessagingTimeoutSeconds
+  ) -> AXUIElement? {
     guard AXIsProcessTrusted() else { return nil }
 
     // Resolve the owning process from the captured element itself — never from
@@ -574,7 +577,7 @@ public enum PasteService {
     let application = AXUIElementCreateApplication(pid)
     // Bound every subsequent read. A wedged destination must not hang the
     // dictation path; this is a failure bound, not a latency target.
-    AXUIElementSetMessagingTimeout(application, Float(axMessagingTimeoutSeconds))
+    AXUIElementSetMessagingTimeout(application, Float(messagingTimeout))
 
     var focusedRef: CFTypeRef?
     guard
@@ -710,23 +713,7 @@ public enum PasteService {
     let dependencies = TerminalContextResolver.Dependencies(
       bundleIdentifier: { NSRunningApplication(processIdentifier: pid)?.bundleIdentifier },
       scanProcesses: { TerminalProcessScanner.liveSnapshot() },
-      readScreenTail: {
-        // Bound the accessibility call ITSELF to what is left of the budget,
-        // rather than only noticing afterwards that it overran.
-        //
-        // The default messaging timeout is 0.5 s per call, so a wedged terminal
-        // would otherwise block delivery for five times the budget before
-        // anything could react. This is the one lever that shortens the call
-        // instead of just measuring it, and it needs no async ripple through a
-        // synchronous, main-actor read path.
-        //
-        // The breaker still matters: this bounds ONE call, while the breaker
-        // stops the next dictation paying the same cost again.
-        let application = AXUIElementCreateApplication(pid)
-        AXUIElementSetMessagingTimeout(application, Float(max(0.010, budget.remaining)))
-        defer { AXUIElementSetMessagingTimeout(application, Float(axMessagingTimeoutSeconds)) }
-        return terminalScreenTail(of: element)
-      })
+      readScreenTail: { terminalScreenTail(of: element) })
 
     guard
       let evidence = TerminalContextResolver.resolve(
@@ -751,7 +738,65 @@ public enum PasteService {
     terminalBudget: TerminalResolutionBudget? = nil,
     terminalBreaker: TerminalCircuitBreaker = .shared
   ) -> CaretContext? {
-    guard let fresh = freshFocusedElement(matching: element) else { return nil }
+    // CLASS FIX, whole-diff review r2. The budget previously covered only the
+    // resolver's own steps, so the FIVE accessibility reads that run before it —
+    // focused element, role, character count, selection, and the two windows —
+    // were each bounded at the 0.5 s failure timeout and charged nothing. A
+    // wedge in any of them returned nil before the resolver ran, so the breaker
+    // was never armed and every dictation repeated the delay.
+    //
+    // Every read on this path is now bounded at its single entry point, and the
+    // WHOLE operation is charged and can arm the breaker, not just its tail.
+    guard let terminalBudget else {
+      // No budget means no terminal attempt, byte-identical to today.
+      return caretDerivedContext(element: element, window: window)
+    }
+
+    var targetPID: pid_t = 0
+    guard AXUIElementGetPid(element, &targetPID) == .success else { return nil }
+    if terminalBreaker.isOpen(for: targetPID) {
+      return caretDerivedContext(element: element, window: window)
+    }
+
+    let started = Date().timeIntervalSinceReferenceDate
+    var context = caretDerivedContext(
+      element: element, window: window,
+      messagingTimeout: max(0.010, min(terminalBudget.remaining, axMessagingTimeoutSeconds)))
+
+    if TerminalContextResolver.overspent(
+      by: Date().timeIntervalSinceReferenceDate - started,
+      budget: terminalBudget, breaker: terminalBreaker, pid: targetPID)
+    {
+      // Whatever came back arrived too late to spend more time on.
+      return context
+    }
+
+    // The terminal signature, and the exact condition the shipped repair already
+    // refuses on: no usable left anchor with a non-empty right window. A
+    // terminal reports a caret pinned at 0 while its character count grows, so
+    // the "text after the caret" is really the TOP of the scrollback.
+    //
+    // Gate 0 inside the resolver is what stops this firing in an honest app
+    // whose user simply put the cursor at the very start of a document.
+    let looksLikeATerminal =
+      context == nil || (context?.leftWindow.isEmpty == true && context?.rightWindow.isEmpty == false)
+    guard looksLikeATerminal else { return context }
+
+    context =
+      terminalCaretContext(element: element, budget: terminalBudget, breaker: terminalBreaker)
+      ?? context
+    return context
+  }
+
+  /// Today's selected-range read, unchanged. Split out so the terminal path can
+  /// reuse it without duplicating a single accessibility call.
+  static func caretDerivedContext(
+    element: AXUIElement,
+    window: Int,
+    messagingTimeout: Double = axMessagingTimeoutSeconds
+  ) -> CaretContext? {
+    guard let fresh = freshFocusedElement(matching: element, messagingTimeout: messagingTimeout)
+    else { return nil }
 
     // Role is read from the FRESH element, never the captured handle.
     var roleRef: CFTypeRef?
@@ -769,7 +814,7 @@ public enum PasteService {
 
     guard let range = selectedRange(of: fresh) else { return nil }
 
-    let caretDerived = assembleCaretContext(
+    return assembleCaretContext(
       characterCount: characterCount,
       selectionLocation: range.location,
       selectionLength: range.length,
@@ -777,21 +822,6 @@ public enum PasteService {
       readRange: { location, length in
         string(of: fresh, at: location, length: length)
       })
-
-    // The terminal signature, and the exact condition the shipped repair already
-    // refuses on: no usable left anchor with a non-empty right window. A
-    // terminal reports a caret pinned at 0 while its character count grows, so
-    // the "text after the caret" is really the TOP of the scrollback.
-    //
-    // Gate 0 inside the resolver is what stops this firing in an honest app
-    // whose user simply put the cursor at the very start of a document.
-    let looksLikeATerminal =
-      caretDerived == nil
-      || (caretDerived?.leftWindow.isEmpty == true && caretDerived?.rightWindow.isEmpty == false)
-    guard looksLikeATerminal, let terminalBudget else { return caretDerived }
-
-    return terminalCaretContext(
-      element: fresh, budget: terminalBudget, breaker: terminalBreaker) ?? caretDerived
   }
 
   /// Exact UTF-16 code-unit identity.

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -745,43 +745,58 @@ public enum PasteService {
     terminalBreaker: TerminalCircuitBreaker = .shared,
     onTerminalRefusal: ((TerminalContextRefusal) -> Void)? = nil
   ) -> CaretContext? {
-    // CLASS FIX, whole-diff review r2. The budget previously covered only the
-    // resolver's own steps, so the FIVE accessibility reads that run before it —
-    // focused element, role, character count, selection, and the two windows —
-    // were each bounded at the 0.5 s failure timeout and charged nothing. A
-    // wedge in any of them returned nil before the resolver ran, so the breaker
-    // was never armed and every dictation repeated the delay.
+    // CLASS, enumerated rather than patched — this is the THIRD review round to
+    // find the same shape, so every path is accounted for here instead of the
+    // one that was reported.
     //
-    // Every read on this path is now bounded at its single entry point, and the
-    // WHOLE operation is charged and can arm the breaker, not just its tail.
+    // THE RULE: on a delivery that could touch a terminal, EVERY accessibility
+    // read is bounded by the remaining budget. There are exactly four paths out
+    // of this function, and each one states its bound:
+    //
+    //   1. no budget            -> today's default. Not a terminal delivery.
+    //   2. breaker already open -> BOUNDED. Round 3 found this returning to the
+    //                              0.5 s default, so a terminal known to be
+    //                              wedged still cost half a second on every
+    //                              later dictation — the exact cost the breaker
+    //                              exists to stop paying.
+    //   3. read overran         -> BOUNDED, charged, breaker armed.
+    //   4. normal               -> BOUNDED, charged.
+    //
+    // Rounds one and two each fixed one path and left the others; the fix is a
+    // single place that computes the bound, not another branch that remembers to.
     guard let terminalBudget else {
-      // No budget means no terminal attempt, byte-identical to today.
+      // Path 1. No budget means no terminal attempt, byte-identical to today.
       return caretDerivedContext(element: element, window: window)
     }
 
     var targetPID: pid_t = 0
     guard AXUIElementGetPid(element, &targetPID) == .success else { return nil }
+
+    // ONE owner of the bound, so no path can forget it.
+    let bound = max(0.010, min(terminalBudget.remaining, axMessagingTimeoutSeconds))
+
     if terminalBreaker.isOpen(for: targetPID) {
+      // Path 2. Still read the caret — every other app's behaviour depends on it
+      // — but never at the default timeout, because this target is known wedged.
       onTerminalRefusal?(.breakerOpen)
-      return caretDerivedContext(element: element, window: window)
+      return caretDerivedContext(element: element, window: window, messagingTimeout: bound)
     }
 
     let started = Date().timeIntervalSinceReferenceDate
     var context = caretDerivedContext(
-      element: element, window: window,
-      messagingTimeout: max(0.010, min(terminalBudget.remaining, axMessagingTimeoutSeconds)))
+      element: element, window: window, messagingTimeout: bound)
 
     if TerminalContextResolver.overspent(
       by: Date().timeIntervalSinceReferenceDate - started,
       budget: terminalBudget, breaker: terminalBreaker, pid: targetPID)
     {
-      // Whatever came back arrived too late to spend more time on.
+      // Path 3. Whatever came back arrived too late to spend more time on.
       onTerminalRefusal?(.deadline)
       return context
     }
 
-    // The terminal signature, and the exact condition the shipped repair already
-    // refuses on: no usable left anchor with a non-empty right window. A
+    // Path 4. The terminal signature, and the exact condition the shipped repair
+    // already refuses on: no usable left anchor with a non-empty right window. A
     // terminal reports a caret pinned at 0 while its character count grows, so
     // the "text after the caret" is really the TOP of the scrollback.
     //

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -708,13 +708,25 @@ public enum PasteService {
     breaker: TerminalCircuitBreaker,
     onRefusal: ((TerminalContextRefusal) -> Void)? = nil
   ) -> CaretContext? {
+    // REVALIDATE FOCUS FIRST — the captured element may be a tab the user has
+    // since left.
+    //
+    // The caret path has always done this through `freshFocusedElement`, and the
+    // terminal path was reading the captured handle directly. So when the user
+    // switched tabs after recording started, the caret read correctly refused
+    // the stale element and the screen read then went to that same stale
+    // element anyway, describing a tab that is no longer in front of them.
+    // Cloud review found it; the discipline already existed one function away.
+    guard let fresh = freshFocusedElement(matching: element, messagingTimeout: budget.remaining)
+    else { return nil }
+
     var pid: pid_t = 0
-    guard AXUIElementGetPid(element, &pid) == .success else { return nil }
+    guard AXUIElementGetPid(fresh, &pid) == .success else { return nil }
 
     let dependencies = TerminalContextResolver.Dependencies(
       bundleIdentifier: { NSRunningApplication(processIdentifier: pid)?.bundleIdentifier },
       scanProcesses: { TerminalProcessScanner.liveSnapshot() },
-      readScreenTail: { terminalScreenTail(of: element) })
+      readScreenTail: { terminalScreenTail(of: fresh) })
 
     // The typed refusal is REPORTED, not discarded. §8 of the plan lists eight
     // distinct outcomes, and cloud review found every one of them collapsing

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -717,7 +717,9 @@ public enum PasteService {
     // the stale element and the screen read then went to that same stale
     // element anyway, describing a tab that is no longer in front of them.
     // Cloud review found it; the discipline already existed one function away.
-    guard let fresh = freshFocusedElement(matching: element, messagingTimeout: budget.remaining)
+    guard let fresh = budget.step(applying: element, {
+      freshFocusedElement(matching: element, messagingTimeout: max(0.005, budget.remaining))
+    })
     else { return nil }
 
     var pid: pid_t = 0
@@ -726,7 +728,7 @@ public enum PasteService {
     let dependencies = TerminalContextResolver.Dependencies(
       bundleIdentifier: { NSRunningApplication(processIdentifier: pid)?.bundleIdentifier },
       scanProcesses: { TerminalProcessScanner.liveSnapshot() },
-      readScreenTail: { terminalScreenTail(of: fresh) })
+      readScreenTail: { budget.step(applying: fresh) { terminalScreenTail(of: fresh) } })
 
     // The typed refusal is REPORTED, not discarded. §8 of the plan lists eight
     // distinct outcomes, and cloud review found every one of them collapsing
@@ -805,23 +807,20 @@ public enum PasteService {
       return caretDerivedContext(element: element, window: window)
     }
 
-    // ONE owner of the bound, so no path can forget it.
-    let bound = max(0.010, min(terminalBudget.remaining, axMessagingTimeoutSeconds))
-
     if terminalBreaker.isOpen(for: targetPID) {
       // Path 2. Still read the caret — every other app's behaviour depends on it
       // — but never at the default timeout, because this target is known wedged.
       onTerminalRefusal?(.breakerOpen)
-      return caretDerivedContext(element: element, window: window, messagingTimeout: bound)
+      return caretDerivedContext(element: element, window: window, budget: terminalBudget)
     }
 
-    let started = Date().timeIntervalSinceReferenceDate
+    // Each read inside charges the shared budget as it goes, so this checks a
+    // total that is already accurate rather than timing the block from outside.
     var context = caretDerivedContext(
-      element: element, window: window, messagingTimeout: bound)
+      element: element, window: window, budget: terminalBudget)
 
     if TerminalContextResolver.overspent(
-      by: Date().timeIntervalSinceReferenceDate - started,
-      budget: terminalBudget, breaker: terminalBreaker, pid: targetPID)
+      by: 0, budget: terminalBudget, breaker: terminalBreaker, pid: targetPID)
     {
       // Path 3. Whatever came back arrived too late to spend more time on.
       onTerminalRefusal?(.deadline)
@@ -848,29 +847,51 @@ public enum PasteService {
 
   /// Today's selected-range read, unchanged. Split out so the terminal path can
   /// reuse it without duplicating a single accessibility call.
+  /// Today's selected-range read.
+  ///
+  /// When a `budget` is supplied, EVERY accessibility call inside is wrapped so
+  /// the cap applies to all of them TOGETHER (founder 2026-07-28: "it has to be
+  /// a 100 ms cap for all the questions"). Passing no budget is today's path
+  /// exactly, at the standard failure timeout — which is what every non-terminal
+  /// app takes.
   static func caretDerivedContext(
     element: AXUIElement,
     window: Int,
-    messagingTimeout: Double = axMessagingTimeoutSeconds
+    budget: TerminalResolutionBudget? = nil
   ) -> CaretContext? {
-    guard let fresh = freshFocusedElement(matching: element, messagingTimeout: messagingTimeout)
+    // One helper, so no read can be added later that forgets to be counted.
+    func bounded<T>(_ body: () -> T) -> T {
+      guard let budget else { return body() }
+      return budget.step(applying: element, body)
+    }
+
+    guard
+      let fresh = bounded({
+        freshFocusedElement(
+          matching: element,
+          messagingTimeout: budget.map { max(0.005, $0.remaining) } ?? axMessagingTimeoutSeconds)
+      })
     else { return nil }
 
     // Role is read from the FRESH element, never the captured handle.
     var roleRef: CFTypeRef?
     guard
-      AXUIElementCopyAttributeValue(fresh, kAXRoleAttribute as CFString, &roleRef) == .success,
+      bounded({
+        AXUIElementCopyAttributeValue(fresh, kAXRoleAttribute as CFString, &roleRef)
+      }) == .success,
       let role = roleRef as? String, textRoles.contains(role)
     else { return nil }
 
     var countRef: CFTypeRef?
     guard
-      AXUIElementCopyAttributeValue(
-        fresh, kAXNumberOfCharactersAttribute as CFString, &countRef) == .success,
+      bounded({
+        AXUIElementCopyAttributeValue(
+          fresh, kAXNumberOfCharactersAttribute as CFString, &countRef)
+      }) == .success,
       let characterCount = countRef as? Int
     else { return nil }
 
-    guard let range = selectedRange(of: fresh) else { return nil }
+    guard let range = bounded({ selectedRange(of: fresh) }) else { return nil }
 
     return assembleCaretContext(
       characterCount: characterCount,
@@ -878,7 +899,7 @@ public enum PasteService {
       selectionLength: range.length,
       window: window,
       readRange: { location, length in
-        string(of: fresh, at: location, length: length)
+        bounded { string(of: fresh, at: location, length: length) }
       })
   }
 

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -381,10 +381,39 @@ public enum PasteService {
     legacy: String,
     repaired: String?,
     context: CaretContext?,
-    element: AXUIElement?
+    element: AXUIElement?,
+    terminalBudget: TerminalResolutionBudget? = nil
   ) -> (text: String, kind: PastePayloadKind) {
     guard let repaired, let context, let element,
-      caretUnchanged(element: element, since: context)
+      caretUnchanged(element: element, since: context, terminalBudget: terminalBudget)
+    else { return (legacy, .legacy) }
+    return (repaired, .repaired)
+  }
+
+  /// Which payload the Tier 1 accessibility write may commit.
+  ///
+  /// Extracted so the rule can be tested. It was previously inline, where the
+  /// only reachable test had to pass a nil element and therefore passed for the
+  /// wrong reason — it proved "no element means legacy", not the rule itself.
+  package static func accessibilityWritePayload(
+    legacy: String,
+    repaired: String?,
+    context: CaretContext?,
+    rangeBefore: CFRange,
+    fieldBefore: String
+  ) -> (text: String, kind: PastePayloadKind) {
+    // Screen evidence can NEVER authorise this route. Tier 1's authorisation
+    // rests on real selection offsets and matching surrounding windows read from
+    // the field microseconds before it writes. A screen-derived context has
+    // neither — its offsets are synthesised from the parsed line and its right
+    // window is empty by construction — so every check below would compare
+    // against something that was never read from the field. Tier 1 always
+    // submits today's payload in a terminal.
+    guard context?.isScreenDerived != true else { return (legacy, .legacy) }
+    guard let repaired, let context,
+      rangeBefore.location == context.selectionLocation,
+      rangeBefore.length == context.selectionLength,
+      contextWindowsStillMatch(context, inFieldBefore: fieldBefore)
     else { return (legacy, .legacy) }
     return (repaired, .repaired)
   }
@@ -405,13 +434,30 @@ public enum PasteService {
     /// UTF-16 length of the selection. Zero for a plain caret.
     package let selectionLength: Int
 
+    /// Non-nil when this context came from a terminal's rendered SCREEN rather
+    /// than from a real caret, carrying the complete evidence all three gates
+    /// agreed on.
+    ///
+    /// Typed provenance is load-bearing in three places: repair enforces
+    /// terminal-only policy, screen evidence is barred from authorising the
+    /// Tier 1 accessibility write, and commit revalidation is source-aware. The
+    /// evidence participates in equality, so a screen that scrolled, a CLI that
+    /// exited, or focus that moved all fail revalidation — a screen-derived
+    /// context has no selection offsets to compare, so this IS its identity.
+    package let terminalEvidence: TerminalEvidence?
+
+    /// Whether this context was derived from a terminal screen.
+    package var isScreenDerived: Bool { terminalEvidence != nil }
+
     package init(
-      leftWindow: String, rightWindow: String, selectionLocation: Int, selectionLength: Int
+      leftWindow: String, rightWindow: String, selectionLocation: Int, selectionLength: Int,
+      terminalEvidence: TerminalEvidence? = nil
     ) {
       self.leftWindow = leftWindow
       self.rightWindow = rightWindow
       self.selectionLocation = selectionLocation
       self.selectionLength = selectionLength
+      self.terminalEvidence = terminalEvidence
     }
   }
 
@@ -558,8 +604,16 @@ public enum PasteService {
   /// into `. ` leaves every offset identical while inverting whether the next
   /// word should be lowercased. Offsets alone would have called that unchanged
   /// and committed a repair computed from punctuation that is no longer there.
-  package static func caretUnchanged(element: AXUIElement, since context: CaretContext) -> Bool {
-    guard let fresh = readCaretContext(element: element) else { return false }
+  package static func caretUnchanged(
+    element: AXUIElement,
+    since context: CaretContext,
+    terminalBudget: TerminalResolutionBudget? = nil
+  ) -> Bool {
+    // The SAME budget as the initial read, so resolution plus every commit check
+    // share one cumulative per-delivery bound rather than one bound each.
+    guard let fresh = readCaretContext(element: element, terminalBudget: terminalBudget) else {
+      return false
+    }
     return fresh == context
   }
 
@@ -606,9 +660,75 @@ public enum PasteService {
     return String(utf16[startIndex..<endIndex])
   }
 
+  /// How much of a terminal's rendered screen Gate 2 may read.
+  ///
+  /// 6,000 UTF-16 units, MEASURED rather than chosen: 2,000 lost the opening
+  /// boundary row on long Claude Code input, while 6,000 retained it at every
+  /// length up to 4,800 typed characters. Never a whole-field `AXValue` read —
+  /// on a terminal that is the ENTIRE scrollback.
+  package static let terminalScreenTailUnits = 6000
+
+  /// Read the bounded tail of a terminal's rendered screen.
+  ///
+  /// The returned length must EQUAL the requested length. A short or long
+  /// result, a boundary landing inside a surrogate pair, or an app with no
+  /// parameterized-range support all refuse — a partially-read screen would
+  /// silently produce a wrong input line.
+  static func terminalScreenTail(of element: AXUIElement) -> String? {
+    var countRef: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(
+        element, kAXNumberOfCharactersAttribute as CFString, &countRef) == .success,
+      let characterCount = countRef as? Int, characterCount > 0
+    else { return nil }
+
+    let length = min(characterCount, terminalScreenTailUnits)
+    let location = characterCount - length
+    guard let tail = string(of: element, at: location, length: length),
+      tail.utf16.count == length
+    else { return nil }
+    return tail
+  }
+
+  /// Resolve a terminal context for `element`, or nil.
+  ///
+  /// Gate 0 reads the bundle identifier from the element's OWN pid rather than
+  /// from anything the caller measured earlier.
+  static func terminalCaretContext(
+    element: AXUIElement,
+    budget: TerminalResolutionBudget,
+    breaker: TerminalCircuitBreaker
+  ) -> CaretContext? {
+    var pid: pid_t = 0
+    guard AXUIElementGetPid(element, &pid) == .success else { return nil }
+
+    let dependencies = TerminalContextResolver.Dependencies(
+      bundleIdentifier: { NSRunningApplication(processIdentifier: pid)?.bundleIdentifier },
+      scanProcesses: { TerminalProcessScanner.liveSnapshot() },
+      readScreenTail: { terminalScreenTail(of: element) })
+
+    guard
+      let evidence = TerminalContextResolver.resolve(
+        targetPID: pid, budget: budget, breaker: breaker, dependencies: dependencies
+      ).evidence
+    else { return nil }
+
+    // The right window is EMPTY BY CONSTRUCTION. Under the founder's
+    // end-of-line assumption there is no text after the cursor to read, and this
+    // is what keeps the drop-our-full-stop rule inert in terminals.
+    return CaretContext(
+      leftWindow: evidence.located.inputLine,
+      rightWindow: "",
+      selectionLocation: evidence.located.inputLine.utf16.count,
+      selectionLength: 0,
+      terminalEvidence: evidence)
+  }
+
   package static func readCaretContext(
     element: AXUIElement,
-    window: Int = caretContextWindow
+    window: Int = caretContextWindow,
+    terminalBudget: TerminalResolutionBudget? = nil,
+    terminalBreaker: TerminalCircuitBreaker = .shared
   ) -> CaretContext? {
     guard let fresh = freshFocusedElement(matching: element) else { return nil }
 
@@ -628,7 +748,7 @@ public enum PasteService {
 
     guard let range = selectedRange(of: fresh) else { return nil }
 
-    return assembleCaretContext(
+    let caretDerived = assembleCaretContext(
       characterCount: characterCount,
       selectionLocation: range.location,
       selectionLength: range.length,
@@ -636,6 +756,21 @@ public enum PasteService {
       readRange: { location, length in
         string(of: fresh, at: location, length: length)
       })
+
+    // The terminal signature, and the exact condition the shipped repair already
+    // refuses on: no usable left anchor with a non-empty right window. A
+    // terminal reports a caret pinned at 0 while its character count grows, so
+    // the "text after the caret" is really the TOP of the scrollback.
+    //
+    // Gate 0 inside the resolver is what stops this firing in an honest app
+    // whose user simply put the cursor at the very start of a document.
+    let looksLikeATerminal =
+      caretDerived == nil
+      || (caretDerived?.leftWindow.isEmpty == true && caretDerived?.rightWindow.isEmpty == false)
+    guard looksLikeATerminal, let terminalBudget else { return caretDerived }
+
+    return terminalCaretContext(
+      element: fresh, budget: terminalBudget, breaker: terminalBreaker) ?? caretDerived
   }
 
   /// Exact UTF-16 code-unit identity.
@@ -804,14 +939,9 @@ public enum PasteService {
     // enough (Codex review r2): rewriting a preceding `, ` as `. ` leaves every
     // offset identical while inverting whether the next word should be
     // lowercased.
-    let payload: (text: String, kind: PastePayloadKind) = {
-      guard let repaired, let context,
-        rangeBefore.location == context.selectionLocation,
-        rangeBefore.length == context.selectionLength,
-        contextWindowsStillMatch(context, inFieldBefore: fieldBefore)
-      else { return (legacy, .legacy) }
-      return (repaired, .repaired)
-    }()
+    let payload = accessibilityWritePayload(
+      legacy: legacy, repaired: repaired, context: context, rangeBefore: rangeBefore,
+      fieldBefore: fieldBefore)
     let text = payload.text
     let insertedLength = text.utf16.count
 

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -753,7 +753,7 @@ public enum PasteService {
     // read is bounded by the remaining budget. There are exactly four paths out
     // of this function, and each one states its bound:
     //
-    //   1. no budget            -> today's default. Not a terminal delivery.
+    //   1. not a terminal       -> today's default, unchanged.
     //   2. breaker already open -> BOUNDED. Round 3 found this returning to the
     //                              0.5 s default, so a terminal known to be
     //                              wedged still cost half a second on every
@@ -764,13 +764,34 @@ public enum PasteService {
     //
     // Rounds one and two each fixed one path and left the others; the fix is a
     // single place that computes the bound, not another branch that remembers to.
-    guard let terminalBudget else {
-      // Path 1. No budget means no terminal attempt, byte-identical to today.
+    //
+    // GATE 0 FIRST, and this ordering is load-bearing rather than tidy.
+    //
+    // Production supplies a budget on EVERY delivery, so gating the terminal
+    // policy on "was a budget passed" applied it to every app in the product.
+    // Cloud review caught both consequences: an ordinary app's caret read was
+    // being squeezed from the 0.5 s failure bound down to 100 ms, so a slow but
+    // perfectly honest field could start failing to read where it used to
+    // succeed; and an ordinary app with the caret at the start of a non-empty
+    // field matched the terminal signature, so Gate 0's refusal was reported as
+    // terminal telemetry for something that is not a terminal.
+    //
+    // Asking "is this app a terminal" costs one bundle-id lookup and no
+    // accessibility call, so it is asked BEFORE any policy is applied. A
+    // non-terminal delivery then takes exactly today's path: default timeout, no
+    // budget charged, no terminal outcome recorded.
+    var targetPID: pid_t = 0
+    let hasPID = AXUIElementGetPid(element, &targetPID) == .success
+    let surface =
+      hasPID
+      ? NSRunningApplication(processIdentifier: targetPID)?.bundleIdentifier
+        .flatMap(TerminalSurface.init(bundleIdentifier:))
+      : nil
+
+    guard let terminalBudget, surface != nil, hasPID else {
+      // Path 1. Not a terminal delivery — byte-identical to today.
       return caretDerivedContext(element: element, window: window)
     }
-
-    var targetPID: pid_t = 0
-    guard AXUIElementGetPid(element, &targetPID) == .success else { return nil }
 
     // ONE owner of the bound, so no path can forget it.
     let bound = max(0.010, min(terminalBudget.remaining, axMessagingTimeoutSeconds))

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -705,7 +705,8 @@ public enum PasteService {
   static func terminalCaretContext(
     element: AXUIElement,
     budget: TerminalResolutionBudget,
-    breaker: TerminalCircuitBreaker
+    breaker: TerminalCircuitBreaker,
+    onRefusal: ((TerminalContextRefusal) -> Void)? = nil
   ) -> CaretContext? {
     var pid: pid_t = 0
     guard AXUIElementGetPid(element, &pid) == .success else { return nil }
@@ -715,11 +716,16 @@ public enum PasteService {
       scanProcesses: { TerminalProcessScanner.liveSnapshot() },
       readScreenTail: { terminalScreenTail(of: element) })
 
-    guard
-      let evidence = TerminalContextResolver.resolve(
-        targetPID: pid, budget: budget, breaker: breaker, dependencies: dependencies
-      ).evidence
-    else { return nil }
+    // The typed refusal is REPORTED, not discarded. §8 of the plan lists eight
+    // distinct outcomes, and cloud review found every one of them collapsing
+    // into "unreadable" at the caller — which is exactly the diagnosability gap
+    // that cost three rounds of guessing during founder testing on 2026-07-26.
+    let result = TerminalContextResolver.resolve(
+      targetPID: pid, budget: budget, breaker: breaker, dependencies: dependencies)
+    guard let evidence = result.evidence else {
+      if case .refused(let reason) = result { onRefusal?(reason) }
+      return nil
+    }
 
     // The right window is EMPTY BY CONSTRUCTION. Under the founder's
     // end-of-line assumption there is no text after the cursor to read, and this
@@ -736,7 +742,8 @@ public enum PasteService {
     element: AXUIElement,
     window: Int = caretContextWindow,
     terminalBudget: TerminalResolutionBudget? = nil,
-    terminalBreaker: TerminalCircuitBreaker = .shared
+    terminalBreaker: TerminalCircuitBreaker = .shared,
+    onTerminalRefusal: ((TerminalContextRefusal) -> Void)? = nil
   ) -> CaretContext? {
     // CLASS FIX, whole-diff review r2. The budget previously covered only the
     // resolver's own steps, so the FIVE accessibility reads that run before it —
@@ -755,6 +762,7 @@ public enum PasteService {
     var targetPID: pid_t = 0
     guard AXUIElementGetPid(element, &targetPID) == .success else { return nil }
     if terminalBreaker.isOpen(for: targetPID) {
+      onTerminalRefusal?(.breakerOpen)
       return caretDerivedContext(element: element, window: window)
     }
 
@@ -768,6 +776,7 @@ public enum PasteService {
       budget: terminalBudget, breaker: terminalBreaker, pid: targetPID)
     {
       // Whatever came back arrived too late to spend more time on.
+      onTerminalRefusal?(.deadline)
       return context
     }
 
@@ -783,8 +792,9 @@ public enum PasteService {
     guard looksLikeATerminal else { return context }
 
     context =
-      terminalCaretContext(element: element, budget: terminalBudget, breaker: terminalBreaker)
-      ?? context
+      terminalCaretContext(
+        element: element, budget: terminalBudget, breaker: terminalBreaker,
+        onRefusal: onTerminalRefusal) ?? context
     return context
   }
 

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -93,24 +93,39 @@ package final class TerminalResolutionBudget: Sendable {
 /// CANNOT preempt a blocked thread, so the abandoned reads accumulate. Precedent
 /// is the oracle deadline, which already latches its failing dependency off.
 ///
-/// Keyed by target PID, so a relaunched terminal starts closed.
+/// Keyed by PID **and process start time**, so a relaunched terminal starts
+/// closed and PID REUSE cannot inherit a latch.
+///
+/// Cloud review found the gap: the latch lasts the whole process lifetime and
+/// nothing ever cleared it, so once macOS recycled that PID an unrelated
+/// terminal would be refused forever with no way back. Identity, not a number.
 package final class TerminalCircuitBreaker: Sendable {
   package static let shared = TerminalCircuitBreaker()
 
-  private let open = OSAllocatedUnfairLock(initialState: Set<pid_t>())
+  /// A process, not merely a PID.
+  struct Key: Hashable {
+    let pid: pid_t
+    /// Nil when the start time is unreadable — which cannot be conflated with a
+    /// known one, so an unreadable process gets its own distinct key.
+    let startedAt: UInt64?
+  }
+
+  private let open = OSAllocatedUnfairLock(initialState: Set<Key>())
 
   package init() {}
 
+  private func key(_ pid: pid_t) -> Key {
+    Key(pid: pid, startedAt: TerminalProcessScanner.startTime(of: pid))
+  }
+
   package func isOpen(for pid: pid_t) -> Bool {
-    open.withLock { $0.contains(pid) }
+    let key = key(pid)
+    return open.withLock { $0.contains(key) }
   }
 
   package func trip(for pid: pid_t) {
-    open.withLock { _ = $0.insert(pid) }
-  }
-
-  package func reset(for pid: pid_t) {
-    open.withLock { _ = $0.remove(pid) }
+    let key = key(pid)
+    open.withLock { _ = $0.insert(key) }
   }
 
   package func resetAll() {

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -131,21 +131,26 @@ package enum TerminalContextResolver {
   /// Everything the resolver touches from the outside world, injected so the
   /// decision logic is testable without a terminal, a process table or an
   /// accessibility connection.
-  package struct Dependencies: Sendable {
+  /// Deliberately NOT `Sendable`: resolution is synchronous and single-threaded
+  /// per delivery, and the accessibility element these closures read is not
+  /// Sendable either. Marking them `@Sendable` would force the caller to smuggle
+  /// a foreign app's accessibility handle across an isolation boundary, which is
+  /// the opposite of what this type is for.
+  package struct Dependencies {
     /// Bundle identifier of the app being pasted into.
-    package let bundleIdentifier: @Sendable () -> String?
+    package let bundleIdentifier: () -> String?
     /// Every readable process, or `.unavailable`.
-    package let scanProcesses: @Sendable () -> TerminalProcessScan
+    package let scanProcesses: () -> TerminalProcessScan
     /// The bounded tail of the focused tab's rendered screen, or nil.
-    package let readScreenTail: @Sendable () -> String?
+    package let readScreenTail: () -> String?
     /// Seconds elapsed, for charging the budget.
-    package let now: @Sendable () -> Double
+    package let now: () -> Double
 
     package init(
-      bundleIdentifier: @escaping @Sendable () -> String?,
-      scanProcesses: @escaping @Sendable () -> TerminalProcessScan,
-      readScreenTail: @escaping @Sendable () -> String?,
-      now: @escaping @Sendable () -> Double = { Date().timeIntervalSinceReferenceDate }
+      bundleIdentifier: @escaping () -> String?,
+      scanProcesses: @escaping () -> TerminalProcessScan,
+      readScreenTail: @escaping () -> String?,
+      now: @escaping () -> Double = { Date().timeIntervalSinceReferenceDate }
     ) {
       self.bundleIdentifier = bundleIdentifier
       self.scanProcesses = scanProcesses

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import Darwin
 import Foundation
 import os
@@ -81,6 +82,33 @@ package final class TerminalResolutionBudget: Sendable {
   /// Charge the time a step made the caller wait.
   package func charge(_ seconds: Double) {
     spent.withLock { $0 += max(0, seconds) }
+  }
+
+  /// Run one bounded step: apply the remaining budget as the accessibility
+  /// messaging timeout, run the call, then charge what it actually took.
+  ///
+  /// This is what makes the cap CUMULATIVE rather than per-call (founder,
+  /// 2026-07-28: "it has to be a 100 ms cap for all the questions"). An earlier
+  /// version applied the same bound to each of the five reads, so five could
+  /// take five times the cap between them.
+  ///
+  /// Measured live the same day, which is why this is a FAILURE bound and not a
+  /// latency target: all five reads together cost mean 0.78 ms in Ghostty and
+  /// 1.79 ms in iTerm2, with the only spikes (19-35 ms) on a cold first call.
+  /// The cap is roughly fifty times the typical cost and three times the worst
+  /// observed — it exists to bound a wedge, and never bites healthy work.
+  package func step<T>(applying element: AXUIElement, _ body: () -> T) -> T {
+    let application = AXUIElementCreateApplication(processIdentifier(of: element))
+    AXUIElementSetMessagingTimeout(application, Float(max(0.005, remaining)))
+    let started = DispatchTime.now().uptimeNanoseconds
+    defer { charge(Double(DispatchTime.now().uptimeNanoseconds - started) / 1e9) }
+    return body()
+  }
+
+  private func processIdentifier(of element: AXUIElement) -> pid_t {
+    var pid: pid_t = 0
+    AXUIElementGetPid(element, &pid)
+    return pid
   }
 }
 
@@ -217,6 +245,9 @@ package enum TerminalContextResolver {
     // Gate 1 — the veto. An unreadable process list is NOT "nothing is
     // running": both refuse, but they are different facts, and the typed scan
     // result is what keeps them apart.
+    //
+    // Timed from out here because the process sweep is NOT an accessibility
+    // call, so nothing else charges it. Measured mean 3 ms / p95 7 ms.
     let scanStart = dependencies.now()
     let scan = dependencies.scanProcesses()
     if overspent(by: dependencies.now() - scanStart, budget: budget, breaker: breaker, pid: targetPID) {
@@ -233,9 +264,13 @@ package enum TerminalContextResolver {
     guard !running.isEmpty else { return .refused(.noSupportedCLI) }
 
     // Gate 2 — WHERE the line is. Never whether.
-    let readStart = dependencies.now()
+    //
+    // Charged with ZERO here: the read is an accessibility call and already
+    // charged itself through `budget.step`, which is what makes the cap
+    // cumulative. Timing it again from out here would double-count it and
+    // halve the effective budget.
     let tail = dependencies.readScreenTail()
-    if overspent(by: dependencies.now() - readStart, budget: budget, breaker: breaker, pid: targetPID) {
+    if overspent(by: 0, budget: budget, breaker: breaker, pid: targetPID) {
       // The evidence may well be complete, and it is discarded anyway. A result
       // that arrived after the deadline is a result the user already waited too
       // long for, and accepting it would make the promised bound meaningless.

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -159,6 +159,25 @@ package enum TerminalContextResolver {
     }
   }
 
+  /// Charge a step, and decide whether the budget is now spent.
+  ///
+  /// Tripping the breaker HERE is what arms it. Whole-diff review found that
+  /// nothing in production ever called `trip`, so the breaker was tested,
+  /// documented, and inert — a wedged terminal would have repeated its delay on
+  /// every single dictation forever. Tests that only trip it by hand cannot
+  /// catch that; this is the one place the product itself does.
+  static func overspent(
+    by elapsed: Double,
+    budget: TerminalResolutionBudget,
+    breaker: TerminalCircuitBreaker,
+    pid: pid_t
+  ) -> Bool {
+    budget.charge(elapsed)
+    guard budget.isExhausted else { return false }
+    breaker.trip(for: pid)
+    return true
+  }
+
   /// Run all three gates.
   ///
   /// Order is deliberate and is a cost decision as much as a safety one: the
@@ -185,7 +204,9 @@ package enum TerminalContextResolver {
     // result is what keeps them apart.
     let scanStart = dependencies.now()
     let scan = dependencies.scanProcesses()
-    budget.charge(dependencies.now() - scanStart)
+    if overspent(by: dependencies.now() - scanStart, budget: budget, breaker: breaker, pid: targetPID) {
+      return .refused(.deadline)
+    }
 
     let running: [RunningTerminalCLI]
     switch scan {
@@ -195,12 +216,16 @@ package enum TerminalContextResolver {
       running = TerminalProcessScanner.supportedCLIs(in: snapshots, hostedBy: surface)
     }
     guard !running.isEmpty else { return .refused(.noSupportedCLI) }
-    if budget.isExhausted { return .refused(.deadline) }
 
     // Gate 2 — WHERE the line is. Never whether.
     let readStart = dependencies.now()
     let tail = dependencies.readScreenTail()
-    budget.charge(dependencies.now() - readStart)
+    if overspent(by: dependencies.now() - readStart, budget: budget, breaker: breaker, pid: targetPID) {
+      // The evidence may well be complete, and it is discarded anyway. A result
+      // that arrived after the deadline is a result the user already waited too
+      // long for, and accepting it would make the promised bound meaningless.
+      return .refused(.deadline)
+    }
 
     guard let tail else { return .refused(.screenUnreadable) }
     guard let located = TerminalScreenParser.locate(inScreenTail: tail) else {

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -1,0 +1,234 @@
+import Darwin
+import Foundation
+import os
+
+// MARK: - Evidence
+
+/// Everything the three gates agreed on, as ONE opaque token.
+///
+/// No caller may validate it in parts. At every route's last boundary before a
+/// write the gates re-run and the COMPLETE token must match — the raw screen
+/// tail included, because a screen-derived context has no selection offsets to
+/// compare and the tail is the only identity it has.
+package struct TerminalEvidence: Equatable, Sendable {
+  package let surface: TerminalSurface
+  /// The supported CLIs that satisfied the veto, sorted so that equality does
+  /// not depend on the order the kernel happened to enumerate processes in.
+  package let runningCLIs: [RunningTerminalCLI]
+  /// The raw screen tail the input line was derived from.
+  package let screenTail: String
+  package let located: TerminalScreenParser.Located
+
+  package init(
+    surface: TerminalSurface, runningCLIs: [RunningTerminalCLI], screenTail: String,
+    located: TerminalScreenParser.Located
+  ) {
+    self.surface = surface
+    self.runningCLIs = runningCLIs.sorted { $0.processIdentifier < $1.processIdentifier }
+    self.screenTail = screenTail
+    self.located = located
+  }
+}
+
+/// Why a terminal read was refused. Recorded as telemetry; metadata only, never
+/// a path, a window title, screen text or the derived line.
+package enum TerminalContextRefusal: String, Equatable, Sendable {
+  case surfaceIneligible = "terminal_surface_refused"
+  case noSupportedCLI = "terminal_no_supported_cli"
+  case processScanUnavailable = "terminal_process_scan_unavailable"
+  case screenUnreadable = "terminal_screen_unreadable"
+  case screenRefused = "terminal_screen_refused"
+  case deadline = "terminal_deadline"
+  case breakerOpen = "terminal_breaker_open"
+  case staleAtCommit = "terminal_stale_at_commit"
+}
+
+package enum TerminalContextResult: Equatable, Sendable {
+  case resolved(TerminalEvidence)
+  case refused(TerminalContextRefusal)
+
+  package var evidence: TerminalEvidence? {
+    if case .resolved(let evidence) = self { return evidence }
+    return nil
+  }
+}
+
+// MARK: - Budget
+
+/// ONE cumulative time budget per delivery, shared by the initial resolution and
+/// every later commit revalidation.
+///
+/// The accessibility messaging timeout is 0.5 s PER CALL, and a full resolution
+/// plus revalidation is several calls — up to seconds before raw text reaches
+/// the user, on the heart path. A per-CALL limit would not bound that; only a
+/// cumulative one does. No call, route, retry or revalidation resets it.
+package final class TerminalResolutionBudget: Sendable {
+  package static let defaultTotal: Double = 0.100
+
+  private let total: Double
+  private let spent = OSAllocatedUnfairLock(initialState: 0.0)
+
+  package init(total: Double = defaultTotal) {
+    self.total = total
+  }
+
+  package var remaining: Double {
+    spent.withLock { max(0, total - $0) }
+  }
+
+  package var isExhausted: Bool { remaining <= 0 }
+
+  /// Charge the time a step made the caller wait.
+  package func charge(_ seconds: Double) {
+    spent.withLock { $0 += max(0, seconds) }
+  }
+}
+
+// MARK: - Circuit breaker
+
+/// Latches a wedged terminal off for the rest of the process's life.
+///
+/// Without this, repeated dictations against one wedged terminal each start
+/// another blocked read: `withDeadline` resumes the caller at the deadline but
+/// CANNOT preempt a blocked thread, so the abandoned reads accumulate. Precedent
+/// is the oracle deadline, which already latches its failing dependency off.
+///
+/// Keyed by target PID, so a relaunched terminal starts closed.
+package final class TerminalCircuitBreaker: Sendable {
+  package static let shared = TerminalCircuitBreaker()
+
+  private let open = OSAllocatedUnfairLock(initialState: Set<pid_t>())
+
+  package init() {}
+
+  package func isOpen(for pid: pid_t) -> Bool {
+    open.withLock { $0.contains(pid) }
+  }
+
+  package func trip(for pid: pid_t) {
+    open.withLock { _ = $0.insert(pid) }
+  }
+
+  package func reset(for pid: pid_t) {
+    open.withLock { _ = $0.remove(pid) }
+  }
+
+  package func resetAll() {
+    open.withLock { $0.removeAll() }
+  }
+}
+
+// MARK: - Resolver
+
+/// The single owner of the complete terminal decision: surface eligibility, the
+/// running-CLI veto, screen-line location, and commit revalidation.
+///
+/// The alternative — several private helpers on `PasteService` — would make the
+/// central paste type the owner of both delivery AND terminal-session discovery,
+/// which is two concerns.
+package enum TerminalContextResolver {
+
+  /// Everything the resolver touches from the outside world, injected so the
+  /// decision logic is testable without a terminal, a process table or an
+  /// accessibility connection.
+  package struct Dependencies: Sendable {
+    /// Bundle identifier of the app being pasted into.
+    package let bundleIdentifier: @Sendable () -> String?
+    /// Every readable process, or `.unavailable`.
+    package let scanProcesses: @Sendable () -> TerminalProcessScan
+    /// The bounded tail of the focused tab's rendered screen, or nil.
+    package let readScreenTail: @Sendable () -> String?
+    /// Seconds elapsed, for charging the budget.
+    package let now: @Sendable () -> Double
+
+    package init(
+      bundleIdentifier: @escaping @Sendable () -> String?,
+      scanProcesses: @escaping @Sendable () -> TerminalProcessScan,
+      readScreenTail: @escaping @Sendable () -> String?,
+      now: @escaping @Sendable () -> Double = { Date().timeIntervalSinceReferenceDate }
+    ) {
+      self.bundleIdentifier = bundleIdentifier
+      self.scanProcesses = scanProcesses
+      self.readScreenTail = readScreenTail
+      self.now = now
+    }
+  }
+
+  /// Run all three gates.
+  ///
+  /// Order is deliberate and is a cost decision as much as a safety one: the
+  /// cheapest, most decisive gate runs first, so an ineligible app never reaches
+  /// a process scan and a terminal with nothing running never reaches a screen
+  /// read.
+  package static func resolve(
+    targetPID: pid_t,
+    budget: TerminalResolutionBudget,
+    breaker: TerminalCircuitBreaker = .shared,
+    dependencies: Dependencies
+  ) -> TerminalContextResult {
+    if breaker.isOpen(for: targetPID) { return .refused(.breakerOpen) }
+    if budget.isExhausted { return .refused(.deadline) }
+
+    // Gate 0 — terminal surface. Cheapest, and it licenses everything after it.
+    guard
+      let identifier = dependencies.bundleIdentifier(),
+      let surface = TerminalSurface(bundleIdentifier: identifier)
+    else { return .refused(.surfaceIneligible) }
+
+    // Gate 1 — the veto. An unreadable process list is NOT "nothing is
+    // running": both refuse, but they are different facts, and the typed scan
+    // result is what keeps them apart.
+    let scanStart = dependencies.now()
+    let scan = dependencies.scanProcesses()
+    budget.charge(dependencies.now() - scanStart)
+
+    let running: [RunningTerminalCLI]
+    switch scan {
+    case .unavailable:
+      return .refused(.processScanUnavailable)
+    case .available(let snapshots):
+      running = TerminalProcessScanner.supportedCLIs(in: snapshots, hostedBy: surface)
+    }
+    guard !running.isEmpty else { return .refused(.noSupportedCLI) }
+    if budget.isExhausted { return .refused(.deadline) }
+
+    // Gate 2 — WHERE the line is. Never whether.
+    let readStart = dependencies.now()
+    let tail = dependencies.readScreenTail()
+    budget.charge(dependencies.now() - readStart)
+
+    guard let tail else { return .refused(.screenUnreadable) }
+    guard let located = TerminalScreenParser.locate(inScreenTail: tail) else {
+      return .refused(.screenRefused)
+    }
+
+    return .resolved(
+      TerminalEvidence(
+        surface: surface, runningCLIs: running, screenTail: tail, located: located))
+  }
+
+  /// Re-run every gate at a write boundary and require the COMPLETE token to
+  /// match.
+  ///
+  /// Process exit, focus change, a scroll, an edit, or any value becoming
+  /// unreadable all select today's payload. Partial validation is not offered:
+  /// the token is opaque by design, because a caller checking only the derived
+  /// line would miss the buffer moving underneath it.
+  package static func revalidate(
+    _ captured: TerminalEvidence,
+    targetPID: pid_t,
+    budget: TerminalResolutionBudget,
+    breaker: TerminalCircuitBreaker = .shared,
+    dependencies: Dependencies
+  ) -> TerminalContextResult {
+    let fresh = resolve(
+      targetPID: targetPID, budget: budget, breaker: breaker, dependencies: dependencies)
+    guard let evidence = fresh.evidence else {
+      // Carry the specific refusal through rather than flattening it: a
+      // deadline at commit and a changed screen are different facts.
+      return fresh
+    }
+    guard evidence == captured else { return .refused(.staleAtCommit) }
+    return .resolved(evidence)
+  }
+}

--- a/Sources/EnviousWisprServices/TerminalProcessScanner.swift
+++ b/Sources/EnviousWisprServices/TerminalProcessScanner.swift
@@ -1,0 +1,376 @@
+import Darwin
+import Foundation
+
+// MARK: - Supported surfaces and tools
+
+/// Terminal apps whose rendered screen Gate 0 admits.
+///
+/// This is NOT the CLI support decision — Gate 1 owns that — but it IS a real
+/// authorisation gate, because it licenses interpreting an app's bounded
+/// `AXStringForRange` tail as a rendered terminal grid, which is a
+/// terminal-specific reading of ordinary text. A correct bundle id for an
+/// UNMEASURED terminal is therefore not inert, and the set ships with measured
+/// entries only.
+package enum TerminalSurface: String, CaseIterable, Sendable {
+  case ghostty
+  case terminalApp
+  case iTerm2
+
+  package init?(bundleIdentifier: String) {
+    switch bundleIdentifier {
+    case "com.mitchellh.ghostty": self = .ghostty
+    case "com.apple.Terminal": self = .terminalApp
+    case "com.googlecode.iterm2": self = .iTerm2
+    default: return nil
+    }
+  }
+
+  /// The `TERM_PROGRAM` value this terminal exports into the shells it spawns.
+  ///
+  /// Measured 2026-07-28, each from the shipped artifact rather than from
+  /// documentation: `ghostty` observed live on 48 running processes;
+  /// `Apple_Terminal` and `iTerm.app` read out of the Terminal.app and iTerm2
+  /// binaries themselves.
+  package var termProgramValue: String {
+    switch self {
+    case .ghostty: return "ghostty"
+    case .terminalApp: return "Apple_Terminal"
+    case .iTerm2: return "iTerm.app"
+    }
+  }
+}
+
+/// The terminal-hosted assistants whose input line Gate 2 knows how to locate.
+package enum SupportedTerminalCLI: String, CaseIterable, Sendable {
+  case claudeCode = "claude_code"
+  case codex = "codex"
+  case geminiCLI = "gemini_cli"
+}
+
+/// One supported CLI observed running, with the terminal it reported.
+package struct RunningTerminalCLI: Equatable, Hashable, Sendable {
+  package let processIdentifier: pid_t
+  package let cli: SupportedTerminalCLI
+
+  package init(processIdentifier: pid_t, cli: SupportedTerminalCLI) {
+    self.processIdentifier = processIdentifier
+    self.cli = cli
+  }
+}
+
+/// The outcome of one process sweep.
+///
+/// `.unavailable` is NOT `.available([])`. An unreadable process list is
+/// indistinguishable from an empty one at the point of decision, so both must
+/// veto — but they are different facts, and only a typed result stops a caller
+/// erasing the difference with `?? []`.
+package enum TerminalProcessScan: Equatable, Sendable {
+  case unavailable
+  case available([TerminalProcessSnapshot])
+}
+
+/// What one process looks like to the veto. Plain values only: no ports, no
+/// handles, nothing that keeps another process alive or escapes Services.
+package struct TerminalProcessSnapshot: Equatable, Sendable {
+  package let processIdentifier: pid_t
+  package let executablePath: String
+  package let arguments: [String]
+  package let termProgram: String?
+  /// Whether the process holds a controlling terminal.
+  ///
+  /// The single condition that separates a terminal program from an app: on the
+  /// founder's machine 63 of 732 processes hold one, and every one of the 35
+  /// name-lookalikes is in the other 669.
+  package let isAttachedToTerminal: Bool
+
+  package init(
+    processIdentifier: pid_t, executablePath: String, arguments: [String], termProgram: String?,
+    isAttachedToTerminal: Bool
+  ) {
+    self.processIdentifier = processIdentifier
+    self.executablePath = executablePath
+    self.arguments = arguments
+    self.termProgram = termProgram
+    self.isAttachedToTerminal = isAttachedToTerminal
+  }
+}
+
+// MARK: - Scanner
+
+/// Gate 1's evidence source: which supported CLIs are running, and under which
+/// terminal app.
+///
+/// Gate 1 is a VETO, not a tab selector (founder 2026-07-28). It answers only
+/// "is at least one supported CLI running under this terminal app"; the focused
+/// tab's own screen decides which tool it is and where the line is. The
+/// superseded design tried to pick the tab by matching working directories, and
+/// measurement killed it: a terminal exposes only one directory per tab, so five
+/// tabs in one project all report the same one, and the strict rule REFUSED on
+/// the founder's own main project. No directory is read here, deliberately.
+package enum TerminalProcessScanner {
+
+  // MARK: Identity
+
+  /// The command name each supported CLI runs under.
+  static let commandNames: [String: SupportedTerminalCLI] = [
+    "claude": .claudeCode,
+    "codex": .codex,
+    "gemini": .geminiCLI,
+  ]
+
+  /// Script runtimes that host a CLI, so that `argv[1]` is the real program.
+  ///
+  /// This is not a guess about installers — it is how a shebang script runs at
+  /// all. Without it, `vim codex` would be read as Codex, because the file being
+  /// edited sits in `argv[1]`.
+  static let scriptRuntimes: Set<String> = ["node", "bun", "deno"]
+
+  /// Identify a process by the name it runs under.
+  ///
+  /// **Only ever applied to a process that holds a controlling terminal.** That
+  /// precondition is what makes a name usable at all. Measured 2026-07-28: the
+  /// substrings `codex`/`gemini` matched **35 unrelated processes** on the
+  /// founder's machine — every ChatGPT desktop helper, `Codex (Renderer)`,
+  /// `codex_chronicle`, and a real executable literally named `codex` inside
+  /// `ChatGPT.app` — and **every one of them is a GUI process with no terminal**.
+  /// The terminal precondition eliminates the whole class structurally, rather
+  /// than by a list of exceptions that would need extending forever.
+  ///
+  /// This REPLACED an install-path matcher (founder decision 2026-07-28). That
+  /// matcher was measured to miss the Homebrew Codex installed on the founder's
+  /// own machine, because it predicted where vendors install rather than asking
+  /// what is running. Head-to-head on the same live processes: both approaches
+  /// rejected all 35 impostors; only this one found Homebrew Codex.
+  ///
+  /// Known and accepted (founder: "we can't deal with every edge case — if
+  /// people are doing these fooling things and complain we can fix for it"): a
+  /// file deliberately named `codex` and run in a terminal is read as Codex.
+  /// That requires a user to mislead their own machine, there is no attacker,
+  /// and the worst outcome is a wrong space or capital in one sentence.
+  static func identify(executablePath: String, arguments: [String]) -> SupportedTerminalCLI? {
+    func commandName(_ path: String) -> String {
+      var name = (path as NSString).lastPathComponent.lowercased()
+      if name.hasSuffix(".js") { name = String(name.dropLast(3)) }
+      return name
+    }
+
+    // Claude Code's executable is named after its VERSION
+    // (`…/claude/versions/2.1.220`), so `argv[0]` is the only place its name
+    // appears. Codex installed through Homebrew is the opposite: a real binary
+    // named `codex`. Both shapes are live on the founder's machine.
+    let executableName = commandName(executablePath)
+    if let cli = commandNames[executableName] { return cli }
+    if let first = arguments.first, let cli = commandNames[commandName(first)] { return cli }
+
+    // A script runtime hosts the real program in `argv[1]`.
+    guard scriptRuntimes.contains(executableName) else { return nil }
+    guard let hosted = arguments.dropFirst().first, hosted.hasPrefix("/") else { return nil }
+    return commandNames[commandName(hosted)]
+  }
+
+  // MARK: The veto
+
+  /// Every supported CLI in `snapshots` that reports running under `surface`.
+  ///
+  /// `TERM_PROGRAM` is INHERITED down process trees, so it is a HEURISTIC for
+  /// terminal ownership, not proof of it. Measured 2026-07-28: an iTerm2 process
+  /// launched from a Ghostty shell still reported `ghostty`.
+  ///
+  /// The honest statement of the limit — an earlier comment here called the
+  /// inheritance "benign", which grounded review correctly rejected: a process
+  /// can report a terminal it is not running under. `TERM_PROGRAM=ghostty claude`
+  /// run from Terminal.app, or a tmux server started under one terminal and
+  /// attached from another, both attribute a CLI to the wrong app. Consequences
+  /// are bounded by what this gate authorises: it can only ever let the veto
+  /// PASS when it should have refused, never the reverse, and a passing veto
+  /// still only permits Gate 2 to read the focused tab's own screen. The cost of
+  /// being wrong here is the accepted class — a wrong space, a wrong capital, or
+  /// one dropped word — never a wrong destination.
+  ///
+  /// A CLI reporting no `TERM_PROGRAM` is attributed to no terminal.
+  static func supportedCLIs(
+    in snapshots: [TerminalProcessSnapshot],
+    hostedBy surface: TerminalSurface
+  ) -> [RunningTerminalCLI] {
+    let expected = surface.termProgramValue
+    var found: [RunningTerminalCLI] = []
+    for snapshot in snapshots {
+      // The terminal precondition comes FIRST and is load-bearing: it is what
+      // makes matching by name safe. Measured — all 35 name-lookalikes are GUI
+      // processes with no controlling terminal.
+      guard snapshot.isAttachedToTerminal else { continue }
+      guard snapshot.termProgram == expected else { continue }
+      guard
+        let cli = identify(
+          executablePath: snapshot.executablePath, arguments: snapshot.arguments)
+      else { continue }
+      found.append(RunningTerminalCLI(processIdentifier: snapshot.processIdentifier, cli: cli))
+    }
+    return found
+  }
+
+  // MARK: Live capture
+
+  /// Snapshot every readable process.
+  ///
+  /// The result is TYPED rather than optional so that "the process list could
+  /// not be read" cannot be collapsed into "nothing is running" by a caller
+  /// writing `?? []`. Both outcomes veto, but they are different facts and the
+  /// telemetry distinguishes them; an optional invites erasing that at the one
+  /// call site where it matters.
+  ///
+  /// No pre-filter by executable name. Measured cost for the whole sweep is
+  /// mean 3 ms / p95 7 ms against a 100 ms budget (710 processes, hardened
+  /// runtime, Developer-ID signed), so filtering would buy nothing while adding
+  /// a hand-authored guess about how CLIs are launched — the guess that would
+  /// silently drop an unusual install.
+  static func liveSnapshot() -> TerminalProcessScan {
+    guard let pids = allProcessIdentifiers() else { return .unavailable }
+    var snapshots: [TerminalProcessSnapshot] = []
+    snapshots.reserveCapacity(pids.count)
+    for pid in pids {
+      guard let path = executablePath(of: pid) else { continue }
+      // Reading another user's or root's process is refused by the kernel for
+      // roughly a third of PIDs. That is expected and is not an error.
+      guard let (arguments, environment) = argumentsAndEnvironment(of: pid) else { continue }
+      snapshots.append(
+        TerminalProcessSnapshot(
+          processIdentifier: pid,
+          executablePath: path,
+          arguments: arguments,
+          termProgram: environment["TERM_PROGRAM"],
+          isAttachedToTerminal: holdsControllingTerminal(pid)))
+    }
+    return .available(snapshots)
+  }
+
+  /// Whether `pid` holds a controlling terminal.
+  ///
+  /// Fails CLOSED: an unreadable process reports false, so it cannot license a
+  /// read. Verified with a two-way control — the same `/bin/sleep` binary
+  /// reports true under a terminal and false outside one, so nothing but the
+  /// terminal explains the difference.
+  static func holdsControllingTerminal(_ pid: pid_t) -> Bool {
+    var info = proc_bsdinfo()
+    let size = Int32(MemoryLayout<proc_bsdinfo>.size)
+    guard proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, size) == size else { return false }
+    // NODEV, the "no controlling terminal" sentinel, is all-bits-set.
+    return Int32(bitPattern: info.e_tdev) != -1
+  }
+
+  // MARK: Darwin plumbing
+
+  private static func allProcessIdentifiers() -> [pid_t]? {
+    let needed = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
+    guard needed > 0 else { return nil }
+    // Head-room: the list can grow between sizing and reading.
+    let capacity = Int(needed) / MemoryLayout<pid_t>.size + 64
+    var buffer = [pid_t](repeating: 0, count: capacity)
+    let written = buffer.withUnsafeMutableBufferPointer { pointer -> Int32 in
+      guard let base = pointer.baseAddress else { return 0 }
+      return proc_listpids(
+        UInt32(PROC_ALL_PIDS), 0, base, Int32(pointer.count * MemoryLayout<pid_t>.size))
+    }
+    guard written > 0 else { return nil }
+    let count = min(Int(written) / MemoryLayout<pid_t>.size, capacity)
+    return Array(buffer.prefix(count)).filter { $0 > 0 }
+  }
+
+  /// Read a process's executable path with a BOUNDED decode.
+  ///
+  /// `String(cString:)` would trust that the call wrote a terminator inside the
+  /// buffer. That is normally guaranteed; decoding against the reported length
+  /// costs nothing and removes the trust.
+  private static func executablePath(of pid: pid_t) -> String? {
+    // `PROC_PIDPATHINFO_MAXSIZE` is a C macro and is not imported into Swift;
+    // it is defined as 4 * MAXPATHLEN, which is what this reproduces.
+    var buffer = [CChar](repeating: 0, count: Int(4 * MAXPATHLEN))
+    let written = buffer.withUnsafeMutableBytes { bytes -> Int32 in
+      guard let base = bytes.baseAddress else { return 0 }
+      return proc_pidpath(pid, base, UInt32(bytes.count))
+    }
+    guard written > 0, Int(written) <= buffer.count else { return nil }
+    let bytes = buffer[..<Int(written)].map { UInt8(bitPattern: $0) }
+    guard let path = String(bytes: bytes, encoding: .utf8), !path.isEmpty else { return nil }
+    return path
+  }
+
+  /// Read `KERN_PROCARGS2` and split it into arguments and environment.
+  ///
+  /// The kernel hands back a packed blob laid out as `argc`, the executable
+  /// path, null padding, `argc` argument strings, then environment strings.
+  /// Every step is bounds-checked against the returned size: this is another
+  /// process's memory image, and a malformed or truncated blob must fail
+  /// closed rather than read past the end.
+  static func argumentsAndEnvironment(of pid: pid_t) -> (
+    arguments: [String], environment: [String: String]
+  )? {
+    var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+    var size = 0
+    guard sysctl(&mib, 3, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+
+    var raw = [UInt8](repeating: 0, count: size)
+    let readOK = raw.withUnsafeMutableBufferPointer { pointer -> Bool in
+      guard let base = pointer.baseAddress else { return false }
+      return sysctl(&mib, 3, base, &size, nil, 0) == 0
+    }
+    guard readOK, size > 0, size <= raw.count else { return nil }
+    return parseProcArgs(Array(raw.prefix(size)))
+  }
+
+  /// Pure blob parser, split out so the layout can be tested without a process.
+  ///
+  /// FAILS CLOSED on anything malformed, and that is the whole contract. An
+  /// earlier version returned partial success for a truncated blob — a short
+  /// argument list and an empty environment — which is the worst possible
+  /// outcome here: an absent `TERM_PROGRAM` is indistinguishable from a genuine
+  /// one, so a half-read process would be quietly mis-attributed rather than
+  /// skipped. Grounded review caught that the tests had frozen the wrong
+  /// behaviour.
+  static func parseProcArgs(_ raw: [UInt8]) -> (
+    arguments: [String], environment: [String: String]
+  )? {
+    let headerSize = MemoryLayout<Int32>.size
+    guard raw.count > headerSize else { return nil }
+    let argumentCount = raw.withUnsafeBytes { $0.loadUnaligned(as: Int32.self) }
+    // argc of zero means the blob carries no argv at all, which no live process
+    // produces; treat it as malformed rather than as an empty success.
+    guard argumentCount > 0, argumentCount < 4096 else { return nil }
+
+    var index = headerSize
+    // The executable path must be present AND terminated.
+    guard let executableEnd = raw[index...].firstIndex(of: 0), executableEnd > index else {
+      return nil
+    }
+    index = executableEnd
+    while index < raw.count, raw[index] == 0 { index += 1 }
+
+    func nextString() -> String? {
+      guard index < raw.count, let end = raw[index...].firstIndex(of: 0) else { return nil }
+      guard let value = String(bytes: raw[index..<end], encoding: .utf8) else { return nil }
+      index = end + 1
+      return value
+    }
+
+    var arguments: [String] = []
+    arguments.reserveCapacity(Int(argumentCount))
+    for _ in 0..<Int(argumentCount) {
+      guard let argument = nextString() else { return nil }
+      arguments.append(argument)
+    }
+
+    // The environment runs to the end of the blob. Every entry must be a
+    // terminated, decodable string; a trailing empty entry ends it early.
+    var environment: [String: String] = [:]
+    while index < raw.count {
+      guard let entry = nextString() else { return nil }
+      if entry.isEmpty { break }
+      guard let separator = entry.firstIndex(of: "="), separator != entry.startIndex else {
+        continue
+      }
+      environment[String(entry[entry.startIndex..<separator])] =
+        String(entry[entry.index(after: separator)...])
+    }
+    return (arguments, environment)
+  }
+}

--- a/Sources/EnviousWisprServices/TerminalProcessScanner.swift
+++ b/Sources/EnviousWisprServices/TerminalProcessScanner.swift
@@ -251,11 +251,26 @@ package enum TerminalProcessScanner {
   /// reports true under a terminal and false outside one, so nothing but the
   /// terminal explains the difference.
   static func holdsControllingTerminal(_ pid: pid_t) -> Bool {
-    var info = proc_bsdinfo()
-    let size = Int32(MemoryLayout<proc_bsdinfo>.size)
-    guard proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, size) == size else { return false }
+    guard let info = bsdInfo(pid) else { return false }
     // NODEV, the "no controlling terminal" sentinel, is all-bits-set.
     return Int32(bitPattern: info.e_tdev) != -1
+  }
+
+  /// When `pid` started, in seconds since the epoch.
+  ///
+  /// Pairs with the PID to make a key that survives PID REUSE. macOS recycles
+  /// PIDs, so a latch keyed on the number alone would keep punishing an
+  /// unrelated process that happened to inherit it.
+  package static func startTime(of pid: pid_t) -> UInt64? {
+    guard let info = bsdInfo(pid) else { return nil }
+    return UInt64(info.pbi_start_tvsec)
+  }
+
+  private static func bsdInfo(_ pid: pid_t) -> proc_bsdinfo? {
+    var info = proc_bsdinfo()
+    let size = Int32(MemoryLayout<proc_bsdinfo>.size)
+    guard proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, size) == size else { return nil }
+    return info
   }
 
   // MARK: Darwin plumbing

--- a/Sources/EnviousWisprServices/TerminalScreenParser.swift
+++ b/Sources/EnviousWisprServices/TerminalScreenParser.swift
@@ -58,9 +58,17 @@ package enum TerminalScreenParser {
   /// box. Requires four to avoid matching a short `---` in prose.
   static func boundaryClass(of row: Substring) -> BoundaryClass? {
     let trimmed = row.trimmingCharacters(in: .whitespaces)
-    guard trimmed.count >= 4 else { return nil }
-    if trimmed.allSatisfy({ lightBoxGlyphs.contains($0) }) { return .light }
-    if trimmed.allSatisfy({ blockBoxGlyphs.contains($0) }) { return .block }
+    // ONE repeated glyph, which is what the rule always claimed and did not
+    // enforce: a mixture such as `─━═─` was accepted, so ASCII art or another
+    // tool's output could be misread as a box.
+    guard
+      trimmed.count >= 4,
+      let glyph = trimmed.first,
+      trimmed.dropFirst().allSatisfy({ $0 == glyph })
+    else { return nil }
+
+    if lightBoxGlyphs.contains(glyph) { return .light }
+    if blockBoxGlyphs.contains(glyph) { return .block }
     return nil
   }
 
@@ -167,6 +175,18 @@ package enum TerminalScreenParser {
 
     let cli: SupportedTerminalCLI = closing.1 == .block ? .geminiCLI : .claudeCode
     let marker = closing.1 == .block ? geminiMarker : claudeMarker
+    // The row must carry its tool's marker.
+    //
+    // Grounded review caught a real error here, and the error was in my
+    // reasoning rather than the code: because screen matching is spoofable AS A
+    // CLASS, I concluded it was not worth refusing a measured INSTANCE. Wrong.
+    // The measured spoof — a file of box-drawing rows shown in vim or less —
+    // carries NO marker, while both real input rows always do, so this refuses
+    // it at no cost. A faithful spoof that reproduces the marker still passes,
+    // which is exactly why Gate 1 remains the authority; closing an instance is
+    // not a claim to have closed the class.
+    guard openingCharacter(of: row) == marker else { return nil }
+
     let line = stripLeadingMarker(row, marker)
     // An EMPTY box refuses. The prototype's exact failure was reading an empty
     // box back as the hint text printed below it, which would delete words

--- a/Sources/EnviousWisprServices/TerminalScreenParser.swift
+++ b/Sources/EnviousWisprServices/TerminalScreenParser.swift
@@ -108,6 +108,25 @@ package enum TerminalScreenParser {
     return String(body).replacingOccurrences(of: "\u{00A0}", with: " ")
   }
 
+  /// Whether a LIVE shell prompt sits below `index`, which proves the match was
+  /// scrollback: the user ran a full-screen tool, quit it, and is now at a shell.
+  ///
+  /// CLASS FIX, whole-diff review r2. This check existed only on the boxed path,
+  /// so an old Codex row with a shell prompt beneath it still matched — the
+  /// prompt merely counted as one of the two permitted status rows. Both layout
+  /// paths now share this one owner, because "which layouts apply the staleness
+  /// check" is exactly the kind of question that drifts when each path answers
+  /// it separately.
+  static func aLivePromptSits(below index: Int, in rows: [Substring]) -> Bool {
+    guard index + 1 < rows.count else { return false }
+    for row in rows[(index + 1)...] where !isBlank(row) {
+      if let opener = openingCharacter(of: row), shellPromptMarkers.contains(opener) {
+        return true
+      }
+    }
+    return false
+  }
+
   // MARK: - Entry point
 
   /// Locate the input line, or nil to refuse.
@@ -140,6 +159,9 @@ package enum TerminalScreenParser {
 
     let populatedBelow = rows[(index + 1)...].filter { !isBlank($0) }.count
     guard populatedBelow <= 2 else { return nil }
+    // Same staleness rule as the boxed layouts: a live shell prompt below means
+    // Codex has exited and this row is history.
+    guard !aLivePromptSits(below: index, in: rows) else { return nil }
 
     let line = stripLeadingMarker(rows[index], codexMarker)
     guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
@@ -165,13 +187,7 @@ package enum TerminalScreenParser {
     // rows reconstructs different text — a soft wrap can fall mid-word.
     guard body.count == 1, let row = body.first else { return nil }
 
-    // A LIVE shell prompt below the box proves the box is scrollback: the user
-    // ran a full-screen tool earlier, quit it, and is now at a shell.
-    for below in rows[(closing.0 + 1)...] where !isBlank(below) {
-      if let opener = openingCharacter(of: below), shellPromptMarkers.contains(opener) {
-        return nil
-      }
-    }
+    guard !aLivePromptSits(below: closing.0, in: rows) else { return nil }
 
     let cli: SupportedTerminalCLI = closing.1 == .block ? .geminiCLI : .claudeCode
     let marker = closing.1 == .block ? geminiMarker : claudeMarker

--- a/Sources/EnviousWisprServices/TerminalScreenParser.swift
+++ b/Sources/EnviousWisprServices/TerminalScreenParser.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Gate 2: locate the input line inside a terminal's rendered screen.
+///
+/// **This never decides WHETHER to act.** Screen content is spoofable and that is
+/// proven, not argued: in live measurement a printed `❯` line, and a file
+/// containing two box-drawing rows shown in vim and in less, were BOTH read as
+/// live input boxes. Guards close instances; the class stays open, because
+/// anything drawn on a screen looks like an input box to a screen reader. Gate 1
+/// — is a supported CLI actually running — is what authorises a read. This type
+/// only answers "where is the line", and only after that.
+///
+/// Ported from the parked Level 3 prototype rather than reinvented
+/// (`research/seam-joining/code/join_hotkey.py`), which drove ten dictated chunks
+/// through Ghostty and paid for every rule here.
+package enum TerminalScreenParser {
+
+  /// Where the input line is, and which tool drew it.
+  package struct Located: Equatable, Sendable {
+    package let cli: SupportedTerminalCLI
+    package let inputLine: String
+
+    package init(cli: SupportedTerminalCLI, inputLine: String) {
+      self.cli = cli
+      self.inputLine = inputLine
+    }
+  }
+
+  // MARK: - Glyphs
+
+  /// Box rules drawn by Claude Code. Matched as a CLASS, never one codepoint.
+  static let lightBoxGlyphs: Set<Character> = ["\u{2500}", "\u{2501}", "\u{2550}"]
+  /// Half-block rules drawn by Gemini CLI.
+  static let blockBoxGlyphs: Set<Character> = ["\u{2584}", "\u{2580}", "\u{2588}"]
+
+  /// Codex opens its input row with this and draws no box at all.
+  static let codexMarker: Character = "\u{203A}"
+  /// Claude Code's in-box marker.
+  static let claudeMarker: Character = "\u{276F}"
+  /// Gemini's in-box marker.
+  ///
+  /// A bare `>` is ordinary in mail quoting, diffs and shell redirection, so it
+  /// is STRIPPED once the box has already identified the row, and NEVER searched
+  /// for. Searching by it would anchor on any quoted line on screen.
+  static let geminiMarker: Character = ">"
+
+  /// Markers that indicate a LIVE shell prompt.
+  ///
+  /// Used defensively only — never to locate input, because bare shell is
+  /// deliberately unsupported (prompts are user-customisable, so there is no set
+  /// to enumerate). A prompt appearing BELOW a matched box proves the box was
+  /// scrollback rather than the live input.
+  static let shellPromptMarkers: Set<Character> = ["\u{276F}", "\u{279C}", "$", "%", "#"]
+
+  // MARK: - Row helpers
+
+  /// Whether a row is one repeated box glyph — the rule above or below an input
+  /// box. Requires four to avoid matching a short `---` in prose.
+  static func boundaryClass(of row: Substring) -> BoundaryClass? {
+    let trimmed = row.trimmingCharacters(in: .whitespaces)
+    guard trimmed.count >= 4 else { return nil }
+    if trimmed.allSatisfy({ lightBoxGlyphs.contains($0) }) { return .light }
+    if trimmed.allSatisfy({ blockBoxGlyphs.contains($0) }) { return .block }
+    return nil
+  }
+
+  package enum BoundaryClass: Equatable, Sendable {
+    case light
+    case block
+  }
+
+  /// A row carrying nothing a user typed. `CharacterSet.whitespaces` includes
+  /// the non-breaking space a box pads with, so padding counts as blank.
+  static func isBlank(_ row: Substring) -> Bool {
+    row.trimmingCharacters(in: .whitespaces).isEmpty
+  }
+
+  /// The first non-whitespace character of a row, treating the box's
+  /// non-breaking padding as whitespace.
+  static func openingCharacter(of row: Substring) -> Character? {
+    row.first { !$0.isWhitespace && $0 != "\u{00A0}" }
+  }
+
+  /// Strip one leading marker and the single space that separates it from the
+  /// user's text.
+  ///
+  /// Trailing whitespace SURVIVES, deliberately: every dictation ends with a
+  /// space, so the buffer is one character longer than the visible sentence, and
+  /// dropping it welds the next word onto the last.
+  static func stripLeadingMarker(_ row: Substring, _ marker: Character) -> String {
+    var body = Substring(row.drop(while: { $0.isWhitespace || $0 == "\u{00A0}" }))
+    if body.first == marker {
+      body = body.dropFirst()
+      if let next = body.first, next == " " || next == "\u{00A0}" {
+        body = body.dropFirst()
+      }
+    }
+    // NBSP is what a box pads with: whitespace to a human, a distinct character
+    // to everything else.
+    return String(body).replacingOccurrences(of: "\u{00A0}", with: " ")
+  }
+
+  // MARK: - Entry point
+
+  /// Locate the input line, or nil to refuse.
+  ///
+  /// Refusals ARE the feature. A wrapped box, an empty box, a stale box, an
+  /// unrecognised layout and a bare shell all return nil, and the user gets
+  /// today's behaviour unchanged.
+  package static func locate(inScreenTail tail: String) -> Located? {
+    let rows = tail.split(separator: "\n", omittingEmptySubsequences: false)
+
+    // Codex first: it draws NO box, so the box search cannot find it, and its
+    // status bar sits below the input. Anchoring on "the last non-empty row"
+    // was measured to return `weekly 63% left` from that status bar.
+    if let located = locateCodex(rows) { return located }
+    return locateBoxed(rows)
+  }
+
+  // MARK: - Codex
+
+  /// Codex: the last row that OPENS with `›`, with at most two populated rows
+  /// below it (its status bar).
+  ///
+  /// "Opens" is load-bearing. A row that merely CONTAINS the marker — a footer
+  /// reading `Press › to continue` — is not input, and requiring the marker to
+  /// start the row is what separates them.
+  static func locateCodex(_ rows: [Substring]) -> Located? {
+    guard
+      let index = rows.indices.last(where: { openingCharacter(of: rows[$0]) == codexMarker })
+    else { return nil }
+
+    let populatedBelow = rows[(index + 1)...].filter { !isBlank($0) }.count
+    guard populatedBelow <= 2 else { return nil }
+
+    let line = stripLeadingMarker(rows[index], codexMarker)
+    guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+    return Located(cli: .codex, inputLine: line)
+  }
+
+  // MARK: - Boxed layouts
+
+  /// Claude Code and Gemini both draw a box; the RULE GLYPH tells them apart.
+  static func locateBoxed(_ rows: [Substring]) -> Located? {
+    let boundaries = rows.indices.compactMap { index -> (Int, BoundaryClass)? in
+      boundaryClass(of: rows[index]).map { (index, $0) }
+    }
+    guard boundaries.count >= 2 else { return nil }
+
+    let closing = boundaries[boundaries.count - 1]
+    let opening = boundaries[boundaries.count - 2]
+    // Both rules must be the same kind of box.
+    guard opening.1 == closing.1, closing.0 > opening.0 + 1 else { return nil }
+
+    let body = rows[(opening.0 + 1)..<closing.0].filter { !isBlank($0) }
+    // More than one populated row means the input wrapped, and joining screen
+    // rows reconstructs different text — a soft wrap can fall mid-word.
+    guard body.count == 1, let row = body.first else { return nil }
+
+    // A LIVE shell prompt below the box proves the box is scrollback: the user
+    // ran a full-screen tool earlier, quit it, and is now at a shell.
+    for below in rows[(closing.0 + 1)...] where !isBlank(below) {
+      if let opener = openingCharacter(of: below), shellPromptMarkers.contains(opener) {
+        return nil
+      }
+    }
+
+    let cli: SupportedTerminalCLI = closing.1 == .block ? .geminiCLI : .claudeCode
+    let marker = closing.1 == .block ? geminiMarker : claudeMarker
+    let line = stripLeadingMarker(row, marker)
+    // An EMPTY box refuses. The prototype's exact failure was reading an empty
+    // box back as the hint text printed below it, which would delete words
+    // nobody typed.
+    guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+    return Located(cli: cli, inputLine: line)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -543,7 +543,7 @@ import Testing
           submittedPayload: .repaired)
       },
       registry: registry,
-      readCaretContext: { _, _ in Self.midSentenceCaret },
+      readCaretContext: { _, _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let processed = try await wiring.processText("Review this before the meeting") {}
@@ -572,7 +572,7 @@ import Testing
           submittedPayload: .legacy)
       },
       registry: registry,
-      readCaretContext: { _, _ in Self.midSentenceCaret },
+      readCaretContext: { _, _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let processed = try await wiring.processText("Review this before the meeting") {}
@@ -768,7 +768,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in Self.midSentenceCaret },
+      readCaretContext: { _, _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let processed = try await wiring.processText("Review this before the meeting") {}
@@ -809,7 +809,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in
+      readCaretContext: { _, _, _ in
         PasteService.CaretContext(
           leftWindow: "Ich gehe zum ", rightWindow: "", selectionLocation: 13, selectionLength: 0)
       },
@@ -849,7 +849,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in
+      readCaretContext: { _, _, _ in
         PasteService.CaretContext(
           leftWindow: "I want to go to the ", rightWindow: "", selectionLocation: 20,
           selectionLength: 0)
@@ -885,7 +885,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in
+      readCaretContext: { _, _, _ in
         PasteService.CaretContext(
           leftWindow: "\u{4ECA}\u{65E5}", rightWindow: "", selectionLocation: 2,
           selectionLength: 0)
@@ -914,7 +914,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in nil })
+      readCaretContext: { _, _, _ in nil })
 
     let processed = try await wiring.processText(
       "The store is closed today and I will go tomorrow instead"
@@ -939,7 +939,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in Self.midSentenceCaret },
+      readCaretContext: { _, _, _ in Self.midSentenceCaret },
       adapter: Self.transcribedEngine(language: "en"))
 
     let processed = try await wiring.processText(
@@ -979,7 +979,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in
+      readCaretContext: { _, _, _ in
         reads.count += 1
         return Self.midSentenceCaret
       })
@@ -1019,7 +1019,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in nil })
+      readCaretContext: { _, _, _ in nil })
 
     let outcome = await wiring.deliver("Review this before the meeting")
 
@@ -1048,7 +1048,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in Self.midSentenceCaret },
+      readCaretContext: { _, _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let first = try await wiring.processText("Review this before the meeting") {}
@@ -1085,7 +1085,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in midWord })
+      readCaretContext: { _, _, _ in midWord })
 
     _ = await wiring.deliver("Store today")
 
@@ -1110,7 +1110,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in Self.midSentenceCaret },
+      readCaretContext: { _, _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     _ = await wiring.deliver("Review this before the meeting ")
@@ -1135,7 +1135,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in Self.midSentenceCaret },
+      readCaretContext: { _, _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     // The vocabulary is EMPTY while this dictation is processed, so nothing
@@ -1173,7 +1173,7 @@ import Testing
         secondCaptured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _, _ in Self.midSentenceCaret },
+      readCaretContext: { _, _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let secondProcessed = try await secondWiring.processText("Review this before the meeting") {}
@@ -1210,7 +1210,7 @@ import Testing
     currentTime: @escaping @MainActor () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
     // Defaults to UNREADABLE, so every pre-existing test in this suite keeps
     // exactly today's behaviour and only tests that opt in see a candidate.
-    readCaretContext: @escaping @MainActor (AXUIElement, TerminalResolutionBudget) -> PasteService.CaretContext? = { _, _ in
+    readCaretContext: @escaping @MainActor (AXUIElement, TerminalResolutionBudget, ((TerminalContextRefusal) -> Void)?) -> PasteService.CaretContext? = { _, _, _ in
       nil
     },
     // Delivery only ever runs after a transcription produced the text being

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -543,7 +543,7 @@ import Testing
           submittedPayload: .repaired)
       },
       registry: registry,
-      readCaretContext: { _ in Self.midSentenceCaret },
+      readCaretContext: { _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let processed = try await wiring.processText("Review this before the meeting") {}
@@ -572,7 +572,7 @@ import Testing
           submittedPayload: .legacy)
       },
       registry: registry,
-      readCaretContext: { _ in Self.midSentenceCaret },
+      readCaretContext: { _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let processed = try await wiring.processText("Review this before the meeting") {}
@@ -768,7 +768,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in Self.midSentenceCaret },
+      readCaretContext: { _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let processed = try await wiring.processText("Review this before the meeting") {}
@@ -809,7 +809,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in
+      readCaretContext: { _, _ in
         PasteService.CaretContext(
           leftWindow: "Ich gehe zum ", rightWindow: "", selectionLocation: 13, selectionLength: 0)
       },
@@ -849,7 +849,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in
+      readCaretContext: { _, _ in
         PasteService.CaretContext(
           leftWindow: "I want to go to the ", rightWindow: "", selectionLocation: 20,
           selectionLength: 0)
@@ -885,7 +885,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in
+      readCaretContext: { _, _ in
         PasteService.CaretContext(
           leftWindow: "\u{4ECA}\u{65E5}", rightWindow: "", selectionLocation: 2,
           selectionLength: 0)
@@ -914,7 +914,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in nil })
+      readCaretContext: { _, _ in nil })
 
     let processed = try await wiring.processText(
       "The store is closed today and I will go tomorrow instead"
@@ -939,7 +939,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in Self.midSentenceCaret },
+      readCaretContext: { _, _ in Self.midSentenceCaret },
       adapter: Self.transcribedEngine(language: "en"))
 
     let processed = try await wiring.processText(
@@ -979,7 +979,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in
+      readCaretContext: { _, _ in
         reads.count += 1
         return Self.midSentenceCaret
       })
@@ -1019,7 +1019,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in nil })
+      readCaretContext: { _, _ in nil })
 
     let outcome = await wiring.deliver("Review this before the meeting")
 
@@ -1048,7 +1048,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in Self.midSentenceCaret },
+      readCaretContext: { _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let first = try await wiring.processText("Review this before the meeting") {}
@@ -1085,7 +1085,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in midWord })
+      readCaretContext: { _, _ in midWord })
 
     _ = await wiring.deliver("Store today")
 
@@ -1110,7 +1110,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in Self.midSentenceCaret },
+      readCaretContext: { _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     _ = await wiring.deliver("Review this before the meeting ")
@@ -1135,7 +1135,7 @@ import Testing
         captured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in Self.midSentenceCaret },
+      readCaretContext: { _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     // The vocabulary is EMPTY while this dictation is processed, so nothing
@@ -1173,7 +1173,7 @@ import Testing
         secondCaptured.requests.append(request)
         return Self.deliveredResult
       },
-      readCaretContext: { _ in Self.midSentenceCaret },
+      readCaretContext: { _, _ in Self.midSentenceCaret },
       englishWordOracle: { Self.testOracle })
 
     let secondProcessed = try await secondWiring.processText("Review this before the meeting") {}
@@ -1210,7 +1210,7 @@ import Testing
     currentTime: @escaping @MainActor () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
     // Defaults to UNREADABLE, so every pre-existing test in this suite keeps
     // exactly today's behaviour and only tests that opt in see a candidate.
-    readCaretContext: @escaping @MainActor (AXUIElement) -> PasteService.CaretContext? = { _ in
+    readCaretContext: @escaping @MainActor (AXUIElement, TerminalResolutionBudget) -> PasteService.CaretContext? = { _, _ in
       nil
     },
     // Delivery only ever runs after a transcription produced the text being

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -280,6 +280,63 @@ struct TerminalContextResolverTests {
     #expect(!breaker.isOpen(for: 900))
   }
 
+  @Test("A read that overruns the budget TRIPS the breaker, in production code")
+  func overrunTripsTheBreaker() {
+    // Whole-diff review found the breaker was never armed: it was tested,
+    // documented, and inert, so a wedged terminal would have repeated its delay
+    // on every dictation forever. Tests that trip it by hand cannot catch that.
+    // This drives the PRODUCT path and asserts the breaker ends up open.
+    let clock = TestClock()
+    clock.perCallCost = 0.400  // one wedged accessibility call
+    let breaker = TerminalCircuitBreaker()
+    let budget = TerminalResolutionBudget(total: 0.100)
+
+    let result = resolve(dependencies(clock: clock), budget: budget, breaker: breaker, pid: 900)
+    #expect(result == .refused(.deadline))
+    #expect(breaker.isOpen(for: 900), "an overrun must arm the breaker, not merely refuse once")
+  }
+
+  @Test("Evidence that arrived AFTER the deadline is discarded, not used")
+  func overspentEvidenceIsRejected() {
+    // The read can complete perfectly and still be too late. Accepting it would
+    // make the promised bound meaningless, because the user already waited.
+    let clock = TestClock()
+    clock.perCallCost = 0.400
+    let result = resolve(
+      dependencies(clock: clock), budget: .init(total: 0.100), breaker: .init(), pid: 900)
+    #expect(result.evidence == nil)
+  }
+
+  @Test("The NEXT dictation after an overrun starts no read at all")
+  func breakerStopsTheFollowingDelivery() {
+    let clock = TestClock()
+    clock.perCallCost = 0.400
+    let breaker = TerminalCircuitBreaker()
+    _ = resolve(dependencies(clock: clock), budget: .init(total: 0.100), breaker: breaker, pid: 900)
+
+    // A fresh delivery: fresh budget, healthy clock, nothing wedged.
+    let scanned = Flag()
+    let healthy = TerminalContextResolver.Dependencies(
+      bundleIdentifier: { "com.mitchellh.ghostty" },
+      scanProcesses: {
+        scanned.raise()
+        return Self.runningClaude()
+      },
+      readScreenTail: { Self.claudeScreen })
+    #expect(
+      resolve(healthy, budget: .init(), breaker: breaker, pid: 900) == .refused(.breakerOpen))
+    #expect(!scanned.wasRaised, "the wedged terminal must not be touched again")
+  }
+
+  @Test("A healthy resolution leaves the breaker closed")
+  func healthyResolutionDoesNotTrip() {
+    // The two-way control: without this, a breaker that tripped on EVERY
+    // resolution would pass the tests above and disable the feature entirely.
+    let breaker = TerminalCircuitBreaker()
+    #expect(resolve(dependencies(), breaker: breaker, pid: 900).evidence != nil)
+    #expect(!breaker.isOpen(for: 900))
+  }
+
   // MARK: - Revalidation
 
   @Test("Unchanged evidence revalidates")

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -157,21 +157,32 @@ struct TerminalContextResolverTests {
       resolve(dependencies(screen: "just output\nand more")) == .refused(.screenRefused))
   }
 
-  @Test("The two live spoofs still need Gate 1 — the screen alone cannot refuse them")
-  func spoofRequiresTheVeto() {
-    // A file drawing two box rules, shown in a pager. Gate 2 matches it; Gate 1
-    // is what refuses, and only when nothing supported is running.
-    let spoof = """
+  @Test("A markerless box-drawn file refuses at Gate 2, before the veto matters")
+  func markerlessSpoofRefusesAtGate2() {
+    let markerless = """
       \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
       text between rules
       \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
       """
+    #expect(resolve(dependencies(screen: markerless)) == .refused(.screenRefused))
+  }
+
+  @Test("A FAITHFUL spoof needs Gate 1 — the screen alone cannot refuse it")
+  func faithfulSpoofRequiresTheVeto() {
+    // A file that reproduces the marker too is indistinguishable from real input
+    // by construction, which is exactly why the veto exists.
+    let faithful = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} text between rules
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    // Nothing supported running: the veto refuses it.
     #expect(
-      resolve(dependencies(scan: .available([]), screen: spoof)) == .refused(.noSupportedCLI))
-    // With a CLI genuinely running elsewhere in the same terminal, this is the
+      resolve(dependencies(scan: .available([]), screen: faithful)) == .refused(.noSupportedCLI))
+    // A supported CLI running in ANOTHER tab of the same terminal: this is the
     // founder's ACCEPTED residual risk, recorded as an observed outcome rather
     // than claimed closed.
-    #expect(resolve(dependencies(screen: spoof)).evidence != nil)
+    #expect(resolve(dependencies(screen: faithful)).evidence != nil)
   }
 
   // MARK: - Budget

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -1,0 +1,359 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// The three gates as one decision, plus the budget and the circuit breaker.
+@Suite("Terminal context resolver")
+struct TerminalContextResolverTests {
+
+  // MARK: - Fixtures
+
+  private static let claudePath = "/Users/m4pro_sv/.local/share/claude/versions/2.1.220"
+
+  private static let claudeScreen = """
+    some earlier output
+    \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+    \u{276F} git commit -m fix the
+    \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      ? for shortcuts
+    """
+
+  private static func runningClaude(term: String = "ghostty") -> TerminalProcessScan {
+    .available([
+      TerminalProcessSnapshot(
+        processIdentifier: 42, executablePath: claudePath, arguments: ["claude"],
+        termProgram: term, isAttachedToTerminal: true)
+    ])
+  }
+
+  /// Records whether an injected dependency was reached. The closures are
+  /// `@Sendable`, so a plain captured var will not compile.
+  private final class Flag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var raised = false
+    func raise() {
+      lock.lock()
+      defer { lock.unlock() }
+      raised = true
+    }
+    var wasRaised: Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      return raised
+    }
+  }
+
+  /// A clock the test drives, so no assertion depends on wall time.
+  private final class TestClock: @unchecked Sendable {
+    private var value: Double = 0
+    var perCallCost: Double = 0
+    func read() -> Double {
+      defer { value += perCallCost }
+      return value
+    }
+  }
+
+  private func dependencies(
+    bundle: String? = "com.mitchellh.ghostty",
+    scan: TerminalProcessScan = runningClaude(),
+    screen: String? = claudeScreen,
+    clock: TestClock = TestClock()
+  ) -> TerminalContextResolver.Dependencies {
+    .init(
+      bundleIdentifier: { bundle },
+      scanProcesses: { scan },
+      readScreenTail: { screen },
+      now: { clock.read() })
+  }
+
+  private func resolve(
+    _ dependencies: TerminalContextResolver.Dependencies,
+    budget: TerminalResolutionBudget = .init(),
+    breaker: TerminalCircuitBreaker = .init(),
+    pid: pid_t = 900
+  ) -> TerminalContextResult {
+    TerminalContextResolver.resolve(
+      targetPID: pid, budget: budget, breaker: breaker, dependencies: dependencies)
+  }
+
+  // MARK: - The happy path
+
+  @Test("All three gates agreeing yields the input line and the tool")
+  func resolvesWhenEveryGateAgrees() throws {
+    let result = resolve(dependencies())
+    let evidence = try #require(result.evidence)
+    #expect(evidence.surface == .ghostty)
+    #expect(evidence.located.cli == .claudeCode)
+    #expect(evidence.located.inputLine == "git commit -m fix the")
+    #expect(evidence.runningCLIs.map(\.processIdentifier) == [42])
+  }
+
+  // MARK: - Gate 0
+
+  @Test("An app that is not a measured terminal refuses before any other work")
+  func refusesIneligibleSurface() {
+    let scanned = Flag()
+    let screenRead = Flag()
+    let dependencies = TerminalContextResolver.Dependencies(
+      bundleIdentifier: { "com.apple.TextEdit" },
+      scanProcesses: {
+        scanned.raise()
+        return Self.runningClaude()
+      },
+      readScreenTail: {
+        screenRead.raise()
+        return Self.claudeScreen
+      })
+
+    #expect(resolve(dependencies) == .refused(.surfaceIneligible))
+    // Ordering is a cost decision too: an ineligible app must never reach a
+    // process scan or an accessibility read.
+    #expect(!scanned.wasRaised, "an ineligible app must not trigger a process scan")
+    #expect(!screenRead.wasRaised, "an ineligible app must not trigger a screen read")
+  }
+
+  @Test("An unreadable bundle identifier refuses")
+  func refusesUnknownBundleIdentifier() {
+    #expect(resolve(dependencies(bundle: nil)) == .refused(.surfaceIneligible))
+  }
+
+  // MARK: - Gate 1, the veto
+
+  @Test("Nothing supported running refuses, and never reads the screen")
+  func vetoRefusesAndSkipsTheScreen() {
+    let screenRead = Flag()
+    let dependencies = TerminalContextResolver.Dependencies(
+      bundleIdentifier: { "com.mitchellh.ghostty" },
+      scanProcesses: { .available([]) },
+      readScreenTail: {
+        screenRead.raise()
+        return Self.claudeScreen
+      })
+
+    #expect(resolve(dependencies) == .refused(.noSupportedCLI))
+    #expect(!screenRead.wasRaised, "the veto must refuse before the screen is read at all")
+  }
+
+  @Test("An unreadable process list is its own refusal, not 'nothing running'")
+  func unreadableProcessListIsDistinct() {
+    #expect(resolve(dependencies(scan: .unavailable)) == .refused(.processScanUnavailable))
+  }
+
+  @Test("A CLI running under a DIFFERENT terminal does not license this one")
+  func vetoIsScopedToTheFocusedTerminal() {
+    #expect(
+      resolve(dependencies(scan: Self.runningClaude(term: "iTerm.app")))
+        == .refused(.noSupportedCLI))
+  }
+
+  // MARK: - Gate 2
+
+  @Test("An unreadable screen refuses separately from an unrecognised one")
+  func screenFailuresAreDistinct() {
+    #expect(resolve(dependencies(screen: nil)) == .refused(.screenUnreadable))
+    #expect(
+      resolve(dependencies(screen: "just output\nand more")) == .refused(.screenRefused))
+  }
+
+  @Test("The two live spoofs still need Gate 1 — the screen alone cannot refuse them")
+  func spoofRequiresTheVeto() {
+    // A file drawing two box rules, shown in a pager. Gate 2 matches it; Gate 1
+    // is what refuses, and only when nothing supported is running.
+    let spoof = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      text between rules
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    #expect(
+      resolve(dependencies(scan: .available([]), screen: spoof)) == .refused(.noSupportedCLI))
+    // With a CLI genuinely running elsewhere in the same terminal, this is the
+    // founder's ACCEPTED residual risk, recorded as an observed outcome rather
+    // than claimed closed.
+    #expect(resolve(dependencies(screen: spoof)).evidence != nil)
+  }
+
+  // MARK: - Budget
+
+  @Test("An exhausted budget refuses immediately and touches nothing")
+  func exhaustedBudgetRefusesImmediately() {
+    let scanned = Flag()
+    let dependencies = TerminalContextResolver.Dependencies(
+      bundleIdentifier: { "com.mitchellh.ghostty" },
+      scanProcesses: {
+        scanned.raise()
+        return Self.runningClaude()
+      },
+      readScreenTail: { Self.claudeScreen })
+
+    let budget = TerminalResolutionBudget(total: 0.100)
+    budget.charge(0.100)
+    #expect(resolve(dependencies, budget: budget) == .refused(.deadline))
+    #expect(!scanned.wasRaised)
+  }
+
+  @Test("The budget is CUMULATIVE across resolution and revalidation, not per call")
+  func budgetIsCumulativeAcrossCalls() {
+    // The defect this freezes: a per-CALL limit lets initial resolution plus
+    // every commit check exceed the bound that was promised to the user.
+    let clock = TestClock()
+    clock.perCallCost = 0.030
+    let budget = TerminalResolutionBudget(total: 0.100)
+    let dependencies = dependencies(clock: clock)
+
+    // Each resolve charges two steps at 0.030 each.
+    #expect(resolve(dependencies, budget: budget).evidence != nil)
+    let afterFirst = budget.remaining
+    #expect(afterFirst < 0.100, "the first resolution must consume budget")
+
+    _ = resolve(dependencies, budget: budget)
+    #expect(budget.remaining < afterFirst, "a second call must not reset the budget")
+  }
+
+  @Test("Budget spending accumulates and never goes negative")
+  func budgetAccounting() {
+    let budget = TerminalResolutionBudget(total: 0.100)
+    #expect(budget.remaining == 0.100)
+    budget.charge(0.040)
+    #expect(abs(budget.remaining - 0.060) < 0.0001)
+    budget.charge(0.500)
+    #expect(budget.remaining == 0)
+    #expect(budget.isExhausted)
+    // A negative charge cannot buy time back.
+    budget.charge(-1.0)
+    #expect(budget.isExhausted)
+  }
+
+  // MARK: - Circuit breaker
+
+  @Test("A tripped breaker refuses the NEXT delivery without starting any read")
+  func breakerSurvivesAcrossDeliveries() {
+    // Stateful across deliveries by design: a per-delivery breaker would defeat
+    // the whole point, because the accumulating blocked reads are what it exists
+    // to prevent.
+    let breaker = TerminalCircuitBreaker()
+    breaker.trip(for: 900)
+
+    let scanned = Flag()
+    let dependencies = TerminalContextResolver.Dependencies(
+      bundleIdentifier: { "com.mitchellh.ghostty" },
+      scanProcesses: {
+        scanned.raise()
+        return Self.runningClaude()
+      },
+      readScreenTail: { Self.claudeScreen })
+
+    // A FRESH budget, i.e. a new delivery.
+    #expect(
+      resolve(dependencies, budget: .init(), breaker: breaker, pid: 900)
+        == .refused(.breakerOpen))
+    #expect(!scanned.wasRaised, "an open breaker must not start another blocked read")
+  }
+
+  @Test("A different terminal starts with a closed breaker")
+  func breakerIsPerTargetProcess() {
+    let breaker = TerminalCircuitBreaker()
+    breaker.trip(for: 900)
+    #expect(resolve(dependencies(), breaker: breaker, pid: 901).evidence != nil)
+    #expect(breaker.isOpen(for: 900))
+    #expect(!breaker.isOpen(for: 901))
+  }
+
+  @Test("A relaunched terminal resets")
+  func breakerResets() {
+    let breaker = TerminalCircuitBreaker()
+    breaker.trip(for: 900)
+    #expect(breaker.isOpen(for: 900))
+    breaker.reset(for: 900)
+    #expect(!breaker.isOpen(for: 900))
+  }
+
+  // MARK: - Revalidation
+
+  @Test("Unchanged evidence revalidates")
+  func revalidatesWhenNothingChanged() throws {
+    let dependencies = dependencies()
+    let captured = try #require(resolve(dependencies).evidence)
+    let result = TerminalContextResolver.revalidate(
+      captured, targetPID: 900, budget: .init(), breaker: .init(),
+      dependencies: dependencies)
+    #expect(result.evidence == captured)
+  }
+
+  @Test("A screen that scrolled between read and commit is stale")
+  func staleWhenScreenChanged() throws {
+    let captured = try #require(resolve(dependencies()).evidence)
+    // Same input line, but the buffer above it moved. The raw tail is the only
+    // identity a screen-derived context has, so this MUST fail.
+    let scrolled = "one more line of output\n" + Self.claudeScreen
+    let result = TerminalContextResolver.revalidate(
+      captured, targetPID: 900, budget: .init(), breaker: .init(),
+      dependencies: dependencies(screen: scrolled))
+    #expect(result == .refused(.staleAtCommit))
+  }
+
+  @Test("The CLI exiting between read and commit refuses")
+  func staleWhenCLIExited() throws {
+    let captured = try #require(resolve(dependencies()).evidence)
+    let result = TerminalContextResolver.revalidate(
+      captured, targetPID: 900, budget: .init(), breaker: .init(),
+      dependencies: dependencies(scan: .available([])))
+    #expect(result == .refused(.noSupportedCLI))
+  }
+
+  @Test("Focus moving to another app between read and commit refuses")
+  func staleWhenFocusChanged() throws {
+    let captured = try #require(resolve(dependencies()).evidence)
+    let result = TerminalContextResolver.revalidate(
+      captured, targetPID: 900, budget: .init(), breaker: .init(),
+      dependencies: dependencies(bundle: "com.apple.TextEdit"))
+    #expect(result == .refused(.surfaceIneligible))
+  }
+
+  @Test("The user editing the line between read and commit is stale")
+  func staleWhenInputLineChanged() throws {
+    let captured = try #require(resolve(dependencies()).evidence)
+    let edited = Self.claudeScreen.replacingOccurrences(
+      of: "git commit -m fix the", with: "git commit -m fix")
+    let result = TerminalContextResolver.revalidate(
+      captured, targetPID: 900, budget: .init(), breaker: .init(),
+      dependencies: dependencies(screen: edited))
+    #expect(result == .refused(.staleAtCommit))
+  }
+
+  @Test("Evidence equality ignores the order processes were enumerated in")
+  func evidenceOrderIndependence() {
+    let located = TerminalScreenParser.Located(cli: .claudeCode, inputLine: "x")
+    let a = TerminalEvidence(
+      surface: .ghostty,
+      runningCLIs: [
+        .init(processIdentifier: 7, cli: .codex), .init(processIdentifier: 3, cli: .claudeCode),
+      ],
+      screenTail: "tail", located: located)
+    let b = TerminalEvidence(
+      surface: .ghostty,
+      runningCLIs: [
+        .init(processIdentifier: 3, cli: .claudeCode), .init(processIdentifier: 7, cli: .codex),
+      ],
+      screenTail: "tail", located: located)
+    // The kernel does not promise an enumeration order; a spurious mismatch here
+    // would refuse at commit for no reason at all.
+    #expect(a == b)
+  }
+
+  @Test("A CLI appearing or disappearing changes the token")
+  func evidenceTracksTheRunningSet() {
+    let located = TerminalScreenParser.Located(cli: .claudeCode, inputLine: "x")
+    let one = TerminalEvidence(
+      surface: .ghostty, runningCLIs: [.init(processIdentifier: 3, cli: .claudeCode)],
+      screenTail: "tail", located: located)
+    let two = TerminalEvidence(
+      surface: .ghostty,
+      runningCLIs: [
+        .init(processIdentifier: 3, cli: .claudeCode), .init(processIdentifier: 7, cli: .codex),
+      ],
+      screenTail: "tail", located: located)
+    #expect(one != two)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import Darwin
 import Foundation
 import Testing
@@ -234,6 +235,45 @@ struct TerminalContextResolverTests {
     // A negative charge cannot buy time back.
     budget.charge(-1.0)
     #expect(budget.isExhausted)
+  }
+
+  @Test("The cap is CUMULATIVE across calls, not applied to each one")
+  func budgetStepChargesEveryCall() {
+    // Founder 2026-07-28: "it has to be a 100 ms cap for all the questions."
+    // The defect this freezes: the same bound applied to each of five reads, so
+    // five could take five times the cap between them and no single call ever
+    // looked late.
+    let budget = TerminalResolutionBudget(total: 0.100)
+    let element = AXUIElementCreateSystemWide()
+
+    var calls = 0
+    for _ in 0..<5 {
+      _ = budget.step(applying: element) {
+        calls += 1
+        // Busy-wait rather than sleep: the charge must reflect real elapsed
+        // time, and a test that slept would prove only that sleeping works.
+        let until = DispatchTime.now().uptimeNanoseconds + 25_000_000
+        while DispatchTime.now().uptimeNanoseconds < until {}
+        return true
+      }
+      if budget.isExhausted { break }
+    }
+
+    #expect(calls >= 4, "each call must run until the SHARED budget is gone")
+    #expect(budget.isExhausted, "five 25 ms calls must exhaust a 100 ms cumulative cap")
+    #expect(budget.remaining == 0)
+  }
+
+  @Test("A healthy sequence of calls barely touches the budget")
+  func budgetStepIsFreeWhenCallsAreFast() {
+    // Measured live 2026-07-28: all five reads cost mean 0.78 ms in Ghostty and
+    // 1.79 ms in iTerm2. The cap is a failure bound, not a latency target, and
+    // must never bite healthy work.
+    let budget = TerminalResolutionBudget(total: 0.100)
+    let element = AXUIElementCreateSystemWide()
+    for _ in 0..<5 { _ = budget.step(applying: element) { true } }
+    #expect(!budget.isExhausted)
+    #expect(budget.remaining > 0.090, "five instant calls must leave the budget nearly whole")
   }
 
   // MARK: - Circuit breaker

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -271,13 +271,22 @@ struct TerminalContextResolverTests {
     #expect(!breaker.isOpen(for: 901))
   }
 
-  @Test("A relaunched terminal resets")
-  func breakerResets() {
+  @Test("The breaker is keyed by process IDENTITY, so PID reuse cannot inherit it")
+  func breakerKeyedByProcessIdentity() {
+    // Cloud review found the gap: the latch lasts the whole process lifetime and
+    // nothing clears it, so once macOS recycled that PID an unrelated terminal
+    // would be refused forever with no way back.
+    //
+    // pid 900 does not exist here, so its start time is unreadable and it keys
+    // consistently. THIS process does exist, so it keys on a real start time —
+    // proving the key is more than the number.
     let breaker = TerminalCircuitBreaker()
-    breaker.trip(for: 900)
-    #expect(breaker.isOpen(for: 900))
-    breaker.reset(for: 900)
-    #expect(!breaker.isOpen(for: 900))
+    let live = getpid()
+    breaker.trip(for: live)
+    #expect(breaker.isOpen(for: live))
+    #expect(!breaker.isOpen(for: 900), "a different process must not inherit the latch")
+    #expect(TerminalProcessScanner.startTime(of: live) != nil)
+    #expect(TerminalProcessScanner.startTime(of: pid_t(Int32.max)) == nil)
   }
 
   @Test("A read that overruns the budget TRIPS the breaker, in production code")

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -148,6 +148,29 @@ struct TerminalInsertionPolicyTests {
     #expect(PasteService.axMessagingTimeoutSeconds == 0.5)
   }
 
+  @Test("An ordinary app is untouched by terminal policy")
+  func ordinaryAppsKeepTodaysBehaviour() {
+    // Cloud review caught this as a REGRESSION I introduced: production supplies
+    // a budget on every delivery, so gating terminal policy on "was a budget
+    // passed" squeezed every app's caret read from the 0.5 s failure bound to
+    // 100 ms, and reported terminal refusals for apps that are not terminals.
+    //
+    // TextEdit is not a Gate 0 surface, so no terminal policy may apply to it.
+    #expect(TerminalSurface(bundleIdentifier: "com.apple.TextEdit") == nil)
+    #expect(TerminalSurface(bundleIdentifier: "com.microsoft.Word") == nil)
+    #expect(TerminalSurface(bundleIdentifier: "com.tinyspeck.slackmacgap") == nil)
+
+    // And an ordinary app's context carries no terminal provenance, so neither
+    // the multiline refusal nor the Tier 1 exclusion can reach it.
+    let ordinary = PasteService.CaretContext(
+      leftWindow: "notes: ", rightWindow: "", selectionLocation: 7, selectionLength: 0)
+    #expect(!ordinary.isScreenDerived)
+    let payload = PasteService.accessibilityWritePayload(
+      legacy: "Fix it ", repaired: "fix it ", context: ordinary,
+      rangeBefore: CFRange(location: 7, length: 0), fieldBefore: "notes: ")
+    #expect(payload.kind == .repaired, "an ordinary app must still get its repair")
+  }
+
   // MARK: - Tier 1 exclusion
 
   @Test("Screen evidence never authorises the accessibility-write route")

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -120,6 +120,34 @@ struct TerminalInsertionPolicyTests {
     #expect(payloads.repairedText != nil, "ordinary apps must keep today's behaviour")
   }
 
+  // MARK: - Every read path is bounded
+
+  @Test("The messaging bound has ONE owner, and it never exceeds the failure bound")
+  func boundIsDerivedFromTheBudget() {
+    // Round 3 of the same review finding: each earlier fix bounded one path and
+    // left the others at the 0.5 s default. The bound now comes from a single
+    // expression, so this asserts its shape rather than each branch separately.
+    let fresh = TerminalResolutionBudget()
+    #expect(fresh.remaining <= PasteService.axMessagingTimeoutSeconds)
+
+    // A nearly-spent budget still yields a usable, non-zero bound rather than
+    // an instant-failure timeout.
+    let spent = TerminalResolutionBudget(total: 0.100)
+    spent.charge(0.099)
+    #expect(spent.remaining > 0)
+    #expect(max(0.010, min(spent.remaining, PasteService.axMessagingTimeoutSeconds)) >= 0.010)
+
+    // An exhausted budget clamps to the floor, never to zero or a negative.
+    let exhausted = TerminalResolutionBudget(total: 0.100)
+    exhausted.charge(1.0)
+    #expect(max(0.010, min(exhausted.remaining, PasteService.axMessagingTimeoutSeconds)) == 0.010)
+  }
+
+  @Test("The failure bound is a single named owner, not a repeated literal")
+  func messagingTimeoutHasOneOwner() {
+    #expect(PasteService.axMessagingTimeoutSeconds == 0.5)
+  }
+
   // MARK: - Tier 1 exclusion
 
   @Test("Screen evidence never authorises the accessibility-write route")

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+@testable import EnviousWisprServices
+
+/// The policy the wiring introduces: what a SCREEN-derived context may and may
+/// not authorise.
+///
+/// These are the rules that keep a terminal read from reaching a route whose
+/// safety argument depends on evidence a screen cannot supply.
+@Suite("Terminal insertion policy")
+struct TerminalInsertionPolicyTests {
+
+  /// Every word this suite dictates is an ordinary lowercase word, so the
+  /// leading-case rule is exercised rather than skipped as a proper noun.
+  static let ordinaryWords = EnglishWordOracle(
+    unavailableReason: nil,
+    dictionaryVerdict: { ["fix", "first", "second", "a", "b"].contains($0) ? .ordinary : .notOrdinary },
+    isLearnedWord: { _ in false },
+    isRecognizedName: { _, _ in false })
+
+  private func terminalContext(line: String) -> PasteService.CaretContext {
+    PasteService.CaretContext(
+      leftWindow: line,
+      rightWindow: "",
+      selectionLocation: line.utf16.count,
+      selectionLength: 0,
+      terminalEvidence: TerminalEvidence(
+        surface: .ghostty,
+        runningCLIs: [.init(processIdentifier: 42, cli: .claudeCode)],
+        screenTail: "\u{276F} \(line)",
+        located: .init(cli: .claudeCode, inputLine: line)))
+  }
+
+  // MARK: - Provenance
+
+  @Test("A caret-derived context is not screen-derived, and a terminal one is")
+  func provenanceIsTyped() {
+    let caret = PasteService.CaretContext(
+      leftWindow: "abc", rightWindow: "", selectionLocation: 3, selectionLength: 0)
+    #expect(!caret.isScreenDerived)
+    #expect(terminalContext(line: "abc").isScreenDerived)
+  }
+
+  @Test("The screen tail is the identity: a scrolled buffer is a different context")
+  func screenTailParticipatesInEquality() {
+    // A screen-derived context has no selection offsets to compare, so the raw
+    // tail is the ONLY thing that can detect the buffer moving underneath it.
+    let line = "git commit -m fix the"
+    let original = terminalContext(line: line)
+    let scrolled = PasteService.CaretContext(
+      leftWindow: line, rightWindow: "", selectionLocation: line.utf16.count, selectionLength: 0,
+      terminalEvidence: TerminalEvidence(
+        surface: .ghostty,
+        runningCLIs: [.init(processIdentifier: 42, cli: .claudeCode)],
+        screenTail: "one more line\n\u{276F} \(line)",
+        located: .init(cli: .claudeCode, inputLine: line)))
+    #expect(original != scrolled)
+  }
+
+  @Test("A terminal context's right window is empty by construction")
+  func rightWindowIsEmptyByConstruction() {
+    // This is what keeps the drop-our-full-stop rule inert in a terminal: that
+    // rule needs a character to the RIGHT, and under the founder's end-of-line
+    // assumption there is none.
+    #expect(terminalContext(line: "some text").rightWindow.isEmpty)
+  }
+
+  // MARK: - The rules that DO run
+
+  @Test("The leading capital is lowered when continuing a sentence in a terminal")
+  func loweringHappensInATerminal() {
+    // The complaint this whole feature exists for: pause mid-sentence, resume,
+    // and the next word arrives capitalised.
+    let payloads = CursorInsertionRepair.repair(
+      text: "Fix the handler",
+      context: .init(left: "git commit -m ", right: "", isScreenDerived: true),
+      protectedWords: [],
+      oracle: Self.ordinaryWords)
+    #expect(payloads.repairedText?.hasPrefix("fix") == true)
+  }
+
+  @Test("A sentence that genuinely ends keeps its capital")
+  func capitalSurvivesAfterAFullStop() {
+    let payloads = CursorInsertionRepair.repair(
+      text: "Fix the handler",
+      context: .init(left: "done. ", right: "", isScreenDerived: true),
+      protectedWords: [],
+      oracle: Self.ordinaryWords)
+    #expect(payloads.repairedText?.hasPrefix("Fix") != false)
+  }
+
+  // MARK: - The multiline refusal
+
+  @Test(
+    "A screen-derived payload containing ANY line break refuses",
+    arguments: ["a\nb", "a\r\nb", "a\rb", "a\u{2028}b", "a\u{2029}b", "a\u{0085}b"])
+  func screenDerivedMultilineRefuses(text: String) {
+    // A screen-derived context describes ONE rendered row, and in a terminal a
+    // newline can SUBMIT the command. Refusing is cheaper than reasoning.
+    let payloads = CursorInsertionRepair.repair(
+      text: text,
+      context: .init(left: "git commit -m ", right: "", isScreenDerived: true),
+      protectedWords: [],
+      oracle: Self.ordinaryWords)
+    #expect(payloads.repairedText == nil, "a line break must refuse in a terminal")
+    #expect(payloads.legacyText.hasPrefix(text))
+  }
+
+  @Test("The same payload is NOT refused in an ordinary app")
+  func caretDerivedMultilineIsUnaffected() {
+    // The two-way control: the refusal must be scoped to screen-derived
+    // contexts, not applied to every app in the product.
+    let payloads = CursorInsertionRepair.repair(
+      text: "first\nsecond",
+      context: .init(left: "notes: ", right: "", isScreenDerived: false),
+      protectedWords: [],
+      oracle: Self.ordinaryWords)
+    #expect(payloads.repairedText != nil, "ordinary apps must keep today's behaviour")
+  }
+
+  // MARK: - Tier 1 exclusion
+
+  @Test("Screen evidence never authorises the accessibility-write route")
+  func tierOneNeverCommitsAScreenDerivedRepair() {
+    // Every OTHER condition is deliberately satisfied — matching offsets and a
+    // field whose windows agree — so the ONLY thing that can refuse here is the
+    // screen-derived rule itself. An earlier version of this test passed a nil
+    // element and therefore proved "no element means legacy" instead.
+    let line = "git commit -m fix the"
+    let context = terminalContext(line: line)
+    let payload = PasteService.accessibilityWritePayload(
+      legacy: "Fix the handler ",
+      repaired: "fix the handler ",
+      context: context,
+      rangeBefore: CFRange(location: context.selectionLocation, length: 0),
+      fieldBefore: line)
+    #expect(payload.kind == .legacy)
+    #expect(payload.text == "Fix the handler ")
+  }
+
+  @Test("A caret-derived repair IS authorised on the same route")
+  func tierOneCommitsACaretDerivedRepair() {
+    // The two-way control. Without it, the test above could pass because the
+    // route refuses everything.
+    let left = "git commit -m "
+    let caret = PasteService.CaretContext(
+      leftWindow: left, rightWindow: "", selectionLocation: left.utf16.count, selectionLength: 0)
+    let payload = PasteService.accessibilityWritePayload(
+      legacy: "Fix the handler ",
+      repaired: "fix the handler ",
+      context: caret,
+      rangeBefore: CFRange(location: left.utf16.count, length: 0),
+      fieldBefore: left)
+    #expect(payload.kind == .repaired)
+    #expect(payload.text == "fix the handler ")
+  }
+
+  @Test("A nil element at a commit boundary always takes today's payload")
+  func commitBoundaryWithoutAnElementIsLegacy() {
+    let payload = PasteService.payloadAtCommitBoundary(
+      legacy: "legacy ", repaired: "repaired ", context: nil, element: nil)
+    #expect(payload.kind == .legacy)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalInsertionPolicyTests.swift
@@ -91,6 +91,76 @@ struct TerminalInsertionPolicyTests {
     #expect(payloads.repairedText?.hasPrefix("Fix") != false)
   }
 
+  // MARK: - No leading space in a terminal
+
+  @Test("A terminal never gets a leading space, because the screen cannot show one")
+  func noLeadingSpaceInATerminal() {
+    // FOUND IN LIVE TESTING, 2026-07-28. A terminal truncates each rendered row
+    // at its last VISIBLE character — measured, an input row reported length 2
+    // while the box rules around it reported 68 — because it draws a cursor
+    // where the trailing space would be. So `fix the` and `fix the ` are
+    // byte-identical on screen.
+    //
+    // Every dictation already ends with a trailing space, so this rule fired on
+    // every consecutive dictation and produced a double space each time. The
+    // founder saw it on the first real test.
+    let payloads = CursorInsertionRepair.repair(
+      text: "handler",
+      context: .init(left: "git commit -m fix the", right: "", isScreenDerived: true),
+      protectedWords: [],
+      oracle: Self.ordinaryWords)
+    #expect(payloads.repairedText?.hasPrefix(" ") != true, "no leading space in a terminal")
+  }
+
+  @Test("An ordinary app STILL gets its leading space")
+  func leadingSpaceSurvivesOutsideTerminals() {
+    // The two-way control. Without it, disabling the rule everywhere would pass
+    // the test above while silently welding words together in every other app.
+    let payloads = CursorInsertionRepair.repair(
+      text: "handler",
+      context: .init(left: "fix the", right: "", isScreenDerived: false),
+      protectedWords: [],
+      oracle: Self.ordinaryWords)
+    #expect(payloads.repairedText?.hasPrefix(" ") == true, "ordinary apps keep the leading space")
+  }
+
+  @Test("The trailing space is KEPT in terminals — it is a learned product promise")
+  func trailingSpaceSurvivesInTerminals() {
+    // Founder 2026-07-28: users are already used to a space being added after
+    // every dictation. Removing it in terminals alone would make terminals the
+    // one inconsistent surface, so the leading rule was dropped instead.
+    let payloads = CursorInsertionRepair.repair(
+      text: "handler",
+      context: .init(left: "git commit -m fix the ", right: "", isScreenDerived: true),
+      protectedWords: [],
+      oracle: Self.ordinaryWords)
+    let delivered = payloads.repairedText ?? payloads.legacyText
+    #expect(delivered.hasSuffix(" "), "every dictation still ends with a space")
+  }
+
+  @Test("Consecutive terminal dictations produce exactly one space between them")
+  func consecutiveDictationsDoNotDoubleSpace() {
+    // The end-to-end shape of the bug, as the founder hit it: dictation one
+    // leaves a trailing space the screen cannot show, and dictation two used to
+    // add another one on top of it.
+    let first = CursorInsertionRepair.repair(
+      text: "fix the",
+      context: .init(left: "git commit -m ", right: "", isScreenDerived: true),
+      protectedWords: [], oracle: Self.ordinaryWords)
+    let afterFirst = "git commit -m " + (first.repairedText ?? first.legacyText)
+    #expect(afterFirst.hasSuffix(" "))
+
+    // What the SCREEN reports back: the trailing space is invisible.
+    let asScreenReportsIt = String(afterFirst.reversed().drop(while: { $0 == " " }).reversed())
+    let second = CursorInsertionRepair.repair(
+      text: "handler",
+      context: .init(left: asScreenReportsIt, right: "", isScreenDerived: true),
+      protectedWords: [], oracle: Self.ordinaryWords)
+    let joined = afterFirst + (second.repairedText ?? second.legacyText)
+    #expect(!joined.contains("  "), "no double space anywhere in the joined result")
+    #expect(joined == "git commit -m fix the handler ")
+  }
+
   // MARK: - The multiline refusal
 
   @Test(

--- a/Tests/EnviousWisprTests/Services/TerminalProcessScannerTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalProcessScannerTests.swift
@@ -375,39 +375,48 @@ struct TerminalProcessScannerTests {
     #expect(parsed.environment["PATH"] != nil)
   }
 
-  @Test("The terminal flag discriminates on live data, rather than being stuck")
-  func terminalFlagDiscriminatesLive() {
-    // A flag hard-stuck at false disables the feature everywhere; stuck at true
-    // removes the precondition that makes name matching safe. Either failure
-    // leaves every hand-built unit fixture green, so assert BOTH values appear
-    // in real data. Measured baseline 2026-07-28: 63 attached of 732.
+  @Test("The terminal flag is computed, not stuck, and fails closed on a dead PID")
+  func terminalFlagIsComputedAndFailsClosed() {
+    // ENVIRONMENT-INDEPENDENT by design. An earlier version asserted that live
+    // data contained BOTH tty-attached and detached processes; that passes on a
+    // developer Mac and FAILS on a headless CI runner, where nothing holds a
+    // controlling terminal. The assertion was about the machine, not the code.
+    //
+    // What is actually deterministic: a PID that cannot exist must report false
+    // (fails closed), and every machine has detached processes. The positive
+    // direction is proven where it belongs — `vetoRefusesDetachedCLI` drives the
+    // same snapshot through with the flag true and false and asserts opposite
+    // outcomes.
+    #expect(!TerminalProcessScanner.holdsControllingTerminal(pid_t(Int32.max)))
+
     guard case .available(let snapshots) = TerminalProcessScanner.liveSnapshot() else {
       Issue.record("process enumeration was unavailable")
       return
     }
-    let attached = snapshots.filter(\.isAttachedToTerminal).count
-    let detached = snapshots.count - attached
-    #expect(attached > 0, "no process reported a controlling terminal — the flag is stuck false")
-    #expect(detached > 0, "every process reported a terminal — the flag is stuck true")
+    #expect(snapshots.contains { !$0.isAttachedToTerminal })
   }
 
   @Test("The strict parser still accepts real kernel blobs at scale")
-  func strictParserDoesNotRejectRealProcesses() throws {
+  func strictParserDoesNotRejectRealProcesses() {
     // The parser was tightened to fail closed on malformed input. A tightening
-    // that also rejects HONEST blobs would disable the veto everywhere while
+    // that also rejected HONEST blobs would disable the veto everywhere while
     // every unit test stayed green, because the unit fixtures are hand-built.
-    // Measured baseline 2026-07-28: 705 of 710 paths and 456 environments read.
-    // Assert the real distribution, not a single self-read.
+    //
+    // Counts only what exists on EVERY machine: a process list, and successfully
+    // parsed arguments. It deliberately does NOT count `TERM_PROGRAM`, which is
+    // absent on a headless runner and made an earlier version of this test
+    // machine-dependent.
     guard case .available(let snapshots) = TerminalProcessScanner.liveSnapshot() else {
       Issue.record("process enumeration was unavailable")
       return
     }
-    let withEnvironment = snapshots.filter { $0.termProgram != nil }.count
+    let withArguments = snapshots.filter { !$0.arguments.isEmpty }.count
     #expect(
-      snapshots.count > 100,
+      snapshots.count > 20,
       "only \(snapshots.count) processes parsed — the strict parser is rejecting real blobs")
     #expect(
-      withEnvironment > 5,
-      "only \(withEnvironment) processes exposed TERM_PROGRAM — environment parsing regressed")
+      withArguments > 10,
+      "only \(withArguments) processes yielded arguments — argument parsing regressed")
   }
+
 }

--- a/Tests/EnviousWisprTests/Services/TerminalProcessScannerTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalProcessScannerTests.swift
@@ -1,0 +1,413 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// Gate 1's veto: which supported CLIs are running, and under which terminal.
+///
+/// Every decoy path below was CAPTURED from the founder's running machine on
+/// 2026-07-28, not invented. A matcher tuned against imagined lookalikes proves
+/// nothing about the real ones — `/Applications/ChatGPT.app/Contents/Resources/codex`
+/// is a genuine executable literally named `codex`, and no amount of guessing
+/// would have produced it.
+@Suite("Terminal process scanner")
+struct TerminalProcessScannerTests {
+
+  private func snapshot(
+    _ pid: pid_t, _ path: String, _ args: [String] = [], term: String?,
+    terminal: Bool = true
+  ) -> TerminalProcessSnapshot {
+    TerminalProcessSnapshot(
+      processIdentifier: pid, executablePath: path, arguments: args, termProgram: term,
+      isAttachedToTerminal: terminal)
+  }
+
+  /// Captured live 2026-07-28 while all three tools were genuinely running.
+  private let claudePath = "/Users/m4pro_sv/.local/share/claude/versions/2.1.220"
+  private let nodePath = "/opt/homebrew/Cellar/node/26.4.0/bin/node"
+  private let homebrewCodexPath = "/opt/homebrew/Caskroom/codex/0.144.1/bin/codex"
+
+  // MARK: - Terminal surfaces
+
+  @Test("Gate 0 admits exactly the three measured terminals")
+  func surfaceMembership() {
+    #expect(TerminalSurface(bundleIdentifier: "com.mitchellh.ghostty") == .ghostty)
+    #expect(TerminalSurface(bundleIdentifier: "com.apple.Terminal") == .terminalApp)
+    #expect(TerminalSurface(bundleIdentifier: "com.googlecode.iterm2") == .iTerm2)
+
+    // Unmeasured terminals are excluded, NOT carried as harmless: admitting one
+    // licenses reading its screen as a terminal grid.
+    for excluded in [
+      "io.alacritty", "net.kovidgoyal.kitty", "com.github.wez.wezterm", "dev.warp.Warp",
+      "com.apple.TextEdit", "com.microsoft.VSCode",
+    ] {
+      #expect(
+        TerminalSurface(bundleIdentifier: excluded) == nil, "\(excluded) must not be admitted")
+    }
+  }
+
+  @Test("TERM_PROGRAM values match what each terminal actually exports")
+  func termProgramValues() {
+    // Read out of the shipped binaries / observed live 2026-07-28.
+    #expect(TerminalSurface.ghostty.termProgramValue == "ghostty")
+    #expect(TerminalSurface.terminalApp.termProgramValue == "Apple_Terminal")
+    #expect(TerminalSurface.iTerm2.termProgramValue == "iTerm.app")
+  }
+
+  // MARK: - Identity: the three tools as they actually run
+
+  @Test("Claude Code's version-named executable is identified from argv[0]")
+  func identifiesClaudeCode() {
+    // Captured live: the executable is named after its VERSION, so argv[0] is
+    // the only place the name appears.
+    #expect(
+      TerminalProcessScanner.identify(
+        executablePath: claudePath, arguments: ["claude", "--resume"]) == .claudeCode)
+  }
+
+  @Test("Homebrew Codex is identified — the install-path matcher missed this one")
+  func identifiesHomebrewCodex() {
+    // THE case that changed the design (founder decision 2026-07-28). This
+    // binary is installed on the founder's machine and the previous install-path
+    // matcher walked straight past it, so terminal insertion would silently
+    // never engage for anyone who installed Codex this way.
+    #expect(
+      TerminalProcessScanner.identify(
+        executablePath: homebrewCodexPath, arguments: ["codex"]) == .codex)
+  }
+
+  @Test("npm-hosted Gemini and Codex are identified through their script runtime")
+  func identifiesScriptHostedCLIs() {
+    #expect(
+      TerminalProcessScanner.identify(
+        executablePath: nodePath,
+        arguments: ["node", "/Users/m4pro_sv/.npm-global/bin/gemini"]) == .geminiCLI)
+    #expect(
+      TerminalProcessScanner.identify(
+        executablePath: nodePath,
+        arguments: ["node", "/Users/m4pro_sv/.npm-global/bin/codex"]) == .codex)
+    // Invoked at the script itself rather than through the npm bin symlink.
+    #expect(
+      TerminalProcessScanner.identify(
+        executablePath: nodePath,
+        arguments: [
+          "node", "/Users/x/lib/node_modules/@google/gemini-cli/bundle/gemini.js",
+        ]) == .geminiCLI)
+  }
+
+  @Test("A file argument is only read as a program when a script runtime hosts it")
+  func onlyScriptRuntimesHostTheirArgument() {
+    // Editing a file that happens to be named `codex` must not read as Codex.
+    #expect(
+      TerminalProcessScanner.identify(
+        executablePath: "/usr/bin/vim", arguments: ["vim", "/Users/x/notes/codex"]) == nil)
+    #expect(
+      TerminalProcessScanner.identify(
+        executablePath: "/bin/cat", arguments: ["cat", "/Users/x/gemini"]) == nil)
+  }
+
+  @Test("A relative hosted argument is ignored")
+  func ignoresRelativeHostedArgument() {
+    // A relative path belongs to the CLI's own working directory, which is
+    // deliberately never read.
+    #expect(
+      TerminalProcessScanner.identify(
+        executablePath: nodePath, arguments: ["node", "./bin/codex"]) == nil)
+  }
+
+  @Test("A flag argument is not a program name")
+  func ignoresFlagArguments() {
+    #expect(
+      TerminalProcessScanner.identify(
+        executablePath: "/usr/bin/true", arguments: ["true", "--resume"]) == nil)
+  }
+
+  // MARK: - Identity: the real negatives
+
+  /// Captured 2026-07-28. A name-substring matcher fires on every one of these,
+  /// and every one is a GUI process holding NO controlling terminal — which is
+  /// why the terminal precondition closes the class structurally.
+  static let capturedDecoys: [String] = [
+    "/Applications/ChatGPT.app/Contents/Resources/codex",
+    "/Applications/ChatGPT.app/Contents/Resources/codex_chronicle",
+    "/Applications/ChatGPT.app/Contents/Resources/codex-code-mode-host",
+    "/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Versions/150.0.7871.128/Helpers/Codex (Renderer).app/Contents/MacOS/Codex (Renderer)",
+    "/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Versions/150.0.7871.128/Helpers/Codex (Service).app/Contents/MacOS/Codex (Service)",
+    "/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Versions/150.0.7871.128/Helpers/browser_crashpad_handler",
+    "/Users/m4pro_sv/.codex/computer-use/Codex Computer Use.app/Contents/MacOS/SkyComputerUseService",
+    "/Users/m4pro_sv/.codex/plugins/cache/openai-bundled/chrome/latest/extension-host/macos/arm64/ChatGPT for Chrome",
+    "/Users/m4pro_sv/.claude/mcp-servers/envious-canvas/.venv/bin/python3",
+  ]
+
+  @Test(
+    "Every captured GUI lookalike is refused by the terminal precondition",
+    arguments: capturedDecoys)
+  func terminalPreconditionRefusesGUILookalikes(path: String) {
+    // These run with no controlling terminal, exactly as measured.
+    let found = TerminalProcessScanner.supportedCLIs(
+      in: [snapshot(1, path, [path], term: "ghostty", terminal: false)],
+      hostedBy: .ghostty)
+    #expect(found.isEmpty, "\(path) must not license a terminal read")
+  }
+
+  @Test("The ChatGPT binary literally named codex is refused")
+  func refusesChatGPTCodexBinary() {
+    // The hardest single decoy: a real executable named `codex`. It is a GUI
+    // helper, so it holds no terminal.
+    let path = "/Applications/ChatGPT.app/Contents/Resources/codex"
+    #expect(
+      TerminalProcessScanner.supportedCLIs(
+        in: [snapshot(1, path, ["codex", "exec", "--json"], term: "ghostty", terminal: false)],
+        hostedBy: .ghostty
+      ).isEmpty)
+  }
+
+  // MARK: - The veto
+
+  @Test("No supported CLI under the terminal app means the veto fires")
+  func vetoFiresWhenNothingSupportedRuns() {
+    let snapshots = [
+      snapshot(1, "/bin/zsh", ["zsh"], term: "ghostty"),
+      snapshot(2, "/usr/bin/vim", ["vim", "notes.txt"], term: "ghostty"),
+      snapshot(
+        3, "/Applications/ChatGPT.app/Contents/Resources/codex", ["codex"],
+        term: "ghostty", terminal: false),
+    ]
+    #expect(
+      TerminalProcessScanner.supportedCLIs(in: snapshots, hostedBy: .ghostty).isEmpty,
+      "this is the configuration that closes the vim/less spoof")
+  }
+
+  @Test("A terminal-attached supported CLI passes the veto")
+  func vetoPassesWithOneCLI() {
+    #expect(
+      TerminalProcessScanner.supportedCLIs(
+        in: [snapshot(1, claudePath, ["claude"], term: "ghostty")],
+        hostedBy: .ghostty) == [RunningTerminalCLI(processIdentifier: 1, cli: .claudeCode)])
+  }
+
+  @Test("A CLI with no controlling terminal never passes the veto")
+  func vetoRefusesDetachedCLI() {
+    // Same process, same name, same TERM_PROGRAM — only the terminal differs.
+    // This is the two-way control for the precondition.
+    #expect(
+      TerminalProcessScanner.supportedCLIs(
+        in: [snapshot(1, claudePath, ["claude"], term: "ghostty", terminal: false)],
+        hostedBy: .ghostty
+      ).isEmpty)
+    #expect(
+      TerminalProcessScanner.supportedCLIs(
+        in: [snapshot(1, claudePath, ["claude"], term: "ghostty", terminal: true)],
+        hostedBy: .ghostty
+      ).count == 1)
+  }
+
+  @Test("Several supported CLIs pass — multi-tab is the normal case")
+  func vetoPassesWithSeveralCLIs() {
+    // The founder runs five tabs in one project. The superseded strict design
+    // REFUSED here; refusing again would silently break his everyday setup.
+    let snapshots = (1...5).map { snapshot(pid_t($0), claudePath, ["claude"], term: "ghostty") }
+    #expect(TerminalProcessScanner.supportedCLIs(in: snapshots, hostedBy: .ghostty).count == 5)
+  }
+
+  @Test("A CLI in a different terminal does not license a read in this one")
+  func vetoIsScopedToTheFocusedTerminal() {
+    let snapshots = [
+      snapshot(1, claudePath, ["claude"], term: "iTerm.app"),
+      snapshot(2, claudePath, ["claude"], term: "Apple_Terminal"),
+    ]
+    #expect(TerminalProcessScanner.supportedCLIs(in: snapshots, hostedBy: .ghostty).isEmpty)
+    #expect(
+      TerminalProcessScanner.supportedCLIs(in: snapshots, hostedBy: .iTerm2)
+        .map(\.processIdentifier) == [1])
+  }
+
+  @Test("A CLI reporting no TERM_PROGRAM is attributed to no terminal")
+  func unattributedCLIDoesNotPassTheVeto() {
+    #expect(
+      TerminalProcessScanner.supportedCLIs(
+        in: [snapshot(1, claudePath, ["claude"], term: nil)], hostedBy: .ghostty
+      ).isEmpty)
+  }
+
+  // MARK: - Blob parsing
+
+  /// Build a `KERN_PROCARGS2` blob the way the kernel lays one out.
+  private func procArgsBlob(
+    execPath: String, arguments: [String], environment: [String], padding: Int = 3
+  ) -> [UInt8] {
+    var blob = [UInt8]()
+    withUnsafeBytes(of: Int32(arguments.count).littleEndian) { blob.append(contentsOf: $0) }
+    blob.append(contentsOf: Array(execPath.utf8))
+    blob.append(contentsOf: [UInt8](repeating: 0, count: padding))
+    for value in arguments + environment {
+      blob.append(contentsOf: Array(value.utf8))
+      blob.append(0)
+    }
+    blob.append(0)
+    return blob
+  }
+
+  @Test("A well-formed blob yields its arguments and environment")
+  func parsesWellFormedBlob() throws {
+    let blob = procArgsBlob(
+      execPath: "/opt/homebrew/bin/node",
+      arguments: ["node", "/Users/x/.npm-global/bin/gemini"],
+      environment: ["TERM_PROGRAM=ghostty", "PATH=/usr/bin", "LANG=en_US.UTF-8"])
+    let parsed = try #require(TerminalProcessScanner.parseProcArgs(blob))
+    #expect(parsed.arguments == ["node", "/Users/x/.npm-global/bin/gemini"])
+    #expect(parsed.environment["TERM_PROGRAM"] == "ghostty")
+    #expect(parsed.environment["LANG"] == "en_US.UTF-8")
+  }
+
+  @Test("An environment value containing '=' keeps its whole value")
+  func parsesEnvironmentValueWithEquals() throws {
+    let blob = procArgsBlob(
+      execPath: "/bin/zsh", arguments: ["zsh"],
+      environment: ["TERM_PROGRAM=ghostty", "OPTS=a=b=c"])
+    let parsed = try #require(TerminalProcessScanner.parseProcArgs(blob))
+    #expect(parsed.environment["OPTS"] == "a=b=c")
+  }
+
+  @Test("A truncated or malformed blob fails closed rather than reading past the end")
+  func malformedBlobFailsClosed() {
+    #expect(TerminalProcessScanner.parseProcArgs([]) == nil)
+    #expect(TerminalProcessScanner.parseProcArgs([1, 2]) == nil)
+
+    // Negative and absurd argument counts are hostile input from another
+    // process's memory image.
+    var negative = [UInt8]()
+    withUnsafeBytes(of: Int32(-1).littleEndian) { negative.append(contentsOf: $0) }
+    negative.append(contentsOf: Array("/bin/zsh".utf8) + [0])
+    #expect(TerminalProcessScanner.parseProcArgs(negative) == nil)
+
+    var absurd = [UInt8]()
+    withUnsafeBytes(of: Int32(100_000).littleEndian) { absurd.append(contentsOf: $0) }
+    absurd.append(contentsOf: Array("/bin/zsh".utf8) + [0])
+    #expect(TerminalProcessScanner.parseProcArgs(absurd) == nil)
+  }
+
+  @Test("A blob claiming more arguments than it contains fails closed")
+  func blobWithOverstatedArgumentCountFailsClosed() {
+    // This test previously asserted PARTIAL SUCCESS, which froze the wrong
+    // behaviour: a half-read process reports no TERM_PROGRAM, and "absent" is
+    // indistinguishable from "genuinely unset", so it would be mis-attributed
+    // rather than skipped. Grounded review caught the test, not just the code.
+    var blob = [UInt8]()
+    withUnsafeBytes(of: Int32(9).littleEndian) { blob.append(contentsOf: $0) }
+    blob.append(contentsOf: Array("/bin/zsh".utf8))
+    blob.append(contentsOf: [0, 0])
+    blob.append(contentsOf: Array("zsh".utf8) + [0])
+    #expect(TerminalProcessScanner.parseProcArgs(blob) == nil)
+  }
+
+  @Test("Unterminated executable, argument and environment strings fail closed")
+  func unterminatedStringsFailClosed() {
+    var header = [UInt8]()
+    withUnsafeBytes(of: Int32(1).littleEndian) { header.append(contentsOf: $0) }
+
+    // Executable path never terminated.
+    #expect(TerminalProcessScanner.parseProcArgs(header + Array("/bin/zsh".utf8)) == nil)
+
+    // Argument never terminated.
+    #expect(
+      TerminalProcessScanner.parseProcArgs(
+        header + Array("/bin/zsh".utf8) + [0, 0] + Array("zsh".utf8)) == nil)
+
+    // Environment entry never terminated.
+    #expect(
+      TerminalProcessScanner.parseProcArgs(
+        header + Array("/bin/zsh".utf8) + [0, 0] + Array("zsh".utf8) + [0]
+          + Array("TERM_PROGRAM=ghostty".utf8)) == nil)
+  }
+
+  @Test("An argument count of zero is malformed, not an empty success")
+  func zeroArgumentCountFailsClosed() {
+    var blob = [UInt8]()
+    withUnsafeBytes(of: Int32(0).littleEndian) { blob.append(contentsOf: $0) }
+    blob.append(contentsOf: Array("/bin/zsh".utf8) + [0, 0])
+    #expect(TerminalProcessScanner.parseProcArgs(blob) == nil)
+  }
+
+  @Test("Invalid UTF-8 in the blob fails closed")
+  func invalidUTF8FailsClosed() {
+    var blob = [UInt8]()
+    withUnsafeBytes(of: Int32(1).littleEndian) { blob.append(contentsOf: $0) }
+    blob.append(contentsOf: Array("/bin/zsh".utf8) + [0, 0])
+    blob.append(contentsOf: [0xFF, 0xFE, 0xFD] + [0])
+    #expect(TerminalProcessScanner.parseProcArgs(blob) == nil)
+  }
+
+  // MARK: - Live capture, positive control
+
+  @Test("An unreadable process list is a different result from an empty one")
+  func scanResultDistinguishesUnavailableFromEmpty() {
+    // `?? []` at the one call site that matters would erase this. The type is
+    // what stops it.
+    #expect(TerminalProcessScan.unavailable != TerminalProcessScan.available([]))
+  }
+
+  @Test("The live scanner sees this very process")
+  func liveScannerSeesSelf() throws {
+    // Without a positive control, an empty result and a broken scanner are
+    // indistinguishable — and a veto reading "nothing is running" fails the
+    // feature silently rather than loudly.
+    guard case .available(let snapshots) = TerminalProcessScanner.liveSnapshot() else {
+      Issue.record("process enumeration was unavailable")
+      return
+    }
+    #expect(snapshots.count > 20, "process enumeration returned implausibly few processes")
+
+    let me = getpid()
+    let mine = try #require(
+      snapshots.first { $0.processIdentifier == me },
+      "the scanner must be able to see its own process")
+    #expect(!mine.executablePath.isEmpty)
+    #expect(!mine.arguments.isEmpty)
+  }
+
+  @Test("Live argument and environment reads work against this process")
+  func liveArgumentsAndEnvironmentForSelf() throws {
+    let parsed = try #require(TerminalProcessScanner.argumentsAndEnvironment(of: getpid()))
+    #expect(!parsed.arguments.isEmpty)
+    // PATH is set for any process the test runner can spawn.
+    #expect(parsed.environment["PATH"] != nil)
+  }
+
+  @Test("The terminal flag discriminates on live data, rather than being stuck")
+  func terminalFlagDiscriminatesLive() {
+    // A flag hard-stuck at false disables the feature everywhere; stuck at true
+    // removes the precondition that makes name matching safe. Either failure
+    // leaves every hand-built unit fixture green, so assert BOTH values appear
+    // in real data. Measured baseline 2026-07-28: 63 attached of 732.
+    guard case .available(let snapshots) = TerminalProcessScanner.liveSnapshot() else {
+      Issue.record("process enumeration was unavailable")
+      return
+    }
+    let attached = snapshots.filter(\.isAttachedToTerminal).count
+    let detached = snapshots.count - attached
+    #expect(attached > 0, "no process reported a controlling terminal — the flag is stuck false")
+    #expect(detached > 0, "every process reported a terminal — the flag is stuck true")
+  }
+
+  @Test("The strict parser still accepts real kernel blobs at scale")
+  func strictParserDoesNotRejectRealProcesses() throws {
+    // The parser was tightened to fail closed on malformed input. A tightening
+    // that also rejects HONEST blobs would disable the veto everywhere while
+    // every unit test stayed green, because the unit fixtures are hand-built.
+    // Measured baseline 2026-07-28: 705 of 710 paths and 456 environments read.
+    // Assert the real distribution, not a single self-read.
+    guard case .available(let snapshots) = TerminalProcessScanner.liveSnapshot() else {
+      Issue.record("process enumeration was unavailable")
+      return
+    }
+    let withEnvironment = snapshots.filter { $0.termProgram != nil }.count
+    #expect(
+      snapshots.count > 100,
+      "only \(snapshots.count) processes parsed — the strict parser is rejecting real blobs")
+    #expect(
+      withEnvironment > 5,
+      "only \(withEnvironment) processes exposed TERM_PROGRAM — environment parsing regressed")
+  }
+}

--- a/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
@@ -264,6 +264,52 @@ struct TerminalScreenParserTests {
     #expect(TerminalScreenParser.locate(inScreenTail: blanksOnly) == nil)
   }
 
+  @Test("A stale Codex row with a shell prompt below it refuses")
+  func staleCodexRowBelowALivePromptRefuses() {
+    // CLASS FIX, whole-diff review r2: the staleness check lived only on the
+    // boxed path, so an exited Codex left its last input row matchable — the
+    // shell prompt beneath merely counted as one of the two permitted status
+    // rows. With another supported CLI open in a different tab, Gate 1 passes
+    // too, and dictation at the shell prompt would have been joined onto stale
+    // Codex text.
+    let stale = """
+      \u{203A} an old codex prompt
+      \u{276F} git commit -m fix the
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: stale) == nil)
+  }
+
+  @Test("Both layout paths apply the SAME staleness rule", arguments: ["\u{203A}", "boxed"])
+  func stalenessAppliesToEveryLayout(kind: String) {
+    // Enumerating the class rather than fixing the reported instance: there are
+    // exactly two layout paths, and both must refuse.
+    let screen =
+      kind == "boxed"
+      ? """
+        \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+        \u{276F} old boxed input
+        \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+        $ ls -la
+        """
+      : """
+        \u{203A} old codex input
+        $ ls -la
+        """
+    #expect(TerminalScreenParser.locate(inScreenTail: screen) == nil)
+  }
+
+  @Test("Codex still matches when only its own status bar sits below")
+  func codexStillMatchesWithItsStatusBar() {
+    // The two-way control: the staleness rule must not refuse Codex's normal
+    // screen, or the fix above would disable the tool entirely.
+    let live = """
+      earlier output
+      \u{203A} refactor the handler
+        weekly 63% left
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: live)?.cli == .codex)
+  }
+
   // MARK: - Character handling
 
   @Test("The box's non-breaking padding becomes an ordinary space")

--- a/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
@@ -185,21 +185,83 @@ struct TerminalScreenParserTests {
     #expect(TerminalScreenParser.locate(inScreenTail: spoof) == nil)
   }
 
-  @Test("A file drawing two box rules, shown in a pager, does not become input")
-  func boxDrawingFileSpoofIsBoundedToOneLine() {
-    // MEASURED live: a file with two `────` rows displayed in vim and in less
-    // returned `text between rules`. Gate 2 CANNOT tell this from a real box —
-    // that is precisely why Gate 1 exists and why this test asserts the shape is
-    // matched rather than pretending a guard closes it.
-    let spoofed = """
+  @Test("Box-drawn output carrying no tool marker refuses")
+  func markerlessBoxDrawingOutputRefuses() {
+    // The MEASURED spoof: a file with two box rows shown in vim and in less,
+    // which was read as `text between rules`. It carries no marker, and both
+    // real input rows always do — so it refuses at no cost.
+    //
+    // This corrects my own reasoning, not just the code. I had argued that
+    // because screen matching is spoofable as a CLASS, refusing a measured
+    // INSTANCE was not worth it, and froze the false positive in a test that
+    // claimed Gate 2 "cannot tell". Gate 2 cannot defeat a FAITHFUL spoof; it
+    // can reject this one.
+    let claudeLike = """
       \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
       text between rules
       \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
       """
-    let located = TerminalScreenParser.locate(inScreenTail: spoofed)
+    let geminiLike = """
+      \u{2584}\u{2584}\u{2584}\u{2584}\u{2584}\u{2584}\u{2584}\u{2584}
+      text between rules
+      \u{2580}\u{2580}\u{2580}\u{2580}\u{2580}\u{2580}\u{2580}\u{2580}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: claudeLike) == nil)
+    #expect(TerminalScreenParser.locate(inScreenTail: geminiLike) == nil)
+  }
+
+  @Test("A FAITHFUL spoof still passes — which is why Gate 1 is the authority")
+  func faithfulSpoofStillPasses() {
+    // A file that also reproduces the marker is indistinguishable from real
+    // input, by construction. Asserting this keeps the honest framing: Gate 2
+    // narrows, Gate 1 authorises.
+    let faithful = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} text between rules
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: faithful)?.inputLine == "text between rules")
+  }
+
+  @Test("A boundary must repeat ONE glyph")
+  func mixedBoundaryGlyphsRefuse() {
+    let mixed = """
+      \u{2500}\u{2501}\u{2500}\u{2501}
+      \u{276F} old text
+      \u{2500}\u{2501}\u{2500}\u{2501}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: mixed) == nil)
+  }
+
+  @Test("Every row-boundary shape is index-safe")
+  func rowBoundaryShapesAreSafe() {
+    // Swift ranges TRAP on invalid bounds and this runs on the paste heart path,
+    // so a crash would be worse than a wrong answer.
+    #expect(TerminalScreenParser.locate(inScreenTail: "") == nil)
+    #expect(TerminalScreenParser.locate(inScreenTail: "ordinary row") == nil)
     #expect(
-      located?.inputLine == "text between rules",
-      "the screen alone cannot refuse this — Gate 1 is the gate that does")
+      TerminalScreenParser.locate(inScreenTail: "\u{203A} final row")?.inputLine == "final row")
+
+    let boundedAtEdges = """
+      \u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} edge text
+      \u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: boundedAtEdges)?.inputLine == "edge text")
+
+    let adjacent = """
+      \u{2500}\u{2500}\u{2500}\u{2500}
+      \u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: adjacent) == nil)
+
+    let blanksOnly = """
+      \u{2500}\u{2500}\u{2500}\u{2500}
+
+
+      \u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: blanksOnly) == nil)
   }
 
   // MARK: - Character handling

--- a/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalScreenParserTests.swift
@@ -1,0 +1,252 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// Gate 2: locating the input line on a terminal's rendered screen.
+///
+/// Every layout here mirrors a real one observed in Ghostty, and every refusal
+/// freezes a failure that actually happened — the prototype's empty-box read, the
+/// status-bar anchor, and both live spoofs.
+@Suite("Terminal screen parser")
+struct TerminalScreenParserTests {
+
+  // MARK: - Layout builders
+
+  /// Claude Code: light box rules with `❯` inside, hints printed BELOW.
+  private static func claudeBox(_ input: String, footer: String = "  ? for shortcuts") -> String {
+    """
+    some earlier output
+    \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+    \u{276F} \(input)
+    \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+    \(footer)
+    """
+  }
+
+  /// Gemini: half-block rules with a plain `>` inside.
+  private static func geminiBox(_ input: String) -> String {
+    """
+    earlier output
+    \u{2584}\u{2584}\u{2584}\u{2584}\u{2584}\u{2584}\u{2584}\u{2584}
+    > \(input)
+    \u{2580}\u{2580}\u{2580}\u{2580}\u{2580}\u{2580}\u{2580}\u{2580}
+    """
+  }
+
+  /// Codex: no box at all, status bar below the input.
+  private static func codexScreen(
+    _ input: String, status: String = "  weekly 63% left"
+  ) -> String {
+    """
+    earlier output
+    \u{203A} \(input)
+    \(status)
+    """
+  }
+
+  // MARK: - The three tools
+
+  @Test("Claude Code's boxed input line is found, and the footer below it is not")
+  func findsClaudeCodeInput() {
+    let located = TerminalScreenParser.locate(inScreenTail: Self.claudeBox("git commit -m fix the"))
+    #expect(located?.cli == .claudeCode)
+    #expect(located?.inputLine == "git commit -m fix the")
+  }
+
+  @Test("Gemini's block-ruled box is found and its plain marker is stripped")
+  func findsGeminiInput() {
+    let located = TerminalScreenParser.locate(inScreenTail: Self.geminiBox("explain this to me"))
+    #expect(located?.cli == .geminiCLI)
+    #expect(located?.inputLine == "explain this to me")
+  }
+
+  @Test("Codex is found from its opening marker, never from its status bar")
+  func findsCodexInput() {
+    // MEASURED failure this freezes: "take the last non-empty row" returned
+    // `weekly 63% left` from Codex's status bar. Codex draws no box, so the box
+    // search cannot find it either.
+    let located = TerminalScreenParser.locate(
+      inScreenTail: Self.codexScreen("refactor the handler"))
+    #expect(located?.cli == .codex)
+    #expect(located?.inputLine == "refactor the handler")
+  }
+
+  // MARK: - Refusals that are the feature
+
+  @Test("A WRAPPED box refuses rather than joining rows")
+  func wrappedBoxRefuses() {
+    // Joining screen rows reconstructs different text, and a soft wrap can fall
+    // mid-word.
+    let wrapped = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} this line is long enough that it
+      wrapped onto a second row
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: wrapped) == nil)
+  }
+
+  @Test("An EMPTY box refuses, never reading back the hints printed below it")
+  func emptyBoxRefuses() {
+    // The prototype's exact failure: an untouched box read back as
+    // "/rc ⧉ seam-join-explainer". Joining onto that deletes words nobody typed.
+    #expect(TerminalScreenParser.locate(inScreenTail: Self.claudeBox("")) == nil)
+    #expect(TerminalScreenParser.locate(inScreenTail: Self.geminiBox("")) == nil)
+  }
+
+  @Test("A bare shell prompt refuses — it is deliberately unsupported")
+  func bareShellRefuses() {
+    // Founder 2026-07-27: prompts are user-customisable, so there is no set to
+    // enumerate. The superseded design DID read this shape; V3 must not.
+    let bare = """
+      total 24
+      drwxr-xr-x  5 user  staff  160 Jul 26 09:00 .
+      \u{276F} git commit -m fix the
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: bare) == nil)
+  }
+
+  @Test("A box left in scrollback refuses once a live prompt sits below it")
+  func staleBoxBelowALivePromptRefuses() {
+    // The user ran a full-screen tool, quit it, and is now at a shell. The box
+    // is history; anchoring on it would join onto text from minutes ago.
+    let stale = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} old input from earlier
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} git commit -m fix the
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: stale) == nil)
+  }
+
+  @Test("A row that merely CONTAINS a marker is not an input row")
+  func markerMustOpenTheRow() {
+    // A live footer reading `Press › to continue` is not input. Requiring the
+    // marker to START the row is what separates them.
+    let footer = """
+      earlier output
+      Press \u{203A} to continue
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: footer) == nil)
+  }
+
+  @Test(
+    "Weak markers never locate input",
+    arguments: [
+      "$ echo hello", "% echo hello", "# echo hello", "81% | $107.40", "> quoted mail line",
+    ])
+  func weakMarkersRefuse(row: String) {
+    // `$` is also a dollar amount and `%` a percentage: Claude Code's own status
+    // bar reads `81% | $107.40`, which anchored the prototype on the status bar.
+    // A bare `>` is ordinary in mail, diffs and redirection — it is STRIPPED
+    // once a box has identified the row, and never SEARCHED for.
+    #expect(TerminalScreenParser.locate(inScreenTail: "output\n\(row)") == nil)
+  }
+
+  @Test("Mismatched box rules refuse")
+  func mismatchedBoxRulesRefuse() {
+    // A light rule above and a block rule below is not a box either tool draws.
+    let mixed = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      \u{276F} some text
+      \u{2580}\u{2580}\u{2580}\u{2580}\u{2580}\u{2580}\u{2580}\u{2580}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: mixed) == nil)
+  }
+
+  @Test("A short run of dashes is not a box rule")
+  func shortDashRunIsNotABoundary() {
+    let prose = """
+      \u{2500}\u{2500}
+      \u{276F} some text
+      \u{2500}\u{2500}
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: prose) == nil)
+  }
+
+  @Test("An unrecognised screen refuses")
+  func unrecognisedScreenRefuses() {
+    #expect(TerminalScreenParser.locate(inScreenTail: "") == nil)
+    #expect(TerminalScreenParser.locate(inScreenTail: "just some output\nand more") == nil)
+  }
+
+  // MARK: - The two live spoofs
+
+  @Test("A printed prompt glyph in a file does not become an input line")
+  func printedPromptSpoofRefuses() {
+    // MEASURED live in Ghostty: `echo "❯ this is not a real prompt"` then typing
+    // returned the PRINTED line. Gate 2 must not read it; Gate 1 is what refuses
+    // the case where nothing supported is running at all.
+    let spoof = """
+      \u{276F} echo "\u{276F} this is not a real prompt"
+      \u{276F} this is not a real prompt
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: spoof) == nil)
+  }
+
+  @Test("A file drawing two box rules, shown in a pager, does not become input")
+  func boxDrawingFileSpoofIsBoundedToOneLine() {
+    // MEASURED live: a file with two `────` rows displayed in vim and in less
+    // returned `text between rules`. Gate 2 CANNOT tell this from a real box —
+    // that is precisely why Gate 1 exists and why this test asserts the shape is
+    // matched rather than pretending a guard closes it.
+    let spoofed = """
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      text between rules
+      \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}
+      """
+    let located = TerminalScreenParser.locate(inScreenTail: spoofed)
+    #expect(
+      located?.inputLine == "text between rules",
+      "the screen alone cannot refuse this — Gate 1 is the gate that does")
+  }
+
+  // MARK: - Character handling
+
+  @Test("The box's non-breaking padding becomes an ordinary space")
+  func normalisesNonBreakingSpace() {
+    let located = TerminalScreenParser.locate(inScreenTail: Self.claudeBox("git\u{00A0}commit the"))
+    #expect(located?.inputLine == "git commit the")
+    #expect(located?.inputLine.contains("\u{00A0}") == false)
+  }
+
+  @Test("Trailing whitespace survives, because it is load-bearing")
+  func preservesTrailingWhitespace() {
+    // Every dictation ends with a space, so the buffer is one character longer
+    // than the visible sentence. Dropping it welds the next word onto the last.
+    let located = TerminalScreenParser.locate(inScreenTail: Self.claudeBox("fix the "))
+    #expect(located?.inputLine == "fix the ")
+  }
+
+  @Test("A marker with no separating space still strips cleanly")
+  func stripsMarkerWithoutSpace() {
+    let located = TerminalScreenParser.locate(inScreenTail: Self.claudeBox("\u{276F}no space"))
+    // The builder already supplies one marker; this adds a second immediately
+    // before the text, which must survive as ordinary content.
+    #expect(located?.inputLine == "\u{276F}no space")
+  }
+
+  @Test("Emoji and non-Latin text survive intact")
+  func preservesNonLatinText() {
+    #expect(
+      TerminalScreenParser.locate(inScreenTail: Self.claudeBox("ship it 🚀 déjà vu"))?.inputLine
+        == "ship it 🚀 déjà vu")
+    #expect(
+      TerminalScreenParser.locate(inScreenTail: Self.codexScreen("日本語のテキスト"))?.inputLine
+        == "日本語のテキスト")
+  }
+
+  @Test("Codex refuses when too much sits below its input row")
+  func codexRefusesWhenBuriedInOutput() {
+    // Its status bar is at most two rows. More means the marker row is
+    // scrollback, not the live input.
+    let buried = """
+      \u{203A} an old command
+      output line one
+      output line two
+      output line three
+      """
+    #expect(TerminalScreenParser.locate(inScreenTail: buried) == nil)
+  }
+}


### PR DESCRIPTION
## What this fixes

You pause mid-sentence in a terminal, carry on dictating, and the next word arrives with a capital letter it should not have. That is the complaint this exists for — the founder's words: *"multiple people have raised concerns and complained that when they paused mid-sentence, the first letter is capitalized and it looks bad."*

Cursor-aware insertion already fixes that everywhere the app can see the cursor. A terminal reports a caret pinned at 0 while its character count grows, so the shipped repair correctly refuses there and nothing replaced it. Now something does.

## Why it needs three gates rather than one screen read

Reading the screen alone is not safe, and that is measured rather than argued. Two spoofs, both reproduced live in Ghostty:

- `echo "❯ this is not a real prompt"`, then typing — the reader returned the PRINTED line.
- a file containing two box-drawing rows, shown in `vim` and in `less` — returned `text between rules`.

Guards close instances; the class stays open, because anything drawn on a screen IS an input box to a screen reader. So the support decision moved off the screen entirely.

| Gate | Question | Answered by |
|---|---|---|
| 0 | Is this a terminal we have measured? | bundle identifier |
| 1 | Is a supported CLI actually running here? | the process list — a file cannot fake a running program |
| 2 | Where is the input line? | the focused tab's screen |

Any refusal delivers today's payload byte for byte.

## Two design changes the founder made, each after a measurement

**Gate 1 is a VETO, not a tab selector.** The approved rule matched a job's folder against the focused window's. Measured on his machine, it REFUSED on his own main project, because Claude Code and a plain shell shared that folder — and a terminal exposes only one folder per tab, so five tabs in one project all report the same one. The folder was never going to identify a tab. The session-directory read was then deleted rather than left in.

**Identity is "runs in a terminal", not "installed here".** An install-path matcher was built first, then measured to miss the Homebrew Codex on his own machine — silently, so the feature would simply never engage for anyone who installed that way. The replacement asks one question impostors fail: does this process hold a controlling terminal?

Head-to-head on the same live processes, with all three tools genuinely running:

| Running for real | install path | terminal + name |
|---|---|---|
| Claude Code ×3 | found | found |
| Gemini (npm) | found | found |
| **Codex (Homebrew)** | **MISSED** | found |
| 35 name-lookalikes | rejected | rejected |

All 35 lookalikes — every ChatGPT desktop helper, and a real executable literally named `codex` inside ChatGPT.app — are GUI processes holding no terminal, so the class closes structurally rather than by a list needing perpetual extension.

## Measured, not assumed

- Signed Developer-ID binary under hardened runtime: 710 PIDs, 705 exec paths, 456 environments, **mean 3 ms / p95 7 ms** against a 100 ms budget. No candidate pre-filter, because at that cost it would only add a guess about how CLIs are launched.
- **`argv[1]` must be read as the path AS INVOKED.** npm CLIs are shebang scripts behind a bin symlink, so matching the package folder found nothing for a normal install while still working on Claude Code — the asymmetry that would have shipped this half-broken.
- Screen tail is 6,000 UTF-16 units: 2,000 lost the opening boundary row on long input, 6,000 held it to 4,800 typed characters. Never a whole-field read — on a terminal that is the entire scrollback.

## Safety properties

- **Screen evidence can never authorise the Tier 1 accessibility write.** That route's safety rests on real selection offsets and surrounding windows read from the field microseconds before writing; a screen-derived context has neither.
- **One cumulative resolution budget per delivery**, shared by the initial read and all three commit boundaries. A fresh budget per route would let the wait grow with the number of routes tried.
- **A wedged terminal latches off** by target PID, because `withDeadline` cannot preempt a blocked thread and abandoned reads would otherwise accumulate.
- **Any line break refuses** in a terminal — a newline there can submit the command.
- Refusals: wrapped box, empty box, stale box, bare shell, unrecognised layout, mismatched rules, unreadable process list.

## Accepted limits, stated rather than hidden

- **Mid-line dictation can lose a spoken word** to de-duplication. Founder's ruling: assume end-of-line.
- **A supported CLI in one tab plus a box-drawing file open in another can still be read.** Three coincidences; cost is a wrong space, a wrong capital, or one dropped word. This is a UAT receipt to DEMONSTRATE, not a claim to have closed.
- **Bare shell is unsupported.** Prompts are user-customisable, so there is no set to enumerate.
- A file deliberately named `codex` run in a terminal reads as Codex. Founder: *"we can't deal with every edge case."*

## Tests

**4,155 across 397 suites, all green.** New: 28 process-veto, 22 screen-parser, 22 resolver, 10 policy.

Verified two-way rather than merely passing:
- The parser suite was **mutation-tested** — relaxing "the marker must open the row" makes exactly the intended test fail.
- The Tier 1 exclusion is tested with identical offsets both ways: screen-derived refuses, caret-derived commits. (An earlier version passed for the wrong reason — it could only be reached with a nil element — and was fixed, not kept.)
- Live controls fail loudly if the strict process parser starts rejecting real blobs, or the terminal flag sticks to one value.

## Review

One chunk review returned CHUNK-NEEDS-WORK and found two things reasoned wrong, not just coded wrong: a truncated process blob returned partial success (and my own test had frozen that as correct), and I had argued a measured spoof was not worth refusing because the class is spoofable. Both fixed. Two suggested containments were REJECTED with reasons — each disabled the feature over a residual needing a user to mislead their own machine.

## Not done

**Live UAT.** It means dictating into live terminal sessions; leaving it for the founder, as agreed. Receipts needed: all three tools in all three terminals, five tabs in one project, bare shell refusing, both spoofs, and the accepted residual demonstrated.

Part of #1803.
