### PR TITLE
fix(audio): close the recovery spool's two cross-session defects (#1579)

### DIFF
--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -118,7 +118,28 @@ public protocol AudioCaptureInterface: AnyObject {
   /// convenience in the extension below.
   func beginCapturePhase(recoveryPayload: Data?) async throws -> AsyncStream<AVAudioPCMBuffer>
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer>  // periphery:ignore - convenience method combining engine + capture phases
-  func stopCapture() async -> CaptureResult
+  /// Stop the capture session identified by `sessionID`, returning its samples.
+  /// Fenced on the armed capture generation (#1579): a mismatched ID is a total
+  /// no-op returning empty samples, so an older armed generation cannot clear a
+  /// newer armed take's samples, deactivate its source, or finalize its spool.
+  ///
+  /// Deliberately fenced ONLY on the armed capture counter. It does NOT identify
+  /// prepared-but-unarmed ownership — the counter advances in `beginCapturePhase`,
+  /// so an engine prepared and then cancelled is still session 0 (#1579 P9).
+  /// Callers must separately gate that interval using lifecycle ownership. Unlike
+  /// `retireCapturingSource(sessionID:)` below, this must not copy the
+  /// source-identity checks: retire is destructive on a specific retained source
+  /// object, stop is not. Requiring
+  /// source identity or a non-nil source here would refuse a legitimate stop
+  /// after a route change, a format restabilisation, a zero-signal retire, or an
+  /// idle teardown — and would break the nil-source salvage path that still owes
+  /// the caller its accumulated samples.
+  ///
+  /// Callers pass the id they observed when they took ownership of the stop, NOT
+  /// a value re-read at call time. `0` is a legitimate argument: an engine that
+  /// was prepared but never armed has not advanced the counter, and that cleanup
+  /// must still be allowed through or the prepared engine leaks.
+  func stopCapture(sessionID: UInt64) async -> CaptureResult
   func rebuildEngine()
   /// Retire (tear down) the source that captured the session identified by
   /// `sessionID`, so the next press opens a fresh one. Fenced + idempotent: a

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -449,6 +449,16 @@ public final class AudioCaptureManager: AudioCaptureInterface {
         source: "AudioCaptureManager.beginCapturePhase.no_active_source")
     }
 
+    // #1579: retire any predecessor spool FIRST — before the sample reset below
+    // and before the `await source.startCapture()` further down. Two reasons, and
+    // the order matters for both. During that await an unstopped predecessor's
+    // feed still sees `isCapturing == true` and could reach the new take's
+    // buffer; and `capturedSamples` is cleared on the very next line, so anything
+    // the predecessor's 1s poll had not yet consumed would be unrecoverable if
+    // this ran afterwards (cloud review P2 — the previous placement was below the
+    // reset while its own comment claimed otherwise).
+    retirePredecessorRecoverySpool()
+
     // Pre-allocate sample buffer
     capturedSamples = []
     capturedSamples.reserveCapacity(16000 * 30)
@@ -561,10 +571,34 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     return try await beginCapturePhase()
   }
 
-  public func stopCapture() async -> CaptureResult {
+  public func stopCapture(sessionID: UInt64) async -> CaptureResult {
+    // #1579 layer 2: ARMED-session identity fence. MUST precede every existing
+    // stop-path read and mutation — a stale stop that got this far would clear a
+    // newer take's samples and deactivate its source. A mismatch returns empty and
+    // changes nothing; both production callers discard a stale result. `0` stays
+    // valid: it is the id of a prepared-but-never-armed engine, whose cleanup must
+    // be allowed through or the engine leaks. This guard cannot identify that
+    // prepared interval; callers must separately gate it using lifecycle ownership.
+    guard sessionID == captureSessionCounter else {
+      Self.btRouteLog("Stop skipped: stale capture session")
+      return CaptureResult(samples: [])
+    }
+
     guard let source = activeSource else {
       let samples = capturedSamples
       capturedSamples = []
+      // #1579 (defect 1c): finalize the spool HERE too. This early return used to
+      // skip `stopRecoverySpooling` entirely, leaving an armed spool with no
+      // terminal marker. Reachable in production: an engine interruption clears
+      // `isCapturing` without clearing `activeSource`, the user then switches
+      // "Keep engine warm" off, reconciliation is now permitted and tears the
+      // source down — and the kernel's stop lands here. `RecoverySpoolStore`
+      // scans every file without requiring a marker and the replayer accepts a
+      // truncated prefix, so the leftover could be replayed as a real recording.
+      // Only best-effort deletion on the live ending masked it, and that does not
+      // run if the process dies first. Reached only after the identity fence, so
+      // this is always THIS session's spool. Idempotent via `recoveryFinalized`.
+      stopRecoverySpooling(tail: samples)
       return CaptureResult(samples: samples)
     }
 
@@ -740,6 +774,28 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     func clearActiveSourceForTesting() {
       activeSource = nil
     }
+
+    /// Test seam (#1579): arm the recovery spool directly. `startRecoverySpooling`
+    /// is private and only reachable through `beginCapturePhase`, which needs a
+    /// real device format a stub cannot provide — the same constraint that forced
+    /// `installCapturedSourceForTesting`. Lets the predecessor-retirement tests
+    /// assert against the REAL spool files rather than manager internals.
+    func armRecoverySpoolingForTesting(payload: Data?) {
+      startRecoverySpooling(payload: payload)
+    }
+
+    /// Test oracle (#1579): whether a live feed task is currently retained. A
+    /// retired predecessor must leave none.
+    var debugHasLiveRecoveryFeedTask: Bool {
+      guard let task = recoveryFeedTask else { return false }
+      return !task.isCancelled
+    }
+
+    /// Test oracle (#1579): the currently armed writer, so a test can hold a
+    /// reference across the action under test and then barrier on its write queue.
+    /// The manager clears its own reference on every finalize path, so a test that
+    /// grabs the writer afterwards would get nil and silently assert nothing.
+    var debugRecoverySpoolWriter: RecoverySpoolWriter? { recoverySpoolWriter }
   #endif
 
   public func preWarm() async throws {
@@ -1287,7 +1343,42 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   /// Decode the directive and arm the spool writer + feed loop. Fail-open: any
   /// decode/preflight failure leaves recovery off and capture byte-identical.
+  /// Retire any live predecessor spool: write its terminal marker and cancel its
+  /// feed. Single owner (#1579 §3c), called from BOTH the start of
+  /// `beginCapturePhase` (so nothing of the new take can reach an old writer) and
+  /// the top of `startRecoverySpooling` (so a direct arm is safe on its own).
+  /// Idempotent — `finalizeRecovery` no-ops once the writer is gone.
+  private func retirePredecessorRecoverySpool() {
+    // Feed the tail the poll loop had not reached yet, so a superseded spool is
+    // still complete up to the moment it was superseded. `finalizeRecovery` marks
+    // it `.interrupted` rather than `.cleanFinalized`: this session did not end
+    // cleanly, and the marker must not claim it did.
+    if let writer = recoverySpoolWriter, !recoveryFinalized,
+      capturedSamples.count > recoveryFedSampleCount
+    {
+      writer.append(Array(capturedSamples[recoveryFedSampleCount...]))
+      recoveryFedSampleCount = capturedSamples.count
+    }
+    if recoverySpoolWriter != nil { finalizeRecovery(.interrupted) }
+    // A task can outlive its writer (the writer is cleared on every finalize
+    // path); cancel unconditionally so no stale feed survives.
+    recoveryFeedTask?.cancel()
+    recoveryFeedTask = nil
+  }
+
   private func startRecoverySpooling(payload: Data?) {
+    // #1579 (defect 1b): RETIRE any predecessor before resetting, never drop it.
+    // The old code nil'd `recoverySpoolWriter` and left `recoveryFeedTask` alive.
+    // That task holds its writer strongly and guards only on `isCapturing` +
+    // `writer.isHealthy` — both true again once this new session arms — so it
+    // would wake and append THIS session's samples into the PREVIOUS session's
+    // encrypted spool. Worse, it advances the shared `recoveryFedSampleCount`,
+    // so the new writer then skips the range the stale task consumed:
+    // contamination in both directions. Routed through `finalizeRecovery` rather
+    // than repeated inline — that is the single owner of "cancel the feed, write
+    // the terminal marker, clear the writer" (#1579 §3c).
+    retirePredecessorRecoverySpool()
+
     recoveryFinalized = false
     recoveryFedSampleCount = 0
     recoverySpoolWriter = nil

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -208,6 +208,7 @@ final class RecordingSessionKernel {
     /// controller (unarmed = every hook is a no-op); tests inject an isolated
     /// instance. Compiled out of release entirely.
     var crashBoundaryController: CrashBoundaryFaultController = .shared
+
   #endif
 
   /// Logical-time seam (PR-3 plan §14a). Production wiring of a real clock is
@@ -1358,12 +1359,16 @@ final class RecordingSessionKernel {
     // truer figure anyway (audio kept arriving until `stopCapture()` below).
     freezeRecordingSnapshot()
     markPipelineTimingStart()
+    // #1579: snapshot the capture session this stop OWNS at the stop-ownership
+    // point, immediately before the synchronous transition. Nothing between here
+    // and `stopCapture` suspends, so the value cannot go stale before it is used.
+    let ownedCaptureSessionID = audioCapture.currentCaptureSessionID
     transition(to: .stopping)
     // PR-4.5 #4 (Codex r1): latch the tick BEFORE `stopCapture()`'s await so
     // capture-teardown latency does not count as visible-recording time.
     stoppingStartedAtTick = currentTick()
     captureLifecycle = .stopping
-    var captureResult = await audioCapture.stopCapture()
+    var captureResult = await audioCapture.stopCapture(sessionID: ownedCaptureSessionID)
     // Guard BEFORE touching kernel state — if a new session started while
     // `stopCapture()` was suspended, these fields belong to that session now
     // (Codex P2-round4 stale-completion guard).
@@ -3423,10 +3428,15 @@ final class RecordingSessionKernel {
       // No stop in flight — this terminal owns it.
       captureLifecycle = .stopping
       resourcesReleased = false
+      // #1579: snapshot the owned capture session SYNCHRONOUSLY, before the Task
+      // is created. The scheduling window between task creation and task body is
+      // exactly this site's exposure; re-reading the id inside the Task would
+      // return the newer session's value and defeat the fence entirely.
+      let ownedCaptureSessionID = audioCapture.currentCaptureSessionID
       Task { @MainActor [weak self] in
         guard let self else { return }
         self.bump()
-        _ = await self.audioCapture.stopCapture()
+        _ = await self.audioCapture.stopCapture(sessionID: ownedCaptureSessionID)
         // Gate on the capture lifecycle, not `SessionID`. A new session that
         // started while this stop was suspended sets `captureLifecycle` to
         // `.active` via `beginCapturePhase()`, so this guard refuses to
@@ -3435,6 +3445,12 @@ final class RecordingSessionKernel {
         // `SessionID` but leaves `captureLifecycle` at `.stopping`, so this
         // task completes its own bookkeeping rather than being orphaned
         // (Codex P2-round6).
+        //
+        // #1579 NOTE: the pre-stop lifecycle gate that belongs here was split out
+        // to its own issue. Two review rounds each found a hole in it, both in the
+        // direction of refusing a legitimate stop (which loses a dictation), and
+        // the correct shape needs an explicit capture handoff in the forward path
+        // rather than a refusal here.
         guard self.captureLifecycle == .stopping else { return }
         self.captureLifecycle = .stopped
         self.resourcesReleased = true

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -47,7 +47,7 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
     AsyncStream { $0.finish() }
   }
-  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func stopCapture(sessionID: UInt64) async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
   func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -184,7 +184,7 @@ private final class SettableAudioCapture: AudioCaptureInterface {
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
     AsyncStream { $0.finish() }
   }
-  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func stopCapture(sessionID: UInt64) async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
   func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}
@@ -232,7 +232,7 @@ private final class ObservableAudioCapture: AudioCaptureInterface {
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
     AsyncStream { $0.finish() }
   }
-  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func stopCapture(sessionID: UInt64) async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
   func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerMaxDurationBackstopTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerMaxDurationBackstopTests.swift
@@ -62,7 +62,7 @@ struct AudioCaptureManagerMaxDurationBackstopTests {
 
     // stopCapture has no isCapturing guard: the capped recording's audio is
     // still the user's words and still comes back for transcription.
-    let result = await manager.stopCapture()
+    let result = await manager.stopCapture(sessionID: manager.currentCaptureSessionID)
     #expect(result.samples == [1, 2, 3, 4])
   }
 

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerSpoolPredecessorTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerSpoolPredecessorTests.swift
@@ -1,0 +1,279 @@
+@preconcurrency import AVFoundation
+import EnviousWisprCore
+import EnviousWisprStorage
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// Uses the manager's `#if DEBUG` arming seam, so the whole suite is DEBUG-only.
+#if DEBUG
+
+  // MARK: - #1579 defect 1b — arming a spool must RETIRE its predecessor.
+  //
+  // `startRecoverySpooling` used to nil `recoverySpoolWriter` and leave
+  // `recoveryFeedTask` running. That task retains its writer and guards only on
+  // `isCapturing` + `writer.isHealthy`, both true again once a new session arms,
+  // so it would wake and append the NEW session's audio into the OLD session's
+  // encrypted spool — and advance the shared `recoveryFedSampleCount` so the new
+  // writer skipped that same range. A crash could then hand the user a recording
+  // spliced from two dictations, or one silently missing a chunk.
+  //
+  // These tests assert on the REAL spool files on disk, not manager internals:
+  // the user-visible property is "the previous recording's file is properly
+  // closed", and that is what the replayer reads.
+  @MainActor
+  @Suite("AudioCaptureManager recovery-spool predecessor retirement (#1579)")
+  struct AudioCaptureManagerSpoolPredecessorTests {
+
+    private static func key() -> Data {
+      Data(repeating: 7, count: RecoveryConstants.aesKeyByteCount)
+    }
+
+    private static func snapshot() -> RecordingSettingsSnapshot {
+      RecordingSettingsSnapshot(
+        backendType: .parakeet, backendSupportsLanguageDetection: false, languageMode: .auto,
+        wordCorrectionEnabled: false, fillerRemovalEnabled: false,
+        emojiFormatterEnabled: false, spokenPunctuationEnabled: false,
+        customWordsVersion: nil,
+        llmProvider: "none", llmModel: "none", polishPromptVersion: nil)
+    }
+
+    /// A directive pointing at a fresh file inside `dir`, encoded exactly as the
+    /// kernel encodes it (the manager decodes this same JSON in production).
+    private static func payload(sessionID: String, dir: URL) throws -> Data {
+      let directive = RecoverySpoolDirective(
+        enabled: true,
+        recoverySessionID: sessionID,
+        spoolPath: dir.appendingPathComponent("\(sessionID).\(RecoveryConstants.fileExtension)")
+          .path,
+        keyData: key(),
+        settingsSnapshot: snapshot())
+      return try JSONEncoder().encode(directive)
+    }
+
+    private static func makeTempDir() throws -> URL {
+      let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ew-1579-spool-\(UUID().uuidString)")
+      try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      return dir
+    }
+
+    private static func terminationReason(of sessionID: String, in dir: URL) throws
+      -> RecoverySpoolTerminationReason?
+    {
+      let store = RecoverySpoolStore(directory: dir)
+      return try store.recover(
+        recoverySessionID: sessionID, cipher: RecoverySpoolCipher(mode: .aesGcm256, keyData: key())
+      ).terminationReason
+    }
+
+
+    /// Barrier on a writer's serial write queue. `finalize` is idempotent and
+    /// ALWAYS invokes `completion` — including on the already-finalized path — so
+    /// this cannot hang; it simply queues behind whatever the manager already
+    /// submitted. Without it these tests race the writer's async file I/O and pass
+    /// or fail on timing. Same pattern as `RecoverySpoolWriterTests.awaitFinalize`.
+    private static func drain(_ writer: RecoverySpoolWriter?) async {
+      guard let writer else { return }
+      await withCheckedContinuation { continuation in
+        writer.finalize(reason: .cleanFinalized) { continuation.resume() }
+      }
+    }
+
+    // MARK: - 1. Arming a successor retires the predecessor
+
+    @Test("arming a second spool finalizes the first as .interrupted and leaves no live feed")
+    func armingRetiresThePredecessor() async throws {
+      let dir = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let manager = AudioCaptureManager()
+      manager.isCapturing = true  // the feed loop's guard, armed without hardware
+
+      manager.armRecoverySpoolingForTesting(payload: try Self.payload(sessionID: "first", dir: dir))
+      // Precondition: the first arm really did start a feed. Without this the
+      // retirement assertion below would pass against nothing.
+      #expect(manager.debugHasLiveRecoveryFeedTask)
+      let firstWriter = manager.debugRecoverySpoolWriter
+
+      // The successor arms with no intervening stop. This is the 1b scenario.
+      manager.armRecoverySpoolingForTesting(
+        payload: try Self.payload(sessionID: "second", dir: dir))
+      await Self.drain(firstWriter)
+
+      #expect(
+        try Self.terminationReason(of: "first", in: dir) == .interrupted,
+        "the predecessor's file is properly closed, not abandoned unmarked")
+      #expect(
+        manager.debugHasLiveRecoveryFeedTask,
+        "the SUCCESSOR's feed is live (the first one's was cancelled and replaced)")
+    }
+
+    // MARK: - 2. Control: a first arm does not write a spurious terminal marker
+    //
+    // Without this control, a bug that finalized EVERY arm — including the first
+    // — would still pass the test above while destroying live recovery.
+
+    @Test("a first arm with no predecessor retires nothing and leaves its feed live")
+    func firstArmDoesNotFinalizeAnything() async throws {
+      let dir = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let manager = AudioCaptureManager()
+      manager.isCapturing = true
+
+      manager.armRecoverySpoolingForTesting(payload: try Self.payload(sessionID: "only", dir: dir))
+
+      // Deliberately NOT asserting `terminationReason == nil` here. The writer's
+      // file I/O is async, so an unmarked read is indistinguishable from a file
+      // that simply has not been written yet — it would pass for the wrong reason,
+      // and the only available barrier (`finalize`) would itself write the marker.
+      // The live feed task IS deterministic and is the real control: a bug that
+      // finalized every arm, including the first, would cancel this feed and fail
+      // here while still passing the retirement test above.
+      #expect(manager.debugHasLiveRecoveryFeedTask, "its own feed is running, not retired")
+      // Deterministic oracle rather than a directory read: `writer.start()`
+      // creates the file asynchronously, so listing the directory here can come
+      // back empty under load even though arming succeeded (whole-diff review P2).
+      #expect(manager.debugRecoverySpoolWriter != nil, "its own writer is armed")
+    }
+
+    // MARK: - 3. Disabled directive still retires a live predecessor
+    //
+    // The early `return` for a disabled/undecodable directive sits AFTER the
+    // retirement block. If retirement had been placed after that guard instead,
+    // turning recovery off mid-session would strand the previous writer forever.
+
+    @Test("arming with recovery DISABLED still retires a live predecessor")
+    func disabledDirectiveStillRetiresPredecessor() async throws {
+      let dir = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let manager = AudioCaptureManager()
+      manager.isCapturing = true
+
+      manager.armRecoverySpoolingForTesting(payload: try Self.payload(sessionID: "live", dir: dir))
+      #expect(manager.debugHasLiveRecoveryFeedTask)
+      let liveWriter = manager.debugRecoverySpoolWriter
+
+      manager.armRecoverySpoolingForTesting(payload: nil)  // recovery off for the next take
+      await Self.drain(liveWriter)
+
+      #expect(
+        try Self.terminationReason(of: "live", in: dir) == .interrupted,
+        "the predecessor is closed even though the successor arms nothing")
+      #expect(
+        manager.debugHasLiveRecoveryFeedTask == false,
+        "and no feed task survives into a session that has no spool")
+    }
+
+    // MARK: - 3b. A superseded spool keeps the audio the poll loop never reached
+    //
+    // Cloud review P2. The feed task polls about once a second, so a predecessor
+    // retired mid-poll has unfed samples sitting in `capturedSamples`. If
+    // retirement runs after that buffer is cleared — which is where it originally
+    // sat, despite a comment claiming otherwise — those samples are gone from the
+    // spool forever. Recovery would then hand back a recording missing its ending.
+
+    @Test("retiring a predecessor writes the samples its poll loop had not consumed")
+    func retirementPreservesTheUnfedTail() async throws {
+      let dir = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let manager = AudioCaptureManager()
+      manager.isCapturing = true
+
+      manager.armRecoverySpoolingForTesting(payload: try Self.payload(sessionID: "tail", dir: dir))
+      let writer = try #require(manager.debugRecoverySpoolWriter)
+      // Audio arrives but the 1s poll has not run, so none of it is fed yet.
+      manager.ingestSamples([0.5, -0.5, 0.25, -0.25], level: 0.5)
+      #expect(manager.capturedSamples.count == 4, "precondition: samples are pending, unfed")
+
+      manager.armRecoverySpoolingForTesting(payload: try Self.payload(sessionID: "next", dir: dir))
+      await Self.drain(writer)
+
+      let recovered = try RecoverySpoolStore(directory: dir).recover(
+        recoverySessionID: "tail", cipher: RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key()))
+      #expect(recovered.terminationReason == .interrupted, "marked superseded, not clean")
+      #expect(
+        recovered.samples == [0.5, -0.5, 0.25, -0.25],
+        "the pending tail reached the spool before the successor cleared the buffer")
+    }
+
+    // MARK: - 4. Defect 1c — the no-active-source stop still closes its spool
+    //
+    // Production ingress, reached through real code rather than by installing the
+    // end state: an engine interruption clears `isCapturing` while leaving
+    // `activeSource` alive, the user switches "Keep engine warm" off, and the
+    // manager's OWN `reconcileWarmEnginePolicy` tears the source down. The
+    // kernel's stop then lands on the nil-source early return, which used to
+    // return without ever finalizing the spool.
+
+    @Test("stop with no active source finalizes its spool instead of abandoning it")
+    func nilSourceStopStillFinalizesTheSpool() async throws {
+      let dir = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let manager = AudioCaptureManager()
+      let stub = StopFenceStub()
+      manager.installSourceFactoryForTesting { stub }
+      try await manager.startEnginePhase()
+
+      manager.armRecoverySpoolingForTesting(
+        payload: try Self.payload(sessionID: "interrupted-take", dir: dir))
+      manager.isCapturing = true
+      #expect(manager.debugHasLiveRecoveryFeedTask, "precondition: the spool is armed and live")
+      let takeWriter = manager.debugRecoverySpoolWriter
+
+      // The interruption's observable effect: capture stops, the source survives.
+      manager.isCapturing = false
+      // The user's setting change, driving the manager's real reconciliation into
+      // `performEngineTeardown()` — this is what actually nils `activeSource`.
+      manager.warmEnginePolicy = .off
+
+      let result = await manager.stopCapture(sessionID: manager.currentCaptureSessionID)
+      await Self.drain(takeWriter)
+
+      #expect(result.samples.isEmpty, "no audio was ingested in this test")
+      // THE 1c fix: the spool is closed with a terminal marker, so a later launch
+      // cannot replay it as a truncated recording.
+      #expect(try Self.terminationReason(of: "interrupted-take", in: dir) == .cleanFinalized)
+      #expect(
+        manager.debugHasLiveRecoveryFeedTask == false, "and its feed task is cancelled")
+    }
+  }
+
+  /// Local stub for the teardown ingress above. Mirrors the stop-fence suite's
+  /// stub; kept separate because that one is nested in its own suite.
+  private final class StopFenceStub: AudioInputSource {
+    var onSamples: (@Sendable ([Float], Float) -> Void)?
+    var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+    var onInterrupted: ((EngineInterruptionCause) -> Void)?
+    var onLifecycleSignal: (@Sendable (String) -> Void)?
+    var onCaptureStalled: ((CaptureStallContext) -> Void)?
+    var captureGeneration: UInt64 = 0
+    let captureSourceType = "stub"
+    var running = true
+    var isCapturing = false
+    var isRunning: Bool { running }
+    #if DEBUG
+      var debugZeroFillController: DebugZeroFillController?
+      var wakeDiagnostic: (firstNonZeroRoutedIndex: Int?, routedCountAtActivation: Int?) {
+        (nil, nil)
+      }
+    #endif
+    var boundToReturn = BoundInputDevice(
+      deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub")
+    func prepare() async throws -> BoundInputDevice { boundToReturn }
+    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+      AsyncStream { $0.finish() }
+    }
+    func stop() async -> [Float] {
+      running = false
+      return []
+    }
+    func deactivateCapture() {}
+    func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async
+      -> Bool
+    { true }
+    func abortPrepare() {}
+    func rebuild() { running = false }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerStopFenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerStopFenceTests.swift
@@ -1,0 +1,177 @@
+@preconcurrency import AVFoundation
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// This suite uses AudioCaptureManager's `#if DEBUG` test seams
+// (`installCapturedSourceForTesting`, `installSourceFactoryForTesting`), so the
+// whole suite is DEBUG-only — the Release test-target lane must not compile it.
+#if DEBUG
+
+  // MARK: - #1579 — the armed-session identity fence on the terminal stop.
+  //
+  // `stopCapture(sessionID:)` must be a TOTAL no-op when the id names a session
+  // that is no longer current, because every statement in its body mutates
+  // session-scoped state: a stale stop would clear a newer take's accumulated
+  // samples and deactivate its source. These tests drive the REAL
+  // `AudioCaptureManager`, not a `FakeAudioCapture` — the fake is a pass-through
+  // recorder and would test itself rather than the guard.
+  //
+  // Every test here is TWO-WAY on purpose (`validation-discipline.md`
+  // RULE: a-guard-nothing-arms-is-not-a-guard): a fence that refuses EVERYTHING
+  // passes a refusal-only test while disabling the product. The acceptance cases
+  // are what make the refusal case mean anything.
+  @MainActor
+  @Suite("AudioCaptureManager stop identity fence (#1579)")
+  struct AudioCaptureManagerStopFenceTests {
+
+    /// Minimal `AudioInputSource` stub. Unlike the retire-fence suite's stub this
+    /// one counts `deactivateCapture()`, which is the observable the stop path
+    /// asserts on. Kept local rather than shared: the retire suite's stub is
+    /// nested in its own suite and counting deactivations there would edit a file
+    /// outside this chunk's scope.
+    final class StubSource: AudioInputSource {
+      var onSamples: (@Sendable ([Float], Float) -> Void)?
+      var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+      var onInterrupted: ((EngineInterruptionCause) -> Void)?
+      var onLifecycleSignal: (@Sendable (String) -> Void)?
+      var onCaptureStalled: ((CaptureStallContext) -> Void)?
+      var captureGeneration: UInt64 = 0
+      let captureSourceType = "stub"
+      var running = true
+      var isCapturing = false
+      var isRunning: Bool { running }
+      private(set) var deactivateCallCount = 0
+      private(set) var stopCallCount = 0
+      private(set) var rebuildCallCount = 0
+      #if DEBUG
+        var debugZeroFillController: DebugZeroFillController?
+        var wakeDiagnostic: (firstNonZeroRoutedIndex: Int?, routedCountAtActivation: Int?) {
+          (nil, nil)
+        }
+      #endif
+
+      var boundToReturn = BoundInputDevice(
+        deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub")
+      private(set) var prepareCallCount = 0
+
+      func prepare() async throws -> BoundInputDevice {
+        prepareCallCount += 1
+        return boundToReturn
+      }
+      func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { $0.finish() }
+      }
+      func stop() async -> [Float] {
+        stopCallCount += 1
+        running = false
+        return []
+      }
+      func deactivateCapture() { deactivateCallCount += 1 }
+      func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async
+        -> Bool
+      {
+        true
+      }
+      func abortPrepare() {}
+      func rebuild() {
+        rebuildCallCount += 1
+        running = false
+      }
+    }
+
+    /// Arm the manager with a live capture session WITHOUT hardware: install a
+    /// stub as both the retained and active source at `sessionID`, flip the
+    /// `internal(set)` capture flag, and accumulate real samples through the
+    /// production ingest path.
+    private func makeArmedManager(sessionID: UInt64, samples: [Float]) -> (
+      AudioCaptureManager, StubSource
+    ) {
+      let manager = AudioCaptureManager()
+      let stub = StubSource()
+      manager.installCapturedSourceForTesting(stub, sessionID: sessionID)
+      manager.isCapturing = true
+      manager.ingestSamples(samples, level: 0.5)
+      return (manager, stub)
+    }
+
+    // MARK: - 1. A stale id changes nothing at all
+
+    @Test("stale session id → total no-op: empty return, samples and source untouched")
+    func staleSessionIsATotalNoOp() async {
+      // Session 8 is live; an older take's cleanup arrives naming session 7.
+      let (manager, stub) = makeArmedManager(sessionID: 8, samples: [1, 2, 3, 4])
+
+      let result = await manager.stopCapture(sessionID: 7)
+
+      #expect(result.samples.isEmpty, "a refused stop returns nothing")
+      #expect(
+        manager.capturedSamples == [1, 2, 3, 4],
+        "THE point of the fence: the live take's audio must survive a stale stop")
+      #expect(manager.isCapturing, "capture must still be running")
+      #expect(stub.deactivateCallCount == 0, "the live source must not be deactivated")
+      #expect(stub.stopCallCount == 0, "no teardown may be scheduled for the live source")
+      #expect(manager.currentCaptureSessionID == 8, "the counter is not touched")
+    }
+
+    // MARK: - 2. Control: the current id still stops, exactly as before
+
+    @Test("current session id → stop proceeds: samples returned, state cleared, source deactivated")
+    func currentSessionStopsNormally() async {
+      let (manager, stub) = makeArmedManager(sessionID: 8, samples: [1, 2, 3, 4])
+
+      let result = await manager.stopCapture(sessionID: manager.currentCaptureSessionID)
+
+      #expect(result.samples == [1, 2, 3, 4], "the take's audio comes back for transcription")
+      #expect(manager.capturedSamples.isEmpty, "the live buffer is drained by an accepted stop")
+      #expect(manager.isCapturing == false)
+      #expect(stub.deactivateCallCount == 1, "the accepted stop deactivates its own source")
+    }
+
+    // MARK: - 3. Control: a prepared-but-never-armed engine is still stoppable
+    //
+    // The regression this test exists for: `beginCapturePhase` is what advances
+    // the counter, so an engine that was PREPARED and then cancelled has session
+    // id 0. An earlier draft of this fence keyed on "the id I got when I armed",
+    // which does not exist on this path — it would have refused the cleanup and
+    // left the prepared engine running. Reached through the real
+    // `startEnginePhase()`, not by hand-installing the end state.
+
+    @Test("prepared engine, capture never armed → stop with id 0 is ACCEPTED, not fenced out")
+    func preparedButUnarmedEngineIsStoppable() async throws {
+      let manager = AudioCaptureManager()
+      let stub = StubSource()
+      manager.installSourceFactoryForTesting { stub }
+      // `.off` BEFORE preparation: setting it afterwards would trip
+      // `reconcileWarmEnginePolicy()` and tear the engine down before the stop,
+      // leaving this test asserting against a state it never reached.
+      manager.warmEnginePolicy = .off
+
+      try await manager.startEnginePhase()
+
+      #expect(stub.prepareCallCount == 1, "the engine really was prepared through startEnginePhase")
+      #expect(
+        manager.currentCaptureSessionID == 0,
+        "capture was never armed, so the counter has not advanced")
+
+      let result = await manager.stopCapture(sessionID: 0)
+
+      #expect(result.samples.isEmpty, "nothing was captured, so there is nothing to return")
+      #expect(stub.deactivateCallCount == 1, "the stop was ACCEPTED, not fenced out")
+
+      // And the prepared engine really is GONE, not merely deactivated. `.off`
+      // clears `activeSource` synchronously inside the stop, before the async
+      // `source.stop()`, so `beginCapturePhase` — which requires an active source
+      // — now throws. This observes the torn-down end state without widening
+      // production visibility (`activeSource` is private) and without waiting on
+      // the teardown Task (banned by swift-patterns.md RULE:
+      // tests-no-unconditional-continuation-await).
+      await #expect(throws: AudioError.self) {
+        _ = try await manager.beginCapturePhase()
+      }
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -82,7 +82,7 @@ private final class ExtrasAudioCapture: AudioCaptureInterface {
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
     AsyncStream { $0.finish() }
   }
-  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func stopCapture(sessionID: UInt64) async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
   func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -299,7 +299,7 @@ private final class HeartPathHarness {
   func run() async throws -> HeartPathHarnessResult {
     try await audioCapture.startEnginePhase()
     _ = try await audioCapture.beginCapturePhase()
-    let captureResult = await audioCapture.stopCapture()
+    let captureResult = await audioCapture.stopCapture(sessionID: audioCapture.currentCaptureSessionID)
 
     // ONE adapter drives both transcription and the wiring, so the stored
     // language, duration and processing time come from the same result the
@@ -557,7 +557,7 @@ internal final class FixtureAudioCapture: AudioCaptureInterface {
     return try await beginCapturePhase()
   }
 
-  func stopCapture() async -> CaptureResult {
+  func stopCapture(sessionID: UInt64) async -> CaptureResult {
     stopCaptureCallCount += 1
     isCapturing = false
     isActivelyCapturing = false

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -299,7 +299,7 @@ private final class NoOpAudioCapture: AudioCaptureInterface {
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
     AsyncStream { $0.finish() }
   }
-  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func stopCapture(sessionID: UInt64) async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
   func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -172,7 +172,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
     return try await beginCapturePhase()
   }
 
-  func stopCapture() async -> CaptureResult {
+  func stopCapture(sessionID: UInt64) async -> CaptureResult {
     stopCaptureCallCount += 1
     isCapturing = false
     bufferContinuation?.finish()

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCaptureTests.swift
@@ -24,7 +24,7 @@ struct FakeAudioCaptureTests {
     await Task.yield()
     capture.deliverBuffer()
     capture.deliverBuffer()
-    _ = await capture.stopCapture()
+    _ = await capture.stopCapture(sessionID: capture.currentCaptureSessionID)
     await consumer.value
 
     #expect(callbackCount.value == 2, "onBufferCaptured fires once per delivered buffer")
@@ -38,7 +38,7 @@ struct FakeAudioCaptureTests {
     #expect(capture.stopCaptureCallCount == 0)
     _ = try await capture.beginCapturePhase()
     #expect(capture.isCapturing == true)
-    _ = await capture.stopCapture()
+    _ = await capture.stopCapture(sessionID: capture.currentCaptureSessionID)
     #expect(capture.stopCaptureCallCount == 1)
     #expect(capture.isCapturing == false, "capture must not be left hot after stop")
   }
@@ -67,7 +67,7 @@ struct FakeAudioCaptureTests {
     _ = try await capture.beginCapturePhase()
     capture.deliverBuffer(frameCount: 100)
     capture.addSpeechSegment(startSample: 0, endSample: 80)
-    let result = await capture.stopCapture()
+    let result = await capture.stopCapture(sessionID: capture.currentCaptureSessionID)
     #expect(result.samples.count == 100)
     #expect(result.vadSegments.count == 1)
   }

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -193,7 +193,7 @@ private final class NeverFinishingAudioCapture: AudioCaptureInterface {
     try await startEnginePhase()
     return try await beginCapturePhase()
   }
-  func stopCapture() async -> CaptureResult {
+  func stopCapture(sessionID: UInt64) async -> CaptureResult {
     continuation?.finish()
     continuation = nil
     isCapturing = false


### PR DESCRIPTION
Closes #1579. Follow-up for the split-out half: #1854.

## What was actually wrong

The ticket was filed as "no live bug, P3-low, resilience to future change". Grounding found that was true of one third of it and false of the rest, so it was relabelled P2-medium.

**1b — a recovery spool could be written by the wrong session.** Arming a spool nil'd the writer and left the feed task running. That task retains its writer and guards only on `isCapturing` + `writer.isHealthy`, both true again once a new session arms, so it could wake and append the NEW take's audio into the PREVIOUS take's encrypted spool — while advancing the shared fed-count so the new spool skipped that same range. Contamination in both directions.

**1c — a stop could abandon its spool unmarked.** The no-active-source early return finished before `stopRecoverySpooling`. `RecoverySpoolStore` scans every `.ewrec` without requiring a terminal marker (`:42-51`), EOF-without-marker yields `truncated == true` (`:81-91`), and `RecoverySpoolReplayer` does not reject truncated or missing-reason spools (`:202-264`) — it replays the prefix. Only best-effort deletion on the live ending masked it, and that does not run if the process dies first.

Reachable ingress for 1c, traced end to end: engine interruption clears `isCapturing` while leaving `activeSource` (`:487-499`) → user switches "Keep engine warm" off (`AudioSettingsView.swift:69-78` → `PipelineSettingsSync.swift:188-189`) → reconciliation is now permitted (`:842-848`) → teardown clears `activeSource` (`:828-839`) → the stop lands on the early return.

User-visible consequence: recovered audio is written to History with a success notice, so either defect could surface as a wrong or incomplete transcript appearing after a crash.

## What changed

- **Predecessor retirement** now runs at the top of `beginCapturePhase`, before the sample reset and before the capture-start await, so nothing of the new take can reach an old writer. Routed through `finalizeRecovery` as the single owner of cancel → mark → clear.
- **The nil-source stop finalizes its spool** instead of returning early.
- **`stopCapture(sessionID:)`** — the stop now names the session it owns and refuses a stale armed generation. `0` is valid: a prepared-but-never-armed engine has not advanced the counter and its cleanup must pass, or the engine leaks.

Deliberately fenced on the counter alone. Four legitimate events change or clear `activeSource` without advancing it (route rebuild, format restabilisation, zero-signal retire clearing the retained slot, idle teardown), so a source-identity check would refuse legitimate stops — which loses a dictation.

## What was split out, and why

The terminal-cleanup lifecycle gate is **not** in this PR. Two review rounds each found a hole in it, both refusing a legitimate stop:

1. `== .stopping` refused `.notStarted`, stranding a live engine, because `start()` resets the lifecycle before spawning forward work.
2. Permitting `.notStarted` let a stale cleanup stop the engine being *prepared* for the new session.
3. Refusing during `.arming` meant nobody stopped the predecessor, so the next session reused a still-capturing source and hit `AudioError.alreadyCapturing` — the next dictation fails to start.

The correct shape is an explicit capture handoff in the forward path, not a third refusal condition. Full analysis in #1854, including the test-infrastructure gap that let (3) survive a green suite: `FakeAudioCapture` permits duplicate capture starts, so it cannot reproduce HAL's rejection.

## Validation

- Full suite: **4,259 + 179 tests green.**
- Both standalone eval packages (`apple_runner`, `alias_runner`) compile — CI does not build them.
- New tests carry **two-way controls**; the guard was deleted to confirm each test fails without it.
- Live UAT on the rebuilt debug app, built-in mic: normal dictation PASS; **five rapid back-to-back PASS 5/5**; cancel-then-immediately-record PASS. Log evidence: 7 completed pipelines, 0 no-speech terminals, **0 fence refusals on healthy takes**, 0 leftover spool files, slowest 1.48s (cold polish) and the rest ~0.5s.

## Known limitation

A fence refusal is DEBUG-logged only. `EnviousWisprAudio` cannot emit a Sentry breadcrumb without an Audio → Services dependency, which the dependency-direction rule forbids, and the stop contract has no typed refusal outcome. Release-build refusal incidence is therefore unobservable. Accepted, not mitigated.
