### PR TITLE
feat(audio): zero-signal refusals record why they were refused (#1578)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/WedgeRecoveryRouter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/WedgeRecoveryRouter.swift
@@ -24,6 +24,19 @@ final class WedgeRecoveryRouter {
       guard let self, self.isCurrentSession(ctx.sessionID) else { return }
       self.resolveActiveTelemetryTarget()?.handleCaptureStall(ctx)
     }
+
+    // #1578: the same stale-session funnel, but delivery-aware. The stall
+    // callback above returns `Void`, so a stale drop or an unresolved target
+    // is invisible to the producer and the observation is simply lost. This
+    // one answers: `true` only once the target's method has actually been
+    // called, so a `false` tells the capture manager to keep the context for a
+    // terminal drain instead of discarding it.
+    audioCapture.onZeroSignalRefused = { [weak self] context in
+      guard let self, self.isCurrentSession(context.sessionID) else { return false }
+      guard let target = self.resolveActiveTelemetryTarget() else { return false }
+      target.handleZeroSignalRefusal(context)
+      return true
+    }
   }
 
 }

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -92,18 +92,48 @@ public protocol AudioCaptureInterface: AnyObject {
   /// treat a `deviceID` match alone as identity — that is what `deviceUID` is for.
   var zeroSignalDiscriminatorDevice: BoundInputDevice? { get }
 
-  /// #1317 (cloud review round 2, P2; scope narrowed round 3, P2): true
-  /// once a reactive zero-signal check observed a candidate buffer,
-  /// somewhere in the CURRENT trailing all-zero run, while the device was
-  /// ineligible (muted). The kernel's STOP-time backstop must fail closed
-  /// once this is true even if the device's LIVE state has since become
-  /// eligible (the user unmuted right before releasing does not undo that
-  /// THAT silent stretch was genuinely muted) — but scoped to the current
-  /// run only, so an earlier resolved mute elsewhere in the same recording
-  /// can't blind the backstop to a later, unrelated genuine failure.
-  /// Default `false` — conformers with no reactive per-buffer detector
-  /// (there is nothing to observe) correctly never set it.
+  /// #1317, superseded as a consumer surface by #1578: a COMPATIBILITY VIEW of
+  /// whether the CURRENT trailing all-zero run has a categorical refusal reason.
+  /// True once the reactive check refused a candidate buffer somewhere in that
+  /// run, for ANY of the classifier's five non-eligible reasons — not mute alone.
+  ///
+  /// Scoped to the current run: a non-zero sample that breaks the trailing zero
+  /// run clears it, so an earlier refusal elsewhere in the same recording cannot
+  /// blind a later, unrelated genuine failure.
+  ///
+  /// `AudioCaptureManager` DERIVES this from `zeroSignalRefusalReason`; it is not
+  /// independent storage. New code reads the reason and the
+  /// reactively-classified flag below instead — the kernel's STOP path no longer
+  /// consults this at all. Default `false` for conformers with no reactive
+  /// per-buffer detector, which have nothing to observe.
   var zeroSignalDiscriminatorSawIneligible: Bool { get }
+
+  /// #1578: WHY the current trailing zero run was refused, or `nil` when the
+  /// run has no refusal. The compatibility view above answers only THAT a
+  /// refusal happened; this carries the categorical reason, which is the fact
+  /// #1578 exists to stop discarding.
+  var zeroSignalRefusalReason: ZeroSignalEligibility? { get }
+
+  /// #1578: whether the CURRENT zero run was already classified by the reactive
+  /// producer. This — never forwarding success — is what suppresses a second
+  /// STOP-time classification of the same run.
+  var zeroSignalRunWasClassifiedReactively: Bool { get }
+
+  /// #1578: one forward attempt per refused run. `true` means the observation
+  /// was delivered immediately; `false` means the consumer rejected it (stale
+  /// session, no active target) and the producer must enqueue the context in
+  /// its per-session backlog exactly once.
+  var onZeroSignalRefused: ((ZeroSignalRefusalContext) -> Bool)? { get set }
+
+  /// #1578: ATOMIC take-and-clear of the pending refusal backlog, MainActor.
+  /// Returns every rejected context and empties the backlog in ONE synchronous
+  /// step, so a second caller — including a cancel landing while `stopCapture()`
+  /// is suspended — gets an empty array rather than a duplicate. Callers MUST
+  /// invoke it before any `await` and before the session FSM returns to idle.
+  ///
+  /// NOT `mutating`: this protocol is class-bound (`: AnyObject`, line 7), and
+  /// Swift rejects a `mutating` method declared in a class-bound protocol.
+  func takePendingZeroSignalRefusals() -> [ZeroSignalRefusalContext]
 
   // Configuration properties (read-write)
   var selectedInputDeviceUID: String { get set }
@@ -178,11 +208,79 @@ extension AudioCaptureInterface {
   /// overrides it with the bind its own `prepare()` returned (#1844).
   public var zeroSignalDiscriminatorDevice: BoundInputDevice? { nil }
 
-  /// #1317 (cloud review round 2, P2): default `false` — test fakes and
-  /// simulator doubles have no reactive per-buffer detector, so nothing to
-  /// latch. `AudioCaptureManager` overrides it with its own session-scoped
-  /// latch (ported in-process at #1543).
+  /// #1317: default `false` — test fakes and simulator doubles have no reactive
+  /// per-buffer detector, so no run of theirs can carry a refusal reason.
+  /// `AudioCaptureManager` overrides it with a value DERIVED from the current
+  /// run's categorical reason (#1578), never with separate storage.
   public var zeroSignalDiscriminatorSawIneligible: Bool { false }
+
+  /// #1578: no reactive per-buffer detector means no refusal reason to report.
+  public var zeroSignalRefusalReason: ZeroSignalEligibility? { nil }
+
+  /// #1578: same reasoning — a conformer with no reactive classifier never
+  /// classified the current run, so STOP-time classification stays permitted.
+  public var zeroSignalRunWasClassifiedReactively: Bool { false }
+
+  /// #1578: an explicit `get { nil } set {}` pair, NOT the read-only computed
+  /// shape the two properties above use. A settable protocol requirement cannot
+  /// be satisfied by a getter alone, so copying that shape here would not
+  /// compile. Assignment through an existential is accepted and discarded.
+  public var onZeroSignalRefused: ((ZeroSignalRefusalContext) -> Bool)? {
+    get { nil }
+    set {}
+  }
+
+  /// #1578: a conformer with no backlog has nothing to hand over. Synchronous
+  /// and non-`mutating`, matching the requirement.
+  public func takePendingZeroSignalRefusals() -> [ZeroSignalRefusalContext] {
+    []
+  }
+}
+
+/// #1578: the observation a refused zero run produces — the reason plus the
+/// minimum context needed to make it countable by transport and failure shape.
+/// Lives in `EnviousWisprAudio` beside the protocol that carries it, not in
+/// Core, which this change deliberately leaves untouched.
+public struct ZeroSignalRefusalContext: Sendable, Equatable {
+  public let sessionID: UInt64
+  public let reason: ZeroSignalEligibility
+  public let transport: String
+  public let failureShape: CaptureStallFailureMode
+
+  public init(
+    sessionID: UInt64,
+    reason: ZeroSignalEligibility,
+    transport: String,
+    failureShape: CaptureStallFailureMode
+  ) {
+    self.sessionID = sessionID
+    self.reason = reason
+    self.transport = transport
+    self.failureShape = failureShape
+  }
+}
+
+/// #1578: what the kernel's STOP-time seam returns — the classification plus
+/// the one fact that decides whether STOP may classify the run again.
+public struct ZeroSignalDecisionSnapshot: Sendable, Equatable {
+  public let eligibility: ZeroSignalEligibility
+
+  /// Whether the CURRENT run was already classified reactively — NOT whether
+  /// its first forward succeeded. A rejected forward is emitted from the
+  /// backlog, so a forwarding-success discriminator would invite STOP to emit
+  /// it a second time.
+  ///
+  /// This snapshot deliberately carries NO backlog: consumption belongs to the
+  /// atomic take-and-clear, and two owners of one queue is a defect.
+  public let currentRunWasClassifiedReactively: Bool
+
+  public init(
+    eligibility: ZeroSignalEligibility,
+    currentRunWasClassifiedReactively: Bool
+  ) {
+    self.eligibility = eligibility
+    self.currentRunWasClassifiedReactively = currentRunWasClassifiedReactively
+  }
 }
 
 /// Heartpath 5b (#1520): the observational outcome of `retireCapturingSource`.

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -55,19 +55,74 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   public var zeroSignalDiscriminatorDevice: BoundInputDevice? { effectiveDiscriminatorDevice }
 
   /// #1317 (ported in-process from the former app-side capture proxy at the C1
-  /// collapse, #1543): true once the CURRENT trailing all-zero run has been observed
-  /// while the device discriminator was ineligible (muted/mute-unknown). The
-  /// kernel's STOP-time backstop reads this guard-first so a genuinely-muted
-  /// silent stretch is not misread as the harness glitch just because the user
-  /// unmuted right before releasing. Scoped to the current run, not
-  /// session-wide: a non-zero sample that breaks the trailing zero-run clears
-  /// it (`feedDeadAirDetector`), so an earlier resolved mute cannot blind the
-  /// backstop to a later, unrelated genuine zero-signal failure. Reset in
+  /// collapse, #1543): WHY the CURRENT trailing all-zero run was refused by the
+  /// device discriminator. The kernel's STOP-time backstop reads this guard-first
+  /// so a refused silent stretch is not later misclassified as the harness glitch.
+  /// Scoped to the current run, not session-wide: a non-zero sample that breaks
+  /// the trailing zero run clears it, so an earlier resolved refusal cannot blind
+  /// the backstop to a later, unrelated genuine zero-signal failure. Reset in
   /// `beginCapturePhase`; per the `effectiveDiscriminatorDevice` invariant no
   /// teardown path may clear it early.
-  private var sawIneligibleZeroSignalDuringSession = false
+  ///
+  /// #1578 replaces the former Boolean latch with its categorical reason, so WHY
+  /// and whether a refusal happened cannot drift apart.
+  private var currentZeroSignalRefusalReason: ZeroSignalEligibility?
 
-  public var zeroSignalDiscriminatorSawIneligible: Bool { sawIneligibleZeroSignalDuringSession }
+  /// #1578: whether the CURRENT zero run has already produced its reactive refusal
+  /// observation. Classification still runs on every candidate batch so a later
+  /// `.eligible` verdict preserves the shipping stall behavior. This flag suppresses
+  /// only duplicate refusal forwarding, backlog admission, and STOP-time
+  /// reclassification. Forwarding acceptance never controls it.
+  private var currentRunWasClassifiedReactively = false
+
+  /// #1578: refusal contexts whose one forward attempt was REJECTED (no
+  /// subscriber, or a stale-session rejection). Per SESSION, not per run:
+  /// clearing this on non-zero recovery would erase a refusal that genuinely
+  /// happened just because the microphone came back. Drained atomically at a
+  /// terminal.
+  private var pendingZeroSignalRefusals: [ZeroSignalRefusalContext] = []
+
+  public var zeroSignalDiscriminatorSawIneligible: Bool {
+    currentZeroSignalRefusalReason != nil
+  }
+
+  public var zeroSignalRefusalReason: ZeroSignalEligibility? {
+    currentZeroSignalRefusalReason
+  }
+
+  public var zeroSignalRunWasClassifiedReactively: Bool {
+    currentRunWasClassifiedReactively
+  }
+
+  /// #1578: the manager MUST store this itself. The protocol extension's default
+  /// is an explicit no-op setter for conformers with no reactive detector, so
+  /// inheriting it here would silently swallow the production subscriber.
+  public var onZeroSignalRefused: ((ZeroSignalRefusalContext) -> Bool)?
+
+  /// #1578: ONE owner for the three fields above, so a future third reset point
+  /// cannot clear two of them and miss the other.
+  ///
+  /// `clearBacklog` is the entire difference between the two call sites, and it
+  /// is load-bearing: session start clears everything, while non-zero recovery
+  /// clears only the current-run facts. A recovery that also emptied the backlog
+  /// would delete a rejected refusal for the very reason it should be kept — the
+  /// microphone started working again.
+  private func resetZeroSignalState(clearBacklog: Bool) {
+    currentZeroSignalRefusalReason = nil
+    currentRunWasClassifiedReactively = false
+    if clearBacklog {
+      pendingZeroSignalRefusals.removeAll(keepingCapacity: true)
+    }
+  }
+
+  /// #1578: ATOMIC take-and-clear. Synchronous and MainActor-isolated, so a
+  /// second caller — a cancel landing while `stopCapture()` is suspended — gets
+  /// an empty array instead of a duplicate. Append order is preserved.
+  public func takePendingZeroSignalRefusals() -> [ZeroSignalRefusalContext] {
+    let pending = pendingZeroSignalRefusals
+    pendingZeroSignalRefusals.removeAll(keepingCapacity: true)
+    return pending
+  }
 
   /// Current audio level (0.0 - 1.0) for waveform visualization.
   public private(set) var audioLevel: Float = 0.0
@@ -466,7 +521,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
     // Reset per-session reactive dead-air + stall-latch state (#1317 / #1543).
     deadAirDetector = DeadAirStreamingDetector()
-    sawIneligibleZeroSignalDuringSession = false
+    // #1578: session start is the ONE place the backlog is cleared without a
+    // consumer having taken it — a new session must never inherit the previous
+    // one's undelivered refusals.
+    resetZeroSignalState(clearBacklog: true)
     captureStallReported = false
     #if DEBUG
       didLogZeroPrefixThisSession = false
@@ -1129,12 +1187,12 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   /// Feed this batch's raw samples into the per-generation all-zero
   /// harness-glitch detector; when it crosses a confidence threshold, run the
-  /// §3.0 device-alive + not-muted discriminator and — only if it passes —
-  /// fire `onCaptureStalled` with the matching failure mode. A muted or
-  /// mute-unknown device fails closed: no fire, today's honest no-speech path
-  /// is untouched, the trailing-zero-run latch is set so the kernel's STOP-time
-  /// backstop stays fail-closed, and the next batch re-evaluates (mute state
-  /// can legitimately change mid-recording). MainActor-isolated (called from
+  /// §3.0 device discriminator and — only if it returns `.eligible` — fire
+  /// `onCaptureStalled` with the matching failure mode. Any of the five
+  /// non-eligible reasons fails closed: no fire, today's honest no-speech path
+  /// is untouched, the run's reason is frozen so the kernel's STOP-time backstop
+  /// stays fail-closed, and the next batch re-evaluates (device state can
+  /// legitimately change mid-recording). MainActor-isolated (called from
   /// `ingestSamples`), so the detector is never mutated off the consumer thread.
   private func feedDeadAirDetector(_ samples: [Float]) {
     guard !deadAirDetector.fired, !captureStallReported, !samples.isEmpty else { return }
@@ -1142,11 +1200,14 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     samples.withUnsafeBufferPointer { deadAirDetector.ingest($0) }
     // A non-zero sample anywhere in this batch breaks the trailing zero-run —
     // `consecutiveExactZeroSuffix` after ingest is then strictly less than
-    // `suffixBefore + samples.count`. Any earlier ineligible (muted) result
-    // applied to THAT run, not this new one, so it must not suppress detection
-    // of a later, unrelated zero-signal failure.
+    // `suffixBefore + samples.count`. Any earlier refusal applied to THAT run,
+    // not this new one, so it must not suppress detection of a later, unrelated
+    // zero-signal failure.
     if deadAirDetector.consecutiveExactZeroSuffix != suffixBefore + samples.count {
-      sawIneligibleZeroSignalDuringSession = false
+      // #1578: current-run facts only. Anything already REJECTED stays in the
+      // backlog — the run it described really happened, and recovery does not
+      // undo it.
+      resetZeroSignalState(clearBacklog: false)
     }
     #if DEBUG
       emitZeroPrefixDiagnosticIfNeeded()
@@ -1164,15 +1225,46 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // Evaluate against the bind this attempt's `prepare()` RETURNED (#1844),
     // not a live re-read — the live UID properties can already reflect a device
     // the user switched to mid-recording, and a settings-derived value can name
-    // a microphone HAL never opened.
-    guard
-      let bound = effectiveDiscriminatorDevice,
-      ZeroSignalDeviceDiscriminator.isEligible(bound: bound)
-    else {
-      // A zero-signal-candidate batch observed while ineligible (muted) — latch
-      // it so the STOP-time backstop can't later see a since-unmuted live state
-      // and misclassify this genuinely-muted stretch as the harness glitch.
-      sawIneligibleZeroSignalDuringSession = true
+    // a microphone HAL never opened. The optional goes straight to the
+    // classifier: #1578 made it the single owner of the missing-bind outcome,
+    // so translating `nil` here would put that policy in two places.
+    let reason = ZeroSignalDeviceDiscriminator.classify(bound: effectiveDiscriminatorDevice)
+
+    guard reason == .eligible else {
+      // This candidate was refused for one of the classifier's five non-eligible
+      // reasons. Freeze the first reason so STOP cannot later reinterpret the run
+      // from a changed live device state.
+      //
+      // ONE observation per RUN, though the classification above still runs per
+      // BATCH. `feedDeadAirDetector` fires on every incoming batch and a zero run
+      // spans many of them; this flag — not callback success, not backlog
+      // membership, not either stall latch — is what silences the second and
+      // later refusals of the same run.
+      guard !currentRunWasClassifiedReactively else { return }
+
+      // Set BOTH fields before calling out: a subscriber that synchronously
+      // re-enters capture must find this run already classified.
+      currentZeroSignalRefusalReason = reason
+      currentRunWasClassifiedReactively = true
+
+      // Same authorities `fireDeadAirStall` uses for the same two facts — the
+      // detector-selected shape and the resolved effective transport — so the
+      // refusal event and the stall event can never disagree about a take.
+      let context = ZeroSignalRefusalContext(
+        sessionID: currentCaptureSessionID,
+        reason: reason,
+        transport: currentResolvedRoute?.effective ?? "unknown",
+        failureShape: mode
+      )
+      // ONE attempt. A missing subscriber and an explicit `false` are the same
+      // answer — not delivered — so the context is preserved for a terminal
+      // drain rather than lost. Note this deliberately sets neither
+      // `deadAirDetector.fired` nor `captureStallReported`: a refusal is an
+      // observation, and latching either one would suppress a later GENUINE
+      // failure in the same take.
+      if onZeroSignalRefused?(context) != true {
+        pendingZeroSignalRefusals.append(context)
+      }
       return
     }
 

--- a/Sources/EnviousWisprAudio/CoreAudioDeviceLiveness.swift
+++ b/Sources/EnviousWisprAudio/CoreAudioDeviceLiveness.swift
@@ -135,25 +135,66 @@ public enum CoreAudioDeviceMute {
   }
 }
 
-/// #1317 §3.0: the single, shared "is this device eligible for harness-glitch
-/// recovery" decision — device `.alive` AND NOT muted. Both the in-process
-/// reactive detector (`AudioCaptureManager`) and the kernel's STOP-time
-/// classification read through this ONE function so the discriminator has a
-/// single authority, not two independent alive+mute combinations.
+/// #1578: WHY the zero-signal discriminator answered as it did. The Boolean
+/// `isEligible` collapsed identity mismatch, not-alive, muted and mute-unknown
+/// into one `false`, so a refusal recorded no reason at all — which is the
+/// defect #1578 exists to close.
+///
+/// Diagnostic classification, NEVER a failure: only `.eligible` permits
+/// `fireDeadAirStall`, and every other case leaves the take on today's silent
+/// no-speech path unchanged.
+public enum ZeroSignalEligibility: String, Sendable, CaseIterable {
+  case eligible
+  /// No frozen bind to classify. A defensive invariant canary, not an ordinary
+  /// input: `startEnginePhase()` adopts the non-optional result of a successful
+  /// `prepare()` and no teardown path clears it, so this should never appear in
+  /// production — if it does, the invariant broke and that is itself the finding.
+  case boundDeviceUnavailable = "bound_device_unavailable"
+  /// The bind's UID is unknown, unreadable now, or no longer matches the live
+  /// UID for that `AudioDeviceID`. All three are one outcome because all three
+  /// mean the same thing operationally: we cannot prove this handle still names
+  /// the microphone we bound, so nothing CoreAudio says about it can be trusted.
+  case identityMismatch = "identity_mismatch"
+  /// Liveness answered anything other than `.alive` — including `.unverified`,
+  /// which fails closed per the #1317 binding decision.
+  case notAlive = "not_alive"
+  /// The input-scope mute read succeeded and reported muted. Trustworthy in this
+  /// direction only: `.unmuted` is NOT trustworthy (`gotchas-audio.md`).
+  case deviceMuted = "device_muted"
+  /// The mute property is absent, or the read returned non-`noErr`. "Cannot
+  /// tell" is a distinct answer from "not muted"; collapsing them was part of
+  /// the defect.
+  case muteUnverified = "mute_unverified"
+}
+
+/// #1317 §3.0, widened at #1578: the single authority for deciding whether
+/// the frozen capture device is eligible for harness-glitch recovery and, when
+/// it is not, why. Both the in-process reactive detector (`AudioCaptureManager`)
+/// and the kernel's STOP-time classification use this type, so identity,
+/// liveness, and input-scope mute precedence cannot drift between callers.
 public enum ZeroSignalDeviceDiscriminator {
   /// Production entry point. Public, with no default arguments or injected seams
   /// — a `public` function's default argument cannot reference the internal
   /// `AudioDeviceEnumerator.inputDeviceUID(for:)`, so the injected form is a
   /// separate `package` overload below rather than defaults on this one.
   ///
-  /// Fails closed: any non-`.alive` liveness or non-`.unmuted` mute state —
-  /// including `.unverified` — returns false. #1317 adds no hardware-mute
-  /// UX; ambiguity must never be read as "safe to run harness recovery."
+  /// Fails closed: an unverifiable identity, any non-`.alive` liveness, or any
+  /// non-`.unmuted` mute state returns false. `classify` below preserves the
+  /// categorical reason. #1317 adds no hardware-mute UX; ambiguity must never
+  /// be read as "safe to run harness recovery."
   ///
   /// Callers must pass the FROZEN bind (`prepare()`'s return value, #1844), never
   /// a freshly resolved device.
   public static func isEligible(bound: BoundInputDevice) -> Bool {
-    isEligible(
+    classify(bound: bound) == .eligible
+  }
+
+  /// #1578: the reason-bearing production entry point, and the sole owner of all
+  /// SIX outcomes — including the missing-bind case, which both call sites used
+  /// to manufacture independently (the very scatter this type's doc comment
+  /// forbids). Takes the OPTIONAL bind for exactly that reason.
+  public static func classify(bound: BoundInputDevice?) -> ZeroSignalEligibility {
+    classify(
       bound: bound,
       inputDeviceUID: AudioDeviceEnumerator.inputDeviceUID(for:),
       liveness: CoreAudioDeviceLiveness.classify(deviceID:),
@@ -170,6 +211,23 @@ public enum ZeroSignalDeviceDiscriminator {
     liveness: (AudioDeviceID) -> DeviceLiveness,
     muteState: (AudioDeviceID) -> DeviceMuteState
   ) -> Bool {
+    classify(
+      bound: bound, inputDeviceUID: inputDeviceUID, liveness: liveness, muteState: muteState)
+      == .eligible
+  }
+
+  /// #1578: the injected reason-bearing seam. Same evaluation order as the
+  /// Boolean form it now backs — identity, then liveness, then hardware mute
+  /// (#1844: a recycled `AudioDeviceID` makes every later answer describe the
+  /// wrong microphone, so identity must come first, and each refusal
+  /// short-circuits before the reads below it).
+  package static func classify(
+    bound: BoundInputDevice?,
+    inputDeviceUID: (AudioDeviceID) -> String?,
+    liveness: (AudioDeviceID) -> DeviceLiveness,
+    muteState: (AudioDeviceID) -> DeviceMuteState
+  ) -> ZeroSignalEligibility {
+    guard let bound else { return .boundDeviceUnavailable }
     // #1844: an AudioDeviceID is a runtime handle CoreAudio MAY reuse, so a
     // numeric match is not physical identity — liveness on a recycled id would
     // answer ALIVE about the WRONG microphone. Confirm the id still resolves to
@@ -178,7 +236,12 @@ public enum ZeroSignalDeviceDiscriminator {
     // NOTE: ID reuse is HYPOTHETICAL — never observed here. This guard is
     // retained as a fail-closed identity check, not because reuse was measured.
     guard let boundUID = bound.deviceUID, inputDeviceUID(bound.deviceID) == boundUID
-    else { return false }
-    return liveness(bound.deviceID) == .alive && muteState(bound.deviceID) == .unmuted
+    else { return .identityMismatch }
+    guard liveness(bound.deviceID) == .alive else { return .notAlive }
+    switch muteState(bound.deviceID) {
+    case .unmuted: return .eligible
+    case .muted: return .deviceMuted
+    case .unverified: return .muteUnverified
+    }
   }
 }

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -1,3 +1,4 @@
+import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
@@ -268,6 +269,38 @@ final class HeartPathTelemetryEmitter {
       msSinceLastGood: msSinceLastGood,
       routeFallbackReason: ctx.routeFallbackReason,
       takeID: ctx.takeID)
+  }
+
+  /// #1578: the zero-signal discriminator refused to fire recovery, and this
+  /// records why. Same content-free breadcrumb + PostHog fan-out as
+  /// `deadMicRetireAttempted` above, from ONE set of computed values so the two
+  /// sinks can never disagree.
+  ///
+  /// NO dedup here, deliberately. `stallFired` dedups because two independent
+  /// producers (the HAL watchdog and the raw-samples route) can observe the
+  /// SAME stall. Refusal cardinality is already enforced before the emitter:
+  /// the manager's per-run flag permits one reactive forward attempt, and STOP
+  /// emits only when that run was not classified reactively. Several zero runs
+  /// in one session are legitimately several events; emitter-side dedup would
+  /// suppress the later ones.
+  ///
+  /// Observational: a breadcrumb, never a `captureError`, so this raises no
+  /// Sentry issue and no alert.
+  func zeroSignalRefused(_ context: ZeroSignalRefusalContext) {
+    let reason = context.reason.rawValue
+    let transport = context.transport
+    let failureShape = context.failureShape.rawValue
+    addBreadcrumb(
+      "recording", "Zero signal refusal observed",
+      [
+        "reason": reason,
+        "transport": transport,
+        "failure_shape": failureShape,
+      ])
+    TelemetryService.shared.zeroSignalRefused(
+      reason: reason,
+      transport: transport,
+      failureShape: failureShape)
   }
 
   /// Heartpath 5b (#1520): a pending dead-mic watch resolved (a later take

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1214,6 +1214,18 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
     kernel.externalCaptureStalled(ctx)
   }
 
+  /// #1578: ONE arm, deliberately — the observer only.
+  ///
+  /// This is the asymmetry with `handleCaptureStall` directly above, and the
+  /// single easiest mistake in this change. A refusal means the discriminator
+  /// DECLINED to treat the silence as a harness glitch, so the take stays on
+  /// today's silent no-speech path. Calling `kernel.externalCaptureStalled`
+  /// here would latch a recording exit and turn an observability change into a
+  /// behaviour regression.
+  public func handleZeroSignalRefusal(_ context: ZeroSignalRefusalContext) {
+    observer.handleZeroSignalRefusal(context)
+  }
+
   // MARK: DEBUG
 
   #if DEBUG

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -480,6 +480,22 @@ public enum KernelDictationDriverFactory {
       stopTimeZeroSignalTelemetry: { ctx in
         emitter.stallFired(ctx: ctx, isActivelyCapturing: false)
       },
+      // #1578: the DELAYED path's only route to the emitter — both the drained
+      // backlog of rejected reactive refusals AND a STOP-time refusal for a run
+      // the reactive detector never classified. The immediate path (reactive →
+      // router → driver → observer) reaches the same method through its own
+      // wiring; without THIS line everything upstream still works and production
+      // emits nothing, with every other test green, because every other test
+      // drives the sink directly.
+      //
+      // One call per context, in order. The take returns an array; the emitter
+      // takes one context. Batching or de-duplicating here would silently
+      // undercount runs the producer already proved distinct.
+      zeroSignalRefusalSink: { contexts in
+        for context in contexts {
+          emitter.zeroSignalRefused(context)
+        }
+      },
       recordingStoppedTelemetry: { sampleCount in
         telemetryRelay.emitRecordingStopped(sampleCount: sampleCount)
       },

--- a/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
+++ b/Sources/EnviousWisprPipeline/KernelHeartPathTelemetryObserver.swift
@@ -132,9 +132,12 @@ final class KernelHeartPathTelemetryObserver {
 
   // MARK: Capture-diagnostic callbacks (the kernel does not consume these)
   //
-  // These three method names match `HeartPathTelemetryTarget`; the
-  // App-facing `KernelDictationDriver` conforms to that protocol and forwards
-  // its three methods here. The observer is the single telemetry brain.
+  // These method names match `HeartPathTelemetryTarget`; the App-facing
+  // `KernelDictationDriver` conforms to that protocol and forwards its two
+  // methods here. The observer is the single telemetry brain.
+  //
+  // The two are NOT symmetric, and the difference lives in the driver: a stall
+  // also reaches `kernel.externalCaptureStalled`, a refusal never does.
 
   /// Capture-stall telemetry. Reached through the driver's
   /// `HeartPathTelemetryTarget` conformance (PR-4 §3.9).
@@ -151,6 +154,14 @@ final class KernelHeartPathTelemetryObserver {
       captureRebuiltForFormat: stabilization.rebuiltForFormat
     )
     emitter.stallFired(ctx: enriched, isActivelyCapturing: audioCapture.isActivelyCapturing)
+  }
+
+  /// #1578: zero-signal refusal telemetry. A pure forward — unlike the stall
+  /// above it reads no kernel state, enriches nothing, and creates no error.
+  /// The context arrives complete from the capture layer, which is the only
+  /// layer that knows which device it classified.
+  func handleZeroSignalRefusal(_ context: ZeroSignalRefusalContext) {
+    emitter.zeroSignalRefused(context)
   }
 
   // MARK: Raw-state observation

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -190,4 +190,9 @@ public enum RecordingRecoveryEnding: Equatable, Sendable {
 @MainActor
 public protocol HeartPathTelemetryTarget: AnyObject {
   func handleCaptureStall(_ ctx: CaptureStallContext)
+
+  /// #1578: the zero-signal discriminator refused to fire capture-stall
+  /// recovery, and this is WHY. Observation only — unlike `handleCaptureStall`,
+  /// nothing on this path may move the recording state machine.
+  func handleZeroSignalRefusal(_ context: ZeroSignalRefusalContext)
 }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -275,23 +275,40 @@ final class RecordingSessionKernel {
   /// uses. The emitter's per-mode dedup makes a duplicate submission (both
   /// paths agreeing on the same session + mode) safe.
   private let stopTimeZeroSignalTelemetry: @MainActor (CaptureStallContext) -> Void
-  /// #1317 §3.0/§3.6: the STOP-time device-alive/not-muted discriminator,
+  /// #1317 §3.0/§3.6, widened at #1578: the STOP-time zero-signal decision,
   /// injected (not a direct `AudioDeviceEnumerator`/`ZeroSignalDeviceDiscriminator`
   /// call) so deterministic kernel tests can substitute a fake instead of
-  /// depending on the test machine's real microphone state. The production
-  /// default checks `audioCapture.zeroSignalDiscriminatorDevice` — the
-  /// device the CAPTURE LAYER's `prepare()` actually OPENED (#1844; only that
+  /// depending on the test machine's real microphone state.
+  ///
+  /// It returns a SNAPSHOT, not a Boolean, because STOP needs two facts and they
+  /// answer different questions. `eligibility` is the categorical reason — only
+  /// `.eligible` may reach the stall path, and every other case names WHY it did
+  /// not. `currentRunWasClassifiedReactively` says whether the reactive producer
+  /// already classified this run, which is what stops STOP re-classifying and
+  /// re-emitting the same run; it NEVER means the reactive forward was accepted,
+  /// because a rejected forward is emitted from the backlog instead.
+  ///
+  /// The production default reads `audioCapture.zeroSignalDiscriminatorDevice` —
+  /// the device the CAPTURE LAYER's `prepare()` actually OPENED (#1844; only that
   /// layer sees its own internal retries, so the kernel defers to it instead of
   /// independently freezing its own snapshot, which could still race a
-  /// mid-startup device switch or name a microphone HAL never opened).
-  /// Alive/mute status is still re-checked live against that frozen device
-  /// on every call — only the device IDENTITY is frozen, not its mute
-  /// state — EXCEPT that `zeroSignalDiscriminatorSawIneligible` (cloud
-  /// review round 2, second P2) short-circuits to ineligible if the device
-  /// was EVER seen muted during this session's own zero-signal candidate
-  /// buffers, so a since-unmuted live re-check can't override an earlier
-  /// genuine mute.
-  private let zeroSignalDeviceEligible: @MainActor () -> Bool
+  /// mid-startup device switch or name a microphone HAL never opened). Device
+  /// state is re-read live against that frozen identity — EXCEPT when the run was
+  /// already classified reactively, in which case the FROZEN reason wins, so a
+  /// device that has since become healthy cannot overwrite what was genuinely
+  /// observed during the silent stretch.
+  private let zeroSignalDecisionSnapshot: @MainActor () -> ZeroSignalDecisionSnapshot
+
+  /// #1578: where a zero-signal REFUSAL goes. Deliberately separate from
+  /// `stopTimeZeroSignalTelemetry` above: that one carries a
+  /// `CaptureStallContext` to the stall authority, and a refusal is not a stall.
+  ///
+  /// TWO producers feed it, and both matter. The terminal drain hands over the
+  /// backlog of reactive refusals whose forward was rejected; the STOP-time
+  /// branch hands over a single newly classified refusal for a run the reactive
+  /// path never saw. It takes an array because the atomic take returns one, and
+  /// the factory maps each element to exactly one emitted event.
+  private let zeroSignalRefusalSink: @MainActor ([ZeroSignalRefusalContext]) -> Void
   private let recordingStoppedTelemetry: @MainActor (_ sampleCount: Int) -> Void
 
   /// #1846: called SYNCHRONOUSLY the moment a session is accepted, before any
@@ -748,7 +765,8 @@ final class RecordingSessionKernel {
     // layer's `prepare()` actually opened (see that protocol property's doc for
     // why the kernel defers to it instead of independently resolving
     // `preferredInputDeviceIDOverride`/`selectedInputDeviceUID`).
-    zeroSignalDeviceEligible: (@MainActor () -> Bool)? = nil,
+    zeroSignalDecisionSnapshot: (@MainActor () -> ZeroSignalDecisionSnapshot)? = nil,
+    zeroSignalRefusalSink: @escaping @MainActor ([ZeroSignalRefusalContext]) -> Void = { _ in },
     recordingStoppedTelemetry: @escaping @MainActor (_ sampleCount: Int) -> Void = { _ in },
     sessionAcceptedTelemetry: @escaping @MainActor (_ takeID: String) -> Void = { _ in },
     markPipelineTimingStart: @escaping @MainActor () -> Void = {},
@@ -786,18 +804,36 @@ final class RecordingSessionKernel {
     // kernel cannot see) — instead of independently re-resolving
     // `preferredInputDeviceIDOverride`/`selectedInputDeviceUID`, which only
     // reflects the kernel's OWN view and can already differ from what actually
-    // got captured. Also checks `zeroSignalDiscriminatorSawIneligible` FIRST
-    // (#1317 cloud review round 2, second P2): a live re-check here would only
-    // see the device's CURRENT mute state, which can already have changed since
-    // a genuinely-muted silent stretch — that earlier ineligible result must
-    // stick.
-    self.zeroSignalDeviceEligible =
-      zeroSignalDeviceEligible
+    // got captured. #1578: it checks `zeroSignalRunWasClassifiedReactively`
+    // FIRST and takes the frozen `zeroSignalRefusalReason` when that is true —
+    // a live re-check would see only the device's CURRENT state, which can
+    // already have changed since the silent stretch, so the earlier categorical
+    // answer must stick. The legacy Boolean is no longer read here.
+    self.zeroSignalDecisionSnapshot =
+      zeroSignalDecisionSnapshot
       ?? {
-        guard !audioCapture.zeroSignalDiscriminatorSawIneligible else { return false }
-        guard let bound = audioCapture.zeroSignalDiscriminatorDevice else { return false }
-        return ZeroSignalDeviceDiscriminator.isEligible(bound: bound)
+        // #1578: the reactive producer already froze this run's reason, so read
+        // it rather than re-deriving. A live re-read here would only see the
+        // device's CURRENT state, which can already have changed since the
+        // silent stretch — that earlier answer must stick.
+        let wasClassifiedReactively = audioCapture.zeroSignalRunWasClassifiedReactively
+        let eligibility =
+          if wasClassifiedReactively {
+            // The flag and the reason are written together, so a true flag with
+            // no reason is a broken invariant. Fail closed THROUGH the one
+            // authority rather than manufacturing a case here — §3c's whole
+            // point is that the kernel never invents an outcome.
+            audioCapture.zeroSignalRefusalReason
+              ?? ZeroSignalDeviceDiscriminator.classify(bound: nil)
+          } else {
+            ZeroSignalDeviceDiscriminator.classify(
+              bound: audioCapture.zeroSignalDiscriminatorDevice)
+          }
+        return ZeroSignalDecisionSnapshot(
+          eligibility: eligibility,
+          currentRunWasClassifiedReactively: wasClassifiedReactively)
       }
+    self.zeroSignalRefusalSink = zeroSignalRefusalSink
     self.recordingStoppedTelemetry = recordingStoppedTelemetry
     self.sessionAcceptedTelemetry = sessionAcceptedTelemetry
     self.markPipelineTimingStart = markPipelineTimingStart
@@ -1410,6 +1446,15 @@ final class RecordingSessionKernel {
     // capture-teardown latency does not count as visible-recording time.
     stoppingStartedAtTick = currentTick()
     captureLifecycle = .stopping
+    // #1578 drain ownership point 1 of 2, and it MUST precede the await. A cancel
+    // can conclude the session while `stopCapture()` is suspended, return the FSM
+    // to idle, and let a NEW session start before this continuation resumes — at
+    // which point a drain here would either find the backlog already cleared or,
+    // worse, consume the new session's contexts. Claiming it before suspending
+    // makes this path the unambiguous owner of everything queued so far. Covers
+    // user, VAD and max-duration STOP plus every recoverable audio interruption,
+    // which falls through this same tail by the #1408 salvage design.
+    drainPendingZeroSignalRefusals()
     var captureResult = await audioCapture.stopCapture(sessionID: ownedCaptureSessionID)
     // Guard BEFORE touching kernel state — if a new session started while
     // `stopCapture()` was suspended, these fields belong to that session now
@@ -1515,48 +1560,42 @@ final class RecordingSessionKernel {
     // down (independent of eligibility — the #1520 gap).
     let signalZeroMode = Self.classifyZeroSignalAtStop(captureResult.samples)
 
-    // #1317 §3.6 STOP-win row: only when the reactive detector never fired
-    // for this session (raced by STOP, or the capture was too short to reach
-    // its own confidence threshold). MUST run before the no-speech gate
-    // below (N1) — that gate would otherwise swallow an all-zero capture as
-    // ordinary quiet-room silence. `zeroSignalDeviceEligible` resolves the
-    // SAME bound/selected/default precedence the reactive detector uses —
-    // the device the session actually captured from (Codex code-diff
-    // review: checking unconditionally the system default would misclassify
-    // a selected non-default mic that's genuinely muted while the system
-    // default happens to be alive+unmuted).
-    if telemetryState.zeroSignalFailureMode == nil,
-      let mode = signalZeroMode,
-      zeroSignalDeviceEligible()
-    {
-      telemetryState.zeroSignalFailureMode = mode
-      stopTimeZeroSignalTelemetry(
-        CaptureStallContext(
-          sessionID: audioCapture.currentCaptureSessionID,
-          armedAtUptimeNs: recordingStartedAtUptimeNs ?? DispatchTime.now().uptimeNanoseconds,
-          firedAtUptimeNs: DispatchTime.now().uptimeNanoseconds,
-          route: audioCapture.currentAudioRoute,
-          sourceType: "stop_time_classification",
-          engineStartedSuccessfully: true,
-          tapInstalled: true,
-          formatMismatchObserved: false,
-          inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
-            ? nil : audioCapture.preferredInputDeviceIDOverride,
-          inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
-          failureMode: mode,
-          selectedTransport: audioCapture.currentResolvedRoute?.selected,
-          effectiveTransport: audioCapture.currentResolvedRoute?.effective,
-          routeReason: audioCapture.currentResolvedRoute?.routeReason,
-          routeFallbackReason: audioCapture.currentResolvedRoute?.routeFallbackReason,
-          inputSelectionMode: audioCapture.currentResolvedRoute?.inputSelectionMode,
-          outputTransport: audioCapture.currentResolvedRoute?.outputTransport,
-          routeResolutionSource: audioCapture.currentResolvedRoute?.routeResolutionSource,
-          // #1523: stamp the bound device's channel count on the zero-signal
-          // terminal. This is the near-silent-capture event §3a correlates a
-          // >1-channel count against (voice on a later channel → AUHAL takes
-          // channel 0 → silence), so the count belongs precisely here.
-          nativeChannelCount: captureResult.metadata?.nativeChannelCount
-        ))
+    // #1317 §3.6 STOP-win row: only when the reactive detector never classified
+    // this run (raced by STOP, or the capture was too short to reach its own
+    // confidence threshold). MUST run before the no-speech gate below (N1) —
+    // that gate would otherwise swallow an all-zero capture as ordinary
+    // quiet-room silence. `zeroSignalDecisionSnapshot` resolves the SAME
+    // bound-device precedence the reactive detector uses — the device the
+    // session actually captured from (Codex code-diff review: checking the
+    // system default unconditionally would misclassify a selected non-default
+    // mic that is genuinely unusable while the system default happens to be
+    // alive and unmuted).
+    //
+    // #1578: ONE snapshot read, then a three-way split. Reading it once matters —
+    // the production closure consults live capture state, so two reads could
+    // disagree within the same STOP.
+    if telemetryState.zeroSignalFailureMode == nil, let mode = signalZeroMode {
+      let decision = zeroSignalDecisionSnapshot()
+      if decision.currentRunWasClassifiedReactively {
+        // The reactive producer already owns this run's observation — whether it
+        // was delivered immediately or is waiting in the backlog for a drain.
+        // STOP adds nothing, or the same run counts twice.
+      } else if decision.eligibility == .eligible {
+        stampEligibleStopTimeZeroSignal(mode: mode, captureResult: captureResult)
+      } else {
+        // A run the reactive path never classified — too short to reach its
+        // threshold, or raced by STOP — and the device is not eligible. This is
+        // the ONLY new event STOP itself produces, and it deliberately does not
+        // stamp `zeroSignalFailureMode`: a refusal is an observation, not the
+        // stall confirmation that stamp represents.
+        zeroSignalRefusalSink([
+          ZeroSignalRefusalContext(
+            sessionID: audioCapture.currentCaptureSessionID,
+            reason: decision.eligibility,
+            transport: audioCapture.currentResolvedRoute?.effective ?? "unknown",
+            failureShape: mode)
+        ])
+      }
     }
 
     // Map the eligibility-gated stamp ONCE — it drives both the retire's stamp arm
@@ -1589,8 +1628,8 @@ final class RecordingSessionKernel {
       let effectiveTransport = takeRoute?.effective ?? "unknown"
       // The retire ran on the sample fact alone (no eligibility-gated stamp) —
       // the #1520 signature. Derived from the already-computed stamp outcome,
-      // never a re-call of `zeroSignalDeviceEligible()` (which reads a
-      // possibly-changed live mute state).
+      // never a re-call of `zeroSignalDecisionSnapshot()` (which can read a
+      // since-changed live device state).
       let healthGuessRefused = signalZeroMode != nil && zeroSignalRecoveryMode == nil
       deadMicRetireAttemptTelemetry(
         DeadMicRetireAttemptContext(
@@ -3391,15 +3430,72 @@ final class RecordingSessionKernel {
     }
   }
 
-  /// Conclude the session: set the ending `recordingOutcome`, return the FSM to
-  /// `.idle`, run nonblocking cleanup, drain the task bag (PR-1 §B.1.6, PR-3
-  /// plan §3.1a — cancel + clear, never `await`). Discards the adapter's open
-  /// session and stops the capture engine if either is still in flight (PR-1
-  /// §B.1.3 cleanup column; Codex P1b / P2-r3). `recordingOutcome != nil` is
-  /// the session-concluded barrier (#1548 D1).
+  /// #1317 §3.6, extracted at #1578: the ELIGIBLE STOP-time zero-signal stamp,
+  /// byte-for-byte the behaviour that shipped — same stamp, same context, same
+  /// authority. It moved into its own method only because the call site now
+  /// branches three ways, and an inline 40-line arm would have buried the
+  /// branch that matters.
+  @MainActor
+  private func stampEligibleStopTimeZeroSignal(
+    mode: CaptureStallFailureMode, captureResult: CaptureResult
+  ) {
+    telemetryState.zeroSignalFailureMode = mode
+    stopTimeZeroSignalTelemetry(
+      CaptureStallContext(
+        sessionID: audioCapture.currentCaptureSessionID,
+        armedAtUptimeNs: recordingStartedAtUptimeNs ?? DispatchTime.now().uptimeNanoseconds,
+        firedAtUptimeNs: DispatchTime.now().uptimeNanoseconds,
+        route: audioCapture.currentAudioRoute,
+        sourceType: "stop_time_classification",
+        engineStartedSuccessfully: true,
+        tapInstalled: true,
+        formatMismatchObserved: false,
+        inputDeviceUIDPreferred: audioCapture.preferredInputDeviceIDOverride.isEmpty
+          ? nil : audioCapture.preferredInputDeviceIDOverride,
+        inputDeviceUIDSystemDefault: AudioDeviceEnumerator.defaultInputDeviceUID(),
+        failureMode: mode,
+        selectedTransport: audioCapture.currentResolvedRoute?.selected,
+        effectiveTransport: audioCapture.currentResolvedRoute?.effective,
+        routeReason: audioCapture.currentResolvedRoute?.routeReason,
+        routeFallbackReason: audioCapture.currentResolvedRoute?.routeFallbackReason,
+        inputSelectionMode: audioCapture.currentResolvedRoute?.inputSelectionMode,
+        outputTransport: audioCapture.currentResolvedRoute?.outputTransport,
+        routeResolutionSource: audioCapture.currentResolvedRoute?.routeResolutionSource,
+        // #1523: stamp the bound device's channel count on the zero-signal
+        // terminal. This is the near-silent-capture event §3a correlates a
+        // >1-channel count against (voice on a later channel → AUHAL takes
+        // channel 0 → silence), so the count belongs precisely here.
+        nativeChannelCount: captureResult.metadata?.nativeChannelCount
+      ))
+  }
+
+  /// #1578: hand every rejected reactive refusal to the sink, exactly once.
+  /// This is ONE of the sink's two producers — the STOP-time branch submits its
+  /// own single newly classified refusal directly.
   ///
-  /// Fixed order (§5.3 r4): floor + `isLegalConclusion` validate → set
-  /// `recordingOutcome` → `→ .idle` → drain.
+  /// Synchronous by contract. `takePendingZeroSignalRefusals()` is an atomic
+  /// MainActor take-and-clear, so a second caller — a cancel landing while
+  /// `stopCapture()` is suspended — finds an empty array instead of a duplicate.
+  /// Adding an `await`, a `Task`, or a lock here would reopen exactly the window
+  /// that contract closes.
+  @MainActor
+  private func drainPendingZeroSignalRefusals() {
+    let contexts = audioCapture.takePendingZeroSignalRefusals()
+    guard !contexts.isEmpty else { return }
+    zeroSignalRefusalSink(contexts)
+  }
+
+  /// Conclude the session: set the ending `recordingOutcome`, drain pending
+  /// zero-signal refusals, return the FSM to `.idle`, run nonblocking cleanup,
+  /// and drain the task bag (PR-1 §B.1.6, PR-3 plan §3.1a — cancel + clear,
+  /// never `await`). Discards the adapter's open session and stops the capture
+  /// engine if either is still in flight (PR-1 §B.1.3 cleanup column; Codex
+  /// P1b / P2-r3). `recordingOutcome != nil` is the session-concluded barrier
+  /// (#1548 D1).
+  ///
+  /// Fixed order (§5.3 r4, #1578): validate the floor and legal conclusion →
+  /// set `recordingOutcome` → stamp `lastTakeID` (#1846) → drain pending
+  /// zero-signal refusals → transition to `.idle` → drain the task bag.
   private func finishTerminal(_ rawOutcome: RecordingOutcome, sid: SessionID) {
     // Set-once barrier: `isCurrent` fences stale sessions; `recordingOutcome ==
     // nil` prevents a double conclusion.
@@ -3419,6 +3515,14 @@ final class RecordingSessionKernel {
     // `isCurrent(sid)` guard above already proved they match, and `sid` is
     // unambiguously the session being concluded.
     lastTakeID = sid.raw.uuidString
+    // #1578 drain ownership point 2 of 2 — cancellation, non-recoverable
+    // interruption, and every other direct terminal. Placed AFTER the set-once
+    // outcome write so a stale or losing terminal (both bail on the guard above)
+    // cannot consume a backlog it does not own, and BEFORE the idle transition
+    // below so a newly started session cannot clear or repopulate capture state
+    // first. When a normal STOP already claimed the backlog, the atomic take
+    // returns empty here and the helper does nothing.
+    drainPendingZeroSignalRefusals()
     #if DEBUG
       // #1755 chunk 6: crash-boundary hold — immediately after the set-once
       // outcome write, before the idle transition and downstream cleanup.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -571,6 +571,35 @@ public final class TelemetryService {
     PostHogSDK.shared.capture(event, properties: props)
   }
 
+  /// #1578: one event per uninterrupted zero run whose frozen-device
+  /// classification came back non-eligible. Records WHY stall recovery was
+  /// refused; it does NOT assert the microphone died. Content-free by
+  /// construction: three closed-vocabulary strings, never transcript, audio,
+  /// device name, or UID — and no session or take identifier.
+  public func zeroSignalRefused(
+    reason: String,
+    transport: String,
+    failureShape: String
+  ) {
+    let event = "audio.zero_signal_refused"
+    let props: [String: Any] = [
+      "reason": reason,
+      "transport": transport,
+      "failure_shape": failureShape,
+    ]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: event,
+          stringProps: [
+            "reason": reason,
+            "transport": transport,
+            "failure_shape": failureShape,
+          ]))
+    #endif
+    PostHogSDK.shared.capture(event, properties: props)
+  }
+
   /// Heartpath 5b (#1520): a completed take came back zero-signal, so the fenced
   /// retire primitive was invoked. `retireAction` records whether teardown
   /// actually ran (`retired`) or was a fenced no-op. Content-free by

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -26,6 +26,11 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   var onVADAutoStop: (() -> Void)?
   var onMaxDurationReached: (() -> Void)?
   var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  /// #1578: STORED, not inherited. The protocol extension's default is a
+  /// deliberate no-op setter for conformers with no reactive detector, so
+  /// relying on it here would silently discard whatever the router installs and
+  /// leave the router tests with nothing to invoke.
+  var onZeroSignalRefused: ((ZeroSignalRefusalContext) -> Bool)?
   var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
   var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool = false

--- a/Tests/EnviousWisprTests/App/WedgeRecoveryRouterTests.swift
+++ b/Tests/EnviousWisprTests/App/WedgeRecoveryRouterTests.swift
@@ -32,6 +32,124 @@ struct WedgeRecoveryRouterTests {
     )
 
     #expect(audio.onCaptureStalled != nil)
+    // #1578: the refusal callback rides the same funnel and must be installed
+    // by the same initializer — an uninstalled one is a silent dead route.
+    #expect(audio.onZeroSignalRefused != nil)
+    withExtendedLifetime(router) {}
+  }
+
+  // MARK: - #1578 — the refusal callback's delivery contract
+  //
+  // Every exit must return the right Boolean, because `false` is what tells the
+  // capture manager to KEEP the context for a terminal drain. A router that
+  // returned `true` on a dropped callback would lose the observation silently,
+  // which is the exact failure the void-returning stall callback above cannot
+  // even detect.
+
+  /// Records what a telemetry target actually received.
+  private final class RefusalSpy: HeartPathTelemetryTarget {
+    var stalls: [CaptureStallContext] = []
+    var refusals: [ZeroSignalRefusalContext] = []
+    func handleCaptureStall(_ ctx: CaptureStallContext) { stalls.append(ctx) }
+    func handleZeroSignalRefusal(_ context: ZeroSignalRefusalContext) {
+      refusals.append(context)
+    }
+  }
+
+  private static func refusalContext(sessionID: UInt64) -> ZeroSignalRefusalContext {
+    ZeroSignalRefusalContext(
+      sessionID: sessionID,
+      reason: .deviceMuted,
+      transport: "usb",
+      failureShape: .becameZeroMidCapture)
+  }
+
+  private static func makeRouter(
+    audio: RouterTestAudioCapture,
+    isCurrentSession: @escaping @MainActor (UInt64) -> Bool,
+    resolveActiveTelemetryTarget: @escaping @MainActor () -> (any HeartPathTelemetryTarget)?
+  ) -> WedgeRecoveryRouter {
+    let asr = RouterTestASRManager()
+    let store = DictationRuntimeFixtures.tempStore()
+    return WedgeRecoveryRouter(
+      audioCapture: audio,
+      kernelDriver: DictationRuntimeFixtures.makeParakeetDriver(
+        audioCapture: audio, asrManager: asr, store: store),
+      whisperKitKernelDriver: DictationRuntimeFixtures.makeWhisperKitPipeline(
+        audioCapture: audio, store: store),
+      isCurrentSession: isCurrentSession,
+      resolveActiveTelemetryTarget: resolveActiveTelemetryTarget)
+  }
+
+  @Test("#1578: a stale refusal returns false without consulting the resolver")
+  func staleRefusalReturnsFalse() {
+    let audio = RouterTestAudioCapture()
+    let spy = RefusalSpy()
+    var sessionFilterCalls: [UInt64] = []
+    var resolverCallCount = 0
+
+    let router = Self.makeRouter(
+      audio: audio,
+      isCurrentSession: { sessionID in
+        sessionFilterCalls.append(sessionID)
+        return false
+      },
+      resolveActiveTelemetryTarget: {
+        resolverCallCount += 1
+        return spy
+      })
+
+    let delivered = audio.onZeroSignalRefused?(Self.refusalContext(sessionID: 7))
+
+    #expect(delivered == false)
+    #expect(sessionFilterCalls == [7])
+    // The staleness check must come FIRST — resolving a target for a session
+    // that has already ended is work the router should never do.
+    #expect(resolverCallCount == 0)
+    #expect(spy.refusals.isEmpty)
+    withExtendedLifetime(router) {}
+  }
+
+  @Test("#1578: a current-session refusal with no active target returns false")
+  func noTargetRefusalReturnsFalse() {
+    let audio = RouterTestAudioCapture()
+    var resolverCallCount = 0
+
+    let router = Self.makeRouter(
+      audio: audio,
+      isCurrentSession: { _ in true },
+      resolveActiveTelemetryTarget: {
+        resolverCallCount += 1
+        return nil
+      })
+
+    let delivered = audio.onZeroSignalRefused?(Self.refusalContext(sessionID: 1))
+
+    // Nothing consumed it, so the producer must keep it.
+    #expect(delivered == false)
+    #expect(resolverCallCount == 1)
+    withExtendedLifetime(router) {}
+  }
+
+  @Test("#1578: a delivered refusal returns true and reaches the target exactly once")
+  func deliveredRefusalReturnsTrue() {
+    let audio = RouterTestAudioCapture()
+    let spy = RefusalSpy()
+
+    let router = Self.makeRouter(
+      audio: audio,
+      isCurrentSession: { _ in true },
+      resolveActiveTelemetryTarget: { spy })
+
+    let context = Self.refusalContext(sessionID: 42)
+    let delivered = audio.onZeroSignalRefused?(context)
+
+    // `true` must mean the target's method actually ran, not merely that a
+    // target existed.
+    #expect(delivered == true)
+    #expect(spy.refusals == [context])
+    // The refusal route must not touch the stall route.
+    #expect(spy.stalls.isEmpty)
     withExtendedLifetime(router) {}
   }
 

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureInterfaceZeroSignalDefaultsTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureInterfaceZeroSignalDefaultsTests.swift
@@ -1,0 +1,187 @@
+@preconcurrency import AVFoundation
+import EnviousWisprAudio
+import EnviousWisprCore
+import Foundation
+import Testing
+
+// #1578: the refusal conduit's value types and its source-compatibility
+// contract for conformers that have no reactive detector.
+//
+// Deliberately a plain `import`, not `@testable`: the whole point of these two
+// structures and four protocol members is that they are PUBLIC surface the
+// Pipeline and AppKit modules consume, so the test exercises them exactly as a
+// cross-module caller would. A `@testable` import would hide a missing `public`.
+//
+// The fixture is a PRIVATE conformer that overrides nothing, and that is
+// load-bearing rather than convenient. This suite originally borrowed the shared
+// `RouterTestAudioCapture`, on the reasoning that a real conformer is better
+// evidence than a purpose-built stub. One chunk later that conformer legitimately
+// gained a stored `onZeroSignalRefused` (the router tests need to invoke what the
+// router installs), and this suite silently stopped testing the extension default
+// while still claiming to — it went red on the assertion that would otherwise
+// have quietly become meaningless.
+//
+// The lesson generalises: a test whose SUBJECT is "what a type that overrides
+// nothing receives" cannot use a shared fixture, because any shared fixture may
+// legitimately gain an override later. Its fixture has to be a type that by
+// construction never will.
+//
+// This double is deliberately inert everywhere else, so an assertion here can
+// only be describing the protocol extension.
+@MainActor
+@Suite("#1578 zero-signal refusal conduit — value types + conformer defaults")
+struct AudioCaptureInterfaceZeroSignalDefaultsTests {
+
+  // MARK: - The two value types
+
+  @Test("refusal context preserves every field, and equality sees a changed one")
+  func refusalContextRoundTripsAndComparesByValue() {
+    let ctx = ZeroSignalRefusalContext(
+      sessionID: 7,
+      reason: .deviceMuted,
+      transport: "usb",
+      failureShape: .becameZeroMidCapture)
+
+    #expect(ctx.sessionID == 7)
+    #expect(ctx.reason == .deviceMuted)
+    #expect(ctx.transport == "usb")
+    #expect(ctx.failureShape == .becameZeroMidCapture)
+
+    // Identical input compares equal — without this, the four inequality
+    // assertions below would pass for a type that considered nothing equal.
+    #expect(
+      ctx
+        == ZeroSignalRefusalContext(
+          sessionID: 7, reason: .deviceMuted, transport: "usb",
+          failureShape: .becameZeroMidCapture))
+
+    // Each field participates: a dashboard that groups by reason × transport ×
+    // shape depends on all four being carried, not just the reason.
+    #expect(
+      ctx
+        != ZeroSignalRefusalContext(
+          sessionID: 8, reason: .deviceMuted, transport: "usb",
+          failureShape: .becameZeroMidCapture))
+    #expect(
+      ctx
+        != ZeroSignalRefusalContext(
+          sessionID: 7, reason: .muteUnverified, transport: "usb",
+          failureShape: .becameZeroMidCapture))
+    #expect(
+      ctx
+        != ZeroSignalRefusalContext(
+          sessionID: 7, reason: .deviceMuted, transport: "bluetooth",
+          failureShape: .becameZeroMidCapture))
+    #expect(
+      ctx
+        != ZeroSignalRefusalContext(
+          sessionID: 7, reason: .deviceMuted, transport: "usb",
+          failureShape: .allZeroFromStart))
+  }
+
+  @Test("decision snapshot preserves both fields, and equality sees a changed one")
+  func decisionSnapshotRoundTripsAndComparesByValue() {
+    let snapshot = ZeroSignalDecisionSnapshot(
+      eligibility: .identityMismatch, currentRunWasClassifiedReactively: true)
+
+    #expect(snapshot.eligibility == .identityMismatch)
+    #expect(snapshot.currentRunWasClassifiedReactively == true)
+
+    #expect(
+      snapshot
+        == ZeroSignalDecisionSnapshot(
+          eligibility: .identityMismatch, currentRunWasClassifiedReactively: true))
+    #expect(
+      snapshot
+        != ZeroSignalDecisionSnapshot(
+          eligibility: .notAlive, currentRunWasClassifiedReactively: true))
+    #expect(
+      snapshot
+        != ZeroSignalDecisionSnapshot(
+          eligibility: .identityMismatch, currentRunWasClassifiedReactively: false))
+  }
+
+  // MARK: - Conformer defaults, seen through the existential
+
+  @Test("a conformer with no reactive detector reports no refusal reason")
+  func defaultRefusalReasonIsNil() {
+    let audioCapture: any AudioCaptureInterface = DefaultsOnlyAudioCapture()
+    #expect(audioCapture.zeroSignalRefusalReason == nil)
+  }
+
+  @Test("a conformer with no reactive detector never claims it classified the run")
+  func defaultReactivelyClassifiedFlagIsFalse() {
+    let audioCapture: any AudioCaptureInterface = DefaultsOnlyAudioCapture()
+    #expect(audioCapture.zeroSignalRunWasClassifiedReactively == false)
+  }
+
+  @Test("a conformer with no backlog hands over an empty array, synchronously")
+  func defaultTakePendingReturnsEmpty() {
+    let audioCapture: any AudioCaptureInterface = DefaultsOnlyAudioCapture()
+    #expect(audioCapture.takePendingZeroSignalRefusals().isEmpty)
+  }
+
+  /// The settable requirement needs an explicit no-op setter in the extension;
+  /// a read-only computed default would not compile against `{ get set }`. This
+  /// test is the compile-time proof of that, plus the runtime proof that the
+  /// discard is deliberate rather than an accidental store.
+  @Test("assigning the refusal callback through the existential compiles and is discarded")
+  func defaultCallbackAcceptsAssignmentAndStaysNil() {
+    // `let`, not `var`: the protocol is class-bound, so its property setters are
+    // non-mutating and the binding itself is never reassigned.
+    let audioCapture: any AudioCaptureInterface = DefaultsOnlyAudioCapture()
+
+    audioCapture.onZeroSignalRefused = { _ in true }
+
+    // The default getter is `nil` by contract, so the closure above is not
+    // retrievable and must never be invoked from here.
+    #expect(audioCapture.onZeroSignalRefused == nil)
+  }
+}
+
+/// A conformer that overrides NOTHING of the #1578 surface — no stored reason,
+/// no stored flag, no stored callback, no backlog. Every zero-signal answer it
+/// gives therefore comes from the protocol extension, which is the only thing
+/// the four default tests above are entitled to be describing.
+///
+/// Everything else is inert by design. If a future assertion in this suite needs
+/// this double to DO something, that assertion belongs in a different suite.
+@MainActor
+private final class DefaultsOnlyAudioCapture: AudioCaptureInterface {
+  var isCapturing: Bool = false
+  var audioLevel: Float = 0
+  var capturedSamples: [Float] = []
+  var currentAudioRoute: String = "built_in_mic"
+  var currentResolvedRoute: ResolvedRouteTransports?
+  var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+  var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
+  var onVADAutoStop: (() -> Void)?
+  var onMaxDurationReached: (() -> Void)?
+  var onCaptureStalled: ((CaptureStallContext) -> Void)?
+  var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+  var currentCaptureSessionID: UInt64 = 0
+  var isActivelyCapturing: Bool = false
+  var captureSourceType: String = "defaults_only_stub"
+  var selectedInputDeviceUID: String = ""
+  var preferredInputDeviceIDOverride: String = ""
+  var warmEnginePolicy: WarmEnginePolicy = .off
+
+  func startEnginePhase() async throws {}
+  func beginCapturePhase(recoveryPayload: Data?) async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+    AsyncStream { $0.finish() }
+  }
+  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func rebuildEngine() {}
+  func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
+  func preWarm() async throws {}
+  func abortPreWarm() {}
+  func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async -> Bool {
+    true
+  }
+  func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool) {}
+  func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) { ([], 0) }
+  func getVADSegments() async -> [SpeechSegment] { [] }
+}

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureInterfaceZeroSignalDefaultsTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureInterfaceZeroSignalDefaultsTests.swift
@@ -173,7 +173,7 @@ private final class DefaultsOnlyAudioCapture: AudioCaptureInterface {
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
     AsyncStream { $0.finish() }
   }
-  func stopCapture() async -> CaptureResult { CaptureResult(samples: []) }
+  func stopCapture(sessionID _: UInt64) async -> CaptureResult { CaptureResult(samples: []) }
   func rebuildEngine() {}
   func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
   func preWarm() async throws {}

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
@@ -4,63 +4,272 @@ import Testing
 
 @testable import EnviousWisprAudio
 
-// MARK: - #1317 / #1543 — the reactive dead-air "ineligible" latch, ported
-// in-process from the former capture proxy.
+// MARK: - #1317 / #1543 / #1578 — reactive dead-air refusal state
 //
-// The manager feeds the authoritative captured samples into a
-// `DeadAirStreamingDetector` on the MainActor (via `ingestSamples`). When an
-// all-zero run crosses the confidence threshold AND the frozen input device is
-// ineligible (muted, or — as in these unit tests — never frozen, so `nil`), the
-// manager latches `zeroSignalDiscriminatorSawIneligible`. The latch is scoped to
-// the CURRENT trailing zero-run: a non-zero sample that breaks the run clears
-// it, so a muted-then-unmuted stretch cannot blind the kernel's STOP-time
-// backstop to a later, unrelated genuine failure. The detector's own tile/zero
-// math is covered by `DeadAirStreamingDetectorTests`; this pins the manager's
-// latch wiring.
+// The manager feeds authoritative captured samples into a
+// `DeadAirStreamingDetector` on the MainActor through `ingestSamples`. When an
+// all-zero run crosses the confidence threshold and the frozen-device
+// discriminator returns any non-eligible reason, the manager records that
+// categorical reason and attempts one forward for the run. The current-run
+// reason and reactive-classification flag clear when a non-zero sample breaks
+// the run; rejected contexts remain in the per-session backlog. The detector's
+// tile and zero-run math is covered by `DeadAirStreamingDetectorTests`; this
+// suite pins the manager's refusal, reset, forwarding, and backlog wiring.
 @MainActor
-@Suite("AudioCaptureManager dead-air ineligible latch (#1317/#1543)")
+@Suite("AudioCaptureManager dead-air refusal + compatibility view (#1317/#1543/#1578)")
 struct AudioCaptureManagerDeadAirLatchTests {
 
   /// A manager armed to ingest without real hardware. No `startEnginePhase`, so
-  /// the frozen discriminator device is `nil` — the "ineligible" state a real
-  /// muted device produces, driving the fail-closed latch path.
+  /// the frozen discriminator device is `nil` — which the classifier owns as
+  /// `.boundDeviceUnavailable`, driving the fail-closed refusal path.
   private func armedManager() -> AudioCaptureManager {
     let manager = AudioCaptureManager()
     manager.isCapturing = true  // internal(set): arm ingest without hardware
     return manager
   }
 
-  @Test("an all-zero run with an ineligible device latches saw-ineligible")
-  func allZeroLatchesWhenIneligible() {
+  @Test("an all-zero run with a non-eligible device sets the compatibility view")
+  func allZeroSetsCompatibilityViewWhenRefused() {
     let manager = armedManager()
     #expect(!manager.zeroSignalDiscriminatorSawIneligible)
 
     // Exactly-zero samples past the minimum-transcription threshold ⇒
-    // `isAllZeroFromStart`. Device is nil ⇒ ineligible ⇒ latch sets.
+    // `isAllZeroFromStart`. No frozen bind ⇒ a refusal reason ⇒ the derived
+    // compatibility view reads true.
     manager.ingestSamples(
       [Float](repeating: 0, count: AudioConstants.minimumTranscriptionSamples), level: 0)
     #expect(manager.zeroSignalDiscriminatorSawIneligible)
   }
 
-  @Test("a non-zero sample breaks the trailing zero-run and clears the latch")
-  func nonZeroClearsTheLatch() {
+  @Test("a non-zero sample breaks the trailing zero-run and clears the compatibility view")
+  func nonZeroClearsTheCompatibilityView() {
     let manager = armedManager()
     manager.ingestSamples(
       [Float](repeating: 0, count: AudioConstants.minimumTranscriptionSamples), level: 0)
-    #expect(manager.zeroSignalDiscriminatorSawIneligible, "precondition: latched")
+    #expect(manager.zeroSignalDiscriminatorSawIneligible, "precondition: refused")
 
-    // The muted-then-unmuted negative: real audio breaks the trailing zero-run,
-    // so the earlier ineligible result must no longer stick.
+    // The refused-then-recovered negative: real audio breaks the trailing
+    // zero-run, so the earlier refusal must no longer stick.
     manager.ingestSamples([0.5], level: 0.5)
     #expect(!manager.zeroSignalDiscriminatorSawIneligible)
   }
 
-  @Test("meaningful signal from the start never latches saw-ineligible")
-  func realSignalNeverLatches() {
+  @Test("meaningful signal from the start never sets the compatibility view")
+  func realSignalNeverSetsCompatibilityView() {
     let manager = armedManager()
     manager.ingestSamples(
       [Float](repeating: 0.5, count: AudioConstants.minimumTranscriptionSamples), level: 0.5)
     #expect(!manager.zeroSignalDiscriminatorSawIneligible)
+  }
+
+  // MARK: - #1578 — the refusal carries a reason, and is counted exactly once
+
+  private static func zeros(_ n: Int = AudioConstants.minimumTranscriptionSamples) -> [Float] {
+    [Float](repeating: 0, count: n)
+  }
+
+  /// Enough real signal for `meaningfulSignalSeen` to latch, which is what turns
+  /// a following zero run into `.becameZeroMidCapture` rather than
+  /// `.allZeroFromStart`.
+  private static func loud(_ n: Int = 8_000) -> [Float] {
+    [Float](repeating: 0.5, count: n)
+  }
+
+  @Test("an ineligible zero run records WHY, not just THAT")
+  func refusalRecordsTheReason() {
+    let manager = armedManager()
+    #expect(manager.zeroSignalRefusalReason == nil)
+    #expect(!manager.zeroSignalRunWasClassifiedReactively)
+
+    manager.ingestSamples(Self.zeros(), level: 0)
+
+    // No `startEnginePhase`, so no frozen bind — the classifier owns that
+    // outcome, and the manager must report it rather than a generic refusal.
+    #expect(manager.zeroSignalRefusalReason == .boundDeviceUnavailable)
+    #expect(manager.zeroSignalRunWasClassifiedReactively)
+    // The legacy Boolean now derives from the reason; it must not have drifted.
+    #expect(manager.zeroSignalDiscriminatorSawIneligible)
+  }
+
+  @Test("meaningful signal records no reason, attempts no forward, adds no backlog")
+  func healthySignalRecordsNothing() {
+    let manager = armedManager()
+    var attempts = 0
+    manager.onZeroSignalRefused = { _ in
+      attempts += 1
+      return true
+    }
+
+    manager.ingestSamples(Self.loud(AudioConstants.minimumTranscriptionSamples), level: 0.5)
+
+    // The paired negative control for every positive below: without it, a
+    // manager that refused unconditionally would satisfy all of them.
+    #expect(manager.zeroSignalRefusalReason == nil)
+    #expect(!manager.zeroSignalRunWasClassifiedReactively)
+    #expect(attempts == 0)
+    #expect(manager.takePendingZeroSignalRefusals().isEmpty)
+  }
+
+  @Test("a zero run spanning many batches forwards exactly once")
+  func multiBatchRunForwardsOnce() {
+    let manager = armedManager()
+    var attempts = 0
+    manager.onZeroSignalRefused = { _ in
+      attempts += 1
+      return true
+    }
+
+    // First batch crosses the candidate threshold; the next three stay inside
+    // the SAME uninterrupted zero run and must be silent.
+    manager.ingestSamples(Self.zeros(), level: 0)
+    manager.ingestSamples(Self.zeros(4_000), level: 0)
+    manager.ingestSamples(Self.zeros(4_000), level: 0)
+    manager.ingestSamples(Self.zeros(4_000), level: 0)
+
+    #expect(attempts == 1)
+    #expect(manager.takePendingZeroSignalRefusals().isEmpty)
+  }
+
+  @Test("an accepted forward leaves the backlog empty; a rejected one holds exactly one")
+  func acceptedVersusRejectedForward() {
+    let accepted = armedManager()
+    accepted.onZeroSignalRefused = { _ in true }
+    accepted.ingestSamples(Self.zeros(), level: 0)
+    #expect(accepted.takePendingZeroSignalRefusals().isEmpty)
+
+    let rejected = armedManager()
+    rejected.onZeroSignalRefused = { _ in false }
+    rejected.ingestSamples(Self.zeros(), level: 0)
+    #expect(rejected.takePendingZeroSignalRefusals().count == 1)
+
+    // No subscriber at all is the same answer as an explicit refusal: not
+    // delivered. This is the state production is in until the route is wired.
+    let unsubscribed = armedManager()
+    unsubscribed.ingestSamples(Self.zeros(), level: 0)
+    #expect(unsubscribed.takePendingZeroSignalRefusals().count == 1)
+  }
+
+  @Test("both an accepted and a rejected forward mark the run classified")
+  func bothOutcomesMarkTheRunClassified() {
+    // Forwarding success must never be what suppresses STOP-time
+    // reclassification — otherwise a rejected refusal would be emitted from the
+    // backlog AND re-emitted by STOP.
+    let accepted = armedManager()
+    accepted.onZeroSignalRefused = { _ in true }
+    accepted.ingestSamples(Self.zeros(), level: 0)
+    #expect(accepted.zeroSignalRunWasClassifiedReactively)
+
+    let rejected = armedManager()
+    rejected.onZeroSignalRefused = { _ in false }
+    rejected.ingestSamples(Self.zeros(), level: 0)
+    #expect(rejected.zeroSignalRunWasClassifiedReactively)
+  }
+
+  @Test("recovery clears the current run but never the rejected backlog")
+  func recoveryClearsRunStateAndKeepsBacklog() {
+    let manager = armedManager()
+    manager.ingestSamples(Self.zeros(), level: 0)
+    #expect(manager.zeroSignalRefusalReason != nil, "precondition: refused")
+
+    manager.ingestSamples(Self.loud(), level: 0.5)
+
+    // Current-run facts are gone, so the next run gets its own forward…
+    #expect(manager.zeroSignalRefusalReason == nil)
+    #expect(!manager.zeroSignalRunWasClassifiedReactively)
+    // …but the refusal that already happened is NOT undone by the microphone
+    // coming back. This is the case that produces nothing at all today.
+    #expect(manager.takePendingZeroSignalRefusals().count == 1)
+  }
+
+  @Test("an accepted refusal that recovers clears run state and leaves no backlog")
+  func acceptedRecoveredRunClearsWithoutBacklog() {
+    // The fourth cell of accepted/rejected × final/recovered. Without it, a
+    // recovery that wrongly re-forwarded an already-delivered refusal would go
+    // unnoticed, because the other three cells never re-run the callback.
+    let manager = armedManager()
+    var attempts = 0
+    manager.onZeroSignalRefused = { _ in
+      attempts += 1
+      return true
+    }
+
+    manager.ingestSamples(Self.zeros(), level: 0)
+    #expect(attempts == 1)
+    #expect(manager.zeroSignalRefusalReason != nil)
+    #expect(manager.zeroSignalRunWasClassifiedReactively)
+
+    manager.ingestSamples(Self.loud(), level: 0.5)
+
+    #expect(attempts == 1)
+    #expect(manager.zeroSignalRefusalReason == nil)
+    #expect(!manager.zeroSignalRunWasClassifiedReactively)
+    #expect(manager.takePendingZeroSignalRefusals().isEmpty)
+  }
+
+  @Test("two rejected runs in one take keep both contexts, in order, with their own shapes")
+  func twoRejectedRunsPreserveOrderAndShape() {
+    let manager = armedManager()
+
+    // Run 1: silent from the very first sample.
+    manager.ingestSamples(Self.zeros(), level: 0)
+    // Recovery: real audio breaks the run and re-arms classification.
+    manager.ingestSamples(Self.loud(), level: 0.5)
+    // Run 2: silence AFTER real speech — a different failure shape entirely.
+    manager.ingestSamples(Self.zeros(), level: 0)
+
+    let pending = manager.takePendingZeroSignalRefusals()
+    #expect(pending.count == 2)
+    #expect(pending.first?.failureShape == .allZeroFromStart)
+    #expect(pending.last?.failureShape == .becameZeroMidCapture)
+    // Both describe the same session and the same absent bind.
+    #expect(pending.allSatisfy { $0.reason == .boundDeviceUnavailable })
+    #expect(pending.allSatisfy { $0.sessionID == manager.currentCaptureSessionID })
+  }
+
+  @Test("the context carries session, reason, transport and shape from the shipped authorities")
+  func contextPayloadUsesExistingAuthorities() {
+    let manager = armedManager()
+    var seen: ZeroSignalRefusalContext?
+    manager.onZeroSignalRefused = { ctx in
+      seen = ctx
+      return true
+    }
+
+    manager.ingestSamples(Self.zeros(), level: 0)
+
+    #expect(seen?.sessionID == manager.currentCaptureSessionID)
+    #expect(seen?.reason == .boundDeviceUnavailable)
+    #expect(seen?.failureShape == .allZeroFromStart)
+    // No route has resolved on a manager armed without hardware, so the shared
+    // low-cardinality fallback applies — the same expression the dead-air stall
+    // diagnostic uses, not a second transport source.
+    #expect(seen?.transport == "unknown")
+  }
+
+  @Test("the atomic take hands over everything once, then reports empty")
+  func atomicTakeIsExactlyOnce() {
+    let manager = armedManager()
+    manager.ingestSamples(Self.zeros(), level: 0)
+
+    let first = manager.takePendingZeroSignalRefusals()
+    #expect(first.count == 1)
+
+    // The whole point: a second consumer — a cancel landing while a stop is
+    // suspended — must get nothing rather than a duplicate.
+    #expect(manager.takePendingZeroSignalRefusals().isEmpty)
+  }
+
+  @Test("a refusal does not latch the dead-air detector, so a later run still refuses")
+  func refusalDoesNotLatchTheDetector() {
+    let manager = armedManager()
+    manager.ingestSamples(Self.zeros(), level: 0)
+    manager.ingestSamples(Self.loud(), level: 0.5)
+    manager.ingestSamples(Self.zeros(), level: 0)
+
+    // Behaviour, not private storage: a second refusal could not have been
+    // reached if the first had set `deadAirDetector.fired`, whose guard sits at
+    // the top of the reactive path.
+    #expect(manager.takePendingZeroSignalRefusals().count == 2)
   }
 
   // MARK: - #1788 — the mid-take all-zero ceiling has ONE owner
@@ -167,6 +376,88 @@ struct AudioCaptureManagerDeadAirLatchTests {
 }
 
 #if DEBUG
+  // #1578: the two claims that cannot be made without driving a real capture
+  // session. Both need the manager's existing `#if DEBUG` source-factory seam,
+  // so this whole suite is DEBUG-only — the Release lane strips the seam and
+  // must not try to compile against it (the trap that turned main red in #1520).
+  //
+  // The stub source is the one `BoundDeviceAdoptionTests` already maintains for
+  // exactly this purpose. A second copy would be a second thing to keep true.
+  @MainActor
+  @Suite("AudioCaptureManager zero-signal refusal — real session paths (#1578)")
+  struct AudioCaptureManagerRefusalSessionTests {
+
+    private static func zeros(_ n: Int = AudioConstants.minimumTranscriptionSamples) -> [Float] {
+      [Float](repeating: 0, count: n)
+    }
+
+    /// A manager that will build its source from the stub, so `startEnginePhase`
+    /// and `beginCapturePhase` run for real without hardware.
+    private static func makeManager(_ stub: BoundDeviceAdoptionTests.StubSource)
+      -> AudioCaptureManager
+    {
+      let manager = AudioCaptureManager()
+      manager.installSourceFactoryForTesting { stub }
+      return manager
+    }
+
+    @Test("starting a new session clears the reason, the flag AND the backlog")
+    func sessionStartClearsEverythingIncludingBacklog() async throws {
+      let stub = BoundDeviceAdoptionTests.StubSource()
+      let manager = Self.makeManager(stub)
+
+      // Strand a rejected refusal from a prior take.
+      manager.isCapturing = true
+      manager.ingestSamples(Self.zeros(), level: 0)
+      #expect(manager.zeroSignalRefusalReason != nil, "precondition: refused")
+      #expect(manager.zeroSignalRunWasClassifiedReactively, "precondition: classified")
+
+      try await manager.startEnginePhase()
+      _ = try await manager.beginCapturePhase()
+
+      // A new session must inherit none of it. Recovery keeps the backlog; a new
+      // session is the one place it is dropped without a consumer taking it.
+      #expect(manager.zeroSignalRefusalReason == nil)
+      #expect(!manager.zeroSignalRunWasClassifiedReactively)
+      #expect(manager.takePendingZeroSignalRefusals().isEmpty)
+    }
+
+    @Test("a refusal leaves the genuine capture-stall path armed for the same take")
+    func refusalDoesNotConsumeTheStallLatch() async throws {
+      let stub = BoundDeviceAdoptionTests.StubSource()
+      let manager = Self.makeManager(stub)
+      var stalls: [CaptureStallContext] = []
+      manager.onCaptureStalled = { stalls.append($0) }
+
+      try await manager.startEnginePhase()
+      _ = try await manager.beginCapturePhase()
+
+      // The bound stub device cannot pass the identity re-check, so this refuses.
+      manager.ingestSamples(Self.zeros(), level: 0)
+      #expect(manager.zeroSignalRefusalReason != nil, "precondition: refused")
+      #expect(stalls.isEmpty, "a refusal must not itself raise a capture stall")
+
+      // Now the SOURCE reports a genuine stall in the same take. The manager's
+      // forwarding is gated on `captureStallReported`, so this arriving at the
+      // consumer is the proof that the refusal did not consume that latch.
+      stub.onCaptureStalled?(
+        CaptureStallContext(
+          sessionID: manager.currentCaptureSessionID,
+          armedAtUptimeNs: 0,
+          firedAtUptimeNs: 1,
+          route: "stub",
+          sourceType: "stub",
+          engineStartedSuccessfully: true,
+          tapInstalled: true,
+          formatMismatchObserved: false,
+          inputDeviceUIDPreferred: nil,
+          inputDeviceUIDSystemDefault: nil,
+          failureMode: .noBuffers))
+
+      #expect(stalls.count == 1)
+    }
+  }
+
   /// The wake instrument's honesty rule (#1788, cloud review r5-r7). SEVEN review
   /// rounds on this one diagnostic all reduced to reading a quantity over an interval
   /// it does not describe, so the rule deciding `stream_measured` vs `floor` is

--- a/Tests/EnviousWisprTests/Audio/ZeroSignalDeviceIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Audio/ZeroSignalDeviceIdentityTests.swift
@@ -31,6 +31,7 @@ struct ZeroSignalDeviceIdentityTests {
   /// Counts hardware classifications so a test can prove a guard short-circuited
   /// BEFORE consulting them, rather than merely returning the right boolean.
   private final class ReadCounter {
+    var uidCalls = 0
     var livenessCalls = 0
     var muteCalls = 0
   }
@@ -43,21 +44,59 @@ struct ZeroSignalDeviceIdentityTests {
     muteState: DeviceMuteState = .unmuted,
     counter: ReadCounter = ReadCounter()
   ) -> Bool {
-    // Default the "UID now" from the bind UNDER TEST, not the shared fixture, so a
-    // case supplying its own non-nil bind cannot silently be compared against the
-    // wrong identity.
-    let resolvedUID: String? = uidNow ?? bound.deviceUID
-    return ZeroSignalDeviceDiscriminator.isEligible(
+    ZeroSignalDeviceDiscriminator.isEligible(
       bound: bound,
-      inputDeviceUID: { _ in resolvedUID },
-      liveness: { _ in
-        counter.livenessCalls += 1
-        return liveness
-      },
-      muteState: { _ in
-        counter.muteCalls += 1
-        return muteState
-      })
+      inputDeviceUID: Self.uidReader(bound: bound, uidNow: uidNow, counter: counter),
+      liveness: Self.livenessReader(liveness, counter),
+      muteState: Self.muteReader(muteState, counter))
+  }
+
+  /// #1578: the reason-bearing form of `evaluate`, driving the SAME injected
+  /// implementation the Boolean wrapper now delegates to — no second classifier
+  /// is reconstructed here.
+  private static func classify(
+    bound: BoundInputDevice? = Self.bound,
+    uidNow: String?? = nil,
+    liveness: DeviceLiveness = .alive,
+    muteState: DeviceMuteState = .unmuted,
+    counter: ReadCounter = ReadCounter()
+  ) -> ZeroSignalEligibility {
+    ZeroSignalDeviceDiscriminator.classify(
+      bound: bound,
+      inputDeviceUID: Self.uidReader(bound: bound, uidNow: uidNow, counter: counter),
+      liveness: Self.livenessReader(liveness, counter),
+      muteState: Self.muteReader(muteState, counter))
+  }
+
+  // Default the "UID now" from the bind UNDER TEST, not the shared fixture, so a
+  // case supplying its own non-nil bind cannot silently be compared against the
+  // wrong identity.
+  private static func uidReader(
+    bound: BoundInputDevice?, uidNow: String??, counter: ReadCounter
+  ) -> (AudioDeviceID) -> String? {
+    let resolvedUID: String? = uidNow ?? bound?.deviceUID
+    return { _ in
+      counter.uidCalls += 1
+      return resolvedUID
+    }
+  }
+
+  private static func livenessReader(
+    _ liveness: DeviceLiveness, _ counter: ReadCounter
+  ) -> (AudioDeviceID) -> DeviceLiveness {
+    { _ in
+      counter.livenessCalls += 1
+      return liveness
+    }
+  }
+
+  private static func muteReader(
+    _ muteState: DeviceMuteState, _ counter: ReadCounter
+  ) -> (AudioDeviceID) -> DeviceMuteState {
+    { _ in
+      counter.muteCalls += 1
+      return muteState
+    }
   }
 
   // MARK: - 1. Positive control (mandatory)
@@ -65,6 +104,7 @@ struct ZeroSignalDeviceIdentityTests {
   @Test("matching UID + alive + unmuted → eligible")
   func matchingUIDAliveUnmutedIsEligible() {
     #expect(Self.evaluate() == true)
+    #expect(Self.classify() == .eligible)
   }
 
   // MARK: - 2-4. Identity failures
@@ -81,6 +121,7 @@ struct ZeroSignalDeviceIdentityTests {
     // liveness is asking about the wrong microphone.
     #expect(counter.livenessCalls == 0, "liveness consulted despite a UID mismatch")
     #expect(counter.muteCalls == 0, "mute consulted despite a UID mismatch")
+    #expect(Self.classify(uidNow: .some("00-11-22-33-44-55:input")) == .identityMismatch)
   }
 
   @Test("UID unknown at bind time → refused, fails closed")
@@ -94,6 +135,9 @@ struct ZeroSignalDeviceIdentityTests {
     #expect(eligible == false)
     #expect(counter.livenessCalls == 0, "liveness consulted despite no bind-time UID")
     #expect(counter.muteCalls == 0, "mute consulted despite no bind-time UID")
+    // An unknown bind UID is an IDENTITY answer, not a missing bind: the bind
+    // itself exists, we simply cannot prove it still names the same microphone.
+    #expect(Self.classify(bound: bindWithoutUID) == .identityMismatch)
   }
 
   @Test("UID lookup fails now → refused, fails closed")
@@ -106,6 +150,7 @@ struct ZeroSignalDeviceIdentityTests {
     #expect(eligible == false)
     #expect(counter.livenessCalls == 0, "liveness consulted despite an unreadable UID")
     #expect(counter.muteCalls == 0, "mute consulted despite an unreadable UID")
+    #expect(Self.classify(uidNow: .some(nil)) == .identityMismatch)
   }
 
   // MARK: - 5-6. Liveness failures
@@ -113,11 +158,13 @@ struct ZeroSignalDeviceIdentityTests {
   @Test("device removed → refused")
   func removedDeviceRefuses() {
     #expect(Self.evaluate(liveness: .removed) == false)
+    #expect(Self.classify(liveness: .removed) == .notAlive)
   }
 
   @Test("liveness unverified → refused, never read as alive")
   func unverifiedLivenessRefuses() {
     #expect(Self.evaluate(liveness: .unverified) == false)
+    #expect(Self.classify(liveness: .unverified) == .notAlive)
   }
 
   // MARK: - 7-8. Mute failures
@@ -125,10 +172,111 @@ struct ZeroSignalDeviceIdentityTests {
   @Test("device muted → refused (a muted mic zero-fills by design)")
   func mutedDeviceRefuses() {
     #expect(Self.evaluate(muteState: .muted) == false)
+    #expect(Self.classify(muteState: .muted) == .deviceMuted)
   }
 
   @Test("mute unverified → refused, never read as unmuted")
   func unverifiedMuteRefuses() {
     #expect(Self.evaluate(muteState: .unverified) == false)
+    #expect(Self.classify(muteState: .unverified) == .muteUnverified)
+  }
+
+  // MARK: - 9. #1578 — the reason set itself
+
+  /// The closed set is the contract §3a's metric definition reads. A silently
+  /// added or renamed case would change what every dashboard row means, so the
+  /// exact membership AND the exact wire values are frozen here.
+  @Test("#1578: the eligibility reason set is exactly these six cases and raw values")
+  func eligibilityCaseSetIsFrozen() {
+    #expect(
+      ZeroSignalEligibility.allCases == [
+        .eligible, .boundDeviceUnavailable, .identityMismatch,
+        .notAlive, .deviceMuted, .muteUnverified,
+      ])
+    #expect(
+      ZeroSignalEligibility.allCases.map(\.rawValue) == [
+        "eligible", "bound_device_unavailable", "identity_mismatch",
+        "not_alive", "device_muted", "mute_unverified",
+      ])
+  }
+
+  @Test("#1578: a missing frozen bind classifies as boundDeviceUnavailable, reading nothing")
+  func missingBindClassifiesWithoutReadingHardware() {
+    let counter = ReadCounter()
+
+    let reason = Self.classify(bound: nil, counter: counter)
+
+    #expect(reason == .boundDeviceUnavailable)
+    // It must not lie as identity mismatch, mute-unverified, or eligible — and
+    // it must not consult CoreAudio about a device it does not have.
+    #expect(counter.uidCalls == 0, "UID consulted despite no frozen bind")
+    #expect(counter.livenessCalls == 0, "liveness consulted despite no frozen bind")
+    #expect(counter.muteCalls == 0, "mute consulted despite no frozen bind")
+  }
+
+  // MARK: - 10. #1578 — precedence and wrapper equivalence
+
+  /// Identity beats liveness beats mute. Asserted with read counters rather than
+  /// return values alone: a classifier that returned the right reason while
+  /// still questioning a recycled handle would pass a value-only test.
+  @Test("#1578: precedence is identity → liveness → mute, each short-circuiting")
+  func precedenceShortCircuitsInOrder() {
+    // All three unhealthy at once: identity must win and nothing below runs.
+    let identityFirst = ReadCounter()
+    #expect(
+      Self.classify(
+        uidNow: .some("00-11-22-33-44-55:input"), liveness: .removed, muteState: .muted,
+        counter: identityFirst) == .identityMismatch)
+    #expect(identityFirst.livenessCalls == 0)
+    #expect(identityFirst.muteCalls == 0)
+
+    // Identity healthy, liveness and mute both unhealthy: liveness wins and the
+    // mute read never happens.
+    let livenessSecond = ReadCounter()
+    #expect(
+      Self.classify(liveness: .removed, muteState: .muted, counter: livenessSecond) == .notAlive)
+    #expect(livenessSecond.livenessCalls == 1)
+    #expect(livenessSecond.muteCalls == 0, "mute consulted despite a non-alive device")
+
+    // Only mute unhealthy: the mute read is reached and decides.
+    let muteLast = ReadCounter()
+    #expect(Self.classify(muteState: .muted, counter: muteLast) == .deviceMuted)
+    #expect(muteLast.livenessCalls == 1)
+    #expect(muteLast.muteCalls == 1)
+  }
+
+  /// The Boolean wrapper is retained for direct callers, so it must stay exactly
+  /// `classify(...) == .eligible` for every reachable non-nil outcome — including
+  /// the healthy one, or an always-false wrapper would satisfy the refusals alone.
+  @Test("#1578: isEligible equals classify == .eligible for every non-nil outcome")
+  func booleanWrapperMatchesClassificationForEveryOutcome() {
+    let bindWithoutUID = BoundInputDevice(
+      deviceID: 121, deviceUID: nil, transportLabel: "bluetooth")
+
+    // (bind, uidNow, liveness, mute) → the outcome each row is here to cover.
+    let rows: [(BoundInputDevice, String??, DeviceLiveness, DeviceMuteState)] = [
+      (Self.bound, nil, .alive, .unmuted),  // eligible
+      (Self.bound, .some("00-11-22-33-44-55:input"), .alive, .unmuted),  // identityMismatch
+      (bindWithoutUID, nil, .alive, .unmuted),  // identityMismatch
+      (Self.bound, .some(nil), .alive, .unmuted),  // identityMismatch
+      (Self.bound, nil, .removed, .unmuted),  // notAlive
+      (Self.bound, nil, .unverified, .unmuted),  // notAlive
+      (Self.bound, nil, .alive, .muted),  // deviceMuted
+      (Self.bound, nil, .alive, .unverified),  // muteUnverified
+    ]
+
+    var observed: Set<ZeroSignalEligibility> = []
+    for (bind, uidNow, liveness, muteState) in rows {
+      let reason = Self.classify(
+        bound: bind, uidNow: uidNow, liveness: liveness, muteState: muteState)
+      let boolean = Self.evaluate(
+        bound: bind, uidNow: uidNow, liveness: liveness, muteState: muteState)
+      #expect(boolean == (reason == .eligible), "wrapper disagreed with \(reason)")
+      observed.insert(reason)
+    }
+
+    // Every case except the nil-bind one — which `isEligible` structurally cannot
+    // reach, since it takes a non-optional bind — is exercised above.
+    #expect(observed == Set(ZeroSignalEligibility.allCases).subtracting([.boundDeviceUnavailable]))
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
@@ -657,12 +658,97 @@ struct HeartPathTelemetryEmitterTests {
       #expect(captured?.intProps["gap_ms"] == 1_200)
     }
 
+    // MARK: - #1578 zero-signal refusal
+
+    @Test("zeroSignalRefused adds one breadcrumb AND one PostHog event with identical props")
+    func zeroSignalRefusedFansOut() {
+      let recorder = Recorder()
+      let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+      let box = CapturedEventsBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      emitter.zeroSignalRefused(
+        ZeroSignalRefusalContext(
+          sessionID: 12,
+          reason: .deviceMuted,
+          transport: "usb",
+          failureShape: .becameZeroMidCapture))
+
+      #expect(recorder.breadcrumbs.count == 1)
+      #expect(recorder.breadcrumbs.first?.stage == "recording")
+      #expect(recorder.breadcrumbs.first?.message == "Zero signal refusal observed")
+      // Exactly three keys, no more: the payload carries no session id, device
+      // id, UID, or anything that could identify a user or a recording.
+      let breadcrumbKeys = Set(recorder.breadcrumbs.first.map { Array($0.data.keys) } ?? [])
+      #expect(breadcrumbKeys == ["reason", "transport", "failure_shape"])
+      #expect(recorder.breadcrumbs.first?.data["reason"] as? String == "device_muted")
+      #expect(recorder.breadcrumbs.first?.data["transport"] as? String == "usb")
+      #expect(
+        recorder.breadcrumbs.first?.data["failure_shape"] as? String == "became_zero_mid_capture")
+      // A user or environment condition, not a bug: breadcrumb only, so no
+      // standalone Sentry issue and no alert.
+      #expect(recorder.errors.isEmpty)
+
+      #expect(box.events.count == 1)
+      let captured = box.events.first
+      #expect(captured?.name == "audio.zero_signal_refused")
+      #expect(
+        captured?.stringProps == [
+          "reason": "device_muted",
+          "transport": "usb",
+          "failure_shape": "became_zero_mid_capture",
+        ])
+      #expect(captured?.intProps.isEmpty == true)
+      #expect(captured?.doubleProps.isEmpty == true)
+      #expect(captured?.boolProps.isEmpty == true)
+    }
+
+    @Test("zeroSignalRefused does NOT dedup — two identical runs emit twice")
+    func zeroSignalRefusedDoesNotDedup() {
+      let recorder = Recorder()
+      let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+      let box = CapturedEventsBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      // Same session, same reason, same transport, same shape — which is what a
+      // muted mic that recovers and goes silent again genuinely produces.
+      // Exactly-once already holds at the producer (one refusal per zero run);
+      // a second mechanism here would delete the later runs.
+      let context = ZeroSignalRefusalContext(
+        sessionID: 12,
+        reason: .deviceMuted,
+        transport: "usb",
+        failureShape: .becameZeroMidCapture)
+      emitter.zeroSignalRefused(context)
+      emitter.zeroSignalRefused(context)
+
+      #expect(recorder.breadcrumbs.count == 2)
+      #expect(box.events.count == 2)
+      #expect(recorder.errors.isEmpty)
+    }
+
     /// Sendable-safe capture box for the DEBUG `testEventHook` (a `@Sendable`
     /// closure): a `@MainActor` class is implicitly Sendable, mutated via
     /// `MainActor.assumeIsolated` since the emit is synchronous on the main actor.
     @MainActor
     private final class CapturedEventBox {
       var event: CapturedTelemetryEvent?
+    }
+
+    /// #1578: the counting twin of `CapturedEventBox`. The single-slot box
+    /// above overwrites, so it cannot tell one emission from two — which is the
+    /// whole claim of the no-dedup test.
+    @MainActor
+    private final class CapturedEventsBox {
+      var events: [CapturedTelemetryEvent] = []
     }
   #endif
 }

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -263,7 +263,298 @@ struct HeartPathTelemetryWiringTests {
 
     await pipeline.cancelRecording()
   }
+
+  // #1578: the asymmetry test. `handleCaptureStall` deliberately reaches the
+  // kernel FSM; `handleZeroSignalRefusal` deliberately does not. Asserting only
+  // that the observer fired would pass for a method that ALSO stopped the
+  // recording, so this drives a real session to `.live` and then proves the FSM
+  // did not move. `hasUnconsumedRecordingExit` is the strong witness: an
+  // accidental `externalCaptureStalled` on a zero-signal mode latches a
+  // recording exit synchronously, so it would be `true` the moment the call
+  // returned. It needs `kernelForTesting`, which is DEBUG-only.
+  #if DEBUG
+    @Test("KernelDictationDriver.handleZeroSignalRefusal observes without moving the FSM")
+    func refusalReachesTelemetryWithoutTouchingTheFSM() async throws {
+      let fixture = try SyntheticAudioFixture.make(
+        fileName: "1578-refusal-no-fsm-move.wav",
+        pattern: .toneBurst
+      )
+      let audioCapture = try FixtureAudioCapture(fixtureURL: fixture.url, deliverFirstBuffer: true)
+      let asrManager = MockASRManager(
+        transcribeBehavior: .success(
+          ASRResult(
+            text: "",
+            language: "en",
+            duration: fixture.durationSeconds,
+            processingTime: 0.01,
+            backendType: .parakeet
+          )
+        )
+      )
+      let vad = KernelDictationDriverFactory.makeSharedVADSignalSource(
+        audioCapture: audioCapture)
+      let pipeline = KernelDictationDriverFactory.makeForParakeet(
+        inputs: .init(
+          audioCapture: audioCapture,
+          asrManager: asrManager,
+          vadSignalSource: vad,
+          transcriptStore: TranscriptStore(),
+          keychainManager: KeychainManager(),
+          captureTelemetry: CaptureTelemetryState(),
+          pasteCompletionRegistry: PasteCompletionRegistry(),
+          engineMutationScope: .alwaysAllowedForTesting,
+          captureErrorSink: { _, _, _, _, _ in }
+        ))
+      let stateWaiter = PipelineStateWaiter(pipeline)
+
+      let config = DictationSessionConfig.testDefault(
+        autoPasteToActiveApp: false,
+        vadSensitivity: 0.5,
+        languageMode: .auto,
+        llmProvider: .openAI,
+        llmModel: "gpt-test"
+      )
+      try await pipeline.handle(event: .toggleRecording(config))
+      // `PipelineStateWaiter` subscribes to `onStateChange` and parks on a
+      // continuation until `.recording` is observed; its 5s timeout is only the
+      // deadline fallback around that signal. Same helper, same call, as the
+      // stall test above.
+      // settle: signal wait on an observed state change, not a clock wait.
+      await stateWaiter.wait(for: .recording)
+
+      // Preconditions, so the post-call assertions cannot pass vacuously.
+      #expect(pipeline.state == .recording)
+      #expect(pipeline.kernelForTesting.state == .live)
+      #expect(pipeline.kernelForTesting.hasUnconsumedRecordingExit == false)
+      #expect(pipeline.kernelForTesting.recordingOutcome == nil)
+
+      let box = RefusalEventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      pipeline.handleZeroSignalRefusal(
+        ZeroSignalRefusalContext(
+          sessionID: 5,
+          reason: .deviceMuted,
+          transport: "usb",
+          failureShape: .becameZeroMidCapture))
+
+      // 1. The observation genuinely travelled the whole route.
+      #expect(box.events.map(\.name) == ["audio.zero_signal_refused"])
+
+      // 2. And the recording is untouched. An accidental zero-signal stall call
+      // would synchronously flip `hasUnconsumedRecordingExit`; the other three
+      // assertions freeze the broader observer-only contract.
+      #expect(pipeline.state == .recording)
+      #expect(pipeline.kernelForTesting.state == .live)
+      #expect(
+        pipeline.kernelForTesting.hasUnconsumedRecordingExit == false,
+        "a refusal latched a recording exit — did handleZeroSignalRefusal call externalCaptureStalled?"
+      )
+      #expect(pipeline.kernelForTesting.recordingOutcome == nil)
+
+      await pipeline.cancelRecording()
+    }
+
+    /// Collects PostHog events emitted through the DEBUG hook during a single
+    /// synchronous main-actor call.
+    @MainActor
+    private final class RefusalEventBox {
+      var events: [CapturedTelemetryEvent] = []
+    }
+
+    // #1578: the backlog's ONLY route to the emitter is a single line in
+    // `KernelDictationDriverFactory`. Delete it and the kernel still drains, the
+    // sink is still called, and every direct kernel, manager, router, emitter and
+    // service test stays green — while production emits nothing at all. That is
+    // the definition of a guard nothing arms, so this test builds the driver
+    // through the REAL factory and watches the REAL telemetry hook.
+    @Test("#1578: the drained backlog reaches PostHog through the production factory wiring")
+    func drainedBacklogReachesTelemetryThroughFactoryWiring() async throws {
+      let audioCapture = BacklogAudioCapture()
+      let pipeline = Self.makeFactoryDriver(audioCapture: audioCapture)
+      let stateWaiter = PipelineStateWaiter(pipeline)
+
+      let box = RefusalEventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      // A real session, then a real terminal — `cancel()` from `.idle` concludes
+      // nothing and would reach no drain point at all.
+      try await pipeline.handle(event: .toggleRecording(Self.refusalConfig))
+      // settle: signal wait on an observed state change, not a clock wait.
+      await stateWaiter.wait(for: .recording)
+      #expect(pipeline.state == .recording)
+
+      // Populate the backlog INSIDE the active session. Seeding it beforehand
+      // would model a state production cannot reach: `AudioCaptureManager`
+      // clears any prior-session backlog when capture begins, so a pre-start
+      // seed is a context production would already have thrown away.
+      let activeSessionID = audioCapture.currentCaptureSessionID
+      audioCapture.stubbedPending = [
+        ZeroSignalRefusalContext(
+          sessionID: activeSessionID,
+          reason: .deviceMuted,
+          transport: "usb",
+          failureShape: .becameZeroMidCapture),
+        ZeroSignalRefusalContext(
+          sessionID: activeSessionID,
+          reason: .notAlive,
+          transport: "bluetooth",
+          failureShape: .allZeroFromStart),
+      ]
+      #expect(audioCapture.stubbedPending.count == 2)
+
+      await pipeline.cancelRecording()
+
+      let refusals = box.events.filter { $0.name == "audio.zero_signal_refused" }
+      #expect(refusals.count == 2, "N pending contexts must produce N events, not one batch")
+      #expect(
+        refusals.map { $0.stringProps["reason"] } == ["device_muted", "not_alive"],
+        "order lost between the atomic take and the emitter")
+      #expect(refusals.map { $0.stringProps["transport"] } == ["usb", "bluetooth"])
+      #expect(
+        refusals.map { $0.stringProps["failure_shape"] }
+          == ["became_zero_mid_capture", "all_zero_from_start"])
+      #expect(audioCapture.takeCallCount == 1, "the terminal did not perform exactly one drain")
+      #expect(audioCapture.stubbedPending.isEmpty)
+    }
+
+    @Test("#1578: an empty backlog emits nothing through the production wiring")
+    func emptyBacklogEmitsNothingThroughFactoryWiring() async throws {
+      let audioCapture = BacklogAudioCapture()
+      let pipeline = Self.makeFactoryDriver(audioCapture: audioCapture)
+      let stateWaiter = PipelineStateWaiter(pipeline)
+
+      let box = RefusalEventBox()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.events.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      try await pipeline.handle(event: .toggleRecording(Self.refusalConfig))
+      // settle: signal wait on an observed state change, not a clock wait.
+      await stateWaiter.wait(for: .recording)
+      #expect(pipeline.state == .recording)
+      #expect(audioCapture.stubbedPending.isEmpty)
+
+      await pipeline.cancelRecording()
+
+      // The paired control. Without it, a factory that emitted a spurious event on
+      // every terminal would satisfy the positive test above. The take assertion
+      // matters as much as the event one: it proves the control actually ENTERED
+      // the drain and found nothing, rather than silently skipping it.
+      #expect(audioCapture.takeCallCount == 1, "the empty control never entered the drain")
+      #expect(audioCapture.stubbedPending.isEmpty)
+      #expect(box.events.allSatisfy { $0.name != "audio.zero_signal_refused" })
+    }
+
+    private static let refusalConfig = DictationSessionConfig.testDefault(
+      autoPasteToActiveApp: false,
+      vadSensitivity: 0.5,
+      languageMode: .auto,
+      llmProvider: .openAI,
+      llmModel: "gpt-test"
+    )
+
+    private static func makeFactoryDriver(
+      audioCapture: BacklogAudioCapture
+    ) -> KernelDictationDriver {
+      KernelDictationDriverFactory.makeForParakeet(
+        inputs: .init(
+          audioCapture: audioCapture,
+          // MockASRManager, not NoOpASRManager: the no-op stub throws from its
+          // lifecycle methods, so the forward path never reaches `.recording` and
+          // no terminal drain point is ever exercised. Same choice the
+          // recording-state test above makes.
+          asrManager: MockASRManager(
+            transcribeBehavior: .success(
+              ASRResult(
+                text: "hello", language: "en", duration: 1,
+                processingTime: 0.01, backendType: .parakeet))),
+          vadSignalSource: KernelDictationDriverFactory.makeSharedVADSignalSource(
+            audioCapture: audioCapture),
+          transcriptStore: TranscriptStore(),
+          keychainManager: KeychainManager(),
+          captureTelemetry: CaptureTelemetryState(),
+          pasteCompletionRegistry: PasteCompletionRegistry(),
+          engineMutationScope: .alwaysAllowedForTesting,
+          captureErrorSink: { _, _, _, _, _ in }
+        ))
+    }
+  #endif
 }
+
+#if DEBUG
+  /// A capture double whose ONLY interesting behaviour is the pending-refusal
+  /// backlog, so the factory-wiring test observes the wire and nothing else.
+  @MainActor
+  private final class BacklogAudioCapture: AudioCaptureInterface {
+    var stubbedPending: [ZeroSignalRefusalContext] = []
+    private(set) var takeCallCount = 0
+
+    func takePendingZeroSignalRefusals() -> [ZeroSignalRefusalContext] {
+      takeCallCount += 1
+      let pending = stubbedPending
+      stubbedPending.removeAll(keepingCapacity: true)
+      return pending
+    }
+
+    var isCapturing: Bool = false
+    var audioLevel: Float = 0
+    var capturedSamples: [Float] = []
+    var currentAudioRoute: String = "built_in_mic"
+    var currentResolvedRoute: ResolvedRouteTransports?
+    var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+    var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
+    var onVADAutoStop: (() -> Void)?
+    var onMaxDurationReached: (() -> Void)?
+    var onCaptureStalled: ((CaptureStallContext) -> Void)?
+    var onRouteResolved: ((CaptureRouteDecision, _ sourceTypeChanged: Bool) -> Void)?
+    var currentCaptureSessionID: UInt64 = 1
+    var isActivelyCapturing: Bool = false
+    var captureSourceType: String = "hal_device_input"
+    var selectedInputDeviceUID: String = ""
+    var preferredInputDeviceIDOverride: String = ""
+    var warmEnginePolicy: WarmEnginePolicy = .off
+
+    func startEnginePhase() async throws {}
+    func beginCapturePhase(recoveryPayload: Data?) async throws -> AsyncStream<AVAudioPCMBuffer> {
+      // Same shape as `FixtureAudioCapture`: flip the capture flags and bump the
+      // session id so the forward path can reach `.recording`. Without this the
+      // session never leaves arming and no terminal drain point is ever reached.
+      currentCaptureSessionID += 1
+      isCapturing = true
+      isActivelyCapturing = true
+      return AsyncStream { $0.finish() }
+    }
+    func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+      try await beginCapturePhase(recoveryPayload: nil)
+    }
+    func stopCapture() async -> CaptureResult {
+      isCapturing = false
+      isActivelyCapturing = false
+      // Real audio, so the take is an ordinary recording rather than a
+      // zero-signal one — this test is about the BACKLOG route, not classification.
+      return CaptureResult(samples: [Float](repeating: 0.5, count: 16_000))
+    }
+    func rebuildEngine() {}
+    func retireCapturingSource(sessionID: UInt64) -> ZeroSignalRetireResult { .sourceNotRunning }
+    func preWarm() async throws {}
+    func abortPreWarm() {}
+    func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async
+      -> Bool
+    { true }
+    func configureVAD(autoStop: Bool, silenceTimeout: Double, sensitivity: Float, energyGate: Bool)
+    {}
+    func getSamplesSnapshot(fromIndex: Int) async -> (samples: [Float], totalCount: Int) { ([], 0) }
+    func getVADSegments() async -> [SpeechSegment] { [] }
+  }
+#endif
 
 // MARK: - Stubs (test-local)
 

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -535,7 +535,10 @@ struct HeartPathTelemetryWiringTests {
     func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
       try await beginCapturePhase(recoveryPayload: nil)
     }
-    func stopCapture() async -> CaptureResult {
+    // #1579 fence parameter deliberately ignored: this fixture never starts a
+    // second capture session, so a stale stop cannot arise here. The backlog
+    // route under test is orthogonal to the fence.
+    func stopCapture(sessionID _: UInt64) async -> CaptureResult {
       isCapturing = false
       isActivelyCapturing = false
       // Real audio, so the take is an ordinary recording rather than a

--- a/Tests/EnviousWisprTests/Pipeline/KernelFrozenBindGuardTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFrozenBindGuardTests.swift
@@ -4,17 +4,20 @@ import Testing
 
 @testable import EnviousWisprPipeline
 
-// #1844: the kernel's PRODUCTION eligibility closure — the one it builds itself when
-// no replacement is injected — must read the frozen `BoundInputDevice` the capture
-// layer published, and must fail closed when there is none.
+// #1844/#1578: the kernel's PRODUCTION decision-snapshot closure — the one it
+// builds when no replacement is injected — must read the frozen
+// `BoundInputDevice` the capture layer published, and must fail closed when
+// there is none.
 //
-// Every other zero-signal test in this repo injects a replacement closure (default
-// `{ true }`), which is correct for those scenarios but means the production default
-// has never been under test. These five cases drive it directly by passing nil.
+// Every other zero-signal test in this repo injects a replacement closure (since
+// #1578, one returning an eligible snapshot), which is correct for those scenarios
+// but means the production default has never been under test. These five cases
+// drive it directly by passing nil.
 //
-// HOW THE CLAIM IS PROVEN, since the closure's boolean output cannot carry it: with a
-// synthetic bind the closure returns false, and with no bind it also returns false, so
-// the output alone is uninformative. `FakeAudioCapture` therefore COUNTS reads of
+// HOW THE CLAIM IS PROVEN, since the closure's returned value cannot carry it: a
+// synthetic bind yields `.identityMismatch` and no bind yields
+// `.boundDeviceUnavailable`, and neither says whether the bind was actually
+// consulted. `FakeAudioCapture` therefore COUNTS reads of
 // `zeroSignalDiscriminatorDevice`. The count is what distinguishes "consulted the
 // frozen bind" from "refused without looking".
 //
@@ -25,7 +28,7 @@ import Testing
 // exactly what the injected `package` overload is for (covered by
 // `ZeroSignalDeviceIdentityTests`).
 @MainActor
-@Suite("Kernel production eligibility closure reads the frozen bind — #1844")
+@Suite("Kernel production decision snapshot reads the frozen bind — #1844/#1578")
 struct KernelFrozenBindGuardTests {
 
   private let threshold = AudioConstants.minimumTranscriptionSamples  // 16_000
@@ -44,7 +47,7 @@ struct KernelFrozenBindGuardTests {
     let vad: FakeVADSignalSource
   }
 
-  /// Builds a session whose eligibility closure is the KERNEL'S OWN, by passing nil.
+  /// Builds a session whose decision-snapshot closure is the KERNEL'S OWN, by passing nil.
   private func makeContext() -> Context {
     let clock = FakeClock()
     let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
@@ -52,7 +55,7 @@ struct KernelFrozenBindGuardTests {
     let vad = FakeVADSignalSource()
     let wrapper = KernelRecordingSession(
       engine: engine, capture: capture, vad: vad, clock: clock, paste: FakePasteTarget(),
-      zeroSignalDeviceEligible: nil)  // ← the production default, not a stand-in
+      zeroSignalDecisionSnapshot: nil)  // ← the production default, not a stand-in
     return Context(wrapper: wrapper, capture: capture, vad: vad)
   }
 
@@ -68,12 +71,12 @@ struct KernelFrozenBindGuardTests {
   }
 
   /// A bind built from a device this machine reports as genuinely alive AND unmuted,
-  /// using the same two classifiers the authority consults — but NOT `isEligible`
-  /// itself, so the fixture is not chosen by the function under test.
+  /// using the same liveness and mute readers the authority consults, but not
+  /// `classify(bound:)` itself, so the fixture is not chosen by the function under test.
   ///
-  /// This is the only case that can force the authority to answer TRUE, and it is
-  /// therefore the only case that distinguishes "the closure calls the shared
-  /// authority" from "the closure refuses unconditionally". Measured on this machine
+  /// This is the only case that can force the snapshot's eligibility to `.eligible`,
+  /// and therefore the only case that distinguishes "the closure calls the shared
+  /// authority" from "the closure manufactures a refusal." Measured on this machine
   /// 2026-07-30: all three input devices classify alive+unmuted, including the
   /// built-in microphone.
   /// `nonisolated` because `.enabled(if:)` is evaluated OUTSIDE actor isolation, the
@@ -114,8 +117,8 @@ struct KernelFrozenBindGuardTests {
 
     await driveAllZeroCapture(ctx)
 
-    // Only the shared authority can produce an ELIGIBLE verdict. A closure that
-    // dropped the `isEligible(bound:)` call and returned false would fail here while
+    // Only the shared classifier can produce an ELIGIBLE verdict. A closure that
+    // skipped `classify(bound:)` and manufactured a refusal would fail here while
     // still satisfying every other case in this suite.
     #expect(
       ctx.wrapper.testKernel.zeroSignalFailureMode != nil,
@@ -166,20 +169,23 @@ struct KernelFrozenBindGuardTests {
     #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
   }
 
-  @Test("an earlier muted observation short-circuits BEFORE the bind is read (#1844)")
-  func sawIneligibleShortCircuitsBeforeReadingBind() async {
+  @Test("a run already classified reactively short-circuits BEFORE the bind is read")
+  func reactivelyClassifiedRunShortCircuitsBeforeReadingBind() async {
     let ctx = makeContext()
     ctx.capture.stubbedZeroSignalDiscriminatorDevice = Self.syntheticBind
-    ctx.capture.stubbedZeroSignalDiscriminatorSawIneligible = true
+    // #1578: the categorical replacement for the old Boolean latch. The reactive
+    // producer froze a REASON for this run, and the flag says it did so.
+    ctx.capture.stubbedZeroSignalRunWasClassifiedReactively = true
+    ctx.capture.stubbedZeroSignalRefusalReason = .deviceMuted
 
     await driveAllZeroCapture(ctx)
 
-    // Guard ORDER is the contract: a genuinely-muted stretch must stay ineligible
-    // even if the device's live state has since become fine, so the latch is checked
-    // first and the device is never consulted.
+    // Guard ORDER is the contract: a stretch that was genuinely unusable must stay
+    // refused even if the device's live state has since become fine, so the frozen
+    // reason is taken and the device is never consulted.
     #expect(
       ctx.capture.zeroSignalDiscriminatorDeviceReadCount == 0,
-      "the device was consulted despite an earlier ineligible observation")
+      "the device was consulted despite a run already classified reactively")
     #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -79,6 +79,14 @@ final class FakeAudioCapture: AudioCaptureInterface {
   private var gateReachedContinuation: CheckedContinuation<Void, Never>?
   private var gateReached = false
 
+  /// #1578: same shape for `stopCapture()`. When set, the Nth (1-based) stop
+  /// parks until `releaseStopCaptureGate()`, so a test can conclude the session
+  /// by cancel while the normal STOP path is suspended mid-`await`.
+  var gateStopCaptureCall: Int?
+  private var stopGateContinuation: CheckedContinuation<Void, Never>?
+  private var stopGateReachedContinuation: CheckedContinuation<Void, Never>?
+  private var stopGateReached = false
+
   // MARK: Captured audio
 
   private var accumulatedSamples: [Float] = []
@@ -103,28 +111,55 @@ final class FakeAudioCapture: AudioCaptureInterface {
   var isActivelyCapturing: Bool { isCapturing }
   var captureSourceType: String { "hal_device_input" }
 
-  // MARK: #1844 — observing what the kernel's PRODUCTION eligibility closure reads
+  // MARK: #1844 — observing what the kernel's PRODUCTION snapshot closure reads
   //
   // Overriding the protocol's nil default lets a test hand the kernel a frozen bind
   // and, crucially, COUNT whether the closure consulted it. The count is the only
-  // way to discriminate "read the frozen bind and refused" from "refused for some
-  // other reason" — the closure returns false either way, so its boolean output
-  // proves nothing on its own.
+  // way to discriminate "read the frozen bind and refused" from "refused without
+  // looking" — since #1578 the closure returns a categorical reason, and several
+  // distinct paths can produce the same non-eligible one, so the returned value
+  // alone still cannot carry the claim.
 
   /// The frozen bind this fake publishes. nil models an invalidated attempt.
   var stubbedZeroSignalDiscriminatorDevice: BoundInputDevice?
   /// Incremented on every read of `zeroSignalDiscriminatorDevice`.
   private(set) var zeroSignalDiscriminatorDeviceReadCount = 0
-  /// Set true to model an earlier muted observation, which must short-circuit
-  /// BEFORE the device is consulted.
-  var stubbedZeroSignalDiscriminatorSawIneligible = false
-
   var zeroSignalDiscriminatorDevice: BoundInputDevice? {
     zeroSignalDiscriminatorDeviceReadCount += 1
     return stubbedZeroSignalDiscriminatorDevice
   }
 
-  var zeroSignalDiscriminatorSawIneligible: Bool { stubbedZeroSignalDiscriminatorSawIneligible }
+  // #1578: the categorical replacements for the old boolean saw-ineligible
+  // seam, which is deleted here rather than kept. The kernel no longer
+  // reads the legacy Boolean at all, so stubbing it here would model a path
+  // production does not take. `zeroSignalDiscriminatorSawIneligible` now comes
+  // from the protocol's own compatibility default.
+
+  /// The reason the reactive producer froze for the current run, if any. Read by
+  /// the production snapshot closure when the run was classified reactively.
+  var stubbedZeroSignalRefusalReason: ZeroSignalEligibility?
+  /// Whether the current run was already classified by the reactive producer.
+  /// True must short-circuit BEFORE the frozen bind is consulted.
+  var stubbedZeroSignalRunWasClassifiedReactively = false
+  /// Contexts a rejected reactive forward left behind, handed over in order by
+  /// the atomic take.
+  var stubbedPendingZeroSignalRefusals: [ZeroSignalRefusalContext] = []
+  /// Counts atomic takes, so a test can prove a second drain happened AND was
+  /// empty rather than never happening at all.
+  private(set) var takePendingZeroSignalRefusalsCallCount = 0
+
+  var zeroSignalRefusalReason: ZeroSignalEligibility? { stubbedZeroSignalRefusalReason }
+
+  var zeroSignalRunWasClassifiedReactively: Bool { stubbedZeroSignalRunWasClassifiedReactively }
+
+  /// Mirrors `AudioCaptureManager`'s contract exactly: synchronous, order
+  /// preserving, and empty on every call after the first.
+  func takePendingZeroSignalRefusals() -> [ZeroSignalRefusalContext] {
+    takePendingZeroSignalRefusalsCallCount += 1
+    let pending = stubbedPendingZeroSignalRefusals
+    stubbedPendingZeroSignalRefusals.removeAll(keepingCapacity: true)
+    return pending
+  }
 
   // MARK: AudioCaptureInterface — callbacks
 
@@ -178,7 +213,31 @@ final class FakeAudioCapture: AudioCaptureInterface {
     bufferContinuation?.finish()
     bufferContinuation = nil
     bufferStream = nil
-    return CaptureResult(samples: accumulatedSamples, vadSegments: segments)
+    let result = CaptureResult(samples: accumulatedSamples, vadSegments: segments)
+    // #1578: park the Nth stop so a test can land a cancel while the normal STOP
+    // is suspended — the exact race the drain-before-await ordering exists for.
+    // Modelled on `gateStabilizationCall` above; signal-based, never a sleep, so
+    // it satisfies the simulator's wall-clock ban.
+    if let gate = gateStopCaptureCall, gate == stopCaptureCallCount {
+      stopGateReached = true
+      stopGateReachedContinuation?.resume()
+      stopGateReachedContinuation = nil
+      await withCheckedContinuation { stopGateContinuation = $0 }
+    }
+    return result
+  }
+
+  /// Suspend until the gated `stopCapture()` call has parked. Returns
+  /// immediately if it already parked.
+  func awaitStopCaptureGateReached() async {
+    if stopGateReached { return }
+    await withCheckedContinuation { stopGateReachedContinuation = $0 }
+  }
+
+  /// Resume the parked `stopCapture()` call.
+  func releaseStopCaptureGate() {
+    stopGateContinuation?.resume()
+    stopGateContinuation = nil
   }
 
   func rebuildEngine() { rebuildEngineCallCount += 1 }

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -210,9 +210,15 @@ final class KernelRecordingSession: RecordingSessionDriving {
     // default (real CoreAudio calls).
     // #1844: OPTIONAL so a test can pass nil and reach the kernel's PRODUCTION
     // default closure, which is the only way to prove that closure reads the frozen
-    // bind. Still defaults to `{ true }`, so all 37 existing scenarios are unchanged
-    // and none of them starts depending on this machine's real microphone.
-    zeroSignalDeviceEligible: (@MainActor () -> Bool)? = { true }
+    // bind. #1578 widened it from a Boolean to the decision snapshot; the default
+    // is the eligible/not-yet-classified pair, which is exactly what `{ true }`
+    // meant before, so every existing scenario is unchanged and none of them
+    // starts depending on this machine's real microphone.
+    zeroSignalDecisionSnapshot: (@MainActor () -> ZeroSignalDecisionSnapshot)? = {
+      ZeroSignalDecisionSnapshot(eligibility: .eligible, currentRunWasClassifiedReactively: false)
+    },
+    /// #1578: collects refusals the kernel drains or classifies at STOP.
+    zeroSignalRefusalSink: @escaping @MainActor ([ZeroSignalRefusalContext]) -> Void = { _ in }
   ) {
     self.vad = vad
     let limb = self.limb
@@ -269,7 +275,8 @@ final class KernelRecordingSession: RecordingSessionDriving {
       stopTimeZeroSignalTelemetry: { [stopTimeTelemetryLog] ctx in
         stopTimeTelemetryLog.fired.append(ctx)
       },
-      zeroSignalDeviceEligible: zeroSignalDeviceEligible,
+      zeroSignalDecisionSnapshot: zeroSignalDecisionSnapshot,
+      zeroSignalRefusalSink: zeroSignalRefusalSink,
       telemetryState: telemetryState)
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ZeroSignalRecoveryTests.swift
@@ -15,8 +15,9 @@ import Testing
 // its own confidence threshold, or STOP raced it — so the kernel classifies
 // the complete `captureResult.samples` itself at stop time, §3.6).
 //
-// `zeroSignalDeviceEligible` is injected per-scenario (deterministic — never
-// depends on the test machine's real microphone/mute state).
+// `zeroSignalDecisionSnapshot` is injected per-scenario (deterministic — never
+// depends on the test machine's real microphone or device state). #1578 widened
+// it from a Boolean to a categorical reason plus the reactively-classified flag.
 
 @MainActor
 @Suite("RecordingSessionKernel — zero-signal recovery (#1317)")
@@ -32,7 +33,10 @@ struct ZeroSignalRecoveryTests {
   }
 
   private func makeContext(
-    zeroSignalDeviceEligible: @escaping @MainActor () -> Bool = { true },
+    zeroSignalDecisionSnapshot: @escaping @MainActor () -> ZeroSignalDecisionSnapshot = {
+      ZeroSignalDecisionSnapshot(eligibility: .eligible, currentRunWasClassifiedReactively: false)
+    },
+    zeroSignalRefusalSink: @escaping @MainActor ([ZeroSignalRefusalContext]) -> Void = { _ in },
     minimumRecordingTicks: Int = 0
   ) -> Context {
     let clock = FakeClock()
@@ -43,7 +47,8 @@ struct ZeroSignalRecoveryTests {
     let wrapper = KernelRecordingSession(
       engine: engine, capture: capture, vad: vad, clock: clock, paste: paste,
       minimumRecordingTicks: minimumRecordingTicks,
-      zeroSignalDeviceEligible: zeroSignalDeviceEligible)
+      zeroSignalDecisionSnapshot: zeroSignalDecisionSnapshot,
+      zeroSignalRefusalSink: zeroSignalRefusalSink)
     return Context(wrapper: wrapper, engine: engine, capture: capture, vad: vad)
   }
 
@@ -364,7 +369,12 @@ struct ZeroSignalRecoveryTests {
     "STOP-win: an all-zero capture on an ineligible device (muted or unverified) stays ordinary no-speech"
   )
   func stopWinFailsClosedWhenDeviceNotEligible() async {
-    let ctx = makeContext(zeroSignalDeviceEligible: { false })
+    let ctx = makeContext(
+      zeroSignalDecisionSnapshot: {
+        // #1578: "ineligible" is now a NAMED reason, not a bare false.
+        ZeroSignalDecisionSnapshot(
+          eligibility: .deviceMuted, currentRunWasClassifiedReactively: false)
+      })
     await startToRecording(ctx)
     ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
     ctx.vad.evidence = .confirmedNoSpeech
@@ -553,7 +563,12 @@ struct ZeroSignalRecoveryTests {
 
   @Test("ineligible all-zero (the #1520 gap) emits a retire-attempt with health_guess_refused=true")
   func deadMicTelemetryIneligibleAllZero() async {
-    let ctx = makeContext(zeroSignalDeviceEligible: { false })
+    let ctx = makeContext(
+      zeroSignalDecisionSnapshot: {
+        // #1578: "ineligible" is now a NAMED reason, not a bare false.
+        ZeroSignalDecisionSnapshot(
+          eligibility: .deviceMuted, currentRunWasClassifiedReactively: false)
+      })
     await startToRecording(ctx)
     ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
     ctx.vad.evidence = .confirmedNoSpeech
@@ -611,5 +626,376 @@ struct ZeroSignalRecoveryTests {
     #expect(ctx.wrapper.deadMicRecoveries.count == 1)
     #expect(ctx.wrapper.deadMicRecoveries.first?.recovered == false)
     #expect(ctx.wrapper.deadMicRecoveries.first?.resolution == "later_retire")
+  }
+
+  // MARK: - #1578 group 1: STOP snapshot cardinality
+  //
+  // STOP reads the snapshot ONCE and splits three ways. These four rows pin every
+  // reachable combination, and the two reactive-true rows matter most: whether the
+  // reactive forward was ACCEPTED (empty backlog) or REJECTED (a pending context)
+  // must make no difference to STOP. If it ever did, a rejected refusal would be
+  // emitted from the backlog AND re-emitted here.
+
+  private static func refusal(
+    _ sessionID: UInt64, _ reason: ZeroSignalEligibility = .deviceMuted,
+    _ transport: String = "usb", _ shape: CaptureStallFailureMode = .becameZeroMidCapture
+  ) -> ZeroSignalRefusalContext {
+    ZeroSignalRefusalContext(
+      sessionID: sessionID, reason: reason, transport: transport, failureShape: shape)
+  }
+
+  /// Collects everything the kernel hands the refusal sink, flattened in order.
+  private final class RefusalSinkLog {
+    var batches: [[ZeroSignalRefusalContext]] = []
+    var flattened: [ZeroSignalRefusalContext] { batches.flatMap { $0 } }
+  }
+
+  private func makeRefusalContext(
+    snapshot: @escaping @MainActor () -> ZeroSignalDecisionSnapshot,
+    log: RefusalSinkLog
+  ) -> Context {
+    makeContext(
+      zeroSignalDecisionSnapshot: snapshot,
+      zeroSignalRefusalSink: { contexts in log.batches.append(contexts) })
+  }
+
+  private func driveZeroSignalStop(_ ctx: Context) async {
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0)
+    ctx.vad.evidence = .confirmedNoSpeech
+    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+  }
+
+  @Test("#1578 STOP: a run already classified reactively and ACCEPTED adds nothing")
+  func stopAddsNothingWhenReactivelyClassifiedAndAccepted() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .deviceMuted, currentRunWasClassifiedReactively: true)
+      }, log: log)
+    // Accepted forward ⇒ nothing left pending.
+    ctx.capture.stubbedPendingZeroSignalRefusals = []
+
+    await driveZeroSignalStop(ctx)
+
+    #expect(log.flattened.isEmpty, "STOP re-emitted a run the reactive path already owned")
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+  }
+
+  @Test("#1578 STOP: a run classified reactively but REJECTED emits only from the backlog")
+  func stopEmitsOnlyBacklogWhenReactivelyClassifiedAndRejected() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .deviceMuted, currentRunWasClassifiedReactively: true)
+      }, log: log)
+    ctx.capture.stubbedPendingZeroSignalRefusals = [Self.refusal(1)]
+
+    await driveZeroSignalStop(ctx)
+
+    // Exactly one — the drained one. STOP must not add a second for the same run,
+    // which is why forwarding success never controls suppression.
+    #expect(log.flattened.count == 1)
+    #expect(log.flattened.first == Self.refusal(1))
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+  }
+
+  @Test("#1578 STOP: an unclassified ELIGIBLE run keeps today's stall behaviour exactly")
+  func stopEligibleUnclassifiedPreservesStallPath() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: false)
+      }, log: log)
+
+    await driveZeroSignalStop(ctx)
+
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode != nil, "the stamp regressed")
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.count == 1)
+    #expect(log.flattened.isEmpty, "an eligible run must produce no refusal")
+  }
+
+  @Test("#1578 STOP: an unclassified NON-ELIGIBLE run emits one refusal and no stall")
+  func stopNonEligibleUnclassifiedEmitsOneRefusal() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .notAlive, currentRunWasClassifiedReactively: false)
+      }, log: log)
+
+    await driveZeroSignalStop(ctx)
+
+    #expect(log.flattened.count == 1)
+    #expect(log.flattened.first?.reason == .notAlive)
+    #expect(log.flattened.first?.failureShape == .allZeroFromStart)
+    // A refusal is an observation, never a stall confirmation.
+    #expect(ctx.wrapper.testKernel.zeroSignalFailureMode == nil)
+    #expect(ctx.wrapper.stopTimeZeroSignalTelemetryFired.isEmpty)
+  }
+
+  // MARK: - #1578 group 2: terminal × backlog cross-product
+  //
+  // Three terminals reach a drain point, each with an empty and a non-empty
+  // backlog. The non-empty cells use TWO distinct contexts so order and
+  // completeness are observable, not just "something arrived".
+
+  private static let twoPending: [ZeroSignalRefusalContext] = [
+    refusal(7, .deviceMuted, "usb", .becameZeroMidCapture),
+    refusal(7, .notAlive, "bluetooth", .allZeroFromStart),
+  ]
+
+  private func assertDrainedExactlyOnce(_ ctx: Context, _ log: RefusalSinkLog) {
+    #expect(log.flattened == Self.twoPending, "contexts lost, reordered, or duplicated")
+    #expect(
+      ctx.capture.stubbedPendingZeroSignalRefusals.isEmpty,
+      "the backlog was not cleared by the take")
+  }
+
+  @Test("#1578 terminal: normal STOP drains a non-empty backlog exactly once, in order")
+  func normalStopDrainsBacklogInOrder() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: true)
+      }, log: log)
+    ctx.capture.stubbedPendingZeroSignalRefusals = Self.twoPending
+
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.5)
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    assertDrainedExactlyOnce(ctx, log)
+  }
+
+  @Test("#1578 terminal: normal STOP with an empty backlog emits nothing")
+  func normalStopEmptyBacklogEmitsNothing() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: true)
+      }, log: log)
+
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.5)
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    // The paired control: without it, a sink that fired unconditionally would
+    // satisfy every positive cell above.
+    #expect(log.batches.isEmpty)
+  }
+
+  @Test("#1578 terminal: cancel drains a non-empty backlog exactly once, in order")
+  func cancelDrainsBacklogInOrder() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: true)
+      }, log: log)
+    ctx.capture.stubbedPendingZeroSignalRefusals = Self.twoPending
+
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.5)
+    await ctx.wrapper.apply(.cancel)
+    await ctx.wrapper.drainReadyWork()
+
+    assertDrainedExactlyOnce(ctx, log)
+  }
+
+  @Test("#1578 terminal: cancel with an empty backlog emits nothing")
+  func cancelEmptyBacklogEmitsNothing() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: true)
+      }, log: log)
+
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.5)
+    await ctx.wrapper.apply(.cancel)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(log.batches.isEmpty)
+  }
+
+  @Test("#1578 terminal: a recoverable device-removed interruption drains the backlog")
+  func deviceRemovedInterruptionDrainsBacklog() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: true)
+      }, log: log)
+    ctx.capture.stubbedPendingZeroSignalRefusals = Self.twoPending
+
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.5)
+    // Both current causes are RECOVERABLE, so both fall through the normal stop
+    // tail rather than a direct terminal — that is the #1408 salvage design, and
+    // it is why the normal-STOP drain point covers interruption too.
+    ctx.wrapper.testKernel.externalEngineInterrupted(.deviceRemoved)
+    await ctx.wrapper.drainReadyWork()
+
+    assertDrainedExactlyOnce(ctx, log)
+  }
+
+  @Test("#1578 terminal: a recoverable engine-lost interruption with an empty backlog is silent")
+  func engineLostInterruptionEmptyBacklogEmitsNothing() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: true)
+      }, log: log)
+
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.5)
+    ctx.wrapper.testKernel.externalEngineInterrupted(.engineLost)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(log.batches.isEmpty)
+  }
+
+  // MARK: - #1578 group 3: cancel landing while STOP is suspended
+  //
+  // THE hardest case in the plan, and the reason the drain sits BEFORE the await.
+  // Normal STOP claims the backlog, then suspends inside `stopCapture()`. A cancel
+  // concludes the session and drains again — finding nothing, because the take was
+  // atomic. A new session then starts and queues its OWN context. When the stale
+  // continuation finally resumes it must consume none of it.
+
+  @Test("#1578 interleaving: a cancel during a suspended STOP double-drains nothing")
+  func cancelDuringSuspendedStopConsumesNothingTwice() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: true)
+      }, log: log)
+    ctx.capture.stubbedPendingZeroSignalRefusals = Self.twoPending
+    ctx.capture.gateStopCaptureCall = 1  // park the first stop
+
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.5)
+    await ctx.wrapper.apply(.stop)
+    // Signal-based, never a sleep: resume only once the stop has genuinely parked.
+    await ctx.capture.awaitStopCaptureGateReached()
+
+    // The drain ran BEFORE the suspension, so the old contexts are already out.
+    #expect(log.flattened == Self.twoPending)
+    #expect(ctx.capture.stubbedPendingZeroSignalRefusals.isEmpty)
+    #expect(ctx.capture.takePendingZeroSignalRefusalsCallCount == 1)
+
+    // The cancel concludes while the stop is still suspended. Its second drain
+    // genuinely runs but atomically finds nothing — the take counter is what
+    // distinguishes "ran and found nothing" from "never ran at all".
+    await ctx.wrapper.apply(.cancel)
+    #expect(ctx.wrapper.testKernel.state == .idle)
+    #expect(log.flattened == Self.twoPending, "the cancel duplicated an already-drained context")
+    #expect(ctx.capture.takePendingZeroSignalRefusalsCallCount == 2)
+
+    // Start a GENUINELY new session while the old STOP continuation is parked.
+    // Inserting a context without starting one would model a window production
+    // never reaches, and would not exercise the stale continuation's fence.
+    await startToRecording(ctx)
+    #expect(ctx.wrapper.testKernel.state == .live)
+
+    let newSessionContext = Self.refusal(
+      ctx.capture.currentCaptureSessionID,
+      .identityMismatch,
+      "built_in",
+      .allZeroFromStart)
+    ctx.capture.stubbedPendingZeroSignalRefusals = [newSessionContext]
+
+    ctx.capture.releaseStopCaptureGate()
+    await ctx.wrapper.drainReadyWork()
+
+    // The stale continuation returned through its session fence without taking
+    // anything owned by the new session.
+    #expect(
+      log.flattened == Self.twoPending,
+      "a stale STOP continuation consumed a later session's refusal")
+    #expect(ctx.capture.stubbedPendingZeroSignalRefusals == [newSessionContext])
+    #expect(ctx.capture.takePendingZeroSignalRefusalsCallCount == 2)
+
+    // Clean up the new session and prove its OWN terminal is the consumer.
+    await ctx.wrapper.apply(.cancel)
+    await ctx.wrapper.drainReadyWork()
+    #expect(ctx.capture.takePendingZeroSignalRefusalsCallCount == 3)
+    #expect(log.flattened == Self.twoPending + [newSessionContext])
+  }
+
+  // MARK: - #1578 group 4: refusal and retire CO-FIRE
+  //
+  // These are not mutually exclusive, and a test asserting exclusivity would
+  // enforce a contract the code does not have. A refused FINAL run legitimately
+  // produces both.
+
+  @Test("#1578 co-fire: a refused FINAL run emits one refusal AND one refused retire")
+  func refusedFinalRunCoFiresRefusalAndRetire() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .deviceMuted, currentRunWasClassifiedReactively: false)
+      }, log: log)
+
+    await driveZeroSignalStop(ctx)
+
+    #expect(log.flattened.count == 1)
+    #expect(log.flattened.first?.reason == .deviceMuted)
+    #expect(ctx.wrapper.deadMicRetireAttempts.count == 1)
+    #expect(
+      ctx.wrapper.deadMicRetireAttempts.first?.healthGuessRefused == true,
+      "the retire must record that the health guess refused")
+  }
+
+  @Test("#1578 co-fire: an ELIGIBLE final run emits no refusal and an unrefused retire")
+  func eligibleFinalRunEmitsRetireWithoutRefusal() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: false)
+      }, log: log)
+
+    await driveZeroSignalStop(ctx)
+
+    #expect(log.flattened.isEmpty)
+    #expect(ctx.wrapper.deadMicRetireAttempts.count == 1)
+    #expect(ctx.wrapper.deadMicRetireAttempts.first?.healthGuessRefused == false)
+  }
+
+  @Test("#1578 co-fire: a refused RECOVERED run emits its refusal and no retire")
+  func refusedRecoveredRunEmitsRefusalWithoutRetire() async {
+    let log = RefusalSinkLog()
+    let ctx = makeRefusalContext(
+      snapshot: {
+        ZeroSignalDecisionSnapshot(
+          eligibility: .eligible, currentRunWasClassifiedReactively: true)
+      }, log: log)
+    // The refusal happened earlier in the take and was rejected; the microphone
+    // then recovered, so the take ends with real audio and never retires.
+    ctx.capture.stubbedPendingZeroSignalRefusals = [Self.refusal(3, .muteUnverified)]
+
+    await startToRecording(ctx)
+    ctx.capture.deliverBuffer(frameCount: threshold, amplitude: 0.5)
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+
+    #expect(log.flattened.count == 1)
+    #expect(log.flattened.first?.reason == .muteUnverified)
+    #expect(ctx.wrapper.deadMicRetireAttempts.isEmpty, "a recovered take must not retire")
   }
 }


### PR DESCRIPTION
Closes #1578.

## What was wrong

The zero-signal discriminator answered with a Boolean, so every refusal collapsed identity mismatch, dead device, hardware mute and unreadable mute into one indistinguishable `false`. A take that silently produced no audio left no diagnosable reason behind.

## What changed

- **`ZeroSignalEligibility` (6 cases) replaces the Boolean.** `ZeroSignalDeviceDiscriminator.classify(bound:)` now owns all six outcomes, including the missing-bind case that both call sites used to manufacture independently. `isEligible` is a thin `== .eligible` shim, so identity → liveness → mute precedence cannot drift between callers.
- **`AudioCaptureManager`** replaces the single Boolean latch with a reason, a per-run reactive-classification flag, and a refusal backlog, reset through one `resetZeroSignalState(clearBacklog:)` helper. The per-run gate sits INSIDE the non-eligible branch so mid-run re-evaluation still happens after a non-zero recovery (plan NG5).
- **`RecordingSessionKernel`** drains the backlog at exactly two points: immediately before `await audioCapture.stopCapture(sessionID:)`, and after the set-once `recordingOutcome` write. Take-and-clear is atomic on the MainActor, so a refusal is delivered exactly once.
- **New content-free telemetry `audio.zero_signal_refused`** carrying reason, transport and failure shape only, plus a Sentry breadcrumb (never a `captureError`, so it raises no issue and no alert).

No user-facing change. A refused take stays on today's silent no-speech path, which is the founder-locked salvage behaviour.

## Evidence

- **Tests:** 4344 pass. Three full-suite runs on this branch (one intermittent failure, see Known issues).
- **Release build:** `EnviousWispr-Release` exit 0, `** BUILD SUCCEEDED **`, zero `error:` lines.
- **Eval runners** (#1770 regression check): `swift build --package-path scripts/eval/apple_runner` and `alias_runner` both exit 0.
- **Six mutation probes**, each proving a test can actually fail: four protocol-default probes; a drain-ordering probe (moving the drain after the `await` let a stale STOP continuation consume a LATER session's refusal); a factory-wire probe (deleting the mapping produced zero production events while every other suite stayed green).
- **Whole-diff `codex review --base origin/main`**, fresh and independent of the build orchestrator: *"No actionable correctness issues were found."*
- **Phase 3:** `.validation/runs/2026-07-31T01-19-13Z-2967fae7`, Code lane, `check-validation.sh --strict` PASS.
- **Production caller grep** returns two non-`Tests/` hits: `KernelDictationDriverFactory.swift:496`, `KernelHeartPathTelemetryObserver.swift:164`.
- **Analytics schema** registered in `analytics-operations.md`.

## Live UAT

**Core acceptance PASS.** Dictated `Purple elephants dance quietly beside the copper fountain.` on the rebuilt dev app; transcribed verbatim, pasted, `Pipeline timing TOTAL: 1.726s`. No crash, no stuck overlay. `zero_signal_refused` fired 0 times on healthy takes, which is the healthy-path control plan §11 requires.

Two earlier takes were **discarded, not failed**: unrelated narrated audio was playing into the room and the microphone captured it mixed with the harness TTS. Run 2 showed the mixing directly, transcribing the expected tail verbatim while the opening was overwritten. Recorded in `live-uat-detail.json`.

**Feature positive arm BLOCKED**, which plan §11.1 names as a legitimate outcome — but the reason is now measured rather than assumed.

A hardware probe found that all three attached input devices, *including the built-in MacBook microphone*, do implement `kAudioDevicePropertyMute` on the input scope and report it settable. That contradicts the assumption in `CoreAudioDeviceMute.classify`'s doc comment that most built-in mics do not implement the property.

Setting the real property and recording, however, produces this trace:

```
21:51:28.539  SET mute=1
21:51:28.540  -> muted
21:51:37       app: Recording started
21:51:38.006  -> unmuted        <-- macOS cleared it, mid-recording
21:51:43       app: capture ended
21:51:46.686  -> muted          <-- returned on its own after release
```

**macOS clears the input-scope mute on the built-in microphone whenever a client opens the device, and restores it after release.** Our code never writes that property (`grep -rn "AudioObjectSetPropertyData" Sources/` returns nothing), so this is platform behaviour, not ours. The consequence is that `reason=device_muted` is unreachable on a built-in mic during a take; the other five reasons carry the diagnostic load. The design fails closed either way.

The first attempt at this arm transcribed perfectly and would have read as a PASS. The plan's own discard condition — verify the readback, discard if it slipped — is what caught it. Founder will re-run the arm with a USB headset that has a hardware mute.

## Known issues, not introduced here

- **#1857** — `KernelPhase2RetryTests.retryRescuedCompletionSurvivesClipboardFallback()` failed once in three full-suite runs on this branch and passed in a clean-main baseline. The shared simulator helper `drainReadyWork()` gives up after a fixed iteration count and returns silently, which is a clock in disguise. This diff adds no `Task`, no `await`, and no new async work in `Sources/`, and does not touch `drainReadyWork`, `workEpoch`, `hasUnconsumedRecordingExit`, or `deliverRecordingExit`. Filed with all four runs recorded rather than fixed by editing the test to go green.

## Corrections to the commit history

The second commit's body claims it also carries the `finishTerminal` doc-order edit for `lastTakeID`. It does not — that edit is in the first commit, made while resolving the rebase conflict. `git commit --amend` was blocked by a safety layer, so the correction is recorded here.

## Open decision, deliberately not built

#1846 landed mid-flight and now stamps a take id on diagnostic events, including the immediate neighbour `audio.dead_mic_retire_attempted`. `audio.zero_signal_refused` does not carry one, because the approved plan predates that convention. Without it a refusal cannot be joined to the dictation it belongs to. Adding it is small and mechanical but changes an approved telemetry contract, so it awaits a founder call rather than being folded in silently.
