### PR TITLE
fix(audio): give Bluetooth 3.0s to wake before calling the mic dead (#1788)

### DIFF
--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -254,7 +254,14 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// input-device setting change (which `PipelineSettingsSync` applies for the
   /// NEXT recording while the current source keeps its old device) cannot make a
   /// later failure-terminal telemetry read report the wrong transport. Nil
-  /// before the first resolution. Telemetry-only observation.
+  /// before the first resolution.
+  ///
+  /// NO LONGER TELEMETRY-ONLY (#1788): `effective` is now a CAPTURE-POLICY input,
+  /// selecting the mid-take all-zero ceiling via `allZeroCeilingSamples`. The
+  /// freezing described above is what makes that safe — the ceiling is chosen from
+  /// the route the session actually bound, not from a live re-read that a mid-take
+  /// device switch could have already changed. Nil still falls to the shipping 1.0s
+  /// ceiling, so a session that never resolved behaves exactly as before.
   public private(set) var currentResolvedRoute: ResolvedRouteTransports?
 
   /// Adopt a fresh route decision: freeze it plus its derived transports (using
@@ -305,7 +312,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// consulted, never in how the verdict is computed (#1788).
   ///
   /// Release, and DEBUG with no override set, is `minimumTranscriptionSamples`
-  /// (16,000 = 1.0s), byte-identical to shipped behaviour.
+  /// (16,000 = 1.0s) on every transport EXCEPT Bluetooth, which gets 3.0s (#1788 —
+  /// see `allZeroFromStartCeilingSamples(forEffectiveTransport:)` for why, and note
+  /// the DEBUG override still wins over both so a measurement run can see past
+  /// either).
   ///
   /// The DEBUG override exists because a Bluetooth wake slower than the ceiling is
   /// otherwise CENSORED — the take aborts before the wake completes, so the tail we
@@ -323,7 +333,33 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         forKey: "EWDebugAllZeroCeilingSamples")
       if override > 0 { return override }
     #endif
-    return AudioConstants.minimumTranscriptionSamples
+    return Self.allZeroFromStartCeilingSamples(
+      forEffectiveTransport: currentResolvedRoute?.effective)
+  }
+
+  /// THE #1788 FIX, and the only transport conditional in it.
+  ///
+  /// Bluetooth alone negotiates a voice link before audio flows, so it alone tolerates
+  /// 3.0s of exact silence mid-take instead of 1.0s. Every other value — `"built_in"`,
+  /// `"usb"`, `"unknown"`, and `nil` — returns the shipping ceiling, so a wired user's
+  /// behaviour is byte-identical to before and an UNREADABLE transport fails to
+  /// today's behaviour rather than to the longer one.
+  ///
+  /// Pure and static so the wired-unchanged guarantee is unit-testable without opening
+  /// real hardware: `currentResolvedRoute` is `private(set)` with only private
+  /// production writers, so a test cannot inject a route through the manager.
+  ///
+  /// Scope, deliberately narrow: this governs the MID-TAKE all-zero abort only.
+  /// `RecordingSessionKernel.classifyZeroSignalAtStop` is untouched and keeps 1.0s on
+  /// every transport, so a genuinely dead Bluetooth mic released before 3.0s still
+  /// ends with the same honest failure. `.becameZeroMidCapture` also keeps its own
+  /// threshold — do not "harmonise" the two.
+  nonisolated static func allZeroFromStartCeilingSamples(
+    forEffectiveTransport effectiveTransport: String?
+  ) -> Int {
+    effectiveTransport == "bluetooth"
+      ? AudioConstants.bluetoothAllZeroMidTakeCeilingSamples
+      : AudioConstants.minimumTranscriptionSamples
   }
 
   #if DEBUG

--- a/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
+++ b/Sources/EnviousWisprAudio/ResolvedRouteTransports.swift
@@ -1,18 +1,30 @@
 import CoreAudio
 
-/// A pure, per-recording OBSERVATION of the resolver's route decision, derived
-/// into the low-cardinality transport facts the telemetry layer emits (#1376,
-/// Bluetooth-capture epic Phase 1). Never a control input — nothing branches
-/// capture on it; both sinks (`dictation.completed` PostHog + `SentryAudioExtras`)
-/// read this one value instead of re-deriving from raw inputs
+/// A pure, per-recording derivation of the resolver's route decision into the
+/// low-cardinality transport facts the telemetry layer emits (#1376,
+/// Bluetooth-capture epic Phase 1). Both sinks (`dictation.completed` PostHog +
+/// `SentryAudioExtras`) read this one value instead of re-deriving from raw inputs
 /// (`telemetry-observes-resolved-value-deny-by-default`).
+///
+/// **`effective` IS A CONTROL INPUT as of #1788** — it selects the mid-take all-zero
+/// ceiling in `AudioCaptureManager.allZeroFromStartCeilingSamples(forEffectiveTransport:)`,
+/// so Bluetooth tolerates 3.0s of silence where every other transport keeps 1.0s.
+/// This header previously said the type was never a control input; that is no longer
+/// true and a reader trusting it would conclude the branch can never fire. The other
+/// fields remain observation-only. Anything that changes what `effective` reports now
+/// changes capture BEHAVIOUR, not just telemetry.
 ///
 /// `routeResolutionSource` is `"app_derived"` unless the caller supplies the
 /// actual transport reported by the bound capture source.
 public struct ResolvedRouteTransports: Sendable, Equatable {
   /// Transport of the user's picked device, or `"unknown"` on Auto / unmappable.
   public let selected: String
-  /// Transport the decision binds (built-in for the capture-session path today).
+  /// Transport the decision actually BINDS: the bound source's own reported transport
+  /// when readable, otherwise the app-derived one, otherwise `"unknown"`. The former
+  /// comment here said "built-in for the capture-session path today" — that path is
+  /// retired and `.halDeviceInput` is the only source type, so the old wording both
+  /// described dead code and implied this can only ever be built-in. It cannot: the
+  /// #1788 Bluetooth ceiling branches on this exact string being `"bluetooth"`.
   public let effective: String
   /// `CaptureRouteReason.rawValue` — the machine-readable route reason.
   public let routeReason: String

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -229,6 +229,29 @@ public enum AudioConstants {
   /// Minimum samples required for valid transcription (1 second).
   public static let minimumTranscriptionSamples: Int = 16000
 
+  /// Mid-take all-exact-zero ceiling for a BLUETOOTH capture (#1788), 3.0s.
+  ///
+  /// Distinct from `minimumTranscriptionSamples`, which stays 1.0s and continues to
+  /// govern BOTH every non-Bluetooth transport mid-take AND the stop-time classifier
+  /// on all transports. Bluetooth alone gets the longer bar because it alone
+  /// NEGOTIATES before audio flows: the A2DP->SCO/HFP handshake delivers exact zeros
+  /// for a measured 1-3s (#1441, 1,109 cold presses) before real samples arrive. No
+  /// wired or USB device does this, which is why the ceiling is transport-scoped
+  /// rather than raised for everyone.
+  ///
+  /// Evidence for 3.0s specifically: 9 instrumented cold-radio presses on AirPods Pro
+  /// measured 500/599/600/606/644/659/719/719/794ms (median 644, max 794) — every one
+  /// UNDER today's 1.0s cutoff, which is why the failure is an intermittent 14.55%
+  /// rather than constant: the cutoff sits on the upper shoulder of the distribution
+  /// and production aborts cluster at a median 974ms, just past where local sampling
+  /// stops. The upper tail comes from founder field observation ("sometimes two
+  /// seconds, never more"), so 3.0s carries ~50% headroom over the worst reported
+  /// case and ~3.8x the measured local max.
+  ///
+  /// Rollback is this one value: setting it to 16_000 restores byte-identical prior
+  /// behaviour on every transport without touching another line.
+  public static let bluetoothAllZeroMidTakeCeilingSamples: Int = 48_000
+
 }
 
 // MARK: - Crash-Recovery Constants

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
@@ -90,6 +90,50 @@ struct AudioCaptureManagerDeadAirLatchTests {
     }
   }
 
+  // MARK: - #1788 — the Bluetooth-only ceiling
+
+  /// The fix: Bluetooth alone waits 3.0s for the link to wake.
+  @Test("bluetooth gets the 3.0s ceiling")
+  func bluetoothGetsTheLongerCeiling() {
+    #expect(
+      AudioCaptureManager.allZeroFromStartCeilingSamples(forEffectiveTransport: "bluetooth")
+        == AudioConstants.bluetoothAllZeroMidTakeCeilingSamples)
+    #expect(
+      AudioCaptureManager.allZeroFromStartCeilingSamples(forEffectiveTransport: "bluetooth")
+        == 48_000)
+  }
+
+  /// THE WIRED-UNCHANGED GUARANTEE, asserted rather than assumed. This is the test
+  /// that must be GREEN on both pre-fix and post-fix code — that is what proves the
+  /// change is Bluetooth-scoped instead of a universal ceiling raise, which is the
+  /// design coverage review rejected. A nil or unreadable transport falls to TODAY's
+  /// behaviour, never to the longer one: an unknown route must not silently buy
+  /// every user three seconds of tolerated silence.
+  @Test("every non-bluetooth transport, including nil and unknown, keeps 1.0s")
+  func everyOtherTransportKeepsTheShippingCeiling() {
+    for transport in ["built_in", "usb", "unknown", "", "Bluetooth", "BLUETOOTH"] {
+      #expect(
+        AudioCaptureManager.allZeroFromStartCeilingSamples(forEffectiveTransport: transport)
+          == AudioConstants.minimumTranscriptionSamples,
+        "\(transport) must keep the shipping ceiling")
+    }
+    #expect(
+      AudioCaptureManager.allZeroFromStartCeilingSamples(forEffectiveTransport: nil)
+        == AudioConstants.minimumTranscriptionSamples)
+  }
+
+  /// The two ceilings must stay DISTINCT constants. A future maintainer collapsing
+  /// them would silently apply 3.0s everywhere (or 1.0s to Bluetooth), which is the
+  /// exact regression the transport branch exists to prevent.
+  @Test("the two ceilings are separate values, 1.0s and 3.0s")
+  func ceilingsAreDistinct() {
+    #expect(AudioConstants.minimumTranscriptionSamples == 16_000)
+    #expect(AudioConstants.bluetoothAllZeroMidTakeCeilingSamples == 48_000)
+    #expect(
+      AudioConstants.bluetoothAllZeroMidTakeCeilingSamples
+        > AudioConstants.minimumTranscriptionSamples)
+  }
+
   // The override exists ONLY in DEBUG, so these two tests are mirror images and
   // both must be compiled — asserting the override works where it exists, and
   // asserting it is genuinely ABSENT where it must not exist. A single

--- a/Tests/EnviousWisprTests/Audio/DeadAirStreamingDetectorTests.swift
+++ b/Tests/EnviousWisprTests/Audio/DeadAirStreamingDetectorTests.swift
@@ -140,7 +140,9 @@ struct DeadAirStreamingDetectorTests {
     let chunked = ingestChunked(samples, chunkSize: 500)
 
     #expect(whole.meaningfulSignalSeen == chunked.meaningfulSignalSeen)
-    #expect(whole.isAllZeroFromStart(ceilingSamples: threshold) == chunked.isAllZeroFromStart(ceilingSamples: threshold))
+    #expect(
+      whole.isAllZeroFromStart(ceilingSamples: threshold)
+        == chunked.isAllZeroFromStart(ceilingSamples: threshold))
     #expect(whole.isBecameZeroMidCapture == chunked.isBecameZeroMidCapture)
     #expect(whole.totalSampleCount == chunked.totalSampleCount)
     #expect(whole.consecutiveExactZeroSuffix == chunked.consecutiveExactZeroSuffix)
@@ -162,7 +164,9 @@ struct DeadAirStreamingDetectorTests {
     let samples = [Float](repeating: 0, count: threshold + 500)
     let whole = ingestWhole(samples)
     let chunked = ingestChunked(samples, chunkSize: 333)  // deliberately not a 640 divisor
-    #expect(whole.isAllZeroFromStart(ceilingSamples: threshold) == chunked.isAllZeroFromStart(ceilingSamples: threshold))
+    #expect(
+      whole.isAllZeroFromStart(ceilingSamples: threshold)
+        == chunked.isAllZeroFromStart(ceilingSamples: threshold))
     #expect(whole.isAllZeroFromStart(ceilingSamples: threshold))
   }
 
@@ -304,5 +308,33 @@ struct DeadAirStreamingDetectorTests {
     let chunked = ingestChunked(samples, chunkSize: 513)  // deliberately not tile-aligned
     #expect(whole.zeroPrefixSampleCount == chunked.zeroPrefixSampleCount)
     #expect(whole.zeroPrefixSampleCount == 7_777)
+  }
+
+  // MARK: - #1788 sibling-threshold freeze
+
+  /// THIS TEST EXISTS TO STOP A FUTURE MAINTAINER "HARMONISING" THE TWO THRESHOLDS.
+  /// #1788 raises the all-zero-FROM-START ceiling on Bluetooth to 3.0s, and the two
+  /// predicates now read as inconsistent — one takes a ceiling parameter, the other
+  /// keeps a hard 1.0s. That is deliberate and they answer different questions:
+  /// `isAllZeroFromStart` asks "did audio ever start" (Bluetooth negotiates, so it
+  /// needs longer), while `isBecameZeroMidCapture` asks "did working audio DIE"
+  /// (nothing negotiates mid-stream, so the longer bar would only delay a real
+  /// failure the user is already living through).
+  @Test("#1788: becameZeroMidCapture keeps 1.0s and ignores the all-zero ceiling")
+  func becameZeroMidCaptureIsNotAffectedByTheCeiling() {
+    var samples: [Float] = [0.5, 0.5, 0.5]  // meaningful signal first
+    samples.append(
+      contentsOf: [Float](repeating: 0, count: AudioConstants.minimumTranscriptionSamples))
+    let detector = ingestWhole(samples)
+
+    // Fires at 1.0s of trailing zeros, well under the 3.0s Bluetooth ceiling...
+    #expect(detector.isBecameZeroMidCapture)
+    // ...and passing that ceiling to the SIBLING predicate changes nothing here,
+    // because real signal was seen, so `isAllZeroFromStart` is permanently false.
+    #expect(
+      !detector.isAllZeroFromStart(
+        ceilingSamples: AudioConstants.bluetoothAllZeroMidTakeCeilingSamples))
+    #expect(
+      !detector.isAllZeroFromStart(ceilingSamples: AudioConstants.minimumTranscriptionSamples))
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelDeadAirFloorTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelDeadAirFloorTests.swift
@@ -217,4 +217,34 @@ struct RecordingSessionKernelDeadAirFloorTests {
       [SpeechSegment(startSample: 20_000, endSample: 24_000)], to: 8_000)
     #expect(result.isEmpty)
   }
+
+  // MARK: - #1788 stop-time parity: the honest failure survives the longer ceiling
+
+  /// THE TEST THAT PROVES A DEAD BLUETOOTH MIC STILL FAILS HONESTLY. #1788 raises the
+  /// MID-TAKE ceiling to 3.0s on Bluetooth, and the obvious worry is that a genuinely
+  /// dead mic released before 3.0s now slips through silently. It does not: the
+  /// stop-time classifier is untouched and keeps `minimumTranscriptionSamples` on
+  /// EVERY transport, so a 2.5s all-zero capture ended by release still classifies as
+  /// `.allZeroFromStart` and reaches the same terminal it always did.
+  @Test("#1788: a 2.5s all-zero capture still classifies at stop, below the 3.0s ceiling")
+  func stopTimeClassifierUnaffectedByBluetoothCeiling() {
+    let twoPointFiveSeconds = 40_000  // < 48_000, the new Bluetooth mid-take ceiling
+    #expect(twoPointFiveSeconds < AudioConstants.bluetoothAllZeroMidTakeCeilingSamples)
+    let allZero = [Float](repeating: 0, count: twoPointFiveSeconds)
+    #expect(RecordingSessionKernel.classifyZeroSignalAtStop(allZero) == .allZeroFromStart)
+  }
+
+  /// The floor is unchanged too: shorter than 1.0s still classifies as nothing, on
+  /// every transport. Pins that #1788 moved the mid-take ceiling ONLY.
+  @Test("#1788: the stop-time floor is still 1.0s, not the Bluetooth ceiling")
+  func stopTimeFloorIsStillTheShippingMinimum() {
+    let justUnderOneSecond = AudioConstants.minimumTranscriptionSamples - 1
+    #expect(
+      RecordingSessionKernel.classifyZeroSignalAtStop(
+        [Float](repeating: 0, count: justUnderOneSecond)) == nil)
+    #expect(
+      RecordingSessionKernel.classifyZeroSignalAtStop(
+        [Float](repeating: 0, count: AudioConstants.minimumTranscriptionSamples))
+        == .allZeroFromStart)
+  }
 }


### PR DESCRIPTION
## What this fixes

Bluetooth cold presses lose **14.55%** of dictations, against 1.6% built-in and 0.6% USB. The mid-take dead-air detector aborts a take after 1.0s of exact-zero samples with no spin-up grace, and the A2DP→SCO/HFP handshake delivers exact zeros for 1-3s before real audio arrives. The abort fires *inside the handshake*, on the one transport that negotiates before audio flows.

## The change

One transport conditional over one new constant:

```
allZeroFromStartCeilingSamples(forEffectiveTransport:)
  "bluetooth"                          -> 48_000  (3.0s)
  everything else, incl. nil/"unknown" -> 16_000  (1.0s, unchanged)
```

Pure and static, because `currentResolvedRoute` is `private(set)` with only private production writers — otherwise the wired-unchanged guarantee could not be tested without real hardware.

## Why 3.0s

Nine instrumented cold-radio presses on AirPods Pro: **500 / 599 / 600 / 606 / 644 / 659 / 719 / 719 / 794 ms** (median 644, max 794). Every one is *under* today's cutoff — that is the finding. The cutoff sits on the upper shoulder of the distribution, so most presses squeeze under and unlucky ones die, which is why failure is an intermittent 14.55% rather than constant. Production aborts cluster at a median 974ms, just past where local sampling stops.

The upper tail comes from founder field observation ("sometimes two seconds, never more"), so 3.0s carries ~50% headroom over the worst reported case and ~3.8× the measured local max.

## Why Bluetooth only

Coverage review killed the universal version: it would make every wired user wait 3s on a genuinely dead mic to fix a problem only Bluetooth has. Nothing else negotiates a link before audio flows.

## The honest failure still works

`classifyZeroSignalAtStop` is **untouched** and keeps 1.0s on every transport, so a dead Bluetooth mic released before 3.0s still fails the same way — frozen by a new test. `.becameZeroMidCapture` keeps its own 1.0s bar, with a freeze test whose comment explains why the two must not be harmonised: one asks *did audio ever start* (Bluetooth negotiates), the other *did working audio die* (nothing negotiates mid-stream).

Fault injection confirmed a permanently dead mic terminates at 1.04s under the old ceiling and 3.04s under the new one, identical failure both times. Nothing hangs.

## Two-way control

Expectation declared before running. Setting the constant to its documented rollback value of `16_000`:

| test | rollback arm | fixed arm |
|---|---|---|
| bluetooth gets the 3.0s ceiling | **RED** | GREEN |
| the two ceilings are separate values | **RED** | GREEN |
| every non-bluetooth transport, incl. nil/unknown, keeps 1.0s | GREEN | GREEN |
| detector sibling-threshold freeze | GREEN | GREEN |

The wired arm staying green on **both** is the control proving this is Bluetooth-scoped rather than a universal raise. One prediction was wrong and is recorded rather than dropped: I expected both stop-time parity tests green on both arms, and one goes red on the rollback arm — but only on its own fixture-validity guard (2.5s is not below a 1.0s ceiling), never on the classification claim, which held on both. That run also verified the documented one-value rollback works.

## Live UAT on real hardware

Wiring proof, cold radio, dev build verified by executable path:

```
transport=bluetooth wake_ms=579 wake_is=stream_measured timeline_gaps=0 ceiling_samples=48000
transport=built_in  wake_ms=0   wake_is=floor            timeline_gaps=0 ceiling_samples=16000
```

Same binary, both transports. `ceiling_samples` proves the branch fires on hardware and that the wired path is untouched.

**Outstanding:** the plan's 30-cold-presses-per-rate-path acceptance run has not been done — that is founder time, not automatable. `wispr_eyes.test_recording()` drives TTS through the default input and cannot synthesise a real A2DP→SCO negotiation past a 30-second teardown.

## Three stale comments corrected

This change makes a previously observation-only type load-bearing, and a comment justifying a design carries the plan's evidence burden:

- `ResolvedRouteTransports` header said "never a control input" — `effective` now selects a capture ceiling.
- `effective`'s own comment said "built-in for the capture-session path today" — that path is retired, and the wording implied the new branch can never fire.
- `currentResolvedRoute` said "telemetry-only observation" — it is now capture policy, and the existing freeze-at-resolve-time is what makes that safe.

## Blast radius

**Touched:** one constant, one conditional, three comments, six tests.
**Untouched:** stop-time classifier, `.becameZeroMidCapture`, the FSM and all exit routing, warm-engine policy, the pill/overlay, all customer copy, the no-buffer watchdog, ASR, polish, paste.
**Rollback:** set `bluetoothAllZeroMidTakeCeilingSamples = 16_000` — byte-identical prior behaviour on every transport, one value, no other line touched. Verified by the control run above.

## Known limits

- A handshake slower than 3.0s still fails.
- A Bluetooth device whose transport macOS cannot identify reports `"unknown"` and keeps today's behaviour (fails to current behaviour, never to the longer one).
- On a genuinely dead Bluetooth mic the user now speaks 3s instead of 1s before the take ends. Accepted cost.
- **Not proven:** no instrumented run ever caught a real handshake past 1.0s, so the rescue has been shown to have *room*, not observed saving a dictation.

## Validation

| check | result |
|---|---|
| `scripts/xcode-test.sh` | exit 0, `** TEST SUCCEEDED **`, **4,410** executed (+6) |
| Xcode Release build | exit 0, `** BUILD SUCCEEDED **` |
| `swift build --package-path scripts/eval/apple_runner` | exit 0 |
| `swift build --package-path scripts/eval/alias_runner` | exit 0 |
| Local `codex review --base origin/main` | clean, **zero findings** |
| Live UAT wiring proof | Bluetooth 48000 / built-in 16000, same binary |

Both eval packages are built explicitly because they depend on `EnviousWisprCore`, where the constant lands, and no CI workflow compiles them.

Closes #1788
