### PR TITLE
fix(test): make the corrector benchmark gate load-invariant

### DIFF
--- a/Tests/EnviousWisprTests/PostProcessing/ContactsImportCorrectorBenchmark.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ContactsImportCorrectorBenchmark.swift
@@ -19,12 +19,13 @@ struct ContactsImportCorrectorBenchmark {
     }
   }
 
-  @Test("Per-dictation correct(using:) stays well under the 3s step cap at +2000 terms")
+  @Test("Corrector cost grows no worse than linearly in vocabulary size")
   func latencyAtScale() {
     let sentence = "loop in Surnamenum1500 on the SSO thread before standup with the team"
     let sizes = [0, 500, 1000, 2000]
     let iterations = 8
     var maxPerCallMs = 0.0
+    var msBySize: [Int: Double] = [:]
 
     for size in sizes {
       let lookups = WordCorrector.buildLookups(words: personVocab(size))
@@ -35,14 +36,59 @@ struct ContactsImportCorrectorBenchmark {
       }
       let perCallMs = Date().timeIntervalSince(start) / Double(iterations) * 1000.0
       maxPerCallMs = max(maxPerCallMs, perCallMs)
+      msBySize[size] = perCallMs
       print(
         String(
           format: "[#636 corrector-latency] +%4d person terms: %.3f ms/dictation", size, perCallMs))
     }
 
-    // Step cap is 3000 ms; a regression would have to be ~3x before the user
-    // ever sees a graceful skip. 1500 ms floor is a catastrophic-regression
-    // backstop, not a measured bound.
-    #expect(maxPerCallMs < 1500.0)
+    // #1805 — the primary assertion is the GROWTH RATIO, not a wall-clock bound.
+    //
+    // The old assertion was `maxPerCallMs < 1500`, an absolute wall-clock bound
+    // on a machine shared with ~4300 parallel tests. It went red on unmodified
+    // main at 2836 ms while a heavily loaded machine (concurrent Codex reviews
+    // and Xcode builds) ran the suite, then passed on every rerun — a false
+    // alarm that cost a session and this issue.
+    //
+    // A ratio cannot be inflated by machine load: contention scales both
+    // buckets together, so it divides out. Measured, rather than assumed:
+    //
+    //   idle, 10 paired samples   ratio 2000/500 = 2.85 … 3.93 (median 3.77)
+    //   4 further idle runs                       3.55, 4.21, 4.41
+    //   14-core busy-loop load                    3.65  (inside the idle range)
+    //   inside a full 4346-test suite run         3.87
+    //
+    // 14 samples, full range 2.85 … 4.41. 4x the terms costs ~4x the time, i.e.
+    // this is linear. The threshold of 8 sits at ~1.8x the worst observed ratio
+    // and at half of the 16x an O(n^2) regression would produce, so it
+    // discriminates the thing the gate exists for while staying unreachable by
+    // contention. If a future run ever lands near 8 on unmodified main, widen
+    // the sweep instead of nudging the bar — a drifting ratio IS the signal.
+    let baseline = msBySize[500] ?? 0
+    let atScale = msBySize[2000] ?? 0
+    if baseline > 0 {
+      let growth = atScale / baseline
+      print(String(format: "[#636 corrector-latency] growth 2000/500: %.2fx (bar: 8.0x)", growth))
+      #expect(
+        growth < 8.0,
+        """
+        Corrector cost grew \(String(format: "%.2f", growth))x for 4x the vocabulary. \
+        Worst measured is 3.93x; 16x would mean quadratic. This ratio is immune to \
+        machine load, so a failure here is an algorithmic regression, not contention.
+        """)
+    }
+
+    // Secondary net ONLY. A uniform constant-factor blowup leaves the ratio
+    // unchanged, so one absolute bound is still needed — but set where load
+    // cannot reach it. Worst ever observed is 3132 ms, on the pathological
+    // machine that produced this issue; everything reproducible sits under
+    // 550 ms. 10 s catches a ~20x constant-factor regression and nothing else.
+    //
+    // NOTE: this is deliberately NOT the 3000 ms WordCorrectionStep cap. Whether
+    // a real user with a very large address book can approach that cap is a
+    // PRODUCT question and is tracked separately; a load-sensitive test on a
+    // shared machine cannot police it, and pretending otherwise is what made
+    // this gate flaky in the first place.
+    #expect(maxPerCallMs < 10000.0)
   }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/ContactsImportCorrectorBenchmark.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/ContactsImportCorrectorBenchmark.swift
@@ -53,28 +53,61 @@ struct ContactsImportCorrectorBenchmark {
     // A ratio cannot be inflated by machine load: contention scales both
     // buckets together, so it divides out. Measured, rather than assumed:
     //
-    //   idle, 10 paired samples   ratio 2000/500 = 2.85 … 3.93 (median 3.77)
-    //   4 further idle runs                       3.55, 4.21, 4.41
-    //   14-core busy-loop load                    3.65  (inside the idle range)
-    //   inside a full 4346-test suite run         3.87
+    // Sequentially-measured buckets (the sweep above) span 2.85 … 4.41 across 14
+    // samples. TIME-ADJACENT pairs, measured below, are tighter because load
+    // that starts or stops between two distant measurements no longer leaks in:
     //
-    // 14 samples, full range 2.85 … 4.41. 4x the terms costs ~4x the time, i.e.
-    // this is linear. The threshold of 8 sits at ~1.8x the worst observed ratio
-    // and at half of the 16x an O(n^2) regression would produce, so it
-    // discriminates the thing the gate exists for while staying unreachable by
-    // contention. If a future run ever lands near 8 on unmodified main, widen
-    // the sweep instead of nudging the bar — a drifting ratio IS the signal.
-    let baseline = msBySize[500] ?? 0
-    let atScale = msBySize[2000] ?? 0
-    if baseline > 0 {
-      let growth = atScale / baseline
-      print(String(format: "[#636 corrector-latency] growth 2000/500: %.2fx (bar: 8.0x)", growth))
+    //   idle                    median 3.84  (min 3.29, max 4.13, n=9)
+    //   14-core busy-loop load  median 3.62  (min 2.82, max 3.97, n=9)
+    //
+    // The loaded run took 28 s against 13 s idle, so the contention was real and
+    // the ratio still held. 4x the terms costs ~4x the time: linear. The
+    // threshold of 8 sits at ~2x the worst paired ratio and at half of the 16x
+    // an O(n^2) regression would produce, so it discriminates the thing the gate
+    // exists for while staying unreachable by contention. If a future run ever
+    // lands near 8 on unmodified main, widen the sample count instead of nudging
+    // the bar — a drifting ratio IS the signal.
+    // The two buckets above are measured SEQUENTIALLY, so load that starts or
+    // stops between them does NOT divide out — a quiet 500-term measurement
+    // followed by a contended 2000-term one inflates the ratio for reasons that
+    // have nothing to do with the algorithm. Pair them in time instead:
+    // alternate the two sizes round by round and take the MEDIAN ratio, so a
+    // contention spike has to land on the same phase of most rounds to matter.
+    let lookups500 = WordCorrector.buildLookups(words: personVocab(500))
+    let lookups2000 = WordCorrector.buildLookups(words: personVocab(2000))
+    _ = WordCorrector().correct(sentence, using: lookups500)  // warm
+    _ = WordCorrector().correct(sentence, using: lookups2000)  // warm
+
+    func timeOne(_ lookups: WordCorrector.Lookups) -> Double {
+      let start = Date()
+      _ = WordCorrector().correct(sentence, using: lookups)
+      return Date().timeIntervalSince(start) * 1000.0
+    }
+
+    var pairedRatios: [Double] = []
+    for _ in 0..<9 {
+      // Adjacent in time, so both see the same machine.
+      let small = timeOne(lookups500)
+      let large = timeOne(lookups2000)
+      if small > 0 { pairedRatios.append(large / small) }
+    }
+
+    if !pairedRatios.isEmpty {
+      let sorted = pairedRatios.sorted()
+      let growth = sorted[sorted.count / 2]
+      print(
+        String(
+          format: "[#636 corrector-latency] paired growth 2000/500: median %.2fx "
+            + "(min %.2f, max %.2f, n=%d, bar 8.0x)",
+          growth, sorted[0], sorted[sorted.count - 1], sorted.count))
       #expect(
         growth < 8.0,
         """
-        Corrector cost grew \(String(format: "%.2f", growth))x for 4x the vocabulary. \
-        Worst measured is 3.93x; 16x would mean quadratic. This ratio is immune to \
-        machine load, so a failure here is an algorithmic regression, not contention.
+        Corrector cost grew \(String(format: "%.2f", growth))x for 4x the vocabulary \
+        (median of \(sorted.count) time-adjacent pairs). Worst measured on healthy \
+        code is 4.41x; 16x would mean quadratic. Pairing the samples in time is what \
+        makes this robust to contention, so a failure here is an algorithmic \
+        regression rather than a busy machine.
         """)
     }
 


### PR DESCRIPTION
## What

`ContactsImportCorrectorBenchmark` asserted an **absolute wall-clock bound** (`maxPerCallMs < 1500`) on a machine running ~4,300 tests in parallel. It went red on **unmodified main** at 2,836 ms while the machine was also running Codex reviews and Xcode builds, then passed on every rerun.

## I measured before changing anything

"Flaky gate" and "real latency problem" look identical from one red run, and 2,836 ms against a live 3,000 ms `WordCorrectionStep` cap would have been a product problem, not a test problem.

| condition | 2000 terms | ratio 2000/500 |
|---|---|---|
| idle, 10 samples | 373 – 544 ms (median 390) | 2.85 – 3.93 |
| 14-core busy-loop load | 446 ms | 3.65 |
| inside a full 4,346-test suite run | 382 ms | 3.87 |

**The failure is not reproducible in any condition I could construct.** Every measurement sits 3–4x under the old bar. The reported 2,836 ms needed a pathological machine state.

## Fix

Assert the **growth ratio**, which contention cannot inflate — load scales both buckets together, so it divides out. That is verified, not assumed: the ratio under 14-core load (3.65) lands inside the idle range, as does the full-suite run (3.87).

Across 14 samples in all three conditions the ratio spans **2.85 – 4.41**. 4x the terms costs ~4x the time, so this is linear. The bar of 8 sits at ~1.8x the worst observed and at half the 16x an O(n²) regression would produce.

A ratio alone would miss a uniform constant-factor blowup, so one absolute bound remains as a **secondary net at 10 s**, where load cannot reach it (worst ever observed anywhere is 3,132 ms).

That bound is deliberately **not** the 3,000 ms product cap. Whether a real user with a very large address book can approach that cap is a product question — filed separately as #1865 with the measured distribution. A load-sensitive test on a shared machine cannot police it, and pretending it could is what made this gate flaky.

## Controls

- **Two-way:** dropping the bar to 3.0 turns the test red on the real measurement (3.55x observed), so the assertion is live and reads real data rather than passing vacuously.
- Full suite: **4,344 tests in 414 suites passed**, plus 179 in 18 suites.
- `scripts/build-dev-app.sh` succeeded.

## One correction worth recording

An early single cold-start sample showed 6.05x growth and I read it as superlinear. Ten paired samples disproved that — the cold run was the outlier, not the signal. #1865 is filed with the corrected linear figure.

Test-only. No `Sources/` change.

**Lane:** Code

Closes #1805
