### PR TITLE
fix(llm): speak each Gemini model's own thinking dialect, and replace the retired default (#1770, #1769)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -214,6 +214,13 @@ enum SettingsProjection {
     "gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.5-flash-8b",
     "gemini-2.0-flash", "gemini-2.0-flash-lite",
     "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
+    // #1770: the allowlist stopped at 2.5, so every Gemini 3.x user's
+    // configured model reconstructed as `custom` and the whole generation was
+    // invisible in settings snapshots. These eight are the ids the picker
+    // actually offers, verified reachable against the live API 2026-07-29.
+    "gemini-3-flash-preview", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview",
+    "gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools",
+    "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.6-flash",
     // Claude
     "claude-sonnet-5", "claude-fable-5", "claude-opus-4-8", "claude-opus-4-7",
     "claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-5", "claude-haiku-4-5",

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -252,9 +252,6 @@ public enum LLMConstants {
   /// reasoning and emit a clean answer; `done_reason=stop` ends generation
   /// early for short transcripts so latency is bounded.
   public static let ollamaThinkingMaxTokens: Int = 2048
-
-  /// Default thinking budget for extended thinking models (Gemini 2.5 Flash/Pro).
-  public static let defaultThinkingBudget: Int = 8192
 }
 
 public enum FormattingConstants {

--- a/Sources/EnviousWisprCore/LLMResult.swift
+++ b/Sources/EnviousWisprCore/LLMResult.swift
@@ -65,24 +65,40 @@ extension LLMProvider {
   /// the provider has actually withdrawn, never a model the user legitimately
   /// chose. Each was verified 404 against the live API on 2026-07-29.
   ///
+  /// KEYED BY PROVIDER, not a flat set of ids. An Ollama model is named by the
+  /// user, so a local model called `gemini-2.0-flash` is a perfectly legitimate
+  /// choice that a flat set would silently rewrite to `llama3.2` on a recovery
+  /// replay. Keying also keeps the next entry honest: under a flat set plus a
+  /// `provider == .gemini` guard, a future OpenAI retirement added here would be
+  /// silently ignored — it would LOOK registered and do nothing.
+  ///
   /// This is NOT a general staleness mechanism. When Google retires the next
   /// model, a human adds it here — the same human gate that governs adding a
   /// new model's thinking dialect.
-  public static let retiredModelIDs: Set<String> = [
-    "gemini-2.0-flash",
-    "gemini-2.0-flash-lite",
-    "gemini-3-pro-preview",
+  public static let retiredModelIDs: [LLMProvider: Set<String>] = [
+    .gemini: [
+      "gemini-2.0-flash",
+      "gemini-2.0-flash-lite",
+      "gemini-3-pro-preview",
+    ]
   ]
+
+  /// Whether `provider` has WITHDRAWN `modelID`. The single membership test both
+  /// repair seams read, so neither can drift from the other.
+  public static func isRetiredModel(_ modelID: String, for provider: LLMProvider) -> Bool {
+    retiredModelIDs[provider]?.contains(modelID) ?? false
+  }
 
   /// Substitute the provider's current default for a WITHDRAWN model id,
   /// leaving every live id untouched (#1770).
   ///
   /// The shared authority is `retiredModelIDs` above, which both repair seams
-  /// read. This helper is `RecoveryTextProcessor`'s convenience for the
-  /// standalone substitution; `SettingsManager` tests the set directly inside
-  /// its larger canonicalization branch, which is clearer there.
+  /// read through `isRetiredModel`. This helper is `RecoveryTextProcessor`'s
+  /// convenience for the standalone substitution; `SettingsManager` calls the
+  /// membership test directly inside its larger canonicalization branch, which
+  /// is clearer there.
   public static func replacingRetiredModel(_ modelID: String, for provider: LLMProvider) -> String {
-    retiredModelIDs.contains(modelID) ? defaultModel(for: provider) : modelID
+    isRetiredModel(modelID, for: provider) ? defaultModel(for: provider) : modelID
   }
 
   /// Coarse "does this model id look like it could belong to `provider`"

--- a/Sources/EnviousWisprCore/LLMResult.swift
+++ b/Sources/EnviousWisprCore/LLMResult.swift
@@ -125,14 +125,31 @@ public enum OutputTokenPolicy: Codable, Sendable, Equatable {
   case capped(Int)
 }
 
+/// The resolved "how hard to think" value for ONE request (#1770).
+///
+/// Replaces the previous sibling optionals `thinkingBudget: Int?` and
+/// `reasoningEffort: String?`, which let a request carry BOTH a budget and an
+/// effort — two dialects at once, which no provider accepts. One value makes
+/// that unconstructible. `nil` still means "deliberately send no thinking
+/// field", a declared decision in the same spirit as `OutputTokenPolicy`
+/// above; it is a legal state, not an impossible one.
+public enum ResolvedThinking: Codable, Sendable, Equatable {
+  /// Gemini 2.5 dialect: integer token budget.
+  case budget(Int)
+  /// Gemini 3 dialect: string level (minimal/low/medium/high).
+  case level(String)
+  /// OpenAI dialect: `reasoning_effort`.
+  case effort(String)
+}
+
 /// Configuration for an LLM provider.
 public struct LLMProviderConfig: Codable, Sendable {
   public let model: String
   public let apiKeyKeychainId: String?
   public let outputTokens: OutputTokenPolicy
   public let temperature: Double
-  public let thinkingBudget: Int?
-  public let reasoningEffort: String?
+  /// Nil means no thinking field is sent at all.
+  public let thinking: ResolvedThinking?
   /// Detected input language (ISO 639-1 base code). Nil for the Parakeet
   /// highway, pre-W2 callsites, or when no language hint is available.
   /// Consumed by providers that gate or condition behavior on input language
@@ -144,16 +161,14 @@ public struct LLMProviderConfig: Codable, Sendable {
     apiKeyKeychainId: String?,
     outputTokens: OutputTokenPolicy,
     temperature: Double,
-    thinkingBudget: Int?,
-    reasoningEffort: String?,
+    thinking: ResolvedThinking?,
     detectedLanguage: String? = nil
   ) {
     self.model = model
     self.apiKeyKeychainId = apiKeyKeychainId
     self.outputTokens = outputTokens
     self.temperature = temperature
-    self.thinkingBudget = thinkingBudget
-    self.reasoningEffort = reasoningEffort
+    self.thinking = thinking
     self.detectedLanguage = detectedLanguage
   }
 }

--- a/Sources/EnviousWisprCore/LLMResult.swift
+++ b/Sources/EnviousWisprCore/LLMResult.swift
@@ -37,13 +37,52 @@ extension LLMProvider {
   {
     switch provider {
     case .openAI: return "gpt-4o-mini"
-    case .gemini: return "gemini-2.0-flash"
+    // #1770: was `gemini-2.0-flash`, which Google shut down 2026-06-01 (live
+    // 404 "no longer available"). `gemini-3.5-flash` is the only replacement
+    // candidate with a measured polish score on our own corpus (92.6% Type B).
+    // #1832 may swap it once 3.6 Flash and the cheap tier are benchmarked.
+    case .gemini: return "gemini-3.5-flash"
     case .claude: return "claude-haiku-4-5"
     case .ollama: return ollamaModel
     case .appleIntelligence: return "apple-intelligence"
     case .egOne: return LLMProvider.egOneModelName
     case .none: return ""
     }
+  }
+
+  /// Model ids the provider has WITHDRAWN, which must be swept off a user's
+  /// saved settings rather than left to fail forever (#1770).
+  ///
+  /// Lives in Core, not privately in `SettingsManager`, because a saved model
+  /// reaches the polish path through TWO production seams and both need the
+  /// same authority: the live setting (`SettingsManager
+  /// .canonicalizeLLMModelForProvider`) and a crash-recovery replay, which
+  /// deliberately restores the model recorded in the spool at capture time
+  /// (`RecoveryTextProcessor`). Duplicating the set in Pipeline would be the
+  /// exact drift this design removes.
+  ///
+  /// Deliberately an EXPLICIT set, never a predicate: we only ever replace ids
+  /// the provider has actually withdrawn, never a model the user legitimately
+  /// chose. Each was verified 404 against the live API on 2026-07-29.
+  ///
+  /// This is NOT a general staleness mechanism. When Google retires the next
+  /// model, a human adds it here — the same human gate that governs adding a
+  /// new model's thinking dialect.
+  public static let retiredModelIDs: Set<String> = [
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
+    "gemini-3-pro-preview",
+  ]
+
+  /// Substitute the provider's current default for a WITHDRAWN model id,
+  /// leaving every live id untouched (#1770).
+  ///
+  /// The shared authority is `retiredModelIDs` above, which both repair seams
+  /// read. This helper is `RecoveryTextProcessor`'s convenience for the
+  /// standalone substitution; `SettingsManager` tests the set directly inside
+  /// its larger canonicalization branch, which is clearer there.
+  public static func replacingRetiredModel(_ modelID: String, for provider: LLMProvider) -> String {
+    retiredModelIDs.contains(modelID) ? defaultModel(for: provider) : modelID
   }
 
   /// Coarse "does this model id look like it could belong to `provider`"

--- a/Sources/EnviousWisprLLM/EGOne/EGOneServerManager.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneServerManager.swift
@@ -379,8 +379,7 @@ public actor EGOneServerManager {
         apiKeyKeychainId: nil,
         outputTokens: .capped(128),
         temperature: 0,
-        thinkingBudget: nil,
-        reasoningEffort: nil,
+        thinking: nil,
         detectedLanguage: nil
       )
       let start = ContinuousClock.now

--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -97,8 +97,21 @@ public struct GeminiConnector: TranscriptPolisher {
     if case .capped(let value) = config.outputTokens {
       generationConfig["maxOutputTokens"] = value
     }
-    if let budget = config.thinkingBudget {
-      generationConfig["thinkingConfig"] = ["thinkingBudget": budget]
+    // #1770: Gemini speaks TWO thinking dialects and refuses the other one.
+    // 2.5 takes an integer `thinkingBudget`; 3.x takes a string `thinkingLevel`
+    // and rejects `thinkingBudget: 0` outright (400) — which was exactly what
+    // the Deep-reasoning toggle sent in its default OFF position. Which dialect
+    // a model speaks is decided by `LLMModelCapabilities`, never here.
+    switch config.thinking {
+    case .budget(let value):
+      generationConfig["thinkingConfig"] = ["thinkingBudget": value]
+    case .level(let value):
+      generationConfig["thinkingConfig"] = ["thinkingLevel": value]
+    case .effort, .none:
+      // `.effort` is OpenAI's dialect and never reaches Gemini; `nil` is the
+      // deliberate "send no thinking field" case, which every measured Gemini
+      // model accepts.
+      break
     }
     return generationConfig
   }

--- a/Sources/EnviousWisprLLM/LLMModelCapabilities.swift
+++ b/Sources/EnviousWisprLLM/LLMModelCapabilities.swift
@@ -9,12 +9,44 @@ import Foundation
 /// non-reasoning — collapsing these into one "is reasoning" bit is the
 /// conflation that produced the silent gpt-5.5 polish outage (#1330).
 ///
-/// Consumers: `LLMPolishStep.resolveThinkingConfig` and
-/// `AIPolishSettingsView.isReasoningModel` read `supportsReasoning`;
+/// Consumers: `LLMPolishStep.resolveThinking` reads `thinkingControl` to build
+/// the request; `AIPolishSettingsView.isReasoningModel` reads the derived
+/// `supportsReasoning` to decide whether to show the Deep-reasoning toggle;
 /// `OpenAIConnector` reads `temperaturePolicy` and preflights
 /// `supportsChatCompletions`; `LLMModelDiscovery` filters the picker on
 /// `supportsChatCompletions`.
 public struct LLMModelCapabilities: Sendable, Equatable {
+  /// How a model expresses "how hard to think", and the two values our
+  /// Deep-reasoning toggle maps onto (#1770).
+  ///
+  /// Dialect and values travel TOGETHER because providers disagree on both the
+  /// KEY and the legal values per model: Gemini 2.5 takes an integer
+  /// `thinkingBudget`, Gemini 3 takes a string `thinkingLevel` and rejects
+  /// `thinkingBudget: 0` outright. A dialect without its values is exactly what
+  /// let `thinkingBudget: 0` reach models that refuse it.
+  ///
+  /// Keyed on EXACT model ids, never prefixes. A `gemini-3` prefix row would
+  /// silently capture a future `gemini-3.7-flash` we have never tested and send
+  /// it an unverified value; with exact ids anything unknown reaches
+  /// `.unsupported`, which sends no thinking field at all. That shape succeeded
+  /// on all eleven working Gemini models measured on 2026-07-28/29; future
+  /// models are unverified by construction, so it is the safest first attempt
+  /// rather than a guarantee.
+  public enum ThinkingControl: Sendable, Equatable {
+    /// Send no thinking parameter. Covers two different situations: providers
+    /// that have no thinking control at all (Claude, Ollama, Apple
+    /// Intelligence, EG-1) and Gemini/OpenAI ids absent from the tables below.
+    /// What the provider then does is its own business — Gemini 3 Flash, for
+    /// instance, thinks by default and is measurably slower for it.
+    case unsupported
+    /// Gemini 2.5 dialect: integer token budget.
+    case budget(fast: Int, deep: Int)
+    /// Gemini 3 dialect: string level (minimal/low/medium/high).
+    case level(fast: String, deep: String)
+    /// OpenAI dialect: `reasoning_effort`.
+    case effort(fast: String, deep: String)
+  }
+
   public enum TemperaturePolicy: Sendable, Equatable {
     /// Classic chat models: send `temperature: 0` for deterministic polish.
     case include
@@ -28,7 +60,12 @@ public struct LLMModelCapabilities: Sendable, Equatable {
     case omit
   }
 
-  public let supportsReasoning: Bool
+  public let thinkingControl: ThinkingControl
+  /// Whether the Deep-reasoning toggle is meaningful for this model.
+  ///
+  /// DERIVED, never stored: toggle visibility and request shape are two
+  /// statements about one fact, and storing both is how they drift (#1770).
+  public var supportsReasoning: Bool { thinkingControl != .unsupported }
   public let temperaturePolicy: TemperaturePolicy
   /// Primary-endpoint (Chat Completions) eligibility. Meaningful for
   /// `.openAI` only — Responses-API-only families (`-pro`, codex) can never
@@ -37,11 +74,11 @@ public struct LLMModelCapabilities: Sendable, Equatable {
   public let supportsChatCompletions: Bool
 
   public init(
-    supportsReasoning: Bool,
+    thinkingControl: ThinkingControl,
     temperaturePolicy: TemperaturePolicy,
     supportsChatCompletions: Bool
   ) {
-    self.supportsReasoning = supportsReasoning
+    self.thinkingControl = thinkingControl
     self.temperaturePolicy = temperaturePolicy
     self.supportsChatCompletions = supportsChatCompletions
   }
@@ -73,14 +110,16 @@ extension LLMProvider {
       let isResponsesOnly = id.contains("codex") || id.contains("-pro")
 
       return LLMModelCapabilities(
-        supportsReasoning: isReasoning,
+        // Unchanged behaviour, restated as a dialect: the prior resolver
+        // has always sent low/medium for these ids (#1330).
+        thinkingControl: isReasoning ? .effort(fast: "low", deep: "medium") : .unsupported,
         temperaturePolicy: isReasoning ? .omit : .include,
         supportsChatCompletions: !isResponsesOnly
       )
 
     case .gemini:
       return LLMModelCapabilities(
-        supportsReasoning: id.hasPrefix("gemini-2.5") || id.hasPrefix("gemini-3"),
+        thinkingControl: LLMModelCapabilities.geminiThinkingControl(id),
         temperaturePolicy: .include,
         supportsChatCompletions: false
       )
@@ -92,17 +131,68 @@ extension LLMProvider {
       // unconditional-omit shape #1330 established for OpenAI's reasoning
       // family, applied here so a future catalog model doesn't silently break.
       return LLMModelCapabilities(
-        supportsReasoning: false,
+        thinkingControl: .unsupported,
         temperaturePolicy: .omit,
         supportsChatCompletions: false
       )
 
     case .ollama, .appleIntelligence, .egOne, .none:
       return LLMModelCapabilities(
-        supportsReasoning: false,
+        thinkingControl: .unsupported,
         temperaturePolicy: .include,
         supportsChatCompletions: false
       )
+    }
+  }
+}
+
+extension LLMModelCapabilities {
+  /// Gemini's thinking dialect, keyed on EXACT model ids (#1770).
+  ///
+  /// Every value here was verified against the live API on 2026-07-28/29 by
+  /// issuing the real request shape; none is inferred from documentation, which
+  /// is wrong in both directions (it claims Gemini 3 Flash cannot disable
+  /// thinking — `minimal` measurably spends zero thinking tokens — and it lists
+  /// `gemini-3.1-flash-lite-preview` as withdrawn when it returns 200).
+  ///
+  /// Deliberately NOT prefix-matched. `gemini-3` would capture an untested
+  /// future id and hand it an unverified value. Unlisted ids fall through to
+  /// `.unsupported`, which sends no thinking field — a shape that succeeded on
+  /// all eleven working Gemini models measured on 2026-07-28/29. Future models
+  /// are unverified by construction, so that is the safest first attempt, not a
+  /// guarantee; an unlisted model also loses the Deep-reasoning toggle until a
+  /// row is added here.
+  ///
+  /// The `deep:` values are provisional — #1832 measures whether thinking level
+  /// changes polish quality at all. `"high"` is the widest separation from
+  /// `minimal`, not an evidence-backed optimum.
+  fileprivate static func geminiThinkingControl(_ id: String) -> ThinkingControl {
+    switch id {
+    // Gemini 3 Flash tier: `minimal` returns 200 and spends 0 thinking tokens.
+    case "gemini-3.6-flash", "gemini-3.5-flash", "gemini-3.5-flash-lite",
+      "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview",
+      "gemini-3-flash-preview":
+      return .level(fast: "minimal", deep: "high")
+
+    // Gemini 3 Pro tier: `minimal` -> 400 "Thinking level MINIMAL is not
+    // supported for this model", so `low` is the floor Google permits.
+    case "gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools":
+      return .level(fast: "low", deep: "high")
+
+    // Gemini 2.5 Flash tier: budget 0 is legal and spends 0 thinking tokens.
+    // NOTE 2.5-flash-lite rejects 128 ("choose a value between 512 and 24576")
+    // while accepting 0 — which is why the off-state value is per-model here
+    // and not a per-tier rule.
+    case "gemini-2.5-flash", "gemini-2.5-flash-lite":
+      return .budget(fast: 0, deep: 8192)
+
+    // Gemini 2.5 Pro: budget 0 -> 400 "This model only works in thinking
+    // mode"; 128 is the documented and measured minimum.
+    case "gemini-2.5-pro":
+      return .budget(fast: 128, deep: 8192)
+
+    default:
+      return .unsupported
     }
   }
 }

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -122,8 +122,12 @@ public struct OpenAIConnector: TranscriptPolisher {
     if capabilities.temperaturePolicy == .include && !omitting.contains("temperature") {
       body["temperature"] = config.temperature
     }
-    if let reasoningEffort = config.reasoningEffort, !omitting.contains("reasoning_effort") {
-      body["reasoning_effort"] = reasoningEffort
+    // #1770: reasoning effort now travels in the shared `thinking` value.
+    // Only `.effort` is OpenAI's dialect — Gemini's `.budget`/`.level` can
+    // never reach here, and `nil` means send nothing. Behaviour is unchanged;
+    // the strip-and-retry allowlist still governs omission (#1330).
+    if case .effort(let value) = config.thinking, !omitting.contains("reasoning_effort") {
+      body["reasoning_effort"] = value
     }
     return body
   }

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -206,6 +206,76 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     }
   }
 
+  /// Gemini's budget scales with the transcript; every other provider keeps its
+  /// fixed one (#1770).
+  ///
+  /// A fixed 5 s was timing out long dictations. Measured live against
+  /// real dictations, Gemini in fast mode: 1,709 chars -> 1.33 s, 4,605 -> 2.69 s,
+  /// 11,324 (a 10-minute dictation) -> 6.12 s, 66,896 (the longest transcript we
+  /// have recorded) -> 50.65 s. Everything past roughly 5,000 chars lost its
+  /// polish and showed the failure notice. Production corroborates it: Gemini's
+  /// `llm_seconds` maxes at 5.05 s against the 5 s cap — a censored distribution.
+  ///
+  /// A larger FIXED number is not the fix. It would make a 20-word dictation
+  /// wait far longer than today before its raw text appears, degrading the
+  /// common case (p50 is 8 seconds of speech) to rescue the 0.1% tail.
+  ///
+  /// So: `base + inputChars / 500`. Throughput measured 1,285 / 1,712 / 1,850 /
+  /// 1,320 chars per second across those four long buckets, so budgeting 500
+  /// chars/second leaves ~2.6x margin on the variable part alone. Headroom
+  /// lands at 6x / 6x / 4.5x / 2.7x across the table above.
+  ///
+  /// `base` is 5 s normally — preserving today's short-dictation failure speed
+  /// almost exactly (110 chars -> 5.22 s) — and 60 s when the resolved request
+  /// carries a deep-thinking value, because deep mode spends a measured
+  /// 42.2-42.4 s thinking BEFORE the first byte, a fixed cost rather than a
+  /// per-character one. It keys off the resolved `ThinkingControl`, not the raw
+  /// toggle: an `.unsupported` model sends no thinking field at all, so it must
+  /// not inherit the deep base merely because the toggle is on.
+  ///
+  /// Capped at 180 s to match `URLSession`'s `timeoutIntervalForResource`
+  /// (`LLMNetworkSession`): beyond that the transport terminates the attempt
+  /// anyway, so a larger logical budget buys another long attempt rather than
+  /// preserving the first response.
+  ///
+  /// Transport liveness is NOT reimplemented here — the shared session already
+  /// provides a 60 s inter-data idle timer and the 180 s resource cap.
+  /// Reads `llmProvider` / `llmModel` / `useExtendedThinking` live, exactly as
+  /// the existing `maxDuration` above already reads `llmProvider` live at this
+  /// same call site. Safe because `PipelineSettingsSync` deliberately does NOT
+  /// mirror these three onto a live step — `.llmProvider` ("live steps are
+  /// seeded per recording, so nothing to mirror here") and `.useExtendedThinking`
+  /// ("Frozen per recording") are explicit no-ops there, and the values are
+  /// frozen into `DictationSessionConfig` at record start. The only writers are
+  /// session start and `RecoveryTextProcessor.applySettings`, neither of which
+  /// runs while a `process()` is in flight.
+  ///
+  /// KNOWN LIMIT, recorded rather than engineered around: this is an invariant
+  /// held elsewhere, not a guarantee of this function. If mirroring is ever
+  /// added for these fields, the budget and the request could be computed for
+  /// different settings — a deep request could inherit the 5 s fast budget.
+  /// Closing that properly means giving the runner and the step one shared
+  /// snapshot, which is a change to the execution boundary and not warranted
+  /// for a window no current code can open.
+  public func maxDuration(for context: TextProcessingContext) -> Duration {
+    guard llmProvider == .gemini else { return maxDuration }
+    let control = llmProvider.modelCapabilities(model: llmModel).thinkingControl
+    let isDeep = useExtendedThinking && control != .unsupported
+    let base = isDeep ? Self.geminiDeepBaseSeconds : Self.geminiFastBaseSeconds
+    let scaled = base + Double(context.text.count) / Self.geminiCharsPerSecond
+    return .seconds(min(Self.geminiMaxBudgetSeconds, scaled))
+  }
+
+  /// Fast-mode base: preserves today's 5 s short-dictation failure speed.
+  private static let geminiFastBaseSeconds: Double = 5
+  /// Deep-mode base: covers the measured 42.2-42.4 s of pre-first-byte thinking.
+  private static let geminiDeepBaseSeconds: Double = 60
+  /// Budgeted throughput, ~2.6x slower than the slowest measured rate.
+  private static let geminiCharsPerSecond: Double = 500
+  /// Matches `URLSession.timeoutIntervalForResource`; beyond it the transport
+  /// kills the attempt regardless.
+  private static let geminiMaxBudgetSeconds: Double = 180
+
   public init(keychainManager: KeychainManager) {
     self.keychainManager = keychainManager
     self.telemetry = .live
@@ -290,8 +360,8 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
     onWillProcess?()
     // #827 PR-8: snapshot the mutable provider/model at entry. process()
-    // suspends at the polish await; a concurrent PipelineSettingsSync mutation
-    // on the shared re-polish step would otherwise tear the post-await reads
+    // suspends at the polish await, so every read after it must come from
+    // these locals or the post-await reads could tear
     // (provider/model attribution in ctx, the family label, and the two
     // telemetry helpers). Mirrors WordCorrectionStep's entry snapshot. Every
     // read below uses these locals, never `self`, so reentrancy cannot tear it.
@@ -417,9 +487,11 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
 
     // Resolved from the ENTRY snapshot, never from `self` — this function's
     // own contract above ("every read below uses these locals") applies to the
-    // thinking value too: a concurrent PipelineSettingsSync mutation between
-    // entry and here would otherwise let the deadline, the request and the
-    // telemetry disagree about which model they are for.
+    // thinking value too, so the request, the deadline and the telemetry all
+    // describe one model. (#1770 verified that no production code mutates
+    // these three on a live step: PipelineSettingsSync no-ops all of them and
+    // the values are frozen per recording. The discipline is kept because
+    // internal consistency should not depend on an invariant held elsewhere.)
     let thinking = Self.resolveThinking(
       control: provider.modelCapabilities(model: model).thinkingControl,
       useExtendedThinking: extendedThinking

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -297,6 +297,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     // read below uses these locals, never `self`, so reentrancy cannot tear it.
     let provider = llmProvider
     let model = llmModel
+    let extendedThinking = useExtendedThinking
     telemetry.breadcrumbStarted(
       "LLM polish started",
       [
@@ -414,7 +415,15 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       default: nil
       }
 
-    let (thinkingBudget, reasoningEffort) = resolveThinkingConfig()
+    // Resolved from the ENTRY snapshot, never from `self` — this function's
+    // own contract above ("every read below uses these locals") applies to the
+    // thinking value too: a concurrent PipelineSettingsSync mutation between
+    // entry and here would otherwise let the deadline, the request and the
+    // telemetry disagree about which model they are for.
+    let thinking = Self.resolveThinking(
+      control: provider.modelCapabilities(model: model).thinkingControl,
+      useExtendedThinking: extendedThinking
+    )
     let outputTokens = Self.outputTokenPolicy(
       provider: provider, model: model, textCount: context.text.count)
 
@@ -431,18 +440,19 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       apiKeyKeychainId: keychainId,
       outputTokens: outputTokens,
       temperature: 0,
-      thinkingBudget: thinkingBudget,
-      reasoningEffort: reasoningEffort,
+      thinking: thinking,
       detectedLanguage: detectedLanguage
     )
 
     // #1710 request-shape receipt for Live UAT: policy only, never content.
+    // #1770 makes the DIALECT visible here — which wire key we chose, not just
+    // its value — because sending the wrong dialect is the defect this receipt
+    // now has to be able to prove absent.
+    let thinkingReceipt = Self.thinkingReceipt(thinking)
     Task {
       await AppLogger.shared.log(
         "LLM request budget: provider=\(provider.rawValue), model=\(model), "
-          + "output_tokens=\(outputTokens), "
-          + "thinking_budget=\(thinkingBudget.map(String.init) ?? "nil"), "
-          + "reasoning_effort=\(reasoningEffort ?? "nil")",
+          + "output_tokens=\(outputTokens), thinking=\(thinkingReceipt)",
         level: .info, category: "LLM"
       )
     }
@@ -834,18 +844,40 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     }
   }
 
-  /// Resolve thinking/reasoning config based on provider, model, and user toggle.
-  private func resolveThinkingConfig() -> (thinkingBudget: Int?, reasoningEffort: String?) {
-    guard llmProvider.modelCapabilities(model: llmModel).supportsReasoning else {
-      return (nil, nil)
+  /// Shape-only receipt of the resolved thinking value for the debug log
+  /// (#1770). Names the dialect as well as the value, since sending the wrong
+  /// KEY is the failure this line exists to make visible. No user content.
+  private static func thinkingReceipt(_ thinking: ResolvedThinking?) -> String {
+    switch thinking {
+    case .none: return "none"
+    case .budget(let v): return "budget=\(v)"
+    case .level(let v): return "level=\(v)"
+    case .effort(let v): return "effort=\(v)"
     }
-    switch llmProvider {
-    case .gemini:
-      return (useExtendedThinking ? LLMConstants.defaultThinkingBudget : 0, nil)
-    case .openAI:
-      return (nil, useExtendedThinking ? "medium" : "low")
-    case .ollama, .appleIntelligence, .egOne, .claude, .none:
-      return (nil, nil)
+  }
+
+  /// Resolve the thinking value for this request from the per-model capability
+  /// authority and the user's toggle (#1770).
+  ///
+  /// This function knows NO model ids. Providers disagree on both the wire key
+  /// and the legal values per model — Gemini 2.5 wants an integer budget,
+  /// Gemini 3 wants a string level and rejects budget 0 — and encoding that
+  /// here is what shipped `thinkingBudget: 0` to models that refuse it. The
+  /// dialect and its fast/deep values live together in
+  /// `LLMModelCapabilities.thinkingControl`; this only picks which of the two.
+  ///
+  /// Static and fed from `process()`'s entry snapshot, never from `self`, so a
+  /// concurrent settings change cannot tear it away from the model the rest of
+  /// the request was built for.
+  private static func resolveThinking(
+    control: LLMModelCapabilities.ThinkingControl,
+    useExtendedThinking: Bool
+  ) -> ResolvedThinking? {
+    switch control {
+    case .unsupported: return nil
+    case .budget(let fast, let deep): return .budget(useExtendedThinking ? deep : fast)
+    case .level(let fast, let deep): return .level(useExtendedThinking ? deep : fast)
+    case .effort(let fast, let deep): return .effort(useExtendedThinking ? deep : fast)
     }
   }
 }

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -177,7 +177,13 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     llmProvider != .none
   }
 
-  /// Provider-aware timeout budget. Cloud providers respond in <2s so 5s is generous.
+  /// Provider-aware timeout budget for providers whose cost does not scale here.
+  /// (#1770 corrected an older claim on this line that "cloud providers respond
+  /// in <2s so 5s is generous": false for Gemini on the measured long
+  /// dictations (11,324 chars took 6.12s, 66,896 took 50.65s), and #158 already
+  /// measured a 9.16s Claude call. Gemini now
+  /// scales via `maxDuration(for:)` below; the rest keep fixed budgets, and
+  /// OpenAI/Claude are #1833.)
   /// Local models (Ollama 12B) generate ~18 tok/s and need 10-15s for long dictations.
   /// Apple Intelligence runs on-device with variable latency depending on model size.
   public var maxDuration: Duration {
@@ -212,8 +218,9 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// A fixed 5 s was timing out long dictations. Measured live against
   /// real dictations, Gemini in fast mode: 1,709 chars -> 1.33 s, 4,605 -> 2.69 s,
   /// 11,324 (a 10-minute dictation) -> 6.12 s, 66,896 (the longest transcript we
-  /// have recorded) -> 50.65 s. Everything past roughly 5,000 chars lost its
-  /// polish and showed the failure notice. Production corroborates it: Gemini's
+  /// have recorded) -> 50.65 s. The last measurement under the old 5 s budget was
+  /// 4,605 chars at 2.69 s, so the crossing lies between 4,605 and 11,324 chars;
+  /// the measured long cases lost their polish and showed the failure notice. Production corroborates it: Gemini's
   /// `llm_seconds` maxes at 5.05 s against the 5 s cap — a censored distribution.
   ///
   /// A larger FIXED number is not the fix. It would make a 20-word dictation

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -94,7 +94,18 @@ public final class RecoveryTextProcessor {
     // record-time capability, never an engine-identity literal (Codex PR0 P2).
     steps.inverseTextNormalization.backendSupportsLID = snapshot.backendSupportsLanguageDetection
     steps.llmPolish.llmProvider = LLMProvider(rawValue: snapshot.llmProvider) ?? .none
-    steps.llmPolish.llmModel = snapshot.llmModel
+    // #1770: replay the RECORDED model, except when the provider has since
+    // withdrawn it. This is the second of exactly two production seams where a
+    // user-selected model reaches `LLMPolishStep` (the other is the live frozen
+    // config), and it bypasses `SettingsManager`'s sweep entirely because it
+    // deliberately restores capture-time settings rather than current ones. A
+    // spool captured while the user was pinned to a retired id would otherwise
+    // replay against a dead model and return unpolished text.
+    //
+    // This does not violate the replay-original-settings contract: the original
+    // model no longer exists, so the honest reproduction is the current default.
+    steps.llmPolish.llmModel = LLMProvider.replacingRetiredModel(
+      snapshot.llmModel, for: steps.llmPolish.llmProvider)
     steps.llmPolish.backend = snapshot.backendType
     // Reasoning setting at record time, so a reasoning-capable provider replays
     // under the same setting the live dictation used (Codex PR0 P2).

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -15,7 +15,7 @@ internal struct TextProcessingRunResult {
 /// Runs the post-ASR text processing chain: word correction -> filler removal -> LLM polish.
 ///
 /// Does NOT own step instances. Steps are passed in by the pipeline, which retains
-/// ownership for PipelineSettingsSync mutation.
+/// ownership across the timeout await.
 /// The runner owns only the execution algorithm: ordering, timeout, cancellation,
 /// failure continuation (heart & limbs), and CORRECTION_DEBUG logging.
 ///
@@ -190,15 +190,26 @@ internal final class TextProcessingRunner {
       let stepName = step.name
       let input = context
       let stepStart = CFAbsoluteTimeGetCurrent()
+      // #1770: the context-aware form. Five steps inherit the default, which
+      // returns their fixed `maxDuration`; LLM polish scales with the text it
+      // is about to process, because its cost does. `input` is already the
+      // exact context that will be handed to `process(_:)` below, so the
+      // budget and the work can never disagree about what is being measured.
+      let stepBudget = step.maxDuration(for: input)
       let budgetSeconds =
-        Double(step.maxDuration.components.seconds)
-        + Double(step.maxDuration.components.attoseconds) / 1e18
-      // #1055: snapshot the polish provider BEFORE the await. `LLMPolishStep.
-      // llmProvider` is a mutable @MainActor property that PipelineSettingsSync
-      // can change while `process()` is in flight; reading it in the catch block
-      // (after the timeout suspension) would misclassify the timeout if the user
-      // switched providers mid-polish. Snapshotting here mirrors the step's own
-      // entry snapshot of `provider` and the `stepName` snapshot above.
+        Double(stepBudget.components.seconds)
+        + Double(stepBudget.components.attoseconds) / 1e18
+      // #1055: snapshot the polish provider BEFORE the await, so failure
+      // attribution in the catch block below reads a value fixed at dispatch
+      // rather than mutable post-await state. Mirrors the step's own entry
+      // snapshot of `provider` and the `stepName` snapshot above.
+      //
+      // #1770 note: an earlier version of this comment justified the snapshot
+      // by saying PipelineSettingsSync can change `llmProvider` mid-flight. It
+      // cannot — that case is an explicit no-op there, and the value is frozen
+      // per recording. The snapshot is kept because attribution should not
+      // depend on an invariant held in another file, not because a live writer
+      // exists.
       let polishProviderAtStart = (step as? LLMPolishStep)?.llmProvider
       // #945: snapshot the attempted model alongside the provider, pre-await. On
       // failure `context.llmModel` is never stamped (set only on success,

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -67,7 +67,26 @@ protocol TextProcessingStep {
   /// Whether this step should run. Checked before each invocation.
   var isEnabled: Bool { get }
   /// Maximum time this step may run before being skipped.
+  ///
+  /// The FIXED policy for steps whose cost does not depend on the input. Five
+  /// of the six steps declare only this; the runner always calls
+  /// `maxDuration(for:)` below, whose default returns this value.
   var maxDuration: Duration { get }
+  /// Maximum time this step may run, given the text it is about to process
+  /// (#1770).
+  ///
+  /// Exists because LLM polish is the one step whose cost tracks input length:
+  /// measured live, a 10-minute dictation polishes in 6.1s and the longest
+  /// transcript we have recorded in 50.7s, against a former flat 5s budget that
+  /// timed out both (visibly, for cloud providers — the user gets the "AI
+  /// polish failed" notice). A single larger flat number is not the answer either
+  /// — it would make a 20-word dictation wait far longer than today before its
+  /// raw text appears.
+  ///
+  /// This is the SAME duration authority made context-aware, not a second one:
+  /// the default below delegates to `maxDuration`, so a step opts in only by
+  /// overriding.
+  func maxDuration(for context: TextProcessingContext) -> Duration
   /// Process the text and return an updated context.
   func process(_ context: TextProcessingContext) async throws -> TextProcessingContext
   /// How `TextProcessingRunner` should treat an error thrown by `process`.
@@ -77,4 +96,7 @@ protocol TextProcessingStep {
 
 extension TextProcessingStep {
   var errorSurfacePolicy: ErrorSurfacePolicy { .swallow }
+  /// Default: the step's cost does not depend on its input, so the fixed
+  /// policy applies. Only `LLMPolishStep` overrides this.
+  func maxDuration(for context: TextProcessingContext) -> Duration { maxDuration }
 }

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -166,7 +166,13 @@ public final class SettingsManager {
         llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)
       }
     case .openAI, .gemini, .claude, .none:
+      // #1770: a WITHDRAWN id is well-formed, so the prefix check below waves
+      // it through and the user 404s on every dictation, forever. Discovery
+      // would repair it, but discovery does not run at launch and opening AI
+      // Polish settings only loads CACHED rows — the real rescan sits behind
+      // the manual refresh button, which a user has no reason to press.
       if fixedLiterals.contains(llmModel) || llmModel.isEmpty
+        || LLMProvider.retiredModelIDs.contains(llmModel)
         || !LLMProvider.modelIDLooksLikeCloudProvider(llmModel, llmProvider)
       {
         llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -172,7 +172,7 @@ public final class SettingsManager {
       // Polish settings only loads CACHED rows — the real rescan sits behind
       // the manual refresh button, which a user has no reason to press.
       if fixedLiterals.contains(llmModel) || llmModel.isEmpty
-        || LLMProvider.retiredModelIDs.contains(llmModel)
+        || LLMProvider.isRetiredModel(llmModel, for: llmProvider)
         || !LLMProvider.modelIDLooksLikeCloudProvider(llmModel, llmProvider)
       {
         llmModel = LLMProvider.defaultModel(for: llmProvider, ollamaModel: ollamaModel)

--- a/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
@@ -307,6 +307,33 @@ import Testing
       #expect(project("someones-finetune") == "custom")
     }
 
+    /// #1770: the allowlist stopped at Gemini 2.5, so every 3.x user's
+    /// configured model reconstructed as `custom` and the generation was
+    /// invisible in settings snapshots. Public model names only — this is
+    /// cardinality, not content.
+    @Test("Gemini 3.x ids are recognised, and unknown ids still collapse to custom")
+    func geminiThreeIsRecognised() {
+      func project(_ model: String) -> String? {
+        let suite = UserDefaults(suiteName: "SCT-g3-\(UUID().uuidString)")!
+        let settings = SettingsManager(defaults: suite)
+        settings.llmProvider = .gemini
+        settings.llmModel = model
+        return SettingsProjection.value(for: .llmModel, settings: settings)
+      }
+      for id in [
+        "gemini-3.6-flash", "gemini-3.5-flash", "gemini-3.5-flash-lite",
+        "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools",
+        "gemini-3-flash-preview",
+      ] {
+        #expect(project(id) == id, "\(id) is offered by the picker and must not read as custom")
+      }
+      // The deny-by-default anchor still holds: anything unlisted is `custom`,
+      // so no private or unknown string can leak through this dimension.
+      #expect(project("gemini-4.0-flash-imaginary") == "custom")
+      #expect(project("gemini-my-private-tune") == "custom")
+    }
+
     @Test("Ollama discovery correction emits one source=system delta")
     func ollamaDiscoveryIsSystem() {
       let (settings, telemetry, box, _) = makeHarness()

--- a/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
@@ -460,7 +460,12 @@ import Testing
       #expect(settings.llmModel == "gpt-4o-mini")
       settings.llmProvider = .egOne
       settings.llmProvider = .gemini
-      #expect(settings.llmModel == "gemini-2.0-flash")
+      // #1770: deliberately the EXACT id, not `defaultModel(for:)`. An earlier
+      // revision of this change replaced it with the constant to stop it
+      // "rotting" — which made it `x == x`, a tautology that can never fail and
+      // silently gave up the ability to catch a wrong shipped default. Breaking
+      // when a shipped default moves is the POINT: it forces a human to look.
+      #expect(settings.llmModel == "gemini-3.5-flash")
     }
 
     @Test("Language lock projects to mode only, never the code")

--- a/Tests/EnviousWisprTests/LLM/AppleIntelligencePolishTests.swift
+++ b/Tests/EnviousWisprTests/LLM/AppleIntelligencePolishTests.swift
@@ -148,8 +148,7 @@ struct LLMProviderConfigDetectedLanguageTests {
       apiKeyKeychainId: nil,
       outputTokens: .capped(100),
       temperature: 0,
-      thinkingBudget: nil,
-      reasoningEffort: nil
+      thinking: nil
     )
     #expect(config.detectedLanguage == nil)
   }
@@ -161,8 +160,7 @@ struct LLMProviderConfigDetectedLanguageTests {
       apiKeyKeychainId: nil,
       outputTokens: .capped(100),
       temperature: 0,
-      thinkingBudget: nil,
-      reasoningEffort: nil,
+      thinking: nil,
       detectedLanguage: "de"
     )
     #expect(config.detectedLanguage == "de")
@@ -196,8 +194,7 @@ struct LLMProviderConfigDetectedLanguageTests {
       apiKeyKeychainId: nil,
       outputTokens: .capped(100),
       temperature: 0,
-      thinkingBudget: nil,
-      reasoningEffort: nil,
+      thinking: nil,
       detectedLanguage: "ja"
     )
     let encoded = try JSONEncoder().encode(original)
@@ -318,8 +315,7 @@ struct UnsupportedBaseCodeTests {
         apiKeyKeychainId: nil,
         outputTokens: .capped(500),
         temperature: 0,
-        thinkingBudget: nil,
-        reasoningEffort: nil,
+        thinking: nil,
         detectedLanguage: detectedLanguage
       )
     }

--- a/Tests/EnviousWisprTests/LLM/ClaudeConnectorTests.swift
+++ b/Tests/EnviousWisprTests/LLM/ClaudeConnectorTests.swift
@@ -278,8 +278,7 @@ struct ClaudeConnectorTests {
   private func truncConfig() -> LLMProviderConfig {
     LLMProviderConfig(
       model: "claude-haiku-4-5", apiKeyKeychainId: "claude-api-key",
-      outputTokens: .capped(8192), temperature: 0, thinkingBudget: nil,
-      reasoningEffort: nil)
+      outputTokens: .capped(8192), temperature: 0, thinking: nil)
   }
 
   @Test("stop_reason=max_tokens rejects through the production decision seam")

--- a/Tests/EnviousWisprTests/LLM/ClaudeLiveSweepTests.swift
+++ b/Tests/EnviousWisprTests/LLM/ClaudeLiveSweepTests.swift
@@ -73,8 +73,7 @@ struct ClaudeLiveSweepTests {
         apiKeyKeychainId: KeychainManager.claudeKeyID,
         outputTokens: .capped(LLMConstants.claudeMaxOutputTokens),
         temperature: 0,
-        thinkingBudget: nil,
-        reasoningEffort: nil
+        thinking: nil
       )
 
       // One test-level retry on top of the connector's own internal retry
@@ -164,7 +163,7 @@ struct ClaudeLiveSweepTests {
           let config = LLMProviderConfig(
             model: model, apiKeyKeychainId: KeychainManager.claudeKeyID,
             outputTokens: .capped(LLMConstants.claudeMaxOutputTokens),
-            temperature: 0, thinkingBudget: nil, reasoningEffort: nil)
+            temperature: 0, thinking: nil)
           let envelope = Self.productionEnvelope(transcript: text, modelID: model)
           let start = ContinuousClock.now
           do {
@@ -268,7 +267,7 @@ struct ClaudeLiveSweepTests {
           let config = LLMProviderConfig(
             model: model, apiKeyKeychainId: KeychainManager.claudeKeyID,
             outputTokens: .capped(LLMConstants.claudeMaxOutputTokens),
-            temperature: 0, thinkingBudget: nil, reasoningEffort: nil)
+            temperature: 0, thinking: nil)
           let envelope = Self.productionEnvelope(transcript: input, modelID: model)
           let start = ContinuousClock.now
           do {

--- a/Tests/EnviousWisprTests/LLM/ConnectorAPIKeyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/ConnectorAPIKeyTests.swift
@@ -54,7 +54,7 @@ struct ConnectorAPIKeyTests {
   private func config(keychainId: String?) -> LLMProviderConfig {
     LLMProviderConfig(
       model: "test-model", apiKeyKeychainId: keychainId, outputTokens: .capped(64),
-      temperature: 0, thinkingBudget: nil, reasoningEffort: nil)
+      temperature: 0, thinking: nil)
   }
 
   // MARK: - No key was ever saved: the user's setup, not a defect

--- a/Tests/EnviousWisprTests/LLM/EGOneServerManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/EGOneServerManagerTests.swift
@@ -199,8 +199,7 @@ struct EGOneConnectorResponseTests {
       apiKeyKeychainId: nil,
       outputTokens: .capped(963),
       temperature: 0,
-      thinkingBudget: nil,
-      reasoningEffort: nil
+      thinking: nil
     )
     let body = try EGOneConnector.makeRequestBody(system: "sys", user: "hello", config: config)
     #expect(body["max_tokens"] as? Int == 963)
@@ -214,8 +213,7 @@ struct EGOneConnectorResponseTests {
       apiKeyKeychainId: nil,
       outputTokens: .providerDefault,
       temperature: 0,
-      thinkingBudget: nil,
-      reasoningEffort: nil
+      thinking: nil
     )
     let expected = LLMError.requestFailed(
       "Local polish requires an explicit output-token cap")

--- a/Tests/EnviousWisprTests/LLM/GeminiRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/GeminiRequestBodyTests.swift
@@ -60,7 +60,9 @@ struct GeminiRequestBodyTests {
   }
 
   /// The fail-open case, asserted positively: an unknown model sends no
-  /// `thinkingConfig` at all — the one shape measured to work on every model.
+  /// `thinkingConfig` at all — the shape that succeeded on all eleven working
+  /// Gemini models measured 2026-07-28/29. Future models are unverified by
+  /// construction; this is the safest first attempt, not a guarantee.
   @Test func unsupportedSendsNoThinkingKeyAtAll() {
     let generationConfig = GeminiConnector.makeGenerationConfig(config: config(thinking: nil))
     #expect(generationConfig["thinkingConfig"] == nil)

--- a/Tests/EnviousWisprTests/LLM/GeminiRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/GeminiRequestBodyTests.swift
@@ -8,13 +8,12 @@ import Testing
 struct GeminiRequestBodyTests {
   // MARK: - Output-token policy (#1710)
 
-  private func config(outputTokens: OutputTokenPolicy, thinkingBudget: Int? = nil)
+  private func config(outputTokens: OutputTokenPolicy, budget: Int? = nil)
     -> LLMProviderConfig
   {
     LLMProviderConfig(
       model: "gemini-2.5-flash", apiKeyKeychainId: "gemini-api-key",
-      outputTokens: outputTokens, temperature: 0, thinkingBudget: thinkingBudget,
-      reasoningEffort: nil)
+      outputTokens: outputTokens, temperature: 0, thinking: budget.map { .budget($0) })
   }
 
   @Test func providerDefaultOmitsMaxOutputTokens() {
@@ -32,9 +31,48 @@ struct GeminiRequestBodyTests {
 
   @Test func thinkingBudgetPassesThroughUnchanged() {
     let generationConfig = GeminiConnector.makeGenerationConfig(
-      config: config(outputTokens: .providerDefault, thinkingBudget: 0))
+      config: config(outputTokens: .providerDefault, budget: 0))
     let thinking = generationConfig["thinkingConfig"] as? [String: Int]
     #expect(thinking?["thinkingBudget"] == 0)
+  }
+
+  // MARK: - Thinking dialect (#1770)
+
+  private func config(thinking: ResolvedThinking?) -> LLMProviderConfig {
+    LLMProviderConfig(
+      model: "gemini-3.6-flash", apiKeyKeychainId: "gemini-api-key",
+      outputTokens: .providerDefault, temperature: 0, thinking: thinking)
+  }
+
+  /// Each dialect must emit its OWN key and only its own key. Sending
+  /// `thinkingBudget` to a Gemini 3 model is the HTTP 400 this fixes, so the
+  /// absence of the wrong key is as load-bearing as the presence of the right one.
+  @Test func eachDialectEmitsExactlyItsOwnKey() {
+    let level = GeminiConnector.makeGenerationConfig(config: config(thinking: .level("minimal")))
+    let levelCfg = level["thinkingConfig"] as? [String: Any]
+    #expect(levelCfg?["thinkingLevel"] as? String == "minimal")
+    #expect(levelCfg?["thinkingBudget"] == nil)
+
+    let budget = GeminiConnector.makeGenerationConfig(config: config(thinking: .budget(8192)))
+    let budgetCfg = budget["thinkingConfig"] as? [String: Any]
+    #expect(budgetCfg?["thinkingBudget"] as? Int == 8192)
+    #expect(budgetCfg?["thinkingLevel"] == nil)
+  }
+
+  /// The fail-open case, asserted positively: an unknown model sends no
+  /// `thinkingConfig` at all — the one shape measured to work on every model.
+  @Test func unsupportedSendsNoThinkingKeyAtAll() {
+    let generationConfig = GeminiConnector.makeGenerationConfig(config: config(thinking: nil))
+    #expect(generationConfig["thinkingConfig"] == nil)
+    // Everything else about the request is untouched.
+    #expect(generationConfig["temperature"] as? Double == 0)
+  }
+
+  /// OpenAI's dialect can never reach Gemini serialization.
+  @Test func effortDialectIsIgnoredByGemini() {
+    let generationConfig = GeminiConnector.makeGenerationConfig(
+      config: config(thinking: .effort("low")))
+    #expect(generationConfig["thinkingConfig"] == nil)
   }
 
   @Test func polishRequestBodyDisablesProviderLogging() {

--- a/Tests/EnviousWisprTests/LLM/GeminiResponseParsingTests.swift
+++ b/Tests/EnviousWisprTests/LLM/GeminiResponseParsingTests.swift
@@ -67,8 +67,7 @@ struct GeminiResponseParsingTests {
   private func config() -> LLMProviderConfig {
     LLMProviderConfig(
       model: "gemini-2.5-flash", apiKeyKeychainId: "gemini-api-key",
-      outputTokens: .providerDefault, temperature: 0, thinkingBudget: nil,
-      reasoningEffort: nil)
+      outputTokens: .providerDefault, temperature: 0, thinking: nil)
   }
 
   private final class StatusBox: @unchecked Sendable {

--- a/Tests/EnviousWisprTests/LLM/LLMProviderCapabilityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMProviderCapabilityTests.swift
@@ -100,7 +100,8 @@ struct LLMProviderCapabilityTests {
         == .budget(fast: 128, deep: 8192))
 
     // Unknown / untested / retired ids reach the fallback and send NOTHING —
-    // the one request shape measured to succeed on every offered model.
+    // the shape that succeeded on all eleven working Gemini models measured
+    // 2026-07-28/29, not a guarantee about models that do not exist yet.
     for unknown in ["gemini-3-flash", "gemini-3.7-flash", "gemini-2.0-flash", "nonsense"] {
       #expect(
         LLMProvider.gemini.modelCapabilities(model: unknown).thinkingControl == .unsupported,

--- a/Tests/EnviousWisprTests/LLM/LLMProviderCapabilityTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMProviderCapabilityTests.swift
@@ -75,14 +75,44 @@ struct LLMProviderCapabilityTests {
 
   // MARK: - Other providers
 
-  @Test func geminiReasoningPrefixesPreserved() {
-    #expect(LLMProvider.gemini.modelCapabilities(model: "gemini-2.5-pro").supportsReasoning)
-    #expect(LLMProvider.gemini.modelCapabilities(model: "gemini-3-flash").supportsReasoning)
-    #expect(!LLMProvider.gemini.modelCapabilities(model: "gemini-2.0-flash").supportsReasoning)
+  /// #1770 REPLACES `geminiReasoningPrefixesPreserved`, which asserted that
+  /// `gemini-3-flash` supports reasoning. That id does not exist — the real one
+  /// is `gemini-3-flash-preview` — and the assertion only passed because the old
+  /// implementation prefix-matched `gemini-3`. That is precisely the defect this
+  /// change removes: a prefix silently claims authority over ids nobody tested.
+  /// Under exact matching a fictional id correctly resolves to `.unsupported`.
+  @Test func geminiDialectIsKeyedOnExactIDs() {
+    // Gemini 3 Flash tier: string level, `minimal` is a real thinking-off.
+    #expect(
+      LLMProvider.gemini.modelCapabilities(model: "gemini-3.6-flash").thinkingControl
+        == .level(fast: "minimal", deep: "high"))
+    // Gemini 3 Pro tier: rejects `minimal`, so `low` is the floor.
+    #expect(
+      LLMProvider.gemini.modelCapabilities(model: "gemini-3.1-pro-preview").thinkingControl
+        == .level(fast: "low", deep: "high"))
+    // Gemini 2.5 Flash tier: integer budget, 0 is legal.
+    #expect(
+      LLMProvider.gemini.modelCapabilities(model: "gemini-2.5-flash").thinkingControl
+        == .budget(fast: 0, deep: 8192))
+    // Gemini 2.5 Pro: rejects budget 0, documented minimum 128.
+    #expect(
+      LLMProvider.gemini.modelCapabilities(model: "gemini-2.5-pro").thinkingControl
+        == .budget(fast: 128, deep: 8192))
+
+    // Unknown / untested / retired ids reach the fallback and send NOTHING —
+    // the one request shape measured to succeed on every offered model.
+    for unknown in ["gemini-3-flash", "gemini-3.7-flash", "gemini-2.0-flash", "nonsense"] {
+      #expect(
+        LLMProvider.gemini.modelCapabilities(model: unknown).thinkingControl == .unsupported,
+        "\(unknown) must fall through to .unsupported, not inherit an untested value")
+      #expect(LLMProvider.gemini.modelCapabilities(model: unknown).supportsReasoning == false)
+    }
+
     // Gemini models always keep temperature.
     #expect(
       LLMProvider.gemini.modelCapabilities(model: "gemini-2.5-pro").temperaturePolicy == .include)
   }
+
 
   @Test func localProvidersNeverReasonAndKeepTemperature() {
     for provider in [LLMProvider.ollama, .appleIntelligence, .egOne, .none] {

--- a/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OllamaConnectorRequestBodyTests.swift
@@ -153,8 +153,7 @@ struct OllamaConnectorRequestBodyTests {
       apiKeyKeychainId: nil,
       outputTokens: .capped(128),
       temperature: 0.3,
-      thinkingBudget: nil,
-      reasoningEffort: nil
+      thinking: nil
     )
     await #expect(throws: LLMError.self) {
       _ = try await connector.polish(
@@ -186,8 +185,7 @@ struct OllamaConnectorRequestBodyTests {
       apiKeyKeychainId: nil,
       outputTokens: .capped(431),
       temperature: 0.3,
-      thinkingBudget: nil,
-      reasoningEffort: nil
+      thinking: nil
     )
     _ = try? await connector.polish(
       text: "hello",
@@ -214,8 +212,7 @@ struct OllamaConnectorRequestBodyTests {
       apiKeyKeychainId: nil,
       outputTokens: .providerDefault,
       temperature: 0.3,
-      thinkingBudget: nil,
-      reasoningEffort: nil
+      thinking: nil
     )
     let expected = LLMError.requestFailed(
       "Local polish requires an explicit output-token cap")

--- a/Tests/EnviousWisprTests/LLM/OpenAILiveSweepTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAILiveSweepTests.swift
@@ -41,8 +41,7 @@ struct OpenAILiveSweepTests {
         apiKeyKeychainId: KeychainManager.openAIKeyID,
         outputTokens: .providerDefault,
         temperature: 0,
-        thinkingBudget: nil,
-        reasoningEffort: capabilities.supportsReasoning ? "low" : nil
+        thinking: capabilities.supportsReasoning ? .effort("low") : nil
       )
 
       let start = ContinuousClock.now

--- a/Tests/EnviousWisprTests/LLM/OpenAIParamStripTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAIParamStripTests.swift
@@ -140,10 +140,10 @@ struct OpenAIParamStripTests {
     KeychainManager(backend: .legacyFiles, legacyStore: PopulatedKeyStore())
   }
 
-  private func config(model: String, reasoningEffort: String? = nil) -> LLMProviderConfig {
+  private func config(model: String, effort: String? = nil) -> LLMProviderConfig {
     LLMProviderConfig(
       model: model, apiKeyKeychainId: "openai-api-key", outputTokens: .capped(512),
-      temperature: 0, thinkingBudget: nil, reasoningEffort: reasoningEffort)
+      temperature: 0, thinking: effort.map { .effort($0) })
   }
 
   private static let endpoint = URL(string: "https://api.openai.com/v1/chat/completions")!
@@ -233,7 +233,7 @@ struct OpenAIParamStripTests {
 
     let result = try await connector(transport).polish(
       text: "hello", instructions: .default,
-      config: config(model: model, reasoningEffort: "low"), onToken: nil)
+      config: config(model: model, effort: "low"), onToken: nil)
 
     #expect(result.polishedText == "Polished.")
     #expect(transport.requestCount == 3)

--- a/Tests/EnviousWisprTests/LLM/OpenAIRequestBodyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/OpenAIRequestBodyTests.swift
@@ -29,12 +29,12 @@ struct OpenAIRequestBodyTests {
   // MARK: - Polish request body per family (#1330)
 
   private func config(
-    model: String, reasoningEffort: String? = nil,
+    model: String, effort: String? = nil,
     outputTokens: OutputTokenPolicy = .capped(512)
   ) -> LLMProviderConfig {
     LLMProviderConfig(
       model: model, apiKeyKeychainId: "openai-api-key", outputTokens: outputTokens,
-      temperature: 0, thinkingBudget: nil, reasoningEffort: reasoningEffort)
+      temperature: 0, thinking: effort.map { .effort($0) })
   }
 
   private let messages: [[String: String]] = [
@@ -52,7 +52,7 @@ struct OpenAIRequestBodyTests {
 
   @Test func reasoningModelOmitsTemperatureAndSendsEffort() {
     let body = OpenAIConnector.makeRequestBody(
-      config: config(model: "gpt-5.6-sol", reasoningEffort: "low"), messages: messages)
+      config: config(model: "gpt-5.6-sol", effort: "low"), messages: messages)
     #expect(body["temperature"] == nil)
     #expect(body["reasoning_effort"] as? String == "low")
   }
@@ -68,7 +68,7 @@ struct OpenAIRequestBodyTests {
 
   @Test func omittingSetRemovesParamsRegardlessOfFamily() {
     let body = OpenAIConnector.makeRequestBody(
-      config: config(model: "gpt-4o-mini", reasoningEffort: "low"),
+      config: config(model: "gpt-4o-mini", effort: "low"),
       messages: messages,
       omitting: ["temperature", "reasoning_effort"])
     #expect(body["temperature"] == nil)

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishBudgetScalingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishBudgetScalingTests.swift
@@ -1,0 +1,112 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1770: the polish deadline scales with the transcript for Gemini.
+///
+/// A flat 5 s was timing out every dictation past roughly 5,000
+/// characters — measured live, a 10-minute dictation polishes in 6.12 s and the
+/// longest transcript we have recorded in 50.65 s. A flat LARGER number was
+/// rejected because it would slow the common case (p50 is 8 seconds of speech)
+/// down to rescue the 0.1% tail.
+///
+/// One table-driven test rather than "long > short": that weaker assertion
+/// would pass with the base, the divisor, the ceiling, the unsupported-model
+/// case or the deep base all wrong.
+@MainActor
+@Suite("Gemini polish budget scales with transcript length (#1770)")
+struct LLMPolishBudgetScalingTests {
+
+  private func step(model: String, deep: Bool = false, provider: LLMProvider = .gemini)
+    -> LLMPolishStep
+  {
+    let s = LLMPolishStep(keychainManager: KeychainManager())
+    s.llmProvider = provider
+    s.llmModel = model
+    s.useExtendedThinking = deep
+    return s
+  }
+
+  /// Returns the `Duration` itself so assertions compare exact values rather
+  /// than a float tolerance that could mask a wrong base or divisor.
+  private func budget(_ s: LLMPolishStep, chars: Int) -> Duration {
+    s.maxDuration(
+      for: TextProcessingContext(text: String(repeating: "a", count: chars), language: "en"))
+  }
+
+  /// Exact expected values, not display rounding: `base + chars / 500`.
+  @Test("fast mode: base 5s plus one second per 500 characters")
+  func fastModeScales() {
+    let s = step(model: "gemini-3.6-flash")
+    // ~20 words. Preserves today's short-dictation failure speed almost exactly.
+    #expect(budget(s, chars: 110) == .seconds(5 + 110.0 / 500))
+    // p99 of real dictations.
+    #expect(budget(s, chars: 1709) == .seconds(5 + 1709.0 / 500))
+    // A 10-minute dictation — 6.12s measured, so 4.5x headroom.
+    #expect(budget(s, chars: 11324) == .seconds(5 + 11324.0 / 500))
+    // The longest transcript ever recorded — 50.65s measured, 2.7x headroom.
+    #expect(budget(s, chars: 66896) == .seconds(5 + 66896.0 / 500))
+  }
+
+  /// Beyond this the transport terminates the attempt anyway, so a larger
+  /// logical budget only buys another long attempt.
+  @Test("the budget is capped at the transport's 180s resource limit")
+  func budgetIsCapped() {
+    let s = step(model: "gemini-3.6-flash")
+    #expect(budget(s, chars: 1_000_000) == .seconds(180))
+  }
+
+  /// Deep mode pays a fixed pre-first-byte thinking cost (measured 42.2-42.4s),
+  /// not a per-character one.
+  @Test("deep mode uses the larger base")
+  func deepModeUsesLargerBase() {
+    let s = step(model: "gemini-3.6-flash", deep: true)
+    #expect(budget(s, chars: 110) == .seconds(60 + 110.0 / 500))
+  }
+
+  /// The case that keys off the RESOLVED request rather than the raw toggle: a
+  /// model we have never verified sends no thinking field at all, so it must
+  /// not inherit the deep base just because the toggle happens to be on.
+  @Test("an unsupported model with the toggle ON still gets the fast base")
+  func unsupportedModelDoesNotGetDeepBase() {
+    let s = step(model: "gemini-4.0-flash-imaginary", deep: true)
+    #expect(budget(s, chars: 110) == .seconds(5 + 110.0 / 500))
+  }
+
+  /// Only Gemini scales. OpenAI and Claude keep their fixed budgets; widening
+  /// them without measuring their streaming behaviour is #1833.
+  @Test("other providers keep their fixed budgets regardless of length")
+  func otherProvidersUnchanged() {
+    let openAI = step(model: "gpt-4o-mini", provider: .openAI)
+    #expect(budget(openAI, chars: 110) == .seconds(5))
+    #expect(budget(openAI, chars: 66896) == .seconds(5))
+
+    let claude = step(model: "claude-haiku-4-5", provider: .claude)
+    #expect(budget(claude, chars: 66896) == .seconds(15))
+
+    let ollama = step(model: "llama3.2", provider: .ollama)
+    #expect(budget(ollama, chars: 66896) == .seconds(15))
+  }
+
+  /// The five non-LLM steps inherit the protocol default, which returns their
+  /// fixed `maxDuration` — they must not have been disturbed by adding the
+  /// context-aware form.
+  @Test("fixed-duration steps are unaffected by the context-aware form")
+  func fixedDurationStepsUnchanged() {
+    let context = TextProcessingContext(text: String(repeating: "a", count: 66896), language: "en")
+    let filler = FillerRemovalStep()
+    #expect(filler.maxDuration(for: context) == filler.maxDuration)
+    let itn = InverseTextNormalizationStep()
+    #expect(itn.maxDuration(for: context) == itn.maxDuration)
+    let wordCorrection = WordCorrectionStep()
+    #expect(wordCorrection.maxDuration(for: context) == .seconds(3))
+    let emojiFormatter = EmojiFormatterStep()
+    #expect(emojiFormatter.maxDuration(for: context) == emojiFormatter.maxDuration)
+    let emojiRestore = EmojiRestoreStep()
+    #expect(emojiRestore.maxDuration(for: context) == emojiRestore.maxDuration)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishBudgetScalingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishBudgetScalingTests.swift
@@ -8,8 +8,8 @@ import Testing
 
 /// #1770: the polish deadline scales with the transcript for Gemini.
 ///
-/// A flat 5 s was timing out every dictation past roughly 5,000
-/// characters — measured live, a 10-minute dictation polishes in 6.12 s and the
+/// A flat 5 s was timing out the measured long dictations (11,324 chars at
+/// 6.12 s, 66,896 at 50.65 s; the last case under budget was 4,605 at 2.69 s) — measured live, a 10-minute dictation polishes in 6.12 s and the
 /// longest transcript we have recorded in 50.65 s. A flat LARGER number was
 /// rejected because it would slow the common case (p50 is 8 seconds of speech)
 /// down to rescue the 0.1% tail.

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishStepThinkingDialectTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishStepThinkingDialectTests.swift
@@ -1,0 +1,144 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #1770: the thinking value that actually reaches the provider.
+///
+/// Chunk-1 review caught that asserting on `LLMModelCapabilities` alone proves
+/// only that the TABLE is right — it cannot detect a broken resolver or a
+/// broken config handoff, which is where the shipped defect lived. These tests
+/// drive the real `LLMPolishStep.process()` path and capture what the polisher
+/// is actually handed, with no production test seam added.
+///
+/// The defect being pinned: with Deep reasoning OFF (the default, used by 570
+/// of 571 users) we sent `thinkingBudget: 0` to every Gemini 2.5/3 model. Gemini
+/// 3 answers that with HTTP 400, so five of the eleven offered models failed
+/// every polish attempt.
+@MainActor
+@Suite("LLMPolishStep thinking dialect reaches the provider (#1770)")
+struct LLMPolishStepThinkingDialectTests {
+
+  /// Box for the resolved thinking value handed to the polisher. `@unchecked
+  /// Sendable` mirrors the established fixture in
+  /// `LLMPolishStepLanguageFallbackTests`: written once inside the polisher
+  /// call, read only after `process()` has fully awaited.
+  private final class ThinkingCapture: @unchecked Sendable {
+    var thinking: ResolvedThinking?
+    var sawCall = false
+  }
+
+  private struct CapturingPolisher: TranscriptPolisher {
+    let capture: ThinkingCapture
+    let result: String
+
+    func polish(
+      text: String,
+      instructions: PolishInstructions,
+      config: LLMProviderConfig,
+      onToken: (@Sendable (String) -> Void)?
+    ) async throws -> LLMResult {
+      capture.thinking = config.thinking
+      capture.sawCall = true
+      return LLMResult(polishedText: result)
+    }
+  }
+
+  private static let input =
+    "so um i was thinking maybe we could move the meeting to tuesday instead of monday"
+  private static let polished =
+    "I was thinking maybe we could move the meeting to Tuesday instead of Monday."
+
+  private func capturedThinking(
+    model: String, extendedThinking: Bool
+  ) async throws -> (value: ResolvedThinking?, sawCall: Bool) {
+    let step = LLMPolishStep(keychainManager: KeychainManager())
+    step.llmProvider = .gemini
+    step.llmModel = model
+    step.useExtendedThinking = extendedThinking
+
+    let capture = ThinkingCapture()
+    step.makePolisher = { _, _, _ in
+      CapturingPolisher(capture: capture, result: Self.polished)
+    }
+
+    _ = try await step.process(TextProcessingContext(text: Self.input, language: "en"))
+    return (capture.thinking, capture.sawCall)
+  }
+
+  /// THE REGRESSION. Before this change a Gemini 3 model with the toggle off
+  /// received `.budget(0)`, which Google rejects with HTTP 400.
+  @Test("Gemini 3, Deep reasoning OFF → thinkingLevel minimal, never budget 0")
+  func geminiThreeToggleOffSendsLevel() async throws {
+    for model in ["gemini-3.6-flash", "gemini-3.5-flash-lite"] {
+      let (thinking, sawCall) = try await capturedThinking(
+        model: model, extendedThinking: false)
+      #expect(sawCall, "\(model): the polisher was never reached, so this proves nothing")
+      #expect(
+        thinking == .level("minimal"),
+        "\(model) must receive .level(\"minimal\"); .budget(0) is HTTP 400")
+    }
+  }
+
+  /// The opposite direction: an unrecognised model must reach the provider with
+  /// NO thinking field at all. Asserted positively — a fallback that silently
+  /// sent something would pass a mere "did not crash" check.
+  @Test("unknown Gemini model, Deep reasoning ON → no thinking field at all")
+  func unknownModelSendsNothingEvenWithToggleOn() async throws {
+    let (thinking, sawCall) = try await capturedThinking(
+      model: "gemini-4.0-flash-imaginary", extendedThinking: true)
+    #expect(sawCall)
+    #expect(
+      thinking == nil,
+      "an untested model must not inherit a deep value merely because the toggle is on")
+  }
+
+  /// Gemini 2.5 keeps the integer dialect; the two generations must not blur.
+  @Test("Gemini 2.5, Deep reasoning OFF → thinkingBudget 0, not a level")
+  func geminiTwoFiveKeepsBudgetDialect() async throws {
+    let (thinking, sawCall) = try await capturedThinking(
+      model: "gemini-2.5-flash", extendedThinking: false)
+    #expect(sawCall)
+    #expect(thinking == .budget(0), "2.5 rejects thinkingLevel with HTTP 400")
+  }
+
+  /// The toggle still does something on a model that supports it.
+  @Test("Deep reasoning ON selects the deep value")
+  func toggleOnSelectsDeepValue() async throws {
+    let (thinking, _) = try await capturedThinking(
+      model: "gemini-3.6-flash", extendedThinking: true)
+    #expect(thinking == .level("high"))
+  }
+
+  // MARK: - Codable contract
+
+  /// `LLMProviderConfig` is `Codable` and this change altered its stored shape,
+  /// replacing two optionals with one. Two things must hold: previously-encoded
+  /// JSON (carrying the now-deleted keys) must still decode rather than throw,
+  /// and a live value must survive a round trip.
+  @Test("legacy encoded config decodes with no thinking value")
+  func legacyJSONDecodesWithNilThinking() throws {
+    let legacy = """
+      {"model":"gemini-2.5-flash","outputTokens":{"providerDefault":{}},
+       "temperature":0,"thinkingBudget":0,"reasoningEffort":"low"}
+      """.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LLMProviderConfig.self, from: legacy)
+    #expect(decoded.thinking == nil, "unknown legacy keys must not throw, and must not be guessed")
+    #expect(decoded.model == "gemini-2.5-flash")
+  }
+
+  @Test("a resolved thinking value survives a Codable round trip")
+  func thinkingRoundTrips() throws {
+    for value: ResolvedThinking in [.level("minimal"), .budget(8192), .effort("low")] {
+      let config = LLMProviderConfig(
+        model: "gemini-3.6-flash", apiKeyKeychainId: nil,
+        outputTokens: .providerDefault, temperature: 0, thinking: value)
+      let restored = try JSONDecoder().decode(
+        LLMProviderConfig.self, from: JSONEncoder().encode(config))
+      #expect(restored.thinking == value)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
@@ -215,6 +215,25 @@ struct RecoveryTextProcessorTests {
     }
   }
 
+  /// The retirement is Google's, so it may only ever apply to Google's provider.
+  /// An Ollama model is named by the USER: `ollama cp` will happily produce a
+  /// local model called `gemini-2.0-flash`, and that is a legitimate choice.
+  /// A provider-blind membership test would rewrite it to `llama3.2` on replay,
+  /// so a recovered take would polish through the wrong local model — or skip
+  /// polish entirely if `llama3.2` is not installed.
+  @Test("a retired GEMINI id is left alone under a different provider")
+  func retiredIDIsScopedToItsProvider() {
+    for foreign in [LLMProvider.ollama, .openAI, .claude] {
+      #expect(
+        LLMProvider.replacingRetiredModel("gemini-2.0-flash", for: foreign) == "gemini-2.0-flash",
+        "\(foreign) never had this id withdrawn — only Gemini did")
+    }
+    // And the membership test itself, so the scoping is pinned at the authority
+    // rather than only at one caller.
+    #expect(LLMProvider.isRetiredModel("gemini-2.0-flash", for: .gemini))
+    #expect(LLMProvider.isRetiredModel("gemini-2.0-flash", for: .ollama) == false)
+  }
+
   /// The WIRING, proved without adding a production test seam — `steps` is
   /// private by design, and the established pattern in this file is a static
   /// source check (see the `.silent` tests above).

--- a/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryTextProcessorTests.swift
@@ -198,4 +198,51 @@ struct RecoveryTextProcessorTests {
     #expect(buildsStepFromSilent)
     #expect(handRolledSeams.isEmpty, "recovery must name .silent, not per-seam closures")
   }
+
+  // MARK: - Retired-model repair at the replay seam (#1770)
+
+  /// The pure decision, tested directly: withdrawn ids are replaced, live ids
+  /// are not. The negative direction is the one that protects user choice —
+  /// a rule that caught legitimate models would silently override what the
+  /// user picked, which is worse than the bug it fixes.
+  @Test("retired ids are replaced; live ids survive untouched")
+  func retiredModelSubstitution() {
+    #expect(
+      LLMProvider.replacingRetiredModel("gemini-2.0-flash", for: .gemini)
+        == LLMProvider.defaultModel(for: .gemini))
+    for live in ["gemini-3.6-flash", "gemini-2.5-pro", "gemini-3.1-flash-lite-preview"] {
+      #expect(LLMProvider.replacingRetiredModel(live, for: .gemini) == live)
+    }
+  }
+
+  /// The WIRING, proved without adding a production test seam — `steps` is
+  /// private by design, and the established pattern in this file is a static
+  /// source check (see the `.silent` tests above).
+  ///
+  /// Why this matters: recovery deliberately replays the model recorded in the
+  /// spool at capture time, so it BYPASSES `SettingsManager`'s sweep entirely.
+  /// A spool captured while the user was pinned to a retired id would replay
+  /// against a dead model and return unpolished text. A substitution helper
+  /// nothing calls is not a repair.
+  @Test("the replay seam actually routes the snapshot model through the retired-id repair")
+  func recoveryAppliesRetiredModelRepair() throws {
+    let path = RepoRoot.url.appending(
+      path: "Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift")
+    let source = try String(contentsOf: path, encoding: .utf8)
+    let code = source.split(separator: "\n")
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.hasPrefix("//") }
+      .joined(separator: " ")
+
+    let routesThroughRepair = code.contains(
+      "steps.llmPolish.llmModel = LLMProvider.replacingRetiredModel(")
+    // The regression: assigning the snapshot id straight through, which is what
+    // this file did before #1770 and what a careless revert would restore.
+    let assignsRawSnapshotModel = code.contains("steps.llmPolish.llmModel = snapshot.llmModel")
+
+    #expect(routesThroughRepair)
+    #expect(
+      assignsRawSnapshotModel == false,
+      "recovery must not replay a raw snapshot model id — a retired one 404s")
+  }
 }

--- a/Tests/EnviousWisprTests/Services/SettingsManagerOllamaTruthTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsManagerOllamaTruthTests.swift
@@ -158,6 +158,54 @@ struct SettingsManagerOllamaTruthTests {
     #expect(settings.llmModel == LLMProvider.defaultModel(for: .claude))
   }
 
+  // MARK: - Retired-model sweep (#1770)
+
+  /// Google shut down `gemini-2.0-flash` on 2026-06-01. It is a well-formed
+  /// Gemini id, so the foreign-provider check waves it through and a pinned
+  /// user 404s on every dictation forever — discovery does not run at launch,
+  /// and opening AI Polish settings only loads cached rows.
+  @Test("a persisted RETIRED model id is swept at launch")
+  func launchSweepsRetiredModel() {
+    let settings = freshSettings { suite in
+      suite.set("gemini", forKey: "llmProvider")
+      suite.set("gemini-2.0-flash", forKey: "llmModel")
+    }
+
+    #expect(settings.llmModel == LLMProvider.defaultModel(for: .gemini))
+  }
+
+  /// The direction that protects user choice. This sweep rewrites a persisted
+  /// setting, so it must touch ONLY ids the provider actually withdrew — a
+  /// predicate that caught legitimate models would silently override what the
+  /// user picked, which is far worse than the bug it fixes.
+  @Test("a persisted LIVE model id is NOT swept")
+  func launchPreservesLiveModel() {
+    for live in ["gemini-3.6-flash", "gemini-2.5-pro", "gemini-3.1-flash-lite"] {
+      let settings = freshSettings { suite in
+        suite.set("gemini", forKey: "llmProvider")
+        suite.set(live, forKey: "llmModel")
+      }
+      #expect(settings.llmModel == live, "\(live) is live and must survive the sweep untouched")
+    }
+  }
+
+  /// The sweep runs during initialization, and this file persists
+  /// initialization-time values by write-through rather than relying on the
+  /// `didSet` observer. Without that, the repair would be forgotten on quit.
+  @Test("the swept value survives a reload")
+  func sweptValuePersistsAcrossReload() {
+    let suiteName = "ew-tests-\(UUID().uuidString)"
+    let suite = UserDefaults(suiteName: suiteName)!
+    suite.set("gemini", forKey: "llmProvider")
+    suite.set("gemini-2.0-flash", forKey: "llmModel")
+
+    _ = SettingsManager(defaults: suite)
+    let reloaded = SettingsManager(defaults: suite)
+
+    #expect(reloaded.llmModel == LLMProvider.defaultModel(for: .gemini))
+    suite.removePersistentDomain(forName: suiteName)
+  }
+
   @Test("turning polish off preserves the selected model (#158 Codex r5 P1 claim, verified false)")
   func polishOffPreservesSelectedModel() {
     let settings = freshSettings()

--- a/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
+++ b/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
@@ -144,8 +144,10 @@ struct RunnerMain {
       apiKeyKeychainId: nil,
       outputTokens: .capped(2048),
       temperature: 0,
-      thinkingBudget: nil,
-      reasoningEffort: nil,
+      // #1770: the two sibling optionals collapsed into one `ResolvedThinking?`.
+      // Apple Intelligence has no thinking dialect, so this stays nil — the same
+      // "send no thinking field" decision the two nils encoded before.
+      thinking: nil,
       // Empty string maps to nil so the bench can mirror the DEFAULT Parakeet
       // production path (no LID → language nil → LeadingMarkerRepair does NOT
       // fire). Passing "en" forces the repair on, which inflates onset numbers


### PR DESCRIPTION
## What was broken

**Two independent faults, both silent.**

**1. Wrong dialect on Gemini 3.** Google's newer models replaced the integer `thinkingBudget` with a string `thinkingLevel`. We sent `thinkingBudget: 0` to every Gemini model. Gemini 3.x rejects it with HTTP 400, so with the Deep-reasoning toggle OFF — the default — polish failed on every attempt for five models: `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`, `gemini-3-flash-preview`. `gemini-2.5-pro` failed the same way for a different reason: it documents 128 as its minimum budget and rejects 0.

**2. The default Gemini model has not existed since 2026-06-01.** `defaultModel(for: .gemini)` returned `gemini-2.0-flash`, which Google withdrew. Any user who selected Gemini and never opened the model picker got no polish at all, indefinitely. Discovery does not run at launch, and opening AI Polish settings only loads cached rows — the rescan is behind a manual refresh button, so nothing self-healed.

Blast radius, Sentry 90d: Gemini `bad_request` = 3 events / 1 user; cloud `model_unavailable` = 0. This is fix-before-it-spreads, not a live outage.

## What changed

- **`ThinkingControl`** on `LLMModelCapabilities` carries the dialect and its two values together, so a model cannot be given a budget in a level-only dialect. `supportsReasoning` is now derived from it rather than tracked separately. Exact-ID matching, never prefixes — a prefix would silently capture untested future models.
- **`ResolvedThinking`** replaces the sibling optionals `thinkingBudget: Int?` / `reasoningEffort: String?`, which allowed a request to carry both dialects at once. That state is now unconstructible.
- **`LLMPolishStep` knows no model IDs.** It reads the capability and picks fast or deep.
- **Retired-model sweep.** `LLMProvider.retiredModelIDs` is an explicit set (each verified 404 against the live API), read by both production seams that carry a user-selected model: the live setting in `SettingsManager`, and crash-recovery replay in `RecoveryTextProcessor`. Deliberately a set, not a predicate — this rewrites a saved user preference, so it must touch only IDs the provider actually withdrew.
- **Length-scaled polish deadline.** The flat 5s budget was replaced with `5s + chars/500`, capped at 180s, matching the transport's existing 180s absolute ceiling. Deep reasoning starts at 60s.
- **Telemetry allowlist** recognises the eight live Gemini 3.x IDs.

## Evidence

Root cause was reproduced against the live API, not inferred from docs — Google's own documentation claims Gemini 3 Flash cannot disable thinking, which probing disproved: `thinkingLevel: "minimal"` returns 200 with **zero** thinking tokens.

Coverage was proven by reimplementing `filterModels` against the live catalogue: 16 IDs survive the filter, 11 are in the dialect table, and the other 5 are unreachable regardless (three 404, one Interactions-API-only, one requires an unenabled developer instruction).

**Two claims in earlier commit messages in this branch overstate the evidence and are corrected by `b029bd65`:**
- `7d3ada42` says thinking-off is "fully available on Gemini 3". False for `gemini-3.1-pro-preview` and its customtools variant, which reject `minimal`; `low` is the floor Google permits. The claim holds only for the six Flash-tier IDs.
- `842344b9` says the flat budget timed out "every dictation past roughly 5,000 characters". Not measured. Measured: 4,605 chars completed in 2.69s, 11,324 chars took 6.12s. The crossing lies between those points; "roughly 5,000" was an interpolation presented as a measurement.

## Tests

New suites driving the real `process()` path rather than asserting on construction. Each was mutation-tested: the pre-fix behaviour was injected to confirm the tests actually fail without the fix. Full suite 4,375 tests, `** TEST SUCCEEDED **`.

Per the founder's direction on this issue, test investment was deliberately bounded; deeper coverage is deferred to #1834.

## Live UAT

Real dictation through the rebuilt dev app, verdicts from `app.log`, never the clipboard. **All 11 models, Deep reasoning OFF (the default)** — every one sent its own dialect and returned HTTP 200:

| Dialect sent | Models | Result |
|---|---|---|
| `thinking=level=minimal` | 3.6-flash, 3.5-flash, 3.5-flash-lite, 3.1-flash-lite, 3.1-flash-lite-preview, 3-flash-preview | 200 |
| `thinking=level=low` | 3.1-pro-preview, 3.1-pro-preview-customtools | 200 |
| `thinking=budget=0` | 2.5-flash, 2.5-flash-lite | 200 |
| `thinking=budget=128` | 2.5-pro | 200 |

Deep reasoning ON spot-checked on both families: `level=high` (3.5-flash) and `budget=8192` (2.5-flash), both 200.

`gemini-2.5-flash-lite` logged a 503 on the warm-up call only; its polish request returned 200. Google-side transient, not a rejected request shape.

**A methodology note worth recording.** The first UAT run appeared to pass and was invalid. User settings live in the shared `com.enviouswispr.app` domain, and the harness was writing to `com.enviouswispr.app.dev`, which holds bench knobs. The app therefore stayed on its default the entire time — which happened to be the model the run claimed to be testing, so it reported a pass while proving nothing. Caught by a gate asserting the model in the request log matches the model the harness set; every result above cleared that gate. This is [[measure-with-the-real-tool-never-a-simulation]]'s positive-control clause: a negative is worthless until you have shown the instrument reaches the target.

**Not covered live:** a >5,000-character dictation. Producing one needs ~8 minutes of continuous speech. The scaling is unit-tested with exact `Duration` comparisons, and the wiring was observed live (`budget: 5280ms` for a 140-character transcript, i.e. the 5s base plus the length term rather than the old flat 5s).

## Review findings applied

The independent whole-diff review was run twice over the same tree and each pass surfaced a different defect, which is the argument for having run it twice. Both are fixed in `46027754`, and a third confirming round returned no actionable defects.

1. **The retired-model sweep was provider-blind.** `replacingRetiredModel` took a provider and ignored it for the membership test. Reachable through crash-recovery replay: Ollama models are named by the user, so a local model called `gemini-2.0-flash` is a legitimate choice that would have been rewritten to `llama3.2`. Classified hypothetical rather than reproducible (it needs that exact name), fixed anyway because the change is one condition and the failure is silent.

   Fixed by keying the authority on provider rather than by the suggested `provider == .gemini` guard. That guard fixes today and traps tomorrow: a future OpenAI retirement added to a flat set would look registered and do nothing.

2. **The change did not compile.** Collapsing the two thinking optionals broke `scripts/eval/apple_runner`, a standalone SwiftPM package depending on Core by path. Neither `xcode-test.sh` nor any CI workflow compiles it, so 4,374 tests passed over a tree with a build error. Swept the class rather than the instance — the repo has three tracked `Package.swift` files and all three now build. Grep cannot catch this; only a build can. CI coverage filed as #1836.

## Follow-ups filed

- #1831 — remove the Deep reasoning toggle (1 user in 571 has ever enabled it)
- #1832 — benchmark the Gemini default (3.6 Flash vs 3.5 Flash Lite)
- #1833 — OpenAI and Claude still lose long dictations to a fixed deadline
- #1834 — record the thinking dialect on polish telemetry
- #1836 — CI never compiles the two standalone eval packages

Closes #1770
Closes #1769
