### PR TITLE
docs(recovery): correct three comments that still describe the removed launch purge

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -379,7 +379,8 @@ final class RecordingStarter {
       // running (Codex code-diff P1). `preWarm` already started the engine, so
       // tear it down exactly like the pre-warm-release guard above does (Codex
       // code-diff r2 P2) — a bare hide/unlock would leave the mic engine running.
-      // Any key armed above is swept by the launch purge's orphan-key pass.
+      // The key armed above is cleaned inline below; the launch recovery scan's
+      // orphan-key sweep is only the backstop if this process dies first.
       if let lastStop = lastUserStopAccess.read(), lastStop > pttStart {
         audioCapture.abortPreWarm()
         // A key was armed for this take but no session will start — no terminal

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -24,8 +24,9 @@ public final class WisprBootstrapper {
   // into views via `.environment(...)` inside the view factories below.
   let navigationCoordinator: NavigationCoordinator
   let diagnosticsCoordinator: DiagnosticsCoordinator
-  /// Owns the crash-recovery limb (#1063 PR1): arms each recording's encrypted
-  /// spool, deletes it on durable save, purges orphans on launch.
+  /// Owns the crash-recovery limb: arms each recording's encrypted spool,
+  /// deletes it on durable save, and on launch scans for orphan spools and
+  /// replays them (#1063 PR2 — replaces PR1's launch purge).
   let recoveryCoordinator: RecoveryCoordinator
   let languageSuggestionPresenter: LanguageSuggestionPresenter
   let updateCoordinatorHolder: UpdateCoordinatorHolder

--- a/Sources/EnviousWisprServices/RecoveryKeyStore.swift
+++ b/Sources/EnviousWisprServices/RecoveryKeyStore.swift
@@ -92,10 +92,10 @@ public struct RecoveryKeyStore: Sendable {
   }
 
   /// Every `recoverySessionID` that currently has a stored key. Lets the launch
-  /// purge sweep ORPHAN keys (a key with no spool — e.g. a recording that armed
-  /// then aborted before any frame was written), which a spool-only scan misses.
-  /// Best-effort: an enumeration failure returns an empty list (the caller is a
-  /// purge — failing closed there just defers cleanup to the next launch).
+  /// recovery scan sweep ORPHAN keys (a key with no spool — e.g. a recording that
+  /// armed then aborted before any frame was written), which a spool-only scan
+  /// misses. Best-effort: an enumeration failure returns an empty list (the caller
+  /// is a cleanup sweep — failing closed there just defers it to the next launch).
   public func listAccountIDs() -> [String] {
     switch backend {
     case .file:


### PR DESCRIPTION
## What

Three live code comments still described #1063 PR1's launch purge, which PR2 replaced with launch replay two releases ago.

| Site | Was | Now |
|---|---|---|
| `WisprBootstrapper.swift:27` | "purges orphans on launch" | scans for orphan spools and replays them |
| `RecordingStarter.swift:382` | armed key is "swept by the launch purge's orphan-key pass" | cleaned inline two lines below; the launch sweep is only the backstop if the process dies first |
| `RecoveryKeyStore.swift:94` | `listAccountIDs` serves "the launch purge" | serves the launch recovery scan's orphan-key sweep |

The `RecordingStarter` one had drifted twice: the mechanism was renamed AND the cleanup became immediate (`cleanupRecoveryArm` at line 388, added in Codex r3), so the comment described a deferred sweep that no longer governs that path.

## Why the sweep is wider than the issue

#1841 named only the `WisprBootstrapper` line. Per `self-review-and-grep-before-codex` (fix every member of the class, not the named instance), `grep -rn "purge" Sources/ Tests/ docs/` found five more. Three of those are accurate PR1 history and are deliberately left alone:

- `RecoveryCoordinator.swift:594` — explains why the key-only sweep exists, correctly attributed to PR1.
- `WisprBootstrapper.swift:1096` — "(replaces PR1's purge)".
- `EnviousWisprAppCeilingsTests.swift:271` — the #1063 PR2 ratchet-log entry.

## Validation

- `swift build --target EnviousWisprAppKit` — clean.
- `scripts/build-dev-app.sh` — BUILD SUCCEEDED, signed, deployed, launched.
- No test run: comment-only, zero executable lines changed.

`council-skip: zero-blast-radius (comment-only)`

Closes #1841
