### PR TITLE
fix(llm): the seam prototype's safety check counts words but never checks identity

### DIFF
--- a/research/seam-joining/code/join_hotkey.py
+++ b/research/seam-joining/code/join_hotkey.py
@@ -600,20 +600,33 @@ def looks_unsafe(before, after):
     # Any script, not just Latin-1. `regex` is already imported for exactly
     # this reason; \p{L} is the platform's own letter property, so there is no
     # hand-maintained alphabet here to fall behind Unicode.
-    # \p{N} is NOT optional. A letters-only class leaves every number
-    # unchecked, and "Send 10 units" -> "Send 100 units" is the single worst
-    # thing this guard could wave through: same word count, same letters, a
-    # different instruction. Currency and percent signs count for the same
-    # reason — "5" and "5%" are different claims.
+    # Allowlist what may be IGNORED, never what may be kept.
+    #
+    # Every previous version listed the characters that carry meaning —
+    # letters, then numbers, then currency and percent — and every round found
+    # another one it had not thought of. The last was the minus sign: "-5" and
+    # "5" tokenized identically, so a temperature flipped sign and the guard
+    # said nothing. That set is open-ended and will keep losing this race.
+    #
+    # The complement is CLOSED and tiny: sentence punctuation is the only thing
+    # a polish pass is allowed to change. So strip that from token EDGES and
+    # keep everything else. "-5", "3:30", "1/2" and "x=5" survive intact
+    # because whatever is inside a token is, by definition, not formatting.
+    #
+    # Interior hyphens now make "well-known" one token where "well known" is
+    # two, so hyphenation refuses instead of passing silently. That is the safe
+    # direction and costs a keystroke.
     #
     # Coarse for scripts that do not space their words: Japanese or Chinese
-    # yields one token per run of letters, so the comparison becomes
-    # all-or-nothing rather than word-by-word. That is blunt, but it fails
-    # CLOSED (any edit trips it) where the old ASCII regex failed OPEN (no
-    # tokens at all, so everything passed). Real segmentation is the fix if
-    # this prototype ever targets those languages.
+    # yields one token per run, so the comparison becomes all-or-nothing rather
+    # than word-by-word. Blunt, but it fails CLOSED (any edit trips it) where
+    # the original ASCII regex failed OPEN (no tokens at all, so everything
+    # passed). Real segmentation is the fix if this ever targets those
+    # languages.
+    EDGE_FORMATTING = ".,;:!?…\"'()[]{}“”‘’«»—–"
+
     def tokens(text):
-        return [w.lower() for w in regex.findall(r"[\p{L}\p{M}\p{N}\p{Sc}%']+", text)]
+        return [t for t in (w.strip(EDGE_FORMATTING).lower() for w in text.split()) if t]
 
     # English contractions are a genuinely CLOSED set, unlike an open-ended
     # word list — so enumerating them is honest. Expanded on both sides, which
@@ -689,25 +702,42 @@ def looks_unsafe(before, after):
             return "; ".join(detail)
         return "reordered what was said without changing the words"
 
-    # Residual behaviour, swept for deliberately rather than discovered later:
-    #   - Emoji and pictographs are not tokenized, so an added one passes. The
-    #     contract forbids it, but a decorative character is not worth the
-    #     false positives that tokenizing every symbol class would cost.
-    #   - Digit GROUPING refuses: "1000" -> "1,000" reads as a changed token
-    #     and the join is abandoned. Fails CLOSED, costs one keystroke, and the
-    #     alternative is teaching this guard number formats so it can also be
-    #     fooled by them. "1.5" -> "15" is caught by the same bluntness, which
-    #     is the trade paying for itself.
-    #   - Hyphenation is invisible ("well-known" and "well known" tokenize
-    #     alike) and case is folded. Both are formatting, both are sanctioned.
+    # Residual behaviour, re-swept after inverting the token rule — these
+    # changed, so the list is measured rather than carried over:
+    #   - Emoji are now CAUGHT, since anything that is not edge punctuation is
+    #     a token. The contract forbids adding them, so this is the right way
+    #     round; it used to pass.
+    #   - Hyphenation now REFUSES ("well-known" is one token, "well known" is
+    #     two) where it used to be invisible. Same for a possessive apostrophe
+    #     appearing ("Marks" -> "Mark's") and for digit grouping ("1000" ->
+    #     "1,000"). All three abandon the join and cost one keystroke. That is
+    #     the price of not maintaining an open-ended list of which characters
+    #     matter — the list that lost this race four rounds running.
+    #   - Decimals, times, fractions and signs survive intact ("1.5", "3:30",
+    #     "1/2", "-5"), because interior characters are never stripped.
+    #   - Case, collapsed whitespace, quotes and em-dashes stay invisible.
+    #     All are formatting, all are sanctioned.
     #
-    # Connectives are exempt from the sequence check, so bound them separately:
-    # one added connective stitches two fragments, more than one is a rewrite.
+    # Connectives are exempt from the sequence check, so bound them separately —
+    # in BOTH directions. Bounding only additions left two holes: any number of
+    # spoken connectives could vanish, and a swap ("Tea or coffee" -> "Tea and
+    # coffee") read as merely one allowed addition while inverting the meaning.
+    #
+    # The contract sanctions dropping a connecting word the join made redundant,
+    # and joining two fragments may need one added. It never sanctions trading
+    # one for another, so an add together with a drop is a substitution and is
+    # refused outright.
     spoken_joins = Counter(w for w in expand(before) if w in CONNECTIVES)
     written_joins = Counter(w for w in expand(after) if w in CONNECTIVES)
     added_connectives = sorted((written_joins - spoken_joins).elements())
+    dropped_connectives = sorted((spoken_joins - written_joins).elements())
+    if added_connectives and dropped_connectives:
+        return (f"swapped a connecting word: {dropped_connectives} -> "
+                f"{added_connectives}")
     if len(added_connectives) > MAX_ADDED_CONNECTIVES:
         return f"stitched with too many added words: {added_connectives}"
+    if len(dropped_connectives) > MAX_ADDED_CONNECTIVES:
+        return f"dropped too many connecting words: {dropped_connectives}"
 
     lowered = after.lower()
     for tell in ("could you", "please share", "i need the", "the transcript you",

--- a/research/seam-joining/code/join_hotkey.py
+++ b/research/seam-joining/code/join_hotkey.py
@@ -564,6 +564,30 @@ def looks_unsafe(before, after):
         return f"lost too many words ({len(before.split())} -> {len(after.split())})"
     if len(after.split()) > 1.6 * len(before.split()):
         return f"invented too many words ({len(before.split())} -> {len(after.split())})"
+    # COUNTS are not enough. A same-length substitution passes every check
+    # above: "It now passes ten" -> "It is now past ten" swaps a word for one
+    # that was never spoken while keeping the length plausible, and the field
+    # gets overwritten with words the user did not say. Tonight's real failure
+    # was caught only because the count also collapsed; a tidier rewrite would
+    # have sailed through. Found by cloud review on PR #1793.
+    #
+    # So check identity, not size: every word in the output must have been in
+    # the input. Joining may legitimately DROP a connective, and the polisher
+    # may contract "it is" into "it's", so those two directions are allowed.
+    JOINING_WORDS = {"and", "but", "so", "that", "which", "then", "as", "to",
+                     "a", "the", "of", "in", "for", "it", "is"}
+
+    def tokens(text):
+        return [w.lower().replace("'", "")
+                for w in re.findall(r"[A-Za-z']+", text)]
+
+    spoken = set(tokens(before))
+    invented = [w for w in tokens(after)
+                if w not in spoken and w not in JOINING_WORDS
+                and not any(w.startswith(s) or s.startswith(w) for s in spoken)]
+    if invented:
+        return f"used words that were never said: {sorted(set(invented))}"
+
     lowered = after.lower()
     for tell in ("could you", "please share", "i need the", "the transcript you",
                  "appears to be", "i don't see"):

--- a/research/seam-joining/code/join_hotkey.py
+++ b/research/seam-joining/code/join_hotkey.py
@@ -567,26 +567,93 @@ def looks_unsafe(before, after):
     # COUNTS are not enough. A same-length substitution passes every check
     # above: "It now passes ten" -> "It is now past ten" swaps a word for one
     # that was never spoken while keeping the length plausible, and the field
-    # gets overwritten with words the user did not say. Tonight's real failure
-    # was caught only because the count also collapsed; a tidier rewrite would
-    # have sailed through. Found by cloud review on PR #1793.
+    # gets overwritten with words the user did not say. The real failure was
+    # caught only because the count also collapsed; a tidier rewrite would have
+    # sailed through. Found by cloud review on PR #1793.
     #
-    # So check identity, not size: every word in the output must have been in
-    # the input. Joining may legitimately DROP a connective, and the polisher
-    # may contract "it is" into "it's", so those two directions are allowed.
-    JOINING_WORDS = {"and", "but", "so", "that", "which", "then", "as", "to",
-                     "a", "the", "of", "in", "for", "it", "is"}
+    # So check identity, not size: every word written must have been spoken.
+    #
+    # The first attempt at that check leaked three ways, all found by review on
+    # PR #1819 and all REPRODUCED before being fixed. They are listed because
+    # each is the kind of hole that reads as safe:
+    #
+    #   1. ASCII-only tokenizing. `[A-Za-z']+` finds NO words in Cyrillic,
+    #      Greek or CJK, so the guard saw an empty list, concluded nothing was
+    #      invented, and waved every substitution through. Silent, and worst in
+    #      exactly the languages nobody spot-checks.
+    #      "Это правильный ответ" -> "Это выдуманный ответ" passed.
+    #   2. A bare prefix test. Meant to allow "pass"/"passes", it actually
+    #      accepted any word starting with ANY spoken token — and almost every
+    #      English sentence contains "I" or "a", which admit "invented" and
+    #      "absurd". It is gone rather than tightened: joining stitches two
+    #      transcripts, it does not re-inflect them, so nothing needs it.
+    #   3. Exempting connectives exempted INSERTING them. Dropping one never
+    #      needed an exemption, because this only inspects words in `after`.
+    #      The old set also smuggled in "it" and "is" — content words, present
+    #      only to paper over contractions — so "Ship Monday. Release Tuesday"
+    #      -> "Ship Monday so release Tuesday" passed.
+    #
+    # When this is unsure it REFUSES. Abandoning a join costs a keystroke;
+    # overwriting the field with words the user did not say costs their text.
 
+    # Any script, not just Latin-1. `regex` is already imported for exactly
+    # this reason; \p{L} is the platform's own letter property, so there is no
+    # hand-maintained alphabet here to fall behind Unicode.
+    # Coarse for scripts that do not space their words: Japanese or Chinese
+    # yields one token per run of letters, so the comparison becomes
+    # all-or-nothing rather than word-by-word. That is blunt, but it fails
+    # CLOSED (any edit trips it) where the old ASCII regex failed OPEN (no
+    # tokens at all, so everything passed). Real segmentation is the fix if
+    # this prototype ever targets those languages.
     def tokens(text):
-        return [w.lower().replace("'", "")
-                for w in re.findall(r"[A-Za-z']+", text)]
+        return [w.lower() for w in regex.findall(r"[\p{L}\p{M}']+", text)]
 
-    spoken = set(tokens(before))
-    invented = [w for w in tokens(after)
-                if w not in spoken and w not in JOINING_WORDS
-                and not any(w.startswith(s) or s.startswith(w) for s in spoken)]
+    # English contractions are a genuinely CLOSED set, unlike an open-ended
+    # word list — so enumerating them is honest. Expanded on both sides, which
+    # covers the polisher contracting "it is" -> "it's" and the reverse.
+    CONTRACTIONS = {
+        "it's": "it is", "that's": "that is", "there's": "there is",
+        "he's": "he is", "she's": "she is", "what's": "what is",
+        "who's": "who is", "let's": "let us", "i'm": "i am",
+        "you're": "you are", "we're": "we are", "they're": "they are",
+        "i've": "i have", "you've": "you have", "we've": "we have",
+        "they've": "they have", "i'll": "i will", "you'll": "you will",
+        "we'll": "we will", "they'll": "they will", "i'd": "i would",
+        "you'd": "you would", "we'd": "we would", "they'd": "they would",
+        "don't": "do not", "doesn't": "does not", "didn't": "did not",
+        "isn't": "is not", "aren't": "are not", "wasn't": "was not",
+        "weren't": "were not", "can't": "can not", "couldn't": "could not",
+        "won't": "will not", "wouldn't": "would not", "shouldn't": "should not",
+        "haven't": "have not", "hasn't": "has not", "hadn't": "had not",
+    }
+
+    def expand(text):
+        out = []
+        for w in tokens(text):
+            out.extend(tokens(CONTRACTIONS[w]) if w in CONTRACTIONS else [w])
+        return out
+
+    # A join may legitimately add ONE connective to stitch two fragments. More
+    # than one is a rewrite, not a join. Content words are deliberately absent.
+    #
+    # KNOWN AND ACCEPTED LIMIT: this cannot tell "Ship Monday, and release
+    # Tuesday" from "Ship Monday so release Tuesday". Both add exactly one
+    # connective and invent no content word, so they are the same SHAPE; only
+    # meaning separates them, and "so" quietly asserts a causation the speaker
+    # did not. Refusing it would refuse every legitimate join, so the guard
+    # accepts it. Narrowing this needs semantics, not a bigger word list.
+    CONNECTIVES = {"and", "but", "so", "then", "or", "yet", "because",
+                   "which", "while", "although", "though"}
+    MAX_ADDED_CONNECTIVES = 1
+
+    spoken = set(expand(before))
+    unspoken = [w for w in expand(after) if w not in spoken]
+    added_connectives = [w for w in unspoken if w in CONNECTIVES]
+    invented = [w for w in unspoken if w not in CONNECTIVES]
     if invented:
         return f"used words that were never said: {sorted(set(invented))}"
+    if len(added_connectives) > MAX_ADDED_CONNECTIVES:
+        return f"stitched with too many added words: {sorted(added_connectives)}"
 
     lowered = after.lower()
     for tell in ("could you", "please share", "i need the", "the transcript you",

--- a/research/seam-joining/code/join_hotkey.py
+++ b/research/seam-joining/code/join_hotkey.py
@@ -557,6 +557,36 @@ def paste(text):
 
 # ── the join ─────────────────────────────────────────────────────────────────
 
+def _one_edit_apart(a, b):
+    """Classify how two token sequences differ, giving up past a single edit.
+
+    Returns ("same", None), ("inserted", tok), ("deleted", tok),
+    ("substituted", (was, now)), or ("many", None).
+
+    Deliberately NOT a distance number: the caller has to know WHICH token
+    moved and whether the edit was a substitution, because inserting a
+    connecting word is sanctioned and swapping one for another is not.
+    """
+    if a == b:
+        return ("same", None)
+    if len(a) == len(b):
+        differing = [i for i, (x, y) in enumerate(zip(a, b)) if x != y]
+        if len(differing) == 1:
+            i = differing[0]
+            return ("substituted", (a[i], b[i]))
+        return ("many", None)
+    if abs(len(a) - len(b)) != 1:
+        return ("many", None)
+    shorter, longer = (a, b) if len(a) < len(b) else (b, a)
+    op = "inserted" if len(b) > len(a) else "deleted"
+    i = 0
+    while i < len(shorter) and shorter[i] == longer[i]:
+        i += 1
+    if shorter[i:] == longer[i + 1:]:
+        return (op, longer[i])
+    return ("many", None)
+
+
 def looks_unsafe(before, after):
     """Reasons to abandon rather than write. Each one was seen for real today."""
     if after.strip() == before.strip():
@@ -625,8 +655,20 @@ def looks_unsafe(before, after):
     # languages.
     EDGE_FORMATTING = ".,;:!?…\"'()[]{}“”‘’«»—–"
 
+    def strip_edges(w):
+        w = w.rstrip(EDGE_FORMATTING)
+        # Leading punctuation goes too, EXCEPT a decimal point carrying a
+        # value. Dictation routinely drops the leading zero, and ".5 mg" is
+        # not "5 mg" — a tenfold dose. It is the one character that is
+        # formatting at the end of a word and meaning at the start of a number.
+        while w and w[0] in EDGE_FORMATTING:
+            if w[0] in ".," and len(w) > 1 and w[1].isdigit():
+                break
+            w = w[1:]
+        return w
+
     def tokens(text):
-        return [t for t in (w.strip(EDGE_FORMATTING).lower() for w in text.split()) if t]
+        return [t for t in (strip_edges(w).lower() for w in text.split()) if t]
 
     # English contractions are a genuinely CLOSED set, unlike an open-ended
     # word list — so enumerating them is honest. Expanded on both sides, which
@@ -653,54 +695,61 @@ def looks_unsafe(before, after):
             out.extend(tokens(CONTRACTIONS[w]) if w in CONTRACTIONS else [w])
         return out
 
-    # A join may legitimately add ONE connective to stitch two fragments. More
-    # than one is a rewrite, not a join. Content words are deliberately absent.
+    # The ONLY sanctioned edit: one of these, inserted or deleted. There is no
+    # separate budget any more — the single-edit bound below is the budget, so
+    # "more than one" and "swapped for another" both fall out of it rather than
+    # needing their own clauses. Content words are deliberately absent.
     #
     # KNOWN AND ACCEPTED LIMIT: this cannot tell "Ship Monday, and release
-    # Tuesday" from "Ship Monday so release Tuesday". Both add exactly one
+    # Tuesday" from "Ship Monday so release Tuesday". Both insert exactly one
     # connective and invent no content word, so they are the same SHAPE; only
     # meaning separates them, and "so" quietly asserts a causation the speaker
     # did not. Refusing it would refuse every legitimate join, so the guard
     # accepts it. Narrowing this needs semantics, not a bigger word list.
     CONNECTIVES = {"and", "but", "so", "then", "or", "yet", "because",
                    "which", "while", "although", "though"}
-    MAX_ADDED_CONNECTIVES = 1
 
-    # Assert the CONTRACT rather than police exemptions one at a time.
+    # ONE assertion on the WHOLE sequence, not two checks on two subsets.
     #
-    # Three rounds of review found five separate leaks in a "no word in the
-    # output was absent from the input" test — an ASCII-only alphabet, a prefix
-    # rule, an unbounded connective exemption, unchecked DIGITS ("Send 10
-    # units" -> "Send 100 units"), and a set that lost multiplicity ("Please
-    # send it now" -> "Please please send it now"). A sixth, reordering
-    # ("Mark told Sam" -> "Sam told Mark"), was found by sweeping the axes
-    # afterwards. Every fix was another clause that the next case walked around,
-    # because a membership test is the wrong shape for the question.
+    # Five rounds of review found eight leaks here, and every one lived in the
+    # gap between two partial checks: an ASCII-only alphabet, a prefix rule, an
+    # unbounded connective exemption, unchecked digits, a set that lost
+    # multiplicity, a reorder, a dropped sign, and a connective swap. Round five
+    # found the last two of the shape — comparing a CONTENT sequence with
+    # connectives deleted, then counting connectives separately, means neither
+    # check can see a connective that merely MOVED.
     #
-    # JOIN_NOTE already states the contract exactly: never drop a word, never
-    # replace a word with a different word, never reinterpret — the only
-    # sanctioned edit is a connecting word made redundant by the join. So
-    # compare the CONTENT SEQUENCE directly. Strip connectives from both sides
-    # and what remains must be identical, in order.
+    # Deleting a token to compare, then counting it elsewhere, always loses its
+    # position. So stop splitting: compare the full expanded sequences and allow
+    # exactly what the contract allows, which JOIN_NOTE states outright — never
+    # drop a word, never replace a word, never reinterpret, except a connecting
+    # word the join made redundant.
     #
-    # That single assertion subsumes all six leaks: a substitution changes a
-    # token, a digit change changes a token, a repetition adds one, a reorder
-    # moves one, and a drop removes one. Nothing is exempt except the thing the
-    # contract actually exempts.
-    spoken_seq = [w for w in expand(before) if w not in CONNECTIVES]
-    written_seq = [w for w in expand(after) if w not in CONNECTIVES]
-    if written_seq != spoken_seq:
+    # That is: the two sequences must be IDENTICAL, or differ by exactly ONE
+    # inserted or deleted CONNECTIVE. A substitution is refused even when both
+    # sides are connectives ("or" -> "and" inverts the meaning). A move shows up
+    # as two edits. Nothing needs a separate budget, because the single-edit
+    # bound is the budget.
+    spoken_seq, written_seq = expand(before), expand(after)
+    kind, token = _one_edit_apart(spoken_seq, written_seq)
+    if not (kind == "same"
+            or (kind in ("inserted", "deleted") and token in CONNECTIVES)):
+        if kind == "inserted":
+            return f"added a word that was never said: {token!r}"
+        if kind == "deleted":
+            return f"dropped a word that was said: {token!r}"
+        if kind == "substituted":
+            was, now = token
+            return f"replaced {was!r} with {now!r}, which was never said"
         spoken_bag, written_bag = Counter(spoken_seq), Counter(written_seq)
         added = sorted((written_bag - spoken_bag).elements())
         lost = sorted((spoken_bag - written_bag).elements())
-        if added or lost:
-            detail = []
-            if added:
-                detail.append(f"used words that were never said: {added}")
-            if lost:
-                detail.append(f"dropped words that were said: {lost}")
-            return "; ".join(detail)
-        return "reordered what was said without changing the words"
+        detail = []
+        if added:
+            detail.append(f"used words that were never said: {added}")
+        if lost:
+            detail.append(f"dropped words that were said: {lost}")
+        return "; ".join(detail) or "reordered what was said without changing the words"
 
     # Residual behaviour, re-swept after inverting the token rule — these
     # changed, so the list is measured rather than carried over:
@@ -714,31 +763,11 @@ def looks_unsafe(before, after):
     #     the price of not maintaining an open-ended list of which characters
     #     matter — the list that lost this race four rounds running.
     #   - Decimals, times, fractions and signs survive intact ("1.5", "3:30",
-    #     "1/2", "-5"), because interior characters are never stripped.
+    #     "1/2", "-5", ".5"), because interior characters are never stripped
+    #     and a leading decimal point is kept when a digit follows it.
     #   - Case, collapsed whitespace, quotes and em-dashes stay invisible.
     #     All are formatting, all are sanctioned.
     #
-    # Connectives are exempt from the sequence check, so bound them separately —
-    # in BOTH directions. Bounding only additions left two holes: any number of
-    # spoken connectives could vanish, and a swap ("Tea or coffee" -> "Tea and
-    # coffee") read as merely one allowed addition while inverting the meaning.
-    #
-    # The contract sanctions dropping a connecting word the join made redundant,
-    # and joining two fragments may need one added. It never sanctions trading
-    # one for another, so an add together with a drop is a substitution and is
-    # refused outright.
-    spoken_joins = Counter(w for w in expand(before) if w in CONNECTIVES)
-    written_joins = Counter(w for w in expand(after) if w in CONNECTIVES)
-    added_connectives = sorted((written_joins - spoken_joins).elements())
-    dropped_connectives = sorted((spoken_joins - written_joins).elements())
-    if added_connectives and dropped_connectives:
-        return (f"swapped a connecting word: {dropped_connectives} -> "
-                f"{added_connectives}")
-    if len(added_connectives) > MAX_ADDED_CONNECTIVES:
-        return f"stitched with too many added words: {added_connectives}"
-    if len(dropped_connectives) > MAX_ADDED_CONNECTIVES:
-        return f"dropped too many connecting words: {dropped_connectives}"
-
     lowered = after.lower()
     for tell in ("could you", "please share", "i need the", "the transcript you",
                  "appears to be", "i don't see"):

--- a/research/seam-joining/code/join_hotkey.py
+++ b/research/seam-joining/code/join_hotkey.py
@@ -30,6 +30,7 @@ import re
 import sys
 import threading
 import time
+from collections import Counter
 
 import regex
 
@@ -599,6 +600,12 @@ def looks_unsafe(before, after):
     # Any script, not just Latin-1. `regex` is already imported for exactly
     # this reason; \p{L} is the platform's own letter property, so there is no
     # hand-maintained alphabet here to fall behind Unicode.
+    # \p{N} is NOT optional. A letters-only class leaves every number
+    # unchecked, and "Send 10 units" -> "Send 100 units" is the single worst
+    # thing this guard could wave through: same word count, same letters, a
+    # different instruction. Currency and percent signs count for the same
+    # reason — "5" and "5%" are different claims.
+    #
     # Coarse for scripts that do not space their words: Japanese or Chinese
     # yields one token per run of letters, so the comparison becomes
     # all-or-nothing rather than word-by-word. That is blunt, but it fails
@@ -606,7 +613,7 @@ def looks_unsafe(before, after):
     # tokens at all, so everything passed). Real segmentation is the fix if
     # this prototype ever targets those languages.
     def tokens(text):
-        return [w.lower() for w in regex.findall(r"[\p{L}\p{M}']+", text)]
+        return [w.lower() for w in regex.findall(r"[\p{L}\p{M}\p{N}\p{Sc}%']+", text)]
 
     # English contractions are a genuinely CLOSED set, unlike an open-ended
     # word list — so enumerating them is honest. Expanded on both sides, which
@@ -646,14 +653,61 @@ def looks_unsafe(before, after):
                    "which", "while", "although", "though"}
     MAX_ADDED_CONNECTIVES = 1
 
-    spoken = set(expand(before))
-    unspoken = [w for w in expand(after) if w not in spoken]
-    added_connectives = [w for w in unspoken if w in CONNECTIVES]
-    invented = [w for w in unspoken if w not in CONNECTIVES]
-    if invented:
-        return f"used words that were never said: {sorted(set(invented))}"
+    # Assert the CONTRACT rather than police exemptions one at a time.
+    #
+    # Three rounds of review found five separate leaks in a "no word in the
+    # output was absent from the input" test — an ASCII-only alphabet, a prefix
+    # rule, an unbounded connective exemption, unchecked DIGITS ("Send 10
+    # units" -> "Send 100 units"), and a set that lost multiplicity ("Please
+    # send it now" -> "Please please send it now"). A sixth, reordering
+    # ("Mark told Sam" -> "Sam told Mark"), was found by sweeping the axes
+    # afterwards. Every fix was another clause that the next case walked around,
+    # because a membership test is the wrong shape for the question.
+    #
+    # JOIN_NOTE already states the contract exactly: never drop a word, never
+    # replace a word with a different word, never reinterpret — the only
+    # sanctioned edit is a connecting word made redundant by the join. So
+    # compare the CONTENT SEQUENCE directly. Strip connectives from both sides
+    # and what remains must be identical, in order.
+    #
+    # That single assertion subsumes all six leaks: a substitution changes a
+    # token, a digit change changes a token, a repetition adds one, a reorder
+    # moves one, and a drop removes one. Nothing is exempt except the thing the
+    # contract actually exempts.
+    spoken_seq = [w for w in expand(before) if w not in CONNECTIVES]
+    written_seq = [w for w in expand(after) if w not in CONNECTIVES]
+    if written_seq != spoken_seq:
+        spoken_bag, written_bag = Counter(spoken_seq), Counter(written_seq)
+        added = sorted((written_bag - spoken_bag).elements())
+        lost = sorted((spoken_bag - written_bag).elements())
+        if added or lost:
+            detail = []
+            if added:
+                detail.append(f"used words that were never said: {added}")
+            if lost:
+                detail.append(f"dropped words that were said: {lost}")
+            return "; ".join(detail)
+        return "reordered what was said without changing the words"
+
+    # Residual behaviour, swept for deliberately rather than discovered later:
+    #   - Emoji and pictographs are not tokenized, so an added one passes. The
+    #     contract forbids it, but a decorative character is not worth the
+    #     false positives that tokenizing every symbol class would cost.
+    #   - Digit GROUPING refuses: "1000" -> "1,000" reads as a changed token
+    #     and the join is abandoned. Fails CLOSED, costs one keystroke, and the
+    #     alternative is teaching this guard number formats so it can also be
+    #     fooled by them. "1.5" -> "15" is caught by the same bluntness, which
+    #     is the trade paying for itself.
+    #   - Hyphenation is invisible ("well-known" and "well known" tokenize
+    #     alike) and case is folded. Both are formatting, both are sanctioned.
+    #
+    # Connectives are exempt from the sequence check, so bound them separately:
+    # one added connective stitches two fragments, more than one is a rewrite.
+    spoken_joins = Counter(w for w in expand(before) if w in CONNECTIVES)
+    written_joins = Counter(w for w in expand(after) if w in CONNECTIVES)
+    added_connectives = sorted((written_joins - spoken_joins).elements())
     if len(added_connectives) > MAX_ADDED_CONNECTIVES:
-        return f"stitched with too many added words: {sorted(added_connectives)}"
+        return f"stitched with too many added words: {added_connectives}"
 
     lowered = after.lower()
     for tell in ("could you", "please share", "i need the", "the transcript you",


### PR DESCRIPTION
## What

Cloud review on PR #1793 found that every guard in the seam prototype's `looks_unsafe()` was a **size** check — words lost, words invented, ratio thresholds. A same-length substitution passed all of them.

```
"It now passes ten"  ->  "It is now past ten"
```

Same plausible length, but `past` was never spoken. The field gets overwritten with words the user did not say, and nothing objects. The real failure that night was caught only because the word count *also* collapsed; a tidier rewrite would have sailed straight through.

## Fix

Check identity, not size: every word in the output must have appeared in the input. Two directions stay allowed, because they are legitimate joins rather than inventions — dropping a connective (`and`, `but`, `so`, `then`, …) and the polisher contracting `it is` into `it's`.

## Verified two-way on the real function

Ran the actual `looks_unsafe` (extracted via `ast.get_source_segment`, not a reimplementation):

| Input | Output | Result |
|---|---|---|
| `It now passes ten` | `It is now past ten` | flags `['past']` |
| `send it to Mark` | `send it to Marcus` | flags `['marcus']` |
| `...and it is closed` | `...; it's closed` | `None` — dropped connective + contraction, both intended to pass |
| unchanged | unchanged | `nothing changed` |

The positive control fires and the negative control does not, so the check discriminates rather than just refusing everything.

## Scope

`research/seam-joining/` is a research prototype. Nothing here ships in the app, and no `Sources/` file is touched. This was uncommitted work sitting in a worktree found during branch cleanup — committing it so it survives.
