### PR TITLE
feat(audio): permanent debug instrument for Bluetooth mic wake time

### DIFF
--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -326,11 +326,6 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     return AudioConstants.minimumTranscriptionSamples
   }
 
-  /// Uptime at which the input engine became live for this attempt (end of
-  /// `startEnginePhase`). Used only by the #1788 wake diagnostic. 0 before the
-  /// first engine phase.
-  private var engineOpenUptimeNs: UInt64 = 0
-
   #if DEBUG
     /// One-shot per capture generation so the zero-prefix line is emitted once,
     /// not on every subsequent batch. Reset in `beginCapturePhase`.
@@ -380,9 +375,6 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     if let halSource = source as? HALDeviceInputSource {
       refreshResolvedRoute(actualBoundTransport: halSource.actualBoundTransport)
     }
-    // #1788: the moment the input engine is running, which is the only timebase
-    // for wake measurement that a saturating pre-roll ring cannot corrupt.
-    engineOpenUptimeNs = DispatchTime.now().uptimeNanoseconds
     onLifecycleSignal?("manager_prepare_completed")
   }
 
@@ -1067,27 +1059,35 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       else { return }
       didLogZeroPrefixThisSession = true
       let zeroPrefixMs = Double(zeroPrefixSamples) / AudioConstants.sampleRate * 1000
-      let now = DispatchTime.now().uptimeNanoseconds
-      let wallMs = Double(now &- captureStartUptimeNs) / 1_000_000
-      // THE authoritative wake number. `zero_prefix_ms` is derived from samples
-      // the detector RECEIVED, and the pre-roll ring holds only 500ms
-      // (`PreRollForwarder` capacity 8,000) with a saturating count — so when
-      // capture activates more than 500ms after the engine opened, the oldest
-      // zeros were overwritten and the sample-derived value is a LOWER BOUND
-      // (cloud review, PR #1843). Wall clock from engine-open cannot lose data
-      // to a ring, so read this one when the two disagree.
-      let wakeFromOpenMs =
-        engineOpenUptimeNs == 0
-        ? Double.nan : Double(now &- engineOpenUptimeNs) / 1_000_000
+      // #1788, after two review rounds on the SAME class: every earlier version
+      // of this line measured when the diagnostic OBSERVED the wake, not when the
+      // wake happened. A sample count taken from the detector misses pre-roll the
+      // ring overwrote; a wall clock read here is late by the whole pre-roll batch,
+      // because pre-roll arrives all at once AT activation. The only quantity that
+      // corresponds to occurrence is the sample's own position in the stream,
+      // latched by `PreRollForwarder` the moment it arrived.
+      let wake =
+        activeSource?.wakeDiagnostic
+        ?? (firstNonZeroRoutedIndex: nil, routedCountAtActivation: nil)
+      let wakeSamples: Int? = {
+        // Latched during pre-roll: already stream-absolute and immune to the ring.
+        if let preRoll = wake.firstNonZeroRoutedIndex { return preRoll }
+        // Otherwise the wake was live; rebase the detector's exact live index onto
+        // the stream. Nothing is dropped in the live phase.
+        guard let base = wake.routedCountAtActivation else { return nil }
+        return base + zeroPrefixSamples
+      }()
+      let wakeMs = wakeSamples.map { Double($0) / AudioConstants.sampleRate * 1000 }
+      let wakeField =
+        wakeMs.map { String(format: "%.0f", $0) } ?? "unavailable"
       let transport = currentResolvedRoute?.effective ?? "unknown"
       let ceiling = allZeroCeilingSamples
       Task {
         await AppLogger.shared.log(
           "ZERO_PREFIX_MEASURE transport=\(transport) "
-            + "wake_from_open_ms=\(String(format: "%.0f", wakeFromOpenMs)) "
-            + "zero_prefix_samples=\(zeroPrefixSamples) "
-            + "zero_prefix_ms=\(String(format: "%.0f", zeroPrefixMs)) "
-            + "wall_ms=\(String(format: "%.0f", wallMs)) "
+            + "wake_ms=\(wakeField) "
+            + "detector_zero_prefix_ms=\(String(format: "%.0f", zeroPrefixMs)) "
+            + "detector_zero_prefix_samples=\(zeroPrefixSamples) "
             + "ceiling_samples=\(ceiling)",
           level: .info, category: "Audio")
       }

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -326,6 +326,11 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     return AudioConstants.minimumTranscriptionSamples
   }
 
+  /// Uptime at which the input engine became live for this attempt (end of
+  /// `startEnginePhase`). Used only by the #1788 wake diagnostic. 0 before the
+  /// first engine phase.
+  private var engineOpenUptimeNs: UInt64 = 0
+
   #if DEBUG
     /// One-shot per capture generation so the zero-prefix line is emitted once,
     /// not on every subsequent batch. Reset in `beginCapturePhase`.
@@ -375,6 +380,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     if let halSource = source as? HALDeviceInputSource {
       refreshResolvedRoute(actualBoundTransport: halSource.actualBoundTransport)
     }
+    // #1788: the moment the input engine is running, which is the only timebase
+    // for wake measurement that a saturating pre-roll ring cannot corrupt.
+    engineOpenUptimeNs = DispatchTime.now().uptimeNanoseconds
     onLifecycleSignal?("manager_prepare_completed")
   }
 
@@ -1059,13 +1067,24 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       else { return }
       didLogZeroPrefixThisSession = true
       let zeroPrefixMs = Double(zeroPrefixSamples) / AudioConstants.sampleRate * 1000
-      let wallMs =
-        Double(DispatchTime.now().uptimeNanoseconds &- captureStartUptimeNs) / 1_000_000
+      let now = DispatchTime.now().uptimeNanoseconds
+      let wallMs = Double(now &- captureStartUptimeNs) / 1_000_000
+      // THE authoritative wake number. `zero_prefix_ms` is derived from samples
+      // the detector RECEIVED, and the pre-roll ring holds only 500ms
+      // (`PreRollForwarder` capacity 8,000) with a saturating count — so when
+      // capture activates more than 500ms after the engine opened, the oldest
+      // zeros were overwritten and the sample-derived value is a LOWER BOUND
+      // (cloud review, PR #1843). Wall clock from engine-open cannot lose data
+      // to a ring, so read this one when the two disagree.
+      let wakeFromOpenMs =
+        engineOpenUptimeNs == 0
+        ? Double.nan : Double(now &- engineOpenUptimeNs) / 1_000_000
       let transport = currentResolvedRoute?.effective ?? "unknown"
       let ceiling = allZeroCeilingSamples
       Task {
         await AppLogger.shared.log(
           "ZERO_PREFIX_MEASURE transport=\(transport) "
+            + "wake_from_open_ms=\(String(format: "%.0f", wakeFromOpenMs)) "
             + "zero_prefix_samples=\(zeroPrefixSamples) "
             + "zero_prefix_ms=\(String(format: "%.0f", zeroPrefixMs)) "
             + "wall_ms=\(String(format: "%.0f", wallMs)) "

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -1044,9 +1044,21 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   }
 
   #if DEBUG
-    /// `exact` is claimed only when the stream lost nothing AND at least one sample
-    /// was routed BEFORE the first non-zero one. Both failure modes under-report,
-    /// never over-report, so the fallback label is `floor`.
+    /// Is the wake a clean measurement OF THE DELIVERED STREAM? True only when the
+    /// stream lost nothing AND at least one sample was routed before the first
+    /// non-zero one. Both failure modes under-report, never over-report, so the
+    /// fallback label is `floor`.
+    ///
+    /// The label deliberately says `stream_measured`, NOT `exact`. r7 pointed out
+    /// that a callback-free startup followed by a few zeros still satisfies
+    /// `wakeSamples > 0` while covering only the zeros AFTER callbacks began, so a
+    /// true press-to-audio figure would need a second timebase. That was tried in
+    /// r2 and deleted for being late by the whole pre-roll batch, and two numbers
+    /// that disagree is how a future session trusts the wrong one. So the honest fix
+    /// is naming: NO sample-derived wake can be exact with respect to press-to-audio,
+    /// and a word that claimed otherwise was the actual defect. Every value here is
+    /// a lower bound; `stream_measured` says only that the delivered stream was
+    /// gap-free and carried an observed silent prefix.
     ///
     /// The second condition is the whole of r5 and r6, and it reduces to
     /// `wakeSamples > 0`. A sample clock cannot measure an interval containing no
@@ -1063,7 +1075,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// when index 0 is exactly the ambiguous case. Both errors are gone rather than
     /// special-cased, because the quantity actually being asked about is the wake
     /// itself. An unknown gap count or an unavailable wake fails CLOSED.
-    nonisolated static func wakeIsExact(gapCount: Int?, wakeSamples: Int?) -> Bool {
+    nonisolated static func wakeIsStreamMeasured(gapCount: Int?, wakeSamples: Int?) -> Bool {
       guard let gapCount, let wakeSamples else { return false }
       return gapCount == 0 && wakeSamples > 0
     }
@@ -1107,14 +1119,18 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         wakeMs.map { String(format: "%.0f", $0) } ?? "unavailable"
       let transport = currentResolvedRoute?.effective ?? "unknown"
       let ceiling = allZeroCeilingSamples
-      // A sample index is an elapsed time only if TWO things hold, and cloud
-      // review found one per round until both were stated here rather than
-      // assumed:
+      // EVERY value on this line is a LOWER BOUND on press-to-audio latency: a
+      // sample clock cannot see an interval in which no samples exist, and no
+      // second clock is carried (see `wakeIsStreamMeasured`). `wake_is` reports
+      // only whether the DELIVERED stream was a clean measurement, which needs two
+      // things — cloud review found one per round until both were stated here
+      // rather than assumed:
       //  1. the stream lost nothing — `CaptureStopMetadata.inputTimelineGapCount`
       //     owns that enumeration and its window (r3, r4, r5), so a new lossy
       //     edge needs no new field here;
       //  2. at least one sample was routed BEFORE the first non-zero one, i.e.
-      //     `wakeSamples > 0` (r5, corrected in r6 — see `wakeIsExact`). A sample
+      //     `wakeSamples > 0` (r5, corrected in r6 — see
+      //     `wakeIsStreamMeasured`). A sample
       //     clock cannot measure an interval containing no samples, so a zero wake
       //     cannot distinguish a link that was already awake from one that woke
       //     during a callback-free startup. No second clock: that was tried in r2
@@ -1126,12 +1142,13 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       // this closes.
       let gaps = activeSource?.captureStopMetadata?.inputTimelineGapCount
       let gapField = gaps.map(String.init) ?? "unknown"
-      let exactness =
-        Self.wakeIsExact(gapCount: gaps, wakeSamples: wakeSamples) ? "exact" : "floor"
+      let basis =
+        Self.wakeIsStreamMeasured(gapCount: gaps, wakeSamples: wakeSamples)
+        ? "stream_measured" : "floor"
       Task {
         await AppLogger.shared.log(
           "ZERO_PREFIX_MEASURE transport=\(transport) "
-            + "wake_ms=\(wakeField) wake_is=\(exactness) timeline_gaps=\(gapField) "
+            + "wake_ms=\(wakeField) wake_is=\(basis) timeline_gaps=\(gapField) "
             + "detector_zero_prefix_ms=\(String(format: "%.0f", zeroPrefixMs)) "
             + "detector_zero_prefix_samples=\(zeroPrefixSamples) "
             + "ceiling_samples=\(ceiling)",

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -1044,6 +1044,31 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   }
 
   #if DEBUG
+    /// Did the sample stream exist before the wake happened? A sample clock cannot
+    /// measure an interval containing no samples, so when nothing was routed prior
+    /// to activation the first delivered sample sits at index 0 and a link that woke
+    /// during a callback-free startup is indistinguishable from one that was already
+    /// awake (#1788 cloud review r5). A wake latched during pre-roll proves the
+    /// stream predated it outright; otherwise the proof is that samples had been
+    /// routed before activation. Pure and static so the rule is unit-testable
+    /// without opening hardware.
+    nonisolated static func wakeStreamStartedBeforeWake(
+      firstNonZeroRoutedIndex: Int?,
+      routedCountAtActivation: Int?
+    ) -> Bool {
+      if firstNonZeroRoutedIndex != nil { return true }
+      return (routedCountAtActivation ?? 0) > 0
+    }
+
+    /// `exact` is claimed only when the stream lost nothing AND predated the wake.
+    /// Both failure modes under-report, never over-report, so the fallback label is
+    /// `floor`. An unknown gap count is NOT treated as zero: an unreadable
+    /// measurement authority must fail closed.
+    nonisolated static func wakeIsExact(gapCount: Int?, streamStartedFirst: Bool) -> Bool {
+      guard let gapCount else { return false }
+      return gapCount == 0 && streamStartedFirst
+    }
+
     /// Report the exact-zero prefix once per capture generation (#1788).
     ///
     /// On Bluetooth this is the A2DP->SCO/HFP link wake time. It is a DEBUG
@@ -1083,20 +1108,36 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         wakeMs.map { String(format: "%.0f", $0) } ?? "unavailable"
       let transport = currentResolvedRoute?.effective ?? "unknown"
       let ceiling = allZeroCeilingSamples
-      // A sample index is an elapsed time only while the stream that produced it
-      // lost nothing. Rather than answer that per-edge (three review rounds each
-      // found one more edge upstream of the last fix), the instrument REPORTS the
-      // answer: `CaptureStopMetadata.inputTimelineGapCount` owns the enumeration
-      // of every lossy edge, and `gaps=0` — the only value seen in 3,111 logged
-      // sessions — means `wake_ms` is exact. Any nonzero value makes it a floor,
-      // says so on the line, and needs no new field when an edge is added.
+      // A sample index is an elapsed time only if TWO things hold, and cloud
+      // review found one per round until both were stated here rather than
+      // assumed:
+      //  1. the stream lost nothing — `CaptureStopMetadata.inputTimelineGapCount`
+      //     owns that enumeration and its window (r3, r4, r5), so a new lossy
+      //     edge needs no new field here;
+      //  2. the stream STARTED before the wake did. A sample clock cannot measure
+      //     an interval containing no samples: if nothing had been routed before
+      //     activation, the first delivered sample sits at index 0, so a link that
+      //     woke during a callback-free startup reads `wake_ms=0` (r5). Whether
+      //     samples preceded activation is exactly `routedCountAtActivation > 0`,
+      //     already latched — no second clock, which was tried and deleted in r2.
+      // Both failures under-report, never over-report, so the honest label is
+      // `floor` and `exact` is claimed only when both hold. Of 13 Bluetooth
+      // readings taken before this, 8 read 0 and the log alone could NOT tell a
+      // genuinely warm link from a delayed first buffer — that ambiguity is what
+      // this closes.
       let gaps = activeSource?.captureStopMetadata?.inputTimelineGapCount
       let gapField = gaps.map(String.init) ?? "unknown"
-      let exactness = (gaps == 0) ? "exact" : "floor"
+      let streamStartedFirst = Self.wakeStreamStartedBeforeWake(
+        firstNonZeroRoutedIndex: wake.firstNonZeroRoutedIndex,
+        routedCountAtActivation: wake.routedCountAtActivation)
+      let exactness =
+        Self.wakeIsExact(gapCount: gaps, streamStartedFirst: streamStartedFirst)
+        ? "exact" : "floor"
       Task {
         await AppLogger.shared.log(
           "ZERO_PREFIX_MEASURE transport=\(transport) "
             + "wake_ms=\(wakeField) wake_is=\(exactness) timeline_gaps=\(gapField) "
+            + "stream_started_first=\(streamStartedFirst) "
             + "detector_zero_prefix_ms=\(String(format: "%.0f", zeroPrefixMs)) "
             + "detector_zero_prefix_samples=\(zeroPrefixSamples) "
             + "ceiling_samples=\(ceiling)",

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -299,6 +299,39 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// fresh `beginCapturePhase`.
   private var deadAirDetector = DeadAirStreamingDetector()
 
+  /// How many leading exact-zero samples the mid-take all-zero detector tolerates
+  /// before it concludes the microphone is dead. ONE owner, ONE code path in every
+  /// configuration — release and DEBUG differ only in whether an override is
+  /// consulted, never in how the verdict is computed (#1788).
+  ///
+  /// Release, and DEBUG with no override set, is `minimumTranscriptionSamples`
+  /// (16,000 = 1.0s), byte-identical to shipped behaviour.
+  ///
+  /// The DEBUG override exists because a Bluetooth wake slower than the ceiling is
+  /// otherwise CENSORED — the take aborts before the wake completes, so the tail we
+  /// most need to see is the one we structurally cannot observe. Raising it makes
+  /// that tail measurable. Diagnostic recipe: gotchas-audio.md
+  /// FACT: bt-mic-warmup-delay-is-industry-wide-not-eviouswispr-specific.
+  ///
+  ///     defaults write com.enviouswispr.app.dev EWDebugAllZeroCeilingSamples -int 160000
+  ///
+  /// A non-positive or absent value yields the shipping ceiling, so an
+  /// unconfigured DEBUG build cannot behave differently from production.
+  var allZeroCeilingSamples: Int {
+    #if DEBUG
+      let override = UserDefaults.standard.integer(
+        forKey: "EWDebugAllZeroCeilingSamples")
+      if override > 0 { return override }
+    #endif
+    return AudioConstants.minimumTranscriptionSamples
+  }
+
+  #if DEBUG
+    /// One-shot per capture generation so the zero-prefix line is emitted once,
+    /// not on every subsequent batch. Reset in `beginCapturePhase`.
+    private var didLogZeroPrefixThisSession = false
+  #endif
+
   /// The ONE shared latch the HAL no-buffer watchdog and the dead-air detector
   /// both check-and-set before calling `onCaptureStalled`, so the callback's
   /// documented at-most-once-per-session contract holds across the two
@@ -367,6 +400,9 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     deadAirDetector = DeadAirStreamingDetector()
     sawIneligibleZeroSignalDuringSession = false
     captureStallReported = false
+    #if DEBUG
+      didLogZeroPrefixThisSession = false
+    #endif
 
     // Wire source callbacks → manager state.
     // Source identity check prevents stale callbacks from a replaced source
@@ -976,9 +1012,12 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     if deadAirDetector.consecutiveExactZeroSuffix != suffixBefore + samples.count {
       sawIneligibleZeroSignalDuringSession = false
     }
+    #if DEBUG
+      emitZeroPrefixDiagnosticIfNeeded()
+    #endif
 
     let mode: CaptureStallFailureMode
-    if deadAirDetector.isAllZeroFromStart {
+    if deadAirDetector.isAllZeroFromStart(ceilingSamples: allZeroCeilingSamples) {
       mode = .allZeroFromStart
     } else if deadAirDetector.isBecameZeroMidCapture {
       mode = .becameZeroMidCapture
@@ -1003,6 +1042,38 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     deadAirDetector.fired = true
     fireDeadAirStall(mode: mode)
   }
+
+  #if DEBUG
+    /// Report the exact-zero prefix once per capture generation (#1788).
+    ///
+    /// On Bluetooth this is the A2DP->SCO/HFP link wake time. It is a DEBUG
+    /// diagnostic on purpose and permanently: production telemetry carries no
+    /// such field, and without this line a future Bluetooth investigation has to
+    /// re-derive wake timing by hand, which is how #1788 started. Writes to
+    /// `app.log` only (requires in-app Debug Mode) — never PostHog, never Sentry,
+    /// never the network. Emits a duration, a sample count and a transport label,
+    /// so it is inside the privacy boundary by construction.
+    private func emitZeroPrefixDiagnosticIfNeeded() {
+      guard !didLogZeroPrefixThisSession,
+        let zeroPrefixSamples = deadAirDetector.zeroPrefixSampleCount
+      else { return }
+      didLogZeroPrefixThisSession = true
+      let zeroPrefixMs = Double(zeroPrefixSamples) / AudioConstants.sampleRate * 1000
+      let wallMs =
+        Double(DispatchTime.now().uptimeNanoseconds &- captureStartUptimeNs) / 1_000_000
+      let transport = currentResolvedRoute?.effective ?? "unknown"
+      let ceiling = allZeroCeilingSamples
+      Task {
+        await AppLogger.shared.log(
+          "ZERO_PREFIX_MEASURE transport=\(transport) "
+            + "zero_prefix_samples=\(zeroPrefixSamples) "
+            + "zero_prefix_ms=\(String(format: "%.0f", zeroPrefixMs)) "
+            + "wall_ms=\(String(format: "%.0f", wallMs)) "
+            + "ceiling_samples=\(ceiling)",
+          level: .info, category: "Audio")
+      }
+    }
+  #endif
 
   /// Overlay the manager's app-lifetime session id + frozen route decision onto
   /// a HAL-built stall context before forwarding (#1543 Codex review P2). The

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -1044,29 +1044,28 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   }
 
   #if DEBUG
-    /// Did the sample stream exist before the wake happened? A sample clock cannot
-    /// measure an interval containing no samples, so when nothing was routed prior
-    /// to activation the first delivered sample sits at index 0 and a link that woke
-    /// during a callback-free startup is indistinguishable from one that was already
-    /// awake (#1788 cloud review r5). A wake latched during pre-roll proves the
-    /// stream predated it outright; otherwise the proof is that samples had been
-    /// routed before activation. Pure and static so the rule is unit-testable
-    /// without opening hardware.
-    nonisolated static func wakeStreamStartedBeforeWake(
-      firstNonZeroRoutedIndex: Int?,
-      routedCountAtActivation: Int?
-    ) -> Bool {
-      if firstNonZeroRoutedIndex != nil { return true }
-      return (routedCountAtActivation ?? 0) > 0
-    }
-
-    /// `exact` is claimed only when the stream lost nothing AND predated the wake.
-    /// Both failure modes under-report, never over-report, so the fallback label is
-    /// `floor`. An unknown gap count is NOT treated as zero: an unreadable
-    /// measurement authority must fail closed.
-    nonisolated static func wakeIsExact(gapCount: Int?, streamStartedFirst: Bool) -> Bool {
-      guard let gapCount else { return false }
-      return gapCount == 0 && streamStartedFirst
+    /// `exact` is claimed only when the stream lost nothing AND at least one sample
+    /// was routed BEFORE the first non-zero one. Both failure modes under-report,
+    /// never over-report, so the fallback label is `floor`.
+    ///
+    /// The second condition is the whole of r5 and r6, and it reduces to
+    /// `wakeSamples > 0`. A sample clock cannot measure an interval containing no
+    /// samples: a wake of zero means the first sample that ever existed was already
+    /// non-zero, so a link that woke during a callback-free startup is
+    /// indistinguishable from one that was awake all along. A measured zero prefix
+    /// is the only evidence that the stream was running while the link was still
+    /// silent.
+    ///
+    /// r6 killed the previous formulation, which asked `routedCountAtActivation > 0`
+    /// — that field is the rebase offset for pre-roll the ring OVERWROTE, not a
+    /// count of samples that preceded activation, so it is legitimately 0 whenever
+    /// nothing was dropped. It also treated a pre-roll latch at index 0 as proof,
+    /// when index 0 is exactly the ambiguous case. Both errors are gone rather than
+    /// special-cased, because the quantity actually being asked about is the wake
+    /// itself. An unknown gap count or an unavailable wake fails CLOSED.
+    nonisolated static func wakeIsExact(gapCount: Int?, wakeSamples: Int?) -> Bool {
+      guard let gapCount, let wakeSamples else { return false }
+      return gapCount == 0 && wakeSamples > 0
     }
 
     /// Report the exact-zero prefix once per capture generation (#1788).
@@ -1114,12 +1113,12 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       //  1. the stream lost nothing — `CaptureStopMetadata.inputTimelineGapCount`
       //     owns that enumeration and its window (r3, r4, r5), so a new lossy
       //     edge needs no new field here;
-      //  2. the stream STARTED before the wake did. A sample clock cannot measure
-      //     an interval containing no samples: if nothing had been routed before
-      //     activation, the first delivered sample sits at index 0, so a link that
-      //     woke during a callback-free startup reads `wake_ms=0` (r5). Whether
-      //     samples preceded activation is exactly `routedCountAtActivation > 0`,
-      //     already latched — no second clock, which was tried and deleted in r2.
+      //  2. at least one sample was routed BEFORE the first non-zero one, i.e.
+      //     `wakeSamples > 0` (r5, corrected in r6 — see `wakeIsExact`). A sample
+      //     clock cannot measure an interval containing no samples, so a zero wake
+      //     cannot distinguish a link that was already awake from one that woke
+      //     during a callback-free startup. No second clock: that was tried in r2
+      //     and deleted for being late by the whole pre-roll batch.
       // Both failures under-report, never over-report, so the honest label is
       // `floor` and `exact` is claimed only when both hold. Of 13 Bluetooth
       // readings taken before this, 8 read 0 and the log alone could NOT tell a
@@ -1127,17 +1126,12 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       // this closes.
       let gaps = activeSource?.captureStopMetadata?.inputTimelineGapCount
       let gapField = gaps.map(String.init) ?? "unknown"
-      let streamStartedFirst = Self.wakeStreamStartedBeforeWake(
-        firstNonZeroRoutedIndex: wake.firstNonZeroRoutedIndex,
-        routedCountAtActivation: wake.routedCountAtActivation)
       let exactness =
-        Self.wakeIsExact(gapCount: gaps, streamStartedFirst: streamStartedFirst)
-        ? "exact" : "floor"
+        Self.wakeIsExact(gapCount: gaps, wakeSamples: wakeSamples) ? "exact" : "floor"
       Task {
         await AppLogger.shared.log(
           "ZERO_PREFIX_MEASURE transport=\(transport) "
             + "wake_ms=\(wakeField) wake_is=\(exactness) timeline_gaps=\(gapField) "
-            + "stream_started_first=\(streamStartedFirst) "
             + "detector_zero_prefix_ms=\(String(format: "%.0f", zeroPrefixMs)) "
             + "detector_zero_prefix_samples=\(zeroPrefixSamples) "
             + "ceiling_samples=\(ceiling)",

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -1059,13 +1059,14 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       else { return }
       didLogZeroPrefixThisSession = true
       let zeroPrefixMs = Double(zeroPrefixSamples) / AudioConstants.sampleRate * 1000
-      // #1788, after two review rounds on the SAME class: every earlier version
+      // #1788, after THREE review rounds on the same class: every earlier version
       // of this line measured when the diagnostic OBSERVED the wake, not when the
       // wake happened. A sample count taken from the detector misses pre-roll the
       // ring overwrote; a wall clock read here is late by the whole pre-roll batch,
       // because pre-roll arrives all at once AT activation. The only quantity that
       // corresponds to occurrence is the sample's own position in the stream,
-      // latched by `PreRollForwarder` the moment it arrived.
+      // latched by `PreRollForwarder` the moment it arrived — and that holds only
+      // while the stream is gap-free, which the `gaps` field below reports.
       let wake =
         activeSource?.wakeDiagnostic
         ?? (firstNonZeroRoutedIndex: nil, routedCountAtActivation: nil)
@@ -1082,10 +1083,20 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         wakeMs.map { String(format: "%.0f", $0) } ?? "unavailable"
       let transport = currentResolvedRoute?.effective ?? "unknown"
       let ceiling = allZeroCeilingSamples
+      // A sample index is an elapsed time only while the stream that produced it
+      // lost nothing. Rather than answer that per-edge (three review rounds each
+      // found one more edge upstream of the last fix), the instrument REPORTS the
+      // answer: `CaptureStopMetadata.inputTimelineGapCount` owns the enumeration
+      // of every lossy edge, and `gaps=0` — the only value seen in 3,111 logged
+      // sessions — means `wake_ms` is exact. Any nonzero value makes it a floor,
+      // says so on the line, and needs no new field when an edge is added.
+      let gaps = activeSource?.captureStopMetadata?.inputTimelineGapCount
+      let gapField = gaps.map(String.init) ?? "unknown"
+      let exactness = (gaps == 0) ? "exact" : "floor"
       Task {
         await AppLogger.shared.log(
           "ZERO_PREFIX_MEASURE transport=\(transport) "
-            + "wake_ms=\(wakeField) "
+            + "wake_ms=\(wakeField) wake_is=\(exactness) timeline_gaps=\(gapField) "
             + "detector_zero_prefix_ms=\(String(format: "%.0f", zeroPrefixMs)) "
             + "detector_zero_prefix_samples=\(zeroPrefixSamples) "
             + "ceiling_samples=\(ceiling)",

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -66,6 +66,13 @@ protocol AudioInputSource: AnyObject {
     /// compiler forces every conformer to participate — a newly-added source cannot
     /// silently bypass the injector. Compiled out of release.
     var debugZeroFillController: DebugZeroFillController? { get set }
+
+    /// #1788 wake diagnostic: the stream-absolute index of the first non-zero
+    /// sample, latched at ARRIVAL by the source's `PreRollForwarder`, plus the
+    /// pre-roll/live rebase point. A REQUIREMENT rather than a defaulted member,
+    /// same reasoning as the injector above: a newly-added source must not
+    /// silently report a wake it never measured. Compiled out of release.
+    var wakeDiagnostic: (firstNonZeroRoutedIndex: Int?, routedCountAtActivation: Int?) { get }
   #endif
 
   /// #1434: stop-time capture-health facts (native rate, drop/error counters,

--- a/Sources/EnviousWisprAudio/DeadAirStreamingDetector.swift
+++ b/Sources/EnviousWisprAudio/DeadAirStreamingDetector.swift
@@ -34,6 +34,9 @@ struct DeadAirStreamingDetector {
   mutating func ingest(_ samples: UnsafeBufferPointer<Float>) {
     guard !fired else { return }
     for s in samples {
+      // Latch the first non-zero position BEFORE incrementing, so the value is
+      // the zero-prefix length in samples (#1788 diagnostic).
+      if s != 0, firstNonZeroIndex == nil { firstNonZeroIndex = totalSampleCount }
       totalSampleCount += 1
       let a = abs(s)
       if a > runningPeak { runningPeak = a }
@@ -62,12 +65,38 @@ struct DeadAirStreamingDetector {
     if !isDeadAirSoFar { meaningfulSignalSeen = true }
   }
 
-  /// `total received >= minimumTranscriptionSamples AND every received
-  /// sample exactly zero` (#1317 §3.1).
-  var isAllZeroFromStart: Bool {
-    totalSampleCount >= AudioConstants.minimumTranscriptionSamples
+  /// `total received >= ceilingSamples AND every received sample exactly zero`
+  /// (#1317 §3.1).
+  ///
+  /// The ceiling is supplied by the caller rather than read from
+  /// `AudioConstants` so this struct stays sample-only — it owns no transport,
+  /// device, or policy knowledge, and the boundary is unit-testable without a
+  /// capture manager. `AudioCaptureManager.allZeroCeilingSamples` is the single
+  /// production caller and the sole owner of what the ceiling should be (#1788).
+  ///
+  /// One-way by construction: `consecutiveExactZeroSuffix` resets to 0 on any
+  /// non-zero sample (`ingest`) while `totalSampleCount` only grows, so once
+  /// real audio arrives this can never be true again for that generation. A
+  /// microphone that wakes up therefore cannot be aborted later in the same take.
+  func isAllZeroFromStart(ceilingSamples: Int) -> Bool {
+    totalSampleCount >= ceilingSamples
       && consecutiveExactZeroSuffix == totalSampleCount
   }
+
+  /// Number of leading samples that were exactly zero before the first non-zero
+  /// sample, or `nil` while the capture is still entirely zeros. Diagnostic only:
+  /// on Bluetooth this is the SCO/HFP link wake time, which is otherwise
+  /// unobservable because the abort fires before a slow wake completes (#1788).
+  var zeroPrefixSampleCount: Int? {
+    guard totalSampleCount > 0 else { return nil }
+    // Still all-zero: the prefix has not ended, so there is nothing to report.
+    guard consecutiveExactZeroSuffix != totalSampleCount else { return nil }
+    return firstNonZeroIndex
+  }
+
+  /// Index of the first non-zero sample in this generation; `nil` until one
+  /// arrives. Latched once — later zero runs do not move it.
+  private(set) var firstNonZeroIndex: Int?
 
   /// `meaningfulSignalSeen was set, then a sustained suffix of >=
   /// minimumTranscriptionSamples CONSECUTIVE exact-zero samples` (#1317 §3.1).

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -764,8 +764,10 @@ final class HALDeviceInputSource: AudioInputSource {
     preRollGapCount =
       renderContext.map {
         let s = $0.counters.snapshotAndReset()
-        return s.ringDrops + s.converterErrors + s.renderFailures + s.oversizedSlices
-          + s.lostChunks
+        // Mirrors `CaptureStopMetadata.inputTimelineGapCount`: one addend per death
+        // point, and `converterErrors` is excluded because it is a subset of
+        // `lostChunks` (r8). If that sum changes, change this with it.
+        return s.ringDrops + s.renderFailures + s.oversizedSlices + s.lostChunks
       } ?? 0
 
     let stream = AsyncStream<AVAudioPCMBuffer> { continuation in

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -121,6 +121,18 @@ private final class HALSessionCounters: Sendable {
   func incrementOversizedSlice() { state.withLock { $0.oversizedSlices += 1 } }
   func snapshot() -> Snapshot { state.withLock { $0 } }
   func reset() { state.withLock { $0 = Snapshot() } }
+  /// Read and clear under ONE lock acquisition. A separate `snapshot()` then
+  /// `reset()` leaves a window in which the RT and consumer threads can increment
+  /// a counter that neither the returned snapshot nor the cleared state contains,
+  /// so the gap is erased from both — the wake would then be labelled `exact`
+  /// over a lossy stream (#1788 cloud review r5).
+  func snapshotAndReset() -> Snapshot {
+    state.withLock { current in
+      let taken = current
+      current = Snapshot()
+      return taken
+    }
+  }
 }
 
 /// The RT-callback-reachable context, passed by raw pointer via `Unmanaged`
@@ -700,15 +712,20 @@ final class HALDeviceInputSource: AudioInputSource {
         source: "HALDeviceInputSource.startCapture.missing_forwarder")
     }
 
-    // Read the idle pre-roll's gaps BEFORE `counters.reset()` below discards
-    // them (#1788 cloud review r4). The reset is right for #1434 per-session
-    // telemetry, but the wake measurement starts inside retained pre-roll, so a
-    // gap in there is inside its window: dropping it would let the diagnostic
-    // print `exact` over a stream that provably lost frames. Read before
-    // `fwd.activate` too, which drains the pre-roll on this same call.
+    // Carry the idle pre-roll's gaps forward and clear the session counters in
+    // ONE atomic step, BEFORE `fwd.activate(...)` drains the pre-roll (#1788
+    // cloud review r4 + r5). Three things have to be true at once here:
+    //   - clearing is right for #1434, whose counters must mean "this session";
+    //   - the wake measurement begins inside retained pre-roll, so a gap in
+    //     there is inside its window and must survive the clear;
+    //   - read-then-clear as two calls leaves a window where the RT and consumer
+    //     threads (still running) increment a counter that lands in neither, so
+    //     the gap is erased from both and a wake reads `exact` over a lossy
+    //     stream. Hence `snapshotAndReset`, and hence doing it before activate:
+    //     every increment after this line belongs to the live session.
     preRollGapCount =
       renderContext.map {
-        let s = $0.counters.snapshot()
+        let s = $0.counters.snapshotAndReset()
         return s.ringDrops + s.converterErrors + s.renderFailures + s.oversizedSlices
       } ?? 0
 
@@ -726,9 +743,10 @@ final class HALDeviceInputSource: AudioInputSource {
     captureGeneration &+= 1
     captureLiveness.reset()
     // #1434: per-session capture-health state. The warm unit outlives sessions
-    // (deactivateCapture keeps it pre-rolling), so an idle-time format change
-    // or pre-roll ring drop must not bleed into the next recording's telemetry.
-    renderContext?.counters.reset()
+    // (deactivateCapture keeps it pre-rolling), so an idle-time format change or
+    // pre-roll ring drop must not bleed into the next recording's telemetry. The
+    // counter half of that clear moved ABOVE `fwd.activate` as an atomic
+    // snapshot-and-reset (#1788 r5); only the format flag is cleared here.
     formatDivergenceObserved = false
     // #1523: a fresh session must never serve the previous session's cached
     // stop-metadata; the live path repopulates it via teardownUnit().

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -376,6 +376,14 @@ final class HALDeviceInputSource: AudioInputSource {
   private var forwarder: PreRollForwarder?
 
   #if DEBUG
+    /// #1788: forward the forwarder's arrival-latched wake facts. Nil-safe — a
+    /// source with no forwarder yet has measured nothing.
+    var wakeDiagnostic: (firstNonZeroRoutedIndex: Int?, routedCountAtActivation: Int?) {
+      forwarder?.wakeDiagnosticSnapshot() ?? (nil, nil)
+    }
+  #endif
+
+  #if DEBUG
     var debugZeroFillController: DebugZeroFillController?
   #endif
   /// Dedicated thread draining `HALRenderContext.ring` off the HAL IO thread.

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -112,6 +112,7 @@ private final class HALSessionCounters: Sendable {
     var zeroOutputs = 0
     var renderFailures = 0
     var oversizedSlices = 0
+    var lostChunks = 0
   }
   private let state = OSAllocatedUnfairLock(initialState: Snapshot())
   func incrementRingDrop() { state.withLock { $0.ringDrops += 1 } }
@@ -119,6 +120,12 @@ private final class HALSessionCounters: Sendable {
   func incrementZeroOutput() { state.withLock { $0.zeroOutputs += 1 } }
   func incrementRenderFailure() { state.withLock { $0.renderFailures += 1 } }
   func incrementOversizedSlice() { state.withLock { $0.oversizedSlices += 1 } }
+  /// A popped chunk that left `drainAndForward` without reaching `route` and
+  /// without being a benign priming call. Deliberately a CATCH-ALL rather than one
+  /// counter per cause: #1788 r3/r5/r7 each found another silent exit, so the
+  /// bookkeeping is now at the single place a chunk can die instead of at each
+  /// reason it might.
+  func incrementLostChunk() { state.withLock { $0.lostChunks += 1 } }
   func snapshot() -> Snapshot { state.withLock { $0 } }
   func reset() { state.withLock { $0 = Snapshot() } }
   /// Read and clear under ONE lock acquisition. A separate `snapshot()` then
@@ -229,7 +236,13 @@ private final class HALRenderContext: @unchecked Sendable {
       guard
         let nativeBuffer = AVAudioPCMBuffer(
           pcmFormat: nativeFormat, frameCapacity: AVAudioFrameCount(count))
-      else { continue }
+      else {
+        // A popped chunk that cannot be wrapped is lost audio (#1788 r7). Every
+        // exit from this loop that is not `.routed` or `.benignZeroOutput` must
+        // count, or the gap enumeration silently reopens.
+        counters.incrementLostChunk()
+        continue
+      }
       nativeBuffer.frameLength = AVAudioFrameCount(count)
       if let channelData = nativeBuffer.floatChannelData {
         popScratch.withUnsafeBufferPointer { src in
@@ -248,24 +261,48 @@ private final class HALRenderContext: @unchecked Sendable {
       // session reset landing between the mark and the flag-set left the flag
       // true while liveness was reset false, falsely tripping the watchdog
       // (#1540, Codex r1 P2). Deleting the flag closes that race.
-      if forward(nativeBuffer: nativeBuffer) {
+      switch forward(nativeBuffer: nativeBuffer) {
+      case .routed:
         liveness.markReceived()
+      case .benignZeroOutput:
+        break  // priming: input is buffered and emitted next call, nothing lost
+      case .lost:
+        counters.incrementLostChunk()
       }
     }
   }
 
+  /// What became of one popped chunk. A three-way result rather than `Bool`
+  /// BECAUSE the enumeration kept reopening (#1788 r3, r5, r7 each found another
+  /// silent `return false`): a bool lets a new early exit mean "not routed" without
+  /// the author deciding whether audio was LOST, and the caller then cannot tell.
+  /// Every exit from `forward` must now pick a case, and only `.benignZeroOutput`
+  /// is loss-free.
+  private enum ForwardOutcome {
+    /// Converted samples reached `forwarder.route` — the only success.
+    case routed
+    /// Converter consumed the input and emitted no frames yet. Priming does this
+    /// once; the input is buffered internally and emitted on the following call,
+    /// so the output timeline stays continuous and nothing is lost.
+    case benignZeroOutput
+    /// The chunk is gone. Counts toward `inputTimelineGapCount`.
+    case lost
+  }
+
   /// Resample `nativeBuffer` (the device's real rate) to `targetFormat`
   /// (16kHz mono, what the pipeline expects) and forward the converted
-  /// samples — never the raw native-rate ones (cloud review P2). Returns
-  /// whether a converted buffer actually reached `forwarder.route`.
-  @discardableResult
-  private func forward(nativeBuffer: AVAudioPCMBuffer) -> Bool {
+  /// samples — never the raw native-rate ones (cloud review P2).
+  private func forward(nativeBuffer: AVAudioPCMBuffer) -> ForwardOutcome {
     let ratio = targetFormat.sampleRate / nativeFormat.sampleRate
     let outputFrameCount = AVAudioFrameCount(Double(nativeBuffer.frameLength) * ratio) + 1
     guard outputFrameCount > 0,
       let convertedBuffer = AVAudioPCMBuffer(
         pcmFormat: targetFormat, frameCapacity: outputFrameCount)
-    else { return false }
+    else {
+      // Output-buffer allocation failed (memory pressure) — the chunk dies here,
+      // and until #1788 r7 nothing recorded it.
+      return .lost
+    }
 
     var error: NSError?
     nonisolated(unsafe) var inputConsumed = false
@@ -286,11 +323,11 @@ private final class HALRenderContext: @unchecked Sendable {
     // zero-frame output; more than ~1 per session is a signal.
     if error != nil {
       counters.incrementConverterError()
-      return false
+      return .lost
     }
     guard convertedBuffer.frameLength > 0 else {
       counters.incrementZeroOutput()
-      return false
+      return .benignZeroOutput
     }
 
     let level = AudioBufferProcessor.calculateRMS(convertedBuffer)
@@ -298,12 +335,12 @@ private final class HALRenderContext: @unchecked Sendable {
       // Converted frames exist but are unreadable — the chunk is lost exactly
       // like a converter error, so it counts as one rather than vanishing.
       counters.incrementConverterError()
-      return false
+      return .lost
     }
     let frameCount = Int(convertedBuffer.frameLength)
     let samples = Array(UnsafeBufferPointer(start: channelData[0], count: frameCount))
     forwarder.route(samples: samples, level: level, buffer: convertedBuffer)
-    return true
+    return .routed
   }
 
 }
@@ -467,6 +504,7 @@ final class HALDeviceInputSource: AudioInputSource {
       renderFailureCount: snap.renderFailures,
       oversizedSliceCount: snap.oversizedSlices,
       preRollGapCount: preRollGapCount,
+      lostChunkCount: snap.lostChunks,
       rateDivergenceDetected: formatDivergenceObserved,
       nativeChannelCount: boundNativeChannelCount
     )
@@ -727,6 +765,7 @@ final class HALDeviceInputSource: AudioInputSource {
       renderContext.map {
         let s = $0.counters.snapshotAndReset()
         return s.ringDrops + s.converterErrors + s.renderFailures + s.oversizedSlices
+          + s.lostChunks
       } ?? 0
 
     let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
@@ -837,7 +876,7 @@ final class HALDeviceInputSource: AudioInputSource {
           + "ringDrops=\(snap.ringDrops) convErrors=\(snap.converterErrors) "
           + "zeroConvOut=\(snap.zeroOutputs) renderFails=\(snap.renderFailures) "
           + "oversizedSlices=\(snap.oversizedSlices) "
-          + "preRollGaps=\(preRollGapCount) "
+          + "lostChunks=\(snap.lostChunks) preRollGaps=\(preRollGapCount) "
           + "rateDivergence=\(formatDivergenceObserved)"
       )
     }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -110,11 +110,15 @@ private final class HALSessionCounters: Sendable {
     var ringDrops = 0
     var converterErrors = 0
     var zeroOutputs = 0
+    var renderFailures = 0
+    var oversizedSlices = 0
   }
   private let state = OSAllocatedUnfairLock(initialState: Snapshot())
   func incrementRingDrop() { state.withLock { $0.ringDrops += 1 } }
   func incrementConverterError() { state.withLock { $0.converterErrors += 1 } }
   func incrementZeroOutput() { state.withLock { $0.zeroOutputs += 1 } }
+  func incrementRenderFailure() { state.withLock { $0.renderFailures += 1 } }
+  func incrementOversizedSlice() { state.withLock { $0.oversizedSlices += 1 } }
   func snapshot() -> Snapshot { state.withLock { $0 } }
   func reset() { state.withLock { $0 = Snapshot() } }
 }
@@ -278,7 +282,12 @@ private final class HALRenderContext: @unchecked Sendable {
     }
 
     let level = AudioBufferProcessor.calculateRMS(convertedBuffer)
-    guard let channelData = convertedBuffer.floatChannelData else { return false }
+    guard let channelData = convertedBuffer.floatChannelData else {
+      // Converted frames exist but are unreadable — the chunk is lost exactly
+      // like a converter error, so it counts as one rather than vanishing.
+      counters.incrementConverterError()
+      return false
+    }
     let frameCount = Int(convertedBuffer.frameLength)
     let samples = Array(UnsafeBufferPointer(start: channelData[0], count: frameCount))
     forwarder.route(samples: samples, level: level, buffer: convertedBuffer)
@@ -438,6 +447,8 @@ final class HALDeviceInputSource: AudioInputSource {
       ringDropCount: snap.ringDrops,
       converterErrorCount: snap.converterErrors,
       zeroOutputCount: snap.zeroOutputs,
+      renderFailureCount: snap.renderFailures,
+      oversizedSliceCount: snap.oversizedSlices,
       rateDivergenceDetected: formatDivergenceObserved,
       nativeChannelCount: boundNativeChannelCount
     )
@@ -788,7 +799,9 @@ final class HALDeviceInputSource: AudioInputSource {
         "HAL session stats: native=\(Int(context.nativeFormat.sampleRate)) "
           + "target=\(Int(context.targetFormat.sampleRate)) "
           + "ringDrops=\(snap.ringDrops) convErrors=\(snap.converterErrors) "
-          + "zeroConvOut=\(snap.zeroOutputs) rateDivergence=\(formatDivergenceObserved)"
+          + "zeroConvOut=\(snap.zeroOutputs) renderFails=\(snap.renderFailures) "
+          + "oversizedSlices=\(snap.oversizedSlices) "
+          + "rateDivergence=\(formatDivergenceObserved)"
       )
     }
     AudioCaptureManager.btRouteLog(
@@ -1248,6 +1261,13 @@ private func halRenderProc(
   // scratch buffer actually holds; a device that oversizes its slice loses
   // the excess of that one callback rather than overflowing.
   let clampedFrames = min(inNumberFrames, UInt32(context.capacityFrames))
+  if inNumberFrames > UInt32(context.capacityFrames) {
+    // The clamp above is a SAFETY behaviour that discards audio, and until
+    // #1788 nothing recorded it (cloud review r3 named the class: every gap
+    // between the microphone and the sample counter must be countable, or a
+    // sample index silently stops being an elapsed time).
+    context.counters.incrementOversizedSlice()
+  }
   let byteCapacity = Int(clampedFrames) * MemoryLayout<Float>.size
   // Reset every render — `AudioUnitRender` can shrink `mDataByteSize` to the
   // actual bytes written, so a stale smaller value from a prior callback
@@ -1257,7 +1277,12 @@ private func halRenderProc(
   let status = AudioUnitRender(
     context.audioUnit, ioActionFlags, inTimeStamp, 1, clampedFrames,
     context.scratch.unsafeMutablePointer)
-  guard status == noErr else { return status }
+  guard status == noErr else {
+    // This callback's frames are gone — same gap class as a ring drop, and
+    // likewise uncounted before #1788.
+    context.counters.incrementRenderFailure()
+    return status
+  }
   guard !context.stopped.isSet() else { return noErr }
 
   guard let data = context.scratch[0].mData else { return noErr }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -1368,6 +1368,13 @@ private func halRenderProc(
   // trust the requested frame count alone.
   let renderedFrames = Int(context.scratch[0].mDataByteSize) / MemoryLayout<Float>.size
   let frameCount = min(Int(clampedFrames), renderedFrames)
+  // A SHORT RENDER IS NOT A GAP, and #1788 r9 proposed counting it as one.
+  // `noErr` with a reduced `mDataByteSize` means the device had fewer frames than
+  // the slice asked for — those frames never existed, so nothing was lost. Counting
+  // them would inflate `inputTimelineGapCount` on healthy captures and mark every
+  // reading `floor`, making the instrument worse rather than more honest. Declined
+  // deliberately, not overlooked; revisit only with evidence that a short render
+  // accompanies actual audio loss.
   guard frameCount > 0 else { return noErr }
   let floatPtr = data.assumingMemoryBound(to: Float.self)
 

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -439,6 +439,11 @@ final class HALDeviceInputSource: AudioInputSource {
   /// prior session's metadata.
   private var cachedStopMetadata: CaptureStopMetadata?
 
+  /// Gaps carried in from the idle pre-roll window, snapshotted at the top of
+  /// `startCapture` before the per-session counter reset (#1788 r4). Assigned
+  /// fresh every session, so it never accumulates across takes.
+  private var preRollGapCount = 0
+
   private func computeStopMetadataFromLiveState() -> CaptureStopMetadata? {
     guard let context = renderContext else { return nil }
     let snap = context.counters.snapshot()
@@ -449,6 +454,7 @@ final class HALDeviceInputSource: AudioInputSource {
       zeroOutputCount: snap.zeroOutputs,
       renderFailureCount: snap.renderFailures,
       oversizedSliceCount: snap.oversizedSlices,
+      preRollGapCount: preRollGapCount,
       rateDivergenceDetected: formatDivergenceObserved,
       nativeChannelCount: boundNativeChannelCount
     )
@@ -694,6 +700,18 @@ final class HALDeviceInputSource: AudioInputSource {
         source: "HALDeviceInputSource.startCapture.missing_forwarder")
     }
 
+    // Read the idle pre-roll's gaps BEFORE `counters.reset()` below discards
+    // them (#1788 cloud review r4). The reset is right for #1434 per-session
+    // telemetry, but the wake measurement starts inside retained pre-roll, so a
+    // gap in there is inside its window: dropping it would let the diagnostic
+    // print `exact` over a stream that provably lost frames. Read before
+    // `fwd.activate` too, which drains the pre-roll on this same call.
+    preRollGapCount =
+      renderContext.map {
+        let s = $0.counters.snapshot()
+        return s.ringDrops + s.converterErrors + s.renderFailures + s.oversizedSlices
+      } ?? 0
+
     let stream = AsyncStream<AVAudioPCMBuffer> { continuation in
       self.streamContinuation = continuation
     }
@@ -801,6 +819,7 @@ final class HALDeviceInputSource: AudioInputSource {
           + "ringDrops=\(snap.ringDrops) convErrors=\(snap.converterErrors) "
           + "zeroConvOut=\(snap.zeroOutputs) renderFails=\(snap.renderFailures) "
           + "oversizedSlices=\(snap.oversizedSlices) "
+          + "preRollGaps=\(preRollGapCount) "
           + "rateDivergence=\(formatDivergenceObserved)"
       )
     }

--- a/Sources/EnviousWisprAudio/PreRollForwarder.swift
+++ b/Sources/EnviousWisprAudio/PreRollForwarder.swift
@@ -33,6 +33,18 @@ final class PreRollForwarder: @unchecked Sendable {
     var ring: [Float]
     var writeIdx: Int = 0
     var count: Int = 0
+    /// #1788: total samples routed since `prepare()`, INCLUDING ones the ring
+    /// later overwrote. The ring's `count` saturates at capacity, so it cannot
+    /// answer "how far into the stream are we" — this can.
+    var routedCount: Int = 0
+    /// #1788: index (from the first routed sample) of the first non-zero sample
+    /// ever routed while pre-rolling. Latched at ARRIVAL, so an overwritten
+    /// pre-roll sample still contributes its position. `nil` if the pre-roll
+    /// window was entirely silent.
+    var firstNonZeroRoutedIndex: Int?
+    /// #1788: `routedCount` at the moment activation drained the ring, so the
+    /// manager can convert a live-phase index into a stream-absolute one.
+    var routedCountAtActivation: Int?
     var onSamples: (@Sendable (_ samples: [Float], _ audioLevel: Float) -> Void)?
     var onBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?
     var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
@@ -86,6 +98,11 @@ final class PreRollForwarder: @unchecked Sendable {
         appendToRing(samples, state: &state)
         return .store
       case .capturing:
+        // #1788: keep the stream-absolute counter advancing. An integer add only
+        // — no per-sample scan is added to the live path, because nothing is
+        // dropped here: the detector's own index is already exact for live
+        // samples and the manager rebases it onto `routedCountAtActivation`.
+        state.routedCount += samples.count
         return .forward(
           onSamples: state.onSamples,
           onBuffer: state.onBuffer,
@@ -155,6 +172,10 @@ final class PreRollForwarder: @unchecked Sendable {
       state.continuation = continuation
 
       let result = drainRing(&state)
+      // #1788: the rebase point for converting a live-phase index into a
+      // stream-absolute one. Recorded BEFORE the mode flip so it reflects
+      // exactly the samples handed to the detector as pre-roll.
+      state.routedCountAtActivation = state.routedCount - result.count
       state.mode = .activating
       return result
     }
@@ -168,6 +189,13 @@ final class PreRollForwarder: @unchecked Sendable {
       state.mode = .capturing
       return delta
     }
+  }
+
+  /// #1788 wake diagnostic: the stream-absolute position of the first non-zero
+  /// sample latched during pre-roll, plus the pre-roll/live rebase point. Both
+  /// are `nil` when unavailable. Read on the MainActor after capture is live.
+  func wakeDiagnosticSnapshot() -> (firstNonZeroRoutedIndex: Int?, routedCountAtActivation: Int?) {
+    lock.withLock { ($0.firstNonZeroRoutedIndex, $0.routedCountAtActivation) }
   }
 
   /// Return to pre-rolling mode. Called when recording stops but engine stays warm.
@@ -193,6 +221,12 @@ final class PreRollForwarder: @unchecked Sendable {
       state.onBuffer = nil
       state.count = 0
       state.writeIdx = 0
+      // #1788: per-generation wake state MUST reset with the ring. A warm engine
+      // returns here between takes (`prepareForNextRecording`), so without this
+      // the latch stays set and every later take reports the FIRST take's wake.
+      state.routedCount = 0
+      state.firstNonZeroRoutedIndex = nil
+      state.routedCountAtActivation = nil
       state.mode = targetMode
       return c
     }
@@ -307,6 +341,18 @@ final class PreRollForwarder: @unchecked Sendable {
 
   /// Append samples to the circular ring buffer. MUST be called under lock.
   private func appendToRing(_ samples: [Float], state: inout State) {
+    // #1788: latch the first non-zero at ARRIVAL. Doing it here rather than at
+    // drain time is the whole point — the ring overwrites its oldest samples, so
+    // a wake that happened more than 500ms before activation would otherwise be
+    // erased before anyone could observe it. One comparison per sample, added to
+    // a loop already writing every sample, and skipped entirely once latched.
+    if state.firstNonZeroRoutedIndex == nil {
+      for (offset, sample) in samples.enumerated() where sample != 0 {
+        state.firstNonZeroRoutedIndex = state.routedCount + offset
+        break
+      }
+    }
+    state.routedCount += samples.count
     for sample in samples {
       state.ring[state.writeIdx] = sample
       state.writeIdx = (state.writeIdx + 1) % capacity

--- a/Sources/EnviousWisprAudio/PreRollForwarder.swift
+++ b/Sources/EnviousWisprAudio/PreRollForwarder.swift
@@ -346,6 +346,14 @@ final class PreRollForwarder: @unchecked Sendable {
     // a wake that happened more than 500ms before activation would otherwise be
     // erased before anyone could observe it. One comparison per sample, added to
     // a loop already writing every sample, and skipped entirely once latched.
+    //
+    // KNOWN LIMIT, r9: `debugZeroFillController` transforms samples at DRAIN and
+    // live-forward time, i.e. AFTER this latch, so under an armed fault injection
+    // the latch sees real audio while the detector sees zeros and `wake_ms` becomes
+    // meaningless. NOT fixed, because the fix would move the latch after the
+    // transform and reintroduce the ring-overwrite bug this line exists to prevent,
+    // and because a wake measured during a simulated dead mic is meaningless by
+    // construction anyway. IGNORE `wake_ms` on any `EW_FAULT_INJECTION=1` run.
     if state.firstNonZeroRoutedIndex == nil {
       for (offset, sample) in samples.enumerated() where sample != 0 {
         state.firstNonZeroRoutedIndex = state.routedCount + offset

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -62,8 +62,23 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   /// AVAudioConverter calls that returned an error (converted chunk lost).
   public let converterErrorCount: Int
   /// Converter calls that produced zero output frames (expected once at
-  /// priming; more than ~1 per session is a signal).
+  /// priming; more than ~1 per session is a signal). Deliberately NOT part of
+  /// `inputTimelineGapCount`: a priming call CONSUMES its input and emits it on
+  /// the following call, so the output timeline stays continuous.
   public let zeroOutputCount: Int
+  /// `AudioUnitRender` calls that returned a non-`noErr` status (that whole
+  /// callback's frames never reached the ring = lost audio).
+  public let renderFailureCount: Int
+  /// Render callbacks whose hardware slice exceeded the scratch allocation, so
+  /// the excess frames of that callback were clamped away = lost audio.
+  ///
+  /// This and `renderFailureCount` are dev-log + `inputTimelineGapCount` only.
+  /// The three older counters also travel to `dictation.completed`; these two
+  /// deliberately do NOT yet, because that chain spans four layers and a PostHog
+  /// property-naming decision that is a separate change, not a deferred half of
+  /// this one. The asymmetry is recorded so it reads as chosen, not forgotten,
+  /// and tracked in #1847.
+  public let oversizedSliceCount: Int
   /// A stream-format / nominal-rate change notification fired for the bound
   /// device while capturing (#1434 — log-and-telemetry only in v1; never
   /// interrupts the recording).
@@ -75,11 +90,31 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   /// source doesn't read a channel count (e.g. proxy-origin stalls).
   public let nativeChannelCount: Int?
 
+  /// Every way the captured stream can lose frames between the microphone and
+  /// the pipeline, summed. THE point of this property is to be the one place
+  /// that enumerates them, so anything measuring positions in the sample stream
+  /// asks one question instead of rediscovering the edges one review round at a
+  /// time (#1788 took three rounds of exactly that). Zero means the sample
+  /// stream is a faithful, gap-free timeline of what the device delivered, so a
+  /// sample INDEX is an exact elapsed time; nonzero makes any such index a lower
+  /// bound. The four edges, all in `HALDeviceInputSource`:
+  ///   1. `AudioUnitRender` returned an error   -> `renderFailureCount`
+  ///   2. slice larger than the scratch buffer  -> `oversizedSliceCount`
+  ///   3. RT ring full, consumer lagging        -> `ringDropCount`
+  ///   4. `AVAudioConverter` returned an error  -> `converterErrorCount`
+  /// A fifth candidate, a zero-frame converter output, is NOT a gap (see
+  /// `zeroOutputCount`). Adding a new lossy edge means adding it here too.
+  public var inputTimelineGapCount: Int {
+    renderFailureCount + oversizedSliceCount + ringDropCount + converterErrorCount
+  }
+
   public init(
     nativeRateHz: Double?,
     ringDropCount: Int = 0,
     converterErrorCount: Int = 0,
     zeroOutputCount: Int = 0,
+    renderFailureCount: Int = 0,
+    oversizedSliceCount: Int = 0,
     rateDivergenceDetected: Bool = false,
     nativeChannelCount: Int? = nil
   ) {
@@ -87,8 +122,29 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     self.ringDropCount = ringDropCount
     self.converterErrorCount = converterErrorCount
     self.zeroOutputCount = zeroOutputCount
+    self.renderFailureCount = renderFailureCount
+    self.oversizedSliceCount = oversizedSliceCount
     self.rateDivergenceDetected = rateDivergenceDetected
     self.nativeChannelCount = nativeChannelCount
+  }
+
+  /// Counters decode as ABSENT-MEANS-ZERO rather than as required keys, so a stop
+  /// reply produced before a given counter existed still decodes. The synthesized
+  /// decoder would instead throw on the missing key, which is how #1788's two new
+  /// gap counters would have broken the #1523 forward-compatibility test. Adding
+  /// another counter therefore needs a line here as well as in
+  /// `inputTimelineGapCount` — both are deliberate, both fail loudly in tests.
+  public init(from decoder: any Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    nativeRateHz = try c.decodeIfPresent(Double.self, forKey: .nativeRateHz)
+    ringDropCount = try c.decodeIfPresent(Int.self, forKey: .ringDropCount) ?? 0
+    converterErrorCount = try c.decodeIfPresent(Int.self, forKey: .converterErrorCount) ?? 0
+    zeroOutputCount = try c.decodeIfPresent(Int.self, forKey: .zeroOutputCount) ?? 0
+    renderFailureCount = try c.decodeIfPresent(Int.self, forKey: .renderFailureCount) ?? 0
+    oversizedSliceCount = try c.decodeIfPresent(Int.self, forKey: .oversizedSliceCount) ?? 0
+    rateDivergenceDetected =
+      try c.decodeIfPresent(Bool.self, forKey: .rateDivergenceDetected) ?? false
+    nativeChannelCount = try c.decodeIfPresent(Int.self, forKey: .nativeChannelCount)
   }
 }
 

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -59,7 +59,10 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   public let nativeRateHz: Double?
   /// Chunks the RT ring refused because the consumer lagged (drop = lost audio).
   public let ringDropCount: Int
-  /// AVAudioConverter calls that returned an error (converted chunk lost).
+  /// AVAudioConverter calls that returned an error (converted chunk lost). A SUBSET
+  /// of `lostChunkCount`, never an independent addend in `inputTimelineGapCount` —
+  /// every converter failure also returns `.lost`, so summing both counts the same
+  /// chunk twice (r8).
   public let converterErrorCount: Int
   /// Converter calls that produced zero output frames (expected once at
   /// priming; more than ~1 per session is a signal). Deliberately NOT part of
@@ -117,15 +120,23 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   /// stream is a faithful, gap-free timeline of what the device delivered, so a
   /// sample INDEX is an exact elapsed time; nonzero makes any such index a lower
   /// bound. The four edges, all in `HALDeviceInputSource`:
+  /// ONE ADDEND PER DEATH POINT, which is what keeps this sum honest:
   ///   1. `AudioUnitRender` returned an error   -> `renderFailureCount`
   ///   2. slice larger than the scratch buffer  -> `oversizedSliceCount`
   ///   3. RT ring full, consumer lagging        -> `ringDropCount`
-  ///   4. `AVAudioConverter` returned an error  -> `converterErrorCount`
-  ///   5. anything else on the pop->route path  -> `lostChunkCount`
-  /// A further candidate, a zero-frame converter output, is NOT a gap (see
-  /// `zeroOutputCount`). Edge 5 is the catch-all that stopped this list needing an
-  /// entry per newly-discovered exit: three separate review rounds each found one,
-  /// so `ForwardOutcome` now forces every exit to declare loss and edge 5 counts it.
+  ///   4. ANY death on the pop->route path      -> `lostChunkCount`
+  /// 1-3 are separate because each is a distinct death point in the RT callback,
+  /// before a chunk ever reaches the consumer. 4 is a single catch-all because that
+  /// path kept sprouting new silent exits (r3, r5, r7 each found one), so
+  /// `ForwardOutcome` now forces every exit to declare loss and this counts them all.
+  ///
+  /// `converterErrorCount` is deliberately NOT an addend: every converter failure
+  /// also returns `.lost`, so it is a SUBSET of `lostChunkCount` kept for #1434
+  /// diagnostic breakdown. Adding both double-counted the same lost chunk (r8 —
+  /// introduced by r7's own fix, which is the hazard of a catch-all landing beside
+  /// per-cause counters). A zero-frame converter output is not a gap at all (see
+  /// `zeroOutputCount`). Before adding an addend here, ask whether its chunk already
+  /// dies at an existing death point.
   ///
   /// The WINDOW matters as much as the edge list: a measured wake starts inside
   /// retained pre-roll, so `preRollGapCount` is part of the sum even though the
@@ -134,8 +145,8 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   /// r1-r3 each found a different edge — the same root cause four times, which
   /// is why both halves are stated here rather than in a call site.
   public var inputTimelineGapCount: Int {
-    renderFailureCount + oversizedSliceCount + ringDropCount + converterErrorCount
-      + lostChunkCount + preRollGapCount
+    renderFailureCount + oversizedSliceCount + ringDropCount + lostChunkCount
+      + preRollGapCount
   }
 
   public init(

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -90,6 +90,14 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   /// rather than only the ~500ms the ring still holds, so it can say `floor` when
   /// `exact` was defensible. A measurement authority fails closed.
   public let preRollGapCount: Int
+  /// Popped chunks that died between the ring and `PreRollForwarder.route` for any
+  /// reason other than a benign converter priming call — buffer allocation failure
+  /// under memory pressure, an unreadable converted buffer, or any future early
+  /// exit. A CATCH-ALL by design: #1788 rounds 3, 5 and 7 each uncovered another
+  /// silent `return false` on that path, so the count now lives at the single point
+  /// a chunk can die rather than at each reason it might, and a new exit has to
+  /// declare itself through `ForwardOutcome`.
+  public let lostChunkCount: Int
   /// A stream-format / nominal-rate change notification fired for the bound
   /// device while capturing (#1434 — log-and-telemetry only in v1; never
   /// interrupts the recording).
@@ -113,8 +121,11 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   ///   2. slice larger than the scratch buffer  -> `oversizedSliceCount`
   ///   3. RT ring full, consumer lagging        -> `ringDropCount`
   ///   4. `AVAudioConverter` returned an error  -> `converterErrorCount`
-  /// A fifth candidate, a zero-frame converter output, is NOT a gap (see
-  /// `zeroOutputCount`). Adding a new lossy edge means adding it here too.
+  ///   5. anything else on the pop->route path  -> `lostChunkCount`
+  /// A further candidate, a zero-frame converter output, is NOT a gap (see
+  /// `zeroOutputCount`). Edge 5 is the catch-all that stopped this list needing an
+  /// entry per newly-discovered exit: three separate review rounds each found one,
+  /// so `ForwardOutcome` now forces every exit to declare loss and edge 5 counts it.
   ///
   /// The WINDOW matters as much as the edge list: a measured wake starts inside
   /// retained pre-roll, so `preRollGapCount` is part of the sum even though the
@@ -124,7 +135,7 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   /// is why both halves are stated here rather than in a call site.
   public var inputTimelineGapCount: Int {
     renderFailureCount + oversizedSliceCount + ringDropCount + converterErrorCount
-      + preRollGapCount
+      + lostChunkCount + preRollGapCount
   }
 
   public init(
@@ -135,6 +146,7 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     renderFailureCount: Int = 0,
     oversizedSliceCount: Int = 0,
     preRollGapCount: Int = 0,
+    lostChunkCount: Int = 0,
     rateDivergenceDetected: Bool = false,
     nativeChannelCount: Int? = nil
   ) {
@@ -145,6 +157,7 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     self.renderFailureCount = renderFailureCount
     self.oversizedSliceCount = oversizedSliceCount
     self.preRollGapCount = preRollGapCount
+    self.lostChunkCount = lostChunkCount
     self.rateDivergenceDetected = rateDivergenceDetected
     self.nativeChannelCount = nativeChannelCount
   }
@@ -164,6 +177,7 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     renderFailureCount = try c.decodeIfPresent(Int.self, forKey: .renderFailureCount) ?? 0
     oversizedSliceCount = try c.decodeIfPresent(Int.self, forKey: .oversizedSliceCount) ?? 0
     preRollGapCount = try c.decodeIfPresent(Int.self, forKey: .preRollGapCount) ?? 0
+    lostChunkCount = try c.decodeIfPresent(Int.self, forKey: .lostChunkCount) ?? 0
     rateDivergenceDetected =
       try c.decodeIfPresent(Bool.self, forKey: .rateDivergenceDetected) ?? false
     nativeChannelCount = try c.decodeIfPresent(Int.self, forKey: .nativeChannelCount)

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -79,6 +79,17 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   /// this one. The asymmetry is recorded so it reads as chosen, not forgotten,
   /// and tracked in #1847.
   public let oversizedSliceCount: Int
+  /// Gaps that accrued while the warm unit was PRE-ROLLING, before this session's
+  /// counters were reset (#1788 cloud review r4). The other counters are reset per
+  /// session on purpose, so idle-time faults cannot bleed into a recording's
+  /// #1434 telemetry — but the wake measurement spans retained pre-roll, so for
+  /// IT those gaps are inside the window and erasing them would let the line
+  /// claim `exact` over a stream that provably lost frames. Carried separately
+  /// rather than folded into the four counters above, which must keep meaning
+  /// "this session". Deliberately CONSERVATIVE: it spans the whole idle stretch
+  /// rather than only the ~500ms the ring still holds, so it can say `floor` when
+  /// `exact` was defensible. A measurement authority fails closed.
+  public let preRollGapCount: Int
   /// A stream-format / nominal-rate change notification fired for the bound
   /// device while capturing (#1434 — log-and-telemetry only in v1; never
   /// interrupts the recording).
@@ -104,8 +115,16 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   ///   4. `AVAudioConverter` returned an error  -> `converterErrorCount`
   /// A fifth candidate, a zero-frame converter output, is NOT a gap (see
   /// `zeroOutputCount`). Adding a new lossy edge means adding it here too.
+  ///
+  /// The WINDOW matters as much as the edge list: a measured wake starts inside
+  /// retained pre-roll, so `preRollGapCount` is part of the sum even though the
+  /// four session counters are reset before that pre-roll is drained. Counting
+  /// the right edges over the wrong window was cloud review r4 on #1788, after
+  /// r1-r3 each found a different edge — the same root cause four times, which
+  /// is why both halves are stated here rather than in a call site.
   public var inputTimelineGapCount: Int {
     renderFailureCount + oversizedSliceCount + ringDropCount + converterErrorCount
+      + preRollGapCount
   }
 
   public init(
@@ -115,6 +134,7 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     zeroOutputCount: Int = 0,
     renderFailureCount: Int = 0,
     oversizedSliceCount: Int = 0,
+    preRollGapCount: Int = 0,
     rateDivergenceDetected: Bool = false,
     nativeChannelCount: Int? = nil
   ) {
@@ -124,6 +144,7 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     self.zeroOutputCount = zeroOutputCount
     self.renderFailureCount = renderFailureCount
     self.oversizedSliceCount = oversizedSliceCount
+    self.preRollGapCount = preRollGapCount
     self.rateDivergenceDetected = rateDivergenceDetected
     self.nativeChannelCount = nativeChannelCount
   }
@@ -142,6 +163,7 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     zeroOutputCount = try c.decodeIfPresent(Int.self, forKey: .zeroOutputCount) ?? 0
     renderFailureCount = try c.decodeIfPresent(Int.self, forKey: .renderFailureCount) ?? 0
     oversizedSliceCount = try c.decodeIfPresent(Int.self, forKey: .oversizedSliceCount) ?? 0
+    preRollGapCount = try c.decodeIfPresent(Int.self, forKey: .preRollGapCount) ?? 0
     rateDivergenceDetected =
       try c.decodeIfPresent(Bool.self, forKey: .rateDivergenceDetected) ?? false
     nativeChannelCount = try c.decodeIfPresent(Int.self, forKey: .nativeChannelCount)

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
@@ -123,23 +123,28 @@ struct AudioCaptureManagerDeadAirLatchTests {
 }
 
 #if DEBUG
-  /// The wake instrument's honesty rule (#1788 cloud review r5). Five review rounds
-  /// on this one diagnostic all reduced to reading a quantity over an interval it
-  /// does not describe, so the rule that decides `exact` vs `floor` is frozen here
-  /// as pure logic rather than left inside the emitter where each round found it
-  /// again. Both failure modes UNDER-report, so the safe label is always `floor`.
-  @Suite("AudioCaptureManager — wake exactness rule (#1788)")
+  /// The wake instrument's honesty rule (#1788, cloud review r5-r7). SEVEN review
+  /// rounds on this one diagnostic all reduced to reading a quantity over an interval
+  /// it does not describe, so the rule deciding `stream_measured` vs `floor` is
+  /// frozen here as pure logic rather than left inside the emitter where each round
+  /// found it again. Both failure modes UNDER-report, so the safe label is `floor`.
+  ///
+  /// Note the label is `stream_measured`, not `exact`: no sample-derived wake can be
+  /// exact with respect to press-to-audio, because a callback-free startup is
+  /// invisible to a sample clock (r7). These tests pin the delivered-stream claim,
+  /// which is the only claim the instrument makes.
+  @Suite("AudioCaptureManager — wake measurement basis (#1788)")
   struct AudioCaptureManagerWakeExactnessTests {
 
-    @Test("a measured zero prefix is what makes a wake exact")
+    @Test("a measured zero prefix is what makes a wake stream-measured")
     func measuredPrefixMakesItExact() {
       // Samples were routed while the link was still silent, so the interval is
       // observed rather than inferred.
-      #expect(AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 9591))
-      #expect(AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 1))
+      #expect(AudioCaptureManager.wakeIsStreamMeasured(gapCount: 0, wakeSamples: 9591))
+      #expect(AudioCaptureManager.wakeIsStreamMeasured(gapCount: 0, wakeSamples: 1))
     }
 
-    @Test("a zero wake is ALWAYS a floor, never exact")
+    @Test("a zero wake is ALWAYS a floor, never stream-measured")
     func zeroWakeIsNeverExact() {
       // THE r5/r6 CASE. A wake of 0 means the first sample that ever existed was
       // already non-zero, so an already-awake link and one that woke during a
@@ -147,15 +152,15 @@ struct AudioCaptureManagerDeadAirLatchTests {
       // of this suite ASSERTING THE OPPOSITE for a pre-roll latch at index 0 — the
       // bug was written into its own oracle, which is why the rule is now expressed
       // over the wake itself rather than over a proxy field.
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 0))
+      #expect(!AudioCaptureManager.wakeIsStreamMeasured(gapCount: 0, wakeSamples: 0))
     }
 
     @Test("gaps and a measured prefix are both required")
     func exactRequiresBothConditions() {
-      #expect(AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 8000))
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 1, wakeSamples: 8000))
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 0))
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 3, wakeSamples: 0))
+      #expect(AudioCaptureManager.wakeIsStreamMeasured(gapCount: 0, wakeSamples: 8000))
+      #expect(!AudioCaptureManager.wakeIsStreamMeasured(gapCount: 1, wakeSamples: 8000))
+      #expect(!AudioCaptureManager.wakeIsStreamMeasured(gapCount: 0, wakeSamples: 0))
+      #expect(!AudioCaptureManager.wakeIsStreamMeasured(gapCount: 3, wakeSamples: 0))
     }
 
     @Test("an unreadable gap count or wake fails CLOSED, never as zero")
@@ -163,9 +168,9 @@ struct AudioCaptureManagerDeadAirLatchTests {
       // A measurement authority that cannot read its own inputs must not print the
       // confident label. nil gaps = the source offered no stop metadata; nil wake =
       // the stream position could not be reconstructed at all.
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: nil, wakeSamples: 8000))
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: nil))
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: nil, wakeSamples: nil))
+      #expect(!AudioCaptureManager.wakeIsStreamMeasured(gapCount: nil, wakeSamples: 8000))
+      #expect(!AudioCaptureManager.wakeIsStreamMeasured(gapCount: 0, wakeSamples: nil))
+      #expect(!AudioCaptureManager.wakeIsStreamMeasured(gapCount: nil, wakeSamples: nil))
     }
   }
 #endif

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
@@ -62,4 +62,42 @@ struct AudioCaptureManagerDeadAirLatchTests {
       [Float](repeating: 0.5, count: AudioConstants.minimumTranscriptionSamples), level: 0.5)
     #expect(!manager.zeroSignalDiscriminatorSawIneligible)
   }
+
+  // MARK: - #1788 — the mid-take all-zero ceiling has ONE owner
+
+  /// The production-critical claim: with no DEBUG override set, the ceiling is
+  /// the shipping 1.0s value, so release behaviour is unchanged by the #1788
+  /// instrument. This is the assertion that must never regress — if the default
+  /// ever drifts, every transport silently changes how long it tolerates silence.
+  @Test("no override -> ceiling is the shipping minimumTranscriptionSamples")
+  func ceilingDefaultsToShippingValue() {
+    UserDefaults.standard.removeObject(forKey: "EWDebugAllZeroCeilingSamples")
+    let manager = AudioCaptureManager()
+    #expect(manager.allZeroCeilingSamples == AudioConstants.minimumTranscriptionSamples)
+    #expect(manager.allZeroCeilingSamples == 16_000)
+  }
+
+  /// A non-positive override must be IGNORED rather than producing a zero or
+  /// negative ceiling — a 0 ceiling would abort every capture instantly, which is
+  /// the worst possible failure for a debug knob to be able to cause by typo.
+  @Test("non-positive override is ignored, never applied")
+  func nonPositiveOverrideIsIgnored() {
+    defer { UserDefaults.standard.removeObject(forKey: "EWDebugAllZeroCeilingSamples") }
+    for bad in [0, -1, -160_000] {
+      UserDefaults.standard.set(bad, forKey: "EWDebugAllZeroCeilingSamples")
+      let manager = AudioCaptureManager()
+      #expect(manager.allZeroCeilingSamples == AudioConstants.minimumTranscriptionSamples)
+    }
+  }
+
+  /// DEBUG-only: a positive override is honoured. This is what made the #1788
+  /// hardware measurement possible — without it a slow Bluetooth wake is censored
+  /// by the abort rather than observed.
+  @Test("positive override is honoured in DEBUG")
+  func positiveOverrideIsHonoured() {
+    defer { UserDefaults.standard.removeObject(forKey: "EWDebugAllZeroCeilingSamples") }
+    UserDefaults.standard.set(160_000, forKey: "EWDebugAllZeroCeilingSamples")
+    let manager = AudioCaptureManager()
+    #expect(manager.allZeroCeilingSamples == 160_000)
+  }
 }

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
@@ -121,3 +121,60 @@ struct AudioCaptureManagerDeadAirLatchTests {
     }
   #endif
 }
+
+#if DEBUG
+  /// The wake instrument's honesty rule (#1788 cloud review r5). Five review rounds
+  /// on this one diagnostic all reduced to reading a quantity over an interval it
+  /// does not describe, so the rule that decides `exact` vs `floor` is frozen here
+  /// as pure logic rather than left inside the emitter where each round found it
+  /// again. Both failure modes UNDER-report, so the safe label is always `floor`.
+  @Suite("AudioCaptureManager — wake exactness rule (#1788)")
+  struct AudioCaptureManagerWakeExactnessTests {
+
+    @Test("a pre-roll latch proves the stream predated the wake")
+    func preRollLatchProvesStreamCameFirst() {
+      #expect(
+        AudioCaptureManager.wakeStreamStartedBeforeWake(
+          firstNonZeroRoutedIndex: 9591, routedCountAtActivation: nil))
+      // Even index 0 counts: a latch existing at all means route() saw the sample.
+      #expect(
+        AudioCaptureManager.wakeStreamStartedBeforeWake(
+          firstNonZeroRoutedIndex: 0, routedCountAtActivation: 0))
+    }
+
+    @Test("samples routed before activation prove it too")
+    func routedBeforeActivationProvesStreamCameFirst() {
+      #expect(
+        AudioCaptureManager.wakeStreamStartedBeforeWake(
+          firstNonZeroRoutedIndex: nil, routedCountAtActivation: 8000))
+    }
+
+    @Test("nothing routed before activation means the wake is unmeasurable below")
+    func noPriorSamplesMeansNotExact() {
+      // THE r5 CASE: AUHAL delivers no callback for a while, then its first sample
+      // is already nonzero. Index 0 reads as wake_ms=0 and no gap counter moves, so
+      // without this the line would claim `exact` over a real link delay.
+      #expect(
+        !AudioCaptureManager.wakeStreamStartedBeforeWake(
+          firstNonZeroRoutedIndex: nil, routedCountAtActivation: 0))
+      #expect(
+        !AudioCaptureManager.wakeStreamStartedBeforeWake(
+          firstNonZeroRoutedIndex: nil, routedCountAtActivation: nil))
+    }
+
+    @Test("exact requires a gap-free stream AND a stream that came first")
+    func exactRequiresBothConditions() {
+      #expect(AudioCaptureManager.wakeIsExact(gapCount: 0, streamStartedFirst: true))
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 1, streamStartedFirst: true))
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 0, streamStartedFirst: false))
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 3, streamStartedFirst: false))
+    }
+
+    @Test("an unreadable gap count fails CLOSED, never as zero")
+    func unknownGapCountIsNotExact() {
+      // A measurement authority that cannot read its own inputs must not print the
+      // confident label; nil here means the source had no stop metadata to offer.
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: nil, streamStartedFirst: true))
+    }
+  }
+#endif

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
@@ -131,50 +131,41 @@ struct AudioCaptureManagerDeadAirLatchTests {
   @Suite("AudioCaptureManager — wake exactness rule (#1788)")
   struct AudioCaptureManagerWakeExactnessTests {
 
-    @Test("a pre-roll latch proves the stream predated the wake")
-    func preRollLatchProvesStreamCameFirst() {
-      #expect(
-        AudioCaptureManager.wakeStreamStartedBeforeWake(
-          firstNonZeroRoutedIndex: 9591, routedCountAtActivation: nil))
-      // Even index 0 counts: a latch existing at all means route() saw the sample.
-      #expect(
-        AudioCaptureManager.wakeStreamStartedBeforeWake(
-          firstNonZeroRoutedIndex: 0, routedCountAtActivation: 0))
+    @Test("a measured zero prefix is what makes a wake exact")
+    func measuredPrefixMakesItExact() {
+      // Samples were routed while the link was still silent, so the interval is
+      // observed rather than inferred.
+      #expect(AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 9591))
+      #expect(AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 1))
     }
 
-    @Test("samples routed before activation prove it too")
-    func routedBeforeActivationProvesStreamCameFirst() {
-      #expect(
-        AudioCaptureManager.wakeStreamStartedBeforeWake(
-          firstNonZeroRoutedIndex: nil, routedCountAtActivation: 8000))
+    @Test("a zero wake is ALWAYS a floor, never exact")
+    func zeroWakeIsNeverExact() {
+      // THE r5/r6 CASE. A wake of 0 means the first sample that ever existed was
+      // already non-zero, so an already-awake link and one that woke during a
+      // callback-free startup are indistinguishable. r6 caught the previous version
+      // of this suite ASSERTING THE OPPOSITE for a pre-roll latch at index 0 — the
+      // bug was written into its own oracle, which is why the rule is now expressed
+      // over the wake itself rather than over a proxy field.
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 0))
     }
 
-    @Test("nothing routed before activation means the wake is unmeasurable below")
-    func noPriorSamplesMeansNotExact() {
-      // THE r5 CASE: AUHAL delivers no callback for a while, then its first sample
-      // is already nonzero. Index 0 reads as wake_ms=0 and no gap counter moves, so
-      // without this the line would claim `exact` over a real link delay.
-      #expect(
-        !AudioCaptureManager.wakeStreamStartedBeforeWake(
-          firstNonZeroRoutedIndex: nil, routedCountAtActivation: 0))
-      #expect(
-        !AudioCaptureManager.wakeStreamStartedBeforeWake(
-          firstNonZeroRoutedIndex: nil, routedCountAtActivation: nil))
-    }
-
-    @Test("exact requires a gap-free stream AND a stream that came first")
+    @Test("gaps and a measured prefix are both required")
     func exactRequiresBothConditions() {
-      #expect(AudioCaptureManager.wakeIsExact(gapCount: 0, streamStartedFirst: true))
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 1, streamStartedFirst: true))
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 0, streamStartedFirst: false))
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 3, streamStartedFirst: false))
+      #expect(AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 8000))
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 1, wakeSamples: 8000))
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: 0))
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 3, wakeSamples: 0))
     }
 
-    @Test("an unreadable gap count fails CLOSED, never as zero")
-    func unknownGapCountIsNotExact() {
+    @Test("an unreadable gap count or wake fails CLOSED, never as zero")
+    func unknownInputsAreNotExact() {
       // A measurement authority that cannot read its own inputs must not print the
-      // confident label; nil here means the source had no stop metadata to offer.
-      #expect(!AudioCaptureManager.wakeIsExact(gapCount: nil, streamStartedFirst: true))
+      // confident label. nil gaps = the source offered no stop metadata; nil wake =
+      // the stream position could not be reconstructed at all.
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: nil, wakeSamples: 8000))
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: 0, wakeSamples: nil))
+      #expect(!AudioCaptureManager.wakeIsExact(gapCount: nil, wakeSamples: nil))
     }
   }
 #endif

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
@@ -90,14 +90,34 @@ struct AudioCaptureManagerDeadAirLatchTests {
     }
   }
 
-  /// DEBUG-only: a positive override is honoured. This is what made the #1788
-  /// hardware measurement possible — without it a slow Bluetooth wake is censored
-  /// by the abort rather than observed.
-  @Test("positive override is honoured in DEBUG")
-  func positiveOverrideIsHonoured() {
-    defer { UserDefaults.standard.removeObject(forKey: "EWDebugAllZeroCeilingSamples") }
-    UserDefaults.standard.set(160_000, forKey: "EWDebugAllZeroCeilingSamples")
-    let manager = AudioCaptureManager()
-    #expect(manager.allZeroCeilingSamples == 160_000)
-  }
+  // The override exists ONLY in DEBUG, so these two tests are mirror images and
+  // both must be compiled — asserting the override works where it exists, and
+  // asserting it is genuinely ABSENT where it must not exist. A single
+  // unconditional test would fail the `scripts/xcode-test.sh --release` lane,
+  // which strips `#if DEBUG` and returns the shipping ceiling (Codex review r1).
+
+  #if DEBUG
+    /// A positive override is honoured. This is what made the #1788 hardware
+    /// measurement possible — without it a slow Bluetooth wake is censored by the
+    /// abort rather than observed.
+    @Test("positive override is honoured in DEBUG")
+    func positiveOverrideIsHonoured() {
+      defer { UserDefaults.standard.removeObject(forKey: "EWDebugAllZeroCeilingSamples") }
+      UserDefaults.standard.set(160_000, forKey: "EWDebugAllZeroCeilingSamples")
+      let manager = AudioCaptureManager()
+      #expect(manager.allZeroCeilingSamples == 160_000)
+    }
+  #else
+    /// The release-lane twin, and the more important of the two: it proves the
+    /// debug knob cannot influence a shipped build. Setting the key must change
+    /// NOTHING — if this ever fails, a diagnostic override has leaked into
+    /// production and can alter how long every capture tolerates silence.
+    @Test("override key has NO effect in release — the knob cannot ship")
+    func overrideIsInertInRelease() {
+      defer { UserDefaults.standard.removeObject(forKey: "EWDebugAllZeroCeilingSamples") }
+      UserDefaults.standard.set(160_000, forKey: "EWDebugAllZeroCeilingSamples")
+      let manager = AudioCaptureManager()
+      #expect(manager.allZeroCeilingSamples == AudioConstants.minimumTranscriptionSamples)
+    }
+  #endif
 }

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
@@ -43,6 +43,12 @@ import Testing
       private(set) var rebuildCallCount = 0
       #if DEBUG
         var debugZeroFillController: DebugZeroFillController?
+        /// #1788: this stub has no forwarder, so it measured no wake. Nil is the
+        /// honest answer and the manager renders it as `unavailable` rather than
+        /// inventing a 0ms wake.
+        var wakeDiagnostic: (firstNonZeroRoutedIndex: Int?, routedCountAtActivation: Int?) {
+          (nil, nil)
+        }
       #endif
 
       func prepare() async throws {}

--- a/Tests/EnviousWisprTests/Audio/DeadAirStreamingDetectorTests.swift
+++ b/Tests/EnviousWisprTests/Audio/DeadAirStreamingDetectorTests.swift
@@ -42,14 +42,14 @@ struct DeadAirStreamingDetectorTests {
   @Test("every sample exactly zero, at threshold → allZeroFromStart")
   func allZeroFromStartAtThreshold() {
     let detector = ingestWhole([Float](repeating: 0, count: threshold))
-    #expect(detector.isAllZeroFromStart)
+    #expect(detector.isAllZeroFromStart(ceilingSamples: threshold))
     #expect(!detector.isBecameZeroMidCapture)
   }
 
   @Test("every sample exactly zero, BELOW threshold → not yet confident")
   func allZeroBelowThresholdNotYetConfident() {
     let detector = ingestWhole([Float](repeating: 0, count: threshold - 1))
-    #expect(!detector.isAllZeroFromStart)
+    #expect(!detector.isAllZeroFromStart(ceilingSamples: threshold))
   }
 
   // MARK: - No false alarm on genuine quiet-room noise
@@ -62,7 +62,7 @@ struct DeadAirStreamingDetectorTests {
   @Test("uniform tiny non-zero noise never triggers allZeroFromStart")
   func quietRoomNoiseNeverFalseAlarms() {
     let detector = ingestWhole([Float](repeating: 0.001, count: threshold * 2))
-    #expect(!detector.isAllZeroFromStart)
+    #expect(!detector.isAllZeroFromStart(ceilingSamples: threshold))
     #expect(!detector.isBecameZeroMidCapture)
   }
 
@@ -71,7 +71,7 @@ struct DeadAirStreamingDetectorTests {
     var samples = [Float](repeating: 0, count: threshold)
     samples[threshold / 2] = 0.01
     let detector = ingestWhole(samples)
-    #expect(!detector.isAllZeroFromStart)
+    #expect(!detector.isAllZeroFromStart(ceilingSamples: threshold))
   }
 
   // MARK: - becameZeroMidCapture
@@ -83,7 +83,7 @@ struct DeadAirStreamingDetectorTests {
     let detector = ingestWhole(samples)
     #expect(detector.meaningfulSignalSeen)
     #expect(detector.isBecameZeroMidCapture)
-    #expect(!detector.isAllZeroFromStart)
+    #expect(!detector.isAllZeroFromStart(ceilingSamples: threshold))
   }
 
   @Test("meaningful signal then a zero suffix BELOW threshold → not yet confident")
@@ -110,14 +110,14 @@ struct DeadAirStreamingDetectorTests {
     let detector = ingestWhole([Float](repeating: 0, count: threshold))
     #expect(!detector.meaningfulSignalSeen)
     #expect(!detector.isBecameZeroMidCapture)
-    #expect(detector.isAllZeroFromStart)
+    #expect(detector.isAllZeroFromStart(ceilingSamples: threshold))
   }
 
   @Test("meaningful signal that never goes to zero triggers neither mode")
   func continuousSignalTriggersNeitherMode() {
     let detector = ingestWhole([Float](repeating: 0.1, count: threshold * 2))
     #expect(detector.meaningfulSignalSeen)
-    #expect(!detector.isAllZeroFromStart)
+    #expect(!detector.isAllZeroFromStart(ceilingSamples: threshold))
     #expect(!detector.isBecameZeroMidCapture)
   }
 
@@ -140,7 +140,7 @@ struct DeadAirStreamingDetectorTests {
     let chunked = ingestChunked(samples, chunkSize: 500)
 
     #expect(whole.meaningfulSignalSeen == chunked.meaningfulSignalSeen)
-    #expect(whole.isAllZeroFromStart == chunked.isAllZeroFromStart)
+    #expect(whole.isAllZeroFromStart(ceilingSamples: threshold) == chunked.isAllZeroFromStart(ceilingSamples: threshold))
     #expect(whole.isBecameZeroMidCapture == chunked.isBecameZeroMidCapture)
     #expect(whole.totalSampleCount == chunked.totalSampleCount)
     #expect(whole.consecutiveExactZeroSuffix == chunked.consecutiveExactZeroSuffix)
@@ -162,8 +162,8 @@ struct DeadAirStreamingDetectorTests {
     let samples = [Float](repeating: 0, count: threshold + 500)
     let whole = ingestWhole(samples)
     let chunked = ingestChunked(samples, chunkSize: 333)  // deliberately not a 640 divisor
-    #expect(whole.isAllZeroFromStart == chunked.isAllZeroFromStart)
-    #expect(whole.isAllZeroFromStart)
+    #expect(whole.isAllZeroFromStart(ceilingSamples: threshold) == chunked.isAllZeroFromStart(ceilingSamples: threshold))
+    #expect(whole.isAllZeroFromStart(ceilingSamples: threshold))
   }
 
   // MARK: - RawAudioDeadAirClassifier.isDeadAir generic-slice equivalence
@@ -213,5 +213,96 @@ struct DeadAirStreamingDetectorTests {
     let sliceResult = RawAudioDeadAirClassifier.isDeadAir(slice, peak: peak)
     #expect(arrayResult == sliceResult)
     #expect(!arrayResult)  // the loud window must be found, not silently missed
+  }
+
+  // MARK: - Caller-supplied ceiling (#1788)
+  //
+  // The ceiling is a PARAMETER so the mid-take owner can raise it for a
+  // transport that legitimately needs longer, without the detector knowing
+  // anything about transports. These tests pin the boundary at an arbitrary
+  // custom ceiling so they cannot silently pass just because it happens to
+  // equal `minimumTranscriptionSamples`.
+
+  @Test("custom ceiling: below it, all-zero is not yet confident")
+  func customCeilingBelowIsNotConfident() {
+    let ceiling = 48_000
+    let detector = ingestWhole([Float](repeating: 0, count: ceiling - 1))
+    #expect(!detector.isAllZeroFromStart(ceilingSamples: ceiling))
+    // ...and the SAME samples DO trip the shipping 1.0s ceiling, proving the
+    // parameter is what moved the verdict rather than the sample shape.
+    #expect(detector.isAllZeroFromStart(ceilingSamples: threshold))
+  }
+
+  @Test("custom ceiling: exactly at it, all-zero fires")
+  func customCeilingAtFires() {
+    let ceiling = 48_000
+    let detector = ingestWhole([Float](repeating: 0, count: ceiling))
+    #expect(detector.isAllZeroFromStart(ceilingSamples: ceiling))
+  }
+
+  @Test("custom ceiling: one sample above it, all-zero fires")
+  func customCeilingAboveFires() {
+    let ceiling = 48_000
+    let detector = ingestWhole([Float](repeating: 0, count: ceiling + 1))
+    #expect(detector.isAllZeroFromStart(ceilingSamples: ceiling))
+  }
+
+  /// THE case the #1788 fix exists to protect: a link that wakes up late.
+  /// Once any real sample arrives, all-zero-from-start must be false FOREVER
+  /// for that generation, at every ceiling — otherwise a woken microphone
+  /// could still be aborted later in the same take.
+  @Test("a late wake makes all-zero-from-start permanently false at every ceiling")
+  func lateWakeIsPermanentlyNotAllZero() {
+    let ceiling = 48_000
+    var samples = [Float](repeating: 0, count: ceiling - 1)
+    samples.append(0.05)  // the link comes up
+    samples.append(contentsOf: [Float](repeating: 0, count: ceiling * 2))  // then quiet again
+    let detector = ingestWhole(samples)
+    #expect(!detector.isAllZeroFromStart(ceilingSamples: threshold))
+    #expect(!detector.isAllZeroFromStart(ceilingSamples: ceiling))
+    #expect(!detector.isAllZeroFromStart(ceilingSamples: 1))
+  }
+
+  // MARK: - Zero-prefix diagnostic (#1788)
+
+  @Test("zero prefix is nil while the capture is still entirely zeros")
+  func zeroPrefixNilWhileAllZero() {
+    let detector = ingestWhole([Float](repeating: 0, count: 5_000))
+    #expect(detector.zeroPrefixSampleCount == nil)
+  }
+
+  @Test("zero prefix reports the leading zero count once real audio arrives")
+  func zeroPrefixReportsLeadingZeroCount() {
+    var samples = [Float](repeating: 0, count: 9_600)  // 600ms at 16kHz
+    samples.append(0.02)
+    let detector = ingestWhole(samples)
+    #expect(detector.zeroPrefixSampleCount == 9_600)
+  }
+
+  @Test("zero prefix latches the FIRST wake, not a later one")
+  func zeroPrefixLatchesFirstWake() {
+    var samples = [Float](repeating: 0, count: 1_000)
+    samples.append(0.02)
+    samples.append(contentsOf: [Float](repeating: 0, count: 5_000))
+    samples.append(0.03)
+    let detector = ingestWhole(samples)
+    #expect(detector.zeroPrefixSampleCount == 1_000)
+  }
+
+  @Test("zero prefix is 0 when audio flows from the very first sample")
+  func zeroPrefixZeroWhenImmediatelyLive() {
+    let detector = ingestWhole([Float](repeating: 0.02, count: 1_000))
+    #expect(detector.zeroPrefixSampleCount == 0)
+  }
+
+  @Test("zero prefix is identical whole vs chunked (buffer boundaries must not matter)")
+  func zeroPrefixSurvivesChunking() {
+    var samples = [Float](repeating: 0, count: 7_777)
+    samples.append(0.02)
+    samples.append(contentsOf: [Float](repeating: 0.01, count: 500))
+    let whole = ingestWhole(samples)
+    let chunked = ingestChunked(samples, chunkSize: 513)  // deliberately not tile-aligned
+    #expect(whole.zeroPrefixSampleCount == chunked.zeroPrefixSampleCount)
+    #expect(whole.zeroPrefixSampleCount == 7_777)
   }
 }

--- a/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
+++ b/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
@@ -274,4 +274,17 @@ struct CaptureStopMetadataGapTests {
       nativeRateHz: 24000, ringDropCount: 1, preRollGapCount: 3)
     #expect(both.inputTimelineGapCount == 4)
   }
+
+  @Test("the catch-all lost-chunk count is a gap too (r7)")
+  func lostChunkCountsAsAGap() {
+    // r7 found TWO more silent exits on the pop->route path: buffer allocation
+    // failure under memory pressure, and an unreadable converted buffer. Rather
+    // than add a counter per cause — the list had already reopened in r3 and r5 —
+    // `ForwardOutcome` now forces every exit to declare loss and this one counter
+    // catches all of them, including exits not yet written.
+    let lost = CaptureStopMetadata(nativeRateHz: 24000, lostChunkCount: 2)
+    #expect(lost.inputTimelineGapCount == 2)
+    #expect(lost.ringDropCount == 0)
+    #expect(lost.converterErrorCount == 0)
+  }
 }

--- a/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
+++ b/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
@@ -185,18 +185,21 @@ struct CaptureStopMetadataTransportTests {
     // Absent-means-zero keeps the boundary decoding instead of throwing.
     #expect(decoded.renderFailureCount == 0)
     #expect(decoded.oversizedSliceCount == 0)
+    #expect(decoded.preRollGapCount == 0)
     #expect(decoded.inputTimelineGapCount == 1)  // the one ring drop above
   }
 
-  @Test("#1788: the two new gap counters survive the round trip")
+  @Test("#1788: the new gap counters survive the round trip")
   func gapCountersRoundTrip() throws {
     let original = CaptureStopMetadata(
-      nativeRateHz: 48000, renderFailureCount: 2, oversizedSliceCount: 5)
+      nativeRateHz: 48000, renderFailureCount: 2, oversizedSliceCount: 5,
+      preRollGapCount: 7)
     let data = try JSONEncoder().encode(original)
     let decoded = try JSONDecoder().decode(CaptureStopMetadata.self, from: data)
     #expect(decoded == original)
     #expect(decoded.renderFailureCount == 2)
     #expect(decoded.oversizedSliceCount == 5)
+    #expect(decoded.preRollGapCount == 7)
   }
 }
 
@@ -249,5 +252,26 @@ struct CaptureStopMetadataGapTests {
       nativeRateHz: 16000, ringDropCount: 4, converterErrorCount: 3,
       zeroOutputCount: 9, renderFailureCount: 2, oversizedSliceCount: 1)
     #expect(messy.inputTimelineGapCount == 10)  // 4+3+2+1, zeroOutput excluded
+  }
+
+  @Test("a gap carried in from idle pre-roll still counts (r4: the WINDOW)")
+  func preRollGapIsInsideTheWakeWindow() {
+    // The four session counters are reset before the retained pre-roll is
+    // drained, and a measured wake begins inside that pre-roll. If the carry-in
+    // were excluded, every one of those gaps would report as `exact` — the
+    // instrument confidently wrong in exactly the window it measures. Cloud
+    // review found this AFTER three rounds of edge-hunting, so the window is
+    // frozen here separately from the edge list.
+    let carried = CaptureStopMetadata(nativeRateHz: 24000, preRollGapCount: 2)
+    #expect(carried.inputTimelineGapCount == 2)
+    #expect(carried.ringDropCount == 0)  // not folded into a session counter
+    #expect(carried.converterErrorCount == 0)
+  }
+
+  @Test("pre-roll carry-in adds to session gaps rather than replacing them")
+  func preRollGapAddsToSessionGaps() {
+    let both = CaptureStopMetadata(
+      nativeRateHz: 24000, ringDropCount: 1, preRollGapCount: 3)
+    #expect(both.inputTimelineGapCount == 4)
   }
 }

--- a/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
+++ b/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
@@ -181,5 +181,73 @@ struct CaptureStopMetadataTransportTests {
     let decoded = try JSONDecoder().decode(CaptureStopMetadata.self, from: data)
     #expect(decoded.nativeChannelCount == nil)
     #expect(decoded.nativeRateHz == 24000)
+    // #1788: the same blob predates the two gap counters, which are NOT optional.
+    // Absent-means-zero keeps the boundary decoding instead of throwing.
+    #expect(decoded.renderFailureCount == 0)
+    #expect(decoded.oversizedSliceCount == 0)
+    #expect(decoded.inputTimelineGapCount == 1)  // the one ring drop above
+  }
+
+  @Test("#1788: the two new gap counters survive the round trip")
+  func gapCountersRoundTrip() throws {
+    let original = CaptureStopMetadata(
+      nativeRateHz: 48000, renderFailureCount: 2, oversizedSliceCount: 5)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(CaptureStopMetadata.self, from: data)
+    #expect(decoded == original)
+    #expect(decoded.renderFailureCount == 2)
+    #expect(decoded.oversizedSliceCount == 5)
+  }
+}
+
+// MARK: - #1788 input-timeline gap enumeration
+
+/// The wake instrument reads a sample INDEX as an elapsed time, which holds only
+/// while the stream lost nothing. `inputTimelineGapCount` is the single owner of
+/// "did it lose anything", so these tests pin every edge it must count — and the
+/// one it must not. Cloud review found a fresh missing edge in three consecutive
+/// rounds; the point of a freeze test here is that a fourth edge added without a
+/// line in the sum fails loudly instead of silently under-reporting.
+@Suite("CaptureStopMetadata — input-timeline gap enumeration (#1788)")
+struct CaptureStopMetadataGapTests {
+
+  @Test("a clean session reports zero gaps, so a wake is exact")
+  func cleanSessionHasNoGaps() {
+    let clean = CaptureStopMetadata(nativeRateHz: 24000)
+    #expect(clean.inputTimelineGapCount == 0)
+  }
+
+  @Test("each lossy edge contributes exactly one gap")
+  func everyLossyEdgeCounts() {
+    #expect(
+      CaptureStopMetadata(nativeRateHz: nil, ringDropCount: 1)
+        .inputTimelineGapCount == 1)
+    #expect(
+      CaptureStopMetadata(nativeRateHz: nil, converterErrorCount: 1)
+        .inputTimelineGapCount == 1)
+    #expect(
+      CaptureStopMetadata(nativeRateHz: nil, renderFailureCount: 1)
+        .inputTimelineGapCount == 1)
+    #expect(
+      CaptureStopMetadata(nativeRateHz: nil, oversizedSliceCount: 1)
+        .inputTimelineGapCount == 1)
+  }
+
+  @Test("a zero-frame converter output is NOT a gap — the input is emitted later")
+  func zeroConverterOutputIsNotAGap() {
+    // Cloud review r3 named this as a third loss source. It is not one: a priming
+    // call consumes its input and emits it on the following call, so the output
+    // timeline stays continuous. Counting it would report a floor on every
+    // session, since priming legitimately yields one.
+    let primed = CaptureStopMetadata(nativeRateHz: 24000, zeroOutputCount: 1)
+    #expect(primed.inputTimelineGapCount == 0)
+  }
+
+  @Test("gaps sum across edges rather than saturating at one")
+  func gapsSumAcrossEdges() {
+    let messy = CaptureStopMetadata(
+      nativeRateHz: 16000, ringDropCount: 4, converterErrorCount: 3,
+      zeroOutputCount: 9, renderFailureCount: 2, oversizedSliceCount: 1)
+    #expect(messy.inputTimelineGapCount == 10)  // 4+3+2+1, zeroOutput excluded
   }
 }

--- a/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
+++ b/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
@@ -226,14 +226,32 @@ struct CaptureStopMetadataGapTests {
       CaptureStopMetadata(nativeRateHz: nil, ringDropCount: 1)
         .inputTimelineGapCount == 1)
     #expect(
-      CaptureStopMetadata(nativeRateHz: nil, converterErrorCount: 1)
-        .inputTimelineGapCount == 1)
-    #expect(
       CaptureStopMetadata(nativeRateHz: nil, renderFailureCount: 1)
         .inputTimelineGapCount == 1)
     #expect(
       CaptureStopMetadata(nativeRateHz: nil, oversizedSliceCount: 1)
         .inputTimelineGapCount == 1)
+    #expect(
+      CaptureStopMetadata(nativeRateHz: nil, lostChunkCount: 1)
+        .inputTimelineGapCount == 1)
+  }
+
+  @Test("a converter error is a SUBSET of lost chunks, never a second gap (r8)")
+  func converterErrorIsNotAnIndependentAddend() {
+    // Every converter failure also returns `.lost`, so the real pairing is
+    // (converterErrorCount: 1, lostChunkCount: 1) for ONE lost chunk. Summing both
+    // reported 2 — the double count r7's catch-all introduced beside the per-cause
+    // counters. The gap total must follow death points, not causes.
+    let oneChunkLostToConverter = CaptureStopMetadata(
+      nativeRateHz: 24000, converterErrorCount: 1, lostChunkCount: 1)
+    #expect(oneChunkLostToConverter.inputTimelineGapCount == 1)
+    // And the diagnostic breakdown is still available on its own.
+    #expect(oneChunkLostToConverter.converterErrorCount == 1)
+    // A converter error alone contributes nothing: it cannot occur without the
+    // matching lost chunk, so this shape only appears in a hand-built fixture.
+    #expect(
+      CaptureStopMetadata(nativeRateHz: nil, converterErrorCount: 1)
+        .inputTimelineGapCount == 0)
   }
 
   @Test("a zero-frame converter output is NOT a gap — the input is emitted later")
@@ -248,10 +266,14 @@ struct CaptureStopMetadataGapTests {
 
   @Test("gaps sum across edges rather than saturating at one")
   func gapsSumAcrossEdges() {
+    // 3 of the lost chunks were converter failures, so `converterErrorCount: 3`
+    // describes part of `lostChunkCount: 5` rather than adding to it.
     let messy = CaptureStopMetadata(
       nativeRateHz: 16000, ringDropCount: 4, converterErrorCount: 3,
-      zeroOutputCount: 9, renderFailureCount: 2, oversizedSliceCount: 1)
-    #expect(messy.inputTimelineGapCount == 10)  // 4+3+2+1, zeroOutput excluded
+      zeroOutputCount: 9, renderFailureCount: 2, oversizedSliceCount: 1,
+      lostChunkCount: 5)
+    // 4 + 2 + 1 + 5; zeroOutput and converterError both excluded.
+    #expect(messy.inputTimelineGapCount == 12)
   }
 
   @Test("a gap carried in from idle pre-roll still counts (r4: the WINDOW)")


### PR DESCRIPTION
Part of #1788.

Makes the Bluetooth microphone wake-time instrument a permanent DEBUG capability, and lays the single-owner seam the #1788 fix needs.

## Why

Bluetooth capture delivers exact-zero frames while the A2DP→SCO/HFP voice link negotiates. How long that lasts was **structurally unobservable**: the mid-take all-zero abort fires at 1.0s, so any wake slower than the ceiling is censored by the very check we wanted to measure. #1788 began by re-deriving this timing by hand; this makes it a permanent capability so the next investigation does not have to.

Founder decision 2026-07-29: keep this rather than revert the measurement scaffolding.

## What

Three pieces, **no production behaviour change**:

1. `DeadAirStreamingDetector.isAllZeroFromStart` takes the ceiling as a parameter instead of reading `AudioConstants`. The struct stays sample-only — no transport, device or policy knowledge — and its boundary becomes unit-testable without a capture manager.
2. `AudioCaptureManager.allZeroCeilingSamples` is the single owner of what the ceiling is, with **one code path in every configuration**. Release, and DEBUG with no override, is `minimumTranscriptionSamples` (16,000 = 1.0s) — byte-identical to shipped behaviour. DEBUG alone consults `EWDebugAllZeroCeilingSamples`; non-positive or absent yields the shipping value, so an unconfigured DEBUG build cannot diverge from production.
3. `ZERO_PREFIX_MEASURE` logs the exact-zero prefix once per capture generation. DEBUG-only, `app.log` only — never PostHog, never Sentry, never the network. A duration, a sample count and a transport label, so it is inside the privacy boundary by construction.

An earlier draft forked the predicate with `#if DEBUG` / `#else`, computing the verdict two different ways. That divergence is the kind that rots until the two disagree; replaced by the single-owner shape above.

## Hot-path cost, quantified

`ingest` gains one short-circuiting compare per sample to latch the first non-zero index. At 16 kHz that is ~16,000 extra integer compares per second of audio, against a loop already doing abs + compare + multiply-add + compare + increment per sample. Well under the 100ms negligible threshold; capture is not the pipeline bottleneck.

## Validation

- Full suite: **4,391 tests** pass. Detector suite 22 (13 migrated to the parameterised predicate, 9 new); manager suite 6.
- **Both configurations** exercised: Debug lane 6 tests, Release lane 6 tests, counts read from `Test run with N tests`.
- Release compile of the DEBUG-stripped path: exit 0.
- Both eval runner packages build — they depend on `EnviousWisprCore` and no CI workflow compiles them (#1836).
- **Live hardware:** the instrument produced 8 cold-radio wake samples on AirPods Pro (24 kHz path) — 500 / 600 / 606 / 644 / 659 / 719 / 719 / 794 ms, median 652. Every sample is under the shipping 1,000ms cutoff, which is the finding: the cutoff sits on the upper shoulder of the wake distribution, so failure is intermittent rather than constant.
- **Two-arm fault-injection control:** an injected permanently-dead mic terminated at 1.04s with the shipping ceiling and 3.04s with a 3.0s override — same `zeroSignal` terminal both times, proving the honest failure survives a raised ceiling.

## Review

Codex r1 raised one P1: the debug-override test would fail the Release lane, which strips `#if DEBUG`. Real defect. Fixed as a **mirror pair** rather than by gating alone — gating would have deleted Release coverage entirely. DEBUG asserts the override is honoured; Release asserts it does **nothing**, which is the guard that catches a diagnostic knob leaking into a shipped build. That case was untested before.

The reviewer's stated mechanism was **not** adopted: it claimed CI runs the full Release suite after merge. No workflow invokes `scripts/xcode-test.sh` (`grep -rn "xcode-test.sh" .github/workflows/` returns nothing) — the Release lane exists and is run manually. Real defect, wrong explanation, recorded so a future session does not infer main was failing.

## Notes for the reviewer

- Two false greens were caught while validating and are worth knowing: `swift build --target` does **not** compile the test target, so the build stayed green while 11 test call sites were broken by the signature change; and an identifier sweep run inside a worktree silently finds nothing in `docs/` and `.claude/`, which are gitignored and therefore absent there.
- The `#1788` production fix is deliberately **not** in this PR. It is one branch inside `allZeroCeilingSamples` and awaits founder Gate 2.
