### PR TITLE
fix(audio): dictation falls back to a real microphone when macOS reports no default (#1714)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AudioEnvironmentSnapshotter.swift
+++ b/Sources/EnviousWisprAppKit/App/AudioEnvironmentSnapshotter.swift
@@ -165,7 +165,11 @@ struct CoreAudioEnvironmentCollector: AudioEnvironmentCollecting {
     let dataStatus = AudioObjectGetPropertyData(
       AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &processIDs)
     guard dataStatus == noErr else { return nil }
-    return processIDs
+    // The list can shrink between the size call and this one, which shrinks
+    // `dataSize` but not the buffer, leaving a zero-filled tail that would be
+    // counted as phantom audio-using processes (#1714 cloud review P2, third
+    // instance of the class). Iterate only what CoreAudio actually wrote.
+    return Array(processIDs.prefix(Int(dataSize) / MemoryLayout<AudioObjectID>.size))
   }
 
   private static func defaultDeviceID(selector: AudioObjectPropertySelector) -> AudioDeviceID? {

--- a/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/DebugFaultEndpoint.swift
@@ -36,7 +36,11 @@
   ///   route to the ONE `BatchDecodeFaultController`); `force_recovery_key_fault(status)`
   ///   (#1707 Phase 3 — arms the NEXT crash-recovery Keychain read to fail
   ///   with the given OSStatus, simulating a locked-keychain-state read
-  ///   without a real signed-release Data-Protection-Keychain).
+  ///   without a real signed-release Data-Protection-Keychain);
+  ///   `force_default_input_absent`, `clear_default_input_absent` (#1714 —
+  ///   force the input resolver to see no system default so the list-fallback
+  ///   rung actually runs in Live UAT; both refuse while capture is active and
+  ///   tear down any idle warm source first).
   /// - Each command dispatches to `@MainActor` via `Task { @MainActor in ... }`
   ///   so command handling matches the actor isolation of the seams it drives.
   ///
@@ -218,6 +222,14 @@
 
     /// Parse a two-line request and dispatch to the matching seam. Returns the
     /// reply line (without trailing newline).
+    /// #1714 test seam: drive command routing without a live socket. The whole
+    /// file is already `#if DEBUG`, so this widens nothing in a release build.
+    /// Prepends the endpoint's own token so a test cannot accidentally assert
+    /// the auth failure while believing it tested routing.
+    func handleForTesting(command: String) async -> String {
+      await handle(request: "\(token)\n\(command)")
+    }
+
     private func handle(request: String) async -> String {
       let lines = request.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
       guard lines.count == 2 else { return "ERR malformed" }
@@ -236,6 +248,18 @@
         guard let asrProxy else { return "ERR no_dependency" }
         asrProxy.forceConnectionTerminationNow()
         return "OK"
+
+      // #1714: force / clear "no system default input". Both refuse while
+      // capture is active and tear the warm source down before acknowledging,
+      // because a still-warm source would skip resolution entirely and the UAT
+      // would report a pass having tested nothing.
+      case "force_default_input_absent":
+        guard let audioCapture else { return "ERR no_dependency" }
+        return audioCapture.debugSetDefaultInputAbsent(true) ? "OK" : "ERR capture_active"
+
+      case "clear_default_input_absent":
+        guard let audioCapture else { return "ERR no_dependency" }
+        return audioCapture.debugSetDefaultInputAbsent(false) ? "OK" : "ERR capture_active"
 
       case "query_state":
         let p = kernelDriver.state

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
@@ -31,6 +31,9 @@ enum DictationCompletedReporting {
       inputSelectionMode: route?.inputSelectionMode,
       outputTransport: route?.outputTransport,
       routeResolutionSource: route?.routeResolutionSource,
+      // #1714: WHY this session's microphone was chosen, frozen by the kernel
+      // after the final engine-start attempt.
+      inputResolutionSource: driver.lastInputResolutionSource,
       // #1434: capture-health facts + salvage marker. Counters/flags ride
       // only when non-zero/true (omit-when-zero keeps the event lean).
       captureNativeRateHz: health?.nativeRateHz,

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/InputResolutionTelemetryReporting.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/InputResolutionTelemetryReporting.swift
@@ -22,9 +22,15 @@ enum InputResolutionTelemetryReporting {
   /// root wires it in one line.
   ///
   /// The installation lives here rather than inline in `WisprBootstrapper`
-  /// because that file is AT its architecture-test ceiling: the inline
-  /// three-line form measured 1331 against a limit of 1330, and the ceiling is
-  /// not ours to raise for a telemetry wire.
+  /// because that file sits at its architecture-test ceiling: the inline
+  /// three-line form measured 1331 against a limit of 1330, and this extraction
+  /// bought the line back.
+  ///
+  /// That saving was later spent anyway — main independently reached 1329 before
+  /// this branch merged, so the ceiling went to 1335 with a changelog entry in
+  /// `EnviousWisprAppCeilingsTests`. Keep the extraction regardless: it is the
+  /// named seam these tests drive, and it keeps the composition root's line about
+  /// wiring rather than about telemetry field mapping.
   static func observing(_ manager: AudioCaptureManager) -> AudioCaptureManager {
     manager.onFinalizedInputResolutionAttempt = report
     return manager

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/InputResolutionTelemetryReporting.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/InputResolutionTelemetryReporting.swift
@@ -1,0 +1,45 @@
+import EnviousWisprAudio
+import EnviousWisprServices
+
+/// #1714: the sole mapper from the Audio module's cold-attempt projection to
+/// `TelemetryService`.
+///
+/// Exists so `EnviousWisprAudio` never imports `EnviousWisprServices`. The
+/// manager owns the fact and publishes a flat value; the composition root wires
+/// this function to it; nothing in between reinterprets anything.
+///
+/// Pure argument mapping — no state, no defaulting, no recomputation. Every
+/// field is passed through unchanged, including the two counts whose `nil`
+/// means NOT KNOWN rather than zero. Deriving or defaulting anything here would
+/// put a second opinion between the resolver's decision and the recorded event.
+///
+/// It lives in its own file rather than inside `WisprBootstrapper` because that
+/// file is at its architecture-test line ceiling (1330,
+/// `EnviousWisprAppCeilingsTests.swift:432`).
+@MainActor
+enum InputResolutionTelemetryReporting {
+  /// Install this observer on the manager and hand it back, so the composition
+  /// root wires it in one line.
+  ///
+  /// The installation lives here rather than inline in `WisprBootstrapper`
+  /// because that file is AT its architecture-test ceiling: the inline
+  /// three-line form measured 1331 against a limit of 1330, and the ceiling is
+  /// not ours to raise for a telemetry wire.
+  static func observing(_ manager: AudioCaptureManager) -> AudioCaptureManager {
+    manager.onFinalizedInputResolutionAttempt = report
+    return manager
+  }
+
+  static func report(_ attempt: InputResolutionAttemptTelemetry) {
+    TelemetryService.shared.audioInputResolution(
+      defaultPresent: attempt.defaultPresent,
+      enumerationOutcome: attempt.enumerationOutcome,
+      inputDeviceCount: attempt.inputDeviceCount,
+      eligibleDeviceCount: attempt.eligibleDeviceCount,
+      inputResolutionSource: attempt.inputResolutionSource,
+      selectedTransport: attempt.selectedTransport,
+      bindOutcome: attempt.bindOutcome,
+      prepareOutcome: attempt.prepareOutcome
+    )
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/PipelineStateChangeHandlerFactory.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/PipelineStateChangeHandlerFactory.swift
@@ -58,7 +58,10 @@ enum PipelineStateChangeHandlerFactory {
       reportPipelineFailed: { msg in
         TelemetryService.shared.pipelineFailed(
           stage: "transcription", errorCategory: "pipeline_error", errorCode: msg,
-          recoverable: false, backend: backendLabel)
+          recoverable: false, backend: backendLabel,
+          // #1714: the failing population is the one this issue exists to
+          // measure, so a failed take must still say which microphone it used.
+          inputResolutionSource: deps.driver.lastInputResolutionSource)
       },
       // #1167: history-save-failed pill (post-completion warning slot, ~400 ms).
       scheduleHistorySaveFailedWarning: { reason in

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -150,7 +150,8 @@ public final class WisprBootstrapper {
 
     // Audio capture runs in-process (#1543, D-028 — the separate XPC audio
     // helper was collapsed away). The ASR helper below stays isolated.
-    let audioCapture: any AudioCaptureInterface = AudioCaptureManager()
+    let audioCapture: any AudioCaptureInterface = InputResolutionTelemetryReporting.observing(
+      AudioCaptureManager())
 
     // #1707 Phase 3 (§3.2): the atomic mutual-exclusion primitive between
     // crash-recovery replay and every OTHER engine-mutating operation. One

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -24,6 +24,15 @@ enum WhatsNewContent {
       version: "2.4.2"
     ),
 
+    Entry(
+      id: "automatic-microphone-fallback",
+      icon: "mic.fill",
+      title: "Dictation finds another microphone automatically",
+      description:
+        "When macOS temporarily has no default microphone, EnviousWispr now finds another connected physical microphone so you can keep dictating instead of being told to connect one.",
+      version: "2.4.2"
+    ),
+
     // MARK: - v2.4.1
 
     Entry(

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -18,6 +18,8 @@ public protocol AudioCaptureInterface: AnyObject {
   /// route resolution. Telemetry-only observation — nothing branches capture on
   /// it (#1376).
   var currentResolvedRoute: ResolvedRouteTransports? { get }
+  /// #1714: see the defaulted implementation below.
+  var currentInputResolutionSource: String? { get }
 
   // Callback properties (read-write)
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)? { get set }
@@ -207,6 +209,14 @@ extension AudioCaptureInterface {
   /// source-compatible. The real capture backend (`AudioCaptureManager`)
   /// overrides it with the bind its own `prepare()` returned (#1844).
   public var zeroSignalDiscriminatorDevice: BoundInputDevice? { nil }
+
+  /// #1714: WHY the microphone this session is using was chosen —
+  /// `pinned_uid`, `system_default` or `list_fallback`. Default `nil` so every
+  /// existing conformer (test fakes, simulator doubles) stays source-compatible;
+  /// `AudioCaptureManager` overrides it. A low-cardinality telemetry string, and
+  /// the ONLY public surface #1714 adds. Observation-only: nothing may branch
+  /// capture on it, and a nil value degrades attribution, never recording.
+  public var currentInputResolutionSource: String? { nil }
 
   /// #1317: default `false` — test fakes and simulator doubles have no reactive
   /// per-buffer detector, so no run of theirs can carry a refusal reason.

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -245,7 +245,10 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// bound-device adoption tests can drive `startEnginePhase()` against a stub
     /// with a controlled `prepare()` return. Installed via
     /// `installSourceFactoryForTesting`; nil in production, always.
-    private var debugSourceFactory: (() -> any AudioInputSource)?
+    /// Takes the already-resolved route decision so an armed factory can honour
+    /// the user's actual device choice instead of re-reading settings — a second
+    /// read there would be the stale-selection defect this whole issue avoids.
+    private var debugSourceFactory: ((CaptureRouteDecision) -> any AudioInputSource)?
 
     /// #1317 proof-bench (DEBUG only): arm the injector from the in-process
     /// DEBUG fault endpoint (#1543). Translates the Core wire enum into the
@@ -480,8 +483,70 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     onLifecycleSignal?("manager_prepare_entered")
     // The awaited call PRODUCES the value adopted below: the ordering #1844
     // existed to fix is now a data dependency, not a convention.
-    adoptBoundState(try await source.prepare())
+    adoptBoundState(try await prepareAndAttribute(source))
     onLifecycleSignal?("manager_prepare_completed")
+  }
+
+  // MARK: - #1714: input-resolution attribution
+
+  /// The latest COLD attempt, kept because a THROWING prepare returns no bind at
+  /// all — without this, a resolution or bind failure could never be attributed.
+  private var latestInputResolutionAttempt: FinalizedInputResolutionAttempt?
+
+  /// #1714: the outbound observer, installed once by the composition root so
+  /// this module never imports Services. Separate from the SOURCE-level
+  /// callback above, which the manager consumes for its own state — one
+  /// callback cannot serve both without the manager losing ownership.
+  ///
+  /// Synchronous, nonthrowing, observation-only.
+  package var onFinalizedInputResolutionAttempt:
+    (@MainActor (InputResolutionAttemptTelemetry) -> Void)?
+
+  /// #1714: forward the RETAINED attempt, never the callback argument.
+  ///
+  /// Reading `latestInputResolutionAttempt` rather than the parameter is
+  /// deliberate: it makes the manager's own state the single authority for what
+  /// gets reported, so an emitted event can never describe an attempt the
+  /// manager did not itself record.
+  private func forwardLatestInputResolutionAttempt() {
+    guard let attempt = latestInputResolutionAttempt else { return }
+    onFinalizedInputResolutionAttempt?(InputResolutionAttemptTelemetry(attempt))
+  }
+
+  /// WHY the current session's microphone was chosen. Manager-owned writes only.
+  public private(set) var currentInputResolutionSource: String?
+
+  /// The ONE place a source is prepared (#1714). Both production call sites —
+  /// recording start and pre-warm — route through here so the clear, the
+  /// callback wiring, retention across a throw, and successful-bind adoption
+  /// cannot drift apart.
+  ///
+  /// Ordering is the whole point, and it is this:
+  ///   1. clear BOTH prior facts, so a failure can never expose a previous
+  ///      session's answer;
+  ///   2. install the callback, which stores the attempt SYNCHRONOUSLY — that is
+  ///      what survives a throw;
+  ///   3. on success, the RETURNED BIND wins over the callback's provisional
+  ///      value (`RULE: read-the-bind-prepare-returned-never-re-derive-it`), and
+  ///      it is also the only source of truth on the warm path, which fires no
+  ///      callback at all.
+  private func prepareAndAttribute(_ source: any AudioInputSource) async throws -> BoundInputDevice {
+    latestInputResolutionAttempt = nil
+    currentInputResolutionSource = nil
+    source.onInputResolutionAttemptFinalized = { [weak self] attempt in
+      guard let self else { return }
+      self.latestInputResolutionAttempt = attempt
+      // Provisional: nil when resolution selected nothing, which is honest —
+      // there is no device to attribute. The returned bind overwrites this on
+      // success.
+      self.currentInputResolutionSource = attempt.resolution.resolutionSource?.rawValue
+      // The manager's own state is stored FIRST, so an external observer can
+      // never see the manager mid-update.
+      self.forwardLatestInputResolutionAttempt()
+    }
+    let bound = try await source.prepare()
+    currentInputResolutionSource = bound.resolutionSource
+    return bound
   }
 
   /// #1844: the ONE place the manager adopts post-bind facts. Takes the value, not
@@ -821,8 +886,67 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// `startEnginePhase()` with a stub whose `prepare()` returns a controlled
     /// bind — no hardware, no real AUHAL unit. nil restores normal resolution.
     /// Consumed in `resolveSource()`; production never sets it.
-    func installSourceFactoryForTesting(_ factory: (() -> any AudioInputSource)?) {
+    func installSourceFactoryForTesting(
+      _ factory: ((CaptureRouteDecision) -> any AudioInputSource)?
+    ) {
       debugSourceFactory = factory
+    }
+
+    /// #1714 Live UAT seam: force the resolver to see NO system default, so the
+    /// list-fallback rung — the whole point of this issue — actually runs on a
+    /// real build with real hardware.
+    ///
+    /// Recording a normal dictation proves nothing about the fallback: with a
+    /// working default present, resolution returns at the unchanged default rung
+    /// and the new code never executes. This is the only way the Live UAT can
+    /// reach its own subject.
+    ///
+    /// Everything except the default lookup stays REAL — a real
+    /// `HALDeviceInputSource`, real enumeration, real AUHAL binding. Only the
+    /// one question "what is the default input device?" is forced to nil.
+    ///
+    /// Returns `false` and changes nothing while capture is active. Otherwise it
+    /// tears down any idle warm source SYNCHRONOUSLY before returning, because
+    /// `warmReuseBind` returns before resolution — an armed-but-warm source
+    /// would skip the branch entirely and the UAT would report a pass having
+    /// tested nothing.
+    @discardableResult
+    package func debugSetDefaultInputAbsent(_ absent: Bool) -> Bool {
+      guard !isCapturing else { return false }
+      warmEngineTeardownTask?.cancel()
+      warmEngineTeardownTask = nil
+      if let existing = activeSource {
+        rebuildActiveSource(existing)
+        activeSource = nil
+      }
+      debugSourceFactory =
+        absent
+        ? { decision in
+          let source = HALDeviceInputSource()
+          source.targetDeviceUID = decision.effectiveDeviceUID
+          source.inputDeviceResolver = InputDeviceResolver(
+            defaultInputDeviceID: { nil },
+            inputDeviceSnapshot: AudioDeviceEnumerator.inputDeviceSnapshot
+          )
+          return source
+        } : nil
+      return true
+    }
+
+    /// #1714 test seam: build a source from a GIVEN decision.
+    ///
+    /// Lets the arming tests observe the factory by its EFFECT — does the built
+    /// source have its default lookup forced? — rather than by peeking at a
+    /// stored closure. A test that only checked the closure was stored would
+    /// pass even if nothing ever consumed it.
+    ///
+    /// Deliberately NOT a wrapper around `resolveSource()`: that runs
+    /// `CaptureRouteResolver.resolve()`, which reads the live default OUTPUT
+    /// device. On a CI runner with no audio hardware those tests could pass
+    /// vacuously or fail for reasons unrelated to arming. Taking the decision as
+    /// an argument keeps the seam to exactly the construction step under test.
+    func buildSourceForTesting(_ decision: CaptureRouteDecision) -> any AudioInputSource {
+      buildSource(for: decision)
     }
 
     /// Test seam (heartpath 5b): drop the live active source while KEEPING the
@@ -868,7 +992,13 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     do {
       // #1844: pre-warm runs OUTSIDE any session, so it must not adopt a
       // health-check snapshot — the discarded bind is a visible decision.
-      _ = try await source.prepare()
+      //
+      // #1714: but it MUST still attribute. Pre-warm is where cold resolution
+      // normally happens; the recording that follows usually takes warm reuse,
+      // so attributing only on the recording's own prepare would report almost
+      // nothing. The bind is discarded for HEALTH purposes only — the shared
+      // helper still retains the attempt and exposes its source.
+      _ = try await prepareAndAttribute(source)
     } catch {
       Task {
         await AppLogger.shared.log(
@@ -1000,6 +1130,18 @@ public final class AudioCaptureManager: AudioCaptureInterface {
 
   /// Resolve and create the appropriate capture source based on BT state and user preference.
   /// Re-evaluates on every call — BT state may change between recordings.
+  /// The ONE place a capture source is constructed (#1714). Extracted so the
+  /// DEBUG arming tests can exercise construction from a given decision without
+  /// running `CaptureRouteResolver.resolve()`, which reads live output hardware.
+  private func buildSource(for decision: CaptureRouteDecision) -> any AudioInputSource {
+    #if DEBUG
+      if let debugSourceFactory {
+        return debugSourceFactory(decision)  // #1844/#1714 seam; nil in production
+      }
+    #endif
+    return Self.makeSource(for: decision)
+  }
+
   private func resolveSource() -> any AudioInputSource {
     // Cancel idle teardown — we're about to record
     warmEngineTeardownTask?.cancel()
@@ -1072,16 +1214,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       )
     }
 
-    let source: any AudioInputSource
-    #if DEBUG
-      if let debugSourceFactory {
-        source = debugSourceFactory()  // #1844 test seam; nil in production
-      } else {
-        source = Self.makeSource(for: decision)
-      }
-    #else
-      source = Self.makeSource(for: decision)
-    #endif
+    let source = buildSource(for: decision)
 
     // heartpath 5b: a stopped prior source overwritten here must not stay retained
     // by the capture-session fence.

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -32,7 +32,20 @@ struct InputDeviceCandidate: Sendable, Equatable {
 /// telling the user to connect a microphone after a failed READ would be a
 /// false statement.
 enum InputDeviceSnapshot: Sendable, Equatable {
-  case success([InputDeviceCandidate])
+  /// Devices we could read, plus whether we managed to read them ALL.
+  ///
+  /// The two facts are separate because a per-device read failure must not cost
+  /// the user the devices that ARE readable (#1714 cloud review r2). A USB stick
+  /// pulled mid-enumeration makes its own properties unreadable while the
+  /// built-in microphone beside it stays perfectly usable, and refusing to
+  /// dictate there would break founder priority 1 — dictation works whenever it
+  /// physically can.
+  ///
+  /// `complete: false` narrows to exactly one thing: the list can no longer
+  /// PROVE absence. Candidates in hand stay fully usable; an EMPTY incomplete
+  /// list is uncertainty, never grounds for "connect a microphone".
+  case success(candidates: [InputDeviceCandidate], complete: Bool)
+  /// The device LIST itself could not be read, so we hold no candidates at all.
   case readFailed
 }
 
@@ -130,14 +143,20 @@ public enum AudioDeviceEnumerator {
     guard let deviceIDs = systemDeviceIDs() else { return .readFailed }
 
     var candidates: [InputDeviceCandidate] = []
+    var complete = true
     for deviceID in deviceIDs {
-      // #1714 whole-diff review: a FAILED channel-count read must not be dropped
-      // like an output-only device. If it were the only microphone, the snapshot
-      // would come back successfully empty and the resolver would treat that as
-      // PROOF no microphone exists — the exact failure-vs-empty conflation this
-      // type exists to prevent, one level down. Fail the whole snapshot to
-      // uncertainty instead.
-      guard let channels = inputChannelCountRaw(for: deviceID) else { return .readFailed }
+      // A FAILED channel-count read is not an output-only device (#1714
+      // whole-diff review) and is not grounds for discarding the devices we CAN
+      // read (#1714 cloud review r2). It means exactly one thing: we do not know
+      // what this device is. So it becomes neither a candidate nor evidence —
+      // it is skipped, and the snapshot records that it can no longer prove
+      // absence. Collapsing this to a candidate would risk binding a device we
+      // never verified; collapsing it to a whole-snapshot failure would throw
+      // away working microphones.
+      guard let channels = inputChannelCountRaw(for: deviceID) else {
+        complete = false
+        continue
+      }
       guard channels > 0 else { continue }
       candidates.append(
         InputDeviceCandidate(
@@ -146,7 +165,7 @@ public enum AudioDeviceEnumerator {
           rawTransport: transportTypeRaw(for: deviceID)
         ))
     }
-    return .success(candidates)
+    return .success(candidates: candidates, complete: complete)
   }
 
   /// The closed allow-list of transports we will bind a microphone on (#1714).

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -38,8 +38,19 @@ enum InputDeviceSnapshot: Sendable, Equatable {
 
 /// Enumerates audio input devices using CoreAudio HAL.
 public enum AudioDeviceEnumerator {
-  /// Returns all audio input devices currently connected.
-  public static func allInputDevices() -> [AudioInputDevice] {
+  /// The system's current device-ID list, or nil when either HAL read fails.
+  ///
+  /// SOLE owner of the size-then-read sequence for `kAudioHardwarePropertyDevices`
+  /// (#1714 cloud review P2). The two are separate calls, so the list can shrink
+  /// between them — a microphone unplugged in that window makes
+  /// `AudioObjectGetPropertyData` write back a SMALLER `dataSize` while the
+  /// buffer keeps its original length and a zero-filled tail. Iterating the
+  /// whole buffer then treats `kAudioObjectUnknown` (0) as a real device. Both
+  /// callers get the truncation for free rather than each remembering it.
+  ///
+  /// An empty list is a successful read of a machine with no devices; only a
+  /// nonzero HAL status is a failure. Callers own how failure collapses.
+  private static func systemDeviceIDs() -> [AudioDeviceID]? {
     var propertyAddress = AudioObjectPropertyAddress(
       mSelector: kAudioHardwarePropertyDevices,
       mScope: kAudioObjectPropertyScopeGlobal,
@@ -54,7 +65,8 @@ public enum AudioDeviceEnumerator {
       nil,
       &dataSize
     )
-    guard status == noErr, dataSize > 0 else { return [] }
+    guard status == noErr else { return nil }
+    guard dataSize > 0 else { return [] }
 
     let deviceCount = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
     var deviceIDs = [AudioDeviceID](repeating: 0, count: deviceCount)
@@ -67,7 +79,17 @@ public enum AudioDeviceEnumerator {
       &dataSize,
       &deviceIDs
     )
-    guard status == noErr else { return [] }
+    guard status == noErr else { return nil }
+
+    // `dataSize` now holds the bytes CoreAudio ACTUALLY wrote. `prefix` clamps,
+    // so a list that grew between the calls cannot read past the buffer either.
+    let returnedCount = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+    return Array(deviceIDs.prefix(returnedCount))
+  }
+
+  /// Returns all audio input devices currently connected.
+  public static func allInputDevices() -> [AudioInputDevice] {
+    guard let deviceIDs = systemDeviceIDs() else { return [] }
 
     return deviceIDs.compactMap { deviceID -> AudioInputDevice? in
       let channelCount = inputChannelCount(for: deviceID)
@@ -102,37 +124,10 @@ public enum AudioDeviceEnumerator {
   /// failure-collapses-to-empty behaviour, capture resolution needs transports
   /// and cannot. Two owners for two questions, not an accident to tidy up.
   static func inputDeviceSnapshot() -> InputDeviceSnapshot {
-    var propertyAddress = AudioObjectPropertyAddress(
-      mSelector: kAudioHardwarePropertyDevices,
-      mScope: kAudioObjectPropertyScopeGlobal,
-      mElement: kAudioObjectPropertyElementMain
-    )
-
-    var dataSize: UInt32 = 0
-    var status = AudioObjectGetPropertyDataSize(
-      AudioObjectID(kAudioObjectSystemObject),
-      &propertyAddress,
-      0,
-      nil,
-      &dataSize
-    )
-    guard status == noErr else { return .readFailed }
-    // A zero-byte device list is a SUCCESSFUL read of an empty machine, not a
-    // failure — the size call already returned noErr.
-    guard dataSize > 0 else { return .success([]) }
-
-    let deviceCount = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
-    var deviceIDs = [AudioDeviceID](repeating: 0, count: deviceCount)
-
-    status = AudioObjectGetPropertyData(
-      AudioObjectID(kAudioObjectSystemObject),
-      &propertyAddress,
-      0,
-      nil,
-      &dataSize,
-      &deviceIDs
-    )
-    guard status == noErr else { return .readFailed }
+    // A successful read of an empty machine yields `.success([])`; only a HAL
+    // failure is uncertainty. Truncation to what CoreAudio actually returned is
+    // `systemDeviceIDs()`'s job — this reader must never re-derive it.
+    guard let deviceIDs = systemDeviceIDs() else { return .readFailed }
 
     var candidates: [InputDeviceCandidate] = []
     for deviceID in deviceIDs {

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -8,6 +8,34 @@ public struct AudioInputDevice: Sendable, Identifiable, Hashable {
   public let uid: String
 }
 
+/// One input-device candidate, frozen during a SINGLE enumeration pass (#1714).
+///
+/// Distinct from `AudioInputDevice`, which carries no transport: capture
+/// resolution has to rank candidates by transport, and re-reading the transport
+/// per candidate later would describe a different hardware state than the one
+/// that was enumerated.
+struct InputDeviceCandidate: Sendable, Equatable {
+  let id: AudioDeviceID
+  let uid: String
+  /// Raw CoreAudio transport constant, or nil if the property read FAILED.
+  /// Nil-preserving on purpose: `kAudioDeviceTransportTypeUnknown` (0) is itself
+  /// a real reported value, so collapsing a failed read into it would hide the
+  /// failure from telemetry.
+  let rawTransport: UInt32?
+}
+
+/// The result of ONE input-device enumeration pass (#1714).
+///
+/// A CoreAudio read failure is a distinct case, never an empty success. The two
+/// are different facts and they select different errors: an empty successful
+/// list proves no microphone is attached, a failed read proves nothing, and
+/// telling the user to connect a microphone after a failed READ would be a
+/// false statement.
+enum InputDeviceSnapshot: Sendable, Equatable {
+  case success([InputDeviceCandidate])
+  case readFailed
+}
+
 /// Enumerates audio input devices using CoreAudio HAL.
 public enum AudioDeviceEnumerator {
   /// Returns all audio input devices currently connected.
@@ -55,6 +83,122 @@ public enum AudioDeviceEnumerator {
         uid: uid
       )
     }
+  }
+
+  /// ONE frozen input-device enumeration for capture resolution (#1714).
+  ///
+  /// Two differences from `allInputDevices()`, both load-bearing:
+  /// a property-read failure stays a typed failure instead of collapsing into
+  /// an empty list (`allInputDevices()` returns `[]` for both), and every
+  /// candidate carries the RAW transport read during this same pass.
+  ///
+  /// This is one frozen RESOLUTION INPUT, not an atomic CoreAudio transaction:
+  /// the device list and each device's own properties are separate reads at
+  /// separate instants. `InputDeviceResolver` calls this at most once per
+  /// attempt; callers must never re-enumerate for logging or telemetry.
+  ///
+  /// Deliberately NOT merged with `allInputDevices()`, which stays the settings
+  /// picker's reader: the picker needs display names and can live with the
+  /// failure-collapses-to-empty behaviour, capture resolution needs transports
+  /// and cannot. Two owners for two questions, not an accident to tidy up.
+  static func inputDeviceSnapshot() -> InputDeviceSnapshot {
+    var propertyAddress = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDevices,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+
+    var dataSize: UInt32 = 0
+    var status = AudioObjectGetPropertyDataSize(
+      AudioObjectID(kAudioObjectSystemObject),
+      &propertyAddress,
+      0,
+      nil,
+      &dataSize
+    )
+    guard status == noErr else { return .readFailed }
+    // A zero-byte device list is a SUCCESSFUL read of an empty machine, not a
+    // failure — the size call already returned noErr.
+    guard dataSize > 0 else { return .success([]) }
+
+    let deviceCount = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+    var deviceIDs = [AudioDeviceID](repeating: 0, count: deviceCount)
+
+    status = AudioObjectGetPropertyData(
+      AudioObjectID(kAudioObjectSystemObject),
+      &propertyAddress,
+      0,
+      nil,
+      &dataSize,
+      &deviceIDs
+    )
+    guard status == noErr else { return .readFailed }
+
+    var candidates: [InputDeviceCandidate] = []
+    for deviceID in deviceIDs {
+      // #1714 whole-diff review: a FAILED channel-count read must not be dropped
+      // like an output-only device. If it were the only microphone, the snapshot
+      // would come back successfully empty and the resolver would treat that as
+      // PROOF no microphone exists — the exact failure-vs-empty conflation this
+      // type exists to prevent, one level down. Fail the whole snapshot to
+      // uncertainty instead.
+      guard let channels = inputChannelCountRaw(for: deviceID) else { return .readFailed }
+      guard channels > 0 else { continue }
+      candidates.append(
+        InputDeviceCandidate(
+          id: deviceID,
+          uid: stringProperty(for: deviceID, selector: kAudioDevicePropertyDeviceUID) ?? "",
+          rawTransport: transportTypeRaw(for: deviceID)
+        ))
+    }
+    return .success(candidates)
+  }
+
+  /// The closed allow-list of transports we will bind a microphone on (#1714).
+  ///
+  /// An ALLOW-list, not a deny-list: the dominant risk is silently binding a
+  /// loopback or meeting-app virtual device and recording digital silence,
+  /// which is worse for the user than an honest error. So an unreadable (nil),
+  /// unknown (0) or future unrecognised transport is REFUSED, not accepted.
+  ///
+  /// AirPlay is deliberately absent — it is an output protocol, not a known
+  /// microphone path. A newly observed working transport is added from fleet
+  /// evidence, never accepted before its behaviour is known.
+  ///
+  /// This constrains only the automatic last resort. A device the user pinned
+  /// is selected before this predicate is ever consulted.
+  static func isAllowedPhysicalInputTransport(_ rawTransport: UInt32?) -> Bool {
+    guard let rawTransport else { return false }
+    switch rawTransport {
+    case kAudioDeviceTransportTypeBuiltIn,
+      kAudioDeviceTransportTypeUSB,
+      kAudioDeviceTransportTypeBluetooth,
+      kAudioDeviceTransportTypeBluetoothLE,
+      kAudioDeviceTransportTypeContinuityCaptureWired,
+      kAudioDeviceTransportTypeContinuityCaptureWireless,
+      kAudioDeviceTransportTypeThunderbolt,
+      kAudioDeviceTransportTypeDisplayPort,
+      kAudioDeviceTransportTypeHDMI,
+      kAudioDeviceTransportTypePCI,
+      kAudioDeviceTransportTypeFireWire,
+      kAudioDeviceTransportTypeAVB:
+      return true
+    default:
+      return false
+    }
+  }
+
+  /// Transports we recognise as definitively NOT a physical microphone, so a
+  /// list containing only these PROVES no microphone is attached (#1714 §4.1).
+  ///
+  /// Deliberately narrower than "fails the allow-list". Everything else that
+  /// fails it — unreadable, unknown (0), AirPlay, a future constant — is
+  /// UNCERTAINTY, and telling the user to connect a microphone there would be a
+  /// claim we cannot back.
+  static func isKnownNonMicrophoneTransport(_ rawTransport: UInt32?) -> Bool {
+    guard let rawTransport else { return false }
+    return rawTransport == kAudioDeviceTransportTypeVirtual
+      || rawTransport == kAudioDeviceTransportTypeAggregate
   }
 
   /// Returns the default system input device ID, or nil if unavailable.
@@ -110,12 +254,6 @@ public enum AudioDeviceEnumerator {
       || transport == kAudioDeviceTransportTypeBluetoothLE
   }
 
-  /// Returns the AudioDeviceID of the built-in microphone, if one exists.
-  public static func builtInMicrophoneDeviceID() -> AudioDeviceID? {
-    let devices = allInputDevices()
-    return devices.first { transportType(for: $0.id) == kAudioDeviceTransportTypeBuiltIn }?.id
-  }
-
   /// Returns the default system output device ID, or nil if unavailable.
   public static func defaultOutputDeviceID() -> AudioDeviceID? {
     var propertyAddress = AudioObjectPropertyAddress(
@@ -153,16 +291,6 @@ public enum AudioDeviceEnumerator {
     return isRunning != 0
   }
 
-  /// Recommended input device given current output device and media-playing state.
-  /// Returns the built-in mic if Bluetooth output is active and media is playing;
-  /// nil otherwise (meaning "use whatever is currently selected").
-  public static func recommendedInputDevice() -> AudioDeviceID? {
-    guard let outputDeviceID = defaultOutputDeviceID() else { return nil }
-    guard isBluetoothDevice(outputDeviceID) else { return nil }
-    guard isDeviceRunningSomewhere(outputDeviceID) else { return nil }
-    return builtInMicrophoneDeviceID()
-  }
-
   // MARK: - Transport labels (#1376 single authority)
 
   /// Maps a CoreAudio transport-type constant to the app's low-cardinality
@@ -195,6 +323,16 @@ public enum AudioDeviceEnumerator {
       return "fire_wire"
     case kAudioDeviceTransportTypeThunderbolt:
       return "thunderbolt"
+    // #1714 founder decision 2026-07-30: the physical allow-list ACCEPTS these
+    // three, so reporting them as `unknown` said "we bound something we could
+    // not identify" about a device we selected on purpose. Naming them changes
+    // only what a bound device is CALLED — never eligibility or selection.
+    case kAudioDeviceTransportTypeContinuityCaptureWired:
+      return "continuity_capture_wired"
+    case kAudioDeviceTransportTypeContinuityCaptureWireless:
+      return "continuity_capture_wireless"
+    case kAudioDeviceTransportTypeAVB:
+      return "avb"
     default:
       return "unknown"
     }
@@ -239,7 +377,19 @@ public enum AudioDeviceEnumerator {
   /// stream (`kAudioDevicePropertyStreamConfiguration`). Module-internal (#1523)
   /// so the capture backend can record it as prepare-time fleet telemetry —
   /// this is the single channel-count authority; do not add a second reader.
-  static func inputChannelCount(for deviceID: AudioDeviceID) -> Int {
+  /// Nil-preserving channel count (#1714 whole-diff review).
+  ///
+  /// Returns nil when a CoreAudio property READ FAILS, and 0 when the device
+  /// genuinely exposes no input streams. `inputChannelCount(for:)` collapses
+  /// both to 0, which is right for its two callers but WRONG for capture
+  /// resolution: a device whose read failed would be silently dropped from the
+  /// snapshot, and if it were the only microphone the resolver would treat the
+  /// empty list as PROOF none exists and tell the user to connect one.
+  ///
+  /// Same nil-preserving shape as `transportTypeRaw(for:)` above, for the same
+  /// reason — this is the per-DEVICE twin of the failure-vs-empty distinction
+  /// `inputDeviceSnapshot()` already makes for the device LIST.
+  static func inputChannelCountRaw(for deviceID: AudioDeviceID) -> Int? {
     var propertyAddress = AudioObjectPropertyAddress(
       mSelector: kAudioDevicePropertyStreamConfiguration,
       mScope: kAudioObjectPropertyScopeInput,
@@ -248,7 +398,10 @@ public enum AudioDeviceEnumerator {
 
     var dataSize: UInt32 = 0
     let status = AudioObjectGetPropertyDataSize(deviceID, &propertyAddress, 0, nil, &dataSize)
-    guard status == noErr, dataSize > 0 else { return 0 }
+    guard status == noErr else { return nil }
+    // A zero-size stream configuration is a SUCCESSFUL read of a device with no
+    // input streams — an output-only device, correctly skipped.
+    guard dataSize > 0 else { return 0 }
 
     // AudioBufferList has a variable-length trailing array of AudioBuffer entries.
     // Allocate the exact byte count reported by CoreAudio to avoid heap corruption
@@ -263,10 +416,17 @@ public enum AudioDeviceEnumerator {
 
     let getStatus = AudioObjectGetPropertyData(
       deviceID, &propertyAddress, 0, nil, &dataSize, bufferListPointer)
-    guard getStatus == noErr else { return 0 }
+    guard getStatus == noErr else { return nil }
 
     let bufferList = UnsafeMutableAudioBufferListPointer(bufferListPointer)
     return bufferList.reduce(0) { $0 + Int($1.mNumberChannels) }
+  }
+
+  /// Collapsing channel count: a failed read reads as 0, which is what the
+  /// settings picker and the bind-time telemetry both want. Capture resolution
+  /// must NOT use this — see `inputChannelCountRaw(for:)`.
+  static func inputChannelCount(for deviceID: AudioDeviceID) -> Int {
+    inputChannelCountRaw(for: deviceID) ?? 0
   }
 
   private static func stringProperty(

--- a/Sources/EnviousWisprAudio/AudioInputSource.swift
+++ b/Sources/EnviousWisprAudio/AudioInputSource.swift
@@ -22,6 +22,18 @@ protocol AudioInputSource: AnyObject {
   var onInterrupted: ((EngineInterruptionCause) -> Void)? { get set }
   var onLifecycleSignal: (@Sendable (String) -> Void)? { get set }
 
+  /// #1714: fires exactly once per COLD `prepare()`, synchronously, before it
+  /// returns or throws. Warm reuse fires nothing — a reused bind is not a new
+  /// resolution.
+  ///
+  /// **Deliberately undefaulted.** A no-op default would let a future conformer
+  /// silently report no attribution at all, and the failure would look exactly
+  /// like "this user never had a cold open" in the data. The compiler forces
+  /// each conformer to say whether it supports this.
+  var onInputResolutionAttemptFinalized: ((FinalizedInputResolutionAttempt) -> Void)? {
+    get set
+  }
+
   /// Liveness-watchdog callback — fires once per capture session if zero
   /// buffers are delivered within `Constants.audioCaptureStallWindowMs` of
   /// tap install. Set by `AudioCaptureManager` on every `resolveSource()`.

--- a/Sources/EnviousWisprAudio/BoundInputDevice.swift
+++ b/Sources/EnviousWisprAudio/BoundInputDevice.swift
@@ -9,9 +9,9 @@ import CoreAudio
 /// could describe a microphone the session never recorded from. Returning the
 /// bind makes "read it before it exists" unexpressible rather than merely tested.
 ///
-/// All three fields are read together in HAL's single all-succeeded commit block
+/// All four fields are read together in HAL's single all-succeeded commit block
 /// and cleared together in its single teardown, so they are ONE fact with one
-/// lifetime — not three accessors that could drift apart.
+/// lifetime, not four accessors that could drift apart.
 ///
 /// **Visibility.** `public` is the NARROWEST WORKING visibility, not a default.
 /// `AudioCaptureInterface` is already `public` (`AudioCaptureInterface.swift:7`)
@@ -35,9 +35,29 @@ public struct BoundInputDevice: Equatable, Sendable {
   /// authority; this is not a second home for the fact.
   public let transportLabel: String?
 
-  public init(deviceID: AudioDeviceID, deviceUID: String?, transportLabel: String?) {
+  /// WHY this device was chosen, frozen at resolution time (#1714):
+  /// `pinned_uid`, `system_default` or `list_fallback`.
+  ///
+  /// **Non-optional and undefaulted, deliberately.** Cold resolution normally
+  /// happens during `preWarm()`, which discards the bind it gets back, and the
+  /// recording that follows takes the WARM path — so by the time a take
+  /// completes, nothing else on the session still knows why this microphone was
+  /// picked. Riding on the bind is what carries the fact across that gap. An
+  /// optional or defaulted field would let a conformer commit a bind without
+  /// saying why and still compile, and the attribution would silently read
+  /// `system_default` for every fallback take — which is precisely the metric
+  /// #1714 ships to prove the fix works.
+  ///
+  /// A low-cardinality `String`, not the resolver enum: `AudioCaptureInterface`
+  /// is `public`, and a public requirement cannot expose a package type.
+  public let resolutionSource: String
+
+  public init(
+    deviceID: AudioDeviceID, deviceUID: String?, transportLabel: String?, resolutionSource: String
+  ) {
     self.deviceID = deviceID
     self.deviceUID = deviceUID
     self.transportLabel = transportLabel
+    self.resolutionSource = resolutionSource
   }
 }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -403,9 +403,19 @@ final class HALDeviceInputSource: AudioInputSource {
   /// Target capture device UID. Nil means follow the live system default input.
   var targetDeviceUID: String?
 
-  var resolveDeviceIDForUID: (String) -> AudioDeviceID? = AudioDeviceEnumerator.deviceID(forUID:)
-  var defaultInputDeviceIDProvider: () -> AudioDeviceID? =
-    AudioDeviceEnumerator.defaultInputDeviceID
+  /// The single capture device-selection authority (#1714). Injected so the
+  /// whole ladder — and the warm-compatibility projection below — is testable
+  /// without hardware. This REPLACED two narrower seams
+  /// (`resolveDeviceIDForUID`, `defaultInputDeviceIDProvider`) that let this
+  /// file hold selection policy of its own.
+  var inputDeviceResolver = InputDeviceResolver()
+
+  /// Fires exactly once per COLD attempt, synchronously, before `prepare()`
+  /// returns or throws. Never fires on warm reuse because a reused bind is not a
+  /// new resolution. Nil changes nothing. `AudioCaptureManager` consumes this
+  /// callback for lifetime ownership, then exposes a separate package projection
+  /// to AppKit so `EnviousWisprAudio` never imports Services.
+  var onInputResolutionAttemptFinalized: ((FinalizedInputResolutionAttempt) -> Void)?
 
   // MARK: - Private state
 
@@ -425,9 +435,8 @@ final class HALDeviceInputSource: AudioInputSource {
   /// Log-and-telemetry only in v1 — never interrupts the recording. Reset
   /// per session in `startCapture()`.
   private var formatDivergenceObserved = false
-  /// #1434 test seam: injectable native-rate reader (mirrors the existing
-  /// `resolveDeviceIDForUID` injection pattern). Defaults to the real
-  /// HAL property query.
+  /// #1434 test seam: injectable native-rate reader (mirrors this file's other
+  /// injected readers). Defaults to the real HAL property query.
   var nativeRateReader: (AudioDeviceID) -> Double? = { deviceID in
     HALDeviceInputSource.queryNativeStreamFormat(deviceID: deviceID)?.mSampleRate
   }
@@ -455,6 +464,9 @@ final class HALDeviceInputSource: AudioInputSource {
   private var boundDeviceID: AudioDeviceID?
   private var boundUID: String?
   private var boundTransport: String?
+  /// #1714: WHY this bind's device was chosen. Committed and cleared with the
+  /// other three, so the four are one fact with one lifetime.
+  private var boundResolutionSource: String?
   private var lastBindOK = true
   /// #1523: the bound device's total native input channel count, read once at
   /// prepare from the single channel-count authority
@@ -467,32 +479,29 @@ final class HALDeviceInputSource: AudioInputSource {
   var actualBoundTransport: String? { boundTransport }
 
   /// #1844: the committed bind, or nil before `prepare()` succeeded / after
-  /// teardown. All three fields are assigned together in the cold commit block
-  /// and cleared together in `teardownUnit()`, so this reads one fact, not three
+  /// teardown. All four fields are assigned together in the cold commit block
+  /// and cleared together in `teardownUnit()`, so this reads one fact, not four
   /// that could drift.
   private var currentBoundInputDevice: BoundInputDevice? {
-    guard let boundDeviceID else { return nil }
+    guard let boundDeviceID, let boundResolutionSource else { return nil }
     return BoundInputDevice(
-      deviceID: boundDeviceID, deviceUID: boundUID, transportLabel: boundTransport)
+      deviceID: boundDeviceID, deviceUID: boundUID, transportLabel: boundTransport,
+      resolutionSource: boundResolutionSource)
   }
 
-  func resolvedDeviceIDForTesting() -> AudioDeviceID? {
-    resolveDeviceID()
-  }
-
-  func setBoundDeviceIDForTesting(_ deviceID: AudioDeviceID?) {
-    boundDeviceID = deviceID
-  }
-
-  /// #1844: sets or clears ALL THREE committed bind fields together, the way the
-  /// cold commit block and `teardownUnit()` each do. `setBoundDeviceIDForTesting`
-  /// moves only the numeric id, which is right for the numeric reuse predicate but
-  /// would let a warm-reuse test pass on a correct id with a stale UID — and the
-  /// UID is exactly what the health check's identity re-check depends on.
+  /// #1844: sets or clears ALL FOUR committed bind fields together, the way the
+  /// cold commit block and `teardownUnit()` each do.
+  ///
+  /// This is the ONLY bind-setting seam. A partial-bind setter used to sit
+  /// beside it, moving just the numeric id; #1714 deleted it once the warm
+  /// predicate started reading the whole bind, because a test could otherwise
+  /// pass on a correct id with a stale UID — and the UID is exactly what the
+  /// health check's identity re-check depends on. Do not reintroduce one.
   func setBoundInputDeviceForTesting(_ bound: BoundInputDevice?) {
     boundDeviceID = bound?.deviceID
     boundUID = bound?.deviceUID
     boundTransport = bound?.transportLabel
+    boundResolutionSource = bound?.resolutionSource
   }
 
   /// #1844: the warm-reuse DECISION, split from the hardware that answers
@@ -528,9 +537,13 @@ final class HALDeviceInputSource: AudioInputSource {
     warmReuseBind(hasLiveUnit: hasLiveUnit)
   }
 
+  /// #1714: the POLICY moved to `InputDeviceResolver`; this stays as the narrow
+  /// predicate `AudioCaptureManager` already calls, and only supplies the
+  /// committed bind. HAL must not own selection rules — that was the defect
+  /// that let a private selector drift from the cold ladder.
   func boundDeviceMatchesResolvedTargetForReuse() -> Bool {
-    guard let boundDeviceID else { return false }
-    return boundDeviceID == resolveDeviceID()
+    guard let bound = currentBoundInputDevice else { return false }
+    return inputDeviceResolver.isWarmBindCompatible(bound, preferredUID: targetDeviceUID)
   }
 
   /// #1523: the last live stop-metadata, cached in `teardownUnit()` right before
@@ -594,8 +607,35 @@ final class HALDeviceInputSource: AudioInputSource {
     }
 
     onLifecycleSignal?("hal_find_device_entered")
-    let deviceID = resolveDeviceID()
-    guard let deviceID else { throw AudioError.noBuiltInMicrophoneFound }
+
+    // #1714: the ONE resolution for this cold attempt. Nothing below re-reads
+    // the default, the device list, a UID or a transport to decide WHICH device
+    // to open — a second read would describe different hardware than the one
+    // this attempt resolved against.
+    let resolution = inputDeviceResolver.resolve(preferredUID: targetDeviceUID)
+
+    // #1714: finalise exactly once on EVERY cold exit — resolution failure,
+    // bind failure, a later setup failure, or success. Declared immediately
+    // after resolution and before the first `throw` below, so no cold path can
+    // leave without a record. Warm reuse returned above and never reaches here,
+    // which is why a reused bind reports no new attempt.
+    var attemptState = InputResolutionAttemptState()
+    defer {
+      onInputResolutionAttemptFinalized?(attemptState.finalized(resolution: resolution))
+    }
+
+    // Exhaustive on purpose: a `?? .noBuiltInMicrophoneFound` fallback here
+    // would be a second, unreachable error authority that could go wrong
+    // silently. The resolver already decided which error is truthful.
+    let deviceID: AudioDeviceID
+    let selectedSource: InputResolutionSource
+    switch resolution.outcome {
+    case .selected(let id, let source):
+      deviceID = id
+      selectedSource = source
+    case .failed(let error):
+      throw error
+    }
     onLifecycleSignal?("hal_find_device_completed")
 
     onLifecycleSignal?("hal_configure_entered")
@@ -641,6 +681,12 @@ final class HALDeviceInputSource: AudioInputSource {
       &pinnedDevice, UInt32(MemoryLayout<AudioDeviceID>.size))
     let bindOK = status == noErr
     lastBindOK = bindOK
+    // #1714: recorded from the authoritative current-device result, BEFORE the
+    // guard below can throw. Everything after this point that fails leaves
+    // `bind_outcome = succeeded` with `prepare_outcome = failed`, which is what
+    // separates "could not open the microphone" from "opened it, then a later
+    // setup step failed".
+    attemptState.recordBind(succeeded: bindOK)
     guard bindOK else {
       AudioComponentInstanceDispose(unit)
       throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.set_device")
@@ -777,6 +823,10 @@ final class HALDeviceInputSource: AudioInputSource {
     boundDeviceID = deviceID
     boundUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
     boundTransport = AudioDeviceEnumerator.transportLabel(for: deviceID)
+    // #1714: the fourth committed field, taken from the same switch that chose
+    // the device — so there is no defaulted or optional path by which a bind
+    // could claim a source this attempt did not actually use.
+    boundResolutionSource = selectedSource.rawValue
     // #1523: read the device's total native channel count once at prepare from
     // the single channel-count authority. We capture mono (client format
     // channels: 1 above) and AUHAL down-mixes by TAKING CHANNEL 0 — so a device
@@ -797,10 +847,14 @@ final class HALDeviceInputSource: AudioInputSource {
     )
 
     // #1844: the bind this attempt established, handed straight back to the
-    // caller. Built from the same three fields committed above, so there is no
+    // caller. Built from the same four fields committed above, so there is no
     // window in which a caller could observe a device this attempt did not open.
+    // #1714: only NOW is the attempt a success — every fallible step above
+    // returned and the four-field bind is committed.
+    attemptState.recordPrepareSucceeded()
     return BoundInputDevice(
-      deviceID: deviceID, deviceUID: boundUID, transportLabel: boundTransport)
+      deviceID: deviceID, deviceUID: boundUID, transportLabel: boundTransport,
+      resolutionSource: selectedSource.rawValue)
   }
 
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
@@ -1168,19 +1222,8 @@ final class HALDeviceInputSource: AudioInputSource {
     boundDeviceID = nil
     boundUID = nil
     boundTransport = nil
+    boundResolutionSource = nil
     boundNativeChannelCount = nil
-  }
-
-  // MARK: - Private: device resolution
-
-  /// Resolve the pinned target device, falling back to the live system default.
-  private func resolveDeviceID() -> AudioDeviceID? {
-    if let uid = targetDeviceUID, !uid.isEmpty {
-      if let id = resolveDeviceIDForUID(uid) { return id }
-      AudioCaptureManager.btRouteLog(
-        "HALDeviceInputSource: target device uid=\(uid) not found — falling back to system default")
-    }
-    return defaultInputDeviceIDProvider()
   }
 
   /// Read the device's OWN native stream format directly from the HAL device

--- a/Sources/EnviousWisprAudio/InputDeviceResolver.swift
+++ b/Sources/EnviousWisprAudio/InputDeviceResolver.swift
@@ -196,6 +196,28 @@ struct InputDeviceResolver {
     // snapshot here, so report the default's transport from it rather than
     // discarding a fact we have; nil only when the default is not itself an
     // input candidate.
+    //
+    // KNOWN LIMIT, accepted deliberately (#1714 cloud review r3). `defaultID` was
+    // read before the snapshot, so a default unplugged in between is selected
+    // stale even when the snapshot holds a live alternative. Not fixed by
+    // rechecking `candidates` for three reasons:
+    //   1. Absence from `candidates` does not PROVE the default is gone. On an
+    //      incomplete list it proves nothing at all, and even on a complete one a
+    //      device is excluded for having no readable input channels, which is not
+    //      the same fact. Overriding the user's system default on inconclusive
+    //      evidence, in the heart path, is the worse trade.
+    //   2. Rung 1 above carries the identical staleness and deliberately does
+    //      NOT enumerate, so this check would make the pinned path stricter than
+    //      the Auto path about the same physical event, for no reason the user
+    //      could perceive. Making them consistent means enumerating on every
+    //      dictation, which §3 rung 1 exists to avoid.
+    //   3. It needs a double coincidence — pinned device missing AND default
+    //      changing inside the gap between two adjacent reads. Founder priority 3
+    //      is explicit that rare genuine failures get simple handling rather than
+    //      machinery.
+    // The outcome is a failed bind, which `bind_outcome = failed` records; if it
+    // instead binds and captures silence, that is the silent-capture family
+    // (#1845 / #1578 / #1809), which owns detection and is out of scope here.
     if let defaultID {
       return resolution(
         .selected(defaultID, source: .systemDefault),

--- a/Sources/EnviousWisprAudio/InputDeviceResolver.swift
+++ b/Sources/EnviousWisprAudio/InputDeviceResolver.swift
@@ -20,6 +20,11 @@ enum InputResolutionSource: String, Sendable, Equatable {
 enum InputEnumerationOutcome: String, Sendable, Equatable {
   case notAttempted = "not_attempted"
   case succeeded
+  /// The list read, but at least one device in it did not (#1714 cloud review
+  /// r2). Its own case rather than a flag because it is the one field that makes
+  /// this path visible in the field, and the race that produces it — a device
+  /// unplugged between two CoreAudio calls — cannot be constructed in a test.
+  case succeededPartial = "succeeded_partial"
   case readFailed = "read_failed"
 }
 
@@ -124,7 +129,7 @@ struct InputDeviceResolver {
     // The only enumeration in this function.
     let snapshot = inputDeviceSnapshot()
 
-    guard case .success(let candidates) = snapshot else {
+    guard case .success(let candidates, let listComplete) = snapshot else {
       // Founder decision 2026-07-30, overriding plan §3 rung 7: a pinned device
       // we cannot find — dead AirPods, out of range, unplugged, or a list we
       // could not even read — swaps to auto, and that behaviour must not be
@@ -172,7 +177,7 @@ struct InputDeviceResolver {
       InputDeviceResolution(
         outcome: outcome,
         defaultPresent: defaultID != nil,
-        enumerationOutcome: .succeeded,
+        enumerationOutcome: listComplete ? .succeeded : .succeededPartial,
         inputDeviceCount: candidates.count,
         eligibleDeviceCount: eligible.count,
         selectedTransport: AudioDeviceEnumerator.transportLabel(forTransportType: transport)
@@ -209,9 +214,18 @@ struct InputDeviceResolver {
 
     // Nothing eligible. Which error depends on whether the list PROVES there is
     // no microphone, or merely fails to prove there is one.
-    let provesAbsence = candidates.allSatisfy {
-      AudioDeviceEnumerator.isKnownNonMicrophoneTransport($0.rawTransport)
-    }
+    //
+    // `listComplete` is the first term for two reasons. An INCOMPLETE list can
+    // never prove absence — the device we failed to read is exactly the one that
+    // might have been a microphone. And `allSatisfy` is vacuously TRUE on an
+    // empty array, so without this gate an enumeration where every single device
+    // failed its read would sail into "connect a microphone", which is the
+    // strongest possible false claim from the weakest possible evidence.
+    let provesAbsence =
+      listComplete
+      && candidates.allSatisfy {
+        AudioDeviceEnumerator.isKnownNonMicrophoneTransport($0.rawTransport)
+      }
     return resolution(
       .failed(
         provesAbsence
@@ -252,7 +266,13 @@ struct InputDeviceResolver {
     }
 
     // Pinned: one snapshot, purely to ask "is the chosen device back?".
-    guard case .success(let candidates) = inputDeviceSnapshot() else {
+    //
+    // Completeness is deliberately ignored here, unlike the cold ladder. This
+    // asks only whether the pinned device was SEEN, and a partial list either
+    // contains it or does not. Not finding it already falls through to the
+    // conservative answer below, which is the same answer an unreadable device
+    // deserves — so there is nothing for a completeness check to change.
+    guard case .success(let candidates, _) = inputDeviceSnapshot() else {
       // The read failed, so it has NOT shown the pinned device returned. Fall
       // back to the same question Auto asks rather than guessing.
       return matchesDefaultOrKeepsFallback(bound, defaultID: defaultID)

--- a/Sources/EnviousWisprAudio/InputDeviceResolver.swift
+++ b/Sources/EnviousWisprAudio/InputDeviceResolver.swift
@@ -1,0 +1,385 @@
+import CoreAudio
+
+/// Why a particular input device was chosen (#1714). Low-cardinality, safe to
+/// put on a telemetry event.
+enum InputResolutionSource: String, Sendable, Equatable {
+  /// The user pinned this device and it was present in the frozen snapshot.
+  case pinnedUID = "pinned_uid"
+  /// CoreAudio reported a default input device and we took it.
+  case systemDefault = "system_default"
+  /// No default was reported, so an allow-listed physical device was chosen
+  /// from the frozen list. This is the rung #1714 exists to add.
+  case listFallback = "list_fallback"
+}
+
+/// Whether the device list was read, and how it went (#1714).
+///
+/// `notAttempted` is a first-class outcome, not a gap: on the ordinary Auto path
+/// with a present system default the list is never enumerated at all, and that
+/// has to be distinguishable from "enumerated and found nothing".
+enum InputEnumerationOutcome: String, Sendable, Equatable {
+  case notAttempted = "not_attempted"
+  case succeeded
+  case readFailed = "read_failed"
+}
+
+/// One immutable resolution result (#1714).
+///
+/// Carries the facts that were true AT RESOLUTION TIME, including on the failure
+/// paths, so telemetry never has to re-read hardware to describe the decision —
+/// a second read would describe a different hardware state than the one that was
+/// actually resolved against.
+struct InputDeviceResolution: Sendable {
+  enum Outcome: Sendable {
+    case selected(AudioDeviceID, source: InputResolutionSource)
+    case failed(AudioError)
+  }
+
+  let outcome: Outcome
+  /// Whether CoreAudio reported a default input device on this attempt.
+  let defaultPresent: Bool
+  let enumerationOutcome: InputEnumerationOutcome
+  /// Input devices in the frozen snapshot. Nil when enumeration was not
+  /// attempted or the read failed — nil means "not known", never zero.
+  let inputDeviceCount: Int?
+  /// Snapshot candidates passing the physical allow-list. Same nil convention.
+  let eligibleDeviceCount: Int?
+  /// Low-cardinality transport label of the SELECTED device, when it came from
+  /// the frozen snapshot. Nil on the not-attempted default path, where the
+  /// transport is genuinely unknown without a second hardware read.
+  let selectedTransport: String?
+
+  var selectedDeviceID: AudioDeviceID? {
+    if case .selected(let id, _) = outcome { return id }
+    return nil
+  }
+
+  var resolutionSource: InputResolutionSource? {
+    if case .selected(_, let source) = outcome { return source }
+    return nil
+  }
+
+  var thrownError: AudioError? {
+    if case .failed(let error) = outcome { return error }
+    return nil
+  }
+}
+
+/// Chooses which input device capture should open (#1714).
+///
+/// Exists because the shipped path asked CoreAudio exactly one question — "what
+/// is the default input device?" — and aborted the recording when the answer was
+/// nil, without ever looking at the device list. 226 events across 19 installs,
+/// half of which never completed a single dictation.
+///
+/// Stateless and hardware-free by construction: every fact arrives through the
+/// two injected providers, so the whole ladder is unit-testable and cannot
+/// smuggle in a live CoreAudio read. It holds no remembered device — the
+/// session-log 2026-07-14 defect class was three shipped sites deriving the Auto
+/// device from a stored selection, and this type cannot join it.
+///
+/// Ownership: this is the SOLE capture device-selection authority.
+/// `AudioDeviceEnumerator.inputDeviceSnapshot()` is the sole list read;
+/// `HALDeviceInputSource` owns opening and committing the chosen device;
+/// `AudioDeviceMonitor` observes device changes and never selects.
+struct InputDeviceResolver {
+  /// The live system default input. Injected so a test — and the DEBUG UAT seam
+  /// — can force its absence, which is the whole failing condition.
+  let defaultInputDeviceID: () -> AudioDeviceID?
+  /// ONE frozen enumeration. Invoked AT MOST ONCE per `resolve` call: every
+  /// count and transport reported below has to describe the same list the
+  /// selected device came from.
+  let inputDeviceSnapshot: () -> InputDeviceSnapshot
+
+  init(
+    defaultInputDeviceID: @escaping () -> AudioDeviceID? = AudioDeviceEnumerator
+      .defaultInputDeviceID,
+    inputDeviceSnapshot: @escaping () -> InputDeviceSnapshot = AudioDeviceEnumerator
+      .inputDeviceSnapshot
+  ) {
+    self.defaultInputDeviceID = defaultInputDeviceID
+    self.inputDeviceSnapshot = inputDeviceSnapshot
+  }
+
+  /// Resolve the device to open. `preferredUID` is the user's pinned device;
+  /// nil or empty means Auto.
+  func resolve(preferredUID: String?) -> InputDeviceResolution {
+    let defaultID = defaultInputDeviceID()
+    let hasPreferred = !(preferredUID ?? "").isEmpty
+
+    // Rung 1 — the ordinary Auto path. A present default is taken WITHOUT
+    // touching the device list, so the overwhelmingly common case does no
+    // extra hardware work and reports `not_attempted` honestly.
+    if !hasPreferred, let defaultID {
+      return InputDeviceResolution(
+        outcome: .selected(defaultID, source: .systemDefault),
+        defaultPresent: true,
+        enumerationOutcome: .notAttempted,
+        inputDeviceCount: nil,
+        eligibleDeviceCount: nil,
+        selectedTransport: nil
+      )
+    }
+
+    // The only enumeration in this function.
+    let snapshot = inputDeviceSnapshot()
+
+    guard case .success(let candidates) = snapshot else {
+      // Founder decision 2026-07-30, overriding plan §3 rung 7: a pinned device
+      // we cannot find — dead AirPods, out of range, unplugged, or a list we
+      // could not even read — swaps to auto, and that behaviour must not be
+      // disrupted. An error belongs where the device is PRESENT and capture
+      // actually fails, not where selection is merely uncertain while a working
+      // default sits right there. So take the default rather than abort a take
+      // that succeeds today; the read failure still reaches telemetry through
+      // `enumerationOutcome`.
+      if let defaultID {
+        return InputDeviceResolution(
+          outcome: .selected(defaultID, source: .systemDefault),
+          defaultPresent: true,
+          enumerationOutcome: .readFailed,
+          inputDeviceCount: nil,
+          eligibleDeviceCount: nil,
+          selectedTransport: nil
+        )
+      }
+
+      // No default either. A failed READ proves nothing about whether a
+      // microphone exists, so it must not reach the "connect a microphone"
+      // sentence — the user is told the capture failed, not that their
+      // hardware is missing.
+      return InputDeviceResolution(
+        outcome: .failed(
+          .formatCreationFailed(source: "InputDeviceResolver.enumerate_input_devices")),
+        defaultPresent: false,
+        enumerationOutcome: .readFailed,
+        inputDeviceCount: nil,
+        eligibleDeviceCount: nil,
+        selectedTransport: nil
+      )
+    }
+
+    let eligible = candidates.filter {
+      AudioDeviceEnumerator.isAllowedPhysicalInputTransport($0.rawTransport)
+    }
+
+    // `transport` is nil both when nothing was selected and when the selected
+    // device's transport was unreadable; `transportLabel` maps nil to nil, and
+    // the two cases are already told apart by `outcome`.
+    func resolution(
+      _ outcome: InputDeviceResolution.Outcome, transport: UInt32? = nil
+    ) -> InputDeviceResolution {
+      InputDeviceResolution(
+        outcome: outcome,
+        defaultPresent: defaultID != nil,
+        enumerationOutcome: .succeeded,
+        inputDeviceCount: candidates.count,
+        eligibleDeviceCount: eligible.count,
+        selectedTransport: AudioDeviceEnumerator.transportLabel(forTransportType: transport)
+      )
+    }
+
+    // Rung 2 — a pinned device, resolved ONLY inside the frozen snapshot. The
+    // allow-list is not consulted: an explicit choice is the user's to make,
+    // including an aggregate device.
+    if hasPreferred, let pinned = candidates.first(where: { $0.uid == preferredUID }) {
+      return resolution(.selected(pinned.id, source: .pinnedUID), transport: pinned.rawTransport)
+    }
+
+    // Rung 3 — the pinned device is gone. Fall through to the system default,
+    // exactly as the shipped code already does. We already hold the frozen
+    // snapshot here, so report the default's transport from it rather than
+    // discarding a fact we have; nil only when the default is not itself an
+    // input candidate.
+    if let defaultID {
+      return resolution(
+        .selected(defaultID, source: .systemDefault),
+        transport: candidates.first(where: { $0.id == defaultID })?.rawTransport
+      )
+    }
+
+    // Rung 4 — nobody chose anything and CoreAudio has no default. Prefer the
+    // built-in microphone over whatever happens to be listed first, then take
+    // the first allow-listed physical device in snapshot order.
+    let builtIn = eligible.first { $0.rawTransport == kAudioDeviceTransportTypeBuiltIn }
+    if let chosen = builtIn ?? eligible.first {
+      return resolution(
+        .selected(chosen.id, source: .listFallback), transport: chosen.rawTransport)
+    }
+
+    // Nothing eligible. Which error depends on whether the list PROVES there is
+    // no microphone, or merely fails to prove there is one.
+    let provesAbsence = candidates.allSatisfy {
+      AudioDeviceEnumerator.isKnownNonMicrophoneTransport($0.rawTransport)
+    }
+    return resolution(
+      .failed(
+        provesAbsence
+          ? .noBuiltInMicrophoneFound
+          : .formatCreationFailed(
+            source: "InputDeviceResolver.unclassifiable_input_transport")))
+  }
+
+  // MARK: - Warm-bind compatibility
+
+  /// Is an ALREADY-OPEN bind still the device the user is asking for?
+  ///
+  /// A deliberately separate projection from `resolve(preferredUID:)`, not a
+  /// call into it. The cold ladder RANKS candidates and may pick a fallback
+  /// device; this one only ANSWERS whether the live bind still matches intent.
+  /// Running the ladder here would let automatic fallback ranking decide a warm
+  /// take, which the plan confines to cold opens (§12).
+  ///
+  /// **Founder decision 2026-07-30: a reconnected pinned device reclaims the
+  /// take immediately.** So when the pinned UID reappears in the snapshot and is
+  /// not what we are bound to, this returns false, the manager tears the warm
+  /// source down (`AudioCaptureManager.swift:899`) and the next open is cold —
+  /// which is exactly how the user's chosen microphone wins back the take. This
+  /// is the mirror of rung 3: a chosen device that vanishes swaps to auto, and a
+  /// chosen device that returns takes the take back.
+  ///
+  /// Cost note: on the pinned path this reads the device list, as the shipped
+  /// code it replaces already did (`resolveDeviceID()` → `deviceID(forUID:)` →
+  /// `allInputDevices()`). On Auto it reads only the default and never
+  /// enumerates, also as before. No new work on either path.
+  func isWarmBindCompatible(_ bound: BoundInputDevice, preferredUID: String?) -> Bool {
+    let defaultID = defaultInputDeviceID()
+    let hasPreferred = !(preferredUID ?? "").isEmpty
+
+    // Auto: the live default is the whole question. Never enumerate.
+    guard hasPreferred else {
+      return matchesDefaultOrKeepsFallback(bound, defaultID: defaultID)
+    }
+
+    // Pinned: one snapshot, purely to ask "is the chosen device back?".
+    guard case .success(let candidates) = inputDeviceSnapshot() else {
+      // The read failed, so it has NOT shown the pinned device returned. Fall
+      // back to the same question Auto asks rather than guessing.
+      return matchesDefaultOrKeepsFallback(bound, defaultID: defaultID)
+    }
+
+    if let pinned = candidates.first(where: { $0.uid == preferredUID }) {
+      return bound.deviceID == pinned.id
+    }
+
+    return matchesDefaultOrKeepsFallback(bound, defaultID: defaultID)
+  }
+
+  /// The shared tail of both compatibility paths: track the live default when
+  /// there is one, and otherwise keep ONLY a bind that the fallback rung chose.
+  ///
+  /// The `list_fallback` restriction is load-bearing. A bind that came from a
+  /// pinned device or a since-vanished default is not made correct by both of
+  /// those disappearing — only a bind we selected precisely BECAUSE no default
+  /// existed is still the right answer in that state.
+  private func matchesDefaultOrKeepsFallback(
+    _ bound: BoundInputDevice, defaultID: AudioDeviceID?
+  ) -> Bool {
+    if let defaultID { return bound.deviceID == defaultID }
+    return bound.resolutionSource == InputResolutionSource.listFallback.rawValue
+  }
+}
+
+/// Did the AudioUnit actually get pointed at the chosen device? (#1714)
+///
+/// Separate from `InputPrepareOutcome` because binding is ONE step
+/// (`AudioUnitSetProperty(kAudioOutputUnitProperty_CurrentDevice)`) and several
+/// fallible setup steps follow it. Collapsing the two would make "we could not
+/// open the microphone" indistinguishable from "we opened it and the converter
+/// failed", which are different bugs with different owners.
+enum InputBindOutcome: String, Sendable, Equatable {
+  /// Resolution failed, or the attempt exited before the bind was tried.
+  case notAttempted = "not_attempted"
+  case failed
+  case succeeded
+}
+
+/// Did the whole cold `prepare()` succeed? (#1714)
+enum InputPrepareOutcome: String, Sendable, Equatable {
+  case failed
+  case succeeded
+}
+
+/// Accumulates one cold attempt's outcomes as `prepare()` walks its steps
+/// (#1714). Extracted so the OUTCOME TRANSITIONS THEMSELVES are the thing tests
+/// exercise: an earlier version had `prepare()` mutate two local variables and
+/// the suite assert a table it wrote itself, which proved only that the copy
+/// agreed with the copy. Deleting the success transition left it green.
+///
+/// **`prepareOutcome` is DERIVED, never stored.** A prepare cannot have
+/// succeeded on a device that was never bound, so that combination is not
+/// representable rather than merely tested. The reviewer proposed a
+/// `precondition` in `recordPrepareSucceeded`; declined and replaced with this,
+/// because a `precondition` on the cold-open path is a crash primitive on the
+/// heart path guarding a state the control flow already rules out — and the
+/// project's rule is to make the window impossible, not to handle it with the
+/// most destructive response available.
+struct InputResolutionAttemptState: Sendable {
+  private(set) var bindOutcome: InputBindOutcome = .notAttempted
+  private var prepareReachedTheEnd = false
+
+  /// `failed` until every fallible step has run AND the device was bound.
+  var prepareOutcome: InputPrepareOutcome {
+    bindOutcome == .succeeded && prepareReachedTheEnd ? .succeeded : .failed
+  }
+
+  /// Record the authoritative current-device property result.
+  mutating func recordBind(succeeded: Bool) {
+    bindOutcome = succeeded ? .succeeded : .failed
+  }
+
+  /// Called once, after the four-field bind is committed.
+  mutating func recordPrepareSucceeded() {
+    prepareReachedTheEnd = true
+  }
+
+  func finalized(resolution: InputDeviceResolution) -> FinalizedInputResolutionAttempt {
+    FinalizedInputResolutionAttempt(
+      resolution: resolution, bindOutcome: bindOutcome, prepareOutcome: prepareOutcome)
+  }
+}
+
+/// One COLD attempt, finalised (#1714).
+///
+/// Emitted exactly once per cold `prepare()` exit — success, resolution failure,
+/// bind failure, or a later setup failure — and never on warm reuse. Carries the
+/// resolution facts frozen at decision time so no consumer re-reads hardware to
+/// describe an attempt that has already finished.
+struct FinalizedInputResolutionAttempt: Sendable {
+  let resolution: InputDeviceResolution
+  let bindOutcome: InputBindOutcome
+  let prepareOutcome: InputPrepareOutcome
+}
+
+/// One finalised cold attempt, projected for telemetry (#1714).
+///
+/// A flat value of primitives so the composition root can hand it to
+/// `TelemetryService` without `EnviousWisprAudio` importing Services, and
+/// without resolver or hardware types escaping this module. `package`, not
+/// `public`: only the app shell needs it.
+package struct InputResolutionAttemptTelemetry: Sendable, Equatable {
+  package let defaultPresent: Bool
+  package let enumerationOutcome: String
+  /// Nil means NOT KNOWN — enumeration was not attempted or its read failed.
+  /// Never flatten to zero: zero is a real, different answer meaning the machine
+  /// genuinely listed no input devices.
+  package let inputDeviceCount: Int?
+  /// Same nil convention as `inputDeviceCount`.
+  package let eligibleDeviceCount: Int?
+  package let inputResolutionSource: String?
+  package let selectedTransport: String?
+  package let bindOutcome: String
+  package let prepareOutcome: String
+
+  /// Internal: only this module constructs one.
+  init(_ attempt: FinalizedInputResolutionAttempt) {
+    self.defaultPresent = attempt.resolution.defaultPresent
+    self.enumerationOutcome = attempt.resolution.enumerationOutcome.rawValue
+    self.inputDeviceCount = attempt.resolution.inputDeviceCount
+    self.eligibleDeviceCount = attempt.resolution.eligibleDeviceCount
+    self.inputResolutionSource = attempt.resolution.resolutionSource?.rawValue
+    self.selectedTransport = attempt.resolution.selectedTransport
+    self.bindOutcome = attempt.bindOutcome.rawValue
+    self.prepareOutcome = attempt.prepareOutcome.rawValue
+  }
+}

--- a/Sources/EnviousWisprPipeline/AudioCaptureFailureExtras.swift
+++ b/Sources/EnviousWisprPipeline/AudioCaptureFailureExtras.swift
@@ -25,7 +25,10 @@ enum AudioCaptureFailureExtras {
       routeFallbackReason: resolvedRoute?.routeFallbackReason,
       inputSelectionMode: resolvedRoute?.inputSelectionMode,
       outputTransport: resolvedRoute?.outputTransport,
-      routeResolutionSource: resolvedRoute?.routeResolutionSource
+      routeResolutionSource: resolvedRoute?.routeResolutionSource,
+      // #1714: read from the interface this builder already receives — no new
+      // argument, no downcast to the concrete manager.
+      inputResolutionSource: audioCapture.currentInputResolutionSource
     )
 
     if let source = (error as? AudioError)?.diagnosticSource {

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -985,6 +985,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// the App layer's `dictation.completed` telemetry. LIVE pass-through from the
   /// kernel; never persisted. Low-cardinality transport/reason strings only.
   public var lastResolvedRoute: ResolvedRouteTransports? { kernel.lastResolvedRoute }
+  /// #1714: WHY this session's microphone was chosen — `pinned_uid`,
+  /// `system_default` or `list_fallback`. A direct read-through of the kernel's
+  /// frozen value, following `lastResolvedRoute`'s precedent; the App layer
+  /// reads it after completion OR failure for terminal telemetry.
+  public var lastInputResolutionSource: String? { kernel.lastInputResolutionSource }
   /// #1434: non-nil when the most recent completion was a degraded-lead
   /// SALVAGE (the transcript was recovered by trimming a poisoned opening) —
   /// drives the post-completion disclosure pill and `dictation.completed`

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -624,6 +624,28 @@ final class RecordingSessionKernel {
   /// mid-flight device change cannot tear the recorded value. Overwritten each
   /// session; never persisted.
   private(set) var lastResolvedRoute: ResolvedRouteTransports?
+  /// #1714: WHY this session's microphone was chosen — `pinned_uid`,
+  /// `system_default` or `list_fallback`. Frozen after the FINAL engine-start
+  /// attempt, including the failing ones, because an engine-start failure never
+  /// reaches Live and those failures are the population #1714 exists to measure.
+  ///
+  /// FINAL-ATTEMPT semantics across the one permitted rebuild retry: exactly one
+  /// of the three mutually exclusive freeze sites executes per session, and it
+  /// reads only after the retry decision is final. That is not in tension with
+  /// terminal first-wins, which decides which competing OUTCOME owns the
+  /// session; this field describes the attempt that established or terminated
+  /// the take.
+  ///
+  /// The freeze helper deliberately uses plain assignment. With today's
+  /// topology, reset clears the field and only one freeze executes, so
+  /// assignment and `??` are behaviorally equivalent. Plain assignment encodes
+  /// the required ownership if another freeze site is ever introduced: the final
+  /// attempt must win.
+  ///
+  /// Observation-only. Nothing may branch capture, retry, routing, error
+  /// classification or terminal selection on it. `nil` degrades attribution,
+  /// never the recording.
+  private(set) var lastInputResolutionSource: String?
   /// #1434: non-nil when the most recent completion was a degraded-lead
   /// salvage — the winning trim in ms. Cleared with `lastStopReason` at the
   /// next `→ recording` transition (the App layer reads it at `.complete`).
@@ -1160,6 +1182,11 @@ final class RecordingSessionKernel {
       try await audioCapture.startEnginePhase()
     } catch {
       guard isCurrent(sid) else { return }
+      // #1714: this attempt was the last one, so freeze its attribution BEFORE
+      // the terminal is published. Without this, every engine-start failure —
+      // the exact population this issue exists to measure — would be reported
+      // with no device source at all.
+      freezeFinalInputResolutionSource()
       // #1525 PR J-1: the write-site static type is `any Error` (an untyped
       // `throws` surface), so an intersection cast is required before
       // narrowing — a miss leaves the property nil and the read-side
@@ -1199,6 +1226,10 @@ final class RecordingSessionKernel {
         try await audioCapture.startEnginePhase()
       } catch {
         guard isCurrent(sid) else { return }
+        // #1714: the rebuild was the final attempt — freeze ITS source, not the
+        // first attempt's. A retry that lands on a different device would
+        // otherwise file the failure against the wrong microphone.
+        freezeFinalInputResolutionSource()
         // #1525 PR J-1: see the identical cast note at the first
         // `startEnginePhase()` catch above.
         telemetryState.captureFailureError = error as? (any Error & StableSentryErrorIdentity)
@@ -1225,6 +1256,11 @@ final class RecordingSessionKernel {
       guard isCurrent(sid) else { return }
       formatStabilizedThisSession = reverified
     }
+    // #1714: the single success-path freeze, placed AFTER the optional rebuild
+    // and its re-verification so it reads the final attempt's device. Freezing
+    // right after the first successful attempt would miss a rebuild that
+    // resolved differently.
+    freezeFinalInputResolutionSource()
     // The capture engine is up — every terminal from here must stop capture.
     captureLifecycle = .active
     // First-wins invariant (Codex code-diff P2): a stop/cancel and a latched
@@ -3658,6 +3694,16 @@ final class RecordingSessionKernel {
     currentSessionID == sid
   }
 
+  /// #1714: snapshot WHY the final engine-start attempt's microphone was chosen.
+  ///
+  /// A plain assignment, never `??` or an `if let` guard. Today that is not
+  /// observable — one freeze per session, on an already-cleared field — but it
+  /// encodes the ownership rule if a second freeze site is ever added: the final
+  /// attempt must win, and a final `nil` must not inherit an earlier device.
+  private func freezeFinalInputResolutionSource() {
+    lastInputResolutionSource = audioCapture.currentInputResolutionSource
+  }
+
   private func resetSessionState() {
     stopLatched = false
     cancelRequested = false
@@ -3696,6 +3742,10 @@ final class RecordingSessionKernel {
     lastTakeID = nil  // #1846 — absent, never the new session's id
     lastSalvagedLeadTrimMs = nil  // #1434
     lastCaptureHealth = nil  // #1434
+    // #1714: cleared with the other prior-session facts so a new session cannot
+    // inherit the previous take's device attribution before its own final
+    // engine-start attempt publishes one.
+    lastInputResolutionSource = nil
     lastRecordingDurationSeconds = nil  // #1060
     deliveredTranscript = nil
     deliveryOutcome = nil

--- a/Sources/EnviousWisprServices/SentryAudioExtras.swift
+++ b/Sources/EnviousWisprServices/SentryAudioExtras.swift
@@ -28,7 +28,8 @@ public enum SentryAudioExtras {
     routeFallbackReason: String? = nil,
     inputSelectionMode: String? = nil,
     outputTransport: String? = nil,
-    routeResolutionSource: String? = nil
+    routeResolutionSource: String? = nil,
+    inputResolutionSource: String? = nil
   ) -> [String: Any] {
     var extras: [String: Any] = [
       "capture.source_type": sourceType,
@@ -95,6 +96,12 @@ public enum SentryAudioExtras {
     if let ism = inputSelectionMode { extras["capture.input_selection_mode"] = ism }
     if let ot = outputTransport { extras["capture.output_transport"] = ot }
     if let rrs = routeResolutionSource { extras["capture.route_resolution_source"] = rrs }
+    // #1714: WHY the input device was selected. Deliberately NOT named
+    // `resolution_source`: `route_resolution_source` above already carries
+    // `app_derived` / `helper_reported`, which is how a TRANSPORT LABEL was
+    // derived — an unrelated question. Two near-identical keys on one event
+    // would make every future query ambiguous. Nil omits the key entirely.
+    if let irs = inputResolutionSource { extras["capture.input_resolution_source"] = irs }
 
     return extras
   }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -112,6 +112,7 @@ public final class TelemetryService {
     routeReason: String? = nil, routeFallbackReason: String? = nil,
     inputSelectionMode: String? = nil, outputTransport: String? = nil,
     routeResolutionSource: String? = nil,
+    inputResolutionSource: String? = nil,
     // #1434: capture-health facts + degraded-lead salvage marker. Hardware-
     // class numbers and flags only (telemetry-privacy-boundary).
     captureNativeRateHz: Double? = nil, captureRingDropCount: Int? = nil,
@@ -175,6 +176,7 @@ public final class TelemetryService {
       inputSelectionMode: inputSelectionMode,
       outputTransport: outputTransport,
       routeResolutionSource: routeResolutionSource,
+      inputResolutionSource: inputResolutionSource,
       captureNativeRateHz: captureNativeRateHz,
       captureRingDropCount: captureRingDropCount,
       captureConverterErrorCount: captureConverterErrorCount,
@@ -720,6 +722,7 @@ public final class TelemetryService {
     routeReason: String? = nil, routeFallbackReason: String? = nil,
     inputSelectionMode: String? = nil, outputTransport: String? = nil,
     routeResolutionSource: String? = nil,
+    inputResolutionSource: String? = nil,
     // #1434: capture-health + salvage (absent -> keys omitted).
     captureNativeRateHz: Double? = nil, captureRingDropCount: Int? = nil,
     captureConverterErrorCount: Int? = nil, captureZeroOutputCount: Int? = nil,
@@ -801,6 +804,11 @@ public final class TelemetryService {
     if let ot = outputTransport { props["output_transport"] = ot }
     if let rrs = routeResolutionSource { props["route_resolution_source"] = rrs }
     if let takeID { props["take_id"] = takeID }
+    // #1714: WHY the microphone was chosen. One word from
+    // `route_resolution_source` above and a different question entirely.
+    // Set BEFORE the hook below, which now DERIVES from `props` — a line added
+    // after it would ship to PostHog and be invisible to every test.
+    if let irs = inputResolutionSource { props["input_resolution_source"] = irs }
     #if DEBUG
       // #1846: the hook now DERIVES from the payload that PostHog receives.
       // `reportDictationCompleted` previously built a parallel `hookStringProps`
@@ -1473,11 +1481,65 @@ public final class TelemetryService {
     }
   }
 
+  // MARK: - Input resolution (#1714)
+
+  /// Cold-attempt diagnostic only. Never use this event as the denominator for
+  /// dictation.completed or pipeline.failed rates because one cold prepare may
+  /// serve many warm dictations.
+  ///
+  /// One event per COLD prepare, including ordinary system-default attempts, so
+  /// the population is complete rather than branch-selected. Warm reuse emits
+  /// nothing.
+  public func audioInputResolution(
+    defaultPresent: Bool,
+    enumerationOutcome: String,
+    inputDeviceCount: Int?,
+    eligibleDeviceCount: Int?,
+    inputResolutionSource: String?,
+    selectedTransport: String?,
+    bindOutcome: String,
+    prepareOutcome: String
+  ) {
+    #if DEBUG
+      var hookStrings: [String: String] = [
+        "enumeration_outcome": enumerationOutcome,
+        "bind_outcome": bindOutcome,
+        "prepare_outcome": prepareOutcome,
+      ]
+      if let s = inputResolutionSource { hookStrings["input_resolution_source"] = s }
+      if let t = selectedTransport { hookStrings["selected_transport"] = t }
+      var hookInts: [String: Int] = [:]
+      if let c = inputDeviceCount { hookInts["input_device_count"] = c }
+      if let c = eligibleDeviceCount { hookInts["eligible_device_count"] = c }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "audio.input_resolution",
+          stringProps: hookStrings,
+          intProps: hookInts,
+          boolProps: ["default_present": defaultPresent]
+        ))
+    #endif
+    var props: [String: Any] = [
+      "default_present": defaultPresent,
+      "enumeration_outcome": enumerationOutcome,
+      "bind_outcome": bindOutcome,
+      "prepare_outcome": prepareOutcome,
+    ]
+    // Omitted when nil because nil means NOT KNOWN. An explicit zero is a real
+    // answer and must ride as zero.
+    if let c = inputDeviceCount { props["input_device_count"] = c }
+    if let c = eligibleDeviceCount { props["eligible_device_count"] = c }
+    if let s = inputResolutionSource { props["input_resolution_source"] = s }
+    if let t = selectedTransport { props["selected_transport"] = t }
+    PostHogSDK.shared.capture("audio.input_resolution", properties: props)
+  }
+
   // MARK: - Errors
 
   public func pipelineFailed(
     stage: String, errorCategory: String, errorCode: String,
-    recoverable: Bool, backend: String?
+    recoverable: Bool, backend: String?,
+    inputResolutionSource: String? = nil
   ) {
     #if DEBUG
       var hookStrings: [String: String] = [
@@ -1486,6 +1548,7 @@ public final class TelemetryService {
         "error_code": errorCode,
       ]
       if let b = backend { hookStrings["backend"] = b }
+      if let s = inputResolutionSource { hookStrings["input_resolution_source"] = s }
       testEventHook?(
         CapturedTelemetryEvent(
           name: "pipeline.failed",
@@ -1500,6 +1563,9 @@ public final class TelemetryService {
       "recoverable": recoverable,
     ]
     if let b = backend { props["backend"] = b }
+    // #1714: WHY the microphone was chosen. Distinct from
+    // `route_resolution_source`, which is how a TRANSPORT LABEL was derived.
+    if let s = inputResolutionSource { props["input_resolution_source"] = s }
     PostHogSDK.shared.capture("pipeline.failed", properties: props)
   }
 

--- a/Tests/EnviousWisprTests/App/DebugFaultEndpointInputFallbackTests.swift
+++ b/Tests/EnviousWisprTests/App/DebugFaultEndpointInputFallbackTests.swift
@@ -1,0 +1,159 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprAudio
+@testable import EnviousWisprPipeline
+
+// #1714 — freezes the two DEBUG commands the Live UAT drives.
+//
+// These are the only way the fallback branch can be reached on a real build, so
+// the exact command strings, the boolean each one passes, and all three replies
+// are frozen here. A typo in a command string would otherwise surface as a
+// confusing UAT failure hours later, on a rebuilt app, with no obvious cause.
+//
+// Hardware-free: the endpoint is driven through its own handler seam, no socket
+// and no real device.
+#if DEBUG
+
+  @MainActor
+  @Suite("DebugFaultEndpoint input-fallback commands — #1714")
+  struct DebugFaultEndpointInputFallbackTests {
+
+    /// An explicit decision, so construction is exercised without
+    /// `CaptureRouteResolver.resolve()` reading live output hardware.
+    private static func decision() -> CaptureRouteDecision {
+      CaptureRouteDecision(
+        sourceType: .halDeviceInput, reason: .noBTAutoInput, rationale: "test")
+    }
+
+    private func makeEndpoint(audioCapture: AudioCaptureManager?) -> DebugFaultEndpoint {
+      let clock = FakeClock()
+      let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: clock)
+      let steps = LimbSteps(
+        wordCorrection: WordCorrectionStep(),
+        fillerRemoval: FillerRemovalStep(),
+        emojiFormatter: EmojiFormatterStep(),
+        inverseTextNormalization: InverseTextNormalizationStep(),
+        llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
+        emojiRestore: EmojiRestoreStep())
+      func makeDriver() -> KernelDictationDriver {
+        let kernel = RecordingSessionKernel(
+          adapter: engine,
+          audioCapture: FakeAudioCapture(),
+          vad: FakeVADSignalSource(),
+          currentTick: { 0 }, sleepTicks: { _ in },
+          processText: { raw, _ in raw },
+          store: { _, _ in }, deliver: { _ in .pasted },
+          engineMutationScope: .alwaysAllowedForTesting,
+          minimumRecordingTicks: 0)
+        let observer = KernelHeartPathTelemetryObserver(
+          kernel: kernel, audioCapture: FakeAudioCapture(),
+          emitter: HeartPathTelemetryEmitter(
+            backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
+          emitLifecycleEvent: { _ in })
+        return KernelDictationDriver(
+          kernel: kernel, observer: observer,
+          outcome: KernelFinalizationOutcome(), context: KernelSessionContext(),
+          steps: steps, adapter: engine,
+          engineMutationScope: .alwaysAllowedForTesting)
+      }
+      return DebugFaultEndpoint(
+        audioCapture: audioCapture,
+        asrProxy: nil,
+        kernelDriver: makeDriver(),
+        whisperKitKernelDriver: makeDriver(),
+        activeBackend: { .parakeet })
+    }
+
+    // MARK: - The happy path, both directions
+
+    @Test("force_default_input_absent arms the manager and replies OK")
+    func forceCommandArms() async {
+      let manager = AudioCaptureManager()
+      let endpoint = makeEndpoint(audioCapture: manager)
+
+      let reply = await endpoint.handleForTesting(command: "force_default_input_absent")
+
+      #expect(reply == "OK")
+      // Observed by effect through the real construction authority, not by
+      // peeking at a stored closure.
+      let source = manager.buildSourceForTesting(Self.decision()) as? HALDeviceInputSource
+      #expect(source?.inputDeviceResolver.defaultInputDeviceID() == nil)
+    }
+
+    @Test("clear_default_input_absent disarms the manager and replies OK")
+    func clearCommandDisarms() async {
+      let manager = AudioCaptureManager()
+      let endpoint = makeEndpoint(audioCapture: manager)
+      #expect(await endpoint.handleForTesting(command: "force_default_input_absent") == "OK")
+
+      let reply = await endpoint.handleForTesting(command: "clear_default_input_absent")
+
+      #expect(reply == "OK")
+      // Disarmed: the manager builds its ordinary source again.
+      let source = manager.buildSourceForTesting(Self.decision()) as? HALDeviceInputSource
+      #expect(source != nil)
+    }
+
+    // MARK: - Refusals
+
+    @Test("both commands refuse while capture is active")
+    func bothRefuseDuringCapture() async {
+      let manager = AudioCaptureManager()
+      let endpoint = makeEndpoint(audioCapture: manager)
+      manager.isCapturing = true
+
+      #expect(
+        await endpoint.handleForTesting(command: "force_default_input_absent")
+          == "ERR capture_active")
+      #expect(
+        await endpoint.handleForTesting(command: "clear_default_input_absent")
+          == "ERR capture_active")
+    }
+
+    @Test("both commands report a missing manager rather than silently succeeding")
+    func bothReportMissingDependency() async {
+      let endpoint = makeEndpoint(audioCapture: nil)
+
+      #expect(
+        await endpoint.handleForTesting(command: "force_default_input_absent")
+          == "ERR no_dependency")
+      #expect(
+        await endpoint.handleForTesting(command: "clear_default_input_absent")
+          == "ERR no_dependency")
+    }
+
+    // MARK: - The command strings themselves
+
+    @Test("the exact command strings are frozen")
+    func commandStringsFrozen() async {
+      // A typo here surfaces hours later as a confusing UAT failure on a
+      // rebuilt app, so the literals are pinned rather than inferred.
+      let endpoint = makeEndpoint(audioCapture: AudioCaptureManager())
+
+      #expect(await endpoint.handleForTesting(command: "force_default_input_absent") == "OK")
+      #expect(await endpoint.handleForTesting(command: "clear_default_input_absent") == "OK")
+      // Near-misses must NOT route.
+      #expect(await endpoint.handleForTesting(command: "force_default_input") != "OK")
+      #expect(await endpoint.handleForTesting(command: "default_input_absent") != "OK")
+    }
+
+    @Test("an unknown command does not reach the arming seam")
+    func unknownCommandDoesNotArm() async {
+      // The previous version asserted a tautology against live hardware. The
+      // dispatcher's own reply is the real evidence.
+      let endpoint = makeEndpoint(audioCapture: AudioCaptureManager())
+
+      let reply = await endpoint.handleForTesting(command: "force_default_input_absent_typo")
+
+      #expect(reply == "ERR unknown_command")
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/App/InputResolutionTelemetryReportingTests.swift
+++ b/Tests/EnviousWisprTests/App/InputResolutionTelemetryReportingTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprAudio
+@testable import EnviousWisprServices
+
+// #1714 — locks the ONE mapper from the Audio module's cold-attempt projection
+// to `TelemetryService`.
+//
+// The mapper is deliberately dumb: eight fields in, eight fields out, no
+// renaming, defaulting or recomputation. This suite exists because a mapper is
+// exactly where a `?? 0` or a renamed key gets added later without anyone
+// noticing that the resolver's decision and the recorded event have drifted.
+//
+// `testEventHook` is DEBUG-only, so this suite is DEBUG-gated.
+@Suite("InputResolutionTelemetryReporting — #1714")
+@MainActor
+struct InputResolutionTelemetryReportingTests {
+  #if DEBUG
+
+    private final class Box: @unchecked Sendable {
+      var event: CapturedTelemetryEvent?
+    }
+
+    /// Builds the projection the way production does: through a real finalised
+    /// attempt, not by hand. A hand-built projection would let this suite
+    /// disagree with the resolver and still pass.
+    private func projection(
+      _ source: InputResolutionSource?,
+      bindSucceeded: Bool,
+      prepareSucceeded: Bool,
+      counts: (Int, Int)?
+    ) -> InputResolutionAttemptTelemetry {
+      var state = InputResolutionAttemptState()
+      state.recordBind(succeeded: bindSucceeded)
+      if prepareSucceeded { state.recordPrepareSucceeded() }
+      let outcome: InputDeviceResolution.Outcome =
+        source.map { .selected(42, source: $0) } ?? .failed(.noBuiltInMicrophoneFound)
+      return InputResolutionAttemptTelemetry(
+        state.finalized(
+          resolution: InputDeviceResolution(
+            outcome: outcome,
+            defaultPresent: source == .systemDefault,
+            enumerationOutcome: counts == nil ? .notAttempted : .succeeded,
+            inputDeviceCount: counts?.0,
+            eligibleDeviceCount: counts?.1,
+            selectedTransport: source == nil ? nil : "built_in")))
+    }
+
+    private func capture(_ attempt: InputResolutionAttemptTelemetry)
+      -> CapturedTelemetryEvent?
+    {
+      let box = Box()
+      let previous = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = previous }
+      InputResolutionTelemetryReporting.report(attempt)
+      return box.event
+    }
+
+    @Test("every field reaches TelemetryService unchanged")
+    func allFieldsPassThrough() {
+      let event = capture(
+        projection(.listFallback, bindSucceeded: true, prepareSucceeded: true, counts: (4, 1)))
+
+      #expect(event?.name == "audio.input_resolution")
+      #expect(event?.boolProps["default_present"] == false)
+      #expect(event?.stringProps["enumeration_outcome"] == "succeeded")
+      #expect(event?.intProps["input_device_count"] == 4)
+      #expect(event?.intProps["eligible_device_count"] == 1)
+      #expect(event?.stringProps["input_resolution_source"] == "list_fallback")
+      #expect(event?.stringProps["selected_transport"] == "built_in")
+      #expect(event?.stringProps["bind_outcome"] == "succeeded")
+      #expect(event?.stringProps["prepare_outcome"] == "succeeded")
+    }
+
+    @Test("the mapper does not invent counts for a not-attempted enumeration")
+    func doesNotInventCounts() {
+      let event = capture(
+        projection(.systemDefault, bindSucceeded: true, prepareSucceeded: true, counts: nil))
+
+      #expect(event?.intProps.keys.contains("input_device_count") == false)
+      #expect(event?.intProps.keys.contains("eligible_device_count") == false)
+      #expect(event?.stringProps["enumeration_outcome"] == "not_attempted")
+      #expect(event?.boolProps["default_present"] == true)
+    }
+
+    @Test("a failed resolution reports no source and no transport")
+    func failedResolutionReportsNoSource() {
+      let event = capture(
+        projection(nil, bindSucceeded: false, prepareSucceeded: false, counts: (0, 0)))
+
+      #expect(event?.stringProps.keys.contains("input_resolution_source") == false)
+      #expect(event?.stringProps.keys.contains("selected_transport") == false)
+      // An explicit zero is a real answer and must still ride.
+      #expect(event?.intProps["input_device_count"] == 0)
+      #expect(event?.stringProps["bind_outcome"] == "failed")
+      #expect(event?.stringProps["prepare_outcome"] == "failed")
+    }
+
+    @Test("a prepare cannot report success on a device that was never bound")
+    func neverReportsSuccessWithoutBind() {
+      // The structural invariant from Chunk 2, carried all the way to the wire.
+      let event = capture(
+        projection(.systemDefault, bindSucceeded: false, prepareSucceeded: true, counts: nil))
+
+      #expect(event?.stringProps["bind_outcome"] == "failed")
+      #expect(event?.stringProps["prepare_outcome"] == "failed")
+    }
+
+    // MARK: - The installer, and its ONE production call site
+    //
+    // `report(_:)` being correct proves nothing if nobody installs it. These two
+    // cover the wire itself: deleting the installer or its bootstrapper call
+    // previously left every other test in this suite green.
+
+    @Test("observing installs the manager's outbound callback")
+    func observingInstallsOutboundCallback() {
+      let manager = InputResolutionTelemetryReporting.observing(AudioCaptureManager())
+
+      #expect(
+        manager.onFinalizedInputResolutionAttempt.map { _ in true } ?? false,
+        "the reporting helper must install the manager observer")
+    }
+
+    @Test("the production composition root installs observing exactly once")
+    func bootstrapperInstallsObservingExactlyOnce() throws {
+      let source = try String(
+        contentsOf: RepoRoot.sourceURL(
+          "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift"),
+        encoding: .utf8)
+      let needle = "InputResolutionTelemetryReporting.observing("
+      let count = source.components(separatedBy: needle).count - 1
+
+      #expect(count == 1, "expected one production installer, found \(count)")
+    }
+
+  #endif
+}

--- a/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
@@ -113,4 +113,125 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
       interruptionDisclosure: nil)
     #expect(box.reasons.isEmpty)
   }
+
+  // MARK: - #1714: the terminal stamps, driven through the PRODUCTION owners
+  //
+  // Asserting `TelemetryService` directly proves the SERVICE carries the field.
+  // It says nothing about whether the two production call sites actually pass
+  // it. These drive a real kernel to a frozen source, build a real driver, and
+  // go through the factory handler — so deleting either stamp turns them red.
+
+  private final class EventBox: @unchecked Sendable {
+    var event: CapturedTelemetryEvent?
+  }
+
+  /// A factory handler whose driver's kernel has really frozen `source`.
+  private func makeAttributedHandler(source: String?) async -> PipelineStateChangeHandler {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: clock)
+    let capture = FakeAudioCapture()
+    capture.stabilizationResults = [true]
+    capture.inputResolutionSourcePerAttempt = [source]
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: FakeVADSignalSource(), clock: clock,
+      paste: FakePasteTarget())
+
+    await wrapper.apply(.start)
+    await wrapper.drainReadyWork()
+    #expect(wrapper.testKernel.lastInputResolutionSource == source)
+
+    let steps = LimbSteps(
+      wordCorrection: WordCorrectionStep(),
+      fillerRemoval: FillerRemovalStep(),
+      emojiFormatter: EmojiFormatterStep(),
+      inverseTextNormalization: InverseTextNormalizationStep(),
+      llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
+      emojiRestore: EmojiRestoreStep())
+    let observer = KernelHeartPathTelemetryObserver(
+      kernel: wrapper.testKernel, audioCapture: capture,
+      emitter: HeartPathTelemetryEmitter(
+        backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
+      emitLifecycleEvent: { _ in })
+    let driver = KernelDictationDriver(
+      kernel: wrapper.testKernel, observer: observer,
+      outcome: KernelFinalizationOutcome(), context: KernelSessionContext(),
+      steps: steps, adapter: engine,
+      engineMutationScope: .alwaysAllowedForTesting)
+    let box = WarningBox()
+    let deps = PipelineStateChangeHandlerFactory.Deps(
+      showOverlay: { _ in },
+      cancelPendingWarning: {},
+      schedulePostCompletionWarning: { box.reasons.append($0) },
+      appendTranscript: { _ in },
+      onDurableSave: { _ in },
+      inputMode: { "ptt" },
+      driver: driver)
+    return PipelineStateChangeHandlerFactory.make(backendLabel: "parakeet", deps: deps)
+  }
+
+  @Test("factory completion stamps the driver's final input source")
+  func completionStampsFinalInputSource() async {
+    let handler = await makeAttributedHandler(source: "list_fallback")
+    let box = EventBox()
+    let previous = TelemetryService.shared.testEventHook
+    TelemetryService.shared.testEventHook = { @Sendable event in
+      MainActor.assumeIsolated { box.event = event }
+    }
+    defer { TelemetryService.shared.testEventHook = previous }
+
+    handler.handle(
+      to: PipelineState.complete,
+      pipelineOverlayIntent: .hidden,
+      lastPolishError: nil,
+      currentTranscript: Transcript(text: "hello", backendType: .parakeet),
+      historySaved: true,
+      historySaveReason: nil)
+
+    #expect(box.event?.name == "dictation.completed")
+    #expect(box.event?.stringProps["input_resolution_source"] == "list_fallback")
+  }
+
+  @Test("factory failure stamps the driver's final input source")
+  func failureStampsFinalInputSource() async {
+    let handler = await makeAttributedHandler(source: "list_fallback")
+    let box = EventBox()
+    let previous = TelemetryService.shared.testEventHook
+    TelemetryService.shared.testEventHook = { @Sendable event in
+      MainActor.assumeIsolated { box.event = event }
+    }
+    defer { TelemetryService.shared.testEventHook = previous }
+
+    handler.handle(
+      to: PipelineState.error(.deviceRemoved),
+      pipelineOverlayIntent: .error(reason: .deviceRemoved),
+      lastPolishError: nil,
+      currentTranscript: nil,
+      historySaved: true,
+      historySaveReason: nil)
+
+    #expect(box.event?.name == "pipeline.failed")
+    #expect(box.event?.stringProps["input_resolution_source"] == "list_fallback")
+  }
+
+  @Test("factory failure omits an unavailable input source")
+  func failureOmitsUnavailableInputSource() async {
+    let handler = await makeAttributedHandler(source: nil)
+    let box = EventBox()
+    let previous = TelemetryService.shared.testEventHook
+    TelemetryService.shared.testEventHook = { @Sendable event in
+      MainActor.assumeIsolated { box.event = event }
+    }
+    defer { TelemetryService.shared.testEventHook = previous }
+
+    handler.handle(
+      to: PipelineState.error(.deviceRemoved),
+      pipelineOverlayIntent: .error(reason: .deviceRemoved),
+      lastPolishError: nil,
+      currentTranscript: nil,
+      historySaved: true,
+      historySaveReason: nil)
+
+    #expect(box.event?.name == "pipeline.failed")
+    #expect(box.event?.stringProps.keys.contains("input_resolution_source") == false)
+  }
 }

--- a/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
@@ -120,118 +120,125 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
   // It says nothing about whether the two production call sites actually pass
   // it. These drive a real kernel to a frozen source, build a real driver, and
   // go through the factory handler — so deleting either stamp turns them red.
-
-  private final class EventBox: @unchecked Sendable {
-    var event: CapturedTelemetryEvent?
-  }
-
-  /// A factory handler whose driver's kernel has really frozen `source`.
-  private func makeAttributedHandler(source: String?) async -> PipelineStateChangeHandler {
-    let clock = FakeClock()
-    let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: clock)
-    let capture = FakeAudioCapture()
-    capture.stabilizationResults = [true]
-    capture.inputResolutionSourcePerAttempt = [source]
-    let wrapper = KernelRecordingSession(
-      engine: engine, capture: capture, vad: FakeVADSignalSource(), clock: clock,
-      paste: FakePasteTarget())
-
-    await wrapper.apply(.start)
-    await wrapper.drainReadyWork()
-    #expect(wrapper.testKernel.lastInputResolutionSource == source)
-
-    let steps = LimbSteps(
-      wordCorrection: WordCorrectionStep(),
-      fillerRemoval: FillerRemovalStep(),
-      emojiFormatter: EmojiFormatterStep(),
-      inverseTextNormalization: InverseTextNormalizationStep(),
-      llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
-      emojiRestore: EmojiRestoreStep())
-    let observer = KernelHeartPathTelemetryObserver(
-      kernel: wrapper.testKernel, audioCapture: capture,
-      emitter: HeartPathTelemetryEmitter(
-        backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
-      emitLifecycleEvent: { _ in })
-    let driver = KernelDictationDriver(
-      kernel: wrapper.testKernel, observer: observer,
-      outcome: KernelFinalizationOutcome(), context: KernelSessionContext(),
-      steps: steps, adapter: engine,
-      engineMutationScope: .alwaysAllowedForTesting)
-    let box = WarningBox()
-    let deps = PipelineStateChangeHandlerFactory.Deps(
-      showOverlay: { _ in },
-      cancelPendingWarning: {},
-      schedulePostCompletionWarning: { box.reasons.append($0) },
-      appendTranscript: { _ in },
-      onDurableSave: { _ in },
-      inputMode: { "ptt" },
-      driver: driver)
-    return PipelineStateChangeHandlerFactory.make(backendLabel: "parakeet", deps: deps)
-  }
-
-  @Test("factory completion stamps the driver's final input source")
-  func completionStampsFinalInputSource() async {
-    let handler = await makeAttributedHandler(source: "list_fallback")
-    let box = EventBox()
-    let previous = TelemetryService.shared.testEventHook
-    TelemetryService.shared.testEventHook = { @Sendable event in
-      MainActor.assumeIsolated { box.event = event }
+  //
+  // `#if DEBUG` because `testEventHook` and `CapturedTelemetryEvent` are compiled
+  // out of release builds, and CI compiles the test target in Release as well as
+  // running it in Debug — so an unguarded reference passes every local Debug run
+  // and fails `build-release` only. Same gate and same reason as
+  // `OllamaReadinessGateTests` and `HeartPathTelemetryWiringTests`.
+  #if DEBUG
+    private final class EventBox: @unchecked Sendable {
+      var event: CapturedTelemetryEvent?
     }
-    defer { TelemetryService.shared.testEventHook = previous }
 
-    handler.handle(
-      to: PipelineState.complete,
-      pipelineOverlayIntent: .hidden,
-      lastPolishError: nil,
-      currentTranscript: Transcript(text: "hello", backendType: .parakeet),
-      historySaved: true,
-      historySaveReason: nil)
+    /// A factory handler whose driver's kernel has really frozen `source`.
+    private func makeAttributedHandler(source: String?) async -> PipelineStateChangeHandler {
+      let clock = FakeClock()
+      let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: clock)
+      let capture = FakeAudioCapture()
+      capture.stabilizationResults = [true]
+      capture.inputResolutionSourcePerAttempt = [source]
+      let wrapper = KernelRecordingSession(
+        engine: engine, capture: capture, vad: FakeVADSignalSource(), clock: clock,
+        paste: FakePasteTarget())
 
-    #expect(box.event?.name == "dictation.completed")
-    #expect(box.event?.stringProps["input_resolution_source"] == "list_fallback")
-  }
+      await wrapper.apply(.start)
+      await wrapper.drainReadyWork()
+      #expect(wrapper.testKernel.lastInputResolutionSource == source)
 
-  @Test("factory failure stamps the driver's final input source")
-  func failureStampsFinalInputSource() async {
-    let handler = await makeAttributedHandler(source: "list_fallback")
-    let box = EventBox()
-    let previous = TelemetryService.shared.testEventHook
-    TelemetryService.shared.testEventHook = { @Sendable event in
-      MainActor.assumeIsolated { box.event = event }
+      let steps = LimbSteps(
+        wordCorrection: WordCorrectionStep(),
+        fillerRemoval: FillerRemovalStep(),
+        emojiFormatter: EmojiFormatterStep(),
+        inverseTextNormalization: InverseTextNormalizationStep(),
+        llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
+        emojiRestore: EmojiRestoreStep())
+      let observer = KernelHeartPathTelemetryObserver(
+        kernel: wrapper.testKernel, audioCapture: capture,
+        emitter: HeartPathTelemetryEmitter(
+          backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
+        emitLifecycleEvent: { _ in })
+      let driver = KernelDictationDriver(
+        kernel: wrapper.testKernel, observer: observer,
+        outcome: KernelFinalizationOutcome(), context: KernelSessionContext(),
+        steps: steps, adapter: engine,
+        engineMutationScope: .alwaysAllowedForTesting)
+      let box = WarningBox()
+      let deps = PipelineStateChangeHandlerFactory.Deps(
+        showOverlay: { _ in },
+        cancelPendingWarning: {},
+        schedulePostCompletionWarning: { box.reasons.append($0) },
+        appendTranscript: { _ in },
+        onDurableSave: { _ in },
+        inputMode: { "ptt" },
+        driver: driver)
+      return PipelineStateChangeHandlerFactory.make(backendLabel: "parakeet", deps: deps)
     }
-    defer { TelemetryService.shared.testEventHook = previous }
 
-    handler.handle(
-      to: PipelineState.error(.deviceRemoved),
-      pipelineOverlayIntent: .error(reason: .deviceRemoved),
-      lastPolishError: nil,
-      currentTranscript: nil,
-      historySaved: true,
-      historySaveReason: nil)
+    @Test("factory completion stamps the driver's final input source")
+    func completionStampsFinalInputSource() async {
+      let handler = await makeAttributedHandler(source: "list_fallback")
+      let box = EventBox()
+      let previous = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = previous }
 
-    #expect(box.event?.name == "pipeline.failed")
-    #expect(box.event?.stringProps["input_resolution_source"] == "list_fallback")
-  }
+      handler.handle(
+        to: PipelineState.complete,
+        pipelineOverlayIntent: .hidden,
+        lastPolishError: nil,
+        currentTranscript: Transcript(text: "hello", backendType: .parakeet),
+        historySaved: true,
+        historySaveReason: nil)
 
-  @Test("factory failure omits an unavailable input source")
-  func failureOmitsUnavailableInputSource() async {
-    let handler = await makeAttributedHandler(source: nil)
-    let box = EventBox()
-    let previous = TelemetryService.shared.testEventHook
-    TelemetryService.shared.testEventHook = { @Sendable event in
-      MainActor.assumeIsolated { box.event = event }
+      #expect(box.event?.name == "dictation.completed")
+      #expect(box.event?.stringProps["input_resolution_source"] == "list_fallback")
     }
-    defer { TelemetryService.shared.testEventHook = previous }
 
-    handler.handle(
-      to: PipelineState.error(.deviceRemoved),
-      pipelineOverlayIntent: .error(reason: .deviceRemoved),
-      lastPolishError: nil,
-      currentTranscript: nil,
-      historySaved: true,
-      historySaveReason: nil)
+    @Test("factory failure stamps the driver's final input source")
+    func failureStampsFinalInputSource() async {
+      let handler = await makeAttributedHandler(source: "list_fallback")
+      let box = EventBox()
+      let previous = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = previous }
 
-    #expect(box.event?.name == "pipeline.failed")
-    #expect(box.event?.stringProps.keys.contains("input_resolution_source") == false)
-  }
+      handler.handle(
+        to: PipelineState.error(.deviceRemoved),
+        pipelineOverlayIntent: .error(reason: .deviceRemoved),
+        lastPolishError: nil,
+        currentTranscript: nil,
+        historySaved: true,
+        historySaveReason: nil)
+
+      #expect(box.event?.name == "pipeline.failed")
+      #expect(box.event?.stringProps["input_resolution_source"] == "list_fallback")
+    }
+
+    @Test("factory failure omits an unavailable input source")
+    func failureOmitsUnavailableInputSource() async {
+      let handler = await makeAttributedHandler(source: nil)
+      let box = EventBox()
+      let previous = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = previous }
+
+      handler.handle(
+        to: PipelineState.error(.deviceRemoved),
+        pipelineOverlayIntent: .error(reason: .deviceRemoved),
+        lastPolishError: nil,
+        currentTranscript: nil,
+        historySaved: true,
+        historySaveReason: nil)
+
+      #expect(box.event?.name == "pipeline.failed")
+      #expect(box.event?.stringProps.keys.contains("input_resolution_source") == false)
+    }
+  #endif  // DEBUG (#1714 terminal-stamp tests — TelemetryService.testEventHook)
 }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -424,14 +424,28 @@ import Testing
   /// composition-root residue as the entries above; no domain logic moved
   /// here. Cap by deterministic rule (actual 1326 + ~2, rounded up to
   /// nearest 5 = 1330).
+  /// #1714 (input-device resolution telemetry): 1330 → 1335 for ONE line —
+  /// wrapping the capture manager in `InputResolutionTelemetryReporting
+  /// .observing(_:)` so the resolver's per-attempt outcome reaches
+  /// `TelemetryService`. The wiring cannot live anywhere else: `EnviousWisprAudio`
+  /// must not import `EnviousWisprServices` (that boundary is the reason the
+  /// resolver reports through a closure at all), and only the composition root
+  /// holds the concrete `AudioCaptureManager`. The installer was already
+  /// extracted to its own type earlier in #1714 precisely to keep this to two
+  /// lines instead of three; the inline form measured 1331 then and the
+  /// extraction bought a line back. This entry spends that line again because
+  /// main reached 1329 on its own before this branch merged, so the two changes
+  /// together, not either alone, exhaust the budget. No domain logic moved here —
+  /// same class of irreducible composition-root residue as every entry above.
+  /// Cap by deterministic rule (actual 1331 + ~2, rounded up to nearest 5 = 1335).
   @Test func envWisprAppLineCountCeilingHolds() throws {
     let url = envWisprAppURL()
     let source = try String(contentsOf: url, encoding: .utf8)
     let lineCount = source.split(separator: "\n", omittingEmptySubsequences: false).count
     #expect(
-      lineCount <= 1330,
+      lineCount <= 1335,
       """
-      WisprBootstrapper line count exceeded: \(lineCount) > 1330. \
+      WisprBootstrapper line count exceeded: \(lineCount) > 1335. \
       Raising the ceiling requires a Bible changelog entry.
       """)
   }

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerDeadAirLatchTests.swift
@@ -397,7 +397,7 @@ struct AudioCaptureManagerDeadAirLatchTests {
       -> AudioCaptureManager
     {
       let manager = AudioCaptureManager()
-      manager.installSourceFactoryForTesting { stub }
+      manager.installSourceFactoryForTesting { _ in stub }
       return manager
     }
 

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
@@ -55,7 +55,13 @@ import Testing
       /// the manager adopts what `prepare()` RETURNED rather than anything it
       /// could have derived from settings.
       var boundToReturn = BoundInputDevice(
-        deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub")
+        deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub",
+        resolutionSource: "system_default")
+      /// #1714: the undefaulted protocol witness. This suite is about retire
+      /// behaviour and never fires it; declaring it explicitly is exactly what
+      /// the undefaulted requirement is for.
+      var onInputResolutionAttemptFinalized: ((FinalizedInputResolutionAttempt) -> Void)?
+
       /// When set, `prepare()` throws it instead of returning a bind.
       var prepareError: Error?
       private(set) var prepareCallCount = 0

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerSpoolPredecessorTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerSpoolPredecessorTests.swift
@@ -212,7 +212,7 @@ import Testing
       defer { try? FileManager.default.removeItem(at: dir) }
       let manager = AudioCaptureManager()
       let stub = StopFenceStub()
-      manager.installSourceFactoryForTesting { stub }
+      manager.installSourceFactoryForTesting { _ in stub }
       try await manager.startEnginePhase()
 
       manager.armRecoverySpoolingForTesting(
@@ -258,8 +258,12 @@ import Testing
         (nil, nil)
       }
     #endif
+    /// #1714: the undefaulted protocol witness. This suite never fires it;
+    /// declaring it explicitly is exactly what the undefaulted requirement is for.
+    var onInputResolutionAttemptFinalized: ((FinalizedInputResolutionAttempt) -> Void)?
     var boundToReturn = BoundInputDevice(
-      deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub")
+      deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub",
+      resolutionSource: "system_default")
     func prepare() async throws -> BoundInputDevice { boundToReturn }
     func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
       AsyncStream { $0.finish() }

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerStopFenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerStopFenceTests.swift
@@ -53,8 +53,12 @@ import Testing
         }
       #endif
 
+      /// #1714: the undefaulted protocol witness. This suite never fires it;
+      /// declaring it explicitly is exactly what the undefaulted requirement is for.
+      var onInputResolutionAttemptFinalized: ((FinalizedInputResolutionAttempt) -> Void)?
       var boundToReturn = BoundInputDevice(
-        deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub")
+        deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub",
+        resolutionSource: "system_default")
       private(set) var prepareCallCount = 0
 
       func prepare() async throws -> BoundInputDevice {
@@ -143,7 +147,7 @@ import Testing
     func preparedButUnarmedEngineIsStoppable() async throws {
       let manager = AudioCaptureManager()
       let stub = StubSource()
-      manager.installSourceFactoryForTesting { stub }
+      manager.installSourceFactoryForTesting { _ in stub }
       // `.off` BEFORE preparation: setting it afterwards would trip
       // `reconcileWarmEnginePolicy()` and tear the engine down before the stop,
       // leaving this test asserting against a state it never reached.

--- a/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
@@ -123,7 +123,7 @@ struct HALDeviceInputSourceDeviceTargetTests {
     let source = HALDeviceInputSource()
     source.inputDeviceResolver = InputDeviceResolver(
       defaultInputDeviceID: { 42 },
-      inputDeviceSnapshot: { Issue.record("Auto must not enumerate"); return .success([]) }
+      inputDeviceSnapshot: { Issue.record("Auto must not enumerate"); return .complete([]) }
     )
     source.setBoundInputDeviceForTesting(committedBind(42))
 
@@ -136,7 +136,7 @@ struct HALDeviceInputSourceDeviceTargetTests {
     nonisolated(unsafe) var currentDefault: AudioDeviceID = 42
     source.inputDeviceResolver = InputDeviceResolver(
       defaultInputDeviceID: { currentDefault },
-      inputDeviceSnapshot: { Issue.record("Auto must not enumerate"); return .success([]) }
+      inputDeviceSnapshot: { Issue.record("Auto must not enumerate"); return .complete([]) }
     )
     source.setBoundInputDeviceForTesting(committedBind(42))
 
@@ -153,7 +153,7 @@ struct HALDeviceInputSourceDeviceTargetTests {
     // absent one must refuse rather than pass a partial value to the resolver.
     let source = HALDeviceInputSource()
     source.inputDeviceResolver = InputDeviceResolver(
-      defaultInputDeviceID: { 42 }, inputDeviceSnapshot: { .success([]) })
+      defaultInputDeviceID: { 42 }, inputDeviceSnapshot: { .complete([]) })
 
     #expect(!source.boundDeviceMatchesResolvedTargetForReuse())
   }
@@ -237,7 +237,7 @@ struct HALDeviceInputSourceDeviceTargetTests {
       defaultInputDeviceID: { currentDefault },
       // The pinned device is genuinely absent from the list.
       inputDeviceSnapshot: {
-        .success([
+        .complete([
           InputDeviceCandidate(
             id: 42, uid: "something-else", rawTransport: kAudioDeviceTransportTypeBuiltIn)
         ])
@@ -262,7 +262,7 @@ struct HALDeviceInputSourceDeviceTargetTests {
     source.inputDeviceResolver = InputDeviceResolver(
       defaultInputDeviceID: { nil },
       inputDeviceSnapshot: {
-        .success([
+        .complete([
           InputDeviceCandidate(
             id: 77, uid: "airpods", rawTransport: kAudioDeviceTransportTypeBluetooth)
         ])
@@ -297,7 +297,7 @@ struct HALInputResolutionFinalizationTests {
     let source = HALDeviceInputSource()
     // Successful but empty enumeration: the resolver's proven-absence path.
     source.inputDeviceResolver = InputDeviceResolver(
-      defaultInputDeviceID: { nil }, inputDeviceSnapshot: { .success([]) })
+      defaultInputDeviceID: { nil }, inputDeviceSnapshot: { .complete([]) })
 
     nonisolated(unsafe) var finalised: [FinalizedInputResolutionAttempt] = []
     source.onInputResolutionAttemptFinalized = { finalised.append($0) }
@@ -353,7 +353,7 @@ struct HALInputResolutionFinalizationTests {
   func nilCallbackIsHarmless() async {
     let source = HALDeviceInputSource()
     source.inputDeviceResolver = InputDeviceResolver(
-      defaultInputDeviceID: { nil }, inputDeviceSnapshot: { .success([]) })
+      defaultInputDeviceID: { nil }, inputDeviceSnapshot: { .complete([]) })
     source.onInputResolutionAttemptFinalized = nil
 
     await #expect(throws: AudioError.self) { try await source.prepare() }

--- a/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
@@ -97,36 +97,35 @@ struct HALDeviceInputSourceDeviceTargetTests {
     #expect(source.targetDeviceUID == "BC-87-FA-9C-7E-71:input")
   }
 
-  @Test("nil target resolves to current system default input")
-  func nilTargetResolvesToDefaultInput() {
-    let source = HALDeviceInputSource()
-    source.defaultInputDeviceIDProvider = { 42 }
-    #expect(source.resolvedDeviceIDForTesting() == 42)
-  }
+  // MARK: - #1714: warm compatibility, delegated to InputDeviceResolver
+  //
+  // The three PURE resolution behaviours that used to live here — nil target
+  // resolves to the default, a missing pinned target falls back to the default,
+  // a present pinned target wins — moved to `InputDeviceResolverTests` when
+  // `resolvedDeviceIDForTesting()` was deleted. They are behaviours of the
+  // resolver now, not of this file. The three WARM behaviours stay here, because
+  // they are about what THIS source does with its committed bind, and are
+  // rewritten against the injected resolver plus a complete four-field bind.
 
-  @Test("unresolvable target falls back to current system default input")
-  func missingTargetFallsBackToDefaultInput() {
-    let source = HALDeviceInputSource()
-    source.targetDeviceUID = "gone"
-    source.resolveDeviceIDForUID = { _ in nil }
-    source.defaultInputDeviceIDProvider = { 42 }
-    #expect(source.resolvedDeviceIDForTesting() == 42)
-  }
-
-  @Test("resolvable target wins over system default input")
-  func resolvedTargetWins() {
-    let source = HALDeviceInputSource()
-    source.targetDeviceUID = "present"
-    source.resolveDeviceIDForUID = { uid in uid == "present" ? 99 : nil }
-    source.defaultInputDeviceIDProvider = { 42 }
-    #expect(source.resolvedDeviceIDForTesting() == 99)
+  /// A committed bind, stated in full. A partial setter used to sit beside the
+  /// complete one and moved only the numeric id; #1714 deleted it, because a
+  /// partial value can no longer express a four-field #1844 bind.
+  private func committedBind(
+    _ deviceID: AudioDeviceID, source: String = "system_default"
+  ) -> BoundInputDevice {
+    BoundInputDevice(
+      deviceID: deviceID, deviceUID: "uid-\(deviceID)", transportLabel: "built_in",
+      resolutionSource: source)
   }
 
   @Test("warm automatic source is reusable while bound to current system default")
   func automaticReuseMatchesCurrentDefault() {
     let source = HALDeviceInputSource()
-    source.defaultInputDeviceIDProvider = { 42 }
-    source.setBoundDeviceIDForTesting(42)
+    source.inputDeviceResolver = InputDeviceResolver(
+      defaultInputDeviceID: { 42 },
+      inputDeviceSnapshot: { Issue.record("Auto must not enumerate"); return .success([]) }
+    )
+    source.setBoundInputDeviceForTesting(committedBind(42))
 
     #expect(source.boundDeviceMatchesResolvedTargetForReuse())
   }
@@ -134,11 +133,27 @@ struct HALDeviceInputSourceDeviceTargetTests {
   @Test("warm automatic source rejects stale system default")
   func automaticReuseRejectsStaleDefault() {
     let source = HALDeviceInputSource()
-    var currentDefault: AudioDeviceID = 42
-    source.defaultInputDeviceIDProvider = { currentDefault }
-    source.setBoundDeviceIDForTesting(42)
+    nonisolated(unsafe) var currentDefault: AudioDeviceID = 42
+    source.inputDeviceResolver = InputDeviceResolver(
+      defaultInputDeviceID: { currentDefault },
+      inputDeviceSnapshot: { Issue.record("Auto must not enumerate"); return .success([]) }
+    )
+    source.setBoundInputDeviceForTesting(committedBind(42))
+
+    #expect(source.boundDeviceMatchesResolvedTargetForReuse())
 
     currentDefault = 43
+
+    #expect(!source.boundDeviceMatchesResolvedTargetForReuse())
+  }
+
+  @Test("a source with no committed bind is never warm-compatible")
+  func noBindIsNeverCompatible() {
+    // Guards the delegation: the predicate now reads the whole bind, so an
+    // absent one must refuse rather than pass a partial value to the resolver.
+    let source = HALDeviceInputSource()
+    source.inputDeviceResolver = InputDeviceResolver(
+      defaultInputDeviceID: { 42 }, inputDeviceSnapshot: { .success([]) })
 
     #expect(!source.boundDeviceMatchesResolvedTargetForReuse())
   }
@@ -163,7 +178,8 @@ struct HALDeviceInputSourceDeviceTargetTests {
     let committed = BoundInputDevice(
       deviceID: 121,
       deviceUID: "BC-87-FA-9C-7E-71:input",
-      transportLabel: "bluetooth"
+      transportLabel: "bluetooth",
+      resolutionSource: "system_default"
     )
     source.setBoundInputDeviceForTesting(committed)
 
@@ -181,7 +197,8 @@ struct HALDeviceInputSourceDeviceTargetTests {
     // A complete, stale bind is still NOT grounds for reuse without a live unit.
     source.setBoundInputDeviceForTesting(
       BoundInputDevice(
-        deviceID: 121, deviceUID: "BC-87-FA-9C-7E-71:input", transportLabel: "bluetooth"))
+        deviceID: 121, deviceUID: "BC-87-FA-9C-7E-71:input", transportLabel: "bluetooth",
+        resolutionSource: "system_default"))
 
     #expect(source.warmReuseBindForTesting(hasLiveUnit: false) == nil)
   }
@@ -199,12 +216,13 @@ struct HALDeviceInputSourceDeviceTargetTests {
     let committed = BoundInputDevice(
       deviceID: 121,
       deviceUID: "BC-87-FA-9C-7E-71:input",
-      transportLabel: "bluetooth"
+      transportLabel: "bluetooth",
+      resolutionSource: "system_default"
     )
     source.setBoundInputDeviceForTesting(committed)
     #expect(source.warmReuseBindForTesting(hasLiveUnit: true) == committed)
 
-    // All three fields at once, the way `teardownUnit()` clears them.
+    // All four fields at once, the way `teardownUnit()` clears them.
     source.setBoundInputDeviceForTesting(nil)
 
     #expect(source.warmReuseBindForTesting(hasLiveUnit: true) == nil)
@@ -214,15 +232,213 @@ struct HALDeviceInputSourceDeviceTargetTests {
   func explicitMissingTargetReuseTracksFallbackDefault() {
     let source = HALDeviceInputSource()
     source.targetDeviceUID = "missing"
-    source.resolveDeviceIDForUID = { _ in nil }
-    var currentDefault: AudioDeviceID = 42
-    source.defaultInputDeviceIDProvider = { currentDefault }
-    source.setBoundDeviceIDForTesting(42)
+    nonisolated(unsafe) var currentDefault: AudioDeviceID = 42
+    source.inputDeviceResolver = InputDeviceResolver(
+      defaultInputDeviceID: { currentDefault },
+      // The pinned device is genuinely absent from the list.
+      inputDeviceSnapshot: {
+        .success([
+          InputDeviceCandidate(
+            id: 42, uid: "something-else", rawTransport: kAudioDeviceTransportTypeBuiltIn)
+        ])
+      }
+    )
+    source.setBoundInputDeviceForTesting(committedBind(42))
 
     #expect(source.boundDeviceMatchesResolvedTargetForReuse())
 
     currentDefault = 43
 
     #expect(!source.boundDeviceMatchesResolvedTargetForReuse())
+  }
+
+  @Test("a reconnected pinned device rejects the warm fallback bind (founder decision)")
+  func reconnectedPinnedDeviceRejectsFallbackBind() {
+    // The founder's rule running forwards: AirPods come back, so the take they
+    // lost is theirs again. Refusing compatibility here is what makes the
+    // manager tear the warm source down so the next open is cold and pinned.
+    let source = HALDeviceInputSource()
+    source.targetDeviceUID = "airpods"
+    source.inputDeviceResolver = InputDeviceResolver(
+      defaultInputDeviceID: { nil },
+      inputDeviceSnapshot: {
+        .success([
+          InputDeviceCandidate(
+            id: 77, uid: "airpods", rawTransport: kAudioDeviceTransportTypeBluetooth)
+        ])
+      }
+    )
+    // Bound to the built-in mic the fallback picked while they were gone.
+    source.setBoundInputDeviceForTesting(committedBind(30, source: "list_fallback"))
+
+    #expect(!source.boundDeviceMatchesResolvedTargetForReuse())
+  }
+}
+
+// #1714 — freezes the cold-attempt finalisation contract.
+//
+// Every cold `prepare()` exit must produce exactly one finalised attempt, and
+// warm reuse must produce none. Two fields, not one, because binding is a single
+// step and several fallible setup steps follow it: collapsing them would make
+// "could not open the microphone" indistinguishable from "opened it, then the
+// converter failed", which are different bugs with different owners.
+//
+// Scope stated honestly: the resolution-failure exit is driven through the REAL
+// `prepare()` with an injected failing resolver. The three post-resolution rows
+// need a live `AudioUnit` no seam can construct, so they are frozen as the
+// outcome matrix here and confirmed by structural audit plus Live UAT rather
+// than by fabricating hardware.
+@MainActor
+@Suite("HAL cold-attempt finalisation — #1714")
+struct HALInputResolutionFinalizationTests {
+
+  @Test("a cold attempt that fails at resolution finalises exactly once, before the throw")
+  func resolutionFailureFinalisesOnceBeforeThrow() async {
+    let source = HALDeviceInputSource()
+    // Successful but empty enumeration: the resolver's proven-absence path.
+    source.inputDeviceResolver = InputDeviceResolver(
+      defaultInputDeviceID: { nil }, inputDeviceSnapshot: { .success([]) })
+
+    nonisolated(unsafe) var finalised: [FinalizedInputResolutionAttempt] = []
+    source.onInputResolutionAttemptFinalized = { finalised.append($0) }
+
+    await #expect(throws: AudioError.self) { try await source.prepare() }
+
+    #expect(finalised.count == 1, "exactly one finalised attempt per cold exit")
+    #expect(finalised.first?.bindOutcome == .notAttempted)
+    #expect(finalised.first?.prepareOutcome == .failed)
+    // The frozen facts travel with it, so no consumer re-reads hardware.
+    #expect(finalised.first?.resolution.enumerationOutcome == .succeeded)
+    #expect(finalised.first?.resolution.inputDeviceCount == 0)
+    #expect(finalised.first?.resolution.defaultPresent == false)
+  }
+
+  @Test("a device-list read failure with no default also finalises exactly once")
+  func readFailureFinalisesOnce() async {
+    let source = HALDeviceInputSource()
+    source.inputDeviceResolver = InputDeviceResolver(
+      defaultInputDeviceID: { nil }, inputDeviceSnapshot: { .readFailed })
+
+    nonisolated(unsafe) var finalised: [FinalizedInputResolutionAttempt] = []
+    source.onInputResolutionAttemptFinalized = { finalised.append($0) }
+
+    await #expect(throws: AudioError.self) { try await source.prepare() }
+
+    #expect(finalised.count == 1)
+    #expect(finalised.first?.bindOutcome == .notAttempted)
+    #expect(finalised.first?.prepareOutcome == .failed)
+    #expect(finalised.first?.resolution.enumerationOutcome == .readFailed)
+  }
+
+  @Test("warm reuse finalises nothing — a reused bind is not a new resolution")
+  func warmReuseFinalisesNothing() {
+    let source = HALDeviceInputSource()
+    source.setBoundInputDeviceForTesting(
+      BoundInputDevice(
+        deviceID: 121, deviceUID: "uid-121", transportLabel: "bluetooth",
+        resolutionSource: "list_fallback"))
+
+    nonisolated(unsafe) var finalised: [FinalizedInputResolutionAttempt] = []
+    source.onInputResolutionAttemptFinalized = { finalised.append($0) }
+
+    // The warm early return, driven through the same seam #1844 froze.
+    let reused = source.warmReuseBindForTesting(hasLiveUnit: true)
+
+    #expect(reused != nil)
+    #expect(reused?.resolutionSource == "list_fallback", "warm reuse carries the ORIGINAL source")
+    #expect(finalised.isEmpty)
+  }
+
+  @Test("a nil callback changes nothing — observability is a limb")
+  func nilCallbackIsHarmless() async {
+    let source = HALDeviceInputSource()
+    source.inputDeviceResolver = InputDeviceResolver(
+      defaultInputDeviceID: { nil }, inputDeviceSnapshot: { .success([]) })
+    source.onInputResolutionAttemptFinalized = nil
+
+    await #expect(throws: AudioError.self) { try await source.prepare() }
+  }
+
+  // MARK: - The outcome matrix, driven through the PRODUCTION accumulator
+  //
+  // These instantiate `InputResolutionAttemptState` — the same type `prepare()`
+  // mutates — so deleting or inverting a transition turns them red. An earlier
+  // version asserted a table this suite wrote itself, which proved only that the
+  // copy agreed with the copy and stayed green when the success transition was
+  // removed.
+
+  private func selectedResolution() -> InputDeviceResolution {
+    InputDeviceResolution(
+      outcome: .selected(42, source: .systemDefault),
+      defaultPresent: true,
+      enumerationOutcome: .notAttempted,
+      inputDeviceCount: nil,
+      eligibleDeviceCount: nil,
+      selectedTransport: nil
+    )
+  }
+
+  @Test("an exit before binding is not_attempted / failed")
+  func preBindOutcome() {
+    let state = InputResolutionAttemptState()
+    let result = state.finalized(resolution: selectedResolution())
+
+    #expect(result.bindOutcome == .notAttempted)
+    #expect(result.prepareOutcome == .failed)
+  }
+
+  @Test("a failed bind is failed / failed")
+  func bindFailureOutcome() {
+    var state = InputResolutionAttemptState()
+    state.recordBind(succeeded: false)
+    let result = state.finalized(resolution: selectedResolution())
+
+    #expect(result.bindOutcome == .failed)
+    #expect(result.prepareOutcome == .failed)
+  }
+
+  @Test("a successful bind followed by setup failure is succeeded / failed")
+  func postBindFailureOutcome() {
+    var state = InputResolutionAttemptState()
+    state.recordBind(succeeded: true)
+    let result = state.finalized(resolution: selectedResolution())
+
+    #expect(result.bindOutcome == .succeeded)
+    #expect(result.prepareOutcome == .failed)
+  }
+
+  @Test("full preparation success is succeeded / succeeded")
+  func prepareSuccessOutcome() {
+    var state = InputResolutionAttemptState()
+    state.recordBind(succeeded: true)
+    state.recordPrepareSucceeded()
+    let result = state.finalized(resolution: selectedResolution())
+
+    #expect(result.bindOutcome == .succeeded)
+    #expect(result.prepareOutcome == .succeeded)
+  }
+
+  @Test("a prepare can never report success on a device that was never bound")
+  func successWithoutBindIsUnrepresentable() {
+    // The invariant is structural, not a test-only assertion: `prepareOutcome`
+    // is derived from the bind, so this combination cannot be constructed even
+    // by calling the transitions out of order.
+    var neverBound = InputResolutionAttemptState()
+    neverBound.recordPrepareSucceeded()
+    #expect(neverBound.finalized(resolution: selectedResolution()).prepareOutcome == .failed)
+
+    var bindFailed = InputResolutionAttemptState()
+    bindFailed.recordBind(succeeded: false)
+    bindFailed.recordPrepareSucceeded()
+    #expect(bindFailed.finalized(resolution: selectedResolution()).prepareOutcome == .failed)
+  }
+
+  @Test("the wire values telemetry will carry are frozen")
+  func wireValuesAreFrozen() {
+    #expect(InputBindOutcome.notAttempted.rawValue == "not_attempted")
+    #expect(InputBindOutcome.failed.rawValue == "failed")
+    #expect(InputBindOutcome.succeeded.rawValue == "succeeded")
+    #expect(InputPrepareOutcome.failed.rawValue == "failed")
+    #expect(InputPrepareOutcome.succeeded.rawValue == "succeeded")
   }
 }

--- a/Tests/EnviousWisprTests/Audio/BoundDeviceAdoptionTests.swift
+++ b/Tests/EnviousWisprTests/Audio/BoundDeviceAdoptionTests.swift
@@ -55,13 +55,26 @@ import Testing
       /// The bind this stub publishes from `prepare()`. Mutate between attempts to
       /// model a retry that lands on a different device.
       var boundToReturn = BoundInputDevice(
-        deviceID: 99, deviceUID: "stub-uid-99", transportLabel: "usb")
+        deviceID: 99, deviceUID: "stub-uid-99", transportLabel: "usb",
+        resolutionSource: "system_default")
       /// When set, `prepare()` throws this instead of returning a bind.
       var prepareError: Error?
       private(set) var prepareCallCount = 0
 
+      /// #1714: the undefaulted protocol witness. Explicit rather than inherited
+      /// so a conformer cannot silently report no attribution.
+      var onInputResolutionAttemptFinalized: ((FinalizedInputResolutionAttempt) -> Void)?
+
+      /// When set, `prepare()` fires this SYNCHRONOUSLY before returning or
+      /// throwing, modelling a real cold attempt. Nil models warm reuse, which
+      /// finalises nothing.
+      var finalizedAttemptToFire: FinalizedInputResolutionAttempt?
+
       func prepare() async throws -> BoundInputDevice {
         prepareCallCount += 1
+        if let finalizedAttemptToFire {
+          onInputResolutionAttemptFinalized?(finalizedAttemptToFire)
+        }
         if let prepareError { throw prepareError }
         return boundToReturn
       }
@@ -90,7 +103,7 @@ import Testing
       let manager = AudioCaptureManager()
       manager.preferredInputDeviceIDOverride = preferredOverride
       manager.selectedInputDeviceUID = rememberedSelection
-      manager.installSourceFactoryForTesting { stub }
+      manager.installSourceFactoryForTesting { _ in stub }
       return manager
     }
 
@@ -100,7 +113,8 @@ import Testing
     func adoptsTheReturnedBind() async throws {
       let stub = StubSource()
       stub.boundToReturn = BoundInputDevice(
-        deviceID: 99, deviceUID: "stub-uid-99", transportLabel: "usb")
+        deviceID: 99, deviceUID: "stub-uid-99", transportLabel: "usb",
+        resolutionSource: "system_default")
       let manager = Self.makeManager(stub)
 
       try await manager.startEnginePhase()
@@ -117,7 +131,8 @@ import Testing
     func adoptionIgnoresRememberedSelection() async throws {
       let stub = StubSource()
       stub.boundToReturn = BoundInputDevice(
-        deviceID: 7, deviceUID: "actually-bound-uid", transportLabel: "built_in")
+        deviceID: 7, deviceUID: "actually-bound-uid", transportLabel: "built_in",
+        resolutionSource: "system_default")
       let manager = Self.makeManager(
         stub, rememberedSelection: "remembered-but-never-opened-uid")
 
@@ -152,7 +167,8 @@ import Testing
     func finalAttemptWins() async throws {
       let stub = StubSource()
       stub.boundToReturn = BoundInputDevice(
-        deviceID: 99, deviceUID: "first-attempt-uid", transportLabel: "usb")
+        deviceID: 99, deviceUID: "first-attempt-uid", transportLabel: "usb",
+        resolutionSource: "system_default")
       let manager = Self.makeManager(stub)
 
       try await manager.startEnginePhase()
@@ -161,7 +177,8 @@ import Testing
       // The real manager rebuild path, then a second real attempt binding elsewhere.
       manager.rebuildEngine()
       stub.boundToReturn = BoundInputDevice(
-        deviceID: 42, deviceUID: "final-attempt-uid", transportLabel: "built_in")
+        deviceID: 42, deviceUID: "final-attempt-uid", transportLabel: "built_in",
+        resolutionSource: "system_default")
       try await manager.startEnginePhase()
 
       #expect(manager.zeroSignalDiscriminatorDevice == stub.boundToReturn)
@@ -182,6 +199,217 @@ import Testing
       #expect(
         manager.zeroSignalDiscriminatorDevice == nil,
         "pre-warm runs outside any session and must not publish a health-check device")
+    }
+
+    // MARK: - 6. #1714 attribution lifetime
+    //
+    // The manager is the LIFETIME owner because a THROWING cold attempt returns
+    // no bind at all — without retention, a resolution or bind failure could
+    // never be attributed, and the previous session's answer would still be
+    // sitting there looking current.
+
+    /// A finalised cold attempt that SELECTED a device but failed later, so its
+    /// source is non-nil and distinguishable from any earlier one.
+    private static func finalizedAttempt(
+      _ source: InputResolutionSource, bind: InputBindOutcome = .succeeded
+    ) -> FinalizedInputResolutionAttempt {
+      var state = InputResolutionAttemptState()
+      state.recordBind(succeeded: bind == .succeeded)
+      return state.finalized(
+        resolution: InputDeviceResolution(
+          outcome: .selected(42, source: source),
+          defaultPresent: source == .systemDefault,
+          enumerationOutcome: source == .systemDefault ? .notAttempted : .succeeded,
+          inputDeviceCount: nil,
+          eligibleDeviceCount: nil,
+          selectedTransport: nil))
+    }
+
+    @Test("a successful prepare with NO cold callback still exposes the returned bind's source")
+    func warmSuccessExposesReturnedBindSource() async throws {
+      // Warm reuse fires no finalisation but returns a bind carrying the
+      // ORIGINAL source, so the returned bind is the only authority here.
+      let stub = StubSource()
+      stub.finalizedAttemptToFire = nil
+      stub.boundToReturn = BoundInputDevice(
+        deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
+        resolutionSource: "list_fallback")
+      let manager = Self.makeManager(stub)
+
+      try await manager.startEnginePhase()
+
+      #expect(manager.currentInputResolutionSource == "list_fallback")
+    }
+
+    @Test("on success the RETURNED BIND wins over the cold callback's provisional value")
+    func returnedBindWinsOverCallback() async throws {
+      // Deliberately disagreeing values. #1844's rule is that the bind
+      // `prepare()` returned is the authority; the callback is provisional
+      // because it fires before the attempt is known to have succeeded.
+      let stub = StubSource()
+      stub.finalizedAttemptToFire = Self.finalizedAttempt(.systemDefault)
+      stub.boundToReturn = BoundInputDevice(
+        deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
+        resolutionSource: "list_fallback")
+      let manager = Self.makeManager(stub)
+
+      try await manager.startEnginePhase()
+
+      #expect(manager.currentInputResolutionSource == "list_fallback")
+    }
+
+    @Test("a throwing cold attempt exposes THIS attempt's source, never the previous one")
+    func throwingAttemptReplacesPriorSource() async throws {
+      let stub = StubSource()
+      // First attempt succeeds on the system default.
+      stub.boundToReturn = BoundInputDevice(
+        deviceID: 42, deviceUID: "default-uid", transportLabel: "built_in",
+        resolutionSource: "system_default")
+      let manager = Self.makeManager(stub)
+      try await manager.startEnginePhase()
+      #expect(manager.currentInputResolutionSource == "system_default")
+
+      // Second attempt resolves to the FALLBACK, then throws after the bind.
+      // Two distinct non-nil sources, so replacement is proven by the value
+      // changing rather than by comparing nil with nil.
+      stub.finalizedAttemptToFire = Self.finalizedAttempt(.listFallback)
+      stub.prepareError = AudioError.formatCreationFailed(source: "test.after_bind")
+
+      await #expect(throws: AudioError.self) { try await manager.startEnginePhase() }
+
+      #expect(manager.currentInputResolutionSource == "list_fallback")
+    }
+
+    @Test("a throwing attempt that finalises NOTHING clears the prior source")
+    func throwingAttemptWithoutFinalisationClearsSource() async throws {
+      // Proves the clear happens BEFORE prepare, so stale attribution cannot
+      // survive an attempt that never got far enough to report anything.
+      let stub = StubSource()
+      stub.boundToReturn = BoundInputDevice(
+        deviceID: 42, deviceUID: "default-uid", transportLabel: "built_in",
+        resolutionSource: "system_default")
+      let manager = Self.makeManager(stub)
+      try await manager.startEnginePhase()
+      #expect(manager.currentInputResolutionSource == "system_default")
+
+      stub.finalizedAttemptToFire = nil
+      stub.prepareError = AudioError.noBuiltInMicrophoneFound
+
+      await #expect(throws: AudioError.self) { try await manager.startEnginePhase() }
+
+      #expect(manager.currentInputResolutionSource == nil)
+    }
+
+    @Test("successful preWarm attributes without publishing a health-check device")
+    func preWarmAttributesWithoutAdopting() async throws {
+      // Pre-warm is where cold resolution normally happens, so attributing only
+      // on the recording's own prepare would report almost nothing.
+      let stub = StubSource()
+      stub.finalizedAttemptToFire = Self.finalizedAttempt(.listFallback)
+      stub.boundToReturn = BoundInputDevice(
+        deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
+        resolutionSource: "list_fallback")
+      let manager = Self.makeManager(stub)
+
+      try await manager.preWarm()
+
+      #expect(manager.currentInputResolutionSource == "list_fallback")
+      #expect(
+        manager.zeroSignalDiscriminatorDevice == nil,
+        "pre-warm still must not publish a health-check device")
+    }
+
+    @Test("a throwing preWarm retains the new attempt's source before rethrowing")
+    func throwingPreWarmRetainsSource() async throws {
+      let stub = StubSource()
+      stub.finalizedAttemptToFire = Self.finalizedAttempt(.listFallback, bind: .failed)
+      stub.prepareError = AudioError.formatCreationFailed(source: "test.prewarm")
+      let manager = Self.makeManager(stub)
+
+      await #expect(throws: AudioError.self) { try await manager.preWarm() }
+
+      #expect(manager.currentInputResolutionSource == "list_fallback")
+      #expect(manager.zeroSignalDiscriminatorDevice == nil)
+    }
+
+    // MARK: - 7. #1714 outbound telemetry projection
+
+    @Test("a cold attempt forwards ONE projection built from the retained attempt")
+    func coldAttemptForwardsOneProjection() async throws {
+      let stub = StubSource()
+      stub.finalizedAttemptToFire = Self.finalizedAttempt(.listFallback)
+      stub.boundToReturn = BoundInputDevice(
+        deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
+        resolutionSource: "list_fallback")
+      let manager = Self.makeManager(stub)
+
+      var forwarded: [InputResolutionAttemptTelemetry] = []
+      manager.onFinalizedInputResolutionAttempt = { forwarded.append($0) }
+
+      try await manager.startEnginePhase()
+
+      #expect(forwarded.count == 1, "exactly one projection per cold attempt")
+      #expect(forwarded.first?.inputResolutionSource == "list_fallback")
+      #expect(forwarded.first?.bindOutcome == "succeeded")
+      #expect(forwarded.first?.prepareOutcome == "failed", "the attempt was finalised pre-success")
+      #expect(forwarded.first?.defaultPresent == false)
+    }
+
+    @Test("a WARM success forwards nothing — a reused bind is not a new resolution")
+    func warmSuccessForwardsNothing() async throws {
+      let stub = StubSource()
+      stub.finalizedAttemptToFire = nil
+      stub.boundToReturn = BoundInputDevice(
+        deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
+        resolutionSource: "list_fallback")
+      let manager = Self.makeManager(stub)
+
+      var forwarded: [InputResolutionAttemptTelemetry] = []
+      manager.onFinalizedInputResolutionAttempt = { forwarded.append($0) }
+
+      try await manager.startEnginePhase()
+
+      #expect(forwarded.isEmpty)
+      // Attribution still updates from the returned bind.
+      #expect(manager.currentInputResolutionSource == "list_fallback")
+    }
+
+    @Test("a THROWING cold attempt still forwards before the throw escapes")
+    func throwingColdAttemptStillForwards() async throws {
+      let stub = StubSource()
+      stub.finalizedAttemptToFire = Self.finalizedAttempt(.listFallback, bind: .failed)
+      stub.prepareError = AudioError.formatCreationFailed(source: "test.set_device")
+      let manager = Self.makeManager(stub)
+
+      var forwarded: [InputResolutionAttemptTelemetry] = []
+      manager.onFinalizedInputResolutionAttempt = { forwarded.append($0) }
+
+      await #expect(throws: AudioError.self) { try await manager.startEnginePhase() }
+
+      // The failing population is the one #1714 exists to measure, so it must
+      // still be reported.
+      #expect(forwarded.count == 1)
+      #expect(forwarded.first?.bindOutcome == "failed")
+      #expect(forwarded.first?.prepareOutcome == "failed")
+    }
+
+    @Test("nil counts survive the projection as nil, never as zero")
+    func nilCountsSurviveProjection() async throws {
+      // The attempt fixture uses a not-attempted enumeration, whose counts are
+      // unknown. Flattening them to 0 here would claim the machine listed no
+      // input devices.
+      let stub = StubSource()
+      stub.finalizedAttemptToFire = Self.finalizedAttempt(.systemDefault)
+      let manager = Self.makeManager(stub)
+
+      var forwarded: [InputResolutionAttemptTelemetry] = []
+      manager.onFinalizedInputResolutionAttempt = { forwarded.append($0) }
+
+      try await manager.startEnginePhase()
+
+      #expect(forwarded.first?.inputDeviceCount == nil)
+      #expect(forwarded.first?.eligibleDeviceCount == nil)
+      #expect(forwarded.first?.enumerationOutcome == "not_attempted")
     }
 
     // MARK: - Fail-closed lives with the CONSUMER, not here

--- a/Tests/EnviousWisprTests/Audio/DebugInputFallbackArmingTests.swift
+++ b/Tests/EnviousWisprTests/Audio/DebugInputFallbackArmingTests.swift
@@ -1,0 +1,238 @@
+@preconcurrency import AVFoundation
+import CoreAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+@testable import EnviousWisprCore
+
+// #1714 — the DEBUG seam that lets Live UAT reach the list-fallback rung.
+//
+// Why a seam at all: on a machine with a working default microphone, resolution
+// returns at the unchanged default rung and the new code never runs. A "normal
+// dictation worked" UAT would report a pass having exercised the OLD path. This
+// is the only way the acceptance check can reach its own subject.
+//
+// The two invariants that make it trustworthy, both of which fail silently:
+//   - it must REFUSE while capture is active, so a live take is never disturbed;
+//   - it must tear down any idle WARM source before acknowledging, because
+//     `warmReuseBind` returns before resolution — an armed-but-warm source would
+//     skip the branch and the UAT would pass having tested nothing.
+//
+// Hardware-free: every test drives the manager with stubs or inspects the
+// factory's topology. Nothing opens a real device.
+#if DEBUG
+
+  @MainActor
+  @Suite("DEBUG input-fallback arming — #1714")
+  struct DebugInputFallbackArmingTests {
+
+    /// An inert source. This suite is about what the MANAGER does around the
+    /// factory, not about capture.
+    private final class StubSource: AudioInputSource {
+      var onSamples: (@Sendable ([Float], Float) -> Void)?
+      var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
+      var onInterrupted: ((EngineInterruptionCause) -> Void)?
+      var onLifecycleSignal: (@Sendable (String) -> Void)?
+      var onCaptureStalled: ((CaptureStallContext) -> Void)?
+      var onInputResolutionAttemptFinalized: ((FinalizedInputResolutionAttempt) -> Void)?
+      var captureGeneration: UInt64 = 0
+      let captureSourceType = "stub"
+      var isCapturing = false
+      var isRunning = false
+      private(set) var rebuildCount = 0
+      #if DEBUG
+        var debugZeroFillController: DebugZeroFillController?
+        var wakeDiagnostic: (firstNonZeroRoutedIndex: Int?, routedCountAtActivation: Int?) {
+          (nil, nil)
+        }
+      #endif
+
+      func prepare() async throws -> BoundInputDevice {
+        BoundInputDevice(
+          deviceID: 1, deviceUID: "stub", transportLabel: "built_in",
+          resolutionSource: "system_default")
+      }
+      func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { $0.finish() }
+      }
+      func stop() async -> [Float] { [] }
+      func deactivateCapture() {}
+      func waitForFormatStabilization(maxWait: TimeInterval, pollInterval: TimeInterval) async
+        -> Bool
+      { true }
+      func abortPrepare() {}
+      func rebuild() { rebuildCount += 1 }
+      var captureStopMetadata: CaptureStopMetadata? { nil }
+      var lastBindOK: Bool { true }
+      var actualBoundTransport: String? { nil }
+    }
+
+    /// Installs a warm source through the SAME seam the retire-fence tests use,
+    /// so this suite exercises real manager state rather than a parallel fake.
+    private func managerWithWarmSource(_ source: StubSource) -> AudioCaptureManager {
+      let manager = AudioCaptureManager()
+      manager.installCapturedSourceForTesting(source, sessionID: 1)
+      return manager
+    }
+
+    /// A route decision supplied by the test, so construction can be exercised
+    /// without `CaptureRouteResolver.resolve()` reading live output hardware.
+    private static func decision(uid: String? = nil) -> CaptureRouteDecision {
+      CaptureRouteDecision(
+        sourceType: .halDeviceInput,
+        reason: uid == nil ? .noBTAutoInput : .noBTUserSelectedDevice,
+        rationale: "test",
+        effectiveDeviceUID: uid
+      )
+    }
+
+    private static func armedHALSource(
+      _ manager: AudioCaptureManager, uid: String? = nil
+    ) -> HALDeviceInputSource? {
+      manager.buildSourceForTesting(decision(uid: uid)) as? HALDeviceInputSource
+    }
+
+    /// Is this manager armed? Asked by EFFECT — does the built source have its
+    /// default lookup forced? — so the factory is proven consumed rather than
+    /// merely stored. Only called on a source already proven to be a HAL source.
+    private static func defaultIsForcedNil(_ manager: AudioCaptureManager) -> Bool {
+      guard let hal = armedHALSource(manager) else { return false }
+      return hal.inputDeviceResolver.defaultInputDeviceID() == nil
+    }
+
+    // MARK: - Refusal while capture is active
+
+    @Test("arming is REFUSED while capture is active")
+    func armRefusedDuringCapture() {
+      let manager = AudioCaptureManager()
+      manager.isCapturing = true
+
+      #expect(manager.debugSetDefaultInputAbsent(true) == false)
+    }
+
+    @Test("disarming is REFUSED while capture is active")
+    func disarmRefusedDuringCapture() {
+      let manager = AudioCaptureManager()
+      manager.isCapturing = true
+
+      #expect(manager.debugSetDefaultInputAbsent(false) == false)
+    }
+
+    @Test("a refused change leaves the previously installed factory untouched")
+    func refusalPreservesFactory() {
+      let manager = AudioCaptureManager()
+      // Arm while idle, then start capturing and try to disarm.
+      #expect(manager.debugSetDefaultInputAbsent(true))
+      manager.isCapturing = true
+
+      #expect(manager.debugSetDefaultInputAbsent(false) == false)
+      // Observed through the REAL consumption path: a still-armed manager builds
+      // a HAL source whose default lookup is forced nil.
+      manager.isCapturing = false
+      #expect(Self.defaultIsForcedNil(manager), "the armed factory must survive a refusal")
+    }
+
+    @Test("a refused change does NOT rebuild the active source")
+    func refusalDoesNotRebuild() {
+      let stub = StubSource()
+      let manager = managerWithWarmSource(stub)
+      manager.isCapturing = true
+
+      #expect(manager.debugSetDefaultInputAbsent(true) == false)
+      #expect(stub.rebuildCount == 0, "a live take must never be disturbed by arming")
+    }
+
+    // MARK: - Idle arming tears the warm source down
+
+    @Test("arming while idle rebuilds the warm source exactly once")
+    func armRebuildsWarmSourceOnce() {
+      let stub = StubSource()
+      let manager = managerWithWarmSource(stub)
+
+      #expect(manager.debugSetDefaultInputAbsent(true))
+      // Without this, the next take would reuse the warm bind and return before
+      // resolution ever ran — the branch under test would be skipped.
+      #expect(stub.rebuildCount == 1)
+    }
+
+    @Test("disarming while idle also rebuilds the warm source exactly once")
+    func disarmRebuildsWarmSourceOnce() {
+      let stub = StubSource()
+      let manager = managerWithWarmSource(stub)
+
+      #expect(manager.debugSetDefaultInputAbsent(false))
+      // The negative control needs this too: otherwise it would run against a
+      // source still built by the armed factory and report the right answer for
+      // the wrong reason.
+      #expect(stub.rebuildCount == 1)
+    }
+
+    @Test("arming and disarming succeed with no active source")
+    func succeedsWithNoActiveSource() {
+      let manager = AudioCaptureManager()
+
+      #expect(manager.debugSetDefaultInputAbsent(true))
+      #expect(Self.defaultIsForcedNil(manager))
+      #expect(manager.debugSetDefaultInputAbsent(false))
+      // The disarmed side is proven by `disarmedInstallsNothing`, which uses a
+      // sentinel. Asserting it here would call the PRODUCTION default provider
+      // and read real hardware.
+    }
+
+    // MARK: - The armed factory's topology
+
+    @Test("the armed factory builds a REAL HAL source with only the default forced nil")
+    func armedFactoryTopology() {
+      let manager = AudioCaptureManager()
+      #expect(manager.debugSetDefaultInputAbsent(true))
+
+      // Built through the same construction authority production uses.
+      let hal = Self.armedHALSource(manager, uid: "chosen-mic")
+
+      // A REAL source, not a stub: real enumeration and real AUHAL binding are
+      // the point. Only the "what is the default?" question is forced.
+      #expect(hal != nil, "the armed factory must build a real HAL source")
+      // The route decision is honoured rather than re-read from settings inside
+      // the factory, which would be the stale-selection defect this issue avoids.
+      #expect(hal?.targetDeviceUID == "chosen-mic")
+      // The forced default — the whole point of the seam.
+      #expect(hal?.inputDeviceResolver.defaultInputDeviceID() == nil)
+    }
+
+    @Test("a disarmed manager clears the installed factory")
+    func disarmedInstallsNothing() {
+      // A sentinel proves the factory is GONE rather than merely returning
+      // something HAL-shaped, and it needs no hardware read to do it.
+      let manager = AudioCaptureManager()
+      let sentinel = StubSource()
+      manager.installSourceFactoryForTesting { _ in sentinel }
+
+      #expect(manager.debugSetDefaultInputAbsent(false))
+
+      let built = manager.buildSourceForTesting(Self.decision())
+      #expect(built is HALDeviceInputSource)
+      #expect(ObjectIdentifier(built) != ObjectIdentifier(sentinel))
+    }
+
+    @Test("the armed factory keeps the LIVE input snapshot provider")
+    func armedFactoryKeepsLiveSnapshotProvider() throws {
+      // `armedFactoryTopology` proves the default is forced. It cannot prove the
+      // SNAPSHOT provider was left alone: swapping it for `{ .success([]) }`
+      // leaves that test green while silently disabling real enumeration, which
+      // is the half of the seam that must stay real.
+      let source = try String(
+        contentsOf: RepoRoot.sourceURL("Sources/EnviousWisprAudio/AudioCaptureManager.swift"),
+        encoding: .utf8
+      )
+      let start = try #require(source.range(of: "package func debugSetDefaultInputAbsent"))
+      let end = try #require(
+        source.range(of: "func buildSourceForTesting", range: start.upperBound..<source.endIndex))
+      let armingSection = source[start.lowerBound..<end.lowerBound]
+
+      #expect(
+        armingSection.contains("inputDeviceSnapshot: AudioDeviceEnumerator.inputDeviceSnapshot"))
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
@@ -4,6 +4,23 @@ import Testing
 
 @testable import EnviousWisprAudio
 
+/// Names the completeness axis at every construction site (#1714 cloud review
+/// r2). Deliberately NOT a defaulted parameter: `complete` decides whether an
+/// unusable list may tell the user to connect a microphone, so a test must say
+/// which world it is describing rather than inherit one silently.
+extension InputDeviceSnapshot {
+  /// Every enumerated device was readable — the ordinary case.
+  static func complete(_ candidates: [InputDeviceCandidate]) -> InputDeviceSnapshot {
+    .success(candidates: candidates, complete: true)
+  }
+
+  /// At least one enumerated device could not be read, so the list can no
+  /// longer prove that a microphone is absent.
+  static func partial(_ candidates: [InputDeviceCandidate]) -> InputDeviceSnapshot {
+    .success(candidates: candidates, complete: false)
+  }
+}
+
 // #1714 — freezes the capture device-selection ladder.
 //
 // Entirely hardware-free: every fact arrives through the resolver's two injected
@@ -99,7 +116,7 @@ struct InputDeviceResolverTests {
 
   @Test("default present on Auto selects it and never enumerates")
   func defaultPresentSkipsEnumeration() {
-    let spy = SnapshotSpy(.success([candidate(7, "built-in", kAudioDeviceTransportTypeBuiltIn)]))
+    let spy = SnapshotSpy(.complete([candidate(7, "built-in", kAudioDeviceTransportTypeBuiltIn)]))
     let result = resolve(defaultID: 42, spy: spy)
 
     #expect(result.selectedDeviceID == 42)
@@ -114,7 +131,7 @@ struct InputDeviceResolverTests {
 
   @Test("an empty preferred UID is treated as Auto, not as a device named empty")
   func emptyPreferredUIDIsAuto() {
-    let spy = SnapshotSpy(.success([candidate(110, "", kAudioDeviceTransportTypeVirtual)]))
+    let spy = SnapshotSpy(.complete([candidate(110, "", kAudioDeviceTransportTypeVirtual)]))
     let result = resolve(preferredUID: "", defaultID: 42, spy: spy)
 
     // Auto with a present default: no enumeration, and crucially NOT a match
@@ -129,7 +146,7 @@ struct InputDeviceResolverTests {
   @Test("pinned UID present in the frozen snapshot wins over the system default")
   func pinnedUIDWins() {
     let spy = SnapshotSpy(
-      .success([
+      .complete([
         candidate(10, "other", kAudioDeviceTransportTypeUSB),
         candidate(11, "wanted", kAudioDeviceTransportTypeUSB),
       ]))
@@ -150,7 +167,7 @@ struct InputDeviceResolverTests {
     let result = resolve(
       preferredUID: "my-aggregate",
       defaultID: nil,
-      snapshot: .success([
+      snapshot: .complete([
         candidate(20, "my-aggregate", kAudioDeviceTransportTypeAggregate)
       ]))
 
@@ -165,7 +182,7 @@ struct InputDeviceResolverTests {
   @Test("pinned UID absent falls through to the system default")
   func pinnedUIDAbsentFallsBackToDefault() {
     let spy = SnapshotSpy(
-      .success([
+      .complete([
         candidate(10, "something-else", kAudioDeviceTransportTypeUSB),
         candidate(42, "system-default", kAudioDeviceTransportTypeBuiltIn),
       ]))
@@ -187,7 +204,7 @@ struct InputDeviceResolverTests {
     let result = resolve(
       preferredUID: "gone",
       defaultID: 999,
-      snapshot: .success([candidate(10, "something-else", kAudioDeviceTransportTypeUSB)]))
+      snapshot: .complete([candidate(10, "something-else", kAudioDeviceTransportTypeUSB)]))
 
     #expect(result.selectedDeviceID == 999)
     #expect(result.resolutionSource == .systemDefault)
@@ -198,7 +215,7 @@ struct InputDeviceResolverTests {
 
   @Test("default absent selects the built-in microphone from the frozen list")
   func defaultAbsentSelectsBuiltIn() {
-    let spy = SnapshotSpy(.success([candidate(30, "builtin", kAudioDeviceTransportTypeBuiltIn)]))
+    let spy = SnapshotSpy(.complete([candidate(30, "builtin", kAudioDeviceTransportTypeBuiltIn)]))
     let result = resolve(defaultID: nil, spy: spy)
 
     #expect(result.selectedDeviceID == 30)
@@ -214,7 +231,7 @@ struct InputDeviceResolverTests {
   func defaultAbsentSelectsUSB() {
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([candidate(31, "usb-mic", kAudioDeviceTransportTypeUSB)]))
+      snapshot: .complete([candidate(31, "usb-mic", kAudioDeviceTransportTypeUSB)]))
 
     #expect(result.selectedDeviceID == 31)
     #expect(result.resolutionSource == .listFallback)
@@ -226,7 +243,7 @@ struct InputDeviceResolverTests {
     // Ordering matters: "first eligible" alone would pick the USB device.
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([
+      snapshot: .complete([
         candidate(40, "usb-mic", kAudioDeviceTransportTypeUSB),
         candidate(41, "builtin", kAudioDeviceTransportTypeBuiltIn),
       ]))
@@ -242,7 +259,7 @@ struct InputDeviceResolverTests {
     // alongside the real microphone. Binding either records digital silence.
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([
+      snapshot: .complete([
         candidate(50, "BlackHole2ch", kAudioDeviceTransportTypeVirtual),
         candidate(51, "TeamsAudio", kAudioDeviceTransportTypeVirtual),
         candidate(52, "aggregate", kAudioDeviceTransportTypeAggregate),
@@ -258,7 +275,7 @@ struct InputDeviceResolverTests {
   func unclassifiableDoesNotBlockAnEligibleDevice() {
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([
+      snapshot: .complete([
         candidate(80, "mystery", nil),
         candidate(81, "usb-mic", kAudioDeviceTransportTypeUSB),
       ]))
@@ -273,7 +290,7 @@ struct InputDeviceResolverTests {
 
   @Test("successful but empty enumeration reports no microphone")
   func emptyEnumerationIsAbsence() {
-    let result = resolve(defaultID: nil, snapshot: .success([]))
+    let result = resolve(defaultID: nil, snapshot: .complete([]))
 
     #expect(result.selectedDeviceID == nil)
     #expect(isNoMicrophoneFound(result.thrownError))
@@ -286,13 +303,69 @@ struct InputDeviceResolverTests {
   func onlyKnownNonMicrophonesIsAbsence() {
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([
+      snapshot: .complete([
         candidate(60, "BlackHole2ch", kAudioDeviceTransportTypeVirtual),
         candidate(61, "aggregate", kAudioDeviceTransportTypeAggregate),
       ]))
 
     #expect(isNoMicrophoneFound(result.thrownError))
     #expect(result.eligibleDeviceCount == 0)
+  }
+
+  // MARK: - Partial enumeration: one device unreadable, the rest still usable
+
+  @Test("an unreadable device never costs the user the microphones that ARE readable")
+  func partialEnumerationStillSelectsAReadableDevice() {
+    // #1714 cloud review r2. A USB stick pulled mid-enumeration makes its own
+    // properties unreadable; the built-in microphone beside it is untouched.
+    // Refusing to dictate here would break founder priority 1.
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .partial([candidate(80, "builtin", kAudioDeviceTransportTypeBuiltIn)]))
+
+    #expect(result.selectedDeviceID == 80)
+    #expect(result.resolutionSource == .listFallback)
+    #expect(result.thrownError == nil)
+    #expect(result.enumerationOutcome == .succeededPartial)
+  }
+
+  @Test("an incomplete list never claims the microphone is missing")
+  func partialEnumerationWithNothingLeftIsUncertaintyNotAbsence() {
+    // The vacuous-truth trap: `allSatisfy` on an EMPTY array returns true, so
+    // without the completeness gate an enumeration where every device failed
+    // its read would produce the strongest possible claim from the weakest
+    // possible evidence.
+    let result = resolve(defaultID: nil, snapshot: .partial([]))
+
+    #expect(result.selectedDeviceID == nil)
+    #expect(isNoMicrophoneFound(result.thrownError) == false)
+    #expect(result.enumerationOutcome == .succeededPartial)
+  }
+
+  @Test("an incomplete list of only virtual devices is still uncertainty")
+  func partialEnumerationOfNonMicrophonesDoesNotProveAbsence() {
+    // The same list COMPLETE proves absence (see `onlyKnownNonMicrophonesIsAbsence`).
+    // Completeness is the only difference, so this pins the gate itself rather
+    // than the transport classification.
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .partial([candidate(81, "BlackHole2ch", kAudioDeviceTransportTypeVirtual)]))
+
+    #expect(isNoMicrophoneFound(result.thrownError) == false)
+    #expect(result.enumerationOutcome == .succeededPartial)
+  }
+
+  @Test("a complete enumeration still reports plain succeeded")
+  func completeEnumerationReportsSucceeded() {
+    // Two-way control for the telemetry field: without this, a bug that marked
+    // every enumeration partial would pass all three tests above while making
+    // the "connect a microphone" message unreachable forever.
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .complete([candidate(82, "builtin", kAudioDeviceTransportTypeBuiltIn)]))
+
+    #expect(result.selectedDeviceID == 82)
+    #expect(result.enumerationOutcome == .succeeded)
   }
 
   // MARK: - Uncertainty: the list fails to prove anything
@@ -330,7 +403,7 @@ struct InputDeviceResolverTests {
   func unreadableTransportIsUncertainty() {
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([candidate(70, "mystery", nil)]))
+      snapshot: .complete([candidate(70, "mystery", nil)]))
 
     #expect(
       diagnosticSource(result.thrownError) == "InputDeviceResolver.unclassifiable_input_transport")
@@ -341,7 +414,7 @@ struct InputDeviceResolverTests {
   func unknownTransportIsUncertainty() {
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([candidate(71, "unknown", kAudioDeviceTransportTypeUnknown)]))
+      snapshot: .complete([candidate(71, "unknown", kAudioDeviceTransportTypeUnknown)]))
 
     #expect(
       diagnosticSource(result.thrownError) == "InputDeviceResolver.unclassifiable_input_transport")
@@ -351,7 +424,7 @@ struct InputDeviceResolverTests {
   func futureTransportIsUncertainty() {
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([candidate(72, "future", Self.futureUnknownTransport)]))
+      snapshot: .complete([candidate(72, "future", Self.futureUnknownTransport)]))
 
     #expect(
       diagnosticSource(result.thrownError) == "InputDeviceResolver.unclassifiable_input_transport")
@@ -364,7 +437,7 @@ struct InputDeviceResolverTests {
     // microphone exists, so the user must not be told to connect one.
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([candidate(73, "airplay", kAudioDeviceTransportTypeAirPlay)]))
+      snapshot: .complete([candidate(73, "airplay", kAudioDeviceTransportTypeAirPlay)]))
 
     #expect(
       diagnosticSource(result.thrownError) == "InputDeviceResolver.unclassifiable_input_transport")
@@ -382,7 +455,7 @@ struct InputDeviceResolverTests {
     // And end to end: a lone device on this transport is selectable.
     let result = resolve(
       defaultID: nil,
-      snapshot: .success([candidate(90, entry.name, entry.raw)]))
+      snapshot: .complete([candidate(90, entry.name, entry.raw)]))
     #expect(result.selectedDeviceID == 90)
     #expect(result.resolutionSource == .listFallback)
   }
@@ -429,10 +502,10 @@ struct InputDeviceResolverTests {
   func enumeratesAtMostOnce() {
     let snapshots: [InputDeviceSnapshot] = [
       .readFailed,
-      .success([]),
-      .success([candidate(100, "builtin", kAudioDeviceTransportTypeBuiltIn)]),
-      .success([candidate(101, "virtual", kAudioDeviceTransportTypeVirtual)]),
-      .success([candidate(102, "mystery", nil)]),
+      .complete([]),
+      .complete([candidate(100, "builtin", kAudioDeviceTransportTypeBuiltIn)]),
+      .complete([candidate(101, "virtual", kAudioDeviceTransportTypeVirtual)]),
+      .complete([candidate(102, "mystery", nil)]),
     ]
     var enumeratedAtLeastOnce = false
     for snapshot in snapshots {
@@ -478,7 +551,7 @@ struct InputDeviceResolverTests {
   // MIGRATED: "nil target resolves to current system default input".
   @Test("Auto: a bind on the current default stays compatible, and never enumerates")
   func warmAutoMatchesDefault() {
-    let spy = SnapshotSpy(.success([candidate(1, "anything", kAudioDeviceTransportTypeUSB)]))
+    let spy = SnapshotSpy(.complete([candidate(1, "anything", kAudioDeviceTransportTypeUSB)]))
 
     #expect(warmCompatible(bind(42, .systemDefault), defaultID: 42, spy: spy))
     #expect(spy.callCount == 0, "Auto must answer from the default alone")
@@ -487,7 +560,7 @@ struct InputDeviceResolverTests {
   // MIGRATED: the stale-default half of the old Auto reuse pair.
   @Test("Auto: a bind on a stale default is rejected")
   func warmAutoRejectsStaleDefault() {
-    let spy = SnapshotSpy(.success([]))
+    let spy = SnapshotSpy(.complete([]))
 
     #expect(!warmCompatible(bind(42, .systemDefault), defaultID: 43, spy: spy))
     #expect(spy.callCount == 0)
@@ -497,7 +570,7 @@ struct InputDeviceResolverTests {
   @Test("Pinned: a bind on the pinned device stays compatible")
   func warmPinnedMatches() {
     let spy = SnapshotSpy(
-      .success([candidate(99, "present", kAudioDeviceTransportTypeUSB)]))
+      .complete([candidate(99, "present", kAudioDeviceTransportTypeUSB)]))
 
     #expect(
       warmCompatible(bind(99, .pinnedUID), preferredUID: "present", defaultID: 42, spy: spy))
@@ -509,7 +582,7 @@ struct InputDeviceResolverTests {
     // The founder's rule forwards: the chosen mic is back, so it takes the take
     // back. Rejecting here is what forces the next open to be cold and pinned.
     let spy = SnapshotSpy(
-      .success([candidate(77, "airpods", kAudioDeviceTransportTypeBluetooth)]))
+      .complete([candidate(77, "airpods", kAudioDeviceTransportTypeBluetooth)]))
 
     #expect(
       !warmCompatible(
@@ -520,36 +593,36 @@ struct InputDeviceResolverTests {
   @Test("Pinned but absent: compatibility falls through to the current default")
   func warmPinnedAbsentTracksDefault() {
     let spy = SnapshotSpy(
-      .success([candidate(1, "something-else", kAudioDeviceTransportTypeUSB)]))
+      .complete([candidate(1, "something-else", kAudioDeviceTransportTypeUSB)]))
 
     #expect(
       warmCompatible(bind(42, .systemDefault), preferredUID: "gone", defaultID: 42, spy: spy))
 
     let spy2 = SnapshotSpy(
-      .success([candidate(1, "something-else", kAudioDeviceTransportTypeUSB)]))
+      .complete([candidate(1, "something-else", kAudioDeviceTransportTypeUSB)]))
     #expect(
       !warmCompatible(bind(42, .systemDefault), preferredUID: "gone", defaultID: 43, spy: spy2))
   }
 
   @Test("Auto with no default: only a list_fallback bind survives")
   func warmAutoNoDefaultKeepsFallbackOnly() {
-    let spy = SnapshotSpy(.success([]))
+    let spy = SnapshotSpy(.complete([]))
     #expect(warmCompatible(bind(30, .listFallback), defaultID: nil, spy: spy))
     #expect(spy.callCount == 0)
 
     // A bind that came from a since-vanished default is NOT made correct by the
     // default vanishing. Only a bind chosen BECAUSE none existed still holds.
-    let spy2 = SnapshotSpy(.success([]))
+    let spy2 = SnapshotSpy(.complete([]))
     #expect(!warmCompatible(bind(30, .systemDefault), defaultID: nil, spy: spy2))
 
-    let spy3 = SnapshotSpy(.success([]))
+    let spy3 = SnapshotSpy(.complete([]))
     #expect(!warmCompatible(bind(30, .pinnedUID), defaultID: nil, spy: spy3))
   }
 
   @Test("Pinned absent with no default: a list_fallback bind survives")
   func warmPinnedAbsentNoDefaultKeepsFallback() {
     let spy = SnapshotSpy(
-      .success([candidate(1, "something-else", kAudioDeviceTransportTypeUSB)]))
+      .complete([candidate(1, "something-else", kAudioDeviceTransportTypeUSB)]))
 
     #expect(
       warmCompatible(
@@ -578,7 +651,7 @@ struct InputDeviceResolverTests {
     // A snapshot holding an eligible built-in mic must NOT make an incompatible
     // bind compatible. Ranking belongs to cold opens only.
     let spy = SnapshotSpy(
-      .success([
+      .complete([
         candidate(55, "builtin", kAudioDeviceTransportTypeBuiltIn),
         candidate(56, "usb", kAudioDeviceTransportTypeUSB),
       ]))
@@ -601,7 +674,8 @@ struct InputDeviceResolverTests {
     // down. The enumerator now returns `.readFailed` instead, which lands here.
     let result = resolve(defaultID: nil, snapshot: .readFailed)
 
-    #expect(isNoMicrophoneFound(result.thrownError) == false, "never claim absence on a failed read")
+    #expect(
+      isNoMicrophoneFound(result.thrownError) == false, "never claim absence on a failed read")
     #expect(diagnosticSource(result.thrownError) == "InputDeviceResolver.enumerate_input_devices")
     #expect(result.enumerationOutcome == .readFailed)
     // Counts stay unknown rather than zero: 0 would read as an empty machine.

--- a/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
@@ -1,0 +1,622 @@
+import CoreAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #1714 — freezes the capture device-selection ladder.
+//
+// Entirely hardware-free: every fact arrives through the resolver's two injected
+// providers, so this suite runs identically on a laptop and on the CI runner,
+// which has no audio input device at all.
+//
+// The two invariants worth stating outright, because both fail SILENTLY:
+//   - the snapshot provider runs AT MOST ONCE per attempt, so every count and
+//     transport describes the same list the selected device came from;
+//   - the fallback does NOT run when a system default resolves. A guard that
+//     fired on every call would pass the positive tests while quietly taking
+//     device selection away from the system default on every dictation.
+@Suite("InputDeviceResolver ladder — #1714")
+struct InputDeviceResolverTests {
+
+  // MARK: - Harness
+
+  /// Counts provider invocations so "at most one enumeration" is asserted, not
+  /// assumed. A class because the resolver's closure captures it; the suite is
+  /// single-threaded, hence `@unchecked`.
+  private final class SnapshotSpy: @unchecked Sendable {
+    private(set) var callCount = 0
+    private let result: InputDeviceSnapshot
+
+    init(_ result: InputDeviceSnapshot) { self.result = result }
+
+    func provide() -> InputDeviceSnapshot {
+      callCount += 1
+      return result
+    }
+  }
+
+  private func candidate(
+    _ id: AudioDeviceID, _ uid: String, _ transport: UInt32?
+  ) -> InputDeviceCandidate {
+    InputDeviceCandidate(id: id, uid: uid, rawTransport: transport)
+  }
+
+  /// The spy is the ONLY source of the snapshot, so no test can pass a snapshot
+  /// that is silently ignored.
+  private func resolve(
+    preferredUID: String? = nil,
+    defaultID: AudioDeviceID?,
+    spy: SnapshotSpy
+  ) -> InputDeviceResolution {
+    InputDeviceResolver(
+      defaultInputDeviceID: { defaultID },
+      inputDeviceSnapshot: { spy.provide() }
+    ).resolve(preferredUID: preferredUID)
+  }
+
+  private func resolve(
+    preferredUID: String? = nil,
+    defaultID: AudioDeviceID?,
+    snapshot: InputDeviceSnapshot
+  ) -> InputDeviceResolution {
+    resolve(preferredUID: preferredUID, defaultID: defaultID, spy: SnapshotSpy(snapshot))
+  }
+
+  /// One accepted transport. A named type rather than a tuple so the
+  /// parameterised test has an unambiguous single argument.
+  struct AcceptedTransport: Sendable, CustomStringConvertible {
+    let raw: UInt32
+    let name: String
+    var description: String { name }
+  }
+
+  /// Every transport the allow-list accepts. Frozen: adding one is a fleet-
+  /// evidence decision, and silently dropping one would strand those users on
+  /// the "no microphone" error.
+  private static let acceptedTransports: [AcceptedTransport] = [
+    AcceptedTransport(raw: kAudioDeviceTransportTypeBuiltIn, name: "built_in"),
+    AcceptedTransport(raw: kAudioDeviceTransportTypeUSB, name: "usb"),
+    AcceptedTransport(raw: kAudioDeviceTransportTypeBluetooth, name: "bluetooth"),
+    AcceptedTransport(raw: kAudioDeviceTransportTypeBluetoothLE, name: "bluetooth_le"),
+    AcceptedTransport(
+      raw: kAudioDeviceTransportTypeContinuityCaptureWired, name: "continuity_wired"),
+    AcceptedTransport(
+      raw: kAudioDeviceTransportTypeContinuityCaptureWireless, name: "continuity_wireless"),
+    AcceptedTransport(raw: kAudioDeviceTransportTypeThunderbolt, name: "thunderbolt"),
+    AcceptedTransport(raw: kAudioDeviceTransportTypeDisplayPort, name: "display_port"),
+    AcceptedTransport(raw: kAudioDeviceTransportTypeHDMI, name: "hdmi"),
+    AcceptedTransport(raw: kAudioDeviceTransportTypePCI, name: "pci"),
+    AcceptedTransport(raw: kAudioDeviceTransportTypeFireWire, name: "fire_wire"),
+    AcceptedTransport(raw: kAudioDeviceTransportTypeAVB, name: "avb"),
+  ]
+
+  /// A raw value no CoreAudio constant uses, standing in for a transport a
+  /// future macOS invents. It must be REFUSED, not accepted by default.
+  private static let futureUnknownTransport: UInt32 = 0x5A5A_5A5A
+
+  // MARK: - Rung 1: the ordinary Auto path
+
+  @Test("default present on Auto selects it and never enumerates")
+  func defaultPresentSkipsEnumeration() {
+    let spy = SnapshotSpy(.success([candidate(7, "built-in", kAudioDeviceTransportTypeBuiltIn)]))
+    let result = resolve(defaultID: 42, spy: spy)
+
+    #expect(result.selectedDeviceID == 42)
+    #expect(result.resolutionSource == .systemDefault)
+    #expect(result.defaultPresent)
+    #expect(result.enumerationOutcome == .notAttempted)
+    #expect(result.inputDeviceCount == nil)
+    #expect(result.eligibleDeviceCount == nil)
+    // The two-way control: the fallback must NOT run when the default resolves.
+    #expect(spy.callCount == 0)
+  }
+
+  @Test("an empty preferred UID is treated as Auto, not as a device named empty")
+  func emptyPreferredUIDIsAuto() {
+    let spy = SnapshotSpy(.success([candidate(110, "", kAudioDeviceTransportTypeVirtual)]))
+    let result = resolve(preferredUID: "", defaultID: 42, spy: spy)
+
+    // Auto with a present default: no enumeration, and crucially NOT a match
+    // against the empty-UID virtual device.
+    #expect(result.selectedDeviceID == 42)
+    #expect(result.resolutionSource == .systemDefault)
+    #expect(spy.callCount == 0)
+  }
+
+  // MARK: - Rung 2: a pinned device
+
+  @Test("pinned UID present in the frozen snapshot wins over the system default")
+  func pinnedUIDWins() {
+    let spy = SnapshotSpy(
+      .success([
+        candidate(10, "other", kAudioDeviceTransportTypeUSB),
+        candidate(11, "wanted", kAudioDeviceTransportTypeUSB),
+      ]))
+    let result = resolve(preferredUID: "wanted", defaultID: 42, spy: spy)
+
+    #expect(result.selectedDeviceID == 11)
+    #expect(result.resolutionSource == .pinnedUID)
+    #expect(result.selectedTransport == "usb")
+    #expect(result.enumerationOutcome == .succeeded)
+    #expect(result.inputDeviceCount == 2)
+    #expect(spy.callCount == 1)
+  }
+
+  @Test("a deliberately pinned aggregate device is still selectable")
+  func pinnedAggregateIsAllowed() {
+    // The allow-list constrains the AUTOMATIC last resort only. An explicit
+    // choice is the user's to make.
+    let result = resolve(
+      preferredUID: "my-aggregate",
+      defaultID: nil,
+      snapshot: .success([
+        candidate(20, "my-aggregate", kAudioDeviceTransportTypeAggregate)
+      ]))
+
+    #expect(result.selectedDeviceID == 20)
+    #expect(result.resolutionSource == .pinnedUID)
+    #expect(result.selectedTransport == "aggregate")
+    #expect(result.eligibleDeviceCount == 0)
+  }
+
+  // MARK: - Rung 3: pinned device gone
+
+  @Test("pinned UID absent falls through to the system default")
+  func pinnedUIDAbsentFallsBackToDefault() {
+    let spy = SnapshotSpy(
+      .success([
+        candidate(10, "something-else", kAudioDeviceTransportTypeUSB),
+        candidate(42, "system-default", kAudioDeviceTransportTypeBuiltIn),
+      ]))
+    let result = resolve(preferredUID: "gone", defaultID: 42, spy: spy)
+
+    #expect(result.selectedDeviceID == 42)
+    #expect(result.resolutionSource == .systemDefault)
+    #expect(result.enumerationOutcome == .succeeded)
+    // The snapshot is already in hand on this rung, so the default's transport
+    // is reported rather than discarded.
+    #expect(result.selectedTransport == "built_in")
+    #expect(spy.callCount == 1)
+  }
+
+  @Test("a system default that is not itself an input candidate reports no transport")
+  func defaultOutsideSnapshotHasNoTransport() {
+    // Guards the lookup added above: nil means "not in the frozen list", and
+    // must not be mistaken for a device we failed to classify.
+    let result = resolve(
+      preferredUID: "gone",
+      defaultID: 999,
+      snapshot: .success([candidate(10, "something-else", kAudioDeviceTransportTypeUSB)]))
+
+    #expect(result.selectedDeviceID == 999)
+    #expect(result.resolutionSource == .systemDefault)
+    #expect(result.selectedTransport == nil)
+  }
+
+  // MARK: - Rung 4: the fallback #1714 exists to add
+
+  @Test("default absent selects the built-in microphone from the frozen list")
+  func defaultAbsentSelectsBuiltIn() {
+    let spy = SnapshotSpy(.success([candidate(30, "builtin", kAudioDeviceTransportTypeBuiltIn)]))
+    let result = resolve(defaultID: nil, spy: spy)
+
+    #expect(result.selectedDeviceID == 30)
+    #expect(result.resolutionSource == .listFallback)
+    #expect(result.selectedTransport == "built_in")
+    #expect(result.defaultPresent == false)
+    #expect(result.inputDeviceCount == 1)
+    #expect(result.eligibleDeviceCount == 1)
+    #expect(spy.callCount == 1)
+  }
+
+  @Test("default absent selects a USB microphone when no built-in exists")
+  func defaultAbsentSelectsUSB() {
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([candidate(31, "usb-mic", kAudioDeviceTransportTypeUSB)]))
+
+    #expect(result.selectedDeviceID == 31)
+    #expect(result.resolutionSource == .listFallback)
+    #expect(result.selectedTransport == "usb")
+  }
+
+  @Test("built-in wins over an EARLIER-listed eligible USB candidate")
+  func builtInPreferredOverEarlierUSB() {
+    // Ordering matters: "first eligible" alone would pick the USB device.
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([
+        candidate(40, "usb-mic", kAudioDeviceTransportTypeUSB),
+        candidate(41, "builtin", kAudioDeviceTransportTypeBuiltIn),
+      ]))
+
+    #expect(result.selectedDeviceID == 41)
+    #expect(result.selectedTransport == "built_in")
+    #expect(result.eligibleDeviceCount == 2)
+  }
+
+  @Test("virtual and aggregate devices are skipped in favour of a real microphone")
+  func virtualDevicesSkipped() {
+    // The founder's own machine: a loopback and a meeting-app device listed
+    // alongside the real microphone. Binding either records digital silence.
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([
+        candidate(50, "BlackHole2ch", kAudioDeviceTransportTypeVirtual),
+        candidate(51, "TeamsAudio", kAudioDeviceTransportTypeVirtual),
+        candidate(52, "aggregate", kAudioDeviceTransportTypeAggregate),
+        candidate(53, "MacBookProMicrophone", kAudioDeviceTransportTypeBuiltIn),
+      ]))
+
+    #expect(result.selectedDeviceID == 53)
+    #expect(result.inputDeviceCount == 4)
+    #expect(result.eligibleDeviceCount == 1)
+  }
+
+  @Test("one unclassifiable device does not stop an eligible one being selected")
+  func unclassifiableDoesNotBlockAnEligibleDevice() {
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([
+        candidate(80, "mystery", nil),
+        candidate(81, "usb-mic", kAudioDeviceTransportTypeUSB),
+      ]))
+
+    #expect(result.selectedDeviceID == 81)
+    #expect(result.resolutionSource == .listFallback)
+    #expect(result.inputDeviceCount == 2)
+    #expect(result.eligibleDeviceCount == 1)
+  }
+
+  // MARK: - Absence: the list PROVES there is no microphone
+
+  @Test("successful but empty enumeration reports no microphone")
+  func emptyEnumerationIsAbsence() {
+    let result = resolve(defaultID: nil, snapshot: .success([]))
+
+    #expect(result.selectedDeviceID == nil)
+    #expect(isNoMicrophoneFound(result.thrownError))
+    #expect(result.enumerationOutcome == .succeeded)
+    #expect(result.inputDeviceCount == 0)
+    #expect(result.eligibleDeviceCount == 0)
+  }
+
+  @Test("only virtual and aggregate devices reports no microphone")
+  func onlyKnownNonMicrophonesIsAbsence() {
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([
+        candidate(60, "BlackHole2ch", kAudioDeviceTransportTypeVirtual),
+        candidate(61, "aggregate", kAudioDeviceTransportTypeAggregate),
+      ]))
+
+    #expect(isNoMicrophoneFound(result.thrownError))
+    #expect(result.eligibleDeviceCount == 0)
+  }
+
+  // MARK: - Uncertainty: the list fails to prove anything
+
+  @Test("a pinned device we cannot look up swaps to auto rather than aborting the take")
+  func readFailureWithDefaultStillRecords() {
+    // Founder decision 2026-07-30: dead AirPods, out of range, unplugged, or a
+    // device list we could not even read all mean the same thing to the user —
+    // the device they picked is not there — and that has always swapped to
+    // auto. Aborting here would make a working case worse.
+    let result = resolve(preferredUID: "airpods", defaultID: 42, snapshot: .readFailed)
+
+    #expect(result.selectedDeviceID == 42)
+    #expect(result.resolutionSource == .systemDefault)
+    #expect(result.thrownError == nil)
+    // The failure is still reported, it just does not stop the recording.
+    #expect(result.enumerationOutcome == .readFailed)
+    #expect(result.defaultPresent)
+  }
+
+  @Test("device-list read failure with NO default reports a generic capture error")
+  func readFailureIsUncertainty() {
+    let result = resolve(defaultID: nil, snapshot: .readFailed)
+
+    #expect(result.selectedDeviceID == nil)
+    #expect(diagnosticSource(result.thrownError) == "InputDeviceResolver.enumerate_input_devices")
+    #expect(isNoMicrophoneFound(result.thrownError) == false)
+    #expect(result.enumerationOutcome == .readFailed)
+    // Counts are unknown, not zero — reporting 0 would read as an empty machine.
+    #expect(result.inputDeviceCount == nil)
+    #expect(result.eligibleDeviceCount == nil)
+  }
+
+  @Test("an unreadable transport with no eligible device reports a generic capture error")
+  func unreadableTransportIsUncertainty() {
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([candidate(70, "mystery", nil)]))
+
+    #expect(
+      diagnosticSource(result.thrownError) == "InputDeviceResolver.unclassifiable_input_transport")
+    #expect(isNoMicrophoneFound(result.thrownError) == false)
+  }
+
+  @Test("transport 0 (unknown) with no eligible device reports a generic capture error")
+  func unknownTransportIsUncertainty() {
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([candidate(71, "unknown", kAudioDeviceTransportTypeUnknown)]))
+
+    #expect(
+      diagnosticSource(result.thrownError) == "InputDeviceResolver.unclassifiable_input_transport")
+  }
+
+  @Test("a future unrecognised transport with no eligible device reports a generic capture error")
+  func futureTransportIsUncertainty() {
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([candidate(72, "future", Self.futureUnknownTransport)]))
+
+    #expect(
+      diagnosticSource(result.thrownError) == "InputDeviceResolver.unclassifiable_input_transport")
+  }
+
+  @Test("AirPlay alone reports uncertainty, not absence")
+  func airPlayIsUncertaintyNotAbsence() {
+    // AirPlay is refused because it is an output protocol, not a known
+    // microphone path — but refusing to trust it is not proof that no
+    // microphone exists, so the user must not be told to connect one.
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([candidate(73, "airplay", kAudioDeviceTransportTypeAirPlay)]))
+
+    #expect(
+      diagnosticSource(result.thrownError) == "InputDeviceResolver.unclassifiable_input_transport")
+    #expect(isNoMicrophoneFound(result.thrownError) == false)
+  }
+
+  // MARK: - The allow-list itself
+
+  @Test(
+    "every approved physical transport is accepted",
+    arguments: InputDeviceResolverTests.acceptedTransports)
+  func approvedTransportsAccepted(_ entry: AcceptedTransport) {
+    #expect(AudioDeviceEnumerator.isAllowedPhysicalInputTransport(entry.raw))
+
+    // And end to end: a lone device on this transport is selectable.
+    let result = resolve(
+      defaultID: nil,
+      snapshot: .success([candidate(90, entry.name, entry.raw)]))
+    #expect(result.selectedDeviceID == 90)
+    #expect(result.resolutionSource == .listFallback)
+  }
+
+  @Test("every refused transport is refused, including nil and a future value")
+  func refusedTransportsRefused() {
+    let refused: [UInt32?] = [
+      kAudioDeviceTransportTypeVirtual,
+      kAudioDeviceTransportTypeAggregate,
+      kAudioDeviceTransportTypeUnknown,
+      kAudioDeviceTransportTypeAirPlay,
+      Self.futureUnknownTransport,
+      nil,
+    ]
+    for raw in refused {
+      #expect(AudioDeviceEnumerator.isAllowedPhysicalInputTransport(raw) == false)
+    }
+  }
+
+  @Test("only virtual and aggregate count as proof that no microphone exists")
+  func absenceProofIsNarrow() {
+    #expect(AudioDeviceEnumerator.isKnownNonMicrophoneTransport(kAudioDeviceTransportTypeVirtual))
+    #expect(AudioDeviceEnumerator.isKnownNonMicrophoneTransport(kAudioDeviceTransportTypeAggregate))
+
+    // Everything else fails the allow-list without proving absence.
+    for raw: UInt32? in [
+      kAudioDeviceTransportTypeUnknown,
+      kAudioDeviceTransportTypeAirPlay,
+      Self.futureUnknownTransport,
+      nil,
+    ] {
+      #expect(AudioDeviceEnumerator.isKnownNonMicrophoneTransport(raw) == false)
+    }
+
+    // A transport we DO accept is obviously not proof of absence either.
+    #expect(
+      AudioDeviceEnumerator.isKnownNonMicrophoneTransport(kAudioDeviceTransportTypeBuiltIn) == false
+    )
+  }
+
+  // MARK: - The one-enumeration guarantee
+
+  @Test("every path that enumerates does so at most once")
+  func enumeratesAtMostOnce() {
+    let snapshots: [InputDeviceSnapshot] = [
+      .readFailed,
+      .success([]),
+      .success([candidate(100, "builtin", kAudioDeviceTransportTypeBuiltIn)]),
+      .success([candidate(101, "virtual", kAudioDeviceTransportTypeVirtual)]),
+      .success([candidate(102, "mystery", nil)]),
+    ]
+    var enumeratedAtLeastOnce = false
+    for snapshot in snapshots {
+      for preferred in [nil, "pinned"] as [String?] {
+        for defaultID in [nil, 42] as [AudioDeviceID?] {
+          let spy = SnapshotSpy(snapshot)
+          _ = resolve(preferredUID: preferred, defaultID: defaultID, spy: spy)
+          #expect(spy.callCount <= 1)
+          if spy.callCount == 1 { enumeratedAtLeastOnce = true }
+        }
+      }
+    }
+    // Guards against a vacuous pass: if nothing ever enumerated, `<= 1` would
+    // hold trivially and prove nothing.
+    #expect(enumeratedAtLeastOnce)
+  }
+
+  // MARK: - Warm-bind compatibility (#1714)
+  //
+  // Three of these are the behaviours that used to live in
+  // `HALDeviceInputSourceDeviceTargetTests` against `resolvedDeviceIDForTesting()`.
+  // They are the resolver's behaviours now, so they moved with the authority
+  // rather than being deleted with the seam.
+
+  private func bind(_ id: AudioDeviceID, _ source: InputResolutionSource) -> BoundInputDevice {
+    BoundInputDevice(
+      deviceID: id, deviceUID: "uid-\(id)", transportLabel: "built_in",
+      resolutionSource: source.rawValue)
+  }
+
+  private func warmCompatible(
+    _ bound: BoundInputDevice,
+    preferredUID: String? = nil,
+    defaultID: AudioDeviceID?,
+    spy: SnapshotSpy
+  ) -> Bool {
+    InputDeviceResolver(
+      defaultInputDeviceID: { defaultID },
+      inputDeviceSnapshot: { spy.provide() }
+    ).isWarmBindCompatible(bound, preferredUID: preferredUID)
+  }
+
+  // MIGRATED: "nil target resolves to current system default input".
+  @Test("Auto: a bind on the current default stays compatible, and never enumerates")
+  func warmAutoMatchesDefault() {
+    let spy = SnapshotSpy(.success([candidate(1, "anything", kAudioDeviceTransportTypeUSB)]))
+
+    #expect(warmCompatible(bind(42, .systemDefault), defaultID: 42, spy: spy))
+    #expect(spy.callCount == 0, "Auto must answer from the default alone")
+  }
+
+  // MIGRATED: the stale-default half of the old Auto reuse pair.
+  @Test("Auto: a bind on a stale default is rejected")
+  func warmAutoRejectsStaleDefault() {
+    let spy = SnapshotSpy(.success([]))
+
+    #expect(!warmCompatible(bind(42, .systemDefault), defaultID: 43, spy: spy))
+    #expect(spy.callCount == 0)
+  }
+
+  // MIGRATED: "resolvable target wins over system default input".
+  @Test("Pinned: a bind on the pinned device stays compatible")
+  func warmPinnedMatches() {
+    let spy = SnapshotSpy(
+      .success([candidate(99, "present", kAudioDeviceTransportTypeUSB)]))
+
+    #expect(
+      warmCompatible(bind(99, .pinnedUID), preferredUID: "present", defaultID: 42, spy: spy))
+    #expect(spy.callCount == 1, "pinned compatibility reads at most one snapshot")
+  }
+
+  @Test("Pinned: a RECONNECTED pinned device rejects a fallback bind (founder decision)")
+  func warmPinnedReconnectRejectsFallback() {
+    // The founder's rule forwards: the chosen mic is back, so it takes the take
+    // back. Rejecting here is what forces the next open to be cold and pinned.
+    let spy = SnapshotSpy(
+      .success([candidate(77, "airpods", kAudioDeviceTransportTypeBluetooth)]))
+
+    #expect(
+      !warmCompatible(
+        bind(30, .listFallback), preferredUID: "airpods", defaultID: nil, spy: spy))
+  }
+
+  // MIGRATED: "unresolvable target falls back to current system default input".
+  @Test("Pinned but absent: compatibility falls through to the current default")
+  func warmPinnedAbsentTracksDefault() {
+    let spy = SnapshotSpy(
+      .success([candidate(1, "something-else", kAudioDeviceTransportTypeUSB)]))
+
+    #expect(
+      warmCompatible(bind(42, .systemDefault), preferredUID: "gone", defaultID: 42, spy: spy))
+
+    let spy2 = SnapshotSpy(
+      .success([candidate(1, "something-else", kAudioDeviceTransportTypeUSB)]))
+    #expect(
+      !warmCompatible(bind(42, .systemDefault), preferredUID: "gone", defaultID: 43, spy: spy2))
+  }
+
+  @Test("Auto with no default: only a list_fallback bind survives")
+  func warmAutoNoDefaultKeepsFallbackOnly() {
+    let spy = SnapshotSpy(.success([]))
+    #expect(warmCompatible(bind(30, .listFallback), defaultID: nil, spy: spy))
+    #expect(spy.callCount == 0)
+
+    // A bind that came from a since-vanished default is NOT made correct by the
+    // default vanishing. Only a bind chosen BECAUSE none existed still holds.
+    let spy2 = SnapshotSpy(.success([]))
+    #expect(!warmCompatible(bind(30, .systemDefault), defaultID: nil, spy: spy2))
+
+    let spy3 = SnapshotSpy(.success([]))
+    #expect(!warmCompatible(bind(30, .pinnedUID), defaultID: nil, spy: spy3))
+  }
+
+  @Test("Pinned absent with no default: a list_fallback bind survives")
+  func warmPinnedAbsentNoDefaultKeepsFallback() {
+    let spy = SnapshotSpy(
+      .success([candidate(1, "something-else", kAudioDeviceTransportTypeUSB)]))
+
+    #expect(
+      warmCompatible(
+        bind(30, .listFallback), preferredUID: "airpods", defaultID: nil, spy: spy))
+    #expect(spy.callCount == 1)
+  }
+
+  @Test("Pinned with a FAILED snapshot: the pinned device has not been shown to return")
+  func warmPinnedSnapshotFailureIsConservative() {
+    // A failed read is not evidence the device came back, so it must not evict
+    // a working fallback bind — that would rebuild the engine on a read error.
+    let spy = SnapshotSpy(.readFailed)
+    #expect(
+      warmCompatible(
+        bind(30, .listFallback), preferredUID: "airpods", defaultID: nil, spy: spy))
+
+    // With a default present, it falls through to the same question Auto asks.
+    let spy2 = SnapshotSpy(.readFailed)
+    #expect(
+      warmCompatible(
+        bind(42, .systemDefault), preferredUID: "airpods", defaultID: 42, spy: spy2))
+  }
+
+  @Test("warm compatibility never runs the physical fallback ranking")
+  func warmCompatibilityNeverRanks() {
+    // A snapshot holding an eligible built-in mic must NOT make an incompatible
+    // bind compatible. Ranking belongs to cold opens only.
+    let spy = SnapshotSpy(
+      .success([
+        candidate(55, "builtin", kAudioDeviceTransportTypeBuiltIn),
+        candidate(56, "usb", kAudioDeviceTransportTypeUSB),
+      ]))
+
+    #expect(
+      !warmCompatible(
+        bind(30, .systemDefault), preferredUID: "airpods", defaultID: nil, spy: spy))
+  }
+
+  // MARK: - The per-device failure-vs-empty distinction (whole-diff review)
+
+  @Test("a snapshot that FAILED per-device reads never reaches the no-microphone sentence")
+  func perDeviceReadFailureIsUncertainty() {
+    // Found by the independent whole-diff review. `inputChannelCount(for:)`
+    // returns 0 for BOTH "this device has no input streams" and "the property
+    // read failed", so a device whose read failed used to be dropped silently.
+    // If it were the only microphone, the snapshot came back SUCCESSFULLY EMPTY
+    // and this resolver would call that proof of absence — the same
+    // failure-vs-empty conflation the snapshot type exists to prevent, one level
+    // down. The enumerator now returns `.readFailed` instead, which lands here.
+    let result = resolve(defaultID: nil, snapshot: .readFailed)
+
+    #expect(isNoMicrophoneFound(result.thrownError) == false, "never claim absence on a failed read")
+    #expect(diagnosticSource(result.thrownError) == "InputDeviceResolver.enumerate_input_devices")
+    #expect(result.enumerationOutcome == .readFailed)
+    // Counts stay unknown rather than zero: 0 would read as an empty machine.
+    #expect(result.inputDeviceCount == nil)
+    #expect(result.eligibleDeviceCount == nil)
+  }
+
+  // MARK: - Error identity helpers
+
+  private func isNoMicrophoneFound(_ error: AudioError?) -> Bool {
+    if case .noBuiltInMicrophoneFound = error { return true }
+    return false
+  }
+
+  private func diagnosticSource(_ error: AudioError?) -> String? {
+    error?.diagnosticSource
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/TransportLabelParityTests.swift
+++ b/Tests/EnviousWisprTests/Audio/TransportLabelParityTests.swift
@@ -27,7 +27,13 @@ struct TransportLabelParityTests {
       (kAudioDeviceTransportTypePCI, "pci"),
       (kAudioDeviceTransportTypeFireWire, "fire_wire"),
       (kAudioDeviceTransportTypeThunderbolt, "thunderbolt"),
+      // #1714 founder decision 2026-07-30: these three are ACCEPTED by the
+      // capture allow-list, so they must not report as `unknown`.
+      (kAudioDeviceTransportTypeContinuityCaptureWired, "continuity_capture_wired"),
+      (kAudioDeviceTransportTypeContinuityCaptureWireless, "continuity_capture_wireless"),
+      (kAudioDeviceTransportTypeAVB, "avb"),
     ]
+    #expect(cases.count == 15, "the frozen table must cover every named transport")
     for (raw, expected) in cases {
       #expect(AudioDeviceEnumerator.transportLabel(forTransportType: raw) == expected)
     }
@@ -41,5 +47,28 @@ struct TransportLabelParityTests {
   @Test("an unmapped transport constant falls back to unknown, not nil")
   func unknownFallback() {
     #expect(AudioDeviceEnumerator.transportLabel(forTransportType: 0xFFFF_FFFF) == "unknown")
+  }
+}
+
+// #1714 whole-diff review: the per-device channel-count read has the same
+// failure-vs-empty split as the transport read above. `inputChannelCountRaw`
+// preserves it; `inputChannelCount` deliberately collapses it for the settings
+// picker and bind-time telemetry, whose behaviour must not change.
+@Suite("input channel count — failure vs empty (#1714)")
+struct InputChannelCountNilPreservationTests {
+
+  @Test("the collapsing wrapper is defined as the raw value or zero")
+  func collapsingWrapperMatchesRaw() {
+    // Both read the same live device id. The point is not the number — it is
+    // that the collapsing form never returns nil and the raw form is what the
+    // capture snapshot consumes. A device id no machine assigns exercises the
+    // failure path without depending on this machine's hardware.
+    let absentDeviceID: AudioDeviceID = 0xFFFF_FFFE
+
+    let raw = AudioDeviceEnumerator.inputChannelCountRaw(for: absentDeviceID)
+    let collapsed = AudioDeviceEnumerator.inputChannelCount(for: absentDeviceID)
+
+    #expect(raw == nil, "a failed read must be nil, not zero")
+    #expect(collapsed == 0, "the collapsing wrapper preserves today's behaviour for its callers")
   }
 }

--- a/Tests/EnviousWisprTests/Audio/ZeroSignalDeviceIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Audio/ZeroSignalDeviceIdentityTests.swift
@@ -25,7 +25,8 @@ struct ZeroSignalDeviceIdentityTests {
   private static let bound = BoundInputDevice(
     deviceID: 121,
     deviceUID: "BC-87-FA-9C-7E-71:input",
-    transportLabel: "bluetooth"
+    transportLabel: "bluetooth",
+    resolutionSource: "system_default"
   )
 
   /// Counts hardware classifications so a test can prove a guard short-circuited
@@ -128,7 +129,8 @@ struct ZeroSignalDeviceIdentityTests {
   func nilUIDAtBindRefuses() {
     let counter = ReadCounter()
     let bindWithoutUID = BoundInputDevice(
-      deviceID: 121, deviceUID: nil, transportLabel: "bluetooth")
+      deviceID: 121, deviceUID: nil, transportLabel: "bluetooth",
+      resolutionSource: "system_default")
 
     let eligible = Self.evaluate(bound: bindWithoutUID, counter: counter)
 
@@ -251,7 +253,8 @@ struct ZeroSignalDeviceIdentityTests {
   @Test("#1578: isEligible equals classify == .eligible for every non-nil outcome")
   func booleanWrapperMatchesClassificationForEveryOutcome() {
     let bindWithoutUID = BoundInputDevice(
-      deviceID: 121, deviceUID: nil, transportLabel: "bluetooth")
+      deviceID: 121, deviceUID: nil, transportLabel: "bluetooth",
+      resolutionSource: "system_default")
 
     // (bind, uidNow, liveness, mute) → the outcome each row is here to cover.
     let rows: [(BoundInputDevice, String??, DeviceLiveness, DeviceMuteState)] = [

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -43,6 +43,65 @@ struct AudioCaptureFailureExtrasTests {
     #expect(extras["backend"] as? String == "whisperKit")
   }
 
+  // MARK: - #1714 input-resolution attribution
+
+  @Test("a capture-start failure carries the input resolution source")
+  func failureCarriesInputResolutionSource() {
+    // The failing population is the point: a fix whose own failures are
+    // unattributable cannot be measured.
+    let capture = ExtrasAudioCapture()
+    capture.currentInputResolutionSource = "list_fallback"
+
+    let extras = AudioCaptureFailureExtras.build(
+      error: AudioError.noBuiltInMicrophoneFound,
+      audioCapture: capture,
+      failureMode: "no_microphone_found"
+    )
+
+    #expect(extras["capture.input_resolution_source"] as? String == "list_fallback")
+  }
+
+  @Test("nil input resolution OMITS the key entirely")
+  func nilInputResolutionOmitsKey() {
+    // Not NSNull, not "unknown", not an empty string — absent.
+    let extras = AudioCaptureFailureExtras.build(
+      error: AudioError.noBuiltInMicrophoneFound,
+      audioCapture: ExtrasAudioCapture(),
+      failureMode: "no_microphone_found"
+    )
+
+    #expect(extras["capture.input_resolution_source"] == nil)
+    #expect(extras.keys.contains("capture.input_resolution_source") == false)
+  }
+
+  @Test("input and ROUTE resolution sources coexist with distinct values")
+  func inputAndRouteResolutionSourcesCoexist() {
+    // These two keys look alike and mean different things: one is WHY the input
+    // device was selected, the other is how a TRANSPORT LABEL was derived.
+    // Proving they coexist with different values is what stops a future reader
+    // collapsing them.
+    let capture = ExtrasAudioCapture()
+    capture.currentInputResolutionSource = "list_fallback"
+    capture.currentResolvedRoute = ResolvedRouteTransports(
+      selected: "built_in",
+      effective: "built_in",
+      routeReason: "automatic",
+      routeFallbackReason: nil,
+      inputSelectionMode: "automatic",
+      outputTransport: "built_in",
+      routeResolutionSource: "app_derived"
+    )
+
+    let extras = AudioCaptureFailureExtras.build(
+      error: AudioError.noBuiltInMicrophoneFound,
+      audioCapture: capture,
+      failureMode: "no_microphone_found"
+    )
+
+    #expect(extras["capture.input_resolution_source"] as? String == "list_fallback")
+    #expect(extras["capture.route_resolution_source"] as? String == "app_derived")
+  }
+
   @Test("audio error keeps user-facing message stable")
   func audioErrorMessageStable() {
     let error = AudioError.formatCreationFailed(source: "unit.test")
@@ -62,6 +121,9 @@ private final class ExtrasAudioCapture: AudioCaptureInterface {
   var capturedSamples: [Float] = []
   var currentAudioRoute: String = "built_in_mic"
   var currentResolvedRoute: ResolvedRouteTransports? = nil
+  /// #1714: the fake overrides the interface's `nil` default so a test can
+  /// script attribution the builder must carry through.
+  var currentInputResolutionSource: String? = nil
   var onBufferCaptured: (@Sendable (AVAudioPCMBuffer) -> Void)?
   var onEngineInterrupted: ((EngineInterruptionCause) -> Void)?
   var onVADAutoStop: (() -> Void)?

--- a/Tests/EnviousWisprTests/Pipeline/KernelFrozenBindGuardTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFrozenBindGuardTests.swift
@@ -38,7 +38,8 @@ struct KernelFrozenBindGuardTests {
   private static let syntheticBind = BoundInputDevice(
     deviceID: 121,
     deviceUID: "synthetic-uid-no-real-device-carries-this",
-    transportLabel: "bluetooth"
+    transportLabel: "bluetooth",
+    resolutionSource: "system_default"
   )
 
   private struct Context {
@@ -91,7 +92,9 @@ struct KernelFrozenBindGuardTests {
       else { continue }
       // `AudioInputDevice.uid` is already public, so this needs no `@testable`
       // widening of `AudioDeviceEnumerator.inputDeviceUID(for:)`, which is internal.
-      return BoundInputDevice(deviceID: device.id, deviceUID: device.uid, transportLabel: nil)
+      return BoundInputDevice(
+        deviceID: device.id, deviceUID: device.uid, transportLabel: nil,
+        resolutionSource: "system_default")
     }
     return nil
   }

--- a/Tests/EnviousWisprTests/Pipeline/KernelInputResolutionFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelInputResolutionFreezeTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - #1714 kernel input-resolution freeze
+//
+// The kernel freezes WHY the final engine-start attempt's microphone was chosen,
+// so a take can be attributed after it completes OR after it fails. The failing
+// population is the whole point: #1714 exists because 226 recordings across 19
+// installs aborted at start, and a fix whose own failures are unattributable
+// cannot be measured.
+//
+// LAST-WINS across the one permitted rebuild retry. That is not the terminal
+// first-wins rule — that one decides which competing OUTCOME owns the session;
+// this is an attempt fact updated through the controlled retry before any
+// terminal is published.
+//
+// Hardware-free: every value is scripted on `FakeAudioCapture`, which only
+// publishes what the interface would report per attempt and never decides when
+// the kernel reads it.
+@MainActor
+@Suite("RecordingSessionKernel — #1714 input-resolution freeze")
+struct KernelInputResolutionFreezeTests {
+
+  private func makeWrapper() -> (FakeAudioCapture, KernelRecordingSession) {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    return (capture, wrapper)
+  }
+
+  private func startAndSettle(_ wrapper: KernelRecordingSession) async {
+    await wrapper.apply(.start)
+    await wrapper.drainReadyWork()
+  }
+
+  // MARK: 1 — the ordinary success path
+
+  @Test("a successful first engine-start attempt freezes its source")
+  func successfulFirstAttemptFreezes() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [true]
+    capture.inputResolutionSourcePerAttempt = ["system_default"]
+
+    await startAndSettle(wrapper)
+
+    #expect(capture.startEnginePhaseCallCount == 1, "no rebuild on a stable device")
+    #expect(wrapper.testKernel.lastInputResolutionSource == "system_default")
+  }
+
+  // MARK: 2 — the failing population this issue exists to measure
+
+  @Test("an initial engine-start FAILURE freezes its source before the terminal")
+  func initialFailureFreezesBeforeTerminal() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.inputResolutionSourcePerAttempt = ["list_fallback"]
+    capture.failEngineStart = true
+
+    await startAndSettle(wrapper)
+
+    // Asserted AFTER the kernel reached its failed terminal, not before the
+    // throw: a pre-throw assertion would prove the fake, not the freeze.
+    #expect(wrapper.testKernel.state == .idle, "the kernel must have finished a terminal")
+    #expect(wrapper.testKernel.lastInputResolutionSource == "list_fallback")
+  }
+
+  // MARK: 3-4 — last-wins across the single rebuild retry
+
+  @Test("a successful rebuild retry uses attempt 2's source, not attempt 1's")
+  func successfulRebuildUsesSecondAttempt() async {
+    let (capture, wrapper) = makeWrapper()
+    // Unstable device: one rebuild, so two engine-start attempts.
+    capture.stabilizationResults = [false, true]
+    // Two DISTINCT non-nil values, so last-wins cannot pass vacuously.
+    capture.inputResolutionSourcePerAttempt = ["system_default", "list_fallback"]
+
+    await startAndSettle(wrapper)
+
+    #expect(capture.startEnginePhaseCallCount == 2, "the rebuild retry must have run")
+    #expect(wrapper.testKernel.lastInputResolutionSource == "list_fallback")
+  }
+
+  @Test("a THROWING rebuild retry uses attempt 2's source before the failed terminal")
+  func throwingRebuildUsesSecondAttempt() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [false, true]
+    capture.inputResolutionSourcePerAttempt = ["system_default", "list_fallback"]
+    // Attempt 1 succeeds; the rebuild attempt throws.
+    capture.failEngineStartOnAttempt = 2
+
+    await startAndSettle(wrapper)
+
+    #expect(capture.startEnginePhaseCallCount == 2)
+    #expect(wrapper.testKernel.state == .idle)
+    #expect(
+      wrapper.testKernel.lastInputResolutionSource == "list_fallback",
+      "a retry that lands elsewhere must not file the failure against attempt 1's device")
+  }
+
+  // MARK: 5 — the final attempt's nil is what gets frozen
+
+  @Test("a final attempt reporting nil is frozen as nil")
+  func finalAttemptNilIsFrozen() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [false, true]
+    capture.inputResolutionSourcePerAttempt = ["system_default", nil]
+
+    await startAndSettle(wrapper)
+
+    // This proves PLACEMENT: the sole freeze reads attempt 2 after the retry.
+    // It cannot distinguish plain assignment from `??` today because exactly one
+    // of the three mutually exclusive freeze sites executes per session. An
+    // earlier name claimed it proved nil-OVERWRITE; it never did.
+    #expect(capture.startEnginePhaseCallCount == 2)
+    #expect(wrapper.testKernel.lastInputResolutionSource == nil)
+  }
+
+  // MARK: 6 — no cross-session bleed
+
+  @Test("a new session clears the prior frozen source")
+  func newSessionClearsPriorSource() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [true]
+    capture.inputResolutionSourcePerAttempt = ["list_fallback"]
+
+    await startAndSettle(wrapper)
+    #expect(wrapper.testKernel.lastInputResolutionSource == "list_fallback")
+
+    // Return to idle before starting again. `.start` on a still-recording
+    // kernel is a no-op, and an earlier draft of this test missed that — it
+    // asserted a "cleared" value that was really just session 1's, never
+    // overwritten because session 2 never ran.
+    await wrapper.apply(.stop)
+    await wrapper.drainReadyWork()
+    #expect(wrapper.testKernel.state == .idle, "session 1 must have finished")
+
+    // Park session 2 AFTER engine start publishes its new source but BEFORE the
+    // kernel's common success-path freeze. At that instant only
+    // `resetSessionState()` can explain a nil — a second draft asserted nil
+    // after the freeze had already written one, so deleting the reset entirely
+    // would still have passed.
+    capture.stabilizationResults = [true, true]
+    capture.inputResolutionSourcePerAttempt = ["list_fallback", "pinned_uid"]
+    capture.gateStabilizationCall = 2
+
+    await wrapper.apply(.start)
+    await capture.awaitStabilizationGateReached()
+
+    #expect(capture.startEnginePhaseCallCount == 2, "session 2 must have run engine start")
+    #expect(capture.currentInputResolutionSource == "pinned_uid")
+    #expect(
+      wrapper.testKernel.lastInputResolutionSource == nil,
+      "resetSessionState must clear session 1 before session 2 reaches its final freeze")
+
+    capture.releaseStabilizationGate()
+    await wrapper.drainReadyWork()
+
+    #expect(wrapper.testKernel.lastInputResolutionSource == "pinned_uid")
+  }
+
+  // MARK: 7 — a stop immediately after startup still keeps the frozen source
+
+  @Test("stop right after successful engine startup leaves the source frozen")
+  func stopAfterStartupKeepsFrozenSource() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [true]
+    capture.inputResolutionSourcePerAttempt = ["pinned_uid"]
+
+    await startAndSettle(wrapper)
+    await wrapper.apply(.stop)
+    await wrapper.drainReadyWork()
+
+    #expect(wrapper.testKernel.lastInputResolutionSource == "pinned_uid")
+  }
+
+  // MARK: 8 — the route freeze is independent
+
+  @Test("the route freeze remains independent of input-resolution freezing")
+  func routeFreezeIsIndependent() async {
+    let (capture, wrapper) = makeWrapper()
+    capture.stabilizationResults = [true]
+    capture.inputResolutionSourcePerAttempt = ["list_fallback"]
+
+    await startAndSettle(wrapper)
+
+    // The fake reports no resolved route, so route attribution stays nil while
+    // input attribution is populated. Two separate facts, two separate freezes.
+    #expect(wrapper.testKernel.lastInputResolutionSource == "list_fallback")
+    #expect(wrapper.testKernel.lastResolvedRoute == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -107,6 +107,23 @@ final class FakeAudioCapture: AudioCaptureInterface {
   var routeOverride: String = "fake"
   var currentAudioRoute: String { routeOverride }
   var currentResolvedRoute: ResolvedRouteTransports? { nil }
+
+  // MARK: #1714 — scripted input-resolution attribution
+  //
+  // The fake only PUBLISHES what the interface would report at each attempt; it
+  // never decides when the kernel reads or freezes. Keeping that decision solely
+  // in the kernel is what makes the freeze tests meaningful.
+
+  /// What `currentInputResolutionSource` reports, per `startEnginePhase()`
+  /// attempt, 1-indexed. A shorter list means later attempts reuse the last
+  /// entry; an explicit `nil` entry models an attempt with no attribution.
+  var inputResolutionSourcePerAttempt: [String?] = []
+  private(set) var currentInputResolutionSource: String?
+
+  /// When set, that 1-indexed attempt throws `engineStartFailed`, so the retry
+  /// and failing-terminal paths are reachable without `failEngineStart`
+  /// failing every attempt.
+  var failEngineStartOnAttempt: Int?
   private(set) var currentCaptureSessionID: UInt64 = 0
   var isActivelyCapturing: Bool { isCapturing }
   var captureSourceType: String { "hal_device_input" }
@@ -182,8 +199,17 @@ final class FakeAudioCapture: AudioCaptureInterface {
 
   func startEnginePhase() async throws {
     startEnginePhaseCallCount += 1
+    // #1714: publish this attempt's attribution BEFORE any throw, the way the
+    // real manager stores it synchronously inside `prepare()`.
+    if !inputResolutionSourcePerAttempt.isEmpty {
+      let index = min(startEnginePhaseCallCount, inputResolutionSourcePerAttempt.count) - 1
+      currentInputResolutionSource = inputResolutionSourcePerAttempt[index]
+    }
     if permissionDenied { throw FakeCaptureError.permissionDenied }
     if failEngineStart { throw FakeCaptureError.engineStartFailed }
+    if failEngineStartOnAttempt == startEnginePhaseCallCount {
+      throw FakeCaptureError.engineStartFailed
+    }
   }
 
   func beginCapturePhase(recoveryPayload: Data?) async throws -> AsyncStream<AVAudioPCMBuffer> {

--- a/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
@@ -240,5 +240,43 @@ struct DictationCompletedRouteFieldsTests {
 
       #expect(box.event?.stringProps["asr_retry_outcome"] == nil)
     }
+
+    // MARK: - #1714 input resolution source
+
+    @Test("input and ROUTE resolution sources ride the SAME event with distinct values")
+    func inputAndRouteResolutionSourcesCoexist() {
+      // These two keys are one word apart and answer different questions. If a
+      // future edit ever collapses them, this is the test that fails.
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt",
+        routeResolutionSource: "app_derived",
+        inputResolutionSource: "list_fallback")
+
+      let props = box.event?.stringProps
+      #expect(props?["route_resolution_source"] == "app_derived")
+      #expect(props?["input_resolution_source"] == "list_fallback")
+      #expect(props?.keys.contains("resolution_source") == false)
+    }
+
+    @Test("dictation.completed omits the input resolution source when nil")
+    func inputResolutionSourceOmittedWhenNil() {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt")
+
+      #expect(box.event?.stringProps.keys.contains("input_resolution_source") == false)
+    }
+
   #endif
 }

--- a/Tests/EnviousWisprTests/Services/InputResolutionTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/InputResolutionTelemetryTests.swift
@@ -1,0 +1,177 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+// #1714 locks the `audio.input_resolution` event shape and the
+// `input_resolution_source` stamps on both terminal events.
+//
+// `route_resolution_source` answers how a transport label was derived.
+// `input_resolution_source` answers why the input device was selected.
+// `dictation.completed` can carry both, so its coexistence test freezes their
+// distinct names and values.
+//
+// `testEventHook` + `CapturedTelemetryEvent` are DEBUG-only, so this suite is
+// DEBUG-gated to compile under both flavors.
+@Suite("input resolution telemetry — #1714")
+@MainActor
+struct InputResolutionTelemetryTests {
+  #if DEBUG
+
+    private final class Box: @unchecked Sendable {
+      var event: CapturedTelemetryEvent?
+    }
+
+    private func capture(_ body: () -> Void) -> CapturedTelemetryEvent? {
+      let box = Box()
+      let previous = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = previous }
+      body()
+      return box.event
+    }
+
+    // MARK: - audio.input_resolution
+
+    @Test("the ordinary system-default cold attempt emits a complete event")
+    func systemDefaultAttemptEmits() {
+      let event = capture {
+        TelemetryService.shared.audioInputResolution(
+          defaultPresent: true,
+          enumerationOutcome: "not_attempted",
+          inputDeviceCount: nil,
+          eligibleDeviceCount: nil,
+          inputResolutionSource: "system_default",
+          selectedTransport: nil,
+          bindOutcome: "succeeded",
+          prepareOutcome: "succeeded"
+        )
+      }
+
+      #expect(event?.name == "audio.input_resolution")
+      #expect(event?.boolProps["default_present"] == true)
+      #expect(event?.stringProps["enumeration_outcome"] == "not_attempted")
+      #expect(event?.stringProps["input_resolution_source"] == "system_default")
+      #expect(event?.stringProps["bind_outcome"] == "succeeded")
+      #expect(event?.stringProps["prepare_outcome"] == "succeeded")
+    }
+
+    @Test("a nil count is OMITTED, never flattened to zero")
+    func nilCountsOmitted() {
+      // nil means NOT KNOWN — enumeration was skipped or its read failed.
+      // Emitting 0 would claim the machine listed no input devices, which is a
+      // different and much more alarming fact.
+      let event = capture {
+        TelemetryService.shared.audioInputResolution(
+          defaultPresent: true,
+          enumerationOutcome: "not_attempted",
+          inputDeviceCount: nil,
+          eligibleDeviceCount: nil,
+          inputResolutionSource: "system_default",
+          selectedTransport: nil,
+          bindOutcome: "succeeded",
+          prepareOutcome: "succeeded"
+        )
+      }
+
+      #expect(event?.intProps["input_device_count"] == nil)
+      #expect(event?.intProps.keys.contains("input_device_count") == false)
+      #expect(event?.intProps.keys.contains("eligible_device_count") == false)
+      #expect(event?.stringProps.keys.contains("selected_transport") == false)
+    }
+
+    @Test("an explicit ZERO count rides as zero")
+    func explicitZeroCountsEmitted() {
+      // The other half of the same distinction: a successful enumeration that
+      // genuinely found nothing must be visible as 0, not absent.
+      let event = capture {
+        TelemetryService.shared.audioInputResolution(
+          defaultPresent: false,
+          enumerationOutcome: "succeeded",
+          inputDeviceCount: 0,
+          eligibleDeviceCount: 0,
+          inputResolutionSource: nil,
+          selectedTransport: nil,
+          bindOutcome: "not_attempted",
+          prepareOutcome: "failed"
+        )
+      }
+
+      #expect(event?.intProps["input_device_count"] == 0)
+      #expect(event?.intProps["eligible_device_count"] == 0)
+      #expect(event?.boolProps["default_present"] == false)
+      // No device was selected, so there is nothing to attribute.
+      #expect(event?.stringProps.keys.contains("input_resolution_source") == false)
+    }
+
+    @Test("the fallback attempt carries every field")
+    func fallbackAttemptCarriesEverything() {
+      let event = capture {
+        TelemetryService.shared.audioInputResolution(
+          defaultPresent: false,
+          enumerationOutcome: "succeeded",
+          inputDeviceCount: 4,
+          eligibleDeviceCount: 1,
+          inputResolutionSource: "list_fallback",
+          selectedTransport: "built_in",
+          bindOutcome: "succeeded",
+          prepareOutcome: "succeeded"
+        )
+      }
+
+      #expect(event?.boolProps["default_present"] == false)
+      #expect(event?.intProps["input_device_count"] == 4)
+      #expect(event?.intProps["eligible_device_count"] == 1)
+      #expect(event?.stringProps["input_resolution_source"] == "list_fallback")
+      #expect(event?.stringProps["selected_transport"] == "built_in")
+    }
+
+    @Test("the event never carries the ambiguous name `resolution_source`")
+    func neverEmitsAmbiguousName() {
+      let event = capture {
+        TelemetryService.shared.audioInputResolution(
+          defaultPresent: true,
+          enumerationOutcome: "not_attempted",
+          inputDeviceCount: nil,
+          eligibleDeviceCount: nil,
+          inputResolutionSource: "system_default",
+          selectedTransport: nil,
+          bindOutcome: "succeeded",
+          prepareOutcome: "succeeded"
+        )
+      }
+
+      #expect(event?.stringProps.keys.contains("resolution_source") == false)
+      #expect(event?.stringProps.keys.contains("route_resolution_source") == false)
+    }
+
+    // MARK: - pipeline.failed
+
+    @Test("pipeline.failed carries the frozen input resolution source")
+    func pipelineFailedCarriesSource() {
+      let event = capture {
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error",
+          errorCode: "no_microphone_found", recoverable: false, backend: "parakeet",
+          inputResolutionSource: "list_fallback")
+      }
+
+      #expect(event?.name == "pipeline.failed")
+      #expect(event?.stringProps["input_resolution_source"] == "list_fallback")
+    }
+
+    @Test("pipeline.failed omits the key when attribution is unavailable")
+    func pipelineFailedOmitsNilSource() {
+      let event = capture {
+        TelemetryService.shared.pipelineFailed(
+          stage: "transcription", errorCategory: "pipeline_error",
+          errorCode: "no_microphone_found", recoverable: false, backend: "parakeet")
+      }
+
+      #expect(event?.stringProps.keys.contains("input_resolution_source") == false)
+    }
+  #endif
+}

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
@@ -200,4 +200,58 @@ struct SentryAudioExtrasTests {
     )
     #expect(extras["capture.time_since_last_successful_recording_ms"] as? Int == 45_000)
   }
+
+  // MARK: - #1714 input-resolution source
+
+  @Test("input resolution source rides under the settled capture. key")
+  func inputResolutionSourceEmitted() {
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in",
+      sourceType: "hal_device_input",
+      sessionID: 1,
+      isActivelyCapturing: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "no_microphone_found",
+      inputResolutionSource: "list_fallback"
+    )
+    #expect(extras["capture.input_resolution_source"] as? String == "list_fallback")
+  }
+
+  @Test("a nil input resolution source omits the key entirely")
+  func nilInputResolutionSourceOmitted() {
+    // Absent, not NSNull, not "unknown", not empty — an omitted key is what
+    // lets a query distinguish "no attribution" from "attributed as unknown".
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in",
+      sourceType: "hal_device_input",
+      sessionID: 1,
+      isActivelyCapturing: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "no_microphone_found"
+    )
+    #expect(extras["capture.input_resolution_source"] == nil)
+    #expect(extras.keys.contains("capture.input_resolution_source") == false)
+  }
+
+  @Test("input and ROUTE resolution sources are distinct keys carrying distinct values")
+  func inputAndRouteResolutionSourcesAreDistinct() {
+    // The two names are one word apart and answer different questions. Freezing
+    // them together is what stops a future edit collapsing them, which would
+    // make every query over either one ambiguous.
+    let extras = SentryAudioExtras.buildCaptureExtras(
+      route: "built_in",
+      sourceType: "hal_device_input",
+      sessionID: 1,
+      isActivelyCapturing: false,
+      inputDeviceUIDPreferred: nil,
+      inputDeviceUIDSystemDefault: nil,
+      failureMode: "no_microphone_found",
+      routeResolutionSource: "app_derived",
+      inputResolutionSource: "pinned_uid"
+    )
+    #expect(extras["capture.route_resolution_source"] as? String == "app_derived")
+    #expect(extras["capture.input_resolution_source"] as? String == "pinned_uid")
+  }
 }


### PR DESCRIPTION
Closes #1714

## Problem

Dictation aborted with "no built-in microphone found" whenever macOS momentarily reported no default input device. The old resolver asked CoreAudio exactly one question on Auto and threw when the answer was nil. 226 events across 19 installs in 90 days; 10 of those installs never completed a single dictation. Permission was ruled out (572 authorized vs 2 denied fleet-wide).

## Fix

A four-rung resolution ladder replaces the single question:

1. Pinned device UID, when the user has chosen one and it is present.
2. System default input device.
3. Allow-listed physical device from the enumerated list.
4. Honest failure, with the reason attributed.

Selection is an **allow-list** of 12 physical transports (BuiltIn, USB, Bluetooth, BluetoothLE, Continuity Capture wired/wireless, Thunderbolt, DisplayPort, HDMI, PCI, FireWire, AVB). A separate, deliberately narrow set (virtual + aggregate) is the only thing that proves absence — so an unknown transport is refused for selection without being counted as evidence that no microphone exists.

Every failed HAL read is preserved as uncertainty rather than collapsing to "nothing there": the device-list read, the per-device transport read, and the per-device channel-count read each distinguish failure from empty. A successful-but-empty snapshot is the only thing that produces the connect-a-microphone message.

### Founder decisions encoded

- **Read failure with a default present** selects the default rather than aborting. AirPods dying mid-session must fall back to auto; a connected-but-broken device must surface a real error.
- **A reconnected pinned device** takes priority immediately over a fallback bind on the next recording.
- **Transport labels are named properly** rather than bucketed as "other" — three new labels shipped.

## Telemetry

New `audio.input_resolution` event carries the source, outcome, enumeration outcome, whether a default was present, and device/eligible counts. `input_resolution_source` also rides `dictation.completed` and `pipeline.failed`, frozen at the cold-path exits so a warm reuse never overwrites it. No content crosses the network: counts, enum labels, and outcomes only.

## Validation

- 4,624 debug tests green (`Test run with 4445 tests in 422 suites passed` + `179 tests in 18 suites passed`), exit 0.
- 70 new tests across 6 new suites covering the ladder, warm-bind projection, kernel freeze semantics, telemetry mapping, and the debug fault seam.
- Chunked build: 7 chunks, each self-reviewed and driven to CHUNK-CLEAN in a persistent review session, plus an integration audit.
- Whole-diff review: 2 rounds. Round 1 found one real defect (a per-device channel-count read failure silently dropping the device, which could have produced the exact false "no microphone" this PR fixes). Round 2 returned an explicit all-clear.

### Live UAT on real hardware

Verified end to end on the dev build with the fault seam arming an absent default, confirmed via dev-environment telemetry:

| Time | default present | source | devices seen | eligible |
|---|---|---|---|---|
| 22:29:42 | yes | system_default | – | – |
| 22:31:46 | **no** | **list_fallback** | 3 | 1 |
| 22:32:41 | **no** | **list_fallback** | 3 | 1 |
| 22:33:41 | yes | system_default | – | – |

"3 seen, 1 eligible" is the allow-list refusing two virtual devices on real hardware. The bracketing rows are negative controls: the fallback does not run when a default is present.

## Known limit

The channel-count fix is covered by a test on the read functions themselves, not on the snapshot's use of them; a mutation control on the snapshot call site did not fail. Recorded rather than papered over.
