### PR TITLE
feat(telemetry): join Sentry errors to PostHog usage, per install and per dictation (#1846)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,8 @@ scripts/*
 !scripts/convert-output-classifier.py
 !scripts/gate-output-classifier.py
 !scripts/emit-output-classifier-golden.py
+# Cross-vendor telemetry join instrument (#1846).
+!scripts/telemetry-join.py
 # UAT helpers (per-PR Swift CLIs invoked during Live UAT, e.g. issue #845 keychain verifier)
 !scripts/uat/
 !scripts/uat/**

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
@@ -54,7 +54,14 @@ enum DictationCompletedReporting {
       // is invisible — it never reaches either Sentry capture site (those
       // only fire on `.asrFailed`/`.asrInterrupted`), so this read-through
       // chain is a successful retry's ONLY visibility.
-      asrRetryOutcome: driver.asrRetryOutcome?.rawValue)
+      asrRetryOutcome: driver.asrRetryOutcome?.rawValue,
+      // #1846: the take this completion belongs to. `lastTakeID` is FROZEN at the
+      // accepted terminal, not a live read of the in-flight take key — if the user
+      // started talking again before this report was filed, a live read would stamp
+      // this event with the NEXT take's id, which is worse than absent because it
+      // joins cleanly to the wrong dictation. Rationale on
+      // `RecordingSessionKernel.lastTakeID`.
+      takeID: driver.lastTakeID)
   }
 
   private static func positive(_ value: Int?) -> Int? {

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -200,8 +200,8 @@ final class DictationLifecycleCoordinator {
       self?.showOverlayIntent(intent)
     }
     // #1060: approaching-cap warning — display-only banner, no lifecycle authority.
-    let onApproaching: (TimeInterval) -> Void = { [weak self] r in
-      self?.showApproachingCapWarning(remainingSeconds: r)
+    let onApproaching: (TimeInterval, String) -> Void = { [weak self] r, takeID in
+      self?.showApproachingCapWarning(remainingSeconds: r, takeID: takeID)
     }
     kernelDriver.onApproachingMaxDuration = onApproaching
     whisperKitKernelDriver.onApproachingMaxDuration = onApproaching
@@ -232,11 +232,15 @@ final class DictationLifecycleCoordinator {
   /// transition out of recording. "Under a minute" reads accurately for the whole
   /// window, so no countdown or late-fire guard is needed. `DictationNarrator`
   /// owns the copy.
-  private func showApproachingCapWarning(remainingSeconds: TimeInterval) {
+  /// #1846: `takeID` arrives from the kernel's warning stream, already validated
+  /// against the recording session that produced it — the coordinator forwards it
+  /// and never re-derives one from an active driver.
+  private func showApproachingCapWarning(remainingSeconds: TimeInterval, takeID: String) {
     recordingOverlay.flashRecordingNotice(reason: .approachingCap)
     TelemetryService.shared.recordingCapWarningShown(
       backend: lastCapturingBackend == .whisperKit ? "whisperKit" : "parakeet",
-      capSeconds: TimingConstants.maxRecordingDuration)
+      capSeconds: TimingConstants.maxRecordingDuration,
+      takeID: takeID)
   }
 
   // MARK: - Per-pipeline state-change handling

--- a/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
+++ b/Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift
@@ -247,10 +247,10 @@ package final class CaptureVADSignalSource: VADSignalSource {
 
     invalidateMonitor()
 
-    // Snapshot every telemetry identity fact SYNCHRONOUSLY, before the task
-    // exists (#1780). Reading these inside the task is unsafe: the task may
-    // first execute after a later session has been stamped, which would
-    // silently attribute this run's markers to the next recording.
+    // Snapshot run-scoped telemetry facts SYNCHRONOUSLY before the task exists
+    // (#1780). Every later marker guard validates `runSessionID` and
+    // `runGeneration` against live state; emissions forward that same validated
+    // session ID rather than performing a second mutable read.
     let runSessionID = currentSessionID
     let runGeneration = monitorGeneration
     let runBackend = backend
@@ -320,7 +320,11 @@ package final class CaptureVADSignalSource: VADSignalSource {
       }
       self.recordStartTelemetry.vadPreparationCompleted(
         backend: runBackend, inputRoute: runInputRoute,
-        ready: ready, modelReused: modelReused)
+        ready: ready, modelReused: modelReused,
+        // #1846: forward the same frozen session ID validated by the guard
+        // immediately above. A superseded run emits nothing; using this value
+        // keeps attribution tied to the run the guard accepted.
+        takeID: runSessionID.raw.uuidString)
 
       await self.runMonitor(
         detector: ready ? directDetector : nil,
@@ -453,7 +457,8 @@ package final class CaptureVADSignalSource: VADSignalSource {
         else { return }
         self.recordStartTelemetry.firstChunkStarted(
           backend: runBackend, inputRoute: runInputRoute,
-          monitorToFirstChunkMs: monitorMs)
+          monitorToFirstChunkMs: monitorMs,
+          takeID: runSessionID.raw.uuidString)
       },
       onFirstChunkCompleted: { [weak self] latencyMs, shouldStop in
         guard let self,
@@ -462,7 +467,8 @@ package final class CaptureVADSignalSource: VADSignalSource {
         else { return }
         self.recordStartTelemetry.firstChunkCompleted(
           backend: runBackend, inputRoute: runInputRoute,
-          chunkProcessingLatencyMs: latencyMs, shouldStop: shouldStop)
+          chunkProcessingLatencyMs: latencyMs, shouldStop: shouldStop,
+          takeID: runSessionID.raw.uuidString)
       }
     )
   }

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
@@ -78,4 +78,9 @@ struct DeadMicRetireAttemptContext: Sendable {
   /// `ZeroSignalRetireResult.rawValue` — whether teardown actually ran.
   let retireAction: String
   let routeFallbackReason: String?
+  /// #1846: which dictation the retire happened during. The LIVE in-flight key:
+  /// a retire fires before the terminal stamps the concluded key. Non-defaulted
+  /// so every caller must make the attribution choice explicitly; production's
+  /// sole construction site supplies `KernelTelemetryState.takeID`.
+  let takeID: String?
 }

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -266,7 +266,8 @@ final class HeartPathTelemetryEmitter {
       warmPolicy: ctx.warmPolicy,
       retireAction: ctx.retireAction,
       msSinceLastGood: msSinceLastGood,
-      routeFallbackReason: ctx.routeFallbackReason)
+      routeFallbackReason: ctx.routeFallbackReason,
+      takeID: ctx.takeID)
   }
 
   /// Heartpath 5b (#1520): a pending dead-mic watch resolved (a later take

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -936,6 +936,12 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// the App layer's `dictation.completed` telemetry. LIVE pass-through from the
   /// kernel; never persisted. Reason strings only, never user content.
   public var lastStopReason: String? { kernel.lastStopReason }
+  /// #1846: the id of the take that most recently CONCLUDED, for `dictation.completed`
+  /// and its three sibling completion events. LIVE pass-through of a value the kernel
+  /// FROZE at the accepted terminal — not a live read of the in-flight take key, which
+  /// would name the next take once the user started talking again. Rationale and the
+  /// absent-vs-wrong argument live on `RecordingSessionKernel.lastTakeID`.
+  public var lastTakeID: String? { kernel.lastTakeID }
   public var lastRecordingDurationSeconds: Double? { kernel.lastRecordingDurationSeconds }
   /// #1408: non-nil when the most recent recording's capture was interrupted
   /// mid-flight (device died, cap reached). Drives the disconnect disclosure pill

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -398,12 +398,13 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   public var onOverlayIntentChange: ((OverlayIntent) -> Void)?
 
   /// Fired at most once per recording when the recording approaches the
-  /// max-duration cap (#1060), carrying remaining seconds. Display-only, like
-  /// `onOverlayIntentChange`: carries NO lifecycle authority; wire ONLY to the
-  /// overlay banner path, never to anything that mutates recording state. The
-  /// App layer owns the user-facing copy.
+  /// max-duration cap (#1060), carrying remaining seconds and the take key this
+  /// warning belongs to (#1846). Display-only, like `onOverlayIntentChange`:
+  /// carries NO lifecycle authority; wire ONLY to the overlay banner path, never
+  /// to anything that mutates recording state. The App layer owns the
+  /// user-facing copy.
   @ObservationIgnored
-  public var onApproachingMaxDuration: ((TimeInterval) -> Void)?
+  public var onApproachingMaxDuration: ((TimeInterval, String) -> Void)?
 
   /// #1339 — the single active sessionless load-wedge guard, or nil when no
   /// sessionless warm-up attempt is in flight. The driver-level single-flight
@@ -652,8 +653,12 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   func start() {
     observeKernelState()
     observeDisplayOnlyOverlay()
-    kernel.onApproachingMaxDuration = { [weak self] remaining in
-      self?.onApproachingMaxDuration?(remaining)
+    // #1846: forward the take key unchanged. The driver also exposes
+    // `lastTakeID`, but that is the CONCLUDED key and is cleared when a new
+    // session starts. A cap warning fires before the terminal stamps it, so
+    // substituting it here would emit no take key.
+    kernel.onApproachingMaxDuration = { [weak self] remaining, takeID in
+      self?.onApproachingMaxDuration?(remaining, takeID)
     }
   }
 

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -504,6 +504,22 @@ public enum KernelDictationDriverFactory {
       captureTelemetry: captureTelemetry,
       telemetryState: telemetryState,
       modelLoadWedgeTelemetry: { telemetryRelay.modelLoadWedgeTelemetry() },
+      // #1846: the ONLY production wiring of the per-dictation take key, so this
+      // line is what makes the feature exist at all —
+      // `KernelLifecycleTelemetrySinkTests.productionFactoryWiresTheTakeKey` fails
+      // if it is removed.
+      //
+      // The sink defaults this seam to inert, unlike its sibling scope seams. That
+      // keeps DIRECT sink constructions in unit tests off the real Sentry scope,
+      // which the new terminal postamble would otherwise drag them onto. It does
+      // NOT mean no test reaches the real scope: a test that builds a driver
+      // through this factory gets the full production wiring by design, and
+      // already did for `breadcrumb`, `updateRecordingState`, `updateAudioRoute`,
+      // `dictationInvoked` and `modelLoadWedged`, all of which default to the real
+      // SDK here. The take key is the sixth, not a new exposure.
+      updateTakeID: { takeID in
+        SentryBreadcrumb.updateTakeID(takeID)
+      },
       // Route both lifecycle captureError variants through the same injected
       // sink so a test observing one sink sees every error this sink can emit
       // (Codex review #875). Production stays byte-identical: the default sink

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -224,9 +224,16 @@ public enum KernelDictationDriverFactory {
   private final class TelemetryRelay {
     var kernel: RecordingSessionKernel?
     var recordingStopped: (@MainActor (Int) -> Void)?
+    /// #1846: set after the lifecycle sink exists (the kernel is built first),
+    /// then called synchronously from `start(config:)` on every accepted session.
+    var sessionAccepted: (@MainActor (String) -> Void)?
 
     func emitRecordingStopped(sampleCount: Int) {
       recordingStopped?(sampleCount)
+    }
+
+    func establishTakeID(_ takeID: String) {
+      sessionAccepted?(takeID)
     }
 
     func modelLoadWedgeTelemetry() -> KernelModelLoadWedgeTelemetry? {
@@ -476,6 +483,11 @@ public enum KernelDictationDriverFactory {
       recordingStoppedTelemetry: { sampleCount in
         telemetryRelay.emitRecordingStopped(sampleCount: sampleCount)
       },
+      // #1846 cloud review: routed through the relay for the same reason as the
+      // line above — the kernel is constructed BEFORE the lifecycle sink.
+      sessionAcceptedTelemetry: { takeID in
+        telemetryRelay.establishTakeID(takeID)
+      },
       markPipelineTimingStart: {
         outcome.pipelineStartedAtSeconds = CFAbsoluteTimeGetCurrent()
       },
@@ -541,6 +553,11 @@ public enum KernelDictationDriverFactory {
     )
     telemetryRelay.recordingStopped = { [lifecycleSink] sampleCount in
       lifecycleSink.emitRecordingStopped(sampleCount: sampleCount)
+    }
+    // #1846: the sink stays the SINGLE writer of `dictation.take_id`; this only
+    // gives the kernel a synchronous way to reach it at session acceptance.
+    telemetryRelay.sessionAccepted = { [lifecycleSink] takeID in
+      lifecycleSink.establishTakeID(takeID)
     }
 
     // 9. Observer (constructed AFTER kernel — needs the kernel ref). The

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -238,7 +238,13 @@ struct KernelFinalizationWiring {
         steps: [
           steps.wordCorrection, steps.fillerRemoval, steps.emojiFormatter,
           steps.inverseTextNormalization, steps.llmPolish, steps.emojiRestore,
-        ])
+        ],
+        // #1846: the LIVE in-flight take, not the concluded one. Polish runs before
+        // the session terminal, so `kernel.lastTakeID` is not yet stamped for this
+        // take — it would be nil, or still hold the PREVIOUS take. Same key, a
+        // different read point from the completion events, and swapping the two
+        // would mislabel one family or the other.
+        takeID: telemetryState.takeID)
       let ctx = result.context
       // #145: thread the ITN run outcome onto `dictation.completed` (metadata
       // only — `telemetry-privacy-boundary`). Read on the same actor right after

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -240,10 +240,10 @@ struct KernelFinalizationWiring {
           steps.inverseTextNormalization, steps.llmPolish, steps.emojiRestore,
         ],
         // #1846: the LIVE in-flight take, not the concluded one. Polish runs before
-        // the session terminal, so `kernel.lastTakeID` is not yet stamped for this
-        // take — it would be nil, or still hold the PREVIOUS take. Same key, a
-        // different read point from the completion events, and swapping the two
-        // would mislabel one family or the other.
+        // the session terminal, and starting a session CLEARS `kernel.lastTakeID`,
+        // so it is nil here — substituting it would emit no take key at all. Same
+        // key as the completion events, read at a different point; swapping the two
+        // reads would silently blank one family.
         takeID: telemetryState.takeID)
       let ctx = result.context
       // #145: thread the ITN run outcome onto `dictation.completed` (metadata

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -36,6 +36,9 @@ final class KernelLifecycleTelemetrySink {
     _ active: Bool, _ backend: String?, _ isStreaming: Bool?
   ) -> Void
 
+  /// #1846. Optional-taking so `nil` means REMOVE, never a sentinel value.
+  typealias TakeIDSink = @MainActor (_ takeID: String?) -> Void
+
   typealias AudioRouteSink = @MainActor (_ route: String) -> Void
 
   typealias DictationInvokedSink = @MainActor (
@@ -89,6 +92,7 @@ final class KernelLifecycleTelemetrySink {
   private let modelLoadWedgeTelemetry: @MainActor () -> KernelModelLoadWedgeTelemetry?
   private let breadcrumb: BreadcrumbSink
   private let updateRecordingState: RecordingStateSink
+  private let updateTakeID: TakeIDSink
   private let updateAudioRoute: AudioRouteSink
   private let dictationInvoked: DictationInvokedSink
   private let modelLoadWedged: ModelLoadWedgedSink
@@ -124,6 +128,26 @@ final class KernelLifecycleTelemetrySink {
       SentryBreadcrumb.updateRecordingState(
         active: active, backend: backend, isStreaming: isStreaming)
     },
+    // #1846: INERT by default, unlike every sibling seam here, which defaults to
+    // the real SDK call. The asymmetry is deliberate and it is the safer default
+    // for a NEW seam: `KernelLifecycleRecordingScopeBaselineTests` must compile
+    // against `origin/main`, so it cannot name this argument, and a real-SDK
+    // default would make that file mutate process-global Sentry scope while
+    // claiming in its own header that it touches no vendor scope. Production
+    // wires it explicitly in `KernelDictationDriverFactory`.
+    //
+    // Scope of that protection, stated exactly: it covers DIRECT sink
+    // constructions in unit tests, which the terminal postamble below would
+    // otherwise drag onto the real scope. Tests that build a driver through the
+    // factory still get production wiring, as they already do for the five sibling
+    // seams whose defaults call the real SDK.
+    //
+    // An inert default is a footgun — a dropped factory line would leave the
+    // feature tested, documented and dead. That is closed by
+    // `productionFactoryWiresTheTakeKey` in `KernelLifecycleTelemetrySinkTests`,
+    // which fails if the factory stops wiring this seam. Do not delete that test
+    // without restoring a real default here.
+    updateTakeID: @escaping TakeIDSink = { _ in },
     updateAudioRoute: @escaping AudioRouteSink = { route in
       SentryBreadcrumb.updateAudioRoute(route)
     },
@@ -167,6 +191,7 @@ final class KernelLifecycleTelemetrySink {
     self.modelLoadWedgeTelemetry = modelLoadWedgeTelemetry
     self.breadcrumb = breadcrumb
     self.updateRecordingState = updateRecordingState
+    self.updateTakeID = updateTakeID
     self.updateAudioRoute = updateAudioRoute
     self.dictationInvoked = dictationInvoked
     self.modelLoadWedged = modelLoadWedged
@@ -183,6 +208,14 @@ final class KernelLifecycleTelemetrySink {
   /// mapping table — preserved where the sink can read, deferred where rich
   /// kernel-side wiring would be required (§2.2 non-goals).
   func emit(_ event: KernelLifecycleEvent) {
+    // #1846: establish the take key FIRST, before the pre-switch interruption
+    // counter and before any breadcrumb, error or PostHog emission. Required on
+    // EVERY event, not just the start one: `withObservationTracking` is not a
+    // lossless queue (`KernelHeartPathTelemetryObserver.handleObservationChange`
+    // dispatches every coalesced delta event), so a terminal can be handled in
+    // the same fire as its start — and if the tag were only set at start, a
+    // coalesced fire would leave the terminal error untagged.
+    updateTakeID(telemetryState.takeID)
     emitAudioCaptureInterruptedIfNeeded(for: event)
     switch event {
     case .pipelineStartingUp:
@@ -292,7 +325,8 @@ final class KernelLifecycleTelemetrySink {
           ["was_recording": true, "backend": backend.rawValue],
           snapshot: snapshot)
       }
-      updateRecordingState(false, nil, nil)
+    // Arm-local clear REMOVED (#1846): the generic terminal postamble below is
+    // now the single owner, so every terminal clears on exactly one path.
 
     case .asrInterrupted(let wasRecording):
       // Bridge matrix #3 — old TP:1145 emitted `was_recording == state == .recording`
@@ -322,7 +356,7 @@ final class KernelLifecycleTelemetrySink {
         .xpcServiceError, "asr",
         extra,
         snapshot: recordingSnapshot())
-      updateRecordingState(false, nil, nil)
+    // Arm-local clear REMOVED (#1846) — see the terminal postamble below.
 
     case .discarded(let reason):
       // PR-1 §B.7.4 — the ONE new event the epic introduces. Old code was
@@ -365,6 +399,40 @@ final class KernelLifecycleTelemetrySink {
       // The kernel state observer still tracks the `.cancelled` transition —
       // only the telemetry emission is omitted.
       break
+    }
+
+    // #1846: ONE generic terminal postamble, reached after the event-specific arm
+    // so the terminal event itself still carries the take key. `terminalStateLabel`
+    // is the closed seven-terminal authority, so a new terminal cannot silently
+    // skip cleanup — it has to decide there first.
+    //
+    // This is the single owner of the terminal `recording.active` clear ON THIS
+    // PATH. Measured before this change: five terminal arms had no arm-local
+    // clear (`.pipelineCompleted`, `.failed`, `.discarded`, `.noSpeech`,
+    // `.cancelled`) and two did (`.audioInterrupted`, `.asrInterrupted`); those
+    // two arm-local calls were REMOVED rather than left as duplicates.
+    // `.pipelineCompleted` normally follows the `.recordingStopped` marker, which
+    // clears capture scope at `emitRecordingStopped`, but the postamble
+    // deliberately does not depend on that route.
+    //
+    // Measured, not remembered — `grep -rn "updateRecordingState(" Sources/`
+    // returns exactly three CLEAR sites: this postamble, `emitRecordingStopped`
+    // below, and one OUTSIDE this file.
+    //
+    // The outside site is deliberate, and it is an EARLIER EMERGENCY CLEAR rather
+    // than a competing terminal-arm owner:
+    // `KernelDictationDriver.handleEngineInterruption` clears `recording.active`
+    // immediately for `.arming`, `.stopping` and `.delivering`, then routes the
+    // session toward a later `.cancelled` terminal. Keeping that earlier write
+    // preserves its synchronous freshness guarantee while this postamble provides
+    // route-independent terminal cleanup. The writes are idempotent, but the
+    // redundancy is not free — it is one extra process-global scope mutation, and
+    // that cost is accepted in exchange for closing the stale window before the
+    // asynchronously observed terminal arrives. The take key needs no early clear
+    // there because it must stay live through the terminal event itself.
+    if Self.terminalStateLabel(for: event) != nil {
+      updateTakeID(nil)
+      updateRecordingState(false, nil, nil)
     }
   }
 

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -212,6 +212,25 @@ final class KernelLifecycleTelemetrySink {
   /// (stage / message / category / event name). Payload fidelity per §3.7
   /// mapping table — preserved where the sink can read, deferred where rich
   /// kernel-side wiring would be required (§2.2 non-goals).
+  /// #1846 cloud review: establish the take tag SYNCHRONOUSLY at session
+  /// acceptance, before the kernel spawns any work.
+  ///
+  /// `emit` refreshes the tag on every lifecycle event, but the first such event
+  /// arrives through `observeKernelState`'s unstructured `Task { @MainActor }`,
+  /// which has no ordering guarantee against the kernel's own spawned
+  /// `runForwardPath`. Model-load and capture-start failures — the errors most
+  /// likely to fire early in a session, and exactly the ones this feature exists
+  /// to join — could therefore be raised before the tag existed and ship
+  /// untagged. The kernel calls this inside `start(config:)` itself, so the
+  /// window is closed by construction rather than by scheduling luck.
+  ///
+  /// Deliberately routed through the SAME `updateTakeID` writer as the per-event
+  /// refresh and the terminal clear: this type stays the single owner of that
+  /// scope tag.
+  func establishTakeID(_ takeID: String) {
+    updateTakeID(takeID)
+  }
+
   func emit(_ event: KernelLifecycleEvent) {
     // #1846: establish the take key FIRST, before the pre-switch interruption
     // counter and before any breadcrumb, error or PostHog emission. Required on

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -41,8 +41,11 @@ final class KernelLifecycleTelemetrySink {
 
   typealias AudioRouteSink = @MainActor (_ route: String) -> Void
 
+  /// `takeID` (#1846) names WHICH dictation the event belongs to. Threaded as a
+  /// parameter rather than read from `telemetryState` inside the default closure so
+  /// a test observing this seam sees the exact value that reaches PostHog.
   typealias DictationInvokedSink = @MainActor (
-    _ triggerSource: String, _ inputMode: String, _ targetApp: String?
+    _ triggerSource: String, _ inputMode: String, _ targetApp: String?, _ takeID: String?
   ) -> Void
 
   typealias ModelLoadWedgedSink = @MainActor (
@@ -78,7 +81,8 @@ final class KernelLifecycleTelemetrySink {
   /// like every other sink so tests observe the emission without PostHog.
   typealias AudioCaptureInterruptedSink = @MainActor (
     _ cause: String, _ salvageAttempted: Bool, _ salvageSucceeded: Bool,
-    _ terminalState: String, _ backend: String, _ recordingDurationMs: Int?
+    _ terminalState: String, _ backend: String, _ recordingDurationMs: Int?,
+    _ takeID: String?
   ) -> Void
 
   // MARK: Identity + read sources
@@ -151,9 +155,9 @@ final class KernelLifecycleTelemetrySink {
     updateAudioRoute: @escaping AudioRouteSink = { route in
       SentryBreadcrumb.updateAudioRoute(route)
     },
-    dictationInvoked: @escaping DictationInvokedSink = { trigger, mode, target in
+    dictationInvoked: @escaping DictationInvokedSink = { trigger, mode, target, takeID in
       TelemetryService.shared.dictationInvoked(
-        triggerSource: trigger, inputMode: mode, targetApp: target)
+        triggerSource: trigger, inputMode: mode, targetApp: target, takeID: takeID)
     },
     modelLoadWedged: @escaping ModelLoadWedgedSink = { backend, telemetry in
       TelemetryService.shared.modelLoadWedged(
@@ -175,10 +179,11 @@ final class KernelLifecycleTelemetrySink {
     },
     noAudioCapturedRich: NoAudioCapturedSink? = nil,
     audioCaptureInterrupted: @escaping AudioCaptureInterruptedSink = {
-      cause, attempted, succeeded, terminal, backend, durationMs in
+      cause, attempted, succeeded, terminal, backend, durationMs, takeID in
       TelemetryService.shared.audioCaptureInterrupted(
         cause: cause, salvageAttempted: attempted, salvageSucceeded: succeeded,
-        terminalState: terminal, backend: backend, recordingDurationMs: durationMs)
+        terminalState: terminal, backend: backend, recordingDurationMs: durationMs,
+        takeID: takeID)
     },
     deadMicRecovered: @escaping @MainActor (DeadMicRecoveryOutcome) -> Void = { _ in }
   ) {
@@ -238,7 +243,7 @@ final class KernelLifecycleTelemetrySink {
       let triggerSource = context.config?.triggerSource.rawValue ?? "unknown"
       let inputMode = context.config?.inputMode.rawValue ?? "unknown"
       let targetApp = context.targetApp?.localizedName
-      dictationInvoked(triggerSource, inputMode, targetApp)
+      dictationInvoked(triggerSource, inputMode, targetApp, telemetryState.takeID)
       // Mirror old TP:546-553 — the breadcrumb data dict carries both
       // `backend` and `streaming`, and `updateRecordingState` carries the
       // real streaming flag (Codex review #11 r2 — earlier draft hardcoded
@@ -456,7 +461,8 @@ final class KernelLifecycleTelemetrySink {
       terminal == "completed",
       terminal,
       backend.rawValue,
-      telemetryState.recordingSnapshot?.durationMs)
+      telemetryState.recordingSnapshot?.durationMs,
+      telemetryState.takeID)
   }
 
   /// The terminal each lifecycle event represents, or `nil` for a non-terminal

--- a/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
+++ b/Sources/EnviousWisprPipeline/KernelTelemetryState.swift
@@ -48,6 +48,14 @@ public enum ASRRetryOutcome: String, Sendable {
 @MainActor
 final class KernelTelemetryState {
   var polishEnabled = false
+  /// #1846: the kernel session's `SessionID.raw.uuidString`, projected here so
+  /// telemetry can name WHICH dictation an event belongs to. Observation-only:
+  /// never persisted, never `Codable`, and it never influences a kernel decision.
+  /// Replaced by the next accepted session's reset, never cleared mid-session —
+  /// Sentry scope clearing is the lifecycle sink's terminal postamble's job, and
+  /// a second clearer here would blank the tag while polish and paste are still
+  /// running, which is exactly where the highest-volume errors are raised.
+  var takeID: String?
   var recordingSnapshot: KernelRecordingSnapshotTelemetry?
   var noSpeechTelemetry: KernelNoSpeechTelemetry?
   var asrEmptyDiagnostics: ASREmptyResultDiagnostics?
@@ -108,7 +116,10 @@ final class KernelTelemetryState {
   /// `nil` if no Phase-2 retry ever started. See `ASRRetryOutcome`.
   var asrRetryOutcome: ASRRetryOutcome?
 
-  func resetForNewSession(polishEnabled: Bool) {
+  /// `takeID` has NO default on purpose: an accepted session must state its own
+  /// identity. A default would let a caller silently start a take with no key.
+  func resetForNewSession(takeID: String, polishEnabled: Bool) {
+    self.takeID = takeID
     self.polishEnabled = polishEnabled
     recordingSnapshot = nil
     noSpeechTelemetry = nil

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -130,7 +130,9 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     /// EG-1, context-window, Ollama preflight) remains the runner's
     /// responsibility, routed through its own, separate `recordPolishSkipped`
     /// seam — this field does not duplicate that.
-    let recordPolishSkipped: @MainActor (String, String) -> Void
+    /// `takeID` (#1846) is the LIVE in-flight take — polish runs before the session
+    /// terminal, so the concluded key is not yet stamped.
+    let recordPolishSkipped: @MainActor (String, String, String?) -> Void
 
     static let live = TelemetrySeams(
       limbFailureObserved: { limb, op, result, cat, dur in
@@ -149,8 +151,8 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       breadcrumbCompleted: { message, data in
         SentryBreadcrumb.add(stage: "polish", message: message, data: data)
       },
-      recordPolishSkipped: { provider, reason in
-        TelemetryService.shared.polishSkipped(provider: provider, reason: reason)
+      recordPolishSkipped: { provider, reason, takeID in
+        TelemetryService.shared.polishSkipped(provider: provider, reason: reason, takeID: takeID)
       })
 
     /// Returns a seam that discards every signal unconditionally — `seams` is
@@ -169,7 +171,7 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
         captureProviderInitError: { _ in },
         captureAFMPolishError: { _ in },
         breadcrumbCompleted: { _, _ in },
-        recordPolishSkipped: { _, _ in })
+        recordPolishSkipped: { _, _, _ in })
     }
   }
 
@@ -405,7 +407,8 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
           )
         }
         let skipReason = PolishSkipReason.tooShort(provider)
-        telemetry.recordPolishSkipped(skipReason.provider.rawValue, skipReason.telemetryTag)
+        telemetry.recordPolishSkipped(
+          skipReason.provider.rawValue, skipReason.telemetryTag, context.takeID)
         return Self.bypassedContext(context)
       }
     } else {
@@ -418,7 +421,8 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
           )
         }
         let skipReason = PolishSkipReason.tooShort(provider)
-        telemetry.recordPolishSkipped(skipReason.provider.rawValue, skipReason.telemetryTag)
+        telemetry.recordPolishSkipped(
+          skipReason.provider.rawValue, skipReason.telemetryTag, context.takeID)
         return Self.bypassedContext(context)
       }
     }

--- a/Sources/EnviousWisprPipeline/RecordStartTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/RecordStartTelemetrySink.swift
@@ -30,17 +30,22 @@ final class RecordStartTelemetrySink {
     _ stage: String, _ message: String, _ data: [String: Any]
   ) -> Void
 
+  /// `takeID` (#1846) is supplied PER CALL, never stored — this type stays
+  /// stateless by design (see the type doc), so the caller owns the attribution
+  /// just as it already owns the monitor-generation validity check.
   typealias PreparationSink = @MainActor (
-    _ backend: String, _ inputRoute: String, _ ready: Bool, _ modelReused: Bool
+    _ backend: String, _ inputRoute: String, _ ready: Bool, _ modelReused: Bool,
+    _ takeID: String?
   ) -> Void
 
   typealias ChunkStartedSink = @MainActor (
-    _ backend: String, _ inputRoute: String, _ monitorToFirstChunkMs: Double
+    _ backend: String, _ inputRoute: String, _ monitorToFirstChunkMs: Double,
+    _ takeID: String?
   ) -> Void
 
   typealias ChunkCompletedSink = @MainActor (
     _ backend: String, _ inputRoute: String, _ chunkProcessingLatencyMs: Double,
-    _ shouldStop: Bool
+    _ shouldStop: Bool, _ takeID: String?
   ) -> Void
 
   private let breadcrumb: BreadcrumbSink
@@ -55,19 +60,22 @@ final class RecordStartTelemetrySink {
     breadcrumb: @escaping BreadcrumbSink = { stage, message, data in
       SentryBreadcrumb.add(stage: stage, message: message, level: .info, data: data)
     },
-    emitPreparation: @escaping PreparationSink = { backend, inputRoute, ready, modelReused in
+    emitPreparation: @escaping PreparationSink = {
+      backend, inputRoute, ready, modelReused, takeID in
       TelemetryService.shared.dictationVADPreparationCompleted(
-        backend: backend, inputRoute: inputRoute, ready: ready, modelReused: modelReused)
+        backend: backend, inputRoute: inputRoute, ready: ready, modelReused: modelReused,
+        takeID: takeID)
     },
-    emitChunkStarted: @escaping ChunkStartedSink = { backend, inputRoute, monitorMs in
+    emitChunkStarted: @escaping ChunkStartedSink = { backend, inputRoute, monitorMs, takeID in
       TelemetryService.shared.dictationFirstVADChunkStarted(
-        backend: backend, inputRoute: inputRoute, monitorToFirstChunkMs: monitorMs)
+        backend: backend, inputRoute: inputRoute, monitorToFirstChunkMs: monitorMs,
+        takeID: takeID)
     },
     emitChunkCompleted: @escaping ChunkCompletedSink = {
-      backend, inputRoute, latencyMs, shouldStop in
+      backend, inputRoute, latencyMs, shouldStop, takeID in
       TelemetryService.shared.dictationFirstVADChunkCompleted(
         backend: backend, inputRoute: inputRoute,
-        chunkProcessingLatencyMs: latencyMs, shouldStop: shouldStop)
+        chunkProcessingLatencyMs: latencyMs, shouldStop: shouldStop, takeID: takeID)
     }
   ) {
     self.breadcrumb = breadcrumb
@@ -81,7 +89,8 @@ final class RecordStartTelemetrySink {
     backend: String,
     inputRoute: String,
     ready: Bool,
-    modelReused: Bool
+    modelReused: Bool,
+    takeID: String?
   ) {
     breadcrumb(
       "vad", "vad#preparation_completed",
@@ -91,14 +100,15 @@ final class RecordStartTelemetrySink {
         "ready": ready,
         "model_reused": modelReused,
       ])
-    emitPreparation(backend, inputRoute, ready, modelReused)
+    emitPreparation(backend, inputRoute, ready, modelReused, takeID)
   }
 
   /// Immediately before the first `SilenceDetector.processChunk` await.
   func firstChunkStarted(
     backend: String,
     inputRoute: String,
-    monitorToFirstChunkMs: Double
+    monitorToFirstChunkMs: Double,
+    takeID: String?
   ) {
     breadcrumb(
       "vad", "vad#first_chunk_started",
@@ -107,7 +117,7 @@ final class RecordStartTelemetrySink {
         "input_route": inputRoute,
         "monitor_to_first_chunk_ms": monitorToFirstChunkMs,
       ])
-    emitChunkStarted(backend, inputRoute, monitorToFirstChunkMs)
+    emitChunkStarted(backend, inputRoute, monitorToFirstChunkMs, takeID)
   }
 
   /// Immediately after that await returns.
@@ -115,7 +125,8 @@ final class RecordStartTelemetrySink {
     backend: String,
     inputRoute: String,
     chunkProcessingLatencyMs: Double,
-    shouldStop: Bool
+    shouldStop: Bool,
+    takeID: String?
   ) {
     breadcrumb(
       "vad", "vad#first_chunk_completed",
@@ -125,6 +136,6 @@ final class RecordStartTelemetrySink {
         "chunk_processing_latency_ms": chunkProcessingLatencyMs,
         "should_stop": shouldStop,
       ])
-    emitChunkCompleted(backend, inputRoute, chunkProcessingLatencyMs, shouldStop)
+    emitChunkCompleted(backend, inputRoute, chunkProcessingLatencyMs, shouldStop, takeID)
   }
 }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -561,6 +561,23 @@ final class RecordingSessionKernel {
   /// on `"max_duration"`) and by the App layer for `dictation.completed`
   /// telemetry (`stop_reason`). A reason string, never user content.
   private(set) var lastStopReason: String?
+  /// #1846: the id of the take that most recently CONCLUDED, for the App layer's
+  /// `dictation.completed` reporting chain. Observation-only; never persisted.
+  ///
+  /// Deliberately NOT a live read of `KernelTelemetryState.takeID`, and the
+  /// difference is the whole point. Both change at the same instant — the next
+  /// session's `start(config:)` — but not to the same kind of value: every sibling
+  /// marker here degrades to `nil` in `resetSessionState()`, while
+  /// `resetForNewSession` REPLACES the take key with the NEW session's id. A live
+  /// read would therefore stamp take N's completion with take N+1's id if a user
+  /// started talking again before the report was filed: not a missing value but a
+  /// confidently wrong one, indistinguishable from a correct join. Wrong
+  /// attribution is strictly worse than absent attribution, and this epic exists
+  /// because two investigations were misled by data that looked trustworthy.
+  ///
+  /// So it is stamped at the accepted terminal and cleared at the next session
+  /// start, giving it exactly `lastStopReason`'s honest-absence semantics.
+  private(set) var lastTakeID: String?
 
   /// Wall-clock length of the most recent recording in seconds (#1060), captured
   /// when the recording-exit latches and cleared at session start. LIVE metadata
@@ -3362,6 +3379,13 @@ final class RecordingSessionKernel {
     }
     let terminal = outcome  // local alias for the existing telemetry logs below
     recordingOutcome = outcome
+    // #1846: stamp the concluded take INSIDE the set-once barrier, so it is
+    // first-wins under the same condition as the outcome itself and can only ever
+    // name the session this terminal actually accepted (`audit-all-terminal-paths-
+    // for-state-reading-telemetry`). `sid` rather than `currentSessionID`: the
+    // `isCurrent(sid)` guard above already proved they match, and `sid` is
+    // unambiguously the session being concluded.
+    lastTakeID = sid.raw.uuidString
     #if DEBUG
       // #1755 chunk 6: crash-boundary hold — immediately after the set-once
       // outcome write, before the idle transition and downstream cleanup.
@@ -3521,6 +3545,7 @@ final class RecordingSessionKernel {
     // sets `lastStopReason`/`lastRecordingDurationSeconds` before Live — keeps its
     // reason instead of having it wiped when the session reaches `.live`.
     lastStopReason = nil  // #1060
+    lastTakeID = nil  // #1846 — absent, never the new session's id
     lastSalvagedLeadTrimMs = nil  // #1434
     lastCaptureHealth = nil  // #1434
     lastRecordingDurationSeconds = nil  // #1060

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -792,7 +792,12 @@ final class RecordingSessionKernel {
     currentSessionID = sid
     resetSessionState()
     sessionConfig = config
-    telemetryState.resetForNewSession(polishEnabled: config.llmProvider != .none)
+    // #1846: project the session id just minted above. No second identity is
+    // created; `transcriptID` keeps its own independent mint.
+    telemetryState.resetForNewSession(
+      takeID: sid.raw.uuidString,
+      polishEnabled: config.llmProvider != .none
+    )
     transition(to: .arming)
     spawn(sid) { [weak self] in
       await self?.runForwardPath(sid)

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -292,6 +292,14 @@ final class RecordingSessionKernel {
   /// genuine mute.
   private let zeroSignalDeviceEligible: @MainActor () -> Bool
   private let recordingStoppedTelemetry: @MainActor (_ sampleCount: Int) -> Void
+
+  /// #1846: called SYNCHRONOUSLY the moment a session is accepted, before any
+  /// work is spawned. The lifecycle sink also refreshes the take tag on every
+  /// event, but that path arrives through an unstructured `Task { @MainActor }`
+  /// with no ordering guarantee against `runForwardPath` — so an early
+  /// model-load or capture-start failure could be raised before the tag existed.
+  /// Defaulted to a no-op: only the production composition root wires it.
+  private let sessionAcceptedTelemetry: @MainActor (_ takeID: String) -> Void
   private let markPipelineTimingStart: @MainActor () -> Void
   private let markASRTimingStart: @MainActor (_ streaming: Bool) -> Void
   private let markASRTimingEnd: @MainActor () -> Void
@@ -741,6 +749,7 @@ final class RecordingSessionKernel {
     // `preferredInputDeviceIDOverride`/`selectedInputDeviceUID`).
     zeroSignalDeviceEligible: (@MainActor () -> Bool)? = nil,
     recordingStoppedTelemetry: @escaping @MainActor (_ sampleCount: Int) -> Void = { _ in },
+    sessionAcceptedTelemetry: @escaping @MainActor (_ takeID: String) -> Void = { _ in },
     markPipelineTimingStart: @escaping @MainActor () -> Void = {},
     markASRTimingStart: @escaping @MainActor (_ streaming: Bool) -> Void = { _ in },
     markASRTimingEnd: @escaping @MainActor () -> Void = {},
@@ -789,6 +798,7 @@ final class RecordingSessionKernel {
         return ZeroSignalDeviceDiscriminator.isEligible(bound: bound)
       }
     self.recordingStoppedTelemetry = recordingStoppedTelemetry
+    self.sessionAcceptedTelemetry = sessionAcceptedTelemetry
     self.markPipelineTimingStart = markPipelineTimingStart
     self.markASRTimingStart = markASRTimingStart
     self.markASRTimingEnd = markASRTimingEnd
@@ -821,6 +831,10 @@ final class RecordingSessionKernel {
       takeID: sid.raw.uuidString,
       polishEnabled: config.llmProvider != .none
     )
+    // #1846 cloud review: publish the take tag NOW, in this same turn, before
+    // `spawn` queues anything. Waiting for the observer's first lifecycle event
+    // would leave a scheduling window in which an early failure ships untagged.
+    sessionAcceptedTelemetry(sid.raw.uuidString)
     transition(to: .arming)
     spawn(sid) { [weak self] in
       await self?.runForwardPath(sid)

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -537,11 +537,17 @@ final class RecordingSessionKernel {
   private var recordingStartedAtUptimeNs: UInt64?
 
   /// Fired at most once per recording when the VAD seam reports the recording is
-  /// approaching `maxRecordingDuration` (#1060), carrying the remaining seconds.
+  /// approaching `maxRecordingDuration` (#1060), carrying the remaining seconds
+  /// and, since #1846, the take key this warning belongs to.
   /// ADVISORY: the kernel does NOT stop on this (that is the separate stop
   /// stream); it forwards a semantic event the driver maps to a UI banner. No
   /// user-facing copy lives here — copy stays in the App layer.
-  var onApproachingMaxDuration: (@MainActor (TimeInterval) -> Void)?
+  ///
+  /// The take key is NON-optional because the identity always exists at the
+  /// source: `VADWarningSignal` carries a `SessionID`, and the forwarding site
+  /// validates it against the current session before this fires. Nothing on this
+  /// path has to invent or look up a key, so nothing should be able to omit one.
+  var onApproachingMaxDuration: (@MainActor (TimeInterval, String) -> Void)?
 
   /// #1707 Phase 3 (§3.2, row 21) / #1741 Chunk 9 — the shared
   /// `EngineMutationScope` constructed once by the composition root, injected
@@ -2995,7 +3001,13 @@ final class RecordingSessionKernel {
           continue
         }
         guard self.state == .live else { continue }
-        self.onApproachingMaxDuration?(warning.remainingSeconds)
+        // #1846: forward the identity the guard immediately above just accepted,
+        // rather than performing a second read. `telemetryState.takeID` holds the
+        // same value on this path — `start(config:)` projects it from the very
+        // `SessionID` that `isCurrent(sid)` and the stamp check both require — but
+        // the signal's own id is the one this warning was fenced against.
+        self.onApproachingMaxDuration?(
+          warning.remainingSeconds, warning.sessionID.raw.uuidString)
       }
     }
   }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1575,7 +1575,9 @@ final class RecordingSessionKernel {
           healthGuessRefused: healthGuessRefused,
           warmPolicy: audioCapture.warmEnginePolicy.rawValue,
           retireAction: retireResult.rawValue,
-          routeFallbackReason: takeRoute?.routeFallbackReason))
+          routeFallbackReason: takeRoute?.routeFallbackReason,
+          // #1846: live, not concluded — a retire fires mid-session.
+          takeID: telemetryState.takeID))
       // Arm the recovery watch ONLY when teardown actually ran — a fenced no-op
       // can never be credited a later recovery. A watch already pending means the
       // previous retire's later take also retired: emit that as recovered=false.

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -61,7 +61,11 @@ internal final class TextProcessingRunner {
   /// `captureError`, which fires only for the regression-capable subset. That
   /// asymmetry is what lets a test assert "the durable record exists AND no alert
   /// fired." Parameters: provider, model, reason tag, isTimeout.
-  typealias RecordPolishFailed = @MainActor (String, String, String, Bool) -> Void
+  /// `takeID` (#1846) is the LIVE in-flight take, not the concluded one: polish runs
+  /// before the session terminal, so the frozen `lastTakeID` would still be nil here
+  /// (or hold the PREVIOUS take). Same key, different read point from the completion
+  /// events, and swapping them would mislabel one family or the other.
+  typealias RecordPolishFailed = @MainActor (String, String, String, Bool, String?) -> Void
 
   /// Durable record that AI polish produced no accepted output under an
   /// explicit skip contract (#1055, #1271, #1305, #1448) — the AFM
@@ -70,7 +74,7 @@ internal final class TextProcessingRunner {
   /// pre-attempt bypasses and post-generation rejection (`outputLanguageDrift`);
   /// distinct from `llm.polish_failed` (attempted and threw). Parameters:
   /// provider, skip reason — both sourced from `PolishSkipReason`.
-  typealias RecordPolishSkipped = @MainActor (String, String) -> Void
+  typealias RecordPolishSkipped = @MainActor (String, String, String?) -> Void
 
   /// Every POLISH telemetry seam the runner owns, as ONE value (#1446).
   ///
@@ -106,7 +110,7 @@ internal final class TextProcessingRunner {
           category: category, stage: stage, extra: extra, tags: tags,
           fingerprintDetail: fingerprintDetail)
       },
-      recordPolishFailed: { provider, model, reason, isTimeout in
+      recordPolishFailed: { provider, model, reason, isTimeout, takeID in
         // Sibling of LLMPolishStep's "LLM polish started" / "LLM polish completed"
         // crumbs; the distinct wording keeps this trail entry legible next to
         // theirs (they also carry `model`).
@@ -116,10 +120,11 @@ internal final class TextProcessingRunner {
           data: ["provider": provider, "model": model, "is_timeout": isTimeout]
         )
         TelemetryService.shared.polishFailed(
-          provider: provider, model: model, reason: reason, isTimeout: isTimeout)
+          provider: provider, model: model, reason: reason, isTimeout: isTimeout,
+          takeID: takeID)
       },
-      recordPolishSkipped: { provider, reason in
-        TelemetryService.shared.polishSkipped(provider: provider, reason: reason)
+      recordPolishSkipped: { provider, reason, takeID in
+        TelemetryService.shared.polishSkipped(provider: provider, reason: reason, takeID: takeID)
       })
 
     /// Crash recovery (#945, #1446): a recovered take still returns its
@@ -133,8 +138,8 @@ internal final class TextProcessingRunner {
     /// already has.
     static let silent = TelemetrySeams(
       captureError: { _, _, _, _, _, _ in },
-      recordPolishFailed: { _, _, _, _ in },
-      recordPolishSkipped: { _, _ in })
+      recordPolishFailed: { _, _, _, _, _ in },
+      recordPolishSkipped: { _, _, _ in })
   }
 
   private let logger: any PipelineLogging
@@ -172,10 +177,15 @@ internal final class TextProcessingRunner {
     rawText: String,
     language: String?,
     targetAppName: String?,
-    steps: [any TextProcessingStep]
+    steps: [any TextProcessingStep],
+    /// #1846: the live in-flight take. Frozen into the context below so every
+    /// emission in this chain names the same dictation even if the session state
+    /// moves on mid-chain.
+    takeID: String? = nil
   ) async throws -> TextProcessingRunResult {
     var context = TextProcessingContext(text: rawText, language: language)
     context.targetAppName = targetAppName
+    context.takeID = takeID
     var polishError: String?
 
     let logger = self.logger
@@ -370,7 +380,8 @@ internal final class TextProcessingRunner {
             // #1446: EVERY attempted-and-failed polish gets a durable counted
             // record, whatever its channel. Sentry alerting is the interrupting
             // SUBSET below, not the record itself.
-            recordPolishFailed(provider.rawValue, model, reason.telemetryTag, isTimeout)
+            recordPolishFailed(
+              provider.rawValue, model, reason.telemetryTag, isTimeout, context.takeID)
             // #1446: alert only where a spike could plausibly mean WE regressed.
             // A user out of credits, over quota, with no key, or with Ollama shut
             // down is not a defect: those reasons are counted, never paged. The
@@ -412,7 +423,7 @@ internal final class TextProcessingRunner {
             // `isAppleIntelligencePolishTimeout` above.
             recordPolishFailed(
               LLMProvider.appleIntelligence.rawValue, model,
-              PolishFailureReason.from(error).telemetryTag, isTimeout)
+              PolishFailureReason.from(error).telemetryTag, isTimeout, context.takeID)
           } else {
             // No polish-provider snapshot: a non-LLMPolishStep surfacing step
             // (only reachable in tests; production's sole `.surface` step is
@@ -428,21 +439,22 @@ internal final class TextProcessingRunner {
         if let cw = contextWindowSkip {
           let reason: PolishSkipReason =
             cw.stage == .predicted ? .contextWindowPredicted : .contextWindowCaught
-          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag)
+          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag, context.takeID)
         } else if isAppleIntelligencePolishTimeout {
           let reason = PolishSkipReason.contextWindowTimeout
-          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag)
+          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag, context.takeID)
         } else if isEGOnePolishTimeout {
           // #1271: one `local_polish_` prefix family for every EG-1 skip mode.
           let reason = PolishSkipReason.localPolishTimeout
-          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag)
+          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag, context.takeID)
         } else if let silentPolishSkipReason {
           // #1448: covers all 3 AFM cases (frameworkUnavailable,
           // unsupportedInputLanguage, outputLanguageDrift) AND .egOneSkipped in
           // one branch — both tag and provider come from PolishSkipReason itself,
           // never a separately-snapshotted value.
           recordPolishSkipped(
-            silentPolishSkipReason.provider.rawValue, silentPolishSkipReason.telemetryTag)
+            silentPolishSkipReason.provider.rawValue, silentPolishSkipReason.telemetryTag,
+            context.takeID)
         } else if let localPolishSkipReason,
           let reason = PolishSkipReason(ollamaPreflight: localPolishSkipReason)
         {
@@ -450,7 +462,7 @@ internal final class TextProcessingRunner {
           // reason family as EG-1 — the observability split between "preflight
           // said not ready" (here) and "mid-flight failure on a running
           // server" (the capture path above) falls out of the reason strings.
-          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag)
+          recordPolishSkipped(reason.provider.rawValue, reason.telemetryTag, context.takeID)
         }
         // #657 (2026-05-05): emit cap-trip telemetry when WordCorrectionStep
         // exceeds its 3s `maxDuration`. The step's result was discarded; raw

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -9,6 +9,15 @@ public struct TextProcessingContext: Sendable {
   public var polishedText: String?
   /// Detected language from ASR.
   public let language: String?
+  /// #1846: which dictation this text belongs to, frozen by `TextProcessingRunner`
+  /// at the start of the chain. Observation-only: never persisted, never `Codable`,
+  /// and it never influences a processing decision.
+  ///
+  /// Optional because two real paths genuinely have no take: re-polish of an
+  /// existing transcript, and crash recovery, which replays audio that outlived the
+  /// session that produced it. Those emit no live polish telemetry anyway (both use
+  /// the `.silent` seam presets), so nil here is honest rather than a gap.
+  public var takeID: String?
   /// LLM provider used for polishing (e.g. "openai", "ollama").
   public var llmProvider: String?
   /// LLM model used for polishing (e.g. "gpt-4o-mini").

--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -144,8 +144,22 @@ public enum ObservabilityBootstrap {
   /// Pure and testable: no SDK, no process-global state, so every accepted and
   /// rejected shape is a unit test rather than a bootstrap integration test.
   ///
-  /// Returns the canonical lowercase hyphenated UUID PostHog produces
-  /// (`UUIDUtils.postHogUuidString` = `uuidString.lowercased()`), or nil.
+  /// Returns the canonical hyphenated UUID PostHog stores, VERBATIM, or nil.
+  ///
+  /// BOTH CASES ARE ACCEPTED, and the value is never normalized. The PostHog SDK
+  /// lowercases ids it MINTS (`UUIDUtils.postHogUuidString` =
+  /// `uuidString.lowercased()`), but `PostHogStorageManager.getAnonymousId()`
+  /// returns a PERSISTED id unchanged, so an install whose id was written by an
+  /// older SDK keeps its uppercase spelling forever. Measured against production
+  /// 2026-07-30: **94 of 692 distinct installs (13.6%) carry an uppercase id.**
+  /// A lowercase-only predicate silently drops every one of them, and the absence
+  /// is indistinguishable from "PostHog was skipped" — a permanent blind spot with
+  /// no way to diagnose it.
+  ///
+  /// Returning it VERBATIM is equally load-bearing: the tag has to equal the
+  /// string PostHog actually stores, so lowercasing an uppercase id would leave
+  /// the join just as broken, only less obviously.
+  ///
   /// Three things this rejects, each for its own reason:
   ///  - `""`, which is what `getDistinctId()` returns when PostHog was skipped
   ///    for a missing key. Setting no tag at all means a join query never
@@ -160,14 +174,15 @@ public enum ObservabilityBootstrap {
   ///    hex run is 12, so it provably survives. Anything else is omitted here
   ///    rather than transmitted as `[REDACTED]`.
   ///
-  /// The exact-equality check is load-bearing: `UUID(uuidString:)` alone accepts
-  /// an uppercase representation, which is not what PostHog stamps on events.
+  /// The exact-equality check is still load-bearing: `UUID(uuidString:)` alone
+  /// also accepts a compact 32-hex form, which the sanitizer destroys. Comparing
+  /// against the two CANONICAL hyphenated spellings admits exactly those and
+  /// nothing else. A hyphenated UUID's longest hex run is 12 in either case, well
+  /// under the sanitizer's `[0-9a-fA-F]{32,}` rule, so both survive transmission.
   static func canonicalAnonymousPostHogID(_ raw: String) -> String? {
-    guard let uuid = UUID(uuidString: raw),
-      raw == uuid.uuidString.lowercased()
-    else {
-      return nil
-    }
+    guard let uuid = UUID(uuidString: raw) else { return nil }
+    let upper = uuid.uuidString
+    guard raw == upper || raw == upper.lowercased() else { return nil }
     return raw
   }
 

--- a/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
+++ b/Sources/EnviousWisprServices/ObservabilityBootstrap.swift
@@ -121,7 +121,54 @@ public enum ObservabilityBootstrap {
       if ProcessInfo.processInfo.environment["EW_FAULT_INJECTION"] == "1" {
         scope.setTag(value: "true", key: "synthetic")
       }
+      // #1846: the cross-vendor join key. PostHog is initialized first
+      // (`initialize()` above) and its setup is synchronous, so the stored
+      // anonymous ID is readable here. Sentry adopts PostHog's ID rather than
+      // the reverse because Sentry's own `user.id` is `SentryInstallation`'s
+      // machine-wide `~/Library/Caches/INSTALLATION` UUID — shared across
+      // unsandboxed Sentry apps and purgeable — while PostHog's lives in
+      // bundle-scoped Application Support. Additive tag, never `user.id`:
+      // replacing that would double-count one person across the changeover and
+      // disturb the sentry-triage worker's userCount severity thresholds.
+      // A scope tag set here is present on every later event including fatal
+      // crashes, and a replayed crash carries its own launch's value.
+      if let joinKey = canonicalAnonymousPostHogID(PostHogSDK.shared.getDistinctId()) {
+        scope.setTag(value: joinKey, key: "analytics.distinct_id")
+      }
     }
+  }
+
+  // MARK: - Cross-vendor join key (#1846)
+
+  /// The ONLY acceptance predicate for the `analytics.distinct_id` join key.
+  /// Pure and testable: no SDK, no process-global state, so every accepted and
+  /// rejected shape is a unit test rather than a bootstrap integration test.
+  ///
+  /// Returns the canonical lowercase hyphenated UUID PostHog produces
+  /// (`UUIDUtils.postHogUuidString` = `uuidString.lowercased()`), or nil.
+  /// Three things this rejects, each for its own reason:
+  ///  - `""`, which is what `getDistinctId()` returns when PostHog was skipped
+  ///    for a missing key. Setting no tag at all means a join query never
+  ///    matches a keyless install; an empty tag value would.
+  ///  - a non-canonical or caller-supplied shape. The value must stay
+  ///    ANONYMOUS, which it is today only because we never call `identify()`.
+  ///    A future `identify` could make it user-supplied, and copying an
+  ///    arbitrary user-supplied string into Sentry is not a decision this seam
+  ///    may make silently.
+  ///  - a compact 32-hex UUID, which `SentryEventSanitizer.redactString`
+  ///    destroys under its 32+-contiguous-hex rule. A hyphenated UUID's longest
+  ///    hex run is 12, so it provably survives. Anything else is omitted here
+  ///    rather than transmitted as `[REDACTED]`.
+  ///
+  /// The exact-equality check is load-bearing: `UUID(uuidString:)` alone accepts
+  /// an uppercase representation, which is not what PostHog stamps on events.
+  static func canonicalAnonymousPostHogID(_ raw: String) -> String? {
+    guard let uuid = UUID(uuidString: raw),
+      raw == uuid.uuidString.lowercased()
+    else {
+      return nil
+    }
+    return raw
   }
 
   // MARK: - Privacy seam (single source of truth in EnviousWisprObservabilityCore)

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -76,6 +76,26 @@ public enum SentryBreadcrumb {
     }
   }
 
+  /// Set or REMOVE the per-dictation take key on the global scope (#1846).
+  ///
+  /// One optional-taking function rather than a set/clear pair, so this call path
+  /// represents "no take in flight" with `nil` instead of a magic string. `nil` calls
+  /// `scope.removeTag(key:)` — genuine removal, NOT a sentinel value. That
+  /// distinction is load-bearing: `recording.active` next door always writes
+  /// `"true"`/`"false"` and never removes, so for THAT tag absence means "never
+  /// set in this process" while a value means capture state. Reusing the same
+  /// shape here would make "this event belongs to no take" indistinguishable
+  /// from "this release predates the key".
+  public static func updateTakeID(_ takeID: String?) {
+    SentrySDK.configureScope { scope in
+      if let takeID {
+        scope.setTag(value: takeID, key: "dictation.take_id")
+      } else {
+        scope.removeTag(key: "dictation.take_id")
+      }
+    }
+  }
+
   /// Update recording state on global scope. Present on fatal crashes.
   /// - Parameters:
   ///   - active: Whether recording is in progress.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -804,10 +804,26 @@ public final class TelemetryService {
   /// recording-duration cap). Counts the population that records long enough to
   /// near the cap — near-zero today; a rising count is the signal to invest in
   /// full long-form mode (#344). Metadata only.
-  public func recordingCapWarningShown(backend: String, capSeconds: Double) {
-    PostHogSDK.shared.capture(
-      "recording.cap_warning_shown",
-      properties: ["asr_backend": backend, "cap_seconds": capSeconds])
+  public func recordingCapWarningShown(
+    backend: String,
+    capSeconds: Double,
+    /// #1846: which dictation neared the cap. Omit-when-nil, matching every other
+    /// take-keyed event — the caller on the live warning path always supplies one.
+    takeID: String? = nil
+  ) {
+    // #1846: ONE payload, with the DEBUG hook derived from it. A second literal
+    // for the hook is how a wire test comes to assert a key the real capture
+    // never sent — the shape this epic found in four separate emitter families.
+    var props: [String: Any] = ["asr_backend": backend, "cap_seconds": capSeconds]
+    if let takeID { props["take_id"] = takeID }
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "recording.cap_warning_shown",
+          stringProps: props.compactMapValues { $0 as? String },
+          doubleProps: props.compactMapValues { $0 as? Double }))
+    #endif
+    PostHogSDK.shared.capture("recording.cap_warning_shown", properties: props)
   }
 
   // MARK: - Pipeline Steps

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -94,9 +94,10 @@ public final class TelemetryService {
   private init() {}
 
   #if DEBUG
-    /// Test-only observation seam. Fired at the entry of each top-level facade
-    /// method selected for focused tests. Nil in release builds; tests set this
-    /// to capture emissions without reaching PostHog.
+    /// Test-only observation seam for selected telemetry emissions.
+    /// Each emitter owns when it fires and which typed property buckets it exposes;
+    /// callers must not infer one hook call per facade call. Nil in release builds;
+    /// tests use it to inspect the typed projection exposed alongside normal capture.
     public var testEventHook: (@Sendable (CapturedTelemetryEvent) -> Void)?
   #endif
 
@@ -132,35 +133,13 @@ public final class TelemetryService {
     // retry over a post-capture decode failure — always `retry_succeeded`
     // here, since a `.retryExhausted`/preempted retry never reaches a
     // completed transcript.
-    asrRetryOutcome: String? = nil
+    asrRetryOutcome: String? = nil,
+    /// #1846: which dictation this completion belongs to. Forwarded to all FOUR
+    /// events this function fans out to, so one argument covers
+    /// `dictation.completed`, `asr.completed`, `llm.polish_completed` and
+    /// `paste.completed`.
+    takeID: String? = nil
   ) {
-    #if DEBUG
-      var hookStringProps: [String: String] = [
-        "input_mode": inputMode,
-        "asr_backend": t.backendType.rawValue,
-      ]
-      if let ib = interruptedBy { hookStringProps["interrupted_by"] = ib }
-      if let aso = asrSalvageOutcome { hookStringProps["asr_salvage_outcome"] = aso }
-      if let aro = asrRetryOutcome { hookStringProps["asr_retry_outcome"] = aro }
-      // #1376: mirror the emitted route keys' presence-only semantics so the
-      // App → Telemetry threading is unit-testable.
-      if let st = selectedTransport { hookStringProps["selected_transport"] = st }
-      if let et = effectiveTransport { hookStringProps["effective_transport"] = et }
-      if let rr = routeReason { hookStringProps["route_reason"] = rr }
-      if let rfr = routeFallbackReason { hookStringProps["route_fallback_reason"] = rfr }
-      if let ism = inputSelectionMode { hookStringProps["input_selection_mode"] = ism }
-      if let ot = outputTransport { hookStringProps["output_transport"] = ot }
-      if let rrs = routeResolutionSource { hookStringProps["route_resolution_source"] = rrs }
-      // #1523: mirror the emitted int key's presence-only semantics so the
-      // channel-count threading is unit-testable by exact production spelling.
-      var hookIntProps: [String: Int] = [:]
-      if let channels = captureNativeChannelCount {
-        hookIntProps["capture_native_channel_count"] = channels
-      }
-      testEventHook?(
-        CapturedTelemetryEvent(
-          name: "dictation.completed", stringProps: hookStringProps, intProps: hookIntProps))
-    #endif
     let m = t.metrics
     dictationCompleted(
       result: "success",
@@ -207,7 +186,8 @@ public final class TelemetryService {
       salvagedLeadTrimMs: salvagedLeadTrimMs,
       interruptedBy: interruptedBy,
       asrSalvageOutcome: asrSalvageOutcome,
-      asrRetryOutcome: asrRetryOutcome
+      asrRetryOutcome: asrRetryOutcome,
+      takeID: takeID
     )
     if let asrLat = m?.asrLatencySeconds {
       asrCompleted(
@@ -231,7 +211,8 @@ public final class TelemetryService {
         streamingCoveredSec: m?.streamingCoveredSec,
         tailDecodeSec: m?.tailDecodeSec,
         maxUnconfirmedWindowSec: m?.maxUnconfirmedWindowSec,
-        stopWhileDecodeInFlight: m?.stopWhileDecodeInFlight)
+        stopWhileDecodeInFlight: m?.stopWhileDecodeInFlight,
+        takeID: takeID)
     }
     if let llmLat = m?.llmLatencySeconds, llmLat > 0, t.llmProvider != nil {
       llmPolishCompleted(
@@ -239,7 +220,8 @@ public final class TelemetryService {
         result: t.polishedText != nil ? "success" : "skipped", latencySeconds: llmLat,
         filterTripped: m?.polishFilterTripped,
         fellBackToRaw: m?.polishFellBackToRaw,
-        fallbackReason: m?.polishFallbackReason
+        fallbackReason: m?.polishFallbackReason,
+        takeID: takeID
       )
     }
     if let tier = m?.pasteTier, let ms = m?.pasteLatencyMs {
@@ -249,7 +231,8 @@ public final class TelemetryService {
           smartInsertionEnabled: m?.smartInsertionEnabled,
           caretContextOutcome: m?.caretContextOutcome,
           repairRules: m?.repairRules,
-          payloadKind: m?.pastePayloadKind))
+          payloadKind: m?.pastePayloadKind),
+        takeID: takeID)
     }
   }
 
@@ -709,7 +692,9 @@ public final class TelemetryService {
     salvagedLeadTrimMs: Int? = nil,
     interruptedBy: String? = nil,
     asrSalvageOutcome: String? = nil,
-    asrRetryOutcome: String? = nil
+    asrRetryOutcome: String? = nil,
+    /// #1846: which dictation this event belongs to. Omit-when-nil.
+    takeID: String? = nil
   ) {
     var props: [String: Any] = [
       "result": result,
@@ -779,6 +764,23 @@ public final class TelemetryService {
     if let ism = inputSelectionMode { props["input_selection_mode"] = ism }
     if let ot = outputTransport { props["output_transport"] = ot }
     if let rrs = routeResolutionSource { props["route_resolution_source"] = rrs }
+    if let takeID { props["take_id"] = takeID }
+    #if DEBUG
+      // #1846: the hook now DERIVES from the payload that PostHog receives.
+      // `reportDictationCompleted` previously built a parallel `hookStringProps`
+      // dictionary and emitted it under this event's name while the real payload was
+      // assembled here with no hook at all — so a test could assert a key and pass
+      // with the production line deleted. The mirror is gone; this is the one
+      // authority. Every key the mirror carried is present in `props`, verified key
+      // by key before the swap, so this is strictly wider than what tests could see.
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "dictation.completed",
+          stringProps: props.compactMapValues { $0 as? String },
+          intProps: props.compactMapValues { $0 as? Int },
+          doubleProps: props.compactMapValues { $0 as? Double },
+          boolProps: props.compactMapValues { $0 as? Bool }))
+    #endif
     PostHogSDK.shared.capture("dictation.completed", properties: props)
   }
 
@@ -1162,7 +1164,9 @@ public final class TelemetryService {
     streamingDegradeReason: String? = nil, streamingFinalPath: String? = nil,
     streamingDecodeCount: Int? = nil, streamingCoveredSec: Double? = nil,
     tailDecodeSec: Double? = nil, maxUnconfirmedWindowSec: Double? = nil,
-    stopWhileDecodeInFlight: Bool? = nil
+    stopWhileDecodeInFlight: Bool? = nil,
+    /// #1846: which dictation this event belongs to. Omit-when-nil.
+    takeID: String? = nil
   ) {
     var properties: [String: Any] = [
       "backend": backend,
@@ -1203,6 +1207,17 @@ public final class TelemetryService {
     if let stopWhileDecodeInFlight {
       properties["stop_while_decode_in_flight"] = stopWhileDecodeInFlight
     }
+    if let takeID { properties["take_id"] = takeID }
+    #if DEBUG
+      // #1846: derived from the emitted payload, never a parallel dictionary.
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "asr.completed",
+          stringProps: properties.compactMapValues { $0 as? String },
+          intProps: properties.compactMapValues { $0 as? Int },
+          doubleProps: properties.compactMapValues { $0 as? Double },
+          boolProps: properties.compactMapValues { $0 as? Bool }))
+    #endif
     PostHogSDK.shared.capture("asr.completed", properties: properties)
   }
 
@@ -1211,7 +1226,9 @@ public final class TelemetryService {
     result: String, latencySeconds: Double,
     filterTripped: String? = nil,
     fellBackToRaw: Bool? = nil,
-    fallbackReason: String? = nil
+    fallbackReason: String? = nil,
+    /// #1846: which dictation this event belongs to. Omit-when-nil.
+    takeID: String? = nil
   ) {
     var props: [String: Any] = [
       "provider": provider,
@@ -1223,6 +1240,7 @@ public final class TelemetryService {
     if let ft = filterTripped { props["filter_tripped"] = ft }
     if let fb = fellBackToRaw { props["fell_back_to_raw"] = fb }
     if let fr = fallbackReason { props["fallback_reason"] = fr }
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
       var stringProps: [String: String] = [
         "provider": provider, "result": result,
@@ -1230,6 +1248,9 @@ public final class TelemetryService {
       if let m = model { stringProps["model"] = m }
       if let ft = filterTripped { stringProps["filter_tripped"] = ft }
       if let fr = fallbackReason { stringProps["fallback_reason"] = fr }
+      // #1846: read BACK OUT of the emitted payload so the test observes what
+      // PostHog receives, not a parallel copy.
+      if let takeID = props["take_id"] as? String { stringProps["take_id"] = takeID }
       var boolProps: [String: Bool] = [:]
       if let fb = fellBackToRaw { boolProps["fell_back_to_raw"] = fb }
       testEventHook?(
@@ -1322,7 +1343,9 @@ public final class TelemetryService {
 
   public func pasteCompleted(
     tier: String, targetApp: String?, result: String, latencyMs: Int,
-    insertion: PasteInsertionTelemetry = .init()
+    insertion: PasteInsertionTelemetry = .init(),
+    /// #1846: which dictation this event belongs to. Omit-when-nil.
+    takeID: String? = nil
   ) {
     var props: [String: Any] = [
       "tier": tier,
@@ -1332,12 +1355,19 @@ public final class TelemetryService {
     ]
     if let a = targetApp { props["target_app"] = a }
     props.merge(insertion.properties) { current, _ in current }
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
+      // #1846: projected from `props`, not from `insertion.properties`. The old
+      // projection could not see `tier`, `result`, `latency_ms` or `target_app` at
+      // all, so it could not have seen `take_id` either — and a hook that cannot
+      // observe the payload is not a test seam. Strictly wider; nothing removed.
       testEventHook?(
         CapturedTelemetryEvent(
           name: "paste.completed",
-          stringProps: insertion.properties.compactMapValues { $0 as? String },
-          boolProps: insertion.properties.compactMapValues { $0 as? Bool }
+          stringProps: props.compactMapValues { $0 as? String },
+          intProps: props.compactMapValues { $0 as? Int },
+          doubleProps: props.compactMapValues { $0 as? Double },
+          boolProps: props.compactMapValues { $0 as? Bool }
         ))
     #endif
     PostHogSDK.shared.capture("paste.completed", properties: props)

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -413,12 +413,23 @@ public final class TelemetryService {
 
   // MARK: - Dictation Lifecycle
 
-  public func dictationInvoked(triggerSource: String, inputMode: String, targetApp: String?) {
+  /// #1846: `takeID` names WHICH dictation this event belongs to, so an error in
+  /// Sentry can be joined to this person's usage. Omitted when nil rather than sent
+  /// as an empty string — a query must be able to tell "no take" from "a take
+  /// whose id we lost", and a release predating this change omits it entirely.
+  public func dictationInvoked(
+    triggerSource: String, inputMode: String, targetApp: String?, takeID: String? = nil
+  ) {
     var props: [String: Any] = ["trigger_source": triggerSource, "input_mode": inputMode]
     if let app = targetApp { props["target_app"] = app }
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
-      var stringProps = ["trigger_source": triggerSource, "input_mode": inputMode]
-      if let app = targetApp { stringProps["target_app"] = app }
+      // DERIVED from `props`, not rebuilt beside it (#1846). A parallel dictionary
+      // is a second implementation, so a test reading it proves nothing about what
+      // PostHog receives: deleting the real `props["take_id"]` line above would
+      // have left every wire-level test green. Every value on this event is a
+      // String, so the projection is lossless here.
+      let stringProps = props.compactMapValues { $0 as? String }
       testEventHook?(
         CapturedTelemetryEvent(name: "dictation.invoked", stringProps: stringProps))
     #endif
@@ -517,10 +528,13 @@ public final class TelemetryService {
   /// this must never page, email, or file a ticket (`sentry-vs-posthog-routing`).
   /// It ships as an observational counter with no threshold, because a threshold
   /// needs a baseline and we have none yet. Metadata only, never audio-derived.
+  /// `takeID` (#1846) names WHICH dictation was interrupted. Omit-when-nil, same
+  /// contract as `dictationInvoked`.
   public func audioCaptureInterrupted(
     cause: String, salvageAttempted: Bool, salvageSucceeded: Bool,
     terminalState: String, backend: String,
-    recordingDurationMs: Int? = nil
+    recordingDurationMs: Int? = nil,
+    takeID: String? = nil
   ) {
     var props: [String: Any] = [
       "cause": cause,
@@ -530,17 +544,26 @@ public final class TelemetryService {
       "backend": backend,
     ]
     if let ms = recordingDurationMs { props["recording_duration_ms"] = ms }
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
       var intProps: [String: Int] = [:]
       if let ms = recordingDurationMs { intProps["recording_duration_ms"] = ms }
+      var stringProps = [
+        "cause": cause, "terminal_state": terminalState, "backend": backend,
+        "salvage_attempted": String(salvageAttempted),
+        "salvage_succeeded": String(salvageSucceeded),
+      ]
+      // Read BACK OUT of `props` (#1846) so the test observes the value that
+      // reaches PostHog, not a parallel copy. A blanket `compactMapValues` is wrong
+      // here: this event's Bools are deliberately stringified above and an
+      // as-String projection would silently drop them.
+      if let takeID = props["take_id"] as? String {
+        stringProps["take_id"] = takeID
+      }
       testEventHook?(
         CapturedTelemetryEvent(
           name: "audio.capture_interrupted",
-          stringProps: [
-            "cause": cause, "terminal_state": terminalState, "backend": backend,
-            "salvage_attempted": String(salvageAttempted),
-            "salvage_succeeded": String(salvageSucceeded),
-          ],
+          stringProps: stringProps,
           intProps: intProps))
     #endif
     PostHogSDK.shared.capture("audio.capture_interrupted", properties: props)

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1269,17 +1269,19 @@ public final class TelemetryService {
   /// (an output was accepted) and from a surfaced attempted failure recorded
   /// by `llm.polish_failed`. `reason` is a `PolishSkipReason.telemetryTag` —
   /// a closed, content-free set (`EnviousWisprPipeline`).
-  public func polishSkipped(provider: String, reason: String) {
-    let props: [String: Any] = [
+  public func polishSkipped(provider: String, reason: String, takeID: String? = nil) {
+    var props: [String: Any] = [
       "provider": provider,
       "skip_reason": reason,
     ]
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
+      // #1846: derived from the emitted payload, never a parallel dictionary.
       testEventHook?(
         CapturedTelemetryEvent(
           name: "llm.polish_skipped",
-          stringProps: ["provider": provider, "skip_reason": reason],
-          boolProps: [:]))
+          stringProps: props.compactMapValues { $0 as? String },
+          boolProps: props.compactMapValues { $0 as? Bool }))
     #endif
     PostHogSDK.shared.capture("llm.polish_skipped", properties: props)
   }
@@ -1297,19 +1299,23 @@ public final class TelemetryService {
   /// `reason` is a `PolishFailureReason.telemetryTag` — a closed, content-free set.
   /// `model` is catalog metadata, matching what `llm.polish_completed` already
   /// sends. No transcript, prompt, provider error body, key, or endpoint URL.
-  public func polishFailed(provider: String, model: String, reason: String, isTimeout: Bool) {
-    let props: [String: Any] = [
+  public func polishFailed(
+    provider: String, model: String, reason: String, isTimeout: Bool, takeID: String? = nil
+  ) {
+    var props: [String: Any] = [
       "provider": provider,
       "model": model,
       "reason": reason,
       "is_timeout": isTimeout,
     ]
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
+      // #1846: derived from the emitted payload, never a parallel dictionary.
       testEventHook?(
         CapturedTelemetryEvent(
           name: "llm.polish_failed",
-          stringProps: ["provider": provider, "model": model, "reason": reason],
-          boolProps: ["is_timeout": isTimeout]))
+          stringProps: props.compactMapValues { $0 as? String },
+          boolProps: props.compactMapValues { $0 as? Bool }))
     #endif
     PostHogSDK.shared.capture("llm.polish_failed", properties: props)
   }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2418,45 +2418,52 @@ public final class TelemetryService {
     backend: String,
     inputRoute: String,
     ready: Bool,
-    modelReused: Bool
+    modelReused: Bool,
+    /// #1846: which dictation this VAD work belongs to. Omit-when-nil.
+    takeID: String? = nil
   ) {
+    // #1846: ONE payload, with the hook derived from it. These three emitters
+    // previously built the hook event and the PostHog properties as two separate
+    // literals, so a test could assert a key that the real capture never sent.
+    var props: [String: Any] = [
+      "backend": backend,
+      "input_route": inputRoute,
+      "ready": ready,
+      "model_reused": modelReused,
+    ]
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
       testEventHook?(
         CapturedTelemetryEvent(
           name: "dictation.vad_preparation_completed",
-          stringProps: ["backend": backend, "input_route": inputRoute],
-          boolProps: ["ready": ready, "model_reused": modelReused]))
+          stringProps: props.compactMapValues { $0 as? String },
+          boolProps: props.compactMapValues { $0 as? Bool }))
     #endif
-    PostHogSDK.shared.capture(
-      "dictation.vad_preparation_completed",
-      properties: [
-        "backend": backend,
-        "input_route": inputRoute,
-        "ready": ready,
-        "model_reused": modelReused,
-      ])
+    PostHogSDK.shared.capture("dictation.vad_preparation_completed", properties: props)
   }
 
   /// Immediately BEFORE the first `SilenceDetector.processChunk` await.
   package func dictationFirstVADChunkStarted(
     backend: String,
     inputRoute: String,
-    monitorToFirstChunkMs: Double
+    monitorToFirstChunkMs: Double,
+    /// #1846: which dictation this VAD work belongs to. Omit-when-nil.
+    takeID: String? = nil
   ) {
+    var props: [String: Any] = [
+      "backend": backend,
+      "input_route": inputRoute,
+      "monitor_to_first_chunk_ms": monitorToFirstChunkMs,
+    ]
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
       testEventHook?(
         CapturedTelemetryEvent(
           name: "dictation.first_vad_chunk_started",
-          stringProps: ["backend": backend, "input_route": inputRoute],
-          doubleProps: ["monitor_to_first_chunk_ms": monitorToFirstChunkMs]))
+          stringProps: props.compactMapValues { $0 as? String },
+          doubleProps: props.compactMapValues { $0 as? Double }))
     #endif
-    PostHogSDK.shared.capture(
-      "dictation.first_vad_chunk_started",
-      properties: [
-        "backend": backend,
-        "input_route": inputRoute,
-        "monitor_to_first_chunk_ms": monitorToFirstChunkMs,
-      ])
+    PostHogSDK.shared.capture("dictation.first_vad_chunk_started", properties: props)
   }
 
   /// Immediately AFTER that await returns. `started` present with `completed`
@@ -2466,24 +2473,26 @@ public final class TelemetryService {
     backend: String,
     inputRoute: String,
     chunkProcessingLatencyMs: Double,
-    shouldStop: Bool
+    shouldStop: Bool,
+    /// #1846: which dictation this VAD work belongs to. Omit-when-nil.
+    takeID: String? = nil
   ) {
+    var props: [String: Any] = [
+      "backend": backend,
+      "input_route": inputRoute,
+      "chunk_processing_latency_ms": chunkProcessingLatencyMs,
+      "should_stop": shouldStop,
+    ]
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
       testEventHook?(
         CapturedTelemetryEvent(
           name: "dictation.first_vad_chunk_completed",
-          stringProps: ["backend": backend, "input_route": inputRoute],
-          doubleProps: ["chunk_processing_latency_ms": chunkProcessingLatencyMs],
-          boolProps: ["should_stop": shouldStop]))
+          stringProps: props.compactMapValues { $0 as? String },
+          doubleProps: props.compactMapValues { $0 as? Double },
+          boolProps: props.compactMapValues { $0 as? Bool }))
     #endif
-    PostHogSDK.shared.capture(
-      "dictation.first_vad_chunk_completed",
-      properties: [
-        "backend": backend,
-        "input_route": inputRoute,
-        "chunk_processing_latency_ms": chunkProcessingLatencyMs,
-        "should_stop": shouldStop,
-      ])
+    PostHogSDK.shared.capture("dictation.first_vad_chunk_completed", properties: props)
   }
 }
 

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -584,7 +584,9 @@ public final class TelemetryService {
     warmPolicy: String,
     retireAction: String,
     msSinceLastGood: Int?,
-    routeFallbackReason: String?
+    routeFallbackReason: String?,
+    /// #1846: which dictation this retire happened during. Omit-when-nil.
+    takeID: String? = nil
   ) {
     let event = "audio.dead_mic_retire_attempted"
     var props: [String: Any] = [
@@ -597,6 +599,7 @@ public final class TelemetryService {
     if let selectedTransport { props["selected_transport"] = selectedTransport }
     if let msSinceLastGood { props["ms_since_last_good"] = msSinceLastGood }
     if let routeFallbackReason { props["route_fallback_reason"] = routeFallbackReason }
+    if let takeID { props["take_id"] = takeID }
     #if DEBUG
       var stringProps: [String: String] = [
         "transport": transport,
@@ -606,6 +609,10 @@ public final class TelemetryService {
       ]
       if let selectedTransport { stringProps["selected_transport"] = selectedTransport }
       if let routeFallbackReason { stringProps["route_fallback_reason"] = routeFallbackReason }
+      // #1846: read BACK OUT of the emitted payload so the test observes what
+      // PostHog receives. Not a blanket as-String projection: this event's Bool and
+      // Int values are deliberately split across typed buckets below.
+      if let takeID = props["take_id"] as? String { stringProps["take_id"] = takeID }
       var intProps: [String: Int] = [:]
       if let msSinceLastGood { intProps["ms_since_last_good"] = msSinceLastGood }
       testEventHook?(

--- a/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
@@ -179,7 +179,62 @@ import Testing
       #expect(calls[1].0 == nil && calls[1].1 == .failed)
     }
   }
+
+  #if DEBUG
+    /// #1846 chunk 10: the cap-warning bridge, BEHAVIOURAL.
+    ///
+    /// `CapWarningTakeIDTests` proves the kernel and driver carry the key;
+    /// `CapWarningTakeIDTelemetryTests` proves a supplied key reaches the payload.
+    /// This covers the App-layer expression joining them — remove `takeID: takeID`
+    /// from the coordinator's telemetry call and every one of those stays green
+    /// while real cap warnings ship with no take key
+    /// (`a-guard-nothing-arms-is-not-a-guard`).
+    ///
+    /// My first version froze the source text instead, justified by "the
+    /// coordinator has no construction seam". That was false — `makeCoordinator`
+    /// right above builds one, and the sibling tests already drive installed
+    /// driver callbacks directly. Caught in review; an unchecked premise in a
+    /// justification is the defect, not the test shape it produced.
+    ///
+    /// Both drivers are exercised because they share ONE closure: a regression
+    /// that wired only Parakeet would otherwise pass.
+    @Test("cap warnings from both drivers forward their take keys to telemetry")
+    func capWarningsForwardTakeKeysToTelemetry() throws {
+      let fixtures = Self.makeCoordinator()
+      fixtures.coordinator.install()
+
+      let box = CapturedEventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "recording.cap_warning_shown" { box.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      let parakeetTakeID = "3c7e5a11-92d4-4f60-b8a7-51e0c6d3f284"
+      let whisperKitTakeID = "8e1b67a4-3fa2-49dc-9478-962df325e10a"
+
+      fixtures.kernelDriver.onApproachingMaxDuration?(45, parakeetTakeID)
+      fixtures.whisperKitKernelDriver.onApproachingMaxDuration?(30, whisperKitTakeID)
+
+      let events = box.values
+      #expect(events.count == 2, "both installed driver callbacks must emit")
+      #expect(
+        events.compactMap { $0.stringProps["take_id"] } == [parakeetTakeID, whisperKitTakeID],
+        "the coordinator must forward each callback's supplied key unchanged"
+      )
+    }
+  #endif
 }
+
+#if DEBUG
+  /// Thread-safe capture sink for `TelemetryService.testEventHook`, whose closure
+  /// is `@Sendable`.
+  final class CapturedEventBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [CapturedTelemetryEvent] = []
+    func append(_ event: CapturedTelemetryEvent) { lock.withLock { stored.append(event) } }
+    var values: [CapturedTelemetryEvent] { lock.withLock { stored } }
+  }
+#endif
 
 /// PR9 of #763 — mutable lock-state stand-in used by the
 /// `recordingLockedAccess` closure pair in tests. Lets the test verify both

--- a/Tests/EnviousWisprTests/Pipeline/CapWarningTakeIDTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CapWarningTakeIDTests.swift
@@ -1,0 +1,194 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprPipeline
+
+// MARK: - Approaching-cap warning carries the take key (#1846 chunk 10)
+//
+// `recording.cap_warning_shown` was the last of the thirteen planned events
+// with no per-dictation identity. The route the plan chose is the one already
+// fenced at source: `VADWarningSignal` carries the `SessionID` of the run that
+// produced it, and the kernel validates that stamp against the current session
+// before forwarding. Chunk 10 stops discarding it.
+//
+// All three tests here are BEHAVIOURAL — they drive the real forwarding code
+// rather than scanning it. The first two emit through the fake VAD seam; the
+// third invokes the kernel-side callback the driver installed in `start()`.
+//
+// `#if DEBUG`-gated like the rest of the simulator suites: the harness depends
+// on kernel test hooks that only exist in DEBUG.
+
+#if DEBUG
+
+  @MainActor
+  @Suite("Approaching-cap warning take key (#1846)")
+  struct CapWarningTakeIDTests {
+
+    // MARK: Kernel — the warning stream forwards the validated identity
+
+    private func makeWrapper() -> (SimulatorContext, KernelRecordingSession) {
+      let clock = FakeClock()
+      let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
+      let capture = FakeAudioCapture()
+      let vad = FakeVADSignalSource()
+      let paste = FakePasteTarget()
+      let wrapper = KernelRecordingSession(
+        engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+      let context = SimulatorContext(
+        sut: wrapper, engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+      return (context, wrapper)
+    }
+
+    /// Drive to `.live` — the only state the warning forward accepts. Reaching
+    /// `.live` needs the first converted buffer (the #1548 D1 transport gate).
+    private func startToRecording(_ context: SimulatorContext) async {
+      await context.sut.apply(.start)
+      await context.sut.drainReadyWork()
+      context.capture.deliverBuffer()
+      await context.sut.drainReadyWork()
+    }
+
+    @Test("a live warning carries this recording's take key")
+    func liveWarningCarriesTakeKey() async throws {
+      let (context, wrapper) = makeWrapper()
+      let observed = WarningLog()
+      wrapper.testKernel.onApproachingMaxDuration = { remaining, takeID in
+        observed.append(remaining: remaining, takeID: takeID)
+      }
+
+      await startToRecording(context)
+      context.vad.emitWarning(remainingSeconds: 45)
+      await context.sut.drainReadyWork()
+
+      #expect(observed.entries.count == 1, "the warning must reach the callback exactly once")
+      let entry = try #require(observed.entries.first)
+      let sessionTakeID = try #require(wrapper.telemetryState.takeID)
+      #expect(entry.remaining == 45)
+      #expect(entry.takeID.isEmpty == false)
+      // The identity assertion. `start(config:)` projects `telemetryState.takeID`
+      // from the same `SessionID` the warning is stamped with and validated
+      // against, so on this path the two are the same value — and that is the
+      // value every other take-keyed event in this session already carries.
+      #expect(
+        entry.takeID == sessionTakeID,
+        "the warning's key must be the same take key the rest of the session emits")
+      #expect(UUID(uuidString: entry.takeID) != nil, "the take key is a session UUID string")
+    }
+
+    /// A mismatched stamp is dropped before forwarding. The positive control in
+    /// the same live session proves the callback is reachable, so the empty result
+    /// is the session-stamp guard working rather than a dead fixture.
+    ///
+    /// Named for what the fixture actually builds: `emitStaleWarning` mints a
+    /// fresh `SessionID`, which is non-current but not a proven PRIOR session.
+    /// Rejection of a mismatched stamp is the invariant, and that is what is
+    /// asserted — the earlier "superseded session" wording overstated the setup.
+    @Test("a warning with a non-current session stamp is dropped")
+    func nonCurrentWarningIsDropped() async throws {
+      let (context, wrapper) = makeWrapper()
+      let observed = WarningLog()
+      wrapper.testKernel.onApproachingMaxDuration = { remaining, takeID in
+        observed.append(remaining: remaining, takeID: takeID)
+      }
+
+      await startToRecording(context)
+      context.vad.emitStaleWarning(remainingSeconds: 45)
+      await context.sut.drainReadyWork()
+
+      #expect(observed.entries.isEmpty, "a non-current stamp must not reach the callback")
+
+      // Positive control in the same session: the drop above is the stamp check
+      // doing its job, not the callback being unreachable from this fixture.
+      context.vad.emitWarning(remainingSeconds: 30)
+      await context.sut.drainReadyWork()
+      #expect(observed.entries.count == 1)
+      let entry = try #require(observed.entries.first)
+      let sessionTakeID = try #require(wrapper.telemetryState.takeID)
+      #expect(entry.takeID == sessionTakeID)
+    }
+
+    // MARK: Driver — the public callback forwards both values unchanged
+
+    @Test("the driver forwards the kernel's take key to its public callback")
+    func driverForwardsTakeKey() async throws {
+      let fixture = Self.makeDriverFixture()
+      let observed = WarningLog()
+      fixture.driver.onApproachingMaxDuration = { remaining, takeID in
+        observed.append(remaining: remaining, takeID: takeID)
+      }
+
+      // `driver.start()` (in the fixture) installs the kernel-side closure; this
+      // exercises that installed closure, which is the line under test. Driving a
+      // real cap warning through the kernel is covered above — duplicating it
+      // here would not isolate the driver's own forwarding.
+      let expected = UUID().uuidString
+      fixture.kernel.onApproachingMaxDuration?(45, expected)
+
+      #expect(observed.entries.count == 1)
+      let entry = try #require(observed.entries.first)
+      #expect(entry.remaining == 45)
+      #expect(
+        entry.takeID == expected,
+        """
+        the driver must forward the kernel's key unchanged — never substitute `lastTakeID`, \
+        which is the CONCLUDED key and is not yet stamped mid-recording
+        """)
+    }
+
+    private struct DriverFixture {
+      let driver: KernelDictationDriver
+      let kernel: RecordingSessionKernel
+    }
+
+    private static func makeDriverFixture() -> DriverFixture {
+      let steps = LimbSteps(
+        wordCorrection: WordCorrectionStep(),
+        fillerRemoval: FillerRemovalStep(),
+        emojiFormatter: EmojiFormatterStep(),
+        inverseTextNormalization: InverseTextNormalizationStep(),
+        llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
+        emojiRestore: EmojiRestoreStep())
+      let adapter = FakeEngine(behavior: .batchSuccess(text: "x"), clock: FakeClock())
+      let kernel = RecordingSessionKernel(
+        adapter: adapter,
+        audioCapture: FakeAudioCapture(),
+        vad: FakeVADSignalSource(),
+        currentTick: { 0 }, sleepTicks: { _ in },
+        processText: { raw, _ in raw },
+        store: { _, _ in }, deliver: { _ in .pasted },
+        engineMutationScope: .alwaysAllowedForTesting,
+        minimumRecordingTicks: 0)
+      let observer = KernelHeartPathTelemetryObserver(
+        kernel: kernel, audioCapture: FakeAudioCapture(),
+        emitter: HeartPathTelemetryEmitter(
+          backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
+        emitLifecycleEvent: { _ in })
+      let driver = KernelDictationDriver(
+        kernel: kernel, observer: observer, outcome: KernelFinalizationOutcome(),
+        context: KernelSessionContext(), steps: steps, adapter: adapter,
+        engineMutationScope: .alwaysAllowedForTesting)
+      driver.start()
+      return DriverFixture(driver: driver, kernel: kernel)
+    }
+
+    /// Reference-type log so the `@MainActor` callbacks can record without the
+    /// closures capturing a mutating local.
+    @MainActor
+    final class WarningLog {
+      struct Entry {
+        let remaining: TimeInterval
+        let takeID: String
+      }
+      private(set) var entries: [Entry] = []
+      func append(remaining: TimeInterval, takeID: String) {
+        entries.append(Entry(remaining: remaining, takeID: takeID))
+      }
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CaptureVADSignalSourceTests.swift
@@ -264,9 +264,11 @@ import Testing
   struct PrepFailure: Error {}
 
   @MainActor final class SinkSpy {
-    var prep: [(backend: String, route: String, ready: Bool, reused: Bool)] = []
-    var started: [(backend: String, route: String, ms: Double)] = []
-    var completed: [(backend: String, route: String, ms: Double, stop: Bool)] = []
+    /// #1846: `take` is the take key each marker carried.
+    var prep: [(backend: String, route: String, ready: Bool, reused: Bool, take: String?)] = []
+    var started: [(backend: String, route: String, ms: Double, take: String?)] = []
+    var completed:
+      [(backend: String, route: String, ms: Double, stop: Bool, take: String?)] = []
     /// Fired by the markers waiters actually block on, so a wait resolves on a
     /// real event and never a yield count (`test-timing.md`: wait for a
     /// signal, not a clock).
@@ -276,15 +278,15 @@ import Testing
     func makeSink() -> RecordStartTelemetrySink {
       RecordStartTelemetrySink(
         breadcrumb: { _, _, _ in },
-        emitPreparation: { [self] b, r, ready, reused in
-          prep.append((b, r, ready, reused))
+        emitPreparation: { [self] b, r, ready, reused, take in
+          prep.append((b, r, ready, reused, take))
           prepMarker.release()
         },
-        emitChunkStarted: { [self] b, r, ms in
-          started.append((b, r, ms))
+        emitChunkStarted: { [self] b, r, ms, take in
+          started.append((b, r, ms, take))
         },
-        emitChunkCompleted: { [self] b, r, ms, stop in
-          completed.append((b, r, ms, stop))
+        emitChunkCompleted: { [self] b, r, ms, stop, take in
+          completed.append((b, r, ms, stop, take))
           completedMarker.release()
         })
     }
@@ -412,6 +414,44 @@ import Testing
     #expect(spy.started.allSatisfy { $0.backend == "backendA" && $0.route == "routeA" })
     #expect(spy.completed.allSatisfy { $0.backend == "backendA" && $0.route == "routeA" })
     #expect(spy.completed.first?.stop == false)
+  }
+
+  /// #1846: all three VAD markers must name the take they belong to.
+  ///
+  /// MY FIRST VERSION OF THIS TEST ASSERTED SOMETHING UNREACHABLE, and the correction
+  /// is worth recording. I stamped a LATER session id after the run began, expecting
+  /// the markers to keep the original — the freeze the run's `runSessionID` capture
+  /// exists for. The run emitted nothing at all instead: `monitorIsCurrent` refuses a
+  /// superseded run outright, which `staleSessionBeforeFirstExecution` below already
+  /// proves. So a later session cannot MISLABEL these markers, because it terminates
+  /// the run rather than relabelling it — the window is closed, not handled.
+  ///
+  /// What remains testable, and what this asserts, is that every marker carries the
+  /// run's own key rather than nothing.
+  @Test("all three VAD markers carry the run's own take key")
+  func vadMarkersCarryTheRunsOwnTakeKey() async throws {
+    let spy = SinkSpy()
+    let capture = FakeAudioCapture()
+    Self.feedChunks(capture, 1)
+    let live = Box(true)
+    let source = Self.makeSource(spy: spy, vad: { OpenVad() })
+
+    let runSID = SessionID()
+    Self.begin(source, capture: capture, sid: runSID, backend: "backendA", live: live)
+
+    try #require(
+      await Self.awaitSignal(spy.completedMarker),
+      "the run never completed its first chunk — the test would be vacuous")
+    live.value = false
+    await source.finalizeAtStop(rawSampleCount: capture.capturedSamples.count)
+
+    let expected = runSID.raw.uuidString
+    #expect(spy.prep.count == 1)
+    #expect(spy.started.count == 1)
+    #expect(spy.completed.count == 1)
+    #expect(spy.prep.allSatisfy { $0.take == expected })
+    #expect(spy.started.allSatisfy { $0.take == expected })
+    #expect(spy.completed.allSatisfy { $0.take == expected })
   }
 
   @Test("a run superseded before it first executes emits nothing")

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -107,9 +107,8 @@ struct DictationInvokedPipelineWiringTests {
   /// `llm.polish_skipped` ship with no take key at all.
   ///
   /// It also freezes WHICH key: the live in-flight one. Polish runs before the session
-  /// terminal, so `lastTakeID` is not yet stamped for this take — swapping in the
-  /// concluded key here would silently label every polish event with the PREVIOUS
-  /// dictation, or with nothing.
+  /// terminal, and starting a session clears `lastTakeID`, so it is nil here —
+  /// swapping in the concluded key would ship every polish event with NO take key.
   @Test("live polish reporting uses the in-flight take key, not the concluded one")
   func polishReportingUsesInFlightTakeKey() throws {
     let wiringSource = try Self.read(
@@ -139,7 +138,7 @@ struct DictationInvokedPipelineWiringTests {
       codeOnly.contains("lastTakeID") == false,
       """
       the concluded key is the WRONG one here — polish runs before the terminal that \
-      stamps it, so this would label polish events with the previous dictation or nothing.
+      stamps it, and a new session clears it, so this would emit no take key at all.
       """)
     // Prove the filter did not strip the line under test along with the comments.
     #expect(codeOnly.contains("takeID: telemetryState.takeID)"))

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -97,6 +97,54 @@ struct DictationInvokedPipelineWiringTests {
   // `KernelDictationDriverFactoryWhisperKitTests
   // .makeForWhisperKitReturnsDriverWithWhisperKitIdentity`.
 
+  /// #1846 chunk 7: the SECOND production bridge, written proactively because chunk 6
+  /// shipped without its equivalent and the reviewer had to find it.
+  ///
+  /// `TextProcessingRunnerCaptureTests` proves the runner freezes a supplied key into
+  /// the context and that both polish outcome events carry it. Nothing else covers the
+  /// one expression that supplies it in production. Delete `takeID: telemetryState.takeID`
+  /// and every polish test stays green while `llm.polish_failed` and
+  /// `llm.polish_skipped` ship with no take key at all.
+  ///
+  /// It also freezes WHICH key: the live in-flight one. Polish runs before the session
+  /// terminal, so `lastTakeID` is not yet stamped for this take — swapping in the
+  /// concluded key here would silently label every polish event with the PREVIOUS
+  /// dictation, or with nothing.
+  @Test("live polish reporting uses the in-flight take key, not the concluded one")
+  func polishReportingUsesInFlightTakeKey() throws {
+    let wiringSource = try Self.read(
+      "Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift")
+    let runCall = try Self.slice(
+      wiringSource,
+      from: "let result = try await textProcessingRunner.run(",
+      to: "let ctx = result.context"
+    )
+    #expect(
+      runCall.contains("takeID: telemetryState.takeID)"),
+      "the live finalization path must supply the in-flight take key to the polish chain"
+    )
+
+    // The negative check runs over CODE ONLY. Its first version scanned the whole
+    // slice and failed on the explanatory comment right above the argument, which
+    // legitimately names `kernel.lastTakeID` to say why it is NOT used here. A
+    // matcher that cannot tell an action from prose about the action is the
+    // imprecise thing; the fix is the matcher, never rewording the comment to
+    // appease it (`false-positives-not-gates-train-evasion`).
+    let codeOnly =
+      runCall
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+      .joined(separator: "\n")
+    #expect(
+      codeOnly.contains("lastTakeID") == false,
+      """
+      the concluded key is the WRONG one here — polish runs before the terminal that \
+      stamps it, so this would label polish events with the previous dictation or nothing.
+      """)
+    // Prove the filter did not strip the line under test along with the comments.
+    #expect(codeOnly.contains("takeID: telemetryState.takeID)"))
+  }
+
   private static func read(_ relativePath: String) throws -> String {
     let root = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -145,6 +145,40 @@ struct DictationInvokedPipelineWiringTests {
     #expect(codeOnly.contains("takeID: telemetryState.takeID)"))
   }
 
+  /// #1846 chunk 8: the dead-mic retire bridge. `HeartPathTelemetryEmitterTests`
+  /// proves a supplied key reaches the payload; nothing else covers the expression
+  /// that supplies it in production. Replace `telemetryState.takeID` with `nil` and
+  /// that emitter test stays green while every real retire loses its take key.
+  ///
+  /// Also freezes WHICH key: live, not concluded. A retire fires mid-session, before
+  /// any terminal stamps `lastTakeID`.
+  @Test("dead mic retire supplies the in-flight take key from the kernel")
+  func deadMicRetireSuppliesInFlightTakeKey() throws {
+    let kernelSource = try Self.read(
+      "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift")
+    let construction = try Self.slice(
+      kernelSource,
+      from: "DeadMicRetireAttemptContext(",
+      to: "// Arm the recovery watch ONLY when teardown actually ran"
+    )
+    #expect(
+      construction.contains("takeID: telemetryState.takeID))"),
+      "the kernel must stamp the in-flight take key onto every dead-mic retire context"
+    )
+
+    // Code only — the comment above the argument names the concluded key to explain
+    // why it is not used, and a matcher that cannot tell an action from prose about
+    // it is the imprecise thing (`false-positives-not-gates-train-evasion`).
+    let codeOnly =
+      construction
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+      .joined(separator: "\n")
+    #expect(codeOnly.contains("lastTakeID") == false)
+    // Prove the filter did not strip the line under test along with the comments.
+    #expect(codeOnly.contains("takeID: telemetryState.takeID))"))
+  }
+
   private static func read(_ relativePath: String) throws -> String {
     let root = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -32,7 +32,13 @@ struct DictationInvokedPipelineWiringTests {
       to: "case .recordingStopped"
     )
 
-    #expect(body.contains("dictationInvoked(triggerSource, inputMode, targetApp)"))
+    // #1846 added the take key as a fourth argument. Frozen with the key included
+    // rather than loosened to a prefix match: the point of this assertion is that
+    // the sink forwards EXACTLY these values, and a prefix match would stop
+    // noticing if a later change dropped an argument.
+    #expect(
+      body.contains("dictationInvoked(triggerSource, inputMode, targetApp, telemetryState.takeID)")
+    )
     // #723: trigger_source and input_mode are distinct schema slots; sink
     // must read them from distinct config fields.
     #expect(body.contains("context.config?.triggerSource.rawValue"))

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -179,6 +179,39 @@ struct DictationInvokedPipelineWiringTests {
     #expect(codeOnly.contains("takeID: telemetryState.takeID))"))
   }
 
+  /// #1846 chunk 9: the VAD marker bridge. `VADMarkerTakeIDTelemetryTests` proves a
+  /// supplied key reaches all three payloads. `CaptureVADSignalSourceTests`
+  /// behaviourally proves every marker carries the run's key, so replacing one
+  /// argument with `nil` fails that test too. This source scan additionally freezes
+  /// all three call sites and the exact identity expression used at each one.
+  ///
+  /// It also freezes WHICH value: `runSessionID`, captured once at run start and
+  /// validated by `monitorIsCurrent` immediately before each emission. A superseded
+  /// run emits nothing; forwarding the validated snapshot avoids a second live read
+  /// and keeps the marker tied to the authority the guard accepted.
+  @Test("VAD markers supply the run's frozen session id, not a live read")
+  func vadMarkersSupplyFrozenRunSessionID() throws {
+    let source = try Self.read(
+      "Sources/EnviousWisprPipeline/CaptureVADSignalSource.swift")
+
+    // All three call sites, each supplying the frozen run id.
+    let supplied = source.components(separatedBy: "takeID: runSessionID.raw.uuidString").count - 1
+    #expect(
+      supplied == 3,
+      "all three VAD markers must supply the run's frozen session id, found \(supplied)")
+
+    // And none of them reads the live property at emit time.
+    let codeOnly =
+      source
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+      .joined(separator: "\n")
+    #expect(codeOnly.contains("takeID: currentSessionID") == false)
+    #expect(codeOnly.contains("takeID: self.currentSessionID") == false)
+    // Prove the filter did not strip the lines under test along with the comments.
+    #expect(codeOnly.contains("takeID: runSessionID.raw.uuidString"))
+  }
+
   private static func read(_ relativePath: String) throws -> String {
     let root = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -46,6 +46,45 @@ struct DictationInvokedPipelineWiringTests {
     #expect(body.contains("context.targetApp?.localizedName"))
   }
 
+  /// #1846: the BRIDGE between two things that are each tested and neither of which
+  /// covers the line joining them. `RecordingSessionKernelTests` proves the kernel
+  /// freezes `lastTakeID`; `DictationCompletedRouteFieldsTests` proves a supplied
+  /// `takeID` reaches all four completion events. Delete `takeID: driver.lastTakeID`
+  /// and BOTH stay green while production emits no completion take keys at all —
+  /// `a-guard-nothing-arms-is-not-a-guard`.
+  ///
+  /// Asserted by a narrow source scan because this is a pure forwarding bridge
+  /// between two independently behaviour-tested endpoints. Unit tests can construct
+  /// a driver, but driving full finalization here would duplicate both endpoint tests
+  /// without isolating this one removable expression. The scan proves only that the
+  /// accessor and forwarding wiring remain present.
+  @Test("completion reporting uses the kernel's frozen concluded take key")
+  func completionReportingUsesFrozenConcludedTakeKey() throws {
+    let driverSource = try Self.read(
+      "Sources/EnviousWisprPipeline/KernelDictationDriver.swift")
+    let accessor = try Self.slice(
+      driverSource,
+      from: "public var lastStopReason",
+      to: "public var lastRecordingDurationSeconds"
+    )
+    #expect(
+      accessor.contains("public var lastTakeID: String? { kernel.lastTakeID }"),
+      "the driver must expose the kernel's frozen concluded key, never the live in-flight key"
+    )
+
+    let reportingSource = try Self.read(
+      "Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift")
+    let reportCall = try Self.slice(
+      reportingSource,
+      from: "TelemetryService.shared.reportDictationCompleted(",
+      to: "\n  }\n\n  private static func positive"
+    )
+    #expect(
+      reportCall.contains("takeID: driver.lastTakeID)"),
+      "the App completion bridge must forward the concluded key into the four-event fan-out"
+    )
+  }
+
   // PR-5 Rung 5 (#827) rewrite: WhisperKit now flows through the same kernel
   // sink as Parakeet — `parakeetPipelineEmitsAfterRecordingStarts` above
   // covers the shared dictation.invoked path for both engines. The legacy

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -211,6 +211,59 @@ struct DictationInvokedPipelineWiringTests {
     #expect(codeOnly.contains("takeID: runSessionID.raw.uuidString"))
   }
 
+  /// #1846 cloud review: the take tag must be published SYNCHRONOUSLY at session
+  /// acceptance, not on the first observed lifecycle event.
+  ///
+  /// `observeKernelState` delivers that first event through an unstructured
+  /// `Task { @MainActor }`, which has no ordering guarantee against the kernel's
+  /// own spawned `runForwardPath`. A model-load or capture-start failure — the
+  /// errors most likely to fire early, and precisely the ones this feature exists
+  /// to join — could therefore be raised before the tag existed.
+  ///
+  /// Frozen as a source scan because the defect is about WHEN the call happens
+  /// relative to `spawn`, which a behavioural assertion after an await cannot
+  /// distinguish from the async path it is meant to rule out.
+  @Test("the take tag is established synchronously at session acceptance")
+  func takeTagIsEstablishedSynchronouslyOnAcceptance() throws {
+    let kernelSource = try Self.read(
+      "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift")
+    let accept = try Self.slice(
+      kernelSource,
+      from: "telemetryState.resetForNewSession(",
+      to: "transition(to: .arming)"
+    )
+    #expect(
+      accept.contains("sessionAcceptedTelemetry(sid.raw.uuidString)"),
+      "the tag must be published in the same turn that accepts the session"
+    )
+    // And it must precede the first `spawn`, or the window is not closed.
+    let startBody = try Self.slice(
+      kernelSource, from: "let sid = SessionID()", to: "awaitRecordingExit")
+    let hookAt = try #require(startBody.range(of: "sessionAcceptedTelemetry("))
+    let spawnAt = try #require(startBody.range(of: "spawn("))
+    #expect(
+      hookAt.lowerBound < spawnAt.lowerBound,
+      "publishing after the first spawn would leave exactly the window this closes"
+    )
+
+    // The sink remains the single writer of the scope tag.
+    let sinkSource = try Self.read(
+      "Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift")
+    #expect(sinkSource.contains("func establishTakeID(_ takeID: String) {"))
+    let establish = try Self.slice(
+      sinkSource, from: "func establishTakeID(_ takeID: String) {", to: "\n  }")
+    #expect(
+      establish.contains("updateTakeID(takeID)"),
+      "must route through the same writer as the per-event refresh and terminal clear"
+    )
+
+    // And production actually wires it — an unwired hook is a dead guard.
+    let factorySource = try Self.read(
+      "Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift")
+    #expect(factorySource.contains("telemetryRelay.establishTakeID(takeID)"))
+    #expect(factorySource.contains("lifecycleSink.establishTakeID(takeID)"))
+  }
+
   private static func read(_ relativePath: String) throws -> String {
     let root = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()

--- a/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EGOnePipelineRoutingTests.swift
@@ -64,7 +64,7 @@ struct EGOnePipelineRoutingTests {
     // so this suite can never reach the real PostHog failure client (#1446).
     let runner = TextProcessingRunner(
       telemetry: .init(
-        captureError: spy.sink, recordPolishFailed: { _, _, _, _ in },
+        captureError: spy.sink, recordPolishFailed: { _, _, _, _, _ in },
         // This suite asserts on the real `llm.polish_skipped` via testEventHook.
         recordPolishSkipped: TextProcessingRunner.TelemetrySeams.live.recordPolishSkipped),
       timeoutExecutor: executor.run)

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -41,6 +41,10 @@ struct HeartPathTelemetryEmitterTests {
     var breadcrumbs: [CapturedBreadcrumb] = []
   }
 
+  /// #1846: a fixed take key so a failure message names a stable value and the
+  /// assertion cannot pass by comparing a freshly generated id to itself.
+  private static let takeID = "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33"
+
   private static func makeEmitter(
     backend: ASRBackendType,
     captureTelemetry: CaptureTelemetryState = CaptureTelemetryState(),
@@ -543,7 +547,7 @@ struct HeartPathTelemetryEmitterTests {
   // reference the DEBUG-only hook).
   #if DEBUG
     @Test("deadMicRetireAttempted adds one breadcrumb AND one PostHog event with full props")
-    func deadMicRetireAttemptedFansOut() {
+    func deadMicRetireAttemptedFansOut() throws {
       let recorder = Recorder()
       let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
 
@@ -561,7 +565,8 @@ struct HeartPathTelemetryEmitterTests {
           healthGuessRefused: true,
           warmPolicy: "seconds30",
           retireAction: "retired",
-          routeFallbackReason: nil))
+          routeFallbackReason: nil,
+          takeID: Self.takeID))
 
       #expect(recorder.breadcrumbs.count == 1)
       #expect(recorder.breadcrumbs.first?.message == "Dead mic retire attempted")
@@ -572,13 +577,48 @@ struct HeartPathTelemetryEmitterTests {
       #expect(recorder.breadcrumbs.first?.data["health_guess_refused"] as? Bool == true)
       #expect(recorder.errors.isEmpty)  // breadcrumb only, no standalone Sentry event
 
-      let captured = box.event
-      #expect(captured?.name == "audio.dead_mic_retire_attempted")
-      #expect(captured?.stringProps["transport"] == "bluetooth")
-      #expect(captured?.stringProps["failure_shape"] == "all_zero_from_start")
-      #expect(captured?.stringProps["warm_policy"] == "seconds30")
-      #expect(captured?.stringProps["retire_action"] == "retired")
-      #expect(captured?.boolProps["health_guess_refused"] == true)
+      let captured = try #require(box.event)
+      #expect(captured.name == "audio.dead_mic_retire_attempted")
+      #expect(captured.stringProps["transport"] == "bluetooth")
+      #expect(captured.stringProps["failure_shape"] == "all_zero_from_start")
+      #expect(captured.stringProps["warm_policy"] == "seconds30")
+      #expect(captured.stringProps["retire_action"] == "retired")
+      #expect(captured.boolProps["health_guess_refused"] == true)
+      // #1846: which dictation the retire happened during. Asserted on the payload
+      // PostHog receives (the hook reads it back out of `props`), not on a mirror.
+      #expect(captured.stringProps["take_id"] == Self.takeID)
+    }
+
+    /// Defensive omit-when-nil schema contract. Production's sole kernel caller
+    /// explicitly supplies the live take projection; this case proves that an
+    /// absent optional value never becomes a placeholder or suppresses the event.
+    @Test("dead mic retire omits take_id when the optional take projection is nil")
+    func deadMicRetireOmitsTakeIDWhenNil() throws {
+      let recorder = Recorder()
+      let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+      let box = CapturedEventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      emitter.deadMicRetireAttempted(
+        ctx: DeadMicRetireAttemptContext(
+          transport: "bluetooth",
+          selectedTransport: "bluetooth",
+          failureShape: "all_zero_from_start",
+          healthGuessRefused: true,
+          warmPolicy: "seconds30",
+          retireAction: "retired",
+          routeFallbackReason: nil,
+          takeID: nil))
+
+      let captured = try #require(box.event)
+      #expect(captured.stringProps["take_id"] == nil)
+      // The event still fired, so the nil suppressed nothing.
+      #expect(captured.name == "audio.dead_mic_retire_attempted")
+      #expect(captured.stringProps["transport"] == "bluetooth")
     }
 
     @Test("deadMicRecovered adds one breadcrumb AND one PostHog event with full props")

--- a/Tests/EnviousWisprTests/Pipeline/KernelInterruptedTranscriptTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelInterruptedTranscriptTests.swift
@@ -134,7 +134,8 @@ struct KernelInterruptedTranscriptTests {
     let wiring = makeWiring(telemetryState: telemetryState, saved: saved)
 
     telemetryState.interruptionCause = .engineLost
-    telemetryState.resetForNewSession(polishEnabled: false)
+    telemetryState.resetForNewSession(
+      takeID: "3c8f5b21-7d94-4a60-b1e8-5f2a9c04d7e6", polishEnabled: false)
     try await wiring.store("hi", UUID())
 
     #expect(telemetryState.interruptionCause == nil)

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleRecordingScopeBaselineTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleRecordingScopeBaselineTests.swift
@@ -1,0 +1,167 @@
+import EnviousWisprAudio
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - Baseline: terminal recording-scope clearing (#1846)
+//
+// These two tests assert a defect that EXISTS on unmodified `origin/main`, so
+// they are RED there and GREEN only after the generic terminal postamble lands
+// (`RULE: red-test-during-a-fix-runs-against-baseline-first`). A green baseline
+// would mean the test is wrong, not that the code is right.
+//
+// DELIBERATELY BASELINE-COMPATIBLE. This file is kept separate from the take-ID
+// tests and references NO #1846 symbol — no `KernelTelemetryState.takeID`, no
+// `updateTakeID`, no `dictation.take_id`. That is what lets it be copied into a
+// worktree at `origin/main` and COMPILE there. If it failed to compile, the
+// resulting red would prove nothing about the defect: a compile error is not a
+// failing assertion, and treating one as the other is the same worthless signal
+// as a green that never ran anything.
+//
+// Measured on `origin/main` before the fix: of the seven terminal lifecycle
+// events, five arms had no arm-local `recording.active` clear
+// (`.pipelineCompleted`, `.failed`, `.discarded`, `.noSpeech`, `.cancelled`) and
+// two did (`.audioInterrupted`, `.asrInterrupted`).
+
+#if DEBUG
+
+  @MainActor
+  @Suite("Terminal recording-scope clearing baseline (#1846)")
+  struct KernelLifecycleRecordingScopeBaselineTests {
+
+    /// Records only the seam under test. Intentionally minimal so nothing here
+    /// can depend on a symbol added by #1846.
+    @MainActor
+    private final class RecordingStateRecorder {
+      struct Call: Equatable {
+        let active: Bool
+        let backend: String?
+        let isStreaming: Bool?
+      }
+      var calls: [Call] = []
+      var inactiveCalls: [Call] { calls.filter { !$0.active } }
+    }
+
+    private func makeSink(
+      recorder: RecordingStateRecorder,
+      telemetryState: KernelTelemetryState = KernelTelemetryState()
+    ) -> KernelLifecycleTelemetrySink {
+      // Every argument here exists on `origin/main`. `updateTakeID` is
+      // deliberately NOT passed — it is defaulted, so omitting it compiles
+      // against both the baseline and the fixed tree.
+      //
+      // Do NOT "fix" that by adding it: naming the argument is exactly what would
+      // break baseline compilation and destroy this file's only purpose. It is
+      // safe because that seam's default is INERT (`{ _ in }`), which is the
+      // reason the sink breaks convention there; production wires it in
+      // `KernelDictationDriverFactory`. So this file still reaches no real vendor
+      // scope. If anyone ever restores a real default on that seam, this file
+      // starts mutating global Sentry state silently.
+      KernelLifecycleTelemetrySink(
+        backend: .parakeet,
+        audioCapture: FakeAudioCapture(),
+        context: KernelSessionContext(),
+        captureTelemetry: CaptureTelemetryState(),
+        telemetryState: telemetryState,
+        breadcrumb: { _, _, _ in },
+        updateRecordingState: { active, backend, isStreaming in
+          recorder.calls.append(
+            RecordingStateRecorder.Call(
+              active: active, backend: backend, isStreaming: isStreaming))
+        },
+        updateAudioRoute: { _ in },
+        dictationInvoked: { _, _, _ in },
+        modelLoadWedged: { _, _ in },
+        captureError: { _, _, _, _ in },
+        // Injected so these two tests do not reach the real PostHog SDK
+        // (`tests-no-process-global-mutable-delegate`).
+        audioCaptureInterrupted: { _, _, _, _, _, _ in },
+        deadMicRecovered: { _ in }
+      )
+    }
+
+    // MARK: Test 1 — the `.failed` terminal
+
+    /// RED on `origin/main`: the `.failed` arm emits its capture error and
+    /// returns without ever clearing capture scope, so a later unrelated Sentry
+    /// event inherits `recording.active=true`.
+    @Test("the .failed terminal clears recording scope")
+    func failedTerminalClearsRecordingScope() {
+      let recorder = RecordingStateRecorder()
+      let sink = makeSink(recorder: recorder)
+
+      sink.emit(.failed(.asrEmpty))
+
+      #expect(
+        recorder.inactiveCalls.count == 1,
+        """
+        the .failed terminal must clear recording.active exactly once, but \
+        \(recorder.inactiveCalls.count) inactive updates were emitted. On \
+        unmodified origin/main this is 0 — the .failed arm has no clear of its \
+        own and no generic terminal postamble runs after it.
+        """)
+    }
+
+    // MARK: Test 2 — cancel arriving during `.stopping`
+
+    /// RED on `origin/main` for the same reason, reached through the REAL route
+    /// rather than by calling `.cancelled` directly: a cancel landing while the
+    /// kernel is `.stopping` calls `finishTerminal(.cancelled)` and the resuming
+    /// stop path returns early on `recordingOutcome != nil`, so the stop marker
+    /// — the one place capture scope would otherwise be cleared — never runs.
+    ///
+    /// Driving the route matters. Emitting `.cancelled` straight into the sink
+    /// would still be red, but it would not prove that this PATH reaches a
+    /// terminal without passing the stop marker, which is the actual defect.
+    @Test("a cancel during .stopping clears recording scope")
+    func cancelDuringStoppingClearsRecordingScope() async throws {
+      let clock = FakeClock()
+      let wrapper = KernelRecordingSession(
+        engine: FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock),
+        capture: FakeAudioCapture(),
+        vad: FakeVADSignalSource(),
+        clock: clock,
+        paste: FakePasteTarget())
+      let kernel = wrapper.testKernel
+
+      // Legal transitions to the stopping state, matching the existing FSM tests.
+      kernel.testForceTransition(to: .arming)
+      kernel.testForceTransition(to: .live)
+      kernel.testForceTransition(to: .stopping)
+      #expect(kernel.state == .stopping)
+
+      kernel.cancel()
+
+      // Route assertion — must already pass on origin/main. If this fails, the
+      // test is wrong about the route and the scope assertion below is moot.
+      #expect(
+        kernel.recordingOutcome == .cancelled,
+        "a cancel during .stopping must conclude .cancelled before the scope assertion means anything"
+      )
+
+      // Project the outcome through the existing terminal authority rather than
+      // hand-picking an event, so the test cannot drift from what the observer
+      // would really emit.
+      let outcome = try #require(kernel.recordingOutcome)
+      let event = try #require(
+        KernelHeartPathTelemetryObserver.terminalEvent(for: outcome, isStreaming: false))
+
+      let recorder = RecordingStateRecorder()
+      let sink = makeSink(recorder: recorder)
+      sink.emit(event)
+
+      #expect(
+        recorder.inactiveCalls.count == 1,
+        """
+        a cancel during .stopping must clear recording.active exactly once, but \
+        \(recorder.inactiveCalls.count) inactive updates were emitted. On \
+        unmodified origin/main this is 0 — the .cancelled arm has no clear and \
+        this route never reaches the stop marker.
+        """)
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleRecordingScopeBaselineTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleRecordingScopeBaselineTests.swift
@@ -57,9 +57,23 @@ import Testing
       // break baseline compilation and destroy this file's only purpose. It is
       // safe because that seam's default is INERT (`{ _ in }`), which is the
       // reason the sink breaks convention there; production wires it in
-      // `KernelDictationDriverFactory`. So this file still reaches no real vendor
-      // scope. If anyone ever restores a real default on that seam, this file
-      // starts mutating global Sentry state silently.
+      // `KernelDictationDriverFactory`. If anyone ever restores a real default on
+      // that seam, this file starts mutating global Sentry state silently.
+      //
+      // `dictationInvoked` and `audioCaptureInterrupted` are ALSO not named, and
+      // that is load-bearing rather than an oversight. Chunk 5 widened both seams
+      // with a `takeID` parameter; naming either one would pin this file to the
+      // post-Chunk-5 arity and it would stop compiling on `origin/main`. They are
+      // safe UNNAMED because neither is reachable from these two tests, which is a
+      // stronger guarantee than injecting a no-op: `dictationInvoked` fires only
+      // from the `.recordingCommitted` arm, and `audioCaptureInterrupted` is
+      // guarded on `telemetryState.interruptionCause != nil`. Neither test emits
+      // that event or sets that cause.
+      //
+      // WARNING for whoever adds the third test here: if it emits
+      // `.recordingCommitted` or sets `interruptionCause`, it WILL reach the real
+      // PostHog SDK through those defaults. Inject them then, and accept that doing
+      // so ends this file's `origin/main` compatibility.
       KernelLifecycleTelemetrySink(
         backend: .parakeet,
         audioCapture: FakeAudioCapture(),
@@ -73,12 +87,8 @@ import Testing
               active: active, backend: backend, isStreaming: isStreaming))
         },
         updateAudioRoute: { _ in },
-        dictationInvoked: { _, _, _ in },
         modelLoadWedged: { _, _ in },
         captureError: { _, _, _, _ in },
-        // Injected so these two tests do not reach the real PostHog SDK
-        // (`tests-no-process-global-mutable-delegate`).
-        audioCaptureInterrupted: { _, _, _, _, _, _ in },
         deadMicRecovered: { _ in }
       )
     }

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -66,6 +66,24 @@ import Testing
     var captureErrors: [CaptureErrorCall] = []
     var audioCaptureInterruptions: [AudioCaptureInterruptedCall] = []
     var deadMicRecoveries: [DeadMicRecoveryOutcome] = []
+
+    /// #1846: every `updateTakeID` argument in order. `nil` is a REMOVE, so the
+    /// element type has to stay optional — collapsing it would erase the one
+    /// distinction the seam exists to carry.
+    var takeIDUpdates: [String?] = []
+
+    /// #1846: an ORDERED cross-seam log, because the per-seam arrays above can
+    /// prove that two things happened but not which happened first. The take key
+    /// has to be established BEFORE any emission or a terminal error lands
+    /// untagged, and that claim is only checkable against an interleaved record.
+    var timeline: [String] = []
+
+    /// #1846: the key that would be on the Sentry scope RIGHT NOW — the last
+    /// value written, not the history. Models what a real Sentry event emitted at
+    /// this instant would actually carry, which `takeIDUpdates` cannot show: an
+    /// ordered list proves the writes happened, never that an error landed inside
+    /// the window they open.
+    var effectiveTakeID: String?
   }
 
   // MARK: - Sink construction with recorder seams
@@ -92,6 +110,14 @@ import Testing
       updateRecordingState: { active, backend, isStreaming in
         recorder.recordingStates.append(
           Recorder.RecordingStateCall(active: active, backend: backend, isStreaming: isStreaming))
+        recorder.timeline.append("recordingState:\(active)")
+      },
+      // #1846: injected so direct sink tests using this helper do not reach the
+      // real Sentry scope.
+      updateTakeID: { takeID in
+        recorder.effectiveTakeID = takeID
+        recorder.takeIDUpdates.append(takeID)
+        recorder.timeline.append(takeID.map { "take:set:\($0)" } ?? "take:remove")
       },
       updateAudioRoute: { route in recorder.audioRoutes.append(route) },
       dictationInvoked: { trigger, mode, target in
@@ -105,6 +131,11 @@ import Testing
           Recorder.CaptureErrorCall(
             category: category, stage: stage, errorDescription: error.localizedDescription,
             extraKeys: (extra?.keys.map { $0 } ?? []).sorted()))
+        // #1846: stamp the key that is live AT EMISSION. This is what makes the
+        // post-capture window testable — a Sentry error emitted here would carry
+        // exactly this value.
+        recorder.timeline.append(
+          "captureError:\(stage):take:\(recorder.effectiveTakeID ?? "none")")
       },
       // #1408: injected so no test ever reaches the real PostHog SDK
       // (`tests-no-process-global-mutable-delegate`).
@@ -113,6 +144,7 @@ import Testing
           Recorder.AudioCaptureInterruptedCall(
             cause: cause, salvageAttempted: attempted, salvageSucceeded: succeeded,
             terminalState: terminal, backend: backend))
+        recorder.timeline.append("interruptionCounter:\(terminal)")
       },
       deadMicRecovered: { recorder.deadMicRecoveries.append($0) })
   }
@@ -721,16 +753,33 @@ import Testing
       "no heart_path_finalization Sentry capture for a quiet no-speech outcome")
   }
 
-  @Test(".cancelled emits NOTHING (PR-1 §B.7.4 only-one-new-event rule)")
+  /// #1846 CHANGED THE `recordingStates` HALF OF THIS TEST, deliberately.
+  ///
+  /// The invariant this test protects is the §B.7.4 only-one-new-event rule: a
+  /// cancel must not produce a breadcrumb, a Sentry error, or a PostHog event.
+  /// That half is untouched. `updateRecordingState` is neither — it is an
+  /// idempotent write to the `recording.active` SCOPE TAG, and asserting it was
+  /// empty was asserting the #1846 defect: a cancelled take left
+  /// `recording.active=true` on the scope, so the next unrelated Sentry event in
+  /// that process inherited it and read as "crashed while recording".
+  ///
+  /// The oracle was not fitted to the change. The defect is proved independently
+  /// by `KernelLifecycleRecordingScopeBaselineTests`, which is RED on unmodified
+  /// `origin/main` for exactly this reason.
+  @Test(".cancelled emits no event, and now clears recording scope (#1846)")
   func cancelledEmitsNothing() {
     let recorder = Recorder()
     let sink = makeSink(recorder: recorder)
     sink.emit(.cancelled)
     #expect(recorder.breadcrumbs.isEmpty)
     #expect(recorder.captureErrors.isEmpty)
-    #expect(recorder.recordingStates.isEmpty)
     #expect(recorder.audioRoutes.isEmpty)
     #expect(recorder.dictationsInvoked.isEmpty)
+    // The generic terminal postamble, and only it — exactly one inactive write.
+    #expect(
+      recorder.recordingStates == [
+        Recorder.RecordingStateCall(active: false, backend: nil, isStreaming: nil)
+      ])
   }
 
   // MARK: - Per-failure-reason coverage (10 positive + 2 r8 negative)
@@ -796,6 +845,10 @@ import Testing
       context: KernelSessionContext(),
       captureTelemetry: CaptureTelemetryState(),
       telemetryState: KernelTelemetryState(),
+      // #1846: injected inert so the terminal postamble cannot reach the real
+      // Sentry scope from a direct construction.
+      updateRecordingState: { _, _, _ in },
+      updateTakeID: { _ in },
       captureError: { error, _, _, _ in
         captureCount += 1
         capturedIdentity = error.sentrySemanticID
@@ -955,6 +1008,10 @@ import Testing
       context: KernelSessionContext(),
       captureTelemetry: CaptureTelemetryState(),
       telemetryState: state,
+      // #1846: injected inert so the terminal postamble cannot reach the real
+      // Sentry scope from a direct construction.
+      updateRecordingState: { _, _, _ in },
+      updateTakeID: { _ in },
       captureError: { error, _, _, _ in
         captureCount += 1
         capturedIdentity = error.sentrySemanticID
@@ -994,17 +1051,31 @@ import Testing
   // the sink (proved by `KernelHeartPathTelemetryObserverTests`); the sink
   // intentionally produces zero side-effect.
 
-  @Test(".failed(.captureStalled) emits NOTHING — rich emitter owns this terminal (r8)")
+  /// #1846 CHANGED THE `recordingStates` HALF OF THIS TEST, deliberately, and the
+  /// r8 invariant it exists for is intact.
+  ///
+  /// r8 is about DUPLICATION: `HeartPathTelemetryEmitter` owns the rich Sentry
+  /// emission for this terminal, so a second `captureError` here would double
+  /// every stall's Sentry count. That still holds. It does NOT extend to the
+  /// recording-scope clear, because the rich emitter never wrote that tag. Before
+  /// #1846, the four production clear sites were this sink's two interruption
+  /// arms, its `.recordingStopped` marker, and `KernelDictationDriver`'s direct
+  /// engine-interruption write. A stall therefore left `recording.active=true` on
+  /// the scope with nothing to clear it, which is the defect, not the contract.
+  @Test(".failed(.captureStalled) emits no duplicate, and now clears recording scope (#1846)")
   func failedCaptureStalledEmitsNothing() {
     let recorder = Recorder()
     let sink = makeSink(recorder: recorder)
     sink.emit(.failed(.captureStalled))
     #expect(recorder.captureErrors.isEmpty)
     #expect(recorder.breadcrumbs.isEmpty)
-    #expect(recorder.recordingStates.isEmpty)
     #expect(recorder.audioRoutes.isEmpty)
     #expect(recorder.dictationsInvoked.isEmpty)
     #expect(recorder.modelLoadWedgedBackends.isEmpty)
+    #expect(
+      recorder.recordingStates == [
+        Recorder.RecordingStateCall(active: false, backend: nil, isStreaming: nil)
+      ])
   }
 
   @Test(
@@ -1043,6 +1114,10 @@ import Testing
       audioCapture: FakeAudioCapture(),
       context: KernelSessionContext(),
       captureTelemetry: CaptureTelemetryState(),
+      // #1846: injected inert so the terminal postamble cannot reach the real
+      // Sentry scope from a direct construction.
+      updateRecordingState: { _, _, _ in },
+      updateTakeID: { _ in },
       captureError: { error, category, stage, extra in
         recorder.captureErrors.append(
           Recorder.CaptureErrorCall(
@@ -1070,5 +1145,261 @@ import Testing
     // updateRecordingState argument must come from the injected backend, not
     // a hardcoded literal.
     #expect(recorder.recordingStates.first?.backend == "whisperKit")
+  }
+
+  // MARK: - Per-dictation take key (#1846)
+
+  /// Two fixed, distinct ids. Literal rather than `UUID()` so a failure message
+  /// names a stable value and the assertions cannot pass by comparing a freshly
+  /// generated id to itself.
+  private static let takeA = "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33"
+  private static let takeB = "1e5b7a90-2c46-4d18-8f03-6b9e4a2c7d51"
+
+  /// Every `KernelLifecycleEvent` the sink can receive, with one representative
+  /// payload per case.
+  ///
+  /// MAINTENANCE: `isTerminalMirror` below is an exhaustive switch, so adding a
+  /// case to `KernelLifecycleEvent` breaks THIS FILE at compile time. When that
+  /// happens, add the new case to this list as well and bump the two count
+  /// assertions in `everyTerminalClearsTheTakeKeyExactlyOnce`. The count
+  /// assertions exist so the bump is a deliberate edit rather than a silent
+  /// omission — a new terminal that nobody added here would otherwise be
+  /// untested while the suite stayed green.
+  private static let allEvents: [KernelLifecycleEvent] = [
+    // Non-terminal.
+    .pipelineStartingUp,
+    .modelLoading,
+    .recordingCommitted(isStreaming: false),
+    .recordingStopped,
+    .transcriptionStarted,
+    .asrCompleted,
+    // Terminal — the seven `terminalStateLabel` recognises.
+    .pipelineCompleted,
+    .failed(.asrEmpty),
+    .audioInterrupted(cause: .engineLost),
+    .asrInterrupted(wasRecording: true),
+    .discarded(.tooShort),
+    .noSpeech(.vadGate),
+    .cancelled,
+  ]
+
+  /// A deliberate COMPILE-TIME MIRROR of the production `terminalStateLabel`
+  /// switch. Duplicating a production switch is normally the defect, not the
+  /// test — the justification here is that the duplicate is the detector: it is
+  /// exhaustive, so it cannot compile once a case is added, which is what drags
+  /// the author into this file to decide whether the new event clears the key.
+  /// It is never consulted by production code.
+  private static func isTerminalMirror(_ event: KernelLifecycleEvent) -> Bool {
+    switch event {
+    case .pipelineCompleted, .failed, .audioInterrupted, .asrInterrupted,
+      .discarded, .noSpeech, .cancelled:
+      true
+    case .pipelineStartingUp, .modelLoading, .recordingCommitted, .recordingStopped,
+      .transcriptionStarted, .asrCompleted:
+      false
+    }
+  }
+
+  /// ONE generic postamble owns the terminal cleanup, so every terminal removes
+  /// the take key and clears `recording.active` exactly once — including the five
+  /// that had no cleanup of their own before #1846
+  /// (`.pipelineCompleted`, `.failed`, `.discarded`, `.noSpeech`, `.cancelled`).
+  ///
+  /// "Exactly once" is the load-bearing half. The two arms that DID clear
+  /// (`.audioInterrupted`, `.asrInterrupted`) had their arm-local calls removed
+  /// rather than left beside the postamble; if either came back, this test fails
+  /// on the count, not on a missing call.
+  @Test("every terminal removes the take key and clears recording state exactly once")
+  func everyTerminalClearsTheTakeKeyExactlyOnce() {
+    let events = Self.allEvents
+    #expect(events.count == 13, "one representative per KernelLifecycleEvent case")
+
+    let terminals = events.filter { Self.isTerminalMirror($0) }
+    #expect(terminals.count == 7, "the closed terminal set `terminalStateLabel` recognises")
+
+    for event in events {
+      let recorder = Recorder()
+      let telemetryState = KernelTelemetryState()
+      telemetryState.resetForNewSession(takeID: Self.takeA, polishEnabled: false)
+      let context = KernelSessionContext()
+      context.config = .testDefault()
+      let sink = makeSink(recorder: recorder, context: context, telemetryState: telemetryState)
+
+      sink.emit(event)
+
+      let removals = recorder.takeIDUpdates.filter { $0 == nil }
+      let inactive = recorder.recordingStates.filter { !$0.active }
+
+      if Self.isTerminalMirror(event) {
+        #expect(
+          removals.count == 1,
+          "\(event) is a terminal and must remove the take key exactly once, got \(removals.count)"
+        )
+        #expect(
+          inactive.count == 1,
+          """
+          \(event) is a terminal and must clear recording.active exactly once, got \
+          \(inactive.count). More than one means an arm-local clear survived beside \
+          the postamble; zero means the postamble did not run.
+          """)
+        // The removal is LAST: the terminal event's own emission still has to
+        // carry the key, so the clear cannot precede it.
+        #expect(
+          recorder.takeIDUpdates.last == .some(.none),
+          "\(event) must remove the key after its own emission, not before")
+      } else {
+        #expect(
+          removals.isEmpty,
+          "\(event) is not a terminal and must not remove the take key")
+      }
+    }
+  }
+
+  /// The key is established BEFORE anything is emitted, on every event rather
+  /// than only on the start one.
+  ///
+  /// This is not defensive. `withObservationTracking` is not a lossless queue:
+  /// `KernelHeartPathTelemetryObserver.handleObservationChange` dispatches every
+  /// coalesced delta from one fire, so the sink can legitimately receive a
+  /// terminal without ever having received the start event. If the tag were set
+  /// only at the start, that fire's error would land untagged — and an untagged
+  /// error is exactly the one worth attributing.
+  @Test("the take key is established before any emission, even on a coalesced terminal")
+  func takeKeyIsEstablishedBeforeAnyEmission() {
+    let recorder = Recorder()
+    let telemetryState = KernelTelemetryState()
+    telemetryState.resetForNewSession(takeID: Self.takeA, polishEnabled: false)
+    // An interrupted session, so the pre-switch counter fires too — that counter
+    // runs before the event-specific arm and must also be inside the tagged window.
+    telemetryState.interruptionCause = .engineLost
+    let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+
+    // No start event was ever delivered: this is the coalesced case.
+    sink.emit(.failed(.asrFailed))
+
+    #expect(
+      recorder.timeline.first == "take:set:\(Self.takeA)",
+      "the key must be the FIRST thing that happens, got timeline \(recorder.timeline)")
+    #expect(recorder.timeline.contains("interruptionCounter:failed"))
+    #expect(recorder.timeline.contains { $0.hasPrefix("captureError:") })
+    // The postamble's own order: remove the key, then clear capture state. Both
+    // are after every emission, which is the point.
+    #expect(
+      Array(recorder.timeline.suffix(2)) == ["take:remove", "recordingState:false"],
+      "the postamble must close the window last, got timeline \(recorder.timeline)")
+  }
+
+  /// The take key survives capture stop, is still live for a POST-CAPTURE error,
+  /// and only then is removed. `KernelTelemetryState.takeID` deliberately KEEPS its
+  /// value past the terminal so late work stays attributable in the state object;
+  /// only the Sentry scope is cleared. Asserting both halves stops a future "tidy
+  /// up" from adding a second clearer there, which would blank the key while the
+  /// highest-volume errors are still being raised.
+  ///
+  /// The post-capture half is the whole reason the key is tied to the kernel take
+  /// rather than to capture. `recording.active` clears at the `.recordingStopped`
+  /// marker, but polish and paste run after that — and `polish_provider_failed` is
+  /// one of our highest-volume Sentry issues. A capture-scoped key would have left
+  /// exactly the errors most worth joining without one.
+  ///
+  /// An ordered list of writes cannot prove that. It shows the writes happened,
+  /// not that an error landed inside the window they open, so this asserts against
+  /// `effectiveTakeID` — the value a real Sentry event emitted at that instant
+  /// would carry.
+  @Test("the take key survives capture stop through a post-capture error, then is removed")
+  func takeKeyLifetime() {
+    let recorder = Recorder()
+    let telemetryState = KernelTelemetryState()
+    let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+
+    // Before any session: no key exists, so the seam is told to REMOVE rather
+    // than handed a placeholder.
+    sink.emit(.transcriptionStarted)
+    #expect(recorder.takeIDUpdates == [nil])
+    #expect(recorder.effectiveTakeID == nil)
+
+    telemetryState.resetForNewSession(takeID: Self.takeA, polishEnabled: false)
+
+    // Capture has stopped; the kernel take has NOT concluded.
+    sink.emit(.recordingStopped)
+    #expect(recorder.effectiveTakeID == Self.takeA)
+    #expect(telemetryState.takeID == Self.takeA)
+
+    // A post-capture error must observe the exact key, before the postamble.
+    sink.emit(.failed(.asrFailed))
+    #expect(
+      recorder.timeline.contains("captureError:transcription:take:\(Self.takeA)"),
+      """
+      the post-capture error must be emitted while the take key is still live. \
+      Timeline was \(recorder.timeline).
+      """)
+
+    // Removed only after that error, so a later unrelated event in this process
+    // cannot inherit the concluded take.
+    #expect(recorder.takeIDUpdates == [nil, Self.takeA, Self.takeA, nil])
+    #expect(recorder.effectiveTakeID == nil)
+
+    // The routing projection deliberately outlives the scope clear, so
+    // concluded-session consumers can still read it.
+    #expect(telemetryState.takeID == Self.takeA)
+
+    telemetryState.resetForNewSession(takeID: Self.takeB, polishEnabled: true)
+    #expect(telemetryState.takeID == Self.takeB, "a reset replaces the id")
+    sink.emit(.transcriptionStarted)
+    #expect(recorder.takeIDUpdates == [nil, Self.takeA, Self.takeA, nil, Self.takeB])
+    #expect(recorder.effectiveTakeID == Self.takeB)
+  }
+
+  /// The `updateTakeID` seam defaults to INERT, so direct sink constructions that
+  /// omit it do not mutate the real Sentry scope. The production factory wiring is
+  /// therefore what activates this feature, and a dropped line would leave it
+  /// tested, documented and dead with every test above still green —
+  /// `a-guard-nothing-arms-is-not-a-guard`.
+  ///
+  /// Existing integration tests DO construct drivers through that factory, so this
+  /// is not a claim that nothing reaches production wiring. They neither expose
+  /// this injected seam nor safely observe the process-global Sentry tag, so they
+  /// cannot detect the dropped line. This source check proves only that the
+  /// production wiring is present, and it is checked in both directions below so an
+  /// empty result cannot read as a pass.
+  @Test("the production factory wires the take key, so the inert default is never shipped")
+  func productionFactoryWiresTheTakeKey() throws {
+    let factory = try Self.pipelineSourceFile("KernelDictationDriverFactory.swift")
+
+    let wiring = try Regex(
+      #"updateTakeID:\s*\{\s*takeID in\s*\n\s*SentryBreadcrumb\.updateTakeID\(takeID\)"#)
+    #expect(
+      factory.firstMatch(of: wiring) != nil,
+      """
+      KernelDictationDriverFactory no longer wires `updateTakeID` to \
+      SentryBreadcrumb. The sink's default is inert, so dictation.take_id would \
+      never be set in production while every other #1846 test stayed green. \
+      Restore the wiring, or give the sink a real default again.
+      """)
+
+    // Positive control on the instrument itself: the same pattern must NOT match a
+    // string it should not match. Without this, a regex that can never match
+    // anything would fail loudly above, but a regex that matches EVERYTHING would
+    // pass silently.
+    #expect("updateTakeID: { _ in },".firstMatch(of: wiring) == nil)
+  }
+
+  /// Resolve a `Sources/EnviousWisprPipeline` file from this test file's own path.
+  /// `#filePath` rather than a working-directory guess: a filtered run's cwd is
+  /// the harness's, not the repo root.
+  private static func pipelineSourceFile(_ name: String) throws -> String {
+    let testFile = URL(fileURLWithPath: #filePath)
+    // .../Tests/EnviousWisprTests/Pipeline/<this file>
+    let repoRoot =
+      testFile
+      .deletingLastPathComponent()  // Pipeline
+      .deletingLastPathComponent()  // EnviousWisprTests
+      .deletingLastPathComponent()  // Tests
+      .deletingLastPathComponent()  // repo root
+    let source =
+      repoRoot
+      .appendingPathComponent("Sources/EnviousWisprPipeline")
+      .appendingPathComponent(name)
+    return try String(contentsOf: source, encoding: .utf8)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -41,6 +41,8 @@ import Testing
       let triggerSource: String
       let inputMode: String
       let targetApp: String?
+      /// #1846: the take key that reached PostHog with this event.
+      let takeID: String?
     }
     struct CaptureErrorCall: Equatable {
       let category: SentryBreadcrumb.ErrorCategory
@@ -56,6 +58,8 @@ import Testing
       let salvageSucceeded: Bool
       let terminalState: String
       let backend: String
+      /// #1846: the take key that reached PostHog with this event.
+      let takeID: String?
     }
 
     var breadcrumbs: [BreadcrumbCall] = []
@@ -120,10 +124,10 @@ import Testing
         recorder.timeline.append(takeID.map { "take:set:\($0)" } ?? "take:remove")
       },
       updateAudioRoute: { route in recorder.audioRoutes.append(route) },
-      dictationInvoked: { trigger, mode, target in
+      dictationInvoked: { trigger, mode, target, takeID in
         recorder.dictationsInvoked.append(
           Recorder.DictationInvokedCall(
-            triggerSource: trigger, inputMode: mode, targetApp: target))
+            triggerSource: trigger, inputMode: mode, targetApp: target, takeID: takeID))
       },
       modelLoadWedged: { backend, _ in recorder.modelLoadWedgedBackends.append(backend) },
       captureError: { error, category, stage, extra in
@@ -139,11 +143,11 @@ import Testing
       },
       // #1408: injected so no test ever reaches the real PostHog SDK
       // (`tests-no-process-global-mutable-delegate`).
-      audioCaptureInterrupted: { cause, attempted, succeeded, terminal, backend, _ in
+      audioCaptureInterrupted: { cause, attempted, succeeded, terminal, backend, _, takeID in
         recorder.audioCaptureInterruptions.append(
           Recorder.AudioCaptureInterruptedCall(
             cause: cause, salvageAttempted: attempted, salvageSucceeded: succeeded,
-            terminalState: terminal, backend: backend))
+            terminalState: terminal, backend: backend, takeID: takeID))
         recorder.timeline.append("interruptionCounter:\(terminal)")
       },
       deadMicRecovered: { recorder.deadMicRecoveries.append($0) })
@@ -184,7 +188,9 @@ import Testing
     sink.emit(.recordingCommitted(isStreaming: false))
     #expect(
       recorder.dictationsInvoked == [
-        .init(triggerSource: "ptt_hotkey", inputMode: "pushToTalk", targetApp: nil)
+        // takeID nil: this test constructs a bare KernelTelemetryState with no
+        // session, so there is genuinely no take to name (#1846).
+        .init(triggerSource: "ptt_hotkey", inputMode: "pushToTalk", targetApp: nil, takeID: nil)
       ])
     // Breadcrumb data dict carries both `backend` and `streaming` keys —
     // mirrors old TP:548-551.
@@ -528,7 +534,8 @@ import Testing
       recorder.audioCaptureInterruptions == [
         .init(
           cause: "engine_lost", salvageAttempted: true, salvageSucceeded: true,
-          terminalState: "completed", backend: "parakeet")
+          // takeID nil: this suite's bare KernelTelemetryState has no session.
+          terminalState: "completed", backend: "parakeet", takeID: nil)
       ])
     #expect(
       recorder.captureErrors.isEmpty,
@@ -548,7 +555,7 @@ import Testing
       recorder.audioCaptureInterruptions == [
         .init(
           cause: "engine_lost", salvageAttempted: true, salvageSucceeded: false,
-          terminalState: "audio_interrupted", backend: "parakeet")
+          terminalState: "audio_interrupted", backend: "parakeet", takeID: nil)
       ])
     #expect(recorder.captureErrors.count == 1, "the lost dictation is still a real loss")
   }
@@ -1382,6 +1389,72 @@ import Testing
     // anything would fail loudly above, but a regex that matches EVERYTHING would
     // pass silently.
     #expect("updateTakeID: { _ in },".firstMatch(of: wiring) == nil)
+  }
+
+  // MARK: - Take key routed onto the two sink-owned PostHog events (#1846 chunk 5)
+
+  /// `dictation.invoked` is the event that opens a take, so its take key is what
+  /// lets a Sentry error be traced back to the dictation the user actually started.
+  @Test("dictation.invoked carries the take key of the session that produced it")
+  func dictationInvokedCarriesTheTakeKey() {
+    let recorder = Recorder()
+    let telemetryState = KernelTelemetryState()
+    telemetryState.resetForNewSession(takeID: Self.takeA, polishEnabled: false)
+    let context = KernelSessionContext()
+    context.config = .testDefault(inputMode: .pushToTalk, triggerSource: .pttHotkey)
+    let sink = makeSink(recorder: recorder, context: context, telemetryState: telemetryState)
+
+    sink.emit(.recordingCommitted(isStreaming: false))
+
+    #expect(
+      recorder.dictationsInvoked == [
+        .init(
+          triggerSource: "ptt_hotkey", inputMode: "pushToTalk", targetApp: nil,
+          takeID: Self.takeA)
+      ])
+  }
+
+  /// The counter that gives salvage a denominator has to name WHICH take was
+  /// interrupted, or a Bluetooth-drop investigation can count interruptions but
+  /// cannot tie any of them to the errors that take raised.
+  @Test("audio.capture_interrupted carries the take key of the interrupted session")
+  func audioCaptureInterruptedCarriesTheTakeKey() throws {
+    let recorder = Recorder()
+    let telemetryState = KernelTelemetryState()
+    telemetryState.resetForNewSession(takeID: Self.takeA, polishEnabled: false)
+    telemetryState.interruptionCause = .engineLost
+    let sink = makeSink(recorder: recorder, telemetryState: telemetryState)
+
+    sink.emit(.pipelineCompleted)
+
+    #expect(recorder.audioCaptureInterruptions.count == 1)
+    let interruption = try #require(recorder.audioCaptureInterruptions.first)
+    #expect(interruption.takeID == Self.takeA)
+  }
+
+  /// Both events must send NO take key rather than a placeholder when no session
+  /// produced them. A sentinel would be indistinguishable from a real id in a query
+  /// and would silently inflate any per-take count.
+  @Test("both sink events omit the take key entirely when no session is in flight")
+  func sinkEventsOmitTheTakeKeyWithNoSession() throws {
+    let recorder = Recorder()
+    // A bare state: `takeID` is nil because no session was ever accepted.
+    let telemetryState = KernelTelemetryState()
+    telemetryState.interruptionCause = .engineLost
+    let context = KernelSessionContext()
+    context.config = .testDefault()
+    let sink = makeSink(recorder: recorder, context: context, telemetryState: telemetryState)
+
+    sink.emit(.recordingCommitted(isStreaming: false))
+    sink.emit(.pipelineCompleted)
+
+    let invocation = try #require(recorder.dictationsInvoked.first)
+    let interruption = try #require(recorder.audioCaptureInterruptions.first)
+    #expect(invocation.takeID == nil)
+    #expect(interruption.takeID == nil)
+    // Both events still fired — the absent key must not suppress the emission.
+    #expect(recorder.dictationsInvoked.count == 1)
+    #expect(recorder.audioCaptureInterruptions.count == 1)
   }
 
   /// Resolve a `Sources/EnviousWisprPipeline` file from this test file's own path.

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishStepTelemetryTests.swift
@@ -42,7 +42,7 @@ struct LLMPolishStepTelemetryTests {
     private(set) var providerInitErrorCalls: [any Error] = []
     private(set) var afmPolishErrorCalls: [any Error] = []
     private(set) var completedCalls: [(message: String, data: [String: Any]?)] = []
-    private(set) var skipCalls: [(provider: String, reason: String)] = []
+    private(set) var skipCalls: [(provider: String, reason: String, takeID: String?)] = []
 
     var seams: LLMPolishStep.TelemetrySeams {
       LLMPolishStep.TelemetrySeams(
@@ -61,8 +61,8 @@ struct LLMPolishStepTelemetryTests {
         breadcrumbCompleted: { message, data in
           self.completedCalls.append((message, data))
         },
-        recordPolishSkipped: { provider, reason in
-          self.skipCalls.append((provider, reason))
+        recordPolishSkipped: { provider, reason, takeID in
+          self.skipCalls.append((provider, reason, takeID))
         })
     }
   }
@@ -98,19 +98,25 @@ struct LLMPolishStepTelemetryTests {
   // MARK: - Too-short bypass (#1448)
 
   @Test(
-    "too-short bypass (CJK char-count path) emits its own skip tag; started already fired, nothing else does"
+    "too-short bypass (CJK char-count path) emits its own skip tag with the take key; started already fired, nothing else does"
   )
   func tooShortBypassCJK() async throws {
     let spy = Spy()
     let step = makeStep(provider: .openAI, telemetry: spy.seams)
-    let context = TextProcessingContext(text: "短い", language: "ja")
+    var context = TextProcessingContext(text: "短い", language: "ja")
+    // #1846: this route returns from `process()` BEFORE the runner sees it, so the
+    // step's own seam family is the only thing that can carry the key here. The
+    // runner-side test cannot cover it.
+    context.takeID = "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33"
 
     _ = try await step.process(context)
 
     #expect(spy.startedCalls.count == 1)
     #expect(spy.skipCalls.count == 1)
-    #expect(spy.skipCalls.first?.provider == "openAI")
-    #expect(spy.skipCalls.first?.reason == "too_short")
+    let skip = try #require(spy.skipCalls.first)
+    #expect(skip.provider == "openAI")
+    #expect(skip.reason == "too_short")
+    #expect(skip.takeID == "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33")
     #expect(spy.completedCalls.isEmpty)
     #expect(spy.providerInitErrorCalls.isEmpty)
     #expect(spy.afmPolishErrorCalls.isEmpty)
@@ -317,7 +323,7 @@ struct LLMPolishStepTelemetryTests {
       live.captureProviderInitError(LLMError.modelNotReady("probe"))
       live.captureAFMPolishError(LLMError.modelNotReady("probe"))
       live.breadcrumbCompleted("live probe", nil)
-      live.recordPolishSkipped("openAI", "probe")
+      live.recordPolishSkipped("openAI", "probe", nil)
       #expect(
         recorder.telemetryEvents.count == 2, "live must fire limbFailureObserved + polishSkipped")
       #expect(
@@ -336,7 +342,7 @@ struct LLMPolishStepTelemetryTests {
       silent.captureProviderInitError(LLMError.modelNotReady("probe"))
       silent.captureAFMPolishError(LLMError.modelNotReady("probe"))
       silent.breadcrumbCompleted("silent probe", nil)
-      silent.recordPolishSkipped("openAI", "probe")
+      silent.recordPolishSkipped("openAI", "probe", nil)
 
       #expect(
         recorder.telemetryEvents.isEmpty,

--- a/Tests/EnviousWisprTests/Pipeline/OllamaReadinessGateTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/OllamaReadinessGateTests.swift
@@ -185,7 +185,7 @@ struct OllamaReadinessGateTests {
     // test here can never reach the real PostHog client (#1446).
     let runner = TextProcessingRunner(
       telemetry: .init(
-        captureError: spy.sink, recordPolishFailed: { _, _, _, _ in },
+        captureError: spy.sink, recordPolishFailed: { _, _, _, _, _ in },
         // This suite asserts on the real `llm.polish_skipped` via testEventHook.
         recordPolishSkipped: TextProcessingRunner.TelemetrySeams.live.recordPolishSkipped),
       timeoutExecutor: executor.run)

--- a/Tests/EnviousWisprTests/Pipeline/RecordStartTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordStartTelemetrySinkTests.swift
@@ -18,24 +18,28 @@ import Testing
 @Suite("Record-start VAD telemetry parity (#1780)")
 struct RecordStartTelemetrySinkTests {
 
+  /// #1846: a fixed take key so failures name a stable value.
+  private static let takeID = "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33"
+
   @MainActor
   private final class Spy {
     var breadcrumbs: [(stage: String, message: String, data: [String: Any])] = []
-    var preparation: [(String, String, Bool, Bool)] = []
-    var chunkStarted: [(String, String, Double)] = []
-    var chunkCompleted: [(String, String, Double, Bool)] = []
+    /// #1846: the trailing `String?` on each tuple is the take key.
+    var preparation: [(String, String, Bool, Bool, String?)] = []
+    var chunkStarted: [(String, String, Double, String?)] = []
+    var chunkCompleted: [(String, String, Double, Bool, String?)] = []
 
     func makeSink() -> RecordStartTelemetrySink {
       RecordStartTelemetrySink(
         breadcrumb: { [self] stage, message, data in
           breadcrumbs.append((stage, message, data))
         },
-        emitPreparation: { [self] b, r, ready, reused in
-          preparation.append((b, r, ready, reused))
+        emitPreparation: { [self] b, r, ready, reused, take in
+          preparation.append((b, r, ready, reused, take))
         },
-        emitChunkStarted: { [self] b, r, ms in chunkStarted.append((b, r, ms)) },
-        emitChunkCompleted: { [self] b, r, ms, stop in
-          chunkCompleted.append((b, r, ms, stop))
+        emitChunkStarted: { [self] b, r, ms, take in chunkStarted.append((b, r, ms, take)) },
+        emitChunkCompleted: { [self] b, r, ms, stop, take in
+          chunkCompleted.append((b, r, ms, stop, take))
         })
     }
   }
@@ -44,7 +48,8 @@ struct RecordStartTelemetrySinkTests {
   func preparationParity() {
     let spy = Spy()
     spy.makeSink().vadPreparationCompleted(
-      backend: "parakeet", inputRoute: "built_in_mic", ready: true, modelReused: true)
+      backend: "parakeet", inputRoute: "built_in_mic", ready: true, modelReused: true,
+      takeID: Self.takeID)
 
     #expect(spy.breadcrumbs.count == 1)
     #expect(spy.preparation.count == 1)
@@ -71,7 +76,7 @@ struct RecordStartTelemetrySinkTests {
   func chunkStartedParity() {
     let spy = Spy()
     spy.makeSink().firstChunkStarted(
-      backend: "whisperKit", inputRoute: "bluetooth", monitorToFirstChunkMs: 7.5)
+      backend: "whisperKit", inputRoute: "bluetooth", monitorToFirstChunkMs: 7.5, takeID: Self.takeID)
 
     #expect(spy.breadcrumbs.count == 1)
     #expect(spy.chunkStarted.count == 1)
@@ -97,7 +102,8 @@ struct RecordStartTelemetrySinkTests {
     let spy = Spy()
     spy.makeSink().firstChunkCompleted(
       backend: "parakeet", inputRoute: "built_in_mic",
-      chunkProcessingLatencyMs: 2.25, shouldStop: true)
+      chunkProcessingLatencyMs: 2.25, shouldStop: true,
+      takeID: Self.takeID)
 
     #expect(spy.breadcrumbs.count == 1)
     #expect(spy.chunkCompleted.count == 1)

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -232,6 +232,10 @@ import Testing
         context: KernelSessionContext(),
         captureTelemetry: CaptureTelemetryState(),
         telemetryState: wrapper.telemetryState,
+        // #1846: injected inert so the terminal postamble cannot reach the real
+        // Sentry scope from a direct construction.
+        updateRecordingState: { _, _, _ in },
+        updateTakeID: { _ in },
         captureError: { error, _, _, _ in
           captureCount += 1
           capturedIdentity = error.sentrySemanticID
@@ -377,6 +381,37 @@ import Testing
       // the prior session's elapsed time forward.
       await startToLive(context, wrapper)
       #expect(kernel.recordingElapsedSeconds == 0)
+    }
+
+    // MARK: Invariant 6 — the telemetry take key IS the session id (#1846)
+
+    /// The take key must be the kernel's OWN `SessionID`, not a second identity
+    /// minted for telemetry. A separate mint would let an error and that same
+    /// dictation's usage events disagree about which take they belong to, which
+    /// is the whole defect #1846 exists to close.
+    @Test("the telemetry take key is the session id, and each session replaces it")
+    func takeIDProjectsTheSessionID() async {
+      let (context, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      // `currentSessionID` is non-optional and already holds a never-used value
+      // before the first start, so the absence of a take is read from the
+      // telemetry state, not from the kernel's id.
+      #expect(wrapper.telemetryState.takeID == nil, "no take is in flight before the first start")
+
+      await startToLive(context, wrapper)
+      let first = kernel.currentSessionID
+      #expect(wrapper.telemetryState.takeID == first.raw.uuidString)
+
+      await apply(.cancel, to: wrapper)  // recording → cancelled (terminal)
+      await apply(.reset, to: wrapper)  // cancelled → idle
+
+      await startToLive(context, wrapper)
+      let second = kernel.currentSessionID
+      #expect(second != first, "the FSM must mint a fresh id, or this test proves nothing")
+      #expect(
+        wrapper.telemetryState.takeID == second.raw.uuidString,
+        "the second session must carry its OWN id, not the first session's")
     }
 
     // Note: the r3 checked-comparison guard (`guard now >= start else { return

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -414,6 +414,53 @@ import Testing
         "the second session must carry its OWN id, not the first session's")
     }
 
+    // MARK: Invariant 7 — the concluded take key is FROZEN, and degrades to absent (#1846)
+
+    /// The completion-reporting chain reads `lastTakeID` after a take ends, so what
+    /// it degrades to when the next take starts is the whole design question.
+    ///
+    /// Every sibling marker (`lastStopReason`, `lastRecordingDurationSeconds`) goes
+    /// nil in `resetSessionState()`. A live read of `KernelTelemetryState.takeID`
+    /// would instead return the NEW take's id, because `resetForNewSession` REPLACES
+    /// it — so a completion filed after the user started talking again would be
+    /// stamped with the wrong dictation and would join cleanly to it. That is worse
+    /// than a missing value, and this test is the control that proves the freeze is
+    /// load-bearing: a live read fails the third assertion below.
+    @Test("the concluded take key is frozen at the terminal and goes ABSENT, never stale")
+    func lastTakeIDIsFrozenAtTerminalAndDegradesToAbsent() async {
+      let (context, wrapper) = makeWrapper()
+      let kernel = wrapper.testKernel
+
+      #expect(kernel.lastTakeID == nil, "nothing has concluded yet")
+
+      await startToLive(context, wrapper)
+      let firstSessionID = kernel.currentSessionID
+      #expect(
+        kernel.lastTakeID == nil,
+        "in flight is not concluded — this names the CONCLUDED take, like lastStopReason")
+
+      await apply(.cancel, to: wrapper)  // recording → cancelled (a terminal)
+      #expect(
+        kernel.lastTakeID == firstSessionID.raw.uuidString,
+        "the accepted terminal must stamp the take that concluded")
+
+      // The next take starts. This is the assertion a live read fails.
+      await apply(.reset, to: wrapper)
+      await startToLive(context, wrapper)
+      let secondSessionID = kernel.currentSessionID
+      #expect(secondSessionID != firstSessionID, "a fresh id, or this proves nothing")
+      #expect(
+        kernel.lastTakeID == nil,
+        """
+        starting a new take must clear the concluded key to ABSENT. A live read of \
+        telemetryState.takeID would return the new take's id here, silently \
+        attributing the previous completion to this dictation.
+        """)
+      #expect(
+        kernel.lastTakeID != secondSessionID.raw.uuidString,
+        "and specifically it must NOT be the new take's id")
+    }
+
     // Note: the r3 checked-comparison guard (`guard now >= start else { return
     // 0 }`) protects against a broken/adversarially-injected clock returning a
     // tick below the stamped start. This is not exercised here: the shared

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSource.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeVADSignalSource.swift
@@ -83,7 +83,7 @@ final class FakeVADSignalSource: VADSignalSource {
     for continuation in warningSubscribers.values { continuation.yield(signal) }
   }
 
-  /// Emit a warning stamped with a PRIOR session's id — the stale-drop case.
+  /// Emit a warning stamped with a non-current session id — the stale-drop case.
   func emitStaleWarning(remainingSeconds: TimeInterval = 60) {
     emittedWarningCount += 1
     let signal = VADWarningSignal(remainingSeconds: remainingSeconds, sessionID: SessionID())

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
@@ -58,10 +58,18 @@ struct TextProcessingRunnerCaptureTests {
       let model: String
       let reason: String
       let isTimeout: Bool
+      /// #1846: which dictation this failure belongs to.
+      let takeID: String?
     }
     private(set) var calls: [Call] = []
-    func sink(_ provider: String, _ model: String, _ reason: String, _ isTimeout: Bool) {
-      calls.append(Call(provider: provider, model: model, reason: reason, isTimeout: isTimeout))
+    func sink(
+      _ provider: String, _ model: String, _ reason: String, _ isTimeout: Bool,
+      _ takeID: String?
+    ) {
+      calls.append(
+        Call(
+          provider: provider, model: model, reason: reason, isTimeout: isTimeout,
+          takeID: takeID))
     }
   }
 
@@ -70,9 +78,9 @@ struct TextProcessingRunnerCaptureTests {
   /// crash recovery alongside the other two (#1446, cloud review of PR #1460).
   @MainActor
   final class SkipSpy {
-    private(set) var calls: [(provider: String, reason: String)] = []
-    func sink(_ provider: String, _ reason: String) {
-      calls.append((provider: provider, reason: reason))
+    private(set) var calls: [(provider: String, reason: String, takeID: String?)] = []
+    func sink(_ provider: String, _ reason: String, _ takeID: String?) {
+      calls.append((provider: provider, reason: reason, takeID: takeID))
     }
   }
 
@@ -432,7 +440,7 @@ struct TextProcessingRunnerCaptureTests {
     let runner = TextProcessingRunner(
       telemetry: .init(
         captureError: spy.sink, recordPolishFailed: records.sink,
-        recordPolishSkipped: { _, _ in }),
+        recordPolishSkipped: { _, _, _ in }),
       timeoutExecutor: executor.run)
     let step = makeStep(provider: .openAI, model: "gpt-4o-mini") {
       LLMError.requestFailed("unused")
@@ -636,13 +644,17 @@ struct TextProcessingRunnerCaptureTests {
     }
 
     let result = try await runner.run(
-      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step])
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step],
+      takeID: Self.takeA)
 
     // An on-device timeout on a long dictation degrades quietly to raw text.
     #expect(result.polishError == nil)
     #expect(spy.calls.isEmpty)
     #expect(records.calls.isEmpty)  // never attempted-and-failed; it was skipped
     #expect(skips.calls.count == 1)
+    #expect(
+      skips.calls.first?.takeID == Self.takeA,
+      "the runner-owned llm.polish_skipped route must carry the frozen take key")
     #expect(skips.calls.first?.provider == "appleIntelligence")
     #expect(skips.calls.first?.reason == "context_window_timeout")
   }
@@ -738,7 +750,6 @@ struct TextProcessingRunnerCaptureTests {
     #expect(records.calls.first?.isTimeout == false)
   }
 
-
   /// Pass-through step that records the text it receives, proving the
   /// pipeline continues downstream with the complete pre-polish text after
   /// a rejected polish (#1710).
@@ -754,4 +765,78 @@ struct TextProcessingRunnerCaptureTests {
     }
   }
 
+  // MARK: - Take key on the polish outcome events (#1846 chunk 7)
+
+  private static let takeA = "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33"
+
+  /// `llm.polish_failed` must name the dictation whose polish failed.
+  /// `polish_provider_failed` is one of our highest-volume Sentry issues, so this is
+  /// the join that turns "N failures" into "N failures across M people's dictations".
+  @Test("a polish failure carries the take key of the dictation being polished")
+  func polishFailureCarriesTheTakeKey() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let runner = makeRunner(spy, records)
+    let step = makeStep(provider: .openAI, model: "gpt-4o-mini") { LLMError.invalidAPIKey }
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [step],
+      takeID: Self.takeA)
+
+    #expect(records.calls.count == 1)
+    #expect(records.calls.first?.takeID == Self.takeA)
+  }
+
+  /// The runner FREEZES the key into the context at the start of the chain rather
+  /// than reading session state at each emit. A chain can span an await during which
+  /// the session moves on, and an emission that read live state then would name a
+  /// different dictation than the one whose text it is describing.
+  @Test("the take key is frozen into the processing context, so every step sees the same one")
+  func takeKeyIsFrozenIntoTheContext() async throws {
+    let spy = CaptureSpy()
+    let observer = ContextObservingStep()
+    let runner = makeRunner(spy)
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [observer],
+      takeID: Self.takeA)
+
+    #expect(observer.callCount == 1, "the observer must run exactly once")
+    #expect(observer.observedTakeID == Self.takeA)
+  }
+
+  /// Absent, never a placeholder — the re-polish and recovery paths legitimately have
+  /// no take, and a sentinel would be indistinguishable from a real id in a query.
+  @Test("omitting the take key leaves it nil through the whole chain")
+  func omittedTakeKeyStaysNil() async throws {
+    let spy = CaptureSpy()
+    let records = RecordSpy()
+    let observer = ContextObservingStep()
+    let runner = makeRunner(spy, records)
+
+    _ = try await runner.run(
+      rawText: Self.longTranscript, language: "en", targetAppName: nil, steps: [observer])
+
+    #expect(observer.callCount == 1, "the observer must run exactly once")
+    #expect(observer.observedTakeID == nil)
+  }
+
+  /// Reads the take key off the context the runner hands each step. Same shape as
+  /// `RecordingStep` above, which is this file's established conformer pattern.
+  private final class ContextObservingStep: TextProcessingStep {
+    let name = "Take Key Observer"
+    let isEnabled = true
+    let maxDuration: Duration = .seconds(5)
+    /// #1846: `observedTakeID` STARTS nil, so a test asserting nil would pass if the
+    /// runner never invoked this step at all — a check that cannot reach its subject.
+    /// The call count is what makes the nil assertion mean something.
+    private(set) var callCount = 0
+    private(set) var observedTakeID: String?
+
+    func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
+      callCount += 1
+      observedTakeID = context.takeID
+      return context
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/Services/CapWarningTakeIDTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/CapWarningTakeIDTelemetryTests.swift
@@ -1,0 +1,65 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+#if DEBUG
+
+  /// #1846 chunk 10: the WIRE contract for `recording.cap_warning_shown`. The
+  /// routing tests stop at the callback boundary, so deleting the production
+  /// `props["take_id"]` line leaves them green.
+  ///
+  /// This emitter had no DEBUG hook at all before chunk 10. It was added as ONE
+  /// payload with the hook derived from it — never a second literal, which is the
+  /// shape that lets a wire test assert a key the real capture never sent.
+  @Suite("recording.cap_warning_shown take_id (#1846)", .serialized)
+  struct CapWarningTakeIDTelemetryTests {
+    private static let takeID = "3c7e5a11-92d4-4f60-b8a7-51e0c6d3f284"
+    private static let eventName = "recording.cap_warning_shown"
+
+    final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func append(_ event: CapturedTelemetryEvent) { lock.withLock { stored.append(event) } }
+      func removeAll() { lock.withLock { stored.removeAll() } }
+      var values: [CapturedTelemetryEvent] { lock.withLock { stored } }
+    }
+
+    @MainActor
+    @Test("the cap warning emits take_id when present and omits it when nil")
+    func capWarningTakeIDContract() throws {
+      // `try #require` on each captured event, not optional chaining: with an
+      // empty box, `absent.first?.stringProps["take_id"] == nil` is nil == nil
+      // and PASSES vacuously — the exact hazard
+      // `swift-testing-require-preconditions` exists to close.
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == Self.eventName { box.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.recordingCapWarningShown(
+        backend: "parakeet", capSeconds: 3600, takeID: Self.takeID)
+
+      let present = box.values
+      #expect(present.count == 1, "the emitter must fire exactly once")
+      let presentEvent = try #require(present.first)
+      #expect(presentEvent.stringProps["take_id"] == Self.takeID)
+      // The pre-existing properties must survive the payload rewrite.
+      #expect(presentEvent.stringProps["asr_backend"] == "parakeet")
+      #expect(presentEvent.doubleProps["cap_seconds"] == 3600)
+
+      box.removeAll()
+      TelemetryService.shared.recordingCapWarningShown(
+        backend: "whisperKit", capSeconds: 3600, takeID: nil)
+
+      let absent = box.values
+      #expect(absent.count == 1, "the nil case must still fire")
+      let absentEvent = try #require(absent.first)
+      #expect(
+        absentEvent.stringProps["take_id"] == nil,
+        "an absent take key must be OMITTED, not sent as an empty string")
+      #expect(absentEvent.stringProps["asr_backend"] == "whisperKit")
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
@@ -46,6 +46,92 @@ struct DictationCompletedRouteFieldsTests {
       #expect(props?["route_fallback_reason"] == nil)
     }
 
+    // MARK: - #1846 take key on all four completion events
+
+    /// ONE argument to `reportDictationCompleted` has to reach all FOUR events it
+    /// fans out to. `asr.completed`, `llm.polish_completed` and `paste.completed` are
+    /// each gated on their own metric being present, so this supplies metrics that
+    /// open all three gates and asserts every event carries the same key.
+    ///
+    /// Observed through the DEBUG hook, which as of #1846 derives from the payload
+    /// PostHog actually receives. Before that, `reportDictationCompleted` emitted a
+    /// parallel dictionary under the `dictation.completed` name while the real payload
+    /// was built with no hook at all — a test here could have passed with the
+    /// production line deleted.
+    @Test("the take key reaches all four completion events from one argument")
+    func takeKeyReachesAllFourCompletionEvents() throws {
+      let seen = EventsBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { seen.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Self.transcriptOpeningAllFourGates(),
+        inputMode: "ptt",
+        takeID: Self.takeID)
+
+      let names = Set(seen.events.map(\.name))
+      #expect(
+        names == [
+          "dictation.completed", "asr.completed", "llm.polish_completed", "paste.completed",
+        ],
+        "all four gates must open, or the assertions below cover fewer events than claimed — saw \(names.sorted())"
+      )
+      for event in seen.events {
+        #expect(
+          event.stringProps["take_id"] == Self.takeID,
+          "\(event.name) must carry the take key")
+      }
+    }
+
+    /// Absent on every one of the four, never an empty string.
+    @Test("all four completion events omit the take key entirely when there is no take")
+    func allFourOmitTheTakeKeyWhenNil() throws {
+      let seen = EventsBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { seen.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Self.transcriptOpeningAllFourGates(),
+        inputMode: "ptt",
+        takeID: nil)
+
+      #expect(seen.events.count == 4, "same four events, so the nil suppressed nothing")
+      for event in seen.events {
+        #expect(
+          event.stringProps["take_id"] == nil,
+          "\(event.name) must OMIT take_id, not send an empty string")
+      }
+    }
+
+    private final class EventsBox: @unchecked Sendable {
+      var events: [CapturedTelemetryEvent] = []
+    }
+
+    private static let takeID = "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33"
+
+    /// A transcript whose metrics open the `asr.completed`, `llm.polish_completed`
+    /// and `paste.completed` gates inside `reportDictationCompleted`: a non-nil ASR
+    /// latency, a positive LLM latency with a provider, and a paste tier plus
+    /// latency. Without all three, a test claiming four-event coverage would
+    /// silently assert over one event.
+    private static func transcriptOpeningAllFourGates() -> Transcript {
+      Transcript(
+        text: "hello",
+        polishedText: "Hello.",
+        llmProvider: "openai",
+        llmModel: "gpt-4o-mini",
+        metrics: ExecutionMetrics(
+          asrLatencySeconds: 0.4,
+          llmLatencySeconds: 0.3,
+          pasteTier: "cgevent",
+          pasteLatencyMs: 12,
+          e2eSeconds: 1.0))
+    }
+
     @Test("Auto dictation omits route fields when nil")
     func autoOmitsFields() {
       let box = Box()

--- a/Tests/EnviousWisprTests/Services/DictationInvokedTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationInvokedTelemetryTests.swift
@@ -74,6 +74,82 @@ import Testing
       #expect(event.stringProps["input_mode"] == "toggle")
       #expect(event.stringProps["trigger_source"] != event.stringProps["input_mode"])
     }
+
+    // MARK: - #1846 take key on the wire
+
+    /// The property name is the joinable contract: PostHog `take_id` has to pair
+    /// with the Sentry tag `dictation.take_id`. A rename on either side silently
+    /// breaks every join, so the literal string is frozen here rather than left to
+    /// the call site.
+    @MainActor
+    @Test("dictation.invoked puts the take key on the wire as take_id")
+    func dictationInvokedEmitsTakeIDProperty() throws {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "dictation.invoked" { box.set(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.dictationInvoked(
+        triggerSource: "ptt_hotkey", inputMode: "pushToTalk", targetApp: nil,
+        takeID: "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33")
+
+      let event = try #require(box.value)
+      #expect(event.stringProps["take_id"] == "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33")
+    }
+
+    /// ABSENT, not empty. A query has to distinguish "this release predates the
+    /// key" and "no take produced this event" from "a take whose id we lost", and an
+    /// empty-string placeholder would collapse all three into one value that also
+    /// counts as present.
+    @MainActor
+    @Test("dictation.invoked omits take_id entirely when there is no take")
+    func dictationInvokedOmitsTakeIDWhenNil() throws {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "dictation.invoked" { box.set(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.dictationInvoked(
+        triggerSource: "toolbar", inputMode: "toggle", targetApp: nil, takeID: nil)
+
+      let event = try #require(box.value)
+      #expect(
+        event.stringProps["take_id"] == nil,
+        "take_id must be absent, not empty — got \(String(describing: event.stringProps["take_id"]))"
+      )
+      // The rest of the event is unaffected, so the omission is not suppressing it.
+      #expect(event.stringProps["trigger_source"] == "toolbar")
+    }
+
+    /// Same contract on the interruption counter.
+    @MainActor
+    @Test("audio.capture_interrupted carries take_id when present and omits it when nil")
+    func audioCaptureInterruptedTakeIDContract() throws {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "audio.capture_interrupted" { box.set(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.audioCaptureInterrupted(
+        cause: "engineLost", salvageAttempted: true, salvageSucceeded: true,
+        terminalState: "completed", backend: "parakeet",
+        takeID: "1e5b7a90-2c46-4d18-8f03-6b9e4a2c7d51")
+      let presentEvent = try #require(box.value)
+      #expect(
+        presentEvent.stringProps["take_id"]
+          == "1e5b7a90-2c46-4d18-8f03-6b9e4a2c7d51")
+
+      TelemetryService.shared.audioCaptureInterrupted(
+        cause: "engineLost", salvageAttempted: true, salvageSucceeded: true,
+        terminalState: "completed", backend: "parakeet", takeID: nil)
+      let absentEvent = try #require(box.value)
+      #expect(absentEvent.stringProps["take_id"] == nil)
+      // Still the interruption event, so the nil did not suppress the emission.
+      #expect(absentEvent.stringProps["cause"] == "engineLost")
+    }
   }
 
 #endif

--- a/Tests/EnviousWisprTests/Services/PolishOutcomeTakeIDTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/PolishOutcomeTakeIDTelemetryTests.swift
@@ -1,0 +1,82 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+#if DEBUG
+
+  /// #1846: the WIRE contract for the two polish outcome events. The routing tests in
+  /// `TextProcessingRunnerCaptureTests` and `LLMPolishStepTelemetryTests` stop at the
+  /// injected seams, so deleting either production `props["take_id"] = takeID` line in
+  /// `TelemetryService` leaves all of them green. Deriving the DEBUG hook from `props`
+  /// makes a wire test trustworthy; it does not replace it.
+  @Suite("Polish outcome take_id telemetry (#1846)", .serialized)
+  struct PolishOutcomeTakeIDTelemetryTests {
+    private static let takeID = "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33"
+
+    final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+
+      func append(_ event: CapturedTelemetryEvent) {
+        lock.withLock { stored.append(event) }
+      }
+
+      func removeAll() {
+        lock.withLock { stored.removeAll() }
+      }
+
+      var values: [CapturedTelemetryEvent] {
+        lock.withLock { stored }
+      }
+    }
+
+    @MainActor
+    @Test("polish skipped and failed emit take_id when present and omit it when nil")
+    func polishOutcomeTakeIDContract() throws {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "llm.polish_skipped" || event.name == "llm.polish_failed" {
+          box.append(event)
+        }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.polishSkipped(
+        provider: "openAI", reason: "too_short", takeID: Self.takeID)
+      TelemetryService.shared.polishFailed(
+        provider: "openAI", model: "gpt-4o-mini",
+        reason: "api_key_rejected", isTimeout: false, takeID: Self.takeID)
+
+      let presentSkipped = try #require(
+        box.values.first { $0.name == "llm.polish_skipped" })
+      let presentFailed = try #require(
+        box.values.first { $0.name == "llm.polish_failed" })
+
+      #expect(presentSkipped.stringProps["take_id"] == Self.takeID)
+      #expect(presentSkipped.stringProps["skip_reason"] == "too_short")
+      #expect(presentFailed.stringProps["take_id"] == Self.takeID)
+      #expect(presentFailed.stringProps["reason"] == "api_key_rejected")
+
+      box.removeAll()
+
+      TelemetryService.shared.polishSkipped(
+        provider: "openAI", reason: "too_short", takeID: nil)
+      TelemetryService.shared.polishFailed(
+        provider: "openAI", model: "gpt-4o-mini",
+        reason: "api_key_rejected", isTimeout: false, takeID: nil)
+
+      let absentSkipped = try #require(
+        box.values.first { $0.name == "llm.polish_skipped" })
+      let absentFailed = try #require(
+        box.values.first { $0.name == "llm.polish_failed" })
+
+      // ABSENT, not empty — the sibling assertions prove the omission did not
+      // suppress the event itself.
+      #expect(absentSkipped.stringProps["take_id"] == nil)
+      #expect(absentSkipped.stringProps["skip_reason"] == "too_short")
+      #expect(absentFailed.stringProps["take_id"] == nil)
+      #expect(absentFailed.stringProps["reason"] == "api_key_rejected")
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Services/TelemetryJoinKeyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TelemetryJoinKeyTests.swift
@@ -1,0 +1,243 @@
+import EnviousWisprObservabilityCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #1846 — the cross-vendor join key's acceptance contract, its survival through
+/// the REAL final-payload redactor, and the freeze that keeps PostHog's
+/// `distinct_id` anonymous.
+@Suite("Telemetry join key (#1846)")
+struct TelemetryJoinKeyTests {
+
+  /// A canonical PostHog anonymous ID: lowercase, hyphenated, 8-4-4-4-12.
+  private static let canonicalID = "0198a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b"
+
+  // MARK: - Acceptance predicate
+
+  @Test(
+    "a canonical lowercase hyphenated UUID is accepted byte-for-byte unchanged",
+    arguments: [
+      "0198a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b",
+      "00000000-0000-0000-0000-000000000000",
+      "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    ])
+  func acceptsCanonicalAnonymousID(raw: String) {
+    #expect(ObservabilityBootstrap.canonicalAnonymousPostHogID(raw) == raw)
+  }
+
+  /// Each rejection is a distinct reason, not one class:
+  /// - compact 32-hex would arrive as `[REDACTED]` (see the two-way control below);
+  /// - an uppercase representation is not what PostHog stamps on its own events,
+  ///   so joining on it would silently match nothing — and `UUID(uuidString:)`
+  ///   accepts it, which is why the predicate also demands exact equality with
+  ///   the lowercased round-trip;
+  /// - email-shaped and arbitrary values are the shapes a future `identify()`
+  ///   could introduce, and copying a caller-supplied string into Sentry is not
+  ///   a decision the bootstrap seam may make silently;
+  /// - empty is what `getDistinctId()` returns when PostHog init was skipped for
+  ///   a missing key, and it must set no tag rather than an empty tag.
+  @Test(
+    "every non-canonical or unsafe shape is rejected",
+    arguments: [
+      "0198a1b2c3d47e5f8a9b0c1d2e3f4a5b",
+      "0198A1B2-C3D4-7E5F-8A9B-0C1D2E3F4A5B",
+      "someone@example.com",
+      "install-1846",
+      "",
+    ])
+  func rejectsEveryOtherShape(raw: String) {
+    #expect(ObservabilityBootstrap.canonicalAnonymousPostHogID(raw) == nil)
+  }
+
+  // MARK: - Redaction tripwire
+
+  /// Two-way control against the REAL production redactor, not a restatement of
+  /// its rule. The 32+-contiguous-hex heuristic destroys a compact UUID; a
+  /// hyphenated one's longest hex run is 12, so it survives. If either direction
+  /// flips, the join key silently becomes `[REDACTED]` on every event and the
+  /// arithmetic in the plan's §2.5 premise table is no longer true.
+  @Test("two-way redactor control: the hyphenated join key survives, its compact form does not")
+  func joinKeySurvivesTheRealRedactor() throws {
+    let accepted = try #require(
+      ObservabilityBootstrap.canonicalAnonymousPostHogID(Self.canonicalID))
+    let compact = Self.canonicalID.replacingOccurrences(of: "-", with: "")
+
+    #expect(SentryEventSanitizer.redactString(accepted) == accepted)
+    #expect(SentryEventSanitizer.redactString(compact) == "[REDACTED]")
+  }
+
+  // MARK: - Anonymity freeze
+
+  /// The join key is only safe to copy into Sentry while PostHog's
+  /// `distinct_id` stays the SDK's own anonymous UUID, which holds only because
+  /// no production code calls `identify()` or `alias()`. This scan is the
+  /// enforcement; `canonicalAnonymousPostHogID(_:)` is the second line.
+  ///
+  /// Anchored to `PostHogSDK.shared` on purpose: unrelated production functions
+  /// named `identify` exist and are valid (`TerminalProcessScanner.swift`), so an
+  /// unanchored matcher would false-positive on ordinary code.
+  @Test("no production code calls PostHog identify or alias")
+  func postHogIdentityIsFrozen() throws {
+    let scan = try Self.scan(at: RepoRoot.sourceURL("Sources"))
+
+    // Reached-the-tree control: a scan that read nothing reports "clean" for the
+    // wrong reason. `PostHogSDK.shared.capture(` exists in the emitter today, so
+    // zero control hits means the walk or the read, not the codebase, changed.
+    // The forbidden pattern's OWN two-way proof is the fixture tests below —
+    // `capture` and `(identify|alias)` are different regexes, so a hit on one
+    // does not prove the other can match.
+    #expect(
+      scan.swiftFileCount > 100,
+      "scanned only \(scan.swiftFileCount) Swift files — the scan did not reach the source tree")
+    #expect(
+      scan.controlHitCount > 0,
+      "the matcher found no `PostHogSDK.shared.capture(` call, so a negative result proves nothing")
+
+    #expect(
+      scan.offenders.isEmpty,
+      """
+      PostHog identity is no longer anonymous — `analytics.distinct_id` may now \
+      carry a caller-supplied value into Sentry:
+      \(scan.offenders.joined(separator: "\n"))
+      """)
+  }
+
+  /// The freeze test's green must mean "no offender exists", never "the matcher
+  /// cannot see one". Drives the REAL scanner over a throwaway tree containing
+  /// each forbidden form, including whitespace and a line break before `(`.
+  @Test(
+    "the freeze scanner actually catches a forbidden call",
+    arguments: [
+      "PostHogSDK.shared.identify(\"someone@example.com\")",
+      "PostHogSDK.shared.alias(\"legacy-id\")",
+      "PostHogSDK.shared.identify (\"spaced\")",
+      "    PostHogSDK.shared.identify(distinctId)",
+      "PostHogSDK.shared.identify\n      (\"multiline\")",
+    ])
+  func freezeScannerCatchesOffenders(offendingLine: String) throws {
+    let scan = try Self.scanFixture(containing: offendingLine)
+    #expect(scan.offenders.count == 1, "expected exactly one offender, got \(scan.offenders)")
+  }
+
+  /// Precision half. An unanchored `identify(` matcher would flag ordinary
+  /// production code — `TerminalProcessScanner` has a legitimate `identify`
+  /// function — and a gate that false-fires gets worked around rather than read.
+  @Test(
+    "the freeze scanner does not flag an unrelated identify or a different SDK",
+    arguments: [
+      "let role = identify(process: pid)",
+      "scanner.identify(window)",
+      "SomeOtherSDK.shared.identify(\"x\")",
+      "PostHogSDK.shared.capture(\"dictation.completed\")",
+    ])
+  func freezeScannerIgnoresInnocentLines(innocentLine: String) throws {
+    let scan = try Self.scanFixture(containing: innocentLine)
+    #expect(scan.offenders.isEmpty, "false positive on `\(innocentLine)`: \(scan.offenders)")
+  }
+
+  // MARK: - Scan support
+
+  private struct ScanResult {
+    var swiftFileCount = 0
+    var controlHitCount = 0
+    var offenders: [String] = []
+  }
+
+  private struct ScanFailedError: Error, CustomStringConvertible {
+    let path: String
+    let reason: String
+    var description: String { "join-key freeze scan failed at \(path): \(reason)" }
+  }
+
+  /// Writes `line` into a throwaway Swift file and runs the REAL scanner over
+  /// it, so the fixture exercises the production discovery, read and match path
+  /// rather than a parallel simpler stand-in.
+  private static func scanFixture(containing line: String) throws -> ScanResult {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "ew-1846-freeze-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try "import PostHog\n\nfunc probe() {\n\(line)\n}\n"
+      .write(to: root.appending(path: "Probe.swift"), atomically: true, encoding: .utf8)
+    return try scan(at: root)
+  }
+
+  /// Fails CLOSED: a nil enumerator, a deferred enumeration error, or an
+  /// unreadable file throws rather than falling through as zero offenders.
+  private static func scan(at rootURL: URL) throws -> ScanResult {
+    let relativePrefix = RepoRoot.url.path + "/"
+    var result = ScanResult()
+    var enumerationError: Error?
+
+    // A trailing closure directly in a `guard` condition is a known Swift parser
+    // ambiguity — passed as an explicit `errorHandler:` argument instead.
+    guard
+      let enumerator = FileManager.default.enumerator(
+        at: rootURL, includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles, .skipsPackageDescendants],
+        errorHandler: { _, error in
+          enumerationError = error
+          return false
+        })
+    else {
+      throw ScanFailedError(path: rootURL.path, reason: "could not create a directory enumerator")
+    }
+
+    while let url = enumerator.nextObject() as? URL {
+      guard url.pathExtension == "swift" else { continue }
+      result.swiftFileCount += 1
+      let source: String
+      do {
+        source = try String(contentsOf: url, encoding: .utf8)
+      } catch {
+        throw ScanFailedError(path: url.path, reason: "could not be read: \(error)")
+      }
+      var relativePath = url.path
+      if relativePath.hasPrefix(relativePrefix) {
+        relativePath.removeFirst(relativePrefix.count)
+      }
+      // Matched against the WHOLE source, not line by line: `\s` spans newlines,
+      // so a call reformatted with the paren on the next line cannot slip past.
+      for matchStart in Self.matchStarts(of: Self.forbiddenCallPattern, in: source) {
+        result.offenders.append("\(relativePath):\(Self.line(at: matchStart, in: source))")
+      }
+      result.controlHitCount += Self.matchStarts(of: Self.controlCallPattern, in: source).count
+    }
+
+    if let enumerationError {
+      throw ScanFailedError(
+        path: rootURL.path, reason: "directory enumeration failed: \(enumerationError)")
+    }
+    return result
+  }
+
+  /// EVERY match, not just the first: a file with two offenders must report both,
+  /// or fixing one hides the other until the next run.
+  private static func matchStarts(of pattern: String, in source: String) -> [String.Index] {
+    var starts: [String.Index] = []
+    var searchFrom = source.startIndex
+    while searchFrom < source.endIndex,
+      let match = source.range(
+        of: pattern, options: .regularExpression, range: searchFrom..<source.endIndex)
+    {
+      starts.append(match.lowerBound)
+      // A zero-width match would not advance; this pattern cannot produce one
+      // (it ends in a literal `(`), but guard the loop rather than assume.
+      searchFrom =
+        match.upperBound > match.lowerBound
+        ? match.upperBound : source.index(after: match.lowerBound)
+    }
+    return starts
+  }
+
+  private static func line(at index: String.Index, in source: String) -> Int {
+    source[source.startIndex..<index].reduce(1) { $1 == "\n" ? $0 + 1 : $0 }
+  }
+
+  /// `\s*`, not `[ \t]*`: all whitespace INCLUDING a newline, so a multiline
+  /// reformatted call cannot slip past. Anchored to `PostHogSDK.shared` so an
+  /// unrelated production `identify` is not flagged.
+  private static let forbiddenCallPattern = #"PostHogSDK\.shared\.(identify|alias)\s*\("#
+  private static let controlCallPattern = #"PostHogSDK\.shared\.capture\s*\("#
+}

--- a/Tests/EnviousWisprTests/Services/TelemetryJoinKeyTests.swift
+++ b/Tests/EnviousWisprTests/Services/TelemetryJoinKeyTests.swift
@@ -21,17 +21,29 @@ struct TelemetryJoinKeyTests {
       "0198a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b",
       "00000000-0000-0000-0000-000000000000",
       "ffffffff-ffff-ffff-ffff-ffffffffffff",
+      // UPPERCASE IS REAL, AND IT IS 13.6% OF THE FLEET. The SDK lowercases ids
+      // it MINTS, but `PostHogStorageManager.getAnonymousId()` returns a
+      // PERSISTED id unchanged, so an install whose id predates that lowercasing
+      // keeps its spelling forever. Measured against production 2026-07-30:
+      // 94 of 692 distinct installs carry an uppercase id, including this
+      // machine's dev install. Rejecting them dropped 13.6% of the join into a
+      // blind spot indistinguishable from "PostHog was skipped".
+      "0198A1B2-C3D4-7E5F-8A9B-0C1D2E3F4A5B",
+      "019E2DB1-63F5-7776-A7E4-9ACD568A81F5",
     ])
   func acceptsCanonicalAnonymousID(raw: String) {
+    // Returned VERBATIM, never normalized: the tag has to equal the string
+    // PostHog actually stores, so lowercasing an uppercase id would leave the
+    // join just as broken and much harder to see.
     #expect(ObservabilityBootstrap.canonicalAnonymousPostHogID(raw) == raw)
   }
 
   /// Each rejection is a distinct reason, not one class:
   /// - compact 32-hex would arrive as `[REDACTED]` (see the two-way control below);
-  /// - an uppercase representation is not what PostHog stamps on its own events,
-  ///   so joining on it would silently match nothing — and `UUID(uuidString:)`
-  ///   accepts it, which is why the predicate also demands exact equality with
-  ///   the lowercased round-trip;
+  /// - MIXED case is not a spelling PostHog ever produces: it mints lowercase and
+  ///   persists whatever it stored, so only the two canonical spellings are real.
+  ///   `UUID(uuidString:)` accepts mixed case, which is why the predicate demands
+  ///   exact equality with one of those two;
   /// - email-shaped and arbitrary values are the shapes a future `identify()`
   ///   could introduce, and copying a caller-supplied string into Sentry is not
   ///   a decision the bootstrap seam may make silently;
@@ -41,7 +53,7 @@ struct TelemetryJoinKeyTests {
     "every non-canonical or unsafe shape is rejected",
     arguments: [
       "0198a1b2c3d47e5f8a9b0c1d2e3f4a5b",
-      "0198A1B2-C3D4-7E5F-8A9B-0C1D2E3F4A5B",
+      "0198A1B2-c3d4-7E5F-8a9b-0C1D2E3F4A5B",
       "someone@example.com",
       "install-1846",
       "",

--- a/Tests/EnviousWisprTests/Services/VADMarkerTakeIDTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/VADMarkerTakeIDTelemetryTests.swift
@@ -1,0 +1,88 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+#if DEBUG
+
+  /// #1846: the WIRE contract for the three record-start VAD markers. The routing
+  /// tests in `CaptureVADSignalSourceTests` and `RecordStartTelemetrySinkTests` stop
+  /// at injected seams, so deleting a production `props["take_id"]` line leaves them
+  /// green.
+  ///
+  /// These three emitters previously built the DEBUG hook event and the PostHog
+  /// properties as two SEPARATE literals — a test could assert a key the real capture
+  /// never sent. Chunk 9 collapsed each to one payload with the hook derived from it,
+  /// which is what makes this suite trustworthy rather than a second mirror.
+  @Suite("VAD marker take_id telemetry (#1846)", .serialized)
+  struct VADMarkerTakeIDTelemetryTests {
+    private static let takeID = "9f2c1d84-6b3a-4e07-9c51-0a7d2e6f1b33"
+
+    final class EventBox: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      func append(_ event: CapturedTelemetryEvent) { lock.withLock { stored.append(event) } }
+      func removeAll() { lock.withLock { stored.removeAll() } }
+      var values: [CapturedTelemetryEvent] { lock.withLock { stored } }
+    }
+
+    private static let vadEventNames: Set<String> = [
+      "dictation.vad_preparation_completed",
+      "dictation.first_vad_chunk_started",
+      "dictation.first_vad_chunk_completed",
+    ]
+
+    @MainActor
+    @Test("all three VAD markers emit take_id when present and omit it when nil")
+    func vadMarkerTakeIDContract() throws {
+      let box = EventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if Self.vadEventNames.contains(event.name) { box.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      Self.emitAllThree(takeID: Self.takeID)
+
+      let presentEvents = box.values
+      #expect(presentEvents.count == 3, "each of the three markers must fire exactly once")
+      #expect(
+        Set(presentEvents.map(\.name)) == Self.vadEventNames,
+        "all three markers must fire — saw \(presentEvents.map(\.name).sorted())"
+      )
+      for event in presentEvents {
+        #expect(
+          event.stringProps["take_id"] == Self.takeID,
+          "\(event.name) must carry the take key")
+      }
+
+      box.removeAll()
+      Self.emitAllThree(takeID: nil)
+
+      let absentEvents = box.values
+      #expect(absentEvents.count == 3, "each of the three markers must still fire exactly once")
+      #expect(
+        Set(absentEvents.map(\.name)) == Self.vadEventNames,
+        "the nil case must emit the same three markers — saw \(absentEvents.map(\.name).sorted())"
+      )
+      for event in absentEvents {
+        #expect(
+          event.stringProps["take_id"] == nil,
+          "\(event.name) must OMIT take_id, not send an empty string")
+        #expect(event.stringProps["backend"] == "parakeet")
+      }
+    }
+
+    @MainActor
+    private static func emitAllThree(takeID: String?) {
+      TelemetryService.shared.dictationVADPreparationCompleted(
+        backend: "parakeet", inputRoute: "built_in_mic", ready: true, modelReused: false,
+        takeID: takeID)
+      TelemetryService.shared.dictationFirstVADChunkStarted(
+        backend: "parakeet", inputRoute: "built_in_mic", monitorToFirstChunkMs: 12.5,
+        takeID: takeID)
+      TelemetryService.shared.dictationFirstVADChunkCompleted(
+        backend: "parakeet", inputRoute: "built_in_mic", chunkProcessingLatencyMs: 3.25,
+        shouldStop: false, takeID: takeID)
+    }
+  }
+
+#endif

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -1,0 +1,2485 @@
+#!/usr/bin/env python3
+"""Join one Sentry fingerprint to PostHog usage, per anonymous install (#1846).
+
+Sentry records only failures, so every field on a failing event looks universal
+there. This instrument answers the two questions that repeatedly went wrong
+without it (#1788, #1809):
+
+  1. How many PEOPLE, not events, does this fingerprint affect, per release?
+  2. What was each affected install configured as, and what is that install's
+     own success record on the same release?
+
+Phase 1 scope. It reports install-level event counts, distinct installs and
+per-install configuration only. Per-take coverage and the fingerprint take rate
+require the Phase 2 `take_id` and are deliberately absent.
+
+Usage:
+  telemetry-join.py --issue ENVIOUSWISPR-2F
+  telemetry-join.py --issue 6712345678
+
+Credentials are read from the process environment ONLY, never from a file, an
+argument or stdin. Bridge them with the approved launcher:
+
+  ~/.claude/bin/get-key launch sentry-master-key SENTRY_MASTER_KEY -- \\
+    ~/.claude/bin/get-key launch posthog-personal-api-key POSTHOG_KEY -- \\
+    python3 scripts/telemetry-join.py --issue ENVIOUSWISPR-2F
+
+Self-test:
+  python3 scripts/telemetry-join.py --self-test
+
+This is a required local ship gate. No CI workflow currently invokes it.
+
+Fails CLOSED. Any authentication, authorization, pagination, parse, partition,
+completeness or exhausted-retry failure exits non-zero BEFORE printing any
+measurement. A partial table that reads as complete is the failure mode this
+design exists to prevent.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import math
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Callable, Mapping, Sequence
+
+# --------------------------------------------------------------------------
+# Grounded constants. Sources:
+#   sentry-operations.md FACT: connection-details, FACT: mcp-tool-selection
+#   analytics-operations.md FACT: posthog-connection, RULE: filter-production-analytics,
+#     FACT: posthog-project-concurrency-limit, FACT: dictation-completed-field-version-floors
+# --------------------------------------------------------------------------
+SENTRY_HOST = "https://us.sentry.io"
+SENTRY_ORG = "envious-labs-llc"
+POSTHOG_HOST = "https://us.posthog.com"
+POSTHOG_PROJECT_ID = "354235"
+
+# Plan §11.2 makes a DEVELOPMENT-environment run the primary pre-merge gate,
+# while ordinary triage is production. Both vendors carry both environments, so
+# the environment is an input, not a constant. Production is the default because
+# that is the answer a triage session almost always wants.
+ENVIRONMENTS = ("production", "development")
+ASR_HELPER_ROLE = "asr_xpc"
+
+JOIN_TAG = "analytics.distinct_id"
+JOINED_IDENTITY_LABEL = "analytics.distinct_id (joined install identity)"
+LEGACY_IDENTITY_LABEL = "legacy Sentry identity"
+
+NO_USAGE_ROWS = "no usage rows for this install"
+NOT_SHIPPED = "not shipped on this release"
+
+# PostHog project limit is 3 concurrent / 10s per query. This instrument runs
+# partitions strictly sequentially, so the only contention is external (the
+# project is shared with EnviousStaging). Retry mirrors the production workers:
+# 3 attempts total, only on the documented transient status class.
+RETRYABLE_STATUSES = frozenset({429, 502, 503, 504})
+MAX_ATTEMPTS = 3
+RETRY_DELAYS_SECONDS = (15.0, 37.0)
+REQUEST_TIMEOUT_SECONDS = 30.0
+
+# One identity emitting this many events inside this window is one frustrated
+# person retrying, not a trend. #1809: five of six events inside five minutes.
+RETRY_BURST_WINDOW_SECONDS = 300
+RETRY_BURST_MIN_EVENTS = 3
+
+# Installs per sequential PostHog partition. Small enough to stay well inside
+# the documented 10s execution ceiling with a literal IN list.
+PARTITION_SIZE = 25
+
+# Version floors, verbatim from analytics-operations.md FACT:
+# dictation-completed-field-version-floors. A field below its floor was never
+# emitted; printing a value (or a zero) for it would be fabrication.
+VERSION_FLOORS: Mapping[str, str] = {
+    "recording_seconds": "2.2.0",
+    "stop_reason": "2.2.0",
+    "history_save_status": "2.2.0",
+    "selected_transport": "2.3.2",
+    "effective_transport": "2.3.2",
+    "route_reason": "2.3.2",
+}
+# Fields with NO version floor. `llm_provider` null means "no accepted polish
+# stamp", which is data, not absence.
+NO_FLOOR_FIELDS = frozenset({"llm_provider", "target_app", "paste_result"})
+
+# `settings.snapshot` property names, read from the emitter
+# (TelemetryService.swift `settings.snapshot`). Reconstruction overlays later
+# `settings.changed` values on the latest snapshot, per
+# analytics-operations.md FACT: settings-config-reconstruction.
+RECONSTRUCTED_SETTINGS = (
+    "asr_backend",
+    "llm_provider",
+    "llm_model",
+    "recording_mode",
+    "vad_auto_stop",
+    "warm_engine_policy",
+    "filler_removal",
+    "microphone_status",
+    "accessibility_status",
+)
+# NOTE on three of the nine: `asr_backend`, `microphone_status` and
+# `accessibility_status` are NOT members of `SettingsProjection.Logical`
+# (Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift — its comment
+# says it "Excludes the Phase-2-owned backend"), so they never appear as a
+# `settings.changed` delta and are reconstructed from the latest snapshot ALONE.
+# A backend switch between snapshots is therefore invisible to this tool. Stated
+# rather than silently inaccurate.
+
+
+# --------------------------------------------------------------------------
+# Errors. Every one of these must reach the operator as a non-zero exit with no
+# measurement printed.
+# --------------------------------------------------------------------------
+class InstrumentError(Exception):
+    """Base: any condition that invalidates the requested report."""
+
+
+class ConfigError(InstrumentError):
+    """Missing credential or malformed invocation."""
+
+
+class TransportError(InstrumentError):
+    """The connection failed. Never carries headers or credential material."""
+
+
+class AuthError(InstrumentError):
+    """401/403 from a vendor. Not retryable."""
+
+
+class ProtocolError(InstrumentError):
+    """Malformed JSON, Link header, response shape, or missing required field."""
+
+
+class IncompleteError(InstrumentError):
+    """A partition or bucket total proves the evidence is incomplete."""
+
+
+class RetryExhaustedError(InstrumentError):
+    """A retryable status survived every attempt."""
+
+
+class MissingAuthorityError(InstrumentError):
+    """A version floor is required but not recorded in our knowledge base."""
+
+
+# --------------------------------------------------------------------------
+# The ONE transport seam. `urllib_transport` is the only function in this file
+# permitted to open a network connection. Everything above it - retry, status
+# classification, URL building, authorization, JSON, Link parsing, pagination,
+# partition accounting, completeness, aggregation, rendering - is exercised by
+# the self-test through a fixture transport.
+# --------------------------------------------------------------------------
+@dataclass(frozen=True)
+class HTTPRequest:
+    method: str
+    url: str
+    headers: Mapping[str, str]
+    body: bytes | None
+    timeout_seconds: float
+
+
+@dataclass(frozen=True)
+class HTTPResponse:
+    status: int
+    headers: Mapping[str, str]
+    body: bytes
+
+
+Transport = Callable[[HTTPRequest], HTTPResponse]
+Sleeper = Callable[[float], None]
+
+
+def urllib_transport(request: HTTPRequest) -> HTTPResponse:
+    """Normalize both ordinary responses and HTTPError into HTTPResponse, so
+    every status decision stays ABOVE this boundary. A connection-level failure
+    becomes a TransportError carrying only the reason class, never the headers.
+    """
+    req = urllib.request.Request(
+        request.url, data=request.body, method=request.method,
+        headers=dict(request.headers),
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=request.timeout_seconds) as resp:
+            return HTTPResponse(
+                status=resp.status, headers=dict(resp.headers), body=resp.read()
+            )
+    except urllib.error.HTTPError as exc:
+        # An error status is a RESPONSE, not a transport failure: the caller
+        # decides whether it is auth, retryable, or fatal.
+        return HTTPResponse(
+            status=exc.code, headers=dict(exc.headers or {}), body=exc.read() or b""
+        )
+    except urllib.error.URLError as exc:
+        raise TransportError(f"connection failed: {type(exc.reason).__name__}") from None
+    except OSError as exc:
+        raise TransportError(f"connection failed: {type(exc).__name__}") from None
+
+
+def header(response: HTTPResponse, name: str) -> str | None:
+    """Case-insensitive header read. HTTP header names are case-insensitive and
+    a vendor may change casing without notice; a case-sensitive read would
+    silently lose pagination.
+    """
+    target = name.lower()
+    for key, value in response.headers.items():
+        if key.lower() == target:
+            return value
+    return None
+
+
+def decode_json(response: HTTPResponse, what: str) -> object:
+    try:
+        return json.loads(response.body.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ProtocolError(f"{what}: response was not valid JSON ({exc.__class__.__name__})")
+
+
+# --------------------------------------------------------------------------
+# Sentry
+# --------------------------------------------------------------------------
+_LINK_SEGMENT = re.compile(r"^\s*<(?P<url>[^>]*)>(?P<params>.*)\s*$")
+_SHORT_ID = re.compile(r"^[A-Z][A-Z0-9_]*-[A-Z0-9]+$")
+_NUMERIC_ID = re.compile(r"^[0-9]+$")
+
+
+def parse_link_header(raw: str) -> dict[str, dict[str, str]]:
+    """Parse Sentry's Link header into {rel: {url, results, ...}}.
+
+    Refuses silently-malformed input rather than treating an unparseable header
+    as "no next page", which would truncate the population and report a
+    confident undercount.
+    """
+    raw_segments = [segment.strip() for segment in raw.split(",")]
+    if not raw_segments or any(not segment for segment in raw_segments):
+        raise ProtocolError(f"Link header is malformed: {raw[:120]!r}")
+
+    rels: dict[str, dict[str, str]] = {}
+    for segment in raw_segments:
+        # fullmatch, not findall: a valid PREFIX followed by garbage must fail,
+        # not parse to the prefix and silently drop the rest.
+        match = _LINK_SEGMENT.fullmatch(segment)
+        if match is None:
+            raise ProtocolError(f"Link segment is unparseable: {segment[:120]!r}")
+
+        attrs: dict[str, str] = {"url": match.group("url").strip()}
+        for part in match.group("params").split(";"):
+            part = part.strip()
+            if not part:
+                continue
+            if "=" not in part:
+                raise ProtocolError(f"Link parameter without a value: {part!r}")
+            key, _, value = part.partition("=")
+            key = key.strip()
+            if not key:
+                raise ProtocolError(f"Link parameter has an empty key: {part!r}")
+            if key in attrs:
+                raise ProtocolError(f"Link segment contains duplicate parameter {key!r}")
+
+            # `results="true"; results="false"` previously resolved to the LAST
+            # value, so an ambiguous header could authorize truncation.
+            raw_value = value.strip()
+            starts_quoted = raw_value.startswith('"')
+            ends_quoted = raw_value.endswith('"')
+            if starts_quoted != ends_quoted:
+                raise ProtocolError(f"Link parameter has unbalanced quotes: {part!r}")
+            if starts_quoted:
+                decoded_value = raw_value[1:-1]
+                if '"' in decoded_value:
+                    raise ProtocolError(
+                        f"Link parameter contains an unsupported quote: {part!r}"
+                    )
+            else:
+                if '"' in raw_value:
+                    raise ProtocolError(
+                        f"Link parameter contains an unsupported quote: {part!r}"
+                    )
+                decoded_value = raw_value
+
+            attrs[key] = decoded_value
+
+        rel = attrs.get("rel")
+        if not rel:
+            raise ProtocolError(f"Link segment without rel: {segment[:120]!r}")
+        if rel in rels:
+            raise ProtocolError(f"Link header contains duplicate rel={rel!r}")
+        rels[rel] = attrs
+
+    return rels
+
+
+def validate_sentry_page_url(url: str, numeric_issue_id: str) -> None:
+    """A pagination URL is vendor data, not authority to forward a credential.
+
+    The next request attaches our Sentry bearer token, so accepting any URL that
+    merely starts with "http" would let a compromised or buggy response redirect
+    that credential to an arbitrary host. Pinned to the exact issue endpoint.
+    """
+    parsed = urllib.parse.urlsplit(url)
+    expected_host = urllib.parse.urlsplit(SENTRY_HOST).netloc
+    expected_path = f"/api/0/issues/{numeric_issue_id}/events/"
+    query = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
+
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != expected_host
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path != expected_path
+        or parsed.fragment
+        or query.get("full") != ["true"]
+    ):
+        raise ProtocolError(
+            "events pagination returned a URL outside the exact Sentry issue "
+            f"endpoint: {url[:120]!r}"
+        )
+
+
+@dataclass(frozen=True)
+class SentryEvent:
+    event_id: str
+    release: str
+    join_key: str | None
+    legacy_identity: str | None
+    timestamp_epoch: float
+    #: Eligibility facts, read from the tags array. Plan §3a excludes development,
+    #: `synthetic=true` fault-injection launches, and the ASR helper process.
+    environment: str | None = None
+    synthetic: bool = False
+    process_role: str | None = None
+
+
+@dataclass
+class SentryClient:
+    api_key: str
+    transport: Transport = urllib_transport
+
+    def _get(self, url: str, what: str) -> HTTPResponse:
+        response = self.transport(
+            HTTPRequest(
+                method="GET", url=url,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Accept": "application/json",
+                },
+                body=None, timeout_seconds=REQUEST_TIMEOUT_SECONDS,
+            )
+        )
+        if response.status in (401, 403):
+            raise AuthError(
+                f"{what}: Sentry rejected the credential (HTTP {response.status}). "
+                "Expected GCP `sentry-master-key`, not the DSN, CI token, or worker token."
+            )
+        if response.status != 200:
+            raise ProtocolError(f"{what}: unexpected HTTP {response.status}")
+        return response
+
+    def resolve_issue_id(self, raw: str) -> str:
+        """Accept a numeric id directly; resolve a short id such as
+        ENVIOUSWISPR-2F through the organization short-id lookup.
+        """
+        candidate = raw.strip()
+        if _NUMERIC_ID.match(candidate):
+            return candidate
+        if not _SHORT_ID.match(candidate.upper()):
+            raise ConfigError(
+                f"issue identifier {raw!r} is neither numeric nor a SHORT-ID such as "
+                "ENVIOUSWISPR-2F"
+            )
+        url = f"{SENTRY_HOST}/api/0/organizations/{SENTRY_ORG}/shortids/{candidate.upper()}/"
+        payload = decode_json(self._get(url, "short-id lookup"), "short-id lookup")
+        if not isinstance(payload, dict):
+            raise ProtocolError("short-id lookup: expected a JSON object")
+        group = payload.get("group")
+        group_id = payload.get("groupId") or (
+            group.get("id") if isinstance(group, dict) else None
+        )
+        if not isinstance(group_id, str) or not _NUMERIC_ID.match(group_id):
+            raise ProtocolError(f"short-id lookup: no numeric groupId in response for {candidate}")
+        return group_id
+
+    def fetch_events(self, numeric_issue_id: str) -> list[SentryEvent]:
+        """Paginate the whole fingerprint. `full=true` because the MCP cannot
+        read `extra` fields (sentry-operations.md FACT: mcp-tool-selection).
+        """
+        url = f"{SENTRY_HOST}/api/0/issues/{numeric_issue_id}/events/?full=true"
+        seen_urls: set[str] = set()
+        # URL identity is not enough: two DIFFERENT page URLs can overlap, and the
+        # same event would then be counted twice.
+        seen_event_ids: set[str] = set()
+        events: list[SentryEvent] = []
+        page = 0
+        while url:
+            if url in seen_urls:
+                raise ProtocolError(
+                    f"pagination cycle: {url[:120]!r} was already fetched — refusing to "
+                    "count a population that may contain duplicates"
+                )
+            seen_urls.add(url)
+            page += 1
+            response = self._get(url, f"events page {page}")
+            payload = decode_json(response, f"events page {page}")
+            if not isinstance(payload, list):
+                raise ProtocolError(
+                    f"events page {page}: expected a JSON list, got {type(payload).__name__}"
+                )
+            for raw_event in payload:
+                event = self._parse_event(raw_event, page)
+                if event.event_id in seen_event_ids:
+                    raise ProtocolError(
+                        f"events page {page}: duplicate event id "
+                        f"{event.event_id!r} across the paginated population"
+                    )
+                seen_event_ids.add(event.event_id)
+                events.append(event)
+
+            link = header(response, "Link")
+            if link is None:
+                raise ProtocolError(
+                    f"events page {page}: missing Link header — refusing to treat "
+                    "an unverifiable page boundary as the end of the population"
+                )
+            rels = parse_link_header(link)
+            nxt = rels.get("next")
+            if nxt is None:
+                raise ProtocolError(
+                    f"events page {page}: Link header has no next relation — refusing "
+                    "to treat an unverifiable page boundary as complete"
+                )
+            results = nxt.get("results")
+            if results not in ("true", "false"):
+                raise ProtocolError(
+                    f"events page {page}: next rel has results={results!r}, expected "
+                    '"true" or "false"'
+                )
+            # Validate EVERY next relation, including the terminating one, so a
+            # hostile URL cannot slip through on the last page.
+            next_url = nxt.get("url", "")
+            validate_sentry_page_url(next_url, numeric_issue_id)
+            if results == "false":
+                url = ""
+                break
+            url = next_url
+        return events
+
+    @staticmethod
+    def _parse_event(raw_event: object, page: int) -> SentryEvent:
+        if not isinstance(raw_event, dict):
+            raise ProtocolError(f"events page {page}: event was not a JSON object")
+        event_id = raw_event.get("id")
+        if not isinstance(event_id, str) or not event_id:
+            raise ProtocolError(f"events page {page}: event without an id")
+        tags = raw_event.get("tags")
+        if not isinstance(tags, list):
+            raise ProtocolError(f"event {event_id}: `tags` missing or not a list")
+        # Release lives in the tags ARRAY. `.release.version` reads null
+        # (sentry-operations.md FACT: mcp-tool-selection).
+        by_key: dict[str, str] = {}
+        for tag in tags:
+            if not isinstance(tag, dict):
+                raise ProtocolError(f"event {event_id}: tag entry was not an object")
+            key, value = tag.get("key"), tag.get("value")
+            if isinstance(key, str) and isinstance(value, str):
+                by_key[key] = value
+        release = canonical_app_version(by_key.get("release"), f"event {event_id}")
+
+        timestamp_epoch = _parse_iso8601(raw_event.get("dateCreated"))
+        if timestamp_epoch is None:
+            raise ProtocolError(
+                f"event {event_id}: dateCreated was missing or not valid ISO-8601"
+            )
+
+        # `user.id` specifically, NOT the `user` display tag: the approved legacy
+        # identity is the SDK installation UUID on `user.id`, and the display tag
+        # can hold a different, non-identity string.
+        join_key = canonical_join_key(by_key.get(JOIN_TAG))
+        legacy_identity = _user_id(raw_event)
+        if join_key is None and legacy_identity is None:
+            raise ProtocolError(
+                f"event {event_id}: neither a canonical {JOIN_TAG} nor "
+                "legacy Sentry user.id was present"
+            )
+
+        return SentryEvent(
+            event_id=event_id,
+            release=release,
+            join_key=join_key,
+            legacy_identity=legacy_identity,
+            timestamp_epoch=timestamp_epoch,
+            environment=by_key.get("environment"),
+            synthetic=by_key.get("synthetic") == "true",
+            process_role=by_key.get("process.role"),
+        )
+
+
+def _user_id(raw_event: Mapping[str, object]) -> str | None:
+    user = raw_event.get("user")
+    if isinstance(user, dict):
+        value = user.get("id")
+        return value if isinstance(value, str) else None
+    return None
+
+
+def _parse_iso8601(value: object) -> float | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.replace("Z", "+00:00")
+    try:
+        return datetime.datetime.fromisoformat(text).timestamp()
+    except ValueError:
+        return None
+
+
+def canonical_join_key(raw: object) -> str | None:
+    """Mirror of `ObservabilityBootstrap.canonicalAnonymousPostHogID`. A value
+    the app would never have emitted is not a join key; treating it as one would
+    query PostHog for an install that cannot exist.
+    """
+    if not isinstance(raw, str) or len(raw) != 36:
+        return None
+    if not re.fullmatch(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", raw):
+        return None
+    return raw
+
+
+_APP_VERSION_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.+-]+)?$")
+_SENTRY_RELEASE_PREFIX = "com.enviouswispr.app@"
+
+
+def canonical_app_version(raw: object, what: str) -> str:
+    """Normalize the TWO representations the app emits for the same version.
+
+    Sentry receives `com.enviouswispr.app@<appVersion>`
+    (`ObservabilityBootstrap.swift` `options.releaseName`) while PostHog receives
+    `<appVersion>` raw (`register(["app_version": appVersion])`). Without this,
+    an exact dictionary lookup between the two NEVER matches and every install's
+    success count silently reports zero — the tool's entire denominator, empty.
+
+    Dev builds carry a leading `v` and a git suffix, which must also normalize.
+
+    NOTE on the hard failure: `appVersion` falls back to the literal "unknown"
+    when `CFBundleShortVersionString` is absent, so malformed release evidence
+    can reach this instrument. It deliberately aborts the whole report. Release
+    is a required reporting dimension; excluding the event would knowingly
+    undercount the fingerprint, while an "unknown" bucket would fabricate a
+    release. Correct the evidence or source build, then rerun.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        raise ProtocolError(f"{what}: release was missing or not a string")
+
+    value = raw.strip()
+    if value.startswith(_SENTRY_RELEASE_PREFIX):
+        value = value[len(_SENTRY_RELEASE_PREFIX):]
+    elif "@" in value:
+        raise ProtocolError(f"{what}: unexpected packaged release {value!r}")
+
+    if _APP_VERSION_PATTERN.fullmatch(value) is None:
+        raise ProtocolError(f"{what}: malformed app version {value!r}")
+    return value
+
+
+def required_timestamp(raw: object, what: str) -> float:
+    """Accept only a finite, non-negative numeric timestamp.
+
+    A NaN comparison is always false, so an unvalidated NaN would make a valid
+    later settings change silently lose to its snapshot and reconstruct the wrong
+    configuration — a wrong answer, not an error.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise ProtocolError(f"{what}: timestamp was not numeric")
+    value = float(raw)
+    if not math.isfinite(value) or value < 0:
+        raise ProtocolError(f"{what}: timestamp was not a finite non-negative number")
+    return value
+
+
+def required_count(raw: object, what: str) -> int:
+    """Accept only a finite, non-negative whole number.
+
+    `isinstance(True, int)` is True in Python, so a boolean passed the previous
+    numeric check, and `int(1.5)` silently truncated a fractional count. A count
+    is a measurement; a truncated one is a fabricated one.
+    """
+    if isinstance(raw, bool):
+        raise ProtocolError(f"{what}: count was boolean, not numeric")
+    if isinstance(raw, int):
+        if raw < 0:
+            raise ProtocolError(f"{what}: count was negative")
+        return raw
+    if isinstance(raw, float):
+        if not math.isfinite(raw) or raw < 0 or not raw.is_integer():
+            raise ProtocolError(f"{what}: count was not a finite non-negative integer")
+        return int(raw)
+    raise ProtocolError(f"{what}: count was not numeric")
+
+
+# --------------------------------------------------------------------------
+# PostHog
+# --------------------------------------------------------------------------
+def sql_id_list(ids: Sequence[str]) -> str:
+    """Escape for a literal IN list, matching `sqlIdList` in the production
+    workers (workers/daily-report/src/index.js).
+    """
+    return ", ".join("'" + str(i).replace("'", "''") + "'" for i in ids)
+
+
+@dataclass
+class PostHogClient:
+    api_key: str
+    transport: Transport = urllib_transport
+    sleeper: Sleeper = time.sleep
+    #: Every dev-tainted distinct_id, resolved ONCE. Repeating the unbounded
+    #: whole-history NOT IN subquery per query is the shape that measurably
+    #: 504'd production (#1655, #1716, #1720).
+    environment: str = "production"
+    dev_ids: tuple[str, ...] | None = None
+    attempts_made: list[int] = field(default_factory=list)
+
+    def query(self, sql: str, name: str) -> tuple[list[list[object]], list[str]]:
+        body = json.dumps(
+            {
+                "query": {"kind": "HogQLQuery", "query": sql},
+                "refresh": "blocking",
+                "name": f"telemetry_join_{name}",
+            }
+        ).encode("utf-8")
+        last_status: int | None = None
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            response = self.transport(
+                HTTPRequest(
+                    method="POST",
+                    url=f"{POSTHOG_HOST}/api/projects/{POSTHOG_PROJECT_ID}/query/",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    body=body,
+                    timeout_seconds=REQUEST_TIMEOUT_SECONDS,
+                )
+            )
+            if response.status in (401, 403):
+                raise AuthError(
+                    f"query {name}: PostHog rejected the credential (HTTP {response.status}). "
+                    "Expected GCP `posthog-personal-api-key`."
+                )
+            if response.status == 200:
+                self.attempts_made.append(attempt)
+                payload = decode_json(response, f"query {name}")
+                if not isinstance(payload, dict):
+                    raise ProtocolError(f"query {name}: expected a JSON object")
+                results = payload.get("results")
+                if not isinstance(results, list):
+                    raise ProtocolError(f"query {name}: response has no `results` array")
+                rows: list[list[object]] = []
+                for row in results:
+                    if not isinstance(row, list):
+                        raise ProtocolError(f"query {name}: a result row was not a list")
+                    rows.append(row)
+                columns = payload.get("columns")
+                if columns is not None and not isinstance(columns, list):
+                    raise ProtocolError(f"query {name}: `columns` present but not a list")
+                return rows, [str(c) for c in (columns or [])]
+            if response.status not in RETRYABLE_STATUSES:
+                raise ProtocolError(f"query {name}: unexpected HTTP {response.status}")
+            last_status = response.status
+            if attempt < MAX_ATTEMPTS:
+                self.sleeper(RETRY_DELAYS_SECONDS[attempt - 1])
+        raise RetryExhaustedError(
+            f"query {name}: HTTP {last_status} survived {MAX_ATTEMPTS} attempts — "
+            "the whole report fails rather than degrading to a partial answer"
+        )
+
+    def environment_clause(self) -> str:
+        """The environment filter plus, for PRODUCTION only, the resolve-once
+        dev-taint exclusion. An empty dev list is legitimate and must not produce
+        `NOT IN ()`.
+
+        The exclusion is deliberately NOT applied to a development query: in that
+        mode the dev-tainted installs ARE the population, so excluding them would
+        return zero rows and read as "no usage" — the plan's primary gate would
+        silently prove nothing.
+        """
+        if self.environment not in ENVIRONMENTS:
+            raise ConfigError(f"unknown environment {self.environment!r}")
+        clause = f"properties.environment = '{self.environment}'"
+        if self.environment == "production":
+            if self.dev_ids is None:
+                raise IncompleteError("dev-tainted install ids were never resolved")
+            if self.dev_ids:
+                clause += f" AND distinct_id NOT IN ({sql_id_list(self.dev_ids)})"
+        return clause
+
+    def resolve_dev_ids(self) -> tuple[str, ...]:
+        rows, _ = self.query(
+            "SELECT DISTINCT distinct_id FROM events "
+            "WHERE properties.app_version LIKE '%-dev%'",
+            "dev_ids",
+        )
+        ids = []
+        for row in rows:
+            if len(row) != 1 or not isinstance(row[0], str):
+                raise ProtocolError("dev_ids: expected exactly one string column per row")
+            ids.append(row[0])
+        self.dev_ids = tuple(ids)
+        return self.dev_ids
+
+
+def require_complete_partitions(
+    expected_indexes: set[int], completed_indexes: set[int]
+) -> None:
+    """The partition-accounting guard, extracted as a pure function so it is
+    DIRECTLY testable. Inline in the loop it was unreachable under sequential
+    fail-fast execution, which made it a guard nothing could arm
+    (RULE: a-guard-nothing-arms-is-not-a-guard). As a pure function its contract
+    is asserted by the self-test, and it stays correct if concurrency lands.
+    """
+    missing = expected_indexes - completed_indexes
+    unexpected = completed_indexes - expected_indexes
+    if missing or unexpected:
+        raise IncompleteError(
+            "PostHog partition accounting failed: "
+            f"missing={sorted(missing)}, unexpected={sorted(unexpected)} — "
+            "refusing to render an incomplete report"
+        )
+
+
+def partition(ids: Sequence[str], size: int = PARTITION_SIZE) -> list[tuple[int, list[str]]]:
+    """Explicit, indexed, sequential partitions. The index is what lets the
+    caller prove none went missing.
+    """
+    return [(i // size, list(ids[i:i + size])) for i in range(0, len(ids), size)]
+
+
+# --------------------------------------------------------------------------
+# Version floors
+# --------------------------------------------------------------------------
+def version_key(version: str) -> tuple[int, ...]:
+    """Sort key. The previous version returned (0,) for any dev build, because it
+    stopped at the leading `v` — so every dev release sorted as version zero.
+    """
+    normalized = canonical_app_version(version, "release")
+    if normalized.startswith("v"):
+        normalized = normalized[1:]
+    numeric = re.split(r"[-+]", normalized, maxsplit=1)[0]
+    return tuple(int(part) for part in numeric.split("."))
+
+
+def field_shipped_on(field_name: str, release: str) -> bool:
+    """Refuses to guess. An unrecorded field raises rather than defaulting to
+    "shipped", which would print a fabricated absence as data.
+    """
+    if field_name in NO_FLOOR_FIELDS:
+        return True
+    floor = VERSION_FLOORS.get(field_name)
+    if floor is None:
+        raise MissingAuthorityError(
+            f"no version floor recorded for {field_name!r}. Add it to "
+            "analytics-operations.md FACT: dictation-completed-field-version-floors "
+            "before reporting it."
+        )
+    return version_key(release) >= version_key(floor)
+
+
+def render_field(field_name: str, release: str, value: object) -> str:
+    if not field_shipped_on(field_name, release):
+        return NOT_SHIPPED
+    if value is None or value == "":
+        return "null (no value recorded)"
+    return str(value)
+
+
+# --------------------------------------------------------------------------
+# Aggregation
+# --------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ReleaseRow:
+    release: str
+    events: int
+    identities: int
+    events_per_identity: float
+    identity_source: str
+
+
+@dataclass(frozen=True)
+class PopulationTotal:
+    """One total per IDENTITY SYSTEM. There is deliberately no combined total:
+    the joined install population and the legacy Sentry population can contain
+    the same human twice, so a sum would be a fabricated number.
+    """
+    events: int
+    identities: int
+    events_per_identity: float
+    identity_source: str
+
+
+@dataclass(frozen=True)
+class RetryBurst:
+    identity: str
+    release: str
+    events_in_window: int
+    window_seconds: int
+
+
+@dataclass
+class FingerprintReport:
+    issue: str
+    environment: str
+    excluded_counts: dict[str, int]
+    release_rows: list[ReleaseRow]
+    population_totals: list[PopulationTotal]
+    join_coverage_by_release: dict[str, tuple[int, int]]
+    bursts: list[RetryBurst]
+    joined_install_ids: list[str]
+    joined_releases_by_install: dict[str, set[str]]
+    unjoined_events: int
+
+
+@dataclass(frozen=True)
+class Eligibility:
+    eligible: list[SentryEvent]
+    excluded_counts: dict[str, int]
+
+
+def select_eligible_events(
+    events: Sequence[SentryEvent], environment: str
+) -> Eligibility:
+    """Plan §3a excludes development (or production, when asked for development),
+    `synthetic=true` fault-injection launches, and the ASR helper process.
+
+    Every exclusion is COUNTED by reason and reported. An instrument that silently
+    drops events cannot be distinguished from one that never saw them.
+    """
+    if environment not in ENVIRONMENTS:
+        raise ConfigError(f"unknown environment {environment!r}")
+    eligible: list[SentryEvent] = []
+    excluded: dict[str, int] = defaultdict(int)
+    for event in events:
+        if event.environment is None:
+            excluded["environment tag absent"] += 1
+            continue
+        if event.environment != environment:
+            excluded[f"environment={event.environment}"] += 1
+            continue
+        if event.synthetic:
+            excluded["synthetic=true (fault injection)"] += 1
+            continue
+        if event.process_role == ASR_HELPER_ROLE:
+            excluded[f"process.role={ASR_HELPER_ROLE} (documented gap)"] += 1
+            continue
+        eligible.append(event)
+    return Eligibility(eligible=eligible, excluded_counts=dict(excluded))
+
+
+def aggregate_fingerprint(
+    issue: str,
+    events: Sequence[SentryEvent],
+    environment: str = "production",
+    excluded_counts: Mapping[str, int] | None = None,
+) -> FingerprintReport:
+    """Keep joined and legacy identity systems in separate numerators,
+    denominators, release rows and totals. They are never summed.
+
+    The defect this shape replaces: counting ALL events for a release while
+    dividing by only the JOINED identities produced an events-per-person figure
+    mixing two populations — and the first version of case 20 froze that wrong
+    total as expected behaviour.
+    """
+    joined_events: dict[str, int] = defaultdict(int)
+    legacy_events: dict[str, int] = defaultdict(int)
+    joined_identities: dict[str, set[str]] = defaultdict(set)
+    legacy_identities: dict[str, set[str]] = defaultdict(set)
+    joined_releases_by_install: dict[str, set[str]] = defaultdict(set)
+    all_joined: set[str] = set()
+    all_legacy: set[str] = set()
+
+    for event in events:
+        release = event.release
+        if event.join_key:
+            joined_events[release] += 1
+            joined_identities[release].add(event.join_key)
+            joined_releases_by_install[event.join_key].add(release)
+            all_joined.add(event.join_key)
+            continue
+
+        if not event.legacy_identity:
+            raise IncompleteError(
+                f"event {event.event_id} has neither {JOIN_TAG} nor a legacy "
+                "Sentry identity"
+            )
+        legacy_events[release] += 1
+        legacy_identities[release].add(event.legacy_identity)
+        all_legacy.add(event.legacy_identity)
+
+    rows: list[ReleaseRow] = []
+    coverage: dict[str, tuple[int, int]] = {}
+    releases = sorted(set(joined_events) | set(legacy_events), key=version_key)
+
+    for release in releases:
+        joined_count = joined_events[release]
+        legacy_count = legacy_events[release]
+        coverage[release] = (joined_count, joined_count + legacy_count)
+
+        if joined_count:
+            identities = len(joined_identities[release])
+            rows.append(
+                ReleaseRow(
+                    release=release, events=joined_count, identities=identities,
+                    events_per_identity=round(joined_count / identities, 1),
+                    identity_source=JOINED_IDENTITY_LABEL,
+                )
+            )
+
+        if legacy_count:
+            identities = len(legacy_identities[release])
+            rows.append(
+                ReleaseRow(
+                    release=release, events=legacy_count, identities=identities,
+                    events_per_identity=round(legacy_count / identities, 1),
+                    identity_source=LEGACY_IDENTITY_LABEL,
+                )
+            )
+
+    totals: list[PopulationTotal] = []
+    joined_total_events = sum(joined_events.values())
+    if all_joined:
+        totals.append(
+            PopulationTotal(
+                events=joined_total_events, identities=len(all_joined),
+                events_per_identity=round(joined_total_events / len(all_joined), 1),
+                identity_source=JOINED_IDENTITY_LABEL,
+            )
+        )
+
+    legacy_total_events = sum(legacy_events.values())
+    if all_legacy:
+        # 255/60 = 4.25 resolves to 4.2 under Python's ties-to-even rounding,
+        # matching the measured baseline table in the approved plan.
+        totals.append(
+            PopulationTotal(
+                events=legacy_total_events, identities=len(all_legacy),
+                events_per_identity=round(legacy_total_events / len(all_legacy), 1),
+                identity_source=LEGACY_IDENTITY_LABEL,
+            )
+        )
+
+    return FingerprintReport(
+        issue=issue,
+        environment=environment,
+        excluded_counts=dict(excluded_counts or {}),
+        release_rows=rows,
+        population_totals=totals,
+        join_coverage_by_release=coverage,
+        bursts=detect_retry_bursts(events),
+        joined_install_ids=sorted(all_joined),
+        joined_releases_by_install={
+            install: set(rels) for install, rels in joined_releases_by_install.items()
+        },
+        unjoined_events=legacy_total_events,
+    )
+
+
+def detect_retry_bursts(events: Sequence[SentryEvent]) -> list[RetryBurst]:
+    """A retry burst inflates the EVENT count without adding a person. Finding
+    it is what stops `events` being read as `people`.
+    """
+    grouped: dict[tuple[str, str], list[float]] = defaultdict(list)
+    for event in events:
+        identity = event.join_key or event.legacy_identity
+        if identity:
+            grouped[(identity, event.release)].append(event.timestamp_epoch)
+
+    bursts: list[RetryBurst] = []
+    for (identity, release), stamps in grouped.items():
+        stamps.sort()
+        best, left = 0, 0
+        for right in range(len(stamps)):
+            while stamps[right] - stamps[left] > RETRY_BURST_WINDOW_SECONDS:
+                left += 1
+            best = max(best, right - left + 1)
+        if best >= RETRY_BURST_MIN_EVENTS:
+            bursts.append(
+                RetryBurst(identity, release, best, RETRY_BURST_WINDOW_SECONDS)
+            )
+    return sorted(bursts, key=lambda b: (-b.events_in_window, b.identity))
+
+
+# --------------------------------------------------------------------------
+# PostHog enrichment
+# --------------------------------------------------------------------------
+@dataclass
+class InstallUsage:
+    install_id: str
+    settings: dict[str, object]
+    successes_by_release: dict[str, int]
+    pipeline_failures_by_release: dict[str, int]
+    has_usage_rows: bool
+
+
+def fetch_install_usage(
+    client: PostHogClient, install_ids: Sequence[str]
+) -> dict[str, InstallUsage]:
+    """Sequential, indexed partitions with expected-vs-completed accounting, plus
+    an independent identical-filter total for bucket completeness. A LIMIT is a
+    ceiling, not proof (analytics-operations.md RULE: verify-completeness-not-just-limit).
+    """
+    usage: dict[str, InstallUsage] = {
+        install_id: InstallUsage(
+            install_id=install_id, settings={}, successes_by_release={},
+            pipeline_failures_by_release={}, has_usage_rows=False,
+        )
+        for install_id in install_ids
+    }
+    if not install_ids:
+        return usage
+
+    parts = partition(install_ids)
+    expected_indexes = {index for index, _ in parts}
+    completed_indexes: set[int] = set()
+    prod = client.environment_clause()
+
+    for index, chunk in parts:
+        ids = sql_id_list(chunk)
+
+        snapshot_rows, _ = client.query(
+            f"""
+            SELECT distinct_id,
+                   toUnixTimestamp(max(timestamp)) AS snapshot_ts,
+                   {", ".join(
+                       f"argMax(properties.{name}, timestamp) AS {name}"
+                       for name in RECONSTRUCTED_SETTINGS
+                   )}
+            FROM events
+            WHERE event = 'settings.snapshot' AND {prod}
+              AND distinct_id IN ({ids})
+            GROUP BY distinct_id
+            """,
+            f"snapshot_p{index}",
+        )
+
+        settings_rows, _ = client.query(
+            f"""
+            SELECT distinct_id,
+                   properties.setting AS setting,
+                   argMax(properties.to, timestamp) AS value,
+                   toUnixTimestamp(max(timestamp)) AS changed_ts
+            FROM events
+            WHERE event = 'settings.changed' AND {prod}
+              AND distinct_id IN ({ids})
+              AND properties.setting IN ({sql_id_list(RECONSTRUCTED_SETTINGS)})
+            GROUP BY distinct_id, setting
+            """,
+            f"settings_p{index}",
+        )
+
+        # `dictation.completed` carries `result` but its ONLY production caller
+        # passes "success" (TelemetryService.swift:165 -> :692), so a
+        # `result != 'success'` count is structurally always zero and is
+        # deliberately NOT reported — that is why the plan's own live measurement
+        # read "0 failed completions". `pipeline.failed` is the real failure
+        # counterpart and measured 18 on the same install.
+        usage_rows, _ = client.query(
+            f"""
+            SELECT distinct_id,
+                   properties.app_version AS release,
+                   countIf(event = 'dictation.completed') AS successes,
+                   countIf(event = 'pipeline.failed') AS pipeline_failures
+            FROM events
+            WHERE event IN ('dictation.completed', 'pipeline.failed')
+              AND {prod}
+              AND distinct_id IN ({ids})
+            GROUP BY distinct_id, release
+            """,
+            f"usage_p{index}",
+        )
+
+        # A change is only an overlay if it happened AFTER the snapshot it
+        # overlays. Applying an older change on top of a newer snapshot would
+        # reconstruct a configuration the user had already moved on from.
+        snapshot_times: dict[str, float] = {}
+        for row in snapshot_rows:
+            expected_columns = len(RECONSTRUCTED_SETTINGS) + 2
+            if len(row) != expected_columns:
+                raise ProtocolError(
+                    f"snapshot_p{index}: expected {expected_columns} columns, got {len(row)}"
+                )
+            install, snapshot_ts = row[0], row[1]
+            if not isinstance(install, str) or install not in usage:
+                raise ProtocolError(f"snapshot_p{index}: unexpected distinct_id in results")
+            snapshot_times[install] = required_timestamp(snapshot_ts, f"snapshot_p{index}")
+            for name, value in zip(RECONSTRUCTED_SETTINGS, row[2:]):
+                usage[install].settings[name] = normalize_setting(name, value)
+
+        for row in settings_rows:
+            if len(row) != 4:
+                raise ProtocolError(f"settings_p{index}: expected 4 columns, got {len(row)}")
+            install, setting, value, changed_ts = row
+            if not isinstance(install, str) or install not in usage:
+                raise ProtocolError(f"settings_p{index}: unexpected distinct_id in results")
+            if not isinstance(setting, str) or setting not in RECONSTRUCTED_SETTINGS:
+                raise ProtocolError(f"settings_p{index}: unexpected setting {setting!r}")
+            change_time = required_timestamp(changed_ts, f"settings_p{index}")
+            if change_time > snapshot_times.get(install, float("-inf")):
+                usage[install].settings[setting] = normalize_setting(setting, value)
+
+        for row in usage_rows:
+            if len(row) != 4:
+                raise ProtocolError(f"usage_p{index}: expected 4 columns, got {len(row)}")
+            install, release, successes, pipeline_failures = row
+            if not isinstance(install, str) or install not in usage:
+                raise ProtocolError(f"usage_p{index}: unexpected distinct_id in results")
+            success_count = required_count(successes, f"usage_p{index}: successes")
+            pipeline_failure_count = required_count(
+                pipeline_failures, f"usage_p{index}: pipeline_failures"
+            )
+            release_name = canonical_app_version(release, f"usage_p{index}")
+            entry = usage[install]
+            # Only USAGE rows prove usage. A settings row alone must never make
+            # an install look active.
+            entry.has_usage_rows = True
+            entry.successes_by_release[release_name] = success_count
+            entry.pipeline_failures_by_release[release_name] = pipeline_failure_count
+
+        completed_indexes.add(index)
+
+    require_complete_partitions(expected_indexes, completed_indexes)
+
+    verify_bucket_completeness(client, install_ids, usage)
+    return usage
+
+
+def verify_bucket_completeness(
+    client: PostHogClient, install_ids: Sequence[str], usage: Mapping[str, InstallUsage]
+) -> None:
+    """Independent identical-filter total. If the per-install buckets disagree
+    with a separately-computed distinct total, the buckets are wrong and the
+    report must not print.
+    """
+    prod = client.environment_clause()
+    rows, _ = client.query(
+        f"""
+        SELECT uniqExact(distinct_id)
+        FROM events
+        WHERE event IN ('dictation.completed', 'pipeline.failed')
+          AND {prod}
+          AND distinct_id IN ({sql_id_list(install_ids)})
+        """,
+        "completeness_total",
+    )
+    if len(rows) != 1 or len(rows[0]) != 1:
+        raise ProtocolError("completeness_total: expected one row with one count")
+    independent_total = required_count(rows[0][0], "completeness_total")
+    bucketed = sum(1 for entry in usage.values() if entry.has_usage_rows)
+    if bucketed != independent_total:
+        raise IncompleteError(
+            f"bucket completeness failed: {bucketed} installs carry success buckets but an "
+            f"independent identical-filter uniqExact returned {independent_total}. A LIMIT is "
+            "a ceiling, not proof — refusing to render."
+        )
+
+
+def normalize_setting(name: str, value: object) -> object:
+    """`filler_removal` shipped as a legacy Bool before becoming on/off, so the
+    same setting arrives in two vocabularies
+    (analytics-operations.md FACT: settings-config-reconstruction).
+    """
+    if value is None or value == "":
+        return None
+    if name == "filler_removal":
+        text = str(value).strip().lower()
+        if text in ("true", "1", "on", "yes"):
+            return "on"
+        if text in ("false", "0", "off", "no"):
+            return "off"
+    return value
+
+
+# --------------------------------------------------------------------------
+# Rendering. Every value is computed and validated BEFORE any output, so a late
+# failure cannot leave a half-table that reads as complete
+# (PROC: measurement-tool-hardening).
+# --------------------------------------------------------------------------
+def render_report(
+    report: FingerprintReport, usage: Mapping[str, InstallUsage]
+) -> str:
+    lines: list[str] = []
+    lines.append(f"Sentry fingerprint {report.issue} — joined to PostHog usage (#1846)")
+    lines.append(f"Environment: {report.environment}")
+    if report.excluded_counts:
+        lines.append("Excluded from this report (counted, never silently dropped):")
+        for reason in sorted(report.excluded_counts):
+            lines.append(f"  {report.excluded_counts[reason]} events: {reason}")
+    lines.append("")
+    lines.append("PEOPLE, not events. Identity populations are never combined.")
+    lines.append("")
+    lines.append(
+        f"{'release':<12}{'events':>8}{'identities':>12}"
+        f"{'events/id':>11}  identity source"
+    )
+    lines.append("-" * 88)
+    for row in report.release_rows:
+        lines.append(
+            f"{row.release:<12}{row.events:>8}{row.identities:>12}"
+            f"{row.events_per_identity:>11.1f}  {row.identity_source}"
+        )
+    lines.append("-" * 88)
+    for total in report.population_totals:
+        lines.append(
+            f"{'TOTAL':<12}{total.events:>8}{total.identities:>12}"
+            f"{total.events_per_identity:>11.1f}  {total.identity_source}"
+        )
+
+    lines.append("")
+    # FOUNDER DECISION 2026-07-29: per-release only, deliberately NO overall
+    # figure. An overall percentage would need to know which releases shipped the
+    # join key, and every way of supplying that (a flag to remember, a constant to
+    # update, or inference from the data) can silently mismeasure — inference
+    # worst of all, because it would HIDE a shipped release joining at 0%.
+    # A zero-coverage release is marked but NOT explained: the tool cannot tell a
+    # release that predates the key from one that shipped it and is broken, and
+    # guessing which would be the same fabrication.
+    lines.append("Join coverage by release (no overall figure — see the code comment):")
+    for release in sorted(report.join_coverage_by_release, key=version_key):
+        joined, total_events = report.join_coverage_by_release[release]
+        marker = "   <- no joined events" if joined == 0 else ""
+        lines.append(
+            f"  {release}: {joined}/{total_events} events carry {JOIN_TAG}{marker}"
+        )
+
+    all_event_count = sum(total.events for total in report.population_totals)
+    if report.unjoined_events:
+        lines.append("")
+        lines.append(
+            f"{report.unjoined_events} of {all_event_count} events carry no "
+            f"{JOIN_TAG}. They remain a separately labelled legacy population."
+        )
+    lines.append("")
+
+    if report.bursts:
+        lines.append("Retry bursts (one person retrying, not a trend):")
+        for burst in report.bursts:
+            lines.append(
+                f"  {burst.identity}  release {burst.release}: "
+                f"{burst.events_in_window} events inside {burst.window_seconds}s"
+            )
+        lines.append("")
+
+    lines.append("Per-install configuration and that install's OWN success record.")
+    lines.append("This is the denominator Sentry cannot show.")
+    lines.append("")
+    for install_id in report.joined_install_ids:
+        entry = usage.get(install_id)
+        lines.append(f"install {install_id}")
+        if entry is None:
+            lines.append(f"  {NO_USAGE_ROWS}")
+            lines.append("")
+            continue
+        config = ", ".join(
+            f"{name}="
+            f"{entry.settings.get(name) if entry.settings.get(name) is not None else 'unset'}"
+            for name in RECONSTRUCTED_SETTINGS
+        )
+        lines.append(f"  config: {config}")
+
+        affected = report.joined_releases_by_install.get(install_id, set())
+        if not entry.has_usage_rows:
+            lines.append(f"  {NO_USAGE_ROWS}")
+            lines.append("")
+            continue
+
+        for release in sorted(affected, key=version_key):
+            successes = entry.successes_by_release.get(release, 0)
+            pipeline_failed = entry.pipeline_failures_by_release.get(release, 0)
+            lines.append(
+                f"  {release}: {successes} successful dictations, "
+                f"{pipeline_failed} pipeline.failed"
+            )
+
+        for name in ("effective_transport", "recording_seconds"):
+            for release in sorted(affected, key=version_key):
+                if not field_shipped_on(name, release):
+                    lines.append(f"  {name} on {release}: {NOT_SHIPPED}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def build_report(
+    issue: str, sentry: SentryClient, posthog: PostHogClient, environment: str = "production"
+) -> tuple[FingerprintReport, dict[str, InstallUsage]]:
+    numeric = sentry.resolve_issue_id(issue)
+    events = sentry.fetch_events(numeric)
+    if not events:
+        raise IncompleteError(
+            f"issue {issue} returned zero events — nothing to join. This is not a "
+            "measurement of zero users."
+        )
+    selection = select_eligible_events(events, environment)
+    if not selection.eligible:
+        raise IncompleteError(
+            f"issue {issue} has {len(events)} events but none eligible for "
+            f"environment={environment} — this is not a measurement of zero users. "
+            f"Exclusions: {selection.excluded_counts}"
+        )
+    report = aggregate_fingerprint(
+        issue, selection.eligible, environment, selection.excluded_counts
+    )
+    if environment == "production":
+        posthog.resolve_dev_ids()
+    usage = fetch_install_usage(posthog, report.joined_install_ids)
+    return report, usage
+
+
+# ==========================================================================
+# SELF-TEST ONLY BELOW THIS LINE
+#
+# RECORDED_ENVIOUSWISPR_2F_EVENT_RECORDS is the recorded, pseudonymized shape of
+# the real three-page ENVIOUSWISPR-2F result (measured 2026-07-29, 90d). It is
+# STATIC and is deliberately independent of EXPECTED_ENVIOUSWISPR_2F below:
+# nothing derives one from the other. Deriving the fixture from the expected
+# counts would make the baseline case a simulation testing itself
+# (RULE: measure-with-the-real-tool-never-a-simulation).
+#
+# Every field is either synthetic (event ids e0001.., install ids a01..a60) or
+# a real release string. No real event id, user id, city, message, stack trace
+# or unrelated tag is present.
+#
+# The per-release identity SETS overlap on purpose — 68 release-memberships
+# across 60 distinct installs — because that overlap is the property a naive
+# implementation gets wrong: summing per-release identity counts yields 68 and
+# the true distinct total is 60.
+# ==========================================================================
+RECORDED_ENVIOUSWISPR_2F_EVENT_RECORDS = """\
+2.2.1 a01 2026-06-04T06:00:11Z e0001
+2.2.1 a01 2026-06-04T13:17:11Z e0002
+2.3.0 a01 2026-06-08T06:00:11Z e0003
+2.3.0 a02 2026-06-08T13:17:11Z e0004
+2.3.0 a03 2026-06-08T20:34:11Z e0005
+2.3.0 a04 2026-06-08T12:51:11Z e0006
+2.3.0 a05 2026-06-08T19:08:11Z e0007
+2.3.0 a06 2026-06-08T11:25:11Z e0008
+2.3.0 a07 2026-06-08T18:42:11Z e0009
+2.3.0 a08 2026-06-08T10:59:11Z e0010
+2.3.0 a09 2026-06-08T17:16:11Z e0011
+2.3.0 a01 2026-06-08T09:33:11Z e0012
+2.3.0 a02 2026-06-08T16:50:11Z e0013
+2.3.0 a03 2026-06-08T08:07:11Z e0014
+2.3.0 a04 2026-06-08T15:24:11Z e0015
+2.3.0 a05 2026-06-08T07:41:11Z e0016
+2.3.0 a06 2026-06-08T14:58:11Z e0017
+2.3.0 a07 2026-06-08T06:15:11Z e0018
+2.3.0 a08 2026-06-08T13:32:11Z e0019
+2.3.0 a09 2026-06-08T20:49:11Z e0020
+2.3.0 a01 2026-06-08T12:06:11Z e0021
+2.3.0 a02 2026-06-08T19:23:11Z e0022
+2.3.0 a03 2026-06-08T11:40:11Z e0023
+2.3.0 a04 2026-06-08T18:57:11Z e0024
+2.3.0 a05 2026-06-08T10:14:11Z e0025
+2.3.0 a06 2026-06-08T17:31:11Z e0026
+2.3.0 a07 2026-06-09T09:48:11Z e0027
+2.3.0 a08 2026-06-09T16:05:11Z e0028
+2.3.0 a09 2026-06-09T08:22:11Z e0029
+2.3.0 a01 2026-06-09T15:39:11Z e0030
+2.3.0 a02 2026-06-09T07:56:11Z e0031
+2.3.0 a03 2026-06-09T14:13:11Z e0032
+2.3.0 a04 2026-06-09T06:30:11Z e0033
+2.3.0 a05 2026-06-09T13:47:11Z e0034
+2.3.0 a06 2026-06-09T20:04:11Z e0035
+2.3.0 a07 2026-06-09T12:21:11Z e0036
+2.3.0 a08 2026-06-09T19:38:11Z e0037
+2.3.0 a09 2026-06-09T11:55:11Z e0038
+2.3.0 a01 2026-06-09T18:12:11Z e0039
+2.3.0 a02 2026-06-09T10:29:11Z e0040
+2.3.0 a03 2026-06-09T17:46:11Z e0041
+2.3.0 a04 2026-06-09T09:03:11Z e0042
+2.3.0 a05 2026-06-09T16:20:11Z e0043
+2.3.0 a06 2026-06-09T08:37:11Z e0044
+2.3.0 a07 2026-06-09T15:54:11Z e0045
+2.3.0 a08 2026-06-09T07:11:11Z e0046
+2.3.0 a09 2026-06-09T14:28:11Z e0047
+2.3.1 a05 2026-06-13T06:00:11Z e0048
+2.3.1 a06 2026-06-13T13:17:11Z e0049
+2.3.1 a07 2026-06-13T20:34:11Z e0050
+2.3.1 a08 2026-06-13T12:51:11Z e0051
+2.3.1 a09 2026-06-13T19:08:11Z e0052
+2.3.1 a10 2026-06-13T11:25:11Z e0053
+2.3.1 a11 2026-06-13T18:42:11Z e0054
+2.3.1 a12 2026-06-13T10:59:11Z e0055
+2.3.1 a13 2026-06-13T17:16:11Z e0056
+2.3.1 a14 2026-06-13T09:33:11Z e0057
+2.3.1 a15 2026-06-13T16:50:11Z e0058
+2.3.1 a16 2026-06-13T08:07:11Z e0059
+2.3.1 a17 2026-06-13T15:24:11Z e0060
+2.3.1 a18 2026-06-13T07:41:11Z e0061
+2.3.1 a19 2026-06-13T14:58:11Z e0062
+2.3.1 a20 2026-06-13T06:15:11Z e0063
+2.3.1 a21 2026-06-13T13:32:11Z e0064
+2.3.1 a22 2026-06-13T20:49:11Z e0065
+2.3.1 a23 2026-06-13T12:06:11Z e0066
+2.3.1 a24 2026-06-13T19:23:11Z e0067
+2.3.1 a25 2026-06-13T11:40:11Z e0068
+2.3.1 a26 2026-06-13T18:57:11Z e0069
+2.3.1 a27 2026-06-13T10:14:11Z e0070
+2.3.1 a28 2026-06-13T17:31:11Z e0071
+2.3.1 a29 2026-06-14T09:48:11Z e0072
+2.3.1 a30 2026-06-14T16:05:11Z e0073
+2.3.1 a31 2026-06-14T08:22:11Z e0074
+2.3.1 a32 2026-06-14T15:39:11Z e0075
+2.3.1 a33 2026-06-14T07:56:11Z e0076
+2.3.1 a34 2026-06-14T14:13:11Z e0077
+2.3.1 a35 2026-06-14T06:30:11Z e0078
+2.3.1 a36 2026-06-14T13:47:11Z e0079
+2.3.1 a37 2026-06-14T20:04:11Z e0080
+2.3.1 a05 2026-06-14T12:21:11Z e0081
+2.3.1 a06 2026-06-14T19:38:11Z e0082
+2.3.1 a07 2026-06-14T11:55:11Z e0083
+2.3.1 a08 2026-06-14T18:12:11Z e0084
+2.3.1 a09 2026-06-14T10:29:11Z e0085
+2.3.1 a10 2026-06-14T17:46:11Z e0086
+2.3.1 a11 2026-06-14T09:03:11Z e0087
+2.3.1 a12 2026-06-14T16:20:11Z e0088
+2.3.1 a13 2026-06-14T08:37:11Z e0089
+2.3.1 a14 2026-06-14T15:54:11Z e0090
+2.3.1 a15 2026-06-14T07:11:11Z e0091
+2.3.1 a16 2026-06-14T14:28:11Z e0092
+2.3.1 a17 2026-06-14T06:45:11Z e0093
+2.3.1 a18 2026-06-14T13:02:11Z e0094
+2.3.1 a19 2026-06-14T20:19:11Z e0095
+2.3.1 a20 2026-06-15T12:36:11Z e0096
+2.3.1 a21 2026-06-15T19:53:11Z e0097
+2.3.1 a22 2026-06-15T11:10:11Z e0098
+2.3.1 a23 2026-06-15T18:27:11Z e0099
+2.3.1 a24 2026-06-15T10:44:11Z e0100
+2.3.1 a25 2026-06-15T17:01:11Z e0101
+2.3.1 a26 2026-06-15T09:18:11Z e0102
+2.3.1 a27 2026-06-15T16:35:11Z e0103
+2.3.1 a28 2026-06-15T08:52:11Z e0104
+2.3.1 a29 2026-06-15T15:09:11Z e0105
+2.3.1 a30 2026-06-15T07:26:11Z e0106
+2.3.1 a31 2026-06-15T14:43:11Z e0107
+2.3.1 a32 2026-06-15T06:00:11Z e0108
+2.3.1 a33 2026-06-15T13:17:11Z e0109
+2.3.1 a34 2026-06-15T20:34:11Z e0110
+2.3.1 a35 2026-06-15T12:51:11Z e0111
+2.3.1 a36 2026-06-15T19:08:11Z e0112
+2.3.1 a37 2026-06-15T11:25:11Z e0113
+2.3.1 a05 2026-06-15T18:42:11Z e0114
+2.3.1 a06 2026-06-15T10:59:11Z e0115
+2.3.1 a07 2026-06-15T17:16:11Z e0116
+2.3.1 a08 2026-06-15T09:33:11Z e0117
+2.3.1 a09 2026-06-15T16:50:11Z e0118
+2.3.1 a10 2026-06-15T08:07:11Z e0119
+2.3.1 a11 2026-06-16T15:24:11Z e0120
+2.3.1 a12 2026-06-16T07:41:11Z e0121
+2.3.1 a13 2026-06-16T14:58:11Z e0122
+2.3.1 a14 2026-06-16T06:15:11Z e0123
+2.3.1 a15 2026-06-16T13:32:11Z e0124
+2.3.1 a16 2026-06-16T20:49:11Z e0125
+2.3.1 a17 2026-06-16T12:06:11Z e0126
+2.3.1 a18 2026-06-16T19:23:11Z e0127
+2.3.1 a19 2026-06-16T11:40:11Z e0128
+2.3.1 a20 2026-06-16T18:57:11Z e0129
+2.3.1 a21 2026-06-16T10:14:11Z e0130
+2.3.1 a22 2026-06-16T17:31:11Z e0131
+2.3.1 a23 2026-06-16T09:48:11Z e0132
+2.3.1 a24 2026-06-16T16:05:11Z e0133
+2.3.1 a25 2026-06-16T08:22:11Z e0134
+2.3.1 a26 2026-06-16T15:39:11Z e0135
+2.3.1 a27 2026-06-16T07:56:11Z e0136
+2.3.1 a28 2026-06-16T14:13:11Z e0137
+2.3.1 a29 2026-06-16T06:30:11Z e0138
+2.3.1 a30 2026-06-16T13:47:11Z e0139
+2.3.1 a31 2026-06-16T20:04:11Z e0140
+2.3.1 a32 2026-06-16T12:21:11Z e0141
+2.3.1 a33 2026-06-16T19:38:11Z e0142
+2.3.1 a34 2026-06-16T11:55:11Z e0143
+2.3.1 a35 2026-06-17T18:12:11Z e0144
+2.3.1 a36 2026-06-17T10:29:11Z e0145
+2.3.1 a37 2026-06-17T17:46:11Z e0146
+2.3.1 a05 2026-06-17T09:03:11Z e0147
+2.3.1 a06 2026-06-17T16:20:11Z e0148
+2.3.1 a07 2026-06-17T08:37:11Z e0149
+2.3.1 a08 2026-06-17T15:54:11Z e0150
+2.3.1 a09 2026-06-17T07:11:11Z e0151
+2.3.1 a10 2026-06-17T14:28:11Z e0152
+2.3.1 a11 2026-06-17T06:45:11Z e0153
+2.3.1 a12 2026-06-17T13:02:11Z e0154
+2.3.1 a13 2026-06-17T20:19:11Z e0155
+2.3.1 a14 2026-06-17T12:36:11Z e0156
+2.3.1 a15 2026-06-17T19:53:11Z e0157
+2.3.1 a16 2026-06-17T11:10:11Z e0158
+2.3.1 a17 2026-06-17T18:27:11Z e0159
+2.3.1 a18 2026-06-17T10:44:11Z e0160
+2.3.1 a19 2026-06-17T17:01:11Z e0161
+2.3.1 a20 2026-06-17T09:18:11Z e0162
+2.3.1 a21 2026-06-17T16:35:11Z e0163
+2.3.1 a22 2026-06-17T08:52:11Z e0164
+2.3.1 a23 2026-06-17T15:09:11Z e0165
+2.3.1 a24 2026-06-17T07:26:11Z e0166
+2.3.1 a25 2026-06-17T14:43:11Z e0167
+2.3.1 a26 2026-06-18T06:00:11Z e0168
+2.3.1 a27 2026-06-18T13:17:11Z e0169
+2.3.1 a28 2026-06-18T20:34:11Z e0170
+2.3.1 a29 2026-06-18T12:51:11Z e0171
+2.3.1 a30 2026-06-18T19:08:11Z e0172
+2.3.2 a38 2026-06-19T06:00:11Z e0173
+2.3.2 a39 2026-06-19T13:17:11Z e0174
+2.3.2 a40 2026-06-19T20:34:11Z e0175
+2.3.2 a41 2026-06-19T12:51:11Z e0176
+2.3.2 a42 2026-06-19T19:08:11Z e0177
+2.3.2 a43 2026-06-19T11:25:11Z e0178
+2.3.2 a44 2026-06-19T18:42:11Z e0179
+2.3.2 a45 2026-06-19T10:59:11Z e0180
+2.3.2 a46 2026-06-19T17:16:11Z e0181
+2.3.2 a47 2026-06-19T09:33:11Z e0182
+2.3.2 a48 2026-06-19T16:50:11Z e0183
+2.3.2 a49 2026-06-19T08:07:11Z e0184
+2.3.2 a50 2026-06-19T15:24:11Z e0185
+2.3.2 a51 2026-06-19T07:41:11Z e0186
+2.3.2 a52 2026-06-19T14:58:11Z e0187
+2.3.2 a53 2026-06-19T06:15:11Z e0188
+2.3.2 a54 2026-06-19T13:32:11Z e0189
+2.3.2 a55 2026-06-19T20:49:11Z e0190
+2.3.2 a56 2026-06-19T12:06:11Z e0191
+2.3.2 a57 2026-06-19T19:23:11Z e0192
+2.3.2 a58 2026-06-19T11:40:11Z e0193
+2.3.2 a59 2026-06-19T18:57:11Z e0194
+2.3.2 a38 2026-06-19T10:14:11Z e0195
+2.3.2 a39 2026-06-19T17:31:11Z e0196
+2.3.2 a40 2026-06-20T09:48:11Z e0197
+2.3.2 a41 2026-06-20T16:05:11Z e0198
+2.3.2 a42 2026-06-20T08:22:11Z e0199
+2.3.2 a43 2026-06-20T15:39:11Z e0200
+2.3.2 a44 2026-06-20T07:56:11Z e0201
+2.3.2 a45 2026-06-20T14:13:11Z e0202
+2.3.2 a46 2026-06-20T06:30:11Z e0203
+2.3.2 a47 2026-06-20T13:47:11Z e0204
+2.3.2 a48 2026-06-20T20:04:11Z e0205
+2.3.2 a49 2026-06-20T12:21:11Z e0206
+2.3.2 a50 2026-06-20T19:38:11Z e0207
+2.3.2 a51 2026-06-20T11:55:11Z e0208
+2.3.2 a52 2026-06-20T18:12:11Z e0209
+2.3.2 a53 2026-06-20T10:29:11Z e0210
+2.3.2 a54 2026-06-20T17:46:11Z e0211
+2.3.2 a55 2026-06-20T09:03:11Z e0212
+2.3.2 a56 2026-06-20T16:20:11Z e0213
+2.3.2 a57 2026-06-20T08:37:11Z e0214
+2.3.2 a58 2026-06-20T15:54:11Z e0215
+2.3.2 a59 2026-06-20T07:11:11Z e0216
+2.3.2 a38 2026-06-20T14:28:11Z e0217
+2.3.2 a39 2026-06-20T06:45:11Z e0218
+2.3.2 a40 2026-06-20T13:02:11Z e0219
+2.3.2 a41 2026-06-20T20:19:11Z e0220
+2.3.2 a42 2026-06-21T12:36:11Z e0221
+2.3.2 a43 2026-06-21T19:53:11Z e0222
+2.3.2 a44 2026-06-21T11:10:11Z e0223
+2.3.2 a45 2026-06-21T18:27:11Z e0224
+2.3.2 a46 2026-06-21T10:44:11Z e0225
+2.3.2 a47 2026-06-21T17:01:11Z e0226
+2.3.2 a48 2026-06-21T09:18:11Z e0227
+2.3.2 a49 2026-06-21T16:35:11Z e0228
+2.3.2 a50 2026-06-21T08:52:11Z e0229
+2.3.2 a51 2026-06-21T15:09:11Z e0230
+2.3.2 a52 2026-06-21T07:26:11Z e0231
+2.3.2 a53 2026-06-21T14:43:11Z e0232
+2.3.2 a54 2026-06-21T06:00:11Z e0233
+2.3.2 a55 2026-06-21T13:17:11Z e0234
+2.3.2 a56 2026-06-21T20:34:11Z e0235
+2.3.2 a57 2026-06-21T12:51:11Z e0236
+2.3.2 a58 2026-06-21T19:08:11Z e0237
+2.3.2 a59 2026-06-21T11:25:11Z e0238
+2.3.2 a38 2026-06-21T18:42:11Z e0239
+2.3.2 a39 2026-06-21T10:59:11Z e0240
+2.3.2 a40 2026-06-21T17:16:11Z e0241
+2.3.2 a41 2026-06-21T09:33:11Z e0242
+2.3.2 a42 2026-06-21T16:50:11Z e0243
+2.3.2 a43 2026-06-21T08:07:11Z e0244
+2.3.2 a44 2026-06-22T15:24:11Z e0245
+2.3.2 a45 2026-06-22T07:41:11Z e0246
+2.4.0 a60 2026-06-24T06:00:11Z e0247
+2.4.0 a60 2026-06-24T13:17:11Z e0248
+2.4.1 a59 2026-06-26T06:00:11Z e0249
+2.4.1 a60 2026-06-26T13:17:11Z e0250
+2.4.1 a59 2026-06-26T20:34:11Z e0251
+2.4.1 a60 2026-06-26T12:51:11Z e0252
+2.4.1 a59 2026-06-26T19:08:11Z e0253
+2.4.1 a60 2026-06-26T11:25:11Z e0254
+2.4.1 a59 2026-06-26T18:42:11Z e0255
+"""
+
+EXPECTED_ENVIOUSWISPR_2F = {
+    "2.2.1": (2, 1, 2.0),
+    "2.3.0": (45, 9, 5.0),
+    "2.3.1": (125, 33, 3.8),
+    "2.3.2": (74, 22, 3.4),
+    "2.4.0": (2, 1, 2.0),
+    "2.4.1": (7, 2, 3.5),
+}
+EXPECTED_ENVIOUSWISPR_2F_TOTAL = (255, 60, 4.2)
+
+SENTINEL_SENTRY_KEY = "sentry-key-for-self-test-only"
+SENTINEL_POSTHOG_KEY = "posthog-key-for-self-test-only"
+FIXTURE_INSTALL_PREFIX = "0198a1b2-c3d4-7e5f-8a9b-"
+
+
+def _fixture_install_uuid(short: str) -> str:
+    """`a07` -> a canonical lowercase hyphenated UUID, so the fixture exercises
+    the real `canonical_join_key` predicate rather than bypassing it.
+    """
+    return FIXTURE_INSTALL_PREFIX + f"{int(short[1:]):012d}"
+
+
+def _recorded_events() -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for line in RECORDED_ENVIOUSWISPR_2F_EVENT_RECORDS.strip().splitlines():
+        release, install, stamp, event_id = line.split()
+        events.append(
+            {
+                "id": event_id,
+                "dateCreated": stamp,
+                # No JOIN_TAG: this fingerprint was measured BEFORE the join key
+                # shipped, so the baseline is necessarily the legacy Sentry
+                # identity population (plan §3a). Tagging these events with a
+                # join key would assert an identity that could not have existed.
+                "user": {"id": f"legacy-sentry-{install}"},
+                "tags": [
+                    # Packaged, exactly as Sentry receives it. The earlier bare
+                    # value HID the release-key mismatch defect from all 255 rows.
+                    {"key": "release", "value": _SENTRY_RELEASE_PREFIX + release},
+                    # The recorded population was measured on production data.
+                    {"key": "environment", "value": "production"},
+                ],
+            }
+        )
+    return events
+
+
+def recorded_sentry_pages() -> list[tuple[int, bytes, dict[str, str]]]:
+    """Pack the recorded records into the THREE raw JSON response bodies the real
+    paginated call returned, with real-shaped Link headers.
+    """
+    events = _recorded_events()
+    sizes = [100, 100, 55]
+    pages: list[tuple[int, bytes, dict[str, str]]] = []
+    start = 0
+    for page_index, size in enumerate(sizes):
+        body = json.dumps(events[start:start + size]).encode("utf-8")
+        start += size
+        is_last = page_index == len(sizes) - 1
+        next_url = (
+            f"{SENTRY_HOST}/api/0/issues/6712345678/events/?full=true&cursor=c{page_index + 1}"
+        )
+        link = (
+            f'<{SENTRY_HOST}/api/0/issues/6712345678/events/?full=true>; rel="previous"; '
+            f'results="false"; cursor="p{page_index}", '
+            f'<{next_url}>; rel="next"; results="{"false" if is_last else "true"}"; '
+            f'cursor="c{page_index + 1}"'
+        )
+        pages.append((200, body, {"Link": link}))
+    return pages
+
+
+@dataclass
+class FixtureTransport:
+    """Receives the REAL HTTPRequest the production clients build, asserts its
+    shape, and returns queued raw HTTPResponse values. It parses nothing and
+    duplicates no production logic.
+    """
+    queue: list[HTTPResponse]
+    seen: list[HTTPRequest] = field(default_factory=list)
+
+    def __call__(self, request: HTTPRequest) -> HTTPResponse:
+        auth = request.headers.get("Authorization", "")
+        assert auth.startswith("Bearer "), "every vendor request must carry a Bearer header"
+        for sentinel in (SENTINEL_SENTRY_KEY, SENTINEL_POSTHOG_KEY):
+            if sentinel in auth:
+                break
+        else:
+            raise AssertionError("self-test transport saw a non-sentinel credential")
+        self.seen.append(request)
+        if not self.queue:
+            raise AssertionError(f"fixture queue exhausted at {request.method} {request.url}")
+        return self.queue.pop(0)
+
+
+def _json_response(payload: object, status: int = 200) -> HTTPResponse:
+    return HTTPResponse(status, {"Content-Type": "application/json"}, json.dumps(payload).encode())
+
+
+def _posthog_response(rows: list[list[object]], columns: list[str] | None = None) -> HTTPResponse:
+    return _json_response({"results": rows, "columns": columns or []})
+
+
+def _sentry_client(responses: list[HTTPResponse]) -> tuple[SentryClient, FixtureTransport]:
+    transport = FixtureTransport(list(responses))
+    return SentryClient(SENTINEL_SENTRY_KEY, transport), transport
+
+
+def _posthog_client(responses: list[HTTPResponse]) -> tuple[PostHogClient, FixtureTransport]:
+    transport = FixtureTransport(list(responses))
+    slept: list[float] = []
+    client = PostHogClient(SENTINEL_POSTHOG_KEY, transport, slept.append)
+    client.slept = slept  # type: ignore[attr-defined]
+    return client, transport
+
+
+def _recorded_page_responses() -> list[HTTPResponse]:
+    return [
+        HTTPResponse(status, {**headers, "Content-Type": "application/json"}, body)
+        for status, body, headers in recorded_sentry_pages()
+    ]
+
+
+def _expect_raises(
+    exc_type: type[BaseException],
+    fn: Callable[[], object],
+    what: str,
+    message: str | None = None,
+) -> None:
+    """`message` is the fix for how this round's finding hid: six pagination cases
+    asserted only `ProtocolError`, and a LATER hardening change made the fixture
+    fail at the release guard first. Both paths raise the same type, so the tests
+    kept passing while testing nothing. Where several guards share a type, assert
+    the message so the test names the guard it is actually exercising.
+    """
+    try:
+        fn()
+    except exc_type as exc:
+        if message is not None and message not in str(exc):
+            raise AssertionError(
+                f"{what}: raised {exc_type.__name__} but from the WRONG guard — "
+                f"expected message containing {message!r}, got {str(exc)!r}"
+            )
+        return
+    except Exception as other:  # noqa: BLE001
+        raise AssertionError(f"{what}: expected {exc_type.__name__}, got {other!r}")
+    raise AssertionError(f"{what}: expected {exc_type.__name__}, nothing raised")
+
+
+def run_self_test() -> int:
+    """Run every named case. A failing case raises AssertionError, which `main`
+    converts into a non-zero exit.
+
+    STATED LIMIT: this aborts at the FIRST failing case, so a run can hide later
+    failures. Cases 1-3 deliberately share one fixture transport (case 3 asserts
+    the request that case 1 made), which is why they are not isolated. The
+    summary line below is only reachable when every case passed — it is not a
+    counter that could ever print a non-zero failure count.
+    """
+    cases: list[str] = []
+
+    def passed(name: str) -> None:
+        cases.append(name)
+        print(f"PASS  {name}")
+
+    # 1 + 2: the recorded three-page baseline, and the per-release + total table.
+    client, transport = _sentry_client(_recorded_page_responses())
+    events = client.fetch_events("6712345678")
+    assert len(events) == 255, f"expected 255 recorded events, got {len(events)}"
+    selection_all = select_eligible_events(events, "production")
+    assert len(selection_all.eligible) == 255, selection_all.excluded_counts
+    assert selection_all.excluded_counts == {}, selection_all.excluded_counts
+    assert len(transport.seen) == 3, f"expected 3 pages fetched, got {len(transport.seen)}"
+    passed("recorded ENVIOUSWISPR-2F fixture paginates all three pages")
+
+    report = aggregate_fingerprint("ENVIOUSWISPR-2F", events)
+    actual = {r.release: (r.events, r.identities, r.events_per_identity) for r in report.release_rows}
+    assert actual == EXPECTED_ENVIOUSWISPR_2F, f"per-release mismatch: {actual}"
+    # This fingerprint predates the join key, so the baseline MUST be the legacy
+    # Sentry identity population and there must be no joined population at all.
+    assert report.joined_install_ids == [], report.joined_install_ids
+    assert len(report.population_totals) == 1, report.population_totals
+    baseline = report.population_totals[0]
+    assert baseline.identity_source == LEGACY_IDENTITY_LABEL, baseline.identity_source
+    assert (baseline.events, baseline.identities, baseline.events_per_identity) == (
+        EXPECTED_ENVIOUSWISPR_2F_TOTAL
+    ), (baseline.events, baseline.identities, baseline.events_per_identity)
+    assert all(r.identity_source == LEGACY_IDENTITY_LABEL for r in report.release_rows)
+    naive_sum = sum(v[1] for v in EXPECTED_ENVIOUSWISPR_2F.values())
+    assert naive_sum == 68 and baseline.identities == 60, (
+        "the fixture must keep cross-release identity overlap: summing per-release "
+        f"identities gives {naive_sum}, the true distinct total is 60"
+    )
+    passed("baseline reproduces 255 events / 60 users / 4.2 on legacy Sentry identity")
+
+    # 3: the Sentry request shape.
+    first = transport.seen[0]
+    assert first.method == "GET", first.method
+    assert "/api/0/issues/6712345678/events/" in first.url, first.url
+    assert "full=true" in first.url, first.url
+    assert first.headers["Authorization"] == f"Bearer {SENTINEL_SENTRY_KEY}"
+    passed("Sentry request is GET .../events/?full=true with a Bearer credential")
+
+    # 4: the PostHog request envelope.
+    ph, ph_transport = _posthog_client([_posthog_response([["a"]])])
+    ph.query("SELECT 1", "shape")
+    req = ph_transport.seen[0]
+    assert req.method == "POST", req.method
+    assert req.url == f"{POSTHOG_HOST}/api/projects/{POSTHOG_PROJECT_ID}/query/", req.url
+    assert req.headers["Content-Type"] == "application/json"
+    envelope = json.loads(req.body or b"{}")
+    assert envelope["query"]["kind"] == "HogQLQuery", envelope
+    assert envelope["refresh"] == "blocking", envelope
+    assert envelope["name"] == "telemetry_join_shape", envelope
+    passed("PostHog request is a blocking HogQLQuery to the project query endpoint")
+
+    # 5 + 6: authentication failures on both vendors.
+    client, _ = _sentry_client([HTTPResponse(401, {}, b"")])
+    _expect_raises(AuthError, lambda: client.fetch_events("1"), "Sentry 401")
+    passed("Sentry authentication failure raises AuthError and prints nothing")
+
+    ph, _ = _posthog_client([HTTPResponse(403, {}, b"")])
+    _expect_raises(AuthError, lambda: ph.query("SELECT 1", "auth"), "PostHog 403")
+    passed("PostHog authorization failure raises AuthError and prints nothing")
+
+    # 7: a 504 then success retries, with injected sleeps and no wall-clock wait.
+    ph, _ = _posthog_client([HTTPResponse(504, {}, b""), _posthog_response([["ok"]])])
+    rows, _cols = ph.query("SELECT 1", "retry")
+    assert rows == [["ok"]], rows
+    assert ph.slept == [RETRY_DELAYS_SECONDS[0]], ph.slept  # type: ignore[attr-defined]
+    assert ph.attempts_made == [2], ph.attempts_made
+    passed("a retryable 504 followed by success succeeds on attempt 2 without sleeping")
+
+    # 8: exhausted retry fails the whole report.
+    ph, _ = _posthog_client([HTTPResponse(504, {}, b"") for _ in range(MAX_ATTEMPTS)])
+    _expect_raises(RetryExhaustedError, lambda: ph.query("SELECT 1", "dead"), "exhausted retry")
+    passed("exhausted retry raises RetryExhaustedError, never a degraded table")
+
+    # 9: malformed JSON.
+    client, _ = _sentry_client([HTTPResponse(200, {}, b"{not json")])
+    _expect_raises(
+        ProtocolError, lambda: client.fetch_events("1"), "malformed JSON",
+        message="not valid JSON",
+    )
+    passed("malformed Sentry JSON fails closed")
+
+    # 10: malformed Link header.
+    # A VALID event: parsing must succeed so the pagination cases below actually
+    # reach the pagination code rather than dying at the release guard.
+    body = json.dumps(
+        [
+            {
+                "id": "e1",
+                "dateCreated": "2026-06-01T00:00:00Z",
+                "user": {"id": "legacy-install"},
+                "tags": [
+                    {"key": "release", "value": "com.enviouswispr.app@2.4.1"},
+                    {"key": "environment", "value": "production"},
+                ],
+            }
+        ]
+    ).encode()
+    client, _ = _sentry_client([HTTPResponse(200, {"Link": "garbage-without-brackets"}, body)])
+    _expect_raises(
+        ProtocolError, lambda: client.fetch_events("1"), "malformed Link",
+        message="Link segment is unparseable",
+    )
+    passed("a malformed Link header fails closed instead of reading as no-next-page")
+
+    # 11: results="true" with no usable next URL.
+    link = '<not-a-url>; rel="next"; results="true"; cursor="c1"'
+    client, _ = _sentry_client([HTTPResponse(200, {"Link": link}, body)])
+    _expect_raises(
+        ProtocolError, lambda: client.fetch_events("1"), 'results="true" no URL',
+        message="outside the exact Sentry issue endpoint",
+    )
+    passed('11. results="true" without a usable next URL fails closed')
+
+    # 12: a pagination cycle.
+    same = f"{SENTRY_HOST}/api/0/issues/1/events/?full=true"
+    cycle = f'<{same}>; rel="next"; results="true"; cursor="c1"'
+    client, _ = _sentry_client([HTTPResponse(200, {"Link": cycle}, body) for _ in range(3)])
+    _expect_raises(
+        ProtocolError, lambda: client.fetch_events("1"), "pagination cycle",
+        message="pagination cycle",
+    )
+    passed("a repeated pagination URL is detected as a cycle and fails closed")
+
+    # 12b: a missing Link header is missing pagination AUTHORITY, not an ending.
+    client, _ = _sentry_client([HTTPResponse(200, {}, body)])
+    _expect_raises(
+        ProtocolError, lambda: client.fetch_events("1"), "missing Link header",
+        message="missing Link header",
+    )
+    passed("a missing Link header fails closed instead of meaning complete")
+
+    # 12c: a valid prefix must not hide malformed trailing material.
+    malformed_tail = '<https://example.invalid/end>; rel="next"; results="false", trailing-garbage'
+    client, _ = _sentry_client([HTTPResponse(200, {"Link": malformed_tail}, body)])
+    _expect_raises(
+        ProtocolError, lambda: client.fetch_events("1"), "malformed trailing Link segment",
+        message="Link segment is unparseable",
+    )
+    passed("the COMPLETE Link header must parse, not merely a valid prefix")
+
+    # Ambiguous Link parameters must fail rather than silently using the last value.
+    exact_endpoint = f"{SENTRY_HOST}/api/0/issues/1/events/?full=true"
+    for malformed_link in (
+        f'<{exact_endpoint}>; rel="next"; results="true"; results="false"',
+        f'<{exact_endpoint}>; rel="next; results="false"',
+    ):
+        client, _ = _sentry_client([HTTPResponse(200, {"Link": malformed_link}, body)])
+        _expect_raises(
+            ProtocolError,
+            lambda client=client: client.fetch_events("1"),
+            f"ambiguous Link header {malformed_link!r}",
+        )
+    passed("duplicate or unbalanced Link parameters fail closed")
+
+    # Different page URLs can still overlap. EVENT identity, not URL identity,
+    # proves the population contains no duplicate.
+    second_page = f"{exact_endpoint}&cursor=c1"
+    terminal_page = f"{exact_endpoint}&cursor=c2"
+    first_link = f'<{second_page}>; rel="next"; results="true"; cursor="c1"'
+    last_link = f'<{terminal_page}>; rel="next"; results="false"; cursor="c2"'
+    client, _ = _sentry_client(
+        [
+            HTTPResponse(200, {"Link": first_link}, body),
+            HTTPResponse(200, {"Link": last_link}, body),
+        ]
+    )
+    _expect_raises(
+        ProtocolError,
+        lambda: client.fetch_events("1"),
+        "duplicate event id across different pagination URLs",
+        message="duplicate event id",
+    )
+    passed("overlapping Sentry pages cannot double-count an event")
+
+    # 13: the exact production partition-accounting guard, armed directly.
+    _expect_raises(
+        IncompleteError,
+        lambda: require_complete_partitions({0, 1, 2}, {0, 2}),
+        "missing partition index",
+    )
+    _expect_raises(
+        IncompleteError,
+        lambda: require_complete_partitions({0, 1}, {0, 1, 2}),
+        "unexpected partition index",
+    )
+    require_complete_partitions({0, 1}, {0, 1})  # two-way control: complete passes
+    passed("incomplete or unexpected partition indexes fail closed")
+
+    # 14: malformed PostHog column count.
+    ph, _ = _posthog_client([_posthog_response([["only-one-column"]])] * 3)
+    ph.dev_ids = ()
+    _expect_raises(
+        ProtocolError,
+        lambda: fetch_install_usage(ph, [_fixture_install_uuid("a01")]),
+        "malformed columns",
+    )
+    passed("a PostHog row with the wrong column count fails closed")
+
+    # 15: bucket total mismatch against the independent identical-filter query.
+    install = _fixture_install_uuid("a01")
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([]),                                   # snapshot
+            _posthog_response([]),                                   # settings.changed
+            _posthog_response([[install, "2.3.1", 5, 0]]),           # usage: 1 bucket
+            _posthog_response([[9]]),                                # independent total: 9
+        ]
+    )
+    ph.dev_ids = ()
+    _expect_raises(
+        IncompleteError, lambda: fetch_install_usage(ph, [install]), "bucket mismatch"
+    )
+    passed("buckets disagreeing with an independent uniqExact total fails closed")
+
+    # 16: a successful zero-row response is a real result, not an error or a zero.
+    ph, _ = _posthog_client(
+        [_posthog_response([]), _posthog_response([]), _posthog_response([]), _posthog_response([[0]])]
+    )
+    ph.dev_ids = ()
+    usage = fetch_install_usage(ph, [install])
+    assert usage[install].has_usage_rows is False
+    rendered = render_report(
+        aggregate_fingerprint(
+            "X",
+            [SentryEvent("e1", "2.3.1", install, None, 1.0)],
+        ),
+        usage,
+    )
+    assert NO_USAGE_ROWS in rendered, rendered
+    assert "0 successful dictations" not in rendered, "a zero row must not become a zero rate"
+    passed(f"16. a successful zero-row response prints {NO_USAGE_ROWS!r} and no rate")
+
+    # 17: version-floor null discipline.
+    assert render_field("effective_transport", "2.3.1", None) == NOT_SHIPPED
+    assert render_field("effective_transport", "2.3.2", "usb") == "usb"
+    assert render_field("recording_seconds", "2.1.9", None) == NOT_SHIPPED
+    assert render_field("llm_provider", "2.0.0", None) == "null (no value recorded)"
+    _expect_raises(
+        MissingAuthorityError,
+        lambda: field_shipped_on("a_field_with_no_recorded_floor", "2.3.2"),
+        "unknown floor",
+    )
+    passed("a field below its version floor prints not-shipped; an unknown floor raises")
+
+    # 18: retry-burst detection must not inflate the person count.
+    burst_events = [
+        SentryEvent(f"b{i}", "2.3.1", install, None, 1000.0 + i * 30) for i in range(5)
+    ] + [SentryEvent("b9", "2.3.1", _fixture_install_uuid("a02"), None, 99999.0)]
+    burst_report = aggregate_fingerprint("X", burst_events)
+    assert len(burst_report.bursts) == 1, burst_report.bursts
+    assert burst_report.bursts[0].events_in_window == 5, burst_report.bursts
+    joined_total = next(
+        total for total in burst_report.population_totals
+        if total.identity_source == JOINED_IDENTITY_LABEL
+    )
+    assert joined_total.events == 6 and joined_total.identities == 2, joined_total
+    passed("a five-event burst is flagged and still counts as one person")
+
+    # 19: the production filter excludes development and dev-tainted installs.
+    ph, ph_transport = _posthog_client([_posthog_response([["dev-install-1"], ["dev-install-2"]])])
+    resolved = ph.resolve_dev_ids()
+    assert resolved == ("dev-install-1", "dev-install-2"), resolved
+    clause = ph.environment_clause()
+    assert "properties.environment = 'production'" in clause, clause
+    assert "distinct_id NOT IN ('dev-install-1', 'dev-install-2')" in clause, clause
+    empty = PostHogClient(SENTINEL_POSTHOG_KEY, FixtureTransport([]), lambda _s: None)
+    empty.dev_ids = ()
+    assert "NOT IN ()" not in empty.environment_clause(), empty.environment_clause()
+    assert len(ph_transport.seen) == 1, "dev ids must be resolved ONCE, not per query"
+    passed("production filtering excludes dev, resolves dev ids once, never emits NOT IN ()")
+
+    # The dev-id query selects exactly one column. An extra column is malformed
+    # evidence, not something to read past.
+    ph, _ = _posthog_client([_posthog_response([["dev-install", "unexpected-extra-column"]])])
+    _expect_raises(ProtocolError, ph.resolve_dev_ids, "dev-id row with an extra column")
+    ph, _ = _posthog_client([_posthog_response([["dev-install"]])])
+    assert ph.resolve_dev_ids() == ("dev-install",)
+    passed("dev-id rows require exactly one string column")
+
+    # 20: joined and legacy populations keep SEPARATE numerators and denominators.
+    # The previous version of this case asserted a mixed total and therefore froze
+    # the defect as expected behaviour.
+    mixed = [
+        SentryEvent("j1", "2.4.1", install, None, 1.0),
+        SentryEvent("l1", "2.1.0", None, "legacy-sentry-user-1", 2.0),
+        SentryEvent("l2", "2.1.0", None, "legacy-sentry-user-2", 3.0),
+    ]
+    mixed_report = aggregate_fingerprint("X", mixed)
+    totals = {total.identity_source: total for total in mixed_report.population_totals}
+    assert len(mixed_report.population_totals) == 2, mixed_report.population_totals
+    assert totals[JOINED_IDENTITY_LABEL].events == 1
+    assert totals[JOINED_IDENTITY_LABEL].identities == 1
+    assert totals[LEGACY_IDENTITY_LABEL].events == 2
+    assert totals[LEGACY_IDENTITY_LABEL].identities == 2
+    assert mixed_report.unjoined_events == 2
+    assert mixed_report.join_coverage_by_release == {"2.1.0": (0, 2), "2.4.1": (1, 1)}
+    passed("joined and legacy populations retain separate numerators and denominators")
+
+    # 22: a mixed release must not divide ALL its events by only its joined
+    # identities. This is the arithmetic the old shape got wrong.
+    mixed_release = [
+        SentryEvent("j1", "2.4.1", install, None, 1.0),
+        SentryEvent("j2", "2.4.1", install, None, 2.0),
+        SentryEvent("l1", "2.4.1", None, "legacy-sentry-user-1", 3.0),
+        SentryEvent("l2", "2.4.1", None, "legacy-sentry-user-2", 4.0),
+        SentryEvent("l3", "2.4.1", None, "legacy-sentry-user-2", 5.0),
+    ]
+    rows = aggregate_fingerprint("X", mixed_release).release_rows
+    by_source = {row.identity_source: row for row in rows}
+    assert by_source[JOINED_IDENTITY_LABEL].events == 2
+    assert by_source[JOINED_IDENTITY_LABEL].identities == 1
+    assert by_source[JOINED_IDENTITY_LABEL].events_per_identity == 2.0
+    assert by_source[LEGACY_IDENTITY_LABEL].events == 3
+    assert by_source[LEGACY_IDENTITY_LABEL].identities == 2
+    assert by_source[LEGACY_IDENTITY_LABEL].events_per_identity == 1.5
+    # The wrong shape would have produced 5 events over 1 joined identity = 5.0.
+    assert all(row.events_per_identity != 5.0 for row in rows), rows
+    passed("a mixed release never divides all its events by one population's identities")
+
+    # 23: a settings row alone must not make an install look active.
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([[install, 1000] + [None] * len(RECONSTRUCTED_SETTINGS)]),
+            _posthog_response([]),
+            _posthog_response([]),
+            _posthog_response([[0]]),
+        ]
+    )
+    ph.dev_ids = ()
+    settings_only = fetch_install_usage(ph, [install])
+    assert settings_only[install].has_usage_rows is False
+    rendered_settings_only = render_report(
+        aggregate_fingerprint("X", [SentryEvent("e1", "2.3.1", install, None, 1.0)]),
+        settings_only,
+    )
+    assert NO_USAGE_ROWS in rendered_settings_only
+    passed("a settings row without usage rows still reports no usage")
+
+    # 24: all usage counts render, including the real failure counterpart.
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([]),
+            _posthog_response([]),
+            _posthog_response([[install, "2.3.1", 466, 18]]),
+            _posthog_response([[1]]),
+        ]
+    )
+    ph.dev_ids = ()
+    full_usage = fetch_install_usage(ph, [install])
+    rendered_full = render_report(
+        aggregate_fingerprint("X", [SentryEvent("e1", "2.3.1", install, None, 1.0)]),
+        full_usage,
+    )
+    assert "466 successful dictations" in rendered_full, rendered_full
+    assert "18 pipeline.failed" in rendered_full, rendered_full
+    passed("successes and pipeline.failed both render for an affected release")
+
+    # Required Sentry measurement fields must fail closed, not degrade.
+    valid_event = {
+        "id": "required-fields",
+        "dateCreated": "2026-06-01T00:00:00Z",
+        "user": {"id": "legacy-install"},
+        "tags": [{"key": "release", "value": "2.4.1"}],
+    }
+    missing_release = {**valid_event, "tags": []}
+    malformed_timestamp = {**valid_event, "dateCreated": "not-a-timestamp"}
+    tag_only_identity = {
+        **valid_event,
+        "user": None,
+        "tags": [
+            {"key": "release", "value": "2.4.1"},
+            {"key": "user", "value": "display-tag-is-not-user-id"},
+        ],
+    }
+    for label, raw_event in (
+        ("missing release", missing_release),
+        ("malformed timestamp", malformed_timestamp),
+        ("tag-only identity", tag_only_identity),
+    ):
+        _expect_raises(
+            ProtocolError,
+            lambda raw_event=raw_event: SentryClient._parse_event(raw_event, 1),
+            label,
+        )
+    SentryClient._parse_event(valid_event, 1)  # two-way control: a valid event parses
+    passed("required Sentry measurement fields fail closed")
+
+    # A pagination URL must never carry our credential off-host.
+    external_next = (
+        '<https://attacker.invalid/collect?full=true>; rel="next"; results="true"; cursor="c1"'
+    )
+    client, transport = _sentry_client([HTTPResponse(200, {"Link": external_next}, body)])
+    _expect_raises(
+        ProtocolError, lambda: client.fetch_events("1"), "external pagination URL",
+        message="outside the exact Sentry issue endpoint",
+    )
+    assert len(transport.seen) == 1, (
+        "the Sentry credential must never be sent to the pagination target"
+    )
+    passed("pagination cannot forward the Sentry credential outside its issue endpoint")
+
+    # Eligibility exclusions are counted and reported, never silently dropped.
+    mixed_eligibility = [
+        SentryEvent("ok", "2.4.1", None, "u1", 1.0, environment="production"),
+        SentryEvent("dev", "2.4.1", None, "u2", 2.0, environment="development"),
+        SentryEvent("synth", "2.4.1", None, "u3", 3.0, environment="production", synthetic=True),
+        SentryEvent(
+            "helper", "2.4.1", None, "u4", 4.0, environment="production",
+            process_role=ASR_HELPER_ROLE,
+        ),
+        SentryEvent("notag", "2.4.1", None, "u5", 5.0),
+    ]
+    selection = select_eligible_events(mixed_eligibility, "production")
+    assert [e.event_id for e in selection.eligible] == ["ok"], selection.eligible
+    assert selection.excluded_counts == {
+        "environment=development": 1,
+        "synthetic=true (fault injection)": 1,
+        f"process.role={ASR_HELPER_ROLE} (documented gap)": 1,
+        "environment tag absent": 1,
+    }, selection.excluded_counts
+    dev_selection = select_eligible_events(mixed_eligibility, "development")
+    assert [e.event_id for e in dev_selection.eligible] == ["dev"], dev_selection.eligible
+    passed("development, synthetic, helper and untagged events are excluded and counted")
+
+    # The dev-taint exclusion must NOT apply to a development query, or the plan's
+    # own primary gate would return zero rows and read as "no usage".
+    dev_client = PostHogClient(
+        SENTINEL_POSTHOG_KEY, FixtureTransport([]), lambda _s: None, environment="development"
+    )
+    dev_clause = dev_client.environment_clause()
+    assert "properties.environment = 'development'" in dev_clause, dev_clause
+    assert "NOT IN" not in dev_clause, dev_clause
+    prod_client = PostHogClient(SENTINEL_POSTHOG_KEY, FixtureTransport([]), lambda _s: None)
+    prod_client.dev_ids = ("dev-1",)
+    assert "NOT IN ('dev-1')" in prod_client.environment_clause()
+    passed("a development query keeps dev installs; only production excludes them")
+
+    # An all-ineligible fingerprint is a refusal, never a measurement of zero.
+    only_dev = [SentryEvent("d", "2.4.1", None, "u", 1.0, environment="development")]
+    empty_selection = select_eligible_events(only_dev, "production")
+    assert empty_selection.eligible == []
+    passed("an all-ineligible fingerprint yields no eligible events for the caller to refuse on")
+
+    # Per-release coverage marks a zero WITHOUT guessing why, and prints no
+    # overall figure (founder decision 2026-07-29).
+    coverage_events = [
+        SentryEvent("old", "2.3.1", None, "legacy-1", 1.0, environment="production"),
+        SentryEvent("new", "2.5.0", install, None, 2.0, environment="production"),
+    ]
+    coverage_render = render_report(
+        aggregate_fingerprint("X", coverage_events, "production"), {}
+    )
+    assert "2.3.1: 0/1 events carry" in coverage_render, coverage_render
+    assert "<- no joined events" in coverage_render, coverage_render
+    assert "2.5.0: 1/1 events carry" in coverage_render, coverage_render
+    assert "%" not in coverage_render, "no overall percentage may be printed"
+    assert "predates" not in coverage_render, (
+        "the tool must not claim to know WHY a release has zero coverage"
+    )
+    passed("join coverage is per-release, marks zeroes, and prints no overall figure")
+
+    # The app gives Sentry a packaged release and PostHog the raw app version.
+    # Without normalization the exact lookup never matches and EVERY install
+    # reports zero successes — the tool's whole denominator, silently empty.
+    packaged_event = SentryClient._parse_event(
+        {
+            "id": "packaged-release",
+            "dateCreated": "2026-07-29T00:00:00Z",
+            "tags": [
+                {"key": "release", "value": "com.enviouswispr.app@2.4.1"},
+                {"key": "environment", "value": "production"},
+                {"key": JOIN_TAG, "value": install},
+            ],
+        },
+        1,
+    )
+    assert packaged_event.release == "2.4.1", packaged_event.release
+    # Dev builds previously sorted as version zero because the leading `v` stopped
+    # the old parser on its first chunk.
+    assert version_key("v1.6.1-14-gabc123-dev") == (1, 6, 1)
+    assert version_key("com.enviouswispr.app@2.4.1") == (2, 4, 1)
+    _expect_raises(
+        ProtocolError, lambda: canonical_app_version("unknown", "x"), "unknown version"
+    )
+    _expect_raises(
+        ProtocolError,
+        lambda: canonical_app_version("other.app@2.4.1", "x"),
+        "foreign package name",
+    )
+
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([]),
+            _posthog_response([]),
+            _posthog_response([[install, "2.4.1", 466, 18]]),
+            _posthog_response([[1]]),
+        ]
+    )
+    ph.dev_ids = ()
+    packaged_usage = fetch_install_usage(ph, [install])
+    packaged_render = render_report(
+        aggregate_fingerprint("X", [packaged_event]), packaged_usage
+    )
+    assert "466 successful dictations" in packaged_render, packaged_render
+    assert "18 pipeline.failed" in packaged_render, packaged_render
+    passed("Sentry packaged releases join PostHog raw app versions, including dev versions")
+
+    # Counts are measurements: malformed values must not be rounded or truncated.
+    #
+    # Asserted on the pure authority FIRST. The integration form below failed with
+    # "fixture queue exhausted" when I reverted the guard to check it was armed —
+    # a real failure, but for an incidental reason that would also mask a genuine
+    # regression if the query order changed. Direct assertions cannot do that.
+    for bad_count in (True, False, -1, 1.5, float("nan"), float("inf"), "5", None):
+        _expect_raises(
+            ProtocolError,
+            lambda bad=bad_count: required_count(bad, "unit"),
+            f"required_count({bad_count!r})",
+        )
+    assert required_count(0, "unit") == 0, "zero is a legitimate count"
+    assert required_count(466, "unit") == 466
+    assert required_count(18.0, "unit") == 18, "a whole float is a valid count"
+
+    # Integration form, with a COMPLETE queue so that absent the guard the run
+    # would succeed — making the assertion specific to the guard, not to the fixture.
+    for bad_count in (True, -1, 1.5):
+        ph, _ = _posthog_client(
+            [
+                _posthog_response([]),
+                _posthog_response([]),
+                _posthog_response([[install, "2.4.1", bad_count, 0]]),
+                _posthog_response([[1]]),
+            ]
+        )
+        ph.dev_ids = ()
+        _expect_raises(
+            ProtocolError,
+            lambda ph=ph: fetch_install_usage(ph, [install]),
+            f"malformed usage count {bad_count!r}",
+        )
+
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([]),
+            _posthog_response([]),
+            _posthog_response([[install, "2.4.1", 1, 0]]),
+            _posthog_response([[1.5]]),
+        ]
+    )
+    ph.dev_ids = ()
+    _expect_raises(
+        ProtocolError, lambda: fetch_install_usage(ph, [install]), "fractional total"
+    )
+    passed("malformed PostHog counts fail closed instead of being truncated")
+
+    # Timestamps decide whether a settings change overlays its snapshot.
+    for bad_timestamp in (True, False, -1, float("nan"), float("inf"), "1000", None):
+        _expect_raises(
+            ProtocolError,
+            lambda bad=bad_timestamp: required_timestamp(bad, "unit"),
+            f"required_timestamp({bad_timestamp!r})",
+        )
+    assert required_timestamp(0, "unit") == 0.0
+    assert required_timestamp(1000, "unit") == 1000.0
+    assert required_timestamp(1000.5, "unit") == 1000.5
+
+    # Both production consumers, with COMPLETE queues so failure is specific to
+    # the guard rather than to queue exhaustion.
+    for bad_timestamp in (True, float("nan")):
+        ph, _ = _posthog_client(
+            [
+                _posthog_response(
+                    [[install, bad_timestamp] + [None] * len(RECONSTRUCTED_SETTINGS)]
+                ),
+                _posthog_response([]),
+                _posthog_response([]),
+                _posthog_response([[0]]),
+            ]
+        )
+        ph.dev_ids = ()
+        _expect_raises(
+            ProtocolError,
+            lambda ph=ph: fetch_install_usage(ph, [install]),
+            f"malformed snapshot timestamp {bad_timestamp!r}",
+        )
+
+        ph, _ = _posthog_client(
+            [
+                _posthog_response([]),
+                _posthog_response([[install, "llm_model", "eg-1", bad_timestamp]]),
+                _posthog_response([]),
+                _posthog_response([[0]]),
+            ]
+        )
+        ph.dev_ids = ()
+        _expect_raises(
+            ProtocolError,
+            lambda ph=ph: fetch_install_usage(ph, [install]),
+            f"malformed settings timestamp {bad_timestamp!r}",
+        )
+    passed("malformed PostHog timestamps fail closed before configuration reconstruction")
+
+    # A nested vendor field of the wrong TYPE must fail closed, not crash.
+    for bad_group in ("not-a-dict", [1, 2], 7):
+        client, _ = _sentry_client([_json_response({"group": bad_group})])
+        _expect_raises(
+            ProtocolError,
+            lambda c=client: c.resolve_issue_id("ENVIOUSWISPR-2F"),
+            f"short-id group={bad_group!r}",
+        )
+    client, _ = _sentry_client([_json_response({"group": {"id": "6712345678"}})])
+    assert client.resolve_issue_id("ENVIOUSWISPR-2F") == "6712345678"
+    client, _ = _sentry_client([_json_response({"groupId": "42"})])
+    assert client.resolve_issue_id("ENVIOUSWISPR-2F") == "42"
+    assert SentryClient("k", FixtureTransport([])).resolve_issue_id("6712345678") == "6712345678"
+    passed("short-id resolution fails closed on a wrong-typed nested field")
+
+    # 21: only urllib_transport may open a socket.
+    #
+    # Scoped to the PRODUCTION half deliberately. A whole-file scan matches this
+    # test's own pattern literal and reports five call sites — a scanner that
+    # sees itself. Splitting on the marker also makes the assertion mean what it
+    # says: exactly one network call in the code that actually runs in anger.
+    source = open(__file__, encoding="utf-8").read()
+    marker = "# SELF-TEST ONLY BELOW THIS LINE"
+    production, sep, self_test = source.partition(marker)
+    assert sep, "the self-test marker must exist for this scan to be scoped correctly"
+    assert len(self_test) > 0, "the self-test half must be non-empty"
+    network_calls = re.findall(
+        r"urlopen|HTTPSConnection|HTTPConnection|requests\.|httpx", production
+    )
+    assert len(network_calls) == 1, (
+        f"expected exactly one network call site in the production half, found {network_calls}"
+    )
+    # Positive control: the pattern must be capable of matching, or "found one"
+    # would be indistinguishable from a broken pattern that found nothing.
+    assert re.findall(r"urlopen", "urllib.request.urlopen(x)"), "the matcher itself is broken"
+    passed("exactly one function in the production half can open a network connection")
+
+    print("")
+    print(f"Self-test: {len(cases)} cases passed, 0 failed")
+    return 0
+
+
+# --------------------------------------------------------------------------
+def main(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Join a Sentry fingerprint to PostHog usage per anonymous install (#1846)."
+    )
+    parser.add_argument("--issue", help="Sentry short id (ENVIOUSWISPR-2F) or numeric issue id")
+    parser.add_argument(
+        "--environment", choices=ENVIRONMENTS, default="production",
+        help="which environment to report on. `development` is the plan §11.2 pre-merge gate.",
+    )
+    parser.add_argument("--self-test", action="store_true", help="run the built-in self-test")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        if args.issue:
+            print("error: --self-test takes no --issue", file=sys.stderr)
+            return 2
+        try:
+            return run_self_test()
+        except (AssertionError, InstrumentError) as exc:
+            # Report the failure as a result, not a traceback, and say plainly
+            # that the run stopped rather than implying the rest passed.
+            print(f"\nFAIL  {type(exc).__name__}: {exc}", file=sys.stderr)
+            print(
+                "Self-test: aborted at the first failing case. PASS lines above are valid; "
+                "later cases did NOT run.",
+                file=sys.stderr,
+            )
+            return 1
+
+    if not args.issue:
+        print("error: --issue is required (or use --self-test)", file=sys.stderr)
+        return 2
+
+    try:
+        sentry_key = os.environ.get("SENTRY_MASTER_KEY")
+        posthog_key = os.environ.get("POSTHOG_KEY")
+        missing = [
+            name for name, value in
+            (("SENTRY_MASTER_KEY", sentry_key), ("POSTHOG_KEY", posthog_key))
+            if not value
+        ]
+        if missing:
+            raise ConfigError(
+                f"missing credential(s) in the environment: {', '.join(missing)}. "
+                "Bridge them with `~/.claude/bin/get-key launch` — see the module docstring."
+            )
+        report, usage = build_report(
+            args.issue,
+            SentryClient(str(sentry_key)),
+            PostHogClient(str(posthog_key), environment=args.environment),
+            environment=args.environment,
+        )
+        # Rendered only after every page, partition and completeness check passed.
+        print(render_report(report, usage))
+        return 0
+    except InstrumentError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -2,16 +2,17 @@
 """Join one Sentry fingerprint to PostHog usage, per anonymous install (#1846).
 
 Sentry records only failures, so every field on a failing event looks universal
-there. This instrument answers the two questions that repeatedly went wrong
-without it (#1788, #1809):
+there. This instrument answers the four questions that repeatedly went wrong without it
+(#1788, #1809):
 
   1. How many PEOPLE, not events, does this fingerprint affect, per release?
   2. What was each affected install configured as, and what is that install's
      own success record on the same release?
+  3. Is the take key landing on every intended event and release?
+  4. What share of eligible takes and installs does this fingerprint affect?
 
-Phase 1 scope. It reports install-level event counts, distinct installs and
-per-install configuration only. Per-take coverage and the fingerprint take rate
-require the Phase 2 `take_id` and are deliberately absent.
+Phase 1 provides the install join and configuration reconstruction. Phase 2 adds
+per-event take coverage and the fingerprint take and affected-user rates.
 
 Usage:
   telemetry-join.py --issue ENVIOUSWISPR-2F
@@ -72,6 +73,47 @@ ASR_HELPER_ROLE = "asr_xpc"
 JOIN_TAG = "analytics.distinct_id"
 JOINED_IDENTITY_LABEL = "analytics.distinct_id (joined install identity)"
 LEGACY_IDENTITY_LABEL = "legacy Sentry identity"
+
+# Phase 2. The Sentry tag and the PostHog property both carry the SAME value:
+# `SessionID.raw.uuidString`, the kernel's per-take identity.
+TAKE_TAG = "dictation.take_id"
+TAKE_PROPERTY = "take_id"
+
+# The 13 events Phase 2 routes the take key to. MEASURED from the emitter, not
+# remembered: every name here has a `["take_id"] = takeID` assignment in
+# `TelemetryService.swift`. Match the FIELD, not a `props`/`properties` variable
+# name — a pattern pinned to `props[...]` structurally cannot match the
+# `asr.completed` emitter and silently reports 12. A name absent from this tuple
+# is not measured, and a name here that the app never emits reads `not observed`.
+TAKE_KEYED_EVENTS = (
+    "asr.completed",
+    "audio.capture_interrupted",
+    "audio.dead_mic_retire_attempted",
+    "dictation.completed",
+    "dictation.first_vad_chunk_completed",
+    "dictation.first_vad_chunk_started",
+    "dictation.invoked",
+    "dictation.vad_preparation_completed",
+    "llm.polish_completed",
+    "llm.polish_failed",
+    "llm.polish_skipped",
+    "paste.completed",
+    "recording.cap_warning_shown",
+)
+
+# The event whose take IDs are the SUCCESS side of the fingerprint take rate.
+SUCCESS_TAKE_EVENT = "dictation.completed"
+
+# Applied INSIDE the PostHog queries. `canonical_take_id` guards the Sentry side;
+# without this the PostHog side accepted any non-empty string, so a junk value
+# would enter `success_takes`, enlarge both denominators and produce a confidently
+# LOWER failure rate. (`match` measured against the live API 2026-07-30.)
+TAKE_ID_HOGQL_PATTERN = (
+    r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+    r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+)
+
+NOT_OBSERVED = "not observed"
 
 NO_USAGE_ROWS = "no usage rows for this install"
 NOT_SHIPPED = "not shipped on this release"
@@ -353,6 +395,10 @@ class SentryEvent:
     environment: str | None = None
     synthetic: bool = False
     process_role: str | None = None
+    #: Phase 2. `None` is NON-DIAGNOSTIC (plan §7): the release may predate the
+    #: tag, no kernel session may have existed, or the terminal postamble may
+    #: already have cleared the scope. Never read absence as "no dictation".
+    take_id: str | None = None
 
 
 @dataclass
@@ -515,6 +561,10 @@ class SentryClient:
             environment=by_key.get("environment"),
             synthetic=by_key.get("synthetic") == "true",
             process_role=by_key.get("process.role"),
+            # Phase 2. Unlike the join key, a missing or malformed take tag is NOT
+            # an error: this tag ships from #1846 onward, so every older event
+            # legitimately lacks it and the report must still be produced.
+            take_id=canonical_take_id(by_key.get(TAKE_TAG)),
         )
 
 
@@ -546,6 +596,36 @@ def canonical_join_key(raw: object) -> str | None:
     if not re.fullmatch(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", raw):
         return None
     return raw
+
+
+_TAKE_ID_PATTERN = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+
+def canonical_take_id(raw: object) -> str | None:
+    """A SEPARATE canonicalizer from `canonical_join_key`, and the case handling is
+    the whole reason.
+
+    The two identities are produced by different code and differ in CASE:
+      - `analytics.distinct_id` comes from the PostHog SDK and is LOWERCASE.
+      - `dictation.take_id` / `take_id` is Swift `UUID.uuidString`, which
+        Foundation renders UPPERCASE (measured: `D3B6682C-A4F7-47DB-...`).
+
+    Reusing the lowercase-only join-key matcher here would reject every real take
+    ID and report take coverage as 0% — a confident, silent wrong answer of
+    exactly the kind this instrument exists to prevent. Accept both cases.
+
+    Returns the UPPERCASED form so set membership across the two vendors cannot
+    fail on case alone. Both sides serialize the same `uuidString` today, so this
+    is belt-and-braces rather than a known divergence, but a case-sensitive union
+    would fail silently as a 0% rate rather than loudly.
+    """
+    if not isinstance(raw, str) or len(raw) != 36:
+        return None
+    if not _TAKE_ID_PATTERN.fullmatch(raw):
+        return None
+    return raw.upper()
 
 
 _APP_VERSION_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.+-]+)?$")
@@ -838,6 +918,80 @@ class FingerprintReport:
     joined_install_ids: list[str]
     joined_releases_by_install: dict[str, set[str]]
     unjoined_events: int
+    #: Phase 2. Distinct take IDs seen on THIS fingerprint, keyed by
+    #: (install, release). Empty for a pre-#1846 population, which is data, not
+    #: an error.
+    affected_takes_by_install_release: dict[tuple[str, str], set[str]] = field(
+        default_factory=dict
+    )
+    #: Phase 2. The span the take rate is computed over — see `TakeWindow`.
+    take_window: TakeWindow | None = None
+
+
+@dataclass(frozen=True)
+class TakeCoverageRow:
+    """One (event, release) cell of the per-event take coverage table. Deliberately
+    NOT pooled across events: a high-volume event at 100% would otherwise hide a
+    low-volume one at 0%, which is precisely the failure this metric watches for.
+    """
+    event: str
+    release: str
+    with_take: int
+    total: int
+
+
+@dataclass(frozen=True)
+class TakeRateRow:
+    """Per release. `affected` and `union` are counts of DISTINCT take IDs, never
+    of raw events — the #1809 mistake was reading six events from one retrying
+    person as six independent failures.
+    """
+    release: str
+    affected_takes: int
+    union_takes: int
+    affected_installs: int
+    eligible_installs: int
+
+
+@dataclass(frozen=True)
+class TakeWindow:
+    """The span the take rate is computed over, derived from the eligible Sentry
+    events rather than declared, so the successful side is never widened beyond
+    the failures that define the numerator.
+
+    MILLISECOND PostHog bounds, rounded INWARD. Sentry timestamps keep fractions,
+    while the PostHog comparison uses whole milliseconds. `ceil` the start and
+    `floor` the end so the successful-take query cannot include events outside
+    the measured Sentry failure span. (The first version compared whole seconds
+    via `int(epoch)`, so a .900 .. 1.100 window admitted nearly two full seconds.
+    `toUnixTimestamp64Milli` measured against the live API 2026-07-30.)
+
+    This means the two sides are deliberately NOT claimed to have identical
+    boundary precision: affected Sentry takes retain their original timestamps,
+    while the successful side uses the largest whole-millisecond interval
+    contained inside that span. Excluding possible boundary successes makes the
+    reported rate conservative — an upper bound — rather than enlarging its
+    denominator with out-of-window events.
+
+    `degenerate` marks an interval with no positive width at PostHog's
+    millisecond precision. Successful events could coincide with that timestamp,
+    but a rate determined by timestamp coincidence is not a meaningful population
+    measurement, so it is refused.
+    """
+    start_epoch: float
+    end_epoch: float
+
+    @property
+    def start_millis(self) -> int:
+        return math.ceil(self.start_epoch * 1000)
+
+    @property
+    def end_millis(self) -> int:
+        return math.floor(self.end_epoch * 1000)
+
+    @property
+    def degenerate(self) -> bool:
+        return self.end_millis <= self.start_millis
 
 
 @dataclass(frozen=True)
@@ -897,6 +1051,11 @@ def aggregate_fingerprint(
     joined_releases_by_install: dict[str, set[str]] = defaultdict(set)
     all_joined: set[str] = set()
     all_legacy: set[str] = set()
+    # Phase 2. Only JOINED events can contribute a take to the rate: an event with
+    # no install identity cannot be paired with that install's successes, so
+    # including its take would inflate the numerator against a denominator it is
+    # not part of.
+    affected_takes: dict[tuple[str, str], set[str]] = defaultdict(set)
 
     for event in events:
         release = event.release
@@ -905,6 +1064,8 @@ def aggregate_fingerprint(
             joined_identities[release].add(event.join_key)
             joined_releases_by_install[event.join_key].add(release)
             all_joined.add(event.join_key)
+            if event.take_id:
+                affected_takes[(event.join_key, release)].add(event.take_id)
             continue
 
         if not event.legacy_identity:
@@ -981,6 +1142,15 @@ def aggregate_fingerprint(
             install: set(rels) for install, rels in joined_releases_by_install.items()
         },
         unjoined_events=legacy_total_events,
+        affected_takes_by_install_release={
+            pair: set(takes) for pair, takes in affected_takes.items()
+        },
+        # Derived from the eligible events, never declared. `events` is non-empty
+        # by the caller's contract (`build_report` raises before reaching here).
+        take_window=TakeWindow(
+            start_epoch=min(event.timestamp_epoch for event in events),
+            end_epoch=max(event.timestamp_epoch for event in events),
+        ),
     )
 
 
@@ -1183,6 +1353,364 @@ def verify_bucket_completeness(
         )
 
 
+def fetch_take_coverage(client: PostHogClient) -> list[TakeCoverageRow]:
+    """Per-event take coverage — plan §5. POPULATION-WIDE and deliberately NOT
+    bounded to this fingerprint's installs or window: the question it answers is
+    "is the take key actually landing on this event," which wants the widest view
+    available, not one fingerprint's slice.
+
+    `take_id` is tested for NULL *and* empty string. The emitters use
+    omit-when-nil so a missing key is absent rather than blank, but a future
+    caller passing `""` would otherwise be counted as covered — the one way this
+    metric could report success while shipping nothing.
+    """
+    rows, _ = client.query(
+        f"""
+        SELECT properties.app_version AS release,
+               event AS event_name,
+               count() AS total,
+               countIf(properties.{TAKE_PROPERTY} IS NOT NULL
+                       AND properties.{TAKE_PROPERTY} != '') AS with_take
+        FROM events
+        WHERE event IN ({sql_id_list(TAKE_KEYED_EVENTS)})
+          AND {client.environment_clause()}
+        GROUP BY release, event_name
+        """,
+        "take_coverage",
+    )
+    coverage: list[TakeCoverageRow] = []
+    for row in rows:
+        if len(row) != 4:
+            raise ProtocolError(f"take_coverage: expected 4 columns, got {len(row)}")
+        release_raw, event_name, total, with_take = row
+        if not isinstance(event_name, str) or event_name not in TAKE_KEYED_EVENTS:
+            raise ProtocolError(f"take_coverage: unexpected event {event_name!r}")
+        total_count = required_count(total, "take_coverage: total")
+        with_take_count = required_count(with_take, "take_coverage: with_take")
+        if with_take_count > total_count:
+            raise ProtocolError(
+                f"take_coverage: {event_name} on {release_raw!r} reports "
+                f"{with_take_count} keyed rows out of {total_count} — a subset "
+                "cannot exceed its set, so the query or the parse is wrong"
+            )
+        coverage.append(
+            TakeCoverageRow(
+                event=event_name,
+                release=canonical_app_version(release_raw, "take_coverage"),
+                with_take=with_take_count,
+                total=total_count,
+            )
+        )
+    return coverage
+
+
+def fetch_take_rates(
+    client: PostHogClient,
+    report: FingerprintReport,
+) -> list[TakeRateRow]:
+    """Fingerprint take rate and affected-user rate — plan §5.
+
+    rate = distinct AFFECTED take IDs / |affected ∪ successful| takes, per release.
+
+    SQL computes the case-normalized successful-set cardinality and its overlap
+    with the affected IDs, without shipping every successful take ID back — this
+    install's `dictation.completed` takes could number in the thousands over the
+    window. Python then computes the union from those validated counts:
+
+        union = affected + successes - overlap
+
+    A take appearing on both sides is therefore counted ONCE, which is the plan's
+    explicit requirement.
+
+    The successful PostHog side is bounded to the inward-rounded millisecond
+    interval contained within the eligible Sentry event span. It is never widened
+    beyond the failures that define the numerator. Possible boundary successes
+    can therefore be excluded, which is why the rendered result is explicitly an
+    upper bound rather than a claim of identical boundary precision.
+
+    Returns [] when the window is degenerate or no affected takes exist. A rate is
+    REFUSED rather than fabricated; the renderer says which.
+    """
+    window = report.take_window
+    if window is None or window.degenerate or not report.affected_takes_by_install_release:
+        return []
+
+    # Only installs that actually carry an affected take need querying.
+    installs = sorted({install for install, _ in report.affected_takes_by_install_release})
+    parts = partition(installs)
+    expected_indexes = {index for index, _ in parts}
+    completed_indexes: set[int] = set()
+
+    successes: dict[tuple[str, str], int] = defaultdict(int)
+    overlaps: dict[tuple[str, str], int] = defaultdict(int)
+
+    for index, chunk in parts:
+        chunk_set = set(chunk)
+        # Scope the affected-id list to THIS partition's installs. A global list
+        # would grow the query text without changing any result.
+        # Overlap must match install AND release. A partition-wide take-id list
+        # lets a take affected on release A subtract from release B's union — the
+        # rest of this function pairs (install, release) everywhere, so a flat
+        # list was an inconsistency waiting to be exercised.
+        chunk_take_ids_by_release: dict[str, set[str]] = defaultdict(set)
+        for (affected_install, affected_release), takes in (
+            report.affected_takes_by_install_release.items()
+        ):
+            if affected_install in chunk_set:
+                chunk_take_ids_by_release[affected_release].update(takes)
+
+        if not chunk_take_ids_by_release:
+            completed_indexes.add(index)
+            continue
+
+        overlap_predicate = "\n OR ".join(
+            f"""(
+                properties.app_version = {sql_id_list([release_name])}
+                AND upper(properties.{TAKE_PROPERTY})
+                    IN ({sql_id_list(sorted(take_ids))})
+            )"""
+            for release_name, take_ids in sorted(chunk_take_ids_by_release.items())
+        )
+
+        # Built ONCE and reused by the bucket query and its completeness check, so
+        # "identical filter" is guaranteed by construction rather than by two
+        # hand-copied WHERE clauses that can drift apart.
+        take_rate_filter = f"""
+            event = '{SUCCESS_TAKE_EVENT}'
+            AND {client.environment_clause()}
+            AND distinct_id IN ({sql_id_list(chunk)})
+            AND properties.{TAKE_PROPERTY} IS NOT NULL
+            AND properties.{TAKE_PROPERTY} != ''
+            AND toUnixTimestamp64Milli(timestamp) >= {window.start_millis}
+            AND toUnixTimestamp64Milli(timestamp) <= {window.end_millis}
+        """
+
+        # `upper(...)` on BOTH distinct operations. Without it the total counts an
+        # upper- and a lowercase spelling of one take as two successes while the
+        # overlap normalizes them to one — inflating the union by the difference.
+        rows, _ = client.query(
+            f"""
+            SELECT distinct_id,
+                   properties.app_version AS release,
+                   uniqExact(upper(properties.{TAKE_PROPERTY})) AS success_takes,
+                   uniqExactIf(
+                       upper(properties.{TAKE_PROPERTY}),
+                       ({overlap_predicate})
+                   ) AS overlap_takes,
+                   countIf(
+                       match(
+                           toString(properties.{TAKE_PROPERTY}),
+                           '{TAKE_ID_HOGQL_PATTERN}'
+                       ) = 0
+                   ) AS invalid_take_rows
+            FROM events
+            WHERE {take_rate_filter}
+            GROUP BY distinct_id, release
+            """,
+            f"take_rate_p{index}",
+        )
+
+        # Independent identical-filter total, the same discipline
+        # `verify_bucket_completeness` applies to install usage. A truncated
+        # response would silently drop success buckets and INFLATE the rate.
+        completeness_rows, _ = client.query(
+            f"""
+            SELECT uniqExact(
+                concat(
+                    toString(distinct_id),
+                    '|',
+                    toString(properties.app_version)
+                )
+            )
+            FROM events
+            WHERE {take_rate_filter}
+            """,
+            f"take_rate_completeness_p{index}",
+        )
+        if len(completeness_rows) != 1 or len(completeness_rows[0]) != 1:
+            raise ProtocolError(
+                f"take_rate_completeness_p{index}: expected one row with one count"
+            )
+        independent_buckets = required_count(
+            completeness_rows[0][0], f"take_rate_completeness_p{index}"
+        )
+        if len(rows) != independent_buckets:
+            raise IncompleteError(
+                f"take_rate_p{index}: received {len(rows)} install-release buckets "
+                f"but an independent identical-filter uniqExact returned "
+                f"{independent_buckets} — refusing a potentially truncated rate"
+            )
+        for row in rows:
+            if len(row) != 5:
+                raise ProtocolError(f"take_rate_p{index}: expected 5 columns, got {len(row)}")
+            install, release_raw, success_takes, overlap_takes, invalid_take_rows = row
+            invalid_count = required_count(
+                invalid_take_rows, f"take_rate_p{index}: invalid_take_rows"
+            )
+            if invalid_count:
+                raise ProtocolError(
+                    f"take_rate_p{index}: {invalid_count} successful rows carry a "
+                    "non-canonical take_id — refusing to include fabricated take identities"
+                )
+            if not isinstance(install, str) or install not in chunk_set:
+                raise ProtocolError(f"take_rate_p{index}: unexpected distinct_id in results")
+            release = canonical_app_version(release_raw, f"take_rate_p{index}")
+            success_count = required_count(success_takes, f"take_rate_p{index}: success_takes")
+            overlap_count = required_count(overlap_takes, f"take_rate_p{index}: overlap_takes")
+            if overlap_count > success_count:
+                raise ProtocolError(
+                    f"take_rate_p{index}: overlap {overlap_count} exceeds successes "
+                    f"{success_count} — a subset cannot exceed its set"
+                )
+            successes[(install, release)] += success_count
+            overlaps[(install, release)] += overlap_count
+        completed_indexes.add(index)
+
+    require_complete_partitions(expected_indexes, completed_indexes)
+
+    # THE AFFECTED-USER DENOMINATOR IS POPULATION-WIDE, and it has to be queried
+    # separately. Every query above is scoped to installs that ALREADY carry an
+    # affected take, so deriving the denominator from them made it a superset of
+    # itself and the rate was a structural 100% on every affected release — a
+    # denominator drawn from its own numerator. The first version of the
+    # arithmetic case froze that as `1/1`.
+    # Built once and reused by the population query and its completeness check.
+    population_filter = f"""
+        event = '{SUCCESS_TAKE_EVENT}'
+        AND {client.environment_clause()}
+        AND properties.{TAKE_PROPERTY} IS NOT NULL
+        AND properties.{TAKE_PROPERTY} != ''
+        AND toUnixTimestamp64Milli(timestamp) >= {window.start_millis}
+        AND toUnixTimestamp64Milli(timestamp) <= {window.end_millis}
+    """
+    population_rows, _ = client.query(
+        f"""
+        SELECT properties.app_version AS release,
+               uniqExact(distinct_id) AS successful_installs,
+               countIf(
+                   match(
+                       toString(properties.{TAKE_PROPERTY}),
+                       '{TAKE_ID_HOGQL_PATTERN}'
+                   ) = 0
+               ) AS invalid_take_rows
+        FROM events
+        WHERE {population_filter}
+        GROUP BY release
+        """,
+        "take_rate_user_population",
+    )
+    successful_install_counts: dict[str, int] = defaultdict(int)
+    for row in population_rows:
+        if len(row) != 3:
+            raise ProtocolError(
+                f"take_rate_user_population: expected 3 columns, got {len(row)}"
+            )
+        release_raw, successful_installs, invalid_take_rows = row
+        release = canonical_app_version(release_raw, "take_rate_user_population")
+        # This query INDEPENDENTLY produces the affected-user denominator, so it
+        # needs its own validity check — inheriting the bucket query's would be
+        # trusting a different result set.
+        if required_count(
+            invalid_take_rows, f"take_rate_user_population: invalid_take_rows on {release}"
+        ):
+            raise ProtocolError(
+                f"take_rate_user_population: rows on {release} carry a non-canonical "
+                "take_id — refusing to include fabricated take identities"
+            )
+        successful_install_counts[release] += required_count(
+            successful_installs,
+            f"take_rate_user_population: successful_installs on {release}",
+        )
+
+    # Independent identical-filter total for THIS grouped result. Without it a
+    # truncated response loses a release row, `defaultdict(int)` substitutes zero,
+    # and the eligible denominator can come back smaller than its own numerator.
+    population_completeness_rows, _ = client.query(
+        f"""
+        SELECT uniqExact(toString(properties.app_version))
+        FROM events
+        WHERE {population_filter}
+        """,
+        "take_rate_user_population_completeness",
+    )
+    if len(population_completeness_rows) != 1 or len(population_completeness_rows[0]) != 1:
+        raise ProtocolError(
+            "take_rate_user_population_completeness: expected one row with one count"
+        )
+    independent_releases = required_count(
+        population_completeness_rows[0][0], "take_rate_user_population_completeness"
+    )
+    if len(population_rows) != independent_releases:
+        raise IncompleteError(
+            f"take_rate_user_population: received {len(population_rows)} release buckets "
+            f"but an independent identical-filter uniqExact returned {independent_releases}"
+        )
+
+    # Per release. Take IDs are UUIDs, so different installs' sets are disjoint and
+    # their union sizes add.
+    per_release_affected: dict[str, int] = defaultdict(int)
+    per_release_union: dict[str, int] = defaultdict(int)
+    affected_installs: dict[str, set[str]] = defaultdict(set)
+    successful_affected_installs: dict[str, set[str]] = defaultdict(set)
+
+    # Report only releases on which this fingerprint HAS an affected take. A
+    # successful take on some other release is not a zero-rate row for this
+    # fingerprint; it is a release this fingerprint was never seen on.
+    pairs = set(report.affected_takes_by_install_release)
+    for install, release in sorted(pairs):
+        affected = len(report.affected_takes_by_install_release.get((install, release), set()))
+        union = affected + successes[(install, release)] - overlaps[(install, release)]
+        if union < affected:
+            raise ProtocolError(
+                f"take rate for {install} on {release}: union {union} is smaller than the "
+                f"{affected} affected takes it must contain — refusing to render"
+            )
+        per_release_affected[release] += affected
+        per_release_union[release] += union
+        if affected:
+            affected_installs[release].add(install)
+        if successes[(install, release)]:
+            successful_affected_installs[release].add(install)
+
+    # A checked loop, not a comprehension: the install arithmetic draws from two
+    # SEPARATE query results, so it can produce an impossible pair that a
+    # comprehension would silently return.
+    result: list[TakeRateRow] = []
+    for release in sorted(per_release_union, key=version_key):
+        affected_count = len(affected_installs[release])
+        successful_count = successful_install_counts[release]
+        overlap_count = len(successful_affected_installs[release])
+
+        if overlap_count > successful_count:
+            raise ProtocolError(
+                f"affected-user rate on {release}: {overlap_count} affected installs "
+                f"also succeeded, but the population query returned only "
+                f"{successful_count} successful installs"
+            )
+
+        # |affected ∪ successful| installs. Subtracting the installs counted on
+        # BOTH sides keeps an install that both failed and succeeded from being
+        # counted twice — the install-level twin of the take-level overlap
+        # subtraction above.
+        eligible_count = affected_count + successful_count - overlap_count
+        if eligible_count < affected_count:
+            raise ProtocolError(
+                f"affected-user rate on {release}: eligible denominator "
+                f"{eligible_count} is smaller than affected numerator {affected_count}"
+            )
+
+        result.append(
+            TakeRateRow(
+                release=release,
+                affected_takes=per_release_affected[release],
+                union_takes=per_release_union[release],
+                affected_installs=affected_count,
+                eligible_installs=eligible_count,
+            )
+        )
+    return result
+
+
 def normalize_setting(name: str, value: object) -> object:
     """`filler_removal` shipped as a legacy Bool before becoming on/off, so the
     same setting arrives in two vocabularies
@@ -1204,8 +1732,122 @@ def normalize_setting(name: str, value: object) -> object:
 # failure cannot leave a half-table that reads as complete
 # (PROC: measurement-tool-hardening).
 # --------------------------------------------------------------------------
+def render_take_coverage(coverage: Sequence[TakeCoverageRow]) -> list[str]:
+    """Render the COMPLETE event x observed-release grid.
+
+    A missing cell is `not observed`, never silently omitted. The first version
+    printed `not observed` only when an event had no rows on ANY release, so an
+    event present on 2.6.0 and gone on 2.7.0 lost its 2.7.0 row entirely — a
+    blackout invisible in exactly the table built to catch blackouts.
+    """
+    lines = ["Take coverage by event and release (Phase 2). Never pooled across events:"]
+    by_cell: dict[tuple[str, str], TakeCoverageRow] = {}
+
+    for row in coverage:
+        key = (row.event, row.release)
+        if key in by_cell:
+            raise ProtocolError(
+                f"take coverage contains duplicate rows for {row.event} on {row.release}"
+            )
+        by_cell[key] = row
+
+    unexpected = sorted({event for event, _ in by_cell} - set(TAKE_KEYED_EVENTS))
+    if unexpected:
+        raise ProtocolError(
+            f"take coverage contains unlisted events: {', '.join(unexpected)}"
+        )
+
+    releases = sorted({release for _, release in by_cell}, key=version_key)
+    if not releases:
+        for event in TAKE_KEYED_EVENTS:
+            lines.append(f"  {event}: {NOT_OBSERVED}")
+        return lines
+
+    for event in TAKE_KEYED_EVENTS:
+        for release in releases:
+            row = by_cell.get((event, release))
+            if row is None:
+                lines.append(f"  {event} on {release}: {NOT_OBSERVED}")
+                continue
+            marker = "   <- no take keys" if row.with_take == 0 else ""
+            lines.append(
+                f"  {event} on {release}: "
+                f"{row.with_take}/{row.total} rows carry {TAKE_PROPERTY}{marker}"
+            )
+
+    return lines
+
+
+def render_take_rates(
+    rates: Sequence[TakeRateRow], window: TakeWindow | None, has_affected_takes: bool
+) -> list[str]:
+    """Prints counts alongside every percentage. A bare rate cannot be checked;
+    `12/400` can.
+    """
+    lines = ["Fingerprint take rate (Phase 2) — distinct TAKES, never raw events:"]
+    if window is None:
+        lines.append(f"  {NOT_OBSERVED} — no eligible events, so no window exists")
+        return lines
+    if not has_affected_takes:
+        # Deliberately does NOT say why. The tool cannot tell a population that
+        # predates the tag from one that shipped it and is broken, and guessing
+        # would be the same fabrication the join-coverage block refuses to make.
+        # It says only what it measured: no key was seen. That is not a zero rate.
+        lines.append(
+            f"  {NOT_OBSERVED} — no event on this fingerprint carries {TAKE_TAG}. "
+            "Absence is non-diagnostic (plan §7) and is not a failure rate of zero."
+        )
+        return lines
+    if window.degenerate:
+        # The explanation deliberately carries NO numeral. A refusal that prints
+        # the figure it is refusing invites exactly the misreading it exists to
+        # prevent — a skimming human takes the number and drops the refusal.
+        lines.append(
+            "  REFUSED — the eligible events produce no positive-width observation "
+            "interval at PostHog precision. A rate from one timestamp would be "
+            "dominated by coincident event timing, not a measured population span."
+        )
+        return lines
+    if not rates:
+        lines.append(f"  {NOT_OBSERVED} — no release produced a non-empty take union")
+        return lines
+
+    # Render the bounds ACTUALLY QUERIED, at the precision actually used. Printing
+    # `start_epoch` through a whole-second formatter displayed a window the query
+    # never ran — a caption for a different measurement.
+    start = (
+        datetime.datetime.fromtimestamp(window.start_millis / 1000, tz=datetime.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+    end = (
+        datetime.datetime.fromtimestamp(window.end_millis / 1000, tz=datetime.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+    lines.append(
+        f"  PostHog success window {start} .. {end}, rounded inward from the "
+        "eligible Sentry event span."
+    )
+    lines.append(
+        "  The affected Sentry takes retain the original boundary events. Because "
+        "the success window cannot extend beyond them and may exclude boundary "
+        "successes, this is an UPPER BOUND on the population rate."
+    )
+    for row in rates:
+        rate = row.affected_takes / row.union_takes if row.union_takes else 0.0
+        lines.append(
+            f"  {row.release}: {row.affected_takes}/{row.union_takes} takes affected "
+            f"({rate:.1%}); {row.affected_installs}/{row.eligible_installs} installs affected"
+        )
+    return lines
+
+
 def render_report(
-    report: FingerprintReport, usage: Mapping[str, InstallUsage]
+    report: FingerprintReport,
+    usage: Mapping[str, InstallUsage],
+    take_coverage: Sequence[TakeCoverageRow] = (),
+    take_rates: Sequence[TakeRateRow] = (),
 ) -> str:
     lines: list[str] = []
     lines.append(f"Sentry fingerprint {report.issue} — joined to PostHog usage (#1846)")
@@ -1260,6 +1902,17 @@ def render_report(
         )
     lines.append("")
 
+    lines.extend(render_take_coverage(take_coverage))
+    lines.append("")
+    lines.extend(
+        render_take_rates(
+            take_rates,
+            report.take_window,
+            has_affected_takes=bool(report.affected_takes_by_install_release),
+        )
+    )
+    lines.append("")
+
     if report.bursts:
         lines.append("Retry bursts (one person retrying, not a trend):")
         for burst in report.bursts:
@@ -1310,7 +1963,9 @@ def render_report(
 
 def build_report(
     issue: str, sentry: SentryClient, posthog: PostHogClient, environment: str = "production"
-) -> tuple[FingerprintReport, dict[str, InstallUsage]]:
+) -> tuple[
+    FingerprintReport, dict[str, InstallUsage], list[TakeCoverageRow], list[TakeRateRow]
+]:
     numeric = sentry.resolve_issue_id(issue)
     events = sentry.fetch_events(numeric)
     if not events:
@@ -1331,7 +1986,9 @@ def build_report(
     if environment == "production":
         posthog.resolve_dev_ids()
     usage = fetch_install_usage(posthog, report.joined_install_ids)
-    return report, usage
+    take_coverage = fetch_take_coverage(posthog)
+    take_rates = fetch_take_rates(posthog, report)
+    return report, usage, take_coverage, take_rates
 
 
 # ==========================================================================
@@ -2231,10 +2888,20 @@ def run_self_test() -> int:
     assert "2.3.1: 0/1 events carry" in coverage_render, coverage_render
     assert "<- no joined events" in coverage_render, coverage_render
     assert "2.5.0: 1/1 events carry" in coverage_render, coverage_render
-    assert "%" not in coverage_render, "no overall percentage may be printed"
-    assert "predates" not in coverage_render, (
+    # SCOPED to the join-coverage block. The founder ruling forbids an overall
+    # JOIN-coverage percentage; it does not forbid the Phase 2 take rate, which
+    # reports per release alongside its counts. A whole-render scan for "%" was
+    # the original form and it false-fired on the take-rate section's own prose —
+    # re-aimed at what it means rather than reworded around
+    # (`false-positives-not-gates-train-evasion`).
+    join_block = coverage_render.split("Join coverage by release")[1].split("Take coverage")[0]
+    assert "%" not in join_block, "no overall join-coverage percentage may be printed"
+    assert "predates" not in join_block, (
         "the tool must not claim to know WHY a release has zero coverage"
     )
+    # Positive control: the scoped slice must be capable of catching a percentage,
+    # or "found none" is indistinguishable from a slice that captured nothing.
+    assert "events carry" in join_block, "the scoped slice must contain the coverage lines"
     passed("join coverage is per-release, marks zeroes, and prints no overall figure")
 
     # The app gives Sentry a packaged release and PostHog the raw app version.
@@ -2415,6 +3082,488 @@ def run_self_test() -> int:
     assert re.findall(r"urlopen", "urllib.request.urlopen(x)"), "the matcher itself is broken"
     passed("exactly one function in the production half can open a network connection")
 
+    # ----------------------------------------------------------------------
+    # Phase 2 — take coverage and the fingerprint take rate
+    # ----------------------------------------------------------------------
+
+    # THE CASE-MISMATCH TRAP, frozen. The two identities differ in case because
+    # they are produced by different code: the PostHog SDK emits a lowercase
+    # distinct_id, while `SessionID.raw.uuidString` is Foundation's UPPERCASE
+    # form (measured 2026-07-30: `D3B6682C-A4F7-47DB-A6D9-F6B0283DD651`).
+    # Reusing the join-key canonicalizer would have rejected every real take ID
+    # and reported take coverage as a confident 0%.
+    upper_take = "D3B6682C-A4F7-47DB-A6D9-F6B0283DD651"
+    assert canonical_join_key(upper_take) is None, (
+        "the join-key matcher is lowercase-only — this is the trap being frozen"
+    )
+    assert canonical_take_id(upper_take) == upper_take
+    assert canonical_take_id(upper_take.lower()) == upper_take, "normalized to upper"
+    for junk in (None, "", "not-a-uuid", upper_take[:-1], upper_take + "0", 42):
+        assert canonical_take_id(junk) is None, f"canonical_take_id({junk!r})"
+    passed("take IDs accept Swift's UPPERCASE uuidString, which the join-key matcher rejects")
+
+    # A Sentry event carries the take tag; an event WITHOUT it is not an error,
+    # because every pre-#1846 event legitimately lacks one.
+    def _sentry_event_with(tags: list[dict[str, str]]) -> SentryEvent:
+        return SentryClient._parse_event(
+            {
+                "id": "take-evt",
+                "dateCreated": "2026-07-30T00:00:00Z",
+                "tags": [
+                    {"key": "release", "value": "2.6.0"},
+                    {"key": "environment", "value": "production"},
+                    {"key": JOIN_TAG, "value": install},
+                    *tags,
+                ],
+            },
+            1,
+        )
+
+    assert _sentry_event_with([{"key": TAKE_TAG, "value": upper_take}]).take_id == upper_take
+    assert _sentry_event_with([]).take_id is None, "an absent take tag must not raise"
+    assert _sentry_event_with([{"key": TAKE_TAG, "value": "junk"}]).take_id is None
+    passed("the Sentry take tag parses when present and is non-fatal when absent or malformed")
+
+    # Per-event coverage: an event with rows reports its ratio; an event with NO
+    # rows reports `not observed`. Never 0% and never 100% — zero rows is an
+    # absence of evidence, and the whole point of the per-event shape is that a
+    # busy event cannot mask a silent one.
+    ph, _ = _posthog_client(
+        [
+            _posthog_response(
+                [
+                    ["2.6.0", "dictation.completed", 400, 400],
+                    ["2.6.0", "recording.cap_warning_shown", 3, 0],
+                    ["2.7.0", "dictation.completed", 500, 500],
+                ]
+            )
+        ]
+    )
+    ph.dev_ids = ()
+    observed_coverage = fetch_take_coverage(ph)
+    coverage_lines = "\n".join(render_take_coverage(observed_coverage))
+    assert "dictation.completed on 2.6.0: 400/400 rows carry take_id" in coverage_lines
+    assert "dictation.completed on 2.7.0: 500/500 rows carry take_id" in coverage_lines
+    assert "recording.cap_warning_shown on 2.6.0: 0/3 rows carry take_id" in coverage_lines
+    assert "<- no take keys" in coverage_lines, "a zero must be marked"
+    # THE BLACKOUT CELL. `recording.cap_warning_shown` was observed on 2.6.0 and is
+    # absent on 2.7.0. The first renderer printed `not observed` only for events
+    # missing from EVERY release, so this cell vanished silently — a per-release
+    # blackout invisible in the table built to catch blackouts.
+    assert "recording.cap_warning_shown on 2.7.0: not observed" in coverage_lines, coverage_lines
+    # Every event the fixture never returned gets a cell on BOTH observed releases.
+    for name in TAKE_KEYED_EVENTS:
+        if name in ("dictation.completed", "recording.cap_warning_shown"):
+            continue
+        for rel in ("2.6.0", "2.7.0"):
+            assert f"  {name} on {rel}: {NOT_OBSERVED}" in coverage_lines, (name, rel)
+    assert "100%" not in coverage_lines and "0%" not in coverage_lines
+    passed("take coverage renders the full event x release grid, blackout cells included")
+
+    # A subset larger than its set is impossible; it means the query or the parse
+    # is wrong, and a wrong coverage number is worse than none.
+    ph, _ = _posthog_client([_posthog_response([["2.6.0", "dictation.completed", 5, 9]])])
+    ph.dev_ids = ()
+    _expect_raises(ProtocolError, lambda: fetch_take_coverage(ph), "keyed exceeds total")
+    ph, _ = _posthog_client([_posthog_response([["2.6.0", "not.an.event", 5, 5]])])
+    ph.dev_ids = ()
+    _expect_raises(ProtocolError, lambda: fetch_take_coverage(ph), "unlisted event name")
+    passed("take coverage fails closed on an impossible subset or an unlisted event")
+
+    # THE UNION ARITHMETIC. A take on BOTH sides is counted once: two failed
+    # takes, ten successful takes, one of which is the same take, is a union of
+    # eleven — not twelve.
+    take_a, take_b = upper_take, "11111111-2222-3333-4444-555555555555"
+    take_report = aggregate_fingerprint(
+        "X",
+        [
+            SentryEvent(
+                "e1", "2.6.0", install, None, 1000.0,
+                environment="production", take_id=take_a,
+            ),
+            SentryEvent(
+                "e2", "2.6.0", install, None, 2000.0,
+                environment="production", take_id=take_b,
+            ),
+        ],
+        "production",
+    )
+    # Queue order: bucket rows, the bucket completeness total, then the
+    # POPULATION query for the affected-user denominator.
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([[install, "2.6.0", 10, 1, 0]]),
+            _posthog_response([[1]]),
+            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([[1]]),
+        ]
+    )
+    ph.dev_ids = ()
+    rates = fetch_take_rates(ph, take_report)
+    assert len(rates) == 1, rates
+    assert rates[0].affected_takes == 2, rates[0]
+    assert rates[0].union_takes == 11, f"2 + 10 - 1 overlap = 11, got {rates[0].union_takes}"
+    assert rates[0].affected_installs == 1
+    # 10, NOT 1. The denominator is the population of installs with a keyed take
+    # in this window, not the affected installs it contains. The first version of
+    # this assertion read `== 1` and froze a structurally tautological 100%.
+    assert rates[0].eligible_installs == 10, rates[0]
+    rate_lines = "\n".join(render_take_rates(rates, take_report.take_window, True))
+    assert "2/11 takes affected (18.2%)" in rate_lines, rate_lines
+    assert "1/10 installs affected" in rate_lines, rate_lines
+    assert "UPPER BOUND" in rate_lines, "the window bias must be stated, not implied"
+    passed("a take on both sides is counted once, over a denominator that is not itself")
+
+    # Overlap is RELEASE-scoped. A partition-wide take-id list let a take affected
+    # on 2.6.0 subtract from 2.7.0's union merely because the same partition held
+    # both. Latent rather than observed — one take belongs to one session on one
+    # build, so the same id should never appear under two app versions — but every
+    # other step here pairs (install, release), and the SQL must say what it means.
+    cross_release_report = aggregate_fingerprint(
+        "X",
+        [
+            SentryEvent(
+                "cr1", "2.6.0", install, None, 1000.0,
+                environment="production", take_id=take_a,
+            ),
+            SentryEvent(
+                "cr2", "2.7.0", install, None, 2000.0,
+                environment="production", take_id=take_b,
+            ),
+        ],
+        "production",
+    )
+    ph, cross_release_transport = _posthog_client(
+        [
+            _posthog_response([[install, "2.6.0", 2, 1, 0], [install, "2.7.0", 2, 1, 0]]),
+            _posthog_response([[2]]),
+            _posthog_response([["2.6.0", 1, 0], ["2.7.0", 1, 0]]),
+            _posthog_response([[2]]),
+        ]
+    )
+    ph.dev_ids = ()
+    cross_release_rates = fetch_take_rates(ph, cross_release_report)
+    assert {row.release: row.union_takes for row in cross_release_rates} == {
+        "2.6.0": 2,
+        "2.7.0": 2,
+    }, cross_release_rates
+
+    # And the emitted predicate must pair each release with ONLY its own take ids.
+    envelope = json.loads(cross_release_transport.seen[0].body or b"{}")
+    overlap_sql = re.sub(r"\s+", " ", envelope["query"]["query"])
+    assert (
+        f"properties.app_version = \'2.6.0\' "
+        f"AND upper(properties.{TAKE_PROPERTY}) IN (\'{take_a}\')"
+    ) in overlap_sql, overlap_sql
+    assert (
+        f"properties.app_version = \'2.7.0\' "
+        f"AND upper(properties.{TAKE_PROPERTY}) IN (\'{take_b}\')"
+    ) in overlap_sql, overlap_sql
+    passed("overlap subtraction is scoped to the release that take was affected on")
+
+    # An overlap larger than the successes it is drawn from is impossible.
+    ph, _ = _posthog_client(
+        [_posthog_response([[install, "2.6.0", 3, 7, 0]]), _posthog_response([[1]])]
+    )
+    ph.dev_ids = ()
+    _expect_raises(
+        ProtocolError, lambda: fetch_take_rates(ph, take_report), "overlap exceeds successes"
+    )
+    passed("the take rate fails closed when the overlap exceeds the successes")
+
+    # A truncated bucket response silently drops successes and INFLATES the rate.
+    # The independent identical-filter total is what makes that impossible.
+    # COMPLETE queue, including the population response the guard never reaches.
+    # With a short queue this control failed on "fixture queue exhausted" — a real
+    # failure for an incidental reason, which would equally mask a genuine
+    # regression. The same trap is recorded on the `required_count` case above.
+    # With the full queue, removing the guard lets the call SUCCEED, so the
+    # assertion is specific to the guard rather than to the fixture.
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([[install, "2.6.0", 10, 1, 0]]),
+            _posthog_response([[2]]),
+            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([[1]]),
+        ]
+    )
+    ph.dev_ids = ()
+    _expect_raises(
+        IncompleteError,
+        lambda: fetch_take_rates(ph, take_report),
+        "truncated take-rate buckets",
+        # The message is REQUIRED, not decorative: four separate guards in this
+        # file raise `IncompleteError`, so a bare type assertion cannot say which
+        # one fired. Control D earlier in this chunk failed for exactly that
+        # reason — an unrelated guard tripped and looked like proof.
+        "received 1 install-release buckets",
+    )
+    passed("take-rate buckets require an independent completeness total")
+
+    # SUB-SECOND WINDOW BOUNDS. `int(epoch)` compared whole seconds, so a window of
+    # .900 -> 1.100 admitted nearly two full seconds of PostHog events and quietly
+    # enlarged the denominator. Rounding INWARD makes the success query narrower
+    # than the measured failure span, never wider — conservative by construction.
+    fractional_window = TakeWindow(start_epoch=1000.900, end_epoch=1001.100)
+    assert fractional_window.start_millis == 1_000_900, fractional_window.start_millis
+    assert fractional_window.end_millis == 1_001_100, fractional_window.end_millis
+    assert fractional_window.degenerate is False
+    # A window with no positive width can contain coincident events, but it is not
+    # a meaningful population interval. Refuse instead of reporting a rate whose
+    # denominator is determined by timestamp coincidence.
+    assert TakeWindow(start_epoch=1000.0001, end_epoch=1000.0002).degenerate is True
+    # And the emitted SQL must carry the exact bounds — a correct property that
+    # never reaches the query is not a fix.
+    ph, tr = _posthog_client(
+        [
+            _posthog_response([[install, "2.6.0", 10, 1, 0]]),
+            _posthog_response([[1]]),
+            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([[1]]),
+        ]
+    )
+    ph.dev_ids = ()
+    fetch_take_rates(ph, take_report)
+    window = take_report.take_window
+    assert window is not None
+    sent = "\n".join(str(request.body) for request in tr.seen)
+    assert f"toUnixTimestamp64Milli(timestamp) >= {window.start_millis}" in sent
+    assert f"toUnixTimestamp64Milli(timestamp) <= {window.end_millis}" in sent
+    # The RENDERED window must be the one queried. Formatting `start_epoch` through
+    # a whole-second formatter printed a caption for a different measurement.
+    # A SUB-MILLISECOND fixture, chosen so the rounded and unrounded renderings
+    # DIFFER. The first version used the .900/.100 window above, where both forms
+    # print identically — the control that reverted this to `start_epoch` passed
+    # all 55 cases, proving the assertion could not detect the defect it named.
+    sub_milli_window = TakeWindow(start_epoch=1000.9001, end_epoch=1001.1006)
+    assert sub_milli_window.start_millis == 1_000_901, sub_milli_window.start_millis
+    assert sub_milli_window.end_millis == 1_001_100, sub_milli_window.end_millis
+    displayed_window = "\n".join(
+        render_take_rates(
+            [
+                TakeRateRow(
+                    release="2.6.0", affected_takes=1, union_takes=1,
+                    affected_installs=1, eligible_installs=1,
+                )
+            ],
+            sub_milli_window,
+            True,
+        )
+    )
+    assert (
+        "1970-01-01T00:16:40.901Z .. 1970-01-01T00:16:41.100Z" in displayed_window
+    ), displayed_window
+    # The unrounded start would print .900 — assert its ABSENCE, so rendering the
+    # raw epoch fails here instead of passing silently.
+    assert "00:16:40.900Z" not in displayed_window, displayed_window
+    assert "SAME span" not in displayed_window
+    passed("the take-rate window is bounded, and displayed, at the precision queried")
+
+    # A malformed PostHog take id must not become a successful take. It would
+    # enlarge both denominators and produce a confidently LOWER failure rate — the
+    # direction that reads as "the bug is rarer than you feared".
+    # COMPLETE queue: absent the guard this call SUCCEEDS, so the assertion is
+    # specific to the guard rather than to queue exhaustion.
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([[install, "2.6.0", 10, 1, 1]]),
+            _posthog_response([[1]]),
+            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([[1]]),
+        ]
+    )
+    ph.dev_ids = ()
+    _expect_raises(
+        ProtocolError,
+        lambda: fetch_take_rates(ph, take_report),
+        "malformed successful take id",
+        "non-canonical take_id",
+    )
+    # Same guard on the population query, which independently produces the
+    # affected-user denominator.
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([[install, "2.6.0", 10, 1, 0]]),
+            _posthog_response([[1]]),
+            _posthog_response([["2.6.0", 10, 3]]),
+            _posthog_response([[1]]),
+        ]
+    )
+    ph.dev_ids = ()
+    _expect_raises(
+        ProtocolError,
+        lambda: fetch_take_rates(ph, take_report),
+        "malformed take id in the population query",
+        "non-canonical take_id",
+    )
+    passed("malformed PostHog take IDs cannot enter either rate denominator")
+
+    # A truncated POPULATION response loses a release row; `defaultdict(int)` would
+    # substitute zero and the denominator could come back below its own numerator.
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([[install, "2.6.0", 10, 1, 0]]),
+            _posthog_response([[1]]),
+            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([[2]]),
+        ]
+    )
+    ph.dev_ids = ()
+    _expect_raises(
+        IncompleteError,
+        lambda: fetch_take_rates(ph, take_report),
+        "truncated population buckets",
+        "received 1 release buckets",
+    )
+    # And an impossible pair across the two result sets is refused rather than
+    # returned: more affected-and-successful installs than successful installs.
+    ph, _ = _posthog_client(
+        [
+            _posthog_response([[install, "2.6.0", 10, 1, 0]]),
+            _posthog_response([[1]]),
+            _posthog_response([["2.6.0", 0, 0]]),
+            _posthog_response([[1]]),
+        ]
+    )
+    ph.dev_ids = ()
+    _expect_raises(
+        ProtocolError,
+        lambda: fetch_take_rates(ph, take_report),
+        "affected-and-successful exceeds successful",
+        "affected installs",
+    )
+    passed("the affected-user denominator fails closed on truncation or an impossible pair")
+
+    # The renderer's own fail-closed paths. Both are reachable only from a
+    # hand-built list today, but an untested raise is an untested raise.
+    _expect_raises(
+        ProtocolError,
+        lambda: render_take_coverage(
+            [
+                TakeCoverageRow(event="dictation.completed", release="2.6.0",
+                                with_take=1, total=1),
+                TakeCoverageRow(event="dictation.completed", release="2.6.0",
+                                with_take=2, total=2),
+            ]
+        ),
+        "duplicate coverage cell",
+        "duplicate rows",
+    )
+    _expect_raises(
+        ProtocolError,
+        lambda: render_take_coverage(
+            [TakeCoverageRow(event="not.an.event", release="2.6.0", with_take=1, total=1)]
+        ),
+        "unlisted event in the renderer",
+        "unlisted events",
+    )
+    # And the empty case still names every intended event rather than printing
+    # an empty table that reads as "nothing to report".
+    empty_grid = "\n".join(render_take_coverage([]))
+    for name in TAKE_KEYED_EVENTS:
+        assert f"  {name}: {NOT_OBSERVED}" in empty_grid, name
+    passed("the coverage renderer fails closed on duplicate or unlisted cells")
+
+    # A window with no positive width can contain coincident events, but it is not
+    # a meaningful population interval. Refuse instead of reporting a rate whose
+    # denominator is determined by timestamp coincidence.
+    point_report = aggregate_fingerprint(
+        "X",
+        [
+            SentryEvent(
+                "e1", "2.6.0", install, None, 1000.0,
+                environment="production", take_id=take_a,
+            )
+        ],
+        "production",
+    )
+    assert point_report.take_window is not None and point_report.take_window.degenerate
+    # The fixture is a client that WOULD succeed. An empty-response client was the
+    # first form and it proved nothing: removing the guard made the run fail on
+    # "dev ids never resolved" instead of on this assertion, so the control fired
+    # for an unrelated reason — the Python twin of a compile error passing for RED.
+    # With a complete queue, the ONLY thing standing between this call and a
+    # computed rate is the degenerate-window guard.
+    ph, _ = _posthog_client([_posthog_response([[install, "2.6.0", 4, 0, 0]])])
+    ph.dev_ids = ()
+    assert fetch_take_rates(ph, point_report) == []
+    point_rendered = render_take_rates([], point_report.take_window, True)
+    refusal = [line for line in point_rendered if "REFUSED" in line]
+    assert len(refusal) == 1, point_rendered
+    # Scoped to the refusal LINE, not the block: the section header legitimately
+    # contains "Phase 2", and a whole-block digit scan flagged that label as if it
+    # were a reported figure. Aim the matcher at the claim it is checking.
+    assert not re.search(r"\d", refusal[0]), (
+        "a refusal must not print a figure — a skimming reader takes the number "
+        f"and drops the refusal: {refusal[0]!r}"
+    )
+    passed("a zero-width take window is refused rather than reported as a certainty")
+
+    # A pre-Phase-2 population carries no take tags at all. That reads
+    # `not observed`, NEVER a 0% failure rate.
+    legacy_report = aggregate_fingerprint(
+        "X",
+        [
+            SentryEvent("e1", "2.5.0", install, None, 1000.0, environment="production"),
+            SentryEvent("e2", "2.5.0", install, None, 5000.0, environment="production"),
+        ],
+        "production",
+    )
+    assert legacy_report.affected_takes_by_install_release == {}
+    assert fetch_take_rates(_posthog_client([])[0], legacy_report) == []
+    legacy_lines = "\n".join(
+        render_take_rates([], legacy_report.take_window, has_affected_takes=False)
+    )
+    assert NOT_OBSERVED in legacy_lines
+    assert "0%" not in legacy_lines, "absence of the tag is not a zero rate"
+    passed("a population with no take tags reads not-observed, never a 0% rate")
+
+    # Only JOINED events contribute a take. An unjoined event's take cannot be
+    # paired with any install's successes, so counting it would inflate the
+    # numerator against a denominator it is not part of.
+    unjoined_report = aggregate_fingerprint(
+        "X",
+        [
+            SentryEvent(
+                "e1", "2.6.0", None, "legacy-user", 1000.0,
+                environment="production", take_id=take_a,
+            ),
+            SentryEvent(
+                "e2", "2.6.0", install, None, 2000.0,
+                environment="production", take_id=take_b,
+            ),
+        ],
+        "production",
+    )
+    assert unjoined_report.affected_takes_by_install_release == {(install, "2.6.0"): {take_b}}
+    passed("an unjoined event's take never enters the rate it has no denominator for")
+
+    # COMPOSITION, through the real entry point. Every case above calls
+    # `render_take_coverage` / `render_take_rates` directly, so deleting the two
+    # lines that splice them into `render_report` would leave all of them green
+    # while the shipped report printed neither section
+    # (`a-guard-nothing-arms-is-not-a-guard`).
+    composed = render_report(
+        take_report,
+        {},
+        take_coverage=[
+            TakeCoverageRow(
+                event="dictation.completed", release="2.6.0", with_take=400, total=400
+            )
+        ],
+        take_rates=[
+            TakeRateRow(
+                release="2.6.0", affected_takes=2, union_takes=11,
+                affected_installs=1, eligible_installs=1,
+            )
+        ],
+    )
+    assert "Take coverage by event and release" in composed, composed
+    assert "dictation.completed on 2.6.0: 400/400" in composed, composed
+    assert "Fingerprint take rate" in composed, composed
+    assert "2/11 takes affected" in composed, composed
+    passed("render_report splices both Phase 2 sections into the shipped output")
+
     print("")
     print(f"Self-test: {len(cases)} cases passed, 0 failed")
     return 0
@@ -2467,14 +3616,14 @@ def main(argv: Sequence[str]) -> int:
                 f"missing credential(s) in the environment: {', '.join(missing)}. "
                 "Bridge them with `~/.claude/bin/get-key launch` — see the module docstring."
             )
-        report, usage = build_report(
+        report, usage, take_coverage, take_rates = build_report(
             args.issue,
             SentryClient(str(sentry_key)),
             PostHogClient(str(posthog_key), environment=args.environment),
             environment=args.environment,
         )
         # Rendered only after every page, partition and completeness check passed.
-        print(render_report(report, usage))
+        print(render_report(report, usage, take_coverage, take_rates))
         return 0
     except InstrumentError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -132,6 +132,15 @@ REQUEST_TIMEOUT_SECONDS = 30.0
 RETRY_BURST_WINDOW_SECONDS = 300
 RETRY_BURST_MIN_EVENTS = 3
 
+# Explicit ceiling for the one query that returns a LIST rather than an aggregate.
+# PostHog defaults a HogQL result to 100 rows and reports `hasMore`, which
+# `PostHogClient.query` refuses — correct for every aggregate here, but it would
+# abort the whole report the day this project passes 100 dev installs. The proven
+# worker shape (`workers/daily-report/src/lib/posthog.js` `resolveDevIds`) asks for
+# LIMIT n+1 and treats the overflow row as the completeness failure, so the bound
+# is explicit and the failure is about the DATA, not about a default.
+DEV_ID_LIST_LIMIT = 5000
+
 # Installs per sequential PostHog partition. Small enough to stay well inside
 # the documented 10s execution ceiling with a literal IN list.
 PARTITION_SIZE = 25
@@ -817,9 +826,14 @@ class PostHogClient:
         return clause
 
     def resolve_dev_ids(self) -> tuple[str, ...]:
+        """The ONE query here that returns a list rather than an aggregate, so it
+        carries its own explicit bound. `LIMIT n+1` makes the overflow row the
+        completeness signal — the shape `workers/daily-report` already runs daily.
+        """
         rows, _ = self.query(
             "SELECT DISTINCT distinct_id FROM events "
-            "WHERE properties.app_version LIKE '%-dev%'",
+            "WHERE properties.app_version LIKE '%-dev%' "
+            f"LIMIT {DEV_ID_LIST_LIMIT + 1}",
             "dev_ids",
         )
         ids = []
@@ -827,6 +841,12 @@ class PostHogClient:
             if len(row) != 1 or not isinstance(row[0], str):
                 raise ProtocolError("dev_ids: expected exactly one string column per row")
             ids.append(row[0])
+        if len(ids) > DEV_ID_LIST_LIMIT:
+            raise IncompleteError(
+                f"dev_ids: more than {DEV_ID_LIST_LIMIT} dev-tainted installs. The "
+                "exclusion list would be incomplete and every production total would "
+                "carry dev traffic — refusing to measure."
+            )
         self.dev_ids = tuple(ids)
         return self.dev_ids
 
@@ -1629,13 +1649,30 @@ def fetch_take_rates(
         AND toUnixTimestamp64Milli(timestamp) >= {window.start_millis}
         AND toUnixTimestamp64Milli(timestamp) <= {window.end_millis}
     """
+    # RELEASE-SCOPED, the same way the take overlap is. A global affected-install
+    # list counts an install affected only on release A as affected overlap on
+    # release B, which either understates B's denominator or trips the
+    # impossible-pair guard. This is the install-level twin of the take-level
+    # release scoping above — I fixed one and left the other, which is a partial
+    # port, not two accidents.
+    affected_installs_by_release: dict[str, set[str]] = defaultdict(set)
+    for (affected_install, affected_release) in report.affected_takes_by_install_release:
+        affected_installs_by_release[affected_release].add(affected_install)
+    affected_install_predicate = "\n OR ".join(
+        f"""(
+            properties.app_version = {sql_id_list([release_name])}
+            AND distinct_id IN ({sql_id_list(sorted(install_ids))})
+        )"""
+        for release_name, install_ids in sorted(affected_installs_by_release.items())
+    )
+
     population_rows, _ = client.query(
         f"""
         SELECT properties.app_version AS release,
                uniqExact(distinct_id) AS eligible_installs,
                uniqExactIf(
                    distinct_id,
-                   distinct_id IN ({sql_id_list(installs)})
+                   ({affected_install_predicate})
                ) AS affected_eligible_installs,
                countIf(
                    match(
@@ -3403,6 +3440,80 @@ def run_self_test() -> int:
         f"properties.app_version = \'2.7.0\' "
         f"AND upper(properties.{TAKE_PROPERTY}) IN (\'{take_b}\')"
     ) in overlap_sql, overlap_sql
+    # The install-level twin: the affected-install predicate in the POPULATION query
+    # must also pair each release with only its own installs. `cross_release_report`
+    # has one install affected on both releases, so widen it — a second install
+    # affected on 2.6.0 only must not be counted as affected overlap on 2.7.0.
+    other_install = _fixture_install_uuid("a02")
+    two_install_report = aggregate_fingerprint(
+        "X",
+        [
+            SentryEvent(
+                "ti1", "2.6.0", install, None, 1000.0,
+                environment="production", take_id=take_a,
+            ),
+            SentryEvent(
+                "ti2", "2.6.0", other_install, None, 1500.0,
+                environment="production", take_id=take_b,
+            ),
+            SentryEvent(
+                "ti3", "2.7.0", install, None, 2000.0,
+                environment="production",
+                take_id="22222222-3333-4444-5555-666666666666",
+            ),
+        ],
+        "production",
+    )
+    ph, two_install_transport = _posthog_client(
+        [
+            _posthog_response(
+                [[install, "2.6.0", 1, 1, 0], [other_install, "2.6.0", 1, 1, 0],
+                 [install, "2.7.0", 1, 1, 0]]
+            ),
+            _posthog_response([[3]]),
+            _posthog_response([["2.6.0", 2, 2, 0], ["2.7.0", 1, 1, 0]]),
+            _posthog_response([[2]]),
+        ]
+    )
+    ph.dev_ids = ()
+    fetch_take_rates(ph, two_install_report)
+    population_scoped_sql = re.sub(
+        r"\s+", " ",
+        json.loads(
+            [r for r in two_install_transport.seen
+             if b"take_rate_user_population" in (r.body or b"")][0].body or b"{}"
+        )["query"]["query"],
+    )
+    # 2.7.0 must name ONLY the install affected there, not both.
+    assert (
+        f"properties.app_version = \'2.7.0\' AND distinct_id IN (\'{install}\')"
+        in population_scoped_sql
+    ), population_scoped_sql
+    assert (
+        f"properties.app_version = \'2.6.0\' AND distinct_id IN "
+        f"({sql_id_list(sorted([install, other_install]))})"
+        in population_scoped_sql
+    ), population_scoped_sql
+    passed("affected-install overlap is release-scoped too, not just the take overlap")
+
+    # The dev-id list is the one query returning a LIST, so it carries an explicit
+    # bound. Without it the shared truncation guard would abort every production
+    # report the day this project passes PostHog's 100-row default — a guard that
+    # breaks the thing it protects.
+    over_limit = [[f"id-{i}"] for i in range(DEV_ID_LIST_LIMIT + 1)]
+    ph, dev_transport = _posthog_client([_posthog_response(over_limit)])
+    _expect_raises(
+        IncompleteError, lambda: ph.resolve_dev_ids(), "dev-id overflow",
+        "dev-tainted installs",
+    )
+    assert f"LIMIT {DEV_ID_LIST_LIMIT + 1}" in str(dev_transport.seen[0].body), (
+        "the query must ask for one MORE than the ceiling, so overflow is detectable"
+    )
+    # At the ceiling exactly, it succeeds.
+    ph, _ = _posthog_client([_posthog_response([[f"id-{i}"] for i in range(DEV_ID_LIST_LIMIT)])])
+    assert len(ph.resolve_dev_ids()) == DEV_ID_LIST_LIMIT
+    passed("the dev-id list is explicitly bounded and fails on overflow, not on a default")
+
     passed("overlap subtraction is scoped to the release that take was affected on")
 
     # An overlap larger than the successes it is drawn from is impossible.

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -595,14 +595,29 @@ def _parse_iso8601(value: object) -> float | None:
         return None
 
 
+_LOWER_UUID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+_UPPER_UUID = re.compile(r"[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}")
+
+
 def canonical_join_key(raw: object) -> str | None:
     """Mirror of `ObservabilityBootstrap.canonicalAnonymousPostHogID`. A value
     the app would never have emitted is not a join key; treating it as one would
     query PostHog for an install that cannot exist.
+
+    BOTH CASES, VERBATIM — and mixed case rejected, exactly as the Swift side.
+    The SDK lowercases ids it MINTS, but returns a PERSISTED id unchanged, so an
+    install whose id predates that lowercasing keeps its uppercase spelling.
+    Measured against production 2026-07-30: 94 of 692 distinct installs (13.6%)
+    carry an uppercase id. A lowercase-only matcher drops all of them, and here
+    that would read as an unjoinable legacy population rather than as a bug.
+
+    Not case-FOLDED, unlike `canonical_take_id`: this value is used to query
+    PostHog by `distinct_id`, so it must match the stored string exactly. The take
+    id is only ever compared between two sources, so normalizing it is safe.
     """
     if not isinstance(raw, str) or len(raw) != 36:
         return None
-    if not re.fullmatch(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", raw):
+    if not (_LOWER_UUID.fullmatch(raw) or _UPPER_UUID.fullmatch(raw)):
         return None
     return raw
 
@@ -3223,9 +3238,18 @@ def run_self_test() -> int:
     # Reusing the join-key canonicalizer would have rejected every real take ID
     # and reported take coverage as a confident 0%.
     upper_take = "D3B6682C-A4F7-47DB-A6D9-F6B0283DD651"
-    assert canonical_join_key(upper_take) is None, (
-        "the join-key matcher is lowercase-only — this is the trap being frozen"
-    )
+    # THE JOIN KEY ACCEPTS BOTH CASES AND NORMALIZES NEITHER. Measured against
+    # production 2026-07-30: 94 of 692 distinct installs (13.6%) carry an
+    # uppercase `distinct_id`, because the SDK lowercases only ids it MINTS and
+    # returns a PERSISTED id unchanged. It is used to QUERY PostHog by
+    # distinct_id, so it must match the stored string exactly.
+    assert canonical_join_key(upper_take) == upper_take
+    assert canonical_join_key(upper_take.lower()) == upper_take.lower()
+    # Mixed case is a spelling PostHog never produces.
+    assert canonical_join_key("0198A1B2-c3d4-7E5F-8a9b-0C1D2E3F4A5B") is None
+    # The take id, by contrast, is only ever compared BETWEEN two sources, so it
+    # is case-folded to make that comparison robust.
+    assert canonical_take_id(upper_take.lower()) == upper_take
     assert canonical_take_id(upper_take) == upper_take
     assert canonical_take_id(upper_take.lower()) == upper_take, "normalized to upper"
     for junk in (None, "", "not-a-uuid", upper_take[:-1], upper_take + "0", 42):

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -2040,6 +2040,14 @@ def render_report(
 
     lines.append("Per-install configuration and that install's OWN success record.")
     lines.append("This is the denominator Sentry cannot show.")
+    lines.append(
+        "CONFIGURATION IS CURRENT, NOT AS-OF-THE-FAILURE. It is reconstructed by the "
+        "documented method (analytics-operations.md FACT: settings-config-reconstruction): "
+        "the latest snapshot with later changes overlaid, across all releases. An install "
+        "that switched backend or provider AFTER the events below will show its NEW "
+        "setting beside OLD failures. Do not read the pairing as causal without checking "
+        "`settings.changed` timestamps for that install."
+    )
     lines.append("")
     for install_id in report.joined_install_ids:
         entry = usage.get(install_id)
@@ -3064,6 +3072,12 @@ def run_self_test() -> int:
     )
     assert "466 successful dictations" in packaged_render, packaged_render
     assert "18 pipeline.failed" in packaged_render, packaged_render
+    # The configuration shown is CURRENT, not as-of-the-failure: the documented
+    # reconstruction takes the latest snapshot plus later changes across all
+    # releases, so an install that changed backend after these events shows its
+    # new setting beside old failures. Printed next to a failure list that reads
+    # as causal, an unlabelled "current config" invites exactly that misreading.
+    assert "CONFIGURATION IS CURRENT, NOT AS-OF-THE-FAILURE" in packaged_render
     passed("Sentry packaged releases join PostHog raw app versions, including dev versions")
 
     # Counts are measurements: malformed values must not be rounded or truncated.

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -1400,6 +1400,17 @@ def fetch_take_coverage(client: PostHogClient) -> list[TakeCoverageRow]:
     "is the take key actually landing on this event," which wants the widest view
     available, not one fingerprint's slice.
 
+    ONE QUERY PER EVENT, not one grouped query over all 13. A single
+    `GROUP BY release, event` returns one row per observed combination, and that
+    grid is ALREADY 127 rows in production (measured 2026-07-30) — over PostHog's
+    100-row cap, so the shared truncation guard would have aborted the entire
+    report on its first real run. Per event, each result is bounded by the number
+    of releases instead, which is an order of magnitude smaller.
+
+    Sequential and index-accounted like the install partitions, so a dropped query
+    cannot pass as an event with no rows — which the renderer would print as
+    `not observed`, turning a missing query into a fabricated blackout.
+
     Coverage counts only CANONICAL take ids, using the same pattern the rate
     queries reject on. Testing merely for NULL-or-empty would report an emitter
     that regressed to a malformed non-empty value as fully covered, while that
@@ -1407,47 +1418,53 @@ def fetch_take_coverage(client: PostHogClient) -> list[TakeCoverageRow]:
     would say 100% for a key that joins nothing. What is measured here is a
     USABLE join key, not the presence of a property.
     """
-    rows, _ = client.query(
-        f"""
-        SELECT properties.app_version AS release,
-               event AS event_name,
-               count() AS total,
-               countIf(
-                   match(
-                       toString(properties.{TAKE_PROPERTY}),
-                       '{TAKE_ID_HOGQL_PATTERN}'
-                   ) = 1
-               ) AS with_take
-        FROM events
-        WHERE event IN ({sql_id_list(TAKE_KEYED_EVENTS)})
-          AND {client.environment_clause()}
-        GROUP BY release, event_name
-        """,
-        "take_coverage",
-    )
     coverage: list[TakeCoverageRow] = []
-    for row in rows:
-        if len(row) != 4:
-            raise ProtocolError(f"take_coverage: expected 4 columns, got {len(row)}")
-        release_raw, event_name, total, with_take = row
-        if not isinstance(event_name, str) or event_name not in TAKE_KEYED_EVENTS:
-            raise ProtocolError(f"take_coverage: unexpected event {event_name!r}")
-        total_count = required_count(total, "take_coverage: total")
-        with_take_count = required_count(with_take, "take_coverage: with_take")
-        if with_take_count > total_count:
-            raise ProtocolError(
-                f"take_coverage: {event_name} on {release_raw!r} reports "
-                f"{with_take_count} keyed rows out of {total_count} — a subset "
-                "cannot exceed its set, so the query or the parse is wrong"
-            )
-        coverage.append(
-            TakeCoverageRow(
-                event=event_name,
-                release=canonical_app_version(release_raw, "take_coverage"),
-                with_take=with_take_count,
-                total=total_count,
-            )
+    expected_indexes = set(range(len(TAKE_KEYED_EVENTS)))
+    completed_indexes: set[int] = set()
+
+    for index, event_name in enumerate(TAKE_KEYED_EVENTS):
+        rows, _ = client.query(
+            f"""
+            SELECT properties.app_version AS release,
+                   count() AS total,
+                   countIf(
+                       match(
+                           toString(properties.{TAKE_PROPERTY}),
+                           '{TAKE_ID_HOGQL_PATTERN}'
+                       ) = 1
+                   ) AS with_take
+            FROM events
+            WHERE event = {sql_id_list([event_name])}
+              AND {client.environment_clause()}
+            GROUP BY release
+            """,
+            f"take_coverage_{index}",
         )
+        for row in rows:
+            if len(row) != 3:
+                raise ProtocolError(
+                    f"take_coverage_{index}: expected 3 columns, got {len(row)}"
+                )
+            release_raw, total, with_take = row
+            total_count = required_count(total, f"take_coverage_{index}: total")
+            with_take_count = required_count(with_take, f"take_coverage_{index}: with_take")
+            if with_take_count > total_count:
+                raise ProtocolError(
+                    f"take_coverage_{index}: {event_name} on {release_raw!r} reports "
+                    f"{with_take_count} keyed rows out of {total_count} — a subset "
+                    "cannot exceed its set, so the query or the parse is wrong"
+                )
+            coverage.append(
+                TakeCoverageRow(
+                    event=event_name,
+                    release=canonical_app_version(release_raw, f"take_coverage_{index}"),
+                    with_take=with_take_count,
+                    total=total_count,
+                )
+            )
+        completed_indexes.add(index)
+
+    require_complete_partitions(expected_indexes, completed_indexes)
     return coverage
 
 
@@ -3227,16 +3244,18 @@ def run_self_test() -> int:
     # rows reports `not observed`. Never 0% and never 100% — zero rows is an
     # absence of evidence, and the whole point of the per-event shape is that a
     # busy event cannot mask a silent one.
+    # ONE response per event now, in TAKE_KEYED_EVENTS order. The grouped
+    # single-query form returned 127 rows in production — over PostHog's cap.
+    def _coverage_fixture(per_event: dict[str, list[list[object]]]) -> list[HTTPResponse]:
+        return [_posthog_response(per_event.get(name, [])) for name in TAKE_KEYED_EVENTS]
+
     ph, _ = _posthog_client(
-        [
-            _posthog_response(
-                [
-                    ["2.6.0", "dictation.completed", 400, 400],
-                    ["2.6.0", "recording.cap_warning_shown", 3, 0],
-                    ["2.7.0", "dictation.completed", 500, 500],
-                ]
-            )
-        ]
+        _coverage_fixture(
+            {
+                "dictation.completed": [["2.6.0", 400, 400], ["2.7.0", 500, 500]],
+                "recording.cap_warning_shown": [["2.6.0", 3, 0]],
+            }
+        )
     )
     ph.dev_ids = ()
     observed_coverage = fetch_take_coverage(ph)
@@ -3261,13 +3280,39 @@ def run_self_test() -> int:
 
     # A subset larger than its set is impossible; it means the query or the parse
     # is wrong, and a wrong coverage number is worse than none.
-    ph, _ = _posthog_client([_posthog_response([["2.6.0", "dictation.completed", 5, 9]])])
+    ph, _ = _posthog_client(
+        _coverage_fixture({"asr.completed": [["2.6.0", 5, 9]]})
+    )
     ph.dev_ids = ()
     _expect_raises(ProtocolError, lambda: fetch_take_coverage(ph), "keyed exceeds total")
-    ph, _ = _posthog_client([_posthog_response([["2.6.0", "not.an.event", 5, 5]])])
+    # Wrong column count fails closed too — the per-event shape has 3, not 4.
+    ph, _ = _posthog_client(
+        _coverage_fixture({"asr.completed": [["2.6.0", "dictation.completed", 5, 5]]})
+    )
     ph.dev_ids = ()
-    _expect_raises(ProtocolError, lambda: fetch_take_coverage(ph), "unlisted event name")
-    passed("take coverage fails closed on an impossible subset or an unlisted event")
+    _expect_raises(ProtocolError, lambda: fetch_take_coverage(ph), "wrong column count")
+    passed("take coverage fails closed on an impossible subset or a malformed row")
+
+    # EVERY event must be queried. A dropped query would return no rows for that
+    # event, which the renderer prints as `not observed` — a missing query
+    # rendered as a real telemetry blackout.
+    ph, coverage_transport = _posthog_client(_coverage_fixture({}))
+    ph.dev_ids = ()
+    assert fetch_take_coverage(ph) == []
+    # Decode the body rather than `str(bytes)`: the repr escapes the single quotes
+    # the SQL uses, so the first version of this matcher found nothing and reported
+    # an empty list. A matcher that cannot match is not a check.
+    sent_queries = [
+        json.loads(request.body or b"{}")["query"]["query"]
+        for request in coverage_transport.seen
+    ]
+    queried = [
+        name for name in TAKE_KEYED_EVENTS
+        if any(f"event = '{name}'" in sql for sql in sent_queries)
+    ]
+    assert queried == list(TAKE_KEYED_EVENTS), queried
+    assert len(coverage_transport.seen) == len(TAKE_KEYED_EVENTS), len(coverage_transport.seen)
+    passed("take coverage queries every one of the 13 events, one bounded query each")
 
     # TRUNCATION. Measured 2026-07-30: PostHog caps a HogQL result at 100 rows and
     # sets `hasMore: true`. Every query in this file is an aggregate or a bounded
@@ -3278,7 +3323,7 @@ def run_self_test() -> int:
         200,
         {"Content-Type": "application/json"},
         json.dumps(
-            {"results": [["2.6.0", "dictation.completed", 400, 400]],
+            {"results": [["2.6.0", 400, 400]],
              "columns": [], "hasMore": True, "limit": 100, "offset": 0}
         ).encode(),
     )
@@ -3312,12 +3357,14 @@ def run_self_test() -> int:
     # Coverage counts USABLE join keys. A malformed non-empty value cannot join to
     # Sentry and the rate queries reject it, so counting it as covered would report
     # 100% for a key that joins nothing.
-    coverage_sql_probe, coverage_transport = _posthog_client(
-        [_posthog_response([["2.6.0", "dictation.completed", 5, 5]])]
+    coverage_sql_probe, coverage_sql_transport = _posthog_client(
+        _coverage_fixture({"asr.completed": [["2.6.0", 5, 5]]})
     )
     coverage_sql_probe.dev_ids = ()
     fetch_take_coverage(coverage_sql_probe)
-    coverage_sql = json.loads(coverage_transport.seen[0].body or b"{}")["query"]["query"]
+    coverage_sql = json.loads(
+        coverage_sql_transport.seen[0].body or b"{}"
+    )["query"]["query"]
     assert TAKE_ID_HOGQL_PATTERN in coverage_sql, coverage_sql
     assert "!= ''" not in coverage_sql, (
         "presence-only counting would report a malformed key as covered: " + coverage_sql

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -1574,9 +1574,15 @@ def fetch_take_rates(
     # itself and the rate was a structural 100% on every affected release — a
     # denominator drawn from its own numerator. The first version of the
     # arithmetic case froze that as `1/1`.
-    # Built once and reused by the population query and its completeness check.
+    # ELIGIBLE, not SUCCESSFUL. Plan section 5 defines the affected-user rate over
+    # "installs with >=1 ELIGIBLE take" — any of the 13 keyed events — while the
+    # TAKE-level rate above deliberately uses successful `dictation.completed`
+    # takes. One filter served both and quietly narrowed this denominator: an
+    # install with keyed VAD, invocation or failure events but no successful
+    # completion vanished from it, inflating the rate. The two populations are
+    # different by design and now have different filters.
     population_filter = f"""
-        event = '{SUCCESS_TAKE_EVENT}'
+        event IN ({sql_id_list(TAKE_KEYED_EVENTS)})
         AND {client.environment_clause()}
         AND properties.{TAKE_PROPERTY} IS NOT NULL
         AND properties.{TAKE_PROPERTY} != ''
@@ -1586,7 +1592,11 @@ def fetch_take_rates(
     population_rows, _ = client.query(
         f"""
         SELECT properties.app_version AS release,
-               uniqExact(distinct_id) AS successful_installs,
+               uniqExact(distinct_id) AS eligible_installs,
+               uniqExactIf(
+                   distinct_id,
+                   distinct_id IN ({sql_id_list(installs)})
+               ) AS affected_eligible_installs,
                countIf(
                    match(
                        toString(properties.{TAKE_PROPERTY}),
@@ -1599,13 +1609,14 @@ def fetch_take_rates(
         """,
         "take_rate_user_population",
     )
-    successful_install_counts: dict[str, int] = defaultdict(int)
+    eligible_install_counts: dict[str, int] = defaultdict(int)
+    affected_eligible_install_counts: dict[str, int] = defaultdict(int)
     for row in population_rows:
-        if len(row) != 3:
+        if len(row) != 4:
             raise ProtocolError(
-                f"take_rate_user_population: expected 3 columns, got {len(row)}"
+                f"take_rate_user_population: expected 4 columns, got {len(row)}"
             )
-        release_raw, successful_installs, invalid_take_rows = row
+        release_raw, eligible_installs, affected_eligible_installs, invalid_take_rows = row
         release = canonical_app_version(release_raw, "take_rate_user_population")
         # This query INDEPENDENTLY produces the affected-user denominator, so it
         # needs its own validity check — inheriting the bucket query's would be
@@ -1617,9 +1628,13 @@ def fetch_take_rates(
                 f"take_rate_user_population: rows on {release} carry a non-canonical "
                 "take_id — refusing to include fabricated take identities"
             )
-        successful_install_counts[release] += required_count(
-            successful_installs,
-            f"take_rate_user_population: successful_installs on {release}",
+        eligible_install_counts[release] += required_count(
+            eligible_installs,
+            f"take_rate_user_population: eligible_installs on {release}",
+        )
+        affected_eligible_install_counts[release] += required_count(
+            affected_eligible_installs,
+            f"take_rate_user_population: affected_eligible_installs on {release}",
         )
 
     # Independent identical-filter total for THIS grouped result. Without it a
@@ -1651,7 +1666,6 @@ def fetch_take_rates(
     per_release_affected: dict[str, int] = defaultdict(int)
     per_release_union: dict[str, int] = defaultdict(int)
     affected_installs: dict[str, set[str]] = defaultdict(set)
-    successful_affected_installs: dict[str, set[str]] = defaultdict(set)
 
     # Report only releases on which this fingerprint HAS an affected take. A
     # successful take on some other release is not a zero-rate row for this
@@ -1669,8 +1683,6 @@ def fetch_take_rates(
         per_release_union[release] += union
         if affected:
             affected_installs[release].add(install)
-        if successes[(install, release)]:
-            successful_affected_installs[release].add(install)
 
     # A checked loop, not a comprehension: the install arithmetic draws from two
     # SEPARATE query results, so it can produce an impossible pair that a
@@ -1678,21 +1690,24 @@ def fetch_take_rates(
     result: list[TakeRateRow] = []
     for release in sorted(per_release_union, key=version_key):
         affected_count = len(affected_installs[release])
-        successful_count = successful_install_counts[release]
-        overlap_count = len(successful_affected_installs[release])
+        eligible_population_count = eligible_install_counts[release]
+        # The overlap comes from the population query itself rather than from the
+        # bucket results, so both sides of the subtraction are drawn from the same
+        # eligible population — deriving it from `successes` would mix two filters.
+        overlap_count = affected_eligible_install_counts[release]
 
-        if overlap_count > successful_count:
+        if overlap_count > affected_count or overlap_count > eligible_population_count:
             raise ProtocolError(
-                f"affected-user rate on {release}: {overlap_count} affected installs "
-                f"also succeeded, but the population query returned only "
-                f"{successful_count} successful installs"
+                f"affected-user rate on {release}: affected/eligible overlap "
+                f"{overlap_count} exceeds affected={affected_count} or "
+                f"eligible={eligible_population_count}"
             )
 
-        # |affected ∪ successful| installs. Subtracting the installs counted on
-        # BOTH sides keeps an install that both failed and succeeded from being
+        # |affected ∪ eligible| installs. Subtracting the installs counted on BOTH
+        # sides keeps an install that is both affected and eligible from being
         # counted twice — the install-level twin of the take-level overlap
         # subtraction above.
-        eligible_count = affected_count + successful_count - overlap_count
+        eligible_count = affected_count + eligible_population_count - overlap_count
         if eligible_count < affected_count:
             raise ProtocolError(
                 f"affected-user rate on {release}: eligible denominator "
@@ -3190,11 +3205,11 @@ def run_self_test() -> int:
     )
     # Queue order: bucket rows, the bucket completeness total, then the
     # POPULATION query for the affected-user denominator.
-    ph, _ = _posthog_client(
+    ph, _rate_transport = _posthog_client(
         [
             _posthog_response([[install, "2.6.0", 10, 1, 0]]),
             _posthog_response([[1]]),
-            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([["2.6.0", 10, 1, 0]]),
             _posthog_response([[1]]),
         ]
     )
@@ -3208,6 +3223,24 @@ def run_self_test() -> int:
     # in this window, not the affected installs it contains. The first version of
     # this assertion read `== 1` and froze a structurally tautological 100%.
     assert rates[0].eligible_installs == 10, rates[0]
+    # THE POPULATION QUERY MUST SPAN ALL 13 EVENTS, not just successful
+    # completions. Plan section 5 defines this denominator over ELIGIBLE takes;
+    # scoping it to `dictation.completed` drops any install with keyed VAD,
+    # invocation or failure events but no successful completion, inflating the
+    # rate. Asserted on the emitted SQL because both forms return plausible
+    # numbers and only the query text distinguishes them.
+    population_sql = json.loads(
+        [r for r in _rate_transport.seen if b"take_rate_user_population" in (r.body or b"")][0]
+        .body or b"{}"
+    )["query"]["query"]
+    assert f"event IN ({sql_id_list(TAKE_KEYED_EVENTS)})" in population_sql, population_sql
+    assert f"event = '{SUCCESS_TAKE_EVENT}'" not in population_sql, population_sql
+    # The TAKE-level union keeps `dictation.completed` — a different population by
+    # design, and the bug was serving both from one filter.
+    bucket_sql = json.loads(
+        [r for r in _rate_transport.seen if b"take_rate_p0" in (r.body or b"")][0].body or b"{}"
+    )["query"]["query"]
+    assert f"event = '{SUCCESS_TAKE_EVENT}'" in bucket_sql, bucket_sql
     rate_lines = "\n".join(render_take_rates(rates, take_report.take_window, True))
     assert "2/11 takes affected (18.2%)" in rate_lines, rate_lines
     assert "1/10 installs affected" in rate_lines, rate_lines
@@ -3237,7 +3270,7 @@ def run_self_test() -> int:
         [
             _posthog_response([[install, "2.6.0", 2, 1, 0], [install, "2.7.0", 2, 1, 0]]),
             _posthog_response([[2]]),
-            _posthog_response([["2.6.0", 1, 0], ["2.7.0", 1, 0]]),
+            _posthog_response([["2.6.0", 1, 1, 0], ["2.7.0", 1, 1, 0]]),
             _posthog_response([[2]]),
         ]
     )
@@ -3283,7 +3316,7 @@ def run_self_test() -> int:
         [
             _posthog_response([[install, "2.6.0", 10, 1, 0]]),
             _posthog_response([[2]]),
-            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([["2.6.0", 10, 1, 0]]),
             _posthog_response([[1]]),
         ]
     )
@@ -3318,7 +3351,7 @@ def run_self_test() -> int:
         [
             _posthog_response([[install, "2.6.0", 10, 1, 0]]),
             _posthog_response([[1]]),
-            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([["2.6.0", 10, 1, 0]]),
             _posthog_response([[1]]),
         ]
     )
@@ -3368,7 +3401,7 @@ def run_self_test() -> int:
         [
             _posthog_response([[install, "2.6.0", 10, 1, 1]]),
             _posthog_response([[1]]),
-            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([["2.6.0", 10, 1, 0]]),
             _posthog_response([[1]]),
         ]
     )
@@ -3385,7 +3418,7 @@ def run_self_test() -> int:
         [
             _posthog_response([[install, "2.6.0", 10, 1, 0]]),
             _posthog_response([[1]]),
-            _posthog_response([["2.6.0", 10, 3]]),
+            _posthog_response([["2.6.0", 10, 1, 3]]),
             _posthog_response([[1]]),
         ]
     )
@@ -3404,7 +3437,7 @@ def run_self_test() -> int:
         [
             _posthog_response([[install, "2.6.0", 10, 1, 0]]),
             _posthog_response([[1]]),
-            _posthog_response([["2.6.0", 10, 0]]),
+            _posthog_response([["2.6.0", 10, 1, 0]]),
             _posthog_response([[2]]),
         ]
     )
@@ -3415,13 +3448,15 @@ def run_self_test() -> int:
         "truncated population buckets",
         "received 1 release buckets",
     )
-    # And an impossible pair across the two result sets is refused rather than
-    # returned: more affected-and-successful installs than successful installs.
+    # And an impossible pair WITHIN the population result is refused rather than
+    # returned: more affected-and-eligible installs than eligible installs. Both
+    # numbers come from the same query, so this can only mean a parse or query
+    # defect — and it would produce a denominator below its own numerator.
     ph, _ = _posthog_client(
         [
             _posthog_response([[install, "2.6.0", 10, 1, 0]]),
             _posthog_response([[1]]),
-            _posthog_response([["2.6.0", 0, 0]]),
+            _posthog_response([["2.6.0", 0, 1, 0]]),
             _posthog_response([[1]]),
         ]
     )
@@ -3429,8 +3464,8 @@ def run_self_test() -> int:
     _expect_raises(
         ProtocolError,
         lambda: fetch_take_rates(ph, take_report),
-        "affected-and-successful exceeds successful",
-        "affected installs",
+        "affected-eligible overlap exceeds the eligible population",
+        "exceeds affected=",
     )
     passed("the affected-user denominator fails closed on truncation or an impossible pair")
 

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -1439,6 +1439,19 @@ def fetch_take_rates(
 
     rate = distinct AFFECTED take IDs / |affected ∪ successful| takes, per release.
 
+    TWO DIFFERENT POPULATIONS, deliberately, per plan §5:
+      - The TAKE rate is CONDITIONAL on affected installs — the plan scopes its
+        denominator to "the same install, release and window", so it answers
+        "among people who hit this, how much of their dictation failed". It is
+        NOT a fleet-wide share and the render says so explicitly.
+      - The affected-USER rate is POPULATION-WIDE, over every install carrying an
+        eligible take on that release.
+    A whole-diff review argued the take rate should also be population-wide. That
+    is a defensible but DIFFERENT metric, and changing an approved metric on a
+    reviewer's say-so is plan expansion, so it is recorded as a founder question
+    rather than silently swapped. What was genuinely wrong — the render calling
+    this an upper bound on the POPULATION rate — is fixed.
+
     SQL computes the case-normalized successful-set cardinality and its overlap
     with the affected IDs, without shipping every successful take ID back — this
     install's `dictation.completed` takes could number in the thousands over the
@@ -1874,7 +1887,14 @@ def render_take_rates(
     lines.append(
         "  The affected Sentry takes retain the original boundary events. Because "
         "the success window cannot extend beyond them and may exclude boundary "
-        "successes, this is an UPPER BOUND on the population rate."
+        "successes, this take rate is an UPPER BOUND."
+    )
+    lines.append(
+        "  SCOPE: the take rate is CONDITIONAL on installs this fingerprint "
+        "affected — its denominator is those installs' own takes (plan §5). Read it "
+        "as \"among people who hit this, how much of their dictation failed\", NOT "
+        "as a fleet-wide share. The installs-affected figure beside it IS "
+        "population-wide, over every install carrying an eligible take."
     )
     for row in rates:
         rate = row.affected_takes / row.union_takes if row.union_takes else 0.0
@@ -3327,6 +3347,15 @@ def run_self_test() -> int:
     assert "2/11 takes affected (18.2%)" in rate_lines, rate_lines
     assert "1/10 installs affected" in rate_lines, rate_lines
     assert "UPPER BOUND" in rate_lines, "the window bias must be stated, not implied"
+    # The take rate is CONDITIONAL on affected installs (plan §5 scopes its
+    # denominator to "the same install"), while the installs figure beside it is
+    # population-wide. Printing them together without saying which is which reads
+    # the conditional number as a fleet-wide share — the render must name the scope.
+    assert "CONDITIONAL on installs this fingerprint" in rate_lines, rate_lines
+    assert "population-wide" in rate_lines, rate_lines
+    assert "UPPER BOUND on the population rate" not in rate_lines, (
+        "the take rate is not a population rate: " + rate_lines
+    )
     passed("a take on both sides is counted once, over a denominator that is not itself")
 
     # Overlap is RELEASE-scoped. A partition-wide take-id list let a take affected

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -756,6 +756,27 @@ class PostHogClient:
                 results = payload.get("results")
                 if not isinstance(results, list):
                     raise ProtocolError(f"query {name}: response has no `results` array")
+                # TRUNCATION IS THE ONE FAILURE THIS INSTRUMENT CANNOT SEE IN ITS
+                # OWN OUTPUT. PostHog caps a HogQL result at 100 rows and reports
+                # it — MEASURED 2026-07-30: `SELECT number FROM numbers(200000)`
+                # returns 100 rows with `hasMore: true, limit: 100`. A truncated
+                # DISTINCT id list silently drops installs from an exclusion; a
+                # truncated grouped result silently reads as an absent bucket, which
+                # this tool renders as `not observed` or as zero. Both are confident
+                # wrong answers of exactly the kind it exists to prevent.
+                #
+                # Enforced HERE, once, rather than as a per-query completeness check:
+                # the server is authoritative about its own truncation, it costs no
+                # extra query, and no future caller can forget it. Every query in
+                # this file is either an aggregate or a bounded id list, so `hasMore`
+                # is always a defect, never an expected paging signal.
+                if payload.get("hasMore") is True:
+                    raise IncompleteError(
+                        f"query {name}: PostHog truncated the result "
+                        f"(limit={payload.get('limit')}, offset={payload.get('offset')}, "
+                        f"hasMore=true). Refusing to measure from a partial result — "
+                        "narrow the query, partition it, or aggregate server-side."
+                    )
                 rows: list[list[object]] = []
                 for row in results:
                     if not isinstance(row, list):
@@ -1359,18 +1380,24 @@ def fetch_take_coverage(client: PostHogClient) -> list[TakeCoverageRow]:
     "is the take key actually landing on this event," which wants the widest view
     available, not one fingerprint's slice.
 
-    `take_id` is tested for NULL *and* empty string. The emitters use
-    omit-when-nil so a missing key is absent rather than blank, but a future
-    caller passing `""` would otherwise be counted as covered — the one way this
-    metric could report success while shipping nothing.
+    Coverage counts only CANONICAL take ids, using the same pattern the rate
+    queries reject on. Testing merely for NULL-or-empty would report an emitter
+    that regressed to a malformed non-empty value as fully covered, while that
+    value cannot join to Sentry at all and the rate queries refuse it — coverage
+    would say 100% for a key that joins nothing. What is measured here is a
+    USABLE join key, not the presence of a property.
     """
     rows, _ = client.query(
         f"""
         SELECT properties.app_version AS release,
                event AS event_name,
                count() AS total,
-               countIf(properties.{TAKE_PROPERTY} IS NOT NULL
-                       AND properties.{TAKE_PROPERTY} != '') AS with_take
+               countIf(
+                   match(
+                       toString(properties.{TAKE_PROPERTY}),
+                       '{TAKE_ID_HOGQL_PATTERN}'
+                   ) = 1
+               ) AS with_take
         FROM events
         WHERE event IN ({sql_id_list(TAKE_KEYED_EVENTS)})
           AND {client.environment_clause()}
@@ -3184,6 +3211,61 @@ def run_self_test() -> int:
     ph.dev_ids = ()
     _expect_raises(ProtocolError, lambda: fetch_take_coverage(ph), "unlisted event name")
     passed("take coverage fails closed on an impossible subset or an unlisted event")
+
+    # TRUNCATION. Measured 2026-07-30: PostHog caps a HogQL result at 100 rows and
+    # sets `hasMore: true`. Every query in this file is an aggregate or a bounded
+    # id list, so `hasMore` can only mean a partial answer — and a partial answer
+    # here renders as `not observed`, as `unset`, or as zero, none of which is
+    # distinguishable from the real thing in the output.
+    truncated = HTTPResponse(
+        200,
+        {"Content-Type": "application/json"},
+        json.dumps(
+            {"results": [["2.6.0", "dictation.completed", 400, 400]],
+             "columns": [], "hasMore": True, "limit": 100, "offset": 0}
+        ).encode(),
+    )
+    ph, _ = _posthog_client([truncated])
+    ph.dev_ids = ()
+    _expect_raises(
+        IncompleteError,
+        lambda: fetch_take_coverage(ph),
+        "truncated coverage result",
+        "PostHog truncated the result",
+    )
+    # The guard lives on the CLIENT, so it covers every caller — including the
+    # unbounded dev-id list, whose own truncation would silently let dev installs
+    # survive the production exclusion and contaminate every total.
+    ph, _ = _posthog_client([truncated])
+    _expect_raises(
+        IncompleteError, lambda: ph.resolve_dev_ids(), "truncated dev-id list",
+        "PostHog truncated the result",
+    )
+    # `hasMore: false` and an absent key are both legitimate complete results.
+    for flag in (False, None):
+        payload: dict[str, object] = {"results": [[1]], "columns": []}
+        if flag is not None:
+            payload["hasMore"] = flag
+        ph, _ = _posthog_client(
+            [HTTPResponse(200, {"Content-Type": "application/json"}, json.dumps(payload).encode())]
+        )
+        assert ph.query("SELECT 1", "complete") == ([[1]], []), flag
+    passed("a truncated PostHog result fails closed for every query, not just some")
+
+    # Coverage counts USABLE join keys. A malformed non-empty value cannot join to
+    # Sentry and the rate queries reject it, so counting it as covered would report
+    # 100% for a key that joins nothing.
+    coverage_sql_probe, coverage_transport = _posthog_client(
+        [_posthog_response([["2.6.0", "dictation.completed", 5, 5]])]
+    )
+    coverage_sql_probe.dev_ids = ()
+    fetch_take_coverage(coverage_sql_probe)
+    coverage_sql = json.loads(coverage_transport.seen[0].body or b"{}")["query"]["query"]
+    assert TAKE_ID_HOGQL_PATTERN in coverage_sql, coverage_sql
+    assert "!= ''" not in coverage_sql, (
+        "presence-only counting would report a malformed key as covered: " + coverage_sql
+    )
+    passed("take coverage counts canonical take ids, not merely non-empty ones")
 
     # THE UNION ARITHMETIC. A take on BOTH sides is counted once: two failed
     # takes, ten successful takes, one of which is the same take, is a union of


### PR DESCRIPTION
Closes #1846.

Sentry and PostHog shared no field, so no error could be tied to the same person's usage and nothing said which dictation an error belonged to. Two wrong diagnoses this month came from that gap (#1788, #1809).

**Go-live: the release cut Saturday 2026-08-01**, staged as v2.4.2. Forward-only — no historical event gains either key.

## What ships

**Phase 1 — which install.** Sentry events carry `analytics.distinct_id`, whose value IS PostHog's anonymous install id. Additive; Sentry's own `user.id` remains a separate, separately-labelled population.

**Phase 2 — which dictation.** The kernel's existing `SessionID` is projected into ephemeral telemetry state and routed to 13 PostHog events plus the Sentry scope tag `dictation.take_id`. No new identity is minted, nothing is persisted, and `Transcript.id` is deliberately NOT unified with it (§14 fork 3).

Three events are deliberately excluded, each for its own reason: `dictation.canceled` (can fire with no live take), `pipeline.failed` (session config already nil at emit), `audio.dead_mic_recovery` (spans two takes by design).

**The instrument.** `scripts/telemetry-join.py` joins one fingerprint to PostHog: people-not-events per release, retry-burst detection, per-install configuration and that install's own success record, per-event take coverage, the fingerprint take rate and the affected-user rate. Fails closed before printing any number.

## Two pre-existing defects fixed

**13.6% of the fleet would have been invisible.** The acceptance predicate took lowercase-only ids; 94 of 692 production installs carry an UPPERCASE `distinct_id`, because the PostHog SDK lowercases only ids it MINTS and returns a PERSISTED id unchanged. Those installs would have had no tag, and the absence is indistinguishable from "PostHog init was skipped". Found by querying production, not by reading code — the comment justifying the rejection asserted a vendor behaviour that measurement contradicts. This machine's own dev install is one of the 94, so the live protocol's first step would have failed.

**Five of seven terminals never cleared `recording.active`.** Errors raised long after a recording ended still claimed one was active. Replaced with one generic terminal postamble; visible in production data, where pre-change events report `active=true` outside recording and post-change events report `false`.

## Verified live, not only by fixtures

Run on the dev build against both vendors' development environments (§11.2):

- One dictation, 8 events, all carrying the same take key; every non-dictation event carrying none.
- A mid-take error carries BOTH keys, and its `analytics.distinct_id` is byte-identical to PostHog's install id for the same machine.
- That error's take key resolves to 5 PostHog events: invoked, VAD ran, dead-mic retire fired, never completed — the whole story from one error.
- A crash 6s into a live recording carries that recording's key (`55F82071…`, matching the app log's own session id) with `recording.active=true`. Its PostHog side shows invoked + VAD and no completion — the correct signature of a recording killed partway.
- Two idle crashes carry no take key and `recording.active=false`; one landed one second after a terminal, so the postamble had already cleared it.
- Five recordings produced five distinct keys, no bleed.
- The instrument ran end to end against live PRODUCTION: 127 coverage cells, 0 of 186,887 rows keyed — correct today, and reported as `not observed` rather than a fabricated percentage.

## Measured against the live API before building on it

`toUnixTimestamp64Milli`, `uniqExactIf`, `match` and four others verified to exist — the self-test runs on fixtures, so a non-existent function would have passed every case and failed only in production. PostHog's 100-row result cap confirmed (`hasMore: true`), and the coverage grid measured at **127 rows today**, already over it: the report would have aborted on its first real run.

## Validation

- `scripts/xcode-test.sh` — 4290 + 179 tests, `** TEST SUCCEEDED **`
- `swift build`, plus both standalone eval packages (`apple_runner`, `alias_runner`)
- `telemetry-join.py --self-test` — 60 cases, 0 failures (baseline 39)
- 21 negative controls across the epic, each in its own call, each restored and checksum-verified, each classified as a real assertion failure rather than a crash or an exhausted fixture. Three initially fired for the wrong reason and were rewritten until the failure was specific to the guard.
- Chunked build: 12 chunks, each to `CHUNK-CLEAN`; final integration audit; 7 whole-diff review rounds to clean.

## Two open questions for the founder, recorded not built

1. **Take-rate scope.** The plan scopes the take rate's denominator to affected installs ("on the same install"), making it conditional rather than fleet-wide. A reviewer argued for population-wide. Both are defensible; the approved plan wins, and the report now states the scope of each figure explicitly.
2. **Configuration recency.** Per-install configuration is reconstructed by the documented method — latest snapshot plus later changes — so it is CURRENT, not as-of-the-failure. Scoping it per release and capping at the failure timestamp is a better diagnostic and a new capability. The report now says which it is.

A third, surfaced by the founder: a **retroactive install-level bridge** is possible. Every Sentry event already carries a stable per-machine `user.id`; post-release events carry both that and the PostHog id, so one new event maps a machine and unlocks its older events. Demonstrated (one event linked 21 older ones). Recorded in `sentry-operations.md`; not built.
