### PR TITLE
docs(audio): correct three heart-path comments that claimed more than the evidence (Part of #1784)

### DIFF
--- a/Sources/EnviousWisprAudio/BundledVADModelLoader.swift
+++ b/Sources/EnviousWisprAudio/BundledVADModelLoader.swift
@@ -33,6 +33,23 @@ enum BundledVADModelLoader {
     do {
       // Match the pinned FluidAudio VAD loader (`DownloadUtils.swift:301-303`).
       // Keep this heart-path policy explicit across dependency updates (#1784).
+      //
+      // Deliberately NOT copied from `DownloadUtils.loadModelsOnce` (#1784
+      // audit, 2026-07-30): its aggregate cache-presence check, its three
+      // per-model structural checks (path exists, path is a directory, contains
+      // `coremldata.bin`), and — in the `loadModels` wrapper around it — the
+      // delete-cache-then-redownload retry. The retry has no equivalent here
+      // because this path has no download source to re-fetch from. The three
+      // structural checks are REDUNDANT rather than unreachable: the `Bundle`
+      // lookup above already proves the named resource exists, and
+      // `MLModel(contentsOf:configuration:)` is the authority on whether the
+      // compiled model is loadable — a failure surfaces as `.loadFailed`
+      // carrying the real CoreML error instead of a synthesized one.
+      //
+      // Do not upgrade that to "corruption is impossible here." App-bundle
+      // resources are covered by the code signature's resource seal, but a seal
+      // is integrity EVIDENCE, not proof: bad bytes can be signed at packaging
+      // time, and bytes can change after the initial validation.
       let configuration = MLModelConfiguration()
       configuration.computeUnits = .cpuAndNeuralEngine
       configuration.allowLowPrecisionAccumulationOnGPU = true

--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -155,6 +155,26 @@ public actor SilenceDetector {
       silenceTimeout: silenceTimeout, vadConfig: vadConfig,
       makeStreamingVad: {
         let model = try BundledVADModelLoader.loadModel(in: modelBundle)
+        // `defaultThreshold: 0.5` is our shipped positive entry threshold;
+        // FluidAudio's own default is 0.85 (`VadTypes.swift`, `VadConfig.init`).
+        // The #1784 audit found NO recorded measurement comparing the two. 0.5
+        // first appears in `fb6c254a` (2026-02-18), the commit that introduced
+        // this type. Treat it as shipped-and-unvalidated — not a dependency
+        // default, and not established soft-phoneme tuning. Do not cite a
+        // rationale for it that this file does not contain.
+        //
+        // FluidAudio reads it as the positive streaming threshold when
+        // `VadSegmentationConfig.negativeThreshold` is nil; the negative exit
+        // threshold is DERIVED from it separately, so this value moves both
+        // edges (`VadManager+Streaming.swift`, `streamingStateMachine`). The
+        // user-facing "sensitivity" control never reaches it — that feeds only
+        // the smoothed-EMA auto-stop path below, via `fromSensitivity`.
+        //
+        // `VadConfig.computeUnits` is deliberately NOT set here: this pre-loaded
+        // initializer stores the config and never reads that field (it is read
+        // only inside `loadUnifiedModel`, which this path never calls), so
+        // setting it would be a silent no-op. The model's real compute policy is
+        // pinned at its single construction site, `BundledVADModelLoader`.
         return VadManager(config: VadConfig(defaultThreshold: 0.5), vadModel: model)
       })
   }
@@ -225,12 +245,21 @@ public actor SilenceDetector {
     //    `processStreamingChunk`.
     // `speechPadding: 0.0` puts the boundary exactly at the chunk where
     // probability crossed threshold (no library-default 100ms back-dating).
-    // Codex round-2 (2026-05-04) flagged this as potentially clipping soft
-    // leading phonemes; the corpus run will validate empirically whether
-    // that hypothetical bites our `.validation/uat-602/corpus/multilingual/`
-    // cases. If the corpus shows clipping, flip back to FluidAudio's
-    // calibrated default (0.1) — the Parakeet batch path already uses
-    // equivalent 100ms boundary padding via `SampleFilter.filter(padding:)`.
+    // The library's 100ms is NOT dropped — it is applied one layer down, at the
+    // trim stage, by `SampleFilter.filter(padding:)` (default 1600 samples).
+    // Padding here too would add a SECOND 100ms expansion at each retained
+    // boundary. Not strictly a doubling: the filter no-ops on empty segments
+    // (`guard !segments.isEmpty else { return allSamples }`), clamps at buffer
+    // edges, and merges overlapping ranges, any of which absorbs part of it.
+    //
+    // SETTLED, do not flip back. Codex round-2 (2026-05-04) raised the
+    // hypothetical that 0.0 clips soft leading phonemes; the same-day corpus run
+    // did not show it. Of four English cases, three were wrong before the change
+    // and all four were correct after (two of the three had lost a LEADING word,
+    // which is the edge this setting governs; the third lost a trailing clause).
+    // Eight French cases kept their leading words; PT and PL spot-checks were
+    // clean (#604 / PR #613 — see that PR's per-phrase table, the primary source).
+    // Re-audited 2026-07-30 (#1784) with no change.
     let segConfig = VadSegmentationConfig(
       minSpeechDuration: 0.3,
       minSilenceDuration: silenceTimeout,

--- a/Sources/EnviousWisprAudio/SilenceDetector.swift
+++ b/Sources/EnviousWisprAudio/SilenceDetector.swift
@@ -252,13 +252,26 @@ public actor SilenceDetector {
     // (`guard !segments.isEmpty else { return allSamples }`), clamps at buffer
     // edges, and merges overlapping ranges, any of which absorbs part of it.
     //
-    // SETTLED, do not flip back. Codex round-2 (2026-05-04) raised the
-    // hypothetical that 0.0 clips soft leading phonemes; the same-day corpus run
-    // did not show it. Of four English cases, three were wrong before the change
-    // and all four were correct after (two of the three had lost a LEADING word,
-    // which is the edge this setting governs; the third lost a trailing clause).
-    // Eight French cases kept their leading words; PT and PL spot-checks were
-    // clean (#604 / PR #613 — see that PR's per-phrase table, the primary source).
+    // Why 0.0 and not FluidAudio's 0.1, and what that evidence does NOT cover.
+    // Codex round-2 (2026-05-04) raised the hypothetical that 0.0 clips soft
+    // leading phonemes; the same-day corpus run did not show it. Of four English
+    // cases, three were wrong before the change and all four were correct after
+    // (two of the three had lost a LEADING word, the edge this setting governs;
+    // the third lost a trailing clause). Eight French cases kept their leading
+    // words; PT and PL spot-checks were clean (#604 / PR #613 — see that PR's
+    // per-phrase table, the primary source).
+    //
+    // That corpus predates a REAL leading-loss case it never tested. #843 later
+    // found soft vowel-initial words ("Actually", "Overall") sitting just before
+    // the first VAD segment and being trimmed anyway, despite SampleFilter's
+    // 100 ms — mitigated downstream by the raw-capture fallback documented in
+    // `CapturedAudioConditioner` (see its Step 2a). Whether segmentation padding
+    // here would ALSO help that case was never measured.
+    //
+    // So: do not flip this to 0.1 on the old hypothetical, which was tested and
+    // not shown. Do not treat the question as closed either — a change here needs
+    // its own measurement against the #843 case, and must account for the second
+    // 100 ms expansion it would add at each retained boundary.
     // Re-audited 2026-07-30 (#1784) with no change.
     let segConfig = VadSegmentationConfig(
       minSpeechDuration: 0.3,


### PR DESCRIPTION
Comment-only on the heart path. No behaviour change, no new symbols, no control-flow change.

## What this closes

`Part of #1784` — the audit half. The issue's thesis: every place we hand a library a **pre-built object** instead of letting the library construct it, we silently drop that library's own defaults and guards. Two such defects existed and were already fixed (PR #1787 VAD compute units, PR #1830 output-safety classifier). This pass swept for a third.

**Result: no third dropped-default defect found.** The full inventory — every handoff, suppression and replacement, with the method *and its stated limit* — is at `docs/audits/2026-07-30-1784-prebuilt-object-handoff-inventory.md` (local, gitignored). It deliberately does **not** claim a closed-world proof: objects cross file and target boundaries, so an import list directs a search but cannot bound one.

## Why comment-only work was worth a PR

A code comment justifying a design choice is read as established fact by everyone after us, so a wrong one is worse than none — it stops the next reader checking. All three corrected comments sit on the recording path.

**`SilenceDetector`**
- `speechPadding: 0.0` was justified in the **future tense** ("the corpus run *will* validate…") and never amended after that run answered it the same day. A reader following its instruction would have flipped to `0.1` and added a second 100 ms expansion at each retained boundary, because `SampleFilter.filter(padding:)` already supplies the library's 100 ms at the trim stage.
- `defaultThreshold: 0.5` had **no rationale at all**. It diverges from FluidAudio's `0.85`, first appears in `fb6c254a`, and no measurement in this repo compares the two. Now recorded as shipped-and-unvalidated rather than dressed in invented tuning.
- Records that `VadConfig.computeUnits` is inert on the pre-loaded initializer, so setting it there would be a silent no-op.

**`BundledVADModelLoader`**
- Records which FluidAudio checks are deliberately not copied, and why they are **REDUNDANT** (the `Bundle` lookup proves existence; `MLModel` is the loadability authority) rather than unreachable. A code signature is integrity *evidence*, not proof that a bundled resource cannot be corrupt.

## Evidence discipline

Since the issue is about claiming more than you can show: **eight review rounds found 33 defects in the first drafts of this work, all adopted.** Only three were in these comments; the rest were in the local audit document, which had invented a rationale for `0.5`, asserted corruption was structurally impossible, and claimed a closed-world sweep it had not earned. The last two findings were both on one sentence — I had said 4 of 4 test phrases were previously broken when PR #613's own table shows 3, then said all 3 lost *leading* words when only 2 did.

Every claim in the final comments was verified against the pinned FluidAudio source or the primary PR. **Final code review: CLEAN.**

## Validation

- Debug suite: **4478 pass**
- Release suite: **4139 pass**
- Dev build + launch: clean
- **Live UAT: not run, and not applicable** — no runtime behaviour changes, so there is nothing for it to observe. Stated rather than skipped silently.

Lane: Code (2 files, `Sources/EnviousWisprAudio/`). Tier: SMALL.
