### PR TITLE
fix(pipeline): recovery is one attempt only, spent attempts are never retained (#1740)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -113,11 +113,13 @@ final class DictationLifecycleCoordinator {
   /// `onRecordingEndedWithoutDurableSave` (which never fires for `.complete`)
   /// and from `onDurableSave` (which only fires on a SUCCESSFUL save).
   /// `DictationRuntime` sets it to
-  /// `RecoveryCoordinator.suppressUntilNextLaunch(recoverySessionID:)` so this
-  /// session's spool is protected from THIS SAME terminal transition's own
-  /// `onDictationEndedForRecovery` wake-up before that wake-up fires (both
-  /// calls happen synchronously, in this order, from the kernel's single
-  /// `fireStateChangeIfNeeded()` turn). Off-cap `var` closure, default no-op.
+  /// `RecoveryCoordinator.handleHistorySaveFailed(recoverySessionID:)`, which
+  /// (#1740) DESTROYS this session's spool rather than deferring it, after
+  /// suppressing THIS SAME terminal transition's own
+  /// `onDictationEndedForRecovery` wake-up so a failed deletion cannot be
+  /// rediscovered this launch (both calls happen synchronously, in this order,
+  /// from the kernel's single `fireStateChangeIfNeeded()` turn). Off-cap `var`
+  /// closure, default no-op.
   var onDurableSaveFailed: (String?) -> Void = { _ in }
 
   /// #1171 — fired on every pipeline state change (both drivers). The composition

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -181,7 +181,7 @@ final class DictationRuntime {
     // whose History save failed retains its spool but fires no delete
     // callback — protect it from this same transition's own recovery wake-up.
     dictationLifecycleCoordinator.onDurableSaveFailed = { id in
-      recoveryCoordinator.suppressUntilNextLaunch(recoverySessionID: id)
+      recoveryCoordinator.handleHistorySaveFailed(recoverySessionID: id)
     }
     let hotkeyController = HotkeyController(
       hotkeyService: hotkeyService,

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -266,6 +266,8 @@ final class RecoveryCoordinator {
     case historyDedup = "history_dedup"
     case replayOutcome = "replay_outcome"
     case userDiscard = "user_discard"
+    /// #1740: a live `.complete` dictation whose History write failed.
+    case historySaveFailed = "history_save_failed"
   }
 
   /// #1755 chunk 4 test seams (internal; nil in production — the real spool
@@ -296,6 +298,24 @@ final class RecoveryCoordinator {
     }
   }
 
+  /// #1740 (founder Gate 2): did a SPENT attempt's cleanup actually happen?
+  /// Emitted for both outcomes, success and failure, but ONLY for the two
+  /// spent-attempt sources — `durable_save` fires on every successful
+  /// dictation and would swamp a signal for a path this change does not touch.
+  /// Shape only: source, component, succeeded. Never the id, path, or error.
+  @MainActor private static func emitCleanupOutcome(
+    component: String, source: DestructionSource, succeeded: Bool
+  ) {
+    switch source {
+    case .replayOutcome, .historySaveFailed:
+      TelemetryService.shared.recoveryCleanup(
+        source: source.rawValue, component: component, succeeded: succeeded)
+    case .durableSave, .liveEnding, .preStartAbort, .historyDedup, .userDiscard:
+      // Not a spent recovery attempt — no cleanup-coverage question to answer.
+      break
+    }
+  }
+
   /// The SOLE spool+key destructor (#1464). Deletes the spool file (which also
   /// clears its attempt marker) SYNCHRONOUSLY — it is cheap local FS, and a
   /// follow-up scan / the dedup + discard callers must see it gone at once — then
@@ -316,8 +336,10 @@ final class RecoveryCoordinator {
       } else {
         try makeSpoolStore().delete(recoverySessionID: id)
       }
+      Self.emitCleanupOutcome(component: "spool", source: source, succeeded: true)
     } catch {
       emitDeletionFailed(component: "spool", source: source)
+      Self.emitCleanupOutcome(component: "spool", source: source, succeeded: false)
     }
     // Key deletion ALWAYS runs, detached, even after a spool failure.
     let keyStore = self.keyStore
@@ -343,9 +365,13 @@ final class RecoveryCoordinator {
         } else {
           try keyStore.delete(for: id)
         }
+        await MainActor.run {
+          Self.emitCleanupOutcome(component: "key", source: source, succeeded: true)
+        }
       } catch {
         await MainActor.run {
           self.emitDeletionFailed(component: "key", source: source)
+          Self.emitCleanupOutcome(component: "key", source: source, succeeded: false)
         }
       }
     }
@@ -378,23 +404,29 @@ final class RecoveryCoordinator {
     }
   }
 
-  /// Delete-versus-retain after a launch replay attempt (#1464). Delete a recovered
-  /// (saved) or unrecoverable orphan and a crash-loop `.abandoned` one; RETAIN a
-  /// History-save failure (the audio is still good, §3.3). `.aborted` (the user
-  /// discarded — already deleted by `discardActiveRecovery`), `.deferred` (the
-  /// marker was never written — keep for a future launch), and #1707 Phase 3's
-  /// `.deferredMarkerClearFailed` (Keychain-transient, marker survives — keep for
-  /// a future launch) delete nothing here. Static + internal for direct
-  /// adversarial testing.
+  /// Delete-versus-retain after a launch replay attempt (#1464; #1740 cutover).
+  /// EVERY spent attempt deletes: an attempt that actually ran is the user's one
+  /// rescue, whatever its outcome. Only outcomes where ASR never ran retain.
+  /// Static + internal for direct adversarial testing.
   static func shouldDeleteAfterReplay(_ outcome: RecoveryReplayOutcome) -> Bool {
     switch outcome {
     case .recovered, .abandoned:
       return true
-    case .failed(.unrecoverable):
+    case .failed(.unrecoverable), .failed(.save):
+      // #1740: the ATTEMPT is spent. Recovering the audio and failing only the
+      // History write is still an attempt; retaining it for a later launch is
+      // the safety net the one-attempt rule removes. The committed attempt
+      // marker — not this deletion — is what makes "one attempt" structural: a
+      // spool that survives a failed delete still abandons at the entry guard.
       return true
-    case .failed(.save), .failed(.saveMarkerClearFailed):
+    case .aborted:
+      // `discardActiveRecovery` already requested destruction. NOT a claim that
+      // no attempt ran — a Discard can land after transcription.
       return false
-    case .aborted, .deferred, .deferredMarkerClearFailed:
+    case .deferred, .deferredMarkerClearFailed:
+      // ASR never ran, so the attempt is unspent. `.deferredMarkerClearFailed`
+      // is the transient-Keychain case #1360 closed — never treat it as a
+      // permanent deletion trigger.
       return false
     }
   }
@@ -408,20 +440,27 @@ final class RecoveryCoordinator {
     return destroySpoolAndKey(id: id, source: .durableSave)
   }
 
-  /// A `.complete` dictation whose History save FAILED (GitHub cloud review,
-  /// PR #1732 round 6): `onDurableSave` never fires for this case (correctly
-  /// — nothing to delete, the spool must be retained), but this session's own
-  /// terminal transition ALSO fires `onDictationEndedForRecovery` moments
-  /// later via the SAME synchronous `fireStateChangeIfNeeded()` call that
-  /// dispatches to the caller of this method first — without this
-  /// suppression, that same-launch wake-up could immediately rescan and
-  /// destructively replay the spool this failure meant to retain for a
-  /// healthier future launch. (#1755: this History-save self-heal case is now
-  /// the ONLY live path that retains.) No-op when `id` is nil (armed only
-  /// when recovery was on for this take).
-  func suppressUntilNextLaunch(recoverySessionID id: String?) {
-    guard let id else { return }
+  /// A `.complete` dictation whose History save FAILED (#1740). The live path
+  /// still delivers the text because the save error is absorbed, so retaining
+  /// this spool would buy only a later History row. Request best-effort
+  /// destruction instead: #1740 removed the last live retention path.
+  ///
+  /// Suppress BEFORE the best-effort delete, matching
+  /// `handleRecordingEndedWithoutDurableSave`: the same terminal transition
+  /// fires `onDictationEndedForRecovery` moments later via the SAME synchronous
+  /// `fireStateChangeIfNeeded()` call, and that same-launch wake must not
+  /// rediscover a spool whose deletion failed.
+  ///
+  /// NOTE: unlike launch replay, this spool carries NO attempt marker — no
+  /// replay ever ran for it. If deletion fails, a later launch gives it its
+  /// FIRST crash-recovery attempt, which is consistent with the one-attempt
+  /// rule. No-op when `id` is nil (armed only when recovery was on).
+  @discardableResult
+  func handleHistorySaveFailed(recoverySessionID id: String?) -> Task<Void, Never>? {
+    guard let id else { return nil }
+    if armedSessionID == id { armedSessionID = nil }
     nextLaunchOnlyRecoveryIDs.insert(id)
+    return destroySpoolAndKey(id: id, source: .historySaveFailed)
   }
 
   /// A recording ended at a terminal state WITHOUT a durable transcript save
@@ -661,7 +700,7 @@ final class RecoveryCoordinator {
       // #1707 Phase 3 (§3.3): a marker-clear failure under either deferred
       // outcome means only a genuinely new launch may safely re-check this id.
       switch outcome {
-      case .deferredMarkerClearFailed, .failed(.saveMarkerClearFailed):
+      case .deferredMarkerClearFailed:
         nextLaunchOnlyRecoveryIDs.insert(id)
       default:
         break

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -285,6 +285,13 @@ final class RecoveryCoordinator {
   // periphery:ignore - test seam
   var deletionFailureBreadcrumbForTesting:
     (@MainActor @Sendable (_ stage: String, _ message: String, _ data: [String: String]) -> Void)?
+  /// #1740 cleanup-telemetry seam. INSTANCE-scoped, never the process-global
+  /// `TelemetryService.testEventHook`: this suite runs in parallel, and a
+  /// sibling test's `defer` clearing that global raced this one's emits
+  /// (whole-diff review P1). `tests-no-process-global-mutable-delegate`.
+  // periphery:ignore - test seam
+  var cleanupTelemetryForTesting:
+    (@MainActor @Sendable (_ source: String, _ component: String, _ succeeded: Bool) -> Void)?
 
   /// #1755 chunk 4: one failure-only breadcrumb per failed component per
   /// destruction call. Never includes the recovery ID, path, or raw error —
@@ -303,13 +310,17 @@ final class RecoveryCoordinator {
   /// spent-attempt sources — `durable_save` fires on every successful
   /// dictation and would swamp a signal for a path this change does not touch.
   /// Shape only: source, component, succeeded. Never the id, path, or error.
-  @MainActor private static func emitCleanupOutcome(
+  private func emitCleanupOutcome(
     component: String, source: DestructionSource, succeeded: Bool
   ) {
     switch source {
     case .replayOutcome, .historySaveFailed:
-      TelemetryService.shared.recoveryCleanup(
-        source: source.rawValue, component: component, succeeded: succeeded)
+      if let sink = cleanupTelemetryForTesting {
+        sink(source.rawValue, component, succeeded)
+      } else {
+        TelemetryService.shared.recoveryCleanup(
+          source: source.rawValue, component: component, succeeded: succeeded)
+      }
     case .durableSave, .liveEnding, .preStartAbort, .historyDedup, .userDiscard:
       // Not a spent recovery attempt — no cleanup-coverage question to answer.
       break
@@ -336,10 +347,10 @@ final class RecoveryCoordinator {
       } else {
         try makeSpoolStore().delete(recoverySessionID: id)
       }
-      Self.emitCleanupOutcome(component: "spool", source: source, succeeded: true)
+      emitCleanupOutcome(component: "spool", source: source, succeeded: true)
     } catch {
       emitDeletionFailed(component: "spool", source: source)
-      Self.emitCleanupOutcome(component: "spool", source: source, succeeded: false)
+      emitCleanupOutcome(component: "spool", source: source, succeeded: false)
     }
     // Key deletion ALWAYS runs, detached, even after a spool failure.
     let keyStore = self.keyStore
@@ -366,12 +377,12 @@ final class RecoveryCoordinator {
           try keyStore.delete(for: id)
         }
         await MainActor.run {
-          Self.emitCleanupOutcome(component: "key", source: source, succeeded: true)
+          self.emitCleanupOutcome(component: "key", source: source, succeeded: true)
         }
       } catch {
         await MainActor.run {
           self.emitDeletionFailed(component: "key", source: source)
-          Self.emitCleanupOutcome(component: "key", source: source, succeeded: false)
+          self.emitCleanupOutcome(component: "key", source: source, succeeded: false)
         }
       }
     }

--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -14,9 +14,8 @@ import Security
 /// (the sole destructor) applies the delete-versus-retain predicate.
 enum RecoveryReplayOutcome: Equatable {
   case recovered
-  /// The attempt failed. The payload tells the coordinator whether to delete
-  /// (Camp A / a Camp B *candidate* Phase 1 does not yet retain) or RETAIN (a
-  /// History-write failure — the audio is still good, §3.3).
+  /// The attempt failed. The coordinator deletes on every `.failed` payload
+  /// (#1740: an attempt that ran is spent, whatever its outcome).
   case failed(RecoveryReplayFailure)
   case abandoned
   /// A Discard bumped the recovery generation mid-flight: drop the result, save
@@ -42,13 +41,10 @@ enum RecoveryReplayFailure: Equatable {
   /// The recording could not be turned into text — key / decrypt / reconstruct /
   /// empty-samples / model-load / transcribe / empty-text. DELETE.
   case unrecoverable
-  /// The transcript was produced but the History write threw; the audio is still
-  /// good. RETAIN for a next-launch retry — the attempt marker was cleared.
+  /// Recovery produced text, but the History write failed. The attempt marker
+  /// stays COMMITTED (#1740): the attempt is spent, so no later scan may run
+  /// ASR for this spool again even if best-effort deletion fails.
   case save(RecoveryFailureClass)
-  /// As `.save`, but clearing the attempt marker ALSO threw — RETAIN this launch,
-  /// next-launch retry durability not guaranteed (the marker survives, so a
-  /// future launch may treat the spool as a crashed attempt).
-  case saveMarkerClearFailed(RecoveryFailureClass)
 }
 
 /// Per-orphan recovery execution seam — lets `RecoveryCoordinator` drive scan /
@@ -72,11 +68,12 @@ protocol RecoverySpoolReplaying: AnyObject {
 /// telemetry/breadcrumb and never throws into the heart path. #1464: it no longer
 /// destroys the spool/key — it returns a typed outcome and `RecoveryCoordinator`
 /// (the sole destructor) deletes or retains. It KEEPS the attempt-marker lifecycle
-/// (the crash-loop guard): one attempt only — a per-spool marker written BEFORE the
-/// risky load/transcribe means a recovery that crashed the app is abandoned (not
-/// retried) on the next launch. On a History-save failure it clears that marker
-/// itself so the RETAINED spool replays next launch rather than reading as
-/// abandoned (§3.3).
+/// (the one-attempt guard): a per-spool marker written BEFORE the risky
+/// load/transcribe means a spool whose attempt already started is abandoned (not
+/// retried) on the next launch. #1740: a History-save failure LEAVES that marker
+/// committed — the attempt is spent — so a spool that survives a failed cleanup
+/// cannot run ASR twice. The marker is cleared only where no ASR ran (the
+/// transient-Keychain deferral).
 @MainActor
 final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   /// #1386 PR-2: recovery used to call `ASRManagerInterface.loadModel()`, which for
@@ -148,14 +145,17 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   {
     let spoolStore = makeSpoolStore()
 
-    // One-attempt crash-loop guard: a marker already present means a prior attempt
-    // crashed the app — abandon (log + emit), never retry. #1464: the coordinator
+    // One-attempt guard: a marker already present means a recovery attempt was
+    // already STARTED for this spool and may not run again — whether it crashed,
+    // or completed ASR and failed the History save (#1740), or ended before
+    // cleanup finished. Abandon (log + emit), never retry. #1464: the coordinator
     // deletes on `.abandoned`; the replayer no longer destroys.
     if spoolStore.hasAttemptMarker(for: id) {
       SentryBreadcrumb.captureError(
         RecoveryReplayError.abandonedAfterAttempt,
         category: .recoveryAbandonedAfterAttempt, stage: "recovery")
-      TelemetryService.shared.recoveryCompleted(outcome: "abandoned", reason: .crashLoop)
+      TelemetryService.shared.recoveryCompleted(
+        outcome: "abandoned", reason: .attemptAlreadySpent)
       return .abandoned
     }
     // Write the marker DURABLY before any risky load/transcribe (warm-up included).
@@ -314,27 +314,22 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     do {
       try transcriptStore.save(transcript)
     } catch {
-      // §3.3 (#1464) — a History-write failure is NOT audio loss. RETAIN the spool
-      // (the coordinator does not delete `.save`) and clear the attempt marker so
-      // the next launch REPLAYS instead of reading the spool as a crashed attempt.
-      // The clear can throw (`RecoverySpoolStore.deleteAttemptMarker`); if it does,
-      // retain THIS launch but do not claim durable next-launch retry.
+      // #1740 — the ATTEMPT is spent. ASR ran and produced text; only the
+      // History write failed. The attempt marker written above stays
+      // COMMITTED (it used to be cleared here so the next launch would
+      // replay), so if the coordinator's best-effort deletion fails, the
+      // surviving spool abandons at the entry guard instead of running ASR a
+      // second time. One attempt is therefore a property of the file, not a
+      // consequence of a deletion succeeding. The coordinator deletes on
+      // `.save` (`shouldDeleteAfterReplay`).
       let failureClass = Self.classify(error)
       SentryBreadcrumb.add(
-        stage: "recovery", message: "recovered transcript save failed — retaining spool",
+        stage: "recovery", message: "recovered transcript save failed — attempt spent",
         level: .warning, data: ["error": String(describing: error)])
-      do {
-        try spoolStore.deleteAttemptMarker(for: id)
-        TelemetryService.shared.recoveryCompleted(
-          outcome: "failed", reason: .saveFailed, failureClass: failureClass,
-          audioDecrypted: true, spoolSeconds: spoolSeconds)
-        return .failed(.save(failureClass))
-      } catch {
-        TelemetryService.shared.recoveryCompleted(
-          outcome: "failed", reason: .markerClearFailed, failureClass: failureClass,
-          audioDecrypted: true, spoolSeconds: spoolSeconds)
-        return .failed(.saveMarkerClearFailed(failureClass))
-      }
+      TelemetryService.shared.recoveryCompleted(
+        outcome: "failed", reason: .saveFailed, failureClass: failureClass,
+        audioDecrypted: true, spoolSeconds: spoolSeconds)
+      return .failed(.save(failureClass))
     }
     transcriptCoordinator.append(transcript)
 
@@ -377,13 +372,11 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
 
   /// #1707 Phase 3 (§3.3): a Keychain read failed with a status expected to
   /// clear on its own — defer this attempt WITHOUT treating it as
-  /// unrecoverable. Clears the attempt marker written above (mirrors the
-  /// existing `.save`/`.saveMarkerClearFailed` retention path, RULE:
-  /// port-proven-patterns-wholesale) so a same-launch or next-launch retry
-  /// sees a clean spool, not a crashed one. If the clear itself throws, the
-  /// marker survives and `RecoveryCoordinator` must treat this id as
-  /// next-launch-only — a same-launch rescan would otherwise misread the
-  /// surviving marker as a crashed attempt and abandon (delete) it.
+  /// unrecoverable. ASR never ran, so the attempt is UNSPENT: clear the marker
+  /// written above so a later retry remains eligible. If the clear itself
+  /// throws, the marker survives and the next-launch guard reads the attempt as
+  /// already spent, abandoning before ASR; `RecoveryCoordinator` therefore
+  /// treats this id as next-launch-only so a same-launch rescan cannot burn it.
   private func deferForTransientKeychainFailure(
     spoolStore: RecoverySpoolStore, id: String
   ) -> RecoveryReplayOutcome {

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -142,8 +142,8 @@ public enum RecoveryConstants {
   public static let fileExtension = "ewrec"
   /// File extension for a per-spool recovery-ATTEMPT marker (#1063 PR2). Written
   /// durably (fsync + atomic rename) BEFORE the risky load/transcribe step; its
-  /// presence on the next launch means a prior recovery attempt crashed the app,
-  /// so that spool is abandoned rather than retried (the one-attempt crash-loop
+  /// presence on the next launch means a prior recovery attempt already STARTED
+  /// for that spool, so it is abandoned rather than retried (the one-attempt
   /// guard). Named `<recoverySessionID>.attempt`.
   public static let attemptFileExtension = "attempt"
   /// On-disk format version recorded in the header.
@@ -164,8 +164,6 @@ public enum RecoveryConstants {
   /// Stop spooling when free space drops below this, so recovery never consumes
   /// the last disk the heart path needs (History save / ASR temp / model cache).
   public static let lowDiskWatermarkBytes: Int64 = 1_500_000_000
-  /// Orphan spools older than this are purged on launch (TTL backstop).
-  public static let retentionDays = 30
 }
 
 // MARK: - Timing Constants

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -406,8 +406,8 @@ public enum SentryBreadcrumb {
     /// recover."
     case recoveryTranscribeFailed = "recovery_transcribe_failed"
     /// #1063 PR2: a spool whose attempt marker was already present on launch — a
-    /// prior recovery attempt crashed the app — so it is abandoned (deleted, never
-    /// retried) by the one-attempt crash-loop guard rather than risking a loop.
+    /// prior recovery attempt already STARTED for that spool — so it is abandoned
+    /// (deleted, never retried) by the one-attempt guard rather than risking a loop.
     case recoveryAbandonedAfterAttempt = "recovery_abandoned_after_attempt"
     /// #761: the deterministic post-polish emoji-restore guard re-inserted fewer
     /// glyphs than AFM dropped (`restored < dropped`). Impossible by construction

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -67,7 +67,7 @@ public enum RecoveryTelemetryReason: String, Sendable {
   case saveFailed = "save_failed"
   case markerWriteFailed = "marker_write_failed"
   case markerClearFailed = "marker_clear_failed"
-  case crashLoop = "crash_loop"
+  case attemptAlreadySpent = "attempt_already_spent"
   /// #1707 Phase 3 — a Keychain read returned a transient OSStatus (device
   /// locked / keychain daemon not yet unlocked); the spool is retained and
   /// retried, not deleted. Bypass, not Failure.
@@ -1037,6 +1037,30 @@ public final class TelemetryService {
 
   /// A record-press landed while recovery held the engine, so NO session was
   /// minted (the user saw the "recovering" pill). Mirrors `coldstart.press_blocked`.
+  /// #1740: did the cleanup of a SPENT recovery attempt actually happen?
+  ///
+  /// After #1740 deletion is the only outcome for a spent attempt, so a
+  /// regression that silently stopped deleting — or a deletion that reliably
+  /// fails on real disks — would look exactly like healthy telemetry. This is
+  /// the only signal that would show it.
+  ///
+  /// Deliberately NOT emitted for `durable_save`, which fires on every
+  /// successful dictation and would swamp the signal for a path this change
+  /// does not touch (founder Gate 2, 2026-07-29: "light telemetry"). Only the
+  /// two spent-attempt sources emit.
+  ///
+  /// Privacy: shape only — a source label, a component label, and a boolean.
+  /// Never the recovery id, a path, or an error string.
+  public func recoveryCleanup(source: String, component: String, succeeded: Bool) {
+    PostHogSDK.shared.capture(
+      "recovery.cleanup",
+      properties: [
+        "source": source,
+        "component": component,
+        "succeeded": succeeded,
+      ])
+  }
+
   public func recoveryPressBlocked(asrBackend: String) {
     PostHogSDK.shared.capture(
       "recovery.press_blocked", properties: ["asr_backend": asrBackend])

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -51,15 +51,6 @@ public struct RecoverySpoolStore: Sendable {
       .sorted()
   }
 
-  /// Read just the provenance header without decoding frames. Returns nil when
-  /// the header JSON is unreadable but the file is still a spool (recovery can
-  /// then proceed on frames alone). Throws `notASpool` for a non-spool file.
-  public func readHeader(for recoverySessionID: String) throws -> RecoverySpoolHeader? {
-    let url = spoolURL(for: recoverySessionID)
-    let data = try Data(contentsOf: url, options: .mappedIfSafe)
-    return try RecoverySpoolFileFormat.decodeHeader(from: data).header
-  }
-
   /// Reconstruct the valid continuous prefix of a spool. Walks frames in order,
   /// stopping at the first torn, out-of-sequence, or authentication-failing
   /// frame (the recovered duration is honest about where it stopped). The
@@ -159,16 +150,18 @@ public struct RecoverySpoolStore: Sendable {
     try deleteAttemptMarker(for: recoverySessionID)
   }
 
-  // MARK: - One-attempt crash-loop marker (#1063 PR2)
+  // MARK: - One-attempt marker (#1063 PR2)
 
   /// Sidecar marker path for a spool's recovery attempt (`<id>.attempt`).
-  public func attemptMarkerURL(for recoverySessionID: String) -> URL {
+  private func attemptMarkerURL(for recoverySessionID: String) -> URL {
     directory.appendingPathComponent(
       "\(recoverySessionID).\(RecoveryConstants.attemptFileExtension)")
   }
 
-  /// Whether a recovery-attempt marker exists for this spool. Present on the next
-  /// launch ⇒ a prior recovery attempt crashed the app ⇒ abandon, do not retry.
+  /// Whether a recovery-attempt marker exists for this spool. Presence means a
+  /// prior attempt already began and may not run again, whether that attempt
+  /// crashed, failed after ASR (#1740), or otherwise ended before cleanup
+  /// completed ⇒ abandon, do not retry.
   public func hasAttemptMarker(for recoverySessionID: String) -> Bool {
     FileManager.default.fileExists(atPath: attemptMarkerURL(for: recoverySessionID).path)
   }
@@ -275,7 +268,7 @@ public struct RecoveredSpool: Sendable {
 
 /// Errors thrown by `RecoverySpoolStore` host-side operations (#1063 PR2).
 public enum RecoverySpoolStoreError: Error, Equatable {
-  /// The one-attempt crash-loop marker could not be written durably (carries
+  /// The one-attempt marker could not be written durably (carries
   /// `errno`). The caller treats this as fail-closed: skip recovering this spool
   /// this launch rather than risk an un-guarded retry.
   case attemptMarkerWriteFailed(Int32)

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -211,6 +211,77 @@ struct RecoveryCoordinatorTests {
     #expect(h.replayer.replayedIDs.isEmpty, "a survivor of a failed delete is suppressed")
   }
 
+  // MARK: - #1740 cleanup telemetry (founder Gate 2: "light telemetry")
+
+  /// Instance-scoped sink. Deliberately NOT the process-global
+  /// `TelemetryService.testEventHook`: this suite runs in parallel, and a
+  /// sibling test's `defer` clearing that global raced these emits, dropping
+  /// the detached key result (whole-diff review P1). See
+  /// `swift-patterns.md` RULE: tests-no-process-global-mutable-delegate.
+  private final class CleanupSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [(source: String, component: String, succeeded: Bool)] = []
+    func add(_ source: String, _ component: String, _ succeeded: Bool) {
+      lock.withLock { stored.append((source, component, succeeded)) }
+    }
+    var all: [(source: String, component: String, succeeded: Bool)] { lock.withLock { stored } }
+  }
+
+  /// `a-guard-nothing-arms-is-not-a-guard`: the instrument must fire from the
+  /// PRODUCTION path, and the two-way control is that a NON-spent source stays
+  /// silent — an emitter firing for every source would pass a one-way test
+  /// while swamping the signal it exists to provide.
+  @Test("cleanup telemetry fires for spent-attempt sources and is SILENT for durable save")
+  func cleanupTelemetryOnlyForSpentAttempts() async throws {
+    let h = Self.makeHarness()
+    let sink = CleanupSink()
+    h.coordinator.cleanupTelemetryForTesting = { source, component, ok in
+      sink.add(source, component, ok)
+    }
+
+    // Spent attempt: the live History-save-failure path.
+    let spent = "tele-spent-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, spent)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: spent)
+    await h.coordinator.handleHistorySaveFailed(recoverySessionID: spent)?.value
+
+    // NOT a spent attempt: an ordinary successful dictation.
+    let healthy = "tele-healthy-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, healthy)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: healthy)
+    await h.coordinator.handleDurableSave(recoverySessionID: healthy).value
+
+    let emitted = sink.all
+    #expect(
+      Set(emitted.map { $0.source }) == ["history_save_failed"],
+      "durable_save must NOT emit — it fires on every successful dictation")
+    #expect(Set(emitted.map { $0.component }) == ["spool", "key"], "one result per component")
+    #expect(emitted.allSatisfy { $0.succeeded }, "both components deleted cleanly here")
+  }
+
+  @Test("cleanup telemetry reports succeeded=false when the delete throws")
+  func cleanupTelemetryReportsFailure() async throws {
+    struct InjectedDeleteFailure: Error {}
+    let h = Self.makeHarness()
+    let sink = CleanupSink()
+    h.coordinator.cleanupTelemetryForTesting = { source, component, ok in
+      sink.add(source, component, ok)
+    }
+    let id = "tele-fail-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    h.coordinator.destructionSpoolDeleteForTesting = { _ in throw InjectedDeleteFailure() }
+    h.coordinator.destructionKeyDeleteForTesting = { _ in }
+    await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
+
+    let emitted = sink.all
+    #expect(
+      emitted.first(where: { $0.component == "spool" })?.succeeded == false,
+      "a thrown spool delete reports failure")
+    #expect(
+      emitted.first(where: { $0.component == "key" })?.succeeded == true,
+      "the key delete still ran and succeeded")
+  }
+
   // MARK: - #1740 launch-replay save failure deletes
 
   @Test("launch-replay .failed(.save) destroys the spool AND the key")

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -162,6 +162,71 @@ struct RecoveryCoordinatorTests {
     #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
   }
 
+  // MARK: - #1740 live History-save failure destroys instead of deferring
+
+  @Test("live History-save failure destroys the spool AND the key")
+  func historySaveFailureDestroysSpoolAndKey() async throws {
+    let h = Self.makeHarness()
+    let id = "histsavefail-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    let task = h.coordinator.handleHistorySaveFailed(recoverySessionID: id)
+    await task?.value
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+  }
+
+  /// Two-way control (`a-guard-nothing-arms-is-not-a-guard`): a handler that
+  /// fired unconditionally would pass the test above while destroying a
+  /// perfectly good take. A SUCCESSFUL save must route through
+  /// `handleDurableSave`, never through this handler, and nil must be inert.
+  @Test("live History-save failure: nil is a no-op and a healthy save is untouched")
+  func historySaveFailureNilIsNoOp() async throws {
+    let h = Self.makeHarness()
+    let id = "healthy-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    #expect(h.coordinator.handleHistorySaveFailed(recoverySessionID: nil) == nil)
+    // The unrelated healthy take is still on disk — nil destroyed nothing.
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+  }
+
+  /// PR #1761 invariant, ported to the new handler: the SAME terminal
+  /// transition requests a recovery scan moments later, so a FAILED delete must
+  /// not be rediscovered and replayed within this launch.
+  @Test("live History-save failure suppresses same-launch rediscovery even when delete throws")
+  func historySaveFailureSuppressesBeforeDestroying() async throws {
+    let h = Self.makeHarness()
+    let id = "suppress-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    struct InjectedDeleteFailure: Error {}
+    h.coordinator.destructionSpoolDeleteForTesting = { _ in throw InjectedDeleteFailure() }
+    h.coordinator.destructionKeyDeleteForTesting = { _ in }
+    await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
+    // The spool survived the failed delete...
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    // ...but this launch must not replay it.
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs.isEmpty, "a survivor of a failed delete is suppressed")
+  }
+
+  // MARK: - #1740 launch-replay save failure deletes
+
+  @Test("launch-replay .failed(.save) destroys the spool AND the key")
+  func launchReplaySaveFailureDestroysSpoolAndKey() async throws {
+    let h = Self.makeHarness()
+    let id = "replaysavefail-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    h.replayer.outcomeByID[id] = .failed(.save(.other))
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs == [id])
+    await Self.awaitKeyDeleted(h.keyStore, id: id)
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+  }
+
   // MARK: - Non-saved terminal routing (#1464 live-ending predicate)
 
   @Test("EVERY concluded live ending physically deletes the spool + key (#1755 discard doctrine)")
@@ -228,17 +293,30 @@ struct RecoveryCoordinatorTests {
     #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.asrRetryExhausted), "unchanged")
   }
 
-  @Test(
-    "shouldDeleteAfterReplay: recovered/abandoned/unrecoverable delete; save/aborted/deferred retain"
-  )
+  /// #1740: EVERY spent attempt deletes; only outcomes where ASR never ran
+  /// retain. All SEVEN leaf outcomes are asserted — a new case is a compile
+  /// error in the predicate's `default`-less switch, and an existing case
+  /// silently flipping is caught here (`matcher-set-adversarial-tests`).
+  @Test("shouldDeleteAfterReplay: every SPENT attempt deletes; only unspent attempts retain")
   func replayOutcomePredicate() {
+    // Spent — ASR ran, or the attempt was already spent by a prior run.
     #expect(RecoveryCoordinator.shouldDeleteAfterReplay(.recovered))
     #expect(RecoveryCoordinator.shouldDeleteAfterReplay(.abandoned))
     #expect(RecoveryCoordinator.shouldDeleteAfterReplay(.failed(.unrecoverable)))
-    #expect(!RecoveryCoordinator.shouldDeleteAfterReplay(.failed(.save(.other))))
-    #expect(!RecoveryCoordinator.shouldDeleteAfterReplay(.failed(.saveMarkerClearFailed(.other))))
-    #expect(!RecoveryCoordinator.shouldDeleteAfterReplay(.aborted))
-    #expect(!RecoveryCoordinator.shouldDeleteAfterReplay(.deferred))
+    #expect(
+      RecoveryCoordinator.shouldDeleteAfterReplay(.failed(.save(.other))),
+      "#1740: recovering the audio and failing only the History write is still a spent attempt")
+    // Unspent — ASR never ran. Explicit negatives per matcher-set-adversarial-tests:
+    // these are the rows a later 'consistency' edit would wrongly flip to delete.
+    #expect(
+      !RecoveryCoordinator.shouldDeleteAfterReplay(.aborted),
+      "discardActiveRecovery already destroyed it; deleting again is not this predicate's job")
+    #expect(
+      !RecoveryCoordinator.shouldDeleteAfterReplay(.deferred),
+      "the attempt marker was never written — the one attempt is unspent")
+    #expect(
+      !RecoveryCoordinator.shouldDeleteAfterReplay(.deferredMarkerClearFailed),
+      "#1360: a transient Keychain failure must never trigger permanent deletion")
   }
 
   // MARK: - #1464 sole destructor: post-replay deletion + success notice + pre-start abort
@@ -276,20 +354,6 @@ struct RecoveryCoordinatorTests {
     await Self.awaitKeyDeleted(h.keyStore, id: id)
     #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
     #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
-  }
-
-  @Test("the coordinator RETAINS the spool + key after a save-failure replay (§3.3)")
-  func saveFailureReplayRetains() async throws {
-    let h = Self.makeHarness()
-    let id = "save-\(UUID().uuidString)"
-    try Self.writeSpool(h.spoolStore, id)
-    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
-    h.replayer.outcomeByDefault = .failed(.save(.other))
-    await h.coordinator.scanAndRecover()
-    #expect(
-      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
-      "a History-save failure retains the spool for next-launch retry")
-    #expect((try? h.keyStore.retrieve(for: id)) != nil, "and retains the key")
   }
 
   @Test("onRecoverySucceeded fires once per .recovered orphan, never on failure")
@@ -402,27 +466,23 @@ struct RecoveryCoordinatorTests {
 
   // MARK: - #1707 Phase 3: nextLaunchOnlyRecoveryIDs
 
-  @Test(
-    ".deferredMarkerClearFailed and .failed(.saveMarkerClearFailed) both suppress same-launch rescan"
-  )
-  func markerClearFailureOutcomesSuppressSameLaunchRescan() async throws {
+  /// #1740 narrowed this to ONE case: `.failed(.saveMarkerClearFailed)` no longer
+  /// exists, and launch-replay `.failed(.save)` now DELETES and relies on its
+  /// committed marker rather than on this set.
+  @Test(".deferredMarkerClearFailed retains AND suppresses the same-launch rescan")
+  func deferredMarkerClearFailedStillSuppressedWithinLaunch() async throws {
     let h = Self.makeHarness()
     let deferredID = "deferred-markerfail-\(UUID().uuidString)"
-    let saveID = "save-markerfail-\(UUID().uuidString)"
     try Self.writeSpool(h.spoolStore, deferredID)
-    try Self.writeSpool(h.spoolStore, saveID)
     h.replayer.outcomeByID[deferredID] = .deferredMarkerClearFailed
-    h.replayer.outcomeByID[saveID] = .failed(.saveMarkerClearFailed(.other))
     await h.coordinator.scanAndRecover()
-    #expect(Set(h.replayer.replayedIDs) == Set([deferredID, saveID]))
-    // Both outcomes RETAIN — neither spool is deleted.
+    #expect(h.replayer.replayedIDs == [deferredID])
+    // RETAINS — no ASR ran, so the attempt is unspent.
     #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: deferredID).path))
-    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: saveID).path))
-    // A same-launch rescan (the SAME coordinator instance) must not re-attempt
-    // either id — they are next-launch-only.
+    // A same-launch rescan (the SAME coordinator instance) must not re-attempt it.
     h.replayer.replayedIDs = []
     await h.coordinator.scanAndRecover()
-    #expect(h.replayer.replayedIDs.isEmpty, "both ids suppressed on this instance's rescan")
+    #expect(h.replayer.replayedIDs.isEmpty, "id suppressed on this instance's rescan")
   }
 
   @Test("nextLaunchOnlyRecoveryIDs is never cleared within one coordinator instance's lifetime")
@@ -522,9 +582,11 @@ struct RecoveryCoordinatorTests {
     let second = "second-\(UUID().uuidString)"
     try Self.writeSpool(h.spoolStore, first)
     try Self.writeSpool(h.spoolStore, second)
-    // `second` is RETAINED (not deleted) so it would still be on disk for an
-    // improper immediate re-pass to (incorrectly) rediscover and re-attempt.
-    h.replayer.outcomeByID[second] = .failed(.save(.other))
+    // `second` must stay on disk so an improper immediate re-pass could
+    // (incorrectly) rediscover and re-attempt it. #1740 made `.failed(.save)`
+    // DELETE, so this fixture now uses `.deferred` — an outcome where no ASR
+    // ran, which is the only remaining class that retains.
+    h.replayer.outcomeByID[second] = .deferred
     h.replayer.onReplay = { [coordinator = h.coordinator] id in
       if id == second {
         coordinator.pendingLiveStartSignal = true
@@ -586,10 +648,11 @@ struct RecoveryCoordinatorTests {
     let second = "second-\(UUID().uuidString)"
     try Self.writeSpool(h.spoolStore, first)
     try Self.writeSpool(h.spoolStore, second)
-    // A RETAINED (not deleted) outcome for `first`, so it is still on disk
-    // for pass 2 — isolating the assertion to the signal-clearing behavior,
-    // not to whether a successfully-recovered item gets deleted.
-    h.replayer.outcomeByID[first] = .failed(.save(.other))
+    // `first` must still be on disk for pass 2, isolating the assertion to the
+    // signal-clearing behaviour. #1740 made `.failed(.save)` DELETE, so this
+    // fixture uses `.deferred` — no ASR ran, so it retains and is not
+    // suppressed (only `.deferredMarkerClearFailed` is next-launch-only).
+    h.replayer.outcomeByID[first] = .deferred
     h.replayer.onReplay = { [coordinator = h.coordinator] id in
       if id == first { coordinator.pendingLiveStartSignal = true }
     }

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -13,12 +13,13 @@ import Testing
 
 /// The per-orphan `RecoverySpoolReplayer` (#1063 PR2 / #1464): decrypt →
 /// transcribe → polish → save a non-auto-pasting "Recovered" transcript, ONE
-/// attempt with a crash-loop marker, and a generation guard that drops a
-/// discarded-but-in-flight result before saving. #1464: the replayer NO LONGER
-/// destroys the spool/key — the coordinator (sole destructor) does that after
-/// `replay()` returns — so these tests assert the outcome + typed telemetry + that
-/// the spool/key REMAIN. The one exception is the §3.3 save-failure fix: the
-/// replayer clears its OWN attempt marker so a retained spool replays next launch.
+/// guarded attempt, and a generation guard that drops a discarded-but-in-flight
+/// result before saving. #1464: the replayer NO LONGER destroys the spool/key —
+/// the coordinator (sole destructor) does that after `replay()` returns — so
+/// these tests assert the outcome + typed telemetry + that the spool/key REMAIN.
+/// #1740: a History-save failure now LEAVES the attempt marker committed, so a
+/// second replay abandons before ASR; the marker is cleared only where no ASR
+/// ran (the transient-Keychain deferral).
 /// `.serialized` — the telemetry tests set the process-global `testEventHook`.
 @MainActor
 @Suite("Recovery spool replayer (#1063 PR2, #1464)", .serialized)
@@ -216,13 +217,13 @@ struct RecoverySpoolReplayerTests {
     try h.spoolStore.writeAttemptMarker(for: id)
     let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
     #expect(outcome == .abandoned)
-    #expect(h.asr.transcribeCallCount == 0, "never re-transcribe a recording that crashed us")
+    #expect(h.asr.transcribeCallCount == 0, "never re-transcribe a spool whose attempt already began")
     #expect(h.transcriptCoordinator.transcripts.isEmpty)
     // The coordinator deletes on `.abandoned`; the replayer leaves the spool.
     #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
   }
 
-  @Test("the attempt marker is written BEFORE transcribe (crash-loop guard armed)")
+  @Test("the attempt marker is written BEFORE transcribe (one-attempt guard armed)")
   func markerWrittenBeforeTranscribe() async throws {
     let h = Self.makeHarness()
     let id = "armed-\(UUID().uuidString)"
@@ -265,9 +266,9 @@ struct RecoverySpoolReplayerTests {
       #expect(outcome == .deferred)
       #expect(h.asr.transcribeCallCount == 0, "never reaches transcribe on a deferred key read")
       #expect(h.transcriptCoordinator.transcripts.isEmpty)
-      // Bypass, not failure: the spool + key are retained for a retry, and the
-      // marker is cleared so a later attempt does not misread this as a
-      // crashed attempt (the exact regression this fix prevents).
+      // Bypass, not failure: no ASR ran, so the attempt is UNSPENT. The spool +
+      // key are retained and the marker is cleared so a later attempt remains
+      // eligible instead of being abandoned as already spent.
       #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
       #expect(
         (try? h.keyStore.retrieve(for: id)) != nil, "the ARMED fault is one-shot and consumed")
@@ -376,36 +377,30 @@ struct RecoverySpoolReplayerTests {
     #expect(saved.llmModel == nil)
   }
 
-  // MARK: - #1464 §3.3 save-failure retains + clears marker
+  // MARK: - #1740 save failure is a SPENT attempt: marker stays committed
 
-  @Test("save failure RETAINS the spool + key and clears the marker → .failed(.save)")
-  func saveFailureRetainsAndClearsMarker() async throws {
+  @Test("save failure KEEPS the spent-attempt marker and cannot run ASR twice")
+  func saveFailureKeepsSpentAttemptMarkerAndCannotRunASRTwice() async throws {
     let h = Self.makeHarness(transcriptDir: try Self.unwritableTranscriptDir())
     let id = "savefail-\(UUID().uuidString)"
     try await Self.seedSpool(h, id: id, samples: [0.2, 0.4])
-    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
-    #expect(outcome == .failed(.save(.other)))
-    // The audio is still good — RETAIN it for a next-launch retry, and the marker
-    // must be cleared so the retained spool replays (not read as abandoned).
-    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
-    #expect((try? h.keyStore.retrieve(for: id)) != nil)
-    #expect(!h.spoolStore.hasAttemptMarker(for: id), "marker cleared so next launch replays")
-  }
 
-  @Test("save failure whose marker-clear ALSO throws → .failed(.saveMarkerClearFailed), retained")
-  func saveFailureMarkerClearAlsoFails() async throws {
-    let h = Self.makeHarness(transcriptDir: try Self.unwritableTranscriptDir())
-    let id = "markerfail-\(UUID().uuidString)"
-    try await Self.seedSpool(h, id: id, samples: [0.5])
-    defer { _ = chmod(h.spoolDir.path, 0o700) }  // restore so temp cleanup/GC can proceed
-    // The marker is written before transcribe; flip the spool dir read-only DURING
-    // transcribe so the post-save `deleteAttemptMarker` (removeItem) throws EACCES.
-    h.asr.onTranscribe = { _ = chmod(h.spoolDir.path, 0o500) }
-    let outcome = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
-    #expect(outcome == .failed(.saveMarkerClearFailed(.other)))
-    // Retained THIS launch even though next-launch durability is not guaranteed.
-    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
-    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+    let first = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    #expect(first == .failed(.save(.other)))
+    #expect(h.asr.transcribeCallCount == 1)
+    // #1740: the marker is NOT cleared. It used to be, so that a later launch
+    // would replay; that retry is exactly what the one-attempt rule removes.
+    #expect(
+      h.spoolStore.hasAttemptMarker(for: id),
+      "the spent attempt's marker must stay committed")
+
+    // The coordinator deletes on `.failed(.save)`, but deletion is best-effort.
+    // Simulate a failed cleanup by leaving the spool in place and replaying
+    // again: the committed marker must abandon BEFORE ASR, so one attempt does
+    // not depend on the deletion having succeeded.
+    let second = await h.replayer.replay(recoverySessionID: id, isAborted: { false })
+    #expect(second == .abandoned)
+    #expect(h.asr.transcribeCallCount == 1, "a surviving spool must never transcribe twice")
   }
 
   // MARK: - #1464 root-cause telemetry

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
@@ -237,7 +237,7 @@ struct RecoverySpoolStoreTests {
     try store.delete(recoverySessionID: "alpha")
   }
 
-  // MARK: - One-attempt crash-loop marker (#1063 PR2)
+  // MARK: - One-attempt marker (#1063 PR2; broader meaning since #1740)
 
   @Test("attempt marker: write makes it present, delete removes it (idempotent)")
   func attemptMarkerLifecycle() throws {


### PR DESCRIPTION
## What changes

A recording gets exactly **one** recovery attempt. Once attempted, the audio is released whether or not recovery succeeded. Founder decision 2026-07-29 (#1740), grounded in user behaviour: after a crash a user reopens the app once, and either their audio comes back or they re-dictate. Nobody quits and reopens hoping a dictation appears in History later.

This finishes what #1755 started. That PR flipped `shouldDeleteOnLiveEnding` to delete on every live ending, with the rationale "the in-session salvage/retry was the user's one rescue; a surprise replay at a later launch is a bug in the user's eyes, not a favor." The launch-replay twin never got the same treatment.

## The pivot: a predicate flip alone does NOT enforce one attempt

The launch-replay save-failure path deliberately **cleared** its durable attempt marker (`RecoverySpoolReplayer.swift:327`, comment: "clear the attempt marker so the next launch REPLAYS"). Flipping only the predicate would leave "one attempt" enforced by a best-effort delete, so a failed delete leaves a markerless, decryptable spool that runs ASR again.

The marker now stays **committed**. A spool surviving a failed cleanup abandons at the entry guard before key retrieval or ASR. One attempt became a property of the file rather than a consequence of a deletion succeeding. `.saveMarkerClearFailed` is thereby unreachable and removed.

Found by grounded review r1; my original plan had documented that exact state and called it acceptable.

## Both retention paths closed

| Path | Before | After |
|---|---|---|
| Launch replay, History write fails | retain + clear marker, retry later | **delete**, marker stays committed |
| Live dictation, History write fails | retain, defer to a future launch | **delete** via `handleHistorySaveFailed` |

`suppressUntilNextLaunch` is deleted, not shimmed.

## Marker semantics broadened

A committed marker no longer means only "the previous recovery crashed" — it means "an attempt already started." Eleven production sites documenting the narrow meaning are corrected, plus four test-doc sites. Telemetry reason `crash_loop` → `attempt_already_spent` (one producer, zero in-repo consumers).

**Release note:** any external PostHog insight charting that reason must union `crash_loop` and `attempt_already_spent` across this release boundary.

## Cleanup telemetry (founder-approved at Gate 2)

New `recovery.cleanup` emits `source` / `component` / `succeeded` and no content, **only** for the two spent-attempt sources. `durable_save` is deliberately silent: it fires on every successful dictation (~27k/90d) and would swamp the signal.

## Dead code (the original ask of #1740)

`RecoverySpoolStore.readHeader(for:)` (zero callers) and `RecoveryConstants.retentionDays` (a TTL nothing ever enforced) deleted; `attemptMarkerURL` narrowed to `private`.

## Why deleting here is safe

History-save failure has **never occurred in production**: 0 of 27,384 `dictation.completed` over 90 days, 474 users, versions 2.2.0-2.4.1. The user also still receives their text — the save error is absorbed and delivery proceeds (`RecordingSessionKernel.swift:2518-2535`), so retention bought back only a History row for content already delivered. Every producer is a storage failure, i.e. precisely when holding ~230 MB is most harmful.

## Evidence

**Two-way unit control.** `saveFailureKeepsSpentAttemptMarkerAndCannotRunASRTwice` verified RED on unmodified `origin/main` (3 assertion failures; the second replay re-ran ASR) and GREEN here, with the other 15 replayer tests passing on both arms.

**Live UAT with a discriminating baseline.** Same fault seam (`EW_FAULT_SAVE=out_of_space`), same driver, both arms:

| Code | Save forced to fail | Leftover audio |
|---|---|---|
| `origin/main` | yes | **1 file, 402 KB** |
| this branch | yes | **0 files** (x2) |

Text was still delivered on every faulted run, and none reached History — so the failure was genuinely forced, not a quietly-passing test. Without the baseline arm, "0 spools" would have been indistinguishable from "recovery never armed."

**Suites.** 4,200 + 179 passed via `scripts/xcode-test.sh`. Both standalone eval packages (`apple_runner`, `alias_runner`) build; neither is compiled by CI.

## Review trail

Coverage round + 4 grounded rounds to PROCEED-AS-PLANNED, then whole-diff review. Whole-diff r1 caught a P1 I had missed: the new telemetry tests installed the process-global `testEventHook` while this suite runs in parallel, so a sibling test's `defer` raced the emits. My `xcode-test.sh --filter` run passed; the reviewer's `swift test --filter` failed reproducibly. Fixed with an instance-scoped seam mirroring the existing `deletionFailureBreadcrumbForTesting`, per `tests-no-process-global-mutable-delegate`. Whole-diff r2 clean.

Three pre-existing tests used the old retention purely as a fixture for unrelated assertions and were moved to `.deferred`.

## Deferred by the founder

The customer-facing KB sentence describing crash recovery is now inaccurate, and separately already claims a Settings toggle that does not exist (`crashRecoveryEnabled` has zero hits in `Sources/EnviousWisprAppKit/Views/`). Out of scope: "our help center is offline and needs to be re-written, ignore for now." Findings preserved in the plan for whoever rewrites it.

Plan: `docs/feature-requests/issue-1740-2026-07-29-recovery-one-attempt.md`

Closes #1740
