### PR TITLE
fix(core): buffer log lines written before the file sink opens

### DIFF
--- a/Sources/EnviousWisprCore/AppLogger.swift
+++ b/Sources/EnviousWisprCore/AppLogger.swift
@@ -95,9 +95,10 @@ public actor AppLogger {
     #if DEBUG
       if enabled {
         openFileHandleIfNeeded()
-        // #1361: flush BEFORE the marker so the launch-window lines keep their
-        // real timestamps and stay in ascending order. `isDebugModeEnabled` is
-        // already true above, so nothing written from here re-enters the buffer.
+        // #1361: flush BEFORE the "Debug mode enabled" marker so the launch
+        // window's lines, which are older, appear above it and every timestamp
+        // in the file ascends. `isDebugModeEnabled` is already true above, so
+        // nothing written from here re-enters the buffer.
         flushPendingLines()
         hasAppliedInitialDebugMode = true
         log("Debug mode enabled", level: .info, category: "AppLogger")
@@ -192,18 +193,28 @@ public actor AppLogger {
       pendingDroppedCount = 0
       guard !pending.isEmpty || dropped > 0 else { return }
 
-      let now = timestampFormatter.string(from: Date())
-      writeRendered(
-        timestamp: now, level: .info, category: "AppLogger",
-        message:
-          "Flushing \(pending.count) line(s) buffered before the log file opened"
-          + (dropped > 0 ? "; \(dropped) older line(s) dropped at the \(maxPendingLines) cap" : "")
-          + " — the entries below carry their original timestamps and precede this one")
+      // Entries FIRST, marker after. Writing the marker first stamped it with
+      // `now` and then emitted older entries beneath it, so the file read
+      // now -> launch-time -> now and time ran BACKWARD — the opposite of what
+      // the comment claimed. Emitting the entries first keeps every timestamp in
+      // the file ascending, and the marker then reports what just happened
+      // rather than predicting it.
+      var written = 0
       for entry in pending where entry.level <= logLevel {
         writeRendered(
           timestamp: entry.timestamp, level: entry.level, category: entry.category,
           message: entry.message)
+        written += 1
       }
+
+      let filtered = pending.count - written
+      writeRendered(
+        timestamp: timestampFormatter.string(from: Date()), level: .info, category: "AppLogger",
+        message:
+          "The \(written) line(s) above were buffered before the log file opened and carry their "
+          + "original timestamps"
+          + (filtered > 0 ? "; \(filtered) more were below the current log level" : "")
+          + (dropped > 0 ? "; \(dropped) older line(s) dropped at the \(maxPendingLines) cap" : ""))
     }
 
     private func writeToFile(_ data: Data) {

--- a/Sources/EnviousWisprCore/AppLogger.swift
+++ b/Sources/EnviousWisprCore/AppLogger.swift
@@ -187,6 +187,15 @@ public actor AppLogger {
     }
 
     private func flushPendingLines() {
+      // RETAIN if the sink did not actually open. `openFileHandleIfNeeded` fails
+      // silently on a directory-creation or permission error, leaving
+      // `fileHandle` nil — and `writeToFile` then drops every line on the floor.
+      // Clearing the buffer first would destroy exactly the launch-window
+      // diagnostics this whole change exists to preserve, and destroy them for
+      // the one user whose machine is having a problem. Holding them costs
+      // nothing and a later successful open still flushes.
+      guard fileHandle != nil else { return }
+
       let pending = pendingLines
       let dropped = pendingDroppedCount
       pendingLines = []

--- a/Sources/EnviousWisprCore/AppLogger.swift
+++ b/Sources/EnviousWisprCore/AppLogger.swift
@@ -47,6 +47,45 @@ public actor AppLogger {
     }
     private var currentLogURL: URL { logDirectory.appendingPathComponent("app.log") }
     private var fileHandle: FileHandle?
+
+    // MARK: Pre-sink buffer (#1361)
+    //
+    // Lines logged BEFORE the file sink is enabled used to vanish. The cause is
+    // not a FileHandle race (the issue's original guess) but the plain
+    // `isDebugModeEnabled` guard in `log(...)`: that flag is false until
+    // `PipelineSettingsSync.applyInitialSettings` calls `setDebugMode(true)`,
+    // so everything emitted earlier in launch reached OSLog and nothing else.
+    // A launch-window `finishFailed` never made it to app.log while the
+    // IDENTICAL call at press-time did, and that cost about an hour chasing a
+    // phantom warmup wedge. Same family as #728, which seeded debug mode at
+    // launch; this closes the window that still precedes the seeding.
+    //
+    // Entries are buffered unrendered so the level filter is applied at FLUSH
+    // time against the log level that is actually in force by then, while the
+    // timestamp is captured at LOG time so the flushed lines stay in true
+    // chronological order.
+    private struct PendingLine {
+      let timestamp: String
+      let level: DebugLogLevel
+      let category: String
+      let message: String
+    }
+    private var pendingLines: [PendingLine] = []
+    private var pendingDroppedCount = 0
+    /// The window is EXACTLY "before the persisted debug setting has been
+    /// applied", which is the whole of the bug and nothing more. It closes on
+    /// the first `setDebugMode` call in either direction — that call is
+    /// `PipelineSettingsSync.applyInitialSettings` at launch.
+    ///
+    /// Closing on `false` too is what keeps this free in steady state. Keying it
+    /// on "has never been ENABLED" instead meant that in the overwhelmingly
+    /// common case — a DEBUG build with debug mode off — every one of the ~148
+    /// log call sites would format a timestamp and allocate, forever, for output
+    /// that can never be flushed. Worse, past the cap each further call paid an
+    /// O(n) `removeFirst` on a 500-element array. Neither cost is acceptable to
+    /// buy a launch-window diagnostic.
+    private var hasAppliedInitialDebugMode = false
+    private let maxPendingLines = 500
   #endif
 
   private init() {}
@@ -56,8 +95,19 @@ public actor AppLogger {
     #if DEBUG
       if enabled {
         openFileHandleIfNeeded()
+        // #1361: flush BEFORE the marker so the launch-window lines keep their
+        // real timestamps and stay in ascending order. `isDebugModeEnabled` is
+        // already true above, so nothing written from here re-enters the buffer.
+        flushPendingLines()
+        hasAppliedInitialDebugMode = true
         log("Debug mode enabled", level: .info, category: "AppLogger")
       } else {
+        // #1361: the window closes here too. Debug logging is off, so nothing
+        // buffered can ever be written — discard it rather than hold it, and
+        // stop buffering from now on.
+        hasAppliedInitialDebugMode = true
+        pendingLines = []
+        pendingDroppedCount = 0
         log("Debug mode disabled", level: .info, category: "AppLogger")
         fileHandle?.closeFile()
         fileHandle = nil
@@ -77,13 +127,19 @@ public actor AppLogger {
       case .debug: oslog.debug("[\(category, privacy: .public)] \(message, privacy: .public)")
       }
 
-      guard isDebugModeEnabled, level <= logLevel else { return }
+      guard isDebugModeEnabled, level <= logLevel else {
+        // #1361: only the pre-sink window is buffered. A line rejected because
+        // debug mode is ON but the level is below the threshold is a deliberate
+        // filter, not a lost line, so it is NOT buffered.
+        if !isDebugModeEnabled, !hasAppliedInitialDebugMode {
+          bufferPreSink(level: level, category: category, message: message)
+        }
+        return
+      }
 
-      let timestamp = timestampFormatter.string(from: Date())
-      let line = "[\(timestamp)] [\(level.rawValue.uppercased())] [\(category)] \(message)\n"
-
-      guard let data = line.data(using: .utf8) else { return }
-      writeToFile(data)
+      writeRendered(
+        timestamp: timestampFormatter.string(from: Date()),
+        level: level, category: category, message: message)
     #endif
     // Release: no-op. The 148 call sites still pay the actor-hop cost of
     // `await AppLogger.shared.log(...)`; the privacy win is removing all sink
@@ -103,6 +159,51 @@ public actor AppLogger {
       }
       fileHandle = try? FileHandle(forWritingTo: currentLogURL)
       fileHandle?.seekToEndOfFile()
+    }
+
+    /// Single renderer for both the live path and the #1361 flush, so a format
+    /// change cannot apply to one and not the other.
+    private func writeRendered(
+      timestamp: String, level: DebugLogLevel, category: String, message: String
+    ) {
+      let line = "[\(timestamp)] [\(level.rawValue.uppercased())] [\(category)] \(message)\n"
+      guard let data = line.data(using: .utf8) else { return }
+      writeToFile(data)
+    }
+
+    private func bufferPreSink(level: DebugLogLevel, category: String, message: String) {
+      // Bounded: drop the OLDEST and count it, so a long run with debug mode
+      // never enabled cannot grow without limit. The count is reported at flush
+      // rather than silently swallowed.
+      if pendingLines.count >= maxPendingLines {
+        pendingLines.removeFirst()
+        pendingDroppedCount += 1
+      }
+      pendingLines.append(
+        PendingLine(
+          timestamp: timestampFormatter.string(from: Date()),
+          level: level, category: category, message: message))
+    }
+
+    private func flushPendingLines() {
+      let pending = pendingLines
+      let dropped = pendingDroppedCount
+      pendingLines = []
+      pendingDroppedCount = 0
+      guard !pending.isEmpty || dropped > 0 else { return }
+
+      let now = timestampFormatter.string(from: Date())
+      writeRendered(
+        timestamp: now, level: .info, category: "AppLogger",
+        message:
+          "Flushing \(pending.count) line(s) buffered before the log file opened"
+          + (dropped > 0 ? "; \(dropped) older line(s) dropped at the \(maxPendingLines) cap" : "")
+          + " — the entries below carry their original timestamps and precede this one")
+      for entry in pending where entry.level <= logLevel {
+        writeRendered(
+          timestamp: entry.timestamp, level: entry.level, category: entry.category,
+          message: entry.message)
+      }
     }
 
     private func writeToFile(_ data: Data) {
@@ -136,6 +237,22 @@ public actor AppLogger {
       openFileHandleIfNeeded()
     }
 
+  #endif
+
+  #if DEBUG
+    /// #1361 test seam. `AppLogger` is a singleton, so a suite that has already
+    /// applied a debug mode would leave `hasAppliedInitialDebugMode` latched and the
+    /// pre-sink window unreachable for the next test. `package` rather than
+    /// `internal` so tests reach it on a plain import, without coupling the seam
+    /// to `@testable`.
+    package func resetPreSinkBufferForTesting() {
+      pendingLines = []
+      pendingDroppedCount = 0
+      hasAppliedInitialDebugMode = false
+    }
+
+    /// Count of lines currently held in the pre-sink buffer (#1361 tests).
+    package var pendingPreSinkLineCount: Int { pendingLines.count }
   #endif
 
   // MARK: - Utilities

--- a/Tests/EnviousWisprTests/App/AppLoggerLaunchSyncTests.swift
+++ b/Tests/EnviousWisprTests/App/AppLoggerLaunchSyncTests.swift
@@ -27,6 +27,9 @@ struct AppLoggerLaunchSyncTests {
 
   @Test("applyInitialSettings seeds AppLogger debug mode + log level from persisted settings")
   func applyInitialSettingsSeedsAppLogger() async throws {
+    // Cross-suite exclusion on the AppLogger singleton (#1361). `.serialized`
+    // orders one suite only, and three suites toggle this global.
+    try await withAppLoggerExclusion {
     // Save prior AppLogger state so suite ordering does not leak.
     let priorMode = await AppLogger.shared.isDebugModeEnabled
     let priorLevel = await AppLogger.shared.logLevel
@@ -112,6 +115,7 @@ struct AppLoggerLaunchSyncTests {
       defaults.set(priorDebugLogLevel, forKey: "debugLogLevel")
     } else {
       defaults.removeObject(forKey: "debugLogLevel")
+    }
     }
   }
 }

--- a/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerCompileOutTests.swift
@@ -45,6 +45,9 @@ struct AppLoggerCompileOutTests {
 
     @Test("Debug build: log() emits the marker into the file sink")
     func debugBuildEmitsMarkerIntoFileSink() async throws {
+      // Three separate suites toggle the AppLogger singleton and Swift Testing
+      // runs suites in parallel; `.serialized` cannot span them (#1361).
+      try await withAppLoggerExclusion {
       let marker = Self.uniqueMarker("debug")
       let priorMode = await AppLogger.shared.isDebugModeEnabled
 
@@ -60,12 +63,15 @@ struct AppLoggerCompileOutTests {
       // Restore prior debug-mode state — never assume default false, so suite
       // ordering does not change behavior.
       await AppLogger.shared.setDebugMode(priorMode)
+      }
     }
 
   #else
 
     @Test("Release build: log() does NOT emit the marker (sink is dead code)")
     func releaseBuildSinkIsDeadCode() async throws {
+      // See the DEBUG case above: cross-suite exclusion, not `.serialized`.
+      try await withAppLoggerExclusion {
       let marker = Self.uniqueMarker("release")
       let priorMode = await AppLogger.shared.isDebugModeEnabled
       let url = Self.expectedLogURL
@@ -87,6 +93,7 @@ struct AppLoggerCompileOutTests {
       #expect(isEnabled == true)
 
       await AppLogger.shared.setDebugMode(priorMode)
+      }
     }
 
   #endif

--- a/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
@@ -44,14 +44,21 @@ import Testing
       do {
         try await body()
       } catch {
-        await AppLogger.shared.setDebugMode(priorMode)
-        await AppLogger.shared.setLogLevel(priorLevel)
-        await AppLogger.shared.resetPreSinkBufferForTesting()
+        await restore(mode: priorMode, level: priorLevel)
         throw error
       }
-      await AppLogger.shared.setDebugMode(priorMode)
-      await AppLogger.shared.setLogLevel(priorLevel)
+      await restore(mode: priorMode, level: priorLevel)
+    }
+
+    /// Reset FIRST, then re-apply the mode. The reverse order leaves the
+    /// pre-sink window OPEN: `resetPreSinkBufferForTesting` clears
+    /// `hasAppliedInitialDebugMode`, so running it after `setDebugMode` undoes
+    /// the latch that call just closed, and every later log line in the process
+    /// would start buffering again for output that can never be flushed.
+    private func restore(mode: Bool, level: DebugLogLevel) async {
       await AppLogger.shared.resetPreSinkBufferForTesting()
+      await AppLogger.shared.setLogLevel(level)
+      await AppLogger.shared.setDebugMode(mode)
     }
 
     /// Reads the live `app.log`. Missing or unreadable reads back as empty, so a
@@ -85,6 +92,34 @@ import Testing
         #expect(
           contents.contains("buffered before the log file opened"),
           "the flush must announce itself so the ordering is explainable")
+
+        // The flushed entry must appear ABOVE the notice that describes it, and
+        // above "Debug mode enabled". Writing the notice first stamped it with
+        // `now` and put older entries beneath it, so the file ran backward in
+        // time while a comment claimed it ascended.
+        //
+        // Scope the search to the text AFTER this run's unique marker. app.log
+        // is appended across every run, so a whole-file `range(of:)` finds a
+        // "Debug mode enabled" from some previous session and compares offsets
+        // from different runs — which is how the first version of this
+        // assertion failed against correct code.
+        guard let markerIdx = contents.range(of: marker) else {
+          Issue.record("the buffered line never reached app.log")
+          return
+        }
+        let afterMarker = contents[markerIdx.upperBound...]
+        guard let noticeIdx = afterMarker.range(of: "were buffered before the log file opened")
+        else {
+          Issue.record("the flush notice must follow the entries it describes")
+          return
+        }
+        guard let enabledIdx = afterMarker.range(of: "Debug mode enabled") else {
+          Issue.record("the debug-mode-enabled marker must follow the flush")
+          return
+        }
+        #expect(
+          noticeIdx.lowerBound < enabledIdx.lowerBound,
+          "the flush notice must precede the debug-mode-enabled marker")
       }
     }
 
@@ -167,7 +202,7 @@ import Testing
         await AppLogger.shared.setDebugMode(true)
         let contents = readLog()
         #expect(
-          contents.contains("older line(s) dropped at the 500 cap"),
+          contents.contains("dropped at the 500 cap"),
           "an overflowing buffer must say so rather than silently truncate")
         #expect(
           contents.contains("EW1361-bound-\(runID)-599"),

--- a/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
@@ -34,20 +34,26 @@ import Testing
     private func withRestoredLogger(
       _ body: () async throws -> Void
     ) async throws {
-      let priorMode = await AppLogger.shared.isDebugModeEnabled
-      let priorLevel = await AppLogger.shared.logLevel
+      // `.serialized` orders THIS suite only. AppLoggerLaunchSyncTests and
+      // AppLoggerCompileOutTests toggle the same singleton from their own
+      // suites, and nothing orders those against this one, so exclusion has to
+      // be explicit and process-wide.
+      try await withAppLoggerExclusion {
+        let priorMode = await AppLogger.shared.isDebugModeEnabled
+        let priorLevel = await AppLogger.shared.logLevel
 
-      await AppLogger.shared.setDebugMode(false)
-      await AppLogger.shared.resetPreSinkBufferForTesting()
+        await AppLogger.shared.setDebugMode(false)
+        await AppLogger.shared.resetPreSinkBufferForTesting()
 
-      // `defer` cannot await, so the restore is done on both exits explicitly.
-      do {
-        try await body()
-      } catch {
+        // `defer` cannot await, so the restore is done on both exits explicitly.
+        do {
+          try await body()
+        } catch {
+          await restore(mode: priorMode, level: priorLevel)
+          throw error
+        }
         await restore(mode: priorMode, level: priorLevel)
-        throw error
       }
-      await restore(mode: priorMode, level: priorLevel)
     }
 
     /// Reset FIRST, then re-apply the mode. The reverse order leaves the

--- a/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
@@ -15,25 +15,43 @@ import Testing
 /// and resets the latch through the `#if DEBUG` seam so the pre-sink window is
 /// reachable regardless of suite ordering.
 #if DEBUG
-  @Suite("AppLogger pre-sink buffer (#1361)")
+  /// `.serialized` is load-bearing, not tidiness. Swift Testing runs tests in
+  /// parallel by default and every case here mutates the ONE process-wide
+  /// `AppLogger.shared`. Run concurrently, a sibling enabling the sink midway
+  /// through `bufferIsBoundedAndHonest` would flush and empty the buffer under
+  /// it, and the count assertions would fail for a reason that has nothing to do
+  /// with the code under test. Serializing the suite is the only way these
+  /// assertions mean what they say.
+  @Suite("AppLogger pre-sink buffer (#1361)", .serialized)
   struct AppLoggerPreSinkBufferTests {
 
     /// Runs `body` with AppLogger returned to its prior state afterwards.
+    ///
+    /// Restoration is AWAITED, not fired into a detached `Task`. A `defer` that
+    /// only launches restoration returns before any of it lands, so the next
+    /// test could start against half-restored state and the developer's own
+    /// persisted debug mode could be left wrong after the run.
     private func withRestoredLogger(
       _ body: () async throws -> Void
-    ) async rethrows {
+    ) async throws {
       let priorMode = await AppLogger.shared.isDebugModeEnabled
       let priorLevel = await AppLogger.shared.logLevel
-      defer {
-        Task {
-          await AppLogger.shared.setDebugMode(priorMode)
-          await AppLogger.shared.setLogLevel(priorLevel)
-          await AppLogger.shared.resetPreSinkBufferForTesting()
-        }
-      }
+
       await AppLogger.shared.setDebugMode(false)
       await AppLogger.shared.resetPreSinkBufferForTesting()
-      try await body()
+
+      // `defer` cannot await, so the restore is done on both exits explicitly.
+      do {
+        try await body()
+      } catch {
+        await AppLogger.shared.setDebugMode(priorMode)
+        await AppLogger.shared.setLogLevel(priorLevel)
+        await AppLogger.shared.resetPreSinkBufferForTesting()
+        throw error
+      }
+      await AppLogger.shared.setDebugMode(priorMode)
+      await AppLogger.shared.setLogLevel(priorLevel)
+      await AppLogger.shared.resetPreSinkBufferForTesting()
     }
 
     /// Reads the live `app.log`. Missing or unreadable reads back as empty, so a

--- a/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerPreSinkBufferTests.swift
@@ -1,0 +1,163 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+/// #1361 — lines logged BEFORE the file sink opens used to vanish.
+///
+/// The cause is the `isDebugModeEnabled` guard in `AppLogger.log(...)`, not a
+/// FileHandle race: that flag stays false until `setDebugMode(true)` runs at
+/// launch, so everything emitted earlier reached OSLog and nothing else. A
+/// launch-window `finishFailed` never made it to `app.log` while the identical
+/// call at press-time did.
+///
+/// `AppLogger` is a process-wide singleton writing to the developer's real log
+/// directory, so every test here restores the prior debug mode and log level,
+/// and resets the latch through the `#if DEBUG` seam so the pre-sink window is
+/// reachable regardless of suite ordering.
+#if DEBUG
+  @Suite("AppLogger pre-sink buffer (#1361)")
+  struct AppLoggerPreSinkBufferTests {
+
+    /// Runs `body` with AppLogger returned to its prior state afterwards.
+    private func withRestoredLogger(
+      _ body: () async throws -> Void
+    ) async rethrows {
+      let priorMode = await AppLogger.shared.isDebugModeEnabled
+      let priorLevel = await AppLogger.shared.logLevel
+      defer {
+        Task {
+          await AppLogger.shared.setDebugMode(priorMode)
+          await AppLogger.shared.setLogLevel(priorLevel)
+          await AppLogger.shared.resetPreSinkBufferForTesting()
+        }
+      }
+      await AppLogger.shared.setDebugMode(false)
+      await AppLogger.shared.resetPreSinkBufferForTesting()
+      try await body()
+    }
+
+    /// Reads the live `app.log`. Missing or unreadable reads back as empty, so a
+    /// `contains` assertion fails loudly rather than throwing something unrelated.
+    private func readLog() -> String {
+      let url = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent("Logs/EnviousWispr", isDirectory: true)
+        .appendingPathComponent("app.log")
+      return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    }
+
+    @Test("a line logged before the sink opens survives and reaches the file")
+    func preSinkLineSurvives() async throws {
+      try await withRestoredLogger {
+        let marker = "EW1361-presink-\(UUID().uuidString)"
+
+        // Sink is OFF: this is the launch window that used to lose lines.
+        await AppLogger.shared.log(marker, level: .info, category: "AppLogger1361")
+
+        // Control: it is buffered, not written — nothing can have reached the
+        // file yet, so a later hit proves the FLUSH delivered it.
+        let buffered = await AppLogger.shared.pendingPreSinkLineCount
+        #expect(buffered >= 1, "the pre-sink line must be held, not dropped")
+
+        await AppLogger.shared.setDebugMode(true)
+
+        let contents = readLog()
+        #expect(
+          contents.contains(marker),
+          "the pre-sink line must reach app.log once the sink opens")
+        #expect(
+          contents.contains("buffered before the log file opened"),
+          "the flush must announce itself so the ordering is explainable")
+      }
+    }
+
+    @Test("a line rejected by the level filter is NOT buffered")
+    func levelFilteredLineIsNotBuffered() async throws {
+      try await withRestoredLogger {
+        // Sink ON at the default .info threshold: a .debug line is a deliberate
+        // filter, not a lost line. Buffering it would resurrect output the user
+        // asked not to have.
+        await AppLogger.shared.setDebugMode(true)
+        await AppLogger.shared.setLogLevel(.info)
+        let before = await AppLogger.shared.pendingPreSinkLineCount
+
+        await AppLogger.shared.log(
+          "EW1361-filtered-\(UUID().uuidString)", level: .debug, category: "AppLogger1361")
+
+        let after = await AppLogger.shared.pendingPreSinkLineCount
+        #expect(after == before, "a level-filtered line must never enter the pre-sink buffer")
+      }
+    }
+
+    @Test("after an explicit disable, lines are dropped rather than re-buffered")
+    func disableDoesNotReopenTheBuffer() async throws {
+      try await withRestoredLogger {
+        // Enable then disable: the user has asked logging to STOP. A later
+        // re-enable must not resurrect what was written in between.
+        await AppLogger.shared.setDebugMode(true)
+        await AppLogger.shared.setDebugMode(false)
+        let before = await AppLogger.shared.pendingPreSinkLineCount
+
+        await AppLogger.shared.log(
+          "EW1361-afterdisable-\(UUID().uuidString)", level: .info, category: "AppLogger1361")
+
+        let after = await AppLogger.shared.pendingPreSinkLineCount
+        #expect(
+          after == before,
+          "the buffer covers only the window before the initial setting is applied")
+      }
+    }
+
+    /// The steady-state cost guard. Applying a persisted `false` at launch is
+    /// the overwhelmingly common case in a DEBUG build, and it must CLOSE the
+    /// window — otherwise every one of the ~148 log call sites formats a
+    /// timestamp and allocates forever, for output that can never be flushed,
+    /// and past the cap pays an O(n) `removeFirst` per call on top.
+    @Test("applying a persisted OFF setting closes the window and frees the buffer")
+    func applyingDisabledClosesTheWindow() async throws {
+      try await withRestoredLogger {
+        // Pre-sink window is open: this line buffers.
+        await AppLogger.shared.log(
+          "EW1361-beforeapply-\(UUID().uuidString)", level: .info, category: "AppLogger1361")
+        let buffered = await AppLogger.shared.pendingPreSinkLineCount
+        #expect(buffered >= 1, "the window must be open before the setting is applied")
+
+        // Launch applies the persisted setting — and it is OFF.
+        await AppLogger.shared.setDebugMode(false)
+
+        let afterApply = await AppLogger.shared.pendingPreSinkLineCount
+        #expect(afterApply == 0, "an applied OFF must release the buffer, not hold it")
+
+        await AppLogger.shared.log(
+          "EW1361-steadystate-\(UUID().uuidString)", level: .info, category: "AppLogger1361")
+        let steady = await AppLogger.shared.pendingPreSinkLineCount
+        #expect(steady == 0, "no buffering may continue once the setting has been applied")
+      }
+    }
+
+    @Test("the buffer is bounded and reports what it dropped")
+    func bufferIsBoundedAndHonest() async throws {
+      try await withRestoredLogger {
+        // 600 > the 500 cap, so the oldest 100 must be dropped and counted.
+        let runID = UUID().uuidString
+        for i in 0..<600 {
+          await AppLogger.shared.log(
+            "EW1361-bound-\(runID)-\(i)", level: .info, category: "AppLogger1361")
+        }
+        let held = await AppLogger.shared.pendingPreSinkLineCount
+        #expect(held == 500, "the buffer must cap at 500, got \(held)")
+
+        await AppLogger.shared.setDebugMode(true)
+        let contents = readLog()
+        #expect(
+          contents.contains("older line(s) dropped at the 500 cap"),
+          "an overflowing buffer must say so rather than silently truncate")
+        #expect(
+          contents.contains("EW1361-bound-\(runID)-599"),
+          "the NEWEST line must survive the cap")
+        #expect(
+          !contents.contains("EW1361-bound-\(runID)-0 "),
+          "the OLDEST line is the one dropped")
+      }
+    }
+  }
+#endif

--- a/Tests/EnviousWisprTests/Core/AppLoggerTestExclusion.swift
+++ b/Tests/EnviousWisprTests/Core/AppLoggerTestExclusion.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Cross-SUITE exclusion for the process-wide `AppLogger.shared`.
+///
+/// `.serialized` orders tests within ONE suite and nothing more, but three
+/// separate suites toggle this singleton — `AppLoggerPreSinkBufferTests`,
+/// `AppLoggerLaunchSyncTests`, and `AppLoggerCompileOutTests`. Under the default
+/// parallel run they interleave at every `await`, so one suite enabling the sink
+/// can flush and empty another's pre-sink buffer, or restore a debug mode out
+/// from under an assertion. Swift Testing has no cross-suite mutex, so this is
+/// it.
+///
+/// Same family as `swift-patterns.md` RULE: tests-no-process-global-mutable-delegate:
+/// a process global mutated across an `await` is not safe merely because each
+/// test tidies up after itself.
+///
+/// Fair FIFO, so a suite cannot be starved by a busy neighbour.
+actor AppLoggerTestExclusion {
+  static let shared = AppLoggerTestExclusion()
+
+  private var held = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  private init() {}
+
+  func acquire() async {
+    if !held {
+      held = true
+      return
+    }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      waiters.append(continuation)
+    }
+  }
+
+  func release() {
+    if waiters.isEmpty {
+      held = false
+    } else {
+      // Stays `held`; ownership passes straight to the next waiter.
+      waiters.removeFirst().resume()
+    }
+  }
+
+}
+
+/// Runs `body` with exclusive access to `AppLogger.shared`.
+///
+/// Free function, NOT a method on the actor: as a method the caller's closure
+/// would have to be sent across the actor boundary, and a `@MainActor` test body
+/// is not `Sendable` ("sending value of non-Sendable type risks causing data
+/// races"). Keeping only `acquire`/`release` on the actor lets `body` run in
+/// whatever isolation the caller already has.
+///
+/// Releases on the throwing path too — a leaked hold would deadlock every other
+/// AppLogger suite for the rest of the run.
+/// `isolation: isolated (any Actor)? = #isolation` makes this INHERIT the
+/// caller's isolation instead of hopping off it. Without it a `@MainActor` suite
+/// (`AppLoggerLaunchSyncTests`) cannot pass its body at all: the closure is
+/// MainActor-isolated, therefore non-Sendable, and sending it to a nonisolated
+/// generic function is a Swift 6 error.
+func withAppLoggerExclusion<T>(
+  isolation: isolated (any Actor)? = #isolation,
+  _ body: () async throws -> T
+) async rethrows -> T {
+  await AppLoggerTestExclusion.shared.acquire()
+  do {
+    let value = try await body()
+    await AppLoggerTestExclusion.shared.release()
+    return value
+  } catch {
+    await AppLoggerTestExclusion.shared.release()
+    throw error
+  }
+}


### PR DESCRIPTION
## What

AppLogger's file sink lost everything logged in the launch window. A delivery failure's `finishFailed` line never reached `app.log` while the **identical call at press-time landed fine** — which cost about an hour chasing a phantom warmup wedge that did not exist.

## The issue's suspected cause is wrong

The issue guessed a `FileHandle` initialisation race. It isn't. It's the plain guard in `log(...)`:

```swift
guard isDebugModeEnabled, level <= logLevel else { return }
```

`isDebugModeEnabled` starts `false` and only flips when `PipelineSettingsSync.applyInitialSettings` calls `setDebugMode(true)`. Anything emitted earlier reached OSLog and was then dropped on the floor. Same family as #728, which seeded debug mode at launch; this closes the window that still precedes that seeding.

## Fix

A bounded pre-sink buffer, flushed when the sink first opens.

- Entries are buffered **unrendered**, so the level filter applies at flush time against the log level actually in force by then, while the **timestamp is taken at log time** so flushed lines keep true chronological order.
- Flush runs **before** the "Debug mode enabled" marker so timestamps ascend, and it announces itself so the ordering is explainable to whoever reads the file.
- Bounded at 500. On overflow the oldest is dropped **and counted**, and the count is reported in the flush rather than silently swallowed.
- One renderer (`writeRendered`) now serves both the live path and the flush, so a format change cannot apply to one and not the other.

## Two deliberate scope limits, both tested

**A level-filtered line is not buffered.** Debug mode ON with the level below threshold is a deliberate filter, not a lost line.

**The window is exactly "before the persisted debug setting has been applied"**, closing on the first `setDebugMode` call in *either* direction.

That second one is a correction to my own first version, which keyed on "has never been ENABLED". That kept the window open forever in the overwhelmingly common case — a DEBUG build with debug mode off — so all ~148 log call sites would format a timestamp and allocate, permanently, for output that could never be flushed; past the 500 cap each further call also paid an `O(n)` `removeFirst`. Caught while investigating an unrelated full-suite failure. The narrower window removes the steady-state cost entirely, and there's now a test asserting an applied OFF frees the buffer and stops buffering.

## Tests

5 new, plus a `package` test seam (`resetPreSinkBufferForTesting`, `pendingPreSinkLineCount`) because AppLogger is a process-wide singleton whose latch would otherwise be left set by whichever suite ran first. `package` rather than `internal` so tests reach it on a plain import without coupling the seam to `@testable`.

**Two-way control:** removing the buffering call makes the pre-sink test fail with `buffered → 0` and the marker absent from `app.log` — reproducing the exact pre-fix loss. Restoring makes all pass.

## Validation

- Full suite: **4,349 tests in 415 suites passed**, plus 179 in 18 suites.
- `scripts/build-dev-app.sh` succeeded.
- DEBUG-only throughout; release builds are unaffected (the whole sink is `#if DEBUG`).

**Lane:** Code

Closes #1361
